### PR TITLE
agent host: sync VS Code-configured MCP servers to agent hosts

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.ts
@@ -7,7 +7,7 @@ import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../..
 import { onUnexpectedError } from '../../../../../../base/common/errors.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { equals } from '../../../../../../base/common/objects.js';
-import { derived, IObservable, ISettableObservable, observableValue } from '../../../../../../base/common/observable.js';
+import { autorun, derived, IObservable, ISettableObservable, observableValue } from '../../../../../../base/common/observable.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
 import { createDecorator, IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
@@ -20,6 +20,7 @@ import { ICustomizationSyncProvider } from '../../../common/customizationHarness
 import { IAgentPluginService } from '../../../common/plugins/agentPluginService.js';
 import { IPromptsService } from '../../../common/promptSyntax/service/promptsService.js';
 import { ILanguageModelToolsService } from '../../../common/tools/languageModelToolsService.js';
+import { IMcpService } from '../../../../mcp/common/mcpTypes.js';
 import { AgentCustomizationSyncProvider } from './agentCustomizationSyncProvider.js';
 import { resolveCustomizationRefs } from './agentHostLocalCustomizations.js';
 import { toolDataToDefinition } from './agentHostToolUtils.js';
@@ -69,6 +70,7 @@ export class AgentHostActiveClientService extends Disposable implements IAgentHo
 		@IStorageService private readonly _storageService: IStorageService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IFileService private readonly _fileService: IFileService,
+		@IMcpService private readonly _mcpService: IMcpService,
 	) {
 		super();
 		this._customizationsByType = observableValue('agentHostCustomizationsByType', new Map());
@@ -93,7 +95,7 @@ export class AgentHostActiveClientService extends Disposable implements IAgentHo
 		const updateCustomizations = async () => {
 			const seq = ++updateSeq;
 			try {
-				const refs = await resolveCustomizationRefs(this._fileService, this._promptsService, syncProvider, this._agentPluginService, bundler, sessionType);
+				const refs = await resolveCustomizationRefs(this._fileService, this._promptsService, syncProvider, this._agentPluginService, this._mcpService, bundler, sessionType);
 				if (seq !== updateSeq) {
 					return;
 				}
@@ -112,7 +114,15 @@ export class AgentHostActiveClientService extends Disposable implements IAgentHo
 			this._promptsService.onDidChangeSkills,
 			this._promptsService.onDidChangeInstructions,
 		)(() => updateCustomizations()));
-		updateCustomizations();
+		// Re-resolve when MCP servers configured in VS Code change (added,
+		// removed, enabled/disabled, or reconfigured) so they stay in sync.
+		store.add(autorun(reader => {
+			for (const server of this._mcpService.servers.read(reader)) {
+				server.enablement.read(reader);
+				server.readDefinitions().read(reader);
+			}
+			updateCustomizations();
+		}));
 		store.add(this._setCustomizations(sessionType, customizations));
 		return {
 			syncProvider,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
@@ -8,13 +8,16 @@ import { isEqualOrParent } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { CustomizationType, type URI as ProtocolURI } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { customizationId, type ClientPluginCustomization } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { IMcpServerConfiguration, McpServerType } from '../../../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { AICustomizationSource, AICustomizationSources, BUILTIN_STORAGE } from '../../../common/aiCustomizationWorkspaceService.js';
 import { PromptsType } from '../../../common/promptSyntax/promptTypes.js';
 import { IPromptPath, IPromptsService, matchesSessionType, PromptsStorage } from '../../../common/promptSyntax/service/promptsService.js';
 import { type ICustomizationSyncProvider } from '../../../common/customizationHarnessService.js';
 import { IAgentPlugin, IAgentPluginService } from '../../../common/plugins/agentPluginService.js';
 import { isContributionEnabled } from '../../../common/enablement.js';
-import type { SyncedCustomizationBundler } from './syncedCustomizationBundler.js';
+import { MCP_PLUGIN_COLLECTION_ID_PREFIX } from '../../../../mcp/common/discovery/pluginMcpDiscovery.js';
+import { IMcpService, McpServerLaunch, McpServerTransportType } from '../../../../mcp/common/mcpTypes.js';
+import type { ISyncableMcpServer, SyncedCustomizationBundler } from './syncedCustomizationBundler.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
 import { isDefined } from '../../../../../../base/common/types.js';
 
@@ -123,18 +126,80 @@ export async function enumerateLocalCustomizationsForHarness(
 }
 
 /**
+ * Converts an {@link McpServerLaunch} back into the declarative
+ * {@link IMcpServerConfiguration} shape understood by the agent host's
+ * Open Plugin `.mcp.json` reader. Returns `undefined` for launches that
+ * cannot be expressed declaratively (e.g. extension-resolved servers with
+ * no command or URL).
+ */
+function launchToMcpServerConfiguration(launch: McpServerLaunch): IMcpServerConfiguration | undefined {
+	switch (launch.type) {
+		case McpServerTransportType.Stdio:
+			if (!launch.command) {
+				return undefined;
+			}
+			return {
+				type: McpServerType.LOCAL,
+				command: launch.command,
+				args: launch.args.length > 0 ? [...launch.args] : undefined,
+				env: Object.keys(launch.env).length > 0 ? { ...launch.env } : undefined,
+				envFile: launch.envFile,
+				cwd: launch.cwd,
+			};
+		case McpServerTransportType.HTTP:
+			return {
+				type: McpServerType.REMOTE,
+				url: launch.uri.toString(),
+				headers: launch.headers.length > 0 ? Object.fromEntries(launch.headers) : undefined,
+			};
+	}
+}
+
+/**
+ * Enumerates MCP servers configured directly in VS Code — i.e. those that
+ * are not contributed by an agent plugin — so they can be bundled into the
+ * synthetic synced plugin. Plugin-sourced servers are excluded because they
+ * are already synced via their owning plugin's customization ref. Disabled
+ * servers and servers whose launch cannot be expressed declaratively are
+ * skipped.
+ */
+export function collectNonPluginMcpServers(mcpService: IMcpService): ISyncableMcpServer[] {
+	const result: ISyncableMcpServer[] = [];
+	for (const server of mcpService.servers.get()) {
+		if (server.collection.id.startsWith(MCP_PLUGIN_COLLECTION_ID_PREFIX)) {
+			continue;
+		}
+		if (!isContributionEnabled(server.enablement.get())) {
+			continue;
+		}
+		const launch = server.readDefinitions().get().server?.launch;
+		if (!launch) {
+			continue;
+		}
+		const configuration = launchToMcpServerConfiguration(launch);
+		if (!configuration) {
+			continue;
+		}
+		result.push({ name: server.definition.label, configuration });
+	}
+	return result;
+}
+
+/**
  * Resolves the customization refs to include in an `activeClientChanged`
  * message.
  *
  * Every eligible local file is synced unless the user opted out. Files
  * belonging to installed plugins are de-duped to a single plugin ref;
- * remaining loose files are bundled into a synthetic Open Plugin.
+ * remaining loose files — together with MCP servers configured directly in
+ * VS Code — are bundled into a synthetic Open Plugin.
  */
 export async function resolveCustomizationRefs(
 	fileService: IFileService,
 	promptsService: IPromptsService,
 	syncProvider: ICustomizationSyncProvider,
 	agentPluginService: IAgentPluginService,
+	mcpService: IMcpService,
 	bundler: SyncedCustomizationBundler,
 	sessionType: string,
 ): Promise<ClientPluginCustomization[]> {
@@ -204,8 +269,9 @@ export async function resolveCustomizationRefs(
 	}
 
 	const refs: Promise<ClientPluginCustomization | undefined>[] = [...pluginRefs.values()];
-	if (looseFiles.length > 0) {
-		refs.push(bundler.bundle(looseFiles).then(r => r?.ref));
+	const mcpServers = collectNonPluginMcpServers(mcpService);
+	if (looseFiles.length > 0 || mcpServers.length > 0) {
+		refs.push(bundler.bundle(looseFiles, mcpServers).then(r => r?.ref));
 	}
 	return await Promise.all(refs).then(r => r.filter(isDefined));
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/syncedCustomizationBundler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/syncedCustomizationBundler.ts
@@ -9,6 +9,7 @@ import { basename, dirname } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { hash } from '../../../../../../base/common/hash.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
+import { IMcpServerConfiguration } from '../../../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { PromptsType } from '../../../common/promptSyntax/promptTypes.js';
 import { customizationId, type ClientPluginCustomization } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { CustomizationType, type URI as ProtocolURI } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
@@ -47,6 +48,16 @@ interface ISyncableFile {
 	readonly type: PromptsType;
 }
 
+/**
+ * An MCP server configured directly in VS Code (i.e. not contributed by an
+ * agent plugin) that should be bundled into the synthetic plugin so the
+ * agent host can launch it.
+ */
+export interface ISyncableMcpServer {
+	readonly name: string;
+	readonly configuration: IMcpServerConfiguration;
+}
+
 interface IBundleResult {
 	readonly ref: ClientPluginCustomization;
 }
@@ -62,6 +73,7 @@ interface IBundleResult {
  *
  * ```
  * .plugin/plugin.json
+ * .mcp.json        ← MCP servers configured in VS Code
  * rules/          ← instruction files
  * commands/       ← prompt files
  * agents/         ← agent files
@@ -96,16 +108,17 @@ export class SyncedCustomizationBundler extends Disposable {
 	}
 
 	/**
-	 * Bundles the given files into the in-memory plugin filesystem.
+	 * Bundles the given files and MCP servers into the in-memory plugin
+	 * filesystem.
 	 *
 	 * Overwrites any previous bundle content. Returns a {@link ClientPluginCustomization}
 	 * pointing at the virtual plugin directory with a content-based nonce.
 	 *
-	 * @returns The bundle result, or `undefined` if no syncable files were provided.
+	 * @returns The bundle result, or `undefined` if there is nothing to sync.
 	 */
-	async bundle(files: readonly ISyncableFile[]): Promise<IBundleResult | undefined> {
+	async bundle(files: readonly ISyncableFile[], mcpServers: readonly ISyncableMcpServer[] = []): Promise<IBundleResult | undefined> {
 		const syncable = files.filter(f => pluginDirForType(f.type) !== undefined);
-		if (syncable.length === 0) {
+		if (syncable.length === 0 && mcpServers.length === 0) {
 			return undefined;
 		}
 
@@ -147,6 +160,20 @@ export class SyncedCustomizationBundler extends Disposable {
 			await this._fileService.writeFile(destUri, content.value);
 
 			hashParts.push(`${hashKey}:${content.value.toString()}`);
+		}
+
+		// Write MCP servers into `.mcp.json`. The agent host's Open Plugin
+		// adapter reads this file relative to the plugin root. Servers are
+		// sorted by name so the serialized content (and nonce) is stable.
+		if (mcpServers.length > 0) {
+			const servers: Record<string, IMcpServerConfiguration> = {};
+			for (const server of [...mcpServers].sort((a, b) => a.name.localeCompare(b.name))) {
+				servers[server.name] = server.configuration;
+			}
+			const mcpContent = JSON.stringify({ mcpServers: servers }, null, '\t');
+			const mcpUri = URI.joinPath(this._rootUri, '.mcp.json');
+			await this._fileService.writeFile(mcpUri, VSBuffer.fromString(mcpContent));
+			hashParts.push(`.mcp.json:${mcpContent}`);
 		}
 
 		// Stable nonce: sort so file ordering doesn't matter

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -20,6 +20,7 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { mcpAccessConfig, McpAccessValue } from '../../../../../platform/mcp/common/mcpManagement.js';
 import { IMcpWorkbenchService, IWorkbenchMcpServer, McpConnectionState, McpServerInstallState, IMcpService, IMcpServer } from '../../../../contrib/mcp/common/mcpTypes.js';
 import { IMcpRegistry } from '../../../mcp/common/mcpRegistryTypes.js';
+import { MCP_PLUGIN_COLLECTION_ID_PREFIX } from '../../../mcp/common/discovery/pluginMcpDiscovery.js';
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
 import { isContributionDisabled } from '../../common/enablement.js';
 import { McpCommandIds } from '../../../../contrib/mcp/common/mcpCommandIds.js';
@@ -47,7 +48,7 @@ const $ = DOM.$;
 
 const MCP_ITEM_HEIGHT = 36;
 
-const PLUGIN_COLLECTION_PREFIX = 'plugin.';
+const PLUGIN_COLLECTION_PREFIX = MCP_PLUGIN_COLLECTION_ID_PREFIX;
 
 const COPILOT_EXTENSION_IDS = ['github.copilot', 'github.copilot-chat'];
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/resolveCustomizationRefs.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/resolveCustomizationRefs.test.ts
@@ -10,14 +10,16 @@ import { observableValue } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
+import { McpServerType } from '../../../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { resolveCustomizationRefs } from '../../../browser/agentSessions/agentHost/agentHostLocalCustomizations.js';
-import { type SyncedCustomizationBundler } from '../../../browser/agentSessions/agentHost/syncedCustomizationBundler.js';
+import { type ISyncableMcpServer, type SyncedCustomizationBundler } from '../../../browser/agentSessions/agentHost/syncedCustomizationBundler.js';
 import { BUILTIN_STORAGE } from '../../../common/aiCustomizationWorkspaceService.js';
 import { type ICustomizationSyncProvider } from '../../../common/customizationHarnessService.js';
 import { ContributionEnablementState } from '../../../common/enablement.js';
 import { type IAgentPlugin, type IAgentPluginService } from '../../../common/plugins/agentPluginService.js';
 import { PromptsType } from '../../../common/promptSyntax/promptTypes.js';
 import { type IPromptPath, type IPromptsService, PromptsStorage } from '../../../common/promptSyntax/service/promptsService.js';
+import { type IMcpServer, type IMcpService, McpServerLaunch, McpServerTransportType } from '../../../../mcp/common/mcpTypes.js';
 import { SessionType } from '../../../common/chatSessionsService.js';
 
 function makePromptPath(uri: URI, type: PromptsType, storage: PromptsStorage): IPromptPath {
@@ -70,13 +72,43 @@ function makeFileService(stats: ReadonlyMap<string, { mtime: number }> = new Map
 	} as unknown as IFileService;
 }
 
+function makeMcpServer(options: { id: string; collectionId: string; label?: string; enabled?: boolean; launch?: McpServerLaunch | undefined }): IMcpServer {
+	const { id, collectionId, label = id, enabled = true, launch } = options;
+	const definitions = observableValue('definitions', { server: launch ? { launch } : undefined, collection: undefined });
+	return {
+		definition: { id, label },
+		collection: { id: collectionId, label: collectionId, order: 0 },
+		enablement: observableValue('enablement', enabled ? ContributionEnablementState.EnabledProfile : ContributionEnablementState.DisabledProfile),
+		readDefinitions: () => definitions,
+	} as unknown as IMcpServer;
+}
+
+function makeMcpService(servers: readonly IMcpServer[] = []): IMcpService {
+	return {
+		_serviceBrand: undefined,
+		servers: observableValue('servers', servers),
+	} as unknown as IMcpService;
+}
+
+const stdioLaunch: McpServerLaunch = {
+	type: McpServerTransportType.Stdio,
+	command: 'my-server',
+	args: ['--flag'],
+	env: {},
+	envFile: undefined,
+	cwd: undefined,
+	sandbox: undefined,
+};
+
 type LocalSyncableFile = { readonly uri: URI; readonly type: PromptsType };
 
 class FakeBundler {
 	readonly received: LocalSyncableFile[][] = [];
+	readonly receivedMcp: ISyncableMcpServer[][] = [];
 	constructor(private readonly _result: { uri: string; name: string } | undefined = { uri: 'open-plugin://bundle', name: 'Open Plugin' }) { }
-	async bundle(files: readonly LocalSyncableFile[]) {
+	async bundle(files: readonly LocalSyncableFile[], mcpServers: readonly ISyncableMcpServer[] = []) {
 		this.received.push([...files]);
+		this.receivedMcp.push([...mcpServers]);
 		if (!this._result) {
 			return undefined;
 		}
@@ -100,6 +132,7 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			promptsService,
 			new FakeSyncProvider(),
 			makeAgentPluginService(),
+			makeMcpService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
 		);
@@ -128,6 +161,7 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			promptsService,
 			new FakeSyncProvider(new Set([disabled.toString()])),
 			makeAgentPluginService(),
+			makeMcpService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
 		);
@@ -149,6 +183,7 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			promptsService,
 			new FakeSyncProvider(),
 			makeAgentPluginService(),
+			makeMcpService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
 		);
@@ -175,6 +210,7 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			promptsService,
 			new FakeSyncProvider(new Set([builtin.toString()])),
 			makeAgentPluginService(),
+			makeMcpService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
 		);
@@ -193,6 +229,7 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			promptsService,
 			new FakeSyncProvider(),
 			makeAgentPluginService([makePlugin(pluginUri, { label: 'MCP Only', mcpServers: 1 })]),
+			makeMcpService(),
 			bundler as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
 		);
@@ -210,6 +247,7 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makePromptsService(new Map()),
 			new FakeSyncProvider(),
 			makeAgentPluginService([makePlugin(pluginUri, { enabled: false, mcpServers: 1 })]),
+			makeMcpService(),
 			new FakeBundler() as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
 		);
@@ -223,6 +261,7 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			makePromptsService(new Map()),
 			new FakeSyncProvider(new Set([pluginUri.toString()])),
 			makeAgentPluginService([makePlugin(pluginUri, { mcpServers: 1 })]),
+			makeMcpService(),
 			new FakeBundler() as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
 		);
@@ -240,6 +279,7 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			promptsService,
 			new FakeSyncProvider(),
 			makeAgentPluginService([makePlugin(pluginUri, { label: 'Combined', mcpServers: 2 })]),
+			makeMcpService(),
 			new FakeBundler() as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
 		);
@@ -255,11 +295,76 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 			promptsService,
 			new FakeSyncProvider(),
 			makeAgentPluginService(),
+			makeMcpService(),
 			new FakeBundler() as unknown as SyncedCustomizationBundler,
 			SessionType.CopilotCLI,
 		);
 		assert.deepStrictEqual(refs, []);
 		// Use CancellationToken so the import isn't dead in the bundle.
 		assert.ok(CancellationToken.None.isCancellationRequested === false);
+	});
+
+	test('bundles MCP servers configured directly in VS Code', async () => {
+		const bundler = new FakeBundler();
+		const mcpService = makeMcpService([
+			makeMcpServer({ id: 'user.my-server', collectionId: 'user', label: 'my-server', launch: stdioLaunch }),
+		]);
+
+		const refs = await resolveCustomizationRefs(
+			makeFileService(),
+			makePromptsService(new Map()),
+			new FakeSyncProvider(),
+			makeAgentPluginService(),
+			mcpService,
+			bundler as unknown as SyncedCustomizationBundler,
+			SessionType.CopilotCLI,
+		);
+
+		assert.strictEqual(bundler.received.length, 1);
+		assert.deepStrictEqual(bundler.receivedMcp[0], [
+			{ name: 'my-server', configuration: { type: McpServerType.LOCAL, command: 'my-server', args: ['--flag'], env: undefined, envFile: undefined, cwd: undefined } },
+		]);
+		assert.strictEqual(refs.length, 1);
+		assert.strictEqual(refs[0].name, 'Open Plugin');
+	});
+
+	test('excludes plugin-sourced MCP servers from the bundle', async () => {
+		const bundler = new FakeBundler();
+		const mcpService = makeMcpService([
+			makeMcpServer({ id: 'plugin.foo.srv', collectionId: 'plugin.file:///plugins/foo', label: 'srv', launch: stdioLaunch }),
+		]);
+
+		const refs = await resolveCustomizationRefs(
+			makeFileService(),
+			makePromptsService(new Map()),
+			new FakeSyncProvider(),
+			makeAgentPluginService(),
+			mcpService,
+			bundler as unknown as SyncedCustomizationBundler,
+			SessionType.CopilotCLI,
+		);
+
+		// No loose files and no non-plugin MCP servers: bundler is never called.
+		assert.strictEqual(bundler.received.length, 0);
+		assert.deepStrictEqual(refs, []);
+	});
+
+	test('excludes disabled MCP servers from the bundle', async () => {
+		const bundler = new FakeBundler();
+		const mcpService = makeMcpService([
+			makeMcpServer({ id: 'user.off', collectionId: 'user', label: 'off', enabled: false, launch: stdioLaunch }),
+		]);
+
+		await resolveCustomizationRefs(
+			makeFileService(),
+			makePromptsService(new Map()),
+			new FakeSyncProvider(),
+			makeAgentPluginService(),
+			mcpService,
+			bundler as unknown as SyncedCustomizationBundler,
+			SessionType.CopilotCLI,
+		);
+
+		assert.strictEqual(bundler.received.length, 0);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/syncedCustomizationBundler.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/syncedCustomizationBundler.test.ts
@@ -12,6 +12,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/
 import { FileService } from '../../../../../../platform/files/common/fileService.js';
 import { InMemoryFileSystemProvider } from '../../../../../../platform/files/common/inMemoryFilesystemProvider.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { McpServerType } from '../../../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { SyncedCustomizationBundler } from '../../../browser/agentSessions/agentHost/syncedCustomizationBundler.js';
 import { IAgentHostFileSystemService, SYNCED_CUSTOMIZATION_SCHEME } from '../../../../../../workbench/services/agentHost/common/agentHostFileSystemService.js';
 import { PromptsType } from '../../../common/promptSyntax/promptTypes.js';
@@ -311,5 +312,37 @@ suite('SyncedCustomizationBundler', () => {
 		]);
 		assert.ok(result);
 		assert.ok(result.ref.nonce, 'should produce a nonce reflecting the bundled files');
+	});
+
+	test('writes MCP servers into .mcp.json', async () => {
+		const bundler = createBundler();
+
+		const result = await bundler.bundle([], [
+			{ name: 'my-server', configuration: { type: McpServerType.LOCAL, command: 'my-server', args: ['--flag'] } },
+		]);
+		assert.ok(result, 'a bundle with only MCP servers should still produce a result');
+
+		const mcpUri = URI.from({ scheme: SYNCED_CUSTOMIZATION_SCHEME, path: '/test-agent/.mcp.json' });
+		const parsed = JSON.parse((await fileService.readFile(mcpUri)).value.toString());
+		assert.deepStrictEqual(parsed, {
+			mcpServers: { 'my-server': { type: McpServerType.LOCAL, command: 'my-server', args: ['--flag'] } },
+		});
+	});
+
+	test('MCP server bundle nonce is stable and order-independent', async () => {
+		const bundler = createBundler();
+		const a = { name: 'a', configuration: { type: McpServerType.LOCAL, command: 'a' } } as const;
+		const b = { name: 'b', configuration: { type: McpServerType.LOCAL, command: 'b' } } as const;
+
+		const result1 = await bundler.bundle([], [a, b]);
+		const result2 = await bundler.bundle([], [b, a]);
+		assert.strictEqual(result1!.ref.nonce, result2!.ref.nonce);
+	});
+
+	test('MCP server bundle nonce changes when a server changes', async () => {
+		const bundler = createBundler();
+		const result1 = await bundler.bundle([], [{ name: 'srv', configuration: { type: McpServerType.LOCAL, command: 'v1' } }]);
+		const result2 = await bundler.bundle([], [{ name: 'srv', configuration: { type: McpServerType.LOCAL, command: 'v2' } }]);
+		assert.notStrictEqual(result1!.ref.nonce, result2!.ref.nonce);
 	});
 });

--- a/src/vs/workbench/contrib/mcp/common/discovery/pluginMcpDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/pluginMcpDiscovery.ts
@@ -23,6 +23,14 @@ import { IMcpRegistry } from '../mcpRegistryTypes.js';
 import { McpCollectionSortOrder, McpServerDefinition, McpServerLaunch, McpServerTransportType, McpServerTrust } from '../mcpTypes.js';
 import { IMcpDiscovery } from './mcpDiscovery.js';
 
+/**
+ * Prefix used for the {@link McpCollectionDefinition.id | collection id} of
+ * MCP collections contributed by agent plugins. The remainder of the id is
+ * the plugin's URI. Consumers can use this to tell plugin-sourced MCP servers
+ * apart from servers configured directly in VS Code.
+ */
+export const MCP_PLUGIN_COLLECTION_ID_PREFIX = 'plugin.';
+
 export class PluginMcpDiscovery extends Disposable implements IMcpDiscovery {
 	readonly fromGallery = false;
 
@@ -67,7 +75,7 @@ export class PluginMcpDiscovery extends Disposable implements IMcpDiscovery {
 	}
 
 	private createCollectionState(plugin: IAgentPlugin, manifestURI: URI) {
-		const collectionId = `plugin.${plugin.uri}`;
+		const collectionId = `${MCP_PLUGIN_COLLECTION_ID_PREFIX}${plugin.uri}`;
 		return this._mcpRegistry.registerCollection({
 			id: collectionId,
 			label: `${plugin.label} (Agent Plugin)`,


### PR DESCRIPTION
## What

MCP servers that a user configures **directly in VS Code** (user/workspace `mcp.json`, extension-contributed, etc.) were not exposed in the `vscode-synced-customizations` bundle that we publish to agent hosts. Only MCP servers contributed by an agent plugin were synced (via their owning plugin's customization ref).

This change bundles those non-plugin MCP servers into the synthetic "VS Code Synced Data" Open Plugin by generating a `.mcp.json` inside it — the format the agent host's plugin parser already reads — so agent hosts can launch them.

## How

- **`syncedCustomizationBundler.ts`** — `bundle()` now also accepts MCP servers and writes them to `.mcp.json` in the synthetic plugin root. Servers are sorted by name for a stable content-based nonce; a bundle is produced even when only MCP servers (no loose files) are present.
- **`agentHostLocalCustomizations.ts`** — adds `collectNonPluginMcpServers(mcpService)`, which enumerates `IMcpService.servers`, **excludes** plugin-sourced collections (already synced) and disabled servers, and converts each server's `McpServerLaunch` back into a declarative `IMcpServerConfiguration`. `resolveCustomizationRefs` now takes `IMcpService` and feeds these to the bundler.
- **`agentHostActiveClientService.ts`** — injects `IMcpService`, threads it through, and adds an `autorun` so customizations re-sync when MCP servers are added/removed/enabled/disabled/reconfigured.
- **`pluginMcpDiscovery.ts`** — exports a shared `MCP_PLUGIN_COLLECTION_ID_PREFIX` constant used to distinguish plugin-sourced collections; `mcpListWidget.ts` reuses it instead of a private duplicate.

## Notes for reviewers

- Servers whose launch can't be expressed declaratively (no command/URL) are skipped.
- Tests added/updated in `resolveCustomizationRefs.test.ts` and `syncedCustomizationBundler.test.ts` cover bundling, exclusion of plugin/disabled servers, `.mcp.json` output, and nonce stability.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
