### PR TITLE
Surface agent host MCP server logs and add Show Output command

### DIFF
--- a/src/vs/platform/agentHost/common/otlp/otlpLogEmitter.ts
+++ b/src/vs/platform/agentHost/common/otlp/otlpLogEmitter.ts
@@ -5,7 +5,7 @@
 
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { AbstractMessageLogger, LogLevel } from '../../../log/common/log.js';
+import { AbstractMessageLogger, format, LogLevel } from '../../../log/common/log.js';
 
 /**
  * Channel URI template advertised by an agent host that has an
@@ -104,6 +104,33 @@ export function severityNumberToLogLevel(severityNumber: number): LogLevel {
 }
 
 /**
+ * Scalar value types accepted for a structured log attribute. Mirrors the
+ * subset of OTLP `AnyValue` we serialise on the wire
+ * (`stringValue`/`intValue`/`doubleValue`/`boolValue`).
+ */
+export type OtelAttributeValue = string | number | boolean;
+
+/**
+ * Structured metadata a log call can carry alongside its human-readable
+ * message. Pass an instance as the final argument to any `ILogger` method
+ * (e.g. `logService.info('MCP server started', new OtelData({ server: 'github' }))`).
+ *
+ * - For the regular file logger the value is rendered via {@link toJSON}
+ *   using the usual log formatting (`JSON.stringify`), so it appears as a
+ *   compact object after the message.
+ * - For the {@link OtlpEmitterLogger} the attributes are lifted out of the
+ *   message and emitted as spec-conformant OTLP `LogRecord.attributes`,
+ *   keeping the body free of serialised JSON.
+ */
+export class OtelData {
+	constructor(readonly attributes: Readonly<Record<string, OtelAttributeValue>>) { }
+
+	toJSON(): Readonly<Record<string, OtelAttributeValue>> {
+		return this.attributes;
+	}
+}
+
+/**
  * A single log record produced by an {@link OtlpEmitterLogger}. The shape
  * mirrors the relevant fields from the OTLP/JSON `LogRecord` spec but is
  * kept intentionally small — only what we need to populate a
@@ -126,6 +153,12 @@ export interface IOtlpLogRecord {
 	 * `body: { stringValue }`.
 	 */
 	readonly body: string;
+	/**
+	 * Optional structured metadata carried by an {@link OtelData} argument
+	 * on the originating log call. Serialised to OTLP `LogRecord.attributes`
+	 * and absent when the call had no {@link OtelData}.
+	 */
+	readonly attributes?: Readonly<Record<string, OtelAttributeValue>>;
 }
 
 /**
@@ -165,16 +198,65 @@ export class OtlpEmitterLogger extends AbstractMessageLogger {
 		this.setLevel(initialLevel);
 	}
 
+	override trace(message: string, ...args: unknown[]): void {
+		if (this.canLog(LogLevel.Trace)) {
+			this._emit(LogLevel.Trace, message, args, true);
+		}
+	}
+
+	override debug(message: string, ...args: unknown[]): void {
+		if (this.canLog(LogLevel.Debug)) {
+			this._emit(LogLevel.Debug, message, args);
+		}
+	}
+
+	override info(message: string, ...args: unknown[]): void {
+		if (this.canLog(LogLevel.Info)) {
+			this._emit(LogLevel.Info, message, args);
+		}
+	}
+
+	override warn(message: string, ...args: unknown[]): void {
+		if (this.canLog(LogLevel.Warning)) {
+			this._emit(LogLevel.Warning, message, args);
+		}
+	}
+
+	override error(message: string | Error, ...args: unknown[]): void {
+		if (this.canLog(LogLevel.Error)) {
+			const head = message instanceof Error ? message.stack ?? message.message : message;
+			this._emit(LogLevel.Error, head, args);
+		}
+	}
+
 	protected override log(level: LogLevel, message: string): void {
 		if (level === LogLevel.Off) {
 			return;
+		}
+		this._emit(level, message, []);
+	}
+
+	/**
+	 * Formats `message` + `args` into the OTLP record body, lifting any
+	 * {@link OtelData} argument out into structured `attributes` so the
+	 * metadata is emitted over the channel rather than serialised into the
+	 * body. Mirrors the formatting the base `AbstractMessageLogger` would
+	 * apply (including the verbose flag for `trace`).
+	 */
+	private _emit(level: LogLevel, message: string, args: unknown[], verbose = false): void {
+		let attributes: Readonly<Record<string, OtelAttributeValue>> | undefined;
+		const index = args.findIndex(arg => arg instanceof OtelData);
+		if (index !== -1) {
+			attributes = (args[index] as OtelData).attributes;
+			args = args.slice(0, index).concat(args.slice(index + 1));
 		}
 		const { severityNumber, severityText } = logLevelToOtlpSeverity(level);
 		this._emitter.emit({
 			timeUnixNano: msToUnixNano(Date.now()),
 			severityNumber,
 			severityText,
-			body: message,
+			body: format([message, ...args], verbose),
+			...(attributes ? { attributes } : undefined),
 		});
 	}
 }
