### PR TITLE
Add chat.{agents,editor}.claude.preferAgentHost EXP settings

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -6679,7 +6679,7 @@
         "inputPlaceholder": "Run local tasks with Claude, type `#` for adding context",
         "order": 3,
         "description": "%github.copilot.session.providerDescription.claude%",
-        "when": "config.github.copilot.chat.claudeAgent.enabled",
+        "when": "config.github.copilot.chat.claudeAgent.enabled && ((isSessionsWindow && !config.chat.agents.claude.preferAgentHost) || (!isSessionsWindow && !config.chat.editor.claude.preferAgentHost))",
         "canDelegate": true,
         "requiresCustomModels": true,
         "capabilities": {

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -92,6 +92,32 @@ export const AgentHostClaudeSdkRootEnvVar = 'VSCODE_AGENT_HOST_CLAUDE_SDK_ROOT';
  */
 export const AgentHostSdkSandboxEnabledSettingId = 'chat.agentHost.sdkSandbox.enabled';
 
+/**
+ * Selects which Claude integration fulfills Claude sessions opened from the
+ * **Agents Window**:
+ *  - `true` — Claude is provided by the agent host process.
+ *  - `false` (default) — Claude is provided by the GitHub Copilot Chat extension.
+ *
+ * The agent host always registers Claude when its SDK is reachable; this
+ * setting only controls whether the per-window bridge in
+ * `AgentHostContribution` actually surfaces the AH provider in the Agents
+ * Window. The extension's `chatSessions` contribution mirrors the rule
+ * declaratively (its `when` clause hides the EH provider when this is `true`),
+ * so flipping the setting takes effect live without a window reload.
+ *
+ * Paired with {@link ClaudePreferAgentHostEditorSettingId} which governs the
+ * regular workbench (sidebar). EXP-backed (`experiment: { mode: 'startup' }`).
+ */
+export const ClaudePreferAgentHostAgentsSettingId = 'chat.agents.claude.preferAgentHost';
+
+/**
+ * Sibling of {@link ClaudePreferAgentHostAgentsSettingId} that selects the
+ * Claude implementation for the **regular workbench** (sidebar chat in a
+ * non-Agents-Window window). Same shape, same semantics — just a different
+ * surface scope.
+ */
+export const ClaudePreferAgentHostEditorSettingId = 'chat.editor.claude.preferAgentHost';
+
 // -- Codex agent settings --------------------------------------------------------
 //
 // Codex is opt-in via `chat.agentHost.codexAgent.sdkRoot`. The setting points

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -186,6 +186,12 @@ async function startAgentHost(): Promise<void> {
 		// via a `product.agentSdks.<pkg>` entry that ships with this build.
 		// If neither is present, the provider is not registered and never
 		// appears in the agent picker (matches the pre-CDN UX exactly).
+		//
+		// Per-window AH-vs-EH Claude preference (`chat.{agents,editor}.claude.preferAgentHost`)
+		// is enforced in the renderer by `AgentHostContribution._shouldRegisterAgent`,
+		// which decides whether to bridge this provider into a given window. The
+		// agent host itself stays surface-agnostic: register if reachable, let
+		// each renderer pick.
 		if (agentSdkDownloader.isAvailable(ClaudeSdkPackage)) {
 			agentService.registerProvider(instantiationService.createInstance(ClaudeAgent));
 		}

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -186,12 +186,6 @@ async function startAgentHost(): Promise<void> {
 		// via a `product.agentSdks.<pkg>` entry that ships with this build.
 		// If neither is present, the provider is not registered and never
 		// appears in the agent picker (matches the pre-CDN UX exactly).
-		//
-		// Per-window AH-vs-EH Claude preference (`chat.{agents,editor}.claude.preferAgentHost`)
-		// is enforced in the renderer by `AgentHostContribution._shouldRegisterAgent`,
-		// which decides whether to bridge this provider into a given window. The
-		// agent host itself stays surface-agnostic: register if reachable, let
-		// each renderer pick.
 		if (agentSdkDownloader.isAvailable(ClaudeSdkPackage)) {
 			agentService.registerProvider(instantiationService.createInstance(ClaudeAgent));
 		}

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -43,6 +43,7 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { SessionConfigKey } from '../../../../../platform/agentHost/common/sessionConfigKeys.js';
+import { ClaudePreferAgentHostAgentsSettingId } from '../../../../../platform/agentHost/common/agentService.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { IGitHubService } from '../../../github/browser/githubService.js';
 import { computePullRequestIcon, GitHubPullRequestState } from '../../../github/common/types.js';
@@ -1368,7 +1369,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 	get sessionTypes(): readonly ISessionType[] {
 		const types: ISessionType[] = [CopilotCLISessionType, CopilotCloudSessionType];
-		if (this._claudeEnabled) {
+		if (this._isClaudeAvailable()) {
 			types.push(ClaudeCodeSessionType);
 		}
 		return types;
@@ -1406,6 +1407,18 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 	private readonly _multiChatEnabled: boolean;
 	private _claudeEnabled: boolean;
+	private _preferAgentHostClaude: boolean;
+
+	/**
+	 * Claude is offered by this (Copilot Chat sessions) provider only when the
+	 * underlying `claudeAgent.enabled` setting is on AND the user has not opted
+	 * the agent-host implementation in via `chat.agents.claude.preferAgentHost`.
+	 * When the latter is true, the agent host registers Claude itself and this
+	 * provider stays out of the way so the picker shows a single entry.
+	 */
+	private _isClaudeAvailable(): boolean {
+		return this._claudeEnabled && !this._preferAgentHostClaude;
+	}
 
 	readonly browseActions: readonly ISessionWorkspaceBrowseAction[];
 	readonly supportsLocalWorkspaces = true;
@@ -1429,15 +1442,24 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 		this._multiChatEnabled = this.configurationService.getValue<boolean>(COPILOT_MULTI_CHAT_SETTING) ?? true;
 		this._claudeEnabled = this.configurationService.getValue<boolean>(CLAUDE_CODE_ENABLED_SETTING);
+		this._preferAgentHostClaude = this.configurationService.getValue<boolean>(ClaudePreferAgentHostAgentsSettingId) ?? false;
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(CLAUDE_CODE_ENABLED_SETTING)) {
-				const claudeEnabled = this.configurationService.getValue<boolean>(CLAUDE_CODE_ENABLED_SETTING);
-				if (this._claudeEnabled !== claudeEnabled) {
-					this._claudeEnabled = claudeEnabled;
-					this._onDidChangeSessionTypes.fire();
-					this._refreshSessionCache();
-				}
+			const claudeEnabledChanged = e.affectsConfiguration(CLAUDE_CODE_ENABLED_SETTING);
+			const preferAgentHostChanged = e.affectsConfiguration(ClaudePreferAgentHostAgentsSettingId);
+			if (!claudeEnabledChanged && !preferAgentHostChanged) {
+				return;
+			}
+			const wasAvailable = this._isClaudeAvailable();
+			if (claudeEnabledChanged) {
+				this._claudeEnabled = this.configurationService.getValue<boolean>(CLAUDE_CODE_ENABLED_SETTING);
+			}
+			if (preferAgentHostChanged) {
+				this._preferAgentHostClaude = this.configurationService.getValue<boolean>(ClaudePreferAgentHostAgentsSettingId) ?? false;
+			}
+			if (this._isClaudeAvailable() !== wasAvailable) {
+				this._onDidChangeSessionTypes.fire();
+				this._refreshSessionCache();
 			}
 		}));
 
@@ -1464,7 +1486,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			return [CopilotCloudSessionType];
 		}
 		const types: ISessionType[] = [CopilotCLISessionType];
-		if (this._claudeEnabled) {
+		if (this._isClaudeAvailable()) {
 			types.push(ClaudeCodeSessionType);
 		}
 		return types;
@@ -2531,7 +2553,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 				continue;
 			}
 
-			if (session.providerType === AgentSessionProviders.Claude && !this._claudeEnabled) {
+			if (session.providerType === AgentSessionProviders.Claude && !this._isClaudeAvailable()) {
 				continue;
 			}
 

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
@@ -33,6 +33,7 @@ import { ISessionChangeEvent } from '../../../../../services/sessions/common/ses
 import { GITHUB_REMOTE_FILE_SCHEME, SessionStatus } from '../../../../../services/sessions/common/session.js';
 import { ChatConfiguration, ChatPermissionLevel } from '../../../../../../workbench/contrib/chat/common/constants.js';
 import { CLAUDE_CODE_ENABLED_SETTING, CopilotChatSessionsProvider, COPILOT_PROVIDER_ID, ClaudeCodeSessionType, ICopilotChatSession } from '../../browser/copilotChatSessionsProvider.js';
+import { ClaudePreferAgentHostAgentsSettingId } from '../../../../../../platform/agentHost/common/agentService.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { IUriIdentityService } from '../../../../../../platform/uriIdentity/common/uriIdentity.js';
@@ -113,7 +114,7 @@ class MockAgentSessionsModel {
 function createProvider(
 	disposables: DisposableStore,
 	model: MockAgentSessionsModel,
-	opts?: { multiChatEnabled?: boolean; claudeEnabled?: boolean },
+	opts?: { multiChatEnabled?: boolean; claudeEnabled?: boolean; preferAgentHost?: boolean },
 ): CopilotChatSessionsProvider {
 	return createProviderWithConfig(disposables, model, opts).provider;
 }
@@ -121,13 +122,14 @@ function createProvider(
 function createProviderWithConfig(
 	disposables: DisposableStore,
 	model: MockAgentSessionsModel,
-	opts?: { multiChatEnabled?: boolean; claudeEnabled?: boolean },
+	opts?: { multiChatEnabled?: boolean; claudeEnabled?: boolean; preferAgentHost?: boolean },
 ): { provider: CopilotChatSessionsProvider; configService: TestConfigurationService } {
 	const instantiationService = disposables.add(new TestInstantiationService());
 
 	const configService = new TestConfigurationService();
 	configService.setUserConfiguration('sessions.github.copilot.multiChatSessions', opts?.multiChatEnabled ?? true);
 	configService.setUserConfiguration(CLAUDE_CODE_ENABLED_SETTING, opts?.claudeEnabled ?? true);
+	configService.setUserConfiguration(ClaudePreferAgentHostAgentsSettingId, opts?.preferAgentHost ?? false);
 
 	instantiationService.stub(IConfigurationService, configService);
 	instantiationService.stub(IStorageService, disposables.add(new TestStorageService()));
@@ -294,6 +296,22 @@ suite('CopilotChatSessionsProvider', () => {
 		assert.ok(!provider.sessionTypes.some(t => t.id === ClaudeCodeSessionType.id));
 	});
 
+	test('sessionTypes excludes Claude when preferAgentHost is true', () => {
+		// When the user has opted into the agent host implementation of
+		// Claude, this provider must yield so the picker shows a single
+		// Claude entry (the agent host's). Otherwise both register and the
+		// user sees Claude twice.
+		const provider = createProvider(disposables, model, { claudeEnabled: true, preferAgentHost: true });
+		assert.strictEqual(provider.sessionTypes.length, 2);
+		assert.ok(!provider.sessionTypes.some(t => t.id === ClaudeCodeSessionType.id));
+	});
+
+	test('sessionTypes includes Claude when claudeEnabled and preferAgentHost is false', () => {
+		const provider = createProvider(disposables, model, { claudeEnabled: true, preferAgentHost: false });
+		assert.strictEqual(provider.sessionTypes.length, 3);
+		assert.ok(provider.sessionTypes.some(t => t.id === ClaudeCodeSessionType.id));
+	});
+
 	test('onDidChangeSessionTypes fires when claude setting changes', () => {
 		const { provider, configService } = createProviderWithConfig(disposables, model);
 		assert.strictEqual(provider.sessionTypes.length, 3);
@@ -312,6 +330,29 @@ suite('CopilotChatSessionsProvider', () => {
 
 		assert.ok(fired, 'onDidChangeSessionTypes should have fired');
 		assert.strictEqual(provider.sessionTypes.length, 2);
+	});
+
+	test('onDidChangeSessionTypes fires when preferAgentHost setting changes', () => {
+		// Symmetric with the claude-enabled case above. Must respond live so
+		// flipping the EXP-backed preference unregisters this provider's
+		// Claude entry without requiring a window reload.
+		const { provider, configService } = createProviderWithConfig(disposables, model);
+		assert.strictEqual(provider.sessionTypes.length, 3);
+
+		let fired = false;
+		disposables.add(provider.onDidChangeSessionTypes(() => { fired = true; }));
+
+		configService.setUserConfiguration(ClaudePreferAgentHostAgentsSettingId, true);
+		configService.onDidChangeConfigurationEmitter.fire({
+			source: ConfigurationTarget.USER,
+			affectedKeys: new Set([ClaudePreferAgentHostAgentsSettingId]),
+			change: { keys: [ClaudePreferAgentHostAgentsSettingId], overrides: [] },
+			affectsConfiguration: (key: string) => key === ClaudePreferAgentHostAgentsSettingId,
+		});
+
+		assert.ok(fired, 'onDidChangeSessionTypes should have fired');
+		assert.strictEqual(provider.sessionTypes.length, 2);
+		assert.ok(!provider.sessionTypes.some(t => t.id === ClaudeCodeSessionType.id));
 	});
 
 	test('toggling claude setting refreshes sessions list', () => {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -7,7 +7,7 @@ import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../nls.js';
-import { AgentHostEnabledSettingId, IAgentHostService, type AgentProvider } from '../../../../../../platform/agentHost/common/agentService.js';
+import { AgentHostEnabledSettingId, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHostEditorSettingId, IAgentHostService, type AgentProvider } from '../../../../../../platform/agentHost/common/agentService.js';
 import { type ProtectedResourceMetadata } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { type AgentInfo, type RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
@@ -102,12 +102,57 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 		if (initialRootState && !(initialRootState instanceof Error)) {
 			this._handleRootStateChange(initialRootState);
 		}
+
+		// React to per-window preference flips for AH-vs-EH Claude. The
+		// extension's `chatSessions` contribution gates the EH side declaratively
+		// via its `when` clause; we mirror that on the AH side by toggling
+		// registration of the `claude` provider inside this window. Flipping
+		// the relevant setting unregisters / re-registers Claude live.
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			const relevantSetting = this._isSessionsWindow
+				? ClaudePreferAgentHostAgentsSettingId
+				: ClaudePreferAgentHostEditorSettingId;
+			if (!e.affectsConfiguration(relevantSetting)) {
+				return;
+			}
+			const current = this._agentHostService.rootState.value;
+			if (current && !(current instanceof Error)) {
+				this._handleRootStateChange(current);
+			}
+		}));
+	}
+
+	/**
+	 * Whether this window wants the given agent registered, given the
+	 * per-window AH/EH preference settings. Today only the `claude` provider
+	 * has dual implementations (EH from the Copilot extension, AH from inside
+	 * the agent host process) and a corresponding preference; all other
+	 * providers are AH-only and unconditionally allowed.
+	 *
+	 * Symmetric with the EH-side gate that lives in the extension's
+	 * `chatSessions` contribution `when` clause:
+	 *   - Agents Window  → `chat.agents.claude.preferAgentHost`
+	 *   - Editor Window  → `chat.editor.claude.preferAgentHost`
+	 *
+	 * If the relevant setting is `false`, the EH Claude is the one that
+	 * surfaces in this window, so the AH side suppresses its own registration
+	 * to avoid Claude appearing twice in the same window.
+	 */
+	private _shouldRegisterAgent(provider: AgentProvider): boolean {
+		if (provider !== 'claude') {
+			return true;
+		}
+		const settingId = this._isSessionsWindow
+			? ClaudePreferAgentHostAgentsSettingId
+			: ClaudePreferAgentHostEditorSettingId;
+		return this._configurationService.getValue<boolean>(settingId) === true;
 	}
 
 	private _handleRootStateChange(rootState: RootState): void {
-		const incoming = new Set(rootState.agents.map(a => a.provider));
+		const allowed = rootState.agents.filter(a => this._shouldRegisterAgent(a.provider));
+		const incoming = new Set(allowed.map(a => a.provider));
 
-		// Remove agents that are no longer present
+		// Remove agents that are no longer present OR no longer allowed
 		for (const [provider] of this._agentRegistrations) {
 			if (!incoming.has(provider)) {
 				this._agentRegistrations.deleteAndDispose(provider);
@@ -120,7 +165,7 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 			.catch(() => { /* best-effort */ });
 
 		// Register new agents and push model updates to existing ones
-		for (const agent of rootState.agents) {
+		for (const agent of allowed) {
 			if (!this._agentRegistrations.has(agent.provider)) {
 				this._registerAgent(agent);
 			} else {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -160,8 +160,11 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 			}
 		}
 
-		// Authenticate using protectedResources from agent info
-		this._authenticateWithServer(rootState.agents)
+		// Authenticate using protectedResources from agent info. Only auth the
+		// allowed agents so a suppressed provider (e.g. EH-preferred Claude in
+		// this window) doesn't trigger token resolution work for an
+		// implementation we're not going to bridge.
+		this._authenticateWithServer(allowed)
 			.catch(() => { /* best-effort */ });
 
 		// Register new agents and push model updates to existing ones
@@ -272,7 +275,8 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 
 	private _getRootAgents(): readonly AgentInfo[] {
 		const rootState = this._agentHostService.rootState.value;
-		return (rootState && !(rootState instanceof Error)) ? rootState.agents : [];
+		const agents = (rootState && !(rootState instanceof Error)) ? rootState.agents : [];
+		return agents.filter(a => this._shouldRegisterAgent(a.provider));
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -697,14 +697,14 @@ configurationRegistry.registerConfiguration({
 		},
 		[ClaudePreferAgentHostAgentsSettingId]: {
 			type: 'boolean',
-			description: nls.localize('chat.agents.claude.preferAgentHost', "When enabled, Claude sessions opened from the Agents Window run inside the agent host process instead of the GitHub Copilot Chat extension. Only one Claude implementation surfaces per window. Requires a window reload to take effect."),
+			description: nls.localize('chat.agents.claude.preferAgentHost', "When enabled, Claude sessions opened from the Agents Window run inside the agent host process instead of the GitHub Copilot Chat extension. Only one Claude implementation surfaces per window."),
 			default: false,
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },
 		},
 		[ClaudePreferAgentHostEditorSettingId]: {
 			type: 'boolean',
-			description: nls.localize('chat.editor.claude.preferAgentHost', "When enabled, Claude sessions opened from the regular workbench (sidebar chat) run inside the agent host process instead of the GitHub Copilot Chat extension. Only one Claude implementation surfaces per window. Requires a window reload to take effect."),
+			description: nls.localize('chat.editor.claude.preferAgentHost', "When enabled, Claude sessions opened from the regular workbench (sidebar chat) run inside the agent host process instead of the GitHub Copilot Chat extension. Only one Claude implementation surfaces per window."),
 			default: false,
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -11,7 +11,7 @@ import { isMacintosh } from '../../../../base/common/platform.js';
 import { PolicyCategory } from '../../../../base/common/policy.js';
 import '../../../../platform/agentHost/common/agentHost.config.contribution.js';
 import '../../../../platform/agentHost/common/agentHostStarter.config.contribution.js';
-import { AgentHostAhpJsonlLoggingSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostSdkSandboxEnabledSettingId, AgentHostEnabledSettingId } from '../../../../platform/agentHost/common/agentService.js';
+import { AgentHostAhpJsonlLoggingSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostEnabledSettingId, AgentHostSdkSandboxEnabledSettingId, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHostEditorSettingId } from '../../../../platform/agentHost/common/agentService.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../../../platform/networkFilter/common/networkFilterService.js';
 import { AgentNetworkDomainSettingId } from '../../../../platform/networkFilter/common/settings.js';
 import { AgentSandboxEnabledValue, AgentSandboxSettingId } from '../../../../platform/sandbox/common/settings.js';
@@ -694,6 +694,20 @@ configurationRegistry.registerConfiguration({
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },
 			description: nls.localize('chat.agentsHandoffTip.mode', "Controls the tip shown above the chat input offering to continue eligible agent sessions in the Agents Window."),
+		},
+		[ClaudePreferAgentHostAgentsSettingId]: {
+			type: 'boolean',
+			description: nls.localize('chat.agents.claude.preferAgentHost', "When enabled, Claude sessions opened from the Agents Window run inside the agent host process instead of the GitHub Copilot Chat extension. Only one Claude implementation surfaces per window. Requires a window reload to take effect."),
+			default: false,
+			tags: ['experimental'],
+			experiment: { mode: 'startup' },
+		},
+		[ClaudePreferAgentHostEditorSettingId]: {
+			type: 'boolean',
+			description: nls.localize('chat.editor.claude.preferAgentHost', "When enabled, Claude sessions opened from the regular workbench (sidebar chat) run inside the agent host process instead of the GitHub Copilot Chat extension. Only one Claude implementation surfaces per window. Requires a window reload to take effect."),
+			default: false,
+			tags: ['experimental'],
+			experiment: { mode: 'startup' },
 		},
 		[ChatConfiguration.ChatContextUsageEnabled]: {
 			type: 'boolean',


### PR DESCRIPTION
## Summary

Introduces a pair of EXP-backed boolean settings that select between the Copilot extension's Claude implementation (**EH**) and the agent host's Claude implementation (**AH**) on a per-surface basis:

- `chat.agents.claude.preferAgentHost` — gates the **Agents Window**
- `chat.editor.claude.preferAgentHost` — gates the **regular workbench sidebar**

Both implementations register normally. Per-window suppression happens declaratively in three places:

1. **Extension `chatSessions` contribution `when` clause** (`extensions/copilot/package.json`) — branches on `isSessionsWindow` to read the surface-appropriate setting.
2. **`CopilotChatSessionsProvider`** (Agents Window-only consumer) — reads `chat.agents.claude.preferAgentHost` reactively in the existing `_claudeEnabled` listener.
3. **`AgentHostContribution._shouldRegisterAgent()`** — mirrors the same per-window rule on the AH side; reactive listener flips the bridge live when the relevant setting changes.

**Net effect:** exactly one Claude implementation per window, live-switchable without a reload.

## Why per-window rather than process-level

Earlier iterations forwarded the resolved preference to the agent host process via an env var so the AH would only register Claude when at least one preference was true. That coupled main-process spawn-time logic to UI lifecycle and required a window reload when toggling. The current design keeps the AH surface-agnostic (always register if SDK is reachable) and pushes the "which window sees which implementation" decision to the renderer, which already has the per-window context. The cost is constructing a `ClaudeAgent` instance in the AH process that may not be bridged anywhere — small, no SDK load.

## Relationship to #320896

#320896 adds the same two setting names (plus four more in the family) and gates **picker visibility** without unregistering. Both providers stay in the registry, hidden only at the dropdown. This PR takes the **unregistration** path so downstream consumers (command palette, MRU, URI handlers) also see exactly one Claude. The two PRs conflict on the schema declarations; recommend coordinating before merge.

## Test plan

- [x] Compile-client emits cleanly for changed files
- [x] Existing `copilotChatSessionsProvider` unit tests pass (with new cases added for `preferAgentHost` reactivity)
- [x] Manual launch verification across the matrix:
  - `agents=true, editor=false`: Agents Window shows AH-Claude only; sidebar shows EH-Claude only
  - `agents=false, editor=true`: inverse
  - `agents=false, editor=false` (default): both windows show EH-Claude
  - Live toggle of either setting flips the picker without window reload
- [x] `ChatSessionsService._evaluateAvailability` traces confirm per-window `shouldBeRegistered` matches the matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)