### PR TITLE
Revert "add env var to AH to tag our CAPI traffic (#320814)"

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -546,9 +546,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 			env['COPILOT_CLI_RUN_AS_NODE'] = '1';
 			env['USE_BUILTIN_RIPGREP'] = 'false';
 
-			// Identify VS Code's agent host traffic in CAPI
-			env['GITHUB_COPILOT_INTEGRATION_ID'] = 'vscode-agent-host';
-
 			// Enable the rubber duck critic subagent in the CLI when the agent host
 			// config opts in. `RUBBER_DUCK_AGENT` is the SDK's required interface for
 			// gating this experimental feature


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/320924
This reverts commit 4ab1d982c54ce7177912f2fd75cb36ac07cce6f3.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
