### PR TITLE
make handoff tooltip less sticky

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationService.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationService.ts
@@ -23,6 +23,14 @@ export interface IChatInputNotificationAction {
 	readonly commandArgs?: unknown[];
 }
 
+export interface IChatInputNotificationMuteAction {
+	/** Command executed when the user clicks the mute (bell-slash) button. */
+	readonly commandId: string;
+	readonly commandArgs?: unknown[];
+	/** Tooltip and accessible label for the mute button. */
+	readonly tooltip: string;
+}
+
 export interface IChatInputNotification {
 	readonly id: string;
 	readonly severity: ChatInputNotificationSeverity;
@@ -38,6 +46,12 @@ export interface IChatInputNotification {
 	 * list will render it.
 	 */
 	readonly sessionTypes?: readonly string[];
+	/**
+	 * Optional "mute" affordance rendered as a bell-slash icon button next to
+	 * the dismiss (X) button. Use for a "stop showing this entirely" action
+	 * that is distinct from a one-off dismissal. Omit to hide the button.
+	 */
+	readonly mute?: IChatInputNotificationMuteAction;
 }
 
 export const IChatInputNotificationService = createDecorator<IChatInputNotificationService>('chatInputNotificationService');

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationWidget.ts
@@ -5,6 +5,7 @@
 
 import * as dom from '../../../../../../base/browser/dom.js';
 import { Button } from '../../../../../../base/browser/ui/button/button.js';
+import { getDefaultHoverDelegate } from '../../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { WorkbenchActionExecutedClassification, WorkbenchActionExecutedEvent } from '../../../../../../base/common/actions.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { isMarkdownString } from '../../../../../../base/common/htmlContent.js';
@@ -12,6 +13,7 @@ import { Disposable, DisposableStore } from '../../../../../../base/common/lifec
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../nls.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 import { IMarkdownRendererService } from '../../../../../../platform/markdown/browser/markdownRenderer.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { defaultButtonStyles } from '../../../../../../platform/theme/browser/defaultStyles.js';
@@ -57,6 +59,7 @@ export class ChatInputNotificationWidget extends Disposable {
 		@ICommandService private readonly _commandService: ICommandService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IMarkdownRendererService private readonly _markdownRendererService: IMarkdownRendererService,
+		@IHoverService private readonly _hoverService: IHoverService,
 	) {
 		super();
 		this._sessionTypeProvider = sessionTypeProvider;
@@ -100,7 +103,7 @@ export class ChatInputNotificationWidget extends Disposable {
 		// Apply severity class
 		container.classList.add(severityToClass[notification.severity]);
 
-		// Header row: icon + title + dismiss
+		// Header row: icon + title + mute + dismiss
 		const headerRow = dom.append(container, $('.chat-input-notification-header'));
 
 		// Severity icon
@@ -117,6 +120,34 @@ export class ChatInputNotificationWidget extends Disposable {
 			titleElement.textContent = notification.message;
 		}
 		const ariaTitle = isMarkdownString(notification.message) ? notification.message.value : notification.message;
+
+		if (notification.mute) {
+			const mute = notification.mute;
+			const muteButton = dom.append(headerRow, $('.chat-input-notification-mute'));
+			muteButton.appendChild(dom.$(ThemeIcon.asCSSSelector(Codicon.bellSlash)));
+			muteButton.tabIndex = 0;
+			muteButton.role = 'button';
+			muteButton.ariaLabel = mute.tooltip;
+			this._contentDisposables.add(this._hoverService.setupManagedHover(getDefaultHoverDelegate('element'), muteButton, mute.tooltip));
+
+			// Defer to a microtask for the same reason as the dismiss button:
+			// the command synchronously tears down the notification, and the
+			// resulting re-render must happen after the click has propagated.
+			const doMute = () => queueMicrotask(() => {
+				this._telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', {
+					id: mute.commandId,
+					from: 'chatInputNotification',
+				});
+				this._commandService.executeCommand(mute.commandId, ...(mute.commandArgs ?? []));
+			});
+			this._contentDisposables.add(dom.addDisposableListener(muteButton, dom.EventType.CLICK, doMute));
+			this._contentDisposables.add(dom.addDisposableListener(muteButton, dom.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault();
+					doMute();
+				}
+			}));
+		}
 
 		// Dismiss button (in header row, pushed to the right)
 		if (notification.dismissible) {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/media/chatInputNotificationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/media/chatInputNotificationWidget.css
@@ -167,8 +167,9 @@
 	opacity: 1;
 }
 
