### PR TITLE
smoke: fix flaky Agents Window Copilot CLI session activation

### DIFF
--- a/test/automation/src/agentsWindow.ts
+++ b/test/automation/src/agentsWindow.ts
@@ -262,8 +262,13 @@ export class AgentsWindow {
 	 * would land in the untitled session and the follow-up never reaches
 	 * the intended conversation. When the check fails the active session is
 	 * re-activated and the prompt is re-typed before sending.
+	 *
+	 * `activeRowMatch` (defaulting to `expectedActiveLabel`) is forwarded to
+	 * {@link activateSessionByLabel} to locate the row on re-activation; pass
+	 * both the first prompt and the response so row matching is robust against
+	 * the asynchronously generated session title (see that method's docs).
 	 */
-	async sendFollowUpMessage(prompt: string, sendButtonRetryCount: number = 600, expectedActiveLabel?: string): Promise<void> {
+	async sendFollowUpMessage(prompt: string, sendButtonRetryCount: number = 600, expectedActiveLabel?: string, activeRowMatch?: string | string[]): Promise<void> {
 		const typeAndSend = async () => {
 			await this.code.waitForElement(ACTIVE_SESSION_INPUT_EDITOR);
 			await this.code.waitAndClick(ACTIVE_SESSION_INPUT_EDITOR);
@@ -278,7 +283,7 @@ export class AgentsWindow {
 			if (!stillActive) {
 				// The active slot swapped between activation and send. Re-bind
 				// and re-type the prompt before sending.
-				await this.activateSessionByLabel(expectedActiveLabel);
+				await this.activateSessionByLabel(activeRowMatch ?? expectedActiveLabel, expectedActiveLabel);
 				await typeAndSend();
 			}
 		}
@@ -302,11 +307,25 @@ export class AgentsWindow {
 	 * untitled session and spawn a brand new agent session instead of
 	 * continuing the existing conversation.
 	 *
-	 * `label` should be a substring of the session row's text (typically the
-	 * first response text from message 1, e.g. `MOCKED_COPILOT_RESPONSE`).
-	 * We can't simply click the topmost row because the sessions list
-	 * contains workspace folder group headers and historical sessions from
-	 * prior runs.
+	 * `rowMatch` is one (or several) substrings used to locate the row; a row
+	 * matches when its text contains ANY of them. We can't simply click the
+	 * topmost row because the sessions list contains workspace folder group
+	 * headers and historical sessions from prior runs.
+	 *
+	 * Pass BOTH the user's first prompt and the expected response here. The
+	 * row's text is the session title, which is auto-generated asynchronously
+	 * by a utility model after the first turn: until that lands the title is
+	 * the synchronous fallback (the user's prompt), and once it lands the
+	 * title becomes the generated value (which, in the smoke mock, echoes the
+	 * scenario reply because the title prompt embeds the tagged user message).
+	 * Matching on the prompt alone is racy because the generated title can
+	 * replace it; matching on the response alone is racy because the generated
+	 * title may not have landed yet. Accepting either makes activation
+	 * deterministic regardless of when the title generation completes.
+	 *
+	 * `responseLabel` (defaulting to the first `rowMatch` entry) is the text
+	 * the just-completed conversation's response bubble must contain; it is
+	 * verified in the active session view after the row is clicked.
 	 *
 	 * Returns once the active session has loaded and is ready for input.
 	 *
@@ -330,37 +349,39 @@ export class AgentsWindow {
 	 * guarantees the chat widget has actually re-bound to the session we
 	 * intended to activate before the caller types a follow-up.
 	 */
-	async activateSessionByLabel(label: string, timeoutMs: number = 30_000): Promise<void> {
+	async activateSessionByLabel(rowMatch: string | string[], responseLabel?: string, timeoutMs: number = 30_000): Promise<void> {
 		const retryCount = Math.ceil(timeoutMs / 100);
 		await this.code.waitForElement(SESSION_LIST_ROW, undefined, retryCount);
 		const workingStatus = 'Working...';
 		const deadline = Date.now() + timeoutMs;
-		const needle = label.toLowerCase();
+		const rowMatches = Array.isArray(rowMatch) ? rowMatch : [rowMatch];
+		const rowNeedles = rowMatches.map(s => s.toLowerCase());
+		const responseNeedle = (responseLabel ?? rowMatches[0]).toLowerCase();
 		const activeResponseSelector = `${ACTIVE_SESSION} .interactive-item-container.interactive-response .rendered-markdown`;
 		let lastTexts: string[] = [];
 		let lastActiveTexts: string[] = [];
 		while (Date.now() < deadline) {
 			const rows = await this.code.getElements(SESSION_LIST_ROW, /* recursive */ true);
 			lastTexts = (rows ?? []).map(r => (r.textContent ?? '').trim());
-			const matchIndex = lastTexts.findIndex(t => t.toLowerCase().includes(needle) && !t.includes(workingStatus));
+			const matchIndex = lastTexts.findIndex(t => !t.includes(workingStatus) && rowNeedles.some(n => t.toLowerCase().includes(n)));
 			if (matchIndex < 0) {
 				await new Promise(r => setTimeout(r, 250));
 				continue;
 			}
 
 			const summary = lastTexts.map((t, i) => `[${i}] ${JSON.stringify(t.slice(0, 120))}`).join('\n');
-			console.log(`[agentsWindow] activateSessionByLabel("${label}") clicking index ${matchIndex}; all rows:\n${summary}`);
+			console.log(`[agentsWindow] activateSessionByLabel(${JSON.stringify(rowMatches)}) clicking index ${matchIndex}; all rows:\n${summary}`);
 			await this.code.waitAndClick(`${SESSION_LIST_ROW}[data-index="${matchIndex}"]`);
 			await this.code.waitForElement(ACTIVE_SESSION_INPUT_EDITOR, undefined, retryCount);
 
 			// Wait until the active session view's chat widget actually shows a
-			// response matching `label`. A bare `is-active` check is not enough
-			// because the workbench may auto-create a fresh untitled session
-			// and route it into the active slot between row-render and click.
+			// response matching `responseLabel`. A bare `is-active` check is not
+			// enough because the workbench may auto-create a fresh untitled
+			// session and route it into the active slot between row-render and click.
 			while (Date.now() < deadline) {
 				const responses = await this.code.getElements(activeResponseSelector, /* recursive */ true);
 				lastActiveTexts = (responses ?? []).map(el => (el.textContent ?? '').trim());
-				if (lastActiveTexts.some(t => t.toLowerCase().includes(needle))) {
+				if (lastActiveTexts.some(t => t.toLowerCase().includes(responseNeedle))) {
 					return;
 				}
 				await new Promise(r => setTimeout(r, 250));
@@ -368,10 +389,10 @@ export class AgentsWindow {
 			const activeSummary = lastActiveTexts.length
 				? lastActiveTexts.map((t, i) => `  [${i}] ${JSON.stringify(t.slice(0, 120))}`).join('\n')
 				: '  (no response bubbles in active session view)';
-			throw new Error(`Activated row index ${matchIndex} but the active session view never rendered a response containing "${label}". Active view responses:\n${activeSummary}`);
+			throw new Error(`Activated row index ${matchIndex} but the active session view never rendered a response containing "${responseLabel ?? rowMatches[0]}". Active view responses:\n${activeSummary}`);
 		}
 		const summary = lastTexts.map((t, i) => `  [${i}] ${JSON.stringify(t.slice(0, 120))}`).join('\n');
-		throw new Error(`Timed out waiting for a settled session list row containing "${label}" (without "${workingStatus}"). Last-seen rows:\n${summary}`);
+		throw new Error(`Timed out waiting for a settled session list row containing any of ${JSON.stringify(rowMatches)} (without "${workingStatus}"). Last-seen rows:\n${summary}`);
 	}
 
 	/**

--- a/test/smoke/src/areas/agentsWindow/agentsWindow.test.ts
+++ b/test/smoke/src/areas/agentsWindow/agentsWindow.test.ts
@@ -215,8 +215,9 @@ export function setup(logger: Logger) {
 					await app.workbench.agentsWindow.selectSessionType(session.name);
 
 					const requestsBefore = mockServer.requestCount();
+					const firstPrompt = `hello world [scenario:${session.scenarioId}]`;
 					logger.log(`[Agents Window/${session.name}] submitting prompt; requestCount=${requestsBefore}`);
-					await app.workbench.agentsWindow.submitNewSessionPrompt(`hello world [scenario:${session.scenarioId}]`);
+					await app.workbench.agentsWindow.submitNewSessionPrompt(firstPrompt);
 					logger.log(`[Agents Window/${session.name}] prompt submitted; waiting for assistant text '${session.reply}'; requestCount=${mockServer.requestCount()}`);
 
 					const text = await app.workbench.agentsWindow.waitForAssistantText(session.reply);
@@ -229,10 +230,15 @@ export function setup(logger: Logger) {
 					// than continuing the existing one. Click back into the
 					// just-completed session before sending message 2 so the
 					// follow-up lands in the same session. Identify the row by
-					// its msg1 reply text since the sessions list also contains
-					// workspace folder group headers and historical sessions.
+					// EITHER the first prompt or the msg1 reply: the row text is
+					// the session title, which starts as the prompt (synchronous
+					// fallback) and is asynchronously replaced by a generated
+					// title (the reply, in the mock). Matching either avoids a
+					// race on when title generation lands. The sessions list also
+					// contains workspace folder group headers and historical
+					// sessions, so we can't just click the topmost row.
 					if (session.name === 'Copilot CLI') {
-						await app.workbench.agentsWindow.activateSessionByLabel(session.reply);
+						await app.workbench.agentsWindow.activateSessionByLabel([firstPrompt, session.reply], session.reply);
 					}
 
 					if (!session.skipReply2) {
@@ -244,10 +250,12 @@ export function setup(logger: Logger) {
 						// a fresh untitled session between `activateSessionByLabel`
 						// returning and the send-button click).
 						const expectedActiveLabel = session.name === 'Copilot CLI' ? session.reply : undefined;
+						const activeRowMatch = session.name === 'Copilot CLI' ? [firstPrompt, session.reply] : undefined;
 						await app.workbench.agentsWindow.sendFollowUpMessage(
 							`hello again [scenario:${session.scenarioId2}]`,
 							undefined,
 							expectedActiveLabel,
+							activeRowMatch,
 						);
 
 						const secondTurnTimeout = session.name === 'Copilot CLI' ? 180_000 : 60_000;


### PR DESCRIPTION
## Problem

The `Agents Window › Test Copilot CLI session` smoke test flakily times out at `AgentsWindow.activateSessionByLabel`:

```
Error: Timed out waiting for a settled session list row containing "MOCKED_COPILOT_RESPONSE" (without "Working..."). Last-seen rows:
  [0] "vscode-smoketest-express"
  [1] "hello world [scenario:smoke-hello-copilot]now"
  ...
```

Seen in [run 27843789541](https://github.com/microsoft/vscode/actions/runs/27843789541/job/82408447418) on **Linux**, while **macOS Electron (Smoke) passed in the same run** — i.e. a timing-sensitive flake, not a hard break.

## Root cause

`activateSessionByLabel` located the just-completed session row by its **title**, expecting it to equal the mocked reply `MOCKED_COPILOT_RESPONSE`. The session title is generated **asynchronously** by a utility model after the first turn and races the untitled→committed session swap, so the row title is non-deterministically either:

- the user's prompt — `hello world [scenario:smoke-hello-copilot]` — the synchronous fallback (title-gen hasn't landed, or
- the generated reply —  (in the mock, the title prompt embeds the tagged user message so the mock echoes the scenario reply).

The test matched only the reply, so it timed out whenever generation hadn't landed (Linux), even though the response bubble rendered fine.

> See screenshot from stuck smoke test run:
> <img width="1023" height="767" alt="image" src="https://github.com/user-attachments/assets/a4c978ea-c790-44fd-b0ae-21f2cb6401aa" />


## Fix

Decouple **row identification** from **response verification** in the automation helper:

-  now accepts one *or several* row substrings and matches a row containing **any** of them;  is verified separately against the active session's response bubble.
-  gains an optional  forwarded to re-activation.
- The smoke test passes both the first prompt and the reply, so activation is deterministic regardless of when title generation completes. The actual assertion (response bubble contains the reply) is unchanged.

## Notes

- This is CI-flake hardening on ; orthogonal to the title behavior introduced by #322131 (a likely aggravator of the race).
