### PR TITLE
Fix Agents window aux bar showing Files instead of Changes

### DIFF
--- a/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
@@ -356,29 +356,45 @@ export class LayoutController extends Disposable {
 			return;
 		}
 
-		if (isUntitled) {
-			this._viewsService.openViewContainer(SESSIONS_FILES_CONTAINER_ID, false);
+		// On session switch or initial load, restore the saved view state.
+		// Untitled sessions never carry meaningful saved state.
+		const savedState = isUntitled ? undefined : this._viewStateBySession.get(sessionResource);
+
+		// Honor an explicitly hidden auxiliary bar for this session.
+		if (savedState && !savedState.auxiliaryBarVisible) {
+			this._layoutService.setPartHidden(true, Parts.AUXILIARYBAR_PART);
 			return;
 		}
 
-		// On session switch or initial load, restore the saved view state
-		const savedState = this._viewStateBySession.get(sessionResource);
-		if (savedState) {
-			if (!savedState.auxiliaryBarVisible) {
-				this._layoutService.setPartHidden(true, Parts.AUXILIARYBAR_PART);
-				return;
-			}
-			if (savedState.auxiliaryBarActiveViewContainerId) {
-				this._viewsService.openViewContainer(savedState.auxiliaryBarActiveViewContainerId, false);
-				return;
-			}
+		// Restore a saved non-Files active container (e.g. the user explicitly
+		// chose Changes or another pane), but only if it is still pinned/visible.
+		// A saved Files selection is intentionally not restored here: Files is the
+		// default when a session has no changes, so restoring it unconditionally
+		// would shadow the "prefer Changes when there are changes" rule below.
+		const savedContainerId = savedState?.auxiliaryBarActiveViewContainerId;
+		if (
+			savedContainerId &&
+			savedContainerId !== SESSIONS_FILES_CONTAINER_ID &&
+			this._isAuxiliaryBarContainerPinned(savedContainerId)
+		) {
+			this._viewsService.openViewContainer(savedContainerId, false);
+			return;
 		}
 
-		if (hasChanges) {
+		// Default: prefer Changes when the session has changes. Otherwise show the
+		// Files pane, unless the user has hidden/unpinned it — in which case fall
+		// back to Changes rather than force-opening Files.
+		if (hasChanges || !this._isAuxiliaryBarContainerPinned(SESSIONS_FILES_CONTAINER_ID)) {
 			this._viewsService.openView(CHANGES_VIEW_ID, false);
 		} else {
 			this._viewsService.openViewContainer(SESSIONS_FILES_CONTAINER_ID, false);
 		}
+	}
+
+	private _isAuxiliaryBarContainerPinned(containerId: string): boolean {
+		return this._paneCompositePartService
+			.getPinnedPaneCompositeIds(ViewContainerLocation.AuxiliaryBar)
+			.includes(containerId);
 	}
 
 	private _loadState(): void {

--- a/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
@@ -366,24 +366,20 @@ export class LayoutController extends Disposable {
 			return;
 		}
 
-		// Restore a saved non-Files active container (e.g. the user explicitly
-		// chose Changes or another pane), but only if it is still pinned.
-		// A saved Files selection is intentionally not restored here: Files is the
-		// default when a session has no changes, so restoring it unconditionally
-		// would shadow the "prefer Changes when there are changes" rule below.
+		// Restore the user's last explicit auxiliary bar choice (Files, Changes or
+		// any other pane), but only if that pane is still pinned. If it was hidden /
+		// unpinned (e.g. the user hid the Files tab) we skip it and fall through to
+		// the default below rather than force-opening a hidden pane.
 		const savedContainerId = savedState?.auxiliaryBarActiveViewContainerId;
-		if (
-			savedContainerId &&
-			savedContainerId !== SESSIONS_FILES_CONTAINER_ID &&
-			this._isAuxiliaryBarContainerPinned(savedContainerId)
-		) {
+		if (savedContainerId && this._isAuxiliaryBarContainerPinned(savedContainerId)) {
 			this._viewsService.openViewContainer(savedContainerId, false);
 			return;
 		}
 
-		// Default: prefer Changes when the session has changes. Otherwise show the
-		// Files pane, unless the user has hidden/unpinned it — in which case fall
-		// back to Changes rather than force-opening Files.
+		// Default for a session without a saved choice (e.g. fresh or untitled):
+		// prefer Changes when the session has changes. Otherwise show the Files
+		// pane, unless the user has hidden/unpinned it — in which case fall back to
+		// Changes rather than force-opening Files.
 		if (hasChanges || !this._isAuxiliaryBarContainerPinned(SESSIONS_FILES_CONTAINER_ID)) {
 			this._viewsService.openView(CHANGES_VIEW_ID, false);
 		} else {

--- a/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
@@ -367,7 +367,7 @@ export class LayoutController extends Disposable {
 		}
 
 		// Restore a saved non-Files active container (e.g. the user explicitly
-		// chose Changes or another pane), but only if it is still pinned/visible.
+		// chose Changes or another pane), but only if it is still pinned.
 		// A saved Files selection is intentionally not restored here: Files is the
 		// default when a session has no changes, so restoring it unconditionally
 		// would shadow the "prefer Changes when there are changes" rule below.

--- a/src/vs/sessions/contrib/layout/test/browser/sessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/sessionLayoutController.test.ts
@@ -28,7 +28,7 @@ import { IActiveSession, ISessionsChangeEvent, ISessionsManagementService } from
 import { ISessionsViewService } from '../../../../services/sessions/browser/sessionsViewService.js';
 import { IChat, ISessionFileChange, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { LayoutController } from '../../browser/sessionLayoutController.js';
-import { CHANGES_VIEW_ID } from '../../../changes/common/changes.js';
+import { CHANGES_VIEW_CONTAINER_ID, CHANGES_VIEW_ID } from '../../../changes/common/changes.js';
 import { SESSIONS_FILES_CONTAINER_ID } from '../../../files/browser/files.contribution.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { TestStorageService } from '../../../../../workbench/test/common/workbenchTestServices.js';
@@ -113,6 +113,7 @@ suite('LayoutController', () => {
 	let openedViews: string[];
 	let setPartHiddenCalls: { hidden: boolean; part: Parts }[];
 	let activePaneCompositeId: string | undefined;
+	let pinnedAuxiliaryBarContainerIds: string[];
 
 	interface ICreateOptions {
 		readonly useModal?: 'off' | 'some' | 'all';
@@ -190,12 +191,20 @@ suite('LayoutController', () => {
 		});
 
 		activePaneCompositeId = undefined;
+		pinnedAuxiliaryBarContainerIds = [SESSIONS_FILES_CONTAINER_ID, CHANGES_VIEW_CONTAINER_ID];
 		instaService.stub(IPaneCompositePartService, new class extends mock<IPaneCompositePartService>() {
 			override getActivePaneComposite(_location: ViewContainerLocation): IPaneComposite | undefined {
 				if (activePaneCompositeId) {
 					return { getId: () => activePaneCompositeId! } as IPaneComposite;
 				}
 				return undefined;
+			}
+			override getPinnedPaneCompositeIds(_location: ViewContainerLocation): string[] {
+				const ids = [...pinnedAuxiliaryBarContainerIds];
+				if (activePaneCompositeId && !ids.includes(activePaneCompositeId)) {
+					ids.push(activePaneCompositeId);
+				}
+				return ids;
 			}
 		});
 
@@ -294,6 +303,61 @@ suite('LayoutController', () => {
 		assert.ok(
 			openedViewContainers.includes('some.custom.view'),
 			'should restore active view container when returning to session 1'
+		);
+	});
+
+	test('prefers changes over a stale saved Files selection when the session has changes', () => {
+		createLayoutController();
+		const session1 = makeSession(URI.parse('session:1'), { changes: [makeChange('/file.ts')] });
+		const session2 = makeSession(URI.parse('session:2'));
+
+		// Session 1 has the Files container active (the default for a session
+		// before changes appear / or an explicit user choice).
+		activeSessionObs.set(session1, undefined);
+		activePaneCompositeId = SESSIONS_FILES_CONTAINER_ID;
+
+		activeSessionObs.set(session2, undefined);
+
+		openedViewContainers = [];
+		openedViews = [];
+		activeSessionObs.set(session1, undefined);
+
+		assert.ok(
+			openedViews.includes(CHANGES_VIEW_ID),
+			'should show Changes since the session has changes, ignoring the stale Files selection'
+		);
+		assert.ok(
+			!openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID),
+			'should not restore the stale Files selection'
+		);
+	});
+
+	test('shows changes for untitled session with changes', () => {
+		createLayoutController();
+		const session = makeSession(URI.parse('session:1'), {
+			status: SessionStatus.Untitled,
+			changes: [makeChange('/file.ts')],
+		});
+		activeSessionObs.set(session, undefined);
+
+		assert.ok(openedViews.includes(CHANGES_VIEW_ID));
+	});
+
+	test('does not force-open Files when the Files pane is hidden', () => {
+		createLayoutController();
+		// User has hidden / unpinned the Files pane.
+		pinnedAuxiliaryBarContainerIds = [CHANGES_VIEW_CONTAINER_ID];
+		const session = makeSession(URI.parse('session:1'));
+
+		activeSessionObs.set(session, undefined);
+
+		assert.ok(
+			!openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID),
+			'should not open the hidden Files pane'
+		);
+		assert.ok(
+			openedViews.includes(CHANGES_VIEW_ID),
+			'should fall back to Changes when Files is hidden'
 		);
 	});
 

--- a/src/vs/sessions/contrib/layout/test/browser/sessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/sessionLayoutController.test.ts
@@ -200,11 +200,10 @@ suite('LayoutController', () => {
 				return undefined;
 			}
 			override getPinnedPaneCompositeIds(_location: ViewContainerLocation): string[] {
-				const ids = [...pinnedAuxiliaryBarContainerIds];
-				if (activePaneCompositeId && !ids.includes(activePaneCompositeId)) {
-					ids.push(activePaneCompositeId);
-				}
-				return ids;
+				// Mirrors production: pinned ids only. The active composite is not
+				// necessarily pinned (that distinction lives in getVisiblePaneCompositeIds),
+				// so tests must add a container to pinnedAuxiliaryBarContainerIds to model it as pinned.
+				return [...pinnedAuxiliaryBarContainerIds];
 			}
 		});
 
@@ -293,7 +292,9 @@ suite('LayoutController', () => {
 		const session2 = makeSession(URI.parse('session:2'));
 
 		activeSessionObs.set(session1, undefined);
+		// The active container must also be pinned for it to be restored.
 		activePaneCompositeId = 'some.custom.view';
+		pinnedAuxiliaryBarContainerIds = [...pinnedAuxiliaryBarContainerIds, 'some.custom.view'];
 
 		activeSessionObs.set(session2, undefined);
 

--- a/src/vs/sessions/contrib/layout/test/browser/sessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/sessionLayoutController.test.ts
@@ -307,13 +307,12 @@ suite('LayoutController', () => {
 		);
 	});
 
-	test('prefers changes over a stale saved Files selection when the session has changes', () => {
+	test('restores an explicit Files choice on session switch even when the session has changes', () => {
 		createLayoutController();
 		const session1 = makeSession(URI.parse('session:1'), { changes: [makeChange('/file.ts')] });
 		const session2 = makeSession(URI.parse('session:2'));
 
-		// Session 1 has the Files container active (the default for a session
-		// before changes appear / or an explicit user choice).
+		// The user explicitly selects the (pinned) Files pane for session 1.
 		activeSessionObs.set(session1, undefined);
 		activePaneCompositeId = SESSIONS_FILES_CONTAINER_ID;
 
@@ -324,12 +323,12 @@ suite('LayoutController', () => {
 		activeSessionObs.set(session1, undefined);
 
 		assert.ok(
-			openedViews.includes(CHANGES_VIEW_ID),
-			'should show Changes since the session has changes, ignoring the stale Files selection'
+			openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID),
+			'should restore the user\'s explicit Files choice'
 		);
 		assert.ok(
-			!openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID),
-			'should not restore the stale Files selection'
+			!openedViews.includes(CHANGES_VIEW_ID),
+			'should not override the explicit Files choice with Changes'
 		);
 	});
 


### PR DESCRIPTION
Fixes #321610

## Problem

In the Agents window, opening the right (auxiliary) sidebar sometimes showed **Files** instead of **Changes** in cases where the user never chose Files:

- an **untitled** session with changes always opened Files (ignored `hasChanges`);
- a **hidden/unpinned** Files pane got force-reopened, because `openViewContainer(...)` bypasses the pinned/hidden composite state and the Files container is registered with `hideIfEmpty: false`.

Persisting the user's *explicit* auxiliary-bar choice (e.g. clicking the Files tab) across session switches and restarts is intended and is preserved.

## Fix

`LayoutController._syncAuxiliaryBarVisibility()` now:

1. honors an explicitly hidden auxiliary bar for the session;
2. restores the saved active container (the user's last explicit choice — Files, Changes or any pane) **only if that pane is still pinned**; a hidden/unpinned pane is skipped instead of force-opened;
3. for a session without a saved choice (fresh or untitled), defaults to **Changes** when the session has changes, otherwise the **Files** pane — but only when Files is still pinned, else falls back to Changes.

This fixes the untitled-with-changes and hidden-Files-pane cases while keeping the user's explicit pane choice sticky.

A small `_isAuxiliaryBarContainerPinned()` helper checks `IPaneCompositePartService.getPinnedPaneCompositeIds(AuxiliaryBar)`.

## Tests

`sessionLayoutController.test.ts`:

- restores an explicit Files choice on session switch even when the session has changes;
- shows Changes for an untitled session with changes;
- does not force-open Files when the Files pane is hidden (falls back to Changes).

All 18 `LayoutController` tests pass; `compile-check-ts-native` is clean.
