### PR TITLE
Remove chat.advanced.inlineEdits.eagerBackupRequest setting

### DIFF
--- a/extensions/copilot/src/extension/inlineEdits/node/nesConfigs.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nesConfigs.ts
@@ -5,5 +5,4 @@
 
 export interface INesConfigs {
 	isAsyncCompletions: boolean;
-	isEagerBackupRequest: boolean;
 }

--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
@@ -474,7 +474,6 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 	private determineNesConfigs(telemetryBuilder: LlmNESTelemetryBuilder, logContext: InlineEditRequestLogContext): INesConfigs {
 		const nesConfigs: INesConfigs = {
 			isAsyncCompletions: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsAsyncCompletions, this._expService),
-			isEagerBackupRequest: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsEagerBackupRequest, this._expService),
 		};
 
 		telemetryBuilder.setNESConfigs({ ...nesConfigs });
@@ -576,48 +575,6 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 					return firstEdit.map(val => ({ ...val, isFromSpeculativeRequest: true }));
 				}
 				return nextEditResult.nextEdit.isError() ? nextEditResult.nextEdit : requestToReuse.firstEdit.p;
-			} else if (nesConfigs.isEagerBackupRequest) {
-				// The pending request is stale (document diverged). Start a backup request
-				// in parallel so that if rebase fails, we already have a head start.
-				logger.trace('starting eager backup request in parallel with rebase attempt');
-
-				// _executeNewNextEditRequest cancels the current _pendingStatelessNextEditRequest,
-				// but we're still trying to join+rebase requestToReuse. Temporarily clear the
-				// pending field so the stale request isn't cancelled prematurely.
-				this._pendingStatelessNextEditRequest = null;
-				const backupPromise = this._executeNewNextEditRequest(req, doc, historyContext, nesConfigs, shouldExpandEditWindow, logger, telemetryBuilder, cancellationToken);
-				const cancelBackupRequest = () => {
-					void backupPromise
-						.then(r => r.nextEditRequest.cancellationTokenSource.cancel())
-						.catch(() => undefined);
-				};
-
-				// Simultaneously attempt to join + rebase the stale request
-				const nextEditResult = await this._joinNextEditRequest(requestToReuse, reusedRequestKind, telemetryBuilder, logContext, cancellationToken);
-				const cacheResult = await requestToReuse.firstEdit.p;
-				if (cacheResult.isOk() && cacheResult.val.edit) {
-					const rebaseResult = this._nextEditCache.tryRebaseCacheEntry(cacheResult.val, documentAtInvocationTime, selectionAtInvocationTime);
-					if (rebaseResult.edit) {
-						logger.trace('rebase succeeded, cancelling eager backup request');
-						cancelBackupRequest();
-						telemetryBuilder.setStatelessNextEditTelemetry(nextEditResult.telemetry);
-						return Result.ok(rebaseResult.edit);
-					}
-					this._logRebaseFailure(rebaseResult.failureInfo, logContext);
-				}
-
-				if (cancellationToken.isCancellationRequested) {
-					logger.trace('cancelled after rebase failed (eager backup path)');
-					cancelBackupRequest();
-					telemetryBuilder.setStatelessNextEditTelemetry(nextEditResult.telemetry);
-					return Result.error(new NoNextEditReason.GotCancelled('afterFailedRebase'));
-				}
-
-				// Rebase failed — use the backup request that's already been running in parallel
-				logger.trace('rebase failed, using eager backup request');
-				const backupRes = await backupPromise;
-				telemetryBuilder.setStatelessNextEditTelemetry(backupRes.nextEditResult.telemetry);
-				return backupRes.nextEditResult.nextEdit.isError() ? backupRes.nextEditResult.nextEdit : backupRes.nextEditRequest.firstEdit.p;
 			} else {
 				const nextEditResult = await this._joinNextEditRequest(requestToReuse, reusedRequestKind, telemetryBuilder, logContext, cancellationToken);
 

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -817,7 +817,6 @@ export namespace ConfigKey {
 		export const DebugExpUseNodeFetcher = defineTeamInternalSetting<boolean | undefined>('chat.advanced.debug.useNodeFetcher', ConfigType.ExperimentBased, undefined);
 		export const DebugExpUseElectronFetcher = defineTeamInternalSetting<boolean | undefined>('chat.advanced.debug.useElectronFetcher', ConfigType.ExperimentBased, undefined);
 		export const InlineEditsAsyncCompletions = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.asyncCompletions', ConfigType.ExperimentBased, true);
-		export const InlineEditsEagerBackupRequest = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.eagerBackupRequest', ConfigType.ExperimentBased, false);
 		export const InlineEditsDebounceUseCoreRequestTime = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.debounceUseCoreRequestTime', ConfigType.ExperimentBased, false);
 		export const InlineEditsYieldToCopilot = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.yieldToCopilot', ConfigType.ExperimentBased, false);
 		export const InlineEditsExcludedProviders = defineTeamInternalSetting<string | undefined>('chat.advanced.inlineEdits.excludedProviders', ConfigType.ExperimentBased, undefined);


### PR DESCRIPTION
Removes the team-internal experimental setting `chat.advanced.inlineEdits.eagerBackupRequest` and all code that used it.

The setting defaulted to `false`, so removal preserves the default behavior. It gated an "eager backup request" branch in `NextEditProvider.fetchNextEdit` that started a backup request in parallel with a rebase attempt when the pending request was stale.

### Changes (3 files, 45 deletions)
- `extensions/copilot/src/platform/configuration/common/configurationService. removed the `InlineEditsEagerBackupRequest` config definition.ts` 
- `extensions/copilot/src/extension/inlineEdits/node/nesConfigs. removed the `isEagerBackupRequest` field from `INesConfigs`.ts` 
- `extensions/copilot/src/extension/inlineEdits/node/nextEditProvider. removed the field initialization in `determineNesConfigs` and the entire `else if (nesConfigs.isEagerBackupRequest) { ... }` branch in `fetchNextEdit`. The remaining `if (requestStillCurrent) { ... } else { ... }` preserves the original non-eager rebase-and-fallback behavior.ts` 

### Validation
- `npx tsgo --noEmit --project tsconfig.json` for the `copilot` extension passes clean.

### Note
Any active ExP assignment for the key should be cleaned up separately.