### PR TITLE
Fix webview resource loading detach in Safari/WebKit

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -876,7 +876,12 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 						});
 						listenStream(result.stream, {
 							onData: (chunk) => {
-								const data = new Uint8Array(chunk.buffer.buffer, chunk.buffer.byteOffset, chunk.buffer.byteLength);
+								// Copy into a freshly-owned ArrayBuffer before transferring. `chunk`
+								// may be a view into a larger, shared ArrayBuffer (e.g. from the IPC
+								// deserialize pipeline); transferring its underlying ArrayBuffer would
+								// detach every sibling view. WebKit detaches synchronously, which
+								// previously broke webview resource loading in Safari.
+								const data = chunk.buffer.slice();
 								this._send('did-load-resource-chunk', { id, data }, [data.buffer]);
 							},
 							onError: () => {


### PR DESCRIPTION
fyi @mjbvz this is for https://github.com/microsoft/vscode/issues/316841 -- looks like if this code got ahold of a slice of a larger buffer, it would send off the entire buffer... this would cause other code to throw when it tried to use other pieces of the larger buffer.

---
🤖 

## Context

Fixes the `Underlying ArrayBuffer has been detached from the view or out-of-bounds: subarray` error seen in web/remote mode on Safari/WebKit.

Related: microsoft/vscode#316841, microsoft/vscode#314126

## Problem

When transferable streams are unsupported (Safari/WebKit), webview resource chunks are sent via `postMessage` with a transfer list. The chunk was wrapped as a `Uint8Array` view over its **entire** underlying `ArrayBuffer`, and that whole `ArrayBuffer` was transferred:

```ts
const data = new Uint8Array(chunk.buffer.buffer, chunk.buffer.byteOffset, chunk.buffer.byteLength);
this._send('did-load-resource-chunk', { id, data }, [data.buffer]);
```

In web/remote mode the chunk is frequently a **view aliasing a larger, shared `ArrayBuffer`** (e.g. a message buffer sliced into many views by the IPC deserialize pipeline). Transferring that shared buffer detaches **every sibling view** still in use. WebKit detaches synchronously, so the next IPC read throws `Underlying ArrayBuffer has been detached from the view` and webview resource loading breaks. V8 (Chrome/Edge/desktop) detaches lazily, which is why this reproduces on Safari/iOS only.

## Fix

Copy the chunk into a freshly-owned `ArrayBuffer` (sized to exactly the chunk window) before transferring it, so the transfer can only ever detach the copy:

```ts
const data = chunk.buffer.slice();
this._send('did-load-resource-chunk', { id, data }, [data.buffer]);
```

`Uint8Array.prototype.slice` returns an exact-window copy backed by its own `ArrayBuffer`, leaving the shared source intact.