### PR TITLE
sessions: mention show_ui=false in create-pr skill

### DIFF
--- a/src/vs/sessions/skills/create-pr/SKILL.md
+++ b/src/vs/sessions/skills/create-pr/SKILL.md
@@ -13,4 +13,4 @@ Use the GitHub MCP server to create a pull request — do NOT use the `gh` CLI.
 3. Review all changes in the current session
 4. Write a clear, concise PR title with a short area prefix (e.g. "sessions: …", "editor: …")
 5. Write a description covering what changed, why, and anything reviewers should know
-6. Create the pull request
+6. Create the pull request, passing `show_ui=false` so the PR is created without opening a confirmation UI


### PR DESCRIPTION
## What changed
Updated the built-in `create-pr` skill (`src/vs/sessions/skills/create-pr/SKILL.md`) to instruct that the PR should be created with `show_ui=false` so it is created without opening a confirmation UI.

## Why
The skill previously didn't mention the `show_ui` parameter, which could cause the create-pull-request flow to prompt with a confirmation UI instead of completing automatically.

## Notes for reviewers
Docs-only change to a skill markdown file.