### PR TITLE
Provide tools to local agents in the first message

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -9,6 +9,7 @@ import * as dom from '../../../../base/browser/dom.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { Disposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { Button } from '../../../../base/browser/ui/button/button.js';
@@ -53,10 +54,15 @@ import { AgentHostInputCompletionHandler } from './agentHostInputCompletions.js'
 import { IChatModelInputState } from '../../../../workbench/contrib/chat/common/model/chatModel.js';
 import { IChatRequestVariableEntry, isExplicitFileOrImageVariableEntry, toFileVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../../workbench/contrib/chat/common/constants.js';
+import { ChatSelectedTools } from '../../../../workbench/contrib/chat/browser/widget/input/chatSelectedTools.js';
+import { ChatMode } from '../../../../workbench/contrib/chat/common/chatModes.js';
+import { showToolsPicker } from '../../../../workbench/contrib/chat/browser/actions/chatToolPicker.js';
+import { ILanguageModelsService, ILanguageModelChatMetadataAndIdentifier } from '../../../../workbench/contrib/chat/common/languageModels.js';
+import { SessionType } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ChatHistoryNavigator } from '../../../../workbench/contrib/chat/common/widget/chatWidgetHistoryService.js';
 import { IHistoryNavigationWidget } from '../../../../base/browser/history.js';
 import { registerAndCreateHistoryNavigationContext, IHistoryNavigationContext } from '../../../../platform/history/browser/contextScopedHistoryWidget.js';
-import { autorun, IObservable } from '../../../../base/common/observable.js';
+import { autorun, constObservable, derived, IObservable } from '../../../../base/common/observable.js';
 import { ChatInputNotificationWidget } from '../../../../workbench/contrib/chat/browser/widget/input/chatInputNotificationWidget.js';
 import { INewChatModelPickerService, NewChatModelPickerService } from './newChatModelPicker.js';
 import { ModelPicker, ModelPickerActionViewItem } from './modelPicker.js';
@@ -147,6 +153,10 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 	// Attached context
 	private readonly _contextAttachments: NewChatContextAttachments;
 
+	// Tool selection (local sessions only)
+	private readonly _toolsModel: IObservable<ILanguageModelChatMetadataAndIdentifier | undefined>;
+	private readonly _selectedTools: ChatSelectedTools;
+
 	// Slash commands
 	private _slashCommandHandler: SlashCommandHandler | undefined;
 	private _agentHostInputCompletionHandler: AgentHostInputCompletionHandler | undefined;
@@ -185,12 +195,28 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		@IStorageService private readonly storageService: IStorageService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
+		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
 	) {
 		super();
 		this._scopedInstantiationService = this._register(this.instantiationService.createChild(new ServiceCollection(
 			[INewChatModelPickerService, new NewChatModelPickerService()],
 			[ISessionInputContext, new SessionInputContext(this.options.session)],
 		)));
+		// Tool selection for the new-session composer. Local sessions always run
+		// in Agent mode (their chat mode is never set, so the provider defaults
+		// to Agent), so the picker is bound to the builtin Agent mode and the
+		// session's selected model. It edits the same global tool-enablement
+		// memento the local provider reads when it dispatches the first send, so
+		// no extra plumbing through the send path is needed.
+		this._toolsModel = derived(reader => {
+			const id = this.options.session.read(reader)?.modelId.read(reader);
+			if (!id) {
+				return undefined;
+			}
+			const metadata = this.languageModelsService.lookupLanguageModel(id);
+			return metadata ? { identifier: id, metadata } : undefined;
+		});
+		this._selectedTools = this._register(this._scopedInstantiationService.createInstance(ChatSelectedTools, constObservable(ChatMode.Agent), this._toolsModel));
 		this._history = this._register(this.instantiationService.createInstance(ChatHistoryNavigator, ChatAgentLocation.Chat));
 		if (this.options.historyKey) {
 			this._register(autorun(reader => this._setHistoryKey(this.options.historyKey?.read(reader))));
@@ -490,6 +516,60 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		}));
 	}
 
