### PR TITLE
Emit gen_ai streaming OTel signals for chat responses

### DIFF
--- a/extensions/copilot/docs/monitoring/agent_monitoring.md
+++ b/extensions/copilot/docs/monitoring/agent_monitoring.md
@@ -187,6 +187,8 @@ invoke_agent copilot                           [~15s]
 | `gen_ai.usage.reasoning.output_tokens` | When available | `512` |
 | `gen_ai.usage.reasoning_tokens` | **Legacy** — prefer `gen_ai.usage.reasoning.output_tokens` | `512` |
 | `copilot_chat.time_to_first_token` | On response | `450` |
+| `gen_ai.request.stream` | Streaming responses | `true` |
+| `gen_ai.response.time_to_first_chunk` | Streaming responses (seconds) | `0.45` |
 | `server.address` | When available | `api.github.com` |
 | `copilot_chat.debug_name` | When available | `agentMode` |
 | `error.type` | On error | `TimeoutError` |
@@ -221,6 +223,8 @@ invoke_agent copilot                           [~15s]
 |---|---|---|---|
 | `gen_ai.client.operation.duration` | Histogram | s | LLM API call duration |
 | `gen_ai.client.token.usage` | Histogram | tokens | Token counts (input/output) |
+| `gen_ai.client.operation.time_to_first_chunk` | Histogram | s | Time to first streaming chunk |
+| `gen_ai.client.operation.time_per_output_chunk` | Histogram | s | Inter-chunk latency after the first chunk |
 
 **`gen_ai.client.operation.duration` attributes:**
 
@@ -244,6 +248,17 @@ invoke_agent copilot                           [~15s]
 | `gen_ai.request.model` | Requested model |
 | `gen_ai.response.model` | Resolved model |
 | `server.address` | Server hostname |
+
+**`gen_ai.client.operation.time_to_first_chunk` / `gen_ai.client.operation.time_per_output_chunk` attributes:**
+
+| Attribute | Description |
+|---|---|
+| `gen_ai.operation.name` | Operation type (e.g., `chat`) |
+| `gen_ai.provider.name` | Provider (e.g., `github`, `anthropic`, `gemini`) |
+| `gen_ai.request.model` | Requested model |
+| `gen_ai.response.model` | Resolved model (when known) |
+
+> Both metrics are tagged with `gen_ai.response.model` for per-model slicing. `time_per_output_chunk` is emitted only on the primary GitHub streaming path; BYOK providers (Anthropic, Gemini) emit `time_to_first_chunk` only, as they do not expose per-chunk arrival timing.
 
 #### Extension-Specific Metrics
 

--- a/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
@@ -339,7 +339,9 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 						[GenAiAttr.RESPONSE_ID]: requestId,
 						[GenAiAttr.RESPONSE_FINISH_REASONS]: ['stop'],
 						[GenAiAttr.CONVERSATION_ID]: requestId,
+						[GenAiAttr.REQUEST_STREAM]: true,
 						...(result.ttft ? { [CopilotChatAttr.TIME_TO_FIRST_TOKEN]: result.ttft } : {}),
+						...(result.ttft ? { [GenAiAttr.RESPONSE_TIME_TO_FIRST_CHUNK]: result.ttft / 1000 } : {}),
 						[GenAiAttr.REQUEST_MAX_TOKENS]: model.maxOutputTokens ?? 0,
 					});
 					// Opt-in content capture
@@ -367,6 +369,7 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 					if (result.usage.prompt_tokens) { GenAiMetrics.recordTokenUsage(this._otelService, result.usage.prompt_tokens, 'input', metricAttrs); }
 					if (result.usage.completion_tokens) { GenAiMetrics.recordTokenUsage(this._otelService, result.usage.completion_tokens, 'output', metricAttrs); }
 					if (result.ttft) { GenAiMetrics.recordTimeToFirstToken(this._otelService, model.id, result.ttft / 1000); }
+					if (result.ttft) { GenAiMetrics.recordTimeToFirstChunk(this._otelService, result.ttft / 1000, metricAttrs); }
 				}
 
 				// Emit OTel inference details event

--- a/extensions/copilot/src/extension/byok/vscode-node/geminiNativeProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/geminiNativeProvider.ts
@@ -210,7 +210,9 @@ export class GeminiNativeBYOKLMProvider extends AbstractLanguageModelChatProvide
 						[GenAiAttr.RESPONSE_ID]: requestId,
 						[GenAiAttr.RESPONSE_FINISH_REASONS]: ['stop'],
 						[GenAiAttr.CONVERSATION_ID]: requestId,
