### PR TITLE
AH: Simplify agent SDK distribution to per-platform product.json

### DIFF
--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -65,24 +65,23 @@ export type ExtensionVirtualWorkspaceSupport = {
 };
 
 /**
- * Per-package configuration for downloading an agent SDK on demand. When
- * `IProductConfiguration.agentSdks?.[pkg]` is set, the agent host fetches the
- * per-platform tarball at `format2(urlTemplate, { sdkVersion, sdkTarget })`,
- * verifies its sha256 against `sha256[sdkTarget]`, and caches it under
- * `userDataPath/agent-host/sdk-cache/`.
+ * Per-platform configuration for downloading an agent SDK on demand. When
+ * `IProductConfiguration.agentSdks?.[pkg]` is set, the agent host GETs
+ * `url`, verifies sha256 against `sha256`, and caches the extracted root
+ * under `userDataPath/agent-host/sdk-cache/`.
  *
- * `{sdkTarget}` is `${platform}-${arch}`, plus `-musl` on Linux when musl is
- * detected — same suffixes npm uses for the platform `optionalDependencies`
- * (`@anthropic-ai/claude-agent-sdk-${sdkTarget}`, `@openai/codex-${sdkTarget}`).
+ * The build pipeline patches `agentSdks` per-platform during packaging
+ * (see build/gulpfile.vscode.ts / build/gulpfile.reh.ts), so each shipped
+ * product.json carries only the entry for the platform it targets — there
+ * is no per-target sha lookup at runtime.
  *
- * The `sha256` map's keys define the supported platforms: a `currentSdkTarget()`
- * not present in the map is treated as unsupported and the provider is not
- * registered.
+ * The trust anchor for `sha256` is product.json's own integrity coverage
+ * via `product.checksums` (computed in the same packaging step).
  */
 export interface IAgentSdkProductConfig {
 	readonly version: string;
-	readonly urlTemplate: string;
-	readonly sha256: { readonly [sdkTarget: string]: string };
+	readonly url: string;
+	readonly sha256: string;
 }
 
 export interface IProductConfiguration {

--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -70,10 +70,9 @@ export type ExtensionVirtualWorkspaceSupport = {
  * `url`, verifies sha256 against `sha256`, and caches the extracted root
  * under `userDataPath/agent-host/sdk-cache/`.
  *
- * The build pipeline patches `agentSdks` per-platform during packaging
- * (see build/gulpfile.vscode.ts / build/gulpfile.reh.ts), so each shipped
- * product.json carries only the entry for the platform it targets — there
- * is no per-target sha lookup at runtime.
+ * The build pipeline patches `agentSdks` per-platform during packaging, so
+ * each shipped product.json carries only the entry appropriate for the
+ * platform it targets — there is no per-target sha lookup at runtime.
  *
  * The trust anchor for `sha256` is product.json's own integrity coverage
  * via `product.checksums` (computed in the same packaging step).

--- a/src/vs/platform/agentHost/node/agentSdkDownloader.ts
+++ b/src/vs/platform/agentHost/node/agentSdkDownloader.ts
@@ -10,8 +10,6 @@ import { VSBuffer } from '../../../base/common/buffer.js';
 import { CancellationToken } from '../../../base/common/cancellation.js';
 import { CancellationError } from '../../../base/common/errors.js';
 import * as path from '../../../base/common/path.js';
-import { isLinux } from '../../../base/common/platform.js';
-import { format2 } from '../../../base/common/strings.js';
 import { URI } from '../../../base/common/uri.js';
 import { INativeEnvironmentService } from '../../environment/common/environment.js';
 import { FileOperationError, FileOperationResult, IFileService, toFileOperationResult } from '../../files/common/files.js';
@@ -26,9 +24,7 @@ import { IRequestContext } from '../../../base/parts/request/common/request.js';
 /**
  * One agent-SDK package the downloader can fetch. Holds the per-package
  * knowledge that varies between Claude, Codex, and any future provider —
- * the env var that acts as a dev override, and whether this SDK ships
- * separate `*-musl` Linux packages so the downloader knows whether to
- * append the suffix on musl hosts.
+ * just the package id and the env var that acts as a dev override.
  *
  * The downloader itself is package-agnostic: it consumes this interface and
  * never branches on `id`. Concrete `IAgentSdkPackage` instances live in
@@ -37,56 +33,16 @@ import { IRequestContext } from '../../../base/parts/request/common/request.js';
  * `codex/codexAgent.ts`) so Claude-specific / Codex-specific knowledge
  * stays in those modules — the downloader doesn't name the providers it
  * serves.
+ *
+ * Platform discrimination is done at packaging time: the build patches
+ * `product.agentSdks[pkg]` with the single per-platform entry for the
+ * platform being packaged, so there is no per-target lookup at runtime.
  */
 export interface IAgentSdkPackage {
 	/** Key under `product.agentSdks` — e.g. `'claude'`, `'codex'`. */
 	readonly id: string;
 	/** Env var that, when set, becomes the SDK root and short-circuits the download. */
 	readonly devOverrideEnvVar: string;
-	/**
-	 * True iff this SDK ships separate `*-musl` Linux packages alongside the
-	 * regular `linux-*` ones (Claude does; Codex's Linux binaries are already
-	 * statically musl-linked so it ships a single `linux-*` SKU for both
-	 * libc families).
-	 */
-	readonly hasSeparateMuslLinuxPackage: boolean;
-}
-
-/**
- * `${platform}-${arch}`, optionally suffixed with `-musl` on Linux. Matches
- * the suffix npm uses for the platform `optionalDependencies` packages
- * (`@anthropic-ai/claude-agent-sdk-${target}`, `@openai/codex-${target}`).
- */
-function resolvePlatformArch(pkg: IAgentSdkPackage): string | undefined {
-	const platform = process.platform;
-	const arch = process.arch;
-	if (platform !== 'linux' && platform !== 'darwin' && platform !== 'win32') {
-		return undefined;
-	}
-	if (arch !== 'x64' && arch !== 'arm64') {
-		return undefined;
-	}
-	const base = `${platform}-${arch}`;
-	if (pkg.hasSeparateMuslLinuxPackage && isLinux && isMusl()) {
-		return `${base}-musl`;
-	}
-	return base;
-}
-
-let _muslCached: boolean | undefined;
-/** Linux-only — Node sets `glibcVersionRuntime` only when linked against glibc. */
-function isMusl(): boolean {
-	if (_muslCached !== undefined) {
-		return _muslCached;
-	}
-	try {
-		const report = process.report?.getReport?.();
-		const header = report && (report as { header?: { glibcVersionRuntime?: string } }).header;
-		_muslCached = !header?.glibcVersionRuntime;
-	} catch {
-		_muslCached = false;
-	}
-	return _muslCached;
 }
 
 // #endregion
@@ -116,20 +72,10 @@ export interface IAgentSdkDownloader {
 	/**
 	 * Cheap, synchronous gate used at startup to decide whether to register
 	 * the corresponding agent provider. True iff the dev override is set, OR
-	 * `product.agentSdks?.[pkg.id]` declares a sha256 for the current
-	 * platform. Does NOT trigger a download.
+	 * `product.agentSdks?.[pkg.id]` is populated (which it only is on the
+	 * platform that build packaged for). Does NOT trigger a download.
 	 */
 	isAvailable(pkg: IAgentSdkPackage): boolean;
-
-	/**
-	 * Returns the npm-style `${platform}-${arch}` suffix used by `pkg`'s
-	 * platform `optionalDependencies`, or undefined for unsupported
-	 * (platform, arch) combinations. Honors {@link IAgentSdkPackage.hasSeparateMuslLinuxPackage}
-	 * on Linux musl hosts. Callers that need to locate the platform package
-	 * directory (e.g. to spawn a binary inside it) share this resolution
-	 * with the downloader's internal one.
-	 */
-	resolveSdkTarget(pkg: IAgentSdkPackage): string | undefined;
 }
 
 // #endregion
@@ -143,7 +89,7 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 	declare readonly _serviceBrand: undefined;
 
 	/**
-	 * In-flight downloads keyed by `<pkg>/<sdkVersion>/<sdkTarget>`. Concurrent
+	 * In-flight downloads keyed by `<pkg>/<sdkVersion>`. Concurrent
 	 * `loadSdkRoot` calls in the same process share the same promise so we
 	 * never download the same tarball twice.
 	 */
@@ -167,19 +113,7 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 	) { }
 
 	isAvailable(pkg: IAgentSdkPackage): boolean {
-		if (process.env[pkg.devOverrideEnvVar]) {
-			return true;
-		}
-		const config = this._productService.agentSdks?.[pkg.id];
-		if (!config) {
-			return false;
-		}
-		const target = this.resolveSdkTarget(pkg);
-		return target !== undefined && config.sha256[target] !== undefined;
-	}
-
-	resolveSdkTarget(pkg: IAgentSdkPackage): string | undefined {
-		return resolvePlatformArch(pkg);
+		return !!process.env[pkg.devOverrideEnvVar] || !!this._productService.agentSdks?.[pkg.id];
 	}
 
 	async loadSdkRoot(pkg: IAgentSdkPackage, token: CancellationToken): Promise<string> {
@@ -222,22 +156,9 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 				`no ${pkg.devOverrideEnvVar} dev override set.`,
 			);
 		}
