### PR TITLE
copilot: don't show quota dialog for automatic rename suggestions

### DIFF
--- a/extensions/copilot/src/extension/renameSuggestions/node/renameSuggestionsProvider.ts
+++ b/extensions/copilot/src/extension/renameSuggestions/node/renameSuggestionsProvider.ts
@@ -158,7 +158,7 @@ export class RenameSuggestionsProvider implements vscode.NewSymbolNamesProvider 
 						// @ulugbekna: only show the quota exceeded dialog when the user manually invoked rename suggestions.
 						// For automatic triggers (e.g., when pressing F2), showing a modal dialog steals focus from the
 						// rename widget and cancels the user's rename action - see https://github.com/microsoft/vscode/issues/319414
-						if (triggerKind === NewSymbolNameTriggerKind.Invoke && (fetchResult.type === ChatFetchResponseType.QuotaExceeded || (fetchResult.type === ChatFetchResponseType.RateLimited && this._authService.copilotToken?.isNoAuthUser))) {
+						if (RenameSuggestionsProvider.shouldShowQuotaExceededDialog(triggerKind, fetchResult.type, this._authService.copilotToken?.isNoAuthUser ?? false)) {
 							await this._notificationService.showQuotaExceededDialog({ isNoAuthUser: this._authService.copilotToken?.isNoAuthUser ?? false });
 						}
 
@@ -291,8 +291,22 @@ export class RenameSuggestionsProvider implements vscode.NewSymbolNamesProvider 
 		return newSymbolNames.map(newSymbolName => enforceNamingConvention(newSymbolName, targetNamingConvention));
 	}
 
