### PR TITLE
sessions: clear chat widget before loading new chat

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -189,9 +189,10 @@ Sessions produce file changes organized into **`ISessionChangeset`** groups — 
    → Provider creates the backend chat model and returns an IChat
    → Management fires onWillSendRequest(session); the view follows the send to
      keep the newest chat active in the visible slot
-  → ChatView locks the embedded ChatWidget to the contributed chat session type
-    (for example agent-host-codex) before setting the model, so follow-up turns
-    keep routing to the provider that owns the session; local chat sessions unlock
+  → ChatView clears the embedded ChatWidget before loading a different chat,
+    then locks it to the contributed chat session type (for example
+    agent-host-codex) before setting the model, so follow-up turns keep routing
+    to the provider that owns the session; local chat sessions unlock
    → Delegates to provider.sendRequest(sessionId, chatResource, options)
    → Provider sends request, returns committed session
    → Management fires onDidStartSession(committedSession) + onDidSendRequest(...)

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -161,6 +161,11 @@ export class ChatView extends AbstractChatView {
 		}));
 	}
 
+	override dispose(): void {
+		this._loadCts.value?.cancel();
+		super.dispose();
+	}
+
 	private _buildStyles(active: boolean) {
 		return {
 			listForeground: active ? activeSessionViewForeground : inactiveSessionViewForeground,
@@ -210,7 +215,7 @@ export class ChatView extends AbstractChatView {
 			if (!token.isCancellationRequested) {
 				this.logService.error('[ChatView] Failed to load chat model for chat', err);
 			}
-			if (resource === this._currentChatResource) { // might have changed while we were waiting, only reset if it is still the same
+			if (isEqual(this._currentChatResource, resource)) { // might have changed while we were waiting, only reset if it is still the same
 				this._currentChatResource = undefined;
 			}
 		});
@@ -222,7 +227,7 @@ export class ChatView extends AbstractChatView {
 	}
 
 	private _clearCurrentChat(): void {
-		void this._widget.clear();
+		this._widget.clear().catch(err => this.logService.error('[ChatView] Failed to clear chat widget', err));
 		this._widget.setModel(undefined);
 		this._modelRef.clear();
 	}

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -186,15 +186,20 @@ export class ChatView extends AbstractChatView {
 			return;
 		}
 
+		const previousChatResource = this._currentChatResource;
 		this._currentChatResource = resource;
 
 		// Cancel any in-flight load for the previous chat and start a fresh one.
+		this._loadCts.value?.cancel();
+		if (previousChatResource) {
+			this._clearCurrentChat();
+		}
 		const cts = new CancellationTokenSource();
 		this._loadCts.value = cts;
 		const token = cts.token;
 
 		const loadPromise = this.chatService.acquireOrLoadSession(resource, ChatAgentLocation.Chat, token, 'ChatView').then(ref => {
-			if (token.isCancellationRequested || !ref) {
+			if (token.isCancellationRequested || !ref || !isEqual(this._currentChatResource, resource)) {
 				ref?.dispose();
 				return;
 			}
@@ -214,6 +219,12 @@ export class ChatView extends AbstractChatView {
 		// matching how each editor group shows progress independently. The short
 		// delay avoids flashing the bar for fast cached loads.
 		this.showProgressWhile(loadPromise, 800);
+	}
+
+	private _clearCurrentChat(): void {
+		void this._widget.clear();
+		this._widget.setModel(undefined);
+		this._modelRef.clear();
 	}
 
 	private _applyHistoryKey(): void {


### PR DESCRIPTION
## Summary
- Clear the embedded ChatWidget before a sessions-window chat view loads a different chat resource
- Cancel stale in-flight chat model loads and guard against outdated model attachment
- Update the sessions architecture doc to include the new swap behavior

## Validation
- npm run typecheck-client -- --pretty false
- npm run precommit
- npm run valid-layers-check
- scripts/test.bat --grep ChatView