### PR TITLE
chat: hide model marketplace button in Agents window

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget.ts
@@ -1195,13 +1195,14 @@ export class ChatModelsWidget extends Disposable {
 		// The marketplace button is hidden in the Agents window where installing
 		// model provider extensions is not supported.
 		if (!this.environmentService.isSessionsWindow) {
-			this.browseMarketplaceButton = this._register(new Button(this.addButtonContainer, {
+			const browseMarketplaceButton = this._register(new Button(this.addButtonContainer, {
 				...buttonOptions,
 				secondary: true,
 			}));
-			this.browseMarketplaceButton.label = `$(${Codicon.extensions.id}) ${localize('models.installProviderExtensions', "Install Model Providers")}`;
-			this.browseMarketplaceButton.element.classList.add('models-browse-marketplace-button');
-			this._register(this.browseMarketplaceButton.onDidClick(() => this.openLanguageModelProviderExtensionsSearch()));
+			browseMarketplaceButton.label = `$(${Codicon.extensions.id}) ${localize('models.installProviderExtensions', "Install Model Providers")}`;
+			browseMarketplaceButton.element.classList.add('models-browse-marketplace-button');
+			this._register(browseMarketplaceButton.onDidClick(() => this.openLanguageModelProviderExtensionsSearch()));
+			this.browseMarketplaceButton = browseMarketplaceButton;
 		}
 
 		// Table container

--- a/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget.ts
@@ -43,6 +43,7 @@ import { CONTEXT_MODELS_SEARCH_FOCUS } from '../../common/constants.js';
 import { IExtensionsWorkbenchService } from '../../../extensions/common/extensions.js';
 import { LANGUAGE_MODEL_CHAT_PROVIDER_EXTENSION_TAG } from '../../../../../platform/extensionManagement/common/extensionManagement.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
+import { IWorkbenchEnvironmentService } from '../../../../services/environment/common/environmentService.js';
 import Severity from '../../../../../base/common/severity.js';
 import { IJSONSchema } from '../../../../../base/common/jsonSchema.js';
 import { formatTokenCount } from '../../../../../base/common/numbers.js';
@@ -1050,7 +1051,7 @@ export class ChatModelsWidget extends Disposable {
 	private tableMinWidth: number = 0;
 	private addButtonContainer!: HTMLElement;
 	private addButton!: Button;
-	private browseMarketplaceButton!: Button;
+	private browseMarketplaceButton: Button | undefined;
 	private dropdownActions: IAction[] = [];
 	private viewModel: ChatModelsViewModel;
 	private delayedFiltering: Delayer<void>;
@@ -1071,6 +1072,7 @@ export class ChatModelsWidget extends Disposable {
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IDialogService private readonly dialogService: IDialogService,
 		@IExtensionsWorkbenchService private readonly extensionsWorkbenchService: IExtensionsWorkbenchService,
+		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
 	) {
 		super();
 
@@ -1190,13 +1192,17 @@ export class ChatModelsWidget extends Disposable {
 			}
 		}));
 
-		this.browseMarketplaceButton = this._register(new Button(this.addButtonContainer, {
-			...buttonOptions,
-			secondary: true,
-		}));
-		this.browseMarketplaceButton.label = `$(${Codicon.extensions.id}) ${localize('models.installProviderExtensions', "Install Model Providers")}`;
-		this.browseMarketplaceButton.element.classList.add('models-browse-marketplace-button');
-		this._register(this.browseMarketplaceButton.onDidClick(() => this.openLanguageModelProviderExtensionsSearch()));
+		// The marketplace button is hidden in the Agents window where installing
+		// model provider extensions is not supported.
+		if (!this.environmentService.isSessionsWindow) {
+			this.browseMarketplaceButton = this._register(new Button(this.addButtonContainer, {
+				...buttonOptions,
+				secondary: true,
+			}));
+			this.browseMarketplaceButton.label = `$(${Codicon.extensions.id}) ${localize('models.installProviderExtensions', "Install Model Providers")}`;
+			this.browseMarketplaceButton.element.classList.add('models-browse-marketplace-button');
+			this._register(this.browseMarketplaceButton.onDidClick(() => this.openLanguageModelProviderExtensionsSearch()));
+		}
 
 		// Table container
 		this.tableContainer = DOM.append(container, $('.models-table-container'));

--- a/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget.ts
@@ -1051,7 +1051,6 @@ export class ChatModelsWidget extends Disposable {
 	private tableMinWidth: number = 0;
 	private addButtonContainer!: HTMLElement;
 	private addButton!: Button;
-	private browseMarketplaceButton: Button | undefined;
 	private dropdownActions: IAction[] = [];
 	private viewModel: ChatModelsViewModel;
 	private delayedFiltering: Delayer<void>;
@@ -1202,7 +1201,6 @@ export class ChatModelsWidget extends Disposable {
 			browseMarketplaceButton.label = `$(${Codicon.extensions.id}) ${localize('models.installProviderExtensions', "Install Model Providers")}`;
 			browseMarketplaceButton.element.classList.add('models-browse-marketplace-button');
 			this._register(browseMarketplaceButton.onDidClick(() => this.openLanguageModelProviderExtensionsSearch()));
-			this.browseMarketplaceButton = browseMarketplaceButton;
 		}
 
 		// Table container


### PR DESCRIPTION
## What

Hides the "Install Model Providers" marketplace button in the chat models management widget when running in the Agents window.

## Why

The button (added in #318840) opens the extension marketplace via `IExtensionsWorkbenchService.openSearch`, which is not supported in the Agents window. Its creation is now gated on `IWorkbenchEnvironmentService.isSessionsWindow` so it only appears in the regular workbench.

## Notes

- The "Add Models" button is unaffected.
- `browseMarketplaceButton` is now optional and only constructed (and registered) outside the Agents window.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>