### PR TITLE
Allow Chromium feature switches in argv config

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -235,6 +235,10 @@ function configureCommandlineSwitchesSync(cliArgs: NativeParsedArgs) {
 		// bypass any specified proxy for the given semi-colon-separated list of hosts
 		'proxy-bypass-list',
 
+		// override Chromium feature state for troubleshooting
+		'enable-features',
+		'disable-features',
+
 		'remote-debugging-port'
 	];
 

--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -158,6 +158,8 @@ export interface NativeParsedArgs {
 	'proxy-server'?: string;
 	'proxy-bypass-list'?: string;
 	'proxy-pac-url'?: string;
+	'enable-features'?: string;
+	'disable-features'?: string;
 	'inspect'?: string;
 	'inspect-brk'?: string;
 	'js-flags'?: string;

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -233,6 +233,8 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'proxy-server': { type: 'string' },
 	'proxy-bypass-list': { type: 'string' },
 	'proxy-pac-url': { type: 'string' },
+	'enable-features': { type: 'string' },
+	'disable-features': { type: 'string' },
 	'js-flags': { type: 'string' }, // chrome js flags
 	'inspect': { type: 'string', allowEmptyValue: true },
 	'inspect-brk': { type: 'string', allowEmptyValue: true },

--- a/src/vs/platform/environment/test/node/argv.test.ts
+++ b/src/vs/platform/environment/test/node/argv.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { formatOptions, Option, OptionDescriptions, Subcommand, parseArgs, ErrorReporter } from '../../node/argv.js';
+import { formatOptions, Option, OptionDescriptions, Subcommand, parseArgs, ErrorReporter, OPTIONS } from '../../node/argv.js';
 import { addArg } from '../../node/argvHelper.js';
 
 function o(description: string, type: 'boolean' | 'string' | 'string[]' = 'string'): Option<any> {
@@ -181,6 +181,16 @@ suite('parseArgs', () => {
 			{ testcmd: { testArg: 'foo', testX: true, '_': [] }, '_': [] },
 			[]
 		);
+	});
+
+	test('recognizes Chromium feature switches', () => {
+		const errorReporter = newErrorReporter();
+
+		const args = parseArgs(['--disable-features', 'UiaProvider', '--enable-features=AccessibilityHitTestPointCopy'], OPTIONS, errorReporter);
+
+		assert.strictEqual(args['disable-features'], 'UiaProvider');
+		assert.strictEqual(args['enable-features'], 'AccessibilityHitTestPointCopy');
+		assert.deepStrictEqual(errorReporter.result, []);
 	});
 
 	ensureNoDisposablesAreLeakedInTestSuite();

--- a/src/vs/platform/environment/test/node/argv.test.ts
+++ b/src/vs/platform/environment/test/node/argv.test.ts
@@ -193,5 +193,19 @@ suite('parseArgs', () => {
 		assert.deepStrictEqual(errorReporter.result, []);
 	});
 
+	test('handles Chromium feature switch parser edge cases', () => {
+		const multipleValuesReporter = newErrorReporter();
+		const multipleValuesArgs = parseArgs(['--enable-features=FeatureA', '--enable-features=FeatureB'], OPTIONS, multipleValuesReporter);
+
+		assert.strictEqual(multipleValuesArgs['enable-features'], 'FeatureB');
+		assert.deepStrictEqual(multipleValuesReporter.result, ['onMultipleValues enable-features FeatureB']);
+
+		const emptyValueReporter = newErrorReporter();
+		const emptyValueArgs = parseArgs(['--disable-features='], OPTIONS, emptyValueReporter);
+
+		assert.strictEqual(emptyValueArgs['disable-features'], undefined);
+		assert.deepStrictEqual(emptyValueReporter.result, ['onEmptyValue disable-features']);
+	});
+
 	ensureNoDisposablesAreLeakedInTestSuite();
 });

--- a/src/vs/workbench/electron-browser/desktop.contribution.ts
+++ b/src/vs/workbench/electron-browser/desktop.contribution.ts
@@ -463,6 +463,14 @@ import product from '../../platform/product/common/product.js';
 			'js-flags': {
 				type: 'string',
 				description: localize('argv.jsFlags', "Specifies V8 JavaScript engine flags to pass (e.g. \"--max-old-space-size=4096\"). These flags are applied to the main process, renderer and utility processes.")
+			},
+			'enable-features': {
+				type: 'string',
+				description: localize('argv.enableFeatures', "Enables Chromium runtime features for troubleshooting. Only change this when requested by the VS Code team.")
+			},
+			'disable-features': {
+				type: 'string',
+				description: localize('argv.disableFeatures', "Disables Chromium runtime features for troubleshooting. Only change this when requested by the VS Code team.")
 			}
 		}
 	};

--- a/src/vs/workbench/electron-browser/desktop.contribution.ts
+++ b/src/vs/workbench/electron-browser/desktop.contribution.ts
@@ -466,11 +466,11 @@ import product from '../../platform/product/common/product.js';
 			},
 			'enable-features': {
 				type: 'string',
-				description: localize('argv.enableFeatures', "Enables Chromium runtime features for troubleshooting. Only change this when requested by the VS Code team.")
+				description: localize('argv.enableFeatures', "Enables comma-separated Chromium runtime features for troubleshooting (for example, \"FeatureA,FeatureB\"). Provide this switch once. Only change this when requested by the VS Code team.")
 			},
 			'disable-features': {
 				type: 'string',
-				description: localize('argv.disableFeatures', "Disables Chromium runtime features for troubleshooting. Only change this when requested by the VS Code team.")
+				description: localize('argv.disableFeatures', "Disables comma-separated Chromium runtime features for troubleshooting (for example, \"FeatureA,FeatureB\"). Provide this switch once. Only change this when requested by the VS Code team.")
 			}
 		}
 	};


### PR DESCRIPTION
Related to #247522.

This adds `enable-features` and `disable-features` to the native argument parser, the `argv.json` schema, and the supported Electron switch allowlist.

The default behavior is unchanged. The switches are only forwarded when explicitly configured, but this gives the VS Code team and affected users a persistent way to apply Chromium feature-flag diagnostics or workarounds while investigating accessibility-provider regressions.

Testing:
- `npm ci`
- `npm run compile-check-ts-native`
- `npm run transpile-client`
- `npm run test-node -- --run src/vs/platform/environment/test/node/argv.test.ts --grep "recognizes Chromium feature switches"`
- `npm run valid-layers-check`
- `git diff --check origin/main...HEAD`