### PR TITLE
Filter subagent sessions out of listSessions

### DIFF
--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -29,7 +29,7 @@ import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } f
 import { AhpErrorCodes, AHP_SESSION_NOT_FOUND, ContentEncoding, JSON_RPC_INTERNAL_ERROR, ProtocolError, ResourceChangeType, ResourceType, ResourceWriteMode, type CreateResourceWatchParams, type CreateResourceWatchResult, type DirectoryEntry, type ResourceCopyParams, type ResourceCopyResult, type ResourceDeleteParams, type ResourceDeleteResult, type ResourceListResult, type ResourceMkdirParams, type ResourceMkdirResult, type ResourceMoveParams, type ResourceMoveResult, type ResourceReadResult, type ResourceResolveParams, type ResourceResolveResult, type ResourceWatchState, type ResourceWriteParams, type ResourceWriteResult, type IStateSnapshot } from '../common/state/sessionProtocol.js';
 import { ChangesSummary, MessageAttachmentKind, type MessageAttachment, type MessageResourceAttachment } from '../common/state/protocol/state.js';
 import type { SessionPendingMessageSetAction, SessionTurnStartedAction } from '../common/state/protocol/actions.js';
-import { ResponsePartKind, SessionStatus, ToolCallStatus, ToolResultContentType, buildResourceWatchChannelUri, buildSubagentSessionUriPrefix, hostBuildInfoFromProduct, parseResourceWatchChannelUri, parseSubagentSessionUri, readSessionGitState, type SessionConfigState, type SessionSummary, type ToolResultSubagentContent, type Turn } from '../common/state/sessionState.js';
+import { ResponsePartKind, SessionStatus, ToolCallStatus, ToolResultContentType, buildResourceWatchChannelUri, buildSubagentSessionUriPrefix, hostBuildInfoFromProduct, isSubagentSession, parseResourceWatchChannelUri, parseSubagentSessionUri, readSessionGitState, type SessionConfigState, type SessionSummary, type ToolResultSubagentContent, type Turn } from '../common/state/sessionState.js';
 import { IProductService } from '../../product/common/productService.js';
 import { AgentConfigurationService, IAgentConfigurationService } from './agentConfigurationService.js';
 import { AgentHostTerminalManager, type IAgentHostTerminalManager } from './agentHostTerminalManager.js';
