### PR TITLE
Allow chat-lib embedders to supply the tokenizer implementation

### DIFF
--- a/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/test/tokenizer.test.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/test/tokenizer.test.ts
@@ -5,7 +5,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import { resolve } from 'path';
-import { ApproximateTokenizer, getTokenizer, TokenizerName } from '../tokenization';
+import { ApproximateTokenizer, getTokenizer, initializeTokenizers, Tokenizer, TokenizerName } from '../tokenization';
 
 // Read the source files and normalize the line endings
 const source = fs.readFileSync(resolve(__dirname, 'testdata/example.py'), 'utf8').replace(/\r\n?/g, '\n');
@@ -62,7 +62,14 @@ suite('MockTokenizer', function () {
 });
 
 suite('Tokenizer Test Suite - cl100k', function () {
-	const tokenizer = getTokenizer(TokenizerName.cl100k);
+	// The dictionaries load lazily on the first initializeTokenizers await;
+	// fetch the tokenizer after that instead of at suite definition time,
+	// which would capture the approximate fallback.
+	let tokenizer: Tokenizer;
+	suiteSetup(async function () {
+		await initializeTokenizers;
+		tokenizer = getTokenizer(TokenizerName.cl100k);
+	});
 
 	test('empty string', function () {
 		const str = '';
@@ -262,7 +269,11 @@ with minor edits to make it`;
 });
 
 suite('Tokenizer Test Suite - o200k', function () {
-	const tokenizer = getTokenizer(TokenizerName.o200k);
+	let tokenizer: Tokenizer;
+	suiteSetup(async function () {
+		await initializeTokenizers;
+		tokenizer = getTokenizer(TokenizerName.o200k);
+	});
 
 	test('empty string', function () {
 		const str = '';

--- a/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
@@ -16,7 +16,37 @@ export enum TokenizerName {
 
 const tokenizers = new Map<TokenizerName, Tokenizer>();
 
+/**
+ * Tokenizer implementation supplied by the embedding host via
+ * {@link setExternalTokenizerProvider}. Hosts that already have the
+ * cl100k/o200k BPE dictionaries in memory (e.g. a language server that
+ * bundles its own copy of this prompt library) can register a provider so
+ * this module never loads a duplicate dictionary set (~100 MB per encoder).
+ */
+export interface ExternalTokenizerProvider {
+	/** Returns a tokenizer for the given encoder. */
+	getTokenizer(name: TokenizerName): Tokenizer;
+	/**
+	 * Ensures the host's dictionaries are loaded. Awaited by
+	 * {@link initializeTokenizers}, which callers use as the
+	 * exact-tokenization gate before token counting.
+	 */
+	ensureLoaded(): Promise<void>;
+}
+
+let externalProvider: ExternalTokenizerProvider | undefined;
+
+/**
+ * Registers a host tokenizer used instead of loading this module's own BPE
+ * dictionaries. Call before the first {@link getTokenizer} /
+ * {@link initializeTokenizers} use, e.g. during host startup.
+ */
+export function setExternalTokenizerProvider(provider: ExternalTokenizerProvider): void {
+	externalProvider = provider;
+}
+
 export function getTokenizer(name: TokenizerName = TokenizerName.o200k): Tokenizer {
+	if (externalProvider) { return externalProvider.getTokenizer(name); }
 	let tokenizer = tokenizers.get(name);
 	if (tokenizer !== undefined) { return tokenizer; }
 	// Fallback to o200k
@@ -378,8 +408,39 @@ async function setTokenizer(name: TokenizerName) {
 	}
 }
 
-/** Load tokenizers on start. Export promise for to be awaited by initialization. */
-export const initializeTokenizers = (async () => {
-	tokenizers.set(TokenizerName.mock, new MockTokenizer());
-	await Promise.all([setTokenizer(TokenizerName.cl100k), setTokenizer(TokenizerName.o200k)]);
-})();
+tokenizers.set(TokenizerName.mock, new MockTokenizer());
+
+let ownLoadPromise: Promise<void> | undefined;
+
+function loadTokenizers(): Promise<void> {
+	if (externalProvider) { return externalProvider.ensureLoaded(); }
+	ownLoadPromise ??= Promise.all([setTokenizer(TokenizerName.cl100k), setTokenizer(TokenizerName.o200k)]).then(() => undefined);
+	return ownLoadPromise;
+}
+
+/**
+ * Loads the tokenizers. This is a lazy thenable rather than an eagerly
+ * started promise: the dictionary load starts the first time it is awaited
+ * (callers like ghostText await it before token counting) instead of at
+ * module evaluation. That gives an embedding host the chance to register an
+ * {@link setExternalTokenizerProvider | external provider} first, in which
+ * case awaiting this defers to the host's dictionaries and this module's own
+ * dictionaries are never loaded.
+ */
+export const initializeTokenizers: Promise<void> = {
+	then<TResult1 = void, TResult2 = never>(
+		onfulfilled?: ((value: void) => TResult1 | PromiseLike<TResult1>) | null,
+		onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+	): Promise<TResult1 | TResult2> {
+		return loadTokenizers().then(onfulfilled, onrejected);
+	},
+	catch<TResult = never>(
+		onrejected?: ((reason: unknown) => TResult | PromiseLike<TResult>) | null
+	): Promise<void | TResult> {
+		return loadTokenizers().catch(onrejected);
+	},
+	finally(onfinally?: (() => void) | null): Promise<void> {
+		return loadTokenizers().finally(onfinally);
+	},
+	[Symbol.toStringTag]: 'Promise',
+} as Promise<void>;

--- a/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
@@ -63,6 +63,9 @@ export function getTokenizer(name: TokenizerName = TokenizerName.o200k): Tokeniz
 	}
 	let tokenizer = tokenizers.get(name);
 	if (tokenizer !== undefined) { return tokenizer; }
+	// Kick the lazy dictionary load (fire-and-forget) so callers that never
+	// await initializeTokenizers still converge on exact tokenization.
+	void loadTokenizers();
 	// Fallback to o200k
 	tokenizer = tokenizers.get(TokenizerName.o200k);
 	if (tokenizer !== undefined) { return tokenizer; }

--- a/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
@@ -38,15 +38,29 @@ let externalProvider: ExternalTokenizerProvider | undefined;
 
 /**
  * Registers a host tokenizer used instead of loading this module's own BPE
- * dictionaries. Call before the first {@link getTokenizer} /
- * {@link initializeTokenizers} use, e.g. during host startup.
+ * dictionaries. Must be called once, before the first
+ * {@link initializeTokenizers} await (e.g. during host startup) — throws on
+ * re-registration or after this module's own dictionary load has started, so
+ * the load strategy cannot silently switch mid-session.
  */
 export function setExternalTokenizerProvider(provider: ExternalTokenizerProvider): void {
+	if (externalProvider) {
+		throw new Error('External tokenizer provider is already registered');
+	}
+	if (ownLoadPromise) {
+		throw new Error('Cannot register an external tokenizer provider after the built-in tokenizers started loading');
+	}
 	externalProvider = provider;
 }
 
 export function getTokenizer(name: TokenizerName = TokenizerName.o200k): Tokenizer {
-	if (externalProvider) { return externalProvider.getTokenizer(name); }
+	if (externalProvider) {
+		try {
+			return externalProvider.getTokenizer(name);
+		} catch {
+			// Preserve this function's never-throws contract; fall back below.
+		}
+	}
 	let tokenizer = tokenizers.get(name);
 	if (tokenizer !== undefined) { return tokenizer; }
 	// Fallback to o200k
@@ -411,9 +425,20 @@ async function setTokenizer(name: TokenizerName) {
 tokenizers.set(TokenizerName.mock, new MockTokenizer());
 
 let ownLoadPromise: Promise<void> | undefined;
+let externalLoadPromise: Promise<void> | undefined;
 
 function loadTokenizers(): Promise<void> {
-	if (externalProvider) { return externalProvider.ensureLoaded(); }
+	if (externalProvider) {
+		const provider = externalProvider;
+		// Single-flight: concurrent awaits share one ensureLoaded() call. Like
+		// the built-in path (setTokenizer swallows load errors), the gate never
+		// rejects — but a failed attempt clears the memo so a later await can
+		// retry instead of pinning approximate tokenization forever.
+		externalLoadPromise ??= Promise.resolve().then(() => provider.ensureLoaded()).catch(() => {
+			externalLoadPromise = undefined;
+		});
+		return externalLoadPromise;
+	}
 	ownLoadPromise ??= Promise.all([setTokenizer(TokenizerName.cl100k), setTokenizer(TokenizerName.o200k)]).then(() => undefined);
 	return ownLoadPromise;
 }
@@ -425,7 +450,9 @@ function loadTokenizers(): Promise<void> {
  * module evaluation. That gives an embedding host the chance to register an
  * {@link setExternalTokenizerProvider | external provider} first, in which
  * case awaiting this defers to the host's dictionaries and this module's own
- * dictionaries are never loaded.
+ * dictionaries are never loaded. Like before, awaiting never rejects — load
+ * failures (built-in or external) resolve and leave the approximate
+ * tokenizer fallback in place.
  */
 export const initializeTokenizers: Promise<void> = {
 	then<TResult1 = void, TResult2 = never>(

--- a/extensions/copilot/src/lib/node/chatLibMain.ts
+++ b/extensions/copilot/src/lib/node/chatLibMain.ts
@@ -411,7 +411,7 @@ function setupServices(options: INESProviderOptions) {
 	builder.define(IChatQuotaService, new SyncDescriptor(ChatQuotaService));
 	builder.define(IInteractionService, new SyncDescriptor(InteractionService));
 	builder.define(IRequestLogger, new SyncDescriptor(NullRequestLogger));
-	builder.define(ITokenizerProvider, options.tokenizerProvider || new SyncDescriptor(TokenizerProvider, [false]));
+	builder.define(ITokenizerProvider, options.tokenizerProvider ?? new SyncDescriptor(TokenizerProvider, [false]));
 	builder.define(IConversationOptions, {
 		_serviceBrand: undefined,
 		maxResponseTokens: undefined,

--- a/extensions/copilot/src/lib/node/chatLibMain.ts
+++ b/extensions/copilot/src/lib/node/chatLibMain.ts
@@ -194,6 +194,14 @@ export interface INESProviderOptions {
 	 * {@link TestLanguageDiagnosticsService} that returns empty diagnostics
 	 */
 	readonly languageDiagnosticsService?: ILanguageDiagnosticsService;
+	/**
+	 * Tokenizer provider backing prompt rendering and token budgeting. When
+	 * omitted, falls back to the built-in {@link TokenizerProvider}, which
+	 * loads its own BPE dictionaries. Embedders that already have the
+	 * cl100k/o200k dictionaries in memory can supply a provider here to avoid
+	 * loading a second copy (~100 MB per encoder).
+	 */
+	readonly tokenizerProvider?: ITokenizerProvider;
 }
 
 export interface INESResult {
@@ -403,7 +411,7 @@ function setupServices(options: INESProviderOptions) {
 	builder.define(IChatQuotaService, new SyncDescriptor(ChatQuotaService));
 	builder.define(IInteractionService, new SyncDescriptor(InteractionService));
 	builder.define(IRequestLogger, new SyncDescriptor(NullRequestLogger));
-	builder.define(ITokenizerProvider, new SyncDescriptor(TokenizerProvider, [false]));
+	builder.define(ITokenizerProvider, options.tokenizerProvider || new SyncDescriptor(TokenizerProvider, [false]));
 	builder.define(IConversationOptions, {
 		_serviceBrand: undefined,
 		maxResponseTokens: undefined,


### PR DESCRIPTION
Fixes #321098

`@vscode/chat-lib` ships two independent tokenizer stacks, and each loads its own copy of the cl100k/o200k BPE dictionaries (~150 MB of JS heap per set): the vendored completions-core tokenizer loads both encoders eagerly at module evaluation, and the platform `TokenizerProvider` loads its own copy lazily for NES / prompt-tsx. Embedders that already have these dictionaries in memory get a third copy, with no supported way to share.

This makes the tokenizer host-overridable, following existing patterns; with no provider registered, behavior is unchanged except dictionary load timing (first await instead of module evaluation):

- `INESProviderOptions` gains `tokenizerProvider`, like the existing optional service overrides (`languageDiagnosticsService`, `terminalService`, ...).
- The completions-core tokenizer module gains `setExternalTokenizerProvider()`, checked by `getTokenizer()`, and `initializeTokenizers` becomes a lazy thenable: the load starts on first await — `ghostText` already awaits it before each prompt — giving hosts a chance to register a provider before any load happens. The lazy init also stops the extension host paying the eager double-dictionary load just for importing the module.

Guarantees kept (review round): `getTokenizer()` never throws (provider failures fall back to the existing chain), the `initializeTokenizers` gate never rejects (failed external loads resolve and retry on a later await, single-flight), and the load strategy is frozen — registration throws once the built-in load has started or a provider is already set.

Verified: `tsgo --noEmit` clean, tokenizer vitest suites pass, plus a runtime probe covering delegation, fallback-on-throw, never-reject + retry semantics, and double-registration rejection.