### PR TITLE
Align managed settings MDM and account-based

### DIFF
--- a/src/vs/base/common/defaultAccount.ts
+++ b/src/vs/base/common/defaultAccount.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IExtraKnownMarketplaceEntry } from './managedSettings.js';
 import type { ManagedSettingsData } from './policy.js';
 
 export interface IQuotaSnapshotData {
@@ -61,33 +60,13 @@ export interface IPolicyData {
 
 	/**
 	 * Normalized enterprise-managed settings, keyed by dot-separated managed-settings
-	 * paths such as `permissions.disableBypassPermissionsMode`.
+	 * paths such as `permissions.disableBypassPermissionsMode`. This is the single
+	 * channel for enterprise-managed configuration: server-delivered settings and
+	 * native MDM settings both project into this bag, so policy `value()` callbacks
+	 * behave identically regardless of source. Structured settings (e.g.
+	 * `enabledPlugins`, `extraKnownMarketplaces`) are carried as canonical JSON strings.
 	 */
 	readonly managedSettings?: ManagedSettingsData;
-
-	/**
-	 * Enterprise-managed plugin enablement, delivered via the Copilot
-	 * `managed_settings` API. Keys are plugin IDs in `<plugin>@<marketplace>`
-	 * form; values are explicit enable/disable. Consumers that read
-	 * `chat.pluginLocations` should merge these with user-supplied path-keyed
-	 * entries via `IConfigurationService.inspect()`.
-	 */
-	readonly enabledPlugins?: Readonly<Record<string, boolean>>;
-
-	/**
-	 * Enterprise-managed marketplace references, delivered via the Copilot
-	 * `managed_settings` API. Each entry preserves the marketplace `name`
-	 * (used as `displayLabel` so that `enabledPlugins["plugin@<name>"]` keys
-	 * resolve) plus the original `source` discriminator. Legacy string entries
-	 * are still accepted for forward/backward compatibility.
-	 */
-	readonly extraKnownMarketplaces?: readonly (string | IExtraKnownMarketplaceEntry)[];
-
-	/**
-	 * Enterprise-managed strict-marketplace flag. When true, only marketplaces
-	 * listed in `extraKnownMarketplaces` (plus the user's own) are trusted.
-	 */
-	readonly strictKnownMarketplaces?: boolean;
 }
 
 export interface ICopilotTokenInfo {

--- a/src/vs/base/common/managedSettings.ts
+++ b/src/vs/base/common/managedSettings.ts
@@ -10,3 +10,29 @@
 export type IExtraKnownMarketplaceEntry =
 	| { readonly name: string; readonly source: { readonly source: 'github'; readonly repo: string; readonly ref?: string } }
 	| { readonly name: string; readonly source: { readonly source: 'git'; readonly url: string; readonly ref?: string } };
+
+/**
+ * Converts an {@link IExtraKnownMarketplaceEntry} array into the
+ * `{ [name]: url-or-shorthand }` dict stored on the `chat.plugins.extraMarketplaces`
+ * setting (and carried as the canonical JSON value of the `extraKnownMarketplaces`
+ * managed setting across both the server endpoint and native MDM delivery).
+ *
+ * Plain-string entries (allowed by the policy schema but unnamed) are stored with
+ * the value used as both key and value so they survive the round-trip intact.
+ */
+export function extraKnownMarketplacesToConfigDict(entries: readonly (string | IExtraKnownMarketplaceEntry)[] | undefined): Record<string, string> | undefined {
+	if (!entries?.length) {
+		return undefined;
+	}
+	const obj: Record<string, string> = {};
+	for (const entry of entries) {
+		if (typeof entry === 'string') {
+			obj[entry] = entry;
+		} else {
+			const s = entry.source;
+			const base = s.source === 'github' ? s.repo : s.url;
+			obj[entry.name] = s.ref ? `${base}#${s.ref}` : base;
+		}
+	}
+	return obj;
+}

--- a/src/vs/platform/policy/common/copilotManagedSettings.ts
+++ b/src/vs/platform/policy/common/copilotManagedSettings.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from '../../../base/common/event.js';
-import { ManagedSettingsData } from '../../../base/common/policy.js';
+import { IManagedSettingPolicyDefinition, IManagedSettingsPolicyDefinitions, ManagedSettingValue, ManagedSettingsData } from '../../../base/common/policy.js';
 import { IStringDictionary } from '../../../base/common/collections.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { PolicyDefinition } from './policy.js';
@@ -22,6 +22,15 @@ export const GITHUB_COPILOT_MACOS_BUNDLE_ID = 'com.github.copilot';
 
 /** MDM key for the V0 managed setting. */
 export const COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY = 'permissions.disableBypassPermissionsMode';
+
+/** Managed-settings key for enterprise plugin enablement (carried as a JSON-encoded `{ [pluginId]: boolean }`). */
+export const COPILOT_ENABLED_PLUGINS_KEY = 'enabledPlugins';
+
+/** Managed-settings key for enterprise marketplaces (carried as a JSON-encoded `{ [name]: url-or-shorthand }`). */
+export const COPILOT_EXTRA_MARKETPLACES_KEY = 'extraKnownMarketplaces';
+
+/** Managed-settings key for the strict-marketplace flag (boolean). */
+export const COPILOT_STRICT_MARKETPLACES_KEY = 'strictKnownMarketplaces';
 
 export const ICopilotManagedSettingsService = createDecorator<ICopilotManagedSettingsService>('copilotManagedSettingsService');
 
@@ -65,4 +74,48 @@ function flattenManagedSettingsValue(value: unknown, prefix: string | undefined,
 
 function isManagedSettingsObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Aggregate the `managedSettings` declarations of every policy definition into a single
+ * key -> definition map. This is the single source of truth for which Copilot managed-settings
+ * keys (and their value types) are honored, and it drives both delivery channels: the native
+ * MDM watcher and the server `managed_settings` endpoint projection.
+ */
+export function collectManagedSettingsDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): IManagedSettingsPolicyDefinitions {
+	const definitions: Record<string, IManagedSettingPolicyDefinition> = {};
+	for (const policyName in policyDefinitions) {
+		const policyManagedSettings = policyDefinitions[policyName].managedSettings;
+		if (policyManagedSettings) {
+			for (const key in policyManagedSettings) {
+				definitions[key] = policyManagedSettings[key];
+			}
+		}
+	}
+	return definitions;
+}
+
+/**
+ * Project a raw managed-settings bag onto the declared schema: keep only keys declared by a
+ * policy definition whose runtime value matches the declared type. Undeclared keys and
+ * type-mismatched values are dropped (with an optional warning). Values are validated, never
+ * coerced, so a key declared as `string` keeps its string value untouched.
+ *
+ * This keeps the server endpoint and native MDM delivery aligned on the same
+ * declaration-driven key set and value types.
+ */
+export function projectManagedSettings(values: ManagedSettingsData, definitions: IManagedSettingsPolicyDefinitions, onWarn?: (msg: string) => void): ManagedSettingsData {
+	const projected: Record<string, ManagedSettingValue> = {};
+	for (const key in definitions) {
+		const value = values[key];
+		if (value === undefined) {
+			continue;
+		}
+		if (typeof value === definitions[key].type) {
+			projected[key] = value;
+		} else {
+			onWarn?.(`Ignoring managed setting "${key}": expected ${definitions[key].type}, got ${typeof value}`);
+		}
+	}
+	return projected;
 }

--- a/src/vs/platform/policy/node/copilotManagedSettingsService.ts
+++ b/src/vs/platform/policy/node/copilotManagedSettingsService.ts
@@ -7,9 +7,9 @@ import { Throttler } from '../../../base/common/async.js';
 import { IStringDictionary } from '../../../base/common/collections.js';
 import { Emitter } from '../../../base/common/event.js';
 import { Disposable, MutableDisposable } from '../../../base/common/lifecycle.js';
-import { IManagedSettingPolicyDefinition, ManagedSettingsData } from '../../../base/common/policy.js';
+import { IManagedSettingsPolicyDefinitions, ManagedSettingsData } from '../../../base/common/policy.js';
 import { ILogService } from '../../log/common/log.js';
-import { ICopilotManagedSettingsService } from '../common/copilotManagedSettings.js';
+import { collectManagedSettingsDefinitions, ICopilotManagedSettingsService } from '../common/copilotManagedSettings.js';
 import { PolicyDefinition, PolicyValue } from '../common/policy.js';
 import type { Watcher } from '@vscode/policy-watcher';
 
@@ -31,7 +31,7 @@ export class CopilotManagedSettingsService extends Disposable implements ICopilo
 	private readonly throttler = this._register(new Throttler());
 	private readonly watcher = this._register(new MutableDisposable<Watcher>());
 	private readonly managedSettingsValues = new Map<string, PolicyValue>();
-	private watchedSettings: Record<string, IManagedSettingPolicyDefinition> = {};
+	private watchedSettings: IManagedSettingsPolicyDefinitions = {};
 
 	private readonly _onDidChangeManagedSettings = this._register(new Emitter<ManagedSettingsData>());
 	readonly onDidChangeManagedSettings = this._onDidChangeManagedSettings.event;
@@ -50,15 +50,7 @@ export class CopilotManagedSettingsService extends Disposable implements ICopilo
 	}
 
 	async updatePolicyDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): Promise<ManagedSettingsData> {
-		const managedSettings: Record<string, IManagedSettingPolicyDefinition> = {};
-		for (const policyName in policyDefinitions) {
-			const policyManagedSettings = policyDefinitions[policyName].managedSettings;
-			if (policyManagedSettings) {
-				for (const key in policyManagedSettings) {
-					managedSettings[key] = policyManagedSettings[key];
-				}
-			}
-		}
+		const managedSettings = collectManagedSettingsDefinitions(policyDefinitions);
 
 		if (areManagedSettingDefinitionsEqual(this.watchedSettings, managedSettings)) {
 			return this.managedSettings;
@@ -140,7 +132,7 @@ export class CopilotManagedSettingsService extends Disposable implements ICopilo
 	}
 }
 
