### PR TITLE
Remove preview/experimental tags from plugin settings

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -932,7 +932,6 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			description: nls.localize('chat.plugins.enabled', "Enable agent plugin integration in chat."),
 			default: true,
-			tags: ['preview'],
 			policy: {
 				name: 'ChatPluginsEnabled',
 				category: PolicyCategory.InteractiveSession,
@@ -958,7 +957,6 @@ configurationRegistry.registerConfiguration({
 			additionalProperties: { type: 'boolean' },
 			markdownDescription: nls.localize('chat.plugins.enabledPlugins', "Enterprise-managed plugin enablement. Keys are plugin IDs in `<plugin>@<marketplace>` form (resolved to Copilot CLI install paths); values enable (`true`) or disable (`false`) the plugin. Discovered alongside the path-keyed entries in {0}. When set by policy, also restricts which marketplace-discovered plugins are allowed to load (only IDs mapped to `true` here pass the gate).", `\`#${ChatConfiguration.PluginLocations}#\``),
 			scope: ConfigurationScope.APPLICATION,
-			tags: ['experimental'],
 			policy: {
 				name: 'ChatEnabledPlugins',
 				category: PolicyCategory.InteractiveSession,
@@ -1003,7 +1001,6 @@ configurationRegistry.registerConfiguration({
 			default: {},
 			scope: ConfigurationScope.APPLICATION,
 			included: false,
-			tags: ['experimental'],
 			markdownDescription: nls.localize('chat.plugins.extraMarketplaces', "Enterprise-managed additional plugin marketplaces. Unioned with {0}.", `\`#${ChatConfiguration.PluginMarketplaces}#\``),
 			policy: {
 				name: 'ChatExtraMarketplaces',


### PR DESCRIPTION
Agent plugins are no longer in preview. This removes the `tags: ['preview']` and `tags: ['experimental']` annotations from three plugin configuration settings so they no longer display preview/experimental badges in the Settings UI.

**Settings updated:**
- `chat.plugins.enabled` -- removed `['preview']`
- `chat.plugins.enabledPlugins` -- removed `['experimental']`
- `chat.plugins.extraMarketplaces` -- removed `['experimental']`