### PR TITLE
Distribute Claude and Codex agent SDKs via product.json

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1540,6 +1540,7 @@ export default defineConfig(
 						'ssh2',
 						'stream',
 						'string_decoder',
+						'tar',
 						'tas-client',
 						'tls',
 						'undici',

--- a/package-lock.json
+++ b/package-lock.json
@@ -333,13 +333,12 @@
       ]
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.102.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.102.0.tgz",
-      "integrity": "sha512-cThh3KcPW3lzkFyTz1cjyhJvOVw45NkLMoowO2ZJ/76CBz44ADUon+NsjEc/PypAkARs72Xu8qxTnx6PAOTQUQ==",
+      "version": "0.82.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.82.0.tgz",
+      "integrity": "sha512-xdHTjL1GlUlDugHq/I47qdOKp/ROPvuHl7ROJCgUQigbvPu7asf9KcAcU1EqdrP2LuVhEKaTs7Z+ShpZDRzHdQ==",
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
+        "json-schema-to-ts": "^3.1.1"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -2833,12 +2832,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
-    },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "license": "MIT"
     },
     "node_modules/@stylistic/eslint-plugin-ts": {
       "version": "2.8.0",
@@ -8531,12 +8524,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc= sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
-    },
-    "node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
-      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
@@ -17504,16 +17491,6 @@
       "dev": true,
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/static-extend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.2.128",
+        "@anthropic-ai/claude-agent-sdk": "0.3.168",
         "@openai/codex": "^0.134.0",
         "@playwright/cli": "^0.1.9",
         "@playwright/test": "^1.56.1",
@@ -184,36 +184,34 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.128",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.128.tgz",
-      "integrity": "sha512-KI7H9bocPahGDrrQGME5Eh5a4RTqGrN1fQ69uLs6Ik4icXBZXouCx4Ecum450jMVy58myeh9ahYYLlpDAbQXPA==",
+      "version": "0.3.168",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.168.tgz",
+      "integrity": "sha512-C7n9uS1fsAt9lFKw/ovsFNAlPI7UXE2uPQbOzzKLpDNjfFR5spthALhV49b01PtYWEzTo3W3OJfgCv6wooXtYg==",
       "dev": true,
       "license": "SEE LICENSE IN README.md",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.81.0",
-        "@modelcontextprotocol/sdk": "^1.29.0"
-      },
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.128",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.128",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.128",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.128",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.128",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.128",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.128",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.128"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.168",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.168",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.168",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.168",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.168",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.168",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.168",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.168"
       },
       "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.2.128",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.128.tgz",
-      "integrity": "sha512-RAzmB1ls+GWA/YiyfZLWdFYmj3md5emk7mCEeiKSKl2UN4i+tDWy2m/hjIvMFIzBqJJeGmZZSMnf3S0sL/GbhQ==",
+      "version": "0.3.168",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.168.tgz",
+      "integrity": "sha512-tvFGCGVX9tesGBzfpK008nRmv91pd3ToapDpJbjdwiFSLGWT9n+dc/qurwgxgv9VwWRvV8nWTc3zLRSFI8Lf2g==",
       "cpu": [
         "arm64"
       ],
@@ -225,9 +223,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.2.128",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.128.tgz",
-      "integrity": "sha512-dDPJHxUhL2sgIB8Q2AnBi4xsApImeW0zf1nbL7gBNSc9RWhGoGQAbPm0KaQ7/03jdom30z1VT5VMhQ5KeEYOIw==",
+      "version": "0.3.168",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.168.tgz",
+      "integrity": "sha512-J5dZUCrwjz4+gY2dAds2rMDWWSdcMl9jEDpZIzKNCx0f0KlJfE1C7/+stOJaBv6tGj8d/mmzcfBCeNBS1KScgA==",
       "cpu": [
         "x64"
       ],
@@ -239,13 +237,16 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.2.128",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.128.tgz",
-      "integrity": "sha512-+GbB33eJSlZUWs84nsibY2nyAFQT96WYLGCteVn62Vv6ZK90NrZsm7lwurjw7oYNnvpzXorhZ2/XpQnWvOK6aQ==",
+      "version": "0.3.168",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.168.tgz",
+      "integrity": "sha512-K9fltcI0VJBr21z4t0iJ4aArFtiS9UwhmMGkxl1jAIM0jatGqiHHbbk+qaCB04va3U6vaflukgtmbpogSB36yQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -253,13 +254,16 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.2.128",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.128.tgz",
-      "integrity": "sha512-ZCZEg42St0SCMMZFCvEtkF1LBFMYBxJRXzRno+12vOYYhC6R0l8jPjlgA2ZkN2Lb+TCEOO3fjeWJdZLL/NDM4w==",
+      "version": "0.3.168",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.168.tgz",
+      "integrity": "sha512-uOFtBJjntrYkXlHPRK+cTx1pCc37XxGQ/kN3KBK/KoIDcIrmU8DcX2WUw5IJHJqpG2Qjb7gZ5xAbcw3WTmduwQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -267,13 +271,16 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.2.128",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.128.tgz",
-      "integrity": "sha512-aBBXD6OLN/lq9S1p+BNjuEml0lYIoHunFdzFl49B0fsxEAnz1RfJDrpSNpIUAaL5FMZIaFvLqXtbFRy41N2fxg==",
+      "version": "0.3.168",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.168.tgz",
+      "integrity": "sha512-0Fw4ICZopwKbqNQo64HqkpJw5cqxOxFOV/w8GCS2hDsJ+0aogmK/B78t4iV6rFHIkC076Nm5UH14FP1eOIJ3OA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -281,13 +288,16 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.2.128",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.128.tgz",
-      "integrity": "sha512-sUSJEtvEt2iiMvgUuBGmBJjLhwHxDKOxVBSsXZaY46KAv3ZwLtLuc5xv2XFHId1B5+nMh7b7mr+HAiBmbMUODA==",
+      "version": "0.3.168",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.168.tgz",
+      "integrity": "sha512-JwYD7oxYlIVYDFhgj+QVHgWbJUVGMXsiecB6WQ5VS5u4OqUorivJPFYPaP469otMj4HFtkDupESB+7Zp4jMmUw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -295,9 +305,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.2.128",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.128.tgz",
-      "integrity": "sha512-9Ao2J5KgfkfKxUZK3dbQEGonPYcbUyn7Cn7ykZuP91FN/5ux3Tz90YRJW6UtZdWHoDkmFF0FS8P/jiZuyWPLfw==",
+      "version": "0.3.168",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.168.tgz",
+      "integrity": "sha512-NREaLXAxl23pEzoU7bmX6u8MibAYEY2t8XP5xtj/vMO6UwxFjT3YgGsTuQcnFP+1qsjWaOBCia2ZQnqI68Y0Ng==",
       "cpu": [
         "arm64"
       ],
@@ -309,9 +319,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.2.128",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.128.tgz",
-      "integrity": "sha512-7oxPkgjw1vPZbx6+Qwt9mGouqfpRz5jDcuQ37koayzMdTVzmgCsKAqqbJSpOQfkFGv6gTjcrLWBlk3oapZfBYA==",
+      "version": "0.3.168",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.168.tgz",
+      "integrity": "sha512-Ha3eivz2Wm4y3BR+Xpn/r+CBM8ARC6knYDLbjLqH/DxjKahr6WB60xQkBD1U6wchT6w7zfIQqQGbucuUOTTuew==",
       "cpu": [
         "x64"
       ],
@@ -322,34 +332,14 @@
         "win32"
       ]
     },
-    "node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/sdk": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
-      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.82.0.tgz",
-      "integrity": "sha512-xdHTjL1GlUlDugHq/I47qdOKp/ROPvuHl7ROJCgUQigbvPu7asf9KcAcU1EqdrP2LuVhEKaTs7Z+ShpZDRzHdQ==",
+      "version": "0.102.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.102.0.tgz",
+      "integrity": "sha512-cThh3KcPW3lzkFyTz1cjyhJvOVw45NkLMoowO2ZJ/76CBz44ADUon+NsjEc/PypAkARs72Xu8qxTnx6PAOTQUQ==",
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -2843,6 +2833,12 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@stylistic/eslint-plugin-ts": {
       "version": "2.8.0",
@@ -8535,6 +8531,12 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc= sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
@@ -17502,6 +17504,16 @@
       "dev": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/static-extend": {

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.2.128",
+    "@anthropic-ai/claude-agent-sdk": "0.3.168",
     "@openai/codex": "^0.134.0",
     "@playwright/cli": "^0.1.9",
     "@playwright/test": "^1.56.1",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -47,6 +47,7 @@
         "node-addon-api": "^6.0.0",
         "node-pty": "^1.2.0-beta.13",
         "ssh2": "^1.16.0",
+        "tar": "^7.5.9",
         "tas-client": "0.3.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",

--- a/remote/package.json
+++ b/remote/package.json
@@ -42,6 +42,7 @@
     "node-addon-api": "^6.0.0",
     "node-pty": "^1.2.0-beta.13",
     "ssh2": "^1.16.0",
+    "tar": "^7.5.9",
     "tas-client": "0.3.1",
     "vscode-oniguruma": "1.7.0",
     "vscode-regexpp": "^3.1.0",

--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -64,6 +64,27 @@ export type ExtensionVirtualWorkspaceSupport = {
 	readonly override?: boolean;
 };
 
