### PR TITLE
Fix agent host MCP output review feedback

### DIFF
--- a/src/vs/platform/agentHost/common/otlp/otlpLogEmitter.ts
+++ b/src/vs/platform/agentHost/common/otlp/otlpLogEmitter.ts
@@ -375,7 +375,7 @@ function attributesToOtlp(attributes: Readonly<Record<string, OtelAttributeValue
 function toAnyValue(value: OtelAttributeValue): Record<string, unknown> {
 	switch (typeof value) {
 		case 'boolean': return { boolValue: value };
-		case 'number': return Number.isInteger(value) ? { intValue: value } : { doubleValue: value };
+		case 'number': return Number.isInteger(value) ? { intValue: String(value) } : { doubleValue: value };
 		default: return { stringValue: value };
 	}
 }
@@ -413,9 +413,12 @@ function fromAnyValue(value: unknown): OtelAttributeValue | undefined {
 	const v = value as Record<string, unknown>;
 	if (typeof v.stringValue === 'string') { return v.stringValue; }
 	if (typeof v.boolValue === 'boolean') { return v.boolValue; }
-	if (typeof v.intValue === 'number') { return v.intValue; }
-	if (typeof v.intValue === 'string') { return Number(v.intValue); }
-	if (typeof v.doubleValue === 'number') { return v.doubleValue; }
+	if (typeof v.intValue === 'number') { return Number.isSafeInteger(v.intValue) ? v.intValue : undefined; }
+	if (typeof v.intValue === 'string') {
+		const parsed = Number(v.intValue);
+		return Number.isSafeInteger(parsed) ? parsed : undefined;
+	}
+	if (typeof v.doubleValue === 'number') { return Number.isFinite(v.doubleValue) ? v.doubleValue : undefined; }
 	return undefined;
 }
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -2487,7 +2487,13 @@ export class CopilotAgentSession extends Disposable {
 			if (e.data.tip) {
 				attributes.tip = e.data.tip;
 			}
-			this._logService.info(`[Copilot:${sessionId}] [${e.data.infoType}]: ${e.data.message}`, new OtelData(attributes));
+			const message = `[Copilot:${sessionId}] [${e.data.infoType}]: ${e.data.message}`;
+			const otelData = new OtelData(attributes);
+			if (e.data.infoType === 'mcp') {
+				this._logService.info(message, otelData);
+			} else {
+				this._logService.trace(message, otelData);
+			}
 		}));
 
 		this._register(wrapper.onSessionWarning(e => {

--- a/src/vs/platform/agentHost/test/common/otlpLogEmitter.test.ts
+++ b/src/vs/platform/agentHost/test/common/otlpLogEmitter.test.ts
@@ -145,6 +145,67 @@ suite('OtlpLogEmitter', () => {
 		]);
 	});
 
+	test('integer attributes are string-encoded on the OTLP wire', () => {
+		const record: IOtlpLogRecord = {
+			timeUnixNano: '123000000',
+			severityNumber: 9,
+			severityText: 'info',
+			body: 'a body',
+			attributes: { count: 2, ratio: 1.5, label: 'ready', enabled: true },
+		};
+
+		assert.deepStrictEqual(toResourceLogsPayload(record), {
+			resourceLogs: [{
+				resource: { attributes: [] },
+				scopeLogs: [{
+					scope: { name: 'vscode.agentHost' },
+					logRecords: [{
+						timeUnixNano: '123000000',
+						observedTimeUnixNano: '123000000',
+						severityNumber: 9,
+						severityText: 'info',
+						body: { stringValue: 'a body' },
+						attributes: [
+							{ key: 'count', value: { intValue: '2' } },
+							{ key: 'ratio', value: { doubleValue: 1.5 } },
+							{ key: 'label', value: { stringValue: 'ready' } },
+							{ key: 'enabled', value: { boolValue: true } },
+						],
+					}],
+				}],
+			}],
+		});
+	});
+
+	test('invalid numeric OTLP attributes are ignored', () => {
+		const decoded = [...iterateOtlpLogRecords({
+			resourceLogs: [{
+				scopeLogs: [{
+					logRecords: [{
+						timeUnixNano: '123000000',
+						severityNumber: 9,
+						severityText: 'info',
+						body: { stringValue: 'a body' },
+						attributes: [
+							{ key: 'validInt', value: { intValue: '2' } },
+							{ key: 'nanInt', value: { intValue: 'not-a-number' } },
+							{ key: 'unsafeInt', value: { intValue: '9007199254740992' } },
+							{ key: 'infiniteDouble', value: { doubleValue: Infinity } },
+						],
+					}],
+				}],
+			}],
+		})];
+
+		assert.deepStrictEqual(decoded, [{
+			timeUnixNano: '123000000',
+			severityNumber: 9,
+			severityText: 'info',
+			body: 'a body',
+			attributes: { validInt: 2 },
+		}]);
+	});
+
 	test('iterateOtlpLogRecords tolerates malformed shapes', () => {
 		const decoded = [
 			...iterateOtlpLogRecords({ resourceLogs: [{ scopeLogs: [{ logRecords: [null, { severityNumber: 'bad' }] }] }] }),

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService.ts
@@ -8,6 +8,7 @@ import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable, DisposableMap, IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { AgentSession, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
 import { agentHostAuthority } from '../../../../../../platform/agentHost/common/agentHostUri.js';
+import { isRemoteAgentHostSessionType, remoteAgentHostSessionTypeId } from '../../../../../../platform/agentHost/common/agentHostSessionType.js';
 import { AGENT_HOST_LOG_OUTPUT_CHANNEL_ID, IRemoteAgentHostService, remoteAgentHostLogOutputChannelId } from '../../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { getEffectiveAgents } from '../../../../../../platform/agentHost/common/customAgents.js';
 import { type IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
@@ -19,7 +20,7 @@ import { createDecorator } from '../../../../../../platform/instantiation/common
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { isUntitledChatSession } from '../../../common/model/chatUri.js';
 import { IAgentHostUntitledProvisionalSessionService } from './agentHostUntitledProvisionalSessionService.js';
-import { IAgentHostMcpServer, LOCAL_AGENT_HOST_PROVIDER_ID, REMOTE_AGENT_HOST_PROVIDER_PREFIX } from '../../../../../../sessions/common/agentHostSessionsProvider.js';
+import { IAgentHostMcpServer } from '../../../../../../sessions/common/agentHostSessionsProvider.js';
 
 const AGENT_HOST_SESSION_SCHEME_PREFIX = 'agent-host-';
 
@@ -135,7 +136,7 @@ class WorkbenchAgentHostCustomizationService extends Disposable implements IAgen
 		}
 		const customizations = this._readSessionState(sessionResource)?.customizations ?? [];
 		const channel = backendSession.toString();
-		const logOutputChannelId = this._resolveLogOutputChannelId(backendSession);
+		const logOutputChannelId = this._resolveLogOutputChannelId(sessionResource, backendSession);
 		return customizations
 			.filter((c): c is McpServerCustomization => c.type === CustomizationType.McpServer)
 			.map((c): IAgentHostMcpServer => ({
@@ -154,16 +155,19 @@ class WorkbenchAgentHostCustomizationService extends Disposable implements IAgen
 			}));
 	}
 
-	private _resolveLogOutputChannelId(backendSession: URI): string | undefined {
-		const providerId = AgentSession.provider(backendSession);
-		if (providerId === LOCAL_AGENT_HOST_PROVIDER_ID) {
+	private _resolveLogOutputChannelId(sessionResource: URI, backendSession: URI): string | undefined {
+		if (sessionResource.scheme.startsWith(AGENT_HOST_SESSION_SCHEME_PREFIX)) {
 			return AGENT_HOST_LOG_OUTPUT_CHANNEL_ID;
 		}
-		if (providerId?.startsWith(REMOTE_AGENT_HOST_PROVIDER_PREFIX)) {
-			const authority = providerId.substring(REMOTE_AGENT_HOST_PROVIDER_PREFIX.length);
-			const connection = this._remoteAgentHostService.connections.find(c => agentHostAuthority(c.address) === authority);
+
+		if (isRemoteAgentHostSessionType(sessionResource.scheme)) {
+			const backendProvider = AgentSession.provider(backendSession);
+			const connection = backendProvider
+				? this._remoteAgentHostService.connections.find(c => sessionResource.scheme === remoteAgentHostSessionTypeId(agentHostAuthority(c.address), backendProvider))
+				: undefined;
 			return connection ? remoteAgentHostLogOutputChannelId(connection.address) : undefined;
 		}
+
 		return undefined;
 	}
 

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -344,7 +344,7 @@ export class McpAgentHostServerOptionsCommand extends Action2 {
 
 		if (picked.action === 'showOutput') {
 			if (logOutputChannelId) {
-				outputService.showChannel(logOutputChannelId);
+				await outputService.showChannel(logOutputChannelId);
 			}
 			return;
 		}


### PR DESCRIPTION
## Summary
- address follow-up review feedback for agent host MCP log output
- resolve workbench MCP output channels via agent-host session type helpers
- await Show Output channel reveal and keep non-MCP session info at trace
- make OTLP integer attributes string-encoded and ignore invalid numeric attributes on decode

## Validation
- npm run precommit
- ./scripts/test.sh --run src/vs/platform/agentHost/test/common/otlpLogEmitter.test.ts --grep "OtlpLogEmitter"

Note: `npm run compile-check-ts-native` and `npm run valid-layers-check` are currently blocked locally by outdated installed SDK dependency types in files unrelated to this change.
