### PR TITLE
Fix Claude agent host client tools hanging after confirmation

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeMapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeMapSessionEvents.ts
@@ -14,7 +14,7 @@ import type { SubagentRegistry } from './claudeSubagentRegistry.js';
 import { stripClientToolNamePrefix, hasClientToolNamePrefix } from './clientTools/claudeClientToolMcpServer.js';
 import { buildClaudeToolMeta, getClaudePastTenseMessage, getClaudeToolDisplayName } from './claudeToolDisplay.js';
 import { ClaudeToolCallRegistry } from './claudeToolCallRegistry.js';
-import { ToolCallConfirmationReason, type StringOrMarkdown } from '../../common/state/protocol/state.js';
+import { ToolCallConfirmationReason, ToolCallContributorKind, type StringOrMarkdown } from '../../common/state/protocol/state.js';
 
 /**
  * Cross-call state for {@link mapSDKMessageToAgentSignals}. One instance
@@ -547,7 +547,7 @@ function mapStreamEvent(
 						toolCallId: block.id,
 						toolName,
 						displayName: getClaudeToolDisplayName(toolName),
-						...(toolClientId ? { toolClientId } : {}),
+						...(toolClientId ? { contributor: { kind: ToolCallContributorKind.Client, clientId: toolClientId } } : {}),
 						...(meta ? { _meta: meta } : {}),
 					},
 				}];

--- a/src/vs/platform/agentHost/test/node/claudeMapSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeMapSessionEvents.test.ts
@@ -196,7 +196,7 @@ suite('claudeMapSessionEvents — direct mapper tests', () => {
 		assert.deepStrictEqual(log.warns, []);
 	});
 
-	test('Test 8b — content_block_start for a client tool sets the Client contributor (clientId-prefixed)', () => {
+	test('Test 8b — content_block_start for an mcp__client__* tool sets the Client contributor', () => {
 		// Regression: the mapper used to emit an invalid `toolClientId` field
 		// on the SessionToolCallStart action. Because the spread bypassed
 		// TypeScript's excess-property check and the reducer reads

--- a/src/vs/platform/agentHost/test/node/claudeMapSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeMapSessionEvents.test.ts
@@ -10,7 +10,7 @@ import { NullLogService } from '../../../log/common/log.js';
 import type { AgentSignal } from '../../common/agentService.js';
 import { ActionType } from '../../common/state/sessionActions.js';
 import { ResponsePartKind, ToolResultContentType } from '../../common/state/sessionState.js';
-import { ToolCallConfirmationReason } from '../../common/state/protocol/state.js';
+import { ToolCallConfirmationReason, ToolCallContributorKind } from '../../common/state/protocol/state.js';
 import { ClaudeMapperState, mapSDKMessageToAgentSignals } from '../../node/claude/claudeMapSessionEvents.js';
 import { SubagentRegistry } from '../../node/claude/claudeSubagentRegistry.js';
 import {
@@ -191,6 +191,42 @@ suite('claudeMapSessionEvents — direct mapper tests', () => {
 				toolCallId: 'tu_1',
 				toolName: 'Read',
 				displayName: 'Read file',
+			},
+		}]);
+		assert.deepStrictEqual(log.warns, []);
+	});
+
+	test('Test 8b — content_block_start for a client tool sets the Client contributor (clientId-prefixed)', () => {
+		// Regression: the mapper used to emit an invalid `toolClientId` field
+		// on the SessionToolCallStart action. Because the spread bypassed
+		// TypeScript's excess-property check and the reducer reads
+		// `action.contributor`, the contributor came through as `undefined`,
+		// so the workbench routed client tools to the server-tool path and
+		// never executed them — the in-process MCP handler hung forever.
+		const log = new CapturingLogService();
+		const state = new ClaudeMapperState();
+		const CLIENT_ID = 'client-abc';
+
+		const signals = mapSDKMessageToAgentSignals(
+			makeStreamEvent(SESSION_ID, makeContentBlockStartToolUse(0, 'tu_c', 'mcp__client__problems')),
+			SESSION,
+			TURN_ID,
+			state,
+			log,
+			r(),
+			CLIENT_ID,
+		);
+
+		assert.deepStrictEqual(signals, [{
+			kind: 'action',
+			session: SESSION,
+			action: {
+				type: ActionType.SessionToolCallStart,
+				turnId: TURN_ID,
+				toolCallId: 'tu_c',
+				toolName: 'problems',
+				displayName: 'problems',
+				contributor: { kind: ToolCallContributorKind.Client, clientId: CLIENT_ID },
 			},
 		}]);
 		assert.deepStrictEqual(log.warns, []);


### PR DESCRIPTION
## Problem

In the Agents window, calling any **client-contributed tool** through a local **Claude** Agent Host session (e.g. `problems`, `openBrowserPage`, `navigatePage`, `screenshotPage`) hangs: the confirmation card shows, the user approves it, and then the turn gets stuck "Working…" forever. Sending a follow-up message interrupts the still-parked tool call.

## Root cause

The Claude stream mapper emitted an invalid `toolClientId` field on the `SessionToolCallStart` action instead of `contributor`:

```ts
// claudeMapSessionEvents.ts
...(toolClientId ? { toolClientId } : {}),
```

`SessionToolCallStartAction` has no `toolClientId` field — it expects `contributor?: ToolCallContributor`. The object spread (`...( { toolClientId } )`) bypasses TypeScript's excess-property check, so it compiled silently. The reducer reads `action.contributor`, so client tool calls ended up with **no contributor**.

Downstream, the workbench's `_setupToolCallPart` routes on `contributor?.kind === Client`:

- `undefined` → routed to `_setupServerToolCall`, which renders the confirmation card but **never calls `invokeTool`**.
- So the SDK's in-process `client` MCP handler parked on `awaitResult(toolUseId)` forever → the turn hangs after approval.

## Fix

Emit a proper contributor, matching what `CopilotAgentSession` already does:

```ts
...(toolClientId ? { contributor: { kind: ToolCallContributorKind.Client, clientId: toolClientId } } : {}),
```

Now client tools route to `_setupClientToolCall`, `invokeTool` runs, the result is returned via `SessionToolCallComplete`, and the SDK round-trip completes.

## Verification

- Added a regression test in `claudeMapSessionEvents.test.ts` asserting a `mcp__client__*` tool produces a `SessionToolCallStart` with `contributor: { kind: Client, clientId }`.
- Unit tests green: mapper suite (22) + `agentSideEffects` / `claudeAgent` / `agentHostClientTools` (97).
- Manual end-to-end against a local Claude Agent Host session: `problems`, `openBrowserPage`, `navigatePage`, and `screenshotPage` now execute and the turn completes (no hang). The renderer logs `[AgentHost] Invoking client tool: …` for each, and the turn reaches `turnComplete`.

## Files

- `src/vs/platform/agentHost/node/claude/claudeMapSessionEvents.ts` — the fix
- `src/vs/platform/agentHost/test/node/claudeMapSessionEvents.test.ts` — regression test
