### PR TITLE
fix: improve changeset reconciliation performance in Agents window

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostChangesetConstants.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostChangesetConstants.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Minimum interval between changeset-driven UI recomputes. While an agent
+ * edits, the host streams many changeset envelopes per second; coalescing them
+ * to ~10 updates/second keeps the Changes view responsive without perceptible
+ * lag, and stops every envelope from forcing a full list relayout.
+ */
+export const CHANGESET_UPDATE_THROTTLE_MS = 100;

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostDiffs.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostDiffs.ts
@@ -29,43 +29,59 @@ export function mapProtocolStatus(protocol: ProtocolSessionStatus): SessionStatu
 }
 
 /**
+ * Converts a single agent host diff into the chat session file change
+ * format, or `undefined` when the diff carries no usable URI.
+ *
+ * @param mapUri Optional URI mapper applied after parsing. The remote agent
+ *   host provider uses this to rewrite `file:` URIs into agent-host URIs.
+ */
+export function diffToChange(d: ISessionFileDiff, mapUri?: (uri: URI) => URI): IChatSessionFileChange2 | undefined {
+	const rawUri = d.after?.uri ?? d.before?.uri;
+	if (!rawUri) {
+		return undefined;
+	}
+
+	const parseAndMap = (raw: string): URI => {
+		const parsed = URI.parse(raw);
+		return mapUri ? mapUri(parsed) : parsed;
+	};
+
+	const uri = parseAndMap(rawUri);
+
+	// For deletions (no `after`), `modifiedUri` is `undefined` so the
+	// renderer treats the entry as a deletion and doesn't try to open the
+	// (now-missing) file as the "modified" side of the diff editor.
+	const modifiedUri = d.after ? parseAndMap(d.after.uri) : undefined;
+
+	// Use the before-content reference URI so the diff editor can
+	// fetch the snapshot of the file *before* the session's edits.
+	const originalUri = d.before?.content?.uri ? parseAndMap(d.before.content.uri) : undefined;
+
+	return {
+		uri,
+		modifiedUri,
+		originalUri,
+		insertions: d.diff?.added ?? 0,
+		deletions: d.diff?.removed ?? 0,
+	} satisfies IChatSessionFileChange2;
+}
+
+/**
+ * Converts a single {@link ChangesetFile} into a {@link IChatSessionFileChange2},
+ * or `undefined` when the underlying diff has no usable URI.
+ */
+export function changesetFileToChange(file: ChangesetFile, mapUri?: (uri: URI) => URI): IChatSessionFileChange2 | undefined {
+	return diffToChange(file.edit, mapUri);
+}
+
+/**
  * Converts agent host diffs to the chat session file change format.
  *
  * @param mapUri Optional URI mapper applied after parsing. The remote agent
  *   host provider uses this to rewrite `file:` URIs into agent-host URIs.
  */
 export function diffsToChanges(diffs: readonly ISessionFileDiff[], mapUri?: (uri: URI) => URI): IChatSessionFileChange2[] {
-	return diffs.map(d => {
-		const rawUri = d.after?.uri ?? d.before?.uri;
-		if (!rawUri) {
-			return undefined;
-		}
-
-		const uri = mapUri ? mapUri(URI.parse(rawUri)) : URI.parse(rawUri);
-
-		// For deletions (no `after`), `modifiedUri` is `undefined` so the
-		// renderer treats the entry as a deletion and doesn't try to open the
-		// (now-missing) file as the "modified" side of the diff editor.
-		const modifiedUri = d.after
-			? (mapUri ? mapUri(URI.parse(d.after.uri)) : URI.parse(d.after.uri))
-			: undefined;
-
-		// Use the before-content reference URI so the diff editor can
-		// fetch the snapshot of the file *before* the session's edits.
-		let originalUri: URI | undefined;
-		if (d.before?.content?.uri) {
-			const parsed = URI.parse(d.before.content.uri);
-			originalUri = mapUri ? mapUri(parsed) : parsed;
-		}
-
-		return {
-			uri,
-			modifiedUri,
-			originalUri,
-			insertions: d.diff?.added ?? 0,
-			deletions: d.diff?.removed ?? 0,
-		} satisfies IChatSessionFileChange2;
-	}).filter(isDefined);
+	return diffs.map(d => diffToChange(d, mapUri)).filter(isDefined);
 }
 
 /**

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionChangesets.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionChangesets.ts
@@ -4,19 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
-import { constObservable, derived, derivedObservableWithCache, derivedOpts, IObservable, observableFromEvent, observableValue } from '../../../../../base/common/observable.js';
+import { constObservable, derived, derivedObservableWithCache, derivedOpts, IObservable, mapObservableArrayCached, observableFromEvent, observableValue, throttledObservable } from '../../../../../base/common/observable.js';
 import { basename, isEqual } from '../../../../../base/common/resources.js';
 import { format } from '../../../../../base/common/strings.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { isDefined } from '../../../../../base/common/types.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
 import { ChangesetOperationTargetKind } from '../../../../../platform/agentHost/common/state/protocol/channels-changeset/commands.js';
-import { ChangesetOperation, ChangesetOperationScope } from '../../../../../platform/agentHost/common/state/protocol/state.js';
+import { ChangesetOperation, ChangesetOperationScope, type ChangesetFile } from '../../../../../platform/agentHost/common/state/protocol/state.js';
 import { buildDefaultChatUri, ChangesetStatus, Changeset, StateComponents, type ChangesetState, type ChatState, type ChatSummary, type SessionState } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { ISessionChangeset, ISessionChangesetOperation, ISessionChangesetOperationTarget, ISessionFileChange, SessionChangesetOperationScope, sessionFileChangesEqual } from '../../../../services/sessions/common/session.js';
-import { changesetFilesToChanges } from './agentHostDiffs.js';
-import { IAgentHostAdapterOptions } from './baseAgentHostSessionsProvider.js';
+import { changesetFileToChange } from './agentHostDiffs.js';
+import { CHANGESET_UPDATE_THROTTLE_MS, IAgentHostAdapterOptions } from './baseAgentHostSessionsProvider.js';
 
 const enum ChangesetKind {
 	Branch = 'branch',
@@ -165,8 +166,21 @@ abstract class AbstractAgentHostChangeset implements ISessionChangeset {
 			return changesetState.status === ChangesetStatus.Computing && changesetState.files.length === 0;
 		});
 
-		const changesObs = derivedObservableWithCache<readonly ISessionFileChange[] | undefined>(this, (reader, lastValue) => {
-			const changesetState = this.changesetStateObs.read(reader).read(reader);
+		const mapDiffUri = this._options.mapDiffUri;
+
+		// Throttle only the changes path; `isLoadingChanges` and `operations`
+		// keep reading `this.changesetStateObs` directly so spinners/buttons stay
+		// responsive. Throttle (not debounce) so a continuous stream keeps
+		// updating instead of starving until edits stop. The `derived` wrapper
+		// defers reading the abstract `changesetStateObs` until the observable is
+		// actually observed (it isn't assigned yet during base construction).
+		const throttledChangesetValueObs = throttledObservable(derived(reader => this.changesetStateObs.read(reader).read(reader)), CHANGESET_UPDATE_THROTTLE_MS);
+
+		// Hold the raw `ChangesetFile[]` (with last-value semantics) so unchanged
+		// files keep their reference across reducer updates, enabling the
+		// per-file cache below to skip rebuilding them.
+		const changesetFilesObs = derivedObservableWithCache<readonly ChangesetFile[] | undefined>(this, (reader, lastValue) => {
+			const changesetState = throttledChangesetValueObs.read(reader);
 			if (changesetState === null || changesetState instanceof Error) {
 				return [];
 			}
@@ -182,15 +196,20 @@ abstract class AbstractAgentHostChangeset implements ISessionChangeset {
 				return lastValue;
 			}
 
-			const files = changesetFilesToChanges(changesetState.files);
-			return this._options.mapDiffUri
-				? files.map(f => ({
-					...f,
-					uri: this._options.mapDiffUri!(f.uri),
-					originalUri: f.originalUri ? this._options.mapDiffUri!(f.originalUri) : undefined,
-					modifiedUri: f.modifiedUri ? this._options.mapDiffUri!(f.modifiedUri) : undefined,
-				}))
-				: files;
+			return changesetState.files;
+		});
+
+		// Build one change per file, reusing the cached result for files whose
+		// `ChangesetFile` reference is unchanged so only changed files are
+		// re-parsed and re-mapped.
+		const mappedChangesObs = mapObservableArrayCached(this, changesetFilesObs.map(files => files ?? []), file => changesetFileToChange(file, mapDiffUri));
+
+		const changesObs = derived<readonly ISessionFileChange[] | undefined>(this, reader => {
+			const files = changesetFilesObs.read(reader);
+			if (files === undefined) {
+				return undefined;
+			}
+			return mappedChangesObs.read(reader).filter(isDefined);
 		});
 
 		this.changes = derivedOpts({ equalsFn: sessionFileChangesEqual }, reader => {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionChangesets.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionChangesets.ts
@@ -16,8 +16,9 @@ import { ChangesetOperation, ChangesetOperationScope, type ChangesetFile } from 
 import { buildDefaultChatUri, ChangesetStatus, Changeset, StateComponents, type ChangesetState, type ChatState, type ChatSummary, type SessionState } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { ISessionChangeset, ISessionChangesetOperation, ISessionChangesetOperationTarget, ISessionFileChange, SessionChangesetOperationScope, sessionFileChangesEqual } from '../../../../services/sessions/common/session.js';
+import { CHANGESET_UPDATE_THROTTLE_MS } from './agentHostChangesetConstants.js';
 import { changesetFileToChange } from './agentHostDiffs.js';
-import { CHANGESET_UPDATE_THROTTLE_MS, IAgentHostAdapterOptions } from './baseAgentHostSessionsProvider.js';
+import { IAgentHostAdapterOptions } from './baseAgentHostSessionsProvider.js';
 
 const enum ChangesetKind {
 	Branch = 'branch',

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -11,9 +11,10 @@ import { Emitter, Event } from '../../../../../base/common/event.js';
 import { IMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableMap, DisposableStore, IDisposable, IReference, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { equals } from '../../../../../base/common/objects.js';
-import { constObservable, derived, derivedObservableWithCache, derivedOpts, IObservable, ISettableObservable, observableFromEvent, observableFromPromise, observableValue, observableValueOpts, transaction } from '../../../../../base/common/observable.js';
+import { constObservable, derived, derivedObservableWithCache, derivedOpts, IObservable, ISettableObservable, mapObservableArrayCached, observableFromEvent, observableFromPromise, observableValue, observableValueOpts, throttledObservable, transaction } from '../../../../../base/common/observable.js';
 import { isEqual } from '../../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { isDefined } from '../../../../../base/common/types.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
 import { localize } from '../../../../../nls.js';
@@ -24,7 +25,7 @@ import { getEffectiveAgents } from '../../../../../platform/agentHost/common/cus
 import { KNOWN_AUTO_APPROVE_VALUES, SessionConfigKey } from '../../../../../platform/agentHost/common/sessionConfigKeys.js';
 import type { IAgentSubscription } from '../../../../../platform/agentHost/common/state/agentSubscription.js';
 import { ResolveSessionConfigResult } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
-import { AgentCustomization, AgentSelection, ChangesSummary, Customization, CustomizationType, ModelSelection, SessionStatus as ProtocolSessionStatus, RootConfigState, RootState, SessionActiveClient, SessionState, SessionSummary, type Changeset } from '../../../../../platform/agentHost/common/state/protocol/state.js';
+import { AgentCustomization, AgentSelection, ChangesSummary, type ChangesetFile, Customization, CustomizationType, ModelSelection, SessionStatus as ProtocolSessionStatus, RootConfigState, RootState, SessionActiveClient, SessionState, SessionSummary, type Changeset } from '../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ActionType, isChatAction, isSessionAction, NotificationType } from '../../../../../platform/agentHost/common/state/sessionActions.js';
 import { AgentInfo, readSessionGitState, ROOT_STATE_URI, SessionMeta, StateComponents, type ISessionGitState } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -45,11 +46,19 @@ import { ISessionsService } from '../../../../services/sessions/browser/sessions
 import { ISendRequestOptions, ISessionChangeEvent, ISessionModelPickerOptions } from '../../../../services/sessions/common/sessionsProvider.js';
 import { IGitHubService } from '../../../github/browser/githubService.js';
 import { computePullRequestIcon } from '../../../github/common/types.js';
-import { changesetFilesToChanges, mapProtocolStatus } from './agentHostDiffs.js';
+import { changesetFileToChange, mapProtocolStatus } from './agentHostDiffs.js';
 import { createChangesets } from './agentHostSessionChangesets.js';
 
 const STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES = 'sessions.agentHost.sessionConfigPicker.selectedValues';
 const UNSAFE_SESSION_CONFIG_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * Minimum interval between changeset-driven UI recomputes. While an agent
+ * edits, the host streams many changeset envelopes per second; coalescing them
+ * to ~10 updates/second keeps the Changes view responsive without perceptible
+ * lag, and stops every envelope from forcing a full list relayout.
+ */
+export const CHANGESET_UPDATE_THROTTLE_MS = 100;
 
 function isSafeSessionConfigKey(property: string): boolean {
 	return !UNSAFE_SESSION_CONFIG_KEYS.has(property);
@@ -373,28 +382,45 @@ export class AgentHostSessionAdapter implements ISession {
 			return observableFromEvent(subscriptionRef.object.onDidChange, () => subscriptionRef.object.value);
 		});
 
