### PR TITLE
Remove letter-spacing from agent sessions title style

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/media/chatViewPane.css
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/media/chatViewPane.css
@@ -67,7 +67,6 @@
 		font-size: 11px;
 		font-weight: 700;
 		text-transform: uppercase;
-		letter-spacing: 0.5px;
 
 		.agent-sessions-title {
 			cursor: pointer;


### PR DESCRIPTION
Eliminate letter-spacing from the agent sessions title style to improve text appearance.

