### PR TITLE
Improve reveal of unreviewed comments

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatAgentFeedbackReviewConfirmation.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatAgentFeedbackReviewConfirmation.css
@@ -60,9 +60,64 @@
 	font-size: var(--vscode-bodyFontSize-small);
 }
 
+.chat-agent-feedback-review-text-container {
+	position: relative;
+}
+
 .chat-agent-feedback-review-text {
 	white-space: pre-wrap;
 	word-break: break-word;
+}
+
+.chat-agent-feedback-review-text-container.collapsed .chat-agent-feedback-review-text {
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+/* Fade affordance shown only when the comment is collapsed and overflowing, making it clear there is more text below the two visible lines. */
+.chat-agent-feedback-review-text-container.collapsed.overflowing::after {
+	content: '';
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	height: 1.4em;
+	pointer-events: none;
+	background: linear-gradient(to bottom, transparent, var(--vscode-chat-requestBackground));
+}
+
+.chat-agent-feedback-review-expand-toggle {
+	display: none;
+	position: absolute;
+	bottom: 0;
+	right: 0;
+	align-items: center;
+	justify-content: center;
+	width: 18px;
+	height: 18px;
+	padding: 0;
+	border: none;
+	border-radius: var(--vscode-cornerRadius-xSmall);
+	background: transparent;
+	color: var(--vscode-icon-foreground);
+	cursor: pointer;
+	z-index: 1;
+}
+
+.chat-agent-feedback-review-text-container.overflowing .chat-agent-feedback-review-expand-toggle {
+	display: flex;
+}
+
+.chat-agent-feedback-review-expand-toggle:hover {
+	background: var(--vscode-toolbar-hoverBackground);
+}
+
+.chat-agent-feedback-review-expand-toggle:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
 }
 
 .chat-agent-feedback-review-actions {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAgentFeedbackReviewConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAgentFeedbackReviewConfirmationSubPart.ts
@@ -207,9 +207,11 @@ export class ChatAgentFeedbackReviewConfirmationSubPart extends AbstractToolConf
 		const textElement = dom.append(container, dom.$('.chat-agent-feedback-review-text'));
 		textElement.textContent = text;
 
-		const toggle = dom.append(container, dom.$('button.chat-agent-feedback-review-expand-toggle'));
+		const toggle = dom.append(container, dom.$<HTMLButtonElement>('button.chat-agent-feedback-review-expand-toggle'));
+		toggle.type = 'button';
 		toggle.tabIndex = 0;
 		const toggleIcon = dom.append(toggle, dom.$('span.codicon'));
+		toggleIcon.setAttribute('aria-hidden', 'true');
 
 		const expandLabel = localize('agentFeedback.expandComment', "Show More");
 		const collapseLabel = localize('agentFeedback.collapseComment', "Show Less");

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAgentFeedbackReviewConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAgentFeedbackReviewConfirmationSubPart.ts
@@ -5,6 +5,7 @@
 
 import * as dom from '../../../../../../../base/browser/dom.js';
 import { ActionBar } from '../../../../../../../base/browser/ui/actionbar/actionbar.js';
+import { getDefaultHoverDelegate } from '../../../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { Checkbox } from '../../../../../../../base/browser/ui/toggle/toggle.js';
 import { Action } from '../../../../../../../base/common/actions.js';
 import { Codicon } from '../../../../../../../base/common/codicons.js';
@@ -16,6 +17,7 @@ import { localize } from '../../../../../../../nls.js';
 import { ICommandService } from '../../../../../../../platform/commands/common/commands.js';
 import { IContextKeyService } from '../../../../../../../platform/contextkey/common/contextkey.js';
 import { FileKind } from '../../../../../../../platform/files/common/files.js';
+import { IHoverService } from '../../../../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../../../../platform/keybinding/common/keybinding.js';
 import { ILogService } from '../../../../../../../platform/log/common/log.js';
@@ -65,6 +67,7 @@ export class ChatAgentFeedbackReviewConfirmationSubPart extends AbstractToolConf
 		@IChatToolRiskAssessmentService riskAssessmentService: IChatToolRiskAssessmentService,
 		@ICommandService private readonly commandService: ICommandService,
 		@ILogService private readonly logService: ILogService,
+		@IHoverService private readonly hoverService: IHoverService,
 	) {
 		super(toolInvocation, context, instantiationService, keybindingService, contextKeyService, chatWidgetService, languageModelToolsService, riskAssessmentService);
 
@@ -164,15 +167,14 @@ export class ChatAgentFeedbackReviewConfirmationSubPart extends AbstractToolConf
 			dom.append(header, dom.$('.chat-agent-feedback-review-kind', undefined, comment.kindLabel));
 		}
 		const fileUri = URI.revive(comment.fileUri);
