### PR TITLE
Gate agent-host Claude in the sessions-window session list on preferAgentHost

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -1370,8 +1370,27 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 
 	getSessions(): ISession[] {
 		this._ensureSessionCache();
-		const sessions: ISession[] = [...this._sessionCache.values()];
-		if (this._pendingSession) {
+		// Filter at read time (rather than evicting from the cache) so a gate
+		// flip is instant in both directions: hidden sessions stay cached and
+		// reappear immediately when the preference flips back. The default gate
+		// admits everything; only the local provider suppresses the agent host's
+		// Claude when the window prefers the extension-host Claude.
+		//
+		// Both `agentProvider` (cached) and `sessionType` (pending) carry the
+		// bare provider name (e.g. `claude`), which is what the gate expects —
+		// NOT the `agent-host-<provider>` resource scheme from
+		// `resourceSchemeForProvider`. Keep it that way.
+		//
+		// Subclasses whose `_shouldAdvertiseAgent` can change at runtime MUST
+		// fire `onDidChangeSessions` when it does, so consumers re-query and
+		// re-filter (see the local provider's `preferAgentHost` listener).
+		const sessions: ISession[] = [];
+		for (const cached of this._sessionCache.values()) {
+			if (this._shouldAdvertiseAgent(cached.agentProvider)) {
+				sessions.push(cached);
+			}
+		}
+		if (this._pendingSession && this._shouldAdvertiseAgent(this._pendingSession.sessionType)) {
 			sessions.push(this._pendingSession);
 		}
 		return sessions;

--- a/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
@@ -138,6 +138,13 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 				if (current && !(current instanceof Error)) {
 					this._syncSessionTypesFromRootState(current);
 				}
+				// `getSessions()` filters by the same gate, so the set of visible
+				// sessions just changed too. Fire an empty-payload change so the
+				// open list re-queries and re-filters. The payload is deliberately
+				// empty: these sessions are hidden, not removed, and signalling
+				// them as `removed` would be misread as a remote deletion (e.g. by
+				// the sessions telemetry contribution).
+				this._onDidChangeSessions.fire({ added: [], removed: [], changed: [] });
 			}
 		}));
 	}
@@ -155,6 +162,12 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 	 * session contribution. Without this, the welcome picker's "Local Agent
 	 * Host" group would list Claude even though the running Claude session is
 	 * served by the extension host — surfacing it twice.
+	 *
+	 * TODO: Remove this override (and the gate it applies in `getSessions()`
+	 * plus the `preferAgentHost` re-fire in the constructor) once the
+	 * extension-host Claude implementation is retired. With the agent host as
+	 * the only Claude there is nothing to disambiguate, so the base default
+	 * (advertise everything) is correct. See {@link shouldSurfaceLocalAgentHostProvider}.
 	 */
 	protected override _shouldAdvertiseAgent(provider: string): boolean {
 		return shouldSurfaceLocalAgentHostProvider(provider, this._configurationService, this._isSessionsWindow);

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -541,6 +541,86 @@ suite('LocalAgentHostSessionsProvider', () => {
 		assert.deepStrictEqual(provider.sessionTypes.map(t => t.id), ['copilotcli', 'claude']);
 	});
 
+	test('getSessions hides agent-host Claude sessions when extension-host Claude is preferred', () => {
+		agentHost.setAgents([
+			{ provider: 'copilotcli', displayName: 'Copilot', description: '', models: [] } as AgentInfo,
+			{ provider: 'claude', displayName: 'Claude', description: '', models: [] } as AgentInfo,
+		]);
+		const configService = new TestConfigurationService();
+		configService.setUserConfiguration(ClaudePreferAgentHostAgentsSettingId, false);
+		const provider = createProvider(disposables, agentHost, undefined, { configurationService: configService, isSessionsWindow: true });
+		fireSessionAdded(agentHost, 'cli-sess', { title: 'CLI', provider: 'copilotcli' });
+		fireSessionAdded(agentHost, 'claude-sess', { title: 'Claude', provider: 'claude' });
+
+		assert.deepStrictEqual(provider.getSessions().map(s => s.sessionType), ['copilotcli']);
+	});
+
+	test('getSessions shows agent-host Claude sessions when agent-host Claude is preferred', () => {
+		agentHost.setAgents([
+			{ provider: 'copilotcli', displayName: 'Copilot', description: '', models: [] } as AgentInfo,
+			{ provider: 'claude', displayName: 'Claude', description: '', models: [] } as AgentInfo,
+		]);
+		const configService = new TestConfigurationService();
+		configService.setUserConfiguration(ClaudePreferAgentHostAgentsSettingId, true);
+		const provider = createProvider(disposables, agentHost, undefined, { configurationService: configService, isSessionsWindow: true });
+		fireSessionAdded(agentHost, 'cli-sess', { title: 'CLI', provider: 'copilotcli' });
+		fireSessionAdded(agentHost, 'claude-sess', { title: 'Claude', provider: 'claude' });
+
+		assert.deepStrictEqual(
+			provider.getSessions().map(s => s.sessionType).sort(),
+			['claude', 'copilotcli'],
+		);
+	});
+
+	test('flipping preferAgentHost reveals agent-host Claude sessions and fires a refresh', () => {
+		agentHost.setAgents([
+			{ provider: 'copilotcli', displayName: 'Copilot', description: '', models: [] } as AgentInfo,
+			{ provider: 'claude', displayName: 'Claude', description: '', models: [] } as AgentInfo,
+		]);
+		const configService = new TestConfigurationService();
+		configService.setUserConfiguration(ClaudePreferAgentHostAgentsSettingId, false);
+		const provider = createProvider(disposables, agentHost, undefined, { configurationService: configService, isSessionsWindow: true });
+		fireSessionAdded(agentHost, 'cli-sess', { title: 'CLI', provider: 'copilotcli' });
+		fireSessionAdded(agentHost, 'claude-sess', { title: 'Claude', provider: 'claude' });
+		assert.deepStrictEqual(provider.getSessions().map(s => s.sessionType), ['copilotcli']);
+
+		let fired = false;
+		disposables.add(provider.onDidChangeSessions(() => { fired = true; }));
+
+		configService.setUserConfiguration(ClaudePreferAgentHostAgentsSettingId, true);
+		fireConfigChange(configService, ClaudePreferAgentHostAgentsSettingId);
+
+		assert.ok(fired, 'onDidChangeSessions should fire so the open list re-queries');
+		assert.deepStrictEqual(
+			provider.getSessions().map(s => s.sessionType).sort(),
+			['claude', 'copilotcli'],
+		);
+	});
+
+	test('flipping preferAgentHost off does not announce hidden sessions as removed', () => {
+		// The list refresh fires an empty-payload change: hidden Claude sessions
+		// are filtered out at read time, not reported as `removed` (which the
+		// sessions telemetry contribution would misread as a remote deletion).
+		agentHost.setAgents([
+			{ provider: 'copilotcli', displayName: 'Copilot', description: '', models: [] } as AgentInfo,
+			{ provider: 'claude', displayName: 'Claude', description: '', models: [] } as AgentInfo,
+		]);
+		const configService = new TestConfigurationService();
+		configService.setUserConfiguration(ClaudePreferAgentHostAgentsSettingId, true);
+		const provider = createProvider(disposables, agentHost, undefined, { configurationService: configService, isSessionsWindow: true });
+		fireSessionAdded(agentHost, 'claude-sess', { title: 'Claude', provider: 'claude' });
+		assert.deepStrictEqual(provider.getSessions().map(s => s.sessionType), ['claude']);
+
+		const removed: string[] = [];
+		disposables.add(provider.onDidChangeSessions(e => removed.push(...e.removed.map(s => s.sessionType))));
+
+		configService.setUserConfiguration(ClaudePreferAgentHostAgentsSettingId, false);
+		fireConfigChange(configService, ClaudePreferAgentHostAgentsSettingId);
+
+		assert.deepStrictEqual(removed, [], 'hidden sessions must not be reported as removed');
+		assert.deepStrictEqual(provider.getSessions().map(s => s.sessionType), []);
+	});
+
 	test('session icons match the session type icon', () => {
 		agentHost.setAgents([
 			{ provider: 'copilotcli', displayName: 'Copilot', description: '', models: [] } as AgentInfo,


### PR DESCRIPTION
Follow-up to #321654. Fixes the second half of microsoft/vscode-internalbacklog#8020.

Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8021

## Problem

#321654 gated the **new-session type picker** on `chat.agents.claude.preferAgentHost`, so Claude no longer appears twice when picking a session target. But the **session list** was still ungated: `BaseAgentHostSessionsProvider.getSessions()` returned every cached session, so the agent host's Claude *sessions* stayed visible even when the window preferred the extension-host Claude — the list showed Claude sessions from both implementations at once.

## Fix

- `baseAgentHostSessionsProvider.ts` — `getSessions()` filters cached sessions (and the pending session) through the existing `_shouldAdvertiseAgent` hook at read time. Filtering at read time (vs. evicting from the cache) makes a preference flip instant and reversible without a re-fetch. Remote hosts inherit the base default (`true`), so they're unaffected.
- `localAgentHostSessionsProvider.ts` — on a `preferAgentHost` flip, fires an empty-payload `onDidChangeSessions` so the open list re-queries and re-filters live. The payload is **deliberately empty**: these sessions are hidden, not removed, and a `removed` delta would be misread as a remote deletion by the sessions telemetry contribution (`deletedRemotely`).

A `TODO` points at all three sites to remove once the extension-host Claude implementation is retired (mirrors the TODO on the shared gate from #321654).

## Test plan

- [x] `npm run typecheck-client` — clean
- [x] 4 new unit tests (hide/show by setting, live reveal on flip, and the telemetry-safety guard "does not announce hidden sessions as removed"). Local suite 90 passing; remote suite 49 passing (unchanged).
- [x] Adversarial review — confirmed the empty-payload reasoning is sound (no consumer breaks on empty delta; active-session-stays-open is acceptable; `agentProvider`/`sessionType` both resolve to `claude`).
- [x] **Live-verified in the real Agents window**: instrumented `getSessions()` at runtime showed 57 agent-host `claude` sessions returning `false` (hidden) when the setting is `false` and `true` (shown) when `true`, flipping live. Picker fix also confirmed visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)