### PR TITLE
Fix Call Stack view layout when docked outside debug panel

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/callStackView.ts
+++ b/src/vs/workbench/contrib/debug/browser/callStackView.ts
@@ -41,6 +41,7 @@ import { INotificationService } from '../../../../platform/notification/common/n
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { asCssVariable, textLinkForeground } from '../../../../platform/theme/common/colorRegistry.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
+import { Orientation } from '../../../../base/browser/ui/sash/sash.js';
 import { ViewAction, ViewPane } from '../../../browser/parts/views/viewPane.js';
 import { IViewletViewOptions } from '../../../browser/parts/views/viewsViewlet.js';
 import { IViewDescriptorService } from '../../../common/views.js';
@@ -53,6 +54,24 @@ import * as icons from './debugIcons.js';
 import { createDisconnectMenuItemAction } from './debugToolBar.js';
 
 const $ = dom.$;
+
+const MAX_VISIBLE_CALL_STACK_ROWS = 9;
+const CALL_STACK_ROW_HEIGHT = 22;
+const HORIZONTAL_MIN_BODY_SIZE = 170;
+
+export function computeCallStackBodySizes(orientation: Orientation, contentHeight: number, visibleViewCount: number): { minimumBodySize: number; maximumBodySize: number } {
+	if (orientation === Orientation.HORIZONTAL) {
+		return {
+			minimumBodySize: HORIZONTAL_MIN_BODY_SIZE,
+			maximumBodySize: Number.POSITIVE_INFINITY,
+		};
+	}
+
+	return {
+		minimumBodySize: Math.min(MAX_VISIBLE_CALL_STACK_ROWS * CALL_STACK_ROW_HEIGHT, contentHeight),
+		maximumBodySize: visibleViewCount > 1 ? contentHeight : Number.POSITIVE_INFINITY,
+	};
+}
 
 type CallStackItem = IStackFrame | IThread | IDebugSession | string | ThreadAndSessionIds | IStackFrame[];
 
@@ -157,6 +176,7 @@ export class CallStackView extends ViewPane {
 	private tree!: WorkbenchCompressibleAsyncDataTree<IDebugModel, CallStackItem, FuzzyScore>;
 	private autoExpandedSessions = new Set<IDebugSession>();
 	private selectionNeedsUpdate = false;
+	private ignoreLayout = false;
 
 	constructor(
 		private options: IViewletViewOptions,
@@ -221,6 +241,7 @@ export class CallStackView extends ViewPane {
 				this.selectionNeedsUpdate = false;
 				await this.updateTreeSelection();
 			}
+			this.updateSize();
 		}, 50));
 	}
 
@@ -382,6 +403,11 @@ export class CallStackView extends ViewPane {
 			}
 		}));
 
+		this._register(this.tree.onDidChangeContentHeight(() => this.updateSize()));
+
+		const containerModel = this.viewDescriptorService.getViewContainerModel(this.viewDescriptorService.getViewContainerByViewId(this.id)!);
+		this._register(containerModel.onDidChangeAllViewDescriptors(() => this.updateSize()));
+
 		this._register(this.debugService.onDidNewSession(s => {
 			const sessionListeners: IDisposable[] = [];
 			sessionListeners.push(s.onDidChangeName(() => {
@@ -400,8 +426,29 @@ export class CallStackView extends ViewPane {
 	}
 
 	protected override layoutBody(height: number, width: number): void {
+		if (this.ignoreLayout) {
+			return;
+		}
+
 		super.layoutBody(height, width);
 		this.tree.layout(height, width);
+		try {
+			this.ignoreLayout = true;
+			this.updateSize();
+		} finally {
+			this.ignoreLayout = false;
+		}
+	}
+
+	private updateSize(): void {
+		if (!this.tree) {
+			return;
+		}
+
+		const containerModel = this.viewDescriptorService.getViewContainerModel(this.viewDescriptorService.getViewContainerByViewId(this.id)!);
+		const { minimumBodySize, maximumBodySize } = computeCallStackBodySizes(this.orientation, this.tree.contentHeight, containerModel.visibleViewDescriptors.length);
+		this.minimumBodySize = minimumBodySize;
+		this.maximumBodySize = maximumBodySize;
 	}
 
 	override focus(): void {

--- a/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
@@ -147,6 +147,10 @@
 	margin: 0px 10px;
 }
 
+.debug-pane .pane.horizontal:not(.expanded) .pane-header .call-stack-state-message {
+	display: none;
+}
+
 .debug-pane .call-stack-state-message > .label {
 	border-radius: 3px;
 	padding: 1px 2px;

--- a/src/vs/workbench/contrib/debug/test/browser/callStack.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/callStack.test.ts
@@ -16,8 +16,9 @@ import { TestConfigurationService } from '../../../../../platform/configuration/
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { Orientation } from '../../../../../base/browser/ui/sash/sash.js';
 import { createDecorationsForStackFrame } from '../../browser/callStackEditorContribution.js';
-import { getContext, getContextForContributedActions, getSpecificSourceName } from '../../browser/callStackView.js';
+import { computeCallStackBodySizes, getContext, getContextForContributedActions, getSpecificSourceName } from '../../browser/callStackView.js';
 import { debugStackframe, debugStackframeFocused } from '../../browser/debugIcons.js';
 import { getStackFrameThreadAndSessionToFocus } from '../../browser/debugService.js';
 import { DebugSession } from '../../browser/debugSession.js';
@@ -334,6 +335,30 @@ suite('Debug - CallStack', () => {
 
 		assert.strictEqual(getSpecificSourceName(firstStackFrame), '.../b/c/d/internalModule.js');
 		assert.strictEqual(getSpecificSourceName(secondStackFrame), '.../x/c/d/internalModule.js');
+	});
+
+	test('computeCallStackBodySizes vertical with multiple views caps size to content', () => {
+		const sizes = computeCallStackBodySizes(Orientation.VERTICAL, 66, 3);
+		assert.strictEqual(sizes.minimumBodySize, 66);
+		assert.strictEqual(sizes.maximumBodySize, 66);
+	});
+
+	test('computeCallStackBodySizes vertical with single view allows expansion', () => {
+		const sizes = computeCallStackBodySizes(Orientation.VERTICAL, 66, 1);
+		assert.strictEqual(sizes.minimumBodySize, 66);
+		assert.strictEqual(sizes.maximumBodySize, Number.POSITIVE_INFINITY);
+	});
+
+	test('computeCallStackBodySizes vertical limits minimum to max visible rows', () => {
+		const sizes = computeCallStackBodySizes(Orientation.VERTICAL, 500, 2);
+		assert.strictEqual(sizes.minimumBodySize, 198);
+		assert.strictEqual(sizes.maximumBodySize, 500);
+	});
+
+	test('computeCallStackBodySizes horizontal uses panel defaults', () => {
+		const sizes = computeCallStackBodySizes(Orientation.HORIZONTAL, 66, 3);
+		assert.strictEqual(sizes.minimumBodySize, 170);
+		assert.strictEqual(sizes.maximumBodySize, Number.POSITIVE_INFINITY);
 	});
 
 	test('stack frame toString()', () => {


### PR DESCRIPTION
This PR fixes Call Stack view layout and resizing bugs when docked to Explorer or Panel (Issue #321276).

1. Computes dynamic min/max body sizes from tree content so the view can shrink in the Explorer and does not steal space when neighboring views resize.
2. Hides the header state message when collapsed in the panel so the view icon remains visible.