### PR TITLE
sessions: match new agent-host session by type, not just novelty

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -2482,7 +2482,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		this._onDidChangeSessions.fire({ added: [skeleton], removed: [], changed: [] });
 
 		try {
-			const committedSession = await this._waitForNewSession(existingKeys);
+			const committedSession = await this._waitForNewSession(existingKeys, chatResource.scheme);
 			if (committedSession) {
 				this._preserveNewSessionConfig(newSession, committedSession.sessionId);
 				// Session graduated: release the eager subscription without
@@ -2880,10 +2880,21 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	}
 
 
-	private async _waitForNewSession(existingKeys: Set<string>): Promise<ISession | undefined> {
+	/**
+	 * Resolve the freshly-committed backend session for an in-flight send.
+	 *
+	 * The local agent host runs a single provider whose session cache holds
+	 * **every** agent-host session type (codex, claude, copilot, …). A send
+	 * therefore has to identify *its own* new session by both novelty (a raw id
+	 * not present before the send) **and** type: `expectedScheme` is the
+	 * `chatResource` scheme (e.g. `agent-host-codex`), so a session of another
+	 * type that happens to appear mid-send — a slow codex send racing against a
+	 * restored claude session, say — is never mistaken for this send's commit.
+	 */
+	private async _waitForNewSession(existingKeys: Set<string>, expectedScheme: string): Promise<ISession | undefined> {
 		await this._refreshSessions();
 		for (const [key, cached] of this._sessionCache) {
-			if (!existingKeys.has(key)) {
+			if (!existingKeys.has(key) && cached.resource.scheme === expectedScheme) {
 				return cached;
 			}
 		}
@@ -2894,7 +2905,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 				waitDisposables.add(this._onDidChangeSessions.event(e => {
 					const newSession = e.added.find(s => {
 						const rawId = s.resource.path.substring(1);
-						return !existingKeys.has(rawId);
+						return !existingKeys.has(rawId) && s.resource.scheme === expectedScheme;
 					});
 					if (newSession) {
 						resolve(newSession);

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -2123,6 +2123,40 @@ suite('LocalAgentHostSessionsProvider', () => {
 		);
 	});
 
+	test('sendRequest only commits a session of the same type, ignoring a foreign-type session that appears mid-send', async () => {
+		// Regression test: the local agent host runs a single provider whose
+		// session cache holds every agent-host session type (codex, claude,
+		// copilot). When a slow session (e.g. codex cold start) is sent while a
+		// session of a DIFFERENT type appears in the cache, `_waitForNewSession`
+		// must not latch onto that foreign session and return it as the codex
+		// commit — otherwise the active session is swapped to the wrong type.
+		const codexAndClaude = [
+			{ type: 'agent-host-codex', name: 'codex', displayName: 'Codex', description: 'test', icon: undefined },
+			{ type: 'agent-host-claude', name: 'claude', displayName: 'Claude', description: 'test', icon: undefined },
+		];
+		agentHost.setAgents([
+			{ provider: 'codex', displayName: 'Codex', description: '', models: [] } as AgentInfo,
+			{ provider: 'claude', displayName: 'Claude', description: '', models: [] } as AgentInfo,
+		]);
+		const provider = createProvider(disposables, agentHost, codexAndClaude, {
+			openSession: true,
+			sendRequest: async (): Promise<ChatSendResult> => {
+				// While the codex send is in flight, a foreign-type (claude)
+				// session shows up in the host's list (e.g. restored from an
+				// earlier run), and the real codex session also commits.
+				agentHost.addSession(createSession('foreign-claude', { provider: 'claude', summary: 'Foreign Claude' }));
+				agentHost.addSession(createSession('real-codex', { provider: 'codex', summary: 'Real Codex' }));
+				return { kind: 'sent' as const, data: {} as ChatSendResult extends { kind: 'sent'; data: infer D } ? D : never };
+			},
+		});
+
+		const session = provider.createNewSession(URI.parse('file:///home/user/project'), 'codex');
+		const chat = await provider.createNewChat(session.sessionId);
+		const committed = await provider.sendRequest(session.sessionId, chat.resource, { query: 'hello' });
+
+		assert.strictEqual(committed.resource.scheme, 'agent-host-codex', `expected the committed session to be the codex session, got ${committed.resource.toString()}`);
+	});
+
 	test('sendRequest forwards resolved session config to chat service', async () => {
 		const sendOptions: IChatSendRequestOptions[] = [];
 		const provider = createProvider(disposables, agentHost, undefined, {

--- a/test/smoke/src/areas/agentsWindow/agentsWindow.test.ts
+++ b/test/smoke/src/areas/agentsWindow/agentsWindow.test.ts
@@ -557,7 +557,7 @@ export function setup(logger: Logger) {
 		});
 	});
 
-	describe.skip('Agents Window (Codex)', () => {
+	describe('Agents Window (Codex)', () => {
 
 		const codex = setupAgentHostSuite(logger, {
 			serverLabel: 'Codex',


### PR DESCRIPTION
## Problem

The local agent host runs a **single** sessions provider whose session cache holds **every** agent-host session type (codex, claude, copilot), keyed by bare session uuid. When a new session is sent, the provider identifies the freshly-committed backend session in `_waitForNewSession` purely by **novelty** — the first cached session whose raw id was not present before the send. The session's type/scheme was never checked, even though `chatResource.scheme` (e.g. `agent-host-codex`) is available at the call site.

That latches onto the wrong session when a session of a **different type** appears in the cache during the send:

- A **Codex** send cold-starts a native `codex app-server` and only issues its first `/responses` turn ~9s later.
- If a **Claude** session from an earlier run is already in the cache (the smoke suites share one `userDataDir`, and agent sessions also persist globally), `_waitForNewSession` returns the **Claude** session as the Codex commit.
- `sendRequest` then reports `active session replaced: codex -> claude`, the workbench swaps the active slot to the wrong session and removes the Codex one, so the Codex reply renders nowhere.
- Because the Claude harness is suppressed in that window (`chat.agents.claude.preferAgentHost` defaults to `false`), activating it additionally throws `Agent host targets must have an item provider`.

This is exactly why the **Codex smoke test timed out on the Windows CI runner** (where the cold-start race is widest), failing [build 449022](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=449022&view=results). It passed on macOS/Linux because they win the race.

## Fix

Thread the `chatResource` scheme into `_waitForNewSession(existingKeys, expectedScheme)` and filter by it in **both** code paths — the immediate cache scan and the `onDidChangeSessions` wait — so a send only ever commits a session of **its own type**.

Also re-enable the Codex smoke test (`describe.skip` → `describe`) that #321983 disabled to keep the build green after build 449022.

## Changes (3 files, +50/−5)

- `baseAgentHostSessionsProvider.ts`: `_waitForNewSession` takes `expectedScheme` and filters both the cache scan and the event wait by `resource.scheme`.
- `localAgentHostSessionsProvider.test.ts`: new regression test — a foreign-type (claude) session appearing mid-send must not be returned as the codex commit.
- `agentsWindow.test.ts` (smoke): re-enable `Agents Window (Codex)`.

## Verification

- **Unit:** the new test reproduces the cross-type latch — it returns `agent-host-claude` **before** the fix (the exact production symptom) and `agent-host-codex` **after**. Full provider suite (103) + agentHost suites (1006) pass; `typecheck-client` clean.
- **Live (launch + logs):** started a fresh Codex session with stale Claude/Copilot sessions present; the Codex session stayed active, its reply rendered, and the renderer log had **no** `active session replaced: codex -> claude` and **no** `must have an item provider` error.
- **Smoke:** with the suite re-enabled, `Test Codex session` passes end-to-end locally (real codex app-server, mock LLM); the agent host log shows codex/claude/copilot all registered, codex `responses status=200`, and no wrong swap.

## Notes

- Follow-up to #321964 (the CAPI integration-id fix that first let codex/claude load models again).
- The fix is in the shared base provider, so it covers every local agent-host session type.