-		const changesetChangesObs = derivedObservableWithCache<readonly (IChatSessionFileChange | IChatSessionFileChange2)[] | undefined>(this, (reader, lastValue) => {
+		const mapDiffUri = this._options.mapDiffUri;
+
+		// Coalesce the per-envelope changeset stream. `sessionChangesetStateObs`
+		// is a nested observable (which-subscription → value); flatten it to the
+		// value stream, then throttle. Throttle (not debounce) so a continuous
+		// stream keeps updating ~10x/s instead of starving until edits stop; the
+		// trailing read always delivers the final state.
+		const throttledChangesetValueObs = throttledObservable(sessionChangesetStateObs.flatten(), CHANGESET_UPDATE_THROTTLE_MS);
+
+		// Hold the raw `ChangesetFile[]` (with last-value semantics) rather than
+		// the mapped changes. The changeset reducer preserves the reference of
+		// every file that didn't change, so keeping the raw list lets the
+		// per-file cache below skip rebuilding them.
+		const changesetFilesObs = derivedObservableWithCache<readonly ChangesetFile[] | undefined>(this, (reader, lastValue) => {
 			const isActiveSession = this.isActiveSessionObs.read(reader);
 			if (!isActiveSession) {
 				return lastValue;
 			}
 
-			const branchChangesState = sessionChangesetStateObs.read(reader)?.read(reader);
+			const branchChangesState = throttledChangesetValueObs.read(reader);
 			if (!branchChangesState || branchChangesState instanceof Error || branchChangesState.status !== 'ready') {
 				return lastValue;
 			}
 
-			const mapDiffUri = this._options.mapDiffUri;
-			const files = changesetFilesToChanges(branchChangesState.files);
+			return branchChangesState.files;
+		});
 
-			const mapped = mapDiffUri ? files.map(f => ({
-				...f,
-				uri: mapDiffUri(f.uri),
-				originalUri: f.originalUri ? mapDiffUri(f.originalUri) : undefined,
-				modifiedUri: f.modifiedUri ? mapDiffUri(f.modifiedUri) : undefined,
-			})) : files;
+		// Build one change per file, reusing the cached result for files whose
+		// `ChangesetFile` reference is unchanged. Only the file(s) that actually
+		// changed get re-parsed and re-mapped, turning the previous O(all files)
+		// URI work per update into O(changed files).
+		const mappedChangesObs = mapObservableArrayCached(this, changesetFilesObs.map(files => files ?? []), file => changesetFileToChange(file, mapDiffUri));
 
-			return mapped;
+		const changesetChangesObs = derived<readonly (IChatSessionFileChange | IChatSessionFileChange2)[] | undefined>(this, reader => {
+			const files = changesetFilesObs.read(reader);
+			if (files === undefined) {
+				return undefined;
+			}
+			return mappedChangesObs.read(reader).filter(isDefined);
 		});
 
 		const changesetSummaryObs = derivedOpts<ISessionChangesSummary | undefined>({ equalsFn: structuralEquals }, reader => {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -46,19 +46,12 @@ import { ISessionsService } from '../../../../services/sessions/browser/sessions
 import { ISendRequestOptions, ISessionChangeEvent, ISessionModelPickerOptions } from '../../../../services/sessions/common/sessionsProvider.js';
 import { IGitHubService } from '../../../github/browser/githubService.js';
 import { computePullRequestIcon } from '../../../github/common/types.js';
+import { CHANGESET_UPDATE_THROTTLE_MS } from './agentHostChangesetConstants.js';
 import { changesetFileToChange, mapProtocolStatus } from './agentHostDiffs.js';
 import { createChangesets } from './agentHostSessionChangesets.js';
 
 const STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES = 'sessions.agentHost.sessionConfigPicker.selectedValues';
 const UNSAFE_SESSION_CONFIG_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
-/**
- * Minimum interval between changeset-driven UI recomputes. While an agent
- * edits, the host streams many changeset envelopes per second; coalescing them
- * to ~10 updates/second keeps the Changes view responsive without perceptible
- * lag, and stops every envelope from forcing a full list relayout.
- */
-export const CHANGESET_UPDATE_THROTTLE_MS = 100;
 
 function isSafeSessionConfigKey(property: string): boolean {
 	return !UNSAFE_SESSION_CONFIG_KEYS.has(property);

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -15,7 +15,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/
 import { AgentSession, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHostEditorSettingId, IAgentHostService, type IAgentCreateSessionConfig, type IAgentSessionMetadata } from '../../../../../../platform/agentHost/common/agentService.js';
 import type { IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
 import type { ResolveSessionConfigResult } from '../../../../../../platform/agentHost/common/state/protocol/commands.js';
-import { CustomizationLoadStatus, CustomizationType, SessionLifecycle, type AgentInfo, type Customization, type ModelSelection, type RootState, type SessionConfigState, type SessionState, type SessionSummary } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { CustomizationLoadStatus, CustomizationType, SessionLifecycle, type AgentInfo, type ChangesSummary, type Customization, type ModelSelection, type RootState, type SessionConfigState, type SessionState, type SessionSummary } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { buildDefaultChatUri, ChangesetStatus, SessionStatus as ProtocolSessionStatus, StateComponents, type ChangesetState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { ActionType, NotificationType, type ActionEnvelope, type IRootConfigChangedAction, type SessionAction, type TerminalAction, type INotification, type ClientAnnotationsAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { SessionConfigKey } from '../../../../../../platform/agentHost/common/sessionConfigKeys.js';
@@ -34,6 +34,7 @@ import { IActiveSession } from '../../../../../services/sessions/common/sessions
 import { ISessionsService } from '../../../../../services/sessions/browser/sessionsService.js';
 import { IAgentHostActiveClientService } from '../../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.js';
 import { LocalAgentHostSessionsProvider } from '../../browser/localAgentHostSessionsProvider.js';
+import { CHANGESET_UPDATE_THROTTLE_MS } from '../../browser/baseAgentHostSessionsProvider.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { IGitHubService } from '../../../../github/browser/githubService.js';
@@ -333,7 +334,7 @@ async function waitForSessionConfig(provider: LocalAgentHostSessionsProvider, se
 	});
 }
 
-function fireSessionAdded(agentHost: MockAgentHostService, rawId: string, opts?: { provider?: string; title?: string; model?: string; modelConfig?: Record<string, string>; project?: { uri: string; displayName: string }; workingDirectory?: string }): void {
+function fireSessionAdded(agentHost: MockAgentHostService, rawId: string, opts?: { provider?: string; title?: string; model?: string; modelConfig?: Record<string, string>; project?: { uri: string; displayName: string }; workingDirectory?: string; changes?: ChangesSummary }): void {
 	const provider = opts?.provider ?? 'copilotcli';
 	const sessionUri = AgentSession.uri(provider, rawId);
 	agentHost.fireNotification({
@@ -349,6 +350,7 @@ function fireSessionAdded(agentHost: MockAgentHostService, rawId: string, opts?:
 			model: opts?.model ? { id: opts.model, ...(opts.modelConfig ? { config: opts.modelConfig } : {}) } : undefined,
 			project: opts?.project,
 			workingDirectory: opts?.workingDirectory,
+			changes: opts?.changes,
 		},
 	});
 }
@@ -2403,8 +2405,8 @@ suite('LocalAgentHostSessionsProvider - active-session branch changeset subscrip
 		}));
 	}
 
-	function addAndObserve(provider: LocalAgentHostSessionsProvider, rawId: string): ISession {
-		fireSessionAdded(agentHost, rawId, { title: `Session ${rawId}` });
+	function addAndObserve(provider: LocalAgentHostSessionsProvider, rawId: string, opts?: { changes?: ChangesSummary }): ISession {
+		fireSessionAdded(agentHost, rawId, { title: `Session ${rawId}`, changes: opts?.changes });
 		const session = provider.getSessions().find(s => s.title.get() === `Session ${rawId}`);
 		assert.ok(session, `expected session ${rawId}`);
 		observeSession(session);
@@ -2483,7 +2485,7 @@ suite('LocalAgentHostSessionsProvider - active-session branch changeset subscrip
 		assert.strictEqual(unsubsForA, 1, 'leaving the agents window (no active session) must release the subscription');
 	});
 
-	test('active branch changeset uses before content URI as the diff original', () => {
+	test('active branch changeset uses before content URI as the diff original', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
 		const provider = createProvider(disposables, agentHost, undefined, { activeSession });
 		const session = addAndObserve(provider, 'sess-A');
 
@@ -2499,6 +2501,7 @@ suite('LocalAgentHostSessionsProvider - active-session branch changeset subscrip
 				},
 			}],
 		});
+		await timeout(CHANGESET_UPDATE_THROTTLE_MS); // let the changeset throttle flush
 
 		const changes = session.changes.get();
 		assert.deepStrictEqual(changes.map(change => {
@@ -2517,13 +2520,15 @@ suite('LocalAgentHostSessionsProvider - active-session branch changeset subscrip
 			insertions: 2,
 			deletions: 1,
 		}]);
-	});
+	}));
 
 	test('changes summary tracks the live branch changeset while active and the catalogue once inactive', () => {
 		const provider = createProvider(disposables, agentHost, undefined, { activeSession });
 		const session = addAndObserve(provider, 'sess-A');
 
-		activeSession.set(makeActive('sess-A'), undefined);
+		// Seed the live changeset before activating the session. When the
+		// subscription is first observed, this is the initial value of the
+		// throttled observable, so no throttle timer has to elapse.
 		agentHost.setChangesetState(branchChangesKeyFor('sess-A'), {
 			status: ChangesetStatus.Ready,
 			files: [{
@@ -2535,6 +2540,7 @@ suite('LocalAgentHostSessionsProvider - active-session branch changeset subscrip
 				},
 			}],
 		});
+		activeSession.set(makeActive('sess-A'), undefined);
 
 		// While active, the summary reflects the live branch changeset.
 		assert.deepStrictEqual(session.changesSummary?.get(), { additions: 2, deletions: 1, files: 1 });
@@ -2546,4 +2552,157 @@ suite('LocalAgentHostSessionsProvider - active-session branch changeset subscrip
 
 		assert.deepStrictEqual(session.changesSummary?.get(), { additions: 5, deletions: 3, files: 1 });
 	});
+
+	// Builds one changeset file. `version` drives the diff so that "changing" a
+	// file (bumping its version) produces a genuinely different file object,
+	// mirroring what the server reducer emits via a `ChangesetFileSet` action.
+	function makeChangesetFile(index: number, version: number): ChangesetState['files'][number] {
+		const path = `file:///repo/src/file-${index}.ts`;
+		return {
+			id: path,
+			edit: {
+				before: { uri: path, content: { uri: `session-db:///before/file-${index}.ts` } },
+				after: { uri: path, content: { uri: path } },
+				diff: { added: version, removed: 0 },
+			},
+		};
+	}
+
+	// Performance-regression guard for the per-file change cache.
+	//
+	// The server reducer preserves the reference of every `ChangesetFile` that
+	// didn't change across an update; the provider must exploit that and only
+	// rebuild the change object for the file(s) that actually changed. Here we
+	// stream many single-file updates over a large file set and assert that each
+	// update rebuilds exactly ONE change object (identity-wise), not all of them.
+	//
+	// Reverting the per-file caching (i.e. rebuilding/`...spread`-ing every file
+	// on every update) makes this fail immediately: all FILE_COUNT objects are
+	// freshly built on the first update.
+	test('rebuilds only the changed file across many changeset updates (O(changed), not O(all))', () => runWithFakedTimers<void>({ useFakeTimers: true, maxTaskCount: 1_000 }, async () => {
+		const provider = createProvider(disposables, agentHost, undefined, { activeSession });
+		const session = addAndObserve(provider, 'sess-A');
+		activeSession.set(makeActive('sess-A'), undefined);
+
+		const FILE_COUNT = 200;
+		const UPDATE_COUNT = 100;
+		const key = branchChangesKeyFor('sess-A');
+
+		// A stable pool of file objects. Each update below replaces exactly one
+		// entry and keeps every other reference, exactly as the reducer does.
+		const files: ChangesetState['files'] = [];
+		for (let i = 0; i < FILE_COUNT; i++) {
+			files.push(makeChangesetFile(i, 0));
+		}
+		agentHost.setChangesetState(key, { status: ChangesetStatus.Ready, files: [...files] });
+		await timeout(CHANGESET_UPDATE_THROTTLE_MS); // flush the changeset throttle
+
+		let previous = session.changes.get();
+		assert.strictEqual(previous.length, FILE_COUNT, 'every file should surface as a change');
+
+		for (let update = 0; update < UPDATE_COUNT; update++) {
+			const changedIndex = update % FILE_COUNT;
+			files[changedIndex] = makeChangesetFile(changedIndex, update + 1);
+			agentHost.setChangesetState(key, { status: ChangesetStatus.Ready, files: [...files] });
+			await timeout(CHANGESET_UPDATE_THROTTLE_MS); // flush the changeset throttle
+
+			const next = session.changes.get();
+
+			let rebuilt = 0;
+			for (let i = 0; i < FILE_COUNT; i++) {
+				if (next[i] !== previous[i]) {
+					rebuilt++;
+				}
+			}
+
+			assert.strictEqual(rebuilt, 1, `update ${update}: exactly one change object should be rebuilt, but ${rebuilt} of ${FILE_COUNT} were`);
+			previous = next;
+		}
+	}));
+
+	// Companion to the test above, stated as a simple identity invariant: a file
+	// that is never touched must keep the *same* change object instance no matter
+	// how many updates stream in for other files. Reverting the cache rebuilds
+	// every change object on every update, so this identity check fails.
+	test('an untouched file keeps its change-object identity while another file streams updates', () => runWithFakedTimers<void>({ useFakeTimers: true, maxTaskCount: 1_000 }, async () => {
+		const provider = createProvider(disposables, agentHost, undefined, { activeSession });
+		const session = addAndObserve(provider, 'sess-A');
+		activeSession.set(makeActive('sess-A'), undefined);
+
+		const FILE_COUNT = 50;
+		const UPDATE_COUNT = 100;
+		const key = branchChangesKeyFor('sess-A');
+
+		const files: ChangesetState['files'] = [];
+		for (let i = 0; i < FILE_COUNT; i++) {
+			files.push(makeChangesetFile(i, 0));
+		}
+		agentHost.setChangesetState(key, { status: ChangesetStatus.Ready, files: [...files] });
+		await timeout(CHANGESET_UPDATE_THROTTLE_MS); // flush the changeset throttle
+
+		// Index 0 is never touched; only the last file "streams" updates.
+		const untouchedChangeBefore = session.changes.get()[0];
+		assert.ok(untouchedChangeBefore, 'the untouched file should have a change object to begin with');
+
+		const lastIndex = FILE_COUNT - 1;
+		for (let update = 0; update < UPDATE_COUNT; update++) {
+			files[lastIndex] = makeChangesetFile(lastIndex, update + 1);
+			agentHost.setChangesetState(key, { status: ChangesetStatus.Ready, files: [...files] });
+			await timeout(CHANGESET_UPDATE_THROTTLE_MS); // flush the changeset throttle
+			session.changes.get(); // force the derived chain to recompute
+		}
+
+		const untouchedChangeAfter = session.changes.get()[0];
+		assert.strictEqual(untouchedChangeAfter, untouchedChangeBefore, 'an unchanged file must reuse its change object across all updates');
+	}));
+
+	// Performance-regression guard for the changeset update throttle
+	//
+	// While an agent streams edits, the host emits many envelopes per second. Each
+	// envelope fires the subscription's `onDidChange`; without throttling, each one
+	// would drive a full recompute of the `changes` list (and a relayout). The
+	// throttle must collapse a burst that arrives within one window into a single
+	// recompute carrying the final state.
+	//
+	// Reverting the throttle makes the burst recompute the list ~BURST times, so
+	// the `recomputes === 0` assertion (before the window elapses) fails.
+	test('coalesces a burst of changeset envelopes into a single changes recompute', () => runWithFakedTimers<void>({ useFakeTimers: true, maxTaskCount: 1_000 }, async () => {
+		const provider = createProvider(disposables, agentHost, undefined, { activeSession });
+		const session = addAndObserve(provider, 'sess-A');
+		activeSession.set(makeActive('sess-A'), undefined);
+
+		const FILE_COUNT = 20;
+		const BURST = 50;
+		const key = branchChangesKeyFor('sess-A');
+
+		const files: ChangesetState['files'] = [];
+		for (let i = 0; i < FILE_COUNT; i++) {
+			files.push(makeChangesetFile(i, 0));
+		}
+		agentHost.setChangesetState(key, { status: ChangesetStatus.Ready, files: [...files] });
+		await timeout(CHANGESET_UPDATE_THROTTLE_MS); // settle the initial state
+
+		let recomputes = 0;
+		disposables.add(autorun(reader => {
+			session.changes.read(reader);
+			recomputes++;
+		}));
+		recomputes = 0; // ignore the autorun's initial run
+
+		// Fire a burst of single-file updates with NO time passing in between, so
+		// they all land within one throttle window.
+		for (let i = 0; i < BURST; i++) {
+			files[0] = makeChangesetFile(0, i + 1);
+			agentHost.setChangesetState(key, { status: ChangesetStatus.Ready, files: [...files] });
+		}
+		assert.strictEqual(recomputes, 0, `a burst of ${BURST} envelopes within one window must not recompute the list yet`);
+
+		await timeout(CHANGESET_UPDATE_THROTTLE_MS); // flush the throttle
+		assert.strictEqual(recomputes, 1, 'the burst should collapse into exactly one recompute with the final state');
+
+		// And that single recompute carries the latest state.
+		const change0 = session.changes.get()[0];
+		assert.ok(change0 && isIChatSessionFileChange2(change0));
+		assert.strictEqual(change0.insertions, BURST, 'the coalesced update must reflect the final envelope');
+	}));
 });

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -34,7 +34,7 @@ import { IActiveSession } from '../../../../../services/sessions/common/sessions
 import { ISessionsService } from '../../../../../services/sessions/browser/sessionsService.js';
 import { IAgentHostActiveClientService } from '../../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.js';
 import { LocalAgentHostSessionsProvider } from '../../browser/localAgentHostSessionsProvider.js';
-import { CHANGESET_UPDATE_THROTTLE_MS } from '../../browser/baseAgentHostSessionsProvider.js';
+import { CHANGESET_UPDATE_THROTTLE_MS } from '../../browser/agentHostChangesetConstants.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { IGitHubService } from '../../../../github/browser/githubService.js';


### PR DESCRIPTION
- Investigated and resolved a ~16s main-thread freeze when opening a third session in the Agents window.
- Optimized changeset updates by eliminating unnecessary full rebuilds of all files on every envelope.
- Implemented per-file memoization using `mapObservableArrayCached` to reduce URI parsing and GC churn.
- Introduced throttling for changeset updates to coalesce rapid envelopes, improving responsiveness.
- Refactored `diffsToChanges` to `diffToChange` for better clarity and performance.
- Updated tests to ensure performance improvements and validate that only changed files trigger recomputes.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/321743