### PR TITLE
Fix image carousel showing UUID on hover in modal editor title

### DIFF
--- a/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
@@ -361,6 +361,7 @@ export class ModalEditorPart {
 						description: activeEditor.getDescription(labelFormat === 'short' ? Verbosity.SHORT : labelFormat === 'long' ? Verbosity.LONG : Verbosity.MEDIUM) || ''
 					},
 					{
+						title: activeEditor.getTitle(Verbosity.LONG),
 						icon: activeEditor.getIcon(),
 						extraClasses: activeEditor.getLabelExtraClasses(),
 					}


### PR DESCRIPTION
Fixes #301984

### Problem

Hovering the image carousel title in the modal header shows a raw UUID, and the UUID changes every time the carousel is reopened.

Root cause:

- Each carousel open generates a fresh collection id via `generateUuid()` (`imageCarousel.contribution.ts`), which `ImageCarouselEditorInput` turns into its resource URI: `vscode-imagecarousel:///<uuid>`.
- The modal header label (`updateLabel()` in `modalEditorPart.ts`) calls `ResourceLabel.setResource()` without a `title` option.
- With no title provided, `ResourceLabelWidget.render()` (`labels.ts`) falls back to `labelService.getUriLabel(resource)` for the tooltip — i.e. the UUID URI.

### Fix

Pass `title: activeEditor.getTitle(Verbosity.LONG)` in the `ResourceLabel` options for the modal header, mirroring how editor tabs set their hover (`multiEditorTabsControl.ts`, `editorTabsControl.ts#getHoverTitle`).

This makes the modal header hover behave like existing non-file editor tabs — e.g. the Settings editor tab, whose hover shows "Settings" (its `getTitle(Verbosity.LONG)` falls back to `getName()`). The carousel hover now shows its stable title ("Image Carousel" / "Images Preview") instead of a per-open UUID.

The fix applies to all modal editor inputs (chat management, agent plugin, workspace trust, etc.), not just the image carousel. File editors opened modally (`workbench.editor.useModal: "all"`) keep their useful full-path hover, since `FileEditorInput.getTitle(Verbosity.LONG)` returns the full path — no behavior change there.

### Before / After

Before:
<img width="2940" height="1846" alt="uuid2" src="https://github.com/user-attachments/assets/c6e2ecb0-d18b-44a7-8537-7ec8f16fe96b" />

After:
<img width="2940" height="1846" alt="uuid1" src="https://github.com/user-attachments/assets/66624237-a0b2-4272-ae1e-ee548ed8d707" />

### Verification

- Right-click an image in the Explorer → **Open in Images Preview** → hover the modal title: shows the title, not a UUID; stable across reopens.
- Regression check with `"workbench.editor.useModal": "all"`: a file opened in the modal still shows its full path on hover.
- `compile-check-ts-native` and ESLint pass.
