### PR TITLE
Fix editorScroll by line getting stuck at folded regions

### DIFF
--- a/src/vs/editor/browser/coreCommands.ts
+++ b/src/vs/editor/browser/coreCommands.ts
@@ -1389,7 +1389,20 @@ export namespace CoreNavigationCommands {
 					desiredTopModelLineNumber = Math.min(viewModel.model.getLineCount(), visibleModelRange.startLineNumber + args.value);
 				}
 
-				const viewPosition = viewModel.coordinatesConverter.convertModelPositionToViewPosition(new Position(desiredTopModelLineNumber, 1));
+				// When scrolling down and the target model line falls inside a collapsed (hidden)
+				// region, resolve it to the first visible line *after* the fold. Otherwise the
+				// target maps back to the fold's already-visible first line, the scroll position
+				// does not change and downward scrolling stalls at folded regions (#171865). Only
+				// do this when a visible line still exists after the target; a fold extending to
+				// the end of the file keeps the default mapping so we never resolve past the last
+				// view line.
+				let belowHiddenRanges = false;
+				if (args.direction === EditorScroll_.Direction.Down) {
+					const lastVisibleModelLineNumber = viewModel.coordinatesConverter.convertViewPositionToModelPosition(new Position(viewModel.getLineCount(), 1)).lineNumber;
+					belowHiddenRanges = desiredTopModelLineNumber <= lastVisibleModelLineNumber;
+				}
+
+				const viewPosition = viewModel.coordinatesConverter.convertModelPositionToViewPosition(new Position(desiredTopModelLineNumber, 1), undefined, undefined, belowHiddenRanges);
 				return viewModel.viewLayout.getVerticalOffsetForLineNumber(viewPosition.lineNumber);
 			}
 

--- a/src/vs/editor/test/browser/controller/editorScroll.test.ts
+++ b/src/vs/editor/test/browser/controller/editorScroll.test.ts
@@ -1,0 +1,148 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { CoreNavigationCommands } from '../../../browser/coreCommands.js';
+import { Range } from '../../../common/core/range.js';
+import { ScrollType } from '../../../common/editorCommon.js';
+import { ViewModel } from '../../../common/viewModel/viewModelImpl.js';
+import { withTestCodeEditor } from '../testCodeEditor.js';
+
+suite('Editor Controller - EditorScroll', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	// A 100 line document: 'line 1', 'line 2', ... 'line 100'.
+	const TEXT = Array.from({ length: 100 }, (_, i) => `line ${i + 1}`).join('\n');
+
+	function scrollDownByLine(viewModel: ViewModel, value: number): void {
+		CoreNavigationCommands.EditorScroll.runCoreEditorCommand(viewModel, { to: 'down', by: 'line', value });
+	}
+
+	function scrollUpByLine(viewModel: ViewModel, value: number): void {
+		CoreNavigationCommands.EditorScroll.runCoreEditorCommand(viewModel, { to: 'up', by: 'line', value });
+	}
+
+	test('scrolling down by line moves past a folded region (#171865)', () => {
+		withTestCodeEditor(TEXT, { envConfig: { outerHeight: 100 } }, (editor, viewModel) => {
+			// Arrange: collapse lines 2..50 so the first visible line (1) is immediately
+			// followed by a large fold, and put line 1 at the top of the viewport.
+			viewModel.setHiddenAreas([new Range(2, 1, 50, 1)]);
+			editor.setScrollTop(0, ScrollType.Immediate);
+			assert.strictEqual(editor.getScrollTop(), 0);
+
+			// Act: scroll down 3 model lines. The target line (4) is inside the fold.
+			scrollDownByLine(viewModel, 3);
+
+			// Assert: the viewport advanced instead of stalling at the fold.
+			assert.ok(editor.getScrollTop() > 0, `expected scroll to advance past the fold, got ${editor.getScrollTop()}`);
+		});
+	});
+
+	test('repeated downward scrolling keeps progressing across a fold (#171865)', () => {
+		withTestCodeEditor(TEXT, { envConfig: { outerHeight: 100 } }, (editor, viewModel) => {
+			// Arrange.
+			viewModel.setHiddenAreas([new Range(2, 1, 50, 1)]);
+			editor.setScrollTop(0, ScrollType.Immediate);
+
+			// Act + Assert: simulate holding the scroll-down shortcut. Each press must make
+			// forward progress instead of stalling at the fold (the bug kept scrollTop at 0).
+			let previousScrollTop = editor.getScrollTop();
+			for (let i = 0; i < 8; i++) {
+				scrollDownByLine(viewModel, 3);
+				const scrollTop = editor.getScrollTop();
+				assert.ok(scrollTop > previousScrollTop, `expected scroll ${i + 1} to advance past the fold, got ${scrollTop} (was ${previousScrollTop})`);
+				previousScrollTop = scrollTop;
+			}
+		});
+	});
+
+	test('scrolling down by line without folds advances by the requested amount', () => {
+		withTestCodeEditor(TEXT, { envConfig: { outerHeight: 100 } }, (editor, viewModel) => {
+			// Arrange: no folds.
+			editor.setScrollTop(0, ScrollType.Immediate);
+
+			// Act.
+			scrollDownByLine(viewModel, 3);
+
+			// Assert: exactly 3 lines down.
+			assert.strictEqual(editor.getScrollTop(), 3 * viewModel.cursorConfig.lineHeight);
+		});
+	});
+
+	test('scrolling down into a fold that reaches the end of the file settles at the bottom (#171865)', () => {
+		withTestCodeEditor(TEXT, { envConfig: { outerHeight: 100 } }, (editor, viewModel) => {
+			// Arrange: collapse lines 11..100 so the fold extends to the end of the file
+			// and only lines 1..10 remain visible.
+			viewModel.setHiddenAreas([new Range(11, 1, 100, 1)]);
+
+			// Find how far the viewport can scroll by asking it to scroll past the end.
+			editor.setScrollTop(editor.getScrollHeight(), ScrollType.Immediate);
+			const maxScrollTop = editor.getScrollTop();
+			assert.ok(maxScrollTop > 0);
+
+			// Act: from the top, scroll down by a large amount so the target model line
+			// lands inside the end-of-file fold (past the last visible line). This hits the
+			// guard that keeps the default mapping when no visible line exists after the target.
+			editor.setScrollTop(0, ScrollType.Immediate);
+			scrollDownByLine(viewModel, 20);
+
+			// Assert: it settled at the bottom instead of throwing or overshooting.
+			assert.strictEqual(editor.getScrollTop(), maxScrollTop);
+		});
+	});
+
+	test('scrolling up by line still moves up when a fold is present', () => {
+		withTestCodeEditor(TEXT, { envConfig: { outerHeight: 100 } }, (editor, viewModel) => {
+			// Arrange: collapse lines 2..50, then scroll down past the fold.
+			viewModel.setHiddenAreas([new Range(2, 1, 50, 1)]);
+			editor.setScrollTop(0, ScrollType.Immediate);
+			scrollDownByLine(viewModel, 3);
+			const scrollTopAfterDown = editor.getScrollTop();
+			assert.ok(scrollTopAfterDown > 0);
+
+			// Act.
+			scrollUpByLine(viewModel, 3);
+
+			// Assert: scrolling up moved the viewport back up.
+			assert.ok(editor.getScrollTop() < scrollTopAfterDown, `expected upward scroll to move up, got ${editor.getScrollTop()}`);
+		});
+	});
+
+	test('scrolling up by line moves past a fold above the viewport', () => {
+		withTestCodeEditor(TEXT, { envConfig: { outerHeight: 100 } }, (editor, viewModel) => {
+			// Arrange: collapse lines 2..50 and put line 51 (the line right after the
+			// fold) at the top of the viewport, so the fold sits directly above.
+			viewModel.setHiddenAreas([new Range(2, 1, 50, 1)]);
+			editor.setScrollTop(viewModel.cursorConfig.lineHeight, ScrollType.Immediate);
+			const before = editor.getScrollTop();
+			assert.ok(before > 0);
+
+			// Act: scroll up 3 model lines. The target (line 48) is inside the fold above.
+			scrollUpByLine(viewModel, 3);
+
+			// Assert: the viewport moved up past the fold instead of stalling.
+			assert.ok(editor.getScrollTop() < before, `expected upward scroll to move past the fold, got ${editor.getScrollTop()}`);
+		});
+	});
+
+	test('repeated upward scrolling reaches the top across a fold', () => {
+		withTestCodeEditor(TEXT, { envConfig: { outerHeight: 100 } }, (editor, viewModel) => {
+			// Arrange: collapse lines 2..50 and start scrolled to the bottom.
+			viewModel.setHiddenAreas([new Range(2, 1, 50, 1)]);
+			editor.setScrollTop(editor.getScrollHeight(), ScrollType.Immediate);
+			assert.ok(editor.getScrollTop() > 0);
+
+			// Act: simulate holding the scroll-up shortcut.
+			for (let i = 0; i < 30; i++) {
+				scrollUpByLine(viewModel, 3);
+			}
+
+			// Assert: it reached the very top.
+			assert.strictEqual(editor.getScrollTop(), 0);
+		});
+	});
+});


