### PR TITLE
feat: add extensions.gallery.useNetrcAuth for enterprise private gallery authentication

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionGalleryManifest.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryManifest.ts
@@ -98,3 +98,4 @@ export function getExtensionGalleryManifestResourceUri(manifest: IExtensionGalle
 }
 
 export const ExtensionGalleryServiceUrlConfigKey = 'extensions.gallery.serviceUrl';
+export const ExtensionGalleryUseNetrcAuthConfigKey = 'extensions.gallery.useNetrcAuth';

--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -24,7 +24,7 @@ import { IFileService } from '../../files/common/files.js';
 import { ILogService } from '../../log/common/log.js';
 import { IProductService } from '../../product/common/productService.js';
 import { asJson, asTextOrError, IRequestService, isClientError, isServerError, isSuccess } from '../../request/common/request.js';
-import { resolveMarketplaceHeaders } from '../../externalServices/common/marketplace.js';
+import { resolveMarketplaceHeaders, resolveNetrcAuthorizationHeader } from '../../externalServices/common/marketplace.js';
 import { IStorageService } from '../../storage/common/storage.js';
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { StopWatch } from '../../../base/common/stopwatch.js';
@@ -638,6 +638,20 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 
 	isEnabled(): boolean {
 		return this.extensionGalleryManifestService.extensionGalleryManifestStatus === ExtensionGalleryManifestStatus.Available;
+	}
+
+	/**
+	 * Returns base request headers for every gallery call.
+	 * Stable headers (User-Agent, machine ID, etc.) come from the cached commonHeadersPromise.
+	 * The Authorization header is re-resolved on every call so that a rotated ~/.netrc token
+	 * is picked up without requiring a VS Code restart.
+	 */
+	private async getBaseHeaders(): Promise<IHeaders> {
+		const cached = await this.commonHeadersPromise;
+		const serviceUrl = this.productService.extensionsGallery?.serviceUrl;
+		if (!serviceUrl) { return cached; }
+		const authorization = await resolveNetrcAuthorizationHeader(serviceUrl, this.environmentService, this.fileService, this.configurationService);
+		return authorization ? { ...cached, Authorization: authorization } : cached;
 	}
 
 	getExtensions(extensionInfos: ReadonlyArray<IExtensionInfo>, token: CancellationToken): Promise<IGalleryExtension[]>;
@@ -1432,7 +1446,7 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 			}, 0)
 		});
 
