### PR TITLE
Fix raw markdown shown in image carousel caption

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatImageCarouselService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatImageCarouselService.ts
@@ -3,6 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { renderAsPlaintext } from '../../../../base/browser/markdownRenderer.js';
+import { IMarkdownString } from '../../../../base/common/htmlContent.js';
+import { stripIcons } from '../../../../base/common/iconLabels.js';
 import { getMediaMime } from '../../../../base/common/mime.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -100,7 +103,7 @@ export async function collectCarouselSections(
 		if (dedupedImages.length > 0) {
 			sections.push({
 				title: request?.messageText ?? extractedTitle,
-				images: dedupedImages.map(({ uri, name, mimeType, data, caption }) => ({ id: uri.toString(), name, mimeType, data: data.buffer, caption }))
+				images: dedupedImages.map(({ uri, name, mimeType, data, caption }) => ({ id: uri.toString(), name, mimeType, data: data.buffer, caption: toCaptionText(caption) }))
 			});
 		}
 	}
@@ -118,12 +121,24 @@ export async function collectCarouselSections(
 		if (dedupedImages.length > 0) {
 			sections.push({
 				title: item.messageText,
-				images: dedupedImages.map(({ uri, name, mimeType, data, caption }) => ({ id: uri.toString(), name, mimeType, data: data.buffer, caption }))
+				images: dedupedImages.map(({ uri, name, mimeType, data, caption }) => ({ id: uri.toString(), name, mimeType, data: data.buffer, caption: toCaptionText(caption) }))
 			});
 		}
 	}
 
 	return sections;
