### PR TITLE
chat: add viewUnreviewedComments agent-host tool with confirmation UI

### DIFF
--- a/src/vs/platform/agentHost/common/agentFeedbackAnnotations.ts
+++ b/src/vs/platform/agentHost/common/agentFeedbackAnnotations.ts
@@ -20,6 +20,24 @@
 export const FEEDBACK_ANNOTATION_META_KEY = 'vscode.agentFeedback';
 
 /**
+ * Name of the agent host server tool that reveals review comments the user has
+ * not accepted yet. Shared here (in the layer-neutral `common` module) so the
+ * node-side server tool implementation and the browser-side chat adapter that
+ * renders its confirmation agree on the name without drifting. The agent sees
+ * this name directly (Copilot) or prefixed as `mcp__host__<name>` (Claude).
+ */
+export const VIEW_UNREVIEWED_COMMENTS_TOOL_NAME = 'viewUnreviewedComments';
+
+/**
+ * Whether {@link toolName} (a tool name as seen on a tool call) refers to the
+ * {@link VIEW_UNREVIEWED_COMMENTS_TOOL_NAME} server tool. Accepts both the bare
+ * name and the Claude `mcp__<server>__<name>` prefixed form.
+ */
+export function isViewUnreviewedCommentsTool(toolName: string): boolean {
+	return toolName === VIEW_UNREVIEWED_COMMENTS_TOOL_NAME || toolName.endsWith(`__${VIEW_UNREVIEWED_COMMENTS_TOOL_NAME}`);
+}
+
+/**
  * Origin of a feedback item. String values match the client-side
  * `AgentFeedbackKind` enum so a value written by either side decodes on the
  * other without translation.

--- a/src/vs/platform/agentHost/common/agentFeedbackAnnotations.ts
+++ b/src/vs/platform/agentHost/common/agentFeedbackAnnotations.ts
@@ -68,4 +68,13 @@ export interface IFeedbackAnnotationMeta {
 	readonly codeSelection?: string;
 	readonly diffHunks?: string;
 	readonly sourcePRReviewCommentId?: string;
+	/**
+	 * Transient marker set by the client when the user reveals this comment to
+	 * the agent via the `viewUnreviewedComments` tool. The server tool returns
+	 * exactly the comments carrying this flag (so the result is scoped to the
+	 * comments selected for that invocation rather than every accepted review
+	 * comment) and clears it once they have been delivered, so a later
+	 * invocation does not re-return them.
+	 */
+	readonly pendingAgentReveal?: boolean;
 }

