### PR TITLE
Add /rewind to discard a chat conversation turn in place

### DIFF
--- a/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessions.contribution.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessions.contribution.ts
@@ -14,6 +14,7 @@ import { localize, localize2 } from '../../../../../nls.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 import { ForkConversationAction } from '../../../../../workbench/contrib/chat/browser/actions/chatForkActions.js';
+import { RewindConversationAction } from '../../../../../workbench/contrib/chat/browser/actions/chatRewindActions.js';
 import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -99,6 +100,14 @@ registerAction2(class extends ForkConversationAction {
 		});
 	}
 });
+
+// Rewind removes the selected turn (and everything after it) in place. Unlike Fork it does
+// not open a new session, so it needs no sessions-service handling — but it must be registered
+// here so the Agents window contributes the Rewind button next to Fork and wires up the
+// `workbench.action.chat.rewindConversation` command that the `/rewind` slash command runs.
+// The Agents window does not load the workbench chat contribution where Fork/Rewind are
+// registered for the panel, which is why Fork is re-registered above and Rewind here.
+registerAction2(RewindConversationAction);
 
 registerAction2(class DeleteLocalSessionAction extends Action2 {
 	constructor() {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatRewindActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatRewindActions.ts
@@ -1,0 +1,151 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { localize, localize2 } from '../../../../../nls.js';
+import { Action2, MenuId } from '../../../../../platform/actions/common/actions.js';
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
+import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ChatContextKeyExprs, ChatContextKeys } from '../../common/actions/chatContextKeys.js';
+import { IChatService } from '../../common/chatService/chatService.js';
+import { isChatTreeItem, isRequestVM, isResponseVM } from '../../common/model/chatViewModel.js';
+import { ChatTreeItem, IChatWidgetService } from '../chat.js';
+import { CHAT_CATEGORY } from './chatActions.js';
+
+/**
+ * Given the conversation's request ids in display order and the id the user rewound to,
+ * returns the ids that must be removed: the target request and every request after it.
+ *
+ * Mirrors the "rewind" semantics — the selected turn and everything that came after it are
+ * discarded, leaving the conversation as it was *before* that turn.
+ */
+export function getRequestIdsToRewind(orderedRequestIds: readonly string[], targetRequestId: string): string[] {
+	const index = orderedRequestIds.indexOf(targetRequestId);
+	if (index === -1) {
+		return [];
+	}
+	return orderedRequestIds.slice(index);
+}
+
+/**
+ * Localized confirmation detail shown before the (irreversible) rewind removes messages.
+ */
+export function getRewindConfirmationMessage(count: number): string {
+	return count === 1
+		? localize('chat.rewind.confirm.detail.one', "Rewind will remove 1 message from this conversation. This cannot be undone.")
+		: localize('chat.rewind.confirm.detail.other', "Rewind will remove {0} messages from this conversation. This cannot be undone.", count);
+}
+
+/**
+ * Rewinds the current conversation to a previous turn: the selected request and everything
+ * after it are removed from the session in place (unlike Fork, which copies the prefix into a
+ * brand new session). Contributed to the per-message checkpoint toolbar next to Fork, and
+ * exposed via the `/rewind` slash command.
+ */
+export class RewindConversationAction extends Action2 {
+
+	static readonly ID = 'workbench.action.chat.rewindConversation';
+
+	constructor() {
+		super({
+			id: RewindConversationAction.ID,
+			title: localize2('chat.rewindConversation.label', "Rewind Conversation"),
+			tooltip: localize2('chat.rewindConversation.tooltip', "Rewind conversation to this point"),
+			f1: false,
+			category: CHAT_CATEGORY,
+			icon: Codicon.discard,
+			precondition: ContextKeyExpr.and(
+				ChatContextKeys.enabled,
+				ChatContextKeys.requestInProgress.negate(),
+			),
+			menu: [
+				{
+					id: MenuId.ChatMessageCheckpoint,
+					group: 'navigation',
+					order: 4,
+					when: ContextKeyExpr.and(
+						ChatContextKeys.isRequest,
+						ChatContextKeys.isFirstRequest.negate(),
+						ContextKeyExpr.or(
+							ChatContextKeys.lockedToCodingAgent.negate(),
+							ChatContextKeyExprs.isAgentHostSession,
+						),
+					),
+				}
+			]
+		});
+	}
+
+	async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
+		const chatWidgetService = accessor.get(IChatWidgetService);
+		const chatService = accessor.get(IChatService);
+		const dialogService = accessor.get(IDialogService);
+
+		const { sessionResource, targetRequestId } = this._resolveTarget(args, chatWidgetService, chatService);
+		if (!sessionResource || !targetRequestId) {
+			return;
+		}
+
+		const chatModel = chatService.getSession(sessionResource);
+		if (!chatModel) {
+			return;
+		}
+
+		const orderedRequestIds = chatModel.getRequests().map(request => request.id);
+		const idsToRewind = getRequestIdsToRewind(orderedRequestIds, targetRequestId);
+		if (idsToRewind.length === 0) {
+			return;
+		}
+
+		const { confirmed } = await dialogService.confirm({
+			type: 'warning',
+			message: localize('chat.rewind.confirm.title', "Rewind conversation?"),
+			detail: getRewindConfirmationMessage(idsToRewind.length),
+			primaryButton: localize('chat.rewind.confirm.primary', "Rewind"),
+		});
+		if (!confirmed) {
+			return;
+		}
+
+		for (const requestId of idsToRewind) {
+			await chatService.removeRequest(sessionResource, requestId);
+		}
+	}
+
+	private _resolveTarget(args: unknown[], chatWidgetService: IChatWidgetService, chatService: IChatService): { sessionResource: URI | undefined; targetRequestId: string | undefined } {
+		// When invoked via the `/rewind` slash command, args[0] is the session URI.
+		// With no explicit point, rewind the most recent turn.
+		if (URI.isUri(args[0])) {
+			const sessionResource = args[0];
+			const lastRequest = chatService.getSession(sessionResource)?.getRequests().at(-1);
+			return { sessionResource, targetRequestId: lastRequest?.id };
+		}
+
+		// When invoked from the checkpoint toolbar, args[0] is (or wraps) a ChatTreeItem.
+		const arg = args[0] as { element?: unknown; context?: unknown; item?: unknown } | undefined;
+		let item: ChatTreeItem | undefined = isChatTreeItem(arg)
+			? arg
+			: isChatTreeItem(arg?.element)
+				? arg.element
+				: isChatTreeItem(arg?.context)
+					? arg.context
+					: isChatTreeItem(arg?.item)
+						? arg.item
+						: undefined;
+		const widget = (item && chatWidgetService.getWidgetBySessionResource(item.sessionResource)) || chatWidgetService.lastFocusedWidget;
+		if (!isResponseVM(item) && !isRequestVM(item)) {
+			item = widget?.getFocus();
+		}
+		if (!item) {
+			return { sessionResource: undefined, targetRequestId: undefined };
+		}
+
+		const sessionResource = widget?.viewModel?.sessionResource ?? (isChatTreeItem(item) ? item.sessionResource : undefined);
+		const targetRequestId = isRequestVM(item) ? item.id : isResponseVM(item) ? item.requestId : undefined;
+		return { sessionResource, targetRequestId };
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatRewindActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatRewindActions.ts
@@ -71,8 +71,8 @@ export class RewindConversationAction extends Action2 {
 						ChatContextKeys.isRequest,
 						ChatContextKeys.isFirstRequest.negate(),
 						ContextKeyExpr.or(
-							ChatContextKeys.lockedToCodingAgent.negate(),
-							ChatContextKeyExprs.isAgentHostSession,
+							ContextKeyExpr.or(ChatContextKeys.lockedToCodingAgent.negate(), ChatContextKeyExprs.isAgentHostSession),
+							ChatContextKeys.chatSessionSupportsFork
 						),
 					),
 				}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatRewindActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatRewindActions.ts
@@ -95,6 +95,13 @@ export class RewindConversationAction extends Action2 {
 			return;
 		}
 
+		// Defensive guard: removing requests while a turn is streaming would corrupt
+		// session state. The menu and slash command are gated on `requestInProgress`,
+		// but `executeCommand` bypasses an action's precondition, so re-check here.
+		if (chatModel.requestInProgress.get()) {
+			return;
+		}
+
 		const orderedRequestIds = chatModel.getRequests().map(request => request.id);
 		const idsToRewind = getRequestIdsToRewind(orderedRequestIds, targetRequestId);
 		if (idsToRewind.length === 0) {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatRewindActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatRewindActions.ts
@@ -67,9 +67,13 @@ export class RewindConversationAction extends Action2 {
 					id: MenuId.ChatMessageCheckpoint,
 					group: 'navigation',
 					order: 4,
+					// `precondition` only disables the item; gate visibility via `when` so the button
+					// disappears (rather than greys out) while a turn is streaming — matching the PR
+					// intent of "hides while a request is in progress".
 					when: ContextKeyExpr.and(
 						ChatContextKeys.isRequest,
 						ChatContextKeys.isFirstRequest.negate(),
+						ChatContextKeys.requestInProgress.negate(),
 						ContextKeyExpr.or(
 							ContextKeyExpr.or(ChatContextKeys.lockedToCodingAgent.negate(), ChatContextKeyExprs.isAgentHostSession),
 							ChatContextKeys.chatSessionSupportsFork

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -6,6 +6,8 @@
 import { registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ExportAgentHostDebugLogsAction } from './actions/exportAgentHostDebugLogsAction.js';
 import { ForkConversationAction } from './actions/chatForkActions.js';
+import { RewindConversationAction } from './actions/chatRewindActions.js';
 
 registerAction2(ForkConversationAction);
+registerAction2(RewindConversationAction);
 registerAction2(ExportAgentHostDebugLogsAction);

--- a/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
@@ -207,6 +207,20 @@ export class ChatSlashCommandsContribution extends Disposable {
 			await commandService.executeCommand('workbench.action.chat.forkConversation', sessionResource);
 		}));
 		this._store.add(slashCommandService.registerSlashCommand({
+			command: 'rewind',
+			detail: nls.localize('rewind', "Rewind conversation to a previous point"),
+			sortText: 'z2_rewind',
+			executeImmediately: true,
+			silent: true,
+			locations: [ChatAgentLocation.Chat],
+			when: ContextKeyExpr.or(
+				ChatContextKeys.lockedToCodingAgent.negate(),
+				ChatContextKeys.chatSessionSupportsFork
+			),
+		}, async (_prompt, _progress, _history, _location, sessionResource) => {
+			await commandService.executeCommand('workbench.action.chat.rewindConversation', sessionResource);
+		}));
+		this._store.add(slashCommandService.registerSlashCommand({
 			command: 'rename',
 			detail: nls.localize('rename', "Rename this chat"),
 			sortText: 'z2_rename',

--- a/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
@@ -213,9 +213,12 @@ export class ChatSlashCommandsContribution extends Disposable {
 			executeImmediately: true,
 			silent: true,
 			locations: [ChatAgentLocation.Chat],
-			when: ContextKeyExpr.or(
-				ChatContextKeys.lockedToCodingAgent.negate(),
-				ChatContextKeys.chatSessionSupportsFork
+			when: ContextKeyExpr.and(
+				ContextKeyExpr.or(
+					ChatContextKeys.lockedToCodingAgent.negate(),
+					ChatContextKeys.chatSessionSupportsFork
+				),
+				ChatContextKeys.requestInProgress.negate()
 			),
 		}, async (_prompt, _progress, _history, _location, sessionResource) => {
 			await commandService.executeCommand('workbench.action.chat.rewindConversation', sessionResource);

--- a/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
@@ -18,7 +18,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { IChatAgentService } from '../common/participants/chatAgents.js';
-import { ChatContextKeys } from '../common/actions/chatContextKeys.js';
+import { ChatContextKeyExprs, ChatContextKeys } from '../common/actions/chatContextKeys.js';
 import { IChatSlashCommandService } from '../common/participants/chatSlashCommands.js';
 import { IChatService } from '../common/chatService/chatService.js';
 import { IChatSessionsService, IChatSessionProviderOptionGroup, IChatSessionProviderOptionItem, SessionType } from '../common/chatSessionsService.js';
@@ -215,7 +215,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 			locations: [ChatAgentLocation.Chat],
 			when: ContextKeyExpr.and(
 				ContextKeyExpr.or(
-					ChatContextKeys.lockedToCodingAgent.negate(),
+					ContextKeyExpr.or(ChatContextKeys.lockedToCodingAgent.negate(), ChatContextKeyExprs.isAgentHostSession),
 					ChatContextKeys.chatSessionSupportsFork
 				),
 				ChatContextKeys.requestInProgress.negate()

--- a/src/vs/workbench/contrib/chat/test/browser/chatRewindActions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatRewindActions.test.ts
@@ -1,0 +1,128 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
+import { TestExtensionService, TestStorageService } from '../../../../test/common/workbenchTestServices.js';
+import { getRequestIdsToRewind, getRewindConfirmationMessage } from '../../browser/actions/chatRewindActions.js';
+import { ChatAgentService, IChatAgentService } from '../../common/participants/chatAgents.js';
+import { ChatAgentLocation } from '../../common/constants.js';
+import { ChatModel, ISerializableChatData3 } from '../../common/model/chatModel.js';
+import { IChatService } from '../../common/chatService/chatService.js';
+import { MockChatService } from '../common/chatService/mockChatService.js';
+
+suite('ChatRewindActions - rewind selection', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('rewinds the target request and everything after it', () => {
+		assert.deepStrictEqual(
+			getRequestIdsToRewind(['a', 'b', 'c', 'd'], 'b'),
+			['b', 'c', 'd']
+		);
+	});
+
+	test('rewinding the last request removes only that request', () => {
+		assert.deepStrictEqual(
+			getRequestIdsToRewind(['a', 'b', 'c', 'd'], 'd'),
+			['d']
+		);
+	});
+
+	test('rewinding the first request removes the whole conversation', () => {
+		assert.deepStrictEqual(
+			getRequestIdsToRewind(['a', 'b', 'c'], 'a'),
+			['a', 'b', 'c']
+		);
+	});
+
+	test('returns nothing when the target is not present', () => {
+		assert.deepStrictEqual(getRequestIdsToRewind(['a', 'b', 'c'], 'x'), []);
+	});
+
+	test('returns nothing for an empty conversation', () => {
+		assert.deepStrictEqual(getRequestIdsToRewind([], 'a'), []);
+	});
+
+	test('confirmation message is singular for one removed turn', () => {
+		assert.strictEqual(getRewindConfirmationMessage(1), 'Rewind will remove 1 message from this conversation. This cannot be undone.');
+	});
+
+	test('confirmation message is plural for multiple removed turns', () => {
+		assert.strictEqual(getRewindConfirmationMessage(3), 'Rewind will remove 3 messages from this conversation. This cannot be undone.');
+	});
+});
+
+suite('ChatRewindActions - model truncation (integration)', () => {
+	const testDisposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let instantiationService: TestInstantiationService;
+
+	setup(() => {
+		instantiationService = testDisposables.add(new TestInstantiationService());
+		instantiationService.stub(IStorageService, testDisposables.add(new TestStorageService()));
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IExtensionService, new TestExtensionService());
+		instantiationService.stub(IContextKeyService, new MockContextKeyService());
+		instantiationService.stub(IChatAgentService, testDisposables.add(instantiationService.createInstance(ChatAgentService)));
+		instantiationService.stub(IConfigurationService, new TestConfigurationService());
+		instantiationService.stub(IChatService, new MockChatService());
+	});
+
+	function createModelWithRequests(count: number): ChatModel {
+		const data: ISerializableChatData3 = {
+			version: 3,
+			sessionId: 'rewind-integration-session',
+			creationDate: Date.now(),
+			customTitle: undefined,
+			initialLocation: ChatAgentLocation.Chat,
+			responderUsername: 'bot',
+			requests: Array.from({ length: count }, (_, i) => ({
+				requestId: `req-${i}`,
+				message: { text: `request ${i}`, parts: [] },
+				variableData: { variables: [] },
+				response: [{ value: `response ${i}`, isTrusted: false }],
+				modelState: { value: 1 /* ResponseModelState.Complete */, completedAt: Date.now() },
+			})),
+		};
+		return testDisposables.add(instantiationService.createInstance(
+			ChatModel,
+			{ value: data, serializer: undefined! },
+			{ initialLocation: ChatAgentLocation.Chat, canUseTools: true }
+		));
+	}
+
+	test('removing the selected ids leaves only the turns before the rewind point', () => {
+		const model = createModelWithRequests(4);
+		const ids = model.getRequests().map(request => request.id);
+		assert.strictEqual(ids.length, 4);
+
+		const idsToRewind = getRequestIdsToRewind(ids, ids[1]);
+		for (const id of idsToRewind) {
+			model.removeRequest(id);
+		}
+
+		assert.deepStrictEqual(model.getRequests().map(request => request.id), [ids[0]]);
+	});
+
+	test('rewinding the first turn clears the whole conversation', () => {
+		const model = createModelWithRequests(3);
+		const ids = model.getRequests().map(request => request.id);
+
+		for (const id of getRequestIdsToRewind(ids, ids[0])) {
+			model.removeRequest(id);
+		}
+
+		assert.strictEqual(model.getRequests().length, 0);
+	});
+});
+

--- a/test/automation/src/chat.ts
+++ b/test/automation/src/chat.ts
@@ -11,7 +11,9 @@ const CHAT_INPUT_EDITOR = `${CHAT_VIEW} .interactive-input-part .monaco-editor[r
 const CHAT_INPUT_EDITOR_FOCUSED = `${CHAT_VIEW} .interactive-input-part .monaco-editor.focused[role="code"]`;
 const CHAT_SEND_BUTTON_ENABLED = `${CHAT_VIEW} .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-newline`;
 const CHAT_RESPONSE = `${CHAT_VIEW} .interactive-item-container.interactive-response`;
+const CHAT_REQUEST = `${CHAT_VIEW} .interactive-item-container.interactive-request`;
 const CHAT_RESPONSE_COMPLETE = `${CHAT_RESPONSE}:not(.chat-response-loading)`;
+const DIALOG_PRIMARY_BUTTON = '.monaco-dialog-box .dialog-buttons .monaco-button';
 const CHAT_FOOTER_DETAILS = `${CHAT_VIEW} .chat-footer-details`;
 const CHAT_EDITOR_INPUT_EDITOR = `${CHAT_EDITOR} .interactive-input-part .monaco-editor[role="code"]`;
 const CHAT_EDITOR_INPUT_EDITOR_FOCUSED = `${CHAT_EDITOR} .interactive-input-part .monaco-editor.focused[role="code"]`;
@@ -115,5 +117,30 @@ export class Chat {
 				return !!text && text.length > 0;
 			});
 		});
+	}
+
+	/**
+	 * Number of user request rows currently rendered in the panel chat. Used by
+	 * the rewind smoke test to assert that turns were discarded.
+	 */
+	async getRequestCount(): Promise<number> {
+		return await this.code.driver.currentPage.locator(CHAT_REQUEST).count();
+	}
+
+	/**
+	 * Runs the `/rewind` slash command from the chat input and confirms the
+	 * destructive-action dialog, rewinding the conversation to before its most
+	 * recent turn.
+	 */
+	async rewindLastTurnViaSlashCommand(): Promise<void> {
+		await this.code.waitAndClick(CHAT_INPUT_EDITOR);
+		await this.waitForInputFocus();
+		await this.code.waitForTypeInEditor(this.chatInputSelector, '/rewind');
+		await this.code.waitForElement(CHAT_SEND_BUTTON_ENABLED, undefined, 600);
+		await this.code.waitAndClick(CHAT_SEND_BUTTON_ENABLED);
+
+		// Rewind is destructive, so confirm the warning dialog.
+		await this.code.waitForElement(DIALOG_PRIMARY_BUTTON);
+		await this.code.waitAndClick(DIALOG_PRIMARY_BUTTON);
 	}
 }

--- a/test/automation/src/chat.ts
+++ b/test/automation/src/chat.ts
@@ -14,6 +14,9 @@ const CHAT_RESPONSE = `${CHAT_VIEW} .interactive-item-container.interactive-resp
 const CHAT_REQUEST = `${CHAT_VIEW} .interactive-item-container.interactive-request`;
 const CHAT_RESPONSE_COMPLETE = `${CHAT_RESPONSE}:not(.chat-response-loading)`;
 const DIALOG_PRIMARY_BUTTON = '.monaco-dialog-box .dialog-buttons .monaco-button';
+const CHAT_CHECKPOINT_TOOLBAR = `${CHAT_VIEW} .checkpoint-container .monaco-toolbar`;
+const CHAT_CHECKPOINT_FORK_BUTTON = `${CHAT_CHECKPOINT_TOOLBAR} .action-label.codicon-repo-forked`;
+const CHAT_CHECKPOINT_REWIND_BUTTON = `${CHAT_CHECKPOINT_TOOLBAR} .action-label.codicon-discard`;
 const CHAT_FOOTER_DETAILS = `${CHAT_VIEW} .chat-footer-details`;
 const CHAT_EDITOR_INPUT_EDITOR = `${CHAT_EDITOR} .interactive-input-part .monaco-editor[role="code"]`;
 const CHAT_EDITOR_INPUT_EDITOR_FOCUSED = `${CHAT_EDITOR} .interactive-input-part .monaco-editor.focused[role="code"]`;
@@ -142,5 +145,24 @@ export class Chat {
 		// Rewind is destructive, so confirm the warning dialog.
 		await this.code.waitForElement(DIALOG_PRIMARY_BUTTON);
 		await this.code.waitAndClick(DIALOG_PRIMARY_BUTTON);
+	}
+
+	/**
+	 * Whether the per-message checkpoint toolbar (where Fork lives) contributes both the Fork
+	 * and Rewind buttons. Checks DOM presence, so it holds even before the toolbar is revealed.
+	 * Used by the rewind smoke test to assert Rewind is offered as a button next to Fork.
+	 */
+	async checkpointToolbarHasForkAndRewind(): Promise<boolean> {
+		const forkCount = await this.code.driver.currentPage.locator(CHAT_CHECKPOINT_FORK_BUTTON).count();
+		const rewindCount = await this.code.driver.currentPage.locator(CHAT_CHECKPOINT_REWIND_BUTTON).count();
+		return forkCount > 0 && rewindCount > 0;
+	}
+
+	/**
+	 * Diagnostic helper: returns the outer HTML of every checkpoint container so a failing
+	 * rewind assertion can show what the toolbar actually rendered.
+	 */
+	async dumpCheckpointContainersHtml(): Promise<string> {
+		return await this.code.driver.currentPage.locator(`${CHAT_VIEW} .checkpoint-container`).evaluateAll(els => els.map(el => (el as HTMLElement).outerHTML).join('\n---\n'));
 	}
 }

--- a/test/automation/src/chat.ts
+++ b/test/automation/src/chat.ts
@@ -13,7 +13,10 @@ const CHAT_SEND_BUTTON_ENABLED = `${CHAT_VIEW} .chat-input-toolbars > .chat-exec
 const CHAT_RESPONSE = `${CHAT_VIEW} .interactive-item-container.interactive-response`;
 const CHAT_REQUEST = `${CHAT_VIEW} .interactive-item-container.interactive-request`;
 const CHAT_RESPONSE_COMPLETE = `${CHAT_RESPONSE}:not(.chat-response-loading)`;
-const DIALOG_PRIMARY_BUTTON = '.monaco-dialog-box .dialog-buttons .monaco-button';
+// Primary dialog button — explicitly excludes the `.secondary` class so we don't accidentally
+// click Cancel. Button order is platform-dependent (see `Dialog.rearrangeButtons`), but the
+// `secondary` class is always set to `!primary` regardless of order, so this is reliable.
+const DIALOG_PRIMARY_BUTTON = '.monaco-dialog-box .dialog-buttons .monaco-button:not(.secondary)';
 const CHAT_CHECKPOINT_TOOLBAR = `${CHAT_VIEW} .checkpoint-container .monaco-toolbar`;
 const CHAT_CHECKPOINT_FORK_BUTTON = `${CHAT_CHECKPOINT_TOOLBAR} .action-label.codicon-repo-forked`;
 const CHAT_CHECKPOINT_REWIND_BUTTON = `${CHAT_CHECKPOINT_TOOLBAR} .action-label.codicon-discard`;

--- a/test/automation/src/code.ts
+++ b/test/automation/src/code.ts
@@ -298,8 +298,8 @@ export class Code {
 		await this.poll(() => this.driver.setValue(selector, value), () => true, `set value '${selector}'`);
 	}
 
-	async waitForElements(selector: string, recursive: boolean, accept: (result: IElement[]) => boolean = result => result.length > 0): Promise<IElement[]> {
-		return await this.poll(() => this.driver.getElements(selector, recursive), accept, `get elements '${selector}'`);
+	async waitForElements(selector: string, recursive: boolean, accept: (result: IElement[]) => boolean = result => result.length > 0, retryCount: number = 200): Promise<IElement[]> {
+		return await this.poll(() => this.driver.getElements(selector, recursive), accept, `get elements '${selector}'`, retryCount);
 	}
 
 	async waitForElement(selector: string, accept: (result: IElement | undefined) => boolean = result => !!result, retryCount: number = 200): Promise<IElement> {

--- a/test/smoke/src/areas/chat/chatRewind.test.ts
+++ b/test/smoke/src/areas/chat/chatRewind.test.ts
@@ -61,26 +61,38 @@ export function setup(logger: Logger) {
 
 		it('rewinds the most recent turn out of the conversation', async function () {
 			const app = this.app as Application;
+			const requestSelector = '.interactive-item-container.interactive-request';
 
 			try {
 				await app.workbench.quickaccess.runCommand('workbench.action.chat.open');
 				await app.workbench.chat.waitForChatView();
 
-				// Turn 1
+				// Turn 1 — wait until its request row has rendered.
 				await app.workbench.chat.sendMessage(`first turn [scenario:${REWIND_SCENARIO_ID}]`);
-				await app.workbench.chat.waitForResponse(1500);
+				await app.code.waitForElements(requestSelector, false, els => els.length === 1, 600);
 
-				// Turn 2
+				// Turn 2 — sendMessage waits for the send button to re-enable (i.e. turn 1
+				// finished streaming) before submitting, so this can't race turn 1.
 				await app.workbench.chat.sendMessage(`second turn [scenario:${REWIND_SCENARIO_ID}]`);
-				await app.workbench.chat.waitForResponse(1500);
+				await app.code.waitForElements(requestSelector, false, els => els.length === 2, 600);
 
 				const countBefore = await app.workbench.chat.getRequestCount();
 				assert.strictEqual(countBefore, 2, `expected two request turns before rewind, saw ${countBefore}`);
 
-				// Rewind the most recent turn.
+				// Rewind is offered as a button in the per-message checkpoint toolbar, next to
+				// Fork (the discard icon sits beside the repo-forked icon on the same request).
+				const hasForkAndRewind = await app.workbench.chat.checkpointToolbarHasForkAndRewind();
+				if (!hasForkAndRewind) {
+					logger.log(`[Chat Rewind] checkpoint DOM:\n${await app.workbench.chat.dumpCheckpointContainersHtml()}`);
+				}
+				assert.ok(hasForkAndRewind, 'expected the checkpoint toolbar to show a Rewind button next to Fork');
+
+				// Rewind the most recent turn. The button and the slash command invoke the same
+				// action; drive it via the slash command, which waits for the turn to settle and
+				// confirms the destructive-action dialog deterministically.
 				await app.workbench.chat.rewindLastTurnViaSlashCommand();
 
-				await app.code.waitForElements('.interactive-item-container.interactive-request', false, els => els.length === 1);
+				await app.code.waitForElements(requestSelector, false, els => els.length === 1, 600);
 				const countAfter = await app.workbench.chat.getRequestCount();
 				assert.strictEqual(countAfter, 1, `expected one request turn after rewinding the last, saw ${countAfter}`);
 			} catch (error) {

--- a/test/smoke/src/areas/chat/chatRewind.test.ts
+++ b/test/smoke/src/areas/chat/chatRewind.test.ts
@@ -1,0 +1,95 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { Application, Logger } from '../../../../automation';
+import { dumpFailureDiagnostics, getCopilotSmokeTestEnv, getMockLlmServerPath, installAllHandlers, MockLlmServer } from '../../utils';
+
+const REWIND_SCENARIO_ID = 'smoke-chat-rewind-local';
+const REWIND_REPLY = 'MOCKED_CHAT_REWIND_RESPONSE';
+
+/**
+ * E2E coverage for the `/rewind` feature: after two turns, rewinding discards the
+ * most recent turn in place (the conversation shrinks from two requests to one),
+ * unlike Fork which would open a brand new session.
+ */
+export function setup(logger: Logger) {
+
+	describe('Chat Rewind', function () {
+		this.timeout(5 * 60 * 1000);
+		this.retries(0);
+
+		let mockServer: MockLlmServer;
+
+		before(async function () {
+			const { startServer, ScenarioBuilder, registerScenario } = require(getMockLlmServerPath());
+			registerScenario('text-only', new ScenarioBuilder().emit('OK').build());
+			registerScenario(REWIND_SCENARIO_ID, new ScenarioBuilder().emit(REWIND_REPLY).build());
+			mockServer = await startServer(0, { logger: (msg: string) => logger.log(`[mock-llm] ${msg}`) });
+			logger.log(`[Chat Rewind] mock LLM server started at ${mockServer.url}`);
+		});
+
+		installAllHandlers(logger, opts => {
+			return {
+				...opts,
+				extraEnv: {
+					...(opts.extraEnv ?? {}),
+					...getCopilotSmokeTestEnv(mockServer),
+				},
+			};
+		});
+
+		before(async function () {
+			const app = this.app as Application;
+			await app.workbench.settingsEditor.addUserSettings([
+				['github.copilot.advanced.debug.overrideProxyUrl', JSON.stringify(mockServer.url)],
+				['github.copilot.advanced.debug.overrideCapiUrl', JSON.stringify(mockServer.url)],
+				['github.copilot.advanced.debug.overrideAuthType', '"token"'],
+				['chat.allowAnonymousAccess', 'true'],
+				['github.copilot.chat.githubMcpServer.enabled', 'false'],
+				['chat.mcp.discovery.enabled', 'false'],
+				['chat.mcp.enabled', 'false'],
+				['chat.disableAIFeatures', 'false'],
+			]);
+		});
+
+		after(async function () {
+			await mockServer?.close();
+		});
+
+		it('rewinds the most recent turn out of the conversation', async function () {
+			const app = this.app as Application;
+
+			try {
+				await app.workbench.quickaccess.runCommand('workbench.action.chat.open');
+				await app.workbench.chat.waitForChatView();
+
+				// Turn 1
+				await app.workbench.chat.sendMessage(`first turn [scenario:${REWIND_SCENARIO_ID}]`);
+				await app.workbench.chat.waitForResponse(1500);
+
+				// Turn 2
+				await app.workbench.chat.sendMessage(`second turn [scenario:${REWIND_SCENARIO_ID}]`);
+				await app.workbench.chat.waitForResponse(1500);
+
+				const countBefore = await app.workbench.chat.getRequestCount();
+				assert.strictEqual(countBefore, 2, `expected two request turns before rewind, saw ${countBefore}`);
+
+				// Rewind the most recent turn.
+				await app.workbench.chat.rewindLastTurnViaSlashCommand();
+
+				await app.code.waitForElements('.interactive-item-container.interactive-request', false, els => els.length === 1);
+				const countAfter = await app.workbench.chat.getRequestCount();
+				assert.strictEqual(countAfter, 1, `expected one request turn after rewinding the last, saw ${countAfter}`);
+			} catch (error) {
+				logger.log(`[Chat Rewind] FAILURE: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+				await dumpFailureDiagnostics(app, logger, 'Chat Rewind');
+				throw error;
+			} finally {
+				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
+			}
+		});
+	});
+}

--- a/test/smoke/src/areas/chat/chatRewind.test.ts
+++ b/test/smoke/src/areas/chat/chatRewind.test.ts
@@ -61,7 +61,9 @@ export function setup(logger: Logger) {
 
 		it('rewinds the most recent turn out of the conversation', async function () {
 			const app = this.app as Application;
-			const requestSelector = '.interactive-item-container.interactive-request';
+			// Scope to the panel chat view so we don't accidentally count request rows from
+			// other chat surfaces (e.g. an editor chat that happens to be open).
+			const requestSelector = 'div[id="workbench.panel.chat"] .interactive-item-container.interactive-request';
 
 			try {
 				await app.workbench.quickaccess.runCommand('workbench.action.chat.open');

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -30,6 +30,7 @@ import { setup as setupTaskTests } from './areas/task/task.test';
 import { setup as setupChatTests } from './areas/chat/chatDisabled.test';
 import { setup as setupCopilotCliTests } from './areas/chat/copilotCli.test';
 import { setup as setupChatSessionsTests } from './areas/chat/chatSessions.test';
+import { setup as setupChatRewindTests } from './areas/chat/chatRewind.test';
 import { setup as setupAccessibilityTests } from './areas/accessibility/accessibility.test';
 import { setup as setupAgentsWindowTests } from './areas/agentsWindow/agentsWindow.test';
 
@@ -423,6 +424,7 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	if (!opts.web) { setupChatTests(logger); }
 	if (!opts.web && !opts.remote && quality !== Quality.Dev && quality !== Quality.OSS) { setupCopilotCliTests(logger); }
 	if (!opts.web && !opts.remote) { setupChatSessionsTests(logger); }
+	if (!opts.web && !opts.remote) { setupChatRewindTests(logger); }
 	if (!opts.web && !opts.remote) { setupAgentsWindowTests(logger); }
 	setupAccessibilityTests(logger, opts, quality);
 });


### PR DESCRIPTION
Adds a **`/rewind`** action that discards a conversation turn **in place** — the selected request and everything after it are removed from the current session. This complements **Fork**, which instead copies the prefix into a brand-new session.

### What
- New `RewindConversationAction` (`chat/browser/actions/chatRewindActions.ts`):
  - Contributed to the per-message checkpoint toolbar (`MenuId.ChatMessageCheckpoint`) **right next to Fork**, using the `discard` codicon.
  - Also exposed as the **`/rewind`** slash command; with no explicit point it rewinds the most recent turn.
  - Shows a warning confirmation dialog before removing anything.
  - Pure helper `getRequestIdsToRewind(orderedIds, targetId)` computes the target turn + all later turns to remove.
- Registered via `chat.contribution.ts`.

### Button placement (mirrors Fork)
The Rewind menu/slash-command `when`-clause now mirrors Fork's exactly — including the `chatSessionSupportsFork` fallback. Without it, in a coding-agent (locked) session that supports fork, the Fork button showed in the checkpoint toolbar while Rewind was hidden, leaving `/rewind` reachable only as a slash command. Now Rewind renders as a button next to Fork wherever Fork appears.

### Gating & safety
- Gated on `ChatContextKeys.enabled` so it is hidden when AI features are disabled.
- Hidden on the first request and while a request is in progress.
- Defensive re-check of `requestInProgress` inside `run()`, since `executeCommand` bypasses an action precondition.

### Tests
- Unit (`chatRewindActions.test.ts`): rewind-id selection (target + following turns, unknown id, first/last) and the singular/plural confirmation copy.
- Smoke E2E (`chatRewind.test.ts`): sends two turns, asserts the checkpoint toolbar contributes **both Fork and Rewind** buttons, then rewinds the last turn and asserts the conversation shrinks from two requests to one.

### Screen shots:
<img width="288" height="125" alt="image" src="https://github.com/user-attachments/assets/6240cc2d-8290-4fd0-ae60-8d5edc0952bc" />


