### PR TITLE
Gate memoryInstructions on the memory tool being enabled

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/agent/agentPrompt.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/agentPrompt.tsx
@@ -115,6 +115,7 @@ export class AgentPrompt extends PromptElement<AgentPromptProps> {
 		const SafetyRules = customizations.SafetyRulesClass;
 
 		const omitBaseAgentInstructions = this.configurationService.getConfig(ConfigKey.Advanced.OmitBaseAgentInstructions);
+		const hasMemoryTool = !!this.props.promptContext.tools?.availableTools?.find(tool => tool.name === ToolName.Memory);
 		const baseAgentInstructions = <>
 			<SystemMessage>
 				You are an expert AI programming assistant, working with a user in the VS Code editor.<br />
@@ -122,9 +123,9 @@ export class AgentPrompt extends PromptElement<AgentPromptProps> {
 				<SafetyRules />
 			</SystemMessage>
 			{instructions}
-			<SystemMessage>
+			{hasMemoryTool && <SystemMessage>
 				<MemoryInstructionsPrompt />
-			</SystemMessage>
+			</SystemMessage>}
 		</>;
 		const isAutopilot = this.props.promptContext.request?.permissionLevel === 'autopilot';
 		const sessionResource = this.props.promptContext.request?.sessionResource;
@@ -342,6 +343,7 @@ interface GlobalAgentContextProps extends BasePromptElementProps {
  */
 class GlobalAgentContext extends PromptElement<GlobalAgentContextProps> {
 	render() {
+		const hasMemoryTool = !!this.props.availableTools?.find(tool => tool.name === ToolName.Memory);
 		return <UserMessage>
 			<Tag name='environment_info'>
 				<UserOSPrompt />
@@ -354,7 +356,7 @@ class GlobalAgentContext extends PromptElement<GlobalAgentContextProps> {
 				<AgentMultirootWorkspaceStructure maxSize={2000} excludeDotFiles={true} availableTools={this.props.availableTools} workingDir={this.props.workingDir} />
 			</Tag>
 			<UserPreferences flexGrow={7} priority={800} />
-			{this.props.isNewChat && <MemoryContextPrompt sessionResource={this.props.sessionResource} />}
+			{this.props.isNewChat && hasMemoryTool && <MemoryContextPrompt sessionResource={this.props.sessionResource} />}
 			<DeferredToolListReminder availableTools={this.props.availableTools} />
 			{this.props.enableCacheBreakpoints && <cacheBreakpoint type={CacheType} />}
 		</UserMessage>;
@@ -492,6 +494,7 @@ export class AgentUserMessage extends PromptElement<AgentUserMessageProps> {
 		const hasTerminalTool = !!this.props.availableTools?.find(tool => tool.name === ToolName.CoreRunInTerminal);
 		const hasToolsToEditNotebook = hasCreateFileTool || hasEditNotebookTool || hasReplaceStringTool || hasApplyPatchTool || hasEditFileTool;
 		const hasTodoTool = !!this.props.availableTools?.find(tool => tool.name === ToolName.CoreManageTodoList);
+		const hasMemoryTool = !!this.props.availableTools?.find(tool => tool.name === ToolName.Memory);
 
 		const userQueryTagName = this.props.userQueryTagName ?? 'userRequest';
 		const ReminderInstructionsClass = this.props.ReminderInstructionsClass ?? DefaultReminderInstructions;
@@ -501,6 +504,7 @@ export class AgentUserMessage extends PromptElement<AgentUserMessageProps> {
 			hasEditFileTool,
 			hasReplaceStringTool,
 			hasMultiReplaceStringTool,
+			hasMemoryTool,
 		};
 		const ToolReferencesHintClass = this.props.ToolReferencesHintClass ?? DefaultToolReferencesHint;
 		const toolReferencesHintProps: ToolReferencesHintProps = {

--- a/extensions/copilot/src/extension/prompts/node/agent/anthropicPrompts.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/anthropicPrompts.tsx
@@ -608,7 +608,7 @@ class AnthropicReminderInstructionsOptimized extends PromptElement<ReminderInstr
 			{this.props.hasMultiReplaceStringTool && <>For multiple independent edits, use {ToolName.MultiReplaceString} simultaneously rather than sequential {ToolName.ReplaceString} calls.<br /></>}
 			{this.props.hasEditFileTool && this.props.hasReplaceStringTool && <>Prefer {ToolName.ReplaceString}{this.props.hasMultiReplaceStringTool ? <> or {ToolName.MultiReplaceString}</> : ''} over {ToolName.EditFile}.<br /></>}
 			Do NOT create markdown files to document changes unless requested.<br />
-			{contextEditingEnabled && <>
+			{contextEditingEnabled && this.props.hasMemoryTool && <>
 				Do NOT view your memory directory before every task. Your context is managed automatically. Only use memory as described in memoryInstructions.<br />
 			</>}
 		</>;
@@ -691,7 +691,7 @@ class AnthropicReminderInstructions extends PromptElement<ReminderInstructionsPr
 		return <>
 			{getEditingReminder(this.props.hasEditFileTool, this.props.hasReplaceStringTool, false /* useStrongReplaceStringHint */, this.props.hasMultiReplaceStringTool)}
 			Do NOT create a new markdown file to document each change or summarize your work unless specifically requested by the user.<br />
-			{contextEditingEnabled && <>
+			{contextEditingEnabled && this.props.hasMemoryTool && <>
 				<br />
 				IMPORTANT: Do NOT view your memory directory before every task. Do NOT assume your context will be interrupted or reset. Your context is managed automatically — you do not need to urgently save progress to memory. Only use memory as described in the memoryInstructions section. Do not create memory files to record routine progress or status updates unless the user explicitly asks you to.<br />
 			</>}

--- a/extensions/copilot/src/extension/prompts/node/agent/defaultAgentInstructions.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/defaultAgentInstructions.tsx
@@ -72,6 +72,7 @@ export interface ReminderInstructionsProps extends BasePromptElementProps {
 	readonly hasEditFileTool: boolean;
 	readonly hasReplaceStringTool: boolean;
 	readonly hasMultiReplaceStringTool: boolean;
+	readonly hasMemoryTool: boolean;
 }
 
 export function getEditingReminder(hasEditFileTool: boolean, hasReplaceStringTool: boolean, useStrongReplaceStringHint: boolean, hasMultiStringReplace: boolean) {

--- a/extensions/copilot/src/extension/prompts/node/agent/test/agentPrompt.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/agentPrompt.spec.tsx
@@ -89,7 +89,7 @@ testFamilies.forEach(family => {
 			accessor.dispose();
 		});
 
-		async function agentPromptToString(accessor: ITestingServicesAccessor, promptContext: IBuildPromptContext, otherProps?: Partial<AgentPromptProps>): Promise<string> {
+		async function agentPromptToString(accessor: ITestingServicesAccessor, promptContext: IBuildPromptContext, otherProps?: Partial<AgentPromptProps>, includeMemoryTool = true): Promise<string> {
 			const instaService = accessor.get(IInstantiationService);
 			const endpoint = family === 'default'
 				? instaService.createInstance(MockEndpoint, undefined)
@@ -97,6 +97,24 @@ testFamilies.forEach(family => {
 			const isMessagesApi = family.startsWith('claude-');
 			if (!promptContext.conversation) {
 				promptContext = { ...promptContext, conversation };
+			}
+
+			// Real agent requests always advertise the non-deferred memory tool, which gates
+			// the memory instructions/context blocks. Advertise it here so scenarios that don't
+			// otherwise pass tools still exercise the memory-enabled prompt by default; the
+			// `memory tool disabled` test opts out to cover the gated-off behavior.
+			if (includeMemoryTool && !promptContext.tools?.availableTools.some(t => t.name === ToolName.Memory)) {
+				const memoryTool = accessor.get(IToolsService).tools.find(t => t.name === ToolName.Memory);
+				if (memoryTool) {
+					promptContext = {
+						...promptContext,
+						tools: {
+							toolInvocationToken: promptContext.tools?.toolInvocationToken ?? (null as never),
+							toolReferences: promptContext.tools?.toolReferences ?? [],
+							availableTools: [...(promptContext.tools?.availableTools ?? []), memoryTool],
+						}
+					};
+				}
 			}
 
 			const customizations = await PromptRegistry.resolveAllCustomizations(instaService, endpoint);
@@ -176,6 +194,24 @@ testFamilies.forEach(family => {
 					toolReferences: [],
 				}
 			}, undefined)).toMatchFileSnapshot(getSnapshotFile('all_non_edit_tools'));
+		});
+
+		test('memory tool disabled omits memory instructions and context', async () => {
+			const toolsService = accessor.get(IToolsService);
+			const rendered = await agentPromptToString(accessor, {
+				chatVariables: new ChatVariablesCollection(),
+				history: [],
+				query: 'hello',
+				tools: {
+					availableTools: toolsService.tools.filter(t => t.name !== ToolName.Memory),
+					toolInvocationToken: null as never,
+					toolReferences: [],
+				}
+			}, undefined, /* includeMemoryTool */ false);
+			expect(rendered).not.toContain('memoryInstructions');
+			expect(rendered).not.toContain('userMemory');
+			expect(rendered).not.toContain('sessionMemory');
+			expect(rendered).not.toContain('repoMemory');
 		});
 
 		test('one attachment', async () => {

--- a/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
@@ -27,6 +27,7 @@ import { IBuildPromptContext, IToolCall } from '../../../../prompt/common/intent
 import { ToolCallRound } from '../../../../prompt/common/toolCallRound';
 import { createExtensionUnitTestingServices } from '../../../../test/node/services';
 import { ToolName } from '../../../../tools/common/toolNames';
+import { IToolsService } from '../../../../tools/common/toolsService';
 import { PromptRenderer } from '../../base/promptRenderer';
 import { AgentPrompt, AgentPromptProps } from '../agentPrompt';
 import { PromptRegistry } from '../promptRegistry';
@@ -87,6 +88,22 @@ suite('Agent Summarization', () => {
 		normalizeSummariesOnRounds(promptContext.history);
 		if (!promptContext.conversation) {
 			promptContext = { ...promptContext, conversation };
+		}
+
+		// Real agent requests always advertise the non-deferred memory tool, which gates the
+		// memory context blocks. Advertise it here so the rendered Agent prompt matches real usage.
+		if (!promptContext.tools?.availableTools.some(t => t.name === ToolName.Memory)) {
+			const memoryTool = accessor.get(IToolsService).tools.find(t => t.name === ToolName.Memory);
+			if (memoryTool) {
+				promptContext = {
+					...promptContext,
+					tools: {
+						toolInvocationToken: promptContext.tools?.toolInvocationToken ?? (null as never),
+						toolReferences: promptContext.tools?.toolReferences ?? [],
+						availableTools: [...(promptContext.tools?.availableTools ?? []), memoryTool],
+					}
+				};
+			}
 		}
 
 		const baseProps = {


### PR DESCRIPTION
Fixes #321833

### Problem

The `<memoryInstructions>` system block and the `<userMemory>` / `<sessionMemory>` / `<repoMemory>` context blocks were injected into the agent system prompt unconditionally — even when the memory tool is disabled. The model was then told to consult/read/write memory files it had no tool to reach, producing confusing behavior and wasted turns.

### Fix

Render the memory instructions and context blocks only when `ToolName.Memory` is present in `availableTools`, so the prompt and the available tools stay in sync. The two Anthropic reminder lines that reference the `memoryInstructions` section are gated on the same condition.

The memory tool is `nonDeferred`, so when enabled it is always present in `availableTools` at prompt-render time — the gate does not false-negative in real requests.

### Tests

- The agentPrompt + summarization test helpers now advertise the (always-on) memory tool by default, mirroring real requests, so existing snapshots are unchanged.
- Added a focused `memory tool disabled` test asserting the blocks are omitted when the tool is absent.