### PR TITLE
sessions: fix race where in-flight Claude session is spuriously removed

### DIFF
--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -1980,11 +1980,11 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		this._sessionCache.set(session.resource.toString(), session);
 		this._invalidateGroupingCaches();
 
-		// For Claude sessions, chatResource is already the committed resource
-		// (returned by createNewChatSessionItem). Protect it from spurious
-		// removal by _refreshSessionCache before any async work begins —
-		// a concurrent model re-resolve can transiently drop the session from
-		// agentSessionsService.model.sessions, which would otherwise cause
+		// For non-CLI sessions, chatResource is already the resource we will later
+		// wait for in the committed session cache. Protect it from spurious
+		// removal by _refreshSessionCache before any async work begins — a
+		// concurrent model re-resolve can transiently drop the session from
+		// agentSessionsService.model.sessions while the send is still in-flight.
 		// _refreshSessionCache to fire a `removed` event that tears down the
 		// UI while the send is still in-flight.
 		const committedKey = !(session instanceof CopilotCLISession)

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -1386,6 +1386,15 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	/** Cache of adapted sessions, keyed by resource URI string. */
 	private readonly _sessionCache = new Map<string, AgentSessionAdapter | CopilotCLISession | RemoteNewSession | ClaudeCodeNewSession>();
 
+	/**
+	 * Resources of committed sessions that are currently in-flight (i.e.
+	 * between {@link _sendFirstChat} entering the send and the replace
+	 * event firing). Protected from spurious removal by
+	 * {@link _refreshSessionCache} so that a concurrent model re-resolve
+	 * cannot transiently drop them.
+	 */
+	private readonly _inFlightCommits = new Set<string>();
+
 	/** Cache of ISession wrappers, keyed by session group ID. */
 	private readonly _sessionGroupCache = new Map<string, ISession>();
 
@@ -1971,6 +1980,20 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		this._sessionCache.set(session.resource.toString(), session);
 		this._invalidateGroupingCaches();
 
+		// For Claude sessions, chatResource is already the committed resource
+		// (returned by createNewChatSessionItem). Protect it from spurious
+		// removal by _refreshSessionCache before any async work begins —
+		// a concurrent model re-resolve can transiently drop the session from
+		// agentSessionsService.model.sessions, which would otherwise cause
+		// _refreshSessionCache to fire a `removed` event that tears down the
+		// UI while the send is still in-flight.
+		const committedKey = !(session instanceof CopilotCLISession)
+			? chatResource.toString()
+			: undefined;
+		if (committedKey) {
+			this._inFlightCommits.add(committedKey);
+		}
+
 		// Add the new session to the sessions model immediately so it appears in the sessions list
 		const newSession = this._chatToSession(session);
 		this._onDidChangeSessions.fire({ added: [newSession], removed: [], changed: [] });
@@ -2040,18 +2063,26 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 				let committedResource = chatResource;
 				if (session instanceof CopilotCLISession) {
 					committedResource = await this._waitForCommittedSession(session.resource, responseCompletePromise, responseCreatedPromise);
+					// For CopilotCLI, protect the committed resource now that
+					// we know it (Claude sessions were already protected at the
+					// top of _sendFirstChat).
+					this._inFlightCommits.add(committedResource.toString());
 				}
 
-				// Wait for _refreshSessionCache to populate the committed adapter
-				const committedChat = await this._waitForSessionInCache(committedResource, cts.token);
-				this._sessionCache.delete(session.resource.toString());
-				this._clearCurrentNewSessionIfMatch(session);
+				try {
+					// Wait for _refreshSessionCache to populate the committed adapter
+					const committedChat = await this._waitForSessionInCache(committedResource, cts.token);
+					this._sessionCache.delete(session.resource.toString());
+					this._clearCurrentNewSessionIfMatch(session);
 
-				const committedSession = this._chatToSession(committedChat);
-				this._sessionGroupCache.delete(session.sessionId);
-				this._onDidReplaceSession.fire({ from: newSession, to: committedSession });
+					const committedSession = this._chatToSession(committedChat);
+					this._sessionGroupCache.delete(session.sessionId);
+					this._onDidReplaceSession.fire({ from: newSession, to: committedSession });
 
-				return committedSession;
+					return committedSession;
+				} finally {
+					this._inFlightCommits.delete(committedResource.toString());
+				}
 			} catch (error) {
 				this._clearCurrentNewSessionIfMatch(session, /* leak */ true);
 
@@ -2075,6 +2106,9 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			this.logService.error(`[CopilotChatSessionsProvider] Failed to send first chat for session ${session.sessionId}:`, error);
 			throw error;
 		} finally {
+			if (committedKey) {
+				this._inFlightCommits.delete(committedKey);
+			}
 			ref?.dispose();
 		}
 	}
