### PR TITLE
Add opt-in CSRF protection for extension UriHandlers

### DIFF
--- a/src/vs/platform/extensions/common/extensions.ts
+++ b/src/vs/platform/extensions/common/extensions.ts
@@ -242,6 +242,16 @@ export interface IExtensionContributions {
 	readonly languageModelTools?: ReadonlyArray<IToolContribution>;
 	readonly languageModelToolSets?: ReadonlyArray<IToolSetContribution>;
 	readonly mcpServerDefinitionProviders?: ReadonlyArray<IMcpCollectionContribution>;
+	readonly uriHandler?: IUriHandlerContribution;
+}
+
+export interface IUriHandlerCsrfProtection {
+	readonly secretFile?: string;
+	readonly unprotectedPaths?: readonly string[];
+}
+
+export interface IUriHandlerContribution {
+	readonly csrfProtection?: boolean | IUriHandlerCsrfProtection;
 }
 
 export interface IExtensionCapabilities {

--- a/src/vs/workbench/api/browser/extensionHost.contribution.ts
+++ b/src/vs/workbench/api/browser/extensionHost.contribution.ts
@@ -14,6 +14,7 @@ import { TokenClassificationExtensionPoints } from '../../services/themes/common
 import { LanguageConfigurationFileHandler } from '../../contrib/codeEditor/common/languageConfigurationExtensionPoint.js';
 import { StatusBarItemsExtensionPoint } from './statusBarExtensionPoint.js';
 import { CSSExtensionPoint } from '../../services/themes/browser/cssExtensionPoint.js';
+import { UriHandlerExtensionPoint } from '../common/uriHandlerExtensionPoint.js';
 
 // --- mainThread participants
 import './mainThreadLocalization.js';
@@ -120,6 +121,7 @@ export class ExtensionPoints implements IWorkbenchContribution {
 		this.instantiationService.createInstance(LanguageConfigurationFileHandler);
 		this.instantiationService.createInstance(StatusBarItemsExtensionPoint);
 		this.instantiationService.createInstance(CSSExtensionPoint);
+		this.instantiationService.createInstance(UriHandlerExtensionPoint);
 	}
 }
 

--- a/src/vs/workbench/api/browser/mainThreadUrls.ts
+++ b/src/vs/workbench/api/browser/mainThreadUrls.ts
@@ -11,6 +11,9 @@ import { Disposable, IDisposable } from '../../../base/common/lifecycle.js';
 import { IExtensionContributedURLHandler, IExtensionUrlHandler } from '../../services/extensions/browser/extensionUrlHandler.js';
 import { ExtensionIdentifier } from '../../../platform/extensions/common/extensions.js';
 import { ITrustedDomainService } from '../../contrib/url/browser/trustedDomainService.js';
