### PR TITLE
Centralize Modern UI toggle

### DIFF
--- a/src/vs/base/browser/ui/splitview/paneview.ts
+++ b/src/vs/base/browser/ui/splitview/paneview.ts
@@ -5,7 +5,7 @@
 
 import { isFirefox } from '../../browser.js';
 import { DataTransfers } from '../../dnd.js';
-import { $, addDisposableListener, append, clearNode, EventHelper, EventType, getWindow, isHTMLElement, trackFocus } from '../../dom.js';
+import { $, addDisposableListener, append, clearNode, EventHelper, EventType, getWindow, isHTMLElement, scheduleAtNextAnimationFrame, trackFocus } from '../../dom.js';
 import { DomEmitter } from '../../event.js';
 import { StandardKeyboardEvent } from '../../keyboardEvent.js';
 import { Gesture, EventType as TouchEventType } from '../../touch.js';
@@ -13,7 +13,7 @@ import { IBoundarySashes, Orientation } from '../sash/sash.js';
 import { Color, RGBA } from '../../../common/color.js';
 import { Emitter, Event } from '../../../common/event.js';
 import { KeyCode } from '../../../common/keyCodes.js';
-import { Disposable, DisposableStore, IDisposable } from '../../../common/lifecycle.js';
+import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../common/lifecycle.js';
 import { ScrollEvent } from '../../../common/scrollable.js';
 import './paneview.css';
 import { localize } from '../../../../nls.js';