+						[GenAiAttr.REQUEST_STREAM]: true,
 						...(result.ttft ? { [CopilotChatAttr.TIME_TO_FIRST_TOKEN]: result.ttft } : {}),
+						...(result.ttft ? { [GenAiAttr.RESPONSE_TIME_TO_FIRST_CHUNK]: result.ttft / 1000 } : {}),
 						[GenAiAttr.REQUEST_MAX_TOKENS]: model.maxOutputTokens ?? 0,
 					});
 					// Opt-in content capture
@@ -238,6 +240,7 @@ export class GeminiNativeBYOKLMProvider extends AbstractLanguageModelChatProvide
 					if (result.usage.prompt_tokens) { GenAiMetrics.recordTokenUsage(this._otelService, result.usage.prompt_tokens, 'input', metricAttrs); }
 					if (result.usage.completion_tokens) { GenAiMetrics.recordTokenUsage(this._otelService, result.usage.completion_tokens, 'output', metricAttrs); }
 					if (result.ttft) { GenAiMetrics.recordTimeToFirstToken(this._otelService, model.id, result.ttft / 1000); }
+					if (result.ttft) { GenAiMetrics.recordTimeToFirstChunk(this._otelService, result.ttft / 1000, metricAttrs); }
 				}
 
 				// Emit OTel inference details event

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -326,6 +326,8 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			pendingLoggedChatRequest?.markTimeToFirstToken(timeToFirstToken);
 			/** Resolved response model, normalized once and reused by span attributes and the streaming metrics below. */
 			let normalizedResponseModel: string | undefined;