+	/**
+	 * Renders the "Configure Tools..." button, mirroring the tool selector in
+	 * the normal chat input. Shown only for local sessions, where tool selection
+	 * actually affects the dispatched request; other providers route to backends
+	 * that own their own tool set, so the button stays hidden for them.
+	 */
+	private _createToolsButton(container: HTMLElement): void {
+		const toolsButton = dom.append(container, dom.$('.sessions-chat-attach-button.sessions-chat-tools-button'));
+		const toolsButtonLabel = localize("configureTools", "Configure Tools...");
+		toolsButton.tabIndex = 0;
+		toolsButton.role = 'button';
+		toolsButton.ariaLabel = toolsButtonLabel;
+		this._register(this.hoverService.setupDelayedHover(toolsButton, {
+			content: toolsButtonLabel,
+			position: { hoverPosition: HoverPosition.BELOW },
+			appearance: { showPointer: true }
+		}));
+		// Decorative icon — the button itself carries the accessible name, so
+		// hide the icon from the accessibility tree to avoid a spurious announcement.
+		const toolsIcon = dom.append(toolsButton, renderIcon(Codicon.settings));
+		toolsIcon.setAttribute('aria-hidden', 'true');
+		// Activate on click and on Enter/Space, matching native button behavior.
+		const openToolsPicker = () => this._showToolsPicker();
+		this._register(dom.addDisposableListener(toolsButton, dom.EventType.CLICK, () => openToolsPicker()));
+		this._register(dom.addDisposableListener(toolsButton, dom.EventType.KEY_DOWN, e => {
+			const event = new StandardKeyboardEvent(e);
+			if (event.equals(KeyCode.Enter) || event.equals(KeyCode.Space)) {
+				event.preventDefault();
+				event.stopPropagation();
+				openToolsPicker();
+			}
+		}));
+		this._register(autorun(reader => {
+			const isLocal = this.options.session.read(reader)?.sessionType === SessionType.Local;
+			toolsButton.style.display = isLocal ? '' : 'none';
+		}));
+	}
+
+	private async _showToolsPicker(): Promise<void> {
+		const placeholder = localize("configureTools.placeholder", "Select tools that are available to chat.");
+		const description = localize("configureTools.description", "The selected tools are applied to new local sessions that use the default agent.");
+		const result = await this.instantiationService.invokeFunction(
+			showToolsPicker,
+			placeholder,
+			'sessionsNewChatInput',
+			description,
+			() => this._selectedTools.entriesMap.get(),
+			this._toolsModel.get()?.metadata,
+		);
+		if (result) {
+			this._selectedTools.set(result, false);
+		}
+	}
+
 	private _createInputToolbar(container: HTMLElement): void {
 		const toolbar = dom.append(container, dom.$('.sessions-chat-toolbar'));
 
@@ -508,6 +588,10 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 				return undefined;
 			},
 		}));
+
+		// Tools picker, grouped with the mode/model pickers to match the normal
+		// chat input where "Configure Tools..." sits alongside them.
+		this._createToolsButton(configContainer);
 
 		dom.append(toolbar, dom.$('.sessions-chat-toolbar-spacer'));
 

--- a/src/vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp.ts
@@ -27,6 +27,7 @@ export class SessionsChatAccessibilityHelp implements IAccessibleViewImplementat
 		content.push(localize('sessionsChat.input', "You are in the chat input. Type a message and press Enter to send it."));
 		content.push(localize('sessionsChat.inputBackground', "Press Alt+Enter to start the session in the background without navigating into it. The started session appears in the Chat Sessions view."));
 		content.push(localize('sessionsChat.workspace', "Shift+Tab to navigate to the workspace picker and choose a workspace for your session."));
+		content.push(localize('sessionsChat.configureTools', "For local sessions, Tab from the input to reach the Configure Tools button, then press Enter or Space to choose which tools are available to the agent."));
 		content.push(localize('sessionsChat.mobileConfig', "On mobile, the mode and model pickers appear as tappable chips below the input. Tap a chip to open a bottom sheet where you can change the selection."));
 		content.push(localize('sessionsChat.history', "Use up and down arrows to navigate your request history in the input box."));
 		content.push(localize('sessionsChat.navigatePreviousSession', "Navigate to the previous session in the list{0}.", '<keybinding:sessionsViewPane.navigatePreviousSession>'));

