### PR TITLE
fix: re-add copy button after hover verbosity update

### DIFF
--- a/src/vs/editor/contrib/hover/browser/contentHoverRendered.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHoverRendered.ts
@@ -415,6 +415,15 @@ class RenderedContentHoverParts extends Disposable {
 				hoverPart: renderedPart.hoverPart,
 				hoverElement: renderedPart.hoverElement,
 			};
+			// Re-add copy button to the new element after verbosity update
+			if (renderedPart.hoverElement) {
+				this._register(new HoverCopyButton(
+					renderedPart.hoverElement,
+					() => this._markdownHoverParticipant.getAccessibleContent(renderedPart.hoverPart),
+					this._clipboardService,
+					this._hoverService
+				));
+			}
 		}
 		if (focus) {
 			if (index >= 0) {


### PR DESCRIPTION
Fixes #321171

When updating hover verbosity level, the copy button was not being re-added to the new element. This fix ensures the copy button is preserved after verbosity changes.

## Changes
- Add HoverCopyButton to new element in updateHoverVerbosityLevel()
- Maintain consistent behavior with initial rendering

## Root Cause
In `contentHoverRendered.ts`, the `updateHoverVerbosityLevel` method replaces `this._renderedParts[i]` with new content (lines 412-417), but the new element does NOT get a `HoverCopyButton` added.

The `HoverCopyButton` is only added during initial rendering (lines 336-343), but when verbosity is updated, the hover element is recreated without the copy button.

## Fix
After replacing the rendered part in `updateHoverVerbosityLevel`, we now add a `HoverCopyButton` to the new element, maintaining consistent behavior with the initial rendering.

## Testing
1. Open VS Code
2. Hover over a variable with type information
3. Click the verbosity button to increase verbosity
4. Verify the copy button is still visible
5. Click the copy button to verify it works

## Risk Assessment
- **Risk Level**: Low
- **Scope**: Small, focused change (9 lines added)
- **Backward Compatibility**: Yes, no API changes
- **Testing**: Manual testing sufficient for UI fix