### PR TITLE
Normalize terminal file write paths before workspace checks

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
@@ -6,6 +6,7 @@
 import { Disposable } from '../../../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../../../base/common/uri.js';
 import { win32, posix } from '../../../../../../../base/common/path.js';
+import { extUri, normalizePath } from '../../../../../../../base/common/resources.js';
 import { localize } from '../../../../../../../nls.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { IWorkspaceContextService } from '../../../../../../../platform/workspace/common/workspace.js';
@@ -144,7 +145,7 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 									break;
 								}
 							}
-							const fileUri = URI.isUri(fileWrite) ? fileWrite : URI.file(fileWrite);
+							const fileUri = normalizePath(URI.isUri(fileWrite) ? fileWrite : URI.file(fileWrite));
 							// TODO: Handle command substitutions/complex destinations properly https://github.com/microsoft/vscode/issues/274167
 							// TODO: Handle environment variables properly https://github.com/microsoft/vscode/issues/274166
 							// `~` catches POSIX tilde expansion (e.g. `~/foo`) and `%` catches Windows
@@ -160,7 +161,7 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 
 							const isInsideWorkspace = workspaceFolders.some(folder =>
 								folder.uri.scheme === fileUri.scheme &&
-								(fileUri.path.startsWith(folder.uri.path + '/') || fileUri.path === folder.uri.path)
+								extUri.isEqualOrParent(fileUri, folder.uri)
 							);
 							if (!isInsideWorkspace) {
 								// Allow writes to OS temp locations when the user has opted into

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
@@ -110,6 +110,9 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			test('absolute path - /home - block', () => t('echo hello > /home/user/file.txt', 'outsideWorkspace', false, 1));
 			test('absolute path - root - block', () => t('echo hello > /file.txt', 'outsideWorkspace', false, 1));
 			test('absolute path - /dev/null - allow (null device)', () => t('echo hello > /dev/null', 'outsideWorkspace', true, 1));
+			test('absolute path traversal outside workspace - block', () => t('echo hello > /workspace/project/test/../../../tmp/file.txt', 'outsideWorkspace', false, 1));
+			test('absolute path traversal to settings path outside workspace - block', () => t('echo "{}" > "/workspace/project/test/../../../../.config/Code/User/settings.json"', 'outsideWorkspace', false, 1));
+			test('absolute path traversal that remains inside workspace - allow', () => t('echo hello > /workspace/project/test/../file.txt', 'outsideWorkspace', true, 1));
 			test('triple-quoted absolute path outside workspace - block', () => t('echo hello > \'\'\'/tmp/file.txt\'\'\'', 'outsideWorkspace', false, 1));
 			test('triple-quoted settings path outside workspace - block', () => t('echo "{}" > \'\'\'/home/user/.config/Code/User/settings.json\'\'\'', 'outsideWorkspace', false, 1));
 			test('triple double-quoted absolute path outside workspace - block', () => t('echo hello > """/tmp/file.txt"""', 'outsideWorkspace', false, 1));
@@ -575,6 +578,7 @@ suite('CommandLineFileWriteAnalyzer', () => {
 		test('quoted absolute path to settings.json - block', () => t('echo hello > "/home/user/.vscode/settings.json"', false, 1));
 		test('unquoted absolute path inside remote workspace - allow', () => t('echo hello > /home/user/workspace/file.txt', true, 1));
 		test('unquoted absolute path outside remote workspace - block', () => t('echo hello > /home/user/other/file.txt', false, 1));
+		test('unquoted absolute path traversal outside remote workspace - block', () => t('echo hello > /home/user/workspace/test/../../other/file.txt', false, 1));
 		test('relative path in remote workspace - allow', () => t('echo hello > file.txt', true, 1));
 		test('relative path with subdirectory in remote workspace - allow', () => t('echo hello > subdir/file.txt', true, 1));
 	});

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
@@ -305,6 +305,9 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			test('absolute path - C: drive - block', () => t('Write-Host "hello" > C:\\temp\\file.txt', 'outsideWorkspace', false, 1));
 			test('absolute path - D: drive - block', () => t('Write-Host "hello" > D:\\data\\config.txt', 'outsideWorkspace', false, 1));
 			test('absolute path - different drive than workspace - block', () => t('Write-Host "hello" > E:\\external\\file.txt', 'outsideWorkspace', false, 1));
+			test('absolute path traversal outside workspace - block', () => t('Write-Host "hello" > C:\\workspace\\project\\test\\..\\..\\other\\file.txt', 'outsideWorkspace', false, 1));
+			test('absolute path traversal to settings path outside workspace - block', () => t('Write-Host "{}" > C:\\workspace\\project\\test\\..\\..\\..\\Users\\user\\AppData\\Roaming\\Code\\User\\settings.json', 'outsideWorkspace', false, 1));
+			test('absolute path traversal that remains inside workspace - allow', () => t('Write-Host "hello" > C:\\workspace\\project\\test\\..\\file.txt', 'outsideWorkspace', true, 1));
 
 			// Absolute paths - UNC paths
 			test('absolute path - UNC path - block', () => t('Write-Host "hello" > \\\\server\\share\\file.txt', 'outsideWorkspace', false, 1));


### PR DESCRIPTION
msrc 117529 

- Normalize detected terminal file-write paths before workspace containment checks.
- Use URI-aware parent checks instead of raw path prefix checks for detected file writes.
- Preserve existing behavior for paths that normalize inside the workspace.
- Add regression coverage for traversal paths that escape the workspace, including remote-workspace coverage.
- Add coverage that triple-quoted temp writes still follow the session auto-approval policy.

-----------------------------------------
Inspirations from:

- Path canonicalization uses [`ExtUri.normalizePath`](https://github.com/microsoft/vscode/blob/0d229e74bf6743ae04c07c9989f4b423ef654567/src/vs/base/common/resources.ts#L220-L233).
- Workspace containment uses [`ExtUri.isEqualOrParent`](https://github.com/microsoft/vscode/blob/0d229e74bf6743ae04c07c9989f4b423ef654567/src/vs/base/common/resources.ts#L171-L181).
- The traversal containment behavior is covered semantically by [`isEqualOrParent handles ../`](https://github.com/microsoft/vscode/blob/0d229e74bf6743ae04c07c9989f4b423ef654567/src/vs/base/test/common/resources.test.ts#L436-L440).