### PR TITLE
Fix agent host client tool defaults

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -1173,11 +1173,12 @@ configurationRegistry.registerConfiguration({
 			items: { type: 'string' },
 			description: nls.localize('chat.agentHost.clientTools', "Tool reference names to expose as client-provided tools in agent host sessions."),
 			default: [
-				'runTask', 'getTaskOutput', 'problems', 'runTests', 'addComment', 'listComments', 'deleteComments', 'resolveComments',
+				'runTask', 'getTaskOutput', 'problems', 'runTests',
 				// These are always present in the {@link ChatConfiguration.AgentHostClientTools} default but
 				// out of these, only the tools that are actually registered/enabled are seen by the agent.
 				...browserChatToolReferenceNames,
 			],
+			agentsWindow: { default: ['runTask', 'getTaskOutput', ...browserChatToolReferenceNames] },
 			tags: ['experimental', 'advanced'],
 		},
 		[ChatConfiguration.ToolConfirmationCarousel]: {


### PR DESCRIPTION
This updates the agent host client tool defaults so tools that now run server-side in the agent host are no longer exposed as client-provided tools.

Summary:
- Remove feedback/comment tools from the default `chat.agentHost.clientTools` allowlist.
- Add an Agents Window-specific default that excludes `problems` and `runTests`, which are not available there.
- Keep task and browser client tools available where applicable.

Validation:
- `npm run compile-check-ts-native`