### PR TITLE
Update CLI agent commands for AHP 0.4

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "ahp"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff1c5fceb94cf9e8a852eb84dd7f835827a7a2a07b8c23916d192075345e0ea"
+checksum = "8fa7af01c6ff90f8b54fa169a71de21cc26e5a98621249ad882a5b2e137f57c0"
 dependencies = [
  "ahp-types",
  "serde",
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "ahp-types"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b556a5958c99e73aee87d8e638baf648bc902ff0dabc00393522f8e6e88830b2"
+checksum = "1632209b0398b17c4a9928d71eaad0ced329d3617ffcbe32be789f59b1d65c70"
 dependencies = [
  "serde",
  "serde_json",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -56,8 +56,8 @@ console = "0.15.7"
 bytes = "1.11.1"
 tar = "0.4.46"
 local-ip-address = "0.6"
-ahp = "0.3"
-ahp-types = "0.3"
+ahp = "0.4"
+ahp-types = "0.4"
 
 [build-dependencies]
 serde = { version="1.0.163", features = ["derive"] }

--- a/cli/src/commands/agent_logs.rs
+++ b/cli/src/commands/agent_logs.rs
@@ -6,7 +6,7 @@
 use ahp::SubscriptionEvent;
 use ahp_types::actions::StateAction;
 use ahp_types::commands::{SubscribeParams, SubscribeResult};
-use ahp_types::state::{SnapshotState, TurnState};
+use ahp_types::state::{SessionStatus, SnapshotState};
 use console::Style;
 
 use crate::tunnels::shutdown_signal::ShutdownRequest;
@@ -100,23 +100,24 @@ fn print_initial_state(uri: &str, result: &SubscribeResult) {
 				println!("  {} {}", label.apply_to("activity:"), activity);
 			}
 		}
-		println!("  {} {}", label.apply_to("turns:"), session.turns.len());
+		println!("  {} {}", label.apply_to("chats:"), session.chats.len());
 
-		// Print a brief summary of past turns.
-		for turn in &session.turns {
-			let state_str = match turn.state {
-				TurnState::Complete => Styles::success().apply_to("✓"),
-				TurnState::Cancelled => Styles::warning().apply_to("⊘"),
-				TurnState::Error => Styles::error().apply_to("✗"),
+		// Print a brief summary of the chats in this session.
+		for chat in &session.chats {
+			let status = SessionStatus::from_bits(chat.status);
+			let marker = if status.contains(SessionStatus::InProgress) {
+				Style::new().green().bold().apply_to("►")
+			} else if status.contains(SessionStatus::Error) {
+				Styles::error().apply_to("✗")
+			} else {
+				Styles::muted().apply_to("○")
 			};
-			let msg = truncate(&turn.message.text, 80);
-			println!("    {} {}", state_str, Styles::muted().apply_to(msg));
-		}
-
-		// Print active turn if any.
-		if let Some(ref active) = session.active_turn {
-			let msg = truncate(&active.message.text, 80);
-			println!("    {} {}", Style::new().green().bold().apply_to("►"), msg);
+			let title = if chat.title.is_empty() {
+				"(untitled)".to_string()
+			} else {
+				truncate(&chat.title, 80)
+			};
+			println!("    {} {}", marker, Styles::muted().apply_to(title));
 		}
 	}
 

--- a/cli/src/commands/agent_ps.rs
+++ b/cli/src/commands/agent_ps.rs
@@ -61,9 +61,9 @@ pub async fn agent_ps(ctx: CommandContext, args: AgentPsArgs) -> Result<i32, Any
 /// A session is "active" if it is in-progress, needs input, or errored
 /// (i.e. not just idle/archived).
 fn is_active(status: u32) -> bool {
-	let dominated = SessionStatus::IsRead as u32
-		| SessionStatus::IsArchived as u32
-		| SessionStatus::Idle as u32;
+	let dominated = SessionStatus::IsRead.bits()
+		| SessionStatus::IsArchived.bits()
+		| SessionStatus::Idle.bits();
 	status & !dominated != 0
 }
 
@@ -118,15 +118,16 @@ fn format_sessions_list(sessions: &[&SessionSummary]) -> String {
 }
 
 fn status_styled(status: u32) -> console::StyledObject<String> {
-	if status & (SessionStatus::InputNeeded as u32) == (SessionStatus::InputNeeded as u32) {
+	let status = SessionStatus::from_bits(status);
+	if status.contains(SessionStatus::InputNeeded) {
 		Styles::warning().apply_to("● input needed".to_string())
-	} else if status & (SessionStatus::InProgress as u32) != 0 {
+	} else if status.contains(SessionStatus::InProgress) {
 		Styles::success().apply_to("● in progress".to_string())
-	} else if status & (SessionStatus::Error as u32) != 0 {
+	} else if status.contains(SessionStatus::Error) {
 		Styles::error().apply_to("● error".to_string())
-	} else if status & (SessionStatus::Idle as u32) != 0 {
+	} else if status.contains(SessionStatus::Idle) {
 		Styles::muted().apply_to("○ idle".to_string())
 	} else {
-		Styles::muted().apply_to(format!("? unknown ({status})"))
+		Styles::muted().apply_to(format!("? unknown ({})", status.bits()))
 	}
 }

--- a/cli/src/commands/agent_stop.rs
+++ b/cli/src/commands/agent_stop.rs
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-use ahp_types::actions::{SessionTurnCancelledAction, StateAction};
+use ahp_types::actions::{ChatTurnCancelledAction, StateAction};
 use ahp_types::commands::{SubscribeParams, SubscribeResult};
-use ahp_types::state::SnapshotState;
+use ahp_types::state::{SessionStatus, SnapshotState};
 
 use crate::log;
 use crate::util::errors::{wrap, AnyError};
@@ -14,11 +14,12 @@ use super::agent;
 use super::args::AgentStopArgs;
 use super::CommandContext;
 
-/// Cancels the active turn of a session on a running agent host.
+/// Cancels the active turn of every in-progress chat in a session on a running
+/// agent host.
 pub async fn agent_stop(ctx: CommandContext, args: AgentStopArgs) -> Result<i32, AnyError> {
 	let client = agent::connect(&ctx, args.address.as_deref(), args.tunnel.as_deref()).await?;
 
-	// Subscribe to the session to get its current state.
+	// Subscribe to the session to get its catalog of chats.
 	let result: SubscribeResult = agent::request_with_auth(
 		&ctx,
 		&client,
@@ -29,34 +30,61 @@ pub async fn agent_stop(ctx: CommandContext, args: AgentStopArgs) -> Result<i32,
 	)
 	.await?;
 
-	let turn_id = match result.snapshot.map(|s| s.state) {
-		Some(SnapshotState::Session(session)) => session.active_turn.map(|t| t.id),
-		_ => None,
+	// Turns live on individual chats now, so collect the chats that look active
+	// from the session catalog before drilling into each one.
+	let chat_uris: Vec<String> = match result.snapshot.map(|s| s.state) {
+		Some(SnapshotState::Session(session)) => session
+			.chats
+			.into_iter()
+			.filter(|c| SessionStatus::from_bits(c.status).contains(SessionStatus::InProgress))
+			.map(|c| c.resource)
+			.collect(),
+		_ => Vec::new(),
 	};
 
-	let turn_id = match turn_id {
-		Some(id) => id,
-		None => {
-			ctx.log.result("No active turn to cancel.");
-			client.shutdown().await;
-			return Ok(0);
-		}
-	};
-
-	debug!(ctx.log, "Cancelling turn {} on {}", turn_id, args.session);
-
-	client
-		.dispatch(
-			args.session.clone(),
-			StateAction::SessionTurnCancelled(SessionTurnCancelledAction {
-				turn_id: turn_id.clone(),
-			}),
+	let mut cancelled = 0;
+	for chat_uri in chat_uris {
+		// Subscribe to the chat to find its active turn, if any.
+		let chat_result: SubscribeResult = agent::request_with_auth(
+			&ctx,
+			&client,
+			"subscribe",
+			SubscribeParams {
+				channel: chat_uri.clone(),
+			},
 		)
-		.await
-		.map_err(|e| wrap(e, "Failed to dispatch turn cancellation"))?;
+		.await?;
 
-	ctx.log
-		.result(format!("Cancelled turn {turn_id} on {}", args.session));
+		let turn_id = match chat_result.snapshot.map(|s| s.state) {
+			Some(SnapshotState::Chat(chat)) => chat.active_turn.map(|t| t.id),
+			_ => None,
+		};
+
+		let Some(turn_id) = turn_id else {
+			continue;
+		};
+
+		debug!(ctx.log, "Cancelling turn {} on {}", turn_id, chat_uri);
+
+		client
+			.dispatch(
+				chat_uri.clone(),
+				StateAction::ChatTurnCancelled(ChatTurnCancelledAction {
+					turn_id: turn_id.clone(),
+					meta: None,
+				}),
+			)
+			.await
+			.map_err(|e| wrap(e, "Failed to dispatch turn cancellation"))?;
+
+		ctx.log
+			.result(format!("Cancelled turn {turn_id} on {chat_uri}"));
+		cancelled += 1;
+	}
+
+	if cancelled == 0 {
+		ctx.log.result("No active turn to cancel.");
+	}
 
 	client.shutdown().await;
 	Ok(0)


### PR DESCRIPTION
## Summary
Fixes the `cli` cargo build after the AHP `0.4` upgrade, which restructured the state model.

In AHP 0.4:
- `turns`/`active_turn` moved off `SessionState` onto per-chat `ChatState`; `SessionState` now carries a `chats` catalog.
- `SessionStatus` is now a newtype bitset (`SessionStatus(u32)`) instead of a `repr` enum.
- `StateAction::SessionTurnCancelled` was renamed to `StateAction::ChatTurnCancelled` (with an added `_meta` field).

## Changes
- **agent_ps**: use `SessionStatus::bits()` / `from_bits().contains()` instead of `as u32` casts.
- **agent_stop**: resolve in-progress chats from the session catalog, subscribe to each chat to find its active turn, and dispatch `ChatTurnCancelled` to the chat URI.
- **agent_logs**: print the session's `chats` catalog instead of the removed `turns`/`active_turn`.

## Validation
- `cargo build` succeeds with no warnings.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
