### PR TITLE
fix editing inline chat input part

### DIFF
--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -572,7 +572,7 @@
  * transparent background those pieces stop covering the selection layer and the
  * corners render as blocky squares. Paint it with the same color the chat input
  * container uses so the editor still visually matches its surroundings. */
-.agent-sessions-workbench .interactive-session .interactive-input-part .chat-editor-container .interactive-input-editor .monaco-editor .monaco-editor-background {
+.agent-sessions-workbench .interactive-session .interactive-input-part:not(.chat-edit-input-container .interactive-input-part) .chat-editor-container .interactive-input-editor .monaco-editor .monaco-editor-background {
 	background-color: var(--vscode-agentsChatInput-background) !important;
 }
 

--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -64,10 +64,10 @@
 
 	.monaco-workbench.vs-dark.agent-sessions-workbench.shell-gradient-background::before {
 		background: radial-gradient(ellipse 128% 102% at 100% 100%,
-			color-mix(in srgb, var(--vscode-agentsGradient-tintColor) 13%, var(--vscode-agents-background)) 0%,
-			color-mix(in srgb, var(--vscode-agentsGradient-tintColor) 10%, var(--vscode-agents-background)) 17%,
-			color-mix(in srgb, var(--vscode-agentsGradient-tintColor) 7%, var(--vscode-agents-background)) 31%,
-			var(--vscode-agents-background) 60%);
+				color-mix(in srgb, var(--vscode-agentsGradient-tintColor) 13%, var(--vscode-agents-background)) 0%,
+				color-mix(in srgb, var(--vscode-agentsGradient-tintColor) 10%, var(--vscode-agents-background)) 17%,
+				color-mix(in srgb, var(--vscode-agentsGradient-tintColor) 7%, var(--vscode-agents-background)) 31%,
+				var(--vscode-agents-background) 60%);
 	}
 }
 
@@ -576,7 +576,7 @@
 	background-color: var(--vscode-agentsChatInput-background) !important;
 }
 .agent-sessions-workbench .interactive-session .chat-edit-input-container .interactive-input-part .chat-editor-container .interactive-input-editor .monaco-editor .monaco-editor-background {
-	background-color: var(--vscode-chat-requestBubbleBackground) !important;
+	background-color: transparent !important;
 }
 
 /* Scoped to the chat panel (`.part.sessionspart`) and the chat editor host

--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -572,8 +572,11 @@
  * transparent background those pieces stop covering the selection layer and the
  * corners render as blocky squares. Paint it with the same color the chat input
  * container uses so the editor still visually matches its surroundings. */
-.agent-sessions-workbench .interactive-session .interactive-input-part:not(.chat-edit-input-container .interactive-input-part) .chat-editor-container .interactive-input-editor .monaco-editor .monaco-editor-background {
+.agent-sessions-workbench .interactive-session .interactive-input-part .chat-editor-container .interactive-input-editor .monaco-editor .monaco-editor-background {
 	background-color: var(--vscode-agentsChatInput-background) !important;
+}
+.agent-sessions-workbench .interactive-session .chat-edit-input-container .interactive-input-part .chat-editor-container .interactive-input-editor .monaco-editor .monaco-editor-background {
+	background-color: var(--vscode-chat-requestBubbleBackground) !important;
 }
 
 /* Scoped to the chat panel (`.part.sessionspart`) and the chat editor host

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -612,7 +612,7 @@ export class OpenDelegationPickerAction extends Action2 {
 						ChatContextKeys.inQuickChat.negate(),
 						ChatContextKeys.chatSessionSupportsDelegation,
 						ChatContextKeys.chatSessionIsEmpty.negate(),
-						// In the agents window, hide the session target chip while a
+						// In the agents window, hide the delegation chip while a
 						// request (or the input) is being edited. The editor window
 						// keeps showing it during edits.
 						ContextKeyExpr.or(

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -611,7 +611,15 @@ export class OpenDelegationPickerAction extends Action2 {
 						ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
 						ChatContextKeys.inQuickChat.negate(),
 						ChatContextKeys.chatSessionSupportsDelegation,
-						ChatContextKeys.chatSessionIsEmpty.negate()
+						ChatContextKeys.chatSessionIsEmpty.negate(),
+						// In the agents window, hide the session target chip while a
+						// request (or the input) is being edited. The editor window
+						// keeps showing it during edits.
+						ContextKeyExpr.or(
+							IsSessionsWindowContext.negate(),
+							ContextKeyExpr.and(
+								ChatContextKeys.currentlyEditing.negate(),
+								ChatContextKeys.currentlyEditingInput.negate()))
 					),
 					group: 'navigation',
 				},


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

before
<img width="831" height="168" alt="Screenshot 2026-06-15 at 4 12 54 PM" src="https://github.com/user-attachments/assets/ada6d565-dba3-4da1-91c9-132eea8231a7" />

after
<img width="958" height="174" alt="Screenshot 2026-06-15 at 8 49 31 PM" src="https://github.com/user-attachments/assets/02a0bf5d-ff4f-46b8-8546-c3cadb8d946c" />


cc @alexdima from https://github.com/microsoft/vscode/pull/320913 ideally we can avoid `!important` but i'm not really sure what background color you were trying to fix there (i removed `!important` and didn't see a difference)