### PR TITLE
Track terminal-to-session association by session ID instead of cwd

### DIFF
--- a/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
+++ b/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
@@ -349,16 +349,16 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 
 		const instances = await this.ensureTerminal(targetPath, false, session);
 
-		// If the active key changed while we were awaiting, a newer call has
-		// taken over — skip the visibility update to avoid flicker.
-		if (this._activeKey !== targetKey) {
+		// If the active session or key changed while we were awaiting, a newer
+		// call has taken over — skip the visibility update to avoid flicker.
+		if (this._activeKey !== targetKey || this._activeSessionId !== session.sessionId) {
 			return;
 		}
 		await this._updateTerminalVisibility(session, targetKey, instances.map(instance => instance.instanceId));
 	}
 
 	/**
-	 * Finds the first terminal instance whose initial cwd (lower-cased) matches
+	 * Finds all terminal instances whose initial cwd (lower-cased) matches
 	 * the given key.
 	 */
 	private async _findTerminalsForKey(key: string, options?: { excludeTracked?: boolean }): Promise<ITerminalInstance[]> {

--- a/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
+++ b/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
@@ -71,16 +71,19 @@ function getSessionTerminalInfo(session: ISession | undefined, reader?: IReader)
 /**
  * Manages terminal instances in the sessions window, ensuring:
  * - A terminal exists for the active session's worktree (or repository if no worktree).
- * - Terminals are shown/hidden based on their initial cwd matching the active path.
- * - Terminals for an archived/removed session are closed only when no other
- *   live session still owns the same cwd (terminals are reused across sessions
- *   at the same worktree).
+ * - Terminals are tracked per session id and shown/hidden based on that association.
+ * - Terminals created before session-id tracking fall back to initial cwd matching
+ *   until they are associated with a session in this window.
+ * - Terminals for archived/removed sessions are hidden/closed using their tracked
+ *   session id association while keeping the active terminal protected.
  */
 export class SessionsTerminalContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'workbench.contrib.sessionsTerminal';
 
 	private _activeKey: string | undefined;
+	private _activeSessionId: string | undefined;
+	private readonly _sessionTerminals = new Map<string, Set<number>>();
 
 	/**
 	 * Session ids already processed as archived. The archive cleanup runs only
@@ -166,6 +169,7 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 			const session = this._sessionsService.activeSession.read(reader);
 			if (session?.loading.read(reader)) {
 				this._activeKey = undefined;
+				this._activeSessionId = undefined;
 				return;
 			}
 			this._onActiveSessionChanged(session);
@@ -193,17 +197,15 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 			}
 		}));
 
-		// Clean up terminals for archived/removed sessions, but only when no other
-		// live session still owns that cwd. Terminals are reused across sessions
-		// at the same cwd, so a plain cwd match would affect a terminal still in
-		// use (e.g. the committed session from `onDidReplaceSession`).
+		// Clean up terminals for archived/removed sessions using their tracked
+		// session-to-terminal associations.
 		//
 		// Archive vs remove differ in how aggressive the cleanup is:
 		// - Archiving is reversible and terminals can be reused by
-		//   other sessions, so we only HIDE the terminal (the pty survives and can
-		//   be shown again on unarchive or reuse). See `_hideTerminalsForPath`.
+		//   the same session, so we only HIDE the terminal (the pty survives and can
+		//   be shown again on unarchive or reuse). See `_hideTerminalsForSession`.
 		// - Removal is an explicit, destructive user action, so we KILL the
-		//   terminal. See `_closeTerminalsForPath`.
+		//   terminal. See `_closeTerminalsForSession`.
 		//
 		// The archive cleanup runs only on the not-archived → archived transition.
 		// The provider keeps archived sessions cached and re-emits them in
@@ -214,10 +216,8 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		// Both paths are asynchronous and can land while the user is working in a
 		// just-opened terminal at this cwd (e.g. removal also covers untitled →
 		// committed graduation via `onDidReplaceSession`, which surfaces the
-		// skeleton in `removed` while the committed session inherits the same cwd
-		// but may not have resolved its workspace yet). The focused (active)
-		// terminal is therefore never touched on either path. See #313510, #318645.
-		// TODO: tag terminals by sessionId (1:1) instead of guarding by cwd here.
+		// skeleton in `removed`). The focused (active) terminal is therefore never
+		// touched on either path. See #313510, #318645.
 
 		this._register(this._sessionsManagementService.onDidChangeSessions(e => {
 			// Only act on the not-archived → archived transition; ignore re-emits
@@ -247,46 +247,34 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 			if (e.removed.length === 0 && justArchived.length === 0) {
 				return;
 			}
-			const removedIds = new Set(e.removed.map(s => s.sessionId));
-			const liveCwdKeys = new Set<string>();
-			for (const session of this._sessionsManagementService.getSessions()) {
-				if (removedIds.has(session.sessionId) || session.isArchived.get()) {
-					continue;
-				}
-				const info = getSessionTerminalInfo(session);
-				if (info) {
-					liveCwdKeys.add(info.cwd.fsPath.toLowerCase());
-				}
-			}
-			this._logService.info(`[SessionsTerminal] onDidChangeSessions cleanup (removed: ${e.removed.length}, justArchived: ${justArchived.length}, liveCwdKeys: [${[...liveCwdKeys].join(', ')}], activeKey: ${this._activeKey ?? '<none>'})`);
+			this._logService.info(`[SessionsTerminal] onDidChangeSessions cleanup (removed: ${e.removed.length}, justArchived: ${justArchived.length}, trackedSessions: [${[...this._sessionTerminals.keys()].join(', ')}], activeKey: ${this._activeKey ?? '<none>'})`);
 			for (const session of e.removed) {
-				const info = getSessionTerminalInfo(session);
-				if (info && !liveCwdKeys.has(info.cwd.fsPath.toLowerCase())) {
-					this._logService.info(`[SessionsTerminal] Closing terminals for ${info.cwd.fsPath} (session ${session.sessionId} removed; no live session owns this cwd)`);
-					void this._closeTerminalsForPath(info.cwd.fsPath, `session removed (${session.sessionId})`);
-				}
+				this._logService.info(`[SessionsTerminal] Closing terminals for session ${session.sessionId} (session removed)`);
+				void this._closeTerminalsForSession(session.sessionId, `session removed (${session.sessionId})`).finally(() => this._sessionTerminals.delete(session.sessionId));
 			}
 			for (const session of justArchived) {
-				const info = getSessionTerminalInfo(session);
-				if (info && !liveCwdKeys.has(info.cwd.fsPath.toLowerCase())) {
-					this._logService.info(`[SessionsTerminal] Hiding terminals for ${info.cwd.fsPath} (session ${session.sessionId} archived; no live session owns this cwd)`);
-					void this._hideTerminalsForPath(info.cwd.fsPath, `session archived (${session.sessionId})`);
-				}
+				this._logService.info(`[SessionsTerminal] Hiding terminals for session ${session.sessionId} (session archived)`);
+				void this._hideTerminalsForSession(session.sessionId, `session archived (${session.sessionId})`);
 			}
 		}));
 	}
 
 	/**
-	 * Ensures a terminal exists for the given cwd by scanning all terminal
-	 * instances for a matching initial cwd. If none is found, creates a new
-	 * one. Sets it as active and optionally focuses it.
+	 * Ensures a terminal exists for the given cwd. When a session is provided,
+	 * tracked terminals for that session id are preferred; otherwise the method
+	 * falls back to matching untracked terminals by initial cwd for backward
+	 * compatibility before creating a new terminal. Sets newly created terminals
+	 * as active and optionally focuses them.
 	 *
 	 * When {@link session} is provided and the session is backed by an agent
 	 * host, the terminal is created on the agent host instead of locally.
 	 */
 	async ensureTerminal(cwd: URI, focus: boolean, session?: ISession): Promise<ITerminalInstance[]> {
 		const key = cwd.fsPath.toLowerCase();
-		let existing = await this._findTerminalsForKey(key);
+		let existing = session ? this._getTrackedTerminalsForSession(session.sessionId) : [];
+		if (existing.length === 0) {
+			existing = await this._findTerminalsForKey(key, { excludeTracked: !!session });
+		}
 
 		if (existing.length === 0) {
 			try {
@@ -302,6 +290,10 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 				this._logService.trace(`[SessionsTerminal] Cannot create terminal for ${cwd.fsPath}: ${e}`);
 				return [];
 			}
+		}
+
+		if (session) {
+			this._trackTerminalsForSession(session.sessionId, existing);
 		}
 
 		if (focus) {
@@ -349,30 +341,34 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		const info = getSessionTerminalInfo(session);
 		const targetPath = info?.cwd ?? await this._pathService.userHome();
 		const targetKey = targetPath.fsPath.toLowerCase();
-		if (this._activeKey === targetKey) {
+		if (this._activeKey === targetKey && this._activeSessionId === session.sessionId) {
 			return;
 		}
 		this._activeKey = targetKey;
+		this._activeSessionId = session.sessionId;
 
-		const instances = await this.ensureTerminal(targetPath, false, info?.agentHostCwd ? session : undefined);
+		const instances = await this.ensureTerminal(targetPath, false, session);
 
 		// If the active key changed while we were awaiting, a newer call has
 		// taken over — skip the visibility update to avoid flicker.
 		if (this._activeKey !== targetKey) {
 			return;
 		}
-		await this._updateTerminalVisibility(targetKey, instances.map(instance => instance.instanceId));
+		await this._updateTerminalVisibility(session, targetKey, instances.map(instance => instance.instanceId));
 	}
 
 	/**
 	 * Finds the first terminal instance whose initial cwd (lower-cased) matches
 	 * the given key.
 	 */
-	private async _findTerminalsForKey(key: string): Promise<ITerminalInstance[]> {
+	private async _findTerminalsForKey(key: string, options?: { excludeTracked?: boolean }): Promise<ITerminalInstance[]> {
 		const result: ITerminalInstance[] = [];
 		for (const instance of this._terminalService.instances) {
 			// Skip hidden tool terminals — managed by the chat tool lifecycle
 			if (instance.shellLaunchConfig.hideFromUser) {
+				continue;
+			}
+			if (options?.excludeTracked && this._isTerminalTracked(instance.instanceId)) {
 				continue;
 			}
 			try {
@@ -387,6 +383,61 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		return result;
 	}
 
+	private _trackTerminalsForSession(sessionId: string, instances: readonly ITerminalInstance[]): void {
+		if (instances.length === 0) {
+			return;
+		}
+		let terminalIds = this._sessionTerminals.get(sessionId);
+		if (!terminalIds) {
+			terminalIds = new Set<number>();
+			this._sessionTerminals.set(sessionId, terminalIds);
+		}
+		for (const instance of instances) {
+			terminalIds.add(instance.instanceId);
+		}
+	}
+
+	private _getTrackedTerminalsForSession(sessionId: string): ITerminalInstance[] {
+		const terminalIds = this._sessionTerminals.get(sessionId);
+		if (!terminalIds) {
+			return [];
+		}
+
+		const result: ITerminalInstance[] = [];
+		for (const instanceId of [...terminalIds]) {
+			const instance = this._terminalService.getInstanceFromId(instanceId);
+			if (!instance || instance.isDisposed || instance.shellLaunchConfig.hideFromUser) {
+				terminalIds.delete(instanceId);
+				continue;
+			}
+			result.push(instance);
+		}
+
+		if (terminalIds.size === 0) {
+			this._sessionTerminals.delete(sessionId);
+		}
+
+		return result;
+	}
+
+	private _isTerminalTracked(instanceId: number): boolean {
+		for (const terminalIds of this._sessionTerminals.values()) {
+			if (terminalIds.has(instanceId)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private _removeTerminalFromTrackedSessions(instanceId: number): void {
+		for (const [sessionId, terminalIds] of this._sessionTerminals) {
+			terminalIds.delete(instanceId);
+			if (terminalIds.size === 0) {
+				this._sessionTerminals.delete(sessionId);
+			}
+		}
+	}
+
 	private _getAvailableTerminal(instance: ITerminalInstance, action: string): ITerminalInstance | undefined {
 		const currentInstance = this._terminalService.getInstanceFromId(instance.instanceId);
 		if (!currentInstance || currentInstance.isDisposed) {
@@ -397,12 +448,16 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 	}
 
 	/**
-	 * Shows background terminals whose initial cwd matches the active key and
-	 * hides foreground terminals whose initial cwd does not match.
+	 * Shows background terminals that belong to the active session and hides
+	 * foreground terminals that belong to other sessions. When the active
+	 * session has no tracked terminals yet, falls back to initial cwd matching
+	 * for compatibility with restored terminals from previous sessions.
 	 */
-	private async _updateTerminalVisibility(activeKey: string, forceForegroundTerminalIds: number[]): Promise<void> {
+	private async _updateTerminalVisibility(activeSession: ISession, activeKey: string, forceForegroundTerminalIds: number[]): Promise<void> {
 		const toShow: ITerminalInstance[] = [];
 		const toHide: ITerminalInstance[] = [];
+		const trackedTerminalIds = new Set(this._getTrackedTerminalsForSession(activeSession.sessionId).map(instance => instance.instanceId));
+		const useCwdFallback = trackedTerminalIds.size === 0;
 
 		for (const instance of [...this._terminalService.instances]) {
 			// Skip hidden tool terminals — managed by the chat tool lifecycle
@@ -410,19 +465,22 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 				continue;
 			}
 			let cwd: string | undefined;
-			try {
-				cwd = (await instance.getInitialCwd()).toLowerCase();
-			} catch {
-				continue;
-			}
-			const currentInstance = this._getAvailableTerminal(instance, `update visibility for ${cwd}`);
+			const currentInstance = this._getAvailableTerminal(instance, 'update terminal visibility');
 			if (!currentInstance) {
 				continue;
 			}
 
 			const isForeground = this._terminalService.foregroundInstances.includes(currentInstance);
 			const isForceVisible = forceForegroundTerminalIds.includes(currentInstance.instanceId);
-			const belongsToActiveSession = cwd === activeKey;
+			let belongsToActiveSession = trackedTerminalIds.has(currentInstance.instanceId);
+			if (!belongsToActiveSession && useCwdFallback) {
+				try {
+					cwd = (await currentInstance.getInitialCwd()).toLowerCase();
+				} catch {
+					continue;
+				}
+				belongsToActiveSession = cwd === activeKey;
+			}
 			if ((belongsToActiveSession || isForceVisible) && !isForeground) {
 				toShow.push(currentInstance);
 			} else if (!belongsToActiveSession && !isForceVisible && isForeground) {
@@ -462,56 +520,39 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 	}
 
 	/**
-	 * Disposes (kills) terminals whose initial cwd matches the given path. Used
+	 * Disposes (kills) terminals associated with the given session id. Used
 	 * when a session is removed: removal is an explicit user action, so the pty
 	 * is torn down.
 	 *
 	 * Never disposes the terminal the user is currently working in. Removal also
 	 * covers session *graduation* (untitled → committed via `onDidReplaceSession`,
-	 * which surfaces the skeleton in `removed`): the committed session inherits
-	 * the same cwd but its workspace may not be resolved yet, so a plain cwd sweep
-	 * would kill the focused terminal the user just used for the first turn. The
-	 * focused (active) instance is therefore always protected.
+	 * which surfaces the skeleton in `removed`): the focused (active) instance is
+	 * therefore always protected.
 	 *
 	 * {@link reason} is logged for each killed terminal so unexpected disposals in
 	 * the agents window can be diagnosed from the logs. See #313510, #318645.
 	 */
-	private async _closeTerminalsForPath(fsPath: string, reason: string): Promise<void> {
-		const key = fsPath.toLowerCase();
+	private async _closeTerminalsForSession(sessionId: string, reason: string): Promise<void> {
 		const protectedInstanceId = this._terminalService.activeInstance?.instanceId;
-		for (const instance of [...this._terminalService.instances]) {
-			// Skip hidden tool terminals (e.g. run_in_terminal) — those are
-			// managed by the chat tool lifecycle, not the session terminal
-			// contribution.
-			if (instance.shellLaunchConfig.hideFromUser) {
+		for (const instance of this._getTrackedTerminalsForSession(sessionId)) {
+			if (protectedInstanceId !== undefined && instance.instanceId === protectedInstanceId) {
+				this._logService.info(`[SessionsTerminal] Skipping active terminal ${instance.instanceId} for session ${sessionId} (user is working in it)`);
 				continue;
 			}
-			try {
-				const cwd = (await instance.getInitialCwd()).toLowerCase();
-				if (cwd !== key) {
-					continue;
-				}
-				if (protectedInstanceId !== undefined && instance.instanceId === protectedInstanceId) {
-					this._logService.info(`[SessionsTerminal] Skipping active terminal ${instance.instanceId} for ${fsPath} (user is working in it)`);
-					continue;
-				}
-				const availableInstance = this._getAvailableTerminal(instance, `close removed session terminal for ${fsPath}`);
-				if (!availableInstance) {
-					continue;
-				}
-				this._logService.info(`[SessionsTerminal] Killing terminal ${availableInstance.instanceId} (cwd: ${fsPath}, reason: ${reason})`);
-				await this._terminalService.safeDisposeTerminal(availableInstance);
-			} catch {
-				// ignore
+			const availableInstance = this._getAvailableTerminal(instance, `close removed session terminal for session ${sessionId}`);
+			if (!availableInstance) {
+				continue;
 			}
+			this._logService.info(`[SessionsTerminal] Killing terminal ${availableInstance.instanceId} (session: ${sessionId}, reason: ${reason})`);
+			await this._terminalService.safeDisposeTerminal(availableInstance);
+			this._removeTerminalFromTrackedSessions(availableInstance.instanceId);
 		}
 	}
 
 	/**
-	 * Hides (moves to background) terminals whose initial cwd matches the given
-	 * path without disposing them. Used when a session is archived ("Mark as
-	 * Done"): archiving is reversible and terminals are reused across sessions
-	 * at the same cwd, so the pty must survive so it can be shown again.
+	 * Hides (moves to background) terminals associated with the given session id
+	 * without disposing them. Used when a session is archived ("Mark as Done"):
+	 * archiving is reversible and the pty must survive so it can be shown again.
 	 *
 	 * Archiving is asynchronous and can land while the user is working in a
 	 * just-opened terminal at this cwd, so the focused (active) instance is
@@ -521,39 +562,25 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 	 * changes in the agents window can be diagnosed from the logs. See #313510,
 	 * #318645.
 	 */
-	private async _hideTerminalsForPath(fsPath: string, reason: string): Promise<void> {
-		const key = fsPath.toLowerCase();
+	private async _hideTerminalsForSession(sessionId: string, reason: string): Promise<void> {
 		const protectedInstanceId = this._terminalService.activeInstance?.instanceId;
-		for (const instance of [...this._terminalService.instances]) {
-			// Skip hidden tool terminals (e.g. run_in_terminal) — those are
-			// managed by the chat tool lifecycle, not the session terminal
-			// contribution.
-			if (instance.shellLaunchConfig.hideFromUser) {
+		for (const instance of this._getTrackedTerminalsForSession(sessionId)) {
+			if (protectedInstanceId !== undefined && instance.instanceId === protectedInstanceId) {
+				this._logService.info(`[SessionsTerminal] Skipping active terminal ${instance.instanceId} for session ${sessionId} (user is working in it)`);
 				continue;
 			}
-			try {
-				const cwd = (await instance.getInitialCwd()).toLowerCase();
-				if (cwd !== key) {
-					continue;
-				}
-				if (protectedInstanceId !== undefined && instance.instanceId === protectedInstanceId) {
-					this._logService.info(`[SessionsTerminal] Skipping active terminal ${instance.instanceId} for ${fsPath} (user is working in it)`);
-					continue;
-				}
-				const availableInstance = this._getAvailableTerminal(instance, `hide archived terminal for ${fsPath}`);
-				if (!availableInstance) {
-					continue;
-				}
-				this._logService.info(`[SessionsTerminal] Hiding terminal ${availableInstance.instanceId} (cwd: ${fsPath}, reason: ${reason})`);
-				this._terminalService.moveToBackground(availableInstance);
-			} catch {
-				// ignore
+			const availableInstance = this._getAvailableTerminal(instance, `hide archived terminal for session ${sessionId}`);
+			if (!availableInstance) {
+				continue;
 			}
+			this._logService.info(`[SessionsTerminal] Hiding terminal ${availableInstance.instanceId} (session: ${sessionId}, reason: ${reason})`);
+			this._terminalService.moveToBackground(availableInstance);
 		}
 	}
 
 	async dumpTracking(): Promise<void> {
 		console.log(`[SessionsTerminal] Active key: ${this._activeKey ?? '<none>'}`);
+		console.log(`[SessionsTerminal] Session terminals: ${JSON.stringify([...this._sessionTerminals.entries()].map(([sessionId, terminalIds]) => [sessionId, [...terminalIds]]))}`);
 		console.log('[SessionsTerminal] === All Terminals ===');
 		for (const instance of this._terminalService.instances) {
 			let cwd = '<unknown>';
@@ -640,7 +667,7 @@ class OpenSessionInTerminalAction extends Action2 {
 		const activeSession = sessionsService.activeSession.get();
 		const info = getSessionTerminalInfo(activeSession);
 		const cwd = info?.cwd ?? await pathService.userHome();
-		await contribution.ensureTerminal(cwd, true, info?.agentHostCwd ? activeSession : undefined);
+		await contribution.ensureTerminal(cwd, true, activeSession);
 		viewsService.openView(TERMINAL_VIEW_ID);
 	}
 }

--- a/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
+++ b/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
@@ -175,6 +175,31 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 			this._onActiveSessionChanged(session);
 		}));
 
+		// When a session is replaced (untitled → committed graduation), transfer
+		// tracked terminals from the old session id to the new one so they are
+		// not orphaned and closed by the removal cleanup.
+		this._register(this._sessionsManagementService.onDidReplaceSession(({ from, to }) => {
+			const terminalIds = this._sessionTerminals.get(from.sessionId);
+			if (terminalIds && terminalIds.size > 0) {
+				let targetIds = this._sessionTerminals.get(to.sessionId);
+				if (!targetIds) {
+					targetIds = new Set<number>();
+					this._sessionTerminals.set(to.sessionId, targetIds);
+				}
+				for (const id of terminalIds) {
+					targetIds.add(id);
+				}
+				this._logService.trace(`[SessionsTerminal] Transferred ${terminalIds.size} terminal(s) from session ${from.sessionId} to ${to.sessionId}`);
+			}
+			this._sessionTerminals.delete(from.sessionId);
+		}));
+
+		// Clean up tracked terminal ids when terminals are externally disposed
+		// (e.g. user closes a terminal tab) so the map doesn't hold stale entries.
+		this._register(this._terminalService.onDidDisposeInstance(instance => {
+			this._removeTerminalFromTrackedSessions(instance.instanceId);
+		}));
+
 		// Hide restored terminals from a previous window session that don't
 		// belong to the current active session. These arrive asynchronously
 		// during reconnection and would otherwise flash in the foreground.
@@ -421,8 +446,16 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 	}
 
 	private _isTerminalTracked(instanceId: number): boolean {
-		for (const terminalIds of this._sessionTerminals.values()) {
+		for (const [sessionId, terminalIds] of this._sessionTerminals) {
 			if (terminalIds.has(instanceId)) {
+				const instance = this._terminalService.getInstanceFromId(instanceId);
+				if (!instance || instance.isDisposed) {
+					terminalIds.delete(instanceId);
+					if (terminalIds.size === 0) {
+						this._sessionTerminals.delete(sessionId);
+					}
+					continue;
+				}
 				return true;
 			}
 		}
@@ -457,7 +490,6 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		const toShow: ITerminalInstance[] = [];
 		const toHide: ITerminalInstance[] = [];
 		const trackedTerminalIds = new Set(this._getTrackedTerminalsForSession(activeSession.sessionId).map(instance => instance.instanceId));
-		const useCwdFallback = trackedTerminalIds.size === 0;
 
 		for (const instance of [...this._terminalService.instances]) {
 			// Skip hidden tool terminals — managed by the chat tool lifecycle
@@ -473,7 +505,10 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 			const isForeground = this._terminalService.foregroundInstances.includes(currentInstance);
 			const isForceVisible = forceForegroundTerminalIds.includes(currentInstance.instanceId);
 			let belongsToActiveSession = trackedTerminalIds.has(currentInstance.instanceId);
-			if (!belongsToActiveSession && useCwdFallback) {
+			if (!belongsToActiveSession && !this._isTerminalTracked(currentInstance.instanceId)) {
+				// Untracked terminal (e.g. restored from a previous window) — fall
+				// back to cwd matching so it is shown alongside the session's tracked
+				// terminals rather than incorrectly hidden.
 				try {
 					cwd = (await currentInstance.getInitialCwd()).toLowerCase();
 				} catch {

--- a/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
+++ b/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
@@ -214,7 +214,9 @@ suite('SessionsTerminalContribution', () => {
 	let contribution: SessionsTerminalContribution;
 	let activeSessionObs: ReturnType<typeof observableValue<IActiveSession | undefined>>;
 	let onDidChangeSessions: Emitter<ISessionsChangeEvent>;
+	let onDidReplaceSession: Emitter<{ readonly from: ISession; readonly to: ISession }>;
 	let onDidCreateInstance: Emitter<ITerminalInstance>;
+	let onDidDisposeInstance: Emitter<ITerminalInstance>;
 
 	let createdTerminals: { cwd: URI }[];
 	let activeInstanceSet: number[];
@@ -252,12 +254,15 @@ suite('SessionsTerminalContribution', () => {
 
 		activeSessionObs = observableValue<IActiveSession | undefined>('activeSession', undefined);
 		onDidChangeSessions = store.add(new Emitter<ISessionsChangeEvent>());
+		onDidReplaceSession = store.add(new Emitter<{ readonly from: ISession; readonly to: ISession }>());
 		onDidCreateInstance = store.add(new Emitter<ITerminalInstance>());
+		onDidDisposeInstance = store.add(new Emitter<ITerminalInstance>());
 
 		instantiationService.stub(ILogService, logService);
 
 		instantiationService.stub(ISessionsManagementService, new class extends mock<ISessionsManagementService>() {
 			override readonly onDidChangeSessions = onDidChangeSessions.event;
+			override readonly onDidReplaceSession = onDidReplaceSession.event;
 			override getSessions(): ISession[] { return [...allSessions]; }
 		});
 		instantiationService.stub(ISessionsService, new class extends mock<ISessionsService>() {
@@ -266,6 +271,7 @@ suite('SessionsTerminalContribution', () => {
 
 		instantiationService.stub(ITerminalService, new class extends mock<ITerminalService>() {
 			override onDidCreateInstance = onDidCreateInstance.event;
+			override onDidDisposeInstance = onDidDisposeInstance.event;
 			override get instances(): readonly ITerminalInstance[] {
 				return [...terminalInstances.values()];
 			}
@@ -1133,6 +1139,72 @@ suite('SessionsTerminalContribution', () => {
 		await tick();
 
 		assert.ok(!moveToBackgroundCalls.includes(toolTerminal.instanceId), 'hidden tool terminal should not be moved to background on restore');
+	});
+
+	test('transfers tracked terminals when a session is replaced (graduation)', async () => {
+		const worktreeUri = URI.file('/worktree');
+		const untitledSession = makeAgentSession({ sessionId: 'test:untitled', worktree: worktreeUri, providerType: AgentSessionProviders.Background });
+		const committedSession = makeAgentSession({ sessionId: 'test:committed', worktree: worktreeUri, providerType: AgentSessionProviders.Background });
+
+		// Ensure a terminal for the untitled session
+		await contribution.ensureTerminal(worktreeUri, false, untitledSession);
+		assert.strictEqual(createdTerminals.length, 1);
+		const terminalId = [...terminalInstances.keys()][0];
+
+		// Fire onDidReplaceSession to transfer tracking
+		onDidReplaceSession.fire({ from: untitledSession, to: committedSession });
+
+		// Now removing the old session should not kill the terminal since
+		// tracking was transferred to the committed session
+		activeInstanceId = undefined; // terminal is not focused
+		onDidChangeSessions.fire({ added: [], removed: [untitledSession], changed: [] });
+		await tick();
+
+		assert.strictEqual(disposedInstances.length, 0, 'terminal should survive graduation because tracking was transferred');
+		assert.ok(terminalInstances.has(terminalId), 'terminal should still exist');
+
+		// And ensureTerminal for the committed session should reuse, not create
+		const result = await contribution.ensureTerminal(worktreeUri, false, committedSession);
+		assert.strictEqual(createdTerminals.length, 1, 'should reuse the transferred terminal');
+		assert.strictEqual(result[0].instanceId, terminalId);
+	});
+
+	test('cleans up tracked terminal ids when terminals are externally disposed', async () => {
+		const worktreeUri = URI.file('/worktree');
+		const session = makeAgentSession({ sessionId: 'test:session', worktree: worktreeUri, providerType: AgentSessionProviders.Background });
+
+		// Ensure a terminal for the session
+		await contribution.ensureTerminal(worktreeUri, false, session);
+		assert.strictEqual(createdTerminals.length, 1);
+		const instance = [...terminalInstances.values()][0];
+
+		// Externally dispose the terminal (user closes the tab)
+		instance._testSetDisposed(true);
+		terminalInstances.delete(instance.instanceId);
+		onDidDisposeInstance.fire(instance);
+
+		// Now ensureTerminal should create a new terminal since the tracked one was disposed
+		const result = await contribution.ensureTerminal(worktreeUri, false, session);
+		assert.strictEqual(createdTerminals.length, 2, 'should create a new terminal since the tracked one was disposed');
+		assert.notStrictEqual(result[0].instanceId, instance.instanceId, 'should be a different terminal');
+	});
+
+	test('untracked restored terminals are visible alongside tracked terminals for the same session', async () => {
+		const cwd = URI.file('/worktree');
+		const session = makeAgentSession({ sessionId: 'test:session', worktree: cwd, providerType: AgentSessionProviders.Background });
+
+		// Simulate a restored terminal at the same cwd (not tracked)
+		const restoredTerminal = makeTerminalInstance(nextInstanceId++, cwd.fsPath);
+		terminalInstances.set(restoredTerminal.instanceId, restoredTerminal);
+		backgroundedInstances.add(restoredTerminal.instanceId);
+
+		// Activate the session — this creates a tracked terminal
+		activeSessionObs.set(session, undefined);
+		await tick();
+
+		// The restored terminal should have been shown (via cwd fallback)
+		// rather than left in the background
+		assert.ok(showBackgroundCalls.includes(restoredTerminal.instanceId), 'untracked restored terminal at matching cwd should be shown');
 	});
 });
 

--- a/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
+++ b/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
@@ -1176,7 +1176,7 @@ suite('SessionsTerminalContribution', () => {
 		// Ensure a terminal for the session
 		await contribution.ensureTerminal(worktreeUri, false, session);
 		assert.strictEqual(createdTerminals.length, 1);
-		const instance = [...terminalInstances.values()][0];
+		const instance = [...terminalInstances.values()][0] as TestTerminalInstance;
 
 		// Externally dispose the terminal (user closes the tab)
 		instance._testSetDisposed(true);

--- a/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
+++ b/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
@@ -119,7 +119,7 @@ function makeAgentSession(opts: {
 	return session;
 }
 
-function makeNonAgentSession(opts: { repository?: URI; worktree?: URI; providerType?: string }): ISession {
+function makeNonAgentSession(opts: { repository?: URI; worktree?: URI; providerType?: string; sessionId?: string }): ISession {
 	const folder = opts.repository || opts.worktree ? {
 		root: opts.repository ?? opts.worktree!,
 		workingDirectory: opts.worktree ?? opts.repository!,
@@ -143,7 +143,7 @@ function makeNonAgentSession(opts: { repository?: URI; worktree?: URI; providerT
 		description: observableValue('test.description', undefined),
 	} satisfies IChat;
 	const session = {
-		sessionId: 'test:non-agent',
+		sessionId: opts.sessionId ?? 'test:non-agent',
 		resource: chat.resource,
 		providerId: 'test',
 		sessionType: opts.providerType ?? AgentSessionProviders.Local,
@@ -423,17 +423,16 @@ suite('SessionsTerminalContribution', () => {
 		assert.strictEqual(createdTerminals[0].cwd.fsPath, HOME_DIR.fsPath);
 	});
 
-	test('does not recreate terminal when multiple non-background sessions share the home directory', async () => {
-		const session1 = makeAgentSession({ providerType: AgentSessionProviders.Cloud });
+	test('creates separate terminals when different non-background sessions share the home directory', async () => {
+		const session1 = makeAgentSession({ providerType: AgentSessionProviders.Cloud, sessionId: 'test:cloud-1' });
 		activeSessionObs.set(session1, undefined);
 		await tick();
 		assert.strictEqual(createdTerminals.length, 1);
 
-		// Different non-background session — same home dir, no new terminal
-		const session2 = makeAgentSession({ providerType: AgentSessionProviders.Local });
+		const session2 = makeAgentSession({ providerType: AgentSessionProviders.Local, sessionId: 'test:local-1' });
 		activeSessionObs.set(session2, undefined);
 		await tick();
-		assert.strictEqual(createdTerminals.length, 1);
+		assert.strictEqual(createdTerminals.length, 2);
 	});
 
 	test('does not create a terminal when there is no active session', async () => {
@@ -463,14 +462,13 @@ suite('SessionsTerminalContribution', () => {
 
 	test('does not recreate terminal for the same path', async () => {
 		const worktreeUri = URI.file('/worktree');
-		const session1 = makeAgentSession({ worktree: worktreeUri, providerType: AgentSessionProviders.Background });
+		const session1 = makeAgentSession({ sessionId: 'test:session-1', worktree: worktreeUri, providerType: AgentSessionProviders.Background });
 		activeSessionObs.set(session1, undefined);
 		await tick();
 
 		assert.strictEqual(createdTerminals.length, 1);
 
-		// Setting a different session with the same worktree should not create a new terminal
-		const session2 = makeAgentSession({ worktree: worktreeUri, providerType: AgentSessionProviders.Background });
+		const session2 = makeAgentSession({ sessionId: 'test:session-1', worktree: worktreeUri, providerType: AgentSessionProviders.Background });
 		activeSessionObs.set(session2, undefined);
 		await tick();
 
@@ -481,10 +479,10 @@ suite('SessionsTerminalContribution', () => {
 		const worktree1 = URI.file('/worktree1');
 		const worktree2 = URI.file('/worktree2');
 
-		activeSessionObs.set(makeAgentSession({ worktree: worktree1, providerType: AgentSessionProviders.Background }), undefined);
+		activeSessionObs.set(makeAgentSession({ sessionId: 'test:session-1', worktree: worktree1, providerType: AgentSessionProviders.Background }), undefined);
 		await tick();
 
-		activeSessionObs.set(makeAgentSession({ worktree: worktree2, providerType: AgentSessionProviders.Background }), undefined);
+		activeSessionObs.set(makeAgentSession({ sessionId: 'test:session-2', worktree: worktree2, providerType: AgentSessionProviders.Background }), undefined);
 		await tick();
 
 		assert.strictEqual(createdTerminals.length, 2);
@@ -548,13 +546,13 @@ suite('SessionsTerminalContribution', () => {
 
 	test('hides (does not dispose) terminals when session is archived', async () => {
 		const worktreeUri = URI.file('/worktree');
-		await contribution.ensureTerminal(worktreeUri, false); // terminal 1 at /worktree
+		await contribution.ensureTerminal(worktreeUri, false, makeAgentSession({ sessionId: 'test:archived-session', worktree: worktreeUri, providerType: AgentSessionProviders.Background })); // terminal 1 at /worktree
 
 		assert.strictEqual(createdTerminals.length, 1);
 
 		// Archiving flips the active session away from the archived one, so the
 		// archived session's terminal is no longer the focused (active) terminal.
-		const otherSession = makeAgentSession({ worktree: URI.file('/other'), providerType: AgentSessionProviders.Background });
+		const otherSession = makeAgentSession({ sessionId: 'test:other-session', worktree: URI.file('/other'), providerType: AgentSessionProviders.Background });
 		activeSessionObs.set(otherSession, undefined);
 		await tick();
 
@@ -562,6 +560,7 @@ suite('SessionsTerminalContribution', () => {
 		moveToBackgroundCalls.length = 0;
 
 		const session = makeAgentSession({
+			sessionId: 'test:archived-session',
 			isArchived: true,
 			worktree: worktreeUri,
 			providerType: AgentSessionProviders.Background,
@@ -575,11 +574,12 @@ suite('SessionsTerminalContribution', () => {
 
 	test('does not hide or dispose terminals when session is not archived', async () => {
 		const worktreeUri = URI.file('/worktree');
-		await contribution.ensureTerminal(worktreeUri, false);
+		await contribution.ensureTerminal(worktreeUri, false, makeAgentSession({ sessionId: 'test:active-session', worktree: worktreeUri, providerType: AgentSessionProviders.Background }));
 
 		moveToBackgroundCalls.length = 0;
 
 		const session = makeAgentSession({
+			sessionId: 'test:active-session',
 			isArchived: false,
 			worktree: worktreeUri,
 		});
@@ -592,11 +592,11 @@ suite('SessionsTerminalContribution', () => {
 
 	test('does not hide or dispose terminals when archived session has no worktree', async () => {
 		const worktreeUri = URI.file('/worktree');
-		await contribution.ensureTerminal(worktreeUri, false);
+		await contribution.ensureTerminal(worktreeUri, false, makeAgentSession({ sessionId: 'test:active-session', worktree: worktreeUri, providerType: AgentSessionProviders.Background }));
 
 		moveToBackgroundCalls.length = 0;
 
-		const session = makeAgentSession({ isArchived: true });
+		const session = makeAgentSession({ sessionId: 'test:archived-session', isArchived: true });
 		onDidChangeSessions.fire({ added: [], removed: [], changed: [session] });
 		await tick();
 
@@ -606,7 +606,7 @@ suite('SessionsTerminalContribution', () => {
 
 	test('hides terminals when archived session has only a repository (no worktree)', async () => {
 		const repoUri = URI.file('/repo');
-		const session = makeAgentSession({ repository: repoUri, providerType: AgentSessionProviders.Background, isArchived: false });
+		const session = makeAgentSession({ sessionId: 'test:repo-session', repository: repoUri, providerType: AgentSessionProviders.Background, isArchived: false });
 		activeSessionObs.set(session, undefined);
 		await tick();
 
@@ -616,13 +616,13 @@ suite('SessionsTerminalContribution', () => {
 		// Switch the active session to a different cwd so the repo cwd is no longer
 		// the protected active cwd (mirrors archiving flipping the active session
 		// to a new one), then archive the repo-only session.
-		const otherSession = makeAgentSession({ worktree: URI.file('/other'), providerType: AgentSessionProviders.Background });
+		const otherSession = makeAgentSession({ sessionId: 'test:other-session', worktree: URI.file('/other'), providerType: AgentSessionProviders.Background });
 		activeSessionObs.set(otherSession, undefined);
 		await tick();
 
 		moveToBackgroundCalls.length = 0;
 
-		const archivedSession = makeAgentSession({ repository: repoUri, providerType: AgentSessionProviders.Background, isArchived: true });
+		const archivedSession = makeAgentSession({ sessionId: 'test:repo-session', repository: repoUri, providerType: AgentSessionProviders.Background, isArchived: true });
 		onDidChangeSessions.fire({ added: [], removed: [], changed: [archivedSession] });
 		await tick();
 
@@ -635,7 +635,7 @@ suite('SessionsTerminalContribution', () => {
 		// a late archive event must not touch the terminal the user is currently
 		// working in at the active session's cwd.
 		const worktreeUri = URI.file('/worktree');
-		const activeSession = makeAgentSession({ worktree: worktreeUri, providerType: AgentSessionProviders.Background });
+		const activeSession = makeAgentSession({ sessionId: 'test:active-session', worktree: worktreeUri, providerType: AgentSessionProviders.Background });
 		activeSessionObs.set(activeSession, undefined);
 		await tick();
 
@@ -658,8 +658,8 @@ suite('SessionsTerminalContribution', () => {
 		// on every sync. The archive cleanup must only run on the first archived
 		// transition, not on each re-emit.
 		const worktreeUri = URI.file('/worktree');
-		await contribution.ensureTerminal(worktreeUri, false); // terminal 1 at /worktree
-		await contribution.ensureTerminal(URI.file('/other'), false); // terminal 2 at /other, now active
+		await contribution.ensureTerminal(worktreeUri, false, makeAgentSession({ sessionId: 'test:archived', worktree: worktreeUri, providerType: AgentSessionProviders.Background })); // terminal 1 at /worktree
+		await contribution.ensureTerminal(URI.file('/other'), false, makeAgentSession({ sessionId: 'test:other-session', worktree: URI.file('/other'), providerType: AgentSessionProviders.Background })); // terminal 2 at /other, now active
 
 		const archivedSession = makeAgentSession({ sessionId: 'test:archived', worktree: worktreeUri, providerType: AgentSessionProviders.Background, isArchived: true });
 
@@ -672,8 +672,8 @@ suite('SessionsTerminalContribution', () => {
 		assert.deepStrictEqual(moveToBackgroundCalls, [1]);
 
 		// The user opens a new terminal at the same cwd, then moves focus elsewhere.
-		await contribution.ensureTerminal(worktreeUri, false); // terminal 3 at /worktree, active
-		await contribution.ensureTerminal(URI.file('/other'), false); // reuse terminal 2
+		await contribution.ensureTerminal(worktreeUri, false, makeAgentSession({ sessionId: 'test:later-session', worktree: worktreeUri, providerType: AgentSessionProviders.Background })); // terminal 3 at /worktree, active
+		await contribution.ensureTerminal(URI.file('/other'), false, makeAgentSession({ sessionId: 'test:other-session', worktree: URI.file('/other'), providerType: AgentSessionProviders.Background })); // reuse terminal 2
 		activeInstanceId = 2; // simulate the user refocusing terminal 2 at /other
 
 		moveToBackgroundCalls.length = 0;
@@ -701,8 +701,8 @@ suite('SessionsTerminalContribution', () => {
 
 		// A fresh contribution observes the already-archived session at startup.
 		const freshContribution = store.add(instantiationService.createInstance(SessionsTerminalContribution));
-		await freshContribution.ensureTerminal(worktreeUri, false); // terminal at /worktree
-		await freshContribution.ensureTerminal(URI.file('/other'), false); // move focus away
+		await freshContribution.ensureTerminal(worktreeUri, false, makeAgentSession({ sessionId: 'test:restored-archived', worktree: worktreeUri, providerType: AgentSessionProviders.Background })); // terminal at /worktree
+		await freshContribution.ensureTerminal(URI.file('/other'), false, makeAgentSession({ sessionId: 'test:other-session', worktree: URI.file('/other'), providerType: AgentSessionProviders.Background })); // move focus away
 
 		moveToBackgroundCalls.length = 0;
 
@@ -716,15 +716,15 @@ suite('SessionsTerminalContribution', () => {
 
 	test('closes terminals when a non-focused session is removed', async () => {
 		const worktreeUri = URI.file('/worktree');
-		await contribution.ensureTerminal(worktreeUri, false); // terminal 1 at /worktree, active
+		await contribution.ensureTerminal(worktreeUri, false, makeAgentSession({ sessionId: 'test:removed-session', worktree: worktreeUri, providerType: AgentSessionProviders.Background })); // terminal 1 at /worktree, active
 		// Open a terminal elsewhere so the /worktree terminal is no longer the
 		// focused (active) instance — i.e. the user removed a session they were not
 		// currently working in.
-		await contribution.ensureTerminal(URI.file('/other'), false); // terminal 2 at /other, active
+		await contribution.ensureTerminal(URI.file('/other'), false, makeAgentSession({ sessionId: 'test:other-session', worktree: URI.file('/other'), providerType: AgentSessionProviders.Background })); // terminal 2 at /other, active
 
 		assert.strictEqual(createdTerminals.length, 2);
 
-		const session = makeAgentSession({ worktree: worktreeUri, providerType: AgentSessionProviders.Background });
+		const session = makeAgentSession({ sessionId: 'test:removed-session', worktree: worktreeUri, providerType: AgentSessionProviders.Background });
 		onDidChangeSessions.fire({ added: [], removed: [session], changed: [] });
 		await tick();
 
@@ -738,7 +738,7 @@ suite('SessionsTerminalContribution', () => {
 		// yet, so it does not appear in `liveCwdKeys`. The terminal the user just
 		// used for the first turn is the focused (active) instance and must survive.
 		const worktreeUri = URI.file('/worktree');
-		await contribution.ensureTerminal(worktreeUri, false); // terminal 1 at /worktree, active
+		await contribution.ensureTerminal(worktreeUri, false, makeAgentSession({ sessionId: 'test:untitled', worktree: worktreeUri, providerType: AgentSessionProviders.Background })); // terminal 1 at /worktree, active
 
 		assert.strictEqual(createdTerminals.length, 1);
 
@@ -750,9 +750,10 @@ suite('SessionsTerminalContribution', () => {
 		assert.strictEqual(disposedInstances.length, 0, 'the focused terminal must not be disposed on graduation');
 	});
 
-	test('does not close terminal when another live session still owns the cwd (replace case)', async () => {
+	test('closes only the removed session terminal when sessions share a cwd', async () => {
 		const worktreeUri = URI.file('/worktree');
-		await contribution.ensureTerminal(worktreeUri, false);
+		await contribution.ensureTerminal(worktreeUri, false, makeAgentSession({ sessionId: 'test:untitled', worktree: worktreeUri, providerType: AgentSessionProviders.Background }));
+		await contribution.ensureTerminal(worktreeUri, false, makeAgentSession({ sessionId: 'test:committed', worktree: worktreeUri, providerType: AgentSessionProviders.Background }));
 
 		// Simulate the onDidReplaceSession flow: `from` (untitled) is reported as
 		// removed while `to` (committed) is still live at the same cwd.
@@ -763,29 +764,35 @@ suite('SessionsTerminalContribution', () => {
 		onDidChangeSessions.fire({ added: [], removed: [fromSession], changed: [toSession] });
 		await tick();
 
-		assert.strictEqual(disposedInstances.length, 0, 'terminal should be kept alive for the surviving session');
+		assert.deepStrictEqual(disposedInstances.map(instance => instance.instanceId), [1], 'only the removed session terminal should be closed');
+		assert.ok(terminalInstances.has(2), 'the surviving session terminal should remain');
 	});
 
-	test('does not hide or dispose terminal when archiving one of two sessions sharing a cwd', async () => {
+	test('hides only the archived session terminal when sessions share a cwd', async () => {
 		const worktreeUri = URI.file('/worktree');
-		await contribution.ensureTerminal(worktreeUri, false);
+		await contribution.ensureTerminal(worktreeUri, false, makeAgentSession({ sessionId: 'test:live', worktree: worktreeUri, providerType: AgentSessionProviders.Background }));
+		await contribution.ensureTerminal(worktreeUri, false, makeAgentSession({ sessionId: 'test:archived', worktree: worktreeUri, providerType: AgentSessionProviders.Background }));
 
 		const liveSession = makeAgentSession({ sessionId: 'test:live', worktree: worktreeUri, providerType: AgentSessionProviders.Background });
 		const archivedSession = makeAgentSession({ sessionId: 'test:archived', worktree: worktreeUri, providerType: AgentSessionProviders.Background, isArchived: true });
 		allSessions = [liveSession, archivedSession];
+
+		activeSessionObs.set(liveSession, undefined);
+		await tick();
+		activeInstanceId = 1;
 
 		moveToBackgroundCalls.length = 0;
 
 		onDidChangeSessions.fire({ added: [], removed: [], changed: [archivedSession] });
 		await tick();
 
-		assert.strictEqual(disposedInstances.length, 0, 'terminal should be kept for the still-live session');
-		assert.strictEqual(moveToBackgroundCalls.length, 0, 'terminal owned by a still-live session must not be hidden');
+		assert.strictEqual(disposedInstances.length, 0, 'terminal should be hidden, not disposed');
+		assert.deepStrictEqual(moveToBackgroundCalls, [2], 'only the archived session terminal should be hidden');
 	});
 
 	test('closes terminal when the only session at a cwd is removed even if other live sessions exist elsewhere', async () => {
 		const worktreeUri = URI.file('/worktree');
-		await contribution.ensureTerminal(worktreeUri, false); // terminal 1 at /worktree, active
+		await contribution.ensureTerminal(worktreeUri, false, makeAgentSession({ sessionId: 'test:gone', worktree: worktreeUri, providerType: AgentSessionProviders.Background })); // terminal 1 at /worktree, active
 
 		const otherLive = makeAgentSession({ sessionId: 'test:other', worktree: URI.file('/other'), providerType: AgentSessionProviders.Background });
 		const removedSession = makeAgentSession({ sessionId: 'test:gone', worktree: worktreeUri, providerType: AgentSessionProviders.Background });
@@ -793,7 +800,7 @@ suite('SessionsTerminalContribution', () => {
 
 		// Switch focus to the other live session's terminal so the /worktree
 		// terminal is no longer the protected active instance.
-		await contribution.ensureTerminal(URI.file('/other'), false); // terminal 2 at /other, active
+		await contribution.ensureTerminal(URI.file('/other'), false, makeAgentSession({ sessionId: 'test:other', worktree: URI.file('/other'), providerType: AgentSessionProviders.Background })); // terminal 2 at /other, active
 
 		onDidChangeSessions.fire({ added: [], removed: [removedSession], changed: [] });
 		await tick();
@@ -807,31 +814,31 @@ suite('SessionsTerminalContribution', () => {
 		const cwd1 = URI.file('/cwd1');
 		const cwd2 = URI.file('/cwd2');
 
-		activeSessionObs.set(makeAgentSession({ worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
+		activeSessionObs.set(makeAgentSession({ sessionId: 'test:session-1', worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
 		await tick();
 		assert.strictEqual(createdTerminals.length, 1);
 
-		activeSessionObs.set(makeAgentSession({ worktree: cwd2, providerType: AgentSessionProviders.Background }), undefined);
+		activeSessionObs.set(makeAgentSession({ sessionId: 'test:session-2', worktree: cwd2, providerType: AgentSessionProviders.Background }), undefined);
 		await tick();
 		assert.strictEqual(createdTerminals.length, 2);
 
 		// Switch back to cwd1 - should reuse terminal, not create a new one
-		activeSessionObs.set(makeAgentSession({ worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
+		activeSessionObs.set(makeAgentSession({ sessionId: 'test:session-1', worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
 		await tick();
 		assert.strictEqual(createdTerminals.length, 2, 'should reuse the terminal for cwd1');
 	});
 
-	// --- Terminal visibility management (cwd-based) ---
+	// --- Terminal visibility management (session-based with cwd fallback) ---
 
 	test('hides terminals from previous session when switching to a new session', async () => {
 		const cwd1 = URI.file('/cwd1');
 		const cwd2 = URI.file('/cwd2');
 
-		activeSessionObs.set(makeAgentSession({ worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
+		activeSessionObs.set(makeAgentSession({ sessionId: 'test:session-1', worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
 		await tick();
 		assert.strictEqual(createdTerminals.length, 1);
 
-		activeSessionObs.set(makeAgentSession({ worktree: cwd2, providerType: AgentSessionProviders.Background }), undefined);
+		activeSessionObs.set(makeAgentSession({ sessionId: 'test:session-2', worktree: cwd2, providerType: AgentSessionProviders.Background }), undefined);
 		await tick();
 
 		// The first terminal (id=1) should have been moved to background
@@ -843,14 +850,14 @@ suite('SessionsTerminalContribution', () => {
 		const cwd1 = URI.file('/cwd1');
 		const cwd2 = URI.file('/cwd2');
 
-		activeSessionObs.set(makeAgentSession({ worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
+		activeSessionObs.set(makeAgentSession({ sessionId: 'test:session-1', worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
 		await tick();
 
-		activeSessionObs.set(makeAgentSession({ worktree: cwd2, providerType: AgentSessionProviders.Background }), undefined);
+		activeSessionObs.set(makeAgentSession({ sessionId: 'test:session-2', worktree: cwd2, providerType: AgentSessionProviders.Background }), undefined);
 		await tick();
 
 		// Switch back to cwd1
-		activeSessionObs.set(makeAgentSession({ worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
+		activeSessionObs.set(makeAgentSession({ sessionId: 'test:session-1', worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
 		await tick();
 
 		// Terminal for cwd1 (id=1) should be shown again
@@ -865,13 +872,13 @@ suite('SessionsTerminalContribution', () => {
 		const cwd2 = URI.file('/cwd2');
 		const cwd3 = URI.file('/cwd3');
 
-		activeSessionObs.set(makeAgentSession({ worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
+		activeSessionObs.set(makeAgentSession({ sessionId: 'test:session-1', worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
 		await tick();
 
-		activeSessionObs.set(makeAgentSession({ worktree: cwd2, providerType: AgentSessionProviders.Background }), undefined);
+		activeSessionObs.set(makeAgentSession({ sessionId: 'test:session-2', worktree: cwd2, providerType: AgentSessionProviders.Background }), undefined);
 		await tick();
 
-		activeSessionObs.set(makeAgentSession({ worktree: cwd3, providerType: AgentSessionProviders.Background }), undefined);
+		activeSessionObs.set(makeAgentSession({ sessionId: 'test:session-3', worktree: cwd3, providerType: AgentSessionProviders.Background }), undefined);
 		await tick();
 
 		// Only terminal for cwd3 (id=3) should be foreground
@@ -903,7 +910,7 @@ suite('SessionsTerminalContribution', () => {
 		});
 		terminalInstances.set(restoredInstance.instanceId, restoredInstance);
 
-		activeSessionObs.set(makeAgentSession({ worktree: URI.file('/active'), providerType: AgentSessionProviders.Background }), undefined);
+		activeSessionObs.set(makeAgentSession({ sessionId: 'test:active-session', worktree: URI.file('/active'), providerType: AgentSessionProviders.Background }), undefined);
 		await tick();
 
 		onDidCreateInstance.fire(restoredInstance);
@@ -943,28 +950,39 @@ suite('SessionsTerminalContribution', () => {
 		assert.strictEqual(result[0].instanceId, instanceId, 'should return the existing backgrounded terminal');
 	});
 
-	test('visibility is determined by initial cwd, not by stored IDs', async () => {
-		// Create a terminal externally (not via ensureTerminal) with a known cwd
-		const cwd1 = URI.file('/cwd1');
-		const cwd2 = URI.file('/cwd2');
-		const ext1 = makeTerminalInstance(nextInstanceId++, cwd1.fsPath);
-		const ext2 = makeTerminalInstance(nextInstanceId++, cwd2.fsPath);
-		terminalInstances.set(ext1.instanceId, ext1);
-		terminalInstances.set(ext2.instanceId, ext2);
+	test('does not reuse an untracked cwd match when it is already tracked to another session', async () => {
+		const cwd = URI.file('/shared');
+		const session1 = makeAgentSession({ sessionId: 'test:session-1', worktree: cwd, providerType: AgentSessionProviders.Background });
+		const session2 = makeAgentSession({ sessionId: 'test:session-2', worktree: cwd, providerType: AgentSessionProviders.Background });
 
-		// Switch to cwd1 — ext1 should stay visible, ext2 should be hidden
-		activeSessionObs.set(makeAgentSession({ worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
+		activeSessionObs.set(session1, undefined);
+		await tick();
+		activeSessionObs.set(session2, undefined);
 		await tick();
 
-		assert.ok(!backgroundedInstances.has(ext1.instanceId), 'ext1 should be foreground (matching cwd)');
-		assert.ok(backgroundedInstances.has(ext2.instanceId), 'ext2 should be backgrounded (non-matching cwd)');
+		assert.deepStrictEqual(createdTerminals.map(terminal => terminal.cwd.fsPath), [cwd.fsPath, cwd.fsPath]);
+		assert.ok(backgroundedInstances.has(1), 'the first session terminal should be backgrounded');
+		assert.ok(!backgroundedInstances.has(2), 'the second session terminal should stay visible');
+	});
 
-		// Switch to cwd2 — ext2 should be shown, ext1 should be hidden
-		activeSessionObs.set(makeAgentSession({ worktree: cwd2, providerType: AgentSessionProviders.Background }), undefined);
+	test('visibility is determined by tracked session terminals when sessions share a cwd', async () => {
+		const cwd = URI.file('/cwd');
+		const session1 = makeAgentSession({ sessionId: 'test:session-1', worktree: cwd, providerType: AgentSessionProviders.Background });
+		const session2 = makeAgentSession({ sessionId: 'test:session-2', worktree: cwd, providerType: AgentSessionProviders.Background });
+
+		activeSessionObs.set(session1, undefined);
+		await tick();
+		activeSessionObs.set(session2, undefined);
 		await tick();
 
-		assert.ok(backgroundedInstances.has(ext1.instanceId), 'ext1 should now be backgrounded');
-		assert.ok(!backgroundedInstances.has(ext2.instanceId), 'ext2 should now be foreground');
+		assert.ok(backgroundedInstances.has(1), 'session 1 terminal should be backgrounded when session 2 is active');
+		assert.ok(!backgroundedInstances.has(2), 'session 2 terminal should be foreground');
+
+		activeSessionObs.set(session1, undefined);
+		await tick();
+
+		assert.ok(!backgroundedInstances.has(1), 'session 1 terminal should be shown again when reactivated');
+		assert.ok(backgroundedInstances.has(2), 'session 2 terminal should be backgrounded when session 1 is active');
 	});
 
 	// --- Most-recent-command active terminal selection ---
@@ -1019,7 +1037,7 @@ suite('SessionsTerminalContribution', () => {
 
 	test('does not hide hidden tool terminals when session is archived', async () => {
 		const worktreeUri = URI.file('/worktree');
-		await contribution.ensureTerminal(worktreeUri, false); // terminal 1 (regular) at /worktree
+		await contribution.ensureTerminal(worktreeUri, false, makeAgentSession({ sessionId: 'test:regular-session', worktree: worktreeUri, providerType: AgentSessionProviders.Background })); // terminal 1 (regular) at /worktree
 
 		// Simulate a hidden tool terminal (created by run_in_terminal) at the same cwd
 		const toolTerminal = makeTerminalInstance(nextInstanceId++, worktreeUri.fsPath);
@@ -1028,13 +1046,14 @@ suite('SessionsTerminalContribution', () => {
 
 		// Archiving flips the active session away, so the archived session's
 		// regular terminal is no longer the focused (active) terminal.
-		const otherSession = makeAgentSession({ worktree: URI.file('/other'), providerType: AgentSessionProviders.Background });
+		const otherSession = makeAgentSession({ sessionId: 'test:other-session', worktree: URI.file('/other'), providerType: AgentSessionProviders.Background });
 		activeSessionObs.set(otherSession, undefined);
 		await tick();
 
 		moveToBackgroundCalls.length = 0;
 
 		const session = makeAgentSession({
+			sessionId: 'test:regular-session',
 			isArchived: true,
 			worktree: worktreeUri,
 			providerType: AgentSessionProviders.Background,
@@ -1049,16 +1068,16 @@ suite('SessionsTerminalContribution', () => {
 
 	test('does not dispose hidden tool terminals when session is removed', async () => {
 		const worktreeUri = URI.file('/worktree');
-		await contribution.ensureTerminal(worktreeUri, false); // terminal 1 (regular) at /worktree, active
+		await contribution.ensureTerminal(worktreeUri, false, makeAgentSession({ sessionId: 'test:regular-session', worktree: worktreeUri, providerType: AgentSessionProviders.Background })); // terminal 1 (regular) at /worktree, active
 
 		const toolTerminal = makeTerminalInstance(nextInstanceId++, worktreeUri.fsPath);
 		toolTerminal._testSetShellLaunchConfig({ hideFromUser: true } as ITerminalInstance['shellLaunchConfig']);
 		terminalInstances.set(toolTerminal.instanceId, toolTerminal);
 
 		// Switch focus away so the regular terminal is no longer the protected active instance.
-		await contribution.ensureTerminal(URI.file('/other'), false); // terminal at /other, active
+		await contribution.ensureTerminal(URI.file('/other'), false, makeAgentSession({ sessionId: 'test:other-session', worktree: URI.file('/other'), providerType: AgentSessionProviders.Background })); // terminal at /other, active
 
-		const session = makeAgentSession({ worktree: worktreeUri, providerType: AgentSessionProviders.Background });
+		const session = makeAgentSession({ sessionId: 'test:regular-session', worktree: worktreeUri, providerType: AgentSessionProviders.Background });
 		onDidChangeSessions.fire({ added: [], removed: [session], changed: [] });
 		await tick();
 
@@ -1070,7 +1089,7 @@ suite('SessionsTerminalContribution', () => {
 		const cwd1 = URI.file('/cwd1');
 		const cwd2 = URI.file('/cwd2');
 
-		activeSessionObs.set(makeAgentSession({ worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
+		activeSessionObs.set(makeAgentSession({ sessionId: 'test:session-1', worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
 		await tick();
 
 		// Add a hidden tool terminal at cwd1
@@ -1079,7 +1098,7 @@ suite('SessionsTerminalContribution', () => {
 		terminalInstances.set(toolTerminal.instanceId, toolTerminal);
 
 		// Switch to cwd2
-		activeSessionObs.set(makeAgentSession({ worktree: cwd2, providerType: AgentSessionProviders.Background }), undefined);
+		activeSessionObs.set(makeAgentSession({ sessionId: 'test:session-2', worktree: cwd2, providerType: AgentSessionProviders.Background }), undefined);
 		await tick();
 
 		assert.ok(!moveToBackgroundCalls.includes(toolTerminal.instanceId), 'hidden tool terminal should not be moved to background');
@@ -1100,7 +1119,7 @@ suite('SessionsTerminalContribution', () => {
 	});
 
 	test('does not hide restored hidden tool terminals on session create', async () => {
-		activeSessionObs.set(makeAgentSession({ worktree: URI.file('/active'), providerType: AgentSessionProviders.Background }), undefined);
+		activeSessionObs.set(makeAgentSession({ sessionId: 'test:active-session', worktree: URI.file('/active'), providerType: AgentSessionProviders.Background }), undefined);
 		await tick();
 
 		const toolTerminal = makeTerminalInstance(nextInstanceId++, '/other');


### PR DESCRIPTION
Replace the cwd-based terminal matching with a session ID-based map (`Map<sessionId, Set<instanceId>>`) for reliable 1:1 association. This avoids bugs where multiple sessions sharing the same cwd would interfere with each other's terminal lifecycle.

## Key changes
- Add `_sessionTerminals` map to track which terminals belong to which session
- `ensureTerminal` now records associations and prefers tracked terminals
- Visibility, archive, and removal use session ID lookups instead of scanning all terminals by cwd
- Fall back to cwd matching for restored/untracked terminals (backward compat)
- Transfer tracking on `onDidReplaceSession` so terminals survive untitled→committed graduation
- Clean up stale map entries via `onDidDisposeInstance` when terminals are externally closed
- Prune disposed terminals in `_isTerminalTracked` to avoid incorrect cwd fallback exclusion

## Tests
- All 52 tests pass (3 new)
- `transfers tracked terminals when a session is replaced (graduation)`
- `cleans up tracked terminal ids when terminals are externally disposed`
- `untracked restored terminals are visible alongside tracked terminals for the same session`

Fixes #312909