### PR TITLE
agent host: fix blank response after aborting a turn with a queued message

### DIFF
--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -851,6 +851,11 @@ export class AgentSideEffects extends Disposable {
 				agent?.abortSession(URI.parse(channel), chatChannel ? URI.parse(chatChannel) : undefined).catch(err => {
 					this._logService.error('[AgentSideEffects] abortSession failed', err);
 				});
+				// Intentionally do NOT drain queued messages here: cancelling means
+				// "stop", so messages queued behind the turn stay queued for the
+				// user to dequeue/run manually. (A message the user sends *after*
+				// the abort is still consumed via the ChatPendingMessageSet path
+				// once cancellation has cleared the active turn.)
 				break;
 			}
 			case ActionType.SessionModelChanged: {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -328,6 +328,67 @@ export interface ICopilotAgentSessionOptions {
 }
 
 /**
+ * Lifecycle state of a {@link CopilotTurn}.
+ *
+ *  - `pending`   — the host has dispatched the message (`send()`), but the SDK
+ *                  has not yet emitted any event for this turn's agentic loop.
+ *  - `running`   — the SDK has emitted at least one event for this turn.
+ *  - `completed` — the turn finished normally (the loop went idle).
+ *  - `aborted`   — the turn's loop was cancelled via an abort.
+ */
+type CopilotTurnState = 'pending' | 'running' | 'completed' | 'aborted';
+
+/**
+ * Encapsulates all per-turn bookkeeping for a single protocol turn, plus an
+ * explicit lifecycle {@link CopilotTurn.state}. Holding this state on one
+ * object (created fresh per turn) rather than as a handful of mutable session
+ * fields means there is a single, atomic notion of "the current turn": there
+ * is no set of counters/maps that must be reset in lockstep, and turn
+ * transitions (running/completed/aborted) are explicit and checkable.
+ *
+ * The `pending → running` distinction guards turn completion against a stray
+ * idle: an abort's terminal `session.idle` finds a queued message's turn still
+ * `pending` (the SDK has not begun it) and leaves it open, rather than
+ * completing it and orphaning its real response. A non-abort idle still
+ * completes a `pending` turn defensively, so a degenerate no-op send cannot
+ * hang the session.
+ */
+class CopilotTurn {
+
+	private _state: CopilotTurnState = 'pending';
+
+	/** Accumulated Copilot usage for this turn, in nano-AIU. */
+	copilotUsageTotalNanoAiu = 0;
+
+	/**
+	 * Current markdown response part IDs for this turn, keyed by
+	 * `parentToolCallId ?? ''`. Parent and subagent text stream through the
+	 * same SDK session but land in different AHP sessions, so their markdown
+	 * part state must not mask or append to each other.
+	 */
+	readonly markdownPartIds = new Map<string, string>();
+
+	/** Current reasoning response part IDs for this turn, keyed by `parentToolCallId ?? ''`. */
+	readonly reasoningPartIds = new Map<string, string>();
+
+	constructor(readonly id: string) { }
+
+	get state(): CopilotTurnState { return this._state; }
+	get isPending(): boolean { return this._state === 'pending'; }
+	get isRunning(): boolean { return this._state === 'running'; }
+
+	/** Transition `pending → running` on the first SDK event. No-op once running/finished. */
+	markRunning(): void {
+		if (this._state === 'pending') {
+			this._state = 'running';
+		}
+	}
+
+	markCompleted(): void { this._state = 'completed'; }
+	markAborted(): void { this._state = 'aborted'; }
+}
+
+/**
  * Encapsulates a single Copilot SDK session and all its associated bookkeeping.
  *
  * Created by {@link CopilotAgent}, one instance per active session. Disposing
@@ -343,6 +404,13 @@ export class CopilotAgentSession extends Disposable {
 
 	/** Tracks active tool invocations so we can produce past-tense messages on completion. */
 	private readonly _activeToolCalls = new Map<string, { toolName: string; displayName: string; parameters: Record<string, unknown> | undefined; content: ToolResultContent[]; parentToolCallId: string | undefined; startTimeMs: number; mcpServerName: string | undefined; meta: Record<string, unknown> | undefined }>();
+	/**
+	 * Maps a running subagent's `agentId` to its parent tool call id. Session-
+	 * scoped rather than per-turn: a subagent's lifetime is bounded by its
+	 * `subagent.started` / `subagent.completed` events (and background
+	 * subagents can outlive the parent tool call), so this routing must not be
+	 * cleared on turn boundaries.
+	 */
 	private readonly _parentToolCallIdsByAgentId = new Map<string, string>();
 	/** Pending permission requests awaiting a renderer-side decision. */
 	private readonly _pendingPermissions = new Map<string, DeferredPromise<boolean>>();
@@ -378,8 +446,20 @@ export class CopilotAgentSession extends Disposable {
 	private readonly _databaseRef: IReference<ISessionDatabase>;
 	/** On-disk root for per-session data (database, attachments, …). */
 	private readonly _sessionDataDir: URI;
-	/** Protocol turn ID set by {@link send}, used for file edit tracking. */
-	private _turnId = '';
+	/**
+	 * The current protocol turn and its per-turn bookkeeping, or `undefined`
+	 * when the session is idle (no active turn). Replaces the former set of
+	 * loosely-coupled per-turn fields (`_turnId`, usage counter, streaming
+	 * part-id maps) with a single object carrying an explicit
+	 * {@link CopilotTurn.state} lifecycle. Created (`pending`) by
+	 * {@link resetTurnState}, finalized by {@link _completeActiveTurn}.
+	 */
+	private _currentTurn: CopilotTurn | undefined;
+	/**
+	 * Protocol turn ID of the active turn, or `''` when idle. Used by file
+	 * edit tracking and emitted on per-turn actions.
+	 */
+	private get _turnId(): string { return this._currentTurn?.id ?? ''; }
 	/**
 	 * Last model id seen on the SDK's per-LLM-call `Usage` event (or a
 	 * direct {@link setModel} call). We rely on the
@@ -388,8 +468,6 @@ export class CopilotAgentSession extends Disposable {
 	 * an LLM turn precedes that turn's `tool_use` events.
 	 */
 	private _lastSeenModelId: string | undefined;
-	/** Accumulated Copilot usage for the current top-level turn, in nano-AIU. */
-	private _turnCopilotUsageTotalNanoAiu = 0;
 	/** SDK session wrapper, set by {@link initializeSession}. */
 	private _wrapper!: CopilotSessionWrapper;
 	private _runtimeSlashCommandCache: RuntimeSlashCommandCache | undefined;
@@ -457,15 +535,6 @@ export class CopilotAgentSession extends Disposable {
 	 */
 	private readonly _pendingMcpSamplings = new Set<string>();
 
-	/**
-	 * Current markdown response part IDs for the active turn, keyed by
-	 * `parentToolCallId ?? ''`. Parent and subagent text stream through the
-	 * same SDK session but land in different AHP sessions, so their markdown
-	 * part state must not mask or append to each other.
-	 */
-	private readonly _currentMarkdownPartIds = new Map<string, string>();
-	/** Current reasoning response part IDs for the active turn, keyed by `parentToolCallId ?? ''`. */
-	private readonly _currentReasoningPartIds = new Map<string, string>();
 	/** Tracks whether a non-empty activity has been published, so we only emit a clear when needed. */
 	private _hasReportedActivity = false;
 
@@ -594,10 +663,15 @@ export class CopilotAgentSession extends Disposable {
 			message: steering.message,
 			queuedMessageId: steering.id,
 		});
-		// Mirror `resetTurnState` so per-turn counters/mappings (usage
-		// total, streaming part ids, subagent agentId map) don't bleed
-		// from the preempted turn into the new steering turn.
+		// Mirror `resetTurnState` so per-turn counters/mappings (usage total,
+		// streaming part ids) don't bleed from the preempted turn into the new
+		// steering turn. The steering turn is created mid-loop in response to an
+		// SDK `user.message` event, so the SDK is already actively producing its
+		// response: mark it `running` immediately rather than leaving it
+		// `pending`, otherwise an abort during the steering turn would treat it
+		// as a not-yet-started queued turn and leave it open.
 		this.resetTurnState(newTurnId);
+		this._currentTurn?.markRunning();
 		return newTurnId;
 	}
 
@@ -658,30 +732,25 @@ export class CopilotAgentSession extends Disposable {
 	}
 
 	/**
-	 * Resets per-turn streaming state so the next text/reasoning chunk
-	 * allocates a fresh response part for the new turn.
+	 * Starts a fresh `pending` turn, discarding any per-turn streaming state
+	 * from a previous turn so the next text/reasoning chunk allocates a new
+	 * response part. The turn becomes `running` on the first SDK event.
 	 */
 	resetTurnState(turnId: string): void {
-		this._turnId = turnId;
-		this._turnCopilotUsageTotalNanoAiu = 0;
-		this._currentMarkdownPartIds.clear();
-		this._currentReasoningPartIds.clear();
-		this._parentToolCallIdsByAgentId.clear();
+		this._currentTurn = new CopilotTurn(turnId);
 	}
 
 	private _completeActiveTurn(): void {
-		if (!this._turnId) {
+		const turn = this._currentTurn;
+		if (!turn) {
 			return;
 		}
-		const turnId = this._turnId;
+		turn.markCompleted();
 		this._emitAction({
 			type: ActionType.ChatTurnComplete,
-			turnId,
+			turnId: turn.id,
 		});
-		this._turnId = '';
-		this._currentMarkdownPartIds.clear();
-		this._currentReasoningPartIds.clear();
-		this._parentToolCallIdsByAgentId.clear();
+		this._currentTurn = undefined;
 	}
 
 	private _getEditFilePaths(parameters: unknown): string[] {
@@ -735,11 +804,12 @@ export class CopilotAgentSession extends Disposable {
 	 * markdown response part; subsequent deltas append to it.
 	 */
 	private _emitMarkdownDelta(content: string, parentToolCallId?: string): void {
+		const turn = this._currentTurn;
 		const markdownScope = parentToolCallId ?? '';
-		let partId = this._currentMarkdownPartIds.get(markdownScope);
+		let partId = turn?.markdownPartIds.get(markdownScope);
 		if (!partId) {
 			partId = generateUuid();
-			this._currentMarkdownPartIds.set(markdownScope, partId);
+			turn?.markdownPartIds.set(markdownScope, partId);
 			this._emitAction({
 				type: ActionType.ChatResponsePart,
 				turnId: this._turnId,
@@ -757,11 +827,12 @@ export class CopilotAgentSession extends Disposable {
 
 	/** Emits a reasoning delta, similar to {@link _emitMarkdownDelta} but for reasoning parts. */
 	private _emitReasoningDelta(content: string, parentToolCallId?: string): void {
+		const turn = this._currentTurn;
 		const reasoningScope = parentToolCallId ?? '';
-		let partId = this._currentReasoningPartIds.get(reasoningScope);
+		let partId = turn?.reasoningPartIds.get(reasoningScope);
 		if (!partId) {
 			partId = generateUuid();
-			this._currentReasoningPartIds.set(reasoningScope, partId);
+			turn?.reasoningPartIds.set(reasoningScope, partId);
 			this._emitAction({
 				type: ActionType.ChatResponsePart,
 				turnId: this._turnId,
@@ -923,9 +994,11 @@ export class CopilotAgentSession extends Disposable {
 	// ---- session operations -------------------------------------------------
 
 	async send(prompt: string, attachments?: readonly MessageAttachment[], turnId?: string, mode?: CopilotSdkMode): Promise<void> {
-		if (turnId) {
-			this._turnId = turnId;
-			this._turnCopilotUsageTotalNanoAiu = 0;
+		if (turnId && this._currentTurn?.id !== turnId) {
+			// Establish the `pending` turn for this message. Callers normally
+			// call `resetTurnState` just before `send()`; this covers the
+			// direct-send path and is a no-op when the turn already exists.
+			this.resetTurnState(turnId);
 		}
 		this._logService.info(`[Copilot:${this.sessionId}] sendMessage called: "${prompt.substring(0, 100)}${prompt.length > 100 ? '...' : ''}" (${attachments?.length ?? 0} attachments)`);
 
@@ -2027,6 +2100,8 @@ export class CopilotAgentSession extends Disposable {
 			if (e.data.source && e.data.source.toLowerCase() !== 'user') {
 				return;
 			}
+			// First SDK event for the loop: promote the turn out of `pending`.
+			this._currentTurn?.markRunning();
 			const steering = this._takeMatchingPendingSteering(e.data.content);
 			if (steering) {
 				this._beginSteeringTurn(steering);
@@ -2063,11 +2138,11 @@ export class CopilotAgentSession extends Disposable {
 			}
 			const parentToolCallId = this._parentToolCallIdForSubagentEvent(e);
 			const markdownScope = parentToolCallId ?? '';
-			if (this._currentMarkdownPartIds.has(markdownScope)) {
+			if (this._currentTurn?.markdownPartIds.has(markdownScope)) {
 				return;
 			}
 			const partId = generateUuid();
-			this._currentMarkdownPartIds.set(markdownScope, partId);
+			this._currentTurn?.markdownPartIds.set(markdownScope, partId);
 			this._emitAction({
 				type: ActionType.ChatResponsePart,
 				turnId: this._turnId,
@@ -2114,8 +2189,8 @@ export class CopilotAgentSession extends Disposable {
 			this._activeToolCalls.set(e.data.toolCallId, { toolName: e.data.toolName, displayName, parameters, content: [], parentToolCallId, startTimeMs: Date.now(), mcpServerName: e.data.mcpServerName, meta: undefined });
 			if (isTaskCompleteTool(e.data.toolName)) {
 				const scope = parentToolCallId ?? '';
-				this._currentMarkdownPartIds.delete(scope);
-				this._currentReasoningPartIds.delete(scope);
+				this._currentTurn?.markdownPartIds.delete(scope);
+				this._currentTurn?.reasoningPartIds.delete(scope);
 				return;
 			}
 			const toolKind = getToolKind(e.data.toolName);
@@ -2137,8 +2212,8 @@ export class CopilotAgentSession extends Disposable {
 			// starts a fresh part. Without invalidating reasoning here, a
 			// later round of reasoning (after tool_start/tool_complete)
 			// would silently append to the pre-tool-call reasoning block.
-			this._currentMarkdownPartIds.delete(parentToolCallId ?? '');
-			this._currentReasoningPartIds.delete(parentToolCallId ?? '');
+			this._currentTurn?.markdownPartIds.delete(parentToolCallId ?? '');
+			this._currentTurn?.reasoningPartIds.delete(parentToolCallId ?? '');
 
 			const meta: Record<string, unknown> = { toolKind, language: toolKind === 'terminal' ? getShellLanguage(e.data.toolName) : undefined };
 			if (subagentMeta?.description) {
@@ -2324,11 +2399,11 @@ export class CopilotAgentSession extends Disposable {
 			}, parentToolCallId);
 		}));
 
-		this._register(wrapper.onIdle(() => {
+		this._register(wrapper.onIdle(e => {
 			this._logService.info(`[Copilot:${sessionId}] Session idle`);
 			// Clear any in-progress activity description set during the
 			// turn (e.g. via the `report_intent` tool) — the agent is no
-			// longer doing anything once the turn completes.
+			// longer doing anything once the loop settles.
 			if (this._hasReportedActivity) {
 				this._hasReportedActivity = false;
 				this._emitAction({
@@ -2336,6 +2411,34 @@ export class CopilotAgentSession extends Disposable {
 					activity: undefined,
 				});
 			}
+			const turn = this._currentTurn;
+			if (!turn) {
+				return;
+			}
+			// An abort drives the loop to idle. That terminal idle must never
+			// complete a turn:
+			//  - if `turn` is the aborted (running) turn, the client-dispatched
+			//    `ChatTurnCancelled` finalizes the protocol turn; drop our handle
+			//    so a later idle can't complete it.
+			//  - if `turn` is still `pending`, a queued message started it after
+			//    the abort and the SDK has not run it yet; completing it would
+			//    emit an empty `ChatTurnComplete` and orphan its real response.
+			//    Leave it open for its own (non-abort) idle.
+			// The structural `pending` guard below already protects the
+			// queued-message case; reading `e.data.aborted` is the authoritative
+			// SDK signal that lets us also tear down the aborted running turn.
+			if (e.data.aborted) {
+				this._logService.trace(`[Copilot:${sessionId}] Idle from abort; leaving turn ${turn.id} (${turn.state}) open`);
+				if (turn.isRunning) {
+					turn.markAborted();
+					this._currentTurn = undefined;
+				}
+				return;
+			}
+			// Only a `running` turn is completed by a normal idle. A `pending`
+			// turn here means the SDK went idle before emitting any event for it
+			// (a degenerate no-op send); complete it defensively so the session
+			// does not hang.
 			this._completeActiveTurn();
 		}));
 
@@ -2411,11 +2514,12 @@ export class CopilotAgentSession extends Disposable {
 			// TODO: `copilotUsage` is marked `asInternal` in the SDK schema so it is not exposed on the generated
 			// `AssistantUsageData` type, but it is present at runtime. Read it dynamically.
 			const copilotUsage = (e.data as unknown as Record<string, unknown>).copilotUsage as { totalNanoAiu?: number } | undefined;
-			if (typeof copilotUsage?.totalNanoAiu === 'number') {
-				this._turnCopilotUsageTotalNanoAiu += copilotUsage.totalNanoAiu;
+			const turn = this._currentTurn;
+			if (turn && typeof copilotUsage?.totalNanoAiu === 'number') {
+				turn.copilotUsageTotalNanoAiu += copilotUsage.totalNanoAiu;
 				metadata.copilotUsage = {
 					...copilotUsage,
-					totalNanoAiu: this._turnCopilotUsageTotalNanoAiu,
+					totalNanoAiu: turn.copilotUsageTotalNanoAiu,
 				};
 			}
 			// `quotaSnapshots` is likewise `asInternal` in the SDK schema (not on the generated type) but is
@@ -2770,6 +2874,7 @@ export class CopilotAgentSession extends Disposable {
 		}));
 
 		this._register(wrapper.onTurnStart(e => {
+			this._currentTurn?.markRunning();
 			this._logService.trace(`[Copilot:${sessionId}] Turn started: ${e.data.turnId}`);
 		}));
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -805,21 +805,29 @@ export class CopilotAgentSession extends Disposable {
 	 */
 	private _emitMarkdownDelta(content: string, parentToolCallId?: string): void {
 		const turn = this._currentTurn;
+		if (!turn) {
+			// A markdown delta should only ever arrive while a turn is active.
+			// Without a turn we can't persist the part id (so every delta would
+			// allocate a fresh part) and the action would carry an empty turnId.
+			// Drop it and surface the unexpected state.
+			this._logService.error(`[Copilot:${this.sessionId}] Markdown delta emitted with no active turn; dropping`);
+			return;
+		}
 		const markdownScope = parentToolCallId ?? '';
-		let partId = turn?.markdownPartIds.get(markdownScope);
+		let partId = turn.markdownPartIds.get(markdownScope);
 		if (!partId) {
 			partId = generateUuid();
-			turn?.markdownPartIds.set(markdownScope, partId);
+			turn.markdownPartIds.set(markdownScope, partId);
 			this._emitAction({
 				type: ActionType.ChatResponsePart,
-				turnId: this._turnId,
+				turnId: turn.id,
 				part: { kind: ResponsePartKind.Markdown, id: partId, content },
 			}, parentToolCallId);
 			return;
 		}
 		this._emitAction({
 			type: ActionType.ChatDelta,
-			turnId: this._turnId,
+			turnId: turn.id,
 			partId,
 			content,
 		}, parentToolCallId);
@@ -828,21 +836,25 @@ export class CopilotAgentSession extends Disposable {
 	/** Emits a reasoning delta, similar to {@link _emitMarkdownDelta} but for reasoning parts. */
 	private _emitReasoningDelta(content: string, parentToolCallId?: string): void {
 		const turn = this._currentTurn;
+		if (!turn) {
+			this._logService.error(`[Copilot:${this.sessionId}] Reasoning delta emitted with no active turn; dropping`);
+			return;
+		}
 		const reasoningScope = parentToolCallId ?? '';
-		let partId = turn?.reasoningPartIds.get(reasoningScope);
+		let partId = turn.reasoningPartIds.get(reasoningScope);
 		if (!partId) {
 			partId = generateUuid();
-			turn?.reasoningPartIds.set(reasoningScope, partId);
+			turn.reasoningPartIds.set(reasoningScope, partId);
 			this._emitAction({
 				type: ActionType.ChatResponsePart,
-				turnId: this._turnId,
+				turnId: turn.id,
 				part: { kind: ResponsePartKind.Reasoning, id: partId, content },
 			}, parentToolCallId);
 			return;
 		}
 		this._emitAction({
 			type: ActionType.ChatReasoning,
-			turnId: this._turnId,
+			turnId: turn.id,
 			partId,
 			content,
 		}, parentToolCallId);
@@ -2428,10 +2440,12 @@ export class CopilotAgentSession extends Disposable {
 			// queued-message case; reading `e.data.aborted` is the authoritative
 			// SDK signal that lets us also tear down the aborted running turn.
 			if (e.data.aborted) {
-				this._logService.trace(`[Copilot:${sessionId}] Idle from abort; leaving turn ${turn.id} (${turn.state}) open`);
 				if (turn.isRunning) {
+					this._logService.trace(`[Copilot:${sessionId}] Idle from abort; tearing down running turn ${turn.id}`);
 					turn.markAborted();
 					this._currentTurn = undefined;
+				} else {
+					this._logService.trace(`[Copilot:${sessionId}] Idle from abort; leaving ${turn.state} turn ${turn.id} open`);
 				}
 				return;
 			}

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -905,7 +905,7 @@ suite('AgentSideEffects', () => {
 			assert.strictEqual(state?.queuedMessages, undefined);
 		});
 
-		test('does NOT drain queued messages when the active turn is cancelled', () => {
+		test('does not drain queued messages when the active turn is cancelled', () => {
 			// Cancelling a turn means "stop": messages queued behind it must stay
 			// queued for the user to dequeue/run manually, not auto-start. (A
 			// message the user sends *after* the abort is consumed separately via

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -905,6 +905,40 @@ suite('AgentSideEffects', () => {
 			assert.strictEqual(state?.queuedMessages, undefined);
 		});
 
+		test('does NOT drain queued messages when the active turn is cancelled', () => {
+			// Cancelling a turn means "stop": messages queued behind it must stay
+			// queued for the user to dequeue/run manually, not auto-start. (A
+			// message the user sends *after* the abort is consumed separately via
+			// the ChatPendingMessageSet path once cancellation clears the turn.)
+			setupSession();
+			disposables.add(sideEffects.registerProgressListener(agent));
+
+			// Queue a message while a turn is active.
+			startTurn('turn-1');
+			const setAction = {
+				type: ActionType.ChatPendingMessageSet as const,
+				kind: PendingMessageKind.Queued,
+				id: 'q-after-abort',
+				message: { text: 'queued behind abort', origin: { kind: MessageKind.User } },
+			};
+			stateManager.dispatchClientAction(sessionUri.toString(), setAction, { clientId: 'test', clientSeq: 1 });
+			sideEffects.handleAction(sessionUri.toString(), setAction);
+
+			// Not consumed yet — the turn is still active.
+			assert.strictEqual(agent.sendMessageCalls.length, 0);
+
+			// Cancel the active turn (client abort).
+			const cancelAction = { type: ActionType.ChatTurnCancelled as const, turnId: 'turn-1' };
+			stateManager.dispatchClientAction(sessionUri.toString(), cancelAction, { clientId: 'test', clientSeq: 2 });
+			sideEffects.handleAction(sessionUri.toString(), cancelAction);
+
+			// The queued message must NOT auto-start, and must remain queued.
+			assert.strictEqual(agent.sendMessageCalls.length, 0, 'cancelling must not drain queued messages');
+			const state = stateManager.getSessionState(sessionUri.toString());
+			assert.strictEqual(state?.queuedMessages?.length, 1, 'queued message should remain for manual dequeue');
+			assert.strictEqual(state?.queuedMessages?.[0].id, 'q-after-abort');
+		});
+
 		test('intercepts queued /rename and drains the message queued behind it', () => {
 			setupSession();
 			// `/rename` persists the new title, so use a side effects instance

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -1657,8 +1657,9 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual((turnComplete as { turnId: string }).turnId, turnStarted.turnId);
 		});
 
-		test('events after a completed turn do not target the stale previous turn id', async () => {
-			const { session, mockSession, signals } = await createAgentSession(disposables);
+		test('a late event after a completed turn is dropped and logged (never targets the stale turn id)', async () => {
+			const logService = new CapturingLogService();
+			const { session, mockSession, signals } = await createAgentSession(disposables, { logService });
 			session.resetTurnState('turn-old');
 
 			mockSession.fire('session.idle', {} as SessionEventPayload<'session.idle'>['data']);
@@ -1666,12 +1667,13 @@ suite('CopilotAgentSession', () => {
 				deltaContent: 'late text',
 			} as SessionEventPayload<'assistant.message_delta'>['data']);
 
-			const lateMarkdownActions = getActions(signals)
-				.filter(a => a.type === ActionType.ChatResponsePart && a.part.kind === ResponsePartKind.Markdown)
-				.map(a => a as ChatResponsePartAction);
-			const lateMarkdown = lateMarkdownActions[lateMarkdownActions.length - 1];
-			assert.ok(lateMarkdown, 'late event still emits a no-op action for the reducer');
-			assert.notStrictEqual(lateMarkdown.turnId, 'turn-old');
+			// With no active turn, the late delta is dropped (not emitted even as a
+			// no-op), so it can never be attributed to the stale 'turn-old', and the
+			// unexpected state is surfaced via an error log.
+			const markdownActions = getActions(signals)
+				.filter(a => a.type === ActionType.ChatResponsePart && a.part.kind === ResponsePartKind.Markdown);
+			assert.strictEqual(markdownActions.length, 0, 'the late delta must be dropped, not emitted');
+			assert.ok(logService.errors.some(e => /no active turn/i.test(String(e.first))), 'the dropped delta should be logged');
 		});
 	});
 
@@ -2103,6 +2105,24 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual(signals.length, 0);
 		});
 
+		test('drops and logs a markdown delta emitted with no active turn', async () => {
+			// A delta should only arrive while a turn is active. With none, we
+			// can't persist the part id (so every delta would allocate a fresh
+			// part) and the action would carry an empty turnId — drop it and log.
+			const logService = new CapturingLogService();
+			const { mockSession, signals } = await createAgentSession(disposables, { logService });
+
+			// No resetTurnState → no active turn.
+			mockSession.fire('assistant.message_delta', {
+				deltaContent: 'orphan text',
+			} as SessionEventPayload<'assistant.message_delta'>['data']);
+
+			const parts = getActions(signals).filter(a => a.type === ActionType.ChatResponsePart || a.type === ActionType.ChatDelta);
+			assert.strictEqual(parts.length, 0, 'no response part/delta should be emitted without an active turn');
+			assert.strictEqual(logService.errors.length, 1, 'should log an error');
+			assert.match(String(logService.errors[0].first), /no active turn/i);
+		});
+
 		test('abort-induced idle does not complete a pending queued turn', async () => {
 			// Repro for the blank-response-after-abort race: a running turn is
 			// aborted while a queued message exists. The queued message's
@@ -2191,7 +2211,8 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('message delta is forwarded', async () => {
-			const { mockSession, signals } = await createAgentSession(disposables);
+			const { session, mockSession, signals } = await createAgentSession(disposables);
+			session.resetTurnState('turn-1');
 			mockSession.fire('assistant.message_delta', {
 				messageId: 'msg-1',
 				deltaContent: 'Hello ',
@@ -2436,7 +2457,8 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('reasoning delta after tool_start starts a new reasoning response part', async () => {
-			const { mockSession, signals } = await createAgentSession(disposables);
+			const { session, mockSession, signals } = await createAgentSession(disposables);
+			session.resetTurnState('turn-1');
 
 			// First reasoning delta — allocates a fresh reasoning response part.
 			mockSession.fire('assistant.reasoning_delta', {
@@ -3599,6 +3621,7 @@ suite('CopilotAgentSession', () => {
 
 		test('handleExitPlanModeRequest produces a single-select input request with options and recommended', async () => {
 			const { session, runtime, mockSession, signals, waitForSignal } = await createAgentSession(disposables);
+			session.resetTurnState('turn-plan');
 
 			mockSession.planReadResult = { exists: true, content: '## Plan', path: '/sessions/abc/plan.md' };
 

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -1493,6 +1493,35 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual((consumed as { id: string }).id, 'steer-1');
 		});
 
+		test('an abort during a steering turn tears it down without completing it', async () => {
+			// A steering turn is promoted mid-loop while the SDK is actively
+			// producing its response, so it must be `running` (not `pending`).
+			// Otherwise an abort's terminal idle would treat it as a not-yet-
+			// started queued turn and leave it open, and a later idle would
+			// orphan-complete it.
+			const { session, mockSession, signals } = await createAgentSession(disposables);
+			session.resetTurnState('turn-original');
+			mockSession.fire('assistant.turn_start', { turnId: 'sdk-0' } as SessionEventPayload<'assistant.turn_start'>['data']);
+
+			await session.sendSteering({ id: 'steer-1', message: { text: 'focus on tests', origin: { kind: MessageKind.User } } });
+			mockSession.fire('user.message', {
+				content: 'focus on tests',
+				interactionId: 'interaction-steer',
+			} as SessionEventPayload<'user.message'>['data']);
+
+			const steeringTurnId = getActions(signals).find(a => a.type === ActionType.ChatTurnStarted)?.turnId;
+			assert.ok(steeringTurnId && steeringTurnId !== 'turn-original', 'steering should start its own turn');
+
+			// Abort: the running steering turn is finalized by the client's
+			// ChatTurnCancelled, so its terminal idle must tear it down rather
+			// than complete it — and a subsequent stray idle must find no turn.
+			mockSession.fire('session.idle', { aborted: true } as SessionEventPayload<'session.idle'>['data']);
+			mockSession.fire('session.idle', {} as SessionEventPayload<'session.idle'>['data']);
+
+			const steeringCompletions = getActions(signals).filter(a => a.type === ActionType.ChatTurnComplete && a.turnId === steeringTurnId);
+			assert.strictEqual(steeringCompletions.length, 0, 'an aborted steering turn must not be completed');
+		});
+
 		test('does not signal cleanup when send fails', async () => {
 			const { session, mockSession, signals } = await createAgentSession(disposables);
 
@@ -2072,6 +2101,76 @@ suite('CopilotAgentSession', () => {
 			mockSession.fire('session.idle', {} as SessionEventPayload<'session.idle'>['data']);
 
 			assert.strictEqual(signals.length, 0);
+		});
+
+		test('abort-induced idle does not complete a pending queued turn', async () => {
+			// Repro for the blank-response-after-abort race: a running turn is
+			// aborted while a queued message exists. The queued message's
+			// `send()` creates a fresh (pending) turn before the abort's
+			// terminal `session.idle` is delivered. That idle must not complete
+			// the queued turn — structurally, because it has not started running
+			// yet, and because the idle carries `aborted: true`.
+			const { session, mockSession, signals } = await createAgentSession(disposables);
+
+			// The queued message has started its (pending) turn by the time the
+			// abort's terminal idle arrives — no SDK event has run it yet.
+			session.resetTurnState('turn-queued');
+			mockSession.fire('session.idle', { aborted: true } as SessionEventPayload<'session.idle'>['data']);
+
+			assert.strictEqual(
+				getActions(signals).filter(a => a.type === ActionType.ChatTurnComplete).length,
+				0,
+				'abort-induced idle must not complete the pending queued turn',
+			);
+
+			// The queued turn now actually runs (first SDK event) and then
+			// completes on its own (non-abort) idle.
+			mockSession.fire('assistant.turn_start', { turnId: 'sdk-0' } as SessionEventPayload<'assistant.turn_start'>['data']);
+			mockSession.fire('session.idle', {} as SessionEventPayload<'session.idle'>['data']);
+
+			const completions = getActions(signals).filter(a => a.type === ActionType.ChatTurnComplete);
+			assert.strictEqual(completions.length, 1, 'the queued turn should complete on its real idle');
+			assert.strictEqual((completions[0] as ChatTurnCompleteAction).turnId, 'turn-queued');
+		});
+
+		test('abort-induced idle tears down a running turn without completing it', async () => {
+			// Plain abort (no queued message): the running turn is finalized by
+			// the client-dispatched ChatTurnCancelled, so the abort's idle must
+			// not also emit a ChatTurnComplete. The turn handle is dropped so a
+			// later stray idle cannot complete it.
+			const { session, mockSession, signals } = await createAgentSession(disposables);
+
+			session.resetTurnState('turn-aborted');
+			mockSession.fire('assistant.turn_start', { turnId: 'sdk-0' } as SessionEventPayload<'assistant.turn_start'>['data']);
+			mockSession.fire('session.idle', { aborted: true } as SessionEventPayload<'session.idle'>['data']);
+
+			assert.strictEqual(
+				getActions(signals).filter(a => a.type === ActionType.ChatTurnComplete).length,
+				0,
+				'abort-induced idle must not complete the running aborted turn',
+			);
+
+			// A subsequent stray idle has no turn to act on.
+			mockSession.fire('session.idle', {} as SessionEventPayload<'session.idle'>['data']);
+			assert.strictEqual(getActions(signals).filter(a => a.type === ActionType.ChatTurnComplete).length, 0);
+		});
+
+		test('a running turn after a prior abort still completes on its idle', async () => {
+			// No lingering state across turns: the next turn completes normally.
+			const { session, mockSession, signals } = await createAgentSession(disposables);
+
+			session.resetTurnState('turn-aborted');
+			mockSession.fire('assistant.turn_start', { turnId: 'sdk-0' } as SessionEventPayload<'assistant.turn_start'>['data']);
+			mockSession.fire('session.idle', { aborted: true } as SessionEventPayload<'session.idle'>['data']);
+			assert.strictEqual(getActions(signals).filter(a => a.type === ActionType.ChatTurnComplete).length, 0);
+
+			session.resetTurnState('turn-next');
+			mockSession.fire('assistant.turn_start', { turnId: 'sdk-1' } as SessionEventPayload<'assistant.turn_start'>['data']);
+			mockSession.fire('session.idle', {} as SessionEventPayload<'session.idle'>['data']);
+
+			const completions = getActions(signals).filter(a => a.type === ActionType.ChatTurnComplete);
+			assert.strictEqual(completions.length, 1);
+			assert.strictEqual((completions[0] as ChatTurnCompleteAction).turnId, 'turn-next');
 		});
 
 		test('error event is forwarded', async () => {


### PR DESCRIPTION
## Problem

A user reported a chat turn that terminated with **no response** after sending a message while a turn was being aborted.

Root cause: when a running turn is aborted while a follow-up message is queued, the Copilot SDK emits its terminal `session.idle` event asynchronously (after a ~2s teardown). By then, the queued message's `send()` has already reassigned the session's single mutable "current turn" id. The old `onIdle` handler completed *the current turn*, so the abort's stale idle emitted an empty `ChatTurnComplete` for the **freshly-started queued turn** — orphaning its real response and a pending permission prompt. The user saw a blank, terminated turn.

## Fix

1. **Read the authoritative signal.** `session.idle` carries `IdleData.aborted` ("true when the preceding agentic loop was cancelled via abort signal"). Use it instead of guessing.

2. **Durability refactor — `CopilotTurn`.** Replace the scattered per-turn fields (`_turnId`, usage counter, streaming part-id maps) and their two hand-maintained reset sites with a single `CopilotTurn` object carrying an explicit lifecycle:
   - `pending` — between `send()` and the first SDK event
   - `running` — after the first SDK event (`onUserMessage` / `onTurnStart`)
   - `completed` / `aborted`

   `onIdle` is now state-driven: an aborted idle tears down a `running` turn (the client's `ChatTurnCancelled` finalizes it) and **leaves a `pending` queued turn open** for its own idle, so the next turn's response is never orphaned. A non-abort idle completes the turn (defensively also a `pending` one so a no-op send can't hang). `_turnId` is now a getter over the current turn, so all read sites are unchanged.

3. **Steering turns** are marked `running` on creation, since they are promoted mid-loop while the SDK is actively streaming — otherwise an abort during a steering turn would mistreat it as a not-yet-started queued turn.

## Notes for reviewers

- **Cancelling does not drain queued messages** — that's intentional (cancel = "stop"; messages stay for manual dequeue). A message sent *after* the abort is still consumed via the `ChatPendingMessageSet` path once cancellation clears the active turn. Locked in with a test.
- The subagent routing map `_parentToolCallIdsByAgentId` is deliberately kept **session-scoped** (not per-turn): background subagents can outlive the parent tool call, and the map's lifetime is driven by subagent started/completed events.

## Testing

New unit tests cover: pending queued turn left open on an abort idle, running aborted turn torn down (not completed), steering-turn teardown on abort, and the cancel-does-not-drain behavior. Full node unit suite passes; typecheck and eslint clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
