### PR TITLE
Agents window: keep editors open across untitled→committed session replacement

### DIFF
--- a/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
@@ -22,8 +22,8 @@ import { IEditorService } from '../../../../workbench/services/editor/common/edi
 import { IWorkbenchLayoutService, Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { IPaneCompositePartService } from '../../../../workbench/services/panecomposite/browser/panecomposite.js';
 import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
-import { IActiveSession, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsViewService } from '../../../browser/sessionsViewService.js';
+import { IActiveSession, ISessionReplaceEvent, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { SessionStatus } from '../../../services/sessions/common/session.js';
 import { CHANGES_VIEW_ID } from '../../changes/common/changes.js';
 import { SESSIONS_FILES_CONTAINER_ID } from '../../files/browser/files.contribution.js';
@@ -63,6 +63,15 @@ export class LayoutController extends Disposable {
 	private readonly _panelVisibilityBySession = new ResourceMap<boolean>();
 	private readonly _viewStateBySession: ResourceMap<ISessionViewState>;
 	private readonly _workingSets: ResourceMap<IEditorWorkingSet>;
+	/**
+	 * In-flight session replacements (e.g. an untitled session being committed
+	 * to a real backend session). Populated by the `onWillReplaceSession`
+	 * subscription and consumed by the working-set `runOnChange` callback so
+	 * the active-session swap that follows a replace does not get treated as
+	 * a user-initiated session navigation. Keys are the `from.resource` of
+	 * the replace; values are the `to.resource`.
+	 */
+	private readonly _pendingReplacements = new ResourceMap<URI>();
 	private readonly _workingSetSequencer = new Sequencer();
 	private readonly _useModalConfigObs;
 
@@ -290,8 +299,27 @@ export class LayoutController extends Disposable {
 
 			// Session changed (save, apply)
 			reader.store.add(runOnChange(activeSessionForWorkingSet, (session, previousSession) => {
-				// Save working set for previous session (skip for untitled sessions)
-				if (previousSession && previousSession.status.read(undefined) !== SessionStatus.Untitled) {
+				// Skip both save and apply for in-place session replacements
+				// (e.g. an untitled session being committed to a real backend
+				// session after its first turn). The `onWillReplaceSession`
+				// handler in the constructor already migrated the resource-
+				// keyed state from `from.resource` to `to.resource`, and the
+				// workbench editors that were open under the untitled session
+				// should remain in place — saving here would persist them
+				// under the now-orphan untitled URI, and applying here would
+				// (when no working set is present) call `applyWorkingSet
+				// ('empty')` and close every editor, including any AI
+				// customizations editor the user had open.
+				if (previousSession && session) {
+					const expectedTo = this._pendingReplacements.get(previousSession.resource);
+					if (expectedTo && isEqual(expectedTo, session.resource)) {
+						this._pendingReplacements.delete(previousSession.resource);
+						return;
+					}
+				}
+
+				// Save working set for previous session.
+				if (previousSession) {
 					this._saveWorkingSet(previousSession.resource);
 				}
 
@@ -311,6 +339,35 @@ export class LayoutController extends Disposable {
 				}
 			}));
 		}));
+
+		// Session replacements (e.g. untitled→committed) must remap all
+		// resource-keyed per-session state from `from.resource` to
+		// `to.resource` BEFORE the `activeSession` observable swaps —
+		// `onWillReplaceSession` fires synchronously before the swap so this
+		// listener runs first. Registered outside the `useModal` autorun so
+		// the state stays consistent across `useModal` toggles.
+		this._register(this._sessionManagementService.onWillReplaceSession(e => this._onWillReplaceSession(e)));
+	}
+
+	private _onWillReplaceSession({ from, to }: ISessionReplaceEvent): void {
+		if (isEqual(from.resource, to.resource)) {
+			return;
+		}
+
+		this._pendingReplacements.set(from.resource, to.resource);
+		this._remapResourceKey(this._workingSets, from.resource, to.resource);
+		this._remapResourceKey(this._viewStateBySession, from.resource, to.resource);
+		this._remapResourceKey(this._panelVisibilityBySession, from.resource, to.resource);
+		this._remapResourceKey(this._pendingTurnStateByResource, from.resource, to.resource);
+	}
+
+	private _remapResourceKey<T>(map: ResourceMap<T>, from: URI, to: URI): void {
+		const value = map.get(from);
+		if (value === undefined) {
+			return;
+		}
+		map.delete(from);
+		map.set(to, value);
 	}
 
 	// --- Auxiliary bar ---

--- a/src/vs/sessions/contrib/layout/test/browser/sessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/sessionLayoutController.test.ts
@@ -24,8 +24,8 @@ import { IPartVisibilityChangeEvent, IWorkbenchLayoutService, Parts } from '../.
 import { IPaneCompositePartService } from '../../../../../workbench/services/panecomposite/browser/panecomposite.js';
 import { IPaneComposite } from '../../../../../workbench/common/panecomposite.js';
 import { IViewsService } from '../../../../../workbench/services/views/common/viewsService.js';
-import { IActiveSession, ISessionsChangeEvent, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsViewService } from '../../../../browser/sessionsViewService.js';
+import { IActiveSession, ISessionReplaceEvent, ISessionsChangeEvent, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { IChat, ISessionFileChange, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { LayoutController } from '../../browser/sessionLayoutController.js';
 import { CHANGES_VIEW_ID } from '../../../changes/common/changes.js';
@@ -105,6 +105,7 @@ suite('LayoutController', () => {
 	const store = new DisposableStore();
 	let activeSessionObs: ReturnType<typeof observableValue<IActiveSession | undefined>>;
 	let onDidChangeSessions: Emitter<ISessionsChangeEvent>;
+	let onWillReplaceSession: Emitter<ISessionReplaceEvent>;
 	let onDidChangePartVisibility: Emitter<IPartVisibilityChangeEvent>;
 	let onDidSubmitRequest: Emitter<{ chatSessionResource: URI }>;
 	let storageService: TestStorageService;
@@ -113,6 +114,8 @@ suite('LayoutController', () => {
 	let openedViews: string[];
 	let setPartHiddenCalls: { hidden: boolean; part: Parts }[];
 	let activePaneCompositeId: string | undefined;
+	let visibleEditorsRef: { value: number };
+	let appliedWorkingSets: (IEditorWorkingSet | 'empty')[];
 
 	interface ICreateOptions {
 		readonly useModal?: 'off' | 'some' | 'all';
@@ -135,10 +138,12 @@ suite('LayoutController', () => {
 
 		activeSessionObs = observableValue<IActiveSession | undefined>('activeSession', undefined);
 		onDidChangeSessions = store.add(new Emitter<ISessionsChangeEvent>());
+		onWillReplaceSession = store.add(new Emitter<ISessionReplaceEvent>());
 
 		instaService.stub(ISessionsManagementService, new class extends mock<ISessionsManagementService>() {
 			override activeSession = activeSessionObs;
 			override readonly onDidChangeSessions = onDidChangeSessions.event;
+			override readonly onWillReplaceSession = onWillReplaceSession.event;
 			override getSessions() { return []; }
 		});
 		instaService.stub(ISessionsViewService, new class extends mock<ISessionsViewService>() {
@@ -199,13 +204,18 @@ suite('LayoutController', () => {
 			}
 		});
 
+		visibleEditorsRef = { value: 0 };
 		instaService.stub(IEditorService, new class extends mock<IEditorService>() {
-			override get visibleEditors() { return []; }
+			override get visibleEditors() { return new Array(visibleEditorsRef.value); }
 		});
 
+		appliedWorkingSets = [];
 		instaService.stub(IEditorGroupsService, new class extends mock<IEditorGroupsService>() {
 			override saveWorkingSet(name: string): IEditorWorkingSet { return { id: name, name }; }
-			override async applyWorkingSet() { return true; }
+			override async applyWorkingSet(workingSet: IEditorWorkingSet | 'empty') {
+				appliedWorkingSets.push(workingSet);
+				return true;
+			}
 			override deleteWorkingSet() { }
 		});
 
@@ -450,6 +460,48 @@ suite('LayoutController', () => {
 		});
 	});
 
+	// --- Editor working sets ---
+
+	test('keeps editors open across an untitled→committed session replacement', async () => {
+		createLayoutController({ useModal: 'some' });
+
+		// User opens an untitled session and pins a couple of editors (e.g. the
+		// AI customizations editor) into the main editor area.
+		const noWorkspace = { uri: URI.file('/x'), label: 't', icon: Codicon.repo, folders: [], requiresWorkspaceTrust: false, isVirtualWorkspace: false };
+		const untitled = makeSession(URI.parse('untitled-session:1'), { status: SessionStatus.Untitled, workspace: noWorkspace });
+		activeSessionObs.set(untitled, undefined);
+		visibleEditorsRef.value = 2;
+
+		// Provider commits the untitled session to a real backend session:
+		// `onWillReplaceSession` fires synchronously, then the active session
+		// observable swaps to the committed session (mirrors the production
+		// `SessionsManagementService.onDidReplaceSession` ordering).
+		const committed = makeSession(URI.parse('committed-session:abc'), { workspace: noWorkspace });
+		appliedWorkingSets = [];
+		onWillReplaceSession.fire({ from: untitled, to: committed });
+		activeSessionObs.set(committed, undefined);
+
+		// `applyWorkingSet('empty')` would have closed the editors — the fix
+		// makes the replacement-driven swap a no-op for working sets.
+		assert.deepStrictEqual(appliedWorkingSets, [], 'no working set should be applied on replacement');
+	});
+
+	test('applies working set on user-initiated session switch', async () => {
+		createLayoutController({ useModal: 'some' });
+
+		const noWorkspace = { uri: URI.file('/x'), label: 't', icon: Codicon.repo, folders: [], requiresWorkspaceTrust: false, isVirtualWorkspace: false };
+		const session1 = makeSession(URI.parse('session:1'), { workspace: noWorkspace });
+		const session2 = makeSession(URI.parse('session:2'), { workspace: noWorkspace });
+
+		activeSessionObs.set(session1, undefined);
+		appliedWorkingSets = [];
+		activeSessionObs.set(session2, undefined);
+
+		// Sanity check: a regular session switch should still drive an
+		// applyWorkingSet call (the fix must not regress this path).
+		assert.strictEqual(appliedWorkingSets.length, 1, 'applyWorkingSet should be called on normal session switch');
+	});
+
 	test('migrates legacy sessions.workingSets key', () => {
 		const legacyData = JSON.stringify([{
 			sessionResource: 'session:legacy',
@@ -468,6 +520,7 @@ suite('LayoutController', () => {
 		instaService.stub(ISessionsManagementService, new class extends mock<ISessionsManagementService>() {
 			override activeSession = activeSession;
 			override readonly onDidChangeSessions = Event.None;
+			override readonly onWillReplaceSession = Event.None;
 			override getSessions() { return []; }
 		});
 		instaService.stub(ISessionsViewService, new class extends mock<ISessionsViewService>() {

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -14,7 +14,7 @@ import { ChatAgentLocation } from '../../../../workbench/contrib/chat/common/con
 import { IChatWidgetHistoryService } from '../../../../workbench/contrib/chat/common/widget/chatWidgetHistoryService.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { ActiveSessionProviderIdContext, ActiveSessionTypeContext, IsActiveSessionArchivedContext, ActiveSessionWorkspaceIsVirtualContext, IsNewChatSessionContext } from '../../../common/contextkeys.js';
-import { ActiveSessionSupportsMultiChatContext, IActiveSession, ICreateNewSessionOptions, IProviderSessionType, ISendRequestOptions, ISendRequestSentEvent, ISessionsChangeEvent, ISessionsManagementService } from '../common/sessionsManagement.js';
+import { ActiveSessionSupportsMultiChatContext, IActiveSession, ICreateNewSessionOptions, IProviderSessionType, ISendRequestOptions, ISendRequestSentEvent, ISessionReplaceEvent, ISessionsChangeEvent, ISessionsManagementService } from '../common/sessionsManagement.js';
 import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from './sessionsProvidersService.js';
 import { ISessionChangeEvent, ISessionsProvider } from '../common/sessionsProvider.js';
 import { IChat, ISession, ISessionWorkspace, SessionStatus, ISessionType } from '../common/session.js';
@@ -26,6 +26,8 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 	private readonly _onDidChangeSessions = this._register(new Emitter<ISessionsChangeEvent>());
 	readonly onDidChangeSessions: Event<ISessionsChangeEvent> = this._onDidChangeSessions.event;
+	private readonly _onWillReplaceSession = this._register(new Emitter<ISessionReplaceEvent>());
+	readonly onWillReplaceSession: Event<ISessionReplaceEvent> = this._onWillReplaceSession.event;
 	private readonly _onDidStartSession = this._register(new Emitter<ISession>());
 	readonly onDidStartSession: Event<ISession> = this._onDidStartSession.event;
 
@@ -193,6 +195,13 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 	}
 
 	private _handleDidReplaceSession(from: ISession, to: ISession): void {
+		// Fire `onWillReplaceSession` BEFORE `onDidReplaceSession` so listeners
+		// can migrate any resource-keyed state from `from.resource` to
+		// `to.resource` before downstream observers — including the view
+		// service that swaps the active-session observable — react to the
+		// replacement.
+		this._onWillReplaceSession.fire({ from, to });
+
 		this.chatWidgetHistoryService.moveHistory(ChatAgentLocation.Chat, from.sessionId, to.sessionId);
 		// Notify the view service so it can update the visible grid slot.
 		this._onDidReplaceSession.fire({ from, to });

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -88,6 +88,20 @@ export interface IToggleSessionStickinessEvent {
 }
 
 /**
+ * Payload for {@link ISessionsManagementService.onWillReplaceSession}.
+ *
+ * Fired when an existing session is replaced in-place by another (e.g. an
+ * untitled session being replaced by its committed backend session after the
+ * first turn). The `from` and `to` sessions typically have different
+ * {@link ISession.resource} (and possibly different {@link ISession.sessionId})
+ * values.
+ */
+export interface ISessionReplaceEvent {
+	readonly from: ISession;
+	readonly to: ISession;
+}
+
+/**
  * An active session extends {@link ISession} with the currently focused chat.
  */
 export interface IActiveSession extends ISession {
@@ -165,6 +179,18 @@ export interface ISessionsManagementService {
 	 * Fires when sessions change across any provider.
 	 */
 	readonly onDidChangeSessions: Event<ISessionsChangeEvent>;
+
+	/**
+	 * Fires synchronously immediately before an existing session is replaced
+	 * by another (e.g. an untitled session being replaced by its committed
+	 * backend session). Listeners run BEFORE the {@link activeSession}
+	 * observable swaps to the new session, so they can migrate any
+	 * resource-keyed state from {@link ISessionReplaceEvent.from} to
+	 * {@link ISessionReplaceEvent.to} before downstream observers react to
+	 * the swap.
+	 */
+	readonly onWillReplaceSession: Event<ISessionReplaceEvent>;
+
 	/**
 	 * Fires when a brand-new session is started by this window via
 	 * {@link sendNewChatRequest}.

--- a/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
@@ -88,6 +88,7 @@ class MockSessionStore implements ISessionsManagementService {
 	readonly activeSession = observableValue<IActiveSession | undefined>('test.activeSession', undefined);
 	readonly visibleSessions = observableValue<readonly IActiveSession[]>('test.visibleSessions', []);
 	readonly onDidChangeSessions = Event.None;
+	readonly onWillReplaceSession = Event.None;
 	readonly onDidStartSession = Event.None;
 	readonly onDidChangeSessionTypes = Event.None;
 	readonly onWillSendRequest = Event.None;


### PR DESCRIPTION
:robot: AI Assisted PR 

## Bug

Repro in the Agents window (with `workbench.editor.useModal !== 'all'`):

1. Start a new chat session.
2. While the session is running its first turn, open the AI Customizations editor.
3. After the agent finishes responding, the changes view auto-opens. A few moments later, the customizations editor closes on its own.

## Root cause

When the untitled session commits to a real backend session after the first turn, the provider fires `onDidReplaceSession({from, to})`. `SessionsManagementService._handleDidReplaceSession` fires the management-level `onDidReplaceSession`, the view service reacts by calling `_visibility.updateSession(from, to)`, and the `activeSession` observable swaps to the committed session.

`LayoutController`'s working-set `runOnChange` treats that swap as a user-initiated session switch. With no working set saved for the new resource, it calls `applyWorkingSet('empty')` — which closes every editor in the main editor part, including any AI customizations editor the user had opened.

## Fix

1. **New event:** `ISessionsManagementService.onWillReplaceSession` (payload: `ISessionReplaceEvent` = `{ from, to }`), fired by `_handleDidReplaceSession` *before* `onDidReplaceSession` — and therefore before the view service swaps the active session.
2. **Layout controller subscribes** and, on each replacement, migrates all four resource-keyed maps (`_workingSets`, `_viewStateBySession`, `_panelVisibilityBySession`, `_pendingTurnStateByResource`) from `from.resource` to `to.resource`, plus records the transition in a new `_pendingReplacements` map.
3. **`runOnChange` checks `_pendingReplacements`** and skips both save and apply for the replacement-driven swap. Editors stay in place; any per-session state remains correctly keyed under the committed resource for future session navigation.

## Why prior approaches didn't work

| Approach | Why it fails |
|---|---|
| `previousSession.status === Untitled` guard | Status flips to `InProgress` at the start of `_sendFirstChat` (see `copilotChatSessionsProvider.ts:1952`, `baseAgentHostSessionsProvider.ts:1866`), long before the replace fires. The guard is dead code on the replace path. |
| URI prefix check (`/untitled-`) | `baseAgentHostSessionsProvider.ts:721` creates untitled resources as `/{uuid}` with no prefix, so this silently misses Cloud/Remote agent replaces. |
| Subscribing to `onDidReplaceSession` (existing event) | Too late — the view service already swapped the active session by the time other subscribers run. |

This was validated independently by three rubber-duck subagents (Claude Opus, GPT-5.3-Codex, Gemini 3.1 Pro) and all converged on the pre-replace event design.

## Tests

Adds two focused tests in `sessionLayoutController.test.ts` using `useModal: 'some'` (so the working-set autorun is actually engaged — the existing tests use `'all'` which short-circuits that branch):

- `keeps editors open across an untitled→committed session replacement` — fires `onWillReplaceSession`, swaps the active session, asserts no `applyWorkingSet` call.
- `applies working set on user-initiated session switch` — sanity check that the normal switch path is not regressed.

## Validation

- `npm run compile-check-ts-native` — clean
- `npm run valid-layers-check` — clean

## How to verify locally

1. Set `"workbench.editor.useModal": "some"` in settings.
2. In the Agents window, start a new chat session (CLI or Cloud agent).
3. While the first turn is streaming, open the AI Customizations editor.
4. Wait for the response to finish and for the changes view to auto-open.
5. **Expected:** the AI Customizations editor stays open. (Before this fix, it closed a few seconds later when the CLI committed the session.)