### PR TITLE
Add os-theme to .moduleignore as it's not used by the CLI

### DIFF
--- a/build/.moduleignore
+++ b/build/.moduleignore
@@ -225,6 +225,10 @@ zone.js/dist/**
 @github/copilot/sharp/**
 @github/copilot/**/keytar.node
 
+# os-theme is pulled in by @github/copilot but the CLI does not use its native addon.
+# See https://github.com/microsoft/vscode-engineering/issues/3087.
+@os-theme/**
+
 # @github/copilot platform binaries - not needed
 @github/copilot-darwin-arm64/**
 @github/copilot-darwin-x64/**

--- a/build/linux/debian/dep-lists.ts
+++ b/build/linux/debian/dep-lists.ts
@@ -112,7 +112,6 @@ export const referenceGeneratedDepsByArch = {
 		'libatspi2.0-0 (>= 2.9.90)',
 		'libc6 (>= 2.17)',
 		'libc6 (>= 2.25)',
-		'libc6 (>= 2.27)',
 		'libc6 (>= 2.28)',
 		'libcairo2 (>= 1.6.0)',
 		'libcurl3-gnutls | libcurl3-nss | libcurl4 | libcurl3',

--- a/build/linux/debian/dep-lists.ts
+++ b/build/linux/debian/dep-lists.ts
@@ -33,7 +33,6 @@ export const referenceGeneratedDepsByArch = {
 		'libc6 (>= 2.17)',
 		'libc6 (>= 2.2.5)',
 		'libc6 (>= 2.25)',
-		'libc6 (>= 2.27)',
 		'libc6 (>= 2.28)',
 		'libc6 (>= 2.4)',
 		'libcairo2 (>= 1.6.0)',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode-engineering/issues/3087