### PR TITLE
Add constants for Copilot integration and update git clone command

### DIFF
--- a/build/azure-pipelines/alpine/product-build-alpine.yml
+++ b/build/azure-pipelines/alpine/product-build-alpine.yml
@@ -180,6 +180,8 @@ jobs:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         displayName: Download Copilot VSIX (background)
 
+      - template: ../common/mixin-vscode-capi.yml@self
+
       - script: npm run gulp core-ci
         env:
           GITHUB_TOKEN: "$(github-distro-mixin-password)"

--- a/build/azure-pipelines/common/mixin-vscode-capi.yml
+++ b/build/azure-pipelines/common/mixin-vscode-capi.yml
@@ -15,7 +15,7 @@ steps:
       }
 
       try {
-        Invoke-CheckedCommand { git clone https://github.com/microsoft/vscode-capi.git --depth 1 $CapiPath }
+        Invoke-CheckedCommand { git clone https://github.com/microsoft/vscode-capi.git --depth 1 --branch don/pale-lungfish $CapiPath }
         Push-Location $CapiPath
 
         try {

--- a/build/azure-pipelines/common/mixin-vscode-capi.yml
+++ b/build/azure-pipelines/common/mixin-vscode-capi.yml
@@ -15,7 +15,7 @@ steps:
       }
 
       try {
-        Invoke-CheckedCommand { git clone https://github.com/microsoft/vscode-capi.git --depth 1 --branch don/pale-lungfish $CapiPath }
+        Invoke-CheckedCommand { git clone https://github.com/microsoft/vscode-capi.git --depth 1 --branch main $CapiPath }
         Push-Location $CapiPath
 
         try {

--- a/build/azure-pipelines/common/mixin-vscode-capi.yml
+++ b/build/azure-pipelines/common/mixin-vscode-capi.yml
@@ -16,7 +16,7 @@ steps:
       }
 
       try {
-        Invoke-CheckedCommand { git clone https://github.com/microsoft/vscode-capi.git --depth 1 --branch main $CapiPath }
+        Invoke-CheckedCommand { git clone https://github.com/microsoft/vscode-capi.git --depth 1 --branch don/pale-lungfish $CapiPath }
         Push-Location $CapiPath
 
         try {

--- a/build/azure-pipelines/common/mixin-vscode-capi.yml
+++ b/build/azure-pipelines/common/mixin-vscode-capi.yml
@@ -5,7 +5,8 @@ steps:
       function Invoke-CheckedCommand([scriptblock] $Command) {
         & $Command
         if ($LASTEXITCODE -ne 0) {
-          throw "Command failed with exit code $LASTEXITCODE`: $Command"
+          $commandText = $Command.ToString().Trim()
+          throw "Command failed with exit code ${LASTEXITCODE}: ${commandText}"
         }
       }
 

--- a/build/azure-pipelines/common/mixin-vscode-capi.yml
+++ b/build/azure-pipelines/common/mixin-vscode-capi.yml
@@ -1,0 +1,33 @@
+steps:
+  - pwsh: |
+      $ErrorActionPreference = 'Stop'
+
+      function Invoke-CheckedCommand([scriptblock] $Command) {
+        & $Command
+        if ($LASTEXITCODE -ne 0) {
+          throw "Command failed with exit code $LASTEXITCODE`: $Command"
+        }
+      }
+
+      $CapiPath = Join-Path '$(Agent.BuildDirectory)' 'vscode-capi'
+      if (Test-Path $CapiPath) {
+        Remove-Item -Recurse -Force $CapiPath
+      }
+
+      try {
+        Invoke-CheckedCommand { git clone https://github.com/microsoft/vscode-capi.git --depth 1 $CapiPath }
+        Push-Location $CapiPath
+
+        try {
+          Invoke-CheckedCommand { npm ci }
+          $env:BUILD_SOURCESDIRECTORY = '$(Build.SourcesDirectory)'
+          Invoke-CheckedCommand { npm run mixin_vscode }
+        } finally {
+          Pop-Location
+        }
+      } finally {
+        if (Test-Path $CapiPath) {
+          Remove-Item -Recurse -Force $CapiPath
+        }
+      }
+    displayName: Mixin vscode-capi

--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -119,6 +119,8 @@ steps:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     displayName: Download Copilot VSIX (background)
 
+  - template: ../../common/mixin-vscode-capi.yml@self
+
   - script: npm run gulp core-ci
     env:
       GITHUB_TOKEN: "$(github-distro-mixin-password)"

--- a/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
@@ -177,6 +177,8 @@ steps:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     displayName: Download Copilot VSIX (background)
 
+  - template: ../../common/mixin-vscode-capi.yml@self
+
   - script: npm run gulp core-ci
     env:
       GITHUB_TOKEN: "$(github-distro-mixin-password)"

--- a/build/azure-pipelines/product-quality-checks.yml
+++ b/build/azure-pipelines/product-quality-checks.yml
@@ -127,6 +127,8 @@ jobs:
         continueOnError: true
         condition: and(succeeded(), eq(lower(variables['VSCODE_PUBLISH']), 'true'))
 
+      - template: ./common/mixin-vscode-capi.yml@self
+
       - script: npm exec -- npm-run-all2 -lp core-ci hygiene eslint valid-layers-check define-class-fields-check vscode-dts-compile-check tsec-compile-check test-build-scripts
         env:
           GITHUB_TOKEN: "$(github-distro-mixin-password)"

--- a/build/azure-pipelines/web/product-build-web.yml
+++ b/build/azure-pipelines/web/product-build-web.yml
@@ -115,6 +115,8 @@ jobs:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         displayName: Download Copilot VSIX (background)
 
+      - template: ../common/mixin-vscode-capi.yml@self
+
       - script: npm run gulp core-ci
         env:
           GITHUB_TOKEN: "$(github-distro-mixin-password)"

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -102,6 +102,8 @@ steps:
 
   - template: ../common/install-builtin-extensions.yml@self
 
+  - template: ../common/mixin-vscode-capi.yml@self
+
   - powershell: npm run gulp core-ci
     env:
       GITHUB_TOKEN: "$(github-distro-mixin-password)"

--- a/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
+++ b/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
@@ -118,6 +118,8 @@ steps:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     displayName: Download Copilot VSIX (background)
 
+  - template: ../../common/mixin-vscode-capi.yml@self
+
   - powershell: npm run gulp core-ci
     env:
       GITHUB_TOKEN: "$(github-distro-mixin-password)"

--- a/build/filters.ts
+++ b/build/filters.ts
@@ -96,6 +96,7 @@ export const indentationFilter = Object.freeze<string[]>([
 	'!build/darwin/patch-dmg.py',
 	'!build/npm/gyp/patches/gyp_spectre_mitigation_support.patch',
 	'!product.overrides.json',
+	'!src/vs/platform/endpoint/common/licenseAgreement.ts',
 
 	// except specific folders
 	'!test/automation/out/**',

--- a/build/filters.ts
+++ b/build/filters.ts
@@ -71,6 +71,9 @@ export const unicodeFilter = Object.freeze<string[]>([
 	'!src/vs/base/browser/dompurify/**',
 	'!src/vs/workbench/services/keybinding/browser/keyboardLayouts/**',
 	'!src/vs/workbench/contrib/terminal/common/scripts/psreadline/**',
+
+	// Files with licences
+	'!src/vs/platform/endpoint/common/licenseAgreement.ts',
 ]);
 
 export const indentationFilter = Object.freeze<string[]>([

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -52,6 +52,7 @@ import { CopilotSessionLauncher, ContextTierConfigKey, ThinkingLevelConfigKey, g
 import { ShellManager } from './copilotShellTools.js';
 import { CopilotSlashCommandCompletionProvider } from './copilotSlashCommandCompletionProvider.js';
 import { DiscoveredType, SessionCustomizationDiscovery, areDiscoveredDirectoriesEqual, type IDiscoveredDirectory } from './sessionCustomizationDiscovery.js';
+import { COPILOT_INTEGRATION_ID } from '../../../endpoint/common/licenseAgreement.js';
 
 /**
  * Maps a VS Code {@link LogLevel} to the Copilot CLI runtime's `logLevel`
@@ -561,6 +562,9 @@ export class CopilotAgent extends Disposable implements IAgent {
 			}
 			env['COPILOT_CLI_RUN_AS_NODE'] = '1';
 			env['USE_BUILTIN_RIPGREP'] = 'false';
+
+			// Identify VS Code's agent host traffic in CAPI
+			env['GITHUB_COPILOT_INTEGRATION_ID'] = COPILOT_INTEGRATION_ID;
 
 			// Enable the rubber duck critic subagent in the CLI when the agent host
 			// config opts in. `RUBBER_DUCK_AGENT` is the SDK's required interface for

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -565,6 +565,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 			// Identify VS Code's agent host traffic in CAPI
 			env['GITHUB_COPILOT_INTEGRATION_ID'] = COPILOT_INTEGRATION_ID;
+			this._logService.info(`[Copilot] Set CLI env: GITHUB_COPILOT_INTEGRATION_ID=${COPILOT_INTEGRATION_ID}`);
 
 			// Enable the rubber duck critic subagent in the CLI when the agent host
 			// config opts in. `RUBBER_DUCK_AGENT` is the SDK's required interface for

--- a/src/vs/platform/agentHost/node/shared/copilotApiService.ts
+++ b/src/vs/platform/agentHost/node/shared/copilotApiService.ts
@@ -10,6 +10,7 @@ import { getDevDeviceId, getMachineId } from '../../../../base/node/id.js';
 import { createDecorator } from '../../../instantiation/common/instantiation.js';
 import { ILogService } from '../../../log/common/log.js';
 import { IProductService } from '../../../product/common/productService.js';
+import { COPILOT_INTEGRATION_ID, COPILOT_LICENSE_AGREEMENT } from '../../../endpoint/common/licenseAgreement.js';
 
 // #region Types
 
@@ -800,14 +801,14 @@ export class CopilotApiService implements ICopilotApiService {
 	private async _buildClientForToken(githubToken: string): Promise<ICachedClient> {
 		const { extensionInfo, userUrl } = await this._getCapiBase();
 		const fetch = this._fetch;
-		const capiClient = new CAPIClient(extensionInfo, undefined, {
+		const capiClient = new CAPIClient(extensionInfo, COPILOT_LICENSE_AGREEMENT, {
 			fetch: (url, options) => fetch(url, {
 				method: options.method ?? 'GET',
 				headers: options.headers,
 				body: options.body,
 				signal: options.signal as AbortSignal | undefined,
 			}),
-		});
+		}, undefined, COPILOT_INTEGRATION_ID);
 
 		this._logService.debug('[CopilotApiService] Discovering CAPI endpoints via /copilot_internal/user');
 

--- a/src/vs/platform/agentHost/node/shared/copilotApiService.ts
+++ b/src/vs/platform/agentHost/node/shared/copilotApiService.ts
@@ -798,6 +798,9 @@ export class CopilotApiService implements ICopilotApiService {
 		this._clientsByToken.delete(githubToken);
 	}
 
+	protected getIntegrationId(): string | undefined {
+		return COPILOT_INTEGRATION_ID;
+	}
 	private async _buildClientForToken(githubToken: string): Promise<ICachedClient> {
 		const { extensionInfo, userUrl } = await this._getCapiBase();
 		const fetch = this._fetch;
@@ -808,7 +811,7 @@ export class CopilotApiService implements ICopilotApiService {
 				body: options.body,
 				signal: options.signal as AbortSignal | undefined,
 			}),
-		}, undefined, COPILOT_INTEGRATION_ID);
+		}, undefined, this.getIntegrationId());
 
 		this._logService.debug('[CopilotApiService] Discovering CAPI endpoints via /copilot_internal/user');
 

--- a/src/vs/platform/agentHost/test/node/shared/copilotApiService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/shared/copilotApiService.integrationTest.ts
@@ -34,7 +34,15 @@ suite('CopilotApiService.utilityChatCompletion (real CAPI)', () => {
 		// `globalThis.fetch` through `this._fetch(...)` throws
 		// "Illegal invocation" in the Electron renderer.
 		const boundFetch: typeof globalThis.fetch = (...args) => globalThis.fetch(...args);
-		return new CopilotApiService(boundFetch, new NullLogService(), productService);
+		const service = new class extends CopilotApiService {
+			constructor() {
+				super(boundFetch, new NullLogService(), productService);
+			}
+			override getIntegrationId(): string | undefined {
+				return undefined; // Don't send an integration ID for tests
+			}
+		}();
+		return service;
 	}
 
 	(hasToken ? test : test.skip)('answers a trivial arithmetic prompt', async function () {

--- a/src/vs/platform/agentHost/test/node/shared/copilotApiService.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/copilotApiService.test.ts
@@ -85,7 +85,14 @@ function modelsResponse(models: object[]): Response {
 }
 
 function createService(fetchImpl: FetchFunction): CopilotApiService {
-	return new CopilotApiService(fetchImpl, new NullLogService(), testProductService);
+	return new class extends CopilotApiService {
+		constructor() {
+			super(fetchImpl, new NullLogService(), testProductService);
+		}
+		override getIntegrationId(): string | undefined {
+			return undefined; // Don't send an integration ID for tests
+		}
+	}();
 }
 
 type CapturedRequest = { url: string; init: RequestInit | undefined };

--- a/src/vs/platform/endpoint/common/licenseAgreement.ts
+++ b/src/vs/platform/endpoint/common/licenseAgreement.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * This file is modified as part of the production build.
+ *
+ * WARNING: Do not move or rename this file.
+ */
+export const COPILOT_LICENSE_AGREEMENT: string | undefined = undefined;
+export const COPILOT_INTEGRATION_ID: string = 'code-oss';


### PR DESCRIPTION
Introduce constants for `COPILOT_INTEGRATION_ID` and `COPILOT_LICENSE_AGREEMENT` to facilitate CAPI integration. Update the git clone command to specify the branch and log the integration ID in the Copilot agent.

Related PR https://github.com/microsoft/vscode-capi/pull/96