### PR TITLE
completions: fix: don't hide focused suggest item when quickSuggestions is offWhenInlineCompletions

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/suggestWidgetAdapter.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/suggestWidgetAdapter.ts
@@ -20,7 +20,6 @@ import { CompletionItem } from '../../../suggest/browser/suggest.js';
 import { SuggestController } from '../../../suggest/browser/suggestController.js';
 import { ObservableCodeEditor } from '../../../../browser/observableCodeEditor.js';
 import { observableFromEvent } from '../../../../../base/common/observable.js';
-import { EditorOption } from '../../../../common/config/editorOptions.js';
 
 export class SuggestWidgetAdaptor extends Disposable {
 	private isSuggestWidgetVisible: boolean = false;
@@ -147,17 +146,6 @@ export class SuggestWidgetAdaptor extends Disposable {
 	private getSuggestItemInfo(): SuggestItemInfo | undefined {
 		const suggestController = SuggestController.get(this.editor);
 		if (!suggestController || !this.isSuggestWidgetVisible) {
-			return undefined;
-		}
-
-		// When offWhenInlineCompletions is active, don't expose the selected
-		// suggest item to the inline completions model so that it does not
-		// trigger an inline completion request while the suggest widget is open
-		const quickSuggestions = this.editor.getOption(EditorOption.quickSuggestions);
-		if (typeof quickSuggestions === 'object'
-			&& (quickSuggestions.other === 'offWhenInlineCompletions'
-				|| quickSuggestions.comments === 'offWhenInlineCompletions'
-				|| quickSuggestions.strings === 'offWhenInlineCompletions')) {
 			return undefined;
 		}
 

--- a/src/vs/editor/contrib/inlineCompletions/test/browser/suggestWidgetModel.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/browser/suggestWidgetModel.test.ts
@@ -9,7 +9,7 @@ import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
 import { Range } from '../../../../common/core/range.js';
-import { CompletionItemKind, CompletionItemProvider } from '../../../../common/languages.js';
+import { CompletionItemKind, CompletionItemProvider, InlineCompletionsProvider } from '../../../../common/languages.js';
 import { IEditorWorkerService } from '../../../../common/services/editorWorker.js';
 import { ViewModel } from '../../../../common/viewModel/viewModelImpl.js';
 import { GhostTextContext } from './utils.js';
@@ -107,6 +107,36 @@ suite('Suggest Widget Model', () => {
 			}
 		);
 	});
+
+	test('offWhenInlineCompletions: conflicting inline completion does not render over the suggest widget', async () => {
+		// An inline completion that does not augment the suggest item ("hello") => a conflict.
+		const inlineProvider: InlineCompletionsProvider = {
+			provideInlineCompletions: () => ({ items: [{ insertText: 'hi there', range: new Range(1, 1, 1, 2) }] }),
+			disposeInlineCompletions: () => { },
+		};
+		await withAsyncTestCodeEditorAndInlineCompletionsModel('',
+			{
+				fakeClock: true,
+				provider,
+				inlineProvider,
+				quickSuggestions: { other: 'offWhenInlineCompletions', comments: 'off', strings: 'off' },
+			},
+			async ({ editor, context, model }) => {
+				context.keyboardType('h');
+				const suggestController = (editor.getContribution(SuggestController.ID) as SuggestController);
+				suggestController.triggerSuggest();
+				model.triggerExplicitly();
+				await timeout(1000);
+
+				// Regression guard: the focused suggest item must be exposed to the inline model
+				// even when quickSuggestions is offWhenInlineCompletions...
+				assert.strictEqual(!!model.debugGetSelectedSuggestItem().get(), true);
+				// ...so the conflicting inline completion is suppressed instead of rendered over the
+				// widget: no ghost text ever shows, so the view stays at its initial empty state.
+				assert.deepStrictEqual(context.getAndClearViewStates(), ['']);
+			}
+		);
+	});
 });
 
 const provider: CompletionItemProvider = {
@@ -132,7 +162,7 @@ const provider: CompletionItemProvider = {
 
 async function withAsyncTestCodeEditorAndInlineCompletionsModel(
 	text: string,
-	options: TestCodeEditorInstantiationOptions & { provider?: CompletionItemProvider; fakeClock?: boolean; serviceCollection?: never },
+	options: TestCodeEditorInstantiationOptions & { provider?: CompletionItemProvider; inlineProvider?: InlineCompletionsProvider; fakeClock?: boolean; serviceCollection?: never },
 	callback: (args: { editor: ITestCodeEditor; editorViewModel: ViewModel; model: InlineCompletionsModel; context: GhostTextContext }) => Promise<void>
 ): Promise<void> {
 	await runWithFakedTimers({ useFakeTimers: options.fakeClock }, async () => {
@@ -175,10 +205,15 @@ async function withAsyncTestCodeEditorAndInlineCompletionsModel(
 				}],
 			);
 
-			if (options.provider) {
+			if (options.provider || options.inlineProvider) {
 				const languageFeaturesService = new LanguageFeaturesService();
 				serviceCollection.set(ILanguageFeaturesService, languageFeaturesService);
-				disposableStore.add(languageFeaturesService.completionProvider.register({ pattern: '**' }, options.provider));
+				if (options.provider) {
+					disposableStore.add(languageFeaturesService.completionProvider.register({ pattern: '**' }, options.provider));
+				}
+				if (options.inlineProvider) {
+					disposableStore.add(languageFeaturesService.inlineCompletionsProvider.register({ pattern: '**' }, options.inlineProvider));
+				}
 			}
 
 			await withAsyncTestCodeEditor(text, { ...options, serviceCollection }, async (editor, editorViewModel, instantiationService) => {


### PR DESCRIPTION
Fixes a regression where inline-completion **ghost text could render on top of the suggest widget** when `editor.quickSuggestions` is `offWhenInlineCompletions` — e.g. typing `this.` opens the suggest widget with `add` focused while ghost text such as `validateNumber(...)` is drawn over it.

## Root cause

`offWhenInlineCompletions` was introduced in #300371. Its intended effect — not auto-popping the suggest widget while inline completions are showing — lives in `SuggestModel._waitForInlineCompletionsAndTrigger`. But the same PR also added an early-return in `SuggestWidgetAdaptor.getSuggestItemInfo()`:

```ts
// When offWhenInlineCompletions is active, don't expose the selected
// suggest item to the inline completions model ...
const quickSuggestions = this.editor.getOption(EditorOption.quickSuggestions);
if (typeof quickSuggestions === 'object'
    && (quickSuggestions.other === 'offWhenInlineCompletions'
        || quickSuggestions.comments === 'offWhenInlineCompletions'
        || quickSuggestions.strings === 'offWhenInlineCompletions')) {
    return undefined;
}
```

This returns `undefined` **even while the suggest widget is visible with a focused item**, so the focused item never reaches `InlineCompletionsModel._selectedSuggestItem`. With no selected suggest item, the model's `state` derived takes the "show the inline completion independently" branch instead of the augmentation / conflict-suppression branch — and the ghost text is drawn over the widget.

The bug stayed latent until #316900 made `offWhenInlineCompletions` the default; it is also reachable via the `quickSuggestions` experiment or a manual setting.

## Fix

Remove the early-return (and its now-unused `EditorOption` import). The focused suggest item is exposed to the inline model again, so the existing logic handles both cases:

- the inline completion **augments** the focused item → shown as a consistent preview;
- the inline completion **conflicts** with the focused item → `_computeAugmentation` returns nothing and the ghost text is suppressed (no overlap).

## Why this is correct

`offWhenInlineCompletions` only governs the **auto quick-suggest popup while typing**, which is handled entirely in `SuggestModel` — not in this adapter:

1. **Plain typing** (the scenario from #316899): the widget is suppressed, so `isSuggestWidgetVisible` is `false` and `getSuggestItemInfo()` already returns `undefined` via its *first* guard (`!this.isSuggestWidgetVisible`). The removed block had no effect here — inline completions stay unconstrained.
2. **Trigger character (`.`) / `Ctrl+Space`**: these explicitly open the widget regardless of the setting (as noted in #316899). Exposing the focused item is exactly what re-enables conflict suppression / augmentation — restoring the pre-#300371 behavior.

The removed guard was also over-broad: it fired if *any* of `other` / `comments` / `strings` was `offWhenInlineCompletions`, ignoring the token type at the cursor.

## Resulting behavior

1. Non-trigger characters do not pop the suggest widget over inline completions — e.g. typing `cons` shows ghost text rather than the suggest widget.
2. Trigger characters update the ghost text based on the selected item — e.g. typing `this.` shows the suggest widget and the ghost text is augmented with the focused suggest item (or suppressed when it conflicts).

## Test

Adds a regression test in `suggestWidgetModel.test.ts`: with `quickSuggestions.other: 'offWhenInlineCompletions'` and the widget visible with a focused item, a conflicting inline completion is suppressed (no ghost text rendered) and the focused suggest item is exposed to the model. Confirmed it fails without the fix.


cc @alexdima @hediet 
