### PR TITLE
ci: split Electron PR test jobs into unit/integration and smoke

### DIFF
--- a/.github/workflows/pr-darwin-test.yml
+++ b/.github/workflows/pr-darwin-test.yml
@@ -135,8 +135,7 @@ jobs:
         env:
           DEBUG: "*browser*"
 
-      - name: Build integration tests
-        if: ${{ inputs.unit_and_integration_tests }}
+      - name: Compile extensions for integration tests & smoke tests
         run: |
           set -e
           npm run gulp \
@@ -178,11 +177,7 @@ jobs:
         working-directory: test/smoke
         run: npm run compile
 
-      - name: Compile extensions for smoke tests
-        if: ${{ inputs.smoke_tests }}
-        run: npm run gulp compile-extension-media
-
-      - name: Build Copilot Chat extension for smoke tests
+      - name: Compile Copilot Chat extension for smoke tests
         if: ${{ inputs.smoke_tests }}
         working-directory: extensions/copilot
         run: npm run compile

--- a/.github/workflows/pr-darwin-test.yml
+++ b/.github/workflows/pr-darwin-test.yml
@@ -136,6 +136,7 @@ jobs:
           DEBUG: "*browser*"
 
       - name: Build integration tests
+        if: ${{ inputs.unit_and_integration_tests }}
         run: |
           set -e
           npm run gulp \
@@ -187,9 +188,9 @@ jobs:
         run: npm run compile
 
       - name: Diagnostics before smoke test run
+        if: ${{ inputs.smoke_tests && always() }}
         run: ps -ef
         continue-on-error: true
-        if: always()
 
       - name: 🧪 Run smoke tests (Electron)
         if: ${{ inputs.electron_tests && inputs.smoke_tests }}
@@ -207,9 +208,9 @@ jobs:
         run: npm run smoketest-no-compile -- --remote --tracing
 
       - name: Diagnostics after smoke test run
+        if: ${{ inputs.smoke_tests && always() }}
         run: ps -ef
         continue-on-error: true
-        if: always()
 
       - name: Publish Crash Reports
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr-darwin-test.yml
+++ b/.github/workflows/pr-darwin-test.yml
@@ -13,13 +13,19 @@ on:
       remote_tests:
         type: boolean
         default: false
+      unit_and_integration_tests:
+        type: boolean
+        default: true
+      smoke_tests:
+        type: boolean
+        default: true
 
 jobs:
   macOS-test:
     name: ${{ inputs.job_name }}
     runs-on: macos-14-xlarge
     env:
-      ARTIFACT_NAME: ${{ (inputs.electron_tests && 'electron') || (inputs.browser_tests && 'browser') || (inputs.remote_tests && 'remote') || 'unknown' }}
+      ARTIFACT_NAME: ${{ (inputs.electron_tests && 'electron') || (inputs.browser_tests && 'browser') || (inputs.remote_tests && 'remote') || 'unknown' }}${{ (!inputs.unit_and_integration_tests && inputs.smoke_tests) && '-smoke' || '' }}
       NPM_ARCH: arm64
       VSCODE_ARCH: arm64
     steps:
@@ -113,17 +119,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🧪 Run unit tests (Electron)
-        if: ${{ inputs.electron_tests }}
+        if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
         timeout-minutes: 15
         run: ./scripts/test.sh --tfs "Unit Tests"
 
       - name: 🧪 Run unit tests (node.js)
-        if: ${{ inputs.electron_tests }}
+        if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
         timeout-minutes: 15
         run: npm run test-node
 
       - name: 🧪 Run unit tests (Browser, Webkit)
-        if: ${{ inputs.browser_tests }}
+        if: ${{ inputs.browser_tests && inputs.unit_and_integration_tests }}
         timeout-minutes: 30
         run: npm run test-browser-no-install -- --browser webkit --tfs "Browser Unit Tests"
         env:
@@ -152,28 +158,31 @@ jobs:
             compile-extension:vscode-test-resolver
 
       - name: 🧪 Run integration tests (Electron)
-        if: ${{ inputs.electron_tests }}
+        if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
         timeout-minutes: 20
         run: ./scripts/test-integration.sh --tfs "Integration Tests"
 
       - name: 🧪 Run integration tests (Browser, Webkit)
