### PR TITLE
Copilot AH: Use workspace customizations as-is, without bundling

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -21,7 +21,7 @@ import { basename as resourceBasename } from '../../../../base/common/resources.
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { localize } from '../../../../nls.js';
-import { IParsedPlugin, parseAgentFile, parseRuleFile, parsePlugin, parseSkillFile } from '../../../agentPlugins/common/pluginParsers.js';
+import { IParsedPlugin, parseAgentFile, parseRuleFile, parsePlugin, parseSkillFile, IParsedAgent, IParsedSkill, IParsedRule } from '../../../agentPlugins/common/pluginParsers.js';
 import { IFileService } from '../../../files/common/files.js';
 import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
 import { ILogService, LogLevel } from '../../../log/common/log.js';
@@ -48,7 +48,6 @@ import { ShellManager } from './copilotShellTools.js';
 import { CopilotSessionLauncher, ThinkingLevelConfigKey, getCopilotReasoningEffort, type CopilotSessionLaunchPlan, type IActiveClientSnapshot } from './copilotSessionLauncher.js';
 import { ActiveClientState } from '../activeClientState.js';
 import { areDiscoveredDirectoriesEqual, DiscoveredType, SessionCustomizationDiscovery, type IDiscoveredDirectory } from './sessionCustomizationDiscovery.js';
-import { SessionPluginBundler } from '../shared/sessionPluginBundler.js';
 import { CopilotSlashCommandCompletionProvider } from './copilotSlashCommandCompletionProvider.js';
 import { getEffectiveAgents } from '../../common/customAgents.js';
 
@@ -1904,8 +1903,8 @@ interface IResolvedCustomization {
  * discovered itself from disk (workspace + user-home conventions).
  *
  * Owns a {@link SessionCustomizationDiscovery} (filesystem scan +
- * watchers) and a {@link SessionPluginBundler} (in-memory synthetic
- * Open Plugin under the `vscode-synced-customization:` scheme).
+ * watchers) and maps discovered files into an in-memory
+ * {@link IParsedPlugin} while preserving original file URIs.
  *
  * Refreshes itself when the discovery fires `onDidChange`. The owning
  * {@link PluginController} is notified via the supplied `onDidRefresh`