@@ -2552,7 +2586,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 		const removedData: ICopilotChatSession[] = [];
 		for (const [key, adapter] of this._sessionCache) {
-			if (!currentKeys.has(key) && adapter instanceof AgentSessionAdapter) {
+			if (!currentKeys.has(key) && adapter instanceof AgentSessionAdapter && !this._inFlightCommits.has(key)) {
 				removedData.push(adapter);
 				cacheChanged = true;
 			}

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
@@ -1314,4 +1314,54 @@ suite('CopilotChatSessionsProvider', () => {
 			assert.strictEqual(session?.permissionLevel.get(), ChatPermissionLevel.Default);
 		});
 	});
+
+	// ---- In-flight commit protection -------
+
+	test('concurrent model re-resolve does not spuriously remove an in-flight committed session', async () => {
+		// This reproduces the race condition from the smoke test failure:
+		// 1. Claude session is created and committed (added to model)
+		// 2. _sendFirstChat is waiting for the committed adapter in the cache
+		// 3. A concurrent model re-resolve transiently removes the session
+		//    from agentSessionsService.model.sessions
+		// 4. _refreshSessionCache should NOT fire `removed` for the in-flight
+		//    session because it is protected by _inFlightCommits
+
+		const { provider, commitSession, realResource } = makeClaudeInFlightProvider();
+		const workspace = URI.file('/test/project');
+		const session = provider.createNewSession(workspace, ClaudeCodeSessionType.id);
+
+		const removals: string[] = [];
+		disposables.add(provider.onDidChangeSessions(e => {
+			for (const r of e.removed) {
+				removals.push(r.resource.toString());
+			}
+		}));
+
+		const added = waitForSessionAdded(provider);
+		const chat = await provider.createNewChat(session.sessionId);
+		const sendPromise = provider.sendRequest(session.sessionId, chat.resource, { query: 'test' });
+		await added;
+
+		// Commit: adds the real session to the model, triggering
+		// _refreshSessionCache which populates the AgentSessionAdapter.
+		commitSession();
+
+		// Simulate a concurrent model re-resolve transiently dropping the
+		// session: remove it from the model (fires onDidChangeSessions →
+		// _refreshSessionCache). Because _sendFirstChat holds the resource
+		// in _inFlightCommits, _refreshSessionCache must NOT fire `removed`.
+		model.removeSession(realResource);
+
+		// The committed session resource must NOT appear in removals
+		assert.ok(
+			!removals.includes(realResource.toString()),
+			`In-flight committed session ${realResource.toString()} should not be spuriously removed. ` +
+			`Removals seen: [${removals.join(', ')}]`,
+		);
+
+		// Re-add the session so _waitForSessionInCache can resolve
+		model.addSession(createMockAgentSession(realResource, { providerType: AgentSessionProviders.Claude }));
+
+		await sendPromise;
+	});
 });


### PR DESCRIPTION
Failure seen in https://dev.azure.com/monacotools/Monaco/_build/results?buildId=446858&view=logs&j=e352877c-ff47-5dec-32e2-b206099d9704&t=131e513a-8446-56e2-5be5-256b681ae93e

---

## Problem

The "Test Claude session" smoke test intermittently fails because a committed Claude session gets spuriously removed during the send lifecycle. The test times out waiting for `MOCKED_CLAUDE_RESPONSE` because the session's UI is torn down mid-flight.

### Root Cause

`_refreshSessionCache()` in `CopilotChatSessionsProvider` diffs the provider's `_sessionCache` against `agentSessionsService.model.sessions`. When a concurrent model re-resolve (`AgentSessionsModel.doResolveProvider`) replaces the entire `_sessions` map, a recently committed session can transiently disappear from the model. This causes `_refreshSessionCache` to fire a `removed` event, which cascades to:

- **View service**: removes the session from the UI grid
- **Terminal cleanup**: closes terminals for the session's CWD

### Timeline from failed smoke test

```
11:11:49.614 - Active session changed to claude-code:/08fe (committed)  
11:11:49.647 - onDidChangeSessions cleanup: untitled removed [CORRECT]  
11:11:50.196 - Active session changed: new untitled created  
11:11:50.220 - onDidChangeSessions cleanup: /08fe removed [BUG — session still in-flight]  
```

In the working run, the committed session is never removed.

## Fix

Added an `_inFlightCommits` set to `CopilotChatSessionsProvider` that tracks committed session resources during the `_sendFirstChat` lifecycle:

- For Claude sessions: the committed resource is protected eagerly at the start of `_sendFirstChat` (since `chatResource` is already the committed resource from `createNewChatSessionItem`)
- For CopilotCLI sessions: protection is deferred until after `_waitForCommittedSession` resolves
- `_refreshSessionCache` skips removing any session whose key is in `_inFlightCommits`

## Test

Added unit test `concurrent model re-resolve does not spuriously remove an in-flight committed session` that reproduces the exact race condition: starts a Claude send, commits the session, then simulates a concurrent model re-resolve removing the session from the model. Verifies the `removed` event is NOT fired for the in-flight session.