### PR TITLE
policy: export cross-window policyReferences and fix IPC listener leak

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -693,7 +693,8 @@
             "default": true,
             "included": true,
             "referencedSettings": [
-                "chat.agentHost.claudeAgent.enabled"
+                "chat.agentHost.claudeAgent.enabled",
+                "sessions.chat.claudeAgent.enabled"
             ]
         }
     ]

--- a/src/vs/platform/policy/common/policyIpc.ts
+++ b/src/vs/platform/policy/common/policyIpc.ts
@@ -56,7 +56,7 @@ export class PolicyChannelClient extends AbstractPolicyService implements IPolic
 				this.policies.set(name, value);
 			}
 		}
-		this.channel.listen<object>('onDidChange')(policies => {
+		this._register(this.channel.listen<object>('onDidChange')(policies => {
 			for (const name in policies) {
 				const value = policies[name as keyof typeof policies];
 
@@ -68,7 +68,7 @@ export class PolicyChannelClient extends AbstractPolicyService implements IPolic
 			}
 
 			this._onDidChange.fire(Object.keys(policies));
-		});
+		}));
 	}
 
 	protected async _updatePolicyDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): Promise<void> {

--- a/src/vs/workbench/contrib/policyExport/electron-browser/policyExport.contribution.ts
+++ b/src/vs/workbench/contrib/policyExport/electron-browser/policyExport.contribution.ts
@@ -21,6 +21,18 @@ import { PolicyCategory, PolicyCategoryData } from '../../../../base/common/poli
 import { ExportedPolicyDataDto } from '../common/policyDto.js';
 import { join } from '../../../../base/common/path.js';
 
+/**
+ * `policyReference`s for settings registered ONLY in another window (e.g. the Agents window,
+ * `vs/sessions`). This export runs in the workbench window and never loads those registrations,
+ * so the references are listed here to keep each policy's `referencedSettings` complete.
+ * Keep in sync with the `policyReference` declared by the setting in its own window.
+ */
+const EXTERNAL_POLICY_REFERENCES: ReadonlyArray<{ readonly policyName: string; readonly settingKey: string }> = [
+	// `sessions.chat.claudeAgent.enabled` (Agents window) references `Claude3PIntegration`,
+	// owned by `github.copilot.chat.claudeAgent.enabled`.
+	{ policyName: 'Claude3PIntegration', settingKey: 'sessions.chat.claudeAgent.enabled' },
+];
+
 interface ExtensionConfigurationPolicyEntry {
 	readonly name: string;
 	readonly category: string;
@@ -141,16 +153,26 @@ export class PolicyExportContribution extends Disposable implements IWorkbenchCo
 				const policyReferenceConfigurations = configurationRegistry.getPolicyReferenceConfigurations();
 				let linkedReferences = 0;
 				for (const policy of policyData.policies) {
-					const references = policyReferenceConfigurations.get(policy.name);
-					if (references && references.size > 0) {
-						for (const referenceKey of references) {
-							const referenceType = configurationProperties[referenceKey]?.type;
-							if (referenceType !== policy.type) {
-								throw new Error(`Policy '${policy.name}': setting '${referenceKey}' (type '${referenceType}') declares a 'policyReference' to a policy of type '${policy.type}'. A 'policyReference' must match the owning setting's type.`);
-							}
+					const referenceKeys = new Set<string>();
+
+					for (const referenceKey of policyReferenceConfigurations.get(policy.name) ?? []) {
+						const referenceType = configurationProperties[referenceKey]?.type;
+						if (referenceType !== policy.type) {
+							throw new Error(`Policy '${policy.name}': setting '${referenceKey}' (type '${referenceType}') declares a 'policyReference' to a policy of type '${policy.type}'. A 'policyReference' must match the owning setting's type.`);
 						}
-						policy.referencedSettings = [...references].sort();
-						linkedReferences += references.size;
+						referenceKeys.add(referenceKey);
+					}
+
+					// Settings registered only in other windows are invisible to this export; add them statically.
+					for (const reference of EXTERNAL_POLICY_REFERENCES) {
+						if (reference.policyName === policy.name) {
+							referenceKeys.add(reference.settingKey);
+						}
+					}
+
+					if (referenceKeys.size > 0) {
+						policy.referencedSettings = [...referenceKeys].sort();
+						linkedReferences += referenceKeys.size;
 					}
 				}
 				this.log(`Linked ${linkedReferences} referenced settings across ${policyData.policies.length} policies.`);


### PR DESCRIPTION
## What

While auditing the policy subsystem I found that the policy export under-reports the settings an enterprise policy governs, plus a small disposable leak. This PR fixes both.

### 1. Cross-window `policyReference`s missing from the exported catalog

The policy export (`policyExport.contribution.ts`) runs in the **workbench window** and cannot import `vs/sessions` (layering). So settings registered only in the **Agents window** — e.g. `sessions.chat.claudeAgent.enabled`, which declares `policyReference: { name: 'Claude3PIntegration' }` — were never observed at export time and were omitted from that policy's `referencedSettings`. Downstream consumers (the enterprise policy docs on code.visualstudio.com) therefore did not list every setting the policy controls.

Fix: the export augments each policy's `referencedSettings` with a small static list of cross-window references kept **local to the export** (where the discrepancy lives), alongside the live workbench-registered references. Regenerated `build/lib/policies/policyData.jsonc`: `Claude3PIntegration` now lists both `chat.agentHost.claudeAgent.enabled` and `sessions.chat.claudeAgent.enabled`.

### 2. Disposable leak in `PolicyChannelClient`

`PolicyChannelClient` subscribed to the `onDidChange` channel event but discarded the subscription instead of registering it for disposal (its sibling `CopilotManagedSettingsChannelClient` does this correctly). Wrapped in `this._register(...)`.

## Why

Enterprise admins rely on the generated catalog/docs to know exactly which settings a policy locks. Omitting Agents-window settings makes a policy look narrower than it is.

## Validation

- `npm run typecheck-client`, `npm run valid-layers-check`, ESLint all clean.
- Ran the **real export generator** (the integration-test path with the test fixture); its output, normalized the way the integration test compares, matches the checked-in catalog exactly.
- Policy unit tests: **76 passing** (`PolicyChannel`, `MultiplexPolicyService`, `AccountPolicyService`, `PolicyConfiguration`, Copilot managed settings).

## Notes for reviewers

- The static list is intentionally tiny and lives next to the export logic; add an entry whenever a setting outside the workbench window must be governed by a workbench/extension-owned policy. Keep it in sync with the `policyReference` declared by that setting in its own window.
- `policyData.jsonc` is auto-generated; the only content delta here is the new `referencedSettings` entry.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