-		const fileLabel = rowStore.add(this._resourceLabels.create(header, { supportIcons: true }));
+		const fileLabel = rowStore.add(this._resourceLabels.create(header));
 		fileLabel.element.classList.add('chat-agent-feedback-review-file');
 		fileLabel.setResource(
 			{ resource: fileUri, name: basename(fileUri) },
 			{ fileKind: FileKind.FILE, title: fileUri.fsPath || fileUri.path },
 		);
 
-		const textElement = dom.append(main, dom.$('.chat-agent-feedback-review-text'));
-		textElement.textContent = comment.text;
+		this._renderCommentText(rowStore, main, comment.text);
 
 		const actionsContainer = dom.append(rowElement, dom.$('.chat-agent-feedback-review-actions'));
 		const actionBar = rowStore.add(new ActionBar(actionsContainer));
@@ -192,6 +194,83 @@ export class ChatAgentFeedbackReviewConfirmationSubPart extends AbstractToolConf
 		)), { icon: true, label: false });
 
 		this._rows.set(comment.id, { comment, checkbox, element: rowElement });
+	}
+
+	/**
+	 * Renders the comment body clamped to two visual lines by default, with an
+	 * expand/collapse toggle in the bottom-right corner. The toggle and the
+	 * fade/ellipsis affordance only appear when the text actually overflows two
+	 * lines; overflow is re-evaluated whenever the available width changes.
+	 */
+	private _renderCommentText(rowStore: DisposableStore, main: HTMLElement, text: string): void {
+		const container = dom.append(main, dom.$('.chat-agent-feedback-review-text-container'));
+		const textElement = dom.append(container, dom.$('.chat-agent-feedback-review-text'));
+		textElement.textContent = text;
+
+		const toggle = dom.append(container, dom.$('button.chat-agent-feedback-review-expand-toggle'));
+		toggle.tabIndex = 0;
+		const toggleIcon = dom.append(toggle, dom.$('span.codicon'));
+
+		const expandLabel = localize('agentFeedback.expandComment', "Show More");
+		const collapseLabel = localize('agentFeedback.collapseComment', "Show Less");
+
+		let expanded = false;
+
+		const renderState = () => {
+			container.classList.toggle('collapsed', !expanded);
+			container.classList.toggle('expanded', expanded);
+			toggleIcon.classList.toggle('codicon-chevron-down', !expanded);
+			toggleIcon.classList.toggle('codicon-chevron-up', expanded);
+			toggle.setAttribute('aria-label', expanded ? collapseLabel : expandLabel);
+			toggle.setAttribute('aria-expanded', String(expanded));
+		};
+
+		const isOverflowing = (): boolean => {
+			// `scrollHeight` reflects the full content height even while clamped,
+			// so compare it against the (clamped) `clientHeight`. Measure in the
+			// collapsed state, restoring the previous state in the same frame so
+			// no intermediate layout is painted.
+			const wasExpanded = expanded;
+			if (wasExpanded) {
+				container.classList.add('collapsed');
+				container.classList.remove('expanded');
+			}
+			const overflowing = textElement.scrollHeight - textElement.clientHeight > 1;
+			if (wasExpanded) {
+				container.classList.remove('collapsed');
+				container.classList.add('expanded');
+			}
+			return overflowing;
+		};
+
+		const updateOverflow = () => {
+			const overflowing = isOverflowing();
+			container.classList.toggle('overflowing', overflowing);
+			if (!overflowing && expanded) {
+				expanded = false;
+				renderState();
+			}
+		};
+
+		rowStore.add(this.hoverService.setupManagedHover(
+			getDefaultHoverDelegate('element'),
+			toggle,
+			() => expanded ? collapseLabel : expandLabel,
+		));
+
+		rowStore.add(dom.addDisposableListener(toggle, dom.EventType.CLICK, e => {
+			e.preventDefault();
+			e.stopPropagation();
+			expanded = !expanded;
+			renderState();
+		}));
+
+		renderState();
+
+		const targetWindow = dom.getWindow(container);
+		const observer = new targetWindow.ResizeObserver(() => updateOverflow());
+		observer.observe(textElement);
+		rowStore.add(toDisposable(() => observer.disconnect()));
 	}
 
 	private async _reveal(commentId: string): Promise<void> {

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatAgentFeedbackReviewConfirmation.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatAgentFeedbackReviewConfirmation.fixture.ts
@@ -15,10 +15,12 @@ import { IChatWidgetService } from '../../../../contrib/chat/browser/chat.js';
 import { IChatToolRiskAssessmentService } from '../../../../contrib/chat/browser/tools/chatToolRiskAssessmentService.js';
 import { IChatContentPartRenderContext, InlineTextModelCollection } from '../../../../contrib/chat/browser/widget/chatContentParts/chatContentParts.js';
 import { IChatMarkdownAnchorService } from '../../../../contrib/chat/browser/widget/chatContentParts/chatMarkdownAnchorService.js';
-import { ChatAgentFeedbackReviewConfirmationSubPart } from '../../../../contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAgentFeedbackReviewConfirmationSubPart.js';
+import { ChatToolConfirmationCarouselPart, ToolInvocationPartFactory } from '../../../../contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolConfirmationCarouselPart.js';
+import { ChatToolInvocationPart } from '../../../../contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationPart.js';
 import { AgentFeedbackReviewCommandId, IChatAgentFeedbackReviewComment, IChatAgentFeedbackReviewConfirmationData } from '../../../../contrib/chat/common/chatService/chatService.js';
 import { ChatToolInvocation } from '../../../../contrib/chat/common/model/chatProgressTypes/chatToolInvocation.js';
 import { IChatResponseViewModel } from '../../../../contrib/chat/common/model/chatViewModel.js';
+import { IChatTodoListService } from '../../../../contrib/chat/common/tools/chatTodoListService.js';
 import { ILanguageModelToolsService, IToolData, ToolDataSource } from '../../../../contrib/chat/common/tools/languageModelToolsService.js';
 import { IDecorationsService } from '../../../../services/decorations/common/decorations.js';
 import { INotebookDocumentService } from '../../../../services/notebook/common/notebookDocumentService.js';
@@ -28,10 +30,9 @@ import { ComponentFixtureContext, createEditorServices, defineComponentFixture, 
 import '../../../../contrib/chat/browser/widget/media/chat.css';
 import '../../../../contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css';
 import '../../../../contrib/chat/browser/widget/chatContentParts/media/chatAgentFeedbackReviewConfirmation.css';
+import '../../../../contrib/chat/browser/widget/chatContentParts/media/chatToolConfirmationCarousel.css';
 
-const sessionResource = URI.parse('copilot:/fixture-session');
-
-function createMockContext(): IChatContentPartRenderContext {
+function createMockContext(sessionResource: URI): IChatContentPartRenderContext {
 	const element = new class extends mock<IChatResponseViewModel>() {
 		override readonly sessionResource = sessionResource;
 	}();
@@ -51,7 +52,7 @@ function createMockContext(): IChatContentPartRenderContext {
 	};
 }
 
-function createToolInvocation(): ChatToolInvocation {
+function createToolInvocation(toolCallId: string): ChatToolInvocation {
 	const toolData: IToolData = {
 		id: 'viewUnreviewedComments',
 		source: ToolDataSource.Internal,
@@ -71,7 +72,7 @@ function createToolInvocation(): ChatToolInvocation {
 			toolSpecificData,
 		},
 		toolData,
-		'fixture-tool-call',
+		toolCallId,
 		undefined,
 		undefined,
 	);
@@ -79,17 +80,19 @@ function createToolInvocation(): ChatToolInvocation {
 
 /**
  * Mock command service that backs the confirmation renderer. Returns the
- * supplied comments for the "get comments" command and no-ops for the reveal /
- * delete / accept actions so the fixture renders without touching the real
- * feedback service.
+ * comments associated with the requesting session for the "get comments"
+ * command (so each carousel item can resolve its own set) and no-ops for the
+ * reveal / delete / accept actions so the fixture renders without touching the
+ * real feedback service.
  */
-function createCommandService(comments: readonly IChatAgentFeedbackReviewComment[]): ICommandService {
+function createCommandService(commentsBySession: ReadonlyMap<string, readonly IChatAgentFeedbackReviewComment[]>): ICommandService {
 	return new class extends mock<ICommandService>() {
 		override readonly onWillExecuteCommand = Event.None;
 		override readonly onDidExecuteCommand = Event.None;
-		override async executeCommand<R = unknown>(commandId: string): Promise<R | undefined> {
+		override async executeCommand<R = unknown>(commandId: string, sessionResource?: URI): Promise<R | undefined> {
 			if (commandId === AgentFeedbackReviewCommandId.GetComments) {
-				return comments as unknown as R;
+				const key = sessionResource?.toString();
+				return (key ? commentsBySession.get(key) : undefined) as unknown as R ?? ([] as unknown as R);
 			}
 			return undefined;
 		}
@@ -97,7 +100,31 @@ function createCommandService(comments: readonly IChatAgentFeedbackReviewComment
 }
 
 function renderConfirmation(context: ComponentFixtureContext, comments: readonly IChatAgentFeedbackReviewComment[]): void {
+	renderConfirmations(context, [comments]);
+}
+
+/**
+ * Renders one tool confirmation per supplied comment set, all hosted inside a
+ * real {@link ChatToolConfirmationCarouselPart} so the confirmation is shown
+ * with the same overlay chrome (title, Allow All / Skip / expand actions and,
+ * for multiple confirmations, the step indicator and navigation arrows) it has
+ * in the chat input. Each confirmation resolves its own comments via a distinct
+ * session resource.
+ */
+function renderConfirmations(context: ComponentFixtureContext, commentSets: readonly (readonly IChatAgentFeedbackReviewComment[])[]): void {
 	const { container, disposableStore } = context;
+
+	const commentsBySession = new Map<string, readonly IChatAgentFeedbackReviewComment[]>();
+	const contextByToolCallId = new Map<string, IChatContentPartRenderContext>();
+	const tools: ChatToolInvocation[] = [];
+
+	commentSets.forEach((comments, index) => {
+		const sessionResource = URI.parse(`copilot:/fixture-session-${index}`);
+		commentsBySession.set(sessionResource.toString(), comments);
+		const tool = createToolInvocation(`fixture-tool-call-${index}`);
+		tools.push(tool);
+		contextByToolCallId.set(tool.toolCallId, createMockContext(sessionResource));
+	});
 
 	const instantiationService = createEditorServices(disposableStore, {
 		colorTheme: context.theme,
@@ -108,7 +135,8 @@ function renderConfirmation(context: ComponentFixtureContext, comments: readonly
 			reg.defineInstance(ITextFileService, new class extends mock<ITextFileService>() { override readonly untitled = new class extends mock<ITextFileService['untitled']>() { override readonly onDidChangeLabel = Event.None; }(); }());
 			reg.defineInstance(IWorkspaceContextService, new class extends mock<IWorkspaceContextService>() { override onDidChangeWorkspaceFolders = Event.None; override getWorkspace(): IWorkspace { return { id: '', folders: [], configuration: undefined }; } }());
 			reg.defineInstance(INotebookDocumentService, new class extends mock<INotebookDocumentService>() { }());
-			reg.defineInstance(ICommandService, createCommandService(comments));
+			reg.defineInstance(ICommandService, createCommandService(commentsBySession));
+			reg.defineInstance(IChatTodoListService, new class extends mock<IChatTodoListService>() { override setTodos() { } }());
 			reg.defineInstance(IChatMarkdownAnchorService, new class extends mock<IChatMarkdownAnchorService>() {
 				override register() { return { dispose() { } }; }
 			}());
@@ -122,22 +150,38 @@ function renderConfirmation(context: ComponentFixtureContext, comments: readonly
 		},
 	});
 
-	const toolInvocation = createToolInvocation();
-	const part = disposableStore.add(
-		instantiationService.createInstance(
-			ChatAgentFeedbackReviewConfirmationSubPart,
-			toolInvocation,
-			createMockContext(),
-		)
+	const toolPartFactory: ToolInvocationPartFactory = (tool) => instantiationService.createInstance(
+		ChatToolInvocationPart,
+		tool,
+		contextByToolCallId.get(tool.toolCallId)!,
+		undefined!, // renderer — unused by the agent feedback confirmation sub part
+		undefined!, // listPool — unused by the agent feedback confirmation sub part
+		undefined!, // editorPool — unused by the agent feedback confirmation sub part
+		() => 480,
+		undefined,
+		0,
 	);
 
-	container.style.width = '520px';
+	const carousel = disposableStore.add(new ChatToolConfirmationCarouselPart(toolPartFactory, tools));
+
+	container.style.width = '680px';
 	container.style.padding = '8px';
 	container.classList.add('interactive-session');
+	// In product the carousel is hosted in the chat input, which sits on the
+	// side bar / panel background; reproduce that backdrop on the host element
+	// so the carousel reads correctly in place instead of on a transparent
+	// surface.
+	container.style.backgroundColor = 'var(--vscode-sideBar-background, var(--vscode-editor-background))';
 
-	const itemContainer = dom.$('.interactive-item-container');
-	itemContainer.appendChild(part.domNode);
-	container.appendChild(itemContainer);
+	// The carousel layout/visibility CSS keys off
+	// `.interactive-session .interactive-input-part > .chat-tool-confirmation-carousel-container`,
+	// so reproduce that ancestry here.
+	const inputPart = dom.$('.interactive-input-part');
+	const carouselContainer = dom.$('.chat-tool-confirmation-carousel-container');
+	inputPart.appendChild(carouselContainer);
+	container.appendChild(inputPart);
+
+	carouselContainer.appendChild(carousel.domNode);
 }
 
 // ============================================================================
@@ -193,5 +237,14 @@ export default defineThemedFixtureGroup({ path: 'chat/' }, {
 	Empty: defineComponentFixture({
 		labels: { kind: 'screenshot' },
 		render: (ctx) => renderConfirmation(ctx, []),
+	}),
+
+	Carousel: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (ctx) => renderConfirmations(ctx, [
+			[prComment],
+			[longComment],
+			[prComment, agentReviewComment, longComment],
+		]),
 	}),
 });

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatAgentFeedbackReviewConfirmation.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatAgentFeedbackReviewConfirmation.fixture.ts
@@ -89,8 +89,9 @@ function createCommandService(commentsBySession: ReadonlyMap<string, readonly IC
 	return new class extends mock<ICommandService>() {
 		override readonly onWillExecuteCommand = Event.None;
 		override readonly onDidExecuteCommand = Event.None;
-		override async executeCommand<R = unknown>(commandId: string, sessionResource?: URI): Promise<R | undefined> {
+		override async executeCommand<R = unknown>(commandId: string, ...args: unknown[]): Promise<R | undefined> {
 			if (commandId === AgentFeedbackReviewCommandId.GetComments) {
+				const sessionResource = args[0] as URI | undefined;
 				const key = sessionResource?.toString();
 				return (key ? commentsBySession.get(key) : undefined) as unknown as R ?? ([] as unknown as R);
 			}


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a mechanism to render comment bodies clamped to two lines with an expand/collapse toggle for overflowing text. This includes visual affordances to indicate when more text is available.

