### PR TITLE
sessions: keep PR icon visible for inactive sessions and limit PR polling

### DIFF
--- a/src/vs/sessions/contrib/github/browser/github.contribution.ts
+++ b/src/vs/sessions/contrib/github/browser/github.contribution.ts
@@ -3,8 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { structuralEquals } from '../../../../base/common/equals.js';
 import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
-import { autorun, derivedOpts } from '../../../../base/common/observable.js';
+import { autorun, derived, derivedOpts, IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
@@ -12,14 +13,35 @@ import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase 
 import { ISession } from '../../../services/sessions/common/session.js';
 import { ISessionsChangeEvent, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
-import { getPullRequestKey } from '../common/utils.js';
 import { GitHubService, IGitHubService } from './githubService.js';
+
+/**
+ * In addition to the sessions currently open in the grid, poll the pull request
+ * state of the N most recently updated sessions so their list icons stay fresh
+ * without polling every session's PR.
+ */
+const MAX_POLLED_RECENT_SESSIONS = 5;
 
 export class GitHubPullRequestPollingContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'sessions.contrib.githubPullRequestPolling';
 
-	private readonly _pullRequests = new DisposableMap<string>();
+	/**
+	 * Per-session tracking (keyed by {@link ISession.sessionId}) that fetches and
+	 * (when in the polling set) polls each session's pull request state for as
+	 * long as the session exists.
+	 */
+	private readonly _sessionTracking = new DisposableMap<string>();
+
+	/** Reactive mirror of all known sessions, used to pick the most recent ones. */
+	private readonly _allSessions: ISettableObservable<readonly ISession[]> = observableValue(this, []);
+
+	/**
+	 * Session ids whose pull request state should be polled continuously: the
+	 * sessions currently open in the grid plus the {@link MAX_POLLED_RECENT_SESSIONS}
+	 * most recently updated (non-archived) sessions.
+	 */
+	private readonly _polledSessionIds: IObservable<ReadonlySet<string>>;
 
 	constructor(
 		@IGitHubService private readonly _gitHubService: IGitHubService,
@@ -80,70 +102,114 @@ export class GitHubPullRequestPollingContribution extends Disposable implements 
 			reader.store.add(model.startPolling());
 		}));
 
