### PR TITLE
Show task summary in Agents window

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -192,6 +192,11 @@ interface ICopilotWebFetchToolArgs {
 	url: string;
 }
 
+/** Parameters for the `task_complete` tool. */
+interface ICopilotTaskCompleteToolArgs {
+	summary?: string;
+}
+
 /**
  * Parameters for the `apply_patch` / `git_apply_patch` tools. The patch text
  * itself lives in `input` using the V4A diff format (file headers like
@@ -580,6 +585,13 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 		}
 		case CopilotToolName.ExitPlanMode:
 			return localize('toolInvoke.exitPlanMode', "Presenting plan");
+		case CopilotToolName.TaskComplete: {
+			const args = parameters as ICopilotTaskCompleteToolArgs | undefined;
+			if (typeof args?.summary === 'string' && args.summary.length > 0) {
+				return md(args.summary);
+			}
+			return localize('toolInvoke.taskComplete', "Marking task as complete");
+		}
 		default:
 			return localize('toolInvoke.generic', "Using \"{0}\"", displayName);
 	}
@@ -690,6 +702,13 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 		}
 		case CopilotToolName.ExitPlanMode:
 			return localize('toolComplete.exitPlanMode', "Exited plan mode");
+		case CopilotToolName.TaskComplete: {
+			const args = parameters as ICopilotTaskCompleteToolArgs | undefined;
+			if (typeof args?.summary === 'string' && args.summary.length > 0) {
+				return md(args.summary);
+			}
+			return localize('toolComplete.taskComplete', "Task completed");
+		}
 		default:
 			return localize('toolComplete.generic', "Used \"{0}\"", displayName);
 	}

--- a/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
@@ -497,6 +497,40 @@ suite('web_fetch tool display', () => {
 	});
 });
 
+suite('task_complete tool display', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function text(msg: ReturnType<typeof getInvocationMessage> | ReturnType<typeof getPastTenseMessage>): string {
+		return typeof msg === 'string' ? msg : msg.markdown;
+	}
+
+	test('uses the summary as invocation and completion messages so the user sees what the agent did', () => {
+		const parameters = { summary: 'Fixed the failing test by updating the assertion message.' };
+		assert.deepStrictEqual({
+			invocation: text(getInvocationMessage('task_complete', 'Task Complete', parameters)),
+			pastTense: text(getPastTenseMessage('task_complete', 'Task Complete', parameters, true)),
+		}, {
+			invocation: 'Fixed the failing test by updating the assertion message.',
+			pastTense: 'Fixed the failing test by updating the assertion message.',
+		});
+	});
+
+	test('falls back to generic wording when the summary is absent or empty', () => {
+		assert.deepStrictEqual({
+			invocationUndefined: text(getInvocationMessage('task_complete', 'Task Complete', undefined)),
+			pastTenseUndefined: text(getPastTenseMessage('task_complete', 'Task Complete', undefined, true)),
+			invocationEmpty: text(getInvocationMessage('task_complete', 'Task Complete', { summary: '' })),
+			pastTenseEmpty: text(getPastTenseMessage('task_complete', 'Task Complete', { summary: '' }, true)),
+		}, {
+			invocationUndefined: 'Marking task as complete',
+			pastTenseUndefined: 'Task completed',
+			invocationEmpty: 'Marking task as complete',
+			pastTenseEmpty: 'Task completed',
+		});
+	});
+});
+
 suite('sql tool display', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/taskCompleteTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/taskCompleteTool.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolInvocationPresentation, ToolProgress, CountTokensCallback } from '../languageModelToolsService.js';
 
 export const TaskCompleteToolId = 'task_complete';
@@ -58,9 +59,23 @@ export const TaskCompleteToolData: IToolData = {
 };
 
 export class TaskCompleteTool implements IToolImpl {
-	async prepareToolInvocation(_context: IToolInvocationPreparationContext, _token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
+	async prepareToolInvocation(context: IToolInvocationPreparationContext, _token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
+		const params = context.parameters as { summary?: string } | undefined;
+		const summary = typeof params?.summary === 'string' ? params.summary.trim() : '';
+		if (!summary) {
+			// No summary to show — keep the tool invocation hidden from the UI.
+			return {
+				presentation: ToolInvocationPresentation.Hidden,
+			};
+		}
+		// Surface the agent's summary so the user can see what was accomplished.
+		// The tool description tells the model to put the summary here (instead of
+		// in its assistant message text) — so if we hide it the user is left
+		// without any indication of what the agent did. See microsoft/vscode#321390.
+		const message = new MarkdownString(summary);
 		return {
-			presentation: ToolInvocationPresentation.Hidden,
+			invocationMessage: message,
+			pastTenseMessage: message,
 		};
 	}
 

--- a/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/taskCompleteTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/taskCompleteTool.test.ts
@@ -1,0 +1,91 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../../../../base/common/cancellation.js';
+import { isMarkdownString } from '../../../../../../../base/common/htmlContent.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
+import { TaskCompleteTool } from '../../../../common/tools/builtinTools/taskCompleteTool.js';
+import { ToolInvocationPresentation } from '../../../../common/tools/languageModelToolsService.js';
+
+suite('TaskCompleteTool', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function getMessageText(value: string | { value: string } | undefined): string | undefined {
+		if (value === undefined) {
+			return undefined;
+		}
+		return typeof value === 'string' ? value : value.value;
+	}
+
+	test('prepareToolInvocation hides the invocation when no summary is provided', async () => {
+		const tool = new TaskCompleteTool();
+		const result = await tool.prepareToolInvocation({
+			parameters: {},
+			toolCallId: 'call-1',
+			chatSessionResource: undefined,
+		}, CancellationToken.None);
+		assert.strictEqual(result?.presentation, ToolInvocationPresentation.Hidden);
+	});
+
+	test('prepareToolInvocation hides the invocation when summary is an empty string', async () => {
+		const tool = new TaskCompleteTool();
+		const result = await tool.prepareToolInvocation({
+			parameters: { summary: '   ' },
+			toolCallId: 'call-1',
+			chatSessionResource: undefined,
+		}, CancellationToken.None);
+		assert.strictEqual(result?.presentation, ToolInvocationPresentation.Hidden);
+	});
+
+	test('prepareToolInvocation surfaces the summary so the user sees what was done', async () => {
+		const tool = new TaskCompleteTool();
+		const summary = 'Refactored the auth flow and added regression tests.';
+		const result = await tool.prepareToolInvocation({
+			parameters: { summary },
+			toolCallId: 'call-1',
+			chatSessionResource: undefined,
+		}, CancellationToken.None);
+
+		assert.deepStrictEqual({
+			presentation: result?.presentation,
+			invocation: getMessageText(result?.invocationMessage as string | { value: string } | undefined),
+			pastTense: getMessageText(result?.pastTenseMessage as string | { value: string } | undefined),
+			invocationIsMarkdown: isMarkdownString(result?.invocationMessage),
+			pastTenseIsMarkdown: isMarkdownString(result?.pastTenseMessage),
+		}, {
+			presentation: undefined,
+			invocation: summary,
+			pastTense: summary,
+			invocationIsMarkdown: true,
+			pastTenseIsMarkdown: true,
+		});
+	});
+
+	test('invoke returns the provided summary as the tool result', async () => {
+		const tool = new TaskCompleteTool();
+		const result = await tool.invoke({
+			callId: 'call-1',
+			toolId: 'task_complete',
+			parameters: { summary: 'All tests pass.' },
+			context: undefined,
+		}, async () => 0, { report: () => { } }, CancellationToken.None);
+
+		assert.deepStrictEqual(result.content, [{ kind: 'text', value: 'All tests pass.' }]);
+	});
+
+	test('invoke falls back to "All done!" when no summary is provided', async () => {
+		const tool = new TaskCompleteTool();
+		const result = await tool.invoke({
+			callId: 'call-1',
+			toolId: 'task_complete',
+			parameters: {},
+			context: undefined,
+		}, async () => 0, { report: () => { } }, CancellationToken.None);
+
+		assert.deepStrictEqual(result.content, [{ kind: 'text', value: 'All done!' }]);
+	});
+});


### PR DESCRIPTION
Expose the task completion summary in the Agents window when the 'task_complete' tool is invoked. This change ensures users can see what the agent accomplished, addressing the issue where the summary was previously not displayed. Unit tests validate the new behavior. Fixes #321390.