### PR TITLE
smoke: fix flaky Chat Sessions copilot-chat activation race

### DIFF
--- a/test/smoke/extensions/vscode-smoketest-ext-host/extension.js
+++ b/test/smoke/extensions/vscode-smoketest-ext-host/extension.js
@@ -100,6 +100,11 @@ function activate(context) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand('smoketest.openCopilotCliChat', async () => {
 			const command = 'workbench.action.chat.openNewSessionEditor.copilotcli';
+			// Wait until copilot-chat is enabled and activated before invoking its
+			// diagnostic command: the preceding "Chat Disabled" suite disables AI
+			// features and this suite re-enables them, so there is a brief window
+			// where the command is still "not found".
+			await waitForCommand('github.copilot.debug.extensionState', 60_000);
 			await vscode.commands.executeCommand('github.copilot.debug.extensionState');
 			await waitForCommand(command, 60_000);
 			await vscode.commands.executeCommand('workbench.action.closeAllEditors');
@@ -110,6 +115,11 @@ function activate(context) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand('smoketest.openClaudeChat', async () => {
 			const command = 'workbench.action.chat.openNewSessionEditor.claude-code';
+			// Wait until copilot-chat is enabled and activated before invoking its
+			// diagnostic command: the preceding "Chat Disabled" suite disables AI
+			// features and this suite re-enables them, so there is a brief window
+			// where the command is still "not found".
+			await waitForCommand('github.copilot.debug.extensionState', 60_000);
 			await vscode.commands.executeCommand('github.copilot.debug.extensionState');
 			await waitForCommand(command, 60_000);
 			await vscode.commands.executeCommand('workbench.action.closeAllEditors');


### PR DESCRIPTION
## Problem

The `Chat Sessions › Test Copilot CLI session` smoke test failed intermittently with:

```
Error: Timeout: get element '.editor-instance .interactive-session' after 60 seconds.
  at Chat.waitForChatEditor (test/automation/out/chat.js:38)
  at openSession (chatSessions.test.js:51)
```

(seen e.g. in [run 27850813533](https://github.com/microsoft/vscode/actions/runs/27850813533/job/82431338961) — the failing test, while `Test Claude session` and `Test Local session` in the same suite passed.)

## Root cause

The `Chat Sessions` suite runs immediately after the `Chat Disabled` suite, which disables AI features (`chat.disableAIFeatures`). When `Chat Sessions` re-enables them in its `before()` hook, there is a brief window where the copilot-chat extension is still disabled and its contributed commands are not yet registered as activation triggers.

The smoke helper `smoketest.openCopilotCliChat` invoked `github.copilot.debug.extensionState` to force-activate copilot-chat. In that window the renderer `CommandService.executeCommand` path is not robust for an as-yet-disabled extension — it races `*` activation against command registration and rejects with `command 'github.copilot.debug.extensionState' not found`. That rejection aborted the handler **before** it reached `waitForCommand(...)` / opened the chat editor, so `waitForChatEditor` timed out after 60s.

Artifact logs confirm the timing: the `executeCommand` failed at `22:45:00.609`, ~50ms before copilot-chat enablement was applied at `22:45:00.66` (`onEnablementChanged` → `deltaExtensions toAdd: [copilot-chat]`), with the extension only activating at `22:45:01.219`.

## Fix

Reuse the existing `waitForCommand` helper to wait until `github.copilot.debug.extensionState` is registered before invoking it. This gates on copilot-chat being enabled and activated, so the handler no longer races enablement.

Applied to both `smoketest.openCopilotCliChat` and `smoketest.openClaudeChat`.