### PR TITLE
sessions: support multi-select restore and remove Restore All on Done section

### DIFF
--- a/src/vs/sessions/SESSIONS_LIST.md
+++ b/src/vs/sessions/SESSIONS_LIST.md
@@ -124,7 +124,7 @@ The sessions list defines menu IDs that contributions can target to add actions.
 
 | Menu | Constant | Where it appears | Use for |
 |------|----------|------------------|---------|
-| `SessionSectionToolbar` | `SessionSectionToolbarMenuId` | Toolbar on section headers (Pinned, workspace groups, Done) | Section-scoped actions like "New Session for Workspace", "Archive All", "Restore All". Section headers also show a collapsible chevron on hover/focus; the chevron uses the same ghost icon hover background token as toolbar icon buttons. |
+| `SessionSectionToolbar` | `SessionSectionToolbarMenuId` | Toolbar on section headers (Pinned, workspace groups, Done) | Section-scoped actions like "New Session for Workspace" and "Mark All as Done". The Done section restores sessions individually (or via multi-selection) rather than with a section-wide action. Section headers also show a collapsible chevron on hover/focus; the chevron uses the same ghost icon hover background token as toolbar icon buttons. |
 
 ### View Title Menus
 

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -38,7 +38,7 @@ import { GITHUB_REMOTE_FILE_SCHEME, ISession, ISessionWorkspace, SessionStatus }
 import { AgentSessionApprovalModel, IAgentSessionApprovalInfo } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
 import { Button } from '../../../../../base/browser/ui/button/button.js';
 import { IMarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
-import { Action, IAction, Separator } from '../../../../../base/common/actions.js';
+import { Action, ActionRunner, IAction, Separator } from '../../../../../base/common/actions.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { HoverStyle } from '../../../../../base/browser/ui/hover/hover.js';
 import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.js';
@@ -179,6 +179,27 @@ class SessionsTreeDelegate implements IListVirtualDelegate<SessionListItem> {
 
 //#region Session Item Renderer
 
+/**
+ * Resolves the inline toolbar action context to the current multi-selection so
+ * that session item actions (e.g. Restore) operate on all selected sessions
+ * when the clicked session is part of the selection, and on just the clicked
+ * session otherwise.
+ */
+class SessionItemActionRunner extends ActionRunner {
+
+	constructor(private readonly getMultiSelectedSessions: (session: ISession) => ISession[]) {
+		super();
+	}
+
+	protected override async runAction(action: IAction, context?: unknown): Promise<void> {
+		if (context && !Array.isArray(context)) {
+			await super.runAction(action, this.getMultiSelectedSessions(context as ISession));
+			return;
+		}
+		await super.runAction(action, context);
+	}
+}
+
 interface ISessionItemTemplate {
 	readonly container: HTMLElement;
 	readonly statusIcon: SessionStatusIcon;
@@ -210,7 +231,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 	readonly onDidChangeItemHeight: Event<ISession> = this._onDidChangeItemHeight.event;
 
 	constructor(
-		private readonly options: { grouping: () => SessionsGrouping; sorting: () => SessionsSorting; isPinned: (session: ISession) => boolean; isRead: (session: ISession) => boolean; visibleSessions: IObservable<readonly (IActiveSession | undefined)[]> },
+		private readonly options: { grouping: () => SessionsGrouping; sorting: () => SessionsSorting; isPinned: (session: ISession) => boolean; isRead: (session: ISession) => boolean; visibleSessions: IObservable<readonly (IActiveSession | undefined)[]>; getMultiSelectedSessions: (session: ISession) => ISession[] },
 		private readonly approvalModel: AgentSessionApprovalModel | undefined,
 		private readonly instantiationService: IInstantiationService,
 		private readonly contextKeyService: IContextKeyService,
@@ -253,8 +274,10 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 
 		const contextKeyService = disposables.add(this.contextKeyService.createScoped(container));
 		const scopedInstantiationService = disposables.add(this.instantiationService.createChild(new ServiceCollection([IContextKeyService, contextKeyService])));
+		const actionRunner = disposables.add(new SessionItemActionRunner(this.options.getMultiSelectedSessions));
 		const titleToolbar = disposables.add(scopedInstantiationService.createInstance(MenuWorkbenchToolBar, titleToolbarContainer, SessionItemToolbarMenuId, {
 			menuOptions: { shouldForwardArgs: true },
+			actionRunner,
 		}));
 
 		return { container, statusIcon, title, titleToolbar, detailsRow, approvalRow, approvalLabel, approvalButtonContainer, contextKeyService, disposables, elementDisposables };
@@ -934,7 +957,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		// TEMPORARY (#320480): see the note on the `IAgentSessionsService` import.
 		const agentSessionsService = instantiationService.invokeFunction(accessor => accessor.get(IAgentSessionsService));
 		const sessionRenderer = new SessionItemRenderer(
-			{ grouping: this.options.grouping, sorting: this.options.sorting, isPinned: s => this.isSessionPinned(s), isRead: s => this.isSessionRead(s), visibleSessions: this._sessionsService.visibleSessions },
+			{ grouping: this.options.grouping, sorting: this.options.sorting, isPinned: s => this.isSessionPinned(s), isRead: s => this.isSessionRead(s), visibleSessions: this._sessionsService.visibleSessions, getMultiSelectedSessions: s => this.getMultiSelectedSessions(s) },
 			approvalModel,
 			instantiationService,
 			contextKeyService,
@@ -983,7 +1006,9 @@ export class SessionsList extends Disposable implements ISessionsList {
 						if (isSessionShowMore(element)) {
 							return NotSelectableGroupId;
 						}
-						return 1;
+						// Use a distinct group for archived (done) sessions so that
+						// multi-selection cannot span the workspace and done sections.
+						return element.isArchived.get() ? 2 : 1;
 					}
 				},
 				horizontalScrolling: false,
@@ -1424,14 +1449,24 @@ export class SessionsList extends Disposable implements ISessionsList {
 
 	// Context menu
 
+	/**
+	 * Resolves the sessions an action should operate on for a given clicked
+	 * session: when the clicked session is part of the current multi-selection
+	 * the full selection is returned (clicked session first), otherwise just the
+	 * clicked session.
+	 */
+	private getMultiSelectedSessions(session: ISession): ISession[] {
+		const selection = this.tree.getSelection().filter((s): s is ISession => !!s && !isSessionSection(s) && !isSessionShowMore(s));
+		return selection.includes(session) ? [session, ...selection.filter(s => s !== session)] : [session];
+	}
+
 	private onContextMenu(e: ITreeContextMenuEvent<SessionListItem | null>): void {
 		const element = e.element;
 		if (!element || isSessionSection(element) || isSessionShowMore(element)) {
 			return;
 		}
 
-		const selection = this.tree.getSelection().filter((s): s is ISession => !!s && !isSessionSection(s) && !isSessionShowMore(s));
-		const selectedSessions = selection.includes(element) ? [element, ...selection.filter(s => s !== element)] : [element];
+		const selectedSessions = this.getMultiSelectedSessions(element);
 
 		const contextOverlay: [string, boolean | string][] = [
 			[IsSessionPinnedContext.key, this.isSessionPinned(element)],

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -554,56 +554,6 @@ registerAction2(class ArchiveSectionAction extends Action2 {
 	}
 });
 
-registerAction2(class UnarchiveSectionAction extends Action2 {
-	constructor() {
-		super({
-			id: 'sessionsView.sectionUnarchive',
-			title: localize2('unarchiveSection', "Restore All"),
-			icon: Codicon.discard,
-			menu: [{
-				id: SessionSectionToolbarMenuId,
-				group: 'navigation',
-				order: 0,
-				when: ContextKeyExpr.equals(SessionSectionTypeContext.key, 'archived'),
-			}]
-		});
-	}
-	async run(accessor: ServicesAccessor, context?: ISessionSection): Promise<void> {
-		if (!context || !context.sessions || context.sessions.length === 0) {
-			return;
-		}
-
-		const sessionsManagementService = accessor.get(ISessionsManagementService);
-		const dialogService = accessor.get(IDialogService);
-		const storageService = accessor.get(IStorageService);
-
-		if (context.sessions.length > 1) {
-			const skipConfirmation = storageService.getBoolean(ConfirmArchiveStorageKey, StorageScope.PROFILE, false);
-			if (!skipConfirmation) {
-				const confirmed = await dialogService.confirm({
-					message: localize('unarchiveSectionSessions.confirm', "Are you sure you want to restore {0} sessions?", context.sessions.length),
-					primaryButton: localize('unarchiveSectionSessions.unarchive', "Restore All"),
-					checkbox: {
-						label: localize('doNotAskAgain2', "Do not ask me again")
-					}
-				});
-
-				if (!confirmed.confirmed) {
-					return;
-				}
-
-				if (confirmed.checkboxChecked) {
-					storageService.store(ConfirmArchiveStorageKey, true, StorageScope.PROFILE, StorageTarget.USER);
-				}
-			}
-		}
-
-		for (const session of context.sessions) {
-			await sessionsManagementService.unarchiveSession(session);
-		}
-	}
-});
-
 //  Session Item Actions
 
 registerAction2(class PinSessionAction extends Action2 {


### PR DESCRIPTION
## What

Updates the Agents Window sessions list around the **Done** (archived) section:

- **Removed the section-level "Restore All" action** from the Done section toolbar. Sessions are now restored individually from each session row, or via multi-selection.
- **Made the inline `Restore` action multi-select aware.** Selecting several sessions and clicking Restore on one of them restores the whole selection — but only when the clicked row is part of the selection. If you select rows 1–3 and press Restore on row 4, only row 4 is restored; pressing Restore on row 2 restores rows 1–3. This is wired via a custom `ActionRunner` on the inline session toolbar that resolves the clicked session to the current selection (reusing the same logic as the context menu). Pin/Unpin/Mark-as-Done benefit consistently since they already accept `ISession[]`.
- **Archived sessions now get a distinct identity-provider group id**, so multi-selection cannot span the workspace and Done sections.

## Why

The "Restore All" on the section node was redundant with per-row restore, and restore did not honor multi-selection. Scoping the selection group also prevents accidentally mixing active and done sessions in one selection.

## Notes for reviewers

- `getMultiSelectedSessions` is now shared between the inline toolbar action runner and the context menu.
- `SESSIONS_LIST.md` updated to drop the "Restore All" mention.
- Validated with `compile-check-ts-native`, `eslint`, and the pre-commit hygiene hook.