--- a/src/vs/platform/agentHost/common/agentServerTools.ts
+++ b/src/vs/platform/agentHost/common/agentServerTools.ts
@@ -27,6 +27,13 @@ export interface IAgentServerToolHost {
 	/** Advertises all server tools on the session's `serverTools`. */
 	advertise(sessionUri: URI): void;
 	/**
+	 * Whether {@link toolName} must be confirmed by the user before it runs.
+	 * Providers exclude such tools from their server-tool auto-approve lists so
+	 * the call surfaces a confirmation instead of executing silently. Returns
+	 * `false` for unknown tools and for tools that are auto-approved.
+	 */
+	requiresConfirmation(toolName: string): boolean;
+	/**
 	 * Executes a server tool against the session's state, dispatching any
 	 * resulting actions, and returns the textual tool result for the agent.
 	 *

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
@@ -411,7 +411,14 @@ export class ClaudeAgentSession extends Disposable {
 				...(clientServers ?? {}),
 				...(serverToolServer ? { [CLAUDE_SERVER_TOOL_MCP_SERVER_NAME]: serverToolServer } : {}),
 			};
-		return { mcpServers, allowedTools: serverToolHost ? serverToolAllowList(serverToolHost.toolNames) : undefined };
+		// Exclude server tools that require user confirmation from the
+		// auto-approve allow-list so the SDK surfaces them via `canUseTool`
+		// (the host then renders a custom confirmation) instead of running them
+		// silently.
+		const autoApproveToolNames = serverToolHost
+			? serverToolHost.toolNames.filter(name => !serverToolHost.requiresConfirmation(name))
+			: undefined;
+		return { mcpServers, allowedTools: autoApproveToolNames ? serverToolAllowList(autoApproveToolNames) : undefined };
 	}
 
 	/** True once {@link materialize} has installed the SDK pipeline. */

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -1363,9 +1363,11 @@ export class CopilotAgentSession extends Disposable {
 			// Auto-approve the agent host's server tools. They only read or
 			// mutate the session's own server-held state and never touch the
 			// workspace, shell, or network, so prompting for them is redundant
-			// noise.
+			// noise. Tools that explicitly require confirmation (e.g. revealing
+			// unreviewed review comments) are excluded so the user is prompted.
 			if (request.kind === 'custom-tool' && typeof request.toolName === 'string'
 				&& this._serverToolHost?.toolNames.includes(request.toolName)
+				&& !this._serverToolHost.requiresConfirmation(request.toolName)
 			) {
 				this._logService.info(`[Copilot:${this.sessionId}] Auto-approving server tool ${request.toolName}`);
 				return { kind: 'approve-once' };

--- a/src/vs/platform/agentHost/node/shared/agentFeedbackServerTools.ts
+++ b/src/vs/platform/agentHost/node/shared/agentFeedbackServerTools.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { generateUuid } from '../../../../base/common/uuid.js';
-import { FEEDBACK_ANNOTATION_META_KEY, type IFeedbackAnnotationMeta } from '../../common/agentFeedbackAnnotations.js';
+import { FEEDBACK_ANNOTATION_META_KEY, VIEW_UNREVIEWED_COMMENTS_TOOL_NAME, type IFeedbackAnnotationMeta } from '../../common/agentFeedbackAnnotations.js';
 import { buildAnnotationsUri } from '../../common/annotationsUri.js';
 import type { AnnotationsAction } from '../../common/state/sessionActions.js';
 import { ActionType } from '../../common/state/protocol/common/actions.js';
@@ -30,6 +30,29 @@ export const addCommentToolName = 'addComment';
 export const listCommentsToolName = 'listComments';
 export const deleteCommentsToolName = 'deleteComments';
 export const resolveCommentsToolName = 'resolveComments';
+export const viewUnreviewedCommentsToolName = VIEW_UNREVIEWED_COMMENTS_TOOL_NAME;
+
+/**
+ * Feedback kinds that originate from a review the user is expected to triage
+ * (a pull request review or an in-product code review) rather than being
+ * authored by the user directly. Comments of these kinds that are still in the
+ * `created` state are surfaced to the agent via the {@link listCommentsToolName}
+ * note and revealed through {@link viewUnreviewedCommentsToolName}.
+ */
+const REVIEWABLE_FEEDBACK_KINDS: ReadonlySet<string> = new Set(['prReview', 'codeReview']);
+
+/**
+ * Server tools that must not be auto-approved: invoking them surfaces a
+ * confirmation to the user (rendered by a custom client content part) before
+ * the tool body runs. Providers consult {@link feedbackToolRequiresConfirmation}
+ * (via the host) to exclude these from their server-tool auto-approve lists.
+ */
+const feedbackConfirmationToolNames: ReadonlySet<string> = new Set([viewUnreviewedCommentsToolName]);
+
+/** Whether the given feedback server tool requires user confirmation before it runs. */
+export function feedbackToolRequiresConfirmation(toolName: string): boolean {
+	return feedbackConfirmationToolNames.has(toolName);
+}
 
 const addCommentInputSchema: ToolDefinition['inputSchema'] = {
 	type: 'object',
@@ -52,6 +75,11 @@ const addCommentInputSchema: ToolDefinition['inputSchema'] = {
 };
 
 const listCommentsInputSchema: ToolDefinition['inputSchema'] = {
+	type: 'object',
+	properties: {},
+};
+
+const viewUnreviewedCommentsInputSchema: ToolDefinition['inputSchema'] = {
 	type: 'object',
 	properties: {},
 };
@@ -106,6 +134,13 @@ export const feedbackServerToolDefinitions: ToolDefinition[] = [
 		description: 'Mark comments for this session as resolved or unresolved.',
 		inputSchema: resolveCommentsInputSchema,
 		annotations: { readOnlyHint: false },
+	},
+	{
+		name: viewUnreviewedCommentsToolName,
+		title: 'View Unreviewed Comments (Agent Feedback)',
+		description: 'View pull request or code review comments that the user has not reviewed yet. Calling this asks the user to choose which of those comments to reveal; only the comments the user reveals are returned.',
+		inputSchema: viewUnreviewedCommentsInputSchema,
+		annotations: { readOnlyHint: true },
 	},
 ];
 
@@ -262,8 +297,58 @@ function listableAnnotations(state: AnnotationsState): Annotation[] {
 	});
 }
 
-function serializeComments(annotations: readonly Annotation[]): string {
-	return JSON.stringify({ comments: annotations.map(serializeComment) }, undefined, 2);
+/** The effective lifecycle state of a feedback annotation. */
+function getEffectiveState(annotation: Annotation, meta: IFeedbackAnnotationMeta): string {
+	return annotation.resolved ? 'resolved' : (meta.state ?? 'accepted');
+}
+
+/**
+ * Feedback annotations of a {@link REVIEWABLE_FEEDBACK_KINDS reviewable kind}
+ * whose effective state matches {@link lifecycleState}. Used to count/return the
+ * pull-request and code-review comments the user has not reviewed (`created`)
+ * or has just revealed (`accepted`).
+ */
+function reviewableAnnotationsInState(state: AnnotationsState, lifecycleState: string): Annotation[] {
+	return state.annotations.filter(annotation => {
+		const meta = readMeta(annotation);
+		if (!meta || !annotation.entries?.length) {
+			return false;
+		}
+		return REVIEWABLE_FEEDBACK_KINDS.has(meta.kind) && getEffectiveState(annotation, meta) === lifecycleState;
+	});
+}
+
+/**
+ * A short note appended to the {@link listCommentsToolName} result when there
+ * are reviewable comments the user has not accepted yet, pointing the agent at
+ * {@link viewUnreviewedCommentsToolName}. Returns `undefined` (no note) when
+ * there are no such comments.
+ */
+function buildUnreviewedCommentsNote(state: AnnotationsState): string | undefined {
+	const created = reviewableAnnotationsInState(state, 'created');
+	if (!created.length) {
+		return undefined;
+	}
+	let prCount = 0;
+	let codeReviewCount = 0;
+	for (const annotation of created) {
+		const kind = readMeta(annotation)?.kind;
+		if (kind === 'prReview') {
+			prCount++;
+		} else if (kind === 'codeReview') {
+			codeReviewCount++;
+		}
+	}
+	const clauses: string[] = [];
+	if (prCount > 0) {
+		clauses.push(`${prCount} pull request comment${prCount === 1 ? '' : 's'}`);
+	}
+	if (codeReviewCount > 0) {
+		clauses.push(`${codeReviewCount} code review comment${codeReviewCount === 1 ? '' : 's'}`);
+	}
+	const subject = clauses.join(' and ');
+	const verb = created.length === 1 ? 'is' : 'are';
+	return `There ${verb} ${subject} which the user has not reviewed yet. If the user wants you to tackle them, call the \`${viewUnreviewedCommentsToolName}\` tool to view them.`;
 }
 
 // --- Tool execution -----------------------------------------------------------
@@ -307,7 +392,24 @@ export function applyFeedbackTool(state: AnnotationsState, sessionResource: stri
 			};
 		}
 		case listCommentsToolName: {
-			return { actions: [], result: serializeComments(listableAnnotations(state)) };
+			const payload: { comments: ISerializedComment[]; note?: string } = {
+				comments: listableAnnotations(state).map(serializeComment),
+			};
+			const note = buildUnreviewedCommentsNote(state);
+			if (note) {
+				payload.note = note;
+			}
+			return { actions: [], result: JSON.stringify(payload, undefined, 2) };
+		}
+		case viewUnreviewedCommentsToolName: {
+			// The confirmation gate runs before this body: by the time the tool
+			// executes, the user has accepted the comments they chose to reveal
+			// (moving them out of the `created` state on the shared annotations
+			// channel), so reading the current state returns exactly those
+			// now-accepted reviewable comments. Comments the user left unchecked
+			// remain `created` and are not returned.
+			const revealed = reviewableAnnotationsInState(state, 'accepted').map(serializeComment);
+			return { actions: [], result: JSON.stringify({ comments: revealed }, undefined, 2) };
 		}
 		case deleteCommentsToolName: {
 			const ids = getUniqueCommentIds((rawArgs as IDeleteCommentsArgs)?.commentIds, deleteCommentsToolName);
@@ -381,6 +483,9 @@ export function applyFeedbackTool(state: AnnotationsState, sessionResource: stri
  */
 export const feedbackServerToolGroup: IServerToolGroup = {
 	definitions: feedbackServerToolDefinitions,
+	requiresConfirmation(toolName): boolean {
+		return feedbackToolRequiresConfirmation(toolName);
+	},
 	execute(stateManager, sessionUri, toolName, rawArgs): string {
 		const annotationsUri = buildAnnotationsUri(sessionUri);
 		const snapshot = stateManager.getSnapshot(annotationsUri);

--- a/src/vs/platform/agentHost/node/shared/agentFeedbackServerTools.ts
+++ b/src/vs/platform/agentHost/node/shared/agentFeedbackServerTools.ts
@@ -297,24 +297,46 @@ function listableAnnotations(state: AnnotationsState): Annotation[] {
 	});
 }
 
-/** The effective lifecycle state of a feedback annotation. */
-function getEffectiveState(annotation: Annotation, meta: IFeedbackAnnotationMeta): string {
-	return annotation.resolved ? 'resolved' : (meta.state ?? 'accepted');
-}
-
 /**
  * Feedback annotations of a {@link REVIEWABLE_FEEDBACK_KINDS reviewable kind}
- * whose effective state matches {@link lifecycleState}. Used to count/return the
- * pull-request and code-review comments the user has not reviewed (`created`)
- * or has just revealed (`accepted`).
+ * the user has flagged for reveal to the agent (via the confirmation of the
+ * {@link viewUnreviewedCommentsToolName} tool). These are exactly the comments
+ * the user chose to reveal for the current invocation; everything else
+ * (including review comments that happen to be accepted from a previous reveal
+ * or a manual accept) is excluded.
  */
-function reviewableAnnotationsInState(state: AnnotationsState, lifecycleState: string): Annotation[] {
+function pendingRevealAnnotations(state: AnnotationsState): Annotation[] {
 	return state.annotations.filter(annotation => {
 		const meta = readMeta(annotation);
 		if (!meta || !annotation.entries?.length) {
 			return false;
 		}
-		return REVIEWABLE_FEEDBACK_KINDS.has(meta.kind) && getEffectiveState(annotation, meta) === lifecycleState;
+		return REVIEWABLE_FEEDBACK_KINDS.has(meta.kind) && meta.pendingAgentReveal === true;
+	});
+}
+
+/** Returns a copy of {@link annotation} with the {@link IFeedbackAnnotationMeta.pendingAgentReveal} flag cleared. */
+function clearPendingReveal(annotation: Annotation): Annotation {
+	const meta = readMeta(annotation);
+	if (!meta) {
+		return annotation;
+	}
+	const nextMeta: IFeedbackAnnotationMeta = { ...meta, pendingAgentReveal: undefined };
+	return { ...annotation, _meta: { ...annotation._meta, [FEEDBACK_ANNOTATION_META_KEY]: nextMeta } };
+}
+
+/**
+ * Reviewable (PR / code review) feedback annotations the user has not reviewed
+ * yet, i.e. still in the `created` state. Used to build the
+ * {@link listCommentsToolName} note.
+ */
+function createdReviewableAnnotations(state: AnnotationsState): Annotation[] {
+	return state.annotations.filter(annotation => {
+		const meta = readMeta(annotation);
+		if (!meta || !annotation.entries?.length) {
+			return false;
+		}
+		return REVIEWABLE_FEEDBACK_KINDS.has(meta.kind) && !annotation.resolved && (meta.state ?? 'accepted') === 'created';
 	});
 }
 
@@ -325,7 +347,7 @@ function reviewableAnnotationsInState(state: AnnotationsState, lifecycleState: s
  * there are no such comments.
  */
 function buildUnreviewedCommentsNote(state: AnnotationsState): string | undefined {
-	const created = reviewableAnnotationsInState(state, 'created');
+	const created = createdReviewableAnnotations(state);
 	if (!created.length) {
 		return undefined;
 	}
@@ -402,14 +424,20 @@ export function applyFeedbackTool(state: AnnotationsState, sessionResource: stri
 			return { actions: [], result: JSON.stringify(payload, undefined, 2) };
 		}
 		case viewUnreviewedCommentsToolName: {
-			// The confirmation gate runs before this body: by the time the tool
-			// executes, the user has accepted the comments they chose to reveal
-			// (moving them out of the `created` state on the shared annotations
-			// channel), so reading the current state returns exactly those
-			// now-accepted reviewable comments. Comments the user left unchecked
-			// remain `created` and are not returned.
-			const revealed = reviewableAnnotationsInState(state, 'accepted').map(serializeComment);
-			return { actions: [], result: JSON.stringify({ comments: revealed }, undefined, 2) };
+			// The confirmation gate runs before this body. When the user accepts
+			// the confirmation, the client flags exactly the comments they chose
+			// to reveal with `pendingAgentReveal` on the shared annotations
+			// channel. Return those comments and clear the flag so a later
+			// invocation does not re-return them; comments the user left
+			// unchecked (and review comments accepted by other means) are not
+			// flagged and so are excluded.
+			const pending = pendingRevealAnnotations(state);
+			const comments = pending.map(serializeComment);
+			const actions: AnnotationsAction[] = pending.map(annotation => ({
+				type: ActionType.AnnotationsSet,
+				annotation: clearPendingReveal(annotation),
+			}));
+			return { actions, result: JSON.stringify({ comments }, undefined, 2) };
 		}
 		case deleteCommentsToolName: {
 			const ids = getUniqueCommentIds((rawArgs as IDeleteCommentsArgs)?.commentIds, deleteCommentsToolName);

--- a/src/vs/platform/agentHost/node/shared/agentServerToolHost.ts
+++ b/src/vs/platform/agentHost/node/shared/agentServerToolHost.ts
@@ -26,6 +26,14 @@ export interface IServerToolGroup {
 	/** Tool definitions this group advertises on the session's `serverTools`. */
 	readonly definitions: readonly ToolDefinition[];
 	/**
+	 * Whether {@link toolName} (one of this group's {@link definitions}) must be
+	 * confirmed by the user before it runs. Providers exclude such tools from
+	 * their server-tool auto-approve lists so the call surfaces a confirmation.
+	 * Absent or `false` means the tool is auto-approved like every other server
+	 * tool.
+	 */
+	requiresConfirmation?(toolName: string): boolean;
+	/**
 	 * Executes {@link toolName} (one of this group's {@link definitions})
 	 * against the session's state, dispatching any resulting actions through
 	 * the state manager (the single writer), and returns the textual tool
@@ -77,6 +85,10 @@ export class AgentServerToolHost implements IAgentServerToolHost {
 			type: ActionType.SessionServerToolsChanged,
 			tools: [...this.definitions],
 		});
+	}
+
+	requiresConfirmation(toolName: string): boolean {
+		return this._groupByToolName.get(toolName)?.requiresConfirmation?.(toolName) ?? false;
 	}
 
 	executeTool(sessionUri: URI, toolName: string, rawArgs: unknown): string {

--- a/src/vs/platform/agentHost/test/node/agentFeedbackServerTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentFeedbackServerTools.test.ts
@@ -30,7 +30,7 @@ suite('AgentFeedbackServerTools', () => {
 	const sessionResource = 'copilot:/test-session';
 	const fileUri = 'file:///workspace/app.ts';
 
-	function annotation(id: string, state: string, resolved = false, text = 'comment', kind = 'codeReview'): Annotation {
+	function annotation(id: string, state: string, resolved = false, text = 'comment', kind = 'codeReview', pendingAgentReveal = false): Annotation {
 		return {
 			id,
 			turnId: '',
@@ -38,7 +38,7 @@ suite('AgentFeedbackServerTools', () => {
 			range: { start: { line: 0, character: 0 }, end: { line: 0, character: 4 } },
 			resolved,
 			entries: [{ id: `${id}:0`, text }],
-			_meta: { [FEEDBACK_ANNOTATION_META_KEY]: { kind, state, sessionResource } },
+			_meta: { [FEEDBACK_ANNOTATION_META_KEY]: { kind, state, sessionResource, ...(pendingAgentReveal ? { pendingAgentReveal: true } : {}) } },
 		};
 	}
 
@@ -144,17 +144,28 @@ suite('AgentFeedbackServerTools', () => {
 		);
 	});
 
-	test('viewUnreviewedComments returns the accepted reviewable comments and no actions', () => {
+	test('viewUnreviewedComments returns the comments flagged for reveal and clears the flag', () => {
 		const state = stateWith(
 			annotation('pr1', 'created', false, 'still hidden', 'prReview'),
-			annotation('pr2', 'accepted', false, 'revealed pr', 'prReview'),
-			annotation('cr1', 'accepted', false, 'revealed code review', 'codeReview'),
-			// user-authored accepted comment is not reviewable -> excluded
-			annotation('u1', 'accepted', false, 'user comment', 'user'),
+			annotation('pr2', 'accepted', false, 'revealed pr', 'prReview', true),
+			annotation('cr1', 'accepted', false, 'revealed code review', 'codeReview', true),
+			// previously-accepted reviewable comment without the flag -> excluded
+			annotation('pr3', 'accepted', false, 'old accepted pr', 'prReview'),
+			// user-authored comment is not reviewable -> excluded even when flagged
+			annotation('u1', 'accepted', false, 'user comment', 'user', true),
 		);
 		const outcome = applyFeedbackTool(state, sessionResource, viewUnreviewedCommentsToolName, {});
-		assert.strictEqual(outcome.actions.length, 0);
-		assert.deepStrictEqual(JSON.parse(outcome.result).comments.map((c: { id: string }) => c.id), ['pr2', 'cr1']);
+		const clearedIds = outcome.actions.map(a => (a as Extract<typeof a, { type: ActionType.AnnotationsSet }>).annotation.id);
+		const clearedFlags = outcome.actions.map(a => (a as Extract<typeof a, { type: ActionType.AnnotationsSet }>).annotation._meta?.[FEEDBACK_ANNOTATION_META_KEY] as { pendingAgentReveal?: boolean });
+		assert.deepStrictEqual({
+			returnedIds: JSON.parse(outcome.result).comments.map((c: { id: string }) => c.id),
+			clearedIds,
+			flagsCleared: clearedFlags.every(meta => meta.pendingAgentReveal === undefined),
+		}, {
+			returnedIds: ['pr2', 'cr1'],
+			clearedIds: ['pr2', 'cr1'],
+			flagsCleared: true,
+		});
 	});
 
 	test('viewUnreviewedComments requires confirmation; the read/mutate tools do not', () => {

--- a/src/vs/platform/agentHost/test/node/agentFeedbackServerTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentFeedbackServerTools.test.ts
@@ -19,8 +19,10 @@ import {
 	deleteCommentsToolName,
 	feedbackServerToolDefinitions,
 	feedbackServerToolGroup,
+	feedbackToolRequiresConfirmation,
 	listCommentsToolName,
 	resolveCommentsToolName,
+	viewUnreviewedCommentsToolName,
 } from '../../node/shared/agentFeedbackServerTools.js';
 
 suite('AgentFeedbackServerTools', () => {
@@ -28,7 +30,7 @@ suite('AgentFeedbackServerTools', () => {
 	const sessionResource = 'copilot:/test-session';
 	const fileUri = 'file:///workspace/app.ts';
 
-	function annotation(id: string, state: string, resolved = false, text = 'comment'): Annotation {
+	function annotation(id: string, state: string, resolved = false, text = 'comment', kind = 'codeReview'): Annotation {
 		return {
 			id,
 			turnId: '',
@@ -36,7 +38,7 @@ suite('AgentFeedbackServerTools', () => {
 			range: { start: { line: 0, character: 0 }, end: { line: 0, character: 4 } },
 			resolved,
 			entries: [{ id: `${id}:0`, text }],
-			_meta: { [FEEDBACK_ANNOTATION_META_KEY]: { kind: 'codeReview', state, sessionResource } },
+			_meta: { [FEEDBACK_ANNOTATION_META_KEY]: { kind, state, sessionResource } },
 		};
 	}
 
@@ -77,6 +79,7 @@ suite('AgentFeedbackServerTools', () => {
 				kind: 'codeReview',
 				resolved: false,
 			}],
+			note: 'There is 1 code review comment which the user has not reviewed yet. If the user wants you to tackle them, call the `viewUnreviewedComments` tool to view them.',
 		});
 	});
 
@@ -117,6 +120,57 @@ suite('AgentFeedbackServerTools', () => {
 
 	test('unknown tool name throws', () => {
 		assert.throws(() => applyFeedbackTool(stateWith(), sessionResource, 'nope', {}), /Unknown feedback server tool/);
+	});
+
+	test('listComments adds no note when there are no unreviewed reviewable comments', () => {
+		const state = stateWith(annotation('a', 'accepted', false, 'visible'));
+		const outcome = applyFeedbackTool(state, sessionResource, listCommentsToolName, {});
+		assert.strictEqual(JSON.parse(outcome.result).note, undefined);
+	});
+
+	test('listComments note counts created PR and code-review comments per kind', () => {
+		const state = stateWith(
+			annotation('pr1', 'created', false, 'pr a', 'prReview'),
+			annotation('pr2', 'created', false, 'pr b', 'prReview'),
+			annotation('cr1', 'created', false, 'cr a', 'codeReview'),
+			// user-authored created comments are not "reviewable" and never counted
+			annotation('u1', 'created', false, 'user', 'user'),
+			annotation('done', 'accepted', false, 'already reviewed', 'prReview'),
+		);
+		const outcome = applyFeedbackTool(state, sessionResource, listCommentsToolName, {});
+		assert.strictEqual(
+			JSON.parse(outcome.result).note,
+			'There are 2 pull request comments and 1 code review comment which the user has not reviewed yet. If the user wants you to tackle them, call the `viewUnreviewedComments` tool to view them.',
+		);
+	});
+
+	test('viewUnreviewedComments returns the accepted reviewable comments and no actions', () => {
+		const state = stateWith(
+			annotation('pr1', 'created', false, 'still hidden', 'prReview'),
+			annotation('pr2', 'accepted', false, 'revealed pr', 'prReview'),
+			annotation('cr1', 'accepted', false, 'revealed code review', 'codeReview'),
+			// user-authored accepted comment is not reviewable -> excluded
+			annotation('u1', 'accepted', false, 'user comment', 'user'),
+		);
+		const outcome = applyFeedbackTool(state, sessionResource, viewUnreviewedCommentsToolName, {});
+		assert.strictEqual(outcome.actions.length, 0);
+		assert.deepStrictEqual(JSON.parse(outcome.result).comments.map((c: { id: string }) => c.id), ['pr2', 'cr1']);
+	});
+
+	test('viewUnreviewedComments requires confirmation; the read/mutate tools do not', () => {
+		assert.deepStrictEqual({
+			view: feedbackToolRequiresConfirmation(viewUnreviewedCommentsToolName),
+			list: feedbackToolRequiresConfirmation(listCommentsToolName),
+			add: feedbackToolRequiresConfirmation(addCommentToolName),
+			del: feedbackToolRequiresConfirmation(deleteCommentsToolName),
+			resolve: feedbackToolRequiresConfirmation(resolveCommentsToolName),
+		}, {
+			view: true,
+			list: false,
+			add: false,
+			del: false,
+			resolve: false,
+		});
 	});
 
 	test('addComment rejects invalid arguments', () => {
@@ -200,6 +254,18 @@ suite('AgentFeedbackServerTools', () => {
 			host.advertise(sessionResource);
 			const state = manager.getSessionState(sessionResource);
 			assert.deepStrictEqual(state?.serverTools, feedbackServerToolDefinitions);
+		});
+
+		test('requiresConfirmation reflects the owning group', () => {
+			assert.deepStrictEqual({
+				view: host.requiresConfirmation(viewUnreviewedCommentsToolName),
+				list: host.requiresConfirmation(listCommentsToolName),
+				unknown: host.requiresConfirmation('nope'),
+			}, {
+				view: true,
+				list: false,
+				unknown: false,
+			});
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/claudeServerToolMcpServer.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeServerToolMcpServer.test.ts
@@ -49,6 +49,8 @@ class FakeServerToolHost implements IAgentServerToolHost {
 
 	advertise(): void { }
 
+	requiresConfirmation(): boolean { return false; }
+
 	executeTool(sessionUri: string, toolName: string, rawArgs: unknown): string {
 		this.executions.push({ sessionUri, toolName, rawArgs });
 		if (this.error) {

--- a/src/vs/platform/agentHost/test/node/claudeServerToolMcpServer.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeServerToolMcpServer.test.ts
@@ -49,7 +49,7 @@ class FakeServerToolHost implements IAgentServerToolHost {
 
 	advertise(): void { }
 
-	requiresConfirmation(): boolean { return false; }
+	requiresConfirmation(_toolName: string): boolean { return false; }
 
 	executeTool(sessionUri: string, toolName: string, rawArgs: unknown): string {
 		this.executions.push({ sessionUri, toolName, rawArgs });

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -3285,7 +3285,7 @@ suite('CopilotAgentSession', () => {
 				this.advertised.push(sessionUri);
 			}
 
-			requiresConfirmation(): boolean { return false; }
+			requiresConfirmation(_toolName: string): boolean { return false; }
 
 			executeTool(sessionUri: string, toolName: string, rawArgs: unknown): string {
 				this.executions.push({ sessionUri, toolName, rawArgs });

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -3285,6 +3285,8 @@ suite('CopilotAgentSession', () => {
 				this.advertised.push(sessionUri);
 			}
 
+			requiresConfirmation(): boolean { return false; }
+
 			executeTool(sessionUri: string, toolName: string, rawArgs: unknown): string {
 				this.executions.push({ sessionUri, toolName, rawArgs });
 				if (this.error) {

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedback.contribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedback.contribution.ts
@@ -20,6 +20,7 @@ import { AgentFeedbackAttachmentContribution } from './agentFeedbackAttachment.j
 import { AgentFeedbackAttachmentWidget } from './agentFeedbackAttachmentWidget.js';
 import { AgentFeedbackEditorOverlay } from './agentFeedbackEditorOverlay.js';
 import { hasActiveSessionAgentFeedback, registerAgentFeedbackEditorActions, submitActiveSessionFeedbackActionId } from './agentFeedbackEditorActions.js';
+import { registerAgentFeedbackReviewCommands } from './agentFeedbackReviewCommands.js';
 import { IChatAttachmentWidgetRegistry } from '../../../../workbench/contrib/chat/browser/attachments/chatAttachmentWidgetRegistry.js';
 import { IAgentFeedbackVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { Codicon } from '../../../../base/common/codicons.js';
@@ -81,6 +82,8 @@ registerWorkbenchContribution2(AgentFeedbackEditorOverlay.ID, AgentFeedbackEdito
 registerWorkbenchContribution2(AgentFeedbackAttachmentContribution.ID, AgentFeedbackAttachmentContribution, WorkbenchPhase.AfterRestored);
 
 registerAgentFeedbackEditorActions();
+
+registerAgentFeedbackReviewCommands();
 
 registerSingleton(IAgentFeedbackService, AgentFeedbackService, InstantiationType.Delayed);
 

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackItemsBackend.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackItemsBackend.ts
@@ -162,6 +162,7 @@ interface IFeedbackAnnotationMeta {
 	readonly codeSelection?: string;
 	readonly diffHunks?: string;
 	readonly sourcePRReviewCommentId?: string;
+	readonly pendingAgentReveal?: boolean;
 }
 
 function toTextRange(range: IRange): TextRange {
@@ -200,6 +201,7 @@ function feedbackToAnnotation(feedback: IAgentFeedback): Annotation {
 		codeSelection: feedback.codeSelection,
 		diffHunks: feedback.diffHunks,
 		sourcePRReviewCommentId: feedback.sourcePRReviewCommentId,
+		pendingAgentReveal: feedback.pendingAgentReveal,
 	};
 	return {
 		id: feedback.id,
@@ -236,6 +238,7 @@ function annotationToFeedback(annotation: Annotation, sessionResource: URI): IAg
 		sourcePRReviewCommentId: meta?.sourcePRReviewCommentId,
 		replies: replies.length ? replies : undefined,
 		state: annotation.resolved ? AgentFeedbackState.Resolved : (meta?.state ?? AgentFeedbackState.Accepted),
+		pendingAgentReveal: meta?.pendingAgentReveal,
 	};
 }
 

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackModel.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackModel.ts
@@ -84,4 +84,12 @@ export interface IAgentFeedback {
 	readonly replies?: readonly string[];
 	/** Lifecycle state of this feedback item. */
 	readonly state: AgentFeedbackState;
+
+	/**
+	 * Transient marker set when the user reveals this comment to the agent via
+	 * the `viewUnreviewedComments` tool. The agent-host server tool returns the
+	 * comments carrying this flag and then clears it. Only meaningful for
+	 * reviewable (PR / code review) comments.
+	 */
+	readonly pendingAgentReveal?: boolean;
 }

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackReviewCommands.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackReviewCommands.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI, UriComponents } from '../../../../base/common/uri.js';
+import { localize } from '../../../../nls.js';
+import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
+import { AgentFeedbackReviewCommandId, IChatAgentFeedbackReviewComment } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { AgentFeedbackKind, AgentFeedbackState, IAgentFeedbackService } from './agentFeedbackService.js';
+
+/**
+ * Feedback kinds that originate from a review the user triages (a pull request
+ * review or an in-product code review). Mirrors the server-side reviewable
+ * kinds and excludes user-authored feedback.
+ */
+const REVIEWABLE_KINDS: ReadonlySet<AgentFeedbackKind> = new Set([AgentFeedbackKind.PRReview, AgentFeedbackKind.AgentReview]);
+
+/**
+ * Localized origin label for a reviewable feedback item, matching the labels
+ * the agent feedback editor widget shows.
+ */
+function kindLabel(kind: AgentFeedbackKind): string | undefined {
+	switch (kind) {
+		case AgentFeedbackKind.PRReview:
+			return localize('agentFeedbackReview.prReview', "PR Review");
+		case AgentFeedbackKind.AgentReview:
+			return localize('agentFeedbackReview.codeReview', "Code Review");
+		default:
+			return undefined;
+	}
+}
+
+/**
+ * Registers the commands the chat `viewUnreviewedComments` confirmation
+ * renderer (in `vs/workbench/contrib/chat`) uses to fetch unreviewed comments
+ * and apply the user's selection. Keeping the logic here means the chat layer
+ * never depends on the `vs/sessions` feedback model.
+ */
+export function registerAgentFeedbackReviewCommands(): void {
+	CommandsRegistry.registerCommand(AgentFeedbackReviewCommandId.GetComments, (accessor, sessionResource: UriComponents): IChatAgentFeedbackReviewComment[] => {
+		const feedbackService = accessor.get(IAgentFeedbackService);
+		const resource = URI.revive(sessionResource);
+		return feedbackService.getFeedback(resource)
+			.filter(item => item.state === AgentFeedbackState.Created && REVIEWABLE_KINDS.has(item.kind))
+			.map(item => ({
+				id: item.id,
+				kindLabel: kindLabel(item.kind),
+				text: item.text,
+				fileUri: item.resourceUri,
+			}));
+	});
+
+	CommandsRegistry.registerCommand(AgentFeedbackReviewCommandId.Reveal, async (accessor, sessionResource: UriComponents, commentId: string): Promise<void> => {
+		const feedbackService = accessor.get(IAgentFeedbackService);
+		await feedbackService.revealFeedback(URI.revive(sessionResource), commentId);
+	});
+
+	CommandsRegistry.registerCommand(AgentFeedbackReviewCommandId.Delete, (accessor, sessionResource: UriComponents, commentId: string): void => {
+		const feedbackService = accessor.get(IAgentFeedbackService);
+		feedbackService.removeFeedback(URI.revive(sessionResource), commentId);
+	});
+
+	CommandsRegistry.registerCommand(AgentFeedbackReviewCommandId.Accept, (accessor, sessionResource: UriComponents, commentIds: readonly string[]): void => {
+		const feedbackService = accessor.get(IAgentFeedbackService);
+		const resource = URI.revive(sessionResource);
+		for (const id of commentIds) {
+			feedbackService.acceptFeedback(resource, id);
+		}
+	});
+}

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackReviewCommands.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackReviewCommands.ts
@@ -65,7 +65,7 @@ export function registerAgentFeedbackReviewCommands(): void {
 		const feedbackService = accessor.get(IAgentFeedbackService);
 		const resource = URI.revive(sessionResource);
 		for (const id of commentIds) {
-			feedbackService.acceptFeedback(resource, id);
+			feedbackService.acceptFeedback(resource, id, { revealToAgent: true });
 		}
 	});
 }

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
@@ -39,6 +39,16 @@ export interface INavigableSessionComment {
 	readonly id: string;
 }
 
+/** Options for {@link IAgentFeedbackService.acceptFeedback}. */
+export interface IAcceptFeedbackOptions {
+	/**
+	 * Flag the accepted item as pending reveal to the agent so the
+	 * `viewUnreviewedComments` server tool returns it (and only the items
+	 * revealed in the same invocation).
+	 */
+	readonly revealToAgent?: boolean;
+}
+
 export interface IAgentFeedbackChangeEvent {
 	readonly sessionResource: URI;
 	readonly feedbackItems: readonly IAgentFeedback[];
@@ -114,8 +124,13 @@ export interface IAgentFeedbackService {
 	 * {@link AgentFeedbackState.Created} state, transitioning it to
 	 * {@link AgentFeedbackState.Accepted} so it becomes submittable and is
 	 * attached to the chat input.
+	 *
+	 * When {@link IAcceptFeedbackOptions.revealToAgent} is set, the item is
+	 * additionally flagged as pending reveal to the agent so the
+	 * `viewUnreviewedComments` server tool returns exactly the comments the user
+	 * chose to reveal for that invocation.
 	 */
-	acceptFeedback(sessionResource: URI, feedbackId: string): void;
+	acceptFeedback(sessionResource: URI, feedbackId: string, options?: IAcceptFeedbackOptions): void;
 
 	/**
 	 * Remove a single feedback item.
@@ -358,7 +373,7 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 		return feedback;
 	}
 
-	acceptFeedback(sessionResource: URI, feedbackId: string): void {
+	acceptFeedback(sessionResource: URI, feedbackId: string, options?: IAcceptFeedbackOptions): void {
 		const backend = this._backendForSession(sessionResource);
 		const feedbackItems = backend.getItems(sessionResource);
 		const existing = feedbackItems.find(f => f.id === feedbackId);
@@ -366,7 +381,11 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 			return;
 		}
 
-		const accepted: IAgentFeedback = { ...existing, state: AgentFeedbackState.Accepted };
+		const accepted: IAgentFeedback = {
+			...existing,
+			state: AgentFeedbackState.Accepted,
+			...(options?.revealToAgent ? { pendingAgentReveal: true } : {}),
+		};
 		backend.upsert(accepted);
 
 		if (accepted.kind !== AgentFeedbackKind.UserReview) {

--- a/src/vs/workbench/contrib/chat/browser/accessibility/chatResponseAccessibleView.ts
+++ b/src/vs/workbench/contrib/chat/browser/accessibility/chatResponseAccessibleView.ts
@@ -18,7 +18,7 @@ import { IStorageService, StorageScope } from '../../../../../platform/storage/c
 import { AccessibilityVerbositySettingId } from '../../../accessibility/browser/accessibilityConfiguration.js';
 import { migrateLegacyTerminalToolSpecificData } from '../../common/chat.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
-import { IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatPullRequestContent, IChatSearchToolInvocationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTerminalToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolResourcesInvocationData, ILegacyChatTerminalToolInvocationData, IToolResultOutputDetailsSerialized, isLegacyChatTerminalToolInvocationData } from '../../common/chatService/chatService.js';
+import { IChatAgentFeedbackReviewConfirmationData, IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatPullRequestContent, IChatSearchToolInvocationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTerminalToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolResourcesInvocationData, ILegacyChatTerminalToolInvocationData, IToolResultOutputDetailsSerialized, isLegacyChatTerminalToolInvocationData } from '../../common/chatService/chatService.js';
 import { isResponseVM } from '../../common/model/chatViewModel.js';
 import { IToolResultInputOutputDetails, IToolResultOutputDetails, isToolResultInputOutputDetails, isToolResultOutputDetails, toolContentToA11yString } from '../../common/tools/languageModelToolsService.js';
 import { ChatTreeItem, IChatWidget, IChatWidgetService } from '../chat.js';
@@ -60,7 +60,7 @@ export class ChatResponseAccessibleView implements IAccessibleViewImplementation
 	}
 }
 
-type ToolSpecificData = IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData;
+type ToolSpecificData = IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData;
 type ResultDetails = Array<URI | Location> | IToolResultInputOutputDetails | IToolResultOutputDetails | IToolResultOutputDetailsSerialized;
 
 export const CHAT_ACCESSIBLE_VIEW_INCLUDE_THINKING_STORAGE_KEY = 'chat.accessibleView.includeThinking';

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -13,8 +13,9 @@ import { getToolKind } from '../../../../../../platform/agentHost/common/state/s
 import { getChatErrorDetailsFromMeta, IChatErrorContext } from '../../../common/chatErrorMessages.js';
 import { AGENT_HOST_SCHEME, toAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { getAgentFeedbackAttachmentMetadata, isAgentFeedbackAttachment } from '../../../../../../platform/agentHost/common/agentFeedbackAttachments.js';
+import { isViewUnreviewedCommentsTool } from '../../../../../../platform/agentHost/common/agentFeedbackAnnotations.js';
 import { MessageAttachmentKind, type FileEdit, type MessageAttachment, type StringOrMarkdown, type TextRange } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
-import { type ChatExternalEditKind, type ChatMcpAppData, type IChatExternalEdit, type IChatModifiedFilesConfirmationData, type IChatProgress, type IChatResponseErrorDetails, type IChatSearchToolInvocationData, type IChatTerminalToolInvocationData, type IChatToolInputInvocationData, type IChatToolInvocationSerialized, type IChatUsage, ToolConfirmKind } from '../../../common/chatService/chatService.js';
+import { type ChatExternalEditKind, type ChatMcpAppData, type IChatAgentFeedbackReviewConfirmationData, type IChatExternalEdit, type IChatModifiedFilesConfirmationData, type IChatProgress, type IChatResponseErrorDetails, type IChatSearchToolInvocationData, type IChatTerminalToolInvocationData, type IChatToolInputInvocationData, type IChatToolInvocationSerialized, type IChatUsage, ToolConfirmKind } from '../../../common/chatService/chatService.js';
 import { type IChatSessionHistoryItem } from '../../../common/chatSessionsService.js';
 import { ChatToolInvocation } from '../../../common/model/chatProgressTypes/chatToolInvocation.js';
 import { type IChatRequestVariableData } from '../../../common/model/chatModel.js';
@@ -1041,16 +1042,30 @@ export function toolCallStateToInvocation(tc: ToolCallState, subAgentInvocationI
 		// mapper auto-emits `tool_ready` with `confirmed: NotNeeded` paired
 		// with `tool_start`. So no special-case for subagents is needed here.)
 		const confirmationMessages: IToolConfirmationMessages = {
-			title: stringOrMarkdownToString(tc.confirmationTitle, connectionAuthority) ?? tc.displayName,
-			message: stringOrMarkdownToString(tc.invocationMessage, connectionAuthority),
+			title: isViewUnreviewedCommentsTool(tc.toolName)
+				? localize('agentFeedback.reviewTitle', "Reveal unreviewed comments?")
+				: stringOrMarkdownToString(tc.confirmationTitle, connectionAuthority) ?? tc.displayName,
+			message: isViewUnreviewedCommentsTool(tc.toolName)
+				? localize('agentFeedback.reviewMessage', "Choose which comments to reveal to the agent. Unchecked comments stay hidden.")
+				: stringOrMarkdownToString(tc.invocationMessage, connectionAuthority),
 		};
 		if (tc.options) {
 			confirmationMessages.customOptions = tc.options;
 		}
 
-		let toolSpecificData: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatModifiedFilesConfirmationData | undefined;
+		let toolSpecificData: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData | undefined;
 		const pendingEdits = tc.edits?.items;
-		if (pendingEdits?.length) {
+		if (isViewUnreviewedCommentsTool(tc.toolName)) {
+			// The agent host surfaces this server tool as a confirmation (it is
+			// excluded from auto-approve). Render a custom confirmation that lets
+			// the user pick which unreviewed comments to reveal; the renderer
+			// fetches the comments and applies the selection via feedback
+			// commands, so this layer carries only the button labels.
+			toolSpecificData = {
+				kind: 'agentFeedbackReviewConfirmation',
+				options: [localize('agentFeedback.reveal', "Reveal Selected")],
+			};
+		} else if (pendingEdits?.length) {
 			const wrap = (uri: URI) => connectionAuthority ? toAgentHostUri(uri, connectionAuthority) : uri;
 			const mapped = mapFileEdits(pendingEdits, tc.toolCallId);
 			toolSpecificData = {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatAgentFeedbackReviewConfirmation.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatAgentFeedbackReviewConfirmation.css
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.chat-agent-feedback-review-list {
+	display: flex;
+	flex-direction: column;
+	gap: var(--vscode-spacing-size40);
+}
+
+.chat-agent-feedback-review-empty {
+	color: var(--vscode-descriptionForeground);
+	padding: var(--vscode-spacing-size40) 0;
+}
+
+.chat-agent-feedback-review-row {
+	display: flex;
+	align-items: flex-start;
+	gap: var(--vscode-spacing-size80);
+	padding: var(--vscode-spacing-size60);
+	border: var(--vscode-strokeThickness) solid var(--vscode-widget-border);
+	border-radius: var(--vscode-cornerRadius-small);
+}
+
+.chat-agent-feedback-review-row .monaco-checkbox {
+	margin-top: var(--vscode-spacing-size20);
+	flex: 0 0 auto;
+}
+
+.chat-agent-feedback-review-main {
+	display: flex;
+	flex-direction: column;
+	gap: var(--vscode-spacing-size20);
+	min-width: 0;
+	flex: 1 1 auto;
+}
+
+.chat-agent-feedback-review-header {
+	display: flex;
+	align-items: center;
+	gap: var(--vscode-spacing-size60);
+	min-width: 0;
+}
+
+.chat-agent-feedback-review-kind {
+	flex: 0 0 auto;
+	padding: 0 var(--vscode-spacing-size40);
+	border-radius: var(--vscode-cornerRadius-xSmall);
+	background-color: var(--vscode-badge-background);
+	color: var(--vscode-badge-foreground);
+	font-size: var(--vscode-bodyFontSize-xSmall);
+	text-transform: uppercase;
+}
+
+.chat-agent-feedback-review-file {
+	flex: 1 1 auto;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: var(--vscode-descriptionForeground);
+	font-size: var(--vscode-bodyFontSize-small);
+}
+
+.chat-agent-feedback-review-text {
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+
+.chat-agent-feedback-review-actions {
+	flex: 0 0 auto;
+}
+
+.chat-agent-feedback-review-actions .monaco-action-bar .action-label {
+	color: var(--vscode-icon-foreground);
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAgentFeedbackReviewConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAgentFeedbackReviewConfirmationSubPart.ts
@@ -71,7 +71,7 @@ export class ChatAgentFeedbackReviewConfirmationSubPart extends AbstractToolConf
 		}
 
 		const listElement = dom.$('.chat-agent-feedback-review-list');
-		this._populate(listElement);
+		void this._populate(listElement);
 
 		const revealLabel = data.options[0] ?? localize('agentFeedback.reveal', "Reveal Selected");
 		const buttons: IChatConfirmationButton<() => void>[] = [
@@ -228,7 +228,11 @@ export class ChatAgentFeedbackReviewConfirmationSubPart extends AbstractToolConf
 	}
 
 	protected createContentElement(): HTMLElement | string {
-		throw new Error('Not used');
+		// This confirmation builds its own widget content (the comment list) in
+		// the constructor and never goes through the base `render()` flow, so
+		// this is unused. Return an empty string rather than throwing so the
+		// class stays safe if a future refactor routes through `render()`.
+		return '';
 	}
 
 	protected getTitle(): string {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAgentFeedbackReviewConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAgentFeedbackReviewConfirmationSubPart.ts
@@ -1,0 +1,242 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../../../../base/browser/dom.js';
+import { ActionBar } from '../../../../../../../base/browser/ui/actionbar/actionbar.js';
+import { Checkbox } from '../../../../../../../base/browser/ui/toggle/toggle.js';
+import { Action } from '../../../../../../../base/common/actions.js';
+import { Codicon } from '../../../../../../../base/common/codicons.js';
+import { DisposableMap, DisposableStore, toDisposable } from '../../../../../../../base/common/lifecycle.js';
+import { basename } from '../../../../../../../base/common/resources.js';
+import { ThemeIcon } from '../../../../../../../base/common/themables.js';
+import { URI } from '../../../../../../../base/common/uri.js';
+import { localize } from '../../../../../../../nls.js';
+import { ICommandService } from '../../../../../../../platform/commands/common/commands.js';
+import { IContextKeyService } from '../../../../../../../platform/contextkey/common/contextkey.js';
+import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js';
+import { IKeybindingService } from '../../../../../../../platform/keybinding/common/keybinding.js';
+import { ILogService } from '../../../../../../../platform/log/common/log.js';
+import { defaultCheckboxStyles } from '../../../../../../../platform/theme/browser/defaultStyles.js';
+import { AgentFeedbackReviewCommandId, IChatAgentFeedbackReviewComment, IChatToolInvocation, ToolConfirmKind } from '../../../../common/chatService/chatService.js';
+import { ILanguageModelToolsService } from '../../../../common/tools/languageModelToolsService.js';
+import { ChatContextKeys } from '../../../../common/actions/chatContextKeys.js';
+import { IChatCodeBlockInfo, IChatWidgetService } from '../../../chat.js';
+import { IChatToolRiskAssessmentService } from '../../../tools/chatToolRiskAssessmentService.js';
+import { IChatContentPartRenderContext } from '../chatContentParts.js';
+import { ChatCustomConfirmationWidget, IChatConfirmationButton } from '../chatConfirmationWidget.js';
+import { AbstractToolConfirmationSubPart } from './abstractToolConfirmationSubPart.js';
+import '../media/chatAgentFeedbackReviewConfirmation.css';
+
+interface ICommentRow {
+	readonly comment: IChatAgentFeedbackReviewComment;
+	readonly checkbox: Checkbox;
+	readonly element: HTMLElement;
+}
+
+/**
+ * Confirmation for the agent host `viewUnreviewedComments` tool. Lists the
+ * review comments the user has not accepted yet — each with a checkbox (reveal
+ * to the agent or not), an action to open the file at the comment, and an
+ * action to delete the comment. Accepting reveals (accepts) the checked
+ * comments before approving the tool call; the comments and all actions are
+ * fetched/applied via {@link AgentFeedbackReviewCommandId} commands so this
+ * layer stays decoupled from the `vs/sessions` feedback model.
+ */
+export class ChatAgentFeedbackReviewConfirmationSubPart extends AbstractToolConfirmationSubPart {
+	public override readonly domNode: HTMLElement;
+	public override readonly codeblocks: IChatCodeBlockInfo[] = [];
+
+	private readonly _rows = new Map<string, ICommentRow>();
+	private readonly _rowStores = this._register(new DisposableMap<string, DisposableStore>());
+
+	constructor(
+		toolInvocation: IChatToolInvocation,
+		context: IChatContentPartRenderContext,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IKeybindingService keybindingService: IKeybindingService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IChatWidgetService chatWidgetService: IChatWidgetService,
+		@ILanguageModelToolsService languageModelToolsService: ILanguageModelToolsService,
+		@IChatToolRiskAssessmentService riskAssessmentService: IChatToolRiskAssessmentService,
+		@ICommandService private readonly commandService: ICommandService,
+		@ILogService private readonly logService: ILogService,
+	) {
+		super(toolInvocation, context, instantiationService, keybindingService, contextKeyService, chatWidgetService, languageModelToolsService, riskAssessmentService);
+
+		const data = toolInvocation.toolSpecificData;
+		if (!data || data.kind !== 'agentFeedbackReviewConfirmation') {
+			throw new Error('Agent feedback review confirmation data is missing');
+		}
+
+		const listElement = dom.$('.chat-agent-feedback-review-list');
+		this._populate(listElement);
+
+		const revealLabel = data.options[0] ?? localize('agentFeedback.reveal', "Reveal Selected");
+		const buttons: IChatConfirmationButton<() => void>[] = [
+			{
+				label: revealLabel,
+				data: () => this._onReveal(),
+			},
+			{
+				label: localize('agentFeedback.cancel', "Cancel"),
+				isSecondary: true,
+				data: () => this.confirmWith(this.toolInvocation, { type: ToolConfirmKind.Skipped }),
+			},
+		];
+
+		const confirmWidget = this._register(this.instantiationService.createInstance(
+			ChatCustomConfirmationWidget<() => void>,
+			this.context,
+			{
+				title: this.getTitle(),
+				icon: Codicon.commentDiscussion,
+				message: listElement,
+				buttons,
+			}
+		));
+
+		const hasToolConfirmation = ChatContextKeys.Editing.hasToolConfirmation.bindTo(this.contextKeyService);
+		hasToolConfirmation.set(true);
+
+		this._register(confirmWidget.onDidClick(({ button, isTouchClick }) => {
+			button.data();
+			if (!isTouchClick) {
+				this.chatWidgetService.getWidgetBySessionResource(this.context.element.sessionResource)?.focusInput();
+			}
+		}));
+
+		this._register(toDisposable(() => hasToolConfirmation.reset()));
+		this.domNode = confirmWidget.domNode;
+	}
+
+	private get _sessionResource(): URI {
+		return this.context.element.sessionResource;
+	}
+
+	private async _populate(listElement: HTMLElement): Promise<void> {
+		let comments: readonly IChatAgentFeedbackReviewComment[] = [];
+		try {
+			comments = await this.commandService.executeCommand<IChatAgentFeedbackReviewComment[]>(
+				AgentFeedbackReviewCommandId.GetComments,
+				this._sessionResource,
+			) ?? [];
+		} catch (error) {
+			this.logService.warn('[AgentFeedbackReview] Failed to fetch unreviewed comments', error);
+		}
+
+		if (this._store.isDisposed) {
+			return;
+		}
+
+		dom.clearNode(listElement);
+		if (!comments.length) {
+			listElement.append(dom.$('.chat-agent-feedback-review-empty', undefined, localize('agentFeedback.none', "No unreviewed comments.")));
+			return;
+		}
+
+		for (const comment of comments) {
+			this._renderRow(listElement, comment);
+		}
+	}
+
+	private _renderRow(listElement: HTMLElement, comment: IChatAgentFeedbackReviewComment): void {
+		const rowStore = new DisposableStore();
+		this._rowStores.set(comment.id, rowStore);
+		const rowElement = dom.append(listElement, dom.$('.chat-agent-feedback-review-row'));
+
+		const checkbox = rowStore.add(new Checkbox(
+			localize('agentFeedback.revealComment', "Reveal this comment to the agent"),
+			true,
+			defaultCheckboxStyles,
+		));
+		dom.append(rowElement, checkbox.domNode);
+
+		const main = dom.append(rowElement, dom.$('.chat-agent-feedback-review-main'));
+		const header = dom.append(main, dom.$('.chat-agent-feedback-review-header'));
+		if (comment.kindLabel) {
+			dom.append(header, dom.$('.chat-agent-feedback-review-kind', undefined, comment.kindLabel));
+		}
+		const fileUri = URI.revive(comment.fileUri);
+		const fileLabel = dom.append(header, dom.$('span.chat-agent-feedback-review-file'));
+		fileLabel.textContent = basename(fileUri);
+		fileLabel.title = fileUri.fsPath || fileUri.path;
+
+		const textElement = dom.append(main, dom.$('.chat-agent-feedback-review-text'));
+		textElement.textContent = comment.text;
+
+		const actionsContainer = dom.append(rowElement, dom.$('.chat-agent-feedback-review-actions'));
+		const actionBar = rowStore.add(new ActionBar(actionsContainer));
+		actionBar.push(rowStore.add(new Action(
+			'agentFeedbackReview.reveal',
+			localize('agentFeedback.openFile', "Open File and Reveal Comment"),
+			ThemeIcon.asClassName(Codicon.goToFile),
+			true,
+			() => this._reveal(comment.id),
+		)), { icon: true, label: false });
+		actionBar.push(rowStore.add(new Action(
+			'agentFeedbackReview.delete',
+			localize('agentFeedback.delete', "Delete Comment"),
+			ThemeIcon.asClassName(Codicon.close),
+			true,
+			() => this._delete(comment.id),
+		)), { icon: true, label: false });
+
+		this._rows.set(comment.id, { comment, checkbox, element: rowElement });
+	}
+
+	private async _reveal(commentId: string): Promise<void> {
+		try {
+			await this.commandService.executeCommand(AgentFeedbackReviewCommandId.Reveal, this._sessionResource, commentId);
+		} catch (error) {
+			this.logService.warn('[AgentFeedbackReview] Failed to reveal comment', error);
+		}
+	}
+
+	private async _delete(commentId: string): Promise<void> {
+		const row = this._rows.get(commentId);
+		try {
+			await this.commandService.executeCommand(AgentFeedbackReviewCommandId.Delete, this._sessionResource, commentId);
+			row?.element.remove();
+			this._rows.delete(commentId);
+			this._rowStores.deleteAndDispose(commentId);
+		} catch (error) {
+			this.logService.warn('[AgentFeedbackReview] Failed to delete comment', error);
+		}
+	}
+
+	private async _onReveal(): Promise<void> {
+		const checkedIds: string[] = [];
+		for (const row of this._rows.values()) {
+			if (row.checkbox.checked) {
+				checkedIds.push(row.comment.id);
+			}
+		}
+		// Accept the checked comments before approving the tool call so the
+		// annotation writes are dispatched ahead of the approval on the same
+		// connection; the server tool body then reads the updated state and
+		// returns exactly the revealed comments.
+		if (checkedIds.length) {
+			try {
+				await this.commandService.executeCommand(AgentFeedbackReviewCommandId.Accept, this._sessionResource, checkedIds);
+			} catch (error) {
+				this.logService.warn('[AgentFeedbackReview] Failed to accept comments', error);
+			}
+		}
+		this.confirmWith(this.toolInvocation, { type: ToolConfirmKind.UserAction });
+	}
+
+	protected createContentElement(): HTMLElement | string {
+		throw new Error('Not used');
+	}
+
+	protected getTitle(): string {
+		const state = this.toolInvocation.state.get();
+		if (state.type !== IChatToolInvocation.StateKind.WaitingForConfirmation) {
+			return '';
+		}
+		const title = state.confirmationMessages?.title;
+		return typeof title === 'string' ? title : title?.value ?? '';
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
@@ -24,6 +24,7 @@ import { ChatResultListSubPart } from './chatResultListSubPart.js';
 import { ChatSimpleToolProgressPart } from './chatSimpleToolProgressPart.js';
 import { ChatSandboxPrerequisiteConfirmationSubPart } from './chatSandboxPrerequisiteConfirmationSubPart.js';
 import { ChatModifiedFilesConfirmationSubPart } from './chatModifiedFilesConfirmationSubPart.js';
+import { ChatAgentFeedbackReviewConfirmationSubPart } from './chatAgentFeedbackReviewConfirmationSubPart.js';
 import { ChatTerminalToolConfirmationSubPart } from './chatTerminalToolConfirmationSubPart.js';
 import { ChatTerminalToolProgressPart } from './chatTerminalToolProgressPart.js';
 import { ToolConfirmationSubPart } from './chatToolConfirmationSubPart.js';
@@ -193,6 +194,8 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 					return this.instantiationService.createInstance(ChatTerminalToolConfirmationSubPart, this.toolInvocation, this.toolInvocation.toolSpecificData, this.context, this.renderer, this.editorPool, this.currentWidthDelegate, this.codeBlockStartIndex);
 				} else if (this.toolInvocation.toolSpecificData?.kind === 'modifiedFilesConfirmation') {
 					return this.instantiationService.createInstance(ChatModifiedFilesConfirmationSubPart, this.toolInvocation, this.context, this.listPool);
+				} else if (this.toolInvocation.toolSpecificData?.kind === 'agentFeedbackReviewConfirmation') {
+					return this.instantiationService.createInstance(ChatAgentFeedbackReviewConfirmationSubPart, this.toolInvocation, this.context);
 				} else {
 					return this.instantiationService.createInstance(ToolConfirmationSubPart, this.toolInvocation, this.context, this.renderer, this.editorPool, this.currentWidthDelegate, this.codeBlockStartIndex);
 				}

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -701,7 +701,7 @@ export type ConfirmedReason =
 
 export interface IChatToolInvocation {
 	readonly presentation: IPreparedToolInvocation['presentation'];
-	readonly toolSpecificData?: IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData;
+	readonly toolSpecificData?: IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData;
 	/**
 	 * Observable that tracks the `kind` of `toolSpecificData`. Used by the
 	 * tool invocation part to re-render when the kind changes (e.g. from
@@ -979,7 +979,7 @@ export interface IToolResultOutputDetailsSerialized {
  */
 export interface IChatToolInvocationSerialized {
 	presentation: IPreparedToolInvocation['presentation'];
-	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData;
+	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatToolResourcesInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData;
 	invocationMessage: string | IMarkdownString;
 	originMessage: string | IMarkdownString | undefined;
 	pastTenseMessage: string | IMarkdownString | undefined;
@@ -1087,6 +1087,52 @@ export interface IChatModifiedFilesConfirmationData {
 		readonly title?: string;
 		readonly description?: string;
 	}[];
+}
+
+/**
+ * Confirmation data for the agent host `viewUnreviewedComments` tool. The
+ * comments themselves are not carried here: the renderer fetches them (and
+ * performs reveal/delete/accept actions) through commands registered by the
+ * agent feedback feature, so this workbench/chat layer stays decoupled from the
+ * `vs/sessions` feedback model. The renderer resolves the owning session from
+ * its render context. Only the confirmation button labels are needed up front.
+ */
+export interface IChatAgentFeedbackReviewConfirmationData {
+	readonly kind: 'agentFeedbackReviewConfirmation';
+	/** Confirmation button labels (first is the primary/approve action). */
+	readonly options: readonly string[];
+}
+
+/**
+ * A single unreviewed comment shown in the {@link IChatAgentFeedbackReviewConfirmationData}
+ * confirmation. Produced by {@link AgentFeedbackReviewCommandId.GetComments}.
+ */
+export interface IChatAgentFeedbackReviewComment {
+	readonly id: string;
+	/** Localized origin label, e.g. "PR Review" or "Code Review"; absent for user-authored comments. */
+	readonly kindLabel?: string;
+	/** The comment body. */
+	readonly text: string;
+	/** The file the comment is anchored to. */
+	readonly fileUri: UriComponents;
+}
+
+/**
+ * Command ids the agent feedback review confirmation renderer (workbench/chat)
+ * uses to fetch unreviewed comments and apply the user's selection. They are
+ * implemented by the agent feedback feature in `vs/sessions`, keeping the chat
+ * layer decoupled from the feedback model. All take the owning session resource
+ * (`UriComponents`) as their first argument.
+ */
+export const enum AgentFeedbackReviewCommandId {
+	/** `(sessionResource)` -> `IChatAgentFeedbackReviewComment[]` (the `created` reviewable comments). */
+	GetComments = '_agentFeedbackReview.getComments',
+	/** `(sessionResource, commentId)` -> opens the file and reveals the comment. */
+	Reveal = '_agentFeedbackReview.reveal',
+	/** `(sessionResource, commentId)` -> deletes the comment entirely. */
+	Delete = '_agentFeedbackReview.delete',
+	/** `(sessionResource, commentIds)` -> accepts (reveals) the given comments. */
+	Accept = '_agentFeedbackReview.accept',
 }
 
 export interface IChatMcpServersStarting {

--- a/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation.ts
@@ -8,7 +8,7 @@ import { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { IObservable, ISettableObservable, observableValue } from '../../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../nls.js';
-import { ConfirmedReason, IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSearchToolInvocationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind, type IChatTerminalToolInvocationData } from '../../chatService/chatService.js';
+import { ConfirmedReason, IChatAgentFeedbackReviewConfirmationData, IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSearchToolInvocationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind, type IChatTerminalToolInvocationData } from '../../chatService/chatService.js';
 import { IPreparedToolInvocation, isToolResultOutputDetails, IToolConfirmationMessages, IToolData, IToolProgressStep, IToolResult, ToolDataSource } from '../../tools/languageModelToolsService.js';
 
 export interface IStreamingToolCallOptions {
@@ -36,7 +36,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 	public readonly chatRequestId?: string;
 	public isAttachedToThinking: boolean = false;
 
-	private _toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData;
+	private _toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData;
 	private readonly _toolSpecificDataKind = observableValue<string | undefined>(this, undefined);
 	public readonly toolSpecificDataKind: IObservable<string | undefined> = this._toolSpecificDataKind;
 

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -25,7 +25,7 @@ import { createDecorator } from '../../../../../platform/instantiation/common/in
 import { IProgress } from '../../../../../platform/progress/common/progress.js';
 import { ChatRequestToolReferenceEntry } from '../attachments/chatVariableEntries.js';
 import { IVariableReference } from '../chatModes.js';
-import { IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSearchToolInvocationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, type IChatTerminalToolInvocationData } from '../chatService/chatService.js';
+import { IChatAgentFeedbackReviewConfirmationData, IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSearchToolInvocationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, type IChatTerminalToolInvocationData } from '../chatService/chatService.js';
 import { ILanguageModelChatMetadata, LanguageModelPartAudience } from '../languageModels.js';
 import { UserSelectedTools } from '../participants/chatAgents.js';
 import { PromptElementJSON, stringifyPromptElementJSON } from './promptTsxTypes.js';
@@ -190,7 +190,7 @@ export interface IToolInvocation {
 	 * Lets us add some nicer UI to toolcalls that came from a sub-agent, but in the long run, this should probably just be rendered in a similar way to thinking text + tool call groups
 	 */
 	subAgentInvocationId?: string;
-	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData;
+	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData;
 	modelId?: string;
 	userSelectedTools?: UserSelectedTools;
 	/** The label of the custom button selected by the user during confirmation, if custom buttons were used. */
@@ -395,7 +395,7 @@ export interface IPreparedToolInvocation {
 	confirmationMessages?: IToolConfirmationMessages;
 	presentation?: ToolInvocationPresentation;
 	icon?: ThemeIcon;
-	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData;
+	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatSearchToolInvocationData | IChatModifiedFilesConfirmationData | IChatAgentFeedbackReviewConfirmationData;
 }
 
 export interface IToolImpl {

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatAgentFeedbackReviewConfirmation.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatAgentFeedbackReviewConfirmation.fixture.ts
@@ -1,0 +1,189 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../../base/browser/dom.js';
+import { Event } from '../../../../../base/common/event.js';
+import { observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock, upcastPartial } from '../../../../../base/test/common/mock.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IMarkdownRendererService, MarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
+import { IChatWidgetService } from '../../../../contrib/chat/browser/chat.js';
+import { IChatToolRiskAssessmentService } from '../../../../contrib/chat/browser/tools/chatToolRiskAssessmentService.js';
+import { IChatContentPartRenderContext, InlineTextModelCollection } from '../../../../contrib/chat/browser/widget/chatContentParts/chatContentParts.js';
+import { IChatMarkdownAnchorService } from '../../../../contrib/chat/browser/widget/chatContentParts/chatMarkdownAnchorService.js';
+import { ChatAgentFeedbackReviewConfirmationSubPart } from '../../../../contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAgentFeedbackReviewConfirmationSubPart.js';
+import { AgentFeedbackReviewCommandId, IChatAgentFeedbackReviewComment, IChatAgentFeedbackReviewConfirmationData } from '../../../../contrib/chat/common/chatService/chatService.js';
+import { ChatToolInvocation } from '../../../../contrib/chat/common/model/chatProgressTypes/chatToolInvocation.js';
+import { IChatResponseViewModel } from '../../../../contrib/chat/common/model/chatViewModel.js';
+import { ILanguageModelToolsService, IToolData, ToolDataSource } from '../../../../contrib/chat/common/tools/languageModelToolsService.js';
+import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup, registerWorkbenchServices } from '../fixtureUtils.js';
+
+import '../../../../contrib/chat/browser/widget/media/chat.css';
+import '../../../../contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css';
+import '../../../../contrib/chat/browser/widget/chatContentParts/media/chatAgentFeedbackReviewConfirmation.css';
+
+const sessionResource = URI.parse('copilot:/fixture-session');
+
+function createMockContext(): IChatContentPartRenderContext {
+	const element = new class extends mock<IChatResponseViewModel>() {
+		override readonly sessionResource = sessionResource;
+	}();
+	return {
+		element,
+		inlineTextModels: upcastPartial<InlineTextModelCollection>({}),
+		elementIndex: 0,
+		container: document.createElement('div'),
+		content: [],
+		contentIndex: 0,
+		editorPool: undefined!,
+		codeBlockStartIndex: 0,
+		treeStartIndex: 0,
+		diffEditorPool: undefined!,
+		currentWidth: observableValue('currentWidth', 480),
+		onDidChangeVisibility: Event.None,
+	};
+}
+
+function createToolInvocation(): ChatToolInvocation {
+	const toolData: IToolData = {
+		id: 'viewUnreviewedComments',
+		source: ToolDataSource.Internal,
+		displayName: 'View Unreviewed Comments',
+		modelDescription: 'viewUnreviewedComments',
+	};
+	const toolSpecificData: IChatAgentFeedbackReviewConfirmationData = {
+		kind: 'agentFeedbackReviewConfirmation',
+		options: ['Reveal Selected'],
+	};
+	return new ChatToolInvocation(
+		{
+			confirmationMessages: {
+				title: 'Reveal unreviewed comments?',
+				message: 'Choose which comments to reveal to the agent. Unchecked comments stay hidden.',
+			},
+			toolSpecificData,
+		},
+		toolData,
+		'fixture-tool-call',
+		undefined,
+		undefined,
+	);
+}
+
+/**
+ * Mock command service that backs the confirmation renderer. Returns the
+ * supplied comments for the "get comments" command and no-ops for the reveal /
+ * delete / accept actions so the fixture renders without touching the real
+ * feedback service.
+ */
+function createCommandService(comments: readonly IChatAgentFeedbackReviewComment[]): ICommandService {
+	return new class extends mock<ICommandService>() {
+		override readonly onWillExecuteCommand = Event.None;
+		override readonly onDidExecuteCommand = Event.None;
+		override async executeCommand<R = unknown>(commandId: string): Promise<R | undefined> {
+			if (commandId === AgentFeedbackReviewCommandId.GetComments) {
+				return comments as unknown as R;
+			}
+			return undefined;
+		}
+	}();
+}
+
+function renderConfirmation(context: ComponentFixtureContext, comments: readonly IChatAgentFeedbackReviewComment[]): void {
+	const { container, disposableStore } = context;
+
+	const instantiationService = createEditorServices(disposableStore, {
+		colorTheme: context.theme,
+		additionalServices: (reg) => {
+			registerWorkbenchServices(reg);
+			reg.define(IMarkdownRendererService, MarkdownRendererService);
+			reg.defineInstance(ICommandService, createCommandService(comments));
+			reg.defineInstance(IChatMarkdownAnchorService, new class extends mock<IChatMarkdownAnchorService>() {
+				override register() { return { dispose() { } }; }
+			}());
+			reg.defineInstance(IChatWidgetService, new class extends mock<IChatWidgetService>() {
+				override getWidgetBySessionResource() { return undefined; }
+			}());
+			reg.defineInstance(IChatToolRiskAssessmentService, new class extends mock<IChatToolRiskAssessmentService>() { }());
+			reg.defineInstance(ILanguageModelToolsService, new class extends mock<ILanguageModelToolsService>() {
+				override getTool() { return undefined; }
+			}());
+		},
+	});
+
+	const toolInvocation = createToolInvocation();
+	const part = disposableStore.add(
+		instantiationService.createInstance(
+			ChatAgentFeedbackReviewConfirmationSubPart,
+			toolInvocation,
+			createMockContext(),
+		)
+	);
+
+	container.style.width = '520px';
+	container.style.padding = '8px';
+	container.classList.add('interactive-session');
+
+	const itemContainer = dom.$('.interactive-item-container');
+	itemContainer.appendChild(part.domNode);
+	container.appendChild(itemContainer);
+}
+
+// ============================================================================
+// Sample comments
+// ============================================================================
+
+const prComment: IChatAgentFeedbackReviewComment = {
+	id: 'pr-1',
+	kindLabel: 'PR Review',
+	text: 'This function should handle the empty array case before iterating.',
+	fileUri: URI.file('/workspace/src/utils/array.ts'),
+};
+
+const codeReviewComment: IChatAgentFeedbackReviewComment = {
+	id: 'cr-1',
+	kindLabel: 'Code Review',
+	text: 'Consider extracting this into a shared helper — it is duplicated in three places.',
+	fileUri: URI.file('/workspace/src/services/userService.ts'),
+};
+
+const longComment: IChatAgentFeedbackReviewComment = {
+	id: 'pr-2',
+	kindLabel: 'PR Review',
+	text: 'The error handling here swallows the original stack trace, which makes telemetry diagnosis difficult. Re-throw with the cause attached, or at minimum log the original error before wrapping it so we keep the callstack for the dashboard.',
+	fileUri: URI.file('/workspace/src/platform/agentHost/node/agentService.ts'),
+};
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+export default defineThemedFixtureGroup({ path: 'chat/' }, {
+	SingleComment: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (ctx) => renderConfirmation(ctx, [prComment]),
+	}),
+
+	MixedKinds: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (ctx) => renderConfirmation(ctx, [prComment, codeReviewComment]),
+	}),
+
+	ManyComments: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (ctx) => renderConfirmation(ctx, [prComment, codeReviewComment, longComment]),
+	}),
+
+	LongComment: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (ctx) => renderConfirmation(ctx, [longComment]),
+	}),
+
+	Empty: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (ctx) => renderConfirmation(ctx, []),
+	}),
+});


### PR DESCRIPTION
## What

Adds a `viewUnreviewedComments` agent-host server tool and surfaces unreviewed review comments to the agent.

- **`listComments` note**: when there are pull request or code review comments the user has not accepted yet (still in the `created` state), the `listComments` result now appends a short note telling the agent how many there are (per kind) and that it can call `viewUnreviewedComments` to view them. No note is added when there are none, and the created comments themselves are not listed.
- **`viewUnreviewedComments` tool**: a confirmation-gated server tool (excluded from auto-approve for both Claude and Copilot). The user is asked to approve the call.
- **Confirmation UI**: a custom chat content part that lists each unreviewed comment with:
  - a checkbox to choose whether to reveal it to the agent,
  - the feedback kind badge (PR Review / Code Review) and the file it belongs to,
  - a toolbar action to open the file and reveal the comment,
  - an action to delete the comment entirely.
- **On accept**: checked comments move to the `Accepted` state (revealed to the model and shown normally in the UI); unchecked comments stay `created`. The tool returns exactly the revealed comments.

## Notes for reviewers

- The chat/workbench layer stays decoupled from the `vs/sessions` feedback model: the renderer fetches comments and performs reveal/delete/accept through commands registered by the agent feedback feature (`AgentFeedbackReviewCommandId`).
- Accepted-state annotation writes are dispatched before the tool approval (same connection, ordered), so the server tool body reads the updated state.
- Works for both Claude and Copilot providers via a shared `requiresConfirmation` predicate on the server-tool host.
- Adds unit tests for the note + tool behavior and a component explorer fixture for the confirmation UI (validated across 5 variants x both themes).