### PR TITLE
Refactor: remove unused welcome icons from ChangesView and FilesView

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -18,7 +18,6 @@ import { autorun, derived, derivedObservableWithCache, derivedOpts, IObservable,
 import { CountBadge } from '../../../../base/browser/ui/countBadge/countBadge.js';
 import { ProgressBar } from '../../../../base/browser/ui/progressbar/progressbar.js';
 import { basename, isEqual } from '../../../../base/common/resources.js';
-import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { MenuWorkbenchButtonBar } from '../../../../platform/actions/browser/buttonbar.js';
@@ -415,8 +414,6 @@ export class ChangesViewPane extends ViewPane {
 		this.welcomeContainer = dom.append(this.contentContainer, $('.changes-welcome'));
 		this.welcomeContainer.style.display = 'none';
 
-		const welcomeIcon = dom.append(this.welcomeContainer, $('.changes-welcome-icon'));
-		welcomeIcon.classList.add(...ThemeIcon.asClassNameArray(Codicon.diffMultiple));
 		const welcomeMessage = dom.append(this.welcomeContainer, $('.changes-welcome-message'));
 		welcomeMessage.textContent = localize('changesView.noChanges', "Changed files and other session artifacts will appear here.");
 

--- a/src/vs/sessions/contrib/changes/browser/media/changesView.css
+++ b/src/vs/sessions/contrib/changes/browser/media/changesView.css
@@ -35,12 +35,6 @@
 	gap: 8px;
 }
 
-.changes-view-body .changes-welcome-icon.codicon {
-	font-size: 32px !important;
-	color: var(--vscode-descriptionForeground);
-	opacity: 0.4;
-}
-
 .changes-view-body .changes-welcome-message {
 	color: var(--vscode-descriptionForeground);
 	font-size: 12px;

--- a/src/vs/sessions/contrib/files/browser/filesView.ts
+++ b/src/vs/sessions/contrib/files/browser/filesView.ts
@@ -17,8 +17,6 @@ import { IThemeService } from '../../../../platform/theme/common/themeService.js
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { agentsPanelBackground } from '../../../common/theme.js';
 import { ExplorerView } from '../../../../workbench/contrib/files/browser/views/explorerView.js';
-import { Codicon } from '../../../../base/common/codicons.js';
-import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize } from '../../../../nls.js';
 import { IAction } from '../../../../base/common/actions.js';
 import { IActionViewItem } from '../../../../base/browser/ui/actionbar/actionbar.js';
@@ -76,9 +74,6 @@ export class SessionsExplorerEmptyView extends ViewPane {
 
 		const bodyContainer = dom.append(container, $('.files-empty-view-body'));
 		const welcomeContainer = dom.append(bodyContainer, $('.files-empty-welcome'));
-
-		const welcomeIcon = dom.append(welcomeContainer, $('.files-empty-welcome-icon'));
-		welcomeIcon.classList.add(...ThemeIcon.asClassNameArray(Codicon.files));
 
 		const welcomeMessage = dom.append(welcomeContainer, $('.files-empty-welcome-message'));
 		welcomeMessage.textContent = localize('filesView.noFiles', "Folders and files will appear here.");

--- a/src/vs/sessions/contrib/files/browser/media/filesView.css
+++ b/src/vs/sessions/contrib/files/browser/media/filesView.css
@@ -23,12 +23,6 @@
 	gap: 8px;
 }
 
-.files-empty-view-body .files-empty-welcome-icon.codicon {
-	font-size: 32px !important;
-	color: var(--vscode-descriptionForeground);
-	opacity: 0.4;
-}
-
 .files-empty-view-body .files-empty-welcome-message {
 	color: var(--vscode-descriptionForeground);
 	font-size: 12px;


### PR DESCRIPTION
Eliminate unused welcome icons from the ChangesView and FilesView to streamline the codebase and improve maintainability. No associated issue.

