### PR TITLE
Fix new chat session button context

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -596,7 +596,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 		const newSessionButtonContainer = this.sessionsNewButtonContainer = append(sessionsContainer, $('.agent-sessions-new-button-container'));
 		const newSessionButton = this._register(new Button(newSessionButtonContainer, { ...defaultButtonStyles, secondary: true }));
 		newSessionButton.label = localize('newSession', "New Session");
-		this._register(newSessionButton.onDidClick(() => this.commandService.executeCommand(ACTION_ID_NEW_CHAT)));
+		this._register(newSessionButton.onDidClick(() => this.commandService.executeCommand(ACTION_ID_NEW_CHAT, this.getActionsContext())));
 
 		// Sessions Control
 		this.sessionsControlContainer = append(sessionsContainer, $('.agent-sessions-control-container'));


### PR DESCRIPTION
Fixes #321049

When the Chat Sessions viewer is shown side-by-side, its large **New Session** button invoked `workbench.action.chat.newChat` without passing the current chat view action context. The new-chat action then fell back to `IChatWidgetService.lastFocusedWidget`, which can point at a different/stale session after interacting with the sessions list or terminal. That makes this path target the wrong session, while the plus toolbar path does not reproduce because it is invoked with the chat view context.

This changes the side-by-side **New Session** button to pass `getActionsContext()` into the command so the new session is created from the currently displayed chat pane instead of relying on focus fallback.


https://github.com/user-attachments/assets/aa7a424b-a79a-44ad-acf4-2c3a3376f289

