### PR TITLE
Suppress Copilot-Integration-Id on CAPI models discovery

### DIFF
--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -308,7 +308,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		}
 		try {
 			const userAgent = `${USER_AGENT_PREFIX}/${this._productService.version}`;
-			const all = await this._copilotApiService.models(tokenAtStart, { headers: { 'User-Agent': userAgent } });
+			const all = await this._copilotApiService.models(tokenAtStart, { headers: { 'User-Agent': userAgent }, suppressIntegrationId: true });
 			// Stale-write guard: if `authenticate()` rotated the token
 			// while we were awaiting the model list, a newer refresh has
 			// already published the right value — don't overwrite it.

--- a/src/vs/platform/agentHost/node/claude/claudeProxyService.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeProxyService.ts
@@ -367,7 +367,7 @@ export class ClaudeProxyService implements IClaudeProxyService {
 		const headers = buildOutboundHeaders(req.headers);
 		let models: CCAModel[];
 		try {
-			models = await this._copilotApiService.models(runtime.githubToken, { headers });
+			models = await this._copilotApiService.models(runtime.githubToken, { headers, suppressIntegrationId: true });
 		} catch (err) {
 			this._writeUpstreamErrorResponse(res, err);
 			return;

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -713,7 +713,7 @@ export class CodexAgent extends Disposable implements IAgent {
 
 	private async _refreshModels(token: string): Promise<void> {
 		try {
-			const all = await this._copilotApiService.models(token);
+			const all = await this._copilotApiService.models(token, { suppressIntegrationId: true });
 			if (this._githubToken !== token) {
 				return;
 			}

--- a/src/vs/platform/agentHost/node/shared/copilotApiService.ts
+++ b/src/vs/platform/agentHost/node/shared/copilotApiService.ts
@@ -534,6 +534,9 @@ export class CopilotApiService implements ICopilotApiService {
 					...options?.headers,
 					'Authorization': `Bearer ${githubToken}`,
 				},
+				// Opt-in per request — see
+				// `ICopilotApiServiceRequestOptions.suppressIntegrationId`.
+				suppressIntegrationId: options?.suppressIntegrationId,
 				signal: options?.signal,
 			},
 			{ type: RequestType.Models },

--- a/src/vs/platform/agentHost/test/node/shared/copilotApiService.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/copilotApiService.test.ts
@@ -1589,6 +1589,23 @@ suite('CopilotApiService', () => {
 			});
 			assert.strictEqual(capturedHeaders?.['Authorization'], 'Bearer gh-tok');
 		});
+
+		test('suppressIntegrationId opt-in controls the Copilot-Integration-Id header', async () => {
+			const { fetch: fetchFn, captured } = routingFetch(() => modelsResponse([]));
+			const service = createService(fetchFn);
+
+			// Default (no opt-in): @vscode/copilot-api derives and sends the header.
+			await service.models('gh-tok');
+			const withHeader = captured().init?.headers as Record<string, string>;
+
+			// Opt-in: the header is omitted entirely so CAPI authorizes against
+			// the token's real entitlement instead of the derived integration id.
+			await service.models('gh-tok', { suppressIntegrationId: true });
+			const suppressed = captured().init?.headers as Record<string, string>;
+
+			assert.ok(withHeader['Copilot-Integration-Id'], 'integration id should be present by default');
+			assert.strictEqual(suppressed['Copilot-Integration-Id'], undefined, 'integration id should be suppressed when opted in');
+		});
 	});
 
 	// #endregion


### PR DESCRIPTION
## Summary

Forward the `suppressIntegrationId` option through `ICopilotApiService.models()` and opt in from the three premium model-discovery callers, mirroring how their `messages()` / `responses()` calls already suppress the header.

Without it, `@vscode/copilot-api` derives the integration id from the discovered Copilot SKU — a `no_auth_limited_copilot` SKU maps to `vscode-nl`, which CAPI treats as the limited/no-auth integration and uses to refuse premium models. As a result the model list comes back empty or limited.

## Changes

- `copilotApiService.ts` — `models()` now forwards `suppressIntegrationId: options?.suppressIntegrationId` to the CAPI request (same pattern as `messages` and `responses`).
- `claudeAgent.ts` (`_refreshModels`), `claudeProxyService.ts` (`_handleModels`), `codexAgent.ts` (`_refreshModels`) — pass `suppressIntegrationId: true` so model discovery authorizes against the token's real entitlement.
- The internal `gpt-4o-mini` utility model resolver (`_resolveUtilityModelId`) is intentionally left untouched — it doesn't require premium entitlement.

## Verification

Launched the Agents window from sources (launch skill) and opened the Claude model picker:

- Agent host log: `[Claude] Models refreshed. Count: 7`
- Picker shows premium models: **Claude Opus 4.5 / 4.6 / 4.7 / 4.8**, **Claude Sonnet 4.6**, **Claude Haiku 4.5**

Before the change the limited `vscode-nl` integration would refuse these premium models.
