### PR TITLE
Adjust CIStatusWidget header height and update CSS margins for improved layout

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/checksWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/checksWidget.ts
@@ -149,7 +149,7 @@ class CICheckListRenderer implements IListRenderer<ICICheckListItem, ICICheckTem
  */
 export class CIStatusWidget extends Disposable {
 
-	static readonly HEADER_HEIGHT = 34; // total header height in px
+	static readonly HEADER_HEIGHT = 32; // total header height in px (5px section margin + 6px header margin + 28px header)
 	static readonly MIN_BODY_HEIGHT = 3 * CICheckListDelegate.ITEM_HEIGHT + 2; // at least 3 checks (3 * 28) + 2px
 	static readonly PREFERRED_BODY_HEIGHT = 112; // preferred 4 checks (4 * 28)
 	static readonly MAX_BODY_HEIGHT = 240; // at most ~8 checks

--- a/src/vs/sessions/contrib/changes/browser/media/checksWidget.css
+++ b/src/vs/sessions/contrib/changes/browser/media/checksWidget.css
@@ -9,7 +9,6 @@
 	flex-direction: column;
 	flex-shrink: 0;
 	box-sizing: border-box;
-	overflow: hidden;
 	font-size: var(--vscode-agents-fontSize-label1, 12px);
 }
 
@@ -19,9 +18,9 @@
 	display: flex;
 	align-items: center;
 	padding: 4px;
-	margin-top: 4px;
+	margin-top: 6px;
 	border-radius: var(--vscode-cornerRadius-medium);
-	min-height: 22px;
+	min-height: 20px;
 	font-weight: var(--vscode-agents-fontWeight-semiBold, 600);
 	cursor: pointer;
 	user-select: none;


### PR DESCRIPTION
Refine the header height of the CIStatusWidget and adjust CSS margins to enhance the overall layout. These changes improve the visual consistency and usability of the widget. Testing can be done by reviewing the layout in the application after applying the changes.

Addresses: https://github.com/microsoft/vscode/issues/320423
