### PR TITLE
Cache explorer: conversation-level hit rate, exclude utility models, agent-type filter

### DIFF
--- a/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
@@ -332,7 +332,7 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 					otelSpan.setAttributes({
 						[GenAiAttr.USAGE_INPUT_TOKENS]: result.usage.prompt_tokens ?? 0,
 						[GenAiAttr.USAGE_OUTPUT_TOKENS]: result.usage.completion_tokens ?? 0,
-						...(result.usage.prompt_tokens_details?.cached_tokens
+						...(result.usage.prompt_tokens_details?.cached_tokens !== undefined
 							? { [GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS]: result.usage.prompt_tokens_details.cached_tokens }
 							: {}),
 						[GenAiAttr.RESPONSE_MODEL]: model.id,

--- a/extensions/copilot/src/extension/byok/vscode-node/geminiNativeProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/geminiNativeProvider.ts
@@ -203,7 +203,7 @@ export class GeminiNativeBYOKLMProvider extends AbstractLanguageModelChatProvide
 					otelSpan.setAttributes({
 						[GenAiAttr.USAGE_INPUT_TOKENS]: result.usage.prompt_tokens ?? 0,
 						[GenAiAttr.USAGE_OUTPUT_TOKENS]: result.usage.completion_tokens ?? 0,
-						...(result.usage.prompt_tokens_details?.cached_tokens
+						...(result.usage.prompt_tokens_details?.cached_tokens !== undefined
 							? { [GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS]: result.usage.prompt_tokens_details.cached_tokens }
 							: {}),
 						[GenAiAttr.RESPONSE_MODEL]: model.id,

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -424,10 +424,10 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 							[GenAiAttr.RESPONSE_MODEL]: normalizedResponseModel ?? chatEndpoint.model,
 							[GenAiAttr.RESPONSE_ID]: result.requestId,
 							[GenAiAttr.RESPONSE_FINISH_REASONS]: ['stop'],
-							...(result.usage.prompt_tokens_details?.cached_tokens
+							...(result.usage.prompt_tokens_details?.cached_tokens !== undefined
 								? { [GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS]: result.usage.prompt_tokens_details.cached_tokens }
 								: {}),
-							...(result.usage.prompt_tokens_details?.cache_creation_input_tokens
+							...(result.usage.prompt_tokens_details?.cache_creation_input_tokens !== undefined
 								? { [GenAiAttr.USAGE_CACHE_CREATION_INPUT_TOKENS]: result.usage.prompt_tokens_details.cache_creation_input_tokens }
 								: {}),
 							[CopilotChatAttr.TIME_TO_FIRST_TOKEN]: timeToFirstToken,

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheDiff.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheDiff.ts
@@ -143,14 +143,30 @@ export function parseInputMessages(inputMessagesJson: string | undefined): reado
 		return [];
 	}
 
+	// First pass: map tool-call ids to tool names. Tool *result* parts only
+	// carry `{id, response}` on the wire — the name lives on the assistant
+	// turn's matching `tool_call` part — so results are named by correlation.
+	const toolNameByCallId = new Map<string, string>();
+	for (const m of raw as readonly IRawMessage[]) {
+		if (!m || typeof m !== 'object' || !Array.isArray(m.parts)) {
+			continue;
+		}
+		for (const p of m.parts) {
+			if (p && typeof p === 'object' && p.type === 'tool_call' && typeof p.id === 'string' && typeof p.name === 'string' && p.name) {
+				toolNameByCallId.set(p.id, p.name);
+			}
+		}
+	}
+
 	const out: INormalizedMessage[] = [];
 	for (const m of raw as readonly IRawMessage[]) {
 		if (!m || typeof m !== 'object') {
 			continue;
 		}
 		let role = typeof m.role === 'string' ? m.role : 'unknown';
-		const name = typeof m.name === 'string' ? m.name : undefined;
+		let name = typeof m.name === 'string' && m.name ? m.name : undefined;
 		let text = '';
+		let toolResponseName: string | undefined;
 		let hasToolResponse = false;
 		let hasToolCall = false;
 		let hasToolSearchOutput = false;
@@ -180,6 +196,9 @@ export function parseInputMessages(inputMessagesJson: string | undefined): reado
 						} else if (p.content !== undefined) {
 							text += stableStringify(p.content);
 						}
+						if (toolResponseName === undefined && typeof p.id === 'string') {
+							toolResponseName = toolNameByCallId.get(p.id);
+						}
 						hasToolResponse = true;
 						break;
 					case 'tool_call':
@@ -208,6 +227,10 @@ export function parseInputMessages(inputMessagesJson: string | undefined): reado
 			role = 'tool_search';
 		} else if (hasToolResponse && !hasText) {
 			role = 'tool';
+			// Name the tool result after the tool that produced it (resolved
+			// via the matching tool_call id) so labels read `tool-read_file`
+			// instead of an anonymous `tool`.
+			name = name ?? toolResponseName;
 		} else if (hasToolCall && !hasText && role === 'assistant') {
 			role = 'assistant';
 		}

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
@@ -23,6 +23,7 @@ import { IChatDebugEventModelTurnContent, IChatDebugMessageSection, IChatDebugMo
 import { IChatService } from '../../common/chatService/chatService.js';
 import { LocalChatSessionUri } from '../../common/model/chatUri.js';
 import { appendSystemDrift, appendToolsDrift, CacheDiffKind, diffPromptSignature, ICacheDiffResult, IComponentDrift, INormalizedMessage, parseInputMessages } from './chatDebugCacheDiff.js';
+import { analyzeStringDivergence, buildSessionCacheReport, CacheBreakCategory, cacheBreakCategoryLabel, CacheInsightSeverity, categorizeCacheBreak, computeCacheInsights, describeStringDivergence, ICacheInsight, ISessionCacheReport, ISessionPairOutcome, maxInsightSeverity, primaryInsight } from './chatDebugCacheInsights.js';
 import { setupBreadcrumbKeyboardNavigation, TextBreadcrumbItem } from './chatDebugTypes.js';
 
 const $ = DOM.$;
@@ -34,6 +35,9 @@ const RAIL_DEFAULT_WIDTH = 280;
 const RAIL_MIN_WIDTH = 180;
 const RAIL_MAX_WIDTH = 600;
 const CURRENT_CONTINUATION_DELTA_COMPONENT = 'current continuation delta';
+
+/** Idle gaps at or above this many minutes get a TTL marker in the rail. */
+const TTL_GAP_MINUTES = 5;
 
 /** The main panel edit agent, selected by default in the agent filter. */
 const DEFAULT_AGENT_KEY = 'panel/editAgent';
@@ -124,6 +128,20 @@ export class ChatDebugCacheExplorerView extends Disposable {
 	private sigBreakdownOpen = false;
 	/** Rail turn-row elements by turn index, for in-place selection updates without rebuilding the rail. */
 	private readonly railRowsByIndex = new Map<number, HTMLElement>();
+	/**
+	 * Component accordion items by component name (`system`, `tools`,
+	 * `messages[i]`), so findings and signature segments can reveal the
+	 * matching entry. Rebuilt on every content render.
+	 */
+	private readonly componentElements = new Map<string, HTMLElement>();
+	/** Selection index the breaking component was last auto-expanded for. */
+	private autoOpenedForIndex = -1;
+	/**
+	 * Memoized cross-turn session report. Keyed on the session + filtered
+	 * turn list so background refreshes with new events recompute it while
+	 * plain selection changes reuse it.
+	 */
+	private sessionReportCache: { key: string; report: ISessionCacheReport } | undefined;
 
 	/**
 	 * Monotonically-increasing render token. Each call to {@link render}
@@ -213,6 +231,8 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			this.selectedAgents = undefined;
 			this.pendingSelectTurn = undefined;
 			this.sigBreakdownOpen = false;
+			this.autoOpenedForIndex = -1;
+			this.sessionReportCache = undefined;
 		}
 		this.currentSessionResource = sessionResource;
 	}
@@ -337,12 +357,20 @@ export class ChatDebugCacheExplorerView extends Disposable {
 	 */
 	private async renderContentInner(token: number, isCurrent: () => boolean, preserveScroll = false): Promise<void> {
 		const prevScroll = preserveScroll ? this.content.scrollTop : 0;
-		this.contentDisposables.clear();
-		DOM.clearNode(this.content);
-		this.renderTitleRow();
 
 		const bEvent = this.modelTurns[this.selectedIndex];
 		const aEvent = this.selectedIndex > 0 ? this.modelTurns[this.selectedIndex - 1] : undefined;
+
+		// Resolve everything — both sides AND the session report — *before*
+		// touching the DOM, then build the panel in one synchronous pass.
+		// Nothing mutates the layout after it is shown, so it never jumps.
+		// The report is scoped to the turns up to the selected one, which
+		// also makes it immune to new requests streaming in: selecting the
+		// last request shows the whole conversation.
+		const report = await this.ensureSessionReport();
+		if (!isCurrent()) {
+			return;
+		}
 
 		if (!aEvent) {
 			// No prior turn to diff against — still surface OTel-reported cache hit
@@ -351,6 +379,9 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			if (!isCurrent()) {
 				return;
 			}
+			this.contentDisposables.clear();
+			DOM.clearNode(this.content);
+			this.renderTitleRow();
 			this.renderSingleSummary(b);
 			if (preserveScroll) {
 				this.content.scrollTop = prevScroll;
@@ -364,20 +395,178 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			return;
 		}
 
+		this.contentDisposables.clear();
+		DOM.clearNode(this.content);
+		this.renderTitleRow();
+		if (report && report.pairCount > 0) {
+			this.renderSessionHealth(DOM.append(this.content, $('.chat-debug-cache-session-health')), report);
+		}
+
 		const compareInputMessages = shouldCompareInputMessages(a, b);
 		const diff = compareInputMessages
 			? diffPromptSignature(a.inputMessages, b.inputMessages)
 			: diffPromptSignature([], []);
 		const drift = appendToolsDrift(appendSystemDrift([...diff.drift], a.system, b.system), a.tools, b.tools);
+		const { insights, optionsDiff } = this.buildInsights(a, b, diff, compareInputMessages);
 
-		this.renderSummary(a, b, diff);
+		// Auto-expand the breaking component once per selection so the
+		// evidence is one scroll away, while respecting a deliberate
+		// collapse on subsequent re-renders of the same selection.
+		if (this.autoOpenedForIndex !== this.selectedIndex) {
+			this.autoOpenedForIndex = this.selectedIndex;
+			const target = primaryInsight(insights)?.component;
+			if (target) {
+				this.openComponents.add(target);
+			}
+		}
+
+		this.renderSummary(a, b, diff, compareInputMessages, insights, optionsDiff);
 		this.renderSignature(a, b, diff, compareInputMessages);
 		this.renderRequestOptions(a, b);
-		this.renderComponents(drift, a, b, compareInputMessages);
+		this.renderComponents(drift, a, b, compareInputMessages, diff.counts.identical);
 		if (preserveScroll) {
 			this.content.scrollTop = prevScroll;
 		}
 	}
+
+	/**
+	 * Build the findings list for an A→B pair. Shared between the per-turn
+	 * content panel and the cross-turn session report.
+	 */
+	private buildInsights(a: ISideData, b: ISideData, diff: ICacheDiffResult, compareInputMessages: boolean): { insights: ICacheInsight[]; optionsDiff: readonly IOptionDelta[] } {
+		const optionsDiff = computeOptionsDiff(a, b);
+		const minutesSincePrevious = (b.event.created.getTime() - a.event.created.getTime()) / 60_000;
+		const insights = computeCacheInsights({
+			aModel: a.event.model,
+			bModel: b.event.model,
+			aSystem: a.system,
+			bSystem: b.system,
+			aTools: a.tools,
+			bTools: b.tools,
+			aMessages: a.inputMessages,
+			bMessages: b.inputMessages,
+			diff,
+			optionsDiff: optionsDiff.map(d => ({ key: d.key, previousLabel: formatOptionValue(d.previous), currentLabel: formatOptionValue(d.current) })),
+			hitPct: computeCacheHit(b.event),
+			inputTokens: b.event.inputTokens ?? 0,
+			minutesSincePrevious: Number.isFinite(minutesSincePrevious) && minutesSincePrevious >= 0 ? minutesSincePrevious : undefined,
+			isContinuation: b.requestShape.isContinuation,
+			previousIsContinuation: a.requestShape.isContinuation,
+			compareInputMessages,
+		});
+		return { insights, optionsDiff };
+	}
+
+	/**
+	 * Memoization key for the session report. The report is scoped to the
+	 * turns up to (and including) the selected one, so it is stable while
+	 * later requests stream in. Undefined when there is nothing to report
+	 * (no session, or fewer than two turns in scope).
+	 *
+	 * Every in-scope turn contributes its identity AND token counts to the
+	 * key — endpoints alone would miss a middle turn replaced in place, and
+	 * token counts live on the event (not the id-cached resolved content),
+	 * so a usage update arriving after the first render must invalidate the
+	 * memoized report or the overall hit rate stays stale.
+	 */
+	private sessionReportKey(): string | undefined {
+		if (!this.currentSessionResource || this.selectedIndex < 1) {
+			return undefined;
+		}
+		const parts: string[] = [
+			this.currentSessionResource.toString(),
+			[...(this.selectedAgents ?? [])].sort().join(','),
+		];
+		for (let i = 0; i <= this.selectedIndex; i++) {
+			const turn = this.modelTurns[i];
+			parts.push(`${turn.id ?? turn.created.getTime()}:${turn.inputTokens ?? ''}:${turn.cachedTokens ?? ''}`);
+		}
+		return parts.join('|');
+	}
+
+	/**
+	 * Run the insights engine over every consecutive turn pair up to the
+	 * selected turn and aggregate the outcome. Memoized per (session,
+	 * selection prefix, agent filter) — per-turn resolution is cached in
+	 * {@link resolvedCache}, so even a cold run is one pass over in-memory
+	 * events.
+	 */
+	private async ensureSessionReport(): Promise<ISessionCacheReport | undefined> {
+		const key = this.sessionReportKey();
+		if (key === undefined) {
+			return undefined;
+		}
+		const cached = this.sessionReportCache?.key === key ? this.sessionReportCache.report : undefined;
+		if (cached) {
+			return cached;
+		}
+		const scopedTurns = this.modelTurns.slice(0, this.selectedIndex + 1);
+		const sides = await Promise.all(scopedTurns.map(t => this.resolveSide(t)));
+		const pairs: ISessionPairOutcome[] = [];
+		for (let i = 1; i < sides.length; i++) {
+			const a = sides[i - 1];
+			const b = sides[i];
+			const compare = shouldCompareInputMessages(a, b);
+			const diff = compare ? diffPromptSignature(a.inputMessages, b.inputMessages) : diffPromptSignature([], []);
+			const { insights } = this.buildInsights(a, b, diff, compare);
+			const inputTokens = b.event.inputTokens ?? 0;
+			const cachedTokens = b.event.cachedTokens ?? 0;
+			pairs.push({
+				turnIndex: i,
+				category: categorizeCacheBreak(insights),
+				lostTokens: Math.max(0, inputTokens - cachedTokens),
+			});
+		}
+		// All in-scope turns (including the first, which has no pair) feed
+		// the token-weighted overall hit rate.
+		const turnTokens = scopedTurns.map(t => ({ inputTokens: t.inputTokens ?? 0, cachedTokens: t.cachedTokens ?? 0 }));
+		const report = buildSessionCacheReport(pairs, turnTokens);
+		this.sessionReportCache = { key, report };
+		return report;
+	}
+
+	/** Render the session-level cache health card from the cross-turn report. */
+	private renderSessionHealth(container: HTMLElement, report: ISessionCacheReport): void {
+		DOM.append(container, $('.chat-debug-cache-card-h', undefined, localize('chatDebug.cache.sessionHealth', "Session cache health")));
+		// Token-weighted overall hit: per-request percentages overweight
+		// small utility calls (titles, summaries); weighting by input tokens
+		// shows what the session actually cost.
+		if (report.overall) {
+			const headline = DOM.append(container, $('.chat-debug-cache-card-headline'));
+			headline.textContent = localize('chatDebug.cache.sessionOverallHit', "{0}% overall cache hit", formatCachePct(report.overall.hitPct));
+			const sub = DOM.append(container, $('.chat-debug-cache-card-sub'));
+			sub.textContent = localize('chatDebug.cache.sessionOverallSub',
+				"{0} of {1} input tokens served from cache across {2} requests (token-weighted)",
+				numberFormatter.value.format(report.overall.cachedTokens),
+				numberFormatter.value.format(report.overall.inputTokens),
+				report.overall.turnCount);
+		}
+		const statsLine = DOM.append(container, $('.chat-debug-cache-session-health-stats'));
+		statsLine.textContent = report.avoidableLostTokens > 0
+			? localize('chatDebug.cache.sessionHealthStatsLost',
+				"{0} of {1} request pairs healthy · ~{2} tokens recomputed avoidably",
+				report.healthyCount, report.pairCount, numberFormatter.value.format(report.avoidableLostTokens))
+			: localize('chatDebug.cache.sessionHealthStats',
+				"{0} of {1} request pairs healthy",
+				report.healthyCount, report.pairCount);
+
+		if (report.byCategory.length > 0) {
+			const chips = DOM.append(container, $('.chat-debug-cache-session-health-chips'));
+			for (const stat of report.byCategory) {
+				const chip = DOM.append(chips, $(`span.chat-debug-cache-session-health-chip.cause-${stat.category}`));
+				DOM.append(chip, $(`span.codicon.codicon-${categoryIcon(stat.category)}`, { 'aria-hidden': 'true' }));
+				DOM.append(chip, $('span', undefined, localize('chatDebug.cache.sessionHealthChip', "{0} ×{1} · {2} tok", cacheBreakCategoryLabel(stat.category), stat.count, numberFormatter.value.format(stat.lostTokens))));
+			}
+		}
+
+		if (report.findings.length > 0) {
+			const list = DOM.append(container, $('.chat-debug-cache-findings'));
+			for (const finding of report.findings) {
+				this.renderFinding(list, finding);
+			}
+		}
+	}
+
 
 	/**
 	 * Select a turn (the B side of the diff) and refresh only the content
@@ -422,6 +611,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			: Math.min(indices.length - 1, Math.max(0, pos + delta));
 		this.selectTurn(indices[nextPos], { preventScroll: false });
 	}
+
 
 	/**
 	 * Render the agent filter dropdown at the top of the rail. Hidden when a
@@ -507,6 +697,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		rows: readonly IChunkBreakdownRow[],
 		totalA: number,
 		totalB: number,
+		bTokensPerChar: number | undefined,
 	): void {
 		const wrap = DOM.append(section, $('.chat-debug-cache-sig-breakdown'));
 		if (this.sigBreakdownOpen) {
@@ -531,6 +722,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		DOM.append(head, $('.cell.chunk', { role: 'columnheader' }, localize('chatDebug.cache.chunkCol', "Chunk")));
 		DOM.append(head, $('.cell.num', { role: 'columnheader' }, localize('chatDebug.cache.prevCol', "Previous")));
 		DOM.append(head, $('.cell.num', { role: 'columnheader' }, localize('chatDebug.cache.currCol', "Current")));
+		DOM.append(head, $('.cell.num', { role: 'columnheader' }, localize('chatDebug.cache.tokCol', "\u2248 tok")));
 		DOM.append(head, $('.cell.num', { role: 'columnheader' }, localize('chatDebug.cache.pctCol', "% of current")));
 
 		rows.forEach((r, i) => {
@@ -544,6 +736,10 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			DOM.append(chunk, $('span.chat-debug-cache-sig-breakdown-chunk-label', undefined, r.label));
 			DOM.append(row, $('.cell.num', { role: 'cell' }, r.aChars !== undefined ? numberFormatter.value.format(r.aChars) : '\u2014'));
 			DOM.append(row, $('.cell.num', { role: 'cell' }, r.bChars !== undefined ? numberFormatter.value.format(r.bChars) : '\u2014'));
+			// Token estimate for the current side, calibrated against the
+			// request's reported input tokens (chars \u00d7 tokens-per-char).
+			const tok = r.bChars !== undefined && bTokensPerChar !== undefined ? Math.round(r.bChars * bTokensPerChar) : undefined;
+			DOM.append(row, $('.cell.num', { role: 'cell' }, tok !== undefined ? numberFormatter.value.format(tok) : '\u2014'));
 			const pct = r.bChars !== undefined && totalB > 0 ? (r.bChars / totalB) * 100 : undefined;
 			DOM.append(row, $('.cell.num', { role: 'cell' }, pct !== undefined ? localize('chatDebug.cache.pctValue', "{0}%", pct.toFixed(1)) : '\u2014'));
 		});
@@ -553,6 +749,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		DOM.append(totals, $('.cell.chunk', { role: 'cell' }, localize('chatDebug.cache.totalRow', "Total")));
 		DOM.append(totals, $('.cell.num', { role: 'cell' }, numberFormatter.value.format(totalA)));
 		DOM.append(totals, $('.cell.num', { role: 'cell' }, numberFormatter.value.format(totalB)));
+		DOM.append(totals, $('.cell.num', { role: 'cell' }, bTokensPerChar !== undefined ? numberFormatter.value.format(Math.round(totalB * bTokensPerChar)) : '\u2014'));
 		DOM.append(totals, $('.cell.num', { role: 'cell' }, localize('chatDebug.cache.pctValue', "{0}%", '100')));
 	}
 
@@ -601,8 +798,31 @@ export class ChatDebugCacheExplorerView extends Disposable {
 	}
 
 	private renderRail(groups: readonly ITurnGroup[]): void {
+		// Idle-gap markers: a gap at or above the typical cache TTL between
+		// two consecutive turns means the cached prefix likely expired in
+		// between — make that visible in the rail before anyone clicks.
+		const gapBefore = (turnIndex: number): number | undefined => {
+			if (turnIndex <= 0) {
+				return undefined;
+			}
+			const prev = this.modelTurns[turnIndex - 1];
+			const curr = this.modelTurns[turnIndex];
+			const prevEnd = prev.created.getTime() + (prev.durationInMillis ?? 0);
+			const gapMinutes = (curr.created.getTime() - prevEnd) / 60_000;
+			return gapMinutes >= TTL_GAP_MINUTES ? gapMinutes : undefined;
+		};
+		const appendGapMarker = (gapMinutes: number): void => {
+			const gap = DOM.append(this.railList, $('.chat-debug-cache-rail-gap'));
+			DOM.append(gap, $('span.codicon.codicon-clock', { 'aria-hidden': 'true' }));
+			DOM.append(gap, $('span', undefined, localize('chatDebug.cache.railGap', "{0} min idle · cache likely expired", gapMinutes.toFixed(1))));
+		};
+
 		for (const group of groups) {
 			const collapsed = this.collapsedGroups.has(group.key);
+			const groupGap = group.turns.length > 0 ? gapBefore(group.turns[0].index) : undefined;
+			if (groupGap !== undefined) {
+				appendGapMarker(groupGap);
+			}
 			const header = DOM.append(this.railList, $('.chat-debug-cache-group-header'));
 			if (collapsed) {
 				header.classList.add('is-collapsed');
@@ -643,7 +863,15 @@ export class ChatDebugCacheExplorerView extends Disposable {
 				continue;
 			}
 
-			for (const { turn: evt, index: i } of group.turns) {
+			for (const [posInGroup, { turn: evt, index: i }] of group.turns.entries()) {
+				// Gaps before the first turn of a group render before the
+				// group header above; only intra-group gaps render here.
+				if (posInGroup > 0) {
+					const gap = gapBefore(i);
+					if (gap !== undefined) {
+						appendGapMarker(gap);
+					}
+				}
 				const row = DOM.append(this.railList, $('.chat-debug-cache-turn'));
 				this.railRowsByIndex.set(i, row);
 				if (i === this.selectedIndex) { row.classList.add('is-selected'); }
@@ -656,7 +884,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 				const top = DOM.append(main, $('.chat-debug-cache-turn-top'));
 				const source = DOM.append(top, $('span.chat-debug-cache-turn-source'));
 				source.textContent = evt.requestName || localize('chatDebug.cache.modelTurn', "Model Turn");
-				if (evt.cachedTokens !== undefined && evt.inputTokens) {
+				if (evt.inputTokens) {
 					const hit = computeCacheHit(evt);
 					const hitChip = DOM.append(top, $('span.chat-debug-cache-turn-chip.chat-debug-cache-turn-hit', undefined,
 						localize('chatDebug.cache.hitChip', "[cache {0}%]", formatCachePctInt(hit))));
@@ -705,142 +933,81 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		title.textContent = localize('chatDebug.cacheExplorer.title', "Cache Explorer — Prefix Diff");
 	}
 
-	private renderSummary(a: ISideData, b: ISideData, diff: ICacheDiffResult): void {
+	private renderSummary(a: ISideData, b: ISideData, diff: ICacheDiffResult, compareInputMessages: boolean, insights: readonly ICacheInsight[], optionsDiff: readonly IOptionDelta[]): void {
 		const row = DOM.append(this.content, $('.chat-debug-cache-summary'));
 		row.appendChild(this.renderSideCard(a, localize('chatDebug.cache.previousRequest', "Previous request")));
 		row.appendChild(this.renderSideCard(b, localize('chatDebug.cache.requestTitle', "Request")));
 
-		const breakCard = DOM.append(row, $('.chat-debug-cache-card.break'));
-		DOM.append(breakCard, $('.chat-debug-cache-card-h', undefined, localize('chatDebug.cache.performance', "Cache performance")));
-
-		// Section 1: cache hit headline + absolute counts
 		const hit = computeCacheHit(b.event);
 		const inputTokens = b.event.inputTokens ?? 0;
 		const cachedTokens = b.event.cachedTokens ?? 0;
 		const lostTokens = Math.max(0, inputTokens - cachedTokens);
-		const optionsDiff = computeOptionsDiff(a, b);
-		const systemChanged = (a.system ?? '') !== (b.system ?? '');
-		const toolsChanged = (a.tools ?? '') !== (b.tools ?? '');
-		// Treat the comparison as a continuation only when the *current* request
-		// is a continuation. The previous turn's shape doesn't change how the
-		// current request was sent on the wire, so labeling a normal full-input
-		// current request as "continuation" just because the prior turn was
-		// would be misleading. Keep this in sync with `shouldCompareInputMessages`.
-		const continuationComparison = b.requestShape.isContinuation;
-		const expiration = !continuationComparison && isLikelyCacheExpiration(hit, diff, optionsDiff, systemChanged, toolsChanged);
 
+		// Card border color tracks the worst finding \u2014 green/neutral when the
+		// loss is expected growth, red only for an avoidable break.
+		const breakCard = DOM.append(row, $('.chat-debug-cache-card.break'));
+		breakCard.classList.add(`is-${maxInsightSeverity(insights)}`);
+		DOM.append(breakCard, $('.chat-debug-cache-card-h', undefined, localize('chatDebug.cache.performance', "Cache performance")));
+
+		// Headline: hit % + the verdict (the first warning-or-worse finding).
+		const primary = primaryInsight(insights);
 		const headline = DOM.append(breakCard, $('.chat-debug-cache-card-headline'));
-		if (expiration) {
-			headline.textContent = localize('chatDebug.cache.expirationHeadline',
-				"{0}% cache hit \u2014 likely cache expiration",
-				formatCachePct(hit),
-			);
-		} else {
-			headline.textContent = localize('chatDebug.cache.hitHeadline', "{0}% cache hit", formatCachePct(hit));
-		}
+		headline.textContent = primary
+			? localize('chatDebug.cache.hitHeadlineVerdict', "{0}% cache hit \u2014 {1}", formatCachePct(hit), primary.title)
+			: localize('chatDebug.cache.hitHeadline', "{0}% cache hit", formatCachePct(hit));
 		const counts = DOM.append(breakCard, $('.chat-debug-cache-card-sub'));
-		counts.textContent = localize('chatDebug.cache.tokensReused',
-			"{0} of {1} input tokens reused",
-			numberFormatter.value.format(cachedTokens),
-			numberFormatter.value.format(inputTokens),
-		);
+		counts.textContent = lostTokens > 0 && inputTokens > 0
+			? localize('chatDebug.cache.tokensReusedLost',
+				"{0} of {1} input tokens reused \u00b7 {2} uncached ({3}%)",
+				numberFormatter.value.format(cachedTokens),
+				numberFormatter.value.format(inputTokens),
+				numberFormatter.value.format(lostTokens),
+				formatCachePct((lostTokens / inputTokens) * 100),
+			)
+			: localize('chatDebug.cache.tokensReused',
+				"{0} of {1} input tokens reused",
+				numberFormatter.value.format(cachedTokens),
+				numberFormatter.value.format(inputTokens),
+			);
 		if (b.requestShape.description) {
 			const shapeLine = DOM.append(breakCard, $('.chat-debug-cache-perf-line.chat-debug-cache-request-shape-note'));
 			shapeLine.textContent = b.requestShape.description;
 		}
 
-		// Section 2: where the cache broke
+		// Findings: each detected cause in cache-key order (model, tools,
+		// system, options, messages) \u2014 the first critical one is the earliest
+		// byte change and therefore the actual cache breaker.
 		DOM.append(breakCard, $('.chat-debug-cache-perf-rule'));
-		DOM.append(breakCard, $('.chat-debug-cache-perf-section-h', undefined, continuationComparison
-			? localize('chatDebug.cache.visibleWireInput', "Visible wire input")
-			: localize('chatDebug.cache.whereBroke', "Where the cache broke")));
-		const breakLine = DOM.append(breakCard, $('.chat-debug-cache-perf-line'));
-		if (expiration) {
-			breakLine.textContent = localize('chatDebug.cache.expirationNote',
-				"The prompt prefix matches but the model still treated this as a fresh request. Most likely the cached entry expired between requests.",
-			);
-		} else if (systemChanged) {
-			breakLine.textContent = localize('chatDebug.cache.systemBroke',
-				"System instructions changed — the cache was invalidated even though the message prefix matches.",
-			);
-		} else if (toolsChanged) {
-			breakLine.textContent = localize('chatDebug.cache.toolsBroke',
-				"Tool definitions changed — the catalog of available tools differs between requests, which invalidates the cache even though the message prefix matches.",
-			);
-			if (continuationComparison && diff.break) {
-				const deltaName = diff.break.index === 0
-					? localize('chatDebug.cache.firstMessage', "the first message")
-					: `messages[${diff.break.index}]`;
-				const deltaLine = DOM.append(breakCard, $('.chat-debug-cache-perf-line'));
-				deltaLine.textContent = localize('chatDebug.cache.continuationDeltaAlsoChanged',
-					"The visible wire delta also changed at {0}. That is expected when comparing consecutive continuation requests of different kinds, such as tool_search_output followed by a new user input.",
-					deltaName,
-				);
-			}
-		} else if (continuationComparison && diff.break) {
-			const componentName = diff.break.index === 0
-				? localize('chatDebug.cache.firstMessage', "the first message")
-				: `messages[${diff.break.index}]`;
-			breakLine.textContent = localize('chatDebug.cache.continuationDeltaBreak',
-				"The captured wire delta changed at {0} — {1}. This is a delta-to-delta comparison between consecutive Responses API requests, not the full reconstructed prompt prefix.",
-				componentName,
-				describeBreakKind(diff.break.kind, diff, b),
-			);
-			if (lostTokens > 0 && inputTokens > 0) {
-				const lostPct = (lostTokens / inputTokens) * 100;
-				const lossLine = DOM.append(breakCard, $('.chat-debug-cache-perf-line'));
-				lossLine.textContent = localize('chatDebug.cache.uncachedLine',
-					"Uncached in this request: {0} tokens ({1}% of this request)",
-					numberFormatter.value.format(lostTokens),
-					formatCachePct(lostPct),
-				);
-			}
-		} else if (diff.break) {
-			const componentName = diff.break.index === 0
-				? localize('chatDebug.cache.firstMessage', "the first message")
-				: `messages[${diff.break.index}]`;
-			breakLine.textContent = localize('chatDebug.cache.breakAt',
-				"At {0} — {1}",
-				componentName,
-				describeBreakKind(diff.break.kind, diff, b),
-			);
-			if (lostTokens > 0 && inputTokens > 0) {
-				const lostPct = (lostTokens / inputTokens) * 100;
-				const lossLine = DOM.append(breakCard, $('.chat-debug-cache-perf-line'));
-				lossLine.textContent = localize('chatDebug.cache.lossLine',
-					"Lost: {0} tokens ({1}% of this request)",
-					numberFormatter.value.format(lostTokens),
-					formatCachePct(lostPct),
-				);
-			}
-		} else if (optionsDiff.length > 0) {
-			breakLine.textContent = localize('chatDebug.cache.optionsBroke',
-				"Request options changed — the cache was invalidated even though the message prefix matches.",
-			);
-		} else if (continuationComparison) {
-			breakLine.textContent = localize('chatDebug.cache.continuationNoDeltaBreak', "No divergence detected in the captured wire delta. The full reconstructed prompt prefix is provider-side for this continuation request.");
-		} else {
-			breakLine.textContent = localize('chatDebug.cache.noBreak', "No prefix divergence detected.");
+		DOM.append(breakCard, $('.chat-debug-cache-perf-section-h', undefined, localize('chatDebug.cache.findings', "Findings")));
+		const list = DOM.append(breakCard, $('.chat-debug-cache-findings'));
+		if (insights.length === 0) {
+			DOM.append(list, $('.chat-debug-cache-finding-detail', undefined, localize('chatDebug.cache.noFindings', "No findings for this request pair.")));
+		}
+		for (const insight of insights) {
+			this.renderFinding(list, insight);
 		}
 
-		// Section 3: structural diff summary
-		DOM.append(breakCard, $('.chat-debug-cache-perf-rule'));
-		DOM.append(breakCard, $('.chat-debug-cache-perf-section-h', undefined, localize('chatDebug.cache.diffSummary', "Diff summary")));
-		const summaryLine = DOM.append(breakCard, $('.chat-debug-cache-perf-line'));
-		const inPlaceChanged = diff.counts.contentDrift + diff.counts.lengthChange;
-		const addedInB = diff.counts.onlyInB;
-		const droppedFromA = diff.counts.onlyInA;
-		const parts: string[] = [
-			localize('chatDebug.cache.summaryIdentical', "{0} identical", diff.counts.identical),
-			localize('chatDebug.cache.summaryChanged', "{0} in-place changed", inPlaceChanged),
-		];
-		if (addedInB > 0) {
-			parts.push(localize('chatDebug.cache.summaryAdded', "{0} added in this request", addedInB));
+		// Structural diff summary \u2014 only meaningful when messages were
+		// positionally compared (the counts are empty for continuations).
+		if (compareInputMessages) {
+			DOM.append(breakCard, $('.chat-debug-cache-perf-rule'));
+			DOM.append(breakCard, $('.chat-debug-cache-perf-section-h', undefined, localize('chatDebug.cache.diffSummary', "Diff summary")));
+			const summaryLine = DOM.append(breakCard, $('.chat-debug-cache-perf-line'));
+			const inPlaceChanged = diff.counts.contentDrift + diff.counts.lengthChange;
+			const addedInB = diff.counts.onlyInB;
+			const droppedFromA = diff.counts.onlyInA;
+			const parts: string[] = [
+				localize('chatDebug.cache.summaryIdentical', "{0} identical", diff.counts.identical),
+				localize('chatDebug.cache.summaryChanged', "{0} in-place changed", inPlaceChanged),
+			];
+			if (addedInB > 0) {
+				parts.push(localize('chatDebug.cache.summaryAdded', "{0} added in this request", addedInB));
+			}
+			if (droppedFromA > 0) {
+				parts.push(localize('chatDebug.cache.summaryDropped', "{0} dropped from previous", droppedFromA));
+			}
+			summaryLine.textContent = parts.join(' \u00b7 ');
 		}
-		if (droppedFromA > 0) {
-			parts.push(localize('chatDebug.cache.summaryDropped', "{0} dropped from previous", droppedFromA));
-		}
-		summaryLine.textContent = parts.join(' \u00b7 ');
 
 		// Inline one-liner: surface request-option drift right under the
 		// summary cards so it is visible regardless of which card the user
@@ -853,6 +1020,51 @@ export class ChatDebugCacheExplorerView extends Disposable {
 				optionsDiff.map(d => `${d.key} (${formatOptionValue(d.previous)} \u2192 ${formatOptionValue(d.current)})`).join(', '),
 			);
 		}
+	}
+
+	/**
+	 * Render one finding row: severity icon, title, evidence, and hint.
+	 * Findings that point at a Components entry render as a button that
+	 * reveals (scrolls to, expands, and flashes) that component.
+	 */
+	private renderFinding(list: HTMLElement, insight: ICacheInsight): void {
+		const isLink = !!insight.component;
+		const row = DOM.append(list, isLink ? $('button.chat-debug-cache-finding.is-clickable') : $('.chat-debug-cache-finding'));
+		DOM.append(row, $(`span.codicon.codicon-${findingIcon(insight.severity)}.chat-debug-cache-finding-icon.is-${insight.severity}`, { 'aria-hidden': 'true' }));
+		const body = DOM.append(row, $('.chat-debug-cache-finding-body'));
+		DOM.append(body, $('.chat-debug-cache-finding-title', undefined, insight.title));
+		if (insight.detail) {
+			DOM.append(body, $('.chat-debug-cache-finding-detail', undefined, insight.detail));
+		}
+		if (insight.hint) {
+			DOM.append(body, $('.chat-debug-cache-finding-hint', undefined, insight.hint));
+		}
+		if (isLink) {
+			row.title = localize('chatDebug.cache.findingJump', "Reveal {0} in Components", insight.component);
+			this.contentDisposables.add(DOM.addDisposableListener(row, DOM.EventType.CLICK, () => this.revealComponent(insight.component!)));
+		}
+	}
+
+
+	/**
+	 * Scroll the named Components entry into view, expand it, and flash it so
+	 * the eye lands on the right place. No-op when the component isn't part
+	 * of the current drift list (e.g. an identical message).
+	 */
+	private revealComponent(name: string): void {
+		const el = this.componentElements.get(name);
+		if (!el) {
+			return;
+		}
+		if (!this.openComponents.has(name)) {
+			this.openComponents.add(name);
+			el.classList.add('open');
+		}
+		el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+		// Remove + reflow + re-add so a second click restarts the animation.
+		el.classList.remove('flash');
+		void el.offsetWidth;
+		el.classList.add('flash');
 	}
 
 	private renderSideCard(data: ISideData, title?: string): HTMLElement {
@@ -950,6 +1162,9 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		const driftEntry = DOM.append(legend, $('span.chat-debug-cache-sig-legend-entry'));
 		DOM.append(driftEntry, $('span.chat-debug-cache-sig-swatch.role-drift'));
 		DOM.append(driftEntry, DOM.$('span', undefined, localize('chatDebug.cache.driftLegend', "drift")));
+		const groupEntry = DOM.append(legend, $('span.chat-debug-cache-sig-legend-entry'));
+		DOM.append(groupEntry, $('span.chat-debug-cache-sig-swatch.role-coalesced'));
+		DOM.append(groupEntry, DOM.$('span', undefined, localize('chatDebug.cache.groupLegend', "small messages (grouped)")));
 
 		// Per-side char-length sequences. We prepend synthetic 'system' and
 		// 'tools' segments (when present) so they show up in the bar even
@@ -963,18 +1178,20 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			readonly label: string;
 			/** True if this is one of the synthetic prefix segments (system/tools). */
 			readonly synthetic: boolean;
+			/** Components-section anchor for this segment (e.g. `messages[3]`). */
+			readonly component: string;
 		}
 		const toSegments = (side: ISideData, isA: boolean): ISegment[] => {
 			const segs: ISegment[] = [];
 			const sys = side.system;
 			if (sys) {
 				const other = isA ? b.system : a.system;
-				segs.push({ role: 'system', chars: sys.length, drift: sys !== (other ?? ''), label: 'system', synthetic: true });
+				segs.push({ role: 'system', chars: sys.length, drift: sys !== (other ?? ''), label: 'system', synthetic: true, component: 'system' });
 			}
 			const tools = side.tools;
 			if (tools) {
 				const other = isA ? b.tools : a.tools;
-				segs.push({ role: 'tools', chars: tools.length, drift: tools !== (other ?? ''), label: 'tools', synthetic: true });
+				segs.push({ role: 'tools', chars: tools.length, drift: tools !== (other ?? ''), label: 'tools', synthetic: true, component: 'tools' });
 			}
 			side.inputMessages.forEach((m, i) => {
 				const tok = diff.signature[i];
@@ -983,7 +1200,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 					|| kind === CacheDiffKind.LengthChange
 					|| (isA && kind === CacheDiffKind.OnlyInA)
 					|| (!isA && kind === CacheDiffKind.OnlyInB));
-				segs.push({ role: m.role, chars: m.charLength, drift, label: m.name ? `${m.role}-${m.name}` : m.role, synthetic: false });
+				segs.push({ role: m.role, chars: m.charLength, drift, label: m.name ? `${m.role}-${m.name}` : m.role, synthetic: false, component: `messages[${i}]` });
 			});
 			return segs;
 		};
@@ -1021,28 +1238,88 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			return undefined;
 		};
 
-		const buildLane = (label: string, segs: readonly ISegment[], breakPos: number | undefined): HTMLElement => {
+		// Estimated tokens per char, calibrated against the OTel-reported
+		// input token count for each side. Linear, so it doesn't change the
+		// bar proportions — it turns char counts into the unit that's billed.
+		const aTokensPerChar = a.event.inputTokens && totalA > 0 ? a.event.inputTokens / totalA : undefined;
+		const bTokensPerChar = b.event.inputTokens && totalB > 0 ? b.event.inputTokens / totalB : undefined;
+
+		const buildLane = (label: string, segs: readonly ISegment[], breakPos: number | undefined, tokensPerChar: number | undefined): HTMLElement => {
 			const row = $('.chat-debug-cache-sig-lane-row');
 			DOM.append(row, $('.chat-debug-cache-sig-lane-label', undefined, label));
 			const bar = DOM.append(row, $('.chat-debug-cache-sig-bar'));
-			let sideTotal = 0;
-			for (const s of segs) {
-				if (s.chars <= 0) {
-					sideTotal += s.chars;
-					continue;
-				}
-				const widthPct = (s.chars / max) * 100;
+			const sideTotal = segs.reduce((sum, s) => sum + s.chars, 0);
+
+			const sizeText = (chars: number) => tokensPerChar !== undefined
+				? localize('chatDebug.cache.segSizeTokens', "{0} chars (\u2248 {1} tok)", numberFormatter.value.format(chars), numberFormatter.value.format(Math.round(chars * tokensPerChar)))
+				: localize('chatDebug.cache.segSizeChars', "{0} chars", numberFormatter.value.format(chars));
+
+			const renderSegment = (s: ISegment) => {
 				const seg = DOM.append(bar, $(`span.chat-debug-cache-sig-seg.role-${roleClass(s.role)}`));
 				if (s.drift) {
 					seg.classList.add('is-drift');
+					// Drifting segments have a matching Components entry \u2014 make
+					// them clickable so a red mark in the bar can be inspected
+					// directly instead of hunting for it in the accordion.
+					seg.classList.add('is-clickable');
+					seg.setAttribute('role', 'button');
+					seg.tabIndex = 0;
+					const reveal = () => this.revealComponent(s.component);
+					this.contentDisposables.add(DOM.addDisposableListener(seg, DOM.EventType.CLICK, reveal));
+					this.contentDisposables.add(DOM.addDisposableListener(seg, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+						if (e.key === 'Enter' || e.key === ' ') {
+							e.preventDefault();
+							reveal();
+						}
+					}));
 				}
-				seg.style.width = `${widthPct}%`;
-				seg.title = `${s.label}: ${numberFormatter.value.format(s.chars)} chars` + (s.drift ? ` \u2014 drift` : '');
-				if (s.chars > max * 0.05) {
-					seg.textContent = `${s.label}:${numberFormatter.value.format(s.chars)}`;
+				seg.style.width = `${(s.chars / max) * 100}%`;
+				seg.title = s.drift
+					? localize('chatDebug.cache.segDriftTooltip', "{0} ({1}): {2} \u2014 drifted. Click to inspect.", s.component, s.label, sizeText(s.chars))
+					: localize('chatDebug.cache.segTooltip', "{0} ({1}): {2}", s.component, s.label, sizeText(s.chars));
+				// In-bar text is the char count alone \u2014 the role is already
+				// color-coded, and partial labels ("user:24,9\u2026") read worse
+				// than none. Only segments wide enough for the digits get text.
+				if (s.chars > max * 0.06) {
+					seg.textContent = numberFormatter.value.format(s.chars);
 				}
-				sideTotal += s.chars;
+			};
+
+			// Runs of small same-kind messages render as one muted group so
+			// dozens of tiny tool/assistant slivers don't turn the bar into
+			// noise. Drift and synthetic (system/tools) segments always render
+			// individually; a "run" of one keeps its own colors too.
+			const renderGroup = (group: ISegment[]) => {
+				if (group.length === 1) {
+					renderSegment(group[0]);
+					return;
+				}
+				const chars = group.reduce((sum, s) => sum + s.chars, 0);
+				const seg = DOM.append(bar, $('span.chat-debug-cache-sig-seg.role-coalesced'));
+				seg.style.width = `${(chars / max) * 100}%`;
+				seg.title = localize('chatDebug.cache.segGroupTooltip', "{0} \u2026 {1}: {2} small messages, {3}", group[0].component, group[group.length - 1].component, group.length, sizeText(chars));
+			};
+
+			const COALESCE_THRESHOLD = max * 0.015;
+			let pending: ISegment[] = [];
+			for (const s of segs) {
+				if (s.chars <= 0) {
+					continue;
+				}
+				if (!s.synthetic && !s.drift && s.chars < COALESCE_THRESHOLD) {
+					pending.push(s);
+					continue;
+				}
+				if (pending.length) {
+					renderGroup(pending);
+					pending = [];
+				}
+				renderSegment(s);
 			}
+			if (pending.length) {
+				renderGroup(pending);
+			}
+
 			// Pad the lane so both sides share the same x scale.
 			if (sideTotal < max) {
 				const pad = DOM.append(bar, $('span.chat-debug-cache-sig-seg.role-empty'));
@@ -1058,13 +1335,47 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		};
 
 		const lanes = DOM.append(section, $('.chat-debug-cache-sig-lanes'));
-		lanes.appendChild(buildLane(localize('chatDebug.cache.lanePrevious', "Previous"), aSegs, breakCharPos(aSegs)));
-		lanes.appendChild(buildLane(localize('chatDebug.cache.laneCurrent', "Current"), bSegs, breakCharPos(bSegs)));
+		lanes.appendChild(buildLane(localize('chatDebug.cache.lanePrevious', "Previous"), aSegs, breakCharPos(aSegs), aTokensPerChar));
+		lanes.appendChild(buildLane(localize('chatDebug.cache.laneCurrent', "Current"), bSegs, breakCharPos(bSegs), bTokensPerChar));
+
+		// Prefix-match rail: a thin bar under the lanes splitting the current
+		// request into the span that byte-matches the previous request (cache-
+		// servable) and the span after the first drift (recomputed). Walks the
+		// current side's segments in render order — system, tools, messages —
+		// so a tools/system change correctly pulls the boundary to the front.
+		if (compareInputMessages && totalB > 0) {
+			let reused = 0;
+			let sawDrift = false;
+			for (const s of bSegs) {
+				if (s.drift) {
+					sawDrift = true;
+					break;
+				}
+				reused += s.chars;
+			}
+			if (!sawDrift) {
+				reused = totalB;
+			}
+			const railRow = DOM.append(lanes, $('.chat-debug-cache-sig-lane-row.reuse'));
+			DOM.append(railRow, $('.chat-debug-cache-sig-lane-label', undefined, localize('chatDebug.cache.reuseLane', "Match")));
+			const rail = DOM.append(railRow, $('.chat-debug-cache-sig-reuse-rail'));
+			if (reused > 0) {
+				const ok = DOM.append(rail, $('span.chat-debug-cache-sig-reuse-seg.is-reused'));
+				ok.style.width = `${(reused / max) * 100}%`;
+				ok.title = localize('chatDebug.cache.reusedTooltip', "Byte-identical to the previous request: {0} chars can be served from cache", numberFormatter.value.format(reused));
+			}
+			if (totalB - reused > 0) {
+				const bad = DOM.append(rail, $('span.chat-debug-cache-sig-reuse-seg.is-recomputed'));
+				bad.style.width = `${((totalB - reused) / max) * 100}%`;
+				bad.title = localize('chatDebug.cache.recomputedTooltip', "Diverges from the previous request: {0} chars are recomputed", numberFormatter.value.format(totalB - reused));
+			}
+			DOM.append(railRow, $('.chat-debug-cache-sig-lane-total', undefined, localize('chatDebug.cache.reusePct', "{0}% match", String(Math.floor((reused / totalB) * 100)))));
+		}
 
 		// Per-chunk breakdown: an exact, scannable table of where the bytes go on
 		// each side. Complements the bar (which hides small chunks) and the
 		// Components section (which only lists drifting components).
-		this.renderChunkBreakdown(section, alignSignatureChunks(aSegs, bSegs), totalA, totalB);
+		this.renderChunkBreakdown(section, alignSignatureChunks(aSegs, bSegs), totalA, totalB, bTokensPerChar);
 
 		// Single-line text summary below the bars. Compute this in the
 		// same order the provider sees cache-keying inputs: system, tools,
@@ -1146,7 +1457,8 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		}
 	}
 
-	private renderComponents(drift: readonly IComponentDrift[], a: ISideData, b: ISideData, compareInputMessages: boolean): void {
+	private renderComponents(drift: readonly IComponentDrift[], a: ISideData, b: ISideData, compareInputMessages: boolean, identicalCount: number): void {
+		this.componentElements.clear();
 		const section = DOM.append(this.content, $('.chat-debug-cache-section'));
 		DOM.append(section, $('h3.chat-debug-cache-section-h', undefined, localize('chatDebug.cache.componentsHeading', "Components")));
 		if (!compareInputMessages && b.requestShape.isContinuation) {
@@ -1167,11 +1479,19 @@ export class ChatDebugCacheExplorerView extends Disposable {
 
 		for (const c of effectiveDrift) {
 			const item = DOM.append(acc, $('.chat-debug-cache-acc-item'));
+			this.componentElements.set(c.name, item);
 			item.classList.add(c.status);
 			if (this.openComponents.has(c.name)) { item.classList.add('open'); }
 			const head = DOM.append(item, $('.chat-debug-cache-acc-head'));
 			DOM.append(head, $('span.chat-debug-cache-chev'));
 			const name = DOM.append(head, $('.chat-debug-cache-acc-name'));
+			// Lead with the same role swatch the signature bar uses so a
+			// component reads as "one of those colored pieces", not an
+			// anonymous diff row.
+			const swatchRole = c.role ?? (c.name === 'system' || c.name === 'tools' ? c.name : undefined);
+			if (swatchRole) {
+				DOM.append(name, $(`span.chat-debug-cache-sig-swatch.role-${roleClass(swatchRole)}`, { 'aria-hidden': 'true' }));
+			}
 			if (c.role) { DOM.append(name, $('span.role', undefined, c.role)); }
 			DOM.append(name, DOM.$('span', undefined, c.name));
 			const badge = DOM.append(head, $(`span.chat-debug-cache-acc-badge.${c.status}`));
@@ -1193,6 +1513,17 @@ export class ChatDebugCacheExplorerView extends Disposable {
 				note.title = truncationNote;
 				head.title = truncationNote;
 			}
+			// One-line structural summary of the change — "first 130 chars
+			// removed", "edited in place at char N" — so the red/green diff
+			// below has a conclusion to verify rather than being the only
+			// way to understand what happened.
+			if (aText && bText && aText !== bText) {
+				const dv = analyzeStringDivergence(aText, bText);
+				if (dv) {
+					const changeNote = DOM.append(body, $('.chat-debug-cache-acc-change-note'));
+					changeNote.textContent = localize('chatDebug.cache.changeNote', "What changed: {0}", describeStringDivergence(dv));
+				}
+			}
 			body.appendChild(this.renderComponentDiff(aText, bText, c.aSize, c.bSize));
 
 			this.contentDisposables.add(DOM.addDisposableListener(head, DOM.EventType.CLICK, () => {
@@ -1204,6 +1535,14 @@ export class ChatDebugCacheExplorerView extends Disposable {
 					item.classList.add('open');
 				}
 			}));
+		}
+
+		// The accordion only lists drifting components; say how much of the
+		// prompt was identical so "2 entries" isn't misread as "the request
+		// only had 2 messages".
+		if (compareInputMessages && identicalCount > 0) {
+			const note = DOM.append(section, $('.chat-debug-cache-acc-identical-note'));
+			note.textContent = localize('chatDebug.cache.identicalNote', "{0} identical message(s) not shown — they extend the shared, cache-servable prefix.", identicalCount);
 		}
 	}
 
@@ -1457,6 +1796,30 @@ function currentDeltaComponent(side: ISideData): IComponentDrift {
 	};
 }
 
+/** Codicon name for a break-cause category (rail chips, health card). */
+function categoryIcon(category: CacheBreakCategory): string {
+	switch (category) {
+		case CacheBreakCategory.Healthy: return 'check';
+		case CacheBreakCategory.Expiration: return 'clock';
+		case CacheBreakCategory.Model: return 'hubot';
+		case CacheBreakCategory.Tools: return 'tools';
+		case CacheBreakCategory.System: return 'gear';
+		case CacheBreakCategory.Options: return 'symbol-parameter';
+		case CacheBreakCategory.History: return 'history';
+		case CacheBreakCategory.Unknown: return 'question';
+	}
+}
+
+/** Codicon name for a finding severity. */
+function findingIcon(severity: CacheInsightSeverity): string {
+	switch (severity) {
+		case CacheInsightSeverity.Ok: return 'check';
+		case CacheInsightSeverity.Info: return 'info';
+		case CacheInsightSeverity.Warning: return 'warning';
+		case CacheInsightSeverity.Critical: return 'error';
+	}
+}
+
 function badgeLabel(status: CacheDiffKind): string {
 	switch (status) {
 		case CacheDiffKind.Identical: return localize('chatDebug.cache.badge.identical', "identical");
@@ -1500,33 +1863,6 @@ function describeTruncation(aText: string, bText: string): string | undefined {
 		side,
 		numberFormatter.value.format(parseInt(match[1], 10)),
 	);
-}
-
-/**
- * One-line human-readable description of the kind of change at the cache
- * break, including the role and size of the divergent message when known.
- */
-function describeBreakKind(kind: Exclude<CacheDiffKind, CacheDiffKind.Identical>, diff: ICacheDiffResult, b: ISideData): string {
-	const tok = diff.signature.find(t => t.index === diff.break?.index);
-	const role = tok?.bRole ?? tok?.aRole ?? 'message';
-	const bMsg = b.inputMessages[diff.break?.index ?? -1];
-	const charsB = bMsg ? numberFormatter.value.format(bMsg.charLength) : undefined;
-	switch (kind) {
-		case CacheDiffKind.OnlyInB:
-			return charsB
-				? localize('chatDebug.cache.kind.added', "added {0} message ({1} chars)", role, charsB)
-				: localize('chatDebug.cache.kind.addedNoSize', "added {0} message", role);
-		case CacheDiffKind.OnlyInA:
-			return localize('chatDebug.cache.kind.dropped', "previous {0} message dropped", role);
-		case CacheDiffKind.ContentDrift:
-			return charsB
-				? localize('chatDebug.cache.kind.contentDrift', "{0} message body changed ({1} chars)", role, charsB)
-				: localize('chatDebug.cache.kind.contentDriftNoSize', "{0} message body changed", role);
-		case CacheDiffKind.LengthChange:
-			return charsB
-				? localize('chatDebug.cache.kind.lengthChange', "{0} message resized to {1} chars", role, charsB)
-				: localize('chatDebug.cache.kind.lengthChangeNoSize', "{0} message size changed", role);
-	}
 }
 
 function computeCacheHit(event: IChatDebugModelTurnEvent): number {
@@ -1694,6 +2030,18 @@ function sideOptions(side: ISideData): Record<string, unknown> {
 		out.model = side.event.model;
 	}
 	Object.assign(out, parseOptions(side.content?.requestOptions));
+	// Effort is a first-class cost/latency lever, but a thinking-capable
+	// request that doesn't send one falls back to the provider's server-side
+	// default with nothing on the wire. Surface that explicitly so the table
+	// answers "what effort ran?" instead of silently omitting the row \u2014 and
+	// so a request that *stops* sending effort shows up as an option change.
+	const hasEffort = out['output_config.effort'] !== undefined
+		|| out['reasoning.effort'] !== undefined
+		|| out['reasoning_effort'] !== undefined;
+	const hasThinking = Object.keys(out).some(k => k === 'thinking' || k.startsWith('thinking.'));
+	if (!hasEffort && hasThinking) {
+		out['output_config.effort'] = localize('chatDebug.cache.effortNotSent', "(not sent \u2014 provider default)");
+	}
 	return out;
 }
 
@@ -1764,33 +2112,6 @@ function formatOptionValue(value: unknown): string {
 	} catch {
 		return String(value);
 	}
-}
-
-/**
- * Cache "expiration" heuristic. The provider doesn't tell us *why* it
- * invalidated a cache entry, so this is a best-effort guess: if the
- * structural diff says the prompt prefix is byte-identical AND the
- * system instructions match AND the tool catalog matches AND the
- * request options match AND the model still reports 0 cached input
- * tokens, expiration is the most likely cause. Other causes we cannot
- * distinguish from this signal alone include provider-side eviction
- * under cache pressure, server-side restarts, and per-tenant quota
- * resets. The headline copy in the UI says "likely" for that reason.
- */
-function isLikelyCacheExpiration(hitPct: number, diff: ICacheDiffResult, optionsDiff: readonly IOptionDelta[], systemChanged: boolean, toolsChanged: boolean): boolean {
-	if (hitPct >= 1) {
-		return false;
-	}
-	if (diff.break) {
-		return false;
-	}
-	if (optionsDiff.length > 0) {
-		return false;
-	}
-	if (systemChanged || toolsChanged) {
-		return false;
-	}
-	return true;
 }
 
 const DIFF_OPTIONS = {

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
@@ -129,11 +129,13 @@ export class ChatDebugCacheExplorerView extends Disposable {
 	/** Rail turn-row elements by turn index, for in-place selection updates without rebuilding the rail. */
 	private readonly railRowsByIndex = new Map<number, HTMLElement>();
 	/**
-	 * Component accordion items by component name (`system`, `tools`,
+	 * Component accordion entries by component name (`system`, `tools`,
 	 * `messages[i]`), so findings and signature segments can reveal the
-	 * matching entry. Rebuilt on every content render.
+	 * matching entry. We track both the outer item (for the open/flash
+	 * classes and scroll target) and the inner header (the focus target).
+	 * Rebuilt on every content render.
 	 */
-	private readonly componentElements = new Map<string, HTMLElement>();
+	private readonly componentElements = new Map<string, { item: HTMLElement; head: HTMLElement }>();
 	/** Selection index the breaking component was last auto-expanded for. */
 	private autoOpenedForIndex = -1;
 	/**
@@ -1029,7 +1031,9 @@ export class ChatDebugCacheExplorerView extends Disposable {
 	 */
 	private renderFinding(list: HTMLElement, insight: ICacheInsight): void {
 		const isLink = !!insight.component;
-		const row = DOM.append(list, isLink ? $('button.chat-debug-cache-finding.is-clickable') : $('.chat-debug-cache-finding'));
+		// Explicit `type="button"` keeps the row from being treated as a
+		// submit button if a future ancestor `<form>` is ever introduced.
+		const row = DOM.append(list, isLink ? $('button.chat-debug-cache-finding.is-clickable', { type: 'button' }) : $('.chat-debug-cache-finding'));
 		DOM.append(row, $(`span.codicon.codicon-${findingIcon(insight.severity)}.chat-debug-cache-finding-icon.is-${insight.severity}`, { 'aria-hidden': 'true' }));
 		const body = DOM.append(row, $('.chat-debug-cache-finding-body'));
 		DOM.append(body, $('.chat-debug-cache-finding-title', undefined, insight.title));
@@ -1052,19 +1056,25 @@ export class ChatDebugCacheExplorerView extends Disposable {
 	 * of the current drift list (e.g. an identical message).
 	 */
 	private revealComponent(name: string): void {
-		const el = this.componentElements.get(name);
-		if (!el) {
+		const entry = this.componentElements.get(name);
+		if (!entry) {
 			return;
 		}
+		const { item, head } = entry;
 		if (!this.openComponents.has(name)) {
 			this.openComponents.add(name);
-			el.classList.add('open');
+			item.classList.add('open');
+			head.setAttribute('aria-expanded', 'true');
 		}
-		el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+		item.scrollIntoView({ behavior: 'smooth', block: 'start' });
 		// Remove + reflow + re-add so a second click restarts the animation.
-		el.classList.remove('flash');
-		void el.offsetWidth;
-		el.classList.add('flash');
+		item.classList.remove('flash');
+		void item.offsetWidth;
+		item.classList.add('flash');
+		// Move focus to the revealed header so keyboard / screen reader users
+		// know where the activation landed. preventScroll because we already
+		// did the smooth-scroll above and don't want focus to jump-snap on top.
+		head.focus({ preventScroll: true });
 	}
 
 	private renderSideCard(data: ISideData, title?: string): HTMLElement {
@@ -1277,6 +1287,12 @@ export class ChatDebugCacheExplorerView extends Disposable {
 				seg.title = s.drift
 					? localize('chatDebug.cache.segDriftTooltip', "{0} ({1}): {2} \u2014 drifted. Click to inspect.", s.component, s.label, sizeText(s.chars))
 					: localize('chatDebug.cache.segTooltip', "{0} ({1}): {2}", s.component, s.label, sizeText(s.chars));
+				// Mirror the tooltip into an accessible name so screen readers
+				// announce what the button-role span does. Only drift segments
+				// are focusable, so non-drift slivers don't need one.
+				if (s.drift) {
+					seg.setAttribute('aria-label', seg.title);
+				}
 				// In-bar text is the char count alone \u2014 the role is already
 				// color-coded, and partial labels ("user:24,9\u2026") read worse
 				// than none. Only segments wide enough for the digits get text.
@@ -1479,10 +1495,16 @@ export class ChatDebugCacheExplorerView extends Disposable {
 
 		for (const c of effectiveDrift) {
 			const item = DOM.append(acc, $('.chat-debug-cache-acc-item'));
-			this.componentElements.set(c.name, item);
 			item.classList.add(c.status);
-			if (this.openComponents.has(c.name)) { item.classList.add('open'); }
+			const isOpen = this.openComponents.has(c.name);
+			if (isOpen) { item.classList.add('open'); }
 			const head = DOM.append(item, $('.chat-debug-cache-acc-head'));
+			this.componentElements.set(c.name, { item, head });
+			// Expose the header as an expand/collapse button so keyboard and
+			// screen reader users can operate it the same way mouse users can.
+			head.tabIndex = 0;
+			head.setAttribute('role', 'button');
+			head.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
 			DOM.append(head, $('span.chat-debug-cache-chev'));
 			const name = DOM.append(head, $('.chat-debug-cache-acc-name'));
 			// Lead with the same role swatch the signature bar uses so a
@@ -1526,13 +1548,22 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			}
 			body.appendChild(this.renderComponentDiff(aText, bText, c.aSize, c.bSize));
 
-			this.contentDisposables.add(DOM.addDisposableListener(head, DOM.EventType.CLICK, () => {
+			const toggle = () => {
 				if (this.openComponents.has(c.name)) {
 					this.openComponents.delete(c.name);
 					item.classList.remove('open');
+					head.setAttribute('aria-expanded', 'false');
 				} else {
 					this.openComponents.add(c.name);
 					item.classList.add('open');
+					head.setAttribute('aria-expanded', 'true');
+				}
+			};
+			this.contentDisposables.add(DOM.addDisposableListener(head, DOM.EventType.CLICK, toggle));
+			this.contentDisposables.add(DOM.addDisposableListener(head, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault();
+					toggle();
 				}
 			}));
 		}

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheInsights.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheInsights.ts
@@ -1,0 +1,823 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Heuristics engine for the Cache Explorer. Takes the raw diff between two
+ * requests (A = previous, B = current) and produces an ordered list of
+ * human-readable findings explaining *why* the prompt cache behaved the way
+ * it did and what — if anything — can be done about it.
+ *
+ * The heuristics mirror how providers key prefix caches. The prompt renders
+ * as `tools → system → messages`, and a byte change anywhere invalidates
+ * everything after it. So findings are emitted in cache-key order: the first
+ * non-OK finding is the earliest (and therefore the real) cache breaker.
+ *
+ * All functions are pure — no DOM, no services — so they can be unit tested
+ * in isolation.
+ */
+
+import { safeIntl } from '../../../../../base/common/date.js';
+import { localize } from '../../../../../nls.js';
+import { CacheDiffKind, ICacheDiffResult, INormalizedMessage } from './chatDebugCacheDiff.js';
+
+const numberFormatter = safeIntl.NumberFormat();
+
+function fmt(n: number): string {
+	return numberFormatter.value.format(n);
+}
+
+/** Severity of a single cache finding. Rendered as a codicon + color. */
+export const enum CacheInsightSeverity {
+	/** Expected, healthy behavior (e.g. new turn appended). */
+	Ok = 'ok',
+	/** Context that helps interpretation but isn't actionable. */
+	Info = 'info',
+	/** Suspicious but not definitively avoidable (e.g. likely expiration). */
+	Warning = 'warning',
+	/** An avoidable cache break the user should investigate. */
+	Critical = 'critical',
+}
+
+/**
+ * Coarse classification of what broke (or didn't break) the cache for one
+ * request pair. Used for rail chips and cross-turn aggregation.
+ */
+export const enum CacheBreakCategory {
+	/** Pure append or fully stable prefix — the cache behaved as designed. */
+	Healthy = 'healthy',
+	/** Prefix byte-identical but the cache still missed — TTL/eviction. */
+	Expiration = 'expiration',
+	Model = 'model',
+	Tools = 'tools',
+	System = 'system',
+	Options = 'options',
+	/** Conversation history rewritten or truncated in place. */
+	History = 'history',
+	/** Continuations and other pairs we can't classify. */
+	Unknown = 'unknown',
+}
+
+/** One human-readable finding about the cache behavior of the current request. */
+export interface ICacheInsight {
+	readonly severity: CacheInsightSeverity;
+	/** Short, scannable summary — doubles as the headline verdict for the first non-OK finding. */
+	readonly title: string;
+	/** Evidence: what exactly differs and by how much. */
+	readonly detail?: string;
+	/** Actionable guidance derived from how prefix caches work. */
+	readonly hint?: string;
+	/** Name of the Components entry this finding refers to (e.g. `system`, `tools`, `messages[7]`). */
+	readonly component?: string;
+	/** Break category this finding contributes to, for cross-turn aggregation. */
+	readonly category?: CacheBreakCategory;
+}
+
+/** A request-option change, pre-formatted by the caller for display. */
+export interface ICacheInsightOptionDelta {
+	readonly key: string;
+	readonly previousLabel: string;
+	readonly currentLabel: string;
+}
+
+export interface ICacheInsightsInput {
+	readonly aModel: string | undefined;
+	readonly bModel: string | undefined;
+	readonly aSystem: string | undefined;
+	readonly bSystem: string | undefined;
+	readonly aTools: string | undefined;
+	readonly bTools: string | undefined;
+	readonly aMessages: readonly INormalizedMessage[];
+	readonly bMessages: readonly INormalizedMessage[];
+	readonly diff: ICacheDiffResult;
+	readonly optionsDiff: readonly ICacheInsightOptionDelta[];
+	/** Cache hit percentage (0-100) reported for the current request. */
+	readonly hitPct: number;
+	/** Total input tokens reported for the current request (0 when unknown). */
+	readonly inputTokens: number;
+	/** Minutes elapsed between the start of the previous and the current request. */
+	readonly minutesSincePrevious: number | undefined;
+	/** True when the current request is a Responses API continuation (delta-only wire input). */
+	readonly isContinuation: boolean;
+	/** True when the previous request is a Responses API continuation. */
+	readonly previousIsContinuation: boolean;
+	/** False when message-level positional diffing is suppressed (either side is a continuation). */
+	readonly compareInputMessages: boolean;
+}
+
+/** How two unequal strings relate to each other structurally. */
+export const enum StringDivergenceShape {
+	/** B is a strict suffix of A — leading bytes were removed. */
+	LeadingRemoved = 'leadingRemoved',
+	/** A is a strict suffix of B — bytes were prepended. */
+	LeadingAdded = 'leadingAdded',
+	/** B is a strict prefix of A — trailing bytes were removed. */
+	TrailingRemoved = 'trailingRemoved',
+	/** A is a strict prefix of B — bytes were appended. */
+	TrailingAdded = 'trailingAdded',
+	/** The change happens somewhere in the middle. */
+	InnerEdit = 'innerEdit',
+}
+
+/** Maximum excerpt length captured for the changed region on each side. */
+const CHANGED_EXCERPT_CAP = 120;
+
+export interface IStringDivergence {
+	readonly shape: StringDivergenceShape;
+	/** Number of leading chars shared by both sides. */
+	readonly commonPrefix: number;
+	/** Number of trailing chars shared by both sides (disjoint from the prefix). */
+	readonly commonSuffix: number;
+	readonly aLength: number;
+	readonly bLength: number;
+	/** Excerpt of the changed region on the A side (capped). */
+	readonly aChanged: string;
+	/** Excerpt of the changed region on the B side (capped). */
+	readonly bChanged: string;
+}
+
+/**
+ * Locate where two strings diverge: the shared leading/trailing spans and
+ * the changed region in between. Returns `undefined` when the strings are
+ * equal. The common prefix and suffix never overlap, so
+ * `commonPrefix + commonSuffix <= min(aLength, bLength)`.
+ */
+export function analyzeStringDivergence(a: string, b: string): IStringDivergence | undefined {
+	if (a === b) {
+		return undefined;
+	}
+	const aLength = a.length;
+	const bLength = b.length;
+	const minLength = Math.min(aLength, bLength);
+	let commonPrefix = 0;
+	while (commonPrefix < minLength && a.charCodeAt(commonPrefix) === b.charCodeAt(commonPrefix)) {
+		commonPrefix++;
+	}
+	let commonSuffix = 0;
+	while (commonSuffix < minLength - commonPrefix && a.charCodeAt(aLength - 1 - commonSuffix) === b.charCodeAt(bLength - 1 - commonSuffix)) {
+		commonSuffix++;
+	}
+
+	let shape: StringDivergenceShape;
+	if (commonPrefix === bLength && bLength < aLength) {
+		shape = StringDivergenceShape.TrailingRemoved;
+	} else if (commonPrefix === aLength && aLength < bLength) {
+		shape = StringDivergenceShape.TrailingAdded;
+	} else if (commonSuffix === bLength && bLength < aLength) {
+		shape = StringDivergenceShape.LeadingRemoved;
+	} else if (commonSuffix === aLength && aLength < bLength) {
+		shape = StringDivergenceShape.LeadingAdded;
+	} else {
+		shape = StringDivergenceShape.InnerEdit;
+	}
+
+	return {
+		shape,
+		commonPrefix,
+		commonSuffix,
+		aLength,
+		bLength,
+		aChanged: a.substring(commonPrefix, aLength - commonSuffix).slice(0, CHANGED_EXCERPT_CAP),
+		bChanged: b.substring(commonPrefix, bLength - commonSuffix).slice(0, CHANGED_EXCERPT_CAP),
+	};
+}
+
+/** One-line human-readable description of a string divergence. */
+export function describeStringDivergence(d: IStringDivergence): string {
+	switch (d.shape) {
+		case StringDivergenceShape.TrailingAdded:
+			return localize('chatDebug.cache.div.appended', "{0} chars appended — the previous content survives as a shared prefix", fmt(d.bLength - d.aLength));
+		case StringDivergenceShape.TrailingRemoved:
+			return localize('chatDebug.cache.div.truncated', "last {0} chars removed — the remaining content still matches the previous bytes", fmt(d.aLength - d.bLength));
+		case StringDivergenceShape.LeadingAdded:
+			return localize('chatDebug.cache.div.prepended', "{0} chars prepended — this block no longer starts with the same bytes", fmt(d.bLength - d.aLength));
+		case StringDivergenceShape.LeadingRemoved:
+			return localize('chatDebug.cache.div.leadingRemoved', "first {0} chars removed — this block no longer starts with the same bytes", fmt(d.aLength - d.bLength));
+		case StringDivergenceShape.InnerEdit:
+			return localize('chatDebug.cache.div.innerEdit', "edited in place — first difference at char {0} ({1} leading and {2} trailing chars unchanged)", fmt(d.commonPrefix), fmt(d.commonPrefix), fmt(d.commonSuffix));
+	}
+}
+
+/** Categories of volatile values that classically break prompt caches. */
+export const enum VolatileValueKind {
+	Timestamp = 'timestamp',
+	Uuid = 'uuid',
+	Counter = 'counter',
+}
+
+interface IVolatilePattern {
+	readonly kind: VolatileValueKind;
+	readonly re: RegExp;
+}
+
+const VOLATILE_PATTERNS: readonly IVolatilePattern[] = [
+	{ kind: VolatileValueKind.Uuid, re: /\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b/ },
+	{ kind: VolatileValueKind.Timestamp, re: /\b\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2})?)?\b/ },
+	{ kind: VolatileValueKind.Timestamp, re: /\b\d{1,2}:\d{2}:\d{2}\b/ },
+	{ kind: VolatileValueKind.Counter, re: /\b\d{10,13}\b/ },
+];
+
+/**
+ * Detect whether the changed region on both sides carries the *same kind* of
+ * volatile value (timestamp, UUID, epoch-like counter) with *different*
+ * contents — the classic silent cache invalidator: `datetime.now()` or a
+ * request id interpolated into the prompt.
+ */
+export function detectVolatileValue(aChanged: string, bChanged: string): VolatileValueKind | undefined {
+	for (const { kind, re } of VOLATILE_PATTERNS) {
+		const aMatch = re.exec(aChanged)?.[0];
+		const bMatch = re.exec(bChanged)?.[0];
+		if (aMatch !== undefined && bMatch !== undefined && aMatch !== bMatch) {
+			return kind;
+		}
+	}
+	return undefined;
+}
+
+/** Context kept around the changed region when scanning for volatile values. */
+const VOLATILE_CONTEXT = 24;
+/** Cap on the scanned window so huge edits stay cheap to regex. */
+const VOLATILE_WINDOW_CAP = 240;
+
+/**
+ * Run volatile-value detection on a window *around* the changed region of
+ * each side. The shared prefix often eats the head of a volatile value
+ * (`09:15:00` vs `09:21:42` diverges after `09:`), so matching only the
+ * changed bytes would miss the pattern; the surrounding context restores it.
+ * Identical values inside the context (e.g. the same date on both sides)
+ * are ignored because {@link detectVolatileValue} requires the matched
+ * values to differ.
+ */
+function detectVolatileValueAround(a: string, b: string, dv: IStringDivergence): VolatileValueKind | undefined {
+	const start = Math.max(0, dv.commonPrefix - VOLATILE_CONTEXT);
+	const aWindow = a.substring(start, Math.min(dv.aLength - dv.commonSuffix + VOLATILE_CONTEXT, start + VOLATILE_WINDOW_CAP));
+	const bWindow = b.substring(start, Math.min(dv.bLength - dv.commonSuffix + VOLATILE_CONTEXT, start + VOLATILE_WINDOW_CAP));
+	return detectVolatileValue(aWindow, bWindow);
+}
+
+function volatileValueLabel(kind: VolatileValueKind): string {
+	switch (kind) {
+		case VolatileValueKind.Timestamp: return localize('chatDebug.cache.volatile.timestamp', "timestamp");
+		case VolatileValueKind.Uuid: return localize('chatDebug.cache.volatile.uuid', "unique id (UUID)");
+		case VolatileValueKind.Counter: return localize('chatDebug.cache.volatile.counter', "large changing number");
+	}
+}
+
+/** Structured comparison of two JSON tool catalogs. */
+export interface IToolCatalogDelta {
+	readonly added: readonly string[];
+	readonly removed: readonly string[];
+	/** Tools present on both sides whose definition bytes differ. */
+	readonly modified: readonly string[];
+	/** True when the set and every definition match — only the order differs. */
+	readonly reorderedOnly: boolean;
+	readonly aCount: number;
+	readonly bCount: number;
+}
+
+function parseToolList(toolsJson: string | undefined): Map<string, string> | undefined {
+	if (!toolsJson) {
+		return undefined;
+	}
+	let raw: unknown;
+	try {
+		raw = JSON.parse(toolsJson);
+	} catch {
+		return undefined;
+	}
+	if (!Array.isArray(raw)) {
+		return undefined;
+	}
+	const out = new Map<string, string>();
+	for (let i = 0; i < raw.length; i++) {
+		const item = raw[i] as { name?: unknown; type?: unknown; function?: { name?: unknown } } | null;
+		const name =
+			(item && typeof item.name === 'string' && item.name) ||
+			(item && item.function && typeof item.function.name === 'string' && item.function.name) ||
+			(item && typeof item.type === 'string' && item.type) ||
+			`#${i}`;
+		let serialized: string;
+		try {
+			serialized = JSON.stringify(item);
+		} catch {
+			serialized = String(item);
+		}
+		// Collisions (duplicate names) concatenate so a duplicated entry still
+		// reads as a modification rather than silently matching.
+		out.set(name, (out.get(name) ?? '') + serialized);
+	}
+	return out;
+}
+
+/**
+ * Compare two tool catalogs at the tool level: which tools were added,
+ * removed, or had their definition change — or whether the catalog was
+ * merely reordered (same tools, same bytes, different order). Returns
+ * `undefined` when either side isn't a parseable JSON array, in which case
+ * callers should fall back to byte-level divergence.
+ */
+export function analyzeToolCatalog(aTools: string | undefined, bTools: string | undefined): IToolCatalogDelta | undefined {
+	const a = parseToolList(aTools);
+	const b = parseToolList(bTools);
+	if (!a || !b) {
+		return undefined;
+	}
+	const added: string[] = [];
+	const removed: string[] = [];
+	const modified: string[] = [];
+	for (const [name, def] of b) {
+		const aDef = a.get(name);
+		if (aDef === undefined) {
+			added.push(name);
+		} else if (aDef !== def) {
+			modified.push(name);
+		}
+	}
+	for (const name of a.keys()) {
+		if (!b.has(name)) {
+			removed.push(name);
+		}
+	}
+	return {
+		added,
+		removed,
+		modified,
+		reorderedOnly: added.length === 0 && removed.length === 0 && modified.length === 0,
+		aCount: a.size,
+		bCount: b.size,
+	};
+}
+
+const severityRank: Record<CacheInsightSeverity, number> = {
+	[CacheInsightSeverity.Ok]: 0,
+	[CacheInsightSeverity.Info]: 1,
+	[CacheInsightSeverity.Warning]: 2,
+	[CacheInsightSeverity.Critical]: 3,
+};
+
+/** The highest severity present in a findings list (Ok when empty). */
+export function maxInsightSeverity(insights: readonly ICacheInsight[]): CacheInsightSeverity {
+	let max = CacheInsightSeverity.Ok;
+	for (const i of insights) {
+		if (severityRank[i.severity] > severityRank[max]) {
+			max = i.severity;
+		}
+	}
+	return max;
+}
+
+/** The first warning-or-worse finding — the headline verdict. */
+export function primaryInsight(insights: readonly ICacheInsight[]): ICacheInsight | undefined {
+	return insights.find(i => i.severity === CacheInsightSeverity.Critical)
+		?? insights.find(i => i.severity === CacheInsightSeverity.Warning);
+}
+
+/** Cache hit below this is treated as "the cache effectively missed". */
+const EFFECTIVE_MISS_PCT = 1;
+/** Typical provider prompt-cache TTL, used in the expiration hint. */
+const TYPICAL_TTL_MINUTES = 5;
+/**
+ * Most providers only walk back a bounded number of content blocks to find
+ * a prior cache entry (~20 on Anthropic); appending more than this in one
+ * turn can silently miss the cache.
+ */
+const LOOKBACK_WINDOW_BLOCKS = 20;
+/**
+ * Upper bound of the per-model minimum cacheable prefix size (1,024-4,096
+ * tokens depending on model). Prompts below this may silently never cache.
+ */
+const MIN_CACHEABLE_TOKENS = 4096;
+
+/**
+ * Produce the ordered findings list for an A→B request comparison.
+ *
+ * Findings are emitted in provider cache-key order (model, tools, system,
+ * options, messages) so the first critical finding is the earliest byte
+ * change — the one that actually broke the cache; later changes are
+ * recomputed regardless.
+ */
+export function computeCacheInsights(input: ICacheInsightsInput): ICacheInsight[] {
+	const out: ICacheInsight[] = [];
+	const modelChanged = input.aModel !== input.bModel;
+	const toolsChanged = (input.aTools ?? '') !== (input.bTools ?? '');
+	const systemChanged = (input.aSystem ?? '') !== (input.bSystem ?? '');
+
+	if (modelChanged) {
+		out.push({
+			severity: CacheInsightSeverity.Critical,
+			title: localize('chatDebug.cache.insight.model.title', "Model changed"),
+			detail: localize('chatDebug.cache.insight.model.detail', "{0} → {1}", input.aModel ?? '—', input.bModel ?? '—'),
+			hint: localize('chatDebug.cache.insight.model.hint', "Prompt caches are scoped to a model — switching models recomputes the entire prompt. Route sub-tasks that need a different model through a separate request chain so the main loop keeps its cache."),
+			category: CacheBreakCategory.Model,
+		});
+	}
+
+	if (toolsChanged) {
+		out.push(toolsInsight(input.aTools, input.bTools));
+	}
+
+	if (systemChanged) {
+		out.push(systemInsight(input.aSystem, input.bSystem));
+	}
+
+	if (input.optionsDiff.length > 0) {
+		out.push({
+			severity: CacheInsightSeverity.Warning,
+			title: localize('chatDebug.cache.insight.options.title', "Request options changed"),
+			detail: input.optionsDiff.map(d => `${d.key}: ${d.previousLabel} → ${d.currentLabel}`).join(' · '),
+			hint: localize('chatDebug.cache.insight.options.hint', "Options are part of the cache key on most providers. Keep per-request options stable when cache reuse matters."),
+			category: CacheBreakCategory.Options,
+		});
+	}
+
+	if (input.compareInputMessages) {
+		out.push(...messageInsights(input, modelChanged || toolsChanged || systemChanged));
+		if (!modelChanged && !toolsChanged && !systemChanged && input.optionsDiff.length === 0 && !input.diff.break) {
+			out.push(stablePrefixInsight(input));
+		}
+	} else if (input.isContinuation) {
+		out.push({
+			severity: CacheInsightSeverity.Info,
+			title: localize('chatDebug.cache.insight.continuation.title', "Responses API continuation"),
+			detail: localize('chatDebug.cache.insight.continuation.detail', "Only the wire delta is captured for this request; prior context is referenced by previous_response_id and reconstructed provider-side. Analysis is limited to system, tools, and request options."),
+			category: CacheBreakCategory.Unknown,
+		});
+	} else if (input.previousIsContinuation) {
+		out.push({
+			severity: CacheInsightSeverity.Info,
+			title: localize('chatDebug.cache.insight.prevContinuation.title', "Message comparison suppressed"),
+			detail: localize('chatDebug.cache.insight.prevContinuation.detail', "The previous request was a Responses API continuation (delta-only wire input); positionally diffing this full request against it would be misleading."),
+			category: CacheBreakCategory.Unknown,
+		});
+	}
+
+	return out;
+}
+
+function toolsInsight(aTools: string | undefined, bTools: string | undefined): ICacheInsight {
+	const delta = analyzeToolCatalog(aTools, bTools);
+	const component = 'tools';
+	if (delta?.reorderedOnly) {
+		return {
+			severity: CacheInsightSeverity.Critical,
+			title: localize('chatDebug.cache.insight.toolsReorder.title', "Tool definitions reordered"),
+			detail: localize('chatDebug.cache.insight.toolsReorder.detail', "Same {0} tools with identical definitions, sent in a different order.", fmt(delta.bCount)),
+			hint: localize('chatDebug.cache.insight.toolsReorder.hint', "Tools render at the very start of the prompt — a pure reorder still changes the bytes and invalidates the entire cache. Serialize the tool list deterministically (e.g. sort by name)."),
+			component,
+			category: CacheBreakCategory.Tools,
+		};
+	}
+	if (delta && (delta.added.length > 0 || delta.removed.length > 0)) {
+		const parts: string[] = [];
+		if (delta.added.length > 0) {
+			parts.push(localize('chatDebug.cache.insight.toolsAdded', "added: {0}", delta.added.join(', ')));
+		}
+		if (delta.removed.length > 0) {
+			parts.push(localize('chatDebug.cache.insight.toolsRemoved', "removed: {0}", delta.removed.join(', ')));
+		}
+		if (delta.modified.length > 0) {
+			parts.push(localize('chatDebug.cache.insight.toolsModified', "modified: {0}", delta.modified.join(', ')));
+		}
+		return {
+			severity: CacheInsightSeverity.Critical,
+			title: localize('chatDebug.cache.insight.toolsSet.title', "Tool catalog changed ({0} → {1} tools)", fmt(delta.aCount), fmt(delta.bCount)),
+			detail: parts.join(' · '),
+			hint: localize('chatDebug.cache.insight.toolsSet.hint', "Tool definitions render before everything else, so adding or removing a tool mid-session invalidates the whole prompt. Keep the tool set stable for the life of a session, or use deferred/appended tool loading instead of swapping the catalog."),
+			component,
+			category: CacheBreakCategory.Tools,
+		};
+	}
+	if (delta && delta.modified.length > 0) {
+		return {
+			severity: CacheInsightSeverity.Critical,
+			title: localize('chatDebug.cache.insight.toolsDef.title', "Tool definitions modified"),
+			detail: localize('chatDebug.cache.insight.toolsDef.detail', "changed: {0}", delta.modified.join(', ')),
+			hint: localize('chatDebug.cache.insight.toolsDef.hint', "A changed tool description or schema rewrites the prompt from the tools block onward. Check for dynamic content (counts, paths, timestamps) inside tool descriptions."),
+			component,
+			category: CacheBreakCategory.Tools,
+		};
+	}
+	// Not parseable as JSON arrays — fall back to byte-level divergence.
+	const dv = analyzeStringDivergence(aTools ?? '', bTools ?? '');
+	return {
+		severity: CacheInsightSeverity.Critical,
+		title: localize('chatDebug.cache.insight.tools.title', "Tool catalog changed"),
+		detail: dv ? describeStringDivergence(dv) : undefined,
+		hint: localize('chatDebug.cache.insight.tools.hint', "The tool catalog is the first block of the prompt — any byte change here invalidates the entire cache."),
+		component,
+		category: CacheBreakCategory.Tools,
+	};
+}
+
+function systemInsight(aSystem: string | undefined, bSystem: string | undefined): ICacheInsight {
+	const dv = analyzeStringDivergence(aSystem ?? '', bSystem ?? '');
+	const volatile = dv ? detectVolatileValueAround(aSystem ?? '', bSystem ?? '', dv) : undefined;
+	return {
+		severity: CacheInsightSeverity.Critical,
+		title: localize('chatDebug.cache.insight.system.title', "System prompt changed"),
+		detail: dv
+			? localize('chatDebug.cache.insight.system.detail', "{0} → {1} chars · {2}", fmt(dv.aLength), fmt(dv.bLength), describeStringDivergence(dv))
+			: undefined,
+		hint: volatile
+			? localize('chatDebug.cache.insight.system.volatileHint', "The changed region looks like a {0} — volatile values interpolated into the system prompt break the cache on every request. Move dynamic content after the conversation history or drop it.", volatileValueLabel(volatile))
+			: localize('chatDebug.cache.insight.system.hint', "A system prompt change invalidates everything after the tools block. Keep the system prompt byte-stable for the life of a session and inject per-turn context into the newest message instead."),
+		component: 'system',
+		category: CacheBreakCategory.System,
+	};
+}
+
+function messageInsights(input: ICacheInsightsInput, hasEarlierBreak: boolean): ICacheInsight[] {
+	const { diff } = input;
+	if (!diff.break) {
+		return [];
+	}
+	const out: ICacheInsight[] = [];
+	const idx = diff.break.index;
+	const component = `messages[${idx}]`;
+	const counts = diff.counts;
+
+	if (diff.break.kind === CacheDiffKind.OnlyInB) {
+		// The first divergence is a message appended past the end of the
+		// previous request — the healthy growth pattern. (A positional zip
+		// can only report OnlyInB as the *first* divergence when everything
+		// before it was identical.)
+		out.push({
+			// Downgrade to Info when an earlier tier already broke the cache:
+			// the append is still fine, but it isn't the story of this request.
+			severity: hasEarlierBreak ? CacheInsightSeverity.Info : CacheInsightSeverity.Ok,
+			title: localize('chatDebug.cache.insight.append.title', "New messages appended — expected growth"),
+			detail: localize('chatDebug.cache.insight.append.detail', "{0} new message(s) after {1} unchanged — the shared prefix was extended, not broken. The uncached tokens are the new suffix being written to the cache for the next request.", fmt(counts.onlyInB), fmt(counts.identical)),
+			component,
+			category: CacheBreakCategory.Healthy,
+		});
+		// Cache lookback window: providers walk back a bounded number of
+		// content blocks (~20) to find a prior cache entry. A single turn
+		// that appends more than that can miss the previous entry even
+		// though the prefix is byte-identical.
+		if (counts.onlyInB > LOOKBACK_WINDOW_BLOCKS) {
+			out.push({
+				severity: CacheInsightSeverity.Warning,
+				title: localize('chatDebug.cache.insight.lookback.title', "{0} blocks appended — beyond the typical cache lookback window", fmt(counts.onlyInB)),
+				detail: localize('chatDebug.cache.insight.lookback.detail', "Providers typically look back ~{0} content blocks for a prior cache entry; a turn that appends more can silently miss it even though the prefix matches.", LOOKBACK_WINDOW_BLOCKS),
+				hint: localize('chatDebug.cache.insight.lookback.hint', "During long tool loops, place intermediate cache breakpoints every ~15 blocks so the next request can still find a cache entry."),
+			});
+		}
+		return out;
+	}
+
+	if (diff.break.kind === CacheDiffKind.OnlyInA) {
+		out.push({
+			severity: CacheInsightSeverity.Critical,
+			title: localize('chatDebug.cache.insight.truncated.title', "History truncated at messages[{0}]", idx),
+			detail: localize('chatDebug.cache.insight.truncated.detail', "{0} message(s) present in the previous request are missing from this one.", fmt(counts.onlyInA)),
+			hint: localize('chatDebug.cache.insight.truncated.hint', "History slicing or compaction shortens the prefix — the cache can only match up to the cut, and everything after it is recomputed."),
+			component,
+			category: CacheBreakCategory.History,
+		});
+		return out;
+	}
+
+	// In-place change (content drift or length change) inside shared history.
+	const tok = diff.signature.find(t => t.index === idx);
+	const role = tok?.bRole ?? tok?.aRole ?? 'message';
+	const aMsg = input.aMessages[idx];
+	const bMsg = input.bMessages[idx];
+	const dv = aMsg && bMsg ? analyzeStringDivergence(aMsg.text, bMsg.text) : undefined;
+	const volatile = dv && aMsg && bMsg ? detectVolatileValueAround(aMsg.text, bMsg.text, dv) : undefined;
+	const detailParts: string[] = [];
+	if (aMsg && bMsg) {
+		detailParts.push(localize('chatDebug.cache.insight.drift.sizes', "{0} message, {1} → {2} chars", role, fmt(aMsg.charLength), fmt(bMsg.charLength)));
+	}
+	if (dv) {
+		detailParts.push(describeStringDivergence(dv));
+	}
+	out.push({
+		severity: CacheInsightSeverity.Critical,
+		title: localize('chatDebug.cache.insight.drift.title', "History rewritten at messages[{0}]", idx),
+		detail: detailParts.join(' · '),
+		hint: volatile
+			? localize('chatDebug.cache.insight.drift.volatileHint', "The changed region looks like a {0} — a volatile value re-rendered into the conversation history breaks the prefix on every request.", volatileValueLabel(volatile))
+			: localize('chatDebug.cache.insight.drift.hint', "Conversation history must be byte-identical between requests to reuse the cached prefix. A re-serialized {0} turn — trimmed whitespace, dropped reasoning or preamble text, reformatted tool calls — silently invalidates everything after it.", role),
+		component,
+		category: CacheBreakCategory.History,
+	});
+
+	const changedAfterBreak = counts.contentDrift + counts.lengthChange + counts.onlyInA + counts.onlyInB - 1;
+	if (changedAfterBreak > 0) {
+		out.push({
+			severity: CacheInsightSeverity.Info,
+			title: localize('chatDebug.cache.insight.afterBreak.title', "{0} more changed position(s) after the break", fmt(changedAfterBreak)),
+			detail: localize('chatDebug.cache.insight.afterBreak.detail', "Once the prefix breaks at messages[{0}], everything after it is recomputed regardless — fix the first break first.", idx),
+		});
+	}
+	return out;
+}
+
+function stablePrefixInsight(input: ICacheInsightsInput): ICacheInsight {
+	if (input.hitPct < EFFECTIVE_MISS_PCT) {
+		// Byte-identical prefix, nothing changed, yet ~0% served from cache.
+		// Two candidate explanations we can tell apart from the data we have:
+		// a prompt below the provider's minimum cacheable prefix size never
+		// caches at all; otherwise the entry almost certainly expired or was
+		// evicted. We can't observe the provider cache directly, so both
+		// stay "likely"/"may".
+		if (input.inputTokens > 0 && input.inputTokens < MIN_CACHEABLE_TOKENS) {
+			return {
+				severity: CacheInsightSeverity.Warning,
+				title: localize('chatDebug.cache.insight.tooSmall.title', "Prompt may be below the minimum cacheable size"),
+				detail: localize('chatDebug.cache.insight.tooSmall.detail', "{0} input tokens — providers only cache prompts above a minimum prefix size (roughly 1,024-4,096 tokens depending on model), and smaller prompts silently never cache.", fmt(input.inputTokens)),
+				hint: localize('chatDebug.cache.insight.tooSmall.hint', "Small utility requests (titles, summaries) often sit below the threshold; a 0% hit on them is normal and not worth optimizing."),
+				category: CacheBreakCategory.Expiration,
+			};
+		}
+		const minutes = input.minutesSincePrevious;
+		const gap = minutes !== undefined && minutes >= 1
+			? localize('chatDebug.cache.insight.expired.gap', " {0} minute(s) elapsed since the previous request.", fmt(Math.round(minutes)))
+			: '';
+		return {
+			severity: CacheInsightSeverity.Warning,
+			title: localize('chatDebug.cache.insight.expired.title', "Likely cache expiration"),
+			detail: localize('chatDebug.cache.insight.expired.detail', "The prompt is byte-identical to the previous request but only {0}% was served from cache.{1}", input.hitPct.toFixed(2), gap),
+			hint: localize('chatDebug.cache.insight.expired.hint', "Provider prompt caches expire after a few minutes of inactivity (typically ~{0} min). Long gaps between requests recompute the full prompt even when nothing changed.", TYPICAL_TTL_MINUTES),
+			category: CacheBreakCategory.Expiration,
+		};
+	}
+	return {
+		severity: CacheInsightSeverity.Ok,
+		title: localize('chatDebug.cache.insight.stable.title', "Prompt prefix fully stable"),
+		detail: localize('chatDebug.cache.insight.stable.detail', "No divergence detected — {0}% of input tokens were served from cache.", input.hitPct.toFixed(2)),
+		category: CacheBreakCategory.Healthy,
+	};
+}
+
+/** Resolve the break category for one request pair from its findings. */
+export function categorizeCacheBreak(insights: readonly ICacheInsight[]): CacheBreakCategory {
+	const primary = primaryInsight(insights);
+	if (primary?.category) {
+		return primary.category;
+	}
+	for (const i of insights) {
+		if (i.category) {
+			return i.category;
+		}
+	}
+	return CacheBreakCategory.Unknown;
+}
+
+/** Human-readable label for a break category. */
+export function cacheBreakCategoryLabel(category: CacheBreakCategory): string {
+	switch (category) {
+		case CacheBreakCategory.Healthy: return localize('chatDebug.cache.category.healthy', "healthy growth");
+		case CacheBreakCategory.Expiration: return localize('chatDebug.cache.category.expiration', "expiration / not cacheable");
+		case CacheBreakCategory.Model: return localize('chatDebug.cache.category.model', "model changed");
+		case CacheBreakCategory.Tools: return localize('chatDebug.cache.category.tools', "tool catalog changed");
+		case CacheBreakCategory.System: return localize('chatDebug.cache.category.system', "system prompt changed");
+		case CacheBreakCategory.Options: return localize('chatDebug.cache.category.options', "request options changed");
+		case CacheBreakCategory.History: return localize('chatDebug.cache.category.history', "history rewritten");
+		case CacheBreakCategory.Unknown: return localize('chatDebug.cache.category.unknown', "not classified");
+	}
+}
+
+/** Break categories that are avoidable on the client side. */
+const AVOIDABLE_CATEGORIES: readonly CacheBreakCategory[] = [
+	CacheBreakCategory.Model,
+	CacheBreakCategory.Tools,
+	CacheBreakCategory.System,
+	CacheBreakCategory.Options,
+	CacheBreakCategory.History,
+];
+
+/** The outcome of analyzing one consecutive request pair in a session. */
+export interface ISessionPairOutcome {
+	/** Index of the current (B) turn in the session's turn list. */
+	readonly turnIndex: number;
+	readonly category: CacheBreakCategory;
+	/** Input tokens of the B request that were not served from cache. */
+	readonly lostTokens: number;
+}
+
+/** Aggregate stats for one break category across a session. */
+export interface ISessionCategoryStat {
+	readonly category: CacheBreakCategory;
+	readonly count: number;
+	readonly lostTokens: number;
+}
+
+/** Token counts for one turn, used for the token-weighted overall hit rate. */
+export interface ISessionTurnTokens {
+	readonly inputTokens: number;
+	readonly cachedTokens: number;
+}
+
+/**
+ * Token-weighted cache hit across a whole session. Per-request percentages
+ * overweight small utility calls; weighting by input tokens shows the real
+ * cost picture.
+ */
+export interface ISessionOverallHit {
+	readonly inputTokens: number;
+	readonly cachedTokens: number;
+	/** `cachedTokens / inputTokens` as a percentage (0-100). */
+	readonly hitPct: number;
+	/** Number of turns that reported token usage. */
+	readonly turnCount: number;
+}
+
+/** Cross-turn cache health report for a whole session. */
+export interface ISessionCacheReport {
+	readonly pairCount: number;
+	readonly healthyCount: number;
+	/** Uncached tokens across pairs whose break was avoidable. */
+	readonly avoidableLostTokens: number;
+	/** Token-weighted overall hit rate; undefined when no turn reported usage. */
+	readonly overall: ISessionOverallHit | undefined;
+	/** Per-category stats, sorted by lost tokens descending (healthy excluded). */
+	readonly byCategory: readonly ISessionCategoryStat[];
+	/** Per-turn category, for rail decoration. */
+	readonly causeByTurnIndex: ReadonlyMap<number, CacheBreakCategory>;
+	/** Session-level findings: recurring invalidators and the overall verdict. */
+	readonly findings: readonly ICacheInsight[];
+}
+
+/** A recurring break category needs at least this many occurrences. */
+const RECURRING_THRESHOLD = 2;
+
+/**
+ * Aggregate per-pair outcomes into a session-level report: which break
+ * categories recur (a one-off break is a curiosity; a recurring one is a
+ * bug), how many tokens each cost, and the token-weighted overall hit rate
+ * across all turns (`turnTokens` covers every turn, including the first,
+ * which has no pair).
+ */
+export function buildSessionCacheReport(pairs: readonly ISessionPairOutcome[], turnTokens: readonly ISessionTurnTokens[] = []): ISessionCacheReport {
+	let overallInput = 0;
+	let overallCached = 0;
+	let overallTurns = 0;
+	for (const t of turnTokens) {
+		if (t.inputTokens > 0) {
+			overallInput += t.inputTokens;
+			overallCached += Math.min(t.cachedTokens, t.inputTokens);
+			overallTurns++;
+		}
+	}
+	const overall: ISessionOverallHit | undefined = overallInput > 0
+		? { inputTokens: overallInput, cachedTokens: overallCached, hitPct: (overallCached / overallInput) * 100, turnCount: overallTurns }
+		: undefined;
+
+	const stats = new Map<CacheBreakCategory, { count: number; lostTokens: number }>();
+	const causeByTurnIndex = new Map<number, CacheBreakCategory>();
+	let healthyCount = 0;
+	let avoidableLostTokens = 0;
+	for (const pair of pairs) {
+		causeByTurnIndex.set(pair.turnIndex, pair.category);
+		if (pair.category === CacheBreakCategory.Healthy) {
+			healthyCount++;
+			continue;
+		}
+		const stat = stats.get(pair.category) ?? { count: 0, lostTokens: 0 };
+		stat.count++;
+		stat.lostTokens += pair.lostTokens;
+		stats.set(pair.category, stat);
+		if (AVOIDABLE_CATEGORIES.includes(pair.category)) {
+			avoidableLostTokens += pair.lostTokens;
+		}
+	}
+
+	const byCategory = [...stats.entries()]
+		.map(([category, s]) => ({ category, count: s.count, lostTokens: s.lostTokens }))
+		.sort((a, b) => b.lostTokens - a.lostTokens);
+
+	const findings: ICacheInsight[] = [];
+	for (const stat of byCategory) {
+		if (stat.count < RECURRING_THRESHOLD) {
+			continue;
+		}
+		if (AVOIDABLE_CATEGORIES.includes(stat.category)) {
+			findings.push({
+				severity: CacheInsightSeverity.Critical,
+				title: localize('chatDebug.cache.session.recurring.title', "Recurring invalidator: {0} in {1} of {2} request pairs", cacheBreakCategoryLabel(stat.category), fmt(stat.count), fmt(pairs.length)),
+				detail: localize('chatDebug.cache.session.recurring.detail', "~{0} tokens recomputed across those requests. A break that repeats is systemic — look for the same root cause on every occurrence.", fmt(stat.lostTokens)),
+				category: stat.category,
+			});
+		} else if (stat.category === CacheBreakCategory.Expiration) {
+			findings.push({
+				severity: CacheInsightSeverity.Warning,
+				title: localize('chatDebug.cache.session.expiration.title', "Cache likely expired {0} times", fmt(stat.count)),
+				detail: localize('chatDebug.cache.session.expiration.detail', "~{0} tokens recomputed after idle gaps or on prompts below the cacheable minimum.", fmt(stat.lostTokens)),
+				hint: localize('chatDebug.cache.session.expiration.hint', "If long gaps are inherent to the workflow, consider a longer-TTL cache or pre-warming before the user returns."),
+				category: stat.category,
+			});
+		}
+	}
+	if (findings.length === 0 && pairs.length > 0 && healthyCount === pairs.length) {
+		findings.push({
+			severity: CacheInsightSeverity.Ok,
+			title: localize('chatDebug.cache.session.allHealthy.title', "All request pairs grew the prefix cleanly"),
+			detail: localize('chatDebug.cache.session.allHealthy.detail', "Every request either appended new messages or matched the previous prompt exactly — no avoidable cache breaks in this session."),
+			category: CacheBreakCategory.Healthy,
+		});
+	}
+
+	return { pairCount: pairs.length, healthyCount, avoidableLostTokens, overall, byCategory, causeByTurnIndex, findings };
+}

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
@@ -1061,8 +1061,152 @@
 	flex-direction: column;
 	gap: 4px;
 }
-.chat-debug-cache-card.break {
+/* Performance card border tracks the worst finding severity: red only for
+	an avoidable break, yellow for suspected expiration, green for healthy
+	growth — a permanent red border made every request look broken. */
+.chat-debug-cache-card.break.is-critical {
 	border-color: var(--vscode-charts-red);
+}
+.chat-debug-cache-card.break.is-warning {
+	border-color: var(--vscode-charts-yellow);
+}
+.chat-debug-cache-card.break.is-ok,
+.chat-debug-cache-card.break.is-info {
+	border-color: var(--vscode-charts-green);
+}
+.chat-debug-cache-findings {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+.chat-debug-cache-finding {
+	display: grid;
+	grid-template-columns: 16px 1fr;
+	gap: 8px;
+	align-items: start;
+	margin: 0;
+	padding: 0;
+	background: transparent;
+	border: none;
+	text-align: left;
+	color: inherit;
+	font-family: inherit;
+	font-size: inherit;
+}
+button.chat-debug-cache-finding.is-clickable {
+	cursor: pointer;
+	border-radius: 4px;
+}
+button.chat-debug-cache-finding.is-clickable:hover .chat-debug-cache-finding-title {
+	text-decoration: underline;
+}
+button.chat-debug-cache-finding.is-clickable:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+.chat-debug-cache-finding-icon {
+	font-size: 14px;
+	padding-top: 1px;
+}
+.chat-debug-cache-finding-icon.is-ok {
+	color: var(--vscode-charts-green);
+}
+.chat-debug-cache-finding-icon.is-info {
+	color: var(--vscode-charts-blue);
+}
+.chat-debug-cache-finding-icon.is-warning {
+	color: var(--vscode-charts-yellow);
+}
+.chat-debug-cache-finding-icon.is-critical {
+	color: var(--vscode-charts-red);
+}
+.chat-debug-cache-finding-body {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+}
+.chat-debug-cache-finding-title {
+	font-size: 11.5px;
+	font-weight: 600;
+	color: var(--vscode-foreground);
+}
+.chat-debug-cache-finding-detail {
+	font-family: var(--monaco-monospace-font);
+	font-size: 11px;
+	line-height: 1.5;
+	color: var(--vscode-foreground);
+}
+.chat-debug-cache-finding-hint {
+	font-size: 11px;
+	line-height: 1.5;
+	color: var(--vscode-descriptionForeground);
+}
+/* ---- Session cache health (cross-turn report) ---- */
+.chat-debug-cache-session-health {
+	background: var(--vscode-editorWidget-background);
+	border: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+	border-radius: 6px;
+	padding: 10px 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+.chat-debug-cache-session-health-stats {
+	font-family: var(--monaco-monospace-font);
+	font-size: 11.5px;
+	color: var(--vscode-foreground);
+}
+.chat-debug-cache-session-health-chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+}
+.chat-debug-cache-session-health-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	font-family: var(--monaco-monospace-font);
+	font-size: 10.5px;
+	padding: 2px 8px;
+	border-radius: 10px;
+	border: 1px solid var(--vscode-widget-border, transparent);
+	color: var(--vscode-descriptionForeground);
+}
+.chat-debug-cache-session-health-chip .codicon {
+	font-size: 12px;
+}
+.chat-debug-cache-session-health-chip.cause-tools,
+.chat-debug-cache-session-health-chip.cause-system,
+.chat-debug-cache-session-health-chip.cause-model,
+.chat-debug-cache-session-health-chip.cause-options,
+.chat-debug-cache-session-health-chip.cause-history {
+	color: var(--vscode-charts-red);
+	border-color: var(--vscode-charts-red);
+}
+.chat-debug-cache-session-health-chip.cause-expiration {
+	color: var(--vscode-charts-yellow);
+	border-color: var(--vscode-charts-yellow);
+}
+/* ---- Rail: idle-gap separators ---- */
+.chat-debug-cache-rail-gap {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 3px 10px;
+	font-family: var(--monaco-monospace-font);
+	font-size: 10px;
+	color: var(--vscode-charts-yellow);
+	opacity: 0.9;
+}
+.chat-debug-cache-rail-gap .codicon {
+	font-size: 11px;
+}
+.chat-debug-cache-rail-gap::before,
+.chat-debug-cache-rail-gap::after {
+	content: "";
+	flex: 1 1 auto;
+	border-top: 1px dashed color-mix(in srgb, var(--vscode-charts-yellow) 50%, transparent);
 }
 .chat-debug-cache-card-h {
 	display: flex;
@@ -1299,6 +1443,13 @@
 	outline: 2px solid var(--vscode-charts-red);
 	outline-offset: -2px;
 	filter: brightness(0.85);
+	/* A drifted sliver must stay visible and clickable even when its share
+	of the bar rounds to nothing. */
+	min-width: 4px;
+}
+.chat-debug-cache-sig-seg.role-coalesced,
+.chat-debug-cache-sig-swatch.role-coalesced {
+	background: color-mix(in srgb, var(--vscode-descriptionForeground) 30%, transparent);
 }
 .chat-debug-cache-sig-break {
 	position: absolute;
@@ -1306,6 +1457,34 @@
 	bottom: -2px;
 	border-left: 2px dashed var(--vscode-charts-red);
 	pointer-events: none;
+}
+.chat-debug-cache-sig-seg.is-clickable {
+	cursor: pointer;
+}
+.chat-debug-cache-sig-seg.is-clickable:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: 1px;
+}
+/* Prefix-match rail: thin reused/recomputed split under the lanes. */
+.chat-debug-cache-sig-lane-row.reuse {
+	margin-top: 2px;
+}
+.chat-debug-cache-sig-reuse-rail {
+	height: 6px;
+	border-radius: 3px;
+	overflow: hidden;
+	display: flex;
+	background: var(--vscode-input-background, #2a2a2a);
+}
+.chat-debug-cache-sig-reuse-seg {
+	height: 100%;
+}
+.chat-debug-cache-sig-reuse-seg.is-reused {
+	background: var(--vscode-charts-green);
+}
+.chat-debug-cache-sig-reuse-seg.is-recomputed {
+	background: var(--vscode-charts-red);
+	opacity: 0.8;
 }
 .chat-debug-cache-sig-summary {
 	font-family: var(--monaco-monospace-font);
@@ -1349,7 +1528,7 @@
 }
 .chat-debug-cache-sig-breakdown-row {
 	display: grid;
-	grid-template-columns: 36px 1fr 90px 90px 96px;
+	grid-template-columns: 36px 1fr 90px 90px 70px 96px;
 	gap: 8px;
 	align-items: center;
 	padding: 4px 10px;
@@ -1460,6 +1639,10 @@
 	color: var(--vscode-descriptionForeground);
 	margin-right: 6px;
 }
+.chat-debug-cache-acc-name .chat-debug-cache-sig-swatch {
+	margin-right: 6px;
+	vertical-align: text-bottom;
+}
 .chat-debug-cache-acc-badge {
 	font-family: var(--monaco-monospace-font);
 	font-size: 10.5px;
@@ -1519,6 +1702,32 @@
 	flex-shrink: 0;
 	font-size: 12px;
 	line-height: 1;
+}
+/* Flash a component item after a finding / signature segment reveals it. */
+.chat-debug-cache-acc-item.flash {
+	animation: chat-debug-cache-flash 1.2s ease-out;
+}
+@keyframes chat-debug-cache-flash {
+	0% {
+		background: color-mix(in srgb, var(--vscode-focusBorder) 30%, var(--vscode-editorWidget-background));
+	}
+	100% {
+		background: var(--vscode-editorWidget-background);
+	}
+}
+.chat-debug-cache-acc-change-note {
+	padding: 6px 12px;
+	font-family: var(--monaco-monospace-font);
+	font-size: 11px;
+	line-height: 1.5;
+	color: var(--vscode-foreground);
+	background: color-mix(in srgb, var(--vscode-charts-yellow) 8%, transparent);
+	border-bottom: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+}
+.chat-debug-cache-acc-identical-note {
+	margin-top: 6px;
+	font-size: 11px;
+	color: var(--vscode-descriptionForeground);
 }
 .chat-debug-cache-diff {
 	display: grid;

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
@@ -1617,6 +1617,10 @@ button.chat-debug-cache-finding.is-clickable:focus-visible {
 .chat-debug-cache-acc-head:hover {
 	background: var(--vscode-list-hoverBackground);
 }
+.chat-debug-cache-acc-head:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
 .chat-debug-cache-chev::before {
 	content: "\25B6";
 	display: inline-block;

--- a/src/vs/workbench/contrib/chat/test/browser/chatDebugCacheDiff.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatDebugCacheDiff.test.ts
@@ -45,6 +45,19 @@ suite('chatDebugCacheDiff', () => {
 			]);
 		});
 
+		test('names tool results after the matching tool_call (correlated by id)', () => {
+			const json = JSON.stringify([
+				{ role: 'assistant', parts: [{ type: 'tool_call', id: 'call_1', name: 'read_file', arguments: { path: '/a' } }] },
+				{ role: 'user', parts: [{ type: 'tool_call_response', id: 'call_1', response: 'file contents' }] },
+				{ role: 'user', parts: [{ type: 'tool_call_response', id: 'call_unknown', response: 'orphan result' }] },
+			]);
+			assert.deepStrictEqual(parseInputMessages(json).map(m => ({ role: m.role, name: m.name })), [
+				{ role: 'assistant', name: undefined },
+				{ role: 'tool', name: 'read_file' },
+				{ role: 'tool', name: undefined },
+			]);
+		});
+
 		test('extracts tool_call arguments on assistant messages', () => {
 			const json = JSON.stringify([
 				{ role: 'assistant', parts: [{ type: 'tool_call', id: 'call_1', name: 'fs_read', arguments: { path: '/etc/hosts' } }] },

--- a/src/vs/workbench/contrib/chat/test/browser/chatDebugCacheInsights.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatDebugCacheInsights.test.ts
@@ -1,0 +1,366 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { diffPromptSignature, INormalizedMessage } from '../../browser/chatDebug/chatDebugCacheDiff.js';
+import { analyzeStringDivergence, analyzeToolCatalog, buildSessionCacheReport, CacheBreakCategory, CacheInsightSeverity, categorizeCacheBreak, computeCacheInsights, detectVolatileValue, ICacheInsight, ICacheInsightsInput, maxInsightSeverity, primaryInsight, StringDivergenceShape, VolatileValueKind } from '../../browser/chatDebug/chatDebugCacheInsights.js';
+
+function msg(role: string, text: string): INormalizedMessage {
+	return { role, text, charLength: text.length };
+}
+
+function makeInput(overrides: Partial<ICacheInsightsInput> & { aMessages?: readonly INormalizedMessage[]; bMessages?: readonly INormalizedMessage[] }): ICacheInsightsInput {
+	const aMessages = overrides.aMessages ?? [];
+	const bMessages = overrides.bMessages ?? [];
+	return {
+		aModel: 'gpt-test',
+		bModel: 'gpt-test',
+		aSystem: 'system prompt',
+		bSystem: 'system prompt',
+		aTools: undefined,
+		bTools: undefined,
+		diff: diffPromptSignature(aMessages, bMessages),
+		optionsDiff: [],
+		hitPct: 50,
+		inputTokens: 50_000,
+		minutesSincePrevious: 0.5,
+		isContinuation: false,
+		previousIsContinuation: false,
+		compareInputMessages: true,
+		...overrides,
+		aMessages,
+		bMessages,
+	};
+}
+
+/** Project insights down to the fields that matter for scenario assertions. */
+function shape(insights: readonly ICacheInsight[]): { severity: string; component: string | undefined }[] {
+	return insights.map(i => ({ severity: i.severity, component: i.component }));
+}
+
+suite('chatDebugCacheInsights', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('analyzeStringDivergence', () => {
+		test('classifies every shape and reports common spans', () => {
+			assert.deepStrictEqual(
+				[
+					analyzeStringDivergence('same', 'same'),
+					analyzeStringDivergence('hello world', 'hello world!!')?.shape,
+					analyzeStringDivergence('hello world!!', 'hello world')?.shape,
+					analyzeStringDivergence('PREFIX hello', 'hello')?.shape,
+					analyzeStringDivergence('hello', 'PREFIX hello')?.shape,
+					analyzeStringDivergence('aaa MIDDLE zzz', 'aaa OTHER zzz')?.shape,
+				],
+				[
+					undefined,
+					StringDivergenceShape.TrailingAdded,
+					StringDivergenceShape.TrailingRemoved,
+					StringDivergenceShape.LeadingRemoved,
+					StringDivergenceShape.LeadingAdded,
+					StringDivergenceShape.InnerEdit,
+				],
+			);
+		});
+
+		test('inner edit reports first-difference offset and disjoint common spans', () => {
+			const d = analyzeStringDivergence('aaa MIDDLE zzz', 'aaa OTHER zzz')!;
+			assert.deepStrictEqual(
+				{ commonPrefix: d.commonPrefix, commonSuffix: d.commonSuffix, aChanged: d.aChanged, bChanged: d.bChanged },
+				{ commonPrefix: 4, commonSuffix: 4, aChanged: 'MIDDLE', bChanged: 'OTHER' },
+			);
+		});
+	});
+
+	suite('detectVolatileValue', () => {
+		test('detects matching volatile kinds with differing values', () => {
+			assert.deepStrictEqual(
+				[
+					detectVolatileValue('at 2026-06-10 09:15', 'at 2026-06-10 09:21'),
+					detectVolatileValue('id 6e9c0a4e-1f2b-4c3d-8e5f-aa0011223344', 'id 0e9c0a4e-1f2b-4c3d-8e5f-aa0011223344'),
+					detectVolatileValue('seq 1718000000123', 'seq 1718000000456'),
+					detectVolatileValue('same 2026-06-10', 'same 2026-06-10'),
+					detectVolatileValue('plain text', 'other text'),
+				],
+				[VolatileValueKind.Timestamp, VolatileValueKind.Uuid, VolatileValueKind.Counter, undefined, undefined],
+			);
+		});
+	});
+
+	suite('analyzeToolCatalog', () => {
+		test('classifies reorder, add/remove, and modify', () => {
+			const toolA = JSON.stringify([{ name: 'read' }, { name: 'edit' }]);
+			const toolAReordered = JSON.stringify([{ name: 'edit' }, { name: 'read' }]);
+			const toolAPlus = JSON.stringify([{ name: 'read' }, { name: 'edit' }, { name: 'grep' }]);
+			const toolAModified = JSON.stringify([{ name: 'read', description: 'v2' }, { name: 'edit' }]);
+			assert.deepStrictEqual(
+				[
+					analyzeToolCatalog(toolA, toolAReordered),
+					analyzeToolCatalog(toolA, toolAPlus),
+					analyzeToolCatalog(toolA, toolAModified),
+					analyzeToolCatalog('not json', toolA),
+				],
+				[
+					{ added: [], removed: [], modified: [], reorderedOnly: true, aCount: 2, bCount: 2 },
+					{ added: ['grep'], removed: [], modified: [], reorderedOnly: false, aCount: 2, bCount: 3 },
+					{ added: [], removed: [], modified: ['read'], reorderedOnly: false, aCount: 2, bCount: 2 },
+					undefined,
+				],
+			);
+		});
+	});
+
+	suite('computeCacheInsights', () => {
+		test('pure append is a single OK finding pointing at the first new message', () => {
+			const shared = [msg('user', 'question'), msg('assistant', 'answer')];
+			const insights = computeCacheInsights(makeInput({
+				aMessages: shared,
+				bMessages: [...shared, msg('user', 'follow-up')],
+			}));
+			assert.deepStrictEqual(shape(insights), [
+				{ severity: CacheInsightSeverity.Ok, component: 'messages[2]' },
+			]);
+		});
+
+		test('in-place history rewrite is critical and reported before later changes', () => {
+			const insights = computeCacheInsights(makeInput({
+				aMessages: [msg('user', 'question'), msg('assistant', 'PREAMBLE answer'), msg('user', 'next')],
+				bMessages: [msg('user', 'question'), msg('assistant', 'answer'), msg('user', 'changed next')],
+			}));
+			assert.deepStrictEqual(shape(insights), [
+				{ severity: CacheInsightSeverity.Critical, component: 'messages[1]' },
+				{ severity: CacheInsightSeverity.Info, component: undefined },
+			]);
+		});
+
+		test('cache-key order: tools and system findings precede the message finding', () => {
+			const insights = computeCacheInsights(makeInput({
+				aModel: 'model-a',
+				bModel: 'model-b',
+				aTools: JSON.stringify([{ name: 'read' }]),
+				bTools: JSON.stringify([{ name: 'read' }, { name: 'edit' }]),
+				aSystem: 'system v1',
+				bSystem: 'system v2',
+				aMessages: [msg('user', 'hi')],
+				bMessages: [msg('user', 'hi'), msg('assistant', 'reply')],
+			}));
+			// model, tools, system are critical; the append downgrades to info
+			// because an earlier tier already broke the cache.
+			assert.deepStrictEqual(shape(insights), [
+				{ severity: CacheInsightSeverity.Critical, component: undefined },
+				{ severity: CacheInsightSeverity.Critical, component: 'tools' },
+				{ severity: CacheInsightSeverity.Critical, component: 'system' },
+				{ severity: CacheInsightSeverity.Info, component: 'messages[1]' },
+			]);
+		});
+
+		test('byte-identical prompt with ~0% hit reads as likely expiration', () => {
+			const shared = [msg('user', 'question')];
+			const insights = computeCacheInsights(makeInput({
+				aMessages: shared,
+				bMessages: shared,
+				hitPct: 0,
+				minutesSincePrevious: 7,
+			}));
+			assert.deepStrictEqual(
+				insights.map(i => i.severity),
+				[CacheInsightSeverity.Warning],
+			);
+		});
+
+		test('byte-identical prompt with a high hit is OK', () => {
+			const shared = [msg('user', 'question')];
+			const insights = computeCacheInsights(makeInput({
+				aMessages: shared,
+				bMessages: shared,
+				hitPct: 99.5,
+			}));
+			assert.deepStrictEqual(
+				insights.map(i => i.severity),
+				[CacheInsightSeverity.Ok],
+			);
+		});
+
+		test('history truncation is critical at the cut position', () => {
+			const insights = computeCacheInsights(makeInput({
+				aMessages: [msg('user', 'q'), msg('assistant', 'a'), msg('user', 'old tail')],
+				bMessages: [msg('user', 'q'), msg('assistant', 'a')],
+			}));
+			assert.deepStrictEqual(shape(insights), [
+				{ severity: CacheInsightSeverity.Critical, component: 'messages[2]' },
+			]);
+		});
+
+		test('continuation suppresses message analysis and adds the continuation note', () => {
+			const insights = computeCacheInsights(makeInput({
+				aMessages: [msg('user', 'full history')],
+				bMessages: [msg('tool', 'delta only')],
+				diff: diffPromptSignature([], []),
+				isContinuation: true,
+				compareInputMessages: false,
+			}));
+			assert.deepStrictEqual(
+				insights.map(i => i.severity),
+				[CacheInsightSeverity.Info],
+			);
+		});
+
+		test('volatile timestamp in the system prompt is called out in the hint', () => {
+			const insights = computeCacheInsights(makeInput({
+				aSystem: 'You are helpful. Current time: 2026-06-10 09:15:00. Stay safe.',
+				bSystem: 'You are helpful. Current time: 2026-06-10 09:21:42. Stay safe.',
+			}));
+			const system = insights.find(i => i.component === 'system');
+			assert.deepStrictEqual(
+				{ severity: system?.severity, mentionsTimestamp: system?.hint?.includes('timestamp') },
+				{ severity: CacheInsightSeverity.Critical, mentionsTimestamp: true },
+			);
+		});
+
+		test('tiny prompt with a miss reads as below-minimum-cacheable, not expiration', () => {
+			const shared = [msg('user', 'short utility prompt')];
+			const insights = computeCacheInsights(makeInput({
+				aMessages: shared,
+				bMessages: shared,
+				hitPct: 0,
+				inputTokens: 800,
+			}));
+			assert.deepStrictEqual(
+				{ severities: insights.map(i => i.severity), mentionsMinimum: insights[0].title.includes('minimum') },
+				{ severities: [CacheInsightSeverity.Warning], mentionsMinimum: true },
+			);
+		});
+
+		test('appending more blocks than the lookback window adds a warning', () => {
+			const shared = [msg('user', 'q')];
+			const appended = Array.from({ length: 25 }, (_, i) => msg('tool', `result ${i}`));
+			const insights = computeCacheInsights(makeInput({
+				aMessages: shared,
+				bMessages: [...shared, ...appended],
+			}));
+			assert.deepStrictEqual(
+				insights.map(i => i.severity),
+				[CacheInsightSeverity.Ok, CacheInsightSeverity.Warning],
+			);
+		});
+
+		test('helpers: maxInsightSeverity and primaryInsight pick the worst / first actionable finding', () => {
+			const insights = computeCacheInsights(makeInput({
+				aSystem: 'v1',
+				bSystem: 'v2',
+				aMessages: [msg('user', 'q')],
+				bMessages: [msg('user', 'q'), msg('assistant', 'a')],
+			}));
+			assert.deepStrictEqual(
+				{ max: maxInsightSeverity(insights), primaryComponent: primaryInsight(insights)?.component },
+				{ max: CacheInsightSeverity.Critical, primaryComponent: 'system' },
+			);
+		});
+	});
+
+	suite('categorizeCacheBreak', () => {
+		test('classifies pairs by their primary finding', () => {
+			const shared = [msg('user', 'q'), msg('assistant', 'a')];
+			assert.deepStrictEqual(
+				[
+					categorizeCacheBreak(computeCacheInsights(makeInput({ aMessages: shared, bMessages: [...shared, msg('user', 'next')] }))),
+					categorizeCacheBreak(computeCacheInsights(makeInput({ aSystem: 'v1', bSystem: 'v2', aMessages: shared, bMessages: shared }))),
+					categorizeCacheBreak(computeCacheInsights(makeInput({ aMessages: shared, bMessages: shared, hitPct: 0 }))),
+					categorizeCacheBreak(computeCacheInsights(makeInput({
+						aMessages: [msg('user', 'q'), msg('assistant', 'OLD a')],
+						bMessages: [msg('user', 'q'), msg('assistant', 'NEW a')],
+					}))),
+				],
+				[CacheBreakCategory.Healthy, CacheBreakCategory.System, CacheBreakCategory.Expiration, CacheBreakCategory.History],
+			);
+		});
+	});
+
+	suite('buildSessionCacheReport', () => {
+		test('flags recurring avoidable categories and sums wasted tokens', () => {
+			const report = buildSessionCacheReport([
+				{ turnIndex: 1, category: CacheBreakCategory.Healthy, lostTokens: 2_000 },
+				{ turnIndex: 2, category: CacheBreakCategory.Tools, lostTokens: 60_000 },
+				{ turnIndex: 3, category: CacheBreakCategory.Tools, lostTokens: 55_000 },
+				{ turnIndex: 4, category: CacheBreakCategory.Expiration, lostTokens: 40_000 },
+				{ turnIndex: 5, category: CacheBreakCategory.System, lostTokens: 10_000 },
+			]);
+			assert.deepStrictEqual(
+				{
+					pairCount: report.pairCount,
+					healthyCount: report.healthyCount,
+					avoidableLostTokens: report.avoidableLostTokens,
+					byCategory: report.byCategory,
+					findingSeverities: report.findings.map(f => ({ severity: f.severity, category: f.category })),
+					cause3: report.causeByTurnIndex.get(3),
+				},
+				{
+					pairCount: 5,
+					healthyCount: 1,
+					avoidableLostTokens: 125_000,
+					byCategory: [
+						{ category: CacheBreakCategory.Tools, count: 2, lostTokens: 115_000 },
+						{ category: CacheBreakCategory.Expiration, count: 1, lostTokens: 40_000 },
+						{ category: CacheBreakCategory.System, count: 1, lostTokens: 10_000 },
+					],
+					findingSeverities: [{ severity: CacheInsightSeverity.Critical, category: CacheBreakCategory.Tools }],
+					cause3: CacheBreakCategory.Tools,
+				},
+			);
+		});
+
+		test('all-healthy session yields a single OK finding', () => {
+			const report = buildSessionCacheReport([
+				{ turnIndex: 1, category: CacheBreakCategory.Healthy, lostTokens: 1_000 },
+				{ turnIndex: 2, category: CacheBreakCategory.Healthy, lostTokens: 1_500 },
+			]);
+			assert.deepStrictEqual(
+				{ healthyCount: report.healthyCount, findings: report.findings.map(f => f.severity), avoidable: report.avoidableLostTokens },
+				{ healthyCount: 2, findings: [CacheInsightSeverity.Ok], avoidable: 0 },
+			);
+		});
+
+		test('overall hit rate is token-weighted across all turns', () => {
+			// One huge healthy request and one tiny full miss: pair-counting
+			// would read "50% of requests missed", token-weighting shows the
+			// truth — nearly everything was served from cache.
+			const report = buildSessionCacheReport(
+				[{ turnIndex: 1, category: CacheBreakCategory.Expiration, lostTokens: 1_000 }],
+				[
+					{ inputTokens: 99_000, cachedTokens: 99_000 },
+					{ inputTokens: 1_000, cachedTokens: 0 },
+					{ inputTokens: 0, cachedTokens: 0 }, // no usage reported — excluded
+				],
+			);
+			assert.deepStrictEqual(report.overall, {
+				inputTokens: 100_000,
+				cachedTokens: 99_000,
+				hitPct: 99,
+				turnCount: 2,
+			});
+		});
+
+		test('overall is undefined when no turn reported token usage', () => {
+			const report = buildSessionCacheReport(
+				[{ turnIndex: 1, category: CacheBreakCategory.Healthy, lostTokens: 0 }],
+				[{ inputTokens: 0, cachedTokens: 0 }],
+			);
+			assert.strictEqual(report.overall, undefined);
+		});
+
+		test('recurring expiration yields a warning finding', () => {
+			const report = buildSessionCacheReport([
+				{ turnIndex: 1, category: CacheBreakCategory.Expiration, lostTokens: 30_000 },
+				{ turnIndex: 2, category: CacheBreakCategory.Expiration, lostTokens: 35_000 },
+				{ turnIndex: 3, category: CacheBreakCategory.Healthy, lostTokens: 500 },
+			]);
+			assert.deepStrictEqual(
+				report.findings.map(f => ({ severity: f.severity, category: f.category })),
+				[{ severity: CacheInsightSeverity.Warning, category: CacheBreakCategory.Expiration }],
+			);
+		});
+	});
+});


### PR DESCRIPTION
Fixes #320765

- Add a conversation-level cache hit rate to the cache explorer.
- General cache explorer cleanup and a new insights view with tests.