### PR TITLE
Remove delegate picker from agents window

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -616,14 +616,7 @@ export class OpenDelegationPickerAction extends Action2 {
 						ChatContextKeys.inQuickChat.negate(),
 						ChatContextKeys.chatSessionSupportsDelegation,
 						ChatContextKeys.chatSessionIsEmpty.negate(),
-						// In the agents window, hide the delegation chip while a
-						// request (or the input) is being edited. The editor window
-						// keeps showing it during edits.
-						ContextKeyExpr.or(
-							IsSessionsWindowContext.negate(),
-							ContextKeyExpr.and(
-								ChatContextKeys.currentlyEditing.negate(),
-								ChatContextKeys.currentlyEditingInput.negate()))
+						IsSessionsWindowContext.negate()
 					),
 					group: 'navigation',
 				},


### PR DESCRIPTION
```Copilot Generated Description:``` Remove the delegation picker from the agents window to streamline the interface.