+			/** Time (ms) from request issue to the first content-bearing streamed chunk; basis for the GenAI `time_to_first_chunk` signals. Distinct from `timeToFirstToken`, which is the time to receive the Response object. */
+			let timeToFirstChunkMs: number | undefined;
 			switch (response.type) {
 				case FetchResponseKind.Success: {
 					const result = await this.processSuccessfulResponse(response, messages, imageTelemetryMeasurements, requestBody, ourRequestId, maxResponseTokens, tokenCount, timeToFirstToken, streamRecorder, baseTelemetry, chatEndpoint, userInitiatedRequest, interactionType, transport, actualFetcher, actualBytesReceived, suspendEventSeen, resumeEventSeen, actualModelCallId);
@@ -384,6 +386,12 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 
 					pendingLoggedChatRequest?.resolve(result, streamRecorder.deltas);
 
+					// First content-chunk timing, captured after the stream is consumed. Mirrors
+					// `timeToFirstTokenEmitted` below and the CLI runtime's TTFC semantics.
+					if (streamRecorder.firstTokenEmittedTime !== undefined) {
+						timeToFirstChunkMs = streamRecorder.firstTokenEmittedTime - baseTelemetry.issuedTime;
+					}
+
 					// Record OTel token usage metrics if available
 					if (result.type === ChatFetchResponseType.Success && result.usage) {
 						// Store copilot_usage for per-request credits display, scoped to the turn.
@@ -424,7 +432,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 								: {}),
 							[CopilotChatAttr.TIME_TO_FIRST_TOKEN]: timeToFirstToken,
 							[GenAiAttr.REQUEST_STREAM]: true,
-							...(timeToFirstToken > 0 ? { [GenAiAttr.RESPONSE_TIME_TO_FIRST_CHUNK]: timeToFirstToken / 1000 } : {}),
+							...(timeToFirstChunkMs !== undefined && timeToFirstChunkMs > 0 ? { [GenAiAttr.RESPONSE_TIME_TO_FIRST_CHUNK]: timeToFirstChunkMs / 1000 } : {}),
 							...(result.serverRequestId ? { [CopilotChatAttr.SERVER_REQUEST_ID]: result.serverRequestId } : {}),
 							...(result.usage.completion_tokens_details?.reasoning_tokens
 								? {
@@ -492,8 +500,12 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 					// Record OTel time-to-first-token metric
 					if (timeToFirstToken > 0) {
 						GenAiMetrics.recordTimeToFirstToken(this._otelService, chatEndpoint.model, timeToFirstToken / 1000);
-						// GenAI-convention streaming signal, dual-emitted alongside the legacy metric above.
-						GenAiMetrics.recordTimeToFirstChunk(this._otelService, timeToFirstToken / 1000, {
+					}
+
+					// GenAI-convention streaming signal (time to first content chunk), dual-emitted
+					// alongside the legacy time-to-first-token metric above.
+					if (timeToFirstChunkMs !== undefined && timeToFirstChunkMs > 0) {
+						GenAiMetrics.recordTimeToFirstChunk(this._otelService, timeToFirstChunkMs / 1000, {
 							operationName: GenAiOperationName.CHAT,
 							providerName: GenAiProviderName.GITHUB,
 							requestModel: chatEndpoint.model,

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -324,6 +324,8 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 			}
 			const timeToFirstToken = Date.now() - baseTelemetry.issuedTime;
 			pendingLoggedChatRequest?.markTimeToFirstToken(timeToFirstToken);
+			/** Resolved response model, normalized once and reused by span attributes and the streaming metrics below. */
+			let normalizedResponseModel: string | undefined;
 			switch (response.type) {
 				case FetchResponseKind.Success: {
 					const result = await this.processSuccessfulResponse(response, messages, imageTelemetryMeasurements, requestBody, ourRequestId, maxResponseTokens, tokenCount, timeToFirstToken, streamRecorder, baseTelemetry, chatEndpoint, userInitiatedRequest, interactionType, transport, actualFetcher, actualBytesReceived, suspendEventSeen, resumeEventSeen, actualModelCallId);
@@ -392,7 +394,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 
 						// Normalize once so span attributes, metric attributes, and the inference
 						// details event all report the same value (issue #318805).
-						const normalizedResponseModel = normalizeResponseModel(chatEndpoint.model, result.resolvedModel);
+						normalizedResponseModel = normalizeResponseModel(chatEndpoint.model, result.resolvedModel);
 
 						const metricAttrs = {
 							operationName: GenAiOperationName.CHAT,
@@ -421,6 +423,8 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 								? { [GenAiAttr.USAGE_CACHE_CREATION_INPUT_TOKENS]: result.usage.prompt_tokens_details.cache_creation_input_tokens }
 								: {}),
 							[CopilotChatAttr.TIME_TO_FIRST_TOKEN]: timeToFirstToken,
+							[GenAiAttr.REQUEST_STREAM]: true,
+							...(timeToFirstToken > 0 ? { [GenAiAttr.RESPONSE_TIME_TO_FIRST_CHUNK]: timeToFirstToken / 1000 } : {}),
 							...(result.serverRequestId ? { [CopilotChatAttr.SERVER_REQUEST_ID]: result.serverRequestId } : {}),
 							...(result.usage.completion_tokens_details?.reasoning_tokens
 								? {
@@ -488,6 +492,23 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 					// Record OTel time-to-first-token metric
 					if (timeToFirstToken > 0) {
 						GenAiMetrics.recordTimeToFirstToken(this._otelService, chatEndpoint.model, timeToFirstToken / 1000);
+						// GenAI-convention streaming signal, dual-emitted alongside the legacy metric above.
+						GenAiMetrics.recordTimeToFirstChunk(this._otelService, timeToFirstToken / 1000, {
+							operationName: GenAiOperationName.CHAT,
+							providerName: GenAiProviderName.GITHUB,
+							requestModel: chatEndpoint.model,
+							responseModel: normalizedResponseModel,
+						});
+					}
+
+					// Record per-output-chunk inter-arrival latency for the streamed response.
+					for (const gapMs of streamRecorder.outputChunkGapsMs) {
+						GenAiMetrics.recordTimePerOutputChunk(this._otelService, gapMs / 1000, {
+							operationName: GenAiOperationName.CHAT,
+							providerName: GenAiProviderName.GITHUB,
+							requestModel: chatEndpoint.model,
+							responseModel: normalizedResponseModel,
+						});
 					}
 
 					if (useWebSocket && result.type === ChatFetchResponseType.Success) {

--- a/extensions/copilot/src/platform/chat/common/chatMLFetcher.ts
+++ b/extensions/copilot/src/platform/chat/common/chatMLFetcher.ts
@@ -126,12 +126,26 @@ export class FetchStreamRecorder {
 		return this._firstTokenEmittedTime;
 	}
 
+	private _lastOutputChunkTime: number | undefined;
+	private readonly _outputChunkGapsMs: number[] = [];
+	/** Inter-chunk arrival gaps (ms) between consecutive content-bearing output chunks, used for the GenAI `time_per_output_chunk` metric. */
+	public get outputChunkGapsMs(): readonly number[] {
+		return this._outputChunkGapsMs;
+	}
+
 	constructor(
 		callback: FinishedCallback | undefined
 	) {
 		this.callback = async (text: string, index: number, delta: IResponseDelta): Promise<number | undefined> => {
-			if (this._firstTokenEmittedTime === undefined && (delta.text || delta.beginToolCalls || (typeof delta.thinking?.text === 'string' && delta.thinking?.text || delta.thinking?.text?.length) || delta.copilotToolCalls || delta.copilotToolCallStreamUpdates)) {
-				this._firstTokenEmittedTime = Date.now();
+			const isContentChunk = !!(delta.text || delta.beginToolCalls || (typeof delta.thinking?.text === 'string' && delta.thinking?.text || delta.thinking?.text?.length) || delta.copilotToolCalls || delta.copilotToolCallStreamUpdates);
+			if (isContentChunk) {
+				const now = Date.now();
+				if (this._firstTokenEmittedTime === undefined) {
+					this._firstTokenEmittedTime = now;
+				} else if (this._lastOutputChunkTime !== undefined) {
+					this._outputChunkGapsMs.push(now - this._lastOutputChunkTime);
+				}
+				this._lastOutputChunkTime = now;
 			}
 
 			const result = callback ? await callback(text, index, delta) : undefined;

--- a/extensions/copilot/src/platform/chat/test/common/fetchStreamRecorder.spec.ts
+++ b/extensions/copilot/src/platform/chat/test/common/fetchStreamRecorder.spec.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IResponseDelta } from '../../../networking/common/fetch';
+import { FetchStreamRecorder } from '../../common/chatMLFetcher';
+
+describe('FetchStreamRecorder streaming chunk timing', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('stamps first-token time on the first content chunk and records inter-chunk gaps thereafter', async () => {
+		const recorder = new FetchStreamRecorder(undefined);
+
+		vi.setSystemTime(1000);
+		await recorder.callback('a', 0, { text: 'a' } satisfies IResponseDelta);
+		expect(recorder.firstTokenEmittedTime).toBe(1000);
+		expect(recorder.outputChunkGapsMs).toEqual([]);
+
+		vi.setSystemTime(1030);
+		await recorder.callback('b', 0, { text: 'b' } satisfies IResponseDelta);
+		vi.setSystemTime(1050);
+		await recorder.callback('c', 0, { text: 'c' } satisfies IResponseDelta);
+
+		expect(recorder.outputChunkGapsMs).toEqual([30, 20]);
+	});
+
+	it('ignores empty deltas that carry no content', async () => {
+		const recorder = new FetchStreamRecorder(undefined);
+
+		vi.setSystemTime(2000);
+		await recorder.callback('', 0, { text: '' } satisfies IResponseDelta);
+		expect(recorder.firstTokenEmittedTime).toBeUndefined();
+		expect(recorder.outputChunkGapsMs).toEqual([]);
+
+		vi.setSystemTime(2010);
+		await recorder.callback('x', 0, { text: 'x' } satisfies IResponseDelta);
+		expect(recorder.firstTokenEmittedTime).toBe(2010);
+		expect(recorder.outputChunkGapsMs).toEqual([]);
+	});
+});

--- a/extensions/copilot/src/platform/otel/common/genAiAttributes.ts
+++ b/extensions/copilot/src/platform/otel/common/genAiAttributes.ts
@@ -54,11 +54,15 @@ export const GenAiAttr = {
 	REQUEST_PRESENCE_PENALTY: 'gen_ai.request.presence_penalty',
 	REQUEST_SEED: 'gen_ai.request.seed',
 	REQUEST_STOP_SEQUENCES: 'gen_ai.request.stop_sequences',
+	/** Whether the request used streaming mode (recommended on streaming chat spans). */
+	REQUEST_STREAM: 'gen_ai.request.stream',
 
 	// Response
 	RESPONSE_MODEL: 'gen_ai.response.model',
 	RESPONSE_ID: 'gen_ai.response.id',
 	RESPONSE_FINISH_REASONS: 'gen_ai.response.finish_reasons',
+	/** Time to first streaming chunk, in seconds (recommended on streaming chat spans). */
+	RESPONSE_TIME_TO_FIRST_CHUNK: 'gen_ai.response.time_to_first_chunk',
 
 	// Usage
 	USAGE_INPUT_TOKENS: 'gen_ai.usage.input_tokens',

--- a/extensions/copilot/src/platform/otel/common/genAiMetrics.ts
+++ b/extensions/copilot/src/platform/otel/common/genAiMetrics.ts
@@ -93,6 +93,50 @@ export class GenAiMetrics {
 		});
 	}
 
+	/**
+	 * GenAI-convention time-to-first-chunk histogram (seconds). Emitted for streaming
+	 * responses alongside the legacy `copilot_chat.time_to_first_token` metric.
+	 */
+	static recordTimeToFirstChunk(
+		otel: IOTelService,
+		ttfcSec: number,
+		attrs: {
+			operationName: string;
+			providerName: string;
+			requestModel: string;
+			responseModel?: string;
+		},
+	): void {
+		otel.recordMetric('gen_ai.client.operation.time_to_first_chunk', ttfcSec, {
+			[GenAiAttr.OPERATION_NAME]: attrs.operationName,
+			[GenAiAttr.PROVIDER_NAME]: attrs.providerName,
+			[GenAiAttr.REQUEST_MODEL]: attrs.requestModel,
+			...(attrs.responseModel ? { [GenAiAttr.RESPONSE_MODEL]: attrs.responseModel } : {}),
+		});
+	}
+
+	/**
+	 * GenAI-convention inter-chunk latency histogram (seconds). Recorded once per
+	 * streamed output chunk after the first, measuring the gap since the prior chunk.
+	 */
+	static recordTimePerOutputChunk(
+		otel: IOTelService,
+		interChunkSec: number,
+		attrs: {
+			operationName: string;
+			providerName: string;
+			requestModel: string;
+			responseModel?: string;
+		},
+	): void {
+		otel.recordMetric('gen_ai.client.operation.time_per_output_chunk', interChunkSec, {
+			[GenAiAttr.OPERATION_NAME]: attrs.operationName,
+			[GenAiAttr.PROVIDER_NAME]: attrs.providerName,
+			[GenAiAttr.REQUEST_MODEL]: attrs.requestModel,
+			...(attrs.responseModel ? { [GenAiAttr.RESPONSE_MODEL]: attrs.responseModel } : {}),
+		});
+	}
+
 	static incrementSessionCount(otel: IOTelService): void {
 		otel.incrementCounter('copilot_chat.session.count');
 	}

--- a/extensions/copilot/src/platform/otel/common/test/chatMLFetcherSpanLifecycle.spec.ts
+++ b/extensions/copilot/src/platform/otel/common/test/chatMLFetcherSpanLifecycle.spec.ts
@@ -48,6 +48,8 @@ describe('chatMLFetcher Span Lifecycle', () => {
 			[GenAiAttr.RESPONSE_ID]: 'chatcmpl-xyz',
 			[GenAiAttr.RESPONSE_FINISH_REASONS]: ['stop'],
 			[CopilotChatAttr.TIME_TO_FIRST_TOKEN]: 450,
+			[GenAiAttr.REQUEST_STREAM]: true,
+			[GenAiAttr.RESPONSE_TIME_TO_FIRST_CHUNK]: 0.45,
 			[CopilotChatAttr.COPILOT_USAGE_NANO_AIU]: 3_500_000_000,
 		});
 		span.setStatus(SpanStatusCode.OK);
@@ -55,6 +57,8 @@ describe('chatMLFetcher Span Lifecycle', () => {
 
 		expect(s.attributes[GenAiAttr.USAGE_INPUT_TOKENS]).toBe(1500);
 		expect(s.attributes[GenAiAttr.RESPONSE_MODEL]).toBe('gpt-4o-2024-08-06');
+		expect(s.attributes[GenAiAttr.REQUEST_STREAM]).toBe(true);
+		expect(s.attributes[GenAiAttr.RESPONSE_TIME_TO_FIRST_CHUNK]).toBe(0.45);
 		expect(s.attributes[CopilotChatAttr.COPILOT_USAGE_NANO_AIU]).toBe(3_500_000_000);
 		expect(s.statusCode).toBe(SpanStatusCode.OK);
 		expect(s.ended).toBe(true);

--- a/extensions/copilot/src/platform/otel/common/test/genAiMetrics.spec.ts
+++ b/extensions/copilot/src/platform/otel/common/test/genAiMetrics.spec.ts
@@ -72,6 +72,40 @@ describe('GenAiMetrics', () => {
 		});
 	});
 
+	it('recordTimeToFirstChunk records the GenAI streaming histogram with response model', () => {
+		const otel = createMockOTelService();
+
+		GenAiMetrics.recordTimeToFirstChunk(otel, 0.45, {
+			operationName: GenAiOperationName.CHAT,
+			providerName: GenAiProviderName.GITHUB,
+			requestModel: 'gpt-4o',
+			responseModel: 'gpt-4o-2024-08-06',
+		});
+
+		expect(otel.recordMetric).toHaveBeenCalledWith('gen_ai.client.operation.time_to_first_chunk', 0.45, {
+			[GenAiAttr.OPERATION_NAME]: 'chat',
+			[GenAiAttr.PROVIDER_NAME]: 'github',
+			[GenAiAttr.REQUEST_MODEL]: 'gpt-4o',
+			[GenAiAttr.RESPONSE_MODEL]: 'gpt-4o-2024-08-06',
+		});
+	});
+
+	it('recordTimePerOutputChunk records the GenAI inter-chunk histogram', () => {
+		const otel = createMockOTelService();
+
+		GenAiMetrics.recordTimePerOutputChunk(otel, 0.02, {
+			operationName: GenAiOperationName.CHAT,
+			providerName: GenAiProviderName.GITHUB,
+			requestModel: 'gpt-4o',
+		});
+
+		expect(otel.recordMetric).toHaveBeenCalledWith('gen_ai.client.operation.time_per_output_chunk', 0.02, {
+			[GenAiAttr.OPERATION_NAME]: 'chat',
+			[GenAiAttr.PROVIDER_NAME]: 'github',
+			[GenAiAttr.REQUEST_MODEL]: 'gpt-4o',
+		});
+	});
+
 	it('recordToolCallCount increments counter', () => {
 		const otel = createMockOTelService();
 


### PR DESCRIPTION
Closes #320651.

## What

Adds the GenAI semantic-convention **streaming** signals to the Copilot Chat extension, dual-emitted alongside the legacy `copilot_chat.time_to_first_token` and tagged with `gen_ai.response.model` for per-model slicing:

| Signal | Kind | Unit |
|---|---|---|
| `gen_ai.request.stream` | `chat` span attr (bool) | — |
| `gen_ai.response.time_to_first_chunk` | `chat` span attr | seconds |
| `gen_ai.client.operation.time_to_first_chunk` | histogram metric | seconds |
| `gen_ai.client.operation.time_per_output_chunk` | histogram metric | seconds |

This brings the shipping extension to parity with the Copilot CLI runtime, which already emits these signals natively.

## How

- **`genAiAttributes.ts`** — new `REQUEST_STREAM` and `RESPONSE_TIME_TO_FIRST_CHUNK` key constants (hand-declared, consistent with the file's "single source of truth" policy; the official `@opentelemetry/semantic-conventions` package has no equivalents for these `*_chunk` keys).
- **`genAiMetrics.ts`** — `recordTimeToFirstChunk` and `recordTimePerOutputChunk` helpers.
- **`FetchStreamRecorder`** — tracks inter-chunk arrival gaps (`outputChunkGapsMs`) for the per-output-chunk metric.
- **`chatMLFetcher.ts`** (main GitHub path) — emits the full set, including per-output-chunk latency.
- **BYOK providers** (Anthropic, Gemini) — emit the stream attr + `time_to_first_chunk` only; they lack per-chunk arrival timing.

### Coverage across agent paths

- **Foreground / GitHub** — full set via `chatMLFetcher`.
- **Claude agent** — inherits all signals for free, since its LLM calls are proxied back through the shared `chatMLFetcher`.
- **Copilot CLI (background + terminal)** — emitted natively by the Rust runtime; forwarded verbatim by the bridge span processor (no extension change needed).

## Docs & tests

- Updated `extensions/copilot/docs/monitoring/agent_monitoring.md` (span attribute rows, metric table + attribute descriptions, BYOK omission note).
- Unit tests: `genAiMetrics.spec.ts` (metric names + attrs, response-model omission), `chatMLFetcherSpanLifecycle.spec.ts` (new span attrs), new `fetchStreamRecorder.spec.ts` (N−1 gaps for N content chunks, empty-delta handling). All 15 pass.