### PR TITLE
Update hover color for Light 2026 theme

### DIFF
--- a/extensions/theme-defaults/themes/2026-light.json
+++ b/extensions/theme-defaults/themes/2026-light.json
@@ -192,7 +192,7 @@
 		"statusBarItem.prominentBackground": "#0069CCDD",
 		"statusBarItem.prominentForeground": "#FFFFFF",
 		"statusBarItem.prominentHoverBackground": "#0069CC",
-		"toolbar.hoverBackground": "#E3E3E5",
+		"toolbar.hoverBackground": "#0000001F",
 		"toolbar.activeBackground": "#D6D6D8",
 		"tab.activeBackground": "#FFFFFF",
 		"tab.activeForeground": "#202020",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This pull request addresses #321670. It makes a minor update to the `2026-light.json` theme file, specifically adjusting the hover background color for toolbars to improve visual consistency.

- Theme adjustment:
  * Changed the `toolbar.hoverBackground` color from `#E3E3E5` to a semi-transparent black (`#0000001F`) in `2026-light.json`.
  
**Visual Changes (Hover + Selection States):**

https://github.com/user-attachments/assets/826438a7-b01d-4906-b62c-4ab567e0cd8b


