### PR TITLE
Load managed-settings.json from well-known disk path

### DIFF
--- a/.github/skills/add-policy/SKILL.md
+++ b/.github/skills/add-policy/SKILL.md
@@ -25,8 +25,9 @@ Policies allow enterprise administrators to lock configuration settings via OS-l
 |--------|---------------|----------------------|
 | **OS-level** (Windows registry, macOS plist) | `NativePolicyService` via `@vscode/policy-watcher` | Watches `Software\Policies\Microsoft\{productName}` (Windows) or bundle identifier prefs (macOS) |
 | **Linux file** | `FilePolicyService` | Reads `/etc/vscode/policy.json` |
-| **Account/GitHub** | `AccountPolicyService` | Reads `IPolicyData` from `IDefaultAccountService.policyData`, applies `value()` function. Server-delivered managed settings arrive on `policyData.managedSettings`; native MDM is a **separate** input (`ICopilotManagedSettingsService`) that `AccountPolicyService` selects between in `getPolicyData()` (server wins when present; no merging between layers) |
-| **Copilot managed settings (native MDM)** | `CopilotManagedSettingsService` via `@vscode/policy-watcher` | Watches `SOFTWARE\Policies\GitHubCopilot` (Windows) / `com.github.copilot` prefs (macOS); feeds the canonical `managedSettings` bag — see [github-managed-settings.md](./github-managed-settings.md) |
+| **Account/GitHub** | `AccountPolicyService` | Reads `IPolicyData` from `IDefaultAccountService.policyData`, applies `value()` function. Server-delivered managed settings arrive on `policyData.managedSettings`; native MDM (`INativeManagedSettingsService`) and a file on disk (`IFileManagedSettingsService`) are **separate** inputs that `AccountPolicyService` selects among in `getPolicyData()` via `selectManagedSettings(server, nativeMdm, file)` (single authoritative source by precedence server > native MDM > file; no merging between layers) |
+| **Copilot managed settings (native MDM)** | `NativeManagedSettingsService` via `@vscode/policy-watcher` | Watches `SOFTWARE\Policies\GitHubCopilot` (Windows) / `com.github.copilot` prefs (macOS); feeds the canonical `managedSettings` bag — see [github-managed-settings.md](./github-managed-settings.md) |
+| **Copilot managed settings (file)** | `FileManagedSettingsService` | Reads + watches `managed-settings.json` from a well-known per-OS path in the main process, exposed to renderers over IPC; lowest-precedence managed-settings channel — see [github-managed-settings.md](./github-managed-settings.md) |
 | **Multiplex** | `MultiplexPolicyService` | In the main process, combines multiple OS/file policy readers; in desktop and Agents-window renderers, combines the main-process `PolicyChannelClient` with `AccountPolicyService` |
 
 ### Key Files
@@ -35,8 +36,9 @@ Policies allow enterprise administrators to lock configuration settings via OS-l
 |------|---------|
 | `src/vs/base/common/policy.ts` | `PolicyCategory` enum, `IPolicy` interface, `IPolicyReference`, `ManagedSettingsData`, `IManagedSettingsPolicyDefinitions` |
 | `src/vs/platform/policy/common/policy.ts` | `IPolicyService`, `AbstractPolicyService`, `PolicyDefinition`, `toSerializablePolicyDefinition` (drops the non-cloneable `value()` for IPC), `getRestrictedPolicyValue` |
-| `src/vs/platform/policy/common/copilotManagedSettings.ts` | Managed-settings key constants, `collectManagedSettingsDefinitions`, `projectManagedSettings`, `flattenManagedSettings`, `ICopilotManagedSettingsService` |
-| `src/vs/platform/policy/node/copilotManagedSettingsService.ts` | Native MDM watcher (`@vscode/policy-watcher`) for Copilot managed settings |
+| `src/vs/platform/policy/common/copilotManagedSettings.ts` | Managed-settings key constants + well-known file paths, `collectManagedSettingsDefinitions`, `projectManagedSettings`, the shared `normalizeManagedSettings` (single normalizer for all channels), `selectManagedSettings` (channel precedence), `INativeManagedSettingsService` / `IFileManagedSettingsService` |
+| `src/vs/platform/policy/node/nativeManagedSettingsService.ts` | Native MDM watcher (`@vscode/policy-watcher`) for Copilot managed settings |
+| `src/vs/platform/policy/common/fileManagedSettingsService.ts` | File-based channel: reads + watches `managed-settings.json` on a well-known per-OS path, normalizes via `normalizeManagedSettings` |
 | `src/vs/platform/configuration/common/configurations.ts` | `PolicyConfiguration` — bridges policies to configuration values; parses JSON-string managed settings back to typed values; applies values to `policyReference` settings |
 | `src/vs/platform/configuration/common/configurationRegistry.ts` | `policy` / `policyReference` registration; `getPolicyReferenceConfigurations()` (name → subordinate settings) |
 | `src/vs/workbench/services/policies/common/accountPolicyService.ts` | Account/GitHub-based policy evaluation; selects + projects managed settings (server over MDM; single authoritative layer) |

--- a/.github/skills/add-policy/github-managed-settings.md
+++ b/.github/skills/add-policy/github-managed-settings.md
@@ -9,7 +9,7 @@ Managed settings layer **on top of** the existing policy framework. They do **no
 introduce a new `IPolicyService`; they feed `IPolicyData.managedSettings`, which the
 existing `policy.value(policyData)` callback already consumes via `AccountPolicyService`.
 
-## The big idea: one canonical bag, two delivery channels (in VS Code)
+## The big idea: one canonical bag, three delivery channels (in VS Code)
 
 Every enterprise-managed Copilot setting resolves through a single normalized bag:
 
@@ -41,26 +41,26 @@ and parsed back into the object-typed setting on read by `PolicyConfiguration`.
 
 ### Delivery channels
 
-VS Code implements **two** channels feeding the bag; the external schema additionally
-describes a file-based channel that other Copilot clients may implement but that VS Code
-does **not** read today (no `managed-settings.json` reader exists in `src/`).
+VS Code implements **three** channels feeding the bag, matching the external schema's
+described delivery slots (native MDM, server-managed, and file-based).
 
 | Channel | Where it's read | Implementation | Lands on |
 |---------|-----------------|----------------|----------|
-| **Native MDM** (Windows registry / macOS plist) | OS managed preferences | `CopilotManagedSettingsService` (`src/vs/platform/policy/node/copilotManagedSettingsService.ts`) via `@vscode/policy-watcher` | `ICopilotManagedSettingsService.managedSettings` |
+| **Native MDM** (Windows registry / macOS plist) | OS managed preferences | `NativeManagedSettingsService` (`src/vs/platform/policy/node/nativeManagedSettingsService.ts`) via `@vscode/policy-watcher` | `INativeManagedSettingsService.managedSettings` |
 | **Server-managed** (`/copilot_internal/managed_settings`) | GitHub endpoint; per the code comment in `managedSettings.ts`, it returns the enterprise's `.github/copilot/settings.json` content | `adaptManagedSettings` (`src/vs/workbench/services/accounts/browser/managedSettings.ts`) → `DefaultAccountService.policyData` | `accountPolicyData.managedSettings` |
-| **File-based** (`managed-settings.json`) | external schema only | *not implemented in VS Code* | — |
+| **File-based** (`managed-settings.json`) | well-known per-OS disk path (e.g. `/Library/Application Support/GitHubCopilot/` on macOS), read in the main process and exposed to renderer windows over IPC | `FileManagedSettingsService` (`src/vs/platform/policy/common/fileManagedSettingsService.ts`) | `IFileManagedSettingsService.managedSettings` |
 
-Both VS Code channels converge in `AccountPolicyService.getPolicyData()`.
+All three VS Code channels converge in `AccountPolicyService.getPolicyData()`.
 
-**Precedence: server-delivered managed settings win over native MDM.** There is a
-single authoritative source at any point in time — the two layers are **not** merged.
-When the server delivers managed settings, native MDM (`nativeManagedSettings`) is
-ignored entirely; native MDM applies only when the server provides no managed settings.
-Rationale: the server is harder to bypass than local MDM/file policies, and admins need
-one authoritative source to reason about. The winning layer is then projected onto the
-declared schema (see below). Client-side merging still happens *within* the winning
-layer (e.g. `enabledPlugins`, `extraKnownMarketplaces`).
+**Precedence: server-delivered managed settings win over native MDM, which in turn win
+over the file-based channel** (`selectManagedSettings` in `copilotManagedSettings.ts`).
+There is a single authoritative source at any point in time — the channels are **not**
+merged. The highest-precedence non-empty channel wins outright and the rest are ignored.
+Rationale: the server is harder to bypass than local MDM, and a local file is the most
+easily tampered with, so admins need one authoritative source to reason about. The
+winning channel is then projected onto the declared schema (see below). Client-side
+merging still happens *within* the winning channel (e.g. `enabledPlugins`,
+`extraKnownMarketplaces`).
 
 ## Schema source of truth
 
@@ -196,25 +196,27 @@ delivery slot for the managed value.
 
 | Function | Role |
 |----------|------|
-| `flattenManagedSettings(obj)` | Flattens a nested response into dot-path scalars (used by the server adapter). |
+| `flattenManagedSettings(obj)` | Flattens a nested response into dot-path scalars (used by `normalizeManagedSettings`). |
+| `normalizeManagedSettings(parsed, onWarn?)` | The **single** normalizer shared by every channel: turns a parsed managed-settings object (server response, file on disk, …) into the canonical bag. Scalar leaves flatten; structured keys (declared in the `STRUCTURED_MANAGED_SETTINGS` table) are JSON-encoded under a single key each. The server adapter `adaptManagedSettings` and the file channel both call it. |
 | `collectManagedSettingsDefinitions(policyDefinitions)` | Aggregates every policy's `managedSettings` into one `key → { type }` map. **Single source of truth** for which keys (and types) are honored; drives both the MDM watcher and the server projection. |
 | `hasManagedSettingsDefinitions(policyDefinitions)` | Cheap short-circuiting existence check (does *any* policy declare a managed key?) — used to decide whether the native MDM watcher is needed at all, without building the full aggregate. |
 | `projectManagedSettings(values, definitions, onWarn?)` | Keeps only declared keys whose runtime value **matches the declared type**. Undeclared keys and type mismatches are **dropped (validated, never coerced)**, with an optional warning. |