--- a/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
@@ -17,7 +17,7 @@ import { ISession, IChat, ISessionGitRepository, ISessionFolder, ISessionWorkspa
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, ChatPermissionLevel, isChatPermissionLevel } from '../../../../../workbench/contrib/chat/common/constants.js';
 import { basename, dirname, isEqual } from '../../../../../base/common/resources.js';
 import { ISendRequestOptions, ISessionChangeEvent, ISessionModelPickerOptions, ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
-import { isBuiltinChatMode, IChatMode } from '../../../../../workbench/contrib/chat/common/chatModes.js';
+import { isBuiltinChatMode, ChatMode, IChatMode } from '../../../../../workbench/contrib/chat/common/chatModes.js';
 import { IChatModel } from '../../../../../workbench/contrib/chat/common/model/chatModel.js';
 import { IGitService } from '../../../../../workbench/contrib/git/common/gitService.js';
 import { localize } from '../../../../../nls.js';
@@ -29,6 +29,8 @@ import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.j
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService } from '../../../../../workbench/contrib/chat/common/languageModels.js';
 import { ILanguageModelToolsService } from '../../../../../workbench/contrib/chat/common/tools/languageModelToolsService.js';
+import { ChatSelectedTools } from '../../../../../workbench/contrib/chat/browser/widget/input/chatSelectedTools.js';
+import { UserSelectedTools } from '../../../../../workbench/contrib/chat/common/participants/chatAgents.js';
 import { createChangesets } from '../../copilotChatSessions/browser/copilotChatSessionsChangesets.js';
 import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
@@ -1034,6 +1036,7 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 				permissionLevel,
 			},
 			attachedContext,
+			userSelectedTools: this._computeUserSelectedTools(session),
 		};
 
 		// Set model/mode/permission state on the chat model before sending
@@ -1042,6 +1045,34 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 			return await this.chatService.sendRequest(chatResource, query, sendOptions);
 		} finally {
 			modelRef?.dispose();
+		}
+	}
+
+	/**
+	 * Computes the tool enablement snapshot for a headless send, matching what
+	 * the chat widget would pass on a normal turn. Without this, the first
+	 * request to a new session reaches the agent with no tools, because
+	 * `extHostChatAgents2.getToolsForRequest` maps an undefined selection to an
+	 * empty tool set. Reuses {@link ChatSelectedTools} so the session > mode >
+	 * global precedence stays identical to the widget.
+	 *
+	 * Falls back to the builtin Agent mode when the session has no explicit
+	 * mode, mirroring the `?? ChatModeKind.Agent` default used for `modeInfo`
+	 * in {@link _dispatchSend} — local sessions never have their mode set.
+	 */
+	private _computeUserSelectedTools(session: LocalSession): IObservable<UserSelectedTools> {
+		const mode = session.chatMode ?? ChatMode.Agent;
+		const metadata = session.selectedModelId
+			? this.languageModelsService.lookupLanguageModel(session.selectedModelId)
+			: undefined;
+		const modelObs = constObservable<ILanguageModelChatMetadataAndIdentifier | undefined>(
+			metadata && session.selectedModelId ? { identifier: session.selectedModelId, metadata } : undefined
+		);
+		const selectedTools = this.instantiationService.createInstance(ChatSelectedTools, constObservable(mode), modelObs);
+		try {
+			return constObservable(selectedTools.userSelectedTools.get());
+		} finally {
+			selectedTools.dispose();
 		}
 	}
 

--- a/src/vs/sessions/contrib/providers/localChatSessions/test/browser/localChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/test/browser/localChatSessionsProvider.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
-import { IObservable, observableValue } from '../../../../../../base/common/observable.js';
+import { constObservable, IObservable, observableValue } from '../../../../../../base/common/observable.js';
 import { URI, UriComponents } from '../../../../../../base/common/uri.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
@@ -21,13 +21,22 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../../../
 import { TestStorageService } from '../../../../../../workbench/test/common/workbenchTestServices.js';
 import { ChatAgentLocation } from '../../../../../../workbench/contrib/chat/common/constants.js';
 import { IChatModel } from '../../../../../../workbench/contrib/chat/common/model/chatModel.js';