-		const target = this.resolveSdkTarget(pkg);
-		if (!target) {
-			throw new Error(
-				`Cannot load ${pkg.id} SDK: platform ${process.platform}-${process.arch} is not supported.`,
-			);
-		}
-		const expectedSha = config.sha256[target];
-		if (!expectedSha) {
-			const available = Object.keys(config.sha256).sort().join(', ');
-			throw new Error(
-				`Cannot load ${pkg.id} SDK: target \`${target}\` is not in the supported set ` +
-				`[${available}]. Set ${pkg.devOverrideEnvVar} to override.`,
-			);
-		}
+		const expectedSha = config.sha256;
 
-		const cacheDir = this._cacheDir(pkg.id, config.version, target);
+		const cacheDir = this._cacheDir(pkg.id, config.version);
 		const sentinel = URI.joinPath(URI.file(cacheDir), '.complete');
 
 		// Cache hit (always re-verify against product.json sha256).
@@ -252,11 +173,10 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 		}
 
 		// Download (deduped across concurrent callers in the same process).
-		const key = `${pkg.id}/${config.version}/${target}`;
+		const key = `${pkg.id}/${config.version}`;
 		let pending = this._pendingDownloads.get(key);
 		if (!pending) {
-			const url = format2(config.urlTemplate, { sdkVersion: config.version, sdkTarget: target });
-			pending = this._download(pkg, url, expectedSha, cacheDir, sentinel, token).finally(() => {
+			pending = this._download(pkg, config.url, expectedSha, cacheDir, sentinel, token).finally(() => {
 				this._pendingDownloads.delete(key);
 			});
 			this._pendingDownloads.set(key, pending);
@@ -264,14 +184,13 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 		return pending;
 	}
 
-	private _cacheDir(packageId: string, sdkVersion: string, sdkTarget: string): string {
+	private _cacheDir(packageId: string, sdkVersion: string): string {
 		return path.join(
 			this._environmentService.userDataPath,
 			'agent-host',
 			'sdk-cache',
 			packageId,
 			sdkVersion,
-			sdkTarget,
 		);
 	}
 

--- a/src/vs/platform/agentHost/node/agentSdkDownloader.ts
+++ b/src/vs/platform/agentHost/node/agentSdkDownloader.ts
@@ -34,9 +34,10 @@ import { IRequestContext } from '../../../base/parts/request/common/request.js';
  * stays in those modules — the downloader doesn't name the providers it
  * serves.
  *
- * Platform discrimination is done at packaging time: the build patches
- * `product.agentSdks[pkg]` with the single per-platform entry for the
- * platform being packaged, so there is no per-target lookup at runtime.
+ * Platform discrimination is done at packaging time: the build sets
+ * `product.agentSdks[pkg]` to the `{ version, url, sha256 }` appropriate
+ * for the platform being packaged, so there is no per-target lookup at
+ * runtime.
  */
 export interface IAgentSdkPackage {
 	/** Key under `product.agentSdks` — e.g. `'claude'`, `'codex'`. */

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts
@@ -15,15 +15,13 @@ import { AgentHostClaudeSdkRootEnvVar } from '../../common/agentService.js';
 
 /**
  * `@anthropic-ai/claude-agent-sdk` distribution descriptor. Lives in this
- * file because it encodes Claude-specific knowledge — the env-var name and
- * the fact that Claude ships separate `linux-*-musl` packages alongside
- * the regular `linux-*` ones. The downloader consumes this through
- * `IAgentSdkPackage` and never names Claude directly.
+ * file because it encodes Claude-specific knowledge — the env-var name.
+ * The downloader consumes this through `IAgentSdkPackage` and never names
+ * Claude directly.
  */
 export const ClaudeSdkPackage: IAgentSdkPackage = {
 	id: 'claude',
 	devOverrideEnvVar: AgentHostClaudeSdkRootEnvVar,
-	hasSeparateMuslLinuxPackage: true,
 };
 
 export const IClaudeAgentSdkService = createDecorator<IClaudeAgentSdkService>('claudeAgentSdkService');

--- a/src/vs/platform/agentHost/node/claude/roadmap.md
+++ b/src/vs/platform/agentHost/node/claude/roadmap.md
@@ -1293,11 +1293,14 @@ the download.
 **Shape:**
 
 - `product.agentSdks.{claude,codex}` ships a `version`, a `url`, and a
-  single `sha256` string. There is no per-target lookup at runtime: the
-  build pipeline patches `agentSdks` per-platform during packaging, so a
-  `darwin-arm64` build's `product.json` carries only the `darwin-arm64`
-  entry. Codex's Linux entries never carry the `-musl` suffix in their
-  URL because the Codex binary is statically musl-linked.
+  single `sha256` string. There is no per-target map at runtime: the
+  build pipeline patches `agentSdks` per-platform during packaging, so
+  a `darwin-arm64` build's `product.json` contains the URL/sha for the
+  `darwin-arm64` SDK tarball, while a `linux-x64` build contains the
+  URL/sha for the `linux-x64` tarball. The shape on disk is always
+  `{ version, url, sha256 }` — the platform suffix appears in the URL,
+  not in the key. Codex's Linux entries never carry the `-musl` suffix
+  in their URL because the Codex binary is statically musl-linked.
 - `vscode-distro` no longer carries an `agentSdks` fragment — the
   build IS the distribution. OSS `product.json` does not have it either.
 - Tarballs ship as the full `node_modules/` subtree extracted into the

--- a/src/vs/platform/agentHost/node/claude/roadmap.md
+++ b/src/vs/platform/agentHost/node/claude/roadmap.md
@@ -1278,10 +1278,12 @@ Exit criteria: ready to enable for external preview.
 
 ### Phase 15 — SDK distribution via `product.json` + main.vscode-cdn.net
 
-**Status as of 2026-06-09:** Phase 15 has landed in the agent host. The Claude
-and Codex SDK distributions are now declared in `product.json` and downloaded
-on demand by [`agentSdkDownloader.ts`](../agentSdkDownloader.ts) into
-`<userDataPath>/agent-host/sdk-cache/<pkg>/<sdkVersion>/<sdkTarget>/`. The
+**Status as of 2026-06-10:** Runtime shape simplified to per-platform
+`product.json` patching (see
+[`phase15-per-platform-plan.md`](./phase15-per-platform-plan.md)). The
+Claude and Codex SDK distributions are declared in `product.json` and
+downloaded on demand by [`agentSdkDownloader.ts`](../agentSdkDownloader.ts)
+into `<userDataPath>/agent-host/sdk-cache/<pkg>/<sdkVersion>/`. The
 hand-supplied paths (`chat.agentHost.claudeAgent.path` →
 `AgentHostClaudeSdkRootEnvVar`, see
 [`claudeAgentSdkService.ts:148`](./claudeAgentSdkService.ts#L148), and the
@@ -1290,39 +1292,46 @@ the download.
 
 **Shape:**
 
-- `product.agentSdks.{claude,codex}` ships a `version`, a `urlTemplate`
-  with `{sdkVersion}` / `{sdkTarget}` placeholders, and a per-target
-  `sha256` map. `{sdkTarget}` matches the npm `optionalDependencies`
-  suffix (`darwin-arm64`, `linux-x64-musl`, …). Codex's Linux entries
-  never carry the `-musl` suffix because the Codex shim always loads the
-  musl binary regardless of host libc.
-- `vscode-distro` is where `product.agentSdks` is populated; OSS
-  `product.json` does not have it.
+- `product.agentSdks.{claude,codex}` ships a `version`, a `url`, and a
+  single `sha256` string. There is no per-target lookup at runtime: the
+  build pipeline patches `agentSdks` per-platform during packaging, so a
+  `darwin-arm64` build's `product.json` carries only the `darwin-arm64`
+  entry. Codex's Linux entries never carry the `-musl` suffix in their
+  URL because the Codex binary is statically musl-linked.
+- `vscode-distro` no longer carries an `agentSdks` fragment — the
+  build IS the distribution. OSS `product.json` does not have it either.
 - Tarballs ship as the full `node_modules/` subtree extracted into the
   cache directory above. `ClaudeAgentSdkService._loadSdk` and
   `CodexAgent._startConnection` know the package-internal entrypoints
   (`@anthropic-ai/claude-agent-sdk/sdk.mjs`, `@openai/codex/bin/codex.js`)
-  and resolve them off the returned root.
+  and resolve them off the returned root. Codex derives its own
+  `${platform}-${arch}` suffix locally via `codexPackageSuffix()` to
+  construct the binary path; it does NOT read the suffix from
+  `product.json`.
 - Trust: the sha256 in `product.json` (itself inside the signed
   application bundle and covered by `product.checksums`) is the trust
   anchor — CDN tampering fails verification. No separate signed
   manifest.
 - Provider registration is gated on
   `IAgentSdkDownloader.isAvailable(pkg)` — true iff the dev-override
-  env var is set, OR product config has a sha for the current target.
-  If neither, the provider is not registered and never appears in the
+  env var is set, OR `product.agentSdks?.[pkg.id]` is populated. If
+  neither, the provider is not registered and never appears in the
   agent picker (matches the pre-CDN UX).
 
-**Exit criteria (met):**
+**Exit criteria (met for runtime; build is a follow-up PR):**
 - Fresh insiders install can use Claude/Codex without manually
   installing the SDK or setting any path.
-- SDK version bumps are now `vscode-distro` changes that re-pin
-  `product.agentSdks[pkg].version` and the per-target sha256 entries.
+- SDK version bumps are now build-pipeline changes that re-pin
+  `product.agentSdks[pkg]` per platform during packaging.
 - Dev override keeps working for SDK development.
 
 **Build pipeline** — see `build/agent-sdk/` for the tarball production
 and CDN upload tooling, including the deterministic-tar setup that
-makes `verify-determinism.ts` enforceable in CI.
+makes `verify-determinism.ts` enforceable in CI. The inline integration
+into each `packageTask(platform, arch, ...)` so that the gulpfile patches
+`product.json` directly (no `AgentSDK` pipeline stage, no
+`aggregate.ts`) ships in a follow-up PR per
+[`phase15-per-platform-plan.md`](./phase15-per-platform-plan.md) §PR 2.
 
 ### Phase 16 — Eager session materialization at create time
 

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -266,15 +266,15 @@ interface IConnectionReady {
 
 /**
  * `@openai/codex` distribution descriptor. Lives in this file because it
- * encodes Codex-specific knowledge — the env-var name and the fact that
- * Codex's Linux binaries are statically musl-linked, so it ships a single
- * `linux-*` SKU that runs on both glibc and musl hosts. The downloader
- * consumes this through `IAgentSdkPackage` and never names Codex directly.
+ * encodes Codex-specific knowledge — the env-var name. Codex's Linux
+ * binaries are statically musl-linked so a single `linux-*` SKU runs on
+ * both glibc and musl hosts; the runtime never needs to know that — the
+ * build picks the right SKU per platform. The downloader consumes this
+ * through `IAgentSdkPackage` and never names Codex directly.
  */
 export const CodexSdkPackage: IAgentSdkPackage = {
 	id: 'codex',
 	devOverrideEnvVar: AgentHostCodexAgentSdkRootEnvVar,
-	hasSeparateMuslLinuxPackage: false,
 };
 
 export class CodexAgent extends Disposable implements IAgent {
@@ -542,7 +542,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		// `ELECTRON_RUN_AS_NODE` round-trip when the agent host runs as an
 		// Electron utility process.
 		const root = await this._agentSdkDownloader.loadSdkRoot(CodexSdkPackage, CancellationToken.None);
-		const codexTarget = this._agentSdkDownloader.resolveSdkTarget(CodexSdkPackage);
+		const codexTarget = codexPackageSuffix(process.platform, process.arch);
 		if (!codexTarget) {
 			throw new Error(`Codex: unsupported platform ${process.platform}-${process.arch}`);
 		}
@@ -1503,11 +1503,28 @@ function parseBinaryArgs(json: string | undefined): string[] {
 }
 
 /**
+ * The suffix Codex uses for its platform `optionalDependencies` packages
+ * (`@openai/codex-${suffix}`). Codex's Linux binaries are statically
+ * musl-linked and ship under the same `linux-<arch>` package regardless of
+ * host libc, so this never returns a `-musl` suffix.
+ *
+ * Returns undefined for unsupported `(platform, arch)` combinations — the
+ * caller surfaces the error.
+ */
+export function codexPackageSuffix(platform: NodeJS.Platform, arch: string): string | undefined {
+	if ((platform !== 'linux' && platform !== 'darwin' && platform !== 'win32') ||
+		(arch !== 'x64' && arch !== 'arm64')) {
+		return undefined;
+	}
+	return `${platform}-${arch}`;
+}
+
+/**
  * Mirrors the triple table inside `@openai/codex/bin/codex.js` so we can spawn
  * the native binary at `vendor/<triple>/bin/codex` directly without going
  * through the JS shim launcher.
  */
-function codexBinaryTriple(sdkTarget: string): string | undefined {
+export function codexBinaryTriple(sdkTarget: string): string | undefined {
 	switch (sdkTarget) {
 		case 'linux-x64': return 'x86_64-unknown-linux-musl';
 		case 'linux-arm64': return 'aarch64-unknown-linux-musl';

--- a/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
@@ -93,7 +93,7 @@ function makeEnvService(userDataPath: string): INativeEnvironmentService {
 	return { userDataPath, args: { 'force-disable-user-env': true } as never } as unknown as INativeEnvironmentService;
 }
 
-function makeProductService(config: { version: string; urlTemplate: string; sha256: Record<string, string> } | undefined): IProductService {
+function makeProductService(config: { version: string; url: string; sha256: string } | undefined): IProductService {
 	return {
 		agentSdks: config ? { claude: config } : undefined,
 	} as unknown as IProductService;
@@ -157,13 +157,11 @@ suite('AgentSdkDownloader', () => {
 		}
 	});
 
-	function makeDownloader(productConfig?: { version?: string; sha256?: string; urlTemplate?: string }) {
+	function makeDownloader(productConfig?: { version?: string; sha256?: string; url?: string }) {
 		const config = {
 			version: productConfig?.version ?? '1.0.0',
-			urlTemplate: productConfig?.urlTemplate ?? `http://127.0.0.1:${server.port}/{sdkVersion}/{sdkTarget}.tgz`,
-			sha256: productConfig?.sha256
-				? { [`${process.platform}-${process.arch}`]: productConfig.sha256 }
-				: { [`${process.platform}-${process.arch}`]: fixture.tarballSha },
+			url: productConfig?.url ?? `http://127.0.0.1:${server.port}/sdk.tgz`,
+			sha256: productConfig?.sha256 ?? fixture.tarballSha,
 		};
 		return new AgentSdkDownloader(
 			makeEnvService(userDataPath),
@@ -197,25 +195,9 @@ suite('AgentSdkDownloader', () => {
 		assert.strictEqual(downloader.isAvailable(ClaudeSdkPackage), true);
 	});
 
-	test('isAvailable: true when product config has sha for current target', () => {
+	test('isAvailable: true when product config is populated', () => {
 		const downloader = makeDownloader();
 		assert.strictEqual(downloader.isAvailable(ClaudeSdkPackage), true);
-	});
-
-	test('isAvailable: false when product config has no sha for current target', () => {
-		const cfg = {
-			version: '1.0.0',
-			urlTemplate: `http://127.0.0.1:${server.port}/{sdkVersion}/{sdkTarget}.tgz`,
-			sha256: { 'unsupported-platform-arch': 'deadbeef' },
-		};
-		const downloader = new AgentSdkDownloader(
-			makeEnvService(userDataPath),
-			makeProductService(cfg),
-			makeRequestService(disposables),
-			makeFileService(disposables),
-			new NullLogService(),
-		);
-		assert.strictEqual(downloader.isAvailable(ClaudeSdkPackage), false);
 	});
 
 	test('loadSdkRoot: dev override returns the path unchanged', async () => {
@@ -272,7 +254,7 @@ suite('AgentSdkDownloader', () => {
 			/sha256 mismatch|Failed to download/,
 		);
 		// Cache dir absent — only its parent might exist.
-		const target = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude', '1.0.0', `${process.platform}-${process.arch}`);
+		const target = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude', '1.0.0');
 		assert.strictEqual(fs.existsSync(target), false);
 	});
 
@@ -287,25 +269,6 @@ suite('AgentSdkDownloader', () => {
 		await assert.rejects(
 			() => downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
 			/no `product\.agentSdks\.claude` configured/,
-		);
-	});
-
-	test('loadSdkRoot: unsupported target throws with supported list', async () => {
-		const cfg = {
-			version: '1.0.0',
-			urlTemplate: `http://127.0.0.1:${server.port}/{sdkVersion}/{sdkTarget}.tgz`,
-			sha256: { 'unsupported-platform-arch': 'deadbeef' },
-		};
-		const downloader = new AgentSdkDownloader(
-			makeEnvService(userDataPath),
-			makeProductService(cfg),
-			makeRequestService(disposables),
-			makeFileService(disposables),
-			new NullLogService(),
-		);
-		await assert.rejects(
-			() => downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
-			/is not in the supported set/,
 		);
 	});
 
@@ -326,8 +289,8 @@ suite('AgentSdkDownloader', () => {
 				makeEnvService(userDataPath),
 				makeProductService({
 					version: '1.0.0',
-					urlTemplate: `http://127.0.0.1:${port}/{sdkVersion}/{sdkTarget}.tgz`,
-					sha256: { [`${process.platform}-${process.arch}`]: fixture.tarballSha },
+					url: `http://127.0.0.1:${port}/sdk.tgz`,
+					sha256: fixture.tarballSha,
 				}),
 				makeRequestService(disposables),
 				makeFileService(disposables),
@@ -340,7 +303,7 @@ suite('AgentSdkDownloader', () => {
 			cts.cancel();
 			await assert.rejects(() => promise, /Cancel|cancel|Failed to download/);
 			// No half-extracted dir left around.
-			const targetParent = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude', '1.0.0');
+			const targetParent = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude');
 			const leftover = fs.existsSync(targetParent)
 				? (await fsp.readdir(targetParent)).filter(f => f.includes('.tmp.'))
 				: [];
@@ -370,7 +333,7 @@ suite('AgentSdkDownloader', () => {
 
 	test('loadSdkRoot: rename-loser path returns existing cache when winner already published', async () => {
 		const downloader = makeDownloader();
-		const target = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude', '1.0.0', `${process.platform}-${process.arch}`);
+		const target = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude', '1.0.0');
 
 		// Pre-populate the cache as if a "winner" already extracted it.
 		await fsp.mkdir(target, { recursive: true });

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -668,7 +668,6 @@ function stubAgentSdkDownloader(): IAgentSdkDownloader {
 		_serviceBrand: undefined,
 		isAvailable: () => false,
 		loadSdkRoot: () => { throw new Error('test stub: downloader.loadSdkRoot should not be called'); },
-		resolveSdkTarget: () => undefined,
 	};
 }
 

--- a/src/vs/platform/agentHost/test/node/codex/codexPackagePaths.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPackagePaths.test.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { codexBinaryTriple, codexPackageSuffix } from '../../../node/codex/codexAgent.js';
+
+suite('codex package paths', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('codexPackageSuffix', () => {
+
+		test('every supported (platform, arch) returns the npm optionalDependencies suffix', () => {
+			// The downloader and the build pipeline both rely on the runtime
+			// reaching exactly one of these strings. New supported platforms
+			// must update this table, the build's `getSdkTargetForBuild`, AND
+			// codexBinaryTriple in lockstep.
+			assert.deepStrictEqual({
+				'darwin-x64': codexPackageSuffix('darwin', 'x64'),
+				'darwin-arm64': codexPackageSuffix('darwin', 'arm64'),
+				'linux-x64': codexPackageSuffix('linux', 'x64'),
+				'linux-arm64': codexPackageSuffix('linux', 'arm64'),
+				'win32-x64': codexPackageSuffix('win32', 'x64'),
+				'win32-arm64': codexPackageSuffix('win32', 'arm64'),
+			}, {
+				'darwin-x64': 'darwin-x64',
+				'darwin-arm64': 'darwin-arm64',
+				'linux-x64': 'linux-x64',
+				'linux-arm64': 'linux-arm64',
+				'win32-x64': 'win32-x64',
+				'win32-arm64': 'win32-arm64',
+			});
+		});
+
+		test('never returns a -musl suffix on Linux (Codex is statically musl-linked)', () => {
+			// Regression guard: at one point during the per-platform refactor
+			// the helper still appended `-musl` for musl Linux hosts. Codex's
+			// `linux-<arch>` package serves both glibc and musl, so the suffix
+			// must NOT be added.
+			assert.strictEqual(codexPackageSuffix('linux', 'x64'), 'linux-x64');
+			assert.strictEqual(codexPackageSuffix('linux', 'arm64'), 'linux-arm64');
+		});
+
+		test('returns undefined for unsupported platforms and architectures', () => {
+			assert.strictEqual(codexPackageSuffix('freebsd' as NodeJS.Platform, 'x64'), undefined);
+			assert.strictEqual(codexPackageSuffix('aix' as NodeJS.Platform, 'arm64'), undefined);
+			assert.strictEqual(codexPackageSuffix('darwin', 'ia32'), undefined);
+			assert.strictEqual(codexPackageSuffix('linux', 'arm'), undefined);
+			assert.strictEqual(codexPackageSuffix('win32', 'mips'), undefined);
+		});
+	});
+
+	suite('codexBinaryTriple', () => {
+
+		test('every suffix produced by codexPackageSuffix maps to a rust target triple', () => {
+			// The two helpers are paired: the downloader picks a package via
+			// codexPackageSuffix, then this function tells _startConnection
+			// which `vendor/<triple>/bin/codex` exists inside it. A suffix
+			// without a matching triple would crash at spawn — so this test
+			// guards the union.
+			assert.deepStrictEqual({
+				'linux-x64': codexBinaryTriple('linux-x64'),
+				'linux-arm64': codexBinaryTriple('linux-arm64'),
+				'darwin-x64': codexBinaryTriple('darwin-x64'),
+				'darwin-arm64': codexBinaryTriple('darwin-arm64'),
+				'win32-x64': codexBinaryTriple('win32-x64'),
+				'win32-arm64': codexBinaryTriple('win32-arm64'),
+			}, {
+				'linux-x64': 'x86_64-unknown-linux-musl',
+				'linux-arm64': 'aarch64-unknown-linux-musl',
+				'darwin-x64': 'x86_64-apple-darwin',
+				'darwin-arm64': 'aarch64-apple-darwin',
+				'win32-x64': 'x86_64-pc-windows-msvc',
+				'win32-arm64': 'aarch64-pc-windows-msvc',
+			});
+		});
+
+		test('returns undefined for unknown suffixes', () => {
+			assert.strictEqual(codexBinaryTriple('linux-x64-musl'), undefined);
+			assert.strictEqual(codexBinaryTriple('darwin-arm'), undefined);
+			assert.strictEqual(codexBinaryTriple(''), undefined);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Replaces the multi-target `agentSdks` shape (`urlTemplate` + per-target `sha256` map) with a single per-platform entry: `{ version, url, sha256 }`. Each per-platform build's `product.json` carries only the entry for the platform it targets, so the runtime drops all platform-discrimination logic.

This is **PR 1** of two — the runtime simplification. PR 2 will move the build-side production inline into each `packageTask(platform, arch, ...)` so the gulpfile patches `product.json` directly (dropping the `AgentSDK` pipeline stage and `aggregate.ts`).

## Cascade of deletions

- `IAgentSdkProductConfig`: `{ urlTemplate, sha256: { [target]: string } }` → `{ url, sha256 }`
- `AgentSdkDownloader`: drop `resolvePlatformArch`, `isMusl`, `_muslCached`, `format2` import, `resolveSdkTarget` method, per-target sha lookup
- `IAgentSdkPackage`: drop `hasSeparateMuslLinuxPackage` field
- Cache path: `<pkg>/<sdkVersion>/` (was `<pkg>/<sdkVersion>/<sdkTarget>/`)
- `CodexAgent`: replace `_agentSdkDownloader.resolveSdkTarget()` with a local `codexPackageSuffix(platform, arch)` helper (always `${platform}-${arch}` — Codex's static-musl Linux binary covers both libc families at runtime, so the runtime never needs to know about the musl distinction)

OSS behavior is unchanged: when `product.json` has no `agentSdks` field, providers don't register. Dev override env vars (`AgentHostClaudeSdkRootEnvVar` / `AgentHostCodexAgentSdkRootEnvVar`) continue to work.

## Test plan

- [x] `npm run compile-check-ts-native` clean
- [x] `npm run valid-layers-check` clean
- [x] Unit tests: `AgentSdkDownloader` (12 passing, down from 14 — dropped 2 platform-mapping tests), `ClaudeAgent` (123 passing), `Codex*` (17 passing), new `codex package paths` (5 passing — `codexPackageSuffix` table + Linux-no-musl regression guard, `codexBinaryTriple` table, undefined cases)
- [x] E2E dev-override path: launched Code OSS Agents window with `VSCODE_AGENT_HOST_CLAUDE_SDK_ROOT=...`; agent host log shows `using dev override at ...`; sent prompt → SDK result `{"result":"ok","subtype":"success","is_error":false}`; workbench rendered "ok"
- [x] E2E real download path: built fixture tarball from real `node_modules/@anthropic-ai/claude-agent-sdk*`, served from a loopback HTTP server, injected `agentSdks.claude = { version, url, sha256 }` via `product.overrides.json`. Agent host log shows `downloading from http://127.0.0.1:.../sdk.tgz` → `downloaded + verified in 3s`. Cache landed at `sdk-cache/claude/0.0.0-phase15-fixture/` (no `<sdkTarget>` segment — proves new path). Server log shows exactly 1 `GET /sdk.tgz`. Sent prompt → SDK result `{"result":"downloaded","subtype":"success","is_error":false}`; workbench rendered "downloaded"

🤖 Generated with [Claude Code](https://claude.com/claude-code)