### PR TITLE
fix: browser's Right Click > Inspect Element shouldn't add element to chat

### DIFF
--- a/src/vs/platform/browserView/electron-main/browserViewFrameInspector.ts
+++ b/src/vs/platform/browserView/electron-main/browserViewFrameInspector.ts
@@ -145,7 +145,11 @@ export class BrowserViewFrameInspector extends Disposable {
 			switch (event.method) {
 				case 'Overlay.inspectNodeRequested': {
 					const params = event.params as { backendNodeId: number };
-					if (params?.backendNodeId) {
+					// Only handle this event when VS Code's own element picker is active.
+					// This event also fires when the user inspects elements via the
+					// DevTools built-in inspect cursor — in that case we must not
+					// silently add the element to Copilot Chat as context.
+					if (params?.backendNodeId && this.isInspecting) {
 						try {
 							// Verify the node belongs to this frame (important when
 							// sharing a session with same-origin siblings).


### PR DESCRIPTION
Fixes #320888

## Problem

When a user right-clicked in the integrated browser and selected "Inspect" (or used the DevTools built-in element cursor to inspect any element), VS Code was silently adding that element as context to Copilot Chat.

This happened because `Overlay.inspectNodeRequested` — a CDP event — fires in two situations:
1. When **VS Code's own element picker** is active (the user explicitly activated element selection to add to chat) ✅ intentional
2. When the **DevTools built-in inspect cursor** is used to inspect elements ❌ unintentional

Both paths ran through the same handler, unconditionally firing `onDidInspectElement` → `onDidSelectElement` → `_attachElementDataToChat`.

## Fix

Add an `isInspecting` guard to the `Overlay.inspectNodeRequested` handler in `BrowserViewFrameInspector` so it only fires `onDidInspectElement` when VS Code's own element picker is explicitly active.

The "Add Element to Chat" context menu item calls `getElementHandle().addToChat()` which directly fires `_onDidInspectElement` without going through `Overlay.inspectNodeRequested`, so it is completely unaffected by this change.