### PR TITLE
Allow chat-lib embedders to supply the tokenizer implementation

### DIFF
--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/ghostText/ghostText.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/ghostText/ghostText.ts
@@ -11,7 +11,7 @@ import { IInstantiationService, ServicesAccessor } from '../../../../../../util/
 import { LlmNESTelemetryBuilder } from '../../../../../inlineEdits/node/nextEditProviderTelemetry';
 import { isInlineSuggestionFromTextAfterCursor } from '../../../../../xtab/common/inlineSuggestion';
 import { GhostTextLogContext } from '../../../../common/ghostTextContext';
-import { initializeTokenizers } from '../../../prompt/src/tokenization';
+import { ensureTokenizersLoaded } from '../../../prompt/src/tokenization';
 import { CancellationTokenSource, CancellationToken as ICancellationToken } from '../../../types/src';
 import { ICompletionsNotifierService } from '../completionNotifier';
 import { CompletionState } from '../completionState';
@@ -156,7 +156,7 @@ export class GhostTextComputer {
 		// means we can't use `initialize` to actually initialize anything expensive.  This the primary user of the
 		// tokenizer, so settle for initializing here instead.  We don't use waitForTokenizers() because in the event of a
 		// tokenizer load failure, that would spam handleException() on every request.
-		await initializeTokenizers.catch(() => { });
+		await ensureTokenizersLoaded().catch(() => { });
 		try {
 			this.contextProviderBridge.schedule(
 				completionState,

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/ghostText/test/ghostText.test.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/ghostText/test/ghostText.test.ts
@@ -14,7 +14,7 @@ import { SyncDescriptor } from '../../../../../../../util/vs/platform/instantiat
 import { ServicesAccessor } from '../../../../../../../util/vs/platform/instantiation/common/instantiation';
 import { LlmNESTelemetryBuilder } from '../../../../../../inlineEdits/node/nextEditProviderTelemetry';
 import { GhostTextLogContext } from '../../../../../common/ghostTextContext';
-import { initializeTokenizers } from '../../../../prompt/src/tokenization';
+import { ensureTokenizersLoaded } from '../../../../prompt/src/tokenization';
 import { CompletionState, createCompletionState } from '../../completionState';
 import { ConfigKey, ICompletionsConfigProvider, InMemoryConfigProvider } from '../../config';
 import { ICompletionsFetcherService, Response } from '../../networking';
@@ -123,7 +123,7 @@ suite('Isolated GhostText tests', function () {
 	}
 
 	suiteSetup(async function () {
-		await initializeTokenizers;
+		await ensureTokenizersLoaded();
 	});
 
 	test('returns annotations in the result', async function () {

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/prompt/components/test/similarFiles.test.tsx
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/prompt/components/test/similarFiles.test.tsx
@@ -10,7 +10,7 @@ import dedent from 'ts-dedent';
 import { IInstantiationService, ServicesAccessor } from '../../../../../../../../util/vs/platform/instantiation/common/instantiation';
 import { PromptSnapshotNode } from '../../../../../prompt/src/components/components';
 import { VirtualPrompt } from '../../../../../prompt/src/components/virtualPrompt';
-import { initializeTokenizers } from '../../../../../prompt/src/tokenization';
+import { ensureTokenizersLoaded } from '../../../../../prompt/src/tokenization';
 import { CompletionRequestDocument } from '../../../prompt/completionsPromptFactory/componentsCompletionsPromptFactory';
 import { SimilarFiles } from '../../../prompt/components/similarFiles';
 import { CodeSnippetWithId, TraitWithId } from '../../../prompt/contextProviders/contextItemSchemas';
@@ -27,7 +27,7 @@ suite('Similar Files', function () {
 	setup(async function () {
 		accessor = createLibTestingContext().createTestingAccessor();
 		NeighborSource.reset();
-		await initializeTokenizers;
+		await ensureTokenizersLoaded();
 	});
 
 	test('Empty render without similar file', async function () {

--- a/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/test/similarFiles.test.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/test/similarFiles.test.ts
@@ -16,7 +16,7 @@ import {
 	nullSimilarFilesOptions,
 } from '../snippetInclusion/similarFiles';
 import { SnippetWithProviderInfo } from '../snippetInclusion/snippets';
-import { initializeTokenizers } from '../tokenization';
+import { ensureTokenizersLoaded } from '../tokenization';
 
 async function retrieveAllSnippetsWithJaccardScore(
 	objectDoc: SimilarFileInfo,
@@ -52,7 +52,7 @@ async function findBestJaccardMatch(
 
 suite('selectRelevance Test Suite', function () {
 	setup(async function () {
-		await initializeTokenizers;
+		await ensureTokenizersLoaded();
 	});
 
 	test('findBestJaccardMatch computes correct score of two single lines', async function () {
@@ -410,7 +410,7 @@ suite('Test getSimilarSnippets function', function () {
 	];
 
 	setup(async function () {
-		await initializeTokenizers;
+		await ensureTokenizersLoaded();
 	});
 
 	test('Returns correct snippet in conservative mode', async function () {

--- a/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/test/tokenizer.test.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/test/tokenizer.test.ts
@@ -5,7 +5,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import { resolve } from 'path';
-import { ApproximateTokenizer, getTokenizer, TokenizerName } from '../tokenization';
+import { ApproximateTokenizer, getTokenizer, initializeTokenizers, Tokenizer, TokenizerName } from '../tokenization';
 
 // Read the source files and normalize the line endings
 const source = fs.readFileSync(resolve(__dirname, 'testdata/example.py'), 'utf8').replace(/\r\n?/g, '\n');
@@ -62,7 +62,14 @@ suite('MockTokenizer', function () {
 });
 
 suite('Tokenizer Test Suite - cl100k', function () {
-	const tokenizer = getTokenizer(TokenizerName.cl100k);
+	// The dictionaries load lazily on the first initializeTokenizers await;
+	// fetch the tokenizer after that instead of at suite definition time,
+	// which would capture the approximate fallback.
+	let tokenizer: Tokenizer;
+	suiteSetup(async function () {
+		await initializeTokenizers;
+		tokenizer = getTokenizer(TokenizerName.cl100k);
+	});
 
 	test('empty string', function () {
 		const str = '';
@@ -262,7 +269,11 @@ with minor edits to make it`;
 });
 
 suite('Tokenizer Test Suite - o200k', function () {
-	const tokenizer = getTokenizer(TokenizerName.o200k);
+	let tokenizer: Tokenizer;
+	suiteSetup(async function () {
+		await initializeTokenizers;
+		tokenizer = getTokenizer(TokenizerName.o200k);
+	});
 
 	test('empty string', function () {
 		const str = '';

--- a/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/test/tokenizer.test.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/test/tokenizer.test.ts
@@ -5,7 +5,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import { resolve } from 'path';
-import { ApproximateTokenizer, getTokenizer, initializeTokenizers, Tokenizer, TokenizerName } from '../tokenization';
+import { ApproximateTokenizer, ensureTokenizersLoaded, getTokenizer, Tokenizer, TokenizerName } from '../tokenization';
 
 // Read the source files and normalize the line endings
 const source = fs.readFileSync(resolve(__dirname, 'testdata/example.py'), 'utf8').replace(/\r\n?/g, '\n');
@@ -62,12 +62,12 @@ suite('MockTokenizer', function () {
 });
 
 suite('Tokenizer Test Suite - cl100k', function () {
-	// The dictionaries load lazily on the first initializeTokenizers await;
+	// The dictionaries load lazily on the first ensureTokenizersLoaded() call;
 	// fetch the tokenizer after that instead of at suite definition time,
 	// which would capture the approximate fallback.
 	let tokenizer: Tokenizer;
 	suiteSetup(async function () {
-		await initializeTokenizers;
+		await ensureTokenizersLoaded();
 		tokenizer = getTokenizer(TokenizerName.cl100k);
 	});
 
@@ -271,7 +271,7 @@ with minor edits to make it`;
 suite('Tokenizer Test Suite - o200k', function () {
 	let tokenizer: Tokenizer;
 	suiteSetup(async function () {
-		await initializeTokenizers;
+		await ensureTokenizersLoaded();
 		tokenizer = getTokenizer(TokenizerName.o200k);
 	});
 

--- a/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/test/tokenizer.test.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/test/tokenizer.test.ts
@@ -5,7 +5,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import { resolve } from 'path';
-import { ApproximateTokenizer, ensureTokenizersLoaded, getTokenizer, Tokenizer, TokenizerName } from '../tokenization';
+import { ApproximateTokenizer, ensureTokenizersLoaded, ExternalTokenizerProvider, getTokenizer, resetTokenizersForTest, setExternalTokenizerProvider, Tokenizer, TokenizerName } from '../tokenization';
 
 // Read the source files and normalize the line endings
 const source = fs.readFileSync(resolve(__dirname, 'testdata/example.py'), 'utf8').replace(/\r\n?/g, '\n');
@@ -602,5 +602,80 @@ suite('ApproximateTokenizer', function () {
 			const result = cl100kTokenizer.takeLastLinesTokens(text, 10);
 			assert.strictEqual(typeof result, 'string');
 		});
+	});
+});
+
+suite('Tokenizer Test Suite - external provider', function () {
+	class FakeExternalTokenizerProvider implements ExternalTokenizerProvider {
+		ensureLoadedCalls = 0;
+		getTokenizerCalls = 0;
+
+		constructor(
+			private readonly tokenizer: Tokenizer,
+			private readonly behavior: { getTokenizerThrows?: boolean; ensureLoadedRejects?: boolean } = {}
+		) { }
+
+		getTokenizer(_name: TokenizerName): Tokenizer {
+			this.getTokenizerCalls++;
+			if (this.behavior.getTokenizerThrows) {
+				throw new Error('getTokenizer failed');
+			}
+			return this.tokenizer;
+		}
+
+		ensureLoaded(): Promise<void> {
+			this.ensureLoadedCalls++;
+			return this.behavior.ensureLoadedRejects
+				? Promise.reject(new Error('ensureLoaded failed'))
+				: Promise.resolve();
+		}
+	}
+
+	setup(function () {
+		resetTokenizersForTest();
+	});
+
+	teardown(function () {
+		resetTokenizersForTest();
+	});
+
+	test('getTokenizer delegates to the installed provider', function () {
+		const hostTokenizer = new ApproximateTokenizer();
+		setExternalTokenizerProvider(new FakeExternalTokenizerProvider(hostTokenizer));
+
+		assert.strictEqual(getTokenizer(TokenizerName.cl100k), hostTokenizer);
+	});
+
+	test('ensureTokenizersLoaded defers to the provider and single-flights concurrent calls', async function () {
+		const provider = new FakeExternalTokenizerProvider(new ApproximateTokenizer());
+		setExternalTokenizerProvider(provider);
+
+		await Promise.all([ensureTokenizersLoaded(), ensureTokenizersLoaded()]);
+
+		assert.strictEqual(provider.ensureLoadedCalls, 1);
+	});
+
+	test('getTokenizer falls back to the approximate tokenizer when the provider throws', function () {
+		setExternalTokenizerProvider(new FakeExternalTokenizerProvider(new ApproximateTokenizer(), { getTokenizerThrows: true }));
+
+		assert.ok(getTokenizer(TokenizerName.cl100k) instanceof ApproximateTokenizer);
+	});
+
+	test('ensureTokenizersLoaded resolves and retries when the provider load fails', async function () {
+		const provider = new FakeExternalTokenizerProvider(new ApproximateTokenizer(), { ensureLoadedRejects: true });
+		setExternalTokenizerProvider(provider);
+
+		await ensureTokenizersLoaded();
+		await ensureTokenizersLoaded();
+
+		assert.strictEqual(provider.ensureLoadedCalls, 2);
+	});
+
+	test('the first installed provider wins', function () {
+		const first = new ApproximateTokenizer();
+		setExternalTokenizerProvider(new FakeExternalTokenizerProvider(first));
+		setExternalTokenizerProvider(new FakeExternalTokenizerProvider(new ApproximateTokenizer()));
+
+		assert.strictEqual(getTokenizer(TokenizerName.cl100k), first);
 	});
 });

--- a/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
@@ -16,7 +16,37 @@ export enum TokenizerName {
 
 const tokenizers = new Map<TokenizerName, Tokenizer>();
 
+/**
+ * Tokenizer implementation supplied by the embedding host via
+ * {@link setExternalTokenizerProvider}. Hosts that already have the
+ * cl100k/o200k BPE dictionaries in memory (e.g. a language server that
+ * bundles its own copy of this prompt library) can register a provider so
+ * this module never loads a duplicate dictionary set (~100 MB per encoder).
+ */
+export interface ExternalTokenizerProvider {
+	/** Returns a tokenizer for the given encoder. */
+	getTokenizer(name: TokenizerName): Tokenizer;
+	/**
+	 * Ensures the host's dictionaries are loaded. Awaited by
+	 * {@link initializeTokenizers}, which callers use as the
+	 * exact-tokenization gate before token counting.
+	 */
+	ensureLoaded(): Promise<void>;
+}
+
+let externalProvider: ExternalTokenizerProvider | undefined;
+
+/**
+ * Registers a host tokenizer used instead of loading this module's own BPE
+ * dictionaries. Call before the first {@link getTokenizer} /
+ * {@link initializeTokenizers} use, e.g. during host startup.
+ */
+export function setExternalTokenizerProvider(provider: ExternalTokenizerProvider): void {
+	externalProvider = provider;
+}
+
 export function getTokenizer(name: TokenizerName = TokenizerName.o200k): Tokenizer {
+	if (externalProvider) { return externalProvider.getTokenizer(name); }
 	let tokenizer = tokenizers.get(name);
 	if (tokenizer !== undefined) { return tokenizer; }
 	// Fallback to o200k
@@ -378,8 +408,39 @@ async function setTokenizer(name: TokenizerName) {
 	}
 }
 
-/** Load tokenizers on start. Export promise for to be awaited by initialization. */
-export const initializeTokenizers = (async () => {
-	tokenizers.set(TokenizerName.mock, new MockTokenizer());
-	await Promise.all([setTokenizer(TokenizerName.cl100k), setTokenizer(TokenizerName.o200k)]);
-})();
+tokenizers.set(TokenizerName.mock, new MockTokenizer());
+
+let ownLoadPromise: Promise<void> | undefined;
+
+function loadTokenizers(): Promise<void> {
+	if (externalProvider) { return externalProvider.ensureLoaded(); }
+	ownLoadPromise ??= Promise.all([setTokenizer(TokenizerName.cl100k), setTokenizer(TokenizerName.o200k)]).then(() => undefined);
+	return ownLoadPromise;
+}
+
+/**
+ * Loads the tokenizers. This is a lazy thenable rather than an eagerly
+ * started promise: the dictionary load starts the first time it is awaited
+ * (callers like ghostText await it before token counting) instead of at
+ * module evaluation. That gives an embedding host the chance to register an
+ * {@link setExternalTokenizerProvider | external provider} first, in which
+ * case awaiting this defers to the host's dictionaries and this module's own
+ * dictionaries are never loaded.
+ */
+export const initializeTokenizers: Promise<void> = {
+	then<TResult1 = void, TResult2 = never>(
+		onfulfilled?: ((value: void) => TResult1 | PromiseLike<TResult1>) | null,
+		onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+	): Promise<TResult1 | TResult2> {
+		return loadTokenizers().then(onfulfilled, onrejected);
+	},
+	catch<TResult = never>(
+		onrejected?: ((reason: unknown) => TResult | PromiseLike<TResult>) | null
+	): Promise<void | TResult> {
+		return loadTokenizers().catch(onrejected);
+	},
+	finally(onfinally?: (() => void) | null): Promise<void> {
+		return loadTokenizers().finally(onfinally);
+	},
+	[Symbol.toStringTag]: 'Promise',
+} as Promise<void>;

--- a/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
@@ -63,6 +63,9 @@ export function getTokenizer(name: TokenizerName = TokenizerName.o200k): Tokeniz
 	}
 	let tokenizer = tokenizers.get(name);
 	if (tokenizer !== undefined) { return tokenizer; }
+	// Kick the lazy dictionary load (fire-and-forget) so callers that never
+	// await initializeTokenizers still converge on exact tokenization.
+	void loadTokenizers();
 	// Fallback to o200k
 	tokenizer = tokenizers.get(TokenizerName.o200k);
 	if (tokenizer !== undefined) { return tokenizer; }

--- a/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
@@ -38,15 +38,29 @@ let externalProvider: ExternalTokenizerProvider | undefined;
 
 /**
  * Registers a host tokenizer used instead of loading this module's own BPE
- * dictionaries. Call before the first {@link getTokenizer} /
- * {@link initializeTokenizers} use, e.g. during host startup.
+ * dictionaries. Must be called once, before the first
+ * {@link initializeTokenizers} await (e.g. during host startup) — throws on
+ * re-registration or after this module's own dictionary load has started, so
+ * the load strategy cannot silently switch mid-session.
  */
 export function setExternalTokenizerProvider(provider: ExternalTokenizerProvider): void {
+	if (externalProvider) {
+		throw new Error('External tokenizer provider is already registered');
+	}
+	if (ownLoadPromise) {
+		throw new Error('Cannot register an external tokenizer provider after the built-in tokenizers started loading');
+	}
 	externalProvider = provider;
 }
 
 export function getTokenizer(name: TokenizerName = TokenizerName.o200k): Tokenizer {
-	if (externalProvider) { return externalProvider.getTokenizer(name); }
+	if (externalProvider) {
+		try {
+			return externalProvider.getTokenizer(name);
+		} catch {
+			// Preserve this function's never-throws contract; fall back below.
+		}
+	}
 	let tokenizer = tokenizers.get(name);
 	if (tokenizer !== undefined) { return tokenizer; }
 	// Fallback to o200k
@@ -411,9 +425,20 @@ async function setTokenizer(name: TokenizerName) {
 tokenizers.set(TokenizerName.mock, new MockTokenizer());
 
 let ownLoadPromise: Promise<void> | undefined;
+let externalLoadPromise: Promise<void> | undefined;
 
 function loadTokenizers(): Promise<void> {
-	if (externalProvider) { return externalProvider.ensureLoaded(); }
+	if (externalProvider) {
+		const provider = externalProvider;
+		// Single-flight: concurrent awaits share one ensureLoaded() call. Like
+		// the built-in path (setTokenizer swallows load errors), the gate never
+		// rejects — but a failed attempt clears the memo so a later await can
+		// retry instead of pinning approximate tokenization forever.
+		externalLoadPromise ??= Promise.resolve().then(() => provider.ensureLoaded()).catch(() => {
+			externalLoadPromise = undefined;
+		});
+		return externalLoadPromise;
+	}
 	ownLoadPromise ??= Promise.all([setTokenizer(TokenizerName.cl100k), setTokenizer(TokenizerName.o200k)]).then(() => undefined);
 	return ownLoadPromise;
 }
@@ -425,7 +450,9 @@ function loadTokenizers(): Promise<void> {
  * module evaluation. That gives an embedding host the chance to register an
  * {@link setExternalTokenizerProvider | external provider} first, in which
  * case awaiting this defers to the host's dictionaries and this module's own
- * dictionaries are never loaded.
+ * dictionaries are never loaded. Like before, awaiting never rejects — load
+ * failures (built-in or external) resolve and leave the approximate
+ * tokenizer fallback in place.
  */
 export const initializeTokenizers: Promise<void> = {
 	then<TResult1 = void, TResult2 = never>(

--- a/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
@@ -467,3 +467,16 @@ function loadTokenizers(): Promise<void> {
 export function ensureTokenizersLoaded(): Promise<void> {
 	return loadTokenizers();
 }
+
+/**
+ * Test-only: restores this module's tokenizer state to its initial values so a
+ * suite that installs a fake {@link ExternalTokenizerProvider} does not leak
+ * into other suites that share the same process. Not part of the public API.
+ */
+export function resetTokenizersForTest(): void {
+	externalProvider = undefined;
+	ownLoadPromise = undefined;
+	externalLoadPromise = undefined;
+	tokenizers.clear();
+	tokenizers.set(TokenizerName.mock, new MockTokenizer());
+}

--- a/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
@@ -69,7 +69,9 @@ export function getTokenizer(name: TokenizerName = TokenizerName.o200k): Tokeniz
 	let tokenizer = tokenizers.get(name);
 	if (tokenizer !== undefined) { return tokenizer; }
 	// Kick the lazy dictionary load (fire-and-forget) so callers that never
-	// call ensureTokenizersLoaded() still converge on exact tokenization.
+	// call ensureTokenizersLoaded() still get exact tokenization on a later
+	// call once the load finishes — or stay on the approximate fallback if it
+	// fails.
 	void loadTokenizers();
 	// Fallback to o200k
 	tokenizer = tokenizers.get(TokenizerName.o200k);

--- a/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
@@ -28,7 +28,7 @@ export interface ExternalTokenizerProvider {
 	getTokenizer(name: TokenizerName): Tokenizer;
 	/**
 	 * Ensures the host's dictionaries are loaded. Awaited by
-	 * {@link initializeTokenizers}, which callers use as the
+	 * {@link ensureTokenizersLoaded}, which callers use as the
 	 * exact-tokenization gate before token counting.
 	 */
 	ensureLoaded(): Promise<void>;
@@ -69,7 +69,7 @@ export function getTokenizer(name: TokenizerName = TokenizerName.o200k): Tokeniz
 	let tokenizer = tokenizers.get(name);
 	if (tokenizer !== undefined) { return tokenizer; }
 	// Kick the lazy dictionary load (fire-and-forget) so callers that never
-	// await initializeTokenizers still converge on exact tokenization.
+	// call ensureTokenizersLoaded() still converge on exact tokenization.
 	void loadTokenizers();
 	// Fallback to o200k
 	tokenizer = tokenizers.get(TokenizerName.o200k);
@@ -452,30 +452,16 @@ function loadTokenizers(): Promise<void> {
 }
 
 /**
- * Loads the tokenizers. This is a lazy thenable rather than an eagerly
- * started promise: the dictionary load starts the first time it is awaited
- * (callers like ghostText await it before token counting) instead of at
- * module evaluation. That gives an embedding host the chance to register an
- * {@link setExternalTokenizerProvider | external provider} first, in which
- * case awaiting this defers to the host's dictionaries and this module's own
- * dictionaries are never loaded. Like before, awaiting never rejects — load
- * failures (built-in or external) resolve and leave the approximate
- * tokenizer fallback in place.
+ * Ensures the tokenizers are loaded; resolves once tokenization is exact.
+ *
+ * Lazy: the dictionary load starts the first time this is called (callers like
+ * ghostText call it before token counting) instead of at module evaluation.
+ * That gives an embedding host the chance to register an
+ * {@link setExternalTokenizerProvider | external provider} first, in which case
+ * this defers to the host's dictionaries and this module's own dictionaries are
+ * never loaded. Never rejects — load failures (built-in or external) resolve
+ * and leave the approximate tokenizer fallback in place.
  */
-export const initializeTokenizers: Promise<void> = {
-	then<TResult1 = void, TResult2 = never>(
-		onfulfilled?: ((value: void) => TResult1 | PromiseLike<TResult1>) | null,
-		onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
-	): Promise<TResult1 | TResult2> {
-		return loadTokenizers().then(onfulfilled, onrejected);
-	},
-	catch<TResult = never>(
-		onrejected?: ((reason: unknown) => TResult | PromiseLike<TResult>) | null
-	): Promise<void | TResult> {
-		return loadTokenizers().catch(onrejected);
-	},
-	finally(onfinally?: (() => void) | null): Promise<void> {
-		return loadTokenizers().finally(onfinally);
-	},
-	[Symbol.toStringTag]: 'Promise',
-} as Promise<void>;
+export function ensureTokenizersLoaded(): Promise<void> {
+	return loadTokenizers();
+}

--- a/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/prompt/src/tokenization/tokenizer.ts
@@ -37,18 +37,23 @@ export interface ExternalTokenizerProvider {
 let externalProvider: ExternalTokenizerProvider | undefined;
 
 /**
- * Registers a host tokenizer used instead of loading this module's own BPE
- * dictionaries. Must be called once, before the first
- * {@link initializeTokenizers} await (e.g. during host startup) — throws on
- * re-registration or after this module's own dictionary load has started, so
- * the load strategy cannot silently switch mid-session.
+ * Installs a host tokenizer used instead of loading this module's own BPE
+ * dictionaries. chat-lib embedders supply this through the inline-completions
+ * factory option `tokenizerProvider`, which installs it synchronously before
+ * any tokenization — so there is no registration race.
+ *
+ * Never throws, to keep host startup robust. The first provider wins: a later
+ * registration, or one made after the built-in dictionaries already started
+ * loading, is ignored and the current tokenizer keeps being used. The
+ * completions tokenizer is process-global, so only one provider is ever in
+ * effect.
  */
 export function setExternalTokenizerProvider(provider: ExternalTokenizerProvider): void {
-	if (externalProvider) {
-		throw new Error('External tokenizer provider is already registered');
-	}
-	if (ownLoadPromise) {
-		throw new Error('Cannot register an external tokenizer provider after the built-in tokenizers started loading');
+	if (externalProvider || ownLoadPromise) {
+		// A provider is already installed, or the built-in dictionaries already
+		// started loading; keep the current strategy rather than switching
+		// mid-session. The host transparently falls back instead of failing.
+		return;
 	}
 	externalProvider = provider;
 }

--- a/extensions/copilot/src/lib/node/chatLibMain.ts
+++ b/extensions/copilot/src/lib/node/chatLibMain.ts
@@ -411,7 +411,7 @@ function setupServices(options: INESProviderOptions) {
 	builder.define(IChatQuotaService, new SyncDescriptor(ChatQuotaService));
 	builder.define(IInteractionService, new SyncDescriptor(InteractionService));
 	builder.define(IRequestLogger, new SyncDescriptor(NullRequestLogger));
-	builder.define(ITokenizerProvider, options.tokenizerProvider || new SyncDescriptor(TokenizerProvider, [false]));
+	builder.define(ITokenizerProvider, options.tokenizerProvider ?? new SyncDescriptor(TokenizerProvider, [false]));
 	builder.define(IConversationOptions, {
 		_serviceBrand: undefined,
 		maxResponseTokens: undefined,

--- a/extensions/copilot/src/lib/node/chatLibMain.ts
+++ b/extensions/copilot/src/lib/node/chatLibMain.ts
@@ -194,6 +194,14 @@ export interface INESProviderOptions {
 	 * {@link TestLanguageDiagnosticsService} that returns empty diagnostics
 	 */
 	readonly languageDiagnosticsService?: ILanguageDiagnosticsService;
+	/**
+	 * Tokenizer provider backing prompt rendering and token budgeting. When
+	 * omitted, falls back to the built-in {@link TokenizerProvider}, which
+	 * loads its own BPE dictionaries. Embedders that already have the
+	 * cl100k/o200k dictionaries in memory can supply a provider here to avoid
+	 * loading a second copy (~100 MB per encoder).
+	 */
+	readonly tokenizerProvider?: ITokenizerProvider;
 }
 
 export interface INESResult {
@@ -403,7 +411,7 @@ function setupServices(options: INESProviderOptions) {
 	builder.define(IChatQuotaService, new SyncDescriptor(ChatQuotaService));
 	builder.define(IInteractionService, new SyncDescriptor(InteractionService));
 	builder.define(IRequestLogger, new SyncDescriptor(NullRequestLogger));
-	builder.define(ITokenizerProvider, new SyncDescriptor(TokenizerProvider, [false]));
+	builder.define(ITokenizerProvider, options.tokenizerProvider || new SyncDescriptor(TokenizerProvider, [false]));
 	builder.define(IConversationOptions, {
 		_serviceBrand: undefined,
 		maxResponseTokens: undefined,

--- a/extensions/copilot/src/lib/node/chatLibMain.ts
+++ b/extensions/copilot/src/lib/node/chatLibMain.ts
@@ -48,6 +48,7 @@ import { ICompletionsTextDocumentManagerService, TextDocumentChangeEvent, TextDo
 import { Event } from '../../extension/completions-core/vscode-node/lib/src/util/event';
 import { ICompletionsPromiseQueueService, PromiseQueue } from '../../extension/completions-core/vscode-node/lib/src/util/promiseQueue';
 import { ICompletionsRuntimeModeService, RuntimeMode } from '../../extension/completions-core/vscode-node/lib/src/util/runtimeMode';
+import { setExternalTokenizerProvider, type ExternalTokenizerProvider } from '../../extension/completions-core/vscode-node/prompt/src/tokenization';
 import { DocumentContext, WorkspaceFolder } from '../../extension/completions-core/vscode-node/types/src';
 import { DebugRecorder } from '../../extension/inlineEdits/node/debugRecorder';
 import { INextEditProvider, NESInlineCompletionContext, NextEditProvider } from '../../extension/inlineEdits/node/nextEditProvider';
@@ -127,6 +128,8 @@ import { IInstantiationService } from '../../util/vs/platform/instantiation/comm
 export {
 	IAuthenticationService, ICAPIClientService, IEndpointProvider, IExperimentationService, IIgnoreService, ILanguageContextProviderService
 };
+export { TokenizerName } from '../../extension/completions-core/vscode-node/prompt/src/tokenization';
+export type { ExternalTokenizerProvider, Tokenizer } from '../../extension/completions-core/vscode-node/prompt/src/tokenization';
 
 /**
  * Log levels (taken from vscode.d.ts)
@@ -766,6 +769,15 @@ export interface IInlineCompletionsProviderOptions {
 	readonly citationHandler?: IInlineCompletionsCitationHandler;
 	readonly configOverrides?: Map<ConfigKeyType, unknown>;
 	readonly languageDiagnosticsService?: ILanguageDiagnosticsService;
+	/**
+	 * Tokenizer backing prompt token counting/truncation in the completions
+	 * (ghost text) path. When omitted, this module lazily loads its own
+	 * cl100k/o200k BPE dictionaries. Embedders that already hold those
+	 * dictionaries can supply a provider here to avoid loading a second copy
+	 * (~100 MB per encoder). Installed synchronously when the provider is
+	 * created, so it must be passed at construction time.
+	 */
+	readonly tokenizerProvider?: ExternalTokenizerProvider;
 }
 
 export type IGetInlineCompletionsOptions = Exclude<Partial<GetGhostTextOptions>, 'promptOnly'> & {
@@ -781,6 +793,11 @@ export interface IInlineCompletionsProvider {
 }
 
 export function createInlineCompletionsProvider(options: IInlineCompletionsProviderOptions): IInlineCompletionsProvider {
+	if (options.tokenizerProvider) {
+		// Install before building the provider (which constructs GhostText and
+		// tokenizes), so the host's tokenizer is in effect for the first prompt.
+		setExternalTokenizerProvider(options.tokenizerProvider);
+	}
 	const svc = setupCompletionServices(options);
 	return svc.createInstance(InlineCompletionsProvider);
 }

--- a/extensions/copilot/src/lib/node/chatLibMain.ts
+++ b/extensions/copilot/src/lib/node/chatLibMain.ts
@@ -48,7 +48,7 @@ import { ICompletionsTextDocumentManagerService, TextDocumentChangeEvent, TextDo
 import { Event } from '../../extension/completions-core/vscode-node/lib/src/util/event';
 import { ICompletionsPromiseQueueService, PromiseQueue } from '../../extension/completions-core/vscode-node/lib/src/util/promiseQueue';
 import { ICompletionsRuntimeModeService, RuntimeMode } from '../../extension/completions-core/vscode-node/lib/src/util/runtimeMode';
-import { setExternalTokenizerProvider, type ExternalTokenizerProvider } from '../../extension/completions-core/vscode-node/prompt/src/tokenization';
+import { setExternalTokenizerProvider, TokenizerName, type ExternalTokenizerProvider, type Tokenizer } from '../../extension/completions-core/vscode-node/prompt/src/tokenization';
 import { DocumentContext, WorkspaceFolder } from '../../extension/completions-core/vscode-node/types/src';
 import { DebugRecorder } from '../../extension/inlineEdits/node/debugRecorder';
 import { INextEditProvider, NESInlineCompletionContext, NextEditProvider } from '../../extension/inlineEdits/node/nextEditProvider';
@@ -128,8 +128,8 @@ import { IInstantiationService } from '../../util/vs/platform/instantiation/comm
 export {
 	IAuthenticationService, ICAPIClientService, IEndpointProvider, IExperimentationService, IIgnoreService, ILanguageContextProviderService
 };
-export { TokenizerName } from '../../extension/completions-core/vscode-node/prompt/src/tokenization';
-export type { ExternalTokenizerProvider, Tokenizer } from '../../extension/completions-core/vscode-node/prompt/src/tokenization';
+export { TokenizerName };
+export type { ExternalTokenizerProvider, Tokenizer };
 
 /**
  * Log levels (taken from vscode.d.ts)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

builds on top of https://github.com/microsoft/vscode/pull/321100 with changes to
- make sure completions' tokenizer can also be overridden by chat-lib client/host
- replace ad-hoc lazy promise implementation with a function 