### PR TITLE
Remove retry action from out-of-credits chat errors

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuotaExceededPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuotaExceededPart.ts
@@ -16,25 +16,11 @@ import { localize } from '../../../../../../nls.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { defaultButtonStyles } from '../../../../../../platform/theme/browser/defaultStyles.js';
-import { asCssVariable, textLinkForeground } from '../../../../../../platform/theme/common/colorRegistry.js';
 import { ChatEntitlement, IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { IChatErrorDetailsPart, IChatRendererContent, IChatResponseViewModel } from '../../../common/model/chatViewModel.js';
-import { IChatWidgetService } from '../../chat.js';
 import { IChatContentPart } from './chatContentParts.js';
 
 const $ = dom.$;
-
-/**
- * Once the sign up button is clicked, and the retry
- * button has been shown, it should be shown every time.
- */
-let shouldShowRetryButton = false;
-
-/**
- * Once the 'retry' button is clicked, the wait warning
- * should be shown every time.
- */
-let shouldShowWaitWarning = false;
 
 export class ChatQuotaExceededPart extends Disposable implements IChatContentPart {
 
@@ -44,7 +30,6 @@ export class ChatQuotaExceededPart extends Disposable implements IChatContentPar
 		element: IChatResponseViewModel,
 		private readonly content: IChatErrorDetailsPart,
 		renderer: IMarkdownRenderer,
-		@IChatWidgetService chatWidgetService: IChatWidgetService,
 		@ICommandService commandService: ICommandService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IChatEntitlementService chatEntitlementService: IChatEntitlementService
@@ -80,43 +65,6 @@ export class ChatQuotaExceededPart extends Disposable implements IChatContentPar
 			}
 		}
 
-		let hasAddedWaitWarning = false;
-		const addWaitWarningIfNeeded = () => {
-			if (!shouldShowWaitWarning || hasAddedWaitWarning) {
-				return;
-			}
-
-			hasAddedWaitWarning = true;
-			dom.append(messageContainer, $('.chat-quota-wait-warning', undefined, localize('waitWarning', "Changes may take a few minutes to take effect.")));
-		};
-
-		let hasAddedRetryButton = false;
-		const addRetryButtonIfNeeded = () => {
-			if (!shouldShowRetryButton || hasAddedRetryButton) {
-				return;
-			}
-
-			hasAddedRetryButton = true;
-			const retryButton = this._register(new Button(messageContainer, {
-				buttonBackground: undefined,
-				buttonForeground: asCssVariable(textLinkForeground)
-			}));
-			retryButton.element.classList.add('chat-quota-error-secondary-button');
-			retryButton.label = localize('clickToContinue', "Click to Retry");
-
-			this._register(retryButton.onDidClick(() => {
-				const widget = chatWidgetService.getWidgetBySessionResource(element.sessionResource);
-				if (!widget) {
-					return;
-				}
-
-				widget.rerunLastRequest();
-
-				shouldShowWaitWarning = true;
-				addWaitWarningIfNeeded();
-			}));
-		};
-
 		if (primaryButtonLabel) {
 			const primaryButton = this._register(new Button(messageContainer, { ...defaultButtonStyles, supportIcons: true }));
 			primaryButton.label = primaryButtonLabel;
@@ -126,14 +74,8 @@ export class ChatQuotaExceededPart extends Disposable implements IChatContentPar
 				const commandId = chatEntitlementService.entitlement === ChatEntitlement.Free || isAdditionalSpendLimitReached ? 'workbench.action.chat.upgradePlan' : 'workbench.action.chat.manageAdditionalSpend';
 				telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id: commandId, from: 'chat-response' });
 				await commandService.executeCommand(commandId);
-
-				shouldShowRetryButton = true;
-				addRetryButtonIfNeeded();
 			}));
 		}
-
-		addRetryButtonIfNeeded();
-		addWaitWarningIfNeeded();
 	}
 
 	hasSameContent(other: IChatRendererContent): boolean {

--- a/src/vs/workbench/contrib/chat/test/browser/chatQuotaExceededPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatQuotaExceededPart.test.ts
@@ -16,7 +16,6 @@ import { ITelemetryService } from '../../../../../platform/telemetry/common/tele
 import { ChatEntitlement, IChatEntitlementService, IChatSentiment } from '../../../../services/chat/common/chatEntitlementService.js';
 import { IChatResponseErrorDetails } from '../../common/chatService/chatService.js';
 import { IChatErrorDetailsPart, IChatResponseViewModel } from '../../common/model/chatViewModel.js';
-import { IChatWidgetService } from '../../browser/chat.js';
 import { ChatQuotaExceededPart } from '../../browser/widget/chatContentParts/chatQuotaExceededPart.js';
 
 
@@ -86,7 +85,6 @@ suite('ChatQuotaExceededPart', () => {
 	function createWidget(entitlement: ChatEntitlement, errorDetails: IChatResponseErrorDetails): ChatQuotaExceededPart {
 		executedCommands = [];
 
-		const chatWidgetService = {} as IChatWidgetService;
 		const commandService = {
 			executeCommand(id: string) {
 				executedCommands.push(id);
@@ -106,7 +104,6 @@ suite('ChatQuotaExceededPart', () => {
 			element,
 			content,
 			renderer,
-			chatWidgetService,
 			commandService,
 			telemetryService,
 			entitlementService,
@@ -118,6 +115,10 @@ suite('ChatQuotaExceededPart', () => {
 
 	function getPrimaryButton(widget: ChatQuotaExceededPart): HTMLElement | null {
 		return widget.domNode.querySelector('.chat-quota-error-button');
+	}
+
+	function getRetryButton(widget: ChatQuotaExceededPart): HTMLElement | null {
+		return widget.domNode.querySelector('.chat-quota-error-secondary-button');
 	}
 
 	teardown(() => {
@@ -198,6 +199,7 @@ suite('ChatQuotaExceededPart', () => {
 			await new Promise(r => setTimeout(r, 0));
 
 			assert.strictEqual(executedCommands[0], 'workbench.action.chat.manageAdditionalSpend');
+			assert.strictEqual(getRetryButton(widget), null);
 		});
 
 		test('Free user clicks "Upgrade" -> upgradePlan', async () => {


### PR DESCRIPTION
Out-of-credits chat errors should not encourage immediate retries when the user has no remaining credits. This change removes the retry affordance from the quota-exceeded error UI so the message only offers budget/plan actions.

The quota error content part now renders only the primary action (Manage Budget or Upgrade) and no longer keeps global retry/wait-warning state or the chat widget dependency used to rerun the last request. The corresponding unit test was updated to assert that the retry button is absent.

## Testing
- Updated `ChatQuotaExceededPart` unit test coverage for the no-retry behavior.
- Local compile/test scripts could not be executed in this workspace because required dev dependencies are missing.