### PR TITLE
workspace trust: remove "Trust Parent" button

### DIFF
--- a/src/vs/workbench/contrib/workspace/browser/workspaceTrustEditor.ts
+++ b/src/vs/workbench/contrib/workspace/browser/workspaceTrustEditor.ts
@@ -34,7 +34,7 @@ import { isVirtualResource, isVirtualWorkspace } from '../../../../platform/work
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { asCssVariable, buttonBackground, buttonSecondaryBackground, editorErrorForeground } from '../../../../platform/theme/common/colorRegistry.js';
-import { ISingleFolderWorkspaceIdentifier, IWorkspaceContextService, toWorkspaceIdentifier, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
+import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { IWorkspaceTrustManagementService } from '../../../../platform/workspace/common/workspaceTrust.js';
@@ -58,7 +58,6 @@ import { defaultButtonStyles, defaultInputBoxStyles } from '../../../../platform
 import { isMacintosh } from '../../../../base/common/platform.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { ResolvedKeybinding } from '../../../../base/common/keybindings.js';
-import { basename, dirname } from '../../../../base/common/resources.js';
 import { IEditorGroup } from '../../../services/editor/common/editorGroupsService.js';
 
 export const shieldIcon = registerIcon('workspace-trust-banner', Codicon.shield, localize('shieldIcon', 'Icon for workspace trust ion the banner.'));
@@ -753,10 +752,6 @@ export class WorkspaceTrustEditor extends EditorPane {
 				if (this.workspaceTrustManagementService.canSetWorkspaceTrust()) {
 					this.workspaceTrustManagementService.setWorkspaceTrust(!this.workspaceTrustManagementService.isWorkspaceTrusted());
 				}
-			} else if (event.equals(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Enter)) {
-				if (this.workspaceTrustManagementService.canSetParentFolderTrust()) {
-					this.workspaceTrustManagementService.setParentFolderTrust(true);
-				}
 			}
 		}));
 	}
@@ -1057,20 +1052,6 @@ export class WorkspaceTrustEditor extends EditorPane {
 		}));
 
 		const trustActions = [{ action: trustAction, keybinding: this.keybindingService.resolveUserBinding(isMacintosh ? 'Cmd+Enter' : 'Ctrl+Enter')[0] }];
-
-		if (this.workspaceTrustManagementService.canSetParentFolderTrust()) {
-			const workspaceIdentifier = toWorkspaceIdentifier(this.workspaceService.getWorkspace()) as ISingleFolderWorkspaceIdentifier;
-			const name = basename(dirname(workspaceIdentifier.uri));
-
-			const trustMessageElement = append(parent, $('.trust-message-box'));
-			trustMessageElement.innerText = localize('trustMessage', "Trust the authors of all files in the current folder or its parent '{0}'.", name);
-
-			const trustParentAction = this.rerenderDisposables.add(new Action('workspace.trust.button.action.grantParent', localize('trustParentButton', "Trust Parent"), undefined, true, async () => {
-				await this.workspaceTrustManagementService.setParentFolderTrust(true);
-			}));
-
-			trustActions.push({ action: trustParentAction, keybinding: this.keybindingService.resolveUserBinding(isMacintosh ? 'Cmd+Shift+Enter' : 'Ctrl+Shift+Enter')[0] });
-		}
 
 		this.createButtonRow(parent, trustActions);
 	}


### PR DESCRIPTION
The button was located and styled identically to the "Trust [this folder]" button, but "Trust Parent" has far wider impact, risk, and future implications that are likely not immediately obvious.

Even with this gone, a user can always explicitly add an arbitrary directory path below the fold.

Other options I considered:

1. styling: differentiate the button by making it a non-primary action color (e.g. consider red or grey instead)
2. warning: adding a modal/warning when you click "Trust Parent"

