### PR TITLE
Enhance skill file parsing to include name extraction

### DIFF
--- a/src/vs/platform/agentPlugins/common/pluginParsers.ts
+++ b/src/vs/platform/agentPlugins/common/pluginParsers.ts
@@ -782,11 +782,6 @@ export async function readSkills(pluginRoot: URI, dirs: readonly URI[], fileServ
 	const skills: INamedPluginResource[] = [];
 
 	const addSkill = async (name: string, skillMd: URI) => {
-		if (seen.has(name)) {
-			return;
-		}
-		seen.add(name);
-
 		let description: string | undefined;
 		try {
 			const parsedInfo = await parseSkillFile(skillMd, fileService);
@@ -795,6 +790,10 @@ export async function readSkills(pluginRoot: URI, dirs: readonly URI[], fileServ
 		} catch {
 			// Keep the existing best-effort discovery behavior for malformed skills.
 		}
+		if (seen.has(name)) {
+			return;
+		}
+		seen.add(name);
 		skills.push({ uri: skillMd, name, ...(description ? { description } : {}) });
 	};
 

--- a/src/vs/platform/agentPlugins/common/pluginParsers.ts
+++ b/src/vs/platform/agentPlugins/common/pluginParsers.ts
@@ -789,7 +789,9 @@ export async function readSkills(pluginRoot: URI, dirs: readonly URI[], fileServ
 
 		let description: string | undefined;
 		try {
-			description = (await parseSkillFile(skillMd, fileService)).description;
+			const parsedInfo = await parseSkillFile(skillMd, fileService);
+			description = parsedInfo.description;
+			name = parsedInfo.name || name;
 		} catch {
 			// Keep the existing best-effort discovery behavior for malformed skills.
 		}


### PR DESCRIPTION
Improve the `readSkills` function to extract the name from the skill file in addition to the description. This enhancement allows for better handling of skill metadata. Testing can be done by verifying that both name and description are correctly parsed from skill files.

Fixes https://github.com/microsoft/vscode/issues/321399