### PR TITLE
fix: preserve CRLF in stage selected ranges

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -12,7 +12,8 @@ import { ForcePushMode, GitErrorCodes, RefType, Status } from './api/git.constan
 import { Git, GitError, Repository as GitRepository, Stash, Worktree } from './git';
 import { Model } from './model';
 import { GitResourceGroup, Repository, Resource, ResourceGroupType } from './repository';
-import { DiffEditorSelectionHunkToolbarContext, LineChange, applyLineChanges, getIndexDiffInformation, getModifiedRange, getWorkingTreeDiffInformation, intersectDiffWithRange, invertLineChange, normalizeEOL, toLineChanges, toLineRanges, compareLineChanges } from './staging';
+import { DiffEditorSelectionHunkToolbarContext, LineChange, applyLineChanges, getIndexDiffInformation, getModifiedRange, getWorkingTreeDiffInformation, intersectDiffWithRange, invertLineChange, toLineChanges, toLineRanges, compareLineChanges } from './staging';
+import { normalizeEOL } from './eol';
 import { fromGitUri, toGitUri, isGitUri, toMergeUris, toMultiFileDiffEditorUris } from './uri';
 import { coalesce, DiagnosticSeverityConfig, dispose, fromNow, getHistoryItemDisplayName, getStashDescription, grep, isDefined, isDescendant, isLinuxSnap, isRemote, isWindows, pathEquals, relativePath, subject, toDiagnosticSeverity, truncate } from './util';
 import { GitTimelineItem } from './timelineProvider';

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -12,7 +12,7 @@ import { ForcePushMode, GitErrorCodes, RefType, Status } from './api/git.constan
 import { Git, GitError, Repository as GitRepository, Stash, Worktree } from './git';
 import { Model } from './model';
 import { GitResourceGroup, Repository, Resource, ResourceGroupType } from './repository';
-import { DiffEditorSelectionHunkToolbarContext, LineChange, applyLineChanges, getIndexDiffInformation, getModifiedRange, getWorkingTreeDiffInformation, intersectDiffWithRange, invertLineChange, toLineChanges, toLineRanges, compareLineChanges } from './staging';
+import { DiffEditorSelectionHunkToolbarContext, LineChange, applyLineChanges, getIndexDiffInformation, getModifiedRange, getWorkingTreeDiffInformation, intersectDiffWithRange, invertLineChange, normalizeEOL, toLineChanges, toLineRanges, compareLineChanges } from './staging';
 import { fromGitUri, toGitUri, isGitUri, toMergeUris, toMultiFileDiffEditorUris } from './uri';
 import { coalesce, DiagnosticSeverityConfig, dispose, fromNow, getHistoryItemDisplayName, getStashDescription, grep, isDefined, isDescendant, isLinuxSnap, isRemote, isWindows, pathEquals, relativePath, subject, toDiagnosticSeverity, truncate } from './util';
 import { GitTimelineItem } from './timelineProvider';
@@ -1731,7 +1731,15 @@ export class CommandCenter {
 			modifiedDocument = await workspace.openTextDocument(modifiedUri);
 		}
 
-		const result = changes.originalWithModifiedChanges;
+		let result = changes.originalWithModifiedChanges;
+
+		if (changes.originalUri) {
+			const originalDocument = await workspace.openTextDocument(changes.originalUri);
+			if (originalDocument.eol !== modifiedDocument.eol) {
+				result = normalizeEOL(result, originalDocument.eol);
+			}
+		}
+
 		await this.runByRepository(modifiedUri, async (repository, resource) =>
 			await repository.stage(resource, result, modifiedDocument.encoding));
 	}

--- a/extensions/git/src/eol.ts
+++ b/extensions/git/src/eol.ts
@@ -7,7 +7,7 @@
 export const EOL_LF = 1;
 export const EOL_CRLF = 2;
 
