### PR TITLE
Add inline chat OTel invocation span

### DIFF
--- a/extensions/copilot/docs/monitoring/agent_monitoring.md
+++ b/extensions/copilot/docs/monitoring/agent_monitoring.md
@@ -137,6 +137,8 @@ invoke_agent copilot                           [~15s]
   └── (span ends)
 ```
 
+Inline chat uses the same invocation shape, with `invoke_agent Inline Chat` as the root span and nested `chat` / `execute_tool` children.
+
 **`invoke_agent`** — wraps the entire agent orchestration (all LLM calls + tool executions).
 
 | Attribute | Requirement | Example |

--- a/extensions/copilot/docs/monitoring/agent_monitoring_arch.md
+++ b/extensions/copilot/docs/monitoring/agent_monitoring_arch.md
@@ -51,6 +51,16 @@ invoke_agent copilot (INTERNAL)          ← toolCallingLoop.ts
 └── ...
 ```
 
+#### Inline Chat
+
+```
+invoke_agent Inline Chat (INTERNAL)      ← inlineChatIntent.ts
+├── chat gpt-4o (CLIENT)                 ← chatMLFetcher.ts
+├── execute_tool apply_patch (INTERNAL)  ← toolsService.ts
+├── chat gpt-4o (CLIENT)
+└── ...
+```
+
 #### Copilot CLI in-process (Bridge)
 
 ```
@@ -147,6 +157,7 @@ src/extension/trajectory/vscode-node/
 | `chatMLFetcher.ts` | `chat` spans — all LLM API calls (foreground + Claude proxy) |
 | `anthropicProvider.ts`, `geminiNativeProvider.ts` | `chat` spans — BYOK provider requests |
 | `toolCallingLoop.ts` | `invoke_agent` spans — foreground agent orchestration |
+| `inlineChatIntent.ts` | `invoke_agent Inline Chat` spans — inline chat orchestration |
 | `toolsService.ts` | `execute_tool` spans — foreground tool invocations |
 | `chatHookService.ts` | `execute_hook` spans — foreground agent hooks |
 | `copilotcliSession.ts` | `invoke_agent copilotcli` wrapper span + traceparent propagation + hook event stash |

--- a/extensions/copilot/src/extension/inlineChat2/node/inlineChatIntent.ts
+++ b/extensions/copilot/src/extension/inlineChat2/node/inlineChatIntent.ts
@@ -16,6 +16,8 @@ import { IOctoKitService } from '../../../platform/github/common/githubService';
 import { IIgnoreService } from '../../../platform/ignore/common/ignoreService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IChatEndpoint, IMakeChatRequestOptions } from '../../../platform/networking/common/networking';
+import { CopilotChatAttr, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, normalizeResponseModel, StdAttr, stringifyToolDefinitionsForOTel, truncateForOTel } from '../../../platform/otel/common/index';
+import { IOTelService, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { ChatResponseStreamImpl } from '../../../util/common/chatResponseStreamImpl';
 import { toErrorMessage } from '../../../util/common/errorMessage';
@@ -50,6 +52,14 @@ interface IInlineChatEditResult {
 	telemetry: InlineChatTelemetry;
 	lastResponse: ChatResponse;
 	needsExitTool: boolean;
+	toolCallRounds: ToolCallRound[];
+	availableTools: vscode.LanguageModelToolInformation[];
+	totalInputTokens: number;
+	totalOutputTokens: number;
+	totalCacheReadTokens: number;
+	totalCacheCreationTokens: number;
+	totalReasoningTokens: number;
+	lastResolvedModel?: string;
 	errorMessage?: string;
 }
 
@@ -204,11 +214,66 @@ class InlineChatToolCalling {
 		@IToolsService private readonly _toolsService: IToolsService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IExperimentationService private readonly _experimentationService: IExperimentationService,
+		@IOTelService private readonly _otelService: IOTelService,
 	) { }
 
 	async run(endpoint: IChatEndpoint, conversation: Conversation, request: vscode.ChatRequest, stream: vscode.ChatResponseStream, token: CancellationToken, documentContext: IDocumentContext, chatTelemetry: ChatTelemetryBuilder): Promise<IInlineChatEditResult> {
 		assertType(request.location2 instanceof ChatRequestEditorData);
 		assertType(documentContext);
+
+		return this._otelService.startActiveSpan(
+			'invoke_agent Inline Chat',
+			{
+				kind: SpanKind.INTERNAL,
+				attributes: {
+					[GenAiAttr.OPERATION_NAME]: GenAiOperationName.INVOKE_AGENT,
+					[GenAiAttr.PROVIDER_NAME]: GenAiProviderName.GITHUB,
+					[GenAiAttr.AGENT_NAME]: 'Inline Chat',
+					[GenAiAttr.CONVERSATION_ID]: conversation.sessionId,
+					[GenAiAttr.REQUEST_MODEL]: endpoint.model,
+					[CopilotChatAttr.SESSION_ID]: conversation.sessionId,
+					[CopilotChatAttr.INTENT]: this._intent.id,
+					[CopilotChatAttr.LOCATION]: ChatLocation.toStringShorter(ChatLocation.Editor),
+					[CopilotChatAttr.USER_REQUEST]: truncateForOTel(request.prompt, this._otelService.config.maxAttributeSizeChars),
+				},
+			},
+			async span => {
+				const otelStartTime = Date.now();
+				try {
+					const result = await this._runInlineToolLoop(endpoint, conversation, request, stream, token, documentContext, chatTelemetry);
+					const toolDefinitionsJson = stringifyToolDefinitionsForOTel(result.availableTools);
+					const response = result.lastResponse;
+					span.setAttributes({
+						[CopilotChatAttr.TURN_COUNT]: result.toolCallRounds.length,
+						...(response.type === ChatFetchResponseType.Success ? {
+							...(result.lastResolvedModel ? { [GenAiAttr.RESPONSE_MODEL]: normalizeResponseModel(endpoint.model, result.lastResolvedModel) ?? result.lastResolvedModel } : {}),
+							[GenAiAttr.RESPONSE_ID]: response.modelCallId ?? response.requestId,
+							[GenAiAttr.USAGE_INPUT_TOKENS]: result.totalInputTokens,
+							[GenAiAttr.USAGE_OUTPUT_TOKENS]: result.totalOutputTokens,
+							...(result.totalCacheReadTokens ? { [GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS]: result.totalCacheReadTokens } : {}),
+							...(result.totalCacheCreationTokens ? { [GenAiAttr.USAGE_CACHE_CREATION_INPUT_TOKENS]: result.totalCacheCreationTokens } : {}),
+							...(result.totalReasoningTokens ? { [GenAiAttr.USAGE_REASONING_OUTPUT_TOKENS]: result.totalReasoningTokens } : {}),
+							[GenAiAttr.OUTPUT_MESSAGES]: truncateForOTel(JSON.stringify([
+								{ role: 'assistant', parts: [{ type: 'text', content: response.value }] }
+							]), this._otelService.config.maxAttributeSizeChars),
+						} : {}),
+						...(toolDefinitionsJson ? { [GenAiAttr.TOOL_DEFINITIONS]: truncateForOTel(toolDefinitionsJson, this._otelService.config.maxAttributeSizeChars) } : {}),
+					});
+					span.setStatus(SpanStatusCode.OK);
+					const durationSec = (Date.now() - otelStartTime) / 1000;
+					GenAiMetrics.recordAgentDuration(this._otelService, 'Inline Chat', durationSec);
+					GenAiMetrics.recordAgentTurnCount(this._otelService, 'Inline Chat', result.toolCallRounds.length);
+					return result;
+				} catch (err) {
+					span.setStatus(SpanStatusCode.ERROR, err instanceof Error ? err.message : String(err));
+					span.setAttribute(StdAttr.ERROR_TYPE, err instanceof Error ? err.constructor.name : 'Error');
+					throw err;
+				}
+			},
+		);
+	}
+
+	private async _runInlineToolLoop(endpoint: IChatEndpoint, conversation: Conversation, request: vscode.ChatRequest, stream: vscode.ChatResponseStream, token: CancellationToken, documentContext: IDocumentContext, chatTelemetry: ChatTelemetryBuilder): Promise<IInlineChatEditResult> {
 
 		const isLargeFile = documentContext.document.lineCount > LARGE_FILE_LINE_THRESHOLD;
 		const availableTools = await this._getAvailableTools(request, endpoint, isLargeFile);
@@ -220,6 +285,12 @@ class InlineChatToolCalling {
 		let telemetry: InlineChatTelemetry;
 		let lastResponse: ChatResponse;
 		let lastInteractionOutcome: InteractionOutcome;
+		let totalInputTokens = 0;
+		let totalOutputTokens = 0;
+		let totalCacheReadTokens = 0;
+		let totalCacheCreationTokens = 0;
+		let totalReasoningTokens = 0;
+		let lastResolvedModel: string | undefined;
 
 		while (true) {
 
@@ -250,6 +321,14 @@ class InlineChatToolCalling {
 
 			lastInteractionOutcome = new InteractionOutcome(telemetry.editCount > 0 ? 'inlineEdit' : 'none', []);
 			lastResponse = result.fetchResult;
+			if (lastResponse.type === ChatFetchResponseType.Success) {
+				totalInputTokens += lastResponse.usage?.prompt_tokens ?? 0;
+				totalOutputTokens += lastResponse.usage?.completion_tokens ?? 0;
+				totalCacheReadTokens += lastResponse.usage?.prompt_tokens_details?.cached_tokens ?? 0;
+				totalCacheCreationTokens += lastResponse.usage?.prompt_tokens_details?.cache_creation_input_tokens ?? 0;
+				totalReasoningTokens += lastResponse.usage?.completion_tokens_details?.reasoning_tokens ?? 0;
+				lastResolvedModel = lastResponse.resolvedModel;
+			}
 
 			// telemetry
 			{
@@ -319,11 +398,19 @@ class InlineChatToolCalling {
 				lastResponse,
 				telemetry,
 				needsExitTool: false,
+				toolCallRounds,
+				availableTools,
+				totalInputTokens,
+				totalOutputTokens,
+				totalCacheReadTokens,
+				totalCacheCreationTokens,
+				totalReasoningTokens,
+				lastResolvedModel,
 				errorMessage: l10n.t('Failed to edit the file. The requested change could not be applied.'),
 			};
 		}
 
-		return { lastResponse, telemetry, needsExitTool };
+		return { lastResponse, telemetry, needsExitTool, toolCallRounds, availableTools, totalInputTokens, totalOutputTokens, totalCacheReadTokens, totalCacheCreationTokens, totalReasoningTokens, lastResolvedModel };
 	}
 
 	private async _makeRequestAndRunTools(endpoint: IChatEndpoint, request: vscode.ChatRequest, stream: vscode.ChatResponseStream, messages: Raw.ChatMessage[], inlineChatTools: vscode.LanguageModelToolInformation[], telemetry: InlineChatTelemetry, token: CancellationToken) {

--- a/extensions/copilot/src/extension/inlineChat2/node/inlineChatIntent.ts
+++ b/extensions/copilot/src/extension/inlineChat2/node/inlineChatIntent.ts
@@ -278,6 +278,11 @@ class InlineChatToolCalling {
 
 	private async _runInlineToolLoop(endpoint: IChatEndpoint, conversation: Conversation, request: vscode.ChatRequest, stream: vscode.ChatResponseStream, token: CancellationToken, documentContext: IDocumentContext, chatTelemetry: ChatTelemetryBuilder): Promise<IInlineChatEditResult> {
 
+		// Re-narrow `request.location2` for the type checker. `run()` has already asserted this,
+		// but the narrowing does not survive across the async boundary into this private method.
+		assertType(request.location2 instanceof ChatRequestEditorData);
+		const location2 = request.location2;
+
 		const isLargeFile = documentContext.document.lineCount > LARGE_FILE_LINE_THRESHOLD;
 		const availableTools = await this._getAvailableTools(request, endpoint, isLargeFile);
 
@@ -302,7 +307,7 @@ class InlineChatToolCalling {
 				previousRounds,
 				hasFailedEdits: failedEditCount > 0,
 				snapshotAtRequest: documentContext.document,
-				data: request.location2,
+				data: location2,
 				exitToolName: INLINE_CHAT_EXIT_TOOL_NAME,
 				isLargeFile,
 				readToolName: isLargeFile ? ToolName.ReadFile : undefined,

--- a/extensions/copilot/src/extension/inlineChat2/node/inlineChatIntent.ts
+++ b/extensions/copilot/src/extension/inlineChat2/node/inlineChatIntent.ts
@@ -16,7 +16,7 @@ import { IOctoKitService } from '../../../platform/github/common/githubService';
 import { IIgnoreService } from '../../../platform/ignore/common/ignoreService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IChatEndpoint, IMakeChatRequestOptions } from '../../../platform/networking/common/networking';
-import { CopilotChatAttr, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, normalizeResponseModel, StdAttr, stringifyToolDefinitionsForOTel, truncateForOTel } from '../../../platform/otel/common/index';
+import { CopilotChatAttr, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, GitHubCopilotAttr, normalizeResponseModel, StdAttr, stringifyToolDefinitionsForOTel, truncateForOTel } from '../../../platform/otel/common/index';
 import { IOTelService, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { ChatResponseStreamImpl } from '../../../util/common/chatResponseStreamImpl';
@@ -83,7 +83,6 @@ export class InlineChatIntent implements IIntent {
 		@IEndpointProvider private readonly _endpointProvider: IEndpointProvider,
 		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
 		@ILogService private readonly _logService: ILogService,
-		@IToolsService private readonly _toolsService: IToolsService,
 		@IIgnoreService private readonly _ignoreService: IIgnoreService,
 		@IEditSurvivalTrackerService private readonly _editSurvivalTrackerService: IEditSurvivalTrackerService,
 		@IOctoKitService private readonly _octoKitService: IOctoKitService,
@@ -150,16 +149,6 @@ export class InlineChatIntent implements IIntent {
 
 		if (token.isCancellationRequested) {
 			return CanceledResult;
-		}
-
-		if (result.needsExitTool) {
-			this._logService.warn('[InlineChat], BAIL_OUT because of needsExitTool');
-			// BAILOUT: when no edits were emitted, invoke the exit tool manually
-			await this._toolsService.invokeTool(INLINE_CHAT_EXIT_TOOL_NAME, {
-				toolInvocationToken: request.toolInvocationToken, input: {
-					response: result.lastResponse.type === ChatFetchResponseType.Success ? result.lastResponse.value : undefined,
-				}
-			}, token);
 		}
 
 
@@ -235,12 +224,26 @@ class InlineChatToolCalling {
 					[CopilotChatAttr.INTENT]: this._intent.id,
 					[CopilotChatAttr.LOCATION]: ChatLocation.toStringShorter(ChatLocation.Editor),
 					[CopilotChatAttr.USER_REQUEST]: truncateForOTel(request.prompt, this._otelService.config.maxAttributeSizeChars),
+					[GitHubCopilotAttr.AGENT_TYPE]: 'builtin',
 				},
 			},
 			async span => {
 				const otelStartTime = Date.now();
 				try {
 					const result = await this._runInlineToolLoop(endpoint, conversation, request, stream, token, documentContext, chatTelemetry);
+
+					// Invoke the bail-out exit tool inside the active span so its
+					// `execute_tool` span is parented under `invoke_agent Inline Chat`
+					// instead of becoming a sibling root span.
+					if (!token.isCancellationRequested && result.needsExitTool) {
+						this._logService.warn('[InlineChat], BAIL_OUT because of needsExitTool');
+						await this._toolsService.invokeTool(INLINE_CHAT_EXIT_TOOL_NAME, {
+							toolInvocationToken: request.toolInvocationToken, input: {
+								response: result.lastResponse.type === ChatFetchResponseType.Success ? result.lastResponse.value : undefined,
+							}
+						}, token);
+					}
+
 					const toolDefinitionsJson = stringifyToolDefinitionsForOTel(result.availableTools);
 					const response = result.lastResponse;
 					span.setAttributes({

--- a/extensions/copilot/src/extension/inlineChat2/test/node/inlineChatIntent.spec.ts
+++ b/extensions/copilot/src/extension/inlineChat2/test/node/inlineChatIntent.spec.ts
@@ -269,6 +269,7 @@ suite('InlineChatIntent', () => {
 		const rootSpan = harness.otelService.spans[0];
 		const sendToolCallingTelemetryMock = harness.telemetry.sendToolCallingTelemetry as Mock;
 		const invokeToolWithEndpointMock = harness.mockToolsService.invokeToolWithEndpoint as unknown as Mock;
+		expect(sendToolCallingTelemetryMock).toHaveBeenCalledTimes(1);
 		const recordedRounds = sendToolCallingTelemetryMock.mock.calls[0][0] as ToolCallRound[];
 		const rounds = recordedRounds.map(round => ({
 			response: round.response,
@@ -282,7 +283,6 @@ suite('InlineChatIntent', () => {
 			},
 			toolInvocations: invokeToolWithEndpointMock.mock.calls.length,
 			rounds,
-			metrics: harness.otelService.metrics,
 		}).toEqual({
 			rootSpan: {
 				statusCode: SpanStatusCode.OK,
@@ -301,11 +301,22 @@ suite('InlineChatIntent', () => {
 				{ response: 'first try', toolCalls: [{ id: 'tool-call-1', name: ToolName.ApplyPatch }] },
 				{ response: 'second try', toolCalls: [{ id: 'tool-call-2', name: ToolName.ApplyPatch }] },
 			],
-			metrics: [
-				{ name: 'copilot_chat.agent.invocation.duration', value: 0.5, attributes: { [GenAiAttr.AGENT_NAME]: 'Inline Chat' } },
-				{ name: 'copilot_chat.agent.turn.count', value: 2, attributes: { [GenAiAttr.AGENT_NAME]: 'Inline Chat' } },
-			],
 		});
+
+		// Assert metrics individually so the test is not brittle to call ordering
+		// or to harmless additions of unrelated metrics.
+		expect(harness.otelService.metrics).toEqual(expect.arrayContaining([
+			{
+				name: 'copilot_chat.agent.invocation.duration',
+				value: expect.closeTo(0.5, 2),
+				attributes: { [GenAiAttr.AGENT_NAME]: 'Inline Chat' },
+			},
+			{
+				name: 'copilot_chat.agent.turn.count',
+				value: 2,
+				attributes: { [GenAiAttr.AGENT_NAME]: 'Inline Chat' },
+			},
+		]));
 	});
 
 	test('Inline tool loop records error status when the loop fails before recovery', async () => {
@@ -314,7 +325,7 @@ suite('InlineChatIntent', () => {
 
 		try {
 			const result = await harness.run();
-			expect(result).toEqual({
+			expect(result).toMatchObject({
 				errorDetails: {
 					message: 'model failed',
 				}
@@ -397,7 +408,10 @@ function createInlineChatHarness(options: InlineChatHarnessOptions = {}) {
 						otelService as IOTelService,
 					);
 				}
-				return {};
+				// Fail loudly when an unexpected class is instantiated so that
+				// renames or new collaborators surface as a clear test failure
+				// rather than silently returning an empty stub.
+				throw new Error(`Unhandled createInstance for ${ctor.name}. Update the inline chat test harness.`);
 			}),
 			invokeFunction: vi.fn().mockResolvedValue([availableTool])
 		} as unknown as IInstantiationService;

--- a/extensions/copilot/src/extension/inlineChat2/test/node/inlineChatIntent.spec.ts
+++ b/extensions/copilot/src/extension/inlineChat2/test/node/inlineChatIntent.spec.ts
@@ -24,6 +24,42 @@ import { CopilotInteractiveEditorResponse } from '../../../inlineChat/node/promp
 import { TextDocumentSnapshot } from '../../../../platform/editing/common/textDocumentSnapshot';
 import { createTextDocumentData } from '../../../../util/common/test/shims/textDocument';
 import { URI } from '../../../../util/vs/base/common/uri';
+import { IConfigurationService } from '../../../../platform/configuration/common/configurationService';
+import { IExperimentationService } from '../../../../platform/telemetry/common/nullExperimentationService';
+import { IOTelService, SpanStatusCode } from '../../../../platform/otel/common/otelService';
+import { CapturingOTelService } from '../../../../platform/otel/common/test/capturingOTelService';
+import { CopilotChatAttr, GenAiAttr, GenAiOperationName } from '../../../../platform/otel/common/genAiAttributes';
+import { PromptRenderer } from '../../../prompts/node/base/promptRenderer';
+import { ToolName } from '../../../tools/common/toolNames';
+
+type TestToolCall = { id: string; name: string; arguments: string };
+
+interface TestModelResponse {
+	readonly value: string;
+	readonly requestId?: string;
+	readonly modelCallId?: string;
+	readonly resolvedModel?: string;
+	readonly usage?: {
+		readonly prompt_tokens?: number;
+		readonly completion_tokens?: number;
+		readonly prompt_tokens_details?: {
+			readonly cached_tokens?: number;
+			readonly cache_creation_input_tokens?: number;
+		};
+		readonly completion_tokens_details?: {
+			readonly reasoning_tokens?: number;
+		};
+	};
+	readonly toolCalls?: readonly TestToolCall[];
+	readonly advanceTimeMs?: number;
+}
+
+interface InlineChatHarnessOptions {
+	readonly responses?: readonly TestModelResponse[];
+	readonly toolResults?: readonly { readonly hasError?: boolean }[];
+	readonly advanceTime?: (ms: number) => void;
+	readonly markEditOnSuccessfulTool?: boolean;
+}
 
 
 suite('InlineChatIntent', () => {
@@ -126,4 +162,326 @@ suite('InlineChatIntent', () => {
 		expect(metadata.promptQuery.document).toBe(documentContext.document);
 	});
 
+	test('Inline tool loop emits an invoke_agent OTel root span', async () => {
+		const harness = createInlineChatHarness();
+
+		try {
+			await harness.run();
+		} finally {
+			harness.restore();
+		}
+
+		expect(harness.otelService.spans).toEqual([
+			expect.objectContaining({
+				name: 'invoke_agent Inline Chat',
+				statusCode: SpanStatusCode.OK,
+				ended: true,
+				attributes: expect.objectContaining({
+					[GenAiAttr.OPERATION_NAME]: GenAiOperationName.INVOKE_AGENT,
+					[GenAiAttr.AGENT_NAME]: 'Inline Chat',
+					[GenAiAttr.CONVERSATION_ID]: 'someId',
+					[GenAiAttr.REQUEST_MODEL]: 'gpt-4o',
+					[GenAiAttr.RESPONSE_MODEL]: 'gpt-4o-2024-08-06',
+					[GenAiAttr.USAGE_INPUT_TOKENS]: 10,
+					[GenAiAttr.USAGE_OUTPUT_TOKENS]: 5,
+					[CopilotChatAttr.SESSION_ID]: 'someId',
+					[CopilotChatAttr.USER_REQUEST]: 'test prompt',
+					[CopilotChatAttr.TURN_COUNT]: 1,
+				})
+			})
+		]);
+	});
+
+	test('Inline tool loop aggregates tokens, tool rounds, and metrics across recovered tool failures', async () => {
+		let now = 1000;
+		const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+		const firstToolCall = { id: 'tool-call-1', name: ToolName.ApplyPatch, arguments: '{}' };
+		const secondToolCall = { id: 'tool-call-2', name: ToolName.ApplyPatch, arguments: '{}' };
+		const harness = createInlineChatHarness({
+			responses: [
+				{
+					value: 'first try',
+					requestId: 'request-1',
+					modelCallId: 'model-call-1',
+					resolvedModel: 'gpt-4o-2024-08-06',
+					usage: {
+						prompt_tokens: 10,
+						completion_tokens: 5,
+						prompt_tokens_details: { cached_tokens: 2 },
+					},
+					toolCalls: [firstToolCall],
+					advanceTimeMs: 200,
+				},
+				{
+					value: 'second try',
+					requestId: 'request-2',
+					modelCallId: 'model-call-2',
+					resolvedModel: 'gpt-4o-2024-08-06',
+					usage: {
+						prompt_tokens: 20,
+						completion_tokens: 7,
+						prompt_tokens_details: { cached_tokens: 3, cache_creation_input_tokens: 4 },
+						completion_tokens_details: { reasoning_tokens: 6 },
+					},
+					toolCalls: [secondToolCall],
+					advanceTimeMs: 300,
+				},
+			],
+			toolResults: [{ hasError: true }, { hasError: false }],
+			advanceTime: ms => now += ms,
+			markEditOnSuccessfulTool: true,
+		});
+
+		try {
+			await harness.run();
+		} finally {
+			harness.restore();
+			nowSpy.mockRestore();
+		}
+
+		const rootSpan = harness.otelService.spans[0];
+		const rounds = harness.telemetry.sendToolCallingTelemetry.mock.calls[0][0].map(round => ({
+			response: round.response,
+			toolCalls: round.toolCalls.map(toolCall => ({ id: toolCall.id, name: toolCall.name })),
+		}));
+
+		expect({
+			rootSpan: {
+				statusCode: rootSpan.statusCode,
+				attributes: rootSpan.attributes,
+			},
+			toolInvocations: harness.mockToolsService.invokeToolWithEndpoint.mock.calls.length,
+			rounds,
+			metrics: harness.otelService.metrics,
+		}).toEqual({
+			rootSpan: {
+				statusCode: SpanStatusCode.OK,
+				attributes: expect.objectContaining({
+					[CopilotChatAttr.TURN_COUNT]: 2,
+					[GenAiAttr.RESPONSE_ID]: 'model-call-2',
+					[GenAiAttr.USAGE_INPUT_TOKENS]: 30,
+					[GenAiAttr.USAGE_OUTPUT_TOKENS]: 12,
+					[GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS]: 5,
+					[GenAiAttr.USAGE_CACHE_CREATION_INPUT_TOKENS]: 4,
+					[GenAiAttr.USAGE_REASONING_OUTPUT_TOKENS]: 6,
+				}),
+			},
+			toolInvocations: 2,
+			rounds: [
+				{ response: 'first try', toolCalls: [{ id: 'tool-call-1', name: ToolName.ApplyPatch }] },
+				{ response: 'second try', toolCalls: [{ id: 'tool-call-2', name: ToolName.ApplyPatch }] },
+			],
+			metrics: [
+				{ name: 'copilot_chat.agent.invocation.duration', value: 0.5, attributes: { [GenAiAttr.AGENT_NAME]: 'Inline Chat' } },
+				{ name: 'copilot_chat.agent.turn.count', value: 2, attributes: { [GenAiAttr.AGENT_NAME]: 'Inline Chat' } },
+			],
+		});
+	});
+
+	test('Inline tool loop records error status when the loop fails before recovery', async () => {
+		const harness = createInlineChatHarness();
+		harness.mockEndpoint.makeChatRequest2.mockRejectedValueOnce(new Error('model failed'));
+
+		try {
+			const result = await harness.run();
+			expect(result).toEqual({
+				errorDetails: {
+					message: 'model failed',
+				}
+			});
+		} finally {
+			harness.restore();
+		}
+
+		expect(harness.otelService.spans).toEqual([
+			expect.objectContaining({
+				name: 'invoke_agent Inline Chat',
+				statusCode: SpanStatusCode.ERROR,
+				statusMessage: 'model failed',
+				ended: true,
+				attributes: expect.objectContaining({
+					[GenAiAttr.OPERATION_NAME]: GenAiOperationName.INVOKE_AGENT,
+					['error.type']: 'Error',
+				})
+			})
+		]);
+	});
+
 });
+
+function createInlineChatHarness(options: InlineChatHarnessOptions = {}) {
+		const otelService = new CapturingOTelService();
+		const document = createTextDocumentData(URI.parse('file:///test.ts'), 'test content', 'typescript').document;
+		const availableTool = {
+			name: ToolName.ApplyPatch,
+			description: 'Apply a patch',
+			inputSchema: {}
+		} as vscode.LanguageModelToolInformation;
+
+		const mockLogService = {
+			warn: vi.fn(),
+			error: vi.fn(),
+			trace: vi.fn()
+		} as unknown as ILogService;
+
+		const telemetry = {
+			telemetryMessageId: 'test-msg-id',
+			sessionId: 'someId',
+			editCount: 0,
+			markEmittedEdits: vi.fn(),
+			markReceivedToken: vi.fn(),
+			sendTelemetry: vi.fn(),
+			sendToolCallingTelemetry: vi.fn()
+		};
+		let toolResultIndex = 0;
+
+		const mockToolsService = {
+			getTool: vi.fn((name: string) => name === ToolName.ApplyPatch ? availableTool : undefined),
+			invokeTool: vi.fn(),
+			validateToolInput: vi.fn().mockReturnValue({ inputObj: {} }),
+			getCopilotTool: vi.fn(),
+			invokeToolWithEndpoint: vi.fn().mockImplementation(async () => {
+				const result = options.toolResults?.[toolResultIndex++] ?? { hasError: false };
+				if (!result.hasError && options.markEditOnSuccessfulTool) {
+					telemetry.editCount = 1;
+				}
+				return result;
+			})
+		} as unknown as IToolsService;
+
+		const mockInstantiationService = {
+			createInstance: vi.fn((ctor: new (...args: unknown[]) => unknown, ...args: unknown[]) => {
+				if (ctor.name === 'InlineChatProgressMessages') {
+					return {
+						getContextualMessage: vi.fn().mockResolvedValue('mock message')
+					};
+				}
+				if (ctor.name === 'InlineChatToolCalling') {
+					return new ctor(
+						args[0],
+						mockInstantiationService,
+						mockLogService,
+						mockToolsService,
+						{ getExperimentBasedConfig: vi.fn() } as unknown as IConfigurationService,
+						{} as IExperimentationService,
+						otelService as IOTelService,
+					);
+				}
+				return {};
+			}),
+			invokeFunction: vi.fn().mockResolvedValue([availableTool])
+		} as unknown as IInstantiationService;
+
+		const responses = options.responses ?? [{
+			value: 'mocked success!',
+			requestId: 'request-1',
+			modelCallId: 'model-call-1',
+			resolvedModel: 'gpt-4o-2024-08-06',
+			usage: {
+				prompt_tokens: 10,
+				completion_tokens: 5
+			}
+		}];
+		let responseIndex = 0;
+
+		const mockEndpoint = {
+			supportsToolCalls: true,
+			model: 'gpt-4o',
+			acquireTokenizer: vi.fn().mockReturnValue({
+				countToolTokens: vi.fn().mockResolvedValue(7)
+			}),
+			makeChatRequest2: vi.fn().mockImplementation(async (requestOptions: { finishedCb?: (text: string, index: number, delta: { copilotToolCalls?: readonly TestToolCall[] }) => Promise<undefined> }) => {
+				const response = responses[responseIndex++];
+				if (!response) {
+					throw new Error('No mock response configured');
+				}
+				if (response.advanceTimeMs !== undefined) {
+					options.advanceTime?.(response.advanceTimeMs);
+				}
+				if (response.toolCalls) {
+					await requestOptions.finishedCb?.('', 0, { copilotToolCalls: response.toolCalls });
+				}
+				return {
+					type: ChatFetchResponseType.Success,
+					value: response.value,
+					requestId: response.requestId ?? `request-${responseIndex}`,
+					modelCallId: response.modelCallId,
+					resolvedModel: response.resolvedModel ?? 'gpt-4o-2024-08-06',
+					usage: response.usage,
+				};
+			})
+		};
+
+		const mockEndpointProvider = {
+			getChatEndpoint: vi.fn().mockResolvedValue(mockEndpoint)
+		} as unknown as IEndpointProvider;
+
+		const mockAuthService = {
+			getCopilotToken: vi.fn()
+		} as unknown as IAuthenticationService;
+
+		const mockIgnoreService = {
+			isCopilotIgnored: vi.fn().mockResolvedValue(false)
+		} as unknown as IIgnoreService;
+
+		const mockEditTracker = {
+			collectAIEdits: vi.fn()
+		};
+		const mockEditSurvivalTrackerService = {
+			initialize: vi.fn().mockReturnValue(mockEditTracker)
+		} as unknown as IEditSurvivalTrackerService;
+
+		const mockOctoKitService = {
+			getGitHubOutageStatus: vi.fn()
+		} as unknown as IOctoKitService;
+
+		const renderSpy = vi.spyOn(PromptRenderer, 'create').mockReturnValue({
+			render: vi.fn().mockResolvedValue({
+				messages: [],
+				tokenCount: 3,
+				references: []
+			})
+		} as unknown as PromptRenderer<unknown, unknown>);
+
+		const intent = new InlineChatIntent(
+			mockInstantiationService,
+			mockEndpointProvider,
+			mockAuthService,
+			mockLogService,
+			mockToolsService,
+			mockIgnoreService,
+			mockEditSurvivalTrackerService,
+			mockOctoKitService
+		);
+
+		const mockTurn = {
+			setMetadata: vi.fn()
+		};
+		const conversation = new Conversation('someId', [mockTurn as unknown as Turn]);
+		const request = {
+			prompt: 'test prompt',
+			location2: new ChatRequestEditorData({} as vscode.TextEditor, document, { isEmpty: true } as vscode.Selection, {} as vscode.Range),
+			toolInvocationToken: {} as vscode.ChatParticipantToolToken,
+			references: [],
+			tools: new Map()
+		} as unknown as vscode.ChatRequest;
+
+		const stream = {
+			progress: vi.fn(),
+			text: vi.fn()
+		} as unknown as vscode.ChatResponseStream;
+
+		const documentContext = { document: TextDocumentSnapshot.create(document) } as IDocumentContext;
+		const chatTelemetry = {
+			makeRequest: vi.fn().mockReturnValue(telemetry)
+		} as unknown as ChatTelemetryBuilder;
+
+		return {
+			otelService,
+			telemetry,
+			mockEndpoint,
+			mockToolsService,
+			run: () => intent.handleRequest(conversation, request, stream, CancellationToken.None, documentContext, 'agent', ChatLocation.Editor, chatTelemetry),
+			restore: () => renderSpy.mockRestore(),
+		};
+}

--- a/extensions/copilot/src/extension/inlineChat2/test/node/inlineChatIntent.spec.ts
+++ b/extensions/copilot/src/extension/inlineChat2/test/node/inlineChatIntent.spec.ts
@@ -28,7 +28,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IExperimentationService } from '../../../../platform/telemetry/common/nullExperimentationService';
 import { IOTelService, SpanStatusCode } from '../../../../platform/otel/common/otelService';
 import { CapturingOTelService } from '../../../../platform/otel/common/test/capturingOTelService';
-import { CopilotChatAttr, GenAiAttr, GenAiOperationName } from '../../../../platform/otel/common/genAiAttributes';
+import { CopilotChatAttr, GenAiAttr, GenAiOperationName, GitHubCopilotAttr } from '../../../../platform/otel/common/genAiAttributes';
 import { PromptRenderer } from '../../../prompts/node/base/promptRenderer';
 import { ToolName } from '../../../tools/common/toolNames';
 
@@ -99,10 +99,6 @@ suite('InlineChatIntent', () => {
 			trace: vi.fn()
 		} as unknown as ILogService;
 
-		const mockToolsService = {
-			invokeTool: vi.fn()
-		} as unknown as IToolsService;
-
 		const mockIgnoreService = {
 			isCopilotIgnored: vi.fn().mockResolvedValue(false)
 		} as unknown as IIgnoreService;
@@ -123,7 +119,6 @@ suite('InlineChatIntent', () => {
 			mockEndpointProvider,
 			mockAuthService,
 			mockLogService,
-			mockToolsService,
 			mockIgnoreService,
 			mockEditSurvivalTrackerService,
 			mockOctoKitService
@@ -187,9 +182,38 @@ suite('InlineChatIntent', () => {
 					[CopilotChatAttr.SESSION_ID]: 'someId',
 					[CopilotChatAttr.USER_REQUEST]: 'test prompt',
 					[CopilotChatAttr.TURN_COUNT]: 1,
+					[GitHubCopilotAttr.AGENT_TYPE]: 'builtin',
 				})
 			})
 		]);
+	});
+
+	test('Bail-out exit tool is invoked inside the invoke_agent span', async () => {
+		const harness = createInlineChatHarness();
+
+		let invokeToolCalledWhileSpanActive = false;
+		(harness.mockToolsService.invokeTool as ReturnType<typeof vi.fn>).mockImplementation(async (name: string) => {
+			if (name === 'inline_chat_exit') {
+				const rootSpan = harness.otelService.spans.find(s => s.name === 'invoke_agent Inline Chat');
+				invokeToolCalledWhileSpanActive = rootSpan !== undefined && rootSpan.ended === false;
+			}
+			return undefined;
+		});
+
+		try {
+			await harness.run();
+		} finally {
+			harness.restore();
+		}
+
+		// Default harness response has no tool calls -> needsExitTool === true,
+		// so the bail-out invocation must run while the invoke_agent span is still active.
+		expect(harness.mockToolsService.invokeTool).toHaveBeenCalledWith(
+			'inline_chat_exit',
+			expect.anything(),
+			expect.anything()
+		);
+		expect(invokeToolCalledWhileSpanActive).toBe(true);
 	});
 
 	test('Inline tool loop aggregates tokens, tool rounds, and metrics across recovered tool failures', async () => {
@@ -448,7 +472,6 @@ function createInlineChatHarness(options: InlineChatHarnessOptions = {}) {
 			mockEndpointProvider,
 			mockAuthService,
 			mockLogService,
-			mockToolsService,
 			mockIgnoreService,
 			mockEditSurvivalTrackerService,
 			mockOctoKitService

--- a/extensions/copilot/src/extension/inlineChat2/test/node/inlineChatIntent.spec.ts
+++ b/extensions/copilot/src/extension/inlineChat2/test/node/inlineChatIntent.spec.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect, suite, test, vi } from 'vitest';
+import { expect, Mock, suite, test, vi } from 'vitest';
 import type * as vscode from 'vscode';
 import { InlineChatIntent } from '../../node/inlineChatIntent';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
@@ -21,6 +21,8 @@ import { ChatTelemetryBuilder } from '../../../prompt/node/chatParticipantTeleme
 import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
 import { ChatRequestEditorData } from '../../../../vscodeTypes';
 import { CopilotInteractiveEditorResponse } from '../../../inlineChat/node/promptCraftingTypes';
+import { IToolCall } from '../../../prompt/common/intents';
+import { ToolCallRound } from '../../../prompt/common/toolCallRound';
 import { TextDocumentSnapshot } from '../../../../platform/editing/common/textDocumentSnapshot';
 import { createTextDocumentData } from '../../../../util/common/test/shims/textDocument';
 import { URI } from '../../../../util/vs/base/common/uri';
@@ -30,6 +32,7 @@ import { IOTelService, SpanStatusCode } from '../../../../platform/otel/common/o
 import { CapturingOTelService } from '../../../../platform/otel/common/test/capturingOTelService';
 import { CopilotChatAttr, GenAiAttr, GenAiOperationName, GitHubCopilotAttr } from '../../../../platform/otel/common/genAiAttributes';
 import { PromptRenderer } from '../../../prompts/node/base/promptRenderer';
+import { BasePromptElementProps } from '@vscode/prompt-tsx';
 import { ToolName } from '../../../tools/common/toolNames';
 
 type TestToolCall = { id: string; name: string; arguments: string };
@@ -264,9 +267,12 @@ suite('InlineChatIntent', () => {
 		}
 
 		const rootSpan = harness.otelService.spans[0];
-		const rounds = harness.telemetry.sendToolCallingTelemetry.mock.calls[0][0].map(round => ({
+		const sendToolCallingTelemetryMock = harness.telemetry.sendToolCallingTelemetry as Mock;
+		const invokeToolWithEndpointMock = harness.mockToolsService.invokeToolWithEndpoint as unknown as Mock;
+		const recordedRounds = sendToolCallingTelemetryMock.mock.calls[0][0] as ToolCallRound[];
+		const rounds = recordedRounds.map(round => ({
 			response: round.response,
-			toolCalls: round.toolCalls.map(toolCall => ({ id: toolCall.id, name: toolCall.name })),
+			toolCalls: round.toolCalls.map((toolCall: IToolCall) => ({ id: toolCall.id, name: toolCall.name })),
 		}));
 
 		expect({
@@ -274,7 +280,7 @@ suite('InlineChatIntent', () => {
 				statusCode: rootSpan.statusCode,
 				attributes: rootSpan.attributes,
 			},
-			toolInvocations: harness.mockToolsService.invokeToolWithEndpoint.mock.calls.length,
+			toolInvocations: invokeToolWithEndpointMock.mock.calls.length,
 			rounds,
 			metrics: harness.otelService.metrics,
 		}).toEqual({
@@ -465,7 +471,7 @@ function createInlineChatHarness(options: InlineChatHarnessOptions = {}) {
 				tokenCount: 3,
 				references: []
 			})
-		} as unknown as PromptRenderer<unknown, unknown>);
+		} as unknown as PromptRenderer<BasePromptElementProps>);
 
 		const intent = new InlineChatIntent(
 			mockInstantiationService,


### PR DESCRIPTION
## Summary

Adds an ATIF-compatible root OTel invocation span for inline chat requests.

Inline chat previously emitted `chat` / `execute_tool` spans without the root `invoke_agent` span shape used by panel chat. ATIF converter starts from root `invoke_agent` spans, so inline-chat benchmark runs exported traces but produced no `trajectory.json`.

This change:
- wraps the inline chat tool loop in `invoke_agent Inline Chat`
- records agent-level metadata, status, token totals, response metadata, tool definitions, duration, and turn count
- adds a focused regression test for the inline root span
- updates the OTel monitoring docs to document inline chat's span hierarchy
