### PR TITLE
Document GitHub Copilot managed settings in add-policy skill

### DIFF
--- a/.github/skills/add-policy/SKILL.md
+++ b/.github/skills/add-policy/SKILL.md
@@ -40,7 +40,7 @@ Policies allow enterprise administrators to lock configuration settings via OS-l
 | `src/vs/platform/configuration/common/configurationRegistry.ts` | `policy` / `policyReference` registration; `getPolicyReferenceConfigurations()` (name → subordinate settings) |
 | `src/vs/workbench/services/policies/common/accountPolicyService.ts` | Account/GitHub-based policy evaluation; merges + projects managed settings (MDM over server) |
 | `src/vs/workbench/services/accounts/browser/managedSettings.ts` | `adaptManagedSettings` — normalizes the server `managed_settings` response into the canonical bag |
-| `src/vs/workbench/services/policies/common/multiplexPolicyService.ts` | Combines multiple policy services |
+| `src/vs/platform/policy/common/multiplexPolicyService.ts` | Combines multiple policy services |
 | `src/vs/workbench/contrib/policyExport/electron-browser/policyExport.contribution.ts` | `--export-policy-data` CLI handler |
 | `src/vs/base/common/defaultAccount.ts` | `IPolicyData` interface (incl. `managedSettings`) for account-level policy fields |
 | `build/lib/policies/policyData.jsonc` | Auto-generated policy catalog incl. `referencedSettings` (DO NOT edit manually) |


### PR DESCRIPTION
## Summary

Updates the `add-policy` skill to document the enterprise managed-settings modality and the `policyReference` mechanism.

### Changes

- **`.github/skills/add-policy/SKILL.md`** — updated When to Use, Policy Sources table (added `CopilotManagedSettingsService` row), Key Files table (4 new entries), fixed stale file references, added Enterprise Managed Settings and policyReference sections
- **`.github/skills/add-policy/github-managed-settings.md`** (new) — reference doc covering the canonical `managedSettings` bag, delivery channels (native MDM + server), schema source of truth, declaring managed settings on policies, helper functions, wiring, new-key checklist, policyReference mechanics, and PR history

### Grounded in

- [#318623](https://github.com/microsoft/vscode/pull/318623) — wire managed_settings into AccountPolicyService/IPolicyData
- [#320991](https://github.com/microsoft/vscode/pull/320991) — native MDM discovery (CopilotManagedSettingsService)
- [#321218](https://github.com/microsoft/vscode/pull/321218) — IPolicyData.managedSettings as the single canonical channel
- [#321515](https://github.com/microsoft/vscode/pull/321515) — policyReference (one policy, many settings)

Documentation only — no source/runtime changes.