-export function normalizeEOL(text: string, targetEOL: number): string {
+export function normalizeEOL(text: string, targetEOL: typeof EOL_LF | typeof EOL_CRLF): string {
 	if (targetEOL === EOL_CRLF) {
 		return text.replace(/(?<!\r)\n/g, '\r\n');
 	} else {

--- a/extensions/git/src/eol.ts
+++ b/extensions/git/src/eol.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Matches vscode.EndOfLine: LF = 1, CRLF = 2
+export const EOL_LF = 1;
+export const EOL_CRLF = 2;
+
+export function normalizeEOL(text: string, targetEOL: number): string {
+	if (targetEOL === EOL_CRLF) {
+		return text.replace(/(?<!\r)\n/g, '\r\n');
+	} else {
+		return text.replace(/\r\n/g, '\n');
+	}
+}

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1989,7 +1989,7 @@ export class Repository {
 
 	async stage(path: string, data: Uint8Array): Promise<void> {
 		const relativePath = this.sanitizeRelativePath(path);
-		const child = this.stream(['hash-object', '--stdin', '-w', '--path', relativePath], { stdio: [null, null, null] });
+		const child = this.stream(['-c', 'core.autocrlf=false', 'hash-object', '--stdin', '-w', '--path', relativePath], { stdio: [null, null, null] });
 
 		if (!child.stdin) {
 			throw new GitError({

--- a/extensions/git/src/staging.ts
+++ b/extensions/git/src/staging.ts
@@ -7,8 +7,6 @@ import { TextDocument, Range, Selection, Uri, TextEditor, TextEditorDiffInformat
 import { fromGitUri, isGitUri } from './uri';
 import { normalizeEOL } from './eol';
 
-export { normalizeEOL };
-
 export interface LineChange {
 	readonly originalStartLineNumber: number;
 	readonly originalEndLineNumber: number;

--- a/extensions/git/src/staging.ts
+++ b/extensions/git/src/staging.ts
@@ -5,6 +5,9 @@
 
 import { TextDocument, Range, Selection, Uri, TextEditor, TextEditorDiffInformation } from 'vscode';
 import { fromGitUri, isGitUri } from './uri';
+import { normalizeEOL } from './eol';
+
+export { normalizeEOL };
 
 export interface LineChange {
 	readonly originalStartLineNumber: number;
@@ -46,7 +49,13 @@ export function applyLineChanges(original: TextDocument, modified: TextDocument,
 				fromCharacter = modified.lineAt(fromLine).range.end.character;
 			}
 
-			result.push(modified.getText(new Range(fromLine, fromCharacter, diff.modifiedEndLineNumber, 0)));
+			let modifiedText = modified.getText(new Range(fromLine, fromCharacter, diff.modifiedEndLineNumber, 0));
+
+			if (original.eol !== modified.eol) {
+				modifiedText = normalizeEOL(modifiedText, original.eol);
+			}
+
+			result.push(modifiedText);
 		}
 
 		currentLine = isInsertion ? diff.originalStartLineNumber : diff.originalEndLineNumber;

--- a/extensions/git/src/test/staging.integration.test.ts
+++ b/extensions/git/src/test/staging.integration.test.ts
@@ -1,0 +1,165 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'mocha';
+import * as assert from 'assert';
+import { Range, EndOfLine, Position, TextDocument, Uri } from 'vscode';
+import { applyLineChanges, LineChange } from '../staging';
+
+function mockDocument(contents: string, eol: EndOfLine): TextDocument {
+	const eolStr = eol === EndOfLine.CRLF ? '\r\n' : '\n';
+	const lines = contents.split(/\r\n|\n/);
+
+	return {
+		uri: Uri.file('/mock'),
+		fileName: '/mock',
+		isUntitled: false,
+		languageId: 'plaintext',
+		version: 1,
+		isDirty: false,
+		isClosed: false,
+		encoding: 'utf8',
+		eol,
+		lineCount: lines.length,
+		save: () => Promise.resolve(true),
+		lineAt(lineOrPosition: number | Position) {
+			const line = typeof lineOrPosition === 'number' ? lineOrPosition : lineOrPosition.line;
+			const text = lines[line] ?? '';
+			return {
+				lineNumber: line,
+				text,
+				range: new Range(line, 0, line, text.length),
+				rangeIncludingLineBreak: new Range(line, 0, line + 1, 0),
+				firstNonWhitespaceCharacterIndex: text.search(/\S/),
+				isEmptyOrWhitespace: text.trim().length === 0,
+			};
+		},
+		offsetAt(_position: Position) { return 0; },
+		positionAt(_offset: number) { return new Position(0, 0); },
+		getText(range?: Range): string {
+			if (!range) {
+				return lines.join(eolStr);
+			}
+			if (range.isEmpty) {
+				return '';
+			}
+			if (range.isSingleLine) {
+				return lines[range.start.line].substring(range.start.character, range.end.character);
+			}
+			const result: string[] = [];
+			result.push(lines[range.start.line].substring(range.start.character));
+			for (let i = range.start.line + 1; i < range.end.line; i++) {
+				result.push(lines[i]);
+			}
+			result.push(lines[range.end.line].substring(0, range.end.character));
+			return result.join(eolStr);
+		},
+		getWordRangeAtPosition() { return undefined; },
+		validateRange(range: Range) { return range; },
+		validatePosition(position: Position) { return position; },
+	} as unknown as TextDocument;
+}
+
+suite('applyLineChanges', () => {
+
+	test('LF original + LF modified: no EOL change', () => {
+		const original = mockDocument('a\nb\nc\nd\n', EndOfLine.LF);
+		const modified = mockDocument('a\nB\nc\nd\n', EndOfLine.LF);
+		const changes: LineChange[] = [
+			{ originalStartLineNumber: 2, originalEndLineNumber: 2, modifiedStartLineNumber: 2, modifiedEndLineNumber: 2 }
+		];
+		const result = applyLineChanges(original, modified, changes);
+		assert.strictEqual(result, 'a\nB\nc\nd\n');
+	});
+
+	test('CRLF original + CRLF modified: preserves CRLF', () => {
+		const original = mockDocument('a\r\nb\r\nc\r\nd\r\n', EndOfLine.CRLF);
+		const modified = mockDocument('a\r\nB\r\nc\r\nd\r\n', EndOfLine.CRLF);
+		const changes: LineChange[] = [
+			{ originalStartLineNumber: 2, originalEndLineNumber: 2, modifiedStartLineNumber: 2, modifiedEndLineNumber: 2 }
+		];
+		const result = applyLineChanges(original, modified, changes);
+		assert.strictEqual(result, 'a\r\nB\r\nc\r\nd\r\n');
+	});
+
+	test('CRLF original + LF modified: normalizes modified to CRLF', () => {
+		const original = mockDocument('a\r\nb\r\nc\r\nd\r\n', EndOfLine.CRLF);
+		const modified = mockDocument('a\nMOD\nc\nd\n', EndOfLine.LF);
+		const changes: LineChange[] = [
+			{ originalStartLineNumber: 2, originalEndLineNumber: 2, modifiedStartLineNumber: 2, modifiedEndLineNumber: 2 }
+		];
+		const result = applyLineChanges(original, modified, changes);
+		assert.strictEqual(result, 'a\r\nMOD\r\nc\r\nd\r\n');
+		const bareLf = (result.replace(/\r\n/g, '').match(/\n/g) || []).length;
+		assert.strictEqual(bareLf, 0, 'No bare LF');
+	});
+
+	test('LF original + CRLF modified: normalizes modified to LF', () => {
+		const original = mockDocument('a\nb\nc\nd\n', EndOfLine.LF);
+		const modified = mockDocument('a\r\nMOD\r\nc\r\nd\r\n', EndOfLine.CRLF);
+		const changes: LineChange[] = [
+			{ originalStartLineNumber: 2, originalEndLineNumber: 2, modifiedStartLineNumber: 2, modifiedEndLineNumber: 2 }
+		];
+		const result = applyLineChanges(original, modified, changes);
+		assert.strictEqual(result, 'a\nMOD\nc\nd\n');
+		assert.ok(!result.includes('\r'), 'No CR');
+	});
+
+	test('multiple changes with EOL mismatch', () => {
+		const original = mockDocument('a\r\nb\r\nc\r\nd\r\ne\r\n', EndOfLine.CRLF);
+		const modified = mockDocument('a\nB\nc\nD\ne\n', EndOfLine.LF);
+		const changes: LineChange[] = [
+			{ originalStartLineNumber: 2, originalEndLineNumber: 2, modifiedStartLineNumber: 2, modifiedEndLineNumber: 2 },
+			{ originalStartLineNumber: 4, originalEndLineNumber: 4, modifiedStartLineNumber: 4, modifiedEndLineNumber: 4 },
+		];
+		const result = applyLineChanges(original, modified, changes);
+		assert.strictEqual(result, 'a\r\nB\r\nc\r\nD\r\ne\r\n');
+	});
+
+	test('deletion-only diff: no normalization needed', () => {
+		const original = mockDocument('a\r\nb\r\nc\r\nd\r\n', EndOfLine.CRLF);
+		const modified = mockDocument('a\r\nc\r\nd\r\n', EndOfLine.LF);
+		const changes: LineChange[] = [
+			{ originalStartLineNumber: 2, originalEndLineNumber: 2, modifiedStartLineNumber: 1, modifiedEndLineNumber: 0 }
+		];
+		const result = applyLineChanges(original, modified, changes);
+		assert.strictEqual(result, 'a\r\nc\r\nd\r\n');
+	});
+
+	test('insertion with EOL mismatch', () => {
+		const original = mockDocument('a\r\nc\r\n', EndOfLine.CRLF);
+		const modified = mockDocument('a\nNEW\nc\n', EndOfLine.LF);
+		const changes: LineChange[] = [
+			{ originalStartLineNumber: 1, originalEndLineNumber: 0, modifiedStartLineNumber: 2, modifiedEndLineNumber: 2 }
+		];
+		const result = applyLineChanges(original, modified, changes);
+		const bareLf = (result.replace(/\r\n/g, '').match(/\n/g) || []).length;
+		assert.strictEqual(bareLf, 0, 'No bare LF after insertion');
+		assert.ok(result.includes('NEW\r\n'), 'Inserted line has CRLF');
+	});
+
+	test('no trailing newline: CRLF preserved', () => {
+		const original = mockDocument('a\r\nb\r\nc', EndOfLine.CRLF);
+		const modified = mockDocument('a\nMOD\nc', EndOfLine.LF);
+		const changes: LineChange[] = [
+			{ originalStartLineNumber: 2, originalEndLineNumber: 2, modifiedStartLineNumber: 2, modifiedEndLineNumber: 2 }
+		];
+		const result = applyLineChanges(original, modified, changes);
+		assert.strictEqual(result, 'a\r\nMOD\r\nc');
+	});
+
+	test('unstaged lines are byte-identical to original', () => {
+		const original = mockDocument('first\r\nsecond\r\nthird\r\nfourth\r\n', EndOfLine.CRLF);
+		const modified = mockDocument('first\nCHANGED\nALSO\nfourth\n', EndOfLine.LF);
+		const changes: LineChange[] = [
+			{ originalStartLineNumber: 2, originalEndLineNumber: 2, modifiedStartLineNumber: 2, modifiedEndLineNumber: 2 }
+		];
+		const result = applyLineChanges(original, modified, changes);
+		assert.ok(result.startsWith('first\r\n'), 'Unstaged line 1 preserved');
+		assert.ok(result.includes('CHANGED\r\n'), 'Staged line normalized');
+		assert.ok(result.includes('\r\nthird\r\n'), 'Unstaged line 3 preserved');
+		assert.ok(result.endsWith('fourth\r\n'), 'Unstaged line 4 preserved');
+	});
+});

--- a/extensions/git/src/test/staging.integration.test.ts
+++ b/extensions/git/src/test/staging.integration.test.ts
@@ -32,7 +32,7 @@ function mockDocument(contents: string, eol: EndOfLine): TextDocument {
 				text,
 				range: new Range(line, 0, line, text.length),
 				rangeIncludingLineBreak: new Range(line, 0, line + 1, 0),
-				firstNonWhitespaceCharacterIndex: text.search(/\S/),
+				firstNonWhitespaceCharacterIndex: text.search(/\S/) === -1 ? text.length : text.search(/\S/),
 				isEmptyOrWhitespace: text.trim().length === 0,
 			};
 		},
@@ -45,15 +45,18 @@ function mockDocument(contents: string, eol: EndOfLine): TextDocument {
 			if (range.isEmpty) {
 				return '';
 			}
+			const startText = lines[range.start.line]?.substring(range.start.character) ?? '';
 			if (range.isSingleLine) {
-				return lines[range.start.line].substring(range.start.character, range.end.character);
+				return startText.substring(0, range.end.character - range.start.character);
 			}
-			const result: string[] = [];
-			result.push(lines[range.start.line].substring(range.start.character));
+			const result: string[] = [startText];
 			for (let i = range.start.line + 1; i < range.end.line; i++) {
 				result.push(lines[i]);
 			}
-			result.push(lines[range.end.line].substring(0, range.end.character));
+			// range.end.line may equal lines.length (EOF), in which case there is no partial line to append
+			if (range.end.line < lines.length) {
+				result.push(lines[range.end.line].substring(0, range.end.character));
+			}
 			return result.join(eolStr);
 		},
 		getWordRangeAtPosition() { return undefined; },

--- a/extensions/git/src/test/staging.test.ts
+++ b/extensions/git/src/test/staging.test.ts
@@ -1,0 +1,105 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'mocha';
+import * as assert from 'assert';
+import { normalizeEOL, EOL_LF, EOL_CRLF } from '../eol';
+
+suite('staging', () => {
+	suite('normalizeEOL', () => {
+		test('converts LF to CRLF', () => {
+			const result = normalizeEOL('line1\nline2\nline3\n', EOL_CRLF);
+			assert.strictEqual(result, 'line1\r\nline2\r\nline3\r\n');
+		});
+
+		test('converts CRLF to LF', () => {
+			const result = normalizeEOL('line1\r\nline2\r\nline3\r\n', EOL_LF);
+			assert.strictEqual(result, 'line1\nline2\nline3\n');
+		});
+
+		test('LF to CRLF does not double-convert existing CRLF', () => {
+			const result = normalizeEOL('line1\r\nline2\nline3\r\n', EOL_CRLF);
+			assert.strictEqual(result, 'line1\r\nline2\r\nline3\r\n');
+			assert.ok(!result.includes('\r\r\n'), 'Should not double-convert CRLF');
+		});
+
+		test('CRLF to LF with mixed line endings', () => {
+			const result = normalizeEOL('line1\r\nline2\nline3\r\n', EOL_LF);
+			assert.strictEqual(result, 'line1\nline2\nline3\n');
+		});
+
+		test('no-op when text already has target LF endings', () => {
+			const input = 'line1\nline2\nline3\n';
+			assert.strictEqual(normalizeEOL(input, EOL_LF), input);
+		});
+
+		test('no-op when text already has target CRLF endings', () => {
+			const input = 'line1\r\nline2\r\nline3\r\n';
+			assert.strictEqual(normalizeEOL(input, EOL_CRLF), input);
+		});
+
+		test('empty string', () => {
+			assert.strictEqual(normalizeEOL('', EOL_LF), '');
+			assert.strictEqual(normalizeEOL('', EOL_CRLF), '');
+		});
+
+		test('single line without newline', () => {
+			assert.strictEqual(normalizeEOL('hello', EOL_LF), 'hello');
+			assert.strictEqual(normalizeEOL('hello', EOL_CRLF), 'hello');
+		});
+
+		test('preserves content when normalizing', () => {
+			const result = normalizeEOL('function foo() {\n  return bar;\n}\n', EOL_CRLF);
+			assert.strictEqual(result, 'function foo() {\r\n  return bar;\r\n}\r\n');
+		});
+
+		test('CRLF bytes in result match \\r\\n exactly', () => {
+			const result = normalizeEOL('a\nb\nc\n', EOL_CRLF);
+			const bytes = Buffer.from(result);
+			let crlfCount = 0;
+			for (let i = 0; i < bytes.length - 1; i++) {
+				if (bytes[i] === 0x0d && bytes[i + 1] === 0x0a) {
+					crlfCount++;
+				}
+			}
+			assert.strictEqual(crlfCount, 3, 'Should have exactly 3 CRLF sequences');
+		});
+	});
+
+	suite('EOL normalization integration', () => {
+		test('simulated staging: original LF, modified CRLF → result LF', () => {
+			const modifiedText = 'MODIFIED LINE\r\n';
+			const normalized = normalizeEOL(modifiedText, EOL_LF);
+			assert.strictEqual(normalized, 'MODIFIED LINE\n');
+			assert.ok(!normalized.includes('\r'), 'Should not contain \\r');
+		});
+
+		test('simulated staging: original CRLF, modified LF → result CRLF', () => {
+			const modifiedText = 'MODIFIED LINE\n';
+			const normalized = normalizeEOL(modifiedText, EOL_CRLF);
+			assert.strictEqual(normalized, 'MODIFIED LINE\r\n');
+		});
+
+		test('simulated staging: multiple modified lines normalized', () => {
+			const modifiedChunk = 'mod1\nmod2\nmod3\n';
+			const normalized = normalizeEOL(modifiedChunk, EOL_CRLF);
+			assert.strictEqual(normalized, 'mod1\r\nmod2\r\nmod3\r\n');
+		});
+
+		test('whole-file simulation: CRLF original + LF modified = CRLF result', () => {
+			const unchangedPart1 = 'line1\r\n';
+			const unchangedPart2 = 'line3\r\nline4\r\n';
+
+			const modifiedPart = 'CHANGED\n';
+			const normalizedModified = normalizeEOL(modifiedPart, EOL_CRLF);
+
+			const result = unchangedPart1 + normalizedModified + unchangedPart2;
+			assert.strictEqual(result, 'line1\r\nCHANGED\r\nline3\r\nline4\r\n');
+
+			const bareLfCount = (result.replace(/\r\n/g, '').match(/\n/g) || []).length;
+			assert.strictEqual(bareLfCount, 0, 'Should not contain bare LF');
+		});
+	});
+});


### PR DESCRIPTION
Fixes #96104

applyLineChanges() stitches text from two TextDocuments that can have different EOLs. The original from git show uses LF and while the working tree uses CRLF with autocrlf=true which produces ixed line endings. Also git hash-object --path applies the autocrlf clean filter which converts all CRLF to LF in the stored blob even for lines not in the selection.

Changes

- extensions/git/src/eol.ts: normalizeEOL() helper to convert line endings without double-converting
- extensions/git/src/staging.ts: applyLineChanges() normalizes modified chunks to match the original document's EOL
- extensions/git/src/commands.ts: diffStageHunkOrSelection() normalizes originalWithModifiedChanges the same way
- extensions/git/src/git.ts: hash-object uses -c core.autocrlf=false to skip EOL conversion while preserving other filters (LFS, clean/smudge)

Testing

- 14 unit tests for normalizeEOL(), all passing
- 9 integration tests for applyLineChanges() covering EOL mismatch, insertion, deletion, and no trailing newlin