### PR TITLE
agentSdkDownloader: use appRoot/node_modules in dev

### DIFF
--- a/src/vs/platform/agentHost/node/agentSdkDownloader.ts
+++ b/src/vs/platform/agentHost/node/agentSdkDownloader.ts
@@ -44,6 +44,17 @@ export interface IAgentSdkPackage {
 	readonly id: string;
 	/** Env var that, when set, becomes the SDK root and short-circuits the download. */
 	readonly devOverrideEnvVar: string;
+	/**
+	 * npm package name (e.g. `'@anthropic-ai/claude-agent-sdk'`,
+	 * `'@openai/codex'`). When running in dev (`!isBuilt`), the downloader
+	 * uses `<appRoot>/node_modules/<npmModule>/package.json` as a probe to
+	 * decide whether the package is locally installed; if so, `appRoot` is
+	 * returned as the SDK root, skipping the CDN download.
+	 *
+	 * This is the fast-path for contributors: a fresh `npm install` is enough
+	 * to make the provider available, no env var setup required.
+	 */
+	readonly npmModule: string;
 }
 
 // #endregion
@@ -114,7 +125,11 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 	) { }
 
 	isAvailable(pkg: IAgentSdkPackage): boolean {
-		return !!process.env[pkg.devOverrideEnvVar] || !!this._productService.agentSdks?.[pkg.id];
+		return (
+			!!process.env[pkg.devOverrideEnvVar]
+			|| !!this._resolveDevAppRoot(pkg)
+			|| !!this._productService.agentSdks?.[pkg.id]
+		);
 	}
 
 	async loadSdkRoot(pkg: IAgentSdkPackage, token: CancellationToken): Promise<string> {
@@ -125,7 +140,18 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 			return override;
 		}
 
-		// 2. Negative cache: a recent failure short-circuits without I/O.
+		// 2. Dev appRoot fallback. In a `!isBuilt` checkout, the package is
+		//    already npm-installed at `<appRoot>/node_modules/<pkg.npmModule>`,
+		//    so we return `appRoot` and skip the CDN download. Contributors
+		//    get a working provider from `npm install` alone — no env-var or
+		//    setting required.
+		const devRoot = this._resolveDevAppRoot(pkg);
+		if (devRoot) {
+			this._logService.info(`[AgentSdkDownloader] ${pkg.id}: using dev appRoot at ${devRoot}`);
+			return devRoot;
+		}
+
+		// 3. Negative cache: a recent failure short-circuits without I/O.
 		const latched = this._failureLatch.get(pkg.id);
 		if (latched && latched.expiresAt > Date.now()) {
 			throw latched.error;
@@ -147,6 +173,25 @@ export class AgentSdkDownloader implements IAgentSdkDownloader {
 			});
 			throw error;
 		}
