### PR TITLE
telemetry: send X-VSCode-WindowKind exp filter from Copilot Chat

### DIFF
--- a/extensions/copilot/src/platform/telemetry/vscode-node/microsoftExperimentationService.ts
+++ b/extensions/copilot/src/platform/telemetry/vscode-node/microsoftExperimentationService.ts
@@ -198,6 +198,23 @@ class PlatformAndReleaseDateFilterProvider implements IExperimentationFilterProv
 	}
 }
 
+class WindowKindFilterProvider implements IExperimentationFilterProvider {
+	constructor(
+		private _logService: ILogService
+	) { }
+
+	getFilters(): Map<string, string> {
+		const filters = new Map<string, string>();
+
+		// Mirrors the core `X-VSCode-WindowKind` filter (`editor` or `agents`).
+		const windowKind = vscode.workspace.isAgentSessionsWorkspace ? 'agents' : 'editor';
+		filters.set('X-VSCode-WindowKind', windowKind);
+
+		this._logService.trace(`[WindowKindFilterProvider]::getFilters Filters: ${JSON.stringify(Array.from(filters.entries()))}`);
+		return filters;
+	}
+}
+
 export class MicrosoftExperimentationService extends BaseExperimentationService {
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -228,6 +245,7 @@ export class MicrosoftExperimentationService extends BaseExperimentationService 
 				new CopilotCompletionsFilterProvider(() => self?.getCompletionsFilters() ?? new Map(), logService),
 				new DevDeviceIdFilterProvider(vscode.env.devDeviceId),
 				new PlatformAndReleaseDateFilterProvider(logService),
+				new WindowKindFilterProvider(logService),
 			);
 		};
 


### PR DESCRIPTION
Mirrors the core X-VSCode-WindowKind assignment filter (added in #321572) in the Copilot Chat experimentation setup, so experiments can target the editor vs. agents window from Copilot Chat as well.

## What changed
- Added a WindowKindFilterProvider to microsoftExperimentationService.ts that sends the X-VSCode-WindowKind ExP filter (ditor or gents).
- Registered the provider alongside the other filter providers.

## Notes for reviewers
- The window kind is derived from the scode.workspace.isAgentSessionsWorkspace proposed API (already enabled for this extension), matching the core mapping where the sessions/agents window reports gents and otherwise ditor.