### PR TITLE
Adding Delete Button for Agent Sessions in the Chat Browser Overview

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
@@ -75,6 +75,17 @@ MenuRegistry.appendMenuItem(MenuId.ChatWelcomeContext, {
 	when: ChatContextKeys.inChatEditor.negate()
 });
 
+MenuRegistry.appendMenuItem(MenuId.AgentSessionItemToolbar, {
+	command: {
+		id: AGENT_SESSION_DELETE_ACTION_ID,
+		title: localize2('deleteChat.delete', "Delete"),
+		icon: Codicon.trash
+	},
+	group: 'navigation',
+	order: 3,
+	when: ChatContextKeys.agentSessionType.isEqualTo(AgentSessionProviders.Local)
+});
+
 export class SetAgentSessionsOrientationStackedAction extends Action2 {
 
 	constructor() {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
@@ -78,7 +78,7 @@ MenuRegistry.appendMenuItem(MenuId.ChatWelcomeContext, {
 MenuRegistry.appendMenuItem(MenuId.AgentSessionItemToolbar, {
 	command: {
 		id: AGENT_SESSION_DELETE_ACTION_ID,
-		title: localize2('deleteChat.delete', "Delete"),
+		title: localize2('deleteSession.delete', "Delete"),
 		icon: Codicon.trash
 	},
 	group: 'navigation',


### PR DESCRIPTION
# Adding Delete Button for Agent Sessions in the Chat Browser Overview
* Appended a delete button for the `AgentSessionItemToolbar` menu

## Issue
Addresses #320522

## Implementation
<img width="356" height="200" alt="image" src="https://github.com/user-attachments/assets/8e31f700-7836-4eaa-88c3-9b3315855a4d" />


