### PR TITLE
fix: avoid refocusing find input during IME composition

### DIFF
--- a/src/vs/base/browser/ui/findinput/findInput.ts
+++ b/src/vs/base/browser/ui/findinput/findInput.ts
@@ -46,6 +46,10 @@ export interface IFindInputOptions {
 	readonly hideHoverOnValueChange?: boolean;
 }
 
+export interface IFindInputEvent {
+	readonly fromCompositionEnd: boolean;
+}
+
 const NLS_DEFAULT_LABEL = nls.localize('defaultLabel', "input");
 
 export class FindInput extends Widget {
@@ -77,8 +81,8 @@ export class FindInput extends Widget {
 	private readonly _onMouseDown = this._register(new Emitter<IMouseEvent>());
 	public get onMouseDown(): Event<IMouseEvent> { return this._onMouseDown.event; }
 
-	private readonly _onInput = this._register(new Emitter<void>());
-	public get onInput(): Event<void> { return this._onInput.event; }
+	private readonly _onInput = this._register(new Emitter<IFindInputEvent>());
+	public get onInput(): Event<IFindInputEvent> { return this._onInput.event; }
 
 	private readonly _onKeyUp = this._register(new Emitter<IKeyboardEvent>());
 	public get onKeyUp(): Event<IKeyboardEvent> { return this._onKeyUp.event; }
@@ -229,12 +233,12 @@ export class FindInput extends Widget {
 		}));
 		this._register(dom.addDisposableListener(this.inputBox.inputElement, 'compositionend', (e: CompositionEvent) => {
 			this.imeSessionInProgress = false;
-			this._onInput.fire();
+			this._onInput.fire({ fromCompositionEnd: true });
 		}));
 
 		this.onkeydown(this.inputBox.inputElement, (e) => this._onKeyDown.fire(e));
 		this.onkeyup(this.inputBox.inputElement, (e) => this._onKeyUp.fire(e));
-		this.oninput(this.inputBox.inputElement, (e) => this._onInput.fire());
+		this.oninput(this.inputBox.inputElement, (e) => this._onInput.fire({ fromCompositionEnd: false }));
 		this.onmousedown(this.inputBox.inputElement, (e) => this._onMouseDown.fire(e));
 	}
 

--- a/src/vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget.ts
@@ -130,7 +130,9 @@ export abstract class SimpleFindWidget extends Widget implements IVerticalSashLa
 					await this.updateResultCount();
 				}
 				this.updateButtons(this._foundMatch);
-				this.focusFindBox();
+				if (!options.checkImeCompletionState || !e.fromCompositionEnd) {
+					this.focusFindBox();
+				}
 				this._delayedUpdateHistory();
 			}
 		}));
@@ -412,6 +414,9 @@ export abstract class SimpleFindWidget extends Widget implements IVerticalSashLa
 	}
 
 	protected focusFindBox() {
+		if (this._findInput.isImeSessionInProgress) {
+			return;
+		}
 		// Focus back onto the find box, which
 		// requires focusing onto the next button first
 		this.nextBtn.focus();


### PR DESCRIPTION
Fixes #320869

**What changed?**
Updated the shared find input flow so input events fired from compositionend can update search state without immediately restoring focus to the find box (FindInput.onInput now carries { fromCompositionEnd }). Also added a guard so focusFindBox() does not refocus the find input while an IME composition session is still active.

**Why?**
focusFindBox() blurs and refocuses the find input (bouncing through the next-match button). When this runs for the input fired at compositionend — or when an async find result arrives while the next character is already composing — the focus change aborts the active IME composition. Korean IME fires compositionend at every syllable boundary, so characters were dropped or corrupted while typing. The search value is still processed as before; only the focus churn around composition is skipped.

**How I tested this:**
Reproduced the original bug and verified the fix manually with ./scripts/code-web.sh: typing Korean (e.g. 안녕하세요) in the markdown preview find box corrupted characters before this change and is clean after. (Tested on web because webview find is not functional in local desktop builds — stock Electron lacks the findInFrame patch, see [#222244](https://github.com/microsoft/vscode/issues/222244).)
Verified English typing, Enter navigation, and find history behavior are unchanged.
npm run compile-check-ts-native and ESLint on the changed files pass.

**Before / after**
Before:

https://github.com/user-attachments/assets/cb140718-c5db-448c-a112-02307e6cd01d


After:

https://github.com/user-attachments/assets/55404d94-d097-468f-98c5-aca5b0ea6b10
