### PR TITLE
Fix completion feedback issues

### DIFF
--- a/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/copilotCompletionFeedbackTracker.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/copilotCompletionFeedbackTracker.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, commands, InlineCompletionItem, Uri } from 'vscode';
+import { Command, commands, InlineCompletionItem } from 'vscode';
 import { Disposable } from '../../../../../util/vs/base/common/lifecycle';
 import { IInstantiationService, ServicesAccessor } from '../../../../../util/vs/platform/instantiation/common/instantiation';
 import { collectCompletionDiagnostics, formatDiagnosticsAsMarkdown } from '../../lib/src/diagnostics';
@@ -47,8 +47,8 @@ async function openGitHubIssue(
 ) {
 	const body = generateGitHubIssueBody(accessor, item, telemetry);
 	await commands.executeCommand('workbench.action.openIssueReporter', {
-		extensionId: 'github.copilot',
-		uri: Uri.parse('https://github.com/microsoft/vscode'),
+		issueTitle: 'Copilot completion feedback',
+		issueSource: 'vscode',
 		data: body,
 	});
 }

--- a/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/copilotCompletionFeedbackTracker.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/copilotCompletionFeedbackTracker.ts
@@ -49,7 +49,7 @@ async function openGitHubIssue(
 	await commands.executeCommand('workbench.action.openIssueReporter', {
 		issueTitle: 'Copilot completion feedback',
 		issueSource: 'vscode',
-		data: body,
+		issueBody: body,
 	});
 }
 

--- a/src/vs/editor/contrib/hover/browser/contentHoverRendered.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHoverRendered.ts
@@ -333,7 +333,7 @@ class RenderedContentHoverParts extends Disposable {
 				this._focusedHoverPartIndex = -1;
 			}));
 			// Add copy button for marker hovers
-			if (renderedPart.type === 'hoverPart') {
+			if (renderedPart.type === 'hoverPart' && !renderedPart.participant.hideCopyButton) {
 				disposables.add(new HoverCopyButton(
 					element,
 					() => renderedPart.participant.getAccessibleContent(renderedPart.hoverPart),

--- a/src/vs/editor/contrib/hover/browser/hoverTypes.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverTypes.ts
@@ -160,6 +160,7 @@ export class RenderedHoverParts<T extends IHoverPart> implements IRenderedHoverP
 
 export interface IEditorHoverParticipant<T extends IHoverPart = IHoverPart> {
 	readonly hoverOrdinal: number;
+	readonly hideCopyButton?: boolean;
 	suggestHoverAnchor?(mouseEvent: IEditorMouseEvent): HoverAnchor | null;
 	computeSync(anchor: HoverAnchor, lineDecorations: IModelDecoration[], source: HoverStartSource): T[];
 	computeAsync?(anchor: HoverAnchor, lineDecorations: IModelDecoration[], source: HoverStartSource, token: CancellationToken): AsyncIterable<T>;

--- a/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/hoverParticipant.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/hoverParticipant.ts
@@ -40,6 +40,7 @@ export class InlineCompletionsHover implements IHoverPart {
 export class InlineCompletionsHoverParticipant implements IEditorHoverParticipant<InlineCompletionsHover> {
 
 	public readonly hoverOrdinal: number = 4;
+	public readonly hideCopyButton: boolean = true;
 
 	constructor(
 		private readonly _editor: ICodeEditor,

--- a/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/inlineCompletionsHintsWidget.css
+++ b/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/inlineCompletionsHintsWidget.css
@@ -27,6 +27,7 @@
 
 .monaco-editor .inlineSuggestionsHints .keybinding {
 	display: flex;
+	align-items: center;
 	margin-left: 4px;
 	opacity: 0.6;
 }
@@ -43,5 +44,6 @@
 }
 
 .monaco-editor .inlineSuggestionStatusBarItemLabel {
+	align-items: center;
 	margin-right: 2px;
 }

--- a/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/inlineCompletionsHintsWidget.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/inlineCompletionsHintsWidget.ts
@@ -289,7 +289,7 @@ export class InlineSuggestionHintsContentWidget extends Disposable implements IC
 				tooltip: c.command.tooltip || '',
 				label: c.command.title,
 				run: (event) => {
-					return this._commandService.executeCommand(c.command.id);
+					return this._commandService.executeCommand(c.command.id, ...(c.command.arguments ?? []));
 				},
 			}));
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/inlineCompletionsHintsWidget.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/inlineCompletionsHintsWidget.ts
@@ -288,9 +288,7 @@ export class InlineSuggestionHintsContentWidget extends Disposable implements IC
 				enabled: true,
 				tooltip: c.command.tooltip || '',
 				label: c.command.title,
-				run: (event) => {
-					return this._commandService.executeCommand(c.command.id, ...(c.command.arguments ?? []));
-				},
+				run: () => this._commandService.executeCommand(c.command.id, ...(c.command.arguments ?? [])),
 			}));
 
 			for (const [_, group] of this.inlineCompletionsActionsMenus.getActions()) {


### PR DESCRIPTION
Fix editor completion feedback commands.
Align copilot hover vertically.
Hide the copy button that shows up on top of `...`.

Fixes #318871
Fixes #311070
Fixes #252673
Fixes #227954
