### PR TITLE
WIP: CSS cascade-order dependency fuzzer for component fixtures

### DIFF
--- a/build/rspack/cssSourceMarkerLoader.ts
+++ b/build/rspack/cssSourceMarkerLoader.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as path from 'path';
+
+/**
+ * Prepends a marker comment with the CSS module's repo-relative source path.
+ *
+ * Native CSS (`experiments.css`) concatenates every imported `.css` module into
+ * a single stylesheet, but it preserves comments. This marker therefore lets
+ * tooling that reads the bundled stylesheet (e.g. the cascade-order-dependency
+ * detector and its bisection) map each concatenated "document" back to the
+ * exact source file by name, instead of relying on the generic copyright
+ * banner which carries no filename.
+ *
+ * `this.rootContext` is the rspack `context` option (the repo root), so no
+ * `__dirname` handling is needed.
+ */
+export default function cssSourceMarkerLoader(this: { resourcePath: string; rootContext: string }, source: string): string {
+	const rel = path.relative(this.rootContext, this.resourcePath).replace(/\\/g, '/');
+	return `/* @css-source: ${rel} */\n${source}`;
+}

--- a/build/rspack/rspack.serve-out.config.mts
+++ b/build/rspack/rspack.serve-out.config.mts
@@ -66,6 +66,10 @@ export default {
 			{
 				test: /\.css$/,
 				type: 'css',
+				// Tag every CSS module with its repo-relative source path (as a
+				// comment that native CSS preserves) so tooling reading the
+				// bundled stylesheet can map concatenated documents back to files.
+				use: [path.join(__dirname, 'cssSourceMarkerLoader.ts')],
 			},
 			{
 				test: /\.ttf$/,

--- a/src/vs/workbench/test/browser/componentFixtures/CSS_ORDER_FUZZER_TODO.md
+++ b/src/vs/workbench/test/browser/componentFixtures/CSS_ORDER_FUZZER_TODO.md
@@ -1,0 +1,64 @@
+# CSS Cascade-Order Dependency Fuzzer — TODO
+
+Tooling to detect and localize CSS cascade-order dependencies in VS Code
+component fixtures. Fixtures render through `@vscode/component-explorer` over an
+rspack `serve-out` build that concatenates all CSS into one native-CSS bundle,
+so the cascade order of source files can silently affect rendering.
+
+## What's done (in this branch)
+
+- **Input-driven stylesheet reversal** — `installGlobalStyles` accepts a
+  `reverseStylesheets` option (`true` = reverse all documents, or
+  `{ fromIndex, toIndex }` = reverse only that index window). Driven per-run via
+  the render `--input` flag (`parseStyleOptions` in `fixtureUtils.ts`), not via
+  global state. See `fixtureUtilsCss.ts`.
+- **`@css-source` marker loader** — `build/rspack/cssSourceMarkerLoader.ts`
+  prepends each CSS module's repo-relative source path as a comment that native
+  CSS preserves, so tooling can map concatenated bundle "documents" back to
+  source files. Wired into the `.css` rule in `rspack.serve-out.config.mts`.
+
+## What's still missing
+
+### 1. Verify the `.ts` loader actually runs (blocker)
+The loader was converted from `.cjs` to `.ts` to satisfy
+`local/code-no-new-javascript-files`. Confirm rspack/`@rspack/cli` can load a
+`.ts` loader directly in the `serve-out` setup:
+- Do one clean rebuild and check that `/bundled/workbench.css` still contains
+  `@css-source` markers (expected ~294 across the bundle, ~153 within a single
+  fixture's sheets).
+- If rspack cannot transpile a `.ts` loader directly, fall back to inlining the
+  loader function in `rspack.serve-out.config.mts` (it's already `.mts`/ESM).
+
+### 2. Apply the known CSS specificity fix (validation case)
+Fixture `aiCustomizationManagementEditor/LocalHarness/Dark` has an exact
+specificity tie `(0,2,0)` on `display` between:
+- `out/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css`
+  (`.ai-customization-management-editor .section-icon { display: flex }`, etc.)
+- `out/vs/base/browser/ui/codicons/codicon/codicon.css`
+  (`.codicon[class*="codicon-"] { display: inline-block }`)
+
+Product order makes `inline-block` win; reversing `[80..84]` flips icons.
+Fix: raise specificity on the icon rules, e.g.
+`.ai-customization-management-editor .section-icon.codicon { display: flex; }`,
+then re-verify under reversal that the order-dependency is gone.
+
+### 3. Bisection driver
+Add an `applyReversedRange` helper + a driver that does in-page binary search
+against the live `serve` (no rebuilds) to automatically localize which two
+source documents form an order-dependency. Uses the browser as oracle
+(computed-style diff under reversal) — static cascade analysis was abandoned
+(~100% false-positive rate due to `:has`/`:is`/`:where` specificity that can't
+be reconstructed in-page).
+
+### 4. CI guard
+`build/lib/checkStylesheetOrder.ts` + a daily workflow that renders each fixture
+normally and with `--input '{"reverseStylesheets":true}'`, then diffs the
+manifest `imageHash`. A diff means the fixture's appearance depends on CSS
+source order — flag it.
+
+### 5. Component-explorer CLI feature request
+Either of these would remove the need for the bisection driver to boot its own
+rspack server (the expensive part — the bundle is identical for every probe):
+- render input-matrix support (run one fixture across many `--input` values), and/or
+- a `--server-url` attach mode so `render`/bisection can reuse an already-running
+  `serve` instance.

--- a/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
@@ -21,13 +21,11 @@ import '../../../browser/parts/auxiliarybar/media/auxiliaryBarPart.css';
 // Theme
 import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
 import { IExtensionResourceLoaderService } from '../../../../platform/extensionResourceLoader/common/extensionResourceLoader.js';
-import { Registry } from '../../../../platform/registry/common/platform.js';
-import { getIconsStyleSheet } from '../../../../platform/theme/browser/iconsStyleSheet.js';
-import { ColorScheme, ThemeTypeSelector } from '../../../../platform/theme/common/theme.js';
-import { IColorTheme, IThemeService, IThemingRegistry, Extensions as ThemingExtensions } from '../../../../platform/theme/common/themeService.js';
-import { generateColorThemeCSS } from '../../../services/themes/browser/colorThemeCss.js';
+import { ThemeTypeSelector } from '../../../../platform/theme/common/theme.js';
+import { IColorTheme, IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { ColorThemeData } from '../../../services/themes/common/colorThemeData.js';
 import { ExtensionData } from '../../../services/themes/common/workbenchThemeService.js';
+import { installGlobalStyles, InstallGlobalStylesOptions } from './fixtureUtilsCss.js';
 
 // Instantiation
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
@@ -244,9 +242,6 @@ class NullStorageService implements IStorageService {
 // Themes
 // ============================================================================
 
-const themingRegistry = Registry.as<IThemingRegistry>(ThemingExtensions.ThemingContribution);
-const mockEnvironmentService: IEnvironmentService = Object.create(null);
-
 // Eagerly bundle all built-in theme JSON files so they can be served to
 // `_loadColorTheme` via the IExtensionResourceLoaderService code path. The
 // rspack config maps these JSON files to `asset/source`, so they are imported
@@ -296,68 +291,6 @@ function createBuiltInTheme(themePath: string, uiTheme: ThemeTypeSelector): Colo
 export const darkTheme = createBuiltInTheme('/extensions/theme-defaults/themes/dark_modern.json', ThemeTypeSelector.VS_DARK);
 export const lightTheme = createBuiltInTheme('/extensions/theme-defaults/themes/light_modern.json', ThemeTypeSelector.VS);
 
-let globalStyleSheet: CSSStyleSheet | undefined;
-let iconsStyleSheetCache: CSSStyleSheet | undefined;
-let darkThemeStyleSheet: CSSStyleSheet | undefined;
-let lightThemeStyleSheet: CSSStyleSheet | undefined;
-
-function getGlobalStyleSheet(): CSSStyleSheet {
-	if (!globalStyleSheet) {
-		globalStyleSheet = new CSSStyleSheet();
-		const globalRules: string[] = [];
-		for (const sheet of Array.from(document.styleSheets)) {
-			try {
-				for (const rule of Array.from(sheet.cssRules)) {
-					globalRules.push(rule.cssText);
-				}
-			} catch {
-				// Cross-origin stylesheets can't be read
-			}
-		}
-		globalStyleSheet.replaceSync(globalRules.join('\n'));
-	}
-	return globalStyleSheet;
-}
-
-function getIconsStyleSheetCached(): CSSStyleSheet {
-	if (!iconsStyleSheetCache) {
-		iconsStyleSheetCache = new CSSStyleSheet();
-		const iconsSheet = getIconsStyleSheet(undefined);
-		iconsStyleSheetCache.replaceSync(iconsSheet.getCSS() as string);
-		iconsSheet.dispose();
-	}
-	return iconsStyleSheetCache;
-}
-
-function getThemeStyleSheet(theme: ColorThemeData): CSSStyleSheet {
-	const isDark = theme.type === ColorScheme.DARK;
-	if (isDark && darkThemeStyleSheet) {
-		return darkThemeStyleSheet;
-	}
-	if (!isDark && lightThemeStyleSheet) {
-		return lightThemeStyleSheet;
-	}
-
-	const scopeSelector = '.' + theme.classNames[0];
-	const sheet = new CSSStyleSheet();
-	const css = generateColorThemeCSS(
-		theme,
-		scopeSelector,
-		themingRegistry.getThemingParticipants(),
-		mockEnvironmentService
-	);
-	sheet.replaceSync(css.code);
-
-	if (isDark) {
-		darkThemeStyleSheet = sheet;
-	} else {
-		lightThemeStyleSheet = sheet;
-	}
-	return sheet;
-}
-
-let globalStylesInstalled = false;
-
 let themesLoadedPromise: Promise<void> | undefined;
 function ensureThemesLoaded(): Promise<void> {
 	if (!themesLoadedPromise) {
@@ -369,24 +302,33 @@ function ensureThemesLoaded(): Promise<void> {
 	return themesLoadedPromise;
 }
 
-function installGlobalStyles(): void {
-	if (globalStylesInstalled) {
-		return;
-	}
-	globalStylesInstalled = true;
-	document.adoptedStyleSheets = [
-		...document.adoptedStyleSheets,
-		getGlobalStyleSheet(),
-		getIconsStyleSheetCached(),
-		getThemeStyleSheet(darkTheme),
-		getThemeStyleSheet(lightTheme),
-	];
+export async function setupTheme(container: HTMLElement, theme: ColorThemeData, options?: InstallGlobalStylesOptions): Promise<void> {
+	await ensureThemesLoaded();
+	await installGlobalStyles([darkTheme, lightTheme], options);
+	container.classList.add('monaco-workbench', getPlatformClass(), 'disable-animations', ...theme.classNames);
 }
 
-export async function setupTheme(container: HTMLElement, theme: ColorThemeData): Promise<void> {
-	await ensureThemesLoaded();
-	installGlobalStyles();
-	container.classList.add('monaco-workbench', getPlatformClass(), 'disable-animations', ...theme.classNames);
+/**
+ * Derives the global-style install options from the render `input` (passed via
+ * the CLI `--input` flag). Recognises `reverseStylesheets`, which is either
+ * `true` (reverse all stylesheet documents) or `{ fromIndex, toIndex }` (reverse
+ * only that index window, used by the order-dependency bisection).
+ */
+function parseStyleOptions(input: unknown): InstallGlobalStylesOptions | undefined {
+	if (!input || typeof input !== 'object') {
+		return undefined;
+	}
+	const value = (input as Record<string, unknown>).reverseStylesheets;
+	if (value === true) {
+		return { reverseStylesheets: true };
+	}
+	if (value && typeof value === 'object') {
+		const range = value as Record<string, unknown>;
+		if (typeof range.fromIndex === 'number' && typeof range.toIndex === 'number') {
+			return { reverseStylesheets: { fromIndex: range.fromIndex, toIndex: range.toIndex } };
+		}
+	}
+	return undefined;
 }
 
 function getPlatformClass(): string {
@@ -969,7 +911,7 @@ export function defineComponentFixture(options: ComponentFixtureOptions): Themed
 			});
 
 			async function actualRender() {
-				await setupTheme(container, theme);
+				await setupTheme(container, theme, parseStyleOptions(context.input));
 
 				let renderTimeApi: IDisposable | undefined;
 				if (virtualTimeEnabled) {

--- a/src/vs/workbench/test/browser/componentFixtures/fixtureUtilsCss.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/fixtureUtilsCss.ts
@@ -1,0 +1,196 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+import { getIconsStyleSheet } from '../../../../platform/theme/browser/iconsStyleSheet.js';
+import { ColorScheme } from '../../../../platform/theme/common/theme.js';
+import { IThemingRegistry, Extensions as ThemingExtensions } from '../../../../platform/theme/common/themeService.js';
+import { generateColorThemeCSS } from '../../../services/themes/browser/colorThemeCss.js';
+import { ColorThemeData } from '../../../services/themes/common/colorThemeData.js';
+
+const themingRegistry = Registry.as<IThemingRegistry>(ThemingExtensions.ThemingContribution);
+const mockEnvironmentService: IEnvironmentService = Object.create(null);
+
+let globalStyleSheetPromise: Promise<CSSStyleSheet> | undefined;
+let iconsStyleSheetCache: CSSStyleSheet | undefined;
+let darkThemeStyleSheet: CSSStyleSheet | undefined;
+let lightThemeStyleSheet: CSSStyleSheet | undefined;
+
+/**
+ * Controls how the bundled stylesheet documents are reordered.
+ * - `false`: keep the original (product) order.
+ * - `true`: reverse the order of all documents.
+ * - `{ fromIndex, toIndex }`: reverse only the documents in the half-open
+ *   index range `[fromIndex, toIndex)`. This is what the order-dependency
+ *   bisection uses to narrow down which documents conflict.
+ */
+export type ReverseStylesheetsOption = boolean | { readonly fromIndex: number; readonly toIndex: number };
+
+/**
+ * Matches a VS Code source-file copyright banner, which the build preserves in
+ * the bundled CSS and which therefore delimits the per-source-file "documents"
+ * concatenated into a single stylesheet.
+ */
+const COPYRIGHT_BANNER_REGEX = /\/\*-+[\s\S]*?Copyright \(c\) Microsoft Corporation[\s\S]*?\*\//g;
+
+/**
+ * Reverses the order of whole documents (delimited by the copyright banner)
+ * within a stylesheet, while preserving rule order inside each document. Any
+ * text before the first banner is kept in place as a preamble. When `option`
+ * is a range, only the documents in `[fromIndex, toIndex)` are reversed and the
+ * rest stay in place.
+ */
+function reverseDocumentsByBanner(cssText: string, option: Exclude<ReverseStylesheetsOption, false>): string {
+	const banners = Array.from(cssText.matchAll(COPYRIGHT_BANNER_REGEX));
+	if (banners.length < 2) {
+		return cssText;
+	}
+	const preamble = cssText.slice(0, banners[0].index);
+	const documents = banners.map((banner, i) => {
+		const start = banner.index;
+		const end = i + 1 < banners.length ? banners[i + 1].index : cssText.length;
+		return cssText.slice(start, end);
+	});
+
+	const from = option === true ? 0 : Math.max(0, Math.min(documents.length, option.fromIndex));
+	const to = option === true ? documents.length : Math.max(from, Math.min(documents.length, option.toIndex));
+
+	const reordered = [
+		...documents.slice(0, from),
+		...documents.slice(from, to).reverse(),
+		...documents.slice(to),
+	];
+	return preamble + reordered.join('');
+}
+
+/**
+ * Reads the raw source text of a stylesheet (which, unlike `cssRules`, retains
+ * comments such as the copyright banner). Falls back to serialized rules when
+ * the source cannot be read.
+ */
+async function readStyleSheetSource(sheet: CSSStyleSheet): Promise<string> {
+	const owner = sheet.ownerNode;
+	if (owner instanceof HTMLStyleElement) {
+		return owner.textContent ?? '';
+	}
+	if (sheet.href) {
+		try {
+			return await (await fetch(sheet.href)).text();
+		} catch {
+			// Fall back to serialized rules below.
+		}
+	}
+	try {
+		return Array.from(sheet.cssRules, rule => rule.cssText).join('\n');
+	} catch {
+		// Cross-origin stylesheets can't be read
+		return '';
+	}
+}
+
+async function buildGlobalStyleSheet(reverse: ReverseStylesheetsOption): Promise<CSSStyleSheet> {
+	const sheet = new CSSStyleSheet();
+
+	// Reversing the whole-document order of the bundled CSS makes cascade ties
+	// that are decided purely by source order resolve the opposite way. Because
+	// adopted stylesheets are applied after the document's `<link>`/`<style>`
+	// sheets in the cascade, this reversed copy wins those ties and surfaces
+	// order-dependent conflicts. The reverse mode is driven by the render
+	// `input` (e.g. `--input '{"reverseStylesheets":true}'`) so it stays scoped
+	// to a single render run and never mutates persistent global state.
+	if (reverse) {
+		const sources = await Promise.all(Array.from(document.styleSheets, readStyleSheetSource));
+		sheet.replaceSync(reverseDocumentsByBanner(sources.join('\n'), reverse));
+		return sheet;
+	}
+
+	const globalRules: string[] = [];
+	for (const styleSheet of Array.from(document.styleSheets)) {
+		try {
+			for (const rule of Array.from(styleSheet.cssRules)) {
+				globalRules.push(rule.cssText);
+			}
+		} catch {
+			// Cross-origin stylesheets can't be read
+		}
+	}
+	sheet.replaceSync(globalRules.join('\n'));
+	return sheet;
+}
+
+function getGlobalStyleSheet(reverse: ReverseStylesheetsOption): Promise<CSSStyleSheet> {
+	if (!globalStyleSheetPromise) {
+		globalStyleSheetPromise = buildGlobalStyleSheet(reverse);
+	}
+	return globalStyleSheetPromise;
+}
+
+function getIconsStyleSheetCached(): CSSStyleSheet {
+	if (!iconsStyleSheetCache) {
+		iconsStyleSheetCache = new CSSStyleSheet();
+		const iconsSheet = getIconsStyleSheet(undefined);
+		iconsStyleSheetCache.replaceSync(iconsSheet.getCSS() as string);
+		iconsSheet.dispose();
+	}
+	return iconsStyleSheetCache;
+}
+
+function getThemeStyleSheet(theme: ColorThemeData): CSSStyleSheet {
+	const isDark = theme.type === ColorScheme.DARK;
+	if (isDark && darkThemeStyleSheet) {
+		return darkThemeStyleSheet;
+	}
+	if (!isDark && lightThemeStyleSheet) {
+		return lightThemeStyleSheet;
+	}
+
+	const scopeSelector = '.' + theme.classNames[0];
+	const sheet = new CSSStyleSheet();
+	const css = generateColorThemeCSS(
+		theme,
+		scopeSelector,
+		themingRegistry.getThemingParticipants(),
+		mockEnvironmentService
+	);
+	sheet.replaceSync(css.code);
+
+	if (isDark) {
+		darkThemeStyleSheet = sheet;
+	} else {
+		lightThemeStyleSheet = sheet;
+	}
+	return sheet;
+}
+
+let globalStylesPromise: Promise<void> | undefined;
+
+export interface InstallGlobalStylesOptions {
+	/** See {@link ReverseStylesheetsOption}. Defaults to no reversal. */
+	readonly reverseStylesheets?: ReverseStylesheetsOption;
+}
+
+/**
+ * Installs the bundled global styles, the icon font styles, and a scoped
+ * stylesheet for each of the given themes as `document.adoptedStyleSheets`.
+ * Idempotent: the work runs at most once regardless of how often it is called.
+ * The reverse-order behaviour (used to detect cascade-order dependencies) is
+ * controlled per render run via {@link InstallGlobalStylesOptions.reverseStylesheets}.
+ */
+export function installGlobalStyles(themes: readonly ColorThemeData[], options?: InstallGlobalStylesOptions): Promise<void> {
+	if (!globalStylesPromise) {
+		const reverse = options?.reverseStylesheets ?? false;
+		globalStylesPromise = (async () => {
+			const globalSheet = await getGlobalStyleSheet(reverse);
+			document.adoptedStyleSheets = [
+				...document.adoptedStyleSheets,
+				globalSheet,
+				getIconsStyleSheetCached(),
+				...themes.map(getThemeStyleSheet),
+			];
+		})();
+	}
+	return globalStylesPromise;
+}


### PR DESCRIPTION
Work in progress. Tooling to detect and localize CSS cascade-order dependencies in component fixtures, which render through `@vscode/component-explorer` over an rspack `serve-out` build that concatenates all CSS into one native-CSS bundle.

## Done in this branch

- **Input-driven stylesheet reversal** — `installGlobalStyles` accepts a `reverseStylesheets` option (`true` = reverse all documents, or `{ fromIndex, toIndex }` = reverse only that window). Driven per-run via the render `--input` flag (`parseStyleOptions`), not via global state.
- **`@css-source` marker loader** — `build/rspack/cssSourceMarkerLoader.ts` prepends each CSS module's repo-relative source path as a comment that native CSS preserves, so tooling can map concatenated bundle documents back to source files. Wired into the `.css` rule in `rspack.serve-out.config.mts`.

## Remaining work

See `src/vs/workbench/test/browser/componentFixtures/CSS_ORDER_FUZZER_TODO.md` for the full list:

1. **Verify the `.ts` loader runs** (blocker) — confirm `@rspack/cli` loads a `.ts` loader directly; fall back to inlining in the `.mts` config if not.
2. **Apply the known specificity fix** (validation case) — `aiCustomizationManagement.css` vs `codicon.css` `(0,2,0)` tie on `display`.
3. **Bisection driver** — in-page binary search against the live `serve` (no rebuilds) to localize order-dependent document pairs.
4. **CI guard** — `build/lib/checkStylesheetOrder.ts` + daily workflow diffing manifest `imageHash` of normal vs. reversed render.
5. **Component-explorer CLI feature request** — render input-matrix and/or `--server-url` attach mode so bisection reuses a running `serve`.
