### PR TITLE
Limit Copilot CLI startup session listing

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
@@ -664,11 +664,12 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 	async getAllSessions(token: CancellationToken, options?: IListCopilotCLISessionsOptions): Promise<readonly ICopilotCLISessionItem[]> {
 		const key = `${options?.metadataLimit ?? 'all'}:${options?.resolveLabels ?? true}`;
 		if (!this._getAllSessionsProgress.has(key)) {
-			this._getAllSessionsProgress.set(key, this._getAllSessions(token, options));
+			this._getAllSessionsProgress.set(key, this._getAllSessions(CancellationToken.None, options));
 		}
-		return this._getAllSessionsProgress.get(key)!.finally(() => {
+		const promise = this._getAllSessionsProgress.get(key)!.finally(() => {
 			this._getAllSessionsProgress.delete(key);
 		});
+		return raceCancellationError(promise, token);
 	}
 
 	private _sessionLabels: Map<string, string> = new Map();
@@ -731,7 +732,7 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 					const id = metadata.sessionId;
 					const startTime = metadata.startTime.getTime();
 					const endTime = metadata.modifiedTime.getTime();
-					const label = resolveLabels ? await this.getSessionTitleImpl(metadata.sessionId, metadata, token) : 'Copilot CLI Session';
+					const label = resolveLabels ? await this.getSessionTitleImpl(metadata.sessionId, metadata, token) : l10n.t('Copilot CLI Session');
 					if (!label) {
 						return;
 					}

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
@@ -253,6 +253,10 @@ export interface ICopilotCLISessionItem {
 	readonly status?: ChatSessionStatus;
 	readonly workingDirectory?: Uri;
 }
+export interface IListCopilotCLISessionsOptions {
+	readonly metadataLimit?: number;
+	readonly resolveLabels?: boolean;
+}
 export type ExtendedChatRequest = ChatRequest & { prompt: string };
 export type ISessionOptions = {
 	model?: string;
@@ -284,7 +288,7 @@ export interface ICopilotCLISessionService {
 	// Session metadata querying
 	getSessionItem(sessionId: string, token: CancellationToken): Promise<ICopilotCLISessionItem | undefined>;
 	getSessionTitle(sessionId: string, token: CancellationToken): Promise<string>;
-	getAllSessions(token: CancellationToken): Promise<readonly ICopilotCLISessionItem[]>;
+	getAllSessions(token: CancellationToken, options?: IListCopilotCLISessionsOptions): Promise<readonly ICopilotCLISessionItem[]>;
 
 	// SDK session management
 	createNewSessionId(): string;
@@ -655,14 +659,15 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 	}
 
 
-	private _getAllSessionsProgress: Promise<readonly ICopilotCLISessionItem[]> | undefined;
+	private _getAllSessionsProgress = new Map<string, Promise<readonly ICopilotCLISessionItem[]>>();
 	private _isGettingSessions: number = 0;
-	async getAllSessions(token: CancellationToken): Promise<readonly ICopilotCLISessionItem[]> {
-		if (!this._getAllSessionsProgress) {
-			this._getAllSessionsProgress = this._getAllSessions(token);
+	async getAllSessions(token: CancellationToken, options?: IListCopilotCLISessionsOptions): Promise<readonly ICopilotCLISessionItem[]> {
+		const key = `${options?.metadataLimit ?? 'all'}:${options?.resolveLabels ?? true}`;
+		if (!this._getAllSessionsProgress.has(key)) {
+			this._getAllSessionsProgress.set(key, this._getAllSessions(token, options));
 		}
-		return this._getAllSessionsProgress.finally(() => {
-			this._getAllSessionsProgress = undefined;
+		return this._getAllSessionsProgress.get(key)!.finally(() => {
+			this._getAllSessionsProgress.delete(key);
 		});
 	}
 
@@ -697,11 +702,15 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 		return this.fileSystem.stat(dbPath).then(() => true, () => false);
 	}
 
-	async _getAllSessions(token: CancellationToken): Promise<readonly ICopilotCLISessionItem[]> {
+	async _getAllSessions(token: CancellationToken, options?: IListCopilotCLISessionsOptions): Promise<readonly ICopilotCLISessionItem[]> {
 		this._isGettingSessions++;
 		try {
 			const sessionManager = await raceCancellationError(this.getSessionManager(), token);
-			const sessionMetadataList = await raceCancellationError(sessionManager.listSessions(), token);
+			const { metadataLimit, resolveLabels = true } = options ?? {};
+			const sessionMetadataList = await raceCancellationError(
+				metadataLimit !== undefined ? sessionManager.listSessions({ metadataLimit }) : sessionManager.listSessions(),
+				token
+			);
 
 			await this._sessionTracker.initialize();
 
@@ -722,7 +731,7 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 					const id = metadata.sessionId;
 					const startTime = metadata.startTime.getTime();
 					const endTime = metadata.modifiedTime.getTime();
-					const label = await this.getSessionTitleImpl(metadata.sessionId, metadata, token);
+					const label = resolveLabels ? await this.getSessionTitleImpl(metadata.sessionId, metadata, token) : 'Copilot CLI Session';
 					if (!label) {
 						return;
 					}

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliSessionService.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliSessionService.spec.ts
@@ -707,6 +707,28 @@ describe('CopilotCLISessionService', () => {
 			expect(item.id).toBe('s1');
 		});
 
+		it('passes metadata limit to the SDK session manager', async () => {
+			const listSessionsSpy = vi.spyOn(manager, 'listSessions');
+
+			await service.getAllSessions(CancellationToken.None, { metadataLimit: 20 });
+
+			expect(listSessionsSpy).toHaveBeenCalledWith({ metadataLimit: 20 });
+		});
+
+		it('does not load full sessions when label resolution is disabled', async () => {
+			const s1 = new MockCliSdkSession('s1', new Date(0));
+			s1.summary = 'Fix the startup stall';
+			manager.sessions.set(s1.sessionId, s1);
+			const getSessionSpy = vi.spyOn(manager, 'getSession');
+
+			const sessions = await service.getAllSessions(CancellationToken.None, { metadataLimit: 20, resolveLabels: false });
+
+			expect(sessions).toHaveLength(1);
+			expect(sessions[0].id).toBe('s1');
+			expect(sessions[0].label).toBe('Copilot CLI Session');
+			expect(getSessionSpy).not.toHaveBeenCalled();
+		});
+
 		it('falls back to partial session data when getSession fails with an unknown event type', async () => {
 			tempStateHome = await mkdtemp(join(tmpdir(), 'copilot-cli-session-service-'));
 			process.env.XDG_STATE_HOME = tempStateHome;

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/testHelpers.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/testHelpers.ts
@@ -89,7 +89,7 @@ export class MockCliSdkSessionManager {
 		}
 		return Promise.resolve(undefined);
 	}
-	listSessions() {
+	listSessions(_options?: { metadataLimit?: number }) {
 		return Promise.resolve(Array.from(this.sessions.values()).map(s => ({ sessionId: s.sessionId, startTime: s.startTime, modifiedTime: s.startTime, summary: s.summary, name: s.name })));
 	}
 	getSessionMetadata({ sessionId }: { sessionId: string }) {

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts
@@ -65,6 +65,7 @@ export interface ICopilotCLIChatSessionItemProvider extends IDisposable {
 
 const OPEN_IN_COPILOT_CLI_COMMAND_ID = 'github.copilot.cli.openInCopilotCLI';
 const CHECK_FOR_STEERING_DELAY = 100; // ms
+const INITIAL_SESSION_METADATA_LIMIT = 20;
 
 const _invalidCopilotCLISessionIdsWithErrorMessage = new Map<string, string>();
 
@@ -164,7 +165,7 @@ export class CopilotCLIChatSessionContentProvider extends Disposable implements 
 			const stopwatch = new StopWatch();
 			void this._metadataStore.refresh().catch(error => this.logService.error(error, 'Failed to refresh session metadata store during session list refresh'));
 			try {
-				const sessions = await this.sessionService.getAllSessions(CancellationToken.None);
+				const sessions = await this.sessionService.getAllSessions(CancellationToken.None, { metadataLimit: INITIAL_SESSION_METADATA_LIMIT, resolveLabels: false });
 				const items = await Promise.all(sessions.map(async session => this.toChatSessionItem(session)));
 
 				const count = items.length;

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
@@ -74,6 +74,7 @@ const OPEN_REPOSITORY_COMMAND_ID = 'github.copilot.cli.sessions.openRepository';
 const OPEN_IN_COPILOT_CLI_COMMAND_ID = 'github.copilot.cli.openInCopilotCLI';
 const MAX_MRU_ENTRIES = 10;
 const CHECK_FOR_STEERING_DELAY = 100; // ms
+const INITIAL_SESSION_METADATA_LIMIT = 20;
 
 // When we start new sessions, we don't have the real session id, we have a temporary untitled id.
 // We also need this when we open a session and later run it.
@@ -273,7 +274,7 @@ export class CopilotCLIChatSessionItemProvider extends Disposable implements vsc
 
 	public async provideChatSessionItems(token: vscode.CancellationToken): Promise<vscode.ChatSessionItem[]> {
 		const stopwatch = new StopWatch();
-		const sessions = await this.copilotcliSessionService.getAllSessions(token);
+		const sessions = await this.copilotcliSessionService.getAllSessions(token, { metadataLimit: INITIAL_SESSION_METADATA_LIMIT, resolveLabels: false });
 		// Drain the pending set: sessions that were explicitly refreshed get `changes` populated
 		// eagerly so the visible row reflects the latest diff info on this re-provide pass.
 		const pendingIds = new Set(this.pendingChangeIncludeIds);

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessions.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/test/copilotCLIChatSessions.spec.ts
@@ -35,26 +35,33 @@ import { ICopilotCLISessionItem, ICopilotCLISessionService } from '../../copilot
 import { ICopilotCLIChatSessionInitializer } from '../../copilotcli/vscode-node/copilotCLIChatSessionInitializer';
 import { ICopilotCLISessionTracker } from '../../copilotcli/vscode-node/copilotCLISessionTracker';
 import { CopilotCLIChatSessionContentProvider, CopilotCLIChatSessionParticipant, resolveBranchLockState, resolveBranchSelection, resolveIsolationSelection, resolveSessionDirsForTerminal } from '../copilotCLIChatSessions';
+import { CopilotCLIChatSessionItemProvider } from '../copilotCLIChatSessionsContribution';
+import { ICopilotCLITerminalIntegration } from '../copilotCLITerminalIntegration';
 import { PullRequestDetectionService } from '../pullRequestDetectionService';
 import { ISessionOptionGroupBuilder } from '../sessionOptionGroupBuilder';
 import { ISessionRequestLifecycle } from '../sessionRequestLifecycle';
 vi.mock('../copilotCLIShim.ps1', () => ({ default: '# mock powershell script' }));
 
+const chatSessionRefreshHandlers: (() => Promise<void>)[] = [];
+
 beforeAll(() => {
 	(vscodeShim as Record<string, unknown>).chat = {
-		createChatSessionItemController: () => ({
-			id: 'copilotcli',
-			items: {
-				get: () => undefined,
-				add: () => { },
-				delete: () => { },
-				replace: () => { },
-				[Symbol.iterator]: function* () { },
-				forEach: () => { },
-			},
-			createChatSessionItem: (resource: vscode.Uri, label: string): vscode.ChatSessionItem => ({ resource, label }),
-			dispose: () => { },
-		}),
+		createChatSessionItemController: (_id: string, refreshHandler: () => Promise<void>) => {
+			chatSessionRefreshHandlers.push(refreshHandler);
+			return {
+				id: 'copilotcli',
+				items: {
+					get: () => undefined,
+					add: () => { },
+					delete: () => { },
+					replace: () => { },
+					[Symbol.iterator]: function* () { },
+					forEach: () => { },
+				},
+				createChatSessionItem: (resource: vscode.Uri, label: string): vscode.ChatSessionItem => ({ resource, label }),
+				dispose: () => { },
+			};
+		},
 	};
 	(vscodeShim as Record<string, unknown>).workspace = {
 		...((vscodeShim as Record<string, unknown>).workspace as object),
@@ -72,7 +79,7 @@ class TestSessionService extends mock<ICopilotCLISessionService>() {
 	override onDidCreateSession = Event.None;
 	override getSessionWorkingDirectory = vi.fn(() => undefined);
 	override getSessionItem = vi.fn(async () => undefined);
-	override getAllSessions = vi.fn(async () => [] as ICopilotCLISessionItem[]);
+	override getAllSessions = vi.fn(async (_token, _options?: { metadataLimit?: number; resolveLabels?: boolean }) => [] as ICopilotCLISessionItem[]);
 	override createNewSessionId = vi.fn(() => 'new-session');
 	override isNewSessionId = vi.fn((_sessionId: string) => false);
 	override deleteSession = vi.fn(async () => { });
@@ -157,6 +164,18 @@ class TestRunCommandExecutionService extends mock<IRunCommandExecutionService>()
 	override executeCommand = vi.fn(async () => undefined);
 }
 
+class TestTerminalIntegration extends mock<ICopilotCLITerminalIntegration>() {
+	declare readonly _serviceBrand: undefined;
+	override setSessionDirResolver = vi.fn();
+	override dispose = vi.fn();
+}
+
+class TestSessionTracker extends mock<ICopilotCLISessionTracker>() {
+	declare readonly _serviceBrand: undefined;
+	override getSessionIds = vi.fn(() => []);
+	override getTerminal = vi.fn(async () => undefined);
+}
+
 class TestCustomSessionTitleService extends mock<ICustomSessionTitleService>() {
 	declare readonly _serviceBrand: undefined;
 	override getCustomSessionTitle = vi.fn(async () => 'Session Title');
@@ -219,9 +238,24 @@ function createProvider() {
 		new NullWorkspaceService(),
 		worktreeService,
 	);
+	const itemProvider = new CopilotCLIChatSessionItemProvider(
+		sessionService,
+		new TestSessionTracker(),
+		new TestTerminalIntegration(),
+		metadataStore,
+		worktreeService,
+		commandExecutionService,
+		workspaceFolderService,
+		folderRepositoryManager,
+		gitService,
+		octoKitService,
+		logService,
+		configurationService,
+	);
 
 	return {
 		provider,
+		itemProvider,
 		prDetectionService,
 		sessionService,
 		worktreeService,
@@ -233,6 +267,23 @@ function createProvider() {
 describe('CopilotCLIChatSessionContentProvider', () => {
 	beforeEach(() => {
 		vi.restoreAllMocks();
+		chatSessionRefreshHandlers.length = 0;
+	});
+
+	it('bounds the initial session item refresh', async () => {
+		const { sessionService } = createProvider();
+
+		await chatSessionRefreshHandlers[0]();
+
+		expect(sessionService.getAllSessions).toHaveBeenCalledWith(CancellationToken.None, { metadataLimit: 20, resolveLabels: false });
+	});
+
+	it('bounds the legacy session item provider refresh', async () => {
+		const { itemProvider, sessionService } = createProvider();
+
+		await itemProvider.provideChatSessionItems(CancellationToken.None);
+
+		expect(sessionService.getAllSessions).toHaveBeenCalledWith(CancellationToken.None, { metadataLimit: 20, resolveLabels: false });
 	});
 
 	it('triggers pull request detection when opening an existing session', async () => {


### PR DESCRIPTION
Related to microsoft/vscode#319710 and microsoft/vscode#321901.

This limits the initial Copilot CLI session list refresh to a bounded metadata request and skips eager label resolution for that startup list. The full session title path remains available for explicit session resolution, while startup no longer needs to load full session histories for every persisted CLI session.

Validation run in the standalone Copilot Chat checkout before porting this minimal diff into vscode:
- npm exec -- vitest --run --pool=forks src/extension/chatSessions/vscode-node/test/copilotCLIChatSessionParticipant.spec.ts src/extension/chatSessions/vscode-node/test/copilotCLIChatSessions.spec.ts src/extension/chatSessions/copilotcli/node/test/copilotCliSessionService.spec.ts
- npm run typecheck -- --pretty false
- npm run lint -- --max-warnings=0 on the touched Copilot Chat files
- git diff --check
- npm run compile

The vscode fork checkout used for this PR is sparse and only contains the touched extensions/copilot paths, so I did not rerun the full vscode repository test suite there. Account-backed E2E for an existing Copilot CLI session store is also not included in this draft.