### PR TITLE
Fix permission picker screen reader issues

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -14,7 +14,7 @@ import { IAction, SubmenuAction, toAction } from '../../../base/common/actions.j
 import { CancellationToken, CancellationTokenSource } from '../../../base/common/cancellation.js';
 import { Codicon } from '../../../base/common/codicons.js';
 import { Emitter } from '../../../base/common/event.js';
-import { IMarkdownString, MarkdownString } from '../../../base/common/htmlContent.js';
+import { IMarkdownString, isMarkdownString, MarkdownString } from '../../../base/common/htmlContent.js';
 import { ResolvedKeybinding } from '../../../base/common/keybindings.js';
 import { AnchorPosition } from '../../../base/common/layout.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../base/common/lifecycle.js';
@@ -663,6 +663,13 @@ export class ActionListWidget<T> extends Disposable {
 						} else if (element.description) {
 							const descText = typeof element.description === 'string' ? element.description : element.description.value;
 							label = label + ', ' + stripNewlines(descText);
+						}
+						if (element.hover?.content && !element.ariaDescription && !element.description) {
+							const hoverContent = element.hover.content;
+							const hoverText = typeof hoverContent === 'string' ? hoverContent : isMarkdownString(hoverContent) ? hoverContent.value : dom.isHTMLElement(hoverContent) ? hoverContent.textContent ?? undefined : undefined;
+							if (hoverText && (!element.detail || stripNewlines(element.detail) !== stripNewlines(hoverText))) {
+								label = label + ', ' + stripNewlines(hoverText);
+							}
 						}
 						if (element.group?.title) {
 							label = label + ', ' + element.group.title;

--- a/src/vs/platform/actionWidget/browser/actionWidgetDropdown.ts
+++ b/src/vs/platform/actionWidget/browser/actionWidgetDropdown.ts
@@ -217,9 +217,23 @@ export class ActionWidgetDropdown extends BaseDropdown {
 			}
 		}
 
+		const nonSeparatorItems = actionWidgetItems.filter(i => i.kind === ActionListItemKind.Action);
+
 		const accessibilityProvider: Partial<IListAccessibilityProvider<IActionListItem<IActionWidgetDropdownAction>>> = {
 			isChecked(element) {
 				return element.kind === ActionListItemKind.Action && !!element?.item?.checked;
+			},
+			getSetSize: () => nonSeparatorItems.length,
+			getPosInSet: (_element, index) => {
+				// Count only Action items up to this index; clamp to at least 1
+				// since aria-posinset must be in the range 1..aria-setsize
+				let pos = 0;
+				for (let i = 0; i <= index && i < actionWidgetItems.length; i++) {
+					if (actionWidgetItems[i].kind === ActionListItemKind.Action) {
+						pos++;
+					}
+				}
+				return Math.max(pos, 1);
 			},
 			getRole: (e) => {
 				switch (e.kind) {


### PR DESCRIPTION
## Problem
Two accessibility issues with the Permission Picker combobox in Copilot chat:

1. **Incorrect position count** (#321403): NVDA announces "5 of 5" when there are only 4 items (Default, Bypass, Autopilot, Learn More). The separator between the main items and Learn More was being counted in `aria-setsize`/`aria-posinset`.

2. **Tooltip not announced** (#321415): Hover tooltip text associated with each permission level is not announced by screen readers. The tooltip content provides important context about each permission option.

## Fix

**`actionWidgetDropdown.ts`**: Added `getSetSize` and `getPosInSet` to the accessibility provider to exclude separators and headers from the count. Now correctly announces "1 of 4", "2 of 4", etc.

**`actionList.ts`**: Enhanced `getAriaLabel` to include `hover.content` in the aria label when no other description text (`ariaDescription` or `description`) is already present, so the tooltip information is exposed to assistive technologies.

Fixes #321403
Fixes #321415