### PR TITLE
Add stream-stall telemetry to Anthropic Messages streaming (#321432)

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
@@ -603,6 +603,15 @@ function markLastCacheableBlock(msg: MessageParam, cacheTtl?: '1h'): void {
 	}
 }
 
+/**
+ * How long the Anthropic Messages streaming body may go without producing a
+ * chunk before the idle watchdog considers it stalled and aborts it. The HTTP
+ * layer can return 200 with headers and then hang mid-stream with no further
+ * data and no error (see microsoft/vscode#321432), which would otherwise leave
+ * the `for await` loop pending indefinitely.
+ */
+const ANTHROPIC_STREAM_IDLE_TIMEOUT_MS = 120_000;
+
 export async function processResponseFromMessagesEndpoint(
 	instantiationService: IInstantiationService,
 	telemetryService: ITelemetryService,
@@ -622,6 +631,7 @@ export async function processResponseFromMessagesEndpoint(
 		const ghRequestId = response.headers.get('x-github-request-id') ?? '';
 		const { serverExperiments } = getRequestId(response.headers);
 		const processor = instantiationService.createInstance(AnthropicMessagesProcessor, telemetryData, requestId, ghRequestId, serverExperiments);
+		let completionsEmitted = 0;
 		const parser = new SSEParser((ev) => {
 			try {
 				logService.trace(`[messagesAPI]SSE: ${ev.data}`);
@@ -662,6 +672,7 @@ export async function processResponseFromMessagesEndpoint(
 					}
 					sendEngineMessagesTelemetry(telemetryService, [telemetryMessage], telemetryDataWithUsage, true, logService);
 
+					completionsEmitted++;
 					feed.emitOne(completion);
 				}
 			} catch (e) {
@@ -669,8 +680,63 @@ export async function processResponseFromMessagesEndpoint(
 			}
 		});
 
-		for await (const chunk of response.body) {
-			parser.feed(chunk);
+		// Guard against a stalled streaming body: the response can arrive as 200
+		// with headers and then hang mid-stream with no further chunk and no error
+		// (microsoft/vscode#321432), leaving the `for await` below pending forever.
+		// Reset the watchdog on every chunk; if none arrives within the timeout,
+		// emit telemetry so the stall is observable in the wild and destroy the
+		// stream so the iterator settles instead of hanging.
+		const startTime = Date.now();
+		let lastChunkTime = startTime;
+		let chunksReceived = 0;
+		let idleTimedOut = false;
+		let idleTimer: ReturnType<typeof setTimeout> | undefined;
+		const armIdleTimer = () => {
+			if (idleTimer) {
+				clearTimeout(idleTimer);
+			}
+			idleTimer = setTimeout(() => {
+				idleTimedOut = true;
+				const idleMs = Date.now() - lastChunkTime;
+				logService.error(`[messagesAPI] stream idle for ${idleMs}ms with no chunk — aborting (requestId: ${requestId}, ghRequestId: ${ghRequestId}, completions: ${completionsEmitted})`);
+				/* __GDPR__
+					"messagesApi.streamIdleTimeout" : {
+						"owner": "meganrogge",
+						"comment": "Tracks when the Anthropic Messages streaming response stalls mid-stream with no data and no error and the idle watchdog aborts it (microsoft/vscode#321432).",
+						"requestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "The request id from the response headers, used to correlate with server-side logs." },
+						"ghRequestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "The GitHub request id from the response headers, used to correlate with server-side logs." },
+						"idleMs": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Milliseconds since the last received chunk when the watchdog tripped." },
+						"elapsedMs": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Milliseconds since the stream started when the watchdog tripped." },
+						"chunksReceived": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Number of body chunks received before the stall." },
+						"completionsEmitted": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Number of completions emitted before the stall; 0 means the hang occurred on the first turn, greater than 0 means a mid-stream hang." }
+					}
+				*/
+				telemetryService.sendMSFTTelemetryEvent('messagesApi.streamIdleTimeout',
+					{ requestId, ghRequestId },
+					{ idleMs, elapsedMs: Date.now() - startTime, chunksReceived, completionsEmitted }
+				);
+				feed.reject(new Error(`[messagesAPI] Anthropic stream aborted after idle timeout of ${ANTHROPIC_STREAM_IDLE_TIMEOUT_MS}ms (microsoft/vscode#321432)`));
+				// Cancel the underlying reader so the `for await` below settles.
+				response.body.destroy();
+			}, ANTHROPIC_STREAM_IDLE_TIMEOUT_MS);
+		};
+
+		try {
+			armIdleTimer();
+			for await (const chunk of response.body) {
+				lastChunkTime = Date.now();
+				chunksReceived++;
+				armIdleTimer();
+				parser.feed(chunk);
+			}
+		} catch (e) {
+			if (!idleTimedOut) {
+				feed.reject(e);
+			}
+		} finally {
+			if (idleTimer) {
+				clearTimeout(idleTimer);
+			}
 		}
 	}, async () => {
 		await response.body.destroy();

--- a/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
@@ -611,7 +611,7 @@ function markLastCacheableBlock(msg: MessageParam, cacheTtl?: '1h'): void {
  * For now this only observes the stall so we can measure how often it happens
  * in the wild; it does not abort the request.
  */
-const ANTHROPIC_STREAM_IDLE_TIMEOUT_MS = 120_000;
+const ANTHROPIC_STREAM_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 
 export async function processResponseFromMessagesEndpoint(
 	instantiationService: IInstantiationService,

--- a/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
@@ -700,8 +700,15 @@ export async function processResponseFromMessagesEndpoint(
 				return;
 			}
 			idleTimer = setTimeout(() => {
-				idleReported = true;
 				const idleMs = Date.now() - lastChunkTime;
+				// Guard against an event-loop race: a chunk can arrive and re-arm the
+				// timer at the same tick the previously scheduled callback fires, so a
+				// stale callback may still run after clearTimeout. Re-check the actual
+				// idle time before reporting to avoid a false positive on a healthy stream.
+				if (idleReported || idleMs < ANTHROPIC_STREAM_IDLE_TIMEOUT_MS) {
+					return;
+				}
+				idleReported = true;
 				logService.error(`[messagesAPI] stream idle for ${idleMs}ms with no chunk (requestId: ${requestId}, ghRequestId: ${ghRequestId}, completions: ${completionsEmitted})`);
 				/* __GDPR__
 					"messagesApi.streamIdleTimeout" : {

--- a/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
@@ -605,10 +605,11 @@ function markLastCacheableBlock(msg: MessageParam, cacheTtl?: '1h'): void {
 
 /**
  * How long the Anthropic Messages streaming body may go without producing a
- * chunk before the idle watchdog considers it stalled and aborts it. The HTTP
- * layer can return 200 with headers and then hang mid-stream with no further
- * data and no error (see microsoft/vscode#321432), which would otherwise leave
- * the `for await` loop pending indefinitely.
+ * chunk before the idle watchdog considers it stalled and reports it via
+ * telemetry. The HTTP layer can return 200 with headers and then hang
+ * mid-stream with no further data and no error (see microsoft/vscode#321432).
+ * For now this only observes the stall so we can measure how often it happens
+ * in the wild; it does not abort the request.
  */
 const ANTHROPIC_STREAM_IDLE_TIMEOUT_MS = 120_000;
 
@@ -680,29 +681,32 @@ export async function processResponseFromMessagesEndpoint(
 			}
 		});
 
-		// Guard against a stalled streaming body: the response can arrive as 200
-		// with headers and then hang mid-stream with no further chunk and no error
-		// (microsoft/vscode#321432), leaving the `for await` below pending forever.
-		// Reset the watchdog on every chunk; if none arrives within the timeout,
-		// emit telemetry so the stall is observable in the wild and destroy the
-		// stream so the iterator settles instead of hanging.
+		// Observe a stalled streaming body: the response can arrive as 200 with
+		// headers and then hang mid-stream with no further chunk and no error
+		// (microsoft/vscode#321432). Reset the watchdog on every chunk; if no chunk
+		// arrives within the timeout, emit telemetry once so the stall is
+		// measurable in the wild. This intentionally does not abort the stream —
+		// we only want to observe how often this happens before changing behavior.
 		const startTime = Date.now();
 		let lastChunkTime = startTime;
 		let chunksReceived = 0;
-		let idleTimedOut = false;
+		let idleReported = false;
 		let idleTimer: ReturnType<typeof setTimeout> | undefined;
 		const armIdleTimer = () => {
 			if (idleTimer) {
 				clearTimeout(idleTimer);
 			}
+			if (idleReported) {
+				return;
+			}
 			idleTimer = setTimeout(() => {
-				idleTimedOut = true;
+				idleReported = true;
 				const idleMs = Date.now() - lastChunkTime;
-				logService.error(`[messagesAPI] stream idle for ${idleMs}ms with no chunk — aborting (requestId: ${requestId}, ghRequestId: ${ghRequestId}, completions: ${completionsEmitted})`);
+				logService.error(`[messagesAPI] stream idle for ${idleMs}ms with no chunk (requestId: ${requestId}, ghRequestId: ${ghRequestId}, completions: ${completionsEmitted})`);
 				/* __GDPR__
 					"messagesApi.streamIdleTimeout" : {
 						"owner": "meganrogge",
-						"comment": "Tracks when the Anthropic Messages streaming response stalls mid-stream with no data and no error and the idle watchdog aborts it (microsoft/vscode#321432).",
+						"comment": "Tracks when the Anthropic Messages streaming response stalls mid-stream with no data and no error, so we can measure how often this happens in the wild (microsoft/vscode#321432).",
 						"requestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "The request id from the response headers, used to correlate with server-side logs." },
 						"ghRequestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "The GitHub request id from the response headers, used to correlate with server-side logs." },
 						"idleMs": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Milliseconds since the last received chunk when the watchdog tripped." },
@@ -715,9 +719,6 @@ export async function processResponseFromMessagesEndpoint(
 					{ requestId, ghRequestId },
 					{ idleMs, elapsedMs: Date.now() - startTime, chunksReceived, completionsEmitted }
 				);
-				feed.reject(new Error(`[messagesAPI] Anthropic stream aborted after idle timeout of ${ANTHROPIC_STREAM_IDLE_TIMEOUT_MS}ms (microsoft/vscode#321432)`));
-				// Cancel the underlying reader so the `for await` below settles.
-				response.body.destroy();
 			}, ANTHROPIC_STREAM_IDLE_TIMEOUT_MS);
 		};
 
@@ -728,10 +729,6 @@ export async function processResponseFromMessagesEndpoint(
 				chunksReceived++;
 				armIdleTimer();
 				parser.feed(chunk);
-			}
-		} catch (e) {
-			if (!idleTimedOut) {
-				feed.reject(e);
 			}
 		} finally {
 			if (idleTimer) {


### PR DESCRIPTION
### What

Adds an **observe-only** idle watchdog to `processResponseFromMessagesEndpoint` in `messagesApi.ts` (the Anthropic Messages API path used by `vscode-copilot-cli` with Claude models). It detects when the streaming body stalls and emits a new `messagesApi.streamIdleTimeout` telemetry event. It does **not** change request behavior — the stream is not aborted.

### Why

The streaming-stall class of hang in microsoft/vscode#321432: the HTTP response can return `200` with headers and then **stall mid-stream** — the body iterator (`for await (const chunk of response.body)`) stops producing chunks but never completes and never errors, so the request hangs indefinitely. Today only the success path is instrumented, so when this happens the stall is **invisible in telemetry**.

This was the root cause of 4 of the 6 `X_AGENT_STILL_RESPONDING` timeouts in MSBench run `27640643629` (the others were genuine 60-min budget exhaustion). The stall is environment-agnostic — the eval harness just amplifies its frequency — so it likely affects real users too. We want to **measure how often this happens in the wild first** before changing any request behavior.

### What this change does

- Arms an **idle watchdog** that is reset on every received chunk.
- If no chunk arrives within the window, it emits `messagesApi.streamIdleTimeout` **once** and otherwise leaves the stream untouched.
- The watchdog timer is always cleared in a `finally`.

This is intentionally non-invasive: no abort, no reject, no behavior change. A follow-up can add mitigation once we have data on frequency and shape.

### Telemetry dimensions

`messagesApi.streamIdleTimeout` (classification `SystemMetaData`, purpose `PerformanceAndHealth`):

- `requestId`, `ghRequestId` — correlate with server-side logs
- `idleMs` — ms since the last chunk when the watchdog tripped
- `elapsedMs` — ms since the stream started
- `chunksReceived` — chunks received before the stall
- `completionsEmitted` — completions emitted before the stall (`0` = first-turn hang, `>0` = mid-stream hang)

Related: microsoft/vscode#321640
