### PR TITLE
Stop worktreeCreated tasks when a session is marked done

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/sessionTaskRunner.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTaskRunner.ts
@@ -30,8 +30,14 @@ export interface ISessionTaskRunner {
 	/**
 	 * Executes the given task in the session's runtime. The returned promise
 	 * resolves once the task has been launched (not when it has finished).
+	 *
+	 * May resolve to an {@link IDisposable} that stops the launched task (e.g.
+	 * kills its terminal/process). Callers that auto-dispatch tasks (such as
+	 * {@link WorktreeCreatedTaskDispatcher}) use it to stop long-running setup
+	 * processes when a session is marked done. Resolves to `undefined` when the
+	 * runner has nothing to stop.
 	 */
-	runTask(task: ITaskEntry, session: ISession): Promise<void>;
+	runTask(task: ITaskEntry, session: ISession): Promise<IDisposable | undefined>;
 }
 
 /**

--- a/src/vs/sessions/contrib/chat/browser/sessionsTasksService.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsTasksService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { IObservable, observableValue, transaction } from '../../../../base/common/observable.js';
 import { joinPath, dirname, isEqual } from '../../../../base/common/resources.js';
 import { parse } from '../../../../base/common/jsonc.js';
@@ -146,8 +146,11 @@ export interface ISessionsTasksService {
 	/**
 	 * Runs a task via the task service, looking it up by label in the
 	 * workspace folder corresponding to the session worktree.
+	 *
+	 * May resolve to an {@link IDisposable} that stops the launched task; see
+	 * {@link ISessionTaskRunner.runTask}.
 	 */
