### PR TITLE
sessions: keep chat scrollbar at the right edge

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -952,6 +952,7 @@
 		"--mobile-diff-tok-number",
 		"--session-view-background",
 		"--session-view-foreground",
+		"--session-view-centered-content-max-width",
 		"--chat-editing-last-edit-shift",
 		"--chat-current-response-min-height",
 		"--chat-smooth-delay",

--- a/src/vs/sessions/browser/parts/media/sessionsPart.css
+++ b/src/vs/sessions/browser/parts/media/sessionsPart.css
@@ -29,7 +29,10 @@
 	top: 0;
 }
 
-/* Each grid leaf surfaces its own load progress on a bar pinned to its top, mirroring how each editor group owns its own ProgressBar. */
+/* Each grid leaf surfaces its own load progress on a bar pinned to its top, mirroring how each editor group owns its own ProgressBar.
+ * The chat view spans the full leaf width (so the transcript scrollbar stays at the right edge), so the progress bar is centered and
+ * capped to the centered-content width (set as a CSS variable in `SessionView`) to align with the header/content band rather than
+ * starting in the empty side gutters. */
 .monaco-workbench .part.sessionspart .chat-view {
 	position: relative;
 }
@@ -39,6 +42,8 @@
 	top: 0;
 	left: 0;
 	right: 0;
+	margin: 0 auto;
+	max-width: var(--session-view-centered-content-max-width);
 	z-index: 10;
 }
 

