### PR TITLE
Fix duplicate issue reporter capture bar when moving to modal editor

### DIFF
--- a/src/vs/workbench/contrib/issue/electron-browser/issueReporterEditorPane.ts
+++ b/src/vs/workbench/contrib/issue/electron-browser/issueReporterEditorPane.ts
@@ -148,6 +148,13 @@ export class IssueReporterEditorPane extends EditorPane {
 		// Keep our own input reference for revealAndActivate() after clearInput().
 		this.wizardInput = input;
 
+		// The input is a singleton, so only one pane may host its wizard at a time.
+		// When the editor moves between the editor area and a modal editor part the
+		// destination pane builds its own wizard; tear down any wizard (and its
+		// workbench-rooted floating capture bar) still held by another pane so we
+		// never end up with two capture bars. Attachments survive via the input.
+		this.destroyOtherLiveWizards();
+
 		// If the wizard is already built and its DOM is still attached, re-parent floating bar if needed
 		if (this.wizard && this.container.contains(this.wizard.getPanel())) {
 			this.wizard.reparentFloatingBar();
@@ -519,6 +526,21 @@ export class IssueReporterEditorPane extends EditorPane {
 		this.wizardInput = undefined;
 		if (this.container) {
 			clearNode(this.container);
+		}
+	}
+
+	/**
+	 * Tear down the wizard on every other live pane. The issue reporter input is a
+	 * singleton, so a wizard held by another pane is stale once this pane hosts it
+	 * (e.g. after the editor moves between the editor area and a modal editor part).
+	 * This also disposes that pane's workbench-rooted floating capture bar, which
+	 * would otherwise linger as a duplicate.
+	 */
+	private destroyOtherLiveWizards(): void {
+		for (const inst of IssueReporterEditorPane.liveInstances) {
+			if (inst !== this && inst.wizard) {
+				inst.destroyWizard();
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes a regression in the issue reporter wizard when used in the Agents Window.

### Problem
1. Open the issue reporter — it opens docked in the editor area (one floating capture bar). ✅
2. Click **Open in Modal Editor** — it moves to a modal editor and the editor-area copy closes, **but now there are two capture bars** (one from the modal wizard, one left over from the editor-area wizard). ❌
3. Closing the modal wizard leaves the orphaned bar behind, and clicking it re-opens a stale wizard in the editor area. ❌

### Cause
`IssueReporterEditorInput` is a singleton, but the floating capture bar is mounted at the `.monaco-workbench` root and the pane's input disposables intentionally survive `clearInput()` (so the wizard persists across tab switches). When the editor moves between the editor area and a modal editor part, the destination pane builds its own wizard + bar while the source pane keeps its own — two bars, with the orphan re-opening a stale pane.

### Fix
Enforce a single live wizard per input: when a pane hosts the wizard in `setInput`, tear down the wizard (and its workbench-rooted floating bar) on every other live pane. Captured attachments are unaffected since they're mirrored onto the editor input and restored into the hosting wizard.

### Verification
Driven live in the Agents Window via CDP — the bar count stays at exactly **1** across: open, move to modal, move back, two full round-trips, and reopen (reuse); and drops to **0** when the editor tab is closed (no orphan).