+| `selectManagedSettings(server, nativeMdm, file)` | Picks the single authoritative channel by precedence (server → native MDM → file); never merges. **The extension point when adding a new channel** — extend the `ManagedSettingsSource` union and this function together. |
 | `managedSettingValue(key)` | Builds the standard pass-through `value` callback `policyData => policyData.managedSettings?.[key]`. Use for the common "lock to the managed value, else fall through" case (see [Declaring a managed setting](#declaring-a-managed-setting-on-a-policy)). |
 
-### Server-side adaptation: the structured-key descriptor table
+### Normalization: the structured-key descriptor table
 
-`adaptManagedSettings` (`managedSettings.ts`) normalizes the server `managed_settings`
-response into the canonical bag. Scalar leaves flatten directly; **structured** (object/array)
+`normalizeManagedSettings` (`copilotManagedSettings.ts`) turns a parsed managed-settings
+object into the canonical bag, and is shared by every channel — the server adapter
+`adaptManagedSettings` (`managedSettings.ts`) is a thin wrapper around it, and the file
+channel calls it directly. Scalar leaves flatten directly; **structured** (object/array)
 keys are JSON-encoded under a single bag key. The per-key knowledge for the structured ones
-lives in **one table**, `STRUCTURED_MANAGED_SETTINGS`. Each row declares the canonical bag
-`key`, the `responseField` it consumes (a hand-maintained union kept in sync with
-`IManagedSettingsResponse`'s named fields — not compiler-enforced, because the response's index
-signature widens `keyof` to `string`; the `adaptManagedSettings` tests are the drift backstop),
-and an `encode(raw, onWarn?)` that
+lives in **one table**, `STRUCTURED_MANAGED_SETTINGS`. Each row declares the `key` (the source
+field name read from the input, which is also the canonical bag key the JSON string is stored
+under — identical for structured settings by contract) and an `encode(raw, onWarn?)` that
 normalizes the value before `JSON.stringify`. Adding a structured key is **one descriptor row**
-(plus its response-interface field and the policy declaration) — no new bespoke branch in the
-adapter.
+(plus the server `IManagedSettingsResponse` field and the policy declaration) — no new bespoke branch in the
+normalizer. The `adaptManagedSettings` / `normalizeManagedSettings` tests are the drift backstop.
 
 Constants (also in `copilotManagedSettings.ts`):
 
@@ -232,32 +234,40 @@ Constants (also in `copilotManagedSettings.ts`):
 
 Native MDM is desktop-main only (`src/vs/code/electron-main/main.ts`). The real wiring
 constructs the platform service first (Windows / macOS only), then registers it — falling
-back to `NullCopilotManagedSettingsService` on Linux (abbreviated):
+back to `NullNativeManagedSettingsService` on Linux (abbreviated):
 
 ```ts
-let copilotManagedSettingsService: CopilotManagedSettingsService | undefined;
+let nativeManagedSettingsService: NativeManagedSettingsService | undefined;
 if (isWindows) {
-    copilotManagedSettingsService = new CopilotManagedSettingsService(
+    nativeManagedSettingsService = new NativeManagedSettingsService(
         logService, GITHUB_COPILOT_WIN32_POLICY_NAME, { registryPath: GITHUB_COPILOT_WIN32_REGISTRY_PATH });
 } else if (isMacintosh) {
-    copilotManagedSettingsService = new CopilotManagedSettingsService(
+    nativeManagedSettingsService = new NativeManagedSettingsService(
         logService, GITHUB_COPILOT_MACOS_BUNDLE_ID);
 }
-if (copilotManagedSettingsService) {
-    services.set(ICopilotManagedSettingsService, copilotManagedSettingsService);
+if (nativeManagedSettingsService) {
+    services.set(INativeManagedSettingsService, nativeManagedSettingsService);
 } else {
-    services.set(ICopilotManagedSettingsService, new NullCopilotManagedSettingsService());
+    services.set(INativeManagedSettingsService, new NullNativeManagedSettingsService());
 }
 ```
 
-It is exposed to the renderer over IPC via `CopilotManagedSettingsChannel` /
-`CopilotManagedSettingsChannelClient` (`copilotManagedSettingsIpc.ts`), registered as
-the `copilotManagedSettings` channel in `app.ts`. `AccountPolicyService` subscribes to
+It is exposed to the renderer over IPC via `NativeManagedSettingsChannel` /
+`NativeManagedSettingsChannelClient` (`nativeManagedSettingsIpc.ts`), registered as
+the `nativeManagedSettings` channel in `app.ts`. `AccountPolicyService` subscribes to
 `onDidChangeManagedSettings` and re-evaluates policy values when managed settings change.
 
 The service only watches keys that some policy declares: `updatePolicyDefinitions`
 calls `collectManagedSettingsDefinitions`, then `@vscode/policy-watcher` watches exactly
 those dot-paths. No declared keys ⇒ no watcher.
+
+The **file-based** channel is wired the same way (`src/vs/code/electron-main/main.ts`):
+`FileManagedSettingsService` reads `managed-settings.json` from the per-OS well-known path
+(`MANAGED_SETTINGS_*` constants in `copilotManagedSettings.ts`), falling back to
+`NullFileManagedSettingsService` when no path applies. It is exposed to the renderer over IPC
+via `FileManagedSettingsChannel` / `FileManagedSettingsChannelClient`
+(`fileManagedSettingsIpc.ts`), registered as the `fileManagedSettings` channel in `app.ts`,
+and `AccountPolicyService` subscribes to its `onDidChangeManagedSettings` too.
 
 ## Adding a brand-new managed-settings key (checklist)
 
@@ -268,11 +278,12 @@ those dot-paths. No declared keys ⇒ no watcher.
    and a `value` callback. For a plain pass-through use `value: managedSettingValue(KEY)`;
    only hand-write the callback when combining with another condition.
 3. **If the value is structured** (object/array), declare the managed key as `'string'` and
-   let `PolicyConfiguration` parse the JSON back on read. Then teach the **server adapter** by
-   adding one row to `STRUCTURED_MANAGED_SETTINGS` in `managedSettings.ts` (canonical `key`, the
-   `responseField` it consumes, and an `encode` that normalizes the server shape into what an
-   admin would author in MDM) plus the matching field on `IManagedSettingsResponse`. That table
-   is the single place server-side structured-key handling lives.
+   let `PolicyConfiguration` parse the JSON back on read. Then teach the **shared normalizer** by
+   adding one row to `STRUCTURED_MANAGED_SETTINGS` in `copilotManagedSettings.ts` (the `key` and an
+   `encode` that normalizes the raw shape into what an admin would author in MDM) plus the matching
+   field on the server `IManagedSettingsResponse`. That table
+   is the single place structured-key handling lives, and it applies to every channel (server,
+   file-based, …) because they all funnel through `normalizeManagedSettings`.
 4. **Keep the schema aligned.** The runtime, the server endpoint, and
    `managed-settings-schema.json` must agree on the key name and value type. The
    declaration-driven projection (`projectManagedSettings`) silently drops anything that
@@ -282,11 +293,13 @@ those dot-paths. No declared keys ⇒ no watcher.
 
 Reference tests:
 - `src/vs/platform/policy/test/common/copilotManagedSettings.test.ts`
-- `src/vs/platform/policy/test/node/copilotManagedSettingsService.test.ts`
+- `src/vs/platform/policy/test/node/nativeManagedSettingsService.test.ts`
 - `src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts`
 - `src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts`
   (includes an end-to-end equivalence test: a server JSON string and a native MDM JSON
   string resolve to the **identical** typed object).
+- `src/vs/platform/policy/test/common/fileManagedSettingsService.test.ts`
+  (covers `normalizeManagedSettings` and the file-based channel reader).
 
 **Manual/local testing:** use the mock policy server to serve arbitrary
 `managed_settings` (and entitlement/token) responses and apply them via
@@ -342,6 +355,6 @@ Rules & internals:
 | PR | Change |
 |----|--------|
 | [#318623](https://github.com/microsoft/vscode/pull/318623) | Wire `/copilot_internal/managed_settings` into `AccountPolicyService`/`IPolicyData`; add `chat.plugins.enabledPlugins`/`extraMarketplaces`/`strictMarketplaces` settings + `adaptManagedSettings` shape adaptation. No new `IPolicyService`. |
-| [#320991](https://github.com/microsoft/vscode/pull/320991) | Add native MDM delivery: `CopilotManagedSettingsService` + `@vscode/policy-watcher`; let policies declare `managedSettings` mappings; wire the first V0 key `permissions.disableBypassPermissionsMode` → force `ChatToolsAutoApprove=false`. |
+| [#320991](https://github.com/microsoft/vscode/pull/320991) | Add native MDM delivery: `NativeManagedSettingsService` + `@vscode/policy-watcher`; let policies declare `managedSettings` mappings; wire the first V0 key `permissions.disableBypassPermissionsMode` → force `ChatToolsAutoApprove=false`. |
 | [#321218](https://github.com/microsoft/vscode/pull/321218) | Make `IPolicyData.managedSettings` the **single** channel: server + native MDM project into one canonical bag; structured settings carried as canonical JSON strings; remove the typed `enabledPlugins`/`extraKnownMarketplaces`/`strictKnownMarketplaces` fields. End-to-end equivalence test. |
 | [#321515](https://github.com/microsoft/vscode/pull/321515) | Add `policyReference` so one policy governs many settings; callback-free serialization; catalog + diagnostics list governed settings. Used to gate Claude (`Claude3PIntegration`) and Codex (`Codex3PIntegration`) across the editor and Agents windows. |

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -104,8 +104,9 @@ import { IWorkspacesHistoryMainService, WorkspacesHistoryMainService } from '../
 import { WorkspacesMainService } from '../../platform/workspaces/electron-main/workspacesMainService.js';
 import { IWorkspacesManagementMainService, WorkspacesManagementMainService } from '../../platform/workspaces/electron-main/workspacesManagementMainService.js';
 import { IPolicyService } from '../../platform/policy/common/policy.js';
-import { ICopilotManagedSettingsService } from '../../platform/policy/common/copilotManagedSettings.js';
-import { CopilotManagedSettingsChannel } from '../../platform/policy/common/copilotManagedSettingsIpc.js';
+import { INativeManagedSettingsService, IFileManagedSettingsService } from '../../platform/policy/common/copilotManagedSettings.js';
+import { NativeManagedSettingsChannel } from '../../platform/policy/common/nativeManagedSettingsIpc.js';
+import { FileManagedSettingsChannel } from '../../platform/policy/common/fileManagedSettingsIpc.js';
 import { PolicyChannel } from '../../platform/policy/common/policyIpc.js';
 import { IUserDataProfilesMainService } from '../../platform/userDataProfile/electron-main/userDataProfile.js';
 import { IExtensionsProfileScannerService } from '../../platform/extensionManagement/common/extensionsProfileScannerService.js';
@@ -1257,8 +1258,11 @@ export class CodeApplication extends Disposable {
 		mainProcessElectronServer.registerChannel('policy', policyChannel);
 		sharedProcessClient.then(client => client.registerChannel('policy', policyChannel));
 
-		const copilotManagedSettingsChannel = disposables.add(new CopilotManagedSettingsChannel(accessor.get(ICopilotManagedSettingsService)));
-		mainProcessElectronServer.registerChannel('copilotManagedSettings', copilotManagedSettingsChannel);
+		const nativeManagedSettingsChannel = disposables.add(new NativeManagedSettingsChannel(accessor.get(INativeManagedSettingsService)));
+		mainProcessElectronServer.registerChannel('nativeManagedSettings', nativeManagedSettingsChannel);
+
+		const fileManagedSettingsChannel = disposables.add(new FileManagedSettingsChannel(accessor.get(IFileManagedSettingsService)));
+		mainProcessElectronServer.registerChannel('fileManagedSettings', fileManagedSettingsChannel);
 
 		// Local Files
 		const diskFileSystemProvider = this.fileService.getProvider(Schemas.file);

--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -16,7 +16,7 @@ import { IPathWithLineAndColumn, isValidBasename, parseLineAndColumnAware, sanit
 import { Event } from '../../base/common/event.js';
 import { getPathLabel } from '../../base/common/labels.js';
 import { Schemas } from '../../base/common/network.js';
-import { basename, resolve } from '../../base/common/path.js';
+import { basename, join, resolve } from '../../base/common/path.js';
 import { mark } from '../../base/common/performance.js';
 import { IProcessEnvironment, isLinux, isMacintosh, isWindows, OS } from '../../base/common/platform.js';
 import { cwd } from '../../base/common/process.js';
@@ -64,8 +64,9 @@ import { IPolicyService, NullPolicyService } from '../../platform/policy/common/
 import { NativePolicyService } from '../../platform/policy/node/nativePolicyService.js';
 import { FilePolicyService } from '../../platform/policy/common/filePolicyService.js';
 import { MultiplexPolicyService } from '../../platform/policy/common/multiplexPolicyService.js';
-import { GITHUB_COPILOT_MACOS_BUNDLE_ID, GITHUB_COPILOT_WIN32_POLICY_NAME, GITHUB_COPILOT_WIN32_REGISTRY_PATH, ICopilotManagedSettingsService, NullCopilotManagedSettingsService } from '../../platform/policy/common/copilotManagedSettings.js';
-import { CopilotManagedSettingsService } from '../../platform/policy/node/copilotManagedSettingsService.js';
+import { GITHUB_COPILOT_MACOS_BUNDLE_ID, GITHUB_COPILOT_WIN32_POLICY_NAME, GITHUB_COPILOT_WIN32_REGISTRY_PATH, INativeManagedSettingsService, IFileManagedSettingsService, MANAGED_SETTINGS_FILE_NAME, MANAGED_SETTINGS_LINUX_FILE_PATH, MANAGED_SETTINGS_MACOS_FILE_PATH, MANAGED_SETTINGS_WINDOWS_DIR, NullNativeManagedSettingsService, NullFileManagedSettingsService } from '../../platform/policy/common/copilotManagedSettings.js';
+import { FileManagedSettingsService } from '../../platform/policy/common/fileManagedSettingsService.js';
+import { NativeManagedSettingsService } from '../../platform/policy/node/nativeManagedSettingsService.js';
 import { DisposableStore } from '../../base/common/lifecycle.js';
 import { IUriIdentityService } from '../../platform/uriIdentity/common/uriIdentity.js';
 import { UriIdentityService } from '../../platform/uriIdentity/common/uriIdentityService.js';
@@ -229,16 +230,35 @@ class CodeMain {
 			policyServices.push(disposables.add(new FilePolicyService(environmentMainService.policyFile, fileService, logService)));
 		}
 
-		let copilotManagedSettingsService: CopilotManagedSettingsService | undefined;
+		let nativeManagedSettingsService: NativeManagedSettingsService | undefined;
 		if (isWindows) {
-			copilotManagedSettingsService = disposables.add(new CopilotManagedSettingsService(logService, GITHUB_COPILOT_WIN32_POLICY_NAME, { registryPath: GITHUB_COPILOT_WIN32_REGISTRY_PATH }));
+			nativeManagedSettingsService = disposables.add(new NativeManagedSettingsService(logService, GITHUB_COPILOT_WIN32_POLICY_NAME, { registryPath: GITHUB_COPILOT_WIN32_REGISTRY_PATH }));
 		} else if (isMacintosh) {
-			copilotManagedSettingsService = disposables.add(new CopilotManagedSettingsService(logService, GITHUB_COPILOT_MACOS_BUNDLE_ID));
+			nativeManagedSettingsService = disposables.add(new NativeManagedSettingsService(logService, GITHUB_COPILOT_MACOS_BUNDLE_ID));
 		}
-		if (copilotManagedSettingsService) {
-			services.set(ICopilotManagedSettingsService, copilotManagedSettingsService);
+		if (nativeManagedSettingsService) {
+			services.set(INativeManagedSettingsService, nativeManagedSettingsService);
 		} else {
-			services.set(ICopilotManagedSettingsService, new NullCopilotManagedSettingsService());
+			services.set(INativeManagedSettingsService, new NullNativeManagedSettingsService());
+		}
+
+		// File-based managed settings
+		let fileManagedSettingsPath: string | undefined;
+		if (isWindows) {
+			const programFiles = process.env['ProgramFiles'];
+			if (programFiles) {
+				fileManagedSettingsPath = join(programFiles, MANAGED_SETTINGS_WINDOWS_DIR, MANAGED_SETTINGS_FILE_NAME);
+			}
+		} else if (isMacintosh) {
+			fileManagedSettingsPath = MANAGED_SETTINGS_MACOS_FILE_PATH;
+		} else if (isLinux) {
+			fileManagedSettingsPath = MANAGED_SETTINGS_LINUX_FILE_PATH;
+		}
+		if (fileManagedSettingsPath) {
+			const fileManagedSettingsService = disposables.add(new FileManagedSettingsService(URI.file(fileManagedSettingsPath), fileService, logService));
+			services.set(IFileManagedSettingsService, fileManagedSettingsService);
+		} else {
+			services.set(IFileManagedSettingsService, new NullFileManagedSettingsService());
 		}
 
 		if (policyServices.length > 1) {

--- a/src/vs/platform/policy/common/copilotManagedSettings.ts
+++ b/src/vs/platform/policy/common/copilotManagedSettings.ts
@@ -5,9 +5,10 @@
 
 import { Event } from '../../../base/common/event.js';
 import { IPolicyData } from '../../../base/common/defaultAccount.js';
+import { IExtraKnownMarketplaceEntry, extraKnownMarketplacesToConfigDict } from '../../../base/common/managedSettings.js';
 import { IManagedSettingPolicyDefinition, IManagedSettingsPolicyDefinitions, ManagedSettingValue, ManagedSettingsData } from '../../../base/common/policy.js';
 import { IStringDictionary } from '../../../base/common/collections.js';
-import { isEmptyObject } from '../../../base/common/types.js';
+import { isEmptyObject, isObject, isString } from '../../../base/common/types.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { PolicyDefinition } from './policy.js';
 
@@ -55,16 +56,16 @@ export function managedSettingValue(key: string): (policyData: IPolicyData) => M
 	return callback;
 }
 
-export const ICopilotManagedSettingsService = createDecorator<ICopilotManagedSettingsService>('copilotManagedSettingsService');
+export const INativeManagedSettingsService = createDecorator<INativeManagedSettingsService>('nativeManagedSettingsService');
 
-export interface ICopilotManagedSettingsService {
+export interface INativeManagedSettingsService {
 	readonly _serviceBrand: undefined;
 	readonly managedSettings: ManagedSettingsData;
 	readonly onDidChangeManagedSettings: Event<ManagedSettingsData>;
 	updatePolicyDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): Promise<ManagedSettingsData>;
 }
 
-export class NullCopilotManagedSettingsService implements ICopilotManagedSettingsService {
+export class NullNativeManagedSettingsService implements INativeManagedSettingsService {
 	readonly _serviceBrand: undefined;
 	readonly managedSettings: ManagedSettingsData = {};
 	readonly onDidChangeManagedSettings = Event.None;
@@ -72,7 +73,7 @@ export class NullCopilotManagedSettingsService implements ICopilotManagedSetting
 	async updatePolicyDefinitions(): Promise<ManagedSettingsData> { return this.managedSettings; }
 }
 
-export function flattenManagedSettings(object: unknown): Record<string, string | number | boolean> {
+function flattenManagedSettings(object: unknown): Record<string, string | number | boolean> {
 	const result: Record<string, string | number | boolean> = {};
 	flattenManagedSettingsValue(object, undefined, result);
 	return result;
@@ -170,7 +171,9 @@ export type ManagedSettingsSource =
 	/** GitHub `/copilot_internal/managed_settings` endpoint (server-delivered). */
 	| 'server'
 	/** Native MDM: OS registry (Windows) / managed preferences (macOS) via `@vscode/policy-watcher`. */
-	| 'nativeMdm';
+	| 'nativeMdm'
+	/** File on a well-known disk path (`managed-settings.json`). */
+	| 'file';
 
 export interface IManagedSettingsSelection {
 	/** Which channel won. */
@@ -182,18 +185,164 @@ export interface IManagedSettingsSelection {
 /**
  * Select the authoritative managed-settings bag from the available delivery channels.
  *
- * Server-delivered settings win over native MDM and the two are never merged — managed settings
- * have a single authoritative source. Centralizing the precedence here (rather than inlining it at
- * each call site) keeps policy evaluation ({@link AccountPolicyService.getPolicyData}) and the
- * Policy Diagnostics report from drifting apart, and gives one obvious place to extend when a new
- * channel is introduced.
+ * Precedence (highest first): server-delivered → native MDM → file on disk. The channels are
+ * never merged — managed settings have a single authoritative source, so the first non-empty bag
+ * wins outright. Centralizing the precedence here (rather than inlining it at each call site)
+ * keeps policy evaluation ({@link AccountPolicyService.getPolicyData}) and the Policy Diagnostics
+ * report from drifting apart, and gives one obvious place to extend when a new channel is
+ * introduced.
  */
-export function selectManagedSettings(server: ManagedSettingsData | undefined, nativeMdm: ManagedSettingsData | undefined): IManagedSettingsSelection {
+export function selectManagedSettings(server: ManagedSettingsData | undefined, nativeMdm: ManagedSettingsData | undefined, file: ManagedSettingsData | undefined): IManagedSettingsSelection {
 	if (server && !isEmptyObject(server)) {
 		return { source: 'server', values: server };
 	}
 	if (nativeMdm && !isEmptyObject(nativeMdm)) {
 		return { source: 'nativeMdm', values: nativeMdm };
 	}
+	if (file && !isEmptyObject(file)) {
+		return { source: 'file', values: file };
+	}
 	return { source: 'none', values: undefined };
+}
+
+// --- File-based managed settings ---
+
+/** macOS well-known path for file-based managed settings. */
+export const MANAGED_SETTINGS_MACOS_FILE_PATH = '/Library/Application Support/GitHubCopilot/managed-settings.json';
+
+/** Linux well-known path for file-based managed settings. */
+export const MANAGED_SETTINGS_LINUX_FILE_PATH = '/etc/github-copilot/managed-settings.json';
+
+/** Windows directory name under %ProgramFiles% for file-based managed settings. */
+export const MANAGED_SETTINGS_WINDOWS_DIR = 'GitHubCopilot';
+
+/** Managed settings file name. */
+export const MANAGED_SETTINGS_FILE_NAME = 'managed-settings.json';
+
+/**
+ * Descriptor for a structured (object/array) managed setting: one carried across every delivery
+ * channel as a canonical JSON string under a single key. This table is the single place that
+ * knows how to turn a managed-settings schema field into that canonical value, so adding a
+ * structured key is one row here (plus the policy declaration that reads the bag key).
+ *
+ * `key` is both the source field name read from the parsed input and the canonical bag key the
+ * JSON string is stored under — for structured settings these are identical by contract (a
+ * structured key's bag name matches the schema field exactly; only scalar settings flatten to a
+ * differently-shaped dot-path, and those don't go through this table).
+ */
+interface IStructuredManagedSetting {
+	/** Source field name read from the parsed input, and the canonical bag key the JSON string is stored under. */
+	readonly key: string;
+	/**
+	 * Normalize the raw value into the canonical pre-stringify shape an admin authors via native
+	 * MDM. Return `undefined` to omit the key (absent or malformed value). Note an empty array (the
+	 * `strictKnownMarketplaces` lockdown case) is returned as-is, not omitted.
+	 */
+	readonly encode: (value: unknown, onWarn?: (msg: string) => void) => unknown;
+}
+
+const STRUCTURED_MANAGED_SETTINGS: readonly IStructuredManagedSetting[] = [
+	{
+		key: COPILOT_ENABLED_PLUGINS_KEY,
+		encode: value => isObject(value) ? value : undefined,
+	},
+	{
+		key: COPILOT_STRICT_MARKETPLACES_KEY,
+		encode: value => Array.isArray(value) ? value : undefined,
+	},
+	{
+		key: COPILOT_EXTRA_MARKETPLACES_KEY,
+		encode: (value, onWarn) => extraKnownMarketplacesToConfigDict(normalizeExtraKnownMarketplaces(value, onWarn)),
+	},
+];
+
+/**
+ * Normalize a parsed managed-settings object (from the server `managed_settings` API, a file on
+ * disk, or any other source using the managed-settings schema) into the canonical
+ * `ManagedSettingsData` bag that the policy framework consumes. This is the **single**
+ * normalization path for all delivery channels, so downstream projection and policy `value()`
+ * callbacks behave identically regardless of source. It does not enforce the declared
+ * `managedSettings` schema — dropping undeclared or type-mismatched keys happens later, at
+ * {@link projectManagedSettings}.
+ *
+ * - Scalar leaves (`permissions.*` and any forward-compatible scalar keys) are flattened into
+ *   dot-separated keys.
+ * - Structured settings (declared in {@link STRUCTURED_MANAGED_SETTINGS}) are carried as canonical
+ *   JSON strings under a single key each — the same shape an admin authors via native MDM.
+ *   `PolicyConfiguration` parses the JSON back into the object-typed setting on read.
+ *   `extraKnownMarketplaces` is normalized from the schema's `{ [id]: { source } }` map to the
+ *   `{ [name]: url-or-shorthand }` dict.
+ *
+ * Malformed marketplace entries are dropped (with an optional warning via {@link onWarn}) rather
+ * than throwing, so a bad enterprise settings file degrades gracefully instead of blocking startup.
+ */
+export function normalizeManagedSettings(parsed: Record<string, unknown>, onWarn?: (msg: string) => void): ManagedSettingsData {
+	// Spread + delete (not for..in + assignment) so the scalar remainder keeps exact `{ ...rest }`
+	// semantics: it never triggers the inherited `__proto__` setter for a source-sent own
+	// `__proto__` key, matching a destructuring rest.
+	const scalarRest: Record<string, unknown> = { ...parsed };
+	for (const setting of STRUCTURED_MANAGED_SETTINGS) {
+		delete scalarRest[setting.key];
+	}
+
+	const result: Record<string, ManagedSettingValue> = { ...flattenManagedSettings(scalarRest) };
+
+	for (const setting of STRUCTURED_MANAGED_SETTINGS) {
+		const encoded = setting.encode(parsed[setting.key], onWarn);
+		if (encoded !== undefined) {
+			result[setting.key] = JSON.stringify(encoded);
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Normalize the schema's `{ [id]: { source } }` marketplace map into an
+ * {@link IExtraKnownMarketplaceEntry} array, preserving the marketplace `name`,
+ * source discriminator, and any `ref`. Malformed or off-spec entries are dropped
+ * (with an optional warning via {@link onWarn}).
+ */
+function normalizeExtraKnownMarketplaces(value: unknown, onWarn?: (msg: string) => void): IExtraKnownMarketplaceEntry[] | undefined {
+	if (!isObject(value)) {
+		return undefined;
+	}
+	const seen = new Set<string>();
+	const entries: IExtraKnownMarketplaceEntry[] = [];
+	for (const [name, entry] of Object.entries(value)) {
+		if (!isObject(entry) || !isObject((entry as Record<string, unknown>).source)) {
+			onWarn?.(`Skipping malformed extraKnownMarketplaces entry "${name}": expected { source: { source, repo|url } }`);
+			continue;
+		}
+		const src = (entry as Record<string, unknown>).source as { source?: string; repo?: string; url?: string; ref?: string };
+		let normalized: IExtraKnownMarketplaceEntry | undefined;
+		if (src.source === 'github' && isString(src.repo)) {
+			normalized = { name, source: { source: 'github', repo: src.repo, ...(src.ref ? { ref: src.ref } : {}) } };
+		} else if (src.source === 'git' && isString(src.url)) {
+			normalized = { name, source: { source: 'git', url: src.url, ...(src.ref ? { ref: src.ref } : {}) } };
+		} else if (src.source === 'github' || src.source === 'git') {
+			onWarn?.(`Skipping extraKnownMarketplaces entry "${name}": source "${src.source}" requires ${src.source === 'github' ? '"repo"' : '"url"'}`);
+		} else {
+			onWarn?.(`Skipping extraKnownMarketplaces entry "${name}": unknown source type "${src.source}"`);
+		}
+		if (normalized && !seen.has(name)) {
+			seen.add(name);
+			entries.push(normalized);
+		}
+	}
+	return entries;
+}
+
+export const IFileManagedSettingsService = createDecorator<IFileManagedSettingsService>('fileManagedSettingsService');
+
+export interface IFileManagedSettingsService {
+	readonly _serviceBrand: undefined;
+	readonly managedSettings: ManagedSettingsData;
+	readonly onDidChangeManagedSettings: Event<ManagedSettingsData>;
+}
+
+export class NullFileManagedSettingsService implements IFileManagedSettingsService {
+	readonly _serviceBrand: undefined;
+	readonly managedSettings: ManagedSettingsData = {};
+	readonly onDidChangeManagedSettings = Event.None;
 }

--- a/src/vs/platform/policy/common/fileManagedSettingsIpc.ts
+++ b/src/vs/platform/policy/common/fileManagedSettingsIpc.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, Event } from '../../../base/common/event.js';
+import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
+import { equals } from '../../../base/common/objects.js';
+import { ManagedSettingsData } from '../../../base/common/policy.js';
+import { IChannel, IServerChannel } from '../../../base/parts/ipc/common/ipc.js';
+import { IFileManagedSettingsService } from './copilotManagedSettings.js';
+
+export class FileManagedSettingsChannel implements IServerChannel {
+
+	private readonly disposables = new DisposableStore();
+
+	constructor(private readonly service: IFileManagedSettingsService) { }
+
+	listen<T>(_: unknown, event: string): Event<T> {
+		switch (event) {
+			case 'onDidChangeManagedSettings': return this.service.onDidChangeManagedSettings as Event<T>;
+		}
+
+		throw new Error(`Event not found: ${event}`);
+	}
+
+	call<T>(_: unknown, command: string): Promise<T> {
+		switch (command) {
+			case 'getManagedSettings': return Promise.resolve(this.service.managedSettings as T);
+		}
+
+		throw new Error(`Call not found: ${command}`);
+	}
+
+	dispose(): void {
+		this.disposables.dispose();
+	}
+}
+
+export class FileManagedSettingsChannelClient extends Disposable implements IFileManagedSettingsService {
+
+	readonly _serviceBrand: undefined;
+
+	private _managedSettings: ManagedSettingsData = {};
+	get managedSettings(): ManagedSettingsData { return this._managedSettings; }
+	private hasReceivedManagedSettings = false;
+
+	private readonly _onDidChangeManagedSettings = this._register(new Emitter<ManagedSettingsData>());
+	readonly onDidChangeManagedSettings = this._onDidChangeManagedSettings.event;
+
+	constructor(channel: IChannel) {
+		super();
+		this._register(channel.listen<ManagedSettingsData>('onDidChangeManagedSettings')(managedSettings => this.updateManagedSettings(managedSettings, true)));
+		channel.call<ManagedSettingsData>('getManagedSettings').then(managedSettings => {
+			if (!this.hasReceivedManagedSettings) {
+				this.updateManagedSettings(managedSettings, true);
+			}
+		});
+	}
+
+	private updateManagedSettings(managedSettings: ManagedSettingsData, fireEvent: boolean): void {
+		this.hasReceivedManagedSettings = true;
+		if (equals(this._managedSettings, managedSettings)) {
+			return;
+		}
+
+		this._managedSettings = managedSettings;
+		if (fireEvent) {
+			this._onDidChangeManagedSettings.fire(this._managedSettings);
+		}
+	}
+}

--- a/src/vs/platform/policy/common/fileManagedSettingsService.ts
+++ b/src/vs/platform/policy/common/fileManagedSettingsService.ts
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ThrottledDelayer } from '../../../base/common/async.js';
+import { Emitter, Event } from '../../../base/common/event.js';
+import { Disposable } from '../../../base/common/lifecycle.js';
+import { equals } from '../../../base/common/objects.js';
+import { ManagedSettingsData } from '../../../base/common/policy.js';
+import { isObject } from '../../../base/common/types.js';
+import { URI } from '../../../base/common/uri.js';
+import { FileOperationError, FileOperationResult, IFileService } from '../../files/common/files.js';
+import { ILogService } from '../../log/common/log.js';
+import { IFileManagedSettingsService, normalizeManagedSettings } from './copilotManagedSettings.js';
+
+/**
+ * Upper bound on the size of `managed-settings.json` we will read into the main process. A
+ * legitimate settings file is a few KB; capping the read keeps a malformed or hostile file on the
+ * (externally writable, privileged) well-known path from OOM-ing the main process. `readFile`
+ * throws `FILE_TOO_LARGE` past this, which `refresh()` treats like any other read failure.
+ */
+const MANAGED_SETTINGS_MAX_FILE_SIZE = 1024 * 1024; // 1 MB
+
+export class FileManagedSettingsService extends Disposable implements IFileManagedSettingsService {
+
+	readonly _serviceBrand: undefined;
+
+	private _managedSettings: ManagedSettingsData = {};
+	get managedSettings(): ManagedSettingsData { return this._managedSettings; }
+
+	private readonly _onDidChangeManagedSettings = this._register(new Emitter<ManagedSettingsData>());
+	readonly onDidChangeManagedSettings = this._onDidChangeManagedSettings.event;
+
+	private readonly throttledDelayer = this._register(new ThrottledDelayer(500));
+
+	constructor(
+		private readonly file: URI,
+		@IFileService private readonly fileService: IFileService,
+		@ILogService private readonly logService: ILogService,
+	) {
+		super();
+
+		const onDidChangeFile = Event.filter(fileService.onDidFilesChange, e => e.affects(file));
+		this._register(fileService.watch(file));
+		this._register(onDidChangeFile(() => this.throttledDelayer.trigger(() => this.refresh())));
+
+		// Initial read — routed through the same delayer (with no delay) so it is serialized
+		// against change-triggered refreshes and can't be clobbered by a racing read. Non-blocking;
+		// IPC clients handle eventual data arrival.
+		this.throttledDelayer.trigger(() => this.refresh(), 0);
+	}
+
+	private async refresh(): Promise<void> {
+		const previous = this._managedSettings;
+
+		try {
+			const content = await this.fileService.readFile(this.file, { limits: { size: MANAGED_SETTINGS_MAX_FILE_SIZE } });
+			const parsed = JSON.parse(content.value.toString());
+
+			if (isObject(parsed)) {
+				this._managedSettings = normalizeManagedSettings(parsed as Record<string, unknown>,
+					msg => this.logService.warn(`[FileManagedSettingsService] ${msg}`));
+			} else {
+				this.logService.warn('[FileManagedSettingsService] managed-settings.json is not a JSON object');
+				this._managedSettings = {};
+			}
+		} catch (error) {
+			if ((<FileOperationError>error).fileOperationResult !== FileOperationResult.FILE_NOT_FOUND) {
+				this.logService.error('[FileManagedSettingsService] Failed to read managed-settings.json', error);
+			}
+			this._managedSettings = {};
+		}
+
+		if (!equals(previous, this._managedSettings)) {
+			this._onDidChangeManagedSettings.fire(this._managedSettings);
+		}
+	}
+}

--- a/src/vs/platform/policy/common/nativeManagedSettingsIpc.ts
+++ b/src/vs/platform/policy/common/nativeManagedSettingsIpc.ts
@@ -8,14 +8,14 @@ import { IStringDictionary } from '../../../base/common/collections.js';
 import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
 import { equals } from '../../../base/common/objects.js';
 import { IChannel, IServerChannel } from '../../../base/parts/ipc/common/ipc.js';
-import { ICopilotManagedSettingsService, ManagedSettingsData } from './copilotManagedSettings.js';
+import { INativeManagedSettingsService, ManagedSettingsData } from './copilotManagedSettings.js';
 import { PolicyDefinition } from './policy.js';
 
-export class CopilotManagedSettingsChannel implements IServerChannel {
+export class NativeManagedSettingsChannel implements IServerChannel {
 
 	private readonly disposables = new DisposableStore();
 
-	constructor(private readonly service: ICopilotManagedSettingsService) { }
+	constructor(private readonly service: INativeManagedSettingsService) { }
 
 	listen<T>(_: unknown, event: string): Event<T> {
 		switch (event) {
@@ -39,7 +39,7 @@ export class CopilotManagedSettingsChannel implements IServerChannel {
 	}
 }
 
-export class CopilotManagedSettingsChannelClient extends Disposable implements ICopilotManagedSettingsService {
+export class NativeManagedSettingsChannelClient extends Disposable implements INativeManagedSettingsService {
 
 	readonly _serviceBrand: undefined;
 

--- a/src/vs/platform/policy/node/nativeManagedSettingsService.ts
+++ b/src/vs/platform/policy/node/nativeManagedSettingsService.ts
@@ -10,22 +10,22 @@ import { Disposable, MutableDisposable } from '../../../base/common/lifecycle.js
 import { equals } from '../../../base/common/objects.js';
 import { IManagedSettingsPolicyDefinitions, ManagedSettingsData } from '../../../base/common/policy.js';
 import { ILogService } from '../../log/common/log.js';
-import { collectManagedSettingsDefinitions, ICopilotManagedSettingsService } from '../common/copilotManagedSettings.js';
+import { collectManagedSettingsDefinitions, INativeManagedSettingsService } from '../common/copilotManagedSettings.js';
 import { PolicyDefinition, PolicyValue } from '../common/policy.js';
 import type { Watcher } from '@vscode/policy-watcher';
 
-export interface ICopilotPolicyWatcherOptions {
+export interface INativePolicyWatcherOptions {
 	readonly registryPath?: string;
 }
 
-export type CopilotPolicyWatcherFactory = (
+export type NativePolicyWatcherFactory = (
 	productName: string,
 	policies: Record<string, { type: 'string' | 'number' | 'boolean' }>,
 	onDidChange: (update: Record<string, PolicyValue | undefined>) => void,
-	options?: ICopilotPolicyWatcherOptions,
+	options?: INativePolicyWatcherOptions,
 ) => Watcher;
 
-export class CopilotManagedSettingsService extends Disposable implements ICopilotManagedSettingsService {
+export class NativeManagedSettingsService extends Disposable implements INativeManagedSettingsService {
 
 	readonly _serviceBrand: undefined;
 
@@ -44,8 +44,8 @@ export class CopilotManagedSettingsService extends Disposable implements ICopilo
 	constructor(
 		@ILogService private readonly logService: ILogService,
 		private readonly productName: string,
-		private readonly watcherOptions?: ICopilotPolicyWatcherOptions,
-		private readonly watcherFactory?: CopilotPolicyWatcherFactory,
+		private readonly watcherOptions?: INativePolicyWatcherOptions,
+		private readonly watcherFactory?: NativePolicyWatcherFactory,
 	) {
 		super();
 	}
@@ -79,7 +79,7 @@ export class CopilotManagedSettingsService extends Disposable implements ICopilo
 
 	private async updateWatcher(): Promise<void> {
 		const managedSettingDefinitions = this.getManagedSettingDefinitions();
-		this.logService.trace(`CopilotManagedSettingsService#updateWatcher - Found ${Object.keys(managedSettingDefinitions).length} managed-settings definitions`);
+		this.logService.trace(`NativeManagedSettingsService#updateWatcher - Found ${Object.keys(managedSettingDefinitions).length} managed-settings definitions`);
 		if (Object.keys(managedSettingDefinitions).length === 0) {
 			this.watcher.clear();
 			const hadManagedSettings = this.managedSettingsValues.size > 0;
@@ -90,16 +90,16 @@ export class CopilotManagedSettingsService extends Disposable implements ICopilo
 			return;
 		}
 
-		const { createWatcher } = this.watcherFactory ? { createWatcher: this.watcherFactory } : (await import('@vscode/policy-watcher') as { createWatcher: CopilotPolicyWatcherFactory });
+		const { createWatcher } = this.watcherFactory ? { createWatcher: this.watcherFactory } : (await import('@vscode/policy-watcher') as { createWatcher: NativePolicyWatcherFactory });
 		await this.throttler.queue(() => new Promise<void>((c, e) => {
 			try {
-				this.logService.trace(`Creating Copilot managed-settings watcher for productName ${this.productName}`);
+				this.logService.trace(`Creating native managed-settings watcher for productName ${this.productName}`);
 				this.watcher.value = createWatcher(this.productName, managedSettingDefinitions, update => {
 					this._onDidManagedSettingsChange(update as Record<string, PolicyValue | undefined>);
 					c();
 				}, this.watcherOptions);
 			} catch (err) {
-				this.logService.error(`CopilotManagedSettingsService#updateWatcher - Error creating watcher:`, err);
+				this.logService.error(`NativeManagedSettingsService#updateWatcher - Error creating watcher:`, err);
 				e(err);
 			}
 		}));
@@ -121,7 +121,7 @@ export class CopilotManagedSettingsService extends Disposable implements ICopilo
 	}
 
 	private _onDidManagedSettingsChange(update: Record<string, PolicyValue | undefined>): void {
-		this.logService.trace(`CopilotManagedSettingsService#_onDidManagedSettingsChange - Updated managed-settings values: ${JSON.stringify(update)}`);
+		this.logService.trace(`NativeManagedSettingsService#_onDidManagedSettingsChange - Updated managed-settings values: ${JSON.stringify(update)}`);
 
 		let changed = false;
 		for (const [key, value] of Object.entries(update)) {

--- a/src/vs/platform/policy/test/common/copilotManagedSettings.test.ts
+++ b/src/vs/platform/policy/test/common/copilotManagedSettings.test.ts
@@ -108,23 +108,31 @@ suite('Copilot managed settings projection', () => {
 		assert.strictEqual(warnings.length, 1);
 	});
 
-	test('selectManagedSettings: server wins over native MDM, never merged', () => {
+	test('selectManagedSettings: server wins over native MDM and file, never merged', () => {
 		const selection = selectManagedSettings(
 			{ 'permissions.x': 'server' },
 			{ 'permissions.y': 'native' },
+			{ 'permissions.z': 'file' },
 		);
 		assert.deepStrictEqual(selection, { source: 'server', values: { 'permissions.x': 'server' } });
 	});
 
 	test('selectManagedSettings: falls through to native MDM when server is absent or empty', () => {
-		const fromUndefined = selectManagedSettings(undefined, { 'permissions.y': 'native' });
-		const fromEmptyObject = selectManagedSettings({}, { 'permissions.y': 'native' });
+		const fromUndefined = selectManagedSettings(undefined, { 'permissions.y': 'native' }, undefined);
+		const fromEmptyObject = selectManagedSettings({}, { 'permissions.y': 'native' }, undefined);
 		assert.deepStrictEqual(fromUndefined, { source: 'nativeMdm', values: { 'permissions.y': 'native' } });
 		assert.deepStrictEqual(fromEmptyObject, { source: 'nativeMdm', values: { 'permissions.y': 'native' } });
 	});
 
+	test('selectManagedSettings: falls through to file when server and native MDM are absent or empty', () => {
+		const fromUndefined = selectManagedSettings(undefined, undefined, { 'permissions.z': 'file' });
+		const fromEmptyObjects = selectManagedSettings({}, {}, { 'permissions.z': 'file' });
+		assert.deepStrictEqual(fromUndefined, { source: 'file', values: { 'permissions.z': 'file' } });
+		assert.deepStrictEqual(fromEmptyObjects, { source: 'file', values: { 'permissions.z': 'file' } });
+	});
+
 	test('selectManagedSettings: reports `none` with no values when every channel is empty', () => {
-		assert.deepStrictEqual(selectManagedSettings(undefined, undefined), { source: 'none', values: undefined });
-		assert.deepStrictEqual(selectManagedSettings({}, {}), { source: 'none', values: undefined });
+		assert.deepStrictEqual(selectManagedSettings(undefined, undefined, undefined), { source: 'none', values: undefined });
+		assert.deepStrictEqual(selectManagedSettings({}, {}, {}), { source: 'none', values: undefined });
 	});
 });

--- a/src/vs/platform/policy/test/common/fileManagedSettingsService.test.ts
+++ b/src/vs/platform/policy/test/common/fileManagedSettingsService.test.ts
@@ -1,0 +1,301 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../base/common/uri.js';
+import { VSBuffer } from '../../../../base/common/buffer.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { ManagedSettingsData } from '../../../../base/common/policy.js';
+import { IChannel } from '../../../../base/parts/ipc/common/ipc.js';
+import { FileService } from '../../../files/common/fileService.js';
+import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesystemProvider.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { runWithFakedTimers } from '../../../../base/test/common/timeTravelScheduler.js';
+import { COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, normalizeManagedSettings } from '../../common/copilotManagedSettings.js';
+import { FileManagedSettingsService } from '../../common/fileManagedSettingsService.js';
+import { FileManagedSettingsChannelClient } from '../../common/fileManagedSettingsIpc.js';
+
+suite('normalizeManagedSettings', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('flattens scalar leaves to dot-paths', () => {
+		const result = normalizeManagedSettings({
+			permissions: {
+				disableBypassPermissionsMode: 'disable'
+			}
+		});
+		assert.deepStrictEqual(result, {
+			'permissions.disableBypassPermissionsMode': 'disable'
+		});
+	});
+
+	test('JSON-stringifies structured keys (enabledPlugins)', () => {
+		const plugins = { 'plugin@marketplace': false };
+		const result = normalizeManagedSettings({
+			[COPILOT_ENABLED_PLUGINS_KEY]: plugins
+		});
+		assert.deepStrictEqual(result, {
+			[COPILOT_ENABLED_PLUGINS_KEY]: JSON.stringify(plugins)
+		});
+	});
+
+	test('normalizes extraKnownMarketplaces from schema format to config dict', () => {
+		const result = normalizeManagedSettings({
+			[COPILOT_EXTRA_MARKETPLACES_KEY]: {
+				'a': { source: { source: 'github', repo: 'github/agent-skills' } },
+				'b': { source: { source: 'git', url: 'https://example.com/repo.git', ref: 'v1' } },
+			}
+		});
+		assert.deepStrictEqual(result, {
+			[COPILOT_EXTRA_MARKETPLACES_KEY]: '{"a":"github/agent-skills","b":"https://example.com/repo.git#v1"}',
+		});
+	});
+
+	test('drops malformed marketplace entries with warning', () => {
+		const warnings: string[] = [];
+		const result = normalizeManagedSettings({
+			[COPILOT_EXTRA_MARKETPLACES_KEY]: {
+				'good': { source: { source: 'github', repo: 'a/b' } },
+				'bad': {} as Record<string, unknown>,
+			}
+		}, msg => warnings.push(msg));
+		assert.deepStrictEqual(result, {
+			[COPILOT_EXTRA_MARKETPLACES_KEY]: '{"good":"a/b"}',
+		});
+		assert.strictEqual(warnings.length, 1);
+	});
+
+	test('handles mixed scalar and structured keys', () => {
+		const result = normalizeManagedSettings({
+			permissions: { disableBypassPermissionsMode: 'disable' },
+			strictKnownMarketplaces: ['github/foo'],
+			[COPILOT_ENABLED_PLUGINS_KEY]: { 'plugin': true },
+		});
+		assert.deepStrictEqual(result, {
+			'permissions.disableBypassPermissionsMode': 'disable',
+			'strictKnownMarketplaces': '["github/foo"]',
+			[COPILOT_ENABLED_PLUGINS_KEY]: '{"plugin":true}',
+		});
+	});
+
+	test('handles empty object', () => {
+		assert.deepStrictEqual(normalizeManagedSettings({}), {});
+	});
+
+	test('drops a structured key whose value is not an object', () => {
+		const result = normalizeManagedSettings({
+			[COPILOT_ENABLED_PLUGINS_KEY]: 'already-a-string'
+		});
+		assert.deepStrictEqual(result, {});
+	});
+});
+
+suite('FileManagedSettingsService', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+	const managedSettingsFile = URI.file('managed-settings.json').with({ scheme: 'vscode-tests' });
+
+	test('reads managed-settings.json on startup', () => runWithFakedTimers({}, async () => {
+		const logService = new NullLogService();
+		const fileService = disposables.add(new FileService(logService));
+		const inMemoryProvider = disposables.add(new InMemoryFileSystemProvider());
+		disposables.add(fileService.registerProvider('vscode-tests', inMemoryProvider));
+
+		await fileService.writeFile(managedSettingsFile, VSBuffer.fromString(JSON.stringify({
+			permissions: { disableBypassPermissionsMode: 'disable' },
+			strictKnownMarketplaces: ['github/foo']
+		})));
+
+		const service = disposables.add(new FileManagedSettingsService(managedSettingsFile, fileService, logService));
+
+		// Wait for the async refresh to complete
+		await new Promise<void>(resolve => {
+			if (Object.keys(service.managedSettings).length > 0) {
+				resolve();
+			} else {
+				const listener = disposables.add(service.onDidChangeManagedSettings(() => {
+					listener.dispose();
+					resolve();
+				}));
+			}
+		});
+
+		assert.deepStrictEqual(service.managedSettings, {
+			'permissions.disableBypassPermissionsMode': 'disable',
+			'strictKnownMarketplaces': '["github/foo"]'
+		});
+	}));
+
+	test('returns empty object when file does not exist', () => runWithFakedTimers({}, async () => {
+		const logService = new NullLogService();
+		const fileService = disposables.add(new FileService(logService));
+		const inMemoryProvider = disposables.add(new InMemoryFileSystemProvider());
+		disposables.add(fileService.registerProvider('vscode-tests', inMemoryProvider));
+
+		const service = disposables.add(new FileManagedSettingsService(managedSettingsFile, fileService, logService));
+
+		// Give the async refresh a chance to run
+		await new Promise(resolve => setTimeout(resolve, 10));
+
+		assert.deepStrictEqual(service.managedSettings, {});
+	}));
+
+	test('fires event when file changes', () => runWithFakedTimers({}, async () => {
+		const logService = new NullLogService();
+		const fileService = disposables.add(new FileService(logService));
+		const inMemoryProvider = disposables.add(new InMemoryFileSystemProvider());
+		disposables.add(fileService.registerProvider('vscode-tests', inMemoryProvider));
+
+		await fileService.writeFile(managedSettingsFile, VSBuffer.fromString(JSON.stringify({
+			permissions: { disableBypassPermissionsMode: 'disable' }
+		})));
+
+		const service = disposables.add(new FileManagedSettingsService(managedSettingsFile, fileService, logService));
+
+		// Wait for initial read
+		await new Promise<void>(resolve => {
+			if (Object.keys(service.managedSettings).length > 0) {
+				resolve();
+			} else {
+				const listener = disposables.add(service.onDidChangeManagedSettings(() => {
+					listener.dispose();
+					resolve();
+				}));
+			}
+		});
+
+		// Update the file
+		const changePromise = new Promise<void>(resolve => {
+			const listener = disposables.add(service.onDidChangeManagedSettings(() => {
+				listener.dispose();
+				resolve();
+			}));
+		});
+
+		await fileService.writeFile(managedSettingsFile, VSBuffer.fromString(JSON.stringify({
+			strictKnownMarketplaces: ['github/foo']
+		})));
+
+		await changePromise;
+
+		assert.deepStrictEqual(service.managedSettings, {
+			'strictKnownMarketplaces': '["github/foo"]'
+		});
+	}));
+
+	test('returns empty object when the file is malformed JSON', () => runWithFakedTimers({}, async () => {
+		const logService = new NullLogService();
+		const fileService = disposables.add(new FileService(logService));
+		const inMemoryProvider = disposables.add(new InMemoryFileSystemProvider());
+		disposables.add(fileService.registerProvider('vscode-tests', inMemoryProvider));
+
+		await fileService.writeFile(managedSettingsFile, VSBuffer.fromString('{ not: valid json'));
+
+		const service = disposables.add(new FileManagedSettingsService(managedSettingsFile, fileService, logService));
+		await new Promise(resolve => setTimeout(resolve, 10));
+
+		assert.deepStrictEqual(service.managedSettings, {});
+	}));
+
+	test('returns empty object when the file is not a JSON object', () => runWithFakedTimers({}, async () => {
+		const logService = new NullLogService();
+		const fileService = disposables.add(new FileService(logService));
+		const inMemoryProvider = disposables.add(new InMemoryFileSystemProvider());
+		disposables.add(fileService.registerProvider('vscode-tests', inMemoryProvider));
+
+		await fileService.writeFile(managedSettingsFile, VSBuffer.fromString(JSON.stringify(['not', 'an', 'object'])));
+
+		const service = disposables.add(new FileManagedSettingsService(managedSettingsFile, fileService, logService));
+		await new Promise(resolve => setTimeout(resolve, 10));
+
+		assert.deepStrictEqual(service.managedSettings, {});
+	}));
+
+	test('clears managed settings and fires when the file is deleted', () => runWithFakedTimers({}, async () => {
+		const logService = new NullLogService();
+		const fileService = disposables.add(new FileService(logService));
+		const inMemoryProvider = disposables.add(new InMemoryFileSystemProvider());
+		disposables.add(fileService.registerProvider('vscode-tests', inMemoryProvider));
+
+		await fileService.writeFile(managedSettingsFile, VSBuffer.fromString(JSON.stringify({
+			permissions: { disableBypassPermissionsMode: 'disable' }
+		})));
+
+		const service = disposables.add(new FileManagedSettingsService(managedSettingsFile, fileService, logService));
+
+		// Wait for initial read
+		await new Promise<void>(resolve => {
+			if (Object.keys(service.managedSettings).length > 0) {
+				resolve();
+			} else {
+				const listener = disposables.add(service.onDidChangeManagedSettings(() => {
+					listener.dispose();
+					resolve();
+				}));
+			}
+		});
+
+		const changePromise = new Promise<void>(resolve => {
+			const listener = disposables.add(service.onDidChangeManagedSettings(() => {
+				listener.dispose();
+				resolve();
+			}));
+		});
+
+		await fileService.del(managedSettingsFile);
+
+		await changePromise;
+
+		assert.deepStrictEqual(service.managedSettings, {});
+	}));
+});
+
+suite('FileManagedSettingsChannelClient', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('keeps newer event state when the initial snapshot resolves later', async () => {
+		const channel = disposables.add(new DeferredManagedSettingsChannel());
+		const client = disposables.add(new FileManagedSettingsChannelClient(channel));
+
+		// A change event arrives before the initial getManagedSettings call resolves; the later,
+		// stale snapshot must not clobber the newer event-delivered state.
+		channel.fire({ [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' });
+		channel.resolveInitialSnapshot({ [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'enable' });
+		await channel.initialSnapshot;
+
+		assert.deepStrictEqual(client.managedSettings, { [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' });
+	});
+});
+
+class DeferredManagedSettingsChannel extends Disposable implements IChannel {
+	private readonly _onDidChangeManagedSettings = this._register(new Emitter<ManagedSettingsData>());
+	private resolveInitialSnapshotPromise!: (managedSettings: ManagedSettingsData) => void;
+	readonly initialSnapshot = new Promise<ManagedSettingsData>(resolve => this.resolveInitialSnapshotPromise = resolve);
+
+	call<T>(command: string): Promise<T> {
+		switch (command) {
+			case 'getManagedSettings': return this.initialSnapshot as Promise<T>;
+		}
+
+		throw new Error(`Call not found: ${command}`);
+	}
+
+	listen<T>(event: string): Event<T> {
+		assert.strictEqual(event, 'onDidChangeManagedSettings');
+		return this._onDidChangeManagedSettings.event as Event<T>;
+	}
+
+	fire(managedSettings: ManagedSettingsData): void {
+		this._onDidChangeManagedSettings.fire(managedSettings);
+	}
+
+	resolveInitialSnapshot(managedSettings: ManagedSettingsData): void {
+		this.resolveInitialSnapshotPromise(managedSettings);
+	}
+}

--- a/src/vs/platform/policy/test/node/nativeManagedSettingsService.test.ts
+++ b/src/vs/platform/policy/test/node/nativeManagedSettingsService.test.ts
@@ -11,25 +11,25 @@ import { IChannel } from '../../../../base/parts/ipc/common/ipc.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY } from '../../common/copilotManagedSettings.js';
-import { CopilotManagedSettingsChannelClient } from '../../common/copilotManagedSettingsIpc.js';
+import { NativeManagedSettingsChannelClient } from '../../common/nativeManagedSettingsIpc.js';
 import { PolicyValue } from '../../common/policy.js';
-import { CopilotManagedSettingsService, CopilotPolicyWatcherFactory } from '../../node/copilotManagedSettingsService.js';
+import { NativeManagedSettingsService, NativePolicyWatcherFactory } from '../../node/nativeManagedSettingsService.js';
 
-suite('CopilotManagedSettingsService', () => {
+suite('NativeManagedSettingsService', () => {
 
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 	const policyName = 'ChatToolsAutoApprove';
 
 	test('watches managed-settings keys from policy definitions and exposes raw managed settings', async () => {
 		let onDidChange: ((update: Record<string, PolicyValue | undefined>) => void) | undefined;
-		const watcherFactory: CopilotPolicyWatcherFactory = (_productName, policies, callback) => {
+		const watcherFactory: NativePolicyWatcherFactory = (_productName, policies, callback) => {
 			assert.deepStrictEqual(policies, { [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: { type: 'string' } });
 			onDidChange = callback;
 			callback({});
 			return Disposable.None;
 		};
 
-		const service = disposables.add(new CopilotManagedSettingsService(new NullLogService(), 'com.github.copilot', undefined, watcherFactory));
+		const service = disposables.add(new NativeManagedSettingsService(new NullLogService(), 'com.github.copilot', undefined, watcherFactory));
 		await service.updatePolicyDefinitions({
 			[policyName]: {
 				type: 'boolean',
@@ -48,12 +48,12 @@ suite('CopilotManagedSettingsService', () => {
 
 	test('does not create the watcher until a managed-settings policy definition is registered', async () => {
 		let watcherCreated = false;
-		const watcherFactory: CopilotPolicyWatcherFactory = () => {
+		const watcherFactory: NativePolicyWatcherFactory = () => {
 			watcherCreated = true;
 			return Disposable.None;
 		};
 
-		const service = disposables.add(new CopilotManagedSettingsService(new NullLogService(), 'com.github.copilot', undefined, watcherFactory));
+		const service = disposables.add(new NativeManagedSettingsService(new NullLogService(), 'com.github.copilot', undefined, watcherFactory));
 		await service.updatePolicyDefinitions({ OtherPolicy: { type: 'boolean' } });
 
 		assert.strictEqual(watcherCreated, false);
@@ -62,13 +62,13 @@ suite('CopilotManagedSettingsService', () => {
 	test('clears stale watcher values when managed-settings definitions are removed', async () => {
 		let onDidChange: ((update: Record<string, PolicyValue | undefined>) => void) | undefined;
 		let disposeCount = 0;
-		const watcherFactory: CopilotPolicyWatcherFactory = (_productName, _policies, callback) => {
+		const watcherFactory: NativePolicyWatcherFactory = (_productName, _policies, callback) => {
 			onDidChange = callback;
 			callback({});
 			return { dispose: () => disposeCount++ };
 		};
 
-		const service = disposables.add(new CopilotManagedSettingsService(new NullLogService(), 'com.github.copilot', undefined, watcherFactory));
+		const service = disposables.add(new NativeManagedSettingsService(new NullLogService(), 'com.github.copilot', undefined, watcherFactory));
 		await service.updatePolicyDefinitions({
 			[policyName]: {
 				type: 'boolean',
@@ -87,14 +87,14 @@ suite('CopilotManagedSettingsService', () => {
 	test('keeps raw managed settings while definitions are unchanged', async () => {
 		let onDidChange: ((update: Record<string, PolicyValue | undefined>) => void) | undefined;
 		let watcherCreateCount = 0;
-		const watcherFactory: CopilotPolicyWatcherFactory = (_productName, _policies, callback) => {
+		const watcherFactory: NativePolicyWatcherFactory = (_productName, _policies, callback) => {
 			watcherCreateCount++;
 			onDidChange = callback;
 			callback({});
 			return Disposable.None;
 		};
 
-		const service = disposables.add(new CopilotManagedSettingsService(new NullLogService(), 'com.github.copilot', undefined, watcherFactory));
+		const service = disposables.add(new NativeManagedSettingsService(new NullLogService(), 'com.github.copilot', undefined, watcherFactory));
 		await service.updatePolicyDefinitions({
 			[policyName]: {
 				type: 'boolean',
@@ -126,13 +126,13 @@ suite('CopilotManagedSettingsService', () => {
 	test('removes raw managed settings whose definitions are no longer watched', async () => {
 		let onDidChange: ((update: Record<string, PolicyValue | undefined>) => void) | undefined;
 		const otherManagedSettingKey = 'permissions.otherManagedSetting';
-		const watcherFactory: CopilotPolicyWatcherFactory = (_productName, _policies, callback) => {
+		const watcherFactory: NativePolicyWatcherFactory = (_productName, _policies, callback) => {
 			onDidChange = callback;
 			callback({});
 			return Disposable.None;
 		};
 
-		const service = disposables.add(new CopilotManagedSettingsService(new NullLogService(), 'com.github.copilot', undefined, watcherFactory));
+		const service = disposables.add(new NativeManagedSettingsService(new NullLogService(), 'com.github.copilot', undefined, watcherFactory));
 		await service.updatePolicyDefinitions({
 			[policyName]: {
 				type: 'boolean',
@@ -158,7 +158,7 @@ suite('CopilotManagedSettingsService', () => {
 
 	test('channel client keeps newer event state when initial snapshot resolves later', async () => {
 		const channel = disposables.add(new DeferredManagedSettingsChannel());
-		const client = disposables.add(new CopilotManagedSettingsChannelClient(channel));
+		const client = disposables.add(new NativeManagedSettingsChannelClient(channel));
 
 		channel.fire({ [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' });
 		channel.resolveInitialSnapshot({ [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'enable' });
@@ -169,7 +169,7 @@ suite('CopilotManagedSettingsService', () => {
 
 	test('channel client updatePolicyDefinitions updates cache without firing change event', async () => {
 		const channel = disposables.add(new DeferredManagedSettingsChannel());
-		const client = disposables.add(new CopilotManagedSettingsChannelClient(channel));
+		const client = disposables.add(new NativeManagedSettingsChannelClient(channel));
 		channel.resolveInitialSnapshot({});
 		await channel.initialSnapshot;
 

--- a/src/vs/sessions/electron-browser/sessions.main.ts
+++ b/src/vs/sessions/electron-browser/sessions.main.ts
@@ -49,8 +49,9 @@ import { FileUserDataProvider } from '../../platform/userData/common/fileUserDat
 import { IUserDataProfilesService, reviveProfile } from '../../platform/userDataProfile/common/userDataProfile.js';
 import { UserDataProfilesService } from '../../platform/userDataProfile/common/userDataProfileIpc.js';
 import { PolicyChannelClient } from '../../platform/policy/common/policyIpc.js';
-import { CopilotManagedSettingsChannelClient } from '../../platform/policy/common/copilotManagedSettingsIpc.js';
-import { ICopilotManagedSettingsService } from '../../platform/policy/common/copilotManagedSettings.js';
+import { NativeManagedSettingsChannelClient } from '../../platform/policy/common/nativeManagedSettingsIpc.js';
+import { INativeManagedSettingsService, IFileManagedSettingsService } from '../../platform/policy/common/copilotManagedSettings.js';
+import { FileManagedSettingsChannelClient } from '../../platform/policy/common/fileManagedSettingsIpc.js';
 import { IPolicyService } from '../../platform/policy/common/policy.js';
 import { UserDataProfileService } from '../../workbench/services/userDataProfile/common/userDataProfileService.js';
 import { IUserDataProfileService } from '../../workbench/services/userDataProfile/common/userDataProfile.js';
@@ -219,9 +220,11 @@ export class SessionsMain extends Disposable {
 		// Policies
 		let policyService: IPolicyService;
 		const policyChannel = this.configuration.policiesData ? this._register(new PolicyChannelClient(this.configuration.policiesData, mainProcessService.getChannel('policy'))) : undefined;
-		const copilotManagedSettings = this._register(new CopilotManagedSettingsChannelClient(mainProcessService.getChannel('copilotManagedSettings')));
-		serviceCollection.set(ICopilotManagedSettingsService, copilotManagedSettings);
-		const accountPolicy = this._register(new AccountPolicyService(logService, defaultAccountService, policyChannel, copilotManagedSettings));
+		const nativeManagedSettings = this._register(new NativeManagedSettingsChannelClient(mainProcessService.getChannel('nativeManagedSettings')));
+		serviceCollection.set(INativeManagedSettingsService, nativeManagedSettings);
+		const fileManagedSettings = this._register(new FileManagedSettingsChannelClient(mainProcessService.getChannel('fileManagedSettings')));
+		serviceCollection.set(IFileManagedSettingsService, fileManagedSettings);
+		const accountPolicy = this._register(new AccountPolicyService(logService, defaultAccountService, policyChannel, nativeManagedSettings, fileManagedSettings));
 		if (policyChannel) {
 			policyService = this._register(new MultiplexPolicyService([policyChannel, accountPolicy], logService));
 		} else {

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -46,9 +46,9 @@ import { IDefaultAccountService } from '../../../platform/defaultAccount/common/
 import { IAuthenticationService } from '../../services/authentication/common/authentication.js';
 import { IAuthenticationAccessService } from '../../services/authentication/browser/authenticationAccessService.js';
 import { IPolicyService } from '../../../platform/policy/common/policy.js';
-import { COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_STRICT_MARKETPLACES_KEY, ICopilotManagedSettingsService, ManagedSettingsSource, projectManagedSettings, selectManagedSettings } from '../../../platform/policy/common/copilotManagedSettings.js';
+import { COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_STRICT_MARKETPLACES_KEY, INativeManagedSettingsService, IFileManagedSettingsService, ManagedSettingsSource, projectManagedSettings, selectManagedSettings } from '../../../platform/policy/common/copilotManagedSettings.js';
 import { IManagedSettingPolicyDefinition, ManagedSettingsData } from '../../../base/common/policy.js';
-import { APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, IAccountPolicyGateService } from '../../services/policies/common/accountPolicyService.js';
+import { APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, IAccountPolicyGateService } from '../../services/policies/common/accountPolicyService.js';
 import { adaptManagedSettings, IManagedSettingsResponse } from '../../services/accounts/browser/managedSettings.js';
 import { isObject } from '../../../base/common/types.js';
 import * as json from '../../../base/common/json.js';
@@ -676,7 +676,18 @@ function managedSettingsSourceLabel(source: ManagedSettingsSource): string {
 	switch (source) {
 		case 'server': return 'GitHub Server API';
 		case 'nativeMdm': return 'Native MDM';
+		case 'file': return 'File (managed-settings.json)';
 		case 'none': return 'None (no managed settings active)';
+	}
+}
+
+/** Compact label for the "Policy Source" column, where the adjacent "Managed Settings" column already lists the key. */
+function managedSettingsSourceShortLabel(source: ManagedSettingsSource): string {
+	switch (source) {
+		case 'server': return 'Server';
+		case 'nativeMdm': return 'Native MDM';
+		case 'file': return 'File';
+		case 'none': return 'None';
 	}
 }
 
@@ -711,11 +722,19 @@ class PolicyDiagnosticsAction extends Action2 {
 		// Native MDM is a desktop-only channel, registered in the renderer service collection on
 		// desktop and Agents windows but absent in web. Resolve it now, synchronously, because the
 		// accessor is only valid before the first `await` below.
-		let copilotManagedSettingsService: ICopilotManagedSettingsService | undefined;
+		let nativeManagedSettingsService: INativeManagedSettingsService | undefined;
 		try {
-			copilotManagedSettingsService = accessor.get(ICopilotManagedSettingsService);
+			nativeManagedSettingsService = accessor.get(INativeManagedSettingsService);
 		} catch {
 			// no native MDM channel in this window (e.g. web)
+		}
+		// File-based managed settings is likewise a desktop-only channel registered in the renderer
+		// service collection on desktop and Agents windows, absent in web.
+		let fileManagedSettingsService: IFileManagedSettingsService | undefined;
+		try {
+			fileManagedSettingsService = accessor.get(IFileManagedSettingsService);
+		} catch {
+			// no file channel in this window (e.g. web)
 		}
 
 		const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
@@ -810,15 +829,21 @@ class PolicyDiagnosticsAction extends Action2 {
 		}
 
 		content += '## Managed Settings\n\n';
+		// Captured from the Managed Settings section below so the Policy-Controlled Settings table
+		// can attribute managed-settings-driven policies to their actual delivery channel instead
+		// of the generic AccountPolicyService that hosts the projection.
+		let managedSettingsActiveSource: ManagedSettingsSource = 'none';
+		const activeManagedSettingKeys = new Set<string>();
 		try {
 			const policyData = defaultAccountService.policyData;
 			const serverManagedSettings = policyData?.managedSettings;
 
-			const nativeManagedSettings: ManagedSettingsData | undefined = copilotManagedSettingsService?.managedSettings;
+			const nativeManagedSettings: ManagedSettingsData | undefined = nativeManagedSettingsService?.managedSettings;
+			const fileManagedSettings: ManagedSettingsData | undefined = fileManagedSettingsService?.managedSettings;
 
 			// Reuse the same precedence as policy evaluation so this report can never drift from the
 			// source AccountPolicyService actually applies.
-			const selection = selectManagedSettings(serverManagedSettings, nativeManagedSettings);
+			const selection = selectManagedSettings(serverManagedSettings, nativeManagedSettings, fileManagedSettings);
 
 			content += `**Active source**: ${managedSettingsSourceLabel(selection.source)}\n\n`;
 
@@ -848,10 +873,18 @@ class PolicyDiagnosticsAction extends Action2 {
 
 			content += '### Native MDM\n\n';
 			content += PROPERTY_VALUE_TABLE_HEADER;
-			content += `| Available | ${copilotManagedSettingsService ? 'yes' : 'no'} |\n`;
+			content += `| Available | ${nativeManagedSettingsService ? 'yes' : 'no'} |\n`;
 			content += `| Active | ${selection.source === 'nativeMdm' ? 'yes' : 'no'} |\n\n`;
-			if (copilotManagedSettingsService) {
+			if (nativeManagedSettingsService) {
 				content += jsonBlock(nativeManagedSettings);
+			}
+
+			content += '### File (managed-settings.json)\n\n';
+			content += PROPERTY_VALUE_TABLE_HEADER;
+			content += `| Available | ${fileManagedSettingsService ? 'yes' : 'no'} |\n`;
+			content += `| Active | ${selection.source === 'file' ? 'yes' : 'no'} |\n\n`;
+			if (fileManagedSettingsService) {
+				content += jsonBlock(fileManagedSettings);
 			}
 
 			// Mirror AccountPolicyService: project the winning bag onto the keys declared by policies
@@ -864,6 +897,13 @@ class PolicyDiagnosticsAction extends Action2 {
 				}
 			}
 			const effective = projectManagedSettings(selection.values ?? {}, declaredDefinitions, message => parseErrors.push({ stage: 'project', message }));
+
+			// Remember which managed-settings keys actually reached policy evaluation, and from which
+			// channel, so the Policy-Controlled Settings table can attribute them accurately.
+			managedSettingsActiveSource = selection.source;
+			for (const key of Object.keys(effective)) {
+				activeManagedSettingKeys.add(key);
+			}
 
 			// JSON payloads: the structured keys carry a JSON string that PolicyConfiguration parses
 			// back into the object/array-typed setting on read. Re-parse exactly those keys with the
@@ -965,8 +1005,26 @@ class PolicyDiagnosticsAction extends Action2 {
 				}
 			};
 
+			// A managed-settings-driven policy is hosted by AccountPolicyService but its value really
+			// originates from a delivery channel (server / native MDM / file). Attribute it to that
+			// channel when its declared managed key actually reached policy evaluation, so the report
+			// doesn't misleadingly credit every such policy to AccountPolicyService. When the Account
+			// Policy Gate is actively restricting, the value comes from the gate's restricted value
+			// (which overrides managed settings), so don't credit the channel in that case.
+			const gateInfo = accountPolicyGateService.gateInfo;
+			const gateRestricted = gateInfo.state === AccountPolicyGateState.Restricted
+				&& gateInfo.reason !== AccountPolicyGateUnsatisfiedReason.PolicyNotResolved;
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const getRefinedPolicySource = (item: { name: string; property: any }): string => {
+				const declaredKeys = item.property.policy?.managedSettings ? Object.keys(item.property.policy.managedSettings) : [];
+				if (!gateRestricted && managedSettingsActiveSource !== 'none' && declaredKeys.some(key => activeManagedSettingKeys.has(key))) {
+					return `Managed Settings: ${managedSettingsSourceShortLabel(managedSettingsActiveSource)}`;
+				}
+				return getPolicySource(item.name);
+			};
+
 			content += '### Applied Policy\n\n';
-			appliedPolicy.sort((a, b) => getPolicySource(a.name).localeCompare(getPolicySource(b.name)) || a.name.localeCompare(b.name));
+			appliedPolicy.sort((a, b) => getRefinedPolicySource(a).localeCompare(getRefinedPolicySource(b)) || a.name.localeCompare(b.name));
 			if (appliedPolicy.length > 0) {
 				content += '| Setting Key | Policy Name | Policy Source | Managed Settings | Default Value | Current Value | Policy Value |\n';
 				content += '|-------------|-------------|---------------|------------------|---------------|---------------|-------------|\n';
@@ -975,7 +1033,7 @@ class PolicyDiagnosticsAction extends Action2 {
 					const defaultValue = JSON.stringify(setting.property.default);
 					const currentValue = JSON.stringify(setting.inspection.value);
 					const policyValue = JSON.stringify(setting.inspection.policyValue);
-					const policySource = getPolicySource(setting.name);
+					const policySource = getRefinedPolicySource(setting);
 					const managedSettingsKeys = setting.property.policy?.managedSettings ? Object.keys(setting.property.policy.managedSettings).join(', ') : '';
 
 					content += `| ${setting.key} | ${setting.name} | ${policySource} | ${managedSettingsKeys || '*n/a*'} | \`${defaultValue}\` | \`${currentValue}\` | \`${policyValue}\` |\n`;

--- a/src/vs/workbench/electron-browser/desktop.main.ts
+++ b/src/vs/workbench/electron-browser/desktop.main.ts
@@ -52,8 +52,9 @@ import { FileUserDataProvider } from '../../platform/userData/common/fileUserDat
 import { IUserDataProfilesService, reviveProfile } from '../../platform/userDataProfile/common/userDataProfile.js';
 import { UserDataProfilesService } from '../../platform/userDataProfile/common/userDataProfileIpc.js';
 import { PolicyChannelClient } from '../../platform/policy/common/policyIpc.js';
-import { CopilotManagedSettingsChannelClient } from '../../platform/policy/common/copilotManagedSettingsIpc.js';
-import { ICopilotManagedSettingsService } from '../../platform/policy/common/copilotManagedSettings.js';
+import { NativeManagedSettingsChannelClient } from '../../platform/policy/common/nativeManagedSettingsIpc.js';
+import { INativeManagedSettingsService, IFileManagedSettingsService } from '../../platform/policy/common/copilotManagedSettings.js';
+import { FileManagedSettingsChannelClient } from '../../platform/policy/common/fileManagedSettingsIpc.js';
 import { IPolicyService } from '../../platform/policy/common/policy.js';
 import { UserDataProfileService } from '../services/userDataProfile/common/userDataProfileService.js';
 import { IUserDataProfileService } from '../services/userDataProfile/common/userDataProfile.js';
@@ -220,9 +221,11 @@ export class DesktopMain extends Disposable {
 		// Policies
 		let policyService: IPolicyService;
 		const policyChannel = this.configuration.policiesData ? this._register(new PolicyChannelClient(this.configuration.policiesData, mainProcessService.getChannel('policy'))) : undefined;
-		const copilotManagedSettings = this._register(new CopilotManagedSettingsChannelClient(mainProcessService.getChannel('copilotManagedSettings')));
-		serviceCollection.set(ICopilotManagedSettingsService, copilotManagedSettings);
-		const accountPolicy = this._register(new AccountPolicyService(logService, defaultAccountService, policyChannel, copilotManagedSettings));
+		const nativeManagedSettings = this._register(new NativeManagedSettingsChannelClient(mainProcessService.getChannel('nativeManagedSettings')));
+		serviceCollection.set(INativeManagedSettingsService, nativeManagedSettings);
+		const fileManagedSettings = this._register(new FileManagedSettingsChannelClient(mainProcessService.getChannel('fileManagedSettings')));
+		serviceCollection.set(IFileManagedSettingsService, fileManagedSettings);
+		const accountPolicy = this._register(new AccountPolicyService(logService, defaultAccountService, policyChannel, nativeManagedSettings, fileManagedSettings));
 		if (policyChannel) {
 			policyService = this._register(new MultiplexPolicyService([policyChannel, accountPolicy], logService));
 		} else {

--- a/src/vs/workbench/services/accounts/browser/managedSettings.ts
+++ b/src/vs/workbench/services/accounts/browser/managedSettings.ts
@@ -4,10 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IPolicyData } from '../../../../base/common/defaultAccount.js';
-import { IExtraKnownMarketplaceEntry, IStrictMarketplaceSource, extraKnownMarketplacesToConfigDict } from '../../../../base/common/managedSettings.js';
-import { ManagedSettingValue } from '../../../../base/common/policy.js';
-import { isObject, isString } from '../../../../base/common/types.js';
-import { COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_STRICT_MARKETPLACES_KEY, flattenManagedSettings } from '../../../../platform/policy/common/copilotManagedSettings.js';
+import { normalizeManagedSettings } from '../../../../platform/policy/common/copilotManagedSettings.js';
 
 /**
  * Response shape from the Copilot `/copilot_internal/managed_settings` endpoint.
@@ -30,129 +27,20 @@ export interface IManagedSettingsResponse {
 		| { readonly source: 'github'; readonly repo: string; readonly ref?: string }
 		| { readonly source: 'git'; readonly url: string; readonly ref?: string };
 	}>;
-	readonly strictKnownMarketplaces?: readonly IStrictMarketplaceSource[];
+	readonly strictKnownMarketplaces?: readonly unknown[];
 	/** Any unknown keys in the response are accepted for forward compatibility. */
 	readonly [key: string]: unknown;
 }
 
 /**
- * Descriptor for a structured (object/array) managed setting: one carried across both delivery
- * channels as a canonical JSON string under a single key. This table is the single place that
- * knows how to turn a server `managed_settings` response field into that canonical value, so
- * adding a structured key is one row here (plus its {@link IManagedSettingsResponse} field — the
- * `responseField` union is hand-maintained in sync with the interface's named fields, not
- * compiler-enforced, because the response's index signature widens `keyof` to `string`; the
- * `adaptManagedSettings` tests are the drift backstop — and the policy declaration that reads
- * the bag key).
- */
-interface IStructuredManagedSetting {
-	/** Canonical managed-settings bag key (the dot-path constant) the JSON string is stored under. */
-	readonly key: string;
-	/** Server response field this descriptor consumes; excluded from the scalar flatten and fed to `encode`. */
-	readonly responseField: 'enabledPlugins' | 'extraKnownMarketplaces' | 'strictKnownMarketplaces';
-	/**
-	 * Normalize the raw server value into the canonical pre-stringify shape an admin authors via
-	 * native MDM. Return `undefined` to omit the key (absent or malformed value). Note an empty
-	 * array (the `strictKnownMarketplaces` lockdown case) is returned as-is, not omitted.
-	 */
-	readonly encode: (value: unknown, onWarn?: (msg: string) => void) => unknown;
-}
-
-const STRUCTURED_MANAGED_SETTINGS: readonly IStructuredManagedSetting[] = [
-	{
-		key: COPILOT_ENABLED_PLUGINS_KEY,
-		responseField: 'enabledPlugins',
-		encode: value => isObject(value) ? value : undefined,
-	},
-	{
-		key: COPILOT_STRICT_MARKETPLACES_KEY,
-		responseField: 'strictKnownMarketplaces',
-		encode: value => Array.isArray(value) ? value : undefined,
-	},
-	{
-		key: COPILOT_EXTRA_MARKETPLACES_KEY,
-		responseField: 'extraKnownMarketplaces',
-		encode: (value, onWarn) => extraKnownMarketplacesToConfigDict(normalizeExtraKnownMarketplaces(value, onWarn)),
-	},
-];
-
-/**
  * Adapt the `managed_settings` API response into the `managedSettings` slice of
- * {@link IPolicyData} that the policy framework consumes. This is the single
- * server-side normalizer: it encodes the response into the SAME canonical
- * `managedSettings` shape an admin authors via native MDM, so downstream
- * projection and policy `value()` callbacks behave identically regardless of
- * source. It does not itself enforce the declared `managedSettings` schema —
- * dropping undeclared or type-mismatched keys happens later, at the
- * `projectManagedSettings` step.
- *
- * - Scalar leaves (`permissions.*` and any forward-compatible scalar keys) are
- *   flattened into dot-separated keys.
- * - Structured settings (declared in {@link STRUCTURED_MANAGED_SETTINGS}) are
- *   carried as canonical JSON strings under a single key each — the same shape an
- *   admin authors via native MDM. `PolicyConfiguration` parses the JSON back into
- *   the object-typed setting on read. `extraKnownMarketplaces` is normalized from
- *   the API's `Record<id, { source }>` map to the `{ [name]: url-or-shorthand }` dict.
- *
- * Malformed marketplace entries are dropped (with an optional warning via
- * {@link onWarn}) rather than throwing, so a bad enterprise settings file degrades
- * gracefully instead of blocking startup.
+ * {@link IPolicyData} that the policy framework consumes. This is a thin wrapper
+ * around {@link normalizeManagedSettings} — the single normalization path shared
+ * by all delivery channels (server API, file-based, native MDM) — so downstream
+ * projection and policy `value()` callbacks behave identically regardless of source.
  *
  * Exported for unit-testing the shape transformation independently of network I/O.
  */
 export function adaptManagedSettings(response: IManagedSettingsResponse, onWarn?: (msg: string) => void): Partial<IPolicyData> {
-	// Spread + delete (not for..in + assignment) so the scalar remainder keeps exact `{ ...rest }`
-	// semantics: it never triggers the inherited `__proto__` setter for a server-sent own
-	// `__proto__` key, matching the original destructuring rest.
-	const scalarRest: Record<string, unknown> = { ...response };
-	for (const setting of STRUCTURED_MANAGED_SETTINGS) {
-		delete scalarRest[setting.responseField];
-	}
-
-	const managedSettings: Record<string, ManagedSettingValue> = { ...flattenManagedSettings(scalarRest) };
-
-	for (const setting of STRUCTURED_MANAGED_SETTINGS) {
-		const encoded = setting.encode(response[setting.responseField], onWarn);
-		if (encoded !== undefined) {
-			managedSettings[setting.key] = JSON.stringify(encoded);
-		}
-	}
-
-	return { managedSettings };
-}
-
-/**
- * Normalize the endpoint's `{ [id]: { source } }` marketplace map into the
- * {@link IExtraKnownMarketplaceEntry} array, preserving the marketplace `name`,
- * source discriminator, and any `ref`. Malformed or off-spec entries are dropped
- * (with an optional warning via {@link onWarn}).
- */
-function normalizeExtraKnownMarketplaces(value: unknown, onWarn?: (msg: string) => void): IExtraKnownMarketplaceEntry[] | undefined {
-	if (!isObject(value)) {
-		return undefined;
-	}
-	const seen = new Set<string>();
-	const entries: IExtraKnownMarketplaceEntry[] = [];
-	for (const [name, entry] of Object.entries(value)) {
-		if (!isObject(entry) || !isObject(entry.source)) {
-			onWarn?.(`[DefaultAccount] Skipping malformed extraKnownMarketplaces entry "${name}": expected { source: { source, repo|url } }`);
-			continue;
-		}
-		const src = entry.source as { source?: string; repo?: string; url?: string; ref?: string };
-		let normalized: IExtraKnownMarketplaceEntry | undefined;
-		if (src.source === 'github' && isString(src.repo)) {
-			normalized = { name, source: { source: 'github', repo: src.repo, ...(src.ref ? { ref: src.ref } : {}) } };
-		} else if (src.source === 'git' && isString(src.url)) {
-			normalized = { name, source: { source: 'git', url: src.url, ...(src.ref ? { ref: src.ref } : {}) } };
-		} else if (src.source === 'github' || src.source === 'git') {
-			onWarn?.(`[DefaultAccount] Skipping extraKnownMarketplaces entry "${name}": source "${src.source}" requires ${src.source === 'github' ? '"repo"' : '"url"'}`);
-		} else {
-			onWarn?.(`[DefaultAccount] Skipping extraKnownMarketplaces entry "${name}": unknown source type "${src.source}"`);
-		}
-		if (normalized && !seen.has(name)) {
-			seen.add(name);
-			entries.push(normalized);
-		}
-	}
-	return entries;
+	return { managedSettings: normalizeManagedSettings(response as Record<string, unknown>, onWarn) };
 }

--- a/src/vs/workbench/services/policies/common/accountPolicyService.ts
+++ b/src/vs/workbench/services/policies/common/accountPolicyService.ts
@@ -11,7 +11,7 @@ import { localize } from '../../../../nls.js';
 import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { ICopilotManagedSettingsService, collectManagedSettingsDefinitions, hasManagedSettingsDefinitions, projectManagedSettings, selectManagedSettings } from '../../../../platform/policy/common/copilotManagedSettings.js';
+import { INativeManagedSettingsService, IFileManagedSettingsService, collectManagedSettingsDefinitions, hasManagedSettingsDefinitions, projectManagedSettings, selectManagedSettings } from '../../../../platform/policy/common/copilotManagedSettings.js';
 import { AbstractPolicyService, getRestrictedPolicyValue, IPolicyService, PolicyDefinition, PolicyValue } from '../../../../platform/policy/common/policy.js';
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 
@@ -72,18 +72,21 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 
 	// Read-only — the MultiplexPolicyService owns calling updatePolicyDefinitions.
 	private readonly managedPolicyReader?: IPolicyService;
-	private readonly copilotManagedSettingsService?: ICopilotManagedSettingsService;
+	private readonly nativeManagedSettingsService?: INativeManagedSettingsService;
+	private readonly fileManagedSettingsService?: IFileManagedSettingsService;
 
 	constructor(
 		@ILogService private readonly logService: ILogService,
 		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
 		managedPolicyService?: IPolicyService,
-		copilotManagedSettingsService?: ICopilotManagedSettingsService,
+		nativeManagedSettingsService?: INativeManagedSettingsService,
+		fileManagedSettingsService?: IFileManagedSettingsService,
 	) {
 		super();
 
 		this.managedPolicyReader = managedPolicyService;
-		this.copilotManagedSettingsService = copilotManagedSettingsService;
+		this.nativeManagedSettingsService = nativeManagedSettingsService;
+		this.fileManagedSettingsService = fileManagedSettingsService;
 
 		this._updatePolicyDefinitions(this.policyDefinitions);
 		this._register(this.defaultAccountService.onDidChangePolicyData(() => {
@@ -99,8 +102,13 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 				}
 			}));
 		}
-		if (this.copilotManagedSettingsService) {
-			this._register(this.copilotManagedSettingsService.onDidChangeManagedSettings(() => {
+		if (this.nativeManagedSettingsService) {
+			this._register(this.nativeManagedSettingsService.onDidChangeManagedSettings(() => {
+				this._updatePolicyDefinitions(this.policyDefinitions);
+			}));
+		}
+		if (this.fileManagedSettingsService) {
+			this._register(this.fileManagedSettingsService.onDidChangeManagedSettings(() => {
 				this._updatePolicyDefinitions(this.policyDefinitions);
 			}));
 		}
@@ -170,20 +178,22 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 	}
 
 	private async updateCopilotManagedSettingDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): Promise<ManagedSettingsData | undefined> {
-		if (!this.copilotManagedSettingsService || !hasManagedSettingsDefinitions(policyDefinitions)) {
-			return this.copilotManagedSettingsService?.managedSettings;
+		if (!this.nativeManagedSettingsService || !hasManagedSettingsDefinitions(policyDefinitions)) {
+			return this.nativeManagedSettingsService?.managedSettings;
 		}
 
-		return this.copilotManagedSettingsService.updatePolicyDefinitions(policyDefinitions);
+		return this.nativeManagedSettingsService.updatePolicyDefinitions(policyDefinitions);
 	}
 
-	private getPolicyData(managedSettings?: ManagedSettingsData): IPolicyData | undefined {
+	private getPolicyData(mdmManagedSettings?: ManagedSettingsData): IPolicyData | undefined {
 		const accountPolicyData = this.defaultAccountService.policyData ?? undefined;
-		const nativeManagedSettings = managedSettings ?? this.copilotManagedSettingsService?.managedSettings;
+		const nativeManagedSettings = mdmManagedSettings ?? this.nativeManagedSettingsService?.managedSettings;
+		const fileManagedSettings = this.fileManagedSettingsService?.managedSettings;
 
-		// Single authoritative source: server-delivered managed settings win over native MDM.
+		// Single authoritative source: server-delivered managed settings win over native MDM, which
+		// in turn win over the file-based channel. The channels are never merged.
 		// See `.github/skills/add-policy/github-managed-settings.md` for the precedence rationale.
-		const selection = selectManagedSettings(accountPolicyData?.managedSettings, nativeManagedSettings);
+		const selection = selectManagedSettings(accountPolicyData?.managedSettings, nativeManagedSettings, fileManagedSettings);
 		if (!accountPolicyData && selection.source === 'none') {
 			return undefined;
 		}

--- a/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
@@ -12,7 +12,7 @@ import { Extensions, IConfigurationNode, IConfigurationRegistry } from '../../..
 import { DefaultConfiguration, PolicyConfiguration } from '../../../../../platform/configuration/common/configurations.js';
 import { IDefaultAccountProvider, IDefaultAccountService } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
-import { COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_ENABLED_PLUGINS_KEY, ICopilotManagedSettingsService } from '../../../../../platform/policy/common/copilotManagedSettings.js';
+import { COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_ENABLED_PLUGINS_KEY, INativeManagedSettingsService, IFileManagedSettingsService } from '../../../../../platform/policy/common/copilotManagedSettings.js';
 import { AbstractPolicyService, IPolicyService, PolicyDefinition, PolicyValue } from '../../../../../platform/policy/common/policy.js';
 import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { TestProductService } from '../../../../test/common/workbenchTestServices.js';
@@ -258,9 +258,9 @@ suite('AccountPolicyService', () => {
 		});
 	});
 
-	test('should apply managed-settings policy data from Copilot managed-settings service', async () => {
-		const copilotManagedSettingsService = disposables.add(new FakeCopilotManagedSettingsService({ [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' }));
-		policyService = disposables.add(new AccountPolicyService(logService, defaultAccountService, undefined, copilotManagedSettingsService));
+	test('should apply managed-settings policy data from native managed-settings service', async () => {
+		const nativeManagedSettingsService = disposables.add(new FakeNativeManagedSettingsService({ [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' }));
+		policyService = disposables.add(new AccountPolicyService(logService, defaultAccountService, undefined, nativeManagedSettingsService));
 		const defaultConfiguration = disposables.add(new DefaultConfiguration(new NullLogService()));
 		await defaultConfiguration.initialize();
 		policyConfiguration = disposables.add(new PolicyConfiguration(defaultConfiguration, policyService, new NullLogService()));
@@ -273,7 +273,7 @@ suite('AccountPolicyService', () => {
 		assert.deepStrictEqual({
 			policy: policyService.getPolicyValue('PolicySettingF'),
 			configuration: policyConfiguration.configurationModel.getValue('setting.F'),
-			registeredManagedSettings: copilotManagedSettingsService.registeredManagedSettings,
+			registeredManagedSettings: nativeManagedSettingsService.registeredManagedSettings,
 		}, {
 			policy: false,
 			configuration: false,
@@ -288,8 +288,8 @@ suite('AccountPolicyService', () => {
 		// Server says 'enable', native MDM says 'disable'. The server is the authoritative
 		// source when present, so native MDM is ignored entirely and the gated policy is NOT
 		// forced to `false`.
-		const copilotManagedSettingsService = disposables.add(new FakeCopilotManagedSettingsService({ [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' }));
-		policyService = disposables.add(new AccountPolicyService(logService, defaultAccountService, undefined, copilotManagedSettingsService));
+		const nativeManagedSettingsService = disposables.add(new FakeNativeManagedSettingsService({ [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' }));
+		policyService = disposables.add(new AccountPolicyService(logService, defaultAccountService, undefined, nativeManagedSettingsService));
 		const defaultConfiguration = disposables.add(new DefaultConfiguration(new NullLogService()));
 		await defaultConfiguration.initialize();
 		policyConfiguration = disposables.add(new PolicyConfiguration(defaultConfiguration, policyService, new NullLogService()));
@@ -306,8 +306,8 @@ suite('AccountPolicyService', () => {
 	test('managed settings: native MDM applies when the server provides no managed settings', async () => {
 		// No server managed settings — native MDM is the authoritative source and forces the
 		// gated policy to `false`.
-		const copilotManagedSettingsService = disposables.add(new FakeCopilotManagedSettingsService({ [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' }));
-		policyService = disposables.add(new AccountPolicyService(logService, defaultAccountService, undefined, copilotManagedSettingsService));
+		const nativeManagedSettingsService = disposables.add(new FakeNativeManagedSettingsService({ [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' }));
+		policyService = disposables.add(new AccountPolicyService(logService, defaultAccountService, undefined, nativeManagedSettingsService));
 		const defaultConfiguration = disposables.add(new DefaultConfiguration(new NullLogService()));
 		await defaultConfiguration.initialize();
 		policyConfiguration = disposables.add(new PolicyConfiguration(defaultConfiguration, policyService, new NullLogService()));
@@ -320,6 +320,45 @@ suite('AccountPolicyService', () => {
 		assert.strictEqual(policyService.getPolicyValue('PolicySettingF'), false);
 	});
 
+	test('managed settings: three-channel precedence Server > MDM > File', async () => {
+		// All three channels provide the same key with different values.
+		// Server says 'enable', MDM says 'disable', File says 'file-value'.
+		// Server should win.
+		const fileManagedSettingsService = new FakeFileManagedSettingsService({ [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'file-value' });
+		const nativeManagedSettingsService = disposables.add(new FakeNativeManagedSettingsService({ [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' }));
+		policyService = disposables.add(new AccountPolicyService(logService, defaultAccountService, undefined, nativeManagedSettingsService, fileManagedSettingsService));
+		const defaultConfiguration = disposables.add(new DefaultConfiguration(new NullLogService()));
+		await defaultConfiguration.initialize();
+		policyConfiguration = disposables.add(new PolicyConfiguration(defaultConfiguration, policyService, new NullLogService()));
+
+		const policyData: IPolicyData = { managedSettings: { [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'enable' } };
+		defaultAccountService.setDefaultAccountProvider(new DefaultAccountProvider(BASE_DEFAULT_ACCOUNT, policyData));
+		await defaultAccountService.refresh();
+
+		await policyConfiguration.initialize();
+
+		// Server value 'enable' wins — policy is not forced to false
+		assert.strictEqual(policyService.getPolicyValue('PolicySettingF'), undefined);
+	});
+
+	test('managed settings: file-based settings apply when server and MDM are empty', async () => {
+		// Only the file channel provides a value — it should be used.
+		const fileManagedSettingsService = new FakeFileManagedSettingsService({ [COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY]: 'disable' });
+		const nativeManagedSettingsService = disposables.add(new FakeNativeManagedSettingsService({}));
+		policyService = disposables.add(new AccountPolicyService(logService, defaultAccountService, undefined, nativeManagedSettingsService, fileManagedSettingsService));
+		const defaultConfiguration = disposables.add(new DefaultConfiguration(new NullLogService()));
+		await defaultConfiguration.initialize();
+		policyConfiguration = disposables.add(new PolicyConfiguration(defaultConfiguration, policyService, new NullLogService()));
+
+		defaultAccountService.setDefaultAccountProvider(new DefaultAccountProvider(BASE_DEFAULT_ACCOUNT, {}));
+		await defaultAccountService.refresh();
+
+		await policyConfiguration.initialize();
+
+		// File value 'disable' applies — policy is forced to false
+		assert.strictEqual(policyService.getPolicyValue('PolicySettingF'), false);
+	});
+
 	test('managed settings: an object-typed setting resolves identically from server and native MDM JSON strings', async () => {
 		// Structured-setting invariant: whether the canonical JSON string arrives via the server
 		// account policy bag or via native MDM, PolicyConfiguration must parse it back into the
@@ -329,10 +368,10 @@ suite('AccountPolicyService', () => {
 
 		const resolveEnabledPlugins = async (source: { server?: string; mdm?: string }): Promise<unknown> => {
 			const accountService = disposables.add(new DefaultAccountService(TestProductService));
-			const copilotManagedSettingsService = disposables.add(new FakeCopilotManagedSettingsService(
+			const nativeManagedSettingsService = disposables.add(new FakeNativeManagedSettingsService(
 				source.mdm !== undefined ? { [COPILOT_ENABLED_PLUGINS_KEY]: source.mdm } : {},
 			));
-			const svc = disposables.add(new AccountPolicyService(logService, accountService, undefined, copilotManagedSettingsService));
+			const svc = disposables.add(new AccountPolicyService(logService, accountService, undefined, nativeManagedSettingsService));
 			const defaultConfiguration = disposables.add(new DefaultConfiguration(new NullLogService()));
 			await defaultConfiguration.initialize();
 			const config = disposables.add(new PolicyConfiguration(defaultConfiguration, svc, new NullLogService()));
@@ -403,7 +442,7 @@ suite('AccountPolicyService', () => {
 		protected async _updatePolicyDefinitions(): Promise<void> { /* no-op */ }
 	}
 
-	class FakeCopilotManagedSettingsService implements ICopilotManagedSettingsService {
+	class FakeNativeManagedSettingsService implements INativeManagedSettingsService {
 		readonly _serviceBrand: undefined;
 		private readonly _onDidChangeManagedSettings = new Emitter<ManagedSettingsData>();
 		readonly onDidChangeManagedSettings = this._onDidChangeManagedSettings.event;
@@ -432,6 +471,14 @@ suite('AccountPolicyService', () => {
 		dispose(): void {
 			this._onDidChangeManagedSettings.dispose();
 		}
+	}
+
+	class FakeFileManagedSettingsService implements IFileManagedSettingsService {
+		readonly _serviceBrand: undefined;
+		private readonly _onDidChangeManagedSettings = new Emitter<ManagedSettingsData>();
+		readonly onDidChangeManagedSettings = this._onDidChangeManagedSettings.event;
+
+		constructor(public managedSettings: ManagedSettingsData = {}) { }
 	}
 
 	async function setupGate(opts: {


### PR DESCRIPTION
Adds a **file-based** delivery channel for Copilot managed settings, so enterprises using config management (Chef, Puppet, Ansible) can deploy settings without MDM.

The main process reads `managed-settings.json` from a well-known per-OS path and exposes it to renderer windows over IPC, mirroring the existing server and native-MDM channels.

| Platform | Path |
|----------|------|
| macOS | `/Library/Application Support/GitHubCopilot/managed-settings.json` |
| Windows | `%ProgramFiles%\GitHubCopilot\managed-settings.json` |
| Linux | `/etc/github-copilot/managed-settings.json` |

## Precedence

**Server > native MDM > file** — a single authoritative source wins; the channels are **not** merged. The file channel slots in as the lowest precedence via the shared `selectManagedSettings(server, nativeMdm, file)`.

## Notes

- `normalizeManagedSettings()` is the single normalizer shared by all channels (the server adapter `adaptManagedSettings()` is now a thin wrapper around it).
- `FileManagedSettingsService` reads/watches the file via `IFileService` (follows the `FilePolicyService` pattern); IPC follows `CopilotManagedSettingsIpc`.
- **Developer: Policy Diagnostics** gains a File section, a `'file'` active-source label, and now attributes managed-settings-driven policies to their actual channel (e.g. `Managed Settings: File (managed-settings.json)`) instead of the generic `AccountPolicyService`.

Rebased onto latest `main` and aligned with the managed-settings refactor in #322439.

Ref: microsoft/vscode-internalbacklog#7932
