### PR TITLE
build: prevent Dependencies Check from getting stuck

### DIFF
--- a/build/azure-pipelines/dependencies-check.yml
+++ b/build/azure-pipelines/dependencies-check.yml
@@ -18,7 +18,11 @@ jobs:
     pool:
       name: 1es-ubuntu-22.04-x64
       os: linux
-    timeoutInMinutes: 1300
+    # The GitHub App installation token handed off from the queueing GitHub Action has a
+    # 1-hour lifetime. The job must finish (including the final `condition: always()`
+    # cleanup step that PATCHes the GitHub check run) within that window, otherwise the
+    # PATCH 401s and the Dependencies Check stays IN_PROGRESS forever.
+    timeoutInMinutes: 50
     variables:
       VSCODE_ARCH: x64
     steps:
@@ -77,26 +81,31 @@ jobs:
       - script: |
           set -e
 
-          for attempt in {1..120}; do
+          # Bounded retries with per-attempt timeouts so a hung `npm i` cannot block
+          # the pipeline (and by extension the GitHub Dependencies Check) indefinitely.
+          # Worst case: 3 * (20m npm i + 5m postinstall) + 2 * 30s sleep = 76 minutes
+          # of work cap, but `timeoutInMinutes` on the job will cut us off well before
+          # that — and the always() cleanup step will still PATCH the check run.
+          for attempt in 1 2 3; do
             if [ $attempt -gt 1 ]; then
-              echo "Attempt $attempt: Waiting for 10 minutes before retrying..."
-              sleep 600
+              echo "Attempt $attempt: Waiting for 30 seconds before retrying..."
+              sleep 30
             fi
 
-            echo "Attempt $attempt: Running npm ci"
-            if npm i --ignore-scripts; then
-              if node build/npm/postinstall.ts; then
+            echo "Attempt $attempt: Running npm i"
+            if timeout 20m npm i --ignore-scripts; then
+              if timeout 5m node build/npm/postinstall.ts; then
                 echo "npm i succeeded on attempt $attempt"
                 exit 0
               else
-                echo "node build/npm/postinstall.ts failed on attempt $attempt"
+                echo "node build/npm/postinstall.ts failed (or timed out) on attempt $attempt"
               fi
             else
-              echo "npm i failed on attempt $attempt"
+              echo "npm i failed (or timed out) on attempt $attempt"
             fi
           done
 
-          echo "giving up after 120 attempts (20 hours)"
+          echo "giving up after 3 attempts"
           exit 1
         env:
           npm_command: 'install --ignore-scripts'
@@ -104,7 +113,7 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           GITHUB_TOKEN: "$(github-distro-mixin-password)"
         displayName: Install dependencies with retries
-        timeoutInMinutes: 1300
+        timeoutInMinutes: 45
         condition: and(succeeded(), eq(variables['SHOULD_VALIDATE'], 'true'))
 
       - script: |

--- a/build/azure-pipelines/update-dependencies-check.ts
+++ b/build/azure-pipelines/update-dependencies-check.ts
@@ -7,7 +7,7 @@ import https from 'https';
 
 function request(options: https.RequestOptions, body?: object): Promise<Record<string, unknown>> {
 	return new Promise((resolve, reject) => {
-		const req = https.request(options, res => {
+		const req = https.request({ timeout: 30_000, ...options }, res => {
 			let data = '';
 			res.on('data', chunk => data += chunk);
 			res.on('end', () => {
@@ -19,11 +19,16 @@ function request(options: https.RequestOptions, body?: object): Promise<Record<s
 			});
 		});
 		req.on('error', reject);
+		req.on('timeout', () => req.destroy(new Error('Request timed out')));
 		if (body) {
 			req.write(JSON.stringify(body));
 		}
 		req.end();
 	});
+}
+
+function delay(ms: number) {
+	return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 function updateCheckRun(token: string, checkRunId: string, conclusion: string, detailsUrl: string) {
@@ -69,8 +74,35 @@ async function main() {
 			break;
 	}
 
-	await updateCheckRun(token, checkRunId, conclusion, detailsUrl);
+	await updateCheckRunWithRetries(token, checkRunId, conclusion, detailsUrl);
 	console.log(`Updated check run ${checkRunId} with conclusion: ${conclusion}`);
+}
+
+async function updateCheckRunWithRetries(token: string, checkRunId: string, conclusion: string, detailsUrl: string) {
+	// Retry transient PATCH failures (network blips, brief GitHub 5xx). We do NOT retry
+	// 401s — those mean the GitHub App installation token (1h lifetime) has expired and
+	// no amount of retrying will help. Surface that clearly so the pipeline owner can
+	// see it in the log.
+	const attempts = 3;
+	let lastErr: unknown;
+	for (let i = 1; i <= attempts; i++) {
+		try {
+			await updateCheckRun(token, checkRunId, conclusion, detailsUrl);
+			return;
+		} catch (err) {
+			lastErr = err;
+			const message = err instanceof Error ? err.message : String(err);
+			if (message.startsWith('HTTP 401')) {
+				console.error('GitHub returned 401 updating the check run. The installation token (1h lifetime) likely expired before the pipeline finished. The Dependencies Check will remain IN_PROGRESS until manually resolved.');
+				throw err;
+			}
+			console.error(`Attempt ${i}/${attempts} to update check run failed: ${message}`);
+			if (i < attempts) {
+				await delay(2_000 * i);
+			}
+		}
+	}
+	throw lastErr;
 }
 
 main().catch(err => {


### PR DESCRIPTION
The Dependencies Check status would occasionally remain IN_PROGRESS for days on PRs that touch lockfiles (e.g. #320104, stuck 6 days).

## Root causes
In `build/azure-pipelines/dependencies-check.yml` and `update-dependencies-check.ts`:

1. The install retry loop allowed **120 attempts with 10 min sleeps** and had no per-attempt timeout, so a hung `npm i` could keep the pipeline running for ~20h.
2. The job timeout was **1300 min (~21h)**, which let case (1) actually happen.
3. The GitHub App installation token used to PATCH the check run lives only **1h**. If the pipeline ran past that, the final PATCH 401'd and the check stayed IN_PROGRESS forever.
4. The PATCH request itself had no socket timeout and no retry, so any transient network/API blip would leave the check unresolved.

## Fixes
- Drop job timeout to **50 min** (well within token lifetime, leaves headroom for the `always()` cleanup step).
- Reduce retries to **3 attempts  30 s sleep**, and wrap `npm i` / `postinstall.ts` in `timeout 20m` / `timeout 5m` so a single hang fails the attempt instead of the whole job.
- Add a **30 s request timeout** to the PATCH and retry transient failures 3 with backoff.
- Explicitly detect 401 from the check-run PATCH and log a clear diagnostic (no point retrying an expired token).

Net effect: the check can no longer stay IN_PROGRESS for more than ~1h.

## Recommended follow-up (out of scope, vscode-engineering side)
Mint a fresh installation token from within the ADO pipeline so even runs that exceed 1h can update the check. The action's own comment in vscode-engineering already flags this footgun. With the timeouts above this is now defense-in-depth.

cc @yoyokrazy
