### PR TITLE
sessions: fix New Session button showing Ctrl+L instead of Cmd+N

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -50,7 +50,7 @@ class NewChatInSessionsWindowAction extends Action2 {
 			category: CHAT_CATEGORY,
 			f1: true,
 			keybinding: {
-				weight: KeybindingWeight.WorkbenchContrib + 2,
+				weight: KeybindingWeight.SessionsContrib,
 				// Don't shadow Ctrl/Cmd+N (and Ctrl/Cmd+L) when focus is in the
 				// editor area so the standard editor commands (new untitled file,
 				// expand line selection) handle the shortcut instead.

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -32,20 +32,6 @@ import { hasActiveSessionFailedCIChecks } from '../../../changes/browser/checksA
 import { ISessionsPartService } from '../../../../services/sessions/browser/sessionsPartService.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 
-//  Constants
-
-const ACTION_ID_NEW_SESSION = 'workbench.action.chat.newChat';
-//  Keybindings
-
-KeybindingsRegistry.registerKeybindingRule({
-	id: ACTION_ID_NEW_SESSION,
-	weight: KeybindingWeight.SessionsContrib,
-	// Don't shadow Ctrl/Cmd+N when focus is in the editor area so the standard
-	// `workbench.action.files.newUntitledFile` command handles the shortcut.
-	when: EditorAreaFocusContext.negate(),
-	primary: KeyMod.CtrlCmd | KeyCode.KeyN,
-});
-
 const CLOSE_SESSION_COMMAND_ID = 'sessionsViewPane.closeSession';
 registerAction2(class CloseSessionAction extends Action2 {
 	constructor() {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/322062

## Problem

In the Agents window, the **New** button in the titlebar showed `^L` (Ctrl+L) instead of `Cmd+N`.

## Root cause

Two `Cmd+N` keybindings were registered in the Agents window for **two different commands**:

- `workbench.action.sessions.newChat` (`NEW_SESSION_ACTION_ID`, weight `WorkbenchContrib + 2` = 202) — the command the New button executes and looks up for its label.
- `workbench.action.chat.newChat` (a legacy duplicate rule in `sessionsViewActions.ts`) — originally the sessions new-chat shortcut (added in #294912), left behind after the dedicated `workbench.action.sessions.newChat` command superseded it.

Both shared the same `when` clause (`editorArea.negate()`, from #319609). When two bindings on the same key have identical `when` clauses, the keybinding resolver evicts the lower-weight one from the command to keybinding lookup map.

#321910 bumped the legacy rule's weight to `SessionsContrib` (250), making it outrank the canonical command (202). That flipped the eviction: the button's command lost its `Cmd+N` entry and `lookupKeybinding` fell back to its secondary `^L`.

## Fix

- Remove the redundant legacy `workbench.action.chat.newChat` `Cmd+N` rule from `sessionsViewActions.ts`.
- Raise the canonical action's keybinding weight to `SessionsContrib` so `Cmd+N` keeps its priority.

This leaves a single `Cmd+N` binding, on the command the button actually runs, so the button shows `Cmd+N` again. The editor-area fallthrough from #319609 is preserved, and the keystroke and button now invoke the same command.

## Validation

- `npm run typecheck-client` passed
- `npm run valid-layers-check` passed
