### PR TITLE
AHP filesystem: make resolved files writable and add realpath capability

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostFileSystemProvider.ts
+++ b/src/vs/platform/agentHost/common/agentHostFileSystemProvider.ts
@@ -8,7 +8,7 @@ import { disposableTimeout } from '../../../base/common/async.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { URI } from '../../../base/common/uri.js';
-import { createFileSystemProviderError, FileChangeType, FilePermission, FileSystemProviderCapabilities, FileSystemProviderErrorCode, FileType, IFileChange, IFileDeleteOptions, IFileOverwriteOptions, IFileSystemProvider, IFileWriteOptions, IStat, IWatchOptions } from '../../files/common/files.js';
+import { createFileSystemProviderError, FileChangeType, FilePermission, FileSystemProviderCapabilities, FileSystemProviderErrorCode, FileType, IFileChange, IFileDeleteOptions, IFileOverwriteOptions, IFileSystemProvider, IFileSystemProviderWithFileRealpathCapability, IFileWriteOptions, IStat, IWatchOptions } from '../../files/common/files.js';
 import { fromAgentHostUri, toAgentHostUri } from './agentHostUri.js';
 import { ContentEncoding, type CreateResourceWatchParams, type DirectoryEntry, type ResourceCopyParams, type ResourceCopyResult, type ResourceDeleteParams, type ResourceDeleteResult, type ResourceListResult, type ResourceMkdirParams, type ResourceMkdirResult, type ResourceMoveParams, type ResourceMoveResult, type ResourceReadResult, type ResourceRequestParams, type ResourceRequestResult, type ResourceResolveParams, type ResourceResolveResult, type ResourceWriteParams, type ResourceWriteResult } from './state/protocol/commands.js';
 import { AhpErrorCodes } from './state/protocol/errors.js';
