### PR TITLE
Gate chat.agentHost.enabled behind editor preview policy

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -238,6 +238,21 @@
             "included": true
         },
         {
+            "key": "chat.agentHost.enabled",
+            "name": "ChatAgentHostEnabled",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.126",
+            "localization": {
+                "description": {
+                    "key": "chat.agentHost.enabled",
+                    "value": "When enabled, some agents run in a separate agent host process."
+                }
+            },
+            "type": "boolean",
+            "default": true,
+            "included": true
+        },
+        {
             "key": "chat.plugins.enabled",
             "name": "ChatPluginsEnabled",
             "category": "InteractiveSession",

--- a/src/vs/platform/agentHost/browser/agentHost.config.contribution.ts
+++ b/src/vs/platform/agentHost/browser/agentHost.config.contribution.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IPolicyData } from '../../../base/common/defaultAccount.js';
+import { PolicyCategory } from '../../../base/common/policy.js';
+import * as nls from '../../../nls.js';
+import { Extensions as ConfigurationExtensions, IConfigurationNode, IConfigurationRegistry } from '../../configuration/common/configurationRegistry.js';
+import { Registry } from '../../registry/common/platform.js';
+import { AgentHostEnabledSettingId } from '../common/agentService.js';
+import '../common/agentHost.config.contribution.js';
+
+// Re-registers `chat.agentHost.enabled` with the `policy` block attached.
+// The bare setting (type + default) is registered in the common layer so the
+// main process knows the default; this browser-only file adds the policy's
+// `value` callback which cannot be structured-cloned over Electron IPC.
+//
+// Side-effect imports of this file:
+//   - `src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts`
+
+const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+const existingProp = configurationRegistry.getConfigurationProperties()[AgentHostEnabledSettingId];
+const oldNode: IConfigurationNode = { id: 'chatAgentHost', properties: { [AgentHostEnabledSettingId]: existingProp } };
+const newNode: IConfigurationNode = {
+	id: 'chatAgentHost',
+	properties: {
+		[AgentHostEnabledSettingId]: {
+			...existingProp,
+			policy: {
+				name: 'ChatAgentHostEnabled',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.126',
+				value: (policyData: IPolicyData) => policyData.chat_preview_features_enabled === false ? false : undefined,
+				localization: {
+					description: {
+						key: 'chat.agentHost.enabled',
+						value: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process.")
+					}
+				},
+			}
+		},
+	}
+};
+configurationRegistry.updateConfigurations({ remove: [oldNode], add: [newNode] });

--- a/src/vs/platform/agentHost/common/agentHost.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHost.config.contribution.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { isWeb } from '../../../base/common/platform.js';
+import { PolicyCategory } from '../../../base/common/policy.js';
 import * as nls from '../../../nls.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../configuration/common/configurationRegistry.js';
 import product from '../../product/common/product.js';
@@ -34,6 +35,18 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process."),
 			default: !isWeb && product.quality !== 'stable',
 			tags: ['experimental', 'advanced'],
