### PR TITLE
build: stamp product info for tgrep in remote server bundle

### DIFF
--- a/build/gulpfile.reh.ts
+++ b/build/gulpfile.reh.ts
@@ -507,6 +507,7 @@ function patchWin32DependenciesTask(destinationFolderName: string) {
 		const deps = (await Promise.all([
 			promisify(glob)('**/*.node', { cwd }),
 			promisify(glob)('**/rg.exe', { cwd }),
+			promisify(glob)('**/tgrep.exe', { cwd }),
 		])).flatMap(o => o);
 		const packageJsonContents = JSON.parse(await fs.promises.readFile(path.join(cwd, 'package.json'), 'utf8'));
 		const productContents = JSON.parse(await fs.promises.readFile(path.join(cwd, 'product.json'), 'utf8'));


### PR DESCRIPTION
Followup to https://github.com/microsoft/vscode/pull/321097 which missed the remote build configuration.

Fixes https://github.com/microsoft/vscode-engineering/issues/3019

cc @DonJayamanne 