### PR TITLE
chat: align reveal unreviewed widget with agent feedback widget

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackReviewCommands.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackReviewCommands.ts
@@ -25,7 +25,7 @@ function kindLabel(kind: AgentFeedbackKind): string | undefined {
 		case AgentFeedbackKind.PRReview:
 			return localize('agentFeedbackReview.prReview', "PR Review");
 		case AgentFeedbackKind.AgentReview:
-			return localize('agentFeedbackReview.codeReview', "Code Review");
+			return localize('agentFeedbackReview.agentReview', "Agent Review");
 		default:
 			return undefined;
 	}

--- a/src/vs/sessions/contrib/agentFeedback/browser/media/agentFeedbackEditorWidget.css
+++ b/src/vs/sessions/contrib/agentFeedback/browser/media/agentFeedbackEditorWidget.css
@@ -201,9 +201,10 @@
 	color: var(--vscode-descriptionForeground);
 }
 
-.agent-feedback-widget-item-prReview .agent-feedback-widget-item-type {
-	background: color-mix(in srgb, var(--vscode-editorInfo-foreground) 22%, var(--vscode-editorWidget-background));
-	color: var(--vscode-editorInfo-foreground);
+.agent-feedback-widget-item-prReview .agent-feedback-widget-item-type,
+.agent-feedback-widget-item-agentFeedback .agent-feedback-widget-item-type {
+	background: color-mix(in srgb, var(--vscode-charts-purple) 22%, var(--vscode-editorWidget-background));
+	color: var(--vscode-charts-purple);
 }
 
 /* Line info */
@@ -245,7 +246,7 @@
 }
 
 .agent-feedback-widget-item-prReview .agent-feedback-widget-suggestion {
-	border-left: 1px solid color-mix(in srgb, var(--vscode-editorInfo-foreground) 50%, transparent);
+	border-left: 1px solid color-mix(in srgb, var(--vscode-charts-purple) 50%, transparent);
 }
 
 .agent-feedback-widget-suggestion-header {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatAgentFeedbackReviewConfirmation.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatAgentFeedbackReviewConfirmation.css
@@ -74,5 +74,5 @@
 }
 
 .chat-confirmation-widget2 .chat-confirmation-widget-message:has(.chat-agent-feedback-review-list) {
-	padding: 6px 11px 6px 6px;
+	padding: var(--vscode-spacing-size60) var(--vscode-spacing-size120) var(--vscode-spacing-size60) var(--vscode-spacing-size60);
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatAgentFeedbackReviewConfirmation.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatAgentFeedbackReviewConfirmation.css
@@ -47,18 +47,16 @@
 	flex: 0 0 auto;
 	padding: 0 var(--vscode-spacing-size40);
 	border-radius: var(--vscode-cornerRadius-xSmall);
-	background-color: var(--vscode-badge-background);
-	color: var(--vscode-badge-foreground);
+	background: color-mix(in srgb, var(--vscode-charts-purple) 22%, var(--vscode-editorWidget-background));
+	color: var(--vscode-charts-purple);
 	font-size: var(--vscode-bodyFontSize-xSmall);
 	text-transform: uppercase;
 }
 
 .chat-agent-feedback-review-file {
 	flex: 1 1 auto;
+	min-width: 0;
 	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	color: var(--vscode-descriptionForeground);
 	font-size: var(--vscode-bodyFontSize-small);
 }
 
