### PR TITLE
agent host: bring tool approval to parity with the extension

### DIFF
--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -349,7 +349,9 @@ export class AgentSideEffects extends Disposable {
 			if (subagentSession) {
 				const subTurnId = this._stateManager.getActiveTurnId(subagentSession);
 				if (subTurnId) {
-					this._handleToolReady(signal, subagentSession, subTurnId, agent);
+					void this._handleToolReady(signal, subagentSession, subTurnId, agent).catch(err => {
+						this._logService.error('[AgentSideEffects] _handleToolReady failed', err);
+					});
 				}
 				return;
 			}
@@ -381,7 +383,9 @@ export class AgentSideEffects extends Disposable {
 	private _dispatchActionForSession(signal: AgentSignal, sessionKey: ProtocolURI, turnId: string, agent?: IAgent): void {
 		if (signal.kind === 'pending_confirmation') {
 			if (agent) {
-				this._handleToolReady(signal, sessionKey, turnId, agent);
+				void this._handleToolReady(signal, sessionKey, turnId, agent).catch(err => {
+					this._logService.error('[AgentSideEffects] _handleToolReady failed', err);
+				});
 			}
 			return;
 		}
@@ -726,7 +730,7 @@ export class AgentSideEffects extends Disposable {
 	 * dispatches the `ChatToolCallReady` action with confirmation options
 	 * for the client.
 	 */
-	private _handleToolReady(e: IAgentToolPendingConfirmationSignal, sessionKey: ProtocolURI, turnId: string, agent: IAgent): void {
+	private async _handleToolReady(e: IAgentToolPendingConfirmationSignal, sessionKey: ProtocolURI, turnId: string, agent: IAgent): Promise<void> {
 		const approvalEvent = {
 			toolCallId: e.state.toolCallId,
 			session: e.session,
@@ -734,7 +738,7 @@ export class AgentSideEffects extends Disposable {
 			permissionPath: e.permissionPath,
 			toolInput: e.state.toolInput,
 		};
-		const autoApproval = this._permissionManager.getAutoApproval(approvalEvent, sessionKey);
+		const autoApproval = await this._permissionManager.getAutoApproval(approvalEvent, sessionKey);
 		const part = this._stateManager.getSessionState(sessionKey)?.activeTurn?.responseParts.find(part => part.kind === ResponsePartKind.ToolCall && part.toolCall.toolCallId === e.state.toolCallId);
 		const toolCall = part?.kind === ResponsePartKind.ToolCall ? part.toolCall : undefined;
 		const contributor = e.state.contributor ?? toolCall?.contributor;

--- a/src/vs/platform/agentHost/node/claude/claudeCanUseTool.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeCanUseTool.ts
@@ -61,7 +61,7 @@ export interface IClaudeCanUseToolOptions {
  *
  * Note: protocol-level auto-approve for write tools lives in
  * `agentSideEffects.ts:_handleToolReady`, which subscribes to the
-	 * `pending_confirmation` signal and calls
+ * `pending_confirmation` signal and calls
  * `respondToPermissionRequest`. The atomic register-then-fire
  * invariant lives inside {@link ClaudeAgentSession.requestPermission}
  * (via `PendingRequestRegistry.registerAndFire`).

--- a/src/vs/platform/agentHost/node/claude/claudeCanUseTool.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeCanUseTool.ts
@@ -61,7 +61,7 @@ export interface IClaudeCanUseToolOptions {
  *
  * Note: protocol-level auto-approve for write tools lives in
  * `agentSideEffects.ts:_handleToolReady`, which subscribes to the
- * `pending_confirmation` signal and synchronously calls
+	 * `pending_confirmation` signal and calls
  * `respondToPermissionRequest`. The atomic register-then-fire
  * invariant lives inside {@link ClaudeAgentSession.requestPermission}
  * (via `PendingRequestRegistry.registerAndFire`).

--- a/src/vs/platform/agentHost/node/sessionPermissions.ts
+++ b/src/vs/platform/agentHost/node/sessionPermissions.ts
@@ -3,12 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { realpath } from 'fs/promises';
 import { homedir } from 'os';
-import { match as globMatch } from '../../../base/common/glob.js';
+import { match as globMatch, parse as globParse, type ParsedPattern } from '../../../base/common/glob.js';
 import { untildify } from '../../../base/common/labels.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
 import * as path from '../../../base/common/path.js';
+import { isMacintosh, isWindows } from '../../../base/common/platform.js';
 import { extUriBiasedIgnorePathCase, normalizePath } from '../../../base/common/resources.js';
+import { isDefined } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
 import { localize } from '../../../nls.js';
 import { ILogService } from '../../log/common/log.js';
@@ -59,6 +62,124 @@ const DEFAULT_EDIT_AUTO_APPROVE_PATTERNS: Readonly<Record<string, boolean>> = {
 };
 
 /**
+ * Glob patterns matching dotfiles directly under the user's home directory
+ * (e.g. `~/.ssh`, `~/.aws`). Writes to these always require confirmation,
+ * even when the working directory sits inside the home directory.
+ */
+const HOME_DOTFILE_PATTERNS: readonly ParsedPattern[] = [
+	globParse(homedir() + '/.*'),
+	globParse(homedir() + '/.*/**'),
+];
+
+/**
+ * Absolute directory prefixes whose contents are platform configuration data
+ * (e.g. `~/Library`, `%APPDATA%`). Writes under these require confirmation
+ * unless the working directory itself lives inside the restricted directory.
+ */
+const PLATFORM_RESTRICTED_DIRS: readonly string[] = (
+	isWindows
+		? [process.env.APPDATA, process.env.LOCALAPPDATA]
+		: isMacintosh
+			? [homedir() + '/Library']
+			: []
+).filter(isDefined);
+
+/**
+ * Validates that a path doesn't contain suspicious characters that could be
+ * used to bypass security checks on Windows (e.g. NTFS Alternate Data Streams,
+ * invalid characters, reserved device names). Throws if the path is suspicious.
+ */
+function assertPathIsSafe(fsPath: string, _isWindows = isWindows): void {
+	if (fsPath.includes('\0')) {
+		throw new Error(`Path contains null bytes: ${fsPath}`);
+	}
+
+	if (!_isWindows) {
+		return;
+	}
+
+	// Check for NTFS Alternate Data Streams (ADS)
+	const colonIndex = fsPath.indexOf(':', 2);
+	if (colonIndex !== -1) {
+		throw new Error(`Path contains invalid characters (alternate data stream): ${fsPath}`);
+	}
+
+	// Check for invalid Windows filename characters
+	const invalidChars = /[<>"|?*]/;
+	const pathAfterDrive = fsPath.length > 2 ? fsPath.substring(2) : fsPath;
+	if (invalidChars.test(pathAfterDrive)) {
+		throw new Error(`Path contains invalid characters: ${fsPath}`);
+	}
+
+	// Check for named pipes or device paths
+	if (fsPath.startsWith('\\\\.') || fsPath.startsWith('\\\\?')) {
+		throw new Error(`Path is a reserved device path: ${fsPath}`);
+	}
+
+	const reserved = /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\.|$)/i;
+
+	// Check for trailing dots and spaces on path components (Windows quirk)
+	const parts = fsPath.split('\\');
+	for (const part of parts) {
+		if (part.length === 0) {
+			continue;
+		}
+
+		if (reserved.test(part)) {
+			throw new Error(`Reserved device name in path: ${fsPath}`);
+		}
+
+		if (part.endsWith('.') || part.endsWith(' ')) {
+			throw new Error(`Path contains invalid trailing characters: ${fsPath}`);
+		}
+
+		const tildeIndex = part.indexOf('~');
+		if (tildeIndex !== -1) {
+			const afterTilde = part.substring(tildeIndex + 1);
+			if (afterTilde.length > 0 && /^\d/.test(afterTilde)) {
+				throw new Error(`Path appears to use short filename format (8.3 names): ${fsPath}. Please use the full path.`);
+			}
+		}
+	}
+}
+
+/**
+ * Resolves the real path of `fsPath`, walking up the parent chain when the path
+ * (or its ancestors) does not yet exist on disk. This ensures a symlink at any
+ * ancestor is followed even for files that are about to be created.
+ */
+async function resolveRealPathForNonexistent(fsPath: string): Promise<string> {
+	try {
+		return await realpath(fsPath);
+	} catch (e) {
+		if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+			throw e;
+		}
+	}
+
+	const tail: string[] = [path.basename(fsPath)];
+	let current = path.dirname(fsPath);
+	while (true) {
+		const parent = path.dirname(current);
+		if (parent === current) {
+			// Reached the filesystem root without finding an existing ancestor.
+			return fsPath;
+		}
+		try {
+			const resolved = await realpath(current);
+			return path.join(resolved, ...tail);
+		} catch (e) {
+			const code = (e as NodeJS.ErrnoException).code;
+			if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+				throw e;
+			}
+		}
+		tail.unshift(path.basename(current));
+		current = parent;
+	}
+}
+
+/**
  * Single entry point for all tool-call approval logic in the agent host.
  *
  * Modeled after {@link ILanguageModelToolsConfirmationService} in the
@@ -96,8 +217,8 @@ export class SessionPermissionManager extends Disposable {
 
 	/**
 	 * Initializes async resources (tree-sitter WASM) used for shell command
-	 * auto-approval. Await this before any session events can arrive to
-	 * guarantee that {@link getAutoApproval} is fully synchronous.
+	 * auto-approval. Await this before any session events can arrive so that
+	 * shell command parsing within {@link getAutoApproval} is synchronous.
 	 */
 	initialize(): Promise<void> {
 		return this._commandAutoApprover.initialize();
@@ -106,10 +227,10 @@ export class SessionPermissionManager extends Disposable {
 	// ---- Auto-approval (analogous to getPreConfirmAction) -------------------
 
 	/**
-	 * Synchronously checks whether a `tool_ready` event should be
-	 * auto-approved. Returns a {@link ToolCallConfirmationReason} when the
-	 * tool call should proceed without user interaction, or `undefined`
-	 * when user confirmation is required.
+	 * Checks whether a `tool_ready` event should be auto-approved. Returns a
+	 * {@link ToolCallConfirmationReason} when the tool call should proceed
+	 * without user interaction, or `undefined` when user confirmation is
+	 * required.
 	 *
 	 * Checks are evaluated in order:
 	 * 1. Session-level bypass (`autoApprove` config)
@@ -118,7 +239,7 @@ export class SessionPermissionManager extends Disposable {
 	 * 4. Write path rules (within working directory + glob patterns)
 	 * 5. Shell command rules (tree-sitter parsed, default allow/deny)
 	 */
-	getAutoApproval(e: IToolApprovalEvent, sessionKey: ProtocolURI): ToolCallConfirmationReason | undefined {
+	async getAutoApproval(e: IToolApprovalEvent, sessionKey: ProtocolURI): Promise<ToolCallConfirmationReason | undefined> {
 		const workDir = this._configService.getEffectiveWorkingDirectory(sessionKey);
 
 		// 1. Session-level auto-approve
@@ -142,7 +263,7 @@ export class SessionPermissionManager extends Disposable {
 
 		// 4. Write auto-approval
 		if (e.permissionKind === 'write' && e.permissionPath) {
-			if (this._isPathInWorkingDirectory(e.permissionPath, workDir) && this._isEditAutoApproved(e.permissionPath)) {
+			if (await this._isEditAutoApproved(e.permissionPath, workDir)) {
 				this._logService.trace(`[SessionPermissionManager] Auto-approving write to ${e.permissionPath}`);
 				return ToolCallConfirmationReason.NotNeeded;
 			}
@@ -247,7 +368,7 @@ export class SessionPermissionManager extends Disposable {
 		if (!resolved) {
 			return false;
 		}
-		return this._isPathInWorkingDirectory(resolved, workDir) && this._isEditAutoApproved(resolved);
+		return this._checkWritePath(resolved, workDir);
 	}
 
 	/**
@@ -271,7 +392,89 @@ export class SessionPermissionManager extends Disposable {
 		return path.resolve(URI.parse(workDir).fsPath, trimmed);
 	}
 
-	private _isEditAutoApproved(filePath: string): boolean {
+	/**
+	 * Determines whether a write to `filePath` can be auto-approved. Mirrors the
+	 * checks performed by the workbench edit-confirmation pipeline:
+	 *
+	 * 1. The path is resolved through any symlinks (following ancestors that do
+	 *    not yet exist) so a link can't redirect an edit outside the working
+	 *    directory. Both the literal and resolved paths must pass every check.
+	 * 2. The path must be free of suspicious characters (see {@link assertPathIsSafe}).
+	 * 3. The path must live inside the working directory.
+	 * 4. The path must not target a platform-restricted location (home dotfiles,
+	 *    `~/Library`, `%APPDATA%`, ...).
+	 * 5. The path must match the edit auto-approve glob rules.
+	 */
+	private async _isEditAutoApproved(filePath: string, workDir: string | undefined): Promise<boolean> {
+		const pathsToCheck = await this._resolveWritePaths(filePath);
+		return pathsToCheck !== undefined && pathsToCheck.every(p => this._checkWritePath(p, workDir));
+	}
+
+	/**
+	 * Returns the set of paths that must each pass the write checks: the literal
+	 * path plus, for absolute paths, the symlink-resolved real path. Returns
+	 * `undefined` when the path cannot be resolved due to missing permissions,
+	 * signalling that confirmation is required.
+	 */
+	private async _resolveWritePaths(filePath: string): Promise<string[] | undefined> {
+		const pathsToCheck = [filePath];
+		if (path.isAbsolute(filePath)) {
+			try {
+				const linked = await resolveRealPathForNonexistent(filePath);
+				if (linked !== filePath) {
+					pathsToCheck.push(linked);
+				}
+			} catch (e) {
+				if ((e as NodeJS.ErrnoException).code === 'EPERM') {
+					// No permission to resolve the path — require confirmation.
+					return undefined;
+				}
+				// Otherwise fall back to checking the literal path only.
+			}
+		}
+		return pathsToCheck;
+	}
+
+	/** Runs the per-path write checks for a single (already symlink-resolved) path. */
+	private _checkWritePath(filePath: string, workDir: string | undefined): boolean {
+		try {
+			assertPathIsSafe(filePath);
+		} catch {
+			return false;
+		}
+		if (!this._isPathInWorkingDirectory(filePath, workDir)) {
+			return false;
+		}
+		if (this._isPlatformRestrictedPath(filePath, workDir)) {
+			return false;
+		}
+		return this._matchesEditAutoApprovePatterns(filePath);
+	}
+
+	/**
+	 * Returns whether `filePath` targets a platform-restricted location that
+	 * should always require confirmation. Edits within home-directory dotfiles
+	 * are never auto-approved. Edits within platform config directories are
+	 * allowed only when the working directory itself lives inside them.
+	 */
+	private _isPlatformRestrictedPath(filePath: string, workDir: string | undefined): boolean {
+		if (HOME_DOTFILE_PATTERNS.some(pattern => pattern(filePath))) {
+			return true;
+		}
+
+		const uri = URI.file(filePath);
+		const workspaceFolder = workDir ? URI.parse(workDir) : undefined;
+		for (const restricted of PLATFORM_RESTRICTED_DIRS) {
+			const parentURI = URI.file(restricted);
+			if (extUriBiasedIgnorePathCase.isEqualOrParent(uri, parentURI)) {
+				// Allow edits when the working directory is opened inside the restricted area.
+				return !(workspaceFolder && extUriBiasedIgnorePathCase.isEqualOrParent(workspaceFolder, parentURI));
+			}
+		}
+		return false;
+	}
+
+	private _matchesEditAutoApprovePatterns(filePath: string): boolean {
 		let approved = true;
 		for (const [pattern, isApproved] of Object.entries(DEFAULT_EDIT_AUTO_APPROVE_PATTERNS)) {
 			if (isApproved !== approved && globMatch(pattern, filePath)) {

--- a/src/vs/platform/agentHost/node/sessionPermissions.ts
+++ b/src/vs/platform/agentHost/node/sessionPermissions.ts
@@ -425,7 +425,8 @@ export class SessionPermissionManager extends Disposable {
 					pathsToCheck.push(linked);
 				}
 			} catch (e) {
-				if ((e as NodeJS.ErrnoException).code === 'EPERM') {
+				const code = (e as NodeJS.ErrnoException).code;
+				if (code === 'EPERM' || code === 'EACCES') {
 					// No permission to resolve the path — require confirmation.
 					return undefined;
 				}

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -164,6 +164,36 @@ suite('AgentSideEffects', () => {
 		);
 	}
 
+	/**
+	 * Resolves with the first non-`undefined` value returned by `match`,
+	 * re-evaluating it immediately and after every envelope emitted by the
+	 * state manager. Used to await the async tool-approval pipeline
+	 * (`_handleToolReady` -> `getAutoApproval` -> `realpath`) deterministically
+	 * instead of depending on a fixed settle delay.
+	 */
+	function waitForState<T>(manager: AgentHostStateManager, match: () => T | undefined): Promise<T> {
+		return new Promise<T>((resolve, reject) => {
+			const initial = match();
+			if (initial !== undefined) {
+				resolve(initial);
+				return;
+			}
+			const store = new DisposableStore();
+			const timer = setTimeout(() => {
+				store.dispose();
+				reject(new Error('waitForState: condition was not met'));
+			}, 5000);
+			store.add(toDisposable(() => clearTimeout(timer)));
+			store.add(manager.onDidEmitEnvelope(() => {
+				const value = match();
+				if (value !== undefined) {
+					store.dispose();
+					resolve(value);
+				}
+			}));
+		});
+	}
+
 	setup(async () => {
 		fileService = disposables.add(new FileService(new NullLogService()));
 		const memFs = disposables.add(new InMemoryFileSystemProvider());
@@ -1389,7 +1419,7 @@ suite('AgentSideEffects', () => {
 
 	suite('tool_ready dispatches progress actions to advance tool call state', () => {
 
-		test('tool_ready for a non-permission tool dispatches ChatToolCallReady and advances state from Streaming to Running', () => {
+		test('tool_ready for a non-permission tool dispatches ChatToolCallReady and advances state from Streaming to Running', async () => {
 			setupSession();
 			startTurn('turn-1');
 			disposables.add(sideEffects.registerProgressListener(agent));
@@ -1422,14 +1452,18 @@ suite('AgentSideEffects', () => {
 				permissionKind: undefined, permissionPath: undefined,
 			});
 
-			const stateAfterReady = stateManager.getSessionState(sessionUri.toString());
+			const stateAfterReady = await waitForState(stateManager, () => {
+				const s = stateManager.getSessionState(sessionUri.toString());
+				const p = s?.activeTurn?.responseParts[0];
+				return p?.kind === ResponsePartKind.ToolCall && p.toolCall.status === ToolCallStatus.Running ? s : undefined;
+			});
 			const partAfterReady = stateAfterReady?.activeTurn?.responseParts[0];
 			assert.strictEqual(partAfterReady?.kind, ResponsePartKind.ToolCall);
 			assert.strictEqual(partAfterReady?.kind === ResponsePartKind.ToolCall ? partAfterReady.toolCall.status : undefined, ToolCallStatus.Running,
 				'tool call should advance from Streaming to Running after tool_ready');
 		});
 
-		test('tool_ready for a permission-gated tool dispatches ChatToolCallReady and advances state to PendingConfirmation', () => {
+		test('tool_ready for a permission-gated tool dispatches ChatToolCallReady and advances state to PendingConfirmation', async () => {
 			setupSession();
 			startTurn('turn-1');
 			disposables.add(sideEffects.registerProgressListener(agent));
@@ -1456,14 +1490,18 @@ suite('AgentSideEffects', () => {
 				permissionKind: undefined, permissionPath: undefined,
 			});
 
-			const state = stateManager.getSessionState(sessionUri.toString());
+			const state = await waitForState(stateManager, () => {
+				const s = stateManager.getSessionState(sessionUri.toString());
+				const p = s?.activeTurn?.responseParts[0];
+				return p?.kind === ResponsePartKind.ToolCall && p.toolCall.status === ToolCallStatus.PendingConfirmation ? s : undefined;
+			});
 			const part = state?.activeTurn?.responseParts[0];
 			assert.strictEqual(part?.kind, ResponsePartKind.ToolCall);
 			assert.strictEqual(part?.kind === ResponsePartKind.ToolCall ? part.toolCall.status : undefined, ToolCallStatus.PendingConfirmation,
 				'tool call should advance to PendingConfirmation for permission-gated tool_ready');
 		});
 
-		test('pending_confirmation for a tool inside a subagent routes to the subagent session', () => {
+		test('pending_confirmation for a tool inside a subagent routes to the subagent session', async () => {
 			// Regression: a `pending_confirmation` signal for a client tool
 			// inside a subagent must dispatch ChatToolCallReady against
 			// the subagent session, not the parent. Otherwise the parent
@@ -1519,7 +1557,13 @@ suite('AgentSideEffects', () => {
 
 			// The subagent session must contain the ChatToolCallReady.
 			const subagentUri = buildSubagentSessionUri(sessionUri.toString(), 'tc-parent');
-			const subState = stateManager.getSessionState(subagentUri);
+			const subState = await waitForState(stateManager, () => {
+				const s = stateManager.getSessionState(subagentUri);
+				const inner = s?.activeTurn?.responseParts.find(
+					rp => rp.kind === ResponsePartKind.ToolCall && rp.toolCall.toolCallId === 'tc-inner'
+				);
+				return inner?.kind === ResponsePartKind.ToolCall && inner.toolCall.status === ToolCallStatus.Running ? s : undefined;
+			});
 			const innerPart = subState?.activeTurn?.responseParts.find(
 				rp => rp.kind === ResponsePartKind.ToolCall && rp.toolCall.toolCallId === 'tc-inner'
 			);
@@ -1565,7 +1609,7 @@ suite('AgentSideEffects', () => {
 			});
 		}
 
-		test('auto-approves all writes when autoApprove is set to bypass', () => {
+		test('auto-approves all writes when autoApprove is set to bypass', async () => {
 			setupSessionWithConfig('autoApprove');
 			startTurn('turn-1');
 			disposables.add(sideEffects.registerProgressListener(agent));
@@ -1598,13 +1642,14 @@ suite('AgentSideEffects', () => {
 				permissionKind: 'write', permissionPath: '/workspace/.env',
 			});
 
+			await waitForState(stateManager, () => agent.respondToPermissionCalls.length > 0 || undefined);
 			// .env would normally be blocked, but session-level auto-approve overrides
 			assert.deepStrictEqual(agent.respondToPermissionCalls, [
 				{ requestId: 'tc-bypass-1', approved: true },
 			]);
 		});
 
-		test('auto-approves shell commands when autoApprove is set to bypass', () => {
+		test('auto-approves shell commands when autoApprove is set to bypass', async () => {
 			setupSessionWithConfig('autoApprove');
 			startTurn('turn-1');
 			disposables.add(sideEffects.registerProgressListener(agent));
@@ -1637,6 +1682,7 @@ suite('AgentSideEffects', () => {
 				permissionKind: 'shell', permissionPath: undefined,
 			});
 
+			await waitForState(stateManager, () => agent.respondToPermissionCalls.length > 0 || undefined);
 			// Dangerous command would normally be blocked, but session-level
 			// bypass auto-approve overrides.
 			assert.deepStrictEqual(agent.respondToPermissionCalls, [
@@ -1644,7 +1690,7 @@ suite('AgentSideEffects', () => {
 			]);
 		});
 
-		test('marks pending client tool approval for client-side auto-approval in bypass mode', () => {
+		test('marks pending client tool approval for client-side auto-approval in bypass mode', async () => {
 			setupSessionWithConfig('autoApprove');
 			startTurn('turn-1');
 			disposables.add(sideEffects.registerProgressListener(agent));
@@ -1669,7 +1715,11 @@ suite('AgentSideEffects', () => {
 				permissionKind: 'custom-tool', permissionPath: undefined,
 			});
 
-			const state = stateManager.getSessionState(sessionUri.toString());
+			const state = await waitForState(stateManager, () => {
+				const s = stateManager.getSessionState(sessionUri.toString());
+				const p = s?.activeTurn?.responseParts.find(part => part.kind === ResponsePartKind.ToolCall && part.toolCall.toolCallId === 'tc-client-approve-1');
+				return p?.kind === ResponsePartKind.ToolCall && p.toolCall.status === ToolCallStatus.PendingConfirmation ? s : undefined;
+			});
 			const part = state?.activeTurn?.responseParts.find(part => part.kind === ResponsePartKind.ToolCall && part.toolCall.toolCallId === 'tc-client-approve-1');
 			assert.ok(part?.kind === ResponsePartKind.ToolCall);
 			assert.deepStrictEqual({
@@ -1732,7 +1782,7 @@ suite('AgentSideEffects', () => {
 			assert.strictEqual(agent.respondToPermissionCalls.length, 0);
 		});
 
-		test('respects mid-session config change via SessionConfigChanged', () => {
+		test('respects mid-session config change via SessionConfigChanged', async () => {
 			setupSessionWithConfig('default');
 			startTurn('turn-1');
 			disposables.add(sideEffects.registerProgressListener(agent));
@@ -1771,6 +1821,7 @@ suite('AgentSideEffects', () => {
 				permissionKind: 'write', permissionPath: '/workspace/.env',
 			});
 
+			await waitForState(stateManager, () => agent.respondToPermissionCalls.length > 0 || undefined);
 			// Should now be auto-approved after config change
 			assert.deepStrictEqual(agent.respondToPermissionCalls, [
 				{ requestId: 'tc-mid-1', approved: true },
@@ -1815,6 +1866,7 @@ suite('AgentSideEffects', () => {
 				permissionKind: 'write', permissionPath: '/workspace/src/app.ts',
 			});
 
+			await waitForState(stateManager, () => agent.respondToPermissionCalls.length > 0 || undefined);
 			// Auto-approved writes call respondToPermissionRequest directly
 			assert.deepStrictEqual(agent.respondToPermissionCalls, [
 				{ requestId: 'tc-auto-1', approved: true },
@@ -1978,7 +2030,7 @@ suite('AgentSideEffects', () => {
 
 	suite('read auto-approve', () => {
 
-		test('auto-approves reads inside working directory', () => {
+		test('auto-approves reads inside working directory', async () => {
 			setupSession(URI.file('/workspace').toString());
 			startTurn('turn-1');
 			disposables.add(sideEffects.registerProgressListener(agent));
@@ -2011,6 +2063,7 @@ suite('AgentSideEffects', () => {
 				permissionKind: 'read', permissionPath: '/workspace/src/app.ts',
 			});
 
+			await waitForState(stateManager, () => agent.respondToPermissionCalls.length > 0 || undefined);
 			assert.deepStrictEqual(agent.respondToPermissionCalls, [
 				{ requestId: 'tc-read-1', approved: true },
 			]);
@@ -2547,7 +2600,7 @@ suite('AgentSideEffects', () => {
 			assert.strictEqual(parentInnerTool, undefined, 'inner tool must not leak into parent session');
 		});
 
-		test('reads inside parent working directory are auto-approved for tools in subagent sessions', () => {
+		test('reads inside parent working directory are auto-approved for tools in subagent sessions', async () => {
 			// Subagent sessions don't carry their own workingDirectory or
 			// autoApprove config. Without inheritance from the parent, every
 			// tool call inside a subagent (even a read in the workspace) would
@@ -2590,12 +2643,13 @@ suite('AgentSideEffects', () => {
 				permissionKind: 'read', permissionPath: '/workspace/src/app.ts',
 			});
 
+			await waitForState(stateManager, () => agent.respondToPermissionCalls.length > 0 || undefined);
 			assert.deepStrictEqual(agent.respondToPermissionCalls, [
 				{ requestId: 'inner-read-1', approved: true },
 			]);
 		});
 
-		test('session-level autoApprove on the parent is inherited by tools in subagent sessions', () => {
+		test('session-level autoApprove on the parent is inherited by tools in subagent sessions', async () => {
 			setupSession(URI.file('/workspace').toString());
 			startTurn('turn-1');
 			disposables.add(sideEffects.registerProgressListener(agent));
@@ -2650,6 +2704,7 @@ suite('AgentSideEffects', () => {
 				permissionKind: 'write', permissionPath: '/tmp/foo',
 			});
 
+			await waitForState(stateManager, () => agent.respondToPermissionCalls.length > 0 || undefined);
 			assert.deepStrictEqual(agent.respondToPermissionCalls, [
 				{ requestId: 'inner-write-1', approved: true },
 			]);
@@ -2660,7 +2715,7 @@ suite('AgentSideEffects', () => {
 
 	suite('session permissions', () => {
 
-		test('tool_ready action includes confirmation options when confirmation is needed', () => {
+		test('tool_ready action includes confirmation options when confirmation is needed', async () => {
 			setupSession();
 			startTurn('turn-1');
 			disposables.add(sideEffects.registerProgressListener(agent));
@@ -2693,7 +2748,13 @@ suite('AgentSideEffects', () => {
 				permissionKind: 'custom-tool', permissionPath: undefined,
 			});
 
-			const state = stateManager.getSessionState(sessionUri.toString());
+			const state = await waitForState(stateManager, () => {
+				const s = stateManager.getSessionState(sessionUri.toString());
+				const found = s?.activeTurn?.responseParts.find(
+					rp => rp.kind === ResponsePartKind.ToolCall && rp.toolCall.toolCallId === 'tc-perm-1'
+				);
+				return found?.kind === ResponsePartKind.ToolCall && found.toolCall.status === ToolCallStatus.PendingConfirmation ? s : undefined;
+			});
 			const tc = state!.activeTurn!.responseParts.find(
 				rp => rp.kind === ResponsePartKind.ToolCall && rp.toolCall.toolCallId === 'tc-perm-1'
 			);
@@ -2756,7 +2817,7 @@ suite('AgentSideEffects', () => {
 			);
 		});
 
-		test('subsequent tool_ready for same tool is auto-approved after allow-session permission', () => {
+		test('subsequent tool_ready for same tool is auto-approved after allow-session permission', async () => {
 			setupSession();
 			stateManager.setSessionConfig(sessionUri.toString(), {
 				schema: { type: 'object', properties: {} },
@@ -2793,12 +2854,13 @@ suite('AgentSideEffects', () => {
 				permissionKind: 'custom-tool', permissionPath: undefined,
 			});
 
+			await waitForState(stateManager, () => agent.respondToPermissionCalls.length > 0 || undefined);
 			assert.deepStrictEqual(agent.respondToPermissionCalls, [
 				{ requestId: 'tc-perm-3', approved: true },
 			]);
 		});
 
-		test('subagent tool calls inherit parent session permissions', () => {
+		test('subagent tool calls inherit parent session permissions', async () => {
 			setupSession();
 			stateManager.setSessionConfig(sessionUri.toString(), {
 				schema: { type: 'object', properties: {} },
@@ -2859,6 +2921,7 @@ suite('AgentSideEffects', () => {
 				permissionKind: 'custom-tool', permissionPath: undefined,
 			});
 
+			await waitForState(stateManager, () => agent.respondToPermissionCalls.length > 0 || undefined);
 			assert.deepStrictEqual(agent.respondToPermissionCalls, [
 				{ requestId: 'inner-perm-1', approved: true },
 			]);

--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -1,0 +1,136 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync } from 'fs';
+import { homedir, tmpdir } from 'os';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { join } from '../../../../base/common/path.js';
+import { isWindows } from '../../../../base/common/platform.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { platformSessionSchema } from '../../common/agentHostSchema.js';
+import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
+import { SessionStatus, ToolCallConfirmationReason, type SessionSummary } from '../../common/state/sessionState.js';
+import { AgentConfigurationService } from '../../node/agentConfigurationService.js';
+import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
+import { SessionPermissionManager, type IToolApprovalEvent } from '../../node/sessionPermissions.js';
+
+suite('SessionPermissionManager', () => {
+
+	const disposables = new DisposableStore();
+	let manager: AgentHostStateManager;
+	let permissions: SessionPermissionManager;
+
+	// Real (symlink-resolved) temp directories so that the symlink-resolution
+	// checks compare like-for-like (e.g. macOS `/var` -> `/private/var`).
+	let workDir: string;
+	let outsideDir: string;
+
+	const sessionUri = URI.from({ scheme: 'copilot', path: '/s' }).toString();
+
+	function makeSummary(resource: string, workingDirectory?: string): SessionSummary {
+		return {
+			resource,
+			provider: 'copilot',
+			title: 't',
+			status: SessionStatus.Idle,
+			createdAt: Date.now(),
+			modifiedAt: Date.now(),
+			project: { uri: 'file:///project', displayName: 'Project' },
+			workingDirectory,
+		};
+	}
+
+	function writeEvent(permissionPath: string): IToolApprovalEvent {
+		return { toolCallId: 'tc-1', session: URI.parse(sessionUri), permissionKind: 'write', permissionPath };
+	}
+
+	setup(async () => {
+		workDir = realpathSync(mkdtempSync(join(tmpdir(), 'sesperm-work-')));
+		outsideDir = realpathSync(mkdtempSync(join(tmpdir(), 'sesperm-out-')));
+
+		manager = disposables.add(new AgentHostStateManager(new NullLogService()));
+		const configService = disposables.add(new AgentConfigurationService(manager, new NullLogService()));
+		permissions = disposables.add(new SessionPermissionManager(manager, configService, new NullLogService()));
+		await permissions.initialize();
+
+		manager.createSession(makeSummary(sessionUri, URI.file(workDir).toString()));
+	});
+
+	teardown(() => {
+		disposables.clear();
+		rmSync(workDir, { recursive: true, force: true });
+		rmSync(outsideDir, { recursive: true, force: true });
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('auto-approves a normal file inside the working directory', async () => {
+		const result = await permissions.getAutoApproval(writeEvent(join(workDir, 'src', 'app.ts')), sessionUri);
+		assert.strictEqual(result, ToolCallConfirmationReason.NotNeeded);
+	});
+
+	test('requires confirmation for writes outside the working directory', async () => {
+		const result = await permissions.getAutoApproval(writeEvent(join(outsideDir, 'app.ts')), sessionUri);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('requires confirmation for protected files inside the working directory', async () => {
+		const files = ['.env', 'package.json', join('.git', 'config'), 'deps.lock', join('.vscode', 'settings.json')];
+		const results: (ToolCallConfirmationReason | undefined)[] = [];
+		for (const file of files) {
+			results.push(await permissions.getAutoApproval(writeEvent(join(workDir, file)), sessionUri));
+		}
+		assert.deepStrictEqual(results, files.map(() => undefined));
+	});
+
+	test('requires confirmation for paths containing null bytes', async () => {
+		const result = await permissions.getAutoApproval(writeEvent(join(workDir, 'a\u0000b.txt')), sessionUri);
+		assert.strictEqual(result, undefined);
+	});
+
+	(isWindows ? test.skip : test)('requires confirmation when a symlink redirects outside the working directory', async () => {
+		symlinkSync(outsideDir, join(workDir, 'link'), 'dir');
+		const result = await permissions.getAutoApproval(writeEvent(join(workDir, 'link', 'secret.txt')), sessionUri);
+		assert.strictEqual(result, undefined);
+	});
+
+	(isWindows ? test.skip : test)('auto-approves when a symlink stays inside the working directory', async () => {
+		mkdirSync(join(workDir, 'real'));
+		symlinkSync(join(workDir, 'real'), join(workDir, 'link-in'), 'dir');
+		const result = await permissions.getAutoApproval(writeEvent(join(workDir, 'link-in', 'note.txt')), sessionUri);
+		assert.strictEqual(result, ToolCallConfirmationReason.NotNeeded);
+	});
+
+	test('requires confirmation for home-directory dotfiles', async () => {
+		const homeSession = URI.from({ scheme: 'copilot', path: '/home' }).toString();
+		manager.createSession(makeSummary(homeSession, URI.file(homedir()).toString()));
+		const result = await permissions.getAutoApproval(writeEvent(join(homedir(), '.sesperm-config-xyz')), homeSession);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('auto-approves any write when session bypass is enabled', async () => {
+		manager.setSessionConfig(sessionUri, {
+			schema: platformSessionSchema.toProtocol(),
+			values: { [SessionConfigKey.AutoApprove]: 'autoApprove' },
+		});
+		const result = await permissions.getAutoApproval(writeEvent(join(outsideDir, 'anything.txt')), sessionUri);
+		assert.strictEqual(result, ToolCallConfirmationReason.Setting);
+	});
+
+	test('auto-approves reads inside but requires confirmation outside the working directory', async () => {
+		const inside = await permissions.getAutoApproval(
+			{ toolCallId: 'r', session: URI.parse(sessionUri), permissionKind: 'read', permissionPath: join(workDir, 'a.txt') },
+			sessionUri,
+		);
+		const outside = await permissions.getAutoApproval(
+			{ toolCallId: 'r', session: URI.parse(sessionUri), permissionKind: 'read', permissionPath: join(outsideDir, 'a.txt') },
+			sessionUri,
+		);
+		assert.deepStrictEqual([inside, outside], [ToolCallConfirmationReason.NotNeeded, undefined]);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -50,8 +50,14 @@ suite('SessionPermissionManager', () => {
 	}
 
 	setup(async () => {
-		workDir = realpathSync(mkdtempSync(join(tmpdir(), 'sesperm-work-')));
-		outsideDir = realpathSync(mkdtempSync(join(tmpdir(), 'sesperm-out-')));
+		// Prefer the CI runner temp dir (a plain long path) over `os.tmpdir()`,
+		// which on Windows CI is an 8.3 short path (`C:\Users\RUNNER~1\...`) that
+		// `assertPathIsSafe` rejects for its `~1` segment — which would make every
+		// auto-approval fail. `realpathSync` keeps macOS `/var` -> `/private/var`
+		// consistent so the symlink-resolution checks compare like-for-like.
+		const baseTmp = process.env.RUNNER_TEMP || tmpdir();
+		workDir = realpathSync(mkdtempSync(join(baseTmp, 'sesperm-work-')));
+		outsideDir = realpathSync(mkdtempSync(join(baseTmp, 'sesperm-out-')));
 
 		manager = disposables.add(new AgentHostStateManager(new NullLogService()));
 		const configService = disposables.add(new AgentConfigurationService(manager, new NullLogService()));


### PR DESCRIPTION
- The agent host auto-approved write tool calls using only working-directory and glob checks, while the extension's edit-confirmation pipeline also guards against unsafe paths, system/platform-config locations, and symlinks that redirect edits outside the workspace; this closes that gap so the agent host no longer silently approves edits the extension would prompt for.
- Resolves symlinks (including not-yet-created ancestors) so a link cannot be used to escape the working directory, and treats permission-denied resolution as requiring confirmation.
- Makes the approval path async rather than relying on synchronous filesystem calls, while keeping the shell-command approver synchronous so its existing behavior and tests are unaffected.
- Adds unit tests covering the new path-safety, platform-restriction, and symlink-escape checks.

(Commit message generated by Copilot)