### PR TITLE
fix image thumbnail crash on aux windows

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
@@ -686,7 +686,7 @@ function createImageElements(resource: URI | undefined, name: string, fullName: 
 		// only once, and the UI keeps a small object URL for steady-state rendering.
 		const previewImageUrl = disposable.add(new MutableDisposable<IDisposable>());
 		const renderPreviewImage = async () => {
-			const thumbnail = await getOrCreateImageThumbnail(cacheKey, data, IMAGE_HOVER_THUMBNAIL_MAX_SIZE, dom.getWindow(element));
+			const thumbnail = await getOrCreateImageThumbnail(cacheKey, data, IMAGE_HOVER_THUMBNAIL_MAX_SIZE);
 			if (disposable.isDisposed) {
 				return;
 			}

--- a/src/vs/workbench/contrib/chat/browser/chatImageUtils.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatImageUtils.ts
@@ -95,14 +95,12 @@ export async function resizeImage(data: Uint8Array | string, mimeType?: string):
  * re-encoded as PNG.
  * @param data The image bytes.
  * @param maxSize The maximum width or height of the thumbnail, in pixels.
- * @param targetWindow The window whose document is used to decode and resize the
- * image, so the work happens in the same window that renders the thumbnail.
  * @returns A promise that resolves to a {@link Blob} of the thumbnail, or `undefined` on failure.
  */
-function createImageThumbnail(data: Uint8Array, maxSize: number, targetWindow: Window): Promise<Blob | undefined> {
+function createImageThumbnail(data: Uint8Array, maxSize: number): Promise<Blob | undefined> {
 	return new Promise((resolve) => {
 		const blob = new Blob([data as Uint8Array<ArrayBuffer>]);
-		const img = targetWindow.document.createElement('img');
+		const img = document.createElement('img');
 		const url = URL.createObjectURL(blob);
 		img.src = url;
 
@@ -113,7 +111,7 @@ function createImageThumbnail(data: Uint8Array, maxSize: number, targetWindow: W
 			const targetWidth = Math.max(1, Math.round(width * scaleFactor));
 			const targetHeight = Math.max(1, Math.round(height * scaleFactor));
 
-			const canvas = targetWindow.document.createElement('canvas');
+			const canvas = document.createElement('canvas');
 			canvas.width = targetWidth;
 			canvas.height = targetHeight;
 			const ctx = canvas.getContext('2d');
@@ -164,10 +162,9 @@ const THUMBNAIL_DECODE_TIMEOUT_MS = 10_000;
  * @param cacheKey A stable identifier for the source image (e.g. the attachment id).
  * @param data The image bytes.
  * @param maxSize The maximum width or height of the thumbnail, in pixels.
- * @param targetWindow The window whose document is used to decode and resize the image.
  * @returns A promise that resolves to a {@link Blob} of the thumbnail, or `undefined` on failure.
  */
-export function getOrCreateImageThumbnail(cacheKey: string, data: Uint8Array, maxSize: number, targetWindow: Window): Promise<Blob | undefined> {
+export function getOrCreateImageThumbnail(cacheKey: string, data: Uint8Array, maxSize: number): Promise<Blob | undefined> {
 	// Include the size and byte length so a reused id with different content or a
 	// different target size doesn't return a stale thumbnail.
 	const key = `${cacheKey}:${maxSize}:${data.byteLength}`;
@@ -176,7 +173,7 @@ export function getOrCreateImageThumbnail(cacheKey: string, data: Uint8Array, ma
 		return cached;
 	}
 
-	const thumbnail: Promise<Blob | undefined> = raceTimeout(createImageThumbnail(data, maxSize, targetWindow), THUMBNAIL_DECODE_TIMEOUT_MS).then(blob => {
+	const thumbnail: Promise<Blob | undefined> = raceTimeout(createImageThumbnail(data, maxSize), THUMBNAIL_DECODE_TIMEOUT_MS).then(blob => {
 		// Don't keep failures cached so a later render can retry. Only evict our own
 		// entry in case LRU eviction already replaced it with a newer decode.
 		if (!blob && thumbnailCache.peek(key) === thumbnail) {


### PR DESCRIPTION
Fixes #320797

Chat image-attachment thumbnails crashed with *"Not allowed to create elements
in child window JavaScript context"* when the chat input was rendered in an
auxiliary (popped-out/floating) window.

`createImageThumbnail` resolved its target window via `dom.getWindow(element)`,
which is the auxiliary window. That window's `document.createElement` is
overridden to always throw, so creating the offscreen `<img>`/`<canvas>` blew up.

These elements are purely offscreen — never attached to the DOM, and only used
to produce a window-agnostic `Blob` — so they belong in the main window, matching
the sibling `resizeImage` helper in the same file.

**Changes**
- Drop the `targetWindow` parameter from `createImageThumbnail` /
  `getOrCreateImageThumbnail`; create the offscreen `img`/`canvas` via the
  main-window `document`.
- Remove the now-unused `dom.getWindow(element)` argument at the call site.