### PR TITLE
Add RTL (Hebrew/Arabic) support to rendered chat messages

### DIFF
--- a/src/vs/base/browser/textDirection.ts
+++ b/src/vs/base/browser/textDirection.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { detectTextDirection } from '../common/textDirection.js';
+
+/**
+ * Block-level, text-bearing elements that should follow the direction of their content.
+ * `ul`/`ol` are included so an RTL list also flips its marker side (the markers follow the
+ * list's own direction, not the list items').
+ */
+const TEXT_BLOCK_SELECTOR = 'p, li, ul, ol, h1, h2, h3, h4, h5, h6, blockquote, td, th, summary, dt, dd';
+
+/**
+ * Walks the rendered markdown subtree and sets a writing direction on each block-level
+ * text element so Hebrew/Arabic content reads correctly, while code blocks (`<pre>`) are
+ * forced left-to-right. Elements that already carry an explicit `dir` are left untouched.
+ *
+ * Inline `<code>` is intentionally not annotated so it keeps its natural bidi flow inside
+ * a directional paragraph.
+ */
+export function applyBlockTextDirection(root: HTMLElement): void {
+	// eslint-disable-next-line no-restricted-syntax
+	for (const element of root.querySelectorAll<HTMLElement>(TEXT_BLOCK_SELECTOR)) {
+		if (!element.hasAttribute('dir')) {
+			element.setAttribute('dir', detectTextDirection(element.textContent ?? ''));
+		}
+	}
+
+	// eslint-disable-next-line no-restricted-syntax
+	for (const pre of root.querySelectorAll<HTMLElement>('pre')) {
+		if (!pre.hasAttribute('dir')) {
+			pre.setAttribute('dir', 'ltr');
+		}
+	}
+}

--- a/src/vs/base/common/textDirection.ts
+++ b/src/vs/base/common/textDirection.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Matches a single character from a right-to-left script. Covers Hebrew, Arabic,
+ * Syriac, Thaana, N'Ko, Samaritan, Mandaic, the Arabic Extended/Supplement blocks,
+ * and the Arabic Presentation Forms.
+ */
+const RTL_CHARACTER = /[\u0590-\u05FF\u0600-\u06FF\u0700-\u074F\u0750-\u077F\u0780-\u07BF\u07C0-\u07FF\u0800-\u083F\u0840-\u085F\u08A0-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF]/;
+
+/**
+ * Detects the writing direction to apply to a block of text.
+ *
+ * Detection is presence-based: if the text contains *any* RTL character the block is
+ * laid out `rtl`, otherwise `auto` (the browser resolves LTR/neutral content itself).
+ *
+ * This is intentionally not the first-strong-character / `dir="auto"` heuristic: an RTL
+ * paragraph that happens to start with an English word (a brand or tech term, very common
+ * in Hebrew/Arabic writing) would otherwise be laid out left-to-right. The reverse —
+ * an English paragraph containing a single RTL word — is rare, so presence-based detection
+ * is the better trade-off for chat content.
+ */
+export function detectTextDirection(text: string): 'rtl' | 'auto' {
+	return RTL_CHARACTER.test(text) ? 'rtl' : 'auto';
+}

