### PR TITLE
AH: per-platform agent SDK build + CDN upload

### DIFF
--- a/build/agent-sdk/README.md
+++ b/build/agent-sdk/README.md
@@ -1,0 +1,132 @@
+# build/agent-sdk
+
+Per-platform agent SDK production. Each VS Code build (`darwin-arm64`,
+`linux-x64`, Alpine REH, etc.) bakes its own `agentSdks` entry into the
+shipped `product.json` — one entry per SDK, carrying just the `url` +
+`sha256` for the platform this VS Code build targets.
+
+The runtime side (`src/vs/platform/agentHost/`) downloads, sha-verifies,
+and caches the SDK tarball at first use. See `IAgentSdkProductConfig` in
+`src/vs/base/common/product.ts` for the contract.
+
+## How the pipeline uses this
+
+The platform packaging jobs (Linux, macOS, Windows, Alpine) each include
+the shared template `build/azure-pipelines/common/agent-sdk-produce.yml`
+before the existing `gulp vscode-<platform>-<arch>-min-ci` step:
+
+```yaml
+- template: ../../common/agent-sdk-produce.yml@self
+  parameters:
+    vscodePlatform: linux
+```
+
+The template runs `node build/agent-sdk/produce.ts --vscode-platform=<x>
+--arch=$(VSCODE_ARCH)`, which iterates the SDKs (`SDKS = ['claude',
+'codex']`), figures out the matching `sdkTarget` for `(vscode-platform,
+arch, sdk)` via `getSdkTargetForBuild`, runs `buildOne` for each in
+parallel, and drops the tarballs in
+`$(Build.SourcesDirectory)/.build/agent-sdk/tarballs/`.
+
+### Publish vs test runs
+
+`produce.ts` reads the pipeline variable `VSCODE_PUBLISH` from env (Azure
+auto-injects all non-secret pipeline variables) to decide whether to
+hit the CDN:
+
+- **`VSCODE_PUBLISH=true` (real release builds)** — the AzureCLI@2
+  step inside the template fetches CDN credentials, `produce.ts` calls
+  `uploadOne` for every tarball (HEAD-then-decide idempotent), writes
+  the results JSON, and emits `##vso[task.setvariable
+  variable=AGENT_SDK_RESULTS_FILE]<path>`. The downstream gulp packaging
+  step then stamps `product.agentSdks` via `readAgentSdkResults()`.
+
+- **`VSCODE_PUBLISH` unset or not `'true'`** (PR runs, CI runs, manual
+  test runs with the publish toggle off) — the AzureCLI credential
+  step is skipped, the upload is skipped, no results file is written,
+  and `task.setvariable` is not emitted. The tarballs are still produced
+  and published as a pipeline artifact named
+  `agent_sdk_<vscodePlatform>_<arch>_tarballs` so you can download
+  and inspect them. product.json ships without `agentSdks` — same
+  shape as a local dev build, so the runtime falls back to the
+  per-provider env-var override.
+
+### Where the agentSdks gating lives
+
+Inside `packageTask`'s `jsonEditor` callback (the same one that injects
+`commit` / `date` / `checksums` / `version`), `readAgentSdkResults()` loads
+the results file (returns `{}` when the env var is unset) and merges
+`agentSdks` into `product.json`. The REH gulpfile only writes `agentSdks`
+for `type === 'reh'`; the REH-web variant skips it because the agent host
+is node-only and the SDK config has no consumer in a browser-served
+server.
+
+Local `gulp vscode-darwin-arm64` invocations don't set
+`AGENT_SDK_RESULTS_FILE` and don't have `VSCODE_PUBLISH=true`, so
+`readAgentSdkResults()` returns `{}` and product.json ships without
+`agentSdks` — same UX as today's no-config build.
+
+## Why two steps, not inline-in-gulp
+
+The agent SDK work is a distinct concern from the VS Code packaging
+gulp graph. As its own pipeline step:
+
+- Visible in the build log — operators see a discrete "Agent SDK: build
+  + upload" step they can click into instead of grepping inside "Build
+  client" output.
+- Independently re-triggerable — if the SDK step fails, the operator
+  can re-run just the platform job; if it succeeds but the gulp step
+  fails, the SDK upload is already idempotent (HEAD-then-skip).
+- Doesn't add async-stream complexity to the gulpfile. `packageTask`
+  stays a sync stream-returning function; the only change is one
+  synchronous `readAgentSdkResults()` call inside the existing
+  `jsonEditor` callback.
+
+## Files
+
+- `common.ts` — types, `getSdkVersion()` (reads pinned version from
+  repo-root `package.json` devDeps; rejects `^`/`~` ranges),
+  `getSdkTargetForBuild()` (`(vscodePlatform, arch, sdk) → npm-suffix`),
+  `buildCdnUrl()`, `sha256OfFile()`, `parseFlags()` for CLI flag parsing,
+  and `readAgentSdkResults()` for the gulpfile-side reader.
+- `package.ts` — `buildOne({ sdk, sdkTarget, outDir })`. Runs on any
+  OS: `npm install` with `npm_config_libc/os/cpu` fetches the foreign
+  platform binary verbatim, then node-tar+gzip with reproducible flags.
+  Has a thin CLI at bottom.
+- `upload.ts` — `uploadOne(...)`. HEAD-then-decide: absent → upload;
+  matching sha → skip (idempotent re-runs); different / no-metadata sha
+  → fail loud, refusing to overwrite content-addressed history. Thin CLI.
+- `produce.ts` — pipeline-step entry. For one `(vscode-platform, arch)`,
+  iterates the SDKs in parallel, calls `buildOne` + `uploadOne` for each
+  that applies, writes results to `AGENT_SDK_RESULTS_FILE`, and emits
+  `##vso[task.setvariable]` so downstream pipeline steps see the path.
+
+## Bumping an SDK version
+
+1. Edit the corresponding devDep in repo-root `package.json`
+   (`@anthropic-ai/claude-agent-sdk` or `@openai/codex`) to the new exact
+   version.
+2. `npm install` to refresh the lockfile.
+3. Next pipeline run: each platform packaging job builds + uploads its
+   own SDK tarballs at the new content-addressed CDN paths and stamps
+   its `product.json` with the new shas.
+
+No human-paste step into vscode-distro. No coordination between jobs.
+
+## Local dev
+
+Build one tarball locally:
+
+```sh
+node build/agent-sdk/package.ts --sdk=claude --target=darwin-arm64 --out=/tmp/out
+```
+
+For OSS contributors who want to drive the agent host without going
+through the CDN, point the dev override env vars at a local SDK install:
+
+```sh
+VSCODE_AGENT_HOST_CLAUDE_SDK_ROOT=/path/to/anthropic-claude-sdk-install \
+  ./scripts/code.sh
+```
+
+(See `src/vs/platform/agentHost/common/agentService.ts` for env var names.)

--- a/build/agent-sdk/README.md
+++ b/build/agent-sdk/README.md
@@ -87,16 +87,23 @@ gulp graph. As its own pipeline step:
 
 ## Files
 
-- `common.ts` — types, `getSdkVersion()` (reads pinned version from
-  repo-root `package.json` devDeps; rejects `^`/`~` ranges),
-  `getSdkTargetForBuild()` (`(vscodePlatform, arch, sdk) → npm-suffix`),
-  `buildCdnUrl()` / `buildCdnUrlTemplate()`, `sha256OfFile()`,
-  `parseFlags()` for CLI flag parsing, and `readAgentSdkResults()` for
-  the gulpfile-side reader.
+- `agents/<sdk>/` — one folder per SDK we ship. Each contains a
+  `package.json` (single dependency: the SDK's own npm package, pinned
+  to an exact version) and a `package-lock.json` (full transitive
+  graph). Folder name = SDK id = key under `product.agentSdks` = path
+  segment in the CDN URL. The set of folders IS the SDK list — no
+  parallel array to keep in sync.
+- `common.ts` — types, `getSdks()` (discovers SDKs from `agents/`),
+  `getAgentMeta()` / `getSdkVersion()` (reads from `agents/<sdk>/package.json`,
+  rejects `^`/`~` ranges), `getSdkTargetForBuild()` (`(vscodePlatform,
+  arch, sdk) → npm-suffix`), `buildCdnUrl()` / `buildCdnUrlTemplate()`,
+  `sha256OfFile()`, `parseFlags()` for CLI flag parsing, and
+  `readAgentSdkResults()` for the gulpfile-side reader.
 - `package.ts` — `buildOne({ sdk, sdkTarget, outDir })`. Runs on any
-  OS: `npm install` with `npm_config_libc/os/cpu` fetches the foreign
-  platform binary verbatim, then node-tar+gzip with reproducible flags.
-  Has a thin CLI at bottom.
+  OS: copies `agents/<sdk>/{package.json,package-lock.json}` into a
+  scratch dir, `npm ci` with `npm_config_libc/os/cpu` fetches the
+  foreign platform binary verbatim from the locked graph, then
+  node-tar+gzip with reproducible flags. Has a thin CLI at bottom.
 - `upload.ts` — `uploadOne(...)`. HEAD-then-decide: absent → upload;
   matching sha → skip (idempotent re-runs); different / no-metadata sha
   → fail loud, refusing to overwrite content-addressed history. Thin CLI.
@@ -107,14 +114,19 @@ gulp graph. As its own pipeline step:
 
 ## Bumping an SDK version
 
-1. Edit the corresponding devDep in repo-root `package.json`
-   (`@anthropic-ai/claude-agent-sdk` or `@openai/codex`) to the new exact
-   version.
-2. `npm install` to refresh the lockfile.
-3. Next pipeline run: each platform packaging job builds + uploads its
-   own SDK tarballs at the new content-addressed CDN paths and stamps
-   its `product.json` with the new `urlTemplate` pointing at the bumped
-   version.
+1. Edit the `dependencies` version in `build/agent-sdk/agents/<sdk>/package.json`
+   to the new exact version.
+2. From that directory: `npm install --package-lock-only --ignore-scripts`
+   to refresh `package-lock.json`.
+3. Also bump the matching `devDependencies` entry in repo-root
+   `package.json` (the runtime imports types from that copy) so the
+   shipped types and the build-time pin stay in lockstep.
+4. `npm install` at repo root to refresh the root lockfile.
+5. Commit all four edits together.
+
+The next pipeline run rebuilds + uploads each platform tarball at the
+new content-addressed CDN path and re-stamps each `product.json` with
+the new `urlTemplate` pointing at the bumped version.
 
 No human-paste step into vscode-distro. No coordination between jobs.
 

--- a/build/agent-sdk/README.md
+++ b/build/agent-sdk/README.md
@@ -1,12 +1,15 @@
 # build/agent-sdk
 
 Per-platform agent SDK production. Each VS Code build (`darwin-arm64`,
-`linux-x64`, Alpine REH, etc.) bakes its own `agentSdks` entry into the
-shipped `product.json` — one entry per SDK, carrying just the `url` +
-`sha256` for the platform this VS Code build targets.
+`linux-x64`, Alpine REH, etc.) uploads its own platform's SDK tarballs
+to `main.vscode-cdn.net` and stamps `agentSdks` into the shipped
+`product.json` with a `{version, urlTemplate}` per SDK. Every platform
+job emits the same `urlTemplate` per SDK — the runtime substitutes
+`{sdkTarget}` per launch via `resolveSdkTarget()`, which is what lets
+macOS Universal bundles share one `product.json` across arm64 + x64.
 
-The runtime side (`src/vs/platform/agentHost/`) downloads, sha-verifies,
-and caches the SDK tarball at first use. See `IAgentSdkProductConfig` in
+The runtime side (`src/vs/platform/agentHost/`) downloads and caches
+the SDK tarball at first use. See `IAgentSdkProductConfig` in
 `src/vs/base/common/product.ts` for the contract.
 
 ## How the pipeline uses this
@@ -87,8 +90,9 @@ gulp graph. As its own pipeline step:
 - `common.ts` — types, `getSdkVersion()` (reads pinned version from
   repo-root `package.json` devDeps; rejects `^`/`~` ranges),
   `getSdkTargetForBuild()` (`(vscodePlatform, arch, sdk) → npm-suffix`),
-  `buildCdnUrl()`, `sha256OfFile()`, `parseFlags()` for CLI flag parsing,
-  and `readAgentSdkResults()` for the gulpfile-side reader.
+  `buildCdnUrl()` / `buildCdnUrlTemplate()`, `sha256OfFile()`,
+  `parseFlags()` for CLI flag parsing, and `readAgentSdkResults()` for
+  the gulpfile-side reader.
 - `package.ts` — `buildOne({ sdk, sdkTarget, outDir })`. Runs on any
   OS: `npm install` with `npm_config_libc/os/cpu` fetches the foreign
   platform binary verbatim, then node-tar+gzip with reproducible flags.
@@ -109,7 +113,8 @@ gulp graph. As its own pipeline step:
 2. `npm install` to refresh the lockfile.
 3. Next pipeline run: each platform packaging job builds + uploads its
    own SDK tarballs at the new content-addressed CDN paths and stamps
-   its `product.json` with the new shas.
+   its `product.json` with the new `urlTemplate` pointing at the bumped
+   version.
 
 No human-paste step into vscode-distro. No coordination between jobs.
 

--- a/build/agent-sdk/agents/claude/package-lock.json
+++ b/build/agent-sdk/agents/claude/package-lock.json
@@ -1,0 +1,1463 @@
+{
+	"name": "agent-sdk-claude",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "agent-sdk-claude",
+			"dependencies": {
+				"@anthropic-ai/claude-agent-sdk": "0.3.168"
+			}
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk": {
+			"version": "0.3.168",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.168.tgz",
+			"integrity": "sha512-C7n9uS1fsAt9lFKw/ovsFNAlPI7UXE2uPQbOzzKLpDNjfFR5spthALhV49b01PtYWEzTo3W3OJfgCv6wooXtYg==",
+			"license": "SEE LICENSE IN README.md",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.168",
+				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.168",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.168",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.168",
+				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.168",
+				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.168",
+				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.168",
+				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.168"
+			},
+			"peerDependencies": {
+				"@anthropic-ai/sdk": ">=0.93.0",
+				"@modelcontextprotocol/sdk": "^1.29.0",
+				"zod": "^4.0.0"
+			}
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+			"version": "0.3.168",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.168.tgz",
+			"integrity": "sha512-tvFGCGVX9tesGBzfpK008nRmv91pd3ToapDpJbjdwiFSLGWT9n+dc/qurwgxgv9VwWRvV8nWTc3zLRSFI8Lf2g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+			"version": "0.3.168",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.168.tgz",
+			"integrity": "sha512-J5dZUCrwjz4+gY2dAds2rMDWWSdcMl9jEDpZIzKNCx0f0KlJfE1C7/+stOJaBv6tGj8d/mmzcfBCeNBS1KScgA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+			"version": "0.3.168",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.168.tgz",
+			"integrity": "sha512-K9fltcI0VJBr21z4t0iJ4aArFtiS9UwhmMGkxl1jAIM0jatGqiHHbbk+qaCB04va3U6vaflukgtmbpogSB36yQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+			"version": "0.3.168",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.168.tgz",
+			"integrity": "sha512-uOFtBJjntrYkXlHPRK+cTx1pCc37XxGQ/kN3KBK/KoIDcIrmU8DcX2WUw5IJHJqpG2Qjb7gZ5xAbcw3WTmduwQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+			"version": "0.3.168",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.168.tgz",
+			"integrity": "sha512-0Fw4ICZopwKbqNQo64HqkpJw5cqxOxFOV/w8GCS2hDsJ+0aogmK/B78t4iV6rFHIkC076Nm5UH14FP1eOIJ3OA==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+			"version": "0.3.168",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.168.tgz",
+			"integrity": "sha512-JwYD7oxYlIVYDFhgj+QVHgWbJUVGMXsiecB6WQ5VS5u4OqUorivJPFYPaP469otMj4HFtkDupESB+7Zp4jMmUw==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+			"version": "0.3.168",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.168.tgz",
+			"integrity": "sha512-NREaLXAxl23pEzoU7bmX6u8MibAYEY2t8XP5xtj/vMO6UwxFjT3YgGsTuQcnFP+1qsjWaOBCia2ZQnqI68Y0Ng==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+			"version": "0.3.168",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.168.tgz",
+			"integrity": "sha512-Ha3eivz2Wm4y3BR+Xpn/r+CBM8ARC6knYDLbjLqH/DxjKahr6WB60xQkBD1U6wchT6w7zfIQqQGbucuUOTTuew==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.104.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.104.1.tgz",
+			"integrity": "sha512-gGACa/+IaiXzRRmF96aOhamoBgapKRBiFWbmmTFP8aMkpaEcuStF+Q61bjo4vPxBM7gqWJNZqsngslRdnLHv0Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1",
+				"standardwebhooks": "^1.0.0"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@hono/node-server": {
+			"version": "1.19.14",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+			"integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18.14.1"
+			},
+			"peerDependencies": {
+				"hono": "^4"
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk": {
+			"version": "1.29.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+			"integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@hono/node-server": "^1.19.9",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"content-type": "^1.0.5",
+				"cors": "^2.8.5",
+				"cross-spawn": "^7.0.5",
+				"eventsource": "^3.0.2",
+				"eventsource-parser": "^3.0.0",
+				"express": "^5.2.1",
+				"express-rate-limit": "^8.2.1",
+				"hono": "^4.11.4",
+				"jose": "^6.1.3",
+				"json-schema-typed": "^8.0.2",
+				"pkce-challenge": "^5.0.0",
+				"raw-body": "^3.0.0",
+				"zod": "^3.25 || ^4.0",
+				"zod-to-json-schema": "^3.25.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@cfworker/json-schema": "^4.1.1",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@cfworker/json-schema": {
+					"optional": true
+				},
+				"zod": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/@stablelib/base64": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+			"integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/accepts": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"mime-types": "^3.0.0",
+				"negotiator": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/body-parser": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"bytes": "^3.1.2",
+				"content-type": "^1.0.5",
+				"debug": "^4.4.3",
+				"http-errors": "^2.0.0",
+				"iconv-lite": "^0.7.0",
+				"on-finished": "^2.4.1",
+				"qs": "^6.14.1",
+				"raw-body": "^3.0.1",
+				"type-is": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/content-disposition": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie-signature": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6.6.0"
+			}
+		},
+		"node_modules/cors": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/eventsource": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"eventsource-parser": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/eventsource-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+			"integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/express": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"accepts": "^2.0.0",
+				"body-parser": "^2.2.1",
+				"content-disposition": "^1.0.0",
+				"content-type": "^1.0.5",
+				"cookie": "^0.7.1",
+				"cookie-signature": "^1.2.1",
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"finalhandler": "^2.1.0",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.0",
+				"merge-descriptors": "^2.0.0",
+				"mime-types": "^3.0.0",
+				"on-finished": "^2.4.1",
+				"once": "^1.4.0",
+				"parseurl": "^1.3.3",
+				"proxy-addr": "^2.0.7",
+				"qs": "^6.14.0",
+				"range-parser": "^1.2.1",
+				"router": "^2.2.0",
+				"send": "^1.1.0",
+				"serve-static": "^2.2.0",
+				"statuses": "^2.0.1",
+				"type-is": "^2.0.1",
+				"vary": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express-rate-limit": {
+			"version": "8.5.2",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+			"integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ip-address": "^10.2.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/express-rate-limit"
+			},
+			"peerDependencies": {
+				"express": ">= 4.11"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/fast-sha256": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+			"integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+			"license": "Unlicense",
+			"peer": true
+		},
+		"node_modules/fast-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/finalhandler": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.4.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"on-finished": "^2.4.1",
+				"parseurl": "^1.3.3",
+				"statuses": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/hono": {
+			"version": "4.12.25",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+			"integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
+		"node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/ip-address": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/jose": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+			"integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/json-schema-typed": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+			"license": "BSD-2-Clause",
+			"peer": true
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/media-typer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/merge-descriptors": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/negotiator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/on-finished": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-to-regexp": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/pkce-challenge": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+			"integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/qs": {
+			"version": "6.15.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/range-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/raw-body": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.7.0",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/router": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"is-promise": "^4.0.0",
+				"parseurl": "^1.3.3",
+				"path-to-regexp": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/send": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.4.3",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
+				"ms": "^2.1.3",
+				"on-finished": "^2.4.1",
+				"range-parser": "^1.2.1",
+				"statuses": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/serve-static": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"parseurl": "^1.3.3",
+				"send": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+			"integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4",
+				"side-channel-list": "^1.0.1",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/standardwebhooks": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+			"integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@stablelib/base64": "^1.0.0",
+				"fast-sha256": "^1.3.0"
+			}
+		},
+		"node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/type-is": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+			"integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"content-type": "^2.0.0",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/type-is/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"license": "ISC",
+			"peer": true,
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
+		}
+	}
+}

--- a/build/agent-sdk/agents/claude/package-lock.json
+++ b/build/agent-sdk/agents/claude/package-lock.json
@@ -6,26 +6,26 @@
 		"": {
 			"name": "agent-sdk-claude",
 			"dependencies": {
-				"@anthropic-ai/claude-agent-sdk": "0.3.168"
+				"@anthropic-ai/claude-agent-sdk": "0.3.169"
 			}
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk": {
-			"version": "0.3.168",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.168.tgz",
-			"integrity": "sha512-C7n9uS1fsAt9lFKw/ovsFNAlPI7UXE2uPQbOzzKLpDNjfFR5spthALhV49b01PtYWEzTo3W3OJfgCv6wooXtYg==",
+			"version": "0.3.169",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.169.tgz",
+			"integrity": "sha512-pzsd0BBnlfHwAUfKouSNwDLcCxGDq+lbPZTsIdiNSLw+AQw7mjxPxqnFwd4YH7qw+E3XhlotuihCm01XzcybPQ==",
 			"license": "SEE LICENSE IN README.md",
 			"engines": {
 				"node": ">=18.0.0"
 			},
 			"optionalDependencies": {
-				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.168",
-				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.168",
-				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.168",
-				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.168",
-				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.168",
-				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.168",
-				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.168",
-				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.168"
+				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.169",
+				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.169",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.169",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.169",
+				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.169",
+				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.169",
+				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.169",
+				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.169"
 			},
 			"peerDependencies": {
 				"@anthropic-ai/sdk": ">=0.93.0",
@@ -34,9 +34,9 @@
 			}
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-			"version": "0.3.168",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.168.tgz",
-			"integrity": "sha512-tvFGCGVX9tesGBzfpK008nRmv91pd3ToapDpJbjdwiFSLGWT9n+dc/qurwgxgv9VwWRvV8nWTc3zLRSFI8Lf2g==",
+			"version": "0.3.169",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.169.tgz",
+			"integrity": "sha512-5PJU3wqfvJUrgUF3H7iroxAGDyliKmq5q8kK+glERf8YZgmPeDMvQL4mGSB0Vf9RgBWS01dCen93TIsN0O8NPQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -47,9 +47,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-			"version": "0.3.168",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.168.tgz",
-			"integrity": "sha512-J5dZUCrwjz4+gY2dAds2rMDWWSdcMl9jEDpZIzKNCx0f0KlJfE1C7/+stOJaBv6tGj8d/mmzcfBCeNBS1KScgA==",
+			"version": "0.3.169",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.169.tgz",
+			"integrity": "sha512-1Hzt0QYG7N/ExfPbN/C92YRc3BoDnyQMJpuWLVyI/r0NmKV/se/cZbIygbvQXs2ywoXOB/EyNj/hkVHaC1G22g==",
 			"cpu": [
 				"x64"
 			],
@@ -60,9 +60,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-			"version": "0.3.168",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.168.tgz",
-			"integrity": "sha512-K9fltcI0VJBr21z4t0iJ4aArFtiS9UwhmMGkxl1jAIM0jatGqiHHbbk+qaCB04va3U6vaflukgtmbpogSB36yQ==",
+			"version": "0.3.169",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.169.tgz",
+			"integrity": "sha512-J0tyM4t5qxc2/xilsfHqcJv+fyEDhX66Nv+CMXq4mRbquZmMHhbZbh8ryb+BnKYXUeqKX3uoU/J+7K6/fjcY4g==",
 			"cpu": [
 				"arm64"
 			],
@@ -76,9 +76,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-			"version": "0.3.168",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.168.tgz",
-			"integrity": "sha512-uOFtBJjntrYkXlHPRK+cTx1pCc37XxGQ/kN3KBK/KoIDcIrmU8DcX2WUw5IJHJqpG2Qjb7gZ5xAbcw3WTmduwQ==",
+			"version": "0.3.169",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.169.tgz",
+			"integrity": "sha512-xkmyNdU6f7HXXzgR6IZym7x41bjL3rjGrXf5PAmx9PjdThy476+TrpO1evKUza1zlVmUj4tj/jYKQsV4ER7QFw==",
 			"cpu": [
 				"arm64"
 			],
@@ -92,9 +92,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-			"version": "0.3.168",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.168.tgz",
-			"integrity": "sha512-0Fw4ICZopwKbqNQo64HqkpJw5cqxOxFOV/w8GCS2hDsJ+0aogmK/B78t4iV6rFHIkC076Nm5UH14FP1eOIJ3OA==",
+			"version": "0.3.169",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.169.tgz",
+			"integrity": "sha512-ktEPBwzXZagt0cntfRLlvNL0sAplt2HOCbR5iBvq2IV5dLvbEOiBjZQArIcSAN7CTQUFqkZs9HzQMdKe5QPwuQ==",
 			"cpu": [
 				"x64"
 			],
@@ -108,9 +108,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-			"version": "0.3.168",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.168.tgz",
-			"integrity": "sha512-JwYD7oxYlIVYDFhgj+QVHgWbJUVGMXsiecB6WQ5VS5u4OqUorivJPFYPaP469otMj4HFtkDupESB+7Zp4jMmUw==",
+			"version": "0.3.169",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.169.tgz",
+			"integrity": "sha512-Me8VW91pCKgkct/y1isjKNVt+ZPMPhHk3C7O078UO1bakHD6kuPiMtugcCsg4jmmmuuywXQIQUESRbcf0GluUg==",
 			"cpu": [
 				"x64"
 			],
@@ -124,9 +124,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-			"version": "0.3.168",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.168.tgz",
-			"integrity": "sha512-NREaLXAxl23pEzoU7bmX6u8MibAYEY2t8XP5xtj/vMO6UwxFjT3YgGsTuQcnFP+1qsjWaOBCia2ZQnqI68Y0Ng==",
+			"version": "0.3.169",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.169.tgz",
+			"integrity": "sha512-HL9ecP82A/H8aC896Q7ETyl+nLFkMzBHfO0yvK7Lhxbi98CEpqXn3BADTAc5pEgzkO+r18+CDmZdgjTFMvGoTw==",
 			"cpu": [
 				"arm64"
 			],
@@ -137,9 +137,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-			"version": "0.3.168",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.168.tgz",
-			"integrity": "sha512-Ha3eivz2Wm4y3BR+Xpn/r+CBM8ARC6knYDLbjLqH/DxjKahr6WB60xQkBD1U6wchT6w7zfIQqQGbucuUOTTuew==",
+			"version": "0.3.169",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.169.tgz",
+			"integrity": "sha512-34pBbiKe7FNsY8LHuuTmKujmYko/cBOrKJpk9H+MOot+dSfB/FmIHq9USL17otNal5Droq9lqpezAWPBPv3lAQ==",
 			"cpu": [
 				"x64"
 			],

--- a/build/agent-sdk/agents/claude/package.json
+++ b/build/agent-sdk/agents/claude/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "agent-sdk-claude",
+	"private": true,
+	"comment": "Pinned dependency set for the build/agent-sdk claude tarball. The package-lock.json alongside is the source of truth for transitive deps — produce.ts runs `npm ci` against this directory to get byte-deterministic output across pipeline runs.",
+	"dependencies": {
+		"@anthropic-ai/claude-agent-sdk": "0.3.168"
+	}
+}

--- a/build/agent-sdk/agents/claude/package.json
+++ b/build/agent-sdk/agents/claude/package.json
@@ -3,6 +3,6 @@
 	"private": true,
 	"comment": "Pinned dependency set for the build/agent-sdk claude tarball. The package-lock.json alongside is the source of truth for transitive deps — produce.ts runs `npm ci` against this directory to get byte-deterministic output across pipeline runs.",
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.168"
+		"@anthropic-ai/claude-agent-sdk": "0.3.169"
 	}
 }

