### PR TITLE
Avoid stale simple dialog folder updates

### DIFF
--- a/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
+++ b/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
@@ -998,15 +998,17 @@ export class SimpleFileDialog extends Disposable implements ISimpleFileDialog {
 				// The file/directory doesn't exist
 			}
 			const newValue = trailing ? this.pathAppend(newFolder, trailing) : this.pathFromUri(newFolder, true);
-			this.currentFolder = this.endsWithSlash(newFolder.path) ? newFolder : resources.addTrailingPathSeparator(newFolder, this.separator);
-			this.userEnteredPathSegment = trailing ? trailing : '';
+			const currentFolder = this.endsWithSlash(newFolder.path) ? newFolder : resources.addTrailingPathSeparator(newFolder, this.separator);
+			const userEnteredPathSegment = trailing ? trailing : '';
 
-			return this.createItems(folderStat, this.currentFolder, token).then(items => {
+			return this.createItems(folderStat, currentFolder, token).then(items => {
 				if (token.isCancellationRequested) {
 					this.busy = false;
 					return false;
 				}
 
+				this.currentFolder = currentFolder;
+				this.userEnteredPathSegment = userEnteredPathSegment;
 				this.filePickBox.itemActivation = ItemActivation.NONE;
 				this.filePickBox.items = items;
 
@@ -1089,7 +1091,7 @@ export class SimpleFileDialog extends Disposable implements ISimpleFileDialog {
 		// that the authority is preserved and the root is detected correctly.
 		const compareScheme = this.scopedAuthority ? this.scheme : Schemas.file;
 		const compareAuthority = this.scopedAuthority ?? '';
-		const fileRepresentationCurr = this.currentFolder.with({ scheme: compareScheme, authority: compareAuthority });
+		const fileRepresentationCurr = currFolder.with({ scheme: compareScheme, authority: compareAuthority });
 		const fileRepresentationParent = resources.dirname(fileRepresentationCurr);
 		if (!resources.isEqual(fileRepresentationCurr, fileRepresentationParent)) {
 			const parentFolder = resources.dirname(currFolder);

--- a/src/vs/workbench/services/dialogs/test/browser/simpleFileDialog.test.ts
+++ b/src/vs/workbench/services/dialogs/test/browser/simpleFileDialog.test.ts
@@ -4,13 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { timeout } from '../../../../../base/common/async.js';
 import * as resources from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { IFileStat } from '../../../../../platform/files/common/files.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IFileService, IFileStat } from '../../../../../platform/files/common/files.js';
+import { ItemActivation } from '../../../../../platform/quickinput/common/quickInput.js';
+import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
 import { SimpleFileDialog } from '../../browser/simpleFileDialog.js';
 
 suite('SimpleFileDialog', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('does not let a canceled slow folder update overwrite a newer folder', async () => {
 		const slowFolder = URI.file('/slow');
@@ -36,28 +40,32 @@ suite('SimpleFileDialog', () => {
 			};
 		}
 
-		const dialog = Object.assign(Object.create(SimpleFileDialog.prototype), {
-			fileService: {
-				resolve: (resource: URI) => resources.isEqual(resource, slowFolder) ? slowResolve : Promise.resolve(folderStat(resource))
-			},
+		const instantiationService = workbenchInstantiationService(undefined, disposables);
+		instantiationService.stub(IFileService, 'resolve', (resource: URI) => resources.isEqual(resource, slowFolder) ? slowResolve : Promise.resolve(folderStat(resource)));
+
+		const dialog = disposables.add(instantiationService.createInstance(SimpleFileDialog)) as unknown as {
+			updateItems(newFolder: URI, force?: boolean, trailing?: string): Promise<boolean>;
+			currentFolder: URI;
 			filePickBox: {
-				value: '',
-				valueSelection: undefined,
-				items: [],
-				itemActivation: undefined,
-				busy: false,
-				inputHasFocus: () => false
-			},
-			onBusyChangeEmitter: { fire() { } },
-			separator: '/',
-			currentFolder: URI.file('/'),
-			isWindows: false,
-			autoCompletePathSegment: '',
-			userEnteredPathSegment: '',
-			updatingPromise: undefined,
-			scopedAuthority: undefined,
-			createItems: async () => []
-		});
+				value: string;
+				valueSelection: undefined;
+				items: readonly unknown[];
+				itemActivation: ItemActivation | undefined;
+				busy: boolean;
+				inputHasFocus(): boolean;
+			};
+			createItems(): Promise<readonly unknown[]>;
+		};
+		dialog.filePickBox = {
+			value: '',
+			valueSelection: undefined,
+			items: [],
+			itemActivation: undefined,
+			busy: false,
+			inputHasFocus: () => false
+		};
+		dialog.currentFolder = URI.file('/');
+		dialog.createItems = async () => [];
 
 		const slowUpdate = dialog.updateItems(slowFolder, true).catch(() => undefined);
 		await dialog.updateItems(fastFolder, true);
@@ -66,7 +74,6 @@ suite('SimpleFileDialog', () => {
 		assert.strictEqual(dialog.filePickBox.value, '/fast/');
 
 		resolveSlow(folderStat(slowFolder));
-		await timeout(0);
 		await slowUpdate;
 
 		assert.strictEqual(dialog.currentFolder.toString(), resources.addTrailingPathSeparator(fastFolder).toString());

--- a/src/vs/workbench/services/dialogs/test/browser/simpleFileDialog.test.ts
+++ b/src/vs/workbench/services/dialogs/test/browser/simpleFileDialog.test.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { timeout } from '../../../../../base/common/async.js';
+import * as resources from '../../../../../base/common/resources.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { IFileStat } from '../../../../../platform/files/common/files.js';
+import { SimpleFileDialog } from '../../browser/simpleFileDialog.js';
+
+suite('SimpleFileDialog', () => {
+
+	test('does not let a canceled slow folder update overwrite a newer folder', async () => {
+		const slowFolder = URI.file('/slow');
+		const fastFolder = URI.file('/fast');
+
+		let resolveSlow!: (stat: IFileStat) => void;
+		const slowResolve = new Promise<IFileStat>(resolve => resolveSlow = resolve);
+
+		function folderStat(resource: URI): IFileStat {
+			return {
+				resource,
+				name: resources.basename(resource),
+				isFile: false,
+				isDirectory: true,
+				isSymbolicLink: false,
+				mtime: 0,
+				ctime: 0,
+				etag: '',
+				size: 0,
+				readonly: false,
+				locked: false,
+				children: []
+			};
+		}
+
+		const dialog = Object.assign(Object.create(SimpleFileDialog.prototype), {
+			fileService: {
+				resolve: (resource: URI) => resources.isEqual(resource, slowFolder) ? slowResolve : Promise.resolve(folderStat(resource))
+			},
+			filePickBox: {
+				value: '',
+				valueSelection: undefined,
+				items: [],
+				itemActivation: undefined,
+				busy: false,
+				inputHasFocus: () => false
+			},
+			onBusyChangeEmitter: { fire() { } },
+			separator: '/',
+			currentFolder: URI.file('/'),
+			isWindows: false,
+			autoCompletePathSegment: '',
+			userEnteredPathSegment: '',
+			updatingPromise: undefined,
+			scopedAuthority: undefined,
+			createItems: async () => []
+		});
+
+		const slowUpdate = dialog.updateItems(slowFolder, true).catch(() => undefined);
+		await dialog.updateItems(fastFolder, true);
+
+		assert.strictEqual(dialog.currentFolder.toString(), resources.addTrailingPathSeparator(fastFolder).toString());
+		assert.strictEqual(dialog.filePickBox.value, '/fast/');
+
+		resolveSlow(folderStat(slowFolder));
+		await timeout(0);
+		await slowUpdate;
+
+		assert.strictEqual(dialog.currentFolder.toString(), resources.addTrailingPathSeparator(fastFolder).toString());
+		assert.strictEqual(dialog.filePickBox.value, '/fast/');
+	});
+});


### PR DESCRIPTION
Fixes #152089

This fixes a race in the simple file dialog when a slower folder update is canceled by a newer one. Previously, the canceled update could still resume after `fileService.resolve` and write `currentFolder` / `userEnteredPathSegment` before checking the cancellation token. That stale state could then affect subsequent input handling on slow file system providers.

The update now computes the next folder state locally and only commits it after item creation finishes and the token is still active. `createBackItem` also uses the folder passed into `createItems` instead of reading `this.currentFolder`, so the current folder does not need to be mutated before the async item work completes.

Verification:
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npm run compile-client`
- red/green regression: the new browser test failed before the fix with `file:///slow/ === file:///fast/`, then passed after the fix
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npm run test-browser-no-install -- --run src/vs/workbench/services/dialogs/test/browser/simpleFileDialog.test.ts --browser chromium-chrome`
- `git diff --check`