--- a/src/vs/base/common/textDirection.ts
+++ b/src/vs/base/common/textDirection.ts
@@ -15,6 +15,8 @@ const RTL_CHARACTER = /[\u0590-\u05FF\u0600-\u06FF\u0700-\u074F\u0750-\u077F\u07
  *
  * Detection is presence-based: if the text contains *any* RTL character the block is
  * laid out `rtl`, otherwise `auto` (the browser resolves LTR/neutral content itself).
+ * Mixed-direction text (RTL and LTR characters together) therefore resolves to `rtl`,
+ * not `auto`.
  *
  * This is intentionally not the first-strong-character / `dir="auto"` heuristic: an RTL
  * paragraph that happens to start with an English word (a brand or tech term, very common

--- a/src/vs/base/test/browser/textDirection.test.ts
+++ b/src/vs/base/test/browser/textDirection.test.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { applyBlockTextDirection } from '../../browser/textDirection.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../common/utils.js';
+
+suite('applyBlockTextDirection', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function apply(html: string): HTMLElement {
+		const root = document.createElement('div');
+		root.innerHTML = html;
+		applyBlockTextDirection(root);
+		return root;
+	}
+
+	test('sets the right direction on each block-level text element', () => {
+		const root = apply([
+			'<h1>כותרת</h1>',
+			'<p>שלום עולם</p>',
+			'<p>Hello world</p>',
+			'<ul><li>פריט</li></ul>',
+			'<blockquote>ציטוט</blockquote>',
+			'<pre><code>const x = 1;</code></pre>',
+		].join(''));
+
+		const dirOf = (selector: string) => root.querySelector(selector)?.getAttribute('dir') ?? null;
+		assert.deepStrictEqual(
+			{
+				h1: dirOf('h1'),
+				pHebrew: root.querySelectorAll('p')[0].getAttribute('dir'),
+				pEnglish: root.querySelectorAll('p')[1].getAttribute('dir'),
+				ul: dirOf('ul'),
+				li: dirOf('li'),
+				blockquote: dirOf('blockquote'),
+				pre: dirOf('pre'),
+				code: dirOf('code'),
+			},
+			{
+				h1: 'rtl',
+				pHebrew: 'rtl',
+				pEnglish: 'auto',
+				ul: 'rtl',       // the list flips its marker side with its content
+				li: 'rtl',
+				blockquote: 'rtl',
+				pre: 'ltr',      // code is inherently left-to-right
+				code: null,      // inline code keeps its natural bidi flow
+			}
+		);
+	});
+
+	test('does not touch non-text containers', () => {
+		const root = apply('<div>שלום</div><span>שלום</span>');
+		assert.strictEqual(root.querySelector('div')!.getAttribute('dir'), null);
+		assert.strictEqual(root.querySelector('span')!.getAttribute('dir'), null);
+	});
+
+	test('preserves an explicit dir attribute', () => {
+		const root = apply('<p dir="ltr">שלום עולם</p>');
+		assert.strictEqual(root.querySelector('p')!.getAttribute('dir'), 'ltr');
+	});
+});

--- a/src/vs/base/test/common/textDirection.test.ts
+++ b/src/vs/base/test/common/textDirection.test.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { detectTextDirection } from '../../common/textDirection.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
+
+suite('textDirection', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('returns auto for empty text', () => {
+		assert.strictEqual(detectTextDirection(''), 'auto');
+	});
+
+	test('returns auto for neutral characters only', () => {
+		assert.strictEqual(detectTextDirection('123 !@# ...'), 'auto');
+	});
+
+	test('returns auto for pure English text', () => {
+		assert.strictEqual(detectTextDirection('Hello world'), 'auto');
+	});
+
+	test('returns rtl for Hebrew text', () => {
+		assert.strictEqual(detectTextDirection('שלום עולם'), 'rtl');
+	});
+
+	test('returns rtl for Arabic text', () => {
+		assert.strictEqual(detectTextDirection('مرحبا بالعالم'), 'rtl');
+	});
+
+	test('returns rtl when an RTL word appears after an English prefix', () => {
+		assert.strictEqual(detectTextDirection('REACT מאפשרת לבנות ממשקי משתמש'), 'rtl');
+	});
+
+	test('returns rtl when a single RTL word is embedded in English', () => {
+		assert.strictEqual(detectTextDirection('The שלום framework is great'), 'rtl');
+	});
+});

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../../../base/browser/dom.js';
+import { applyBlockTextDirection } from '../../../../../../base/browser/textDirection.js';
 import { allowedMarkdownHtmlAttributes, MarkdownRendererMarkedOptions, type MarkdownRenderOptions } from '../../../../../../base/browser/markdownRenderer.js';
 import { status } from '../../../../../../base/browser/ui/aria/aria.js';
 import { DomScrollableElement } from '../../../../../../base/browser/ui/scrollbar/scrollableElement.js';
@@ -378,6 +379,10 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 
 			const markdownDecorationsRenderer = instantiationService.createInstance(ChatMarkdownDecorationsRenderer);
 			store.add(markdownDecorationsRenderer.walkTreeAndAnnotateReferenceLinks(this.markdown, result.element));
