### PR TITLE
Support stylus/pen text selection on Android tablets

### DIFF
--- a/src/vs/editor/browser/controller/pointerHandler.ts
+++ b/src/vs/editor/browser/controller/pointerHandler.ts
@@ -141,7 +141,7 @@ export class PointerHandler extends Disposable {
 
 	constructor(context: ViewContext, viewController: ViewController, viewHelper: IPointerHandlerHelper) {
 		super();
-		const isPhone = platform.isIOS || (platform.isAndroid && platform.isMobile);
+		const isPhone = platform.isIOS || platform.isAndroid;
 		if (isPhone && BrowserFeatures.pointerEvents) {
 			this.handler = this._register(new PointerEventHandler(context, viewController, viewHelper));
 		} else if (mainWindow.TouchEvent) {


### PR DESCRIPTION
This lets a stylus/pen drag select text in the editor on Android tablets, the same as it already does on iOS and Android phones. A finger drag still scrolls and the mouse is unchanged.

### Problem

#198578 added the pen/stylus selection path (`PointerEventHandler`) for mobile devices, gated by:

```ts
const isPhone = platform.isIOS || (platform.isAndroid && platform.isMobile);
```

`platform.isMobile` looks for a `Mobi` token in the user agent, and Android tablets generally omit it. So on a tablet the editor falls back to `TouchHandler`, where pen input behaves like a finger: it can scroll but never select text.

### Change

Drop the `platform.isMobile` requirement for Android, so any Android device with Pointer Events support gets `PointerEventHandler`. The iOS branch is untouched, and Android phones already satisfied the old condition, so behavior only changes for Android tablets.

### Testing

This change was first made as a patch in code-server (coder/code-server#7841), where I built and tested it on a Samsung tablet with an S Pen in Chrome:

- Pen drag across text selects it.
- Finger drag scrolls.
- Pen barrel button + tap opens the context menu.
- Mouse selection and right-click are unchanged.

It is also reproducible in desktop Chrome with DevTools device mode set to an Android tablet user agent without a `Mobi` token. The code-server maintainers asked that the fix be submitted upstream rather than maintained as a patch, hence this PR.
