### PR TITLE
AgentHost - add per-provider enable settings for Claude/Codex

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
@@ -8,8 +8,10 @@ import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '.
 import product from '../../product/common/product.js';
 import { Registry } from '../../registry/common/platform.js';
 import {
+	AgentHostClaudeAgentEnabledSettingId,
 	AgentHostClaudeAgentSdkRootSettingId,
 	AgentHostCodexAgentBinaryArgsSettingId,
+	AgentHostCodexAgentEnabledSettingId,
 	AgentHostCodexAgentSdkRootSettingId,
 	AgentHostCodexAgentCodexHomeSettingId,
 	AgentHostOTelCaptureContentSettingId,
@@ -42,6 +44,18 @@ configurationRegistry.registerConfiguration({
 	title: nls.localize('chatAgentHostStarterConfigurationTitle', "Chat Agent Host Starter"),
 	type: 'object',
 	properties: {
+		[AgentHostClaudeAgentEnabledSettingId]: {
+			type: 'boolean',
+			description: nls.localize('chat.agentHost.claudeAgent.enabled', "When enabled, the agent host registers the Claude provider (subject to the Claude SDK being reachable). Independent of `#chat.agents.claude.preferAgentHost#` and `#chat.editor.claude.preferAgentHost#`, which choose which integration surfaces Claude. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect."),
+			default: true,
+			tags: ['experimental', 'advanced'],
+		},
+		[AgentHostCodexAgentEnabledSettingId]: {
+			type: 'boolean',
+			description: nls.localize('chat.agentHost.codexAgent.enabled', "When enabled, the agent host registers the Codex provider (subject to the Codex SDK being reachable). Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect."),
+			default: false,
+			tags: ['experimental', 'advanced'],
+		},
 		[AgentHostClaudeAgentSdkRootSettingId]: {
 			type: 'string',
 			description: nls.localize('chat.agentHost.claudeAgent.sdkRoot', "Experimental, for local SDK development only. Absolute path to a directory containing `node_modules/@anthropic-ai/claude-agent-sdk`. When set, the agent host loads Claude from this tree instead of downloading the SDK. Empty (the default) falls through to the SDK distribution shipped with this build. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect."),

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -112,9 +112,13 @@ export const AgentHostCodexAgentEnabledEnvVar = 'VSCODE_AGENT_HOST_CODEX_AGENT_E
 
 /**
  * Resolves the effective enable state for a Claude/Codex provider from the
- * env-var value forwarded by the starter. `'false'` (case-insensitive) is
- * the only value that disables; everything else — including the empty string
- * and `undefined` — falls through to {@link defaultEnabled}.
+ * env-var value forwarded by the starter. Recognized values (case- and
+ * whitespace-insensitive):
+ *
+ *  - `'true'`  / `'1'` → enabled
+ *  - `'false'` / `'0'` → disabled
+ *  - `undefined`, empty string, or any other value → falls through to
+ *    {@link defaultEnabled}
  */
 export function isAgentEnabled(envValue: string | undefined, defaultEnabled: boolean): boolean {
 	if (envValue === undefined || envValue === '') {

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -68,11 +68,67 @@ export const AgentHostCustomTerminalToolEnabledSettingId = 'chat.agentHost.custo
 export const AgentHostClaudeAgentSdkRootSettingId = 'chat.agentHost.claudeAgent.sdkRoot';
 
 /**
+ * Configuration key controlling whether the Claude provider is registered in
+ * the agent host process. When `false`, the agent host skips registering the
+ * Claude provider regardless of SDK availability. Defaults to `true`.
+ *
+ * Independent of {@link ClaudePreferAgentHostAgentsSettingId} /
+ * {@link ClaudePreferAgentHostEditorSettingId}, which control whether the
+ * workbench surfaces the agent host's Claude provider (vs. the GitHub Copilot
+ * Chat extension's). This setting is strictly about whether the agent host
+ * advertises Claude at all. The agent host process must be restarted for
+ * changes to take effect.
+ */
+export const AgentHostClaudeAgentEnabledSettingId = 'chat.agentHost.claudeAgent.enabled';
+
+/**
+ * Configuration key controlling whether the Codex provider is registered in
+ * the agent host process. When `false` (the default), the agent host skips
+ * registering the Codex provider regardless of SDK availability. The agent
+ * host process must be restarted for changes to take effect.
+ */
+export const AgentHostCodexAgentEnabledSettingId = 'chat.agentHost.codexAgent.enabled';
+
+/**
  * Environment variable form of {@link AgentHostClaudeAgentSdkRootSettingId}.
  * Set by the agent host starters from the setting, and may also be set
  * directly by developers as an override.
  */
 export const AgentHostClaudeSdkRootEnvVar = 'VSCODE_AGENT_HOST_CLAUDE_SDK_ROOT';
+
+/**
+ * Environment variable form of {@link AgentHostClaudeAgentEnabledSettingId}.
+ * Set by the agent host starters from the setting. Accepts `'true'` /
+ * `'false'`; absent means "default" (`true` for Claude, `false` for Codex).
+ */
+export const AgentHostClaudeAgentEnabledEnvVar = 'VSCODE_AGENT_HOST_CLAUDE_AGENT_ENABLED';
+
+/**
+ * Environment variable form of {@link AgentHostCodexAgentEnabledSettingId}.
+ * Set by the agent host starters from the setting. Accepts `'true'` /
+ * `'false'`; absent means "default" (`false`).
+ */
+export const AgentHostCodexAgentEnabledEnvVar = 'VSCODE_AGENT_HOST_CODEX_AGENT_ENABLED';
+
+/**
+ * Resolves the effective enable state for a Claude/Codex provider from the
+ * env-var value forwarded by the starter. `'false'` (case-insensitive) is
+ * the only value that disables; everything else — including the empty string
+ * and `undefined` — falls through to {@link defaultEnabled}.
+ */
+export function isAgentEnabled(envValue: string | undefined, defaultEnabled: boolean): boolean {
+	if (envValue === undefined || envValue === '') {
+		return defaultEnabled;
+	}
+	const normalized = envValue.trim().toLowerCase();
+	if (normalized === 'false' || normalized === '0') {
+		return false;
+	}
+	if (normalized === 'true' || normalized === '1') {
+		return true;
+	}
+	return defaultEnabled;
+}
 
 /**
  * Configuration key that controls the sandbox mode for the Copilot SDK's built-in
@@ -281,6 +337,8 @@ export interface IAgentSdkStarterSettings {
 	readonly codexSdkRoot?: string;
 	readonly codexHome?: string;
 	readonly codexBinaryArgs?: readonly string[];
+	readonly claudeAgentEnabled?: boolean;
+	readonly codexAgentEnabled?: boolean;
 }
 
 export function buildAgentSdkEnv(
@@ -299,6 +357,12 @@ export function buildAgentSdkEnv(
 	setIfMissing(AgentHostCodexAgentCodexHomeEnvVar, settings.codexHome);
 	if (Array.isArray(settings.codexBinaryArgs) && settings.codexBinaryArgs.length > 0) {
 		setIfMissing(AgentHostCodexAgentBinaryArgsEnvVar, JSON.stringify(settings.codexBinaryArgs));
+	}
+	if (settings.claudeAgentEnabled !== undefined) {
+		setIfMissing(AgentHostClaudeAgentEnabledEnvVar, settings.claudeAgentEnabled ? 'true' : 'false');
+	}
+	if (settings.codexAgentEnabled !== undefined) {
+		setIfMissing(AgentHostCodexAgentEnabledEnvVar, settings.codexAgentEnabled ? 'true' : 'false');
 	}
 	return out;
 }

--- a/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
@@ -19,7 +19,7 @@ import { getResolvedShellEnv } from '../../shell/node/shellEnv.js';
 import { NullTelemetryService } from '../../telemetry/common/telemetryUtils.js';
 import { UtilityProcess } from '../../utilityProcess/electron-main/utilityProcess.js';
 import { IAgentHostConnection, IAgentHostStarter } from '../common/agent.js';
-import { AgentHostClaudeAgentSdkRootSettingId, AgentHostCodexAgentBinaryArgsSettingId, AgentHostCodexAgentSdkRootSettingId, AgentHostCodexAgentCodexHomeSettingId, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, buildAgentHostOTelEnv, buildAgentSdkEnv } from '../common/agentService.js';
+import { AgentHostClaudeAgentEnabledSettingId, AgentHostClaudeAgentSdkRootSettingId, AgentHostCodexAgentBinaryArgsSettingId, AgentHostCodexAgentEnabledSettingId, AgentHostCodexAgentSdkRootSettingId, AgentHostCodexAgentCodexHomeSettingId, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, buildAgentHostOTelEnv, buildAgentSdkEnv } from '../common/agentService.js';
 import { deepClone } from '../../../base/common/objects.js';
 import '../common/agentHost.config.contribution.js';
 import '../common/agentHostStarter.config.contribution.js';
@@ -74,6 +74,8 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 			codexSdkRoot: this._configurationService.getValue<string>(AgentHostCodexAgentSdkRootSettingId),
 			codexHome: this._configurationService.getValue<string>(AgentHostCodexAgentCodexHomeSettingId),
 			codexBinaryArgs: this._configurationService.getValue<readonly string[]>(AgentHostCodexAgentBinaryArgsSettingId),
+			claudeAgentEnabled: this._configurationService.getValue<boolean>(AgentHostClaudeAgentEnabledSettingId),
+			codexAgentEnabled: this._configurationService.getValue<boolean>(AgentHostCodexAgentEnabledSettingId),
 		}, process.env);
 
 		// Translate `chat.agentHost.otel.*` settings into the env vars consumed by

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -15,7 +15,7 @@ import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
 import * as os from 'os';
 import * as inspector from 'inspector';
-import { AgentHostIpcChannels, IAgentHostInspectInfo, IAgentHostSocketInfo, IAgentService, IConnectionTrackerService } from '../common/agentService.js';
+import { AgentHostClaudeAgentEnabledEnvVar, AgentHostCodexAgentEnabledEnvVar, AgentHostIpcChannels, IAgentHostInspectInfo, IAgentHostSocketInfo, IAgentService, IConnectionTrackerService, isAgentEnabled } from '../common/agentService.js';
 import { AgentService } from './agentService.js';
 import { IAgentConfigurationService } from './agentConfigurationService.js';
 import { IAgentHostCompletions } from './agentHostCompletions.js';
@@ -181,15 +181,19 @@ async function startAgentHost(): Promise<void> {
 		diServices.set(IAgentConfigurationService, agentService.configurationService);
 		diServices.set(IAgentHostCompletions, agentService.completionsService);
 		agentService.registerProvider(instantiationService.createInstance(CopilotAgent));
-		// Claude and Codex providers are gated on the SDK being reachable —
-		// either via the dev-override env var (`VSCODE_AGENT_HOST_*_SDK_ROOT`) or
-		// via a `product.agentSdks.<pkg>` entry that ships with this build.
-		// If neither is present, the provider is not registered and never
-		// appears in the agent picker (matches the pre-CDN UX exactly).
-		if (agentSdkDownloader.isAvailable(ClaudeSdkPackage)) {
+		// Claude and Codex providers are gated on two things:
+		//  1. The user-facing enable toggle (`chat.agentHost.<x>Agent.enabled`,
+		//     forwarded as an env var by the starters). Claude defaults to on,
+		//     Codex defaults to off.
+		//  2. The SDK being reachable — either via the dev-override env var
+		//     (`VSCODE_AGENT_HOST_*_SDK_ROOT`) or via a `product.agentSdks.<pkg>`
+		//     entry that ships with this build.
+		// If either gate fails, the provider is not registered and never appears
+		// in the agent picker (matches the pre-CDN UX exactly).
+		if (isAgentEnabled(process.env[AgentHostClaudeAgentEnabledEnvVar], true) && agentSdkDownloader.isAvailable(ClaudeSdkPackage)) {
 			agentService.registerProvider(instantiationService.createInstance(ClaudeAgent));
 		}
-		if (agentSdkDownloader.isAvailable(CodexSdkPackage)) {
+		if (isAgentEnabled(process.env[AgentHostCodexAgentEnabledEnvVar], false) && agentSdkDownloader.isAvailable(CodexSdkPackage)) {
 			agentService.registerProvider(instantiationService.createInstance(CodexAgent));
 		}
 	} catch (err) {

--- a/src/vs/platform/agentHost/node/agentHostServerMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostServerMain.ts
@@ -44,7 +44,7 @@ import { AgentSdkDownloader, IAgentSdkDownloader } from './agentSdkDownloader.js
 import { IAgentHostOTelService } from '../common/otel/agentHostOTelService.js';
 import { AgentHostOTelService } from './otel/agentHostOTelService.js';
 import { AgentService } from './agentService.js';
-import { AgentHostClaudeSdkRootEnvVar, IAgentService, AgentHostCodexAgentSdkRootEnvVar } from '../common/agentService.js';
+import { AgentHostClaudeAgentEnabledEnvVar, AgentHostClaudeSdkRootEnvVar, AgentHostCodexAgentEnabledEnvVar, IAgentService, AgentHostCodexAgentSdkRootEnvVar, isAgentEnabled } from '../common/agentService.js';
 import { IAgentConfigurationService } from './agentConfigurationService.js';
 import { IAgentHostCompletions } from './agentHostCompletions.js';
 import { IAgentHostTerminalManager } from './agentHostTerminalManager.js';
@@ -281,15 +281,20 @@ async function main(): Promise<void> {
 		const copilotAgent = disposables.add(instantiationService.createInstance(CopilotAgent));
 		agentService.registerProvider(copilotAgent);
 		log('CopilotAgent registered');
-		// Claude and Codex providers are gated on the SDK being reachable —
-		// either via the CLI flag / env var dev override, or via a
-		// `product.agentSdks.<pkg>` entry shipped with this build.
-		if (agentSdkDownloader.isAvailable(ClaudeSdkPackage)) {
+		// Claude and Codex providers are gated on two things:
+		//  1. The user-facing enable toggle (`chat.agentHost.<x>Agent.enabled`,
+		//     forwarded as an env var by the renderer-side starters; the remote
+		//     server reads the env directly). Claude defaults to on, Codex
+		//     defaults to off.
+		//  2. The SDK being reachable — either via the CLI flag / env var dev
+		//     override, or via a `product.agentSdks.<pkg>` entry shipped with
+		//     this build.
+		if (isAgentEnabled(process.env[AgentHostClaudeAgentEnabledEnvVar], true) && agentSdkDownloader.isAvailable(ClaudeSdkPackage)) {
 			const claudeAgent = disposables.add(instantiationService.createInstance(ClaudeAgent));
 			agentService.registerProvider(claudeAgent);
 			log('ClaudeAgent registered');
 		}
-		if (agentSdkDownloader.isAvailable(CodexSdkPackage)) {
+		if (isAgentEnabled(process.env[AgentHostCodexAgentEnabledEnvVar], false) && agentSdkDownloader.isAvailable(CodexSdkPackage)) {
 			const codexAgent = disposables.add(instantiationService.createInstance(CodexAgent));
 			agentService.registerProvider(codexAgent);
 			log('CodexAgent registered');

--- a/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
@@ -13,7 +13,7 @@ import { parseAgentHostDebugPort } from '../../environment/node/environmentServi
 import { ILogService } from '../../log/common/log.js';
 import { getResolvedShellEnv } from '../../shell/node/shellEnv.js';
 import { IAgentHostConnection, IAgentHostStarter } from '../common/agent.js';
-import { AgentHostClaudeAgentSdkRootSettingId, AgentHostCodexAgentBinaryArgsSettingId, AgentHostCodexAgentSdkRootSettingId, AgentHostCodexAgentCodexHomeSettingId, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, buildAgentHostOTelEnv, buildAgentSdkEnv } from '../common/agentService.js';
+import { AgentHostClaudeAgentEnabledSettingId, AgentHostClaudeAgentSdkRootSettingId, AgentHostCodexAgentBinaryArgsSettingId, AgentHostCodexAgentEnabledSettingId, AgentHostCodexAgentSdkRootSettingId, AgentHostCodexAgentCodexHomeSettingId, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, buildAgentHostOTelEnv, buildAgentSdkEnv } from '../common/agentService.js';
 import '../common/agentHostStarter.config.contribution.js';
 
 /**
@@ -82,6 +82,8 @@ export class NodeAgentHostStarter extends Disposable implements IAgentHostStarte
 			codexSdkRoot: this._configurationService.getValue<string>(AgentHostCodexAgentSdkRootSettingId),
 			codexHome: this._configurationService.getValue<string>(AgentHostCodexAgentCodexHomeSettingId),
 			codexBinaryArgs: this._configurationService.getValue<readonly string[]>(AgentHostCodexAgentBinaryArgsSettingId),
+			claudeAgentEnabled: this._configurationService.getValue<boolean>(AgentHostClaudeAgentEnabledSettingId),
+			codexAgentEnabled: this._configurationService.getValue<boolean>(AgentHostCodexAgentEnabledSettingId),
 		}, process.env);
 		Object.assign(env, sdkEnv);
 

--- a/src/vs/platform/agentHost/test/common/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentService.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { AgentSession } from '../../common/agentService.js';
+import { AgentSession, isAgentEnabled } from '../../common/agentService.js';
 
 suite('AgentSession namespace', () => {
 
@@ -33,4 +33,36 @@ suite('AgentSession namespace', () => {
 		const session = AgentSession.uri('copilot', 'sess-1');
 		assert.strictEqual(AgentSession.provider(session), 'copilot');
 	});
+});
+
+suite('isAgentEnabled', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const cases: ReadonlyArray<{ envValue: string | undefined; defaultEnabled: boolean; expected: boolean; description: string }> = [
+		// Fallback to default
+		{ envValue: undefined, defaultEnabled: true, expected: true, description: 'undefined falls back to default=true' },
+		{ envValue: undefined, defaultEnabled: false, expected: false, description: 'undefined falls back to default=false' },
+		{ envValue: '', defaultEnabled: true, expected: true, description: 'empty string falls back to default=true' },
+		{ envValue: '', defaultEnabled: false, expected: false, description: 'empty string falls back to default=false' },
+		{ envValue: '   ', defaultEnabled: true, expected: true, description: 'whitespace-only falls back to default=true' },
+		{ envValue: 'maybe', defaultEnabled: true, expected: true, description: 'unrecognized value falls back to default=true' },
+		{ envValue: 'maybe', defaultEnabled: false, expected: false, description: 'unrecognized value falls back to default=false' },
+		// Explicit enable
+		{ envValue: 'true', defaultEnabled: false, expected: true, description: '"true" enables even when default=false' },
+		{ envValue: 'TRUE', defaultEnabled: false, expected: true, description: '"TRUE" is case-insensitive' },
+		{ envValue: '  true  ', defaultEnabled: false, expected: true, description: '"true" with whitespace is trimmed' },
+		{ envValue: '1', defaultEnabled: false, expected: true, description: '"1" enables even when default=false' },
+		// Explicit disable
+		{ envValue: 'false', defaultEnabled: true, expected: false, description: '"false" disables even when default=true' },
+		{ envValue: 'FALSE', defaultEnabled: true, expected: false, description: '"FALSE" is case-insensitive' },
+		{ envValue: '  false  ', defaultEnabled: true, expected: false, description: '"false" with whitespace is trimmed' },
+		{ envValue: '0', defaultEnabled: true, expected: false, description: '"0" disables even when default=true' },
+	];
+
+	for (const { envValue, defaultEnabled, expected, description } of cases) {
+		test(description, () => {
+			assert.strictEqual(isAgentEnabled(envValue, defaultEnabled), expected);
+		});
+	}
 });


### PR DESCRIPTION
## Summary

Adds two new settings to the agent host's `chat.agentHost.*` namespace that gate provider registration independent of SDK availability:

- `chat.agentHost.claudeAgent.enabled` (default: `true`)
- `chat.agentHost.codexAgent.enabled` (default: `false`)

Both compose with the existing `agentSdkDownloader.isAvailable(...)` check as `enabled && isAvailable`, so the registration condition is now \"the user wants this provider AND the SDK is reachable\" instead of just the latter.

## Why default Claude to `true`?

The new setting only controls whether the agent host **advertises** the Claude provider — it doesn't decide whether the workbench actually surfaces it. That's still governed by `chat.agents.claude.preferAgentHost` (Agents window) and `chat.editor.claude.preferAgentHost` (sidebar), both of which default to `false`. So even with `claudeAgent.enabled: true`, the user has to opt into the agent-host Claude integration via the prefer settings before they see any behavioral change. Defaulting Claude to `true` keeps the agent host's provider available for users who flip the prefer settings, without forcing two opt-ins for what feels like one decision.

Codex defaults to `false` because there's no extension-side Codex integration today — Codex through the agent host is the only path, so making it opt-in matches its experimental status.

## Plumbing

Setting → env var → process gate, identical pattern to the existing SDK-root overrides:

1. Settings registered in `agentHostStarter.config.contribution.ts`.
2. `IAgentSdkStarterSettings` / `buildAgentSdkEnv` in `agentService.ts` get two new boolean fields, forwarded as `VSCODE_AGENT_HOST_{CLAUDE,CODEX}_AGENT_ENABLED`.
3. Both starters (`electronAgentHostStarter.ts`, `nodeAgentHostStarter.ts`) read the settings and pass them through `buildAgentSdkEnv`.
4. `agentHostMain.ts` and `agentHostServerMain.ts` read the env vars via a new shared `isAgentEnabled()` helper that handles the defaults (Claude → `true`, Codex → `false`) when the env var is absent.

## Test plan

Manually verified all combinations end-to-end via the Agents window provider picker, with a dev SDK root pointed at a sibling checkout:

- [x] **defaults** (Claude unset, Codex unset) → log shows `copilotcli`, `claude`; picker shows Copilot CLI + Claude under Local Agent Host
- [x] **both enabled** → log shows `copilotcli`, `claude`, `codex`; picker shows all three
- [x] **Claude off, Codex on** → log shows `copilotcli`, `codex`; picker shows Copilot CLI + Codex
- [x] **both disabled** → log shows only `copilotcli`; picker shows only Copilot CLI under Local Agent Host
- [x] **Claude explicitly true, Codex explicitly false** → matches defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)