### PR TITLE
sessions: order providers in service and inherit session type on new chat

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -68,7 +68,14 @@ class NewChatInSessionsWindowAction extends Action2 {
 	override run(accessor: ServicesAccessor): void {
 		const sessionsManagementService = accessor.get(ISessionsManagementService);
 		const sessionsViewService = accessor.get(ISessionsViewService);
-		sessionsViewService.openNewSession({ folderUri: sessionsManagementService.activeSession.get()?.workspace.get()?.uri });
+		// Inherit the active session's provider and session type so the new
+		// session defaults to the same kind the user is currently working in.
+		const activeSession = sessionsManagementService.activeSession.get();
+		sessionsViewService.openNewSession({
+			folderUri: activeSession?.workspace.get()?.uri,
+			providerId: activeSession?.providerId,
+			sessionTypeId: activeSession?.sessionType,
+		});
 	}
 }
 

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -256,7 +256,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 	getSessionTypesForFolder(folderUri: URI): IProviderSessionType[] {
 		const result: IProviderSessionType[] = [];
-		for (const provider of this._getOrderedProviders()) {
+		for (const provider of this.sessionsProvidersService.getProviders()) {
 			if (!provider.resolveWorkspace(folderUri)) {
 				continue;
 			}
@@ -280,7 +280,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 	private _collectSessionTypes(): ISessionType[] {
 		const types: ISessionType[] = [];
 		const seen = new Set<string>();
-		for (const provider of this._getOrderedProviders()) {
+		for (const provider of this.sessionsProvidersService.getProviders()) {
 			for (const type of provider.sessionTypes) {
 				if (!seen.has(type.id)) {
 					seen.add(type.id);
@@ -289,16 +289,6 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 			}
 		}
 		return types;
-	}
-
-	/**
-	 * Returns the registered providers in the order their session types should
-	 * be surfaced, sorted by each provider's {@link ISessionsProvider.order}
-	 * (lower first). The sort is stable, so providers with equal order keep
-	 * their registration order.
-	 */
-	private _getOrderedProviders(): ISessionsProvider[] {
-		return [...this.sessionsProvidersService.getProviders()].sort((a, b) => a.order - b.order);
 	}
 
 	private _updateSessionTypes(): void {

--- a/src/vs/sessions/services/sessions/browser/sessionsProvidersService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsProvidersService.ts
@@ -21,6 +21,11 @@ export interface ISessionsProvidersService {
 
 	readonly onDidChangeProviders: Event<ISessionsProvidersChangeEvent>;
 	registerProvider(provider: ISessionsProvider): IDisposable;
+	/**
+	 * Returns all registered providers sorted by each provider's
+	 * {@link ISessionsProvider.order} (lower first). The sort is stable, so
+	 * providers with equal order keep their registration order.
+	 */
 	getProviders(): ISessionsProvider[];
 	getProvider<T extends ISessionsProvider>(providerId: string): T | undefined;
 }
@@ -50,8 +55,13 @@ class SessionsProvidersService extends Disposable implements ISessionsProvidersS
 		});
 	}
 
+	/**
+	 * Returns all registered providers sorted by each provider's
+	 * {@link ISessionsProvider.order} (lower first). The sort is stable, so
+	 * providers with equal order keep their registration order.
+	 */
 	getProviders(): ISessionsProvider[] {
-		return Array.from(this._providers.values());
+		return Array.from(this._providers.values()).sort((a, b) => a.order - b.order);
 	}
 
 	getProvider<T extends ISessionsProvider>(providerId: string): T | undefined {

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -119,7 +119,7 @@ class TestSessionsProvidersService extends mock<ISessionsProvidersService>() {
 	}
 
 	override getProviders(): ISessionsProvider[] {
-		return [...this._providers];
+		return [...this._providers].sort((a, b) => a.order - b.order);
 	}
 
 	override getProvider<T extends ISessionsProvider>(providerId: string): T | undefined {


### PR DESCRIPTION
## What

- **Provider ordering moved into the service.** `SessionsProvidersService.getProviders()` now returns providers stably sorted by `ISessionsProvider.order` (lower first). Removed the redundant `_getOrderedProviders()` helper from `SessionsManagementService` and routed all callers through `getProviders()`.
- **New-session provider resolution respects order.** `_resolveProviderForNewSession()` previously iterated providers in raw registration order, so the "first provider that can resolve the folder" ignored provider precedence. It now goes through the ordered list.
- **"New Chat" command inherits the session type.** `NewChatInSessionsWindowAction` now passes the active session's `providerId` and `sessionType` (in addition to its workspace folder), so a new session defaults to the same kind the user is currently working in.

## Why

The previous `_resolveProviderForNewSession` ignored `ISessionsProvider.order`, picking whichever provider happened to be registered first. Centralizing the sort in the service guarantees every consumer gets the correct order. Inheriting the session type makes "New Chat" behave consistently with the active session.

## Notes for reviewers

- The test stub `TestSessionsProvidersService.getProviders()` was updated to sort, mirroring the real service.
- `openNewSession` safely ignores `providerId`/`sessionTypeId` when there is no active folder (all `undefined`, same as before).
- Validated with `compile-check-ts-native`, `valid-layers-check`, and the `SessionsManagementService` unit tests (18 passing).