+
+			// Lay out RTL (Hebrew/Arabic) content right-to-left per paragraph while
+			// keeping code blocks left-to-right.
+			applyBlockTextDirection(result.element);
 
 			const layoutParticipants = new Lazy(() => {
 				const observer = store.add(new dom.DisposableResizeObserver('ChatMarkdownContentPart.mathLayout', () => this.mathLayoutParticipants.forEach(layout => layout())));

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatMarkdownPart.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatMarkdownPart.css
@@ -20,4 +20,19 @@
 		width: fit-content;
 		overflow: hidden;
 	}
+
+	/* RTL support: align directional blocks to their start edge so Hebrew/Arabic
+	   content reads correctly, and keep code blocks left-to-right. */
+	[dir="auto"],
+	[dir="rtl"],
+	[dir="ltr"] {
+		text-align: start;
+	}
+
+	pre,
+	pre code {
+		direction: ltr;
+		text-align: left;
+		unicode-bidi: isolate;
+	}
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -40,6 +40,7 @@ import { EditorOptions, IEditorOptions, IEditorScrollbarOptions } from '../../..
 import { IDimension } from '../../../../../../editor/common/core/2d/dimension.js';
 import { IPosition } from '../../../../../../editor/common/core/position.js';
 import { IRange, Range } from '../../../../../../editor/common/core/range.js';
+import { IEditorDecorationsCollection } from '../../../../../../editor/common/editorCommon.js';
 import { isLocation } from '../../../../../../editor/common/languages.js';
 import { ITextModel } from '../../../../../../editor/common/model.js';
 import { IModelService } from '../../../../../../editor/common/services/model.js';
@@ -128,6 +129,7 @@ import { ChatArtifactsWidget } from '../chatArtifactsWidget.js';
 import { ChatDragAndDrop } from '../chatDragAndDrop.js';
 import { ChatFollowups } from './chatFollowups.js';
 import { IChatInputNotificationService } from './chatInputNotificationService.js';
+import { updateChatInputTextDirection } from './chatInputTextDirection.js';
 import { ChatGoalBannerWidget } from './chatGoalBannerWidget.js';
 import { ChatInputNotificationWidget } from './chatInputNotificationWidget.js';
 import { IChatInputPickerOptions } from './chatInputPickerActionItem.js';
@@ -363,6 +365,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 	private _inputEditor!: CodeEditorWidget;
 	private _inputEditorElement!: HTMLElement;
+	private _inputDirectionDecorations!: IEditorDecorationsCollection;
 	private _forceVisibleScrollbarUntilAccept = false;
 
 	// Reference to the input model for syncing input state
@@ -2739,6 +2742,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		const editorOptions = getSimpleCodeEditorWidgetOptions();
 		editorOptions.contributions?.push(...EditorExtensionsRegistry.getSomeEditorContributions([ContentHoverController.ID, GlyphHoverController.ID, DropIntoEditorController.ID, CopyPasteController.ID, LinkDetector.ID, InlineCompletionsController.ID]));
 		this._inputEditor = this._register(scopedInstantiationService.createInstance(CodeEditorWidget, this._inputEditorElement, options, editorOptions));
+		this._inputDirectionDecorations = this._inputEditor.createDecorationsCollection();
 
 		SuggestController.get(this._inputEditor)?.forceRenderingAbove();
 		options.overflowWidgetsDomNode?.classList.add('hideSuggestTextIcons');
@@ -2771,6 +2775,9 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 					this._layout(this.cachedWidth);
 				}
 			}
