### PR TITLE
copilot: disable process.report in copilot extension

### DIFF
--- a/extensions/copilot/src/extension/extension/vscode-node/disableProcessReport.ts
+++ b/extensions/copilot/src/extension/extension/vscode-node/disableProcessReport.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+if (process.report) {
+	try {
+		Object.defineProperty(process.report, 'getReport', {
+			value: () => undefined,
+			writable: true,
+			configurable: true,
+			enumerable: true
+		});
+	} catch (err) {
+
+	}
+}

--- a/extensions/copilot/src/extension/extension/vscode-node/extension.ts
+++ b/extensions/copilot/src/extension/extension/vscode-node/extension.ts
@@ -3,6 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// Must be the first import to ensure it evaluates before other imports.
+import './disableProcessReport';
+
 import { ExtensionContext } from 'vscode';
 import { resolve } from '../../../util/vs/base/common/path';
 import { baseActivate } from '../vscode/extension';


### PR DESCRIPTION
## What

Disables `process.report` in the Copilot extension by overriding `process.report.getReport` to return `undefined`. The override is loaded as the very first import in the extension entrypoint so it evaluates before anything else.

## Why

Cherry-picked the functional changes from:
- #321998 (Disable process.report)
- #322036 (Override getReport with a function returning undefined)

## Notes for reviewers

- Only the functional changes were brought over. The version-bump/release-prep portions of the original commits (targeting the 1.125.1 line) were intentionally dropped since this branch is on a newer version.
- The recovery-pipeline YAML change was excluded at the author's request.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
