### PR TITLE
extensions: capture raw ext host stdout/stderr in smoke tests

### DIFF
--- a/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
@@ -292,6 +292,21 @@ export class NativeLocalProcessExtensionHost extends Disposable implements IExte
 			Event.map(onStderr.event, o => ({ data: `%c${o}`, format: ['color: red'] }))
 		);
 
+		// Persist the raw extension host process output (stdout/stderr) to the
+		// renderer log. The output is otherwise only forwarded (debounced) to the
+		// renderer DevTools console. A native crash of the extension host process
+		// - e.g. a faulty native addon - prints to the process' stderr but never
+		// reaches the JavaScript layer, so it has no JS stack and (for utility
+		// processes) frequently produces no crash dump; it also cannot go through
+		// the extension host's own log service, which lives in the dying process.
+		// Capturing the raw output from the (surviving) renderer keeps such
+		// crashes diagnosable from the logs. Gated to smoke tests
+		// (`--enable-smoke-test-driver`) so it does not affect regular sessions.
+		if (this._environmentService.args['enable-smoke-test-driver']) {
+			this._register(onStdout.event(line => this._logService.info(`[Extension Host (stdout)] ${line.replace(/\r?\n$/, '')}`)));
+			this._register(onStderr.event(line => this._logService.error(`[Extension Host (stderr)] ${line.replace(/\r?\n$/, '')}`)));
+		}
+
 		// Debounce all output, so we can render it in the Chrome console as a group
 		const onDebouncedOutput = Event.debounce<Output>(onOutput, (r, o) => {
 			return r


### PR DESCRIPTION
## Why

While investigating a Windows `Electron-Smoke` failure (`Chat Sessions › Test Copilot CLI session` timing out on `.editor-instance .interactive-session`), the root cause turned out to be a **native crash of the extension host** utility process (`main.log`: `pid … exited code 57005 (0xDEAD) reason 'crashed'`) during Copilot CLI session init.

The Copilot CLI SDK loads a bundled **native `node-pty` (`pty.node`)** into the extension host to spawn the `copilot` CLI via a pseudo-terminal; a fault there crashes the host with no JS stack. Such crashes are currently **undiagnosable** from the artifacts:

- No JS stack (the crash is native).
- No utility-process minidump is produced (confirmed: only Crashpad `settings.dat`, no `.dmp`, across every suite — even the deliberate-kill *Extension Host Restart* suite).
- The ext host's raw `stdout`/`stderr` is only forwarded to the renderer DevTools console **debounced (100ms)**, so the final pre-crash bytes are lost. It also can't go through the ext host's own log service, which lives inside the dying process.

## What

Capture the raw, **undebounced** extension host `stdout`/`stderr` from the renderer side (which survives the crash) into the existing renderer `_logService` → `renderer.log`, which is already collected in the `logs-*` artifacts. This makes native ext-host crashes (native addon stderr, V8/Node fatals) diagnosable next time.

Gated to smoke tests via the existing `--enable-smoke-test-driver` flag, so regular user sessions are unaffected (no extra logging, no new log file).

## Notes for reviewers

- This is a **diagnostics-only** change (smoke tests only). It does not attempt to fix the underlying node-pty native crash (which lives in the vendored Copilot SDK).
- Validation: after CI runs, `renderer.log` in the smoke `logs-*` artifact should contain `[Extension Host (stdout)]` / `[Extension Host (stderr)]` lines.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
