### PR TITLE
Fix chat.plugins.enabledPlugins setting description for general use

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -956,7 +956,7 @@ configurationRegistry.registerConfiguration({
 		[ChatConfiguration.EnabledPlugins]: {
 			type: 'object',
 			additionalProperties: { type: 'boolean' },
-			markdownDescription: nls.localize('chat.plugins.enabledPlugins', "Enterprise-managed plugin enablement. Keys are plugin IDs in `<plugin>@<marketplace>` form (resolved to Copilot CLI install paths); values enable (`true`) or disable (`false`) the plugin. Discovered alongside the path-keyed entries in {0}. When set by policy, also restricts which marketplace-discovered plugins are allowed to load (only IDs mapped to `true` here pass the gate).", `\`#${ChatConfiguration.PluginLocations}#\``),
+			markdownDescription: nls.localize('chat.plugins.enabledPlugins', "Controls which [agent plugins](https://aka.ms/vscode-agent-plugins) are enabled or disabled. Keys are plugin IDs in `<plugin>@<marketplace>` form (where marketplace is defined in {1}); values enable (`true`) or disable (`false`) the plugin. Discovered alongside the path-keyed entries in {0}. When set by policy, only plugins mapped to `true` here are allowed to load.", `\`#${ChatConfiguration.PluginLocations}#\``, `\`#${ChatConfiguration.PluginMarketplaces}#\``),
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental'],
 			policy: {


### PR DESCRIPTION
The `chat.plugins.enabledPlugins` setting description opened with "Enterprise-managed plugin enablement" which made it sound like a niche admin-only control, even though it applies to all users who work with agent plugins.

This rewrites the description to:
- Lead with "Controls which agent plugins are enabled or disabled" -- clearer and user-friendly
- Link to the docs at https://aka.ms/vscode-agent-plugins so users can learn more
- Reference the `chat.plugins.marketplaces` setting to explain the `@<marketplace>` portion of plugin IDs
- Keep the policy behavior note at the end for admins who need it

Fixes #321479