### PR TITLE
Fix missing CLI session tool calls and agent response in agent debug logs

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -2962,7 +2962,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 		if (turns.length === 0) {
 			// No usage events were reported — still surface the response if we have one.
 			if (responseText) {
-				this._emitChatSpan({ model: fallbackModelId }, responseText, rootTraceContext);
+				this._emitChatSpan({}, responseText, fallbackModelId, rootTraceContext);
 			}
 			return;
 		}
@@ -2976,7 +2976,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 			}
 		}
 		for (let i = 0; i < turns.length; i++) {
-			this._emitChatSpan(turns[i], i === responseTurnIndex ? responseText : '', rootTraceContext);
+			this._emitChatSpan(turns[i], i === responseTurnIndex ? responseText : '', fallbackModelId, rootTraceContext);
 		}
 	}
 
@@ -2984,14 +2984,15 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 	 * Emits a single synthesized `chat` span for one model turn. Token usage attributes are set only when
 	 * present, and the assistant response (`OUTPUT_MESSAGES`) is attached only to the turn that produced it.
 	 */
-	private _emitChatSpan(turn: IModelTurnUsage, responseText: string, rootTraceContext: TraceContext | undefined): void {
-		const chatSpan = this._otelService.startSpan('chat', {
-			kind: SpanKind.INTERNAL,
+	private _emitChatSpan(turn: IModelTurnUsage, responseText: string, fallbackModelId: string | undefined, rootTraceContext: TraceContext | undefined): void {
+		const model = turn.model ?? fallbackModelId;
+		const chatSpan = this._otelService.startSpan(model ? `chat ${model}` : 'chat', {
+			kind: SpanKind.CLIENT,
 			attributes: {
 				[GenAiAttr.OPERATION_NAME]: GenAiOperationName.CHAT,
 				[GenAiAttr.PROVIDER_NAME]: GenAiProviderName.GITHUB,
 				[CopilotChatAttr.CHAT_SESSION_ID]: this.sessionId,
-				...(turn.model ? { [GenAiAttr.REQUEST_MODEL]: turn.model } : {}),
+				...(model ? { [GenAiAttr.REQUEST_MODEL]: model } : {}),
 				...(typeof turn.inputTokens === 'number' ? { [GenAiAttr.USAGE_INPUT_TOKENS]: turn.inputTokens } : {}),
 				...(typeof turn.outputTokens === 'number' ? { [GenAiAttr.USAGE_OUTPUT_TOKENS]: turn.outputTokens } : {}),
 				...(typeof turn.cacheReadTokens === 'number' ? { [GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS]: turn.cacheReadTokens } : {}),

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -1177,6 +1177,11 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 		// Synthesizing these spans is what surfaces native tool calls (e.g. powershell, grep) in the
 		// chat debug logs view for the in-process Copilot CLI experience.
 		const syntheticToolSpans = new Map<string, ISpanHandle>();
+		// Per-model-turn usage reported by the SDK (`assistant.usage`). Used at request completion to
+		// synthesize one `chat` span per turn so the chat debug logs view shows the model turns, token
+		// metrics, and the agent response for the in-process Copilot CLI experience (the SDK performs
+		// the model call natively and never produces a JS span we could observe directly).
+		const modelTurnUsages: IModelTurnUsage[] = [];
 		const invokeAgentTraceContext = invokeAgentSpan.getSpanContext();
 		const editTracker = new ExternalEditTracker();
 		let sdkRequestId: string | undefined;
@@ -1431,12 +1436,23 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 				}
 				// Accumulate per-turn credits from SDK copilotUsage data
 				const copilotUsage = (event.data as Record<string, unknown>).copilotUsage;
+				let copilotUsageNanoAiu: number | undefined;
 				if (copilotUsage && typeof copilotUsage === 'object') {
 					const { totalNanoAiu } = copilotUsage as { totalNanoAiu?: number };
 					if (typeof totalNanoAiu === 'number') {
+						copilotUsageNanoAiu = totalNanoAiu;
 						this._chatQuotaService.setLastCopilotUsage(totalNanoAiu, request.id);
 					}
 				}
+				// Record this model turn so we can synthesize a `chat` span for it at request completion.
+				modelTurnUsages.push({
+					model: event.data.model,
+					inputTokens: event.data.inputTokens,
+					outputTokens: event.data.outputTokens,
+					cacheReadTokens: event.data.cacheReadTokens,
+					copilotUsageNanoAiu,
+					parentToolCallId: event.data.parentToolCallId,
+				});
 			})));
 			disposables.add(toDisposable(this._sdkSession.on('session.usage_info', (event) => {
 				lastUsageInfo = {
@@ -1481,7 +1497,11 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 				toolCalls.set(event.data.toolCallId, event.data as unknown as ToolCall);
 				toolStartTimes.set(event.data.toolCallId, Date.now());
 
-				this._startSyntheticToolSpan(event, syntheticToolSpans, invokeAgentTraceContext);
+				// Only synthesize tool spans when the bridge is absent. If a future SDK registers its own
+				// JS OTel provider the bridge forwards native tool spans, and synthesizing would duplicate them.
+				if (!this._bridgeProcessor) {
+					this._startSyntheticToolSpan(event, syntheticToolSpans, invokeAgentTraceContext);
+				}
 
 				if (isCopilotCliEditToolCall(event.data)) {
 					flushPendingInvocationMessages();
@@ -1705,10 +1725,13 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 		} finally {
 			cancelCancellationAbort?.();
 
-			// Synthesize a `chat` span carrying the assistant response so the chat debug logs view
-			// shows the agent response (and an llm_request entry) for the in-process Copilot CLI
-			// experience, where the model call happens inside the SDK and never produces a JS span.
-			this._injectAgentResponseSpan(assistantMessageChunks.join(''), this._lastResponseModelId ?? modelId, invokeAgentTraceContext);
+			// Synthesize a `chat` span per model turn so the chat debug logs view shows the model
+			// turns, token metrics, and the agent response for the in-process Copilot CLI experience,
+			// where the model calls happen inside the SDK and never produce JS spans. Skip when the bridge
+			// is installed (a future SDK with its own JS provider), since it forwards the native chat spans.
+			if (!this._bridgeProcessor) {
+				this._injectModelTurnSpans(modelTurnUsages, assistantMessageChunks.join(''), this._lastResponseModelId ?? modelId, invokeAgentTraceContext);
+			}
 
 			// End any synthesized tool spans that never received a completion event (e.g. on abort)
 			// so they don't leak.
@@ -2907,10 +2930,14 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 		if (event.data.success) {
 			const content = event.data.result?.content;
 			if (content !== undefined) {
-				toolSpan.setAttribute(GenAiAttr.TOOL_CALL_RESULT, truncateForOTel(
-					typeof content === 'string' ? content : JSON.stringify(content),
-					this._otelService.config.maxAttributeSizeChars,
-				));
+				try {
+					toolSpan.setAttribute(GenAiAttr.TOOL_CALL_RESULT, truncateForOTel(
+						typeof content === 'string' ? content : JSON.stringify(content),
+						this._otelService.config.maxAttributeSizeChars,
+					));
+				} catch (err) {
+					this.logService.trace(`[CopilotCLISession] Failed to serialize tool result for ${event.data.toolCallId}: ${err instanceof Error ? err.message : String(err)}`);
+				}
 			}
 			toolSpan.setStatus(SpanStatusCode.OK);
 		} else {
@@ -2924,23 +2951,52 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 	}
 
 	/**
-	 * Synthesizes a `chat` OTel span carrying the accumulated assistant response. The chat debug logs
-	 * view derives the `agent_response` (and an `llm_request`) entry from this span. For the in-process
-	 * Copilot CLI experience the model call happens inside the SDK and never produces a JS span, so
-	 * without this the agent response would be missing from the debug logs.
+	 * Synthesizes one `chat` OTel span per model turn reported by the SDK (`assistant.usage`), carrying
+	 * that turn's token usage and resolved model. The chat debug logs view derives an `llm_request`
+	 * (model turn) entry from each span and the `agent_response` from the final main-agent turn's output
+	 * messages. For the in-process Copilot CLI experience the model calls happen inside the SDK and never
+	 * produce JS spans, so without this the model turns, token metrics, and agent response would all be
+	 * missing from the debug logs.
 	 */
-	private _injectAgentResponseSpan(responseText: string, modelId: string | undefined, rootTraceContext: TraceContext | undefined): void {
-		if (!responseText) {
+	private _injectModelTurnSpans(turns: readonly IModelTurnUsage[], responseText: string, fallbackModelId: string | undefined, rootTraceContext: TraceContext | undefined): void {
+		if (turns.length === 0) {
+			// No usage events were reported — still surface the response if we have one.
+			if (responseText) {
+				this._emitChatSpan({ model: fallbackModelId }, responseText, rootTraceContext);
+			}
 			return;
 		}
+		// The assistant response belongs to the final main-agent turn (one without a parent tool call;
+		// turns with a parent tool call originate from subagents).
+		let responseTurnIndex = -1;
+		for (let i = turns.length - 1; i >= 0; i--) {
+			if (!turns[i].parentToolCallId) {
+				responseTurnIndex = i;
+				break;
+			}
+		}
+		for (let i = 0; i < turns.length; i++) {
+			this._emitChatSpan(turns[i], i === responseTurnIndex ? responseText : '', rootTraceContext);
+		}
+	}
+
+	/**
+	 * Emits a single synthesized `chat` span for one model turn. Token usage attributes are set only when
+	 * present, and the assistant response (`OUTPUT_MESSAGES`) is attached only to the turn that produced it.
+	 */
+	private _emitChatSpan(turn: IModelTurnUsage, responseText: string, rootTraceContext: TraceContext | undefined): void {
 		const chatSpan = this._otelService.startSpan('chat', {
 			kind: SpanKind.INTERNAL,
 			attributes: {
 				[GenAiAttr.OPERATION_NAME]: GenAiOperationName.CHAT,
 				[GenAiAttr.PROVIDER_NAME]: GenAiProviderName.GITHUB,
 				[CopilotChatAttr.CHAT_SESSION_ID]: this.sessionId,
-				...(modelId ? { [GenAiAttr.REQUEST_MODEL]: modelId } : {}),
-				[GenAiAttr.OUTPUT_MESSAGES]: truncateForOTel(responseText, this._otelService.config.maxAttributeSizeChars),
+				...(turn.model ? { [GenAiAttr.REQUEST_MODEL]: turn.model } : {}),
+				...(typeof turn.inputTokens === 'number' ? { [GenAiAttr.USAGE_INPUT_TOKENS]: turn.inputTokens } : {}),
+				...(typeof turn.outputTokens === 'number' ? { [GenAiAttr.USAGE_OUTPUT_TOKENS]: turn.outputTokens } : {}),
+				...(typeof turn.cacheReadTokens === 'number' ? { [GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS]: turn.cacheReadTokens } : {}),
+				...(typeof turn.copilotUsageNanoAiu === 'number' ? { [CopilotChatAttr.COPILOT_USAGE_NANO_AIU]: turn.copilotUsageNanoAiu } : {}),
+				...(responseText ? { [GenAiAttr.OUTPUT_MESSAGES]: truncateForOTel(JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: responseText }] }]), this._otelService.config.maxAttributeSizeChars) } : {}),
 			},
 			parentTraceContext: rootTraceContext,
 		});
@@ -3077,6 +3133,20 @@ interface UsageInfoData {
 	readonly conversationTokens?: number;
 	readonly toolDefinitionsTokens?: number;
 	readonly tokenLimit?: number;
+}
+
+/**
+ * Token usage for a single model turn, captured from the SDK `assistant.usage` event. Used to
+ * synthesize per-turn `chat` spans for the in-process Copilot CLI chat debug logs view.
+ */
+interface IModelTurnUsage {
+	readonly model?: string;
+	readonly inputTokens?: number;
+	readonly outputTokens?: number;
+	readonly cacheReadTokens?: number;
+	readonly copilotUsageNanoAiu?: number;
+	/** Set when the turn originates from a subagent (nested under a parent tool call). */
+	readonly parentToolCallId?: string;
 }
 
 function buildPromptTokenDetails(usageInfo: UsageInfoData | undefined): { category: string; label: string; percentageOfPrompt: number }[] | undefined {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { Attachment, SendOptions, SessionOptions, ToolExecutionCompleteEvent } from '@github/copilot/sdk';
+import type { Attachment, SendOptions, SessionOptions, ToolExecutionCompleteEvent, ToolExecutionStartEvent } from '@github/copilot/sdk';
 import * as l10n from '@vscode/l10n';
 import * as cp from 'child_process';
 import * as crypto from 'crypto';
@@ -17,7 +17,7 @@ import { IGitService } from '../../../../platform/git/common/gitService';
 import { PermissiveAuthRequiredError } from '../../../../platform/github/common/githubService';
 import { ILogService } from '../../../../platform/log/common/logService';
 import { GenAiMetrics } from '../../../../platform/otel/common/genAiMetrics';
-import { CopilotChatAttr, GenAiAttr, GenAiOperationName, GenAiProviderName, IOTelService, ISpanHandle, resolveWorkspaceOTelMetadata, SpanKind, SpanStatusCode, truncateForOTel, workspaceMetadataToOTelAttributes } from '../../../../platform/otel/common/index';
+import { CopilotChatAttr, GenAiAttr, GenAiOperationName, GenAiProviderName, IOTelService, ISpanHandle, resolveWorkspaceOTelMetadata, SpanKind, SpanStatusCode, TraceContext, truncateForOTel, workspaceMetadataToOTelAttributes } from '../../../../platform/otel/common/index';
 import { CapturingToken } from '../../../../platform/requestLogger/common/capturingToken';
 import { IRequestLogger, LoggedRequestKind } from '../../../../platform/requestLogger/common/requestLogger';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry';
@@ -1171,6 +1171,13 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 		const editToolIds = new Set<string>();
 		const toolCalls = new Map<string, ToolCall>();
 		const toolStartTimes = new Map<string, number>();
+		// Synthesized `execute_tool` spans for native CLI tools (those that execute inside the SDK
+		// and therefore never reach the tools service). MCP/VS Code tools already emit `execute_tool`
+		// spans via the tools service, so we skip those here to avoid duplicate debug-log entries.
+		// Synthesizing these spans is what surfaces native tool calls (e.g. powershell, grep) in the
+		// chat debug logs view for the in-process Copilot CLI experience.
+		const syntheticToolSpans = new Map<string, ISpanHandle>();
+		const invokeAgentTraceContext = invokeAgentSpan.getSpanContext();
 		const editTracker = new ExternalEditTracker();
 		let sdkRequestId: string | undefined;
 		let isQuotaError = false;
@@ -1474,6 +1481,8 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 				toolCalls.set(event.data.toolCallId, event.data as unknown as ToolCall);
 				toolStartTimes.set(event.data.toolCallId, Date.now());
 
+				this._startSyntheticToolSpan(event, syntheticToolSpans, invokeAgentTraceContext);
+
 				if (isCopilotCliEditToolCall(event.data)) {
 					flushPendingInvocationMessages();
 					editToolIds.add(event.data.toolCallId);
@@ -1518,6 +1527,9 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 				const eventError = event.data.error ? { ...event.data.error, code: event.data.error.code || '' } : undefined;
 				const eventData = { ...event.data, error: eventError };
 				this._logToolCall(event.data.toolCallId, toolName, toolCall?.arguments, eventData);
+
+				// Complete the synthesized `execute_tool` span (native CLI tools only).
+				this._endSyntheticToolSpan(event, syntheticToolSpans);
 
 				// Mark the end of the edit if this was an edit tool.
 				toolIdEditMap.set(event.data.toolCallId, editTracker.completeEdit(event.data.toolCallId));
@@ -1692,6 +1704,20 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 			this._logConversation(prompt, assistantMessageChunks.join(''), modelId || '', attachments, logStartTime, 'Failed', errorMessage);
 		} finally {
 			cancelCancellationAbort?.();
+
+			// Synthesize a `chat` span carrying the assistant response so the chat debug logs view
+			// shows the agent response (and an llm_request entry) for the in-process Copilot CLI
+			// experience, where the model call happens inside the SDK and never produces a JS span.
+			this._injectAgentResponseSpan(assistantMessageChunks.join(''), this._lastResponseModelId ?? modelId, invokeAgentTraceContext);
+
+			// End any synthesized tool spans that never received a completion event (e.g. on abort)
+			// so they don't leak.
+			for (const toolSpan of syntheticToolSpans.values()) {
+				toolSpan.setStatus(SpanStatusCode.ERROR, 'incomplete');
+				toolSpan.end();
+			}
+			syntheticToolSpans.clear();
+
 			// End the invoke_agent wrapper span
 			const durationSec = (Date.now() - logStartTime) / 1000;
 			invokeAgentSpan.setAttribute('copilot_chat.duration_sec', durationSec);
@@ -2820,6 +2846,105 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 		result.push(assistantResponse || '(no response)');
 		result.push(`~~~`);
 		return result.join('\n');
+	}
+
+	/**
+	 * Starts a synthesized `execute_tool` OTel span for a native CLI tool call.
+	 *
+	 * Native CLI tools (e.g. `powershell`, `bash`, `grep`, `task`) execute inside the SDK and never
+	 * reach the workbench tools service, so they don't otherwise produce `execute_tool` spans for the
+	 * chat debug logs view. MCP/VS Code tools (those carrying an `mcpServerName`) already emit spans
+	 * via the tools service and are skipped here to avoid duplicate entries.
+	 */
+	private _startSyntheticToolSpan(
+		event: ToolExecutionStartEvent,
+		syntheticToolSpans: Map<string, ISpanHandle>,
+		rootTraceContext: TraceContext | undefined,
+	): void {
+		const toolCall = event.data as unknown as ToolCall;
+		if (toolCall.mcpServerName) {
+			return;
+		}
+		// Nest tool calls made by a subagent under that subagent's tool span when we have it.
+		const parentToolCallId = event.data.parentToolCallId;
+		const parentContext = (parentToolCallId ? syntheticToolSpans.get(parentToolCallId)?.getSpanContext() : undefined) ?? rootTraceContext;
+		const toolSpan = this._otelService.startSpan(`execute_tool ${toolCall.toolName}`, {
+			kind: SpanKind.INTERNAL,
+			attributes: {
+				[GenAiAttr.OPERATION_NAME]: GenAiOperationName.EXECUTE_TOOL,
+				[GenAiAttr.TOOL_NAME]: toolCall.toolName,
+				[GenAiAttr.TOOL_CALL_ID]: toolCall.toolCallId,
+				[CopilotChatAttr.CHAT_SESSION_ID]: this.sessionId,
+			},
+			parentTraceContext: parentContext,
+		});
+		if (toolCall.arguments !== undefined) {
+			try {
+				toolSpan.setAttribute(GenAiAttr.TOOL_CALL_ARGUMENTS, truncateForOTel(
+					typeof toolCall.arguments === 'string' ? toolCall.arguments : JSON.stringify(toolCall.arguments),
+					this._otelService.config.maxAttributeSizeChars,
+				));
+			} catch (err) {
+				this.logService.trace(`[CopilotCLISession] Failed to serialize tool arguments for ${toolCall.toolName}: ${err instanceof Error ? err.message : String(err)}`);
+			}
+		}
+		syntheticToolSpans.set(toolCall.toolCallId, toolSpan);
+	}
+
+	/**
+	 * Completes the synthesized `execute_tool` span for a native CLI tool, recording the result and
+	 * status. No-op for tools that were not synthesized (e.g. MCP/VS Code tools).
+	 */
+	private _endSyntheticToolSpan(
+		event: ToolExecutionCompleteEvent,
+		syntheticToolSpans: Map<string, ISpanHandle>,
+	): void {
+		const toolSpan = syntheticToolSpans.get(event.data.toolCallId);
+		if (!toolSpan) {
+			return;
+		}
+		syntheticToolSpans.delete(event.data.toolCallId);
+		if (event.data.success) {
+			const content = event.data.result?.content;
+			if (content !== undefined) {
+				toolSpan.setAttribute(GenAiAttr.TOOL_CALL_RESULT, truncateForOTel(
+					typeof content === 'string' ? content : JSON.stringify(content),
+					this._otelService.config.maxAttributeSizeChars,
+				));
+			}
+			toolSpan.setStatus(SpanStatusCode.OK);
+		} else {
+			const errorMessage = event.data.error
+				? `${event.data.error.code ?? ''} ${event.data.error.message ?? ''}`.trim() || 'tool error'
+				: 'tool error';
+			toolSpan.setAttribute(GenAiAttr.TOOL_CALL_RESULT, truncateForOTel(`ERROR: ${errorMessage}`, this._otelService.config.maxAttributeSizeChars));
+			toolSpan.setStatus(SpanStatusCode.ERROR, errorMessage);
+		}
+		toolSpan.end();
+	}
+
+	/**
+	 * Synthesizes a `chat` OTel span carrying the accumulated assistant response. The chat debug logs
+	 * view derives the `agent_response` (and an `llm_request`) entry from this span. For the in-process
+	 * Copilot CLI experience the model call happens inside the SDK and never produces a JS span, so
+	 * without this the agent response would be missing from the debug logs.
+	 */
+	private _injectAgentResponseSpan(responseText: string, modelId: string | undefined, rootTraceContext: TraceContext | undefined): void {
+		if (!responseText) {
+			return;
+		}
+		const chatSpan = this._otelService.startSpan('chat', {
+			kind: SpanKind.INTERNAL,
+			attributes: {
+				[GenAiAttr.OPERATION_NAME]: GenAiOperationName.CHAT,
+				[GenAiAttr.PROVIDER_NAME]: GenAiProviderName.GITHUB,
+				[CopilotChatAttr.CHAT_SESSION_ID]: this.sessionId,
+				...(modelId ? { [GenAiAttr.REQUEST_MODEL]: modelId } : {}),
+				[GenAiAttr.OUTPUT_MESSAGES]: truncateForOTel(responseText, this._otelService.config.maxAttributeSizeChars),
+			},
+			parentTraceContext: rootTraceContext,
+		});
+		chatSpan.end();
 	}
 
 	private _logToolCall(toolCallId: string, toolName: string, args: unknown, eventData: { success: boolean; error?: { code: string; message: string }; result?: { content: string } }): void {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
@@ -895,6 +895,18 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 
 			// Navigate: ProxyTracerProvider._delegate → BasicTracerProvider._activeSpanProcessor → MultiSpanProcessor._spanProcessors
 			const delegate = (globalProvider as unknown as Record<string, unknown>)._delegate ?? globalProvider;
+
+			// The in-process Copilot CLI SDK does not register its own JS OTel
+			// provider — its tracing is emitted by a native runtime. As a result the global provider
+			// resolves to the extension's own provider. Attaching the bridge there would re-forward
+			// the extension's own spans and produce duplicate entries in the chat debug logs view.
+			// In this case we skip the bridge entirely: native CLI tool calls and agent responses are
+			// synthesized directly from the SDK event stream in `copilotcliSession.ts`.
+			if ((delegate as Record<string, unknown>).__copilotChatOwnProvider) {
+				this.logService.info('[CopilotCLISession] Global OTel provider is the extension provider; skipping bridge install (debug entries are synthesized from SDK events)');
+				return;
+			}
+
 			const activeProcessor = (delegate as unknown as Record<string, unknown>)._activeSpanProcessor as Record<string, unknown> | undefined;
 			const processorArray = activeProcessor?._spanProcessors;
 

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
@@ -9,7 +9,8 @@ import type { ChatParticipantToolToken, ChatResponseStream } from 'vscode';
 import { ConfigKey, IConfigurationService } from '../../../../../platform/configuration/common/configurationService';
 import { MockGitService } from '../../../../../platform/ignore/node/test/mockGitService';
 import { ILogService } from '../../../../../platform/log/common/logService';
-import { NoopOTelService, resolveOTelConfig } from '../../../../../platform/otel/common/index';
+import { GenAiAttr, IOTelService, NoopOTelService, resolveOTelConfig, SpanKind } from '../../../../../platform/otel/common/index';
+import { CapturingOTelService } from '../../../../../platform/otel/common/test/capturingOTelService';
 import { IRequestLogger } from '../../../../../platform/requestLogger/common/requestLogger';
 import { NullRequestLogger } from '../../../../../platform/requestLogger/node/nullRequestLogger';
 import { NullTelemetryService } from '../../../../../platform/telemetry/common/nullTelemetryService';
@@ -254,6 +255,10 @@ describe('CopilotCLISession', () => {
 
 
 	async function createSession(): Promise<CopilotCLISession> {
+		return createSessionWith(new NoopOTelService(resolveOTelConfig({ env: {}, extensionVersion: '0.0.0', sessionId: 'test' })));
+	}
+
+	async function createSessionWith(otelService: IOTelService): Promise<CopilotCLISession> {
 		class FakeUserQuestionHandler implements IUserQuestionHandler {
 			_serviceBrand: undefined;
 			async askUserQuestion(question: IQuestion, toolInvocationToken: ChatParticipantToolToken, token: CancellationToken, toolCallId?: string): Promise<IQuestionAnswer | undefined> {
@@ -275,7 +280,7 @@ describe('CopilotCLISession', () => {
 			toolsService,
 			new FakeUserQuestionHandler(),
 			configurationService,
-			new NoopOTelService(resolveOTelConfig({ env: {}, extensionVersion: '0.0.0', sessionId: 'test' })),
+			otelService,
 			new MockGitService(),
 			{ _serviceBrand: undefined } as any,
 			{ _serviceBrand: undefined, resetTurnCredits() { }, getCreditsForTurn() { return undefined; }, setLastCopilotUsage() { } } as any,
@@ -294,6 +299,63 @@ describe('CopilotCLISession', () => {
 		expect(session.status).toBe(ChatSessionStatus.Completed);
 		expect(stream.output.join('\n')).toContain('Echo: Hello');
 		// Listeners are disposed after completion, so we only assert original streamed content.
+	});
+
+	it('synthesizes chat and execute_tool spans for the in-process CLI turn', async () => {
+		sdkSession.send = async ({ prompt }) => {
+			sdkSession.emit('user.message', { content: prompt });
+			sdkSession.emit('assistant.turn_start', {});
+			sdkSession.emit('tool.execution_start', { toolCallId: 'tc1', toolName: 'bash', arguments: { command: 'ls' } });
+			sdkSession.emit('tool.execution_complete', { toolCallId: 'tc1', success: true, result: { content: 'file.txt' } });
+			sdkSession.emit('assistant.usage', { model: 'claude-x', inputTokens: 100, outputTokens: 20, cacheReadTokens: 5 });
+			sdkSession.emit('assistant.message', { messageId: 'm1', content: 'Done!' });
+			sdkSession.emit('assistant.turn_end', {});
+		};
+
+		const otel = new CapturingOTelService();
+		const session = await createSessionWith(otel);
+		session.attachStream(new MockChatResponseStream());
+		await session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { prompt: 'Run ls' }, [], undefined, authInfo, CancellationToken.None);
+
+		const [chatSpan] = otel.findSpans('chat');
+		const [toolSpan] = otel.findSpans('execute_tool');
+		expect({
+			chat: {
+				name: chatSpan?.name,
+				kind: chatSpan?.kind,
+				model: chatSpan?.attributes[GenAiAttr.REQUEST_MODEL],
+				inputTokens: chatSpan?.attributes[GenAiAttr.USAGE_INPUT_TOKENS],
+				outputTokens: chatSpan?.attributes[GenAiAttr.USAGE_OUTPUT_TOKENS],
+				cacheReadTokens: chatSpan?.attributes[GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS],
+				outputMessages: chatSpan?.attributes[GenAiAttr.OUTPUT_MESSAGES],
+				parent: chatSpan?.parentTraceContext !== undefined,
+			},
+			tool: {
+				name: toolSpan?.name,
+				kind: toolSpan?.kind,
+				toolName: toolSpan?.attributes[GenAiAttr.TOOL_NAME],
+				result: toolSpan?.attributes[GenAiAttr.TOOL_CALL_RESULT],
+				parent: toolSpan?.parentTraceContext !== undefined,
+			},
+		}).toEqual({
+			chat: {
+				name: 'chat claude-x',
+				kind: SpanKind.CLIENT,
+				model: 'claude-x',
+				inputTokens: 100,
+				outputTokens: 20,
+				cacheReadTokens: 5,
+				outputMessages: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'Done!' }] }]),
+				parent: true,
+			},
+			tool: {
+				name: 'execute_tool bash',
+				kind: SpanKind.INTERNAL,
+				toolName: 'bash',
+				result: 'file.txt',
+				parent: true,
+			},
+		});
 	});
 
 	it('routes in-flight output to the latest attached stream', async () => {

--- a/extensions/copilot/src/platform/otel/node/otelServiceImpl.ts
+++ b/extensions/copilot/src/platform/otel/node/otelServiceImpl.ts
@@ -142,7 +142,9 @@ export class NodeOTelService implements IOTelService {
 			// Mark this provider so consumers (e.g. the Copilot CLI span bridge) can detect when the
 			// global OTel provider is the extension's own provider. Attaching extra span processors to
 			// it would re-forward spans the extension already emits and produce duplicate debug entries.
-			(tracerProvider as unknown as Record<string, unknown>).__copilotChatOwnProvider = true;
+			// Defined as a non-enumerable, non-writable marker so it does not surface in logs/inspection
+			// output or get accidentally mutated.
+			Object.defineProperty(tracerProvider, '__copilotChatOwnProvider', { value: true });
 			tracerProvider.register();
 			this._tracer = api.trace.getTracer(this.config.serviceName, this.config.serviceVersion);
 			this._otelApi = api;

--- a/extensions/copilot/src/platform/otel/node/otelServiceImpl.ts
+++ b/extensions/copilot/src/platform/otel/node/otelServiceImpl.ts
@@ -139,6 +139,10 @@ export class NodeOTelService implements IOTelService {
 				resource,
 				spanProcessors: this._spanProcessors,
 			});
+			// Mark this provider so consumers (e.g. the Copilot CLI span bridge) can detect when the
+			// global OTel provider is the extension's own provider. Attaching extra span processors to
+			// it would re-forward spans the extension already emits and produce duplicate debug entries.
+			(tracerProvider as unknown as Record<string, unknown>).__copilotChatOwnProvider = true;
 			tracerProvider.register();
 			this._tracer = api.trace.getTracer(this.config.serviceName, this.config.serviceVersion);
 			this._otelApi = api;


### PR DESCRIPTION
### Summary:

#### Problem
For in-process Copilot CLI sessions, the Agent Debug Logs view was incomplete:

- Native CLI tool calls (powershell, grep, bash, str_replace_editor, etc.) were missing.
- The agent response (llm_request / agent_response) was missing.
- VS Code / MCP tool calls (manage_todo_list, vscode_get_terminal_confirmation) appeared twice with identical span IDs.
- Local sessions worked correctly; only the CLI path was affected.

#### Root Cause
The @github/copilot SDK (v1.0.61) emits OpenTelemetry from a native runtime and registers no JS OTel provider. The CopilotCliBridgeSpanProcessor was attaching to api.trace.getTracerProvider(), expecting the SDK's JS provider — but that resolved to the extension's own NodeTracerProvider. As a result:

- The bridge re-forwarded spans the extension already emits → duplicates.
- SDK-native spans (chat + native tools) never reach JS → missing entries.

#### Fix

- otelServiceImpl.ts — Tag the extension's NodeTracerProvider with a __copilotChatOwnProvider sentinel so consumers can detect it as the global provider.

- copilotcliSessionService.ts — _installBridgeIfNeeded now skips installing the bridge when the resolved provider carries that sentinel (attaching would only duplicate the extension's own spans). Forward-compatible: a future SDK that registers its own JS provider would not carry the flag, so the bridge attaches as originally intended.
 
- copilotcliSession.ts — Synthesize the missing spans directly from the SDK event stream:

  - execute_tool spans from tool.execution_start / tool.execution_complete, only for native tools (no mcpServerName), parented to the invoke_agent span (or the parent tool span for subagent nesting).
  - A chat span at request completion carrying the accumulated assistant text + model → produces the llm_request and agent_response entries.
  - Leftover synthetic tool spans are closed in the finally block as an abort safety net.