--- a/build/agent-sdk/agents/codex/package-lock.json
+++ b/build/agent-sdk/agents/codex/package-lock.json
@@ -1,0 +1,135 @@
+{
+	"name": "agent-sdk-codex",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "agent-sdk-codex",
+			"dependencies": {
+				"@openai/codex": "0.134.0"
+			}
+		},
+		"node_modules/@openai/codex": {
+			"version": "0.134.0",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0.tgz",
+			"integrity": "sha512-N0vmdTXl/rglZjgd3PaMe9oRrqjO6zZ//uAvUhCDRnJNAUT3LrpYvCK3y9B/ev7QcChfXR43IGUh3ssqWRvMmA==",
+			"license": "Apache-2.0",
+			"bin": {
+				"codex": "bin/codex.js"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"@openai/codex-darwin-arm64": "npm:@openai/codex@0.134.0-darwin-arm64",
+				"@openai/codex-darwin-x64": "npm:@openai/codex@0.134.0-darwin-x64",
+				"@openai/codex-linux-arm64": "npm:@openai/codex@0.134.0-linux-arm64",
+				"@openai/codex-linux-x64": "npm:@openai/codex@0.134.0-linux-x64",
+				"@openai/codex-win32-arm64": "npm:@openai/codex@0.134.0-win32-arm64",
+				"@openai/codex-win32-x64": "npm:@openai/codex@0.134.0-win32-x64"
+			}
+		},
+		"node_modules/@openai/codex-darwin-arm64": {
+			"name": "@openai/codex",
+			"version": "0.134.0-darwin-arm64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0-darwin-arm64.tgz",
+			"integrity": "sha512-pOxwQjb1HHtY6KG66+g/rX7uP4yBvchfCrQw22ddYy64s7fJqnD6UV/Ur60j6MWXt71jcaWLEkV1pJthQy9CFQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@openai/codex-darwin-x64": {
+			"name": "@openai/codex",
+			"version": "0.134.0-darwin-x64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0-darwin-x64.tgz",
+			"integrity": "sha512-XjRtq8PB9dtpxQ5QU6TrzR/z8EVlLLk55oonsyRp3VkMOsKjJWXvLxAnmzUm1MuVZqz90Ua7CJbr+8BG+ZUWpA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@openai/codex-linux-arm64": {
+			"name": "@openai/codex",
+			"version": "0.134.0-linux-arm64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0-linux-arm64.tgz",
+			"integrity": "sha512-fqI8iClQGvrANFx/dJwZK8KNQlqlQKo7A/UB5G7IaeTAAJ+y/CG2R33Bbd9GboH/8ormY39ureNk27eqt++51g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@openai/codex-linux-x64": {
+			"name": "@openai/codex",
+			"version": "0.134.0-linux-x64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0-linux-x64.tgz",
+			"integrity": "sha512-d/o1AVAniQU2oSEq7ZV0hVwzmk6Dj2IWeNPLnX/KXyv1DfIMJbY+qEg/xhfRmuVW4VPhrhQLBITwrkAYviy1MA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@openai/codex-win32-arm64": {
+			"name": "@openai/codex",
+			"version": "0.134.0-win32-arm64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0-win32-arm64.tgz",
+			"integrity": "sha512-8OdRmbCcyLLMF3Bg6945PW6INZ7bZVygYo2lusnC0Q2KZ3MRYrMnXRJ6mfvkDc8kPpFE+djMFnQ70gt/jBLVCA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@openai/codex-win32-x64": {
+			"name": "@openai/codex",
+			"version": "0.134.0-win32-x64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0-win32-x64.tgz",
+			"integrity": "sha512-hW1omBcN1jKeVUVnTqWlpc42nF2qAwCEN6l1IFeKFJegYoZ39YrE7pdh56gAmaZTyT5Eexx7cgNpaEK3JElxvA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		}
+	}
+}

--- a/build/agent-sdk/agents/codex/package-lock.json
+++ b/build/agent-sdk/agents/codex/package-lock.json
@@ -6,13 +6,13 @@
 		"": {
 			"name": "agent-sdk-codex",
 			"dependencies": {
-				"@openai/codex": "0.134.0"
+				"@openai/codex": "0.135.0"
 			}
 		},
 		"node_modules/@openai/codex": {
-			"version": "0.134.0",
-			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0.tgz",
-			"integrity": "sha512-N0vmdTXl/rglZjgd3PaMe9oRrqjO6zZ//uAvUhCDRnJNAUT3LrpYvCK3y9B/ev7QcChfXR43IGUh3ssqWRvMmA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0.tgz",
+			"integrity": "sha512-ID75QEYmAT1WsUQmpxPlNsL5W1a+2eeD7fP6ywdwGseiXUG8D5i16L+dzbr8MT+2oTkaVqzOdvAqVOCeV/H/Bw==",
 			"license": "Apache-2.0",
 			"bin": {
 				"codex": "bin/codex.js"
@@ -21,19 +21,19 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@openai/codex-darwin-arm64": "npm:@openai/codex@0.134.0-darwin-arm64",
-				"@openai/codex-darwin-x64": "npm:@openai/codex@0.134.0-darwin-x64",
-				"@openai/codex-linux-arm64": "npm:@openai/codex@0.134.0-linux-arm64",
-				"@openai/codex-linux-x64": "npm:@openai/codex@0.134.0-linux-x64",
-				"@openai/codex-win32-arm64": "npm:@openai/codex@0.134.0-win32-arm64",
-				"@openai/codex-win32-x64": "npm:@openai/codex@0.134.0-win32-x64"
+				"@openai/codex-darwin-arm64": "npm:@openai/codex@0.135.0-darwin-arm64",
+				"@openai/codex-darwin-x64": "npm:@openai/codex@0.135.0-darwin-x64",
+				"@openai/codex-linux-arm64": "npm:@openai/codex@0.135.0-linux-arm64",
+				"@openai/codex-linux-x64": "npm:@openai/codex@0.135.0-linux-x64",
+				"@openai/codex-win32-arm64": "npm:@openai/codex@0.135.0-win32-arm64",
+				"@openai/codex-win32-x64": "npm:@openai/codex@0.135.0-win32-x64"
 			}
 		},
 		"node_modules/@openai/codex-darwin-arm64": {
 			"name": "@openai/codex",
-			"version": "0.134.0-darwin-arm64",
-			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0-darwin-arm64.tgz",
-			"integrity": "sha512-pOxwQjb1HHtY6KG66+g/rX7uP4yBvchfCrQw22ddYy64s7fJqnD6UV/Ur60j6MWXt71jcaWLEkV1pJthQy9CFQ==",
+			"version": "0.135.0-darwin-arm64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-darwin-arm64.tgz",
+			"integrity": "sha512-wpNzssusKfrldVlq39+HyQh1wCyc9SQNpHdAFGKtPenrgRte4Ct8/oVsDtKWuFZsqLBFwbL4MrzrevnB63+9HA==",
 			"cpu": [
 				"arm64"
 			],
@@ -48,9 +48,9 @@
 		},
 		"node_modules/@openai/codex-darwin-x64": {
 			"name": "@openai/codex",
-			"version": "0.134.0-darwin-x64",
-			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0-darwin-x64.tgz",
-			"integrity": "sha512-XjRtq8PB9dtpxQ5QU6TrzR/z8EVlLLk55oonsyRp3VkMOsKjJWXvLxAnmzUm1MuVZqz90Ua7CJbr+8BG+ZUWpA==",
+			"version": "0.135.0-darwin-x64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-darwin-x64.tgz",
+			"integrity": "sha512-ZrjAqce23lbv9KfkYOhElf1lTI+SysXmyGM0FV5u4+PBCKPkkEs4eaS3H8Uig0i4bUSu1QylrOOCskzYhZ6VyQ==",
 			"cpu": [
 				"x64"
 			],
@@ -65,9 +65,9 @@
 		},
 		"node_modules/@openai/codex-linux-arm64": {
 			"name": "@openai/codex",
-			"version": "0.134.0-linux-arm64",
-			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0-linux-arm64.tgz",
-			"integrity": "sha512-fqI8iClQGvrANFx/dJwZK8KNQlqlQKo7A/UB5G7IaeTAAJ+y/CG2R33Bbd9GboH/8ormY39ureNk27eqt++51g==",
+			"version": "0.135.0-linux-arm64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-linux-arm64.tgz",
+			"integrity": "sha512-dM+cv5ZL+BgIQzEIvMg9AxZ98n5lkKLgtp5zJLXWSrbCllbnUSqxYMUiWI5c1a1uBDUtkbY9fcGKXFLf+d+gyg==",
 			"cpu": [
 				"arm64"
 			],
@@ -82,9 +82,9 @@
 		},
 		"node_modules/@openai/codex-linux-x64": {
 			"name": "@openai/codex",
-			"version": "0.134.0-linux-x64",
-			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0-linux-x64.tgz",
-			"integrity": "sha512-d/o1AVAniQU2oSEq7ZV0hVwzmk6Dj2IWeNPLnX/KXyv1DfIMJbY+qEg/xhfRmuVW4VPhrhQLBITwrkAYviy1MA==",
+			"version": "0.135.0-linux-x64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-linux-x64.tgz",
+			"integrity": "sha512-5EosY67yU28UJSnl/obdN2F1CDaimYbzm9SLR8dwwzkeBBnY6dHgAKJ2GTu9Nc8CmgmtVFBGzgPqehsIcueVvA==",
 			"cpu": [
 				"x64"
 			],
@@ -99,9 +99,9 @@
 		},
 		"node_modules/@openai/codex-win32-arm64": {
 			"name": "@openai/codex",
-			"version": "0.134.0-win32-arm64",
-			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0-win32-arm64.tgz",
-			"integrity": "sha512-8OdRmbCcyLLMF3Bg6945PW6INZ7bZVygYo2lusnC0Q2KZ3MRYrMnXRJ6mfvkDc8kPpFE+djMFnQ70gt/jBLVCA==",
+			"version": "0.135.0-win32-arm64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-win32-arm64.tgz",
+			"integrity": "sha512-SAeR+CUv7KWwE6eTc2UFaFjo6FpHywYfDFKrK6FqLms1rq1NPju2SoX7rhM6UEew/lUx2mdZv/LDs11s/N/Qgg==",
 			"cpu": [
 				"arm64"
 			],
@@ -116,9 +116,9 @@
 		},
 		"node_modules/@openai/codex-win32-x64": {
 			"name": "@openai/codex",
-			"version": "0.134.0-win32-x64",
-			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0-win32-x64.tgz",
-			"integrity": "sha512-hW1omBcN1jKeVUVnTqWlpc42nF2qAwCEN6l1IFeKFJegYoZ39YrE7pdh56gAmaZTyT5Eexx7cgNpaEK3JElxvA==",
+			"version": "0.135.0-win32-x64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-win32-x64.tgz",
+			"integrity": "sha512-uYwUBMbOfmVlCESJZmZsOG+cYwNFYvkMbQ+FB6C1u9RYz0m3mZeYNN0j+l1hRSyUgPMFJHzNpgNx1Usal5QZFQ==",
 			"cpu": [
 				"x64"
 			],

--- a/build/agent-sdk/agents/codex/package.json
+++ b/build/agent-sdk/agents/codex/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "agent-sdk-codex",
+	"private": true,
+	"comment": "Pinned dependency set for the build/agent-sdk codex tarball. The package-lock.json alongside is the source of truth for transitive deps — produce.ts runs `npm ci` against this directory to get byte-deterministic output across pipeline runs.",
+	"dependencies": {
+		"@openai/codex": "0.134.0"
+	}
+}

--- a/build/agent-sdk/agents/codex/package.json
+++ b/build/agent-sdk/agents/codex/package.json
@@ -3,6 +3,6 @@
 	"private": true,
 	"comment": "Pinned dependency set for the build/agent-sdk codex tarball. The package-lock.json alongside is the source of truth for transitive deps — produce.ts runs `npm ci` against this directory to get byte-deterministic output across pipeline runs.",
 	"dependencies": {
-		"@openai/codex": "0.134.0"
+		"@openai/codex": "0.135.0"
 	}
 }

--- a/build/agent-sdk/common.ts
+++ b/build/agent-sdk/common.ts
@@ -1,0 +1,179 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Shared helpers for the per-platform agent SDK build pipeline (`package.ts`,
+ * `upload.ts`, `drift-check.ts`). Called from those scripts and from the
+ * gulpfiles' `packageTask` so each VS Code build can stamp its own
+ * `product.agentSdks.<sdk>` into the per-platform `product.json` at
+ * packaging time.
+ *
+ * The pipeline DOES NOT keep a parallel list of supported targets. The single
+ * source of truth is the SDK's own `package.json` `optionalDependencies`
+ * (e.g. `@anthropic-ai/claude-agent-sdk-darwin-arm64`), looked up via
+ * `getSdkTargetForBuild()` for a `(vscodePlatform, arch, sdk)` triple.
+ */
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+/** SDKs distributed by `build/agent-sdk/`. */
+export type Sdk = 'claude' | 'codex';
+
+/** All SDKs the pipeline knows about. Used by gulpfile iteration. */
+export const SDKS: readonly Sdk[] = ['claude', 'codex'];
+
+/** The npm registry package each SDK is published under. */
+export const PACKAGE_NAME: { readonly [K in Sdk]: string } = {
+	claude: '@anthropic-ai/claude-agent-sdk',
+	codex: '@openai/codex',
+};
+
+/** Strict subset of VS Code build platforms — the SDK pipeline only knows
+ *  about platforms it can target. `web` is excluded (no SDK on web). */
+export type VscodeBuildPlatform = 'darwin' | 'linux' | 'alpine' | 'win32';
+
+/** Runtime whitelist mirroring `VscodeBuildPlatform`. Used by CLI guards so
+ *  a typo like `--vscode-platform=lnux` fails loud instead of silently
+ *  emitting an empty results file. */
+export const KNOWN_VSCODE_PLATFORMS: ReadonlySet<VscodeBuildPlatform> = new Set([
+	'darwin', 'linux', 'alpine', 'win32',
+]);
+
+/** Strict subset of architectures. `armhf` is excluded — no SDK ships armhf. */
+export type VscodeBuildArch = 'x64' | 'arm64';
+
+/**
+ * Resolves the SDK's npm `optionalDependencies` suffix for a particular VS
+ * Code build. Returns undefined when the VS Code build's `(platform, arch)`
+ * has no compatible SDK (e.g. armhf, web, any combination we don't ship).
+ *
+ * - Claude ships `linux-{x64,arm64}-musl` packages separately from the glibc
+ *   variants. Alpine REH builds get the `-musl` variant; regular Linux gets
+ *   the plain `linux-*`.
+ * - Codex's Linux binaries are statically musl-linked and ship under a
+ *   single `linux-*` SKU that runs on both glibc and musl hosts. Alpine
+ *   REH gets the same `linux-*` package as regular Linux.
+ *
+ * REH uses two encodings for Alpine x64: the modern `{platform: 'alpine',
+ * arch: 'x64'}` and the legacy `{platform: 'linux', arch: 'alpine'}`. Both
+ * are accepted.
+ */
+export function getSdkTargetForBuild(
+	vscodePlatform: string,
+	arch: string,
+	sdk: Sdk,
+): string | undefined {
+	// Normalize the legacy Alpine x64 encoding into the modern one.
+	if (vscodePlatform === 'linux' && arch === 'alpine') {
+		vscodePlatform = 'alpine';
+		arch = 'x64';
+	}
+	if (arch !== 'x64' && arch !== 'arm64') {
+		return undefined;
+	}
+	switch (vscodePlatform) {
+		case 'darwin': return `darwin-${arch}`;
+		case 'win32': return `win32-${arch}`;
+		case 'linux': return `linux-${arch}`;
+		case 'alpine':
+			return sdk === 'claude' ? `linux-${arch}-musl` : `linux-${arch}`;
+		default:
+			return undefined;
+	}
+}
+
+/**
+ * Resolves the pinned SDK version from the repo-root `package.json` devDeps.
+ * Bumping the devDep is the entire "land a new SDK" workflow.
+ *
+ * Both SDKs MUST be pinned to exact versions (no `^` or `~` ranges) in
+ * `package.json`. Ranges would let `npm install` resolve different versions
+ * across runs, breaking the "this build is reproducible given the same
+ * inputs" contract that the CDN's HEAD-then-fail upload depends on.
+ */
+export function getSdkVersion(sdk: Sdk): string {
+	const thisDir = path.dirname(fileURLToPath(import.meta.url));
+	const packageJsonPath = path.resolve(thisDir, '..', '..', 'package.json');
+	const json = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
+		devDependencies?: Record<string, string>;
+	};
+	const version = json.devDependencies?.[PACKAGE_NAME[sdk]];
+	if (!version) {
+		throw new Error(`Cannot resolve ${sdk} SDK version: ${PACKAGE_NAME[sdk]} is not in repo-root package.json devDependencies`);
+	}
+	if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+		throw new Error(`Refusing to use ${PACKAGE_NAME[sdk]}@${version} from package.json: must be an exact version (no ^ or ~ ranges)`);
+	}
+	return version;
+}
+
+/**
+ * Builds the CDN URL the per-platform `product.agentSdks.<sdk>.url` points at.
+ * Content-addressed under `agent-sdk/<sdk>/<version>/<target>.tgz`. Matches
+ * the upload path written by `upload.ts`.
+ */
+export function buildCdnUrl(sdk: Sdk, sdkVersion: string, sdkTarget: string): string {
+	return `https://main.vscode-cdn.net/agent-sdk/${sdk}/${sdkVersion}/${sdkTarget}.tgz`;
+}
+
+/** Streams `filePath` into a sha256 hasher. Avoids reading the whole file
+ *  into memory — agent SDK tarballs are 50-100MB. */
+export function sha256OfFile(filePath: string): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const hash = crypto.createHash('sha256');
+		const stream = fs.createReadStream(filePath);
+		stream.on('error', reject);
+		stream.on('data', chunk => hash.update(chunk));
+		stream.on('end', () => resolve(hash.digest('hex')));
+	});
+}
+
+/** Parses `--key=value` CLI flags into a Map. Shared by the script-mode
+ *  entry points in `package.ts`, `upload.ts`, and `produce.ts`. */
+export function parseFlags(argv: readonly string[]): Map<string, string> {
+	const flags = new Map<string, string>();
+	for (const arg of argv) {
+		const m = /^--([a-zA-Z-]+)=(.+)$/.exec(arg);
+		if (m) {
+			flags.set(m[1], m[2]);
+		}
+	}
+	return flags;
+}
+
+/**
+ * Per-SDK product.json entry, written by `produce.ts` and read by the
+ * gulpfiles' `packageTask`. Shape matches `IAgentSdkProductConfig` in
+ * `src/vs/base/common/product.ts` so the values can be dropped straight
+ * into `product.agentSdks`.
+ */
+export interface IAgentSdkResults {
+	[packageId: string]: {
+		readonly version: string;
+		readonly url: string;
+		readonly sha256: string;
+	};
+}
+
+/**
+ * Reads the per-platform agent-SDK results file written by `produce.ts`.
+ * Returns `{}` when `AGENT_SDK_RESULTS_FILE` is unset or the file doesn't
+ * exist — that's the local-dev path (no agent SDKs produced, ship
+ * product.json without `agentSdks`, providers don't register).
+ */
+export function readAgentSdkResults(): IAgentSdkResults {
+	const filePath = process.env.AGENT_SDK_RESULTS_FILE;
+	if (!filePath || !fs.existsSync(filePath)) {
+		return {};
+	}
+	const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+	if (typeof parsed !== 'object' || parsed === null) {
+		throw new Error(`AGENT_SDK_RESULTS_FILE at ${filePath} is not a JSON object`);
+	}
+	return parsed as IAgentSdkResults;
+}

--- a/build/agent-sdk/common.ts
+++ b/build/agent-sdk/common.ts
@@ -4,16 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 /**
- * Shared helpers for the per-platform agent SDK build pipeline (`package.ts`,
- * `upload.ts`, `drift-check.ts`). Called from those scripts and from the
- * gulpfiles' `packageTask` so each VS Code build can stamp its own
- * `product.agentSdks.<sdk>` into the per-platform `product.json` at
- * packaging time.
+ * Shared helpers for the per-platform agent SDK build pipeline. Called
+ * from `package.ts`, `upload.ts`, and `produce.ts`, plus the gulpfiles'
+ * `packageTask` (via `readAgentSdkResults`) so each VS Code build can
+ * stamp its own `product.agentSdks.<sdk>` into the per-platform
+ * `product.json` at packaging time.
  *
- * The pipeline DOES NOT keep a parallel list of supported targets. The single
- * source of truth is the SDK's own `package.json` `optionalDependencies`
- * (e.g. `@anthropic-ai/claude-agent-sdk-darwin-arm64`), looked up via
- * `getSdkTargetForBuild()` for a `(vscodePlatform, arch, sdk)` triple.
+ * The pipeline DOES NOT keep a parallel list of supported targets.
+ * `getSdkTargetForBuild()` hard-codes the `(vscodePlatform, arch, sdk) →
+ * sdkTarget` table; the SDK's own `package.json` `optionalDependencies`
+ * (e.g. `@anthropic-ai/claude-agent-sdk-darwin-arm64`) is the
+ * canonical SKU set, and the table is kept in lockstep with it by
+ * convention — there is no runtime lookup of npm metadata.
  */
 
 import * as crypto from 'crypto';

--- a/build/agent-sdk/common.ts
+++ b/build/agent-sdk/common.ts
@@ -121,6 +121,18 @@ export function buildCdnUrl(sdk: Sdk, sdkVersion: string, sdkTarget: string): st
 	return `https://main.vscode-cdn.net/agent-sdk/${sdk}/${sdkVersion}/${sdkTarget}.tgz`;
 }
 
