### PR TITLE
Add window kind assignment filter

### DIFF
--- a/src/vs/platform/assignment/common/assignment.ts
+++ b/src/vs/platform/assignment/common/assignment.ts
@@ -37,7 +37,8 @@ https://experimentation.visualstudio.com/Analysis%20and%20Experimentation/_git/A
 "X-VSCode-TargetPopulation": "targetpopulation",
 "X-VSCode-Language": "language",
 "X-VSCode-Platform": "platform",
-"X-VSCode-ReleaseDate": "releasedate"
+"X-VSCode-ReleaseDate": "releasedate",
+"X-VSCode-WindowKind": "windowkind"
 */
 export enum Filters {
 	/**

--- a/src/vs/platform/assignment/common/assignment.ts
+++ b/src/vs/platform/assignment/common/assignment.ts
@@ -100,6 +100,16 @@ export enum Filters {
 	 * The release/build date of VS Code (UTC) in the format yyyymmddHH.
 	 */
 	ReleaseDate = 'X-VSCode-ReleaseDate',
+
+	/**
+	 * The kind of window VS Code is running in (`editor` or `agents`).
+	 */
+	WindowKind = 'X-VSCode-WindowKind',
+}
+
+export const enum WindowKind {
+	Editor = 'editor',
+	Agents = 'agents',
 }
 
 export class AssignmentFilterProvider implements IExperimentationFilterProvider {
@@ -109,7 +119,8 @@ export class AssignmentFilterProvider implements IExperimentationFilterProvider 
 		private machineId: string,
 		private devDeviceId: string,
 		private targetPopulation: TargetPopulation,
-		private releaseDate: string
+		private releaseDate: string,
+		private windowKind: WindowKind
 	) { }
 
 	/**
@@ -148,6 +159,8 @@ export class AssignmentFilterProvider implements IExperimentationFilterProvider 
 				return platform.PlatformToString(platform.platform);
 			case Filters.ReleaseDate:
 				return AssignmentFilterProvider.formatReleaseDate(this.releaseDate);
+			case Filters.WindowKind:
+				return this.windowKind;
 			default:
 				return '';
 		}

--- a/src/vs/workbench/services/assignment/common/assignmentService.ts
+++ b/src/vs/workbench/services/assignment/common/assignmentService.ts
@@ -13,7 +13,7 @@ import { ITelemetryData } from '../../../../base/common/actions.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
-import { ASSIGNMENT_REFETCH_INTERVAL, ASSIGNMENT_STORAGE_KEY, AssignmentFilterProvider, IAssignmentService, TargetPopulation } from '../../../../platform/assignment/common/assignment.js';
+import { ASSIGNMENT_REFETCH_INTERVAL, ASSIGNMENT_STORAGE_KEY, AssignmentFilterProvider, IAssignmentService, TargetPopulation, WindowKind } from '../../../../platform/assignment/common/assignment.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { workbenchConfigurationNodeBase } from '../../../common/configuration.js';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions, ConfigurationScope } from '../../../../platform/configuration/common/configurationRegistry.js';
@@ -165,12 +165,12 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 		@IStorageService storageService: IStorageService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IProductService private readonly productService: IProductService,
-		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
+		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) {
 		super();
 
-		this.experimentsEnabled = experimentsEnabled(configurationService, productService, environmentService);
+		this.experimentsEnabled = experimentsEnabled(configurationService, productService, this.environmentService);
 
 		if (this.experimentsEnabled) {
 			this.tasClient = this.setupTASClient();
@@ -261,7 +261,8 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 			this.telemetryService.machineId,
 			this.telemetryService.devDeviceId,
 			targetPopulation,
-			this.productService.date ?? ''
+			this.productService.date ?? '',
+			this.environmentService.isSessionsWindow ? WindowKind.Agents : WindowKind.Editor
 		);
 
 		const extensionsFilterProvider = this.instantiationService.createInstance(CopilotAssignmentFilterProvider);


### PR DESCRIPTION
Adds a new `window kind` assignment filter to the assignment filter provider.

The filter (`X-VSCode-WindowKind`) reports:
- `agents` when `IWorkbenchEnvironmentService.isSessionsWindow` is `true`
- `editor` otherwise

### Changes
- `src/vs/platform/assignment/common/assignment.ts`: added `Filters.WindowKind`, a `WindowKind` enum (`editor`/`agents`), a `windowKind` constructor param on `AssignmentFilterProvider`, and the corresponding `getFilterValue` case.
- `src/vs/workbench/services/assignment/common/assignmentService.ts`: passes `environmentService.isSessionsWindow ? WindowKind.Agents : WindowKind.Editor` to the filter provider.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>