### PR TITLE
Fix insertSnippet() destroying active snippet session tabstops 

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadEditor.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditor.ts
@@ -545,24 +545,16 @@ export class MainThreadTextEditor {
 			clipboardText
 		};
 
-		if (ranges.length === 1) {
-			// When there is a single, contiguous snippet edit, route it through the string-based
-			// `insert` API instead of the array-based `apply` API. The `apply` path always cancels
-			// an active snippet session (see the `this.cancel()` guard in SnippetController2._doInsert),
-			// which destroys the outer snippet's remaining tabstops. The `insert` path instead merges
-			// (nests) the new snippet into the active placeholder, preserving the outer session.
-			// This restores the pre-1.86 behaviour and fixes microsoft/vscode#214757.
-			const range = Range.lift(ranges[0]);
-			this._codeEditor.setSelection(new Selection(range.startLineNumber, range.startColumn, range.endLineNumber, range.endColumn));
-			snippetController.insert(template, insertOptions);
-			return true;
+		if (ranges.length > 0) {
+			const selections = ranges.map(r => {
+				const range = Range.lift(r);
+				return new Selection(range.startLineNumber, range.startColumn, range.endLineNumber, range.endColumn);
+			});
+			this._codeEditor.setSelections(selections);
 		}
 
-		// Multi-range edits cannot be merged into a single active placeholder, so fall back to the
-		// array-based `apply` API.
-		const edits: ISnippetEdit[] = ranges.map(range => ({ range: Range.lift(range), template }));
-		snippetController.apply(edits, insertOptions);
-
+		// Route through the string-based `insert` API so an active snippet session can merge (nest) the new snippet.
+		snippetController.insert(template, insertOptions);
 		return true;
 	}
 }

--- a/src/vs/workbench/api/browser/mainThreadEditor.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditor.ts
@@ -538,14 +538,30 @@ export class MainThreadTextEditor {
 
 		this._codeEditor.focus();
 
-		// make modifications as snippet edit
-		const edits: ISnippetEdit[] = ranges.map(range => ({ range: Range.lift(range), template }));
-		snippetController.apply(edits, {
+		const insertOptions = {
 			overwriteBefore: 0, overwriteAfter: 0,
 			undoStopBefore: opts.undoStopBefore, undoStopAfter: opts.undoStopAfter,
 			adjustWhitespace: !opts.keepWhitespace,
 			clipboardText
-		});
+		};
+
+		if (ranges.length === 1) {
+			// When there is a single, contiguous snippet edit, route it through the string-based
+			// `insert` API instead of the array-based `apply` API. The `apply` path always cancels
+			// an active snippet session (see the `this.cancel()` guard in SnippetController2._doInsert),
+			// which destroys the outer snippet's remaining tabstops. The `insert` path instead merges
+			// (nests) the new snippet into the active placeholder, preserving the outer session.
+			// This restores the pre-1.86 behaviour and fixes microsoft/vscode#214757.
+			const range = Range.lift(ranges[0]);
+			this._codeEditor.setSelection(new Selection(range.startLineNumber, range.startColumn, range.endLineNumber, range.endColumn));
+			snippetController.insert(template, insertOptions);
+			return true;
+		}
+
+		// Multi-range edits cannot be merged into a single active placeholder, so fall back to the
+		// array-based `apply` API.
+		const edits: ISnippetEdit[] = ranges.map(range => ({ range: Range.lift(range), template }));
+		snippetController.apply(edits, insertOptions);
 
 		return true;
 	}


### PR DESCRIPTION
## Problem

Related: #322010

Since VS Code 1.86, calling `editor.insertSnippet()` from an extension while a snippet session is active destroys the outer session's remaining tabstops. This is a regression — it worked correctly in 1.85.2 and earlier.

This breaks extensions like HyperSnips, LTeX, and others that programmatically insert snippets, making nested snippet expansion unusable.

## Root cause

In 1.86, `mainThreadEditor.ts` was refactored to route `insertSnippet()` calls through `snippetController.apply(edits[])` instead of `snippetController.insert(template)`. The `apply()` path calls `this.cancel()` when a session is active:

```typescript
if (this._session && typeof template !== 'string') {
    this.cancel();
}
```

The `insert()` path instead calls `this._session.merge(template, opts)`, which properly nests the new snippet inside the active placeholder. The merge infrastructure (`OneSnippet.merge()`, `_nestingLevel`, `_renormalizePlaceholderIndices()`) is fully implemented and works — the regression was the API bridge switching code paths.

## Fix

Route single-edit `insertSnippet()` calls back through `snippetController.insert()` (the merge path), falling back to `apply()` only for multi-range edits.

## Note on issue #214757

This bug was reported in #214757, which was closed as a duplicate of #63129. However, #63129 is about snippet auto-indentation (fixed in #234858), not tabstop destruction — they are unrelated issues. The bug remains present through current versions.

Fixes #214757

## Test

1. Install [HyperSnips](https://marketplace.visualstudio.com/items?itemName=draivin.hsnips) or any extension that calls `editor.insertSnippet()` during editing
2. Trigger a snippet with multiple tabstops (e.g. `\int_{$1}^{$2} $3 d$4`)
3. While cursor is at `$1`, trigger another snippet insertion via the extension
4. Press Tab — cursor should advance to `$2` (currently it doesn't; the session is destroyed)

---

This fix was researched and developed with the assistance of [Claude Code](https://claude.ai/claude-code) (Claude Opus 4.6).
