### PR TITLE
Gate chat.agentHost.enabled behind editor preview policy

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -238,6 +238,21 @@
             "included": true
         },
         {
+            "key": "chat.agentHost.enabled",
+            "name": "ChatAgentHostEnabled",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.126",
+            "localization": {
+                "description": {
+                    "key": "chat.agentHost.enabled",
+                    "value": "When enabled, some agents run in a separate agent host process."
+                }
+            },
+            "type": "boolean",
+            "default": true,
+            "included": true
+        },
+        {
             "key": "chat.plugins.enabled",
             "name": "ChatPluginsEnabled",
             "category": "InteractiveSession",

--- a/src/vs/platform/agentHost/browser/agentHost.config.contribution.ts
+++ b/src/vs/platform/agentHost/browser/agentHost.config.contribution.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IPolicyData } from '../../../base/common/defaultAccount.js';
+import { isWeb } from '../../../base/common/platform.js';
+import { PolicyCategory } from '../../../base/common/policy.js';
+import * as nls from '../../../nls.js';
+import { Extensions as ConfigurationExtensions, IConfigurationNode, IConfigurationRegistry } from '../../configuration/common/configurationRegistry.js';
+import product from '../../product/common/product.js';
+import { Registry } from '../../registry/common/platform.js';
+import { AgentHostEnabledSettingId } from '../common/agentService.js';
+
+// Re-registers `chat.agentHost.enabled` with the `policy` block attached.
+// The bare setting (type + default) is registered in the common layer so the
+// main process knows the default; this browser-only file adds the policy's
+// `value` callback which cannot be structured-cloned over Electron IPC.
+//
+// Side-effect imports of this file:
+//   - `src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts`
+
+const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+const oldNode: IConfigurationNode = { id: 'chatAgentHost', properties: { [AgentHostEnabledSettingId]: configurationRegistry.getConfigurationProperties()[AgentHostEnabledSettingId] } };
+const newNode: IConfigurationNode = {
+	id: 'chatAgentHost',
+	properties: {
+		[AgentHostEnabledSettingId]: {
+			type: 'boolean',
+			description: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process."),
+			default: !isWeb && product.quality !== 'stable',
+			tags: ['experimental', 'advanced'],
+			policy: {
+				name: 'ChatAgentHostEnabled',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.126',
+				value: (policyData: IPolicyData) => policyData.chat_preview_features_enabled === false ? false : undefined,
+				localization: {
+					description: {
+						key: 'chat.agentHost.enabled',
+						value: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process.")
+					}
+				},
+			}
+		},
+	}
+};
+configurationRegistry.updateConfigurations({ remove: [oldNode], add: [newNode] });

--- a/src/vs/platform/agentHost/common/agentHost.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHost.config.contribution.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { isWeb } from '../../../base/common/platform.js';
+import { PolicyCategory } from '../../../base/common/policy.js';
 import * as nls from '../../../nls.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../configuration/common/configurationRegistry.js';
 import product from '../../product/common/product.js';
@@ -34,6 +35,18 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process."),
 			default: !isWeb && product.quality !== 'stable',
 			tags: ['experimental', 'advanced'],