+}
+
+/**
+ * Converts an extracted image caption to plain display text, stripping
+ * Markdown syntax (e.g. "Viewed image [](file:///path/img.png)" becomes
+ * "Viewed image img.png") the same way chat renders tool invocation messages.
+ */
+function toCaptionText(caption: string | IMarkdownString | undefined): string | undefined {
+	if (caption === undefined) {
+		return undefined;
+	}
+	return typeof caption === 'string' ? caption : stripIcons(renderAsPlaintext(caption, { useLinkFormatter: true }));
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/chatImageExtraction.ts
+++ b/src/vs/workbench/contrib/chat/common/chatImageExtraction.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { decodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
+import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { getExtensionForMimeType, getMediaMime } from '../../../../base/common/mime.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
@@ -21,7 +22,7 @@ export interface IChatExtractedImage {
 	readonly mimeType: string;
 	readonly data: VSBuffer;
 	readonly source: string;
-	readonly caption: string | undefined;
+	readonly caption: string | IMarkdownString | undefined;
 }
 
 export interface IChatExtractedImageCollection {
@@ -71,8 +72,7 @@ export function extractImagesFromToolInvocationOutputDetails(toolInvocation: ICh
 
 	const resultDetails = IChatToolInvocation.resultDetails(toolInvocation);
 
-	const msg = toolInvocation.pastTenseMessage ?? toolInvocation.invocationMessage;
-	const caption = msg ? (typeof msg === 'string' ? msg : msg.value) : undefined;
+	const caption = toolInvocation.pastTenseMessage ?? toolInvocation.invocationMessage;
 	const pushImage = (mimeType: string, data: VSBuffer, outputIndex: number) => {
 		const ext = getExtensionForMimeType(mimeType);
 		const permalinkBasename = ext ? `file${ext}` : 'file.bin';
@@ -140,7 +140,7 @@ export async function extractImagesFromToolInvocationMessages(
 				mimeType,
 				data,
 				source: localize('chatImageExtraction.toolSource', "Tool: {0}", toolInvocation.toolId),
-				caption: message.value,
+				caption: message,
 			});
 		}
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/chatImageCarouselService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatImageCarouselService.test.ts
@@ -353,6 +353,35 @@ suite('ChatImageCarouselService helpers', () => {
 			assert.strictEqual(result.length, 1);
 			assert.strictEqual(result[0].images.length, 1);
 			assert.strictEqual(result[0].images[0].id, expectedUri);
+			assert.strictEqual(result[0].images[0].caption, 'Took screenshot');
+		});
+
+		test('strips markdown from tool invocation message captions', async () => {
+			const imageUri = URI.file('/screenshots/homepage.png');
+			const request = makeRequest('req-1', [], 'Take a screenshot');
+			const response = makeResponse('req-1', 'resp-1', [
+				{
+					kind: 'toolInvocationSerialized',
+					toolId: 'view_image',
+					toolCallId: 'tool-call-1',
+					invocationMessage: 'Viewing image',
+					originMessage: undefined,
+					pastTenseMessage: { value: 'Viewed image [](file:///screenshots/homepage.png)', isTrusted: false, uris: { '0': imageUri.toJSON() } },
+					presentation: undefined,
+					resultDetails: undefined,
+					isConfirmed: { type: 0 },
+					isComplete: true,
+					source: ToolDataSource.Internal,
+					generatedTitle: undefined,
+					isAttachedToThinking: false,
+				} as unknown as IChatToolInvocationSerialized,
+			]);
+
+			const result = await collectCarouselSections([request, response], async () => new Uint8Array([1, 2, 3]));
+
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0].images.length, 1);
+			assert.strictEqual(result[0].images[0].caption, 'Viewed image homepage.png');
 		});
 
 		test('image data is a plain Uint8Array usable by Blob constructor', async () => {

--- a/src/vs/workbench/contrib/chat/test/common/chatImageExtraction.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatImageExtraction.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IChatRequestVariableEntry, IImageVariableEntry } from '../../common/attachments/chatVariableEntries.js';
@@ -295,7 +296,7 @@ suite('extractImagesFromChatResponse', () => {
 		assert.strictEqual(result.images[0].uri.toString(), imageUri.toString());
 		assert.strictEqual(result.images[0].name, 'result.png');
 		assert.strictEqual(result.images[0].mimeType, 'image/png');
-		assert.strictEqual(result.images[0].caption, 'Took a screenshot');
+		assert.strictEqual((result.images[0].caption as IMarkdownString).value, 'Took a screenshot');
 	});
 
 	test('combines output details images and message URI images', async () => {
@@ -377,7 +378,7 @@ suite('extractImagesFromToolInvocationMessages', () => {
 		assert.strictEqual(result[0].uri.toString(), imageUri.toString());
 		assert.strictEqual(result[0].name, 'capture.png');
 		assert.strictEqual(result[0].mimeType, 'image/png');
-		assert.strictEqual(result[0].caption, 'Captured screenshot');
+		assert.strictEqual((result[0].caption as IMarkdownString).value, 'Captured screenshot');
 		assert.ok(result[0].source.includes('screenshot-tool'));
 	});
 
@@ -432,7 +433,7 @@ suite('extractImagesFromToolInvocationMessages', () => {
 		const result = await extractImagesFromToolInvocationMessages(toolInvocation, fakeReadFile);
 
 		assert.strictEqual(result.length, 1);
-		assert.strictEqual(result[0].caption, 'Running tool');
+		assert.strictEqual((result[0].caption as IMarkdownString).value, 'Running tool');
 	});
 });
 

--- a/src/vs/workbench/contrib/chat/test/common/chatImageExtraction.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatImageExtraction.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
-import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
+import { isMarkdownString } from '../../../../../base/common/htmlContent.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IChatRequestVariableEntry, IImageVariableEntry } from '../../common/attachments/chatVariableEntries.js';
@@ -296,7 +296,9 @@ suite('extractImagesFromChatResponse', () => {
 		assert.strictEqual(result.images[0].uri.toString(), imageUri.toString());
 		assert.strictEqual(result.images[0].name, 'result.png');
 		assert.strictEqual(result.images[0].mimeType, 'image/png');
-		assert.strictEqual((result.images[0].caption as IMarkdownString).value, 'Took a screenshot');
+		const caption = result.images[0].caption;
+		assert.ok(isMarkdownString(caption), 'caption should be an IMarkdownString');
+		assert.strictEqual(caption.value, 'Took a screenshot');
 	});
 
 	test('combines output details images and message URI images', async () => {
@@ -378,7 +380,9 @@ suite('extractImagesFromToolInvocationMessages', () => {
 		assert.strictEqual(result[0].uri.toString(), imageUri.toString());
 		assert.strictEqual(result[0].name, 'capture.png');
 		assert.strictEqual(result[0].mimeType, 'image/png');
-		assert.strictEqual((result[0].caption as IMarkdownString).value, 'Captured screenshot');
+		const caption = result[0].caption;
+		assert.ok(isMarkdownString(caption), 'caption should be an IMarkdownString');
+		assert.strictEqual(caption.value, 'Captured screenshot');
 		assert.ok(result[0].source.includes('screenshot-tool'));
 	});
 
@@ -433,7 +437,9 @@ suite('extractImagesFromToolInvocationMessages', () => {
 		const result = await extractImagesFromToolInvocationMessages(toolInvocation, fakeReadFile);
 
 		assert.strictEqual(result.length, 1);
-		assert.strictEqual((result[0].caption as IMarkdownString).value, 'Running tool');
+		const caption = result[0].caption;
+		assert.ok(isMarkdownString(caption), 'caption should be an IMarkdownString');
+		assert.strictEqual(caption.value, 'Running tool');
 	});
 });
 


### PR DESCRIPTION
Fixes #307446

### Problem

The image carousel's bottom caption shows raw markdown instead of readable text, e.g.:

```
Viewed image [](file:///Users/pierceboggan/Documents/GitHub/coloring-book/homepage.png)
```

Root cause:

- Tool invocations carry `invocationMessage`/`pastTenseMessage` typed `string | IMarkdownString`. Copilot's view-image tool produces markdown like `Viewed image [](file:///…/homepage.png)` (the empty-text link renders as a file widget in chat, but is raw syntax anywhere else).
- `chatImageExtraction.ts` flattened the message to its raw markdown source via `.value` and stored that as the image caption.
- The carousel editor renders captions as plain text (`captionText.textContent = …`, per its `caption?: string` contract), so the markdown syntax was displayed verbatim.

### Fix

Preserve the message as `string | IMarkdownString` in `chatImageExtraction.ts` (common layer), and convert it to display text at the presentation layer in `chatImageCarouselService.ts` with a small `toCaptionText()` helper:

```ts
stripIcons(renderAsPlaintext(caption, { useLinkFormatter: true }))
```

This is the same conversion the chat UI already applies when rendering these tool messages as labels (see `chatToolProgressPart.ts`), so the carousel caption now matches what the user sees in chat: `Viewed image homepage.png` (`useLinkFormatter` resolves empty-text links to the file basename).

Notes:

- The conversion lives in the browser layer because `renderAsPlaintext` is in `vs/base/browser` and `chatImageExtraction.ts` is common-layer code.
- The carousel editor (`imageCarouselEditor.ts`) is intentionally untouched — its plain-text caption contract is correct; the chat layer was handing it markdown.
- Plain-string messages pass through verbatim; images without a tool message still show no caption.

### Tests

- Added a regression test in `chatImageCarouselService.test.ts` (`strips markdown from tool invocation message captions`) using the exact message shape from the issue, plus a passthrough assertion for plain-string messages.
- Updated `chatImageExtraction.test.ts` assertions for the caption type change (captions from `IMarkdownString` messages now assert on `.value`).

### Before / After

Before:
<img width="2940" height="1858" alt="markdown1" src="https://github.com/user-attachments/assets/cee761f0-51d3-4bf8-8e7b-ca430c39dd0b" />

After:
<img width="2940" height="1848" alt="markdown2" src="https://github.com/user-attachments/assets/b2dfbb72-36af-4d3e-9bcd-e7000067ad93" />


