### PR TITLE
build: pass publish parameter to Copilot template

### DIFF
--- a/build/azure-pipelines/product-build-template.yml
+++ b/build/azure-pipelines/product-build-template.yml
@@ -104,7 +104,7 @@ stages:
         jobs:
           - template: product-copilot.yml@self
             parameters:
-              VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
+              VSCODE_PUBLISH: ${{ parameters.VSCODE_PUBLISH }}
               VSCODE_RELEASE: ${{ parameters.VSCODE_RELEASE }}
 
       - ${{ if eq(variables['VSCODE_BUILD_STAGE_WINDOWS'], true) }}:


### PR DESCRIPTION
## Summary

- pass the shared template's typed `VSCODE_PUBLISH` parameter to the Copilot job template
- prevent an unavailable template variable from resolving to an empty string
- fix TSA pipeline validation where the nested template requires a Boolean

## Validation

- pre-commit hygiene check
- YAML diagnostics report no errors
- `git diff --check`