### PR TITLE
Suggest Copilot CLI Agent Host when editor local chat is disabled

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentDisabledInputTipContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentDisabledInputTipContribution.ts
@@ -1,0 +1,98 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { localize } from '../../../../../nls.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IsSessionsWindowContext } from '../../../../common/contextkeys.js';
+import { IWorkbenchContribution } from '../../../../common/contributions.js';
+import { ChatConfiguration } from '../../common/constants.js';
+import { IChatSessionsService, localChatSessionType, SessionType } from '../../common/chatSessionsService.js';
+import { getChatSessionType } from '../../common/model/chatUri.js';
+import { IChatWidget, IChatWidgetService, isIChatResourceViewContext } from '../chat.js';
+import { ChatInputNotificationSeverity, IChatInputNotificationService } from '../widget/input/chatInputNotificationService.js';
+
+export class LocalAgentDisabledInputTipContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.localAgentDisabledInputTip';
+
+	private static readonly NOTIFICATION_ID = 'chat.localAgentDisabled.continueInAgentHostCopilot';
+
+	private _lastPostedFor: string | undefined;
+
+	constructor(
+		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
+		@IChatInputNotificationService private readonly notificationService: IChatInputNotificationService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
+	) {
+		super();
+
+		this._register(this.chatWidgetService.onDidChangeFocusedSession(() => this.update()));
+		this._register(this.chatWidgetService.onDidAddWidget(() => this.update()));
+		this._register(this.chatSessionsService.onDidChangeAvailability(() => this.update()));
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(ChatConfiguration.EditorLocalAgentEnabled) || e.affectsConfiguration(ChatConfiguration.EditorDefaultProvider)) {
+				this.update(true);
+			}
+		}));
+
+		this.update();
+	}
+
+	private update(resetDismissal = false): void {
+		const widget = this.chatWidgetService.lastFocusedWidget;
+		const sessionResource = widget?.viewModel?.sessionResource;
+		const key = sessionResource?.toString();
+
+		if (!widget || !sessionResource || !this.isEligible(widget)) {
+			this.clear();
+			return;
+		}
+
+		if (!resetDismissal && this._lastPostedFor === key) {
+			return;
+		}
+
+		this._lastPostedFor = key;
+		this.notificationService.setNotification({
+			id: LocalAgentDisabledInputTipContribution.NOTIFICATION_ID,
+			severity: ChatInputNotificationSeverity.Info,
+			message: localize('chat.localAgentDisabled.continueInAgentHostCopilot.message', "Copilot CLI [Agent Host] is available for use, continuing from this local session."),
+			description: localize('chat.localAgentDisabled.continueInAgentHostCopilot.description', "Select Copilot CLI [Agent Host] from Continue In to continue this local harness history there. To keep using local and turn off this notification, set \"chat.editor.localAgent.enabled\" to true."),
+			actions: [],
+			dismissible: true,
+			autoDismissOnMessage: false,
+			sessionTypes: [localChatSessionType],
+		});
+	}
+
+	private isEligible(widget: IChatWidget): boolean {
+		const model = widget.viewModel?.model;
+		const sessionResource = widget.viewModel?.sessionResource;
+		return !!model
+			&& !!sessionResource
+			&& getChatSessionType(sessionResource) === localChatSessionType
+			&& model.hasRequests
+			&& this.configurationService.getValue<boolean>(ChatConfiguration.EditorLocalAgentEnabled) === false
+			&& this.configurationService.getValue<string>(ChatConfiguration.EditorDefaultProvider) === 'copilotAh'
+			&& !!this.chatSessionsService.getChatSessionContribution(SessionType.AgentHostCopilot)
+			&& !this.isQuickOrInlineChat(widget)
+			&& !IsSessionsWindowContext.getValue(widget.scopedContextKeyService);
+	}
+
+	private isQuickOrInlineChat(widget: IChatWidget): boolean {
+		return isIChatResourceViewContext(widget.viewContext)
+			&& (Boolean(widget.viewContext.isQuickChat) || Boolean(widget.viewContext.isInlineChat));
+	}
+
+	private clear(): void {
+		if (!this._lastPostedFor) {
+			return;
+		}
+		this._lastPostedFor = undefined;
+		this.notificationService.deleteNotification(LocalAgentDisabledInputTipContribution.NOTIFICATION_ID);
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentDisabledInputTipContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentDisabledInputTipContribution.ts
@@ -74,10 +74,10 @@ export class LocalAgentDisabledInputTipContribution extends Disposable implement
 		this.notificationService.setNotification({
 			id: LOCAL_AGENT_DISABLED_NOTIFICATION_ID,
 			severity: ChatInputNotificationSeverity.Info,
-			message: localize('chat.localAgentDisabled.continueInAgentHostCopilot.message', "Copilot CLI can continue with this local chat history."),
-			description: localize('chat.localAgentDisabled.continueInAgentHostCopilot.description', "Use Continue In to carry this local harness history forward. To keep using local and turn off this notification, set \"chat.editor.localAgent.enabled\" to true."),
+			message: localize('chat.localAgentDisabled.continueInAgentHostCopilot.message', "Continue using the agent host."),
+			description: localize('chat.localAgentDisabled.continueInAgentHostCopilot.description', "You can bring your local harness history into a new chat with the agent host. To keep using the local harness instead and hide this notification, set \"chat.editor.localAgent.enabled\" to true."),
 			actions: [{
-				label: localize('chat.localAgentDisabled.continueInAgentHostCopilot.action', "Continue In Copilot CLI"),
+				label: localize('chat.localAgentDisabled.continueInAgentHostCopilot.action', "Continue In Agent Host"),
 				commandId: LOCAL_AGENT_DISABLED_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID,
 			}],
 			dismissible: true,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentDisabledInputTipContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentDisabledInputTipContribution.ts
@@ -60,8 +60,8 @@ export class LocalAgentDisabledInputTipContribution extends Disposable implement
 		this.notificationService.setNotification({
 			id: LocalAgentDisabledInputTipContribution.NOTIFICATION_ID,
 			severity: ChatInputNotificationSeverity.Info,
-			message: localize('chat.localAgentDisabled.continueInAgentHostCopilot.message', "Copilot CLI [Agent Host] is available for use, continuing from this local session."),
-			description: localize('chat.localAgentDisabled.continueInAgentHostCopilot.description', "Select Copilot CLI [Agent Host] from Continue In to continue this local harness history there. To keep using local and turn off this notification, set \"chat.editor.localAgent.enabled\" to true."),
+			message: localize('chat.localAgentDisabled.continueInAgentHostCopilot.message', "Copilot CLI [Agent Host] can continue with this local chat history."),
+			description: localize('chat.localAgentDisabled.continueInAgentHostCopilot.description', "Use Continue In to move this local harness history to Copilot CLI [Agent Host]. To keep using local and turn off this notification, set \"chat.editor.localAgent.enabled\" to true."),
 			actions: [],
 			dismissible: true,
 			autoDismissOnMessage: false,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentDisabledInputTipContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentDisabledInputTipContribution.ts
@@ -5,7 +5,9 @@
 
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { localize } from '../../../../../nls.js';
+import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IsSessionsWindowContext } from '../../../../common/contextkeys.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { ChatConfiguration } from '../../common/constants.js';
@@ -14,11 +16,23 @@ import { getChatSessionType } from '../../common/model/chatUri.js';
 import { IChatWidget, IChatWidgetService, isIChatResourceViewContext } from '../chat.js';
 import { ChatInputNotificationSeverity, IChatInputNotificationService } from '../widget/input/chatInputNotificationService.js';
 
+const LOCAL_AGENT_DISABLED_NOTIFICATION_ID = 'chat.localAgentDisabled.continueInAgentHostCopilot';
+export const LOCAL_AGENT_DISABLED_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID = '_chat.localAgentDisabled.continueInAgentHostCopilot';
+
+CommandsRegistry.registerCommand(LOCAL_AGENT_DISABLED_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID, async (accessor: ServicesAccessor) => {
+	const chatWidgetService = accessor.get(IChatWidgetService);
+	const chatSessionsService = accessor.get(IChatSessionsService);
+	const widget = chatWidgetService.lastFocusedWidget;
+	if (!widget || !chatSessionsService.getChatSessionContribution(SessionType.AgentHostCopilot)) {
+		return;
+	}
+
+	widget.input.continueInSession(SessionType.AgentHostCopilot);
+});
+
 export class LocalAgentDisabledInputTipContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'workbench.contrib.localAgentDisabledInputTip';
-
-	private static readonly NOTIFICATION_ID = 'chat.localAgentDisabled.continueInAgentHostCopilot';
 
 	private _lastPostedFor: string | undefined;
 
@@ -58,11 +72,14 @@ export class LocalAgentDisabledInputTipContribution extends Disposable implement
 
 		this._lastPostedFor = key;
 		this.notificationService.setNotification({
-			id: LocalAgentDisabledInputTipContribution.NOTIFICATION_ID,
+			id: LOCAL_AGENT_DISABLED_NOTIFICATION_ID,
 			severity: ChatInputNotificationSeverity.Info,
-			message: localize('chat.localAgentDisabled.continueInAgentHostCopilot.message', "Copilot CLI [Agent Host] can continue with this local chat history."),
-			description: localize('chat.localAgentDisabled.continueInAgentHostCopilot.description', "Use Continue In to move this local harness history to Copilot CLI [Agent Host]. To keep using local and turn off this notification, set \"chat.editor.localAgent.enabled\" to true."),
-			actions: [],
+			message: localize('chat.localAgentDisabled.continueInAgentHostCopilot.message', "Copilot CLI can continue with this local chat history."),
+			description: localize('chat.localAgentDisabled.continueInAgentHostCopilot.description', "Use Continue In to carry this local harness history forward. To keep using local and turn off this notification, set \"chat.editor.localAgent.enabled\" to true."),
+			actions: [{
+				label: localize('chat.localAgentDisabled.continueInAgentHostCopilot.action', "Continue In Copilot CLI"),
+				commandId: LOCAL_AGENT_DISABLED_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID,
+			}],
 			dismissible: true,
 			autoDismissOnMessage: false,
 			sessionTypes: [localChatSessionType],
@@ -93,6 +110,6 @@ export class LocalAgentDisabledInputTipContribution extends Disposable implement
 			return;
 		}
 		this._lastPostedFor = undefined;
-		this.notificationService.deleteNotification(LocalAgentDisabledInputTipContribution.NOTIFICATION_ID);
+		this.notificationService.deleteNotification(LOCAL_AGENT_DISABLED_NOTIFICATION_ID);
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -57,6 +57,7 @@ import { ChatSlashCommandService, IChatSlashCommandService } from '../common/par
 import { ChatArtifactsService, IChatArtifactsService } from '../common/tools/chatArtifactsService.js';
 import { ChatTodoListService, IChatTodoListService } from '../common/tools/chatTodoListService.js';
 import { ChatTransferService, IChatTransferService } from '../common/model/chatTransferService.js';
+import { LocalAgentDisabledInputTipContribution } from './agentSessions/localAgentDisabledInputTipContribution.js';
 import { IChatVariablesService } from '../common/attachments/chatVariables.js';
 import { ChatWidgetHistoryService, IChatWidgetHistoryService } from '../common/widget/chatWidgetHistoryService.js';
 import { ChatAgentLocation, ChatConfiguration, ChatNotificationMode, ChatPermissionLevel } from '../common/constants.js';
@@ -2409,6 +2410,7 @@ registerWorkbenchContribution2(ChatViewsWelcomeHandler.ID, ChatViewsWelcomeHandl
 registerWorkbenchContribution2(ChatGettingStartedContribution.ID, ChatGettingStartedContribution, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(ChatSetupContribution.ID, ChatSetupContribution, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(ChatQuotaNotificationContribution.ID, ChatQuotaNotificationContribution, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(LocalAgentDisabledInputTipContribution.ID, LocalAgentDisabledInputTipContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(HasByokModelsContribution.ID, HasByokModelsContribution, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(ChatTeardownContribution.ID, ChatTeardownContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(ChatStatusBarEntry.ID, ChatStatusBarEntry, WorkbenchPhase.BlockRestore);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2428,6 +2428,11 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	 * agent and model pickers. Re-selecting the active session clears the pending target and
 	 * restores the pickers.
 	 */
+	public continueInSession(provider: AgentSessionTarget): void {
+		this.setPendingDelegationTarget(provider);
+		this.focus();
+	}
+
 	private setPendingDelegationTarget(provider: AgentSessionTarget): void {
 		const isActive = this.getActiveSessionTypeForDelegation() === provider;
 		this._pendingDelegationTarget = isActive ? undefined : provider;

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentDisabledInputTipContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentDisabledInputTipContribution.test.ts
@@ -1,0 +1,260 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { ConfigurationTarget } from '../../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { MockContextKeyService } from '../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { IsSessionsWindowContext } from '../../../../../common/contextkeys.js';
+import { IChatWidget, IChatWidgetService, IChatWidgetViewContext } from '../../../browser/chat.js';
+import { LocalAgentDisabledInputTipContribution } from '../../../browser/agentSessions/localAgentDisabledInputTipContribution.js';
+import { ChatInputNotificationSeverity, IChatInputNotification, IChatInputNotificationService } from '../../../browser/widget/input/chatInputNotificationService.js';
+import { IChatModel } from '../../../common/model/chatModel.js';
+import { LocalChatSessionUri } from '../../../common/model/chatUri.js';
+import { IChatViewModel } from '../../../common/model/chatViewModel.js';
+import { ChatConfiguration } from '../../../common/constants.js';
+import { IChatSessionsExtensionPoint, localChatSessionType, SessionType } from '../../../common/chatSessionsService.js';
+import { MockChatSessionsService } from '../../common/mockChatSessionsService.js';
+
+class TestChatWidgetService implements IChatWidgetService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onDidAddWidget = new Emitter<IChatWidget>();
+	readonly onDidAddWidget = this._onDidAddWidget.event;
+
+	private readonly _onDidChangeFocusedSession = new Emitter<void>();
+	readonly onDidChangeFocusedSession = this._onDidChangeFocusedSession.event;
+
+	readonly onDidBackgroundSession = Event.None;
+	readonly onDidChangeFocusedWidget = Event.None;
+
+	lastFocusedWidget: IChatWidget | undefined;
+
+	setFocusedWidget(widget: IChatWidget | undefined): void {
+		this.lastFocusedWidget = widget;
+		this._onDidChangeFocusedSession.fire();
+	}
+
+	fireDidAddWidget(widget: IChatWidget): void {
+		this._onDidAddWidget.fire(widget);
+	}
+
+	revealWidget(): Promise<IChatWidget | undefined> { return Promise.resolve(undefined); }
+	reveal(): Promise<boolean> { return Promise.resolve(true); }
+	getAllWidgets(): ReadonlyArray<IChatWidget> { return []; }
+	getWidgetByInputUri(): IChatWidget | undefined { return undefined; }
+	getWidgetBySessionResource(): IChatWidget | undefined { return undefined; }
+	getWidgetsByLocations(): ReadonlyArray<IChatWidget> { return []; }
+	openSession(): Promise<IChatWidget | undefined> { return Promise.resolve(undefined); }
+	register(): { dispose(): void } { return { dispose() { } }; }
+}
+
+class TestChatInputNotificationService implements IChatInputNotificationService {
+	declare readonly _serviceBrand: undefined;
+
+	readonly onDidChange = Event.None;
+	readonly onDidDismiss = Event.None;
+	readonly setCalls: IChatInputNotification[] = [];
+	readonly deleteCalls: string[] = [];
+
+	setNotification(notification: IChatInputNotification): void {
+		this.setCalls.push(notification);
+	}
+
+	deleteNotification(id: string): void {
+		this.deleteCalls.push(id);
+	}
+
+	dismissNotification(): void { }
+	getActiveNotification(): IChatInputNotification | undefined { return this.setCalls.at(-1); }
+	handleMessageSent(): void { }
+}
+
+suite('LocalAgentDisabledInputTipContribution', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let widgetService: TestChatWidgetService;
+	let notificationService: TestChatInputNotificationService;
+	let configurationService: TestConfigurationService;
+	let chatSessionsService: MockChatSessionsService;
+	let testDisposables: DisposableStore;
+
+	setup(() => {
+		testDisposables = store.add(new DisposableStore());
+		widgetService = new TestChatWidgetService();
+		notificationService = new TestChatInputNotificationService();
+		configurationService = new TestConfigurationService({
+			[ChatConfiguration.EditorLocalAgentEnabled]: false,
+			[ChatConfiguration.EditorDefaultProvider]: 'copilotAh',
+		});
+		chatSessionsService = new MockChatSessionsService();
+		chatSessionsService.setContributions([createContribution(SessionType.AgentHostCopilot)]);
+	});
+
+	teardown(() => {
+		testDisposables.dispose();
+	});
+
+	function createContribution(type: string): IChatSessionsExtensionPoint {
+		return {
+			type,
+			name: type,
+			displayName: type,
+			description: type,
+		};
+	}
+
+	function createTipContribution(): LocalAgentDisabledInputTipContribution {
+		const contribution = new LocalAgentDisabledInputTipContribution(widgetService, notificationService, configurationService, chatSessionsService);
+		testDisposables.add(contribution);
+		return contribution;
+	}
+
+	function createWidget(options?: {
+		readonly sessionResource?: URI;
+		readonly hasRequests?: boolean;
+		readonly viewContext?: IChatWidgetViewContext;
+		readonly isSessionsWindow?: boolean;
+	}): IChatWidget {
+		const contextKeyService = new MockContextKeyService();
+		IsSessionsWindowContext.bindTo(contextKeyService).set(options?.isSessionsWindow ?? false);
+
+		const sessionResource = options?.sessionResource ?? LocalChatSessionUri.forSession('history');
+		const model = { hasRequests: options?.hasRequests ?? true } as IChatModel;
+		const viewModel = { sessionResource, model } as IChatViewModel;
+
+		return {
+			viewModel,
+			viewContext: options?.viewContext ?? { viewId: 'workbench.panel.chat' },
+			scopedContextKeyService: contextKeyService,
+		} as unknown as IChatWidget;
+	}
+
+	function fireConfigChange(...keys: string[]): void {
+		configurationService.onDidChangeConfigurationEmitter.fire({
+			source: ConfigurationTarget.USER,
+			affectsConfiguration: (key: string) => keys.includes(key),
+			affectedKeys: new Set(keys),
+			change: { keys, overrides: [] },
+		});
+	}
+
+	test('shows tip for non-empty local session when local is disabled and agent host Copilot is configured', () => {
+		createTipContribution();
+
+		widgetService.setFocusedWidget(createWidget());
+
+		assert.strictEqual(notificationService.setCalls.length, 1);
+		assert.strictEqual(notificationService.setCalls[0].id, 'chat.localAgentDisabled.continueInAgentHostCopilot');
+		assert.strictEqual(notificationService.setCalls[0].severity, ChatInputNotificationSeverity.Info);
+		assert.strictEqual(notificationService.setCalls[0].actions.length, 0);
+		assert.deepStrictEqual(notificationService.setCalls[0].sessionTypes, [localChatSessionType]);
+	});
+
+	test('shows tip for normal Chat view sessions', () => {
+		createTipContribution();
+
+		widgetService.setFocusedWidget(createWidget({ viewContext: { viewId: 'workbench.panel.chat' } }));
+
+		assert.strictEqual(notificationService.setCalls.length, 1);
+	});
+
+	test('does not show tip for empty local session', () => {
+		createTipContribution();
+
+		widgetService.setFocusedWidget(createWidget({ hasRequests: false }));
+
+		assert.strictEqual(notificationService.setCalls.length, 0);
+	});
+
+	test('does not show tip when local is enabled', () => {
+		configurationService = new TestConfigurationService({
+			[ChatConfiguration.EditorLocalAgentEnabled]: true,
+			[ChatConfiguration.EditorDefaultProvider]: 'copilotAh',
+		});
+		createTipContribution();
+
+		widgetService.setFocusedWidget(createWidget());
+
+		assert.strictEqual(notificationService.setCalls.length, 0);
+	});
+
+	test('does not show tip when default provider is not agent host Copilot', () => {
+		configurationService = new TestConfigurationService({
+			[ChatConfiguration.EditorLocalAgentEnabled]: false,
+			[ChatConfiguration.EditorDefaultProvider]: 'copilotEh',
+		});
+		createTipContribution();
+
+		widgetService.setFocusedWidget(createWidget());
+
+		assert.strictEqual(notificationService.setCalls.length, 0);
+	});
+
+	test('does not show tip before agent host Copilot contribution registers', () => {
+		chatSessionsService.setContributions([]);
+		createTipContribution();
+
+		widgetService.setFocusedWidget(createWidget());
+
+		assert.strictEqual(notificationService.setCalls.length, 0);
+	});
+
+	test('does not show tip for non-local sessions', () => {
+		createTipContribution();
+
+		widgetService.setFocusedWidget(createWidget({ sessionResource: URI.from({ scheme: SessionType.AgentHostCopilot, path: '/session' }) }));
+
+		assert.strictEqual(notificationService.setCalls.length, 0);
+	});
+
+	test('does not show tip for quick, inline, or Agents Window sessions', () => {
+		createTipContribution();
+
+		widgetService.setFocusedWidget(createWidget({ viewContext: { isQuickChat: true } }));
+		widgetService.setFocusedWidget(createWidget({ viewContext: { isInlineChat: true } }));
+		widgetService.setFocusedWidget(createWidget({ isSessionsWindow: true }));
+
+		assert.strictEqual(notificationService.setCalls.length, 0);
+	});
+
+	test('clears tip when focused session becomes ineligible', () => {
+		createTipContribution();
+		widgetService.setFocusedWidget(createWidget());
+
+		widgetService.setFocusedWidget(createWidget({ hasRequests: false }));
+
+		assert.deepStrictEqual(notificationService.deleteCalls, ['chat.localAgentDisabled.continueInAgentHostCopilot']);
+	});
+
+	test('does not repost for the same eligible session unless relevant configuration changes', async () => {
+		createTipContribution();
+		const widget = createWidget();
+		widgetService.setFocusedWidget(widget);
+
+		widgetService.setFocusedWidget(widget);
+		assert.strictEqual(notificationService.setCalls.length, 1);
+
+		await configurationService.setUserConfiguration(ChatConfiguration.EditorDefaultProvider, 'copilotAh');
+		fireConfigChange(ChatConfiguration.EditorDefaultProvider);
+
+		assert.strictEqual(notificationService.setCalls.length, 2);
+	});
+
+	test('shows tip when agent host Copilot contribution registers after focus', () => {
+		chatSessionsService.setContributions([]);
+		createTipContribution();
+		widgetService.setFocusedWidget(createWidget());
+
+		chatSessionsService.setContributions([createContribution(SessionType.AgentHostCopilot)]);
+		chatSessionsService.fireDidChangeAvailability();
+
+		assert.strictEqual(notificationService.setCalls.length, 1);
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentDisabledInputTipContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentDisabledInputTipContribution.test.ts
@@ -156,7 +156,7 @@ suite('LocalAgentDisabledInputTipContribution', () => {
 		assert.strictEqual(notificationService.setCalls[0].id, 'chat.localAgentDisabled.continueInAgentHostCopilot');
 		assert.strictEqual(notificationService.setCalls[0].severity, ChatInputNotificationSeverity.Info);
 		assert.strictEqual(notificationService.setCalls[0].actions.length, 1);
-		assert.strictEqual(notificationService.setCalls[0].actions[0].label, 'Continue In Copilot CLI');
+		assert.strictEqual(notificationService.setCalls[0].actions[0].label, 'Continue In Agent Host');
 		assert.strictEqual(notificationService.setCalls[0].actions[0].commandId, LOCAL_AGENT_DISABLED_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID);
 		assert.deepStrictEqual(notificationService.setCalls[0].sessionTypes, [localChatSessionType]);
 	});

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentDisabledInputTipContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentDisabledInputTipContribution.test.ts
@@ -8,18 +8,20 @@ import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { CommandsRegistry } from '../../../../../../platform/commands/common/commands.js';
 import { ConfigurationTarget } from '../../../../../../platform/configuration/common/configuration.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { MockContextKeyService } from '../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { IsSessionsWindowContext } from '../../../../../common/contextkeys.js';
 import { IChatWidget, IChatWidgetService, IChatWidgetViewContext } from '../../../browser/chat.js';
-import { LocalAgentDisabledInputTipContribution } from '../../../browser/agentSessions/localAgentDisabledInputTipContribution.js';
+import { LocalAgentDisabledInputTipContribution, LOCAL_AGENT_DISABLED_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID } from '../../../browser/agentSessions/localAgentDisabledInputTipContribution.js';
 import { ChatInputNotificationSeverity, IChatInputNotification, IChatInputNotificationService } from '../../../browser/widget/input/chatInputNotificationService.js';
 import { IChatModel } from '../../../common/model/chatModel.js';
 import { LocalChatSessionUri } from '../../../common/model/chatUri.js';
 import { IChatViewModel } from '../../../common/model/chatViewModel.js';
 import { ChatConfiguration } from '../../../common/constants.js';
-import { IChatSessionsExtensionPoint, localChatSessionType, SessionType } from '../../../common/chatSessionsService.js';
+import { IChatSessionsExtensionPoint, IChatSessionsService, localChatSessionType, SessionType } from '../../../common/chatSessionsService.js';
 import { MockChatSessionsService } from '../../common/mockChatSessionsService.js';
 
 class TestChatWidgetService implements IChatWidgetService {
@@ -153,8 +155,30 @@ suite('LocalAgentDisabledInputTipContribution', () => {
 		assert.strictEqual(notificationService.setCalls.length, 1);
 		assert.strictEqual(notificationService.setCalls[0].id, 'chat.localAgentDisabled.continueInAgentHostCopilot');
 		assert.strictEqual(notificationService.setCalls[0].severity, ChatInputNotificationSeverity.Info);
-		assert.strictEqual(notificationService.setCalls[0].actions.length, 0);
+		assert.strictEqual(notificationService.setCalls[0].actions.length, 1);
+		assert.strictEqual(notificationService.setCalls[0].actions[0].label, 'Continue In Copilot CLI');
+		assert.strictEqual(notificationService.setCalls[0].actions[0].commandId, LOCAL_AGENT_DISABLED_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID);
 		assert.deepStrictEqual(notificationService.setCalls[0].sessionTypes, [localChatSessionType]);
+	});
+
+	test('continue action selects agent host Copilot as pending delegation target', async () => {
+		const instantiationService = new TestInstantiationService();
+		instantiationService.set(IChatWidgetService, widgetService);
+		instantiationService.set(IChatSessionsService, chatSessionsService);
+
+		let continuedInSession: string | undefined;
+		widgetService.setFocusedWidget(Object.assign(createWidget(), {
+			input: {
+				continueInSession: (provider: string) => continuedInSession = provider,
+			},
+		}) as unknown as IChatWidget);
+
+		const command = CommandsRegistry.getCommand(LOCAL_AGENT_DISABLED_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID);
+		assert.ok(command);
+
+		await command.handler(instantiationService);
+
+		assert.strictEqual(continuedInSession, SessionType.AgentHostCopilot);
 	});
 
 	test('shows tip for normal Chat view sessions', () => {


### PR DESCRIPTION
Should be way-less aggressive than: https://github.com/microsoft/vscode/pull/321811.
Part of the migration journey from Local --> Agent Host Copilot CLI.





https://github.com/user-attachments/assets/20882909-5ad0-4117-b788-7f716c82fce4











- Add a focused chat input tip for historical local sessions when `chat.editor.localAgent.enabled` is `false` and `chat.editor.defaultProvider` is `copilotAh`.
- Suggest continuing the local harness history in Copilot CLI [Agent Host] through the existing Continue In flow.
- Keep the transition non-automatic: this does not set a pending delegation target, migrate history, mutate the local session, or send a request.
- Hide the tip outside the intended scope: empty local sessions, quick chat, inline chat, Agents Window, and cases where Copilot CLI [Agent Host] is not registered.
- Tell users they can set `"chat.editor.localAgent.enabled"` to `true` to keep using local and turn off the notification.

-----------------------------------------
Inspirations from:

- The input notification API shape comes from [`IChatInputNotificationService.setNotification`](https://github.com/microsoft/vscode/blob/95bb74807526482055d71d7abe885977ee9176c4/src/vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationService.ts#L67-L76).
- The focused-widget tip pattern comes from [`AgentsHandoffInputTipContribution`](https://github.com/microsoft/vscode/blob/95bb74807526482055d71d7abe885977ee9176c4/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts#L256-L348).
- The “post once per session so dismissal sticks” behavior comes from [`AgentsHandoffInputTipContribution._update`](https://github.com/microsoft/vscode/blob/95bb74807526482055d71d7abe885977ee9176c4/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts#L421-L481).