+
+			// Lay out Hebrew/Arabic lines right-to-left as the user types.
+			updateChatInputTextDirection(this._inputEditor, this._inputDirectionDecorations);
 
 			this._updateInputContentContextKeys();
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputTextDirection.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputTextDirection.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { detectTextDirection } from '../../../../../../base/common/textDirection.js';
+import { ICodeEditor } from '../../../../../../editor/browser/editorBrowser.js';
+import { Range } from '../../../../../../editor/common/core/range.js';
+import { IEditorDecorationsCollection } from '../../../../../../editor/common/editorCommon.js';
+import { IModelDeltaDecoration, TextDirection } from '../../../../../../editor/common/model.js';
+
+const CHAT_INPUT_RTL_DECORATION_DESCRIPTION = 'chat-input-rtl-direction';
+
+/**
+ * Lays out each Hebrew/Arabic line in the chat input editor right-to-left, mirroring how
+ * rendered responses are handled on the display side.
+ *
+ * This uses Monaco's native, per-line decoration-based text direction
+ * ({@link TextDirection}) rather than forcing a `dir` attribute on the editor container, so
+ * cursor placement, selection and the vertical scrollbar gutter stay correct. Direction is
+ * detected per line — a line with any RTL character is laid out `rtl`, everything else keeps
+ * the editor's default left-to-right flow.
+ */
+export function updateChatInputTextDirection(editor: ICodeEditor, decorations: IEditorDecorationsCollection): void {
+	const model = editor.getModel();
+	if (!model) {
+		decorations.clear();
+		return;
+	}
+
+	const rtlLines: IModelDeltaDecoration[] = [];
+	const lineCount = model.getLineCount();
+	for (let lineNumber = 1; lineNumber <= lineCount; lineNumber++) {
+		if (detectTextDirection(model.getLineContent(lineNumber)) === 'rtl') {
+			rtlLines.push({
+				range: new Range(lineNumber, 1, lineNumber, model.getLineMaxColumn(lineNumber)),
+				options: {
+					description: CHAT_INPUT_RTL_DECORATION_DESCRIPTION,
+					textDirection: TextDirection.RTL
+				}
+			});
+		}
+	}
+
+	decorations.set(rtlLines);
+}

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputTextDirection.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputTextDirection.test.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
+import { TextDirection } from '../../../../../../../editor/common/model.js';
+import { withTestCodeEditor } from '../../../../../../../editor/test/browser/testCodeEditor.js';
+import { updateChatInputTextDirection } from '../../../../browser/widget/input/chatInputTextDirection.js';
+
+suite('updateChatInputTextDirection', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function rtlLineNumbers(lines: string[]): number[] {
+		let result: number[] = [];
+		withTestCodeEditor(lines.join('\n'), {}, editor => {
+			const decorations = editor.createDecorationsCollection();
+			updateChatInputTextDirection(editor, decorations);
+			result = editor.getModel()!.getAllDecorations()
+				.filter(decoration => decoration.options.textDirection === TextDirection.RTL)
+				.map(decoration => decoration.range.startLineNumber)
+				.sort((a, b) => a - b);
+		});
+		return result;
+	}
+
+	test('lays out Hebrew/Arabic and mixed lines RTL, leaves LTR/neutral lines alone', () => {
+		assert.deepStrictEqual(
+			rtlLineNumbers([
+				'hello world',        // 1: LTR
+				'שלום עולם',          // 2: Hebrew -> RTL
+				'مرحبا بالعالم',      // 3: Arabic -> RTL
+				'mixed שלום english', // 4: mixed (contains RTL) -> RTL
+				'',                   // 5: empty -> neutral
+				'1234 + 5678',        // 6: neutral -> LTR
+			]),
+			[2, 3, 4]
+		);
+	});
+});

--- a/test/automation/src/chat.ts
+++ b/test/automation/src/chat.ts
@@ -108,6 +108,15 @@ export class Chat {
 		return (await response.textContent()) ?? '';
 	}
 
