### PR TITLE
Telemetry for hidden terminal interaction

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalTabsChatEntry.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabsChatEntry.ts
@@ -92,6 +92,9 @@ export class TerminalTabsChatEntry extends Disposable {
 
 	private async _deleteAllHiddenTerminals(): Promise<void> {
 		const hiddenTerminals = this._terminalChatService.getToolSessionTerminalInstances(true);
+		if (hiddenTerminals.length === 0) {
+			return;
+		}
 
 		type DeleteHiddenChatTerminalsEvent = {
 			count: number;

--- a/src/vs/workbench/contrib/terminal/browser/terminalTabsChatEntry.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabsChatEntry.ts
@@ -9,6 +9,7 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { $ } from '../../../../base/browser/dom.js';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { ITerminalChatService, ITerminalService } from './terminal.js';
 import * as dom from '../../../../base/browser/dom.js';
 
@@ -31,6 +32,7 @@ export class TerminalTabsChatEntry extends Disposable {
 		@ICommandService private readonly _commandService: ICommandService,
 		@ITerminalChatService private readonly _terminalChatService: ITerminalChatService,
 		@ITerminalService private readonly _terminalService: ITerminalService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
 
@@ -90,6 +92,19 @@ export class TerminalTabsChatEntry extends Disposable {
 
 	private async _deleteAllHiddenTerminals(): Promise<void> {
 		const hiddenTerminals = this._terminalChatService.getToolSessionTerminalInstances(true);
+
+		type DeleteHiddenChatTerminalsEvent = {
+			count: number;
+		};
+		type DeleteHiddenChatTerminalsClassification = {
+			owner: 'anthonykim1';
+			comment: 'Tracks when the user deletes all hidden chat terminals from the terminal tabs entry.';
+			count: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of hidden chat terminals that were deleted.' };
+		};
+		this._telemetryService.publicLog2<DeleteHiddenChatTerminalsEvent, DeleteHiddenChatTerminalsClassification>('terminal.chatDeleteHiddenTerminals', {
+			count: hiddenTerminals.length,
+		});
+
 		await Promise.all(hiddenTerminals.map(terminal => this._terminalService.safeDisposeTerminal(terminal)));
 	}
 

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
@@ -490,7 +490,7 @@ registerAction2(class ShowChatTerminalsAction extends Action2 {
 
 	private _logRevealHiddenTerminal(telemetryService: ITelemetryService, via: 'single' | 'quickPick'): void {
 		type RevealHiddenChatTerminalEvent = {
-			via: string;
+			via: 'single' | 'quickPick';
 		};
 		type RevealHiddenChatTerminalClassification = {
 			owner: 'anthonykim1';

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
@@ -28,6 +28,7 @@ import { TerminalChatController } from './terminalChatController.js';
 import { TerminalCapability } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { isString } from '../../../../../base/common/types.js';
 import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IPreferencesService, IOpenSettingsOptions } from '../../../../services/preferences/common/preferences.js';
 import { ConfigurationTarget } from '../../../../../platform/configuration/common/configuration.js';
 import { TerminalChatAgentToolsSettingId } from '../../chatAgentTools/common/terminalChatAgentToolsConfiguration.js';
@@ -317,6 +318,15 @@ registerActiveXtermAction({
 	}
 });
 
+type ViewHiddenChatTerminalsEvent = {
+	hiddenCount: number;
+};
+type ViewHiddenChatTerminalsClassification = {
+	owner: 'anthonykim1';
+	comment: 'Tracks when the user opens the hidden chat terminals UI to understand how often users need to reach into agent-owned terminals.';
+	hiddenCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of hidden chat terminals that existed when the action was invoked. A value of 1 reveals the terminal directly, while more than 1 shows a quick pick.' };
+};
+
 registerAction2(class ShowChatTerminalsAction extends Action2 {
 	constructor() {
 		super({
@@ -343,6 +353,7 @@ registerAction2(class ShowChatTerminalsAction extends Action2 {
 		const quickInputService = accessor.get(IQuickInputService);
 		const instantiationService = accessor.get(IInstantiationService);
 		const chatService = accessor.get(IChatService);
+		const telemetryService = accessor.get(ITelemetryService);
 
 		const visible = new Set<ITerminalInstance>([...groupService.instances, ...editorService.instances]);
 		const toolInstances = terminalChatService.getToolSessionTerminalInstances();
@@ -364,12 +375,17 @@ registerAction2(class ShowChatTerminalsAction extends Action2 {
 			return;
 		}
 
+		telemetryService.publicLog2<ViewHiddenChatTerminalsEvent, ViewHiddenChatTerminalsClassification>('terminal.chatViewHiddenTerminals', {
+			hiddenCount: all.size,
+		});
+
 		// If there's only one hidden terminal, show it directly without the quick pick
 		if (all.size === 1) {
 			const instance = Array.from(all.values())[0];
 			terminalService.setActiveInstance(instance);
 			await terminalService.revealTerminal(instance);
 			await terminalService.focusInstance(instance);
+			this._logRevealHiddenTerminal(telemetryService, 'single');
 			return;
 		}
 
@@ -457,6 +473,7 @@ registerAction2(class ShowChatTerminalsAction extends Action2 {
 					await terminalService.revealTerminal(instance);
 					qp.hide();
 					await terminalService.focusInstance(instance);
+					this._logRevealHiddenTerminal(telemetryService, 'quickPick');
 				} else {
 					qp.hide();
 				}
@@ -469,6 +486,18 @@ registerAction2(class ShowChatTerminalsAction extends Action2 {
 			qp.dispose();
 		}));
 		qp.show();
+	}
+
+	private _logRevealHiddenTerminal(telemetryService: ITelemetryService, via: 'single' | 'quickPick'): void {
+		type RevealHiddenChatTerminalEvent = {
+			via: string;
+		};
+		type RevealHiddenChatTerminalClassification = {
+			owner: 'anthonykim1';
+			comment: 'Tracks when the user reveals and focuses a specific hidden chat terminal, indicating they needed to interact directly with an agent-owned terminal.';
+			via: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'How the terminal was revealed: single (only one hidden terminal) or quickPick (selected from the list).' };
+		};
+		telemetryService.publicLog2<RevealHiddenChatTerminalEvent, RevealHiddenChatTerminalClassification>('terminal.chatRevealHiddenTerminal', { via });
 	}
 });
 


### PR DESCRIPTION
- Add `terminal.chatViewHiddenTerminals` when the user opens the hidden chat terminals UI, with `hiddenCount` (1 reveals directly, more than 1 shows a quick pick).
- Add `terminal.chatRevealHiddenTerminal` when a specific hidden terminal is revealed and focused, with `via` set to `single` or `quickPick`.
- Add `terminal.chatDeleteHiddenTerminals` when the user kills all hidden chat terminals from the terminal tabs entry, with `count`.
- Keep the existing reveal/focus flow unchanged; telemetry only observes the already-present interactions.
- Capture the funnel intentionally: every reveal is preceded by a view event, while a view with `hiddenCount > 1` and no matching `quickPick` reveal indicates the user browsed the picker and backed out.

-----------------------------------------
Inspirations from:

- `publicLog2` classification shape and GDPR property conventions come from [`RunInTerminalToolTelemetry`](https://github.com/microsoft/vscode/blob/03406e22cb9d90ab83a6ceb61290834a7ba5b6ef/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalToolTelemetry.ts#L83-L90).
- `terminal.chatViewHiddenTerminals` and `terminal.chatRevealHiddenTerminal` are emitted from the existing reveal/quick-pick flow in [`ShowChatTerminalsAction.run`](https://github.com/microsoft/vscode/blob/03406e22cb9d90ab83a6ceb61290834a7ba5b6ef/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts#L378-L500).
- `terminal.chatDeleteHiddenTerminals` is emitted from the status-bar delete handler in [`TerminalTabsChatEntry`](https://github.com/microsoft/vscode/blob/03406e22cb9d90ab83a6ceb61290834a7ba5b6ef/src/vs/workbench/contrib/terminal/browser/terminalTabsChatEntry.ts#L104-L106).
- Sibling terminal-chat interaction events (`terminal/chatFocusInstance`, `terminal/chatToggleOutput`) that this set complements come from [`chatTerminalToolProgressPart`](https://github.com/microsoft/vscode/blob/03406e22cb9d90ab83a6ceb61290834a7ba5b6ef/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts#L1084-L1125).
