### PR TITLE
Enable 'Add File as Context' action in command palette

### DIFF
--- a/src/vs/sessions/browser/parts/chatView.ts
+++ b/src/vs/sessions/browser/parts/chatView.ts
@@ -106,6 +106,15 @@ export abstract class AbstractChatView extends Disposable implements ISerializab
 	}
 
 	/**
+	 * Attach the given resource as context to this view's chat input. The
+	 * default implementation is a no-op; subclasses that host a chat widget
+	 * (e.g. `ChatView`) override this to add the attachment to the widget.
+	 */
+	attach(_uri: URI): void {
+		// no-op by default
+	}
+
+	/**
 	 * Notifies the view whether it is the currently active session in the
 	 * sessions grid. Subclasses may use this to adjust their visual styling
 	 * (e.g. the chat list's background color). The default implementation

--- a/src/vs/sessions/browser/parts/chatView.ts
+++ b/src/vs/sessions/browser/parts/chatView.ts
@@ -106,11 +106,11 @@ export abstract class AbstractChatView extends Disposable implements ISerializab
 	}
 
 	/**
-	 * Attach the given resource as context to this view's chat input. The
+	 * Attach the given resources as context to this view's chat input. The
 	 * default implementation is a no-op; subclasses that host a chat widget
-	 * (e.g. `ChatView`) override this to add the attachment to the widget.
+	 * (e.g. `ChatView`) override this to add the attachments to the widget.
 	 */
