### PR TITLE
sessions: add built-in fix-ci skill for Fix Checks action

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/checksActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/checksActions.ts
@@ -21,6 +21,9 @@ import { GitHubCheckConclusion, GitHubCheckStatus, IGitHubCICheck } from '../../
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 export const hasActiveSessionFailedCIChecks = new RawContextKey<boolean>('sessions.hasActiveSessionFailedCIChecks', false);
 
+/** Slash command that invokes the built-in `fix-ci` skill. */
+const FIX_CI_QUERY = '/fix-ci';
+
 // --- Shared CI check utilities ------------------------------------------------
 
 export const enum CICheckGroup {
@@ -64,7 +67,12 @@ export function getFailedChecks(checks: readonly IGitHubCICheck[]): readonly IGi
 	return checks.filter(check => getCheckGroup(check) === CICheckGroup.Failed);
 }
 
-export function buildFixChecksPrompt(failedChecks: ReadonlyArray<{ check: IGitHubCICheck; annotations: string }>): string {
+/** Builds the GitHub pull request URL for a CI model's coordinates. */
+export function getPullRequestUrl(coords: { owner: string; repo: string; prNumber: number }): string {
+	return `https://github.com/${coords.owner}/${coords.repo}/pull/${coords.prNumber}`;
+}
+
+export function buildFixChecksPrompt(failedChecks: ReadonlyArray<{ check: IGitHubCICheck; annotations: string }>, prUrl?: string): string {
 	const sections = failedChecks.map(({ check, annotations }) => {
 		const parts = [
 			`Check: ${check.name}`,
@@ -80,15 +88,17 @@ export function buildFixChecksPrompt(failedChecks: ReadonlyArray<{ check: IGitHu
 		return parts.join('\n');
 	});
 
-	return [
-		'Please fix the failed CI checks for this session immediately.',
-		'Use the failed check information below, including annotations and check output, to identify the root causes and make the necessary code changes.',
-		'Focus on resolving these CI failures. Avoid unrelated changes unless they are required to fix the checks.',
-		'',
+	const lines = [FIX_CI_QUERY];
+	if (prUrl) {
+		lines.push(`Pull request: ${prUrl}`);
+	}
+	lines.push(
 		'Failed CI checks:',
 		'',
 		sections.join('\n\n---\n\n'),
-	].join('\n');
+	);
+
+	return lines.join('\n');
 }
 
 /**
@@ -163,7 +173,7 @@ class FixCIChecksAction extends Action2 {
 			return { check, annotations };
 		}));
 
-		const prompt = buildFixChecksPrompt(failedCheckDetails);
+		const prompt = buildFixChecksPrompt(failedCheckDetails, getPullRequestUrl(ciModel));
 		const sessionResource = activeSession.resource;
 		const chatWidget = chatWidgetService.getWidgetBySessionResource(sessionResource);
 		if (!chatWidget) {
@@ -171,7 +181,7 @@ class FixCIChecksAction extends Action2 {
 			return;
 		}
 
-		await chatWidget.acceptInput(prompt, { noCommandDetection: true });
+		await chatWidget.acceptInput(prompt);
 	}
 }
 

--- a/src/vs/sessions/contrib/changes/browser/checksWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/checksWidget.ts
@@ -23,7 +23,7 @@ import { DEFAULT_LABELS_CONTAINER, IResourceLabel, ResourceLabels } from '../../
 import { ActionBar } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { GitHubCheckConclusion, GitHubCheckStatus, IGitHubCICheck } from '../../github/common/types.js';
 import { GitHubPullRequestCIModel, parseWorkflowRunId } from '../../github/browser/models/githubPullRequestCIModel.js';
-import { CICheckGroup, buildFixChecksPrompt, getCheckGroup, getCheckStateLabel, getFailedChecks } from './checksActions.js';
+import { CICheckGroup, buildFixChecksPrompt, getCheckGroup, getCheckStateLabel, getFailedChecks, getPullRequestUrl } from './checksActions.js';
 import { ChecksViewModel } from './checksViewModel.js';
 
 const $ = dom.$;
@@ -430,13 +430,13 @@ export class CIStatusWidget extends Disposable {
 			};
 		}));
 
-		const prompt = buildFixChecksPrompt(failedCheckDetails);
+		const prompt = buildFixChecksPrompt(failedCheckDetails, getPullRequestUrl(model));
 		const chatWidget = this._chatWidgetService.getWidgetBySessionResource(sessionResource);
 		if (!chatWidget) {
 			return;
 		}
 
-		await chatWidget.acceptInput(prompt, { noCommandDetection: true });
+		await chatWidget.acceptInput(prompt);
 	}
 }
 

--- a/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
+++ b/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
@@ -276,6 +276,7 @@ export class SessionsAICustomizationWorkspaceService implements IAICustomization
 
 	private static readonly _skillUIIntegrations: ReadonlyMap<string, string> = new Map([
 		['act-on-feedback', localize('skillUI.actOnFeedback', "Used by the Submit Feedback button in the Changes toolbar")],
+		['fix-ci', localize('skillUI.fixCi', "Used by the Fix Checks button in the Changes toolbar")],
 		['code-review', localize('skillUI.codeReview', "Used by the Run Code Review button in the Changes view")],
 		['generate-run-commands', localize('skillUI.generateRunCommands', "Used by the Run button in the title bar")],
 		['create-pr', localize('skillUI.createPr', "Used by the Create Pull Request button in the Changes toolbar")],

--- a/src/vs/sessions/skills/fix-ci/SKILL.md
+++ b/src/vs/sessions/skills/fix-ci/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: fix-ci
+description: Fix the failed CI checks for the current session. Use when the user requests a CI fix via the Fix Checks button in the Changes toolbar.
+---
+<!-- Customize this skill and select save to override its behavior. Delete that copy to restore the built-in behavior. -->
+
+# Fix CI
+
+Please fix the failed CI checks for this session immediately.
+
+Use the failed check information provided with this message, including annotations and check output, to identify the root causes and make the necessary code changes.
+
+## Workflow
+
+1. Read the failed check information attached to this message. It includes a link to the pull request, and for each failed check the check name, status, conclusion, a details URL, and any annotations or output.
+2. Use the annotations and output to identify the root cause of each failure (e.g. compile errors, lint/hygiene violations, failing tests).
+3. Make the necessary code changes to resolve the failures. Focus on resolving these CI failures and avoid unrelated changes unless they are required to fix the checks.
+4. Validate your changes locally where possible (e.g. compile, lint, run the relevant tests) to confirm the failures are addressed.


### PR DESCRIPTION
## What
Adds a built-in ix-ci skill (src/vs/sessions/skills/fix-ci/SKILL.md) and rewires the **Fix Checks** action to invoke it.

Previously the Fix Checks action sent a hardcoded instructional prompt. It now invokes the `/fix-ci` slash command (mirroring the `/act-on-feedback` pattern) followed by the failed CI check information. The instructional prose now lives in the skill, so it can be customized/overridden by users.

The prompt also includes the related pull request link, e.g.:

```
/fix-ci
Pull request: https://github.com/microsoft/vscode/pull/12345
Failed CI checks:

Check: Compile & Hygiene
Status: failed
Conclusion: failure
Details: https://github.com/microsoft/vscode/actions/runs/.../job/...

Annotations and output:
[failure] ...
```

## Changes
- New built-in skill `fix-ci` with workflow instructions.
- `buildFixChecksPrompt` emits `/fix-ci` + PR link + failure info (added `getPullRequestUrl` helper).
- Removed `noCommandDetection: true` so the `/fix-ci` slash command is detected (in both `checksActions.ts` and `checksWidget.ts`).
- Registered the `fix-ci` skill UI-integration badge ("Used by the Fix Checks button in the Changes toolbar").

## Notes for reviewers
- The build glob `out-build/vs/sessions/skills/**/SKILL.md` bundles the new skill automatically.