### PR TITLE
Fix empty terminal command for terminal tools without input

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -426,21 +426,26 @@ function getTerminalLanguage(tc: ToolCallState) {
  *
  * 1. `existingKind === 'terminal'` — preserve the prior render decision so a
  *    tool already set up as terminal stays terminal across snapshots.
- * 2. `getToolKind(tc) === 'terminal'` — the always-available `_meta.toolKind`
- *    flag set by the event mapper for built-in `bash`/`powershell` SDK tools
- *    that never emit a {@link ToolResultContentType.Terminal} content block.
+ * 2. `getToolKind(tc) === 'terminal'` with a command available — the
+ *    always-available `_meta.toolKind` flag set by the event mapper for
+ *    built-in `bash`/`powershell` SDK tools that never emit a
+ *    {@link ToolResultContentType.Terminal} content block. We only render the
+ *    terminal pill once we actually have the command (`getTerminalInput`):
+ *    rendering a terminal pill with an empty command line looks broken, so
+ *    until the command arrives we fall back to the generic tool widget
+ *    (the `invocationMessage`).
  * 3. A `Terminal` content block in `tc.content` (Running/Completed only) —
  *    the AHP-side signal for the custom terminal tool (`agenthost-terminal:`
  *    URIs).
  *
- * Without (1) and (2) the live invocation would race against the async
- * arrival of the Terminal block via `onDidAssociateTerminal`.
+ * Without (1) the live invocation would race against the async arrival of the
+ * Terminal block via `onDidAssociateTerminal`.
  */
 function isTerminalToolCall(tc: ToolCallState, existingKind?: string): boolean {
 	if (existingKind === 'terminal') {
 		return true;
 	}
-	if (getToolKind(tc) === 'terminal') {
+	if (getToolKind(tc) === 'terminal' && getTerminalInput(tc) !== undefined) {
 		return true;
 	}
 	if (tc.status === ToolCallStatus.Running || tc.status === ToolCallStatus.Completed) {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -713,6 +713,24 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(termData.terminalCommandOutput?.text, 'hi\r\n', 'normalizes \\n to \\r\\n for xterm');
 		});
 
+		test('does not render terminal pill for terminal toolKind without a command (falls back to invocationMessage)', () => {
+			// The built-in bash tool advertises `_meta.toolKind === 'terminal'`
+			// from the tool-open seam, but the command only arrives once the
+			// tool input has streamed in. Until then there is nothing to show in
+			// the terminal pill, so we must fall back to the generic tool widget
+			// (the `invocationMessage`) rather than rendering an empty command.
+			const tc = createToolCallState({
+				toolName: 'bash',
+				invocationMessage: 'Running shell command',
+				_meta: { toolKind: 'terminal' },
+				status: ToolCallStatus.Running,
+			});
+
+			const invocation = toolCallStateToInvocation(tc);
+			assert.strictEqual(invocation.toolSpecificData, undefined, 'no terminal pill without a command');
+			assert.strictEqual(invocation.invocationMessage, 'Running shell command');
+		});
+
 		test('creates invocation without toolArguments', () => {
 			const tc = createToolCallState({});
 


### PR DESCRIPTION
Fix #320784

Fixes a regression from [#320251](https://github.com/microsoft/vscode/pull/320251).

When the SDK's built-in `bash` tool runs (no AHP `Terminal` content block), [#320251](https://github.com/microsoft/vscode/pull/320251) added a `getToolKind(tc) === 'terminal'` branch to `isTerminalToolCall` so the terminal pill still renders. But that branch fired **unconditionally**, so while the command (`toolInput`) was still streaming in, `buildTerminalToolSpecificData` produced `commandLine: {  an **empty terminal command** in the UI.original: '' }` 

### Fix

Gate the terminal-kind branch on `getTerminalInput(tc) !== undefined`. Until the command is available, the tool falls back to rendering the generic `invocationMessage` (the pre-#320251 behavior) instead of an empty terminal pill. Once the command arrives, the terminal pill renders as before.

### Tests

Adds a `stateToProgressAdapter.test.ts` case asserting that a tool with `_meta.toolKind: 'terminal'` but no command does not render a terminal pill and falls back to `invocationMessage`.

(Written by Copilot)
