### PR TITLE
build: stamp product info for tgrep executable

### DIFF
--- a/build/gulpfile.vscode.ts
+++ b/build/gulpfile.vscode.ts
@@ -562,6 +562,7 @@ function patchWin32DependenciesTask(destinationFolderName: string) {
 		const deps = (await Promise.all([
 			glob('**/*.node', { cwd, ignore: 'extensions/node_modules/@parcel/watcher/**' }),
 			glob('**/rg.exe', { cwd }),
+			glob('**/tgrep.exe', { cwd }),
 			glob('**/*explorer_command*.dll', { cwd }),
 		])).flatMap(o => o);
 		const packageJson = JSON.parse(await fs.promises.readFile(path.join(cwd, versionedResourcesFolder, 'resources', 'app', 'package.json'), 'utf8'));


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-engineering/issues/3001

Followup to https://github.com/microsoft/vscode/pull/320868

Addresses 
```
Exploration
2026-06-12T06:39:50.0163675Z ##[error][2026-06-12T06:39:50.001Z] ERROR: VersionInfo ProductName is missing or empty for:
2026-06-12T06:39:50.0168777Z C:\Program Files\Microsoft VS Code Exploration\af4e93b1a9\resources\app\extensions\copilot\node_modules\@github\copilot\sdk\tgrep\bin\win32-x64\tgrep.exe
2026-06-12T06:39:50.0169375Z C:\Program Files\Microsoft VS Code Exploration\af4e93b1a9\resources\app\node_modules\@github\copilot\tgrep\bin\win32-x64\tgrep.exe
2026-06-12T06:39:50.0169761Z [2026-06-12T06:39:50.001Z] Test failed with error: VersionInfo ProductName is missing or empty for:
2026-06-12T06:39:50.0170124Z C:\Program Files\Microsoft VS Code Exploration\af4e93b1a9\resources\app\extensions\copilot\node_modules\@github\copilot\sdk\tgrep\bin\win32-x64\tgrep.exe
```

cc @DonJayamanne 