### PR TITLE
Agent debug logs: write to global storage when no workspace is open

### DIFF
--- a/extensions/copilot/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
+++ b/extensions/copilot/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
@@ -187,12 +187,63 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 		if (this._debugLogsDirUri) {
 			return this._debugLogsDirUri;
 		}
-		const storageUri = this._extensionContext.storageUri as URI | undefined;
+		// Prefer workspace-scoped storage. When a workspace/folder is open
+		// `storageUri` is defined and is always used (this is the common case for
+		// both local and Copilot CLI sessions). Only when no workspace is open is
+		// `storageUri` `undefined`; in that case fall back to the always-available
+		// global storage so debug logs are still written to disk.
+		const storageUri = (this._extensionContext.storageUri ?? this._extensionContext.globalStorageUri) as URI | undefined;
 		if (!storageUri) {
 			return undefined;
 		}
 		this._debugLogsDirUri = URI.joinPath(storageUri, DEBUG_LOGS_DIR_NAME);
 		return this._debugLogsDirUri;
+	}
+
+	/**
+	 * Candidate `debug-logs` roots in priority order. The active write root is
+	 * resolved by {@link _getDebugLogsDir} (workspace storage when a workspace is
+	 * open, otherwise global storage). When resolving a *historical* session we
+	 * also consider the other root, because a session may have been written in a
+	 * different window context than the current one — e.g. logged with no
+	 * workspace open (global storage) and later reopened from the session history
+	 * in a window that has a workspace (or vice versa).
+	 */
+	private _getCandidateDebugLogsRoots(): URI[] {
+		const roots: URI[] = [];
+		const seen = new Set<string>();
+		const add = (base: URI | undefined) => {
+			if (!base) {
+				return;
+			}
+			const dir = URI.joinPath(base, DEBUG_LOGS_DIR_NAME);
+			if (!seen.has(dir.fsPath)) {
+				seen.add(dir.fsPath);
+				roots.push(dir);
+			}
+		};
+		add(this._extensionContext.storageUri as URI | undefined);
+		add(this._extensionContext.globalStorageUri as URI | undefined);
+		return roots;
+	}
+
+	/**
+	 * Resolve the directory of a historical session by probing the candidate
+	 * roots on disk and returning the first that actually contains the session
+	 * directory. Returns `undefined` when no root contains it (e.g. a brand new
+	 * session that hasn't been written yet).
+	 */
+	private _resolveHistoricalSessionDir(sessionId: string): URI | undefined {
+		for (const root of this._getCandidateDebugLogsRoots()) {
+			const candidate = URI.joinPath(root, sessionId);
+			try {
+				fs.accessSync(candidate.fsPath);
+				return candidate;
+			} catch {
+				// Not under this root — try the next one.
+			}
+		}
+		return undefined;
 	}
 
 	async startSession(sessionId: string): Promise<void> {
@@ -279,8 +330,12 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 				},
 			});
 		} else {
-			// Parent session — write as main.jsonl in its own directory
-			sessionDir = URI.joinPath(dir, sessionId);
+			// Parent session — write as main.jsonl in its own directory. When the
+			// session was previously written under a different storage root (e.g.
+			// logged with no workspace open, then resumed in a workspace window),
+			// continue in that existing directory instead of starting a fresh file
+			// under the current root.
+			sessionDir = this._resolveHistoricalSessionDir(sessionId) ?? URI.joinPath(dir, sessionId);
 			fileUri = URI.joinPath(sessionDir, 'main.jsonl');
 		}
 
@@ -421,7 +476,16 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 			const dir = this._getDebugLogsDir();
 			return dir ? URI.joinPath(dir, childInfo.parentSessionId) : undefined;
 		}
-		// Unknown session — construct the default path (assuming it's a parent)
+		// Unknown session — likely historical (resumed after restart). It may have
+		// been written under a different storage root than the current window uses
+		// (e.g. a no-workspace session reopened in a workspace window), so probe
+		// disk and prefer the root that actually contains it.
+		const existing = this._resolveHistoricalSessionDir(sessionId);
+		if (existing) {
+			return existing;
+		}
+		// Not found on disk — fall back to the active write root (where it would
+		// be created), so callers still get a well-formed path.
 		const dir = this._getDebugLogsDir();
 		return dir ? URI.joinPath(dir, sessionId) : undefined;
 	}