@@ -433,6 +433,11 @@ export class AgentService extends Disposable implements IAgentService {
 		const additions: IAgentSessionMetadata[] = [];
 		for (const summary of this._stateManager.getAnnouncedSessionSummaries()) {
 			if (known.has(summary.resource)) {
+				continue;
+			}
+			// Subagent sessions are nested under their parent and must never
+			// surface as top-level entries in the session list.
+			if (isSubagentSession(summary.resource)) {
 				continue;
 			}
 			additions.push({

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -23,7 +23,7 @@ import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE } from '../../common/ag
 import { ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { ActionType, ActionEnvelope } from '../../common/state/sessionActions.js';
-import { ChangesetStatus, CustomizationType, MessageAttachmentKind, MessageKind, SessionActiveClient, ResponsePartKind, ROOT_STATE_URI, SessionLifecycle, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildSubagentSessionUri, customizationId, type ChangesetState, type MarkdownResponsePart, type ToolCallCompletedState, type ToolCallResponsePart } from '../../common/state/sessionState.js';
+import { ChangesetStatus, CustomizationType, MessageAttachmentKind, MessageKind, SessionActiveClient, ResponsePartKind, ROOT_STATE_URI, SessionLifecycle, SessionStatus, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildSubagentSessionUri, customizationId, isSubagentSession, type ChangesetState, type MarkdownResponsePart, type ToolCallCompletedState, type ToolCallResponsePart } from '../../common/state/sessionState.js';
 import { type MessageResourceAttachment } from '../../common/state/protocol/state.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { AgentService } from '../../node/agentService.js';
@@ -536,6 +536,46 @@ suite('AgentService (node dispatcher)', () => {
 			const sessions = await service.listSessions();
 			assert.strictEqual(sessions.length, 1);
 			assert.strictEqual(sessions[0].summary, 'Auto-generated Title');
+		});
+
+		test('listSessions never returns subagent sessions', async () => {
+			service.registerProvider(copilotAgent);
+			const parentSession = await service.createSession({ provider: 'copilot' });
+
+			// Simulate a live subagent being spawned: `_handleSubagentStarted`
+			// registers the child session via `restoreSession`, which records
+			// it in the announced-summary map that `listSessions` overlays
+			// onto provider results.
+			const childSessionUri = buildSubagentSessionUri(parentSession.toString(), 'tc-sub');
+			service.stateManager.restoreSession(
+				{
+					resource: childSessionUri,
+					provider: 'subagent',
+					title: 'Explore',
+					status: SessionStatus.Idle,
+					createdAt: Date.now(),
+					modifiedAt: Date.now(),
+				},
+				[],
+			);
+
+			// Sanity: the subagent child session is announced.
+			assert.ok(
+				service.stateManager.getAnnouncedSessionSummaries().some(s => s.resource === childSessionUri),
+				'subagent child session should be announced',
+			);
+
+			const listed = await service.listSessions();
+			assert.deepStrictEqual(
+				{
+					subagentSessions: listed.filter(s => isSubagentSession(s.session.toString())).map(s => s.session.toString()),
+					includesParent: listed.some(s => s.session.toString() === parentSession.toString()),
+				},
+				{
+					subagentSessions: [],
+					includesParent: true,
+				},
+			);
 		});
 
 		test.skip('listSessions synthesizes the session changeset catalogue from persisted diffs for unopened sessions', async () => {

--- a/src/vs/platform/agentHost/test/node/protocol/turnExecution.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/turnExecution.integrationTest.ts
@@ -6,8 +6,8 @@
 import assert from 'assert';
 import { SubscribeResult } from '../../../common/state/protocol/commands.js';
 import type { IResponsePartAction } from '../../../common/state/sessionActions.js';
-import type { FetchTurnsResult } from '../../../common/state/sessionProtocol.js';
-import { ResponsePartKind, buildSubagentSessionUri, type MarkdownResponsePart, type SessionState } from '../../../common/state/sessionState.js';
+import type { FetchTurnsResult, ListSessionsResult } from '../../../common/state/sessionProtocol.js';
+import { ResponsePartKind, ROOT_STATE_URI, buildSubagentSessionUri, isSubagentSession, type MarkdownResponsePart, type SessionState } from '../../../common/state/sessionState.js';
 import {
 	createAndSubscribeSession,
 	dispatchTurnStarted,
@@ -214,5 +214,33 @@ suite('Protocol WebSocket — Turn Execution', function () {
 		const childToolCalls = childTurn.responseParts.filter(p => p.kind === ResponsePartKind.ToolCall);
 		const childToolNames = childToolCalls.map(p => p.toolCall.toolName);
 		assert.deepStrictEqual(childToolNames, ['echo_tool'], 'child subagent session should contain the inner `echo_tool` call');
+	});
+
+	test('subagent: child sessions never appear in listSessions', async function () {
+		this.timeout(15_000);
+
+		const sessionUri = await createAndSubscribeSession(client, 'test-subagent-list');
+		dispatchTurnStarted(client, sessionUri, 'turn-sa-list', 'subagent', 1);
+
+		// Wait for the parent turn to complete so the subagent child session
+		// has been created in the state manager.
+		await client.waitForNotification(n => isActionNotification(n, 'session/turnComplete'));
+
+		// Sanity: the subagent child session is live (subscribing succeeds).
+		const childUri = buildSubagentSessionUri(sessionUri, 'tc-task-1');
+		const childSnapshot = await client.call<SubscribeResult>('subscribe', { channel: childUri });
+		assert.ok(childSnapshot.snapshot, 'subagent child session should be live');
+
+		const result = await client.call<ListSessionsResult>('listSessions', { channel: ROOT_STATE_URI });
+		assert.deepStrictEqual(
+			{
+				subagentSessions: result.items.filter(s => isSubagentSession(s.resource)).map(s => s.resource),
+				includesParent: result.items.some(s => s.resource === sessionUri),
+			},
+			{
+				subagentSessions: [],
+				includesParent: true,
+			},
+		);
 	});
 });


### PR DESCRIPTION
## Problem

`AgentService.listSessions` overlays sessions that were announced via `getAnnouncedSessionSummaries()` onto the providers' results, to recover sessions that providers transiently drop. Subagent child sessions are registered in the state manager's announced summaries (via `restoreSession` in `_handleSubagentStarted`), so they leaked into the top-level session list. Subagent sessions are nested under their parent and should never surface as top-level entries.

## Fix

Skip announced summaries whose resource is a subagent session (`isSubagentSession(summary.resource)`) in the `listSessions` fallback loop.

## Tests

- **Unit** (`agentService.test.ts`): registers a subagent child session in the state manager (matching the live `_handleSubagentStarted` path), confirms it is announced, then asserts `listSessions` returns the parent but no subagent sessions.
- **Integration** (`turnExecution.integrationTest.ts`): drives a real subagent turn over the WebSocket protocol, verifies the child session is live (subscribable), then asserts the `listSessions` RPC result includes the parent but excludes all subagent sessions.

Both new tests pass, and the existing `listSessions` aggregation tests still pass.

(Written by Copilot)