### PR TITLE
sessions: add [PR-ICON-TRACE] logs to PR polling/fetching pipeline

### DIFF
--- a/src/vs/sessions/contrib/github/browser/github.contribution.ts
+++ b/src/vs/sessions/contrib/github/browser/github.contribution.ts
@@ -9,12 +9,15 @@ import { structuralEquals } from '../../../../base/common/equals.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { ISession } from '../../../services/sessions/common/session.js';
 import { ISessionsChangeEvent, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { GitHubPullRequestState } from '../common/types.js';
 import { GitHubService, IGitHubService } from './githubService.js';
+
+const TRACE_PREFIX = '[PR-ICON-TRACE]';
 
 export class GitHubPullRequestPollingContribution extends Disposable implements IWorkbenchContribution {
 
@@ -27,6 +30,7 @@ export class GitHubPullRequestPollingContribution extends Disposable implements 
 		@IGitHubService private readonly _gitHubService: IGitHubService,
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
 		@ISessionsService private readonly _sessionsService: ISessionsService,
+		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
 
@@ -146,10 +150,12 @@ export class GitHubPullRequestPollingContribution extends Disposable implements 
 			const identity = pullRequestIdentityObs.read(reader);
 			if (!identity) {
 				// No PR number yet (or archived); this autorun re-runs once it resolves.
+				this._logService.trace(`${TRACE_PREFIX} [PollingContribution] Session ${session.sessionId} has no PR identity yet (no PR number or archived); waiting`);
 				return;
 			}
 
 			const { owner, repo, prNumber } = identity;
+			this._logService.trace(`${TRACE_PREFIX} [PollingContribution] Session ${session.sessionId} resolved PR identity ${owner}/${repo}#${prNumber}; acquiring model and refreshing`);
 
 			const modelRef = reader.store.add(this._gitHubService.createPullRequestModelReference(owner, repo, prNumber));
 			const model = modelRef.object;
@@ -167,9 +173,11 @@ export class GitHubPullRequestPollingContribution extends Disposable implements 
 			});
 			reader.store.add(autorun(pollReader => {
 				if (!shouldPollObs.read(pollReader)) {
+					this._logService.trace(`${TRACE_PREFIX} [PollingContribution] Session ${session.sessionId} PR ${owner}/${repo}#${prNumber} is merged and not active; not polling`);
 					return;
 				}
 
+				this._logService.trace(`${TRACE_PREFIX} [PollingContribution] Session ${session.sessionId} starting PR polling for ${owner}/${repo}#${prNumber}`);
 				pollReader.store.add(model.startPolling());
 			}));
 
@@ -181,6 +189,8 @@ export class GitHubPullRequestPollingContribution extends Disposable implements 
 				if (!prDetails || prDetails.isDraft || prDetails.state !== GitHubPullRequestState.Open) {
 					return;
 				}
+
+				this._logService.trace(`${TRACE_PREFIX} [PollingContribution] Session ${session.sessionId} starting CI + review-thread polling for ${owner}/${repo}#${prNumber}@${prDetails.headSha}`);
 
 				const ciModelRef = statusReader.store.add(this._gitHubService.createPullRequestCIModelReference(owner, repo, prNumber, prDetails.headSha));
 				ciModelRef.object.refresh();

--- a/src/vs/sessions/contrib/github/browser/githubApiClient.ts
+++ b/src/vs/sessions/contrib/github/browser/githubApiClient.ts
@@ -10,6 +10,7 @@ import { IRequestService, asJson } from '../../../../platform/request/common/req
 import { IAuthenticationService } from '../../../../workbench/services/authentication/common/authentication.js';
 
 const LOG_PREFIX = '[GitHubApiClient]';
+const TRACE_PREFIX = '[PR-ICON-TRACE]';
 const GITHUB_API_BASE = 'https://api.github.com';
 const GITHUB_GRAPHQL_ENDPOINT = `${GITHUB_API_BASE}/graphql`;
 