@@ -431,11 +495,16 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 	}
 
 	isDebugLogUri(uri: URI): boolean {
-		const dir = this._getDebugLogsDir();
-		if (!dir) {
-			return false;
+		// Check every candidate root (workspace + global), not just the active
+		// write root: a session may have been written under a different root than
+		// the current window uses (e.g. a no-workspace session reopened in a
+		// workspace window). The tool read allowlist must cover those too.
+		for (const dir of this._getCandidateDebugLogsRoots()) {
+			if (extUriBiasedIgnorePathCase.isEqualOrParent(uri, dir)) {
+				return true;
+			}
 		}
-		return extUriBiasedIgnorePathCase.isEqualOrParent(uri, dir);
+		return false;
 	}
 
 	getSessionDirForResource(sessionResource: URI): URI | undefined {
@@ -1324,37 +1393,77 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 	}
 
 	async listSessionIds(): Promise<string[]> {
-		const dir = this._getDebugLogsDir();
-		if (!dir) {
-			return [];
-		}
-		try {
-			const entries = await this._fileSystemService.readDirectory(dir);
-			const dirs = entries.filter(([, type]) => type === 2 /* FileType.Directory */);
-
-			// Stat each directory in parallel to sort by most recently modified.
-			const withMtime = await Promise.all(dirs.map(async ([name]) => {
-				try {
-					const stat = await this._fileSystemService.stat(URI.joinPath(dir, name));
-					return { name, mtime: stat.mtime };
-				} catch {
-					return { name, mtime: 0 };
-				}
-			}));
-			withMtime.sort((a, b) => b.mtime - a.mtime);
-			return withMtime.map(e => e.name);
-		} catch {
-			return [];
-		}
+		// Aggregate across all candidate roots (workspace + global) so that
+		// sessions written in a different window context (e.g. with no workspace
+		// open) are still listed. Dedupe by session name, keeping the most recent.
+		const roots = this._getCandidateDebugLogsRoots();
+		const byName = new Map<string, number>();
+		await Promise.all(roots.map(async dir => {
+			try {
+				const entries = await this._fileSystemService.readDirectory(dir);
+				const dirs = entries.filter(([, type]) => type === 2 /* FileType.Directory */);
+				await Promise.all(dirs.map(async ([name]) => {
+					let mtime = 0;
+					try {
+						const stat = await this._fileSystemService.stat(URI.joinPath(dir, name));
+						mtime = stat.mtime;
+					} catch {
+						// Stat failed — treat as oldest.
+					}
+					const existing = byName.get(name);
+					if (existing === undefined || mtime > existing) {
+						byName.set(name, mtime);
+					}
+				}));
+			} catch {
+				// Directory may not exist yet — skip this root.
+			}
+		}));
+		return [...byName.entries()]
+			.sort((a, b) => b[1] - a[1])
+			.map(([name]) => name);
 	}
 
 	private async _cleanupOldLogs(): Promise<void> {
-		const dir = this._getDebugLogsDir();
-		if (!dir) {
+		// Apply the retention cap to each candidate root (workspace + global)
+		// independently. This keeps each workspace's bucket bounded as before
+		// while also trimming the global no-workspace bucket, which may be written
+		// from any window context.
+		const roots = this._getCandidateDebugLogsRoots();
+		if (roots.length === 0) {
 			return;
 		}
 
+		const configuredMax = this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.ChatDebugFileLoggingMaxRetainedSessionLogs, this._experimentationService);
+		const maxRetainedSessionLogs = Number.isFinite(configuredMax) && configuredMax >= 1 ? Math.trunc(configuredMax) : DEFAULT_MAX_RETAINED_LOGS;
+
 		const startTime = Date.now();
+		let totalEntryCount = 0;
+		let totalDeletedCount = 0;
+		for (const dir of roots) {
+			const result = await this._cleanupOldLogsInRoot(dir, maxRetainedSessionLogs);
+			totalEntryCount += result.entryCount;
+			totalDeletedCount += result.deletedCount;
+		}
+
+		/* __GDPR__
+			"chatDebugFileLogger.cleanupOldLogs" : {
+				"owner": "vijayupadya",
+				"comment": "Old debug log files were cleaned up",
+				"durationMs": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Time in ms to perform cleanup" },
+				"entryCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Total number of log entries found" },
+				"deletedCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Number of log entries deleted" }
+			}
+		*/
+		this._telemetryService.sendMSFTTelemetryEvent('chatDebugFileLogger.cleanupOldLogs', undefined, { durationMs: Date.now() - startTime, entryCount: totalEntryCount, deletedCount: totalDeletedCount });
+	}
+
+	/**
+	 * Trim a single `debug-logs` root down to {@link maxRetainedSessionLogs}
+	 * sessions, deleting the oldest first and never deleting a currently active
+	 * session. Returns the number of entries found and deleted in this root.
+	 */
+	private async _cleanupOldLogsInRoot(dir: URI, maxRetainedSessionLogs: number): Promise<{ entryCount: number; deletedCount: number }> {
 		try {
 			const entries = await this._fileSystemService.readDirectory(dir);
 			// Count both directories (new format) and legacy .jsonl files (old format)
@@ -1363,20 +1472,8 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 				(name.endsWith('.jsonl') && type === 1 /* FileType.File */)
 			);
 
-			const configuredMax = this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.ChatDebugFileLoggingMaxRetainedSessionLogs, this._experimentationService);
-			const maxRetainedSessionLogs = Number.isFinite(configuredMax) && configuredMax >= 1 ? Math.trunc(configuredMax) : DEFAULT_MAX_RETAINED_LOGS;
 			if (sessionEntries.length <= maxRetainedSessionLogs) {
-				/* __GDPR__
-					"chatDebugFileLogger.cleanupOldLogs" : {
-						"owner": "vijayupadya",
-						"comment": "Old debug log files were cleaned up",
-						"durationMs": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Time in ms to perform cleanup" },
-						"entryCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Total number of log entries found" },
-						"deletedCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Number of log entries deleted" }
-					}
-				*/
-				this._telemetryService.sendMSFTTelemetryEvent('chatDebugFileLogger.cleanupOldLogs', undefined, { durationMs: Date.now() - startTime, entryCount: sessionEntries.length, deletedCount: 0 });
-				return;
+				return { entryCount: sessionEntries.length, deletedCount: 0 };
 			}
 
 			const entryStats = await Promise.all(
@@ -1410,10 +1507,10 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 					this._logService.warn(`[ChatDebugFileLogger] Failed to delete old debug log: ${entry.name}`);
 				}
 			}
