### PR TITLE
agentHost: stop sending an explicit Copilot integration id to CAPI

### DIFF
--- a/src/typings/copilot-api.d.ts
+++ b/src/typings/copilot-api.d.ts
@@ -26,7 +26,6 @@ declare module '@vscode/copilot-api' {
 		json?: unknown;
 		method?: 'GET' | 'POST' | 'PUT';
 		signal?: IAbortSignal;
-		suppressIntegrationId?: boolean;
 	}
 
 	export type MakeRequestOptions = Omit<FetchOptions, 'callSite'> & {

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -315,7 +315,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		}
 		try {
 			const userAgent = `${USER_AGENT_PREFIX}/${this._productService.version}`;
-			const all = await this._copilotApiService.models(tokenAtStart, { headers: { 'User-Agent': userAgent }, suppressIntegrationId: true });
+			const all = await this._copilotApiService.models(tokenAtStart, { headers: { 'User-Agent': userAgent } });
 			// Stale-write guard: if `authenticate()` rotated the token
 			// while we were awaiting the model list, a newer refresh has
 			// already published the right value — don't overwrite it.

--- a/src/vs/platform/agentHost/node/claude/claudeProxyService.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeProxyService.ts
@@ -429,7 +429,7 @@ export class ClaudeProxyService implements IClaudeProxyService {
 		const headers = buildOutboundHeaders(req.headers);
 		let models: CCAModel[];
 		try {
-			models = await this._copilotApiService.models(runtime.githubToken, { headers, suppressIntegrationId: true });
+			models = await this._copilotApiService.models(runtime.githubToken, { headers });
 		} catch (err) {
 			this._writeUpstreamErrorResponse(res, err);
 			return;
@@ -567,7 +567,7 @@ export class ClaudeProxyService implements IClaudeProxyService {
 		originalSdkModelId: string,
 		sessionId: string | undefined,
 	): Promise<void> {
-		const options: ICopilotApiServiceRequestOptions = { headers, signal: entry.ac.signal, suppressIntegrationId: true };
+		const options: ICopilotApiServiceRequestOptions = { headers, signal: entry.ac.signal };
 		let message: Anthropic.Message;
 		try {
 			message = await this._copilotApiService.messages(runtime.githubToken, body, options);
@@ -603,7 +603,7 @@ export class ClaudeProxyService implements IClaudeProxyService {
 		_originalSdkModelId: string,
 		sessionId: string | undefined,
 	): Promise<void> {
-		const options: ICopilotApiServiceRequestOptions = { headers, signal: entry.ac.signal, suppressIntegrationId: true };
+		const options: ICopilotApiServiceRequestOptions = { headers, signal: entry.ac.signal };
 		let stream: AsyncGenerator<Anthropic.MessageStreamEvent>;
 		try {
 			stream = this._copilotApiService.messages(runtime.githubToken, body, options);

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -713,7 +713,7 @@ export class CodexAgent extends Disposable implements IAgent {
 
 	private async _refreshModels(token: string): Promise<void> {
 		try {
-			const all = await this._copilotApiService.models(token, { suppressIntegrationId: true });
+			const all = await this._copilotApiService.models(token);
 			if (this._githubToken !== token) {
 				return;
 			}

--- a/src/vs/platform/agentHost/node/codex/codexProxyService.ts
+++ b/src/vs/platform/agentHost/node/codex/codexProxyService.ts
@@ -408,7 +408,7 @@ export class CodexProxyService implements ICodexProxyService {
 
 		try {
 			this._logService.info(`[${PROXY_USER_FACING_NAME}] forwarding to CAPI responses...`);
-			const upstream = await this._copilotApiService.responses(dispatchedToken, body, { signal: entry.ac.signal, suppressIntegrationId: true });
+			const upstream = await this._copilotApiService.responses(dispatchedToken, body, { signal: entry.ac.signal });
 			const contentType = upstream.headers.get('content-type') ?? 'application/json';
 			const upstreamHeaders = [...upstream.headers.entries()].map(([k, v]) => `${k}: ${v}`).join(', ');
 			this._logService.info(`[${PROXY_USER_FACING_NAME}] <<< CAPI response: status=${upstream.status}, contentType=${contentType}, headers=[${upstreamHeaders}]`);

--- a/src/vs/platform/agentHost/node/shared/copilotApiService.ts
+++ b/src/vs/platform/agentHost/node/shared/copilotApiService.ts
@@ -10,7 +10,7 @@ import { getDevDeviceId, getMachineId } from '../../../../base/node/id.js';
 import { createDecorator } from '../../../instantiation/common/instantiation.js';
 import { ILogService } from '../../../log/common/log.js';
 import { IProductService } from '../../../product/common/productService.js';
-import { COPILOT_INTEGRATION_ID, COPILOT_LICENSE_AGREEMENT } from '../../../endpoint/common/licenseAgreement.js';
+import { COPILOT_LICENSE_AGREEMENT } from '../../../endpoint/common/licenseAgreement.js';
 
 // #region Types
 
@@ -28,19 +28,6 @@ import { COPILOT_INTEGRATION_ID, COPILOT_LICENSE_AGREEMENT } from '../../../endp
 export interface ICopilotApiServiceRequestOptions {
 	readonly headers?: Readonly<Record<string, string>>;
 	readonly signal?: AbortSignal;
-
-	/**
-	 * Suppress the `Copilot-Integration-Id` header on this request.
-	 *
-	 * When unset, `@vscode/copilot-api` derives the integration id from the
-	 * discovered Copilot SKU: a `no_auth_limited_copilot` SKU maps to
-	 * `vscode-nl`, which the CAPI backend treats as the limited/no-auth
-	 * integration and refuses premium models such as `claude-opus-4.7`.
-	 * Setting this to `true` omits the header so CAPI authorizes against the
-	 * token's real entitlement. Mirrors the Copilot Chat extension's
-	 * `ClaudeStreamingPassThroughEndpoint.getEndpointFetchOptions()`.
-	 */
-	readonly suppressIntegrationId?: boolean;
 }
 
 /**
@@ -535,9 +522,6 @@ export class CopilotApiService implements ICopilotApiService {
 					...options?.headers,
 					'Authorization': `Bearer ${githubToken}`,
 				},
-				// Opt-in per request — see
-				// `ICopilotApiServiceRequestOptions.suppressIntegrationId`.
-				suppressIntegrationId: options?.suppressIntegrationId,
 				signal: options?.signal,
 			},
 			{ type: RequestType.Models },
@@ -582,9 +566,6 @@ export class CopilotApiService implements ICopilotApiService {
 					'X-Request-Id': requestId,
 					'OpenAI-Intent': 'conversation',
 				},
-				// Opt-in per request — see
-				// `ICopilotApiServiceRequestOptions.suppressIntegrationId`.
-				suppressIntegrationId: options?.suppressIntegrationId,
 				body,
 				signal: options?.signal,
 			},
@@ -769,7 +750,6 @@ export class CopilotApiService implements ICopilotApiService {
 					// paths already omit it). Thread a real per-turn initiator here if
 					// that signal ever becomes available at the proxy boundary.
 				},
-				suppressIntegrationId: options?.suppressIntegrationId,
 				body,
 				signal: options?.signal,
 			},
@@ -831,9 +811,6 @@ export class CopilotApiService implements ICopilotApiService {
 		this._clientsByToken.delete(githubToken);
 	}
 
-	protected getIntegrationId(): string | undefined {
-		return COPILOT_INTEGRATION_ID;
-	}
 	private async _buildClientForToken(githubToken: string): Promise<ICachedClient> {
 		const { extensionInfo, userUrl } = await this._getCapiBase();
 		const fetch = this._fetch;
@@ -844,7 +821,7 @@ export class CopilotApiService implements ICopilotApiService {
 				body: options.body,
 				signal: options.signal as AbortSignal | undefined,
 			}),
-		}, undefined, this.getIntegrationId());
+		});
 
 		this._logService.debug('[CopilotApiService] Discovering CAPI endpoints via /copilot_internal/user');
 

--- a/src/vs/platform/agentHost/test/node/shared/copilotApiService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/shared/copilotApiService.integrationTest.ts
@@ -34,15 +34,7 @@ suite('CopilotApiService.utilityChatCompletion (real CAPI)', () => {
 		// `globalThis.fetch` through `this._fetch(...)` throws
 		// "Illegal invocation" in the Electron renderer.
 		const boundFetch: typeof globalThis.fetch = (...args) => globalThis.fetch(...args);
-		const service = new class extends CopilotApiService {
-			constructor() {
-				super(boundFetch, new NullLogService(), productService);
-			}
-			override getIntegrationId(): string | undefined {
-				return undefined; // Don't send an integration ID for tests
-			}
-		}();
-		return service;
+		return new CopilotApiService(boundFetch, new NullLogService(), productService);
 	}
 
 	(hasToken ? test : test.skip)('answers a trivial arithmetic prompt', async function () {

--- a/src/vs/platform/agentHost/test/node/shared/copilotApiService.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/copilotApiService.test.ts
@@ -85,14 +85,7 @@ function modelsResponse(models: object[]): Response {
 }
 
 function createService(fetchImpl: FetchFunction): CopilotApiService {
-	return new class extends CopilotApiService {
-		constructor() {
-			super(fetchImpl, new NullLogService(), testProductService);
-		}
-		override getIntegrationId(): string | undefined {
-			return undefined; // Don't send an integration ID for tests
-		}
-	}();
+	return new CopilotApiService(fetchImpl, new NullLogService(), testProductService);
 }
 
 type CapturedRequest = { url: string; init: RequestInit | undefined };
@@ -594,23 +587,18 @@ suite('CopilotApiService', () => {
 			assert.strictEqual(headers['OpenAI-Intent'], 'messages-proxy');
 		});
 
-		test('suppressIntegrationId opt-in controls the Copilot-Integration-Id header', async () => {
+		test('sends a derived Copilot-Integration-Id header by default', async () => {
 			const { fetch: fetchFn, captured } = routingFetch(
 				() => anthropicResponse([{ type: 'text', text: 'ok' }]),
 			);
 			const service = createService(fetchFn);
 
-			// Default (no opt-in): @vscode/copilot-api derives and sends the header.
+			// @vscode/copilot-api derives the integration id from the license /
+			// SKU / build state and sends it on every request.
 			await service.messages('gh-tok', baseRequest);
-			const withHeader = captured().init?.headers as Record<string, string>;
+			const headers = captured().init?.headers as Record<string, string>;
 
-			// Opt-in: the header is omitted entirely so CAPI authorizes against
-			// the token's real entitlement instead of the derived integration id.
-			await service.messages('gh-tok', baseRequest, { suppressIntegrationId: true });
-			const suppressed = captured().init?.headers as Record<string, string>;
-
-			assert.ok(withHeader['Copilot-Integration-Id'], 'integration id should be present by default');
-			assert.strictEqual(suppressed['Copilot-Integration-Id'], undefined, 'integration id should be suppressed when opted in');
+			assert.ok(headers['Copilot-Integration-Id'], 'integration id should be present');
 		});
 	});
 
@@ -1597,21 +1585,16 @@ suite('CopilotApiService', () => {
 			assert.strictEqual(capturedHeaders?.['Authorization'], 'Bearer gh-tok');
 		});
 
-		test('suppressIntegrationId opt-in controls the Copilot-Integration-Id header', async () => {
+		test('sends a derived Copilot-Integration-Id header by default', async () => {
 			const { fetch: fetchFn, captured } = routingFetch(() => modelsResponse([]));
 			const service = createService(fetchFn);
 
-			// Default (no opt-in): @vscode/copilot-api derives and sends the header.
+			// @vscode/copilot-api derives the integration id from the license /
+			// SKU / build state and sends it on every request.
 			await service.models('gh-tok');
-			const withHeader = captured().init?.headers as Record<string, string>;
+			const headers = captured().init?.headers as Record<string, string>;
 
-			// Opt-in: the header is omitted entirely so CAPI authorizes against
-			// the token's real entitlement instead of the derived integration id.
-			await service.models('gh-tok', { suppressIntegrationId: true });
-			const suppressed = captured().init?.headers as Record<string, string>;
-
-			assert.ok(withHeader['Copilot-Integration-Id'], 'integration id should be present by default');
-			assert.strictEqual(suppressed['Copilot-Integration-Id'], undefined, 'integration id should be suppressed when opted in');
+			assert.ok(headers['Copilot-Integration-Id'], 'integration id should be present');
 		});
 	});
 


### PR DESCRIPTION
## Problem

[#320997](https://github.com/microsoft/vscode/pull/320997) began forwarding `COPILOT_INTEGRATION_ID` into the shared `CopilotApiService`'s `CAPIClient` constructor. In packaged builds the vscode-capi mixin sets that constant to `vscode-chat` (and OSS builds use `code-oss`); **both are reserved** by `@vscode/copilot-api`, whose `CAPIClient` constructor throws:

```
Error: Integration ID vscode-chat is reserved and cannot be used.
    at new CAPIClient (@vscode/copilot-api)
    at CopilotApiService._buildClientForToken → models → _refreshModels
```

Because the client is built **before any request**, the throw happens during endpoint discovery — independent of the per-request suppression flag. The result: **codex and claude model refresh fail with an empty catalog in every packaged build** (and OSS dev). Codex then has no model to drive a turn, so this surfaced as the `Test Codex session` smoke test timing out on the insider pipeline ([build 448906](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=448906&view=results)). The Copilot CLI harness is unaffected (it loads models via the spawned runtime, not this client).

## Why removal (not a guard)

The explicit integration-id argument is only consulted by the library when an **HMAC secret** is also supplied — which the agent host never does. So passing it accomplished nothing except the crash. The correct wire id is derived by the library itself from the license / SKU / build state:

| Derived `Copilot-Integration-Id` | When |
|---|---|
| `vscode-chat` | licensed **stable** build (license arg matches + `buildType==='prod'`) |
| `vscode-nl` | `no_auth_limited_copilot` SKU |
| `code-oss` | everything else (OSS, **and Insiders** — `buildType==='dev'`) |

So this PR drops the dead argument (and the `getIntegrationId` seam). The `COPILOT_LICENSE_AGREEMENT` argument that actually identifies prod traffic is unchanged.

With the id now derived and sent on every request, the per-request `suppressIntegrationId` escape hatch is no longer needed anywhere, so it is removed entirely: the option, its plumbing through `models()`/`messages()`/`responses()`, and the call-site opt-ins in the codex and claude agents and their proxy services.

## Changes (8 files, +20/−137)

- `shared/copilotApiService.ts`: remove `getIntegrationId()` + the explicit id arg; remove `suppressIntegrationId` from `ICopilotApiServiceRequestOptions` and its 3 pass-throughs.
- `codex/codexAgent.ts`, `codex/codexProxyService.ts`, `claude/claudeAgent.ts`, `claude/claudeProxyService.ts` (×3): drop `suppressIntegrationId: true`.
- `src/typings/copilot-api.d.ts`: drop `suppressIntegrationId` from `FetchOptions`.
- tests: simplify `createService`, drop the reserved-id suite, rewrite the two suppression tests into "sends a derived Copilot-Integration-Id header by default".

## Verification

- **Unit:** typecheck-client clean; 86 `CopilotApiService` + 75 codex + 565 claude pass.
- **Live (agents window, OSS dev — the `code-oss` path that used to throw):** agent host log shows codex/claude/copilot all refresh their catalogs (codex 6 `/responses` models incl. gpt-5.5, claude 7, copilot 17) with **no reserved-id error**. A real **codex turn** (`responses()`) returns `status=200` and renders its reply; a real **claude turn** (`messages()`) completes and renders — both exercise the exact call sites where `suppressIntegrationId` was removed.

## Notes

- Fixes **claude** too (shared client).
- Tradeoff: a `no_auth_limited_copilot` token now derives `vscode-nl` (premium-refusing) instead of authorizing against the bare token entitlement. Acceptable for normal paid tokens, which gain the correct catalog.
- A separate draft (#321937) temporarily skips the codex smoke test to keep the build green; it can be reverted once this lands.