### PR TITLE
Issue reporter wizard feedback fixes

### DIFF
--- a/src/vs/workbench/contrib/issue/browser/issueFormService.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueFormService.ts
@@ -393,7 +393,7 @@ export class IssueFormService extends Disposable implements IIssueFormService {
 	}
 
 	private addTemplateToUrl(baseUrl: string, owner?: string, repositoryName?: string, issueSource?: IssueSource): string {
-		const needsTemplate = issueSource === IssueSource.VSCode || (owner?.toLowerCase() === 'microsoft' && repositoryName?.toLowerCase() === 'vscode');
+		const needsTemplate = issueSource === IssueSource.VSCode || issueSource === IssueSource.AgentsWindow || (owner?.toLowerCase() === 'microsoft' && repositoryName?.toLowerCase() === 'vscode');
 		if (!needsTemplate) {
 			return baseUrl;
 		}

--- a/src/vs/workbench/contrib/issue/browser/issueReporterEditorInput.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueReporterEditorInput.ts
@@ -29,7 +29,7 @@ export class IssueReporterEditorInput extends EditorInput {
 	/**
 	 * Captured screenshots/recordings mirrored from the wizard so they survive the
 	 * editor moving between the main editor area and a modal editor part in the
-	 * Agents Window (which rebuilds the wizard). See #318376.
+	 * Agents Window (which rebuilds the wizard).
 	 */
 	savedScreenshots: readonly IScreenshot[] | undefined;
 	savedRecordings: readonly { filePath: string; durationMs: number; thumbnailDataUrl?: string }[] | undefined;

--- a/src/vs/workbench/contrib/issue/browser/issueReporterEditorInput.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueReporterEditorInput.ts
@@ -8,6 +8,7 @@ import { EditorInput, IEditorCloseHandler } from '../../../common/editor/editorI
 import { EditorInputCapabilities } from '../../../common/editor.js';
 import { ConfirmResult, IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IssueReporterData } from '../common/issue.js';
+import { IScreenshot } from './issueReporterOverlay.js';
 import { localize } from '../../../../nls.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js';
@@ -24,6 +25,14 @@ export class IssueReporterEditorInput extends EditorInput {
 
 	/** Set by the editor pane to check if user has entered data */
 	hasUserInputFn: (() => boolean) | undefined;
+
+	/**
+	 * Captured screenshots/recordings mirrored from the wizard so they survive the
+	 * editor moving between the main editor area and a modal editor part in the
+	 * Agents Window (which rebuilds the wizard). See #318376.
+	 */
+	savedScreenshots: readonly IScreenshot[] | undefined;
+	savedRecordings: readonly { filePath: string; durationMs: number; thumbnailDataUrl?: string }[] | undefined;
 
 	override readonly closeHandler: IEditorCloseHandler;
 

--- a/src/vs/workbench/contrib/issue/browser/issueReporterEditorPane.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueReporterEditorPane.ts
@@ -19,7 +19,8 @@ import { IEditorGroup, IEditorGroupsService } from '../../../services/editor/com
 import { IEditorOpenContext } from '../../../common/editor.js';
 import { EditorActivation, IEditorOptions } from '../../../../platform/editor/common/editor.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
-import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
+// eslint-disable-next-line local/code-import-patterns, local/code-layering
+import { INativeWorkbenchEnvironmentService } from '../../../services/environment/electron-browser/environmentService.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { decodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -83,7 +84,7 @@ export class IssueReporterEditorPane extends EditorPane {
 		@IScreenshotService private readonly screenshotService: IScreenshotService,
 		@ILogService private readonly logService: ILogService,
 		@IFileService private readonly fileService: IFileService,
-		@IEnvironmentService private readonly environmentService: IEnvironmentService,
+		@INativeWorkbenchEnvironmentService private readonly environmentService: INativeWorkbenchEnvironmentService,
 		@IEditorService private readonly editorService: IEditorService,
 		@IIssueFormService private readonly issueFormService: IIssueFormService,
 		@IProcessService private readonly processService: IProcessService,
@@ -319,7 +320,9 @@ export class IssueReporterEditorPane extends EditorPane {
 				// Screenshots are either annotated (always PNG via canvas.toDataURL)
 				// or raw native captures (always JPEG); fall back to PNG.
 				const extension = dataUrl.startsWith('data:image/jpeg') ? 'jpg' : 'png';
-				const folder = URI.joinPath(this.environmentService.userRoamingDataHome, 'issue-screenshots');
+				// Save to the OS temp folder (#318309) so artifacts don't bloat the
+				// user data folder and get cleaned up automatically.
+				const folder = URI.joinPath(this.environmentService.tmpDir, 'issue-screenshots');
 				const target = URI.joinPath(folder, `screenshot-${Date.now()}.${extension}`);
 				await this.fileService.createFolder(folder);
 				await this.fileService.writeFile(target, decodeBase64(dataUrl.substring(commaIndex + 1)));
@@ -532,7 +535,9 @@ export class IssueReporterEditorPane extends EditorPane {
 		try {
 			const extension = data.mimeType.startsWith('video/mp4') ? 'mp4' : 'webm';
 			const fileName = `vscode-recording-${new Date().toISOString().replace(/[:.]/g, '-')}.${extension}`;
-			const folder = URI.joinPath(this.environmentService.userRoamingDataHome, 'issue-recordings');
+			// Save to the OS temp folder (#318309) so artifacts don't bloat the
+			// user data folder and get cleaned up automatically.
+			const folder = URI.joinPath(this.environmentService.tmpDir, 'issue-recordings');
 			const target = URI.joinPath(folder, fileName);
 
 			const arrayBuffer = await data.blob.arrayBuffer();

--- a/src/vs/workbench/contrib/issue/browser/issueReporterEditorPane.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueReporterEditorPane.ts
@@ -154,6 +154,11 @@ export class IssueReporterEditorPane extends EditorPane {
 			this.wizard.reparentFloatingBar();
 			this.wizard.showFloatingBar();
 			this.wizard.setUpdateAvailable(this.shouldShowUpdateBanner());
+			// Restore attachments captured before the editor was moved back into
+			// this pane from a modal editor part (#318376). The input is the source
+			// of truth; the existing onDidChangeAttachments subscription keeps it in
+			// sync.
+			this.restoreAttachmentsFromInput(input);
 			return;
 		}
 
@@ -200,6 +205,16 @@ export class IssueReporterEditorPane extends EditorPane {
 		}));
 
 		this.wizard.show();
+
+		// Restore attachments mirrored onto the input before a move, and keep the
+		// input in sync as attachments change so they survive the wizard being
+		// rebuilt when the editor moves between the main editor area and a modal
+		// editor part in the Agents Window (#318376).
+		this.restoreAttachmentsFromInput(input);
+		this.inputDisposables.add(this.wizard.onDidChangeAttachments(() => {
+			input.savedScreenshots = this.wizard?.getScreenshots().slice();
+			input.savedRecordings = this.wizard?.getRecordings().slice();
+		}));
 
 		// Populate system info in background (non-blocking)
 		void this.populateSystemInfo();
@@ -485,6 +500,15 @@ export class IssueReporterEditorPane extends EditorPane {
 			this.wizard?.updateModel({
 				isInstallationPure: data.isInstallationPure,
 			});
+		}
+	}
+
+	private restoreAttachmentsFromInput(input: IssueReporterEditorInput): void {
+		if (!this.wizard) {
+			return;
+		}
+		if (input.savedScreenshots?.length || input.savedRecordings?.length) {
+			this.wizard.restoreAttachments(input.savedScreenshots ?? [], input.savedRecordings ?? []);
 		}
 	}
 

--- a/src/vs/workbench/contrib/issue/browser/issueReporterEditorPane.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueReporterEditorPane.ts
@@ -155,9 +155,8 @@ export class IssueReporterEditorPane extends EditorPane {
 			this.wizard.showFloatingBar();
 			this.wizard.setUpdateAvailable(this.shouldShowUpdateBanner());
 			// Restore attachments captured before the editor was moved back into
-			// this pane from a modal editor part (#318376). The input is the source
-			// of truth; the existing onDidChangeAttachments subscription keeps it in
-			// sync.
+			// this pane from a modal editor part. The input is the source of truth;
+			// the existing onDidChangeAttachments subscription keeps it in sync.
 			this.restoreAttachmentsFromInput(input);
 			return;
 		}
@@ -209,7 +208,7 @@ export class IssueReporterEditorPane extends EditorPane {
 		// Restore attachments mirrored onto the input before a move, and keep the
 		// input in sync as attachments change so they survive the wizard being
 		// rebuilt when the editor moves between the main editor area and a modal
-		// editor part in the Agents Window (#318376).
+		// editor part in the Agents Window.
 		this.restoreAttachmentsFromInput(input);
 		this.inputDisposables.add(this.wizard.onDidChangeAttachments(() => {
 			input.savedScreenshots = this.wizard?.getScreenshots().slice();
@@ -335,8 +334,7 @@ export class IssueReporterEditorPane extends EditorPane {
 				// Screenshots are either annotated (always PNG via canvas.toDataURL)
 				// or raw native captures (always JPEG); fall back to PNG.
 				const extension = dataUrl.startsWith('data:image/jpeg') ? 'jpg' : 'png';
-				// Save to the OS temp folder (#318309) so artifacts don't bloat the
-				// user data folder and get cleaned up automatically.
+				// Write to the OS temp folder so artifacts are cleaned up automatically.
 				const folder = URI.joinPath(this.environmentService.tmpDir, 'issue-screenshots');
 				const target = URI.joinPath(folder, `screenshot-${Date.now()}.${extension}`);
 				await this.fileService.createFolder(folder);
@@ -559,8 +557,7 @@ export class IssueReporterEditorPane extends EditorPane {
 		try {
 			const extension = data.mimeType.startsWith('video/mp4') ? 'mp4' : 'webm';
 			const fileName = `vscode-recording-${new Date().toISOString().replace(/[:.]/g, '-')}.${extension}`;
-			// Save to the OS temp folder (#318309) so artifacts don't bloat the
-			// user data folder and get cleaned up automatically.
+			// Write to the OS temp folder so artifacts are cleaned up automatically.
 			const folder = URI.joinPath(this.environmentService.tmpDir, 'issue-recordings');
 			const target = URI.joinPath(folder, fileName);
 

--- a/src/vs/workbench/contrib/issue/browser/issueReporterOverlay.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueReporterOverlay.ts
@@ -76,6 +76,9 @@ export class IssueReporterOverlay {
 	readonly onDidRequestOpenRecording: Event<string> = this._onDidRequestOpenRecording.event;
 	private readonly _onDidRequestOpenScreenshot = new Emitter<IScreenshot>();
 	readonly onDidRequestOpenScreenshot: Event<IScreenshot> = this._onDidRequestOpenScreenshot.event;
+	private readonly _onDidChangeAttachments = new Emitter<void>();
+	/** Fires whenever the screenshot/recording collection changes so the host can persist it (#318376). */
+	readonly onDidChangeAttachments: Event<void> = this._onDidChangeAttachments.event;
 
 	private wizardPanel!: HTMLElement;
 	private updateBanner!: HTMLElement;
@@ -749,9 +752,11 @@ export class IssueReporterOverlay {
 			{ label: localize('extensionSource', "A VS Code extension"), value: IssueSource.Extension },
 			{ label: localize('marketplace', "Extensions Marketplace"), value: IssueSource.Marketplace },
 		];
-		// Only show the Extension target if there are non-builtin, non-theme extensions installed.
-		// When no extensions exist, the option is useless and clutters the UI (#318315).
-		if (!this.hasReportableExtensions()) {
+		// Hide the Extension target when it can't apply: extensions can't run in
+		// the Agents Window so the picker would always be empty there (#318451),
+		// and in any window there is nothing to report against when no non-builtin,
+		// non-theme extensions are installed (#318315).
+		if (this.data.isSessionsWindow || !this.hasReportableExtensions()) {
 			return options.filter(o => o.value !== IssueSource.Extension);
 		}
 		return options;
@@ -1960,6 +1965,7 @@ export class IssueReporterOverlay {
 		this.updateAttachmentViews();
 		this.updateAttachmentButtons();
 		this.updateStepUI();
+		this._onDidChangeAttachments.fire();
 
 		// Immediately open the annotation editor for the new screenshot
 		this.openAnnotationEditor(this.screenshots.length - 1);
@@ -2060,6 +2066,7 @@ export class IssueReporterOverlay {
 				this.updateScreenshotThumbnails();
 				this.updateAttachmentButtons();
 				this.updateStepUI();
+				this._onDidChangeAttachments.fire();
 			}));
 		}
 
@@ -2083,6 +2090,7 @@ export class IssueReporterOverlay {
 				this.updateScreenshotThumbnails();
 				this.updateAttachmentButtons();
 				this.updateStepUI();
+				this._onDidChangeAttachments.fire();
 			}));
 		}
 
@@ -2123,6 +2131,7 @@ export class IssueReporterOverlay {
 			screenshot.annotatedDataUrl = dataUrl;
 			screenshot.annotationState = state;
 			this.updateAttachmentViews();
+			this._onDidChangeAttachments.fire();
 		}));
 
 		this.disposables.add(editor.onDidCancel(() => {
@@ -2136,6 +2145,23 @@ export class IssueReporterOverlay {
 
 	getRecordings(): readonly { filePath: string; durationMs: number; thumbnailDataUrl?: string }[] {
 		return this.recordings;
+	}
+
+	/**
+	 * Replace the current attachments with a previously-captured set. Used when the
+	 * issue reporter editor is moved between the main editor area and a modal editor
+	 * part in the Agents Window, which rebuilds the wizard and would otherwise drop
+	 * the in-memory screenshots and recordings (#318376). Does not fire
+	 * `onDidChangeAttachments` since the host is the source of this state.
+	 */
+	restoreAttachments(screenshots: readonly IScreenshot[], recordings: readonly { filePath: string; durationMs: number; thumbnailDataUrl?: string }[]): void {
+		this.screenshots.length = 0;
+		this.screenshots.push(...screenshots.slice(0, MAX_ATTACHMENTS));
+		this.recordings.length = 0;
+		this.recordings.push(...recordings.slice(0, Math.max(0, MAX_ATTACHMENTS - this.screenshots.length)));
+		this.updateAttachmentViews();
+		this.updateAttachmentButtons();
+		this.updateStepUI();
 	}
 
 	private buildIssueBody(): string {
@@ -2531,6 +2557,7 @@ ${rows.map(row => row.map(value => this.escapeMarkdownTableCell(value ?? '')).jo
 		this.updateAttachmentViews();
 		this.updateAttachmentButtons();
 		this.updateStepUI();
+		this._onDidChangeAttachments.fire();
 	}
 
 	private updateAttachmentViews(): void {
@@ -2594,6 +2621,7 @@ ${rows.map(row => row.map(value => this.escapeMarkdownTableCell(value ?? '')).jo
 		this._onDidRequestStopRecording.dispose();
 		this._onDidRequestOpenRecording.dispose();
 		this._onDidRequestOpenScreenshot.dispose();
+		this._onDidChangeAttachments.dispose();
 		this._onDidRequestGenerateTitle.dispose();
 	}
 }

--- a/src/vs/workbench/contrib/issue/browser/issueReporterOverlay.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueReporterOverlay.ts
@@ -77,7 +77,7 @@ export class IssueReporterOverlay {
 	private readonly _onDidRequestOpenScreenshot = new Emitter<IScreenshot>();
 	readonly onDidRequestOpenScreenshot: Event<IScreenshot> = this._onDidRequestOpenScreenshot.event;
 	private readonly _onDidChangeAttachments = new Emitter<void>();
-	/** Fires whenever the screenshot/recording collection changes so the host can persist it (#318376). */
+	/** Fires whenever the screenshot/recording collection changes so the host can persist it. */
 	readonly onDidChangeAttachments: Event<void> = this._onDidChangeAttachments.event;
 
 	private wizardPanel!: HTMLElement;
@@ -128,6 +128,7 @@ export class IssueReporterOverlay {
 	private reviewThumbCards: HTMLElement[] = [];
 	private readonly reviewRenderDisposables = new DisposableStore();
 	private readonly similarIssuesDisposables = new DisposableStore();
+	private readonly descriptionGuidanceDisposables = new DisposableStore();
 	private uploading = false;
 	private includeSystemInfo = true;
 	private includeProcessInfo = true;
@@ -199,7 +200,7 @@ export class IssueReporterOverlay {
 
 		// Toolbar with progress indicator and navigation buttons. The nav buttons
 		// sit in their own row directly beneath the step indicator, aligned to the
-		// start, so they read as part of the step UI (#318305).
+		// start, so they read as part of the step UI.
 		const toolbar = append(this.wizardPanel, $('div.wizard-toolbar'));
 
 		// Progress indicator area
@@ -214,7 +215,7 @@ export class IssueReporterOverlay {
 		this.stepLabel = append(progressArea, $('span.wizard-step-label'));
 
 		// Navigation buttons placed in their own row directly under the step
-		// indicator, aligned to the start (#318305).
+		// indicator, aligned to the start.
 		const nav = append(toolbar, $('div.wizard-nav'));
 
 		this.backButton = this.disposables.add(new Button(nav, { ...defaultButtonStyles, secondary: true }));
@@ -523,7 +524,7 @@ export class IssueReporterOverlay {
 		const heading = append(page, $('h2.wizard-heading'));
 		heading.textContent = localize('describeHeading', "Describe your feedback");
 
-		// Issue guidance link — keep the same wording as the classic reporter (#318333).
+		// Issue guidance link — keep the same wording as the classic reporter.
 		if (this.markdownRendererService) {
 			const guidanceContainer = append(page, $('div.wizard-issue-guidance'));
 			const guidanceMd = new MarkdownString(localize(
@@ -550,7 +551,10 @@ export class IssueReporterOverlay {
 		sourceLabel.textContent = localize('target', "Target");
 		this.appendRequiredMarker(sourceLabel);
 		this.sourceButtonGroup = append(sourceField, $('div.wizard-type-buttons.wizard-source-buttons'));
-		for (const option of this.getSourceOptions()) {
+		// Create a button for every source up front so async-loaded extensions can
+		// reveal the Extension target later; updateIssueSourceButtons() controls
+		// which buttons are visible.
+		for (const option of this.getAllSourceOptions()) {
 			const btn = this.disposables.add(new Button(this.sourceButtonGroup, { ...defaultButtonStyles, secondary: true }));
 			btn.element.classList.add('wizard-type-btn', 'wizard-source-btn');
 			btn.element.setAttribute('data-source', option.value);
@@ -592,7 +596,7 @@ export class IssueReporterOverlay {
 		// Default the target to the most likely option when the reporter opens.
 		// In the Agents Window we preselect Agents Window; otherwise default to
 		// VS Code (the most common target). Extension is preselected only when an
-		// extension id was already provided. The user can always override (#318311).
+		// extension id was already provided. The user can always override.
 		if (!this.selectedIssueSource) {
 			if (this.data.extensionId) {
 				this.selectedIssueSource = IssueSource.Extension;
@@ -715,9 +719,9 @@ export class IssueReporterOverlay {
 		this.updateIssueSourceFlags();
 		this.updateTargetStatus();
 
-		// Default the category to Bug (most common). Users can switch to Feature
-		// Request or Performance Issue (#318311). Must run after descriptionGuidance
-		// is initialized because selectType -> updateDescriptionGuidance touches it.
+		// Default the category to Bug (most common). Must run after
+		// descriptionGuidance is initialized because selectType ->
+		// updateDescriptionGuidance touches it.
 		if (this.selectedIssueType === undefined) {
 			selectType(IssueType.Bug);
 		} else {
@@ -737,25 +741,27 @@ export class IssueReporterOverlay {
 			{ type: IssueType.FeatureRequest, label: localize('featureRequest', "Feature Request"), icon: Codicon.lightbulb },
 			{ type: IssueType.PerformanceIssue, label: localize('performanceIssue', "Performance Issue"), icon: Codicon.dashboard },
 		];
-		// Marketplace target is for issues with the marketplace site/service itself,
-		// where performance metrics from a single VS Code instance aren't useful (#318318).
+		// The Marketplace target is for issues with the marketplace site/service
+		// itself, where performance metrics from a single VS Code instance aren't useful.
 		if (this.selectedIssueSource === IssueSource.Marketplace) {
 			return options.filter(o => o.type !== IssueType.PerformanceIssue);
 		}
 		return options;
 	}
 
-	private getSourceOptions(): { label: string; value: IssueSource }[] {
-		const options: { label: string; value: IssueSource }[] = [
+	private getAllSourceOptions(): { label: string; value: IssueSource }[] {
+		return [
 			{ label: product.nameLong || localize('vscode', "Visual Studio Code"), value: IssueSource.VSCode },
 			{ label: localize('agentsWindow', "Agents Window"), value: IssueSource.AgentsWindow },
 			{ label: localize('extensionSource', "A VS Code extension"), value: IssueSource.Extension },
 			{ label: localize('marketplace', "Extensions Marketplace"), value: IssueSource.Marketplace },
 		];
-		// Hide the Extension target when it can't apply: extensions can't run in
-		// the Agents Window so the picker would always be empty there (#318451),
-		// and in any window there is nothing to report against when no non-builtin,
-		// non-theme extensions are installed (#318315).
+	}
+
+	private getSourceOptions(): { label: string; value: IssueSource }[] {
+		const options = this.getAllSourceOptions();
+		// The Extension target only applies when there are non-builtin, non-theme
+		// extensions to report against, which never happens in the Agents Window.
 		if (this.data.isSessionsWindow || !this.hasReportableExtensions()) {
 			return options.filter(o => o.value !== IssueSource.Extension);
 		}
@@ -804,7 +810,7 @@ export class IssueReporterOverlay {
 	/**
 	 * Hide or restore issue type buttons based on the current source. The Marketplace
 	 * source does not support reporting performance issues, so the button is hidden
-	 * and the selection falls back to Bug when it was the Performance option (#318318).
+	 * and the selection falls back to Bug when it was the Performance option.
 	 */
 	private updateIssueTypeButtons(): void {
 		if (!this.issueTypeButtons.length) {
@@ -1214,6 +1220,7 @@ export class IssueReporterOverlay {
 		const perfWikiUrl = 'https://github.com/microsoft/vscode/wiki/Performance-Issues';
 
 		// Reset before updating
+		this.descriptionGuidanceDisposables.clear();
 		this.descriptionGuidance.textContent = '';
 		this.descriptionGuidance.classList.remove('wizard-description-guidance-with-link');
 
@@ -1231,12 +1238,10 @@ export class IssueReporterOverlay {
 				break;
 			case IssueType.PerformanceIssue: {
 				appendText(`${localize('perfGuidance', "Describe what is slow, when it happens, whether it's consistent or intermittent, and any patterns you've noticed.")} `);
-				// Insert the wiki link as a real anchor so users can follow the
-				// guidance for reporting performance issues (#318332).
 				const link = $('a.wizard-description-guidance-link') as HTMLAnchorElement;
 				link.href = perfWikiUrl;
 				link.textContent = localize('perfWikiLink', "See the performance issue reporting guide.");
-				this.disposables.add(addDisposableListener(link, EventType.CLICK, e => {
+				this.descriptionGuidanceDisposables.add(addDisposableListener(link, EventType.CLICK, e => {
 					e.preventDefault();
 					this.openExternalLink?.(perfWikiUrl);
 				}));
@@ -1736,10 +1741,9 @@ export class IssueReporterOverlay {
 			heading.className = 'review-diag-heading';
 
 			// Master checkbox before "Additional Information" shows/hides and
-			// includes/excludes the whole block (#318313). It is an explicit
-			// toggle controlled only by the user: clicking a per-section checkbox
-			// affects that section alone and never changes the master or hides the
-			// other sections (#318312).
+			// includes/excludes the whole block. It is an explicit toggle
+			// controlled only by the user: clicking a per-section checkbox affects
+			// that section alone and never changes the master or hides the others.
 			const masterWrap = append(heading, $('div.review-diag-master-wrap'));
 			const masterCheckbox = this.disposables.add(new Checkbox(localize('additionalInformation', "Additional Information"), !this.diagnosticsCollapsed, defaultCheckboxStyles));
 			masterCheckbox.domNode.classList.add('review-diag-master-checkbox');
@@ -1751,7 +1755,7 @@ export class IssueReporterOverlay {
 				this.setAllDiagnosticSectionsIncluded(masterCheckbox.checked);
 			}));
 
-			// Hide all sections only when the user turns the master off (#318313).
+			// Hide all sections only when the user turns the master off.
 			diagContainer.classList.toggle('all-excluded', this.diagnosticsCollapsed);
 
 			diagContainer.prepend(heading);
@@ -1802,9 +1806,8 @@ export class IssueReporterOverlay {
 		const group = append(parent, $('div.review-diag-group'));
 		group.classList.toggle('excluded', !opts.checked);
 
-		// Header layout (#318313 + #318312): [Checkbox] [Chevron+Title (toggle area)].
-		// The whole title area is clickable to expand/collapse — no separate text
-		// "Expand"/"Collapse" button.
+		// Header layout: [Checkbox] [Chevron + Title (toggle area)]. The whole
+		// title area is clickable to expand/collapse.
 		const header = append(group, $('div.review-diag-header'));
 
 		const checkWrap = append(header, $('div.review-diag-check-wrap'));
@@ -1957,8 +1960,7 @@ export class IssueReporterOverlay {
 		}
 		this.screenshots.push(screenshot);
 		// Navigate to the Attachments step so the user sees where the screenshot
-		// was saved instead of staying on whatever step they were composing on
-		// (#318317).
+		// was saved instead of staying on whatever step they were composing on.
 		if (this.currentStep !== WizardStep.Attachments) {
 			this.setStep(WizardStep.Attachments);
 		}
@@ -2151,7 +2153,7 @@ export class IssueReporterOverlay {
 	 * Replace the current attachments with a previously-captured set. Used when the
 	 * issue reporter editor is moved between the main editor area and a modal editor
 	 * part in the Agents Window, which rebuilds the wizard and would otherwise drop
-	 * the in-memory screenshots and recordings (#318376). Does not fire
+	 * the in-memory screenshots and recordings. Does not fire
 	 * `onDidChangeAttachments` since the host is the source of this state.
 	 */
 	restoreAttachments(screenshots: readonly IScreenshot[], recordings: readonly { filePath: string; durationMs: number; thumbnailDataUrl?: string }[]): void {
@@ -2413,6 +2415,7 @@ ${rows.map(row => row.map(value => this.escapeMarkdownTableCell(value ?? '')).jo
 			this.data.enabledExtensions = newData.allExtensions as IssueReporterExtensionData[];
 			this.updateExtensionOptions();
 			this.updateIssueSourceFlags();
+			this.updateIssueSourceButtons();
 		}
 		// Refresh review details if we're on the review step (async data may have arrived)
 		if (this.currentStep === WizardStep.Review) {
@@ -2550,7 +2553,7 @@ ${rows.map(row => row.map(value => this.escapeMarkdownTableCell(value ?? '')).jo
 
 	addRecording(filePath: string, durationMs: number, thumbnailDataUrl?: string): void {
 		this.recordings.push({ filePath, durationMs, thumbnailDataUrl });
-		// Navigate to the Attachments step so the user sees the saved recording (#318317).
+		// Navigate to the Attachments step so the user sees the saved recording.
 		if (this.currentStep !== WizardStep.Attachments) {
 			this.setStep(WizardStep.Attachments);
 		}
@@ -2613,6 +2616,7 @@ ${rows.map(row => row.map(value => this.escapeMarkdownTableCell(value ?? '')).jo
 		}
 		this.reviewRenderDisposables.dispose();
 		this.similarIssuesDisposables.dispose();
+		this.descriptionGuidanceDisposables.dispose();
 		this.disposables.dispose();
 		this._onDidClose.dispose();
 		this._onDidSubmit.dispose();

--- a/src/vs/workbench/contrib/issue/browser/issueReporterOverlay.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueReporterOverlay.ts
@@ -132,8 +132,7 @@ export class IssueReporterOverlay {
 	private includeExtensions = true;
 	private includeExperiments = true;
 	private includeExtensionData = false;
-	private diagnosticBulkToggleButton: Button | undefined;
-	private diagnosticSectionStates: (() => boolean)[] = [];
+	private diagnosticsCollapsed = false;
 	private performanceInfoLoaded = false;
 	private performanceInfoRefreshing = false;
 
@@ -195,7 +194,9 @@ export class IssueReporterOverlay {
 		this.wizardPanel.setAttribute('aria-label', localize('reportIssue', "Report Issue"));
 		this.wizardPanel.setAttribute('tabindex', '-1');
 
-		// Toolbar (drag region + step indicator + discard)
+		// Toolbar with progress indicator and navigation buttons. The nav buttons
+		// sit in their own row directly beneath the step indicator, aligned to the
+		// start, so they read as part of the step UI (#318305).
 		const toolbar = append(this.wizardPanel, $('div.wizard-toolbar'));
 
 		// Progress indicator area
@@ -209,7 +210,19 @@ export class IssueReporterOverlay {
 		append(progressArea, $('span.wizard-step-separator'));
 		this.stepLabel = append(progressArea, $('span.wizard-step-label'));
 
-		append(toolbar, $('div.wizard-toolbar-spacer'));
+		// Navigation buttons placed in their own row directly under the step
+		// indicator, aligned to the start (#318305).
+		const nav = append(toolbar, $('div.wizard-nav'));
+
+		this.backButton = this.disposables.add(new Button(nav, { ...defaultButtonStyles, secondary: true }));
+		this.backButton.label = localize('back', "Back");
+		this.backButton.element.classList.add('wizard-back');
+		this.backButton.element.title = localize('back', "Back");
+
+		this.nextButton = this.disposables.add(new Button(nav, { ...defaultButtonStyles, supportIcons: true }));
+		this.nextButton.label = localize('next', "Next");
+		this.nextButton.element.classList.add('wizard-next');
+		this.nextButton.element.title = localize('next', "Next");
 
 		this.updateBanner = append(this.wizardPanel, $('div.wizard-update-banner'));
 		this.updateBanner.setAttribute('role', 'status');
@@ -222,19 +235,6 @@ export class IssueReporterOverlay {
 		this.createStep0Attachments();
 		this.createStep1Describe();
 		this.createStep2Review();
-
-		// Bottom navigation
-		const nav = append(this.wizardPanel, $('div.wizard-nav'));
-
-		this.backButton = this.disposables.add(new Button(nav, { ...defaultButtonStyles, secondary: true }));
-		this.backButton.label = localize('back', "Back");
-		this.backButton.element.classList.add('wizard-back');
-		this.backButton.element.title = localize('back', "Back");
-
-		this.nextButton = this.disposables.add(new Button(nav, { ...defaultButtonStyles, supportIcons: true }));
-		this.nextButton.label = localize('next', "Next");
-		this.nextButton.element.classList.add('wizard-next');
-		this.nextButton.element.title = localize('next', "Next");
 
 		this.registerEventHandlers();
 		if (this.data.extensionId) {
@@ -520,11 +520,32 @@ export class IssueReporterOverlay {
 		const heading = append(page, $('h2.wizard-heading'));
 		heading.textContent = localize('describeHeading', "Describe your feedback");
 
+		// Issue guidance link — keep the same wording as the classic reporter (#318333).
+		if (this.markdownRendererService) {
+			const guidanceContainer = append(page, $('div.wizard-issue-guidance'));
+			const guidanceMd = new MarkdownString(localize(
+				{
+					key: 'reviewGuidanceLabelWizard',
+					comment: ['{Locked="https://github.com/microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions"}']
+				},
+				'Before you report an issue here please [review the guidance we provide](https://github.com/microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions). Please complete the form in English.'
+			), { isTrusted: true });
+			const rendered = this.markdownRendererService.render(guidanceMd, {
+				actionHandler: async (link: string) => {
+					await this.openExternalLink?.(link);
+					return true;
+				},
+			});
+			guidanceContainer.appendChild(rendered.element);
+			this.disposables.add(rendered);
+		}
+
 		// Issue source selection + extension dropdown share a row when both are visible
 		const targetRow = append(page, $('div.wizard-target-row'));
 		const sourceField = append(targetRow, $('div.wizard-field.wizard-source-field'));
 		const sourceLabel = append(sourceField, $('label.wizard-field-label'));
 		sourceLabel.textContent = localize('target', "Target");
+		this.appendRequiredMarker(sourceLabel);
 		this.sourceButtonGroup = append(sourceField, $('div.wizard-type-buttons.wizard-source-buttons'));
 		for (const option of this.getSourceOptions()) {
 			const btn = this.disposables.add(new Button(this.sourceButtonGroup, { ...defaultButtonStyles, secondary: true }));
@@ -546,6 +567,7 @@ export class IssueReporterOverlay {
 		this.extensionField = append(targetRow, $('div.wizard-field.wizard-extension-field'));
 		const extensionLabel = append(this.extensionField, $('label.wizard-field-label'));
 		extensionLabel.textContent = localize('extension', "Extension");
+		this.appendRequiredMarker(extensionLabel);
 		const extensionSelectContainer = append(this.extensionField, $('div.wizard-extension-select'));
 		this.extensionOptions = this.getExtensionOptions();
 		this.extensionSelect = this.disposables.add(new SelectBox(
@@ -563,18 +585,29 @@ export class IssueReporterOverlay {
 		this.extensionStatus = append(this.extensionField, $('div.wizard-extension-status'));
 		this.updateExtensionOptions();
 		this.updateExtensionFieldVisibility();
+
+		// Default the target to the most likely option when the reporter opens.
+		// In the Agents Window we preselect Agents Window; otherwise default to
+		// VS Code (the most common target). Extension is preselected only when an
+		// extension id was already provided. The user can always override (#318311).
+		if (!this.selectedIssueSource) {
+			if (this.data.extensionId) {
+				this.selectedIssueSource = IssueSource.Extension;
+			} else if (this.data.isSessionsWindow) {
+				this.selectedIssueSource = IssueSource.AgentsWindow;
+			} else {
+				this.selectedIssueSource = IssueSource.VSCode;
+			}
+			this.updateIssueSourceFlags();
+		}
 		this.updateIssueSourceButtons();
 
 		// Category selection
 		const catLabel = append(page, $('label.wizard-field-label'));
 		catLabel.textContent = localize('feedbackCategory', "Category");
+		this.appendRequiredMarker(catLabel);
 
 		this.typeButtonGroup = append(page, $('div.wizard-type-buttons'));
-		const types = [
-			{ type: IssueType.Bug, label: localize('bug', "Bug"), icon: Codicon.bug },
-			{ type: IssueType.FeatureRequest, label: localize('featureRequest', "Feature Request"), icon: Codicon.lightbulb },
-			{ type: IssueType.PerformanceIssue, label: localize('performanceIssue', "Performance Issue"), icon: Codicon.dashboard },
-		];
 
 		const selectType = (type: IssueType) => {
 			this.selectedIssueType = type;
@@ -593,7 +626,7 @@ export class IssueReporterOverlay {
 			this.searchSimilarIssues();
 		};
 
-		for (const { type, label, icon } of types) {
+		for (const { type, label, icon } of this.getIssueTypeOptions()) {
 			const btn = this.disposables.add(new Button(this.typeButtonGroup, { ...defaultButtonStyles, secondary: true, supportIcons: true }));
 			btn.element.classList.add('wizard-type-btn');
 			btn.element.setAttribute('data-type', String(type));
@@ -609,6 +642,7 @@ export class IssueReporterOverlay {
 		const titleLabelRow = append(titleGroup, $('div.wizard-title-label-row'));
 		const titleLabel = append(titleLabelRow, $('label.wizard-field-label'));
 		titleLabel.textContent = localize('issueTitle', "Title");
+		this.appendRequiredMarker(titleLabel);
 
 		const aiBtn = this.disposables.add(new Button(titleLabelRow, { ...defaultButtonStyles, secondary: true, supportIcons: true }));
 		aiBtn.label = `$(sparkle) ${localize('generateTitleBtn', "Generate from description")}`;
@@ -648,6 +682,7 @@ export class IssueReporterOverlay {
 		const descriptionGroup = append(page, $('div.wizard-field'));
 		const descLabel = append(descriptionGroup, $('label.wizard-field-label'));
 		descLabel.textContent = localize('description', "Description");
+		this.appendRequiredMarker(descLabel);
 
 		this.descriptionGuidance = append(descriptionGroup, $('p.wizard-subtitle.wizard-description-guidance'));
 		this.updateDescriptionGuidance();
@@ -676,15 +711,56 @@ export class IssueReporterOverlay {
 
 		this.updateIssueSourceFlags();
 		this.updateTargetStatus();
+
+		// Default the category to Bug (most common). Users can switch to Feature
+		// Request or Performance Issue (#318311). Must run after descriptionGuidance
+		// is initialized because selectType -> updateDescriptionGuidance touches it.
+		if (this.selectedIssueType === undefined) {
+			selectType(IssueType.Bug);
+		} else {
+			selectType(this.selectedIssueType);
+		}
+	}
+
+	private appendRequiredMarker(label: HTMLElement): void {
+		const marker = append(label, $('span.wizard-required-marker'));
+		marker.textContent = '*';
+		marker.setAttribute('aria-hidden', 'true');
+	}
+
+	private getIssueTypeOptions(): { type: IssueType; label: string; icon: { id: string } }[] {
+		const options = [
+			{ type: IssueType.Bug, label: localize('bug', "Bug"), icon: Codicon.bug },
+			{ type: IssueType.FeatureRequest, label: localize('featureRequest', "Feature Request"), icon: Codicon.lightbulb },
+			{ type: IssueType.PerformanceIssue, label: localize('performanceIssue', "Performance Issue"), icon: Codicon.dashboard },
+		];
+		// Marketplace target is for issues with the marketplace site/service itself,
+		// where performance metrics from a single VS Code instance aren't useful (#318318).
+		if (this.selectedIssueSource === IssueSource.Marketplace) {
+			return options.filter(o => o.type !== IssueType.PerformanceIssue);
+		}
+		return options;
 	}
 
 	private getSourceOptions(): { label: string; value: IssueSource }[] {
 		const options: { label: string; value: IssueSource }[] = [
 			{ label: product.nameLong || localize('vscode', "Visual Studio Code"), value: IssueSource.VSCode },
+			{ label: localize('agentsWindow', "Agents Window"), value: IssueSource.AgentsWindow },
 			{ label: localize('extensionSource', "A VS Code extension"), value: IssueSource.Extension },
 			{ label: localize('marketplace', "Extensions Marketplace"), value: IssueSource.Marketplace },
 		];
+		// Only show the Extension target if there are non-builtin, non-theme extensions installed.
+		// When no extensions exist, the option is useless and clutters the UI (#318315).
+		if (!this.hasReportableExtensions()) {
+			return options.filter(o => o.value !== IssueSource.Extension);
+		}
 		return options;
+	}
+
+	private hasReportableExtensions(): boolean {
+		const modelData = this.model.getData();
+		const sourceExtensions = modelData.enabledNonThemeExtesions ?? modelData.allExtensions ?? [];
+		return sourceExtensions.some(extension => !extension.isTheme && !extension.isBuiltin);
 	}
 
 	private updateIssueSourceButtons(): void {
@@ -712,21 +788,51 @@ export class IssueReporterOverlay {
 		this.setFieldError(this.sourceButtonGroup, this.sourceError, this.didAttemptDescribeSubmit && !source);
 		this.updateIssueSourceFlags();
 		this.updateIssueSourceButtons();
+		this.updateIssueTypeButtons();
 		this.updateExtensionValidation();
 		this.updateTitlePlaceholder();
 		this.updateTargetStatus();
+		this.updateDescriptionGuidance();
 		this.searchSimilarIssues();
+	}
+
+	/**
+	 * Hide or restore issue type buttons based on the current source. The Marketplace
+	 * source does not support reporting performance issues, so the button is hidden
+	 * and the selection falls back to Bug when it was the Performance option (#318318).
+	 */
+	private updateIssueTypeButtons(): void {
+		if (!this.issueTypeButtons.length) {
+			return;
+		}
+		const allowedTypes = new Set(this.getIssueTypeOptions().map(option => String(option.type)));
+		for (const button of this.issueTypeButtons) {
+			const buttonType = button.element.getAttribute('data-type');
+			const isAvailable = !!buttonType && allowedTypes.has(buttonType);
+			button.element.classList.toggle('hidden', !isAvailable);
+		}
+		if (this.selectedIssueType !== undefined && !allowedTypes.has(String(this.selectedIssueType))) {
+			this.selectedIssueType = IssueType.Bug;
+			this.model.update({ issueType: IssueType.Bug });
+			for (const b of this.issueTypeButtons) {
+				const isSelected = b.element.getAttribute('data-type') === String(IssueType.Bug);
+				b.element.classList.toggle('selected', isSelected);
+				b.element.setAttribute('aria-pressed', String(isSelected));
+			}
+		}
 	}
 
 	private updateIssueSourceFlags(): void {
 		const fileOnExtension = this.selectedIssueSource === IssueSource.Extension;
 		const fileOnMarketplace = this.selectedIssueSource === IssueSource.Marketplace;
-		const fileOnProduct = this.selectedIssueSource === IssueSource.VSCode || this.selectedIssueSource === IssueSource.Unknown;
+		const fileOnProduct = this.selectedIssueSource === IssueSource.VSCode || this.selectedIssueSource === IssueSource.AgentsWindow || this.selectedIssueSource === IssueSource.Unknown;
+		const fileOnAgentsWindow = this.selectedIssueSource === IssueSource.AgentsWindow;
 		this.model.update({
 			issueSource: this.selectedIssueSource,
 			fileOnExtension,
 			fileOnMarketplace,
 			fileOnProduct,
+			isSessionsWindow: fileOnAgentsWindow ? true : this.data.isSessionsWindow,
 			selectedExtension: this.selectedExtension,
 		});
 		this.data.issueSource = this.selectedIssueSource;
@@ -746,6 +852,9 @@ export class IssueReporterOverlay {
 				break;
 			case IssueSource.Marketplace:
 				this.titleInput.setPlaceHolder(localize('marketplacePlaceholder', "E.g. Cannot disable installed extension"));
+				break;
+			case IssueSource.AgentsWindow:
+				this.titleInput.setPlaceHolder(localize('agentsWindowPlaceholder', "E.g. Sessions list does not refresh after creating a new session"));
 				break;
 			case IssueSource.VSCode:
 				this.titleInput.setPlaceHolder(localize('vscodePlaceholder', "E.g. Workbench is missing problems panel"));
@@ -940,6 +1049,8 @@ export class IssueReporterOverlay {
 		switch (this.selectedIssueSource) {
 			case IssueSource.VSCode:
 				return product.nameLong || localize('vscode', "Visual Studio Code");
+			case IssueSource.AgentsWindow:
+				return localize('agentsWindow', "Agents Window");
 			case IssueSource.Extension:
 				return this.selectedExtension?.displayName || this.selectedExtension?.name || localize('extensionSource', "A VS Code extension");
 			case IssueSource.Marketplace:
@@ -1095,22 +1206,42 @@ export class IssueReporterOverlay {
 	/** Update the guidance text above the description based on selected category */
 	private updateDescriptionGuidance(): void {
 		const markdownHint = localize('markdownSupported', "Markdown formatting is supported.");
+		const perfWikiUrl = 'https://github.com/microsoft/vscode/wiki/Performance-Issues';
+
+		// Reset before updating
+		this.descriptionGuidance.textContent = '';
+		this.descriptionGuidance.classList.remove('wizard-description-guidance-with-link');
+
+		const appendText = (text: string) => {
+			const targetDocument = getWindow(this.container).document;
+			this.descriptionGuidance.appendChild(targetDocument.createTextNode(text));
+		};
+
 		switch (this.selectedIssueType) {
 			case IssueType.Bug:
-				this.descriptionGuidance.textContent = `${localize('bugGuidance',
-					"Describe what happened, the steps to reproduce, what you expected, and what you observed instead.")}\n${markdownHint}`;
+				appendText(`${localize('bugGuidance', "Describe what happened, the steps to reproduce, what you expected, and what you observed instead.")}\n${markdownHint}`);
 				break;
 			case IssueType.FeatureRequest:
-				this.descriptionGuidance.textContent = `${localize('featureGuidance',
-					"Describe the feature you'd like to see, what problem it would solve, and any alternatives you've considered.")}\n${markdownHint}`;
+				appendText(`${localize('featureGuidance', "Describe the feature you'd like to see, what problem it would solve, and any alternatives you've considered.")}\n${markdownHint}`);
 				break;
-			case IssueType.PerformanceIssue:
-				this.descriptionGuidance.textContent = `${localize('perfGuidance',
-					"Describe what is slow, when it happens, whether it's consistent or intermittent, and any patterns you've noticed.")}\n${markdownHint}`;
+			case IssueType.PerformanceIssue: {
+				appendText(`${localize('perfGuidance', "Describe what is slow, when it happens, whether it's consistent or intermittent, and any patterns you've noticed.")} `);
+				// Insert the wiki link as a real anchor so users can follow the
+				// guidance for reporting performance issues (#318332).
+				const link = $('a.wizard-description-guidance-link') as HTMLAnchorElement;
+				link.href = perfWikiUrl;
+				link.textContent = localize('perfWikiLink', "See the performance issue reporting guide.");
+				this.disposables.add(addDisposableListener(link, EventType.CLICK, e => {
+					e.preventDefault();
+					this.openExternalLink?.(perfWikiUrl);
+				}));
+				this.descriptionGuidance.appendChild(link);
+				appendText(`\n${markdownHint}`);
+				this.descriptionGuidance.classList.add('wizard-description-guidance-with-link');
 				break;
+			}
 			default:
-				this.descriptionGuidance.textContent = `${localize('defaultGuidance',
-					"Select a category above, then describe your feedback in detail.")}\n${markdownHint}`;
+				appendText(`${localize('defaultGuidance', "Select a category above, then describe your feedback in detail.")}\n${markdownHint}`);
 				break;
 		}
 	}
@@ -1407,14 +1538,10 @@ export class IssueReporterOverlay {
 
 		const modelData = this.model.getData();
 		let diagnosticSectionCount = 0;
-		const diagnosticSectionStates: (() => boolean)[] = [];
-		this.diagnosticBulkToggleButton = undefined;
-		this.diagnosticSectionStates = diagnosticSectionStates;
 
 		// System Info
 		if (modelData.versionInfo || modelData.systemInfo) {
 			diagnosticSectionCount++;
-			diagnosticSectionStates.push(() => this.includeSystemInfo);
 			this.createDiagSection(diagContainer, {
 				id: 'system-info',
 				label: localize('systemInformation', "System Information"),
@@ -1454,7 +1581,6 @@ export class IssueReporterOverlay {
 			// Extension (e.g. built-in extensions are filed against VS Code),
 			// even though the extension data still ends up in the submitted body.
 			diagnosticSectionCount++;
-			diagnosticSectionStates.push(() => this.includeExtensionData);
 			this.createDiagSection(diagContainer, {
 				id: 'extension-data',
 				label: localize('extensionData', "Extension Data"),
@@ -1474,7 +1600,6 @@ export class IssueReporterOverlay {
 		const nonThemeExtensions = (modelData.allExtensions ?? []).filter(e => !e.isTheme && !e.isBuiltin);
 		if (!modelData.fileOnExtension && !modelData.fileOnMarketplace && nonThemeExtensions.length > 0) {
 			diagnosticSectionCount++;
-			diagnosticSectionStates.push(() => this.includeExtensions);
 			this.createDiagSection(diagContainer, {
 				id: 'extensions',
 				label: localize('extensions', "Extensions ({0})", nonThemeExtensions.length),
@@ -1504,7 +1629,6 @@ export class IssueReporterOverlay {
 		// Experiments
 		if (modelData.experimentInfo) {
 			diagnosticSectionCount++;
-			diagnosticSectionStates.push(() => this.includeExperiments);
 			this.createDiagSection(diagContainer, {
 				id: 'experiments',
 				label: localize('abExperiments', "A/B Experiments"),
@@ -1563,7 +1687,6 @@ export class IssueReporterOverlay {
 
 			if (modelData.processInfo) {
 				diagnosticSectionCount++;
-				diagnosticSectionStates.push(() => this.includeProcessInfo);
 				this.createDiagSection(performanceContainer, {
 					id: 'process-info',
 					label: localize('runningProcesses', "Running Processes"),
@@ -1584,7 +1707,6 @@ export class IssueReporterOverlay {
 
 			if (modelData.workspaceInfo) {
 				diagnosticSectionCount++;
-				diagnosticSectionStates.push(() => this.includeWorkspaceInfo);
 				this.createDiagSection(performanceContainer, {
 					id: 'workspace-info',
 					label: localize('workspaceMetadata', "Workspace Metadata"),
@@ -1607,22 +1729,30 @@ export class IssueReporterOverlay {
 		if (diagnosticSectionCount > 0) {
 			const heading = document.createElement('div');
 			heading.className = 'review-diag-heading';
-			const title = append(heading, $('h3.review-diag-heading-title'));
+
+			// Master checkbox before "Additional Information" shows/hides and
+			// includes/excludes the whole block (#318313). It is an explicit
+			// toggle controlled only by the user: clicking a per-section checkbox
+			// affects that section alone and never changes the master or hides the
+			// other sections (#318312).
+			const masterWrap = append(heading, $('div.review-diag-master-wrap'));
+			const masterCheckbox = this.disposables.add(new Checkbox(localize('additionalInformation', "Additional Information"), !this.diagnosticsCollapsed, defaultCheckboxStyles));
+			masterCheckbox.domNode.classList.add('review-diag-master-checkbox');
+			masterWrap.appendChild(masterCheckbox.domNode);
+			const title = append(masterWrap, $('h3.review-diag-heading-title'));
 			title.textContent = localize('additionalInformation', "Additional Information");
-			if (diagnosticSectionCount > 1) {
-				const bulkActions = append(heading, $('div.review-diag-bulk-actions'));
-				const toggleAllButton = this.disposables.add(new Button(bulkActions, { ...defaultButtonStyles, secondary: true }));
-				toggleAllButton.element.classList.add('review-diag-toggle-all');
-				this.diagnosticBulkToggleButton = toggleAllButton;
-				this.updateDiagnosticBulkToggleButton();
-				this.disposables.add(toggleAllButton.onDidClick(() => {
-					this.setAllDiagnosticSectionsIncluded(!this.areAllVisibleDiagnosticSectionsIncluded());
-				}));
-			}
+			this.disposables.add(masterCheckbox.onChange(() => {
+				this.diagnosticsCollapsed = !masterCheckbox.checked;
+				this.setAllDiagnosticSectionsIncluded(masterCheckbox.checked);
+			}));
+
+			// Hide all sections only when the user turns the master off (#318313).
+			diagContainer.classList.toggle('all-excluded', this.diagnosticsCollapsed);
+
 			diagContainer.prepend(heading);
 		}
 
-		// Align all title widths dynamically to the widest title
+		// Align all title widths dynamically to the widest title so chevron columns line up.
 		// eslint-disable-next-line no-restricted-syntax
 		const titles = diagContainer.querySelectorAll('.review-diag-title');
 		let maxWidth = 0;
@@ -1637,39 +1767,6 @@ export class IssueReporterOverlay {
 				(t as HTMLElement).style.minWidth = `${maxWidth}px`;
 			}
 		}
-
-		// Align all toggle button widths to the widest
-		// eslint-disable-next-line no-restricted-syntax
-		const toggles = diagContainer.querySelectorAll('.review-diag-toggle');
-		let maxToggleWidth = 0;
-		for (const t of toggles) {
-			(t as HTMLElement).style.minWidth = '';
-		}
-		for (const t of toggles) {
-			maxToggleWidth = Math.max(maxToggleWidth, (t as HTMLElement).offsetWidth);
-		}
-		if (maxToggleWidth > 0) {
-			for (const t of toggles) {
-				(t as HTMLElement).style.minWidth = `${maxToggleWidth}px`;
-			}
-		}
-	}
-
-	private areAllVisibleDiagnosticSectionsIncluded(): boolean {
-		return this.diagnosticSectionStates.length > 0 && this.diagnosticSectionStates.every(getState => getState());
-	}
-
-	private updateDiagnosticBulkToggleButton(): void {
-		if (!this.diagnosticBulkToggleButton) {
-			return;
-		}
-		const allChecked = this.areAllVisibleDiagnosticSectionsIncluded();
-		this.diagnosticBulkToggleButton.label = allChecked
-			? localize('excludeAllExtraAttachments', "Exclude All")
-			: localize('includeAllExtraAttachments', "Include All");
-		this.diagnosticBulkToggleButton.element.setAttribute('aria-label', allChecked
-			? localize('excludeAllExtraAttachmentsAria', "Exclude all additional issue data from this issue")
-			: localize('includeAllExtraAttachmentsAria', "Include all additional issue data in this issue"));
 	}
 
 	private setAllDiagnosticSectionsIncluded(included: boolean): void {
@@ -1698,39 +1795,54 @@ export class IssueReporterOverlay {
 		renderContent: (container: HTMLElement) => void;
 	}): void {
 		const group = append(parent, $('div.review-diag-group'));
+		group.classList.toggle('excluded', !opts.checked);
 
-		// Header: title | "Include in issue" checkbox | Minimize/Expand button
+		// Header layout (#318313 + #318312): [Checkbox] [Chevron+Title (toggle area)].
+		// The whole title area is clickable to expand/collapse — no separate text
+		// "Expand"/"Collapse" button.
 		const header = append(group, $('div.review-diag-header'));
 
-		const title = append(header, $('span.review-diag-title'));
+		const checkWrap = append(header, $('div.review-diag-check-wrap'));
+		const checkbox = this.disposables.add(new Checkbox(opts.label, opts.checked, defaultCheckboxStyles));
+		checkbox.domNode.classList.add('review-diag-checkbox');
+		checkWrap.appendChild(checkbox.domNode);
+
+		const toggleArea = append(header, $('div.review-diag-toggle-area'));
+		toggleArea.setAttribute('role', 'button');
+		toggleArea.setAttribute('tabindex', '0');
+		toggleArea.setAttribute('aria-expanded', 'true');
+
+		const chevron = append(toggleArea, $('span.review-diag-chevron'));
+		chevron.appendChild(renderIcon(Codicon.chevronDown));
+
+		const title = append(toggleArea, $('span.review-diag-title'));
 		title.textContent = opts.label;
 
-		const checkWrap = append(header, $('div.review-diag-check-wrap'));
-		const checkbox = this.disposables.add(new Checkbox(localize('includeInIssue', "Include in issue"), opts.checked, defaultCheckboxStyles));
-		checkWrap.appendChild(checkbox.domNode);
-		const checkLabel = append(checkWrap, $('label.review-diag-check-label'));
-		checkLabel.textContent = localize('includeInIssue', "Include in issue");
-		this.disposables.add(checkbox.onChange(() => {
-			opts.onToggle(checkbox.checked);
-			this.updateDiagnosticBulkToggleButton();
-			this.updateStepUI();
-		}));
-
-		const toggleBtn = this.disposables.add(new Button(header, { ...defaultButtonStyles, secondary: true, supportIcons: true }));
-		toggleBtn.label = `$(chevron-up) ${localize('minimize', "Minimize")}`;
-		toggleBtn.element.classList.add('review-diag-toggle');
-
-		// Content
 		const content = append(group, $('div.review-diag-content'));
 		opts.renderContent(content);
 
 		let expanded = true;
-		this.disposables.add(toggleBtn.onDidClick(() => {
-			expanded = !expanded;
+		const setExpanded = (next: boolean) => {
+			expanded = next;
 			content.style.display = expanded ? '' : 'none';
-			toggleBtn.label = expanded
-				? `$(chevron-up) ${localize('minimize', "Minimize")}`
-				: `$(chevron-down) ${localize('expand', "Expand")}`;
+			toggleArea.setAttribute('aria-expanded', String(expanded));
+			chevron.textContent = '';
+			chevron.appendChild(renderIcon(expanded ? Codicon.chevronDown : Codicon.chevronRight));
+		};
+
+		this.disposables.add(addDisposableListener(toggleArea, EventType.CLICK, () => setExpanded(!expanded)));
+		this.disposables.add(addDisposableListener(toggleArea, EventType.KEY_DOWN, e => {
+			const event = new StandardKeyboardEvent(e);
+			if (event.equals(KeyCode.Enter) || event.equals(KeyCode.Space)) {
+				e.preventDefault();
+				setExpanded(!expanded);
+			}
+		}));
+
+		this.disposables.add(checkbox.onChange(() => {
+			opts.onToggle(checkbox.checked);
+			group.classList.toggle('excluded', !checkbox.checked);
+			this.updateStepUI();
 		}));
 	}
 
@@ -1839,6 +1951,12 @@ export class IssueReporterOverlay {
 			return;
 		}
 		this.screenshots.push(screenshot);
+		// Navigate to the Attachments step so the user sees where the screenshot
+		// was saved instead of staying on whatever step they were composing on
+		// (#318317).
+		if (this.currentStep !== WizardStep.Attachments) {
+			this.setStep(WizardStep.Attachments);
+		}
 		this.updateAttachmentViews();
 		this.updateAttachmentButtons();
 		this.updateStepUI();
@@ -2406,6 +2524,10 @@ ${rows.map(row => row.map(value => this.escapeMarkdownTableCell(value ?? '')).jo
 
 	addRecording(filePath: string, durationMs: number, thumbnailDataUrl?: string): void {
 		this.recordings.push({ filePath, durationMs, thumbnailDataUrl });
+		// Navigate to the Attachments step so the user sees the saved recording (#318317).
+		if (this.currentStep !== WizardStep.Attachments) {
+			this.setStep(WizardStep.Attachments);
+		}
 		this.updateAttachmentViews();
 		this.updateAttachmentButtons();
 		this.updateStepUI();

--- a/src/vs/workbench/contrib/issue/browser/media/issueReporterOverlay.css
+++ b/src/vs/workbench/contrib/issue/browser/media/issueReporterOverlay.css
@@ -1326,7 +1326,7 @@ extension field is hidden (no fixed-width placeholder needed). */
 	padding: 4px 0;
 }
 
-/* Bottom Navigation - now placed in the top toolbar next to the step indicator (#318305) */
+/* Navigation buttons row, placed under the step indicator in the toolbar. */
 .issue-reporter-wizard .wizard-nav {
 	display: flex;
 	align-items: center;
@@ -1773,91 +1773,84 @@ extension field is hidden (no fixed-width placeholder needed). */
 	z-index: 1;
 }
 
-/* --- Wizard feedback (issue #317822) additions --- */
-
-/* Required field marker (*) — see #318311 */
 .issue-reporter-wizard .wizard-required-marker {
-color: var(--vscode-inputValidation-errorForeground, var(--vscode-errorForeground, #f48771));
-margin-left: 4px;
-font-weight: 600;
+	color: var(--vscode-inputValidation-errorForeground, var(--vscode-errorForeground, #f48771));
+	margin-left: 4px;
+	font-weight: 600;
 }
 
-/* Issue guidance link above the form — see #318333 */
 .issue-reporter-wizard .wizard-issue-guidance {
-margin: 0 0 12px;
-padding: 8px 12px;
-border-radius: 4px;
-background: var(--vscode-textBlockQuote-background, rgba(127, 127, 127, 0.1));
-border-left: 3px solid var(--vscode-focusBorder, #007acc);
-font-size: 13px;
-color: var(--vscode-descriptionForeground, #ccc);
+	margin: 0 0 12px;
+	padding: 8px 12px;
+	border-radius: var(--vscode-cornerRadius-small);
+	background: var(--vscode-textBlockQuote-background, rgba(127, 127, 127, 0.1));
+	border-left: 3px solid var(--vscode-focusBorder, #007acc);
+	font-size: 13px;
+	color: var(--vscode-descriptionForeground, #ccc);
 }
 .issue-reporter-wizard .wizard-issue-guidance a,
 .issue-reporter-wizard .wizard-issue-guidance a:focus,
 .issue-reporter-wizard .wizard-issue-guidance a:hover {
-color: var(--vscode-textLink-foreground, #3794ff);
-text-decoration: underline;
+	color: var(--vscode-textLink-foreground, #3794ff);
+	text-decoration: underline;
 }
 
-/* Performance issue wiki link inline in description guidance — see #318332 */
 .issue-reporter-wizard .wizard-description-guidance.wizard-description-guidance-with-link {
-white-space: normal;
+	white-space: normal;
 }
 .issue-reporter-wizard .wizard-description-guidance-link {
-color: var(--vscode-textLink-foreground, #3794ff);
-text-decoration: underline;
-cursor: pointer;
+	color: var(--vscode-textLink-foreground, #3794ff);
+	text-decoration: underline;
+	cursor: pointer;
 }
 
-/* Diagnostic section refactor — see #318312 and #318313 */
 .issue-reporter-wizard .review-diag-heading {
-flex-direction: row;
-align-items: center;
-gap: 8px;
+	flex-direction: row;
+	align-items: center;
+	gap: 8px;
 }
 .issue-reporter-wizard .review-diag-master-wrap {
-display: flex;
-align-items: center;
-gap: 8px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
 }
 .issue-reporter-wizard .review-diag-master-checkbox {
-flex-shrink: 0;
+	flex-shrink: 0;
 }
 .issue-reporter-wizard .review-diagnostics.all-excluded .review-diag-group {
-display: none;
+	display: none;
 }
 .issue-reporter-wizard .review-diag-group.excluded .review-diag-content {
-opacity: 0.55;
+	opacity: 0.55;
 }
 .issue-reporter-wizard .review-diag-group.excluded .review-diag-title {
-color: var(--vscode-descriptionForeground, #999);
+	color: var(--vscode-descriptionForeground, #999);
 }
 .issue-reporter-wizard .review-diag-toggle-area {
-display: inline-flex;
-align-items: center;
-gap: 6px;
-padding: 2px 4px;
-border-radius: 4px;
-cursor: pointer;
-user-select: none;
-flex: 1;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 2px 4px;
+	border-radius: var(--vscode-cornerRadius-small);
+	cursor: pointer;
+	user-select: none;
+	flex: 1;
 }
 .issue-reporter-wizard .review-diag-toggle-area:hover {
-background: var(--vscode-list-hoverBackground, rgba(255, 255, 255, 0.06));
+	background: var(--vscode-list-hoverBackground, rgba(255, 255, 255, 0.06));
 }
 .issue-reporter-wizard .review-diag-toggle-area:focus-visible {
-outline: 1px solid var(--vscode-focusBorder, #007acc);
-outline-offset: -1px;
+	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder, #007acc);
+	outline-offset: -1px;
 }
 .issue-reporter-wizard .review-diag-chevron {
-display: inline-flex;
-align-items: center;
-color: var(--vscode-foreground, #ccc);
-flex-shrink: 0;
+	display: inline-flex;
+	align-items: center;
+	color: var(--vscode-foreground, #ccc);
+	flex-shrink: 0;
 }
 
-/* Modal accessibility: ensure the floating capture bar is always above any
- * workbench overlays (e.g. modal dialogs in the Agents Window) — see #318307 */
+/* Keep the floating capture bar above workbench overlays such as modal dialogs. */
 .issue-reporter-floating-bar {
-z-index: 5000;
+	z-index: 5000;
 }

--- a/src/vs/workbench/contrib/issue/browser/media/issueReporterOverlay.css
+++ b/src/vs/workbench/contrib/issue/browser/media/issueReporterOverlay.css
@@ -9,10 +9,6 @@
  * A floating capture bar appears on step 3.
  */
 
-.issue-reporter-wizard .wizard-toolbar > .wizard-toolbar-spacer {
-	flex: 1;
-}
-
 /* Wizard Panel - renders inside the editor tab */
 .issue-reporter-wizard {
 	position: relative;
@@ -29,7 +25,6 @@
 
 .issue-reporter-wizard .wizard-toolbar {
 	-webkit-app-region: no-drag;
-	padding-right: 0;
 }
 
 .issue-reporter-wizard .wizard-update-banner {
@@ -297,8 +292,9 @@
 /* Toolbar */
 .issue-reporter-wizard .wizard-toolbar {
 	display: flex;
-	align-items: center;
-	gap: 8px;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 10px;
 	padding: 8px 16px;
 	background: var(--vscode-titleBar-activeBackground, #3c3c3c);
 	border-bottom: 1px solid var(--vscode-panel-border, #444);
@@ -1330,14 +1326,12 @@ extension field is hidden (no fixed-width placeholder needed). */
 	padding: 4px 0;
 }
 
-/* Bottom Navigation */
+/* Bottom Navigation - now placed in the top toolbar next to the step indicator (#318305) */
 .issue-reporter-wizard .wizard-nav {
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	padding: 12px 40px;
 	flex-shrink: 0;
-	background: var(--vscode-editor-background, #1e1e1e);
 }
 
 /* Button widget overrides for wizard nav */
@@ -1777,4 +1771,93 @@ extension field is hidden (no fixed-width placeholder needed). */
 	padding: 1px 4px;
 	border-radius: 2px;
 	z-index: 1;
+}
+
+/* --- Wizard feedback (issue #317822) additions --- */
+
+/* Required field marker (*) — see #318311 */
+.issue-reporter-wizard .wizard-required-marker {
+color: var(--vscode-inputValidation-errorForeground, var(--vscode-errorForeground, #f48771));
+margin-left: 4px;
+font-weight: 600;
+}
+
+/* Issue guidance link above the form — see #318333 */
+.issue-reporter-wizard .wizard-issue-guidance {
+margin: 0 0 12px;
+padding: 8px 12px;
+border-radius: 4px;
+background: var(--vscode-textBlockQuote-background, rgba(127, 127, 127, 0.1));
+border-left: 3px solid var(--vscode-focusBorder, #007acc);
+font-size: 13px;
+color: var(--vscode-descriptionForeground, #ccc);
+}
+.issue-reporter-wizard .wizard-issue-guidance a,
+.issue-reporter-wizard .wizard-issue-guidance a:focus,
+.issue-reporter-wizard .wizard-issue-guidance a:hover {
+color: var(--vscode-textLink-foreground, #3794ff);
+text-decoration: underline;
+}
+
+/* Performance issue wiki link inline in description guidance — see #318332 */
+.issue-reporter-wizard .wizard-description-guidance.wizard-description-guidance-with-link {
+white-space: normal;
+}
+.issue-reporter-wizard .wizard-description-guidance-link {
+color: var(--vscode-textLink-foreground, #3794ff);
+text-decoration: underline;
+cursor: pointer;
+}
+
+/* Diagnostic section refactor — see #318312 and #318313 */
+.issue-reporter-wizard .review-diag-heading {
+flex-direction: row;
+align-items: center;
+gap: 8px;
+}
+.issue-reporter-wizard .review-diag-master-wrap {
+display: flex;
+align-items: center;
+gap: 8px;
+}
+.issue-reporter-wizard .review-diag-master-checkbox {
+flex-shrink: 0;
+}
+.issue-reporter-wizard .review-diagnostics.all-excluded .review-diag-group {
+display: none;
+}
+.issue-reporter-wizard .review-diag-group.excluded .review-diag-content {
+opacity: 0.55;
+}
+.issue-reporter-wizard .review-diag-group.excluded .review-diag-title {
+color: var(--vscode-descriptionForeground, #999);
+}
+.issue-reporter-wizard .review-diag-toggle-area {
+display: inline-flex;
+align-items: center;
+gap: 6px;
+padding: 2px 4px;
+border-radius: 4px;
+cursor: pointer;
+user-select: none;
+flex: 1;
+}
+.issue-reporter-wizard .review-diag-toggle-area:hover {
+background: var(--vscode-list-hoverBackground, rgba(255, 255, 255, 0.06));
+}
+.issue-reporter-wizard .review-diag-toggle-area:focus-visible {
+outline: 1px solid var(--vscode-focusBorder, #007acc);
+outline-offset: -1px;
+}
+.issue-reporter-wizard .review-diag-chevron {
+display: inline-flex;
+align-items: center;
+color: var(--vscode-foreground, #ccc);
+flex-shrink: 0;
+}
+
+/* Modal accessibility: ensure the floating capture bar is always above any
+ * workbench overlays (e.g. modal dialogs in the Agents Window) — see #318307 */
+.issue-reporter-floating-bar {
+z-index: 5000;
 }

--- a/src/vs/workbench/contrib/issue/common/issue.ts
+++ b/src/vs/workbench/contrib/issue/common/issue.ts
@@ -25,6 +25,7 @@ export const enum IssueType {
 
 export enum IssueSource {
 	VSCode = 'vscode',
+	AgentsWindow = 'agentsWindow',
 	Extension = 'extension',
 	Marketplace = 'marketplace',
 	Unknown = 'unknown'

--- a/src/vs/workbench/contrib/issue/electron-browser/issue.contribution.ts
+++ b/src/vs/workbench/contrib/issue/electron-browser/issue.contribution.ts
@@ -23,7 +23,7 @@ import { SyncDescriptor } from '../../../../platform/instantiation/common/descri
 import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
 import { IssueQuickAccess } from '../browser/issueQuickAccess.js';
 import '../browser/issueTroubleshoot.js';
-import '../browser/issueReporterKeybindings.js';
+import './issueReporterKeybindings.js';
 import { BaseIssueContribution } from '../common/issue.contribution.js';
 import { IIssueFormService, IWorkbenchIssueService, IssueType } from '../common/issue.js';
 import { NativeIssueService } from './issueService.js';
@@ -34,7 +34,7 @@ import { IRecordingService } from '../browser/recordingService.js';
 import { NativeRecordingService } from './nativeRecordingService.js';
 import { IGitHubUploadService } from '../browser/githubUploadService.js';
 import { NativeGitHubUploadService } from './nativeGitHubUploadService.js';
-import { IssueReporterEditorPane } from '../browser/issueReporterEditorPane.js';
+import { IssueReporterEditorPane } from './issueReporterEditorPane.js';
 import { IssueReporterEditorInput } from '../browser/issueReporterEditorInput.js';
 
 //#region Issue Contribution

--- a/src/vs/workbench/contrib/issue/electron-browser/issueReporterEditorPane.ts
+++ b/src/vs/workbench/contrib/issue/electron-browser/issueReporterEditorPane.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import './media/issueReporterOverlay.css';
+import '../browser/media/issueReporterOverlay.css';
 import { $, append, clearNode, Dimension } from '../../../../base/browser/dom.js';
 import { mainWindow } from '../../../../base/browser/window.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
@@ -19,16 +19,15 @@ import { IEditorGroup, IEditorGroupsService } from '../../../services/editor/com
 import { IEditorOpenContext } from '../../../common/editor.js';
 import { EditorActivation, IEditorOptions } from '../../../../platform/editor/common/editor.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
-// eslint-disable-next-line local/code-import-patterns, local/code-layering
 import { INativeWorkbenchEnvironmentService } from '../../../services/environment/electron-browser/environmentService.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { decodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { URI } from '../../../../base/common/uri.js';
 import { FileAccess } from '../../../../base/common/network.js';
-import { IssueReporterEditorInput } from './issueReporterEditorInput.js';
-import { IssueReporterOverlay } from './issueReporterOverlay.js';
-import { IRecordingService, IRecordingData, RecordingState } from './recordingService.js';
-import { IScreenshotService } from './screenshotService.js';
+import { IssueReporterEditorInput } from '../browser/issueReporterEditorInput.js';
+import { IssueReporterOverlay } from '../browser/issueReporterOverlay.js';
+import { IRecordingService, IRecordingData, RecordingState } from '../browser/recordingService.js';
+import { IScreenshotService } from '../browser/screenshotService.js';
 import { IIssueFormService } from '../common/issue.js';
 import { IProcessService } from '../../../../platform/process/common/process.js';
 import { IWorkbenchAssignmentService } from '../../../services/assignment/common/assignmentService.js';

--- a/src/vs/workbench/contrib/issue/electron-browser/issueReporterKeybindings.ts
+++ b/src/vs/workbench/contrib/issue/electron-browser/issueReporterKeybindings.ts
@@ -15,9 +15,9 @@ import { IContextKeyService } from '../../../../platform/contextkey/common/conte
 import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
-import { IssueReporterEditorInput } from './issueReporterEditorInput.js';
+import { IssueReporterEditorInput } from '../browser/issueReporterEditorInput.js';
 import { IssueReporterEditorPane, IssueReporterOpenContext } from './issueReporterEditorPane.js';
-import { IssueReporterOverlay } from './issueReporterOverlay.js';
+import { IssueReporterOverlay } from '../browser/issueReporterOverlay.js';
 
 export const ISSUE_REPORTER_CAPTURE_SCREENSHOT_COMMAND_ID = 'workbench.action.issueReporter.captureScreenshot';
 export const ISSUE_REPORTER_TOGGLE_RECORDING_COMMAND_ID = 'workbench.action.issueReporter.toggleRecording';

--- a/src/vs/workbench/contrib/issue/electron-browser/nativeIssueFormService.ts
+++ b/src/vs/workbench/contrib/issue/electron-browser/nativeIssueFormService.ts
@@ -22,6 +22,7 @@ import { IGitHubUploadService } from '../browser/githubUploadService.js';
 import { IssueReporterEditorInput } from '../browser/issueReporterEditorInput.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
 import { IIssueFormService, IssueReporterData } from '../common/issue.js';
 import { IssueReporter } from './issueReporterService.js';
 
@@ -50,6 +51,7 @@ export class NativeIssueFormService extends IssueFormService implements IIssueFo
 		@IEditorService editorService: IEditorService,
 		@IClipboardService clipboardService: IClipboardService,
 		@INativeHostService private readonly nativeHostService: INativeHostService,
+		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService,
 	) {
 		super(instantiationService, auxiliaryWindowService, menuService, contextKeyService, logService, dialogService, hostService, openerService, fileService, githubUploadService, editorService, clipboardService);
 	}
@@ -72,7 +74,14 @@ export class NativeIssueFormService extends IssueFormService implements IIssueFo
 		// Wizard path pulls system info from IProcessService.getSystemInfo() inside
 		// the editor pane, so it does not depend on arch/release/type here.
 		const input = this.instantiationService.createInstance(IssueReporterEditorInput, data);
-		await this.editorService.openEditor(input, { pinned: true });
+
+		// In the Agents window, editors open in a floating modal editor part by
+		// default (`workbench.editor.useModal: 'all'`). The issue reporter needs to
+		// sit alongside the rest of the app so the user can capture screenshots and
+		// recordings, so target the main editor part's active group explicitly to
+		// open it docked in the editor area instead of as a modal overlay.
+		const preferredGroup = data.isSessionsWindow ? this.editorGroupService.mainPart.activeGroup : undefined;
+		await this.editorService.openEditor(input, { pinned: true }, preferredGroup);
 	}
 
 	/**


### PR DESCRIPTION
Implements feedback from the issue reporter wizard test plan (#317822).

### What's included
- **Wizard UX:** default category/target selections with required-field markers, inline guidance and performance-wiki links, navigation moved to its own row under the step indicator, chevron section toggles, and per-section + master checkboxes for diagnostic data.
- **Agents Window:** a dedicated "Agents Window" target (preselected when reporting from there), the reporter now opens docked in the editor area instead of a floating modal, and the irrelevant "A VS Code extension" target is hidden.
- **Attachments:** screenshots/recordings are written to the OS temp folder, capturing jumps to the Attachments step, and attachments are preserved when the editor moves between the editor area and a modal editor part.

Fixes #318305, fixes #318306, fixes #318307, fixes #318309, fixes #318311, fixes #318312, fixes #318313, fixes #318315, fixes #318317, fixes #318318, fixes #318332, fixes #318333, fixes #318376, fixes #318451
