### PR TITLE
Fix Plan agent reporting mode "custom" instead of "plan" in telemetry

### DIFF
--- a/extensions/copilot/src/extension/prompt/node/chatParticipantTelemetry.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatParticipantTelemetry.ts
@@ -33,7 +33,7 @@ import { IToolCall, IToolCallRound } from '../common/intents';
 import { IDocumentContext } from './documentContext';
 import { IIntent, TelemetryData } from './intents';
 import { RepoInfoTelemetry } from './repoInfoTelemetry';
-import { ConversationalBaseTelemetryData, ConversationalTelemetryData, createTelemetryWithId, extendUserMessageTelemetryData, getCodeBlocks, sendModelMessageTelemetry, sendOffTopicMessageTelemetry, sendUserActionTelemetry, sendUserMessageTelemetry } from './telemetry';
+import { ConversationalBaseTelemetryData, ConversationalTelemetryData, createTelemetryWithId, extendUserMessageTelemetryData, getCodeBlocks, getModeNameForTelemetry, sendModelMessageTelemetry, sendOffTopicMessageTelemetry, sendUserActionTelemetry, sendUserMessageTelemetry } from './telemetry';
 
 // #region: internal telemetry for responses
 
@@ -462,11 +462,11 @@ export abstract class ChatTelemetry<C extends IDocumentContext | undefined = IDo
 	}
 
 	protected _getModeNameForTelemetry(): string {
-		return this._request.modeInstructions2 ? (this._request.modeInstructions2.isBuiltin ? this._request.modeInstructions2.name.toLowerCase() : 'custom') :
-			this._intent.id === AgentIntent.ID ? 'agent' :
+		return getModeNameForTelemetry(this._request.modeInstructions2) ??
+			(this._intent.id === AgentIntent.ID ? 'agent' :
 				(this._intent.id === EditCodeIntent.ID) ? 'edit' :
 					(this._intent.id === Intent.InlineChat) ? 'inlineChatIntent' :
-						'ask';
+						'ask');
 	}
 
 	public sendToolCallingTelemetry(toolCallRounds: IToolCallRound[], availableTools: readonly vscode.LanguageModelToolInformation[], responseType: ChatFetchResponseType | 'cancelled' | 'maxToolCalls'): void {

--- a/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
+++ b/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
@@ -57,7 +57,7 @@ import { ChatTelemetry, ChatTelemetryBuilder } from './chatParticipantTelemetry'
 import { IntentInvocationMetadata } from './conversation';
 import { IDocumentContext } from './documentContext';
 import { IBuildPromptResult, IIntent, IIntentInvocation, IResponseProcessor, TelemetryData } from './intents';
-import { ConversationalBaseTelemetryData, createTelemetryWithId, sendModelMessageTelemetry } from './telemetry';
+import { ConversationalBaseTelemetryData, createTelemetryWithId, getModeNameForTelemetry, sendModelMessageTelemetry } from './telemetry';
 
 export interface IDefaultIntentRequestHandlerOptions {
 	maxToolCallIterations: number;
@@ -461,9 +461,9 @@ export class DefaultIntentRequestHandler {
 	}
 
 	private getModeNameForTelemetry(): string {
-		const modeInstructionsName = this.request.modeInstructions2?.name?.toLowerCase();
-		if (modeInstructionsName) {
-			return this.request.modeInstructions2?.isBuiltin ? this.request.modeInstructions2.name.toLowerCase() : 'custom';
+		const modeName = getModeNameForTelemetry(this.request.modeInstructions2);
+		if (modeName !== undefined) {
+			return modeName;
 		}
 
 		if (this.intent.id === 'editAgent') {

--- a/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
+++ b/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
@@ -454,13 +454,13 @@ export class DefaultIntentRequestHandler {
 			requestId,
 			this.documentContext?.document,
 			baseModelTelemetry,
-			this.getModeNameForTelemetry()
+			this.resolveModeNameForTelemetry()
 		);
 
 		return chatResult;
 	}
 
-	private getModeNameForTelemetry(): string {
+	private resolveModeNameForTelemetry(): string {
 		const modeName = getModeNameForTelemetry(this.request.modeInstructions2);
 		if (modeName !== undefined) {
 			return modeName;

--- a/extensions/copilot/src/extension/prompt/node/promptCategorizer.ts
+++ b/extensions/copilot/src/extension/prompt/node/promptCategorizer.ts
@@ -21,6 +21,7 @@ import { IInstantiationService } from '../../../util/vs/platform/instantiation/c
 import { renderPromptElement } from '../../prompts/node/base/promptRenderer';
 import { PromptCategorizationPrompt } from '../../prompts/node/panel/promptCategorization';
 import { CATEGORIZE_PROMPT_TOOL_NAME, CATEGORIZE_PROMPT_TOOL_SCHEMA, isValidDomain, isValidIntent, isValidScope, PromptClassification } from '../common/promptCategorizationTaxonomy';
+import { getModeNameForTelemetry } from './telemetry';
 
 /** Experiment flag to enable prompt categorization */
 const EXP_FLAG_PROMPT_CATEGORIZATION = 'copilotchat.promptCategorization';
@@ -326,7 +327,7 @@ export class PromptCategorizerService implements IPromptCategorizerService {
 				sessionId: request.sessionId ?? '',
 				requestId: telemetryMessageId,
 				vscodeRequestId: request.id ?? '',
-				modeName: request.modeInstructions2?.isBuiltin ? request.modeInstructions2?.name.toLowerCase() : 'custom',
+				modeName: getModeNameForTelemetry(request.modeInstructions2) ?? 'custom',
 				currentLanguage: currentLanguage ?? '',
 				outcome,
 				intent: classification?.intent ?? '',
@@ -358,7 +359,7 @@ export class PromptCategorizerService implements IPromptCategorizerService {
 				sessionId: request.sessionId ?? '',
 				requestId: telemetryMessageId,
 				vscodeRequestId: request.id ?? '',
-				modeName: request.modeInstructions2?.isBuiltin ? request.modeInstructions2?.name.toLowerCase() : 'custom',
+				modeName: getModeNameForTelemetry(request.modeInstructions2) ?? 'custom',
 				currentLanguage: currentLanguage ?? '',
 				outcome,
 				errorDetail: truncatedErrorDetail,

--- a/extensions/copilot/src/extension/prompt/node/telemetry.ts
+++ b/extensions/copilot/src/extension/prompt/node/telemetry.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { TextDocument } from 'vscode';
+import type { ChatRequestModeInstructions, TextDocument } from 'vscode';
 import { ChatLocation } from '../../../platform/chat/common/commonTypes';
 import { TextDocumentSnapshot } from '../../../platform/editing/common/textDocumentSnapshot';
 import { ITelemetryService, TelemetryProperties } from '../../../platform/telemetry/common/telemetry';
@@ -17,6 +17,38 @@ export function createTelemetryWithId(): ConversationalBaseTelemetryData {
 	const uniqueId = generateUuid();
 	const baseTelemetry = TelemetryData.createAndMarkAsIssued({ messageId: uniqueId });
 	return new ConversationalTelemetryData(baseTelemetry);
+}
+
+/**
+ * Legacy telemetry compatibility allowlist of custom-provider agents that should still
+ * be reported under their own name rather than the generic `custom` bucket.
+ *
+ * The Plan agent is contributed via a `ChatCustomAgentProvider`, so `isBuiltin` is `false`
+ * even though it is shipped by Copilot. Downstream metrics (e.g. `chat_panel_plan_mode`) key
+ * off the literal value `plan`, so it must be preserved here.
+ */
+const NAMED_CUSTOM_AGENT_MODES = new Set(['plan']);
+
+/**
+ * Resolves the mode name to report in telemetry for a request's mode instructions.
+ *
+ * Built-in modes (Ask, Edit, Agent) report their lowercased name. Custom-provider agents
+ * report `custom`, except for those in {@link NAMED_CUSTOM_AGENT_MODES} which are reported
+ * under their own name for backwards compatibility with downstream metrics.
+ *
+ * @returns the resolved mode name, or `undefined` when no mode instructions are present.
+ */
+export function getModeNameForTelemetry(modeInstructions: ChatRequestModeInstructions | undefined): string | undefined {
+	if (!modeInstructions) {
+		return undefined;
+	}
+
+	const modeName = modeInstructions.name.toLowerCase();
+	if (modeInstructions.isBuiltin || NAMED_CUSTOM_AGENT_MODES.has(modeName)) {
+		return modeName;
+	}
+
+	return 'custom';
 }
 
 export class ConversationalTelemetryData<P extends TelemetryProperties, M extends { [key: string]: number }> {

--- a/extensions/copilot/src/extension/prompt/node/test/telemetry.spec.ts
+++ b/extensions/copilot/src/extension/prompt/node/test/telemetry.spec.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { suite, test } from 'vitest';
+import type { ChatRequestModeInstructions } from 'vscode';
+import { getModeNameForTelemetry } from '../telemetry';
+
+suite('getModeNameForTelemetry', () => {
+	function modeInstructions(props: Partial<ChatRequestModeInstructions>): ChatRequestModeInstructions {
+		return { name: 'Mode', content: '', ...props } as ChatRequestModeInstructions;
+	}
+
+	test('returns undefined when no mode instructions are present', () => {
+		assert.strictEqual(getModeNameForTelemetry(undefined), undefined);
+	});
+
+	test('returns lowercased name for built-in modes', () => {
+		assert.strictEqual(getModeNameForTelemetry(modeInstructions({ name: 'Agent', isBuiltin: true })), 'agent');
+		assert.strictEqual(getModeNameForTelemetry(modeInstructions({ name: 'Ask', isBuiltin: true })), 'ask');
+		assert.strictEqual(getModeNameForTelemetry(modeInstructions({ name: 'Edit', isBuiltin: true })), 'edit');
+	});
+
+	test('reports the Plan custom-provider agent under its own name', () => {
+		assert.strictEqual(getModeNameForTelemetry(modeInstructions({ name: 'Plan', isBuiltin: false })), 'plan');
+	});
+
+	test('reports other custom agents as custom', () => {
+		assert.strictEqual(getModeNameForTelemetry(modeInstructions({ name: 'my-agent', isBuiltin: false })), 'custom');
+	});
+});


### PR DESCRIPTION
## Summary

Fixes microsoft/vscode-copilot-issues#442.

Since [#4086](https://github.com/microsoft/vscode-copilot-chat/pull/4086), panel chat events from the built-in **Plan** agent emit `mode = "custom"` instead of `mode = "plan"`, breaking the downstream `chat_panel_plan_mode` usage metric that keys off the literal value `"plan"`.

## Root cause

The Plan agent is contributed via a `ChatCustomAgentProvider` (`PlanAgentProvider`), so `modeInstructions2.isBuiltin` is `false` — VS Code core only treats Ask/Edit/Agent as built-in modes (`isBuiltinChatMode`). PR #4086 replaced the old name-based telemetry check:

```ts
modeInstructions2.name.toLowerCase() === 'plan' ? 'plan' : 'custom'
```

with an `isBuiltin`-based check:

```ts
modeInstructions2.isBuiltin ? modeInstructions2.name.toLowerCase() : 'custom'
```

which silently dropped Plan into the generic `custom` bucket.

## Fix

- Add a shared `getModeNameForTelemetry()` helper in `prompt/node/telemetry.ts` with a small legacy-compatibility allowlist (`NAMED_CUSTOM_AGENT_MODES = { 'plan' }`) so the Plan custom-provider agent is reported under its own name.
- Route the four duplicated call sites through the helper to avoid future drift:
  - `chatParticipantTelemetry.ts` (`_getModeNameForTelemetry`)
  - `defaultIntentRequestHandler.ts` (`getModeNameForTelemetry`)
  - `promptCategorizer.ts` (two telemetry sends)

Scope is intentionally narrow: only `plan` is special-cased (a regression restore). Other custom-provider agents (Explore/Ask/Edit) keep reporting `custom`, and core platform semantics (`isBuiltinChatMode`) are unchanged.

## Testing

- New unit tests in `prompt/node/test/telemetry.spec.ts` cover: no instructions, built-in Ask/Edit/Agent, Plan (`isBuiltin: false` → `plan`), and a generic custom agent (→ `custom`).
- `tsc -p tsconfig.json --noEmit` clean; related tests pass; pre-commit hygiene passes.