-        if: ${{ inputs.browser_tests }}
+        if: ${{ inputs.browser_tests && inputs.unit_and_integration_tests }}
         timeout-minutes: 20
         run: ./scripts/test-web-integration.sh --browser webkit
 
       - name: 🧪 Run integration tests (Remote)
-        if: ${{ inputs.remote_tests }}
+        if: ${{ inputs.remote_tests && inputs.unit_and_integration_tests }}
         timeout-minutes: 20
         run: ./scripts/test-remote-integration.sh
 
       - name: Compile smoke tests
+        if: ${{ inputs.smoke_tests }}
         working-directory: test/smoke
         run: npm run compile
 
       - name: Compile extensions for smoke tests
+        if: ${{ inputs.smoke_tests }}
         run: npm run gulp compile-extension-media
 
       - name: Build Copilot Chat extension for smoke tests
+        if: ${{ inputs.smoke_tests }}
         working-directory: extensions/copilot
         run: npm run compile
 
@@ -183,17 +192,17 @@ jobs:
         if: always()
 
       - name: 🧪 Run smoke tests (Electron)
-        if: ${{ inputs.electron_tests }}
+        if: ${{ inputs.electron_tests && inputs.smoke_tests }}
         timeout-minutes: 20
         run: npm run smoketest-no-compile -- --tracing
 
       - name: 🧪 Run smoke tests (Browser, Chromium)
-        if: ${{ inputs.browser_tests }}
+        if: ${{ inputs.browser_tests && inputs.smoke_tests }}
         timeout-minutes: 20
         run: npm run smoketest-no-compile -- --web --tracing --headless
 
       - name: 🧪 Run smoke tests (Remote)
-        if: ${{ inputs.remote_tests }}
+        if: ${{ inputs.remote_tests && inputs.smoke_tests }}
         timeout-minutes: 20
         run: npm run smoketest-no-compile -- --remote --tracing
 

--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -289,8 +289,7 @@ jobs:
         env:
           DEBUG: "*browser*"
 
-      - name: Build integration tests
-        if: ${{ inputs.unit_and_integration_tests }}
+      - name: Compile extensions for integration tests & smoke tests
         run: |
           set -e
           npm run gulp \
@@ -336,9 +335,10 @@ jobs:
         working-directory: test/smoke
         run: npm run compile
 
-      - name: Compile extensions for smoke tests
+      - name: Compile Copilot Chat extension for smoke tests
         if: ${{ inputs.smoke_tests }}
-        run: npm run gulp compile-extension-media
+        working-directory: extensions/copilot
+        run: npm run compile
 
       # Remove the musl-libc Claude Code native binary so the bundled
       # @anthropic-ai/claude-agent-sdk in extensions/copilot falls through to the

--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -13,13 +13,19 @@ on:
       remote_tests:
         type: boolean
         default: false
+      unit_and_integration_tests:
+        type: boolean
+        default: true
+      smoke_tests:
+        type: boolean
+        default: true
 
 jobs:
   linux-test:
     name: ${{ inputs.job_name }}
     runs-on: ubuntu-24.04
     env:
-      ARTIFACT_NAME: ${{ (inputs.electron_tests && 'electron') || (inputs.browser_tests && 'browser') || (inputs.remote_tests && 'remote') || 'unknown' }}
+      ARTIFACT_NAME: ${{ (inputs.electron_tests && 'electron') || (inputs.browser_tests && 'browser') || (inputs.remote_tests && 'remote') || 'unknown' }}${{ (!inputs.unit_and_integration_tests && inputs.smoke_tests) && '-smoke' || '' }}
       NPM_ARCH: x64
       VSCODE_ARCH: x64
     steps:
@@ -265,19 +271,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🧪 Run unit tests (Electron)
-        if: ${{ inputs.electron_tests }}
+        if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
         timeout-minutes: 15
         run: ./scripts/test.sh --tfs "Unit Tests"
         env:
           DISPLAY: ":10"
 
       - name: 🧪 Run unit tests (node.js)
-        if: ${{ inputs.electron_tests }}
+        if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
         timeout-minutes: 15
         run: npm run test-node
 
       - name: 🧪 Run unit tests (Browser, Chromium)
