### PR TITLE
Chat: extract <summary> from foreground history compaction response

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -650,8 +650,14 @@ class ConversationHistorySummarizer {
 
 		const summary = await summaryPromise;
 		const { numRounds, numRoundsSinceLastSummarization } = computeSummarizationRoundCounts(this.props.promptContext.history, this.props.promptContext.toolCallRounds);
+		// The summarization prompt asks the model to reason inside <analysis>
+		// tags and wrap the final summary in <summary> tags. The background
+		// paths (agentIntent.ts) already extract the summary; without doing
+		// the same here the raw response — analysis block and tags included —
+		// is stored on the round and rendered verbatim in the chat.
+		const summaryText = extractSummary(summary.result.value) ?? summary.result.value;
 		return {
-			summary: this.appendTranscriptHint(summary.result.value),
+			summary: this.appendTranscriptHint(summaryText),
 			toolCallRoundId: propsInfo.summarizedToolCallRoundId,
 			thinking: propsInfo.summarizedThinking,
 			usage: summary.result.usage,


### PR DESCRIPTION
Fixes #321200

## Problem

When the **foreground** history compaction runs, the raw model response — the full `<analysis>...</analysis>` reasoning block, the `<summary>` wrapper tags and all — is stored on the tool call round and rendered verbatim in the chat.

The summarization prompt (`ConversationHistorySummarizationPrompt`) explicitly instructs the model to wrap its reasoning in `<analysis>` tags and the final summary in `<summary></summary>` tags. The model follows the format; the client never strips it on this path.

## Fix

`ConversationHistorySummarizer.summarizeHistory()` now applies the existing `extractSummary()` helper (same file) to the response before appending the transcript hint — mirroring what both background compaction paths in `agentIntent.ts` already do (`extractSummary` at the `Background summarization` call sites). Falls back to the raw text when the model ignored the format, since `extractSummary` returns `undefined` in that case and failing the whole compaction over formatting would be worse.

## Notes

- `extractSummary` is already covered by the `extractSummary` suite in `summarization.spec.tsx` (clean tags, missing close tag, no tags, nested `<analysis>` inside `<summary>`).
- Observed in the wild on long agent sessions (~145k tokens context) where compaction triggered with `summarizationMode: "full"`; the stored summary began with `<analysis>` and contained the literal `<summary>` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