+/**
+ * Builds the `format2`-style URL template stamped into
+ * `product.agentSdks.<sdk>.urlTemplate`. The runtime substitutes
+ * `{sdkTarget}` per launch via `resolveSdkTarget` in
+ * `src/vs/platform/agentHost/node/agentSdkDownloader.ts`. Matches the
+ * upload path written by `upload.ts` with `{sdkTarget}` in place of the
+ * concrete target suffix.
+ */
+export function buildCdnUrlTemplate(sdk: Sdk, sdkVersion: string): string {
+	return `https://main.vscode-cdn.net/agent-sdk/${sdk}/${sdkVersion}/{sdkTarget}.tgz`;
+}
+
 /** Streams `filePath` into a sha256 hasher. Avoids reading the whole file
  *  into memory — agent SDK tarballs are 50-100MB. */
 export function sha256OfFile(filePath: string): Promise<string> {
@@ -151,12 +163,16 @@ export function parseFlags(argv: readonly string[]): Map<string, string> {
  * gulpfiles' `packageTask`. Shape matches `IAgentSdkProductConfig` in
  * `src/vs/base/common/product.ts` so the values can be dropped straight
  * into `product.agentSdks`.
+ *
+ * Every platform job emits the SAME `{version, urlTemplate}` per SDK —
+ * the `{sdkTarget}` placeholder is resolved at runtime per launch (see
+ * `resolveSdkTarget` in `agentSdkDownloader.ts`). This is what lets a
+ * macOS Universal bundle share one `product.json` across arm64+x64.
  */
 export interface IAgentSdkResults {
 	[packageId: string]: {
 		readonly version: string;
-		readonly url: string;
-		readonly sha256: string;
+		readonly urlTemplate: string;
 	};
 }
 

--- a/build/agent-sdk/common.ts
+++ b/build/agent-sdk/common.ts
@@ -10,12 +10,19 @@
  * stamp its own `product.agentSdks.<sdk>` into the per-platform
  * `product.json` at packaging time.
  *
- * The pipeline DOES NOT keep a parallel list of supported targets.
- * `getSdkTargetForBuild()` hard-codes the `(vscodePlatform, arch, sdk) →
- * sdkTarget` table; the SDK's own `package.json` `optionalDependencies`
- * (e.g. `@anthropic-ai/claude-agent-sdk-darwin-arm64`) is the
- * canonical SKU set, and the table is kept in lockstep with it by
- * convention — there is no runtime lookup of npm metadata.
+ * Source of truth for the SDK list and version pins:
+ *   `build/agent-sdk/agents/<sdk>/{package.json,package-lock.json}`.
+ * Each subdirectory under `agents/` is one SDK. The folder name is the
+ * SDK id (the key under `product.agentSdks`); the `package.json` names
+ * exactly one npm dependency (the SDK's own package) and its exact
+ * version; the `package-lock.json` pins the full transitive graph for
+ * byte-deterministic `npm ci`. Add an SDK by adding a folder, run
+ * `npm install` inside it once to generate the lockfile, commit both.
+ *
+ * `getSdkTargetForBuild()` hard-codes the
+ * `(vscodePlatform, arch, sdk) → sdkTarget` table; the SDK's own npm
+ * `optionalDependencies` are the canonical SKU set, and the table is
+ * kept in lockstep with it by convention.
  */
 
 import * as crypto from 'crypto';
@@ -23,17 +30,90 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
-/** SDKs distributed by `build/agent-sdk/`. */
-export type Sdk = 'claude' | 'codex';
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
 
-/** All SDKs the pipeline knows about. Used by gulpfile iteration. */
-export const SDKS: readonly Sdk[] = ['claude', 'codex'];
+/** Root of the per-SDK `{package.json, package-lock.json}` directories. */
+export const AGENTS_DIR = path.join(THIS_DIR, 'agents');
 
-/** The npm registry package each SDK is published under. */
-export const PACKAGE_NAME: { readonly [K in Sdk]: string } = {
-	claude: '@anthropic-ai/claude-agent-sdk',
-	codex: '@openai/codex',
-};
+/**
+ * SDK identifier — the folder name under `agents/`, also the key under
+ * `product.agentSdks` and the path segment in the CDN URL. Open string
+ * type rather than a closed union so adding a new SDK is one folder, no
+ * compile-time list change required.
+ */
+export type Sdk = string;
+
+let _sdksCache: readonly Sdk[] | undefined;
+
+/**
+ * All SDKs the pipeline knows about, in stable sort order. Discovered
+ * at load time by listing `agents/`. Cached because the set never
+ * changes mid-process.
+ */
+export function getSdks(): readonly Sdk[] {
+	if (_sdksCache) {
+		return _sdksCache;
+	}
+	const entries = fs.readdirSync(AGENTS_DIR, { withFileTypes: true });
+	_sdksCache = entries
+		.filter(e => e.isDirectory())
+		.map(e => e.name)
+		.sort();
+	return _sdksCache;
+}
+
+/** Path to a given SDK's agents/ subdirectory (the one with package.json). */
+export function getAgentDir(sdk: Sdk): string {
+	const dir = path.join(AGENTS_DIR, sdk);
+	if (!fs.existsSync(dir)) {
+		throw new Error(`Unknown SDK '${sdk}': no directory at ${dir}. Add a folder under build/agent-sdk/agents/ with a package.json + package-lock.json.`);
+	}
+	return dir;
+}
+
+interface IAgentPackageJson {
+	readonly dependencies?: Readonly<Record<string, string>>;
+}
+
+let _agentMetaCache: Map<Sdk, { name: string; version: string }> | undefined;
+
+/**
+ * Returns the npm package name and pinned version this SDK ships. Read
+ * from `agents/<sdk>/package.json`'s single dependency.
+ *
+ * The agent's `package.json` MUST declare exactly one dependency (the SDK's
+ * own npm package) at an exact version — no `^` / `~` ranges. Ranges
+ * would let `npm install` resolve different versions across runs, which
+ * the CDN's HEAD-then-fail upload rejects.
+ */
+export function getAgentMeta(sdk: Sdk): { name: string; version: string } {
+	if (!_agentMetaCache) {
+		_agentMetaCache = new Map();
+	}
+	const cached = _agentMetaCache.get(sdk);
+	if (cached) {
+		return cached;
+	}
+	const pkgPath = path.join(getAgentDir(sdk), 'package.json');
+	const json = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as IAgentPackageJson;
+	const deps = json.dependencies ?? {};
+	const entries = Object.entries(deps);
+	if (entries.length !== 1) {
+		throw new Error(`Expected exactly one dependency in ${pkgPath}, found ${entries.length}: ${entries.map(([k]) => k).join(', ')}`);
+	}
+	const [name, version] = entries[0];
+	if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+		throw new Error(`Refusing to use ${name}@${version} from ${pkgPath}: must be an exact version (no ^ or ~ ranges)`);
+	}
+	const meta = { name, version };
+	_agentMetaCache.set(sdk, meta);
+	return meta;
+}
+
+/** Convenience shortcut for `getAgentMeta(sdk).version`. */
+export function getSdkVersion(sdk: Sdk): string {
+	return getAgentMeta(sdk).version;
+}
 
 /** Strict subset of VS Code build platforms — the SDK pipeline only knows
  *  about platforms it can target. `web` is excluded (no SDK on web). */
@@ -87,31 +167,6 @@ export function getSdkTargetForBuild(
 		default:
 			return undefined;
 	}
-}
-
-/**
- * Resolves the pinned SDK version from the repo-root `package.json` devDeps.
- * Bumping the devDep is the entire "land a new SDK" workflow.
- *
- * Both SDKs MUST be pinned to exact versions (no `^` or `~` ranges) in
- * `package.json`. Ranges would let `npm install` resolve different versions
- * across runs, breaking the "this build is reproducible given the same
- * inputs" contract that the CDN's HEAD-then-fail upload depends on.
- */
-export function getSdkVersion(sdk: Sdk): string {
-	const thisDir = path.dirname(fileURLToPath(import.meta.url));
-	const packageJsonPath = path.resolve(thisDir, '..', '..', 'package.json');
-	const json = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
-		devDependencies?: Record<string, string>;
-	};
-	const version = json.devDependencies?.[PACKAGE_NAME[sdk]];
-	if (!version) {
-		throw new Error(`Cannot resolve ${sdk} SDK version: ${PACKAGE_NAME[sdk]} is not in repo-root package.json devDependencies`);
-	}
-	if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
-		throw new Error(`Refusing to use ${PACKAGE_NAME[sdk]}@${version} from package.json: must be an exact version (no ^ or ~ ranges)`);
-	}
-	return version;
 }
 
 /**

--- a/build/agent-sdk/package.ts
+++ b/build/agent-sdk/package.ts
@@ -160,13 +160,17 @@ function npmInstall(workDir: string, env: NodeJS.ProcessEnv): void {
 	// `--no-package-lock` skips writing a lockfile we'd just throw away.
 	// `--ignore-scripts` blocks any postinstall/preinstall the SDK or its
 	// transitive deps might ship.
-	// On Windows, npm is a `.cmd` shim; Node's child_process won't resolve
-	// PATHEXT without an explicit suffix.
-	const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+	// On Windows, npm is a `.cmd` shim. Two things matter:
+	//   1. The explicit `.cmd` suffix — Node won't resolve PATHEXT.
+	//   2. `shell: true` — since Node 20 (CVE-2024-27980) child_process
+	//      refuses to spawn .cmd/.bat without it.
+	const isWindows = process.platform === 'win32';
+	const npm = isWindows ? 'npm.cmd' : 'npm';
 	const result = spawnSync(npm, ['install', '--no-package-lock', '--ignore-scripts'], {
 		cwd: workDir,
 		env: { ...process.env, ...env },
 		stdio: 'inherit',
+		shell: isWindows,
 	});
 	if (result.error) {
 		throw new Error(`[${SCRIPT}] npm install failed to spawn: ${result.error.message}`);

--- a/build/agent-sdk/package.ts
+++ b/build/agent-sdk/package.ts
@@ -160,11 +160,17 @@ function npmInstall(workDir: string, env: NodeJS.ProcessEnv): void {
 	// `--no-package-lock` skips writing a lockfile we'd just throw away.
 	// `--ignore-scripts` blocks any postinstall/preinstall the SDK or its
 	// transitive deps might ship.
-	const result = spawnSync('npm', ['install', '--no-package-lock', '--ignore-scripts'], {
+	// On Windows, npm is a `.cmd` shim; Node's child_process won't resolve
+	// PATHEXT without an explicit suffix.
+	const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+	const result = spawnSync(npm, ['install', '--no-package-lock', '--ignore-scripts'], {
 		cwd: workDir,
 		env: { ...process.env, ...env },
 		stdio: 'inherit',
 	});
+	if (result.error) {
+		throw new Error(`[${SCRIPT}] npm install failed to spawn: ${result.error.message}`);
+	}
 	if (result.status !== 0) {
 		throw new Error(`[${SCRIPT}] npm install exited ${result.status}`);
 	}

--- a/build/agent-sdk/package.ts
+++ b/build/agent-sdk/package.ts
@@ -1,0 +1,222 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Builds one per-target tarball for one agent SDK. Callable as both a Node
+ * library function (`buildOne(...)`) and a thin CLI (the bottom of this file).
+ *
+ * The library form is what the gulpfile-side packaging tasks use; the CLI
+ * form is for local one-off builds during development.
+ *
+ * Runs on any OS — `npm install` with `npm_config_libc/os/cpu` set fetches
+ * the foreign platform's pre-built binary package as-is from the registry,
+ * no compilation involved. The tarball is then `tar`'d on whatever host is
+ * doing the packaging. Each `(sdk, target)` pair has exactly one producer
+ * per pipeline run (no cross-host race), so we don't need byte-identical
+ * tarballs across OSes — only across re-runs on the same host, which the
+ * same npm install + same tar version produces naturally.
+ *
+ * SDK version pinning:
+ *   - Pinned via repo-root `package.json` devDeps (`getSdkVersion`).
+ *   - No `node_modules` package-lock for the scratch install: transitive
+ *     drift surfaces at upload time as a sha mismatch against the existing
+ *     blob, where a human investigates.
+ *
+ * Uses node-tar (pure JS) for tar creation rather than system tar so that
+ * tarballs produced on a Windows or macOS host have the same shape as ones
+ * produced on Linux — same library, same flags, same output bytes given
+ * the same input tree.
+ */
+
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as tar from 'tar';
+import { getSdkVersion, PACKAGE_NAME, parseFlags, type Sdk, sha256OfFile } from './common.ts';
+
+const SCRIPT = 'package.ts';
+
+export interface IBuildResult {
+	readonly tgzPath: string;
+	readonly sha256: string;
+	readonly sdkVersion: string;
+	readonly sizeBytes: number;
+}
+
+export interface IBuildArgs {
+	readonly sdk: Sdk;
+	readonly sdkTarget: string;
+	readonly outDir: string;
+}
+
+/**
+ * Build one tarball. Resolves the version from `package.json` devDeps,
+ * `npm install`s the SDK + the matching foreign platform package into a
+ * scratch dir, chmods+normalises+tars the result. Returns the produced
+ * `.tgz` path and its sha256.
+ */
+export async function buildOne(args: IBuildArgs): Promise<IBuildResult> {
+	const packageName = PACKAGE_NAME[args.sdk];
+	const sdkVersion = getSdkVersion(args.sdk);
+
+	const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-sdk-pkg-'));
+	try {
+		fs.writeFileSync(path.join(stagingDir, 'package.json'), JSON.stringify({
+			name: `agent-sdk-build-${args.sdk}-${args.sdkTarget}`,
+			private: true,
+			dependencies: { [packageName]: sdkVersion },
+		}, null, 2));
+
+		console.log(`[${SCRIPT}] Building ${args.sdk}@${sdkVersion} for ${args.sdkTarget} in ${stagingDir}`);
+
+		const { os: targetOs, cpu, libc } = parseTargetTriple(args.sdkTarget);
+		const npmEnv: NodeJS.ProcessEnv = { npm_config_os: targetOs, npm_config_cpu: cpu };
+		if (libc) {
+			npmEnv.npm_config_libc = libc;
+		}
+		npmInstall(stagingDir, npmEnv);
+
+		const nodeModulesDir = path.join(stagingDir, 'node_modules');
+		chmodPlatformBinaries(nodeModulesDir, args.sdk);
+
+		fs.mkdirSync(args.outDir, { recursive: true });
+		const tgzPath = path.join(args.outDir, `${args.sdk}-${sdkVersion}-${args.sdkTarget}.tgz`);
+		await buildTarball(stagingDir, tgzPath);
+
+		const sha256 = await sha256OfFile(tgzPath);
+		const sizeBytes = fs.statSync(tgzPath).size;
+
+		console.log(`[${SCRIPT}] Wrote ${tgzPath} (${sizeBytes} bytes, sha256=${sha256})`);
+		return { tgzPath, sha256, sdkVersion, sizeBytes };
+	} finally {
+		fs.rmSync(stagingDir, { recursive: true, force: true });
+	}
+}
+
+function parseTargetTriple(sdkTarget: string): { os: string; cpu: string; libc?: string } {
+	// `darwin-arm64`, `linux-x64`, `linux-x64-musl`, `win32-x64`, …
+	const match = /^([a-z0-9]+)-([a-z0-9]+)(?:-([a-z0-9]+))?$/.exec(sdkTarget);
+	if (!match) {
+		throw new Error(`[${SCRIPT}] Cannot parse target '${sdkTarget}'`);
+	}
+	const [, osStr, cpu, libc] = match;
+	return { os: osStr, cpu, libc };
+}
+
+
+/**
+ * Chmod the executable binaries inside a per-SDK extracted node_modules tree.
+ * Layout differs per SDK; we don't pretend it's configurable:
+ *   - claude: a single top-level `claude` binary per platform package
+ *   - codex:  `vendor/<rust-triple>/bin/codex` under the platform package
+ */
+function chmodPlatformBinaries(nodeModulesDir: string, sdk: Sdk): void {
+	if (sdk === 'claude') {
+		const scopeDir = path.join(nodeModulesDir, '@anthropic-ai');
+		if (!fs.existsSync(scopeDir)) {
+			return;
+		}
+		for (const child of fs.readdirSync(scopeDir)) {
+			if (!child.startsWith('claude-agent-sdk-')) {
+				continue;
+			}
+			const binary = path.join(scopeDir, child, 'claude');
+			if (fs.existsSync(binary)) {
+				fs.chmodSync(binary, 0o755);
+			}
+		}
+		return;
+	}
+
+	// codex
+	const scopeDir = path.join(nodeModulesDir, '@openai');
+	if (!fs.existsSync(scopeDir)) {
+		return;
+	}
+	for (const child of fs.readdirSync(scopeDir)) {
+		if (!child.startsWith('codex-')) {
+			continue;
+		}
+		const vendorDir = path.join(scopeDir, child, 'vendor');
+		if (!fs.existsSync(vendorDir)) {
+			continue;
+		}
+		for (const triple of fs.readdirSync(vendorDir)) {
+			const binDir = path.join(vendorDir, triple, 'bin');
+			if (!fs.existsSync(binDir)) {
+				continue;
+			}
+			for (const f of fs.readdirSync(binDir)) {
+				fs.chmodSync(path.join(binDir, f), 0o755);
+			}
+		}
+	}
+}
+
+function npmInstall(workDir: string, env: NodeJS.ProcessEnv): void {
+	// `--no-package-lock` skips writing a lockfile we'd just throw away.
+	// `--ignore-scripts` blocks any postinstall/preinstall the SDK or its
+	// transitive deps might ship.
+	const result = spawnSync('npm', ['install', '--no-package-lock', '--ignore-scripts'], {
+		cwd: workDir,
+		env: { ...process.env, ...env },
+		stdio: 'inherit',
+	});
+	if (result.status !== 0) {
+		throw new Error(`[${SCRIPT}] npm install exited ${result.status}`);
+	}
+}
+
+/**
+ * Builds the gzipped tar via node-tar. Same library on every host, so the
+ * output is consistent regardless of whether GNU/BSD/Windows tar is what
+ * the host normally ships.
+ */
+async function buildTarball(stagingDir: string, outTgz: string): Promise<void> {
+	await tar.c(
+		{
+			file: outTgz,
+			cwd: stagingDir,
+			gzip: { level: 9 },
+			portable: true, // omit user/group names and similar host-specific metadata
+			mtime: new Date(0),
+		},
+		['node_modules'],
+	);
+}
+
+// #region CLI entry point
+//
+// Lets a developer run `node build/agent-sdk/package.ts --sdk=claude
+// --target=darwin-arm64 --out=/tmp/out` to produce one tarball locally.
+// The gulpfile-side packaging uses `buildOne()` directly.
+
+function isCliInvocation(): boolean {
+	return import.meta.url === `file://${process.argv[1]}`;
+}
+
+function parseCliArgs(): IBuildArgs {
+	const flags = parseFlags(process.argv.slice(2));
+	const sdk = flags.get('sdk');
+	if (sdk !== 'claude' && sdk !== 'codex') {
+		throw new Error(`--sdk must be 'claude' or 'codex'; got '${sdk}'`);
+	}
+	const sdkTarget = flags.get('target');
+	if (!sdkTarget) {
+		throw new Error('--target=<sdkTarget> is required');
+	}
+	const outDir = flags.get('out') ?? path.resolve(process.cwd(), 'out');
+	return { sdk, sdkTarget, outDir };
+}
+
+if (isCliInvocation()) {
+	buildOne(parseCliArgs()).catch(err => {
+		console.error(err);
+		process.exit(1);
+	});
+}
+
+// #endregion

--- a/build/agent-sdk/package.ts
+++ b/build/agent-sdk/package.ts
@@ -7,8 +7,9 @@
  * Builds one per-target tarball for one agent SDK. Callable as both a Node
  * library function (`buildOne(...)`) and a thin CLI (the bottom of this file).
  *
- * The library form is what the gulpfile-side packaging tasks use; the CLI
- * form is for local one-off builds during development.
+ * The library form is what `produce.ts` calls during the per-platform
+ * "Agent SDK: build + upload" pipeline step; the CLI form is for local
+ * one-off builds during development.
  *
  * Runs on any OS — `npm install` with `npm_config_libc/os/cpu` set fetches
  * the foreign platform's pre-built binary package as-is from the registry,