+import { INotificationService, Severity } from '../../../platform/notification/common/notification.js';
+import { ICommandService } from '../../../platform/commands/common/commands.js';
+import { localize } from '../../../nls.js';
 
 class ExtensionUrlHandler implements IExtensionContributedURLHandler {
 
@@ -41,11 +44,18 @@ export class MainThreadUrls extends Disposable implements MainThreadUrlsShape {
 		context: IExtHostContext,
 		@ITrustedDomainService trustedDomainService: ITrustedDomainService,
 		@IURLService private readonly urlService: IURLService,
-		@IExtensionUrlHandler private readonly extensionUrlHandler: IExtensionUrlHandler
+		@IExtensionUrlHandler private readonly extensionUrlHandler: IExtensionUrlHandler,
+		@INotificationService private readonly notificationService: INotificationService,
+		@ICommandService private readonly commandService: ICommandService,
 	) {
 		super();
 
 		this.proxy = context.getProxy(ExtHostContext.ExtHostUrls);
+
+		// Expose this extension host as a pre-activation CSRF verifier.
+		this._register(this.extensionUrlHandler.registerCsrfVerifier({
+			verifyCsrf: (extensionId, uri, secretFile) => this.proxy.$verifyCsrf(extensionId, uri, secretFile)
+		}));
 	}
 
 	async $registerUriHandler(handle: number, extensionId: ExtensionIdentifier, extensionDisplayName: string): Promise<void> {
@@ -76,6 +86,15 @@ export class MainThreadUrls extends Disposable implements MainThreadUrlsShape {
 
 	async $createAppUri(uri: UriComponents): Promise<URI> {
 		return this.urlService.create(uri);
+	}
+
+	async $notifyCsrfDeeplinkRejection(extensionId: ExtensionIdentifier, extensionDisplayName: string): Promise<void> {
+		const message = localize('csrfRejected', "VS Code blocked an unauthenticated link to the '{0}' extension. The link was not signed by a trusted local source.", extensionDisplayName);
+
+		this.notificationService.prompt(Severity.Warning, message, [{
+			label: localize('showLogs', "Show Logs"),
+			run: () => this.commandService.executeCommand('workbench.action.showLogs')
+		}]);
 	}
 
 	override dispose(): void {

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -987,8 +987,8 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			registerFileDecorationProvider(provider: vscode.FileDecorationProvider) {
 				return extHostDecorations.registerFileDecorationProvider(provider, extension);
 			},
-			registerUriHandler(handler: vscode.UriHandler) {
-				return extHostUrls.registerUriHandler(extension, handler);
+			registerUriHandler(handler: vscode.UriHandler, options?: vscode.UriHandlerOptions) {
+				return extHostUrls.registerUriHandler(extension, handler, options);
 			},
 			createQuickPick<T extends vscode.QuickPickItem>(): vscode.QuickPick<T> {
 				return extHostQuickOpen.createQuickPick(extension);

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1860,6 +1860,7 @@ export interface MainThreadUrlsShape extends IDisposable {
 	$registerUriHandler(handle: number, extensionId: ExtensionIdentifier, extensionDisplayName: string): Promise<void>;
 	$unregisterUriHandler(handle: number): Promise<void>;
 	$createAppUri(uri: UriComponents): Promise<UriComponents>;
+	$notifyCsrfDeeplinkRejection(extensionId: ExtensionIdentifier, extensionDisplayName: string): Promise<void>;
 }
 
 export interface IChatResponseProgressFileTreeData {
@@ -1886,6 +1887,13 @@ export type IChatProgressDto =
 
 export interface ExtHostUrlsShape {
 	$handleExternalUri(handle: number, uri: UriComponents): Promise<void>;
+	/**
+	 * Pre-activation CSRF check driven from the workbench. Resolves a manifest-declared CSRF policy
+	 * for `extensionId` (if this extension host hosts it) and verifies the uri's token without
+	 * activating the extension. Returns `unhandled` when there is no manifest policy, the path is
+	 * exempt, or this host does not own the extension.
+	 */
+	$verifyCsrf(extensionId: ExtensionIdentifier, uri: UriComponents, secretFile?: string): Promise<'verified' | 'rejected' | 'unhandled'>;
 }
 
 export interface MainThreadUriOpenersShape extends IDisposable {

--- a/src/vs/workbench/api/common/extHostUriHandlerCsrfSecret.ts
+++ b/src/vs/workbench/api/common/extHostUriHandlerCsrfSecret.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../base/common/uri.js';
+import { createDecorator } from '../../../platform/instantiation/common/instantiation.js';
+
+export const IExtHostUriHandlerCsrfSecret = createDecorator<IExtHostUriHandlerCsrfSecret>('IExtHostUriHandlerCsrfSecret');
+
+export interface IExtHostUriHandlerCsrfSecret {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Return the secret bytes for the given file. When `create` is true (default), the file is created
+	 * atomically with owner-only (`0600`) permissions and high-entropy random contents if absent. When
+	 * `create` is false, an absent file yields `undefined` (used by the pre-activation check so a host
+	 * that does not own the extension never creates a spurious secret).
+	 *
+	 * Returns `undefined` when the secret cannot be safely obtained — absent (with `create: false`),
+	 * group/other-writable, or no local filesystem (web). Callers fail closed on `undefined`.
+	 */
+	getSecret(secretFile: URI, create?: boolean): Promise<Uint8Array | undefined>;
+}
+
+/**
+ * Fail-closed implementation for environments with no trustworthy local filesystem (web worker
+ * extension host). There is no local secret a remote page cannot also reach, so a CSRF-protected
+ * handler can never be satisfied here — every link is rejected.
+ */
+export class NullExtHostUriHandlerCsrfSecret implements IExtHostUriHandlerCsrfSecret {
+	declare readonly _serviceBrand: undefined;
+
+	async getSecret(_secretFile: URI, _create?: boolean): Promise<Uint8Array | undefined> {
+		return undefined;
+	}
+}

--- a/src/vs/workbench/api/common/extHostUrls.ts
+++ b/src/vs/workbench/api/common/extHostUrls.ts
@@ -8,9 +8,37 @@ import { MainContext, ExtHostUrlsShape, MainThreadUrlsShape } from './extHost.pr
 import { URI, UriComponents } from '../../../base/common/uri.js';
 import { toDisposable } from '../../../base/common/lifecycle.js';
 import { onUnexpectedError } from '../../../base/common/errors.js';
-import { ExtensionIdentifierSet, IExtensionDescription } from '../../../platform/extensions/common/extensions.js';
+import { ExtensionIdentifier, ExtensionIdentifierSet, IExtensionDescription, IUriHandlerCsrfProtection } from '../../../platform/extensions/common/extensions.js';
 import { createDecorator } from '../../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../../platform/log/common/log.js';
 import { IExtHostRpcService } from './extHostRpcService.js';
+import { IExtensionStoragePaths } from './extHostStoragePaths.js';
+import { IExtHostUriHandlerCsrfSecret } from './extHostUriHandlerCsrfSecret.js';
+import { stripCsrfToken, verifyCsrfToken } from '../../services/extensions/common/uriHandlerCsrf.js';
+
+const SECRET_FILE_NAME = 'uri-csrf.secret';
+
+/** Resolved CSRF configuration for a registered handler, or `false` if protection is off. */
+type ResolvedCsrf = false | { readonly secretFile?: URI; readonly unprotectedPaths: ReadonlySet<string> };
+
+interface IRegisteredHandler {
+	readonly handler: vscode.UriHandler;
+	readonly extension: IExtensionDescription;
+	readonly csrf: ResolvedCsrf;
+}
+
+function resolveCsrfOption(option: vscode.UriHandlerOptions['csrfProtection']): ResolvedCsrf {
+	if (!option) {
+		return false;
+	}
+	if (option === true) {
+		return { unprotectedPaths: new Set() };
+	}
+	return {
+		secretFile: option.secretFile ? URI.revive(option.secretFile) : undefined,
+		unprotectedPaths: new Set(option.unprotectedPaths ?? []),
+	};
+}
 
 export class ExtHostUrls implements ExtHostUrlsShape {
 
@@ -20,15 +48,18 @@ export class ExtHostUrls implements ExtHostUrlsShape {
 	private readonly _proxy: MainThreadUrlsShape;
 
 	private handles = new ExtensionIdentifierSet();
-	private handlers = new Map<number, vscode.UriHandler>();
+	private handlers = new Map<number, IRegisteredHandler>();
 
 	constructor(
-		@IExtHostRpcService extHostRpc: IExtHostRpcService
+		@IExtHostRpcService extHostRpc: IExtHostRpcService,
+		@IExtensionStoragePaths private readonly storagePaths: IExtensionStoragePaths,
+		@IExtHostUriHandlerCsrfSecret private readonly csrfSecret: IExtHostUriHandlerCsrfSecret,
+		@ILogService private readonly logService: ILogService,
 	) {
 		this._proxy = extHostRpc.getProxy(MainContext.MainThreadUrls);
 	}
 
-	registerUriHandler(extension: IExtensionDescription, handler: vscode.UriHandler): vscode.Disposable {
+	registerUriHandler(extension: IExtensionDescription, handler: vscode.UriHandler, options?: vscode.UriHandlerOptions): vscode.Disposable {
 		const extensionId = extension.identifier;
 		if (this.handles.has(extensionId)) {
 			throw new Error(`Protocol handler already registered for extension ${extensionId}`);
@@ -36,7 +67,7 @@ export class ExtHostUrls implements ExtHostUrlsShape {
 
 		const handle = ExtHostUrls.HandlePool++;
 		this.handles.add(extensionId);
-		this.handlers.set(handle, handler);
+		this.handlers.set(handle, { handler, extension, csrf: this.resolveCsrf(extension, options?.csrfProtection) });
 		this._proxy.$registerUriHandler(handle, extensionId, extension.displayName || extension.name);
 
 		return toDisposable(() => {
@@ -46,19 +77,121 @@ export class ExtHostUrls implements ExtHostUrlsShape {
 		});
 	}
 
-	$handleExternalUri(handle: number, uri: UriComponents): Promise<void> {
-		const handler = this.handlers.get(handle);
-
-		if (!handler) {
-			return Promise.resolve(undefined);
+	/** Manifest `contributes.uriHandler.csrfProtection` is authoritative; the runtime option is a fallback. */
+	private resolveCsrf(extension: IExtensionDescription, runtimeOption: vscode.UriHandlerOptions['csrfProtection']): ResolvedCsrf {
+		const manifest = extension.contributes?.uriHandler?.csrfProtection;
+		if (manifest !== undefined) {
+			return this.resolveManifestCsrf(extension, manifest);
 		}
+		return resolveCsrfOption(runtimeOption);
+	}
+
+	private resolveManifestCsrf(extension: IExtensionDescription, csrf: boolean | IUriHandlerCsrfProtection): ResolvedCsrf {
+		if (!csrf) {
+			return false;
+		}
+		if (csrf === true) {
+			return { unprotectedPaths: new Set() };
+		}
+		return {
+			secretFile: csrf.secretFile ? this.resolveSecretPath(this.storagePaths.globalValue(extension), csrf.secretFile) : undefined,
+			unprotectedPaths: new Set(csrf.unprotectedPaths ?? []),
+		};
+	}
+
+	private resolveSecretPath(globalStorage: URI, raw: string): URI {
+		const placeholder = '${globalStorage}';
+		if (raw.startsWith(placeholder)) {
+			const rest = raw.slice(placeholder.length).replace(/^[\\/]+/, '');
+			return rest ? URI.joinPath(globalStorage, rest) : globalStorage;
+		}
+		if (raw.includes('${')) {
+			this.logService.warn(`[uri-csrf] secretFile '${raw}' contains an unsupported placeholder (only \${globalStorage} is recognized); treating it as a literal path.`);
+		}
+		return URI.file(raw);
+	}
+
+	async $handleExternalUri(handle: number, uri: UriComponents): Promise<void> {
+		const entry = this.handlers.get(handle);
+		if (!entry) {
+			return;
+		}
+
+		const target = URI.revive(uri);
+
+		if (entry.csrf) {
+			// Exempt paths (e.g. OAuth callbacks) are dispatched without a token.
+			if (entry.csrf.unprotectedPaths.has(target.path)) {
+				this.invoke(entry.handler, target);
+				return;
+			}
+			const accepted = await this.verifyCsrf(entry.extension, entry.csrf, target);
+			if (!accepted) {
+				return; // rejected — handler is never invoked
+			}
+			this.invoke(entry.handler, stripCsrfToken(target));
+			return;
+		}
+
+		this.invoke(entry.handler, target);
+	}
+
+	/**
+	 * Pre-activation CSRF check fanned out from the workbench. The owning host (where the secret file
+	 * lives) returns a verdict; other hosts see no secret and return 'unhandled'. The manifest policy
+	 * is passed in (the workbench has it), so this does not depend on the extension registry.
+	 */
+	async $verifyCsrf(extensionId: ExtensionIdentifier, uri: UriComponents, secretFile?: string): Promise<'verified' | 'rejected' | 'unhandled'> {
+		const target = URI.revive(uri);
+		// globalValue only reads `extension.identifier`, so a minimal stub suffices here.
+		const globalStorage = this.storagePaths.globalValue({ identifier: extensionId } as IExtensionDescription);
+		const file = secretFile ? this.resolveSecretPath(globalStorage, secretFile) : URI.joinPath(globalStorage, SECRET_FILE_NAME);
+
+		// Read-only: never create the secret in the pre-check, so a host that does not own the
+		// extension simply sees no file and returns 'unhandled'.
+		const secret = await this.csrfSecret.getSecret(file, false);
+		if (!secret) {
+			return 'unhandled';
+		}
+
+		const result = await verifyCsrfToken(secret, target.path, target.query);
+		if (result.ok) {
+			return 'verified';
+		}
+		this.logService.warn(`[uri-csrf] rejected URI for ${extensionId.value} (path: ${target.path}, reason: ${result.reason})`);
+		this._proxy.$notifyCsrfDeeplinkRejection(extensionId, extensionId.value);
+		return 'rejected';
+	}
+
+	private async verifyCsrf(extension: IExtensionDescription, csrf: Exclude<ResolvedCsrf, false>, uri: URI): Promise<boolean> {
+		const secretFile = csrf.secretFile
+			?? URI.joinPath(this.storagePaths.globalValue(extension), SECRET_FILE_NAME);
+
+		let secret: Uint8Array | undefined;
 		try {
-			handler.handleUri(URI.revive(uri));
+			secret = await this.csrfSecret.getSecret(secretFile);
+		} catch (err) {
+			onUnexpectedError(err);
+			secret = undefined;
+		}
+
+		const result = await verifyCsrfToken(secret, uri.path, uri.query);
+		if (result.ok) {
+			return true;
+		}
+
+		// Always log (redacted: never the token or raw payload), and surface a notification by default.
+		this.logService.warn(`[uri-csrf] rejected URI for ${extension.identifier.value} (path: ${uri.path}, reason: ${result.reason})`);
+		this._proxy.$notifyCsrfDeeplinkRejection(extension.identifier, extension.displayName || extension.name);
+		return false;
+	}
+
+	private invoke(handler: vscode.UriHandler, uri: URI): void {
+		try {
+			handler.handleUri(uri);
 		} catch (err) {
 			onUnexpectedError(err);
 		}
-
-		return Promise.resolve(undefined);
 	}
 
 	async createAppUri(uri: URI): Promise<vscode.Uri> {

--- a/src/vs/workbench/api/common/uriHandlerExtensionPoint.ts
+++ b/src/vs/workbench/api/common/uriHandlerExtensionPoint.ts
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as nls from '../../../nls.js';
+import { ExtensionsRegistry } from '../../services/extensions/common/extensionsRegistry.js';
+import { IUriHandlerContribution } from '../../../platform/extensions/common/extensions.js';
+import { isBoolean, isObject, isString } from '../../../base/common/types.js';
+
+/**
+ * The `contributes.uriHandler` extension point. Declaring CSRF protection here (rather than only at
+ * runtime via `registerUriHandler`) makes it statically auditable. See
+ * docs/uri-handler-csrf-protection-proposal.md.
+ */
+export const uriHandlerExtensionPoint = ExtensionsRegistry.registerExtensionPoint<IUriHandlerContribution>({
+	extensionPoint: 'uriHandler',
+	jsonSchema: {
+		description: nls.localize('contributes.uriHandler', "Configures the extension's `vscode.UriHandler` (system-wide `vscode://` deeplinks)."),
+		type: 'object',
+		properties: {
+			csrfProtection: {
+				description: nls.localize('contributes.uriHandler.csrfProtection', "Require incoming URIs to carry a valid CSRF token (HMAC-signed by a local process) before they reach the handler. `true` protects every path; an object can override the secret file location and exempt paths that are legitimately web-initiated (e.g. OAuth callbacks)."),
+				default: true,
+				oneOf: [
+					{ type: 'boolean' },
+					{
+						type: 'object',
+						properties: {
+							secretFile: {
+								type: 'string',
+								description: nls.localize('contributes.uriHandler.csrfProtection.secretFile', "Path to the shared secret file. Supports the `${globalStorage}` placeholder, or an absolute path. When omitted, a derivable default under the extension's global storage is used.")
+							},
+							unprotectedPaths: {
+								type: 'array',
+								description: nls.localize('contributes.uriHandler.csrfProtection.unprotectedPaths', "Uri paths exempt from CSRF protection — dispatched without a token. Required for web-initiated paths a browser cannot sign, such as OAuth callbacks (e.g. `/did-authenticate`)."),
+								items: { type: 'string' }
+							}
+						}
+					}
+				]
+			}
+		}
+	}
+});
+
+/**
+ * Validates `contributes.uriHandler` declarations and surfaces problems in the extension's
+ * diagnostics. The contribution is consumed in the extension host (see `ExtHostUrls`); this handler
+ * exists to register the schema and report malformed config early.
+ */
+export class UriHandlerExtensionPoint {
+
+	constructor() {
+		uriHandlerExtensionPoint.setHandler((extensions) => {
+			for (const extension of extensions) {
+				const value = extension.value;
+				const collector = extension.collector;
+
+				if (!isObject(value)) {
+					collector.error(nls.localize('invalid.uriHandler', "'contributes.uriHandler' must be an object."));
+					continue;
+				}
+
+				const csrf = value.csrfProtection;
+				if (csrf === undefined || isBoolean(csrf)) {
+					continue;
+				}
+				if (!isObject(csrf)) {
+					collector.error(nls.localize('invalid.uriHandler.csrfProtection', "'contributes.uriHandler.csrfProtection' must be a boolean or an object."));
+					continue;
+				}
+				if (csrf.unprotectedPaths !== undefined && (!Array.isArray(csrf.unprotectedPaths) || !csrf.unprotectedPaths.every(isString))) {
+					collector.error(nls.localize('invalid.uriHandler.unprotectedPaths', "'contributes.uriHandler.csrfProtection.unprotectedPaths' must be an array of strings."));
+				}
+			}
+		});
+	}
+}

--- a/src/vs/workbench/api/node/extHost.node.services.ts
+++ b/src/vs/workbench/api/node/extHost.node.services.ts
@@ -31,6 +31,8 @@ import { IExtHostMpcService } from '../common/extHostMcp.js';
 import { NodeExtHostMpcService } from './extHostMcpNode.js';
 import { IExtHostAuthentication } from '../common/extHostAuthentication.js';
 import { NodeExtHostAuthentication } from './extHostAuthentication.js';
+import { IExtHostUriHandlerCsrfSecret } from '../common/extHostUriHandlerCsrfSecret.js';
+import { NodeExtHostUriHandlerCsrfSecret } from './extHostUriHandlerCsrfSecret.js';
 
 // #########################################################################
 // ###                                                                   ###
@@ -53,3 +55,4 @@ registerSingleton(IExtHostTerminalService, ExtHostTerminalService, Instantiation
 registerSingleton(IExtHostTunnelService, NodeExtHostTunnelService, InstantiationType.Eager);
 registerSingleton(IExtHostVariableResolverProvider, NodeExtHostVariableResolverProviderService, InstantiationType.Eager);
 registerSingleton(IExtHostMpcService, NodeExtHostMpcService, InstantiationType.Eager);
+registerSingleton(IExtHostUriHandlerCsrfSecret, NodeExtHostUriHandlerCsrfSecret, InstantiationType.Delayed);

--- a/src/vs/workbench/api/node/extHostUriHandlerCsrfSecret.ts
+++ b/src/vs/workbench/api/node/extHostUriHandlerCsrfSecret.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { randomBytes } from 'crypto';
+import { promises as fs } from 'fs';
+import { dirname, join } from '../../../base/common/path.js';
+import { URI } from '../../../base/common/uri.js';
+import { ILogService } from '../../../platform/log/common/log.js';
+import { IExtHostUriHandlerCsrfSecret } from '../common/extHostUriHandlerCsrfSecret.js';
+
+const SECRET_BYTES = 32;
+
+/**
+ * Node CSRF secret store: a persistent, owner-only file of high-entropy random bytes, created on
+ * first use (by VS Code or a cooperating same-user tool) and never rotated.
+ */
+export class NodeExtHostUriHandlerCsrfSecret implements IExtHostUriHandlerCsrfSecret {
+	declare readonly _serviceBrand: undefined;
+
+	constructor(@ILogService private readonly logService: ILogService) { }
+
+	async getSecret(secretFile: URI, create: boolean = true): Promise<Uint8Array | undefined> {
+		const path = secretFile.fsPath;
+
+		if (create) {
+			try {
+				await this.ensureCreated(path);
+			} catch (err) {
+				this.logService.error(`[uri-csrf] failed to create secret file at ${path}`, err);
+				return undefined;
+			}
+		}
+
+		try {
+			// Reject a group/other-writable secret (POSIX) — another user could replace it and forge.
+			// Read access is allowed; no local file is web-readable regardless.
+			const stat = await fs.stat(path);
+			if (process.platform !== 'win32' && (stat.mode & 0o022) !== 0) {
+				this.logService.warn(`[uri-csrf] secret file ${path} is group/other-writable (mode ${(stat.mode & 0o777).toString(8)}); refusing to trust it`);
+				return undefined;
+			}
+			const data = await fs.readFile(path);
+			if (data.length < SECRET_BYTES) {
+				this.logService.warn(`[uri-csrf] secret file ${path} is too short; refusing to trust it`);
+				return undefined;
+			}
+			return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+		} catch (err) {
+			// An absent file in read-only mode is the normal "not this host" case — don't log it.
+			if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+				this.logService.error(`[uri-csrf] failed to read secret file at ${path}`, err);
+			}
+			return undefined;
+		}
+	}
+
+	private async ensureCreated(path: string): Promise<void> {
+		try {
+			await this.writeAtomically(path);
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+				await fs.mkdir(dirname(path), { recursive: true, mode: 0o700 });
+				await this.writeAtomically(path);
+				return;
+			}
+			throw err;
+		}
+	}
+
+	// Write to a temp file in the same dir, then atomically link it into place so `path` never appears
+	// partially written. `link` fails with EEXIST if the secret exists, preserving first-writer-wins.
+	private async writeAtomically(path: string): Promise<void> {
+		const tmp = join(dirname(path), `.uri-csrf.${randomBytes(8).toString('hex')}.tmp`);
+		await fs.writeFile(tmp, randomBytes(SECRET_BYTES), { mode: 0o600, flag: 'wx' });
+		try {
+			await fs.link(tmp, path);
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code !== 'EEXIST') {
+				throw err;
+			}
+		} finally {
+			await fs.unlink(tmp).catch(() => undefined);
+		}
+	}
+}

--- a/src/vs/workbench/api/test/browser/extHostAuthentication.integrationTest.ts
+++ b/src/vs/workbench/api/test/browser/extHostAuthentication.integrationTest.ts
@@ -38,6 +38,7 @@ import { IHostService } from '../../../services/host/browser/host.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IUserActivityService, UserActivityService } from '../../../services/userActivity/common/userActivityService.js';
 import { ExtHostUrls } from '../../common/extHostUrls.js';
+import { NullExtHostUriHandlerCsrfSecret } from '../../common/extHostUriHandlerCsrfSecret.js';
 import { ISecretStorageService } from '../../../../platform/secrets/common/secrets.js';
 import { TestSecretStorageService } from '../../../../platform/secrets/test/common/testSecretStorageService.js';
 import { IDynamicAuthenticationProviderStorageService } from '../../../services/authentication/common/dynamicAuthenticationProviderStorage.js';
@@ -178,7 +179,7 @@ suite('ExtHostAuthentication', () => {
 				}
 			} as any,
 			new ExtHostWindow(initData, rpcProtocol),
-			new ExtHostUrls(rpcProtocol),
+			new ExtHostUrls(rpcProtocol, null!, new NullExtHostUriHandlerCsrfSecret(), new NullLogService()),
 			new ExtHostProgress(rpcProtocol),
 			disposables.add(new TestLoggerService()),
 			new NullLogService()

--- a/src/vs/workbench/api/test/common/extHostUriHandlerCsrf.test.ts
+++ b/src/vs/workbench/api/test/common/extHostUriHandlerCsrf.test.ts
@@ -1,0 +1,102 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import {
+	canonicalize,
+	computeToken,
+	CSRF_TOKEN_PARAM,
+	CsrfRejectionReason,
+	extractToken,
+	stripCsrfToken,
+	timingSafeEqual,
+	verifyCsrfToken,
+} from '../../../services/extensions/common/uriHandlerCsrf.js';
+
+suite('ExtHostUriHandlerCsrf', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const secret = new TextEncoder().encode('a-very-secret-32-byte-test-value');
+	const PATH = '/start';
+
+	/** Build the query string a legitimate signer would produce for the given route + params. */
+	async function sign(path: string, params: Record<string, string>): Promise<string> {
+		const base = Object.entries(params).map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join('&');
+		const token = await computeToken(secret, path, base);
+		return `${base}&${CSRF_TOKEN_PARAM}=${token}`;
+	}
+
+	test('canonicalize binds the path, is order/encoding-independent, and excludes the token', () => {
+		const a = canonicalize('/start', 'program=%2Fbin%2Fsh&request=launch');
+		const b = canonicalize('/start', 'request=launch&program=/bin/sh');
+		assert.strictEqual(a, b);
+		assert.strictEqual(a, '%2Fstart\nprogram=%2Fbin%2Fsh\nrequest=launch');
+
+		// Different routes produce different canonical messages even with identical params.
+		assert.notStrictEqual(canonicalize('/start', 'program=/bin/sh'), canonicalize('/run', 'program=/bin/sh'));
+
+		// The reserved token param must never participate in the signed message.
+		assert.strictEqual(canonicalize('/start', `program=/bin/sh&${CSRF_TOKEN_PARAM}=deadbeef`), '%2Fstart\nprogram=%2Fbin%2Fsh');
+	});
+
+	test('serialization is injective: a value with delimiters cannot mimic separate params', () => {
+		// A single param whose value contains '\n' and '=' must not canonicalize to the same message
+		// as two distinct params — otherwise a token could be replayed across different param sets.
+		const oneParamWithDelimiters = canonicalize('/x', `a=${encodeURIComponent('b\nc=d')}`);
+		const twoParams = canonicalize('/x', 'a=b&c=d');
+		assert.notStrictEqual(oneParamWithDelimiters, twoParams);
+	});
+
+	test('extractToken / stripCsrfToken', () => {
+		assert.strictEqual(extractToken('a=1&b=2'), undefined);
+		assert.strictEqual(extractToken(`a=1&${CSRF_TOKEN_PARAM}=abc&b=2`), 'abc');
+
+		const stripped = stripCsrfToken(URI.parse(`vscode://ext.id/start?a=1&${CSRF_TOKEN_PARAM}=abc&b=2`));
+		assert.strictEqual(stripped.query, 'a=1&b=2');
+		assert.strictEqual(extractToken(stripped.query), undefined);
+	});
+
+	test('timingSafeEqual', () => {
+		assert.strictEqual(timingSafeEqual('abc', 'abc'), true);
+		assert.strictEqual(timingSafeEqual('abc', 'abd'), false);
+		assert.strictEqual(timingSafeEqual('abc', 'abcd'), false);
+		assert.strictEqual(timingSafeEqual('', ''), true);
+	});
+
+	test('a correctly signed link verifies', async () => {
+		const query = await sign(PATH, { program: '/bin/sh', request: 'launch' });
+		const result = await verifyCsrfToken(secret, PATH, query);
+		assert.deepStrictEqual(result, { ok: true });
+	});
+
+	test('tampering with any param invalidates the token', async () => {
+		const signed = await sign(PATH, { program: '/bin/sh', request: 'launch' });
+		const token = extractToken(signed)!;
+		const tampered = `program=${encodeURIComponent('/bin/evil')}&request=launch&${CSRF_TOKEN_PARAM}=${token}`;
+		const result = await verifyCsrfToken(secret, PATH, tampered);
+		assert.deepStrictEqual(result, { ok: false, reason: CsrfRejectionReason.Mismatch });
+	});
+
+	test('a token minted for one route does not validate against another (path binding)', async () => {
+		const signed = await sign('/start', { program: '/bin/sh' });
+		// Replay the exact same params + token against a different protected route.
+		const result = await verifyCsrfToken(secret, '/run', signed);
+		assert.deepStrictEqual(result, { ok: false, reason: CsrfRejectionReason.Mismatch });
+	});
+
+	test('missing token is rejected', async () => {
+		const result = await verifyCsrfToken(secret, PATH, 'program=/bin/sh&request=launch');
+		assert.deepStrictEqual(result, { ok: false, reason: CsrfRejectionReason.Missing });
+	});
+
+	test('no secret fails closed (even with a token present)', async () => {
+		const signed = await sign(PATH, { program: '/bin/sh' });
+		const result = await verifyCsrfToken(undefined, PATH, signed);
+		assert.deepStrictEqual(result, { ok: false, reason: CsrfRejectionReason.NoSecret });
+	});
+});

--- a/src/vs/workbench/api/test/node/extHostUriHandlerCsrfSecret.test.ts
+++ b/src/vs/workbench/api/test/node/extHostUriHandlerCsrfSecret.test.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../../platform/log/common/log.js';
+import { NodeExtHostUriHandlerCsrfSecret } from '../../node/extHostUriHandlerCsrfSecret.js';
+import { computeToken, CSRF_TOKEN_PARAM, verifyCsrfToken } from '../../../services/extensions/common/uriHandlerCsrf.js';
+
+suite('NodeExtHostUriHandlerCsrfSecret (integration)', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const isWindows = process.platform === 'win32';
+	let dir: string;
+	let store: NodeExtHostUriHandlerCsrfSecret;
+
+	setup(async () => {
+		dir = await fs.mkdtemp(join(tmpdir(), 'uri-csrf-'));
+		store = new NodeExtHostUriHandlerCsrfSecret(new NullLogService());
+	});
+
+	teardown(async () => {
+		await fs.rm(dir, { recursive: true, force: true });
+	});
+
+	function secretUri(name = 'uri-csrf.secret'): URI {
+		return URI.file(join(dir, name));
+	}
+
+	test('creates an owner-only secret of sufficient length', async () => {
+		const file = secretUri();
+		const secret = await store.getSecret(file);
+
+		assert.ok(secret && secret.length >= 32, 'secret should be at least 32 bytes');
+		const stat = await fs.stat(file.fsPath);
+		if (!isWindows) {
+			assert.strictEqual(stat.mode & 0o777, 0o600, 'secret file should be created mode 0600');
+		}
+	});
+
+	test('is persistent: a second read returns the identical secret (no rotation)', async () => {
+		const file = secretUri();
+		const first = await store.getSecret(file);
+		const second = await store.getSecret(file);
+		assert.deepStrictEqual(Array.from(second!), Array.from(first!), 'secret must not change between reads');
+	});
+
+	test('create=false does not create the file and yields undefined when absent', async () => {
+		const file = secretUri('missing.secret');
+		const secret = await store.getSecret(file, false);
+		assert.strictEqual(secret, undefined);
+		await assert.rejects(fs.stat(file.fsPath), 'file must not have been created');
+	});
+
+	test('end-to-end: a link signed with the stored secret verifies, and tampering is rejected', async () => {
+		const secret = (await store.getSecret(secretUri()))!;
+		const path = '/start';
+		const base = 'program=%2Fbin%2Fsh&request=launch';
+
+		const token = await computeToken(secret, path, base);
+		const signed = `${base}&${CSRF_TOKEN_PARAM}=${token}`;
+		assert.deepStrictEqual(await verifyCsrfToken(secret, path, signed), { ok: true });
+
+		const tampered = `program=%2Fbin%2Fevil&request=launch&${CSRF_TOKEN_PARAM}=${token}`;
+		assert.strictEqual((await verifyCsrfToken(secret, path, tampered)).ok, false);
+	});
+
+	(isWindows ? test.skip : test)('rejects a group/other-writable secret (POSIX)', async () => {
+		const file = secretUri();
+		await store.getSecret(file); // create it 0600
+		await fs.chmod(file.fsPath, 0o660); // make it group-writable
+
+		const secret = await store.getSecret(file);
+		assert.strictEqual(secret, undefined, 'a group-writable secret must not be trusted');
+	});
+});

--- a/src/vs/workbench/api/worker/extHost.worker.services.ts
+++ b/src/vs/workbench/api/worker/extHost.worker.services.ts
@@ -12,6 +12,7 @@ import { ExtHostLogService } from '../common/extHostLogService.js';
 import { ExtensionStoragePaths, IExtensionStoragePaths } from '../common/extHostStoragePaths.js';
 import { ExtHostTelemetry, IExtHostTelemetry } from '../common/extHostTelemetry.js';
 import { ExtHostExtensionService } from './extHostExtensionService.js';
+import { IExtHostUriHandlerCsrfSecret, NullExtHostUriHandlerCsrfSecret } from '../common/extHostUriHandlerCsrfSecret.js';
 
 // #########################################################################
 // ###                                                                   ###
@@ -24,3 +25,4 @@ registerSingleton(IExtHostAuthentication, ExtHostAuthentication, InstantiationTy
 registerSingleton(IExtHostExtensionService, ExtHostExtensionService, InstantiationType.Eager);
 registerSingleton(IExtensionStoragePaths, ExtensionStoragePaths, InstantiationType.Eager);
 registerSingleton(IExtHostTelemetry, new SyncDescriptor(ExtHostTelemetry, [true], true));
+registerSingleton(IExtHostUriHandlerCsrfSecret, NullExtHostUriHandlerCsrfSecret, InstantiationType.Delayed);

--- a/src/vs/workbench/services/extensions/browser/extensionUrlHandler.ts
+++ b/src/vs/workbench/services/extensions/browser/extensionUrlHandler.ts
@@ -13,6 +13,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 import { IURLHandler, IURLService, IOpenURLOptions } from '../../../../platform/url/common/url.js';
 import { IHostService } from '../../host/browser/host.js';
 import { ActivationKind, IExtensionService } from '../common/extensions.js';
+import { stripCsrfToken } from '../common/uriHandlerCsrf.js';
 import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/contributions.js';
@@ -71,10 +72,23 @@ export interface IExtensionContributedURLHandler extends IURLHandler {
 	extensionDisplayName: string;
 }
 
+/** Verdict of a pre-activation CSRF check for a deeplink. */
+export type UriHandlerCsrfVerdict = 'verified' | 'rejected' | 'unhandled';
+
+/**
+ * Verifies a deeplink's CSRF token before the target extension is activated. Implemented per
+ * extension host (by `MainThreadUrls`); only the host that owns the extension returns a definitive
+ * verdict, the rest return `unhandled`.
+ */
+export interface IUriHandlerCsrfVerifier {
+	verifyCsrf(extensionId: ExtensionIdentifier, uri: URI, secretFile?: string): Promise<UriHandlerCsrfVerdict>;
+}
+
 export interface IExtensionUrlHandler {
 	readonly _serviceBrand: undefined;
 	registerExtensionHandler(extensionId: ExtensionIdentifier, handler: IExtensionContributedURLHandler): void;
 	unregisterExtensionHandler(extensionId: ExtensionIdentifier): void;
+	registerCsrfVerifier(verifier: IUriHandlerCsrfVerifier): IDisposable;
 }
 
 export interface IExtensionUrlHandlerOverride {
@@ -118,6 +132,7 @@ class ExtensionUrlHandler implements IExtensionUrlHandler, IURLHandler {
 
 	private extensionHandlers = new Map<string, IExtensionContributedURLHandler>();
 	private uriBuffer = new Map<string, { timestamp: number; uri: URI }[]>();
+	private csrfVerifiers = new Set<IUriHandlerCsrfVerifier>();
 	private userTrustedExtensionsStorage: UserTrustedExtensionIdStorage;
 	private disposable: IDisposable;
 
@@ -168,6 +183,7 @@ class ExtensionUrlHandler implements IExtensionUrlHandler, IURLHandler {
 
 		const initialHandler = this.extensionHandlers.get(ExtensionIdentifier.toKey(extensionId));
 		let extensionDisplayName: string;
+		let csrfTrusted = false;
 
 		if (!initialHandler) {
 			// The extension is not yet activated, so let's check if it is installed and enabled
@@ -175,19 +191,37 @@ class ExtensionUrlHandler implements IExtensionUrlHandler, IURLHandler {
 			if (!extension) {
 				await this.handleUnhandledURL(uri, extensionId, options);
 				return true;
-			} else {
-				extensionDisplayName = extension.displayName ?? '';
+			}
+			extensionDisplayName = extension.displayName ?? '';
+
+			// Pre-activation CSRF check (manifest-declared): drop forged links before activating,
+			// and let a verified link skip the trust prompt.
+			const csrf = extension.contributes?.uriHandler?.csrfProtection;
+			if (csrf && this.csrfVerifiers.size > 0) {
+				const policy = csrf === true ? undefined : csrf;
+				const exempt = policy?.unprotectedPaths?.includes(uri.path) ?? false;
+				if (!exempt) {
+					const verdict = await this.checkCsrf(extension.identifier, uri, policy?.secretFile);
+					if (verdict === 'rejected') {
+						return true; // handled by dropping it — the extension is never activated
+					}
+					csrfTrusted = verdict === 'verified';
+				}
 			}
 		} else {
+			// Already-activated: no pre-activation check needed. Forged links are still gated by the
+			// authoritative verification in ExtHostUrls.$handleExternalUri before the handler runs.
 			extensionDisplayName = initialHandler.extensionDisplayName;
 		}
 
-		const trusted = options?.trusted
+		const trusted = csrfTrusted
+			|| options?.trusted
 			|| this.productService.trustedExtensionProtocolHandlers?.some(value => equalsIgnoreCase(value, extensionId))
 			|| this.didUserTrustExtension(ExtensionIdentifier.toKey(extensionId));
 
 		if (!trusted) {
-			const uriString = uri.toString(false);
+			// don't print invalid csrf token in the toast
+			const uriString = stripCsrfToken(uri).toString(false);
 			let uriLabel = uriString;
 
 			if (uriLabel.length > 40) {
@@ -259,6 +293,25 @@ class ExtensionUrlHandler implements IExtensionUrlHandler, IURLHandler {
 
 	unregisterExtensionHandler(extensionId: ExtensionIdentifier): void {
 		this.extensionHandlers.delete(ExtensionIdentifier.toKey(extensionId));
+	}
+
+	registerCsrfVerifier(verifier: IUriHandlerCsrfVerifier): IDisposable {
+		this.csrfVerifiers.add(verifier);
+		return toDisposable(() => this.csrfVerifiers.delete(verifier));
+	}
+
+	private async checkCsrf(extensionId: ExtensionIdentifier, uri: URI, secretFile?: string): Promise<UriHandlerCsrfVerdict> {
+		const verdicts = await Promise.all(
+			[...this.csrfVerifiers].map(verifier => verifier.verifyCsrf(extensionId, uri, secretFile).then(v => v, () => 'unhandled' as const))
+		);
+		// Fail closed: any host that rejects wins; otherwise a definitive `verified` from the owning host.
+		if (verdicts.some(v => v === 'rejected')) {
+			return 'rejected';
+		}
+		if (verdicts.some(v => v === 'verified')) {
+			return 'verified';
+		}
+		return 'unhandled';
 	}
 
 	private async handleURLByExtension(extensionId: ExtensionIdentifier | string, handler: IURLHandler, uri: URI, options?: IOpenURLOptions): Promise<boolean> {
@@ -342,6 +395,7 @@ class ExtensionUrlHandler implements IExtensionUrlHandler, IURLHandler {
 		this.disposable.dispose();
 		this.extensionHandlers.clear();
 		this.uriBuffer.clear();
+		this.csrfVerifiers.clear();
 	}
 }
 

--- a/src/vs/workbench/services/extensions/common/extensionPoints.json
+++ b/src/vs/workbench/services/extensions/common/extensionPoints.json
@@ -52,6 +52,7 @@
 	"terminal",
 	"terminalQuickFixes",
 	"themes",
+	"uriHandler",
 	"views",
 	"viewsContainers",
 	"viewsWelcome",

--- a/src/vs/workbench/services/extensions/common/uriHandlerCsrf.ts
+++ b/src/vs/workbench/services/extensions/common/uriHandlerCsrf.ts
@@ -1,0 +1,177 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../../base/common/uri.js';
+
+/**
+ * CSRF protection for extension URI handlers.
+ *
+ * A registered URI handler is reachable from any website via `vscode://publisher.ext/...`, and
+ * VS Code cannot tell a browser-initiated deeplink from a locally-initiated one. The only way to
+ * *prove* a link came from a local process is to require it to read an on-disk secret that the web
+ * cannot access.
+ *
+ * A legitimate local tool reads the secret and signs the deeplink's query parameters with
+ * HMAC-SHA256, carrying the signature in the reserved {@link CSRF_TOKEN_PARAM} parameter. The
+ * secret itself never travels in the URL. VS Code recomputes the HMAC over the received parameters
+ * and rejects any link whose signature does not match.
+ *
+ * Properties:
+ * - **Web-CSRF safe** — a browser has no filesystem access, so it cannot read the secret or forge a token.
+ * - **Secret stays off the wire** — only the HMAC is transmitted, so logged URIs do not leak the secret.
+ * - **Tamper-evident** — the token is bound to the exact parameters; changing any one invalidates it.
+ *
+ * NOT provided by this scheme:
+ * - **Replay resistance** — a captured valid link can be replayed *verbatim*; the token carries no
+ *   freshness (nonce/timestamp). Adding that would require the signer to include a fresh value and
+ *   VS Code to track/expire it. See the proposal doc for the trade-offs.
+ */
+
+/**
+ * Reserved query parameter carrying the HMAC token. Extensions may not define this parameter; it
+ * is excluded from signature computation, stripped before `handleUri`, and redacted from logs.
+ */
+export const CSRF_TOKEN_PARAM = 'vscode-csrf-token';
+
+interface IQueryParam {
+	readonly key: string;
+	readonly value: string;
+}
+
+/**
+ * Parse a raw URI query string (the part after `?`, as found in {@link URI.query}) into decoded
+ * key/value pairs. Values are percent-decoded with {@link decodeURIComponent} — the same encoding
+ * the shipped signing helper uses. (`+` is NOT treated as a space; signers must percent-encode.)
+ */
+function parseQuery(query: string): IQueryParam[] {
+	const params: IQueryParam[] = [];
+	if (!query) {
+		return params;
+	}
+	for (const part of query.split('&')) {
+		if (!part) {
+			continue;
+		}
+		const eq = part.indexOf('=');
+		const rawKey = eq === -1 ? part : part.slice(0, eq);
+		const rawValue = eq === -1 ? '' : part.slice(eq + 1);
+		params.push({ key: safeDecode(rawKey), value: safeDecode(rawValue) });
+	}
+	return params;
+}
+
+function safeDecode(value: string): string {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		// Malformed percent-encoding — fall back to the raw value so a broken param can never
+		// accidentally collide with the reserved token name or silently match a signature.
+		return value;
+	}
+}
+
+/**
+ * Canonical form that both the signer and verifier must agree on, byte for byte:
+ *   1. decode the path and params (so transit re-encoding does not matter);
+ *   2. drop the reserved {@link CSRF_TOKEN_PARAM};
+ *   3. sort the params lexicographically by decoded key then value (so transit reordering does not matter);
+ *   4. line 0 is `encodeURIComponent(path)` (binds the token to the route); then one line per param,
+ *      `encodeURIComponent(key)=encodeURIComponent(value)`; all `\n`-separated.
+ *
+ * Encoding **every** component is what makes the serialization injective: an encoded token can never
+ * contain a raw `=`, `&`, or `\n`, so no key or value can be crafted to collide with the line/field
+ * delimiters or the path line. Together with the sort and the decode, distinct `(path, params)`
+ * inputs always map to distinct messages, while pure reordering or re-encoding in transit does not —
+ * but changing any actual path, key, or value invalidates the token.
+ */
+export function canonicalize(path: string, query: string): string {
+	const params = parseQuery(query).filter(p => p.key !== CSRF_TOKEN_PARAM);
+	params.sort((a, b) => a.key < b.key ? -1 : a.key > b.key ? 1 : a.value < b.value ? -1 : a.value > b.value ? 1 : 0);
+	return [encodeURIComponent(path), ...params.map(p => `${encodeURIComponent(p.key)}=${encodeURIComponent(p.value)}`)].join('\n');
+}
+
+/** Extract the claimed token, or `undefined` if the reserved parameter is absent. */
+export function extractToken(query: string): string | undefined {
+	for (const param of parseQuery(query)) {
+		if (param.key === CSRF_TOKEN_PARAM) {
+			return param.value;
+		}
+	}
+	return undefined;
+}
+
+/** Return a copy of `uri` with the reserved token parameter removed, for handing to `handleUri`. */
+export function stripCsrfToken(uri: URI): URI {
+	if (!uri.query) {
+		return uri;
+	}
+	const kept = uri.query.split('&').filter(part => {
+		if (!part) {
+			return false;
+		}
+		const eq = part.indexOf('=');
+		const rawKey = eq === -1 ? part : part.slice(0, eq);
+		return safeDecode(rawKey) !== CSRF_TOKEN_PARAM;
+	});
+	return uri.with({ query: kept.join('&') });
+}
+
+function toHex(bytes: Uint8Array): string {
+	let out = '';
+	for (let i = 0; i < bytes.length; i++) {
+		out += bytes[i].toString(16).padStart(2, '0');
+	}
+	return out;
+}
+
+/** Compute the expected hex-encoded HMAC-SHA256 token for a route path, query string, and secret. */
+export async function computeToken(secret: Uint8Array, path: string, query: string): Promise<string> {
+	const key = await crypto.subtle.importKey('raw', secret as unknown as ArrayBufferView<ArrayBuffer>, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+	const message = new TextEncoder().encode(canonicalize(path, query));
+	const signature = await crypto.subtle.sign('HMAC', key, message as unknown as ArrayBufferView<ArrayBuffer>);
+	return toHex(new Uint8Array(signature));
+}
+
+/**
+ * Constant-time string comparison. Runs in time proportional to the longer input and does not
+ * short-circuit on the first differing byte, so it does not leak match length via timing.
+ */
+export function timingSafeEqual(a: string, b: string): boolean {
+	const aBytes = new TextEncoder().encode(a);
+	const bBytes = new TextEncoder().encode(b);
+	const len = Math.max(aBytes.length, bBytes.length);
+	let diff = aBytes.length ^ bBytes.length;
+	for (let i = 0; i < len; i++) {
+		diff |= (i < aBytes.length ? aBytes[i] : 0) ^ (i < bBytes.length ? bBytes[i] : 0);
+	}
+	return diff === 0;
+}
+
+export const enum CsrfRejectionReason {
+	/** No `vscode-csrf-token` parameter was present. */
+	Missing = 'missing',
+	/** The secret could not be safely obtained (no local fs, or unsafe file permissions). */
+	NoSecret = 'no-secret',
+	/** A token was present but did not match the expected HMAC. */
+	Mismatch = 'mismatch',
+}
+
+export type CsrfVerifyResult = { readonly ok: true } | { readonly ok: false; readonly reason: CsrfRejectionReason };
+
+/**
+ * Verify a URI's CSRF token against a secret, binding the signature to the route `path`. `secret` is
+ * `undefined` when the secret could not be safely obtained — in which case verification fails closed.
+ */
+export async function verifyCsrfToken(secret: Uint8Array | undefined, path: string, query: string): Promise<CsrfVerifyResult> {
+	const claimed = extractToken(query);
+	if (claimed === undefined) {
+		return { ok: false, reason: CsrfRejectionReason.Missing };
+	}
+	if (!secret) {
+		return { ok: false, reason: CsrfRejectionReason.NoSecret };
+	}
+	const expected = await computeToken(secret, path, query);
+	return timingSafeEqual(expected, claimed) ? { ok: true } : { ok: false, reason: CsrfRejectionReason.Mismatch };
+}

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -11062,6 +11062,60 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * Options for CSRF protection of a {@link UriHandler}. See {@link UriHandlerOptions.csrfProtection}.
+	 */
+	export interface UriHandlerCsrfProtectionOptions {
+		/**
+		 * Absolute path to the file holding the shared secret used to sign incoming uris.
+		 *
+		 * When omitted, a derivable default location under the extension's global storage is used so a
+		 * cooperating local tool can find it without configuration. Provide this only when an existing
+		 * local tool expects the secret at a fixed path.
+		 *
+		 * Regardless of location, the editor creates the file if absent (atomically, owner-only), fills
+		 * it with high-entropy random contents, and **refuses to trust it if it is group- or
+		 * world-readable**. The path resolves on the machine where the handler runs (the remote host for
+		 * a remote extension), which is the same machine the signing tool runs on.
+		 */
+		readonly secretFile?: Uri;
+
+		/**
+		 * Uri {@link Uri.path paths} that are exempt from CSRF protection: incoming uris whose path
+		 * matches one of these (exactly, case-sensitively) are dispatched **without** requiring a token.
+		 * Every other path requires a valid token.
+		 *
+		 * This is necessary for legitimately web-initiated routes that a browser cannot sign — most
+		 * importantly authentication callbacks ({@link env.asExternalUri} → {@link env.openExternal} →
+		 * browser redirect back to the handler). Such a path must be exempted or it would be blocked.
+		 */
+		readonly unprotectedPaths?: readonly string[];
+	}
+
+	/**
+	 * Options for {@link window.registerUriHandler}.
+	 */
+	export interface UriHandlerOptions {
+		/**
+		 * Require every incoming uri to carry a valid CSRF token before it reaches
+		 * {@link UriHandler.handleUri}. This proves the uri was created by a local process (which can
+		 * read the shared secret) rather than a remote web page (which cannot), mitigating cross-site
+		 * request forgery against the handler.
+		 *
+		 * - `true` — enable with the derivable default secret location, protecting every route.
+		 * - {@link UriHandlerCsrfProtectionOptions} — enable, optionally override the secret location,
+		 *   and/or exempt specific routes (e.g. authentication callbacks).
+		 *
+		 * A missing, malformed, or mismatched token causes the uri to be rejected — the handler is not
+		 * invoked and the user is notified. The reserved `vscode-csrf-token` query parameter carries the
+		 * signature; it is stripped before {@link UriHandler.handleUri} is called.
+		 *
+		 * This can also be declared in `package.json` via `contributes.uriHandler.csrfProtection`, which
+		 * is the recommended, statically-auditable form and takes precedence over this option.
+		 */
+		readonly csrfProtection?: boolean | UriHandlerCsrfProtectionOptions;
+	}
+
+	/**
 	 * Namespace for dealing with the current window of the editor. That is visible
 	 * and active editors, as well as, UI elements to show messages, selections, and
 	 * asking for user input.
@@ -11719,9 +11773,10 @@ declare module 'vscode' {
 		 * the current extension is about to be handled.
 		 *
 		 * @param handler The uri handler to register for this extension.
+		 * @param options Options controlling how incoming uris are handled, e.g. CSRF protection.
 		 * @returns A {@link Disposable disposable} that unregisters the handler.
 		 */
-		export function registerUriHandler(handler: UriHandler): Disposable;
+		export function registerUriHandler(handler: UriHandler, options?: UriHandlerOptions): Disposable;
 
 		/**
 		 * Registers a webview panel serializer.


### PR DESCRIPTION
TLDR: This allows extension owners to lock down access to their deeplinks to only the local computer, which is a nice defensive boundary.

---

Extension URI handlers (`vscode://publisher.ext/...`) are attack surfaces that are reachable from any code path that can hit the OS protocol handler. This includes  including browsers, so any clicked link may hit this attack surface.

Certain extensions may want to expose functionality only to a local program (for example, a testing extension and associated testing CLI), but not to browsers.

VS Code cannot tell a browser-initiated deeplink from a local one -- both arrive as the same URI string through the OS protocol handler. I thought the best way to prove local origin was to require knowledge of an on-disk secret. This adds an opt-in mechanism where a local tool signs the deeplink's path + params with HMAC-SHA256 (key = an owner-only secret file), carried in a reserved `vscode-csrf-token` query param. VS Code recomputes the HMAC and rejects on mismatch; the secret never travels in the URL.

This allows extension owners to lock down access to their deeplinks to only the local computer, which is a nice defensive boundary.

API (stable, optional -- not behind enabledApiProposals, so published extensions can adopt it):
- package.json: `contributes.uriHandler.csrfProtection` (authoritative)
- runtime: `registerUriHandler(handler, { csrfProtection })` where csrfProtection is `true` or `{ secretFile?, unprotectedPaths? }`. unprotectedPaths exempts legitimately web-initiated routes (e.g. OAuth callbacks) that a browser cannot sign.

Implementation:
- Pure core (canonicalize, HMAC via crypto.subtle, constant-time compare, token strip) in services/extensions/common/uriHandlerCsrf.ts, with unit tests.
- Secret store: owner-only file, crash-safe temp-then-link create, persistent (no rotation); rejects group/other-writable files; fail-closed Null impl for the web worker ext host.
- Enforcement in ExtHostUrls.$handleExternalUri; rejections are logged (redacted) and surface one warning toast.
- Pre-activation hook: the workbench fans out $verifyCsrf to extension hosts so forged links are dropped before the extension activates, and verified links skip the trust prompt (manifest-declared policy only). Maybe this was added complexity that wasn't worth it, and we can tolerate activating the extension for a simpler diff.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
