### PR TITLE
sessions: restore trailing separator in panel part configuration

### DIFF
--- a/src/vs/sessions/browser/parts/panelPart.ts
+++ b/src/vs/sessions/browser/parts/panelPart.ts
@@ -88,7 +88,7 @@ export class PanelPart extends AbstractPaneCompositePart {
 	) {
 		super(
 			Parts.PANEL_PART,
-			{ hasTitle: true, trailingSeparator: false },
+			{ hasTitle: true, trailingSeparator: true },
 			PanelPart.activePanelSettingsKey,
 			ActivePanelContext.bindTo(contextKeyService),
 			PanelFocusContext.bindTo(contextKeyService),


### PR DESCRIPTION
Completes the revert of #320748 (`Agents window: Remove trailing separator from panel part configuration`).

That PR made two changes:
1. Removed the panel-title close menu entry in `layoutActions.ts` — already restored separately (via `MenuRegistry.appendMenuItem(Menus.PanelTitle, …)`).
2. Flipped `trailingSeparator: true` -> `false` in `panelPart.ts` — this was still missing.

This PR restores `trailingSeparator: true` so the panel title toolbar again renders a `Separator()` after its primary actions, restoring the visual divider before the close icon.

Addresses: https://github.com/microsoft/vscode/issues/317695