@@ -211,6 +293,7 @@ export function toResourceLogsPayloadBatch(records: readonly IOtlpLogRecord[]): 
 							severityNumber: r.severityNumber,
 							severityText: r.severityText,
 							body: { stringValue: r.body },
+							...(r.attributes ? { attributes: attributesToOtlp(r.attributes) } : undefined),
 						})),
 					},
 				],
@@ -275,7 +358,65 @@ function coerceLogRecord(raw: unknown): IOtlpLogRecord | undefined {
 		? r.timeUnixNano
 		: typeof r.observedTimeUnixNano === 'string' ? r.observedTimeUnixNano : '0';
 	const body = extractBody(r.body);
-	return { timeUnixNano, severityNumber, severityText, body };
+	const attributes = otlpToAttributes(r.attributes);
+	return attributes
+		? { timeUnixNano, severityNumber, severityText, body, attributes }
+		: { timeUnixNano, severityNumber, severityText, body };
+}
+
+/**
+ * Serialise a flat attribute map into the OTLP `KeyValue[]` shape, mapping
+ * each JS scalar onto the matching `AnyValue` variant.
+ */
+function attributesToOtlp(attributes: Readonly<Record<string, OtelAttributeValue>>): Array<{ key: string; value: Record<string, unknown> }> {
+	return Object.entries(attributes).map(([key, value]) => ({ key, value: toAnyValue(value) }));
+}
+
+function toAnyValue(value: OtelAttributeValue): Record<string, unknown> {
+	switch (typeof value) {
+		case 'boolean': return { boolValue: value };
+		case 'number': return Number.isInteger(value) ? { intValue: value } : { doubleValue: value };
+		default: return { stringValue: value };
+	}
+}
+
+/**
+ * Reverse of {@link attributesToOtlp}: decode an OTLP `KeyValue[]` back into
+ * a flat attribute map. Returns `undefined` when there are no usable
+ * attributes so callers can omit the field entirely.
+ */
+function otlpToAttributes(raw: unknown): Record<string, OtelAttributeValue> | undefined {
+	if (!Array.isArray(raw)) {
+		return undefined;
+	}
+	const result: Record<string, OtelAttributeValue> = {};
+	for (const entry of raw) {
+		if (!entry || typeof entry !== 'object') {
+			continue;
+		}
+		const key = (entry as { key?: unknown }).key;
+		if (typeof key !== 'string') {
+			continue;
+		}
+		const value = fromAnyValue((entry as { value?: unknown }).value);
+		if (value !== undefined) {
+			result[key] = value;
+		}
+	}
+	return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function fromAnyValue(value: unknown): OtelAttributeValue | undefined {
+	if (!value || typeof value !== 'object') {
+		return undefined;
+	}
+	const v = value as Record<string, unknown>;
+	if (typeof v.stringValue === 'string') { return v.stringValue; }
+	if (typeof v.boolValue === 'boolean') { return v.boolValue; }
+	if (typeof v.intValue === 'number') { return v.intValue; }
+	if (typeof v.intValue === 'string') { return Number(v.intValue); }
+	if (typeof v.doubleValue === 'number') { return v.doubleValue; }
+	return undefined;
 }
 
 function severityNameFromNumber(n: number): OtlpLogLevelName {

--- a/src/vs/platform/agentHost/common/remoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/common/remoteAgentHostService.ts
@@ -190,6 +190,13 @@ export function remoteAgentHostLogOutputChannelId(address: string): string {
 	return `agentHost.otlp.${address}`;
 }
 
+/**
+ * Output channel id for the local agent host process logger (forwarded
+ * from the utility process via `RemoteLoggerChannelClient`). Matches the
+ * logger id registered in `agentHostMain.ts`.
+ */
+export const AGENT_HOST_LOG_OUTPUT_CHANNEL_ID = 'agenthost';
+
 export const enum RemoteAgentHostInputValidationError {
 	Empty = 'empty',
 	Invalid = 'invalid',

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -27,6 +27,7 @@ import { AgentHostSandboxConfigKey, sandboxConfigSchema } from '../../common/san
 import { platformSessionSchema } from '../../common/agentHostSchema.js';
 import { AgentSignal, IMcpNotification } from '../../common/agentService.js';
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
+import { OtelData, type OtelAttributeValue } from '../../common/otlp/otlpLogEmitter.js';
 import type { LanguageModelToolInvokedClassification, LanguageModelToolInvokedEvent } from '../../../telemetry/common/languageModelToolTelemetry.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { ISessionDatabase, ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../../common/sessionDataService.js';
@@ -2482,7 +2483,15 @@ export class CopilotAgentSession extends Disposable {
 		}));
 
 		this._register(wrapper.onSessionInfo(e => {
-			this._logService.trace(`[Copilot:${sessionId}] Session info [${e.data.infoType}]: ${e.data.message}`);
+			const attributes: Record<string, OtelAttributeValue> = { infoType: e.data.infoType };
+			if (e.data.tip) {
+				attributes.tip = e.data.tip;
+			}
+			this._logService.info(`[Copilot:${sessionId}] [${e.data.infoType}]: ${e.data.message}`, new OtelData(attributes));
+		}));
+
+		this._register(wrapper.onSessionWarning(e => {
+			this._logService.warn(`[Copilot:${sessionId}] ${e.data.message}`, new OtelData({ warningType: e.data.warningType }));
 		}));
 
 		this._register(wrapper.onSessionModelChange(e => {

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionWrapper.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionWrapper.ts
@@ -68,6 +68,11 @@ export class CopilotSessionWrapper extends Disposable {
 		return this._onSessionInfo ??= this._sdkEvent('session.info');
 	}
 
+	private _onSessionWarning: Event<SessionEventPayload<'session.warning'>> | undefined;
+	get onSessionWarning(): Event<SessionEventPayload<'session.warning'>> {
+		return this._onSessionWarning ??= this._sdkEvent('session.warning');
+	}
+
 	private _onSessionModelChange: Event<SessionEventPayload<'session.model_change'>> | undefined;
 	get onSessionModelChange(): Event<SessionEventPayload<'session.model_change'>> {
 		return this._onSessionModelChange ??= this._sdkEvent('session.model_change');

--- a/src/vs/platform/agentHost/test/common/otlpLogEmitter.test.ts
+++ b/src/vs/platform/agentHost/test/common/otlpLogEmitter.test.ts
@@ -14,6 +14,7 @@ import {
 	levelToSeverityNumber,
 	logLevelToOtlpLevelName,
 	logLevelToOtlpSeverity,
+	OtelData,
 	OtlpEmitterLogger,
 	OtlpLogEmitter,
 	parseOtlpLogLevel,
@@ -125,6 +126,23 @@ suite('OtlpLogEmitter', () => {
 		const payload = toResourceLogsPayload(record);
 		const decoded = [...iterateOtlpLogRecords(payload)];
 		assert.deepStrictEqual(decoded, [record]);
+	});
+
+	test('OtelData attributes survive the OtlpEmitterLogger round-trip and stay out of the body', () => {
+		const emitter = disposables.add(new OtlpLogEmitter());
+		const logger = disposables.add(new OtlpEmitterLogger(emitter, LogLevel.Trace));
+		const received: IOtlpLogRecord[] = [];
+		disposables.add(emitter.onDidLog(record => received.push(record)));
+
+		logger.info('MCP server started', new OtelData({ infoType: 'mcp', attempt: 2, enabled: true }));
+		logger.warn('plain warning');
+
+		const roundTripped = received.map(r => [...iterateOtlpLogRecords(toResourceLogsPayload(r))][0]);
+		const sanitised = roundTripped.map(r => ({ severityText: r.severityText, body: r.body, attributes: r.attributes }));
+		assert.deepStrictEqual(sanitised, [
+			{ severityText: 'info', body: 'MCP server started', attributes: { infoType: 'mcp', attempt: 2, enabled: true } },
+			{ severityText: 'warn', body: 'plain warning', attributes: undefined },
+		]);
 	});
 
 	test('iterateOtlpLogRecords tolerates malformed shapes', () => {

--- a/src/vs/platform/log/common/log.ts
+++ b/src/vs/platform/log/common/log.ts
@@ -177,7 +177,7 @@ export function registerDevConsoleLogForwarder(logService: ILogService): IDispos
 	});
 }
 
-function format(args: any, verbose: boolean = false): string {
+export function format(args: any, verbose: boolean = false): string {
 	let result = '';
 
 	for (let i = 0; i < args.length; i++) {

--- a/src/vs/sessions/common/agentHostSessionsProvider.ts
+++ b/src/vs/sessions/common/agentHostSessionsProvider.ts
@@ -30,6 +30,7 @@ export interface IAgentHostMcpServer {
 	readonly name: string;
 	readonly enabled: boolean;
 	readonly status: McpServerStatus;
+	readonly logOutputChannelId?: string;
 	setEnabled(enabled: boolean): void;
 }
 

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -1061,6 +1061,9 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	abstract readonly icon: ThemeIcon;
 	abstract readonly browseActions: readonly ISessionWorkspaceBrowseAction[];
 
+	/** The workbench Output channel id carrying this host's agent host logs. */
+	protected abstract getLogOutputChannelId(): string | undefined;
+
 	get order(): number { return 0; }
 
 	get sessionTypes(): readonly ISessionType[] { return this._sessionTypes; }
@@ -1900,6 +1903,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			return [];
 		}
 		const sessionUri = AgentSession.uri(cached.agentProvider, rawId);
+		const logOutputChannelId = this.getLogOutputChannelId();
 		return (sessionState.customizations ?? [])
 			.flatMap(c => c.type === CustomizationType.McpServer
 				? [c]
@@ -1911,6 +1915,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 				name: c.name,
 				enabled: c.enabled,
 				status: c.state.kind,
+				logOutputChannelId,
 				setEnabled: (enabled: boolean) => {
 					const connection = this.connection;
 					if (!connection) {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
@@ -24,6 +24,7 @@ import { IChatService } from '../../../../../workbench/contrib/chat/common/chatS
 import { IChatSessionsService } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ILanguageModelsService } from '../../../../../workbench/contrib/chat/common/languageModels.js';
 import { LOCAL_AGENT_HOST_PROVIDER_ID, LocalAgentHostDefaultProviderSettingId } from '../../../../common/agentHostSessionsProvider.js';
+import { AGENT_HOST_LOG_OUTPUT_CHANNEL_ID } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { buildAgentHostSessionWorkspace, readBranchProtectionPatterns } from '../../../../common/agentHostSessionWorkspace.js';
 import { IGitHubInfo, ISessionWorkspace, ISessionWorkspaceBrowseAction, SESSION_WORKSPACE_GROUP_LOCAL } from '../../../../services/sessions/common/session.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
@@ -47,6 +48,10 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 	readonly icon: ThemeIcon = Codicon.vm;
 	readonly browseActions: readonly ISessionWorkspaceBrowseAction[];
 	readonly supportsLocalWorkspaces = true;
+
+	protected override getLogOutputChannelId(): string | undefined {
+		return AGENT_HOST_LOG_OUTPUT_CHANNEL_ID;
+	}
 
 	/**
 	 * When the experimental {@link LocalAgentHostDefaultProviderSettingId}

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostLogForwarder.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostLogForwarder.ts
@@ -287,7 +287,10 @@ function formatRecord(record: IOtlpLogRecord): string {
 	// from the OTLP nanosecond integer string.
 	const timestamp = formatTimestamp(record.timeUnixNano);
 	const severity = record.severityText.toUpperCase().padEnd(5);
-	return `[${timestamp}] [${severity}] ${record.body}`;
+	const attributes = record.attributes && Object.keys(record.attributes).length > 0
+		? ` ${JSON.stringify(record.attributes)}`
+		: '';
+	return `[${timestamp}] [${severity}] ${record.body}${attributes}`;
 }
 
 function formatTimestamp(timeUnixNano: string): string {

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -17,7 +17,7 @@ import { localize } from '../../../../../nls.js';
 import { agentHostUri } from '../../../../../platform/agentHost/common/agentHostFileSystemProvider.js';
 import { AGENT_HOST_SCHEME, agentHostAuthority, fromAgentHostUri, toAgentHostUri } from '../../../../../platform/agentHost/common/agentHostUri.js';
 import { AgentSession, type IAgentConnection, type IAgentSessionMetadata } from '../../../../../platform/agentHost/common/agentService.js';
-import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus, remoteAgentHostLogOutputChannelId } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import type { ISessionGitState } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
@@ -140,6 +140,10 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 	readonly browseActions: readonly ISessionWorkspaceBrowseAction[];
 	readonly canConnectOnDemand: boolean;
 	readonly onDidReportConnectProgress: Event<IAgentHostConnectProgress> | undefined;
+
+	protected override getLogOutputChannelId(): string | undefined {
+		return remoteAgentHostLogOutputChannelId(this.remoteAddress);
+	}
 
 	private readonly _connectionStatus = observableValue<RemoteAgentHostConnectionStatus>('connectionStatus', RemoteAgentHostConnectionStatus.disconnected);
 	readonly connectionStatus: IObservable<RemoteAgentHostConnectionStatus> = this._connectionStatus;

--- a/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction.ts
@@ -13,7 +13,7 @@ import { Categories } from '../../../../../platform/action/common/actionCommonCa
 import { Action2 } from '../../../../../platform/actions/common/actions.js';
 import { agentHostAuthority, toAgentHostUri } from '../../../../../platform/agentHost/common/agentHostUri.js';
 import { AgentHostEnabledSettingId, IAgentHostService } from '../../../../../platform/agentHost/common/agentService.js';
-import { IRemoteAgentHostConnectionInfo, IRemoteAgentHostService, remoteAgentHostLogOutputChannelId } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IRemoteAgentHostConnectionInfo, IRemoteAgentHostService, remoteAgentHostLogOutputChannelId, AGENT_HOST_LOG_OUTPUT_CHANNEL_ID } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IsWebContext } from '../../../../../platform/contextkey/common/contextkeys.js';
 import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
@@ -31,7 +31,7 @@ import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { buildLocalCopilotLogsUri, buildRemoteCopilotLogsUri, COPILOT_CLI_LOCAL_AH_SCHEME, getCopilotCliSessionRawId, parseRemoteAuthorityFromScheme, resolveEventsUri } from '../copilotCliEventsUri.js';
 
 /** Output channel ID for the agent host process logger (forwarded via RemoteLoggerChannelClient). */
-const AGENT_HOST_LOGGER_CHANNEL_ID = 'agenthost';
+const AGENT_HOST_LOGGER_CHANNEL_ID = AGENT_HOST_LOG_OUTPUT_CHANNEL_ID;
 /** Output channel ID for the current window's renderer log. */
 const WINDOW_LOG_CHANNEL_ID = 'rendererLog';
 /** Output channel ID for the shared process compound log. */

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService.ts
@@ -7,6 +7,8 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable, DisposableMap, IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { AgentSession, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
+import { agentHostAuthority } from '../../../../../../platform/agentHost/common/agentHostUri.js';
+import { AGENT_HOST_LOG_OUTPUT_CHANNEL_ID, IRemoteAgentHostService, remoteAgentHostLogOutputChannelId } from '../../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { getEffectiveAgents } from '../../../../../../platform/agentHost/common/customAgents.js';
 import { type IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
 import { ActionType } from '../../../../../../platform/agentHost/common/state/protocol/actions.js';
@@ -17,7 +19,7 @@ import { createDecorator } from '../../../../../../platform/instantiation/common
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { isUntitledChatSession } from '../../../common/model/chatUri.js';
 import { IAgentHostUntitledProvisionalSessionService } from './agentHostUntitledProvisionalSessionService.js';
-import { IAgentHostMcpServer } from '../../../../../../sessions/common/agentHostSessionsProvider.js';
+import { IAgentHostMcpServer, LOCAL_AGENT_HOST_PROVIDER_ID, REMOTE_AGENT_HOST_PROVIDER_PREFIX } from '../../../../../../sessions/common/agentHostSessionsProvider.js';
 
 const AGENT_HOST_SESSION_SCHEME_PREFIX = 'agent-host-';
 
@@ -36,10 +38,11 @@ export interface IAgentHostCustomizationService {
 
 	/**
 	 * Returns the MCP servers exposed by an agent-host session. Each entry
-	 * carries the current status and a {@link IAgentHostMcpServer.setEnabled}
+	 * carries the current status, a {@link IAgentHostMcpServer.setEnabled}
 	 * method that dispatches the protocol-level toggle on behalf of the
-	 * caller. Returns an empty array for sessions not backed by an agent
-	 * host, or that don't expose any MCP servers.
+	 * caller, and the {@link IAgentHostMcpServer.logOutputChannelId} of the
+	 * host backing the session. Returns an empty array for sessions not
+	 * backed by an agent host, or that don't expose any MCP servers.
 	 */
 	getMcpServers(sessionResource: URI): readonly IAgentHostMcpServer[];
 }
@@ -75,6 +78,7 @@ class WorkbenchAgentHostCustomizationService extends Disposable implements IAgen
 		@IAgentHostService private readonly _agentHostService: IAgentHostService,
 		@IAgentHostUntitledProvisionalSessionService private readonly _provisionalSessionService: IAgentHostUntitledProvisionalSessionService,
 		@IChatService chatService: IChatService,
+		@IRemoteAgentHostService private readonly _remoteAgentHostService: IRemoteAgentHostService,
 	) {
 		super();
 
@@ -131,6 +135,7 @@ class WorkbenchAgentHostCustomizationService extends Disposable implements IAgen
 		}
 		const customizations = this._readSessionState(sessionResource)?.customizations ?? [];
 		const channel = backendSession.toString();
+		const logOutputChannelId = this._resolveLogOutputChannelId(backendSession);
 		return customizations
 			.filter((c): c is McpServerCustomization => c.type === CustomizationType.McpServer)
 			.map((c): IAgentHostMcpServer => ({
@@ -138,6 +143,7 @@ class WorkbenchAgentHostCustomizationService extends Disposable implements IAgen
 				name: c.name,
 				enabled: c.enabled,
 				status: c.state.kind,
+				logOutputChannelId,
 				setEnabled: (enabled: boolean) => {
 					this._agentHostService.dispatch(channel, {
 						type: ActionType.SessionCustomizationToggled,
@@ -146,6 +152,19 @@ class WorkbenchAgentHostCustomizationService extends Disposable implements IAgen
 					});
 				},
 			}));
+	}
+
+	private _resolveLogOutputChannelId(backendSession: URI): string | undefined {
+		const providerId = AgentSession.provider(backendSession);
+		if (providerId === LOCAL_AGENT_HOST_PROVIDER_ID) {
+			return AGENT_HOST_LOG_OUTPUT_CHANNEL_ID;
+		}
+		if (providerId?.startsWith(REMOTE_AGENT_HOST_PROVIDER_PREFIX)) {
+			const authority = providerId.substring(REMOTE_AGENT_HOST_PROVIDER_PREFIX.length);
+			const connection = this._remoteAgentHostService.connections.find(c => agentHostAuthority(c.address) === authority);
+			return connection ? remoteAgentHostLogOutputChannelId(connection.address) : undefined;
+		}
+		return undefined;
 	}
 
 	private _readSessionState(sessionResource: URI): SessionState | undefined {

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -46,6 +46,7 @@ import { IAuthenticationService } from '../../../services/authentication/common/
 import { IAccountQuery, IAuthenticationQueryService } from '../../../services/authentication/common/authenticationQuery.js';
 import { MCP_CONFIGURATION_KEY, WORKSPACE_STANDALONE_CONFIGURATIONS } from '../../../services/configuration/common/configuration.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IOutputService } from '../../../services/output/common/output.js';
 import { IRemoteUserDataProfilesService } from '../../../services/userDataProfile/common/remoteUserDataProfiles.js';
 import { IUserDataProfileService } from '../../../services/userDataProfile/common/userDataProfile.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
@@ -302,13 +303,16 @@ export class McpAgentHostServerOptionsCommand extends Action2 {
 	override async run(accessor: ServicesAccessor, agentHostSession: URI, customizationId: string): Promise<void> {
 		const agentHostCustomizations = accessor.get(IAgentHostCustomizationService);
 		const quickInputService = accessor.get(IQuickInputService);
+		const outputService = accessor.get(IOutputService);
 
 		const server = agentHostCustomizations.getMcpServers(agentHostSession).find(s => s.id === customizationId);
 		if (!server) {
 			return;
 		}
 
-		type ItemType = { action: 'toggle' } & IQuickPickItem;
+		const logOutputChannelId = server.logOutputChannelId;
+
+		type ItemType = { action: 'toggle' | 'showOutput' } & IQuickPickItem;
 
 		const items: (ItemType | IQuickPickSeparator)[] = [
 			{ type: 'separator', label: localize('mcp.actions.status', 'Status') },
@@ -323,15 +327,31 @@ export class McpAgentHostServerOptionsCommand extends Action2 {
 			},
 		];
 
+		if (logOutputChannelId) {
+			items.push({
+				label: localize('mcp.showOutput', 'Show Output'),
+				action: 'showOutput',
+			});
+		}
+
 		const picked = await quickInputService.pick(items, {
 			placeHolder: server.name,
 		});
 
-		if (!picked || !hasKey(picked, { action: true }) || picked.action !== 'toggle') {
+		if (!picked || !hasKey(picked, { action: true })) {
 			return;
 		}
 
-		server.setEnabled(!server.enabled);
+		if (picked.action === 'showOutput') {
+			if (logOutputChannelId) {
+				outputService.showChannel(logOutputChannelId);
+			}
+			return;
+		}
+
+		if (picked.action === 'toggle') {
+			server.setEnabled(!server.enabled);
+		}
 	}
 }
 


### PR DESCRIPTION
Listen to session info/warning events from the Copilot SDK and surface MCP-category messages in the agent host log channel. Introduce a structured `OtelData` metadata type so consumers can attach attributes to log records that are serialized over OTLP and rendered via the standard log formatting.

Add a **Show Output** command to agent host MCP server details (mirroring normal MCP servers) that opens the host's log output channel. The channel id is now carried on `IAgentHostMcpServer` and resolved by each agent host sessions provider (local vs remote) via a protected `getLogOutputChannelId` hook, instead of adding a new method to `IAgentHostCustomizationService`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>