### PR TITLE
Don't toggle editor area visibility when multiple sessions are visible

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -98,6 +98,7 @@ export class MenuId {
 	static readonly EditorTitleContextShare = new MenuId('EditorTitleContextShare');
 	static readonly EmptyEditorGroup = new MenuId('EmptyEditorGroup');
 	static readonly EmptyEditorGroupContext = new MenuId('EmptyEditorGroupContext');
+	static readonly EditorGroupWatermarkToolbar = new MenuId('EditorGroupWatermarkToolbar');
 	static readonly EditorTabsBarContext = new MenuId('EditorTabsBarContext');
 	static readonly EditorTabsBarShowTabsSubmenu = new MenuId('EditorTabsBarShowTabsSubmenu');
 	static readonly EditorTabsBarShowTabsZenModeSubmenu = new MenuId('EditorTabsBarShowTabsZenModeSubmenu');

--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -244,6 +244,7 @@
 	position: absolute;
 	top: 0px;
 	right: 0px;
+	height: 35px;
 	flex-direction: row;
 	align-items: center;
 	padding: 0 4px;

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -132,6 +132,17 @@ export interface IAgentWorkbenchLayoutService extends IWorkbenchLayoutService {
 	setEditorMaximized(maximized: boolean): void;
 
 	readonly onDidChangeEditorMaximized: Event<void>;
+
+	/**
+	 * Suppresses the automatic editor part show/hide that normally fires from
+	 * `editorService.onWillOpenEditor` / `onDidCloseEditor`. Use this around
+	 * programmatic editor operations (e.g. applying a working set) so that the
+	 * editor part visibility is not changed as a side-effect. Dispose the
+	 * returned handle to release the suppression. Calls nest via a counter.
+	 *
+	 * Comment: We should consider movin mximization logic into layoutController
+	 */
+	suppressEditorPartAutoVisibility(): IDisposable;
 }
 
 export const IAgentWorkbenchLayoutService = refineServiceDecorator<IWorkbenchLayoutService, IAgentWorkbenchLayoutService>(IWorkbenchLayoutService);
@@ -295,6 +306,7 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 	private _editorMaximized = false;
 	private _editorLastNonMaximizedVisibility: IPartVisibilityState | undefined;
 	private _restoreAttachedEditorMaximizedOnShow = false;
+	private _editorPartAutoVisibilitySuppressionCount = 0;
 
 	private readonly restoredPromise = new DeferredPromise<void>();
 	readonly whenRestored = this.restoredPromise.p;
@@ -1010,8 +1022,13 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 
 		// Editor opens should only affect the main editor part when
 		// they actually target one of the main editor groups. Modal
-		// opens stay neutral.
+		// opens stay neutral. Programmatic opens that suppress auto
+		// visibility (e.g. working set application) are ignored.
 		this._register(this.editorService.onWillOpenEditor(e => {
+			if (this._editorPartAutoVisibilitySuppressionCount > 0) {
+				return;
+			}
+
 			const targetsMainEditorPart = this.editorGroupService.mainPart.groups.some(group => group.id === e.groupId);
 			if (!targetsMainEditorPart) {
 				return;
@@ -1025,6 +1042,9 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 
 		// Hide editor part when last editor closes
 		this._register(this.editorService.onDidCloseEditor(() => {
+			if (this._editorPartAutoVisibilitySuppressionCount > 0) {
+				return;
+			}
 			if (this.partVisibility.editor && this.areAllGroupsInMainPartEmpty()) {
 				this.rememberAttachedEditorMaximizedState();
 				this.setEditorHidden(true);
@@ -1051,6 +1071,18 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 			}
 		}
 		return true;
+	}
+
+	suppressEditorPartAutoVisibility(): IDisposable {
+		this._editorPartAutoVisibilitySuppressionCount++;
+		let disposed = false;
+		return toDisposable(() => {
+			if (disposed) {
+				return;
+			}
+			disposed = true;
+			this._editorPartAutoVisibilitySuppressionCount--;
+		});
 	}
 
 	private rememberAttachedEditorMaximizedState(): void {

--- a/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
@@ -19,9 +19,10 @@ import { IChatService } from '../../../../workbench/contrib/chat/common/chatServ
 import { ViewContainerLocation } from '../../../../workbench/common/views.js';
 import { IEditorGroupsService, IEditorWorkingSet } from '../../../../workbench/services/editor/common/editorGroupsService.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
-import { IWorkbenchLayoutService, Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
+import { Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { IPaneCompositePartService } from '../../../../workbench/services/panecomposite/browser/panecomposite.js';
 import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
+import { IAgentWorkbenchLayoutService } from '../../../browser/workbench.js';
 import { IActiveSession, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsViewService } from '../../../services/sessions/browser/sessionsViewService.js';
 import { SessionStatus } from '../../../services/sessions/common/session.js';
@@ -75,7 +76,7 @@ export class LayoutController extends Disposable {
 	private _suppressAuxiliaryBarEnforcement = false;
 
 	constructor(
-		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
+		@IAgentWorkbenchLayoutService private readonly _layoutService: IAgentWorkbenchLayoutService,
 		@ISessionsManagementService private readonly _sessionManagementService: ISessionsManagementService,
 		@ISessionsViewService private readonly _sessionsViewService: ISessionsViewService,
 		@IChatService private readonly _chatService: IChatService,
@@ -483,6 +484,22 @@ export class LayoutController extends Disposable {
 			: 'empty';
 
 		return this._workingSetSequencer.queue(async () => {
+			// When multiple sessions are visible, applying a working set must never
+			// change the visibility of the editor part: the editor area is shared
+			// across the visible sessions and its visibility is controlled by the
+			// user (and by direct editor open/close events outside this path).
+			// Suppress the auto show/hide so restoring editors into the shared
+			// editor part does not toggle it.
+			if (this._sessionsViewService.visibleSessions.get().length > 1) {
+				const suppression = this._layoutService.suppressEditorPartAutoVisibility();
+				try {
+					await this._editorGroupsService.applyWorkingSet(workingSet, { preserveFocus });
+				} finally {
+					suppression.dispose();
+				}
+				return;
+			}
+
 			// Switching the active session must never reveal the main editor area
 			// (or restore editors into it) while modal-only mode is in effect — the
 			// outer autorun already guards against this, but `useModal` may have

--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -9,12 +9,13 @@ import { KeyChord, KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize, localize2 } from '../../../../nls.js';
-import { Action2, MenuRegistry, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { Action2, MenuRegistry, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../platform/quickinput/common/quickInput.js';
 import { EditorAreaFocusContext, IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
+import { IWorkbenchLayoutService, Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { Menus } from '../../../browser/menus.js';
 import { SessionsCategories } from '../../../common/categories.js';
 import { CanGoBackContext, CanGoForwardContext, ChatSessionProviderIdContext, MultipleSessionsVisibleContext, SessionIsArchivedContext, SessionIsCreatedContext, SessionIsMaximizedContext, SessionIsStickyContext, SessionsFocusContext, SessionSupportsMultipleChatsContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
@@ -498,5 +499,29 @@ registerAction2(class ToggleMaximizeSessionViewAction extends Action2 {
 	override async run(accessor: ServicesAccessor, session: IActiveSession | undefined): Promise<void> {
 		accessor.get(ISessionsPartService).toggleMaximizeSession(session);
 		accessor.get(ISessionsViewService).setActive(session);
+	}
+});
+
+// -- Close Editor Area (Watermark Toolbar) --
+
+registerAction2(class CloseEditorAreaAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessions.closeEditorArea',
+			title: localize2('closeEditorArea', "Close Editor Area"),
+			icon: Codicon.close,
+			category: SessionsCategories.Sessions,
+			menu: {
+				id: MenuId.EditorGroupWatermarkToolbar,
+				group: 'navigation',
+				order: 10,
+				when: IsSessionsWindowContext,
+			},
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const layoutService = accessor.get(IWorkbenchLayoutService);
+		layoutService.setPartHidden(true, Parts.EDITOR_PART);
 	}
 });

--- a/src/vs/workbench/browser/parts/editor/editorGroupWatermark.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupWatermark.ts
@@ -9,9 +9,12 @@ import { coalesce, shuffle } from '../../../../base/common/arrays.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { isMacintosh, isWeb, OS } from '../../../../base/common/platform.js';
 import { localize } from '../../../../nls.js';
+import { MenuId } from '../../../../platform/actions/common/actions.js';
+import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
 import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr, ContextKeyExpression, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { IStorageService, StorageScope, StorageTarget, WillSaveStateReason } from '../../../../platform/storage/common/storage.js';
 import { defaultKeybindingLabelStyles } from '../../../../platform/theme/browser/defaultStyles.js';
@@ -74,6 +77,7 @@ export class EditorGroupWatermark extends Disposable {
 	private readonly cachedWhen: { [when: string]: boolean };
 
 	private readonly shortcuts: HTMLElement;
+	private readonly toolbarContainer: HTMLElement;
 	private readonly transientDisposables = this._register(new DisposableStore());
 	private readonly keybindingLabels = this._register(new DisposableStore());
 
@@ -86,22 +90,33 @@ export class EditorGroupWatermark extends Disposable {
 		@IWorkspaceContextService private readonly contextService: IWorkspaceContextService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
-		@IStorageService private readonly storageService: IStorageService
+		@IStorageService private readonly storageService: IStorageService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService
 	) {
 		super();
 
 		this.cachedWhen = this.storageService.getObject(EditorGroupWatermark.CACHED_WHEN, StorageScope.PROFILE, Object.create(null));
 		this.workbenchState = this.contextService.getWorkbenchState();
 
-		const elements = h('.editor-group-watermark', [
-			h('.watermark-container', [
-				h('.letterpress'),
-				h('.shortcuts@shortcuts'),
+		const elements = h('.editor-group-watermark-wrapper', [
+			h('.editor-group-watermark-toolbar-container@toolbarContainer'),
+			h('.editor-group-watermark', [
+				h('.watermark-container', [
+					h('.letterpress'),
+					h('.shortcuts@shortcuts'),
+				])
 			])
 		]);
 
 		append(container, elements.root);
 		this.shortcuts = elements.shortcuts;
+		this.toolbarContainer = elements.toolbarContainer;
+
+		this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, this.toolbarContainer, MenuId.EditorGroupWatermarkToolbar, {
+			hiddenItemStrategy: HiddenItemStrategy.NoHide,
+			highlightToggledItems: true,
+			menuOptions: { shouldForwardArgs: true }
+		}));
 
 		this.registerListeners();
 

--- a/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
+++ b/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
@@ -80,7 +80,24 @@
 
 /* Watermark & shortcuts */
 
-.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark  {
+.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark-wrapper {
+	position: relative;
+	width: 100%;
+	height: 100%;
+}
+
+.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark-wrapper > .editor-group-watermark-toolbar-container {
+	position: absolute;
+	top: 0;
+	right: 0;
+	height: 35px;
+	display: flex;
+	align-items: center;
+	padding: 0 8px;
+	box-sizing: border-box;
+}
+
+.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark-wrapper > .editor-group-watermark  {
 	display: flex;
 	height: 100%;
 	max-width: 272px;
@@ -90,7 +107,7 @@
 	justify-content: center;
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark > .watermark-container {
+.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark-wrapper > .editor-group-watermark > .watermark-container {
 	display: flex;
 	width: 100%;
 	flex-direction: column;
@@ -99,17 +116,17 @@
 	gap: 24px;
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container:not(.empty) > .editor-group-watermark {
+.monaco-workbench .part.editor > .content .editor-group-container:not(.empty) > .editor-group-watermark-wrapper {
 	display: none;
 }
 
-.monaco-workbench .part.editor > .content:not(.empty) .editor-group-container.empty > .editor-group-watermark,
-.monaco-workbench .part.editor > .content.auxiliary .editor-group-container.empty > .editor-group-watermark {
+.monaco-workbench .part.editor > .content:not(.empty) .editor-group-container.empty > .editor-group-watermark-wrapper > .editor-group-watermark,
+.monaco-workbench .part.editor > .content.auxiliary .editor-group-container.empty > .editor-group-watermark-wrapper > .editor-group-watermark {
 	max-width: 200px;
 	height: calc(100% - 70px);
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark .letterpress {
+.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark-wrapper .editor-group-watermark .letterpress {
 	width: 100%;
 	max-height: 100%;
 	aspect-ratio: 1/1;
@@ -132,22 +149,22 @@
 	background-image: url('./letterpress-hcDark.svg');
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark .shortcuts {
+.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark-wrapper .editor-group-watermark .shortcuts {
 	width: 100%;
 }
 
-.monaco-workbench .part.editor > .content:not(.empty) .editor-group-container > .editor-group-watermark .shortcuts,
-.monaco-workbench .part.editor > .content.auxiliary .editor-group-container > .editor-group-watermark .shortcuts,
-.monaco-workbench .part.editor > .content .editor-group-container.max-height-478px > .editor-group-watermark .shortcuts {
+.monaco-workbench .part.editor > .content:not(.empty) .editor-group-container > .editor-group-watermark-wrapper .editor-group-watermark .shortcuts,
+.monaco-workbench .part.editor > .content.auxiliary .editor-group-container > .editor-group-watermark-wrapper .editor-group-watermark .shortcuts,
+.monaco-workbench .part.editor > .content .editor-group-container.max-height-478px > .editor-group-watermark-wrapper .editor-group-watermark .shortcuts {
 	display: none;
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark .shortcuts > .watermark-box {
+.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark-wrapper .editor-group-watermark .shortcuts > .watermark-box {
 	display: flex;
 	flex-direction: column;
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark .shortcuts dl {
+.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark-wrapper .editor-group-watermark .shortcuts dl {
 	display: flex;
 	justify-content: space-between;
 	margin: 4px 0;
@@ -155,19 +172,19 @@
 	color: var(--vscode-descriptionForeground);
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark .shortcuts dl:first-of-type {
+.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark-wrapper .editor-group-watermark .shortcuts dl:first-of-type {
 	margin-top: 0;
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark .shortcuts dl:last-of-type {
+.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark-wrapper .editor-group-watermark .shortcuts dl:last-of-type {
 	margin-bottom: 0;
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark .shortcuts dt {
+.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark-wrapper .editor-group-watermark .shortcuts dt {
 	letter-spacing: 0.04em;
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark .shortcuts dd {
+.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark-wrapper .editor-group-watermark .shortcuts dd {
 	text-align: left;
 	margin-inline-start: 24px;
 }


### PR DESCRIPTION
```Copilot Generated Description:``` Prevent the editor area from toggling visibility when multiple sessions are active. Introduce a new action to close the editor area via a watermark toolbar. Update the layout service to suppress automatic visibility changes during specific operations.