-        if: ${{ inputs.browser_tests }}
+        if: ${{ inputs.browser_tests && inputs.unit_and_integration_tests }}
         timeout-minutes: 30
         run: npm run test-browser-no-install -- --browser chromium --tfs "Browser Unit Tests"
         env:
@@ -309,29 +315,31 @@ jobs:
         run: npm --prefix extensions/copilot run compile
 
       - name: 🧪 Run integration tests (Electron)
-        if: ${{ inputs.electron_tests }}
+        if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
         timeout-minutes: 20
         run: ./scripts/test-integration.sh --tfs "Integration Tests"
         env:
           DISPLAY: ":10"
 
       - name: 🧪 Run integration tests (Browser, Chromium)
-        if: ${{ inputs.browser_tests }}
+        if: ${{ inputs.browser_tests && inputs.unit_and_integration_tests }}
         timeout-minutes: 20
         run: ./scripts/test-web-integration.sh --browser chromium
 
       - name: 🧪 Run integration tests (Remote)
-        if: ${{ inputs.remote_tests }}
+        if: ${{ inputs.remote_tests && inputs.unit_and_integration_tests }}
         timeout-minutes: 20
         run: ./scripts/test-remote-integration.sh
         env:
           DISPLAY: ":10"
 
       - name: Compile smoke tests
+        if: ${{ inputs.smoke_tests }}
         working-directory: test/smoke
         run: npm run compile
 
       - name: Compile extensions for smoke tests
+        if: ${{ inputs.smoke_tests }}
         run: npm run gulp compile-extension-media
 
       # Remove the musl-libc Claude Code native binary so the bundled
@@ -347,6 +355,7 @@ jobs:
       # https://github.com/anthropics/claude-agent-sdk-typescript for the SDK
       # resolution order.
       - name: Remove musl Claude binary on glibc Linux
+        if: ${{ inputs.smoke_tests }}
         run: rm -rf node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl
 
       - name: Diagnostics before smoke test run (processes, max_user_watches, number of opened file handles)
@@ -359,19 +368,19 @@ jobs:
         if: always()
 
       - name: 🧪 Run smoke tests (Electron)
-        if: ${{ inputs.electron_tests }}
+        if: ${{ inputs.electron_tests && inputs.smoke_tests }}
         timeout-minutes: 20
         run: npm run smoketest-no-compile -- --tracing
         env:
           DISPLAY: ":10"
 
       - name: 🧪 Run smoke tests (Browser, Chromium)
-        if: ${{ inputs.browser_tests }}
+        if: ${{ inputs.browser_tests && inputs.smoke_tests }}
         timeout-minutes: 20
         run: npm run smoketest-no-compile -- --web --tracing --headless
 
       - name: 🧪 Run smoke tests (Remote)
-        if: ${{ inputs.remote_tests }}
+        if: ${{ inputs.remote_tests && inputs.smoke_tests }}
         timeout-minutes: 20
         run: npm run smoketest-no-compile -- --remote --tracing
         env:

--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -290,6 +290,7 @@ jobs:
           DEBUG: "*browser*"
 
       - name: Build integration tests
+        if: ${{ inputs.unit_and_integration_tests }}
         run: |
           set -e
           npm run gulp \
@@ -310,9 +311,6 @@ jobs:
             compile-extension:vscode-colorize-tests \
             compile-extension:vscode-colorize-perf-tests \
             compile-extension:vscode-test-resolver
-
-      - name: Compile Copilot extension
-        run: npm --prefix extensions/copilot run compile
 
       - name: 🧪 Run integration tests (Electron)
         if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
@@ -365,7 +363,7 @@ jobs:
           cat /proc/sys/fs/inotify/max_user_watches
           lsof | wc -l
         continue-on-error: true
-        if: always()
+        if: ${{ inputs.smoke_tests && always() }}
 
       - name: 🧪 Run smoke tests (Electron)
         if: ${{ inputs.electron_tests && inputs.smoke_tests }}
@@ -387,13 +385,13 @@ jobs:
           DISPLAY: ":10"
 
       - name: Diagnostics after smoke test run (processes, max_user_watches, number of opened file handles)
