### PR TITLE
Adjust tab sizing and enable overflow scrolling

### DIFF
--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -331,15 +331,17 @@
 	--tab-border-top-color: transparent !important;
 }
 
-/* Allow tabs to shrink when space is constrained so the close button stays
- * reachable, while still letting them grow to fit their label when there is
- * space. The default `sizing-fit` rule sets `width: 120px; min-width:
- * fit-content; flex-shrink: 0;` — clearing min-width alone leaves the tab
- * pinned at 120px and prevents it from expanding to its full content width. */
+/* Size tabs to their content and never shrink them, so that when more tabs
+ * exist than fit the container they overflow and the horizontal scrollbar
+ * appears (matching the default editor behaviour). The default `sizing-fit`
+ * rule sets `width: 120px; min-width: fit-content; flex-shrink: 0;` — pinning
+ * tabs at 120px. We instead let the width follow the label (`width: auto`)
+ * while keeping `flex-shrink: 0` so tabs keep their content width and the tab
+ * strip scrolls instead of squashing the tabs. */
 .agent-sessions-workbench .part.editor .tabs-container > .tab.sizing-fit {
 	width: auto !important;
 	min-width: 0 !important;
-	flex: 0 1 auto !important;
+	flex: 0 0 auto !important;
 }
 
 .agent-sessions-workbench .part.editor .tabs-container > .tab.sizing-fit .monaco-icon-label,


### PR DESCRIPTION
Size tabs to fit their content without shrinking, allowing overflow scrolling when there are more tabs than can fit in the container. This change enhances usability by preventing tab squashing.

Fixes https://github.com/microsoft/vscode/issues/321029 
Fixes https://github.com/microsoft/vscode/issues/320979