@@ -1916,7 +1915,6 @@ interface IResolvedCustomization {
 class SessionDiscoveredEntry extends Disposable {
 
 	private readonly _discovery: SessionCustomizationDiscovery;
-	private readonly _bundler: SessionPluginBundler;
 	private readonly _refreshThrottler = this._register(new Throttler());
 	private _refreshCancellationSource: CancellationTokenSource | undefined;
 
@@ -1929,14 +1927,12 @@ class SessionDiscoveredEntry extends Disposable {
 	constructor(
 		workingDirectory: URI,
 		userHome: URI,
-		private readonly _resolvePlugin: (uri: URI) => Promise<IParsedPlugin | undefined>,
 		private readonly _onDidRefresh: () => void,
 		private readonly _logService: ILogService,
 		instantiationService: IInstantiationService,
 	) {
 		super();
 		this._discovery = this._register(instantiationService.createInstance(SessionCustomizationDiscovery, workingDirectory, userHome));
-		this._bundler = this._register(instantiationService.createInstance(SessionPluginBundler, workingDirectory));
 		this._fileService = instantiationService.invokeFunction(accessor => accessor.get(IFileService));
 		this._settled = this._queueRefresh(false);
 		this._register(this._discovery.onDidChange(() => {
@@ -1997,22 +1993,15 @@ class SessionDiscoveredEntry extends Disposable {
 				return false;
 			}
 
-			const bundleResult = await this._bundler.bundle(directories, token);
+			const plugin = mapToParsedPlugin(customizations);
 			if (token.isCancellationRequested) {
 				return false;
 			}
 
-			// Don't update `_customizations` / `_plugin` when cancelled.
+			// Don't update `_customizations` / `_plugin` / `_directories` when cancelled.
 			// Otherwise a cancelled refresh could temporarily clear them and cause callers to see empty customizations.
-			if (!bundleResult) {
-				this._customizations = customizations;
-				this._plugin = undefined;
-			} else {
-				const pluginDir = URI.parse(bundleResult.ref.uri);
-				const plugin = await this._resolvePlugin(pluginDir);
-				this._customizations = customizations;
-				this._plugin = plugin;
-			}
+			this._customizations = customizations;
+			this._plugin = plugin;
 			this._directories = directories;
 			return true;
 		} catch (err) {
@@ -2031,7 +2020,7 @@ class SessionDiscoveredEntry extends Disposable {
 	}
 }
 
-function toDiscoveredDirectoryCustomizations(directories: readonly IDiscoveredDirectory[], fileService: IFileService): Promise<DirectoryCustomization[]> {
+export function toDiscoveredDirectoryCustomizations(directories: readonly IDiscoveredDirectory[], fileService: IFileService): Promise<DirectoryCustomization[]> {
 	return Promise.all(directories.map(async directory => {
 		const protocolUri = directory.uri.toString();
 		return {
@@ -2108,6 +2097,69 @@ async function toDiscoveredChildCustomization(file: URI, type: DiscoveredType, f
 		id,
 		uri,
 		name: resourceBasename(file),
+	};
+}
+
+
+/**
+ * Projects already-parsed discovered customizations into an in-memory
+ * {@link IParsedPlugin} while preserving original source URIs.
+ */
+export function mapToParsedPlugin(customizations: readonly DirectoryCustomization[]): IParsedPlugin | undefined {
+	if (customizations.length === 0) {
+		return undefined;
+	}
+
+	const agents: IParsedAgent[] = [];
+	const skills: IParsedSkill[] = [];
+	const instructions: IParsedRule[] = [];
+
+	for (const directory of customizations) {
+		for (const child of directory.children ?? []) {
+			if (child.type === CustomizationType.Agent) {
+				agents.push({
+					uri: URI.parse(child.uri),
+					name: child.name,
+					description: child.description,
+					customization: child,
+				});
+				continue;
+			}
+
+			if (child.type === CustomizationType.Skill) {
+				skills.push({
+					uri: URI.parse(child.uri),
+					name: child.name,
+					description: child.description,
+					customization: child,
+				});
+				continue;
+			}
+
+			if (child.type === CustomizationType.Rule) {
+				if (child.alwaysApply && child.name.match(/\.md$/i)) {
+					continue; // agent instruction
+				}
+				instructions.push({
+					uri: URI.parse(child.uri),
+					name: child.name,
+					description: child.description,
+					customization: child,
+				});
+			}
+		}
+	}
+
+	if (agents.length === 0 && skills.length === 0 && instructions.length === 0) {
+		return undefined;
+	}
+
+	return {
+		hooks: [],
+		mcpServers: [],
+		skills: skills,
+		agents: agents,
+		instructions: instructions,
 	};
 }
 
@@ -2513,7 +2565,6 @@ class SessionPluginController extends Disposable {
 			this._sessionDiscovered.value = new SessionDiscoveredEntry(
 				this._directory,
 				URI.file(this._parent.getUserHome()),
-				uri => this._parent.tryParsePlugin(uri),
 				() => this._onDidPublish.fire({
 					type: ActionType.SessionCustomizationsChanged,
 					customizations: [...this.getCustomizations()],

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -243,6 +243,8 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 		// Else we could end up with duplicates or the like.
 		const pluginsWithoutDirs = plugins.filter(p => !p.pluginDir || p.pluginDir.scheme !== Schemas.file);
 		const customAgents = await toSdkCustomAgents(pluginsWithoutDirs.flatMap(p => p.agents), this._fileService);
+		const skillDirectories = toSdkSkillDirectories(pluginsWithoutDirs.flatMap(p => p.skills));
+		const instructionDirectories = toSdkInstructionDirectories(plugins.flatMap(p => p.instructions));
 		return {
 			clientName: 'vscode',
 			onPermissionRequest: request => runtime.handlePermissionRequest(request),
@@ -256,8 +258,8 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			onExitPlanModeRequest: (request, invocation) => runtime.handleExitPlanModeRequest(request, invocation),
 			workingDirectory: plan.workingDirectory?.fsPath,
 			customAgents,
-			skillDirectories: toSdkSkillDirectories(pluginsWithoutDirs.flatMap(p => p.skills)),
-			instructionDirectories: toSdkInstructionDirectories(plugins.flatMap(p => p.instructions)),
+			skillDirectories,
+			instructionDirectories,
 			systemMessage: COPILOT_AGENT_HOST_SYSTEM_MESSAGE,
 			pluginDirectories: coalesce(plugins.map(p => p.pluginDir))
 				.filter(d => d.scheme === Schemas.file).map(d => d.fsPath),

--- a/src/vs/platform/agentHost/test/node/sessionCustomizationDiscovery.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionCustomizationDiscovery.test.ts
@@ -18,8 +18,9 @@ import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { IAgentPluginManager } from '../../common/agentPluginManager.js';
 import { DiscoveredType, SessionCustomizationDiscovery } from '../../node/copilot/sessionCustomizationDiscovery.js';
 import { SessionPluginBundler } from '../../node/shared/sessionPluginBundler.js';
+import { mapToParsedPlugin, toDiscoveredDirectoryCustomizations } from '../../node/copilot/copilotAgent.js';
 
-suite('SessionCustomizationDiscovery + SessionPluginBundler', () => {
+suite('SessionCustomizationDiscovery', () => {
 
 	const disposables = new DisposableStore();
 	let fileService: FileService;
@@ -232,6 +233,112 @@ suite('SessionCustomizationDiscovery + SessionPluginBundler', () => {
 		].sort((a, b) => a.uri.toString().localeCompare(b.uri.toString())));
 	});
 
+
+
+	test('bundles nested .instructions.md files into rules', async () => {
+		await seed('/workspace/.github/instructions/team/security/policy.instructions.md', 'workspace nested instruction');
+		await seed('/home/.copilot/instructions/domain/tools/deep.instructions.md', 'user nested instruction');
+
+		const discovery = disposables.add(instantiationService.createInstance(SessionCustomizationDiscovery, workspace, userHome));
+		const bundler = disposables.add(instantiationService.createInstance(SessionPluginBundler, workspace));
+		const result = await bundler.bundle(await discovery.directories());
+
+		assert.ok(result);
+
+		const root = bundler.rootUri;
+		const workspaceInstr = await fileService.readFile(URI.joinPath(root, 'rules', 'policy.instructions.md'));
+		assert.strictEqual(workspaceInstr.value.toString(), 'workspace nested instruction');
+
+		const userInstr = await fileService.readFile(URI.joinPath(root, 'rules', 'deep.instructions.md'));
+		assert.strictEqual(userInstr.value.toString(), 'user nested instruction');
+	});
+
+	test('returns undefined when no files were discovered', async () => {
+		const discovery = disposables.add(instantiationService.createInstance(SessionCustomizationDiscovery, workspace, userHome));
+		const bundler = disposables.add(instantiationService.createInstance(SessionPluginBundler, workspace));
+		const directories = await discovery.directories();
+		const result = await bundler.bundle(directories);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('maps discovered files to parsed plugin preserving source URIs', async () => {
+		const agent = await seed('/workspace/.github/agents/foo.agent.md', '---\nname: Workspace Agent\ndescription: Agent description\n---\nbody');
+		const skill = await seed('/workspace/.github/skills/bar/SKILL.md', '---\nname: Workspace Skill\ndescription: Skill description\n---\nbody');
+		const instruction = await seed('/workspace/.github/instructions/baz.instructions.md', '---\nname: Workspace Rule\ndescription: Rule description\nglobs:\n  - src/**\n---\nbody');
+
+		const discovery = disposables.add(instantiationService.createInstance(SessionCustomizationDiscovery, workspace, userHome));
+		const customizations = await toDiscoveredDirectoryCustomizations(await discovery.directories(), fileService);
+
+		const plugin = mapToParsedPlugin(customizations);
+
+		assert.ok(plugin);
+		assert.strictEqual(plugin.agents.length, 1);
+		assert.strictEqual(plugin.skills.length, 1);
+		assert.strictEqual(plugin.instructions.length, 1);
+		assert.deepStrictEqual(
+			{
+				agentUri: plugin.agents[0].uri.toString(),
+				skillUri: plugin.skills[0].uri.toString(),
+				ruleUri: plugin.instructions[0].uri.toString(),
+			},
+			{
+				agentUri: agent.toString(),
+				skillUri: skill.toString(),
+				ruleUri: instruction.toString(),
+			}
+		);
+	});
+
+	test('does not include parsed agent-instruction rules in mapToParsedPlugin output', async () => {
+		await seed('/workspace/.github/copilot-instructions.md', 'workspace instructions');
+		await seed('/workspace/.agents/skills/bar/SKILL.md', '---\nname: bar\ndescription: Skill description\n---\nbody');
+
+		const discovery = disposables.add(instantiationService.createInstance(SessionCustomizationDiscovery, workspace, userHome));
+		const customizations = await toDiscoveredDirectoryCustomizations(await discovery.directories(), fileService);
+
+		const plugin = mapToParsedPlugin(customizations);
+
+		assert.ok(plugin);
+		assert.strictEqual(plugin.skills.length, 1);
+		assert.strictEqual(plugin.instructions.length, 0);
+	});
+});
+
+
+suite('SessionPluginBundler', () => {
+	const disposables = new DisposableStore();
+	let fileService: FileService;
+	let instantiationService: TestInstantiationService;
+	let workspace: URI;
+	let userHome: URI;
+	let pluginBasePath: URI;
+
+	setup(() => {
+		fileService = disposables.add(new FileService(new NullLogService()));
+		const memFs = disposables.add(new InMemoryFileSystemProvider());
+		disposables.add(fileService.registerProvider(Schemas.inMemory, memFs));
+
+		instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(ILogService, new NullLogService());
+
+		workspace = URI.from({ scheme: Schemas.inMemory, path: '/workspace' });
+		userHome = URI.from({ scheme: Schemas.inMemory, path: '/home' });
+		pluginBasePath = URI.from({ scheme: Schemas.inMemory, path: '/agentPlugins' });
+		instantiationService.stub(IAgentPluginManager, { basePath: pluginBasePath } as Partial<IAgentPluginManager>);
+	});
+
+	teardown(() => {
+		disposables.clear();
+	});
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	async function seed(path: string, content = ''): Promise<URI> {
+		const uri = URI.from({ scheme: Schemas.inMemory, path });
+		await fileService.writeFile(uri, VSBuffer.fromString(content));
+		return uri;
+	}
+
 	test('bundles discovered files into the synthetic plugin tree', async () => {
 		await seed('/workspace/.github/agents/foo.agent.md', 'agent body');
 		await seed('/workspace/.github/skills/bar/SKILL.md', 'skill body');
@@ -260,31 +367,6 @@ suite('SessionCustomizationDiscovery + SessionPluginBundler', () => {
 		assert.strictEqual(instr.value.toString(), 'instr body');
 	});
 
-	test('bundles nested .instructions.md files into rules', async () => {
-		await seed('/workspace/.github/instructions/team/security/policy.instructions.md', 'workspace nested instruction');
-		await seed('/home/.copilot/instructions/domain/tools/deep.instructions.md', 'user nested instruction');
-
-		const discovery = disposables.add(instantiationService.createInstance(SessionCustomizationDiscovery, workspace, userHome));
-		const bundler = disposables.add(instantiationService.createInstance(SessionPluginBundler, workspace));
-		const result = await bundler.bundle(await discovery.directories());
-
-		assert.ok(result);
-
-		const root = bundler.rootUri;
-		const workspaceInstr = await fileService.readFile(URI.joinPath(root, 'rules', 'policy.instructions.md'));
-		assert.strictEqual(workspaceInstr.value.toString(), 'workspace nested instruction');
-
-		const userInstr = await fileService.readFile(URI.joinPath(root, 'rules', 'deep.instructions.md'));
-		assert.strictEqual(userInstr.value.toString(), 'user nested instruction');
-	});
-
-	test('returns undefined when no files were discovered', async () => {
-		const discovery = disposables.add(instantiationService.createInstance(SessionCustomizationDiscovery, workspace, userHome));
-		const bundler = disposables.add(instantiationService.createInstance(SessionPluginBundler, workspace));
-		const directories = await discovery.directories();
-		const result = await bundler.bundle(directories);
-		assert.strictEqual(result, undefined);
-	});
 
 	test('produces a stable nonce for identical content', async () => {
 		await seed('/workspace/.github/agents/foo.agent.md', 'agent body');


### PR DESCRIPTION
The Copilot AH currently bundles all discovered customization files (agents/skills/rules/agent instructions) into a bundle at a temp location.
The SDK then gets these temp locations.
This has some drawbacks:
- bundling is done after every change to customization files: needs to be awaited, needs management of the temp folders potentially while they are in use.
- Copilot will see these temp folders and use them from loading, e.g. for skills or on-demand instructions. These instructions might use relative references that are not present, Copilot might mention these folders in its reply.

The change removes the bundling and passes the actual folders/files to the Copilot CLI