### PR TITLE
Avoid CPU-pegging process report in libc detection

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1527,6 +1527,7 @@ export default defineConfig(
 						'console',
 						'cookie',
 						'crypto',
+						'detect-libc',
 						'dns',
 						'events',
 						'fs',

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "@xterm/headless": "^6.1.0-beta.285",
         "@xterm/xterm": "^6.1.0-beta.285",
         "chrome-remote-interface": "^0.33.0",
+        "detect-libc": "^2.1.2",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.2",
         "jschardet": "3.1.4",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "@xterm/headless": "^6.1.0-beta.285",
     "@xterm/xterm": "^6.1.0-beta.285",
     "chrome-remote-interface": "^0.33.0",
+    "detect-libc": "^2.1.2",
     "http-proxy-agent": "^7.0.0",
     "https-proxy-agent": "^7.0.2",
     "jschardet": "3.1.4",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -38,6 +38,7 @@
         "@xterm/headless": "^6.1.0-beta.285",
         "@xterm/xterm": "^6.1.0-beta.285",
         "cookie": "^0.7.0",
+        "detect-libc": "^2.1.2",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.2",
         "jschardet": "3.1.4",

--- a/remote/package.json
+++ b/remote/package.json
@@ -33,6 +33,7 @@
     "@xterm/headless": "^6.1.0-beta.285",
     "@xterm/xterm": "^6.1.0-beta.285",
     "cookie": "^0.7.0",
+    "detect-libc": "^2.1.2",
     "http-proxy-agent": "^7.0.0",
     "https-proxy-agent": "^7.0.2",
     "jschardet": "3.1.4",

--- a/src/vs/base/node/libc.ts
+++ b/src/vs/base/node/libc.ts
@@ -39,6 +39,22 @@ function readFileHead(path: string, length: number): Buffer | undefined {
 }
 
 /**
+ * Reads a little-endian unsigned 64-bit integer expected to fit in a safe JS
+ * integer, or `undefined` if the bytes are unavailable or the value is out of
+ * range.
+ */
+function readSafeUInt64LE(buffer: Buffer, offset: number): number | undefined {
+	if (offset < 0 || offset + 8 > buffer.length) {
+		return undefined;
+	}
+	const value = buffer.readBigUInt64LE(offset);
+	if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+		return undefined;
+	}
+	return Number(value);
+}
+
+/**
  * Extracts the `PT_INTERP` program interpreter (dynamic linker) path from the
  * head of a 64-bit little-endian ELF binary, or `undefined` if it cannot be
  * parsed from the bytes available.
@@ -51,23 +67,33 @@ function elfInterpreterPath(elf: Buffer): string | undefined {
 		return undefined; // not ELF magic
 	}
 	if (elf.readUInt8(4) !== 2) {
-		return undefined; // not 64-bit
+		return undefined; // not 64-bit (ELFCLASS64)
 	}
 	if (elf.readUInt8(5) !== 1) {
 		return undefined; // not little-endian
 	}
-	const programHeaderOffset = elf.readUInt32LE(32);
+	// ELF64 header: e_phoff is a 64-bit file offset at byte 32; e_phentsize and
+	// e_phnum are 16-bit at bytes 54 and 56. Each program header entry
+	// (Elf64_Phdr) is at least 56 bytes, with the 64-bit p_offset at +8 and the
+	// 64-bit p_filesz at +32.
+	const programHeaderOffset = readSafeUInt64LE(elf, 32);
 	const entrySize = elf.readUInt16LE(54);
 	const entryCount = elf.readUInt16LE(56);
+	if (programHeaderOffset === undefined || entrySize < 56) {
+		return undefined;
+	}
 	const PT_INTERP = 3;
 	for (let i = 0; i < entryCount; i++) {
 		const headerOffset = programHeaderOffset + (i * entrySize);
-		if (headerOffset + 36 > elf.length) {
+		if (headerOffset + 40 > elf.length) {
 			break;
 		}
 		if (elf.readUInt32LE(headerOffset) === PT_INTERP) {
-			const fileOffset = elf.readUInt32LE(headerOffset + 8);
-			const fileSize = elf.readUInt32LE(headerOffset + 32);
+			const fileOffset = readSafeUInt64LE(elf, headerOffset + 8);
+			const fileSize = readSafeUInt64LE(elf, headerOffset + 32);
+			if (fileOffset === undefined || fileSize === undefined) {
+				return undefined;
+			}
 			return elf.subarray(fileOffset, fileOffset + fileSize).toString().replace(/\0.*$/, '');
 		}
 	}

--- a/src/vs/base/node/libc.ts
+++ b/src/vs/base/node/libc.ts
@@ -22,9 +22,11 @@ let _cacheValid = false;
  * not peg the CPU on busy hosts. When detection is inconclusive we assume
  * `glibc`, the dominant Linux libc.
  *
- * Cached after first call; libc never changes mid-process.
+ * Cached after first call; libc never changes mid-process. This is the
+ * synchronous variant; add a promise-based `detectLibc` wrapping
+ * `detect-libc`'s async `family()` if a non-blocking caller ever needs one.
  */