@@ -84,6 +84,15 @@ export abstract class Pane extends Disposable implements IView {
 	 * memoized and only re-read once per {@link Pane.layout} pass.
 	 */
 	private _headerSize: number | undefined = undefined;
+
+	/**
+	 * Deferred re-clamp scheduled when {@link Pane.layout} detects that the header
+	 * size changed between passes (e.g. the `--pane-header-size` CSS variable was
+	 * overridden at runtime). Fires {@link Pane.onDidChange} on the next frame so
+	 * the split view re-clamps the size it reserves for this pane without
+	 * reentering the current layout pass.
+	 */
+	private readonly _headerSizeRelayout = this._register(new MutableDisposable());
 
 	private readonly _onDidChange = this._register(new Emitter<number | undefined>());
 	readonly onDidChange: Event<number | undefined> = this._onDidChange.event;
@@ -327,8 +336,20 @@ export abstract class Pane extends Disposable implements IView {
 	layout(size: number): void {
 		// Re-read the header size from CSS once per layout pass; subsequent
 		// `minimumSize` / `maximumSize` reads within the pass reuse the cache.
+		const previousHeaderSize = this._headerSize;
 		this._headerSize = undefined;
 		const headerSize = this.headerSize;
+
+		// If the header size changed since the previous pass — e.g. the
+		// `--pane-header-size` CSS variable was overridden at runtime (a style
+		// override toggled) — the containing split view still reserves the old
+		// size for this pane, most visibly when it is collapsed. Refresh the
+		// header and, on the next frame, fire `onDidChange` so the split view
+		// re-clamps the reservation. Deferring avoids reentering this layout pass.
+		if (previousHeaderSize !== undefined && previousHeaderSize !== headerSize) {
+			this.updateHeader();
+			this._headerSizeRelayout.value = scheduleAtNextAnimationFrame(getWindow(this.element), () => this._onDidChange.fire(undefined));
+		}
 
 		const width = this._orientation === Orientation.VERTICAL ? this.orthogonalSize : size;
 		const height = this._orientation === Orientation.VERTICAL ? size - headerSize : this.orthogonalSize - headerSize;

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -439,7 +439,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			}
 
 			// Floating Panels
-			if (e.affectsConfiguration(LayoutSettings.FLOATING_PANELS)) {
+			if (e.affectsConfiguration(LayoutSettings.MODERN_UI)) {
 				this.updateFloatingPanels();
 				this.layout(); // re-layout so parts pick up the new floating margins
 			}
@@ -619,7 +619,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	}
 
 	isFloatingPanelsEnabled(): boolean {
-		return this.configurationService.getValue<boolean>(LayoutSettings.FLOATING_PANELS) === true;
+		return this.configurationService.getValue<boolean>(LayoutSettings.MODERN_UI) === true;
 	}
 
 	private updateFloatingPanels(): void {

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -438,7 +438,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				this.updateShadows();
 			}
 
-			// Floating Panels
+			// Modern UI Update (floating panels presentation)
 			if (e.affectsConfiguration(LayoutSettings.MODERN_UI)) {
 				this.updateFloatingPanels();
 				this.layout(); // re-layout so parts pick up the new floating margins

--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -6,7 +6,7 @@
 /* ---- Floating Panels (experimental) ---- */
 
 /*
- * When `workbench.experimental.floatingPanels` is set, the primary side
+ * When `workbench.experimental.modernUI` (Modern UI Update) is set, the primary side
  * bar, secondary side bar and bottom panel are rendered as floating cards with a
  * margin, border and rounded corners — echoing the agents window design. The
  * matching content dimensions are reduced in code (AbstractPaneCompositePart) so

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -105,7 +105,7 @@ export class ActivitybarPart extends Part {
 
 			// Floating panels changes the reserved left/bottom gutter (and therefore
 			// the fixed part width): signal the grid that the size constraint changed.
-			if (e.affectsConfiguration(LayoutSettings.FLOATING_PANELS)) {
+			if (e.affectsConfiguration(LayoutSettings.MODERN_UI)) {
 				this._onDidChange.fire(undefined);
 			}
 		}));

--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -223,7 +223,7 @@ class StatusbarPart extends Part implements IStatusbarEntryContainer {
 		// part height) for the main status bar only: signal the grid that the size
 		// constraint changed.
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (this.getId() === Parts.STATUSBAR_PART && e.affectsConfiguration(LayoutSettings.FLOATING_PANELS)) {
+			if (this.getId() === Parts.STATUSBAR_PART && e.affectsConfiguration(LayoutSettings.MODERN_UI)) {
 				this._onDidChange.fire(undefined);
 			}
 		}));

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -1040,17 +1040,17 @@ Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration)
 // enables the unified Modern UI Update experiment.
 Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration)
 	.registerConfigurationMigrations([{
-		key: 'workbench.experimental.floatingPanels', migrateFn: (value: unknown) => {
+		key: 'workbench.experimental.floatingPanels', migrateFn: (value: unknown, valueAccessor) => {
 			const result: ConfigurationKeyValuePairs = [['workbench.experimental.floatingPanels', { value: undefined }]];
-			if (value === true) {
+			if (value === true && valueAccessor(LayoutSettings.MODERN_UI) === undefined) {
 				result.push([LayoutSettings.MODERN_UI, { value: true }]);
 			}
 			return result;
 		}
 	}, {
-		key: 'workbench.experimental.styleOverrides', migrateFn: (value: unknown) => {
+		key: 'workbench.experimental.styleOverrides', migrateFn: (value: unknown, valueAccessor) => {
 			const result: ConfigurationKeyValuePairs = [['workbench.experimental.styleOverrides', { value: undefined }]];
-			if (Array.isArray(value) && value.length > 0) {
+			if (Array.isArray(value) && value.length > 0 && valueAccessor(LayoutSettings.MODERN_UI) === undefined) {
 				result.push([LayoutSettings.MODERN_UI, { value: true }]);
 			}
 			return result;

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -1033,3 +1033,26 @@ Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration)
 			return result;
 		}
 	}]);
+
+// Migrate the previous standalone experiments (`workbench.experimental.floatingPanels`
+// and `workbench.experimental.styleOverrides`) onto the consolidated
+// `workbench.experimental.modernUI` toggle. Either of the old settings being on
+// enables the unified Modern UI Update experiment.
+Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration)
+	.registerConfigurationMigrations([{
+		key: 'workbench.experimental.floatingPanels', migrateFn: (value: unknown) => {
+			const result: ConfigurationKeyValuePairs = [['workbench.experimental.floatingPanels', { value: undefined }]];
+			if (value === true) {
+				result.push([LayoutSettings.MODERN_UI, { value: true }]);
+			}
+			return result;
+		}
+	}, {
+		key: 'workbench.experimental.styleOverrides', migrateFn: (value: unknown) => {
+			const result: ConfigurationKeyValuePairs = [['workbench.experimental.styleOverrides', { value: undefined }]];
+			if (Array.isArray(value) && value.length > 0) {
+				result.push([LayoutSettings.MODERN_UI, { value: true }]);
+			}
+			return result;
+		}
+	}]);

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -807,11 +807,11 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'default': true,
 				'description': localize('shadows', "Controls whether shadow effects are shown around the side panels and other workbench elements.")
 			},
-			[LayoutSettings.FLOATING_PANELS]: {
+			[LayoutSettings.MODERN_UI]: {
 				'type': 'boolean',
 				'default': false,
 				'tags': ['experimental'],
-				'description': localize('floatingPanels', "Controls whether the side bars and bottom panel are shown as floating cards with rounded corners and gaps, similar to the agents window design."),
+				'description': localize('modernUI', "Controls whether the experimental Modern UI Update is enabled. When on, the side bars and bottom panel are shown as floating cards with rounded corners and gaps, and a set of refreshed workbench styles is applied, matching the Agents window design."),
 			},
 		}
 	});

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/commandCenter.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/commandCenter.css
@@ -15,7 +15,7 @@
  *
  * All rules are gated behind the `.style-override-commandCenter` class, which
  * the StyleOverridesContribution toggles onto the workbench container(s) when
- * the `workbench.experimental.styleOverrides` setting includes "commandCenter".
+ * the `workbench.experimental.modernUI` (Modern UI Update) setting is enabled.
  */
 
 /*

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
@@ -25,7 +25,7 @@
  *
  * All rules are gated behind the `.style-override-fontRamp` class, which the
  * StyleOverridesContribution toggles onto the workbench container(s) when the
- * `workbench.experimental.styleOverrides` setting includes "fontRamp". Without
+ * `workbench.experimental.modernUI` (Modern UI Update) setting is enabled. Without
  * that class these rules never apply.
  */
 

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/keyboardFocusOnly.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/keyboardFocusOnly.css
@@ -15,7 +15,7 @@
  *
  * All rules are gated behind the `.style-override-keyboardFocusOnly` class, which
  * the StyleOverridesContribution toggles onto the workbench container(s) when the
- * `workbench.experimental.styleOverrides` setting includes "keyboardFocusOnly".
+ * `workbench.experimental.modernUI` (Modern UI Update) setting is enabled.
  *
  * Scoped to the panel surfaces (side bar, bottom panel, auxiliary bar, status
  * bar) so editor and global widget focus rings are unaffected.

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -11,7 +11,7 @@
  *
  * All rules are gated behind the `.style-override-padding` class, which the
  * StyleOverridesContribution toggles onto the workbench container(s) when the
- * `workbench.experimental.styleOverrides` setting includes "padding".
+ * `workbench.experimental.modernUI` (Modern UI Update) setting is enabled.
  * Without that class these rules never apply.
  */
 

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/paneHeaders.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/paneHeaders.css
@@ -17,7 +17,7 @@
  *
  * All rules are gated behind the `.style-override-paneHeaders` class, which the
  * StyleOverridesContribution toggles onto the workbench container(s) when the
- * `workbench.experimental.styleOverrides` setting includes "paneHeaders".
+ * `workbench.experimental.modernUI` (Modern UI Update) setting is enabled.
  * Without that class these rules never apply.
  */
 

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
@@ -19,7 +19,7 @@
  *
  * All rules are gated behind the `.style-override-roundedCorners` class, which
  * the StyleOverridesContribution toggles onto the workbench container(s) when
- * the `workbench.experimental.styleOverrides` setting includes "roundedCorners".
+ * the `workbench.experimental.modernUI` (Modern UI Update) setting is enabled.
  * Without that class these rules never apply.
  */
 

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/scrollShadows.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/scrollShadows.css
@@ -22,7 +22,7 @@
  *
  * All rules are gated behind the `.style-override-scrollShadows` class, which
  * the StyleOverridesContribution toggles onto the workbench container(s) when
- * the `workbench.experimental.styleOverrides` setting includes "scrollShadows".
+ * the `workbench.experimental.modernUI` (Modern UI Update) setting is enabled.
  */
 
 /*

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -11,8 +11,8 @@
  *
  * All rules are gated behind the `.style-override-tabs` class, which the
  * StyleOverridesContribution toggles onto the workbench container(s) when the
- * `workbench.experimental.styleOverrides` setting includes "tabs". Without that
- * class these rules never apply. Mirrors the Agents window styling defined in
+ * `workbench.experimental.modernUI` (Modern UI Update) setting is enabled. Mirrors
+ * the Agents window styling defined in
  * src/vs/sessions/browser/media/style.css.
  */
 

--- a/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
+++ b/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
@@ -3,15 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from '../../../../nls.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
-import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
+import { IWorkbenchLayoutService, LayoutSettings } from '../../../services/layout/browser/layoutService.js';
 import { Extensions as WorkbenchExtensions, IWorkbenchContribution, IWorkbenchContributionsRegistry } from '../../../common/contributions.js';
 import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
-import { workbenchConfigurationNodeBase } from '../../../common/configuration.js';
 
 // Bundle the CSS for every style-override module. Each file gates all of its
 // rules behind a `.style-override-<id>` ancestor class, so the styles are inert
@@ -27,12 +24,8 @@ import './media/scrollShadows.css';
 import './media/statusBar.css';
 import './media/tabs.css';
 
-const SETTING_ID = 'workbench.experimental.styleOverrides';
-
 interface IStyleOverrideModule {
 	readonly id: string;
-	readonly label: string;
-	readonly description: string;
 	/**
 	 * Whether this module changes layout-affecting CSS variables (e.g. the pane
 	 * header size). Toggling such a module requires a workbench relayout so the
@@ -42,63 +35,22 @@ interface IStyleOverrideModule {
 }
 
 /**
- * The fixed catalog of available style-override experiments. The CSS for each
- * module ships with the product (imported above) and is gated behind the
- * `.style-override-<id>` class. Users can only enable modules from this list;
- * arbitrary CSS cannot be injected.
+ * The fixed catalog of built-in style-override modules. The CSS for each module
+ * ships with the product (imported above) and is gated behind the
+ * `.style-override-<id>` class. All modules are enabled together as part of the
+ * Modern UI Update experiment (`LayoutSettings.MODERN_UI`).
  */
 const STYLE_OVERRIDE_MODULES: readonly IStyleOverrideModule[] = [
-	{
-		id: 'activityBar',
-		label: localize('styleOverrides.activityBar', "Activity Bar"),
-		description: localize('styleOverrides.activityBar.description', "Replaces the active activity bar item's left highlight border with a rounded background behind the icon, and forces item foregrounds to the editor foreground so icons stay legible.")
-	},
-	{
-		id: 'commandCenter',
-		label: localize('styleOverrides.commandCenter', "Agents Window Command Center"),
-		description: localize('styleOverrides.commandCenter.description', "Makes the command center and agent status input transparent at rest, revealing their background on hover to match the Agents window.")
-	},
-	{
-		id: 'fontRamp',
-		label: localize('styleOverrides.fontRamp', "Font Ramp"),
-		description: localize('styleOverrides.fontRamp.description', "Applies a unified typographic ramp across the workbench: headings at 26/18px, 13px body, 12px section titles and tabs, 11px metadata and 10px badges.")
-	},
-	{
-		id: 'keyboardFocusOnly',
-		label: localize('styleOverrides.keyboardFocusOnly', "Keyboard-Only Focus Borders"),
-		description: localize('styleOverrides.keyboardFocusOnly.description', "Hides focus borders that appear when panels are focused with the mouse, while keeping them for keyboard navigation.")
-	},
-	{
-		id: 'padding',
-		label: localize('styleOverrides.padding', "Padding"),
-		description: localize('styleOverrides.padding.description', "Adds extra padding to view pane headers and bodies for more breathing room around content.")
-	},
-	{
-		id: 'paneHeaders',
-		label: localize('styleOverrides.paneHeaders', "Pane Headers"),
-		description: localize('styleOverrides.paneHeaders.description', "Insets the view pane header separators, rounds their corners and adds a background tint on hover."),
-		layoutAffecting: true
-	},
-	{
-		id: 'roundedCorners',
-		label: localize('styleOverrides.roundedCorners', "Rounded Corners"),
-		description: localize('styleOverrides.roundedCorners.description', "Applies a three-tier corner radius system: 8px for overlays (quick input, hovers, menus, dialogs), 6px for non-control containers and 4px for interactable controls (inputs, lists).")
-	},
-	{
-		id: 'scrollShadows',
-		label: localize('styleOverrides.scrollShadows', "Scroll Shadows"),
-		description: localize('styleOverrides.scrollShadows.description', "Adds soft inset shadows to the top and bottom of lists, trees and the editor so content reads as scrolling under a fixed frame.")
-	},
-	{
-		id: 'statusBar',
-		label: localize('styleOverrides.statusBar', "Status Bar"),
-		description: localize('styleOverrides.statusBar.description', "Forces the status bar foreground to the general editor foreground so its text and icons stay legible when the status bar background is neutralized.")
-	},
-	{
-		id: 'tabs',
-		label: localize('styleOverrides.tabs', "Agents Window Tabs"),
-		description: localize('styleOverrides.tabs.description', "Styles editor tabs as transparent, rounded pills to match the Agents window.")
-	}
+	{ id: 'activityBar' },
+	{ id: 'commandCenter' },
+	{ id: 'fontRamp' },
+	{ id: 'keyboardFocusOnly' },
+	{ id: 'padding' },
+	{ id: 'paneHeaders', layoutAffecting: true },
+	{ id: 'roundedCorners' },
+	{ id: 'scrollShadows' },
+	{ id: 'statusBar' },
+	{ id: 'tabs' }
 ];
 
 function classNameFor(moduleId: string): string {
@@ -106,20 +58,17 @@ function classNameFor(moduleId: string): string {
 }
 
 /**
- * A development-oriented contribution that toggles built-in CSS style-override
- * modules on or off based on the `workbench.experimental.styleOverrides` setting.
- *
- * Unlike a free-form CSS loader, the available styles are fixed and shipped with
- * the product. The setting merely selects which of the predefined modules are
- * active, so the styling itself cannot be changed by end users.
+ * A contribution that toggles the built-in CSS style-override modules on or off
+ * as a group, based on the `workbench.experimental.modernUI` setting. When the
+ * Modern UI Update experiment is enabled, all modules are applied together;
+ * otherwise none are.
  */
 export class StyleOverridesContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'workbench.contrib.styleOverrides';
 
-	private readonly knownModuleIds = new Set(STYLE_OVERRIDE_MODULES.map(m => m.id));
 	private readonly knownClassNames = STYLE_OVERRIDE_MODULES.map(m => classNameFor(m.id));
-	private readonly layoutAffectingClassNames = new Set(STYLE_OVERRIDE_MODULES.filter(m => m.layoutAffecting).map(m => classNameFor(m.id)));
+	private readonly hasLayoutAffectingModule = STYLE_OVERRIDE_MODULES.some(m => m.layoutAffecting);
 
 	/** Whether a layout-affecting module was active at the last applied selection. */
 	private layoutAffectingActive = false;
@@ -135,7 +84,7 @@ export class StyleOverridesContribution extends Disposable implements IWorkbench
 		// A config change re-applies to every container (the global `update()`
 		// covers all windows, including auxiliary ones).
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(SETTING_ID)) {
+			if (e.affectsConfiguration(LayoutSettings.MODERN_UI)) {
 				this.update();
 				// Some modules drive layout-affecting CSS variables (e.g. the
 				// `paneHeaders` header size). Only relayout when one of those is
@@ -151,45 +100,30 @@ export class StyleOverridesContribution extends Disposable implements IWorkbench
 		// Apply the current selection to windows opened after startup (e.g.
 		// auxiliary windows). Subsequent config changes are handled by `update()`.
 		this._register(this.layoutService.onDidAddContainer(({ container }) => {
-			this.applyTo(container, this.activeClassNames());
+			this.applyTo(container, this.isEnabled());
 		}));
 
 		this.update();
 	}
 
-	private activeClassNames(): Set<string> {
-		const selection = this.configurationService.getValue<string[]>(SETTING_ID);
-		const active = new Set<string>();
-		if (Array.isArray(selection)) {
-			for (const id of selection) {
-				if (this.knownModuleIds.has(id)) {
-					active.add(classNameFor(id));
-				}
-			}
-		}
-		return active;
+	private isEnabled(): boolean {
+		return this.configurationService.getValue<boolean>(LayoutSettings.MODERN_UI) === true;
 	}
 
 	private hasActiveLayoutAffectingModule(): boolean {
-		const active = this.activeClassNames();
-		for (const className of this.layoutAffectingClassNames) {
-			if (active.has(className)) {
-				return true;
-			}
-		}
-		return false;
+		return this.isEnabled() && this.hasLayoutAffectingModule;
 	}
 
 	private update(): void {
-		const active = this.activeClassNames();
+		const enabled = this.isEnabled();
 		for (const container of this.layoutService.containers) {
-			this.applyTo(container, active);
+			this.applyTo(container, enabled);
 		}
 	}
 
-	private applyTo(container: HTMLElement, active: Set<string>): void {
+	private applyTo(container: HTMLElement, enabled: boolean): void {
 		for (const className of this.knownClassNames) {
-			container.classList.toggle(className, active.has(className));
+			container.classList.toggle(className, enabled);
 		}
 	}
 
@@ -203,24 +137,6 @@ export class StyleOverridesContribution extends Disposable implements IWorkbench
 		super.dispose();
 	}
 }
-
-Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
-	...workbenchConfigurationNodeBase,
-	properties: {
-		[SETTING_ID]: {
-			type: 'array',
-			items: {
-				type: 'string',
-				enum: STYLE_OVERRIDE_MODULES.map(m => m.id),
-				enumDescriptions: STYLE_OVERRIDE_MODULES.map(m => `${m.label}: ${m.description}`)
-			},
-			uniqueItems: true,
-			default: [],
-			tags: ['experimental'],
-			markdownDescription: localize('styleOverrides', "Enables one or more built-in style-override modules that adjust the appearance of the workbench. Each module is a predefined set of styles that ships with the product; only modules from this list can be enabled and the styles themselves cannot be customized. Leave empty to disable all overrides. This is an experimental setting intended for trying out style ideas.")
-		}
-	}
-});
 
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
 	.registerWorkbenchContribution(StyleOverridesContribution, LifecyclePhase.Restored);

--- a/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
+++ b/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
@@ -87,8 +87,14 @@ export class StyleOverridesContribution extends Disposable implements IWorkbench
 			if (e.affectsConfiguration(LayoutSettings.MODERN_UI)) {
 				this.update();
 				// Some modules drive layout-affecting CSS variables (e.g. the
-				// `paneHeaders` header size). Only relayout when one of those is
-				// toggled, to avoid an unnecessary full workbench relayout.
+				// `paneHeaders` header size) that the JS layout reads back, so a
+				// relayout is required once the classes are toggled. The base layout
+				// (`Layout`) also relayouts for this same setting, but its listener
+				// runs earlier (startup) than this contribution's (Restored phase),
+				// so that pass happens *before* these classes are applied and reads
+				// stale values. This relayout therefore runs last and is the
+				// authoritative one — do not remove it as "redundant". Guarded so it
+				// only fires when the enabled state actually flips.
 				const layoutAffectingActive = this.hasActiveLayoutAffectingModule();
 				if (layoutAffectingActive !== this.layoutAffectingActive) {
 					this.layoutAffectingActive = layoutAffectingActive;

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -50,12 +50,12 @@ export const enum LayoutSettings {
 	COMMAND_CENTER = 'window.commandCenter',
 	LAYOUT_ACTIONS = 'workbench.layoutControl.enabled',
 	SHADOWS = 'workbench.shadows',
-	FLOATING_PANELS = 'workbench.experimental.floatingPanels'
+	MODERN_UI = 'workbench.experimental.modernUI'
 }
 
 /**
- * The margin (in pixels) reserved on each side of a part when the floating
- * panels experiment (`LayoutSettings.FLOATING_PANELS`) is enabled. Parts grow
+ * The margin (in pixels) reserved on each side of a part when the modern UI
+ * experiment (`LayoutSettings.MODERN_UI`) is enabled. Parts grow
  * or shrink their content by this amount to leave room for the card margin and
  * border applied in CSS (`part.css`, `.floating-panels`). This value must be
  * kept in sync with the `--floating-panel-margin` custom property defined there.

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -225,9 +225,11 @@ export interface IWorkbenchLayoutService extends ILayoutService {
 	hasFocus(part: Parts): boolean;
 
 	/**
-	 * Returns whether the floating panels experiment is enabled for this
-	 * workbench. Always `false` for the agents window, which has its own floating
-	 * card design and must not apply the experiment's content insets.
+	 * Returns whether the floating panels presentation is enabled for this
+	 * workbench, i.e. whether the Modern UI Update experiment
+	 * (`LayoutSettings.MODERN_UI`) is on. Always `false` for the agents window,
+	 * which has its own floating card design and must not apply the experiment's
+	 * content insets.
 	 */
 	isFloatingPanelsEnabled(): boolean;
 

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -54,11 +54,11 @@ export const enum LayoutSettings {
 }
 
 /**
- * The margin (in pixels) reserved on each side of a part when the modern UI
- * experiment (`LayoutSettings.MODERN_UI`) is enabled. Parts grow
- * or shrink their content by this amount to leave room for the card margin and
- * border applied in CSS (`part.css`, `.floating-panels`). This value must be
- * kept in sync with the `--floating-panel-margin` custom property defined there.
+ * The margin (in pixels) reserved on each side of a part when the Modern UI Update
+ * experiment (`LayoutSettings.MODERN_UI`) is enabled. Parts grow or shrink their
+ * content by this amount to leave room for the margin/border applied in CSS
+ * (`src/vs/workbench/browser/media/floatingPanels.css`, `.floating-panels`).
+ * Keep in sync with the `--vscode-spacing-size60` (6px) token used there.
  */
 export const FLOATING_PANEL_MARGIN = 6;
 

--- a/src/vs/workbench/test/browser/parts/activitybar/activitybarPart.test.ts
+++ b/src/vs/workbench/test/browser/parts/activitybar/activitybarPart.test.ts
@@ -74,7 +74,7 @@ suite('ActivitybarPart', () => {
 	function createActivitybarPart(compact: boolean, floatingPanelsEnabled = false): { part: ActivitybarPart; configService: TestConfigurationService; layoutService: TestFloatingPanelsLayoutService } {
 		const configService = new TestConfigurationService({
 			[LayoutSettings.ACTIVITY_BAR_COMPACT]: compact,
-			[LayoutSettings.FLOATING_PANELS]: floatingPanelsEnabled,
+			[LayoutSettings.MODERN_UI]: floatingPanelsEnabled,
 		});
 		const storageService = disposables.add(new TestStorageService());
 		const themeService = new TestThemeService();
@@ -244,8 +244,8 @@ suite('ActivitybarPart', () => {
 		disposables.add(part.onDidChange(e => events.push(e)));
 
 		layoutService.floatingPanelsEnabled = true;
-		configService.setUserConfiguration(LayoutSettings.FLOATING_PANELS, true);
-		fireConfigChange(configService, LayoutSettings.FLOATING_PANELS);
+		configService.setUserConfiguration(LayoutSettings.MODERN_UI, true);
+		fireConfigChange(configService, LayoutSettings.MODERN_UI);
 
 		assert.deepStrictEqual(events, [undefined]);
 		assert.strictEqual(part.minimumWidth, ActivitybarPart.ACTIVITYBAR_WIDTH + ActivitybarPart.FLOATING_MARGIN);


### PR DESCRIPTION
This pull request consolidates the experimental UI settings in the workbench by introducing a single `workbench.experimental.modernUI` toggle, replacing the previous `floatingPanels` and `styleOverrides` settings. All related experimental style and layout features are now managed together under this unified setting. The change also updates the codebase and documentation to reference the new setting and migrates existing user configurations to the new model.

**Key changes:**

**Modern UI experiment consolidation:**
- Replaces `workbench.experimental.floatingPanels` and `workbench.experimental.styleOverrides` with a single `workbench.experimental.modernUI` setting, which enables all experimental UI features as a group. [[1]](diffhunk://#diff-e2fff02847b3a908c6d7da18b89daa74c1aac378548cf83065141e8a705af76dL810-R814) [[2]](diffhunk://#diff-e2fff02847b3a908c6d7da18b89daa74c1aac378548cf83065141e8a705af76dR1036-R1058)
- Updates configuration migration logic to automatically migrate users' old settings to the new unified `modernUI` toggle.

**Code and configuration updates:**
- Refactors all references in the codebase and configuration checks to use `LayoutSettings.MODERN_UI` instead of the old settings, ensuring consistent feature toggling for floating panels and style overrides. [[1]](diffhunk://#diff-078b5d27a2efa14fa7a778b52365c0cb1f26a34779ff90b81c26712cdd670da3L442-R442) [[2]](diffhunk://#diff-078b5d27a2efa14fa7a778b52365c0cb1f26a34779ff90b81c26712cdd670da3L622-R622) [[3]](diffhunk://#diff-7aaf3f75660a11bc7c949d968b2c9c0178d9aed7eebeae75c4255e2e1a597b9bL108-R108) [[4]](diffhunk://#diff-e2402cd5a743ffaf3e48c4365bc26bd758aaeac48f1e1d80f683892b04b370b0L226-R226)
- Updates the configuration schema and descriptions to reflect the new setting and its broader scope.

**Style override and CSS documentation:**
- Updates all style override CSS files and their documentation comments to reference the new `modernUI` setting, clarifying that these styles are now enabled as part of the Modern UI Update. [[1]](diffhunk://#diff-8e2ceea31169b12f5b4980518294f2593f6fa0cec858088b35a8b3bc18b37347L18-R18) [[2]](diffhunk://#diff-949ec94438c04f89d57f6ad30dfdd93a1ea7e72c5d2d51b032ed5e6c16d0901fL28-R28) [[3]](diffhunk://#diff-ac3294ab4f135eb1db1a6f725ae25fbfdedc46311de22631c313542d04c8f47cL18-R18) [[4]](diffhunk://#diff-c8ee8affb5927140b6da1cb8ec3b4b31cbf0e4116f95bbbfd9d35154799833cbL14-R14) [[5]](diffhunk://#diff-328c173e3312e692e691ef6f8d6d29de9c08c04b8b7e7fb8bf425b92421cca85L20-R20) [[6]](diffhunk://#diff-b0561a8126c7834dc178055e8241cd2bbd48746b3b27b4fd36339caa5cd2abf5L22-R22) [[7]](diffhunk://#diff-b9cad1835089f105c68f39817a5bd098aff4aa4ba22582767c6827969e51b1dfL25-R25) [[8]](diffhunk://#diff-915cccdddaa0b83d00bb30841bbd79387a84f1f638b32f49633b200309e03024L14-R15)
- Simplifies the style override module registration to enable all modules together under the Modern UI experiment, removing individual module toggles and related metadata.

**Pane layout improvements:**
- Improves pane layout logic to handle dynamic header size changes (e.g., when CSS variables are overridden at runtime), ensuring the split view correctly re-clamps pane sizes without re-entering the layout pass. [[1]](diffhunk://#diff-3f812b66fc0cd0a1bb0cf1eb80d5ee3fdd79e19f35d9f3adcd4f3b30ae5b803bL8-R16) [[2]](diffhunk://#diff-3f812b66fc0cd0a1bb0cf1eb80d5ee3fdd79e19f35d9f3adcd4f3b30ae5b803bR88-R96) [[3]](diffhunk://#diff-3f812b66fc0cd0a1bb0cf1eb80d5ee3fdd79e19f35d9f3adcd4f3b30ae5b803bR339-R353)

**Cleanup and refactoring:**
- Removes now-obsolete code related to the old style override setting and simplifies the style override contribution logic. [[1]](diffhunk://#diff-a865927f9a8f20356e381f95544db109d49d6ae661c7a60a1a50a37e329aadc2L6-L14) [[2]](diffhunk://#diff-a865927f9a8f20356e381f95544db109d49d6ae661c7a60a1a50a37e329aadc2L30-L35)

These changes streamline the management of experimental UI features, making it easier for users and developers to enable and maintain the Modern UI Update as a cohesive experience.