### PR TITLE
fix: Restrict continue comment to whitespace separated slashes

### DIFF
--- a/extensions/cpp/language-configuration.json
+++ b/extensions/cpp/language-configuration.json
@@ -117,12 +117,8 @@
 		},
 		// Add // when pressing enter from inside line comment
 		{
-			"beforeText": {
-				"pattern": "\/\/.*"
-			},
-			"afterText": {
-				"pattern": "^(?!\\s*$).+"
-			},
+			"beforeText": "^\\s*//|\\s//\\s",
+			"afterText": "^(?!\\s*$)",
 			"action": {
 				"indent": "none",
 				"appendText": "// "

--- a/extensions/csharp/language-configuration.json
+++ b/extensions/csharp/language-configuration.json
@@ -101,29 +101,22 @@
 		}
 	},
 	"onEnterRules": [
-		// Add // when pressing enter from inside line comment
-		// We do not want to match /// (a documentation comment)
-		{
-			"beforeText": {
-				"pattern": "[^\/]\/\/[^\/].*"
-			},
-			"afterText": {
-				"pattern": "^(?!\\s*$).+"
-			},
-			"action": {
-				"indent": "none",
-				"appendText": "// "
-			}
-		},
 		// Add /// when pressing enter from anywhere inside a documentation comment.
 		// Documentation comments are not valid after non-whitespace.
 		{
-			"beforeText": {
-				"pattern": "^\\s*\/\/\/"
-			},
+			"beforeText": "^\\s*\/\/\/",
 			"action": {
 				"indent": "none",
 				"appendText": "/// "
+			}
+		},
+		// Add // when pressing enter from inside line comment
+		{
+			"beforeText": "^\\s*//|\\s//\\s",
+			"afterText": "^(?!\\s*$)",
+			"action": {
+				"indent": "none",
+				"appendText": "// "
 			}
 		},
 	]