@@ -94,6 +95,7 @@ export class GitHubApiClient extends Disposable {
 		const token = await this._getAuthToken();
 
 		this._logService.trace(`${LOG_PREFIX} ${method} ${pathForLogging}`);
+		this._logService.trace(`${TRACE_PREFIX} [GitHubApiClient] -> ${method} ${pathForLogging} (callSite ${callSite}${options?.etag !== undefined ? `, ifNoneMatch ${options.etag}` : ''})`);
 
 		const response = await this._requestService.request({
 			type: method,
@@ -116,6 +118,8 @@ export class GitHubApiClient extends Disposable {
 
 		const statusCode = response.res.statusCode ?? 0;
 		const responseETag = response.res.headers?.['etag'];
+
+		this._logService.trace(`${TRACE_PREFIX} [GitHubApiClient] <- ${method} ${pathForLogging} status ${statusCode}${responseETag ? `, etag ${responseETag}` : ''}${rateLimitRemaining !== undefined ? `, rateLimitRemaining ${rateLimitRemaining}` : ''} (callSite ${callSite})`);
 
 		if (
 			statusCode === 204 /* No Content */ ||

--- a/src/vs/sessions/contrib/github/browser/githubService.ts
+++ b/src/vs/sessions/contrib/github/browser/githubService.ts
@@ -5,6 +5,7 @@
 
 import { Disposable, IReference } from '../../../../base/common/lifecycle.js';
 import { createDecorator, IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
 import { IGitHubChangedFile } from '../common/types.js';
 import { GitHubApiClient } from './githubApiClient.js';
 import { GitHubRepositoryModel, GitHubRepositoryModelReferenceCollection } from './models/githubRepositoryModel.js';
@@ -16,6 +17,14 @@ import { getPullRequestKey } from '../common/utils.js';
 import { derived, derivedOpts, IObservable } from '../../../../base/common/observable.js';
 import { structuralEquals } from '../../../../base/common/equals.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+
+/**
+ * Shared trace prefix for the pull-request polling/fetching pipeline that feeds
+ * the session PR status icons. Filter the logs on this token to follow the
+ * whole flow end-to-end (lookup -> fetch -> poll -> icon).
+ */
+const TRACE_PREFIX = '[PR-ICON-TRACE]';
+
 export interface IGitHubService {
 	readonly _serviceBrand: undefined;
 
@@ -89,6 +98,7 @@ export class GitHubService extends Disposable implements IGitHubService {
 	constructor(
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ISessionsService sessionsService: ISessionsService,
+		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
 
@@ -195,6 +205,7 @@ export class GitHubService extends Disposable implements IGitHubService {
 		const key = `${owner}/${repo}#${branch}`;
 		let promise = this._findPRByBranchCache.get(key);
 		if (!promise) {
+			this._logService.trace(`${TRACE_PREFIX} [GitHubService] findPullRequestNumberByHeadBranch cache MISS for ${key}; starting lookup`);
 			promise = this._fetchPullRequestNumberByHeadBranch(owner, repo, branch);
 			this._findPRByBranchCache.set(key, promise);
 			// Only cache successful, numeric results indefinitely; the PR number
@@ -204,13 +215,19 @@ export class GitHubService extends Disposable implements IGitHubService {
 			promise.then(
 				value => {
 					if (typeof value !== 'number') {
+						this._logService.trace(`${TRACE_PREFIX} [GitHubService] findPullRequestNumberByHeadBranch for ${key} resolved with NO pr number; dropping cache entry so a later call retries`);
 						this._findPRByBranchCache.delete(key);
+					} else {
+						this._logService.trace(`${TRACE_PREFIX} [GitHubService] findPullRequestNumberByHeadBranch for ${key} resolved PR #${value}; caching indefinitely`);
 					}
 				},
-				() => {
+				err => {
+					this._logService.trace(`${TRACE_PREFIX} [GitHubService] findPullRequestNumberByHeadBranch for ${key} FAILED; dropping cache entry. Error: ${err}`);
 					this._findPRByBranchCache.delete(key);
 				},
 			);
+		} else {
+			this._logService.trace(`${TRACE_PREFIX} [GitHubService] findPullRequestNumberByHeadBranch cache HIT for ${key}`);
 		}
 		return promise.catch(() => undefined);
 	}
@@ -221,12 +238,14 @@ export class GitHubService extends Disposable implements IGitHubService {
 		// surfaces the PR after the agent run finishes and the PR is merged.
 		// `per_page=1` + `sort=updated` gives us the most recent match.
 		const path = `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls?head=${encodeURIComponent(`${owner}:${branch}`)}&state=all&sort=updated&direction=desc&per_page=1`;
+		this._logService.trace(`${TRACE_PREFIX} [GitHubService] Fetching PR number for head ${owner}:${branch} via GET ${path}`);
 		const response = await this._apiClient.request<readonly { readonly number: number }[]>(
 			'GET',
 			path,
 			'githubApi.findPullRequestByHeadBranch',
 		);
 		const first = response.data?.[0];
+		this._logService.trace(`${TRACE_PREFIX} [GitHubService] PR number lookup for ${owner}:${branch} -> ${first ? `#${first.number}` : 'no match'} (status ${response.statusCode}, ${response.data?.length ?? 0} result(s))`);
 		return first ? first.number : undefined;
 	}
 }

--- a/src/vs/sessions/contrib/github/browser/githubService.ts
+++ b/src/vs/sessions/contrib/github/browser/githubService.ts
@@ -222,7 +222,7 @@ export class GitHubService extends Disposable implements IGitHubService {
 					}
 				},
 				err => {
-					this._logService.trace(`${TRACE_PREFIX} [GitHubService] findPullRequestNumberByHeadBranch for ${key} FAILED; dropping cache entry. Error: ${err}`);
+					this._logService.trace(`${TRACE_PREFIX} [GitHubService] findPullRequestNumberByHeadBranch for ${key} FAILED; dropping cache entry.`, err);
 					this._findPRByBranchCache.delete(key);
 				},
 			);

--- a/src/vs/sessions/contrib/github/browser/models/githubPullRequestCIModel.ts
+++ b/src/vs/sessions/contrib/github/browser/models/githubPullRequestCIModel.ts
@@ -12,6 +12,7 @@ import { GitHubApiClient } from '../githubApiClient.js';
 import { computeOverallCIStatus, GitHubPRCIFetcher } from '../fetchers/githubPRCIFetcher.js';
 
 const LOG_PREFIX = '[GitHubPullRequestCIModel]';
+const TRACE_PREFIX = '[PR-ICON-TRACE]';
 const DEFAULT_POLL_INTERVAL_MS = 60_000;
 
 export class GitHubPullRequestCIModelReferenceCollection extends ReferenceCollection<GitHubPullRequestCIModel> {
@@ -90,6 +91,7 @@ export class GitHubPullRequestCIModel extends Disposable {
 	}
 
 	private async _refresh(): Promise<void> {
+		this._logService.trace(`${TRACE_PREFIX} [CIModel] Refreshing CI for ${this.owner}/${this.repo}#${this.prNumber}@${this.headSha} (checksEtag ${this._checksEtag ?? 'none'})`);
 		try {
 			const response = await this._fetcher.getCheckRuns(this.owner, this.repo, this.headSha, this._checksEtag);
 			if (response.statusCode === 200 && response.data) {
@@ -97,8 +99,9 @@ export class GitHubPullRequestCIModel extends Disposable {
 				this._checks.set(response.data, undefined);
 				this._overallStatus.set(computeOverallCIStatus(response.data), undefined);
 			}
+			this._logService.trace(`${TRACE_PREFIX} [CIModel] Refreshed CI for ${this.owner}/${this.repo}#${this.prNumber}@${this.headSha}: status ${response.statusCode}, ${this._checks.get().length} check(s), overallStatus ${this._overallStatus.get()}`);
 		} catch (err) {
-			this._logService.error(`${LOG_PREFIX} Failed to refresh CI checks for ${this.owner}/${this.repo}#${this.prNumber}@${this.headSha}:`, err);
+			this._logService.error(`${TRACE_PREFIX} ${LOG_PREFIX} Failed to refresh CI checks for ${this.owner}/${this.repo}#${this.prNumber}@${this.headSha}:`, err);
 		}
 	}
 
@@ -128,6 +131,7 @@ export class GitHubPullRequestCIModel extends Disposable {
 	 */
 	startPolling(intervalMs: number = DEFAULT_POLL_INTERVAL_MS): IDisposable {
 		if (this._pollingClientCount++ === 0) {
+			this._logService.trace(`${TRACE_PREFIX} [CIModel] Start polling ${this.owner}/${this.repo}#${this.prNumber}@${this.headSha} every ${intervalMs}ms`);
 			this._pollScheduler.schedule(intervalMs);
 		}
 
@@ -143,6 +147,7 @@ export class GitHubPullRequestCIModel extends Disposable {
 	}
 
 	private async _poll(): Promise<void> {
+		this._logService.trace(`${TRACE_PREFIX} [CIModel] Poll cycle for ${this.owner}/${this.repo}#${this.prNumber}@${this.headSha}`);
 		await this.refresh();
 		// Re-schedule if not disposed (RunOnceScheduler is one-shot)
 		if (!this._store.isDisposed && this._pollingClientCount > 0) {

--- a/src/vs/sessions/contrib/github/browser/models/githubPullRequestModel.ts
+++ b/src/vs/sessions/contrib/github/browser/models/githubPullRequestModel.ts
@@ -12,6 +12,7 @@ import { computeMergeability, GitHubPRFetcher } from '../fetchers/githubPRFetche
 import { GitHubApiClient } from '../githubApiClient.js';
 
 const LOG_PREFIX = '[GitHubPullRequestModel]';
+const TRACE_PREFIX = '[PR-ICON-TRACE]';
 const DEFAULT_POLL_INTERVAL_MS = 60_000;
 
 export class GitHubPullRequestModelReferenceCollection extends ReferenceCollection<GitHubPullRequestModel> {
@@ -105,6 +106,7 @@ export class GitHubPullRequestModel extends Disposable {
 		this._pollingDisposables.add(disposable);
 
 		if (this._pollingDisposables.size === 1) {
+			this._logService.trace(`${TRACE_PREFIX} [PRModel] Start polling ${this.owner}/${this.repo}#${this.prNumber} every ${intervalMs}ms`);
 			this._pollScheduler.schedule(intervalMs);
 		}
 
@@ -112,6 +114,7 @@ export class GitHubPullRequestModel extends Disposable {
 	}
 
 	private async _poll(): Promise<void> {
+		this._logService.trace(`${TRACE_PREFIX} [PRModel] Poll cycle for ${this.owner}/${this.repo}#${this.prNumber}`);
 		await this.refresh();
 		// Re-schedule for next poll cycle (RunOnceScheduler is one-shot)
 		if (!this._store.isDisposed && this._pollingDisposables.size > 0) {
@@ -120,6 +123,7 @@ export class GitHubPullRequestModel extends Disposable {
 	}
 
 	private async _refresh(): Promise<void> {
+		this._logService.trace(`${TRACE_PREFIX} [PRModel] Refreshing ${this.owner}/${this.repo}#${this.prNumber} (prEtag ${this._pullRequestEtag ?? 'none'}, reviewsEtag ${this._reviewsEtag ?? 'none'})`);
 		try {
 			const [pr, reviews] = await Promise.all([
 				this._fetcher.getPullRequest(this.owner, this.repo, this.prNumber, this._pullRequestEtag),
@@ -150,8 +154,11 @@ export class GitHubPullRequestModel extends Disposable {
 					}
 				}
 			});
+
+			const current = this._pullRequest.get();
+			this._logService.trace(`${TRACE_PREFIX} [PRModel] Refreshed ${this.owner}/${this.repo}#${this.prNumber}: prStatus ${pr.statusCode}, reviewsStatus ${reviews.statusCode}, state ${current?.state ?? 'unknown'}, isDraft ${current?.isDraft ?? 'unknown'}, headSha ${current?.headSha ?? 'unknown'}`);
 		} catch (err) {
-			this._logService.error(`${LOG_PREFIX} Failed to refresh PR #${this.prNumber}:`, err);
+			this._logService.error(`${TRACE_PREFIX} ${LOG_PREFIX} Failed to refresh PR #${this.prNumber}:`, err);
 		}
 	}
 

--- a/src/vs/sessions/contrib/github/browser/models/githubPullRequestReviewThreadsModel.ts
+++ b/src/vs/sessions/contrib/github/browser/models/githubPullRequestReviewThreadsModel.ts
@@ -12,6 +12,7 @@ import { GitHubApiClient } from '../githubApiClient.js';
 import { GitHubPRFetcher } from '../fetchers/githubPRFetcher.js';
 
 const LOG_PREFIX = '[GitHubPullRequestReviewThreadsModel]';
+const TRACE_PREFIX = '[PR-ICON-TRACE]';
 const DEFAULT_POLL_INTERVAL_MS = 60_000;
 
 export class GitHubPullRequestReviewThreadsModelReferenceCollection extends ReferenceCollection<GitHubPullRequestReviewThreadsModel> {
@@ -86,11 +87,14 @@ export class GitHubPullRequestReviewThreadsModel extends Disposable {
 	}
 
 	private async _refresh(): Promise<void> {
+		this._logService.trace(`${TRACE_PREFIX} [ReviewThreadsModel] Refreshing review threads for ${this.owner}/${this.repo}#${this.prNumber}`);
 		try {
 			const data = await this._fetcher.getReviewThreads(this.owner, this.repo, this.prNumber);
 			this._reviewThreads.set(data, undefined);
+			const unresolved = data.filter(thread => !thread.isResolved).length;
+			this._logService.trace(`${TRACE_PREFIX} [ReviewThreadsModel] Refreshed review threads for ${this.owner}/${this.repo}#${this.prNumber}: ${data.length} thread(s), ${unresolved} unresolved`);
 		} catch (err) {
-			this._logService.error(`${LOG_PREFIX} Failed to refresh threads for PR #${this.prNumber}:`, err);
+			this._logService.error(`${TRACE_PREFIX} ${LOG_PREFIX} Failed to refresh threads for PR #${this.prNumber}:`, err);
 		}
 	}
 
@@ -116,6 +120,7 @@ export class GitHubPullRequestReviewThreadsModel extends Disposable {
 	 */
 	startPolling(intervalMs: number = DEFAULT_POLL_INTERVAL_MS): IDisposable {
 		if (this._pollingClientCount++ === 0) {
+			this._logService.trace(`${TRACE_PREFIX} [ReviewThreadsModel] Start polling ${this.owner}/${this.repo}#${this.prNumber} every ${intervalMs}ms`);
 			this._pollScheduler.schedule(intervalMs);
 		}
 
@@ -131,6 +136,7 @@ export class GitHubPullRequestReviewThreadsModel extends Disposable {
 	}
 
 	private async _poll(): Promise<void> {
+		this._logService.trace(`${TRACE_PREFIX} [ReviewThreadsModel] Poll cycle for ${this.owner}/${this.repo}#${this.prNumber}`);
 		await this.refresh();
 		if (!this._store.isDisposed && this._pollingClientCount > 0) {
 			this._pollScheduler.schedule();

--- a/src/vs/sessions/contrib/github/test/browser/githubContribution.test.ts
+++ b/src/vs/sessions/contrib/github/test/browser/githubContribution.test.ts
@@ -9,6 +9,7 @@ import { Emitter, Event } from '../../../../../base/common/event.js';
 import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
 import { DisposableStore, IDisposable, ImmortalReference, IReference, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { constObservable, IObservable, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { GitHubPullRequestModel } from '../../browser/models/githubPullRequestModel.js';
 import { GitHubPullRequestCIModel } from '../../browser/models/githubPullRequestCIModel.js';
 import { GitHubPullRequestReviewThreadsModel } from '../../browser/models/githubPullRequestReviewThreadsModel.js';
@@ -25,6 +26,7 @@ import { ISessionsService } from '../../../../services/sessions/browser/sessions
 suite('GitHubPullRequestPollingContribution', () => {
 
 	const store = new DisposableStore();
+	const logService = new NullLogService();
 	let sessionsManagementService: TestSessionsManagementService;
 	let sessionsService: ISessionsService;
 	let gitHubService: TestGitHubService;
@@ -46,7 +48,7 @@ suite('GitHubPullRequestPollingContribution', () => {
 	test('starts polling existing and added pull request sessions', () => {
 		const existingSession = sessionsManagementService.addSession('existing', makeGitHubInfo(1));
 
-		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService));
+		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService, logService));
 
 		const addedSession = sessionsManagementService.addSession('added', makeGitHubInfo(2));
 		sessionsManagementService.fireSessionsChanged({ added: [addedSession] });
@@ -60,7 +62,7 @@ suite('GitHubPullRequestPollingContribution', () => {
 
 	test('stops polling when a session is archived, then resumes when unarchived', () => {
 		const session = sessionsManagementService.addSession('session', makeGitHubInfo(1));
-		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService));
+		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService, logService));
 
 		sessionsManagementService.setArchived(session, true);
 		sessionsManagementService.fireSessionsChanged({ changed: [session] });
@@ -79,7 +81,7 @@ suite('GitHubPullRequestPollingContribution', () => {
 
 	test('does not poll archived sessions until they are unarchived', () => {
 		const session = sessionsManagementService.addSession('session', makeGitHubInfo(1), true);
-		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService));
+		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService, logService));
 
 		assert.deepStrictEqual(gitHubService.snapshot(), {});
 
@@ -93,7 +95,7 @@ suite('GitHubPullRequestPollingContribution', () => {
 
 	test('stops polling tracked pull requests when disposed', () => {
 		const session = sessionsManagementService.addSession('session', makeGitHubInfo(1));
-		const contribution = store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService));
+		const contribution = store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService, logService));
 
 		contribution.dispose();
 
@@ -105,7 +107,7 @@ suite('GitHubPullRequestPollingContribution', () => {
 
 	test('polls CI checks and review threads once an open pull request resolves', () => {
 		sessionsManagementService.addSession('session', makeGitHubInfo(1));
-		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService));
+		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService, logService));
 
 		// Until the PR details load, only the PR model is polled.
 		assert.deepStrictEqual(gitHubService.statusModelSnapshot(), { ci: {}, reviewThreads: {} });
@@ -120,7 +122,7 @@ suite('GitHubPullRequestPollingContribution', () => {
 
 	test('does not poll CI checks or review threads for draft pull requests', () => {
 		sessionsManagementService.addSession('session', makeGitHubInfo(1));
-		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService));
+		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService, logService));
 
 		gitHubService.setPullRequestDetails('owner', 'repo', 1, { state: GitHubPullRequestState.Open, isDraft: true, headSha: 'sha1' });
 
@@ -131,7 +133,7 @@ suite('GitHubPullRequestPollingContribution', () => {
 		// Mirrors the agent-host provider, whose `gitHubInfo` initially has no PR
 		// number (it is resolved asynchronously via findPullRequestNumberByHeadBranch).
 		const session = sessionsManagementService.addSession('async', { owner: 'owner', repo: 'repo' });
-		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService));
+		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService, logService));
 
 		// No PR number yet → nothing is polled.
 		assert.deepStrictEqual(gitHubService.snapshot(), {});
@@ -146,7 +148,7 @@ suite('GitHubPullRequestPollingContribution', () => {
 
 	test('stops polling a merged pull request unless it is the active session', () => {
 		const session = sessionsManagementService.addSession('session', makeGitHubInfo(1));
-		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService));
+		store.add(new GitHubPullRequestPollingContribution(gitHubService, sessionsManagementService, sessionsService, logService));
 
 		// Open PR → polling.
 		gitHubService.setPullRequestDetails('owner', 'repo', 1, { state: GitHubPullRequestState.Open, isDraft: false, headSha: 'sha1' });

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -53,6 +53,7 @@ import { changesetFileToChange, mapProtocolStatus } from './agentHostDiffs.js';
 import { createChangesets } from './agentHostSessionChangesets.js';
 
 const STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES = 'sessions.agentHost.sessionConfigPicker.selectedValues';
+const TRACE_PREFIX = '[PR-ICON-TRACE]';
 const UNSAFE_SESSION_CONFIG_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 function isSafeSessionConfigKey(property: string): boolean {
@@ -301,7 +302,8 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 		resourceScheme: string,
 		logicalSessionType: string,
 		private readonly _options: IAgentHostAdapterOptions,
-		@ISessionsService private readonly _sessionsService: ISessionsService
+		@ISessionsService private readonly _sessionsService: ISessionsService,
+		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
 		const rawId = AgentSession.id(metadata.session);
@@ -360,11 +362,13 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 		this.gitHubInfo = derived<IGitHubInfo | undefined>(this, reader => {
 			const coords = gitHubCoords.read(reader);
 			if (!coords) {
+				this._logService.trace(`${TRACE_PREFIX} [IconAdapter] Session ${this.sessionId} has no GitHub coords (missing owner/repo/branch in git state); no PR icon`);
 				return undefined;
 			}
 			const innerObs = pullRequestNumberObs.read(reader);
 			const prNumber = innerObs?.read(reader)?.value;
 			if (prNumber === undefined) {
+				this._logService.trace(`${TRACE_PREFIX} [IconAdapter] Session ${this.sessionId} coords ${coords.owner}/${coords.repo}@${coords.branch}: PR number not resolved yet; emitting gitHubInfo without pullRequest`);
 				return { owner: coords.owner, repo: coords.repo };
 			}
 			const uri = URI.parse(`https://github.com/${coords.owner}/${coords.repo}/pull/${prNumber}`);
@@ -383,7 +387,12 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 						hasUnresolvedComments = reviewThreadsRef.object.reviewThreads.read(reader).some(thread => !thread.isResolved);
 					}
 					icon = computePullRequestIcon(livePR.isDraft ? 'draft' : livePR.state, { hasFailingChecks, hasUnresolvedComments });
+					this._logService.trace(`${TRACE_PREFIX} [IconAdapter] Session ${this.sessionId} PR ${coords.owner}/${coords.repo}#${prNumber}: livePR present (state ${livePR.state}, isDraft ${livePR.isDraft}, headSha ${livePR.headSha}), hasFailingChecks ${hasFailingChecks}, hasUnresolvedComments ${hasUnresolvedComments} -> icon ${icon?.id ?? 'none'}`);
+				} else {
+					this._logService.trace(`${TRACE_PREFIX} [IconAdapter] Session ${this.sessionId} PR ${coords.owner}/${coords.repo}#${prNumber}: livePR not loaded yet; icon undefined (waiting for PR model refresh)`);
 				}
+			} else {
+				this._logService.trace(`${TRACE_PREFIX} [IconAdapter] Session ${this.sessionId} PR ${coords.owner}/${coords.repo}#${prNumber}: no GitHub service available; icon undefined`);
 			}
 			return {
 				owner: coords.owner,


### PR DESCRIPTION
## What

Adds trace-level logging across the GitHub pull-request **polling / fetching** pipeline that feeds the agent-host session **PR status icons**. Every log line shares the filter token [PR-ICON-TRACE] so the whole flow (lookup → fetch → poll → icon) can be isolated in the logs while debugging missing or incorrect session PR icons.

## Where

- **`githubService.ts`** `[GitHubService]` — PR-number lookup cache hit/miss, REST fetch path, resolved number / no-match / failure.
- **`githubApiClient.ts`** `[GitHubApiClient]` — each request (`->` with callSite + `If-None-Match`) and response (`<-` status, etag, rate-limit).
- **`githubPullRequestModel.ts`** `[PRModel]` — refresh start/result, poll cycles, `startPolling`.
- **`githubPullRequestCIModel.ts`** `[CIModel]` — refresh start/result, poll cycles, `startPolling`.
- **`githubPullRequestReviewThreadsModel.ts`** `[ReviewThreadsModel]` — refresh start/result, poll cycles, `startPolling`.
- **`github.contribution.ts`** `[PollingContribution]` — per-session PR identity resolution and PR/CI/review-thread poll start.
- **`baseAgentHostSessionsProvider.ts`** `[IconAdapter]` — the icon derivation: coords, PR-number resolution, live PR state, failing-checks / unresolved-comments, final computed icon.

## Notes

- All new logs are `trace` level (enable Trace log level to see them). Existing `error` logs in these files now also carry the prefix so failures show up in the same filter.
- Injected `ILogService` into `GitHubService`, the polling contribution, and `AgentHostSessionAdapter`; updated the polling-contribution test accordingly.
- Validated: `tsgo` typecheck (0 errors) and ESLint (0 issues).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
