### PR TITLE
build: add diagnostics to Copilot VSIX download poller

### DIFF
--- a/build/azure-pipelines/common/downloadCopilotVsix.ts
+++ b/build/azure-pipelines/common/downloadCopilotVsix.ts
@@ -15,13 +15,43 @@ import { retry } from './retry.ts';
 const ARTIFACT_NAME = 'copilot_vsix';
 const COPILOT_JOB_NAME = 'Copilot';
 
+interface TimelineRecord {
+	readonly name: string;
+	readonly type: string;
+	readonly state: string;
+	readonly result: string;
+}
+
 interface Timeline {
-	readonly records: {
-		readonly name: string;
-		readonly type: string;
-		readonly state: string;
-		readonly result: string;
-	}[];
+	readonly records: TimelineRecord[];
+}
+
+function log(message: string): void {
+	console.log(`[${new Date().toISOString()}] ${message}`);
+}
+
+/**
+ * Installs process-level diagnostic handlers so that, when this script runs detached
+ * via `deemon`, an abnormal termination still leaves a trace in the captured output.
+ * Without these, a crash or a received signal can surface only as an opaque daemon
+ * exit code (e.g. `0xDEAD`) with no indication of the cause.
+ */
+function installDiagnostics(): void {
+	process.on('uncaughtException', err => {
+		console.error('[downloadCopilotVsix] Uncaught exception:', err);
+		process.exit(1);
+	});
+	process.on('unhandledRejection', reason => {
+		console.error('[downloadCopilotVsix] Unhandled rejection:', reason);
+		process.exit(1);
+	});
+	for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGBREAK'] as const) {
+		process.on(signal, () => {
+			console.error(`[downloadCopilotVsix] Received ${signal}, exiting.`);
+			process.exit(1);
+		});
+	}
+	process.on('exit', code => log(`Process exiting with code ${code}.`));
 }
 
 function getAzdoFetchOptions() {
@@ -45,21 +75,9 @@ async function getPipelineTimeline(): Promise<Timeline> {
 	return await requestAZDOAPI<Timeline>('timeline');
 }
 
-async function checkCopilotJobFailed(): Promise<boolean> {
-	try {
-		const timeline = await retry(() => getPipelineTimeline());
-		const copilotJob = timeline.records.find(
-			r => r.type === 'Job' && r.name === COPILOT_JOB_NAME
-		);
-
-		if (copilotJob && copilotJob.state === 'completed' && copilotJob.result !== 'succeeded' && copilotJob.result !== 'succeededWithIssues') {
-			return true;
-		}
-	} catch (err) {
-		console.error(`WARNING: Failed to check Copilot job status: ${err}`);
-	}
-
-	return false;
+async function getCopilotJob(): Promise<TimelineRecord | undefined> {
+	const timeline = await retry(() => getPipelineTimeline());
+	return timeline.records.find(r => r.type === 'Job' && r.name === COPILOT_JOB_NAME);
 }
 
 async function downloadArtifact(artifact: Artifact, downloadPath: string): Promise<void> {
@@ -120,25 +138,37 @@ async function unzip(zipPath: string, outputPath: string): Promise<string[]> {
 }
 
 async function waitForArtifact(): Promise<Artifact> {
-	for (let index = 0; index < 60; index++) {
-		try {
-			console.log(`Waiting for Copilot VSIX artifact to be uploaded (${index + 1}/60)...`);
+	const startTime = Date.now();
 
-			// Check if the Copilot job failed
-			const failed = await checkCopilotJobFailed();
-			if (failed) {
-				throw new Error('Copilot job failed. Aborting.');
+	for (let index = 0; index < 60; index++) {
+		const elapsed = Math.round((Date.now() - startTime) / 1000);
+
+		try {
+			log(`Waiting for Copilot VSIX artifact to be uploaded (attempt ${index + 1}/60, ${elapsed}s elapsed)...`);
+
+			// Check the Copilot job status so we can abort early if it failed
+			log('  * Checking Copilot job status...');
+			const copilotJob = await getCopilotJob();
+			if (copilotJob) {
+				log(`  * Copilot job status: state=${copilotJob.state}, result=${copilotJob.result ?? 'n/a'}`);
+				if (copilotJob.state === 'completed' && copilotJob.result !== 'succeeded' && copilotJob.result !== 'succeededWithIssues') {
+					throw new Error(`Copilot job failed (result=${copilotJob.result}). Aborting.`);
+				}
+			} else {
+				log('  * Copilot job not found in timeline yet');
 			}
 
+			log('  * Fetching pipeline artifacts...');
 			const allArtifacts = await retry(() => getPipelineArtifacts());
-			const artifact = allArtifacts.find(a => a.name === ARTIFACT_NAME);
+			log(`  * Found ${allArtifacts.length} artifact(s): ${allArtifacts.map(a => a.name).join(', ') || '(none)'}`);
 
+			const artifact = allArtifacts.find(a => a.name === ARTIFACT_NAME);
 			if (artifact) {
-				console.log('  * Copilot VSIX artifact found');
+				log('  * Copilot VSIX artifact found');
 				return artifact;
 			}
 
-			console.log('  * Not found yet, waiting...');
+			log('  * Not found yet, waiting 30s...');
 		} catch (err) {
 			if (err instanceof Error && err.message.includes('Copilot job failed')) {
 				throw err;
@@ -153,9 +183,11 @@ async function waitForArtifact(): Promise<Artifact> {
 }
 
 async function main(): Promise<void> {
+	installDiagnostics();
+
 	const outputDir = path.resolve('.build/extensions/copilot');
 
-	console.log('Waiting for Copilot VSIX artifact...');
+	log('Waiting for Copilot VSIX artifact...');
 	const artifact = await waitForArtifact();
 
 	// Download the artifact (a zip containing the VSIX)
@@ -218,6 +250,6 @@ function copyDirSync(src: string, dest: string): void {
 }
 
 main().catch(err => {
-	console.error(err);
+	console.error('[downloadCopilotVsix] Fatal error:', err);
 	process.exitCode = 1;
 });


### PR DESCRIPTION
## Why

While investigating a Windows CI failure ([build 447506](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=447506)), the `Download Copilot VSIX` step failed with only:

```
Waiting for Copilot VSIX artifact to be uploaded (1/60)...
[deemon] Daemon was stopped when client attached (exit code 57005, signal null).
[deemon] Build daemon exited with code 173
```

The background poller (`downloadCopilotVsix.ts`, run detached via `deemon`) died **mid-first-iteration** with exit code `57005` (`0xDEAD`) and produced no further output — no stack, no signal, no indication of which step was in flight. (`deemon` relays the exit code as a single byte, so `0xDEAD & 0xFF = 173`.) That left us with nothing actionable to diagnose the root cause.

## What changed

`build/azure-pipelines/common/downloadCopilotVsix.ts`:

- **Process-level diagnostics** (`installDiagnostics`): handlers for `uncaughtException`, `unhandledRejection`, termination signals (`SIGINT/SIGTERM/SIGHUP/SIGBREAK`), and `exit`, so abnormal terminations leave a trace instead of an opaque daemon exit code.
- **Granular, timestamped progress logging** in the poll loop: logs the Copilot job `state`/`result`, the artifacts seen each attempt, and elapsed wall-clock time. A future failure will now show exactly which network call was in progress when the process stopped.
- Clearer fatal-error and abort messages (include the actual Copilot job `result`).

No behavioral change to the download/extract logic.

## Notes for reviewers

- The original death (`0xDEAD`, `signal null`) looks like an external `TerminateProcess`, which Node signal handlers cannot intercept — but the new step-by-step logging will pinpoint where/when it stops, which is the clue we lacked.
- Typecheck (`npm run typecheck` in `build/`) and ESLint pass; the script still loads/runs (exits on missing env locally, as expected).
- The sibling `waitForArtifacts.ts` uses the same `deemon` pattern and could get the same treatment in a follow-up.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>