### PR TITLE
server: improve error logging for remote extension host startup

### DIFF
--- a/src/vs/server/node/extensionHostConnection.ts
+++ b/src/vs/server/node/extensionHostConnection.ts
@@ -257,6 +257,8 @@ export class ExtensionHostConnection extends Disposable {
 				];
 			}
 
+			this._log(`Starting extension host process...`);
+
 			const env = await buildUserEnvironment(startParams.env, true, startParams.language, this._environmentService, this._logService, this._configurationService);
 			removeDangerousEnvVariables(env);
 
@@ -329,10 +331,9 @@ export class ExtensionHostConnection extends Disposable {
 			}
 
 		} catch (error) {
-			console.error('ExtensionHostConnection errored');
-			if (error) {
-				console.error(error);
-			}
+			this._logError(`Failed to start extension host process`);
+			this._logService.error(error);
+			this._cleanResources();
 		}
 	}
 

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -481,7 +481,9 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 					delete this._extHostConnections[reconnectionToken];
 					this._extHostLifetimeTokens.deleteAndDispose(reconnectionToken);
 				});
-				con.start(startParams);
+				con.start(startParams).catch(error => {
+					this._logService.error(`${logPrefix} Failed to start extension host connection:`, error);
+				});
 			}
 
 		} else if (msg.desiredConnectionType === ConnectionType.Tunnel) {


### PR DESCRIPTION
## Problem

When the remote extension host fails to start during smoke tests, there are **no error logs** in the uploaded artifacts explaining what went wrong. This makes flaky CI failures like [this one](https://github.com/microsoft/vscode/actions/runs/27449543414/job/81141750553?pr=321226) very hard to diagnose.

Investigation of the smoke test artifacts showed:
- The renderer successfully established the socket connection to the server
- The server received the `ManagementConnection` but never created the `ExtensionHostConnection`
- No error was logged on either side — the test just timed out after 30s waiting for the status bar to change from "Opening Remote..."

## Root Cause

Two issues in the error handling:

1. **`ExtensionHostConnection.start()`** caught errors with `console.error` instead of `_logService`, so failures never appeared in `remoteagent.log` (the artifact that gets uploaded). It also didn't call `_cleanResources()` on failure.

2. **`RemoteExtensionHostAgentServer`** called `con.start(startParams)` without awaiting or catching — a fire-and-forget async call. If `start()` rejected, it was an unhandled promise rejection with no logging.

## Changes

- **`extensionHostConnection.ts`**: Replace `console.error` with `_logError()` + `_logService.error()` in the catch block, and call `_cleanResources()` to properly tear down on failure. Added a `Starting extension host process...` log line to confirm `start()` was entered.
- **`remoteExtensionHostAgentServer.ts`**: Add `.catch()` handler to the `con.start()` call so promise rejections are logged via `_logService`.

With these changes, future failures will show clear error messages in the `remoteagent.log` artifact.