### PR TITLE
Fix Agents Window smoke test: use runCommand instead of keybinding

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -48,6 +48,7 @@ class NewChatInSessionsWindowAction extends Action2 {
 			id: NEW_SESSION_ACTION_ID,
 			title: localize2('chat.newEdits.label', "New Chat"),
 			category: CHAT_CATEGORY,
+			f1: true,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib + 2,
 				// Don't shadow Ctrl/Cmd+N (and Ctrl/Cmd+L) when focus is in the

--- a/test/automation/src/agentsWindow.ts
+++ b/test/automation/src/agentsWindow.ts
@@ -36,14 +36,15 @@ export class AgentsWindow {
 	}
 
 	/**
-	 * Start a new session from inside the Agents Window via the
-	 * `workbench.action.sessions.newChat` keybinding (Ctrl+L). The action
-	 * is not exposed in the command palette, so we drive it through its
-	 * key chord which works cross-platform (mac uses WinCtrl+L as the
-	 * secondary binding, which maps to plain Ctrl+L).
+	 * Start a new session from inside the Agents Window by executing
+	 * `workbench.action.sessions.newChat` via the command palette. We
+	 * avoid a raw keybinding dispatch because the action's Ctrl+L
+	 * binding is gated on `!editorAreaFocus`, which is false after
+	 * interacting with the chat editor.
 	 */
 	async startNewSession(): Promise<void> {
-		await this.code.dispatchKeybinding('ctrl+l', async () => this.waitForNewSessionView());
+		await this.quickaccess.runCommand('workbench.action.sessions.newChat');
+		await this.waitForNewSessionView();
 	}
 
 	/**


### PR DESCRIPTION
## Problem

The `NewChatInSessionsWindowAction` keybinding (`Ctrl+L`) is gated on `EditorAreaFocusContext.negate()`, meaning it only fires when focus is **not** in the editor area. After `warmUpClaudeModel` interacts with the chat editor (click → type → send), focus remains in the editor area, so the subsequent `ctrl+l` dispatch is silently ignored. This caused both "Test Claude session" and "Test Local session" smoke tests to time out waiting for `.sessions-chat-widget .new-chat-widget-container`.

## Fix

1. **Add `f1: true`** to `NewChatInSessionsWindowAction` so the command is accessible via the command palette (the action is only registered in the Agents Window context via `sessions.common.main.ts`)
2. **Change `startNewSession()`** in the smoke test automation to use `quickaccess.runCommand('workbench.action.sessions.newChat')` instead of `dispatchKeybinding('ctrl+l')`, bypassing the focus gate entirely

## Build reference

Investigated from [build 447362](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=447362) — macOS arm64 Electron smoke tests failed.