### PR TITLE
Fix surrounding a selection with brackets after arrow functions (#225916)

### DIFF
--- a/src/vs/editor/common/languages/autoIndent.ts
+++ b/src/vs/editor/common/languages/autoIndent.ts
@@ -407,7 +407,7 @@ export function getIndentActionForType(
 	}
 
 	const previousLineNumber = range.startLineNumber - 1;
-	if (previousLineNumber > 0) {
+	if (range.isEmpty() && previousLineNumber > 0) {
 		const previousLine = model.getLineContent(previousLineNumber);
 		if (indentRulesSupport.shouldIndentNextLine(previousLine) && indentRulesSupport.shouldIncrease(textAroundRangeWithCharacter)) {
 			const inheritedIndentationData = getInheritIndentForLine(autoIndent, model, range.startLineNumber, false, languageConfigurationService);

--- a/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
+++ b/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
@@ -1115,20 +1115,24 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 
 		// https://github.com/microsoft/vscode/issues/225916
 
-		const model = createTextModel([
-			'const fn = () =>',
-			'    doSomething()',
-		].join('\n'), languageId, {});
-		disposables.add(model);
+		const bracketPairs = [['{', '}'], ['[', ']'], ['(', ')']];
 
-		withTestCodeEditor(model, { autoIndent: 'full', serviceCollection }, (editor, viewModel) => {
-			editor.setSelection(new Selection(2, 5, 2, 18));
-			viewModel.type('{', 'keyboard');
-			assert.strictEqual(model.getValue(), [
+		for (const [open, close] of bracketPairs) {
+			const model = createTextModel([
 				'const fn = () =>',
-				'    {doSomething()}',
-			].join('\n'));
-		});
+				'    doSomething()',
+			].join('\n'), languageId, {});
+			disposables.add(model);
+
+			withTestCodeEditor(model, { autoIndent: 'full', serviceCollection }, (editor, viewModel) => {
+				editor.setSelection(new Selection(2, 5, 2, 18));
+				viewModel.type(open, 'keyboard');
+				assert.strictEqual(model.getValue(), [
+					'const fn = () =>',
+					`    ${open}doSomething()${close}`,
+				].join('\n'), `failed to surround selection with ${open}${close}`);
+			});
+		}
 	});
 
 	// Failing tests...

--- a/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
+++ b/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
@@ -1111,6 +1111,26 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 		});
 	});
 
+	test('issue #225916: surrounding with brackets works after arrow function', () => {
+
+		// https://github.com/microsoft/vscode/issues/225916
+
+		const model = createTextModel([
+			'const fn = () =>',
+			'    doSomething()',
+		].join('\n'), languageId, {});
+		disposables.add(model);
+
+		withTestCodeEditor(model, { autoIndent: 'full', serviceCollection }, (editor, viewModel) => {
+			editor.setSelection(new Selection(2, 5, 2, 18));
+			viewModel.type('{', 'keyboard');
+			assert.strictEqual(model.getValue(), [
+				'const fn = () =>',
+				'    {doSomething()}',
+			].join('\n'));
+		});
+	});
+
 	// Failing tests...
 
 	test.skip('issue #43244: indent after equal sign is detected', () => {


### PR DESCRIPTION
## issue

resolve #225916

- I am not the author of this issue and I am not assigned to it.
- I ran into the same problem myself, and since the issue has been open since 2024 with no recent activity, I decided to submit a fix.

## background

- Since VS Code 1.91, typing `{`, `[` or `(` over a selected text deletes the selection instead of surrounding it, when the line above ends with `=>` (or is an `if`/`for`/`while` without braces) in TypeScript/JavaScript.

  ```ts
  const fn = () =>
    doSomething()   // select `doSomething()` and type `{`
  ```

- Expected: `{doSomething()}`
- Actual: the selection is deleted and `{` is inserted at the start of the line.
- This happens with the default settings (`editor.autoIndent: "full"`).

## problem

- Regression introduced by 8ca1b8c (#216500), which added a new branch to `getIndentActionForType` to support allman-style braces (#209802).
- The branch checks that the typed character is the first non-whitespace character on the line using `textAroundRange`, which contains only the text *around* the range — the selected text is excluded. A selection covering the rest of the line therefore passes the check.

https://github.com/microsoft/vscode/blob/43a13cad7f4d7c1f0c87dd6459bb6d85f394d5fb/src/vs/editor/common/languages/autoIndent.ts#L421-L427

- `AutoIndentOperation` runs before `SurroundSelectionOperation` in the typing pipeline, so once the branch fires, surround-with-brackets is never reached.

https://github.com/microsoft/vscode/blob/43a13cad7f4d7c1f0c87dd6459bb6d85f394d5fb/src/vs/editor/common/cursor/cursorTypeOperations.ts#L172-L190

- The resulting edit rewrites the line from column 1 through the end of the selection without the selected text — the selection is deleted.

https://github.com/microsoft/vscode/blob/43a13cad7f4d7c1f0c87dd6459bb6d85f394d5fb/src/vs/editor/common/cursor/cursorTypeEditOperations.ts#L96-L107

## fix

- Require an empty selection for that branch (`range.isEmpty()`).
- Non-empty selections now fall through to `SurroundSelectionOperation`, restoring the pre-1.91 behavior.
- The empty-selection case the branch was added for (allman-style braces, #209802) is unaffected.

## checks

- [x] Verified manually with a build from source

  ```sh
  npm run compile
  ./scripts/code.sh
  ```

  Followed the repro steps from the issue: the selection is now surrounded (`{doSomething()}`), and `[` / `(` work as well.

- [x] Added a regression test, and confirmed it fails without the fix (reproducing the exact behavior reported in the issue)

  ```sh
  ./scripts/test.sh --glob '**/indentation.test.js'   # 60 passing, including the allman-brace test for #209802
  ```

- [x] `./scripts/test.sh` (full unit tests), hygiene, eslint and `valid-layers-check` all pass
