### PR TITLE
sessions: reorder agent feedback actions and rename convert to Accept

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
@@ -239,15 +239,6 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 
 			const itemActions: ICommentItemActions = { editAction: undefined!, convertAction: undefined, removeAction: undefined!, addReplyAction: undefined! };
 
-			itemActions.editAction = this._eventStore.add(new Action(
-				'agentFeedback.widget.edit',
-				nls.localize('editComment', "Edit"),
-				ThemeIcon.asClassName(Codicon.edit),
-				true,
-				(): void => { this._startEditing(comment, text, itemActions); },
-			));
-			actionBar.push(itemActions.editAction, { icon: true, label: false });
-
 			itemActions.addReplyAction = this._eventStore.add(new Action(
 				'agentFeedback.widget.addReply',
 				nls.localize('addToComment', "Add to Comment"),
@@ -257,10 +248,19 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 			));
 			actionBar.push(itemActions.addReplyAction, { icon: true, label: false });
 
+			itemActions.editAction = this._eventStore.add(new Action(
+				'agentFeedback.widget.edit',
+				nls.localize('editComment', "Edit"),
+				ThemeIcon.asClassName(Codicon.edit),
+				true,
+				(): void => { this._startEditing(comment, text, itemActions); },
+			));
+			actionBar.push(itemActions.editAction, { icon: true, label: false });
+
 			if (comment.canConvertToAgentFeedback) {
 				itemActions.convertAction = this._eventStore.add(new Action(
 					'agentFeedback.widget.convert',
-					nls.localize('convertComment', "Convert to Agent Feedback"),
+					nls.localize('convertComment', "Accept"),
 					ThemeIcon.asClassName(Codicon.check),
 					true,
 					() => this._convertToAgentFeedback(comment),


### PR DESCRIPTION
Reorders the agent feedback item action bar and renames an action.

## What changed
- Show **Add to Comment** before **Edit** in the feedback item action bar (left-to-right order is now: Add to Comment, Edit, Accept (convert), Accept, Remove).
- Rename the **Convert to Agent Feedback** action label to **Accept**.

## Why
Aligns the action ordering and labeling with the desired UX.