+	/**
+	 * Reads the resolved writing direction of the latest rendered response. Used by the
+	 * RTL smoke test to assert Hebrew/Arabic content is laid out right-to-left.
+	 */
+	async getLatestResponseTextDirection(): Promise<string | null> {
+		const directional = this.code.driver.currentPage.locator(`${CHAT_RESPONSE_COMPLETE} .chat-markdown-part [dir]`).last();
+		return await directional.getAttribute('dir');
+	}
+
 	async waitForModelInFooter(): Promise<void> {
 		await this.code.waitForElements(CHAT_FOOTER_DETAILS, false, el => {
 			return el.some(el => {

--- a/test/automation/src/chat.ts
+++ b/test/automation/src/chat.ts
@@ -118,6 +118,26 @@ export class Chat {
 		return await directional.getAttribute('dir');
 	}
 
+	/**
+	 * Types text into the chat input without submitting it. Used by the RTL smoke test to
+	 * assert the input box itself lays Hebrew/Arabic out right-to-left while composing.
+	 */
+	async typeInInput(text: string): Promise<void> {
+		await this.code.waitAndClick(CHAT_INPUT_EDITOR);
+		await this.waitForInputFocus();
+		const sanitizedText = text.replace(/\n/g, ' ');
+		await this.code.waitForTypeInEditor(this.chatInputSelector, sanitizedText);
+	}
+
+	/**
+	 * Reads the writing direction Monaco resolved for the last rendered line of the chat input
+	 * editor. A Hebrew/Arabic line is rendered with `dir="rtl"` on its view line.
+	 */
+	async getInputTextDirection(): Promise<string | null> {
+		const inputViewLine = this.code.driver.currentPage.locator(`${CHAT_INPUT_EDITOR} .view-line`).last();
+		return await inputViewLine.getAttribute('dir');
+	}
+
 	async waitForModelInFooter(): Promise<void> {
 		await this.code.waitForElements(CHAT_FOOTER_DETAILS, false, el => {
 			return el.some(el => {

--- a/test/automation/src/chat.ts
+++ b/test/automation/src/chat.ts
@@ -113,7 +113,8 @@ export class Chat {
 	 * RTL smoke test to assert Hebrew/Arabic content is laid out right-to-left.
 	 */
 	async getLatestResponseTextDirection(): Promise<string | null> {
-		const directional = this.code.driver.currentPage.locator(`${CHAT_RESPONSE_COMPLETE} .chat-markdown-part [dir]`).last();
+		const latestResponse = this.code.driver.currentPage.locator(CHAT_RESPONSE_COMPLETE).last();
+		const directional = latestResponse.locator(`.chat-markdown-part [dir]`).last();
 		return await directional.getAttribute('dir');
 	}
 

--- a/test/smoke/src/areas/chat/chatRtl.test.ts
+++ b/test/smoke/src/areas/chat/chatRtl.test.ts
@@ -66,6 +66,11 @@ export function setup(logger: Logger) {
 				await app.workbench.quickaccess.runCommand('workbench.action.chat.open');
 				await app.workbench.chat.waitForChatView();
 
+				// The input box itself should lay Hebrew out right-to-left while composing.
+				await app.workbench.chat.typeInInput('שלום זהו טקסט בעברית');
+				const inputDirection = await app.workbench.chat.getInputTextDirection();
+				assert.strictEqual(inputDirection, 'rtl', `expected the Hebrew chat input line to be dir="rtl", saw ${inputDirection}`);
+
 				await app.workbench.chat.sendMessage(`reply in hebrew [scenario:${RTL_SCENARIO_ID}]`);
 				await app.workbench.chat.waitForResponse(1500);
 

--- a/test/smoke/src/areas/chat/chatRtl.test.ts
+++ b/test/smoke/src/areas/chat/chatRtl.test.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { Application, Logger } from '../../../../automation';
+import { dumpFailureDiagnostics, getCopilotSmokeTestEnv, getMockLlmServerPath, installAllHandlers, MockLlmServer } from '../../utils';
+
+const RTL_SCENARIO_ID = 'smoke-chat-rtl-hebrew';
+// A Hebrew sentence: the rendered response must be laid out right-to-left.
+const RTL_REPLY = 'שלום עולם, זהו טקסט בעברית שצריך להופיע מימין לשמאל';
+
+/**
+ * E2E coverage for RTL support: a response containing Hebrew text is rendered with
+ * `dir="rtl"` on its paragraph, so it reads right-to-left.
+ */
+export function setup(logger: Logger) {
+
+	describe('Chat RTL', function () {
+		this.timeout(5 * 60 * 1000);
+		this.retries(0);
+
+		let mockServer: MockLlmServer;
+
+		before(async function () {
+			const { startServer, ScenarioBuilder, registerScenario } = require(getMockLlmServerPath());
+			registerScenario('text-only', new ScenarioBuilder().emit('OK').build());
+			registerScenario(RTL_SCENARIO_ID, new ScenarioBuilder().emit(RTL_REPLY).build());
+			mockServer = await startServer(0, { logger: (msg: string) => logger.log(`[mock-llm] ${msg}`) });
+			logger.log(`[Chat RTL] mock LLM server started at ${mockServer.url}`);
+		});
+
+		installAllHandlers(logger, opts => {
+			return {
+				...opts,
+				extraEnv: {
+					...(opts.extraEnv ?? {}),
+					...getCopilotSmokeTestEnv(mockServer),
+				},
+			};
+		});
+
+		before(async function () {
+			const app = this.app as Application;
+			await app.workbench.settingsEditor.addUserSettings([
+				['github.copilot.advanced.debug.overrideProxyUrl', JSON.stringify(mockServer.url)],
+				['github.copilot.advanced.debug.overrideCapiUrl', JSON.stringify(mockServer.url)],
+				['github.copilot.advanced.debug.overrideAuthType', '"token"'],
+				['chat.allowAnonymousAccess', 'true'],
+				['github.copilot.chat.githubMcpServer.enabled', 'false'],
+				['chat.mcp.discovery.enabled', 'false'],
+				['chat.mcp.enabled', 'false'],
+				['chat.disableAIFeatures', 'false'],
+			]);
+		});
+
+		after(async function () {
+			await mockServer?.close();
+		});
+
+		it('renders a Hebrew response right-to-left', async function () {
+			const app = this.app as Application;
+
+			try {
+				await app.workbench.quickaccess.runCommand('workbench.action.chat.open');
+				await app.workbench.chat.waitForChatView();
+
+				await app.workbench.chat.sendMessage(`reply in hebrew [scenario:${RTL_SCENARIO_ID}]`);
+				await app.workbench.chat.waitForResponse(1500);
+
+				const responseText = (await app.workbench.chat.getLatestResponseText()).trim();
+				assert.ok(
+					responseText.includes('עברית'),
+					`expected the Hebrew mock reply to be rendered.\n\nResponse:\n${responseText}`
+				);
+
+				const direction = await app.workbench.chat.getLatestResponseTextDirection();
+				assert.strictEqual(direction, 'rtl', `expected the Hebrew response paragraph to be dir="rtl", saw ${direction}`);
+			} catch (error) {
+				logger.log(`[Chat RTL] FAILURE: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+				await dumpFailureDiagnostics(app, logger, 'Chat RTL');
+				throw error;
+			} finally {
+				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
+			}
+		});
+	});
+}

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -30,6 +30,7 @@ import { setup as setupTaskTests } from './areas/task/task.test';
 import { setup as setupChatTests } from './areas/chat/chatDisabled.test';
 import { setup as setupCopilotCliTests } from './areas/chat/copilotCli.test';
 import { setup as setupChatSessionsTests } from './areas/chat/chatSessions.test';
+import { setup as setupChatRtlTests } from './areas/chat/chatRtl.test';
 import { setup as setupAccessibilityTests } from './areas/accessibility/accessibility.test';
 import { setup as setupAgentsWindowTests } from './areas/agentsWindow/agentsWindow.test';
 
@@ -423,6 +424,7 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	if (!opts.web) { setupChatTests(logger); }
 	if (!opts.web && !opts.remote && quality !== Quality.Dev && quality !== Quality.OSS) { setupCopilotCliTests(logger); }
 	if (!opts.web && !opts.remote) { setupChatSessionsTests(logger); }
+	if (!opts.web) { setupChatRtlTests(logger); }
 	if (!opts.web && !opts.remote) { setupAgentsWindowTests(logger); }
 	setupAccessibilityTests(logger, opts, quality);
 });


### PR DESCRIPTION
This PR adds automatic right-to-left (RTL) layout for Hebrew/Arabic text in rendered chat markdown messages, while keeping code blocks left-to-right.

### What
- New `detectTextDirection(text)` in `vs/base/common/textDirection.ts` — DOM-free, presence-based detection across the RTL Unicode ranges (Hebrew, Arabic, Syriac, Thaana, N'Ko, …). Returns `'rtl'` if the text contains **any** RTL character, otherwise `'auto'`.
- New `applyBlockTextDirection(root)` in `vs/base/browser/textDirection.ts` — sets `dir` on block-level text elements (`p`, `li`, `ul`/`ol`, headings, `blockquote`, table cells, `summary`, `dt`/`dd`) and forces `<pre>` to `dir="ltr"`. Explicit `dir` attributes are preserved.
- Wired into `ChatMarkdownContentPart` after render.
- `chatMarkdownPart.css`: `text-align: start` for directional blocks; `<pre>` stays LTR / left-aligned.

### Why
Hebrew/Arabic chat responses currently render left-aligned LTR, which is hard to read. This lays them out naturally per block based on content, without affecting English text or code blocks.

### Detection behavior
Detection is **presence-based** and per block: any RTL character in a block lays that block out `rtl`; blocks with no RTL characters use `auto` (the browser resolves LTR/neutral content itself). This is deliberately *not* the first-strong-character `dir="auto"` heuristic, because RTL paragraphs in Hebrew/Arabic very commonly start with an English brand or tech term. Mixed-direction text (RTL + LTR together) therefore resolves to `rtl`. Code blocks (`<pre>`) are always forced LTR.

### Tests
- Unit tests for the detector (Hebrew / Arabic / English / neutral / mixed).
- Browser unit test for the DOM applier.
- A smoke (E2E) test asserting a Hebrew response renders `dir="rtl"`.
