### PR TITLE
sessions: deep-link customization entries

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -255,7 +255,9 @@ Provider-supplied customization rows that include an explicit storage origin are
 
 ### Sidebar Entrypoint Mode
 
-The Agents sidebar `AICustomizationShortcutsWidget` supports three entrypoint modes via `sessions.customizations.sidebarMode`: `welcome` (default) keeps the per-category sidebar rows but opens the AI Customization management editor welcome page, `section` restores per-category deep linking, and `single` replaces the per-category rows with one Customizations entry that opens the welcome page. All modes keep the active customization harness in sync with the active session before opening the editor.
+The Agents sidebar `AICustomizationShortcutsWidget` supports three entrypoint modes via `sessions.customizations.sidebarMode`: `section` (default) shows per-category sidebar rows, and clicking a category deep-links to that category's section in the AI Customization management editor. `welcome` is a legacy alias for `section`. `single` replaces the per-category rows with one Customizations entry that opens the welcome page. All modes keep the active customization harness in sync with the active session before opening the editor.
+
+The AI Customization overview cards in the Agents window behave like the sidebar category rows: activating a card opens the management editor with that section selected instead of resetting to the welcome page.
 
 When the harness selector dropdown is disabled in the management editor, the sidebar overview button displays the active harness name and harness icon (matching the picker icon) with a distinct background treatment.
 

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
@@ -22,7 +22,8 @@ import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { ResourceSet } from '../../../../base/common/map.js';
 import { IPromptsService } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
-import { AICustomizationManagementSection, AI_CUSTOMIZATION_MANAGEMENT_EDITOR_ID } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
+import { AICustomizationManagementSection } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
+import { AICustomizationManagementEditor } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.js';
 import { AICustomizationManagementEditorInput } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
 import { agentIcon, instructionsIcon, mcpServerIcon, pluginIcon, skillIcon } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
@@ -30,14 +31,12 @@ import { IAICustomizationWorkspaceService } from '../../../../workbench/contrib/
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
 import { IMcpService } from '../../../../workbench/contrib/mcp/common/mcpTypes.js';
 import { IAgentPluginService } from '../../../../workbench/contrib/chat/common/plugins/agentPluginService.js';
+import { ICustomizationHarnessService } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
+import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 
 const $ = DOM.$;
 
 export const AI_CUSTOMIZATION_OVERVIEW_VIEW_ID = 'workbench.view.aiCustomizationOverview';