--- a/extensions/go/language-configuration.json
+++ b/extensions/go/language-configuration.json
@@ -95,12 +95,8 @@
 	"onEnterRules": [
 		// Add // when pressing enter from inside line comment
 		{
-			"beforeText": {
-				"pattern": "\/\/.*"
-			},
-			"afterText": {
-				"pattern": "^(?!\\s*$).+"
-			},
+			"beforeText": "^\\s*//|\\s//\\s",
+			"afterText": "^(?!\\s*$)",
 			"action": {
 				"indent": "none",
 				"appendText": "// "

--- a/extensions/groovy/language-configuration.json
+++ b/extensions/groovy/language-configuration.json
@@ -73,12 +73,8 @@
 	"onEnterRules": [
 		// Add // when pressing enter from inside line comment
 		{
-			"beforeText": {
-				"pattern": "\/\/.*"
-			},
-			"afterText": {
-				"pattern": "^(?!\\s*$).+"
-			},
+			"beforeText": "^\\s*//|\\s//\\s",
+			"afterText": "^(?!\\s*$)",
 			"action": {
 				"indent": "none",
 				"appendText": "// "

--- a/extensions/java/language-configuration.json
+++ b/extensions/java/language-configuration.json
@@ -157,12 +157,8 @@
 		},
 		// Add // when pressing enter from inside line comment
 		{
-			"beforeText": {
-				"pattern": "\/\/.*"
-			},
-			"afterText": {
-				"pattern": "^(?!\\s*$).+"
-			},
+			"beforeText": "^\\s*//|\\s//\\s",
+			"afterText": "^(?!\\s*$)",
 			"action": {
 				"indent": "none",
 				"appendText": "// "

--- a/extensions/javascript/javascript-language-configuration.json
+++ b/extensions/javascript/javascript-language-configuration.json
@@ -242,8 +242,8 @@
 		},
 		// Add // when pressing enter from inside line comment
 		{
-			"beforeText": "(?<!\\\\|\\w:)\/\/\\s*\\S",
-			"afterText": "^(?!\\s*$).+",
+			"beforeText": "^\\s*//|\\s//\\s",
+			"afterText": "^(?!\\s*$)",
 			"action": {
 				"indent": "none",
 				"appendText": "// "

--- a/extensions/json/language-configuration.json
+++ b/extensions/json/language-configuration.json
@@ -69,12 +69,8 @@
 	"onEnterRules": [
 		// Add // when pressing enter from inside line comment
 		{
-			"beforeText": {
-				"pattern": "\/\/.*"
-			},
-			"afterText": {
-				"pattern": "^(?!\\s*$).+"
-			},
+			"beforeText": "^\\s*//|\\s//\\s",
+			"afterText": "^(?!\\s*$)",
 			"action": {
 				"indent": "none",
 				"appendText": "// "

--- a/extensions/less/language-configuration.json
+++ b/extensions/less/language-configuration.json
@@ -98,12 +98,8 @@
 	"onEnterRules": [
 		// Add // when pressing enter from inside line comment
 		{
-			"beforeText": {
-				"pattern": "\/\/.*"
-			},
-			"afterText": {
-				"pattern": "^(?!\\s*$).+"
-			},
+			"beforeText": "^\\s*//|\\s//\\s",
+			"afterText": "^(?!\\s*$)",
 			"action": {
 				"indent": "none",
 				"appendText": "// "

--- a/extensions/objective-c/language-configuration.json
+++ b/extensions/objective-c/language-configuration.json
@@ -73,12 +73,8 @@
 	"onEnterRules": [
 		// Add // when pressing enter from inside line comment
 		{
-			"beforeText": {
-				"pattern": "\/\/.*"
-			},
-			"afterText": {
-				"pattern": "^(?!\\s*$).+"
-			},
+			"beforeText": "^\\s*//|\\s//\\s",
+			"afterText": "^(?!\\s*$)",
 			"action": {
 				"indent": "none",
 				"appendText": "// "

--- a/extensions/php/language-configuration.json
+++ b/extensions/php/language-configuration.json
@@ -159,12 +159,8 @@
 		},
 		// Add // when pressing enter from inside line comment
 		{
-			"beforeText": {
-				"pattern": "\/\/.*"
-			},
-			"afterText": {
-				"pattern": "^(?!\\s*$).+"
-			},
+			"beforeText": "^\\s*//|\\s//\\s",
+			"afterText": "^(?!\\s*$)",
 			"action": {
 				"indent": "none",
 				"appendText": "// "

--- a/extensions/rust/language-configuration.json
+++ b/extensions/rust/language-configuration.json
@@ -76,12 +76,8 @@
 	"onEnterRules": [
 		// Add // when pressing enter from inside line comment
 		{
-			"beforeText": {
-				"pattern": "\/\/.*"
-			},
-			"afterText": {
-				"pattern": "^(?!\\s*$).+"
-			},
+			"beforeText": "^\\s*//|\\s//\\s",
+			"afterText": "^(?!\\s*$)",
 			"action": {
 				"indent": "none",
 				"appendText": "// "

--- a/extensions/swift/language-configuration.json
+++ b/extensions/swift/language-configuration.json
@@ -84,12 +84,8 @@
 	"onEnterRules": [
 		// Add // when pressing enter from inside line comment
 		{
-			"beforeText": {
-				"pattern": "\/\/.*"
-			},
-			"afterText": {
-				"pattern": "^(?!\\s*$).+"
-			},
+			"beforeText": "^\\s*//|\\s//\\s",
+			"afterText": "^(?!\\s*$)",
 			"action": {
 				"indent": "none",
 				"appendText": "// "

--- a/extensions/typescript-basics/language-configuration.json
+++ b/extensions/typescript-basics/language-configuration.json
@@ -260,8 +260,8 @@
 		},
 		// Add // when pressing enter from inside line comment
 		{
-			"beforeText": "(?<!\\\\|\\w:)\/\/\\s*\\S",
-			"afterText": "^(?!\\s*$).+",
+			"beforeText": "^\\s*//|\\s//\\s",
+			"afterText": "^(?!\\s*$)",
 			"action": {
 				"indent": "none",
 				"appendText": "// "


### PR DESCRIPTION
fixes #298057

comments now must take up an entire line 
OR
be surrounded with at least one whitespace before and after 

cc @aiday-mar 