### PR TITLE
Add Codex3PIntegration policy for chat.agentHost.codexAgent.enabled

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -129,6 +129,21 @@
             "included": true
         },
         {
+            "key": "chat.agentHost.codexAgent.enabled",
+            "name": "Codex3PIntegration",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.126",
+            "localization": {
+                "description": {
+                    "key": "chat.agentHost.codexAgent.enabled.policy",
+                    "value": "Enable Codex Agent sessions in VS Code. Start and resume agentic coding sessions powered by OpenAI Codex SDK directly in the editor. Uses your existing Copilot subscription."
+                }
+            },
+            "type": "boolean",
+            "default": false,
+            "included": true
+        },
+        {
             "key": "chat.tools.global.autoApprove",
             "name": "ChatToolsAutoApprove",
             "category": "InteractiveSession",

--- a/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as nls from '../../../nls.js';
+import { PolicyCategory } from '../../../base/common/policy.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../configuration/common/configurationRegistry.js';
 import product from '../../product/common/product.js';
 import { Registry } from '../../registry/common/platform.js';
@@ -54,6 +55,17 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.agentHost.codexAgent.enabled', "When enabled, the agent host registers the Codex provider (subject to the Codex SDK being reachable). Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect."),
 			default: false,
 			tags: ['experimental', 'advanced'],
+			policy: {
+				name: 'Codex3PIntegration',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.126',
+				localization: {
+					description: {
+						key: 'chat.agentHost.codexAgent.enabled.policy',
+						value: nls.localize('chat.agentHost.codexAgent.enabled.policy', "Enable Codex Agent sessions in VS Code. Start and resume agentic coding sessions powered by OpenAI Codex SDK directly in the editor. Uses your existing Copilot subscription."),
+					}
+				}
+			}
 		},
 		[AgentHostCodexAgentSdkRootSettingId]: {
 			type: 'string',


### PR DESCRIPTION
Enterprise admins currently have no policy control over the Codex agent provider. This mirrors the existing `Claude3PIntegration` pattern by adding a `Codex3PIntegration` policy to `chat.agentHost.codexAgent.enabled`, allowing organizations to lock or disable the Codex agent via OS-level mechanisms (Windows Group Policy, macOS managed preferences, Linux config files) or GitHub account-level policy.

**Approach:**

- Added a `policy:` block to the `chat.agentHost.codexAgent.enabled` setting registration in `agentHostStarter.config.contribution.ts`
- Includes a `value` function that respects `policyData.chat_preview_features_enabled === false`, so orgs that disable preview features automatically prevent Codex from being enabled
- Regenerated `build/lib/policies/policyData.jsonc` via `npm run export-policy-data`

**Details:**
- Policy name: `Codex3PIntegration`
- Category: `InteractiveSession`
- minimumVersion: `1.126`