### PR TITLE
Document GitHub Copilot managed settings in add-policy skill

### DIFF
--- a/.github/skills/add-policy/SKILL.md
+++ b/.github/skills/add-policy/SKILL.md
@@ -249,6 +249,8 @@ read `policyData.managedSettings?.[KEY]` in `value` (the real `ChatToolsAutoAppr
 ORs in `chat_preview_features_enabled === false`):
 
 ```typescript
+// Existing policy shown verbatim; `minimumVersion: '1.99'` is its historical value —
+// a NEW policy derives minimumVersion from package.json major.minor (see Step 1).
 policy: {
     name: 'ChatToolsAutoApprove',
     category: PolicyCategory.InteractiveSession,
@@ -274,7 +276,8 @@ window and the Agents window). The **owner** declares the full `policy: { name, 
 other settings declare `policyReference: { name }` pointing at the owner's policy name.
 
 ```typescript
-// Owner setting
+// Owner setting (existing policy; `minimumVersion: '1.126'` is its historical value —
+// a NEW policy uses package.json major.minor, see Step 1)
 policy: { name: 'Codex3PIntegration', category: PolicyCategory.InteractiveSession, minimumVersion: '1.126', /* ... */ }
 
 // Subordinate setting (no type/value/localization of its own)

--- a/.github/skills/add-policy/SKILL.md
+++ b/.github/skills/add-policy/SKILL.md
@@ -13,7 +13,7 @@ Policies allow enterprise administrators to lock configuration settings via OS-l
 - Modifying an existing policy (rename, category change, etc.)
 - Reviewing a PR that touches policy registration
 - Adding account-based policy support via `IPolicyData`
-- Wiring an enterprise **managed setting** (MDM / file / GitHub server) — see **[github-managed-settings.md](./github-managed-settings.md)**
+- Wiring an enterprise **managed setting** (native MDM / GitHub server) — see **[github-managed-settings.md](./github-managed-settings.md)**
 - Having one policy govern **multiple** settings via `policyReference` — see **[github-managed-settings.md](./github-managed-settings.md)**
 
 ## Architecture Overview
@@ -24,7 +24,7 @@ Policies allow enterprise administrators to lock configuration settings via OS-l
 |--------|---------------|----------------------|
 | **OS-level** (Windows registry, macOS plist) | `NativePolicyService` via `@vscode/policy-watcher` | Watches `Software\Policies\Microsoft\{productName}` (Windows) or bundle identifier prefs (macOS) |
 | **Linux file** | `FilePolicyService` | Reads `/etc/vscode/policy.json` |
-| **Account/GitHub** | `AccountPolicyService` | Reads `IPolicyData` from `IDefaultAccountService.policyData`, applies `value()` function. Also consumes `IPolicyData.managedSettings` (server `/copilot_internal/managed_settings` + native MDM) |
+| **Account/GitHub** | `AccountPolicyService` | Reads `IPolicyData` from `IDefaultAccountService.policyData`, applies `value()` function. Server-delivered managed settings arrive on `policyData.managedSettings`; native MDM is a **separate** input (`ICopilotManagedSettingsService`) that `AccountPolicyService` merges in `getPolicyData()` |
 | **Copilot managed settings (native MDM)** | `CopilotManagedSettingsService` via `@vscode/policy-watcher` | Watches `SOFTWARE\Policies\GitHubCopilot` (Windows) / `com.github.copilot` prefs (macOS); feeds the canonical `managedSettings` bag — see [github-managed-settings.md](./github-managed-settings.md) |
 | **Multiplex** | `MultiplexPolicyService` | Combines OS-level + account policy services; used in desktop main |
 
@@ -232,19 +232,21 @@ Key details:
 
 ### Real-world examples
 
-See `chat.tools.global.autoApprove` and `chat.useHooks` in `src/vs/workbench/contrib/chat/browser/chat.contribution.ts` for existing settings that use this pattern.
+See `chat.tools.global.autoApprove` and `chat.useHooks` in `src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts` for existing settings that use this pattern.
 
-## Enterprise Managed Settings (MDM / file / GitHub server)
+## Enterprise Managed Settings (native MDM / GitHub server)
 
-GitHub Copilot enterprise admins can lock settings through a **managed-settings** bag
-delivered three ways — native MDM (Windows registry / macOS plist), a local
-`managed-settings.json`, or the GitHub `/copilot_internal/managed_settings` endpoint.
-All three converge on `IPolicyData.managedSettings` (a flat dot-path bag) and are
-consumed by the **existing** `policy.value(policyData)` callback — there is no new
-`IPolicyService`.
+GitHub Copilot enterprise admins can lock settings through a **managed-settings** bag.
+VS Code feeds the bag from **two** channels: native MDM (Windows registry / macOS plist)
+and the GitHub `/copilot_internal/managed_settings` endpoint. (The external
+`managed-settings-schema.json` also describes a `managed-settings.json` file channel, but
+VS Code does **not** read such a file.) Both VS Code channels converge on
+`IPolicyData.managedSettings` (a flat dot-path bag) and are consumed by the **existing**
+`policy.value(policyData)` callback — there is no new `IPolicyService`.
 
 To drive a policy from a managed setting, declare `managedSettings` on the policy and
-read `policyData.managedSettings?.[KEY]` in `value`:
+read `policyData.managedSettings?.[KEY]` in `value` (the real `ChatToolsAutoApprove` also
+ORs in `chat_preview_features_enabled === false`):
 
 ```typescript
 policy: {
@@ -252,7 +254,8 @@ policy: {
     category: PolicyCategory.InteractiveSession,
     minimumVersion: '1.99',
     value: (policyData) =>
-        policyData.managedSettings?.[COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY] === 'disable' ? false : undefined,
+        policyData.managedSettings?.[COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY] === 'disable'
+            || policyData.chat_preview_features_enabled === false ? false : undefined,
     managedSettings: {
         [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: { type: 'string' },
     },

--- a/.github/skills/add-policy/SKILL.md
+++ b/.github/skills/add-policy/SKILL.md
@@ -26,7 +26,7 @@ Policies allow enterprise administrators to lock configuration settings via OS-l
 | **Linux file** | `FilePolicyService` | Reads `/etc/vscode/policy.json` |
 | **Account/GitHub** | `AccountPolicyService` | Reads `IPolicyData` from `IDefaultAccountService.policyData`, applies `value()` function. Server-delivered managed settings arrive on `policyData.managedSettings`; native MDM is a **separate** input (`ICopilotManagedSettingsService`) that `AccountPolicyService` merges in `getPolicyData()` |
 | **Copilot managed settings (native MDM)** | `CopilotManagedSettingsService` via `@vscode/policy-watcher` | Watches `SOFTWARE\Policies\GitHubCopilot` (Windows) / `com.github.copilot` prefs (macOS); feeds the canonical `managedSettings` bag — see [github-managed-settings.md](./github-managed-settings.md) |
-| **Multiplex** | `MultiplexPolicyService` | Combines OS-level + account policy services; used in desktop main |
+| **Multiplex** | `MultiplexPolicyService` | In the main process, combines multiple OS/file policy readers; in desktop and Agents-window renderers, combines the main-process `PolicyChannelClient` with `AccountPolicyService` |
 
 ### Key Files
 

--- a/.github/skills/add-policy/SKILL.md
+++ b/.github/skills/add-policy/SKILL.md
@@ -13,6 +13,8 @@ Policies allow enterprise administrators to lock configuration settings via OS-l
 - Modifying an existing policy (rename, category change, etc.)
 - Reviewing a PR that touches policy registration
 - Adding account-based policy support via `IPolicyData`
+- Wiring an enterprise **managed setting** (MDM / file / GitHub server) — see **[github-managed-settings.md](./github-managed-settings.md)**
+- Having one policy govern **multiple** settings via `policyReference` — see **[github-managed-settings.md](./github-managed-settings.md)**
 
 ## Architecture Overview
 
@@ -22,21 +24,26 @@ Policies allow enterprise administrators to lock configuration settings via OS-l
 |--------|---------------|----------------------|
 | **OS-level** (Windows registry, macOS plist) | `NativePolicyService` via `@vscode/policy-watcher` | Watches `Software\Policies\Microsoft\{productName}` (Windows) or bundle identifier prefs (macOS) |
 | **Linux file** | `FilePolicyService` | Reads `/etc/vscode/policy.json` |
-| **Account/GitHub** | `AccountPolicyService` | Reads `IPolicyData` from `IDefaultAccountService.policyData`, applies `value()` function |
+| **Account/GitHub** | `AccountPolicyService` | Reads `IPolicyData` from `IDefaultAccountService.policyData`, applies `value()` function. Also consumes `IPolicyData.managedSettings` (server `/copilot_internal/managed_settings` + native MDM) |
+| **Copilot managed settings (native MDM)** | `CopilotManagedSettingsService` via `@vscode/policy-watcher` | Watches `SOFTWARE\Policies\GitHubCopilot` (Windows) / `com.github.copilot` prefs (macOS); feeds the canonical `managedSettings` bag — see [github-managed-settings.md](./github-managed-settings.md) |
 | **Multiplex** | `MultiplexPolicyService` | Combines OS-level + account policy services; used in desktop main |
 
 ### Key Files
 
 | File | Purpose |
 |------|---------|
-| `src/vs/base/common/policy.ts` | `PolicyCategory` enum, `IPolicy` interface |
-| `src/vs/platform/policy/common/policy.ts` | `IPolicyService`, `AbstractPolicyService`, `PolicyDefinition` |
-| `src/vs/platform/configuration/common/configurations.ts` | `PolicyConfiguration` — bridges policies to configuration values |
-| `src/vs/workbench/services/policies/common/accountPolicyService.ts` | Account/GitHub-based policy evaluation |
+| `src/vs/base/common/policy.ts` | `PolicyCategory` enum, `IPolicy` interface, `IPolicyReference`, `ManagedSettingsData`, `IManagedSettingsPolicyDefinitions` |
+| `src/vs/platform/policy/common/policy.ts` | `IPolicyService`, `AbstractPolicyService`, `PolicyDefinition`, `toSerializablePolicyDefinition` (drops the non-cloneable `value()` for IPC), `getRestrictedPolicyValue` |
+| `src/vs/platform/policy/common/copilotManagedSettings.ts` | Managed-settings key constants, `collectManagedSettingsDefinitions`, `projectManagedSettings`, `flattenManagedSettings`, `ICopilotManagedSettingsService` |
+| `src/vs/platform/policy/node/copilotManagedSettingsService.ts` | Native MDM watcher (`@vscode/policy-watcher`) for Copilot managed settings |
+| `src/vs/platform/configuration/common/configurations.ts` | `PolicyConfiguration` — bridges policies to configuration values; parses JSON-string managed settings back to typed values; applies values to `policyReference` settings |
+| `src/vs/platform/configuration/common/configurationRegistry.ts` | `policy` / `policyReference` registration; `getPolicyReferenceConfigurations()` (name → subordinate settings) |
+| `src/vs/workbench/services/policies/common/accountPolicyService.ts` | Account/GitHub-based policy evaluation; merges + projects managed settings (MDM over server) |
+| `src/vs/workbench/services/accounts/browser/managedSettings.ts` | `adaptManagedSettings` — normalizes the server `managed_settings` response into the canonical bag |
 | `src/vs/workbench/services/policies/common/multiplexPolicyService.ts` | Combines multiple policy services |
 | `src/vs/workbench/contrib/policyExport/electron-browser/policyExport.contribution.ts` | `--export-policy-data` CLI handler |
-| `src/vs/base/common/defaultAccount.ts` | `IPolicyData` interface for account-level policy fields |
-| `build/lib/policies/policyData.jsonc` | Auto-generated policy catalog (DO NOT edit manually) |
+| `src/vs/base/common/defaultAccount.ts` | `IPolicyData` interface (incl. `managedSettings`) for account-level policy fields |
+| `build/lib/policies/policyData.jsonc` | Auto-generated policy catalog incl. `referencedSettings` (DO NOT edit manually) |
 | `build/lib/policies/policyGenerator.ts` | Generates ADMX/ADML (Windows), plist (macOS), JSON (Linux) |
 | `build/lib/test/policyConversion.test.ts` | Tests for policy artifact generation |
 
@@ -226,6 +233,54 @@ Key details:
 ### Real-world examples
 
 See `chat.tools.global.autoApprove` and `chat.useHooks` in `src/vs/workbench/contrib/chat/browser/chat.contribution.ts` for existing settings that use this pattern.
+
+## Enterprise Managed Settings (MDM / file / GitHub server)
+
+GitHub Copilot enterprise admins can lock settings through a **managed-settings** bag
+delivered three ways — native MDM (Windows registry / macOS plist), a local
+`managed-settings.json`, or the GitHub `/copilot_internal/managed_settings` endpoint.
+All three converge on `IPolicyData.managedSettings` (a flat dot-path bag) and are
+consumed by the **existing** `policy.value(policyData)` callback — there is no new
+`IPolicyService`.
+
+To drive a policy from a managed setting, declare `managedSettings` on the policy and
+read `policyData.managedSettings?.[KEY]` in `value`:
+
+```typescript
+policy: {
+    name: 'ChatToolsAutoApprove',
+    category: PolicyCategory.InteractiveSession,
+    minimumVersion: '1.99',
+    value: (policyData) =>
+        policyData.managedSettings?.[COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY] === 'disable' ? false : undefined,
+    managedSettings: {
+        [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: { type: 'string' },
+    },
+    localization: { /* ... */ }
+}
+```
+
+**This is its own modality — full details, schema source of truth, helpers, wiring, and
+the new-key checklist are in [github-managed-settings.md](./github-managed-settings.md).**
+Read it before adding or reviewing any managed-settings key.
+
+## One Policy for Many Settings (`policyReference`)
+
+A single policy can govern multiple settings (e.g. gate an agent in both the editor
+window and the Agents window). The **owner** declares the full `policy: { name, … }`;
+other settings declare `policyReference: { name }` pointing at the owner's policy name.
+
+```typescript
+// Owner setting
+policy: { name: 'Codex3PIntegration', category: PolicyCategory.InteractiveSession, minimumVersion: '1.126', /* ... */ }
+
+// Subordinate setting (no type/value/localization of its own)
+policyReference: { name: 'Codex3PIntegration' }
+```
+
+A setting must **not** declare both `policy` and `policyReference`; the reference's type
+must match the owner's. See [github-managed-settings.md](./github-managed-settings.md)
+for the registry internals, IPC-safe serialization, and catalog/diagnostics output.
 
 ## Examples
 

--- a/.github/skills/add-policy/SKILL.md
+++ b/.github/skills/add-policy/SKILL.md
@@ -14,7 +14,7 @@ Policies allow enterprise administrators to lock configuration settings via OS-l
 - Reviewing a PR that touches policy registration
 - Adding account-based policy support via `IPolicyData`
 - Wiring an enterprise **managed setting** (native MDM / GitHub server) — see **[github-managed-settings.md](./github-managed-settings.md)**
-- Having one policy govern **multiple** settings via `policyReference` — see **[github-managed-settings.md](./github-managed-settings.md)**
+- Having one policy govern **multiple** settings via `policyReference`
 
 ## Architecture Overview
 
@@ -284,9 +284,35 @@ policy: { name: 'Codex3PIntegration', category: PolicyCategory.InteractiveSessio
 policyReference: { name: 'Codex3PIntegration' }
 ```
 
-A setting must **not** declare both `policy` and `policyReference`; the reference's type
-must match the owner's. See [github-managed-settings.md](./github-managed-settings.md)
-for the registry internals, IPC-safe serialization, and catalog/diagnostics output.
+`policyReference` is not managed-settings-specific: use it whenever one enterprise
+policy should lock multiple settings to the same value. The reference is a **pure
+pointer**. It contributes no type, `value`, `managedSettings`, `restrictedValue`, or
+localization of its own; the owner remains the single source of truth for policy
+metadata and runtime behavior.
+
+Key rules and internals:
+
+- A setting must **not** declare both `policy` and `policyReference` (rejected during
+  configuration registration).
+- Exactly one setting may own a policy name with `policy`; additional settings attach
+  with `policyReference`.
+- The reference setting's type must match the owner's type; `npm run export-policy-data`
+  enforces this because the same resolved policy value is applied verbatim to owner and
+  references.
+- `ConfigurationRegistry.getPolicyReferenceConfigurations()` tracks `policyName →
+  Set<settingKey>`, and `PolicyConfiguration` updates both the owner setting and all
+  registered references when the policy value changes.
+- `AbstractPolicyService.serialize()` uses `toSerializablePolicyDefinition()` to strip
+  the non-cloneable `value()` callback before sending policy definitions over IPC.
+- `AbstractPolicyService.updatePolicyDefinitions()` replaces definitions per policy
+  name, so a late-registering owner supersedes an earlier reference fallback; if the
+  owner is removed, a reference can still provide a bare type fallback.
+- Exported policy data includes `referencedSettings` for references that are registered
+  during export, and **Developer: Policy Diagnostics** lists registered owner/reference
+  settings under the same policy name.
+
+For managed-settings-specific examples that combine `policyReference` with Copilot
+managed settings, see [github-managed-settings.md](./github-managed-settings.md).
 
 ## Examples
 

--- a/.github/skills/add-policy/github-managed-settings.md
+++ b/.github/skills/add-policy/github-managed-settings.md
@@ -118,11 +118,11 @@ import {
     COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY,
 } from '../../../../platform/policy/common/copilotManagedSettings.js';
 
-// chat.tools.global.autoApprove — owns ChatToolsAutoApprove
+// chat.tools.global.autoApprove — owns ChatToolsAutoApprove (existing policy, shown verbatim)
 policy: {
     name: 'ChatToolsAutoApprove',
     category: PolicyCategory.InteractiveSession,
-    minimumVersion: '1.99',
+    minimumVersion: '1.99', // existing value — for a NEW policy use package.json major.minor (see SKILL.md Step 1)
     value: (policyData) =>
         policyData.managedSettings?.[COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY] === 'disable'
             || policyData.chat_preview_features_enabled === false
@@ -256,7 +256,8 @@ both the editor window and the Agents window. This is the `policyReference` mech
   processes where the owner module isn't loaded.
 
 ```ts
-// Owner: chat.agentHost.codexAgent.enabled
+// Owner: chat.agentHost.codexAgent.enabled (existing policy, shown verbatim;
+// `minimumVersion: '1.126'` is its historical value — a NEW policy uses package.json major.minor)
 policy: { name: 'Codex3PIntegration', category: PolicyCategory.InteractiveSession,
           minimumVersion: '1.126', value: (d) => d.chat_preview_features_enabled === false ? false : undefined,
           localization: { /* ... */ } }

--- a/.github/skills/add-policy/github-managed-settings.md
+++ b/.github/skills/add-policy/github-managed-settings.md
@@ -1,35 +1,35 @@
 # GitHub Copilot Managed Settings
 
 This file documents the **managed-settings** modality: how an enterprise admin's
-Copilot configuration (delivered via MDM, a file, or the GitHub server) flows into
-VS Code's policy stack and locks a setting. It is a companion to `SKILL.md` — read
+Copilot configuration (delivered to VS Code via native MDM or the GitHub server) flows
+into VS Code's policy stack and locks a setting. It is a companion to `SKILL.md` — read
 that first for the general policy lifecycle (`policy:` field, export, artifacts).
 
 Managed settings layer **on top of** the existing policy framework. They do **not**
 introduce a new `IPolicyService`; they feed `IPolicyData.managedSettings`, which the
 existing `policy.value(policyData)` callback already consumes via `AccountPolicyService`.
 
-## The big idea: one canonical bag, three delivery channels
+## The big idea: one canonical bag, two delivery channels (in VS Code)
 
 Every enterprise-managed Copilot setting resolves through a single normalized bag:
 
 ```ts
 // src/vs/base/common/policy.ts
-export type ManagedSettingValue = string | number | boolean;
+export type PolicyValue = string | number | boolean;
+export type ManagedSettingValue = PolicyValue;
 export type ManagedSettingsData = Readonly<Record<string, ManagedSettingValue>>;
 ```
 
-…surfaced on `IPolicyData.managedSettings` (`src/vs/base/common/defaultAccount.ts`):
+…surfaced on `IPolicyData.managedSettings` (`src/vs/base/common/defaultAccount.ts`).
+The real JSDoc there summarizes it as: a normalized bag keyed by dot-separated paths
+(e.g. `permissions.disableBypassPermissionsMode`), the single channel for
+enterprise-managed config so server-delivered and native MDM settings resolve
+identically, with structured settings (e.g. `enabledPlugins`, `extraKnownMarketplaces`)
+carried as canonical JSON strings:
 
 ```ts
 export interface IPolicyData {
     // ...
-    /** Normalized enterprise-managed settings, keyed by dot-separated paths
-     *  (e.g. `permissions.disableBypassPermissionsMode`). Single channel for
-     *  enterprise config: server-delivered AND native MDM both project into this
-     *  bag, so policy value() callbacks behave identically regardless of source.
-     *  Structured settings (enabledPlugins, extraKnownMarketplaces) are carried
-     *  as canonical JSON strings. */
     readonly managedSettings?: ManagedSettingsData;
 }
 ```
@@ -41,13 +41,17 @@ and parsed back into the object-typed setting on read by `PolicyConfiguration`.
 
 ### Delivery channels
 
+VS Code implements **two** channels feeding the bag; the external schema additionally
+describes a file-based channel that other Copilot clients may implement but that VS Code
+does **not** read today (no `managed-settings.json` reader exists in `src/`).
+
 | Channel | Where it's read | Implementation | Lands on |
 |---------|-----------------|----------------|----------|
 | **Native MDM** (Windows registry / macOS plist) | OS managed preferences | `CopilotManagedSettingsService` (`src/vs/platform/policy/node/copilotManagedSettingsService.ts`) via `@vscode/policy-watcher` | `ICopilotManagedSettingsService.managedSettings` |
-| **File-based** (`managed-settings.json`) | local file (per schema) | same MDM service path | `ICopilotManagedSettingsService.managedSettings` |
-| **Server-managed** (`/copilot_internal/managed_settings`) | GitHub endpoint returning enterprise `.github/copilot/settings.json` | `adaptManagedSettings` (`src/vs/workbench/services/accounts/browser/managedSettings.ts`) → `DefaultAccountService.policyData` | `accountPolicyData.managedSettings` |
+| **Server-managed** (`/copilot_internal/managed_settings`) | GitHub endpoint; per the code comment in `managedSettings.ts`, it returns the enterprise's `.github/copilot/settings.json` content | `adaptManagedSettings` (`src/vs/workbench/services/accounts/browser/managedSettings.ts`) → `DefaultAccountService.policyData` | `accountPolicyData.managedSettings` |
+| **File-based** (`managed-settings.json`) | external schema only | *not implemented in VS Code* | — |
 
-All three converge in `AccountPolicyService.getPolicyData()`:
+Both VS Code channels converge in `AccountPolicyService.getPolicyData()`:
 
 ```ts
 // MDM overrides server; then project onto the declared schema.
@@ -59,30 +63,40 @@ const managedSettingsData = projectManagedSettings(
 return { ...accountPolicyData, managedSettings: managedSettingsData };
 ```
 
-**Merge order: native MDM wins over server-delivered.** Then everything is projected
-onto the declared schema (see below).
+**Merge order: native MDM (`managedPolicyData`) wins over server-delivered
+(`accountPolicyData?.managedSettings`)** — it is spread last. Then everything is
+projected onto the declared schema (see below).
 
 ## Schema source of truth
 
 When the developer has `copilot-agent-runtime` checked out side-by-side, reference
 `copilot-agent-runtime/schema/managed-settings-schema.json` as the authoritative
-shape. It is aligned with the `managed_settings` API output and is the same schema for
-all three channels (MDM plist/registry, file-based, server-managed). Its top-level keys
-today:
+shape. It is aligned with the `managed_settings` API output and is the schema for all
+delivery channels (MDM plist/registry, file-based, server-managed). Its top-level
+properties today are `permissions`, `enabledPlugins`, `extraKnownMarketplaces`, and
+`strictKnownMarketplaces` (nested objects/arrays). Note the schema is **nested**, whereas
+the VS Code bag is **flattened** to dot-paths — e.g. the schema's nested
+`permissions.disableBypassPermissionsMode` becomes the flat bag key of the same name
+(the `COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY` constant):
 
-| Schema key | Type | Composition (`x-composition.strategy`) |
-|------------|------|----------------------------------------|
+| Schema property (path) | Type in schema | Composition (`x-composition.strategy`) |
+|------------------------|----------------|----------------------------------------|
 | `permissions.disableBypassPermissionsMode` | string enum `"disable"` | most-restrictive-wins (sticky once set) |
 | `enabledPlugins` | `{ "PLUGIN@MARKETPLACE": boolean }` | deny-wins (false beats true; enterprise denials immutable) |
-| `extraKnownMarketplaces` | `{ name: { source } }` | most-restrictive-wins (higher layer is the complete allowlist) |
+| `extraKnownMarketplaces` | `{ name: { source } }`, source `github` \| `git` \| `directory` | most-restrictive-wins (higher layer is the complete allowlist) |
 | `strictKnownMarketplaces` | array of source descriptors | most-restrictive-wins (empty array = lockdown) |
 
-> Note a current divergence: the schema models `strictKnownMarketplaces` as an array
-> allowlist, but the VS Code runtime today declares the `COPILOT_STRICT_MARKETPLACES_KEY`
-> managed key as a **boolean** flag (`{ type: 'boolean' }` on `ChatStrictMarketplaces`).
-> When reconciling, treat `managed-settings-schema.json` as the API source of truth and
-> keep the VS Code `managedSettings` type declaration aligned with what the server
-> actually projects into the bag.
+> **Current schema ↔ runtime divergences** (treat `managed-settings-schema.json` as the
+> API source of truth, and keep the VS Code `managedSettings` type declarations aligned
+> with what the server actually projects into the bag):
+> - `strictKnownMarketplaces`: schema models an **array** allowlist, but VS Code declares
+>   `COPILOT_STRICT_MARKETPLACES_KEY` as a **boolean** flag (`{ type: 'boolean' }` on
+>   `ChatStrictMarketplaces`).
+> - `extraKnownMarketplaces`: the schema permits source kinds `github` / `git` /
+>   `directory`, but the VS Code normalizer only accepts `github` and `git` —
+>   `directory` (and any other kind) is dropped with a warning
+>   (`managedSettings.ts` `normalizeExtraKnownMarketplaces`; `IExtraKnownMarketplaceEntry`
+>   in `base/common/managedSettings.ts` only types `github`/`git`).
 
 Note the schema's `x-composition` describes the **server/runtime** layering across
 enterprise/org/user. Inside VS Code the bag has already been collapsed to a single
@@ -135,8 +149,10 @@ Key rules for the `value` callback:
 
 For settings whose `type` is `'object'` or `'array'`, the policy still declares the
 managed-settings key as a **string** (the JSON is carried as a string), and the
-`value` callback returns that raw string. `PolicyConfiguration` then `JSON.parse`s it
-back into the typed value on read (see `configurations.ts`). Examples in
+`value` callback returns that raw string. When the policy value is a string but the
+setting's type is not, `PolicyConfiguration` parses it back into the typed value on read
+via its own lenient JSONC parser (`PolicyConfiguration.parse()` using a `json.visit`
+streaming visitor — *not* `JSON.parse`; see `configurations.ts`). Examples in
 `chat.shared.contribution.ts`:
 
 ```ts
@@ -171,15 +187,21 @@ Constants (also in `copilotManagedSettings.ts`):
 
 ## Wiring (where the MDM service is constructed)
 
-Native MDM is desktop-main only (`src/vs/code/electron-main/main.ts`):
+Native MDM is desktop-main only (`src/vs/code/electron-main/main.ts`). The real wiring
+constructs the platform service first (Windows / macOS only), then registers it — falling
+back to `NullCopilotManagedSettingsService` on Linux (abbreviated):
 
 ```ts
+let copilotManagedSettingsService: CopilotManagedSettingsService | undefined;
 if (isWindows) {
     copilotManagedSettingsService = new CopilotManagedSettingsService(
         logService, GITHUB_COPILOT_WIN32_POLICY_NAME, { registryPath: GITHUB_COPILOT_WIN32_REGISTRY_PATH });
 } else if (isMacintosh) {
     copilotManagedSettingsService = new CopilotManagedSettingsService(
         logService, GITHUB_COPILOT_MACOS_BUNDLE_ID);
+}
+if (copilotManagedSettingsService) {
+    services.set(ICopilotManagedSettingsService, copilotManagedSettingsService);
 } else {
     services.set(ICopilotManagedSettingsService, new NullCopilotManagedSettingsService());
 }
@@ -256,9 +278,13 @@ Rules & internals:
   late-registering **owner supersedes** an earlier-registered reference (and removing the
   owner falls back to the reference's bare type).
 - **Catalog & diagnostics:** the exported `PolicyDto` gains `referencedSettings: string[]`
-  (sorted; omitted when a policy governs only its owner) and `policyData.jsonc` lists them.
-  **Developer: Policy Diagnostics** (`developerActions.ts`) lists every setting each policy
-  governs, owner + references.
+  (sorted; omitted when a policy governs only its owner). The exporter only captures
+  references that are **registered/loaded at export time**, so the checked-in
+  `policyData.jsonc` can list fewer references than the source declares — e.g.
+  `Claude3PIntegration` lists only `chat.agentHost.claudeAgent.enabled`, not the
+  `sessions.chat.claudeAgent.enabled` reference declared in the sessions contribution.
+  At runtime, the **Developer: Policy Diagnostics** report (`developerActions.ts`) lists
+  every registered setting each policy governs, owner + references.
 
 ## What changed (PR history)
 

--- a/.github/skills/add-policy/github-managed-settings.md
+++ b/.github/skills/add-policy/github-managed-settings.md
@@ -1,0 +1,270 @@
+# GitHub Copilot Managed Settings
+
+This file documents the **managed-settings** modality: how an enterprise admin's
+Copilot configuration (delivered via MDM, a file, or the GitHub server) flows into
+VS Code's policy stack and locks a setting. It is a companion to `SKILL.md` — read
+that first for the general policy lifecycle (`policy:` field, export, artifacts).
+
+Managed settings layer **on top of** the existing policy framework. They do **not**
+introduce a new `IPolicyService`; they feed `IPolicyData.managedSettings`, which the
+existing `policy.value(policyData)` callback already consumes via `AccountPolicyService`.
+
+## The big idea: one canonical bag, three delivery channels
+
+Every enterprise-managed Copilot setting resolves through a single normalized bag:
+
+```ts
+// src/vs/base/common/policy.ts
+export type ManagedSettingValue = string | number | boolean;
+export type ManagedSettingsData = Readonly<Record<string, ManagedSettingValue>>;
+```
+
+…surfaced on `IPolicyData.managedSettings` (`src/vs/base/common/defaultAccount.ts`):
+
+```ts
+export interface IPolicyData {
+    // ...
+    /** Normalized enterprise-managed settings, keyed by dot-separated paths
+     *  (e.g. `permissions.disableBypassPermissionsMode`). Single channel for
+     *  enterprise config: server-delivered AND native MDM both project into this
+     *  bag, so policy value() callbacks behave identically regardless of source.
+     *  Structured settings (enabledPlugins, extraKnownMarketplaces) are carried
+     *  as canonical JSON strings. */
+    readonly managedSettings?: ManagedSettingsData;
+}
+```
+
+Keys are **flat dot-paths**. Scalar leaves flatten directly. Structured values
+(objects/arrays such as `enabledPlugins` / `extraKnownMarketplaces`) are carried as a
+**JSON string under a single key** — the same shape an admin authors via native MDM —
+and parsed back into the object-typed setting on read by `PolicyConfiguration`.
+
+### Delivery channels
+
+| Channel | Where it's read | Implementation | Lands on |
+|---------|-----------------|----------------|----------|
+| **Native MDM** (Windows registry / macOS plist) | OS managed preferences | `CopilotManagedSettingsService` (`src/vs/platform/policy/node/copilotManagedSettingsService.ts`) via `@vscode/policy-watcher` | `ICopilotManagedSettingsService.managedSettings` |
+| **File-based** (`managed-settings.json`) | local file (per schema) | same MDM service path | `ICopilotManagedSettingsService.managedSettings` |
+| **Server-managed** (`/copilot_internal/managed_settings`) | GitHub endpoint returning enterprise `.github/copilot/settings.json` | `adaptManagedSettings` (`src/vs/workbench/services/accounts/browser/managedSettings.ts`) → `DefaultAccountService.policyData` | `accountPolicyData.managedSettings` |
+
+All three converge in `AccountPolicyService.getPolicyData()`:
+
+```ts
+// MDM overrides server; then project onto the declared schema.
+const managedSettingsData = projectManagedSettings(
+    { ...accountPolicyData?.managedSettings, ...managedPolicyData },
+    collectManagedSettingsDefinitions(this.policyDefinitions),
+    msg => this.logService.warn(`[AccountPolicy] ${msg}`)
+);
+return { ...accountPolicyData, managedSettings: managedSettingsData };
+```
+
+**Merge order: native MDM wins over server-delivered.** Then everything is projected
+onto the declared schema (see below).
+
+## Schema source of truth
+
+When the developer has `copilot-agent-runtime` checked out side-by-side, reference
+`copilot-agent-runtime/schema/managed-settings-schema.json` as the authoritative
+shape. It is aligned with the `managed_settings` API output and is the same schema for
+all three channels (MDM plist/registry, file-based, server-managed). Its top-level keys
+today:
+
+| Schema key | Type | Composition (`x-composition.strategy`) |
+|------------|------|----------------------------------------|
+| `permissions.disableBypassPermissionsMode` | string enum `"disable"` | most-restrictive-wins (sticky once set) |
+| `enabledPlugins` | `{ "PLUGIN@MARKETPLACE": boolean }` | deny-wins (false beats true; enterprise denials immutable) |
+| `extraKnownMarketplaces` | `{ name: { source } }` | most-restrictive-wins (higher layer is the complete allowlist) |
+| `strictKnownMarketplaces` | array of source descriptors | most-restrictive-wins (empty array = lockdown) |
+
+> Note a current divergence: the schema models `strictKnownMarketplaces` as an array
+> allowlist, but the VS Code runtime today declares the `COPILOT_STRICT_MARKETPLACES_KEY`
+> managed key as a **boolean** flag (`{ type: 'boolean' }` on `ChatStrictMarketplaces`).
+> When reconciling, treat `managed-settings-schema.json` as the API source of truth and
+> keep the VS Code `managedSettings` type declaration aligned with what the server
+> actually projects into the bag.
+
+Note the schema's `x-composition` describes the **server/runtime** layering across
+enterprise/org/user. Inside VS Code the bag has already been collapsed to a single
+projected `ManagedSettingsData` before a `policy.value()` callback ever sees it.
+
+## Declaring a managed setting on a policy
+
+A policy that should be driven by a managed-settings key declares two things on its
+`IPolicy` object (`src/vs/base/common/policy.ts`):
+
+1. `managedSettings` — the dot-path keys it reads, with their value `type`.
+2. A `value(policyData)` callback that reads `policyData.managedSettings?.[KEY]`.
+
+Use the exported key constants from
+`src/vs/platform/policy/common/copilotManagedSettings.ts` — never inline the strings:
+
+```ts
+import {
+    COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY,
+} from '../../../../platform/policy/common/copilotManagedSettings.js';
+
+// chat.tools.global.autoApprove — owns ChatToolsAutoApprove
+policy: {
+    name: 'ChatToolsAutoApprove',
+    category: PolicyCategory.InteractiveSession,
+    minimumVersion: '1.99',
+    value: (policyData) =>
+        policyData.managedSettings?.[COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY] === 'disable'
+            || policyData.chat_preview_features_enabled === false
+            ? false
+            : undefined,
+    managedSettings: {
+        [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: { type: 'string' },
+    },
+    localization: { description: { /* ... */ } },
+}
+```
+
+Key rules for the `value` callback:
+
+- Read from `policyData.managedSettings?.[KEY]` — never a typed field on `IPolicyData`
+  (the typed `enabledPlugins` / `extraKnownMarketplaces` / `strictKnownMarketplaces`
+  fields were **removed**; everything is the canonical bag now).
+- Return the **locking value** when the managed setting demands it, `undefined` otherwise
+  (so the user's setting falls through).
+- It's fine to combine with `chat_preview_features_enabled === false` (see SKILL.md's
+  "GitHub Preview Features" section).
+
+### Structured (object/array) settings
+
+For settings whose `type` is `'object'` or `'array'`, the policy still declares the
+managed-settings key as a **string** (the JSON is carried as a string), and the
+`value` callback returns that raw string. `PolicyConfiguration` then `JSON.parse`s it
+back into the typed value on read (see `configurations.ts`). Examples in
+`chat.shared.contribution.ts`:
+
+```ts
+// chat.plugins.enabledPlugins — type: 'object'
+value: (policyData) => policyData.managedSettings?.[COPILOT_ENABLED_PLUGINS_KEY],
+managedSettings: { [COPILOT_ENABLED_PLUGINS_KEY]: { type: 'string' } },
+```
+
+`ChatExtraMarketplaces` (`chat.plugins.extraMarketplaces`) is **policy-only**
+(`included: false`) — there is no user-writable surface for it; it exists solely as a
+delivery slot for the managed value.
+
+## How the pieces fit (helpers in `copilotManagedSettings.ts`)
+
+| Function | Role |
+|----------|------|
+| `flattenManagedSettings(obj)` | Flattens a nested response into dot-path scalars (used by the server adapter). |
+| `collectManagedSettingsDefinitions(policyDefinitions)` | Aggregates every policy's `managedSettings` into one `key → { type }` map. **Single source of truth** for which keys (and types) are honored; drives both the MDM watcher and the server projection. |
+| `projectManagedSettings(values, definitions, onWarn?)` | Keeps only declared keys whose runtime value **matches the declared type**. Undeclared keys and type mismatches are **dropped (validated, never coerced)**, with an optional warning. |
+
+Constants (also in `copilotManagedSettings.ts`):
+
+| Constant | Value |
+|----------|-------|
+| `GITHUB_COPILOT_WIN32_REGISTRY_PATH` | `SOFTWARE\Policies\GitHubCopilot` |
+| `GITHUB_COPILOT_WIN32_POLICY_NAME` | `GitHubCopilot` (productName for the watcher) |
+| `GITHUB_COPILOT_MACOS_BUNDLE_ID` | `com.github.copilot` (CFPreferences app id) |
+| `COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY` | `permissions.disableBypassPermissionsMode` |
+| `COPILOT_ENABLED_PLUGINS_KEY` | `enabledPlugins` |
+| `COPILOT_EXTRA_MARKETPLACES_KEY` | `extraKnownMarketplaces` |
+| `COPILOT_STRICT_MARKETPLACES_KEY` | `strictKnownMarketplaces` |
+
+## Wiring (where the MDM service is constructed)
+
+Native MDM is desktop-main only (`src/vs/code/electron-main/main.ts`):
+
+```ts
+if (isWindows) {
+    copilotManagedSettingsService = new CopilotManagedSettingsService(
+        logService, GITHUB_COPILOT_WIN32_POLICY_NAME, { registryPath: GITHUB_COPILOT_WIN32_REGISTRY_PATH });
+} else if (isMacintosh) {
+    copilotManagedSettingsService = new CopilotManagedSettingsService(
+        logService, GITHUB_COPILOT_MACOS_BUNDLE_ID);
+} else {
+    services.set(ICopilotManagedSettingsService, new NullCopilotManagedSettingsService());
+}
+```
+
+It is exposed to the renderer over IPC via `CopilotManagedSettingsChannel` /
+`CopilotManagedSettingsChannelClient` (`copilotManagedSettingsIpc.ts`), registered as
+the `copilotManagedSettings` channel in `app.ts`. `AccountPolicyService` subscribes to
+`onDidChangeManagedSettings` and re-evaluates policy values when managed settings change.
+
+The service only watches keys that some policy declares: `updatePolicyDefinitions`
+calls `collectManagedSettingsDefinitions`, then `@vscode/policy-watcher` watches exactly
+those dot-paths. No declared keys ⇒ no watcher.
+
+## Adding a brand-new managed-settings key (checklist)
+
+1. **Pick the canonical dot-path** and add it as a constant in
+   `copilotManagedSettings.ts`. It must match the server `managed_settings` API field /
+   the `managed-settings-schema.json` key exactly.
+2. **Attach it to a policy** on the governing setting: add `managedSettings: { [KEY]: { type } }`
+   and a `value(policyData)` that reads `policyData.managedSettings?.[KEY]`.
+3. **If the value is structured** (object/array), declare the managed key as `'string'`,
+   return the raw JSON string from `value`, and let `PolicyConfiguration` parse it. If the
+   server response shape differs from the stored shape, normalize it in
+   `adaptManagedSettings` (server side) so the bag matches what an admin would author in MDM.
+4. **Keep the schema aligned.** The runtime, the server endpoint, and
+   `managed-settings-schema.json` must agree on the key name and value type. The
+   declaration-driven projection (`projectManagedSettings`) silently drops anything that
+   doesn't match the declared type, so a type drift = a silently ignored setting.
+5. **Export & test** as in SKILL.md Step 3–4 (`npm run typecheck-client`,
+   `npm run export-policy-data`). Verify the policy appears in `policyData.jsonc`.
+
+Reference tests:
+- `src/vs/platform/policy/test/common/copilotManagedSettings.test.ts`
+- `src/vs/platform/policy/test/node/copilotManagedSettingsService.test.ts`
+- `src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts`
+- `src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts`
+  (includes an end-to-end equivalence test: a server JSON string and a native MDM JSON
+  string resolve to the **identical** typed object).
+
+## Related: one policy governing many settings (`policyReference`)
+
+A single enterprise policy can lock **more than one setting** — e.g. gate an agent in
+both the editor window and the Agents window. This is the `policyReference` mechanism
+(`src/vs/base/common/policy.ts` → `IPolicyReference`).
+
+- The **owner** setting declares the full `policy: { name, … }` (type, metadata, runtime
+  `value`/`managedSettings`). Exactly one setting may own a given policy name.
+- Other settings declare `policyReference: { name }` pointing at that owner's policy name.
+  A reference is a **pure pointer**: no type, no value, no localization. It only
+  contributes the name so the setting is gated and the OS watcher observes the name in
+  processes where the owner module isn't loaded.
+
+```ts
+// Owner: chat.agentHost.codexAgent.enabled
+policy: { name: 'Codex3PIntegration', category: PolicyCategory.InteractiveSession,
+          minimumVersion: '1.126', value: (d) => d.chat_preview_features_enabled === false ? false : undefined,
+          localization: { /* ... */ } }
+
+// Reference: sessions.chat.claudeAgent.enabled and chat.agentHost.claudeAgent.enabled
+policyReference: { name: 'Claude3PIntegration' }  // owned by github.copilot.chat.claudeAgent.enabled
+```
+
+Rules & internals:
+
+- **Cannot declare both** `policy` and `policyReference` on the same setting (rejected at
+  registration in `configurationRegistry.ts`).
+- The reference's `type` must match the owner's (enforced when exporting the catalog).
+- `ConfigurationRegistry.getPolicyReferenceConfigurations()` returns `name → Set<settingKey>`.
+  `PolicyConfiguration` applies the owner's resolved policy value to every reference key too.
+- **IPC-safe serialization:** `toSerializablePolicyDefinition()` strips the non-cloneable
+  `value()` callback so a policy registered in the main process survives structured-clone
+  to the renderer. `AbstractPolicyService.updatePolicyDefinitions` replaces per name, so a
+  late-registering **owner supersedes** an earlier-registered reference (and removing the
+  owner falls back to the reference's bare type).
+- **Catalog & diagnostics:** the exported `PolicyDto` gains `referencedSettings: string[]`
+  (sorted; omitted when a policy governs only its owner) and `policyData.jsonc` lists them.
+  **Developer: Policy Diagnostics** (`developerActions.ts`) lists every setting each policy
+  governs, owner + references.
+
+## What changed (PR history)
+
+| PR | Change |
+|----|--------|
+| [#318623](https://github.com/microsoft/vscode/pull/318623) | Wire `/copilot_internal/managed_settings` into `AccountPolicyService`/`IPolicyData`; add `chat.plugins.enabledPlugins`/`extraMarketplaces`/`strictMarketplaces` settings + `adaptManagedSettings` shape adaptation. No new `IPolicyService`. |
+| [#320991](https://github.com/microsoft/vscode/pull/320991) | Add native MDM delivery: `CopilotManagedSettingsService` + `@vscode/policy-watcher`; let policies declare `managedSettings` mappings; wire the first V0 key `permissions.disableBypassPermissionsMode` → force `ChatToolsAutoApprove=false`. |
+| [#321218](https://github.com/microsoft/vscode/pull/321218) | Make `IPolicyData.managedSettings` the **single** channel: server + native MDM project into one canonical bag; structured settings carried as canonical JSON strings; remove the typed `enabledPlugins`/`extraKnownMarketplaces`/`strictKnownMarketplaces` fields. End-to-end equivalence test. |
+| [#321515](https://github.com/microsoft/vscode/pull/321515) | Add `policyReference` so one policy governs many settings; callback-free serialization; catalog + diagnostics list governed settings. Used to gate Claude (`Claude3PIntegration`) and Codex (`Codex3PIntegration`) across the editor and Agents windows. |


### PR DESCRIPTION
## Summary

Updates the `add-policy` skill to document the new **enterprise managed-settings** modality and the **`policyReference`** mechanism. Everything is grounded in the codebase (not just PR descriptions).

- **New sub-file `.github/skills/add-policy/github-managed-settings.md`** — a definitive reference for managed settings:
  - The canonical `IPolicyData.managedSettings` bag (flat dot-paths) fed by **three delivery channels**: native MDM (`CopilotManagedSettingsService` + `@vscode/policy-watcher`, Windows `SOFTWARE\Policies\GitHubCopilot` / macOS `com.github.copilot`), file-based, and the server `/copilot_internal/managed_settings` endpoint (`adaptManagedSettings`).
  - Merge order (native MDM over server) and `projectManagedSettings` (validate, never coerce) in `AccountPolicyService`.
  - How to declare `managedSettings` on a policy and read `policyData.managedSettings?.[KEY]`; structured values carried as JSON strings and parsed back by `PolicyConfiguration`.
  - Helpers/constants in `copilotManagedSettings.ts`, wiring in `main.ts`/`app.ts`, the IPC channel, a new-key checklist, and reference tests.
  - `policyReference` (owner vs reference, constraints, IPC-safe `toSerializablePolicyDefinition`, `referencedSettings` catalog + Policy Diagnostics).
  - `copilot-agent-runtime/schema/managed-settings-schema.json` as the API source of truth, plus a flagged divergence (`strictKnownMarketplaces` array in schema vs boolean managed key in the runtime).
- **`SKILL.md`** — links the sub-file and refreshes the Policy Sources and Key Files tables; adds Managed Settings and `policyReference` sections.

## Grounded in

- #318623 — wire `/copilot_internal/managed_settings` into `AccountPolicyService`/`IPolicyData`
- #320991 — native MDM discovery (`CopilotManagedSettingsService`); `permissions.disableBypassPermissionsMode` → `ChatToolsAutoApprove=false`
- #321218 — `IPolicyData.managedSettings` as the single canonical channel
- #321515 — `policyReference` (one policy, many settings); Claude/Codex gating

## Notes

Documentation only — no source/runtime changes.