### PR TITLE
Kill and restart esbuild instances during watch mode

### DIFF
--- a/extensions/esbuild-common.mts
+++ b/extensions/esbuild-common.mts
@@ -38,20 +38,21 @@ export async function runBuild(
 
 	const isWatch = args.indexOf('--watch') >= 0;
 	if (isWatch) {
-		const ctx = await esbuild.context(resolvedOptions);
-		await watchWithParcel(ctx, config.srcDir, () => didBuild?.(outdir));
+		await watchWithParcel(resolvedOptions, config.srcDir, () => didBuild?.(outdir));
 	} else {
 		try {
 			await esbuild.build(resolvedOptions);
 			await didBuild?.(outdir);
 		} catch {
 			process.exit(1);
+		} finally {
+			esbuild.stop();
 		}
 	}
 }
 
 // We use @parcel/watcher as it has much lower cpu usage when idle compared to esbuild's watch mode
-async function watchWithParcel(ctx: esbuild.BuildContext, srcDir: string, didBuild?: () => Promise<unknown> | unknown): Promise<void> {
+async function watchWithParcel(options: esbuild.BuildOptions, srcDir: string, didBuild?: () => Promise<unknown> | unknown): Promise<void> {
 	let debounce: ReturnType<typeof setTimeout> | undefined;
 	const rebuild = () => {
 		if (debounce) {
@@ -59,13 +60,16 @@ async function watchWithParcel(ctx: esbuild.BuildContext, srcDir: string, didBui
 		}
 		debounce = setTimeout(async () => {
 			try {
-				await ctx.cancel();
-				const result = await ctx.rebuild();
+				// Also instead of retaining the esbuild context, we are re-running the entire build on each change.
+				// This reduces memory usage since most projects don't need to be re-built often.
+				const result = await esbuild.build(options);
 				if (result.errors.length === 0) {
 					await didBuild?.();
 				}
 			} catch (error) {
 				console.error('[watch] build error:', error);
+			} finally {
+				esbuild.stop();
 			}
 		}, 100);
 	};

--- a/extensions/esbuild-common.mts
+++ b/extensions/esbuild-common.mts
@@ -12,6 +12,22 @@ export interface RunConfig {
 	readonly additionalOptions?: Partial<esbuild.BuildOptions>;
 }
 
+// `esbuild.stop()` shuts down the single esbuild service shared by all concurrent builds, so we
+// must only call it once no builds are in flight. Otherwise a finishing build would tear down the
+// service while a sibling build (e.g. running in the same `Promise.all`) is still using it.
+let pendingBuilds = 0;
+
+async function buildOnce(options: esbuild.BuildOptions): Promise<esbuild.BuildResult> {
+	pendingBuilds++;
+	try {
+		return await esbuild.build(options);
+	} finally {
+		if (--pendingBuilds === 0) {
+			esbuild.stop();
+		}
+	}
+}
+
 /**
  * Shared build/watch runner for extension esbuild scripts.
  */
@@ -41,12 +57,10 @@ export async function runBuild(
 		await watchWithParcel(resolvedOptions, config.srcDir, () => didBuild?.(outdir));
 	} else {
 		try {
-			await esbuild.build(resolvedOptions);
+			await buildOnce(resolvedOptions);
 			await didBuild?.(outdir);
 		} catch {
 			process.exit(1);
-		} finally {
-			esbuild.stop();
 		}
 	}
 }
@@ -62,14 +76,12 @@ async function watchWithParcel(options: esbuild.BuildOptions, srcDir: string, di
 			try {
 				// Also instead of retaining the esbuild context, we are re-running the entire build on each change.
 				// This reduces memory usage since most projects don't need to be re-built often.
-				const result = await esbuild.build(options);
+				const result = await buildOnce(options);
 				if (result.errors.length === 0) {
 					await didBuild?.();
 				}
 			} catch (error) {
 				console.error('[watch] build error:', error);
-			} finally {
-				esbuild.stop();
 			}
 		}, 100);
 	};


### PR DESCRIPTION
Reduces memory usage since we don't need rebuilds all that often. Perf still is reasonable in for the full rebuild

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
