### PR TITLE
Prevent symbol tool file paths from escaping the working directory

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/tools/renameTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/renameTool.ts
@@ -23,7 +23,7 @@ import { IChatService } from '../../common/chatService/chatService.js';
 import { ChatModel } from '../../common/model/chatModel.js';
 import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress } from '../../common/tools/languageModelToolsService.js';
 import { createToolSimpleTextResult } from '../../common/tools/builtinTools/toolHelpers.js';
-import { errorResult, findLineNumber, findSymbolColumn, ISymbolToolInput, resolveToolUri } from './toolHelpers.js';
+import { errorResult, findLineNumber, findSymbolColumn, ISymbolToolInput, resolveSymbolToolFileUri } from './toolHelpers.js';
 
 export const RenameToolId = 'vscode_renameSymbol';
 
@@ -122,7 +122,7 @@ export class RenameTool extends Disposable implements IToolImpl {
 		const input = invocation.parameters as IRenameToolInput;
 
 		// --- resolve URI ---
-		const uri = resolveToolUri(input, this._workspaceContextService, invocation.context?.workingDirectory);
+		const uri = resolveSymbolToolFileUri(input, this._workspaceContextService, invocation.context?.workingDirectory);
 		if (!uri) {
 			return errorResult('Provide either "uri" (a full URI) or "filePath" (a workspace-relative path) to identify the file.');
 		}

--- a/src/vs/workbench/contrib/chat/browser/tools/toolHelpers.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/toolHelpers.ts
@@ -27,8 +27,12 @@ export interface ISymbolToolInput {
  * Resolves a URI from tool input. Accepts either a full URI string or a
  * workspace-relative file path. When a {@link workingDirectory} is provided
  * (agents window), relative paths are resolved against it first.
+ *
+ * Relative paths that escape the resolution base directory via parent-directory
+ * segments (e.g. `../outside.ts`) are rejected and `undefined` is returned, so a
+ * `filePath` cannot traverse out of the working directory boundary.
  */
-export function resolveToolUri(input: ISymbolToolInput, workspaceContextService: IWorkspaceContextService, workingDirectory?: URI): URI | undefined {
+export function resolveSymbolToolFileUri(input: ISymbolToolInput, workspaceContextService: IWorkspaceContextService, workingDirectory?: URI): URI | undefined {
 	if (input.uri) {
 		return URI.parse(input.uri);
 	}

--- a/src/vs/workbench/contrib/chat/browser/tools/usagesTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/usagesTool.ts
@@ -25,7 +25,7 @@ import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { ISearchService, QueryType, resultIsMatch } from '../../../../services/search/common/search.js';
 import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress, } from '../../common/tools/languageModelToolsService.js';
 import { createToolSimpleTextResult } from '../../common/tools/builtinTools/toolHelpers.js';
-import { errorResult, findLineNumber, findSymbolColumn, ISymbolToolInput, resolveToolUri } from './toolHelpers.js';
+import { errorResult, findLineNumber, findSymbolColumn, ISymbolToolInput, resolveSymbolToolFileUri } from './toolHelpers.js';
 
 export const UsagesToolId = 'vscode_listCodeUsages';
 
@@ -115,7 +115,7 @@ export class UsagesTool extends Disposable implements IToolImpl {
 		const input = invocation.parameters as ISymbolToolInput;
 
 		// --- resolve URI ---
-		const uri = resolveToolUri(input, this._workspaceContextService, invocation.context?.workingDirectory);
+		const uri = resolveSymbolToolFileUri(input, this._workspaceContextService, invocation.context?.workingDirectory);
 		if (!uri) {
 			return errorResult('Provide either "uri" (a full URI) or "filePath" (a workspace-relative path) to identify the file.');
 		}

--- a/src/vs/workbench/contrib/chat/common/workingDirectory.ts
+++ b/src/vs/workbench/contrib/chat/common/workingDirectory.ts
@@ -49,15 +49,21 @@ export class WorkingDirectory {
 	 * Resolves a workspace-relative file path to a URI.
 	 * When a working directory is set, resolves against it.
 	 * Otherwise resolves against the first workspace folder.
+	 *
+	 * The resolved URI is guaranteed to stay within the base directory: a
+	 * `filePath` containing parent-directory segments (e.g. `../outside.ts`)
+	 * that escapes the base directory is rejected and `undefined` is returned.
+	 * This prevents path traversal out of the working directory boundary.
 	 */
 	resolveRelativePath(filePath: string): URI | undefined {
-		if (this._uri) {
-			return joinPath(this._uri, filePath);
+		const base = this._uri ?? this._workspaceContextService.getWorkspace().folders.at(0)?.uri;
+		if (!base) {
+			return undefined;
 		}
-		const folders = this._workspaceContextService.getWorkspace().folders;
-		if (folders.length > 0) {
-			return folders[0].toResource(filePath);
+		const resolved = joinPath(base, filePath);
+		if (!extUriBiasedIgnorePathCase.isEqualOrParent(resolved, base)) {
+			return undefined;
 		}
-		return undefined;
+		return resolved;
 	}
 }

--- a/src/vs/workbench/contrib/chat/test/browser/tools/renameTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/renameTool.test.ts
@@ -315,6 +315,38 @@ suite('RenameTool', () => {
 			assert.ok(getTextContent(result).includes('Renamed'));
 		});
 
+		test('rejects filePath that escapes the session working directory', async () => {
+			const outsideUri = URI.parse('file:///outside.ts');
+			const outsideModel = disposables.add(createTextModel('const OutsideSecretMarker = 1;', 'typescript', undefined, outsideUri));
+			const requestedUris: URI[] = [];
+			const textModelService = {
+				_serviceBrand: undefined,
+				createModelReference: async (uri: URI) => {
+					requestedUris.push(uri);
+					return { object: { textEditorModel: outsideModel }, dispose: () => { } };
+				},
+				registerTextModelContentProvider: () => ({ dispose: () => { } }),
+				canHandleResource: () => false,
+			} as unknown as ITextModelService;
+			disposables.add(langFeatures.renameProvider.register('typescript', {
+				provideRenameEdits: (): WorkspaceEdit & Rejection => ({ edits: [makeEdit(outsideUri, new Range(1, 7, 1, 26), 'RenamedSecretMarker')] }),
+			}));
+
+			const bulkEditService = createMockBulkEditService();
+			const tool = disposables.add(createTool(textModelService, { bulkEditService }));
+			const result = await tool.invoke(
+				{
+					parameters: { symbol: 'OutsideSecretMarker', newName: 'RenamedSecretMarker', filePath: '../outside.ts', lineContent: 'const OutsideSecretMarker = 1;' },
+					context: { workingDirectory: URI.parse('file:///session-dir') },
+				} as unknown as IToolInvocation,
+				noopCountTokens, noopProgress, CancellationToken.None
+			);
+
+			assert.ok(getTextContent(result).includes('Provide either'));
+			assert.strictEqual(requestedUris.length, 0);
+			assert.strictEqual(bulkEditService.appliedEdits.length, 0);
+		});
+
 		test('result includes toolResultMessage', async () => {
 			const model = disposables.add(createTextModel(testContent, 'typescript', undefined, testUri));
 			const edits = [

--- a/src/vs/workbench/contrib/chat/test/browser/tools/toolHelpers.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/toolHelpers.test.ts
@@ -9,7 +9,7 @@ import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../pl
 import { createTextModel } from '../../../../../../editor/test/common/testTextModel.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
-import { resolveToolUri, findLineNumber, findSymbolColumn, errorResult, getChatPermissionLevelForToolInvocation, getSandboxPrecheckInputsForToolInvocation } from '../../../browser/tools/toolHelpers.js';
+import { resolveSymbolToolFileUri, findLineNumber, findSymbolColumn, errorResult, getChatPermissionLevelForToolInvocation, getSandboxPrecheckInputsForToolInvocation } from '../../../browser/tools/toolHelpers.js';
 import type { IChatService } from '../../../common/chatService/chatService.js';
 import { ChatPermissionLevel } from '../../../common/constants.js';
 import type { IChatWidgetService } from '../../../browser/chat.js';
@@ -56,51 +56,78 @@ suite('Tool Helpers', () => {
 		} as unknown as IChatWidgetService;
 	}
 
-	suite('resolveToolUri', () => {
+	suite('resolveSymbolToolFileUri', () => {
 
 		test('resolves full URI string', () => {
 			const ws = createMockWorkspaceService();
-			const result = resolveToolUri({ symbol: 'x', lineContent: 'x', uri: 'file:///test/file.ts' }, ws);
+			const result = resolveSymbolToolFileUri({ symbol: 'x', lineContent: 'x', uri: 'file:///test/file.ts' }, ws);
 			assert.strictEqual(result?.toString(), 'file:///test/file.ts');
 		});
 
 		test('resolves workspace-relative filePath', () => {
 			const ws = createMockWorkspaceService(URI.parse('file:///project'));
-			const result = resolveToolUri({ symbol: 'x', lineContent: 'x', filePath: 'src/index.ts' }, ws);
+			const result = resolveSymbolToolFileUri({ symbol: 'x', lineContent: 'x', filePath: 'src/index.ts' }, ws);
 			assert.strictEqual(result?.toString(), 'file:///project/src/index.ts');
 		});
 
 		test('prefers uri over filePath', () => {
 			const ws = createMockWorkspaceService();
-			const result = resolveToolUri({ symbol: 'x', lineContent: 'x', uri: 'file:///explicit.ts', filePath: 'other.ts' }, ws);
+			const result = resolveSymbolToolFileUri({ symbol: 'x', lineContent: 'x', uri: 'file:///explicit.ts', filePath: 'other.ts' }, ws);
 			assert.strictEqual(result?.toString(), 'file:///explicit.ts');
 		});
 
 		test('returns undefined when neither provided', () => {
 			const ws = createMockWorkspaceService();
-			const result = resolveToolUri({ symbol: 'x', lineContent: 'x' }, ws);
+			const result = resolveSymbolToolFileUri({ symbol: 'x', lineContent: 'x' }, ws);
 			assert.strictEqual(result, undefined);
 		});
 
 		test('resolves filePath against workingDirectory when provided', () => {
 			const ws = createMockWorkspaceService(URI.parse('file:///other-workspace'));
 			const workingDirectory = URI.parse('file:///session-dir');
-			const result = resolveToolUri({ symbol: 'x', lineContent: 'x', filePath: 'src/index.ts' }, ws, workingDirectory);
+			const result = resolveSymbolToolFileUri({ symbol: 'x', lineContent: 'x', filePath: 'src/index.ts' }, ws, workingDirectory);
 			assert.strictEqual(result?.toString(), 'file:///session-dir/src/index.ts');
 		});
 
 		test('workingDirectory takes precedence over workspace folders', () => {
 			const ws = createMockWorkspaceService(URI.parse('file:///workspace'));
 			const workingDirectory = URI.parse('file:///my-project');
-			const result = resolveToolUri({ symbol: 'x', lineContent: 'x', filePath: 'file.ts' }, ws, workingDirectory);
+			const result = resolveSymbolToolFileUri({ symbol: 'x', lineContent: 'x', filePath: 'file.ts' }, ws, workingDirectory);
 			assert.strictEqual(result?.toString(), 'file:///my-project/file.ts');
 		});
 
 		test('uri field ignores workingDirectory', () => {
 			const ws = createMockWorkspaceService();
 			const workingDirectory = URI.parse('file:///session-dir');
-			const result = resolveToolUri({ symbol: 'x', lineContent: 'x', uri: 'file:///absolute/path.ts' }, ws, workingDirectory);
+			const result = resolveSymbolToolFileUri({ symbol: 'x', lineContent: 'x', uri: 'file:///absolute/path.ts' }, ws, workingDirectory);
 			assert.strictEqual(result?.toString(), 'file:///absolute/path.ts');
+		});
+
+		test('rejects filePath that escapes the workingDirectory via parent segments', () => {
+			const ws = createMockWorkspaceService(URI.parse('file:///workspace'));
+			const workingDirectory = URI.parse('file:///my-project');
+			const result = resolveSymbolToolFileUri({ symbol: 'x', lineContent: 'x', filePath: '../outside.ts' }, ws, workingDirectory);
+			assert.strictEqual(result, undefined);
+		});
+
+		test('rejects filePath that escapes the workingDirectory via nested parent segments', () => {
+			const ws = createMockWorkspaceService(URI.parse('file:///workspace'));
+			const workingDirectory = URI.parse('file:///my-project');
+			const result = resolveSymbolToolFileUri({ symbol: 'x', lineContent: 'x', filePath: 'src/../../outside.ts' }, ws, workingDirectory);
+			assert.strictEqual(result, undefined);
+		});
+
+		test('allows filePath with interior parent segments that stays within the workingDirectory', () => {
+			const ws = createMockWorkspaceService(URI.parse('file:///workspace'));
+			const workingDirectory = URI.parse('file:///my-project');
+			const result = resolveSymbolToolFileUri({ symbol: 'x', lineContent: 'x', filePath: 'src/../file.ts' }, ws, workingDirectory);
+			assert.strictEqual(result?.toString(), 'file:///my-project/file.ts');
+		});
+
+		test('rejects filePath that escapes the workspace folder via parent segments', () => {
+			const ws = createMockWorkspaceService(URI.parse('file:///project/sub'));
+			const result = resolveSymbolToolFileUri({ symbol: 'x', lineContent: 'x', filePath: '../../outside.ts' }, ws);
+			assert.strictEqual(result, undefined);
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/browser/tools/usagesTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/usagesTool.test.ts
@@ -326,5 +326,40 @@ suite('UsagesTool', () => {
 
 			assert.ok(getTextContent(result).includes('1 usages'));
 		});
+
+		test('rejects filePath that escapes the session working directory', async () => {
+			const outsideUri = URI.parse('file:///outside.ts');
+			const outsideContent = 'export const OutsideSecretMarker = 1;';
+			const outsideModel = disposables.add(createTextModel(outsideContent, 'typescript', undefined, outsideUri));
+			const requestedUris: URI[] = [];
+			const textModelService = {
+				_serviceBrand: undefined,
+				createModelReference: async (uri: URI) => {
+					requestedUris.push(uri);
+					return { object: { textEditorModel: outsideModel }, dispose: () => { } };
+				},
+				registerTextModelContentProvider: () => ({ dispose: () => { } }),
+				canHandleResource: () => false,
+			} as unknown as ITextModelService;
+			disposables.add(langFeatures.referenceProvider.register('typescript', {
+				provideReferences: (): Location[] => [
+					{ uri: outsideUri, range: new Range(1, 14, 1, 33) },
+				]
+			}));
+
+			const tool = disposables.add(createTool(textModelService, createMockWorkspaceService(), { modelService: createMockModelService([outsideModel]) }));
+			const result = await tool.invoke(
+				{
+					parameters: { symbol: 'OutsideSecretMarker', filePath: '../outside.ts', lineContent: outsideContent },
+					context: { workingDirectory: URI.parse('file:///session-dir') },
+				} as unknown as IToolInvocation,
+				noopCountTokens, noopProgress, CancellationToken.None
+			);
+
+			const text = getTextContent(result);
+			assert.ok(text.includes('Provide either'));
+			assert.ok(!text.includes(outsideContent));
+			assert.strictEqual(requestedUris.length, 0);
+		});
 	});
 });


### PR DESCRIPTION
## Summary

`WorkingDirectory.resolveRelativePath` joined a relative `filePath` against the base directory (the session working directory, or the first workspace folder as a fallback) without any containment check. As a result, a `filePath` containing parent-directory segments (e.g. `../outside.ts`) could resolve to a URI **outside** the base directory.

This change normalizes the resolved URI and rejects it when it is not equal to or contained within the base directory, returning `undefined`. The symbol tools (`vscode_renameSymbol`, `vscode_listCodeUsages`) already treat an unresolved path as an input error, so they now short-circuit before opening or editing any file.

Explicit full `uri` inputs are unchanged — that remains a deliberate full-URI path that bypasses the working-directory base.

## Changes

- `workingDirectory.ts`: `resolveRelativePath` now validates containment via `extUriBiasedIgnorePathCase.isEqualOrParent` and returns `undefined` for paths that escape the base directory.
- Renamed `resolveToolUri` → `resolveSymbolToolFileUri` to better describe that it resolves the file URI referenced by a symbol tool input.
- Added regression tests in `toolHelpers.test.ts`, `renameTool.test.ts`, and `usagesTool.test.ts`.

## Testing

- `npm run compile-check-ts-native` — clean
- Unit tests: `Tool Helpers`, `RenameTool`, `UsagesTool` — 58 passing