-export function detectLibc(): LibcFamily | undefined {
+export function detectLibcSync(): LibcFamily | undefined {
 	if (_cacheValid) {
 		return _cached;
 	}

--- a/src/vs/base/node/libc.ts
+++ b/src/vs/base/node/libc.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as fs from 'fs';
+import { familySync, MUSL } from 'detect-libc';
 import * as Platform from '../common/platform.js';
 
 /** The libc family the current process is linked against. */
@@ -12,171 +12,15 @@ export type LibcFamily = 'glibc' | 'musl';
 let _cached: LibcFamily | undefined;
 let _cacheValid = false;
 
-const MAX_HEAD_LENGTH = 2048;
-
-/**
- * Reads up to `length` bytes from the start of a file, or `undefined` if the
- * file cannot be opened or read.
- */
-function readFileHead(path: string, length: number): Buffer | undefined {
-	let fd: number | undefined;
-	try {
-		fd = fs.openSync(path, 'r');
-		const buffer = Buffer.alloc(length);
-		const bytesRead = fs.readSync(fd, buffer, 0, length, 0);
-		return buffer.subarray(0, bytesRead);
-	} catch {
-		return undefined;
-	} finally {
-		if (fd !== undefined) {
-			try {
-				fs.closeSync(fd);
-			} catch {
-				// ignore
-			}
-		}
-	}
-}
-
-/**
- * Reads a little-endian unsigned 64-bit integer expected to fit in a safe JS
- * integer, or `undefined` if the bytes are unavailable or the value is out of
- * range.
- */
-function readSafeUInt64LE(buffer: Buffer, offset: number): number | undefined {
-	if (offset < 0 || offset + 8 > buffer.length) {
-		return undefined;
-	}
-	const value = buffer.readBigUInt64LE(offset);
-	if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
-		return undefined;
-	}
-	return Number(value);
-}
-
-/**
- * Extracts the `PT_INTERP` program interpreter (dynamic linker) path from the
- * head of a 64-bit little-endian ELF binary, or `undefined` if it cannot be
- * parsed from the bytes available.
- */
-function elfInterpreterPath(elf: Buffer): string | undefined {
-	if (elf.length < 64) {
-		return undefined;
-	}
-	if (elf.readUInt32BE(0) !== 0x7F454C46) {
-		return undefined; // not ELF magic
-	}
-	if (elf.readUInt8(4) !== 2) {
-		return undefined; // not 64-bit (ELFCLASS64)
-	}
-	if (elf.readUInt8(5) !== 1) {
-		return undefined; // not little-endian
-	}
-	// ELF64 header: e_phoff is a 64-bit file offset at byte 32; e_phentsize and
-	// e_phnum are 16-bit at bytes 54 and 56. Each program header entry
-	// (Elf64_Phdr) is at least 56 bytes, with the 64-bit p_offset at +8 and the
-	// 64-bit p_filesz at +32.
-	const programHeaderOffset = readSafeUInt64LE(elf, 32);
-	const entrySize = elf.readUInt16LE(54);
-	const entryCount = elf.readUInt16LE(56);
-	if (programHeaderOffset === undefined || entrySize < 56) {
-		return undefined;
-	}
-	const PT_INTERP = 3;
-	for (let i = 0; i < entryCount; i++) {
-		const headerOffset = programHeaderOffset + (i * entrySize);
-		if (headerOffset + 40 > elf.length) {
-			break;
-		}
-		if (elf.readUInt32LE(headerOffset) === PT_INTERP) {
-			const fileOffset = readSafeUInt64LE(elf, headerOffset + 8);
-			const fileSize = readSafeUInt64LE(elf, headerOffset + 32);
-			if (fileOffset === undefined || fileSize === undefined) {
-				return undefined;
-			}
-			return elf.subarray(fileOffset, fileOffset + fileSize).toString().replace(/\0.*$/, '');
-		}
-	}
-	return undefined;
-}
-
-function familyFromInterpreterPath(path: string): LibcFamily | undefined {
-	if (path.includes('/ld-musl-')) {
-		return 'musl';
-	}
-	if (path.includes('/ld-linux-')) {
-		return 'glibc';
-	}
-	return undefined;
-}
-
-/** Cheap probe: the dynamic linker named in this process's own ELF header. */
-function familyFromSelfInterpreter(): LibcFamily | undefined {
-	const elf = readFileHead('/proc/self/exe', MAX_HEAD_LENGTH);
-	if (!elf) {
-		return undefined;
-	}
-	const interpreter = elfInterpreterPath(elf);
-	return interpreter ? familyFromInterpreterPath(interpreter) : undefined;
-}
-
-/** Cheap probe: the contents of the `ldd` script/binary. */
-function familyFromLdd(): LibcFamily | undefined {
-	const content = readFileHead('/usr/bin/ldd', MAX_HEAD_LENGTH)?.toString();
-	if (!content) {
-		return undefined;
-	}
-	if (content.includes('musl')) {
-		return 'musl';
-	}
-	if (content.includes('GNU C Library')) {
-		return 'glibc';
-	}
-	return undefined;
-}
-
-/**
- * Expensive fallback: Node's process report exposes `glibcVersionRuntime` in
- * its header on glibc builds and a musl loader among its shared objects on musl
- * builds. `excludeNetwork` is set so the report skips libuv/socket enumeration,
- * which is the part that can peg the CPU on busy hosts.
- */
-function familyFromReport(): LibcFamily | undefined {
-	// `excludeNetwork` is present at runtime (added in Node 22.13 / 23.3, and
-	// verified present on the Node we ship) but is missing from the bundled
-	// `@types/node`, so reach it through a narrow cast.
-	const report = process.report as (NodeJS.ProcessReport & { excludeNetwork?: boolean }) | undefined;
-	if (!report) {
-		return undefined;
-	}
-	const previousExcludeNetwork = report.excludeNetwork;
-	report.excludeNetwork = true;
-	try {
-		const data = report.getReport() as {
-			header?: { glibcVersionRuntime?: string };
-			sharedObjects?: string[];
-		};
-		if (data.header?.glibcVersionRuntime) {
-			return 'glibc';
-		}
-		if (data.sharedObjects?.some(o => o.includes('libc.musl-') || o.includes('ld-musl-'))) {
-			return 'musl';
-		}
-	} finally {
-		report.excludeNetwork = previousExcludeNetwork;
-	}
-	return undefined;
-}
-
 /**
  * Returns the libc family of the running Node process on Linux, or `undefined`
  * on non-Linux platforms (where the question is meaningless).
  *
- * Detection tries cheap signals first — the dynamic linker named in this
- * process's ELF header (`/proc/self/exe`), then the `ldd` contents — and only
- * falls back to Node's (network-excluded) process report, which is expensive
- * because it serializes heap, native stack and libuv state. When nothing is
- * conclusive we assume `glibc`, the dominant Linux libc.
+ * Delegates to the `detect-libc` package, which probes cheap signals first (the
+ * ELF interpreter of `/proc/self/exe`, then `/usr/bin/ldd`) and only falls back
+ * to Node's process report — with the libuv/socket section excluded so it does
+ * not peg the CPU on busy hosts. When detection is inconclusive we assume
+ * `glibc`, the dominant Linux libc.
  *
  * Cached after first call; libc never changes mid-process.
  */
@@ -185,7 +29,7 @@ export function detectLibc(): LibcFamily | undefined {
 		return _cached;
 	}
 	if (Platform.isLinux) {
-		_cached = familyFromSelfInterpreter() ?? familyFromLdd() ?? familyFromReport() ?? 'glibc';
+		_cached = familySync() === MUSL ? 'musl' : 'glibc';
 	} else {
 		_cached = undefined;
 	}

--- a/src/vs/base/node/libc.ts
+++ b/src/vs/base/node/libc.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as fs from 'fs';
 import * as Platform from '../common/platform.js';
 
 /** The libc family the current process is linked against. */
@@ -11,26 +12,154 @@ export type LibcFamily = 'glibc' | 'musl';
 let _cached: LibcFamily | undefined;
 let _cacheValid = false;
 
+const MAX_HEAD_LENGTH = 2048;
+
 /**
- * Returns the libc family of the running Node process on Linux, or
- * `undefined` on non-Linux platforms (where the question is meaningless).
+ * Reads up to `length` bytes from the start of a file, or `undefined` if the
+ * file cannot be opened or read.
+ */
+function readFileHead(path: string, length: number): Buffer | undefined {
+	let fd: number | undefined;
+	try {
+		fd = fs.openSync(path, 'r');
+		const buffer = Buffer.alloc(length);
+		const bytesRead = fs.readSync(fd, buffer, 0, length, 0);
+		return buffer.subarray(0, bytesRead);
+	} catch {
+		return undefined;
+	} finally {
+		if (fd !== undefined) {
+			try {
+				fs.closeSync(fd);
+			} catch {
+				// ignore
+			}
+		}
+	}
+}
+
+/**
+ * Extracts the `PT_INTERP` program interpreter (dynamic linker) path from the
+ * head of a 64-bit little-endian ELF binary, or `undefined` if it cannot be
+ * parsed from the bytes available.
+ */
+function elfInterpreterPath(elf: Buffer): string | undefined {
+	if (elf.length < 64) {
+		return undefined;
+	}
+	if (elf.readUInt32BE(0) !== 0x7F454C46) {
+		return undefined; // not ELF magic
+	}
+	if (elf.readUInt8(4) !== 2) {
+		return undefined; // not 64-bit
+	}
+	if (elf.readUInt8(5) !== 1) {
+		return undefined; // not little-endian
+	}
+	const programHeaderOffset = elf.readUInt32LE(32);
+	const entrySize = elf.readUInt16LE(54);
+	const entryCount = elf.readUInt16LE(56);
+	const PT_INTERP = 3;
+	for (let i = 0; i < entryCount; i++) {
+		const headerOffset = programHeaderOffset + (i * entrySize);
+		if (headerOffset + 36 > elf.length) {
+			break;
+		}
+		if (elf.readUInt32LE(headerOffset) === PT_INTERP) {
+			const fileOffset = elf.readUInt32LE(headerOffset + 8);
+			const fileSize = elf.readUInt32LE(headerOffset + 32);
+			return elf.subarray(fileOffset, fileOffset + fileSize).toString().replace(/\0.*$/, '');
+		}
+	}
+	return undefined;
+}
+
+function familyFromInterpreterPath(path: string): LibcFamily | undefined {
+	if (path.includes('/ld-musl-')) {
+		return 'musl';
+	}
+	if (path.includes('/ld-linux-')) {
+		return 'glibc';
+	}
+	return undefined;
+}
+
+/** Cheap probe: the dynamic linker named in this process's own ELF header. */
+function familyFromSelfInterpreter(): LibcFamily | undefined {
+	const elf = readFileHead('/proc/self/exe', MAX_HEAD_LENGTH);
+	if (!elf) {
+		return undefined;
+	}
+	const interpreter = elfInterpreterPath(elf);
+	return interpreter ? familyFromInterpreterPath(interpreter) : undefined;
+}
+
+/** Cheap probe: the contents of the `ldd` script/binary. */
+function familyFromLdd(): LibcFamily | undefined {
+	const content = readFileHead('/usr/bin/ldd', MAX_HEAD_LENGTH)?.toString();
+	if (!content) {
+		return undefined;
+	}
+	if (content.includes('musl')) {
+		return 'musl';
+	}
+	if (content.includes('GNU C Library')) {
+		return 'glibc';
+	}
+	return undefined;
+}
+
+/**
+ * Expensive fallback: Node's process report exposes `glibcVersionRuntime` in
+ * its header on glibc builds and a musl loader among its shared objects on musl
+ * builds. `excludeNetwork` is set so the report skips libuv/socket enumeration,
+ * which is the part that can peg the CPU on busy hosts.
+ */
+function familyFromReport(): LibcFamily | undefined {
+	// `excludeNetwork` is present at runtime (added in Node 22.13 / 23.3, and
+	// verified present on the Node we ship) but is missing from the bundled
+	// `@types/node`, so reach it through a narrow cast.
+	const report = process.report as (NodeJS.ProcessReport & { excludeNetwork?: boolean }) | undefined;
+	if (!report) {
+		return undefined;
+	}
+	const previousExcludeNetwork = report.excludeNetwork;
+	report.excludeNetwork = true;
+	try {
+		const data = report.getReport() as {
+			header?: { glibcVersionRuntime?: string };
+			sharedObjects?: string[];
+		};
+		if (data.header?.glibcVersionRuntime) {
+			return 'glibc';
+		}
+		if (data.sharedObjects?.some(o => o.includes('libc.musl-') || o.includes('ld-musl-'))) {
+			return 'musl';
+		}
+	} finally {
+		report.excludeNetwork = previousExcludeNetwork;
+	}
+	return undefined;
+}
+
+/**
+ * Returns the libc family of the running Node process on Linux, or `undefined`
+ * on non-Linux platforms (where the question is meaningless).
  *
- * Mechanism: Node's process report exposes `glibcVersionRuntime` in the
- * header on glibc-linked builds and omits it on musl-linked builds. The
- * field's presence is itself the signal — no `ldd` subprocess, no
- * `/etc/os-release` parsing, no filesystem probe.
+ * Detection tries cheap signals first — the dynamic linker named in this
+ * process's ELF header (`/proc/self/exe`), then the `ldd` contents — and only
+ * falls back to Node's (network-excluded) process report, which is expensive
+ * because it serializes heap, native stack and libuv state. When nothing is
+ * conclusive we assume `glibc`, the dominant Linux libc.
  *
- * Cached after first call. `process.report.getReport()` is expensive
- * (serializes heap + native stack + libuv state) so the cache pays for
- * itself; libc never changes mid-process.
+ * Cached after first call; libc never changes mid-process.
  */
 export function detectLibc(): LibcFamily | undefined {
 	if (_cacheValid) {
 		return _cached;
 	}
 	if (Platform.isLinux) {
-		const report = process.report?.getReport() as { header?: { glibcVersionRuntime?: string } } | undefined;
-		_cached = report?.header?.glibcVersionRuntime ? 'glibc' : 'musl';
+		_cached = familyFromSelfInterpreter() ?? familyFromLdd() ?? familyFromReport() ?? 'glibc';
 	} else {
 		_cached = undefined;
 	}

--- a/src/vs/base/test/node/libc.test.ts
+++ b/src/vs/base/test/node/libc.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import * as Platform from '../../common/platform.js';
-import { detectLibc } from '../../node/libc.js';
+import { detectLibcSync } from '../../node/libc.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../common/utils.js';
 
 suite('libc', () => {
@@ -13,20 +13,20 @@ suite('libc', () => {
 
 	test('non-Linux platforms return undefined', () => {
 		if (!Platform.isLinux) {
-			assert.strictEqual(detectLibc(), undefined);
+			assert.strictEqual(detectLibcSync(), undefined);
 		}
 	});
 
 	test('Linux returns one of the two known values', () => {
 		if (Platform.isLinux) {
-			const family = detectLibc();
+			const family = detectLibcSync();
 			assert.ok(family === 'glibc' || family === 'musl', `unexpected libc family: ${family}`);
 		}
 	});
 
 	test('caches the result across calls', () => {
-		const first = detectLibc();
-		const second = detectLibc();
+		const first = detectLibcSync();
+		const second = detectLibcSync();
 		assert.strictEqual(first, second);
 	});
 });

--- a/src/vs/platform/agentHost/node/agentSdkDownloader.ts
+++ b/src/vs/platform/agentHost/node/agentSdkDownloader.ts
@@ -11,7 +11,7 @@ import { CancellationError } from '../../../base/common/errors.js';
 import * as path from '../../../base/common/path.js';
 import { format2 } from '../../../base/common/strings.js';
 import { URI } from '../../../base/common/uri.js';
-import { detectLibc, type LibcFamily } from '../../../base/node/libc.js';
+import { detectLibcSync, type LibcFamily } from '../../../base/node/libc.js';
 import { INativeEnvironmentService } from '../../environment/common/environment.js';
 import { FileOperationError, FileOperationResult, IFileService, toFileOperationResult } from '../../files/common/files.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
@@ -94,7 +94,7 @@ const SUPPORTED_ARCHES = new Set<string>(['x64', 'arm64']);
  */
 export function resolveSdkTarget(
 	pkg: Pick<IAgentSdkPackage, 'hasSeparateMuslLinuxPackage'>,
-	host: ISdkTargetHost = { platform: process.platform, arch: process.arch, libc: detectLibc() },
+	host: ISdkTargetHost = { platform: process.platform, arch: process.arch, libc: detectLibcSync() },
 ): string | undefined {
 	if (!SUPPORTED_PLATFORMS.has(host.platform) || !SUPPORTED_ARCHES.has(host.arch)) {
 		return undefined;


### PR DESCRIPTION
## Problem

`detectLibc()` (`src/vs/base/node/libc.ts`) called Node's `process.report.getReport()` on every Linux process to distinguish glibc from musl. That report serializes the heap, native stack, and libuv state — and the network/socket-handle enumeration in particular can **peg the CPU on busy hosts**.

## Change

Depend on the [`detect-libc`](https://www.npmjs.com/package/detect-libc) package instead of probing by hand. `detectLibcSync()` now delegates to its `familySync()`:

- `detect-libc` does cheapest-first detection — parses the ELF `PT_INTERP` dynamic linker from `/proc/self/exe`, then falls back to `/usr/bin/ldd`, and only as a last resort to Node's process report.
- Crucially, it sets `process.report.excludeNetwork = true` around that report call, so the expensive libuv/socket enumeration (the CPU-pegging part) is skipped. We get the fix without maintaining an ELF parser.
- Detection is mapped so that `musl` → `'musl'` and everything else (glibc **or** an inconclusive result) → `'glibc'`, keeping glibc as the conservative default for the unknown case.

The function is named `detectLibcSync()` to signal its blocking nature and leave room for a future promise-based `detectLibc()` wrapping detect-libc's async `family()`.

`detect-libc` was already present transitively (via `@parcel/watcher`, `kerberos`, `@github/copilot`); it's now declared as a direct dependency in both `package.json` and `remote/package.json`, since `detectLibcSync` is reachable from the server/REH build (`agentHostServerMain` → `agentSdkDownloader`). Added to the `hasNode` import allowlist in `eslint.config.js`.

## Notes

- The inconclusive-case default is `glibc`. This is safe for the sole consumer (`resolveSdkTarget()` in `agentSdkDownloader.ts`), which only special-cases `'musl'`. (Chosen over detect-libc's `isNonGlibcLinuxSync()`, which would treat an inconclusive result as non-glibc/musl.)
- Public API shape (`LibcFamily`, `undefined` off-Linux, first-call caching) is unchanged.

## Validation

- `npm run typecheck-client`, `npm run valid-layers-check`, and `eslint` on the changed file all pass.
- Reviewed by a multi-model council — no blocking issues.
