### PR TITLE
fix: guard against missing voiceWsUrl in voice client

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
@@ -118,6 +118,10 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 		}
 
 		const baseUrl = this._getWsUrl();
+		if (!baseUrl) {
+			this._logService.error('[voice] No voice WebSocket URL configured (set voiceWsUrl in product.json or agents.voice.backendUrl in settings)');
+			return;
+		}
 		const url = this._authToken
 			? `${baseUrl}?token=${encodeURIComponent(this._authToken)}`
 			: baseUrl;


### PR DESCRIPTION
When `voiceWsUrl` is not set in product.json, the voice client would attempt `new WebSocket('')` which silently fails — pressing the mic button does nothing with no errors.

This adds a guard that logs an error and returns early when no URL is configured.

The proprietary product.json (Insiders/Stable) needs `voiceWsUrl` added to enable Voice Mode.