### PR TITLE
Fix askQuestions rejecting single option with allowFreeformInput

### DIFF
--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/askQuestionsTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/askQuestionsTool.ts
@@ -281,7 +281,7 @@ export class AskQuestionsTool extends Disposable implements IToolImpl {
 		}
 
 		for (const question of questions) {
-			if (question.options && question.options.length === 1) {
+			if (question.options && question.options.length === 1 && !question.allowFreeformInput) {
 				throw new Error(localize('askQuestionsTool.invalidOptions', 'Question "{0}" must have at least two options, or none for free text input.', question.header));
 			}
 		}

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/askQuestionsTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/askQuestionsTool.ts
@@ -282,7 +282,7 @@ export class AskQuestionsTool extends Disposable implements IToolImpl {
 
 		for (const question of questions) {
 			if (question.options && question.options.length === 1 && !question.allowFreeformInput) {
-				throw new Error(localize('askQuestionsTool.invalidOptions', 'Question "{0}" must have at least two options, or none for free text input.', question.header));
+				throw new Error(localize('askQuestionsTool.invalidOptions', 'Question "{0}" must have at least two options, or set allowFreeformInput when providing a single option, or omit options for free text input.', question.header));
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/askQuestionsTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/askQuestionsTool.test.ts
@@ -266,3 +266,56 @@ suite('AskQuestionsTool - invoke', () => {
 		});
 	});
 });
+
+suite('AskQuestionsTool - prepareToolInvocation validation', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+	let tool: AskQuestionsTool;
+
+	setup(() => {
+		tool = store.add(new AskQuestionsTool(
+			null! as IChatService,
+			NullTelemetryService,
+			new NullLogService(),
+			new TestConfigurationService()
+		));
+	});
+
+	function makeContext(questions: IQuestion[]) {
+		return {
+			parameters: { questions },
+			toolCallId: 'test-call',
+			chatRequestId: 'request-1',
+			chatSessionResource: URI.parse('test://session'),
+		};
+	}
+
+	test('rejects single option without freeform input', async () => {
+		await assert.rejects(
+			tool.prepareToolInvocation(makeContext([
+				{ header: 'Q1', question: 'Pick one', options: [{ label: 'Only option' }] }
+			]), CancellationToken.None),
+			/must have at least two options/
+		);
+	});
+
+	test('allows single option with freeform input', async () => {
+		const result = await tool.prepareToolInvocation(makeContext([
+			{ header: 'Q1', question: 'Pick one', options: [{ label: 'Only option' }], allowFreeformInput: true }
+		]), CancellationToken.None);
+		assert.ok(result);
+	});
+
+	test('allows two or more options without freeform input', async () => {
+		const result = await tool.prepareToolInvocation(makeContext([
+			{ header: 'Q1', question: 'Pick one', options: [{ label: 'A' }, { label: 'B' }] }
+		]), CancellationToken.None);
+		assert.ok(result);
+	});
+
+	test('allows no options (free text)', async () => {
+		const result = await tool.prepareToolInvocation(makeContext([
+			{ header: 'Q1', question: 'Type something' }
+		]), CancellationToken.None);
+		assert.ok(result);
+	});
+});


### PR DESCRIPTION
## Problem
`vscode_askQuestions` rejects questions with exactly 1 option even when `allowFreeformInput: true`. The validation at `prepareToolInvocation` checks `options.length === 1` unconditionally, without considering that freeform input effectively provides a second choice.

## Fix
Added `&& !question.allowFreeformInput` guard to the single-option validation check. When `allowFreeformInput` is true, 1 predefined option + free-text input gives the user a meaningful choice.

## Tests
Added 4 test cases covering the validation logic:
- Rejects single option without freeform input ✓
- Allows single option with freeform input ✓  
- Allows two or more options without freeform input ✓
- Allows no options (free text) ✓

Fixes #312672