### PR TITLE
fix: use Ctrl+Alt+T for Go to Symbol in Workspace when in browser/Codespaces

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchActionsSymbol.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsSymbol.ts
@@ -10,6 +10,7 @@ import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/c
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
+import { isWeb } from '../../../../base/common/platform.js';
 
 //#region Actions
 registerAction2(class ShowAllSymbolsAction extends Action2 {
@@ -29,7 +30,7 @@ registerAction2(class ShowAllSymbolsAction extends Action2 {
 			f1: true,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyMod.CtrlCmd | KeyCode.KeyT
+				primary: isWeb ? KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyT : KeyMod.CtrlCmd | KeyCode.KeyT
 			},
 			menu: {
 				id: MenuId.MenubarGoMenu,


### PR DESCRIPTION
In Codespaces/web (browser), Ctrl+T opens a new browser tab instead of triggering 'Go to Symbol in Workspace'. This changes the default keybinding to Ctrl+Alt+T in web context to avoid the conflict. On desktop, Ctrl+T remains unchanged.

Fixes #232381