+			policy: {
+				name: 'ChatAgentHostEnabled',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.109',
+				value: (policyData) => policyData.chat_preview_features_enabled === false ? false : undefined,
+				localization: {
+					description: {
+						key: 'chat.agentHost.enabled.description',
+						value: nls.localize('chat.agentHost.enabled.description', "When enabled, some agents run in a separate agent host process.")
+					}
+				},
+			}
 		},
 		'chat.agents.copilotCli.hideExtensionHost': {
 			type: 'boolean',

--- a/src/vs/platform/agentHost/common/agentHost.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHost.config.contribution.ts
@@ -38,12 +38,12 @@ configurationRegistry.registerConfiguration({
 			policy: {
 				name: 'ChatAgentHostEnabled',
 				category: PolicyCategory.InteractiveSession,
-				minimumVersion: '1.109',
+				minimumVersion: '1.126',
 				value: (policyData) => policyData.chat_preview_features_enabled === false ? false : undefined,
 				localization: {
 					description: {
-						key: 'chat.agentHost.enabled.description',
-						value: nls.localize('chat.agentHost.enabled.description', "When enabled, some agents run in a separate agent host process.")
+						key: 'chat.agentHost.enabled',
+						value: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process.")
 					}
 				},
 			}

--- a/src/vs/platform/agentHost/common/agentHost.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHost.config.contribution.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { isWeb } from '../../../base/common/platform.js';
-import { PolicyCategory } from '../../../base/common/policy.js';
 import * as nls from '../../../nls.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../configuration/common/configurationRegistry.js';
 import product from '../../product/common/product.js';
@@ -23,6 +22,11 @@ import { AgentHostEnabledSettingId } from './agentService.js';
 //     (loaded transitively from `app.ts`).
 //   - `src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts`
 //     (renderer registration for the settings UI).
+//
+// The `policy` block for `chat.agentHost.enabled` is added in the browser
+// layer (`agentHost/browser/agentHost.config.contribution.ts`) via
+// `updateConfigurations` because the `value` callback cannot be
+// structured-cloned over Electron IPC.
 
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 configurationRegistry.registerConfiguration({
@@ -35,18 +39,6 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process."),
 			default: !isWeb && product.quality !== 'stable',
 			tags: ['experimental', 'advanced'],
-			policy: {
-				name: 'ChatAgentHostEnabled',
-				category: PolicyCategory.InteractiveSession,
-				minimumVersion: '1.126',
-				value: (policyData) => policyData.chat_preview_features_enabled === false ? false : undefined,
-				localization: {
-					description: {
-						key: 'chat.agentHost.enabled',
-						value: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process.")
-					}
-				},
-			}
 		},
 		'chat.agents.copilotCli.hideExtensionHost': {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -10,6 +10,7 @@ import { autorun, observableFromEvent } from '../../../../base/common/observable
 import { isMacintosh } from '../../../../base/common/platform.js';
 import { PolicyCategory } from '../../../../base/common/policy.js';
 import '../../../../platform/agentHost/common/agentHost.config.contribution.js';
+import '../../../../platform/agentHost/browser/agentHost.config.contribution.js';
 import '../../../../platform/agentHost/common/agentHostStarter.config.contribution.js';
 import { AgentHostAhpJsonlLoggingSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostSdkSandboxEnabledSettingId, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHostEditorSettingId } from '../../../../platform/agentHost/common/agentService.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../../../platform/networkFilter/common/networkFilterService.js';


### PR DESCRIPTION
ref https://github.com/microsoft/vscode-internalbacklog/issues/7955

Organizations that set `chat_preview_features_enabled` to `false` expect all preview/experimental chat features to be disabled. The agent host setting (`chat.agentHost.enabled`) was not gated by this policy.

## Approach

The policy `value` callback cannot be structured-cloned over Electron IPC (`createIPCObjectUrl` in `protocolMainService.ts` uses structured cloning to send window configuration from main → renderer). All other policies with `value` callbacks live in the browser layer — this aligns `ChatAgentHostEnabled` with that pattern.

The setting is split across two layers:

- **Common layer** (`agentHost/common/agentHost.config.contribution.ts`): bare setting (type + default + tags, no policy) — ensures the main process has the correct default for agent host spawning via `isAgentHostEnabled()`
- **Browser layer** (`agentHost/browser/agentHost.config.contribution.ts`): uses `updateConfigurations` to re-register with the `policy` block. Uses `...existingProp` spread to avoid schema duplication and drift.

## Regression prevention

1. **Main process default preserved**: The bare setting stays in the common layer (loaded via `electronAgentHostStarter.ts`), so `configurationService.getValue('chat.agentHost.enabled')` returns the correct default (`true` on non-stable desktop) before the renderer starts.
2. **No schema duplication**: The browser file spreads the already-registered property (`...existingProp`) and only layers the `policy` block on top — if the base setting metadata changes, the policy override stays in sync.
3. **Import ordering guaranteed**: The browser file explicitly imports `../common/agentHost.config.contribution.js` as a side-effect, ensuring the bare registration has run before `getConfigurationProperties()` is called — independent of import order in `chat.shared.contribution.ts`.
4. **Existing pattern**: `updateConfigurations` remove+add is already used in the codebase (e.g., `chat.agent.maxRequests` in `chat.shared.contribution.ts`).

## How to test

1. Non-stable desktop build: verify agent host spawns (setting defaults to `true`)
2. Simulate `chat_preview_features_enabled: false` in account policy data → verify `chat.agentHost.enabled` resolves to `false` and agent host does not spawn
3. Stable build: verify setting defaults to `false` regardless of policy

Co-authored-by: digitarald <digitarald@github.com>