### PR TITLE
Auto: keep model cache across token refresh 

### DIFF
--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -878,6 +878,11 @@ export namespace ConfigKey {
 		 * For experiments, this setting selects the routing method only when router usage is enabled;
 		 * it does not by itself determine whether the router is called. */
 		export const AutoModeRoutingMethod = defineTeamInternalSetting<string>('chat.advanced.autoModeRoutingMethod', ConfigType.ExperimentBased, '', undefined, undefined, { experimentName: 'copilotchat.autoModeRoutingMethod' });
+		/** When enabled, a periodic auth/token refresh refreshes each Auto conversation's
+		 * CAPI session token in place instead of clearing the model cache, so the
+		 * conversation stays pinned to the model Auto already selected and keeps its
+		 * provider prompt cache warm. Gated for experimentation. */
+		export const AutoModePreserveModelOnTokenRefresh = defineTeamInternalSetting<boolean>('chat.advanced.autoModePreserveModelOnTokenRefresh', ConfigType.ExperimentBased, false, undefined, undefined, { experimentName: 'copilotchat.autoModePreserveModelOnTokenRefresh' });
 
 		/** Inline Completions */
 		export const InlineCompletionsDefaultDiagnosticsOptions = defineTeamInternalSetting<string | undefined>('chat.advanced.inlineCompletions.defaultDiagnosticsOptionsString', ConfigType.ExperimentBased, undefined);

--- a/extensions/copilot/src/platform/endpoint/node/automodeService.ts
+++ b/extensions/copilot/src/platform/endpoint/node/automodeService.ts
@@ -137,10 +137,21 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 	) {
 		super();
 		this._register(this._authService.onDidAuthenticationChange(() => {
-			for (const entry of this._autoModelCache.values()) {
-				entry.tokenBank.dispose();
+			// EXPERIMENT (AutoModePreserveModelOnTokenRefresh): onDidAuthenticationChange
+			// fires on the routine Copilot token refresh (~every 20+ min, same identity).
+			// Clearing the per-conversation model cache here makes the next turn of an
+			// in-flight conversation silently re-resolve its model — often to a different
+			// model or provider — which throws away the provider prompt cache. When the
+			// experiment is enabled we keep the cache so each conversation stays pinned to
+			// the model Auto already selected; its token bank refreshes itself with the new
+			// token on its own expiry.
+			const preserveModelPin = this._configurationService.getExperimentBasedConfig(ConfigKey.TeamInternal.AutoModePreserveModelOnTokenRefresh, this._expService);
+			if (!preserveModelPin) {
+				for (const entry of this._autoModelCache.values()) {
+					entry.tokenBank.dispose();
+				}
+				this._autoModelCache.clear();
 			}
-			this._autoModelCache.clear();
 			const keys = Array.from(this._reserveTokens.keys());
 			this._reserveTokens.clearAndDisposeAll();
 			for (const location of keys) {


### PR DESCRIPTION
Gate the per-conversation Auto model-cache clear in the onDidAuthenticationChange handler behind a new experiment-based setting, chat.advanced.autoModePreserveModelOnTokenRefresh (default false).

onDidAuthenticationChange fires on the routine Copilot token refresh (same identity). Clearing _autoModelCache there makes the next turn of an in-flight Auto conversation re-resolve its model and silently switch model or provider, landing on a cold provider prompt cache. When the experiment is enabled the cache is preserved so the conversation stays pinned to its selected model; each token bank still refreshes itself on its own expiry. Reserve token-bank refresh is unchanged. No-op when the flag is false.

If this theory is correct we should see
- Overall auto cache hit rate improve, bring in line with the same models chosen in the picker
- Between model auto vs non auto differences should be more consistent (claude vs oai differences in auto vs non auto should be similar), due to compaction firing on top of cold call after switch (oai vs haiku/sonnet context size differences exacerbate the switching cost for oai --> sonnet or haiku). 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