-	public static parseResponse(reply: string): { replyFormat: ReplyFormat; redundantCharCount: number; symbolNames: string[] } {
+	/**
+	 * Determines whether to show the quota exceeded dialog for a rename suggestions fetch result.
+	 *
+	 * The dialog is only shown for manually-invoked rename suggestions ({@link NewSymbolNameTriggerKind.Invoke}).
+	 * For automatic triggers (e.g., when pressing F2), showing a modal dialog steals focus from the rename
+	 * widget and cancels the user's rename action - see https://github.com/microsoft/vscode/issues/319414
+	 */
+	public static shouldShowQuotaExceededDialog(triggerKind: NewSymbolNameTriggerKind, fetchResultType: ChatFetchResponseType, isNoAuthUser: boolean): boolean {
+		if (triggerKind !== NewSymbolNameTriggerKind.Invoke) {
+			return false;
+		}
+		return fetchResultType === ChatFetchResponseType.QuotaExceeded
+			|| (fetchResultType === ChatFetchResponseType.RateLimited && isNoAuthUser);
+	}
 
+	public static parseResponse(reply: string): { replyFormat: ReplyFormat; redundantCharCount: number; symbolNames: string[] } {
 		const parsedAsJSONStringArray = RenameSuggestionsProvider._parseReplyAsJSONStringArray(reply);
 		if (parsedAsJSONStringArray !== undefined) {
 			return parsedAsJSONStringArray;

--- a/extensions/copilot/src/extension/renameSuggestions/node/renameSuggestionsProvider.ts
+++ b/extensions/copilot/src/extension/renameSuggestions/node/renameSuggestionsProvider.ts
@@ -155,7 +155,10 @@ export class RenameSuggestionsProvider implements vscode.NewSymbolNamesProvider 
 						);
 						const fetchTime = sw.elapsed();
 
-						if (fetchResult.type === ChatFetchResponseType.QuotaExceeded || (fetchResult.type === ChatFetchResponseType.RateLimited && this._authService.copilotToken?.isNoAuthUser)) {
+						// @ulugbekna: only show the quota exceeded dialog when the user manually invoked rename suggestions.
+						// For automatic triggers (e.g., when pressing F2), showing a modal dialog steals focus from the
+						// rename widget and cancels the user's rename action - see https://github.com/microsoft/vscode/issues/319414
+						if (triggerKind === NewSymbolNameTriggerKind.Invoke && (fetchResult.type === ChatFetchResponseType.QuotaExceeded || (fetchResult.type === ChatFetchResponseType.RateLimited && this._authService.copilotToken?.isNoAuthUser))) {
 							await this._notificationService.showQuotaExceededDialog({ isNoAuthUser: this._authService.copilotToken?.isNoAuthUser ?? false });
 						}
 

--- a/extensions/copilot/src/extension/renameSuggestions/test/node/renameSuggestionsProvider.spec.tsx
+++ b/extensions/copilot/src/extension/renameSuggestions/test/node/renameSuggestionsProvider.spec.tsx
@@ -5,6 +5,8 @@
 
 import { outdent } from 'outdent';
 import { expect, suite, test } from 'vitest';
+import { ChatFetchResponseType } from '../../../../platform/chat/common/commonTypes';
+import { NewSymbolNameTriggerKind } from '../../../../vscodeTypes';
 import { RenameSuggestionsProvider } from '../../node/renameSuggestionsProvider';
 
 suite('processReply', () => {
@@ -257,5 +259,32 @@ suite('preprocessSymbolNames', () => {
 			languageId: 'javascript',
 		});
 		expect(result).toEqual(['camelCase', 'snake_case', 'PascalCase', 'UPPER_SNAKE_CASE', 'lower-kebab-case']);
+	});
+});
+
+suite('shouldShowQuotaExceededDialog', () => {
+	test('shows for manual invoke + quota exceeded', () => {
+		expect(RenameSuggestionsProvider.shouldShowQuotaExceededDialog(NewSymbolNameTriggerKind.Invoke, ChatFetchResponseType.QuotaExceeded, false)).toBe(true);
+	});
+
+	test('shows for manual invoke + rate limited + no-auth user', () => {
+		expect(RenameSuggestionsProvider.shouldShowQuotaExceededDialog(NewSymbolNameTriggerKind.Invoke, ChatFetchResponseType.RateLimited, true)).toBe(true);
+	});
+
+	test('does not show for manual invoke + rate limited + signed-in user', () => {
+		expect(RenameSuggestionsProvider.shouldShowQuotaExceededDialog(NewSymbolNameTriggerKind.Invoke, ChatFetchResponseType.RateLimited, false)).toBe(false);
+	});
+
+	test('does not show for manual invoke + success', () => {
+		expect(RenameSuggestionsProvider.shouldShowQuotaExceededDialog(NewSymbolNameTriggerKind.Invoke, ChatFetchResponseType.Success, false)).toBe(false);
+	});
+
+	// Regression test for https://github.com/microsoft/vscode/issues/319414
+	test('does not show for automatic trigger + quota exceeded', () => {
+		expect(RenameSuggestionsProvider.shouldShowQuotaExceededDialog(NewSymbolNameTriggerKind.Automatic, ChatFetchResponseType.QuotaExceeded, false)).toBe(false);
+	});
+
+	test('does not show for automatic trigger + rate limited + no-auth user', () => {
+		expect(RenameSuggestionsProvider.shouldShowQuotaExceededDialog(NewSymbolNameTriggerKind.Automatic, ChatFetchResponseType.RateLimited, true)).toBe(false);
 	});
 });


### PR DESCRIPTION
Fixes #319414

## Problem

When the user presses **F2** to rename a symbol, the rename widget automatically requests AI rename suggestions from Copilot in the background (`triggerKind = Automatic`). If the user has hit their Copilot quota, the provider invokes a modal *Quota Exceeded* dialog (`workbench.action.chat.openQuotaExceededDialog`).

That modal steals focus from the rename widget, which then  leaving the user unable to rename a variable at all. Dismissing the dialog and pressing F2 again just reopens the dialog.cancels 

This matches the workaround discovered by users in the issue: disabling `github.copilot.renameSuggestions.triggerAutomatically` skips the AI fetch entirely so the dialog never appears.

## Fix

Gate the quota-exceeded dialog on `triggerKind === NewSymbolNameTriggerKind.Invoke`, so it only shows when the user **explicitly** asked for AI rename suggestions. For automatic background triggers fired by the rename widget, the provider now fails silently (returning `null`) and lets the rename widget proceed normally.

This is consistent with the broader principle that automatic background AI features must not disrupt the user's primary editing flow.