+        if: ${{ inputs.smoke_tests && always() }}
         run: |
           set -e
           ps -ef
           cat /proc/sys/fs/inotify/max_user_watches
           lsof | wc -l
         continue-on-error: true
-        if: always()
 
       - name: Publish Crash Reports
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr-win32-test.yml
+++ b/.github/workflows/pr-win32-test.yml
@@ -127,25 +127,26 @@ jobs:
 
       - name: 🧪 Run unit tests (Electron)
         if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
+        timeout-minutes: 15
         shell: pwsh
         run: .\scripts\test.bat --tfs "Unit Tests"
-        timeout-minutes: 15
 
       - name: 🧪 Run unit tests (node.js)
         if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
+        timeout-minutes: 15
         shell: pwsh
         run: npm run test-node
-        timeout-minutes: 15
 
       - name: 🧪 Run unit tests (Browser, Chromium)
         if: ${{ inputs.browser_tests && inputs.unit_and_integration_tests }}
+        timeout-minutes: 20
         shell: pwsh
         run: node test/unit/browser/index.js --browser chromium --tfs "Browser Unit Tests"
         env:
           DEBUG: "*browser*"
-        timeout-minutes: 20
 
       - name: Build integration tests
+        if: ${{ inputs.unit_and_integration_tests }}
         shell: pwsh
         run: |
           . build/azure-pipelines/win32/exec.ps1