-import { IChatModelReference, IChatService, IChatSessionStartOptions, IChatSessionTiming } from '../../../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { IChatModelReference, IChatSendRequestOptions, IChatService, IChatSessionStartOptions, IChatSessionTiming } from '../../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { ILanguageModelsService } from '../../../../../../workbench/contrib/chat/common/languageModels.js';
-import { ILanguageModelToolsService } from '../../../../../../workbench/contrib/chat/common/tools/languageModelToolsService.js';
+import { ILanguageModelToolsService, IToolData, ToolDataSource } from '../../../../../../workbench/contrib/chat/common/tools/languageModelToolsService.js';
 import { IGitService } from '../../../../../../workbench/contrib/git/common/gitService.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
 import { ISession, SessionStatus } from '../../../../../services/sessions/common/session.js';
 import { LocalChatSessionsProvider, LocalSessionType, LOCAL_SESSION_ENABLED_SETTING } from '../../browser/localChatSessionsProvider.js';
+
+/** Prompt-referenceable tool the fake tools service advertises, so a send's tool selection is non-empty. */
+const TEST_TOOL: IToolData = {
+	id: 'test.tool',
+	source: ToolDataSource.Internal,
+	displayName: 'Test Tool',
+	modelDescription: 'A tool used by the local chat sessions provider tests',
+	canBeReferencedInPrompt: true,
+};
 
 // ---- Mock chat service ----------------------------------------------------
 
@@ -49,7 +58,7 @@ class MockChatService extends Disposable {
 	private readonly _models = new Map<string, IChatModel>();
 	private _counter = 0;
 
-	readonly sendRequestCalls: { resource: URI; query: string }[] = [];
+	readonly sendRequestCalls: { resource: URI; query: string; options?: IChatSendRequestOptions }[] = [];
 
 	/** When a query matches an entry here, sendRequest reports a rejection. */
 	readonly rejectQueries = new Set<string>();
@@ -79,8 +88,8 @@ class MockChatService extends Disposable {
 		return undefined;
 	}
 
-	async sendRequest(resource: URI, query: string) {
-		this.sendRequestCalls.push({ resource, query });
+	async sendRequest(resource: URI, query: string, options?: IChatSendRequestOptions) {
+		this.sendRequestCalls.push({ resource, query, options });
 		if (this.rejectQueries.has(query)) {
 			return { kind: 'rejected', reason: 'test-rejected' };
 		}
@@ -126,7 +135,10 @@ function createFixture(store: DisposableStore): ITestFixture {
 		override getUriLabel(uri: URI): string { return uri.fsPath; }
 	}());
 	instantiationService.stub(ILanguageModelsService, new class extends mock<ILanguageModelsService>() { }());
-	instantiationService.stub(ILanguageModelToolsService, new class extends mock<ILanguageModelToolsService>() { }());
+	instantiationService.stub(ILanguageModelToolsService, new class extends mock<ILanguageModelToolsService>() {
+		override observeTools() { return constObservable<readonly IToolData[]>([TEST_TOOL]); }
+		override getToolSetsForModel() { return []; }
+	}());
 	instantiationService.stub(IGitService, new class extends mock<IGitService>() {
 		override async openRepository() { return undefined; }
 	}());
@@ -201,6 +213,19 @@ suite('LocalChatSessionsProvider', () => {
 		const chat = await provider.createNewChat(newSession.sessionId);
 		await provider.sendRequest(newSession.sessionId, chat.resource, { query: 'hi' });
 		assert.strictEqual(provider.getSessions().length, 1);
+	});
+
+	test('first request to a new session carries the resolved tool selection', async () => {
+		const store = leaks.add(new DisposableStore());
+		const { instantiationService, chatService } = createFixture(store);
+		const provider = store.add(instantiationService.createInstance(LocalChatSessionsProvider));
+
+		await commitNewSession(provider);
+
+		// Regression: the headless first send used to omit userSelectedTools, so
+		// extHostChatAgents2.getToolsForRequest mapped it to an empty tool set.
+		const sent = chatService.sendRequestCalls.at(-1);
+		assert.deepStrictEqual(sent?.options?.userSelectedTools?.get(), { [TEST_TOOL.id]: true });
 	});
 
 	test('createNewSession rejects unknown session types', () => {


### PR DESCRIPTION
This ensures that local agents recieve a set of tools with the first message, rather than silently providing none until the second message.

This also makes the tool selector visible when Local agents are selected, and hidden otherwise.

A new unit test has been added, and manual testing to verify it does what it says it does was completed.

Fixes https://github.com/microsoft/vscode/issues/321882