-		const commonHeaders = await this.commonHeadersPromise;
+		const commonHeaders = await this.getBaseHeaders();
 		const headers = {
 			...commonHeaders,
 			'Content-Type': 'application/json',
@@ -1587,7 +1601,7 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 		const stopWatch = new StopWatch();
 
 		try {
-			const commonHeaders = await this.commonHeadersPromise;
+			const commonHeaders = await this.getBaseHeaders();
 			const headers = {
 				...commonHeaders,
 				'Content-Type': 'application/json',
@@ -1692,7 +1706,7 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 		const url = format2(resource, { publisher, name, version, statTypeName: type });
 
 		const Accept = '*/*;api-version=4.0-preview.1';
-		const commonHeaders = await this.commonHeadersPromise;
+		const commonHeaders = await this.getBaseHeaders();
 		const headers = { ...commonHeaders, Accept };
 		try {
 			await this.requestService.request({
@@ -1883,7 +1897,7 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 	}
 
 	private async getAsset(extension: string, asset: IGalleryExtensionAsset, assetType: string, extensionVersion: string, callSite: string, options: Omit<IRequestOptions, 'callSite'> = {}, token: CancellationToken = CancellationToken.None): Promise<IRequestContext> {
-		const commonHeaders = await this.commonHeadersPromise;
+		const commonHeaders = await this.getBaseHeaders();
 		const baseOptions = { type: 'GET' };
 		const headers = { ...commonHeaders, ...(options.headers || {}) };
 		options = { ...options, ...baseOptions, headers };

--- a/src/vs/platform/extensionManagement/test/common/extensionGalleryService.test.ts
+++ b/src/vs/platform/extensionManagement/test/common/extensionGalleryService.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { joinPath } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { isUUID } from '../../../../base/common/uuid.js';
@@ -18,7 +19,7 @@ import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesy
 import { NullLogService } from '../../../log/common/log.js';
 import product from '../../../product/common/product.js';
 import { IProductService } from '../../../product/common/productService.js';
-import { resolveMarketplaceHeaders } from '../../../externalServices/common/marketplace.js';
+import { resolveMarketplaceHeaders, resolveNetrcAuthorizationHeader } from '../../../externalServices/common/marketplace.js';
 import { InMemoryStorageService, IStorageService } from '../../../storage/common/storage.js';
 import { TelemetryConfiguration, TELEMETRY_SETTING_ID } from '../../../telemetry/common/telemetry.js';
 import { TargetPlatform } from '../../../extensions/common/extensions.js';
@@ -31,6 +32,17 @@ class EnvironmentServiceMock extends mock<IEnvironmentService>() {
 		super();
 		this.serviceMachineIdResource = serviceMachineIdResource;
 		this.isBuilt = true;
+	}
+}
+
+class EnvironmentServiceWithHomeMock extends mock<IEnvironmentService>() {
+	override readonly serviceMachineIdResource: URI;
+	readonly userHome: URI; // accessed via duck-type cast in resolveNetrcAuthorizationHeader; not part of IEnvironmentService
+	constructor(serviceMachineIdResource: URI, userHome: URI) {
+		super();
+		this.serviceMachineIdResource = serviceMachineIdResource;
+		this.isBuilt = true;
+		this.userHome = userHome;
 	}
 }
 
@@ -457,6 +469,88 @@ suite('Extension Gallery Service', () => {
 			assert.ok(result.includes(versions[1])); // 0.14.0 universal (release)
 		});
 
+	});
+});
+
+suite('resolveNetrcAuthorizationHeader', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	const homeScheme = 'vscode-tests-netrc';
+	const homeUri = URI.file('/home/testuser').with({ scheme: homeScheme });
+	const serviceUrl = 'https://registry.example.com/vsix';
+
+	let fileService: IFileService;
+	let environmentService: IEnvironmentService;
+	let configurationService: TestConfigurationService;
+
+	setup(() => {
+		fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider(homeScheme, disposables.add(new InMemoryFileSystemProvider())));
+		environmentService = new EnvironmentServiceWithHomeMock(homeUri, homeUri);
+		configurationService = new TestConfigurationService({ 'extensions.gallery.useNetrcAuth': true });
+	});
+
+	async function writeNetrc(content: string): Promise<void> {
+		await fileService.writeFile(URI.joinPath(homeUri, '.netrc'), VSBuffer.fromString(content));
+	}
+
+	test('returns undefined when setting is disabled', async () => {
+		const config = new TestConfigurationService({ 'extensions.gallery.useNetrcAuth': false });
+		await writeNetrc('machine registry.example.com login user password token');
+		const result = await resolveNetrcAuthorizationHeader(serviceUrl, environmentService, fileService, config);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('returns undefined when userHome is unavailable (web context)', async () => {
+		const envWithoutHome = new EnvironmentServiceMock(homeUri);
+		await writeNetrc('machine registry.example.com login user password token');
+		const result = await resolveNetrcAuthorizationHeader(serviceUrl, envWithoutHome, fileService, configurationService);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('returns undefined when .netrc does not exist', async () => {
+		const result = await resolveNetrcAuthorizationHeader(serviceUrl, environmentService, fileService, configurationService);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('returns undefined when no matching machine entry exists', async () => {
+		await writeNetrc('machine other.example.com login user password token');
+		const result = await resolveNetrcAuthorizationHeader(serviceUrl, environmentService, fileService, configurationService);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('returns correct Basic header for matching machine entry', async () => {
+		await writeNetrc('machine registry.example.com login myuser password mytoken');
+		const result = await resolveNetrcAuthorizationHeader(serviceUrl, environmentService, fileService, configurationService);
+		assert.strictEqual(result, 'Basic ' + encodeBase64(VSBuffer.fromString('myuser:mytoken')));
+	});
+
+	test('picks correct entry from multi-machine .netrc', async () => {
+		await writeNetrc([
+			'machine other.example.com login otheruser password othertoken',
+			'machine registry.example.com login myuser password correcttoken',
+			'machine another.example.com login anotheruser password anothertoken',
+		].join('\n'));
+		const result = await resolveNetrcAuthorizationHeader(serviceUrl, environmentService, fileService, configurationService);
+		assert.strictEqual(result, 'Basic ' + encodeBase64(VSBuffer.fromString('myuser:correcttoken')));
+	});
+
+	test('does not fall back to default entry', async () => {
+		await writeNetrc('default login defaultuser password defaulttoken');
+		const result = await resolveNetrcAuthorizationHeader(serviceUrl, environmentService, fileService, configurationService);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('reads fresh credentials on each call without caching', async () => {
+		await writeNetrc('machine registry.example.com login myuser password firsttoken');
+		const first = await resolveNetrcAuthorizationHeader(serviceUrl, environmentService, fileService, configurationService);
+
+		await writeNetrc('machine registry.example.com login myuser password rotatedtoken');
+		const second = await resolveNetrcAuthorizationHeader(serviceUrl, environmentService, fileService, configurationService);
+
+		assert.strictEqual(first, 'Basic ' + encodeBase64(VSBuffer.fromString('myuser:firsttoken')));
+		assert.strictEqual(second, 'Basic ' + encodeBase64(VSBuffer.fromString('myuser:rotatedtoken')));
+		assert.notStrictEqual(first, second);
 	});
 });
 

--- a/src/vs/platform/externalServices/common/marketplace.ts
+++ b/src/vs/platform/externalServices/common/marketplace.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { encodeBase64, VSBuffer } from '../../../base/common/buffer.js';
+import { URI } from '../../../base/common/uri.js';
 import { IHeaders } from '../../../base/parts/request/common/request.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { IEnvironmentService } from '../../environment/common/environment.js';
@@ -36,4 +38,76 @@ export async function resolveMarketplaceHeaders(version: string,
 	}
 
 	return headers;
+}
+
+/**
+ * Returns an Authorization header value read from ~/.netrc for the given serviceUrl hostname,
+ * or undefined if the setting is off, userHome is unavailable (web), or no entry exists.
+ *
+ * Intentionally NOT part of resolveMarketplaceHeaders so callers can invoke it per-request —
+ * the .netrc token rotates daily and must not be cached for the lifetime of the process.
+ */
+export async function resolveNetrcAuthorizationHeader(
+	serviceUrl: string,
+	environmentService: IEnvironmentService,
+	fileService: IFileService,
+	configurationService: IConfigurationService,
+): Promise<string | undefined> {
+	if (!configurationService.getValue<boolean>('extensions.gallery.useNetrcAuth')) {
+		return undefined;
+	}
+	// userHome is only present in native (desktop) environments; silently skip in web.
+	const homeUri: URI | undefined = (environmentService as { userHome?: URI }).userHome;
+	if (!homeUri) {
+		return undefined;
+	}
+	return resolveNetrcAuthorization(serviceUrl, homeUri, fileService);
+}
+
+/**
+ * Reads ~/.netrc and returns a Basic Authorization header value for the given
+ * URL's hostname, or undefined if no matching entry exists.
+ *
+ * This lets enterprises point extensionsGallery.serviceUrl at a private registry
+ * and rotate credentials via standard tooling (e.g. netrc-based credential helpers)
+ * without touching product.json.
+ */
+async function resolveNetrcAuthorization(serviceUrl: string, homeUri: URI, fileService: IFileService): Promise<string | undefined> {
+	let hostname: string;
+	try {
+		hostname = new URL(serviceUrl).hostname;
+	} catch {
+		return undefined;
+	}
+
+	const netrcUri = URI.joinPath(homeUri, '.netrc');
+	let content: VSBuffer;
+	try {
+		const file = await fileService.readFile(netrcUri);
+		content = file.value;
+	} catch {
+		return undefined; // no .netrc or unreadable
+	}
+
+	// Tokenise on whitespace; netrc entries are space- or newline-delimited.
+	const tokens = content.toString().split(/\s+/).filter(t => t.length > 0);
+	let login = '', password = '', inMachine = false;
+	for (let i = 0; i < tokens.length; i++) {
+		const t = tokens[i];
+		if (t === 'machine') {
+			if (inMachine) { break; } // past our entry
+			if (tokens[i + 1] === hostname) { inMachine = true; i++; }
+		} else if (inMachine) {
+			if (t === 'login') { login = tokens[++i]; }
+			else if (t === 'password') { password = tokens[++i]; }
+			else if (t === 'macdef' || t === 'default') { break; }
+		}
+		// `default` entries (catch-all) are intentionally not matched: injecting credentials
+		// into an unintended host (e.g. the Microsoft marketplace) would be a silent overshare.
+	}
+
+	if (!inMachine || !login || !password) {
+		return undefined;
+	}
+	return 'Basic ' + encodeBase64(VSBuffer.fromString(`${login}:${password}`));
 }

--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -861,8 +861,11 @@ export class CodeWindow extends BaseWindow implements ICodeWindow {
 		// Inject headers when requests are incoming
 		const urls = ['https://*.vsassets.io/*'];
 		if (this.productService.extensionsGallery?.serviceUrl) {
-			const serviceUrl = URI.parse(this.productService.extensionsGallery.serviceUrl);
-			urls.push(`${serviceUrl.scheme}://${serviceUrl.authority}/*`);
+			// Use WHATWG URL so that .host gives "hostname:port" without userinfo.
+			// URI.parse().authority follows RFC 3986 and includes userinfo when present
+			// (e.g. "user:pass@host:port"), which Electron's URL pattern validator rejects.
+			const serviceUrl = new URL(this.productService.extensionsGallery.serviceUrl);
+			urls.push(`${serviceUrl.protocol}//${serviceUrl.host}/*`);
 		}
 		this._win.webContents.session.webRequest.onBeforeSendHeaders({ urls }, async (details, cb) => {
 			const headers = await this.getMarketplaceHeaders();

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -24,7 +24,7 @@ import { CommandsRegistry, ICommandService } from '../../../../platform/commands
 import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService, IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
-import { ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, ExtensionGalleryServiceUrlConfigKey, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, ExtensionGalleryServiceUrlConfigKey, ExtensionGalleryUseNetrcAuthConfigKey, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 import { EXTENSION_INSTALL_SOURCE_CONTEXT, ExtensionInstallSource, ExtensionRequestsTimeoutConfigKey, ExtensionsLocalizedLabel, FilterType, IExtensionGalleryService, IExtensionManagementService, PreferencesLocalizedLabel, SortBy, VerifyExtensionSignatureConfigKey } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { areSameExtensions, getIdAndVersion } from '../../../../platform/extensionManagement/common/extensionManagementUtil.js';
 import { ExtensionStorageService } from '../../../../platform/extensionManagement/common/extensionStorage.js';
@@ -325,6 +325,12 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 						}
 					}
 				},
+			},
+			[ExtensionGalleryUseNetrcAuthConfigKey]: {
+				type: 'boolean',
+				description: localize('extensions.gallery.useNetrcAuth', "When enabled, VS Code reads ~/.netrc for credentials when authenticating to a custom extension gallery (extensions.gallery.serviceUrl). Useful for enterprise setups where the registry token is managed by external tooling."),
+				default: false,
+				scope: ConfigurationScope.APPLICATION,
 			},
 			'extensions.supportNodeGlobalNavigator': {
 				type: 'boolean',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

## Summary

This PR makes two related changes:

1. **Bug fix** (`windowImpl.ts`): VS Code crashes at startup with `TypeError: Invalid port` when `extensionsGallery.serviceUrl` contains userinfo (e.g. `https://user:pass@host/path`). The crash is in Electron's URL pattern validator, triggered because `URI.parse().authority` follows RFC 3986 and includes the userinfo component (`user:pass@host:port`), which the validator misparses as a port value. Fixed by switching to WHATWG `new URL().host`, which returns `hostname:port` without userinfo. See https://github.com/microsoft/vscode/issues/320930

2. **Feature** (`marketplace.ts`, `extensionGalleryService.ts`, `extensionGalleryManifest.ts`, `extensions.contribution.ts`): A new opt-in setting `extensions.gallery.useNetrcAuth` that lets VS Code read `~/.netrc` for gallery credentials on every request, enabling enterprise deployments to authenticate to a self-hosted extension registry without patching `product.json`. See https://github.com/microsoft/vscode/issues/320935

## Motivation

Enterprises that want to control which extensions developers can install currently must use Private Marketplace. For organizations that already operate in-house dependency registries or software approval pipelines, a simpler path exists: point `extensionsGallery.serviceUrl` at a lightweight proxy that filters `extensionquery` responses. The blocker is authentication. Today there is no supported way to supply credentials to a custom `serviceUrl`.

Credentials embedded directly in the URL do not work. There is no setting to inject an `Authorization` header.

## Design decisions

**Why `~/.netrc` and not an explicit setting or SecretStorage?**

- A password field in settings would be stored in `settings.json`, which is synced across machines and may appear in logs, not appropriate for secrets.
- SecretStorage is per-machine and not writable by external tooling. Enterprise environments typically rotate registry tokens via credential helpers or daemons that already manage `~/.netrc` (the same file used by npm, pip, and the Go module proxy).
- `~/.netrc` is already a trusted credential store on developer machines, is not synced by VS Code, and is the natural home for registry credentials in this context.

**Why per-request and not cached at startup?**

`commonHeadersPromise` in `AbstractExtensionGalleryService` is resolved once at constructor time. Registry tokens typically rotate on a daily or shorter cadence. Caching the token at startup means it could silently expires depending on the expiration settings. The new `getBaseHeaders()` private method reads `.netrc` on every gallery call so a rotated token is picked up without restarting VS Code.

**Why not match `default` entries in `.netrc`?**

`default` is a catch-all that matches any host. Falling back to it would silently inject credentials into `extensionsGallery.serviceUrl` if the user has a `default` entry in their `.netrc` for unrelated reasons. Only explicit `machine <hostname>` entries are matched.

## Testing

**Unit tests** are in `src/vs/platform/extensionManagement/test/common/extensionGalleryService.test.ts` (`resolveNetrcAuthorizationHeader` suite, 8 cases). Run with:

```bash
./scripts/test.sh --grep "resolveNetrcAuthorizationHeader"
```

**Manual end-to-end** (requires a custom registry, for reviewers who want to spot-check the header injection without one, the unit tests cover all code paths):

1. Add an entry to `~/.netrc`:
   ```
   machine marketplace.visualstudio.com login testuser password testtoken
   ```
2. Set `"extensions.gallery.useNetrcAuth": true` in user settings.
3. Open the Extensions panel.
4. In `Help → Toggle Developer Tools → Network`, inspect the `extensionquery` request. The `Authorization: Basic <base64(testuser:testtoken)>` header should be present.
5. Update the `.netrc` entry with a new password and search again without restarting VS Code. The new token should appear in the next request, confirming per-request reads.

## Security considerations

- Setting is opt-in, default `false`.
- `ConfigurationScope.APPLICATION` prevents workspace-level override (a malicious workspace cannot enable this setting to exfiltrate credentials to an attacker-controlled registry).
- VS Code reads `~/.netrc` but never writes to it.
- `default` entries are explicitly excluded (see above).