### PR TITLE
fix: exit process cleanly on fatal startup errors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -202,7 +202,8 @@ async function onReady() {
 		await startup(codeCachePath, nlsConfig);
 	} catch (error) {
 		console.error('Fatal error during startup:', error);
-		app.exit(1);
+		process.exitCode = 1;
+		app.quit();
 	}
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -201,7 +201,8 @@ async function onReady() {
 
 		await startup(codeCachePath, nlsConfig);
 	} catch (error) {
-		console.error(error);
+		console.error('Fatal error during startup:', error);
+		app.exit(1);
 	}
 }
 


### PR DESCRIPTION
Fixes #320760

**What changed?**
Added `app.exit(1)` to the catch block in `onReady()` inside `src/main.ts`. 

**Why?**
As discussed in the issue, if a fatal error occurs during the core initialization (`resolveNlsConfiguration`, etc.), the error was previously just logged while the process stayed alive in an invalid state. This ensures we fail fast and the process is correctly terminated.

**How I tested this:**
- Pulled the latest `main`.
- Manually injected an error inside the `try` block before `startup()`.
- Verified that running `.\scripts\code.bat` (or `.sh`) now cleanly exits the process with code 1 instead of leaving Electron hanging in the background.