### PR TITLE
Fix terminal tool handling of interactive prompts in agent terminals

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/toolTerminalCreator.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/toolTerminalCreator.ts
@@ -164,6 +164,10 @@ export class ToolTerminalCreator {
 			// `:` is a POSIX shell built-in no-op (returns 0), works cross-platform
 			// since git always invokes the editor via `sh -c`.
 			GIT_EDITOR: ':',
+			// Prevent apt/dpkg from opening interactive prompts (e.g. needrestart
+			// "Which services should be restarted?" dialogs). The agent cannot
+			// drive TUI prompts, so non-interactive mode picks safe defaults.
+			DEBIAN_FRONTEND: 'noninteractive',
 		};
 
 		const preventShellHistory = this._configurationService.getValue(TerminalChatAgentToolsSettingId.PreventShellHistory) === true;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -147,6 +147,7 @@ function createPowerShellModelDescription(shell: string, isSandboxEnabled: boole
 		'- Be specific with Select-Object properties to avoid excessive output',
 		'- Avoid printing credentials unless absolutely required',
 		`- NEVER run Start-Sleep or similar wait commands. You will be automatically notified on your next turn when async terminal commands or timed-out sync commands complete or need input. Do NOT poll for completion.`,
+		'- NEVER pipe interactive commands through Select-Object, Where-Object, or other filters — this hides prompts and prevents the terminal from detecting when input is needed. Run interactive commands without pipes.',
 		'',
 		'Interactive Input Handling:',
 		'- When a terminal command is waiting for interactive input, do NOT suggest alternatives or ask the user whether to proceed. Instead, use the vscode_askQuestions tool to collect the needed values from the user, then send them.',
@@ -242,6 +243,7 @@ Best Practices:
 - Be specific with commands to avoid excessive output
 - Avoid printing credentials unless absolutely required
 - NEVER run sleep or similar wait commands in a terminal. You will be automatically notified on your next turn when async terminal commands or timed-out sync commands complete or need input. Do NOT poll for completion.
+- NEVER pipe interactive commands through tail, head, grep, or other filters — this hides prompts and prevents the terminal from detecting when input is needed. Run interactive commands without pipes.
 
 Interactive Input Handling:
 - When a terminal command is waiting for interactive input, do NOT suggest alternatives or ask the user whether to proceed. Instead, use the vscode_askQuestions tool to collect the needed values from the user, then send them.


### PR DESCRIPTION
Fixes #321444

## Problem

Two issues cause the agent terminal to get stuck on interactive prompts during package installs:

1. **needrestart/debconf TUI prompts** — `apt-get install` triggers a "Which services should be restarted?" TUI dialog that no `OutputMonitor` pattern matches. The agent waits 60s for the idle silence timeout, gets handed back a "moved to background" message, and gives up.

2. **Pipe buffering hides prompts** — When the model pipes interactive commands through `tail`/`head`/`grep`, the pipe buffers all output. Interactive prompts (like opam `[Y/n]`) never reach the terminal buffer, so the `OutputMonitor` cannot detect them. The `[Y/n]` pattern *would* match `detectsHighConfidenceInputPattern` — but the pipe prevents it.

## Fix

- Set `DEBIAN_FRONTEND=noninteractive` in the copilot agent terminal env vars (`toolTerminalCreator.ts`), alongside existing `GIT_PAGER`, `GIT_EDITOR`, etc. This prevents apt/dpkg from ever opening interactive prompts — packages install normally with default selections.

- Add system prompt guidance in `runInTerminalTool.ts` (both bash and PowerShell descriptions) warning the model to never pipe interactive commands through filters.

## Evidence

Found via terminalbench2 eval analysis comparing vscode-copilot-cli vs copilot-cli (12 consistent regressions, ~13% gap). These two issues account for 2 of those 12:
- **nginx-request-logging**: agent wasted 5 min on needrestart prompt, never configured nginx. copilot-cli finished in 33s.
- **compile-compcert**: `opam install ... | tail -20` hid the `[Y/n]` depext prompt for 5 min. copilot-cli answered `n` and continued.