### PR TITLE
Add per-model system-prompt registry for Copilot agent-host sessions

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostCustomizationConfig.ts
+++ b/src/vs/platform/agentHost/common/agentHostCustomizationConfig.ts
@@ -24,6 +24,12 @@ export const enum AgentHostConfigKey {
 	EnableCustomTerminalTool = 'enableCustomTerminalTool',
 	/** When true, Copilot SDK sessions enable the rubber duck critic subagent. */
 	RubberDuck = 'rubberDuck',
+	/**
+	 * When true, Copilot SDK sessions running a Claude Opus 4.8 model apply the
+	 * Opus 4.8-tuned system-prompt section overrides on top of the SDK
+	 * foundation prompt. Opt-in; disabled by default.
+	 */
+	Opus48Prompt = 'opus48Prompt',
 }
 
 /**
@@ -80,6 +86,12 @@ export const agentHostCustomizationConfigSchema = createSchema({
 		type: 'boolean',
 		title: localize('agentHost.config.rubberDuck.title', "Rubber Duck Agent"),
 		description: localize('agentHost.config.rubberDuck.description', "When enabled, the coding agent uses a rubber duck critic subagent to review code changes using a complementary model."),
+		default: false,
+	}),
+	[AgentHostConfigKey.Opus48Prompt]: schemaProperty<boolean>({
+		type: 'boolean',
+		title: localize('agentHost.config.opus48Prompt.title', "Opus 4.8 Agent Prompt"),
+		description: localize('agentHost.config.opus48Prompt.description', "When enabled, Copilot SDK sessions running a Claude Opus 4.8 model apply Opus 4.8-tuned system-prompt section overrides on top of the default system message."),
 		default: false,
 	}),
 });

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -57,6 +57,14 @@ export const AgentHostAhpJsonlLoggingSettingId = 'chat.agentHost.ahpJsonlLogging
 export const AgentHostCustomTerminalToolEnabledSettingId = 'chat.agentHost.customTerminalTool.enabled';
 
 /**
+ * Configuration key that controls whether Copilot SDK sessions running a Claude
+ * Opus 4.8 model apply the Opus 4.8-tuned system-prompt section overrides.
+ * Forwarded into the agent host's root config (`opus48Prompt`) by
+ * `AgentHostCopilotPromptContribution`.
+ */
+export const AgentHostOpus48PromptEnabledSettingId = 'chat.agentHost.opus48Prompt.enabled';
+
+/**
  * Configuration key controlling whether the Claude provider is registered in
  * the agent host process. When `false`, the agent host skips registering the
  * Claude provider regardless of SDK availability. Defaults to `true`.

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -120,7 +120,7 @@ interface IProvisionalSession {
 	readonly project: IAgentSessionProjectInfo | undefined;
 }
 
-export { COPILOT_AGENT_HOST_SYSTEM_MESSAGE } from './copilotSessionLauncher.js';
+export { COPILOT_AGENT_HOST_SYSTEM_MESSAGE } from './prompts/systemMessage.js';
 
 type ModelInfo = Awaited<ReturnType<CopilotClient['rpc']['models']['list']>>['models'][number];
 

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -22,6 +22,8 @@ import { toSdkCustomAgents, toSdkHooks, toSdkInstructionDirectories, toSdkMcpSer
 import { buildSandboxConfigForSdk, type ISdkSandboxConfig } from './sandboxConfigForSdk.js';
 import type { ITypedPermissionRequest } from './copilotToolDisplay.js';
 import type { ICopilotPluginInfo } from './copilotAgent.js';
+import { agentHostPromptRegistry, type IAgentHostPromptContext } from './prompts/promptRegistry.js';
+import './prompts/allPrompts.js';
 
 export const ThinkingLevelConfigKey = 'thinkingLevel';
 export const ContextTierConfigKey = 'contextTier';
@@ -46,16 +48,6 @@ type CopilotSessionLaunchConfig = ResumeSessionConfig & {
 	readonly pluginDirectories?: string[];
 	readonly remoteSession?: 'export';
 };
-
-export const COPILOT_AGENT_HOST_SYSTEM_MESSAGE = {
-	mode: 'customize',
-	sections: {
-		identity: {
-			action: 'replace',
-			content: 'You are an AI assistant using Copilot CLI runtime in VS Code. You help users with software engineering tasks. When asked about your identity, you must state that you are an AI assistant using Copilot CLI runtime in VS Code.',
-		},
-	},
-} satisfies NonNullable<ResumeSessionConfig['systemMessage']>;
 
 /**
  * Immutable snapshot of the active client's structural contributions at
@@ -311,6 +303,10 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 		const customAgents = await toSdkCustomAgents(pluginsWithoutDirs.flatMap(p => p.agents), this._fileService);
 		const skillDirectories = toSdkSkillDirectories(pluginsWithoutDirs.flatMap(p => p.skills));
 		const instructionDirectories = toSdkInstructionDirectories(plugins.flatMap(p => p.instructions));
+		const model = plan.kind === 'create' ? plan.model : plan.fallback.model;
+		const promptContext: IAgentHostPromptContext = {
+			getSetting: key => this._configurationService.getRootValue(agentHostCustomizationConfigSchema, key),
+		};
 		return {
 			clientName: 'vscode',
 			enableMcpApps: true,
@@ -327,7 +323,7 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			customAgents,
 			skillDirectories,
 			instructionDirectories,
-			systemMessage: COPILOT_AGENT_HOST_SYSTEM_MESSAGE,
+			systemMessage: agentHostPromptRegistry.resolveSystemMessageConfig(model, promptContext),
 			pluginDirectories: coalesce(plugins.map(p => p.pluginDir))
 				.filter(d => d.scheme === Schemas.file).map(d => d.fsPath),
 			tools: [...shellTools, ...runtime.createClientSdkTools(), ...runtime.createServerSdkTools()],

--- a/src/vs/platform/agentHost/node/copilot/prompts/allPrompts.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/allPrompts.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Side-effect import hub for per-model Copilot CLI agent-host prompt
+// contributors. Importing this module registers every contributor into the
+// shared `agentHostPromptRegistry`. Mirrors the Copilot extension's
+// `allAgentPrompts.ts`.
+//
+// Add per-model modules here as they are ported over, e.g.:
+//
+//   import './geminiPrompt.js';
+//   import './openaiPrompt.js';
+
+import './anthropicPrompt.js';

--- a/src/vs/platform/agentHost/node/copilot/prompts/anthropicPrompt.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/anthropicPrompt.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { SectionOverride, SystemMessageSection } from '@github/copilot-sdk';
+import { AgentHostConfigKey } from '../../../common/agentHostCustomizationConfig.js';
+import type { ModelSelection } from '../../../common/state/protocol/state.js';
+import { agentHostPromptRegistry, type IAgentHostPrompt, type IAgentHostPromptContext } from './promptRegistry.js';
+import { COPILOT_AGENT_HOST_IDENTITY } from './systemMessage.js';
+
+/**
+ * `customize`-mode section overrides for Claude Opus 4.8, tuned per Anthropic's
+ * "Prompting Claude Opus 4.8" guide:
+ * https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-4-8
+ *
+ * Opus 4.8 performs well out of the box, so this stays intentionally minimal:
+ * it keeps the SDK foundation prompt (and its tool/safety sections) intact and
+ * only nudges the two behaviors the guide calls out for tuning —
+ *  - verbosity/tone: the model calibrates length to task complexity, so steer
+ *    it toward concision when a consistent style is wanted; and
+ *  - subagents: the model spawns fewer by default, so give explicit fan-out
+ *    guidance.
+ * The guide warns against forcing interim-progress scaffolding ("summarize
+ * after every N tool calls"), so none is added here. The identity is re-stated
+ * to keep the agent-host self-description that the default message applies.
+ */
+function opus48SectionOverrides(): Partial<Record<SystemMessageSection, SectionOverride>> {
+	return {
+		identity: {
+			action: 'replace',
+			content: COPILOT_AGENT_HOST_IDENTITY,
+		},
+		tone: {
+			action: 'append',
+			content: 'Provide concise, focused responses. Skip non-essential context, and keep examples minimal. Use a direct style and use emojis sparingly.',
+		},
+		guidelines: {
+			action: 'append',
+			content: [
+				'Do not spawn a subagent for work you can complete directly in a single response (e.g. refactoring a function you can already see).',
+				'Spawn multiple subagents in the same turn when fanning out across items or reading multiple files.',
+			].join('\n'),
+		},
+	};
+}
+
+/**
+ * Returns whether `model` is a Claude Opus 4.8 model. Mirrors the Copilot
+ * extension's version-specific `isOpus47`, matching both the SDK dashed id
+ * (`claude-opus-4-8`) and the CAPI dotted id (`claude-opus-4.8`).
+ */
+function isOpus48(model: ModelSelection): boolean {
+	return model.id.startsWith('claude-opus-4-8') || model.id.startsWith('claude-opus-4.8');
+}
+
+/**
+ * Resolves the Opus 4.8 agent prompt for Claude Opus 4.8 Copilot SDK sessions.
+ *
+ * Mirrors the Copilot extension's version-specific opus resolver
+ * (`Claude47OpusPrompt`, gated by `isOpus47` + a setting): it matches only Opus
+ * 4.8 via {@link isOpus48}, and is opt-in via
+ * {@link AgentHostConfigKey.Opus48Prompt}. When the setting is off it returns
+ * `undefined` and the registry falls back to the default system message.
+ */
+class Claude48OpusPromptResolver implements IAgentHostPrompt {
+	static readonly familyPrefixes: readonly string[] = [];
+
+	static matchesModel(model: ModelSelection): boolean {
+		return isOpus48(model);
+	}
+
+	resolveSectionOverrides(_model: ModelSelection, context: IAgentHostPromptContext): Partial<Record<SystemMessageSection, SectionOverride>> | undefined {
+		return context.getSetting(AgentHostConfigKey.Opus48Prompt) === true ? opus48SectionOverrides() : undefined;
+	}
+}
+
+agentHostPromptRegistry.registerPrompt(Claude48OpusPromptResolver);

