### PR TITLE
PR polling improvements

### DIFF
--- a/src/vs/sessions/contrib/github/browser/github.contribution.ts
+++ b/src/vs/sessions/contrib/github/browser/github.contribution.ts
@@ -21,7 +21,7 @@ export class GitHubPullRequestPollingContribution extends Disposable implements 
 	static readonly ID = 'sessions.contrib.githubPullRequestPolling';
 
 	/** Per-session pollers, keyed by `session.sessionId`. */
-	private readonly _sessionTrackers = new DisposableMap<string>();
+	private readonly _sessionTrackers = this._register(new DisposableMap<string>());
 
 	constructor(
 		@IGitHubService private readonly _gitHubService: IGitHubService,
@@ -200,12 +200,6 @@ export class GitHubPullRequestPollingContribution extends Disposable implements 
 		}
 
 		return isEqual(activeSession.resource, session.resource);
-	}
-
-	override dispose(): void {
-		this._sessionTrackers.dispose();
-
-		super.dispose();
 	}
 }
 

--- a/src/vs/sessions/contrib/github/browser/github.contribution.ts
+++ b/src/vs/sessions/contrib/github/browser/github.contribution.ts
@@ -3,8 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
-import { autorun, derivedOpts } from '../../../../base/common/observable.js';
+import { Disposable, DisposableMap, IDisposable } from '../../../../base/common/lifecycle.js';
+import { autorun, derived, derivedOpts, IReader } from '../../../../base/common/observable.js';
+import { structuralEquals } from '../../../../base/common/equals.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
@@ -12,7 +13,6 @@ import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase 
 import { ISession } from '../../../services/sessions/common/session.js';
 import { ISessionsChangeEvent, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
-import { getPullRequestKey } from '../common/utils.js';
 import { GitHubPullRequestState } from '../common/types.js';
 import { GitHubService, IGitHubService } from './githubService.js';
 
@@ -20,7 +20,8 @@ export class GitHubPullRequestPollingContribution extends Disposable implements 
 
 	static readonly ID = 'sessions.contrib.githubPullRequestPolling';
 
-	private readonly _pullRequests = new DisposableMap<string>();
+	/** Per-session pollers, keyed by `session.sessionId`. */
+	private readonly _sessionTrackers = new DisposableMap<string>();
 
 	constructor(
 		@IGitHubService private readonly _gitHubService: IGitHubService,
@@ -86,83 +87,123 @@ export class GitHubPullRequestPollingContribution extends Disposable implements 
 	}
 
 	private _onDidChangeSessions(e: ISessionsChangeEvent): void {
-		// Added sessions
+		// Track added and changed sessions. Archived state and async PR-number
+		// resolution are handled reactively inside the per-session poller, so we
+		// can track unconditionally here (the tracker is a no-op until a PR
+		// number actually resolves).
 		for (const session of e.added) {
-			// Archived
-			if (session.isArchived.get()) {
-				continue;
-			}
-
-			this._startPolling(session);
+			this._trackSession(session);
 		}
 
-		// Changes sessions
 		for (const session of e.changed) {
-			// Archived
-			if (session.isArchived.get()) {
-				this._disposePolling(session);
-				continue;
-			}
-
-			this._startPolling(session);
+			this._trackSession(session);
 		}
 
 		// Removed sessions
 		for (const session of e.removed) {
-			this._disposePolling(session);
+			this._sessionTrackers.deleteAndDispose(session.sessionId);
 		}
 	}
 
-	private _startPolling(session: ISession): void {
-		const gitHubInfo = session.workspace.get()?.folders[0]?.gitRepository?.gitHubInfo.get();
-		if (!gitHubInfo || !gitHubInfo.pullRequest) {
+	private _trackSession(session: ISession): void {
+		if (this._sessionTrackers.has(session.sessionId)) {
 			return;
 		}
 
-		const key = getPullRequestKey(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number);
-		if (this._pullRequests.has(key)) {
-			return;
-		}
+		this._sessionTrackers.set(session.sessionId, this._createSessionPoller(session));
+	}
 
-		const disposables = new DisposableStore();
-		const modelRef = this._gitHubService.createPullRequestModelReference(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number);
+	/**
+	 * Reactively poll the pull request for a single session.
+	 *
+	 * Unlike a one-shot snapshot, the returned autorun re-runs when the session's
+	 * pull-request identity changes — so polling starts once a provider resolves
+	 * the PR number asynchronously (e.g. the agent host), and stops when the
+	 * session is archived or the PR goes away. A merged pull request can never
+	 * change again, so it stops polling unless it is the active session.
+	 */
+	private _createSessionPoller(session: ISession): IDisposable {
+		// PR identity (owner/repo/number) only. Structural equality keeps this
+		// stable while the PR's live data — and therefore its computed icon —
+		// updates, so the poller doesn't churn (or feed back into itself) every
+		// time `gitHubInfo` re-derives.
+		const pullRequestIdentityObs = derivedOpts<{ readonly owner: string; readonly repo: string; readonly prNumber: number } | undefined>(
+			{ owner: this, equalsFn: structuralEquals },
+			reader => {
+				if (session.isArchived.read(reader)) {
+					return undefined;
+				}
 
-		disposables.add(modelRef);
-		disposables.add(modelRef.object.startPolling());
+				const gitHubInfo = session.workspace.read(reader)?.folders[0]?.gitRepository?.gitHubInfo.read(reader);
+				if (!gitHubInfo?.pullRequest) {
+					return undefined;
+				}
 
-		// Poll CI checks and review threads so the session's PR icon can reflect
-		// failing checks / unresolved comments even when the session is not active.
-		const prNumber = gitHubInfo.pullRequest.number;
-		disposables.add(autorun(reader => {
-			const prDetails = modelRef.object.pullRequest.read(reader);
-			if (!prDetails || prDetails.isDraft || prDetails.state !== GitHubPullRequestState.Open) {
+				return { owner: gitHubInfo.owner, repo: gitHubInfo.repo, prNumber: gitHubInfo.pullRequest.number };
+			});
+
+		return autorun(reader => {
+			const identity = pullRequestIdentityObs.read(reader);
+			if (!identity) {
+				// No PR number yet (or archived); this autorun re-runs once it resolves.
 				return;
 			}
 
-			const ciModelRef = reader.store.add(this._gitHubService.createPullRequestCIModelReference(gitHubInfo.owner, gitHubInfo.repo, prNumber, prDetails.headSha));
-			ciModelRef.object.refresh();
-			reader.store.add(ciModelRef.object.startPolling());
+			const { owner, repo, prNumber } = identity;
 
-			const reviewThreadsModelRef = reader.store.add(this._gitHubService.createPullRequestReviewThreadsModelReference(gitHubInfo.owner, gitHubInfo.repo, prNumber));
-			reviewThreadsModelRef.object.refresh();
-			reader.store.add(reviewThreadsModelRef.object.startPolling());
-		}));
+			const modelRef = reader.store.add(this._gitHubService.createPullRequestModelReference(owner, repo, prNumber));
+			const model = modelRef.object;
 
-		this._pullRequests.set(key, disposables);
+			// Fetch once so we learn the PR state and can render the icon — even for
+			// a merged PR that won't keep polling.
+			model.refresh();
+
+			// Gate the repeating poll loop on a stable boolean so poll results (which
+			// update `pullRequest`) don't toggle the loop on every refresh.
+			const shouldPollObs = derived(this, pollReader => {
+				const prDetails = model.pullRequest.read(pollReader);
+				const isMerged = prDetails?.state === GitHubPullRequestState.Merged;
+				return !isMerged || this._isActiveSession(session, pollReader);
+			});
+			reader.store.add(autorun(pollReader => {
+				if (!shouldPollObs.read(pollReader)) {
+					return;
+				}
+
+				pollReader.store.add(model.startPolling());
+			}));
+
+			// Poll CI checks and review threads so the session's PR icon can reflect
+			// failing checks / unresolved comments even when the session is not active.
+			// Only open, non-draft PRs need this (merged/closed/draft don't surface it).
+			reader.store.add(autorun(statusReader => {
+				const prDetails = model.pullRequest.read(statusReader);
+				if (!prDetails || prDetails.isDraft || prDetails.state !== GitHubPullRequestState.Open) {
+					return;
+				}
+
+				const ciModelRef = statusReader.store.add(this._gitHubService.createPullRequestCIModelReference(owner, repo, prNumber, prDetails.headSha));
+				ciModelRef.object.refresh();
+				statusReader.store.add(ciModelRef.object.startPolling());
+
+				const reviewThreadsModelRef = statusReader.store.add(this._gitHubService.createPullRequestReviewThreadsModelReference(owner, repo, prNumber));
+				reviewThreadsModelRef.object.refresh();
+				statusReader.store.add(reviewThreadsModelRef.object.startPolling());
+			}));
+		});
 	}
 
-	private _disposePolling(session: ISession): void {
-		const gitHubInfo = session.workspace.get()?.folders[0]?.gitRepository?.gitHubInfo.get();
-		if (!gitHubInfo || !gitHubInfo.pullRequest) {
-			return;
+	private _isActiveSession(session: ISession, reader: IReader): boolean {
+		const activeSession = this._sessionsService.activeSession.read(reader);
+		if (!activeSession || activeSession.isArchived.read(reader)) {
+			return false;
 		}
 
-		const key = getPullRequestKey(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number);
-		this._pullRequests.deleteAndDispose(key);
+		return isEqual(activeSession.resource, session.resource);
 	}
 
 	override dispose(): void {
-		this._pullRequests.dispose();
+		this._sessionTrackers.dispose();
 
 		super.dispose();
 	}

--- a/src/vs/sessions/contrib/github/test/browser/githubContribution.test.ts
+++ b/src/vs/sessions/contrib/github/test/browser/githubContribution.test.ts
@@ -8,7 +8,7 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
 import { DisposableStore, IDisposable, ImmortalReference, IReference, toDisposable } from '../../../../../base/common/lifecycle.js';
-import { constObservable, IObservable, observableValue } from '../../../../../base/common/observable.js';
+import { constObservable, IObservable, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
 import { GitHubPullRequestModel } from '../../browser/models/githubPullRequestModel.js';
 import { GitHubPullRequestCIModel } from '../../browser/models/githubPullRequestCIModel.js';
 import { GitHubPullRequestReviewThreadsModel } from '../../browser/models/githubPullRequestReviewThreadsModel.js';
@@ -28,11 +28,13 @@ suite('GitHubPullRequestPollingContribution', () => {
 	let sessionsManagementService: TestSessionsManagementService;
 	let sessionsService: ISessionsService;
 	let gitHubService: TestGitHubService;
+	let activeSession: ISettableObservable<IActiveSession | undefined>;
 
 	setup(() => {
 		sessionsManagementService = new TestSessionsManagementService(store);
+		activeSession = observableValue<IActiveSession | undefined>('test.activeSession', undefined);
 		sessionsService = new class extends mock<ISessionsService>() {
-			override readonly activeSession = constObservable<IActiveSession | undefined>(undefined);
+			override readonly activeSession = activeSession;
 		};
 		gitHubService = new TestGitHubService();
 	});
@@ -123,6 +125,47 @@ suite('GitHubPullRequestPollingContribution', () => {
 		gitHubService.setPullRequestDetails('owner', 'repo', 1, { state: GitHubPullRequestState.Open, isDraft: true, headSha: 'sha1' });
 
 		assert.deepStrictEqual(gitHubService.statusModelSnapshot(), { ci: {}, reviewThreads: {} });
+	});
+
+	test('starts polling once an asynchronously resolved PR number appears', () => {
+		// Mirrors the agent-host provider, whose `gitHubInfo` initially has no PR
+		// number (it is resolved asynchronously via findPullRequestNumberByHeadBranch).
+		const session = sessionsManagementService.addSession('async', { owner: 'owner', repo: 'repo' });
+		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService));
+
+		// No PR number yet → nothing is polled.
+		assert.deepStrictEqual(gitHubService.snapshot(), {});
+
+		// The PR number resolves later.
+		sessionsManagementService.setGitHubInfo(session, makeGitHubInfo(1));
+
+		assert.deepStrictEqual(gitHubService.snapshot(), {
+			'owner/repo/1': { startPollingCalls: 1, stopPollingCalls: 0, disposeCalls: 0 },
+		});
+	});
+
+	test('stops polling a merged pull request unless it is the active session', () => {
+		const session = sessionsManagementService.addSession('session', makeGitHubInfo(1));
+		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService));
+
+		// Open PR → polling.
+		gitHubService.setPullRequestDetails('owner', 'repo', 1, { state: GitHubPullRequestState.Open, isDraft: false, headSha: 'sha1' });
+		assert.deepStrictEqual(gitHubService.snapshot(), {
+			'owner/repo/1': { startPollingCalls: 1, stopPollingCalls: 0, disposeCalls: 0 },
+		});
+
+		// Merges while not the active session → the repeating poll loop stops (the
+		// single initial fetch already produced the merged icon).
+		gitHubService.setPullRequestDetails('owner', 'repo', 1, { state: GitHubPullRequestState.Merged, isDraft: false, headSha: 'sha1' });
+		assert.deepStrictEqual(gitHubService.snapshot(), {
+			'owner/repo/1': { startPollingCalls: 1, stopPollingCalls: 1, disposeCalls: 0 },
+		});
+
+		// Becomes the active session → polling resumes even though it is merged.
+		activeSession.set(session as unknown as IActiveSession, undefined);
+		assert.deepStrictEqual(gitHubService.snapshot(), {
+			'owner/repo/1': { startPollingCalls: 2, stopPollingCalls: 1, disposeCalls: 0 },
+		});
 	});
 });
 


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce improvements to the polling mechanism for GitHub pull requests, including starting polling when a PR number is resolved asynchronously and stopping polling for merged PRs unless they are the active session.

