### PR TITLE
Add AI-generated Agent Host session titles

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
+++ b/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
@@ -1,0 +1,184 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken, CancellationTokenSource } from '../../../base/common/cancellation.js';
+import { Disposable } from '../../../base/common/lifecycle.js';
+import { URI } from '../../../base/common/uri.js';
+import { ILogService } from '../../log/common/log.js';
+import { ISessionDataService } from '../common/sessionDataService.js';
+import { ActionType } from '../common/state/sessionActions.js';
+import { type URI as ProtocolURI } from '../common/state/sessionState.js';
+import { AgentHostStateManager } from './agentHostStateManager.js';
+import { ICopilotApiService, type ICopilotUtilityChatMessage } from './shared/copilotApiService.js';
+
+const MAX_TITLE_LENGTH = 200;
+
+export interface IAgentHostSessionTitleControllerOptions {
+	readonly sessionDataService: ISessionDataService;
+	readonly getGitHubCopilotToken?: () => string | undefined;
+	readonly copilotApiService?: ICopilotApiService;
+}
+
+export class AgentHostSessionTitleController extends Disposable {
+
+	private readonly _titleGenerationCancellationSources = new Map<ProtocolURI, CancellationTokenSource>();
+
+	constructor(
+		private readonly _stateManager: AgentHostStateManager,
+		private readonly _options: IAgentHostSessionTitleControllerOptions,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+	}
+
+	seedTitleFromFirstMessage(channel: ProtocolURI, userPrompt: string): void {
+		const state = this._stateManager.getSessionState(channel);
+		const fallbackTitle = userPrompt.trim().replace(/\s+/g, ' ').slice(0, 200);
+		if (!state || state.turns.length !== 0 || state.summary.title || fallbackTitle.length === 0) {
+			return;
+		}
+
+		this._stateManager.dispatchServerAction(channel, {
+			type: ActionType.SessionTitleChanged,
+			title: fallbackTitle,
+		});
+		this._generateTitleSoon(channel, userPrompt, fallbackTitle);
+	}
+
+	cancelTitleGeneration(session: ProtocolURI): void {
+		this._cancelTitleGeneration(session);
+	}
+
+	private _generateTitleSoon(channel: ProtocolURI, userPrompt: string, fallbackTitle: string): void {
+		this._cancelTitleGeneration(channel);
+		const source = new CancellationTokenSource();
+		this._titleGenerationCancellationSources.set(channel, source);
+		void this._generateTitle(channel, userPrompt, fallbackTitle, source.token).catch(err => {
+			if (!source.token.isCancellationRequested) {
+				this._logService.warn(`[AgentHostSessionTitleController] Failed to apply generated title for ${channel}`, err);
+			}
+		}).finally(() => {
+			if (this._titleGenerationCancellationSources.get(channel) === source) {
+				this._titleGenerationCancellationSources.delete(channel);
+				source.dispose();
+			}
+		});
+	}
+
+	private async _generateTitle(channel: ProtocolURI, userPrompt: string, fallbackTitle: string, token: CancellationToken): Promise<void> {
+		const generatedTitle = await this._generateTitleFromPrompt(userPrompt, token);
+		if (token.isCancellationRequested || !generatedTitle) {
+			return;
+		}
+
+		const state = this._stateManager.getSessionState(channel);
+		if (!state || state.summary.title !== fallbackTitle) {
+			return;
+		}
+
+		if (generatedTitle !== fallbackTitle) {
+			this._stateManager.dispatchServerAction(channel, {
+				type: ActionType.SessionTitleChanged,
+				title: generatedTitle,
+			});
+		}
+		this._persistCustomTitle(channel, generatedTitle);
+	}
+
+	private async _generateTitleFromPrompt(userPrompt: string, token: CancellationToken): Promise<string | undefined> {
+		if (token.isCancellationRequested) {
+			return undefined;
+		}
+
+		const githubToken = this._options.getGitHubCopilotToken?.();
+		const copilotApiService = this._options.copilotApiService;
+		if (!githubToken || !copilotApiService) {
+			return undefined;
+		}
+
+		const abortController = new AbortController();
+		const cancellationListener = token.onCancellationRequested(() => abortController.abort());
+		try {
+			const rawTitle = await copilotApiService.utilityChatCompletion(githubToken, {
+				messages: this._buildTitlePrompt(userPrompt),
+			}, {
+				signal: abortController.signal,
+			});
+			return this._cleanTitle(rawTitle);
+		} catch (err) {
+			if (token.isCancellationRequested) {
+				return undefined;
+			}
+			this._logService.warn('[AgentHostSessionTitleController] Failed to generate session title', err);
+			return undefined;
+		} finally {
+			cancellationListener.dispose();
+		}
+	}
+
+	private _buildTitlePrompt(userPrompt: string): ICopilotUtilityChatMessage[] {
+		return [
+			{
+				role: 'system',
+				content: [
+					'You are an expert in crafting ultra-compact titles for chatbot conversations.',
+					'You are presented with a chat request, and you reply with only a brief title that captures the main topic of that request.',
+					'Write the title in sentence case, not title case.',
+					'Preserve product names, abbreviations, code symbols, and proper nouns.',
+					'Aim for 3-6 words. Prefer the shortest accurate title.',
+					'Drop articles like "a", "an", and "the" unless needed for clarity.',
+					'Drop filler and generic framing like "help with", "question about", "request for", or "issue with".',
+					'Prefer short, concrete synonyms and omit unnecessary words.',
+					'Do not wrap the title in quotes or add trailing punctuation.',
+				].join(' '),
+			},
+			{
+				role: 'user',
+				content: `Please write a brief title for the following request:\n\n${userPrompt}`,
+			},
+		];
+	}
+
+	private _cleanTitle(rawTitle: string): string | undefined {
+		let title = rawTitle.trim();
+		const firstLine = title.split(/\r?\n/).map(line => line.trim()).find(line => line.length > 0);
+		title = firstLine ?? '';
+		if (title.startsWith('"') && title.endsWith('"') && title.length > 1) {
+			title = title.slice(1, -1).trim();
+		}
+		title = title.replace(/[.!?]+$/, '').trim();
+
+		if (!title || title.includes('can\'t assist with that')) {
+			return undefined;
+		}
+		return title.slice(0, MAX_TITLE_LENGTH);
+	}
+
+	private _persistCustomTitle(session: ProtocolURI, title: string): void {
+		const ref = this._options.sessionDataService.openDatabase(URI.parse(session));
+		ref.object.setMetadata('customTitle', title).catch(err => {
+			this._logService.warn('[AgentHostSessionTitleController] Failed to persist customTitle', err);
+		}).finally(() => {
+			ref.dispose();
+		});
+	}
+
+	private _cancelTitleGeneration(session: ProtocolURI): void {
+		const source = this._titleGenerationCancellationSources.get(session);
+		if (!source) {
+			return;
+		}
+		source.dispose(true);
+		this._titleGenerationCancellationSources.delete(session);
+	}
+
+	override dispose(): void {
+		for (const source of this._titleGenerationCancellationSources.values()) {
+			source.dispose(true);
+		}
+		this._titleGenerationCancellationSources.clear();
+		super.dispose();
+	}
+}