-	runTask(task: ITaskEntry, session: ISession): Promise<void>;
+	runTask(task: ITaskEntry, session: ISession): Promise<IDisposable | undefined>;
 
 	/**
 	 * Observable label of the pinned task for the given repository.
@@ -385,13 +388,14 @@ export class SessionsTasksService extends Disposable implements ISessionsTasksSe
 		}
 	}
 
-	async runTask(task: ITaskEntry, session: ISession): Promise<void> {
+	async runTask(task: ITaskEntry, session: ISession): Promise<IDisposable | undefined> {
 		const runner = this._taskRunnerRegistry.getRunner(session);
 		if (!runner) {
-			return;
+			return undefined;
 		}
-		await runner.runTask(task, session);
+		const handle = await runner.runTask(task, session);
 		this._onDidRunTask.fire({ task, session });
+		return handle;
 	}
 
 	getPinnedTaskLabel(repository: URI | undefined): IObservable<string | undefined> {

--- a/src/vs/sessions/contrib/chat/browser/workbenchSessionTaskRunner.ts
+++ b/src/vs/sessions/contrib/chat/browser/workbenchSessionTaskRunner.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Schemas } from '../../../../base/common/network.js';
+import { IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { TaskRunSource } from '../../../../workbench/contrib/tasks/common/tasks.js';
 import { ITaskService } from '../../../../workbench/contrib/tasks/common/taskService.js';
@@ -40,20 +41,26 @@ export class WorkbenchSessionTaskRunner implements ISessionTaskRunner {
 		return !!this._workspaceContextService.getWorkspaceFolder(cwd);
 	}
 
-	async runTask(task: ITaskEntry, session: ISession): Promise<void> {
+	async runTask(task: ITaskEntry, session: ISession): Promise<IDisposable | undefined> {
 		const cwd = this._getCwd(session);
 		if (!cwd) {
-			return;
+			return undefined;
 		}
 		const workspaceFolder = this._workspaceContextService.getWorkspaceFolder(cwd);
 		if (!workspaceFolder) {
-			return;
+			return undefined;
 		}
 		const resolved = await this._taskService.getTask(workspaceFolder, task.label);
 		if (!resolved) {
-			return;
+			return undefined;
 		}
 		await this._taskService.run(resolved, undefined, TaskRunSource.User);
+
+		// Hand back a stop handle so auto-dispatched setup/build tasks can be
+		// terminated when the session is marked done. See #321021.
+		return toDisposable(() => {
+			this._taskService.terminate(resolved);
+		});
 	}
 
 	private _getCwd(session: ISession) {

--- a/src/vs/sessions/contrib/chat/browser/worktreeCreatedTaskDispatcher.ts
+++ b/src/vs/sessions/contrib/chat/browser/worktreeCreatedTaskDispatcher.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
-import { registerAutorunSelfDisposable } from '../../../../base/common/observable.js';
+import { autorun, registerAutorunSelfDisposable } from '../../../../base/common/observable.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
@@ -30,6 +30,10 @@ export const AGENT_HOST_RUN_WORKTREE_CREATED_TASKS_SETTING = 'chat.agentHost.run
  * Sessions whose runtime already runs these tasks server-side (signalled via
  * {@link ISessionCapabilities.runsWorktreeCreatedTasks}) are skipped to avoid
  * double-execution.
+ *
+ * The stop handles returned by the dispatched tasks are tracked per session and
+ * disposed when the session is marked done (archived) or removed, so the
+ * long-running setup/build processes don't leak. See #321021.
  *
  * We deliberately ignore sessions that predate this contribution so restored
  * sessions don't re-run setup tasks when the agents window opens.
@@ -72,6 +76,8 @@ export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbe
 		const store = new DisposableStore();
 		this._sessionDisposables.set(session.sessionId, store);
 
+		const taskHandles = store.add(new DisposableStore());
+
 		registerAutorunSelfDisposable(store, reader => {
 			if (session.loading.read(reader)) {
 				return;
@@ -83,11 +89,17 @@ export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbe
 				return;
 			}
 			reader.dispose();
-			this._dispatchWorktreeCreatedTasks(session);
+			this._dispatchWorktreeCreatedTasks(session, taskHandles);
 		});
+
+		store.add(autorun(reader => {
+			if (session.isArchived.read(reader)) {
+				taskHandles.clear();
+			}
+		}));
 	}
 
-	private async _dispatchWorktreeCreatedTasks(session: ISession): Promise<void> {
+	private async _dispatchWorktreeCreatedTasks(session: ISession, taskHandles: DisposableStore): Promise<void> {
 		if (isAgentHostProviderId(session.providerId) && !this._configurationService.getValue<boolean>(AGENT_HOST_RUN_WORKTREE_CREATED_TASKS_SETTING)) {
 			this._logService.trace(`${LOG_PREFIX} Skipping worktreeCreated tasks for agent host session '${session.sessionId}' — '${AGENT_HOST_RUN_WORKTREE_CREATED_TASKS_SETTING}' is disabled.`);
 			return;
@@ -107,7 +119,14 @@ export class WorktreeCreatedTaskDispatcher extends Disposable implements IWorkbe
 			}
 			this._logService.trace(`${LOG_PREFIX} Running worktreeCreated task '${task.label}' for session '${session.sessionId}'`);
 			try {
-				await this._sessionsTasksService.runTask(task, session);
+				const handle = await this._sessionsTasksService.runTask(task, session);
+				if (handle) {
+					if (session.isArchived.get()) {
+						handle.dispose();
+					} else {
+						taskHandles.add(handle);
+					}
+				}
 			} catch (err) {
 				this._logService.warn(`${LOG_PREFIX} Failed to run task '${task.label}' for session '${session.sessionId}': ${err}`);
 			}

--- a/src/vs/sessions/contrib/chat/test/browser/workbenchSessionTaskRunner.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/workbenchSessionTaskRunner.test.ts
@@ -69,6 +69,7 @@ suite('WorkbenchSessionTaskRunner', () => {
 	const store = new DisposableStore();
 	let runner: WorkbenchSessionTaskRunner;
 	let ranTasks: { label: string }[];
+	let terminatedTasks: { label: string }[];
 	let tasksByLabel: Map<string, Task>;
 	let workspaceFoldersByUri: Map<string, IWorkspaceFolder>;
 
@@ -77,6 +78,7 @@ suite('WorkbenchSessionTaskRunner', () => {
 
 	setup(() => {
 		ranTasks = [];
+		terminatedTasks = [];
 		tasksByLabel = new Map();
 		workspaceFoldersByUri = new Map();
 
@@ -92,6 +94,10 @@ suite('WorkbenchSessionTaskRunner', () => {
 					ranTasks.push({ label: task._label });
 				}
 				return undefined;
+			}
+			override async terminate(task: Task) {
+				terminatedTasks.push({ label: task._label });
+				return { success: true, task };
 			}
 		});
 
@@ -137,9 +143,21 @@ suite('WorkbenchSessionTaskRunner', () => {
 		registerMockTask('build', worktreeUri);
 		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
 
-		await runner.runTask(makeTask('build'), session);
+		(await runner.runTask(makeTask('build'), session))?.dispose();
 
 		assert.deepStrictEqual(ranTasks, [{ label: 'build' }]);
+	});
+
+	test('returned handle terminates the task via ITaskService', async () => {
+		registerMockTask('build', worktreeUri);
+		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
+
+		const handle = await runner.runTask(makeTask('build'), session);
+		assert.deepStrictEqual(terminatedTasks, []);
+
+		handle?.dispose();
+
+		assert.deepStrictEqual(terminatedTasks, [{ label: 'build' }]);
 	});
 
 	test('runTask is a no-op when task is not registered', async () => {
@@ -155,7 +173,7 @@ suite('WorkbenchSessionTaskRunner', () => {
 		registerMockTask('build', repoUri);
 		const session = makeSession({ repository: repoUri });
 
-		await runner.runTask(makeTask('build'), session);
+		(await runner.runTask(makeTask('build'), session))?.dispose();
 
 		assert.deepStrictEqual(ranTasks, [{ label: 'build' }]);
 	});

--- a/src/vs/sessions/contrib/chat/test/browser/worktreeCreatedTaskDispatcher.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/worktreeCreatedTaskDispatcher.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { Emitter } from '../../../../../base/common/event.js';
-import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { DisposableStore, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { constObservable, observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
@@ -25,6 +25,7 @@ interface ITestSession {
 	readonly loading: ReturnType<typeof observableValue<boolean>>;
 	readonly status: ReturnType<typeof observableValue<SessionStatus>>;
 	readonly workspace: ReturnType<typeof observableValue<ISessionWorkspace | undefined>>;
+	readonly isArchived: ReturnType<typeof observableValue<boolean>>;
 }
 
 function makeWorkspace(hasWorktree: boolean): ISessionWorkspace {
@@ -50,6 +51,7 @@ function makeSession(opts: { id?: string; providerId?: string; runsWorktreeCreat
 	const loading = observableValue('loading', opts.loading ?? false);
 	const status = observableValue('status', opts.status ?? SessionStatus.InProgress);
 	const workspace = observableValue<ISessionWorkspace | undefined>('workspace', makeWorkspace(opts.hasWorktree ?? true));
+	const isArchived = observableValue('isArchived', false);
 	const chat = { resource: URI.parse('file:///session') } as IChat;
 	const session: ISession = {
 		sessionId: opts.id ?? 'test:session',
@@ -67,7 +69,7 @@ function makeSession(opts: { id?: string; providerId?: string; runsWorktreeCreat
 		modelId: observableValue('modelId', undefined),
 		mode: observableValue('mode', undefined),
 		loading,
-		isArchived: observableValue('isArchived', false),
+		isArchived,
 		isRead: observableValue('isRead', true),
 		lastTurnEnd: observableValue('lastTurnEnd', undefined),
 		description: observableValue('description', undefined),
@@ -75,7 +77,7 @@ function makeSession(opts: { id?: string; providerId?: string; runsWorktreeCreat
 		mainChat: constObservable(chat),
 		capabilities: { supportsMultipleChats: false, runsWorktreeCreatedTasks: opts.runsWorktreeCreatedTasks },
 	};
-	return { session, loading, status, workspace };
+	return { session, loading, status, workspace, isArchived };
 }
 
 function entry(label: string, runOn?: 'worktreeCreated' | 'folderOpen' | 'default'): ISessionTaskWithTarget {
@@ -91,6 +93,7 @@ function entry(label: string, runOn?: 'worktreeCreated' | 'folderOpen' | 'defaul
 class FakeSessionsTasksService implements Partial<ISessionsTasksService> {
 	declare readonly _serviceBrand: undefined;
 	readonly ranTasks: { label: string; sessionId: string }[] = [];
+	readonly stoppedTasks: { label: string; sessionId: string }[] = [];
 	private readonly _tasks = new Map<string, readonly ISessionTaskWithTarget[]>();
 	runTaskFails = false;
 
@@ -102,11 +105,12 @@ class FakeSessionsTasksService implements Partial<ISessionsTasksService> {
 		return this._tasks.get(session.sessionId) ?? [];
 	}
 
-	async runTask(task: ITaskEntry, session: ISession): Promise<void> {
+	async runTask(task: ITaskEntry, session: ISession): Promise<IDisposable | undefined> {
 		this.ranTasks.push({ label: task.label, sessionId: session.sessionId });
 		if (this.runTaskFails) {
 			throw new Error('simulated launch failure');
 		}
+		return toDisposable(() => this.stoppedTasks.push({ label: task.label, sessionId: session.sessionId }));
 	}
 }
 
@@ -291,5 +295,53 @@ suite('WorktreeCreatedTaskDispatcher', () => {
 		await settle();
 
 		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'a' }]);
+	});
+
+	test('stops dispatched tasks when the session is marked done (archived)', async () => {
+		createDispatcher();
+		const { session, workspace, isArchived } = makeSession({ id: 'a', hasWorktree: false });
+		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
+
+		mgmt.sessionStartedEmitter.fire(session);
+		workspace.set(makeWorkspace(true), undefined);
+		await settle();
+		assert.deepStrictEqual(tasks.stoppedTasks, []);
+
+		isArchived.set(true, undefined);
+		await settle();
+
+		assert.deepStrictEqual(tasks.stoppedTasks, [{ label: 'setup', sessionId: 'a' }]);
+	});
+
+	test('stops dispatched tasks when a started session is removed', async () => {
+		createDispatcher();
+		const { session, workspace } = makeSession({ id: 'a', hasWorktree: false });
+		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
+
+		mgmt.sessionStartedEmitter.fire(session);
+		workspace.set(makeWorkspace(true), undefined);
+		await settle();
+		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'a' }]);
+
+		mgmt.sessionsChangedEmitter.fire({ added: [], removed: [session], changed: [] });
+		await settle();
+
+		assert.deepStrictEqual(tasks.stoppedTasks, [{ label: 'setup', sessionId: 'a' }]);
+	});
+
+	test('stops a task that finishes launching after the session is archived', async () => {
+		createDispatcher();
+		const { session, workspace, isArchived } = makeSession({ id: 'a', hasWorktree: false });
+		tasks.setTasks(session.sessionId, [entry('setup', 'worktreeCreated')]);
+
+		mgmt.sessionStartedEmitter.fire(session);
+		// Archive before the worktree appears so the task is launched against an
+		// already-archived session.
+		isArchived.set(true, undefined);
+		workspace.set(makeWorkspace(true), undefined);
+		await settle();
+
+		assert.deepStrictEqual(tasks.ranTasks, [{ label: 'setup', sessionId: 'a' }]);
+		assert.deepStrictEqual(tasks.stoppedTasks, [{ label: 'setup', sessionId: 'a' }]);
 	});
 });

--- a/src/vs/sessions/contrib/terminal/browser/agentHostSessionTaskRunner.ts
+++ b/src/vs/sessions/contrib/terminal/browser/agentHostSessionTaskRunner.ts
@@ -5,9 +5,11 @@
 
 import { localize } from '../../../../nls.js';
 import { Schemas } from '../../../../base/common/network.js';
+import { IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { AGENT_HOST_SCHEME, fromAgentHostUri } from '../../../../platform/agentHost/common/agentHostUri.js';
+import { TerminalExitReason } from '../../../../platform/terminal/common/terminal.js';
 import { IAgentHostTerminalService } from '../../../../workbench/contrib/terminal/browser/agentHostTerminalService.js';
 import { ITerminalGroupService, ITerminalService } from '../../../../workbench/contrib/terminal/browser/terminal.js';
 import { isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
@@ -43,10 +45,10 @@ export class AgentHostSessionTaskRunner implements ISessionTaskRunner {
 		return this._getAddress(session) !== undefined;
 	}
 
-	async runTask(task: ITaskEntry, session: ISession): Promise<void> {
+	async runTask(task: ITaskEntry, session: ISession): Promise<IDisposable | undefined> {
 		const address = this._getAddress(session);
 		if (!address) {
-			return;
+			return undefined;
 		}
 
 		const allTasks = await this._sessionsTasksService.getAllTasks(session);
@@ -58,7 +60,7 @@ export class AgentHostSessionTaskRunner implements ISessionTaskRunner {
 		const command = resolveTaskCommand(task, { lookup: label => byLabel.get(label) });
 		if (!command) {
 			this._logService.trace(`${LOG_PREFIX} Skipping task '${task.label}' — no command could be resolved.`);
-			return;
+			return undefined;
 		}
 
 		const cwd = this._getCwd(session);
@@ -68,12 +70,16 @@ export class AgentHostSessionTaskRunner implements ISessionTaskRunner {
 		});
 		if (!instance) {
 			this._logService.warn(`${LOG_PREFIX} Failed to create terminal for task '${task.label}' on '${address}'.`);
-			return;
+			return undefined;
 		}
 
 		this._terminalService.setActiveInstance(instance);
 		await this._terminalGroupService.showPanel(true);
 		await instance.sendText(command, /*shouldExecute*/ true);
