### PR TITLE
extensions: show info notification when a private marketplace is configured by policy

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
@@ -13,6 +13,9 @@ import { Disposable, DisposableStore, MutableDisposable } from '../../../../base
 import { Event } from '../../../../base/common/event.js';
 import { Action } from '../../../../base/common/actions.js';
 import { append, $, Dimension, hide, show, DragAndDropObserver, trackFocus, addDisposableListener, EventType, clearNode } from '../../../../base/browser/dom.js';
+import { renderMarkdown, renderAsPlaintext } from '../../../../base/browser/markdownRenderer.js';
+import { isMarkdownString } from '../../../../base/common/htmlContent.js';
+import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
@@ -569,6 +572,7 @@ export class ExtensionsViewPaneContainer extends ViewPaneContainer<IExtensionsVi
 		@IPreferencesService private readonly preferencesService: IPreferencesService,
 		@ICommandService private readonly commandService: ICommandService,
 		@ILogService logService: ILogService,
+		@IOpenerService private readonly openerService: IOpenerService,
 	) {
 		super(VIEWLET_ID, { mergeViewWithContainerWhenSingleView: true }, instantiationService, configurationService, layoutService, contextMenuService, telemetryService, extensionService, themeService, storageService, contextService, viewDescriptorService, logService);
 
@@ -769,26 +773,37 @@ export class ExtensionsViewPaneContainer extends ViewPaneContainer<IExtensionsVi
 		const status = this.extensionsWorkbenchService.getExtensionsNotification();
 		const query = status?.query ?? status?.extensions.map(extension => `@id:${extension.identifier.id}`).join(' ');
 		if (status && (query === this.searchBox?.getValue() || !this.searchMarketplaceExtensionsContextKey.get())) {
-			this.notificationContainer.setAttribute('aria-label', status.message);
+			const messagePlainText = isMarkdownString(status.message) ? renderAsPlaintext(status.message) : status.message;
+			this.notificationContainer.setAttribute('aria-label', messagePlainText);
 			this.notificationContainer.classList.remove('hidden');
 			const messageContainer = append(this.notificationContainer, $('.message-container'));
 			append(messageContainer, $('span')).className = SeverityIcon.className(status.severity);
 			const messageText = append(messageContainer, $('span.message-text'));
-			append(messageText, $('span.message', undefined, status.message));
-			const showAction = append(messageText,
-				$('span.message-text-action', {
-					'tabindex': '0',
-					'role': 'button',
-					'aria-label': `${status.message}. ${localize('click show', "Click to Show")}`
-				}, localize('show', "Show")));
-			this.notificationDisposables.value.add(addDisposableListener(showAction, EventType.CLICK, () => this.search(query ?? '')));
-			this.notificationDisposables.value.add(addDisposableListener(showAction, EventType.KEY_DOWN, (e: KeyboardEvent) => {
-				const standardKeyboardEvent = new StandardKeyboardEvent(e);
-				if (standardKeyboardEvent.keyCode === KeyCode.Enter || standardKeyboardEvent.keyCode === KeyCode.Space) {
-					this.search(query ?? '');
-				}
-				standardKeyboardEvent.stopPropagation();
-			}));
+			const messageElement = append(messageText, $('span.message'));
+			if (isMarkdownString(status.message)) {
+				const rendered = this.notificationDisposables.value.add(renderMarkdown(status.message, {
+					actionHandler: link => { this.openerService.open(link, { allowCommands: true }); },
+				}));
+				messageElement.appendChild(rendered.element);
+			} else {
+				messageElement.textContent = status.message;
+			}
+			if (status.extensions.length) {
+				const showAction = append(messageText,
+					$('span.message-text-action', {
+						'tabindex': '0',
+						'role': 'button',
+						'aria-label': `${messagePlainText}. ${localize('click show', "Click to Show")}`
+					}, localize('show', "Show")));
+				this.notificationDisposables.value.add(addDisposableListener(showAction, EventType.CLICK, () => this.search(query ?? '')));
+				this.notificationDisposables.value.add(addDisposableListener(showAction, EventType.KEY_DOWN, (e: KeyboardEvent) => {
+					const standardKeyboardEvent = new StandardKeyboardEvent(e);
+					if (standardKeyboardEvent.keyCode === KeyCode.Enter || standardKeyboardEvent.keyCode === KeyCode.Space) {
+						this.search(query ?? '');
+					}
+					standardKeyboardEvent.stopPropagation();
+				}));
+			}
 			const actionsContainer = append(this.notificationContainer, $('.notification-actions'));
 			if (status.action) {
 				const actionButton = append(actionsContainer,
@@ -804,6 +819,25 @@ export class ExtensionsViewPaneContainer extends ViewPaneContainer<IExtensionsVi
 					const standardKeyboardEvent = new StandardKeyboardEvent(e);
 					if (standardKeyboardEvent.keyCode === KeyCode.Enter || standardKeyboardEvent.keyCode === KeyCode.Space) {
 						Promise.resolve(status.action!.run()).catch(error => this.notificationService.error(error));
+					}
+					standardKeyboardEvent.stopPropagation();
+				}));
+			}
+			const dismiss = status.dismiss;
+			if (dismiss) {
+				const dismissLabel = localize('dismiss notification', "Dismiss");
+				const dismissButton = append(actionsContainer,
+					$('span.dismiss-action.codicon.codicon-close', {
+						'tabindex': '0',
+						'role': 'button',
+						'aria-label': dismissLabel,
+						'title': dismissLabel,
+					}));
+				this.notificationDisposables.value.add(addDisposableListener(dismissButton, EventType.CLICK, () => dismiss()));
+				this.notificationDisposables.value.add(addDisposableListener(dismissButton, EventType.KEY_DOWN, (e: KeyboardEvent) => {
+					const standardKeyboardEvent = new StandardKeyboardEvent(e);
+					if (standardKeyboardEvent.keyCode === KeyCode.Enter || standardKeyboardEvent.keyCode === KeyCode.Space) {
+						dismiss();
 					}
 					standardKeyboardEvent.stopPropagation();
 				}));
@@ -1006,7 +1040,7 @@ export class StatusUpdater extends Disposable implements IWorkbenchContribution 
 
 		const extensionsNotification = this.extensionsWorkbenchService.getExtensionsNotification();
 		if (extensionsNotification && extensionsNotification.severity === Severity.Warning) {
-			badge = new WarningBadge(() => extensionsNotification.message);
+			badge = new WarningBadge(() => isMarkdownString(extensionsNotification.message) ? renderAsPlaintext(extensionsNotification.message) : extensionsNotification.message);
 		}
 
 		if (!badge) {

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
@@ -781,10 +781,11 @@ export class ExtensionsViewPaneContainer extends ViewPaneContainer<IExtensionsVi
 			const messageText = append(messageContainer, $('span.message-text'));
 			const messageElement = append(messageText, $('span.message'));
 			if (isMarkdownString(status.message)) {
-				const rendered = this.notificationDisposables.value.add(renderMarkdown(status.message, {
-					actionHandler: link => { this.openerService.open(link, { allowCommands: true }); },
-				}));
-				messageElement.appendChild(rendered.element);
+				const isTrusted = status.message.isTrusted;
+				const allowCommands = typeof isTrusted === 'object' ? isTrusted.enabledCommands : !!isTrusted;
+				this.notificationDisposables.value.add(renderMarkdown(status.message, {
+					actionHandler: link => { this.openerService.open(link, { allowCommands }); },
+				}, messageElement));
 			} else {
 				messageElement.textContent = status.message;
 			}

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -71,7 +71,7 @@ import { ShowCurrentReleaseNotesActionId } from '../../update/common/update.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
-import { ExtensionGalleryResourceType, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { ExtensionGalleryResourceType, ExtensionGalleryServiceUrlConfigKey, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 import { fromNow } from '../../../../base/common/date.js';
 import { IUserDataProfilesService } from '../../../../platform/userDataProfile/common/userDataProfile.js';
 import { IMeteredConnectionService } from '../../../../platform/meteredConnection/common/meteredConnection.js';
@@ -1116,6 +1116,11 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 			this.updateExtensionsNotificaiton();
 			this.reportProgressFromOtherSources();
 		}));
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(ExtensionGalleryServiceUrlConfigKey)) {
+				this.updateExtensionsNotificaiton();
+			}
+		}));
 	}
 
 	private initializeAutoUpdate(): void {
@@ -1585,6 +1590,20 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 				severity: Severity.Warning,
 				extensions: deprecatedExtensions,
 				key: 'deprecatedExtensions:' + deprecatedExtensions.sort((a, b) => a.identifier.id.localeCompare(b.identifier.id)).map(e => e.identifier.id.toLowerCase()).join('-'),
+			});
+		}
+
+		const privateMarketplaceUrl = this.configurationService.inspect<string>(ExtensionGalleryServiceUrlConfigKey).policyValue;
+		if (privateMarketplaceUrl) {
+			const settingsQuery = `@hasPolicy ${ExtensionGalleryServiceUrlConfigKey}`;
+			const settingsCommandUri = `command:workbench.action.openSettings?${encodeURIComponent(JSON.stringify(settingsQuery))}`;
+			const message = new MarkdownString(nls.localize('privateMarketplace', "This window is connected to a [private extension marketplace]({0}) managed by your organization.", settingsCommandUri));
+			message.isTrusted = { enabledCommands: ['workbench.action.openSettings'] };
+			computedNotificiations.push({
+				message,
+				severity: Severity.Info,
+				extensions: [],
+				key: `privateMarketplace:${privateMarketplaceUrl}`,
 			});
 		}
 

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -73,6 +73,7 @@ import { IQuickInputService } from '../../../../platform/quickinput/common/quick
 import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
 import { ExtensionGalleryResourceType, ExtensionGalleryServiceUrlConfigKey, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 import { fromNow } from '../../../../base/common/date.js';
+import { hash } from '../../../../base/common/hash.js';
 import { IUserDataProfilesService } from '../../../../platform/userDataProfile/common/userDataProfile.js';
 import { IMeteredConnectionService } from '../../../../platform/meteredConnection/common/meteredConnection.js';
 
@@ -1603,7 +1604,7 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 				message,
 				severity: Severity.Info,
 				extensions: [],
-				key: `privateMarketplace:${privateMarketplaceUrl}`,
+				key: `privateMarketplace:${hash(privateMarketplaceUrl)}`,
 			});
 		}
 

