### PR TITLE
add restricted token parsing on AH

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -50,6 +50,7 @@ import { ICopilotSessionContext, projectFromCopilotContext } from './copilotGitP
 import { parsedPluginsEqual, toChildCustomizations } from './copilotPluginConverters.js';
 import { CopilotSessionLauncher, ContextTierConfigKey, ThinkingLevelConfigKey, getCopilotContextTier, getCopilotReasoningEffort, type CopilotSessionLaunchPlan, type IActiveClientSnapshot } from './copilotSessionLauncher.js';
 import { ShellManager } from './copilotShellTools.js';
+import { isRestrictedTelemetryEnabled } from './copilotTokenFields.js';
 import { CopilotSlashCommandCompletionProvider } from './copilotSlashCommandCompletionProvider.js';
 import { DiscoveredType, SessionCustomizationDiscovery, areDiscoveredDirectoriesEqual, type IDiscoveredDirectory } from './sessionCustomizationDiscovery.js';
 
@@ -275,6 +276,21 @@ export class CopilotAgent extends Disposable implements IAgent {
 	private _client: CopilotClient | undefined;
 	private _clientStarting: Promise<CopilotClient> | undefined;
 	private _githubToken: string | undefined;
+
+	/**
+	 * Parsed from the `rt=1` field on the GitHub Copilot bearer token, the
+	 * same way `BaseGHTelemetrySender._processToken` does in the extension-host
+	 * path. Read by the AHP-side IGHTelemetryService before sending events
+	 * via `sendEnhancedGHTelemetryEvent`.
+	 */
+	private _restrictedTelemetryEnabled = false;
+	private readonly _onDidChangeRestrictedTelemetry = this._register(new Emitter<void>());
+	readonly onDidChangeRestrictedTelemetry = this._onDidChangeRestrictedTelemetry.event;
+
+	get restrictedTelemetryEnabled(): boolean {
+		return this._restrictedTelemetryEnabled;
+	}
+
 	private readonly _sessions = this._register(new DisposableMap<string, CopilotAgentSession>());
 	/**
 	 * Per-session MCP-notification subscriptions, keyed by `sessionId`.
@@ -448,6 +464,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		}
 		const tokenChanged = this._githubToken !== token;
 		this._githubToken = token;
+		this._updateRestrictedTelemetry(token);
 		this._logService.info(`[Copilot] Auth token ${tokenChanged ? 'updated' : 'unchanged'}`);
 		if (tokenChanged && this._client && this._sessions.size === 0) {
 			this._logService.info('[Copilot] Restarting CopilotClient with new token');
@@ -457,6 +474,15 @@ export class CopilotAgent extends Disposable implements IAgent {
 			void this._refreshModels();
 		}
 		return true;
+	}
+
+	private _updateRestrictedTelemetry(token: string | undefined): void {
+		const rtEnabled = isRestrictedTelemetryEnabled(token);
+		if (rtEnabled !== this._restrictedTelemetryEnabled) {
+			this._restrictedTelemetryEnabled = rtEnabled;
+			this._logService.info(`[Copilot] Restricted telemetry ${rtEnabled ? 'enabled' : 'disabled'}`);
+			this._onDidChangeRestrictedTelemetry.fire();
+		}
 	}
 
 	private async _refreshModels(): Promise<void> {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -277,12 +277,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	private _clientStarting: Promise<CopilotClient> | undefined;
 	private _githubToken: string | undefined;
 
-	/**
-	 * Parsed from the `rt=1` field on the GitHub Copilot bearer token, the
-	 * same way `BaseGHTelemetrySender._processToken` does in the extension-host
-	 * path. Read by the AHP-side IGHTelemetryService before sending events
-	 * via `sendEnhancedGHTelemetryEvent`.
-	 */
+	/** Reflects the `rt=1` field on the GitHub Copilot bearer token; gates enhanced GH telemetry. */
 	private _restrictedTelemetryEnabled = false;
 	private readonly _onDidChangeRestrictedTelemetry = this._register(new Emitter<void>());
 	readonly onDidChangeRestrictedTelemetry = this._onDidChangeRestrictedTelemetry.event;

--- a/src/vs/platform/agentHost/node/copilot/copilotTokenFields.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotTokenFields.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Parses the field map encoded in the first colon-delimited segment of a
+ * Copilot token (e.g. `"tid=abc;exp=123;rt=1:HMAC..."`).
+ *
+ * Mirrors `CopilotToken.parseToken` in
+ * `extensions/copilot/src/platform/authentication/common/copilotToken.ts`
+ * but does not require the full `CopilotToken` class (which imports
+ * extension-host-only dependencies that aren't available in the AHP
+ * utility process).
+ */
+export function parseCopilotTokenFields(token: string | undefined): ReadonlyMap<string, string> {
+	const result = new Map<string, string>();
+	if (!token) {
+		return result;
+	}
+	const firstPart = token.split(':')[0];
+	for (const field of firstPart.split(';')) {
+		const [key, value] = field.split('=');
+		if (key) {
+			result.set(key, value);
+		}
+	}
+	return result;
+}
+
+/**
+ * Returns true if the token has the `rt=1` field set, indicating the user
+ * has opted in to restricted (enhanced) GitHub telemetry.
+ */
+export function isRestrictedTelemetryEnabled(token: string | undefined): boolean {
+	return parseCopilotTokenFields(token).get('rt') === '1';
+}

--- a/src/vs/platform/agentHost/node/copilot/copilotTokenFields.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotTokenFields.ts
@@ -3,16 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-/**
- * Parses the field map encoded in the first colon-delimited segment of a
- * Copilot token (e.g. `"tid=abc;exp=123;rt=1:HMAC..."`).
- *
- * Mirrors `CopilotToken.parseToken` in
- * `extensions/copilot/src/platform/authentication/common/copilotToken.ts`
- * but does not require the full `CopilotToken` class (which imports
- * extension-host-only dependencies that aren't available in the AHP
- * utility process).
- */
+/** Parses the `key=value;...` field map from the leading colon-delimited segment of a Copilot token (e.g. `tid=abc;exp=123;rt=1:HMAC...`). */
 export function parseCopilotTokenFields(token: string | undefined): ReadonlyMap<string, string> {
 	const result = new Map<string, string>();
 	if (!token) {
@@ -28,10 +19,6 @@ export function parseCopilotTokenFields(token: string | undefined): ReadonlyMap<
 	return result;
 }
 
-/**
- * Returns true if the token has the `rt=1` field set, indicating the user
- * has opted in to restricted (enhanced) GitHub telemetry.
- */
 export function isRestrictedTelemetryEnabled(token: string | undefined): boolean {
 	return parseCopilotTokenFields(token).get('rt') === '1';
 }

--- a/src/vs/platform/agentHost/node/copilot/copilotTokenFields.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotTokenFields.ts
@@ -9,12 +9,14 @@ export function parseCopilotTokenFields(token: string | undefined): ReadonlyMap<
 	if (!token) {
 		return result;
 	}
-	const firstPart = token.split(':')[0];
-	for (const field of firstPart.split(';')) {
-		const [key, value] = field.split('=');
-		if (key) {
-			result.set(key, value);
+	const colonIdx = token.indexOf(':');
+	const header = colonIdx === -1 ? token : token.substring(0, colonIdx);
+	for (const field of header.split(';')) {
+		const eqIdx = field.indexOf('=');
+		if (eqIdx <= 0) {
+			continue;
 		}
+		result.set(field.substring(0, eqIdx), field.substring(eqIdx + 1));
 	}
 	return result;
 }

--- a/src/vs/platform/agentHost/test/node/copilotTokenFields.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotTokenFields.test.ts
@@ -32,6 +32,13 @@ suite('copilotTokenFields', () => {
 			assert.strictEqual(fields.get('tid'), 'abc');
 			assert.strictEqual(fields.get('rt'), '1');
 		});
+
+		test('skips segments without a value separator', () => {
+			const fields = parseCopilotTokenFields('tid=abc;rt;exp=123:HMAC');
+			assert.strictEqual(fields.has('rt'), false);
+			assert.strictEqual(fields.get('tid'), 'abc');
+			assert.strictEqual(fields.get('exp'), '123');
+		});
 	});
 
 	suite('isRestrictedTelemetryEnabled', () => {
@@ -63,7 +70,7 @@ suite('copilotTokenFields', () => {
 			assert.strictEqual(isRestrictedTelemetryEnabled('tid=abc;exp=123;rt=1:HMAC'), true);
 		});
 
-		test('true for malformed token with no colon separator', () => {
+		test('true when token has no colon-delimited signature segment', () => {
 			assert.strictEqual(isRestrictedTelemetryEnabled('tid=abc;rt=1'), true);
 		});
 	});

--- a/src/vs/platform/agentHost/test/node/copilotTokenFields.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotTokenFields.test.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { isRestrictedTelemetryEnabled, parseCopilotTokenFields } from '../../node/copilot/copilotTokenFields.js';
+
+suite('copilotTokenFields', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('parseCopilotTokenFields', () => {
+		test('returns empty map for undefined token', () => {
+			assert.strictEqual(parseCopilotTokenFields(undefined).size, 0);
+		});
+
+		test('returns empty map for empty token', () => {
+			assert.strictEqual(parseCopilotTokenFields('').size, 0);
+		});
+
+		test('parses fields from the leading colon-delimited segment', () => {
+			const fields = parseCopilotTokenFields('tid=abc;exp=123;rt=1:HMACSIGNATURE');
+			assert.strictEqual(fields.get('tid'), 'abc');
+			assert.strictEqual(fields.get('exp'), '123');
+			assert.strictEqual(fields.get('rt'), '1');
+		});
+
+		test('parses fields when no colon separator is present', () => {
+			const fields = parseCopilotTokenFields('tid=abc;rt=1');
+			assert.strictEqual(fields.get('tid'), 'abc');
+			assert.strictEqual(fields.get('rt'), '1');
+		});
+	});
+
+	suite('isRestrictedTelemetryEnabled', () => {
+		test('false for undefined token', () => {
+			assert.strictEqual(isRestrictedTelemetryEnabled(undefined), false);
+		});
+
+		test('false for empty token', () => {
+			assert.strictEqual(isRestrictedTelemetryEnabled(''), false);
+		});
+
+		test('false when rt field is missing', () => {
+			assert.strictEqual(isRestrictedTelemetryEnabled('tid=abc;exp=123:HMAC'), false);
+		});
+
+		test('false when rt=0', () => {
+			assert.strictEqual(isRestrictedTelemetryEnabled('tid=abc;rt=0;exp=123:HMAC'), false);
+		});
+
+		test('true when rt=1 with other fields', () => {
+			assert.strictEqual(isRestrictedTelemetryEnabled('tid=abc;rt=1;exp=123:HMAC'), true);
+		});
+
+		test('true when rt=1 is the first field', () => {
+			assert.strictEqual(isRestrictedTelemetryEnabled('rt=1;tid=abc:HMAC'), true);
+		});
+
+		test('true when rt=1 is the last field', () => {
+			assert.strictEqual(isRestrictedTelemetryEnabled('tid=abc;exp=123;rt=1:HMAC'), true);
+		});
+
+		test('true for malformed token with no colon separator', () => {
+			assert.strictEqual(isRestrictedTelemetryEnabled('tid=abc;rt=1'), true);
+		});
+	});
+});


### PR DESCRIPTION
wires up restricted-telemetry detection on the agent-host (AHP) side, mirroring what BaseGHTelemetrySender does in the extension host side.