### PR TITLE
chat: open new-file edit pills in a normal editor instead of diff

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
@@ -26,6 +26,7 @@ import { Range } from '../../../../../../editor/common/core/range.js';
 import { isLocation, type SymbolTag } from '../../../../../../editor/common/languages.js';
 import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
 import { IModelService } from '../../../../../../editor/common/services/model.js';
+import { ITextModelService } from '../../../../../../editor/common/services/resolverService.js';
 import { EditDeltaInfo } from '../../../../../../editor/common/textModelEditSource.js';
 import { localize } from '../../../../../../nls.js';
 import { getFlatContextMenuActions } from '../../../../../../platform/actions/browser/menuEntryActionViewItem.js';
@@ -851,6 +852,7 @@ export class CollapsedCodeBlock extends ChatEditPillElement {
 		@IHoverService hoverService: IHoverService,
 		@IChatService private readonly chatService: IChatService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@ITextModelService private readonly textModelService: ITextModelService,
 	) {
 		super(labelService, modelService, languageService, hoverService);
 
@@ -877,15 +879,40 @@ export class CollapsedCodeBlock extends ChatEditPillElement {
 		}));
 	}
 
-	private showDiff({ editorOptions: options, openToSide }: IOpenEditorOptions): void {
+	private async showDiff({ editorOptions: options, openToSide }: IOpenEditorOptions): Promise<void> {
+		const group = openToSide ? SIDE_GROUP : undefined;
 		if (this.currentDiff) {
+			// If the change is a pure addition into a file whose original version did not
+			// exist or was empty, there is nothing meaningful to diff against. Open the
+			// file in a normal editor instead of a diff editor.
+			if (this.currentDiff.removed === 0 && await this.isOriginalEmpty(this.currentDiff.originalURI) && this.uri) {
+				this.editorService.openEditor({ resource: this.uri, options }, group);
+				return;
+			}
 			this.editorService.openEditor({
 				original: { resource: this.currentDiff.originalURI },
 				modified: { resource: this.currentDiff.modifiedURI },
 				options
-			}, openToSide ? SIDE_GROUP : undefined);
+			}, group);
 		} else if (this.uri) {
-			this.editorService.openEditor({ resource: this.uri, options }, openToSide ? SIDE_GROUP : undefined);
+			this.editorService.openEditor({ resource: this.uri, options }, group);
+		}
+	}
+
+	/**
+	 * Resolves the original (pre-edit) snapshot and reports whether it had no
+	 * content, which is the case when the file was newly created or was empty.
+	 */
+	private async isOriginalEmpty(originalURI: URI): Promise<boolean> {
+		try {
+			const ref = await this.textModelService.createModelReference(originalURI);
+			try {
+				return ref.object.textEditorModel.getValueLength() === 0;
+			} finally {
+				ref.dispose();
+			}
+		} catch {
+			return false;
 		}
 	}
 


### PR DESCRIPTION
## What

When clicking a file-edit pill shown inline in the chat widget, VS Code always opened a diff editor for the change. For a brand-new file (or one whose original version was empty), the left-hand side of that diff is empty, which isn't useful.

This change makes the inline edit pill (`CollapsedCodeBlock` in `chatMarkdownContentPart.ts`) open the file in a normal code editor instead of a diff editor when the change is a pure addition whose original version did not exist or was empty.

## How

In `CollapsedCodeBlock.showDiff`:
- Cheap pre-filter on `currentDiff.removed === 0` (no deletions).
- Resolve the original snapshot via `ITextModelService` and check `getValueLength() === 0` to confirm the original was empty/nonexistent.
- If so, open the on-disk file (`this.uri`) in a normal editor; otherwise fall back to the diff editor as before.

## Notes for reviewers

- The parallel agent-host pill (`ChatExternalEditContentPart`) already opens a normal editor for newly-created files (its `beforeContentUri` is undefined for creates), so no change was needed there.
- Validated with the TS language service (no errors) and ESLint (clean). The repo hygiene pre-commit script could not run in this environment due to a missing build dependency (`gulp-merge-json`), unrelated to this change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>