### PR TITLE
sessions: show provider names as section headers in session type picker

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker.ts
@@ -12,7 +12,7 @@ import { IChatSessionsService } from '../../../../../workbench/contrib/chat/comm
 import { ILanguageModelsService } from '../../../../../workbench/contrib/chat/common/languageModels.js';
 import { getSessionTypeAvailability, getSessionTypeUnavailableLabel, SessionTypeAvailability } from '../../../../../workbench/contrib/chat/browser/agentSessions/sessionTypeAvailability.js';
 import { IChatEntitlementService } from '../../../../../workbench/services/chat/common/chatEntitlementService.js';
-import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { IProviderSessionType, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISession } from '../../../../services/sessions/common/session.js';
 import { IObservable } from '../../../../../base/common/observable.js';
@@ -72,34 +72,38 @@ export class MobileSessionTypePicker extends SessionTypePicker {
 		}
 
 		// Build sheet items — composite id is `providerId\u0000sessionTypeId`
-		// so we can map back to the right provider on selection. Show the
-		// provider's label as a section title only for provider groups
-		// that contain at least one duplicated session type label.
-		const labelCounts = new Map<string, number>();
-		for (const { sessionType } of this._folderSessionTypes) {
-			labelCounts.set(sessionType.label, (labelCounts.get(sessionType.label) ?? 0) + 1);
-		}
-		const providersWithDuplicates = new Set<string>();
-		for (const { providerId, sessionType } of this._folderSessionTypes) {
-			if ((labelCounts.get(sessionType.label) ?? 0) > 1) {
-				providersWithDuplicates.add(providerId);
+		// so we can map back to the right provider on selection. Group session
+		// types by their provider's display label (preserving first-seen order)
+		// so each section title is shown once even when providers are
+		// interleaved or share a label. Show titles only when more than one
+		// group exists.
+		const groups = new Map<string, IProviderSessionType[]>();
+		for (const folderType of this._folderSessionTypes) {
+			const groupTitle = this._sessionsProvidersService.getProvider(folderType.providerId)?.label ?? folderType.providerId;
+			const existing = groups.get(groupTitle);
+			if (existing) {
+				existing.push(folderType);
+			} else {
+				groups.set(groupTitle, [folderType]);
 			}
 		}
+		const showSectionHeaders = groups.size > 1;
 		const sheetItems: IMobilePickerSheetItem[] = [];
-		let lastProviderId: string | undefined;
-		for (const { providerId, sessionType } of this._folderSessionTypes) {
-			const isFirstInGroup = providerId !== lastProviderId;
-			lastProviderId = providerId;
-			const availability = getSessionTypeAvailability(this.chatSessionsService, this.chatEntitlementService, this.languageModelsService, sessionType.chatSessionType ?? sessionType.id);
-			sheetItems.push({
-				id: `${providerId}\u0000${sessionType.id}`,
-				label: sessionType.label,
-				icon: sessionType.icon,
-				checked: providerId === this._picked?.providerId && sessionType.id === this._picked?.sessionTypeId,
-				disabled: availability !== SessionTypeAvailability.Available,
-				description: getSessionTypeUnavailableLabel(availability),
-				sectionTitle: providersWithDuplicates.has(providerId) && isFirstInGroup ? (this._sessionsProvidersService.getProvider(providerId)?.label ?? providerId) : undefined,
-			});
+		for (const [groupTitle, types] of groups) {
+			let isFirstInGroup = true;
+			for (const { providerId, sessionType } of types) {
+				const availability = getSessionTypeAvailability(this.chatSessionsService, this.chatEntitlementService, this.languageModelsService, sessionType.chatSessionType ?? sessionType.id);
+				sheetItems.push({
+					id: `${providerId}\u0000${sessionType.id}`,
+					label: sessionType.label,
+					icon: sessionType.icon,
+					checked: providerId === this._picked?.providerId && sessionType.id === this._picked?.sessionTypeId,
+					disabled: availability !== SessionTypeAvailability.Available,
+					description: getSessionTypeUnavailableLabel(availability),
+					sectionTitle: showSectionHeaders && isFirstInGroup ? groupTitle : undefined,
+				});
+				isFirstInGroup = false;
+			}
 		}
 
 		const trigger = this._triggerElement;

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -219,51 +219,57 @@ export class SessionTypePicker extends Disposable {
 			return;
 		}
 
-		// Determine which providers contain at least one duplicated label.
-		// Only those providers need a group title for disambiguation.
-		const labelCounts = new Map<string, number>();
-		for (const { sessionType } of folderTypes) {
-			labelCounts.set(sessionType.label, (labelCounts.get(sessionType.label) ?? 0) + 1);
-		}
-		const providersWithDuplicates = new Set<string>();
-		for (const { providerId, sessionType } of folderTypes) {
-			if ((labelCounts.get(sessionType.label) ?? 0) > 1) {
-				providersWithDuplicates.add(providerId);
+		// Group session types by their provider's display label, preserving
+		// first-seen order. Providers can be interleaved in the folder list and
+		// distinct providers can share a label, so collecting by label avoids
+		// rendering the same section header more than once.
+		const groups = new Map<string, IProviderSessionType[]>();
+		for (const folderType of folderTypes) {
+			const provider = this.sessionsProvidersService.getProvider(folderType.providerId);
+			const groupTitle = provider?.label ?? folderType.providerId;
+			const existing = groups.get(groupTitle);
+			if (existing) {
+				existing.push(folderType);
+			} else {
+				groups.set(groupTitle, [folderType]);
 			}
 		}
-		const hasDuplicateLabels = providersWithDuplicates.size > 0;
+		const showSectionHeaders = groups.size > 1;
 
-		const providersService = this.sessionsProvidersService;
 		const groupedItems: IActionListItem<ISessionTypePickerItem>[] = [];
-		let lastProviderId: string | undefined;
-		for (const { providerId, sessionType } of folderTypes) {
-			const provider = providersService.getProvider(providerId);
-			const groupTitle = provider?.label ?? providerId;
-			const isFirstInGroup = providerId !== lastProviderId;
-			lastProviderId = providerId;
-			const isCurrent = this._picked?.providerId === providerId && this._picked?.sessionTypeId === sessionType.id;
-			const availability = getSessionTypeAvailability(this.chatSessionsService, this.chatEntitlementService, this.languageModelsService, sessionType.chatSessionType ?? sessionType.id);
-			const unavailable = availability !== SessionTypeAvailability.Available;
-			const item: ISessionTypePickerItem = isCurrent
-				? { providerId, sessionTypeId: sessionType.id, label: sessionType.label, checked: true }
-				: { providerId, sessionTypeId: sessionType.id, label: sessionType.label };
-			groupedItems.push({
-				kind: ActionListItemKind.Action,
-				label: sessionType.label,
-				disabled: unavailable,
-				...(unavailable ? {
-					description: getSessionTypeUnavailableDescription(availability),
-					hover: { content: getSessionTypeUnavailableHover(availability) },
-				} : {}),
-				group: providersWithDuplicates.has(providerId) ? {
-					title: isFirstInGroup ? groupTitle : '',
-					icon: sessionType.icon,
-				} : {
-					title: '',
-					icon: sessionType.icon,
-				},
-				item,
-			});
+		for (const [groupTitle, types] of groups) {
+			if (showSectionHeaders) {
+				if (groupedItems.length > 0) {
+					groupedItems.push({ kind: ActionListItemKind.Separator, label: '' });
+				}
+				groupedItems.push({
+					kind: ActionListItemKind.Header,
+					group: { title: groupTitle },
+					label: groupTitle,
+				});
+			}
+			for (const { providerId, sessionType } of types) {
+				const isCurrent = this._picked?.providerId === providerId && this._picked?.sessionTypeId === sessionType.id;
+				const availability = getSessionTypeAvailability(this.chatSessionsService, this.chatEntitlementService, this.languageModelsService, sessionType.chatSessionType ?? sessionType.id);
+				const unavailable = availability !== SessionTypeAvailability.Available;
+				const item: ISessionTypePickerItem = isCurrent
+					? { providerId, sessionTypeId: sessionType.id, label: sessionType.label, checked: true }
+					: { providerId, sessionTypeId: sessionType.id, label: sessionType.label };
+				groupedItems.push({
+					kind: ActionListItemKind.Action,
+					label: sessionType.label,
+					disabled: unavailable,
+					...(unavailable ? {
+						description: getSessionTypeUnavailableDescription(availability),
+						hover: { content: getSessionTypeUnavailableHover(availability) },
+					} : {}),
+					group: {
+						title: '',
+						icon: sessionType.icon,
+					},
+					item,
+				});
+			}
 		}
 
 		const triggerElement = this._triggerElement;
@@ -287,7 +293,6 @@ export class SessionTypePicker extends Disposable {
 				getAriaLabel: (item) => item.label ?? '',
 				getWidgetAriaLabel: () => localize('sessionTypePicker.ariaLabel', "Session Type"),
 			},
-			{ showGroupTitleOnFirstItem: hasDuplicateLabels },
 		);
 	}
 

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -293,6 +293,7 @@ export class SessionTypePicker extends Disposable {
 				getAriaLabel: (item) => item.label ?? '',
 				getWidgetAriaLabel: () => localize('sessionTypePicker.ariaLabel', "Session Type"),
 			},
+			{ minWidth: 220 },
 		);
 	}
 

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -65,6 +65,13 @@ interface ISessionTypePickerItem {
 	readonly sessionTypeId: string;
 	readonly label: string;
 	readonly checked?: boolean;
+	/**
+	 * Provider display label, set when the picker shows section headers so the
+	 * accessibility label can disambiguate same-named types (e.g. "Claude")
+	 * across providers — headers are skipped by list navigation and aren't
+	 * announced on their own.
+	 */
+	readonly groupLabel?: string;
 }
 
 export class SessionTypePicker extends Disposable {
@@ -252,9 +259,13 @@ export class SessionTypePicker extends Disposable {
 				const isCurrent = this._picked?.providerId === providerId && this._picked?.sessionTypeId === sessionType.id;
 				const availability = getSessionTypeAvailability(this.chatSessionsService, this.chatEntitlementService, this.languageModelsService, sessionType.chatSessionType ?? sessionType.id);
 				const unavailable = availability !== SessionTypeAvailability.Available;
-				const item: ISessionTypePickerItem = isCurrent
-					? { providerId, sessionTypeId: sessionType.id, label: sessionType.label, checked: true }
-					: { providerId, sessionTypeId: sessionType.id, label: sessionType.label };
+				const item: ISessionTypePickerItem = {
+					providerId,
+					sessionTypeId: sessionType.id,
+					label: sessionType.label,
+					...(isCurrent ? { checked: true } : {}),
+					...(showSectionHeaders ? { groupLabel: groupTitle } : {}),
+				};
 				groupedItems.push({
 					kind: ActionListItemKind.Action,
 					label: sessionType.label,
@@ -290,7 +301,7 @@ export class SessionTypePicker extends Disposable {
 			undefined,
 			[],
 			{
-				getAriaLabel: (item) => item.label ?? '',
+				getAriaLabel: (element) => element.item?.groupLabel ? localize('sessionTypePicker.itemAriaLabel', "{0}, {1}", element.label ?? '', element.item.groupLabel) : (element.label ?? ''),
 				getWidgetAriaLabel: () => localize('sessionTypePicker.ariaLabel', "Session Type"),
 			},
 			{ minWidth: 200 },

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -293,7 +293,7 @@ export class SessionTypePicker extends Disposable {
 				getAriaLabel: (item) => item.label ?? '',
 				getWidgetAriaLabel: () => localize('sessionTypePicker.ariaLabel', "Session Type"),
 			},
-			{ minWidth: 220 },
+			{ minWidth: 200 },
 		);
 	}
 

--- a/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
@@ -395,7 +395,7 @@ class LocalSession extends Disposable {
 export class LocalChatSessionsProvider extends Disposable implements ISessionsProvider {
 
 	readonly id = LOCAL_PROVIDER_ID;
-	readonly label = localize('localChatSessionsProvider', "Local Chat");
+	readonly label = localize('localChatSessionsProvider', "Copilot Chat");
 	readonly icon = Codicon.vm;
 	readonly order = 0;
 	readonly browseActions: readonly [] = [];

--- a/test/automation/src/agentsWindow.ts
+++ b/test/automation/src/agentsWindow.ts
@@ -121,11 +121,26 @@ export class AgentsWindow {
 		}
 
 		const items = await this.code.waitForElements(itemSel, /* recursive */ true);
-		const matchIndex = items.findIndex(el => (el.textContent ?? '').trim().toLowerCase().includes(needle));
+		const isActionRow = (el: { className: string }) => el.className.includes('action');
+		const rowText = (el: { textContent: string }) => (el.textContent ?? '').trim().toLowerCase();
+
+		// Prefer an actionable row whose label matches directly (e.g. a
+		// session type label like "Claude" or "Copilot CLI").
+		let matchIndex = items.findIndex(el => isActionRow(el) && rowText(el).includes(needle));
+		// Otherwise treat the label as a provider section header (e.g. "Local
+		// Agent Host"): headers are non-clickable rows rendered above their
+		// session types, so select the first actionable row beneath the header.
+		if (matchIndex < 0) {
+			const headerIndex = items.findIndex(el => !isActionRow(el) && rowText(el).includes(needle));
+			if (headerIndex >= 0) {
+				matchIndex = items.findIndex((el, index) => index > headerIndex && isActionRow(el));
+			}
+		}
 		if (matchIndex < 0) {
 			throw new Error(`Session type "${label}" not found in picker. Available: ${items.map(i => (i.textContent ?? '').trim()).join(', ')}`);
 		}
-		await this.code.waitAndClick(`.action-widget .monaco-list-row[data-index="${matchIndex}"]`);
+		const dataIndex = items[matchIndex].attributes['data-index'] ?? String(matchIndex);
+		await this.code.waitAndClick(`.action-widget .monaco-list-row[data-index="${dataIndex}"]`);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #321535

### What

The session type picker (harness picker) showed provider names like **Copilot Chat** and **Local Agent Host** as inline descriptors to the right of the first row in each group. They read like a label on that adjacent row, making it look like there were duplicate/broken entries (e.g. two "Claude" rows).

This change renders the provider name as a proper **section header above** each group, with a divider between sections, when more than one provider contributes session types.

### Details

- Session types are grouped by their provider's display label, preserving first-seen order, so each header is shown **once** even when providers are interleaved in the folder list or share a label (dedup).
- The same grouping/header treatment is applied to the mobile bottom-sheet variant (`MobileSessionTypePicker`).
- Renames the local provider label from "Local Chat" to "Copilot Chat".

### Notes for reviewers

- Headers/dividers only render when there is more than one group; single-provider pickers are unchanged.
- Validated with `compile-check-ts-native`, `valid-layers-check`, ESLint, and the `SessionTypePicker` unit tests.
