### PR TITLE
preferences: open settings UI/JSON in the same editor part

### DIFF
--- a/src/vs/workbench/services/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/services/preferences/browser/preferencesService.ts
@@ -377,10 +377,11 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 
 		// When the caller knows the source editor group (e.g. the editor title actions
 		// and their keyboard shortcuts that switch between the settings UI and JSON editor),
-		// always open in that same group so the editor stays in the editor part (main, modal
-		// or auxiliary window) it was invoked from. If that group lives in the modal editor
-		// part, request the modal group so it stays modal; otherwise open in that exact group.
-		if (options?.groupId !== undefined) {
+		// open in that same group so the editor stays in the editor part (main, modal or
+		// auxiliary window) it was invoked from. If that group lives in the modal editor part,
+		// request the modal group so it stays modal; otherwise open in that exact group. This
+		// is skipped when opening to the side, where a new side group is preferred instead.
+		if (options?.groupId !== undefined && !options.openToSide) {
 			const group = this.editorGroupService.getGroup(options.groupId);
 			if (group) {
 				const modalEditorPart = this.editorGroupService.activeModalEditorPart;

--- a/src/vs/workbench/services/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/services/preferences/browser/preferencesService.ts
@@ -374,6 +374,23 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 	}
 
 	private getEditorGroupFromOptions(options: { groupId?: number; openToSide?: boolean }): PreferredGroup {
+
+		// When the caller knows the source editor group (e.g. the editor title actions
+		// and their keyboard shortcuts that switch between the settings UI and JSON editor),
+		// always open in that same group so the editor stays in the editor part (main, modal
+		// or auxiliary window) it was invoked from. If that group lives in the modal editor
+		// part, request the modal group so it stays modal; otherwise open in that exact group.
+		if (options?.groupId !== undefined) {
+			const group = this.editorGroupService.getGroup(options.groupId);
+			if (group) {
+				const modalEditorPart = this.editorGroupService.activeModalEditorPart;
+				if (modalEditorPart?.groups.some(modalGroup => modalGroup.id === group.id)) {
+					return MODAL_GROUP;
+				}
+				return group;
+			}
+		}
+
 		if (
 			this.configurationService.getValue<string>('workbench.editor.useModal') !== 'off' &&					// modal editors enabled in settings
 			!this.environmentService.enableSmokeTestDriver && !this.environmentService.extensionTestsLocationURI	// but not in smoke test or extension test environments to reduce flakiness

--- a/src/vs/workbench/services/preferences/test/browser/preferencesService.test.ts
+++ b/src/vs/workbench/services/preferences/test/browser/preferencesService.test.ts
@@ -14,25 +14,33 @@ import { DEFAULT_EDITOR_ASSOCIATION, isEditorInput, IUntypedEditorInput } from '
 import { EditorInput } from '../../../../common/editor/editorInput.js';
 import { IJSONEditingService } from '../../../configuration/common/jsonEditing.js';
 import { TestJSONEditingService } from '../../../configuration/test/common/testServices.js';
-import { IEditorService, PreferredGroup } from '../../../editor/common/editorService.js';
+import { IEditorService, MODAL_GROUP, PreferredGroup } from '../../../editor/common/editorService.js';
+import { IEditorGroupsService, IModalEditorPart } from '../../../editor/common/editorGroupsService.js';
 import { PreferencesService } from '../../browser/preferencesService.js';
 import { IPreferencesService, ISettingsEditorOptions } from '../../common/preferences.js';
 import { IRemoteAgentService } from '../../../remote/common/remoteAgentService.js';
-import { TestRemoteAgentService, ITestInstantiationService, workbenchInstantiationService, TestEditorService } from '../../../../test/browser/workbenchTestServices.js';
+import { TestRemoteAgentService, workbenchInstantiationService, TestEditorService, TestEditorGroupsService, TestEditorGroupView } from '../../../../test/browser/workbenchTestServices.js';
 import { IEditorOptions } from '../../../../../platform/editor/common/editor.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 
 suite('PreferencesService', () => {
-	let testInstantiationService: ITestInstantiationService;
-	let testObject: PreferencesService;
 	let lastOpenEditorOptions: IEditorOptions | undefined;
+	let lastOpenEditorGroup: PreferredGroup | undefined;
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
-	setup(() => {
-		testInstantiationService = workbenchInstantiationService({}, disposables);
+	function createTestObject(editorGroupsService?: IEditorGroupsService, configurationService?: TestConfigurationService): PreferencesService {
+		lastOpenEditorOptions = undefined;
+		lastOpenEditorGroup = undefined;
+
+		const testInstantiationService = workbenchInstantiationService(
+			configurationService ? { configurationService: () => configurationService } : {},
+			disposables
+		);
 
 		class TestPreferencesEditorService extends TestEditorService {
 			override async openEditor(editor: EditorInput | IUntypedEditorInput, optionsOrGroup?: IEditorOptions | PreferredGroup, group?: PreferredGroup): Promise<undefined> {
 				lastOpenEditorOptions = optionsOrGroup as IEditorOptions;
+				lastOpenEditorGroup = group;
 				// openEditor takes ownership of the input
 				if (isEditorInput(editor)) {
 					editor.dispose();
@@ -46,18 +54,49 @@ suite('PreferencesService', () => {
 		testInstantiationService.stub(IRemoteAgentService, TestRemoteAgentService);
 		testInstantiationService.stub(ICommandService, TestCommandService);
 		testInstantiationService.stub(IURLService, { registerHandler: () => { } });
+		if (editorGroupsService) {
+			testInstantiationService.stub(IEditorGroupsService, editorGroupsService);
+		}
 
 		// PreferencesService creates a PreferencesEditorInput which depends on IPreferencesService, add the real one, not a stub
 		const collection = new ServiceCollection();
 		collection.set(IPreferencesService, new SyncDescriptor(PreferencesService));
 		const instantiationService = disposables.add(testInstantiationService.createChild(collection));
-		testObject = disposables.add(instantiationService.createInstance(PreferencesService));
-	});
+		return disposables.add(instantiationService.createInstance(PreferencesService));
+	}
+
 	test('options are preserved when calling openEditor', async () => {
+		const testObject = createTestObject();
 		await testObject.openSettings({ jsonEditor: false, query: 'test query' });
 		const options = lastOpenEditorOptions as ISettingsEditorOptions;
 		assert.strictEqual(options.focusSearch, true);
 		assert.strictEqual(options.override, DEFAULT_EDITOR_ASSOCIATION.id);
 		assert.strictEqual(options.query, 'test query');
+	});
+
+	test('opens in the source group when it lives in the main editor part (even with modal editors enabled)', async () => {
+		const mainGroup = new TestEditorGroupView(1);
+		const testObject = createTestObject(new TestEditorGroupsService([mainGroup]));
+
+		await testObject.openUserSettings({ jsonEditor: false, groupId: mainGroup.id });
+
+		assert.strictEqual(lastOpenEditorGroup, mainGroup);
+	});
+
+	test('opens in the modal group when the source group lives in the modal editor part', async () => {
+		const modalGroup = new TestEditorGroupView(2);
+		const modalEditorPart = { groups: [modalGroup] } as Partial<IModalEditorPart> as IModalEditorPart;
+		const editorGroupsService = new class extends TestEditorGroupsService {
+			override readonly activeModalEditorPart = modalEditorPart;
+		}([modalGroup]);
+
+		// Modal editors are turned off in settings to prove the routing comes from the
+		// active modal editor part the action was invoked from and not from the modal default.
+		const configurationService = new TestConfigurationService({ workbench: { editor: { useModal: 'off' } } });
+		const testObject = createTestObject(editorGroupsService, configurationService);
+
+		await testObject.openUserSettings({ jsonEditor: false, groupId: modalGroup.id });
+
+		assert.strictEqual(lastOpenEditorGroup, MODAL_GROUP);
 	});
 });

--- a/src/vs/workbench/services/preferences/test/browser/preferencesService.test.ts
+++ b/src/vs/workbench/services/preferences/test/browser/preferencesService.test.ts
@@ -19,7 +19,7 @@ import { IEditorGroupsService, IModalEditorPart } from '../../../editor/common/e
 import { PreferencesService } from '../../browser/preferencesService.js';
 import { IPreferencesService, ISettingsEditorOptions } from '../../common/preferences.js';
 import { IRemoteAgentService } from '../../../remote/common/remoteAgentService.js';
-import { TestRemoteAgentService, workbenchInstantiationService, TestEditorService, TestEditorGroupsService, TestEditorGroupView } from '../../../../test/browser/workbenchTestServices.js';
+import { TestRemoteAgentService, ITestInstantiationService, workbenchInstantiationService, TestEditorService, TestEditorGroupsService, TestEditorGroupView } from '../../../../test/browser/workbenchTestServices.js';
 import { IEditorOptions } from '../../../../../platform/editor/common/editor.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 
@@ -32,7 +32,7 @@ suite('PreferencesService', () => {
 		lastOpenEditorOptions = undefined;
 		lastOpenEditorGroup = undefined;
 
-		const testInstantiationService = workbenchInstantiationService(
+		const testInstantiationService: ITestInstantiationService = workbenchInstantiationService(
 			configurationService ? { configurationService: () => configurationService } : {},
 			disposables
 		);


### PR DESCRIPTION
Fixes #321374

When pressing the **Open Settings (JSON)** action in the editor title of the Settings editor while the Settings editor lives in the main editor area, the JSON editor opened in the modal editor part instead of the same part. The same happened in the opposite direction (Open Settings UI from the JSON editor), and for the keyboard shortcuts of these editor-title actions.

## Cause

`PreferencesService.getEditorGroupFromOptions` returned `MODAL_GROUP` whenever modal editors were enabled, *before* honoring the source `groupId` that the switch actions already provide. So switching always landed in the modal part.

## Fix

When a source `groupId` is known (supplied by the editor-title switch actions and their keyboard shortcuts), open in that same group so the editor stays in the editor part it was invoked from:

- source group in the **modal** part → request `MODAL_GROUP` (stays modal)
- otherwise → open in that exact group (main editor area or auxiliary window)

Command-palette opens (no `groupId`) keep the existing modal-by-default behavior.

## Notes for reviewers

- Single, surgical change in `getEditorGroupFromOptions`.
- Validated with the TypeScript language server (no errors). The repo hygiene/compile hook could not run in this worktree because dependencies are not installed there.
