### PR TITLE
Exclude gated session types from the agent sessions list

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -498,8 +498,13 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 	 * are treated as available, since there is no `when` clause gating them.
 	 */
 	private _isContributionAvailableForType(sessionType: string): boolean {
-		const resolvedType = this._resolveToPrimaryType(sessionType) ?? sessionType;
-		const contribution = this._contributions.get(resolvedType)?.contribution;
+		// Resolve the owning contribution by primary type, falling back to the
+		// alternative-id map. We must NOT use `_resolveToPrimaryType` here: it
+		// returns `undefined` once the primary contribution is unavailable, which
+		// would make a gated contribution reached via an alternative id read as
+		// "no contribution" and therefore available.
+		const primaryType = this._contributions.has(sessionType) ? sessionType : this._alternativeIdMap.get(sessionType);
+		const contribution = primaryType ? this._contributions.get(primaryType)?.contribution : undefined;
 		return !contribution || this._isContributionAvailable(contribution);
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -489,6 +489,21 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 	}
 
 	/**
+	 * Type-keyed companion to {@link _isContributionAvailable}. Resolves the
+	 * session type (including alternative ids) to its contribution and reports
+	 * whether that contribution is currently enabled by its `when` clause.
+	 *
+	 * Session types with no contribution entry (e.g. the built-in `local`
+	 * provider, or item controllers registered without a matching contribution)
+	 * are treated as available, since there is no `when` clause gating them.
+	 */
+	private _isContributionAvailableForType(sessionType: string): boolean {
+		const resolvedType = this._resolveToPrimaryType(sessionType) ?? sessionType;
+		const contribution = this._contributions.get(resolvedType)?.contribution;
+		return !contribution || this._isContributionAvailable(contribution);
+	}
+
+	/**
 	 * Resolves a session type to its primary type, checking for alternative IDs.
 	 * @param sessionType The session type or alternative ID to resolve
 	 * @returns The primary session type, or undefined if not found or not available
@@ -846,8 +861,7 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 			chatViewType = resolvedType;
 		}
 
-		const contribution = this._contributions.get(chatViewType)?.contribution;
-		if (contribution && !this._isContributionAvailable(contribution)) {
+		if (!this._isContributionAvailableForType(chatViewType)) {
 			return false;
 		}
 
@@ -863,9 +877,7 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 
 	async canResolveChatSession(sessionType: string) {
 		await this._extensionService.whenInstalledExtensionsRegistered();
-		const resolvedType = this._resolveToPrimaryType(sessionType) || sessionType;
-		const contribution = this._contributions.get(resolvedType)?.contribution;
-		if (contribution && !this._isContributionAvailable(contribution)) {
+		if (!this._isContributionAvailableForType(sessionType)) {
 			return false;
 		}
 
@@ -945,6 +957,15 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 				const resolvedType = this._resolveToPrimaryType(chatSessionType) ?? chatSessionType;
 				if (providersToResolve && !providersToResolve.includes(resolvedType)) {
 					return; // skip: not considered for resolving
+				}
+
+				// Skip controllers whose contribution is gated off by its `when`
+				// clause. The item controller is registered independently of the
+				// contribution (e.g. by the extension host), so without this check
+				// its sessions would still be listed even though they can no longer
+				// be resolved/opened (which obeys the same `when` via canResolveChatSession).
+				if (!this._isContributionAvailableForType(chatSessionType)) {
+					return; // skip: contribution disabled by its `when` clause
 				}
 
 				try {

--- a/src/vs/workbench/contrib/chat/test/browser/chatSessions/chatSessionsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatSessions/chatSessionsService.test.ts
@@ -4,9 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { ContextKeyService } from '../../../../../../platform/contextkey/browser/contextKeyService.js';
+import { IContextKey, RawContextKey } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { ChatSessionsService } from '../../../browser/chatSessions/chatSessions.contribution.js';
-import { ChatSessionOptionsMap, ReadonlyChatSessionOptionsMap } from '../../../common/chatSessionsService.js';
+import { ChatSessionOptionsMap, IChatSessionItem, IChatSessionItemController, IChatSessionItemsDelta, IChatSessionsExtensionPoint, ReadonlyChatSessionOptionsMap } from '../../../common/chatSessionsService.js';
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
 
 suite.skip('ChatSessionsService', () => {
@@ -104,6 +110,90 @@ suite.skip('ChatSessionsService', () => {
 			const result = callExtractFileNameFromLink(input);
 			assert.strictEqual(result, '   Check test.js   ');
 		});
+	});
+});
+
+suite('ChatSessionsService - getChatSessionItems availability', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	const GATED_TYPE = 'gated-type';
+	const UNGATED_TYPE = 'ungated-type';
+	const gatedKey = new RawContextKey<boolean>('test.gatedTypeEnabled', false);
+
+	let service: ChatSessionsService;
+	let contextKeyService: ContextKeyService;
+	let gatedEnabled: IContextKey<boolean>;
+
+	/**
+	 * A minimal item controller that immediately exposes a single session item.
+	 * This stands in for an extension-host-registered controller, which is
+	 * registered independently of the contribution's `when` clause.
+	 */
+	class FakeItemController implements IChatSessionItemController {
+		private readonly _onDidChange = store.add(new Emitter<IChatSessionItemsDelta>());
+		readonly onDidChangeChatSessionItems: Event<IChatSessionItemsDelta> = this._onDidChange.event;
+
+		constructor(private readonly _type: string) { }
+
+		get items(): readonly IChatSessionItem[] {
+			return [{
+				resource: URI.from({ scheme: this._type, path: `/session-1` }),
+				label: `${this._type} session`,
+				timing: { created: 0, lastRequestStarted: undefined, lastRequestEnded: undefined },
+			}];
+		}
+
+		async refresh(): Promise<void> { }
+	}
+
+	function registerType(type: string, when: string | undefined): void {
+		const contribution: IChatSessionsExtensionPoint = { type, name: type, displayName: type, description: '', when };
+		store.add(service.registerChatSessionContribution(contribution));
+		store.add(service.registerChatSessionItemController(type, new FakeItemController(type)));
+	}
+
+	async function resolvedTypes(): Promise<string[]> {
+		const types: string[] = [];
+		for await (const { chatSessionType, items } of service.getChatSessionItems(undefined, CancellationToken.None)) {
+			if (items.length > 0) {
+				types.push(chatSessionType);
+			}
+		}
+		return types.sort();
+	}
+
+	setup(() => {
+		const configurationService = new TestConfigurationService();
+		contextKeyService = store.add(new ContextKeyService(configurationService));
+		gatedEnabled = gatedKey.bindTo(contextKeyService);
+
+		const instantiationService = store.add(workbenchInstantiationService({
+			contextKeyService: () => contextKeyService,
+			configurationService: () => configurationService,
+		}, store));
+		service = store.add(instantiationService.createInstance(ChatSessionsService));
+
+		registerType(GATED_TYPE, `${gatedKey.key}`);
+		registerType(UNGATED_TYPE, undefined);
+	});
+
+	test('excludes a type whose contribution `when` is false', async () => {
+		gatedEnabled.set(false);
+		assert.deepStrictEqual(await resolvedTypes(), [UNGATED_TYPE]);
+	});
+
+	test('includes a type whose contribution `when` is true', async () => {
+		gatedEnabled.set(true);
+		assert.deepStrictEqual(await resolvedTypes(), [GATED_TYPE, UNGATED_TYPE]);
+	});
+
+	test('reflects a runtime `when` flip without re-registration', async () => {
+		gatedEnabled.set(true);
+		assert.deepStrictEqual(await resolvedTypes(), [GATED_TYPE, UNGATED_TYPE]);
+
+		gatedEnabled.set(false);
+		assert.deepStrictEqual(await resolvedTypes(), [UNGATED_TYPE]);
 	});
 });
 


