### PR TITLE
Initialize language pack service in CLI process

### DIFF
--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -236,9 +236,6 @@ class CliMain extends Disposable {
 		services.set(IExtensionGalleryManifestService, new SyncDescriptor(ExtensionGalleryManifestService));
 		services.set(IExtensionGalleryService, new SyncDescriptor(ExtensionGalleryServiceWithNoStorageService, undefined, true));
 
-		// Localizations
-		services.set(ILanguagePackService, new SyncDescriptor(NativeLanguagePackService, undefined, false));
-
 		// MCP
 		services.set(IAllowedMcpServersService, new SyncDescriptor(AllowedMcpServersService, undefined, true));
 		services.set(IMcpResourceScannerService, new SyncDescriptor(McpResourceScannerService, undefined, true));
@@ -267,7 +264,10 @@ class CliMain extends Disposable {
 			services.set(ITelemetryService, NullTelemetryService);
 		}
 
-		return [new InstantiationService(services), appenders];
+		const instantiationService = new InstantiationService(services);
+		services.set(ILanguagePackService, instantiationService.createInstance(NativeLanguagePackService));
+
+		return [instantiationService, appenders];
 	}
 
 	private allowWindowsUNCPath(path: string): string {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #237663

## Summary

Initialize `NativeLanguagePackService` during CLI service setup so language pack install participants run when installing extensions from the command line.

This ensures that installing a language pack via `--install-extension` updates `languagepacks.json`, allowing VS Code to use the locale configured in `argv.json` on the next launch.

## Testing

1. Run `code-oss --install-extension <path-to-ms-ceintl.vscode-language-pack-ja.vsix>`.
2. Set `"locale": "ja"` in `argv.json`.
3. Launch Code - OSS.
4. Confirm that the display language is Japanese.