-/* Dismiss button */
-.chat-input-notification .chat-input-notification-dismiss {
+/* Dismiss + mute icon buttons (header, right-aligned) */
+.chat-input-notification .chat-input-notification-dismiss,
+.chat-input-notification .chat-input-notification-mute {
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -181,14 +182,19 @@
 	border: none;
 	outline: none;
 	flex-shrink: 0;
+}
+
+.chat-input-notification .chat-input-notification-dismiss {
 	margin-left: auto;
 }
 
-.chat-input-notification .chat-input-notification-dismiss:hover {
+.chat-input-notification .chat-input-notification-dismiss:hover,
+.chat-input-notification .chat-input-notification-mute:hover {
 	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
-.chat-input-notification .chat-input-notification-dismiss:focus-visible {
+.chat-input-notification .chat-input-notification-dismiss:focus-visible,
+.chat-input-notification .chat-input-notification-mute:focus-visible {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: -1px;
 }

--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
@@ -34,7 +34,6 @@ import { SessionType } from '../../common/chatSessionsService.js';
 import { IChatViewTitleActionContext } from '../../common/actions/chatActions.js';
 import { getChatSessionType, isUntitledChatSession } from '../../common/model/chatUri.js';
 import { ChatInputNotificationSeverity, IChatInputNotificationService } from '../../browser/widget/input/chatInputNotificationService.js';
-import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { OPEN_WORKSPACE_IN_AGENTS_WINDOW_COMMAND_ID, OPEN_AGENTS_WINDOW_PRECONDITION, OPEN_AGENTS_WINDOW_COMMAND_ID, ChatConfiguration } from '../../common/constants.js';
 import { CommandsRegistry, ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
@@ -286,44 +285,39 @@ export class AgentsHandoffInputTipContribution extends Disposable implements IWo
 	/** Session types eligible for the handoff tip — the same set the Agents window can render directly. */
 	private static readonly ELIGIBLE_SESSION_TYPES: ReadonlySet<string> = new Set([SessionType.CopilotCLI, SessionType.AgentHostCopilot]);
 
-	/**
-	 * Storage key for the dismissed-sessions list. WORKSPACE scope so a user's
-	 * dismissal in one workspace doesn't permanently silence the tip across
-	 * all of their workspaces. The empty-workspace dismissal lives under the
-	 * shared key {@link EMPTY_WORKSPACE_KEY} and is itself scoped per
-	 * empty-workspace window.
-	 */
-	private static readonly DISMISSED_STORAGE_KEY = 'chat.agentsHandoff.tip.dismissedSessions';
-
-	/** Pseudo-key tracking dismissal of the empty-workspace tip (no real session URI exists). */
+	/** Pseudo-key used as the {@link _lastPostedFor} value for the empty-workspace tip (no real session URI exists). */
 	private static readonly EMPTY_WORKSPACE_KEY = '__empty-workspace__';
 
-	/** The session URI we last posted a notification for. Used to avoid clearing the user's dismissal when re-evaluating the same state. */
+	/** The key (session URI or {@link EMPTY_WORKSPACE_KEY}) we last posted a notification for. Used to avoid redundantly re-posting the tip when the same state is re-evaluated. */
 	private _lastPostedFor: string | undefined;
 
 	/** The session type (agent harness) of the currently posted tip, for telemetry. */
 	private _lastPostedSessionType: string | undefined;
 
-	/** Sessions for which the user has previously dismissed the tip; never re-posted. */
-	private readonly _dismissedSessions: Set<string>;
+	/**
+	 * Set once the user dismisses (X) or opens the tip. Suppresses the tip for
+	 * the rest of this window's lifetime — intentionally in-memory only, so it
+	 * shows again the next time VS Code is reopened.
+	 */
+	private _dismissedForWindow = false;
 
 	constructor(
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
 		@IChatInputNotificationService private readonly _notificationService: IChatInputNotificationService,
 		@IContextKeyService contextKeyService: IContextKeyService,
-		@IStorageService private readonly _storageService: IStorageService,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
-		this._dismissedSessions = new Set(this._loadDismissed());
 
 		this._register(CommandsRegistry.registerCommand(AgentsHandoffInputTipContribution.TIP_OPEN_COMMAND_ID, (accessor, ...args) => {
 			this._telemetryService.publicLog2<AgentsHandoffTipActionEvent, AgentsHandoffTipActionClassification>('chat.agentsHandoffTip.action', {
 				mode: this._getMode(),
 				sessionType: this._lastPostedSessionType ?? '',
 			});
+			// Opening the tip counts as handling it: don't show it again this window.
+			this._dismissForWindow();
 			return accessor.get(ICommandService).executeCommand(OpenChatSessionInAgentsWindowAction.ID, ...args);
 		}));
 
@@ -340,11 +334,10 @@ export class AgentsHandoffInputTipContribution extends Disposable implements IWo
 			}
 		}));
 		this._register(this._notificationService.onDidDismiss(id => {
-			if (id !== AgentsHandoffInputTipContribution.NOTIFICATION_ID || !this._lastPostedFor) {
+			if (id !== AgentsHandoffInputTipContribution.NOTIFICATION_ID) {
 				return;
 			}
-			this._dismissedSessions.add(this._lastPostedFor);
-			this._saveDismissed();
+			this._dismissForWindow();
 		}));
 
 		this._update();
@@ -364,8 +357,9 @@ export class AgentsHandoffInputTipContribution extends Disposable implements IWo
 	private _update(): void {
 		const mode = this._getMode();
 
-		// Mode that suppresses the tip entirely.
-		if (mode === AgentsHandoffTipMode.Hidden) {
+		// Suppress the tip entirely when the mode hides it, or once the user has
+		// dismissed/opened it for this window.
+		if (mode === AgentsHandoffTipMode.Hidden || this._dismissedForWindow) {
 			if (this._lastPostedFor) {
 				this._notificationService.deleteNotification(AgentsHandoffInputTipContribution.NOTIFICATION_ID);
 				this._lastPostedFor = undefined;
@@ -387,8 +381,7 @@ export class AgentsHandoffInputTipContribution extends Disposable implements IWo
 			&& !!sessionResource
 			&& !!resourceSessionType
 			&& AgentsHandoffInputTipContribution.ELIGIBLE_SESSION_TYPES.has(resourceSessionType)
-			&& !isUntitledChatSession(sessionResource)
-			&& !this._dismissedSessions.has(sessionResource.toString());
+			&& !isUntitledChatSession(sessionResource);
 
 		// Empty-workspace path: no usable session yet (CLI / agent-host local
 		// can't run here, and picking the mode only creates a placeholder
@@ -402,8 +395,7 @@ export class AgentsHandoffInputTipContribution extends Disposable implements IWo
 		const emptyWorkspaceEligible = preconditionMet
 			&& isEmptyWorkspace
 			&& (!sessionResource || isUntitledChatSession(sessionResource))
-			&& widgetSessionType === SessionType.AgentHostCopilot
-			&& !this._dismissedSessions.has(AgentsHandoffInputTipContribution.EMPTY_WORKSPACE_KEY);
+			&& widgetSessionType === SessionType.AgentHostCopilot;
 
 		if (!eligible && !emptyWorkspaceEligible) {
 			if (this._lastPostedFor) {
@@ -467,26 +459,16 @@ export class AgentsHandoffInputTipContribution extends Disposable implements IWo
 		});
 	}
 
-	private _loadDismissed(): readonly string[] {
-		const raw = this._storageService.get(AgentsHandoffInputTipContribution.DISMISSED_STORAGE_KEY, StorageScope.WORKSPACE);
-		if (!raw) {
-			return [];
+	/**
+	 * Mark the tip as handled (dismissed or opened) for the rest of this
+	 * window's lifetime and tear down any currently posted notification.
+	 */
+	private _dismissForWindow(): void {
+		if (this._dismissedForWindow) {
+			return;
 		}
-		try {
-			const parsed = JSON.parse(raw);
-			return Array.isArray(parsed) ? parsed.filter((s): s is string => typeof s === 'string') : [];
-		} catch {
-			return [];
-		}
-	}
-
-	private _saveDismissed(): void {
-		this._storageService.store(
-			AgentsHandoffInputTipContribution.DISMISSED_STORAGE_KEY,
-			JSON.stringify(Array.from(this._dismissedSessions)),
-			StorageScope.WORKSPACE,
-			StorageTarget.MACHINE,
-		);
+		this._dismissedForWindow = true;
+		this._update();
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
@@ -462,6 +462,11 @@ export class AgentsHandoffInputTipContribution extends Disposable implements IWo
 			: mode === AgentsHandoffTipMode.Custom
 				? localize('chat.agentsHandoff.tip.description.copilot', "Free with your Copilot plan — get a dedicated, multi-pane view alongside your workspace.")
 				: localize('chat.agentsHandoff.tip.description', "Get a dedicated, multi-pane view alongside your workspace.");
+		const actionLabel = useEmptyWorkspaceCopy
+			? localize('chat.agentsHandoff.tip.action', "Open in Agents Window")
+			: mode === AgentsHandoffTipMode.Custom
+				? localize('chat.agentsHandoff.tip.action.custom', "Give your agent more room?")
+				: localize('chat.agentsHandoff.tip.action.default', "Continue in Agents Window");
 
 		this._notificationService.setNotification({
 			id: AgentsHandoffInputTipContribution.NOTIFICATION_ID,
@@ -470,7 +475,7 @@ export class AgentsHandoffInputTipContribution extends Disposable implements IWo
 			description,
 			actions: [
 				{
-					label: localize('chat.agentsHandoff.tip.action', "Open in Agents Window"),
+					label: actionLabel,
 					commandId: AgentsHandoffInputTipContribution.TIP_OPEN_COMMAND_ID,
 					commandArgs,
 				},

--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
@@ -251,15 +251,17 @@ export const enum AgentsHandoffTipMode {
 }
 
 type AgentsHandoffTipActionEvent = {
+	action: string;
 	mode: string;
 	sessionType: string;
 };
 
 type AgentsHandoffTipActionClassification = {
+	action: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Which tip affordance the user activated: open, dismiss, or mute.' };
 	mode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The configured tip mode active when the tip was clicked (default, custom).' };
 	sessionType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The chat session type / agent harness being handed off (e.g. copilot-cli, agent-host-copilot).' };
 	owner: 'justschen';
-	comment: 'Tracks clicks on the agents-window handoff input tip to measure engagement across wording variants.';
+	comment: 'Tracks user interactions (open, dismiss, mute) with the agents-window handoff input tip to measure engagement across wording variants.';
 };
 
 /**
@@ -281,6 +283,13 @@ export class AgentsHandoffInputTipContribution extends Disposable implements IWo
 	 * intentionally not tracked here).
 	 */
 	private static readonly TIP_OPEN_COMMAND_ID = 'workbench.action.chat.agentsHandoffTip.open';
+
+	/**
+	 * Dedicated command backing the tip's "Don't Show Again" button. Closes the
+	 * tip and flips {@link ChatConfiguration.AgentsHandoffTipMode} to `hidden`
+	 * so it never shows again.
+	 */
+	private static readonly TIP_MUTE_COMMAND_ID = 'workbench.action.chat.agentsHandoffTip.mute';
 
 	/** Session types eligible for the handoff tip — the same set the Agents window can render directly. */
 	private static readonly ELIGIBLE_SESSION_TYPES: ReadonlySet<string> = new Set([SessionType.CopilotCLI, SessionType.AgentHostCopilot]);
@@ -312,13 +321,18 @@ export class AgentsHandoffInputTipContribution extends Disposable implements IWo
 		super();
 
 		this._register(CommandsRegistry.registerCommand(AgentsHandoffInputTipContribution.TIP_OPEN_COMMAND_ID, (accessor, ...args) => {
-			this._telemetryService.publicLog2<AgentsHandoffTipActionEvent, AgentsHandoffTipActionClassification>('chat.agentsHandoffTip.action', {
-				mode: this._getMode(),
-				sessionType: this._lastPostedSessionType ?? '',
-			});
+			this._logTipAction('open');
 			// Opening the tip counts as handling it: don't show it again this window.
 			this._dismissForWindow();
 			return accessor.get(ICommandService).executeCommand(OpenChatSessionInAgentsWindowAction.ID, ...args);
+		}));
+
+		this._register(CommandsRegistry.registerCommand(AgentsHandoffInputTipContribution.TIP_MUTE_COMMAND_ID, () => {
+			this._logTipAction('mute');
+			// Tear down the visible tip first (uses the still-valid `_lastPostedFor`),
+			// then persist `hidden` so it never shows again.
+			this._dismissForWindow();
+			return this._configurationService.updateValue(ChatConfiguration.AgentsHandoffTipMode, AgentsHandoffTipMode.Hidden);
 		}));
 
 		this._register(this._chatWidgetService.onDidChangeFocusedSession(() => this._update()));
@@ -337,10 +351,20 @@ export class AgentsHandoffInputTipContribution extends Disposable implements IWo
 			if (id !== AgentsHandoffInputTipContribution.NOTIFICATION_ID) {
 				return;
 			}
+			this._logTipAction('dismiss');
 			this._dismissForWindow();
 		}));
 
 		this._update();
+	}
+
+	/** Log a user interaction (open, dismiss, mute) with the handoff tip. */
+	private _logTipAction(action: 'open' | 'dismiss' | 'mute'): void {
+		this._telemetryService.publicLog2<AgentsHandoffTipActionEvent, AgentsHandoffTipActionClassification>('chat.agentsHandoffTip.action', {
+			action,
+			mode: this._getMode(),
+			sessionType: this._lastPostedSessionType ?? '',
+		});
 	}
 
 	private _getMode(): AgentsHandoffTipMode {
@@ -453,6 +477,10 @@ export class AgentsHandoffInputTipContribution extends Disposable implements IWo
 			],
 			dismissible: true,
 			autoDismissOnMessage: false,
+			mute: {
+				commandId: AgentsHandoffInputTipContribution.TIP_MUTE_COMMAND_ID,
+				tooltip: localize('chat.agentsHandoff.tip.mute', "Don't Show Again"),
+			},
 			sessionTypes: useEmptyWorkspaceCopy
 				? [SessionType.AgentHostCopilot]
 				: Array.from(AgentsHandoffInputTipContribution.ELIGIBLE_SESSION_TYPES),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

handoffs now close after user have clicked on it once, or if they close it once. the tooltip will not show again until the application is restarted or reloaded. 

you can also hit `mute` and it will never be shown again.


<img width="647" height="200" alt="Screenshot 2026-06-09 at 4 19 07 PM" src="https://github.com/user-attachments/assets/8224f9c2-d46f-4694-815d-3cf043cd1efb" />

<img width="599" height="220" alt="Screenshot 2026-06-09 at 4 18 39 PM" src="https://github.com/user-attachments/assets/6ace7452-5406-431d-aeea-916c5b66f19f" />

<img width="610" height="238" alt="Screenshot 2026-06-09 at 4 18 15 PM" src="https://github.com/user-attachments/assets/b99ef19a-ced0-44e7-8269-a6e3640844e0" />