-
-function isWelcomePageEditor(editor: unknown): editor is { showWelcomePage(): void } {
-	return typeof (editor as { showWelcomePage?: unknown })?.showWelcomePage === 'function';
-}
 
 interface ISectionSummary {
 	readonly id: AICustomizationManagementSection;
@@ -76,6 +75,8 @@ export class AICustomizationOverviewView extends ViewPane {
 		@IAICustomizationWorkspaceService private readonly workspaceService: IAICustomizationWorkspaceService,
 		@IMcpService private readonly mcpService: IMcpService,
 		@IAgentPluginService private readonly agentPluginService: IAgentPluginService,
+		@ICustomizationHarnessService private readonly harnessService: ICustomizationHarnessService,
+		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 	) {
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, hoverService);
 
@@ -138,16 +139,16 @@ export class AICustomizationOverviewView extends ViewPane {
 			countElement.textContent = `${section.count}`;
 			this.countElements.set(section.id, countElement);
 
-			// Click handler to open the management editor overview
+			// Click handler to open the management editor section
 			this._register(DOM.addDisposableListener(sectionElement, 'click', () => {
-				this.openOverview();
+				void this.openSection(section.id);
 			}));
 
 			// Keyboard support
 			this._register(DOM.addDisposableListener(sectionElement, 'keydown', (e: KeyboardEvent) => {
 				if (e.key === 'Enter' || e.key === ' ') {
 					e.preventDefault();
-					this.openOverview();
+					void this.openSection(section.id);
 				}
 			}));
 
@@ -235,14 +236,17 @@ export class AICustomizationOverviewView extends ViewPane {
 		}
 	}
 
-	private async openOverview(): Promise<void> {
+	private async openSection(section: AICustomizationManagementSection): Promise<void> {
+		const sessionResource = this.sessionsManagementService.activeSession.get()?.resource;
+		if (sessionResource) {
+			this.harnessService.setActiveSession(sessionResource);
+		}
+
 		const input = AICustomizationManagementEditorInput.getOrCreate();
 		const editor = await this.editorService.openEditor(input, { pinned: true });
 
-		// Always reset to the welcome page when opening from the sidebar,
-		// so we don't restore the previously selected section.
-		if (editor?.getId() === AI_CUSTOMIZATION_MANAGEMENT_EDITOR_ID && isWelcomePageEditor(editor)) {
-			editor.showWelcomePage();
+		if (editor instanceof AICustomizationManagementEditor) {
+			editor.selectSectionById(section);
 		}
 	}
 

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
@@ -5,6 +5,7 @@
 
 import './media/aiCustomizationManagement.css';
 import * as DOM from '../../../../base/browser/dom.js';
+import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
@@ -127,6 +128,7 @@ export class AICustomizationOverviewView extends ViewPane {
 			sectionElement.setAttribute('role', 'button');
 			sectionElement.setAttribute('aria-label', this.getSectionAriaLabel(section));
 			this.sectionElements.set(section.id, sectionElement);
+			this._register(Gesture.addTarget(sectionElement));
 
 			const iconElement = DOM.append(sectionElement, $('.section-icon'));
 			iconElement.classList.add(...ThemeIcon.asClassNameArray(section.icon));
@@ -139,10 +141,13 @@ export class AICustomizationOverviewView extends ViewPane {
 			countElement.textContent = `${section.count}`;
 			this.countElements.set(section.id, countElement);
 
-			// Click handler to open the management editor section
-			this._register(DOM.addDisposableListener(sectionElement, 'click', () => {
+			const openSection = (e: Event) => {
+				DOM.EventHelper.stop(e, true);
 				void this.openSection(section.id);
-			}));
+			};
+			for (const eventType of [DOM.EventType.CLICK, TouchEventType.Tap]) {
+				this._register(DOM.addDisposableListener(sectionElement, eventType, openSection));
+			}
 
 			// Keyboard support
 			this._register(DOM.addDisposableListener(sectionElement, 'keydown', (e: KeyboardEvent) => {

--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -68,8 +68,7 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		this._renderForCurrentMode();
 
 		// Re-render only when crossing the single<->non-single boundary. The
-		// `welcome` and `section` modes produce identical DOM (only click
-		// behavior differs, resolved at click-time in the contribution), so
+		// `welcome` and `section` modes produce identical DOM and behavior, so
 		// toggling between them needs no re-render.
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING)) {

--- a/src/vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution.ts
+++ b/src/vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution.ts
@@ -30,7 +30,6 @@ import { AICustomizationManagementSection } from '../../../../workbench/contrib/
 import { ICustomizationHarnessService } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
 import { ISession } from '../../../services/sessions/common/session.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 
@@ -47,7 +46,7 @@ export const SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING = 'sessions.customizat
  * See {@link SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING}.
  */
 export enum SessionsCustomizationsSidebarMode {
-	/** One item per category; click opens the welcome page. */
+	/** Legacy alias for per-category rows that deep-link to that category. */
 	Welcome = 'welcome',
 	/** One item per category; click deep-links to that category. */
 	Section = 'section',
@@ -67,12 +66,12 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 				SessionsCustomizationsSidebarMode.Single,
 			],
 			enumDescriptions: [
-				localize('sessions.customizations.sidebarMode.welcome', "Show one item per customization category. Clicking a category opens the Customizations welcome page."),
+				localize('sessions.customizations.sidebarMode.welcome', "Legacy alias for section mode. Show one item per customization category. Clicking a category deep-links to that category's section in the Customizations editor."),
 				localize('sessions.customizations.sidebarMode.section', "Show one item per customization category. Clicking a category deep-links to that category's section in the Customizations editor."),
 				localize('sessions.customizations.sidebarMode.single', "Show a single \"Customizations\" entry instead of one item per category. Clicking it opens the Customizations welcome page."),
 			],
 			description: localize('sessions.customizations.sidebarMode', "Controls how the Customizations section in the Agents sidebar is presented and what happens when an entry is clicked."),
-			default: SessionsCustomizationsSidebarMode.Welcome,
+			default: SessionsCustomizationsSidebarMode.Section,
 		},
 	},
 });
@@ -287,7 +286,6 @@ export class CustomizationsToolbarContribution extends Disposable implements IWo
 					const editorService = accessor.get(IEditorService);
 					const harnessService = accessor.get(ICustomizationHarnessService);
 					const sessionsManagementService = accessor.get(ISessionsManagementService);
-					const configurationService = accessor.get(IConfigurationService);
 					const sessionResource = sessionsManagementService.activeSession.get()?.resource;
 					if (sessionResource) {
 						harnessService.setActiveSession(sessionResource);
@@ -295,13 +293,7 @@ export class CustomizationsToolbarContribution extends Disposable implements IWo
 					const input = AICustomizationManagementEditorInput.getOrCreate();
 					const pane = await editorService.openEditor(input, { pinned: true });
 					if (pane instanceof AICustomizationManagementEditor) {
-						const mode = configurationService.getValue<string>(SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING);
-						if (mode === SessionsCustomizationsSidebarMode.Section) {
-							pane.selectSectionById(config.section);
-						} else {
-							// 'welcome' (default) and 'single' both land on the welcome page.
-							pane.showWelcomePage();
-						}
+						pane.selectSectionById(config.section);
 					}
 				}
 			}));