--- a/src/vs/platform/agentHost/node/copilot/prompts/anthropicPrompt.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/anthropicPrompt.ts
@@ -33,7 +33,9 @@ function opus48SectionOverrides(): Partial<Record<SystemMessageSection, SectionO
 		},
 		tone: {
 			action: 'append',
-			content: 'Provide concise, focused responses. Skip non-essential context, and keep examples minimal. Use a direct style and use emojis sparingly.',
+			// Leading newline so the appended text starts on its own line rather
+			// than running on from the SDK foundation tone section's last sentence.
+			content: '\nProvide concise, focused responses. Skip non-essential context, and keep examples minimal. Use a direct style and use emojis sparingly.',
 		},
 		guidelines: {
 			action: 'append',

--- a/src/vs/platform/agentHost/node/copilot/prompts/promptRegistry.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/promptRegistry.ts
@@ -1,0 +1,145 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { SectionOverride, SystemMessageConfig, SystemMessageSection } from '@github/copilot-sdk';
+import { agentHostCustomizationConfigSchema } from '../../../common/agentHostCustomizationConfig.js';
+import type { SchemaValue } from '../../../common/agentHostSchema.js';
+import type { ModelSelection } from '../../../common/state/protocol/state.js';
+import { COPILOT_AGENT_HOST_SYSTEM_MESSAGE, fullSystemPrompt, sectionOverrides } from './systemMessage.js';
+
+type CustomizationConfigDefinition = typeof agentHostCustomizationConfigSchema.definition;
+
+/**
+ * Read-time context handed to prompt contributors so they can gate behavior on
+ * host configuration — the agent-host equivalent of the Copilot extension
+ * injecting `IConfigurationService` into a resolver.
+ *
+ * Scoped to the host customization schema so contributors (and tests) read
+ * settings in a fully-typed way without depending on the whole configuration
+ * service.
+ */
+export interface IAgentHostPromptContext {
+	/**
+	 * Returns the host-level value for a customization setting, or `undefined`
+	 * when unset. Mirrors `IAgentConfigurationService.getRootValue` bound to
+	 * {@link agentHostCustomizationConfigSchema}.
+	 */
+	getSetting<K extends keyof CustomizationConfigDefinition & string>(key: K): SchemaValue<CustomizationConfigDefinition[K]> | undefined;
+}
+
+/**
+ * Per-model system-prompt contributor for Copilot CLI agent-host sessions.
+ *
+ * Mirrors the Copilot extension's `IAgentPrompt`, but — because the agent host
+ * runs in its own process and cannot use prompt-tsx — a contributor returns
+ * plain data the SDK accepts directly rather than prompt-tsx elements.
+ *
+ * A contributor may provide EITHER a full system-prompt override OR a set of
+ * section overrides. When it provides a full prompt that wins (`replace` mode);
+ * otherwise the section overrides are applied (`customize` mode).
+ */
+export interface IAgentHostPrompt {
+	/**
+	 * Full system-prompt override. Resolved into `{ mode: 'replace' }`, which
+	 * drops the SDK foundation prompt and its guardrails.
+	 */
+	resolveFullSystemPrompt?(model: ModelSelection, context: IAgentHostPromptContext): string | undefined;
+
+	/**
+	 * Section-level overrides. Resolved into `{ mode: 'customize' }`, keeping the
+	 * SDK foundation prompt and guardrails intact.
+	 */
+	resolveSectionOverrides?(model: ModelSelection, context: IAgentHostPromptContext): Partial<Record<SystemMessageSection, SectionOverride>> | undefined;
+}
+
+/**
+ * Constructor/static shape for a registered prompt contributor. Mirrors the
+ * Copilot extension's `IAgentPromptCtor`: a contributor matches a model either
+ * by a custom {@link matchesModel} predicate or by a model-id family prefix.
+ */
+export interface IAgentHostPromptCtor {
+	/** Model-id prefixes this contributor handles (e.g. `'claude'`, `'gpt-5'`). */
+	readonly familyPrefixes: readonly string[];
+
+	/** Optional custom matcher; takes precedence over {@link familyPrefixes}. */
+	matchesModel?(model: ModelSelection): boolean;
+
+	new(): IAgentHostPrompt;
+}
+
+type PromptWithMatcher = IAgentHostPromptCtor & { matchesModel: (model: ModelSelection) => boolean };
+
+/**
+ * Registry of per-model system-prompt contributors for Copilot CLI agent-host
+ * sessions. Mirrors the Copilot extension's `PromptRegistry`: contributors
+ * register a model match (custom predicate or family prefix) and the session
+ * launcher calls {@link resolveSystemMessageConfig} when building a session.
+ *
+ * Exported as a class for isolated unit testing; a shared singleton
+ * ({@link agentHostPromptRegistry}) is what contributors register into and the
+ * launcher consumes.
+ */
+export class AgentHostPromptRegistry {
+	private readonly _promptsWithMatcher: PromptWithMatcher[] = [];
+	private readonly _familyPrefixList: { readonly prefix: string; readonly ctor: IAgentHostPromptCtor }[] = [];
+
+	registerPrompt(ctor: IAgentHostPromptCtor): void {
+		if (ctor.matchesModel) {
+			this._promptsWithMatcher.push(ctor as PromptWithMatcher);
+		}
+		for (const prefix of ctor.familyPrefixes) {
+			this._familyPrefixList.push({ prefix, ctor });
+		}
+	}
+
+	private _getContributor(model: ModelSelection): IAgentHostPromptCtor | undefined {
+		for (const ctor of this._promptsWithMatcher) {
+			if (ctor.matchesModel(model)) {
+				return ctor;
+			}
+		}
+		for (const { prefix, ctor } of this._familyPrefixList) {
+			if (model.id.startsWith(prefix)) {
+				return ctor;
+			}
+		}
+		return undefined;
+	}
+
+	/**
+	 * Resolves the {@link SystemMessageConfig} for a session's model.
+	 *
+	 * Falls back to {@link COPILOT_AGENT_HOST_SYSTEM_MESSAGE} when the model is
+	 * unknown (e.g. server-side "Auto" selection where no model is chosen at
+	 * create time), when no contributor matches, or when the matching
+	 * contributor opts out for the current {@link context} (e.g. a setting that
+	 * gates it is disabled).
+	 */
+	resolveSystemMessageConfig(model: ModelSelection | undefined, context: IAgentHostPromptContext): SystemMessageConfig {
+		if (!model) {
+			return COPILOT_AGENT_HOST_SYSTEM_MESSAGE;
+		}
+		const ctor = this._getContributor(model);
+		if (!ctor) {
+			return COPILOT_AGENT_HOST_SYSTEM_MESSAGE;
+		}
+		const contributor = new ctor();
+		const fullPrompt = contributor.resolveFullSystemPrompt?.(model, context);
+		if (fullPrompt !== undefined) {
+			return fullSystemPrompt(fullPrompt);
+		}
+		const sections = contributor.resolveSectionOverrides?.(model, context);
+		if (sections) {
+			return sectionOverrides(sections);
+		}
+		return COPILOT_AGENT_HOST_SYSTEM_MESSAGE;
+	}
+}
+
+/**
+ * Shared registry instance. Per-model contributors register here (see
+ * `allPrompts.ts`) and the session launcher reads from it.
+ */
+export const agentHostPromptRegistry = new AgentHostPromptRegistry();

--- a/src/vs/platform/agentHost/node/copilot/prompts/promptRegistry.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/promptRegistry.ts
@@ -131,7 +131,10 @@ export class AgentHostPromptRegistry {
 			return fullSystemPrompt(fullPrompt);
 		}
 		const sections = contributor.resolveSectionOverrides?.(model, context);
-		if (sections) {
+		// An empty overrides object is treated as "no override" so we keep the
+		// default identity customization rather than emitting a
+		// `{ mode: 'customize', sections: {} }` that drops it.
+		if (sections && Object.keys(sections).length > 0) {
 			return sectionOverrides(sections);
 		}
 		return COPILOT_AGENT_HOST_SYSTEM_MESSAGE;

--- a/src/vs/platform/agentHost/node/copilot/prompts/systemMessage.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/systemMessage.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { SectionOverride, SystemMessageConfig, SystemMessageSection } from '@github/copilot-sdk';
+
+/**
+ * Identity section content shared by the default agent-host system message and
+ * any per-model override that wants to keep the same self-description. Kept as
+ * a single constant so the identity text is defined in exactly one place.
+ */
+export const COPILOT_AGENT_HOST_IDENTITY = 'You are an AI assistant using Copilot CLI runtime in VS Code. You help users with software engineering tasks. When asked about your identity, you must state that you are an AI assistant using Copilot CLI runtime in VS Code.';
+
+/**
+ * Default system-message customization applied to every Copilot CLI agent-host
+ * session that has no per-model override registered in the
+ * {@link AgentHostPromptRegistry}.
+ *
+ * Uses `customize` mode so the CLI/SDK foundation prompt (and its built-in
+ * guardrails) stay intact — only the `identity` section is replaced.
+ */
+export const COPILOT_AGENT_HOST_SYSTEM_MESSAGE = {
+	mode: 'customize',
+	sections: {
+		identity: {
+			action: 'replace',
+			content: COPILOT_AGENT_HOST_IDENTITY,
+		},
+	},
+} satisfies SystemMessageConfig;
+
+/**
+ * Builds a {@link SystemMessageConfig} that fully replaces the CLI/SDK system
+ * prompt with `content`.
+ *
+ * ⚠️ `replace` mode drops ALL SDK guardrails (including security restrictions);
+ * prefer {@link sectionOverrides} unless the caller intends to own the entire
+ * prompt.
+ */
+export function fullSystemPrompt(content: string): SystemMessageConfig {
+	return { mode: 'replace', content };
+}
+
+/**
+ * Builds a `customize`-mode {@link SystemMessageConfig} that overrides only the
+ * given sections, leaving the rest of the CLI/SDK foundation prompt intact.
+ */
+export function sectionOverrides(sections: Partial<Record<SystemMessageSection, SectionOverride>>): SystemMessageConfig {
+	return { mode: 'customize', sections };
+}

--- a/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
@@ -1,0 +1,111 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import type { SectionOverride, SystemMessageSection } from '@github/copilot-sdk';
+import { AgentHostConfigKey, agentHostCustomizationConfigSchema } from '../../common/agentHostCustomizationConfig.js';
+import type { SchemaValues } from '../../common/agentHostSchema.js';
+import type { ModelSelection } from '../../common/state/protocol/state.js';
+import { AgentHostPromptRegistry, agentHostPromptRegistry, type IAgentHostPromptContext } from '../../node/copilot/prompts/promptRegistry.js';
+import { COPILOT_AGENT_HOST_SYSTEM_MESSAGE } from '../../node/copilot/prompts/systemMessage.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import '../../node/copilot/prompts/allPrompts.js';
+
+/** Builds a prompt context backed by an in-memory bag of customization settings. */
+function context(settings: SchemaValues<typeof agentHostCustomizationConfigSchema.definition> = {}): IAgentHostPromptContext {
+	return { getSetting: key => settings[key] };
+}
+
+suite('AgentHostPromptRegistry', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('falls back to the default system message when no model is provided', () => {
+		const registry = new AgentHostPromptRegistry();
+		assert.deepStrictEqual(registry.resolveSystemMessageConfig(undefined, context()), COPILOT_AGENT_HOST_SYSTEM_MESSAGE);
+	});
+
+	test('falls back to the default when no contributor matches the model', () => {
+		const registry = new AgentHostPromptRegistry();
+		assert.deepStrictEqual(registry.resolveSystemMessageConfig({ id: 'unknown-model' }, context()), COPILOT_AGENT_HOST_SYSTEM_MESSAGE);
+	});
+
+	test('a contributor can fully replace the system prompt (replace mode)', () => {
+		const registry = new AgentHostPromptRegistry();
+		registry.registerPrompt(class {
+			static readonly familyPrefixes = ['gpt-5'];
+			resolveFullSystemPrompt(): string {
+				return 'FULL PROMPT';
+			}
+		});
+		assert.deepStrictEqual(
+			registry.resolveSystemMessageConfig({ id: 'gpt-5-mini' }, context()),
+			{ mode: 'replace', content: 'FULL PROMPT' }
+		);
+	});
+
+	test('a contributor can override individual sections (customize mode)', () => {
+		const registry = new AgentHostPromptRegistry();
+		registry.registerPrompt(class {
+			static readonly familyPrefixes = ['claude'];
+			resolveSectionOverrides(): Partial<Record<SystemMessageSection, SectionOverride>> {
+				return { guidelines: { action: 'append', content: 'Be concise.' } };
+			}
+		});
+		assert.deepStrictEqual(
+			registry.resolveSystemMessageConfig({ id: 'claude-sonnet' }, context()),
+			{ mode: 'customize', sections: { guidelines: { action: 'append', content: 'Be concise.' } } }
+		);
+	});
+
+	test('matchesModel takes precedence over family prefixes', () => {
+		const registry = new AgentHostPromptRegistry();
+		registry.registerPrompt(class {
+			static readonly familyPrefixes: readonly string[] = [];
+			static matchesModel(model: ModelSelection): boolean {
+				return model.id.includes('codex');
+			}
+			resolveFullSystemPrompt(): string {
+				return 'CODEX';
+			}
+		});
+		assert.deepStrictEqual(
+			registry.resolveSystemMessageConfig({ id: 'gpt-5-codex' }, context()),
+			{ mode: 'replace', content: 'CODEX' }
+		);
+	});
+
+	test('contributors gate on the prompt context', () => {
+		const registry = new AgentHostPromptRegistry();
+		registry.registerPrompt(class {
+			static readonly familyPrefixes = ['claude'];
+			resolveSectionOverrides(_model: ModelSelection, ctx: IAgentHostPromptContext): Partial<Record<SystemMessageSection, SectionOverride>> | undefined {
+				return ctx.getSetting(AgentHostConfigKey.Opus48Prompt) === true ? { tone: { action: 'append', content: 'GATED' } } : undefined;
+			}
+		});
+		assert.deepStrictEqual(
+			registry.resolveSystemMessageConfig({ id: 'claude-x' }, context({ [AgentHostConfigKey.Opus48Prompt]: true })),
+			{ mode: 'customize', sections: { tone: { action: 'append', content: 'GATED' } } }
+		);
+		assert.deepStrictEqual(
+			registry.resolveSystemMessageConfig({ id: 'claude-x' }, context()),
+			COPILOT_AGENT_HOST_SYSTEM_MESSAGE
+		);
+	});
+
+	suite('Opus contributor (registered via allPrompts)', () => {
+		const opusModel: ModelSelection = { id: 'claude-opus-4-8' };
+
+		function resolveOpus(enabled: boolean | undefined) {
+			return agentHostPromptRegistry.resolveSystemMessageConfig(opusModel, context(enabled === undefined ? {} : { [AgentHostConfigKey.Opus48Prompt]: enabled }));
+		}
+
+		test('applies customize overrides only when enabled', () => {
+			assert.strictEqual(resolveOpus(undefined), COPILOT_AGENT_HOST_SYSTEM_MESSAGE);
+			assert.strictEqual(resolveOpus(false), COPILOT_AGENT_HOST_SYSTEM_MESSAGE);
+			assert.strictEqual(resolveOpus(true).mode, 'customize');
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
@@ -60,6 +60,20 @@ suite('AgentHostPromptRegistry', () => {
 		);
 	});
 
+	test('treats empty section overrides as no override (falls back to default)', () => {
+		const registry = new AgentHostPromptRegistry();
+		registry.registerPrompt(class {
+			static readonly familyPrefixes = ['claude'];
+			resolveSectionOverrides(): Partial<Record<SystemMessageSection, SectionOverride>> {
+				return {};
+			}
+		});
+		assert.deepStrictEqual(
+			registry.resolveSystemMessageConfig({ id: 'claude-sonnet' }, context()),
+			COPILOT_AGENT_HOST_SYSTEM_MESSAGE
+		);
+	});
+
 	test('matchesModel takes precedence over family prefixes', () => {
 		const registry = new AgentHostPromptRegistry();
 		registry.registerPrompt(class {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCopilotPromptContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCopilotPromptContribution.ts
@@ -1,0 +1,112 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
+import { AgentHostEnabledSettingId, AgentHostOpus48PromptEnabledSettingId, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
+import { AgentHostConfigKey } from '../../../../../../platform/agentHost/common/agentHostCustomizationConfig.js';
+import { ActionType } from '../../../../../../platform/agentHost/common/state/protocol/actions.js';
+import { ROOT_STATE_URI } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { IWorkbenchContribution } from '../../../../../../workbench/common/contributions.js';
+
+/**
+ * Forwards the `chat.agentHost.opus48Prompt.enabled` VS Code setting into the
+ * **local** agent host's root config (`opus48Prompt`) so
+ * {@link CopilotSessionLauncher} can read it at session launch via
+ * `getRootValue`. Gated on `chat.agentHost.enabled`.
+ *
+ * `AgentHostTerminalContribution` has a more elaborate, multi-key version of
+ * this forwarding for its terminal keys; this contribution intentionally stays
+ * single-key and self-contained. It still respects the two correctness
+ * constraints that forwarding into the shared root config requires:
+ *  - schema gate + hydration retry: only dispatch once the host advertises the
+ *    key (its `rootState` may hydrate after this contribution starts); and
+ *  - cross-window loop guard: only push on the setting changing, the schema
+ *    first appearing, or an agent-host (re)start — never on value-only
+ *    root-state changes, which another window's write would otherwise bounce
+ *    back and forth forever (#314385).
+ */
+export class AgentHostCopilotPromptContribution extends Disposable implements IWorkbenchContribution {
+	static readonly ID = 'workbench.contrib.agentHostCopilotPrompt';
+
+	private readonly _conditionalListeners = this._register(new MutableDisposable<DisposableStore>());
+
+	/** Whether the host has advertised the `opus48Prompt` key in its schema yet. */
+	private _schemaSeen = false;
+
+	constructor(
+		@IAgentHostService private readonly _agentHostService: IAgentHostService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+	) {
+		super();
+
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(AgentHostEnabledSettingId)) {
+				this._updateEnabled();
+			}
+		}));
+		this._updateEnabled();
+	}
+
+	private _updateEnabled(): void {
+		if (this._configurationService.getValue<boolean>(AgentHostEnabledSettingId)) {
+			if (!this._conditionalListeners.value) {
+				const store = new DisposableStore();
+				store.add(this._agentHostService.onAgentHostStart(() => this._push()));
+				store.add(this._configurationService.onDidChangeConfiguration(e => {
+					if (e.affectsConfiguration(AgentHostOpus48PromptEnabledSettingId)) {
+						this._push();
+					}
+				}));
+				store.add(this._agentHostService.rootState.onDidChange(() => this._onRootStateChanged()));
+				this._schemaSeen = this._schemaHasKey();
+				this._conditionalListeners.value = store;
+				this._push();
+			}
+		} else {
+			this._schemaSeen = false;
+			this._conditionalListeners.value = undefined;
+		}
+	}
+
+	private _onRootStateChanged(): void {
+		if (this._schemaHasKey()) {
+			// Push only on the schema's first appearance (hydration), not on
+			// value-only changes — see the class doc for the cross-window rationale.
+			if (!this._schemaSeen) {
+				this._schemaSeen = true;
+				this._push();
+			}
+		} else {
+			this._schemaSeen = false;
+		}
+	}
+
+	private _schemaHasKey(): boolean {
+		const rootState = this._agentHostService.rootState.value;
+		if (!rootState || rootState instanceof Error) {
+			return false;
+		}
+		return !!rootState.config?.schema.properties[AgentHostConfigKey.Opus48Prompt];
+	}
+
+	private _push(): void {
+		if (!this._schemaHasKey()) {
+			return;
+		}
+		const rootState = this._agentHostService.rootState.value;
+		if (!rootState || rootState instanceof Error || !rootState.config) {
+			return;
+		}
+		const value = this._configurationService.getValue<boolean>(AgentHostOpus48PromptEnabledSettingId) === true;
+		if (rootState.config.values[AgentHostConfigKey.Opus48Prompt] === value) {
+			return;
+		}
+		this._agentHostService.dispatch(ROOT_STATE_URI, {
+			type: ActionType.RootConfigChanged,
+			config: { [AgentHostConfigKey.Opus48Prompt]: value },
+		});
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -12,7 +12,7 @@ import { PolicyCategory } from '../../../../base/common/policy.js';
 import '../../../../platform/agentHost/common/agentHost.config.contribution.js';
 import '../../../../platform/agentHost/browser/agentHost.config.contribution.js';
 import '../../../../platform/agentHost/common/agentHostStarter.config.contribution.js';
-import { AgentHostAhpJsonlLoggingSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostSdkSandboxEnabledSettingId, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHostEditorSettingId } from '../../../../platform/agentHost/common/agentService.js';
+import { AgentHostAhpJsonlLoggingSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostOpus48PromptEnabledSettingId, AgentHostSdkSandboxEnabledSettingId, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHostEditorSettingId } from '../../../../platform/agentHost/common/agentService.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../../../platform/networkFilter/common/networkFilterService.js';
 import { AgentNetworkDomainSettingId } from '../../../../platform/networkFilter/common/settings.js';
 import { COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_STRICT_MARKETPLACES_KEY } from '../../../../platform/policy/common/copilotManagedSettings.js';
@@ -1200,6 +1200,12 @@ configurationRegistry.registerConfiguration({
 		[AgentHostCustomTerminalToolEnabledSettingId]: {
 			type: 'boolean',
 			description: nls.localize('chat.agentHost.customTerminalTool.enabled', "When enabled, Copilot SDK sessions use the Agent Host terminal tool override instead of the SDK's default terminal behavior."),
+			default: false,
+			tags: ['experimental', 'advanced'],
+		},
+		[AgentHostOpus48PromptEnabledSettingId]: {
+			type: 'boolean',
+			description: nls.localize('chat.agentHost.opus48Prompt.enabled', "When enabled, Copilot SDK sessions running a Claude Opus 4.8 model apply Opus 4.8-tuned system-prompt section overrides on top of the default system message."),
 			default: false,
 			tags: ['experimental', 'advanced'],
 		},

--- a/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/chat.contribution.ts
@@ -34,6 +34,7 @@ import { ACTION_ID_NEW_CHAT, CHAT_OPEN_ACTION_ID, IChatViewOpenOptions } from '.
 import { AgentHostContribution } from '../browser/agentSessions/agentHost/agentHostChatContribution.js';
 import { AgentHostSessionListContribution } from '../browser/agentSessions/agentHost/agentHostSessionListContribution.js';
 import { AgentHostTerminalContribution } from '../browser/agentSessions/agentHost/agentHostTerminalContribution.js';
+import { AgentHostCopilotPromptContribution } from '../browser/agentSessions/agentHost/agentHostCopilotPromptContribution.js';
 import { AgentSessionProviders, getAgentSessionProviderName } from '../browser/agentSessions/agentSessions.js';
 import { IAgentSessionsService } from '../browser/agentSessions/agentSessionsService.js';
 import { ChatViewPaneTarget, IChatWidgetService } from '../browser/chat.js';
@@ -263,6 +264,7 @@ registerWorkbenchContribution2(ChatLifecycleHandler.ID, ChatLifecycleHandler, Wo
 registerWorkbenchContribution2(AgentHostContribution.ID, AgentHostContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(AgentHostSessionListContribution.ID, AgentHostSessionListContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(AgentHostTerminalContribution.ID, AgentHostTerminalContribution, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(AgentHostCopilotPromptContribution.ID, AgentHostCopilotPromptContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(OpenWorkspaceInAgentsContribution.ID, OpenWorkspaceInAgentsContribution, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(AgentsHandoffInputTipContribution.ID, AgentsHandoffInputTipContribution, WorkbenchPhase.Eventually);
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostCopilotPromptContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostCopilotPromptContribution.test.ts
@@ -15,7 +15,7 @@ import { AgentHostEnabledSettingId, AgentHostOpus48PromptEnabledSettingId, IAgen
 import { AgentHostConfigKey } from '../../../../../../platform/agentHost/common/agentHostCustomizationConfig.js';
 import { IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
 import type { ClientAnnotationsAction, INotification, IRootConfigChangedAction, SessionAction, TerminalAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
-import type { RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import type { ConfigPropertySchema, RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { AgentHostCopilotPromptContribution } from '../../../browser/agentSessions/agentHost/agentHostCopilotPromptContribution.js';
 
 class MockAgentHostService extends mock<IAgentHostService>() {
@@ -57,11 +57,11 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 	}
 }
 
-function makeRootStateWithSchema(properties: Record<string, unknown>): RootState {
+function makeRootStateWithSchema(properties: Record<string, ConfigPropertySchema>): RootState {
 	return {
 		agents: [],
 		config: {
-			schema: { type: 'object', properties: properties as Record<string, never> },
+			schema: { type: 'object', properties },
 			values: {},
 		},
 	};

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostCopilotPromptContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostCopilotPromptContribution.test.ts
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { mock } from '../../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { AgentHostEnabledSettingId, AgentHostOpus48PromptEnabledSettingId, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
+import { AgentHostConfigKey } from '../../../../../../platform/agentHost/common/agentHostCustomizationConfig.js';
+import { IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
+import type { ClientAnnotationsAction, INotification, IRootConfigChangedAction, SessionAction, TerminalAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
+import type { RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { AgentHostCopilotPromptContribution } from '../../../browser/agentSessions/agentHost/agentHostCopilotPromptContribution.js';
+
+class MockAgentHostService extends mock<IAgentHostService>() {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onAgentHostStart = new Emitter<void>();
+	override readonly onAgentHostStart = this._onAgentHostStart.event;
+	override readonly onAgentHostExit = Event.None;
+	override readonly onDidAction = Event.None;
+	override readonly onDidNotification: Event<INotification> = Event.None;
+
+	public dispatchedActions: { channel: string; action: SessionAction | TerminalAction | ClientAnnotationsAction | IRootConfigChangedAction }[] = [];
+
+	override dispatch(channel: string, action: SessionAction | TerminalAction | ClientAnnotationsAction | IRootConfigChangedAction): void {
+		this.dispatchedActions.push({ channel, action });
+	}
+
+	private _rootStateValue: RootState | undefined = undefined;
+	private readonly _rootStateOnDidChange = new Emitter<RootState>();
+	override readonly rootState: IAgentSubscription<RootState> = (() => {
+		const self = this;
+		return {
+			get value() { return self._rootStateValue; },
+			get verifiedValue() { return self._rootStateValue; },
+			onDidChange: this._rootStateOnDidChange.event,
+			onWillApplyAction: Event.None,
+			onDidApplyAction: Event.None,
+		};
+	})();
+
+	setRootState(state: RootState): void {
+		this._rootStateValue = state;
+		this._rootStateOnDidChange.fire(state);
+	}
+
+	dispose(): void {
+		this._onAgentHostStart.dispose();
+		this._rootStateOnDidChange.dispose();
+	}
+}
+
+function makeRootStateWithSchema(properties: Record<string, unknown>): RootState {
+	return {
+		agents: [],
+		config: {
+			schema: { type: 'object', properties: properties as Record<string, never> },
+			values: {},
+		},
+	};
+}
+
+/** Two microtask hops: one for the await on computeValue, one for the dispatch. */
+async function flush(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+function setup(disposables: DisposableStore, opus48Enabled: boolean) {
+	const instantiationService = disposables.add(new TestInstantiationService());
+	const agentHostService = new MockAgentHostService();
+	disposables.add({ dispose: () => agentHostService.dispose() });
+	const configurationService = new TestConfigurationService({
+		[AgentHostEnabledSettingId]: true,
+		[AgentHostOpus48PromptEnabledSettingId]: opus48Enabled,
+	});
+	instantiationService.stub(IAgentHostService, agentHostService);
+	instantiationService.stub(IConfigurationService, configurationService);
+	disposables.add(instantiationService.createInstance(AgentHostCopilotPromptContribution));
+	return { agentHostService };
+}
+
+suite('AgentHostCopilotPromptContribution', () => {
+
+	const disposables = new DisposableStore();
+
+	teardown(() => disposables.clear());
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('forwards the Opus 4.8 prompt setting into root config once the schema advertises it', async () => {
+		const { agentHostService } = setup(disposables, /*opus48Enabled*/ true);
+		agentHostService.setRootState(makeRootStateWithSchema({
+			[AgentHostConfigKey.Opus48Prompt]: { type: 'boolean', title: 'Opus 4.8 Agent Prompt' },
+		}));
+		await flush();
+
+		assert.strictEqual(agentHostService.dispatchedActions.length, 1);
+		assert.deepStrictEqual((agentHostService.dispatchedActions[0].action as IRootConfigChangedAction).config, {
+			[AgentHostConfigKey.Opus48Prompt]: true,
+		});
+	});
+
+	test('does not dispatch to a host whose schema does not advertise the key', async () => {
+		const { agentHostService } = setup(disposables, /*opus48Enabled*/ true);
+		agentHostService.setRootState(makeRootStateWithSchema({}));
+		await flush();
+
+		assert.deepStrictEqual(agentHostService.dispatchedActions as readonly unknown[], []);
+	});
+});


### PR DESCRIPTION

Adds a **per-model system-prompt registry** for Copilot CLI agent-host sessions, mirroring the Copilot extension's `PromptRegistry` / `IAgentPrompt` pattern. The Copilot session launcher now resolves the SDK `systemMessage` per session based on the session's model, instead of using a single hardcoded constant.

