### PR TITLE
AgentHost - drop chat.agentHost.claudeAgent.sdkRoot in favor of bare import

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
@@ -9,7 +9,6 @@ import product from '../../product/common/product.js';
 import { Registry } from '../../registry/common/platform.js';
 import {
 	AgentHostClaudeAgentEnabledSettingId,
-	AgentHostClaudeAgentSdkRootSettingId,
 	AgentHostCodexAgentBinaryArgsSettingId,
 	AgentHostCodexAgentEnabledSettingId,
 	AgentHostCodexAgentSdkRootSettingId,
@@ -55,13 +54,6 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.agentHost.codexAgent.enabled', "When enabled, the agent host registers the Codex provider (subject to the Codex SDK being reachable). Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect."),
 			default: false,
 			tags: ['experimental', 'advanced'],
-		},
-		[AgentHostClaudeAgentSdkRootSettingId]: {
-			type: 'string',
-			description: nls.localize('chat.agentHost.claudeAgent.sdkRoot', "Experimental, for local SDK development only. Absolute path to a directory containing `node_modules/@anthropic-ai/claude-agent-sdk`. When set, the agent host loads Claude from this tree instead of downloading the SDK. Empty (the default) falls through to the SDK distribution shipped with this build. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect."),
-			default: '',
-			tags: ['experimental', 'advanced'],
-			included: product.quality !== 'stable',
 		},
 		[AgentHostCodexAgentSdkRootSettingId]: {
 			type: 'string',

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -56,18 +56,6 @@ export const AgentHostAhpJsonlLoggingSettingId = 'chat.agentHost.ahpJsonlLogging
 export const AgentHostCustomTerminalToolEnabledSettingId = 'chat.agentHost.customTerminalTool.enabled';
 
 /**
- * Configuration key that holds the absolute path to the **SDK root directory**
- * — the directory that contains a `node_modules/@anthropic-ai/claude-agent-sdk`
- * subtree. When non-empty, the agent host treats it as a dev override and skips
- * the on-demand download from `product.agentSdks.claude` for the Claude SDK.
- *
- * Empty (the default) means: load the SDK from `product.agentSdks.claude` if
- * the build supplies one; otherwise the Claude provider is not registered.
- * The agent host process must be restarted for changes to take effect.
- */
-export const AgentHostClaudeAgentSdkRootSettingId = 'chat.agentHost.claudeAgent.sdkRoot';
-
-/**
  * Configuration key controlling whether the Claude provider is registered in
  * the agent host process. When `false`, the agent host skips registering the
  * Claude provider regardless of SDK availability. Defaults to `true`.
@@ -90,9 +78,13 @@ export const AgentHostClaudeAgentEnabledSettingId = 'chat.agentHost.claudeAgent.
 export const AgentHostCodexAgentEnabledSettingId = 'chat.agentHost.codexAgent.enabled';
 
 /**
- * Environment variable form of {@link AgentHostClaudeAgentSdkRootSettingId}.
- * Set by the agent host starters from the setting, and may also be set
- * directly by developers as an override.
+ * Optional override that points at an **SDK root directory** containing a
+ * `node_modules/@anthropic-ai/claude-agent-sdk` subtree. When set, the agent
+ * host loads the Claude SDK from that path instead of the bare import (which
+ * resolves via this repo's `node_modules` in dev) or the on-demand download
+ * from `product.agentSdks.claude` (built products). Mainly exists for the
+ * remote server's `--claude-sdk-root` CLI flag and for one-off developer
+ * overrides pointing at an out-of-tree SDK build.
  */
 export const AgentHostClaudeSdkRootEnvVar = 'VSCODE_AGENT_HOST_CLAUDE_SDK_ROOT';
 
@@ -337,7 +329,6 @@ export function buildAgentHostOTelEnv(
  * the caller spreads into the spawned child's environment.
  */
 export interface IAgentSdkStarterSettings {
-	readonly claudeSdkRoot?: string;
 	readonly codexSdkRoot?: string;
 	readonly codexHome?: string;
 	readonly codexBinaryArgs?: readonly string[];
@@ -356,7 +347,6 @@ export function buildAgentSdkEnv(
 		}
 		out[key] = value;
 	};
-	setIfMissing(AgentHostClaudeSdkRootEnvVar, settings.claudeSdkRoot);
 	setIfMissing(AgentHostCodexAgentSdkRootEnvVar, settings.codexSdkRoot);
 	setIfMissing(AgentHostCodexAgentCodexHomeEnvVar, settings.codexHome);
 	if (Array.isArray(settings.codexBinaryArgs) && settings.codexBinaryArgs.length > 0) {

--- a/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
@@ -19,7 +19,7 @@ import { getResolvedShellEnv } from '../../shell/node/shellEnv.js';
 import { NullTelemetryService } from '../../telemetry/common/telemetryUtils.js';
 import { UtilityProcess } from '../../utilityProcess/electron-main/utilityProcess.js';
 import { IAgentHostConnection, IAgentHostStarter } from '../common/agent.js';
-import { AgentHostClaudeAgentEnabledSettingId, AgentHostClaudeAgentSdkRootSettingId, AgentHostCodexAgentBinaryArgsSettingId, AgentHostCodexAgentEnabledSettingId, AgentHostCodexAgentSdkRootSettingId, AgentHostCodexAgentCodexHomeSettingId, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, buildAgentHostOTelEnv, buildAgentSdkEnv } from '../common/agentService.js';
+import { AgentHostClaudeAgentEnabledSettingId, AgentHostCodexAgentBinaryArgsSettingId, AgentHostCodexAgentEnabledSettingId, AgentHostCodexAgentSdkRootSettingId, AgentHostCodexAgentCodexHomeSettingId, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, buildAgentHostOTelEnv, buildAgentSdkEnv } from '../common/agentService.js';
 import { deepClone } from '../../../base/common/objects.js';
 import '../common/agentHost.config.contribution.js';
 import '../common/agentHostStarter.config.contribution.js';
@@ -70,7 +70,6 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 		// workbench settings to the agent host process. Parent env wins on
 		// collision — see `buildAgentSdkEnv` for the precedence rule.
 		const sdkEnv = buildAgentSdkEnv({
-			claudeSdkRoot: this._configurationService.getValue<string>(AgentHostClaudeAgentSdkRootSettingId),
 			codexSdkRoot: this._configurationService.getValue<string>(AgentHostCodexAgentSdkRootSettingId),
 			codexHome: this._configurationService.getValue<string>(AgentHostCodexAgentCodexHomeSettingId),
 			codexBinaryArgs: this._configurationService.getValue<readonly string[]>(AgentHostCodexAgentBinaryArgsSettingId),

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -185,12 +185,15 @@ async function startAgentHost(): Promise<void> {
 		//  1. The user-facing enable toggle (`chat.agentHost.<x>Agent.enabled`,
 		//     forwarded as an env var by the starters). Claude defaults to on,
 		//     Codex defaults to off.
-		//  2. The SDK being reachable — either via the dev-override env var
-		//     (`VSCODE_AGENT_HOST_*_SDK_ROOT`) or via a `product.agentSdks.<pkg>`
-		//     entry that ships with this build.
+		//  2. The SDK being reachable. Claude is a devDependency of this repo
+		//     so the bare-import path in `ClaudeAgentSdkService._loadSdk`
+		//     always succeeds in dev; in built products the SDK ships via
+		//     `product.agentSdks.claude` and the downloader handles it. Codex
+		//     has no equivalent dev path yet, so it still requires either the
+		//     env-var override or a `product.agentSdks.codex` entry.
 		// If either gate fails, the provider is not registered and never appears
 		// in the agent picker (matches the pre-CDN UX exactly).
-		if (isAgentEnabled(process.env[AgentHostClaudeAgentEnabledEnvVar], true) && agentSdkDownloader.isAvailable(ClaudeSdkPackage)) {
+		if (isAgentEnabled(process.env[AgentHostClaudeAgentEnabledEnvVar], true) && (!environmentService.isBuilt || agentSdkDownloader.isAvailable(ClaudeSdkPackage))) {
 			agentService.registerProvider(instantiationService.createInstance(ClaudeAgent));
 		}
 		if (isAgentEnabled(process.env[AgentHostCodexAgentEnabledEnvVar], false) && agentSdkDownloader.isAvailable(CodexSdkPackage)) {

--- a/src/vs/platform/agentHost/node/agentHostServerMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostServerMain.ts
@@ -286,10 +286,13 @@ async function main(): Promise<void> {
 		//     forwarded as an env var by the renderer-side starters; the remote
 		//     server reads the env directly). Claude defaults to on, Codex
 		//     defaults to off.
-		//  2. The SDK being reachable — either via the CLI flag / env var dev
-		//     override, or via a `product.agentSdks.<pkg>` entry shipped with
-		//     this build.
-		if (isAgentEnabled(process.env[AgentHostClaudeAgentEnabledEnvVar], true) && agentSdkDownloader.isAvailable(ClaudeSdkPackage)) {
+		//  2. The SDK being reachable. Claude is a devDependency of this repo
+		//     so the bare-import path in `ClaudeAgentSdkService._loadSdk`
+		//     always succeeds in dev; in built/shipped server installs the
+		//     SDK comes from the CLI flag / env var dev override or a
+		//     `product.agentSdks.claude` entry. Codex still requires the
+		//     env-var override or product config.
+		if (isAgentEnabled(process.env[AgentHostClaudeAgentEnabledEnvVar], true) && (!environmentService.isBuilt || agentSdkDownloader.isAvailable(ClaudeSdkPackage))) {
 			const claudeAgent = disposables.add(instantiationService.createInstance(ClaudeAgent));
 			agentService.registerProvider(claudeAgent);
 			log('ClaudeAgent registered');

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts
@@ -194,23 +194,28 @@ export class ClaudeAgentSdkService implements IClaudeAgentSdkService {
 			return import(pathToFileURL(entry).href);
 		}
 
-		// 2. Production path: downloader resolves from cache or fetches the
-		//    per-host tarball described by `product.agentSdks.claude`. In a
-		//    built/shipped VS Code this succeeds; in dev there's no product
-		//    config and it throws cleanly without any I/O.
-		try {
+		// 2. Built products: load via the downloader (cache → fetch the
+		//    per-host tarball described by `product.agentSdks.claude`). Errors
+		//    from this path propagate as-is so users see actionable diagnostics
+		//    on a CDN outage / corrupt cache / etc., not a misleading
+		//    "cannot find module" from a fallback that would never succeed in
+		//    a shipped build anyway.
+		//
+		//    We use `isAvailable` (env var || product config) — already false
+		//    in dev — to discriminate without injecting `INativeEnvironmentService`
+		//    here. The env-var branch above already returned, so reaching this
+		//    point with `isAvailable === true` means product config is present
+		//    and the downloader is the correct path.
+		if (this._downloader.isAvailable(ClaudeSdkPackage)) {
 			const root = await this._downloader.loadSdkRoot(ClaudeSdkPackage, CancellationToken.None);
 			const entry = join(root, 'node_modules', '@anthropic-ai', 'claude-agent-sdk', 'sdk.mjs');
-			return await import(pathToFileURL(entry).href);
-		} catch {
-			// Fall through to the dev fallback.
+			return import(pathToFileURL(entry).href);
 		}
 
-		// 3. Dev fallback: bare import resolves via this repo's `node_modules`
-		//    where `@anthropic-ai/claude-agent-sdk` is a devDependency. Built
-		//    products don't bundle the SDK, so this path is dev-only — if it
-		//    fails here, the original downloader error from step 2 was the
-		//    real problem and the import error here will be the message.
+		// 3. Dev: bare import resolves via this repo's `node_modules` where
+		//    `@anthropic-ai/claude-agent-sdk` is a devDependency. Only reached
+		//    when neither the env var nor product config supplied a path —
+		//    i.e. exclusively in dev launches.
 		return import('@anthropic-ai/claude-agent-sdk');
 	}
 }

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts
@@ -194,23 +194,24 @@ export class ClaudeAgentSdkService implements IClaudeAgentSdkService {
 			return import(pathToFileURL(entry).href);
 		}
 
-		// 2. Bare import — succeeds in dev where the SDK is a devDependency in
-		//    the repo's `node_modules`. Fails in built products (the SDK is
-		//    NOT bundled — it's distributed via `product.agentSdks.claude` and
-		//    fetched on demand by the downloader). We swallow the failure and
-		//    fall through to the downloader path so built products still work.
+		// 2. Production path: downloader resolves from cache or fetches the
+		//    per-host tarball described by `product.agentSdks.claude`. In a
+		//    built/shipped VS Code this succeeds; in dev there's no product
+		//    config and it throws cleanly without any I/O.
 		try {
-			return await import('@anthropic-ai/claude-agent-sdk');
+			const root = await this._downloader.loadSdkRoot(ClaudeSdkPackage, CancellationToken.None);
+			const entry = join(root, 'node_modules', '@anthropic-ai', 'claude-agent-sdk', 'sdk.mjs');
+			return await import(pathToFileURL(entry).href);
 		} catch {
-			// Fall through.
+			// Fall through to the dev fallback.
 		}
 
-		// 3. Downloader: resolves from cache or fetches the per-host tarball
-		//    described by `product.agentSdks.claude`. This is the only path
-		//    that runs in built/shipped VS Code.
-		const root = await this._downloader.loadSdkRoot(ClaudeSdkPackage, CancellationToken.None);
-		const entry = join(root, 'node_modules', '@anthropic-ai', 'claude-agent-sdk', 'sdk.mjs');
-		return import(pathToFileURL(entry).href);
+		// 3. Dev fallback: bare import resolves via this repo's `node_modules`
+		//    where `@anthropic-ai/claude-agent-sdk` is a devDependency. Built
+		//    products don't bundle the SDK, so this path is dev-only — if it
+		//    fails here, the original downloader error from step 2 was the
+		//    real problem and the import error here will be the message.
+		return import('@anthropic-ai/claude-agent-sdk');
 	}
 }
 

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSdkService.ts
@@ -185,10 +185,29 @@ export class ClaudeAgentSdkService implements IClaudeAgentSdkService {
 	}
 
 	protected async _loadSdk(): Promise<IClaudeSdkBindings> {
-		// Resolve the SDK root via the downloader: dev override → cache →
-		// download from `product.agentSdks.claude`. The known internal
-		// `sdk.mjs` entrypoint is hard-coded here because this file is the
-		// one place that owns knowledge of the Claude SDK's import surface.
+		// 1. Env-var override wins — both for the air-gapped server case
+		//    (`--claude-sdk-root` flag) and for developers who want to point
+		//    at an out-of-tree SDK build without touching `node_modules`.
+		const override = process.env[AgentHostClaudeSdkRootEnvVar];
+		if (override) {
+			const entry = join(override, 'node_modules', '@anthropic-ai', 'claude-agent-sdk', 'sdk.mjs');
+			return import(pathToFileURL(entry).href);
+		}
+
+		// 2. Bare import — succeeds in dev where the SDK is a devDependency in
+		//    the repo's `node_modules`. Fails in built products (the SDK is
+		//    NOT bundled — it's distributed via `product.agentSdks.claude` and
+		//    fetched on demand by the downloader). We swallow the failure and
+		//    fall through to the downloader path so built products still work.
+		try {
+			return await import('@anthropic-ai/claude-agent-sdk');
+		} catch {
+			// Fall through.
+		}
+
+		// 3. Downloader: resolves from cache or fetches the per-host tarball
+		//    described by `product.agentSdks.claude`. This is the only path
+		//    that runs in built/shipped VS Code.
 		const root = await this._downloader.loadSdkRoot(ClaudeSdkPackage, CancellationToken.None);
 		const entry = join(root, 'node_modules', '@anthropic-ai', 'claude-agent-sdk', 'sdk.mjs');
 		return import(pathToFileURL(entry).href);

--- a/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
@@ -13,7 +13,7 @@ import { parseAgentHostDebugPort } from '../../environment/node/environmentServi
 import { ILogService } from '../../log/common/log.js';
 import { getResolvedShellEnv } from '../../shell/node/shellEnv.js';
 import { IAgentHostConnection, IAgentHostStarter } from '../common/agent.js';
-import { AgentHostClaudeAgentEnabledSettingId, AgentHostClaudeAgentSdkRootSettingId, AgentHostCodexAgentBinaryArgsSettingId, AgentHostCodexAgentEnabledSettingId, AgentHostCodexAgentSdkRootSettingId, AgentHostCodexAgentCodexHomeSettingId, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, buildAgentHostOTelEnv, buildAgentSdkEnv } from '../common/agentService.js';
+import { AgentHostClaudeAgentEnabledSettingId, AgentHostCodexAgentBinaryArgsSettingId, AgentHostCodexAgentEnabledSettingId, AgentHostCodexAgentSdkRootSettingId, AgentHostCodexAgentCodexHomeSettingId, AgentHostOTelCaptureContentSettingId, AgentHostOTelDbSpanExporterEnabledSettingId, AgentHostOTelEnabledSettingId, AgentHostOTelExporterTypeSettingId, AgentHostOTelOtlpEndpointSettingId, AgentHostOTelOutfileSettingId, buildAgentHostOTelEnv, buildAgentSdkEnv } from '../common/agentService.js';
 import '../common/agentHostStarter.config.contribution.js';
 
 /**
@@ -78,7 +78,6 @@ export class NodeAgentHostStarter extends Disposable implements IAgentHostStarte
 		// workbench settings to the agent host process. Parent env wins on
 		// collision — see `buildAgentSdkEnv` for the precedence rule.
 		const sdkEnv = buildAgentSdkEnv({
-			claudeSdkRoot: this._configurationService.getValue<string>(AgentHostClaudeAgentSdkRootSettingId),
 			codexSdkRoot: this._configurationService.getValue<string>(AgentHostCodexAgentSdkRootSettingId),
 			codexHome: this._configurationService.getValue<string>(AgentHostCodexAgentCodexHomeSettingId),
 			codexBinaryArgs: this._configurationService.getValue<readonly string[]>(AgentHostCodexAgentBinaryArgsSettingId),


### PR DESCRIPTION
> Stacks on top of #321155. Will rebase to `main` once that lands.

## Summary

The `chat.agentHost.claudeAgent.sdkRoot` setting was a dev-only knob (`included: product.quality !== 'stable'`) that pointed at a directory containing `node_modules/@anthropic-ai/claude-agent-sdk`. But the SDK is already a devDependency of this repo — so in dev, the path the setting pointed at was almost always this repo's own `node_modules`, which is exactly what `import('@anthropic-ai/claude-agent-sdk')` would resolve via Node module resolution. The setting was doing nothing the bare import couldn't do.

This PR removes the setting and rewrites `ClaudeAgentSdkService._loadSdk` to try three sources in order:

1. **`VSCODE_AGENT_HOST_CLAUDE_SDK_ROOT` env var** — escape hatch. Still honored when set externally; the `--claude-sdk-root` CLI flag on `agentHostServerMain` (used by air-gapped server deployments) continues to map to it.
2. **Bare `import('@anthropic-ai/claude-agent-sdk')`** — succeeds in dev where the SDK is a devDependency. New.
3. **`agentSdkDownloader.loadSdkRoot(ClaudeSdkPackage, ...)`** — the production path. Fetches the per-host tarball described by `product.agentSdks.claude`.

If the env var is set it wins. Otherwise the bare import is tried; if it fails (built products don't bundle the SDK), the downloader runs. No `isBuilt` branch in `_loadSdk` — just try/catch, which means no new constructor dependency and no test-helper churn.

## Registration gate update

`agentHostMain.ts` and `agentHostServerMain.ts` previously gated Claude registration on `agentSdkDownloader.isAvailable(ClaudeSdkPackage)`, which returns false in dev (no env var override and no product config). Both files updated to also register in dev (`!environmentService.isBuilt`) since the bare-import path is always reachable there:

```ts
isAgentEnabled(...) && (!environmentService.isBuilt || agentSdkDownloader.isAvailable(ClaudeSdkPackage))
```

Codex untouched — it has no equivalent dev-resolvable path yet (its SDK shape is a native binary, not a Node module).

## Test plan

- [x] `compile-check-ts-native` clean
- [x] All existing `claudeAgent` tests pass (125 / 125) — `_loadSdk` is still `protected`, the test subclasses that override it work unchanged
- [x] All existing `agentService` tests pass (20 / 20) including the `isAgentEnabled` table-driven suite from #321155
- [x] **Manual verification**: launched a clean dev build (`launch.sh --agents`) with `settings.json` containing only `chat.agentHost.enabled: true` (no `claudeAgent.*` keys at all) and no `VSCODE_AGENT_HOST_CLAUDE_SDK_ROOT` env var. Agent host log shows `Registering agent provider: claude` followed by `[Claude] Models refreshed. Count: 3` once a Claude session is created — confirming the bare import resolves and the SDK actually loads at runtime, not just at registration time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)