### PR TITLE
sessions: restore close button for the bottom panel

### DIFF
--- a/src/vs/sessions/browser/layoutActions.ts
+++ b/src/vs/sessions/browser/layoutActions.ts
@@ -108,29 +108,18 @@ class ToggleSecondarySidebarVisibilityAction extends Action2 {
 	}
 }
 
-class TogglePanelVisibilityAction extends Action2 {
-
-	static readonly ID = 'workbench.action.agentTogglePanelVisibility';
-
-	constructor() {
-		super({
-			id: TogglePanelVisibilityAction.ID,
-			title: localize2('togglePanel', 'Toggle Panel Visibility'),
-			category: Categories.View,
-			f1: true,
-			icon: panelCloseIcon
-		});
-	}
-
-	run(accessor: ServicesAccessor): void {
-		const layoutService = accessor.get(IWorkbenchLayoutService);
-		layoutService.setPartHidden(layoutService.isVisible(Parts.PANEL_PART), Parts.PANEL_PART);
-	}
-}
-
 registerAction2(ToggleSidebarVisibilityAction);
 registerAction2(ToggleSecondarySidebarVisibilityAction);
-registerAction2(TogglePanelVisibilityAction);
+
+MenuRegistry.appendMenuItem(Menus.PanelTitle, {
+	command: {
+		id: 'workbench.action.closePanel',
+		title: localize('closePanel', "Hide Panel"),
+		icon: panelCloseIcon
+	},
+	group: 'navigation',
+	order: 2
+});
 
 // Floating window controls: always-on-top
 MenuRegistry.appendMenuItem(Menus.TitleBarRightLayout, {


### PR DESCRIPTION
## What

Restores the close (Hide Panel) button in the bottom panel's title bar in the Agents window.

## How

Contributes the existing `workbench.action.closePanel` command to the Agents window panel title menu (`Menus.PanelTitle`) in the `navigation` group with the panel close icon. The previous `TogglePanelVisibilityAction` (a toggle) is removed in favor of this dedicated close command.

## Notes for reviewers

- `workbench.action.closePanel` already declares `precondition: PanelVisibleContext`, so the button only renders while the panel is visible.
- No new action is introduced; we reuse the existing workbench command rather than duplicating the toggle.