+			policy: {
+				name: 'ChatAgentHostEnabled',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.109',
+				value: (policyData) => policyData.chat_preview_features_enabled === false ? false : undefined,
+				localization: {
+					description: {
+						key: 'chat.agentHost.enabled.description',
+						value: nls.localize('chat.agentHost.enabled.description', "When enabled, some agents run in a separate agent host process.")
+					}
+				},
+			}
 		},
 		'chat.agents.copilotCli.hideExtensionHost': {
 			type: 'boolean',

--- a/src/vs/platform/agentHost/common/agentHost.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHost.config.contribution.ts
@@ -4,25 +4,22 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { isWeb } from '../../../base/common/platform.js';
-import { PolicyCategory } from '../../../base/common/policy.js';
 import * as nls from '../../../nls.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../configuration/common/configurationRegistry.js';
 import product from '../../product/common/product.js';
 import { Registry } from '../../registry/common/platform.js';
 import { AgentHostEnabledSettingId } from './agentService.js';
 
-// `chat.agentHost.enabled` is read in the desktop main process
-// (`src/vs/code/electron-main/app.ts`) to decide whether to spawn the agent
-// host, and in the renderer for various gating decisions. The remote server
-// does **not** consume this key — it spawns the agent host based on its own
-// `--agent-host-port` / `--agent-host-path` CLI args — so this registration
-// is intentionally not imported there.
-//
 // Side-effect imports of this file:
 //   - `src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts`
 //     (loaded transitively from `app.ts`).
 //   - `src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts`
 //     (renderer registration for the settings UI).
+//
+// The `policy` block for `chat.agentHost.enabled` is added in the browser
+// layer (`agentHost/browser/agentHost.config.contribution.ts`) via
+// `updateConfigurations` because the `value` callback cannot be
+// structured-cloned over Electron IPC.
 
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 configurationRegistry.registerConfiguration({
@@ -35,18 +32,6 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process."),
 			default: !isWeb && product.quality !== 'stable',
 			tags: ['experimental', 'advanced'],
-			policy: {
-				name: 'ChatAgentHostEnabled',
-				category: PolicyCategory.InteractiveSession,
-				minimumVersion: '1.126',
-				value: (policyData) => policyData.chat_preview_features_enabled === false ? false : undefined,
-				localization: {
-					description: {
-						key: 'chat.agentHost.enabled',
-						value: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process.")
-					}
-				},
-			}
 		},
 		'chat.agents.copilotCli.hideExtensionHost': {
 			type: 'boolean',

--- a/src/vs/platform/agentHost/common/agentHost.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHost.config.contribution.ts
@@ -38,12 +38,12 @@ configurationRegistry.registerConfiguration({
 			policy: {
 				name: 'ChatAgentHostEnabled',
 				category: PolicyCategory.InteractiveSession,
-				minimumVersion: '1.109',
+				minimumVersion: '1.126',
 				value: (policyData) => policyData.chat_preview_features_enabled === false ? false : undefined,
 				localization: {
 					description: {
-						key: 'chat.agentHost.enabled.description',
-						value: nls.localize('chat.agentHost.enabled.description', "When enabled, some agents run in a separate agent host process.")
+						key: 'chat.agentHost.enabled',
+						value: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process.")
 					}
 				},
 			}

--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -532,5 +532,5 @@ const _allApiProposals = {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.workspaceTrust.d.ts',
 	}
 };
-export const allApiProposals = Object.freeze<{ [proposalName: string]: Readonly<{ proposal: string; version?: number }> }>(_allApiProposals);
+export const allApiProposals = Object.freeze<{ [proposalName: string]: Readonly<{ proposal: string }> }>(_allApiProposals);
 export type ApiProposalName = keyof typeof _allApiProposals;

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -10,6 +10,7 @@ import { autorun, observableFromEvent } from '../../../../base/common/observable
 import { isMacintosh } from '../../../../base/common/platform.js';
 import { PolicyCategory } from '../../../../base/common/policy.js';
 import '../../../../platform/agentHost/common/agentHost.config.contribution.js';
+import '../../../../platform/agentHost/browser/agentHost.config.contribution.js';
 import '../../../../platform/agentHost/common/agentHostStarter.config.contribution.js';
 import { AgentHostAhpJsonlLoggingSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostSdkSandboxEnabledSettingId, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHostEditorSettingId } from '../../../../platform/agentHost/common/agentService.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../../../platform/networkFilter/common/networkFilterService.js';


### PR DESCRIPTION
Organizations that set `chat_preview_features_enabled` to `false` expect all preview/experimental chat features to be disabled. The agent host setting (`chat.agentHost.enabled`) was not gated by this policy, meaning the agent host process could still spawn even when the org has preview features turned off.

This adds a `policy` block to the setting registration, following the same pattern used by `ChatHooks` and `ChatToolsAutoApprove`. When the account policy data has `chat_preview_features_enabled === false`, the setting is forced to `false`.

**How to test:**
1. Simulate account policy data with `chat_preview_features_enabled: false`
2. Verify `chat.agentHost.enabled` resolves to `false` and the agent host does not spawn