--- a/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
+++ b/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
@@ -35,7 +35,7 @@ export class AgentHostSessionTitleController extends Disposable {
 
 	seedTitleFromFirstMessage(channel: ProtocolURI, userPrompt: string): void {
 		const state = this._stateManager.getSessionState(channel);
-		const fallbackTitle = userPrompt.trim().replace(/\s+/g, ' ').slice(0, 200);
+		const fallbackTitle = userPrompt.trim().replace(/\s+/g, ' ').slice(0, MAX_TITLE_LENGTH);
 		if (!state || state.turns.length !== 0 || state.summary.title || fallbackTitle.length === 0) {
 			return;
 		}

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -20,7 +20,7 @@ import { FileChangeType, FileOperationError, FileOperationResult, FileSystemProv
 import { InstantiationService } from '../../instantiation/common/instantiationService.js';
 import { ServiceCollection } from '../../instantiation/common/serviceCollection.js';
 import { ILogService } from '../../log/common/log.js';
-import { AgentProvider, AgentSession, IAgent, IAgentCreateSessionConfig, IAgentHostAuthTokenRequest, IAgentMaterializeSessionEvent, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IMcpNotification } from '../common/agentService.js';
+import { AgentProvider, AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, IAgent, IAgentCreateSessionConfig, IAgentHostAuthTokenRequest, IAgentMaterializeSessionEvent, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IMcpNotification } from '../common/agentService.js';
 import { ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../common/sessionDataService.js';
 import { buildDefaultChangesetCatalogue, parseChangesetUri } from '../common/changesetUri.js';
 import { ActionType, ActionEnvelope, INotification, type IRootConfigChangedAction, type SessionAction, type TerminalAction } from '../common/state/sessionActions.js';
@@ -199,6 +199,7 @@ export class AgentService extends Disposable implements IAgentService {
 		private readonly _rootConfigResource?: URI,
 		private readonly _telemetryService: ITelemetryService = NullTelemetryService,
 		_fileMonitorService?: IAgentHostFileMonitorService,
+		copilotApiService?: ICopilotApiService,
 	) {
 		super();
 		this._logService.info('AgentService initialized');
@@ -239,7 +240,8 @@ export class AgentService extends Disposable implements IAgentService {
 		const instantiationService = this._register(new InstantiationService(services, /*strict*/ true));
 		const agentHostOctoKitService = instantiationService.createInstance(AgentHostOctoKitService, undefined);
 		services.set(IAgentHostOctoKitService, agentHostOctoKitService);
-		services.set(ICopilotApiService, instantiationService.createInstance(CopilotApiService, undefined));
+		const effectiveCopilotApiService = copilotApiService ?? instantiationService.createInstance(CopilotApiService, undefined);
+		services.set(ICopilotApiService, effectiveCopilotApiService);
 		this._sessionGitStateService = this._register(instantiationService.createInstance(AgentHostSessionGitStateService, this._stateManager));
 		this._changesetOperationContributionService = this._register(instantiationService.createInstance(AgentHostChangesetOperationContributionService, this._stateManager, this._sessionGitStateService));
 
@@ -288,6 +290,13 @@ export class AgentService extends Disposable implements IAgentService {
 			getAgent: session => this._findProviderForSession(session),
 			sessionDataService: this._sessionDataService,
 			agents: this._agents,
+			copilotApiService: effectiveCopilotApiService,
+			getGitHubCopilotToken: () => {
+				return this.getAuthToken({
+					resource: GITHUB_COPILOT_PROTECTED_RESOURCE.resource,
+					scopes: GITHUB_COPILOT_PROTECTED_RESOURCE.scopes_supported,
+				});
+			},
 			onTurnComplete: session => {
 				const workingDirStr = this._stateManager.getSessionState(session)?.summary.workingDirectory;
 				this._attachGitState(URI.parse(session), workingDirStr ? URI.parse(workingDirStr) : undefined);
@@ -807,6 +816,7 @@ export class AgentService extends Disposable implements IAgentService {
 			this._sessionToProvider.delete(session.toString());
 		}
 		this._changesetCoordinator.onSessionDisposed(session.toString());
+		this._sideEffects.cancelSessionTitleGeneration(session.toString());
 		// Remove all subagent sessions for this parent
 		this._sideEffects.removeSubagentSessions(session.toString());
 		this._stateManager.deleteSession(session.toString());

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -41,6 +41,8 @@ import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { updateAgentHostTelemetryLevelFromConfig } from './agentHostTelemetryService.js';
 import { AgentHostTelemetryReporter } from './agentHostTelemetryReporter.js';
 import { AgentHostTurnTracker } from './agentHostTurnTracker.js';
+import { AgentHostSessionTitleController } from './agentHostSessionTitleController.js';
+import type { ICopilotApiService } from './shared/copilotApiService.js';
 
 /**
  * Options for constructing an {@link AgentSideEffects} instance.
@@ -52,6 +54,10 @@ export interface IAgentSideEffectsOptions {
 	readonly agents: IObservable<readonly IAgent[]>;
 	/** Session data service for cleaning up per-session data on disposal. */
 	readonly sessionDataService: ISessionDataService;
+	/** Get the GitHub token used for Copilot utility title generation. */
+	readonly getGitHubCopilotToken?: () => string | undefined;
+	/** CAPI service used for Copilot utility title generation. */
+	readonly copilotApiService?: ICopilotApiService;
 	/**
 	 * Called after each top-level session turn completes so git state can be
 	 * refreshed and published via `SessionMetaChanged`. Subagent turns are
@@ -104,6 +110,7 @@ export class AgentSideEffects extends Disposable {
 	private readonly _pendingSubagentSignals = new Map<string, IPendingSubagentSignal[]>();
 	private readonly _telemetryReporter: AgentHostTelemetryReporter;
 	private readonly _turnTracker: AgentHostTurnTracker;
+	private readonly _titleController: AgentHostSessionTitleController;
 
 	constructor(
 		private readonly _stateManager: AgentHostStateManager,
@@ -118,6 +125,11 @@ export class AgentSideEffects extends Disposable {
 		this._telemetryReporter = new AgentHostTelemetryReporter(this._telemetryService);
 		this._turnTracker = new AgentHostTurnTracker(this._telemetryReporter);
 		this._permissionManager = this._register(instantiationService.createInstance(SessionPermissionManager, this._stateManager));
+		this._titleController = this._register(instantiationService.createInstance(AgentHostSessionTitleController, this._stateManager, {
+			sessionDataService: this._options.sessionDataService,
+			getGitHubCopilotToken: this._options.getGitHubCopilotToken,
+			copilotApiService: this._options.copilotApiService,
+		}));
 
 		// Whenever the agents observable changes, publish to root state.
 		this._register(autorun(reader => {
@@ -743,19 +755,8 @@ export class AgentSideEffects extends Disposable {
 					break;
 				}
 
-				// On the very first turn, immediately set the session title to the
-				// user's message so the UI shows a meaningful title right away
-				// while waiting for the AI-generated title. Only apply when the
-				// title is still the default placeholder to avoid clobbering a
-				// title set by the user or provider before the first turn.
 				const state = this._stateManager.getSessionState(channel);
-				const fallbackTitle = action.message.text.trim().replace(/\s+/g, ' ').slice(0, 200);
-				if (state && state.turns.length === 0 && !state.summary.title && fallbackTitle.length > 0) {
-					this._stateManager.dispatchServerAction(channel, {
-						type: ActionType.SessionTitleChanged,
-						title: fallbackTitle,
-					});
-				}
+				this._titleController.seedTitleFromFirstMessage(channel, action.message.text);
 
 				const agent = this._options.getAgent(channel);
 				if (!agent) {
@@ -916,6 +917,10 @@ export class AgentSideEffects extends Disposable {
 				break;
 			}
 		}
+	}
+
+	cancelSessionTitleGeneration(session: ProtocolURI): void {
+		this._titleController.cancelTitleGeneration(session);
 	}
 
 	/**

--- a/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
@@ -1,0 +1,188 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import type Anthropic from '@anthropic-ai/sdk';
+import type { CCAModel } from '@vscode/copilot-api';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
+import { AgentHostSessionTitleController } from '../../node/agentHostSessionTitleController.js';
+import { ActionType } from '../../common/state/sessionActions.js';
+import { SessionStatus, type SessionSummary } from '../../common/state/sessionState.js';
+import { type ICopilotApiService, type ICopilotApiServiceRequestOptions, type ICopilotUtilityChatCompletionRequest } from '../../node/shared/copilotApiService.js';
+import { createSessionDataService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
+
+class TestCopilotApiService implements ICopilotApiService {
+	declare readonly _serviceBrand: undefined;
+
+	readonly utilityCalls: { token: string; request: ICopilotUtilityChatCompletionRequest; options?: ICopilotApiServiceRequestOptions }[] = [];
+	response = 'Generated title';
+	responsePromise: Promise<string> | undefined;
+	error: Error | undefined;
+
+	messages(_githubToken: string, _request: Anthropic.MessageCreateParamsStreaming, _options?: ICopilotApiServiceRequestOptions): AsyncGenerator<Anthropic.MessageStreamEvent>;
+	messages(_githubToken: string, _request: Anthropic.MessageCreateParamsNonStreaming, _options?: ICopilotApiServiceRequestOptions): Promise<Anthropic.Message>;
+	messages(): AsyncGenerator<Anthropic.MessageStreamEvent> | Promise<Anthropic.Message> {
+		throw new Error('not used');
+	}
+	async countTokens(): Promise<Anthropic.MessageTokensCount> { throw new Error('not used'); }
+	async models(): Promise<CCAModel[]> { return []; }
+	async responses(): Promise<Response> { throw new Error('not used'); }
+	async utilityChatCompletion(githubToken: string, request: ICopilotUtilityChatCompletionRequest, options?: ICopilotApiServiceRequestOptions): Promise<string> {
+		this.utilityCalls.push({ token: githubToken, request, options });
+		if (this.error) {
+			throw this.error;
+		}
+		if (this.responsePromise) {
+			return this.responsePromise;
+		}
+		return this.response;
+	}
+}
+
+suite('AgentHostSessionTitleController', () => {
+	const disposables = new DisposableStore();
+
+	teardown(() => disposables.clear());
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createSummary(session: URI, title = ''): SessionSummary {
+		return {
+			resource: session.toString(),
+			provider: 'copilot',
+			title,
+			status: SessionStatus.Idle,
+			createdAt: 1,
+			modifiedAt: 1,
+		};
+	}
+
+	async function waitForCondition(predicate: () => boolean | Promise<boolean>, message: string): Promise<void> {
+		for (let i = 0; i < 20; i++) {
+			if (await predicate()) {
+				return;
+			}
+			await new Promise(resolve => setTimeout(resolve, 5));
+		}
+		assert.ok(await predicate(), message);
+	}
+
+	function setup(copilotApiService = new TestCopilotApiService(), title = '', getGitHubCopilotToken = () => 'gh-token'): {
+		controller: AgentHostSessionTitleController;
+		stateManager: AgentHostStateManager;
+		session: URI;
+		db: TestSessionDatabase;
+		titleActions: string[];
+		copilotApiService: TestCopilotApiService;
+	} {
+		const stateManager = disposables.add(new AgentHostStateManager(new NullLogService()));
+		const db = new TestSessionDatabase();
+		const session = URI.parse('agenthost-session://copilot/session-title-test');
+		stateManager.createSession(createSummary(session, title));
+		const titleActions: string[] = [];
+		disposables.add(stateManager.onDidEmitEnvelope(e => {
+			if (e.action.type === ActionType.SessionTitleChanged) {
+				titleActions.push(e.action.title);
+			}
+		}));
+		const controller = disposables.add(new AgentHostSessionTitleController(stateManager, {
+			sessionDataService: createSessionDataService(db),
+			getGitHubCopilotToken,
+			copilotApiService,
+		}, new NullLogService()));
+		return { controller, stateManager, session, db, titleActions, copilotApiService };
+	}
+
+	test('seedTitleFromFirstMessage applies fallback and persists generated title', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		copilotApiService.response = '"Generated title."';
+		const { controller, session, db, titleActions } = setup(copilotApiService);
+
+		controller.seedTitleFromFirstMessage(session.toString(), '  Please   explain title generation  ');
+		await waitForCondition(async () => await db.getMetadata('customTitle') === 'Generated title', 'generated title should be persisted');
+
+		assert.deepStrictEqual({
+			titles: titleActions,
+			token: copilotApiService.utilityCalls[0]?.token,
+			promptIncludesUserText: copilotApiService.utilityCalls[0]?.request.messages.some(message => message.content.includes('Please   explain title generation')),
+			persistedTitle: await db.getMetadata('customTitle'),
+		}, {
+			titles: ['Please explain title generation', 'Generated title'],
+			token: 'gh-token',
+			promptIncludesUserText: true,
+			persistedTitle: 'Generated title',
+		});
+	});
+
+	test('seedTitleFromFirstMessage does not clobber a changed title', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		let resolveTitle!: (title: string) => void;
+		copilotApiService.responsePromise = new Promise(resolve => { resolveTitle = resolve; });
+		const { controller, stateManager, session, db } = setup(copilotApiService);
+
+		controller.seedTitleFromFirstMessage(session.toString(), 'Create title tests');
+		await waitForCondition(() => copilotApiService.utilityCalls.length === 1, 'title generation should start');
+		stateManager.dispatchServerAction(session.toString(), {
+			type: ActionType.SessionTitleChanged,
+			title: 'Manual title',
+		});
+		resolveTitle('Generated title');
+		await Promise.resolve();
+
+		assert.deepStrictEqual({
+			title: stateManager.getSessionState(session.toString())?.summary.title,
+			persistedTitle: await db.getMetadata('customTitle'),
+		}, {
+			title: 'Manual title',
+			persistedTitle: undefined,
+		});
+	});
+
+	test('cancelTitleGeneration cancels delayed generated title application', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		let resolveTitle!: (title: string) => void;
+		copilotApiService.responsePromise = new Promise(resolve => { resolveTitle = resolve; });
+		const { controller, stateManager, session, db } = setup(copilotApiService);
+
+		controller.seedTitleFromFirstMessage(session.toString(), 'Investigate title cancellation');
+		await waitForCondition(() => copilotApiService.utilityCalls.length === 1, 'title generation should start');
+		controller.cancelTitleGeneration(session.toString());
+		resolveTitle('Generated title');
+		await Promise.resolve();
+
+		assert.deepStrictEqual({
+			aborted: copilotApiService.utilityCalls[0].options?.signal?.aborted,
+			title: stateManager.getSessionState(session.toString())?.summary.title,
+			persistedTitle: await db.getMetadata('customTitle'),
+		}, {
+			aborted: true,
+			title: 'Investigate title cancellation',
+			persistedTitle: undefined,
+		});
+	});
+
+	test('seedTitleFromFirstMessage skips sessions with an existing title', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		const { controller, stateManager, session, db, titleActions } = setup(copilotApiService, 'Forked: Source title');
+
+		controller.seedTitleFromFirstMessage(session.toString(), 'Continue forked session');
+		await Promise.resolve();
+
+		assert.deepStrictEqual({
+			calls: copilotApiService.utilityCalls.length,
+			title: stateManager.getSessionState(session.toString())?.summary.title,
+			titles: titleActions,
+			persistedTitle: await db.getMetadata('customTitle'),
+		}, {
+			calls: 0,
+			title: 'Forked: Source title',
+			titles: [],
+			persistedTitle: undefined,
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import type Anthropic from '@anthropic-ai/sdk';
+import type { CCAModel } from '@vscode/copilot-api';
 import { mkdtempSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
@@ -30,9 +32,10 @@ import { AgentService } from '../../node/agentService.js';
 import { MockAgent, ScriptedMockAgent } from './mockAgent.js';
 import { mapSessionEventsToHistoryRecords } from './historyRecordFixtures.js';
 import { type ISessionEvent } from '../../node/copilot/mapSessionEvents.js';
-import { createNoopGitService, createSessionDataService } from '../common/sessionTestHelpers.js';
+import { createNoopGitService, createSessionDataService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
 import { NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
 import { buildSessionChangesetUri, buildUncommittedChangesetUri } from '../../common/changesetUri.js';
+import { type ICopilotApiService, type ICopilotApiServiceRequestOptions, type ICopilotUtilityChatCompletionRequest } from '../../node/shared/copilotApiService.js';
 
 /**
  * Loads a JSONL fixture of raw Copilot SDK events, runs them through
@@ -56,6 +59,34 @@ async function loadFixtureMessages(fixtureName: string, session: URI) {
 	const raw = readFileSync(`${fixtureDir}${sep}test-cases${sep}${fixtureName}`, 'utf-8');
 	const events: ISessionEvent[] = raw.trim().split('\n').map(line => JSON.parse(line));
 	return mapSessionEventsToHistoryRecords(session, undefined, events);
+}
+
+class TestCopilotApiService implements ICopilotApiService {
+	declare readonly _serviceBrand: undefined;
+
+	readonly utilityCalls: { token: string; request: ICopilotUtilityChatCompletionRequest; options?: ICopilotApiServiceRequestOptions }[] = [];
+	response = 'Generated session title';
+	responsePromise: Promise<string> | undefined;
+	error: Error | undefined;
+
+	messages(_githubToken: string, _request: Anthropic.MessageCreateParamsStreaming, _options?: ICopilotApiServiceRequestOptions): AsyncGenerator<Anthropic.MessageStreamEvent>;
+	messages(_githubToken: string, _request: Anthropic.MessageCreateParamsNonStreaming, _options?: ICopilotApiServiceRequestOptions): Promise<Anthropic.Message>;
+	messages(): AsyncGenerator<Anthropic.MessageStreamEvent> | Promise<Anthropic.Message> {
+		throw new Error('not used');
+	}
+	async countTokens(): Promise<Anthropic.MessageTokensCount> { throw new Error('not used'); }
+	async models(): Promise<CCAModel[]> { return []; }
+	async responses(): Promise<Response> { throw new Error('not used'); }
+	async utilityChatCompletion(githubToken: string, request: ICopilotUtilityChatCompletionRequest, options?: ICopilotApiServiceRequestOptions): Promise<string> {
+		this.utilityCalls.push({ token: githubToken, request, options });
+		if (this.error) {
+			throw this.error;
+		}
+		if (this.responsePromise) {
+			return this.responsePromise;
+		}
+		return this.response;
+	}
 }
 
 suite('AgentService (node dispatcher)', () => {
@@ -136,6 +167,43 @@ suite('AgentService (node dispatcher)', () => {
 
 	suite('dispatchAction', () => {
 
+		async function waitForCondition(predicate: () => boolean | Promise<boolean>, message: string): Promise<void> {
+			for (let i = 0; i < 20; i++) {
+				if (await predicate()) {
+					return;
+				}
+				await new Promise(resolve => setTimeout(resolve, 5));
+			}
+			assert.ok(await predicate(), message);
+		}
+
+		async function setupTitleGeneration(copilotApiService: TestCopilotApiService): Promise<{ svc: AgentService; agent: MockAgent; session: URI; db: TestSessionDatabase }> {
+			const db = new TestSessionDatabase();
+			const sessionDataService = createSessionDataService(db);
+			const svc = disposables.add(new AgentService(
+				new NullLogService(),
+				fileService,
+				sessionDataService,
+				{ _serviceBrand: undefined } as IProductService,
+				createNoopGitService(),
+				NULL_CHECKPOINT_SERVICE,
+				undefined,
+				undefined,
+				undefined,
+				copilotApiService,
+			));
+			const agent = new MockAgent('copilot');
+			disposables.add(toDisposable(() => agent.dispose()));
+			svc.registerProvider(agent);
+			await svc.authenticate({
+				resource: GITHUB_COPILOT_PROTECTED_RESOURCE.resource,
+				scopes: GITHUB_COPILOT_PROTECTED_RESOURCE.scopes_supported,
+				token: 'gh-token',
+			});
+			const session = await svc.createSession({ provider: 'copilot' });
+			return { svc, agent, session, db };
+		}
+
 		test('applies and persists root config changes from clients', async () => {
 			const tempDir = URI.file(mkdtempSync(`${tmpdir()}/agent-host-config-`));
 			// Use a local DisposableStore so that svc can be explicitly disposed
@@ -180,6 +248,161 @@ suite('AgentService (node dispatcher)', () => {
 				localDisposables.dispose();
 				rmSync(tempDir.fsPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 			}
+		});
+
+		test('generates and persists an AI title after first-turn fallback title', async () => {
+			const copilotApiService = new TestCopilotApiService();
+			copilotApiService.response = '"Fix TypeScript compile errors."';
+			const { svc, session, db } = await setupTitleGeneration(copilotApiService);
+			const titleActions: string[] = [];
+			disposables.add(svc.onDidAction(e => {
+				if (e.action.type === ActionType.SessionTitleChanged) {
+					titleActions.push(e.action.title);
+				}
+			}));
+
+			svc.dispatchAction(
+				session.toString(),
+				{ type: ActionType.SessionTurnStarted, turnId: 'turn-1', message: { text: 'Please help me fix the TypeScript compile errors', origin: { kind: MessageKind.User } } },
+				'test-client', 1,
+			);
+
+			await waitForCondition(() => svc.stateManager.getSessionState(session.toString())?.summary.title === 'Fix TypeScript compile errors', 'generated title should be applied');
+			await waitForCondition(async () => await db.getMetadata('customTitle') !== undefined, 'generated title should be persisted');
+
+			assert.deepStrictEqual({
+				titles: titleActions,
+				token: copilotApiService.utilityCalls[0]?.token,
+				promptIncludesUserText: copilotApiService.utilityCalls[0]?.request.messages.some(message => message.content.includes('Please help me fix the TypeScript compile errors')),
+				persistedTitle: await db.getMetadata('customTitle'),
+			}, {
+				titles: ['Please help me fix the TypeScript compile errors', 'Fix TypeScript compile errors'],
+				token: 'gh-token',
+				promptIncludesUserText: true,
+				persistedTitle: 'Fix TypeScript compile errors',
+			});
+		});
+
+		test('leaves fallback title when AI title generation fails', async () => {
+			const copilotApiService = new TestCopilotApiService();
+			copilotApiService.error = new Error('title failed');
+			const { svc, session, db } = await setupTitleGeneration(copilotApiService);
+
+			svc.dispatchAction(
+				session.toString(),
+				{ type: ActionType.SessionTurnStarted, turnId: 'turn-1', message: { text: 'Explain workspace search indexing', origin: { kind: MessageKind.User } } },
+				'test-client', 1,
+			);
+
+			await waitForCondition(() => copilotApiService.utilityCalls.length === 1, 'title generation should be attempted');
+			await Promise.resolve();
+
+			assert.deepStrictEqual({
+				title: svc.stateManager.getSessionState(session.toString())?.summary.title,
+				persistedTitle: await db.getMetadata('customTitle'),
+			}, {
+				title: 'Explain workspace search indexing',
+				persistedTitle: undefined,
+			});
+		});
+
+		test('does not overwrite a manual rename with delayed AI title', async () => {
+			const copilotApiService = new TestCopilotApiService();
+			let resolveTitle!: (title: string) => void;
+			copilotApiService.responsePromise = new Promise(resolve => { resolveTitle = resolve; });
+			const { svc, session, db } = await setupTitleGeneration(copilotApiService);
+
+			svc.dispatchAction(
+				session.toString(),
+				{ type: ActionType.SessionTurnStarted, turnId: 'turn-1', message: { text: 'Create tests for terminal persistence', origin: { kind: MessageKind.User } } },
+				'test-client', 1,
+			);
+			await waitForCondition(() => copilotApiService.utilityCalls.length === 1, 'title generation should be in flight');
+
+			svc.dispatchAction(
+				session.toString(),
+				{ type: ActionType.SessionTitleChanged, title: 'Manual title' },
+				'test-client', 2,
+			);
+			resolveTitle('Terminal persistence tests');
+			await waitForCondition(async () => await db.getMetadata('customTitle') === 'Manual title', 'manual title should be persisted');
+
+			assert.deepStrictEqual({
+				title: svc.stateManager.getSessionState(session.toString())?.summary.title,
+				persistedTitle: await db.getMetadata('customTitle'),
+			}, {
+				title: 'Manual title',
+				persistedTitle: 'Manual title',
+			});
+		});
+
+		test('aborts pending AI title generation when session is disposed', async () => {
+			const copilotApiService = new TestCopilotApiService();
+			let resolveTitle!: (title: string) => void;
+			copilotApiService.responsePromise = new Promise(resolve => { resolveTitle = resolve; });
+			const { svc, session, db } = await setupTitleGeneration(copilotApiService);
+
+			svc.dispatchAction(
+				session.toString(),
+				{ type: ActionType.SessionTurnStarted, turnId: 'turn-1', message: { text: 'Investigate flaky terminal tests', origin: { kind: MessageKind.User } } },
+				'test-client', 1,
+			);
+			await waitForCondition(() => copilotApiService.utilityCalls.length === 1, 'title generation should be in flight');
+
+			await svc.disposeSession(session);
+			resolveTitle('Flaky terminal tests');
+			await Promise.resolve();
+
+			assert.deepStrictEqual({
+				aborted: copilotApiService.utilityCalls[0].options?.signal?.aborted,
+				state: svc.stateManager.getSessionState(session.toString()),
+				persistedTitle: await db.getMetadata('customTitle'),
+			}, {
+				aborted: true,
+				state: undefined,
+				persistedTitle: undefined,
+			});
+		});
+
+		test('does not generate an AI title for forked sessions with an existing title', async () => {
+			const copilotApiService = new TestCopilotApiService();
+			copilotApiService.response = 'Source generated title';
+			const { svc, session: sourceSession } = await setupTitleGeneration(copilotApiService);
+
+			svc.dispatchAction(
+				sourceSession.toString(),
+				{ type: ActionType.SessionTurnStarted, turnId: 'source-turn', message: { text: 'Seed fork title', origin: { kind: MessageKind.User } } },
+				'test-client', 1,
+			);
+			await waitForCondition(() => svc.stateManager.getSessionState(sourceSession.toString())?.summary.title === 'Source generated title', 'source generated title should be applied');
+			svc.dispatchAction(
+				sourceSession.toString(),
+				{ type: ActionType.SessionTurnComplete, turnId: 'source-turn' },
+				'test-client', 2,
+			);
+			await waitForCondition(() => (svc.stateManager.getSessionState(sourceSession.toString())?.turns.length ?? 0) === 1, 'source turn should be complete before forking');
+			const forkedSession = await svc.createSession({
+				provider: 'copilot',
+				fork: {
+					session: sourceSession,
+					turnIndex: 0,
+					turnId: 'source-turn',
+				},
+			});
+
+			svc.dispatchAction(
+				forkedSession.toString(),
+				{ type: ActionType.SessionTurnStarted, turnId: 'fork-turn-1', message: { text: 'Continue from the fork', origin: { kind: MessageKind.User } } },
+				'test-client', 3,
+			);
+
+			assert.deepStrictEqual({
+				title: svc.stateManager.getSessionState(forkedSession.toString())?.summary.title,
+				utilityCalls: copilotApiService.utilityCalls.length,
+			}, {
+				title: 'Forked: Source generated title',
+				utilityCalls: 1,
+			});
 		});
 	});
 


### PR DESCRIPTION
Adds AI-generated session titles for Agent Host sessions using Copilot utility chat completion after seeding the existing first-message fallback title.

The title workflow now guards against clobbering manual renames, skips pre-titled/forked sessions, cancels pending generation when sessions are disposed, and persists generated titles as custom titles.

Validation:
- npm run compile-check-ts-native -- --pretty false
- fnm exec --using 24 npm run test-node -- --run src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts --run src/vs/platform/agentHost/test/node/agentService.test.ts --run src/vs/platform/agentHost/test/node/agentSideEffects.test.ts --run src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
- npm run precommit