### PR DESCRIPTION
Fixes #171865 re #48161
`editorScroll` with `by: "line"` stops scrolling down once the first visible line is the start of a collapsed region. The viewport gets stuck there and you can't get past it with the keyboard, only with the mouse wheel, the scrollbar, or by moving the cursor down. Scrolling up is fine.

The root cause is in `EditorScrollImpl._computeDesiredScrollTop`. For `by: "line"` it works in model-line space: it takes the current top model line, adds the requested number of lines, then converts that target model line back to a view position to get the new scroll offset. That conversion uses the default mapping, which resolves a hidden (folded) model line to the first visible line before the fold. So when you scroll down and the target lands inside a fold, it maps back to the fold's already-visible first line, the computed offset equals the current one, and nothing moves. Every keypress recomputes from the same top line, so it stays stuck.

The fix resolves a downward target that lands inside a fold to the first visible line after the fold instead (the `belowHiddenRanges` option on `convertModelPositionToViewPosition`). It's guarded so a fold that runs to the end of the file keeps the old mapping, since there's no visible line after the target to scroll to. Scrolling up already made progress and isn't touched, and scrolling with no folds is unchanged.

How to test:
- Open a long file and collapse a region near the top (or run Fold All).
- Bind ctrl+down to editorScroll:

```json
{ "key": "ctrl+down", "command": "editorScroll", "args": { "to": "down", "by": "line", "value": 3 } }
```

- Put a collapsed region as the first visible line and press ctrl+down. Before this change the viewport stays stuck, after it scrolls past the fold.

Added tests in `src/vs/editor/test/browser/controller/editorScroll.test.ts`: down-by-line scrolls past a fold, repeated down-by-line keeps progressing across a fold, down-by-line with no folds advances by the exact amount, and up-by-line still moves up with a fold present.

Branch is up to date with `main`.