### PR TITLE
AH: refine session title from first turn context

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
+++ b/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
@@ -9,11 +9,18 @@ import { URI } from '../../../base/common/uri.js';
 import { ILogService } from '../../log/common/log.js';
 import { ISessionDataService } from '../common/sessionDataService.js';
 import { ActionType } from '../common/state/sessionActions.js';
-import { isAhpChatChannel, isDefaultChatUri, type URI as ProtocolURI } from '../common/state/sessionState.js';
+import { isAhpChatChannel, isDefaultChatUri, ResponsePartKind, type ResponsePart, type Turn, type URI as ProtocolURI } from '../common/state/sessionState.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
 import { ICopilotApiService, type ICopilotUtilityChatMessage } from './shared/copilotApiService.js';
 
 const MAX_TITLE_LENGTH = 200;
+
+/**
+ * Soft upper bound, in characters, for the first-turn context fed to the
+ * utility model when refining a session title. Sized to stay well within the
+ * small model's context window while leaving room for the prompt scaffolding.
+ */
+const MAX_TITLE_CONTEXT_CHARS = 20000;
 
 export interface IAgentHostSessionTitleControllerOptions {
 	readonly sessionDataService: ISessionDataService;
@@ -24,6 +31,14 @@ export interface IAgentHostSessionTitleControllerOptions {
 export class AgentHostSessionTitleController extends Disposable {
 
 	private readonly _titleGenerationCancellationSources = new Map<ProtocolURI, CancellationTokenSource>();
+
+	/**
+	 * The most recent title this controller applied for a given session/chat
+	 * key. Used to detect whether the title was changed (e.g. a manual
+	 * `/rename` or user edit) since we last set it, so we never clobber a
+	 * deliberate title with an auto-generated one.
+	 */
+	private readonly _lastAppliedTitle = new Map<ProtocolURI, string>();
 
 	constructor(
 		private readonly _stateManager: AgentHostStateManager,
@@ -47,14 +62,15 @@ export class AgentHostSessionTitleController extends Disposable {
 			if (!chatState || chatState.turns.length !== 0 || chatState.title) {
 				return;
 			}
-			const apply = (title: string) => this._stateManager.updateChatTitle(channel, chatChannel, title);
+			const apply = (title: string) => this._applyTitle(chatChannel, title, t => this._stateManager.updateChatTitle(channel, chatChannel, t));
 			apply(fallbackTitle);
 			this._generateTitleSoon(
 				chatChannel,
 				userPrompt,
+				false,
 				fallbackTitle,
 				apply,
-				() => this._stateManager.getChatState(chatChannel)?.title === fallbackTitle,
+				() => this._stateManager.getChatState(chatChannel)?.title === this._lastAppliedTitle.get(chatChannel),
 				title => this._persistSessionFlag(channel, `customChatTitle:${chatChannel}`, title),
 			);
 			return;
@@ -65,19 +81,93 @@ export class AgentHostSessionTitleController extends Disposable {
 			return;
 		}
 
-		const apply = (title: string) => this._stateManager.dispatchServerAction(channel, {
+		const apply = (title: string) => this._applyTitle(channel, title, t => this._stateManager.dispatchServerAction(channel, {
 			type: ActionType.SessionTitleChanged,
-			title,
-		});
+			title: t,
+		}));
 		apply(fallbackTitle);
 		this._generateTitleSoon(
 			channel,
 			userPrompt,
+			false,
 			fallbackTitle,
 			apply,
-			() => this._stateManager.getSessionState(channel)?.summary.title === fallbackTitle,
+			() => this._stateManager.getSessionState(channel)?.summary.title === this._lastAppliedTitle.get(channel),
 			title => this._persistSessionFlag(channel, 'customTitle', title),
 		);
+	}
+
+	/**
+	 * Re-generates the title once the first turn has completed, this time
+	 * using the full first-turn context (the user request plus the agent's
+	 * textual response) rather than just the opening message. This only runs
+	 * for the very first turn and only when the current title is still the one
+	 * this controller last applied — a manual `/rename`, a user edit, or a
+	 * forked session's inherited title all suppress it.
+	 *
+	 * Only normal text response parts are considered (tool calls, reasoning,
+	 * and other parts are ignored). If the context still exceeds the budget
+	 * the middle is removed (marked with `...`). The user's first request is
+	 * always preserved.
+	 */
+	refineTitleFromFirstTurn(channel: ProtocolURI, chatChannel?: ProtocolURI): void {
+		const isAdditionalChat = !!chatChannel && isAhpChatChannel(chatChannel) && !isDefaultChatUri(chatChannel);
+		if (isAdditionalChat) {
+			const chatState = this._stateManager.getChatState(chatChannel);
+			if (!chatState || chatState.turns.length !== 1) {
+				return;
+			}
+			const lastApplied = this._lastAppliedTitle.get(chatChannel);
+			if (lastApplied === undefined || chatState.title !== lastApplied) {
+				return;
+			}
+			const context = this._buildFirstTurnContext(chatState.turns[0]);
+			if (!context) {
+				return;
+			}
+			const apply = (title: string) => this._applyTitle(chatChannel, title, t => this._stateManager.updateChatTitle(channel, chatChannel, t));
+			this._generateTitleSoon(
+				chatChannel,
+				context,
+				true,
+				lastApplied,
+				apply,
+				() => this._stateManager.getChatState(chatChannel)?.title === this._lastAppliedTitle.get(chatChannel),
+				title => this._persistSessionFlag(channel, `customChatTitle:${chatChannel}`, title),
+			);
+			return;
+		}
+
+		const state = this._stateManager.getSessionState(channel);
+		if (!state || state.turns.length !== 1) {
+			return;
+		}
+		const lastApplied = this._lastAppliedTitle.get(channel);
+		if (lastApplied === undefined || state.summary.title !== lastApplied) {
+			return;
+		}
+		const context = this._buildFirstTurnContext(state.turns[0]);
+		if (!context) {
+			return;
+		}
+		const apply = (title: string) => this._applyTitle(channel, title, t => this._stateManager.dispatchServerAction(channel, {
+			type: ActionType.SessionTitleChanged,
+			title: t,
+		}));
+		this._generateTitleSoon(
+			channel,
+			context,
+			true,
+			lastApplied,
+			apply,
+			() => this._stateManager.getSessionState(channel)?.summary.title === this._lastAppliedTitle.get(channel),
+			title => this._persistSessionFlag(channel, 'customTitle', title),
+		);
+	}
+
+	private _applyTitle(key: ProtocolURI, title: string, dispatch: (title: string) => void): void {
+		this._lastAppliedTitle.set(key, title);
+		dispatch(title);
 	}
 
 	cancelTitleGeneration(session: ProtocolURI): void {
@@ -86,7 +176,8 @@ export class AgentHostSessionTitleController extends Disposable {
 
 	private _generateTitleSoon(
 		key: ProtocolURI,
-		userPrompt: string,
+		promptContent: string,
+		isConversation: boolean,
 		fallbackTitle: string,
 		apply: (title: string) => void,
 		currentTitleMatchesFallback: () => boolean,
@@ -95,7 +186,7 @@ export class AgentHostSessionTitleController extends Disposable {
 		this._cancelTitleGeneration(key);
 		const source = new CancellationTokenSource();
 		this._titleGenerationCancellationSources.set(key, source);
-		void this._generateTitle(key, userPrompt, fallbackTitle, apply, currentTitleMatchesFallback, persist, source.token).catch(err => {
+		void this._generateTitle(key, promptContent, isConversation, fallbackTitle, apply, currentTitleMatchesFallback, persist, source.token).catch(err => {
 			if (!source.token.isCancellationRequested) {
 				this._logService.warn(`[AgentHostSessionTitleController] Failed to apply generated title for ${key}`, err);
 			}
@@ -109,14 +200,15 @@ export class AgentHostSessionTitleController extends Disposable {
 
 	private async _generateTitle(
 		key: ProtocolURI,
-		userPrompt: string,
+		promptContent: string,
+		isConversation: boolean,
 		fallbackTitle: string,
 		apply: (title: string) => void,
 		currentTitleMatchesFallback: () => boolean,
 		persist: (title: string) => void,
 		token: CancellationToken,
 	): Promise<void> {
-		const generatedTitle = await this._generateTitleFromPrompt(userPrompt, token);
+		const generatedTitle = await this._generateTitleFromPrompt(promptContent, isConversation, token);
 		if (token.isCancellationRequested || !generatedTitle) {
 			return;
 		}
@@ -131,7 +223,7 @@ export class AgentHostSessionTitleController extends Disposable {
 		persist(generatedTitle);
 	}
 
-	private async _generateTitleFromPrompt(userPrompt: string, token: CancellationToken): Promise<string | undefined> {
+	private async _generateTitleFromPrompt(promptContent: string, isConversation: boolean, token: CancellationToken): Promise<string | undefined> {
 		if (token.isCancellationRequested) {
 			return undefined;
 		}
@@ -146,7 +238,7 @@ export class AgentHostSessionTitleController extends Disposable {
 		const cancellationListener = token.onCancellationRequested(() => abortController.abort());
 		try {
 			const rawTitle = await copilotApiService.utilityChatCompletion(githubToken, {
-				messages: this._buildTitlePrompt(userPrompt),
+				messages: this._buildTitlePrompt(promptContent, isConversation),
 			}, {
 				signal: abortController.signal,
 			});
@@ -162,13 +254,16 @@ export class AgentHostSessionTitleController extends Disposable {
 		}
 	}
 
-	private _buildTitlePrompt(userPrompt: string): ICopilotUtilityChatMessage[] {
+	private _buildTitlePrompt(promptContent: string, isConversation: boolean): ICopilotUtilityChatMessage[] {
+		const userInstruction = isConversation
+			? `Please write a brief title for the following conversation:\n\n${promptContent}`
+			: `Please write a brief title for the following request:\n\n${promptContent}`;
 		return [
 			{
 				role: 'system',
 				content: [
 					'You are an expert in crafting ultra-compact titles for chatbot conversations.',
-					'You are presented with a chat request, and you reply with only a brief title that captures the main topic of that request.',
+					'You are presented with a chat request or conversation, and you reply with only a brief title that captures the main topic.',
 					'Write the title in sentence case, not title case.',
 					'Preserve product names, abbreviations, code symbols, and proper nouns.',
 					'Aim for 3-6 words. Prefer the shortest accurate title.',
@@ -180,7 +275,7 @@ export class AgentHostSessionTitleController extends Disposable {
 			},
 			{
 				role: 'user',
-				content: `Please write a brief title for the following request:\n\n${userPrompt}`,
+				content: userInstruction,
 			},
 		];
 	}
@@ -198,6 +293,68 @@ export class AgentHostSessionTitleController extends Disposable {
 			return undefined;
 		}
 		return title.slice(0, MAX_TITLE_LENGTH);
+	}
+
+	/**
+	 * Builds the first-turn context string for title refinement. The user's
+	 * request is always kept (truncated in the middle only if it alone exceeds
+	 * half the budget). Only normal text (markdown) response parts are
+	 * considered — tool calls, reasoning, and other parts are ignored. If the
+	 * combined text is over budget, the middle of the response is removed.
+	 *
+	 * @returns the context string, or `undefined` when the turn has no text
+	 * response worth refining from (the opening message already produced a
+	 * title in that case).
+	 */
+	private _buildFirstTurnContext(turn: Turn): string | undefined {
+		const response = this._renderResponseText(turn.responseParts);
+		if (!response) {
+			return undefined;
+		}
+
+		const userBudget = Math.floor(MAX_TITLE_CONTEXT_CHARS / 2);
+		let userRequest = turn.message.text.trim();
+		if (userRequest.length > userBudget) {
+			userRequest = this._truncateMiddle(userRequest, userBudget);
+		}
+		const userBlock = `User request:\n${userRequest}`;
+		const responseLabel = '\n\nAgent response:\n';
+
+		const responseBudget = Math.max(0, MAX_TITLE_CONTEXT_CHARS - userBlock.length - responseLabel.length);
+		const trimmedResponse = response.length > responseBudget ? this._truncateMiddle(response, responseBudget) : response;
+
+		return trimmedResponse ? `${userBlock}${responseLabel}${trimmedResponse}` : userBlock;
+	}
+
+	private _renderResponseText(parts: readonly ResponsePart[]): string {
+		const segments: string[] = [];
+		for (const part of parts) {
+			if (part.kind === ResponsePartKind.Markdown) {
+				const text = part.content.trim();
+				if (text) {
+					segments.push(text);
+				}
+			}
+		}
+		return segments.join('\n\n');
+	}
+
+	/**
+	 * Truncates `text` to at most `maxChars` characters by removing the middle
+	 * and inserting a `...` marker, preserving the start and end.
+	 */
+	private _truncateMiddle(text: string, maxChars: number): string {
+		if (text.length <= maxChars) {
+			return text;
+		}
+		const marker = '\n...\n';
+		if (maxChars <= marker.length) {
+			return text.slice(0, maxChars);
+		}
+		const keep = maxChars - marker.length;
+		const head = Math.ceil(keep / 2);
+		const tail = keep - head;
+		return `${text.slice(0, head)}${marker}${text.slice(text.length - tail)}`;
 	}
 
 	private _persistSessionFlag(session: ProtocolURI, key: string, value: string): void {
@@ -223,6 +380,7 @@ export class AgentHostSessionTitleController extends Disposable {
 			source.dispose(true);
 		}
 		this._titleGenerationCancellationSources.clear();
+		this._lastAppliedTitle.clear();
 		super.dispose();
 	}
 }

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -496,6 +496,14 @@ export class AgentSideEffects extends Disposable {
 		}
 		this._tryConsumeNextQueuedMessage(sessionKey);
 		this._options.onTurnComplete(sessionScope);
+
+		// After the first turn completes, refine the auto-generated title using
+		// the full first-turn context (request + response). No-op for later
+		// turns or when the title has since been changed. `sessionKey` may be an
+		// additional chat channel; route it as `chatChannel` so the refinement
+		// targets that chat's title, mirroring `seedTitleFromFirstMessage`.
+		const titleChatChannel = isAhpChatChannel(sessionKey) && !isDefaultChatUri(sessionKey) ? sessionKey : undefined;
+		this._titleController.refineTitleFromFirstTurn(sessionScope, titleChatChannel);
 	}
 
 	private _describeSignal(signal: AgentSignal): string {

--- a/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
@@ -13,7 +13,7 @@ import { NullLogService } from '../../../log/common/log.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 import { AgentHostSessionTitleController } from '../../node/agentHostSessionTitleController.js';
 import { ActionType } from '../../common/state/sessionActions.js';
-import { SessionStatus, type SessionSummary } from '../../common/state/sessionState.js';
+import { MessageKind, ResponsePartKind, SessionStatus, ToolCallConfirmationReason, ToolCallStatus, TurnState, type ResponsePart, type SessionSummary, type ToolCallCompletedState, type Turn } from '../../common/state/sessionState.js';
 import { type ICopilotApiService, type ICopilotApiServiceRequestOptions, type ICopilotUtilityChatCompletionRequest } from '../../node/shared/copilotApiService.js';
 import { createSessionDataService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
 
@@ -183,6 +183,144 @@ suite('AgentHostSessionTitleController', () => {
 			title: 'Forked: Source title',
 			titles: [],
 			persistedTitle: undefined,
+		});
+	});
+
+	function textPart(content: string): ResponsePart {
+		return { kind: ResponsePartKind.Markdown, id: 'm1', content };
+	}
+
+	function reasoningPart(content: string): ResponsePart {
+		return { kind: ResponsePartKind.Reasoning, id: 'r1', content };
+	}
+
+	function toolCallPart(displayName: string, invocationMessage: string): ResponsePart {
+		const toolCall: ToolCallCompletedState = {
+			status: ToolCallStatus.Completed,
+			toolCallId: 'tc1',
+			toolName: 'tool',
+			displayName,
+			invocationMessage,
+			success: true,
+			pastTenseMessage: 'done',
+			confirmed: ToolCallConfirmationReason.NotNeeded,
+		};
+		return { kind: ResponsePartKind.ToolCall, toolCall };
+	}
+
+	function firstTurn(text: string, responseParts: ResponsePart[]): Turn {
+		return {
+			id: 'turn-1',
+			message: { text, origin: { kind: MessageKind.User } },
+			responseParts,
+			usage: undefined,
+			state: TurnState.Complete,
+		};
+	}
+
+	async function seedFirstTitle(controller: AgentHostSessionTitleController, copilotApiService: TestCopilotApiService, db: TestSessionDatabase, session: URI, userPrompt: string, title: string): Promise<void> {
+		copilotApiService.response = title;
+		controller.seedTitleFromFirstMessage(session.toString(), userPrompt);
+		await waitForCondition(async () => await db.getMetadata('customTitle') === title, 'first title should be persisted');
+	}
+
+	test('refineTitleFromFirstTurn regenerates the title from the first-turn context', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		const { controller, stateManager, session, db } = setup(copilotApiService);
+		await seedFirstTitle(controller, copilotApiService, db, session, 'Add dark mode toggle', 'First title');
+
+		copilotApiService.response = 'Dark mode setting';
+		stateManager.seedDefaultChatTurns(session.toString(), [firstTurn('Add dark mode toggle', [textPart('Implemented the toggle in the settings editor.')])]);
+		controller.refineTitleFromFirstTurn(session.toString());
+		await waitForCondition(async () => await db.getMetadata('customTitle') === 'Dark mode setting', 'refined title should be persisted');
+
+		const lastCall = copilotApiService.utilityCalls[copilotApiService.utilityCalls.length - 1];
+		const userMessage = lastCall.request.messages.find(message => message.role === 'user')?.content ?? '';
+		assert.deepStrictEqual({
+			title: stateManager.getSessionState(session.toString())?.summary.title,
+			persistedTitle: await db.getMetadata('customTitle'),
+			mentionsConversation: userMessage.includes('conversation'),
+			includesUserRequest: userMessage.includes('Add dark mode toggle'),
+			includesResponse: userMessage.includes('Implemented the toggle in the settings editor.'),
+		}, {
+			title: 'Dark mode setting',
+			persistedTitle: 'Dark mode setting',
+			mentionsConversation: true,
+			includesUserRequest: true,
+			includesResponse: true,
+		});
+	});
+
+	test('refineTitleFromFirstTurn does not clobber a title changed in the meantime', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		const { controller, stateManager, session, db } = setup(copilotApiService);
+		await seedFirstTitle(controller, copilotApiService, db, session, 'Add dark mode toggle', 'First title');
+		const callsAfterSeed = copilotApiService.utilityCalls.length;
+
+		stateManager.dispatchServerAction(session.toString(), { type: ActionType.SessionTitleChanged, title: 'Manual title' });
+		stateManager.seedDefaultChatTurns(session.toString(), [firstTurn('Add dark mode toggle', [textPart('Implemented the toggle.')])]);
+		controller.refineTitleFromFirstTurn(session.toString());
+		await Promise.resolve();
+
+		assert.deepStrictEqual({
+			calls: copilotApiService.utilityCalls.length,
+			title: stateManager.getSessionState(session.toString())?.summary.title,
+		}, {
+			calls: callsAfterSeed,
+			title: 'Manual title',
+		});
+	});
+
+	test('refineTitleFromFirstTurn ignores tool calls and reasoning, keeping only text parts', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		const { controller, stateManager, session, db } = setup(copilotApiService);
+		await seedFirstTitle(controller, copilotApiService, db, session, 'Add dark mode toggle', 'First title');
+
+		copilotApiService.response = 'Refined title';
+		stateManager.seedDefaultChatTurns(session.toString(), [firstTurn('Add dark mode toggle', [
+			reasoningPart('Thinking about THINKING_MARKER the approach'),
+			toolCallPart('SearchTool', 'searched the workspace TOOL_MARKER'),
+			textPart('Added the toggle TEXT_MARKER to settings.'),
+		])]);
+		controller.refineTitleFromFirstTurn(session.toString());
+		await waitForCondition(() => copilotApiService.utilityCalls.length >= 2, 'refine should issue a utility call');
+
+		const lastCall = copilotApiService.utilityCalls[copilotApiService.utilityCalls.length - 1];
+		const userMessage = lastCall.request.messages.find(message => message.role === 'user')?.content ?? '';
+		assert.deepStrictEqual({
+			includesText: userMessage.includes('TEXT_MARKER'),
+			excludesReasoning: !userMessage.includes('THINKING_MARKER'),
+			excludesToolCall: !userMessage.includes('TOOL_MARKER') && !userMessage.includes('SearchTool'),
+		}, {
+			includesText: true,
+			excludesReasoning: true,
+			excludesToolCall: true,
+		});
+	});
+
+	test('refineTitleFromFirstTurn truncates the middle of an oversized text response', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		const { controller, stateManager, session, db } = setup(copilotApiService);
+		await seedFirstTitle(controller, copilotApiService, db, session, 'Add dark mode toggle', 'First title');
+
+		copilotApiService.response = 'Refined title';
+		const hugeResponse = 'A'.repeat(15000) + ' MIDDLE_MARKER ' + 'B'.repeat(15000);
+		stateManager.seedDefaultChatTurns(session.toString(), [firstTurn('Add dark mode toggle', [textPart(hugeResponse)])]);
+		controller.refineTitleFromFirstTurn(session.toString());
+		await waitForCondition(() => copilotApiService.utilityCalls.length >= 2, 'refine should issue a utility call');
+
+		const lastCall = copilotApiService.utilityCalls[copilotApiService.utilityCalls.length - 1];
+		const userMessage = lastCall.request.messages.find(message => message.role === 'user')?.content ?? '';
+		assert.deepStrictEqual({
+			withinBudget: userMessage.length <= 20200,
+			middleTruncated: userMessage.includes('...') && !userMessage.includes('MIDDLE_MARKER'),
+			includesUserRequest: userMessage.includes('Add dark mode toggle'),
+			keepsHeadAndTail: userMessage.includes('AAAA') && userMessage.includes('BBBB'),
+		}, {
+			withinBudget: true,
+			middleTruncated: true,
+			includesUserRequest: true,
+			keepsHeadAndTail: true,
 		});
 	});
 });


### PR DESCRIPTION
AH: refine session title from first turn context

## What

After the first turn of an agent-host session completes, the auto-generated
session title is regenerated using the full first-turn context (the user's
request plus the agent's text response) instead of just the opening message.

This builds on the existing first-message title seeding: the title is still
seeded immediately from the first user message, then upgraded once the first
turn finishes and there is real conversation context to summarize.

## Details

- New `AgentHostSessionTitleController.refineTitleFromFirstTurn(channel, chatChannel?)`,
  invoked from `AgentSideEffects._runTurnCompleteSideEffects` on turn complete.
- Runs only for the very first turn, and only when the current title still
  matches the one this controller last applied — a manual `/rename`, a user
  edit, or a forked session's inherited title all suppress it (tracked via a
  new `_lastAppliedTitle` map).
- Context building:
  - The user's first request is always included.
  - Only normal markdown text response parts are considered — tool calls,
    reasoning/thinking, content refs, and system notifications are ignored.
  - The context is capped at 20,000 characters; oversized text has its middle
    removed and replaced with an ellipsis marker, preserving head and tail.
- Uses the same utility completion path as the existing title generation
  (gpt-4o-mini), with the prompt phrased for a "conversation" when refining.

## Testing

- `npm run typecheck-client` passes; ESLint clean on changed files.
- Added unit tests in `agentHostSessionTitleController.test.ts` covering:
  regeneration from first-turn context, no-clobber after a manual rename,
  text-only filtering (tool calls / reasoning ignored), and middle-truncation
  of oversized responses.

Note: the in-repo Electron unit-test runner could not be executed locally
because the full `out/` build is currently blocked by a missing `esbuild` in
the extensions' `node_modules` (a pre-existing environment gap). The
truncation/context algorithm was additionally validated with a standalone
reproduction.
