### PR TITLE
Detect telemetry exp setting change and switch dynamically

### DIFF
--- a/extensions/copilot/src/platform/telemetry/common/baseTelemetryService.ts
+++ b/extensions/copilot/src/platform/telemetry/common/baseTelemetryService.ts
@@ -17,7 +17,7 @@ export class BaseTelemetryService implements ITelemetryService {
 	private _sharedProperties: Record<string, string | TelemetryTrustedValue<string>> = {};
 	private _originalExpAssignments: string | undefined;
 	private _additionalExpAssignments: string[] = [];
-	private _disposables: IDisposable[] = [];
+	protected _disposables: IDisposable[] = [];
 	constructor(
 		protected readonly _tokenStore: ICopilotTokenStore,
 		private readonly _capiClientService: ICAPIClientService,

--- a/extensions/copilot/src/platform/telemetry/vscode-node/githubTelemetrySender.ts
+++ b/extensions/copilot/src/platform/telemetry/vscode-node/githubTelemetrySender.ts
@@ -24,7 +24,7 @@ class TelemetryReporterAdapter implements TelemetrySender {
 	private readonly newReporter?: TelemetryReporter;
 	private readonly useNewTelemetryLibGetter: () => boolean;
 	private readonly namespace: string;
-	private cachedFlagValue: boolean | undefined;
+	private lastUseNewTelemetryLib: boolean | undefined;
 	private readonly getTrackingId: () => string | undefined;
 
 	constructor(
@@ -42,14 +42,23 @@ class TelemetryReporterAdapter implements TelemetrySender {
 	}
 
 	/**
-	 * Lazily evaluates the flag and caches the result.
-	 * This allows the experimentation service to be initialized after TelemetryService.
+	 * Resolves whether the new telemetry library should be used. The getter is a cheap
+	 * cached read so runtime ExP treatment changes take effect without requiring a window reload.
+	 *
+	 * When the value transitions between events, the reporter being switched away from
+	 * is drained so buffered events are not delayed: switching old -> new flushes the
+	 * old reporter immediately. Switching new -> old relies on the new SDK's own flush
+	 * timer, because its only flush primitive (dispose) also tears down the client,
+	 * which we must keep usable in case the flag flips back.
 	 */
-	private get useNewTelemetryLib(): boolean {
-		if (this.cachedFlagValue === undefined) {
-			this.cachedFlagValue = this.useNewTelemetryLibGetter();
+	private resolveUseNewTelemetryLib(): boolean {
+		const value = this.useNewTelemetryLibGetter();
+		if (this.lastUseNewTelemetryLib === false && value === true) {
+			// Switching old -> new: drain the old reporter's buffered events now.
+			void this.oldReporter.flush();
 		}
-		return this.cachedFlagValue;
+		this.lastUseNewTelemetryLib = value;
+		return value;
 	}
 
 	/**
@@ -95,8 +104,9 @@ class TelemetryReporterAdapter implements TelemetrySender {
 	sendEventData(eventName: string, data?: Record<string, unknown>): void {
 		const { properties, measurements } = this.extractPropertiesAndMeasurements(data);
 
+		// Read the cached flag so ExP treatment changes are honored at runtime.
 		// Use either NEW or OLD API based on experiment flag (not both)
-		if (this.useNewTelemetryLib && this.newReporter) {
+		if (this.resolveUseNewTelemetryLib() && this.newReporter) {
 			// Apply the same event name processing as AzureInsightReporter.massageEventName:
 			// unwrap if wrapped, otherwise add extension prefix
 			const processedEventName = this.massageEventName(eventName);
@@ -121,8 +131,9 @@ class TelemetryReporterAdapter implements TelemetrySender {
 	sendErrorData(error: Error, data?: Record<string, unknown>): void {
 		const { properties, measurements } = this.extractPropertiesAndMeasurements(data);
 
+		// Read the cached flag so ExP treatment changes are honored at runtime.
 		// Use either NEW or OLD API based on experiment flag
-		if (this.useNewTelemetryLib && this.newReporter) {
+		if (this.resolveUseNewTelemetryLib() && this.newReporter) {
 			const trackingId = this.getTrackingId();
 			const tagOverrides = trackingId ? { 'ai.user.id': trackingId } : undefined;
 

--- a/extensions/copilot/src/platform/telemetry/vscode-node/telemetryServiceImpl.ts
+++ b/extensions/copilot/src/platform/telemetry/vscode-node/telemetryServiceImpl.ts
@@ -87,8 +87,7 @@ export class TelemetryService extends BaseTelemetryService {
 		// Refresh the cached experiment flag when ExP treatments change so a runtime treatment flip
 		// takes effect without requiring a window reload. We only recompute once
 		// the flag has been read at least once, preserving the lazy initialization above (so the
-		// experimentation service is not pulled on before the first telemetry event). ExP updates
-		// fire with `affectsConfiguration() === true`, so this also covers user setting overrides.
+		// experimentation service is not pulled on before the first telemetry event).
 		this._disposables.push(configService.onDidChangeConfiguration(e => {
 			if (cachedUseNewTelemetryLib !== undefined && e.affectsConfiguration(ConfigKey.TeamInternal.UseVSCodeTelemetryLibForGH.fullyQualifiedId)) {
 				cachedUseNewTelemetryLib = computeUseNewTelemetryLib();

--- a/extensions/copilot/src/platform/telemetry/vscode-node/telemetryServiceImpl.ts
+++ b/extensions/copilot/src/platform/telemetry/vscode-node/telemetryServiceImpl.ts
@@ -50,13 +50,19 @@ export class TelemetryService extends BaseTelemetryService {
 			customFetcher
 		);
 
-		// Lazy getter for the experiment flag.
-		// Uses IInstantiationService to get IExperimentationService lazily to avoid circular dependency:
-		// TelemetryService -> IExperimentationService -> ITelemetryService
-		// The flag is only evaluated on the first telemetry event, by which time both services are initialized.
-		const useNewTelemetryLibGetter = () => {
+		// The experiment flag is read lazily on the first telemetry event (to avoid the circular
+		// dependency TelemetryService -> IExperimentationService -> ITelemetryService) and then
+		// cached.
+		let cachedUseNewTelemetryLib: boolean | undefined;
+		const computeUseNewTelemetryLib = () => {
 			const expService = instantiationService.invokeFunction(accessor => accessor.get(IExperimentationService));
 			return configService.getExperimentBasedConfig(ConfigKey.TeamInternal.UseVSCodeTelemetryLibForGH, expService);
+		};
+		const useNewTelemetryLibGetter = () => {
+			if (cachedUseNewTelemetryLib === undefined) {
+				cachedUseNewTelemetryLib = computeUseNewTelemetryLib();
+			}
+			return cachedUseNewTelemetryLib;
 		};
 
 		const ghTelemetrySender = new GitHubTelemetrySender(
@@ -77,6 +83,17 @@ export class TelemetryService extends BaseTelemetryService {
 		if (fetcherService instanceof FetcherService) {
 			fetcherService.setTelemetryService(this);
 		}
+
+		// Refresh the cached experiment flag when ExP treatments change so a runtime treatment flip
+		// takes effect without requiring a window reload. We only recompute once
+		// the flag has been read at least once, preserving the lazy initialization above (so the
+		// experimentation service is not pulled on before the first telemetry event). ExP updates
+		// fire with `affectsConfiguration() === true`, so this also covers user setting overrides.
+		this._disposables.push(configService.onDidChangeConfiguration(e => {
+			if (cachedUseNewTelemetryLib !== undefined && e.affectsConfiguration(ConfigKey.TeamInternal.UseVSCodeTelemetryLibForGH.fullyQualifiedId)) {
+				cachedUseNewTelemetryLib = computeUseNewTelemetryLib();
+			}
+		}));
 
 		// Subscribe to fetch telemetry events on Insiders only to track request counts and latency per call site
 		if (envService.isPreRelease()) {


### PR DESCRIPTION
Detect telemetry exp setting change and switch telemetry module used dynamically so that we dont have to wait for vscode restart for it to take effect.