+		this._polledSessionIds = derived(this, reader => {
+			const ids = new Set<string>();
+
+			// Always poll the sessions currently open in the grid.
+			for (const session of this._sessionsService.visibleSessions.read(reader)) {
+				if (session && !session.isArchived.read(reader)) {
+					ids.add(session.sessionId);
+				}
+			}
+
+			// Plus the most recently updated (non-archived) sessions.
+			const recent = this._allSessions.read(reader)
+				.filter(session => !session.isArchived.read(reader))
+				.sort((a, b) => b.updatedAt.read(reader).getTime() - a.updatedAt.read(reader).getTime())
+				.slice(0, MAX_POLLED_RECENT_SESSIONS);
+			for (const session of recent) {
+				ids.add(session.sessionId);
+			}
+
+			return ids;
+		});
+
 		this._sessionsManagementService.onDidChangeSessions(this._onDidChangeSessions, this, this._store);
 		this._onDidChangeSessions({ added: this._sessionsManagementService.getSessions(), removed: [], changed: [] });
 	}
 
 	private _onDidChangeSessions(e: ISessionsChangeEvent): void {
-		// Added sessions
-		for (const session of e.added) {
-			// Archived
-			if (session.isArchived.get()) {
-				continue;
-			}
-
-			this._startPolling(session);
+		for (const session of [...e.added, ...e.changed]) {
+			this._trackSession(session);
 		}
 
-		// Changes sessions
-		for (const session of e.changed) {
-			// Archived
-			if (session.isArchived.get()) {
-				this._disposePolling(session);
-				continue;
-			}
-
-			this._startPolling(session);
-		}
-
-		// Removed sessions
 		for (const session of e.removed) {
-			this._disposePolling(session);
+			this._sessionTracking.deleteAndDispose(session.sessionId);
 		}
+
+		this._allSessions.set(this._sessionsManagementService.getSessions(), undefined);
 	}
 
-	private _startPolling(session: ISession): void {
-		const gitHubInfo = session.workspace.get()?.folders[0]?.gitRepository?.gitHubInfo.get();
-		if (!gitHubInfo || !gitHubInfo.pullRequest) {
+	/**
+	 * Track a session's pull request state.
+	 *
+	 * The PR icon shown in the sessions list is derived from the shared PR-state
+	 * cache, so we must keep that cache populated for the session. We do two
+	 * things, both reactive on the session's `gitHubInfo` (some providers — e.g.
+	 * the agent host — resolve the PR number asynchronously):
+	 *
+	 * - Fetch the state once when the PR number first resolves (or changes),
+	 *   unless the cache is already populated (it may have been seeded from
+	 *   storage on reload). This keeps the icon correct for every session without
+	 *   polling all of them.
+	 * - Poll the state continuously while the session is in the limited polling
+	 *   set (see {@link _polledSessionIds}). When the session leaves the set we
+	 *   stop polling but keep the last-seen state in the cache, so the icon keeps
+	 *   rendering.
+	 */
+	private _trackSession(session: ISession): void {
+		const key = session.sessionId;
+		if (this._sessionTracking.has(key)) {
 			return;
 		}
 
-		const key = getPullRequestKey(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number);
-		if (this._pullRequests.has(key)) {
-			return;
-		}
+		// Depend only on the PR identity (owner/repo/number) via structural
+		// equality so cache writes (which recompute `gitHubInfo`) don't re-trigger
+		// the autoruns below. Archived sessions resolve to `undefined`.
+		const pullRequestObs = derivedOpts<{ owner: string; repo: string; number: number } | undefined>(
+			{ equalsFn: structuralEquals },
+			reader => {
+				if (session.isArchived.read(reader)) {
+					return undefined;
+				}
+				const gitHubInfo = session.workspace.read(reader)?.folders[0]?.gitRepository?.gitHubInfo.read(reader);
+				if (!gitHubInfo?.pullRequest) {
+					return undefined;
+				}
+				return { owner: gitHubInfo.owner, repo: gitHubInfo.repo, number: gitHubInfo.pullRequest.number };
+			});
+
+		// Boolean membership with default (value) equality so the polling autorun
+		// only re-runs when this session actually joins/leaves the polling set.
+		const isPolledObs = derived(reader => this._polledSessionIds.read(reader).has(session.sessionId));
 
 		const disposables = new DisposableStore();
-		const modelRef = this._gitHubService.createPullRequestModelReference(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number);
 
-		disposables.add(modelRef);
-		disposables.add(modelRef.object.startPolling());
+		// Fetch once when the PR number resolves/changes (skip if already cached).
+		disposables.add(autorun(reader => {
+			const pullRequest = pullRequestObs.read(reader);
+			if (!pullRequest) {
+				return;
+			}
+			if (this._gitHubService.getCachedPullRequestState(pullRequest.owner, pullRequest.repo, pullRequest.number).read(undefined) === undefined) {
+				this._gitHubService.fetchPullRequestState(pullRequest.owner, pullRequest.repo, pullRequest.number);
+			}
+		}));
 
-		this._pullRequests.set(key, disposables);
-	}
+		// Poll while in the polling set; stops (retaining cached state) otherwise.
+		disposables.add(autorun(reader => {
+			const pullRequest = pullRequestObs.read(reader);
+			if (!pullRequest || !isPolledObs.read(reader)) {
+				return;
+			}
+			reader.store.add(this._gitHubService.pollPullRequestState(pullRequest.owner, pullRequest.repo, pullRequest.number));
+		}));
 
-	private _disposePolling(session: ISession): void {
-		const gitHubInfo = session.workspace.get()?.folders[0]?.gitRepository?.gitHubInfo.get();
-		if (!gitHubInfo || !gitHubInfo.pullRequest) {
-			return;
-		}
-
-		const key = getPullRequestKey(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number);
-		this._pullRequests.deleteAndDispose(key);
+		this._sessionTracking.set(key, disposables);
 	}
 
 	override dispose(): void {
-		this._pullRequests.dispose();
+		this._sessionTracking.dispose();
 
 		super.dispose();
 	}

--- a/src/vs/sessions/contrib/github/browser/githubPullRequestStateCache.ts
+++ b/src/vs/sessions/contrib/github/browser/githubPullRequestStateCache.ts
@@ -1,0 +1,186 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { RunOnceScheduler } from '../../../../base/common/async.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
+import { IStorageService, StorageScope, StorageTarget, WillSaveStateReason } from '../../../../platform/storage/common/storage.js';
+import { getPullRequestKey } from '../common/utils.js';
+import { GitHubPullRequestState } from '../common/types.js';
+
+/**
+ * The minimal last-seen pull request state needed to render the sessions list
+ * PR icon. The icon glyph is fully determined by {@link iconState}, the same
+ * value {@link computePullRequestIcon} consumes.
+ */
+export interface IPullRequestStateSnapshot {
+	readonly iconState: GitHubPullRequestState | 'draft';
+}
+
+interface IStoredPullRequestStateEntry {
+	readonly owner: string;
+	readonly repo: string;
+	readonly number: number;
+	readonly iconState: GitHubPullRequestState | 'draft';
+	/** Epoch ms of the last write; used to evict the oldest entries. */
+	readonly lastUpdated: number;
+}
+
+const STORAGE_KEY = 'sessions.github.pullRequestState';
+
+/** Cap the number of persisted PR states; oldest entries are evicted first. */
+const MAX_ENTRIES = 100;
+
+const SAVE_DEBOUNCE_MS = 500;
+
+/**
+ * Caches the last-seen pull request state per `(owner, repo, number)` so the
+ * sessions list can render the PR icon for any session — not just the active
+ * one — and can show it instantly on reload from global storage.
+ *
+ * The cache is the source of truth the providers read for the icon; it is
+ * written to whenever a session's PR is fetched or polled (see
+ * {@link IGitHubService.fetchPullRequestState} / `pollPullRequestState`). State
+ * is retained when a session becomes inactive/invisible (we simply stop
+ * polling), so the icon keeps rendering from the last-seen value.
+ */
+export class GitHubPullRequestStateCache extends Disposable {
+
+	/** Live snapshot observables, created lazily per key. */
+	private readonly _observables = new Map<string, ISettableObservable<IPullRequestStateSnapshot | undefined>>();
+
+	/** Persisted source of truth, mirrored to {@link _observables}. */
+	private readonly _entries = new Map<string, IStoredPullRequestStateEntry>();
+
+	private readonly _saveScheduler = this._register(new RunOnceScheduler(() => this._save(), SAVE_DEBOUNCE_MS));
+
+	constructor(
+		@IStorageService private readonly _storageService: IStorageService,
+	) {
+		super();
+
+		this._load();
+
+		// Flush any pending debounced write before the window goes away so the
+		// icons are available on the next reload.
+		this._register(this._storageService.onWillSaveState(e => {
+			if (e.reason === WillSaveStateReason.SHUTDOWN && this._saveScheduler.isScheduled()) {
+				this._saveScheduler.cancel();
+				this._save();
+			}
+		}));
+	}
+
+	/**
+	 * Returns a stable observable of the last-seen state for the given pull
+	 * request. The observable is created on first access (seeded from persisted
+	 * storage) and reused thereafter so consumers stay subscribed across writes.
+	 */
+	getState(owner: string, repo: string, prNumber: number): IObservable<IPullRequestStateSnapshot | undefined> {
+		return this._getOrCreateObservable(getPullRequestKey(owner, repo, prNumber));
+	}
+
+	/**
+	 * Records the latest state for a pull request and schedules a debounced
+	 * persist. Evicts the oldest entries when the cap is exceeded.
+	 */
+	setState(owner: string, repo: string, prNumber: number, snapshot: IPullRequestStateSnapshot): void {
+		const key = getPullRequestKey(owner, repo, prNumber);
+		const existing = this._entries.get(key);
+		if (existing && existing.iconState === snapshot.iconState) {
+			// No glyph change — just bump recency so the entry survives eviction.
+			this._entries.set(key, { ...existing, lastUpdated: Date.now() });
+			this._scheduleSave();
+			return;
+		}
+
+		this._entries.set(key, { owner, repo, number: prNumber, iconState: snapshot.iconState, lastUpdated: Date.now() });
+		this._getOrCreateObservable(key).set({ iconState: snapshot.iconState }, undefined);
+		this._evictIfNeeded();
+		this._scheduleSave();
+	}
+
+	private _getOrCreateObservable(key: string): ISettableObservable<IPullRequestStateSnapshot | undefined> {
+		let observable = this._observables.get(key);
+		if (!observable) {
+			const entry = this._entries.get(key);
+			observable = observableValue<IPullRequestStateSnapshot | undefined>(`githubPullRequestState.${key}`, entry ? { iconState: entry.iconState } : undefined);
+			this._observables.set(key, observable);
+		}
+		return observable;
+	}
+
+	private _evictIfNeeded(): void {
+		while (this._entries.size > MAX_ENTRIES) {
+			let oldestKey: string | undefined;
+			let oldestTime = Number.POSITIVE_INFINITY;
+			for (const [key, entry] of this._entries) {
+				if (entry.lastUpdated < oldestTime) {
+					oldestTime = entry.lastUpdated;
+					oldestKey = key;
+				}
+			}
+			if (oldestKey === undefined) {
+				break;
+			}
+			this._entries.delete(oldestKey);
+			// Drop the icon for the evicted PR so any subscriber stops rendering a
+			// stale value; the observable is kept so the subscription stays valid.
+			this._observables.get(oldestKey)?.set(undefined, undefined);
+		}
+	}
+
+	private _scheduleSave(): void {
+		if (!this._saveScheduler.isScheduled()) {
+			this._saveScheduler.schedule();
+		}
+	}
+
+	private _load(): void {
+		const raw = this._storageService.get(STORAGE_KEY, StorageScope.APPLICATION);
+		if (!raw) {
+			return;
+		}
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(raw);
+		} catch {
+			return;
+		}
+		if (!Array.isArray(parsed)) {
+			return;
+		}
+		for (const candidate of parsed) {
+			const entry = this._coerceEntry(candidate);
+			if (entry) {
+				this._entries.set(getPullRequestKey(entry.owner, entry.repo, entry.number), entry);
+			}
+		}
+		this._evictIfNeeded();
+	}
+
+	private _coerceEntry(candidate: unknown): IStoredPullRequestStateEntry | undefined {
+		if (!candidate || typeof candidate !== 'object') {
+			return undefined;
+		}
+		const { owner, repo, number, iconState, lastUpdated } = candidate as Record<string, unknown>;
+		if (typeof owner !== 'string' || typeof repo !== 'string' || typeof number !== 'number') {
+			return undefined;
+		}
+		if (iconState !== GitHubPullRequestState.Open && iconState !== GitHubPullRequestState.Closed && iconState !== GitHubPullRequestState.Merged && iconState !== 'draft') {
+			return undefined;
+		}
+		return { owner, repo, number, iconState, lastUpdated: typeof lastUpdated === 'number' ? lastUpdated : 0 };
+	}
+
+	private _save(): void {
+		if (this._entries.size === 0) {
+			this._storageService.remove(STORAGE_KEY, StorageScope.APPLICATION);
+			return;
+		}
+		const entries = [...this._entries.values()];
+		this._storageService.store(STORAGE_KEY, JSON.stringify(entries), StorageScope.APPLICATION, StorageTarget.MACHINE);
+	}
+}

--- a/src/vs/sessions/contrib/github/browser/githubService.ts
+++ b/src/vs/sessions/contrib/github/browser/githubService.ts
@@ -3,17 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, IReference } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, IDisposable, IReference } from '../../../../base/common/lifecycle.js';
 import { createDecorator, IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { IGitHubChangedFile } from '../common/types.js';
+import { IGitHubChangedFile, IGitHubPullRequest } from '../common/types.js';
 import { GitHubApiClient } from './githubApiClient.js';
 import { GitHubRepositoryModel, GitHubRepositoryModelReferenceCollection } from './models/githubRepositoryModel.js';
 import { GitHubPullRequestModel, GitHubPullRequestModelReferenceCollection } from './models/githubPullRequestModel.js';
 import { GitHubPullRequestReviewThreadsModel, GitHubPullRequestReviewThreadsModelReferenceCollection } from './models/githubPullRequestReviewThreadsModel.js';
 import { GitHubPullRequestCIModel, GitHubPullRequestCIModelReferenceCollection } from './models/githubPullRequestCIModel.js';
 import { GitHubChangesFetcher } from './fetchers/githubChangesFetcher.js';
+import { GitHubPullRequestStateCache, IPullRequestStateSnapshot } from './githubPullRequestStateCache.js';
 import { getPullRequestKey } from '../common/utils.js';
-import { derived, derivedOpts, IObservable } from '../../../../base/common/observable.js';
+import { autorun, derived, derivedOpts, IObservable } from '../../../../base/common/observable.js';
 import { structuralEquals } from '../../../../base/common/equals.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 export interface IGitHubService {
@@ -58,6 +59,29 @@ export interface IGitHubService {
 	 * not cached, so a later retry can succeed once a PR is created.
 	 */
 	findPullRequestNumberByHeadBranch(owner: string, repo: string, branch: string): Promise<number | undefined>;
+
+	/**
+	 * Observable of the last-seen state for a pull request, used to render the
+	 * sessions list PR icon for any session — not just the active one. Seeded
+	 * from global storage so the icon shows instantly on reload, and updated
+	 * by {@link fetchPullRequestState} / {@link pollPullRequestState}.
+	 */
+	getCachedPullRequestState(owner: string, repo: string, prNumber: number): IObservable<IPullRequestStateSnapshot | undefined>;
+
+	/**
+	 * Fetch a pull request's state once and write it to the cache. Use when a
+	 * session's PR number first resolves (or changes) so its icon updates even
+	 * when the session is not being polled.
+	 */
+	fetchPullRequestState(owner: string, repo: string, prNumber: number): Promise<void>;
+
+	/**
+	 * Refresh a pull request's state immediately, then keep it fresh by polling,
+	 * writing every update through to the cache. Returns a disposable that stops
+	 * polling (the last-seen state is retained in the cache). Use only for the
+	 * limited set of sessions worth polling (visible + most recently updated).
+	 */
+	pollPullRequestState(owner: string, repo: string, prNumber: number): IDisposable;
 }
 
 export const IGitHubService = createDecorator<IGitHubService>('sessionsGitHubService');
@@ -76,6 +100,7 @@ export class GitHubService extends Disposable implements IGitHubService {
 	private readonly _pullRequestReviewThreadsReferences: GitHubPullRequestReviewThreadsModelReferenceCollection;
 	private readonly _pullRequestCIReferences: GitHubPullRequestCIModelReferenceCollection;
 	private readonly _apiClient: GitHubApiClient;
+	private readonly _stateCache: GitHubPullRequestStateCache;
 
 	/**
 	 * Cache of in-flight / resolved `findPullRequestNumberByHeadBranch`
@@ -101,6 +126,7 @@ export class GitHubService extends Disposable implements IGitHubService {
 		this._pullRequestReferences = instantiationService.createInstance(GitHubPullRequestModelReferenceCollection, apiClient);
 		this._pullRequestReviewThreadsReferences = instantiationService.createInstance(GitHubPullRequestReviewThreadsModelReferenceCollection, apiClient);
 		this._pullRequestCIReferences = instantiationService.createInstance(GitHubPullRequestCIModelReferenceCollection, apiClient);
+		this._stateCache = this._register(instantiationService.createInstance(GitHubPullRequestStateCache));
 
 		const gitHubInfoObs = derivedOpts<{ owner: string; repo: string; pullRequestNumber: number } | undefined>({ equalsFn: structuralEquals },
 			reader => {
@@ -228,5 +254,40 @@ export class GitHubService extends Disposable implements IGitHubService {
 		);
 		const first = response.data?.[0];
 		return first ? first.number : undefined;
+	}
+
+	getCachedPullRequestState(owner: string, repo: string, prNumber: number): IObservable<IPullRequestStateSnapshot | undefined> {
+		return this._stateCache.getState(owner, repo, prNumber);
+	}
+
+	async fetchPullRequestState(owner: string, repo: string, prNumber: number): Promise<void> {
+		const modelRef = this.createPullRequestModelReference(owner, repo, prNumber);
+		try {
+			await modelRef.object.refresh();
+			this._writeStateFromModel(owner, repo, prNumber, modelRef.object.pullRequest.get());
+		} finally {
+			modelRef.dispose();
+		}
+	}
+
+	pollPullRequestState(owner: string, repo: string, prNumber: number): IDisposable {
+		const store = new DisposableStore();
+		const modelRef = store.add(this.createPullRequestModelReference(owner, repo, prNumber));
+		const model = modelRef.object;
+		model.refresh();
+		store.add(model.startPolling());
+		// Mirror every refresh/poll update into the cache so the icon stays
+		// current while polling and retains its last value once polling stops.
+		store.add(autorun(reader => {
+			this._writeStateFromModel(owner, repo, prNumber, model.pullRequest.read(reader));
+		}));
+		return store;
+	}
+
+	private _writeStateFromModel(owner: string, repo: string, prNumber: number, pullRequest: IGitHubPullRequest | undefined): void {
+		if (!pullRequest) {
+			return;
+		}
+		this._stateCache.setState(owner, repo, prNumber, { iconState: pullRequest.isDraft ? 'draft' : pullRequest.state });
 	}
 }

--- a/src/vs/sessions/contrib/github/test/browser/githubContribution.test.ts
+++ b/src/vs/sessions/contrib/github/test/browser/githubContribution.test.ts
@@ -7,14 +7,16 @@ import assert from 'assert';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
-import { DisposableStore, IDisposable, ImmortalReference, IReference, toDisposable } from '../../../../../base/common/lifecycle.js';
-import { constObservable, IObservable, observableValue } from '../../../../../base/common/observable.js';
-import { GitHubPullRequestModel } from '../../browser/models/githubPullRequestModel.js';
+import { DisposableStore, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { constObservable, IObservable, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { GitHubPullRequestPollingContribution } from '../../browser/github.contribution.js';
 import { IGitHubService } from '../../browser/githubService.js';
+import { IPullRequestStateSnapshot } from '../../browser/githubPullRequestStateCache.js';
+import { GitHubPullRequestState } from '../../common/types.js';
+import { getPullRequestKey } from '../../common/utils.js';
 import { IChat, IGitHubInfo, ISession, ISessionCapabilities, ISessionChangeset, IChatCheckpoints, ISessionFileChange, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { IActiveSession, ISessionsChangeEvent, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
@@ -23,14 +25,12 @@ suite('GitHubPullRequestPollingContribution', () => {
 
 	const store = new DisposableStore();
 	let sessionsManagementService: TestSessionsManagementService;
-	let sessionsService: ISessionsService;
+	let sessionsService: TestSessionsService;
 	let gitHubService: TestGitHubService;
 
 	setup(() => {
 		sessionsManagementService = new TestSessionsManagementService(store);
-		sessionsService = new class extends mock<ISessionsService>() {
-			override readonly activeSession = constObservable<IActiveSession | undefined>(undefined);
-		};
+		sessionsService = new TestSessionsService();
 		gitHubService = new TestGitHubService();
 	});
 
@@ -38,71 +38,107 @@ suite('GitHubPullRequestPollingContribution', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('starts polling existing and added pull request sessions', () => {
-		const existingSession = sessionsManagementService.addSession('existing', makeGitHubInfo(1));
+	function createContribution(): GitHubPullRequestPollingContribution {
+		return store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService));
+	}
 
-		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService));
+	test('fetches pull request state once when it resolves asynchronously', () => {
+		// Some providers (e.g. the agent host) resolve the PR number
+		// asynchronously, so a session can be present before its `gitHubInfo`
+		// carries a pull request. The contribution must observe `gitHubInfo`
+		// reactively and fetch the state once it resolves.
+		const session = sessionsManagementService.addSession('async', undefined);
+		createContribution();
 
-		const addedSession = sessionsManagementService.addSession('added', makeGitHubInfo(2));
-		sessionsManagementService.fireSessionsChanged({ added: [addedSession] });
+		assert.deepStrictEqual(gitHubService.fetchCalls, []);
 
-		assert.deepStrictEqual(gitHubService.snapshot(), {
-			'owner/repo/1': { startPollingCalls: 1, stopPollingCalls: 0, disposeCalls: 0 },
-			'owner/repo/2': { startPollingCalls: 1, stopPollingCalls: 0, disposeCalls: 0 },
-		});
-		assert.strictEqual(existingSession.isArchived.get(), false);
+		sessionsManagementService.setGitHubInfo(session, makeGitHubInfo(1));
+
+		assert.deepStrictEqual(gitHubService.fetchCalls, ['owner/repo/1']);
 	});
 
-	test('stops polling when a session is archived, then resumes when unarchived', () => {
+	test('does not fetch when the state is already cached (seeded from storage)', () => {
+		gitHubService.seedCache('owner', 'repo', 1, { iconState: GitHubPullRequestState.Open });
+		sessionsManagementService.addSession('cached', makeGitHubInfo(1));
+
+		createContribution();
+
+		assert.deepStrictEqual(gitHubService.fetchCalls, []);
+	});
+
+	test('polls sessions that are open in the grid', () => {
+		gitHubService.seedCache('owner', 'repo', 1, { iconState: GitHubPullRequestState.Open });
+		const session = sessionsManagementService.addSession('visible', makeGitHubInfo(1));
+		sessionsService.setVisibleSessions([session]);
+
+		createContribution();
+
+		assert.deepStrictEqual(gitHubService.pollSnapshot(), { 'owner/repo/1': { start: 1, stop: 0 } });
+	});
+
+	test('only polls the most recently updated sessions, retaining cached state for the rest', () => {
+		// 6 non-visible sessions, each with a distinct PR and update time. Only
+		// the 5 most recently updated should be polled.
+		for (let i = 1; i <= 6; i++) {
+			gitHubService.seedCache('owner', 'repo', i, { iconState: GitHubPullRequestState.Open });
+			const session = sessionsManagementService.addSession(`s${i}`, makeGitHubInfo(i));
+			session.updatedAt.set(new Date(i * 1000), undefined);
+		}
+
+		createContribution();
+
+		// The oldest (s1 -> PR #1) is not polled; the rest are.
+		assert.deepStrictEqual(gitHubService.pollSnapshot(), {
+			'owner/repo/2': { start: 1, stop: 0 },
+			'owner/repo/3': { start: 1, stop: 0 },
+			'owner/repo/4': { start: 1, stop: 0 },
+			'owner/repo/5': { start: 1, stop: 0 },
+			'owner/repo/6': { start: 1, stop: 0 },
+		});
+
+		// The un-polled session still has its (last-seen) cached state available.
+		assert.deepStrictEqual(gitHubService.getCachedPullRequestState('owner', 'repo', 1).get(), { iconState: GitHubPullRequestState.Open });
+	});
+
+	test('stops polling when a session is archived but keeps its cached state', () => {
+		gitHubService.seedCache('owner', 'repo', 1, { iconState: GitHubPullRequestState.Open });
 		const session = sessionsManagementService.addSession('session', makeGitHubInfo(1));
-		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService));
+		createContribution();
+
+		assert.deepStrictEqual(gitHubService.pollSnapshot(), { 'owner/repo/1': { start: 1, stop: 0 } });
 
 		sessionsManagementService.setArchived(session, true);
 		sessionsManagementService.fireSessionsChanged({ changed: [session] });
 
-		assert.deepStrictEqual(gitHubService.snapshot(), {
-			'owner/repo/1': { startPollingCalls: 1, stopPollingCalls: 1, disposeCalls: 0 },
-		});
-
-		sessionsManagementService.setArchived(session, false);
-		sessionsManagementService.fireSessionsChanged({ changed: [session] });
-
-		assert.deepStrictEqual(gitHubService.snapshot(), {
-			'owner/repo/1': { startPollingCalls: 2, stopPollingCalls: 1, disposeCalls: 0 },
-		});
+		assert.deepStrictEqual(gitHubService.pollSnapshot(), { 'owner/repo/1': { start: 1, stop: 1 } });
+		assert.deepStrictEqual(gitHubService.getCachedPullRequestState('owner', 'repo', 1).get(), { iconState: GitHubPullRequestState.Open });
 	});
 
-	test('does not poll archived sessions until they are unarchived', () => {
-		const session = sessionsManagementService.addSession('session', makeGitHubInfo(1), true);
-		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService));
-
-		assert.deepStrictEqual(gitHubService.snapshot(), {});
-
-		sessionsManagementService.setArchived(session, false);
-		sessionsManagementService.fireSessionsChanged({ changed: [session] });
-
-		assert.deepStrictEqual(gitHubService.snapshot(), {
-			'owner/repo/1': { startPollingCalls: 1, stopPollingCalls: 0, disposeCalls: 0 },
-		});
-	});
-
-	test('stops polling tracked pull requests when disposed', () => {
-		const session = sessionsManagementService.addSession('session', makeGitHubInfo(1));
-		const contribution = store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService));
+	test('stops polling when disposed', () => {
+		gitHubService.seedCache('owner', 'repo', 1, { iconState: GitHubPullRequestState.Open });
+		sessionsManagementService.addSession('session', makeGitHubInfo(1));
+		const contribution = createContribution();
 
 		contribution.dispose();
 
-		assert.deepStrictEqual(gitHubService.snapshot(), {
-			'owner/repo/1': { startPollingCalls: 1, stopPollingCalls: 1, disposeCalls: 0 },
-		});
-		assert.strictEqual(session.isArchived.get(), false);
+		assert.deepStrictEqual(gitHubService.pollSnapshot(), { 'owner/repo/1': { start: 1, stop: 1 } });
 	});
 });
+
+class TestSessionsService extends mock<ISessionsService>() {
+
+	override readonly activeSession = constObservable<IActiveSession | undefined>(undefined);
+	override readonly visibleSessions: ISettableObservable<readonly (IActiveSession | undefined)[]> = observableValue('test.visibleSessions', []);
+
+	setVisibleSessions(sessions: readonly ISession[]): void {
+		this.visibleSessions.set(sessions as readonly IActiveSession[], undefined);
+	}
+}
 
 class TestSessionsManagementService extends mock<ISessionsManagementService>() {
 
 	private readonly _onDidChangeSessions: Emitter<ISessionsChangeEvent>;
-	private readonly _sessions = new Map<string, ISession>();
+	private readonly _sessions = new Map<string, TestSession>();
 
 	override readonly onDidChangeSessions: Event<ISessionsChangeEvent>;
 
@@ -112,26 +148,21 @@ class TestSessionsManagementService extends mock<ISessionsManagementService>() {
 		this.onDidChangeSessions = this._onDidChangeSessions.event;
 	}
 
-	addSession(id: string, gitHubInfo: IGitHubInfo | undefined, archived = false): ISession {
+	addSession(id: string, gitHubInfo: IGitHubInfo | undefined, archived = false): TestSession {
 		const session = new TestSession(id, gitHubInfo, archived);
 		this._sessions.set(session.sessionId, session);
 		return session;
 	}
 
-	removeSession(session: ISession): void {
-		this._sessions.delete(session.sessionId);
-		this.fireSessionsChanged({ removed: [session] });
-	}
-
 	setArchived(session: ISession, archived: boolean): void {
-		(session.isArchived as ReturnType<typeof observableValue<boolean>>).set(archived, undefined);
+		(session.isArchived as ISettableObservable<boolean>).set(archived, undefined);
 	}
 
 	setGitHubInfo(session: ISession, gitHubInfo: IGitHubInfo | undefined): void {
 		const workspace = session.workspace.get();
 		const folder = workspace?.folders[0];
 		if (folder) {
-			(folder.gitRepository!.gitHubInfo as ReturnType<typeof observableValue<IGitHubInfo | undefined>>).set(gitHubInfo, undefined);
+			(folder.gitRepository!.gitHubInfo as ISettableObservable<IGitHubInfo | undefined>).set(gitHubInfo, undefined);
 		}
 	}
 
@@ -148,7 +179,7 @@ class TestSessionsManagementService extends mock<ISessionsManagementService>() {
 	}
 }
 
-class TestSession implements ISession {
+class TestSession implements IActiveSession {
 
 	readonly sessionId: string;
 	readonly resource: URI;
@@ -156,21 +187,24 @@ class TestSession implements ISession {
 	readonly sessionType = 'test';
 	readonly icon = Codicon.comment;
 	readonly createdAt = new Date(0);
-	readonly title: ReturnType<typeof observableValue<string>>;
-	readonly updatedAt: ReturnType<typeof observableValue<Date>>;
-	readonly status: ReturnType<typeof observableValue<SessionStatus>>;
-	readonly changesets: ReturnType<typeof observableValue<readonly ISessionChangeset[]>>;
-	readonly changes: ReturnType<typeof observableValue<readonly ISessionFileChange[]>>;
-	readonly workspace: ReturnType<typeof observableValue<ISessionWorkspace | undefined>>;
-	readonly modelId: ReturnType<typeof observableValue<string | undefined>>;
-	readonly mode: ReturnType<typeof observableValue<{ readonly id: string; readonly kind: string } | undefined>>;
-	readonly loading: ReturnType<typeof observableValue<boolean>>;
-	readonly isArchived: ReturnType<typeof observableValue<boolean>>;
-	readonly isRead: ReturnType<typeof observableValue<boolean>>;
-	readonly description: ReturnType<typeof observableValue<IMarkdownString | undefined>>;
-	readonly lastTurnEnd: ReturnType<typeof observableValue<Date | undefined>>;
-	readonly chats: ReturnType<typeof observableValue<readonly IChat[]>>;
+	readonly title: ISettableObservable<string>;
+	readonly updatedAt: ISettableObservable<Date>;
+	readonly status: ISettableObservable<SessionStatus>;
+	readonly changesets: ISettableObservable<readonly ISessionChangeset[]>;
+	readonly changes: ISettableObservable<readonly ISessionFileChange[]>;
+	readonly workspace: ISettableObservable<ISessionWorkspace | undefined>;
+	readonly modelId: ISettableObservable<string | undefined>;
+	readonly mode: ISettableObservable<{ readonly id: string; readonly kind: string } | undefined>;
+	readonly loading: ISettableObservable<boolean>;
+	readonly isArchived: ISettableObservable<boolean>;
+	readonly isRead: ISettableObservable<boolean>;
+	readonly description: ISettableObservable<IMarkdownString | undefined>;
+	readonly lastTurnEnd: ISettableObservable<Date | undefined>;
+	readonly chats: ISettableObservable<readonly IChat[]>;
 	readonly mainChat: IObservable<IChat>;
+	readonly activeChat: IObservable<IChat>;
+	readonly isCreated: IObservable<boolean> = constObservable(true);
+	readonly sticky: IObservable<boolean> = constObservable(false);
 	readonly capabilities: ISessionCapabilities = { supportsMultipleChats: false };
 
 	constructor(id: string, gitHubInfo: IGitHubInfo | undefined, archived: boolean) {
@@ -223,55 +257,49 @@ class TestSession implements ISession {
 			lastTurnEnd: this.lastTurnEnd,
 		};
 		this.mainChat = constObservable(mainChat);
+		this.activeChat = this.mainChat;
 		this.chats = observableValue<readonly IChat[]>(`test.chats.${id}`, [mainChat]);
 	}
 }
 
 class TestGitHubService extends mock<IGitHubService>() {
 
-	private readonly _models = new Map<string, TestPullRequestModel>();
+	readonly fetchCalls: string[] = [];
+	private readonly _polls = new Map<string, { start: number; stop: number }>();
+	private readonly _cache = new Map<string, ISettableObservable<IPullRequestStateSnapshot | undefined>>();
 
-	override readonly activeSessionPullRequestObs = observableValue('test.activePR', undefined);
-	override readonly activeSessionPullRequestCIObs = observableValue('test.activePRCI', undefined);
-	override readonly activeSessionPullRequestReviewThreadsObs = observableValue('test.activePRReviewThreads', undefined);
-
-	override createPullRequestModelReference(owner: string, repo: string, prNumber: number): IReference<GitHubPullRequestModel> {
-		const key = `${owner}/${repo}/${prNumber}`;
-		let model = this._models.get(key);
-		if (!model) {
-			model = new TestPullRequestModel();
-			this._models.set(key, model);
-		}
-		return new ImmortalReference(model as unknown as GitHubPullRequestModel);
+	override getCachedPullRequestState(owner: string, repo: string, prNumber: number): IObservable<IPullRequestStateSnapshot | undefined> {
+		return this._obs(getPullRequestKey(owner, repo, prNumber));
 	}
 
-	snapshot(): Record<string, { startPollingCalls: number; stopPollingCalls: number; disposeCalls: number }> {
-		const entries = [...this._models.entries()].map(([key, model]) => [key, {
-			startPollingCalls: model.startPollingCalls,
-			stopPollingCalls: model.stopPollingCalls,
-			disposeCalls: model.disposeCalls,
-		}] as const);
-		return Object.fromEntries(entries);
-	}
-}
-
-class TestPullRequestModel implements IDisposable {
-
-	startPollingCalls = 0;
-	stopPollingCalls = 0;
-	disposeCalls = 0;
-
-	startPolling(): IDisposable {
-		this.startPollingCalls++;
-		return toDisposable(() => this.stopPollingCalls++);
-	}
-
-	refresh(): Promise<void> {
+	override fetchPullRequestState(owner: string, repo: string, prNumber: number): Promise<void> {
+		this.fetchCalls.push(getPullRequestKey(owner, repo, prNumber));
 		return Promise.resolve();
 	}
 
-	dispose(): void {
-		this.disposeCalls++;
+	override pollPullRequestState(owner: string, repo: string, prNumber: number): IDisposable {
+		const key = getPullRequestKey(owner, repo, prNumber);
+		const entry = this._polls.get(key) ?? { start: 0, stop: 0 };
+		entry.start++;
+		this._polls.set(key, entry);
+		return toDisposable(() => { entry.stop++; });
+	}
+
+	seedCache(owner: string, repo: string, prNumber: number, snapshot: IPullRequestStateSnapshot): void {
+		this._obs(getPullRequestKey(owner, repo, prNumber)).set(snapshot, undefined);
+	}
+
+	pollSnapshot(): Record<string, { start: number; stop: number }> {
+		return Object.fromEntries([...this._polls.entries()].map(([key, value]) => [key, { ...value }]));
+	}
+
+	private _obs(key: string): ISettableObservable<IPullRequestStateSnapshot | undefined> {
+		let observable = this._cache.get(key);
+		if (!observable) {
+			observable = observableValue<IPullRequestStateSnapshot | undefined>(`test.cache.${key}`, undefined);
+			this._cache.set(key, observable);
+		}
+		return observable;
 	}
 }
 

--- a/src/vs/sessions/contrib/github/test/browser/githubPullRequestStateCache.test.ts
+++ b/src/vs/sessions/contrib/github/test/browser/githubPullRequestStateCache.test.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { InMemoryStorageService, IStorageService, WillSaveStateReason } from '../../../../../platform/storage/common/storage.js';
+import { GitHubPullRequestStateCache } from '../../browser/githubPullRequestStateCache.js';
+import { GitHubPullRequestState } from '../../common/types.js';
+
+suite('GitHubPullRequestStateCache', () => {
+
+	const store = new DisposableStore();
+	let storageService: InMemoryStorageService;
+
+	setup(() => {
+		storageService = store.add(new InMemoryStorageService());
+	});
+
+	teardown(() => store.clear());
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createCache(storage: IStorageService = storageService): GitHubPullRequestStateCache {
+		return store.add(new GitHubPullRequestStateCache(storage));
+	}
+
+	test('getState reflects writes and returns a stable observable', () => {
+		const cache = createCache();
+		const observable = cache.getState('owner', 'repo', 1);
+
+		assert.strictEqual(observable.get(), undefined);
+		assert.strictEqual(cache.getState('owner', 'repo', 1), observable);
+
+		cache.setState('owner', 'repo', 1, { iconState: GitHubPullRequestState.Open });
+
+		assert.deepStrictEqual(observable.get(), { iconState: GitHubPullRequestState.Open });
+	});
+
+	test('persists state across reloads via global storage', async () => {
+		const cache = createCache();
+		cache.setState('owner', 'repo', 1, { iconState: GitHubPullRequestState.Merged });
+
+		// Force the debounced save (as on shutdown) then reload from the same storage.
+		await storageService.flush(WillSaveStateReason.SHUTDOWN);
+
+		const reloaded = createCache();
+		assert.deepStrictEqual(reloaded.getState('owner', 'repo', 1).get(), { iconState: GitHubPullRequestState.Merged });
+	});
+
+	test('caps stored entries at 100, evicting the oldest', () => {
+		const cache = createCache();
+		for (let i = 1; i <= 101; i++) {
+			cache.setState('owner', 'repo', i, { iconState: GitHubPullRequestState.Open });
+		}
+
+		// The first (oldest) entry is evicted; the newest are retained.
+		assert.strictEqual(cache.getState('owner', 'repo', 1).get(), undefined);
+		assert.deepStrictEqual(cache.getState('owner', 'repo', 2).get(), { iconState: GitHubPullRequestState.Open });
+		assert.deepStrictEqual(cache.getState('owner', 'repo', 101).get(), { iconState: GitHubPullRequestState.Open });
+	});
+});

--- a/src/vs/sessions/contrib/github/test/browser/githubService.test.ts
+++ b/src/vs/sessions/contrib/github/test/browser/githubService.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { NullLogService, ILogService } from '../../../../../platform/log/common/log.js';
+import { InMemoryStorageService, IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { GitHubService } from '../../browser/githubService.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -20,6 +21,7 @@ suite('GitHubService', () => {
 	setup(() => {
 		const instantiationService = store.add(new TestInstantiationService());
 		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IStorageService, store.add(new InMemoryStorageService()));
 
 		service = store.add(instantiationService.createInstance(GitHubService));
 	});

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -275,10 +275,15 @@ export class AgentHostSessionAdapter implements ISession {
 			const uri = URI.parse(`https://github.com/${coords.owner}/${coords.repo}/pull/${prNumber}`);
 			let icon: ThemeIcon | undefined;
 			if (gitHubService) {
-				const ref = reader.store.add(gitHubService.createPullRequestModelReference(coords.owner, coords.repo, prNumber));
-				const livePR = ref.object.pullRequest.read(reader);
-				if (livePR) {
-					icon = computePullRequestIcon(livePR.isDraft ? 'draft' : livePR.state);
+				// Read the last-seen PR state from the shared cache rather than
+				// holding a live model reference here. This keeps the icon
+				// rendering even when the session is inactive/invisible (the cache
+				// retains the last value and is seeded from storage on reload),
+				// while polling is driven centrally for only a limited set of
+				// sessions (see GitHubPullRequestPollingContribution).
+				const cached = gitHubService.getCachedPullRequestState(coords.owner, coords.repo, prNumber).read(reader);
+				if (cached) {
+					icon = computePullRequestIcon(cached.iconState);
 				}
 			}
 			return {

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -992,12 +992,14 @@ class AgentSessionAdapter implements ICopilotChatSession {
 			if (!base?.pullRequest || !this._gitHubService) {
 				return base;
 			}
-			const prModelRef = reader.store.add(this._gitHubService.createPullRequestModelReference(base.owner, base.repo, base.pullRequest.number));
-			const livePR = prModelRef.object.pullRequest.read(reader);
-			if (!livePR) {
+			// Prefer the last-seen PR state from the shared cache (retained while
+			// the session is inactive and seeded from storage on reload). Fall
+			// back to the metadata icon from `base` until the cache is populated.
+			const cached = this._gitHubService.getCachedPullRequestState(base.owner, base.repo, base.pullRequest.number).read(reader);
+			if (!cached) {
 				return base;
 			}
-			return { ...base, pullRequest: { ...base.pullRequest, icon: computePullRequestIcon(livePR.isDraft ? 'draft' : livePR.state) } };
+			return { ...base, pullRequest: { ...base.pullRequest, icon: computePullRequestIcon(cached.iconState) } };
 		});
 
 		this._workspace = observableValue(this, this._buildWorkspace(session));


### PR DESCRIPTION
## Problem

In the sessions list we show the pull-request codicon when a session has an open PR. The icon only stayed visible for the **active** session — opening another session made the PR icon disappear (intermittently) from the now-inactive session's row. Most visible for the agent host provider, whose PR number resolves asynchronously.

### Root cause

The icon was derived from a **shared, ref-counted** GitHubPullRequestModel. A durable reference + refresh existed only for the active session (ctiveSessionPullRequestObs). The provider's gitHubInfo derived held its own reference, but a derived's eader.store is cleared *just before* re-evaluation, so on each recompute the reference was released-then-reacquired. While inactive (active reference gone; per-session polling bailed because the agent host resolves the PR number asynchronously), the ref count briefly hit 0 → the shared model was disposed → its fetched state was lost → the icon vanished.

## Changes

- **New GitHubPullRequestStateCache** — per-`(owner/repo/number)` observable of the last-seen PR icon-state, backed by **global storage** (`APPLICATION`/`MACHINE`). Seeded on startup (instant icon on reload), debounced save + flush on shutdown, **capped at 100 entries** (oldest evicted).
- **GitHubService** owns the cache and exposes `getCachedPullRequestState` (read by providers), `fetchPullRequestState` (one-shot refresh → cache), and `pollPullRequestState` (refresh + poll + write-through; stops polling but **keeps** the cached state).
- **Providers** (agent host + copilot) derive the icon from the cache instead of holding a live model reference, so the icon persists when inactive/invisible.
- **`GitHubPullRequestPollingContribution`** now:
  - fetches a PR's state **once** when its number resolves/changes (skipped if already cached),
  - **polls only** the sessions open in the grid plus the **5 most recently updated** sessions — no longer polling hundreds of PRs.

## Tests

- New cache tests (stable observable, persistence round-trip, 100-cap eviction).
- Rewritten contribution tests (fetch-once on async resolve, skip-when-cached, polls-visible, top-5-only + retain-when-inactive, stop-on-archive/dispose).
- Full `vs/sessions` browser unit suite: **883 passing**.