--- a/src/vs/workbench/contrib/extensions/browser/media/extensionsViewlet.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionsViewlet.css
@@ -78,6 +78,21 @@
 	min-width: 0;
 }
 
+.extensions-viewlet .notification-container .message-container .message-text .message p {
+	margin: 0;
+	display: inline;
+}
+
+.extensions-viewlet .notification-container .message-container .message-text .message a {
+	color: var(--vscode-textLink-foreground);
+	cursor: pointer;
+}
+
+.extensions-viewlet .notification-container .message-container .message-text .message a:hover,
+.extensions-viewlet .notification-container .message-container .message-text .message a:active {
+	color: var(--vscode-textLink-activeForeground);
+}
+
 .extensions-viewlet .notification-container .message-text-action {
 	cursor: pointer;
 	margin-left: 5px;
@@ -109,6 +124,17 @@
 	align-items: center;
 	gap: 4px;
 	margin-left: 24px;
+}
+
+.extensions-viewlet .notification-container .notification-actions .dismiss-action {
+	cursor: pointer;
+	color: var(--vscode-icon-foreground);
+	padding: 2px;
+	border-radius: var(--vscode-cornerRadius-small);
+}
+
+.extensions-viewlet .notification-container .notification-actions .dismiss-action:hover {
+	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
 .extensions-viewlet > .extensions {

--- a/src/vs/workbench/contrib/extensions/common/extensions.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensions.ts
@@ -121,12 +121,12 @@ export interface InstallExtensionOptions extends InstallOptions {
 }
 
 export interface IExtensionsNotification {
-	readonly message: string;
+	readonly message: string | IMarkdownString;
 	readonly severity: Severity;
 	readonly extensions: IExtension[];
 	readonly query?: string;
 	readonly action?: { readonly label: string; run(): void };
-	dismiss(): void;
+	dismiss?(): void;
 }
 
 export interface IExtensionsWorkbenchService {


### PR DESCRIPTION
When a private extension marketplace is configured through org policy (`extensions.gallery.serviceUrl`), the Extensions viewlet now shows an informational, dismissable notification so users are aware their window is connected to an organization-managed marketplace. The message includes a command link that opens the Settings editor filtered to policy settings (`@hasPolicy extensions.gallery.serviceUrl`).

## Why

Users have no clear indication when their extension marketplace has been overridden by an organization policy. This surfaces that state non-intrusively and points them to the relevant policy setting.

## How

- Reuses the existing `getExtensionsNotification` mechanism (`computeExtensionsNotifications()` in `ExtensionsWorkbenchService`) rather than a bespoke UI banner.
- Adds a computed `Info` notification when `extensions.gallery.serviceUrl` has a `policyValue`, and recomputes it on configuration change.
- Extends `IExtensionsNotification`: `message` widened to `string | IMarkdownString` for command links; `dismiss?()` made optional.
- Viewlet `renderNotificaiton()` renders markdown messages (command links via `IOpenerService` `allowCommands`), gates the "Show" link on `extensions.length`, and renders a dismiss button when `dismiss` is provided.
- CSS for inline markdown rendering and the dismiss action.

## Notes for reviewers

`extensions.gallery.serviceUrl` is registered with `included: false` so it won't appear as a row in the Settings editor even via `@hasPolicy`; the command link still opens Settings filtered to policy settings.