+	}
+
+	/**
+	 * Returns the dev appRoot iff `!isBuilt` AND the package's `npmModule` is
+	 * installed under `appRoot/node_modules/`. Used as a startup-time gate by
+	 * `isAvailable` and as a resolution step by `loadSdkRoot`.
+	 *
+	 * Uses sync `fs.existsSync` because `isAvailable` is a cheap synchronous
+	 * gate by contract. A built VS Code never has its source `node_modules/`
+	 * shipped alongside, so the probe always returns `undefined` in built
+	 * environments — there's no production-mode I/O hit.
+	 */
+	private _resolveDevAppRoot(pkg: IAgentSdkPackage): string | undefined {
+		if (this._environmentService.isBuilt) {
+			return undefined;
+		}
+		const appRoot = this._environmentService.appRoot;
+		const probe = path.join(appRoot, 'node_modules', pkg.npmModule, 'package.json');
+		return fs.existsSync(probe) ? appRoot : undefined;
 	}
 
 	private async _resolveOrDownload(pkg: IAgentSdkPackage, token: CancellationToken): Promise<string> {

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts
@@ -22,6 +22,7 @@ import { AgentHostClaudeSdkRootEnvVar } from '../../common/agentService.js';
 export const ClaudeSdkPackage: IAgentSdkPackage = {
 	id: 'claude',
 	devOverrideEnvVar: AgentHostClaudeSdkRootEnvVar,
+	npmModule: '@anthropic-ai/claude-agent-sdk',
 };
 
 export const IClaudeAgentSdkService = createDecorator<IClaudeAgentSdkService>('claudeAgentSdkService');

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -275,6 +275,7 @@ interface IConnectionReady {
 export const CodexSdkPackage: IAgentSdkPackage = {
 	id: 'codex',
 	devOverrideEnvVar: AgentHostCodexAgentSdkRootEnvVar,
+	npmModule: '@openai/codex',
 };
 
 export class CodexAgent extends Disposable implements IAgent {

--- a/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSdkDownloader.test.ts
@@ -90,7 +90,19 @@ function makeEnvService(userDataPath: string): INativeEnvironmentService {
 	// `force-disable-user-env: true` short-circuits before spawning a shell —
 	// without it `shellEnv.ts:140` registers a cancellation listener that
 	// leaks across tests and trips ensureNoDisposablesAreLeakedInTestSuite.
-	return { userDataPath, args: { 'force-disable-user-env': true } as never } as unknown as INativeEnvironmentService;
+	//
+	// `isBuilt: true` so the downloader's dev-appRoot fallback is bypassed —
+	// these tests exercise the env-override + product-config + CDN paths and
+	// would otherwise resolve to the running test process's appRoot.
+	return { userDataPath, isBuilt: true, args: { 'force-disable-user-env': true } as never } as unknown as INativeEnvironmentService;
+}
+
+/**
+ * Build an env service that simulates a `!isBuilt` checkout with the given
+ * `appRoot`. Tests that exercise the dev-appRoot fallback use this.
+ */
+function makeDevEnvService(userDataPath: string, appRoot: string): INativeEnvironmentService {
+	return { userDataPath, isBuilt: false, appRoot, args: { 'force-disable-user-env': true } as never } as unknown as INativeEnvironmentService;
 }
 
 function makeProductService(config: { version: string; url: string; sha256: string } | undefined): IProductService {
@@ -198,6 +210,44 @@ suite('AgentSdkDownloader', () => {
 	test('isAvailable: true when product config is populated', () => {
 		const downloader = makeDownloader();
 		assert.strictEqual(downloader.isAvailable(ClaudeSdkPackage), true);
+	});
+
+	test('isAvailable: true when running in dev (!isBuilt) with the npm package installed under appRoot', async () => {
+		// Synthesize an appRoot that contains node_modules/@anthropic-ai/claude-agent-sdk/package.json.
+		// In a real dev checkout, `npm install` puts this in place; the
+		// downloader treats its presence as "the SDK is locally available,
+		// skip the CDN" so contributors don't need to set the env var.
+		const appRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'sdk-approot-'));
+		disposables.add({ dispose: () => fsp.rm(appRoot, { recursive: true, force: true }) });
+		const pkgDir = path.join(appRoot, 'node_modules', ClaudeSdkPackage.npmModule);
+		await fsp.mkdir(pkgDir, { recursive: true });
+		await fsp.writeFile(path.join(pkgDir, 'package.json'), '{}');
+
+		const downloader = new AgentSdkDownloader(
+			makeDevEnvService(userDataPath, appRoot),
+			makeProductService(undefined),
+			makeRequestService(disposables),
+			makeFileService(disposables),
+			new NullLogService(),
+		);
+		assert.strictEqual(downloader.isAvailable(ClaudeSdkPackage), true);
+		const root = await downloader.loadSdkRoot(ClaudeSdkPackage, newToken());
+		assert.strictEqual(root, appRoot);
+	});
+
+	test('isAvailable: false in dev when the npm package is missing under appRoot', async () => {
+		const appRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'sdk-approot-'));
+		disposables.add({ dispose: () => fsp.rm(appRoot, { recursive: true, force: true }) });
+		// Deliberately do NOT install the package — appRoot exists but is empty.
+
+		const downloader = new AgentSdkDownloader(
+			makeDevEnvService(userDataPath, appRoot),
+			makeProductService(undefined),
+			makeRequestService(disposables),
+			makeFileService(disposables),
+			new NullLogService(),
+		);
+		assert.strictEqual(downloader.isAvailable(ClaudeSdkPackage), false);
 	});
 
 	test('loadSdkRoot: dev override returns the path unchanged', async () => {


### PR DESCRIPTION
## Summary

- Adds a dev fallback in `AgentSdkDownloader`: when `!isBuilt` AND `<appRoot>/node_modules/<pkg.npmModule>/package.json` exists, the downloader returns `appRoot` as the SDK root instead of going through the CDN. Contributors get a working Claude / Codex provider from `npm install` alone — no env var or workbench setting required.
- `IAgentSdkPackage` now carries `npmModule` so the downloader stays generic and never branches on `pkg.id`.
- Resolution order is unchanged for prod: dev-override env var → **appRoot dev fallback (new)** → `product.json` + CDN. The env var stays useful as the documented escape hatch for air-gapped server deployments (`agentHostServerMain.ts:115`) and for testing forked SDKs against a built VS Code.

## Test plan

- [x] New unit tests: `isAvailable: true when running in dev` (with the npm package installed under appRoot) and `isAvailable: false in dev when the npm package is missing` — both passing in `npm run test-node`.
- [x] Launch validation via the launch skill: with no SDK env var set, the agent host log shows `[AgentSdkDownloader] claude: using dev appRoot at <repo>` and `[AgentSdkDownloader] codex: using dev appRoot at <repo>`. Both providers register cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)