### PR TITLE
sessions: show repo and working dir on separate lines in session header hover

### DIFF
--- a/src/vs/sessions/browser/parts/sessionHeader.ts
+++ b/src/vs/sessions/browser/parts/sessionHeader.ts
@@ -26,6 +26,7 @@ import { IHoverService } from '../../../platform/hover/browser/hover.js';
 import { getDefaultHoverDelegate } from '../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { IManagedHoverTooltipMarkdownString } from '../../../base/browser/ui/hover/hover.js';
 import { MarkdownString } from '../../../base/common/htmlContent.js';
+import { extUri } from '../../../base/common/resources.js';
 import { Menus } from '../menus.js';
 import { LocalSelectionTransfer } from '../../../platform/dnd/browser/dnd.js';
 import { DraggedSessionIdentifier, SessionsDataTransfers } from '../dnd.js';
@@ -370,8 +371,9 @@ export class SessionHeader extends Disposable {
 	}
 
 	/**
-	 * Builds the workspace hover content for the current session: the complete
-	 * absolute folder path and git branch, mirroring the session list hover.
+	 * Builds the workspace hover content for the current session. Shows the repo
+	 * folder and, when the working directory differs from the repo root, the
+	 * working directory on a separate line, followed by the git branch.
 	 * Returns `undefined` when there is no workspace to describe.
 	 */
 	private _buildWorkspaceHover(): IManagedHoverTooltipMarkdownString | undefined {
@@ -381,25 +383,35 @@ export class SessionHeader extends Disposable {
 			return undefined;
 		}
 
-		const path = folder.root.fsPath;
+		const repoPath = folder.root.fsPath;
+		const workingDirPath = folder.workingDirectory.fsPath;
+		const hasSeparateWorkingDir = !extUri.isEqual(folder.root, folder.workingDirectory);
 		const branch = folder.gitRepository?.branchName?.trim();
 
 		const md = new MarkdownString('', { supportThemeIcons: true });
 
-		// Folder icon + absolute path. Mirror the meta-row icon logic: cloud for
-		// virtual workspaces, folder when the session runs in the repo checkout,
-		// worktree otherwise.
-		const isWorkspaceFolder = folder.gitRepository?.workTreeUri === undefined;
-		const folderIcon = workspace.isVirtualWorkspace ? Codicon.cloud : isWorkspaceFolder ? Codicon.folder : Codicon.worktree;
-		md.appendMarkdown(`$(${folderIcon.id}) `);
-		md.appendText(path);
-
-		if (branch) {
-			md.appendMarkdown(' · $(git-branch) ');
-			md.appendText(branch);
+		const fallbackLines: string[] = [];
+		if (hasSeparateWorkingDir) {
+			const isWorkspaceFolder = folder.gitRepository?.workTreeUri === undefined;
+			const repoIcon = workspace.isVirtualWorkspace ? Codicon.cloud : isWorkspaceFolder ? Codicon.folder : Codicon.worktree;
+			md.appendMarkdown(`$(${repoIcon.id}) `);
+			md.appendText(repoPath);
+			md.appendMarkdown(`\n\n$(${Codicon.folder.id}) `);
+			md.appendText(workingDirPath);
+			fallbackLines.push(repoPath, workingDirPath);
+		} else {
+			md.appendMarkdown(`$(${Codicon.folder.id}) `);
+			md.appendText(workingDirPath);
+			fallbackLines.push(workingDirPath);
 		}
 
-		return { markdown: md, markdownNotSupportedFallback: branch ? `${path} · ${branch}` : path };
+		if (branch) {
+			md.appendMarkdown('\n\n$(git-branch) ');
+			md.appendText(branch);
+			fallbackLines.push(branch);
+		}
+
+		return { markdown: md, markdownNotSupportedFallback: fallbackLines.join('\n') };
 	}
 
 	private _setVisible(visible: boolean): void {


### PR DESCRIPTION
## What

Updates the session header workspace hover in `src/vs/sessions/browser/parts/sessionHeader.ts`:

- Folder path and git branch are now shown on **separate lines** instead of being joined with `·`.
- The working directory always uses the **folder icon**.
- When the working directory differs from the repo root, the **repo folder** is shown on its own line above the working directory, keeping its original icon (cloud for virtual workspaces, folder for repo checkout, worktree otherwise).

## Why

The previous single-line hover was hard to read. Separating folder and branch (and surfacing the working directory distinctly from the repo) matches the requested layout.

## Notes for reviewers

- Scoped to the Agents window (`src/vs/sessions`).
- `npm run typecheck-client` passes.