### PR TITLE
agentHost: fix client tool auto-approval

### DIFF
--- a/src/vs/platform/agentHost/common/state/protocol/channels-session/reducer.ts
+++ b/src/vs/platform/agentHost/common/state/protocol/channels-session/reducer.ts
@@ -374,6 +374,7 @@ export function sessionReducer(state: SessionState, action: SessionAction, log?:
 						invocationMessage: action.invocationMessage,
 						toolInput: action.toolInput,
 						confirmed: action.confirmed,
+						_meta: action._meta ?? base._meta,
 					};
 				}
 				return {
@@ -384,6 +385,7 @@ export function sessionReducer(state: SessionState, action: SessionAction, log?:
 					confirmationTitle: action.confirmationTitle,
 					edits: action.edits,
 					editable: action.editable,
+					_meta: action._meta ?? base._meta,
 					...(action.options ? { options: action.options } : {}),
 				};
 			}));

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -18,7 +18,7 @@ import { IAgentHostCheckpointService } from '../common/agentHostCheckpointServic
 
 import { ISessionDataService } from '../common/sessionDataService.js';
 import { SessionConfigKey } from '../common/sessionConfigKeys.js';
-import type { AgentInfo } from '../common/state/protocol/state.js';
+import { ToolCallContributorKind, type AgentInfo } from '../common/state/protocol/state.js';
 import { ActionType, StateAction, type SessionToolCallCompleteAction } from '../common/state/sessionActions.js';
 import {
 	buildSubagentSessionUri,
@@ -702,8 +702,16 @@ export class AgentSideEffects extends Disposable {
 			toolInput: e.state.toolInput,
 		};
 		const autoApproval = this._permissionManager.getAutoApproval(approvalEvent, sessionKey);
+		const part = this._stateManager.getSessionState(sessionKey)?.activeTurn?.responseParts.find(part => part.kind === ResponsePartKind.ToolCall && part.toolCall.toolCallId === e.state.toolCallId);
+		const contributor = e.state.contributor ?? (part?.kind === ResponsePartKind.ToolCall ? part.toolCall.contributor : undefined);
 		let effective = e;
-		if (autoApproval !== undefined) {
+		const clientShouldAutoApprove = autoApproval !== undefined
+			&& contributor?.kind === ToolCallContributorKind.Client
+			&& !!e.state.confirmationTitle;
+		if (clientShouldAutoApprove) {
+			this._toolCallAgents.set(`${sessionKey}:${e.state.toolCallId}`, agent.id);
+			effective = { ...e, state: { ...e.state, _meta: { ...e.state._meta, autoApproveBySetting: true } } };
+		} else if (autoApproval !== undefined) {
 			this._toolCallAgents.delete(`${sessionKey}:${e.state.toolCallId}`);
 			agent.respondToPermissionRequest(e.state.toolCallId, true);
 			// Strip confirmationTitle so createToolReadyAction emits the

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -703,14 +703,15 @@ export class AgentSideEffects extends Disposable {
 		};
 		const autoApproval = this._permissionManager.getAutoApproval(approvalEvent, sessionKey);
 		const part = this._stateManager.getSessionState(sessionKey)?.activeTurn?.responseParts.find(part => part.kind === ResponsePartKind.ToolCall && part.toolCall.toolCallId === e.state.toolCallId);
-		const contributor = e.state.contributor ?? (part?.kind === ResponsePartKind.ToolCall ? part.toolCall.contributor : undefined);
+		const toolCall = part?.kind === ResponsePartKind.ToolCall ? part.toolCall : undefined;
+		const contributor = e.state.contributor ?? toolCall?.contributor;
 		let effective = e;
 		const clientShouldAutoApprove = autoApproval !== undefined
 			&& contributor?.kind === ToolCallContributorKind.Client
 			&& !!e.state.confirmationTitle;
 		if (clientShouldAutoApprove) {
 			this._toolCallAgents.set(`${sessionKey}:${e.state.toolCallId}`, agent.id);
-			effective = { ...e, state: { ...e.state, _meta: { ...e.state._meta, autoApproveBySetting: true } } };
+			effective = { ...e, state: { ...e.state, _meta: { ...toolCall?._meta, ...e.state._meta, autoApproveBySetting: true } } };
 		} else if (autoApproval !== undefined) {
 			this._toolCallAgents.delete(`${sessionKey}:${e.state.toolCallId}`);
 			agent.respondToPermissionRequest(e.state.toolCallId, true);

--- a/src/vs/platform/agentHost/node/sessionPermissions.ts
+++ b/src/vs/platform/agentHost/node/sessionPermissions.ts
@@ -119,12 +119,10 @@ export class SessionPermissionManager extends Disposable {
 	 * 5. Shell command rules (tree-sitter parsed, default allow/deny)
 	 */
 	getAutoApproval(e: IToolApprovalEvent, sessionKey: ProtocolURI): ToolCallConfirmationReason | undefined {
-		const autoApproveLevel = this._configService.getEffectiveValue(sessionKey, platformSessionSchema, SessionConfigKey.AutoApprove);
 		const workDir = this._configService.getEffectiveWorkingDirectory(sessionKey);
 
 		// 1. Session-level auto-approve
-		if (autoApproveLevel === 'autoApprove' || autoApproveLevel === 'autopilot') {
-			this._logService.trace(`[SessionPermissionManager] Auto-approving tool call (session autoApprove=${autoApproveLevel})`);
+		if (this.isSessionAutoApproveEnabled(sessionKey)) {
 			return ToolCallConfirmationReason.Setting;
 		}
 
@@ -169,6 +167,11 @@ export class SessionPermissionManager extends Disposable {
 		return undefined;
 	}
 
+	isSessionAutoApproveEnabled(sessionKey: ProtocolURI): boolean {
+		const autoApproveLevel = this._configService.getEffectiveValue(sessionKey, platformSessionSchema, SessionConfigKey.AutoApprove);
+		return autoApproveLevel === 'autoApprove' || autoApproveLevel === 'autopilot';
+	}
+
 	// ---- Action construction (analogous to getPreConfirmActions) -------------
 
 	/**
@@ -189,6 +192,7 @@ export class SessionPermissionManager extends Disposable {
 				confirmationTitle: state.confirmationTitle,
 				edits: state.edits,
 				editable: state.editable,
+				...(state._meta ? { _meta: state._meta } : {}),
 				// Agents can supply tool-specific buttons (e.g. ExitPlanMode's
 				// `Approve`/`Deny`) by populating `state.options`. The standard
 				// `Allow Once / Allow in this Session / Skip` set is the default.
@@ -202,6 +206,7 @@ export class SessionPermissionManager extends Disposable {
 			invocationMessage: state.invocationMessage,
 			toolInput: state.toolInput,
 			confirmed: ToolCallConfirmationReason.NotNeeded,
+			...(state._meta ? { _meta: state._meta } : {}),
 		};
 	}
 

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -138,11 +138,16 @@ suite('AgentService (node dispatcher)', () => {
 
 		test('applies and persists root config changes from clients', async () => {
 			const tempDir = URI.file(mkdtempSync(`${tmpdir()}/agent-host-config-`));
+			// Use a local DisposableStore so that svc can be explicitly disposed
+			// before cleaning up the temp directory. On Windows, rmSync fails with
+			// EPERM if the AgentService (and its child AgentConfigurationService)
+			// still holds references while the directory is being deleted.
+			const localDisposables = new DisposableStore();
 			try {
 				const rootConfigResource = joinPath(tempDir, 'agent-host-config.json');
-				const svc = disposables.add(new AgentService(new NullLogService(), fileService, nullSessionDataService, { _serviceBrand: undefined } as IProductService, createNoopGitService(), NULL_CHECKPOINT_SERVICE, rootConfigResource));
+				const svc = localDisposables.add(new AgentService(new NullLogService(), fileService, nullSessionDataService, { _serviceBrand: undefined } as IProductService, createNoopGitService(), NULL_CHECKPOINT_SERVICE, rootConfigResource));
 				const agent = new MockAgent('copilot');
-				disposables.add(toDisposable(() => agent.dispose()));
+				localDisposables.add(toDisposable(() => agent.dispose()));
 				svc.registerProvider(agent);
 
 				const customization = { uri: 'file:///plugin-a', displayName: 'Plugin A' };
@@ -172,6 +177,7 @@ suite('AgentService (node dispatcher)', () => {
 
 				assert.ok(persisted, 'should persist the root config change');
 			} finally {
+				localDisposables.dispose();
 				rmSync(tempDir.fsPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 			}
 		});

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -1614,6 +1614,7 @@ suite('AgentSideEffects', () => {
 				action: {
 					type: ActionType.SessionToolCallStart, turnId: 'turn-1',
 					toolCallId: 'tc-client-approve-1', toolName: 'runTask', displayName: 'Run Task', contributor: { kind: ToolCallContributorKind.Client, clientId: 'test-client' },
+					_meta: { toolKind: 'terminal' },
 				},
 			});
 
@@ -1637,7 +1638,7 @@ suite('AgentSideEffects', () => {
 				permissionCalls: agent.respondToPermissionCalls,
 			}, {
 				status: ToolCallStatus.PendingConfirmation,
-				meta: { autoApproveBySetting: true },
+				meta: { toolKind: 'terminal', autoApproveBySetting: true },
 				permissionCalls: [],
 			});
 

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -1604,6 +1604,56 @@ suite('AgentSideEffects', () => {
 			]);
 		});
 
+		test('marks pending client tool approval for client-side auto-approval in bypass mode', () => {
+			setupSessionWithConfig('autoApprove');
+			startTurn('turn-1');
+			disposables.add(sideEffects.registerProgressListener(agent));
+
+			agent.fireProgress({
+				kind: 'action', session: sessionUri,
+				action: {
+					type: ActionType.SessionToolCallStart, turnId: 'turn-1',
+					toolCallId: 'tc-client-approve-1', toolName: 'runTask', displayName: 'Run Task', contributor: { kind: ToolCallContributorKind.Client, clientId: 'test-client' },
+				},
+			});
+
+			agent.fireProgress({
+				kind: 'pending_confirmation', session: sessionUri,
+				state: {
+					status: ToolCallStatus.PendingConfirmation,
+					toolCallId: 'tc-client-approve-1', toolName: 'runTask', displayName: 'Run Task',
+					invocationMessage: 'Run task', toolInput: '{"task":"build"}',
+					confirmationTitle: 'Run task', edits: undefined,
+				},
+				permissionKind: 'custom-tool', permissionPath: undefined,
+			});
+
+			const state = stateManager.getSessionState(sessionUri.toString());
+			const part = state?.activeTurn?.responseParts.find(part => part.kind === ResponsePartKind.ToolCall && part.toolCall.toolCallId === 'tc-client-approve-1');
+			assert.ok(part?.kind === ResponsePartKind.ToolCall);
+			assert.deepStrictEqual({
+				status: part.toolCall.status,
+				meta: part.toolCall._meta,
+				permissionCalls: agent.respondToPermissionCalls,
+			}, {
+				status: ToolCallStatus.PendingConfirmation,
+				meta: { autoApproveBySetting: true },
+				permissionCalls: [],
+			});
+
+			sideEffects.handleAction(sessionUri.toString(), {
+				type: ActionType.SessionToolCallConfirmed,
+				turnId: 'turn-1',
+				toolCallId: 'tc-client-approve-1',
+				approved: true,
+				confirmed: ToolCallConfirmationReason.Setting,
+			});
+
+			assert.deepStrictEqual(agent.respondToPermissionCalls, [
+				{ requestId: 'tc-client-approve-1', approved: true },
+			]);
+		});
+
 		test('does NOT auto-approve when autoApprove is default', () => {
 			setupSessionWithConfig('default');
 			startTurn('turn-1');

--- a/src/vs/platform/agentHost/test/node/reducers.test.ts
+++ b/src/vs/platform/agentHost/test/node/reducers.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { changesetReducer, sessionReducer } from '../../common/state/protocol/reducers.js';
 import { ActionType } from '../../common/state/sessionActions.js';
-import { ChangesetStatus, ChangesetOperationStatus, CustomizationLoadStatus, MessageKind, SessionInputAnswerState, SessionInputAnswerValueKind, SessionInputQuestionKind, SessionInputResponseKind, SessionLifecycle, SessionStatus, ToolCallConfirmationReason, type AgentCustomization, type ChangesetState, type Customization, type PluginCustomization, type SessionState } from '../../common/state/sessionState.js';
+import { ChangesetStatus, ChangesetOperationStatus, CustomizationLoadStatus, MessageKind, ResponsePartKind, SessionInputAnswerState, SessionInputAnswerValueKind, SessionInputQuestionKind, SessionInputResponseKind, SessionLifecycle, SessionStatus, ToolCallConfirmationReason, ToolCallStatus, type AgentCustomization, type ChangesetState, type Customization, type PluginCustomization, type SessionState } from '../../common/state/sessionState.js';
 import { CustomizationType } from '../../common/state/protocol/state.js';
 
 function makeSession(): SessionState {
@@ -180,6 +180,40 @@ suite('sessionReducer – summaryStatus with tool call confirmations and input r
 		});
 
 		assert.strictEqual(state.summary.status, SessionStatus.InputNeeded);
+	});
+
+	test('SessionToolCallReady preserves action metadata on pending and running tool calls', () => {
+		const state = withActiveTurnAndToolCall(makeSession());
+		const pending = sessionReducer(state, {
+			type: ActionType.SessionToolCallReady,
+			turnId: 'turn-1',
+			toolCallId: 'tc-1',
+			invocationMessage: 'Read file?',
+			toolInput: '/foo.ts',
+			_meta: { autoApproveBySetting: true },
+		});
+		const running = sessionReducer(state, {
+			type: ActionType.SessionToolCallReady,
+			turnId: 'turn-1',
+			toolCallId: 'tc-1',
+			invocationMessage: 'Read file',
+			toolInput: '/foo.ts',
+			confirmed: ToolCallConfirmationReason.NotNeeded,
+			_meta: { autoApproveBySetting: true },
+		});
+
+		const getToolCall = (s: SessionState) => {
+			const part = s.activeTurn?.responseParts.find(part => part.kind === ResponsePartKind.ToolCall && part.toolCall.toolCallId === 'tc-1');
+			assert.ok(part?.kind === ResponsePartKind.ToolCall);
+			return part.toolCall;
+		};
+		assert.deepStrictEqual([
+			{ status: getToolCall(pending).status, meta: getToolCall(pending)._meta },
+			{ status: getToolCall(running).status, meta: getToolCall(running)._meta },
+		], [
+			{ status: ToolCallStatus.PendingConfirmation, meta: { autoApproveBySetting: true } },
+			{ status: ToolCallStatus.Running, meta: { autoApproveBySetting: true } },
+		]);
 	});
 });
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -20,6 +20,7 @@ import { isLocation, type Location } from '../../../../../../editor/common/langu
 import { localize } from '../../../../../../nls.js';
 import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/agentFeedbackAttachments.js';
 import { AgentProvider, AgentSession, type IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
+import { SessionConfigKey } from '../../../../../../platform/agentHost/common/sessionConfigKeys.js';
 import { IAgentSubscription, observableFromSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
 import { SessionTruncatedAction } from '../../../../../../platform/agentHost/common/state/protocol/actions.js';
 import { CompletionItemKind as AhpCompletionItemKind, type CompletionItem as AhpCompletionItem } from '../../../../../../platform/agentHost/common/state/protocol/commands.js';
@@ -145,6 +146,10 @@ function confirmedReasonToProtocol(reason: ConfirmedReason | undefined): ToolCal
 		default:
 			return ToolCallConfirmationReason.UserAction;
 	}
+}
+
+function shouldAutoApproveClientToolCall(toolCall: ToolCallState): boolean {
+	return toolCall._meta?.autoApproveBySetting === true;
 }
 
 /**
@@ -1716,6 +1721,11 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		// idempotent.
 		store.add(autorun(reader => {
 			const state = invocation.state.read(reader);
+			const tc = part$.read(reader).toolCall;
+			if (state.type === IChatToolInvocation.StateKind.WaitingForConfirmation && shouldAutoApproveClientToolCall(tc)) {
+				state.confirm({ type: ToolConfirmKind.Setting, id: SessionConfigKey.AutoApprove });
+				return;
+			}
 			if (confirmationDispatched) {
 				return;
 			}
@@ -1780,6 +1790,10 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		// `cts.token.isCancellationRequested`.
 		store.add(autorun(reader => {
 			const tc = part$.read(reader).toolCall;
+			const state = invocation.state.read(reader);
+			if (state.type === IChatToolInvocation.StateKind.WaitingForConfirmation && shouldAutoApproveClientToolCall(tc)) {
+				state.confirm({ type: ToolConfirmKind.Setting, id: SessionConfigKey.AutoApprove });
+			}
 			if (tc.status === ToolCallStatus.Cancelled) {
 				if (cts.token.isCancellationRequested) {
 					return;

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
@@ -238,7 +238,7 @@ suite('AgentHostClientTools', () => {
 
 	suite('client tools registration', () => {
 
-		function createMockToolsService(disposables: DisposableStore, tools: IToolData[]) {
+		function createMockToolsService(disposables: DisposableStore, tools: IToolData[], options?: { requireConfirmation?: boolean }) {
 			const onDidChangeTools = disposables.add(new Emitter<void>());
 			const pendingToolCalls = new Map<string, ChatToolInvocation>();
 			const begunToolCalls: ChatToolInvocation[] = [];
@@ -257,7 +257,18 @@ suite('AgentHostClientTools', () => {
 					invokedToolCalls.push(invocation);
 					const toolInvocation = pendingToolCalls.get(invocation.chatStreamToolCallId ?? invocation.callId);
 					pendingToolCalls.delete(invocation.chatStreamToolCallId ?? invocation.callId);
-					toolInvocation?.transitionFromStreaming(undefined, invocation.parameters, { type: ToolConfirmKind.ConfirmationNotNeeded });
+					if (options?.requireConfirmation && toolInvocation) {
+						toolInvocation.transitionFromStreaming({
+							invocationMessage: 'Run Task',
+							confirmationMessages: {
+								title: 'Confirm tool execution',
+								message: 'Run the task?',
+							},
+						}, invocation.parameters, undefined);
+						await IChatToolInvocation.awaitConfirmation(toolInvocation, CancellationToken.None);
+					} else {
+						toolInvocation?.transitionFromStreaming(undefined, invocation.parameters, { type: ToolConfirmKind.ConfirmationNotNeeded });
+					}
 					const result: IToolResult = { content: [{ kind: 'text', value: 'done' }] };
 					await toolInvocation?.didExecuteTool(result);
 					return result;
@@ -386,11 +397,12 @@ suite('AgentHostClientTools', () => {
 			disposables: DisposableStore,
 			tools: IToolData[],
 			configOverrides?: { clientTools?: string[] },
+			toolServiceOptions?: { requireConfirmation?: boolean },
 		) {
 			const instantiationService = disposables.add(new TestInstantiationService());
 			const connection = new MockAgentHostConnection();
 
-			const toolsService = createMockToolsService(disposables, tools);
+			const toolsService = createMockToolsService(disposables, tools, toolServiceOptions);
 			const configValues: Record<string, unknown> = {
 				'chat.agentHost.clientTools': configOverrides?.clientTools ?? ['runTask', 'runTests'],
 			};
@@ -616,6 +628,77 @@ suite('AgentHostClientTools', () => {
 			assert.ok(connection.dispatchedActions.some(entry => isSessionAction(entry.action)
 				&& entry.action.type === ActionType.SessionToolCallComplete
 				&& entry.action.toolCallId === 'tool-call-1'));
+		});
+
+		test('auto-approves client tool confirmation as a setting when the agent host marks the call', async () => {
+			const { handler, connection } = createHandlerWithMocks(disposables, [testRunTaskTool], undefined, { requireConfirmation: true });
+			const sessionResource = URI.parse('agent-host-copilot:/session-1');
+			const backendSession = AgentSession.uri('copilot', 'session-1').toString();
+
+			connection.applySessionAction(URI.parse(backendSession), {
+				type: ActionType.SessionTurnStarted,
+				turnId: 'turn-1',
+				message: { text: 'run the task', origin: { kind: MessageKind.User } },
+			} as SessionAction);
+			connection.applySessionAction(URI.parse(backendSession), {
+				type: ActionType.SessionToolCallStart,
+				turnId: 'turn-1',
+				toolCallId: 'tool-call-1',
+				toolName: 'runTask',
+				displayName: 'Run Task',
+				contributor: { kind: ToolCallContributorKind.Client, clientId: connection.clientId },
+			} as SessionAction);
+			connection.applySessionAction(URI.parse(backendSession), {
+				type: ActionType.SessionToolCallReady,
+				turnId: 'turn-1',
+				toolCallId: 'tool-call-1',
+				invocationMessage: 'Run Task',
+				toolInput: '{"task":"build"}',
+				confirmationTitle: 'Run Task',
+				_meta: { autoApproveBySetting: true },
+			} as SessionAction);
+
+			await handler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			await timeout(0);
+			await timeout(0);
+			await timeout(0);
+
+			assert.deepStrictEqual(connection.dispatchedActions
+				.filter(entry => isSessionAction(entry.action)
+					&& (entry.action.type === ActionType.SessionToolCallConfirmed || entry.action.type === ActionType.SessionToolCallComplete)
+					&& entry.action.toolCallId === 'tool-call-1')
+				.map(entry => {
+					if (entry.action.type === ActionType.SessionToolCallConfirmed) {
+						return {
+							type: entry.action.type,
+							approved: entry.action.approved,
+							confirmed: entry.action.approved ? entry.action.confirmed : undefined,
+							success: undefined,
+						};
+					}
+					if (entry.action.type === ActionType.SessionToolCallComplete) {
+						return {
+							type: entry.action.type,
+							approved: undefined,
+							confirmed: undefined,
+							success: entry.action.result.success,
+						};
+					}
+					throw new Error(`Unexpected action type: ${entry.action.type}`);
+				}), [
+				{
+					type: ActionType.SessionToolCallConfirmed,
+					approved: true,
+					confirmed: ToolCallConfirmationReason.Setting,
+					success: undefined,
+				},
+				{
+					type: ActionType.SessionToolCallComplete,
+					approved: undefined,
+					confirmed: undefined,
+					success: true,
+				},
+			]);
 		});
 
 		test('reconnecting to an active turn with owned client tool completes the initial snapshot invocation', async () => {


### PR DESCRIPTION
Fixes #314149

## Summary
- Preserve tool-call metadata through pending/running ready transitions
- Mark pending client-owned tool approvals with `_meta.autoApproveBySetting` when agent-host bypass/autopilot approval applies
- Have the workbench auto-confirm those client tool invocations using `ToolConfirmKind.Setting`

## Validation
- npm run compile-check-ts-native
- npm run gulp compile
- env -u ELECTRON_RUN_AS_NODE scripts/test.sh --grep "AgentSideEffects|AgentHostClientTools|sessionReducer"
- npm run valid-layers-check
- node --experimental-strip-types build/hygiene.ts <changed files>