### PR TITLE
fix(diffEditor): reset wordWrapOverride2 when switching from inline to side-by-side view

### DIFF
--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorEditors.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorEditors.ts
@@ -148,6 +148,7 @@ export class DiffEditorEditors extends Disposable {
 		} else {
 			result.unicodeHighlight = this._options.editorOptions.get().unicodeHighlight || {};
 			result.wordWrapOverride1 = this._options.diffWordWrap.get();
+			result.wordWrapOverride2 = 'inherit';
 		}
 		result.glyphMargin = this._options.renderSideBySide.get();
 


### PR DESCRIPTION
In inline view, _adjustOptionsForLeftHandSide disables word wrap on the hidden original editor by setting both wordWrapOverride1 and wordWrapOverride2 to 'off'. When switching back to side-by-side view, wordWrapOverride1 is correctly restored via diffWordWrap, but wordWrapOverride2 is never reset.

Since wordWrapOverride2 has higher priority than wordWrapOverride1, the stale 'off' value permanently suppresses word wrap on the original editor regardless of the diffWordWrap setting.

Fix by resetting wordWrapOverride2 to 'inherit' in the side-by-side branch, matching the behaviour of the right-hand side editor which never sets wordWrapOverride2 at all.

Fixes https://github.com/microsoft/monaco-editor/issues/5353

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
