### PR TITLE
agentHost: fix flaky write auto-approval on Windows from native realpath

### DIFF
--- a/src/vs/platform/agentHost/node/sessionPermissions.ts
+++ b/src/vs/platform/agentHost/node/sessionPermissions.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { realpath } from 'fs/promises';
 import { homedir } from 'os';
 import { match as globMatch, parse as globParse, type ParsedPattern } from '../../../base/common/glob.js';
 import { untildify } from '../../../base/common/labels.js';
@@ -13,6 +12,7 @@ import { isMacintosh, isWindows } from '../../../base/common/platform.js';
 import { extUriBiasedIgnorePathCase, normalizePath } from '../../../base/common/resources.js';
 import { isDefined } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
+import { Promises } from '../../../base/node/pfs.js';
 import { localize } from '../../../nls.js';
 import { ILogService } from '../../log/common/log.js';
 import { platformSessionSchema } from '../common/agentHostSchema.js';
@@ -150,7 +150,7 @@ function assertPathIsSafe(fsPath: string, _isWindows = isWindows): void {
  */
 async function resolveRealPathForNonexistent(fsPath: string): Promise<string> {
 	try {
-		return await realpath(fsPath);
+		return await Promises.realpath(fsPath);
 	} catch (e) {
 		if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
 			throw e;
@@ -166,7 +166,7 @@ async function resolveRealPathForNonexistent(fsPath: string): Promise<string> {
 			return fsPath;
 		}
 		try {
-			const resolved = await realpath(current);
+			const resolved = await Promises.realpath(current);
 			return path.join(resolved, ...tail);
 		} catch (e) {
 			const code = (e as NodeJS.ErrnoException).code;


### PR DESCRIPTION
Fixes a flaky `SessionPermissionManager` test on Windows CI:

```
auto-approves a normal file inside the working directory:
  + expected - actual
  - undefined
  + 'not-needed'
```

### Root cause

`resolveRealPathForNonexistent` in `sessionPermissions.ts` imported `realpath` from `fs/promises`, which internally calls **`fs.realpath.native`**. On Windows that resolves `subst` drives to their real target (and normalizes paths differently) compared to the JS `fs.realpath` implementation — which is what the test uses via `fs.realpathSync` to build its working directory.

As a result, the symlink-resolved `linked` path could diverge from the configured working directory and be judged *outside* it, so `getAutoApproval` returned `undefined` (confirmation required) instead of `ToolCallConfirmationReason.NotNeeded`.

### Fix

Use `Promises.realpath` from `vs/base/node/pfs`, which exists precisely to avoid `fs.realpath.native` (see #118562). This aligns the agent-host approval path with the test and with the rest of the codebase's filesystem handling.

Verified `typecheck-client` passes and all 9 `SessionPermissionManager` tests pass, including the symlink-resolution cases.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
