### PR TITLE
Cherry picking MSRC [115444]

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
@@ -146,7 +146,12 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 							const fileUri = URI.isUri(fileWrite) ? fileWrite : URI.file(fileWrite);
 							// TODO: Handle command substitutions/complex destinations properly https://github.com/microsoft/vscode/issues/274167
 							// TODO: Handle environment variables properly https://github.com/microsoft/vscode/issues/274166
-							if (fileUri.fsPath.match(/[$\(\){}`~]/)) {
+							// `~` catches POSIX tilde expansion (e.g. `~/foo`) and `%` catches Windows
+							// environment variable expansions (e.g. `%APPDATA%\foo`). Neither is
+							// recognized as absolute by `posix.isAbsolute` / `win32.isAbsolute`, so
+							// without this guard they would be joined onto cwd and incorrectly classified
+							// as inside the workspace while expanding at runtime to a location outside it.
+							if (fileUri.fsPath.match(/[$\(\){}`~%]/)) {
 								isAutoApproveAllowed = false;
 								this._log('File write blocked due to likely containing a variable, sub-command, or tilde expansion', fileUri.toString());
 								break;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
@@ -118,6 +118,8 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			test('variable in filename - block', () => t('echo hello > $HOME/file.txt', 'outsideWorkspace', false, 1));
 			test('command substitution - block', () => t('echo hello > $(pwd)/file.txt', 'outsideWorkspace', false, 1));
 			test('brace expansion - block', () => t('echo hello > {a,b}.txt', 'outsideWorkspace', false, 1));
+			test('tilde expansion - block', () => t('echo hello > ~/file.txt', 'outsideWorkspace', false, 1));
+			test('percent-style variable - block', () => t('echo hello > %HOME%/file.txt', 'outsideWorkspace', false, 1));
 		});
 
 		suite('blockDetectedFileWrites: all', () => {
@@ -300,6 +302,8 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			test('no redirections - allow', () => t('Write-Host "hello"', 'outsideWorkspace', true, 0));
 			test('variable in filename - block', () => t('Write-Host "hello" > $env:TEMP\\file.txt', 'outsideWorkspace', false, 1));
 			test('subexpression - block', () => t('Write-Host "hello" > $(Get-Date).log', 'outsideWorkspace', false, 1));
+			test('percent-style variable - block', () => t('Write-Host "hello" > %APPDATA%\\file.txt', 'outsideWorkspace', false, 1));
+			test('tilde expansion - block', () => t('Write-Host "hello" > ~\\file.txt', 'outsideWorkspace', false, 1));
 		});
 
 		suite('blockDetectedFileWrites: all', () => {


### PR DESCRIPTION
## Pull request overview

This PR updates the terminal chat agent’s command-line file write analysis to more conservatively block auto-approval when redirection targets include path expansions that may resolve outside the workspace at runtime (notably `~` and `%...%`-style patterns), and adds unit tests to cover the new blocking behavior.

**Changes:**
- Block auto-approval for file-write destinations containing `~` (tilde expansion) and `%...%`-style variables to prevent misclassification as in-workspace writes.
- Extend the existing analyzer test suite with new cases for tilde and percent-style patterns.

<details open>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts | Expands the “suspicious destination” guard to include `%`-style patterns alongside existing variable/subcommand checks. |
| src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts | Adds tests covering tilde expansion and percent-style variable destinations for bash and PowerShell scenarios. |
</details>

## Copilot's findings





- **Files reviewed:** 2/2 changed files
- **Comments generated:** 3


