### PR TITLE
Add Copilot Agent Host runtime slash commands

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -352,6 +352,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		this._register(completions.registerProvider(new CopilotSlashCommandCompletionProvider(this.id, {
 			hasHistory: (sessionId) => !this._provisionalSessions.has(sessionId) && this._sessions.has(sessionId),
 			isRubberDuckEnabled: () => this._isRubberDuckEnabled(),
+			hasRuntimeSlashCommand: async (sessionId, command) => this._sessions.get(sessionId)?.hasRuntimeSlashCommand(command) ?? false,
 		})));
 
 		// Restart the CLI client when a setting baked into the client/subprocess at

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -69,7 +69,7 @@ type RuntimeSlashCommandCache = { readonly expiresAt: number; readonly promise: 
 const COPILOT_HOME_DIRECTORY = '.copilot';
 const SESSION_STATE_DIRECTORY = join(COPILOT_HOME_DIRECTORY, 'session-state');
 const EMPTY_TOOL_RESULT_TEXT = '<empty />';
-const RUNTIME_SLASH_COMMAND_CACHE_TTL_MS = 10_000;
+const RUNTIME_SLASH_COMMAND_CACHE_TTL_MS = 30_000;
 
 function getEmptyToolResultText(binaryResults: readonly { readonly type: 'image' | 'resource' }[] | undefined): string {
 	if (!binaryResults?.length) {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -64,10 +64,12 @@ import { McpServerStatus, type McpServerState } from '../../common/state/protoco
 export type CopilotSdkMode = 'interactive' | 'plan' | 'autopilot';
 type CopilotSdkAttachment = Required<MessageOptions>['attachments'][number];
 type CopilotCommandInvocationResult = Awaited<ReturnType<CopilotSession['rpc']['commands']['invoke']>>;
+type RuntimeSlashCommandCache = { readonly expiresAt: number; readonly promise: Promise<ReadonlySet<string>> };
 
 const COPILOT_HOME_DIRECTORY = '.copilot';
 const SESSION_STATE_DIRECTORY = join(COPILOT_HOME_DIRECTORY, 'session-state');
 const EMPTY_TOOL_RESULT_TEXT = '<empty />';
+const RUNTIME_SLASH_COMMAND_CACHE_TTL_MS = 10_000;
 
 function getEmptyToolResultText(binaryResults: readonly { readonly type: 'image' | 'resource' }[] | undefined): string {
 	if (!binaryResults?.length) {
@@ -379,6 +381,7 @@ export class CopilotAgentSession extends Disposable {
 	private _turnCopilotUsageTotalNanoAiu = 0;
 	/** SDK session wrapper, set by {@link initializeSession}. */
 	private _wrapper!: CopilotSessionWrapper;
+	private _runtimeSlashCommandCache: RuntimeSlashCommandCache | undefined;
 	/** Last agent mode pushed to the SDK via {@link applyMode}, to elide redundant `rpc.mode.set` calls. */
 	private _lastAppliedMode: CopilotSdkMode | undefined;
 	private readonly _steeringMessagesInFlight = new Set<string>();
@@ -1002,12 +1005,27 @@ export class CopilotAgentSession extends Disposable {
 
 	async hasRuntimeSlashCommand(command: string): Promise<boolean> {
 		try {
-			const result = await this._wrapper.session.rpc.commands.list({ includeBuiltins: true, includeSkills: false, includeClientCommands: false });
-			return result.commands.some(candidate => candidate.kind === 'builtin' && candidate.name === command);
+			return (await this._getRuntimeSlashCommands()).has(command);
 		} catch (err) {
 			this._logService.warn(`[Copilot:${this.sessionId}] rpc.commands.list failed`, err);
 			return false;
 		}
+	}
+
+	private _getRuntimeSlashCommands(): Promise<ReadonlySet<string>> {
+		const now = Date.now();
+		if (this._runtimeSlashCommandCache && this._runtimeSlashCommandCache.expiresAt > now) {
+			return this._runtimeSlashCommandCache.promise;
+		}
+		const promise = this._wrapper.session.rpc.commands.list({ includeBuiltins: true, includeSkills: false, includeClientCommands: false })
+			.then(result => new Set(result.commands.filter(command => command.kind === 'builtin').map(command => command.name)));
+		this._runtimeSlashCommandCache = { expiresAt: now + RUNTIME_SLASH_COMMAND_CACHE_TTL_MS, promise };
+		promise.catch(() => {
+			if (this._runtimeSlashCommandCache?.promise === promise) {
+				this._runtimeSlashCommandCache = undefined;
+			}
+		});
+		return promise;
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -42,7 +42,7 @@ import type { CopilotSessionLaunchPlan, IActiveClientSnapshot, ICopilotSessionLa
 import { ActiveClientState } from '../activeClientState.js';
 import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
 import { buildCopilotSystemNotification } from './copilotSystemNotification.js';
-import { commandExpectsInput, isRuntimeCopilotSlashCommand, parseLeadingSlashCommand } from './copilotSlashCommandCompletionProvider.js';
+import { isPromptInvokedCopilotSlashCommand, isRuntimeCopilotSlashCommand, parseLeadingSlashCommand } from './copilotSlashCommandCompletionProvider.js';
 import type { IUnsandboxedCommandConfirmationRequest, ShellManager } from './copilotShellTools.js';
 import { buildSandboxConfigForSdk } from './sandboxConfigForSdk.js';
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
@@ -939,7 +939,6 @@ export class CopilotAgentSession extends Disposable {
 			try {
 				result = await this._wrapper.session.rpc.commands.invoke({
 					name: slashCommand.command,
-					...(commandExpectsInput(slashCommand.command) && slashCommand.rest ? { input: slashCommand.rest } : {}),
 				});
 			} catch (err) {
 				this._logService.error(err, `[Copilot:${this.sessionId}] rpc.commands.invoke(${slashCommand.command}) failed`);
@@ -972,8 +971,8 @@ export class CopilotAgentSession extends Disposable {
 				return;
 			}
 		}
-		if (slashCommand?.command === 'research') {
-			prompt = slashCommand.rest ? `/research ${slashCommand.rest}` : '/research';
+		if (slashCommand && isPromptInvokedCopilotSlashCommand(slashCommand.command)) {
+			prompt = slashCommand.rest ? `/${slashCommand.command} ${slashCommand.rest}` : `/${slashCommand.command}`;
 		}
 		if (slashCommand?.command === 'plan') {
 			mode = 'plan';

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -8,6 +8,7 @@ import { DeferredPromise } from '../../../../base/common/async.js';
 import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { CancellationError } from '../../../../base/common/errors.js';
+import { escapeMarkdownSyntaxTokens } from '../../../../base/common/htmlContent.js';
 import { Disposable, IReference, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { isAbsolute, join } from '../../../../base/common/path.js';
@@ -946,7 +947,7 @@ export class CopilotAgentSession extends Disposable {
 			}
 			switch (result.kind) {
 				case 'text':
-					this._emitMarkdownDelta(result.text);
+					this._emitMarkdownDelta(result.markdown === true ? result.text : escapeMarkdownSyntaxTokens(result.text));
 					break;
 				case 'completed':
 					if (result.message) {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { ExitPlanModeRequest, MessageOptions, PermissionRequestResult, SessionConfig, Tool, ToolResultObject, McpServerStatus as SdkMcpServerStatus } from '@github/copilot-sdk';
+import type { CopilotSession, ExitPlanModeRequest, MessageOptions, PermissionRequestResult, SessionConfig, Tool, ToolResultObject, McpServerStatus as SdkMcpServerStatus } from '@github/copilot-sdk';
 import { DeferredPromise } from '../../../../base/common/async.js';
 import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter } from '../../../../base/common/event.js';
@@ -41,7 +41,7 @@ import type { CopilotSessionLaunchPlan, IActiveClientSnapshot, ICopilotSessionLa
 import { ActiveClientState } from '../activeClientState.js';
 import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
 import { buildCopilotSystemNotification } from './copilotSystemNotification.js';
-import { parseLeadingSlashCommand } from './copilotSlashCommandCompletionProvider.js';
+import { isRuntimeCopilotSlashCommand, parseLeadingSlashCommand } from './copilotSlashCommandCompletionProvider.js';
 import type { IUnsandboxedCommandConfirmationRequest, ShellManager } from './copilotShellTools.js';
 import { buildSandboxConfigForSdk } from './sandboxConfigForSdk.js';
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
@@ -63,6 +63,7 @@ import { McpServerStatus, type McpServerState } from '../../common/state/protoco
  */
 export type CopilotSdkMode = 'interactive' | 'plan' | 'autopilot';
 type CopilotSdkAttachment = Required<MessageOptions>['attachments'][number];
+type CopilotCommandInvocationResult = Awaited<ReturnType<CopilotSession['rpc']['commands']['invoke']>>;
 
 const COPILOT_HOME_DIRECTORY = '.copilot';
 const SESSION_STATE_DIRECTORY = join(COPILOT_HOME_DIRECTORY, 'session-state');
@@ -132,6 +133,17 @@ type ToolUseHookInput = PreToolUseHookInput | PostToolUseHookInput;
 function getToolCommand(input: ToolUseHookInput): string | undefined {
 	const command = isObject(input.toolArgs) ? Reflect.get(input.toolArgs, 'command') : undefined;
 	return isString(command) ? command : undefined;
+}
+
+function toCopilotSdkMode(mode: string | undefined): CopilotSdkMode | undefined {
+	switch (mode) {
+		case 'interactive':
+		case 'plan':
+		case 'autopilot':
+			return mode;
+		default:
+			return undefined;
+	}
 }
 
 /**
@@ -918,6 +930,44 @@ export class CopilotAgentSession extends Disposable {
 			this._completeActiveTurn();
 			return;
 		}
+		if (slashCommand && isRuntimeCopilotSlashCommand(slashCommand.command) && await this.hasRuntimeSlashCommand(slashCommand.command)) {
+			let result: CopilotCommandInvocationResult;
+			try {
+				result = await this._wrapper.session.rpc.commands.invoke({
+					name: slashCommand.command,
+					...(slashCommand.command !== 'env' && slashCommand.rest ? { input: slashCommand.rest } : {}),
+				});
+			} catch (err) {
+				this._logService.error(err, `[Copilot:${this.sessionId}] rpc.commands.invoke(${slashCommand.command}) failed`);
+				throw err;
+			}
+			switch (result.kind) {
+				case 'text':
+					this._emitMarkdownDelta(result.text);
+					break;
+				case 'completed':
+					if (result.message) {
+						this._emitMarkdownDelta(result.message);
+					}
+					break;
+				case 'agent-prompt': {
+					const runtimeMode = toCopilotSdkMode(result.mode);
+					if (runtimeMode) {
+						mode = runtimeMode;
+					}
+					prompt = result.prompt;
+					break;
+				}
+				default:
+					this._logService.warn(`[Copilot:${this.sessionId}] Unexpected /${slashCommand.command} command result kind: ${result.kind}`);
+					this._emitMarkdownDelta(localize('copilotSlashCommand.unsupportedRuntimeResult', "The /{0} command returned an unsupported result.", slashCommand.command));
+					break;
+			}
+			if (result.kind !== 'agent-prompt') {
+				this._completeActiveTurn();
+				return;
+			}
+		}
 		if (slashCommand?.command === 'research') {
 			prompt = slashCommand.rest ? `/research ${slashCommand.rest}` : '/research';
 		}
@@ -948,6 +998,16 @@ export class CopilotAgentSession extends Disposable {
 		await this.applyMode(mode);
 		await this._wrapper.session.send({ prompt, attachments: sdkAttachments?.length ? sdkAttachments : undefined });
 		this._logService.info(`[Copilot:${this.sessionId}] session.send() returned`);
+	}
+
+	async hasRuntimeSlashCommand(command: string): Promise<boolean> {
+		try {
+			const result = await this._wrapper.session.rpc.commands.list({ includeBuiltins: true, includeSkills: false, includeClientCommands: false });
+			return result.commands.some(candidate => candidate.kind === 'builtin' && candidate.name === command);
+		} catch (err) {
+			this._logService.warn(`[Copilot:${this.sessionId}] rpc.commands.list failed`, err);
+			return false;
+		}
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -41,7 +41,7 @@ import type { CopilotSessionLaunchPlan, IActiveClientSnapshot, ICopilotSessionLa
 import { ActiveClientState } from '../activeClientState.js';
 import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
 import { buildCopilotSystemNotification } from './copilotSystemNotification.js';
-import { isRuntimeCopilotSlashCommand, parseLeadingSlashCommand } from './copilotSlashCommandCompletionProvider.js';
+import { commandExpectsInput, isRuntimeCopilotSlashCommand, parseLeadingSlashCommand } from './copilotSlashCommandCompletionProvider.js';
 import type { IUnsandboxedCommandConfirmationRequest, ShellManager } from './copilotShellTools.js';
 import { buildSandboxConfigForSdk } from './sandboxConfigForSdk.js';
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
@@ -938,7 +938,7 @@ export class CopilotAgentSession extends Disposable {
 			try {
 				result = await this._wrapper.session.rpc.commands.invoke({
 					name: slashCommand.command,
-					...(slashCommand.command !== 'env' && slashCommand.rest ? { input: slashCommand.rest } : {}),
+					...(commandExpectsInput(slashCommand.command) && slashCommand.rest ? { input: slashCommand.rest } : {}),
 				});
 			} catch (err) {
 				this._logService.error(err, `[Copilot:${this.sessionId}] rpc.commands.invoke(${slashCommand.command}) failed`);

--- a/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
@@ -18,7 +18,8 @@ import { extractLeadingSlashToken } from '../agentHostSlashCompletion.js';
 export type CopilotSlashCommandName = 'plan' | 'compact' | 'research' | 'rubber-duck' | 'env' | 'review' | 'security-review';
 
 const COMMANDS: readonly CopilotSlashCommandName[] = ['plan', 'compact', 'research', 'rubber-duck', 'env', 'review', 'security-review'];
-const RUNTIME_COMMANDS = new Set<CopilotSlashCommandName>(['env', 'review', 'security-review']);
+const RUNTIME_RPC_INVOKED_COMMANDS = new Set<CopilotSlashCommandName>(['env']);
+const PROMPT_INVOKED_COMMANDS = new Set<CopilotSlashCommandName>(['research', 'review', 'security-review']);
 function getCommandDescription(command: CopilotSlashCommandName): string {
 	switch (command) {
 		case 'plan': return localize('copilotSlashCommand.plan.description', "Create an implementation plan before coding");
@@ -32,10 +33,14 @@ function getCommandDescription(command: CopilotSlashCommandName): string {
 }
 
 export function isRuntimeCopilotSlashCommand(command: CopilotSlashCommandName): boolean {
-	return RUNTIME_COMMANDS.has(command);
+	return RUNTIME_RPC_INVOKED_COMMANDS.has(command);
 }
 
-export function commandExpectsInput(command: CopilotSlashCommandName): boolean {
+export function isPromptInvokedCopilotSlashCommand(command: CopilotSlashCommandName): boolean {
+	return PROMPT_INVOKED_COMMANDS.has(command);
+}
+
+function commandExpectsInput(command: CopilotSlashCommandName): boolean {
 	return command !== 'compact' && command !== 'env';
 }
 /**

--- a/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
@@ -15,16 +15,28 @@ import { extractLeadingSlashToken } from '../agentHostSlashCompletion.js';
  * Slash-command name and the token we surface to the user / round-trip on
  * the {@link MessageAttachmentKind.Simple} attachment's `_meta`.
  */
-export type CopilotSlashCommandName = 'plan' | 'compact' | 'research' | 'rubber-duck';
+export type CopilotSlashCommandName = 'plan' | 'compact' | 'research' | 'rubber-duck' | 'env' | 'review' | 'security-review';
 
-const COMMANDS: readonly CopilotSlashCommandName[] = ['plan', 'compact', 'research', 'rubber-duck'];
+const COMMANDS: readonly CopilotSlashCommandName[] = ['plan', 'compact', 'research', 'rubber-duck', 'env', 'review', 'security-review'];
+const RUNTIME_COMMANDS = new Set<CopilotSlashCommandName>(['env', 'review', 'security-review']);
 function getCommandDescription(command: CopilotSlashCommandName): string {
 	switch (command) {
 		case 'plan': return localize('copilotSlashCommand.plan.description', "Create an implementation plan before coding");
 		case 'compact': return localize('copilotSlashCommand.compact.description', "Free up context by compacting the conversation history");
 		case 'research': return localize('copilotSlashCommand.research.description', "Run deep research on a topic using search and web sources");
 		case 'rubber-duck': return localize('copilotSlashCommand.rubberDuck.description', "Get an independent critique of the current approach");
+		case 'env': return localize('copilotSlashCommand.env.description', "Show loaded environment details");
+		case 'review': return localize('copilotSlashCommand.review.description', "Run code review agent to analyze changes");
+		case 'security-review': return localize('copilotSlashCommand.securityReview.description', "Analyze staged and unstaged changes for security vulnerabilities");
 	}
+}
+
+export function isRuntimeCopilotSlashCommand(command: CopilotSlashCommandName): boolean {
+	return RUNTIME_COMMANDS.has(command);
+}
+
+function commandExpectsInput(command: CopilotSlashCommandName): boolean {
+	return command !== 'compact' && command !== 'env';
 }
 /**
  * Lookup hook used by {@link CopilotSlashCommandCompletionProvider} to
@@ -40,6 +52,8 @@ export interface ICopilotSlashCommandSessionInfo {
 	 * the agent host config. When absent or `false`, `/rubber-duck` is hidden.
 	 */
 	isRubberDuckEnabled?(): boolean;
+	/** Whether the runtime reports the given slash command as available. */
+	hasRuntimeSlashCommand?(sessionId: string, command: string): Promise<boolean>;
 }
 
 /**
@@ -54,13 +68,13 @@ export interface IParsedLeadingSlashCommand {
 /**
  * Parses a Copilot CLI slash command at the very start of `prompt`.
  *
- * The command must be `/plan`, `/compact`, `/research`, or `/rubber-duck`,
+ * The command must be `/plan`, `/compact`, `/research`, `/rubber-duck`, `/env`, `/review`, or `/security-review`,
  * followed either by end-of-input or by at least one whitespace character.
  * `/compact-hello`, `/plans`, or a leading-space `/compact` all return
  * `undefined`. Match is case-sensitive.
  */
 export function parseLeadingSlashCommand(prompt: string): IParsedLeadingSlashCommand | undefined {
-	const match = /^\/(plan|compact|research|rubber-duck)(?:$|\s+([\s\S]*))/.exec(prompt);
+	const match = /^\/(plan|compact|research|rubber-duck|env|review|security-review)(?:$|\s+([\s\S]*))/.exec(prompt);
 	if (!match) {
 		return undefined;
 	}
@@ -116,8 +130,11 @@ export class CopilotSlashCommandCompletionProvider implements IAgentHostCompleti
 			if (command === 'rubber-duck' && !rubberDuckEnabled) {
 				continue;
 			}
+			if (isRuntimeCopilotSlashCommand(command) && !(await this._sessionInfo?.hasRuntimeSlashCommand?.(sessionId, command))) {
+				continue;
+			}
 			items.push({
-				insertText: command === 'compact' ? '/' + command : '/' + command + ' ',
+				insertText: commandExpectsInput(command) ? '/' + command + ' ' : '/' + command,
 				rangeStart: 0,
 				rangeEnd: leading.rangeEnd,
 				attachment: {

--- a/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
@@ -35,7 +35,7 @@ export function isRuntimeCopilotSlashCommand(command: CopilotSlashCommandName): 
 	return RUNTIME_COMMANDS.has(command);
 }
 
-function commandExpectsInput(command: CopilotSlashCommandName): boolean {
+export function commandExpectsInput(command: CopilotSlashCommandName): boolean {
 	return command !== 'compact' && command !== 'env';
 }
 /**

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -47,7 +47,11 @@ class MockCopilotSession {
 	readonly sendRequests: unknown[] = [];
 	readonly modeSetCalls: Array<{ mode: 'interactive' | 'plan' | 'autopilot' }> = [];
 	readonly compactCalls: unknown[] = [];
+	readonly commandListCalls: unknown[] = [];
+	readonly commandInvokeCalls: Array<{ name: string; input?: string }> = [];
 	compactResult: { success: boolean; tokensRemoved: number; messagesRemoved: number } = { success: true, tokensRemoved: 0, messagesRemoved: 0 };
+	commandListResult: { commands: Array<{ name: string; kind: 'builtin' | 'skill' | 'client'; description: string; allowDuringAgentExecution: boolean }> } = { commands: [] };
+	commandInvokeResult: { kind: 'text'; text: string; markdown?: boolean } | { kind: 'completed'; message?: string } | { kind: 'agent-prompt'; prompt: string; displayPrompt: string; mode?: 'interactive' | 'plan' | 'autopilot' } = { kind: 'text', text: '' };
 	messages: SessionEvent[] = [];
 
 	private readonly _handlers = new Map<string, Set<(event: SessionEvent) => void>>();
@@ -100,6 +104,16 @@ class MockCopilotSession {
 			compact: async (params?: unknown) => {
 				this.compactCalls.push(params ?? null);
 				return this.compactResult;
+			},
+		},
+		commands: {
+			list: async (params?: unknown) => {
+				this.commandListCalls.push(params ?? null);
+				return this.commandListResult;
+			},
+			invoke: async (params: { name: string; input?: string }) => {
+				this.commandInvokeCalls.push(params);
+				return this.commandInvokeResult;
 			},
 		},
 		mcp: {
@@ -558,6 +572,147 @@ suite('CopilotAgentSession', () => {
 		assert.deepStrictEqual(mockSession.sendRequests, []);
 		const turnComplete = getActions(signals).find(a => a.type === ActionType.ChatTurnComplete);
 		assert.ok(turnComplete, 'expected the turn to complete on a failed compaction');
+	});
+
+	test('`/env` runs the runtime command when listed and emits markdown output', async () => {
+		const { session, mockSession, signals } = await createAgentSession(disposables);
+		mockSession.commandListResult = {
+			commands: [{
+				name: 'env',
+				kind: 'builtin',
+				description: 'Show loaded environment details',
+				allowDuringAgentExecution: true,
+			}],
+		};
+		mockSession.commandInvokeResult = { kind: 'text', text: '## Environment\n\nLoaded.', markdown: true };
+
+		await session.send('/env', undefined, 'turn-env');
+
+		const actions = getActions(signals);
+		assert.deepStrictEqual({
+			commandListCalls: mockSession.commandListCalls,
+			commandInvokeCalls: mockSession.commandInvokeCalls,
+			sendRequests: mockSession.sendRequests,
+			responseParts: actions
+				.filter(a => a.type === ActionType.ChatResponsePart)
+				.map(a => {
+					const part = (a as ChatResponsePartAction).part;
+					return part.kind === ResponsePartKind.Markdown ? { kind: part.kind, content: part.content } : { kind: part.kind };
+				}),
+			turnComplete: actions
+				.filter(a => a.type === ActionType.ChatTurnComplete)
+				.map(a => (a as ChatTurnCompleteAction).turnId),
+		}, {
+			commandListCalls: [{ includeBuiltins: true, includeSkills: false, includeClientCommands: false }],
+			commandInvokeCalls: [{ name: 'env' }],
+			sendRequests: [],
+			responseParts: [{ kind: ResponsePartKind.Markdown, content: '## Environment\n\nLoaded.' }],
+			turnComplete: ['turn-env'],
+		});
+	});
+
+	test('`/env` falls through to a normal SDK send when not listed', async () => {
+		const { session, mockSession, signals } = await createAgentSession(disposables);
+		mockSession.commandListResult = { commands: [] };
+
+		await session.send('/env', undefined, 'turn-env');
+
+		assert.deepStrictEqual({
+			commandListCalls: mockSession.commandListCalls,
+			commandInvokeCalls: mockSession.commandInvokeCalls,
+			sendRequests: mockSession.sendRequests,
+			responseParts: getActions(signals).filter(a => a.type === ActionType.ChatResponsePart),
+			turnComplete: getActions(signals).filter(a => a.type === ActionType.ChatTurnComplete),
+		}, {
+			commandListCalls: [{ includeBuiltins: true, includeSkills: false, includeClientCommands: false }],
+			commandInvokeCalls: [],
+			sendRequests: [{ prompt: '/env', attachments: undefined }],
+			responseParts: [],
+			turnComplete: [],
+		});
+	});
+
+	test('`/review` invokes the runtime command and forwards the returned agent prompt', async () => {
+		const { session, mockSession, signals } = await createAgentSession(disposables);
+		mockSession.commandListResult = {
+			commands: [{
+				name: 'review',
+				kind: 'builtin',
+				description: 'Run code review agent to analyze changes',
+				allowDuringAgentExecution: false,
+			}],
+		};
+		mockSession.commandInvokeResult = {
+			kind: 'agent-prompt',
+			prompt: 'Use the code-review agent. Additional instructions: focus on tests',
+			displayPrompt: 'Review: focus on tests',
+		};
+
+		await session.send('/review focus on tests', undefined, 'turn-review');
+
+		assert.deepStrictEqual({
+			commandListCalls: mockSession.commandListCalls,
+			commandInvokeCalls: mockSession.commandInvokeCalls,
+			sendRequests: mockSession.sendRequests,
+			responseParts: getActions(signals).filter(a => a.type === ActionType.ChatResponsePart),
+			turnComplete: getActions(signals).filter(a => a.type === ActionType.ChatTurnComplete),
+		}, {
+			commandListCalls: [{ includeBuiltins: true, includeSkills: false, includeClientCommands: false }],
+			commandInvokeCalls: [{ name: 'review', input: 'focus on tests' }],
+			sendRequests: [{ prompt: 'Use the code-review agent. Additional instructions: focus on tests', attachments: undefined }],
+			responseParts: [],
+			turnComplete: [],
+		});
+	});
+
+	test('`/security-review` invokes the runtime command and forwards the returned agent prompt', async () => {
+		const { session, mockSession, signals } = await createAgentSession(disposables);
+		mockSession.commandListResult = {
+			commands: [{
+				name: 'security-review',
+				kind: 'builtin',
+				description: 'Analyze staged and unstaged changes for security vulnerabilities.',
+				allowDuringAgentExecution: false,
+			}],
+		};
+		mockSession.commandInvokeResult = {
+			kind: 'agent-prompt',
+			prompt: 'Use the security-review agent.',
+			displayPrompt: 'Security Review: analyzing for vulnerabilities',
+		};
+
+		await session.send('/security-review', undefined, 'turn-security-review');
+
+		assert.deepStrictEqual({
+			commandListCalls: mockSession.commandListCalls,
+			commandInvokeCalls: mockSession.commandInvokeCalls,
+			sendRequests: mockSession.sendRequests,
+			responseParts: getActions(signals).filter(a => a.type === ActionType.ChatResponsePart),
+			turnComplete: getActions(signals).filter(a => a.type === ActionType.ChatTurnComplete),
+		}, {
+			commandListCalls: [{ includeBuiltins: true, includeSkills: false, includeClientCommands: false }],
+			commandInvokeCalls: [{ name: 'security-review' }],
+			sendRequests: [{ prompt: 'Use the security-review agent.', attachments: undefined }],
+			responseParts: [],
+			turnComplete: [],
+		});
+	});
+
+	test('`/review` falls through to a normal SDK send when not listed', async () => {
+		const { session, mockSession } = await createAgentSession(disposables);
+		mockSession.commandListResult = { commands: [] };
+
+		await session.send('/review focus on tests', undefined, 'turn-review');
+
+		assert.deepStrictEqual({
+			commandListCalls: mockSession.commandListCalls,
+			commandInvokeCalls: mockSession.commandInvokeCalls,
+			sendRequests: mockSession.sendRequests,
+		}, {
+			commandListCalls: [{ includeBuiltins: true, includeSkills: false, includeClientCommands: false }],
+			commandInvokeCalls: [],
+			sendRequests: [{ prompt: '/review focus on tests', attachments: undefined }],
+		});
 	});
 
 	test('emits accumulated Copilot usage metadata', async () => {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -611,6 +611,27 @@ suite('CopilotAgentSession', () => {
 		});
 	});
 
+	test('`/env` escapes plain text runtime command output before emitting markdown', async () => {
+		const { session, mockSession, signals } = await createAgentSession(disposables);
+		mockSession.commandListResult = {
+			commands: [{
+				name: 'env',
+				kind: 'builtin',
+				description: 'Show loaded environment details',
+				allowDuringAgentExecution: true,
+			}],
+		};
+		mockSession.commandInvokeResult = { kind: 'text', text: '*plain*\n- item', markdown: false };
+
+		await session.send('/env', undefined, 'turn-env');
+
+		const responsePart = getActions(signals).find(a => a.type === ActionType.ChatResponsePart) as ChatResponsePartAction | undefined;
+		assert.strictEqual(responsePart?.part.kind, ResponsePartKind.Markdown);
+		if (responsePart?.part.kind === ResponsePartKind.Markdown) {
+			assert.strictEqual(responsePart.part.content, '\\*plain\\*\n\\- item');
+		}
+	});
+
 	test('`/env` falls through to a normal SDK send when not listed', async () => {
 		const { session, mockSession, signals } = await createAgentSession(disposables);
 		mockSession.commandListResult = { commands: [] };

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -632,6 +632,44 @@ suite('CopilotAgentSession', () => {
 		});
 	});
 
+	test('caches runtime slash command availability across checks', async () => {
+		const { session, mockSession } = await createAgentSession(disposables);
+		mockSession.commandListResult = {
+			commands: [
+				{
+					name: 'env',
+					kind: 'builtin',
+					description: 'Show loaded environment details',
+					allowDuringAgentExecution: true,
+				},
+				{
+					name: 'review',
+					kind: 'builtin',
+					description: 'Run code review agent to analyze changes',
+					allowDuringAgentExecution: false,
+				},
+				{
+					name: 'not-a-builtin',
+					kind: 'skill',
+					description: 'Skill command',
+					allowDuringAgentExecution: false,
+				},
+			],
+		};
+
+		assert.deepStrictEqual({
+			env: await session.hasRuntimeSlashCommand('env'),
+			review: await session.hasRuntimeSlashCommand('review'),
+			skill: await session.hasRuntimeSlashCommand('not-a-builtin'),
+			commandListCalls: mockSession.commandListCalls,
+		}, {
+			env: true,
+			review: true,
+			skill: false,
+			commandListCalls: [{ includeBuiltins: true, includeSkills: false, includeClientCommands: false }],
+		});
+	});
+
 	test('`/review` invokes the runtime command and forwards the returned agent prompt', async () => {
 		const { session, mockSession, signals } = await createAgentSession(disposables);
 		mockSession.commandListResult = {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -691,21 +691,8 @@ suite('CopilotAgentSession', () => {
 		});
 	});
 
-	test('`/review` invokes the runtime command and forwards the returned agent prompt', async () => {
+	test('`/review` forwards as a prompt-invoked command', async () => {
 		const { session, mockSession, signals } = await createAgentSession(disposables);
-		mockSession.commandListResult = {
-			commands: [{
-				name: 'review',
-				kind: 'builtin',
-				description: 'Run code review agent to analyze changes',
-				allowDuringAgentExecution: false,
-			}],
-		};
-		mockSession.commandInvokeResult = {
-			kind: 'agent-prompt',
-			prompt: 'Use the code-review agent. Additional instructions: focus on tests',
-			displayPrompt: 'Review: focus on tests',
-		};
 
 		await session.send('/review focus on tests', undefined, 'turn-review');
 
@@ -716,29 +703,16 @@ suite('CopilotAgentSession', () => {
 			responseParts: getActions(signals).filter(a => a.type === ActionType.ChatResponsePart),
 			turnComplete: getActions(signals).filter(a => a.type === ActionType.ChatTurnComplete),
 		}, {
-			commandListCalls: [{ includeBuiltins: true, includeSkills: false, includeClientCommands: false }],
-			commandInvokeCalls: [{ name: 'review', input: 'focus on tests' }],
-			sendRequests: [{ prompt: 'Use the code-review agent. Additional instructions: focus on tests', attachments: undefined }],
+			commandListCalls: [],
+			commandInvokeCalls: [],
+			sendRequests: [{ prompt: '/review focus on tests', attachments: undefined }],
 			responseParts: [],
 			turnComplete: [],
 		});
 	});
 
-	test('`/security-review` invokes the runtime command and forwards the returned agent prompt', async () => {
+	test('`/security-review` forwards as a prompt-invoked command', async () => {
 		const { session, mockSession, signals } = await createAgentSession(disposables);
-		mockSession.commandListResult = {
-			commands: [{
-				name: 'security-review',
-				kind: 'builtin',
-				description: 'Analyze staged and unstaged changes for security vulnerabilities.',
-				allowDuringAgentExecution: false,
-			}],
-		};
-		mockSession.commandInvokeResult = {
-			kind: 'agent-prompt',
-			prompt: 'Use the security-review agent.',
-			displayPrompt: 'Security Review: analyzing for vulnerabilities',
-		};
 
 		await session.send('/security-review', undefined, 'turn-security-review');
 
@@ -749,28 +723,11 @@ suite('CopilotAgentSession', () => {
 			responseParts: getActions(signals).filter(a => a.type === ActionType.ChatResponsePart),
 			turnComplete: getActions(signals).filter(a => a.type === ActionType.ChatTurnComplete),
 		}, {
-			commandListCalls: [{ includeBuiltins: true, includeSkills: false, includeClientCommands: false }],
-			commandInvokeCalls: [{ name: 'security-review' }],
-			sendRequests: [{ prompt: 'Use the security-review agent.', attachments: undefined }],
+			commandListCalls: [],
+			commandInvokeCalls: [],
+			sendRequests: [{ prompt: '/security-review', attachments: undefined }],
 			responseParts: [],
 			turnComplete: [],
-		});
-	});
-
-	test('`/review` falls through to a normal SDK send when not listed', async () => {
-		const { session, mockSession } = await createAgentSession(disposables);
-		mockSession.commandListResult = { commands: [] };
-
-		await session.send('/review focus on tests', undefined, 'turn-review');
-
-		assert.deepStrictEqual({
-			commandListCalls: mockSession.commandListCalls,
-			commandInvokeCalls: mockSession.commandInvokeCalls,
-			sendRequests: mockSession.sendRequests,
-		}, {
-			commandListCalls: [{ includeBuiltins: true, includeSkills: false, includeClientCommands: false }],
-			commandInvokeCalls: [],
-			sendRequests: [{ prompt: '/review focus on tests', attachments: undefined }],
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/copilotSlashCommandCompletionProvider.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSlashCommandCompletionProvider.test.ts
@@ -35,12 +35,48 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 			assert.deepStrictEqual(parseLeadingSlashCommand('/rubber-duck'), { command: 'rubber-duck', rest: '' });
 		});
 
+		test('matches lone /env', () => {
+			assert.deepStrictEqual(parseLeadingSlashCommand('/env'), { command: 'env', rest: '' });
+		});
+
+		test('matches lone /review', () => {
+			assert.deepStrictEqual(parseLeadingSlashCommand('/review'), { command: 'review', rest: '' });
+		});
+
+		test('matches lone /security-review', () => {
+			assert.deepStrictEqual(parseLeadingSlashCommand('/security-review'), { command: 'security-review', rest: '' });
+		});
+
 		test('captures trailing text after a space for /rubber-duck', () => {
 			assert.deepStrictEqual(parseLeadingSlashCommand('/rubber-duck review my approach'), { command: 'rubber-duck', rest: 'review my approach' });
 		});
 
+		test('captures trailing text after a space for /env', () => {
+			assert.deepStrictEqual(parseLeadingSlashCommand('/env ignored input'), { command: 'env', rest: 'ignored input' });
+		});
+
+		test('captures trailing text after a space for /review', () => {
+			assert.deepStrictEqual(parseLeadingSlashCommand('/review focus on tests'), { command: 'review', rest: 'focus on tests' });
+		});
+
+		test('captures trailing text after a space for /security-review', () => {
+			assert.deepStrictEqual(parseLeadingSlashCommand('/security-review focus on auth'), { command: 'security-review', rest: 'focus on auth' });
+		});
+
 		test('rejects /rubber-duck-extra (no separator)', () => {
 			assert.strictEqual(parseLeadingSlashCommand('/rubber-duck-extra'), undefined);
+		});
+
+		test('rejects /env-extra (no separator)', () => {
+			assert.strictEqual(parseLeadingSlashCommand('/env-extra'), undefined);
+		});
+
+		test('rejects /review-extra (no separator)', () => {
+			assert.strictEqual(parseLeadingSlashCommand('/review-extra'), undefined);
+		});
+
+		test('rejects /security-review-extra (no separator)', () => {
+			assert.strictEqual(parseLeadingSlashCommand('/security-review-extra'), undefined);
 		});
 
 		test('rejects /rubber alone (incomplete command)', () => {
@@ -73,7 +109,7 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 	});
 
 	suite('provideCompletionItems', () => {
-		const provider = new CopilotSlashCommandCompletionProvider('copilotcli', { hasHistory: () => true, isRubberDuckEnabled: () => true });
+		const provider = new CopilotSlashCommandCompletionProvider('copilotcli', { hasHistory: () => true, isRubberDuckEnabled: () => true, hasRuntimeSlashCommand: async () => true });
 		const session = 'copilotcli:/abc';
 
 		async function run(text: string, offset = text.length) {
@@ -92,7 +128,7 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 
 		test('returns all items for lone "/"', async () => {
 			const items = await run('/');
-			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/compact', '/research ', '/rubber-duck ']);
+			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/compact', '/research ', '/rubber-duck ', '/env', '/review ', '/security-review ']);
 		});
 
 		test('filters to /plan when "/p" typed', async () => {
@@ -105,9 +141,19 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 			assert.deepStrictEqual(items.map(i => i.insertText), ['/compact']);
 		});
 
+		test('filters to /env when "/e" typed and runtime command exists', async () => {
+			const items = await run('/e');
+			assert.deepStrictEqual(items.map(i => i.insertText), ['/env']);
+		});
+
 		test('filters to /research and /rubber-duck when "/r" typed', async () => {
 			const items = await run('/r');
-			assert.deepStrictEqual(items.map(i => i.insertText), ['/research ', '/rubber-duck ']);
+			assert.deepStrictEqual(items.map(i => i.insertText), ['/research ', '/rubber-duck ', '/review ']);
+		});
+
+		test('filters to /security-review when "/s" typed and runtime command exists', async () => {
+			const items = await run('/s');
+			assert.deepStrictEqual(items.map(i => i.insertText), ['/security-review ']);
 		});
 
 		test('returns nothing when /word does not match any command prefix', async () => {
@@ -164,23 +210,60 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 						description: 'Get an independent critique of the current approach',
 					},
 				},
+				{
+					type: MessageAttachmentKind.Simple,
+					meta: {
+						command: 'env',
+						description: 'Show loaded environment details',
+					},
+				},
+				{
+					type: MessageAttachmentKind.Simple,
+					meta: {
+						command: 'review',
+						description: 'Run code review agent to analyze changes',
+					},
+				},
+				{
+					type: MessageAttachmentKind.Simple,
+					meta: {
+						command: 'security-review',
+						description: 'Analyze staged and unstaged changes for security vulnerabilities',
+					},
+				},
 			]);
 		});
 
 		test('omits /compact when session has no history', async () => {
-			const gated = new CopilotSlashCommandCompletionProvider('copilotcli', { hasHistory: () => false, isRubberDuckEnabled: () => true });
+			const gated = new CopilotSlashCommandCompletionProvider('copilotcli', { hasHistory: () => false, isRubberDuckEnabled: () => true, hasRuntimeSlashCommand: async () => true });
 			const items = await gated.provideCompletionItems({
 				kind: CompletionItemKind.UserMessage, channel: session, text: '/', offset: 1,
 			}, CancellationToken.None);
-			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/research ', '/rubber-duck ']);
+			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/research ', '/rubber-duck ', '/env', '/review ', '/security-review ']);
 		});
 
 		test('omits /rubber-duck when not enabled', async () => {
-			const gated = new CopilotSlashCommandCompletionProvider('copilotcli', { hasHistory: () => true, isRubberDuckEnabled: () => false });
+			const gated = new CopilotSlashCommandCompletionProvider('copilotcli', { hasHistory: () => true, isRubberDuckEnabled: () => false, hasRuntimeSlashCommand: async () => true });
 			const items = await gated.provideCompletionItems({
 				kind: CompletionItemKind.UserMessage, channel: session, text: '/', offset: 1,
 			}, CancellationToken.None);
-			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/compact', '/research ']);
+			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/compact', '/research ', '/env', '/review ', '/security-review ']);
+		});
+
+		test('omits /env when runtime command is unavailable', async () => {
+			const gated = new CopilotSlashCommandCompletionProvider('copilotcli', { hasHistory: () => true, isRubberDuckEnabled: () => true, hasRuntimeSlashCommand: async (_id, command) => command !== 'env' });
+			const items = await gated.provideCompletionItems({
+				kind: CompletionItemKind.UserMessage, channel: session, text: '/', offset: 1,
+			}, CancellationToken.None);
+			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/compact', '/research ', '/rubber-duck ', '/review ', '/security-review ']);
+		});
+
+		test('omits /review and /security-review when runtime commands are unavailable', async () => {
+			const gated = new CopilotSlashCommandCompletionProvider('copilotcli', { hasHistory: () => true, isRubberDuckEnabled: () => true, hasRuntimeSlashCommand: async (_id, command) => command === 'env' });
+			const items = await gated.provideCompletionItems({
+				kind: CompletionItemKind.UserMessage, channel: session, text: '/', offset: 1,
+			}, CancellationToken.None);
+			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/compact', '/research ', '/rubber-duck ', '/env']);
 		});
 
 		test('passes raw session id (no scheme/slash) to hasHistory', async () => {
@@ -188,9 +271,23 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 			const gated = new CopilotSlashCommandCompletionProvider('copilotcli', {
 				hasHistory: (id: string) => { seen = id; return true; },
 				isRubberDuckEnabled: () => true,
+				hasRuntimeSlashCommand: async () => true,
 			});
 			await gated.provideCompletionItems({
 				kind: CompletionItemKind.UserMessage, channel: 'copilotcli:/abc', text: '/', offset: 1,
+			}, CancellationToken.None);
+			assert.strictEqual(seen, 'abc');
+		});
+
+		test('passes raw session id to runtime command availability', async () => {
+			let seen: string | undefined;
+			const gated = new CopilotSlashCommandCompletionProvider('copilotcli', {
+				hasHistory: () => true,
+				isRubberDuckEnabled: () => true,
+				hasRuntimeSlashCommand: async (id: string) => { seen = id; return true; },
+			});
+			await gated.provideCompletionItems({
+				kind: CompletionItemKind.UserMessage, channel: 'copilotcli:/abc', text: '/e', offset: 2,
 			}, CancellationToken.None);
 			assert.strictEqual(seen, 'abc');
 		});

--- a/src/vs/platform/agentHost/test/node/copilotSlashCommandCompletionProvider.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotSlashCommandCompletionProvider.test.ts
@@ -151,7 +151,7 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 			assert.deepStrictEqual(items.map(i => i.insertText), ['/research ', '/rubber-duck ', '/review ']);
 		});
 
-		test('filters to /security-review when "/s" typed and runtime command exists', async () => {
+		test('filters to /security-review when "/s" typed', async () => {
 			const items = await run('/s');
 			assert.deepStrictEqual(items.map(i => i.insertText), ['/security-review ']);
 		});
@@ -258,12 +258,12 @@ suite('CopilotSlashCommandCompletionProvider', () => {
 			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/compact', '/research ', '/rubber-duck ', '/review ', '/security-review ']);
 		});
 
-		test('omits /review and /security-review when runtime commands are unavailable', async () => {
+		test('keeps prompt-invoked commands when runtime commands are unavailable', async () => {
 			const gated = new CopilotSlashCommandCompletionProvider('copilotcli', { hasHistory: () => true, isRubberDuckEnabled: () => true, hasRuntimeSlashCommand: async (_id, command) => command === 'env' });
 			const items = await gated.provideCompletionItems({
 				kind: CompletionItemKind.UserMessage, channel: session, text: '/', offset: 1,
 			}, CancellationToken.None);
-			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/compact', '/research ', '/rubber-duck ', '/env']);
+			assert.deepStrictEqual(items.map(i => i.insertText), ['/plan ', '/compact', '/research ', '/rubber-duck ', '/env', '/review ', '/security-review ']);
 		});
 
 		test('passes raw session id (no scheme/slash) to hasHistory', async () => {


### PR DESCRIPTION
Adds list-gated support for Copilot runtime slash commands in Agent Host.

- Shows `/env`, `/review`, and `/security-review` completions only when the runtime reports those built-in commands from `session.rpc.commands.list()`
- Invokes available runtime commands through `session.rpc.commands.invoke()`
- Renders text results such as `/env` as markdown and forwards agent-prompt results such as `/review` and `/security-review` through the normal SDK send path
- Falls back to normal prompt handling when a runtime command is not listed

Validation:
- `npm run compile-check-ts-native`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/copilotSlashCommandCompletionProvider.test.ts --run src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts`
- `node --experimental-strip-types build/hygiene.ts src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts src/vs/platform/agentHost/node/copilot/copilotAgent.ts src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts src/vs/platform/agentHost/test/node/copilotSlashCommandCompletionProvider.test.ts src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts`