### PR TITLE
Fix agent-host Claude sending reasoning effort to models that reject it

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -96,6 +96,9 @@ function toAgentModelInfo(m: CCAModel, provider: AgentProvider): IAgentModelInfo
 	const multiplier = m.billing?.multiplier;
 	return {
 		provider,
+		// CAPI/endpoint format, dotted version (e.g. `claude-haiku-4.5`) — the
+		// canonical id through `ModelSelection.id`. Convert to SDK format at SDK
+		// seams via `toSdkModelId`.
 		id: m.id,
 		name: m.name,
 		maxContextWindow: m.capabilities?.limits?.max_context_window_tokens,

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
@@ -24,6 +24,7 @@ import { PendingMessage, ChatInputAnswer, ChatInputRequest, ChatInputResponseKin
 import type { Customization, ToolCallResult } from '../../common/state/sessionState.js';
 import { IClaudeAgentSdkService } from './claudeAgentSdkService.js';
 import { buildClientMcpServers, buildOptions } from './claudeSdkOptions.js';
+import { toSdkModelId } from './claudeModelId.js';
 import { buildServerToolMcpServer, CLAUDE_SERVER_TOOL_MCP_SERVER_NAME, serverToolAllowList } from './claudeServerToolMcpServer.js';
 import { ClaudeSessionMetadataStore } from './claudeSessionMetadataStore.js';
 import { convertToolCallResult } from './clientTools/claudeClientToolResult.js';
@@ -305,7 +306,7 @@ export class ClaudeAgentSession extends Disposable {
 		// the user's last-chosen model / effort without losing the picker
 		// config. Read provisional state directly off the session.
 		pipeline.seedCurrentConfig(
-			this._provisionalModel?.id,
+			toSdkModelId(this._provisionalModel?.id),
 			clampEffortForRuntime(resolveClaudeEffort(this._provisionalModel)),
 			permissionMode,
 		);
@@ -526,10 +527,14 @@ export class ClaudeAgentSession extends Disposable {
 			if (requestedEffort === 'max') {
 				this._logService.warn(`[Claude:${this.sessionId}] setModel: 'max' effort clamped to 'xhigh' (Copilot CAPI has no 'max' model yet)`);
 			}
-			await this._pipeline.setModel(model.id);
-			if (runtimeEffort !== undefined) {
-				await this._pipeline.setEffort(runtimeEffort);
-			}
+			await this._pipeline.setModel(toSdkModelId(model.id));
+			// Always push the resolved effort, including `undefined`. Switching
+			// to a model that does not support reasoning effort (e.g. Haiku)
+			// resolves to `undefined`, which must actively CLEAR any effort the
+			// SDK is still applying from a prior effort-capable model — otherwise
+			// the next turn replays e.g. `'high'` onto Haiku and the API 400s
+			// (`output_config.effort ... does not support reasoning effort`).
+			await this._pipeline.setEffort(runtimeEffort);
 		}
 		await this._metadataStore.write(this.sessionUri, { model });
 	}

--- a/src/vs/platform/agentHost/node/claude/claudeModelId.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeModelId.ts
@@ -53,6 +53,24 @@ export function parseClaudeModelId(modelId: string): ParsedClaudeModelId {
 }
 
 /**
+ * Normalize a Claude model ID to the SDK format (dash-separated version, e.g.
+ * `claude-haiku-4-5`). The Claude Agent SDK / CLI only recognizes this form;
+ * given the endpoint format (`claude-haiku-4.5`) it treats the model as unknown
+ * and falls back to a generic feature set (adaptive thinking + reasoning effort)
+ * that the model may not support, producing a 400 from CAPI. Unparseable /
+ * non-Claude IDs pass through unchanged; `undefined` passes through as
+ * `undefined` so callers can normalize an optional model id in one step.
+ */
+export function toSdkModelId(modelId: string): string;
+export function toSdkModelId(modelId: string | undefined): string | undefined;
+export function toSdkModelId(modelId: string | undefined): string | undefined {
+	if (modelId === undefined) {
+		return undefined;
+	}
+	return tryParseClaudeModelId(modelId)?.toSdkModelId() ?? modelId;
+}
+
+/**
  * Attempts to parse a Claude model ID string (SDK or endpoint format) into its components.
  *
  * Accepts either format:

--- a/src/vs/platform/agentHost/node/claude/claudeProxyService.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeProxyService.ts
@@ -446,6 +446,9 @@ export class ClaudeProxyService implements IClaudeProxyService {
 			writeJsonError(res, 404, 'not_found_error', `Unknown model: ${sdkModelId}`);
 			return;
 		}
+		// The SDK/CLI sends the model in SDK format (dashed, `claude-haiku-4-5`);
+		// CAPI's `/v1/messages` expects the endpoint format (dotted,
+		// `claude-haiku-4.5`). Rewrite on the way out.
 		const endpointModelId = parsedModel.toEndpointModelId();
 		body.model = endpointModelId;
 

--- a/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
@@ -14,6 +14,7 @@ import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
 import type { ModelSelection } from '../../common/state/protocol/state.js';
 import { IClaudeAgentSdkService } from './claudeAgentSdkService.js';
 import { buildClientToolMcpServer } from './clientTools/claudeClientToolMcpServer.js';
+import { toSdkModelId } from './claudeModelId.js';
 import { IClaudeProxyHandle } from './claudeProxyService.js';
 import { SessionClientToolsDiff } from './clientTools/claudeSessionClientToolsModel.js';
 
@@ -106,7 +107,7 @@ export async function buildOptions(
 		includePartialMessages: true,
 		forwardSubagentText: true,
 		enableFileCheckpointing: true,
-		model: input.model?.id,
+		model: toSdkModelId(input.model?.id),
 		effort: resolveClaudeEffort(input.model),
 		permissionMode: input.permissionMode,
 		...(input.isResume

--- a/src/vs/platform/agentHost/node/claude/claudeSdkPipeline.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkPipeline.ts
@@ -262,12 +262,19 @@ export class ClaudeSdkPipeline extends Disposable {
 	 * Eagerly push an effort-level change to the SDK via
 	 * `applyFlagSettings({ effortLevel })`. Same mid-turn safety as
 	 * {@link setModel}.
+	 *
+	 * `undefined` means "clear the effort the SDK is currently applying" —
+	 * issued as `applyFlagSettings({ effortLevel: null })` (sdk.d.ts:2263:
+	 * passing `null` clears a key from the flag layer). This is what makes a
+	 * switch to a model that does not support reasoning effort (e.g. Haiku)
+	 * drop a `'high'` left over from a prior effort-capable model instead of
+	 * replaying it onto a model the API will 400 on.
 	 */
-	async setEffort(effort: ClaudeRuntimeEffortLevel): Promise<void> {
+	async setEffort(effort: ClaudeRuntimeEffortLevel | undefined): Promise<void> {
 		this._currentEffort = effort;
 		if (this._query && effort !== this._appliedEffort) {
 			try {
-				await this._query.applyFlagSettings({ effortLevel: effort });
+				await this._query.applyFlagSettings({ effortLevel: effort ?? null });
 				this._appliedEffort = effort;
 			} catch (err) {
 				this._logService.warn(`[ClaudeSdkPipeline:${this.sessionId}] setEffort failed: ${err}`);

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -1397,7 +1397,9 @@ suite('ClaudeAgent', () => {
 			model: sdk.capturedStartupOptions[0]?.model,
 			permissionMode: sdk.capturedStartupOptions[0]?.permissionMode,
 		}, {
-			model: 'claude-sonnet-4.6',
+			// Endpoint id `claude-sonnet-4.6` is normalized to SDK format at the
+			// SDK seam (see `toSdkModelId`); the CLI only recognizes the dashed form.
+			model: 'claude-sonnet-4-6',
 			permissionMode: 'plan',
 		});
 	});
@@ -1430,7 +1432,8 @@ suite('ClaudeAgent', () => {
 			model: sdk.capturedStartupOptions[0]?.model,
 			effort: sdk.capturedStartupOptions[0]?.effort,
 		}, {
-			model: 'claude-opus-4.6',
+			// Endpoint id `claude-opus-4.6` → SDK format at the SDK seam.
+			model: 'claude-opus-4-6',
 			effort: 'high',
 		});
 	});
@@ -4309,7 +4312,7 @@ suite('ClaudeAgent (Phase 9 — runtime mutation surface)', () => {
 		ctx.sdk.nextQueryMessages = [makeSystemInitMessage(sid), makeResultSuccess(sid)];
 		await ctx.agent.sendMessage(created.session, 'hi', undefined, 'turn-1');
 		const opts = ctx.sdk.capturedStartupOptions[0];
-		assert.deepStrictEqual({ model: opts.model, effort: opts.effort }, { model: 'claude-sonnet-4.6', effort: 'medium' });
+		assert.deepStrictEqual({ model: opts.model, effort: opts.effort }, { model: 'claude-sonnet-4-6', effort: 'medium' });
 	});
 
 	test('changeModel on a materialized session queues a model+effort bundle that drains at the next yield boundary', async () => {
@@ -4325,7 +4328,7 @@ suite('ClaudeAgent (Phase 9 — runtime mutation surface)', () => {
 			models: query.recordedModels,
 			efforts: query.recordedFlagSettings.map(s => s.effortLevel),
 		}, {
-			models: ['claude-sonnet-4.6'],
+			models: ['claude-sonnet-4-6'],
 			efforts: ['high'],
 		});
 	});
@@ -4523,7 +4526,7 @@ suite('ClaudeAgent (Phase 9 — runtime mutation surface)', () => {
 		await tick();
 		advance.complete();
 		await p2;
-		assert.deepStrictEqual({ models: firstQuery.recordedModels, efforts: firstQuery.recordedFlagSettings.map(s => s.effortLevel) }, { models: ['claude-sonnet-4.6'], efforts: ['high'] });
+		assert.deepStrictEqual({ models: firstQuery.recordedModels, efforts: firstQuery.recordedFlagSettings.map(s => s.effortLevel) }, { models: ['claude-sonnet-4-6'], efforts: ['high'] });
 
 		// Now abort and resend; the rebound query MUST receive the same
 		// model + effort via the rebind's re-apply pass.
@@ -4536,7 +4539,7 @@ suite('ClaudeAgent (Phase 9 — runtime mutation surface)', () => {
 		assert.deepStrictEqual({
 			models: reboundQuery.recordedModels,
 			efforts: reboundQuery.recordedFlagSettings.map(s => s.effortLevel),
-		}, { models: ['claude-sonnet-4.6'], efforts: ['high'] });
+		}, { models: ['claude-sonnet-4-6'], efforts: ['high'] });
 	});
 
 	test('intermediate result during steering does NOT complete the in-flight sendMessage or fire ChatTurnComplete', async () => {

--- a/src/vs/platform/agentHost/test/node/claudeModelId.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeModelId.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { parseClaudeModelId, tryParseClaudeModelId } from '../../node/claude/claudeModelId.js';
+import { parseClaudeModelId, toSdkModelId, tryParseClaudeModelId } from '../../node/claude/claudeModelId.js';
 
 suite('parseClaudeModelId', () => {
 
@@ -256,6 +256,15 @@ suite('parseClaudeModelId', () => {
 
 		test('is identity for endpoint-format IDs', () => {
 			assert.strictEqual(parseClaudeModelId('claude-haiku-4.5').toEndpointModelId(), 'claude-haiku-4.5');
+		});
+	});
+
+	suite('toSdkModelId (standalone)', () => {
+		test('normalizes endpoint-format Claude IDs to SDK format; passes through SDK-format and non-Claude IDs unchanged', () => {
+			assert.deepStrictEqual(
+				['claude-haiku-4.5', 'claude-opus-4.5', 'claude-haiku-4-5', 'claude-sonnet-4', 'gpt-4o'].map(toSdkModelId),
+				['claude-haiku-4-5', 'claude-opus-4-5', 'claude-haiku-4-5', 'claude-sonnet-4', 'gpt-4o'],
+			);
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/claudeSdkPipeline.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeSdkPipeline.test.ts
@@ -56,7 +56,7 @@ class ImmediatelyDoneQuery implements Query {
 	async return(): Promise<IteratorResult<never, void>> { return { done: true, value: undefined }; }
 	async throw(err: unknown): Promise<IteratorResult<never, void>> { throw err; }
 	async setModel(): Promise<void> { /* not exercised here */ }
-	async applyFlagSettings(): Promise<void> { /* not exercised here */ }
+	async applyFlagSettings(_settings: Parameters<Query['applyFlagSettings']>[0]): Promise<void> { /* not exercised here */ }
 	async setPermissionMode(): Promise<void> { /* not exercised here */ }
 	async interrupt(): Promise<void> { /* not exercised here */ }
 	streamInput(): never { throw new Error('not modeled'); }
@@ -87,6 +87,49 @@ class ImmediatelyDoneQuery implements Query {
 	readMcpResource(): never { throw new Error('not modeled'); }
 }
 
+/**
+ * `WarmQuery` whose bound `Query` records every `applyFlagSettings` call so
+ * tests can assert the exact effort payload pushed to the SDK (including the
+ * `{ effortLevel: null }` clear emitted when switching to a model that does
+ * not support reasoning effort).
+ *
+ * Unlike {@link ImmediatelyDoneQuery}, its async iterator BLOCKS rather than
+ * ending immediately — otherwise the consumer loop would hit "stream ended
+ * without a result", null out `_query`, and the runtime setters would no-op
+ * before the test can observe them. A blocking iterator models a live turn.
+ *
+ * The block is abort-aware: `next()` resolves `{ done: true }` once the
+ * pipeline's {@link AbortController} fires (on dispose/teardown), so the
+ * consumer loop and the fire-and-forget `send()` promise unwind instead of
+ * pinning the pipeline/query graph for the rest of the run.
+ */
+class RecordingQuery extends ImmediatelyDoneQuery {
+	constructor(
+		private readonly _flagSettings: Array<Parameters<Query['applyFlagSettings']>[0]>,
+		private readonly _signal: AbortSignal,
+	) { super(); }
+	override next(): Promise<IteratorResult<never, void>> {
+		if (this._signal.aborted) {
+			return Promise.resolve({ done: true, value: undefined });
+		}
+		return new Promise<IteratorResult<never, void>>(resolve => {
+			this._signal.addEventListener('abort', () => resolve({ done: true, value: undefined }), { once: true });
+		});
+	}
+	override async applyFlagSettings(settings: Parameters<Query['applyFlagSettings']>[0]): Promise<void> { this._flagSettings.push(settings); }
+}
+
+class RecordingWarmQuery extends FakeWarmQuery {
+	readonly flagSettings: Array<Parameters<Query['applyFlagSettings']>[0]> = [];
+
+	constructor(private readonly _signal: AbortSignal) { super(); }
+
+	override query(_prompt: string | AsyncIterable<SDKUserMessage>): Query {
+		this.queryCallCount++;
+		return new RecordingQuery(this.flagSettings, this._signal);
+	}
+}
+
 // ===== Harness =====
 
 interface IPipelineHarness {
@@ -95,9 +138,12 @@ interface IPipelineHarness {
 	readonly controller: AbortController;
 }
 
-function createPipeline(disposables: Pick<DisposableStore, 'add'>): IPipelineHarness {
+function createPipeline(
+	disposables: Pick<DisposableStore, 'add'>,
+	warmOrFactory: FakeWarmQuery | ((signal: AbortSignal) => FakeWarmQuery) = new FakeWarmQuery(),
+): IPipelineHarness {
 	const controller = new AbortController();
-	const warm = new FakeWarmQuery();
+	const warm = typeof warmOrFactory === 'function' ? warmOrFactory(controller.signal) : warmOrFactory;
 	const fileService = disposables.add(new FileService(new NullLogService()));
 	const fs = disposables.add(new InMemoryFileSystemProvider());
 	disposables.add(fileService.registerProvider('file', fs));
@@ -138,6 +184,18 @@ function makePrompt(uuid: string, text: string = uuid): SDKUserMessage {
 function makeUuid(label: string): `${string}-${string}-${string}-${string}-${string}` {
 	const pad = (s: string, n: number) => s.padEnd(n, '0').slice(0, n);
 	return `${pad(label, 8)}-0000-0000-0000-000000000000`;
+}
+
+/**
+ * Let the pipeline's fire-and-forget `send()` run far enough to bind the
+ * Query and finish its synchronous `_replayCurrentConfig` (a no-op when the
+ * seeded config already matches). A few microtask turns is enough; the stub
+ * Query never awaits real I/O.
+ */
+async function flushMicrotasks(): Promise<void> {
+	for (let i = 0; i < 5; i++) {
+		await Promise.resolve();
+	}
 }
 
 suite('ClaudeSdkPipeline', () => {
@@ -323,6 +381,55 @@ suite('ClaudeSdkPipeline', () => {
 			pipeline.send(makePrompt('p1'), 'turn-A').catch(() => { /* expected: stream ends without result */ });
 			await Promise.resolve();
 			assert.strictEqual(warm.queryCallCount, 1);
+		});
+	});
+
+	suite('setEffort', () => {
+
+		// Bind a live Query (send() lazily binds it) seeded as if the session
+		// materialized on an effort-capable model. Returns the recorder so each
+		// test asserts the exact applyFlagSettings payloads pushed afterwards.
+		async function seededHighThenBind(disposables: Pick<DisposableStore, 'add'>): Promise<{ pipeline: ClaudeSdkPipeline; warm: RecordingWarmQuery }> {
+			let warm!: RecordingWarmQuery;
+			const { pipeline } = createPipeline(disposables, signal => (warm = new RecordingWarmQuery(signal)));
+			pipeline.seedCurrentConfig('claude-opus-4-7', 'high', 'default');
+			pipeline.send(makePrompt('p1'), 'turn-A').catch(() => { /* stream ends without result */ });
+			await flushMicrotasks();
+			assert.strictEqual(warm.queryCallCount, 1, 'query should be bound after send');
+			warm.flagSettings.length = 0; // drop any replay from bind; isolate the switch
+			return { pipeline, warm };
+		}
+
+		test('switching to a model with no effort clears the stale effort via applyFlagSettings({ effortLevel: null })', async () => {
+			// Repro of the Haiku 400: a session materialized on Opus applies
+			// effort 'high' at SDK startup; switching to Haiku must CLEAR it, not
+			// leave 'high' to be replayed onto a model the API 400s on.
+			const { pipeline, warm } = await seededHighThenBind(disposables);
+			await pipeline.setEffort(undefined);
+			assert.deepStrictEqual(warm.flagSettings, [{ effortLevel: null }]);
+		});
+
+		test('switching between two effort-capable levels pushes the new value', async () => {
+			const { pipeline, warm } = await seededHighThenBind(disposables);
+			await pipeline.setEffort('low');
+			assert.deepStrictEqual(warm.flagSettings, [{ effortLevel: 'low' }]);
+		});
+
+		test('re-applying the already-applied effort is a no-op (no redundant SDK call)', async () => {
+			const { pipeline, warm } = await seededHighThenBind(disposables);
+			await pipeline.setEffort('high');
+			assert.deepStrictEqual(warm.flagSettings, []);
+		});
+
+		test('clearing an already-clear effort is a no-op', async () => {
+			let warm!: RecordingWarmQuery;
+			const { pipeline } = createPipeline(disposables, signal => (warm = new RecordingWarmQuery(signal)));
+			pipeline.seedCurrentConfig('claude-haiku-4-5', undefined, 'default');
+			pipeline.send(makePrompt('p1'), 'turn-A').catch(() => { /* stream ends without result */ });
+			await flushMicrotasks();
+			warm.flagSettings.length = 0;
+			await pipeline.setEffort(undefined);
+			assert.deepStrictEqual(warm.flagSettings, []);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8031

Fresh agent-host Claude sessions on `claude-haiku-4.5` failed with:

> `400 output_config.effort "high" was provided, but model claude-haiku-4.5 does not support reasoning effort`

**Root cause:** the agent host passed the **CAPI/endpoint** model id (dotted, `claude-haiku-4.5`) straight to the Claude SDK/CLI, but the CLI keys its internal model table by the **SDK** format (dashed, `claude-haiku-4-5`). Given an id it doesn't recognize, the CLI falls back to a generic full-feature request — `thinking: { type: "adaptive" }` + `output_config: { effort: "high" }` — which CAPI rejects for models that don't support reasoning effort. Our own `Options.effort` was already `undefined`; the effort came entirely from the CLI's unknown-model fallback.

## Fix

- Add `toSdkModelId()` and normalize the model id to SDK format at every SDK seam (`buildOptions` startup, runtime `setModel`, pipeline seed). Codename / non-Claude ids pass through unchanged.
- Document the dotted (CAPI/endpoint) vs dashed (SDK) format boundary at the id origin (`claudeAgent.toAgentModelInfo`) and the proxy round-trip (`/v1/messages` rewrite).
- Clear stale runtime effort when switching to a no-effort model (`setEffort(undefined)` → `applyFlagSettings({ effortLevel: null })`).

## Validation

- Standalone repro (Claude Agent SDK + a fake `/v1/messages` capture endpoint, no CAPI): dotted id → `output_config.effort: "high"`; dashed id → no `output_config`, correct `thinking: { type: "enabled" }`.
- 23 unit tests pass (`toSdkModelId` normalization + `ClaudeSdkPipeline` effort suite); clean `tsgo` type-check.

## Test plan

- [ ] In an Agents window with `chat.agents.claude.preferAgentHost: true`, start a Claude session on **Haiku 4.5** and send a message → no 400, model responds.
- [ ] Repeat on an effort-capable model (Opus/Sonnet) → reasoning effort still applied as before.
- [ ] Switch model mid-session from an effort model to Haiku and back → no stale-effort 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)