@@ -170,45 +171,36 @@ jobs:
             compile-extension:vscode-test-resolver `
           }
 
-      - name: Compile Copilot extension
-        shell: pwsh
-        run: npm --prefix extensions/copilot run compile
-
       - name: Diagnostics before integration test runs
+        if: ${{ inputs.unit_and_integration_tests && always() }}
         shell: pwsh
         run: .\build\azure-pipelines\win32\listprocesses.bat
         continue-on-error: true
-        if: always()
 
       - name: 🧪 Run integration tests (Electron)
         if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
+        timeout-minutes: 20
         shell: pwsh
         run: .\scripts\test-integration.bat --tfs "Integration Tests"
-        timeout-minutes: 20
 
       - name: 🧪 Run integration tests (Browser, Chromium)
         if: ${{ inputs.browser_tests && inputs.unit_and_integration_tests }}
+        timeout-minutes: 20
         shell: pwsh
         run: .\scripts\test-web-integration.bat --browser chromium
-        timeout-minutes: 20
 
       - name: 🧪 Run integration tests (Remote)
         if: ${{ inputs.remote_tests && inputs.unit_and_integration_tests }}
+        timeout-minutes: 20
         shell: pwsh
         run: .\scripts\test-remote-integration.bat
-        timeout-minutes: 20
 
       - name: Diagnostics after integration test runs
+        if: ${{ inputs.unit_and_integration_tests && always() }}
         shell: pwsh
         run: .\build\azure-pipelines\win32\listprocesses.bat
         continue-on-error: true
-        if: always()
 
-      - name: Diagnostics before smoke test run
-        shell: pwsh
-        run: .\build\azure-pipelines\win32\listprocesses.bat
-        continue-on-error: true
-        if: always()
 
       - name: Compile smoke tests
         if: ${{ inputs.smoke_tests }}
@@ -220,6 +212,17 @@ jobs:
         if: ${{ inputs.smoke_tests }}
         shell: pwsh
         run: npm run gulp compile-extension-media
+
+      - name: Build Copilot Chat extension for smoke tests
+        if: ${{ inputs.smoke_tests }}
+        working-directory: extensions/copilot
+        run: npm run compile
+
+      - name: Diagnostics before smoke test run
+        if: ${{ inputs.smoke_tests && always() }}
+        shell: pwsh
+        run: .\build\azure-pipelines\win32\listprocesses.bat
+        continue-on-error: true
 
       - name: 🧪 Run smoke tests (Electron)
         if: ${{ inputs.electron_tests && inputs.smoke_tests }}
@@ -240,10 +243,10 @@ jobs:
         run: npm run smoketest-no-compile -- --remote --tracing
 
       - name: Diagnostics after smoke test run
+        if: ${{ inputs.smoke_tests && always() }}
         shell: pwsh
         run: .\build\azure-pipelines\win32\listprocesses.bat
         continue-on-error: true
-        if: always()
 
       - name: Publish Crash Reports
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr-win32-test.yml
+++ b/.github/workflows/pr-win32-test.yml
@@ -13,13 +13,19 @@ on:
       remote_tests:
         type: boolean
         default: false
+      unit_and_integration_tests:
+        type: boolean
+        default: true
+      smoke_tests:
+        type: boolean
+        default: true
 
 jobs:
   windows-test:
     name: ${{ inputs.job_name }}
     runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-windows-2022-x64, "JobId=windows-test-${{ inputs.job_name }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" ]
     env:
-      ARTIFACT_NAME: ${{ (inputs.electron_tests && 'electron') || (inputs.browser_tests && 'browser') || (inputs.remote_tests && 'remote') || 'unknown' }}
+      ARTIFACT_NAME: ${{ (inputs.electron_tests && 'electron') || (inputs.browser_tests && 'browser') || (inputs.remote_tests && 'remote') || 'unknown' }}${{ (!inputs.unit_and_integration_tests && inputs.smoke_tests) && '-smoke' || '' }}
       NPM_ARCH: x64
       VSCODE_ARCH: x64
     steps:
@@ -120,19 +126,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🧪 Run unit tests (Electron)
-        if: ${{ inputs.electron_tests }}
+        if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
         shell: pwsh
         run: .\scripts\test.bat --tfs "Unit Tests"
         timeout-minutes: 15
 
       - name: 🧪 Run unit tests (node.js)
-        if: ${{ inputs.electron_tests }}
+        if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
         shell: pwsh
         run: npm run test-node
         timeout-minutes: 15
 
       - name: 🧪 Run unit tests (Browser, Chromium)
-        if: ${{ inputs.browser_tests }}
+        if: ${{ inputs.browser_tests && inputs.unit_and_integration_tests }}
         shell: pwsh
         run: node test/unit/browser/index.js --browser chromium --tfs "Browser Unit Tests"
         env:
@@ -175,19 +181,19 @@ jobs:
         if: always()
 
       - name: 🧪 Run integration tests (Electron)
-        if: ${{ inputs.electron_tests }}
+        if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
         shell: pwsh
         run: .\scripts\test-integration.bat --tfs "Integration Tests"
         timeout-minutes: 20
 
       - name: 🧪 Run integration tests (Browser, Chromium)
-        if: ${{ inputs.browser_tests }}
+        if: ${{ inputs.browser_tests && inputs.unit_and_integration_tests }}
         shell: pwsh
         run: .\scripts\test-web-integration.bat --browser chromium
         timeout-minutes: 20
 
       - name: 🧪 Run integration tests (Remote)
-        if: ${{ inputs.remote_tests }}
+        if: ${{ inputs.remote_tests && inputs.unit_and_integration_tests }}
         shell: pwsh
         run: .\scripts\test-remote-integration.bat
         timeout-minutes: 20
@@ -205,28 +211,30 @@ jobs:
         if: always()
 
       - name: Compile smoke tests
+        if: ${{ inputs.smoke_tests }}
         working-directory: test/smoke
         shell: pwsh
         run: npm run compile
 
       - name: Compile extensions for smoke tests
+        if: ${{ inputs.smoke_tests }}
         shell: pwsh
         run: npm run gulp compile-extension-media
 
       - name: 🧪 Run smoke tests (Electron)
-        if: ${{ inputs.electron_tests }}
+        if: ${{ inputs.electron_tests && inputs.smoke_tests }}
         timeout-minutes: 20
         shell: pwsh
         run: npm run smoketest-no-compile -- --tracing
 
       - name: 🧪 Run smoke tests (Browser, Chromium)
-        if: ${{ inputs.browser_tests }}
+        if: ${{ inputs.browser_tests && inputs.smoke_tests }}
         timeout-minutes: 20
         shell: pwsh
         run: npm run smoketest-no-compile -- --web --tracing --headless
 
       - name: 🧪 Run smoke tests (Remote)
-        if: ${{ inputs.remote_tests }}
+        if: ${{ inputs.remote_tests && inputs.smoke_tests }}
         timeout-minutes: 20
         shell: pwsh
         run: npm run smoketest-no-compile -- --remote --tracing

--- a/.github/workflows/pr-win32-test.yml
+++ b/.github/workflows/pr-win32-test.yml
@@ -145,8 +145,7 @@ jobs:
         env:
           DEBUG: "*browser*"
 
-      - name: Build integration tests
-        if: ${{ inputs.unit_and_integration_tests }}
+      - name: Compile extensions for integration tests & smoke tests
         shell: pwsh
         run: |
           . build/azure-pipelines/win32/exec.ps1
@@ -208,12 +207,7 @@ jobs:
         shell: pwsh
         run: npm run compile
 
-      - name: Compile extensions for smoke tests
-        if: ${{ inputs.smoke_tests }}
-        shell: pwsh
-        run: npm run gulp compile-extension-media
-
-      - name: Build Copilot Chat extension for smoke tests
+      - name: Compile Copilot Chat extension for smoke tests
         if: ${{ inputs.smoke_tests }}
         working-directory: extensions/copilot
         run: npm run compile

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -109,7 +109,7 @@ jobs:
     name: Linux
     uses: ./.github/workflows/pr-linux-test.yml
     with:
-      job_name: Electron (Smoke)
+      job_name: Electron-Smoke
       electron_tests: true
       unit_and_integration_tests: false
 
@@ -139,7 +139,7 @@ jobs:
     name: macOS
     uses: ./.github/workflows/pr-darwin-test.yml
     with:
-      job_name: Electron (Smoke)
+      job_name: Electron-Smoke
       electron_tests: true
       unit_and_integration_tests: false
 
@@ -169,7 +169,7 @@ jobs:
     name: Windows
     uses: ./.github/workflows/pr-win32-test.yml
     with:
-      job_name: Electron (Smoke)
+      job_name: Electron-Smoke
       electron_tests: true
       unit_and_integration_tests: false
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -103,6 +103,15 @@ jobs:
     with:
       job_name: Electron
       electron_tests: true
+      smoke_tests: false
+
+  linux-electron-smoke-tests:
+    name: Linux
+    uses: ./.github/workflows/pr-linux-test.yml
+    with:
+      job_name: Electron (Smoke)
+      electron_tests: true
+      unit_and_integration_tests: false
 
   linux-browser-tests:
     name: Linux
@@ -124,6 +133,15 @@ jobs:
     with:
       job_name: Electron
       electron_tests: true
+      smoke_tests: false
+
+  macos-electron-smoke-tests:
+    name: macOS
+    uses: ./.github/workflows/pr-darwin-test.yml
+    with:
+      job_name: Electron (Smoke)
+      electron_tests: true
+      unit_and_integration_tests: false
 
   macos-browser-tests:
     name: macOS
@@ -145,6 +163,15 @@ jobs:
     with:
       job_name: Electron
       electron_tests: true
+      smoke_tests: false
+
+  windows-electron-smoke-tests:
+    name: Windows
+    uses: ./.github/workflows/pr-win32-test.yml
+    with:
+      job_name: Electron (Smoke)
+      electron_tests: true
+      unit_and_integration_tests: false
 
   windows-browser-tests:
     name: Windows


### PR DESCRIPTION
## What

Splits the **Electron** PR test job on Linux, Windows and macOS into two parallel jobs:

- `… / Electron` — unit + integration tests
- `… / Electron (Smoke)` — smoke tests

## Why

The Electron jobs are the slowest in PR CI (Linux ~22m, Windows ~20m, macOS ~13m), dominated by the smoke test run (~10m on Linux). Running smoke tests in a separate parallel job cuts the wall-clock time of the Electron lane to roughly the longer of the two halves.

## How

No job duplication — this is parameter-driven. The reusable workflows (`pr-linux-test.yml`, `pr-win32-test.yml`, `pr-darwin-test.yml`) gain two boolean inputs, both defaulting to `true`:

- `unit_and_integration_tests`
- `smoke_tests`

The unit/integration/smoke execution steps (and the smoke-only compile steps) are gated on these. `pr.yml` now calls each Electron workflow twice — once with `smoke_tests: false`, once with `unit_and_integration_tests: false`.

## Notes for reviewers

- **Browser and Remote jobs are untouched** — they don't pass the new inputs, so both phases run via the defaults, exactly as before.
- Artifact names (logs/crashes/node-modules) get a `-smoke` suffix on the smoke-only job to avoid upload-name collisions within a run.
- Existing check names `Linux / Electron`, `Windows / Electron`, `macOS / Electron` are preserved (now without smoke); new `… / Electron (Smoke)` checks are added. Required-status-check config may need updating to include the new checks.
- Shared setup/build runs in both halves (cached, seconds-scale) — the normal trade-off for parallelizing into independent jobs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

## CI timing comparison

Splitting the Electron lane into two parallel jobs (`Electron` = unit + integration, `Electron (Smoke)` = smoke) cuts the wall-clock time of the Electron lane to roughly the longer of its two halves.

- **BEFORE:** [run 27849438377](https://github.com/microsoft/vscode/actions/runs/27849438377?pr=322167)
- **AFTER:** [run 27849712750](https://github.com/microsoft/vscode/actions/runs/27849712750?pr=322168)

### Electron lane wall-clock

After the split, the lane finishes when the slower of its two parallel jobs completes (`AFTER = max(Electron, Electron (Smoke))`).

| Lane | BEFORE | AFTER | DELTA | % |
|------|-------:|------:|------:|----:|
| Linux / Electron | 18m35s | 12m12s | −6m23s | -34.3% |
| Windows / Electron | 20m29s | 11m36s | −8m53s | -43.4% |
| macOS / Electron | 12m48s | 8m31s | −4m17s | -33.5% |

### All jobs

Every job that ran, listed individually. The `… / Electron (Smoke)` jobs are **new** (smoke tests were previously part of the combined `… / Electron` job), so they have no BEFORE counterpart.

| Job | BEFORE | AFTER | DELTA | % |
|-----|-------:|------:|------:|----:|
| Compile & Hygiene | 5m33s | 5m51s | +0m18s | +5.4% |
| Linux / CLI | 1m35s | 1m37s | +0m02s | +2.1% |
| Linux / Electron | 18m35s | 11m44s | −6m51s | -36.9% |
| Linux / Electron (Smoke) | — | 12m12s | — | — |
| Linux / Browser | 10m17s | 11m04s | +0m47s | +7.6% |
| Linux / Remote | 14m18s | 12m57s | −1m21s | -9.4% |
| macOS / Electron | 12m48s | 6m58s | −5m50s | -45.6% |
| macOS / Electron (Smoke) | — | 8m31s | — | — |
| macOS / Browser | 8m09s | 7m56s | −0m13s | -2.7% |
| macOS / Remote | 7m19s | 7m36s | +0m17s | +3.9% |
| Windows / Electron | 20m29s | 11m36s | −8m53s | -43.4% |
| Windows / Electron (Smoke) | — | 10m52s | — | — |
| Windows / Browser | 12m39s | 12m58s | +0m19s | +2.5% |
| Windows / Remote | 13m00s | 12m43s | −0m17s | -2.2% |
| Copilot - Test (Linux) | 7m49s | 8m03s | +0m14s | +3.0% |
| Copilot - Test (Windows) | 12m14s | 11m54s | −0m20s | -2.7% |
| Copilot - Check Test Cache | 0m31s | 0m39s | +0m08s | +25.8% |
| Copilot - Check Telemetry | 0m18s | 0m17s | −0m01s | -5.6% |
| **MAX (critical path / wall-clock)** | **20m29s** | **12m58s** | **−7m31s** | **-36.7%** |
| **SUM (total runner-minutes)** | **145m34s** | **155m28s** | **+9m54s** | **+6.8%** |

> **MAX** is the longest single job in the run (the wall-clock-determining critical path). **SUM** is the actual total runner-minutes across every job. SUM goes **up** because the smoke job re-runs the (cached) setup/build in parallel — that extra compute is the cost paid for the shorter wall-clock.

**Summary:** Splitting smoke into a parallel `… / Electron (Smoke)` job cuts the Electron lane wall-clock by **−34% (Linux)**, **−43% (Windows)** and **−34% (macOS)**, and drops the run's critical path from **20m29s → 12m58s (−36.7%)**. The trade-off is **+6.8% total runner-minutes** (145m34s → 155m28s) from the extra parallel job. All non-Electron jobs are untouched and within run-to-run noise.