### PR TITLE
Fix voice mode mini view bugs

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget.ts
@@ -9,7 +9,7 @@ import { Disposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { localize } from '../../../../nls.js';
 import { URI } from '../../../../base/common/uri.js';
 import { getWindow } from '../../../../base/browser/dom.js';
-import { AGENTS_VOICE_WINDOW_DEFAULT_WIDTH, AGENTS_VOICE_WINDOW_DEFAULT_HEIGHT } from '../common/agentsVoice.js';
+import { AGENTS_VOICE_WINDOW_DEFAULT_WIDTH } from '../common/agentsVoice.js';
 import { createHeader } from './components/headerComponent.js';
 import { createStatusRows } from './components/statusRowsComponent.js';
 import { createTranscript, updateTranscriptOverflowState } from './components/transcriptComponent.js';
@@ -176,7 +176,7 @@ export class AgentsVoiceWidget extends Disposable {
 		const opts = this._options;
 		const widthStyle = opts.width === 'auto'
 			? 'width:100%;position:relative;'
-			: `position:absolute;top:0;left:0;width:${opts.width}px;min-height:${AGENTS_VOICE_WINDOW_DEFAULT_HEIGHT}px;`;
+			: `position:absolute;top:0;left:0;width:${opts.width}px;`;
 
 		this._rootDiv = dom.$('div');
 		this._rootDiv.style.cssText = `${widthStyle}display:flex;flex-direction:column;user-select:none;font-family:inherit;font-size:${FONT_SIZE.base};color:var(--vscode-foreground);box-sizing:border-box;margin:0;`;

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget.ts
@@ -16,6 +16,7 @@ import { createTranscript, updateTranscriptOverflowState } from './components/tr
 import { createSessionList, type SessionRowData, type SessionGroupData } from './components/sessionListComponent.js';
 import { createFeedbackDialog, type FeedbackDialogState } from './components/feedbackDialog.js';
 import { createOnboarding } from './components/onboardingComponent.js';
+import { createVoiceBar } from './components/voiceBarComponent.js';
 import { FONT_SIZE } from './components/tokens.js';
 import type { VoiceState, IPendingToolConfirmation, ITranscriptTurn } from '../../chat/browser/voiceClient/voiceSessionController.js';
 
@@ -142,6 +143,7 @@ export class AgentsVoiceWidget extends Disposable {
 	private readonly _headerComponent = createHeader();
 	private readonly _onboardingComponent = createOnboarding();
 	private readonly _feedbackDialogComponent = createFeedbackDialog();
+	private readonly _voiceBarComponent = createVoiceBar();
 	private readonly _transcriptComponent = createTranscript();
 	private readonly _statusRowsComponent = createStatusRows();
 	private readonly _sessionListComponent = createSessionList();
@@ -228,6 +230,7 @@ export class AgentsVoiceWidget extends Disposable {
 		this._contentDiv.append(
 			this._onboardingComponent.element,
 			this._headerComponent.element,
+			this._voiceBarComponent.element,
 			this._feedbackDialogComponent.element,
 			this._statusTextDiv,
 			this._transcriptComponent.element,
@@ -378,6 +381,7 @@ export class AgentsVoiceWidget extends Disposable {
 		if (onboarding) {
 			this._onboardingComponent.element.style.display = '';
 			this._headerComponent.element.style.display = 'none';
+			this._voiceBarComponent.element.style.display = 'none';
 			this._feedbackDialogComponent.element.style.display = 'none';
 			this._statusTextDiv.style.display = 'none';
 			this._transcriptComponent.element.style.display = 'none';
@@ -433,6 +437,7 @@ export class AgentsVoiceWidget extends Disposable {
 			});
 
 			if (feedbackState) {
+				this._voiceBarComponent.element.style.display = 'none';
 				this._feedbackDialogComponent.element.style.display = '';
 				this._feedbackDialogComponent.update({
 					onSubmit: (text) => this._submitFeedback(text),
@@ -448,11 +453,21 @@ export class AgentsVoiceWidget extends Disposable {
 			} else {
 				this._feedbackDialogComponent.element.style.display = 'none';
 
-				// Status text
+				// Voice bar (listening/speaking indicator with stop button)
+				this._voiceBarComponent.update({
+					voiceState,
+					speakingSessionLabel: this._speakingSessionLabel.read(reader),
+					speakingSession: this._speakingSession.read(reader),
+					onStopSpeech: () => this.callbacks.stopPlayback(),
+				});
+
+				// Status text — always show when in error state (e.g. mic denied)
 				const statusText = this._statusText.read(reader);
-				if (opts.showStatusText && statusText) {
+				const isError = voiceState === 'error';
+				if ((opts.showStatusText || isError) && statusText) {
 					this._statusTextDiv.style.display = '';
 					this._statusTextDiv.textContent = statusText;
+					this._statusTextDiv.style.color = isError ? 'var(--vscode-editorError-foreground)' : 'var(--vscode-foreground)';
 				} else {
 					this._statusTextDiv.style.display = 'none';
 				}

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget.ts
@@ -9,7 +9,7 @@ import { Disposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { localize } from '../../../../nls.js';
 import { URI } from '../../../../base/common/uri.js';
 import { getWindow } from '../../../../base/browser/dom.js';
-import { AGENTS_VOICE_WINDOW_DEFAULT_WIDTH } from '../common/agentsVoice.js';
+import { AGENTS_VOICE_WINDOW_DEFAULT_WIDTH, AGENTS_VOICE_WINDOW_DEFAULT_HEIGHT } from '../common/agentsVoice.js';
 import { createHeader } from './components/headerComponent.js';
 import { createStatusRows } from './components/statusRowsComponent.js';
 import { createTranscript, updateTranscriptOverflowState } from './components/transcriptComponent.js';
@@ -176,7 +176,7 @@ export class AgentsVoiceWidget extends Disposable {
 		const opts = this._options;
 		const widthStyle = opts.width === 'auto'
 			? 'width:100%;position:relative;'
-			: `position:absolute;top:0;left:0;width:${opts.width}px;`;
+			: `position:absolute;top:0;left:0;width:${opts.width}px;min-height:${AGENTS_VOICE_WINDOW_DEFAULT_HEIGHT}px;`;
 
 		this._rootDiv = dom.$('div');
 		this._rootDiv.style.cssText = `${widthStyle}display:flex;flex-direction:column;user-select:none;font-family:inherit;font-size:${FONT_SIZE.base};color:var(--vscode-foreground);box-sizing:border-box;margin:0;`;
@@ -504,7 +504,7 @@ export class AgentsVoiceWidget extends Disposable {
 					});
 				}
 
-				this._expandSpacer.style.display = showExpanded ? '' : 'none';
+				this._expandSpacer.style.display = '';
 				this._chevronWrapper.style.display = opts.showExpandChevron ? 'flex' : 'none';
 				this._chevronWrapper.title = showExpanded ? 'Collapse sessions' : 'Expand sessions';
 				this._chevronIcon.className = `codicon codicon-${showExpanded ? 'chevron-up' : 'chevron-down'}`;

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget.ts
@@ -504,7 +504,7 @@ export class AgentsVoiceWidget extends Disposable {
 					});
 				}
 
-				this._expandSpacer.style.display = '';
+				this._expandSpacer.style.display = showExpanded ? '' : 'none';
 				this._chevronWrapper.style.display = opts.showExpandChevron ? 'flex' : 'none';
 				this._chevronWrapper.title = showExpanded ? 'Collapse sessions' : 'Expand sessions';
 				this._chevronIcon.className = `codicon codicon-${showExpanded ? 'chevron-up' : 'chevron-down'}`;

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWindowService.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWindowService.ts
@@ -161,9 +161,6 @@ export class AgentsVoiceWindowService extends Disposable implements IAgentsVoice
 		void minimizeMain();
 		auxiliaryWindow.whenStylesHaveLoaded.then(() => {
 			void minimizeMain();
-			// Resize to fit content once styles are applied — the initial
-			// window bounds use a small default height that may clip content.
-			this._resizeWindow(auxiliaryWindow);
 			setTimeout(() => { void minimizeMain(); }, 250);
 		});
 

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWindowService.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWindowService.ts
@@ -137,7 +137,6 @@ export class AgentsVoiceWindowService extends Disposable implements IAgentsVoice
 			transparent: false,
 			disableFullscreen: true,
 			nativeTitlebar: false,
-			notResizable: true,
 			noBackgroundThrottling: true,
 			backgroundColor: this.themeService.getColorTheme().getColor(editorBackground)?.toString() ?? '#1e1e1e',
 		});
@@ -350,13 +349,17 @@ export class AgentsVoiceWindowService extends Disposable implements IAgentsVoice
 		const targetHeight = Math.ceil(pillHeight * zoomFactor);
 		const currentWidth = auxiliaryWindow.window.outerWidth;
 		const currentHeight = auxiliaryWindow.window.outerHeight;
-		if (targetWidth !== currentWidth || targetHeight !== currentHeight) {
+		// Only resize width unconditionally; for height, only grow (never
+		// shrink) so that manual vertical resizing by the user is preserved.
+		const newWidth = targetWidth !== currentWidth ? targetWidth : currentWidth;
+		const newHeight = targetHeight > currentHeight ? targetHeight : currentHeight;
+		if (newWidth !== currentWidth || newHeight !== currentHeight) {
 			// Capture position before resize — resizeTo can shift the window
 			// on some platforms (macOS), causing accumulated drift.
 			const preX = auxiliaryWindow.window.screenX;
 			const preY = auxiliaryWindow.window.screenY;
 			try {
-				auxiliaryWindow.window.resizeTo(targetWidth, targetHeight);
+				auxiliaryWindow.window.resizeTo(newWidth, newHeight);
 				// Restore position if it drifted
 				const postX = auxiliaryWindow.window.screenX;
 				const postY = auxiliaryWindow.window.screenY;

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWindowService.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWindowService.ts
@@ -299,6 +299,7 @@ export class AgentsVoiceWindowService extends Disposable implements IAgentsVoice
 
 		// Clean up when user closes window via OS controls
 		Event.once(auxiliaryWindow.onUnload)(() => {
+			this.voiceSessionController.setTargetSession(undefined);
 			this.voiceSessionController.disconnect();
 			this._window = undefined;
 			this._windowDisposables.clear();

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWindowService.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWindowService.ts
@@ -161,6 +161,9 @@ export class AgentsVoiceWindowService extends Disposable implements IAgentsVoice
 		void minimizeMain();
 		auxiliaryWindow.whenStylesHaveLoaded.then(() => {
 			void minimizeMain();
+			// Resize to fit content once styles are applied — the initial
+			// window bounds use a small default height that may clip content.
+			this._resizeWindow(auxiliaryWindow);
 			setTimeout(() => { void minimizeMain(); }, 250);
 		});
 
@@ -315,6 +318,8 @@ export class AgentsVoiceWindowService extends Disposable implements IAgentsVoice
 		// Don't disconnect — closing the floating window minimizes the UI but
 		// keeps the voice session alive. The session ends on terminal disconnect
 		// (Disconnect button or app exit via onUnload).
+		// Clear target session selection so it doesn't silently persist.
+		this.voiceSessionController.setTargetSession(undefined);
 		this.storageService.store(AgentsVoiceStorageKeys.WindowOpen, false, StorageScope.WORKSPACE, StorageTarget.MACHINE);
 
 		this._window = undefined;
@@ -348,7 +353,19 @@ export class AgentsVoiceWindowService extends Disposable implements IAgentsVoice
 		const currentWidth = auxiliaryWindow.window.outerWidth;
 		const currentHeight = auxiliaryWindow.window.outerHeight;
 		if (targetWidth !== currentWidth || targetHeight !== currentHeight) {
-			try { auxiliaryWindow.window.resizeTo(targetWidth, targetHeight); } catch { /* resize may not be supported */ }
+			// Capture position before resize — resizeTo can shift the window
+			// on some platforms (macOS), causing accumulated drift.
+			const preX = auxiliaryWindow.window.screenX;
+			const preY = auxiliaryWindow.window.screenY;
+			try {
+				auxiliaryWindow.window.resizeTo(targetWidth, targetHeight);
+				// Restore position if it drifted
+				const postX = auxiliaryWindow.window.screenX;
+				const postY = auxiliaryWindow.window.screenY;
+				if (postX !== preX || postY !== preY) {
+					auxiliaryWindow.window.moveTo(preX, preY);
+				}
+			} catch { /* resize may not be supported */ }
 		}
 	}
 

--- a/src/vs/workbench/contrib/agentsVoice/browser/components/headerComponent.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/components/headerComponent.ts
@@ -128,9 +128,10 @@ export function createHeader(): HeaderComponent {
 			copilotIcon.src = props.copilotIconSrc;
 
 			// Mic color
-			const micColor = props.voiceState === 'listening' ? 'var(--vscode-editorInfo-foreground)'
-				: props.voiceState === 'speaking' ? 'var(--vscode-agentsVoice-speakingForeground)'
-					: 'var(--vscode-descriptionForeground)';
+			const micColor = props.voiceState === 'error' ? 'var(--vscode-editorError-foreground)'
+				: props.voiceState === 'listening' ? 'var(--vscode-editorInfo-foreground)'
+					: props.voiceState === 'speaking' ? 'var(--vscode-agentsVoice-speakingForeground)'
+						: 'var(--vscode-descriptionForeground)';
 			micBtn.style.color = micColor;
 			micBtn.onmouseenter = () => { micBtn.style.color = 'var(--vscode-foreground)'; };
 			micBtn.onmouseleave = () => { micBtn.style.color = micColor; };

--- a/src/vs/workbench/contrib/agentsVoice/browser/components/voiceBarComponent.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/components/voiceBarComponent.ts
@@ -58,6 +58,11 @@ export function createVoiceBar(): VoiceBarComponent {
 
 			if ((isSpeaking && props.speakingSession) || (!isSpeaking && !isListening)) {
 				container.style.display = 'none';
+				// Detach handler when hidden to avoid stale listeners
+				if (currentStopHandler) {
+					stopBtn.removeEventListener('click', currentStopHandler);
+					currentStopHandler = undefined;
+				}
 				return;
 			}
 			container.style.display = 'flex';
@@ -68,11 +73,16 @@ export function createVoiceBar(): VoiceBarComponent {
 				: localize('agentsVoice.listening', "Listening");
 
 			stopBtn.style.display = isSpeaking ? '' : 'none';
-			if (currentStopHandler) {
+			if (isSpeaking) {
+				if (currentStopHandler) {
+					stopBtn.removeEventListener('click', currentStopHandler);
+				}
+				currentStopHandler = (e: Event) => { e.preventDefault(); e.stopPropagation(); props.onStopSpeech(); };
+				stopBtn.addEventListener('click', currentStopHandler);
+			} else if (currentStopHandler) {
 				stopBtn.removeEventListener('click', currentStopHandler);
+				currentStopHandler = undefined;
 			}
-			currentStopHandler = (e: Event) => { e.preventDefault(); e.stopPropagation(); props.onStopSpeech(); };
-			stopBtn.addEventListener('click', currentStopHandler);
 		}
 	};
 }

--- a/src/vs/workbench/contrib/agentsVoice/browser/components/voiceBarComponent.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/components/voiceBarComponent.ts
@@ -44,12 +44,11 @@ export function createVoiceBar(): VoiceBarComponent {
 	stopBtn.tabIndex = 0;
 	stopBtn.ariaLabel = localize('agentsVoice.stopSpeech', "Stop speech");
 	stopBtn.style.cssText = `font-size:${FONT_SIZE.body};color:var(--vscode-editorError-foreground);cursor:pointer;-webkit-app-region:no-drag;padding:2px;`;
-	stopBtn.addEventListener('click', (e) => { e.preventDefault(); e.stopPropagation(); });
 	addKeyboardActivation(stopBtn);
 
 	container.append(dot, label, waveform, stopBtn);
 
-	let currentStopHandler: (() => void) | undefined;
+	let currentStopHandler: ((e: Event) => void) | undefined;
 
 	return {
 		element: container,
@@ -70,10 +69,10 @@ export function createVoiceBar(): VoiceBarComponent {
 
 			stopBtn.style.display = isSpeaking ? '' : 'none';
 			if (currentStopHandler) {
-				stopBtn.removeEventListener('click', currentStopHandler as EventListener);
+				stopBtn.removeEventListener('click', currentStopHandler);
 			}
-			currentStopHandler = () => props.onStopSpeech();
-			stopBtn.addEventListener('click', currentStopHandler as EventListener);
+			currentStopHandler = (e: Event) => { e.preventDefault(); e.stopPropagation(); props.onStopSpeech(); };
+			stopBtn.addEventListener('click', currentStopHandler);
 		}
 	};
 }

--- a/src/vs/workbench/contrib/agentsVoice/common/agentsVoice.ts
+++ b/src/vs/workbench/contrib/agentsVoice/common/agentsVoice.ts
@@ -12,7 +12,7 @@ import './agentsVoiceColors.js'; // Register custom voice theme colors
  * Default dimensions for the Agents Voice floating window.
  */
 export const AGENTS_VOICE_WINDOW_DEFAULT_WIDTH = 220;
-export const AGENTS_VOICE_WINDOW_DEFAULT_HEIGHT = 200;
+export const AGENTS_VOICE_WINDOW_DEFAULT_HEIGHT = 100;
 
 /**
  * Storage keys for persisting window state across restarts.

--- a/src/vs/workbench/contrib/agentsVoice/common/agentsVoice.ts
+++ b/src/vs/workbench/contrib/agentsVoice/common/agentsVoice.ts
@@ -12,7 +12,7 @@ import './agentsVoiceColors.js'; // Register custom voice theme colors
  * Default dimensions for the Agents Voice floating window.
  */
 export const AGENTS_VOICE_WINDOW_DEFAULT_WIDTH = 220;
-export const AGENTS_VOICE_WINDOW_DEFAULT_HEIGHT = 100;
+export const AGENTS_VOICE_WINDOW_DEFAULT_HEIGHT = 200;
 
 /**
  * Storage keys for persisting window state across restarts.


### PR DESCRIPTION
Addresses multiple voice mode mini view issues:

## Changes

### Stop button no-op (fixes microsoft/vscode-internalbacklog#8044)
- Integrated the voice bar component (with stop-speech button) into the widget — it was previously dead code, never rendered
- Fixed the click handler which had a no-op `stopPropagation` handler that didn't call `onStopSpeech`

### No mic permission indication (fixes microsoft/vscode-internalbacklog#8058)
- Status text (e.g. "Microphone denied") now always displays when `voiceState` is `'error'`, regardless of the `showStatusText` option
- Mic icon in the header turns red on error state

### Window drifts across screen (fixes microsoft/vscode-internalbacklog#8042)
- `_resizeWindow` now captures window position before `resizeTo()` and restores it if the OS shifted the window (common on macOS)

### Send-to boundaries confusing (fixes microsoft/vscode-internalbacklog#8045)
- Target session selection is cleared when the mini view is closed, preventing silent persistence

### Resizing weirdness (fixes microsoft/vscode-internalbacklog#8054)
- Fix layout issue
