### PR TITLE
Refactor restore-node-modules action for lookup-only functionality

### DIFF
--- a/.github/actions/restore-node-modules/action.yml
+++ b/.github/actions/restore-node-modules/action.yml
@@ -8,9 +8,9 @@ inputs:
   key-args:
     description: Arguments passed to build/azure-pipelines/common/computeNodeModulesCacheKey.ts.
     required: true
-  extract:
-    description: When 'true', the restored archive is extracted into node_modules on a cache hit.
-    default: 'true'
+  lookup-only:
+    description: When 'true', only checks whether the cache entry exists (sets cache-hit) without downloading or extracting the archive. Use for cache-warming jobs that only need the cache-hit result.
+    default: 'false'
 
 outputs:
   cache-hit:
@@ -38,6 +38,7 @@ runs:
       with:
         path: .build/node_modules_cache
         key: "${{ inputs.key-prefix }}-${{ hashFiles('.build/packagelockhash') }}"
+        lookup-only: ${{ inputs.lookup-only }}
 
     - name: Export node_modules cache key
       if: runner.os != 'Windows'
@@ -50,11 +51,11 @@ runs:
       run: Add-Content -Path $env:GITHUB_ENV -Value "NODE_MODULES_CACHE_KEY=${{ steps.restore.outputs.cache-primary-key }}"
 
     - name: Extract node_modules cache
-      if: runner.os != 'Windows' && inputs.extract == 'true' && steps.restore.outputs.cache-hit == 'true'
+      if: runner.os != 'Windows' && inputs.lookup-only != 'true' && steps.restore.outputs.cache-hit == 'true'
       shell: bash
       run: ./.github/workflows/node_modules_cache/cache.sh extract
 
     - name: Extract node_modules cache
-      if: runner.os == 'Windows' && inputs.extract == 'true' && steps.restore.outputs.cache-hit == 'true'
+      if: runner.os == 'Windows' && inputs.lookup-only != 'true' && steps.restore.outputs.cache-hit == 'true'
       shell: pwsh
       run: ./.github/workflows/node_modules_cache/cache.ps1 extract

--- a/.github/workflows/pr-node-modules.yml
+++ b/.github/workflows/pr-node-modules.yml
@@ -267,6 +267,7 @@ jobs:
         with:
           key-prefix: copilot-node_modules-linux
           key-args: "$(node -p process.platform) $(node -p process.arch)"
+          lookup-only: 'true'
 
       - name: Install root dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -299,6 +300,7 @@ jobs:
         with:
           key-prefix: copilot-node_modules-windows
           key-args: "$(node -p process.platform) $(node -p process.arch)"
+          lookup-only: 'true'
 
       - name: Install root dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/pr-node-modules.yml
+++ b/.github/workflows/pr-node-modules.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           key-prefix: node_modules-linux
           key-args: "linux ${{ env.VSCODE_ARCH }} $(node -p process.arch)"
-          extract: 'false'
+          lookup-only: 'true'
 
       - name: Install build dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -160,7 +160,7 @@ jobs:
         with:
           key-prefix: node_modules-macos
           key-args: "darwin ${{ env.VSCODE_ARCH }} $(node -p process.arch)"
-          extract: 'false'
+          lookup-only: 'true'
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -215,7 +215,7 @@ jobs:
         with:
           key-prefix: node_modules-windows
           key-args: "win32 ${{ env.VSCODE_ARCH }} $(node -p process.arch)"
-          extract: 'false'
+          lookup-only: 'true'
 
       - name: Install dependencies
         if: steps.node-modules-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Update the restore-node-modules action to support a 'lookup-only' input, allowing cache checks without downloading or extracting. Adjust workflow files to utilize this new functionality for cache-warming jobs across different operating systems.