### PR TITLE
Enable persistent CoT for GPT-5.4 and GPT-5.5

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -27,7 +27,7 @@ import { IChatWebSocketManager } from '../../networking/node/chatWebSocketManage
 import { IExperimentationService } from '../../telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../telemetry/common/telemetry';
 import { TelemetryData } from '../../telemetry/common/telemetryData';
-import { getVerbosityForModelSync, isHiddenModelM } from '../common/chatModelCapabilities';
+import { getVerbosityForModelSync, isGpt54, isGpt55, isHiddenModelM } from '../common/chatModelCapabilities';
 import { rawPartAsCompactionData } from '../common/compactionDataContainer';
 import { rawPartAsPhaseData } from '../common/phaseDataContainer';
 import { getIndexOfStatefulMarker, getStatefulMarkerAndIndex } from '../common/statefulMarkerContainer';
@@ -164,7 +164,7 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 		: undefined;
 	const summary = summaryConfig === 'off' || shouldDisableReasoningSummary ? undefined : summaryConfig;
 	const persistentCoTEnabled = configService.getExperimentBasedConfig(ConfigKey.ResponsesApiPersistentCoTEnabled, expService)
-		&& isHiddenModelM(endpoint);
+		&& (isGpt54(endpoint) || isGpt55(endpoint) || isHiddenModelM(endpoint));
 	if (effort || summary || persistentCoTEnabled) {
 		body.reasoning = {
 			...(effort ? { effort } : {}),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This expands the Responses API persistent chain-of-thought experiment to cover gpt-5.4 and gpt-5.5 while preserving the existing supported model-family behavior. Previously, the setting did not affect the GPT-5.4/GPT-5.5 families.

The request builder now includes gpt-5.4 and gpt-5.5 in the persistent CoT model-family gate when `github.copilot.chat.responsesApi.persistentCoT.enabled` is enabled. The user-facing setting description remains unchanged.

Testing:
- `git diff --check`
- Not run: full compile/test/hygiene. This worktree was missing dependencies, and `npm ci` failed with `ENOSPC` before dependency installation could complete.