### PR TITLE
Browser: fix URLs incorrectly matching file:// scheme

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/features/browserRemoteFeatures.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/features/browserRemoteFeatures.ts
@@ -7,8 +7,6 @@ import { localize } from '../../../../../nls.js';
 import { $ } from '../../../../../base/browser/dom.js';
 import { renderIcon } from '../../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
-import { Schemas } from '../../../../../base/common/network.js';
-import { URI } from '../../../../../base/common/uri.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { BrowserEditor, BrowserEditorContribution, BrowserWidgetLocation, IBrowserEditorWidget } from '../browserEditor.js';
 import { IBrowserViewModel, IBrowserViewWorkbenchService } from '../../common/browserView.js';
@@ -65,7 +63,7 @@ class BrowserRemoteIndicatorContribution extends BrowserEditorContribution {
 		let isWarning = false;
 
 		if (model) {
-			if (URI.parse(model.url).scheme === Schemas.file) {
+			if (model.url.startsWith('file://')) {
 				isConnected = false;
 				statusMessage = localize('browser.connectedLocally.file', "File URLs are served locally, not over the remote connection.");
 				isWarning = true;


### PR DESCRIPTION
`Uri.parse()` defaults to adding a `file:` scheme, resulting in some URLs (like the empty state) being marked incorrectly