+
+		return toDisposable(() => {
+			instance.dispose(TerminalExitReason.User);
+		});
 	}
 
 	private _getAddress(session: ISession): string | undefined {

--- a/src/vs/sessions/contrib/terminal/test/browser/agentHostSessionTaskRunner.test.ts
+++ b/src/vs/sessions/contrib/terminal/test/browser/agentHostSessionTaskRunner.test.ts
@@ -72,12 +72,17 @@ suite('AgentHostSessionTaskRunner', () => {
 	let runner: AgentHostSessionTaskRunner;
 	let createdTerminals: { address: string; options?: IAgentHostTerminalCreateOptions }[];
 	let sentText: { text: string; shouldExecute: boolean }[];
+	let disposedTerminals: ITerminalInstance[];
 	let allTasks: ISessionTaskWithTarget[];
-	const fakeInstance = { sendText: async (text: string, shouldExecute: boolean) => { sentText.push({ text, shouldExecute }); } } as ITerminalInstance;
+	const fakeInstance = {
+		sendText: async (text: string, shouldExecute: boolean) => { sentText.push({ text, shouldExecute }); },
+		dispose: () => { disposedTerminals.push(fakeInstance); },
+	} as unknown as ITerminalInstance;
 
 	setup(() => {
 		createdTerminals = [];
 		sentText = [];
+		disposedTerminals = [];
 		allTasks = [];
 
 		const instantiationService = store.add(new TestInstantiationService());
@@ -146,12 +151,23 @@ suite('AgentHostSessionTaskRunner', () => {
 		const cwd = URI.parse('file:///path/to/worktree');
 		const session = makeSession({ providerId: LOCAL_AGENT_HOST_PROVIDER_ID, cwd });
 
-		await runner.runTask(shellTask(), session);
+		(await runner.runTask(shellTask(), session))?.dispose();
 
 		assert.strictEqual(createdTerminals.length, 1);
 		assert.strictEqual(createdTerminals[0].address, '__local__');
 		assert.deepStrictEqual(createdTerminals[0].options?.cwd?.toString(), cwd.toString());
 		assert.deepStrictEqual(sentText, [{ text: 'echo hi', shouldExecute: true }]);
+	});
+
+	test('returned handle stops the task by disposing its terminal', async () => {
+		const session = makeSession({ providerId: LOCAL_AGENT_HOST_PROVIDER_ID, cwd: URI.parse('file:///x') });
+
+		const handle = await runner.runTask(shellTask(), session);
+		assert.deepStrictEqual(disposedTerminals, []);
+
+		handle?.dispose();
+
+		assert.deepStrictEqual(disposedTerminals, [fakeInstance]);
 	});
 
 	test('agent-host scheme cwds are unwrapped to their original URI', async () => {
@@ -160,7 +176,7 @@ suite('AgentHostSessionTaskRunner', () => {
 		assert.strictEqual(wrapped.scheme, AGENT_HOST_SCHEME, 'precondition: wrapped uri');
 		const session = makeSession({ providerId: 'agenthost-myhost', cwd: wrapped });
 
-		await runner.runTask(shellTask(), session);
+		(await runner.runTask(shellTask(), session))?.dispose();
 
 		assert.strictEqual(createdTerminals.length, 1);
 		assert.strictEqual(createdTerminals[0].options?.cwd?.toString(), innerCwd.toString());
@@ -169,7 +185,7 @@ suite('AgentHostSessionTaskRunner', () => {
 	test('unknown scheme cwds are omitted (host uses default)', async () => {
 		const session = makeSession({ providerId: 'agenthost-myhost', cwd: URI.parse('vscode-vfs://github/owner/repo') });
 
-		await runner.runTask(shellTask(), session);
+		(await runner.runTask(shellTask(), session))?.dispose();
 
 		assert.strictEqual(createdTerminals.length, 1);
 		assert.strictEqual(createdTerminals[0].options?.cwd, undefined);
@@ -177,7 +193,7 @@ suite('AgentHostSessionTaskRunner', () => {
 
 	test('skips when no command can be resolved from the task', async () => {
 		const session = makeSession({ providerId: LOCAL_AGENT_HOST_PROVIDER_ID, cwd: URI.parse('file:///x') });
-		await runner.runTask({ label: 'empty' }, session);
+		(await runner.runTask({ label: 'empty' }, session))?.dispose();
 		assert.deepStrictEqual(createdTerminals, []);
 	});
 
@@ -197,7 +213,7 @@ suite('AgentHostSessionTaskRunner', () => {
 			{ task: top, target: 'workspace' },
 		];
 
-		await runner.runTask(top, session);
+		(await runner.runTask(top, session))?.dispose();
 
 		assert.deepStrictEqual(sentText, [{ text: 'npm run transpile && npm run dev', shouldExecute: true }]);
 	});


### PR DESCRIPTION
Fixes #321021

### Problem
`WorktreeCreatedTaskDispatcher` auto-dispatches `runOptions.runOn === 'worktreeCreated'` setup/build tasks for new sessions, but never stopped them. When a session was marked done (archived), the launched terminals — and their (potentially remote, agent-host) host processes — kept running and leaked.

### Fix
- `ISessionTaskRunner.runTask` / `ISessionsTasksService.runTask` now return a `Promise<IDisposable | undefined>` stop handle.
- `AgentHostSessionTaskRunner` returns a handle that disposes the created terminal directly with `TerminalExitReason.User` (prompt-free, so the automated cleanup never triggers a "confirm on kill" modal). Disposing the instance shuts down the `AgentHostPty`, which sends `disposeTerminal` over the connection and the host kills the node-pty process.
- `WorkbenchSessionTaskRunner` returns a handle that terminates the task via `ITaskService.terminate`.
- `WorktreeCreatedTaskDispatcher` tracks the stop handles per session and disposes them when the session is archived (`isArchived`) or removed. A launch/archive race is handled so a task that finishes launching after archival is stopped immediately.

### Verification
- `npm run typecheck-client`: clean
- Unit tests pass, with new coverage for: stop-on-archive, stop-on-remove, stop-after-archive race, and handle-kills-terminal / terminates-task for both runners.

Manual `Run Task` invocations are intentionally unaffected (their handles are dropped, matching prior behavior); only auto-dispatched `worktreeCreated` tasks are stopped on done.