--- a/src/vs/sessions/contrib/sessions/test/browser/customizationsToolbar.contribution.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/customizationsToolbar.contribution.test.ts
@@ -1,0 +1,118 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event } from '../../../../../base/common/event.js';
+import { observableValue } from '../../../../../base/common/observable.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IActionViewItemFactory, IActionViewItemService } from '../../../../../platform/actions/browser/actionViewItemService.js';
+import { MenuId } from '../../../../../platform/actions/common/actions.js';
+import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IEditorOptions, IResourceEditorInput } from '../../../../../platform/editor/common/editor.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { EditorInput } from '../../../../../workbench/common/editor/editorInput.js';
+import { IEditorPane, IResourceDiffEditorInput, ITextDiffEditorPane, IUntitledTextResourceEditorInput, IUntypedEditorInput } from '../../../../../workbench/common/editor.js';
+import { IEditorService, PreferredGroup } from '../../../../../workbench/services/editor/common/editorService.js';
+import { TestEditorService } from '../../../../../workbench/test/browser/workbenchTestServices.js';
+import { AICustomizationManagementEditor } from '../../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.js';
+import { AICustomizationManagementSection, AICustomizationSources } from '../../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
+import { ICustomizationHarnessService, IHarnessDescriptor } from '../../../../../workbench/contrib/chat/common/customizationHarnessService.js';
+import { PromptsType } from '../../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
+import { IActiveSession, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { CUSTOMIZATION_ITEMS, CustomizationsToolbarContribution } from '../../browser/customizationsToolbar.contribution.js';
+
+class TestActionViewItemService implements IActionViewItemService {
+	declare _serviceBrand: undefined;
+	readonly onDidChange = Event.None;
+
+	register(_menu: MenuId, _commandId: string | MenuId, _provider: IActionViewItemFactory): { dispose(): void } {
+		return { dispose: () => { } };
+	}
+
+	lookUp(_menu: MenuId, _commandId: string | MenuId): IActionViewItemFactory | undefined {
+		return undefined;
+	}
+}
+
+class TestCustomizationEditorService extends TestEditorService {
+
+	constructor(private readonly editor: IEditorPane) {
+		super();
+	}
+
+	override openEditor(editor: EditorInput, options?: IEditorOptions, group?: PreferredGroup): Promise<IEditorPane | undefined>;
+	override openEditor(editor: IResourceEditorInput | IUntitledTextResourceEditorInput, group?: PreferredGroup): Promise<IEditorPane | undefined>;
+	override openEditor(editor: IResourceDiffEditorInput, group?: PreferredGroup): Promise<ITextDiffEditorPane | undefined>;
+	override openEditor(_editor: EditorInput | IUntypedEditorInput, _optionsOrGroup?: IEditorOptions | PreferredGroup, _group?: PreferredGroup): Promise<IEditorPane | undefined> {
+		if (_editor instanceof EditorInput) {
+			this._register(_editor);
+		}
+		return Promise.resolve(this.editor);
+	}
+}
+
+suite('Sessions Customizations Toolbar Contribution', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('customization category actions deep-link to the clicked section', async () => {
+		const instantiationService = store.add(new TestInstantiationService());
+		const sessionResource = URI.parse('test-session:///session');
+		const selectedSections: AICustomizationManagementSection[] = [];
+		const activeSessionResources: URI[] = [];
+		const editor = Object.setPrototypeOf({
+			selectSectionById: (section: AICustomizationManagementSection) => selectedSections.push(section),
+		}, AICustomizationManagementEditor.prototype) as AICustomizationManagementEditor;
+
+		const descriptor: IHarnessDescriptor = {
+			id: 'test-session',
+			label: 'Test Session',
+			icon: ThemeIcon.fromId('testing-view-icon'),
+			getStorageSourceFilter: (_type: PromptsType) => ({ sources: AICustomizationSources.all }),
+		};
+
+		instantiationService.set(IActionViewItemService, new TestActionViewItemService());
+		instantiationService.set(ICustomizationHarnessService, new class extends mock<ICustomizationHarnessService>() {
+			override readonly activeHarness = observableValue('activeHarness', descriptor.id);
+			override readonly availableHarnesses = observableValue<readonly IHarnessDescriptor[]>('availableHarnesses', [descriptor]);
+
+			override getActiveDescriptor(): IHarnessDescriptor {
+				return descriptor;
+			}
+
+			override setActiveSession(resource: URI): void {
+				activeSessionResources.push(resource);
+			}
+		});
+		instantiationService.set(IContextKeyService, new MockContextKeyService());
+		instantiationService.set(IEditorService, store.add(new TestCustomizationEditorService(editor)));
+		instantiationService.set(ISessionsManagementService, new class extends mock<ISessionsManagementService>() {
+			override readonly activeSession = observableValue<IActiveSession | undefined>('activeSession', new class extends mock<IActiveSession>() {
+				override readonly resource = sessionResource;
+			});
+		});
+
+		store.add(instantiationService.createInstance(CustomizationsToolbarContribution));
+
+		const pluginsAction = CUSTOMIZATION_ITEMS.find(item => item.section === AICustomizationManagementSection.Plugins);
+		assert.ok(pluginsAction);
+		const handler = CommandsRegistry.getCommand(pluginsAction.id)?.handler;
+		assert.ok(handler);
+
+		await handler(instantiationService);
+
+		assert.deepStrictEqual({
+			selectedSections,
+			activeSessionResources,
+		}, {
+			selectedSections: [AICustomizationManagementSection.Plugins],
+			activeSessionResources: [sessionResource],
+		});
+	});
+});

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -698,6 +698,7 @@
 	border: 1px solid var(--vscode-widget-border);
 	border-radius: 6px;
 	cursor: pointer;
