### PR TITLE
Fix Wayland display detection in snap electron-launch

### DIFF
--- a/resources/linux/snap/electron-launch
+++ b/resources/linux/snap/electron-launch
@@ -153,13 +153,14 @@ if [[ -n "$XDG_RUNTIME_DIR" && -z "$DISABLE_WAYLAND" ]]; then
     fi
     wayland_sockpath="$XDG_RUNTIME_DIR/../$wdisplay"
     wayland_snappath="$XDG_RUNTIME_DIR/$wdisplay"
-    if [ -S "$wayland_sockpath" ]; then
+    # Check both the snap path and the parent directory path for the Wayland socket
+    if [ -S "$wayland_snappath" ] || [ -S "$wayland_sockpath" ]; then
         # if running under wayland, use it
         #export WAYLAND_DEBUG=1
         # shellcheck disable=SC2034
         wayland_available=true
-        # create the compat symlink for now
-        if [ ! -e "$wayland_snappath" ]; then
+        # create the compat symlink for now (only if parent path exists and snap path doesn't)
+        if [ -S "$wayland_sockpath" ] && [ ! -e "$wayland_snappath" ]; then
             ln -s "$wayland_sockpath" "$wayland_snappath"
         fi
     fi


### PR DESCRIPTION
The Wayland socket detection in the snap electron-launch script only checked for the socket at $XDG_RUNTIME_DIR/../$wdisplay (parent directory). On many systems the socket is directly at $XDG_RUNTIME_DIR/$wdisplay, causing the check to fail and wayland_available to remain false, which leads to the xdg-open Wayland display warning.

Fix by checking both paths, and only creating the compat symlink when the parent path exists and the snap path doesn't.

Fixes #223591