### PR TITLE
Update @vscode/codicons to version 0.0.46-20 and add new icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@microsoft/mxc-sdk": "0.6.0",
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
-        "@vscode/codicons": "^0.0.46-18",
+        "@vscode/codicons": "^0.0.46-20",
         "@vscode/copilot-api": "^0.4.2",
         "@vscode/deviceid": "^0.1.1",
         "@vscode/diff": "0.0.2-7",
@@ -3663,9 +3663,9 @@
       }
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.46-18",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-18.tgz",
-      "integrity": "sha512-QjEdxo7jKiIZ1dwP4D2uixrsrqO/MknXRTjZn5EddAK3hoiBNlzxHFu9p2+1grSXNwhwmjpANKmtOYo1r7wpJA==",
+      "version": "0.0.46-20",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-20.tgz",
+      "integrity": "sha512-o5OF7Agy3TBp2R3AXRWeL74MjEWXOLi8fp/HUvFZ/coXq5V9wEOC1okYadc1hZGNLcSmI9NXqYu057sldqbGiA==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/component-explorer": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@microsoft/mxc-sdk": "0.6.0",
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
-    "@vscode/codicons": "^0.0.46-18",
+    "@vscode/codicons": "^0.0.46-20",
     "@vscode/copilot-api": "^0.4.2",
     "@vscode/deviceid": "^0.1.1",
     "@vscode/diff": "0.0.2-7",

--- a/remote/web/package-lock.json
+++ b/remote/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@vscode/codicons": "^0.0.46-18",
+        "@vscode/codicons": "^0.0.46-20",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/tree-sitter-wasm": "^0.3.1",
         "@vscode/vscode-languagedetection": "1.0.23",
@@ -73,9 +73,9 @@
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.46-18",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-18.tgz",
-      "integrity": "sha512-QjEdxo7jKiIZ1dwP4D2uixrsrqO/MknXRTjZn5EddAK3hoiBNlzxHFu9p2+1grSXNwhwmjpANKmtOYo1r7wpJA==",
+      "version": "0.0.46-20",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-20.tgz",
+      "integrity": "sha512-o5OF7Agy3TBp2R3AXRWeL74MjEWXOLi8fp/HUvFZ/coXq5V9wEOC1okYadc1hZGNLcSmI9NXqYu057sldqbGiA==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/iconv-lite-umd": {

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@vscode/codicons": "^0.0.46-18",
+    "@vscode/codicons": "^0.0.46-20",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/tree-sitter-wasm": "^0.3.1",
     "@vscode/vscode-languagedetection": "1.0.23",

--- a/src/vs/base/common/codiconsLibrary.ts
+++ b/src/vs/base/common/codiconsLibrary.ts
@@ -722,4 +722,9 @@ export const codiconsLibrary = {
 	runCompact: register('run-compact', 0xecc4),
 	gitPullRequestComment: register('git-pull-request-comment', 0xecc5),
 	gitPullRequestError: register('git-pull-request-error', 0xecc6),
+	rightPanelHide: register('right-panel-hide', 0xecc7),
+	rightPanelShow: register('right-panel-show', 0xecc8),
+	vscodeInsidersOutline: register('vscode-insiders-outline', 0xecc9),
+	vscodeOutline: register('vscode-outline', 0xecca),
+	voiceMode: register('voice-mode', 0xeccb),
 } as const;


### PR DESCRIPTION
Upgrade the @vscode/codicons package to version 0.0.46-20, which includes new icons for enhanced functionality. This change ensures the application utilizes the latest icon set. No issues are associated with this update.