+	touch-action: manipulation;
 	transition: background-color 0.1s ease;
 	flex: 1 1 120px;
 	min-width: 100px;


### PR DESCRIPTION
## Summary

Fixes #321166.

Fixes Agents window customization category entries opening the management dialog without selecting the clicked section. For example, clicking **Plugins** now opens the Customizations editor with **Plugins** selected instead of landing on the welcome page.

Changes in this PR:
- Deep-link per-category sidebar entries to their matching management editor section.
- Deep-link AI Customization overview cards and sync the active session harness before selecting the section, matching the sidebar path.
- Keep the single **Customizations** entry as the welcome-page entry point.
- Treat `sessions.customizations.sidebarMode=welcome` as a legacy alias for section mode and make `section` the default.
- Add a regression test for the **Plugins** category action.

## Review instructions

Please focus on the Agents window customization entry points:
- In the Agents window sidebar, click category rows such as **Agents**, **MCP Servers**, and **Plugins** and confirm the dialog opens with the clicked section selected.
- If `sessions.customizations.sidebarMode` is set to `single`, confirm the single **Customizations** entry still opens the welcome page.
- From the AI Customization overview cards, confirm section cards select the clicked section for the active session harness.
- Pay particular attention to harness switching/hidden-section behavior; the overview path now mirrors the sidebar by syncing the active session before selecting a section.

## Validation

- `npm run compile-check-ts-native`
- `npm run valid-layers-check`
- `scripts/test.sh --grep "Sessions Customizations Toolbar Contribution"`
- `npm run precommit`

