### PR TITLE
sessions: show toggled state for editor layout controls

### DIFF
--- a/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
+++ b/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
@@ -88,6 +88,7 @@ class RestoreMainEditorPartAction extends Action2 {
 			title: localize2('restoreMainEditorPart', "Restore Editor Area"),
 			icon: Codicon.screenNormal,
 			f1: false,
+			toggled: EditorMaximizedContext,
 			menu: {
 				id: MenuId.EditorTitleLayout,
 				group: 'navigation',
@@ -186,6 +187,7 @@ class PullEditorLeftAction extends Action2 {
 			title: localize2('pullEditorLeft', "Show Secondary Side Bar"),
 			icon: Codicon.chevronLeft,
 			f1: false,
+			toggled: AuxiliaryBarVisibleContext.toNegated(),
 			menu: {
 				id: MenuId.EditorTitleLayout,
 				group: 'navigation',


### PR DESCRIPTION
Show the editor title layout-control actions in their toggled (highlighted) state when the layout deviates from the default.

## What changed
- `Restore Editor Area` is now `toggled` while the editor area is maximized (`EditorMaximizedContext`).
- `Show Secondary Side Bar` is now `toggled` while the secondary side bar is hidden (`AuxiliaryBarVisibleContext` negated).

## Why
These controls live in the `MenuId.EditorTitleLayout` toolbar (which already enables `highlightToggledItems`). Reflecting the toggled state gives a clear visual indicator that the current layout is non-default.

## Notes for reviewers
Surgical change in `src/vs/sessions/contrib/editor/browser/editor.contribution.ts` only. Typecheck and ESLint pass.
