### PR TITLE
Update icon for continue in background action in chat terminal tool progress part

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -712,7 +712,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			const action = new Action(
 				TerminalContribCommandId.ContinueInBackground,
 				localize('continueInBackground', 'Continue in Background'),
-				ThemeIcon.asClassName(Codicon.debugContinue),
+				ThemeIcon.asClassName(Codicon.debugContinueSmall),
 				true,
 				() => this.continueInBackground()
 			);


### PR DESCRIPTION
Replace the icon for the "Continue in Background" action in the chat terminal tool progress part to improve visual consistency. Test the change by verifying the updated icon appears correctly in the relevant UI component.

