### PR TITLE
Fix run_in_terminal returning empty output when command exceeds scrollback

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -379,13 +379,13 @@ export class XtermTerminal extends Disposable implements IXtermTerminal, IDetach
 	getContentsAsText(startMarker?: IXtermMarker, endMarker?: IXtermMarker): string {
 		const lines: string[] = [];
 		const buffer = this.raw.buffer.active;
-		if (startMarker?.line === -1) {
-			throw new Error('Cannot get contents of a disposed startMarker');
-		}
 		if (endMarker?.line === -1) {
 			throw new Error('Cannot get contents of a disposed endMarker');
 		}
-		const startLine = startMarker?.line ?? 0;
+		// When the start marker is disposed (scrolled out of the buffer due to
+		// scrollback limits), fall back to line 0 to return whatever remains in
+		// the buffer rather than losing all output.
+		const startLine = (startMarker === undefined || startMarker.line === -1) ? 0 : startMarker.line;
 		const endLine = endMarker?.line ?? buffer.length - 1;
 		for (let y = startLine; y <= endLine; y++) {
 			lines.push(buffer.getLine(y)?.translateToString(true) ?? '');

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { Terminal } from '@xterm/xterm';
-import { deepStrictEqual, strictEqual } from 'assert';
+import { deepStrictEqual, ok, strictEqual } from 'assert';
 import { importAMDNodeModule } from '../../../../../../amdX.js';
 import { Color, RGBA } from '../../../../../../base/common/color.js';
 import { Emitter } from '../../../../../../base/common/event.js';
@@ -173,19 +173,17 @@ suite('XtermTerminal', () => {
 			strictEqual(result.startsWith('hello world\n  indented line\nline with $pecial chars!@#\n\nempty line above'), true, 'Should handle spaces and special characters correctly');
 		});
 
-		test('should throw error when startMarker is disposed (line === -1)', async () => {
+		test('should fall back to line 0 when startMarker is disposed (line === -1)', async () => {
 			await write('line 1\r\n');
 			const disposedMarker = xterm.raw.registerMarker(0)!;
 			await write('line 2\r\nline 3\r\nline 4\r\nline 5');
 
 			disposedMarker.dispose();
 
-			try {
-				xterm.getContentsAsText(disposedMarker);
-				throw new Error('Expected error was not thrown');
-			} catch (error: any) {
-				strictEqual(error.message, 'Cannot get contents of a disposed startMarker');
-			}
+			const result = xterm.getContentsAsText(disposedMarker);
+			// Should return content from line 0 instead of throwing
+			ok(result.length > 0);
+			ok(result.includes('line'));
 		});
 
 		test('should throw error when endMarker is disposed (line === -1)', async () => {

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
@@ -183,6 +183,7 @@ suite('XtermTerminal', () => {
 			const result = xterm.getContentsAsText(disposedMarker);
 			// Should return content from line 0 (including line 1) instead of throwing
 			ok(result.startsWith('line 1\nline 2\nline 3\nline 4\nline 5'), `Unexpected result: ${result}`);
+		});
 
 		test('should throw error when endMarker is disposed (line === -1)', async () => {
 			await write('line 1\r\n');

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
@@ -181,10 +181,8 @@ suite('XtermTerminal', () => {
 			disposedMarker.dispose();
 
 			const result = xterm.getContentsAsText(disposedMarker);
-			// Should return content from line 0 instead of throwing
-			ok(result.length > 0);
-			ok(result.includes('line'));
-		});
+			// Should return content from line 0 (including line 1) instead of throwing
+			ok(result.startsWith('line 1\nline 2\nline 3\nline 4\nline 5'), `Unexpected result: ${result}`);
 
 		test('should throw error when endMarker is disposed (line === -1)', async () => {
 			await write('line 1\r\n');

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
@@ -268,6 +268,7 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 			}
 			if (output === undefined) {
 				try {
+					const startMarkerDisposed = this._startMarker.value?.line === -1;
 					output = xterm.getContentsAsText(this._startMarker.value, endMarker);
 					this._log('Fetched output via markers');
 
@@ -275,6 +276,11 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 					// prompt lines. Strip them to isolate the actual command output.
 					if (output !== undefined) {
 						output = stripCommandEchoAndPrompt(output, commandLine, this._log.bind(this));
+					}
+
+					if (startMarkerDisposed) {
+						this._log('Start marker was disposed (output exceeded scrollback), output may be truncated from the beginning');
+						additionalInformationLines.push('Output exceeded terminal scrollback; beginning of output was lost');
 					}
 				} catch {
 					this._log('Failed to fetch output via markers');

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/noneExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/noneExecuteStrategy.ts
@@ -154,6 +154,7 @@ export class NoneExecuteStrategy extends Disposable implements ITerminalExecuteS
 			let output: string | undefined;
 			const additionalInformationLines: string[] = [];
 			try {
+				const startMarkerDisposed = this._startMarker.value?.line === -1;
 				output = xterm.getContentsAsText(this._startMarker.value, endMarker);
 				this._log('Fetched output via markers');
 
@@ -164,6 +165,11 @@ export class NoneExecuteStrategy extends Disposable implements ITerminalExecuteS
 				// sendText), and trailing lines that look like shell prompts are removed.
 				if (output !== undefined) {
 					output = stripCommandEchoAndPrompt(output, commandLine, this._log.bind(this));
+				}
+
+				if (startMarkerDisposed) {
+					this._log('Start marker was disposed (output exceeded scrollback), output may be truncated from the beginning');
+					additionalInformationLines.push('Output exceeded terminal scrollback; beginning of output was lost');
 				}
 			} catch {
 				this._log('Failed to fetch output via markers');

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
@@ -216,6 +216,7 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 			}
 			if (output === undefined) {
 				try {
+					const startMarkerDisposed = this._startMarker.value?.line === -1;
 					output = xterm.getContentsAsText(this._startMarker.value, endMarker);
 					this._log('Fetched output via markers');
 
@@ -223,6 +224,11 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 					// prompt lines. Strip them to isolate the actual command output.
 					if (output !== undefined) {
 						output = stripCommandEchoAndPrompt(output, commandLine, this._log.bind(this));
+					}
+
+					if (startMarkerDisposed) {
+						this._log('Start marker was disposed (output exceeded scrollback), output may be truncated from the beginning');
+						additionalInformationLines.push('Output exceeded terminal scrollback; beginning of output was lost');
 					}
 				} catch {
 					this._log('Failed to fetch output via markers');


### PR DESCRIPTION
Only caught now because default scrollback is 1000 and mine is set to 10,000!!!

When a command's output exceeds the terminal scrollback buffer, the start marker gets disposed (line = -1). Previously `getContentsAsText` threw an error, causing the tool to report 'Failed to retrieve command output' with no content.

Now it falls back to reading from line 0 of the buffer, returning whatever remains. The strategies also add an informational note: 'Output exceeded terminal scrollback; beginning of output was lost' so the model knows the output is partial.

Fixes #321667

Before:

<img width="1501" height="566" alt="Screenshot 2026-06-16 at 4 43 53 PM" src="https://github.com/user-attachments/assets/08eab52a-5f2c-4226-a465-46454f44f203" />

After:

<img width="338" height="374" alt="Screenshot 2026-06-16 at 4 41 36 PM" src="https://github.com/user-attachments/assets/511b1956-6c61-4b69-8339-5bcff0528956" />