-			// GDPR comment above covers this event
-			this._telemetryService.sendMSFTTelemetryEvent('chatDebugFileLogger.cleanupOldLogs', undefined, { durationMs: Date.now() - startTime, entryCount: sessionEntries.length, deletedCount: deleted });
+			return { entryCount: sessionEntries.length, deletedCount: deleted };
 		} catch {
 			// Directory may not exist yet
+			return { entryCount: 0, deletedCount: 0 };
 		}
 	}
 }

--- a/extensions/copilot/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
+++ b/extensions/copilot/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
@@ -237,13 +237,31 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 		for (const root of this._getCandidateDebugLogsRoots()) {
 			const candidate = URI.joinPath(root, sessionId);
 			try {
-				fs.accessSync(candidate.fsPath);
-				return candidate;
+				// Verify the candidate is an actual directory, not a stray file,
+				// so we never return a path under which `main.jsonl` could never exist.
+				if (fs.statSync(candidate.fsPath).isDirectory()) {
+					return candidate;
+				}
 			} catch {
 				// Not under this root — try the next one.
 			}
 		}
 		return undefined;
+	}
+
+	/**
+	 * Resolve the directory a child session should be written to. A child must
+	 * live under its parent's *actual* directory, which may sit under a different
+	 * storage root than the current window's active write root (e.g. when the
+	 * parent was logged with no workspace open and later resumed in a workspace
+	 * window). Prefer the parent's already-resolved active `sessionDir`, then
+	 * probe disk for a historical parent directory, and only fall back to the
+	 * current write root when neither is available.
+	 */
+	private _resolveParentSessionDir(parentSessionId: string, fallbackRoot: URI): URI {
+		return this._activeSessions.get(parentSessionId)?.sessionDir
+			?? this._resolveHistoricalSessionDir(parentSessionId)
+			?? URI.joinPath(fallbackRoot, parentSessionId);
 	}
 
 	async startSession(sessionId: string): Promise<void> {
@@ -302,16 +320,19 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 		let fileUri: URI;
 
 		if (childInfo) {
-			// Child session — write under parent's directory
-			sessionDir = URI.joinPath(dir, childInfo.parentSessionId);
-			const safeLabel = childInfo.label.replace(/[/\\:*?"<>|\x00-\x1f]/g, '_').replace(/\.\./g, '_');
-			const fileName = `${safeLabel}-${sessionId}.jsonl`;
-			fileUri = URI.joinPath(sessionDir, fileName);
-
-			// Ensure parent session exists so we can write a cross-reference.
+			// Ensure parent session exists so we can write a cross-reference and
+			// resolve the parent's actual directory before deriving the child path.
 			// A child referencing a parent proves it is a main user session,
 			// so promote it with hasOwnSpans = true.
 			this._ensureSession(childInfo.parentSessionId, /* hasOwnSpans */ true);
+
+			// Child session — write under the parent's *actual* directory, which may
+			// live under a different storage root than the current write root when
+			// the parent was resumed from history.
+			sessionDir = this._resolveParentSessionDir(childInfo.parentSessionId, dir);
+			const safeLabel = childInfo.label.replace(/[/\\:*?"<>|\x00-\x1f]/g, '_').replace(/\.\./g, '_');
+			const fileName = `${safeLabel}-${sessionId}.jsonl`;
+			fileUri = URI.joinPath(sessionDir, fileName);
 
 			// Write a cross-reference entry in the parent's main.jsonl
 			this._bufferEntry(childInfo.parentSessionId, {
@@ -456,7 +477,7 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 		if (childInfo) {
 			const dir = this._getDebugLogsDir();
 			if (!dir) { return undefined; }
-			const parentDir = URI.joinPath(dir, childInfo.parentSessionId);
+			const parentDir = this._resolveParentSessionDir(childInfo.parentSessionId, dir);
 			return URI.joinPath(parentDir, `${childInfo.label}-${sessionId}.jsonl`);
 		}
 		// For historical sessions (after restart), construct the default path
@@ -474,7 +495,7 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 		const childInfo = this._childSessionMap.get(sessionId);
 		if (childInfo) {
 			const dir = this._getDebugLogsDir();
-			return dir ? URI.joinPath(dir, childInfo.parentSessionId) : undefined;
+			return dir ? this._resolveParentSessionDir(childInfo.parentSessionId, dir) : undefined;
 		}
 		// Unknown session — likely historical (resumed after restart). It may have
 		// been written under a different storage root than the current window uses

--- a/extensions/copilot/src/extension/chat/vscode-node/test/chatDebugFileLoggerService.spec.ts
+++ b/extensions/copilot/src/extension/chat/vscode-node/test/chatDebugFileLoggerService.spec.ts
@@ -99,10 +99,12 @@ class TestOTelService {
 
 class TestExtensionContext {
 	declare readonly _serviceBrand: undefined;
-	readonly storageUri: URI;
+	readonly storageUri: URI | undefined;
+	readonly globalStorageUri: URI | undefined;
 
-	constructor(tmpDir: string) {
-		this.storageUri = URI.file(tmpDir);
+	constructor(storagePath: string | undefined, globalStoragePath?: string) {
+		this.storageUri = storagePath ? URI.file(storagePath) : undefined;
+		this.globalStorageUri = globalStoragePath ? URI.file(globalStoragePath) : undefined;
 	}
 }
 
@@ -266,6 +268,126 @@ describe('ChatDebugFileLoggerService', () => {
 	it('isDebugLogUri returns false for unrelated URIs', () => {
 		const otherUri = URI.file('/some/other/path/file.txt');
 		expect(service.isDebugLogUri(otherUri)).toBe(false);
+	});
+
+	it('isDebugLogUri allows the global root while a workspace is open', async () => {
+		const globalTmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'chatdebug-global-'));
+		try {
+			// Window has a workspace (storageUri = tmpDir) plus a global root.
+			const workspaceService = new ChatDebugFileLoggerService(
+				otelService as unknown as IOTelService,
+				new TestFileSystemService() as unknown as IFileSystemService,
+				new TestExtensionContext(tmpDir, globalTmpDir) as unknown as IVSCodeExtensionContext,
+				new TestLogService() as unknown as ILogService,
+				new TestConfigurationService() as unknown as IConfigurationService,
+				new NullExperimentationService() as unknown as IExperimentationService,
+				new TestTelemetryService() as unknown as ITelemetryService,
+				new TestEnvService() as unknown as IEnvService,
+			);
+			disposables.add(workspaceService);
+
+			// A log under the global root (where a no-workspace session was written)
+			// must still be allowlisted for tool reads.
+			const globalLogUri = URI.joinPath(URI.file(globalTmpDir), 'debug-logs', 'hist-session', 'main.jsonl');
+			expect(workspaceService.isDebugLogUri(globalLogUri)).toBe(true);
+
+			// The workspace root is still allowlisted too.
+			const workspaceLogUri = URI.joinPath(URI.file(tmpDir), 'debug-logs', 'ws-session', 'main.jsonl');
+			expect(workspaceService.isDebugLogUri(workspaceLogUri)).toBe(true);
+		} finally {
+			await fs.promises.rm(globalTmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it('falls back to global storage when no workspace is open', async () => {
+		const globalTmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'chatdebug-global-'));
+		try {
+			// No workspace open: storageUri is undefined, only globalStorageUri is
+			// available (e.g. an empty VS Code window). Workspace-scoped storage is
+			// preferred whenever a folder is open; this fallback only applies when
+			// no workspace is open.
+			const noWorkspaceService = new ChatDebugFileLoggerService(
+				otelService as unknown as IOTelService,
+				new TestFileSystemService() as unknown as IFileSystemService,
+				new TestExtensionContext(undefined, globalTmpDir) as unknown as IVSCodeExtensionContext,
+				new TestLogService() as unknown as ILogService,
+				new TestConfigurationService() as unknown as IConfigurationService,
+				new NullExperimentationService() as unknown as IExperimentationService,
+				new TestTelemetryService() as unknown as ITelemetryService,
+				new TestEnvService() as unknown as IEnvService,
+			);
+			disposables.add(noWorkspaceService);
+
+			expect(noWorkspaceService.debugLogsDir?.fsPath).toBe(URI.joinPath(URI.file(globalTmpDir), 'debug-logs').fsPath);
+
+			await noWorkspaceService.startSession('session-1');
+			otelService.fireSpan(makeToolCallSpan('session-1', 'read_file'));
+			await noWorkspaceService.endSession('session-1');
+
+			const logPath = URI.joinPath(URI.file(globalTmpDir), 'debug-logs', 'session-1', 'main.jsonl');
+			const content = await fs.promises.readFile(logPath.fsPath, 'utf-8');
+			expect(content.trim()).not.toBe('');
+		} finally {
+			await fs.promises.rm(globalTmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it('returns undefined debug logs dir when neither workspace nor global storage is available', () => {
+		const noStorageService = new ChatDebugFileLoggerService(
+			otelService as unknown as IOTelService,
+			new TestFileSystemService() as unknown as IFileSystemService,
+			new TestExtensionContext(undefined, undefined) as unknown as IVSCodeExtensionContext,
+			new TestLogService() as unknown as ILogService,
+			new TestConfigurationService() as unknown as IConfigurationService,
+			new NullExperimentationService() as unknown as IExperimentationService,
+			new TestTelemetryService() as unknown as ITelemetryService,
+			new TestEnvService() as unknown as IEnvService,
+		);
+		disposables.add(noStorageService);
+
+		expect(noStorageService.debugLogsDir).toBeUndefined();
+	});
+
+	it('resolves a historical session from global storage when reopened in a workspace window', async () => {
+		const globalTmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'chatdebug-global-'));
+		try {
+			// Phase 1: session logged with no workspace open → written to global storage.
+			const noWorkspaceService = new ChatDebugFileLoggerService(
+				otelService as unknown as IOTelService,
+				new TestFileSystemService() as unknown as IFileSystemService,
+				new TestExtensionContext(undefined, globalTmpDir) as unknown as IVSCodeExtensionContext,
+				new TestLogService() as unknown as ILogService,
+				new TestConfigurationService() as unknown as IConfigurationService,
+				new NullExperimentationService() as unknown as IExperimentationService,
+				new TestTelemetryService() as unknown as ITelemetryService,
+				new TestEnvService() as unknown as IEnvService,
+			);
+			disposables.add(noWorkspaceService);
+			await noWorkspaceService.startSession('hist-session');
+			otelService.fireSpan(makeToolCallSpan('hist-session', 'read_file'));
+			await noWorkspaceService.endSession('hist-session');
+
+			// Phase 2: reopen in a window that has a workspace (storageUri defined).
+			// The session is now "historical" (unknown to the fresh service), but it
+			// must still resolve to the global-storage location where it was written.
+			const workspaceService = new ChatDebugFileLoggerService(
+				otelService as unknown as IOTelService,
+				new TestFileSystemService() as unknown as IFileSystemService,
+				new TestExtensionContext(tmpDir, globalTmpDir) as unknown as IVSCodeExtensionContext,
+				new TestLogService() as unknown as ILogService,
+				new TestConfigurationService() as unknown as IConfigurationService,
+				new NullExperimentationService() as unknown as IExperimentationService,
+				new TestTelemetryService() as unknown as ITelemetryService,
+				new TestEnvService() as unknown as IEnvService,
+			);
+			disposables.add(workspaceService);
+
+			const expectedDir = URI.joinPath(URI.file(globalTmpDir), 'debug-logs', 'hist-session');
+			expect(workspaceService.getSessionDir('hist-session')?.fsPath).toBe(expectedDir.fsPath);
+			expect(workspaceService.getLogPath('hist-session')?.fsPath).toBe(URI.joinPath(expectedDir, 'main.jsonl').fsPath);
+		} finally {
+			await fs.promises.rm(globalTmpDir, { recursive: true, force: true });
+		}
 	});
 
 	it('endSession flushes and removes session', async () => {
@@ -814,6 +936,96 @@ describe('ChatDebugFileLoggerService', () => {
 			const ids = await service.listSessionIds();
 			expect(ids).toContain('good-session');
 			expect(ids).toContain('empty-dir');
+		});
+
+		it('aggregates sessions across workspace and global roots', async () => {
+			const globalTmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'chatdebug-global-'));
+			try {
+				// A session written to the global root by a previous no-workspace window.
+				await fs.promises.mkdir(path.join(globalTmpDir, 'debug-logs', 'global-session'), { recursive: true });
+				await fs.promises.writeFile(path.join(globalTmpDir, 'debug-logs', 'global-session', 'main.jsonl'), '{}');
+
+				// Current window has a workspace (storageUri = tmpDir) plus the same global root.
+				const workspaceService = new ChatDebugFileLoggerService(
+					otelService as unknown as IOTelService,
+					new TestFileSystemService() as unknown as IFileSystemService,
+					new TestExtensionContext(tmpDir, globalTmpDir) as unknown as IVSCodeExtensionContext,
+					new TestLogService() as unknown as ILogService,
+					new TestConfigurationService() as unknown as IConfigurationService,
+					new NullExperimentationService() as unknown as IExperimentationService,
+					new TestTelemetryService() as unknown as ITelemetryService,
+					new TestEnvService() as unknown as IEnvService,
+				);
+				disposables.add(workspaceService);
+
+				await workspaceService.startSession('workspace-session');
+				otelService.fireSpan(makeToolCallSpan('workspace-session', 'read_file'));
+				await workspaceService.flush('workspace-session');
+
+				const ids = await workspaceService.listSessionIds();
+				expect(ids).toContain('workspace-session');
+				expect(ids).toContain('global-session');
+			} finally {
+				await fs.promises.rm(globalTmpDir, { recursive: true, force: true });
+			}
+		});
+	});
+
+	describe('_cleanupOldLogs', () => {
+		it('trims both workspace and global roots independently to the cap', async () => {
+			const globalTmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'chatdebug-global-'));
+			try {
+				// Config with a small retention cap of 2 sessions per root.
+				class LowCapConfigService extends TestConfigurationService {
+					override getExperimentBasedConfig(key: { defaultValue: unknown }) {
+						if (key === ConfigKey.Advanced.ChatDebugFileLogging) {
+							return true;
+						}
+						if (key === ConfigKey.Advanced.ChatDebugFileLoggingMaxRetainedSessionLogs) {
+							return 2;
+						}
+						return key.defaultValue;
+					}
+				}
+
+				const workspaceRoot = path.join(tmpDir, 'debug-logs');
+				const globalRoot = path.join(globalTmpDir, 'debug-logs');
+
+				// Seed 4 session dirs in each root with increasing mtimes.
+				const seed = async (root: string, prefix: string) => {
+					for (let i = 0; i < 4; i++) {
+						const sessionDir = path.join(root, `${prefix}-${i}`);
+						await fs.promises.mkdir(sessionDir, { recursive: true });
+						await fs.promises.writeFile(path.join(sessionDir, 'main.jsonl'), '{}');
+						await new Promise(resolve => setTimeout(resolve, 10));
+					}
+				};
+				await seed(workspaceRoot, 'ws');
+				await seed(globalRoot, 'gl');
+
+				const svc = new ChatDebugFileLoggerService(
+					otelService as unknown as IOTelService,
+					new TestFileSystemService() as unknown as IFileSystemService,
+					new TestExtensionContext(tmpDir, globalTmpDir) as unknown as IVSCodeExtensionContext,
+					new TestLogService() as unknown as ILogService,
+					new LowCapConfigService() as unknown as IConfigurationService,
+					new NullExperimentationService() as unknown as IExperimentationService,
+					new TestTelemetryService() as unknown as ITelemetryService,
+					new TestEnvService() as unknown as IEnvService,
+				);
+				disposables.add(svc);
+
+				await (svc as unknown as { _cleanupOldLogs(): Promise<void> })._cleanupOldLogs();
+
+				const wsRemaining = (await fs.promises.readdir(workspaceRoot)).sort();
+				const glRemaining = (await fs.promises.readdir(globalRoot)).sort();
+
+				// Each root is independently trimmed to the 2 most recent.
+				expect(wsRemaining).toEqual(['ws-2', 'ws-3']);
+				expect(glRemaining).toEqual(['gl-2', 'gl-3']);
+			} finally {
+				await fs.promises.rm(globalTmpDir, { recursive: true, force: true });
+			}
 		});
 	});
 });

--- a/extensions/copilot/src/platform/chat/common/chatDebugFileLoggerService.ts
+++ b/extensions/copilot/src/platform/chat/common/chatDebugFileLoggerService.ts
@@ -74,8 +74,10 @@ export interface IChatDebugFileLoggerService {
 
 	/**
 	 * Get the URI of the debug logs directory, or undefined if it cannot be
-	 * determined (e.g. no workspace, or an error occurs). The directory may
-	 * not actually exist on disk yet if no sessions have been started.
+	 * determined (e.g. no storage is available at all, or an error occurs).
+	 * Resolves to workspace-scoped storage when a workspace/folder is open and
+	 * only falls back to global storage when no workspace is open. The directory
+	 * may not actually exist on disk yet if no sessions have been started.
 	 */
 	readonly debugLogsDir: URI | undefined;
 


### PR DESCRIPTION
Chat debug JSONL logs were only written when a workspace/folder was open, because the logger derived its directory solely from extensionContext.storageUri (which is undefined in an empty window). For no-workspace sessions — both local and Copilot CLI delegate sessions — getDebugLogsDir() returned undefined and no logs were written at all, silently disabling the debug panel, the troubleshoot skill, and session history for those sessions.

This PR makes the logger fall back to the always-available global storage when no workspace is open, and ensures every consumer (file writes, reads, the read allowlist, cleanup, and session listing) handles the resulting split between workspace-scoped and global storage roots.