### PR TITLE
sessions: track preferred session type when no explicit user pick

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -124,11 +124,11 @@ export class NewChatWidget extends Disposable {
 		}));
 
 		this._register(this._workspacePicker.onDidSelectWorkspace(async folderUri => {
-			await this._onWorkspaceSelected(folderUri, folderUri ? this._newChatInput.sessionTypePicker.selectedPick : undefined);
+			await this._onWorkspaceSelected(folderUri);
 			this._newChatInput.focus();
 		}));
-		this._register(this._newChatInput.sessionTypePicker.onDidSelectSessionType(async pick => {
-			await this._onWorkspaceSelected(this._workspacePicker.selectedFolderUri, pick);
+		this._register(this._newChatInput.sessionTypePicker.onDidSelectSessionType(async () => {
+			await this._onWorkspaceSelected(this._workspacePicker.selectedFolderUri);
 			this._newChatInput.focus();
 		}));
 	}
@@ -162,7 +162,7 @@ export class NewChatWidget extends Disposable {
 		// from a new-session draft when navigating back from another session).
 		const restoredFolderUri = this._workspacePicker.selectedFolderUri;
 		if (!this._syncWorkspacePickerFromActiveSession() && restoredFolderUri) {
-			this._createNewSession(restoredFolderUri, this._newChatInput.sessionTypePicker.selectedPick);
+			this._createNewSession(restoredFolderUri);
 		}
 
 		chatWidgetContainer.classList.add('revealed');
@@ -199,20 +199,30 @@ export class NewChatWidget extends Disposable {
 			&& t.sessionType.id === pick.sessionTypeId);
 	}
 
-	private _createNewSession(folderUri: URI, pick: IPreferredSessionType | undefined): void {
+	private _createNewSession(folderUri: URI): void {
 		this._pendingPreferredUpgrade.clear();
-		const created = this._createSessionNow(folderUri, pick);
-		// Watch for late-registering providers when the draft could not be
-		// created yet (no provider serves the folder), or was created with a
-		// non-preferred fallback. Agent hosts connect lazily, so there is no
-		// timeout — the listener lives until the draft is sent or replaced.
-		if (!created || (pick && !this._isPreferredServable(folderUri, pick))) {
-			this._scheduleRecreateOnProviderChange(folderUri, pick, created);
+		const userPick = this._newChatInput.sessionTypePicker.getUserPickedSessionType();
+		const created = this._createSessionNow(folderUri, userPick);
+		// Keep the draft in sync with late-registering providers. Agent hosts
+		// connect lazily, so there is no timeout — the listener lives until the
+		// draft is sent or replaced. We watch when:
+		//  - no provider can serve the folder yet (!created),
+		//  - the user's explicit pick isn't servable yet (created with a
+		//    fallback, upgrade once its provider connects), or
+		//  - there is no explicit pick, so the draft tracks the preferred
+		//    (first) type, which can change as the folder's session-type list
+		//    grows.
+		if (!created || !userPick || !this._isPreferredServable(folderUri, userPick)) {
+			this._scheduleRecreateOnProviderChange(folderUri, userPick, created);
 		}
 	}
 
-	private _createSessionNow(folderUri: URI, pick: IPreferredSessionType | undefined): ISession | undefined {
-		const effectivePick = pick && this._isPreferredServable(folderUri, pick) ? pick : undefined;
+	private _createSessionNow(folderUri: URI, userPick: IPreferredSessionType | undefined): ISession | undefined {
+		// Prefer the user's explicit pick when its provider can serve the
+		// folder; otherwise fall back to the preferred (first) session type.
+		const effectivePick = userPick && this._isPreferredServable(folderUri, userPick)
+			? userPick
+			: this._newChatInput.sessionTypePicker.getPreferredSessionType(folderUri);
 		const fallbackProviderId = this._workspacePicker.selectedResolved?.providerId;
 		try {
 			return this.sessionsViewService.openNewSession({
@@ -229,7 +239,7 @@ export class NewChatWidget extends Disposable {
 		}
 	}
 
-	private _scheduleRecreateOnProviderChange(folderUri: URI, pick: IPreferredSessionType | undefined, created: ISession | undefined): void {
+	private _scheduleRecreateOnProviderChange(folderUri: URI, userPick: IPreferredSessionType | undefined, created: ISession | undefined): void {
 		const store = new DisposableStore();
 		store.add(this.sessionsManagementService.onDidChangeSessionTypes(() => {
 			if (created) {
@@ -237,11 +247,20 @@ export class NewChatWidget extends Disposable {
 				if (active?.sessionId !== created.sessionId || active.isCreated.get()) {
 					return; // the draft was sent or is no longer the active session
 				}
-				if (pick && !this._isPreferredServable(folderUri, pick)) {
-					return; // the preferred provider still cannot serve the folder
+				if (userPick) {
+					if (!this._isPreferredServable(folderUri, userPick)) {
+						return; // the preferred provider still cannot serve the folder
+					}
+				} else {
+					// No explicit pick: keep the draft on the preferred (first)
+					// type. Recreate only when that preferred actually changed.
+					const preferred = this._newChatInput.sessionTypePicker.getPreferredSessionType(folderUri);
+					if (!preferred || (preferred.providerId === active.providerId && preferred.sessionTypeId === active.sessionType)) {
+						return;
+					}
 				}
 			}
-			this._createNewSession(folderUri, pick);
+			this._createNewSession(folderUri);
 		}));
 		this._pendingPreferredUpgrade.value = store;
 	}
@@ -369,12 +388,11 @@ export class NewChatWidget extends Disposable {
 			return;
 		}
 
-		// Capture the composer's workspace/session-type selection before the
-		// send: a background send consumes the in-flight new session and resets
-		// the new-session view, so we re-seed a fresh pending session afterwards
+		// Capture the composer's workspace selection before the send: a
+		// background send consumes the in-flight new session and resets the
+		// new-session view, so we re-seed a fresh pending session afterwards
 		// (see below) to keep the composer's pickers functional.
 		const reseedFolderUri = background ? this._workspacePicker.selectedFolderUri : undefined;
-		const reseedPick = background ? this._newChatInput.sessionTypePicker.selectedPick : undefined;
 
 		try {
 			await this.sessionsManagementService.sendNewChatRequest(session, { query, attachedContext, background });
@@ -389,7 +407,7 @@ export class NewChatWidget extends Disposable {
 		// session and this new draft coexist. This restores the
 		// session-type/model pickers for the next message.
 		if (background && reseedFolderUri) {
-			this._createNewSession(reseedFolderUri, reseedPick);
+			this._createNewSession(reseedFolderUri);
 		}
 	}
 
@@ -428,7 +446,7 @@ export class NewChatWidget extends Disposable {
 	 * Handles a workspace selection from the workspace picker.
 	 * Requests folder trust if needed and creates a new session.
 	 */
-	private async _onWorkspaceSelected(folderUri: URI | undefined, pick: IPreferredSessionType | undefined): Promise<void> {
+	private async _onWorkspaceSelected(folderUri: URI | undefined): Promise<void> {
 		// Cancel any in-flight upgrade for a previous selection.
 		this._pendingPreferredUpgrade.clear();
 
@@ -445,7 +463,7 @@ export class NewChatWidget extends Disposable {
 		}
 
 		if (!this._store.isDisposed) {
-			this._createNewSession(folderUri, pick);
+			this._createNewSession(folderUri);
 		}
 	}
 

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -22,7 +22,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { reportNewChatPickerClosed } from './newChatPickerTelemetry.js';
 
-const STORAGE_KEY_LAST_SESSION_TYPE = 'sessions.lastSelectedSessionType1';
+const STORAGE_KEY_LAST_SESSION_TYPE = 'sessions.userSelectedSessionType';
 
 /**
  * A picked session type, paired with the provider that serves it. Two

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -22,7 +22,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { reportNewChatPickerClosed } from './newChatPickerTelemetry.js';
 
-const STORAGE_KEY_LAST_SESSION_TYPE = 'sessions.lastSelectedSessionType';
+const STORAGE_KEY_LAST_SESSION_TYPE = 'sessions.userSelectedSessionType';
 
 /**
  * A picked session type, paired with the provider that serves it. Two

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -17,11 +17,12 @@ import { autorun, IObservable } from '../../../../base/common/observable.js';
 import { ISession } from '../../../services/sessions/common/session.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { isWeb } from '../../../../base/common/platform.js';
+import { URI } from '../../../../base/common/uri.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { reportNewChatPickerClosed } from './newChatPickerTelemetry.js';
 
-const STORAGE_KEY_LAST_SESSION_TYPE = 'sessions.lastSelectedSessionType';
+const STORAGE_KEY_LAST_SESSION_TYPE = 'sessions.lastSelectedSessionType1';
 
 /**
  * A picked session type, paired with the provider that serves it. Two
@@ -97,12 +98,10 @@ export class SessionTypePicker extends Disposable {
 			if (session) {
 				const folderUri = session.workspace.get()?.folders[0]?.root;
 				this._folderSessionTypes = folderUri ? this.sessionsManagementService.getSessionTypesForFolder(folderUri) : [];
-				const concrete = { providerId: session.providerId, sessionTypeId: session.sessionType };
-				const changed = concrete.providerId !== this._picked?.providerId || concrete.sessionTypeId !== this._picked?.sessionTypeId;
-				this._picked = concrete;
-				if (changed) {
-					this._writeStoredPick(concrete);
-				}
+				// Reflect the active session's type in the trigger label, but do
+				// not persist it: the stored preference must only change when the
+				// user explicitly picks a type via the picker.
+				this._picked = { providerId: session.providerId, sessionTypeId: session.sessionType };
 			} else {
 				this._folderSessionTypes = [];
 				// Preserve the stored pick when no active session exists,
@@ -125,6 +124,29 @@ export class SessionTypePicker extends Disposable {
 
 	get selectedPick(): IPreferredSessionType | undefined {
 		return this._picked;
+	}
+
+	/**
+	 * The session type the user explicitly picked, read from the stored
+	 * preference. Unlike {@link selectedPick}, this is independent of any
+	 * active session's type. Returns `undefined` when the user has never
+	 * picked a type (or changed away from the default), in which case
+	 * consumers should fall back to {@link getPreferredSessionType}.
+	 */
+	getUserPickedSessionType(): IPreferredSessionType | undefined {
+		return this._readStoredPick();
+	}
+
+	/**
+	 * The preferred session type for {@link folderUri}: the first entry in
+	 * the folder's session-type list. Recomputed against the live list, so
+	 * it follows provider changes (e.g. a late-registering agent host that
+	 * prepends a new type). Used as the default when the user has made no
+	 * explicit pick.
+	 */
+	getPreferredSessionType(folderUri: URI): IPreferredSessionType | undefined {
+		const first = this.sessionsManagementService.getSessionTypesForFolder(folderUri)[0];
+		return first ? { providerId: first.providerId, sessionTypeId: first.sessionType.id } : undefined;
 	}
 
 	render(container: HTMLElement, options?: { className?: string }): void {
@@ -283,7 +305,16 @@ export class SessionTypePicker extends Disposable {
 
 		const changed = pick.providerId !== this._picked?.providerId || pick.sessionTypeId !== this._picked?.sessionTypeId;
 		if (changed) {
-			this._writeStoredPick(pick);
+			// Picking the preferred (first) type means "no explicit
+			// preference": clear the stored pick so the session keeps
+			// tracking the preferred type as the folder's list changes.
+			const preferred = this._folderSessionTypes[0];
+			const isDefault = !!preferred && preferred.providerId === pick.providerId && preferred.sessionType.id === pick.sessionTypeId;
+			if (isDefault) {
+				this._clearStoredPick(pick);
+			} else {
+				this._writeStoredPick(pick);
+			}
 			this._onDidSelectSessionType.fire(pick);
 		}
 	}
@@ -314,6 +345,16 @@ export class SessionTypePicker extends Disposable {
 		this._picked = pick;
 		const stored: IStoredSessionTypePick = { providerId: pick.providerId, sessionTypeId: pick.sessionTypeId };
 		this.storageService.store(STORAGE_KEY_LAST_SESSION_TYPE, JSON.stringify(stored), StorageScope.PROFILE, StorageTarget.MACHINE);
+	}
+
+	/**
+	 * Forget any explicit preference (e.g. the user re-selected the default
+	 * type). The display still reflects the in-memory pick, but consumers
+	 * reading {@link getUserPickedSessionType} fall back to the preferred type.
+	 */
+	private _clearStoredPick(pick: IPickedSessionType): void {
+		this._picked = pick;
+		this.storageService.remove(STORAGE_KEY_LAST_SESSION_TYPE, StorageScope.PROFILE);
 	}
 
 	private _updateTriggerLabel(): void {

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -22,7 +22,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { reportNewChatPickerClosed } from './newChatPickerTelemetry.js';
 
-const STORAGE_KEY_LAST_SESSION_TYPE = 'sessions.userSelectedSessionType';
+const STORAGE_KEY_LAST_SESSION_TYPE = 'sessions.lastSelectedSessionType';
 
 /**
  * A picked session type, paired with the provider that serves it. Two
@@ -279,10 +279,11 @@ export class SessionTypePicker extends Disposable {
 
 	/**
 	 * Handles the user picking a session type. Emits `newChatPickerClosed`
-	 * telemetry (with the previously selected type read from storage, or
-	 * the in-memory field when nothing is stored), and — when the
-	 * selection actually changed — persists the new pick and fires
-	 * {@link onDidSelectSessionType}.
+	 * telemetry (with the previously selected type read from storage, or the
+	 * in-memory field when nothing is stored). The explicit selection is always
+	 * persisted — picking the preferred (first) type clears the stored
+	 * preference, any other pick stores it — while {@link onDidSelectSessionType}
+	 * fires only when the visible pick actually changed.
 	 *
 	 * Shared between desktop (action-widget popup) and mobile (bottom
 	 * sheet) presentations so both surfaces report identical telemetry.
@@ -303,18 +304,23 @@ export class SessionTypePicker extends Disposable {
 			isPII: false,
 		});
 
-		const changed = pick.providerId !== this._picked?.providerId || pick.sessionTypeId !== this._picked?.sessionTypeId;
-		if (changed) {
-			// Picking the preferred (first) type means "no explicit
-			// preference": clear the stored pick so the session keeps
-			// tracking the preferred type as the folder's list changes.
-			const preferred = this._folderSessionTypes[0];
-			const isDefault = !!preferred && preferred.providerId === pick.providerId && preferred.sessionType.id === pick.sessionTypeId;
-			if (isDefault) {
-				this._clearStoredPick(pick);
-			} else {
-				this._writeStoredPick(pick);
-			}
+		// Persist the explicit selection regardless of whether the visible
+		// pick changed (the visible pick may reflect the active session rather
+		// than the stored preference): picking the preferred (first) type means
+		// "no explicit preference" and clears the stored pick so the session
+		// keeps tracking the preferred type as the folder's list changes; any
+		// other explicit pick is stored.
+		const preferred = this._folderSessionTypes[0];
+		const isDefault = !!preferred && preferred.providerId === pick.providerId && preferred.sessionType.id === pick.sessionTypeId;
+		const visiblePickChanged = pick.providerId !== this._picked?.providerId || pick.sessionTypeId !== this._picked?.sessionTypeId;
+		if (isDefault) {
+			this._clearStoredPick(pick);
+		} else {
+			this._writeStoredPick(pick);
+		}
+		// Only notify (and trigger draft recreation) when the visible pick
+		// actually changed, to avoid unnecessary work.
+		if (visiblePickChanged) {
 			this._onDidSelectSessionType.fire(pick);
 		}
 	}

--- a/src/vs/sessions/contrib/chat/test/browser/sessionTypePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionTypePicker.test.ts
@@ -186,4 +186,28 @@ suite('SessionTypePicker', () => {
 		picker.pick({ providerId: 'local-1', sessionTypeId: 'local' });
 		assert.strictEqual(picker.getUserPickedSessionType(), undefined);
 	});
+
+	test('explicit pick is persisted even when the visible pick is unchanged', () => {
+		management.setSessionTypes([
+			sessionType('local-1', 'local', 'Local'),
+			sessionType('copilot', 'copilot-cli', 'Copilot CLI'),
+		]);
+		const picker = createPicker(disposables, session, management, storage);
+
+		// An active session of a non-default type is current, so the visible
+		// pick reflects it even though nothing has been stored yet.
+		session.set(createFakeSession('copilot', 'copilot-cli', folder), undefined);
+		assert.deepStrictEqual(picker.selectedPick, { providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+		assert.strictEqual(picker.getUserPickedSessionType(), undefined);
+
+		// Explicitly picking that same (already-visible) non-default type still
+		// persists the preference.
+		picker.pick({ providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+		assert.deepStrictEqual(picker.getUserPickedSessionType(), { providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+
+		// Explicitly picking the (already-visible) default type clears it again.
+		session.set(createFakeSession('local-1', 'local', folder), undefined);
+		picker.pick({ providerId: 'local-1', sessionTypeId: 'local' });
+		assert.strictEqual(picker.getUserPickedSessionType(), undefined);
+	});
 });

--- a/src/vs/sessions/contrib/chat/test/browser/sessionTypePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionTypePicker.test.ts
@@ -1,0 +1,189 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { constObservable, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { TestStorageService } from '../../../../../workbench/test/common/workbenchTestServices.js';
+import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
+import { IProviderSessionType, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { ISession, ISessionWorkspace } from '../../../../services/sessions/common/session.js';
+import { IPickedSessionType, IPreferredSessionType, SessionTypePicker } from '../../browser/sessionTypePicker.js';
+
+// ---- Mocks ------------------------------------------------------------------
+
+class MockSessionsManagementService extends Disposable {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onDidChangeSessionTypes = this._register(new Emitter<void>());
+	readonly onDidChangeSessionTypes: Event<void> = this._onDidChangeSessionTypes.event;
+
+	private _types: IProviderSessionType[] = [];
+
+	setSessionTypes(types: IProviderSessionType[]): void {
+		this._types = types;
+		this._onDidChangeSessionTypes.fire();
+	}
+
+	getSessionTypesForFolder(_folderUri: URI): IProviderSessionType[] {
+		return this._types;
+	}
+}
+
+function sessionType(providerId: string, id: string, label: string): IProviderSessionType {
+	return { providerId, sessionType: { id, label, icon: Codicon.terminal } };
+}
+
+function createFakeSession(providerId: string, sessionTypeId: string, folderUri: URI): ISession {
+	const workspace: ISessionWorkspace = {
+		uri: folderUri,
+		label: folderUri.path,
+		icon: Codicon.folder,
+		folders: [{
+			root: folderUri,
+			workingDirectory: folderUri,
+			name: folderUri.path,
+			description: undefined,
+			gitRepository: { uri: folderUri, workTreeUri: undefined, baseBranchName: undefined, gitHubInfo: constObservable(undefined) },
+		}],
+		requiresWorkspaceTrust: false,
+		isVirtualWorkspace: false,
+	};
+	return {
+		providerId,
+		sessionType: sessionTypeId,
+		workspace: constObservable(workspace),
+	} as unknown as ISession;
+}
+
+/** Exposes the protected user-pick handler so tests can drive the real write path. */
+class TestSessionTypePicker extends SessionTypePicker {
+	pick(p: IPickedSessionType): void {
+		this._handleSelectedSessionType(p);
+	}
+}
+
+function createPicker(
+	disposables: DisposableStore,
+	session: ISettableObservable<ISession | undefined>,
+	managementService: MockSessionsManagementService,
+	storage: IStorageService,
+): TestSessionTypePicker {
+	const instantiationService = disposables.add(new TestInstantiationService());
+	instantiationService.stub(IActionWidgetService, { isVisible: false, hide: () => { }, show: () => { } });
+	instantiationService.stub(ISessionsManagementService, managementService);
+	instantiationService.stub(ISessionsProvidersService, { getProvider: () => undefined });
+	instantiationService.stub(IStorageService, storage);
+	instantiationService.stub(ITelemetryService, NullTelemetryService);
+	return disposables.add(instantiationService.createInstance(TestSessionTypePicker, session));
+}
+
+// ---- Tests ------------------------------------------------------------------
+
+suite('SessionTypePicker', () => {
+
+	const disposables = new DisposableStore();
+	const folder = URI.file('/project');
+
+	let management: MockSessionsManagementService;
+	let storage: TestStorageService;
+	let session: ISettableObservable<ISession | undefined>;
+
+	setup(() => {
+		management = disposables.add(new MockSessionsManagementService());
+		storage = disposables.add(new TestStorageService());
+		session = observableValue<ISession | undefined>('session', undefined);
+	});
+
+	teardown(() => {
+		disposables.clear();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('preferred session type is the first one and follows session-type changes', () => {
+		management.setSessionTypes([
+			sessionType('local-1', 'local', 'Local'),
+			sessionType('copilot', 'copilot-cli', 'Copilot CLI'),
+		]);
+		const picker = createPicker(disposables, session, management, storage);
+
+		assert.deepStrictEqual(picker.getPreferredSessionType(folder), { providerId: 'local-1', sessionTypeId: 'local' });
+
+		// A late-registering provider prepends a new type → preferred follows it.
+		management.setSessionTypes([
+			sessionType('copilot', 'copilot-cli', 'Copilot CLI'),
+			sessionType('local-1', 'local', 'Local'),
+		]);
+
+		assert.deepStrictEqual(picker.getPreferredSessionType(folder), { providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+	});
+
+	test('user picked session type is persisted and survives reload', () => {
+		management.setSessionTypes([
+			sessionType('local-1', 'local', 'Local'),
+			sessionType('copilot', 'copilot-cli', 'Copilot CLI'),
+		]);
+		const picker = createPicker(disposables, session, management, storage);
+
+		// No explicit pick yet.
+		assert.strictEqual(picker.getUserPickedSessionType(), undefined);
+
+		picker.pick({ providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+		assert.deepStrictEqual(picker.getUserPickedSessionType(), { providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+
+		// Simulate a reload: a fresh picker reading the same storage restores the pick.
+		const reloaded = createPicker(disposables, observableValue<ISession | undefined>('session2', undefined), management, storage);
+		assert.deepStrictEqual(reloaded.getUserPickedSessionType(), { providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+		assert.deepStrictEqual(reloaded.selectedPick, { providerId: 'copilot', sessionTypeId: 'copilot-cli' } as IPreferredSessionType);
+	});
+
+	test('observing an active session does not overwrite the user pick', () => {
+		management.setSessionTypes([
+			sessionType('local-1', 'local', 'Local'),
+			sessionType('copilot', 'copilot-cli', 'Copilot CLI'),
+		]);
+		const picker = createPicker(disposables, session, management, storage);
+
+		picker.pick({ providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+
+		// An active session of a different type becomes current.
+		session.set(createFakeSession('local-1', 'local', folder), undefined);
+
+		// The in-memory display reflects the active session, but the stored
+		// user pick is untouched (only an explicit pick changes it).
+		assert.deepStrictEqual(picker.selectedPick, { providerId: 'local-1', sessionTypeId: 'local' });
+		assert.deepStrictEqual(picker.getUserPickedSessionType(), { providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+	});
+
+	test('re-selecting the default (first) session type clears the stored pick', () => {
+		management.setSessionTypes([
+			sessionType('local-1', 'local', 'Local'),
+			sessionType('copilot', 'copilot-cli', 'Copilot CLI'),
+		]);
+		const picker = createPicker(disposables, session, management, storage);
+
+		// The picker reflects the active session's folder types (the picker is
+		// always shown with an in-flight draft session in the composer).
+		session.set(createFakeSession('local-1', 'local', folder), undefined);
+
+		// Pick a non-default type → stored.
+		picker.pick({ providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+		assert.deepStrictEqual(picker.getUserPickedSessionType(), { providerId: 'copilot', sessionTypeId: 'copilot-cli' });
+
+		// Switch back to the default (first) type → stored pick is cleared.
+		picker.pick({ providerId: 'local-1', sessionTypeId: 'local' });
+		assert.strictEqual(picker.getUserPickedSessionType(), undefined);
+	});
+});


### PR DESCRIPTION
## What

Reworks how the Agents window decides which session type a new chat uses, so that the picker distinguishes an **explicit user pick** from the **preferred (first) session type** for the folder.

### Picker (`sessionTypePicker.ts`)
- The stored preference is now written **only** when the user explicitly picks a type — observing the active session's type no longer overwrites it.
- `getUserPickedSessionType()` returns the explicit pick (or `undefined` if the user never picked / re-selected the default).
- `getPreferredSessionType(folderUri)` returns the first entry in the folder's live session-type list, recomputed so it follows provider changes.
- Re-selecting the **default (first)** type clears the stored pick (treated as "no explicit preference").

### New chat widget (`newChatWidget.ts`)
- New session creation resolves the type from the picker: the user pick when its provider can serve the folder, otherwise the preferred (first) type.
- When there is no explicit pick, the draft tracks the preferred type and is recreated when the folder's session-type list changes (e.g. a late-registering agent host prepends a new type).

## Why

Previously the stored "last session type" could be silently overwritten just by observing an active session, and a new chat would not follow the preferred default as providers register lazily.

## Notes for reviewers
- Persisted preference survives reload and is honored for new sessions.
- Added unit tests in `sessionTypePicker.test.ts` covering: preferred follows session-type changes, user pick persists across reload, observing a session doesn't overwrite the pick, and re-selecting the default clears the stored pick.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>