### PR TITLE
ci: pin chat-lib tests to windows-2022

### DIFF
--- a/.github/workflows/chat-lib-package.yml
+++ b/.github/workflows/chat-lib-package.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2022]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem

The `chat-lib tests (windows-latest)` job started failing at the **Extract chat-lib** step (`npm ci` in `extensions/copilot`), e.g. [run 27461488041](https://github.com/microsoft/vscode/actions/runs/27461488041/job/81176049178).

`npm ci` builds the native `sqlite3@5.1.7` module — a transitive dependency of the `@keyv/sqlite` devDependency — via `prebuild-install -r napi || node-gyp rebuild`. `prebuild-install` finds no matching prebuilt, so it falls back to `node-gyp`, which fails because the GitHub-hosted `windows-latest` label now resolves to the **Windows Server 2025 + Visual Studio 2026** image, whose VS 18 toolchain the node-gyp used during install cannot detect:

```
gyp ERR! find VS unknown version "undefined" found at "...\Microsoft Visual Studio\18\Enterprise"
gyp ERR! find VS could not find a version of Visual Studio 2017 or newer to use
```

## Why only this job

This was the only `npm ci` job exposed to the new image:
- Every other **Windows** `npm ci` job runs on self-hosted pools pinned to `windows-2022` (still VS 2022) — e.g. `pr-win32-test.yml`, `pr-node-modules.yml`.
- All other **copilot** `npm ci` jobs run on Linux/macOS.

`chat-lib-package.yml` was the only workflow using the `windows-latest` label.

## Fix

Pin the matrix entry to `windows-2022`, matching the rest of the repo and the runner-images migration notice ([actions/runner-images#14017](https://github.com/actions/runner-images/issues/14017)).