### PR TITLE
Give ask-questions carousel a visible box in the Agents window

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
@@ -9,26 +9,35 @@
 	display: none;
 }
 
-/* input specific styling */
+/* input specific styling - box look comes from the shared container rule below */
 .interactive-session .interactive-input-part > .chat-question-carousel-widget-container .chat-question-carousel-container,
 .interactive-session .interactive-input-part .interactive-input-and-edit-session > .chat-question-carousel-widget-container .chat-question-carousel-container {
 	margin: 0;
-	border: 1px solid var(--vscode-input-border, transparent);
-	background-color: var(--vscode-panel-background);
-	border-radius: var(--vscode-cornerRadius-large);
 }
 
-/* general questions styling */
+/* general questions styling - matches the tool confirmation (permissions) box family */
 .interactive-session .chat-question-carousel-container {
 	margin: 8px 0;
-	border: 1px solid var(--vscode-chat-requestBorder);
+	border: 1px solid var(--vscode-input-border, var(--vscode-chat-requestBorder));
 	border-radius: var(--vscode-cornerRadius-large);
+	background-color: var(--vscode-panel-background);
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
 	container-type: inline-size;
 	max-height: min(420px, 45vh);
 	position: relative;
+}
+
+.interactive-session .chat-question-carousel-container:focus-visible,
+.interactive-session .chat-question-carousel-container:focus-within {
+	border-color: var(--vscode-focusBorder);
+}
+
+/* in the agents window / editor the surface is the editor background */
+.agent-sessions-workbench .interactive-session .chat-question-carousel-container,
+.editor-instance .interactive-session .chat-question-carousel-container {
+	background-color: var(--vscode-editor-background);
 }
 
 /* input part wrapper */

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
@@ -18,7 +18,7 @@
 /* general questions styling - matches the tool confirmation (permissions) box family */
 .interactive-session .chat-question-carousel-container {
 	margin: 8px 0;
-	border: 1px solid var(--vscode-input-border, var(--vscode-chat-requestBorder));
+	border: var(--vscode-strokeThickness) solid var(--vscode-input-border, var(--vscode-chat-requestBorder));
 	border-radius: var(--vscode-cornerRadius-large);
 	background-color: var(--vscode-panel-background);
 	display: flex;
@@ -27,6 +27,10 @@
 	container-type: inline-size;
 	max-height: min(420px, 45vh);
 	position: relative;
+}
+
+.interactive-session .chat-question-carousel-container:focus {
+	outline: none;
 }
 
 .interactive-session .chat-question-carousel-container:focus-visible,


### PR DESCRIPTION
## Summary
Gives the **ask-questions** carousel in the Agents window a visible box, so it reads as a bounded surface that belongs to the same "ask the human" family as the tool-call **permissions** dialog.

Previously the question carousel rendered with only a faint `--vscode-chat-requestBorder` outline and no fill. In dark themes (and in the Agents window, where the surface is the editor background) it had no visible boundary — only the internal dividers showed.

This is **CSS-only** — one file, no TypeScript touched.

### Before / After
<!-- Add a before/after screenshot here (dark theme, Agents window). -->
Before---
<img width="1938" height="978" alt="CleanShot 2026-06-19 at 16 47 16@2x" src="https://github.com/user-attachments/assets/640c6f8a-c79b-470b-8f74-c521bf8f3bda" />

After---
<img width="1552" height="936" alt="CleanShot 2026-06-19 at 17 16 54@2x" src="https://github.com/user-attachments/assets/1228a05f-9534-432f-8142-274960ace144" />


## Changes (`chatQuestionCarousel.css`)
- **Consolidated box styling** onto the shared `.chat-question-carousel-container`:
  - `background-color: var(--vscode-panel-background)`
  - `border: 1px solid var(--vscode-input-border, var(--vscode-chat-requestBorder))` — honors a theme's input border, otherwise falls back to the same visible token the internal dividers use, so the box is always visible.
  - keeps `border-radius: var(--vscode-cornerRadius-large)` and `overflow: hidden`.
- **Focus treatment:** `:focus-within / :focus-visible → border-color: var(--vscode-focusBorder)`.
- **Agents window / editor surface override:** `.agent-sessions-workbench` and `.editor-instance` → `background-color: var(--vscode-editor-background)`.
- **De-duplicated** the input-part rule down to `margin: 0`; box styling now lives only on the shared rule, so both render paths (input part + inline fallback) and the Agents-window override apply uniformly.

## Consistency with the permissions box
Intentionally aligned with `chatToolConfirmationCarousel.css`:

| Aspect | Questions (this PR) | Permissions (existing) |
|---|---|---|
| Border | `input-border` → `chat-requestBorder` fallback | `1px solid input-border` |
| Radius | `cornerRadius-large` | `cornerRadius-large` |
| Background | `panel-background` | `panel-background` |
| Focus | `focus-within → focusBorder` | `focus-within → focusBorder` |
| Agents/editor surface | `editor-background` | `editor-background` |
| Internal dividers | `chat-requestBorder` (unchanged) | `chat-requestBorder` |

One deliberate difference: the questions border has a `chat-requestBorder` fallback because `input.border` is `null`/transparent by default — which is exactly why the box wasn't visible before.

## Scope / risk
- No behavior change; purely visual.
- No build/type impact (CSS only).

## Out of scope
This PR only restyles the box. It does **not** change carousel behavior — questions still carousel *within* a single `askQuestions` call, while *separate* invocations stack vertically. Aggregating separate invocations into one carousel (as permissions do via `ChatToolConfirmationCarouselPart`) is a separate, larger change.