+/**
+ * Per-package configuration for downloading an agent SDK on demand. When
+ * `IProductConfiguration.agentSdks?.[pkg]` is set, the agent host fetches the
+ * per-platform tarball at `format2(urlTemplate, { sdkVersion, sdkTarget })`,
+ * verifies its sha256 against `sha256[sdkTarget]`, and caches it under
+ * `userDataPath/agent-host/sdk-cache/`.
+ *
+ * `{sdkTarget}` is `${platform}-${arch}`, plus `-musl` on Linux when musl is
+ * detected — same suffixes npm uses for the platform `optionalDependencies`
+ * (`@anthropic-ai/claude-agent-sdk-${sdkTarget}`, `@openai/codex-${sdkTarget}`).
+ *
+ * The `sha256` map's keys define the supported platforms: a `currentSdkTarget()`
+ * not present in the map is treated as unsupported and the provider is not
+ * registered.
+ */
+export interface IAgentSdkProductConfig {
+	readonly version: string;
+	readonly urlTemplate: string;
+	readonly sha256: { readonly [sdkTarget: string]: string };
+}
+
 export interface IProductConfiguration {
 	readonly version: string;
 	readonly date?: string;
@@ -117,6 +138,8 @@ export interface IProductConfiguration {
 		readonly nlsBaseUrl: string;
 		readonly accessSKUs?: string[];
 	};
+
+	readonly agentSdks?: { readonly [packageId: string]: IAgentSdkProductConfig };
 
 	readonly mcpGallery?: {
 		readonly serviceUrl: string;

--- a/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
@@ -8,9 +8,9 @@ import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '.
 import product from '../../product/common/product.js';
 import { Registry } from '../../registry/common/platform.js';
 import {
-	AgentHostClaudeAgentSdkPathSettingId,
+	AgentHostClaudeAgentSdkRootSettingId,
 	AgentHostCodexAgentBinaryArgsSettingId,
-	AgentHostCodexAgentBinaryPathSettingId,
+	AgentHostCodexAgentSdkRootSettingId,
 	AgentHostCodexAgentCodexHomeSettingId,
 	AgentHostOTelCaptureContentSettingId,
 	AgentHostOTelDbSpanExporterEnabledSettingId,
@@ -42,16 +42,16 @@ configurationRegistry.registerConfiguration({
 	title: nls.localize('chatAgentHostStarterConfigurationTitle', "Chat Agent Host Starter"),
 	type: 'object',
 	properties: {
-		[AgentHostClaudeAgentSdkPathSettingId]: {
+		[AgentHostClaudeAgentSdkRootSettingId]: {
 			type: 'string',
-			description: nls.localize('chat.agentHost.claudeAgent.path', "Experimental, for local testing only. Absolute path to a locally-installed `@anthropic-ai/claude-agent-sdk` package. When set, the Claude agent provider is registered inside the agent host and the SDK is loaded from this path. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect. This setting will be removed once the SDK is delivered through the Extension Marketplace."),
+			description: nls.localize('chat.agentHost.claudeAgent.sdkRoot', "Experimental, for local SDK development only. Absolute path to a directory containing `node_modules/@anthropic-ai/claude-agent-sdk`. When set, the agent host loads Claude from this tree instead of downloading the SDK. Empty (the default) falls through to the SDK distribution shipped with this build. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect."),
 			default: '',
 			tags: ['experimental', 'advanced'],
 			included: product.quality !== 'stable',
 		},
-		[AgentHostCodexAgentBinaryPathSettingId]: {
+		[AgentHostCodexAgentSdkRootSettingId]: {
 			type: 'string',
-			description: nls.localize('chat.agentHost.codexAgent.path', "Experimental, for local testing only. Absolute path to a locally-installed `codex` binary. When set, the Codex agent provider is registered inside the agent host and `codex app-server` is spawned from this path. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect."),
+			description: nls.localize('chat.agentHost.codexAgent.sdkRoot', "Experimental, for local SDK development only. Absolute path to a directory containing `node_modules/@openai/codex`. When set, the agent host spawns the Codex binary from this tree instead of downloading the SDK. Empty (the default) falls through to the SDK distribution shipped with this build. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect."),
 			default: '',
 			tags: ['experimental', 'advanced'],
 			included: product.quality !== 'stable',

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -56,41 +56,44 @@ export const AgentHostAhpJsonlLoggingSettingId = 'chat.agentHost.ahpJsonlLogging
 export const AgentHostCustomTerminalToolEnabledSettingId = 'chat.agentHost.customTerminalTool.enabled';
 
 /**
- * Configuration key that holds the absolute path to a locally-installed
- * `@anthropic-ai/claude-agent-sdk` package. When non-empty, the Claude agent
- * provider is registered inside the agent host and the SDK module is loaded
- * via dynamic `import()` from this path. When empty (the default), the
- * Claude provider is not registered. The SDK is intentionally not bundled
- * with VS Code; users opting into the Claude agent install the SDK
- * themselves and point this setting at it. The agent host process must be
- * restarted for changes to take effect.
+ * Configuration key that holds the absolute path to the **SDK root directory**
+ * — the directory that contains a `node_modules/@anthropic-ai/claude-agent-sdk`
+ * subtree. When non-empty, the agent host treats it as a dev override and skips
+ * the on-demand download from `product.agentSdks.claude` for the Claude SDK.
+ *
+ * Empty (the default) means: load the SDK from `product.agentSdks.claude` if
+ * the build supplies one; otherwise the Claude provider is not registered.
+ * The agent host process must be restarted for changes to take effect.
  */
-export const AgentHostClaudeAgentSdkPathSettingId = 'chat.agentHost.claudeAgent.path';
+export const AgentHostClaudeAgentSdkRootSettingId = 'chat.agentHost.claudeAgent.sdkRoot';
 
 /**
- * Environment variable that holds the absolute path to a locally-installed
- * `@anthropic-ai/claude-agent-sdk` package. When set to a non-empty value,
- * the agent host process registers the Claude agent provider and loads the
- * SDK module from this path. Set by the agent host starters from
- * {@link AgentHostClaudeAgentSdkPathSettingId}, and may also be set directly
- * by developers as an override.
+ * Environment variable form of {@link AgentHostClaudeAgentSdkRootSettingId}.
+ * Set by the agent host starters from the setting, and may also be set
+ * directly by developers as an override.
  */
-export const AgentHostClaudeSdkPathEnvVar = 'VSCODE_AGENT_HOST_CLAUDE_SDK_PATH';
+export const AgentHostClaudeSdkRootEnvVar = 'VSCODE_AGENT_HOST_CLAUDE_SDK_ROOT';
 
 // -- Codex agent settings --------------------------------------------------------
 //
-// Codex is opt-in via `chat.agentHost.codexAgent.path`. The setting points at
-// an absolute path to the `codex` binary; the agent host spawns
-// `<path> app-server` as a long-lived child process and speaks JSON-RPC over
-// stdio. The binary is not bundled; users install codex themselves (typically
-// via `npm install -g @openai/codex` or a platform package manager).
+// Codex is opt-in via `chat.agentHost.codexAgent.sdkRoot`. The setting points
+// at an absolute path to a directory containing a `node_modules/@openai/codex`
+// subtree (the same shape `npm install @openai/codex` produces, and the same
+// shape the agent host downloads on demand from `product.agentSdks.codex`).
+// The agent host spawns the native codex binary from inside that tree as a
+// long-lived child process and speaks JSON-RPC over stdio. The binary is not
+// bundled with VS Code; users either install codex themselves (typically via
+// `npm install -g @openai/codex` or a platform package manager) or rely on
+// the on-demand download.
 
 /**
- * Absolute path to a locally-installed `codex` binary. When non-empty, the
- * Codex agent provider is registered inside the agent host. Empty (the
- * default) disables the provider entirely.
+ * Absolute path to the **SDK root directory** containing a
+ * `node_modules/@openai/codex` subtree. When non-empty, the agent host treats
+ * it as a dev override and skips the on-demand download from
+ * `product.agentSdks.codex`. Empty (the default) falls through to product
+ * config; if neither is present, the provider is not registered.
  */
-export const AgentHostCodexAgentBinaryPathSettingId = 'chat.agentHost.codexAgent.path';
+export const AgentHostCodexAgentSdkRootSettingId = 'chat.agentHost.codexAgent.sdkRoot';
 
 /**
  * Optional override for `$CODEX_HOME`. When set, the codex app-server child
@@ -105,11 +108,10 @@ export const AgentHostCodexAgentCodexHomeSettingId = 'chat.agentHost.codexAgent.
 export const AgentHostCodexAgentBinaryArgsSettingId = 'chat.agentHost.codexAgent.binaryArgs';
 
 /**
- * Environment variable the agent host process reads to locate the codex
- * binary. Forwarded by the starters from
- * {@link AgentHostCodexAgentBinaryPathSettingId}.
+ * Environment variable form of {@link AgentHostCodexAgentSdkRootSettingId}.
+ * Forwarded by the starters from the setting.
  */
-export const AgentHostCodexAgentBinaryPathEnvVar = 'VSCODE_AGENT_HOST_CODEX_APP_SERVER_PATH';
+export const AgentHostCodexAgentSdkRootEnvVar = 'VSCODE_AGENT_HOST_CODEX_SDK_ROOT';
 
 /** Forwarded `$CODEX_HOME`. */
 export const AgentHostCodexAgentCodexHomeEnvVar = 'CODEX_HOME';
@@ -215,6 +217,44 @@ export function buildAgentHostOTelEnv(
 	}
 	if (settings.dbSpanExporterEnabled) {
 		setIfMissing(AgentHostOTelEnvVars.DbSpanExporterEnabled, 'true');
+	}
+	return out;
+}
+
+/**
+ * Settings -> env-var fan-out for the Claude/Codex SDK overrides that the
+ * agent host process consumes. Shared by both starters
+ * (`nodeAgentHostStarter.ts`, `electronAgentHostStarter.ts`) so they don't
+ * drift the next time someone adds a setting.
+ *
+ * The shape mirrors {@link buildAgentHostOTelEnv}: only set a key when the
+ * underlying setting has a non-empty value AND the inherited env doesn't
+ * already define it (developer override wins). Returns a partial env map
+ * the caller spreads into the spawned child's environment.
+ */
+export interface IAgentSdkStarterSettings {
+	readonly claudeSdkRoot?: string;
+	readonly codexSdkRoot?: string;
+	readonly codexHome?: string;
+	readonly codexBinaryArgs?: readonly string[];
+}
+
+export function buildAgentSdkEnv(
+	settings: IAgentSdkStarterSettings,
+	inheritedEnv: Readonly<Record<string, string | undefined>>,
+): Record<string, string> {
+	const out: Record<string, string> = {};
+	const setIfMissing = (key: string, value: string | undefined): void => {
+		if (value === undefined || value === '' || inheritedEnv[key] !== undefined) {
+			return;
+		}
+		out[key] = value;
+	};
+	setIfMissing(AgentHostClaudeSdkRootEnvVar, settings.claudeSdkRoot);
+	setIfMissing(AgentHostCodexAgentSdkRootEnvVar, settings.codexSdkRoot);
+	setIfMissing(AgentHostCodexAgentCodexHomeEnvVar, settings.codexHome);
+	if (Array.isArray(settings.codexBinaryArgs) && settings.codexBinaryArgs.length > 0) {
+		setIfMissing(AgentHostCodexAgentBinaryArgsEnvVar, JSON.stringify(settings.codexBinaryArgs));
 	}
 	return out;
 }

--- a/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
@@ -19,7 +19,7 @@ import { getResolvedShellEnv } from '../../shell/node/shellEnv.js';
 import { NullTelemetryService } from '../../telemetry/common/telemetryUtils.js';
 import { UtilityProcess } from '../../utilityProcess/electron-main/utilityProcess.js';
 import { IAgentHostConnection, IAgentHostStarter } from '../common/agent.js';
-import { AgentHostClaudeAgentSdkPathSettingId, AgentHostClaudeSdkPathEnvVar, AgentHostCodexAgentBinaryArgsEnvVar, AgentHostCodexAgentBinaryArgsSettingId, AgentHostCodexAgentBinaryPathEnvVar, AgentHostCodexAgentBinaryPathSettingId, AgentHostCodexAgentCodexHomeEnvVar, AgentHostCodexAgentCodexHomeSettingId, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, buildAgentHostOTelEnv } from '../common/agentService.js';
+import { AgentHostClaudeAgentSdkRootSettingId, AgentHostCodexAgentBinaryArgsSettingId, AgentHostCodexAgentSdkRootSettingId, AgentHostCodexAgentCodexHomeSettingId, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, buildAgentHostOTelEnv, buildAgentSdkEnv } from '../common/agentService.js';
 import { deepClone } from '../../../base/common/objects.js';
 import '../common/agentHost.config.contribution.js';
 import '../common/agentHostStarter.config.contribution.js';
@@ -66,23 +66,15 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 		// PATH and other vars from the user's login shell (macOS/Linux GUI launches).
 		const shellEnv = await this._resolveShellEnv();
 
-		// Gate optional providers via env vars consumed by `agentHostMain.ts`.
-		// The Claude agent is opt-in: enabled when the user points the SDK path
-		// setting at a locally-installed `@anthropic-ai/claude-agent-sdk` package,
-		// or when the env var is already set on the parent process (developer
-		// override). The SDK itself is intentionally not bundled with VS Code.
-		const claudeSdkPath = this._configurationService.getValue<string>(AgentHostClaudeAgentSdkPathSettingId)
-			|| process.env[AgentHostClaudeSdkPathEnvVar]
-			|| '';
-
-		// Codex agent is opt-in: enabled when the user points the binary-path
-		// setting at a locally-installed `codex` CLI, or when the env var is
-		// already set on the parent process (developer override).
-		const codexBinaryPath = this._configurationService.getValue<string>(AgentHostCodexAgentBinaryPathSettingId)
-			|| process.env[AgentHostCodexAgentBinaryPathEnvVar]
-			|| '';
-		const codexHome = this._configurationService.getValue<string>(AgentHostCodexAgentCodexHomeSettingId) || '';
-		const codexArgs = this._configurationService.getValue<readonly string[]>(AgentHostCodexAgentBinaryArgsSettingId);
+		// Forward the Claude/Codex SDK overrides + codex home/args from
+		// workbench settings to the agent host process. Parent env wins on
+		// collision — see `buildAgentSdkEnv` for the precedence rule.
+		const sdkEnv = buildAgentSdkEnv({
+			claudeSdkRoot: this._configurationService.getValue<string>(AgentHostClaudeAgentSdkRootSettingId),
+			codexSdkRoot: this._configurationService.getValue<string>(AgentHostCodexAgentSdkRootSettingId),
+			codexHome: this._configurationService.getValue<string>(AgentHostCodexAgentCodexHomeSettingId),
+			codexBinaryArgs: this._configurationService.getValue<readonly string[]>(AgentHostCodexAgentBinaryArgsSettingId),
+		}, process.env);
 
 		// Translate `chat.agentHost.otel.*` settings into the env vars consumed by
 		// the agent host process. Any value already present on `process.env` wins
@@ -116,10 +108,7 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 				VSCODE_ESM_ENTRYPOINT: 'vs/platform/agentHost/node/agentHostMain',
 				VSCODE_PIPE_LOGGING: 'true',
 				VSCODE_VERBOSE_LOGGING: 'true',
-				...(claudeSdkPath ? { [AgentHostClaudeSdkPathEnvVar]: claudeSdkPath } : {}),
-				...(codexBinaryPath ? { [AgentHostCodexAgentBinaryPathEnvVar]: codexBinaryPath } : {}),
-				...(codexHome ? { [AgentHostCodexAgentCodexHomeEnvVar]: codexHome } : {}),
-				...(Array.isArray(codexArgs) && codexArgs.length > 0 ? { [AgentHostCodexAgentBinaryArgsEnvVar]: JSON.stringify(codexArgs) } : {}),
+				...sdkEnv,
 				...otelEnv,
 			}
 		});

--- a/src/vs/platform/agentHost/node/agentHostBootstrap.ts
+++ b/src/vs/platform/agentHost/node/agentHostBootstrap.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DisposableStore } from '../../../base/common/lifecycle.js';
+import { joinPath } from '../../../base/common/resources.js';
+import { IConfigurationService } from '../../configuration/common/configuration.js';
+import { ConfigurationService } from '../../configuration/common/configurationService.js';
+import { INativeEnvironmentService } from '../../environment/common/environment.js';
+import { IFileService } from '../../files/common/files.js';
+import { ServiceCollection } from '../../instantiation/common/serviceCollection.js';
+import { ILogService } from '../../log/common/log.js';
+import { IPolicyService, NullPolicyService } from '../../policy/common/policy.js';
+import { IRequestService } from '../../request/common/request.js';
+import { RequestService } from '../../request/node/requestService.js';
+
+/**
+ * Register `IPolicyService`, `IConfigurationService`, and `IRequestService`
+ * into the agent host's DI container — the trio that `IAgentSdkDownloader`
+ * depends on for proxy-aware downloads.
+ *
+ * Used by both entry points (`agentHostMain.ts` and `agentHostServerMain.ts`)
+ * to avoid drift between them. The order of registration matters because
+ * `RequestService` injects `IConfigurationService`; consumers (the downloader
+ * itself, and through it `ClaudeAgentSdkService` / `CodexAgent`) must be
+ * constructed AFTER this call.
+ *
+ * Reads the default profile's `settings.json` from `<userRoamingDataHome>` —
+ * the same file the workbench writes user settings to. Initialization is
+ * async because the settings file is read off disk.
+ *
+ * `NullPolicyService` matches the pattern used by sibling node-side processes
+ * (server, CLI). Enterprise policy enforcement happens in the main process and
+ * lands in `settings.json`; we don't re-resolve it here. `RequestService` runs
+ * in `'local'` mode because the agent host runs on the user's machine.
+ */
+export async function registerAgentHostNetworkServices(
+	diServices: ServiceCollection,
+	fileService: IFileService,
+	environmentService: INativeEnvironmentService,
+	logService: ILogService,
+	disposables: DisposableStore,
+): Promise<void> {
+	const policyService = new NullPolicyService();
+	diServices.set(IPolicyService, policyService);
+	const settingsResource = joinPath(environmentService.userRoamingDataHome, 'settings.json');
+	const configurationService = disposables.add(new ConfigurationService(settingsResource, fileService, policyService, logService));
+	await configurationService.initialize();
+	diServices.set(IConfigurationService, configurationService);
+	diServices.set(IRequestService, new RequestService('local', configurationService, environmentService, logService));
+}

--- a/src/vs/platform/agentHost/node/agentHostBootstrap.ts
+++ b/src/vs/platform/agentHost/node/agentHostBootstrap.ts
@@ -48,5 +48,5 @@ export async function registerAgentHostNetworkServices(
 	const configurationService = disposables.add(new ConfigurationService(settingsResource, fileService, policyService, logService));
 	await configurationService.initialize();
 	diServices.set(IConfigurationService, configurationService);
-	diServices.set(IRequestService, new RequestService('local', configurationService, environmentService, logService));
+	diServices.set(IRequestService, disposables.add(new RequestService('local', configurationService, environmentService, logService)));
 }

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -15,7 +15,7 @@ import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
 import * as os from 'os';
 import * as inspector from 'inspector';
-import { AgentHostClaudeSdkPathEnvVar, AgentHostCodexAgentBinaryPathEnvVar, AgentHostIpcChannels, IAgentHostInspectInfo, IAgentHostSocketInfo, IAgentService, IConnectionTrackerService } from '../common/agentService.js';
+import { AgentHostIpcChannels, IAgentHostInspectInfo, IAgentHostSocketInfo, IAgentService, IConnectionTrackerService } from '../common/agentService.js';
 import { AgentService } from './agentService.js';
 import { IAgentConfigurationService } from './agentConfigurationService.js';
 import { IAgentHostCompletions } from './agentHostCompletions.js';
@@ -23,10 +23,11 @@ import { IAgentHostTerminalManager } from './agentHostTerminalManager.js';
 import { CopilotAgent } from './copilot/copilotAgent.js';
 import { CopilotApiService, ICopilotApiService } from './shared/copilotApiService.js';
 import { ClaudeAgent } from './claude/claudeAgent.js';
-import { ClaudeAgentSdkService, IClaudeAgentSdkService } from './claude/claudeAgentSdkService.js';
+import { ClaudeAgentSdkService, ClaudeSdkPackage, IClaudeAgentSdkService } from './claude/claudeAgentSdkService.js';
 import { ClaudeProxyService, IClaudeProxyService } from './claude/claudeProxyService.js';
-import { CodexAgent } from './codex/codexAgent.js';
+import { CodexAgent, CodexSdkPackage } from './codex/codexAgent.js';
 import { CodexProxyService, ICodexProxyService } from './codex/codexProxyService.js';
+import { AgentSdkDownloader, IAgentSdkDownloader } from './agentSdkDownloader.js';
 import { IAgentHostOTelService } from '../common/otel/agentHostOTelService.js';
 import { AgentHostOTelService } from './otel/agentHostOTelService.js';
 import { ProtocolServerHandler } from './protocolServerHandler.js';
@@ -50,6 +51,7 @@ import { Schemas } from '../../../base/common/network.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { InstantiationService } from '../../instantiation/common/instantiationService.js';
 import { ServiceCollection } from '../../instantiation/common/serviceCollection.js';
+import { registerAgentHostNetworkServices } from './agentHostBootstrap.js';
 import { SessionDataService } from './sessionDataService.js';
 import { ISessionDataService } from '../common/sessionDataService.js';
 import { IWindowsMxcTerminalSandboxRuntime, WindowsMxcTerminalSandboxRuntime } from '../../sandbox/common/terminalSandboxMxcRuntime.js';
@@ -136,6 +138,10 @@ async function startAgentHost(): Promise<void> {
 		diServices.set(ISessionDataService, sessionDataService);
 		diServices.set(IProductService, productService);
 		diServices.set(ITelemetryService, telemetryService);
+		// Wire `IPolicyService` + `IConfigurationService` + `IRequestService`
+		// — the trio that `IAgentSdkDownloader` depends on for proxy-aware
+		// downloads. Must run before any downstream service that injects them.
+		await registerAgentHostNetworkServices(diServices, fileService, environmentService, logService, disposables);
 		instantiationService = new InstantiationService(diServices);
 		const fileMonitorService = disposables.add(instantiationService.createInstance(AgentHostFileMonitorService));
 		diServices.set(IAgentHostFileMonitorService, fileMonitorService);
@@ -149,6 +155,11 @@ async function startAgentHost(): Promise<void> {
 		// pipeline / end-of-turn capture).
 		const checkpointService = disposables.add(instantiationService.createInstance(AgentHostCheckpointService));
 		diServices.set(IAgentHostCheckpointService, checkpointService);
+		// Register the agent SDK downloader BEFORE any service that injects it
+		// (ClaudeAgentSdkService and CodexAgent below). The downloader resolves
+		// dev-override env var → on-disk cache → product.agentSdks download.
+		const agentSdkDownloader = instantiationService.createInstance(AgentSdkDownloader);
+		diServices.set(IAgentSdkDownloader, agentSdkDownloader);
 		const copilotApiService = instantiationService.createInstance(CopilotApiService, undefined);
 		diServices.set(ICopilotApiService, copilotApiService);
 		const claudeProxyService = disposables.add(instantiationService.createInstance(ClaudeProxyService));
@@ -170,21 +181,15 @@ async function startAgentHost(): Promise<void> {
 		diServices.set(IAgentConfigurationService, agentService.configurationService);
 		diServices.set(IAgentHostCompletions, agentService.completionsService);
 		agentService.registerProvider(instantiationService.createInstance(CopilotAgent));
-		// The Claude agent provider is opt-in. Gated on the
-		// `chat.agentHost.claudeAgent.path` workbench setting being non-empty,
-		// forwarded by the agent host starters as `VSCODE_AGENT_HOST_CLAUDE_SDK_PATH`.
-		// The SDK is intentionally not bundled with VS Code; the env var holds the
-		// absolute path to a locally-installed `@anthropic-ai/claude-agent-sdk` package.
-		if (process.env[AgentHostClaudeSdkPathEnvVar]) {
+		// Claude and Codex providers are gated on the SDK being reachable —
+		// either via the dev-override env var (`VSCODE_AGENT_HOST_*_PATH`) or
+		// via a `product.agentSdks.<pkg>` entry that ships with this build.
+		// If neither is present, the provider is not registered and never
+		// appears in the agent picker (matches the pre-CDN UX exactly).
+		if (agentSdkDownloader.isAvailable(ClaudeSdkPackage)) {
 			agentService.registerProvider(instantiationService.createInstance(ClaudeAgent));
 		}
-		// The Codex agent provider is opt-in. Gated on the
-		// `chat.agentHost.codexAgent.path` workbench setting being non-empty,
-		// forwarded by the agent host starters as `VSCODE_AGENT_HOST_CODEX_APP_SERVER_PATH`.
-		// The codex binary is intentionally not bundled; users install it
-		// themselves (`npm install -g @openai/codex` or equivalent) and
-		// point this setting at the absolute path.
-		if (process.env[AgentHostCodexAgentBinaryPathEnvVar]) {
+		if (agentSdkDownloader.isAvailable(CodexSdkPackage)) {
 			agentService.registerProvider(instantiationService.createInstance(CodexAgent));
 		}
 	} catch (err) {

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -182,7 +182,7 @@ async function startAgentHost(): Promise<void> {
 		diServices.set(IAgentHostCompletions, agentService.completionsService);
 		agentService.registerProvider(instantiationService.createInstance(CopilotAgent));
 		// Claude and Codex providers are gated on the SDK being reachable —
-		// either via the dev-override env var (`VSCODE_AGENT_HOST_*_PATH`) or
+		// either via the dev-override env var (`VSCODE_AGENT_HOST_*_SDK_ROOT`) or
 		// via a `product.agentSdks.<pkg>` entry that ships with this build.
 		// If neither is present, the provider is not registered and never
 		// appears in the agent picker (matches the pre-CDN UX exactly).

--- a/src/vs/platform/agentHost/node/agentHostServerMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostServerMain.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 // Standalone agent host server with WebSocket protocol transport.
-// Start with: node out/vs/platform/agentHost/node/agentHostServerMain.js [--port <port>] [--host <host>] [--connection-token <token>] [--connection-token-file <path>] [--without-connection-token] [--enable-mock-agent] [--claude-sdk-path <path>] [--codex-binary-path <path>] [--quiet] [--log <level>]
+// Start with: node out/vs/platform/agentHost/node/agentHostServerMain.js [--port <port>] [--host <host>] [--connection-token <token>] [--connection-token-file <path>] [--without-connection-token] [--enable-mock-agent] [--claude-sdk-root <path>] [--codex-sdk-root <path>] [--quiet] [--log <level>]
 
 import { fileURLToPath } from 'url';
 
@@ -32,17 +32,19 @@ import product from '../../product/common/product.js';
 import { IProductService } from '../../product/common/productService.js';
 import { InstantiationService } from '../../instantiation/common/instantiationService.js';
 import { ServiceCollection } from '../../instantiation/common/serviceCollection.js';
+import { registerAgentHostNetworkServices } from './agentHostBootstrap.js';
 import { CopilotAgent } from './copilot/copilotAgent.js';
 import { CopilotApiService, ICopilotApiService } from './shared/copilotApiService.js';
 import { ClaudeAgent } from './claude/claudeAgent.js';
-import { ClaudeAgentSdkService, IClaudeAgentSdkService } from './claude/claudeAgentSdkService.js';
+import { ClaudeAgentSdkService, ClaudeSdkPackage, IClaudeAgentSdkService } from './claude/claudeAgentSdkService.js';
 import { ClaudeProxyService, IClaudeProxyService } from './claude/claudeProxyService.js';
-import { CodexAgent } from './codex/codexAgent.js';
+import { CodexAgent, CodexSdkPackage } from './codex/codexAgent.js';
 import { CodexProxyService, ICodexProxyService } from './codex/codexProxyService.js';
+import { AgentSdkDownloader, IAgentSdkDownloader } from './agentSdkDownloader.js';
 import { IAgentHostOTelService } from '../common/otel/agentHostOTelService.js';
 import { AgentHostOTelService } from './otel/agentHostOTelService.js';
 import { AgentService } from './agentService.js';
-import { AgentHostClaudeSdkPathEnvVar, IAgentService, AgentHostCodexAgentBinaryPathEnvVar } from '../common/agentService.js';
+import { AgentHostClaudeSdkRootEnvVar, IAgentService, AgentHostCodexAgentSdkRootEnvVar } from '../common/agentService.js';
 import { IAgentConfigurationService } from './agentConfigurationService.js';
 import { IAgentHostCompletions } from './agentHostCompletions.js';
 import { IAgentHostTerminalManager } from './agentHostTerminalManager.js';
@@ -85,10 +87,18 @@ interface IServerOptions {
 	readonly port: number;
 	readonly host: string | undefined;
 	readonly enableMockAgent: boolean;
-	/** Absolute path to a locally-installed `@anthropic-ai/claude-agent-sdk` package, or empty to disable the Claude agent. */
-	readonly claudeSdkPath: string;
-	/** Absolute path to a locally-installed `codex` binary, or empty to disable the Codex agent. */
-	readonly codexBinaryPath: string;
+	/**
+	 * Absolute path to the **SDK root directory** that contains
+	 * `node_modules/@anthropic-ai/claude-agent-sdk`. Acts as the dev override
+	 * for the Claude agent; empty falls through to `product.agentSdks.claude`.
+	 */
+	readonly claudeSdkRoot: string;
+	/**
+	 * Absolute path to the **SDK root directory** that contains
+	 * `node_modules/@openai/codex`. Acts as the dev override for the Codex
+	 * agent; empty falls through to `product.agentSdks.codex`.
+	 */
+	readonly codexSdkRoot: string;
 	readonly quiet: boolean;
 	/** Connection token string, or `undefined` when `--without-connection-token`. */
 	readonly connectionToken: string | undefined;
@@ -102,15 +112,17 @@ function parseServerOptions(): IServerOptions {
 	const hostIdx = argv.indexOf('--host');
 	const host = hostIdx >= 0 ? argv[hostIdx + 1] : undefined;
 	const enableMockAgent = argv.includes('--enable-mock-agent');
-	// Claude agent registration is opt-in: enable by passing a path to a
-	// locally-installed `@anthropic-ai/claude-agent-sdk` package via the CLI
-	// flag or the shared env var (the env var is what the agent host starters
-	// use when the `chat.agentHost.claudeAgent.path` workbench setting is set).
-	// The SDK is intentionally not bundled with VS Code.
-	const sdkPathIdx = argv.indexOf('--claude-sdk-path');
-	const claudeSdkPath = (sdkPathIdx >= 0 ? argv[sdkPathIdx + 1] : process.env[AgentHostClaudeSdkPathEnvVar]) ?? '';
-	const codexBinaryPathIdx = argv.indexOf('--codex-binary-path');
-	const codexBinaryPath = (codexBinaryPathIdx >= 0 ? argv[codexBinaryPathIdx + 1] : process.env[AgentHostCodexAgentBinaryPathEnvVar]) ?? '';
+	// `--claude-sdk-root` and `--codex-sdk-root` are dev overrides — they
+	// short-circuit the on-demand download from `product.agentSdks`. They must
+	// point at an SDK ROOT DIRECTORY (the parent of `node_modules/`), not the
+	// package directory or the binary file itself. Required in air-gapped
+	// deployments where the CDN is unreachable AND no product config is
+	// present; in those environments, set one of these flags or the matching
+	// env var, otherwise the corresponding provider will not register.
+	const claudeSdkRootIdx = argv.indexOf('--claude-sdk-root');
+	const claudeSdkRoot = (claudeSdkRootIdx >= 0 ? argv[claudeSdkRootIdx + 1] : process.env[AgentHostClaudeSdkRootEnvVar]) ?? '';
+	const codexSdkRootIdx = argv.indexOf('--codex-sdk-root');
+	const codexSdkRoot = (codexSdkRootIdx >= 0 ? argv[codexSdkRootIdx + 1] : process.env[AgentHostCodexAgentSdkRootEnvVar]) ?? '';
 	const quiet = argv.includes('--quiet');
 
 	// Connection token
@@ -153,7 +165,7 @@ function parseServerOptions(): IServerOptions {
 		connectionToken = generateUuid();
 	}
 
-	return { port, host, enableMockAgent, claudeSdkPath, codexBinaryPath, quiet, connectionToken };
+	return { port, host, enableMockAgent, claudeSdkRoot, codexSdkRoot, quiet, connectionToken };
 }
 
 // ---- Main -------------------------------------------------------------------
@@ -214,6 +226,10 @@ async function main(): Promise<void> {
 	diServices.set(IFileService, fileService);
 	diServices.set(ISessionDataService, sessionDataService);
 	diServices.set(ITelemetryService, telemetryService);
+	// Wire `IPolicyService` + `IConfigurationService` + `IRequestService`
+	// — the trio that `IAgentSdkDownloader` depends on for proxy-aware
+	// downloads. Must run before any downstream service that injects them.
+	await registerAgentHostNetworkServices(diServices, fileService, environmentService, logService, disposables);
 	const instantiationService = new InstantiationService(diServices);
 	const fileMonitorService = disposables.add(instantiationService.createInstance(AgentHostFileMonitorService));
 	diServices.set(IAgentHostFileMonitorService, fileMonitorService);
@@ -243,6 +259,17 @@ async function main(): Promise<void> {
 		// the proxy service constructor requires it.
 		const copilotApiService = instantiationService.createInstance(CopilotApiService, undefined);
 		diServices.set(ICopilotApiService, copilotApiService);
+		// CLI flags become env vars BEFORE the downloader is constructed so
+		// `isAvailable()` and `loadSdkRoot()` see them as dev overrides.
+		if (options.claudeSdkRoot) {
+			process.env[AgentHostClaudeSdkRootEnvVar] = options.claudeSdkRoot;
+		}
+		if (options.codexSdkRoot) {
+			process.env[AgentHostCodexAgentSdkRootEnvVar] = options.codexSdkRoot;
+		}
+		// Register the agent SDK downloader BEFORE any service that injects it.
+		const agentSdkDownloader = instantiationService.createInstance(AgentSdkDownloader);
+		diServices.set(IAgentSdkDownloader, agentSdkDownloader);
 		const claudeProxyService = disposables.add(instantiationService.createInstance(ClaudeProxyService));
 		diServices.set(IClaudeProxyService, claudeProxyService);
 		const claudeAgentSdkService = instantiationService.createInstance(ClaudeAgentSdkService);
@@ -254,16 +281,15 @@ async function main(): Promise<void> {
 		const copilotAgent = disposables.add(instantiationService.createInstance(CopilotAgent));
 		agentService.registerProvider(copilotAgent);
 		log('CopilotAgent registered');
-		if (options.claudeSdkPath) {
-			// `ClaudeAgentSdkService` reads `AgentHostClaudeSdkPathEnvVar` directly,
-			// so make sure it is set even if the path was provided via CLI flag.
-			process.env[AgentHostClaudeSdkPathEnvVar] = options.claudeSdkPath;
+		// Claude and Codex providers are gated on the SDK being reachable —
+		// either via the CLI flag / env var dev override, or via a
+		// `product.agentSdks.<pkg>` entry shipped with this build.
+		if (agentSdkDownloader.isAvailable(ClaudeSdkPackage)) {
 			const claudeAgent = disposables.add(instantiationService.createInstance(ClaudeAgent));
 			agentService.registerProvider(claudeAgent);
 			log('ClaudeAgent registered');
 		}
-		if (options.codexBinaryPath) {
-			process.env[AgentHostCodexAgentBinaryPathEnvVar] = options.codexBinaryPath;
+		if (agentSdkDownloader.isAvailable(CodexSdkPackage)) {
 			const codexAgent = disposables.add(instantiationService.createInstance(CodexAgent));
 			agentService.registerProvider(codexAgent);
 			log('CodexAgent registered');

--- a/src/vs/platform/agentHost/node/agentSdkDownloader.ts
+++ b/src/vs/platform/agentHost/node/agentSdkDownloader.ts
@@ -1,0 +1,453 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as tar from 'tar';
+import { VSBuffer } from '../../../base/common/buffer.js';
+import { CancellationToken } from '../../../base/common/cancellation.js';
+import { CancellationError } from '../../../base/common/errors.js';
+import * as path from '../../../base/common/path.js';
+import { isLinux } from '../../../base/common/platform.js';
+import { format2 } from '../../../base/common/strings.js';
+import { URI } from '../../../base/common/uri.js';
+import { INativeEnvironmentService } from '../../environment/common/environment.js';
+import { FileOperationError, FileOperationResult, IFileService, toFileOperationResult } from '../../files/common/files.js';
+import { createDecorator } from '../../instantiation/common/instantiation.js';
+import { ILogService } from '../../log/common/log.js';
+import { IProductService } from '../../product/common/productService.js';
+import { IRequestService } from '../../request/common/request.js';
+import { IRequestContext } from '../../../base/parts/request/common/request.js';
+
+// #region Per-package strategy
+
+/**
+ * One agent-SDK package the downloader can fetch. Holds the per-package
+ * knowledge that varies between Claude, Codex, and any future provider —
+ * the env var that acts as a dev override, and whether this SDK ships
+ * separate `*-musl` Linux packages so the downloader knows whether to
+ * append the suffix on musl hosts.
+ *
+ * The downloader itself is package-agnostic: it consumes this interface and
+ * never branches on `id`. Concrete `IAgentSdkPackage` instances live in
+ * their owning agent module (e.g. `ClaudeSdkPackage` in
+ * `claude/claudeAgentSdkService.ts`, `CodexSdkPackage` in
+ * `codex/codexAgent.ts`) so Claude-specific / Codex-specific knowledge
+ * stays in those modules — the downloader doesn't name the providers it
+ * serves.
+ */
+export interface IAgentSdkPackage {
+	/** Key under `product.agentSdks` — e.g. `'claude'`, `'codex'`. */
+	readonly id: string;
+	/** Env var that, when set, becomes the SDK root and short-circuits the download. */
+	readonly devOverrideEnvVar: string;
+	/**
+	 * True iff this SDK ships separate `*-musl` Linux packages alongside the
+	 * regular `linux-*` ones (Claude does; Codex's Linux binaries are already
+	 * statically musl-linked so it ships a single `linux-*` SKU for both
+	 * libc families).
+	 */
+	readonly hasSeparateMuslLinuxPackage: boolean;
+}
+
+/**
+ * `${platform}-${arch}`, optionally suffixed with `-musl` on Linux. Matches
+ * the suffix npm uses for the platform `optionalDependencies` packages
+ * (`@anthropic-ai/claude-agent-sdk-${target}`, `@openai/codex-${target}`).
+ */
+function resolvePlatformArch(pkg: IAgentSdkPackage): string | undefined {
+	const platform = process.platform;
+	const arch = process.arch;
+	if (platform !== 'linux' && platform !== 'darwin' && platform !== 'win32') {
+		return undefined;
+	}
+	if (arch !== 'x64' && arch !== 'arm64') {
+		return undefined;
+	}
+	const base = `${platform}-${arch}`;
+	if (pkg.hasSeparateMuslLinuxPackage && isLinux && isMusl()) {
+		return `${base}-musl`;
+	}
+	return base;
+}
+
+let _muslCached: boolean | undefined;
+/** Linux-only — Node sets `glibcVersionRuntime` only when linked against glibc. */
+function isMusl(): boolean {
+	if (_muslCached !== undefined) {
+		return _muslCached;
+	}
+	try {
+		const report = process.report?.getReport?.();
+		const header = report && (report as { header?: { glibcVersionRuntime?: string } }).header;
+		_muslCached = !header?.glibcVersionRuntime;
+	} catch {
+		_muslCached = false;
+	}
+	return _muslCached;
+}
+
+// #endregion
+
+// #region Service decorator
+
+export const IAgentSdkDownloader = createDecorator<IAgentSdkDownloader>('agentSdkDownloader');
+
+export interface IAgentSdkDownloader {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Returns the absolute path of the SDK root directory — the directory that
+	 * contains the package's `node_modules/` subtree. Callers resolve the
+	 * package-specific entrypoint from there themselves.
+	 *
+	 * Resolution order:
+	 *   1. dev-override env var (returned unchanged)
+	 *   2. on-disk cache hit (re-verified against `product.json` sha256)
+	 *   3. download from `product.agentSdks?.[pkg.id]` and verify
+	 *
+	 * Repeated failures are latched for {@link LOAD_FAILURE_NEGATIVE_CACHE_MS}
+	 * so a misconfigured CDN doesn't get hammered on every SDK method call.
+	 */
+	loadSdkRoot(pkg: IAgentSdkPackage, token: CancellationToken): Promise<string>;
+
+	/**
+	 * Cheap, synchronous gate used at startup to decide whether to register
+	 * the corresponding agent provider. True iff the dev override is set, OR
+	 * `product.agentSdks?.[pkg.id]` declares a sha256 for the current
+	 * platform. Does NOT trigger a download.
+	 */
+	isAvailable(pkg: IAgentSdkPackage): boolean;
+
+	/**
+	 * Returns the npm-style `${platform}-${arch}` suffix used by `pkg`'s
+	 * platform `optionalDependencies`, or undefined for unsupported
+	 * (platform, arch) combinations. Honors {@link IAgentSdkPackage.hasSeparateMuslLinuxPackage}
+	 * on Linux musl hosts. Callers that need to locate the platform package
+	 * directory (e.g. to spawn a binary inside it) share this resolution
+	 * with the downloader's internal one.
+	 */
+	resolveSdkTarget(pkg: IAgentSdkPackage): string | undefined;
+}
+
+// #endregion
+
+// #region Implementation
+
+/** How long a `loadSdkRoot` failure latches before we try again. */
+const LOAD_FAILURE_NEGATIVE_CACHE_MS = 30_000;
+
+export class AgentSdkDownloader implements IAgentSdkDownloader {
+	declare readonly _serviceBrand: undefined;
+
+	/**
+	 * In-flight downloads keyed by `<pkg>/<sdkVersion>/<sdkTarget>`. Concurrent
+	 * `loadSdkRoot` calls in the same process share the same promise so we
+	 * never download the same tarball twice.
+	 */
+	private readonly _pendingDownloads = new Map<string, Promise<string>>();
+
+	/**
+	 * Negative cache: most recent failure per package id, with an expiry. While
+	 * within the window, `loadSdkRoot` re-throws the cached error immediately
+	 * instead of re-attempting the download. Without this, a broken CDN /
+	 * mismatched sha causes every SDK method call (poll-driven UIs hit this
+	 * hard) to fire a fresh request.
+	 */
+	private readonly _failureLatch = new Map<string, { error: Error; expiresAt: number }>();
+
+	constructor(
+		@INativeEnvironmentService private readonly _environmentService: INativeEnvironmentService,
+		@IProductService private readonly _productService: IProductService,
+		@IRequestService private readonly _requestService: IRequestService,
+		@IFileService private readonly _fileService: IFileService,
+		@ILogService private readonly _logService: ILogService,
+	) { }
+
+	isAvailable(pkg: IAgentSdkPackage): boolean {
+		if (process.env[pkg.devOverrideEnvVar]) {
+			return true;
+		}
+		const config = this._productService.agentSdks?.[pkg.id];
+		if (!config) {
+			return false;
+		}
+		const target = this.resolveSdkTarget(pkg);
+		return target !== undefined && config.sha256[target] !== undefined;
+	}
+
+	resolveSdkTarget(pkg: IAgentSdkPackage): string | undefined {
+		return resolvePlatformArch(pkg);
+	}
+
+	async loadSdkRoot(pkg: IAgentSdkPackage, token: CancellationToken): Promise<string> {
+		// 1. Dev override.
+		const override = process.env[pkg.devOverrideEnvVar];
+		if (override) {
+			this._logService.info(`[AgentSdkDownloader] ${pkg.id}: using dev override at ${override}`);
+			return override;
+		}
+
+		// 2. Negative cache: a recent failure short-circuits without I/O.
+		const latched = this._failureLatch.get(pkg.id);
+		if (latched && latched.expiresAt > Date.now()) {
+			throw latched.error;
+		}
+
+		try {
+			const root = await this._resolveOrDownload(pkg, token);
+			this._failureLatch.delete(pkg.id);
+			return root;
+		} catch (err) {
+			if (token.isCancellationRequested) {
+				// Don't latch cancellations — user intent, not a real failure.
+				throw err;
+			}
+			const error = err instanceof Error ? err : new Error(String(err));
+			this._failureLatch.set(pkg.id, {
+				error,
+				expiresAt: Date.now() + LOAD_FAILURE_NEGATIVE_CACHE_MS,
+			});
+			throw error;
+		}
+	}
+
+	private async _resolveOrDownload(pkg: IAgentSdkPackage, token: CancellationToken): Promise<string> {
+		const config = this._productService.agentSdks?.[pkg.id];
+		if (!config) {
+			throw new Error(
+				`Cannot load ${pkg.id} SDK: no \`product.agentSdks.${pkg.id}\` configured and ` +
+				`no ${pkg.devOverrideEnvVar} dev override set.`,
+			);
+		}
+		const target = this.resolveSdkTarget(pkg);
+		if (!target) {
+			throw new Error(
+				`Cannot load ${pkg.id} SDK: platform ${process.platform}-${process.arch} is not supported.`,
+			);
+		}
+		const expectedSha = config.sha256[target];
+		if (!expectedSha) {
+			const available = Object.keys(config.sha256).sort().join(', ');
+			throw new Error(
+				`Cannot load ${pkg.id} SDK: target \`${target}\` is not in the supported set ` +
+				`[${available}]. Set ${pkg.devOverrideEnvVar} to override.`,
+			);
+		}
+
+		const cacheDir = this._cacheDir(pkg.id, config.version, target);
+		const sentinel = URI.joinPath(URI.file(cacheDir), '.complete');
+
+		// Cache hit (always re-verify against product.json sha256).
+		if (await this._cacheHit(sentinel, expectedSha)) {
+			return cacheDir;
+		}
+		// Drop a stale cache before re-downloading — covers the vscode-distro
+		// "same version, different sha" case.
+		if (await this._fileService.exists(sentinel)) {
+			this._logService.warn(`[AgentSdkDownloader] ${pkg.id}@${config.version}: cache sha mismatch, redownloading`);
+			await this._delIgnoringMissing(URI.file(cacheDir));
+		}
+
+		// Download (deduped across concurrent callers in the same process).
+		const key = `${pkg.id}/${config.version}/${target}`;
+		let pending = this._pendingDownloads.get(key);
+		if (!pending) {
+			const url = format2(config.urlTemplate, { sdkVersion: config.version, sdkTarget: target });
+			pending = this._download(pkg, url, expectedSha, cacheDir, sentinel, token).finally(() => {
+				this._pendingDownloads.delete(key);
+			});
+			this._pendingDownloads.set(key, pending);
+		}
+		return pending;
+	}
+
+	private _cacheDir(packageId: string, sdkVersion: string, sdkTarget: string): string {
+		return path.join(
+			this._environmentService.userDataPath,
+			'agent-host',
+			'sdk-cache',
+			packageId,
+			sdkVersion,
+			sdkTarget,
+		);
+	}
+
+	/**
+	 * True iff the `.complete` sentinel at {@link sentinel} exists and contains
+	 * `expectedSha`. Shared by the fast-path cache check and the rename-loser
+	 * race recovery.
+	 */
+	private async _cacheHit(sentinel: URI, expectedSha: string): Promise<boolean> {
+		if (!(await this._fileService.exists(sentinel))) {
+			return false;
+		}
+		const recorded = await this._readFileText(sentinel);
+		return recorded.trim() === expectedSha;
+	}
+
+	private async _download(
+		pkg: IAgentSdkPackage,
+		url: string,
+		expectedSha: string,
+		cacheDir: string,
+		sentinel: URI,
+		token: CancellationToken,
+	): Promise<string> {
+		this._logService.info(`[AgentSdkDownloader] ${pkg.id}: downloading from ${url}`);
+		const start = Date.now();
+		const parent = path.dirname(cacheDir);
+		await this._fileService.createFolder(URI.file(parent));
+
+		// Extract to a per-pid scratch dir alongside the final cache dir, then
+		// rename into place. If two windows of the same install race, the loser
+		// catches the `move`'s `FILE_MOVE_CONFLICT`, verifies the existing
+		// .complete sha, and uses that instead — see the rename-loser path below.
+		const tmpDir = `${cacheDir}.tmp.${process.pid}`;
+		const tmpDirUri = URI.file(tmpDir);
+		await this._delIgnoringMissing(tmpDirUri);
+		await this._fileService.createFolder(tmpDirUri);
+
+		try {
+			const tarballPath = path.join(tmpDir, 'sdk.tgz');
+			await this._fetchAndVerify(url, tarballPath, expectedSha, token);
+			await this._extractTarGz(tarballPath, tmpDir);
+			await this._fileService.del(URI.file(tarballPath));
+
+			// Atomic publish of the completed extraction.
+			try {
+				await this._fileService.move(tmpDirUri, URI.file(cacheDir));
+			} catch (err) {
+				if (await this._handleRenameLoser(err, sentinel, expectedSha, tmpDirUri)) {
+					this._logService.info(`[AgentSdkDownloader] ${pkg.id}: lost rename race, using existing cache`);
+					return cacheDir;
+				}
+				throw err;
+			}
+
+			await this._fileService.writeFile(sentinel, VSBuffer.fromString(expectedSha));
+			const elapsed = Math.round((Date.now() - start) / 1000);
+			this._logService.info(`[AgentSdkDownloader] ${pkg.id}: downloaded + verified in ${elapsed}s`);
+			return cacheDir;
+		} catch (err) {
+			await this._delIgnoringMissing(tmpDirUri);
+			if (token.isCancellationRequested) {
+				throw new CancellationError();
+			}
+			throw new Error(
+				`Failed to download ${pkg.id} SDK from ${url} ` +
+				`(cache target: ${cacheDir}). ` +
+				`Set ${pkg.devOverrideEnvVar} to a local SDK root to bypass. ` +
+				`Cause: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+	}
+
+	private async _handleRenameLoser(
+		err: unknown,
+		sentinel: URI,
+		expectedSha: string,
+		tmpDirUri: URI,
+	): Promise<boolean> {
+		// `IFileService.move` with default (overwrite: false) throws a
+		// FileOperationError with FILE_MOVE_CONFLICT when the target exists.
+		// Anything else is a real error.
+		if (!(err instanceof FileOperationError) || err.fileOperationResult !== FileOperationResult.FILE_MOVE_CONFLICT) {
+			return false;
+		}
+		if (!(await this._cacheHit(sentinel, expectedSha))) {
+			return false;
+		}
+		// Winner already published a matching cache. Drop our scratch dir.
+		await this._delIgnoringMissing(tmpDirUri);
+		return true;
+	}
+
+	private async _fetchAndVerify(url: string, dest: string, expectedSha: string, token: CancellationToken): Promise<void> {
+		// Delegate to IRequestService (corporate proxy, strictSSL, kerberos,
+		// retries, redirect follow). We tee the network stream through a
+		// sha256 hasher AND a write stream so the tarball is verified on
+		// the way in — one pass instead of writing then re-reading.
+		// `fs.createWriteStream` (not `IFileService.writeFile`) so that
+		// cancelling a multi-MB download aborts promptly via destroy().
+		if (token.isCancellationRequested) {
+			throw new CancellationError();
+		}
+		const context: IRequestContext = await this._requestService.request({
+			url,
+			type: 'GET',
+			callSite: 'agentSdkDownloader',
+		}, token);
+		if (token.isCancellationRequested) {
+			context.stream.destroy();
+			throw new CancellationError();
+		}
+
+		const statusCode = context.res.statusCode ?? 0;
+		if (statusCode < 200 || statusCode >= 300) {
+			context.stream.destroy();
+			throw new Error(`HTTP ${statusCode} fetching ${url}`);
+		}
+
+		const hash = crypto.createHash('sha256');
+		await new Promise<void>((resolve, reject) => {
+			const out = fs.createWriteStream(dest);
+			let settled = false;
+			const settleResolve = () => {
+				if (settled) { return; }
+				settled = true;
+				cancelSub.dispose();
+				resolve();
+			};
+			const settleReject = (err: unknown) => {
+				if (settled) { return; }
+				settled = true;
+				cancelSub.dispose();
+				context.stream.destroy();
+				out.destroy();
+				reject(err);
+			};
+			const cancelSub = token.onCancellationRequested(() => settleReject(new CancellationError()));
+			out.on('error', settleReject);
+			out.on('finish', settleResolve);
+			context.stream.on('data', chunk => { hash.update(chunk.buffer); out.write(chunk.buffer); });
+			context.stream.on('end', () => out.end());
+			context.stream.on('error', settleReject);
+		});
+
+		const actualSha = hash.digest('hex');
+		if (actualSha !== expectedSha) {
+			throw new Error(`sha256 mismatch: expected ${expectedSha}, got ${actualSha}`);
+		}
+	}
+
+	private async _extractTarGz(tarball: string, dest: string): Promise<void> {
+		// `tar` (node-tar) is pure JS — works on every platform the agent host
+		// runs on without depending on a system `tar` binary.
+		await tar.x({ file: tarball, cwd: dest });
+	}
+
+	private async _readFileText(uri: URI): Promise<string> {
+		try {
+			const content = await this._fileService.readFile(uri);
+			return content.value.toString();
+		} catch {
+			return '';
+		}
+	}
+
+	private async _delIgnoringMissing(uri: URI): Promise<void> {
+		try {
+			await this._fileService.del(uri, { recursive: true });
+		} catch (err) {
+			// `force: true` behaviour: missing path is a no-op.
+			if (toFileOperationResult(err as Error) !== FileOperationResult.FILE_NOT_FOUND) {
+				throw err;
+			}
+		}
+	}
+}
+
+// #endregion

--- a/src/vs/platform/agentHost/node/agentSdkDownloader.ts
+++ b/src/vs/platform/agentHost/node/agentSdkDownloader.ts
@@ -316,6 +316,17 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 			await this._extractTarGz(tarballPath, tmpDir);
 			await this._fileService.del(URI.file(tarballPath));
 
+			// Write the `.complete` sentinel inside the tmp dir BEFORE the move.
+			// That way the move atomically publishes a directory that already
+			// carries its sentinel — a crash between move and sentinel-write
+			// can't leave a wedged, sentinel-less cacheDir behind (which would
+			// trip `_handleRenameLoser` on the next attempt and require a
+			// manual cache wipe to recover).
+			await this._fileService.writeFile(
+				URI.joinPath(tmpDirUri, '.complete'),
+				VSBuffer.fromString(expectedSha),
+			);
+
 			// Atomic publish of the completed extraction.
 			try {
 				await this._fileService.move(tmpDirUri, URI.file(cacheDir));
@@ -327,7 +338,6 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 				throw err;
 			}
 
-			await this._fileService.writeFile(sentinel, VSBuffer.fromString(expectedSha));
 			const elapsed = Math.round((Date.now() - start) / 1000);
 			this._logService.info(`[AgentSdkDownloader] ${pkg.id}: downloaded + verified in ${elapsed}s`);
 			return cacheDir;

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts
@@ -5,12 +5,26 @@
 
 import type { AnyZodRawShape, GetSessionMessagesOptions, GetSubagentMessagesOptions, InferShape, ListSessionsOptions, ListSubagentsOptions, McpSdkServerConfigWithInstance, Options, SDKSessionInfo, SdkMcpToolDefinition, SessionMessage, WarmQuery } from '@anthropic-ai/claude-agent-sdk';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import * as fs from 'fs';
 import { pathToFileURL } from 'url';
-import { join, resolve } from '../../../../base/common/path.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { join } from '../../../../base/common/path.js';
 import { createDecorator } from '../../../instantiation/common/instantiation.js';
 import { ILogService } from '../../../log/common/log.js';
-import { AgentHostClaudeSdkPathEnvVar } from '../../common/agentService.js';
+import { IAgentSdkDownloader, IAgentSdkPackage } from '../agentSdkDownloader.js';
+import { AgentHostClaudeSdkRootEnvVar } from '../../common/agentService.js';
+
+/**
+ * `@anthropic-ai/claude-agent-sdk` distribution descriptor. Lives in this
+ * file because it encodes Claude-specific knowledge — the env-var name and
+ * the fact that Claude ships separate `linux-*-musl` packages alongside
+ * the regular `linux-*` ones. The downloader consumes this through
+ * `IAgentSdkPackage` and never names Claude directly.
+ */
+export const ClaudeSdkPackage: IAgentSdkPackage = {
+	id: 'claude',
+	devOverrideEnvVar: AgentHostClaudeSdkRootEnvVar,
+	hasSeparateMuslLinuxPackage: true,
+};
 
 export const IClaudeAgentSdkService = createDecorator<IClaudeAgentSdkService>('claudeAgentSdkService');
 
@@ -56,9 +70,11 @@ export interface IClaudeAgentSdkService {
  * Narrowed structural slice of `@anthropic-ai/claude-agent-sdk` covering
  * exactly the bindings the agent host pulls from the SDK. Production
  * `import()` returns the full module which is structurally assignable to
- * this interface; tests subclass {@link ClaudeAgentSdkService} and
- * override {@link ClaudeAgentSdkService._loadSdk} to fault or stub these
- * bindings without having to name every export of the SDK module.
+ * this interface. Tests usually stub {@link IClaudeAgentSdkService} via
+ * the DI container, but a few existing suites subclass
+ * {@link ClaudeAgentSdkService} and override {@link ClaudeAgentSdkService._loadSdk}
+ * to fault or stub these bindings without having to name every export of
+ * the SDK module — `_loadSdk` is `protected` for that reason.
  */
 export interface IClaudeSdkBindings {
 	listSessions(options?: ListSessionsOptions): Promise<SDKSessionInfo[]>;
@@ -99,6 +115,7 @@ export class ClaudeAgentSdkService implements IClaudeAgentSdkService {
 
 	constructor(
 		@ILogService private readonly _logService: ILogService,
+		@IAgentSdkDownloader private readonly _downloader: IAgentSdkDownloader,
 	) { }
 
 	async listSessions(): Promise<readonly SDKSessionInfo[]> {
@@ -168,27 +185,12 @@ export class ClaudeAgentSdkService implements IClaudeAgentSdkService {
 	}
 
 	protected async _loadSdk(): Promise<IClaudeSdkBindings> {
-		// The SDK is intentionally not bundled with VS Code. The user supplies an
-		// absolute path to a locally-installed `@anthropic-ai/claude-agent-sdk`
-		// package via the `chat.agentHost.claudeAgent.path` setting, which is
-		// forwarded to this process as `AgentHostClaudeSdkPathEnvVar`. Convert
-		// to a `file://` URL so dynamic `import()` accepts paths with spaces and
-		// works on Windows.
-		const sdkPath = process.env[AgentHostClaudeSdkPathEnvVar];
-		if (!sdkPath) {
-			throw new Error(`Cannot load @anthropic-ai/claude-agent-sdk: ${AgentHostClaudeSdkPathEnvVar} is not set. Set the 'chat.agentHost.claudeAgent.path' setting to a locally-installed SDK package.`);
-		}
-		// Node ESM rejects directory imports, so if the user pointed at the
-		// package directory, resolve its `exports['.']` / `main` entry first.
-		let entry = sdkPath;
-		if (fs.statSync(sdkPath).isDirectory()) {
-			const pkgJson = JSON.parse(fs.readFileSync(join(sdkPath, 'package.json'), 'utf8'));
-			const mainEntry = pkgJson.exports?.['.']?.default
-				?? pkgJson.exports?.['.']?.import
-				?? pkgJson.main
-				?? 'index.js';
-			entry = resolve(sdkPath, mainEntry);
-		}
+		// Resolve the SDK root via the downloader: dev override → cache →
+		// download from `product.agentSdks.claude`. The known internal
+		// `sdk.mjs` entrypoint is hard-coded here because this file is the
+		// one place that owns knowledge of the Claude SDK's import surface.
+		const root = await this._downloader.loadSdkRoot(ClaudeSdkPackage, CancellationToken.None);
+		const entry = join(root, 'node_modules', '@anthropic-ai', 'claude-agent-sdk', 'sdk.mjs');
 		return import(pathToFileURL(entry).href);
 	}
 }

--- a/src/vs/platform/agentHost/node/claude/phase13-plan.md
+++ b/src/vs/platform/agentHost/node/claude/phase13-plan.md
@@ -32,7 +32,7 @@ Fork support (Phase 6.5) is explicitly *not* a Phase 13 concern. The earlier pla
 ## Prerequisites
 
 - Phase 4 (provider scaffold) ✅, Phase 5 (lifecycle + SDK service) ✅, Phase 6 (live message pipeline + `ClaudeMapperState`) ✅, Phase 9 (abort/steering polish) ✅.
-- SDK is loaded via `AgentHostClaudeSdkPathEnvVar` (current dev mechanism) and matches whatever version is on disk; long-term distribution is Phase 15's marketplace-extension story. Phase 13 binds against the SDK shape currently exposed by [`claudeAgentSdkService.ts`](./claudeAgentSdkService.ts) and does not assume a specific package version.
+- SDK is loaded via `AgentHostClaudeSdkRootEnvVar` (current dev mechanism) and matches whatever version is on disk; long-term distribution is Phase 15's marketplace-extension story. Phase 13 binds against the SDK shape currently exposed by [`claudeAgentSdkService.ts`](./claudeAgentSdkService.ts) and does not assume a specific package version.
 
 ## Approach
 
@@ -113,7 +113,7 @@ Fork support (Phase 6.5) is explicitly *not* a Phase 13 concern. The earlier pla
 - **Wrong-id-class returned to fork.** Phase 13 does not return any id mapping; the risk lives entirely in Phase 6.5. The id-correctness note above documents the trap (`SessionMessage.uuid` is the envelope uuid `forkSession({ upToMessageId })` accepts; `message.id` is the Anthropic `msg_…` id, which fork does *not* accept) so Phase 6.5 picks the right id class when it consumes `SessionMessage` itself.
 - **Subagent allowlist drift.** New SDK versions might introduce additional subagent-spawning tools. Mitigation: `claudeToolDisplay.ts` is the single source of truth for tool kinds — add new entries there and the replay mapper picks them up via the same lookup.
 - **System-message noise.** `includeSystemMessages: true` adds many subtypes. Mitigation: explicit allowlist from [CONTEXT M7](./CONTEXT.md) (only `compact_boundary` and a few notification subtypes become response parts; everything else drops). Test fixture for a non-allowlisted subtype to assert it's dropped.
-- **SDK version mismatch.** ~~See Open Questions Q1.~~ Resolved during grilling: SDK is loaded from `AgentHostClaudeSdkPathEnvVar` and Phase 13 binds against whatever shape `claudeAgentSdkService.ts` currently exposes; long-term version distribution is Phase 15's marketplace-extension problem (see [roadmap.md §Phase 15](./roadmap.md)).
+- **SDK version mismatch.** ~~See Open Questions Q1.~~ Resolved during grilling: SDK is loaded from `AgentHostClaudeSdkRootEnvVar` and Phase 13 binds against whatever shape `claudeAgentSdkService.ts` currently exposes; long-term version distribution is Phase 15's marketplace-extension problem (see [roadmap.md §Phase 15](./roadmap.md)).
 
 ## Verification
 

--- a/src/vs/platform/agentHost/node/claude/roadmap.md
+++ b/src/vs/platform/agentHost/node/claude/roadmap.md
@@ -1276,65 +1276,53 @@ fork end-to-end ships in Phase 6.5.
 
 Exit criteria: ready to enable for external preview.
 
-### Phase 15 — SDK distribution via marketplace extension
+### Phase 15 — SDK distribution via `product.json` + main.vscode-cdn.net
 
-**Status as of 2026-05-13:** the agent host already runs against the latest
-`@anthropic-ai/claude-agent-sdk` rather than `0.2.112`, but the SDK is loaded
-from a path the user supplies (`chat.agentHost.claudeAgent.path` setting →
-`AgentHostClaudeSdkPathEnvVar`, see [`claudeAgentSdkService.ts:148`](./claudeAgentSdkService.ts#L148)).
-That mechanism unblocked development but is **not shippable**: it requires
-every user to install the SDK locally and configure a path.
+**Status as of 2026-06-09:** Phase 15 has landed in the agent host. The Claude
+and Codex SDK distributions are now declared in `product.json` and downloaded
+on demand by [`agentSdkDownloader.ts`](../agentSdkDownloader.ts) into
+`<userDataPath>/agent-host/sdk-cache/<pkg>/<sdkVersion>/<sdkTarget>/`. The
+hand-supplied paths (`chat.agentHost.claudeAgent.path` →
+`AgentHostClaudeSdkRootEnvVar`, see
+[`claudeAgentSdkService.ts:148`](./claudeAgentSdkService.ts#L148), and the
+Codex equivalent) survive as a **dev override** only — set them to bypass
+the download.
 
-**Direction:** distribute the SDK as a versioned VS Code extension so users
-get it through the normal install flow.
+**Shape:**
 
-1. **Agent Host gains marketplace-install capability.** Today the agent
-   host is a closed utility process; it cannot fetch or install
-   extensions. Add the IPC + extension-management surface needed for the
-   agent host to install / update / load extensions from the VS Code
-   marketplace (or a registry it trusts).
-2. **Publish a Claude SDK packaging extension to the marketplace.** A
-   thin extension whose only job is to ship a vetted version of
-   `@anthropic-ai/claude-agent-sdk` (and any native deps) and expose its
-   load path to the agent host. Versioned on the marketplace so SDK
-   upgrades become extension updates, not VS Code releases.
-3. **Agent host loads the SDK from the installed extension** instead of
-   from `AgentHostClaudeSdkPathEnvVar`. The env-var path stays as a dev
-   override. The setting `chat.agentHost.claudeAgent.path` is repurposed
-   (or removed) for end users.
+- `product.agentSdks.{claude,codex}` ships a `version`, a `urlTemplate`
+  with `{sdkVersion}` / `{sdkTarget}` placeholders, and a per-target
+  `sha256` map. `{sdkTarget}` matches the npm `optionalDependencies`
+  suffix (`darwin-arm64`, `linux-x64-musl`, …). Codex's Linux entries
+  never carry the `-musl` suffix because the Codex shim always loads the
+  musl binary regardless of host libc.
+- `vscode-distro` is where `product.agentSdks` is populated; OSS
+  `product.json` does not have it.
+- Tarballs ship as the full `node_modules/` subtree extracted into the
+  cache directory above. `ClaudeAgentSdkService._loadSdk` and
+  `CodexAgent._startConnection` know the package-internal entrypoints
+  (`@anthropic-ai/claude-agent-sdk/sdk.mjs`, `@openai/codex/bin/codex.js`)
+  and resolve them off the returned root.
+- Trust: the sha256 in `product.json` (itself inside the signed
+  application bundle and covered by `product.checksums`) is the trust
+  anchor — CDN tampering fails verification. No separate signed
+  manifest.
+- Provider registration is gated on
+  `IAgentSdkDownloader.isAvailable(pkg)` — true iff the dev-override
+  env var is set, OR product config has a sha for the current target.
+  If neither, the provider is not registered and never appears in the
+  agent picker (matches the pre-CDN UX).
 
-**Why this shape:**
-- SDK upgrades ship out-of-band from VS Code (no need to bundle a
-  specific SDK version into every VS Code release).
-- The native-dependency packaging burden moves to the extension's
-  publishing pipeline, which is already a solved problem for VS Code
-  extensions across `win32-x64`, `darwin-x64`, `darwin-arm64`,
-  `linux-x64`.
-- Multiple SDK-packaging extensions could coexist (e.g. an `@stable`
-  extension and a `@preview` extension), letting the user opt into
-  newer SDKs without a VS Code update.
-- Other agent SDKs (future Anthropic / OpenAI / etc. providers) follow
-  the same model.
+**Exit criteria (met):**
+- Fresh insiders install can use Claude/Codex without manually
+  installing the SDK or setting any path.
+- SDK version bumps are now `vscode-distro` changes that re-pin
+  `product.agentSdks[pkg].version` and the per-target sha256 entries.
+- Dev override keeps working for SDK development.
 
-**Open design points** (to be detailed in a phase plan when scheduled):
-- IPC surface for agent-host-driven extension install (mirror or
-  delegate to the workbench's extension service?).
-- Discovery contract: how does the agent host know which installed
-  extension provides the Claude SDK? (e.g. an extension `contributes`
-  field, a well-known activation event, a manifest-declared capability).
-- Trust model: is the marketplace publisher the source of truth, or
-  does the agent host pin a specific publisher / extension id?
-- Dev override: keep `AgentHostClaudeSdkPathEnvVar` as the
-  non-marketplace fallback for SDK development.
-
-This phase replaces the previous "upgrade the bundled SDK to a newer
-0.2.x" plan, which assumed the SDK would always be a normal `npm`
-dependency. That assumption no longer holds now that the SDK ships
-native binaries.
-
-Exit criteria: a fresh VS Code install can use the Claude agent without
-manually installing the SDK or setting any path. SDK upgrades arrive as
-marketplace extension updates.
+**Build pipeline** — see `build/agent-sdk/` for the tarball production
+and CDN upload tooling, including the deterministic-tar setup that
+makes `verify-determinism.ts` enforceable in CI.
 
 ### Phase 16 — Eager session materialization at create time
 

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -16,7 +16,7 @@ import { IInstantiationService } from '../../../instantiation/common/instantiati
 import { localize } from '../../../../nls.js';
 import { ILogService } from '../../../log/common/log.js';
 import { createSchema, platformSessionSchema, schemaProperty } from '../../common/agentHostSchema.js';
-import { AgentHostCodexAgentBinaryArgsEnvVar, AgentHostCodexAgentBinaryPathEnvVar, AgentHostCodexAgentCodexHomeEnvVar, AgentSession, AgentSignal, GITHUB_COPILOT_PROTECTED_RESOURCE, IAgent, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, type AgentProvider } from '../../common/agentService.js';
+import { AgentHostCodexAgentBinaryArgsEnvVar, AgentHostCodexAgentCodexHomeEnvVar, AgentHostCodexAgentSdkRootEnvVar, AgentSession, AgentSignal, GITHUB_COPILOT_PROTECTED_RESOURCE, IAgent, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, type AgentProvider } from '../../common/agentService.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProtocol.js';
 import { ActionType, type SessionAction } from '../../common/state/sessionActions.js';
@@ -26,6 +26,8 @@ import { type ClientPluginCustomization, type MessageAttachment, type PendingMes
 import type { ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import { ICopilotApiService } from '../shared/copilotApiService.js';
+import { IAgentSdkDownloader, IAgentSdkPackage } from '../agentSdkDownloader.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
 import { CodexAppServerClient, JsonRpcError, transportFromChildProcess, type ICodexAppServerClient } from './codexAppServerClient.js';
 import { ICodexProxyService, type ICodexProxyHandle } from './codexProxyService.js';
@@ -261,6 +263,20 @@ interface IConnectionReady {
  * 10 (no cwd → reject), 15 (cancel, keep streamed content), 16 (steering),
  * 17 (attachments), 18 (apikey auth).
  */
+
+/**
+ * `@openai/codex` distribution descriptor. Lives in this file because it
+ * encodes Codex-specific knowledge — the env-var name and the fact that
+ * Codex's Linux binaries are statically musl-linked, so it ships a single
+ * `linux-*` SKU that runs on both glibc and musl hosts. The downloader
+ * consumes this through `IAgentSdkPackage` and never names Codex directly.
+ */
+export const CodexSdkPackage: IAgentSdkPackage = {
+	id: 'codex',
+	devOverrideEnvVar: AgentHostCodexAgentSdkRootEnvVar,
+	hasSeparateMuslLinuxPackage: false,
+};
+
 export class CodexAgent extends Disposable implements IAgent {
 
 	readonly id: AgentProvider = 'codex';
@@ -288,6 +304,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		@ICopilotApiService private readonly _copilotApiService: ICopilotApiService,
 		@ICodexProxyService private readonly _codexProxyService: ICodexProxyService,
 		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
+		@IAgentSdkDownloader private readonly _agentSdkDownloader: IAgentSdkDownloader,
 		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super();
@@ -517,10 +534,24 @@ export class CodexAgent extends Disposable implements IAgent {
 	}
 
 	private async _startConnection(token: string): Promise<IConnectionReady> {
-		const binaryPath = process.env[AgentHostCodexAgentBinaryPathEnvVar];
-		if (!binaryPath) {
-			throw new Error(`Codex binary path not configured. Set 'chat.agentHost.codexAgent.path' to an absolute path to the codex CLI.`);
+		// Resolve the Codex SDK root via the downloader: dev override → cache →
+		// download from `product.agentSdks.codex`. We spawn the native codex
+		// binary inside the platform package directly (the same shape the JS
+		// shim at `node_modules/@openai/codex/bin/codex.js` would resolve to)
+		// — going through the shim adds a launcher hop and forces an
+		// `ELECTRON_RUN_AS_NODE` round-trip when the agent host runs as an
+		// Electron utility process.
+		const root = await this._agentSdkDownloader.loadSdkRoot(CodexSdkPackage, CancellationToken.None);
+		const codexTarget = this._agentSdkDownloader.resolveSdkTarget(CodexSdkPackage);
+		if (!codexTarget) {
+			throw new Error(`Codex: unsupported platform ${process.platform}-${process.arch}`);
 		}
+		const triple = codexBinaryTriple(codexTarget);
+		if (!triple) {
+			throw new Error(`Codex: no binary triple known for sdkTarget '${codexTarget}'`);
+		}
+		const binaryName = process.platform === 'win32' ? 'codex.exe' : 'codex';
+		const binaryPath = join(root, 'node_modules', `@openai/codex-${codexTarget}`, 'vendor', triple, 'bin', binaryName);
 		try {
 			fs.accessSync(binaryPath, fs.constants.X_OK);
 		} catch (err) {
@@ -559,11 +590,7 @@ export class CodexAgent extends Disposable implements IAgent {
 
 		// Extra args forwarded as JSON from the workbench setting.
 		const extraArgs = parseBinaryArgs(process.env[AgentHostCodexAgentBinaryArgsEnvVar]);
-		const args = ['app-server'];
-		for (const kv of providerOverrides) {
-			args.push('-c', kv);
-		}
-		args.push(...extraArgs);
+		const args = ['app-server', ...providerOverrides.flatMap(kv => ['-c', kv]), ...extraArgs];
 
 		this._logService.info(`[Codex] spawning ${binaryPath} ${args.join(' ')}`);
 		const child = spawn(binaryPath, args, { env, stdio: ['pipe', 'pipe', 'pipe'] });
@@ -1472,5 +1499,22 @@ function parseBinaryArgs(json: string | undefined): string[] {
 		return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : [];
 	} catch {
 		return [];
+	}
+}
+
+/**
+ * Mirrors the triple table inside `@openai/codex/bin/codex.js` so we can spawn
+ * the native binary at `vendor/<triple>/bin/codex` directly without going
+ * through the JS shim launcher.
+ */
+function codexBinaryTriple(sdkTarget: string): string | undefined {
+	switch (sdkTarget) {
+		case 'linux-x64': return 'x86_64-unknown-linux-musl';
+		case 'linux-arm64': return 'aarch64-unknown-linux-musl';
+		case 'darwin-x64': return 'x86_64-apple-darwin';
+		case 'darwin-arm64': return 'aarch64-apple-darwin';
+		case 'win32-x64': return 'x86_64-pc-windows-msvc';
+		case 'win32-arm64': return 'aarch64-pc-windows-msvc';
+		default: return undefined;
 	}
 }

--- a/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
@@ -13,7 +13,7 @@ import { parseAgentHostDebugPort } from '../../environment/node/environmentServi
 import { ILogService } from '../../log/common/log.js';
 import { getResolvedShellEnv } from '../../shell/node/shellEnv.js';
 import { IAgentHostConnection, IAgentHostStarter } from '../common/agent.js';
-import { AgentHostClaudeAgentSdkPathSettingId, AgentHostClaudeSdkPathEnvVar, AgentHostCodexAgentBinaryArgsEnvVar, AgentHostCodexAgentBinaryArgsSettingId, AgentHostCodexAgentBinaryPathEnvVar, AgentHostCodexAgentBinaryPathSettingId, AgentHostCodexAgentCodexHomeEnvVar, AgentHostCodexAgentCodexHomeSettingId, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, buildAgentHostOTelEnv } from '../common/agentService.js';
+import { AgentHostClaudeAgentSdkRootSettingId, AgentHostCodexAgentBinaryArgsSettingId, AgentHostCodexAgentSdkRootSettingId, AgentHostCodexAgentCodexHomeSettingId, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, buildAgentHostOTelEnv, buildAgentSdkEnv } from '../common/agentService.js';
 import '../common/agentHostStarter.config.contribution.js';
 
 /**
@@ -74,34 +74,16 @@ export class NodeAgentHostStarter extends Disposable implements IAgentHostStarte
 			VSCODE_VERBOSE_LOGGING: 'true',
 		};
 
-		// Gate optional providers via env vars consumed by `agentHostMain.ts`.
-		// The Claude agent is opt-in: enabled when the user points the SDK path
-		// setting at a locally-installed `@anthropic-ai/claude-agent-sdk` package,
-		// or when the env var is already set on the parent process (developer
-		// override). The SDK itself is intentionally not bundled with VS Code.
-		const claudeSdkPath = this._configurationService.getValue<string>(AgentHostClaudeAgentSdkPathSettingId)
-			|| process.env[AgentHostClaudeSdkPathEnvVar]
-			|| '';
-		if (claudeSdkPath) {
-			env[AgentHostClaudeSdkPathEnvVar] = claudeSdkPath;
-		}
-
-		// Codex agent is opt-in via `chat.agentHost.codexAgent.path`. Mirrors the
-		// Claude opt-in pattern above.
-		const codexBinaryPath = this._configurationService.getValue<string>(AgentHostCodexAgentBinaryPathSettingId)
-			|| process.env[AgentHostCodexAgentBinaryPathEnvVar]
-			|| '';
-		if (codexBinaryPath) {
-			env[AgentHostCodexAgentBinaryPathEnvVar] = codexBinaryPath;
-		}
-		const codexHome = this._configurationService.getValue<string>(AgentHostCodexAgentCodexHomeSettingId) || '';
-		if (codexHome) {
-			env[AgentHostCodexAgentCodexHomeEnvVar] = codexHome;
-		}
-		const codexArgs = this._configurationService.getValue<readonly string[]>(AgentHostCodexAgentBinaryArgsSettingId);
-		if (Array.isArray(codexArgs) && codexArgs.length > 0) {
-			env[AgentHostCodexAgentBinaryArgsEnvVar] = JSON.stringify(codexArgs);
-		}
+		// Forward the Claude/Codex SDK overrides + codex home/args from
+		// workbench settings to the agent host process. Parent env wins on
+		// collision — see `buildAgentSdkEnv` for the precedence rule.
+		const sdkEnv = buildAgentSdkEnv({
+			claudeSdkRoot: this._configurationService.getValue<string>(AgentHostClaudeAgentSdkRootSettingId),
+			codexSdkRoot: this._configurationService.getValue<string>(AgentHostCodexAgentSdkRootSettingId),
+			codexHome: this._configurationService.getValue<string>(AgentHostCodexAgentCodexHomeSettingId),
+			codexBinaryArgs: this._configurationService.getValue<readonly string[]>(AgentHostCodexAgentBinaryArgsSettingId),
+		}, env);
+		Object.assign(env, sdkEnv);
 
 		// Translate `chat.agentHost.otel.*` settings into the env vars consumed by
 		// the agent host process. Any value already present on `process.env` wins

--- a/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
@@ -82,7 +82,7 @@ export class NodeAgentHostStarter extends Disposable implements IAgentHostStarte
 			codexSdkRoot: this._configurationService.getValue<string>(AgentHostCodexAgentSdkRootSettingId),
 			codexHome: this._configurationService.getValue<string>(AgentHostCodexAgentCodexHomeSettingId),
 			codexBinaryArgs: this._configurationService.getValue<readonly string[]>(AgentHostCodexAgentBinaryArgsSettingId),
-		}, env);
+		}, process.env);
 		Object.assign(env, sdkEnv);
 
 		// Translate `chat.agentHost.otel.*` settings into the env vars consumed by

--- a/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { spawn } from 'child_process';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as fsp from 'fs/promises';
@@ -36,17 +35,14 @@ interface ITestSdkDownloadFixture {
 }
 
 async function buildFixtureTarball(): Promise<ITestSdkDownloadFixture> {
+	const tar = await import('tar');
 	const stagingDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'sdk-fixture-'));
 	const innerRel = path.join('node_modules', '@anthropic-ai', 'claude-agent-sdk', 'sdk.mjs');
 	const innerContents = '// fixture sdk.mjs\nexport default {};\n';
 	await fsp.mkdir(path.dirname(path.join(stagingDir, innerRel)), { recursive: true });
 	await fsp.writeFile(path.join(stagingDir, innerRel), innerContents);
 	const tarballPath = path.join(stagingDir, 'fixture.tgz');
-	await new Promise<void>((resolve, reject) => {
-		const child = spawn('tar', ['-czf', tarballPath, '-C', stagingDir, 'node_modules'], { stdio: 'inherit' });
-		child.on('error', reject);
-		child.on('exit', code => code === 0 ? resolve() : reject(new Error(`tar exit ${code}`)));
-	});
+	await tar.c({ file: tarballPath, cwd: stagingDir, gzip: true }, ['node_modules']);
 	const tarballSha = crypto
 		.createHash('sha256')
 		.update(await fsp.readFile(tarballPath))

--- a/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
@@ -1,0 +1,390 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { spawn } from 'child_process';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as fsp from 'fs/promises';
+import type * as httpType from 'http';
+import * as os from 'os';
+import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../base/common/network.js';
+import * as path from '../../../../base/common/path.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
+import { FileService } from '../../../files/common/fileService.js';
+import type { IFileService } from '../../../files/common/files.js';
+import { DiskFileSystemProvider } from '../../../files/node/diskFileSystemProvider.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { RequestService } from '../../../request/node/requestService.js';
+import { AgentSdkDownloader } from '../../node/agentSdkDownloader.js';
+import { ClaudeSdkPackage } from '../../node/claude/claudeAgentSdkService.js';
+import { AgentHostClaudeSdkRootEnvVar } from '../../common/agentService.js';
+import type { INativeEnvironmentService } from '../../../environment/common/environment.js';
+import type { IProductService } from '../../../product/common/productService.js';
+
+interface ITestSdkDownloadFixture {
+	tarballPath: string;
+	tarballSha: string;
+	innerFile: string; // path that should exist inside the extracted root
+	innerContents: string;
+	cleanup: () => Promise<void>;
+}
+
+async function buildFixtureTarball(): Promise<ITestSdkDownloadFixture> {
+	const stagingDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'sdk-fixture-'));
+	const innerRel = path.join('node_modules', '@anthropic-ai', 'claude-agent-sdk', 'sdk.mjs');
+	const innerContents = '// fixture sdk.mjs\nexport default {};\n';
+	await fsp.mkdir(path.dirname(path.join(stagingDir, innerRel)), { recursive: true });
+	await fsp.writeFile(path.join(stagingDir, innerRel), innerContents);
+	const tarballPath = path.join(stagingDir, 'fixture.tgz');
+	await new Promise<void>((resolve, reject) => {
+		const child = spawn('tar', ['-czf', tarballPath, '-C', stagingDir, 'node_modules'], { stdio: 'inherit' });
+		child.on('error', reject);
+		child.on('exit', code => code === 0 ? resolve() : reject(new Error(`tar exit ${code}`)));
+	});
+	const tarballSha = crypto
+		.createHash('sha256')
+		.update(await fsp.readFile(tarballPath))
+		.digest('hex');
+	return {
+		tarballPath,
+		tarballSha,
+		innerFile: innerRel,
+		innerContents,
+		cleanup: async () => fsp.rm(stagingDir, { recursive: true, force: true }),
+	};
+}
+
+interface ITestServer {
+	port: number;
+	requestCount: number;
+	close: () => Promise<void>;
+}
+
+async function startServer(body: Buffer): Promise<ITestServer> {
+	const http: typeof httpType = await import('http');
+	return new Promise(resolve => {
+		const state = { count: 0 };
+		const server = http.createServer((_req, res) => {
+			state.count++;
+			res.statusCode = 200;
+			res.setHeader('content-type', 'application/octet-stream');
+			res.setHeader('content-length', String(body.length));
+			res.end(body);
+		});
+		server.listen(0, '127.0.0.1', () => {
+			const addr = server.address();
+			const port = typeof addr === 'object' && addr ? addr.port : 0;
+			resolve({
+				get port() { return port; },
+				get requestCount() { return state.count; },
+				close: () => new Promise(res => server.close(() => res())),
+			});
+		});
+	});
+}
+
+function makeEnvService(userDataPath: string): INativeEnvironmentService {
+	// `RequestService.request` calls `getResolvedShellEnv(configService, logService, args, process.env)`.
+	// `force-disable-user-env: true` short-circuits before spawning a shell —
+	// without it `shellEnv.ts:140` registers a cancellation listener that
+	// leaks across tests and trips ensureNoDisposablesAreLeakedInTestSuite.
+	return { userDataPath, args: { 'force-disable-user-env': true } as never } as unknown as INativeEnvironmentService;
+}
+
+function makeProductService(config: { version: string; urlTemplate: string; sha256: Record<string, string> } | undefined): IProductService {
+	return {
+		agentSdks: config ? { claude: config } : undefined,
+	} as unknown as IProductService;
+}
+
+function makeRequestService(disposables: Pick<DisposableStore, 'add'>): RequestService {
+	// Bare RequestService: no http.proxy setting, no special config.
+	// Reads system proxy env vars (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) — none set
+	// in CI so direct connection to the test loopback server works.
+	return disposables.add(new RequestService(
+		'local',
+		new TestConfigurationService(),
+		makeEnvService('/unused-for-requestservice'),
+		new NullLogService(),
+	));
+}
+
+function makeFileService(disposables: Pick<DisposableStore, 'add'>): IFileService {
+	// Real FileService with DiskFileSystemProvider for `file://` — matches
+	// the wiring in `agentHostMain.ts`. Each test gets its own clean instance
+	// so provider registrations don't bleed across tests.
+	const log = new NullLogService();
+	const svc = disposables.add(new FileService(log));
+	disposables.add(svc.registerProvider(Schemas.file, disposables.add(new DiskFileSystemProvider(log))));
+	return svc;
+}
+
+suite('AgentSdkDownloader', () => {
+
+	const disposables = new DisposableStore();
+	teardown(() => disposables.clear());
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	let userDataPath: string;
+	let fixture: ITestSdkDownloadFixture;
+	let server: ITestServer;
+	let originalEnvOverride: string | undefined;
+
+	/** A cancellation token whose source is disposed in teardown. */
+	function newToken() {
+		const src = disposables.add(new CancellationTokenSource());
+		return src.token;
+	}
+
+	setup(async () => {
+		originalEnvOverride = process.env[AgentHostClaudeSdkRootEnvVar];
+		delete process.env[AgentHostClaudeSdkRootEnvVar];
+		userDataPath = await fsp.mkdtemp(path.join(os.tmpdir(), 'sdk-userdata-'));
+		fixture = await buildFixtureTarball();
+		server = await startServer(await fsp.readFile(fixture.tarballPath));
+	});
+
+	teardown(async () => {
+		await server.close();
+		await fixture.cleanup();
+		await fsp.rm(userDataPath, { recursive: true, force: true });
+		if (originalEnvOverride === undefined) {
+			delete process.env[AgentHostClaudeSdkRootEnvVar];
+		} else {
+			process.env[AgentHostClaudeSdkRootEnvVar] = originalEnvOverride;
+		}
+	});
+
+	function makeDownloader(productConfig?: { version?: string; sha256?: string; urlTemplate?: string }) {
+		const config = {
+			version: productConfig?.version ?? '1.0.0',
+			urlTemplate: productConfig?.urlTemplate ?? `http://127.0.0.1:${server.port}/{sdkVersion}/{sdkTarget}.tgz`,
+			sha256: productConfig?.sha256
+				? { [`${process.platform}-${process.arch}`]: productConfig.sha256 }
+				: { [`${process.platform}-${process.arch}`]: fixture.tarballSha },
+		};
+		return new AgentSdkDownloader(
+			makeEnvService(userDataPath),
+			makeProductService(config),
+			makeRequestService(disposables),
+			makeFileService(disposables),
+			new NullLogService(),
+		);
+	}
+
+	test('isAvailable: false when no env override and no product config', () => {
+		const downloader = new AgentSdkDownloader(
+			makeEnvService(userDataPath),
+			makeProductService(undefined),
+			makeRequestService(disposables),
+			makeFileService(disposables),
+			new NullLogService(),
+		);
+		assert.strictEqual(downloader.isAvailable(ClaudeSdkPackage), false);
+	});
+
+	test('isAvailable: true when env override set', () => {
+		process.env[AgentHostClaudeSdkRootEnvVar] = '/some/path';
+		const downloader = new AgentSdkDownloader(
+			makeEnvService(userDataPath),
+			makeProductService(undefined),
+			makeRequestService(disposables),
+			makeFileService(disposables),
+			new NullLogService(),
+		);
+		assert.strictEqual(downloader.isAvailable(ClaudeSdkPackage), true);
+	});
+
+	test('isAvailable: true when product config has sha for current target', () => {
+		const downloader = makeDownloader();
+		assert.strictEqual(downloader.isAvailable(ClaudeSdkPackage), true);
+	});
+
+	test('isAvailable: false when product config has no sha for current target', () => {
+		const cfg = {
+			version: '1.0.0',
+			urlTemplate: `http://127.0.0.1:${server.port}/{sdkVersion}/{sdkTarget}.tgz`,
+			sha256: { 'unsupported-platform-arch': 'deadbeef' },
+		};
+		const downloader = new AgentSdkDownloader(
+			makeEnvService(userDataPath),
+			makeProductService(cfg),
+			makeRequestService(disposables),
+			makeFileService(disposables),
+			new NullLogService(),
+		);
+		assert.strictEqual(downloader.isAvailable(ClaudeSdkPackage), false);
+	});
+
+	test('loadSdkRoot: dev override returns the path unchanged', async () => {
+		process.env[AgentHostClaudeSdkRootEnvVar] = '/path/to/dev/sdk';
+		const downloader = new AgentSdkDownloader(
+			makeEnvService(userDataPath),
+			makeProductService(undefined),
+			makeRequestService(disposables),
+			makeFileService(disposables),
+			new NullLogService(),
+		);
+		const root = await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
+		assert.strictEqual(root, '/path/to/dev/sdk');
+	});
+
+	test('loadSdkRoot: cache miss → downloads, verifies, extracts', async () => {
+		const downloader = makeDownloader();
+		const root = await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
+		assert.strictEqual(server.requestCount, 1);
+		const extracted = await fsp.readFile(path.join(root, fixture.innerFile), 'utf8');
+		assert.strictEqual(extracted, fixture.innerContents);
+		assert.ok(fs.existsSync(path.join(root, '.complete')));
+	});
+
+	test('loadSdkRoot: cache hit returns immediately without re-downloading', async () => {
+		const downloader = makeDownloader();
+		await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
+		assert.strictEqual(server.requestCount, 1);
+
+		// Second call hits the cache.
+		await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
+		assert.strictEqual(server.requestCount, 1, 'cache hit should not re-download');
+	});
+
+	test('loadSdkRoot: stale cache (different sha) is invalidated and re-downloaded', async () => {
+		const downloader = makeDownloader();
+		const cacheDir = await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
+		assert.strictEqual(server.requestCount, 1);
+
+		// Tamper with the cache: write a different sha into .complete.
+		await fsp.writeFile(path.join(cacheDir, '.complete'), 'a'.repeat(64));
+
+		await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
+		assert.strictEqual(server.requestCount, 2, 'sha mismatch must trigger re-download');
+		// Sentinel restored.
+		const recorded = (await fsp.readFile(path.join(cacheDir, '.complete'), 'utf8')).trim();
+		assert.strictEqual(recorded, fixture.tarballSha);
+	});
+
+	test('loadSdkRoot: sha256 mismatch → throws and leaves no cache dir', async () => {
+		const downloader = makeDownloader({ sha256: 'b'.repeat(64) });
+		await assert.rejects(
+			() => downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
+			/sha256 mismatch|Failed to download/,
+		);
+		// Cache dir absent — only its parent might exist.
+		const target = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude', '1.0.0', `${process.platform}-${process.arch}`);
+		assert.strictEqual(fs.existsSync(target), false);
+	});
+
+	test('loadSdkRoot: missing product config and no env override throws actionable error', async () => {
+		const downloader = new AgentSdkDownloader(
+			makeEnvService(userDataPath),
+			makeProductService(undefined),
+			makeRequestService(disposables),
+			makeFileService(disposables),
+			new NullLogService(),
+		);
+		await assert.rejects(
+			() => downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
+			/no `product\.agentSdks\.claude` configured/,
+		);
+	});
+
+	test('loadSdkRoot: unsupported target throws with supported list', async () => {
+		const cfg = {
+			version: '1.0.0',
+			urlTemplate: `http://127.0.0.1:${server.port}/{sdkVersion}/{sdkTarget}.tgz`,
+			sha256: { 'unsupported-platform-arch': 'deadbeef' },
+		};
+		const downloader = new AgentSdkDownloader(
+			makeEnvService(userDataPath),
+			makeProductService(cfg),
+			makeRequestService(disposables),
+			makeFileService(disposables),
+			new NullLogService(),
+		);
+		await assert.rejects(
+			() => downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
+			/is not in the supported set/,
+		);
+	});
+
+	test('loadSdkRoot: cancel before download completes cleans up scratch dir', async function () {
+		this.timeout(15_000);
+		// Replace server with one that hangs forever.
+		await server.close();
+		const http: typeof httpType = await import('http');
+		const hangingServer = http.createServer((_req, res) => {
+			res.writeHead(200, { 'content-length': '999999' });
+			res.write(Buffer.alloc(8));
+			// never end
+		});
+		await new Promise<void>(r => hangingServer.listen(0, '127.0.0.1', () => r()));
+		const port = (hangingServer.address() as { port: number }).port;
+		try {
+			const downloader = new AgentSdkDownloader(
+				makeEnvService(userDataPath),
+				makeProductService({
+					version: '1.0.0',
+					urlTemplate: `http://127.0.0.1:${port}/{sdkVersion}/{sdkTarget}.tgz`,
+					sha256: { [`${process.platform}-${process.arch}`]: fixture.tarballSha },
+				}),
+				makeRequestService(disposables),
+				makeFileService(disposables),
+				new NullLogService(),
+			);
+			const cts = disposables.add(new CancellationTokenSource());
+			const promise = downloader.loadSdkRoot(ClaudeSdkPackage, cts.token);
+			// Give the request a moment to start.
+			await new Promise(r => setTimeout(r, 50));
+			cts.cancel();
+			await assert.rejects(() => promise, /Cancel|cancel|Failed to download/);
+			// No half-extracted dir left around.
+			const targetParent = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude', '1.0.0');
+			const leftover = fs.existsSync(targetParent)
+				? (await fsp.readdir(targetParent)).filter(f => f.includes('.tmp.'))
+				: [];
+			assert.deepStrictEqual(leftover, []);
+		} finally {
+			// Force-close any sockets the test left dangling — the cancel path
+			// only tears down OUR streams, the underlying http connection on
+			// the server side stays alive until the OS reaps it. Without this
+			// `hangingServer.close()` would hang waiting for the still-open
+			// connection.
+			hangingServer.closeAllConnections();
+			await new Promise<void>(r => hangingServer.close(() => r()));
+		}
+	});
+
+	test('loadSdkRoot: concurrent calls in same process share one download', async () => {
+		const downloader = makeDownloader();
+		const [a, b, c] = await Promise.all([
+			downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
+			downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
+			downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
+		]);
+		assert.strictEqual(a, b);
+		assert.strictEqual(b, c);
+		assert.strictEqual(server.requestCount, 1, 'concurrent loaders must dedupe');
+	});
+
+	test('loadSdkRoot: rename-loser path returns existing cache when winner already published', async () => {
+		const downloader = makeDownloader();
+		const target = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude', '1.0.0', `${process.platform}-${process.arch}`);
+
+		// Pre-populate the cache as if a "winner" already extracted it.
+		await fsp.mkdir(target, { recursive: true });
+		await fsp.mkdir(path.dirname(path.join(target, fixture.innerFile)), { recursive: true });
+		await fsp.writeFile(path.join(target, fixture.innerFile), fixture.innerContents);
+		await fsp.writeFile(path.join(target, '.complete'), fixture.tarballSha);
+
+		// loadSdkRoot should hit the cache first and never invoke the server.
+		const root = await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
+		assert.strictEqual(root, target);
+		assert.strictEqual(server.requestCount, 0);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
@@ -114,6 +114,7 @@ function makeMessage(model: string): Anthropic.Message {
 			cache_creation_input_tokens: null,
 			cache_read_input_tokens: null,
 			inference_geo: null,
+			output_tokens_details: null,
 			server_tool_use: null,
 			service_tier: null,
 		},
@@ -141,6 +142,7 @@ function makeCannedStream(model: string): Anthropic.MessageStreamEvent[] {
 			output_tokens: 1,
 			cache_creation_input_tokens: null,
 			cache_read_input_tokens: null,
+			output_tokens_details: null,
 			server_tool_use: null,
 		},
 	};
@@ -193,6 +195,7 @@ function makeResultSuccess(sessionId: string): SDKResultSuccess {
 			input_tokens: 0,
 			iterations: [],
 			output_tokens: 0,
+			output_tokens_details: { thinking_tokens: 0 },
 			server_tool_use: { web_fetch_requests: 0, web_search_requests: 0 },
 			service_tier: 'standard',
 			speed: 'standard',
@@ -472,6 +475,8 @@ class RoundTripQuery implements AsyncGenerator<SDKMessage, void> {
 	setMcpServers(): never { throw new Error('not modeled'); }
 	streamInput(): never { throw new Error('not modeled'); }
 	stopTask(): never { throw new Error('not modeled'); }
+	reloadSkills(): never { throw new Error('not modeled'); }
+	backgroundTasks(): never { throw new Error('not modeled'); }
 	close(): void { /* no-op */ }
 	[Symbol.asyncDispose](): Promise<void> { return Promise.resolve(); }
 }

--- a/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
@@ -114,7 +114,6 @@ function makeMessage(model: string): Anthropic.Message {
 			cache_creation_input_tokens: null,
 			cache_read_input_tokens: null,
 			inference_geo: null,
-			output_tokens_details: null,
 			server_tool_use: null,
 			service_tier: null,
 		},
@@ -142,7 +141,6 @@ function makeCannedStream(model: string): Anthropic.MessageStreamEvent[] {
 			output_tokens: 1,
 			cache_creation_input_tokens: null,
 			cache_read_input_tokens: null,
-			output_tokens_details: null,
 			server_tool_use: null,
 		},
 	};
@@ -195,7 +193,6 @@ function makeResultSuccess(sessionId: string): SDKResultSuccess {
 			input_tokens: 0,
 			iterations: [],
 			output_tokens: 0,
-			output_tokens_details: { thinking_tokens: 0 },
 			server_tool_use: { web_fetch_requests: 0, web_search_requests: 0 },
 			service_tier: 'standard',
 			speed: 'standard',

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -50,6 +50,7 @@ import { ClaudeAgent } from '../../node/claude/claudeAgent.js';
 import { ClaudeAgentSession } from '../../node/claude/claudeAgentSession.js';
 import { ClaudeSessionMetadataStore } from '../../node/claude/claudeSessionMetadataStore.js';
 import { ClaudeAgentSdkService, IClaudeAgentSdkService, IClaudeSdkBindings } from '../../node/claude/claudeAgentSdkService.js';
+import { IAgentSdkDownloader } from '../../node/agentSdkDownloader.js';
 import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
 import { IClaudeProxyHandle, IClaudeProxyService } from '../../node/claude/claudeProxyService.js';
 import { resolvePromptToContentBlocks } from '../../node/claude/claudePromptResolver.js';
@@ -486,6 +487,8 @@ class FakeQuery implements AsyncGenerator<SDKMessage, void> {
 	setMcpServers(): never { throw new Error('FakeQuery: setMcpServers not modeled'); }
 	streamInput(): never { throw new Error('FakeQuery: streamInput not modeled'); }
 	stopTask(): never { throw new Error('FakeQuery: stopTask not modeled'); }
+	reloadSkills(): never { throw new Error('FakeQuery: reloadSkills not modeled'); }
+	backgroundTasks(): never { throw new Error('FakeQuery: backgroundTasks not modeled'); }
 	close(): void { /* no-op */ }
 	[Symbol.asyncDispose](): Promise<void> { return Promise.resolve(); }
 }
@@ -653,6 +656,20 @@ function createTestContext(
 /** Drains the microtask queue so awaited refresh writes settle. */
 function tick(): Promise<void> {
 	return new Promise(resolve => setImmediate(resolve));
+}
+
+/**
+ * Stub for {@link IAgentSdkDownloader} consumed by tests that need a real
+ * `ClaudeAgentSdkService` constructor but override `_loadSdk` themselves —
+ * the downloader is therefore never actually called.
+ */
+function stubAgentSdkDownloader(): IAgentSdkDownloader {
+	return {
+		_serviceBrand: undefined,
+		isAvailable: () => false,
+		loadSdkRoot: () => { throw new Error('test stub: downloader.loadSdkRoot should not be called'); },
+		resolveSdkTarget: () => undefined,
+	};
 }
 
 // #endregion
@@ -2911,7 +2928,10 @@ suite('ClaudeAgent', () => {
 			}
 		}
 
-		const services = new ServiceCollection([ILogService, new RecordingLogService()]);
+		const services = new ServiceCollection(
+			[ILogService, new RecordingLogService()],
+			[IAgentSdkDownloader, stubAgentSdkDownloader()],
+		);
 		const inst = disposables.add(new InstantiationService(services));
 		const svc = inst.createInstance(TestableClaudeAgentSdkService);
 
@@ -2989,7 +3009,10 @@ suite('ClaudeAgent', () => {
 			}
 		}
 
-		const inst = disposables.add(new InstantiationService(new ServiceCollection([ILogService, new NullLogService()])));
+		const inst = disposables.add(new InstantiationService(new ServiceCollection(
+			[ILogService, new NullLogService()],
+			[IAgentSdkDownloader, stubAgentSdkDownloader()],
+		)));
 		const svc = inst.createInstance(TestableClaudeAgentSdkService);
 
 		const subagentIds = await svc.listSubagents('sess-1');

--- a/src/vs/platform/agentHost/test/node/claudeMapSessionEventsTestUtils.ts
+++ b/src/vs/platform/agentHost/test/node/claudeMapSessionEventsTestUtils.ts
@@ -42,7 +42,6 @@ export function makeNonNullableUsage(): SDKResultSuccess['usage'] {
 		input_tokens: 0,
 		iterations: [],
 		output_tokens: 0,
-		output_tokens_details: { thinking_tokens: 0 },
 		server_tool_use: { web_fetch_requests: 0, web_search_requests: 0 },
 		service_tier: 'standard',
 		speed: 'standard',
@@ -123,7 +122,6 @@ export function makeMessageStart(messageId: string = 'msg_test'): BetaRawMessage
 			stop_details: null,
 			container: null,
 			context_management: null,
-			diagnostics: null,
 			usage: {
 				cache_creation: { ephemeral_1h_input_tokens: 0, ephemeral_5m_input_tokens: 0 },
 				cache_creation_input_tokens: 0,
@@ -132,7 +130,6 @@ export function makeMessageStart(messageId: string = 'msg_test'): BetaRawMessage
 				input_tokens: 0,
 				iterations: [],
 				output_tokens: 0,
-				output_tokens_details: { thinking_tokens: 0 },
 				server_tool_use: { web_fetch_requests: 0, web_search_requests: 0 },
 				service_tier: 'standard',
 				speed: 'standard',
@@ -181,7 +178,7 @@ export function makeThinkingDelta(index: number, thinking: string): BetaRawConte
 	return {
 		type: 'content_block_delta',
 		index,
-		delta: { type: 'thinking_delta', thinking, estimated_tokens: 0 },
+		delta: { type: 'thinking_delta', thinking },
 	};
 }
 
@@ -234,7 +231,6 @@ export function makeAssistantMessage(
 			stop_details: null,
 			container: null,
 			context_management: null,
-			diagnostics: null,
 			usage: {
 				cache_creation: { ephemeral_1h_input_tokens: 0, ephemeral_5m_input_tokens: 0 },
 				cache_creation_input_tokens: 0,
@@ -243,7 +239,6 @@ export function makeAssistantMessage(
 				input_tokens: 0,
 				iterations: [],
 				output_tokens: 0,
-				output_tokens_details: { thinking_tokens: 0 },
 				server_tool_use: { web_fetch_requests: 0, web_search_requests: 0 },
 				service_tier: 'standard',
 				speed: 'standard',

--- a/src/vs/platform/agentHost/test/node/claudeMapSessionEventsTestUtils.ts
+++ b/src/vs/platform/agentHost/test/node/claudeMapSessionEventsTestUtils.ts
@@ -42,6 +42,7 @@ export function makeNonNullableUsage(): SDKResultSuccess['usage'] {
 		input_tokens: 0,
 		iterations: [],
 		output_tokens: 0,
+		output_tokens_details: { thinking_tokens: 0 },
 		server_tool_use: { web_fetch_requests: 0, web_search_requests: 0 },
 		service_tier: 'standard',
 		speed: 'standard',
@@ -122,6 +123,7 @@ export function makeMessageStart(messageId: string = 'msg_test'): BetaRawMessage
 			stop_details: null,
 			container: null,
 			context_management: null,
+			diagnostics: null,
 			usage: {
 				cache_creation: { ephemeral_1h_input_tokens: 0, ephemeral_5m_input_tokens: 0 },
 				cache_creation_input_tokens: 0,
@@ -130,6 +132,7 @@ export function makeMessageStart(messageId: string = 'msg_test'): BetaRawMessage
 				input_tokens: 0,
 				iterations: [],
 				output_tokens: 0,
+				output_tokens_details: { thinking_tokens: 0 },
 				server_tool_use: { web_fetch_requests: 0, web_search_requests: 0 },
 				service_tier: 'standard',
 				speed: 'standard',
@@ -178,7 +181,7 @@ export function makeThinkingDelta(index: number, thinking: string): BetaRawConte
 	return {
 		type: 'content_block_delta',
 		index,
-		delta: { type: 'thinking_delta', thinking },
+		delta: { type: 'thinking_delta', thinking, estimated_tokens: 0 },
 	};
 }
 
@@ -228,8 +231,10 @@ export function makeAssistantMessage(
 			content,
 			stop_reason: 'end_turn',
 			stop_sequence: null,
+			stop_details: null,
 			container: null,
 			context_management: null,
+			diagnostics: null,
 			usage: {
 				cache_creation: { ephemeral_1h_input_tokens: 0, ephemeral_5m_input_tokens: 0 },
 				cache_creation_input_tokens: 0,
@@ -238,6 +243,7 @@ export function makeAssistantMessage(
 				input_tokens: 0,
 				iterations: [],
 				output_tokens: 0,
+				output_tokens_details: { thinking_tokens: 0 },
 				server_tool_use: { web_fetch_requests: 0, web_search_requests: 0 },
 				service_tier: 'standard',
 				speed: 'standard',

--- a/src/vs/platform/agentHost/test/node/claudeSdkPipeline.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeSdkPipeline.test.ts
@@ -61,6 +61,8 @@ class ImmediatelyDoneQuery implements Query {
 	async interrupt(): Promise<void> { /* not exercised here */ }
 	streamInput(): never { throw new Error('not modeled'); }
 	stopTask(): never { throw new Error('not modeled'); }
+	reloadSkills(): never { throw new Error('not modeled'); }
+	backgroundTasks(): never { throw new Error('not modeled'); }
 	async close(): Promise<void> { /* not exercised here */ }
 	async [Symbol.asyncDispose](): Promise<void> { /* not exercised here */ }
 	setMaxThinkingTokens(): never { throw new Error('not modeled'); }

--- a/src/vs/platform/agentHost/test/node/codex/codexSessionConfigKeys.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexSessionConfigKeys.test.ts
@@ -13,6 +13,7 @@ import { ISessionDataService } from '../../../common/sessionDataService.js';
 import { CodexAgent } from '../../../node/codex/codexAgent.js';
 import { ICodexProxyService } from '../../../node/codex/codexProxyService.js';
 import { IAgentConfigurationService } from '../../../node/agentConfigurationService.js';
+import { IAgentSdkDownloader } from '../../../node/agentSdkDownloader.js';
 import { ICopilotApiService } from '../../../node/shared/copilotApiService.js';
 
 function createAgent(disposables: Pick<DisposableStore, 'add'>): CodexAgent {
@@ -21,6 +22,7 @@ function createAgent(disposables: Pick<DisposableStore, 'add'>): CodexAgent {
 	instantiationService.stub(ICopilotApiService, { _serviceBrand: undefined });
 	instantiationService.stub(ICodexProxyService, { _serviceBrand: undefined });
 	instantiationService.stub(IAgentConfigurationService, { _serviceBrand: undefined });
+	instantiationService.stub(IAgentSdkDownloader, { _serviceBrand: undefined });
 	instantiationService.stub(ILogService, new NullLogService());
 	return disposables.add(instantiationService.createInstance(CodexAgent));
 }

--- a/src/vs/platform/agentHost/test/node/protocol/claudeRealSdk.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/claudeRealSdk.integrationTest.ts
@@ -32,9 +32,10 @@ const REAL_SDK_ENABLED = process.env['AGENT_HOST_REAL_SDK'] === '1';
 /**
  * Resolve the path of the locally installed `@anthropic-ai/claude-agent-sdk`
  * package. It's a dev dep so it's always present at
- * `<repo>/node_modules/@anthropic-ai/claude-agent-sdk`; we hand its
- * directory to the agent host server via `--claude-sdk-path` so the Claude
- * provider gets registered.
+ * `<repo>/node_modules/@anthropic-ai/claude-agent-sdk`; we hand the repo
+ * directory (the SDK root — the parent of `node_modules/`) to the agent
+ * host server via `--claude-sdk-root` so the Claude provider gets
+ * registered.
  *
  * The Electron renderer test loader rejects bare module-specifier resolution
  * (no `import.meta.resolve('pkg')`, no `require.resolve('pkg')`), so we
@@ -45,14 +46,14 @@ const REAL_SDK_ENABLED = process.env['AGENT_HOST_REAL_SDK'] === '1';
  * once the suite has already opted in via env vars, so the suite's own
  * skip-if-not-found path surfaces the missing dep.
  */
-function resolveClaudeSdkPath(): string | undefined {
-	const candidate = join(process.cwd(), 'node_modules', '@anthropic-ai', 'claude-agent-sdk');
-	return existsSync(candidate) ? candidate : undefined;
+function resolveClaudeSdkRoot(): string | undefined {
+	const sdkPackageDir = join(process.cwd(), 'node_modules', '@anthropic-ai', 'claude-agent-sdk');
+	return existsSync(sdkPackageDir) ? process.cwd() : undefined;
 }
 
 // Resolve lazily: if the suite isn't opted in, skip the filesystem probe so a
 // missing SDK directory can't trip a disabled run.
-const CLAUDE_SDK_PATH = REAL_SDK_ENABLED ? resolveClaudeSdkPath() : undefined;
+const CLAUDE_SDK_ROOT = REAL_SDK_ENABLED ? resolveClaudeSdkRoot() : undefined;
 
 const CLAUDE_CONFIG: IRealSdkProviderConfig = {
 	suiteTitle: 'Protocol WebSocket — Real Claude SDK',
@@ -61,8 +62,8 @@ const CLAUDE_CONFIG: IRealSdkProviderConfig = {
 	shellToolName: 'Bash',
 	subagentToolNames: ['Task', 'Agent'],
 	exitPlanModeToolName: 'ExitPlanMode',
-	enabled: REAL_SDK_ENABLED && !!CLAUDE_SDK_PATH,
-	claudeSdkPath: CLAUDE_SDK_PATH,
+	enabled: REAL_SDK_ENABLED && !!CLAUDE_SDK_ROOT,
+	claudeSdkRoot: CLAUDE_SDK_ROOT,
 	// Claude has not landed worktree isolation yet (deferred to Phase 12).
 	// The shared suite skips that test when the flag is false.
 	supportsWorktreeIsolation: false,

--- a/src/vs/platform/agentHost/test/node/protocol/codexRealSdk.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/codexRealSdk.integrationTest.ts
@@ -24,12 +24,12 @@ import { defineSharedRealSdkTests, type IRealSdkProviderConfig } from './realSdk
 
 const REAL_CODEX_ENABLED = process.env['AGENT_HOST_REAL_CODEX'] === '1';
 
-function resolveCodexBinaryPath(): string | undefined {
-	const candidate = join(process.cwd(), 'node_modules', '@openai', 'codex', 'bin', 'codex.js');
-	return existsSync(candidate) ? candidate : undefined;
+function resolveCodexSdkRoot(): string | undefined {
+	const sdkPackageDir = join(process.cwd(), 'node_modules', '@openai', 'codex');
+	return existsSync(sdkPackageDir) ? process.cwd() : undefined;
 }
 
-const CODEX_BINARY_PATH = REAL_CODEX_ENABLED ? resolveCodexBinaryPath() : undefined;
+const CODEX_SDK_ROOT = REAL_CODEX_ENABLED ? resolveCodexSdkRoot() : undefined;
 
 const CODEX_CONFIG: IRealSdkProviderConfig = {
 	suiteTitle: 'Protocol WebSocket - Real Codex App Server',
@@ -38,8 +38,8 @@ const CODEX_CONFIG: IRealSdkProviderConfig = {
 	shellToolName: 'shell',
 	subagentToolNames: [],
 	exitPlanModeToolName: 'exit_plan_mode',
-	enabled: REAL_CODEX_ENABLED && !!CODEX_BINARY_PATH,
-	codexBinaryPath: CODEX_BINARY_PATH,
+	enabled: REAL_CODEX_ENABLED && !!CODEX_SDK_ROOT,
+	codexSdkRoot: CODEX_SDK_ROOT,
 	supportsWorktreeIsolation: false,
 	supportsSubagents: false,
 	supportsPlanMode: false,

--- a/src/vs/platform/agentHost/test/node/protocol/realSdkTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/realSdkTestHelpers.ts
@@ -102,9 +102,9 @@ export interface IRealSdkProviderConfig {
 	 * package. Forwarded to `startRealServer` so the agent host registers
 	 * the Claude provider.
 	 */
-	readonly claudeSdkPath?: string;
+	readonly claudeSdkRoot?: string;
 	/** Optional path to a locally installed `codex` binary. Forwarded to `startRealServer`. */
-	readonly codexBinaryPath?: string;
+	readonly codexSdkRoot?: string;
 	/**
 	 * Provider implements `config.isolation: 'worktree'` and resolves the
 	 * working directory to a `.worktrees/...` path on materialization.
@@ -474,7 +474,7 @@ export function defineSharedRealSdkTests(config: IRealSdkProviderConfig): void {
 
 		setup(async function () {
 			this.timeout(60_000);
-			server = await startRealServer({ claudeSdkPath: config.claudeSdkPath, codexBinaryPath: config.codexBinaryPath });
+			server = await startRealServer({ claudeSdkRoot: config.claudeSdkRoot, codexSdkRoot: config.codexSdkRoot });
 			client = new TestProtocolClient(server.port);
 			await client.connect();
 		});

--- a/src/vs/platform/agentHost/test/node/protocol/testHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/testHelpers.ts
@@ -226,15 +226,15 @@ export async function startServer(options?: { readonly quiet?: boolean; readonly
  * Start the agent host server with the real Copilot SDK agent (no mock agent).
  * The server is started with logging enabled so the CopilotAgent is registered.
  */
-export async function startRealServer(options?: { readonly claudeSdkPath?: string; readonly codexBinaryPath?: string }): Promise<IServerHandle> {
+export async function startRealServer(options?: { readonly claudeSdkRoot?: string; readonly codexSdkRoot?: string }): Promise<IServerHandle> {
 	return new Promise((resolve, reject) => {
 		const serverPath = fileURLToPath(new URL('../../../node/agentHostServerMain.js', import.meta.url));
 		const args = ['--port', '0', '--without-connection-token'];
-		if (options?.claudeSdkPath) {
-			args.push('--claude-sdk-path', options.claudeSdkPath);
+		if (options?.claudeSdkRoot) {
+			args.push('--claude-sdk-root', options.claudeSdkRoot);
 		}
-		if (options?.codexBinaryPath) {
-			args.push('--codex-binary-path', options.codexBinaryPath);
+		if (options?.codexSdkRoot) {
+			args.push('--codex-sdk-root', options.codexSdkRoot);
 		}
 		const child = fork(serverPath, args, {
 			stdio: ['pipe', 'pipe', 'pipe', 'ipc'],


### PR DESCRIPTION
Tracks microsoft/vscode-internalbacklog#7885.

## Summary

- Adds `product.agentSdks` — a per-package CDN-distribution descriptor (url template + per-target sha256) populated by vscode-distro.
- Adds `IAgentSdkDownloader`, the agent-host service that downloads, verifies, extracts, and caches each SDK on demand. Resolution order: dev-override env var → on-disk cache (always re-verified against `product.json` sha) → CDN download.
- Switches Claude / Codex provider registration from "env-var path present?" to `IAgentSdkDownloader.isAvailable(pkg)`, so providers register whenever either the dev override OR a `product.json` entry covers the current platform.

## Flow

```mermaid
flowchart TD
    Start([Agent host starts]):::start --> Gate{isAvailable pkg ?<br/>dev-override env OR<br/>product.agentSdks pkg.id<br/>sha256 has current target}:::decision
    Gate -- no --> Skip([Provider not registered<br/>same as today]):::terminal
    Gate -- yes --> Register([Register provider<br/>copilotcli / claude / codex]):::terminal
    Register --> FirstUse{{Provider first call<br/>e.g. createSession}}:::start
    FirstUse --> Load[loadSdkRoot pkg, token]:::action

    Load --> DevOverride{dev override env<br/>var set ?}:::decision
    DevOverride -- yes --> ReturnDev([Return env var path<br/>no download]):::cache
    DevOverride -- no --> Negative{failure latched<br/>within 30s ?}:::decision
    Negative -- yes --> Throw([Re-throw cached error<br/>no I/O]):::error
    Negative -- no --> Resolve[Resolve product.agentSdks pkg.id<br/>+ sdkTarget for this platform]:::action

    Resolve --> Cache{cache hit ?<br/>.complete sentinel<br/>matches expected sha256}:::decision
    Cache -- yes --> ReturnCache([Return cached SDK root]):::cache
    Cache -- no --> Stale{stale .complete<br/>present ?}:::decision
    Stale -- yes --> Wipe[del recursive cache dir]:::action --> Dedupe
    Stale -- no --> Dedupe{in-flight download<br/>for same key ?}:::decision
    Dedupe -- yes --> Share([await existing promise<br/>no second download]):::cache
    Dedupe -- no --> Download[GET via IRequestService<br/>tee chunks → sha256 hasher<br/>AND fs.createWriteStream]:::action

    Download --> CheckSha{actual sha256<br/>matches expected ?}:::decision
    CheckSha -- no --> Latch[Latch failure 30s]:::action --> Throw
    CheckSha -- yes --> Extract[tar.x extract to<br/>cacheDir.tmp.PID]:::action
    Extract --> Move[IFileService.move tmpDir → cacheDir]:::action

    Move --> Race{rename<br/>conflict ?}:::decision
    Race -- yes --> Loser{loser's cache<br/>matches expected sha ?}:::decision
    Loser -- yes --> CleanTmp[Drop scratch tmp dir]:::action --> ReturnCache
    Loser -- no --> Latch
    Race -- no --> WriteSentinel[Write .complete = expected sha]:::action --> ReturnFresh([Return fresh SDK root]):::cache

    Cancel[token cancellation]:::error -.-> CleanScratch[Destroy streams,<br/>delete tmp dir]:::action
    CleanScratch -.-> ThrowCancel([CancellationError —<br/>NOT latched]):::error

    classDef start fill:#1f6feb,stroke:#1f6feb,color:#fff
    classDef terminal fill:#238636,stroke:#238636,color:#fff
    classDef cache fill:#8957e5,stroke:#8957e5,color:#fff
    classDef decision fill:#3a3a3a,stroke:#8b8b8b,color:#fff
    classDef action fill:#1f1f1f,stroke:#8b8b8b,color:#fff
    classDef error fill:#da3633,stroke:#da3633,color:#fff
```

The flow runs **per package** (`pkg = ClaudeSdkPackage` or `CodexSdkPackage`), so Claude and Codex have independent gates, caches, in-flight maps, and failure latches.

Key invariants this protects:
- **Trust anchor is `product.json`** — the bundled-and-signed sha256 is checked on every cache hit, not just on download, so a vscode-distro rebuild that re-pins the same `version` to a different sha cleanly invalidates stale caches.
- **One download per concurrent caller in a process** — the in-flight map dedupes; the rename-loser path dedupes across windows of the same install.
- **Misconfigured CDN doesn't get hammered** — failure latch holds for 30 s so poll-driven UIs don't fire a fresh request on every SDK method call.
- **Streaming verify** — the 70+MB tarball is hashed and written in a single pass via tee, not write-then-reread.

## What's new

- `src/vs/platform/agentHost/node/agentSdkDownloader.ts` — the service. Streams the tarball through a sha256 hasher + `fs.createWriteStream` in one pass, extracts via `node-tar`, atomically publishes via `IFileService.move`, handles the rename-loser race for concurrent same-install windows, and latches failures for 30 s so a broken CDN doesn't get hammered.
- `src/vs/platform/agentHost/node/agentHostBootstrap.ts` — shared wiring for both starters (main and server). Registers `IPolicyService` (Null) + `IConfigurationService` (base, reading `userRoamingDataHome/settings.json`) so `IRequestService` works inside the agent host (corporate proxy, kerberos, strictSSL).
- `IAgentSdkPackage` — pure-data strategy interface (`id`, `devOverrideEnvVar`, `hasSeparateMuslLinuxPackage`). `ClaudeSdkPackage` lives in `claudeAgentSdkService.ts`; `CodexSdkPackage` lives in `codexAgent.ts`. The downloader never names a provider directly.
- Settings + env vars renamed `…AgentPath` → `…AgentSdkRoot` to reflect their actual meaning (the parent of `node_modules/`, the same shape extracted tarballs produce). Old names are silently dropped — settings are tagged `experimental, advanced`.

## Test plan

- [x] 14 unit tests in `agentSdkDownloader.test.ts` cover: dev-override precedence, cache hit (sha re-verify on every call), stale-cache invalidation on sha mismatch, real-server download + sha256 verify + extract, concurrent-loader dedupe, cancellation cleanup of the scratch dir, rename-loser race recovery, missing-config / unsupported-target error shapes.
- [x] E2E sanity, all four scenarios pass on a built Code OSS:
  - **A** — only the stale `chat.agentHost.claudeAgent.path` setting present → Claude does NOT register (only `copilotcli`).
  - **B** — new `chat.agentHost.claudeAgent.sdkRoot` set → Claude registers via dev override.
  - **C** — both Claude + Codex `sdkRoot` set → both register; agent picker shows Copilot CLI, Claude, Codex; full Claude and Codex turns succeed end-to-end (Codex spawns the native binary at `vendor/<triple>/bin/codex`).
  - **D** — `product.overrides.json` injects a synthetic `agentSdks.claude` pointing at a local HTTP server, no dev override → provider registers via product config, 71 MB tarball downloads through `IRequestService`, sha256 verified, extracted via node-tar in ~12 s, `[Claude] Models refreshed. Count: 10`, cache lays down at `<userDataPath>/agent-host/sdk-cache/claude/0.3.168/darwin-arm64/` with `.complete` sentinel matching the sha.

## Notes

- `build/agent-sdk/` (the build-side tooling that mints + uploads the per-target tarballs) is intentionally not in this PR; that lives in vscode-distro alongside the publish pipeline that invokes it.
- The codepath in OSS builds with neither a dev override nor a `product.agentSdks` entry is unchanged: provider doesn't register, picker doesn't show it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
