### PR TITLE
policy: escape XML special characters in ADML/profile output

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -61,7 +61,7 @@
             "localization": {
                 "description": {
                     "key": "chat.plugins.extraMarketplaces.policy",
-                    "value": "Additional plugin marketplaces to query. Keys are marketplace names; values are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`<url>[#ref]`)."
+                    "value": "Additional plugin marketplaces to query. Keys are marketplace names; values are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`{url}[#ref]`)."
                 }
             },
             "type": "object",
@@ -275,7 +275,7 @@
             "localization": {
                 "description": {
                     "key": "chat.plugins.enabledPlugins.policy",
-                    "value": "Plugin enablement. Keys are plugin IDs in `<plugin>@<marketplace>` form; values enable or disable the plugin."
+                    "value": "Plugin enablement. Keys are plugin IDs in `{plugin}@{marketplace}` form; values enable or disable the plugin."
                 }
             },
             "type": "object",

--- a/build/lib/policies/render.ts
+++ b/build/lib/policies/render.ts
@@ -5,6 +5,13 @@
 
 import type { NlsString, LanguageTranslations, Category, Policy, Translations, ProductJson } from './types.ts';
 
+export function escapeXml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;');
+}
+
 export function renderADMLString(prefix: string, moduleName: string, nlsString: NlsString, translations?: LanguageTranslations): string {
 	let value: string | undefined;
 
@@ -20,7 +27,7 @@ export function renderADMLString(prefix: string, moduleName: string, nlsString: 
 		value = nlsString.value;
 	}
 
-	return `<string id="${prefix}_${nlsString.nlsKey.replace(/\./g, '_')}">${value}</string>`;
+	return `<string id="${prefix}_${nlsString.nlsKey.replace(/\./g, '_')}">${escapeXml(value)}</string>`;
 }
 
 export function renderProfileString(_prefix: string, moduleName: string, nlsString: NlsString, translations?: LanguageTranslations): string {
@@ -38,7 +45,7 @@ export function renderProfileString(_prefix: string, moduleName: string, nlsStri
 		value = nlsString.value;
 	}
 
-	return value;
+	return escapeXml(value);
 }
 
 export function renderADMX(regKey: string, versions: string[], categories: Category[], policies: Policy[]) {

--- a/build/lib/test/policyConversion.test.ts
+++ b/build/lib/test/policyConversion.test.ts
@@ -534,7 +534,7 @@ suite('Policy E2E conversion', () => {
 		assert.ok(ObjectPolicy.from(category, policy), 'A union array|null type should be classified as an object policy');
 	});
 
-	test('descriptions containing angle brackets produce valid XML (#320551)', () => {
+	test('descriptions containing angle brackets are escaped in ADML output (#320551)', () => {
 		const policyData: ExportedPolicyDataDto = {
 			categories: [{ key: 'InteractiveSession', name: { key: 'interactiveSessionConfigurationTitle', value: 'Chat' } }],
 			policies: [

--- a/build/lib/test/policyConversion.test.ts
+++ b/build/lib/test/policyConversion.test.ts
@@ -534,4 +534,52 @@ suite('Policy E2E conversion', () => {
 		assert.ok(ObjectPolicy.from(category, policy), 'A union array|null type should be classified as an object policy');
 	});
 
+	test('descriptions containing angle brackets produce valid XML (#320551)', () => {
+		const policyData: ExportedPolicyDataDto = {
+			categories: [{ key: 'InteractiveSession', name: { key: 'interactiveSessionConfigurationTitle', value: 'Chat' } }],
+			policies: [
+				{
+					key: 'chat.plugins.enabledPlugins',
+					name: 'ChatEnabledPlugins',
+					category: 'InteractiveSession',
+					minimumVersion: '1.122',
+					localization: {
+						description: {
+							key: 'chat.plugins.enabledPlugins.policy',
+							value: 'Plugin enablement. Keys are plugin IDs in `<plugin>@<marketplace>` form; values enable or disable the plugin.'
+						}
+					},
+					type: 'object',
+					default: {},
+				},
+				{
+					key: 'chat.plugins.extraMarketplaces',
+					name: 'ChatExtraMarketplaces',
+					category: 'InteractiveSession',
+					minimumVersion: '1.122',
+					localization: {
+						description: {
+							key: 'chat.plugins.extraMarketplaces.policy',
+							value: 'Additional plugin marketplaces to query. Keys are marketplace names; values are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`<url>[#ref]`).'
+						}
+					},
+					type: 'object',
+					default: {},
+				}
+			]
+		};
+
+		const parsed = parsePolicies(policyData);
+		const { adml } = renderGP(mockProduct, parsed, []);
+		const enUs = adml.find(a => a.languageId === 'en-us');
+		assert.ok(enUs, 'en-us ADML should exist');
+
+		// Angle brackets must be escaped so the output is valid XML
+		assert.ok(enUs.contents.includes('&lt;plugin&gt;@&lt;marketplace&gt;'), 'angle brackets in descriptions must be XML-escaped');
+		assert.ok(enUs.contents.includes('&lt;url&gt;'), 'angle brackets in descriptions must be XML-escaped');
+		assert.ok(!enUs.contents.includes('<plugin>'), 'raw angle brackets must not appear in ADML output');
+		assert.ok(!enUs.contents.includes('<url>'), 'raw angle brackets must not appear in ADML output');
+	});
+
+
 });

--- a/build/lib/test/render.test.ts
+++ b/build/lib/test/render.test.ts
@@ -5,12 +5,59 @@
 
 import assert from 'assert';
 import { suite, test } from 'node:test';
-import { renderADMLString, renderProfileString, renderADMX, renderADML, renderProfileManifest, renderMacOSPolicy, renderGP, renderJsonPolicies } from '../policies/render.ts';
+import { escapeXml, renderADMLString, renderProfileString, renderADMX, renderADML, renderProfileManifest, renderMacOSPolicy, renderGP, renderJsonPolicies } from '../policies/render.ts';
 import { type NlsString, type LanguageTranslations, type Category, type Policy, PolicyType } from '../policies/types.ts';
 
 suite('Render Functions', () => {
 
+	suite('escapeXml', () => {
+
+		test('should escape ampersands', () => {
+			assert.strictEqual(escapeXml('foo & bar'), 'foo &amp; bar');
+		});
+
+		test('should escape angle brackets', () => {
+			assert.strictEqual(escapeXml('<plugin>@<marketplace>'), '&lt;plugin&gt;@&lt;marketplace&gt;');
+		});
+
+		test('should escape all special characters together', () => {
+			assert.strictEqual(escapeXml('a < b & b > c'), 'a &lt; b &amp; b &gt; c');
+		});
+
+		test('should not alter strings without special characters', () => {
+			assert.strictEqual(escapeXml('plain text'), 'plain text');
+		});
+	});
+
 	suite('renderADMLString', () => {
+
+		test('should escape XML special characters in values', () => {
+			const nlsString: NlsString = {
+				value: 'Keys are plugin IDs in `<plugin>@<marketplace>` form',
+				nlsKey: 'test.description'
+			};
+
+			const result = renderADMLString('TestPrefix', 'testModule', nlsString);
+
+			assert.strictEqual(result, '<string id="TestPrefix_test_description">Keys are plugin IDs in `&lt;plugin&gt;@&lt;marketplace&gt;` form</string>');
+		});
+
+		test('should escape XML special characters in translated values', () => {
+			const nlsString: NlsString = {
+				value: 'Original',
+				nlsKey: 'test.key'
+			};
+
+			const translations: LanguageTranslations = {
+				'testModule': {
+					'test.key': 'Git URIs (`<url>[#ref]`)'
+				}
+			};
+
+			const result = renderADMLString('TestPrefix', 'testModule', nlsString, translations);
+
+			assert.strictEqual(result, '<string id="TestPrefix_test_key">Git URIs (`&lt;url&gt;[#ref]`)</string>');
+		});
 
 		test('should render ADML string without translations', () => {
 			const nlsString: NlsString = {
@@ -114,6 +161,17 @@ suite('Render Functions', () => {
 			const result = renderProfileString('ProfilePrefix', 'testModule', nlsString, translations);
 
 			assert.strictEqual(result, 'Original profile value');
+		});
+
+		test('should escape XML special characters in values', () => {
+			const nlsString: NlsString = {
+				value: 'Git URIs (`<url>[#ref]`)',
+				nlsKey: 'profile.key'
+			};
+
+			const result = renderProfileString('ProfilePrefix', 'testModule', nlsString);
+
+			assert.strictEqual(result, 'Git URIs (`&lt;url&gt;[#ref]`)');
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -1000,7 +1000,7 @@ configurationRegistry.registerConfiguration({
 				localization: {
 					description: {
 						key: 'chat.plugins.enabledPlugins.policy',
-						value: nls.localize('chat.plugins.enabledPlugins.policy', "Plugin enablement. Keys are plugin IDs in `<plugin>@<marketplace>` form; values enable or disable the plugin."),
+						value: nls.localize('chat.plugins.enabledPlugins.policy', "Plugin enablement. Keys are plugin IDs in \`{plugin}@{marketplace}\` form; values enable or disable the plugin."),
 					}
 				},
 			},
@@ -1045,7 +1045,7 @@ configurationRegistry.registerConfiguration({
 				localization: {
 					description: {
 						key: 'chat.plugins.extraMarketplaces.policy',
-						value: nls.localize('chat.plugins.extraMarketplaces.policy', "Additional plugin marketplaces to query. Keys are marketplace names; values are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`<url>[#ref]`)."),
+						value: nls.localize('chat.plugins.extraMarketplaces.policy', "Additional plugin marketplaces to query. Keys are marketplace names; values are GitHub shorthand (\`owner/repo[#ref]\`) or Git URIs (\`{url}[#ref]\`)."),
 					}
 				},
 			},

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -1000,7 +1000,7 @@ configurationRegistry.registerConfiguration({
 				localization: {
 					description: {
 						key: 'chat.plugins.enabledPlugins.policy',
-						value: nls.localize('chat.plugins.enabledPlugins.policy', "Plugin enablement. Keys are plugin IDs in \`{plugin}@{marketplace}\` form; values enable or disable the plugin."),
+						value: nls.localize('chat.plugins.enabledPlugins.policy', "Plugin enablement. Keys are plugin IDs in `{plugin}@{marketplace}` form; values enable or disable the plugin."),
 					}
 				},
 			},
@@ -1045,7 +1045,7 @@ configurationRegistry.registerConfiguration({
 				localization: {
 					description: {
 						key: 'chat.plugins.extraMarketplaces.policy',
-						value: nls.localize('chat.plugins.extraMarketplaces.policy', "Additional plugin marketplaces to query. Keys are marketplace names; values are GitHub shorthand (\`owner/repo[#ref]\`) or Git URIs (\`{url}[#ref]\`)."),
+						value: nls.localize('chat.plugins.extraMarketplaces.policy', "Additional plugin marketplaces to query. Keys are marketplace names; values are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`{url}[#ref]`)."),
 					}
 				},
 			},


### PR DESCRIPTION
## Summary

Fixes #320551 — Enterprise policy ADML files contained invalid XML because policy descriptions with angle brackets (e.g. `<plugin>@<marketplace>`, `<url>`) were inserted unescaped into XML text content. This caused upload failures in Microsoft Intune and Active Directory.
