### PR TITLE
Refactor aquarium toggle icon implementation for improved styling and animation

### DIFF
--- a/src/vs/sessions/contrib/aquarium/browser/aquariumOverlay.ts
+++ b/src/vs/sessions/contrib/aquarium/browser/aquariumOverlay.ts
@@ -241,7 +241,10 @@ export class AquariumService extends Disposable implements IAquariumService {
 				iconSpan.classList.add(cls);
 			}
 		} else {
-			iconSpan.classList.add('agents-aquarium-toggle-logo');
+			const iconClasses = ThemeIcon.asClassName(Codicon.smiley).split(/\s+/).filter(Boolean);
+			for (const cls of iconClasses) {
+				iconSpan.classList.add(cls);
+			}
 		}
 		button.appendChild(iconSpan);
 		const label = this.getToggleLabel(active);

--- a/src/vs/sessions/contrib/aquarium/browser/aquariumOverlay.ts
+++ b/src/vs/sessions/contrib/aquarium/browser/aquariumOverlay.ts
@@ -235,6 +235,8 @@ export class AquariumService extends Disposable implements IAquariumService {
 		// Build the icon as a real DOM child instead of innerHTML to satisfy Trusted Types.
 		button.replaceChildren();
 		const iconSpan = button.ownerDocument.createElement('span');
+		// The icon is purely decorative; the button already has an aria-label.
+		iconSpan.setAttribute('aria-hidden', 'true');
 		if (active) {
 			const iconClasses = ThemeIcon.asClassName(Codicon.close).split(/\s+/).filter(Boolean);
 			for (const cls of iconClasses) {

--- a/src/vs/sessions/contrib/aquarium/browser/media/aquarium.css
+++ b/src/vs/sessions/contrib/aquarium/browser/media/aquarium.css
@@ -196,12 +196,12 @@
 
 .agents-aquarium-toggle {
 	position: absolute;
-	top: 8px;
-	left: 8px;
+	top: 7px;
+	left: 7px;
 	z-index: 100;
-	width: 22px;
-	height: 22px;
-	border-radius: 50%;
+	width: 24px;
+	height: 24px;
+	border-radius: var(--vscode-cornerRadius-circle);
 	border: var(--vscode-strokeThickness) solid transparent;
 	background: transparent;
 	color: var(--vscode-foreground, #cccccc);

--- a/src/vs/sessions/contrib/aquarium/browser/media/aquarium.css
+++ b/src/vs/sessions/contrib/aquarium/browser/media/aquarium.css
@@ -196,11 +196,11 @@
 
 .agents-aquarium-toggle {
 	position: absolute;
-	top: 12px;
-	left: 14px;
+	top: 8px;
+	left: 8px;
 	z-index: 100;
-	width: 24px;
-	height: 24px;
+	width: 22px;
+	height: 22px;
 	border-radius: 50%;
 	border: var(--vscode-strokeThickness) solid transparent;
 	background: transparent;
@@ -238,27 +238,17 @@
 	font-size: var(--vscode-codiconFontSize);
 }
 
-/* Off-state icon: the agents window logo (same asset as the mobile chat
- * shell's workspace picker). Theme-swapped under `.vs` / `.hc-light`. */
-.agents-aquarium-toggle-logo {
-	display: inline-block;
-	width: var(--vscode-codiconFontSize);
-	height: var(--vscode-codiconFontSize);
-	background: url('../../../../browser/media/sessions-logo-light.svg') center / contain no-repeat;
+/* Off-state icon (smiley): brief attention-grabbing wiggle every 12s. The
+ * keyframes hold the rest pose for ~93% of the cycle and only animate during
+ * the first ~7%. */
+.agents-aquarium-toggle:not(.active) .codicon {
 	transform-origin: 50% 50%;
-	/* Brief attention-grabbing wiggle every 12s. Keyframes hold the rest
-	 * pose for ~93% of the cycle and only animate during the first ~7%. */
 	animation: agents-aquarium-toggle-wiggle 12s ease-in-out infinite;
 }
 
-.vs .agents-aquarium-toggle-logo,
-.hc-light .agents-aquarium-toggle-logo {
-	background-image: url('../../../../browser/media/sessions-logo-dark.svg');
-}
-
 /* No need to nag once the user is engaging with the button. */
-.agents-aquarium-toggle:hover .agents-aquarium-toggle-logo,
-.agents-aquarium-toggle:focus-visible .agents-aquarium-toggle-logo {
+.agents-aquarium-toggle:hover .codicon,
+.agents-aquarium-toggle:focus-visible .codicon {
 	animation: none;
 }
 
@@ -292,7 +282,7 @@
 	.agents-aquarium-fish-strip,
 	.agents-aquarium-water::before,
 	.agents-aquarium-water::after,
-	.agents-aquarium-toggle-logo {
+	.agents-aquarium-toggle:not(.active) .codicon {
 		animation: none;
 	}
 


### PR DESCRIPTION
This pull request updates the appearance and behavior of the Aquarium toggle button in the UI, replacing the previous static logo icon with a dynamic smiley icon and refining its styling and animation. 

<img width="472" height="416" alt="image" src="https://github.com/user-attachments/assets/a7138b83-704d-4873-a0c1-d397064e48d8" />

The most important changes are:

**UI Icon Update and Behavior:**

* Replaced the previous static logo icon (`agents-aquarium-toggle-logo`) with a `smiley` Codicon for the Aquarium toggle button, updating the logic in `aquariumOverlay.ts` to use the new icon and its associated classes.
* Updated the CSS to remove references to the old logo asset and apply animation and styling to the new `codicon` icon, including a periodic attention-grabbing wiggle when inactive and stopping animation on hover or focus. [[1]](diffhunk://#diff-8e838ad1cb99ab9e0530bf8b7118aaa68c5f96ae19cc0bf25ca4931dca162ba8L241-R251) [[2]](diffhunk://#diff-8e838ad1cb99ab9e0530bf8b7118aaa68c5f96ae19cc0bf25ca4931dca162ba8L295-R285)

**Styling Adjustments:**

* Adjusted the Aquarium toggle button's size and position for better alignment and appearance, reducing its top, left, width, and height values in the CSS.
