### PR TITLE
Prompt to restart when Claude agent-host settings change

### DIFF
--- a/src/vs/workbench/contrib/relauncher/browser/relauncher.contribution.ts
+++ b/src/vs/workbench/contrib/relauncher/browser/relauncher.contribution.ts
@@ -35,6 +35,7 @@ interface IConfiguration extends IWindowsConfiguration {
 		extensionUnification?: { enabled?: boolean };
 		agentHost?: {
 			enabled?: boolean;
+			claudeAgent?: { enabled?: boolean };
 			otel?: {
 				enabled?: boolean;
 				exporterType?: string;
@@ -44,6 +45,8 @@ interface IConfiguration extends IWindowsConfiguration {
 				dbSpanExporter?: { enabled?: boolean };
 			};
 		};
+		agents?: { claude?: { preferAgentHost?: boolean } };
+		editor?: { claude?: { preferAgentHost?: boolean } };
 	};
 	_extensionsGallery?: { enablePPE?: boolean };
 	accessibility?: { verbosity?: { debug?: boolean } };
@@ -68,6 +71,9 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 		'telemetry.feedback.enabled',
 		'chat.extensionUnification.enabled',
 		'chat.agentHost.enabled',
+		'chat.agentHost.claudeAgent.enabled',
+		'chat.agents.claude.preferAgentHost',
+		'chat.editor.claude.preferAgentHost',
 		'chat.agentHost.otel.enabled',
 		'chat.agentHost.otel.exporterType',
 		'chat.agentHost.otel.otlpEndpoint',
@@ -92,6 +98,9 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 	private readonly telemetryFeedbackEnabled = new ChangeObserver('boolean');
 	private readonly extensionUnificationEnabled = new ChangeObserver('boolean');
 	private readonly agentHostEnabled = new ChangeObserver('boolean');
+	private readonly agentHostClaudeAgentEnabled = new ChangeObserver('boolean');
+	private readonly agentsClaudePreferAgentHost = new ChangeObserver('boolean');
+	private readonly editorClaudePreferAgentHost = new ChangeObserver('boolean');
 	private readonly agentHostOTelEnabled = new ChangeObserver('boolean');
 	private readonly agentHostOTelExporterType = new ChangeObserver('string');
 	private readonly agentHostOTelOtlpEndpoint = new ChangeObserver('string');
@@ -195,6 +204,14 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 
 		// Agent Host
 		processChanged(this.agentHostEnabled.handleChange(config.chat?.agentHost?.enabled));
+
+		// Claude provider registration in the agent host is read at spawn time, and
+		// the two `preferAgentHost` gates pick which Claude implementation surfaces.
+		// Like the agent host child process, these only take effect after a full
+		// app restart.
+		processChanged(this.agentHostClaudeAgentEnabled.handleChange(config.chat?.agentHost?.claudeAgent?.enabled));
+		processChanged(this.agentsClaudePreferAgentHost.handleChange(config.chat?.agents?.claude?.preferAgentHost));
+		processChanged(this.editorClaudePreferAgentHost.handleChange(config.chat?.editor?.claude?.preferAgentHost));
 
 		// Agent Host OTel: settings are forwarded as env vars when the agent host
 		// child process is spawned (see `electronAgentHostStarter.ts`). The child

--- a/src/vs/workbench/contrib/relauncher/test/browser/relauncher.test.ts
+++ b/src/vs/workbench/contrib/relauncher/test/browser/relauncher.test.ts
@@ -1,0 +1,130 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ConfigurationTarget } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { SyncStatus, IUserDataSyncService, IUserDataSyncEnablementService } from '../../../../../platform/userDataSync/common/userDataSync.js';
+import { IUserDataSyncWorkbenchService } from '../../../../services/userDataSync/common/userDataSync.js';
+import { IHostService } from '../../../../services/host/browser/host.js';
+import { SettingsChangeRelauncher } from '../../browser/relauncher.contribution.js';
+
+suite('SettingsChangeRelauncher', () => {
+
+	const disposables = new DisposableStore();
+
+	let restartCount: number;
+	let confirmResult: boolean;
+	let confirmCount: number;
+
+	function createRelauncher(initialConfiguration: Record<string, unknown>): TestConfigurationService {
+		// `update()` reads `config.window.titleBarStyle` unconditionally on native, so
+		// the `window` object must always be present on the configuration root.
+		initialConfiguration.window ??= {};
+		const configurationService = new TestConfigurationService(initialConfiguration);
+
+		const hostService = { hasFocus: true, restart: async () => { restartCount++; } } as Partial<IHostService> as IHostService;
+		const dialogService = { confirm: async () => { confirmCount++; return { confirmed: confirmResult }; } } as Partial<IDialogService> as IDialogService;
+		const userDataSyncService = { status: SyncStatus.Idle } as Partial<IUserDataSyncService> as IUserDataSyncService;
+		const userDataSyncEnablementService = { isEnabled: () => true } as Partial<IUserDataSyncEnablementService> as IUserDataSyncEnablementService;
+		const userDataSyncWorkbenchService = { onDidTurnOnSync: Event.None } as Partial<IUserDataSyncWorkbenchService> as IUserDataSyncWorkbenchService;
+		const productService = { nameLong: 'Test Product' } as Partial<IProductService> as IProductService;
+
+		disposables.add(new SettingsChangeRelauncher(hostService, configurationService, userDataSyncService, userDataSyncEnablementService, userDataSyncWorkbenchService, productService, dialogService));
+
+		return configurationService;
+	}
+
+	function fireChange(configurationService: TestConfigurationService, key: string, source = ConfigurationTarget.USER): void {
+		configurationService.onDidChangeConfigurationEmitter.fire({
+			source,
+			affectedKeys: new Set([key]),
+			change: { keys: [key], overrides: [] },
+			affectsConfiguration: (configuration: string) => configuration === key,
+		});
+	}
+
+	async function changeSetting<T extends Record<string, unknown>>(key: string, createConfiguration: () => T, applyChange: (configuration: T) => void, source = ConfigurationTarget.USER): Promise<void> {
+		const configuration = createConfiguration();
+		const configurationService = createRelauncher(configuration);
+
+		applyChange(configuration);
+		fireChange(configurationService, key, source);
+		await Promise.resolve();
+	}
+
+	setup(() => {
+		restartCount = 0;
+		confirmCount = 0;
+		confirmResult = false;
+	});
+
+	teardown(() => {
+		disposables.clear();
+	});
+
+	test('prompts to restart when chat.agentHost.claudeAgent.enabled changes', async () => {
+		confirmResult = true;
+		await changeSetting(
+			'chat.agentHost.claudeAgent.enabled',
+			() => ({ chat: { agentHost: { claudeAgent: { enabled: true } } } }),
+			c => c.chat.agentHost.claudeAgent.enabled = false);
+
+		assert.strictEqual(confirmCount, 1, 'should prompt to restart');
+		assert.strictEqual(restartCount, 1, 'should restart when confirmed');
+	});
+
+	test('prompts to restart when chat.agents.claude.preferAgentHost changes', async () => {
+		confirmResult = true;
+		await changeSetting(
+			'chat.agents.claude.preferAgentHost',
+			() => ({ chat: { agents: { claude: { preferAgentHost: true } } } }),
+			c => c.chat.agents.claude.preferAgentHost = false);
+
+		assert.strictEqual(confirmCount, 1, 'should prompt to restart');
+		assert.strictEqual(restartCount, 1, 'should restart when confirmed');
+	});
+
+	test('prompts to restart when chat.editor.claude.preferAgentHost changes', async () => {
+		confirmResult = true;
+		await changeSetting(
+			'chat.editor.claude.preferAgentHost',
+			() => ({ chat: { editor: { claude: { preferAgentHost: true } } } }),
+			c => c.chat.editor.claude.preferAgentHost = false);
+
+		assert.strictEqual(confirmCount, 1, 'should prompt to restart');
+		assert.strictEqual(restartCount, 1, 'should restart when confirmed');
+	});
+
+	test('does not restart when the confirmation is declined', async () => {
+		confirmResult = false;
+		await changeSetting(
+			'chat.agentHost.claudeAgent.enabled',
+			() => ({ chat: { agentHost: { claudeAgent: { enabled: true } } } }),
+			c => c.chat.agentHost.claudeAgent.enabled = false);
+
+		assert.strictEqual(confirmCount, 1, 'should prompt to restart');
+		assert.strictEqual(restartCount, 0, 'should not restart when declined');
+	});
+
+	test('does not prompt when only the default value changes', async () => {
+		confirmResult = true;
+		await changeSetting(
+			'chat.agentHost.claudeAgent.enabled',
+			() => ({ chat: { agentHost: { claudeAgent: { enabled: true } } } }),
+			c => c.chat.agentHost.claudeAgent.enabled = false,
+			ConfigurationTarget.DEFAULT);
+
+		assert.strictEqual(confirmCount, 0, 'should not prompt for default changes');
+		assert.strictEqual(restartCount, 0);
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+});


### PR DESCRIPTION
## What

Wires three Claude agent-host settings into the existing `SettingsChangeRelauncher` so that changing any of them prompts the user to restart, matching the behavior already in place for `chat.agentHost.enabled`:

- `chat.agentHost.claudeAgent.enabled`
- `chat.agents.claude.preferAgentHost`
- `chat.editor.claude.preferAgentHost`

## Why

These settings only take effect after the agent host process re-spawns (the host is owned by the main process and is not respawned on a plain window reload), so a full restart is required for changes to apply. Previously toggling them silently had no effect until the next manual restart.

## How

- Added the three keys to `SettingsChangeRelauncher.SETTINGS`, with matching `ChangeObserver`s and `processChanged(...)` calls in `update()`.
- Extended the local `IConfiguration` interface (`chat.agentHost.claudeAgent`, `chat.agents.claude`, `chat.editor.claude`).
- Uses the existing `dialogService.confirm` → `hostService.restart()` path (native restart / web reload).

## Tests

Adds `relauncher.test.ts` (previously no test coverage for this contribution): asserts each of the three settings prompts + restarts on confirm, no restart when declined, and no prompt for `ConfigurationTarget.DEFAULT` changes. Manually verified end-to-end via the launch skill as well.