### PR TITLE
fix: AuthChallengeBadToken on concurrent session restore

### DIFF
--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -579,6 +579,18 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 
 	private readonly _connections = this._register(new DisposableMap<string, SSHConnection>());
 
+	/**
+	 * In-flight first-time establishments, keyed by `connectionKey`. The
+	 * {@link _connections} map only dedups *completed* connections; without
+	 * this, multiple windows restoring the same remote at once each run the
+	 * full establishment in parallel, every one spawning its own competing
+	 * `code agent host` (a machine-wide singleton) and clobbering the shared
+	 * remote lockfile/token — so all but one fail to connect (see #249861).
+	 * Concurrent callers for the same key share a single establishment and
+	 * therefore a single agent host.
+	 */
+	private readonly _pendingConnects = new Map<string, Promise<ISSHConnectResult>>();
+
 	private _nativeRequire: NodeJS.Require | undefined;
 
 	/**
@@ -696,6 +708,27 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			};
 		}
 
+		// No established connection yet. Share a single in-flight
+		// establishment across concurrent callers for the same host so that
+		// restoring multiple windows doesn't spawn competing agent hosts.
+		const pending = this._pendingConnects.get(connectionKey);
+		if (pending) {
+			this._logService.info(`${LOG_PREFIX} Reusing in-flight connect for ${connectionKey}`);
+			return pending;
+		}
+
+		const establishment = this._doConnect(config, connectionKey, replaceRelay);
+		this._pendingConnects.set(connectionKey, establishment);
+		try {
+			return await establishment;
+		} finally {
+			if (this._pendingConnects.get(connectionKey) === establishment) {
+				this._pendingConnects.delete(connectionKey);
+			}
+		}
+	}
+
+	private async _doConnect(config: ISSHAgentHostConfig, connectionKey: string, replaceRelay?: boolean): Promise<ISSHConnectResult> {
 		this._logService.info(`${LOG_PREFIX} ${replaceRelay ? 'Reconnecting' : 'Connecting'} to ${connectionKey}`);
 		let sshClient: SSHClient | undefined;
 

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -580,14 +580,14 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 	private readonly _connections = this._register(new DisposableMap<string, SSHConnection>());
 
 	/**
-	 * In-flight first-time establishments, keyed by `connectionKey`. The
-	 * {@link _connections} map only dedups *completed* connections; without
-	 * this, multiple windows restoring the same remote at once each run the
-	 * full establishment in parallel, every one spawning its own competing
-	 * `code agent host` (a machine-wide singleton) and clobbering the shared
-	 * remote lockfile/token — so all but one fail to connect (see #249861).
-	 * Concurrent callers for the same key share a single establishment and
-	 * therefore a single agent host.
+	 * In-flight establishments for keys with no completed connection yet,
+	 * keyed by `connectionKey`. The {@link _connections} map only dedups
+	 * *completed* connections; without this, multiple windows restoring the
+	 * same remote at once each run the full establishment in parallel, every
+	 * one spawning its own competing `code agent host` (a machine-wide
+	 * singleton) and clobbering the shared remote lockfile/token — so all but
+	 * one fail to connect (see #249861). Concurrent callers for the same key
+	 * share a single establishment and therefore a single agent host.
 	 */
 	private readonly _pendingConnects = new Map<string, Promise<ISSHConnectResult>>();
 

--- a/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
@@ -421,6 +421,59 @@ suite('SSHRemoteAgentHostMainService - connect flow', () => {
 		assert.strictEqual(service.relayCalled, 1); // no new relay
 	});
 
+	test('concurrent connects to the same host share one establishment', async () => {
+		// Restoring multiple windows calls connect() for the same host at
+		// once. Without in-flight dedup each call runs the full establishment
+		// in parallel, every one spawning its own competing agent host and
+		// clobbering the shared remote lockfile/token, so all but one fail
+		// (#249861). Only one establishment (one start + one relay) should run.
+		service.execResponses = [
+			{ stdout: '', code: 1 },              // cat state file (not found)
+			{ stdout: 'Linux\n', code: 0 },       // uname -s
+			{ stdout: 'x86_64\n', code: 0 },      // uname -m
+			{ stdout: '1.0.0\n', code: 0 },       // CLI --version (already installed)
+			{ stdout: '', code: 0 },              // echo state file (write)
+		];
+
+		const config = makeConfig({ sshConfigHost: 'myalias' });
+		const [r1, r2, r3] = await Promise.all([
+			service.connect(config),
+			service.connect(config),
+			service.connect(config),
+		]);
+
+		// Exactly one agent host started and one relay opened, shared by all.
+		assert.strictEqual(service.startCalled, 1);
+		assert.strictEqual(service.relayCalled, 1);
+		// Only one SSH client was created (the others reused the in-flight result).
+		assert.strictEqual(service.mockClients.length, 1);
+		// All callers got the same connection.
+		assert.strictEqual(r1.connectionId, r2.connectionId);
+		assert.strictEqual(r2.connectionId, r3.connectionId);
+		assert.strictEqual(r1.connectionToken, r3.connectionToken);
+	});
+
+	test('connect after an in-flight connect settles returns the established connection', async () => {
+		// Once a connect completes, its pending entry is cleared. A later
+		// duplicate connect for the same host returns the established
+		// connection (via the _connections fast-path) without restarting.
+		service.execResponses = [
+			{ stdout: '', code: 1 },
+			{ stdout: 'Linux\n', code: 0 },
+			{ stdout: 'x86_64\n', code: 0 },
+			{ stdout: '1.0.0\n', code: 0 },
+			{ stdout: '', code: 0 },
+		];
+
+		const config = makeConfig({ sshConfigHost: 'myalias' });
+		const r1 = await service.connect(config);
+		const r2 = await service.connect(config);
+
+		assert.strictEqual(service.startCalled, 1);
+		assert.strictEqual(service.relayCalled, 1);
+		assert.strictEqual(r1.connectionId, r2.connectionId);
+	});
+
 	test('creates fresh relay on reconnect without restarting agent', async () => {
 		// First connect: uname, CLI check, findRunningAgentHost (no state), write state
 		service.execResponses = [


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Restoring multiple remote SSH workspace sessions concurrently fails with `AuthChallengeBadToken` due to a race condition. VS Code doesn't use the cached `_connections` until they're successfully connected, which lead to multiple connection creations simultaneously.

My proposed fix adds a new `_pendingConnects` map with the pending connections that serves as a cache similar to the existing `_connections` map, so only one connection is attempted at once.

Fixes #249861