### PR TITLE
 Add missing unit test coverage for prefixedUuid in uuid.ts

### DIFF
--- a/src/vs/base/common/uuid.ts
+++ b/src/vs/base/common/uuid.ts
@@ -64,7 +64,7 @@ export const generateUuid = (function (): () => string {
 	};
 })();
 
-/** Namespace should be 3 letter. */
+/** Namespace should be 3 letters, e.g. `abc-<uuid>`. */
 export function prefixedUuid(namespace: string): string {
 	return `${namespace}-${generateUuid()}`;
 }

--- a/src/vs/base/test/common/uuid.test.ts
+++ b/src/vs/base/test/common/uuid.test.ts
@@ -23,4 +23,17 @@ suite('UUID', () => {
 			assert.ok(uuid.isUUID(value));
 		}
 	});
+
+	test('prefixedUuid', () => {
+		const namespace = 'abc';
+		const result = uuid.prefixedUuid(namespace);
+
+		assert.ok(result.startsWith(`${namespace}-`), `Expected "${result}" to start with "${namespace}-"`);
+
+		const expectedLength = namespace.length + 1 + 36;
+		assert.strictEqual(result.length, expectedLength);
+
+		const uuidPart = result.slice(namespace.length + 1);
+		assert.ok(uuid.isUUID(uuidPart), `Expected "${uuidPart}" to be a valid UUID`);
+	});
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #321507

Added a test case for `prefixedUuid` in `uuid.test.ts` which was previously untested.

The test verifies:
- The result starts with the given namespace followed by a hyphen
- The total length matches the expected namespace + UUID length
- The portion after the prefix is a valid UUID

Also added a JSDoc comment to `prefixedUuid` in `uuid.ts`.