-function areManagedSettingDefinitionsEqual(a: Record<string, IManagedSettingPolicyDefinition>, b: Record<string, IManagedSettingPolicyDefinition>): boolean {
+function areManagedSettingDefinitionsEqual(a: IManagedSettingsPolicyDefinitions, b: IManagedSettingsPolicyDefinitions): boolean {
 	const aKeys = Object.keys(a);
 	const bKeys = Object.keys(b);
 	if (aKeys.length !== bKeys.length) {

--- a/src/vs/platform/policy/test/common/copilotManagedSettings.test.ts
+++ b/src/vs/platform/policy/test/common/copilotManagedSettings.test.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { IStringDictionary } from '../../../../base/common/collections.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { collectManagedSettingsDefinitions, projectManagedSettings } from '../../common/copilotManagedSettings.js';
+import { PolicyDefinition } from '../../common/policy.js';
+
+suite('Copilot managed settings projection', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const definitions: IStringDictionary<PolicyDefinition> = {
+		PolicyA: {
+			type: 'boolean',
+			managedSettings: { 'permissions.disableBypassPermissionsMode': { type: 'string' } },
+		},
+		PolicyB: {
+			type: 'number',
+			managedSettings: { 'limits.maxFoo': { type: 'number' }, 'flags.enableBar': { type: 'boolean' } },
+		},
+		PolicyC: {
+			type: 'string',
+		},
+	};
+
+	test('collectManagedSettingsDefinitions aggregates declarations across all policies', () => {
+		assert.deepStrictEqual(collectManagedSettingsDefinitions(definitions), {
+			'permissions.disableBypassPermissionsMode': { type: 'string' },
+			'limits.maxFoo': { type: 'number' },
+			'flags.enableBar': { type: 'boolean' },
+		});
+	});
+
+	test('collectManagedSettingsDefinitions returns empty when nothing is declared', () => {
+		assert.deepStrictEqual(collectManagedSettingsDefinitions({ P: { type: 'string' } }), {});
+	});
+
+	test('projectManagedSettings keeps declared+typed keys, drops undeclared and type-mismatched', () => {
+		const projected = projectManagedSettings({
+			'permissions.disableBypassPermissionsMode': 'disable', // declared string -> kept
+			'limits.maxFoo': 5,                                    // declared number -> kept
+			'flags.enableBar': 'true',                             // declared boolean, got string -> dropped
+			'unknown.key': 'x',                                    // undeclared -> dropped
+		}, collectManagedSettingsDefinitions(definitions));
+
+		assert.deepStrictEqual(projected, {
+			'permissions.disableBypassPermissionsMode': 'disable',
+			'limits.maxFoo': 5,
+		});
+	});
+
+	test('projectManagedSettings validates without coercing (string stays a string)', () => {
+		assert.deepStrictEqual(
+			projectManagedSettings(
+				{ 'permissions.disableBypassPermissionsMode': 'false' },
+				{ 'permissions.disableBypassPermissionsMode': { type: 'string' } },
+			),
+			{ 'permissions.disableBypassPermissionsMode': 'false' },
+		);
+	});
+
+	test('projectManagedSettings warns once per type mismatch', () => {
+		const warnings: string[] = [];
+		projectManagedSettings(
+			{ 'flags.enableBar': 'true' },
+			{ 'flags.enableBar': { type: 'boolean' } },
+			msg => warnings.push(msg),
+		);
+		assert.strictEqual(warnings.length, 1);
+	});
+});

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -795,9 +795,6 @@ class PolicyDiagnosticsAction extends Action2 {
 
 			const managedSettingsData = {
 				managedSettings: policyData?.managedSettings,
-				enabledPlugins: policyData?.enabledPlugins,
-				extraKnownMarketplaces: policyData?.extraKnownMarketplaces,
-				strictKnownMarketplaces: policyData?.strictKnownMarketplaces,
 			};
 			content += '```json\n';
 			content += JSON.stringify(managedSettingsData, null, 2);

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -14,7 +14,7 @@ import '../../../../platform/agentHost/common/agentHostStarter.config.contributi
 import { AgentHostAhpJsonlLoggingSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostSdkSandboxEnabledSettingId, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHostEditorSettingId } from '../../../../platform/agentHost/common/agentService.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../../../platform/networkFilter/common/networkFilterService.js';
 import { AgentNetworkDomainSettingId } from '../../../../platform/networkFilter/common/settings.js';
-import { COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY } from '../../../../platform/policy/common/copilotManagedSettings.js';
+import { COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_STRICT_MARKETPLACES_KEY } from '../../../../platform/policy/common/copilotManagedSettings.js';
 import { AgentSandboxEnabledValue, AgentSandboxSettingId } from '../../../../platform/sandbox/common/settings.js';
 import { registerEditorFeature } from '../../../../editor/common/editorFeatures.js';
 import * as nls from '../../../../nls.js';
@@ -173,7 +173,7 @@ import { ToolResultCompressorService } from './tools/toolResultCompressorService
 import { AgentPluginService, ConfiguredAgentPluginDiscovery, CopilotCliAgentPluginDiscovery, ExtensionAgentPluginDiscovery, MarketplaceAgentPluginDiscovery } from '../common/plugins/agentPluginServiceImpl.js';
 import { IAgentPluginRepositoryService } from '../common/plugins/agentPluginRepositoryService.js';
 import { IPluginInstallService } from '../common/plugins/pluginInstallService.js';
-import { extraKnownMarketplacesToConfigDict, IPluginMarketplaceService, PluginMarketplaceService } from '../common/plugins/pluginMarketplaceService.js';
+import { IPluginMarketplaceService, PluginMarketplaceService } from '../common/plugins/pluginMarketplaceService.js';
 import { WorkspacePluginSettingsService, IWorkspacePluginSettingsService } from '../common/plugins/workspacePluginSettingsService.js';
 import { AgentPluginRecommendations } from './claudePluginRecommendations.js';
 import { AgentPluginEditor } from './agentPluginEditor/agentPluginEditor.js';
@@ -957,7 +957,10 @@ configurationRegistry.registerConfiguration({
 				name: 'ChatEnabledPlugins',
 				category: PolicyCategory.InteractiveSession,
 				minimumVersion: '1.122',
-				value: (policyData) => policyData.enabledPlugins ? JSON.stringify(policyData.enabledPlugins) : undefined,
+				value: (policyData) => policyData.managedSettings?.[COPILOT_ENABLED_PLUGINS_KEY],
+				managedSettings: {
+					[COPILOT_ENABLED_PLUGINS_KEY]: { type: 'string' },
+				},
 				localization: {
 					description: {
 						key: 'chat.plugins.enabledPlugins.policy',
@@ -1000,9 +1003,9 @@ configurationRegistry.registerConfiguration({
 				name: 'ChatExtraMarketplaces',
 				category: PolicyCategory.InteractiveSession,
 				minimumVersion: '1.122',
-				value: (policyData) => {
-					const obj = extraKnownMarketplacesToConfigDict(policyData.extraKnownMarketplaces);
-					return obj ? JSON.stringify(obj) : undefined;
+				value: (policyData) => policyData.managedSettings?.[COPILOT_EXTRA_MARKETPLACES_KEY],
+				managedSettings: {
+					[COPILOT_EXTRA_MARKETPLACES_KEY]: { type: 'string' },
 				},
 				localization: {
 					description: {
@@ -1023,7 +1026,10 @@ configurationRegistry.registerConfiguration({
 				name: 'ChatStrictMarketplaces',
 				category: PolicyCategory.InteractiveSession,
 				minimumVersion: '1.122',
-				value: (policyData) => policyData.strictKnownMarketplaces,
+				value: (policyData) => policyData.managedSettings?.[COPILOT_STRICT_MARKETPLACES_KEY],
+				managedSettings: {
+					[COPILOT_STRICT_MARKETPLACES_KEY]: { type: 'boolean' },
+				},
 				localization: {
 					description: {
 						key: 'chat.plugins.strictMarketplaces.policy',

--- a/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from '../../../../../base/common/uri.js';
-import { IExtraKnownMarketplaceEntry } from '../../../../../base/common/managedSettings.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ChatConfiguration } from '../constants.js';
+
+export { extraKnownMarketplacesToConfigDict } from '../../../../../base/common/managedSettings.js';
 
 export const enum MarketplaceReferenceKind {
 	GitHubShorthand = 'githubShorthand',
@@ -45,37 +46,6 @@ export interface IConfiguredMarketplaces {
 
 /** Shorthand-or-URI regex used to detect GitHub `owner/repo[#ref]` entries. */
 const _githubShorthandRe = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:#.+)?$/;
-
-/**
- * Converts the {@link IExtraKnownMarketplaceEntry} array delivered by the
- * `ChatExtraMarketplaces` policy into the `{ [name]: url-or-shorthand }` dict
- * stored on the `chat.plugins.extraMarketplaces` setting.
- *
- * The dict shape is what the Settings Editor's ComplexObject renderer can
- * display inline as key/value rows. {@link readConfiguredMarketplaces} reverses
- * this conversion so {@link parseMarketplaceReferences} keeps producing
- * `displayLabel = name` (required for `enabledPlugins["plugin@<name>"]` keys).
- *
- * Plain-string entries (allowed by the policy schema but unnamed) are stored
- * with the value used as both key and value so they survive the round-trip
- * intact.
- */
-export function extraKnownMarketplacesToConfigDict(entries: readonly (string | IExtraKnownMarketplaceEntry)[] | undefined): Record<string, string> | undefined {
-	if (!entries?.length) {
-		return undefined;
-	}
-	const obj: Record<string, string> = {};
-	for (const entry of entries) {
-		if (typeof entry === 'string') {
-			obj[entry] = entry;
-		} else {
-			const s = entry.source;
-			const base = s.source === 'github' ? s.repo : s.url;
-			obj[entry.name] = s.ref ? `${base}#${s.ref}` : base;
-		}
-	}
-	return obj;
-}
 
 export function readConfiguredMarketplaces(configurationService: IConfigurationService): IConfiguredMarketplaces {
 	const userValues = configurationService.getValue<(string | object)[]>(ChatConfiguration.PluginMarketplaces) ?? [];

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -876,9 +876,6 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 			return {
 				data: {
 					managedSettings: accountPolicyData.policyData.managedSettings,
-					enabledPlugins: accountPolicyData.policyData.enabledPlugins,
-					extraKnownMarketplaces: accountPolicyData.policyData.extraKnownMarketplaces,
-					strictKnownMarketplaces: accountPolicyData.policyData.strictKnownMarketplaces,
 				},
 				fetchedAt: accountPolicyData.managedSettingsFetchedAt,
 			};
@@ -918,11 +915,8 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 			this.logService.trace('[DefaultAccount] Managed settings raw response:', JSON.stringify(data ?? null));
 			const adapted = adaptManagedSettings(data ?? {}, msg => this.logService.warn(msg));
 			// An empty response (`{}`) is a successful "no policy file present" signal.
-			const pluginCount = adapted.enabledPlugins ? Object.keys(adapted.enabledPlugins).length : 0;
-			const marketplaceCount = adapted.extraKnownMarketplaces?.length ?? 0;
-			const strictSet = adapted.strictKnownMarketplaces !== undefined;
 			const managedSettingsCount = adapted.managedSettings ? Object.keys(adapted.managedSettings).length : 0;
-			if (pluginCount === 0 && marketplaceCount === 0 && !strictSet && managedSettingsCount === 0) {
+			if (managedSettingsCount === 0) {
 				this.logService.debug('[DefaultAccount] Managed settings fetched (empty response — no enterprise policy file present)');
 			} else {
 				this.logService.info('[DefaultAccount] Managed settings applied');

--- a/src/vs/workbench/services/accounts/browser/managedSettings.ts
+++ b/src/vs/workbench/services/accounts/browser/managedSettings.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IPolicyData } from '../../../../base/common/defaultAccount.js';
-import { IExtraKnownMarketplaceEntry } from '../../../../base/common/managedSettings.js';
+import { IExtraKnownMarketplaceEntry, extraKnownMarketplacesToConfigDict } from '../../../../base/common/managedSettings.js';
+import { ManagedSettingValue } from '../../../../base/common/policy.js';
 import { isObject, isString } from '../../../../base/common/types.js';
-import { flattenManagedSettings } from '../../../../platform/policy/common/copilotManagedSettings.js';
+import { COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, flattenManagedSettings } from '../../../../platform/policy/common/copilotManagedSettings.js';
 
 /**
  * Response shape from the Copilot `/copilot_internal/managed_settings` endpoint.
@@ -35,57 +36,75 @@ export interface IManagedSettingsResponse {
 }
 
 /**
- * Adapt the `managed_settings` API response into the slice of {@link IPolicyData}
- * that the policy framework consumes. Primitive leaves are also normalized into
- * dot-separated `managedSettings` paths so policy definitions can evaluate the
- * same managed-settings keys across server and MDM delivery.
+ * Adapt the `managed_settings` API response into the `managedSettings` slice of
+ * {@link IPolicyData} that the policy framework consumes. This is the single
+ * server-side normalizer: it produces the SAME canonical, declaration-driven
+ * `managedSettings` bag that native MDM delivery produces, so policy `value()`
+ * callbacks behave identically regardless of source.
  *
- * `extraKnownMarketplaces` is converted from the API's `Record<id, { source }>`
- * map shape to a flat array of
- * {@link IExtraKnownMarketplaceEntry} objects, preserving the marketplace `name`
- * (used downstream as `displayLabel` so that `enabledPlugins["plugin@<name>"]`
- * keys resolve correctly), the source discriminator, and any `ref`.
+ * - Scalar leaves (`permissions.*`, `strictKnownMarketplaces`, and any
+ *   forward-compatible scalar keys) are flattened into dot-separated keys.
+ * - Structured settings (`enabledPlugins`, `extraKnownMarketplaces`) are carried
+ *   as canonical JSON strings under a single key each — the same shape an admin
+ *   authors via native MDM. `PolicyConfiguration` parses the JSON back into the
+ *   object-typed setting on read. `extraKnownMarketplaces` is normalized from the
+ *   API's `Record<id, { source }>` map to the `{ [name]: url-or-shorthand }` dict.
  *
- * Each field is validated independently at runtime — malformed or off-spec
- * shapes are dropped (with an optional warning via {@link onWarn}) rather than
- * throwing, so a bad enterprise settings file degrades gracefully instead of
- * blocking startup.
+ * Malformed marketplace entries are dropped (with an optional warning via
+ * {@link onWarn}) rather than throwing, so a bad enterprise settings file degrades
+ * gracefully instead of blocking startup.
  *
  * Exported for unit-testing the shape transformation independently of network I/O.
  */
 export function adaptManagedSettings(response: IManagedSettingsResponse, onWarn?: (msg: string) => void): Partial<IPolicyData> {
-	let extraKnownMarketplaces: readonly IExtraKnownMarketplaceEntry[] | undefined;
-	if (isObject(response.extraKnownMarketplaces)) {
-		const seen = new Set<string>();
-		const entries: IExtraKnownMarketplaceEntry[] = [];
-		for (const [name, entry] of Object.entries(response.extraKnownMarketplaces)) {
-			if (!isObject(entry) || !isObject(entry.source)) {
-				onWarn?.(`[DefaultAccount] Skipping malformed extraKnownMarketplaces entry "${name}": expected { source: { source, repo|url } }`);
-				continue;
-			}
-			const src = entry.source as { source?: string; repo?: string; url?: string; ref?: string };
-			let normalized: IExtraKnownMarketplaceEntry | undefined;
-			if (src.source === 'github' && isString(src.repo)) {
-				normalized = { name, source: { source: 'github', repo: src.repo, ...(src.ref ? { ref: src.ref } : {}) } };
-			} else if (src.source === 'git' && isString(src.url)) {
-				normalized = { name, source: { source: 'git', url: src.url, ...(src.ref ? { ref: src.ref } : {}) } };
-			} else if (src.source === 'github' || src.source === 'git') {
-				onWarn?.(`[DefaultAccount] Skipping extraKnownMarketplaces entry "${name}": source "${src.source}" requires ${src.source === 'github' ? '"repo"' : '"url"'}`);
-			} else {
-				onWarn?.(`[DefaultAccount] Skipping extraKnownMarketplaces entry "${name}": unknown source type "${src.source}"`);
-			}
-			if (normalized && !seen.has(name)) {
-				seen.add(name);
-				entries.push(normalized);
-			}
-		}
-		extraKnownMarketplaces = entries;
+	const { enabledPlugins, extraKnownMarketplaces, ...rest } = response;
+
+	const managedSettings: Record<string, ManagedSettingValue> = { ...flattenManagedSettings(rest) };
+
+	if (isObject(enabledPlugins)) {
+		managedSettings[COPILOT_ENABLED_PLUGINS_KEY] = JSON.stringify(enabledPlugins);
 	}
 
-	return {
-		managedSettings: flattenManagedSettings(response),
-		enabledPlugins: isObject(response.enabledPlugins) ? response.enabledPlugins as Record<string, boolean> : undefined,
-		extraKnownMarketplaces,
-		strictKnownMarketplaces: typeof response.strictKnownMarketplaces === 'boolean' ? response.strictKnownMarketplaces : undefined,
-	};
+	const marketplaceDict = extraKnownMarketplacesToConfigDict(normalizeExtraKnownMarketplaces(extraKnownMarketplaces, onWarn));
+	if (marketplaceDict) {
+		managedSettings[COPILOT_EXTRA_MARKETPLACES_KEY] = JSON.stringify(marketplaceDict);
+	}
+
+	return { managedSettings };
+}
+
+/**
+ * Normalize the endpoint's `{ [id]: { source } }` marketplace map into the
+ * {@link IExtraKnownMarketplaceEntry} array, preserving the marketplace `name`,
+ * source discriminator, and any `ref`. Malformed or off-spec entries are dropped
+ * (with an optional warning via {@link onWarn}).
+ */
+function normalizeExtraKnownMarketplaces(value: IManagedSettingsResponse['extraKnownMarketplaces'], onWarn?: (msg: string) => void): IExtraKnownMarketplaceEntry[] | undefined {
+	if (!isObject(value)) {
+		return undefined;
+	}
+	const seen = new Set<string>();
+	const entries: IExtraKnownMarketplaceEntry[] = [];
+	for (const [name, entry] of Object.entries(value)) {
+		if (!isObject(entry) || !isObject(entry.source)) {
+			onWarn?.(`[DefaultAccount] Skipping malformed extraKnownMarketplaces entry "${name}": expected { source: { source, repo|url } }`);
+			continue;
+		}
+		const src = entry.source as { source?: string; repo?: string; url?: string; ref?: string };
+		let normalized: IExtraKnownMarketplaceEntry | undefined;
+		if (src.source === 'github' && isString(src.repo)) {
+			normalized = { name, source: { source: 'github', repo: src.repo, ...(src.ref ? { ref: src.ref } : {}) } };
+		} else if (src.source === 'git' && isString(src.url)) {
+			normalized = { name, source: { source: 'git', url: src.url, ...(src.ref ? { ref: src.ref } : {}) } };
+		} else if (src.source === 'github' || src.source === 'git') {
+			onWarn?.(`[DefaultAccount] Skipping extraKnownMarketplaces entry "${name}": source "${src.source}" requires ${src.source === 'github' ? '"repo"' : '"url"'}`);
+		} else {
+			onWarn?.(`[DefaultAccount] Skipping extraKnownMarketplaces entry "${name}": unknown source type "${src.source}"`);
+		}
+		if (normalized && !seen.has(name)) {
+			seen.add(name);
+			entries.push(normalized);
+		}
+	}
+	return entries;
 }

--- a/src/vs/workbench/services/accounts/browser/managedSettings.ts
+++ b/src/vs/workbench/services/accounts/browser/managedSettings.ts
@@ -38,9 +38,12 @@ export interface IManagedSettingsResponse {
 /**
  * Adapt the `managed_settings` API response into the `managedSettings` slice of
  * {@link IPolicyData} that the policy framework consumes. This is the single
- * server-side normalizer: it produces the SAME canonical, declaration-driven
- * `managedSettings` bag that native MDM delivery produces, so policy `value()`
- * callbacks behave identically regardless of source.
+ * server-side normalizer: it encodes the response into the SAME canonical
+ * `managedSettings` shape an admin authors via native MDM, so downstream
+ * projection and policy `value()` callbacks behave identically regardless of
+ * source. It does not itself enforce the declared `managedSettings` schema —
+ * dropping undeclared or type-mismatched keys happens later, at the
+ * `projectManagedSettings` step.
  *
  * - Scalar leaves (`permissions.*`, `strictKnownMarketplaces`, and any
  *   forward-compatible scalar keys) are flattened into dot-separated keys.

--- a/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
@@ -11,123 +11,115 @@ suite('adaptManagedSettings', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('empty response yields empty managed settings and undefined legacy fields', () => {
+	test('empty response yields an empty managed settings bag', () => {
 		assert.deepStrictEqual(adaptManagedSettings({}), {
 			managedSettings: {},
-			enabledPlugins: undefined,
-			extraKnownMarketplaces: undefined,
-			strictKnownMarketplaces: undefined,
 		});
 	});
 
-	test('normalizes permissions managed settings into dot-path policy data', () => {
+	test('normalizes permissions into a dot-path managed setting', () => {
 		assert.deepStrictEqual(adaptManagedSettings({
 			permissions: { disableBypassPermissionsMode: 'disable' },
-		}).managedSettings, {
-			'permissions.disableBypassPermissionsMode': 'disable',
+		}), {
+			managedSettings: {
+				'permissions.disableBypassPermissionsMode': 'disable',
+			},
 		});
 	});
 
-	test('passes enabledPlugins through untouched (plugin-ID keys, boolean values)', () => {
+	test('carries enabledPlugins as a canonical JSON string under a single key', () => {
 		const response: IManagedSettingsResponse = {
 			enabledPlugins: {
 				'assign-issue-to-copilot@agent-skills': true,
 				'my-plugin@acme': false,
 			},
 		};
-		assert.deepStrictEqual(adaptManagedSettings(response).enabledPlugins, {
-			'assign-issue-to-copilot@agent-skills': true,
-			'my-plugin@acme': false,
+		assert.deepStrictEqual(adaptManagedSettings(response), {
+			managedSettings: {
+				enabledPlugins: '{"assign-issue-to-copilot@agent-skills":true,"my-plugin@acme":false}',
+			},
 		});
 	});
 
-	test('passes strictKnownMarketplaces boolean through untouched', () => {
-		assert.strictEqual(adaptManagedSettings({ strictKnownMarketplaces: true }).strictKnownMarketplaces, true);
-		assert.strictEqual(adaptManagedSettings({ strictKnownMarketplaces: false }).strictKnownMarketplaces, false);
+	test('carries strictKnownMarketplaces as a boolean managed setting', () => {
+		assert.deepStrictEqual(adaptManagedSettings({ strictKnownMarketplaces: true }), {
+			managedSettings: { strictKnownMarketplaces: true },
+		});
+		assert.deepStrictEqual(adaptManagedSettings({ strictKnownMarketplaces: false }), {
+			managedSettings: { strictKnownMarketplaces: false },
+		});
 	});
 
-	test('preserves marketplace name + github source shape', () => {
-		const result = adaptManagedSettings({
+	test('encodes github marketplaces as a { name: shorthand } JSON dict', () => {
+		assert.deepStrictEqual(adaptManagedSettings({
 			extraKnownMarketplaces: {
 				'a': { source: { source: 'github', repo: 'github/agent-skills' } },
 				'b': { source: { source: 'github', repo: 'acme/things', ref: 'main' } },
 			},
+		}), {
+			managedSettings: {
+				extraKnownMarketplaces: '{"a":"github/agent-skills","b":"acme/things#main"}',
+			},
 		});
-		assert.deepStrictEqual(result.extraKnownMarketplaces, [
-			{ name: 'a', source: { source: 'github', repo: 'github/agent-skills' } },
-			{ name: 'b', source: { source: 'github', repo: 'acme/things', ref: 'main' } },
-		]);
 	});
 
-	test('preserves marketplace name + git source shape', () => {
-		const result = adaptManagedSettings({
+	test('encodes git marketplaces as a { name: url } JSON dict', () => {
+		assert.deepStrictEqual(adaptManagedSettings({
 			extraKnownMarketplaces: {
 				'a': { source: { source: 'git', url: 'https://example.com/repo.git' } },
 				'b': { source: { source: 'git', url: 'ssh://git@host/path.git', ref: 'v1' } },
 			},
+		}), {
+			managedSettings: {
+				extraKnownMarketplaces: '{"a":"https://example.com/repo.git","b":"ssh://git@host/path.git#v1"}',
+			},
 		});
-		assert.deepStrictEqual(result.extraKnownMarketplaces, [
-			{ name: 'a', source: { source: 'git', url: 'https://example.com/repo.git' } },
-			{ name: 'b', source: { source: 'git', url: 'ssh://git@host/path.git', ref: 'v1' } },
-		]);
 	});
 
-	test('handles mixed github + git sources, dedups by marketplace name', () => {
-		const result = adaptManagedSettings({
+	test('encodes mixed github + git marketplaces, dedups by name', () => {
+		assert.deepStrictEqual(adaptManagedSettings({
 			extraKnownMarketplaces: {
 				'a': { source: { source: 'github', repo: 'a/b' } },
 				'b': { source: { source: 'git', url: 'https://example.com/r.git' } },
 			},
+		}), {
+			managedSettings: {
+				extraKnownMarketplaces: '{"a":"a/b","b":"https://example.com/r.git"}',
+			},
 		});
-		assert.deepStrictEqual(result.extraKnownMarketplaces, [
-			{ name: 'a', source: { source: 'github', repo: 'a/b' } },
-			{ name: 'b', source: { source: 'git', url: 'https://example.com/r.git' } },
-		]);
 	});
 
-	test('handles full populated response (all three fields together)', () => {
-		const result = adaptManagedSettings({
+	test('handles a full populated response (all three structured settings together)', () => {
+		assert.deepStrictEqual(adaptManagedSettings({
 			enabledPlugins: { 'p@m': true },
 			extraKnownMarketplaces: {
 				'a': { source: { source: 'github', repo: 'a/b', ref: 'r' } },
 			},
 			strictKnownMarketplaces: true,
-		});
-		assert.deepStrictEqual(result, {
+		}), {
 			managedSettings: {
-				'enabledPlugins.p@m': true,
-				'extraKnownMarketplaces.a.source.source': 'github',
-				'extraKnownMarketplaces.a.source.repo': 'a/b',
-				'extraKnownMarketplaces.a.source.ref': 'r',
 				strictKnownMarketplaces: true,
+				enabledPlugins: '{"p@m":true}',
+				extraKnownMarketplaces: '{"a":"a/b#r"}',
 			},
-			enabledPlugins: { 'p@m': true },
-			extraKnownMarketplaces: [
-				{ name: 'a', source: { source: 'github', repo: 'a/b', ref: 'r' } },
-			],
-			strictKnownMarketplaces: true,
 		});
 	});
 
-	test('resilience: unknown top-level keys are preserved only in normalized managed settings', () => {
-		const result = adaptManagedSettings({
+	test('resilience: unknown scalar keys flatten into the bag alongside structured keys', () => {
+		assert.deepStrictEqual(adaptManagedSettings({
 			enabledPlugins: { 'p@m': true },
 			strictKnownMarketplaces: false,
 			joshsFakeSetting: true,
-		} as IManagedSettingsResponse);
-		assert.deepStrictEqual(result, {
+		} as IManagedSettingsResponse), {
 			managedSettings: {
-				'enabledPlugins.p@m': true,
 				strictKnownMarketplaces: false,
 				joshsFakeSetting: true,
+				enabledPlugins: '{"p@m":true}',
 			},
-			enabledPlugins: { 'p@m': true },
-			extraKnownMarketplaces: undefined,
-			strictKnownMarketplaces: false,
 		});
 	});
 
-	test('resilience: malformed extraKnownMarketplaces entry is skipped, valid entries still processed', () => {
+	test('resilience: malformed marketplace entries are skipped, valid entries still processed', () => {
 		const warnings: string[] = [];
 		const result = adaptManagedSettings({
 			extraKnownMarketplaces: {
@@ -136,17 +128,19 @@ suite('adaptManagedSettings', () => {
 				'bad-unknown-type': { source: { source: 'ftp', url: 'ftp://x' } } as IManagedSettingsResponse['extraKnownMarketplaces'] extends Record<string, infer V> ? V : never,
 			},
 		} as IManagedSettingsResponse, msg => warnings.push(msg));
-		assert.deepStrictEqual(result.extraKnownMarketplaces, [
-			{ name: 'good', source: { source: 'github', repo: 'a/b' } },
-		]);
+		assert.deepStrictEqual(result, {
+			managedSettings: {
+				extraKnownMarketplaces: '{"good":"a/b"}',
+			},
+		});
 		assert.strictEqual(warnings.length, 2);
 	});
 
-	test('resilience: extraKnownMarketplaces as a string array (wrong format) yields empty array, no throw', () => {
-		const result = adaptManagedSettings({
+	test('resilience: a marketplace string array (wrong format) is treated as missing, no throw', () => {
+		assert.deepStrictEqual(adaptManagedSettings({
 			extraKnownMarketplaces: ['https://plugins.acme.com'] as unknown as IManagedSettingsResponse['extraKnownMarketplaces'],
-		} as IManagedSettingsResponse);
-		// Array is not an object-record — treated as missing, so yields undefined
-		assert.strictEqual(result.extraKnownMarketplaces, undefined);
+		} as IManagedSettingsResponse), {
+			managedSettings: {},
+		});
 	});
 });

--- a/src/vs/workbench/services/policies/common/accountPolicyService.ts
+++ b/src/vs/workbench/services/policies/common/accountPolicyService.ts
@@ -11,7 +11,7 @@ import { localize } from '../../../../nls.js';
 import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { ICopilotManagedSettingsService } from '../../../../platform/policy/common/copilotManagedSettings.js';
+import { ICopilotManagedSettingsService, collectManagedSettingsDefinitions, projectManagedSettings } from '../../../../platform/policy/common/copilotManagedSettings.js';
 import { AbstractPolicyService, getRestrictedPolicyValue, IPolicyService, PolicyDefinition, PolicyValue } from '../../../../platform/policy/common/policy.js';
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 
@@ -185,12 +185,24 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 			return undefined;
 		}
 
-		return {
-			...accountPolicyData,
-			managedSettings: {
+		// Managed settings arrive from two delivery channels: the server `managed_settings`
+		// endpoint (carried on `accountPolicyData`) and native MDM (the Copilot managed-settings
+		// service). Merge them — MDM overrides server — then project the result onto the schema
+		// declared by policy definitions so both channels honor the same declaration-driven keys
+		// and value types.
+		const declaredManagedSettings = collectManagedSettingsDefinitions(this.policyDefinitions);
+		const managedSettingsData = projectManagedSettings(
+			{
 				...accountPolicyData?.managedSettings,
 				...managedPolicyData,
-			}
+			},
+			declaredManagedSettings,
+			msg => this.logService.warn(`[AccountPolicy] ${msg}`)
+		);
+
+		return {
+			...accountPolicyData,
+			managedSettings: managedSettingsData,
 		};
 	}
 
@@ -236,13 +248,7 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 }
 
 function hasManagedSettingsPolicyDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): boolean {
-	for (const policyName in policyDefinitions) {
-		if (policyDefinitions[policyName].managedSettings) {
-			return true;
-		}
-	}
-
-	return false;
+	return Object.keys(collectManagedSettingsDefinitions(policyDefinitions)).length > 0;
 }
 
 function parseApprovedOrganizations(raw: PolicyValue | undefined): string[] {

--- a/src/vs/workbench/services/policies/common/accountPolicyService.ts
+++ b/src/vs/workbench/services/policies/common/accountPolicyService.ts
@@ -248,7 +248,13 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 }
 
 function hasManagedSettingsPolicyDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): boolean {
-	return Object.keys(collectManagedSettingsDefinitions(policyDefinitions)).length > 0;
+	for (const policyName in policyDefinitions) {
+		const policyManagedSettings = policyDefinitions[policyName].managedSettings;
+		if (policyManagedSettings && Object.keys(policyManagedSettings).length > 0) {
+			return true;
+		}
+	}
+	return false;
 }
 
 function parseApprovedOrganizations(raw: PolicyValue | undefined): string[] {

--- a/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
@@ -12,7 +12,7 @@ import { Extensions, IConfigurationNode, IConfigurationRegistry } from '../../..
 import { DefaultConfiguration, PolicyConfiguration } from '../../../../../platform/configuration/common/configurations.js';
 import { IDefaultAccountProvider, IDefaultAccountService } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
-import { COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, ICopilotManagedSettingsService } from '../../../../../platform/policy/common/copilotManagedSettings.js';
+import { COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_ENABLED_PLUGINS_KEY, ICopilotManagedSettingsService } from '../../../../../platform/policy/common/copilotManagedSettings.js';
 import { AbstractPolicyService, IPolicyService, PolicyDefinition, PolicyValue } from '../../../../../platform/policy/common/policy.js';
 import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { TestProductService } from '../../../../test/common/workbenchTestServices.js';
@@ -138,6 +138,21 @@ suite('AccountPolicyService', () => {
 						[COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: { type: 'string' },
 					}
 				}
+			},
+			'setting.G': {
+				'type': 'object',
+				'additionalProperties': { 'type': 'boolean' },
+				'default': {},
+				policy: {
+					name: 'PolicySettingG',
+					category: PolicyCategory.Extensions,
+					minimumVersion: '1.0.0',
+					localization: { description: { key: '', value: '' } },
+					value: policyData => policyData.managedSettings?.[COPILOT_ENABLED_PLUGINS_KEY],
+					managedSettings: {
+						[COPILOT_ENABLED_PLUGINS_KEY]: { type: 'string' },
+					}
+				}
 			}
 		}
 	};
@@ -261,8 +276,61 @@ suite('AccountPolicyService', () => {
 		}, {
 			policy: false,
 			configuration: false,
-			registeredManagedSettings: { [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: { type: 'string' } },
+			registeredManagedSettings: {
+				[COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: { type: 'string' },
+				[COPILOT_ENABLED_PLUGINS_KEY]: { type: 'string' },
+			},
 		});
+	});
+
+	test('managed settings: native MDM value overrides the server value for the same declared key', async () => {
+		// MDM says 'disable', server says 'enable'. The merged, declaration-projected bag must
+		// let MDM win, so the gated policy resolves to `false`.
+		const copilotManagedSettingsService = disposables.add(new FakeCopilotManagedSettingsService({ [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' }));
+		policyService = disposables.add(new AccountPolicyService(logService, defaultAccountService, undefined, copilotManagedSettingsService));
+		const defaultConfiguration = disposables.add(new DefaultConfiguration(new NullLogService()));
+		await defaultConfiguration.initialize();
+		policyConfiguration = disposables.add(new PolicyConfiguration(defaultConfiguration, policyService, new NullLogService()));
+
+		const policyData: IPolicyData = { managedSettings: { [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'enable' } };
+		defaultAccountService.setDefaultAccountProvider(new DefaultAccountProvider(BASE_DEFAULT_ACCOUNT, policyData));
+		await defaultAccountService.refresh();
+
+		await policyConfiguration.initialize();
+
+		assert.strictEqual(policyService.getPolicyValue('PolicySettingF'), false);
+	});
+
+	test('managed settings: an object-typed setting resolves identically from server and native MDM JSON strings', async () => {
+		// Structured-setting invariant: whether the canonical JSON string arrives via the server
+		// account policy bag or via native MDM, PolicyConfiguration must parse it back into the
+		// SAME typed object for an `object`-typed setting. The only difference is the source.
+		const json = '{"assign-issue@skills":true,"other@acme":false}';
+		const expected = { 'assign-issue@skills': true, 'other@acme': false };
+
+		const resolveEnabledPlugins = async (source: { server?: string; mdm?: string }): Promise<unknown> => {
+			const accountService = disposables.add(new DefaultAccountService(TestProductService));
+			const copilotManagedSettingsService = disposables.add(new FakeCopilotManagedSettingsService(
+				source.mdm !== undefined ? { [COPILOT_ENABLED_PLUGINS_KEY]: source.mdm } : {},
+			));
+			const svc = disposables.add(new AccountPolicyService(logService, accountService, undefined, copilotManagedSettingsService));
+			const defaultConfiguration = disposables.add(new DefaultConfiguration(new NullLogService()));
+			await defaultConfiguration.initialize();
+			const config = disposables.add(new PolicyConfiguration(defaultConfiguration, svc, new NullLogService()));
+
+			const policyData: IPolicyData = source.server !== undefined
+				? { managedSettings: { [COPILOT_ENABLED_PLUGINS_KEY]: source.server } }
+				: {};
+			accountService.setDefaultAccountProvider(new DefaultAccountProvider(BASE_DEFAULT_ACCOUNT, policyData));
+			await accountService.refresh();
+			await config.initialize();
+			return config.configurationModel.getValue('setting.G');
+		};
+
+		const serverConfig = await resolveEnabledPlugins({ server: json });
+		const mdmConfig = await resolveEnabledPlugins({ mdm: json });
+
+		assert.deepStrictEqual({ serverConfig, mdmConfig }, { serverConfig: expected, mdmConfig: expected });
 	});
 
 	// ---------------------------------------------------------------------


### PR DESCRIPTION
Make `IPolicyData.managedSettings` the single channel for enterprise-managed Copilot settings so server-delivered and native MDM-delivered settings resolve identically — the only difference is the source.

- `adaptManagedSettings` now emits only the canonical `managedSettings` bag: scalars flatten to dot-paths; `enabledPlugins` / `extraKnownMarketplaces` are carried as canonical JSON strings (the same shape an admin authors via native MDM). `PolicyConfiguration` parses them back into the object-typed settings.
- `ChatEnabledPlugins` / `ChatExtraMarketplaces` / `ChatStrictMarketplaces` now read from `policyData.managedSettings` and declare their managed-setting keys; removed the typed `enabledPlugins` / `extraKnownMarketplaces` / `strictKnownMarketplaces` fields from `IPolicyData`.
- Relocate `extraKnownMarketplacesToConfigDict` to `base/common/managedSettings` for layering; re-export from the chat contrib.
- Tests: rewrite `adaptManagedSettings` assertions to the canonical bag; add an end-to-end equivalence test proving a server JSON string and a native MDM JSON string resolve to the identical typed object.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
