### PR TITLE
chat: fix tool call confirmation message rendering

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -424,7 +424,7 @@ function truncate(text: string, maxLength: number): string {
  */
 function formatPathAsMarkdownLink(path: string): string {
 	const uri = URI.file(path);
-	return `[${basename(uri)}](${uri})`;
+	return `[${escapeMarkdownLinkLabel(basename(uri))}](${uri})`;
 }
 
 function formatUrlAsMarkdownLink(url: string): string {
@@ -1036,9 +1036,8 @@ export function getPermissionDisplay(request: ITypedPermissionRequest, workingDi
 		}
 		case 'read':
 			return {
-				confirmationTitle: localize('copilot.permission.read.title', "Read file?"),
-				invocationMessage: intention ?? getInvocationMessage(CopilotToolName.View, getToolDisplayName(CopilotToolName.View), path ? { path } : undefined),
-				toolInput: tryStringify(path ? { path, intention } : request) ?? undefined,
+				confirmationTitle: localize('copilot.permission.read.title', "Allow reading file outside of workspace?"),
+				invocationMessage: getInvocationMessage(CopilotToolName.View, getToolDisplayName(CopilotToolName.View), path ? { path } : undefined),
 				permissionKind: 'read',
 				permissionPath: path,
 			};

--- a/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
@@ -164,6 +164,32 @@ suite('getPermissionDisplay — cd-prefix stripping', () => {
 		const display = getPermissionDisplay(request, wd);
 		assert.strictEqual(display.toolInput, 'dir');
 	});
+
+});
+
+suite('getPermissionDisplay — read permission display', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('uses the view-tool invocation message for read permissions', () => {
+		const display = getPermissionDisplay({
+			kind: 'read',
+			path: '/Users/connor/Downloads/context7-copilot-debug-main.json',
+			intention: 'Read file: /Users/connor/Downloads/context7-copilot-debug-main.json',
+		} as ITypedPermissionRequest, URI.file('/repo/project'));
+
+		assert.deepStrictEqual({
+			invocationMessage: display.invocationMessage,
+			toolInput: display.toolInput,
+			permissionKind: display.permissionKind,
+			permissionPath: display.permissionPath,
+		}, {
+			invocationMessage: { markdown: 'Reading [context7-copilot-debug-main.json](file:///Users/connor/Downloads/context7-copilot-debug-main.json)' },
+			toolInput: undefined,
+			permissionKind: 'read',
+			permissionPath: '/Users/connor/Downloads/context7-copilot-debug-main.json',
+		});
+	});
 });
 
 suite('view tool — view_range display', () => {

--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -532,5 +532,5 @@ const _allApiProposals = {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.workspaceTrust.d.ts',
 	}
 };
-export const allApiProposals = Object.freeze<{ [proposalName: string]: Readonly<{ proposal: string; version?: number }> }>(_allApiProposals);
+export const allApiProposals = Object.freeze<{ [proposalName: string]: Readonly<{ proposal: string }> }>(_allApiProposals);
 export type ApiProposalName = keyof typeof _allApiProposals;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatModifiedFilesConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatModifiedFilesConfirmationSubPart.ts
@@ -25,6 +25,8 @@ import { IChatCodeBlockInfo, IChatWidgetService } from '../../../chat.js';
 import { IChatToolRiskAssessmentService } from '../../../tools/chatToolRiskAssessmentService.js';
 import { IChatContentPartRenderContext } from '../chatContentParts.js';
 import { ChatCustomConfirmationWidget, IChatConfirmationButton } from '../chatConfirmationWidget.js';
+import { renderFileWidgets } from '../chatInlineAnchorWidget.js';
+import { IChatMarkdownAnchorService } from '../chatMarkdownAnchorService.js';
 import { CollapsibleListPool, IChatCollapsibleListItem } from '../chatReferencesContentPart.js';
 import { IEditorService } from '../../../../../../services/editor/common/editorService.js';
 import { AbstractToolConfirmationSubPart } from './abstractToolConfirmationSubPart.js';
@@ -43,6 +45,7 @@ export class ChatModifiedFilesConfirmationSubPart extends AbstractToolConfirmati
 		@IChatWidgetService chatWidgetService: IChatWidgetService,
 		@ILanguageModelToolsService languageModelToolsService: ILanguageModelToolsService,
 		@IMarkdownRendererService private readonly markdownRendererService: IMarkdownRendererService,
+		@IChatMarkdownAnchorService private readonly chatMarkdownAnchorService: IChatMarkdownAnchorService,
 		@IEditorService private readonly editorService: IEditorService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IChatToolRiskAssessmentService riskAssessmentService: IChatToolRiskAssessmentService,
@@ -106,6 +109,7 @@ export class ChatModifiedFilesConfirmationSubPart extends AbstractToolConfirmati
 
 		if (message) {
 			const renderedMessage = this._register(this.markdownRendererService.render(typeof message === 'string' ? new MarkdownString(message) : message));
+			renderFileWidgets(renderedMessage.element, this.instantiationService, this.chatMarkdownAnchorService, this._store);
 			container.append(renderedMessage.element);
 		}
 


### PR DESCRIPTION
- Render file widget links in confirmation messages so markdown links
  in tool invocation text display as clickable file pills instead of
  plain markdown. Fixes 'Editing [file]' collapsing to just 'Editing'.
- Remove toolInput from read file confirmations to prevent the generic
  JSON input panel from being shown during permission requests.
- Update read permission display to use the view-tool invocation message
  format (e.g. 'Reading [file.json]' instead of plain text) and correct
  the confirmation title localization.

Fixes #321797