### PR TITLE
Refactor title bar update placement for layout consistency

### DIFF
--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -53,10 +53,14 @@ const SIGN_OUT_ACTION_ID = 'workbench.action.agenticSignOut';
 const SIGN_IN_ACTION_ID = 'workbench.action.agenticSignIn';
 
 // Register the shared VS Code update title bar entry into the Agents titlebar layout.
-registerUpdateTitleBarMenuPlacement(Menus.TitleBarRightLayout, {
+// Placed as the first (leftmost) item of the leftmost right-cluster container so that, in
+// the right-aligned title bar, the update button grows into the empty space on its left
+// when it appears and every other control (session toggles, account widget) stays anchored
+// and doesn't shift.
+registerUpdateTitleBarMenuPlacement(Menus.TitleBarSessionMenu, {
 	when: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated()),
 	group: 'navigation',
-	order: 99,
+	order: -1,
 });
 
 // Sign In (shown when signed out)


### PR DESCRIPTION
This pull request updates the placement of the update button in the title bar to improve the user interface layout. The change ensures that when the update button appears, it expands into available space without shifting other controls like session toggles or the account widget.

**UI/UX Improvements:**

* Changed the update button's placement in the title bar by registering it with `Menus.TitleBarSessionMenu` instead of `Menus.TitleBarRightLayout`, and set its order to `-1` so it appears as the first (leftmost) item in the right-aligned title bar. This prevents other controls from shifting when the update button appears.