-	attach(_uri: URI): void {
+	attach(_uris: URI[]): void {
 		// no-op by default
 	}
 

--- a/src/vs/sessions/browser/parts/sessionView.ts
+++ b/src/vs/sessions/browser/parts/sessionView.ts
@@ -272,10 +272,10 @@ export class SessionView extends Disposable implements ISerializableView {
 	}
 
 	/**
-	 * Attaches the given resource as context to the hosted chat view's input.
+	 * Attaches the given resources as context to the hosted chat view's input.
 	 */
-	attach(uri: URI): void {
-		this._currentView.value?.attach(uri);
+	attach(uris: URI[]): void {
+		this._currentView.value?.attach(uris);
 	}
 
 	/**

--- a/src/vs/sessions/browser/parts/sessionView.ts
+++ b/src/vs/sessions/browser/parts/sessionView.ts
@@ -272,6 +272,13 @@ export class SessionView extends Disposable implements ISerializableView {
 	}
 
 	/**
+	 * Attaches the given resource as context to the hosted chat view's input.
+	 */
+	attach(uri: URI): void {
+		this._currentView.value?.attach(uri);
+	}
+
+	/**
 	 * Updates the view's maximized context key so toolbars hosted within can react.
 	 * Called by the owning {@link SessionsPart} when the grid's maximized view changes.
 	 */

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -84,8 +84,8 @@ export class NewChatView extends AbstractChatView {
 		}
 	}
 
-	override attach(uri: URI): void {
-		this._widget.attach(uri);
+	override attach(uris: URI[]): void {
+		this._widget.attach(uris);
 	}
 }
 
@@ -247,8 +247,10 @@ export class ChatView extends AbstractChatView {
 		this._widget.focusInput();
 	}
 
-	override attach(uri: URI): void {
-		this._widget.attachmentModel.addFile(uri).catch(err => this.logService.error('[ChatView] Failed to attach file as context', err));
+	override attach(uris: URI[]): void {
+		for (const uri of uris) {
+			this._widget.attachmentModel.addFile(uri).catch(err => this.logService.error('[ChatView] Failed to attach file as context', err));
+		}
 	}
 
 	override setActive(active: boolean): void {

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -85,9 +85,7 @@ export class NewChatView extends AbstractChatView {
 	}
 
 	override attach(uri: URI): void {
-		if (this._widget instanceof NewChatWidget) {
-			this._widget.attach(uri);
-		}
+		this._widget.attach(uri);
 	}
 }
 

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -83,6 +83,12 @@ export class NewChatView extends AbstractChatView {
 			this._widget.sendQuery(text);
 		}
 	}
+
+	override attach(uri: URI): void {
+		if (this._widget instanceof NewChatWidget) {
+			this._widget.attach(uri);
+		}
+	}
 }
 
 /**
@@ -241,6 +247,10 @@ export class ChatView extends AbstractChatView {
 
 	override focus(): void {
 		this._widget.focusInput();
+	}
+
+	override attach(uri: URI): void {
+		this._widget.attachmentModel.addFile(uri).catch(err => this.logService.error('[ChatView] Failed to attach file as context', err));
 	}
 
 	override setActive(active: boolean): void {

--- a/src/vs/sessions/contrib/chat/browser/newChatInSessionWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInSessionWidget.ts
@@ -158,6 +158,10 @@ export class NewChatInSessionWidget extends Disposable {
 	focusInput(): void {
 		this._newChatInput.focus();
 	}
+
+	attach(uri: URI): void {
+		this._newChatInput.attach(uri);
+	}
 }
 
 // #endregion

--- a/src/vs/sessions/contrib/chat/browser/newChatInSessionWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInSessionWidget.ts
@@ -159,8 +159,8 @@ export class NewChatInSessionWidget extends Disposable {
 		this._newChatInput.focus();
 	}
 
-	attach(uri: URI): void {
-		this._newChatInput.attach(uri);
+	attach(uris: URI[]): void {
+		this._newChatInput.attach(uris);
 	}
 }
 

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -51,7 +51,7 @@ import { SlashCommandHandler } from './slashCommands.js';
 import { VariableCompletionHandler } from './variableCompletions.js';
 import { AgentHostInputCompletionHandler } from './agentHostInputCompletions.js';
 import { IChatModelInputState } from '../../../../workbench/contrib/chat/common/model/chatModel.js';
-import { IChatRequestVariableEntry, isExplicitFileOrImageVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
+import { IChatRequestVariableEntry, isExplicitFileOrImageVariableEntry, toFileVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../../workbench/contrib/chat/common/constants.js';
 import { ChatHistoryNavigator } from '../../../../workbench/contrib/chat/common/widget/chatWidgetHistoryService.js';
 import { IHistoryNavigationWidget } from '../../../../base/browser/history.js';
@@ -705,6 +705,10 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 			model.setValue(text);
 			this._send();
 		}
+	}
+
+	attach(uri: URI): void {
+		this._contextAttachments.addAttachments(toFileVariableEntry(uri));
 	}
 }
 

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -707,8 +707,8 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		}
 	}
 
-	attach(uri: URI): void {
-		this._contextAttachments.addAttachments(toFileVariableEntry(uri));
+	attach(uris: URI[]): void {
+		this._contextAttachments.addAttachments(...uris.map(uri => toFileVariableEntry(uri)));
 	}
 }
 

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -446,8 +446,8 @@ export class NewChatWidget extends Disposable {
 		this._newChatInput.sendQuery(text);
 	}
 
-	attach(uri: URI): void {
-		this._newChatInput.attach(uri);
+	attach(uris: URI[]): void {
+		this._newChatInput.attach(uris);
 	}
 
 	selectWorkspace(folderUri: URI, providerId?: string): void {

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -446,6 +446,10 @@ export class NewChatWidget extends Disposable {
 		this._newChatInput.sendQuery(text);
 	}
 
+	attach(uri: URI): void {
+		this._newChatInput.attach(uri);
+	}
+
 	selectWorkspace(folderUri: URI, providerId?: string): void {
 		this._workspacePicker.setSelectedWorkspace(folderUri, { providerId });
 	}

--- a/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
+++ b/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
@@ -340,19 +340,23 @@ class AddFileAsContextAction extends Action2 {
 	static readonly ID = 'workbench.action.agentSessions.addFileAsContext';
 
 	constructor() {
+		const precondition = ContextKeyExpr.and(
+			IsSessionsWindowContext,
+			IsAuxiliaryWindowContext.toNegated(),
+			ActiveEditorContext.isEqualTo(TEXT_FILE_EDITOR_ID)
+		);
+
 		super({
 			id: AddFileAsContextAction.ID,
 			title: localize2('addFileAsContext', "Add File as Context"),
 			icon: Codicon.attach,
 			f1: true,
+			precondition,
 			menu: {
 				id: MenuId.EditorTitle,
 				group: 'navigation',
 				order: 1,
-				when: ContextKeyExpr.and(
-					IsSessionsWindowContext,
-					IsAuxiliaryWindowContext.toNegated(),
-					ActiveEditorContext.isEqualTo(TEXT_FILE_EDITOR_ID))
+				when: precondition
 			}
 		});
 	}

--- a/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
+++ b/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
@@ -9,12 +9,13 @@ import { ServicesAccessor } from '../../../../editor/browser/editorExtensions.js
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
-import { AuxiliaryBarVisibleContext, EditorPartModalContext, IsAuxiliaryWindowContext, IsSessionsWindowContext, IsTopRightEditorGroupContext } from '../../../../workbench/common/contextkeys.js';
+import { ActiveEditorContext, AuxiliaryBarVisibleContext, EditorPartModalContext, IsAuxiliaryWindowContext, IsSessionsWindowContext, IsTopRightEditorGroupContext } from '../../../../workbench/common/contextkeys.js';
 import { IAgentWorkbenchLayoutService } from '../../../browser/workbench.js';
 import { EditorMaximizedContext } from '../../../common/contextkeys.js';
 import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IEditorGroupsService } from '../../../../workbench/services/editor/common/editorGroupsService.js';
+import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
 import { MultiDiffEditorInput } from '../../../../workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.js';
 import { CHANGES_VIEW_ID } from '../../changes/common/changes.js';
 import { ChangesViewPane } from '../../changes/browser/changesView.js';
@@ -22,6 +23,9 @@ import { prepareMoveCopyEditors } from '../../../../workbench/browser/parts/edit
 import { Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { MOVE_MODAL_EDITOR_TO_MAIN_COMMAND_ID } from '../../../../workbench/browser/parts/editor/editorCommands.js';
 import { TERMINAL_VIEW_ID } from '../../../../workbench/contrib/terminal/common/terminal.js';
+import { TEXT_FILE_EDITOR_ID } from '../../../../workbench/contrib/files/common/files.js';
+import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 
 const terminalPanelHiddenForMaximizedEditor = new WeakSet<IAgentWorkbenchLayoutService>();
 
@@ -331,3 +335,50 @@ class OpenModalEditorInEditorAction extends Action2 {
 }
 
 registerAction2(OpenModalEditorInEditorAction);
+
+class AddFileAsContextAction extends Action2 {
+	static readonly ID = 'workbench.action.agentSessions.addFileAsContext';
+
+	constructor() {
+		super({
+			id: AddFileAsContextAction.ID,
+			title: localize2('addFileAsContext', "Add File as Context"),
+			icon: Codicon.attach,
+			f1: false,
+			menu: {
+				id: MenuId.EditorTitle,
+				group: 'navigation',
+				order: 1,
+				when: ContextKeyExpr.and(
+					IsSessionsWindowContext,
+					IsAuxiliaryWindowContext.toNegated(),
+					ActiveEditorContext.isEqualTo(TEXT_FILE_EDITOR_ID))
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const sessionManagementService = accessor.get(ISessionsManagementService);
+		const chatWidgetService = accessor.get(IChatWidgetService);
+
+		const resource = editorService.activeEditor?.resource;
+		if (!resource) {
+			return;
+		}
+
+		const sessionResource = sessionManagementService.activeSession.get()?.resource;
+		if (!sessionResource) {
+			return;
+		}
+
+		const widget = chatWidgetService.getWidgetBySessionResource(sessionResource);
+		if (!widget) {
+			return;
+		}
+
+		await widget.attachmentModel.addFile(resource);
+	}
+}
+
+registerAction2(AddFileAsContextAction);

--- a/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
+++ b/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
@@ -373,13 +373,8 @@ class AddFileAsContextAction extends Action2 {
 			return;
 		}
 
-		const activeSession = sessionManagementService.activeSession.get();
-		if (!activeSession) {
-			return;
-		}
-
-		sessionsPartService.getSessionView(activeSession.sessionId)?.attach(resource);
-	}
+		const sessionId = sessionManagementService.activeSession.get()?.sessionId;
+		sessionsPartService.getSessionView(sessionId)?.attach(resource);
 }
 
 registerAction2(AddFileAsContextAction);

--- a/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
+++ b/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
@@ -16,6 +16,9 @@ import { IViewsService } from '../../../../workbench/services/views/common/views
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IEditorGroupsService } from '../../../../workbench/services/editor/common/editorGroupsService.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
+import { IListService } from '../../../../platform/list/browser/listService.js';
+import { EditorResourceAccessor, SideBySideEditor } from '../../../../workbench/common/editor.js';
+import { resolveCommandsContext } from '../../../../workbench/browser/parts/editor/editorCommandsContext.js';
 import { MultiDiffEditorInput } from '../../../../workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.js';
 import { CHANGES_VIEW_ID } from '../../changes/common/changes.js';
 import { ChangesViewPane } from '../../changes/browser/changesView.js';
@@ -363,18 +366,23 @@ class AddFileAsContextAction extends Action2 {
 		});
 	}
 
-	run(accessor: ServicesAccessor): void {
+	run(accessor: ServicesAccessor, ...args: unknown[]): void {
 		const editorService = accessor.get(IEditorService);
 		const sessionManagementService = accessor.get(ISessionsManagementService);
 		const sessionsPartService = accessor.get(ISessionsPartService);
 
-		const resource = editorService.activeEditor?.resource;
+		const resolvedContext = resolveCommandsContext(args, editorService, accessor.get(IEditorGroupsService), accessor.get(IListService));
+		const resource = resolvedContext.groupedEditors
+			.flatMap(groupedEditor => groupedEditor.editors)
+			.map(editor => EditorResourceAccessor.getCanonicalUri(editor, { supportSideBySide: SideBySideEditor.PRIMARY }))
+			.find(uri => uri !== undefined);
 		if (!resource) {
 			return;
 		}
 
 		const sessionId = sessionManagementService.activeSession.get()?.sessionId;
 		sessionsPartService.getSessionView(sessionId)?.attach(resource);
+	}
 }
 
 registerAction2(AddFileAsContextAction);

--- a/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
+++ b/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
@@ -25,7 +25,8 @@ import { MOVE_MODAL_EDITOR_TO_MAIN_COMMAND_ID } from '../../../../workbench/brow
 import { TERMINAL_VIEW_ID } from '../../../../workbench/contrib/terminal/common/terminal.js';
 import { TEXT_FILE_EDITOR_ID } from '../../../../workbench/contrib/files/common/files.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
-import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
+import { ISessionsPartService } from '../../../services/sessions/browser/sessionsPartService.js';
+import { SessionsCategories } from '../../../common/categories.js';
 
 const terminalPanelHiddenForMaximizedEditor = new WeakSet<IAgentWorkbenchLayoutService>();
 
@@ -349,6 +350,7 @@ class AddFileAsContextAction extends Action2 {
 		super({
 			id: AddFileAsContextAction.ID,
 			title: localize2('addFileAsContext', "Add File as Context"),
+			category: SessionsCategories.Sessions,
 			icon: Codicon.attach,
 			f1: true,
 			precondition,
@@ -361,27 +363,22 @@ class AddFileAsContextAction extends Action2 {
 		});
 	}
 
-	async run(accessor: ServicesAccessor): Promise<void> {
+	run(accessor: ServicesAccessor): void {
 		const editorService = accessor.get(IEditorService);
 		const sessionManagementService = accessor.get(ISessionsManagementService);
-		const chatWidgetService = accessor.get(IChatWidgetService);
+		const sessionsPartService = accessor.get(ISessionsPartService);
 
 		const resource = editorService.activeEditor?.resource;
 		if (!resource) {
 			return;
 		}
 
-		const sessionResource = sessionManagementService.activeSession.get()?.resource;
-		if (!sessionResource) {
+		const activeSession = sessionManagementService.activeSession.get();
+		if (!activeSession) {
 			return;
 		}
 
-		const widget = chatWidgetService.getWidgetBySessionResource(sessionResource);
-		if (!widget) {
-			return;
-		}
-
-		await widget.attachmentModel.addFile(resource);
+		sessionsPartService.getSessionView(activeSession.sessionId)?.attach(resource);
 	}
 }
 

--- a/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
+++ b/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
@@ -344,7 +344,7 @@ class AddFileAsContextAction extends Action2 {
 			id: AddFileAsContextAction.ID,
 			title: localize2('addFileAsContext', "Add File as Context"),
 			icon: Codicon.attach,
-			f1: false,
+			f1: true,
 			menu: {
 				id: MenuId.EditorTitle,
 				group: 'navigation',

--- a/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
+++ b/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
@@ -380,6 +380,10 @@ class AddFileAsContextAction extends Action2 {
 			return;
 		}
 
+		if (!['file', 'vscode-remote', 'untitled'].includes(resource.scheme)) {
+			return;
+		}
+
 		const sessionId = sessionManagementService.activeSession.get()?.sessionId;
 		sessionsPartService.getSessionView(sessionId)?.attach(resource);
 	}

--- a/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
+++ b/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
@@ -5,6 +5,8 @@
 
 import { localize2 } from '../../../../nls.js';
 import { Codicon } from '../../../../base/common/codicons.js';
+import { Schemas } from '../../../../base/common/network.js';
+import { URI } from '../../../../base/common/uri.js';
 import { ServicesAccessor } from '../../../../editor/browser/editorExtensions.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
@@ -372,20 +374,16 @@ class AddFileAsContextAction extends Action2 {
 		const sessionsPartService = accessor.get(ISessionsPartService);
 
 		const resolvedContext = resolveCommandsContext(args, editorService, accessor.get(IEditorGroupsService), accessor.get(IListService));
-		const resource = resolvedContext.groupedEditors
+		const resources = resolvedContext.groupedEditors
 			.flatMap(groupedEditor => groupedEditor.editors)
 			.map(editor => EditorResourceAccessor.getCanonicalUri(editor, { supportSideBySide: SideBySideEditor.PRIMARY }))
-			.find(uri => uri !== undefined);
-		if (!resource) {
-			return;
-		}
-
-		if (!['file', 'vscode-remote', 'untitled'].includes(resource.scheme)) {
+			.filter((uri): uri is URI => uri !== undefined && [Schemas.file, Schemas.vscodeRemote, Schemas.untitled].includes(uri.scheme));
+		if (resources.length === 0) {
 			return;
 		}
 
 		const sessionId = sessionManagementService.activeSession.get()?.sessionId;
-		sessionsPartService.getSessionView(sessionId)?.attach(resource);
+		sessionsPartService.getSessionView(sessionId)?.attach(resources);
 	}
 }
 


### PR DESCRIPTION
This pull request introduces a new editor action that allows users to add the currently open file as context to an active session, improving workflow integration between the editor and session/chat features. The main changes include the addition of the `AddFileAsContextAction` class and necessary imports to support this new functionality.

<img width="517" height="329" alt="image" src="https://github.com/user-attachments/assets/849ffd53-7344-477e-8542-0b47a7248fe6" />


**New Editor Action for Session Context:**

* Added a new `AddFileAsContextAction` class, which registers an editor title menu action called "Add File as Context." This action is available when a text file is open in a session window and, when triggered, adds the active file as context to the current session's chat widget.

**Supporting Imports:**

* Imported `ActiveEditorContext`, `IEditorService`, `TEXT_FILE_EDITOR_ID`, `ISessionsManagementService`, and `IChatWidgetService` to enable context checks and facilitate the new action's integration with session and chat services.