### PR TITLE
Add agent instructions for opaque editor background and decorations

### DIFF
--- a/.github/instructions/best-practices.instructions.md
+++ b/.github/instructions/best-practices.instructions.md
@@ -23,3 +23,8 @@ applyTo: src/vs/**
 
 - Don't hardcode URI scheme strings like `'file'`, `'untitled'`, or `'vscode-remote'`. Use the `Schemas` constants from `vs/base/common/network.ts` (e.g. `Schemas.file`, `Schemas.untitled`, `Schemas.vscodeRemote`).
 - Don't compare URIs with `===` or `uri.toString()`. Use the comparison utilities from `vs/base/common/resources.ts`: `isEqual` for equality, `isEqualOrParent` for containment, and `getComparisonKey` when a URI is used as a map/set key. These handle path-case sensitivity and fragment/authority correctly. When you need explicit control over case sensitivity, use an `ExtUri` instance (`extUri`, `extUriIgnorePathCase`, or `extUriBiasedIgnorePathCase`) instead of the bound helpers.
+
+## Editor Decorations
+
+- For editor highlights, use a regular editor decoration with an `inlineClassName` or `className` plus a CSS rule.
+- `ICodeEditorService.registerDecorationType` / `setDecorationsByType` is reserved for the extension host API and should be avoided at all cost.

--- a/.github/instructions/design-tokens.instructions.md
+++ b/.github/instructions/design-tokens.instructions.md
@@ -164,3 +164,13 @@ width of 1px should use the token.
 
 Applies to the `border: 1px solid <color>` shorthand and `border-width: 1px`.
 Other widths have no token — leave them as-is.
+
+## `.monaco-editor-background` must be opaque
+
+`.monaco-editor-background` must use a fully opaque color — making it
+`transparent` (or any partial alpha) is forbidden. Monaco reuses this layer to
+carve the reverse-rounded notches out of text selections, so a non-opaque
+background introduces subtle rendering bugs (blocky selection corners) and
+performance problems. To blend an embedded editor into its surface, keep
+`.monaco-editor` transparent and paint `.monaco-editor-background` with the
+container's solid background color.


### PR DESCRIPTION
Follow-up to #320913. Captures the two antipatterns fixed there as scoped agent instructions so AI agents avoid them up front and Copilot Code Reviews flag them in future PRs.

### Changes

- **`design-tokens.instructions.md`** (`applyTo: src/vs/**/*.css`): `.monaco-editor-background` must be a fully opaque color — making it `transparent` (or any partial alpha) is forbidden because Monaco reuses that layer to carve the reverse-rounded selection notches, causing subtle rendering bugs (blocky selection corners) and performance problems.
- **`best-practices.instructions.md`** (`applyTo: src/vs/**`): editor highlights should use a regular decoration with `inlineClassName`/`className` + CSS; `registerDecorationType`/`setDecorationsByType` is reserved for the extension host API and should be avoided.

Docs-only change.