### PR TITLE
Override getReport with a function returning undefined

### DIFF
--- a/extensions/copilot/src/extension/extension/vscode-node/disableProcessReport.ts
+++ b/extensions/copilot/src/extension/extension/vscode-node/disableProcessReport.ts
@@ -6,7 +6,7 @@
 if (process.report) {
 	try {
 		Object.defineProperty(process.report, 'getReport', {
-			value: undefined,
+			value: () => undefined,
 			writable: true,
 			configurable: true,
 			enumerable: true


### PR DESCRIPTION
Changes the `disableProcessReport` override so that `process.report.getReport` is set to a function that returns `undefined`, instead of being set to the value `undefined`. `getReport` is normally a callable, so consumers calling `process.report.getReport()` would throw if it were `undefined`.

(Written by Copilot)

Towards fixing https://github.com/microsoft/vscode/issues/321901