--- a/src/vs/sessions/browser/parts/sessionView.ts
+++ b/src/vs/sessions/browser/parts/sessionView.ts
@@ -103,6 +103,11 @@ export class SessionView extends Disposable implements ISerializableView {
 
 		const scopedInstantiationService = this._register(instantiationService.createChild(new ServiceCollection([IContextKeyService, scopedContextKeyService])));
 
+		// Expose the centered-content cap as a CSS variable so styles that need
+		// to align with the centered band (e.g. the chat-view progress bar) can
+		// reference it without duplicating the constant.
+		this.element.style.setProperty('--session-view-centered-content-max-width', `${SessionView.CENTERED_CONTENT_MAX_WIDTH}px`);
+
 		// The header and composite bar (tabs) are hosted in a centered, width-capped
 		// container so they align with the centered chat content. The chat content
 		// itself lives in a full-width container so its transcript list spans the

--- a/src/vs/sessions/browser/parts/sessionView.ts
+++ b/src/vs/sessions/browser/parts/sessionView.ts
@@ -221,13 +221,20 @@ export class SessionView extends Disposable implements ISerializableView {
 			return;
 		}
 		const { width, height, top, left } = this._lastLayout;
+
+		// Apply the centered band's width first so the header and tabs wrap to
+		// their final layout before we measure their combined height. Measuring
+		// before the width is applied could read a stale (pre-cap) height and
+		// cause a transient overlap until a later layout pass corrects it.
+		const centeredWidth = Math.min(width, SessionView.CENTERED_CONTENT_MAX_WIDTH);
+		this._centeredContentContainer.style.width = `${centeredWidth}px`;
+
 		const headerHeight = this._header.visible ? this._header.height : 0;
 		const tabsHeight = this._compositeBar.visible ? this._compositeBar.height : 0;
 		const barHeight = headerHeight + tabsHeight;
 
-		// Center and width-cap only the header + tabs band. It is horizontally
-		// centered via CSS (`margin: 0 auto`), so we only need to set its size.
-		const centeredWidth = Math.min(width, SessionView.CENTERED_CONTENT_MAX_WIDTH);
+		// Cap the band's height to the header + tabs (it is horizontally centered
+		// via CSS `margin: 0 auto`) so the full-width chat content sits below it.
 		size(this._centeredContentContainer, centeredWidth, barHeight);
 
 		// Lay out the chat content at full width so its scrollbar reaches the

--- a/src/vs/sessions/browser/parts/sessionView.ts
+++ b/src/vs/sessions/browser/parts/sessionView.ts
@@ -103,6 +103,11 @@ export class SessionView extends Disposable implements ISerializableView {
 
 		const scopedInstantiationService = this._register(instantiationService.createChild(new ServiceCollection([IContextKeyService, scopedContextKeyService])));
 
+		// The header and composite bar (tabs) are hosted in a centered, width-capped
+		// container so they align with the centered chat content. The chat content
+		// itself lives in a full-width container so its transcript list spans the
+		// whole session view and its scrollbar stays pinned to the right edge; the
+		// chat rows and input self-center at the same max-width via CSS.
 		this._centeredContentContainer = $('.session-view-centered-content');
 		this.element.appendChild(this._centeredContentContainer);
 
@@ -113,7 +118,7 @@ export class SessionView extends Disposable implements ISerializableView {
 		this._centeredContentContainer.appendChild(this._compositeBar.element);
 
 		this._contentContainer = $('.session-view-content');
-		this._centeredContentContainer.appendChild(this._contentContainer);
+		this.element.appendChild(this._contentContainer);
 
 		this._floatingToolbar = this._register(scopedInstantiationService.createInstance(SessionViewFloatingToolbar));
 		this.element.appendChild(this._floatingToolbar.element);
@@ -216,13 +221,18 @@ export class SessionView extends Disposable implements ISerializableView {
 			return;
 		}
 		const { width, height, top, left } = this._lastLayout;
-		const centeredWidth = Math.min(width, SessionView.CENTERED_CONTENT_MAX_WIDTH);
-		const centeredLeft = left + (width - centeredWidth) / 2;
-		size(this._centeredContentContainer, centeredWidth, height);
 		const headerHeight = this._header.visible ? this._header.height : 0;
 		const tabsHeight = this._compositeBar.visible ? this._compositeBar.height : 0;
 		const barHeight = headerHeight + tabsHeight;
-		this._currentView.value?.layout(centeredWidth, height - barHeight, top + barHeight, centeredLeft);
+
+		// Center and width-cap only the header + tabs band. It is horizontally
+		// centered via CSS (`margin: 0 auto`), so we only need to set its size.
+		const centeredWidth = Math.min(width, SessionView.CENTERED_CONTENT_MAX_WIDTH);
+		size(this._centeredContentContainer, centeredWidth, barHeight);
+
+		// Lay out the chat content at full width so its scrollbar reaches the
+		// right edge; the chat rows and input center themselves via CSS.
+		this._currentView.value?.layout(width, height - barHeight, top + barHeight, left);
 	}
 
 	toJSON(): object {


### PR DESCRIPTION
Fixes #320801

## What

In the Agents window, the chat transcript scrollbar was appearing in the middle of the session view instead of at the far-right edge.

## Why

The header/tabs alignment change in `bd4d3b75104` ("fix styling of session header and chat content") wrapped the chat content together with the header and tabs inside a new `.session-view-centered-content` container that is width-capped to 950px, and laid the chat view out at that capped width. As a result the chat transcript list — and therefore its scrollbar — was shrunk to a centered 950px column, so the scrollbar floated in the middle of the window on wide layouts.

This also contradicted the documented design in `LAYOUT.md`, which states the chat viewport should stay full width with the scrollbar flush to the far-right edge, and only the inner chat content should be width-constrained.

## Change

- Only the header and composite bar (tabs) remain inside the centered, width-capped band.
- The chat content container (`.session-view-content`) is a full-width child of the session view again, and the chat view is laid out at full `width`/`left`.
- The centered band's height is set to just the header + tabs height during layout.

The chat rows and input still self-center at 950px via existing CSS (`.interactive-item-container` / `.interactive-input-part` in `style.css`), so the header/content alignment introduced by the original commit is preserved — while the list scrollbar returns to the far-right edge.

## Notes for reviewers

- Sessions-only change (`src/vs/sessions/browser/parts/sessionView.ts`); no shared workbench/chat code touched.
- Validated with `compile-check-ts-native` and `valid-layers-check`.