@@ -165,12 +165,13 @@ interface IAuthorityEntry {
  *
  * Individual connections are identified by the URI's authority component.
  */
-export abstract class AHPFileSystemProvider extends Disposable implements IFileSystemProvider {
+export abstract class AHPFileSystemProvider extends Disposable implements IFileSystemProvider, IFileSystemProviderWithFileRealpathCapability {
 
 	readonly capabilities =
 		FileSystemProviderCapabilities.PathCaseSensitive |
 		FileSystemProviderCapabilities.FileReadWrite |
-		FileSystemProviderCapabilities.FileFolderCopy;
+		FileSystemProviderCapabilities.FileFolderCopy |
+		FileSystemProviderCapabilities.FileRealpath;
 
 	private readonly _onDidChangeCapabilities = this._register(new Emitter<void>());
 	readonly onDidChangeCapabilities = this._onDidChangeCapabilities.event;
@@ -401,7 +402,8 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 
 		const connection = await this._getConnection(resource.authority);
 		try {
-			const resolved = await connection.resourceResolve({ channel: ROOT_STATE_URI, uri: decoded.toString() });
+			const resolved = await this._resolve(connection, decoded);
+
 			return {
 				type: resolved.type === 'directory' ? FileType.Directory
 					: resolved.type === 'symlink' ? FileType.SymbolicLink
@@ -409,8 +411,30 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 				mtime: resolved.mtime ? Date.parse(resolved.mtime) : 0,
 				ctime: resolved.ctime ? Date.parse(resolved.ctime) : 0,
 				size: resolved.size ?? 0,
-				permissions: FilePermission.Readonly,
 			};
+		} catch (err) {
+			throw this._mapError(err, FileSystemProviderErrorCode.FileNotFound);
+		}
+	}
+
+	async realpath(resource: URI): Promise<string> {
+		const path = resource.path;
+		// Synthetic roots and virtual content schemes have no distinct
+		// canonical path — return the input path unchanged.
+		if (path === '/' || path === '') {
+			return path;
+		}
+		const decoded = this._decodeUri(resource);
+		if (decoded.scheme === 'session-db' || decoded.scheme === 'git-blob' || decoded.path === '/' || decoded.path === '') {
+			return path;
+		}
+		const connection = await this._getConnection(resource.authority);
+		try {
+			const resolved = await this._resolve(connection, decoded);
+			// `resolved.uri` is the remote canonical (realpath) URI. Re-encode
+			// it back into provider space; the file service applies the
+			// returned path onto the original provider URI.
+			return this._encodeUri(URI.parse(resolved.uri), resource.authority).path;
 		} catch (err) {
 			throw this._mapError(err, FileSystemProviderErrorCode.FileNotFound);
 		}
@@ -583,6 +607,14 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 			err instanceof Error ? err.message : String(err),
 			defaultCode,
 		);
+	}
+
+	/**
+	 * Resolve a decoded resource over {@link connection}. Shared by
+	 * {@link stat} and {@link realpath}.
+	 */
+	private _resolve(connection: IRemoteFilesystemConnection, decoded: URI): Promise<ResourceResolveResult> {
+		return connection.resourceResolve({ channel: ROOT_STATE_URI, uri: decoded.toString() });
 	}
 
 	private async _listDirectory(authority: string, resource: URI): Promise<readonly DirectoryEntry[]> {

--- a/src/vs/platform/agentHost/test/common/agentHostFileSystemProvider.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentHostFileSystemProvider.test.ts
@@ -677,6 +677,32 @@ suite('AgentHostFileSystemProvider - resolve / mkdir / copy / watch', () => {
 		assert.strictEqual(connection.resolveCalls.length, 1, 'resourceResolve was called');
 	});
 
+	test('stat does not mark resolved files readonly so they remain editable', async () => {
+		const { provider, connection } = setup();
+		connection.nextResolveResult = { uri: '', type: ResourceType.File, size: 10, mtime: '2026-01-15T00:00:00.000Z' };
+		const wrapped = agentHostUri('remote', '/some/file.ts');
+
+		const stat = await provider.stat(wrapped);
+
+		assert.strictEqual(stat.permissions ?? 0, 0, 'resolved files must not carry the Readonly permission');
+	});
+
+	test('realpath re-encodes the connection canonical URI back into provider space', async () => {
+		const { provider, connection } = setup();
+		// Simulate a symlink: the resolve reports a canonical target that
+		// differs from the requested path.
+		connection.resourceResolve = async (params: ResourceResolveParams): Promise<ResourceResolveResult> => {
+			connection.resolveCalls.push(params);
+			return { uri: 'file:///real/target.ts', type: ResourceType.File };
+		};
+		const wrapped = agentHostUri('remote', '/link/source.ts');
+
+		const real = await provider.realpath(wrapped);
+
+		assert.strictEqual(real, agentHostUri('remote', '/real/target.ts').path);
+		assert.strictEqual(connection.resolveCalls.length, 1);
+	});
+
 	test('mkdir delegates to resourceMkdir', async () => {
 		const { provider, connection } = setup();
 		const wrapped = agentHostUri('remote', '/new/dir');


### PR DESCRIPTION
## Summary

The `AHPFileSystemProvider` advertises `FileReadWrite` and implements `writeFile`, but every resolved resource was stamped with `FilePermission.Readonly` in `stat()` — so real files opened read-only and editors refused edits.

### Changes
- **Fix read-only files**: drop the spurious `FilePermission.Readonly` from real resources resolved via `resourceResolve`. It's kept only for genuinely read-only cases (the synthetic root and the virtual `session-db` / `git-blob` schemes).
- **Add `FileRealpath` capability**: the AHP `resourceResolve` already returns the canonical (symlink-resolved) URI, so the provider now advertises `FileSystemProviderCapabilities.FileRealpath`, implements `IFileSystemProviderWithFileRealpathCapability`, and exposes `realpath()` which re-encodes the canonical URI back into provider space. A small `_resolve()` helper is shared by `stat` and `realpath`.

### Notes on etags
Etag-based optimistic concurrency is intentionally **not** wired into the provider: the file service performs its own dirty-write prevention (mtime/size-derived etag) and never forwards an etag to `provider.writeFile`, so there is no stateless token for the provider to replay.

## Testing
Added two unit tests (resolved files are not read-only; `realpath` canonicalization). All 30 tests in the suite pass.