### PR TITLE
Restrict GPG sandbox permissions for chained commands

### DIFF
--- a/src/vs/platform/sandbox/common/terminalSandboxRuntimeConfigurationPerOperation.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxRuntimeConfigurationPerOperation.ts
@@ -73,7 +73,7 @@ export function getTerminalSandboxRuntimeConfigurationForCommands(os: OperatingS
 	const operations = new Set<TerminalSandboxRuntimeConfigurationOperation>();
 	for (const command of commandDetails) {
 		for (const rule of terminalSandboxRuntimeConfigurationCommandRules) {
-			if (matchesTerminalSandboxCommandRule(command, rule, { os })) {
+			if (matchesTerminalSandboxCommandRule(command, rule, { os }) && shouldApplyRuntimeConfigurationOperation(rule.value, commandDetails)) {
 				operations.add(rule.value);
 			}
 		}
@@ -84,6 +84,17 @@ export function getTerminalSandboxRuntimeConfigurationForCommands(os: OperatingS
 		mergeAdditionalSandboxConfigProperties(configuration, getTerminalSandboxRuntimeConfigurationForOperation(operation, os));
 	}
 	return configuration;
+}
+
+function shouldApplyRuntimeConfigurationOperation(operation: TerminalSandboxRuntimeConfigurationOperation, commandDetails: readonly ITerminalSandboxCommand[]): boolean {
+	switch (operation) {
+		case TerminalSandboxRuntimeConfigurationOperation.GnuPG:
+			// allowAllUnixSockets applies to the whole sandbox invocation, so only add it when the
+			// signed commit is the only parsed command. Chained commands cannot receive it safely.
+			return commandDetails.length === 1;
+		case TerminalSandboxRuntimeConfigurationOperation.Node:
+			return true;
+	}
 }
 
 function isGpgSignedGitCommit(command: ITerminalSandboxCommand): boolean {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
@@ -416,6 +416,9 @@ suite('TerminalSandboxService - network domains', () => {
 		const signedCommitWithGlobalOptionConfig = await getConfigAfterWrap('git -C repo commit --gpg-sign=key -m "test"', [{ keyword: 'git', args: ['-C', 'repo', 'commit', '--gpg-sign=key', '-m', 'test'] }]);
 		strictEqual(signedCommitWithGlobalOptionConfig.network.allowAllUnixSockets, true, 'Signed git commits with global options should allow Unix sockets for GPG signing');
 
+		const chainedSignedCommitConfig = await getConfigAfterWrap('git commit -S -m "test" && npm install', [{ keyword: 'git', args: ['commit', '-S', '-m', 'test'] }, { keyword: 'npm', args: ['install'] }]);
+		strictEqual(Object.prototype.hasOwnProperty.call(chainedSignedCommitConfig.network, 'allowAllUnixSockets'), false, 'Chained signed git commits should not allow all Unix sockets for the entire invocation');
+
 		const unsignedCommitConfig = await getConfigAfterWrap('git commit -m "test"', [{ keyword: 'git', args: ['commit', '-m', 'test'] }]);
 		strictEqual(Object.prototype.hasOwnProperty.call(unsignedCommitConfig.network, 'allowAllUnixSockets'), false, 'Unsigned git commits should not allow all Unix sockets');
 
@@ -427,6 +430,16 @@ suite('TerminalSandboxService - network domains', () => {
 		const config = getTerminalSandboxRuntimeConfigurationForCommands(OperatingSystem.Windows, [{ keyword: 'git', args: ['commit', '-S', '-m', 'test'] }]);
 
 		deepStrictEqual(config, {}, 'Signed git commit runtime values should not apply on Windows');
+	});
+
+	test('should skip unsafe command-specific runtime values for chained commands', () => {
+		const config = getTerminalSandboxRuntimeConfigurationForCommands(OperatingSystem.Linux, [{ keyword: 'git', args: ['commit', '-S', '-m', 'test'] }, { keyword: 'npm', args: ['install'] }]);
+
+		deepStrictEqual(config, {
+			filesystem: {
+				allowWrite: ['~/.volta/']
+			}
+		});
 	});
 
 	test('should preserve user runtime settings over command-specific runtime values', async () => {


### PR DESCRIPTION

## Summary

- prevent signed Git commit GnuPG runtime configuration, including `network.allowAllUnixSockets`, from applying to an entire chained command invocation
- continue applying safe command-specific runtime configuration for other commands in the chain
- add regression coverage for chained signed commits

## Testing

- `npm run compile-check-ts-native`
- `./scripts/test.sh --run src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts --run src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts` (87 passing)
- changed-file hygiene and `git diff --check`