### PR TITLE
Remove unnecessary scroll shadows for Monaco list and embedded editors

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/scrollShadows.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/scrollShadows.css
@@ -97,3 +97,14 @@
 	bottom: 0;
 	background: linear-gradient(to top, var(--scroll-shadow-surface), transparent);
 }
+
+/* =============================================================================
+ * Embedded single-line editors used as text inputs (settings / keybindings
+ * search boxes, etc.) live inside the editor part but should read as plain
+ * inputs, not as scrolling editor surfaces. Suppress the edge fades there so the
+ * input keeps a flat background and never shows the editor-coloured rectangle.
+ * ========================================================================== */
+.style-override-scrollShadows .suggest-input-container .monaco-editor .editor-scrollable::before,
+.style-override-scrollShadows .suggest-input-container .monaco-editor .editor-scrollable::after {
+	display: none;
+}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/scrollShadows.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/scrollShadows.css
@@ -63,11 +63,6 @@
 	z-index: 10;
 }
 
-.style-override-scrollShadows .monaco-list > .monaco-scrollable-element::after {
-	bottom: 0;
-	background: linear-gradient(to top, var(--scroll-shadow-surface), transparent);
-}
-
 /* =============================================================================
  * Editor area. The main editor viewport scrolls inside `.editor-scrollable`;
  * pin the fades to that scrollable element so they share the scrollbar's


### PR DESCRIPTION
Eliminate the scroll shadow gradient for the Monaco list and suppress edge fades for embedded single-line editors to maintain a consistent appearance.

