### PR TITLE
extensions: migrate auto update setting to on/off values

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -358,6 +358,50 @@
             "included": true
         },
         {
+            "key": "extensions.autoUpdate",
+            "name": "ExtensionsAutoUpdate",
+            "category": "Extensions",
+            "minimumVersion": "1.125",
+            "localization": {
+                "description": {
+                    "key": "extensions.autoUpdate",
+                    "value": "Controls the automatic update behavior of extensions. The updates are fetched from a Microsoft online service."
+                },
+                "enumDescriptions": [
+                    {
+                        "key": "extensions.autoUpdate.on",
+                        "value": "Download and install updates automatically only for enabled extensions."
+                    },
+                    {
+                        "key": "extensions.autoUpdate.off",
+                        "value": "Extensions are not automatically updated."
+                    }
+                ]
+            },
+            "type": "string",
+            "default": "on",
+            "enum": [
+                "on",
+                "off"
+            ],
+            "included": true
+        },
+        {
+            "key": "extensions.autoUpdateDelay",
+            "name": "ExtensionsAutoUpdateDelay",
+            "category": "Extensions",
+            "minimumVersion": "1.125",
+            "localization": {
+                "description": {
+                    "key": "extensions.autoUpdateDelay",
+                    "value": "Controls the delay in hours after an extension update is published before it is automatically installed. Only applies when `#extensions.autoUpdate#` is set to `on`. This delay helps avoid installing potentially problematic updates immediately after release."
+                }
+            },
+            "type": "number",
+            "default": 2,
+            "included": true
+        },
+        {
             "key": "chat.tools.terminal.enableAutoApprove",
             "name": "ChatToolsTerminalEnableAutoApprove",
             "category": "IntegratedTerminal",

--- a/src/vs/workbench/contrib/chat/browser/pluginAutoUpdate.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginAutoUpdate.ts
@@ -23,8 +23,9 @@ import { IPluginMarketplaceService } from '../common/plugins/pluginMarketplaceSe
  * were never auto-updated (see microsoft/vscode#308563).
  *
  * When the signal becomes `true` and `extensions.autoUpdate` is `on`, we
- * silently update all installed plugins. When auto-update is `off`
- * (internally `false`), plugins are not auto-updated.
+ * silently update all installed plugins. When auto-update is `off`, plugins
+ * are not auto-updated. (`getAutoUpdateValue()` normalizes the setting to
+ * `'on' | 'off'`, migrating any legacy stored values such as `false`.)
  *
  * The flag is cleared after every attempt — including failures — so the
  * next periodic check's `false → true` transition can always re-trigger the

--- a/src/vs/workbench/contrib/chat/browser/pluginAutoUpdate.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginAutoUpdate.ts
@@ -22,11 +22,9 @@ import { IPluginMarketplaceService } from '../common/plugins/pluginMarketplaceSe
  * Without this contribution, that signal was never consumed and plugins
  * were never auto-updated (see microsoft/vscode#308563).
  *
- * When the signal becomes `true` and `extensions.autoUpdate === true`, we
- * silently update all installed plugins. Other auto-update modes
- * (`'onlyEnabledExtensions'`, `'onlySelectedExtensions'`) gate updates on a
- * per-extension opt-in that has no plugin equivalent, so they are treated
- * the same as `false` for plugins.
+ * When the signal becomes `true` and `extensions.autoUpdate` is `on`, we
+ * silently update all installed plugins. When auto-update is `off`
+ * (internally `false`), plugins are not auto-updated.
  *
  * The flag is cleared after every attempt — including failures — so the
  * next periodic check's `false → true` transition can always re-trigger the
@@ -61,7 +59,7 @@ export class PluginAutoUpdate extends Disposable implements IWorkbenchContributi
 		}
 
 		const autoUpdate = this._extensionsWorkbenchService.getAutoUpdateValue();
-		if (autoUpdate !== true) {
+		if (autoUpdate === 'off') {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -741,7 +741,7 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 	// --- Periodic update check ------------------------------------------------
 
 	private _isAutoUpdateEnabled(): boolean {
-		return this._extensionsWorkbenchService.getAutoUpdateValue() === true;
+		return this._extensionsWorkbenchService.getAutoUpdateValue() !== 'off';
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/pluginAutoUpdate.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/pluginAutoUpdate.test.ts
@@ -66,13 +66,13 @@ suite('PluginAutoUpdate', () => {
 	}
 
 	test('does not trigger update on construction', async () => {
-		const { state } = createContribution(true);
+		const { state } = createContribution('on');
 		await flushMicrotasks();
 		assert.deepStrictEqual(state.updateAllCalls, []);
 	});
 
 	test('triggers silent updateAllPlugins when hasUpdatesAvailable becomes true', async () => {
-		const { state } = createContribution(true);
+		const { state } = createContribution('on');
 
 		state.hasUpdatesAvailable.set(true, undefined);
 		await flushMicrotasks();
@@ -80,8 +80,8 @@ suite('PluginAutoUpdate', () => {
 		assert.deepStrictEqual(state.updateAllCalls, [{ silent: true }]);
 	});
 
-	test('does not trigger update when extensions.autoUpdate is false', async () => {
-		const { state } = createContribution(false);
+	test('does not trigger update when extensions.autoUpdate is off', async () => {
+		const { state } = createContribution('off');
 
 		state.hasUpdatesAvailable.set(true, undefined);
 		await flushMicrotasks();
@@ -89,17 +89,13 @@ suite('PluginAutoUpdate', () => {
 		assert.deepStrictEqual(state.updateAllCalls, []);
 	});
 
-	test('does not trigger update for non-true auto-update values like onlyEnabledExtensions', async () => {
-		// Plugins have no per-item opt-in equivalent to extensions, so only
-		// `true` (update everything) opts plugins into auto-update.
-		for (const value of ['onlyEnabledExtensions', 'onlySelectedExtensions'] as const) {
-			const { state } = createContribution(value);
+	test('triggers update when extensions.autoUpdate is on', async () => {
+		const { state } = createContribution('on');
 
-			state.hasUpdatesAvailable.set(true, undefined);
-			await flushMicrotasks();
+		state.hasUpdatesAvailable.set(true, undefined);
+		await flushMicrotasks();
 
-			assert.deepStrictEqual(state.updateAllCalls, [], `expected no update for autoUpdate=${value}`);
-		}
+		assert.deepStrictEqual(state.updateAllCalls, [{ silent: true }]);
 	});
 
 	test('does not run a second update concurrently with one in flight', async () => {
@@ -107,7 +103,7 @@ suite('PluginAutoUpdate', () => {
 		const pendingUpdate = new Promise<IUpdateAllPluginsResult>(resolve => {
 			resolveUpdate = () => resolve({ updatedNames: [], failedNames: [] });
 		});
-		const { state } = createContribution(true, {
+		const { state } = createContribution('on', {
 			updateAllImpl: () => pendingUpdate,
 		});
 
@@ -127,7 +123,7 @@ suite('PluginAutoUpdate', () => {
 	});
 
 	test('continues running on subsequent cycles after the previous update finished', async () => {
-		const { state } = createContribution(true);
+		const { state } = createContribution('on');
 
 		state.hasUpdatesAvailable.set(true, undefined);
 		await flushMicrotasks();
@@ -144,7 +140,7 @@ suite('PluginAutoUpdate', () => {
 	});
 
 	test('swallows errors from updateAllPlugins', async () => {
-		const { state } = createContribution(true, {
+		const { state } = createContribution('on', {
 			updateAllImpl: async () => { throw new Error('boom'); },
 		});
 
@@ -167,7 +163,7 @@ suite('PluginAutoUpdate', () => {
 		// path in `PluginInstallService.updateAllPlugins`). Without our own
 		// clear in `finally`, the observable would stay stuck at `true` and
 		// the next periodic check's `set(true)` would not notify subscribers.
-		const { state } = createContribution(true, {
+		const { state } = createContribution('on', {
 			updateAllImpl: async () => ({ updatedNames: [], failedNames: ['plugin-a'] }),
 		});
 
@@ -188,7 +184,7 @@ suite('PluginAutoUpdate', () => {
 	});
 
 	test('clears the flag even when updateAllPlugins throws', async () => {
-		const { state } = createContribution(true, {
+		const { state } = createContribution('on', {
 			updateAllImpl: async () => { throw new Error('boom'); },
 		});
 

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -400,7 +400,7 @@ suite('PluginMarketplaceService - GitHub marketplace refs', () => {
 			onDidChangeTrust: Event.None,
 		} as Partial<IWorkspaceTrustManagementService> as IWorkspaceTrustManagementService);
 		instantiationService.stub(IExtensionsWorkbenchService, {
-			getAutoUpdateValue: () => true,
+			getAutoUpdateValue: () => 'on',
 		} as Partial<IExtensionsWorkbenchService> as IExtensionsWorkbenchService);
 
 		const service = store.add(instantiationService.createInstance(PluginMarketplaceService));
@@ -439,7 +439,7 @@ suite('PluginMarketplaceService - getMarketplacePluginMetadata', () => {
 			onDidChangeTrust: Event.None,
 		} as Partial<IWorkspaceTrustManagementService> as IWorkspaceTrustManagementService);
 		instantiationService.stub(IExtensionsWorkbenchService, {
-			getAutoUpdateValue: () => true,
+			getAutoUpdateValue: () => 'on',
 		} as Partial<IExtensionsWorkbenchService> as IExtensionsWorkbenchService);
 
 		return store.add(instantiationService.createInstance(PluginMarketplaceService));
@@ -518,7 +518,7 @@ suite('PluginMarketplaceService - installed plugins lifecycle', () => {
 			onDidChangeTrust: Event.None,
 		} as Partial<IWorkspaceTrustManagementService> as IWorkspaceTrustManagementService);
 		instantiationService.stub(IExtensionsWorkbenchService, {
-			getAutoUpdateValue: () => true,
+			getAutoUpdateValue: () => 'on',
 		} as Partial<IExtensionsWorkbenchService> as IExtensionsWorkbenchService);
 
 		return store.add(instantiationService.createInstance(PluginMarketplaceService));
@@ -738,7 +738,7 @@ suite('PluginMarketplaceService - hydration after restart', () => {
 			onDidChangeTrust: Event.None,
 		} as Partial<IWorkspaceTrustManagementService> as IWorkspaceTrustManagementService);
 		instantiationService.stub(IExtensionsWorkbenchService, {
-			getAutoUpdateValue: () => true,
+			getAutoUpdateValue: () => 'on',
 		} as Partial<IExtensionsWorkbenchService> as IExtensionsWorkbenchService);
 
 		const service = store.add(instantiationService.createInstance(PluginMarketplaceService));
@@ -791,7 +791,7 @@ suite('PluginMarketplaceService - hydration after restart', () => {
 				onDidChangeTrust: Event.None,
 			} as Partial<IWorkspaceTrustManagementService> as IWorkspaceTrustManagementService);
 			instantiationService.stub(IExtensionsWorkbenchService, {
-				getAutoUpdateValue: () => true,
+				getAutoUpdateValue: () => 'on',
 			} as Partial<IExtensionsWorkbenchService> as IExtensionsWorkbenchService);
 			return store.add(instantiationService.createInstance(PluginMarketplaceService));
 		}

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -158,7 +158,17 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 						description: {
 							key: 'extensions.autoUpdate',
 							value: localize('extensions.autoUpdate', "Controls the automatic update behavior of extensions. The updates are fetched from a Microsoft online service."),
-						}
+						},
+						enumDescriptions: [
+							{
+								key: 'extensions.autoUpdate.on',
+								value: localize('extensions.autoUpdate.on', 'Download and install updates automatically only for enabled extensions.'),
+							},
+							{
+								key: 'extensions.autoUpdate.off',
+								value: localize('extensions.autoUpdate.off', 'Extensions are not automatically updated.'),
+							},
+						]
 					}
 				}
 			},
@@ -758,7 +768,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 		const enableAutoUpdateWhenCondition = ContextKeyExpr.equals(`config.${AutoUpdateConfigurationKey}`, 'off');
 		this.registerExtensionAction({
 			id: 'workbench.extensions.action.enableAutoUpdate',
-			title: localize2('enableAutoUpdate', 'Enable Auto Update for All Extensions'),
+			title: localize2('enableAutoUpdate', 'Enable Auto Update for Extensions'),
 			category: ExtensionsLocalizedLabel,
 			precondition: enableAutoUpdateWhenCondition,
 			menu: [{
@@ -775,7 +785,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 		const disableAutoUpdateWhenCondition = ContextKeyExpr.notEquals(`config.${AutoUpdateConfigurationKey}`, 'off');
 		this.registerExtensionAction({
 			id: 'workbench.extensions.action.disableAutoUpdate',
-			title: localize2('disableAutoUpdate', 'Disable Auto Update for All Extensions'),
+			title: localize2('disableAutoUpdate', 'Disable Auto Update for Extensions'),
 			precondition: disableAutoUpdateWhenCondition,
 			category: ExtensionsLocalizedLabel,
 			menu: [{

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -136,22 +136,49 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 		type: 'object',
 		properties: {
 			'extensions.autoUpdate': {
-				type: ['boolean', 'string'],
-				enum: [true, 'onlyEnabledExtensions', false,],
+				type: 'string',
+				enum: ['on', 'off'],
 				enumItemLabels: [
-					localize('all', "All Extensions"),
-					localize('enabled', "Only Enabled Extensions"),
-					localize('none', "None"),
+					localize('on', "On"),
+					localize('off', "Off"),
 				],
 				enumDescriptions: [
-					localize('extensions.autoUpdate.true', 'Download and install updates automatically for all extensions.'),
-					localize('extensions.autoUpdate.enabled', 'Download and install updates automatically only for enabled extensions.'),
-					localize('extensions.autoUpdate.false', 'Extensions are not automatically updated.'),
+					localize('extensions.autoUpdate.on', 'Download and install updates automatically only for enabled extensions.'),
+					localize('extensions.autoUpdate.off', 'Extensions are not automatically updated.'),
 				],
 				description: localize('extensions.autoUpdate', "Controls the automatic update behavior of extensions. The updates are fetched from a Microsoft online service."),
-				default: true,
+				default: 'on',
 				scope: ConfigurationScope.APPLICATION,
-				tags: ['usesOnlineServices']
+				tags: ['usesOnlineServices'],
+				policy: {
+					name: 'ExtensionsAutoUpdate',
+					category: PolicyCategory.Extensions,
+					minimumVersion: '1.125',
+					localization: {
+						description: {
+							key: 'extensions.autoUpdate',
+							value: localize('extensions.autoUpdate', "Controls the automatic update behavior of extensions. The updates are fetched from a Microsoft online service."),
+						}
+					}
+				}
+			},
+			'extensions.autoUpdateDelay': {
+				type: 'number',
+				default: 2,
+				minimum: 0,
+				markdownDescription: localize('extensions.autoUpdateDelay', "Controls the delay in hours after an extension update is published before it is automatically installed. Only applies when `#extensions.autoUpdate#` is set to `on`. This delay helps avoid installing potentially problematic updates immediately after release."),
+				scope: ConfigurationScope.APPLICATION,
+				policy: {
+					name: 'ExtensionsAutoUpdateDelay',
+					category: PolicyCategory.Extensions,
+					minimumVersion: '1.125',
+					localization: {
+						description: {
+							key: 'extensions.autoUpdateDelay',
+							value: localize('extensions.autoUpdateDelay', "Controls the delay in hours after an extension update is published before it is automatically installed. Only applies when `#extensions.autoUpdate#` is set to `on`. This delay helps avoid installing potentially problematic updates immediately after release."),
+						}
+					}
+				}
 			},
 			'extensions.autoCheckUpdates': {
 				type: 'boolean',
@@ -728,7 +755,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 			}
 		});
 
-		const enableAutoUpdateWhenCondition = ContextKeyExpr.equals(`config.${AutoUpdateConfigurationKey}`, false);
+		const enableAutoUpdateWhenCondition = ContextKeyExpr.equals(`config.${AutoUpdateConfigurationKey}`, 'off');
 		this.registerExtensionAction({
 			id: 'workbench.extensions.action.enableAutoUpdate',
 			title: localize2('enableAutoUpdate', 'Enable Auto Update for All Extensions'),
@@ -745,7 +772,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 			run: (accessor: ServicesAccessor) => accessor.get(IExtensionsWorkbenchService).updateAutoUpdateForAllExtensions(true)
 		});
 
-		const disableAutoUpdateWhenCondition = ContextKeyExpr.notEquals(`config.${AutoUpdateConfigurationKey}`, false);
+		const disableAutoUpdateWhenCondition = ContextKeyExpr.notEquals(`config.${AutoUpdateConfigurationKey}`, 'off');
 		this.registerExtensionAction({
 			id: 'workbench.extensions.action.disableAutoUpdate',
 			title: localize2('disableAutoUpdate', 'Disable Auto Update for All Extensions'),
@@ -1440,7 +1467,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 			id: ToggleAutoUpdateForExtensionAction.ID,
 			title: ToggleAutoUpdateForExtensionAction.LABEL,
 			category: ExtensionsLocalizedLabel,
-			precondition: ContextKeyExpr.and(ContextKeyExpr.or(ContextKeyExpr.notEquals(`config.${AutoUpdateConfigurationKey}`, 'onlyEnabledExtensions'), ContextKeyExpr.equals('isExtensionEnabled', true)), ContextKeyExpr.not('extensionDisallowInstall'), ContextKeyExpr.has('isExtensionAllowed')),
+			precondition: ContextKeyExpr.and(ContextKeyExpr.or(ContextKeyExpr.notEquals(`config.${AutoUpdateConfigurationKey}`, 'on'), ContextKeyExpr.equals('isExtensionEnabled', true)), ContextKeyExpr.not('extensionDisallowInstall'), ContextKeyExpr.has('isExtensionAllowed')),
 			menu: {
 				id: MenuId.ExtensionContext,
 				group: UPDATE_ACTIONS_GROUP,
@@ -1467,7 +1494,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 			id: ToggleAutoUpdatesForPublisherAction.ID,
 			title: { value: ToggleAutoUpdatesForPublisherAction.LABEL, original: 'Auto Update (Publisher)' },
 			category: ExtensionsLocalizedLabel,
-			precondition: ContextKeyExpr.equals(`config.${AutoUpdateConfigurationKey}`, false),
+			precondition: ContextKeyExpr.equals(`config.${AutoUpdateConfigurationKey}`, 'off'),
 			menu: {
 				id: MenuId.ExtensionContext,
 				group: UPDATE_ACTIONS_GROUP,
@@ -2095,18 +2122,26 @@ registerAction2(class ExtensionsGallerySignInAction extends Action2 {
 Registry.as<IConfigurationMigrationRegistry>(ConfigurationMigrationExtensions.ConfigurationMigration)
 	.registerConfigurationMigrations([{
 		key: AutoUpdateConfigurationKey,
+		/**
+		 * Migrates the `extensions.autoUpdate` setting to its new `'on' | 'off'` values.
+		 *
+		 * The setting previously supported several values that are now retired:
+		 * - `true` (All Extensions) and `'onlyEnabledExtensions'` (Only Enabled Extensions)
+		 *   are folded into the new `'on'` value, along with the insiders-only `'delayed'` value.
+		 * - `false` (None) and the internal `'onlySelectedExtensions'` value map to `'off'`.
+		 *   In `'off'` mode, extensions explicitly opted in per-extension are still auto-updated,
+		 *   which preserves the `'onlySelectedExtensions'` behavior.
+		 *
+		 * Returning `[]` is a no-op, used when the value is already in the new format
+		 * (`'on'`/`'off'`) or unset.
+		 */
 		migrateFn: (value, accessor) => {
-			if (value === 'onlySelectedExtensions') {
-				return { value: false };
+			if (value === undefined || value === 'on' || value === 'off') {
+				return [];
 			}
-			// Migrate insiders values ('on' | 'delayed' | 'off') that were
-			// rolled out with the delayed auto-update mode back to booleans.
-			if (value === 'on' || value === 'delayed') {
-				return { value: true };
+			if (value === false || value === 'onlySelectedExtensions') {
+				return { value: 'off' };
 			}
-			if (value === 'off') {
-				return { value: false };
-			}
-			return [];
+			return { value: 'on' };
 		}
 	}]);

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1087,7 +1087,7 @@ export class ToggleAutoUpdateForExtensionAction extends ExtensionAction {
 		if (extension && this.allowedExtensionsService.isAllowed(extension) !== true) {
 			return;
 		}
-		if (this.extensionsWorkbenchService.getAutoUpdateValue() === 'onlyEnabledExtensions' && !this.extensionEnablementService.isEnabledEnablementState(this.extension.enablementState)) {
+		if (this.extensionsWorkbenchService.getAutoUpdateValue() === 'on' && !this.extensionEnablementService.isEnabledEnablementState(this.extension.enablementState)) {
 			return;
 		}
 		this.enabled = true;

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -1135,6 +1135,16 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 				// The auto update value affects whether an extension is shown as delayed
 				this._onChange.fire(undefined);
 			}
+			if (e.affectsConfiguration(AutoUpdateDelayConfigurationKey)) {
+				// The delay affects when delayed updates are applied — cancel any pending
+				// delayed re-check and re-run the scheduling path with the new delay.
+				this.delayedAutoUpdateCheckTimer.value = undefined;
+				if (this.isAutoUpdateEnabled()) {
+					this.eventuallyAutoUpdateExtensions();
+				}
+				// The delay affects whether an extension is shown as delayed
+				this._onChange.fire(undefined);
+			}
 			if (e.affectsConfiguration(AutoCheckUpdatesConfigurationKey)) {
 				if (this.isAutoCheckUpdatesEnabled()) {
 					this.checkForUpdates(`Enabled auto check updates`);
@@ -1259,8 +1269,8 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 		const result = await this.dialogService.confirm({
 			title: nls.localize('confirmEnableDisableAutoUpdate', "Auto Update Extensions"),
 			message: isAutoUpdateEnabled
-				? nls.localize('confirmEnableAutoUpdate', "Do you want to enable auto update for all extensions?")
-				: nls.localize('confirmDisableAutoUpdate', "Do you want to disable auto update for all extensions?"),
+				? nls.localize('confirmEnableAutoUpdate', "Do you want to enable auto update for extensions?")
+				: nls.localize('confirmDisableAutoUpdate', "Do you want to disable auto update for extensions?"),
 			detail: nls.localize('confirmEnableDisableAutoUpdateDetail', "This will reset any auto update settings you have set for individual extensions."),
 		});
 		if (!result.confirmed) {

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -34,7 +34,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IHostService } from '../../../services/host/browser/host.js';
 import { URI } from '../../../../base/common/uri.js';
-import { IExtension, ExtensionState, IExtensionsWorkbenchService, AutoUpdateConfigurationKey, AutoCheckUpdatesConfigurationKey, HasOutdatedExtensionsContext, AutoUpdateConfigurationValue, InstallExtensionOptions, ExtensionRuntimeState, ExtensionRuntimeActionType, AutoRestartConfigurationKey, VIEWLET_ID, IExtensionsViewPaneContainer, IExtensionsNotification } from '../common/extensions.js';
+import { IExtension, ExtensionState, IExtensionsWorkbenchService, AutoUpdateConfigurationKey, AutoUpdateDelayConfigurationKey, AutoCheckUpdatesConfigurationKey, HasOutdatedExtensionsContext, AutoUpdateConfigurationValue, InstallExtensionOptions, ExtensionRuntimeState, ExtensionRuntimeActionType, AutoRestartConfigurationKey, VIEWLET_ID, IExtensionsViewPaneContainer, IExtensionsNotification } from '../common/extensions.js';
 import { ACTIVE_GROUP, IEditorService, MODAL_GROUP, SIDE_GROUP } from '../../../services/editor/common/editorService.js';
 import { IURLService, IURLHandler, IOpenURLOptions } from '../../../../platform/url/common/url.js';
 import { ExtensionsInput, IExtensionEditorOptions } from '../common/extensionsInput.js';
@@ -52,7 +52,7 @@ import { FileAccess } from '../../../../base/common/network.js';
 import { IIgnoredExtensionsManagementService } from '../../../../platform/userDataSync/common/ignoredExtensions.js';
 import { IUserDataAutoSyncService, IUserDataSyncEnablementService, SyncResource } from '../../../../platform/userDataSync/common/userDataSync.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
-import { isBoolean, isDefined, isString, isUndefined } from '../../../../base/common/types.js';
+import { isDefined, isString, isUndefined } from '../../../../base/common/types.js';
 import { IExtensionManifestPropertiesService } from '../../../services/extensions/common/extensionManifestPropertiesService.js';
 import { IExtensionService, IExtensionsStatus as IExtensionRuntimeStatus, toExtension, toExtensionDescription } from '../../../services/extensions/common/extensions.js';
 import { isWeb, language } from '../../../../base/common/platform.js';
@@ -80,8 +80,6 @@ import { IMeteredConnectionService } from '../../../../platform/meteredConnectio
 interface IExtensionStateProvider<T> {
 	(extension: Extension): T;
 }
-
-const DELAYED_AUTO_UPDATE_PERIOD = 2 * 60 * 60 * 1000; // 2 hours in milliseconds
 
 interface InstalledExtensionsEvent {
 	readonly extensionIds: TelemetryTrustedValue<string>;
@@ -1144,7 +1142,7 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 			}
 		}));
 		this._register(this.extensionEnablementService.onEnablementChanged(platformExtensions => {
-			if (this.isAutoCheckUpdatesEnabled() && this.getAutoUpdateValue() === 'onlyEnabledExtensions' && platformExtensions.some(e => this.extensionEnablementService.isEnabled(e))) {
+			if (this.isAutoCheckUpdatesEnabled() && this.getAutoUpdateValue() === 'on' && platformExtensions.some(e => this.extensionEnablementService.isEnabled(e))) {
 				this.checkForUpdates('Extension enablement changed');
 			}
 		}));
@@ -1202,18 +1200,15 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 		if (this.meteredConnectionService.isConnectionMetered) {
 			return false;
 		}
-		return this.getAutoUpdateValue() !== false;
+		return this.getAutoUpdateValue() !== 'off';
 	}
 
 	getAutoUpdateValue(): AutoUpdateConfigurationValue {
-		const autoUpdate = this.configurationService.getValue<AutoUpdateConfigurationValue | 'on' | 'off' | 'delayed'>(AutoUpdateConfigurationKey);
-		if (autoUpdate === 'onlySelectedExtensions' || autoUpdate === 'off') {
-			return false;
+		const autoUpdate = this.configurationService.getValue<AutoUpdateConfigurationValue | boolean | 'onlyEnabledExtensions' | 'onlySelectedExtensions' | 'delayed'>(AutoUpdateConfigurationKey);
+		if (autoUpdate === 'off' || autoUpdate === false || autoUpdate === 'onlySelectedExtensions') {
+			return 'off';
 		}
-		if (autoUpdate === 'on' || autoUpdate === 'delayed') {
-			return true;
-		}
-		return isBoolean(autoUpdate) || autoUpdate === 'onlyEnabledExtensions' ? autoUpdate : true;
+		return 'on';
 	}
 
 	isAutoUpdateDelayed(extension: IExtension): boolean {
@@ -1240,7 +1235,9 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 			// Future timestamp (clock skew) — treat as not delayed
 			return 0;
 		}
-		return Math.max(0, DELAYED_AUTO_UPDATE_PERIOD - elapsed);
+		const delayHours = this.configurationService.getValue<number>(AutoUpdateDelayConfigurationKey) ?? 2;
+		const delayPeriod = delayHours * 60 * 60 * 1000; // Convert hours to milliseconds
+		return Math.max(0, delayPeriod - elapsed);
 	}
 
 	private isFromTrustedPublisher(extension: IExtension): boolean {
@@ -1273,7 +1270,7 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 		// Reset extensions enabled for auto update first to prevent them from being updated
 		this.setEnabledAutoUpdateExtensions([]);
 
-		await this.configurationService.updateValue(AutoUpdateConfigurationKey, isAutoUpdateEnabled);
+		await this.configurationService.updateValue(AutoUpdateConfigurationKey, isAutoUpdateEnabled ? 'on' : 'off');
 
 		this.setDisabledAutoUpdateExtensions([]);
 		await this.updateExtensionsPinnedState(!isAutoUpdateEnabled);
@@ -2329,7 +2326,7 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 
 		const autoUpdateValue = this.getAutoUpdateValue();
 
-		if (autoUpdateValue === false) {
+		if (autoUpdateValue === 'off') {
 			const extensionsToAutoUpdate = this.getEnabledAutoUpdateExtensions();
 			const extensionId = extension.identifier.id.toLowerCase();
 			if (extensionsToAutoUpdate.includes(extensionId)) {
@@ -2350,15 +2347,8 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 			return false;
 		}
 
-		if (autoUpdateValue === true) {
-			return true;
-		}
-
-		if (autoUpdateValue === 'onlyEnabledExtensions') {
-			return extension.enablementState !== EnablementState.DisabledGlobally && extension.enablementState !== EnablementState.DisabledWorkspace;
-		}
-
-		return false;
+		// Auto-update is on; only update enabled extensions.
+		return extension.enablementState !== EnablementState.DisabledGlobally && extension.enablementState !== EnablementState.DisabledWorkspace;
 	}
 
 	async shouldRequireConsentToUpdate(extension: IExtension): Promise<string | undefined> {

--- a/src/vs/workbench/contrib/extensions/common/extensions.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensions.ts
@@ -187,14 +187,16 @@ export const enum ExtensionEditorTab {
 
 export const ConfigurationKey = 'extensions';
 export const AutoUpdateConfigurationKey = 'extensions.autoUpdate';
+export const AutoUpdateDelayConfigurationKey = 'extensions.autoUpdateDelay';
 export const AutoCheckUpdatesConfigurationKey = 'extensions.autoCheckUpdates';
 export const CloseExtensionDetailsOnViewChangeKey = 'extensions.closeExtensionDetailsOnViewChange';
 export const AutoRestartConfigurationKey = 'extensions.autoRestart';
 
-export type AutoUpdateConfigurationValue = boolean | 'onlyEnabledExtensions' | 'onlySelectedExtensions';
+export type AutoUpdateConfigurationValue = 'on' | 'off';
 
 export interface IExtensionsConfiguration {
 	autoUpdate: AutoUpdateConfigurationValue;
+	autoUpdateDelay: number;
 	autoCheckUpdates: boolean;
 	ignoreRecommendations: boolean;
 	closeExtensionDetailsOnViewChange: boolean;

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
@@ -6,7 +6,7 @@
 import * as sinon from 'sinon';
 import assert from 'assert';
 import { generateUuid } from '../../../../../base/common/uuid.js';
-import { ExtensionState, AutoCheckUpdatesConfigurationKey, AutoUpdateConfigurationKey, ExtensionRuntimeActionType, AutoUpdateConfigurationValue } from '../../common/extensions.js';
+import { ExtensionState, AutoCheckUpdatesConfigurationKey, AutoUpdateConfigurationKey, AutoUpdateDelayConfigurationKey, ExtensionRuntimeActionType, AutoUpdateConfigurationValue } from '../../common/extensions.js';
 import { ExtensionsWorkbenchService } from '../../browser/extensionsWorkbenchService.js';
 import {
 	IExtensionManagementService, IExtensionGalleryService, ILocalExtension, IGalleryExtension,
@@ -1792,6 +1792,7 @@ suite('ExtensionsWorkbenchServiceTest', () => {
 	function stubConfiguration(autoUpdateValue?: any, autoCheckUpdatesValue?: any): void {
 		const values: any = {
 			[AutoUpdateConfigurationKey]: autoUpdateValue ?? true,
+			[AutoUpdateDelayConfigurationKey]: 2,
 			[AutoCheckUpdatesConfigurationKey]: autoCheckUpdatesValue ?? true
 		};
 		const emitter = disposableStore.add(new Emitter<IConfigurationChangeEvent>());

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
@@ -489,15 +489,15 @@ suite('ExtensionsWorkbenchServiceTest', () => {
 		assert.strictEqual(testObject.isAutoUpdateDelayed(testObject.local[0]), false);
 	});
 
-	test('test getAutoUpdateValue normalizes legacy insiders values', async () => {
+	test('test getAutoUpdateValue normalizes legacy and migrated values', async () => {
 		const expected = new Map<unknown, AutoUpdateConfigurationValue>([
-			['on', true],
-			['delayed', true],
-			['off', false],
-			['onlySelectedExtensions', false],
-			[true, true],
-			[false, false],
-			['onlyEnabledExtensions', 'onlyEnabledExtensions'],
+			['on', 'on'],
+			['off', 'off'],
+			['delayed', 'on'],
+			['onlySelectedExtensions', 'off'],
+			[true, 'on'],
+			[false, 'off'],
+			['onlyEnabledExtensions', 'on'],
 		]);
 		for (const [configured, normalized] of expected) {
 			stubConfiguration(configured);


### PR DESCRIPTION
Migrates the `extensions.autoUpdate` setting from its boolean/enum values to simple `on`/`off` string values, and adds a new configurable auto-update delay.

### `extensions.autoUpdate` value migration
- **`on`** replaces the previous `onlyEnabledExtensions` behavior. The retired `true` (All Extensions) and insiders-only `delayed` values also migrate to `on`.
- **`off`** replaces `false`. The internal `onlySelectedExtensions` value also migrates to `off` (off-mode still honors per-extension opt-ins, preserving that behavior).

A `migrateFn` handles all legacy stored values, and `getAutoUpdateValue()` now returns only `'on' | 'off'`.

### New `extensions.autoUpdateDelay` setting
- Controls the delay (in **hours**) after an extension update is published before it's automatically installed.
- Default: `2` hours, replacing the previously hardcoded `DELAYED_AUTO_UPDATE_PERIOD` constant.
- Only applies when `extensions.autoUpdate` is `on`.

### Policy support
Both settings are now policy-enabled (`ExtensionsAutoUpdate`, `ExtensionsAutoUpdateDelay`) under the `Extensions` category for enterprise management.