@@ -205,7 +206,11 @@ async function buildTarball(stagingDir: string, outTgz: string): Promise<void> {
 // The gulpfile-side packaging uses `buildOne()` directly.
 
 function isCliInvocation(): boolean {
-	return import.meta.url === `file://${process.argv[1]}`;
+	// `import.meta.filename` is already a real filesystem path; comparing
+	// it directly to `process.argv[1]` works on Windows (where the
+	// manual `file://${argv}` construction breaks because Node URL-encodes
+	// drive letters and spaces). Pattern matches `build/npm/installStateHash.ts:143`.
+	return import.meta.filename === process.argv[1];
 }
 
 function parseCliArgs(): IBuildArgs {

--- a/build/agent-sdk/package.ts
+++ b/build/agent-sdk/package.ts
@@ -36,7 +36,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as tar from 'tar';
-import { getSdkVersion, PACKAGE_NAME, parseFlags, type Sdk, sha256OfFile } from './common.ts';
+import { getAgentDir, getAgentMeta, parseFlags, type Sdk, sha256OfFile } from './common.ts';
 
 const SCRIPT = 'package.ts';
 
@@ -54,31 +54,35 @@ export interface IBuildArgs {
 }
 
 /**
- * Build one tarball. Resolves the version from `package.json` devDeps,
- * `npm install`s the SDK + the matching foreign platform package into a
- * scratch dir, chmods+normalises+tars the result. Returns the produced
- * `.tgz` path and its sha256.
+ * Build one tarball. Copies the SDK's pinned `agents/<sdk>/{package.json,
+ * package-lock.json}` into a scratch dir, runs `npm ci` against the
+ * lockfile (byte-deterministic dep graph), chmods+normalises+tars the
+ * result. Returns the produced `.tgz` path and its sha256.
+ *
+ * Determinism comes from the lockfile + node-tar's portable mode. Two
+ * runs against the same lockfile on different hosts should produce the
+ * same bytes — that's what the CDN's HEAD-then-fail upload depends on.
  */
 export async function buildOne(args: IBuildArgs): Promise<IBuildResult> {
-	const packageName = PACKAGE_NAME[args.sdk];
-	const sdkVersion = getSdkVersion(args.sdk);
+	const { name: packageName, version: sdkVersion } = getAgentMeta(args.sdk);
+	const agentDir = getAgentDir(args.sdk);
 
 	const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-sdk-pkg-'));
 	try {
-		fs.writeFileSync(path.join(stagingDir, 'package.json'), JSON.stringify({
-			name: `agent-sdk-build-${args.sdk}-${args.sdkTarget}`,
-			private: true,
-			dependencies: { [packageName]: sdkVersion },
-		}, null, 2));
+		// Copy the pinned package.json + package-lock.json into the scratch
+		// dir. `npm ci` errors out if a node_modules is already present, so
+		// the scratch dir starts clean.
+		fs.copyFileSync(path.join(agentDir, 'package.json'), path.join(stagingDir, 'package.json'));
+		fs.copyFileSync(path.join(agentDir, 'package-lock.json'), path.join(stagingDir, 'package-lock.json'));
 
-		console.log(`[${SCRIPT}] Building ${args.sdk}@${sdkVersion} for ${args.sdkTarget} in ${stagingDir}`);
+		console.log(`[${SCRIPT}] Building ${packageName}@${sdkVersion} for ${args.sdkTarget} in ${stagingDir}`);
 
 		const { os: targetOs, cpu, libc } = parseTargetTriple(args.sdkTarget);
 		const npmEnv: NodeJS.ProcessEnv = { npm_config_os: targetOs, npm_config_cpu: cpu };
 		if (libc) {
 			npmEnv.npm_config_libc = libc;
 		}
-		npmInstall(stagingDir, npmEnv);
+		npmCi(stagingDir, npmEnv);
 
 		const nodeModulesDir = path.join(stagingDir, 'node_modules');
 		chmodPlatformBinaries(nodeModulesDir, args.sdk);
@@ -157,8 +161,10 @@ function chmodPlatformBinaries(nodeModulesDir: string, sdk: Sdk): void {
 	}
 }
 
-function npmInstall(workDir: string, env: NodeJS.ProcessEnv): void {
-	// `--no-package-lock` skips writing a lockfile we'd just throw away.
+function npmCi(workDir: string, env: NodeJS.ProcessEnv): void {
+	// `npm ci` instead of `npm install`: installs the EXACT graph from the
+	// committed package-lock.json without resolving versions, which is what
+	// makes the tarball bytes reproducible across pipeline runs.
 	// `--ignore-scripts` blocks any postinstall/preinstall the SDK or its
 	// transitive deps might ship.
 	// On Windows, npm is a `.cmd` shim. Two things matter:
@@ -167,17 +173,17 @@ function npmInstall(workDir: string, env: NodeJS.ProcessEnv): void {
 	//      refuses to spawn .cmd/.bat without it.
 	const isWindows = process.platform === 'win32';
 	const npm = isWindows ? 'npm.cmd' : 'npm';
-	const result = spawnSync(npm, ['install', '--no-package-lock', '--ignore-scripts'], {
+	const result = spawnSync(npm, ['ci', '--ignore-scripts'], {
 		cwd: workDir,
 		env: { ...process.env, ...env },
 		stdio: 'inherit',
 		shell: isWindows,
 	});
 	if (result.error) {
-		throw new Error(`[${SCRIPT}] npm install failed to spawn: ${result.error.message}`);
+		throw new Error(`[${SCRIPT}] npm ci failed to spawn: ${result.error.message}`);
 	}
 	if (result.status !== 0) {
-		throw new Error(`[${SCRIPT}] npm install exited ${result.status}`);
+		throw new Error(`[${SCRIPT}] npm ci exited ${result.status}`);
 	}
 }
 

--- a/build/agent-sdk/produce.ts
+++ b/build/agent-sdk/produce.ts
@@ -1,0 +1,156 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Per-(vscode-platform, arch) agent-SDK producer. Builds the tarballs needed
+ * by ONE VS Code build, optionally uploads them to the CDN, and writes a
+ * small JSON results file that the gulpfile-side `packageTask` reads to
+ * stamp `product.json`'s `agentSdks` field.
+ *
+ * Run as a pipeline step BEFORE the gulp packaging step on the same agent
+ * (via `build/azure-pipelines/common/agent-sdk-produce.yml`).
+ *
+ * Behavior split by VSCODE_PUBLISH:
+ *
+ *   - VSCODE_PUBLISH=true (real release builds): build → upload (HEAD-then-
+ *     decide idempotent) → write results JSON → emit task.setvariable so
+ *     the gulp step stamps product.agentSdks.
+ *
+ *   - VSCODE_PUBLISH unset / not 'true' (PR / CI / test runs): build only.
+ *     Tarballs stay on disk at `.build/agent-sdk/tarballs/` so the pipeline
+ *     can publish them as artifacts for inspection, but no CDN upload
+ *     happens and no results file is written — so product.json ships
+ *     without `agentSdks` and the runtime stays on the dev-override path,
+ *     same as a local `npm run gulp` invocation.
+ *
+ * Each (sdk, sdkTarget) pair has exactly one producer per pipeline run —
+ * `darwin-arm64` is only built by the macOS arm64 job, `linux-x64-musl`
+ * only by the Alpine x64 job, etc. So there's no cross-host race over
+ * the same blob, and the HEAD-then-fail in `upload.ts` is purely a
+ * defense against re-runs with drifted bytes (toolchain change, etc.).
+ *
+ * For VS Code builds where no SDK applies (e.g. armhf), exits with an
+ * empty result set. product.json ships without `agentSdks` regardless of
+ * VSCODE_PUBLISH.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+	getSdkTargetForBuild,
+	type IAgentSdkResults,
+	KNOWN_VSCODE_PLATFORMS,
+	parseFlags,
+	type Sdk,
+	SDKS,
+	type VscodeBuildPlatform,
+} from './common.ts';
+import { type IBuildResult, buildOne } from './package.ts';
+import { uploadOne } from './upload.ts';
+
+const SCRIPT = 'produce.ts';
+
+interface ICliArgs {
+	readonly vscodePlatform: VscodeBuildPlatform;
+	readonly arch: string;
+	readonly resultsFile: string;
+	readonly tarballsDir: string;
+	readonly upload: boolean;
+}
+
+function parseCliArgs(): ICliArgs {
+	const flags = parseFlags(process.argv.slice(2));
+	const vscodePlatform = flags.get('vscode-platform');
+	if (!vscodePlatform || !KNOWN_VSCODE_PLATFORMS.has(vscodePlatform as VscodeBuildPlatform)) {
+		const known = [...KNOWN_VSCODE_PLATFORMS].join('|');
+		throw new Error(`--vscode-platform=<${known}> is required (got '${vscodePlatform ?? ''}')`);
+	}
+	const arch = flags.get('arch');
+	if (!arch) {
+		throw new Error('--arch=<x64|arm64|armhf|...> is required');
+	}
+	// Upload only on real publish builds. VSCODE_PUBLISH is a pipeline
+	// variable set to 'True' on publish runs and 'False' otherwise; Azure
+	// Pipelines auto-injects it into every script step's env.
+	const upload = (process.env.VSCODE_PUBLISH ?? '').toLowerCase() === 'true';
+	// Stable, well-known paths so the pipeline can pick the tarballs up as
+	// an artifact and the gulp step can find the results JSON via env.
+	const tarballsDir = path.resolve(process.cwd(), '.build/agent-sdk/tarballs');
+	const resultsFile = process.env.AGENT_SDK_RESULTS_FILE
+		?? path.resolve(process.cwd(), `.build/agent-sdk/${vscodePlatform}-${arch}.json`);
+	return { vscodePlatform: vscodePlatform as VscodeBuildPlatform, arch, resultsFile, tarballsDir, upload };
+}
+
+async function main(): Promise<void> {
+	const args = parseCliArgs();
+	console.log(`[${SCRIPT}] VSCODE_PUBLISH=${process.env.VSCODE_PUBLISH ?? '<unset>'} → upload=${args.upload}`);
+
+	fs.mkdirSync(args.tarballsDir, { recursive: true });
+
+	const results: IAgentSdkResults = {};
+	const produced = await Promise.all(
+		SDKS.map(sdk => produceOne(sdk, args.vscodePlatform, args.arch, args.tarballsDir, args.upload)),
+	);
+	for (let i = 0; i < SDKS.length; i++) {
+		const entry = produced[i];
+		if (entry) {
+			results[SDKS[i]] = entry;
+		}
+	}
+
+	// Signal the pipeline that there's something in `tarballsDir` worth
+	// publishing as an artifact. (Skipped if no SDK applied to this build,
+	// e.g. armhf where every `produceOne` returns undefined.)
+	const tarballCount = fs.readdirSync(args.tarballsDir).filter(f => f.endsWith('.tgz')).length;
+	if (tarballCount > 0) {
+		console.log(`##vso[task.setvariable variable=AGENT_SDK_TARBALLS_PRODUCED]true`);
+	}
+
+	if (!args.upload) {
+		console.log(`[${SCRIPT}] upload=false — ${tarballCount} tarball(s) left in ${args.tarballsDir}; skipping results file and AGENT_SDK_RESULTS_FILE setvariable.`);
+		return;
+	}
+
+	fs.mkdirSync(path.dirname(args.resultsFile), { recursive: true });
+	fs.writeFileSync(args.resultsFile, JSON.stringify(results, null, 2) + '\n');
+	const sdkCount = Object.keys(results).length;
+	console.log(`[${SCRIPT}] Wrote ${sdkCount} SDK entr${sdkCount === 1 ? 'y' : 'ies'} to ${args.resultsFile}`);
+
+	// Tell Azure Pipelines: subsequent steps in this job see
+	// AGENT_SDK_RESULTS_FILE in their env (auto-injected from the variable).
+	console.log(`##vso[task.setvariable variable=AGENT_SDK_RESULTS_FILE]${args.resultsFile}`);
+}
+
+async function produceOne(
+	sdk: Sdk,
+	vscodePlatform: VscodeBuildPlatform,
+	arch: string,
+	tarballsDir: string,
+	upload: boolean,
+): Promise<IAgentSdkResults[string] | undefined> {
+	const sdkTarget = getSdkTargetForBuild(vscodePlatform, arch, sdk);
+	if (!sdkTarget) {
+		console.log(`[${SCRIPT}] ${sdk}: no target for ${vscodePlatform}/${arch} — skipping`);
+		return undefined;
+	}
+	console.log(`[${SCRIPT}] ${sdk}: producing for ${vscodePlatform}/${arch} → ${sdkTarget}`);
+	const built: IBuildResult = await buildOne({ sdk, sdkTarget, outDir: tarballsDir });
+	if (!upload) {
+		return undefined;
+	}
+	const { url } = await uploadOne({
+		sdk,
+		sdkVersion: built.sdkVersion,
+		sdkTarget,
+		tgzPath: built.tgzPath,
+		sha256: built.sha256,
+	});
+	return { version: built.sdkVersion, url, sha256: built.sha256 };
+}
+
+main().catch(err => {
+	console.error(err);
+	process.exit(1);
+});

--- a/build/agent-sdk/produce.ts
+++ b/build/agent-sdk/produce.ts
@@ -39,6 +39,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import {
+	buildCdnUrlTemplate,
 	getSdkTargetForBuild,
 	type IAgentSdkResults,
 	KNOWN_VSCODE_PLATFORMS,
@@ -140,14 +141,18 @@ async function produceOne(
 	if (!upload) {
 		return undefined;
 	}
-	const { url } = await uploadOne({
+	// Upload returns the per-target URL; we discard it and emit the
+	// `{sdkTarget}` template instead. Every platform job ends up with
+	// the same `urlTemplate` per SDK — only the version differs across
+	// SDK bumps. The runtime substitutes `{sdkTarget}` per launch.
+	await uploadOne({
 		sdk,
 		sdkVersion: built.sdkVersion,
 		sdkTarget,
 		tgzPath: built.tgzPath,
 		sha256: built.sha256,
 	});
-	return { version: built.sdkVersion, url, sha256: built.sha256 };
+	return { version: built.sdkVersion, urlTemplate: buildCdnUrlTemplate(sdk, built.sdkVersion) };
 }
 
 main().catch(err => {

--- a/build/agent-sdk/produce.ts
+++ b/build/agent-sdk/produce.ts
@@ -40,12 +40,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 import {
 	buildCdnUrlTemplate,
+	getSdks,
 	getSdkTargetForBuild,
 	type IAgentSdkResults,
 	KNOWN_VSCODE_PLATFORMS,
 	parseFlags,
 	type Sdk,
-	SDKS,
 	type VscodeBuildPlatform,
 } from './common.ts';
 import { type IBuildResult, buildOne } from './package.ts';
@@ -91,13 +91,14 @@ async function main(): Promise<void> {
 	fs.mkdirSync(args.tarballsDir, { recursive: true });
 
 	const results: IAgentSdkResults = {};
+	const sdks = getSdks();
 	const produced = await Promise.all(
-		SDKS.map(sdk => produceOne(sdk, args.vscodePlatform, args.arch, args.tarballsDir, args.upload)),
+		sdks.map(sdk => produceOne(sdk, args.vscodePlatform, args.arch, args.tarballsDir, args.upload)),
 	);
-	for (let i = 0; i < SDKS.length; i++) {
+	for (let i = 0; i < sdks.length; i++) {
 		const entry = produced[i];
 		if (entry) {
-			results[SDKS[i]] = entry;
+			results[sdks[i]] = entry;
 		}
 	}
 

--- a/build/agent-sdk/upload.ts
+++ b/build/agent-sdk/upload.ts
@@ -1,0 +1,136 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Uploads one agent-SDK tarball to the `main.vscode-cdn.net` storage account.
+ * Callable as both a library function (`uploadOne(...)`) and a thin CLI.
+ *
+ * Auth: reads `AZURE_STORAGE_ACCOUNT`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`,
+ * `AZURE_ID_TOKEN` from env — same shape as `build/azure-pipelines/upload-cdn.ts`.
+ *
+ * Idempotency: HEAD-first on the `.tgz` blob.
+ *   - Absent → upload.
+ *   - Present with matching sha256 (in `metadata.sha256`) → skip.
+ *   - Present with different / no sha256 metadata → fail loud, refusing to
+ *     overwrite content-addressed history. Recovery: delete the blob in the
+ *     Azure Portal and re-run.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { ClientAssertionCredential } from '@azure/identity';
+import { BlobServiceClient } from '@azure/storage-blob';
+import { buildCdnUrl, PACKAGE_NAME, parseFlags, type Sdk, sha256OfFile } from './common.ts';
+
+const SCRIPT = 'upload.ts';
+
+export interface IUploadArgs {
+	readonly sdk: Sdk;
+	readonly sdkVersion: string;
+	readonly sdkTarget: string;
+	readonly tgzPath: string;
+	/** Pre-computed sha (e.g. from `buildOne()`); if omitted, computed here. */
+	readonly sha256?: string;
+}
+
+export interface IUploadResult {
+	readonly url: string;
+	readonly sha256: string;
+}
+
+export async function uploadOne(args: IUploadArgs): Promise<IUploadResult> {
+	if (!fs.existsSync(args.tgzPath)) {
+		throw new Error(`[${SCRIPT}] Tarball does not exist: ${args.tgzPath}`);
+	}
+	const sha256 = args.sha256 ?? await sha256OfFile(args.tgzPath);
+
+	const account = requireEnv('AZURE_STORAGE_ACCOUNT');
+	const tenantId = requireEnv('AZURE_TENANT_ID');
+	const clientId = requireEnv('AZURE_CLIENT_ID');
+	const idToken = requireEnv('AZURE_ID_TOKEN');
+
+	const credential = new ClientAssertionCredential(tenantId, clientId, () => Promise.resolve(idToken));
+	const service = new BlobServiceClient(`https://${account}.blob.core.windows.net`, credential);
+	const container = service.getContainerClient('$web');
+	const blobName = `agent-sdk/${args.sdk}/${args.sdkVersion}/${args.sdkTarget}.tgz`;
+	const blob = container.getBlockBlobClient(blobName);
+
+	console.log(`[${SCRIPT}] target: https://${account}.blob.core.windows.net/$web/${blobName}`);
+	console.log(`[${SCRIPT}] local sha256: ${sha256}`);
+
+	let existing;
+	try {
+		existing = await blob.getProperties();
+	} catch (err) {
+		const status = (err as { statusCode?: number }).statusCode;
+		if (status !== 404) {
+			throw err;
+		}
+		existing = undefined;
+	}
+
+	if (existing) {
+		const remoteSha = existing.metadata?.sha256;
+		if (remoteSha === sha256) {
+			console.log(`[${SCRIPT}] blob already present with matching sha256 — skipping upload (idempotent).`);
+			return { url: buildCdnUrl(args.sdk, args.sdkVersion, args.sdkTarget), sha256 };
+		}
+		throw new Error(
+			`[${SCRIPT}] Blob already present with ${remoteSha ? 'DIFFERENT' : 'NO'} sha256 metadata — refusing to overwrite content-addressed history.\n` +
+			`  remote: ${remoteSha ?? '<no metadata.sha256 — was this blob uploaded out-of-band?>'}\n` +
+			`  local:  ${sha256}\n` +
+			`If the local build is what should ship, delete the remote blob in Azure Portal and re-run. ` +
+			`Otherwise: investigate why the same ${PACKAGE_NAME[args.sdk]}@${args.sdkVersion} produced different bytes.`,
+		);
+	}
+
+	console.log(`[${SCRIPT}] uploading ${fs.statSync(args.tgzPath).size} bytes…`);
+	await blob.uploadFile(args.tgzPath, {
+		blobHTTPHeaders: {
+			blobContentType: 'application/gzip',
+			blobCacheControl: 'max-age=31536000, immutable',
+		},
+		metadata: { sha256 },
+	});
+	console.log(`[${SCRIPT}] ✓ uploaded.`);
+	return { url: buildCdnUrl(args.sdk, args.sdkVersion, args.sdkTarget), sha256 };
+}
+
+function requireEnv(name: string): string {
+	const value = process.env[name];
+	if (!value) {
+		throw new Error(`[${SCRIPT}] Missing required environment variable: ${name}`);
+	}
+	return value;
+}
+
+// #region CLI entry point
+
+function isCliInvocation(): boolean {
+	return import.meta.url === `file://${process.argv[1]}`;
+}
+
+function parseCliArgs(): IUploadArgs {
+	const flags = parseFlags(process.argv.slice(2));
+	const tgzPath = flags.get('tarball');
+	if (!tgzPath) { throw new Error('--tarball=<path> is required'); }
+	// Filename convention from package.ts: `<sdk>-<sdkVersion>-<sdkTarget>.tgz`.
+	const basename = path.basename(tgzPath);
+	const match = /^(claude|codex)-(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)-((?:darwin|linux|win32)-(?:x64|arm64)(?:-musl)?)\.tgz$/.exec(basename);
+	if (!match) {
+		throw new Error(`Cannot derive (sdk, version, target) from tarball filename '${basename}'`);
+	}
+	const [, sdk, sdkVersion, sdkTarget] = match;
+	return { sdk: sdk as Sdk, sdkVersion, sdkTarget, tgzPath: path.resolve(tgzPath) };
+}
+
+if (isCliInvocation()) {
+	uploadOne(parseCliArgs()).catch(err => {
+		console.error(err);
+		process.exit(1);
+	});
+}
+
+// #endregion

--- a/build/agent-sdk/upload.ts
+++ b/build/agent-sdk/upload.ts
@@ -22,7 +22,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { ClientAssertionCredential } from '@azure/identity';
 import { BlobServiceClient } from '@azure/storage-blob';
-import { buildCdnUrl, PACKAGE_NAME, parseFlags, type Sdk, sha256OfFile } from './common.ts';
+import { buildCdnUrl, getAgentMeta, parseFlags, type Sdk, sha256OfFile } from './common.ts';
 
 const SCRIPT = 'upload.ts';
 
@@ -82,7 +82,7 @@ export async function uploadOne(args: IUploadArgs): Promise<IUploadResult> {
 			`  remote: ${remoteSha ?? '<no metadata.sha256 — was this blob uploaded out-of-band?>'}\n` +
 			`  local:  ${sha256}\n` +
 			`If the local build is what should ship, delete the remote blob in Azure Portal and re-run. ` +
-			`Otherwise: investigate why the same ${PACKAGE_NAME[args.sdk]}@${args.sdkVersion} produced different bytes.`,
+			`Otherwise: investigate why the same ${getAgentMeta(args.sdk).name}@${args.sdkVersion} produced different bytes.`,
 		);
 	}
 

--- a/build/agent-sdk/upload.ts
+++ b/build/agent-sdk/upload.ts
@@ -109,7 +109,11 @@ function requireEnv(name: string): string {
 // #region CLI entry point
 
 function isCliInvocation(): boolean {
-	return import.meta.url === `file://${process.argv[1]}`;
+	// `import.meta.filename` is already a real filesystem path; comparing
+	// it directly to `process.argv[1]` works on Windows (where the
+	// manual `file://${argv}` construction breaks because Node URL-encodes
+	// drive letters and spaces). Pattern matches `build/npm/installStateHash.ts:143`.
+	return import.meta.filename === process.argv[1];
 }
 
 function parseCliArgs(): IUploadArgs {

--- a/build/azure-pipelines/alpine/product-build-alpine.yml
+++ b/build/azure-pipelines/alpine/product-build-alpine.yml
@@ -48,6 +48,12 @@ jobs:
             sbomBuildDropPath: $(WEB_DIR_PATH)
             sbomPackageName: "VS Code Alpine $(VSCODE_ARCH) Web"
             sbomPackageVersion: $(Build.SourceVersion)
+        - output: pipelineArtifact
+          targetPath: $(Build.SourcesDirectory)/.build/agent-sdk/tarballs
+          artifactName: agent_sdk_alpine_$(VSCODE_ARCH)_tarballs
+          displayName: Publish agent SDK tarballs
+          sbomEnabled: false
+          condition: and(succeededOrFailed(), eq(variables['AGENT_SDK_TARBALLS_PRODUCED'], 'true'))
     steps:
       - template: ../common/checkout.yml@self
 
@@ -189,6 +195,10 @@ jobs:
         env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         displayName: Download Copilot VSIX
+
+      - template: ../common/agent-sdk-produce.yml@self
+        parameters:
+          vscodePlatform: alpine
 
       - script: |
           set -e

--- a/build/azure-pipelines/alpine/product-build-alpine.yml
+++ b/build/azure-pipelines/alpine/product-build-alpine.yml
@@ -181,6 +181,10 @@ jobs:
 
       - template: ../common/install-builtin-extensions.yml@self
 
+      - template: ../common/agent-sdk-produce.yml@self
+        parameters:
+          vscodePlatform: alpine
+
       - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadCopilotVsix.ts
         env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -195,10 +199,6 @@ jobs:
         env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         displayName: Download Copilot VSIX
-
-      - template: ../common/agent-sdk-produce.yml@self
-        parameters:
-          vscodePlatform: alpine
 
       - script: |
           set -e

--- a/build/azure-pipelines/common/agent-sdk-produce.yml
+++ b/build/azure-pipelines/common/agent-sdk-produce.yml
@@ -1,0 +1,64 @@
+parameters:
+  - name: vscodePlatform
+    type: string
+    values:
+      - darwin
+      - linux
+      - alpine
+      - win32
+
+# Builds the agent SDK tarballs for ONE VS Code build, and (on real
+# publish runs) uploads them to the CDN, emits
+# `##vso[task.setvariable variable=AGENT_SDK_RESULTS_FILE]<path>`, and
+# leaves the downstream gulp packaging step to stamp product.agentSdks.
+#
+# Upload is gated on VSCODE_PUBLISH=true (the same pipeline variable
+# used by sourcemap uploads and similar release-only side effects).
+# Non-publish runs (PRs, CI, local pipeline tests) still produce the
+# tarballs into `$(Build.SourcesDirectory)/.build/agent-sdk/tarballs/`
+# so the calling job can publish them as a pipelineArtifact for
+# inspection, but they skip the CDN write and the agentSdks stamp.
+#
+# Three steps:
+#   1. AzureCLI@2 to fetch the SPN credentials for the CDN storage
+#      account — skipped on non-publish runs (no CDN write to auth for).
+#   2. Run `node build/agent-sdk/produce.ts`. Always builds; uploads
+#      only on publish; emits task.setvariable only on publish.
+steps:
+  - task: AzureCLI@2
+    displayName: "Agent SDK: fetch CDN credentials"
+    condition: and(succeeded(), eq(lower(variables['VSCODE_PUBLISH']), 'true'))
+    inputs:
+      azureSubscription: vscode
+      scriptType: pscore
+      scriptLocation: inlineScript
+      addSpnToEnvironment: true
+      inlineScript: |
+        Write-Host "##vso[task.setvariable variable=AZURE_TENANT_ID]$env:tenantId"
+        Write-Host "##vso[task.setvariable variable=AZURE_CLIENT_ID]$env:servicePrincipalId"
+        Write-Host "##vso[task.setvariable variable=AZURE_ID_TOKEN;issecret=true]$env:idToken"
+
+  - ${{ if eq(parameters.vscodePlatform, 'win32') }}:
+    - powershell: |
+        . build/azure-pipelines/win32/exec.ps1
+        $ErrorActionPreference = "Stop"
+        exec { node build/agent-sdk/produce.ts --vscode-platform=${{ parameters.vscodePlatform }} --arch=$(VSCODE_ARCH) }
+      env:
+        AGENT_SDK_RESULTS_FILE: $(Build.SourcesDirectory)/.build/agent-sdk/${{ parameters.vscodePlatform }}-$(VSCODE_ARCH).json
+        AZURE_STORAGE_ACCOUNT: vscodeweb
+        AZURE_TENANT_ID: $(AZURE_TENANT_ID)
+        AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
+        AZURE_ID_TOKEN: $(AZURE_ID_TOKEN)
+      displayName: "Agent SDK: build + upload"
+
+  - ${{ if ne(parameters.vscodePlatform, 'win32') }}:
+    - script: |
+        set -e
+        node build/agent-sdk/produce.ts --vscode-platform=${{ parameters.vscodePlatform }} --arch=$(VSCODE_ARCH)
+      env:
+        AGENT_SDK_RESULTS_FILE: $(Build.SourcesDirectory)/.build/agent-sdk/${{ parameters.vscodePlatform }}-$(VSCODE_ARCH).json
+        AZURE_STORAGE_ACCOUNT: vscodeweb
+        AZURE_TENANT_ID: $(AZURE_TENANT_ID)
+        AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
+        AZURE_ID_TOKEN: $(AZURE_ID_TOKEN)
+      displayName: "Agent SDK: build + upload"

--- a/build/azure-pipelines/common/agent-sdk-produce.yml
+++ b/build/azure-pipelines/common/agent-sdk-produce.yml
@@ -19,12 +19,40 @@ parameters:
 # so the calling job can publish them as a pipelineArtifact for
 # inspection, but they skip the CDN write and the agentSdks stamp.
 #
-# Three steps:
-#   1. AzureCLI@2 to fetch the SPN credentials for the CDN storage
+# Steps:
+#   1. Setup NPM auth for AGENT_SDK_NPMRC_PATH so the `npm ci` inside
+#      produce.ts can talk to the private vscode-build npm mirror. We
+#      have to do this ourselves because the platform job's existing
+#      "Setup NPM Authentication" step is gated on the node_modules
+#      cache being a miss — on a cache hit, the npmrc has no auth and
+#      our `npm ci` fails with E401 against the mirror. Always-on.
+#   2. AzureCLI@2 to fetch the SPN credentials for the CDN storage
 #      account — skipped on non-publish runs (no CDN write to auth for).
-#   2. Run `node build/agent-sdk/produce.ts`. Always builds; uploads
+#   3. Run `node build/agent-sdk/produce.ts`. Always builds; uploads
 #      only on publish; emits task.setvariable only on publish.
 steps:
+  - ${{ if eq(parameters.vscodePlatform, 'win32') }}:
+    - powershell: |
+        . build/azure-pipelines/win32/exec.ps1
+        $ErrorActionPreference = "Stop"
+        $NpmrcPath = (npm config get userconfig)
+        echo "##vso[task.setvariable variable=AGENT_SDK_NPMRC_PATH]$NpmrcPath"
+      condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
+      displayName: "Agent SDK: capture npmrc path"
+
+  - ${{ if ne(parameters.vscodePlatform, 'win32') }}:
+    - script: |
+        set -e
+        echo "##vso[task.setvariable variable=AGENT_SDK_NPMRC_PATH]$(npm config get userconfig)"
+      condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
+      displayName: "Agent SDK: capture npmrc path"
+
+  - task: npmAuthenticate@0
+    inputs:
+      workingFile: $(AGENT_SDK_NPMRC_PATH)
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
+    displayName: "Agent SDK: authenticate npm"
+
   - task: AzureCLI@2
     displayName: "Agent SDK: fetch CDN credentials"
     condition: and(succeeded(), eq(lower(variables['VSCODE_PUBLISH']), 'true'))

--- a/build/azure-pipelines/common/agent-sdk-produce.yml
+++ b/build/azure-pipelines/common/agent-sdk-produce.yml
@@ -35,17 +35,27 @@ steps:
     - powershell: |
         . build/azure-pipelines/win32/exec.ps1
         $ErrorActionPreference = "Stop"
+        # `npm config set` creates ~/.npmrc if missing — needed on
+        # cache-hit runs where the platform job's "Setup NPM" was
+        # skipped and the file doesn't exist yet. Idempotent on
+        # cache-miss runs (just rewrites the same registry line).
+        exec { npm config set registry "$env:NPM_REGISTRY" }
         $NpmrcPath = (npm config get userconfig)
         echo "##vso[task.setvariable variable=AGENT_SDK_NPMRC_PATH]$NpmrcPath"
       condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-      displayName: "Agent SDK: capture npmrc path"
+      displayName: "Agent SDK: prepare npmrc"
 
   - ${{ if ne(parameters.vscodePlatform, 'win32') }}:
     - script: |
         set -e
+        # `npm config set` creates ~/.npmrc if missing — needed on
+        # cache-hit runs where the platform job's "Setup NPM" was
+        # skipped and the file doesn't exist yet. Idempotent on
+        # cache-miss runs (just rewrites the same registry line).
+        npm config set registry "$NPM_REGISTRY"
         echo "##vso[task.setvariable variable=AGENT_SDK_NPMRC_PATH]$(npm config get userconfig)"
       condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
-      displayName: "Agent SDK: capture npmrc path"
+      displayName: "Agent SDK: prepare npmrc"
 
   - task: npmAuthenticate@0
     inputs:

--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -76,6 +76,12 @@ jobs:
           sbomBuildDropPath: $(Build.ArtifactStagingDirectory)/VSCode-darwin-$(VSCODE_ARCH)
           sbomPackageName: "VS Code macOS $(VSCODE_ARCH)"
           sbomPackageVersion: $(Build.SourceVersion)
+        - output: pipelineArtifact
+          targetPath: $(Build.SourcesDirectory)/.build/agent-sdk/tarballs
+          artifactName: agent_sdk_darwin_$(VSCODE_ARCH)_tarballs
+          displayName: Publish agent SDK tarballs
+          sbomEnabled: false
+          condition: and(succeededOrFailed(), eq(variables['AGENT_SDK_TARBALLS_PRODUCED'], 'true'))
     steps:
       - template: ./steps/product-build-darwin-compile.yml@self
         parameters:

--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -145,6 +145,10 @@ steps:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     displayName: Download Copilot VSIX
 
+  - template: ../../common/agent-sdk-produce.yml@self
+    parameters:
+      vscodePlatform: darwin
+
   - script: |
       set -e
       npm run gulp vscode-darwin-$(VSCODE_ARCH)-min-ci

--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -114,6 +114,10 @@ steps:
 
   - template: ../../common/install-builtin-extensions.yml@self
 
+  - template: ../../common/agent-sdk-produce.yml@self
+    parameters:
+      vscodePlatform: darwin
+
   - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadCopilotVsix.ts
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -144,10 +148,6 @@ steps:
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     displayName: Download Copilot VSIX
-
-  - template: ../../common/agent-sdk-produce.yml@self
-    parameters:
-      vscodePlatform: darwin
 
   - script: |
       set -e

--- a/build/azure-pipelines/linux/product-build-linux.yml
+++ b/build/azure-pipelines/linux/product-build-linux.yml
@@ -108,6 +108,12 @@ jobs:
             sbomBuildDropPath: $(SNAP_EXTRACTED_PATH)
             sbomPackageName: "VS Code Linux $(VSCODE_ARCH) SNAP"
             sbomPackageVersion: $(Build.SourceVersion)
+        - output: pipelineArtifact
+          targetPath: $(Build.SourcesDirectory)/.build/agent-sdk/tarballs
+          artifactName: agent_sdk_linux_$(VSCODE_ARCH)_tarballs
+          displayName: Publish agent SDK tarballs
+          sbomEnabled: false
+          condition: and(succeededOrFailed(), eq(variables['AGENT_SDK_TARBALLS_PRODUCED'], 'true'))
     steps:
       - template: ./steps/product-build-linux-compile.yml@self
         parameters:

--- a/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
@@ -204,6 +204,11 @@ steps:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     displayName: Download Copilot VSIX
 
+  - ${{ if ne(parameters.VSCODE_ARCH, 'armhf') }}:
+    - template: ../../common/agent-sdk-produce.yml@self
+      parameters:
+        vscodePlatform: linux
+
   - script: |
       set -e
       npm run gulp vscode-linux-$(VSCODE_ARCH)-min-ci

--- a/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
@@ -172,6 +172,11 @@ steps:
 
   - template: ../../common/install-builtin-extensions.yml@self
 
+  - ${{ if ne(parameters.VSCODE_ARCH, 'armhf') }}:
+    - template: ../../common/agent-sdk-produce.yml@self
+      parameters:
+        vscodePlatform: linux
+
   - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadCopilotVsix.ts
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -203,11 +208,6 @@ steps:
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     displayName: Download Copilot VSIX
-
-  - ${{ if ne(parameters.VSCODE_ARCH, 'armhf') }}:
-    - template: ../../common/agent-sdk-produce.yml@self
-      parameters:
-        vscodePlatform: linux
 
   - script: |
       set -e

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -82,6 +82,12 @@ jobs:
           sbomBuildDropPath: $(Agent.BuildDirectory)/vscode-server-win32-$(VSCODE_ARCH)-web
           sbomPackageName: "VS Code Windows $(VSCODE_ARCH) Web"
           sbomPackageVersion: $(Build.SourceVersion)
+        - output: pipelineArtifact
+          targetPath: $(Build.SourcesDirectory)/.build/agent-sdk/tarballs
+          artifactName: agent_sdk_win32_$(VSCODE_ARCH)_tarballs
+          displayName: Publish agent SDK tarballs
+          sbomEnabled: false
+          condition: and(succeededOrFailed(), eq(variables['AGENT_SDK_TARBALLS_PRODUCED'], 'true'))
       sdl:
         suppression:
           suppressionFile: $(Build.SourcesDirectory)\.config\guardian\.gdnsuppress

--- a/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
+++ b/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
@@ -151,6 +151,10 @@ steps:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     displayName: Download Copilot VSIX
 
+  - template: ../../common/agent-sdk-produce.yml@self
+    parameters:
+      vscodePlatform: win32
+
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"

--- a/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
+++ b/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
@@ -113,6 +113,10 @@ steps:
 
   - template: ../../common/install-builtin-extensions.yml@self
 
+  - template: ../../common/agent-sdk-produce.yml@self
+    parameters:
+      vscodePlatform: win32
+
   - pwsh: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadCopilotVsix.ts
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -150,10 +154,6 @@ steps:
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     displayName: Download Copilot VSIX
-
-  - template: ../../common/agent-sdk-produce.yml@self
-    parameters:
-      vscodePlatform: win32
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1

--- a/build/gulpfile.reh.ts
+++ b/build/gulpfile.reh.ts
@@ -30,6 +30,7 @@ import log from 'fancy-log';
 import buildfile from './buildfile.ts';
 import { fetchUrls, fetchGithub } from './lib/fetch.ts';
 import { getCopilotExcludeFilter, getCopilotRuntimePrebuildFiles, getCopilotTgrepExcludeFilter, getRipgrepExcludeFilter, prepareBuiltInCopilotRipgrepShim } from './lib/copilot.ts';
+import { readAgentSdkResults } from './agent-sdk/common.ts';
 
 
 const rcedit = promisify(rceditCallback);
@@ -362,7 +363,22 @@ function packageTask(type: string, platform: string, arch: string, sourceFolderN
 
 		let productJsonContents = '';
 		const productJsonStream = gulp.src(['product.json'], { base: '.' })
-			.pipe(jsonEditor({ commit, date: readISODate(sourceFolderName), version }))
+			.pipe(jsonEditor((json: Record<string, unknown>) => {
+				json.commit = commit;
+				json.date = readISODate(sourceFolderName);
+				json.version = version;
+				// Stamp agentSdks from the per-platform results file produced
+				// by `build/agent-sdk/produce.ts`. REH-only: REH-web is
+				// browser-served and the agent host is node-only, so the
+				// SDK config has no consumer there.
+				if (type === 'reh') {
+					const agentSdks = readAgentSdkResults();
+					if (Object.keys(agentSdks).length > 0) {
+						json.agentSdks = agentSdks;
+					}
+				}
+				return json;
+			}))
 			.pipe(es.through(function (file) {
 				productJsonContents = file.contents.toString();
 				this.emit('data', file);

--- a/build/gulpfile.vscode.ts
+++ b/build/gulpfile.vscode.ts
@@ -29,6 +29,7 @@ import { compileBuildWithoutManglingTask, compileBuildWithManglingTask } from '.
 import { compileNonNativeExtensionsBuildTask, compileNativeExtensionsBuildTask, compileAllExtensionsBuildTask, compileExtensionMediaBuildTask, cleanExtensionsBuildTask, compileCopilotExtensionBuildTask } from './gulpfile.extensions.ts';
 import { copyCodiconsTask } from './lib/compilation.ts';
 import { getCopilotExcludeFilter, getCopilotRuntimePrebuildFiles, getCopilotTgrepExcludeFilter, getRipgrepExcludeFilter, prepareBuiltInCopilotRipgrepShim } from './lib/copilot.ts';
+import { readAgentSdkResults } from './agent-sdk/common.ts';
 import { useEsbuildTranspile } from './buildConfig.ts';
 import { promisify } from 'util';
 import globCallback from 'glob';
@@ -304,6 +305,13 @@ function packageTask(platform: string, arch: string, sourceFolderName: string, d
 				json.date = readISODate(out);
 				json.checksums = checksums;
 				json.version = version;
+				// Stamp agentSdks from the per-platform results file produced
+				// by `build/agent-sdk/produce.ts` (an earlier pipeline step).
+				// Local dev: file absent → empty → not stamped.
+				const agentSdks = readAgentSdkResults();
+				if (Object.keys(agentSdks).length > 0) {
+					json.agentSdks = agentSdks;
+				}
 				return json;
 			}))
 			.pipe(es.through(function (file) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
       },
       "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.168",
-        "@openai/codex": "^0.134.0",
+        "@openai/codex": "0.134.0",
         "@playwright/cli": "^0.1.9",
         "@playwright/test": "^1.56.1",
         "@stylistic/eslint-plugin-ts": "^2.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,8 +76,8 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.168",
-        "@openai/codex": "0.134.0",
+        "@anthropic-ai/claude-agent-sdk": "0.3.169",
+        "@openai/codex": "0.135.0",
         "@playwright/cli": "^0.1.9",
         "@playwright/test": "^1.56.1",
         "@stylistic/eslint-plugin-ts": "^2.8.0",
@@ -184,23 +184,23 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.168",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.168.tgz",
-      "integrity": "sha512-C7n9uS1fsAt9lFKw/ovsFNAlPI7UXE2uPQbOzzKLpDNjfFR5spthALhV49b01PtYWEzTo3W3OJfgCv6wooXtYg==",
+      "version": "0.3.169",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.169.tgz",
+      "integrity": "sha512-pzsd0BBnlfHwAUfKouSNwDLcCxGDq+lbPZTsIdiNSLw+AQw7mjxPxqnFwd4YH7qw+E3XhlotuihCm01XzcybPQ==",
       "dev": true,
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.168",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.168",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.168",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.168",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.168",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.168",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.168",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.168"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.169",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.169",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.169",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.169",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.169",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.169",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.169",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.169"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -209,9 +209,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.168",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.168.tgz",
-      "integrity": "sha512-tvFGCGVX9tesGBzfpK008nRmv91pd3ToapDpJbjdwiFSLGWT9n+dc/qurwgxgv9VwWRvV8nWTc3zLRSFI8Lf2g==",
+      "version": "0.3.169",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.169.tgz",
+      "integrity": "sha512-5PJU3wqfvJUrgUF3H7iroxAGDyliKmq5q8kK+glERf8YZgmPeDMvQL4mGSB0Vf9RgBWS01dCen93TIsN0O8NPQ==",
       "cpu": [
         "arm64"
       ],
@@ -223,9 +223,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.168",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.168.tgz",
-      "integrity": "sha512-J5dZUCrwjz4+gY2dAds2rMDWWSdcMl9jEDpZIzKNCx0f0KlJfE1C7/+stOJaBv6tGj8d/mmzcfBCeNBS1KScgA==",
+      "version": "0.3.169",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.169.tgz",
+      "integrity": "sha512-1Hzt0QYG7N/ExfPbN/C92YRc3BoDnyQMJpuWLVyI/r0NmKV/se/cZbIygbvQXs2ywoXOB/EyNj/hkVHaC1G22g==",
       "cpu": [
         "x64"
       ],
@@ -237,9 +237,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.168",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.168.tgz",
-      "integrity": "sha512-K9fltcI0VJBr21z4t0iJ4aArFtiS9UwhmMGkxl1jAIM0jatGqiHHbbk+qaCB04va3U6vaflukgtmbpogSB36yQ==",
+      "version": "0.3.169",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.169.tgz",
+      "integrity": "sha512-J0tyM4t5qxc2/xilsfHqcJv+fyEDhX66Nv+CMXq4mRbquZmMHhbZbh8ryb+BnKYXUeqKX3uoU/J+7K6/fjcY4g==",
       "cpu": [
         "arm64"
       ],
@@ -254,9 +254,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.168",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.168.tgz",
-      "integrity": "sha512-uOFtBJjntrYkXlHPRK+cTx1pCc37XxGQ/kN3KBK/KoIDcIrmU8DcX2WUw5IJHJqpG2Qjb7gZ5xAbcw3WTmduwQ==",
+      "version": "0.3.169",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.169.tgz",
+      "integrity": "sha512-xkmyNdU6f7HXXzgR6IZym7x41bjL3rjGrXf5PAmx9PjdThy476+TrpO1evKUza1zlVmUj4tj/jYKQsV4ER7QFw==",
       "cpu": [
         "arm64"
       ],
@@ -271,9 +271,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.168",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.168.tgz",
-      "integrity": "sha512-0Fw4ICZopwKbqNQo64HqkpJw5cqxOxFOV/w8GCS2hDsJ+0aogmK/B78t4iV6rFHIkC076Nm5UH14FP1eOIJ3OA==",
+      "version": "0.3.169",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.169.tgz",
+      "integrity": "sha512-ktEPBwzXZagt0cntfRLlvNL0sAplt2HOCbR5iBvq2IV5dLvbEOiBjZQArIcSAN7CTQUFqkZs9HzQMdKe5QPwuQ==",
       "cpu": [
         "x64"
       ],
@@ -288,9 +288,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.168",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.168.tgz",
-      "integrity": "sha512-JwYD7oxYlIVYDFhgj+QVHgWbJUVGMXsiecB6WQ5VS5u4OqUorivJPFYPaP469otMj4HFtkDupESB+7Zp4jMmUw==",
+      "version": "0.3.169",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.169.tgz",
+      "integrity": "sha512-Me8VW91pCKgkct/y1isjKNVt+ZPMPhHk3C7O078UO1bakHD6kuPiMtugcCsg4jmmmuuywXQIQUESRbcf0GluUg==",
       "cpu": [
         "x64"
       ],
@@ -305,9 +305,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.168",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.168.tgz",
-      "integrity": "sha512-NREaLXAxl23pEzoU7bmX6u8MibAYEY2t8XP5xtj/vMO6UwxFjT3YgGsTuQcnFP+1qsjWaOBCia2ZQnqI68Y0Ng==",
+      "version": "0.3.169",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.169.tgz",
+      "integrity": "sha512-HL9ecP82A/H8aC896Q7ETyl+nLFkMzBHfO0yvK7Lhxbi98CEpqXn3BADTAc5pEgzkO+r18+CDmZdgjTFMvGoTw==",
       "cpu": [
         "arm64"
       ],
@@ -319,9 +319,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.168",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.168.tgz",
-      "integrity": "sha512-Ha3eivz2Wm4y3BR+Xpn/r+CBM8ARC6knYDLbjLqH/DxjKahr6WB60xQkBD1U6wchT6w7zfIQqQGbucuUOTTuew==",
+      "version": "0.3.169",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.169.tgz",
+      "integrity": "sha512-34pBbiKe7FNsY8LHuuTmKujmYko/cBOrKJpk9H+MOot+dSfB/FmIHq9USL17otNal5Droq9lqpezAWPBPv3lAQ==",
       "cpu": [
         "x64"
       ],
@@ -2214,9 +2214,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.134.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0.tgz",
-      "integrity": "sha512-N0vmdTXl/rglZjgd3PaMe9oRrqjO6zZ//uAvUhCDRnJNAUT3LrpYvCK3y9B/ev7QcChfXR43IGUh3ssqWRvMmA==",
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0.tgz",
+      "integrity": "sha512-ID75QEYmAT1WsUQmpxPlNsL5W1a+2eeD7fP6ywdwGseiXUG8D5i16L+dzbr8MT+2oTkaVqzOdvAqVOCeV/H/Bw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2226,19 +2226,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.134.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.134.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.134.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.134.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.134.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.134.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.135.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.135.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.135.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.135.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.135.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.135.0-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.134.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0-darwin-arm64.tgz",
-      "integrity": "sha512-pOxwQjb1HHtY6KG66+g/rX7uP4yBvchfCrQw22ddYy64s7fJqnD6UV/Ur60j6MWXt71jcaWLEkV1pJthQy9CFQ==",
+      "version": "0.135.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-darwin-arm64.tgz",
+      "integrity": "sha512-wpNzssusKfrldVlq39+HyQh1wCyc9SQNpHdAFGKtPenrgRte4Ct8/oVsDtKWuFZsqLBFwbL4MrzrevnB63+9HA==",
       "cpu": [
         "arm64"
       ],
@@ -2254,9 +2254,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.134.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0-darwin-x64.tgz",
-      "integrity": "sha512-XjRtq8PB9dtpxQ5QU6TrzR/z8EVlLLk55oonsyRp3VkMOsKjJWXvLxAnmzUm1MuVZqz90Ua7CJbr+8BG+ZUWpA==",
+      "version": "0.135.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-darwin-x64.tgz",
+      "integrity": "sha512-ZrjAqce23lbv9KfkYOhElf1lTI+SysXmyGM0FV5u4+PBCKPkkEs4eaS3H8Uig0i4bUSu1QylrOOCskzYhZ6VyQ==",
       "cpu": [
         "x64"
       ],
@@ -2272,9 +2272,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.134.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0-linux-arm64.tgz",
-      "integrity": "sha512-fqI8iClQGvrANFx/dJwZK8KNQlqlQKo7A/UB5G7IaeTAAJ+y/CG2R33Bbd9GboH/8ormY39ureNk27eqt++51g==",
+      "version": "0.135.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-linux-arm64.tgz",
+      "integrity": "sha512-dM+cv5ZL+BgIQzEIvMg9AxZ98n5lkKLgtp5zJLXWSrbCllbnUSqxYMUiWI5c1a1uBDUtkbY9fcGKXFLf+d+gyg==",
       "cpu": [
         "arm64"
       ],
@@ -2290,9 +2290,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.134.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0-linux-x64.tgz",
-      "integrity": "sha512-d/o1AVAniQU2oSEq7ZV0hVwzmk6Dj2IWeNPLnX/KXyv1DfIMJbY+qEg/xhfRmuVW4VPhrhQLBITwrkAYviy1MA==",
+      "version": "0.135.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-linux-x64.tgz",
+      "integrity": "sha512-5EosY67yU28UJSnl/obdN2F1CDaimYbzm9SLR8dwwzkeBBnY6dHgAKJ2GTu9Nc8CmgmtVFBGzgPqehsIcueVvA==",
       "cpu": [
         "x64"
       ],
@@ -2308,9 +2308,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.134.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0-win32-arm64.tgz",
-      "integrity": "sha512-8OdRmbCcyLLMF3Bg6945PW6INZ7bZVygYo2lusnC0Q2KZ3MRYrMnXRJ6mfvkDc8kPpFE+djMFnQ70gt/jBLVCA==",
+      "version": "0.135.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-win32-arm64.tgz",
+      "integrity": "sha512-SAeR+CUv7KWwE6eTc2UFaFjo6FpHywYfDFKrK6FqLms1rq1NPju2SoX7rhM6UEew/lUx2mdZv/LDs11s/N/Qgg==",
       "cpu": [
         "arm64"
       ],
@@ -2326,9 +2326,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.134.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.134.0-win32-x64.tgz",
-      "integrity": "sha512-hW1omBcN1jKeVUVnTqWlpc42nF2qAwCEN6l1IFeKFJegYoZ39YrE7pdh56gAmaZTyT5Eexx7cgNpaEK3JElxvA==",
+      "version": "0.135.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-win32-x64.tgz",
+      "integrity": "sha512-uYwUBMbOfmVlCESJZmZsOG+cYwNFYvkMbQ+FB6C1u9RYz0m3mZeYNN0j+l1hRSyUgPMFJHzNpgNx1Usal5QZFQ==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
   },
   "devDependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.168",
-    "@openai/codex": "^0.134.0",
+    "@openai/codex": "0.134.0",
     "@playwright/cli": "^0.1.9",
     "@playwright/test": "^1.56.1",
     "@stylistic/eslint-plugin-ts": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -159,8 +159,8 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.168",
-    "@openai/codex": "0.134.0",
+    "@anthropic-ai/claude-agent-sdk": "0.3.169",
+    "@openai/codex": "0.135.0",
     "@playwright/cli": "^0.1.9",
     "@playwright/test": "^1.56.1",
     "@stylistic/eslint-plugin-ts": "^2.8.0",

--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -65,22 +65,32 @@ export type ExtensionVirtualWorkspaceSupport = {
 };
 
 /**
- * Per-platform configuration for downloading an agent SDK on demand. When
- * `IProductConfiguration.agentSdks?.[pkg]` is set, the agent host GETs
- * `url`, verifies sha256 against `sha256`, and caches the extracted root
- * under `userDataPath/agent-host/sdk-cache/`.
+ * Per-SDK configuration for downloading an agent SDK on demand. Each
+ * shipped `product.json` carries one entry per supported SDK; the
+ * downloader resolves the actual per-target tarball URL at runtime by
+ * substituting `{sdkTarget}` in `urlTemplate` against the host's
+ * `(platform, arch, libc)` triple.
  *
- * The build pipeline patches `agentSdks` per-platform during packaging, so
- * each shipped product.json carries only the entry appropriate for the
- * platform it targets — there is no per-target sha lookup at runtime.
+ * `urlTemplate` uses `format2()`-style named placeholders. Today only
+ * `{sdkTarget}` is recognised; the build emits e.g.
+ * `https://main.vscode-cdn.net/agent-sdk/claude/0.3.168/{sdkTarget}.tgz`
+ * and the runtime substitutes `darwin-arm64`, `linux-x64-musl`, etc.
  *
- * The trust anchor for `sha256` is product.json's own integrity coverage
- * via `product.checksums` (computed in the same packaging step).
+ * Why a template (not a per-platform `{url, sha256}` pair):
+ *
+ *   - **macOS Universal builds** ship one `product.json` for both arm64
+ *     and x64 — a fixed url/sha could only be correct for one half.
+ *     The template lets the same bundle serve both halves.
+ *   - **Sha-based validation is redundant** here: `product.json` is
+ *     covered by `product.checksums` inside the signed app bundle, and
+ *     the URL is HTTPS to a Microsoft-controlled CDN. The transport +
+ *     content-addressed origin do the work; a `sha256` field would
+ *     only guard "trusted URL string, tampered edge bytes" — a much
+ *     harder attack than tampering with `product.json` itself.
  */
 export interface IAgentSdkProductConfig {
 	readonly version: string;
-	readonly url: string;
-	readonly sha256: string;
+	readonly urlTemplate: string;
 }
 
 export interface IProductConfiguration {

--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -65,28 +65,18 @@ export type ExtensionVirtualWorkspaceSupport = {
 };
 
 /**
- * Per-SDK configuration for downloading an agent SDK on demand. Each
- * shipped `product.json` carries one entry per supported SDK; the
- * downloader resolves the actual per-target tarball URL at runtime by
- * substituting `{sdkTarget}` in `urlTemplate` against the host's
- * `(platform, arch, libc)` triple.
+ * Per-SDK configuration for downloading an agent SDK on demand. The
+ * runtime substitutes `{sdkTarget}` in `urlTemplate` against the host's
+ * `(platform, arch, libc)` triple via `resolveSdkTarget()` in the agent
+ * SDK downloader.
  *
  * `urlTemplate` uses `format2()`-style named placeholders. Today only
  * `{sdkTarget}` is recognised; the build emits e.g.
  * `https://main.vscode-cdn.net/agent-sdk/claude/0.3.168/{sdkTarget}.tgz`
  * and the runtime substitutes `darwin-arm64`, `linux-x64-musl`, etc.
  *
- * Why a template (not a per-platform `{url, sha256}` pair):
- *
- *   - **macOS Universal builds** ship one `product.json` for both arm64
- *     and x64 — a fixed url/sha could only be correct for one half.
- *     The template lets the same bundle serve both halves.
- *   - **Sha-based validation is redundant** here: `product.json` is
- *     covered by `product.checksums` inside the signed app bundle, and
- *     the URL is HTTPS to a Microsoft-controlled CDN. The transport +
- *     content-addressed origin do the work; a `sha256` field would
- *     only guard "trusted URL string, tampered edge bytes" — a much
- *     harder attack than tampering with `product.json` itself.
+ * See `src/vs/platform/agentHost/node/claude/roadmap.md` Phase 15 for
+ * the rationale (macOS Universal compatibility, trust model).
  */
 export interface IAgentSdkProductConfig {
 	readonly version: string;

--- a/src/vs/base/node/libc.ts
+++ b/src/vs/base/node/libc.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as Platform from '../common/platform.js';
+
+/**
+ * The libc family the current process is linked against. Only Linux
+ * has a meaningful distinction; everywhere else the answer is
+ * `'glibc'` by convention (these helpers are only consulted to pick a
+ * Linux SKU suffix, where `'glibc'` means "no `-musl` suffix").
+ */
+export type LibcFamily = 'glibc' | 'musl';
+
+let _cached: LibcFamily | undefined;
+
+/**
+ * Returns the libc family of the running Node process.
+ *
+ * Mechanism: Node's process report exposes `glibcVersionRuntime` in the
+ * header on glibc-linked builds and omits it on musl-linked builds. So
+ * the field's presence is itself the signal — no `ldd` subprocess, no
+ * `/etc/os-release` parsing, no filesystem probe.
+ *
+ * Returns `'glibc'` on non-Linux platforms (the answer is unused there
+ * but the type stays simple — callers always get a defined value and
+ * can use it in a single equality check).
+ *
+ * Cached after first call. Node's libc never changes mid-process.
+ */
+export function detectLibc(): LibcFamily {
+	if (_cached !== undefined) {
+		return _cached;
+	}
+	if (!Platform.isLinux) {
+		_cached = 'glibc';
+		return _cached;
+	}
+	const report = process.report?.getReport() as { header?: { glibcVersionRuntime?: string } } | undefined;
+	_cached = report?.header?.glibcVersionRuntime ? 'glibc' : 'musl';
+	return _cached;
+}

--- a/src/vs/base/node/libc.ts
+++ b/src/vs/base/node/libc.ts
@@ -5,39 +5,35 @@
 
 import * as Platform from '../common/platform.js';
 
-/**
- * The libc family the current process is linked against. Only Linux
- * has a meaningful distinction; everywhere else the answer is
- * `'glibc'` by convention (these helpers are only consulted to pick a
- * Linux SKU suffix, where `'glibc'` means "no `-musl` suffix").
- */
+/** The libc family the current process is linked against. */
 export type LibcFamily = 'glibc' | 'musl';
 
 let _cached: LibcFamily | undefined;
+let _cacheValid = false;
 
 /**
- * Returns the libc family of the running Node process.
+ * Returns the libc family of the running Node process on Linux, or
+ * `undefined` on non-Linux platforms (where the question is meaningless).
  *
  * Mechanism: Node's process report exposes `glibcVersionRuntime` in the
- * header on glibc-linked builds and omits it on musl-linked builds. So
- * the field's presence is itself the signal — no `ldd` subprocess, no
+ * header on glibc-linked builds and omits it on musl-linked builds. The
+ * field's presence is itself the signal — no `ldd` subprocess, no
  * `/etc/os-release` parsing, no filesystem probe.
  *
- * Returns `'glibc'` on non-Linux platforms (the answer is unused there
- * but the type stays simple — callers always get a defined value and
- * can use it in a single equality check).
- *
- * Cached after first call. Node's libc never changes mid-process.
+ * Cached after first call. `process.report.getReport()` is expensive
+ * (serializes heap + native stack + libuv state) so the cache pays for
+ * itself; libc never changes mid-process.
  */
-export function detectLibc(): LibcFamily {
-	if (_cached !== undefined) {
+export function detectLibc(): LibcFamily | undefined {
+	if (_cacheValid) {
 		return _cached;
 	}
-	if (!Platform.isLinux) {
-		_cached = 'glibc';
-		return _cached;
+	if (Platform.isLinux) {
+		const report = process.report?.getReport() as { header?: { glibcVersionRuntime?: string } } | undefined;
+		_cached = report?.header?.glibcVersionRuntime ? 'glibc' : 'musl';
+	} else {
+		_cached = undefined;
 	}
-	const report = process.report?.getReport() as { header?: { glibcVersionRuntime?: string } } | undefined;
-	_cached = report?.header?.glibcVersionRuntime ? 'glibc' : 'musl';
+	_cacheValid = true;
 	return _cached;
 }

--- a/src/vs/base/test/node/libc.test.ts
+++ b/src/vs/base/test/node/libc.test.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import * as Platform from '../../common/platform.js';
+import { detectLibc } from '../../node/libc.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../common/utils.js';
+
+suite('libc', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('returns one of the two known values', () => {
+		const family = detectLibc();
+		assert.ok(family === 'glibc' || family === 'musl', `unexpected libc family: ${family}`);
+	});
+
+	test('non-Linux platforms are reported as glibc by convention', () => {
+		if (!Platform.isLinux) {
+			assert.strictEqual(detectLibc(), 'glibc');
+		}
+	});
+
+	test('caches the result across calls', () => {
+		const first = detectLibc();
+		const second = detectLibc();
+		assert.strictEqual(first, second);
+	});
+});

--- a/src/vs/base/test/node/libc.test.ts
+++ b/src/vs/base/test/node/libc.test.ts
@@ -11,14 +11,16 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../common/utils.js';
 suite('libc', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('returns one of the two known values', () => {
-		const family = detectLibc();
-		assert.ok(family === 'glibc' || family === 'musl', `unexpected libc family: ${family}`);
+	test('non-Linux platforms return undefined', () => {
+		if (!Platform.isLinux) {
+			assert.strictEqual(detectLibc(), undefined);
+		}
 	});
 
-	test('non-Linux platforms are reported as glibc by convention', () => {
-		if (!Platform.isLinux) {
-			assert.strictEqual(detectLibc(), 'glibc');
+	test('Linux returns one of the two known values', () => {
+		if (Platform.isLinux) {
+			const family = detectLibc();
+			assert.ok(family === 'glibc' || family === 'musl', `unexpected libc family: ${family}`);
 		}
 	});
 

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -158,7 +158,7 @@ async function startAgentHost(): Promise<void> {
 		// Register the agent SDK downloader BEFORE any service that injects it
 		// (ClaudeAgentSdkService and CodexAgent below). The downloader resolves
 		// dev-override env var → on-disk cache → product.agentSdks download.
-		const agentSdkDownloader = instantiationService.createInstance(AgentSdkDownloader, undefined);
+		const agentSdkDownloader = instantiationService.createInstance(AgentSdkDownloader);
 		diServices.set(IAgentSdkDownloader, agentSdkDownloader);
 		const copilotApiService = instantiationService.createInstance(CopilotApiService, undefined);
 		diServices.set(ICopilotApiService, copilotApiService);

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -158,7 +158,7 @@ async function startAgentHost(): Promise<void> {
 		// Register the agent SDK downloader BEFORE any service that injects it
 		// (ClaudeAgentSdkService and CodexAgent below). The downloader resolves
 		// dev-override env var → on-disk cache → product.agentSdks download.
-		const agentSdkDownloader = instantiationService.createInstance(AgentSdkDownloader);
+		const agentSdkDownloader = instantiationService.createInstance(AgentSdkDownloader, undefined);
 		diServices.set(IAgentSdkDownloader, agentSdkDownloader);
 		const copilotApiService = instantiationService.createInstance(CopilotApiService, undefined);
 		diServices.set(ICopilotApiService, copilotApiService);

--- a/src/vs/platform/agentHost/node/agentHostServerMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostServerMain.ts
@@ -268,7 +268,7 @@ async function main(): Promise<void> {
 			process.env[AgentHostCodexAgentSdkRootEnvVar] = options.codexSdkRoot;
 		}
 		// Register the agent SDK downloader BEFORE any service that injects it.
-		const agentSdkDownloader = instantiationService.createInstance(AgentSdkDownloader, undefined);
+		const agentSdkDownloader = instantiationService.createInstance(AgentSdkDownloader);
 		diServices.set(IAgentSdkDownloader, agentSdkDownloader);
 		const claudeProxyService = disposables.add(instantiationService.createInstance(ClaudeProxyService));
 		diServices.set(IClaudeProxyService, claudeProxyService);

--- a/src/vs/platform/agentHost/node/agentHostServerMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostServerMain.ts
@@ -268,7 +268,7 @@ async function main(): Promise<void> {
 			process.env[AgentHostCodexAgentSdkRootEnvVar] = options.codexSdkRoot;
 		}
 		// Register the agent SDK downloader BEFORE any service that injects it.
-		const agentSdkDownloader = instantiationService.createInstance(AgentSdkDownloader);
+		const agentSdkDownloader = instantiationService.createInstance(AgentSdkDownloader, undefined);
 		diServices.set(IAgentSdkDownloader, agentSdkDownloader);
 		const claudeProxyService = disposables.add(instantiationService.createInstance(ClaudeProxyService));
 		diServices.set(IClaudeProxyService, claudeProxyService);

--- a/src/vs/platform/agentHost/node/agentSdkDownloader.ts
+++ b/src/vs/platform/agentHost/node/agentSdkDownloader.ts
@@ -11,6 +11,7 @@ import { CancellationError } from '../../../base/common/errors.js';
 import * as path from '../../../base/common/path.js';
 import { format2 } from '../../../base/common/strings.js';
 import { URI } from '../../../base/common/uri.js';
+import { detectLibc, type LibcFamily } from '../../../base/node/libc.js';
 import { INativeEnvironmentService } from '../../environment/common/environment.js';
 import { FileOperationError, FileOperationResult, IFileService, toFileOperationResult } from '../../files/common/files.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
@@ -24,9 +25,10 @@ import { IRequestContext } from '../../../base/parts/request/common/request.js';
 /**
  * One agent-SDK package the downloader can fetch. Holds the per-package
  * knowledge that varies between Claude, Codex, and any future provider —
- * the package id, the env var that acts as a dev override, and the
- * `(platform, arch, libc) → sdkTarget` mapping (which differs by SDK:
- * Claude has separate `linux-*-musl` SKUs, Codex doesn't).
+ * the package id, the env var that acts as a dev override, and one
+ * boolean covering the only mapping detail that differs between SDKs
+ * today (Claude has separate `linux-*-musl` SKUs; Codex's Linux binary
+ * is statically musl-linked and ships as a single `linux-*` SKU).
  *
  * The downloader itself is package-agnostic: it consumes this interface and
  * never branches on `id`. Concrete `IAgentSdkPackage` instances live in
@@ -37,10 +39,10 @@ import { IRequestContext } from '../../../base/parts/request/common/request.js';
  * serves.
  *
  * Each shipped `product.json` carries one `{version, urlTemplate}` per
- * SDK. The downloader substitutes `{sdkTarget}` (from
- * `currentSdkTarget()`) into the template to get the per-target tarball
- * URL. This shape supports macOS Universal builds, where the same
- * `product.json` is shared by arm64 and x64 launches.
+ * SDK. The downloader substitutes `{sdkTarget}` (resolved via
+ * `resolveSdkTarget(pkg)`) into the template to get the per-target
+ * tarball URL. This shape supports macOS Universal builds, where the
+ * same `product.json` is shared by arm64 and x64 launches.
  */
 export interface IAgentSdkPackage {
 	/** Key under `product.agentSdks` — e.g. `'claude'`, `'codex'`. */
@@ -48,14 +50,54 @@ export interface IAgentSdkPackage {
 	/** Env var that, when set, becomes the SDK root and short-circuits the download. */
 	readonly devOverrideEnvVar: string;
 	/**
-	 * Resolves the build's `sdkTarget` suffix for the current host:
-	 *   - claude: `'darwin-arm64'`, `'linux-x64'`, `'linux-x64-musl'`, …
-	 *   - codex:  `'darwin-arm64'`, `'linux-x64'`, …  (no musl SKU)
-	 * Returns `undefined` when no SDK applies (`armhf`, browser, …);
-	 * the downloader treats that the same as "no product config" and
-	 * never registers the provider.
+	 * True iff this SDK publishes separate `linux-{x64,arm64}-musl`
+	 * packages alongside the glibc default. Claude does; Codex doesn't
+	 * (its Linux binary is statically musl-linked and runs on both).
 	 */
-	currentSdkTarget(): string | undefined;
+	readonly hasSeparateMuslLinuxPackage: boolean;
+}
+
+/**
+ * Per-host info used by `resolveSdkTarget`. Defaulted from the running
+ * process; tests inject synthetic values to exercise targets the test
+ * host doesn't actually run on (Universal-launch case, musl, etc.).
+ */
+export interface ISdkTargetHost {
+	readonly platform: NodeJS.Platform;
+	readonly arch: string;
+	readonly libc: LibcFamily | undefined;
+}
+
+const SUPPORTED_PLATFORMS = new Set<NodeJS.Platform>(['linux', 'darwin', 'win32']);
+const SUPPORTED_ARCHES = new Set<string>(['x64', 'arm64']);
+
+/**
+ * Resolves the build's `sdkTarget` suffix for the current host:
+ *   - claude on glibc Linux: `linux-x64` / `linux-arm64`
+ *   - claude on musl Linux:  `linux-x64-musl` / `linux-arm64-musl`
+ *   - codex Linux (any libc): `linux-x64` / `linux-arm64`
+ *   - everywhere else:       `<platform>-<arch>`
+ *
+ * Returns `undefined` when no SDK applies (`armhf`, web, etc.); the
+ * downloader treats that the same as "no product config" and never
+ * registers the provider.
+ *
+ * Mirror of the build pipeline's `getSdkTargetForBuild` (in
+ * `build/agent-sdk/common.ts`) translated from build-time
+ * `vscodePlatform` to runtime `process.platform` + libc detection.
+ * Keep the two in sync when adding new target SKUs.
+ */
+export function resolveSdkTarget(
+	pkg: Pick<IAgentSdkPackage, 'hasSeparateMuslLinuxPackage'>,
+	host: ISdkTargetHost = { platform: process.platform, arch: process.arch, libc: detectLibc() },
+): string | undefined {
+	if (!SUPPORTED_PLATFORMS.has(host.platform) || !SUPPORTED_ARCHES.has(host.arch)) {
+		return undefined;
+	}
+	if (host.platform === 'linux' && pkg.hasSeparateMuslLinuxPackage && host.libc === 'musl') {
+		return `linux-${host.arch}-musl`;
+	}
+	return `${host.platform}-${host.arch}`;
 }
 
 // #endregion
@@ -104,36 +146,54 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 	declare readonly _serviceBrand: undefined;
 
 	/**
-	 * In-flight downloads keyed by `<pkg>/<sdkVersion>/<sdkTarget>`.
-	 * Concurrent `loadSdkRoot` calls in the same process share the same
-	 * promise so we never download the same tarball twice. Includes
-	 * `sdkTarget` so macOS Universal builds (which can resolve to
-	 * different targets per launch) don't share a key.
+	 * In-flight downloads keyed by the destination `cacheDir` (which
+	 * already encodes `<pkg>/<sdkVersion>/<sdkTarget>`). Concurrent
+	 * `loadSdkRoot` calls in the same process share the same promise so
+	 * we never download the same tarball twice. Universal launches that
+	 * resolve to different targets get distinct entries because their
+	 * cacheDirs differ.
 	 */
 	private readonly _pendingDownloads = new Map<string, Promise<string>>();
 
 	/**
-	 * Negative cache: most recent failure per package id, with an expiry. While
-	 * within the window, `loadSdkRoot` re-throws the cached error immediately
-	 * instead of re-attempting the download. Without this, a broken CDN
-	 * causes every SDK method call (poll-driven UIs hit this hard) to fire
-	 * a fresh request.
+	 * Negative cache: most recent failure per package id, with an expiry.
+	 * While within the window, `loadSdkRoot` re-throws the cached error
+	 * immediately instead of re-attempting the download. Without this, a
+	 * broken CDN causes every SDK method call (poll-driven UIs hit this
+	 * hard) to fire a fresh request.
+	 *
+	 * Keyed by `pkg.id` (not the finer cacheDir): CDN failures are
+	 * effectively global per SDK (DNS, proxy auth, 5xx) and per-target
+	 * latching wouldn't protect against the actual failure modes — the
+	 * broader latch is intentional.
 	 */
 	private readonly _failureLatch = new Map<string, { error: Error; expiresAt: number }>();
 
+	private readonly _host: ISdkTargetHost;
+
 	constructor(
+		/**
+		 * Host info used to resolve `{sdkTarget}` per launch. Pass `undefined`
+		 * (or omit) in production to derive from `process`. Tests pass a
+		 * synthetic host (Universal launches, musl, …) without monkey-
+		 * patching the runtime. Per project convention non-service params
+		 * come before service ones.
+		 */
+		host: ISdkTargetHost | undefined,
 		@INativeEnvironmentService private readonly _environmentService: INativeEnvironmentService,
 		@IProductService private readonly _productService: IProductService,
 		@IRequestService private readonly _requestService: IRequestService,
 		@IFileService private readonly _fileService: IFileService,
 		@ILogService private readonly _logService: ILogService,
-	) { }
+	) {
+		this._host = host ?? { platform: process.platform, arch: process.arch, libc: detectLibc() };
+	}
 
 	isAvailable(pkg: IAgentSdkPackage): boolean {
 		if (process.env[pkg.devOverrideEnvVar]) {
 			return true;
 		}
-		return !!this._productService.agentSdks?.[pkg.id] && pkg.currentSdkTarget() !== undefined;
+		return !!this._productService.agentSdks?.[pkg.id] && resolveSdkTarget(pkg, this._host) !== undefined;
 	}
 
 	async loadSdkRoot(pkg: IAgentSdkPackage, token: CancellationToken): Promise<string> {
@@ -176,11 +236,11 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 				`no ${pkg.devOverrideEnvVar} dev override set.`,
 			);
 		}
-		const sdkTarget = pkg.currentSdkTarget();
+		const sdkTarget = resolveSdkTarget(pkg, this._host);
 		if (!sdkTarget) {
 			throw new Error(
 				`Cannot load ${pkg.id} SDK: no SDK target for this host ` +
-				`(${process.platform}/${process.arch}). ` +
+				`(${this._host.platform}/${this._host.arch}). ` +
 				`Set ${pkg.devOverrideEnvVar} to a local SDK root to bypass.`,
 			);
 		}
@@ -189,21 +249,23 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 		const cacheDir = this._cacheDir(pkg.id, config.version, sdkTarget);
 		const sentinel = URI.joinPath(URI.file(cacheDir), '.complete');
 
-		if (await this._cacheHit(sentinel)) {
+		// `.complete`'s mere presence is the integrity signal — extracts
+		// that crashed mid-way never write it. See `_download` for why
+		// the sentinel is written inside the tmp dir before the rename.
+		if (await this._fileService.exists(sentinel)) {
 			return cacheDir;
 		}
 
 		// Download (deduped across concurrent callers in the same process).
-		// Key includes sdkTarget so a Universal launch resolving to a
-		// different target than a previous launch doesn't share an in-flight
-		// promise pointing at the wrong tarball.
-		const key = `${pkg.id}/${config.version}/${sdkTarget}`;
-		let pending = this._pendingDownloads.get(key);
+		// cacheDir is already unique per (pkg, version, sdkTarget) — within
+		// a single downloader instance userDataPath is fixed, so it serves
+		// as the dedup key without an extra string allocation.
+		let pending = this._pendingDownloads.get(cacheDir);
 		if (!pending) {
 			pending = this._download(pkg, url, cacheDir, sentinel, token).finally(() => {
-				this._pendingDownloads.delete(key);
+				this._pendingDownloads.delete(cacheDir);
 			});
-			this._pendingDownloads.set(key, pending);
+			this._pendingDownloads.set(cacheDir, pending);
 		}
 		return pending;
 	}
@@ -220,17 +282,6 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 			sdkVersion,
 			sdkTarget,
 		);
-	}
-
-	/**
-	 * True iff the `.complete` sentinel at {@link sentinel} exists. The
-	 * sentinel's mere presence is the integrity signal — extracts that
-	 * crashed mid-way never write it, so a sentinel-bearing dir is known
-	 * to have completed. Shared by the fast-path cache check and the
-	 * rename-loser race recovery.
-	 */
-	private async _cacheHit(sentinel: URI): Promise<boolean> {
-		return this._fileService.exists(sentinel);
 	}
 
 	private async _download(
@@ -262,14 +313,15 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 			await this._fileService.del(URI.file(tarballPath));
 
 			// Write the `.complete` sentinel inside the tmp dir BEFORE the
-			// move. That way the move atomically publishes a directory that
+			// move so the move atomically publishes a directory that
 			// already carries its sentinel — a crash between move and
 			// sentinel-write can't leave a wedged, sentinel-less cacheDir
-			// behind. The sentinel's content (the source URL) is purely
-			// for debugging stale caches; the existence is what matters.
+			// behind. Content is intentionally empty: only existence
+			// matters, and the cache dir path already encodes
+			// `<pkg>/<version>/<sdkTarget>` for debugging.
 			await this._fileService.writeFile(
 				URI.joinPath(tmpDirUri, '.complete'),
-				VSBuffer.fromString(url),
+				VSBuffer.fromString(''),
 			);
 
 			// Atomic publish of the completed extraction.
@@ -311,7 +363,7 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 		if (!(err instanceof FileOperationError) || err.fileOperationResult !== FileOperationResult.FILE_MOVE_CONFLICT) {
 			return false;
 		}
-		if (!(await this._cacheHit(sentinel))) {
+		if (!(await this._fileService.exists(sentinel))) {
 			return false;
 		}
 		// Winner already published a complete cache. Drop our scratch dir.

--- a/src/vs/platform/agentHost/node/agentSdkDownloader.ts
+++ b/src/vs/platform/agentHost/node/agentSdkDownloader.ts
@@ -3,13 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as tar from 'tar';
 import { VSBuffer } from '../../../base/common/buffer.js';
 import { CancellationToken } from '../../../base/common/cancellation.js';
 import { CancellationError } from '../../../base/common/errors.js';
 import * as path from '../../../base/common/path.js';
+import { format2 } from '../../../base/common/strings.js';
 import { URI } from '../../../base/common/uri.js';
 import { INativeEnvironmentService } from '../../environment/common/environment.js';
 import { FileOperationError, FileOperationResult, IFileService, toFileOperationResult } from '../../files/common/files.js';
@@ -24,7 +24,9 @@ import { IRequestContext } from '../../../base/parts/request/common/request.js';
 /**
  * One agent-SDK package the downloader can fetch. Holds the per-package
  * knowledge that varies between Claude, Codex, and any future provider —
- * just the package id and the env var that acts as a dev override.
+ * the package id, the env var that acts as a dev override, and the
+ * `(platform, arch, libc) → sdkTarget` mapping (which differs by SDK:
+ * Claude has separate `linux-*-musl` SKUs, Codex doesn't).
  *
  * The downloader itself is package-agnostic: it consumes this interface and
  * never branches on `id`. Concrete `IAgentSdkPackage` instances live in
@@ -34,16 +36,26 @@ import { IRequestContext } from '../../../base/parts/request/common/request.js';
  * stays in those modules — the downloader doesn't name the providers it
  * serves.
  *
- * Platform discrimination is done at packaging time: the build sets
- * `product.agentSdks[pkg]` to the `{ version, url, sha256 }` appropriate
- * for the platform being packaged, so there is no per-target lookup at
- * runtime.
+ * Each shipped `product.json` carries one `{version, urlTemplate}` per
+ * SDK. The downloader substitutes `{sdkTarget}` (from
+ * `currentSdkTarget()`) into the template to get the per-target tarball
+ * URL. This shape supports macOS Universal builds, where the same
+ * `product.json` is shared by arm64 and x64 launches.
  */
 export interface IAgentSdkPackage {
 	/** Key under `product.agentSdks` — e.g. `'claude'`, `'codex'`. */
 	readonly id: string;
 	/** Env var that, when set, becomes the SDK root and short-circuits the download. */
 	readonly devOverrideEnvVar: string;
+	/**
+	 * Resolves the build's `sdkTarget` suffix for the current host:
+	 *   - claude: `'darwin-arm64'`, `'linux-x64'`, `'linux-x64-musl'`, …
+	 *   - codex:  `'darwin-arm64'`, `'linux-x64'`, …  (no musl SKU)
+	 * Returns `undefined` when no SDK applies (`armhf`, browser, …);
+	 * the downloader treats that the same as "no product config" and
+	 * never registers the provider.
+	 */
+	currentSdkTarget(): string | undefined;
 }
 
 // #endregion
@@ -62,8 +74,9 @@ export interface IAgentSdkDownloader {
 	 *
 	 * Resolution order:
 	 *   1. dev-override env var (returned unchanged)
-	 *   2. on-disk cache hit (re-verified against `product.json` sha256)
-	 *   3. download from `product.agentSdks?.[pkg.id]` and verify
+	 *   2. on-disk cache hit (`.complete` sentinel present)
+	 *   3. download from `product.agentSdks?.[pkg.id]` with
+	 *      `{sdkTarget}` substituted into the urlTemplate
 	 *
 	 * Repeated failures are latched for {@link LOAD_FAILURE_NEGATIVE_CACHE_MS}
 	 * so a misconfigured CDN doesn't get hammered on every SDK method call.
@@ -73,8 +86,9 @@ export interface IAgentSdkDownloader {
 	/**
 	 * Cheap, synchronous gate used at startup to decide whether to register
 	 * the corresponding agent provider. True iff the dev override is set, OR
-	 * `product.agentSdks?.[pkg.id]` is populated (which it only is on the
-	 * platform that build packaged for). Does NOT trigger a download.
+	 * (`product.agentSdks?.[pkg.id]` is populated AND `pkg.currentSdkTarget()`
+	 * resolves — i.e. an SDK exists for this host). Does NOT trigger a
+	 * download.
 	 */
 	isAvailable(pkg: IAgentSdkPackage): boolean;
 }
@@ -90,18 +104,20 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 	declare readonly _serviceBrand: undefined;
 
 	/**
-	 * In-flight downloads keyed by `<pkg>/<sdkVersion>`. Concurrent
-	 * `loadSdkRoot` calls in the same process share the same promise so we
-	 * never download the same tarball twice.
+	 * In-flight downloads keyed by `<pkg>/<sdkVersion>/<sdkTarget>`.
+	 * Concurrent `loadSdkRoot` calls in the same process share the same
+	 * promise so we never download the same tarball twice. Includes
+	 * `sdkTarget` so macOS Universal builds (which can resolve to
+	 * different targets per launch) don't share a key.
 	 */
 	private readonly _pendingDownloads = new Map<string, Promise<string>>();
 
 	/**
 	 * Negative cache: most recent failure per package id, with an expiry. While
 	 * within the window, `loadSdkRoot` re-throws the cached error immediately
-	 * instead of re-attempting the download. Without this, a broken CDN /
-	 * mismatched sha causes every SDK method call (poll-driven UIs hit this
-	 * hard) to fire a fresh request.
+	 * instead of re-attempting the download. Without this, a broken CDN
+	 * causes every SDK method call (poll-driven UIs hit this hard) to fire
+	 * a fresh request.
 	 */
 	private readonly _failureLatch = new Map<string, { error: Error; expiresAt: number }>();
 
@@ -114,7 +130,10 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 	) { }
 
 	isAvailable(pkg: IAgentSdkPackage): boolean {
-		return !!process.env[pkg.devOverrideEnvVar] || !!this._productService.agentSdks?.[pkg.id];
+		if (process.env[pkg.devOverrideEnvVar]) {
+			return true;
+		}
+		return !!this._productService.agentSdks?.[pkg.id] && pkg.currentSdkTarget() !== undefined;
 	}
 
 	async loadSdkRoot(pkg: IAgentSdkPackage, token: CancellationToken): Promise<string> {
@@ -157,27 +176,31 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 				`no ${pkg.devOverrideEnvVar} dev override set.`,
 			);
 		}
-		const expectedSha = config.sha256;
+		const sdkTarget = pkg.currentSdkTarget();
+		if (!sdkTarget) {
+			throw new Error(
+				`Cannot load ${pkg.id} SDK: no SDK target for this host ` +
+				`(${process.platform}/${process.arch}). ` +
+				`Set ${pkg.devOverrideEnvVar} to a local SDK root to bypass.`,
+			);
+		}
+		const url = format2(config.urlTemplate, { sdkTarget });
 
-		const cacheDir = this._cacheDir(pkg.id, config.version);
+		const cacheDir = this._cacheDir(pkg.id, config.version, sdkTarget);
 		const sentinel = URI.joinPath(URI.file(cacheDir), '.complete');
 
-		// Cache hit (always re-verify against product.json sha256).
-		if (await this._cacheHit(sentinel, expectedSha)) {
+		if (await this._cacheHit(sentinel)) {
 			return cacheDir;
-		}
-		// Drop a stale cache before re-downloading — covers the vscode-distro
-		// "same version, different sha" case.
-		if (await this._fileService.exists(sentinel)) {
-			this._logService.warn(`[AgentSdkDownloader] ${pkg.id}@${config.version}: cache sha mismatch, redownloading`);
-			await this._delIgnoringMissing(URI.file(cacheDir));
 		}
 
 		// Download (deduped across concurrent callers in the same process).
-		const key = `${pkg.id}/${config.version}`;
+		// Key includes sdkTarget so a Universal launch resolving to a
+		// different target than a previous launch doesn't share an in-flight
+		// promise pointing at the wrong tarball.
+		const key = `${pkg.id}/${config.version}/${sdkTarget}`;
 		let pending = this._pendingDownloads.get(key);
 		if (!pending) {
-			pending = this._download(pkg, config.url, expectedSha, cacheDir, sentinel, token).finally(() => {
+			pending = this._download(pkg, url, cacheDir, sentinel, token).finally(() => {
 				this._pendingDownloads.delete(key);
 			});
 			this._pendingDownloads.set(key, pending);
@@ -185,33 +208,34 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 		return pending;
 	}
 
-	private _cacheDir(packageId: string, sdkVersion: string): string {
+	private _cacheDir(packageId: string, sdkVersion: string, sdkTarget: string): string {
+		// `sdkTarget` is in the path so macOS Universal builds keep two
+		// independent caches — one per resolved target — instead of
+		// thrashing a single shared one as launches alternate.
 		return path.join(
 			this._environmentService.userDataPath,
 			'agent-host',
 			'sdk-cache',
 			packageId,
 			sdkVersion,
+			sdkTarget,
 		);
 	}
 
 	/**
-	 * True iff the `.complete` sentinel at {@link sentinel} exists and contains
-	 * `expectedSha`. Shared by the fast-path cache check and the rename-loser
-	 * race recovery.
+	 * True iff the `.complete` sentinel at {@link sentinel} exists. The
+	 * sentinel's mere presence is the integrity signal — extracts that
+	 * crashed mid-way never write it, so a sentinel-bearing dir is known
+	 * to have completed. Shared by the fast-path cache check and the
+	 * rename-loser race recovery.
 	 */
-	private async _cacheHit(sentinel: URI, expectedSha: string): Promise<boolean> {
-		if (!(await this._fileService.exists(sentinel))) {
-			return false;
-		}
-		const recorded = await this._readFileText(sentinel);
-		return recorded.trim() === expectedSha;
+	private async _cacheHit(sentinel: URI): Promise<boolean> {
+		return this._fileService.exists(sentinel);
 	}
 
 	private async _download(
 		pkg: IAgentSdkPackage,
 		url: string,
-		expectedSha: string,
 		cacheDir: string,
 		sentinel: URI,
 		token: CancellationToken,
@@ -223,8 +247,9 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 
 		// Extract to a per-pid scratch dir alongside the final cache dir, then
 		// rename into place. If two windows of the same install race, the loser
-		// catches the `move`'s `FILE_MOVE_CONFLICT`, verifies the existing
-		// .complete sha, and uses that instead — see the rename-loser path below.
+		// catches the `move`'s `FILE_MOVE_CONFLICT`, checks the existing
+		// .complete sentinel, and uses that instead — see the rename-loser
+		// path below.
 		const tmpDir = `${cacheDir}.tmp.${process.pid}`;
 		const tmpDirUri = URI.file(tmpDir);
 		await this._delIgnoringMissing(tmpDirUri);
@@ -232,26 +257,26 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 
 		try {
 			const tarballPath = path.join(tmpDir, 'sdk.tgz');
-			await this._fetchAndVerify(url, tarballPath, expectedSha, token);
+			await this._fetch(url, tarballPath, token);
 			await this._extractTarGz(tarballPath, tmpDir);
 			await this._fileService.del(URI.file(tarballPath));
 
-			// Write the `.complete` sentinel inside the tmp dir BEFORE the move.
-			// That way the move atomically publishes a directory that already
-			// carries its sentinel — a crash between move and sentinel-write
-			// can't leave a wedged, sentinel-less cacheDir behind (which would
-			// trip `_handleRenameLoser` on the next attempt and require a
-			// manual cache wipe to recover).
+			// Write the `.complete` sentinel inside the tmp dir BEFORE the
+			// move. That way the move atomically publishes a directory that
+			// already carries its sentinel — a crash between move and
+			// sentinel-write can't leave a wedged, sentinel-less cacheDir
+			// behind. The sentinel's content (the source URL) is purely
+			// for debugging stale caches; the existence is what matters.
 			await this._fileService.writeFile(
 				URI.joinPath(tmpDirUri, '.complete'),
-				VSBuffer.fromString(expectedSha),
+				VSBuffer.fromString(url),
 			);
 
 			// Atomic publish of the completed extraction.
 			try {
 				await this._fileService.move(tmpDirUri, URI.file(cacheDir));
 			} catch (err) {
-				if (await this._handleRenameLoser(err, sentinel, expectedSha, tmpDirUri)) {
+				if (await this._handleRenameLoser(err, sentinel, tmpDirUri)) {
 					this._logService.info(`[AgentSdkDownloader] ${pkg.id}: lost rename race, using existing cache`);
 					return cacheDir;
 				}
@@ -259,7 +284,7 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 			}
 
 			const elapsed = Math.round((Date.now() - start) / 1000);
-			this._logService.info(`[AgentSdkDownloader] ${pkg.id}: downloaded + verified in ${elapsed}s`);
+			this._logService.info(`[AgentSdkDownloader] ${pkg.id}: downloaded in ${elapsed}s`);
 			return cacheDir;
 		} catch (err) {
 			await this._delIgnoringMissing(tmpDirUri);
@@ -278,7 +303,6 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 	private async _handleRenameLoser(
 		err: unknown,
 		sentinel: URI,
-		expectedSha: string,
 		tmpDirUri: URI,
 	): Promise<boolean> {
 		// `IFileService.move` with default (overwrite: false) throws a
@@ -287,21 +311,19 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 		if (!(err instanceof FileOperationError) || err.fileOperationResult !== FileOperationResult.FILE_MOVE_CONFLICT) {
 			return false;
 		}
-		if (!(await this._cacheHit(sentinel, expectedSha))) {
+		if (!(await this._cacheHit(sentinel))) {
 			return false;
 		}
-		// Winner already published a matching cache. Drop our scratch dir.
+		// Winner already published a complete cache. Drop our scratch dir.
 		await this._delIgnoringMissing(tmpDirUri);
 		return true;
 	}
 
-	private async _fetchAndVerify(url: string, dest: string, expectedSha: string, token: CancellationToken): Promise<void> {
+	private async _fetch(url: string, dest: string, token: CancellationToken): Promise<void> {
 		// Delegate to IRequestService (corporate proxy, strictSSL, kerberos,
-		// retries, redirect follow). We tee the network stream through a
-		// sha256 hasher AND a write stream so the tarball is verified on
-		// the way in — one pass instead of writing then re-reading.
-		// `fs.createWriteStream` (not `IFileService.writeFile`) so that
-		// cancelling a multi-MB download aborts promptly via destroy().
+		// retries, redirect follow). `fs.createWriteStream` (not
+		// `IFileService.writeFile`) so that cancelling a multi-MB download
+		// aborts promptly via destroy().
 		if (token.isCancellationRequested) {
 			throw new CancellationError();
 		}
@@ -321,7 +343,6 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 			throw new Error(`HTTP ${statusCode} fetching ${url}`);
 		}
 
-		const hash = crypto.createHash('sha256');
 		await new Promise<void>((resolve, reject) => {
 			const out = fs.createWriteStream(dest);
 			let settled = false;
@@ -342,30 +363,16 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 			const cancelSub = token.onCancellationRequested(() => settleReject(new CancellationError()));
 			out.on('error', settleReject);
 			out.on('finish', settleResolve);
-			context.stream.on('data', chunk => { hash.update(chunk.buffer); out.write(chunk.buffer); });
+			context.stream.on('data', chunk => { out.write(chunk.buffer); });
 			context.stream.on('end', () => out.end());
 			context.stream.on('error', settleReject);
 		});
-
-		const actualSha = hash.digest('hex');
-		if (actualSha !== expectedSha) {
-			throw new Error(`sha256 mismatch: expected ${expectedSha}, got ${actualSha}`);
-		}
 	}
 
 	private async _extractTarGz(tarball: string, dest: string): Promise<void> {
 		// `tar` (node-tar) is pure JS — works on every platform the agent host
 		// runs on without depending on a system `tar` binary.
 		await tar.x({ file: tarball, cwd: dest });
-	}
-
-	private async _readFileText(uri: URI): Promise<string> {
-		try {
-			const content = await this._fileService.readFile(uri);
-			return content.value.toString();
-		} catch {
-			return '';
-		}
 	}
 
 	private async _delIgnoringMissing(uri: URI): Promise<void> {

--- a/src/vs/platform/agentHost/node/agentSdkDownloader.ts
+++ b/src/vs/platform/agentHost/node/agentSdkDownloader.ts
@@ -72,7 +72,12 @@ const SUPPORTED_PLATFORMS = new Set<NodeJS.Platform>(['linux', 'darwin', 'win32'
 const SUPPORTED_ARCHES = new Set<string>(['x64', 'arm64']);
 
 /**
- * Resolves the build's `sdkTarget` suffix for the current host:
+ * Resolves the build's `sdkTarget` suffix for the given host. Defaults
+ * to the current Node process — production callers omit `host`; tests
+ * pass a synthetic host to cover targets the test machine can't reach
+ * (Universal launches from a single-arch host, musl Linux on macOS CI,
+ * etc.).
+ *
  *   - claude on glibc Linux: `linux-x64` / `linux-arm64`
  *   - claude on musl Linux:  `linux-x64-musl` / `linux-arm64-musl`
  *   - codex Linux (any libc): `linux-x64` / `linux-arm64`
@@ -169,31 +174,19 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 	 */
 	private readonly _failureLatch = new Map<string, { error: Error; expiresAt: number }>();
 
-	private readonly _host: ISdkTargetHost;
-
 	constructor(
-		/**
-		 * Host info used to resolve `{sdkTarget}` per launch. Pass `undefined`
-		 * (or omit) in production to derive from `process`. Tests pass a
-		 * synthetic host (Universal launches, musl, …) without monkey-
-		 * patching the runtime. Per project convention non-service params
-		 * come before service ones.
-		 */
-		host: ISdkTargetHost | undefined,
 		@INativeEnvironmentService private readonly _environmentService: INativeEnvironmentService,
 		@IProductService private readonly _productService: IProductService,
 		@IRequestService private readonly _requestService: IRequestService,
 		@IFileService private readonly _fileService: IFileService,
 		@ILogService private readonly _logService: ILogService,
-	) {
-		this._host = host ?? { platform: process.platform, arch: process.arch, libc: detectLibc() };
-	}
+	) { }
 
 	isAvailable(pkg: IAgentSdkPackage): boolean {
 		if (process.env[pkg.devOverrideEnvVar]) {
 			return true;
 		}
-		return !!this._productService.agentSdks?.[pkg.id] && resolveSdkTarget(pkg, this._host) !== undefined;
+		return !!this._productService.agentSdks?.[pkg.id] && resolveSdkTarget(pkg) !== undefined;
 	}
 
 	async loadSdkRoot(pkg: IAgentSdkPackage, token: CancellationToken): Promise<string> {
@@ -236,11 +229,11 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 				`no ${pkg.devOverrideEnvVar} dev override set.`,
 			);
 		}
-		const sdkTarget = resolveSdkTarget(pkg, this._host);
+		const sdkTarget = resolveSdkTarget(pkg);
 		if (!sdkTarget) {
 			throw new Error(
 				`Cannot load ${pkg.id} SDK: no SDK target for this host ` +
-				`(${this._host.platform}/${this._host.arch}). ` +
+				`(${process.platform}/${process.arch}). ` +
 				`Set ${pkg.devOverrideEnvVar} to a local SDK root to bypass.`,
 			);
 		}

--- a/src/vs/platform/agentHost/node/agentSdkDownloader.ts
+++ b/src/vs/platform/agentHost/node/agentSdkDownloader.ts
@@ -238,6 +238,17 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 			);
 		}
 		const url = format2(config.urlTemplate, { sdkTarget });
+		// `format2` leaves unknown `{placeholder}` segments untouched; catch
+		// vscode-distro typos like `{sdkTaret}` here instead of letting the
+		// CDN return a 404 against a clearly-broken URL.
+		const stray = /{[^}]+}/.exec(url);
+		if (stray) {
+			throw new Error(
+				`Cannot load ${pkg.id} SDK: \`product.agentSdks.${pkg.id}.urlTemplate\` ` +
+				`contains an unknown placeholder ${stray[0]} — only {sdkTarget} is substituted. ` +
+				`Template: ${config.urlTemplate}`,
+			);
+		}
 
 		const cacheDir = this._cacheDir(pkg.id, config.version, sdkTarget);
 		const sentinel = URI.joinPath(URI.file(cacheDir), '.complete');
@@ -368,7 +379,9 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 		// Delegate to IRequestService (corporate proxy, strictSSL, kerberos,
 		// retries, redirect follow). `fs.createWriteStream` (not
 		// `IFileService.writeFile`) so that cancelling a multi-MB download
-		// aborts promptly via destroy().
+		// aborts promptly via destroy(). Manual pipe (not `stream.pipeline`)
+		// because the source is a VSBufferReadableStream — not a Node
+		// Readable — so node-stream utilities can't introspect it.
 		if (token.isCancellationRequested) {
 			throw new CancellationError();
 		}
@@ -408,7 +421,17 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 			const cancelSub = token.onCancellationRequested(() => settleReject(new CancellationError()));
 			out.on('error', settleReject);
 			out.on('finish', settleResolve);
-			context.stream.on('data', chunk => { out.write(chunk.buffer); });
+			// Backpressure: tarballs are 70-95MB; if the disk is slower
+			// than the network (Windows AV scan, network home dir, …) an
+			// unthrottled pipe buffers the whole thing in memory. Pause the
+			// source when the sink's internal buffer hits highWaterMark and
+			// resume on 'drain'.
+			out.on('drain', () => context.stream.resume());
+			context.stream.on('data', chunk => {
+				if (!out.write(chunk.buffer)) {
+					context.stream.pause();
+				}
+			});
 			context.stream.on('end', () => out.end());
 			context.stream.on('error', settleReject);
 		});

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts
@@ -8,7 +8,6 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { pathToFileURL } from 'url';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { join } from '../../../../base/common/path.js';
-import { detectLibc } from '../../../../base/node/libc.js';
 import { createDecorator } from '../../../instantiation/common/instantiation.js';
 import { ILogService } from '../../../log/common/log.js';
 import { IAgentSdkDownloader, IAgentSdkPackage } from '../agentSdkDownloader.js';
@@ -17,31 +16,15 @@ import { AgentHostClaudeSdkRootEnvVar } from '../../common/agentService.js';
 /**
  * `@anthropic-ai/claude-agent-sdk` distribution descriptor. Lives in this
  * file because it encodes Claude-specific knowledge — the env-var name
- * and the per-host SDK target lookup.
- *
- * Claude ships separate `linux-{x64,arm64}-musl` packages alongside the
- * default `linux-{x64,arm64}` (glibc) ones, so `currentSdkTarget()`
- * appends `-musl` on musl hosts. The downloader consumes this through
+ * and the fact that Claude ships separate `linux-{x64,arm64}-musl` SKUs
+ * alongside the default glibc ones. The downloader consumes this through
  * `IAgentSdkPackage` and never names Claude directly.
  */
 export const ClaudeSdkPackage: IAgentSdkPackage = {
 	id: 'claude',
 	devOverrideEnvVar: AgentHostClaudeSdkRootEnvVar,
-	currentSdkTarget: claudeSdkTarget,
+	hasSeparateMuslLinuxPackage: true,
 };
-
-function claudeSdkTarget(): string | undefined {
-	const platform = process.platform;
-	const arch = process.arch;
-	if ((platform !== 'linux' && platform !== 'darwin' && platform !== 'win32') ||
-		(arch !== 'x64' && arch !== 'arm64')) {
-		return undefined;
-	}
-	if (platform === 'linux' && detectLibc() === 'musl') {
-		return `linux-${arch}-musl`;
-	}
-	return `${platform}-${arch}`;
-}
 
 export const IClaudeAgentSdkService = createDecorator<IClaudeAgentSdkService>('claudeAgentSdkService');
 

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts
@@ -8,6 +8,7 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { pathToFileURL } from 'url';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { join } from '../../../../base/common/path.js';
+import { detectLibc } from '../../../../base/node/libc.js';
 import { createDecorator } from '../../../instantiation/common/instantiation.js';
 import { ILogService } from '../../../log/common/log.js';
 import { IAgentSdkDownloader, IAgentSdkPackage } from '../agentSdkDownloader.js';
@@ -15,14 +16,32 @@ import { AgentHostClaudeSdkRootEnvVar } from '../../common/agentService.js';
 
 /**
  * `@anthropic-ai/claude-agent-sdk` distribution descriptor. Lives in this
- * file because it encodes Claude-specific knowledge — the env-var name.
- * The downloader consumes this through `IAgentSdkPackage` and never names
- * Claude directly.
+ * file because it encodes Claude-specific knowledge — the env-var name
+ * and the per-host SDK target lookup.
+ *
+ * Claude ships separate `linux-{x64,arm64}-musl` packages alongside the
+ * default `linux-{x64,arm64}` (glibc) ones, so `currentSdkTarget()`
+ * appends `-musl` on musl hosts. The downloader consumes this through
+ * `IAgentSdkPackage` and never names Claude directly.
  */
 export const ClaudeSdkPackage: IAgentSdkPackage = {
 	id: 'claude',
 	devOverrideEnvVar: AgentHostClaudeSdkRootEnvVar,
+	currentSdkTarget: claudeSdkTarget,
 };
+
+function claudeSdkTarget(): string | undefined {
+	const platform = process.platform;
+	const arch = process.arch;
+	if ((platform !== 'linux' && platform !== 'darwin' && platform !== 'win32') ||
+		(arch !== 'x64' && arch !== 'arm64')) {
+		return undefined;
+	}
+	if (platform === 'linux' && detectLibc() === 'musl') {
+		return `linux-${arch}-musl`;
+	}
+	return `${platform}-${arch}`;
+}
 
 export const IClaudeAgentSdkService = createDecorator<IClaudeAgentSdkService>('claudeAgentSdkService');
 

--- a/src/vs/platform/agentHost/node/claude/roadmap.md
+++ b/src/vs/platform/agentHost/node/claude/roadmap.md
@@ -1278,12 +1278,15 @@ Exit criteria: ready to enable for external preview.
 
 ### Phase 15 — SDK distribution via `product.json` + main.vscode-cdn.net
 
-**Status as of 2026-06-10:** Runtime shape simplified to per-platform
-`product.json` patching (see
-[`phase15-per-platform-plan.md`](./phase15-per-platform-plan.md)). The
-Claude and Codex SDK distributions are declared in `product.json` and
-downloaded on demand by [`agentSdkDownloader.ts`](../agentSdkDownloader.ts)
-into `<userDataPath>/agent-host/sdk-cache/<pkg>/<sdkVersion>/`. The
+**Status as of 2026-06-12:** Runtime shape is per-SDK `urlTemplate` +
+runtime `{sdkTarget}` substitution (replaced the per-platform
+`{url, sha256}` pair so macOS Universal bundles can share one
+`product.json`; see
+[`phase15-per-platform-plan.md`](./phase15-per-platform-plan.md) and the
+follow-up `urlTemplate` PR). The Claude and Codex SDK distributions are
+declared in `product.json` and downloaded on demand by
+[`agentSdkDownloader.ts`](../agentSdkDownloader.ts) into
+`<userDataPath>/agent-host/sdk-cache/<pkg>/<sdkVersion>/<sdkTarget>/`. The
 hand-supplied paths (`chat.agentHost.claudeAgent.path` →
 `AgentHostClaudeSdkRootEnvVar`, see
 [`claudeAgentSdkService.ts:148`](./claudeAgentSdkService.ts#L148), and the
@@ -1292,34 +1295,38 @@ the download.
 
 **Shape:**
 
-- `product.agentSdks.{claude,codex}` ships a `version`, a `url`, and a
-  single `sha256` string. There is no per-target map at runtime: the
-  build pipeline patches `agentSdks` per-platform during packaging, so
-  a `darwin-arm64` build's `product.json` contains the URL/sha for the
-  `darwin-arm64` SDK tarball, while a `linux-x64` build contains the
-  URL/sha for the `linux-x64` tarball. The shape on disk is always
-  `{ version, url, sha256 }` — the platform suffix appears in the URL,
-  not in the key. Codex's Linux entries never carry the `-musl` suffix
-  in their URL because the Codex binary is statically musl-linked.
+- `product.agentSdks.{claude,codex}` ships a `version` and a
+  `urlTemplate` — a `format2()`-style template with a `{sdkTarget}`
+  placeholder. The runtime resolves `{sdkTarget}` per-launch from
+  `(process.platform, process.arch, libc)` via
+  `IAgentSdkPackage.currentSdkTarget()`. Claude has separate
+  `linux-{x64,arm64}-musl` SKUs; Codex's Linux binary is statically
+  musl-linked so its `currentSdkTarget()` never appends `-musl`.
+  The build pipeline emits the same template across all platforms — no
+  per-platform stamping at packaging time — so a single shipped
+  `product.json` works for macOS Universal bundles that serve both
+  arm64 and x64 launches.
 - `vscode-distro` no longer carries an `agentSdks` fragment — the
   build IS the distribution. OSS `product.json` does not have it either.
-- Tarballs ship as the full `node_modules/` subtree extracted into the
-  cache directory above. `ClaudeAgentSdkService._loadSdk` and
-  `CodexAgent._startConnection` know the package-internal entrypoints
+- Tarballs ship as the full `node_modules/` subtree extracted into
+  `<userDataPath>/agent-host/sdk-cache/<pkg>/<sdkVersion>/<sdkTarget>/`.
+  The `sdkTarget` segment keeps Universal launches with different
+  resolved targets from thrashing a single cache.
+  `ClaudeAgentSdkService._loadSdk` and `CodexAgent._startConnection`
+  know the package-internal entrypoints
   (`@anthropic-ai/claude-agent-sdk/sdk.mjs`, `@openai/codex/bin/codex.js`)
-  and resolve them off the returned root. Codex derives its own
-  `${platform}-${arch}` suffix locally via `codexPackageSuffix()` to
-  construct the binary path; it does NOT read the suffix from
-  `product.json`.
-- Trust: the sha256 in `product.json` (itself inside the signed
-  application bundle and covered by `product.checksums`) is the trust
-  anchor — CDN tampering fails verification. No separate signed
-  manifest.
+  and resolve them off the returned root.
+- Trust: `product.json` lives inside the signed application bundle
+  and its integrity is covered by `product.checksums`; URLs are HTTPS
+  to a Microsoft-controlled CDN. The runtime no longer carries or
+  verifies a per-tarball sha256 — `product.checksums` + HTTPS are the
+  trust chain.
 - Provider registration is gated on
   `IAgentSdkDownloader.isAvailable(pkg)` — true iff the dev-override
-  env var is set, OR `product.agentSdks?.[pkg.id]` is populated. If
-  neither, the provider is not registered and never appears in the
-  agent picker (matches the pre-CDN UX).
+  env var is set, OR (`product.agentSdks?.[pkg.id]` is populated AND
+  `pkg.currentSdkTarget()` resolves). If neither, the provider is not
+  registered and never appears in the agent picker (matches the
+  pre-CDN UX).
 
 **Exit criteria (met for runtime; build is a follow-up PR):**
 - Fresh insiders install can use Claude/Codex without manually

--- a/src/vs/platform/agentHost/node/claude/roadmap.md
+++ b/src/vs/platform/agentHost/node/claude/roadmap.md
@@ -1298,10 +1298,10 @@ the download.
 - `product.agentSdks.{claude,codex}` ships a `version` and a
   `urlTemplate` — a `format2()`-style template with a `{sdkTarget}`
   placeholder. The runtime resolves `{sdkTarget}` per-launch from
-  `(process.platform, process.arch, libc)` via
-  `IAgentSdkPackage.currentSdkTarget()`. Claude has separate
-  `linux-{x64,arm64}-musl` SKUs; Codex's Linux binary is statically
-  musl-linked so its `currentSdkTarget()` never appends `-musl`.
+  `(process.platform, process.arch, libc)` via `resolveSdkTarget(pkg)`
+  in `agentSdkDownloader.ts`, gated by `IAgentSdkPackage`'s
+  `hasSeparateMuslLinuxPackage` flag (Claude: true, Codex: false — its
+  Linux binary is statically musl-linked so a single SKU runs on both).
   The build pipeline emits the same template across all platforms — no
   per-platform stamping at packaging time — so a single shipped
   `product.json` works for macOS Universal bundles that serve both
@@ -1324,7 +1324,7 @@ the download.
 - Provider registration is gated on
   `IAgentSdkDownloader.isAvailable(pkg)` — true iff the dev-override
   env var is set, OR (`product.agentSdks?.[pkg.id]` is populated AND
-  `pkg.currentSdkTarget()` resolves). If neither, the provider is not
+  `resolveSdkTarget(pkg)` resolves). If neither, the provider is not
   registered and never appears in the agent picker (matches the
   pre-CDN UX).
 

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -266,15 +266,15 @@ interface IConnectionReady {
 
 /**
  * `@openai/codex` distribution descriptor. Lives in this file because it
- * encodes Codex-specific knowledge — the env-var name. Codex's Linux
- * binaries are statically musl-linked so a single `linux-*` SKU runs on
- * both glibc and musl hosts; the runtime never needs to know that — the
- * build picks the right SKU per platform. The downloader consumes this
- * through `IAgentSdkPackage` and never names Codex directly.
+ * encodes Codex-specific knowledge — the env-var name and the per-host
+ * SDK target lookup. Codex's Linux binaries are statically musl-linked
+ * so a single `linux-*` SKU runs on both glibc and musl hosts;
+ * `currentSdkTarget()` never returns a `-musl` suffix.
  */
 export const CodexSdkPackage: IAgentSdkPackage = {
 	id: 'codex',
 	devOverrideEnvVar: AgentHostCodexAgentSdkRootEnvVar,
+	currentSdkTarget: () => codexPackageSuffix(process.platform, process.arch),
 };
 
 export class CodexAgent extends Disposable implements IAgent {

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -266,15 +266,14 @@ interface IConnectionReady {
 
 /**
  * `@openai/codex` distribution descriptor. Lives in this file because it
- * encodes Codex-specific knowledge — the env-var name and the per-host
- * SDK target lookup. Codex's Linux binaries are statically musl-linked
- * so a single `linux-*` SKU runs on both glibc and musl hosts;
- * `currentSdkTarget()` never returns a `-musl` suffix.
+ * encodes Codex-specific knowledge — the env-var name and the fact that
+ * Codex's Linux binaries are statically musl-linked and ship as a single
+ * `linux-*` SKU regardless of host libc.
  */
 export const CodexSdkPackage: IAgentSdkPackage = {
 	id: 'codex',
 	devOverrideEnvVar: AgentHostCodexAgentSdkRootEnvVar,
-	currentSdkTarget: () => codexPackageSuffix(process.platform, process.arch),
+	hasSeparateMuslLinuxPackage: false,
 };
 
 export class CodexAgent extends Disposable implements IAgent {

--- a/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
@@ -19,7 +19,7 @@ import type { IFileService } from '../../../files/common/files.js';
 import { DiskFileSystemProvider } from '../../../files/node/diskFileSystemProvider.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { RequestService } from '../../../request/node/requestService.js';
-import { AgentSdkDownloader, resolveSdkTarget, type IAgentSdkPackage, type ISdkTargetHost } from '../../node/agentSdkDownloader.js';
+import { AgentSdkDownloader, resolveSdkTarget, type IAgentSdkPackage } from '../../node/agentSdkDownloader.js';
 import { ClaudeSdkPackage } from '../../node/claude/claudeAgentSdkService.js';
 import { AgentHostClaudeSdkRootEnvVar } from '../../common/agentService.js';
 import type { INativeEnvironmentService } from '../../../environment/common/environment.js';
@@ -117,9 +117,12 @@ function makeFileService(disposables: Pick<DisposableStore, 'add'>): IFileServic
 	return svc;
 }
 
-/** Host that always resolves to a known target on any test machine. */
-const LINUX_X64_GLIBC: ISdkTargetHost = { platform: 'linux', arch: 'x64', libc: 'glibc' };
-
+/**
+ * Unit tests for the platform/arch/libc → sdkTarget mapping. These cover
+ * the cross-product the downloader can't easily exercise (Universal x64
+ * launches from arm64 hosts, musl Linux from a macOS CI runner, …) by
+ * passing a synthetic host directly to the pure function.
+ */
 suite('resolveSdkTarget', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -171,6 +174,11 @@ suite('resolveSdkTarget', () => {
 	});
 });
 
+/**
+ * Integration tests for the downloader's network → cache → extract flow.
+ * These run against whatever `process.platform` the test host is — the
+ * pure `resolveSdkTarget` suite above covers the cross-host matrix.
+ */
 suite('AgentSdkDownloader', () => {
 
 	const disposables = new DisposableStore();
@@ -181,12 +189,25 @@ suite('AgentSdkDownloader', () => {
 	let fixture: ITestSdkDownloadFixture;
 	let server: ITestServer;
 	let originalEnvOverride: string | undefined;
+	/** Whatever the host resolves to — used for cache-dir path assertions. */
+	let hostSdkTarget: string;
 
 	/** A cancellation token whose source is disposed in teardown. */
 	function newToken() {
 		const src = disposables.add(new CancellationTokenSource());
 		return src.token;
 	}
+
+	suiteSetup(function () {
+		// Skip the integration suite on hosts the downloader can't resolve
+		// a target for (e.g. linux-armhf). `resolveSdkTarget` is covered
+		// above and doesn't need a real host.
+		const target = resolveSdkTarget(ClaudeSdkPackage);
+		if (!target) {
+			this.skip();
+		}
+		hostSdkTarget = target;
+	});
 
 	setup(async () => {
 		originalEnvOverride = process.env[AgentHostClaudeSdkRootEnvVar];
@@ -213,16 +234,12 @@ suite('AgentSdkDownloader', () => {
 	 * explicitly. Pass `productConfig: null` to omit the agentSdks block
 	 * entirely (the "no product config" case).
 	 */
-	function makeDownloader(
-		productConfig?: { version?: string; urlTemplate?: string } | null,
-		host: ISdkTargetHost = LINUX_X64_GLIBC,
-	) {
+	function makeDownloader(productConfig?: { version?: string; urlTemplate?: string } | null) {
 		const config = productConfig === null ? undefined : {
 			version: productConfig?.version ?? '1.0.0',
 			urlTemplate: productConfig?.urlTemplate ?? `http://127.0.0.1:${server.port}/sdk-{sdkTarget}.tgz`,
 		};
 		return new AgentSdkDownloader(
-			host,
 			makeEnvService(userDataPath),
 			makeProductService(config),
 			makeRequestService(disposables),
@@ -244,14 +261,6 @@ suite('AgentSdkDownloader', () => {
 		assert.strictEqual(makeDownloader().isAvailable(ClaudeSdkPackage), true);
 	});
 
-	test('isAvailable: false when product config populated but host has no target', () => {
-		// armhf / unsupported-host case: product.json carries agentSdks
-		// (it would, on a Universal-style build) but the runtime has no
-		// matching SKU — we must NOT register the provider.
-		const downloader = makeDownloader(undefined, { platform: 'linux', arch: 'armhf', libc: 'glibc' });
-		assert.strictEqual(downloader.isAvailable(ClaudeSdkPackage), false);
-	});
-
 	test('loadSdkRoot: dev override returns the path unchanged', async () => {
 		process.env[AgentHostClaudeSdkRootEnvVar] = '/path/to/dev/sdk';
 		const root = await makeDownloader(null).loadSdkRoot(ClaudeSdkPackage, newToken());
@@ -259,10 +268,8 @@ suite('AgentSdkDownloader', () => {
 	});
 
 	test('loadSdkRoot: substitutes {sdkTarget} into urlTemplate', async () => {
-		// Claude on musl Linux → -musl suffix lands in the URL.
-		const downloader = makeDownloader(undefined, { platform: 'linux', arch: 'arm64', libc: 'musl' });
-		await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
-		assert.strictEqual(server.lastPath, '/sdk-linux-arm64-musl.tgz');
+		await makeDownloader().loadSdkRoot(ClaudeSdkPackage, newToken());
+		assert.strictEqual(server.lastPath, `/sdk-${hostSdkTarget}.tgz`);
 	});
 
 	test('loadSdkRoot: cache miss → downloads, extracts, writes sentinel', async () => {
@@ -283,35 +290,20 @@ suite('AgentSdkDownloader', () => {
 		assert.strictEqual(server.requestCount, 1, 'cache hit should not re-download');
 	});
 
-	test('loadSdkRoot: different hosts use separate cache dirs and trigger separate downloads', async () => {
-		// Simulates a macOS Universal build: one product.json, two arches
-		// over the lifetime of an install (or two Rosetta-vs-native users).
-		// Each resolved target gets its own cache, no thrash.
-		const arm64Downloader = makeDownloader(undefined, { platform: 'darwin', arch: 'arm64', libc: undefined });
-		const x64Downloader = makeDownloader(undefined, { platform: 'darwin', arch: 'x64', libc: undefined });
-		const arm64Root = await arm64Downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
-		const x64Root = await x64Downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
-		assert.notStrictEqual(arm64Root, x64Root);
-		assert.strictEqual(server.requestCount, 2);
-
-		// Re-fetching the arm64 target hits the cache; the x64 entry doesn't
-		// invalidate it.
-		await arm64Downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
-		assert.strictEqual(server.requestCount, 2, 'sibling target must not invalidate cache');
+	test('loadSdkRoot: cache dir includes sdkTarget so Universal launches stay separate', async () => {
+		// Direct path check that the cache dir layout encodes sdkTarget —
+		// pairs with the resolveSdkTarget unit tests above to cover the
+		// macOS-Universal case (which we can't simulate end-to-end without
+		// injecting a host the production downloader doesn't accept).
+		const root = await makeDownloader().loadSdkRoot(ClaudeSdkPackage, newToken());
+		const expected = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude', '1.0.0', hostSdkTarget);
+		assert.strictEqual(root, expected);
 	});
 
 	test('loadSdkRoot: missing product config and no env override throws actionable error', async () => {
 		await assert.rejects(
 			() => makeDownloader(null).loadSdkRoot(ClaudeSdkPackage, newToken()),
 			/no `product\.agentSdks\.claude` configured/,
-		);
-	});
-
-	test('loadSdkRoot: host with no target throws actionable error', async () => {
-		const downloader = makeDownloader(undefined, { platform: 'linux', arch: 'armhf', libc: 'glibc' });
-		await assert.rejects(
-			() => downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
-			/no SDK target for this host/,
 		);
 	});
 
@@ -338,7 +330,7 @@ suite('AgentSdkDownloader', () => {
 			await new Promise(r => setTimeout(r, 50));
 			cts.cancel();
 			await assert.rejects(() => promise, /Cancel|cancel|Failed to download/);
-			// No half-extracted dir left around. The scratch dir would land at
+			// No half-extracted dir left around. The scratch dir lands at
 			// <userDataPath>/agent-host/sdk-cache/claude/1.0.0/<target>.tmp.<pid>
 			// — a sibling of the resolved target dir under the version dir.
 			const versionDir = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude', '1.0.0');
@@ -371,7 +363,7 @@ suite('AgentSdkDownloader', () => {
 
 	test('loadSdkRoot: rename-loser path returns existing cache when winner already published', async () => {
 		const downloader = makeDownloader();
-		const target = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude', '1.0.0', 'linux-x64');
+		const target = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude', '1.0.0', hostSdkTarget);
 
 		// Pre-populate the cache as if a "winner" already extracted it.
 		await fsp.mkdir(target, { recursive: true });

--- a/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import type * as httpType from 'http';
@@ -20,7 +19,7 @@ import type { IFileService } from '../../../files/common/files.js';
 import { DiskFileSystemProvider } from '../../../files/node/diskFileSystemProvider.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { RequestService } from '../../../request/node/requestService.js';
-import { AgentSdkDownloader } from '../../node/agentSdkDownloader.js';
+import { AgentSdkDownloader, type IAgentSdkPackage } from '../../node/agentSdkDownloader.js';
 import { ClaudeSdkPackage } from '../../node/claude/claudeAgentSdkService.js';
 import { AgentHostClaudeSdkRootEnvVar } from '../../common/agentService.js';
 import type { INativeEnvironmentService } from '../../../environment/common/environment.js';
@@ -28,7 +27,6 @@ import type { IProductService } from '../../../product/common/productService.js'
 
 interface ITestSdkDownloadFixture {
 	tarballPath: string;
-	tarballSha: string;
 	innerFile: string; // path that should exist inside the extracted root
 	innerContents: string;
 	cleanup: () => Promise<void>;
@@ -43,13 +41,8 @@ async function buildFixtureTarball(): Promise<ITestSdkDownloadFixture> {
 	await fsp.writeFile(path.join(stagingDir, innerRel), innerContents);
 	const tarballPath = path.join(stagingDir, 'fixture.tgz');
 	await tar.c({ file: tarballPath, cwd: stagingDir, gzip: true }, ['node_modules']);
-	const tarballSha = crypto
-		.createHash('sha256')
-		.update(await fsp.readFile(tarballPath))
-		.digest('hex');
 	return {
 		tarballPath,
-		tarballSha,
 		innerFile: innerRel,
 		innerContents,
 		cleanup: async () => fsp.rm(stagingDir, { recursive: true, force: true }),
@@ -59,15 +52,17 @@ async function buildFixtureTarball(): Promise<ITestSdkDownloadFixture> {
 interface ITestServer {
 	port: number;
 	requestCount: number;
+	lastPath: string | undefined;
 	close: () => Promise<void>;
 }
 
 async function startServer(body: Buffer): Promise<ITestServer> {
 	const http: typeof httpType = await import('http');
 	return new Promise(resolve => {
-		const state = { count: 0 };
-		const server = http.createServer((_req, res) => {
+		const state = { count: 0, lastPath: undefined as string | undefined };
+		const server = http.createServer((req, res) => {
 			state.count++;
+			state.lastPath = req.url;
 			res.statusCode = 200;
 			res.setHeader('content-type', 'application/octet-stream');
 			res.setHeader('content-length', String(body.length));
@@ -79,6 +74,7 @@ async function startServer(body: Buffer): Promise<ITestServer> {
 			resolve({
 				get port() { return port; },
 				get requestCount() { return state.count; },
+				get lastPath() { return state.lastPath; },
 				close: () => new Promise(res => server.close(() => res())),
 			});
 		});
@@ -93,7 +89,7 @@ function makeEnvService(userDataPath: string): INativeEnvironmentService {
 	return { userDataPath, args: { 'force-disable-user-env': true } as never } as unknown as INativeEnvironmentService;
 }
 
-function makeProductService(config: { version: string; url: string; sha256: string } | undefined): IProductService {
+function makeProductService(config: { version: string; urlTemplate: string } | undefined): IProductService {
 	return {
 		agentSdks: config ? { claude: config } : undefined,
 	} as unknown as IProductService;
@@ -119,6 +115,23 @@ function makeFileService(disposables: Pick<DisposableStore, 'add'>): IFileServic
 	const svc = disposables.add(new FileService(log));
 	disposables.add(svc.registerProvider(Schemas.file, disposables.add(new DiskFileSystemProvider(log))));
 	return svc;
+}
+
+/**
+ * Test package that lets us pin `currentSdkTarget()` from each test — the
+ * production `ClaudeSdkPackage` would resolve to whatever the test host
+ * is, which makes tests depend on `process.platform`.
+ *
+ * Reuses ClaudeSdkPackage's id + devOverrideEnvVar so the
+ * `process.env[AgentHostClaudeSdkRootEnvVar]` short-circuit still works
+ * and so the cache dir lands under `.../claude/...`.
+ */
+function makeTestPackage(currentSdkTarget: string | undefined): IAgentSdkPackage {
+	return {
+		id: ClaudeSdkPackage.id,
+		devOverrideEnvVar: ClaudeSdkPackage.devOverrideEnvVar,
+		currentSdkTarget: () => currentSdkTarget,
+	};
 }
 
 suite('AgentSdkDownloader', () => {
@@ -157,11 +170,13 @@ suite('AgentSdkDownloader', () => {
 		}
 	});
 
-	function makeDownloader(productConfig?: { version?: string; sha256?: string; url?: string }) {
+	function makeDownloader(productConfig?: { version?: string; urlTemplate?: string }) {
+		// Default urlTemplate references `{sdkTarget}` so we exercise the
+		// substitution path; tests that need a custom URL pass urlTemplate
+		// explicitly.
 		const config = {
 			version: productConfig?.version ?? '1.0.0',
-			url: productConfig?.url ?? `http://127.0.0.1:${server.port}/sdk.tgz`,
-			sha256: productConfig?.sha256 ?? fixture.tarballSha,
+			urlTemplate: productConfig?.urlTemplate ?? `http://127.0.0.1:${server.port}/sdk-{sdkTarget}.tgz`,
 		};
 		return new AgentSdkDownloader(
 			makeEnvService(userDataPath),
@@ -180,7 +195,7 @@ suite('AgentSdkDownloader', () => {
 			makeFileService(disposables),
 			new NullLogService(),
 		);
-		assert.strictEqual(downloader.isAvailable(ClaudeSdkPackage), false);
+		assert.strictEqual(downloader.isAvailable(makeTestPackage('linux-x64')), false);
 	});
 
 	test('isAvailable: true when env override set', () => {
@@ -192,12 +207,20 @@ suite('AgentSdkDownloader', () => {
 			makeFileService(disposables),
 			new NullLogService(),
 		);
-		assert.strictEqual(downloader.isAvailable(ClaudeSdkPackage), true);
+		assert.strictEqual(downloader.isAvailable(makeTestPackage('linux-x64')), true);
 	});
 
-	test('isAvailable: true when product config is populated', () => {
+	test('isAvailable: true when product config populated and currentSdkTarget resolves', () => {
 		const downloader = makeDownloader();
-		assert.strictEqual(downloader.isAvailable(ClaudeSdkPackage), true);
+		assert.strictEqual(downloader.isAvailable(makeTestPackage('linux-x64')), true);
+	});
+
+	test('isAvailable: false when product config populated but currentSdkTarget undefined', () => {
+		// armhf / unsupported-host case: product.json carries agentSdks
+		// (it would, on a Universal-style build) but the runtime has no
+		// matching SKU — we must NOT register the provider.
+		const downloader = makeDownloader();
+		assert.strictEqual(downloader.isAvailable(makeTestPackage(undefined)), false);
 	});
 
 	test('loadSdkRoot: dev override returns the path unchanged', async () => {
@@ -209,13 +232,19 @@ suite('AgentSdkDownloader', () => {
 			makeFileService(disposables),
 			new NullLogService(),
 		);
-		const root = await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
+		const root = await downloader.loadSdkRoot(makeTestPackage('linux-x64'), newToken());
 		assert.strictEqual(root, '/path/to/dev/sdk');
 	});
 
-	test('loadSdkRoot: cache miss → downloads, verifies, extracts', async () => {
+	test('loadSdkRoot: substitutes {sdkTarget} into urlTemplate', async () => {
 		const downloader = makeDownloader();
-		const root = await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
+		await downloader.loadSdkRoot(makeTestPackage('linux-arm64-musl'), newToken());
+		assert.strictEqual(server.lastPath, '/sdk-linux-arm64-musl.tgz');
+	});
+
+	test('loadSdkRoot: cache miss → downloads, extracts, writes sentinel', async () => {
+		const downloader = makeDownloader();
+		const root = await downloader.loadSdkRoot(makeTestPackage('linux-x64'), newToken());
 		assert.strictEqual(server.requestCount, 1);
 		const extracted = await fsp.readFile(path.join(root, fixture.innerFile), 'utf8');
 		assert.strictEqual(extracted, fixture.innerContents);
@@ -224,38 +253,28 @@ suite('AgentSdkDownloader', () => {
 
 	test('loadSdkRoot: cache hit returns immediately without re-downloading', async () => {
 		const downloader = makeDownloader();
-		await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
+		await downloader.loadSdkRoot(makeTestPackage('linux-x64'), newToken());
 		assert.strictEqual(server.requestCount, 1);
 
 		// Second call hits the cache.
-		await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
+		await downloader.loadSdkRoot(makeTestPackage('linux-x64'), newToken());
 		assert.strictEqual(server.requestCount, 1, 'cache hit should not re-download');
 	});
 
-	test('loadSdkRoot: stale cache (different sha) is invalidated and re-downloaded', async () => {
+	test('loadSdkRoot: different sdkTargets use separate cache dirs and trigger separate downloads', async () => {
+		// Simulates a macOS Universal build: one product.json, two arches
+		// over the lifetime of an install (or two Rosetta-vs-native users).
+		// Each resolved target gets its own cache, no thrash.
 		const downloader = makeDownloader();
-		const cacheDir = await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
-		assert.strictEqual(server.requestCount, 1);
+		const arm64Root = await downloader.loadSdkRoot(makeTestPackage('darwin-arm64'), newToken());
+		const x64Root = await downloader.loadSdkRoot(makeTestPackage('darwin-x64'), newToken());
+		assert.notStrictEqual(arm64Root, x64Root);
+		assert.strictEqual(server.requestCount, 2);
 
-		// Tamper with the cache: write a different sha into .complete.
-		await fsp.writeFile(path.join(cacheDir, '.complete'), 'a'.repeat(64));
-
-		await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
-		assert.strictEqual(server.requestCount, 2, 'sha mismatch must trigger re-download');
-		// Sentinel restored.
-		const recorded = (await fsp.readFile(path.join(cacheDir, '.complete'), 'utf8')).trim();
-		assert.strictEqual(recorded, fixture.tarballSha);
-	});
-
-	test('loadSdkRoot: sha256 mismatch → throws and leaves no cache dir', async () => {
-		const downloader = makeDownloader({ sha256: 'b'.repeat(64) });
-		await assert.rejects(
-			() => downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
-			/sha256 mismatch|Failed to download/,
-		);
-		// Cache dir absent — only its parent might exist.
-		const target = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude', '1.0.0');
-		assert.strictEqual(fs.existsSync(target), false);
+		// Re-fetching the arm64 target hits the cache; the x64 entry doesn't
+		// invalidate it.
+		await downloader.loadSdkRoot(makeTestPackage('darwin-arm64'), newToken());
+		assert.strictEqual(server.requestCount, 2, 'sibling target must not invalidate cache');
 	});
 
 	test('loadSdkRoot: missing product config and no env override throws actionable error', async () => {
@@ -267,8 +286,16 @@ suite('AgentSdkDownloader', () => {
 			new NullLogService(),
 		);
 		await assert.rejects(
-			() => downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
+			() => downloader.loadSdkRoot(makeTestPackage('linux-x64'), newToken()),
 			/no `product\.agentSdks\.claude` configured/,
+		);
+	});
+
+	test('loadSdkRoot: currentSdkTarget undefined throws actionable error', async () => {
+		const downloader = makeDownloader();
+		await assert.rejects(
+			() => downloader.loadSdkRoot(makeTestPackage(undefined), newToken()),
+			/no SDK target for this host/,
 		);
 	});
 
@@ -289,15 +316,14 @@ suite('AgentSdkDownloader', () => {
 				makeEnvService(userDataPath),
 				makeProductService({
 					version: '1.0.0',
-					url: `http://127.0.0.1:${port}/sdk.tgz`,
-					sha256: fixture.tarballSha,
+					urlTemplate: `http://127.0.0.1:${port}/sdk-{sdkTarget}.tgz`,
 				}),
 				makeRequestService(disposables),
 				makeFileService(disposables),
 				new NullLogService(),
 			);
 			const cts = disposables.add(new CancellationTokenSource());
-			const promise = downloader.loadSdkRoot(ClaudeSdkPackage, cts.token);
+			const promise = downloader.loadSdkRoot(makeTestPackage('linux-x64'), cts.token);
 			// Give the request a moment to start.
 			await new Promise(r => setTimeout(r, 50));
 			cts.cancel();
@@ -305,7 +331,7 @@ suite('AgentSdkDownloader', () => {
 			// No half-extracted dir left around.
 			const targetParent = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude');
 			const leftover = fs.existsSync(targetParent)
-				? (await fsp.readdir(targetParent)).filter(f => f.includes('.tmp.'))
+				? (await listLeftovers(targetParent))
 				: [];
 			assert.deepStrictEqual(leftover, []);
 		} finally {
@@ -322,9 +348,9 @@ suite('AgentSdkDownloader', () => {
 	test('loadSdkRoot: concurrent calls in same process share one download', async () => {
 		const downloader = makeDownloader();
 		const [a, b, c] = await Promise.all([
-			downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
-			downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
-			downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
+			downloader.loadSdkRoot(makeTestPackage('linux-x64'), newToken()),
+			downloader.loadSdkRoot(makeTestPackage('linux-x64'), newToken()),
+			downloader.loadSdkRoot(makeTestPackage('linux-x64'), newToken()),
 		]);
 		assert.strictEqual(a, b);
 		assert.strictEqual(b, c);
@@ -333,17 +359,52 @@ suite('AgentSdkDownloader', () => {
 
 	test('loadSdkRoot: rename-loser path returns existing cache when winner already published', async () => {
 		const downloader = makeDownloader();
-		const target = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude', '1.0.0');
+		const target = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude', '1.0.0', 'linux-x64');
 
 		// Pre-populate the cache as if a "winner" already extracted it.
 		await fsp.mkdir(target, { recursive: true });
 		await fsp.mkdir(path.dirname(path.join(target, fixture.innerFile)), { recursive: true });
 		await fsp.writeFile(path.join(target, fixture.innerFile), fixture.innerContents);
-		await fsp.writeFile(path.join(target, '.complete'), fixture.tarballSha);
+		await fsp.writeFile(path.join(target, '.complete'), 'http://example/anything');
 
 		// loadSdkRoot should hit the cache first and never invoke the server.
-		const root = await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
+		const root = await downloader.loadSdkRoot(makeTestPackage('linux-x64'), newToken());
 		assert.strictEqual(root, target);
 		assert.strictEqual(server.requestCount, 0);
 	});
 });
+
+/**
+ * Walks the `claude/` cache subtree looking for `*.tmp.*` scratch dirs —
+ * sdkTarget partitioning means leftovers live two levels deeper than they
+ * used to.
+ */
+async function listLeftovers(claudeCacheRoot: string): Promise<string[]> {
+	const found: string[] = [];
+	async function walk(dir: string) {
+		let entries: string[];
+		try {
+			entries = await fsp.readdir(dir);
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			if (entry.includes('.tmp.')) {
+				found.push(entry);
+				continue;
+			}
+			const full = path.join(dir, entry);
+			let stat;
+			try {
+				stat = await fsp.stat(full);
+			} catch {
+				continue;
+			}
+			if (stat.isDirectory()) {
+				await walk(full);
+			}
+		}
+	}
+	await walk(claudeCacheRoot);
+	return found;
+}

--- a/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
@@ -19,7 +19,7 @@ import type { IFileService } from '../../../files/common/files.js';
 import { DiskFileSystemProvider } from '../../../files/node/diskFileSystemProvider.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { RequestService } from '../../../request/node/requestService.js';
-import { AgentSdkDownloader, type IAgentSdkPackage } from '../../node/agentSdkDownloader.js';
+import { AgentSdkDownloader, resolveSdkTarget, type IAgentSdkPackage, type ISdkTargetHost } from '../../node/agentSdkDownloader.js';
 import { ClaudeSdkPackage } from '../../node/claude/claudeAgentSdkService.js';
 import { AgentHostClaudeSdkRootEnvVar } from '../../common/agentService.js';
 import type { INativeEnvironmentService } from '../../../environment/common/environment.js';
@@ -117,22 +117,59 @@ function makeFileService(disposables: Pick<DisposableStore, 'add'>): IFileServic
 	return svc;
 }
 
-/**
- * Test package that lets us pin `currentSdkTarget()` from each test — the
- * production `ClaudeSdkPackage` would resolve to whatever the test host
- * is, which makes tests depend on `process.platform`.
- *
- * Reuses ClaudeSdkPackage's id + devOverrideEnvVar so the
- * `process.env[AgentHostClaudeSdkRootEnvVar]` short-circuit still works
- * and so the cache dir lands under `.../claude/...`.
- */
-function makeTestPackage(currentSdkTarget: string | undefined): IAgentSdkPackage {
-	return {
-		id: ClaudeSdkPackage.id,
-		devOverrideEnvVar: ClaudeSdkPackage.devOverrideEnvVar,
-		currentSdkTarget: () => currentSdkTarget,
-	};
-}
+/** Host that always resolves to a known target on any test machine. */
+const LINUX_X64_GLIBC: ISdkTargetHost = { platform: 'linux', arch: 'x64', libc: 'glibc' };
+
+suite('resolveSdkTarget', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function fakePkg(hasSeparateMuslLinuxPackage: boolean): IAgentSdkPackage {
+		return { id: 'test', devOverrideEnvVar: 'X', hasSeparateMuslLinuxPackage };
+	}
+
+	test('returns <platform>-<arch> for supported (platform, arch)', () => {
+		assert.deepStrictEqual({
+			'darwin-x64': resolveSdkTarget(fakePkg(false), { platform: 'darwin', arch: 'x64', libc: undefined }),
+			'darwin-arm64': resolveSdkTarget(fakePkg(false), { platform: 'darwin', arch: 'arm64', libc: undefined }),
+			'linux-x64': resolveSdkTarget(fakePkg(false), { platform: 'linux', arch: 'x64', libc: 'glibc' }),
+			'linux-arm64': resolveSdkTarget(fakePkg(false), { platform: 'linux', arch: 'arm64', libc: 'glibc' }),
+			'win32-x64': resolveSdkTarget(fakePkg(false), { platform: 'win32', arch: 'x64', libc: undefined }),
+			'win32-arm64': resolveSdkTarget(fakePkg(false), { platform: 'win32', arch: 'arm64', libc: undefined }),
+		}, {
+			'darwin-x64': 'darwin-x64',
+			'darwin-arm64': 'darwin-arm64',
+			'linux-x64': 'linux-x64',
+			'linux-arm64': 'linux-arm64',
+			'win32-x64': 'win32-x64',
+			'win32-arm64': 'win32-arm64',
+		});
+	});
+
+	test('appends -musl on musl Linux iff the package has separate musl SKUs', () => {
+		assert.strictEqual(
+			resolveSdkTarget(fakePkg(true), { platform: 'linux', arch: 'x64', libc: 'musl' }),
+			'linux-x64-musl',
+			'claude-style: musl host → -musl suffix',
+		);
+		assert.strictEqual(
+			resolveSdkTarget(fakePkg(false), { platform: 'linux', arch: 'x64', libc: 'musl' }),
+			'linux-x64',
+			'codex-style: musl host → no suffix (statically musl-linked, single SKU)',
+		);
+		assert.strictEqual(
+			resolveSdkTarget(fakePkg(true), { platform: 'linux', arch: 'x64', libc: 'glibc' }),
+			'linux-x64',
+			'claude-style: glibc host → no suffix',
+		);
+	});
+
+	test('returns undefined for unsupported (platform, arch)', () => {
+		assert.strictEqual(resolveSdkTarget(fakePkg(true), { platform: 'linux', arch: 'armhf', libc: 'glibc' }), undefined);
+		assert.strictEqual(resolveSdkTarget(fakePkg(true), { platform: 'freebsd' as NodeJS.Platform, arch: 'x64', libc: undefined }), undefined);
+		assert.strictEqual(resolveSdkTarget(fakePkg(false), { platform: 'darwin', arch: 'ia32', libc: undefined }), undefined);
+	});
+});
 
 suite('AgentSdkDownloader', () => {
 
@@ -170,15 +207,22 @@ suite('AgentSdkDownloader', () => {
 		}
 	});
 
-	function makeDownloader(productConfig?: { version?: string; urlTemplate?: string }) {
-		// Default urlTemplate references `{sdkTarget}` so we exercise the
-		// substitution path; tests that need a custom URL pass urlTemplate
-		// explicitly.
-		const config = {
+	/**
+	 * Default urlTemplate references `{sdkTarget}` so we exercise the
+	 * substitution path; tests that need a custom URL pass urlTemplate
+	 * explicitly. Pass `productConfig: null` to omit the agentSdks block
+	 * entirely (the "no product config" case).
+	 */
+	function makeDownloader(
+		productConfig?: { version?: string; urlTemplate?: string } | null,
+		host: ISdkTargetHost = LINUX_X64_GLIBC,
+	) {
+		const config = productConfig === null ? undefined : {
 			version: productConfig?.version ?? '1.0.0',
 			urlTemplate: productConfig?.urlTemplate ?? `http://127.0.0.1:${server.port}/sdk-{sdkTarget}.tgz`,
 		};
 		return new AgentSdkDownloader(
+			host,
 			makeEnvService(userDataPath),
 			makeProductService(config),
 			makeRequestService(disposables),
@@ -188,63 +232,41 @@ suite('AgentSdkDownloader', () => {
 	}
 
 	test('isAvailable: false when no env override and no product config', () => {
-		const downloader = new AgentSdkDownloader(
-			makeEnvService(userDataPath),
-			makeProductService(undefined),
-			makeRequestService(disposables),
-			makeFileService(disposables),
-			new NullLogService(),
-		);
-		assert.strictEqual(downloader.isAvailable(makeTestPackage('linux-x64')), false);
+		assert.strictEqual(makeDownloader(null).isAvailable(ClaudeSdkPackage), false);
 	});
 
 	test('isAvailable: true when env override set', () => {
 		process.env[AgentHostClaudeSdkRootEnvVar] = '/some/path';
-		const downloader = new AgentSdkDownloader(
-			makeEnvService(userDataPath),
-			makeProductService(undefined),
-			makeRequestService(disposables),
-			makeFileService(disposables),
-			new NullLogService(),
-		);
-		assert.strictEqual(downloader.isAvailable(makeTestPackage('linux-x64')), true);
+		assert.strictEqual(makeDownloader(null).isAvailable(ClaudeSdkPackage), true);
 	});
 
-	test('isAvailable: true when product config populated and currentSdkTarget resolves', () => {
-		const downloader = makeDownloader();
-		assert.strictEqual(downloader.isAvailable(makeTestPackage('linux-x64')), true);
+	test('isAvailable: true when product config populated and host has a target', () => {
+		assert.strictEqual(makeDownloader().isAvailable(ClaudeSdkPackage), true);
 	});
 
-	test('isAvailable: false when product config populated but currentSdkTarget undefined', () => {
+	test('isAvailable: false when product config populated but host has no target', () => {
 		// armhf / unsupported-host case: product.json carries agentSdks
 		// (it would, on a Universal-style build) but the runtime has no
 		// matching SKU — we must NOT register the provider.
-		const downloader = makeDownloader();
-		assert.strictEqual(downloader.isAvailable(makeTestPackage(undefined)), false);
+		const downloader = makeDownloader(undefined, { platform: 'linux', arch: 'armhf', libc: 'glibc' });
+		assert.strictEqual(downloader.isAvailable(ClaudeSdkPackage), false);
 	});
 
 	test('loadSdkRoot: dev override returns the path unchanged', async () => {
 		process.env[AgentHostClaudeSdkRootEnvVar] = '/path/to/dev/sdk';
-		const downloader = new AgentSdkDownloader(
-			makeEnvService(userDataPath),
-			makeProductService(undefined),
-			makeRequestService(disposables),
-			makeFileService(disposables),
-			new NullLogService(),
-		);
-		const root = await downloader.loadSdkRoot(makeTestPackage('linux-x64'), newToken());
+		const root = await makeDownloader(null).loadSdkRoot(ClaudeSdkPackage, newToken());
 		assert.strictEqual(root, '/path/to/dev/sdk');
 	});
 
 	test('loadSdkRoot: substitutes {sdkTarget} into urlTemplate', async () => {
-		const downloader = makeDownloader();
-		await downloader.loadSdkRoot(makeTestPackage('linux-arm64-musl'), newToken());
+		// Claude on musl Linux → -musl suffix lands in the URL.
+		const downloader = makeDownloader(undefined, { platform: 'linux', arch: 'arm64', libc: 'musl' });
+		await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
 		assert.strictEqual(server.lastPath, '/sdk-linux-arm64-musl.tgz');
 	});
 
 	test('loadSdkRoot: cache miss → downloads, extracts, writes sentinel', async () => {
-		const downloader = makeDownloader();
-		const root = await downloader.loadSdkRoot(makeTestPackage('linux-x64'), newToken());
+		const root = await makeDownloader().loadSdkRoot(ClaudeSdkPackage, newToken());
 		assert.strictEqual(server.requestCount, 1);
 		const extracted = await fsp.readFile(path.join(root, fixture.innerFile), 'utf8');
 		assert.strictEqual(extracted, fixture.innerContents);
@@ -253,48 +275,42 @@ suite('AgentSdkDownloader', () => {
 
 	test('loadSdkRoot: cache hit returns immediately without re-downloading', async () => {
 		const downloader = makeDownloader();
-		await downloader.loadSdkRoot(makeTestPackage('linux-x64'), newToken());
+		await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
 		assert.strictEqual(server.requestCount, 1);
 
 		// Second call hits the cache.
-		await downloader.loadSdkRoot(makeTestPackage('linux-x64'), newToken());
+		await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
 		assert.strictEqual(server.requestCount, 1, 'cache hit should not re-download');
 	});
 
-	test('loadSdkRoot: different sdkTargets use separate cache dirs and trigger separate downloads', async () => {
+	test('loadSdkRoot: different hosts use separate cache dirs and trigger separate downloads', async () => {
 		// Simulates a macOS Universal build: one product.json, two arches
 		// over the lifetime of an install (or two Rosetta-vs-native users).
 		// Each resolved target gets its own cache, no thrash.
-		const downloader = makeDownloader();
-		const arm64Root = await downloader.loadSdkRoot(makeTestPackage('darwin-arm64'), newToken());
-		const x64Root = await downloader.loadSdkRoot(makeTestPackage('darwin-x64'), newToken());
+		const arm64Downloader = makeDownloader(undefined, { platform: 'darwin', arch: 'arm64', libc: undefined });
+		const x64Downloader = makeDownloader(undefined, { platform: 'darwin', arch: 'x64', libc: undefined });
+		const arm64Root = await arm64Downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
+		const x64Root = await x64Downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
 		assert.notStrictEqual(arm64Root, x64Root);
 		assert.strictEqual(server.requestCount, 2);
 
 		// Re-fetching the arm64 target hits the cache; the x64 entry doesn't
 		// invalidate it.
-		await downloader.loadSdkRoot(makeTestPackage('darwin-arm64'), newToken());
+		await arm64Downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
 		assert.strictEqual(server.requestCount, 2, 'sibling target must not invalidate cache');
 	});
 
 	test('loadSdkRoot: missing product config and no env override throws actionable error', async () => {
-		const downloader = new AgentSdkDownloader(
-			makeEnvService(userDataPath),
-			makeProductService(undefined),
-			makeRequestService(disposables),
-			makeFileService(disposables),
-			new NullLogService(),
-		);
 		await assert.rejects(
-			() => downloader.loadSdkRoot(makeTestPackage('linux-x64'), newToken()),
+			() => makeDownloader(null).loadSdkRoot(ClaudeSdkPackage, newToken()),
 			/no `product\.agentSdks\.claude` configured/,
 		);
 	});
 
-	test('loadSdkRoot: currentSdkTarget undefined throws actionable error', async () => {
-		const downloader = makeDownloader();
+	test('loadSdkRoot: host with no target throws actionable error', async () => {
+		const downloader = makeDownloader(undefined, { platform: 'linux', arch: 'armhf', libc: 'glibc' });
 		await assert.rejects(
-			() => downloader.loadSdkRoot(makeTestPackage(undefined), newToken()),
+			() => downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
 			/no SDK target for this host/,
 		);
 	});
@@ -312,26 +328,22 @@ suite('AgentSdkDownloader', () => {
 		await new Promise<void>(r => hangingServer.listen(0, '127.0.0.1', () => r()));
 		const port = (hangingServer.address() as { port: number }).port;
 		try {
-			const downloader = new AgentSdkDownloader(
-				makeEnvService(userDataPath),
-				makeProductService({
-					version: '1.0.0',
-					urlTemplate: `http://127.0.0.1:${port}/sdk-{sdkTarget}.tgz`,
-				}),
-				makeRequestService(disposables),
-				makeFileService(disposables),
-				new NullLogService(),
-			);
+			const downloader = makeDownloader({
+				version: '1.0.0',
+				urlTemplate: `http://127.0.0.1:${port}/sdk-{sdkTarget}.tgz`,
+			});
 			const cts = disposables.add(new CancellationTokenSource());
-			const promise = downloader.loadSdkRoot(makeTestPackage('linux-x64'), cts.token);
+			const promise = downloader.loadSdkRoot(ClaudeSdkPackage, cts.token);
 			// Give the request a moment to start.
 			await new Promise(r => setTimeout(r, 50));
 			cts.cancel();
 			await assert.rejects(() => promise, /Cancel|cancel|Failed to download/);
-			// No half-extracted dir left around.
-			const targetParent = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude');
-			const leftover = fs.existsSync(targetParent)
-				? (await listLeftovers(targetParent))
+			// No half-extracted dir left around. The scratch dir would land at
+			// <userDataPath>/agent-host/sdk-cache/claude/1.0.0/<target>.tmp.<pid>
+			// — a sibling of the resolved target dir under the version dir.
+			const versionDir = path.join(userDataPath, 'agent-host', 'sdk-cache', 'claude', '1.0.0');
+			const leftover = fs.existsSync(versionDir)
+				? (await fsp.readdir(versionDir)).filter(f => f.includes('.tmp.'))
 				: [];
 			assert.deepStrictEqual(leftover, []);
 		} finally {
@@ -348,9 +360,9 @@ suite('AgentSdkDownloader', () => {
 	test('loadSdkRoot: concurrent calls in same process share one download', async () => {
 		const downloader = makeDownloader();
 		const [a, b, c] = await Promise.all([
-			downloader.loadSdkRoot(makeTestPackage('linux-x64'), newToken()),
-			downloader.loadSdkRoot(makeTestPackage('linux-x64'), newToken()),
-			downloader.loadSdkRoot(makeTestPackage('linux-x64'), newToken()),
+			downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
+			downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
+			downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
 		]);
 		assert.strictEqual(a, b);
 		assert.strictEqual(b, c);
@@ -365,46 +377,11 @@ suite('AgentSdkDownloader', () => {
 		await fsp.mkdir(target, { recursive: true });
 		await fsp.mkdir(path.dirname(path.join(target, fixture.innerFile)), { recursive: true });
 		await fsp.writeFile(path.join(target, fixture.innerFile), fixture.innerContents);
-		await fsp.writeFile(path.join(target, '.complete'), 'http://example/anything');
+		await fsp.writeFile(path.join(target, '.complete'), '');
 
 		// loadSdkRoot should hit the cache first and never invoke the server.
-		const root = await downloader.loadSdkRoot(makeTestPackage('linux-x64'), newToken());
+		const root = await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
 		assert.strictEqual(root, target);
 		assert.strictEqual(server.requestCount, 0);
 	});
 });
-
-/**
- * Walks the `claude/` cache subtree looking for `*.tmp.*` scratch dirs —
- * sdkTarget partitioning means leftovers live two levels deeper than they
- * used to.
- */
-async function listLeftovers(claudeCacheRoot: string): Promise<string[]> {
-	const found: string[] = [];
-	async function walk(dir: string) {
-		let entries: string[];
-		try {
-			entries = await fsp.readdir(dir);
-		} catch {
-			return;
-		}
-		for (const entry of entries) {
-			if (entry.includes('.tmp.')) {
-				found.push(entry);
-				continue;
-			}
-			const full = path.join(dir, entry);
-			let stat;
-			try {
-				stat = await fsp.stat(full);
-			} catch {
-				continue;
-			}
-			if (stat.isDirectory()) {
-				await walk(full);
-			}
-		}
-	}
-	await walk(claudeCacheRoot);
-	return found;
-}

--- a/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
@@ -307,6 +307,20 @@ suite('AgentSdkDownloader', () => {
 		);
 	});
 
+	test('loadSdkRoot: urlTemplate with unknown placeholder throws config error', async () => {
+		// vscode-distro typo guard: `{sdkTaret}` left untouched by format2
+		// would otherwise yield a 404 from the CDN with no hint at the
+		// real cause.
+		const downloader = makeDownloader({
+			urlTemplate: `http://127.0.0.1:${server.port}/sdk-{sdkTaret}.tgz`,
+		});
+		await assert.rejects(
+			() => downloader.loadSdkRoot(ClaudeSdkPackage, newToken()),
+			/unknown placeholder \{sdkTaret\}/,
+		);
+		assert.strictEqual(server.requestCount, 0, 'should fail before any HTTP call');
+	});
+
 	test('loadSdkRoot: cancel before download completes cleans up scratch dir', async function () {
 		this.timeout(15_000);
 		// Replace server with one that hangs forever.

--- a/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
@@ -462,6 +462,7 @@ class RoundTripQuery implements AsyncGenerator<SDKMessage, void> {
 	supportedAgents(): never { throw new Error('not modeled'); }
 	mcpServerStatus(): never { throw new Error('not modeled'); }
 	getContextUsage(): never { throw new Error('not modeled'); }
+	usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET(): never { throw new Error('not modeled'); }
 	reloadPlugins(): never { throw new Error('not modeled'); }
 	accountInfo(): never { throw new Error('not modeled'); }
 	rewindFiles(): never { throw new Error('not modeled'); }

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -463,6 +463,7 @@ class FakeQuery implements AsyncGenerator<SDKMessage, void> {
 	supportedAgents(): never { throw new Error('FakeQuery: supportedAgents not modeled'); }
 	mcpServerStatus(): never { throw new Error('FakeQuery: mcpServerStatus not modeled'); }
 	getContextUsage(): never { throw new Error('FakeQuery: getContextUsage not modeled'); }
+	usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET(): never { throw new Error('FakeQuery: usage_EXPERIMENTAL not modeled'); }
 	/** Phase 11 — programmable tool-name snapshot returned by `reloadPlugins()`. */
 	reloadPluginsResults: readonly string[][] = [];
 	reloadPluginsCallCount = 0;

--- a/src/vs/platform/agentHost/test/node/claudeSdkPipeline.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeSdkPipeline.test.ts
@@ -72,6 +72,7 @@ class ImmediatelyDoneQuery implements Query {
 	supportedAgents(): never { throw new Error('not modeled'); }
 	mcpServerStatus(): never { throw new Error('not modeled'); }
 	getContextUsage(): never { throw new Error('not modeled'); }
+	usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET(): never { throw new Error('not modeled'); }
 	reloadPlugins(): never { throw new Error('not modeled'); }
 	accountInfo(): never { throw new Error('not modeled'); }
 	rewindFiles(): never { throw new Error('not modeled'); }

--- a/src/vs/platform/agentHost/test/node/codex/codexPackagePaths.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPackagePaths.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { CodexSdkPackage, codexBinaryTriple, codexPackageSuffix } from '../../../node/codex/codexAgent.js';
+import { codexBinaryTriple, codexPackageSuffix } from '../../../node/codex/codexAgent.js';
 
 suite('codex package paths', () => {
 
@@ -14,7 +14,7 @@ suite('codex package paths', () => {
 	suite('codexPackageSuffix', () => {
 
 		test('every supported (platform, arch) returns the npm optionalDependencies suffix', () => {
-			// The downloader and the build pipeline both rely on the runtime
+			// The build pipeline and codexBinaryTriple both rely on the runtime
 			// reaching exactly one of these strings. New supported platforms
 			// must update this table, the build's `getSdkTargetForBuild`, AND
 			// codexBinaryTriple in lockstep.
@@ -82,21 +82,6 @@ suite('codex package paths', () => {
 			assert.strictEqual(codexBinaryTriple('linux-x64-musl'), undefined);
 			assert.strictEqual(codexBinaryTriple('darwin-arm'), undefined);
 			assert.strictEqual(codexBinaryTriple(''), undefined);
-		});
-	});
-
-	suite('CodexSdkPackage.currentSdkTarget', () => {
-
-		test('agrees with codexPackageSuffix(process.platform, process.arch) for the current host', () => {
-			// The downloader resolves the per-host SDK target through
-			// `CodexSdkPackage.currentSdkTarget()`; the build pipeline and
-			// _startConnection both still use `codexPackageSuffix` directly.
-			// They must agree so the cache directory and the spawn lookup
-			// stay in lockstep.
-			assert.strictEqual(
-				CodexSdkPackage.currentSdkTarget(),
-				codexPackageSuffix(process.platform, process.arch),
-			);
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/codex/codexPackagePaths.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexPackagePaths.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { codexBinaryTriple, codexPackageSuffix } from '../../../node/codex/codexAgent.js';
+import { CodexSdkPackage, codexBinaryTriple, codexPackageSuffix } from '../../../node/codex/codexAgent.js';
 
 suite('codex package paths', () => {
 
@@ -82,6 +82,21 @@ suite('codex package paths', () => {
 			assert.strictEqual(codexBinaryTriple('linux-x64-musl'), undefined);
 			assert.strictEqual(codexBinaryTriple('darwin-arm'), undefined);
 			assert.strictEqual(codexBinaryTriple(''), undefined);
+		});
+	});
+
+	suite('CodexSdkPackage.currentSdkTarget', () => {
+
+		test('agrees with codexPackageSuffix(process.platform, process.arch) for the current host', () => {
+			// The downloader resolves the per-host SDK target through
+			// `CodexSdkPackage.currentSdkTarget()`; the build pipeline and
+			// _startConnection both still use `codexPackageSuffix` directly.
+			// They must agree so the cache directory and the spawn lookup
+			// stay in lockstep.
+			assert.strictEqual(
+				CodexSdkPackage.currentSdkTarget(),
+				codexPackageSuffix(process.platform, process.arch),
+			);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Build-pipeline side of agent SDK distribution. **Stacked on top of #321078** (runtime side). Merge #321078 first, then this PR.

Per-platform VS Code build jobs (darwin/linux/win32/alpine) produce + (optionally) upload the Claude and Codex agent SDK tarballs to `main.vscode-cdn.net`, then stamp `{version, urlTemplate}` into `product.agentSdks` of their own packaged `product.json`. The runtime substitutes `{sdkTarget}` per launch via `resolveSdkTarget()` (see #321078) — so a macOS Universal bundle can share one `product.json` across arm64 + x64.

Tracks https://github.com/microsoft/vscode-internalbacklog/issues/7885.

## How it works

- New `build/agent-sdk/` directory with the producer scripts (see `build/agent-sdk/README.md`).
- New shared template `build/azure-pipelines/common/agent-sdk-produce.yml` that each platform job pulls in before its existing gulp packaging step. The template runs `node build/agent-sdk/produce.ts --vscode-platform=<x> --arch=$(VSCODE_ARCH)`, which:
  - Builds tarballs for every `(vscode-platform, arch, sdk)` triple that applies (e.g. Linux jobs build `claude-linux-x64` + `codex-linux-x64`; Alpine jobs build `claude-linux-*-musl` + `codex-linux-*`).
  - On `VSCODE_PUBLISH=true`: uploads each tarball (HEAD-then-decide idempotent), writes a results JSON containing `{version, urlTemplate}` per SDK, and emits `##vso[task.setvariable variable=AGENT_SDK_RESULTS_FILE]<path>`. The downstream gulp packaging step reads it inside `packageTask`'s `jsonEditor` callback and stamps `product.agentSdks`. Every platform job writes the SAME `urlTemplate` per SDK — only the per-SDK version differs.
  - On non-publish runs: skips the CDN credential fetch + upload entirely. Tarballs are still produced and published as a pipeline artifact (`agent_sdk_<platform>_<arch>_tarballs`) for inspection. product.json ships without `agentSdks` — same shape as a local dev build.
- The REH gulpfile only writes `agentSdks` for `type === 'reh'`; REH-web skips it because the agent host is node-only.

## Test plan

Verified once already on builds 446923 (non-publish) and 446990 (publish):

- [x] Non-publish run: "Agent SDK: fetch CDN credentials" skipped, "Agent SDK: build + upload" runs, `agent_sdk_*_tarballs` artifacts published from every platform job, product.json without `agentSdks`. Linux armhf skipped.
- [x] Publish run: tarballs at `https://main.vscode-cdn.net/agent-sdk/<sdk>/<version>/<target>.tgz`, byte-identical to non-publish artifacts, cache-control `immutable`, product.json stamped.
- [x] Determinism across runs: codex linux-arm64 (built on both Linux arm64 + Alpine arm64 jobs) byte-identical.
- [x] Runtime end-to-end against the real CDN: Code OSS launches with `agentSdks` from product.json, both Claude + Codex download from `main.vscode-cdn.net` and run sessions successfully.

After this PR rebased onto #321078, one more run needed to confirm the new `{urlTemplate}` shape lands correctly in product.json (the CDN content itself is unchanged — same tarballs, same blob URLs, just the runtime metadata is the new shape).

- [ ] One more non-publish + publish run on the rebased branch to confirm `product.agentSdks` contains `{version, urlTemplate}` not `{version, url, sha256}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)