### PR DESCRIPTION
Fixes microsoft/vscode-internalbacklog#8029

## Problem

Chat-session **item controllers** are registered independently of their **contribution**. The extension host registers a `claude-code` item controller from `ClaudeChatSessionContentProvider`'s constructor, regardless of the contribution's `when` clause.

When `chat.editor.claude.preferAgentHost` (or the Agents-window `chat.agents.claude.preferAgentHost`) is set, the `claude-code` contribution's `when` evaluates **false** and the contribution is gated off — but the item controller stays registered. The result was an asymmetry:

- **List** (`getChatSessionItems`) ignored the `when` clause → old `claude-code` sessions kept showing.
- **Open** (`canResolveChatSession` → `_isContributionAvailable`) honored it → clicking one threw `Failed to get model for chat editor`.

## Fix

Make the list honor the same gate the open path already does: skip item controllers whose contribution exists but is unavailable.

Rather than add a fourth slightly-different inline copy of the check, this extracts a shared `_isContributionAvailableForType(sessionType)` predicate (a type-keyed companion to the existing `_isContributionAvailable`). `getChatSessionItems`, `canResolveChatSession`, and `doActivateChatSessionItemController` now all resolve the primary type (alternative ids included) and check availability identically — removing the prior drift where each site resolved the type key differently.

Claude is unaffected as a feature: with `preferAgentHost` on, it's contributed by the agent host (`agent-host-claude`), which has no `when` clause and continues to list and open normally. Only the now-unreachable extension-host `claude-code` sessions are hidden; their history stays on disk and reappears if the setting is turned back off.

## Test plan

- [x] New unit suite `ChatSessionsService - getChatSessionItems availability` (3 tests): excludes a type whose `when` is false, includes it when true, and reflects a runtime `when` flip without re-registration. Uses the real `ContextKeyService` + a minimal fake item controller (no heavy mocking).
- [x] Mutation-checked: neutering the guard fails 2 of the 3 tests.
- [x] `tsgo` type-check and eslint clean on both files.
- [x] Manually verified in Code OSS with the issue's repro settings (`chat.agentHost.enabled: true`, `chat.editor.claude.preferAgentHost: true`) on a workspace with existing `claude-code` sessions on disk: the ext-host log confirmed the `claude-code` item controller was actively refreshing, yet it no longer appeared in the resolved-provider set; `agent-host-claude` listed and the `Failed to get model` error no longer occurred.