### PR TITLE
Disable Bluetooth by default to prevent BlueZ connection popup on Linux startup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -364,6 +364,13 @@ function configureCommandlineSwitchesSync(cliArgs: NativeParsedArgs) {
 	// use up to 2
 	app.commandLine.appendSwitch('max-active-webgl-contexts', '32');
 
+	// Disable Bluetooth to prevent BlueZ connection on startup (Linux)
+	// refs https://github.com/microsoft/vscode/issues/134461
+	// Users can opt-in with --enable-bluetooth CLI flag
+	if (!app.commandLine.hasSwitch('enable-bluetooth')) {
+		app.commandLine.appendSwitch('disable-bluetooth');
+	}
+
 	return argvConfig;
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -364,10 +364,10 @@ function configureCommandlineSwitchesSync(cliArgs: NativeParsedArgs) {
 	// use up to 2
 	app.commandLine.appendSwitch('max-active-webgl-contexts', '32');
 
-	// Disable Bluetooth to prevent BlueZ connection on startup (Linux)
+	// Disable Bluetooth on Linux to prevent BlueZ connection on startup
 	// refs https://github.com/microsoft/vscode/issues/134461
 	// Users can opt-in with --enable-bluetooth CLI flag
-	if (!app.commandLine.hasSwitch('enable-bluetooth')) {
+	if (process.platform === 'linux' && !app.commandLine.hasSwitch('enable-bluetooth') && !app.commandLine.hasSwitch('disable-bluetooth')) {
 		app.commandLine.appendSwitch('disable-bluetooth');
 	}
 


### PR DESCRIPTION
## Description

On Linux, VS Code requests Bluetooth access on startup because Electron initiates a connection to BlueZ (Linux Bluetooth daemon) early in the startup process. This causes a distracting system permission popup for users who don't even use Bluetooth.

## Fix

Add `--disable-bluetooth` Chromium switch early in the startup sequence to prevent Electron from connecting to BlueZ.

Users who need Web Bluetooth functionality can opt in by passing `--enable-bluetooth` CLI flag.

## Changes

- `src/main.ts`: Added `disable-bluetooth` switch before `argvConfig` return, with `--enable-bluetooth` opt-in

## Related

Fixes #134461