### PR TITLE
Use AsyncIterableProducer for text diff changes

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -5,7 +5,7 @@
 
 import type * as vscode from 'vscode';
 import { CancellationTokenSource } from '../../../base/common/cancellation.js';
-import { AsyncIterableObject, raceCancellationError } from '../../../base/common/async.js';
+import { AsyncIterableProducer, raceCancellationError } from '../../../base/common/async.js';
 import * as errors from '../../../base/common/errors.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { combinedDisposable } from '../../../base/common/lifecycle.js';
@@ -1173,7 +1173,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				if (token?.isCancellationRequested) {
 					const error = new errors.CancellationError();
 					return {
-						changes: AsyncIterableObject.EMPTY,
+						changes: AsyncIterableProducer.EMPTY,
 						complete: Promise.reject(error),
 					};
 				}
@@ -1205,7 +1205,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				// In the future, we may want to stream changes incrementally as they are computed
 				// (e.g. by having the worker yield partial results).
 				return {
-					changes: new AsyncIterableObject<vscode.TextDiffChange>(async emitter => {
+					changes: new AsyncIterableProducer<vscode.TextDiffChange>(async emitter => {
 						const result = await mappedPromise;
 						emitter.emitMany(result.changes.map(mapChange));
 					}),


### PR DESCRIPTION
Refs #256854

## Why

`AsyncIterableObject` keeps an internal `_results` array of all emitted values so multiple iterators can replay the same data. The `workspace.getTextDiff` changes stream does not need that replay behavior: the diff result is produced once from the document diff promise, and `TextDiffResponse.changes` is expected to be consumed as a single async iterable.

`AsyncIterableProducer` is a better fit here because it does not retain emitted values. It passes values through its `ProducerConsumer`, which matches the one-shot nature of this stream and avoids the extra retained array.

## What

This updates `src/vs/workbench/api/common/extHost.api.impl.ts` so `getTextDiff` returns `changes` backed by `AsyncIterableProducer` instead of `AsyncIterableObject`.

The change covers:

- the async iterable import
- the cancellation path returning `EMPTY`
- the normal path creating the changes iterable

## Impact

This is a behavior-preserving refactor. API consumers still receive `AsyncIterable<TextDiffChange>` from `TextDiffResponse.changes`, and both implementations satisfy that interface.

There is no breaking API change.

## Validation

- `git diff --check -- src/vs/workbench/api/common/extHost.api.impl.ts`
- `npm run compile-check-ts-native -- --pretty false`

No new tests were added because this is a behavior-preserving implementation swap behind the existing `AsyncIterable<TextDiffChange>` API contract.