### PR TITLE
extensions: show configured auto-update delay in delayed label

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -2861,9 +2861,10 @@ export class ExtensionStatusAction extends ExtensionAction {
 				this.updateStatus({ icon: warningIcon, message: markdown }, true);
 			}
 			if (this.extensionsWorkbenchService.isAutoUpdateDelayed(this.extension)) {
+				const delay = fromNow(Date.now() + this.extensionsWorkbenchService.getAutoUpdateDelay(), false, true);
 				const updateAt = fromNow(Date.now() + this.extensionsWorkbenchService.getAutoUpdateDelayRemaining(this.extension), false, true);
 				// Do not override the higher-priority warning class with the info class.
-				this.updateStatus({ icon: infoIcon, message: new MarkdownString(localize('autoUpdateDelayed', "This extension is not updated yet because new versions are auto updated 2 hours after they are published. It will be auto updated {0}.", updateAt)) }, !hasConsentWarning);
+				this.updateStatus({ icon: infoIcon, message: new MarkdownString(localize('autoUpdateDelayed', "This extension is not updated yet because new versions are auto updated {0} after they are published. It will be auto updated {1}.", delay, updateAt)) }, !hasConsentWarning);
 			}
 		}
 

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -2861,7 +2861,7 @@ export class ExtensionStatusAction extends ExtensionAction {
 				this.updateStatus({ icon: warningIcon, message: markdown }, true);
 			}
 			if (this.extensionsWorkbenchService.isAutoUpdateDelayed(this.extension)) {
-				const delay = fromNow(Date.now() + this.extensionsWorkbenchService.getAutoUpdateDelay(), false, true);
+				const delay = fromNow(Date.now() - this.extensionsWorkbenchService.getAutoUpdateDelay(), false, true);
 				const updateAt = fromNow(Date.now() + this.extensionsWorkbenchService.getAutoUpdateDelayRemaining(this.extension), false, true);
 				// Do not override the higher-priority warning class with the info class.
 				this.updateStatus({ icon: infoIcon, message: new MarkdownString(localize('autoUpdateDelayed', "This extension is not updated yet because new versions are auto updated {0} after they are published. It will be auto updated {1}.", delay, updateAt)) }, !hasConsentWarning);

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -1260,9 +1260,13 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 			// Future timestamp (clock skew) — treat as not delayed
 			return 0;
 		}
-		const delayHours = this.configurationService.getValue<number>(AutoUpdateDelayConfigurationKey) ?? 2;
-		const delayPeriod = delayHours * 60 * 60 * 1000; // Convert hours to milliseconds
+		const delayPeriod = this.getAutoUpdateDelay();
 		return Math.max(0, delayPeriod - elapsed);
+	}
+
+	getAutoUpdateDelay(): number {
+		const delayHours = this.configurationService.getValue<number>(AutoUpdateDelayConfigurationKey) ?? 2;
+		return delayHours * 60 * 60 * 1000; // Convert hours to milliseconds
 	}
 
 	private isFromTrustedPublisher(extension: IExtension): boolean {

--- a/src/vs/workbench/contrib/extensions/common/extensions.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensions.ts
@@ -163,6 +163,7 @@ export interface IExtensionsWorkbenchService {
 	getAutoUpdateValue(): AutoUpdateConfigurationValue;
 	isAutoUpdateDelayed(extension: IExtension): boolean;
 	getAutoUpdateDelayRemaining(extension: IExtension): number;
+	getAutoUpdateDelay(): number;
 	checkForUpdates(): Promise<void>;
 	getExtensionRuntimeStatus(extension: IExtension): IExtensionRuntimeStatus | undefined;
 	updateAll(): Promise<InstallExtensionResult[]>;


### PR DESCRIPTION
Fixes #321577

## What changed
The extension status label that explains why an update is delayed hardcoded "2 hours" as the auto-update delay. As a result, changing `extensions.autoUpdateDelay` (e.g. to 100000 hours) still showed "2h", which is incorrect.

- Added `getAutoUpdateDelay()` to `IExtensionsWorkbenchService`, returning the configured delay period (ms) from `extensions.autoUpdateDelay`.
- Refactored `getAutoUpdateDelayRemaining()` to reuse it (avoiding duplicate config reading).
- Updated the `autoUpdateDelayed` status label in `extensionsActions.ts` to format the configured delay dynamically via `fromNow` instead of the hardcoded "2 hours".

## Notes for reviewers
The label now reflects whatever value the user configured for `extensions.autoUpdateDelay`, consistent with the existing "It will be auto updated …" portion of the message.