### PR TITLE
 decouples the Copilot extension's telemetry module  in AH

### DIFF
--- a/extensions/copilot/src/platform/telemetry/common/failingTelemetryReporter.ts
+++ b/extensions/copilot/src/platform/telemetry/common/failingTelemetryReporter.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { TelemetrySender } from 'vscode';
+import { ITelemetrySenderApi } from './telemetry';
 
-export class FailingTelemetryReporter implements TelemetrySender {
+export class FailingTelemetryReporter implements ITelemetrySenderApi {
 	sendEventData(eventName: string, data?: Record<string, any> | undefined): void {
 		throw new Error('Telemetry disabled');
 	}

--- a/extensions/copilot/src/platform/telemetry/common/ghTelemetrySender.ts
+++ b/extensions/copilot/src/platform/telemetry/common/ghTelemetrySender.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { TelemetryLogger } from 'vscode';
 import { redactPaths } from '../../../util/common/pathRedaction';
 import { DisposableStore } from '../../../util/vs/base/common/lifecycle';
 import { Mutable } from '../../../util/vs/base/common/types';
@@ -12,18 +11,18 @@ import { ICopilotTokenStore } from '../../authentication/common/copilotTokenStor
 import { IConfigurationService } from '../../configuration/common/configurationService';
 import { IDomainService } from '../../endpoint/common/domainService';
 import { IEnvService } from '../../env/common/envService';
-import { ITelemetrySender, ITelemetryUserConfig, TelemetryEventMeasurements, TelemetryEventProperties, TelemetryTrustedValue } from '../common/telemetry';
+import { ITelemetryLoggerApi, ITelemetrySender, ITelemetryUserConfig, TelemetryEventMeasurements, TelemetryEventProperties, TelemetryTrustedValue } from '../common/telemetry';
 import { TelemetryData, eventPropertiesToSimpleObject } from '../common/telemetryData';
 
 
 export class BaseGHTelemetrySender implements ITelemetrySender {
 	protected readonly _disposables: DisposableStore = new DisposableStore();
-	private _standardTelemetryLogger: TelemetryLogger;
-	private _enhancedTelemetryLogger?: TelemetryLogger;
+	private _standardTelemetryLogger: ITelemetryLoggerApi;
+	private _enhancedTelemetryLogger?: ITelemetryLoggerApi;
 
 	constructor(
 		private readonly _tokenStore: ICopilotTokenStore,
-		protected readonly _createTelemetryLogger: (enhanced: boolean) => TelemetryLogger,
+		protected readonly _createTelemetryLogger: (enhanced: boolean) => ITelemetryLoggerApi,
 		private readonly _configService: IConfigurationService,
 		private readonly _telemetryConfig: ITelemetryUserConfig,
 		protected readonly _envService: IEnvService,

--- a/extensions/copilot/src/platform/telemetry/common/ghTelemetryService.ts
+++ b/extensions/copilot/src/platform/telemetry/common/ghTelemetryService.ts
@@ -3,21 +3,20 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { TelemetrySender } from 'vscode';
 import { redactPaths } from '../../../util/common/pathRedaction';
 import { IConfigurationService } from '../../configuration/common/configurationService';
 import { IEnvService } from '../../env/common/envService';
 import { FailingTelemetryReporter } from './failingTelemetryReporter';
-import { IGHTelemetryService, ITelemetryUserConfig } from './telemetry';
+import { IGHTelemetryService, ITelemetrySenderApi, ITelemetryUserConfig } from './telemetry';
 import { TelemetryData } from './telemetryData';
 
 
 // A container for the secure and insecure reporters
 class TelemetryReporters {
-	private reporter: TelemetrySender | undefined;
-	private reporterSecure: TelemetrySender | undefined;
+	private reporter: ITelemetrySenderApi | undefined;
+	private reporterSecure: ITelemetrySenderApi | undefined;
 
-	public getReporter(telemetryUserConfig: ITelemetryUserConfig, isTest: boolean, secure: boolean): TelemetrySender | undefined {
+	public getReporter(telemetryUserConfig: ITelemetryUserConfig, isTest: boolean, secure: boolean): ITelemetrySenderApi | undefined {
 		if (!secure) {
 			return this.reporter;
 		}
@@ -33,10 +32,10 @@ class TelemetryReporters {
 		}
 		return undefined;
 	}
-	public setReporter(reporter: TelemetrySender | undefined): void {
+	public setReporter(reporter: ITelemetrySenderApi | undefined): void {
 		this.reporter = reporter;
 	}
-	public setSecureReporter(reporter: TelemetrySender | undefined): void {
+	public setSecureReporter(reporter: ITelemetrySenderApi | undefined): void {
 		this.reporterSecure = reporter;
 	}
 	async deactivate(): Promise<void> {
@@ -89,10 +88,10 @@ export class GHTelemetryService implements IGHTelemetryService {
 		}
 	}
 
-	public setSecureReporter(reporterSecure: TelemetrySender | undefined): void {
+	public setSecureReporter(reporterSecure: ITelemetrySenderApi | undefined): void {
 		this.reporters.setSecureReporter(reporterSecure);
 	}
-	public setReporter(reporter: TelemetrySender | undefined): void {
+	public setReporter(reporter: ITelemetrySenderApi | undefined): void {
 		this.reporters.setReporter(reporter);
 	}
 

--- a/extensions/copilot/src/platform/telemetry/common/telemetry.ts
+++ b/extensions/copilot/src/platform/telemetry/common/telemetry.ts
@@ -8,24 +8,14 @@ import type { CopilotToken } from '../../authentication/common/copilotToken';
 import { ICopilotTokenStore } from '../../authentication/common/copilotTokenStore';
 import type { TelemetryData } from './telemetryData';
 
-/**
- * Local copy of the shape of `vscode.TelemetrySender`. Defined here so that
- * code in this folder does not need a type-only `import { TelemetrySender }
- * from 'vscode'`, which would prevent reuse from outside the extension host
- * (e.g. the agent host utility process). Structurally compatible with
- * `vscode.TelemetrySender`, so an instance of either can be assigned to
- * either type.
- */
+/** Structural copy of `vscode.TelemetrySender` so this module can be reused outside the extension host (e.g. the agent host utility process). */
 export interface ITelemetrySenderApi {
 	sendEventData(eventName: string, data?: Record<string, any>): void;
 	sendErrorData(error: Error, data?: Record<string, any>): void;
 	flush?(): void | Thenable<void>;
 }
 
-/**
- * Local copy of the subset of `vscode.TelemetryLogger` we use. See
- * {@link ITelemetrySenderApi} for the rationale.
- */
+/** Structural copy of the subset of `vscode.TelemetryLogger` we use. */
 export interface ITelemetryLoggerApi {
 	logUsage(eventName: string, data?: Record<string, any>): void;
 	logError(eventName: string, data?: Record<string, any>): void;

--- a/extensions/copilot/src/platform/telemetry/common/telemetry.ts
+++ b/extensions/copilot/src/platform/telemetry/common/telemetry.ts
@@ -2,13 +2,36 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import type { TelemetrySender } from 'vscode';
 import { createServiceIdentifier } from '../../../util/common/services';
 import { IDisposable } from '../../../util/vs/base/common/lifecycle';
 import type { CopilotToken } from '../../authentication/common/copilotToken';
 import { ICopilotTokenStore } from '../../authentication/common/copilotTokenStore';
 import type { TelemetryData } from './telemetryData';
 
+/**
+ * Local copy of the shape of `vscode.TelemetrySender`. Defined here so that
+ * code in this folder does not need a type-only `import { TelemetrySender }
+ * from 'vscode'`, which would prevent reuse from outside the extension host
+ * (e.g. the agent host utility process). Structurally compatible with
+ * `vscode.TelemetrySender`, so an instance of either can be assigned to
+ * either type.
+ */
+export interface ITelemetrySenderApi {
+	sendEventData(eventName: string, data?: Record<string, any>): void;
+	sendErrorData(error: Error, data?: Record<string, any>): void;
+	flush?(): void | Thenable<void>;
+}
+
+/**
+ * Local copy of the subset of `vscode.TelemetryLogger` we use. See
+ * {@link ITelemetrySenderApi} for the rationale.
+ */
+export interface ITelemetryLoggerApi {
+	logUsage(eventName: string, data?: Record<string, any>): void;
+	logError(eventName: string, data?: Record<string, any>): void;
+	logError(error: Error, data?: Record<string, any>): void;
+	dispose(): void;
+}
 
 // Interfaces taken from and should match `@vscode/extension-telemetry` package
 export interface TelemetryEventMeasurements {
@@ -16,7 +39,7 @@ export interface TelemetryEventMeasurements {
 }
 
 export interface TelemetryEventProperties {
-	readonly [key: string]: string | import('vscode').TelemetryTrustedValue<string> | undefined;
+	readonly [key: string]: string | TelemetryTrustedValue<string> | undefined;
 }
 
 // Interfaces taken from and should match `vscode-tas-client`
@@ -159,8 +182,8 @@ export interface IMSFTTelemetrySender extends ITelemetrySender {
 }
 export interface IGHTelemetryService {
 	readonly _serviceBrand: undefined;
-	setSecureReporter(reporter: TelemetrySender | undefined): void;
-	setReporter(reporter: TelemetrySender | undefined): void;
+	setSecureReporter(reporter: ITelemetrySenderApi | undefined): void;
+	setReporter(reporter: ITelemetrySenderApi | undefined): void;
 
 	/**
 	 * Standard telemetry events can be disabled with VS Code's telemetry settings.

--- a/extensions/copilot/src/platform/telemetry/common/telemetryData.ts
+++ b/extensions/copilot/src/platform/telemetry/common/telemetryData.ts
@@ -2,12 +2,11 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import type { TelemetryTrustedValue } from 'vscode';
 import { generateUuid } from '../../../util/vs/base/common/uuid';
 import { IConfigurationService } from '../../configuration/common/configurationService';
 import { IEnvService } from '../../env/common/envService';
 import { RequestId } from '../../networking/common/fetch';
-import { ITelemetryUserConfig, TelemetryEventProperties, TelemetryProperties } from './telemetry';
+import { ITelemetryUserConfig, TelemetryEventProperties, TelemetryProperties, TelemetryTrustedValue } from './telemetry';
 
 export class TelemetryData {
 

--- a/extensions/copilot/src/platform/telemetry/node/azureInsightsReporter.ts
+++ b/extensions/copilot/src/platform/telemetry/node/azureInsightsReporter.ts
@@ -8,11 +8,10 @@ process.env.APPLICATION_INSIGHTS_NO_STATSBEAT = 'true';
 
 import * as appInsights from 'applicationinsights';
 import * as os from 'os';
-import type { TelemetrySender } from 'vscode';
 import { ICopilotTokenStore } from '../../authentication/common/copilotTokenStore';
 import { ICAPIClientService } from '../../endpoint/common/capiClient';
 import { IEnvService } from '../../env/common/envService';
-import { createTrackingIdGetter, TelemetryProperties } from '../common/telemetry';
+import { createTrackingIdGetter, ITelemetrySenderApi, TelemetryProperties } from '../common/telemetry';
 
 export function wrapEventNameForPrefixRemoval(eventName: string): string {
 	return `wrapped-telemetry-event-name-${eventName}-wrapped-telemetry-event-name`;
@@ -25,7 +24,7 @@ export function unwrapEventNameFromPrefix(eventName: string): string {
 	return match ? match[1] : eventName;
 }
 
-export class AzureInsightReporter implements TelemetrySender {
+export class AzureInsightReporter implements ITelemetrySenderApi {
 	private readonly client: appInsights.TelemetryClient;
 	private readonly getTrackingId: () => string | undefined;
 	constructor(capiClientService: ICAPIClientService, envService: IEnvService, tokenStore: ICopilotTokenStore, private readonly namespace: string, key: string) {


### PR DESCRIPTION
A pure type-refactor that decouples the Copilot extension's telemetry module from the vscode module's ambient types, so the same code can run in the agent-host (AHP) utility process — which has no vscode import. No behavior changes, no tests added, no runtime imports moved.