### PR TITLE
agentHost: fix Windows CI write auto-approval test using Azure temp dir

### DIFF
--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -53,9 +53,13 @@ suite('SessionPermissionManager', () => {
 		// Prefer the CI runner temp dir (a plain long path) over `os.tmpdir()`,
 		// which on Windows CI is an 8.3 short path (`C:\Users\RUNNER~1\...`) that
 		// `assertPathIsSafe` rejects for its `~1` segment — which would make every
-		// auto-approval fail. `realpathSync` keeps macOS `/var` -> `/private/var`
-		// consistent so the symlink-resolution checks compare like-for-like.
-		const baseTmp = process.env.RUNNER_TEMP || tmpdir();
+		// write auto-approval fail. `AGENT_TEMPDIRECTORY` is set by Azure DevOps
+		// (VS Code's CI) and `RUNNER_TEMP` by GitHub Actions. Note that the JS
+		// `fs.realpathSync` does not expand 8.3 short names to their long form, so
+		// the short-path fallback can't be repaired afterwards. `realpathSync`
+		// keeps macOS `/var` -> `/private/var` consistent so the symlink-resolution
+		// checks compare like-for-like.
+		const baseTmp = process.env.AGENT_TEMPDIRECTORY || process.env.RUNNER_TEMP || tmpdir();
 		workDir = realpathSync(mkdtempSync(join(baseTmp, 'sesperm-work-')));
 		outsideDir = realpathSync(mkdtempSync(join(baseTmp, 'sesperm-out-')));
 


### PR DESCRIPTION
## What

Fixes the failing unit test `SessionPermissionManager > auto-approves a normal file inside the working directory` on Windows CI (introduced by #322151).

Single change in `src/vs/platform/agentHost/test/node/sessionPermissions.test.ts`:

```ts
const baseTmp = process.env.AGENT_TEMPDIRECTORY || process.env.RUNNER_TEMP || tmpdir();
```

## Why

The test picked its temp base via `process.env.RUNNER_TEMP || tmpdir()`. `RUNNER_TEMP` is a **GitHub Actions** variable and is **unset** on VS Code's **Azure DevOps** CI, so it fell back to `os.tmpdir()` — which on the Windows agent is an **8.3 short path** containing a `~1` segment (e.g. `C:\Users\...~1\...\Temp`).

The test resolves that path with `fs.realpathSync` (the JS, non-native implementation), which does **not** expand 8.3 short names to long form, so `workDir` kept the `~1` segment. For **write** auto-approval, `_checkWritePath` → `assertPathIsSafe` deliberately rejects any `~1` (8.3) segment, so `getAutoApproval` returned `undefined` instead of `ToolCallConfirmationReason.NotNeeded`:

```
+ actual:   undefined
- expected: 'not-needed'
```

This is exactly why only the *write* auto-approve test failed — the read test (`_isPathInWorkingDirectory`) and the "requires confirmation" tests (which expect `undefined`) never depend on `assertPathIsSafe`.

The earlier follow-up commit `918743e` ("fix flaky write auto-approval on Windows from native realpath") was already present in the failing build; it addressed a different subst-drive angle, not this one.

## Fix

Use `AGENT_TEMPDIRECTORY` (set by Azure DevOps, a long path like `D:\a\_work\_temp`) ahead of `RUNNER_TEMP`, matching how the rest of the VS Code build (`build/azure-pipelines/...`) resolves the CI temp directory. `RUNNER_TEMP` is kept for GitHub Actions and `tmpdir()` as a local fallback.

## Notes for reviewers

- Test-only change; the bug was Windows-CI specific (the test already passes on macOS/Linux).
- `npm run typecheck-client` passes; pre-commit hygiene hook passed.

Failing build for reference: Azure build `449675`, Electron unit tests (Windows).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
