### PR TITLE
Do not require user to hold shift during drag'n'drop to drop into edi…

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorDropTarget.ts
+++ b/src/vs/workbench/browser/parts/editor/editorDropTarget.ts
@@ -37,7 +37,11 @@ function isDropIntoEditorEnabledGlobally(configurationService: IConfigurationSer
 }
 
 function isDragIntoEditorEvent(e: DragEvent): boolean {
-	return e.shiftKey;
+	if (e.dataTransfer?.types.includes(DataTransfers.INTERNAL_URI_LIST)) {
+		return e.shiftKey;
+	} else {
+		return true;
+	}
 }
 
 class DropOverlay extends Themable {

--- a/src/vs/workbench/contrib/webview/browser/webviewWindowDragMonitor.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewWindowDragMonitor.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { DataTransfers } from '../../../../base/browser/dnd.js';
 import * as DOM from '../../../../base/browser/dom.js';
 import { CodeWindow } from '../../../../base/browser/window.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
@@ -39,7 +40,7 @@ export class WebviewWindowDragMonitor extends Disposable {
 		}));
 
 		this._register(DOM.addDisposableListener(targetWindow, DOM.EventType.DRAG, (event) => {
-			if (event.shiftKey) {
+			if (isDragIntoEditorEvent(event)) {
 				onDragEnd();
 			} else {
 				onDragStart();
@@ -47,12 +48,21 @@ export class WebviewWindowDragMonitor extends Disposable {
 		}));
 
 		this._register(DOM.addDisposableListener(targetWindow, DOM.EventType.DRAG_OVER, (event) => {
-			if (event.shiftKey) {
+			if (isDragIntoEditorEvent(event)) {
 				onDragEnd();
 			} else {
 				onDragStart();
 			}
 		}));
 
+	}
+}
+
+
+function isDragIntoEditorEvent(e: DragEvent): boolean {
+	if (e.dataTransfer?.types.includes(DataTransfers.INTERNAL_URI_LIST)) {
+		return e.shiftKey;
+	} else {
+		return true;
 	}
 }


### PR DESCRIPTION
Updates when the "Hold Shift to drop into editor" overlay appears and drag'n'drop is consumed by vscode/webview:
* if some resource URIs are being dragged, the current behavior is preserved and by default new editor is opened for the URI dropped into the editor area unless user holds down the Shift key
* if no resource URIs are associated with the DragEvent, the drop events are delegated to webview under the cursor as if user was holding down the Shift key

<img width="807" height="727" alt="Recording 2026-06-13 at 16 35 26" src="https://github.com/user-attachments/assets/a90308f8-1d2e-473b-a1da-2633b589a557" />


Fixes #256444 

At the moment the PR is just a proof of concept that shows where in the code changes are needed. I'm waiting for your feedback on whether this is the right way to go in the first place. In particular what needs to be reviewed is:
* is using presence of the uri list MIME good enough test to determine when we should delegate the event to webview?
* we would probably want to have the `isDragIntoEditorEvent` function in just one place and reference it from all the places it is needed, what is the right place?

The demo in the screencap uses this repro extension: https://github.com/vaclavHala/vscode_dnd_demo
(`npm run pack` it to get a .vsix)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