@@ -73,4 +71,8 @@
 
 .chat-agent-feedback-review-actions .monaco-action-bar .action-label {
 	color: var(--vscode-icon-foreground);
+}
+
+.chat-confirmation-widget2 .chat-confirmation-widget-message:has(.chat-agent-feedback-review-list) {
+	padding: 6px 11px 6px 6px;
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAgentFeedbackReviewConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAgentFeedbackReviewConfirmationSubPart.ts
@@ -15,10 +15,12 @@ import { URI } from '../../../../../../../base/common/uri.js';
 import { localize } from '../../../../../../../nls.js';
 import { ICommandService } from '../../../../../../../platform/commands/common/commands.js';
 import { IContextKeyService } from '../../../../../../../platform/contextkey/common/contextkey.js';
+import { FileKind } from '../../../../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../../../../platform/keybinding/common/keybinding.js';
 import { ILogService } from '../../../../../../../platform/log/common/log.js';
 import { defaultCheckboxStyles } from '../../../../../../../platform/theme/browser/defaultStyles.js';
+import { DEFAULT_LABELS_CONTAINER, ResourceLabels } from '../../../../../../browser/labels.js';
 import { AgentFeedbackReviewCommandId, IChatAgentFeedbackReviewComment, IChatToolInvocation, ToolConfirmKind } from '../../../../common/chatService/chatService.js';
 import { ILanguageModelToolsService } from '../../../../common/tools/languageModelToolsService.js';
 import { ChatContextKeys } from '../../../../common/actions/chatContextKeys.js';
@@ -50,6 +52,7 @@ export class ChatAgentFeedbackReviewConfirmationSubPart extends AbstractToolConf
 
 	private readonly _rows = new Map<string, ICommentRow>();
 	private readonly _rowStores = this._register(new DisposableMap<string, DisposableStore>());
+	private readonly _resourceLabels: ResourceLabels;
 
 	constructor(
 		toolInvocation: IChatToolInvocation,
@@ -69,6 +72,8 @@ export class ChatAgentFeedbackReviewConfirmationSubPart extends AbstractToolConf
 		if (!data || data.kind !== 'agentFeedbackReviewConfirmation') {
 			throw new Error('Agent feedback review confirmation data is missing');
 		}
+
+		this._resourceLabels = this._register(this.instantiationService.createInstance(ResourceLabels, DEFAULT_LABELS_CONTAINER));
 
 		const listElement = dom.$('.chat-agent-feedback-review-list');
 		void this._populate(listElement);
@@ -159,9 +164,12 @@ export class ChatAgentFeedbackReviewConfirmationSubPart extends AbstractToolConf
 			dom.append(header, dom.$('.chat-agent-feedback-review-kind', undefined, comment.kindLabel));
 		}
 		const fileUri = URI.revive(comment.fileUri);
-		const fileLabel = dom.append(header, dom.$('span.chat-agent-feedback-review-file'));
-		fileLabel.textContent = basename(fileUri);
-		fileLabel.title = fileUri.fsPath || fileUri.path;
+		const fileLabel = rowStore.add(this._resourceLabels.create(header, { supportIcons: true }));
+		fileLabel.element.classList.add('chat-agent-feedback-review-file');
+		fileLabel.setResource(
+			{ resource: fileUri, name: basename(fileUri) },
+			{ fileKind: FileKind.FILE, title: fileUri.fsPath || fileUri.path },
+		);
 
 		const textElement = dom.append(main, dom.$('.chat-agent-feedback-review-text'));
 		textElement.textContent = comment.text;

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -1117,7 +1117,7 @@ export interface IChatAgentFeedbackReviewConfirmationData {
  */
 export interface IChatAgentFeedbackReviewComment {
 	readonly id: string;
-	/** Localized origin label, e.g. "PR Review" or "Code Review"; absent for user-authored comments. */
+	/** Localized origin label, e.g. "PR Review" or "Agent Review"; absent for user-authored comments. */
 	readonly kindLabel?: string;
 	/** The comment body. */
 	readonly text: string;

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatAgentFeedbackReviewConfirmation.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatAgentFeedbackReviewConfirmation.fixture.ts
@@ -21,6 +21,7 @@ import { ChatToolInvocation } from '../../../../contrib/chat/common/model/chatPr
 import { IChatResponseViewModel } from '../../../../contrib/chat/common/model/chatViewModel.js';
 import { ILanguageModelToolsService, IToolData, ToolDataSource } from '../../../../contrib/chat/common/tools/languageModelToolsService.js';
 import { IDecorationsService } from '../../../../services/decorations/common/decorations.js';
+import { INotebookDocumentService } from '../../../../services/notebook/common/notebookDocumentService.js';
 import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
 import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup, registerWorkbenchServices } from '../fixtureUtils.js';
 
@@ -106,6 +107,7 @@ function renderConfirmation(context: ComponentFixtureContext, comments: readonly
 			reg.defineInstance(IDecorationsService, new class extends mock<IDecorationsService>() { override onDidChangeDecorations = Event.None; }());
 			reg.defineInstance(ITextFileService, new class extends mock<ITextFileService>() { override readonly untitled = new class extends mock<ITextFileService['untitled']>() { override readonly onDidChangeLabel = Event.None; }(); }());
 			reg.defineInstance(IWorkspaceContextService, new class extends mock<IWorkspaceContextService>() { override onDidChangeWorkspaceFolders = Event.None; override getWorkspace(): IWorkspace { return { id: '', folders: [], configuration: undefined }; } }());
+			reg.defineInstance(INotebookDocumentService, new class extends mock<INotebookDocumentService>() { }());
 			reg.defineInstance(ICommandService, createCommandService(comments));
 			reg.defineInstance(IChatMarkdownAnchorService, new class extends mock<IChatMarkdownAnchorService>() {
 				override register() { return { dispose() { } }; }

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatAgentFeedbackReviewConfirmation.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatAgentFeedbackReviewConfirmation.fixture.ts
@@ -10,6 +10,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { mock, upcastPartial } from '../../../../../base/test/common/mock.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IMarkdownRendererService, MarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
+import { IWorkspace, IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IChatWidgetService } from '../../../../contrib/chat/browser/chat.js';
 import { IChatToolRiskAssessmentService } from '../../../../contrib/chat/browser/tools/chatToolRiskAssessmentService.js';
 import { IChatContentPartRenderContext, InlineTextModelCollection } from '../../../../contrib/chat/browser/widget/chatContentParts/chatContentParts.js';
@@ -19,6 +20,8 @@ import { AgentFeedbackReviewCommandId, IChatAgentFeedbackReviewComment, IChatAge
 import { ChatToolInvocation } from '../../../../contrib/chat/common/model/chatProgressTypes/chatToolInvocation.js';
 import { IChatResponseViewModel } from '../../../../contrib/chat/common/model/chatViewModel.js';
 import { ILanguageModelToolsService, IToolData, ToolDataSource } from '../../../../contrib/chat/common/tools/languageModelToolsService.js';
+import { IDecorationsService } from '../../../../services/decorations/common/decorations.js';
+import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
 import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup, registerWorkbenchServices } from '../fixtureUtils.js';
 
 import '../../../../contrib/chat/browser/widget/media/chat.css';
@@ -100,6 +103,9 @@ function renderConfirmation(context: ComponentFixtureContext, comments: readonly
 		additionalServices: (reg) => {
 			registerWorkbenchServices(reg);
 			reg.define(IMarkdownRendererService, MarkdownRendererService);
+			reg.defineInstance(IDecorationsService, new class extends mock<IDecorationsService>() { override onDidChangeDecorations = Event.None; }());
+			reg.defineInstance(ITextFileService, new class extends mock<ITextFileService>() { override readonly untitled = new class extends mock<ITextFileService['untitled']>() { override readonly onDidChangeLabel = Event.None; }(); }());
+			reg.defineInstance(IWorkspaceContextService, new class extends mock<IWorkspaceContextService>() { override onDidChangeWorkspaceFolders = Event.None; override getWorkspace(): IWorkspace { return { id: '', folders: [], configuration: undefined }; } }());
 			reg.defineInstance(ICommandService, createCommandService(comments));
 			reg.defineInstance(IChatMarkdownAnchorService, new class extends mock<IChatMarkdownAnchorService>() {
 				override register() { return { dispose() { } }; }
@@ -143,9 +149,9 @@ const prComment: IChatAgentFeedbackReviewComment = {
 	fileUri: URI.file('/workspace/src/utils/array.ts'),
 };
 
-const codeReviewComment: IChatAgentFeedbackReviewComment = {
+const agentReviewComment: IChatAgentFeedbackReviewComment = {
 	id: 'cr-1',
-	kindLabel: 'Code Review',
+	kindLabel: 'Agent Review',
 	text: 'Consider extracting this into a shared helper — it is duplicated in three places.',
 	fileUri: URI.file('/workspace/src/services/userService.ts'),
 };
@@ -169,12 +175,12 @@ export default defineThemedFixtureGroup({ path: 'chat/' }, {
 
 	MixedKinds: defineComponentFixture({
 		labels: { kind: 'screenshot' },
-		render: (ctx) => renderConfirmation(ctx, [prComment, codeReviewComment]),
+		render: (ctx) => renderConfirmation(ctx, [prComment, agentReviewComment]),
 	}),
 
 	ManyComments: defineComponentFixture({
 		labels: { kind: 'screenshot' },
-		render: (ctx) => renderConfirmation(ctx, [prComment, codeReviewComment, longComment]),
+		render: (ctx) => renderConfirmation(ctx, [prComment, agentReviewComment, longComment]),
 	}),
 
 	LongComment: defineComponentFixture({


### PR DESCRIPTION
Aligns the "reveal unreviewed comments" approval widget (chat) with the agent feedback editor widget (sessions).

## What changed
- **Kind label**: The reveal widget and the editor widget now both use **"Agent Review"** for agent-originated review comments (previously the reveal widget showed "Code Review"). PR comments keep the **"PR Review"** label in both places.
- **Badge color**: The kind badge now uses the same color in both widgets and for both kinds (Agent Review + PR Review), reusing the existing `--vscode-charts-purple` token (magenta/purple) rather than introducing a new color. The PR-review suggestion accent border in the editor widget was switched to the same token for coherence.
- **File name + icon**: The reveal widget now renders the comment's file name via `ResourceLabels` (`setResource` with `FileKind.FILE`), so the file icon is shown.
- **Padding**: The reveal confirmation message now uses `padding: 6px 11px 6px 6px` (previously it had no bottom padding).

## Notes for reviewers
- The fixture (`chatAgentFeedbackReviewConfirmation.fixture.ts`) registers the additional services `ResourceLabels` depends on (`IDecorationsService`, `ITextFileService`, `IWorkspaceContextService`), mirroring the established chat-fixture pattern.
- Component screenshot baselines for the reveal widget fixtures will need updating (label text + badge color + file icon changed).
- Verified with a full client type-check and ESLint; hygiene passes (the 2 design-token suggestions reported are on pre-existing lines not touched by this change).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
