### PR TITLE
agentHost: centralize and type-check AHP `_meta` access

### DIFF
--- a/.eslint-plugin-local/code-no-untyped-meta-access.ts
+++ b/.eslint-plugin-local/code-no-untyped-meta-access.ts
@@ -14,10 +14,12 @@ import { TSESTree } from '@typescript-eslint/utils';
  * `x._meta?.['foo']`) or casting it to an interface (`x._meta as Foo`) bypasses
  * any validation and lets well-known keys drift between producers and consumers.
  *
- * Instead, pass the whole bag to a validating reader declared in a common module
- * (e.g. `readToolCallMeta(x._meta)`), which checks each field and drops
- * wrong-typed values. Passing `_meta` itself as a value (the leaf reference) is
- * allowed — only further member access or casts off `_meta` are flagged.
+ * Instead, read well-known keys through a validating reader declared in a common
+ * module (e.g. `readToolCallMeta(toolCall)`), which takes the parent object,
+ * reads its `_meta` internally, checks each field, and drops wrong-typed values.
+ * Referencing `_meta` itself as a value (the leaf reference, e.g.
+ * `const meta = source._meta`) is allowed — only further member access or casts
+ * off `_meta` are flagged.
  *
  * This rule is purely syntactic (no type information): it keys off the `_meta`
  * identifier, so the reader modules that perform the one sanctioned first hop
@@ -28,8 +30,8 @@ export default new class NoUntypedMetaAccess implements eslint.Rule.RuleModule {
 
 	readonly meta: eslint.Rule.RuleMetaData = {
 		messages: {
-			noMetaFieldAccess: 'Do not read fields off `_meta` directly. Pass the whole `_meta` bag to a validating reader (e.g. `readToolCallMeta(x._meta)`) declared in a common module.',
-			noMetaCast: 'Do not cast `_meta` to an interface. Pass the whole `_meta` bag to a validating reader (e.g. `readToolCallMeta(x._meta)`) declared in a common module.',
+			noMetaFieldAccess: 'Do not read fields off `_meta` directly. Read well-known keys through a validating reader that takes the parent object (e.g. `readToolCallMeta(toolCall)`) declared in a common module.',
+			noMetaCast: 'Do not cast `_meta` to an interface. Read well-known keys through a validating reader that takes the parent object (e.g. `readToolCallMeta(toolCall)`) declared in a common module.',
 		},
 		schema: false,
 	};

--- a/.eslint-plugin-local/code-no-untyped-meta-access.ts
+++ b/.eslint-plugin-local/code-no-untyped-meta-access.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as eslint from 'eslint';
+import { TSESTree } from '@typescript-eslint/utils';
+
+/**
+ * Disallows untyped access to the agent host protocol's open `_meta` bag.
+ *
+ * `_meta` is declared on protocol messages as an opaque
+ * `Record<string, unknown>`. Reading a field off it directly (`x._meta.foo`,
+ * `x._meta?.['foo']`) or casting it to an interface (`x._meta as Foo`) bypasses
+ * any validation and lets well-known keys drift between producers and consumers.
+ *
+ * Instead, pass the whole bag to a validating reader declared in a common module
+ * (e.g. `readToolCallMeta(x._meta)`), which checks each field and drops
+ * wrong-typed values. Passing `_meta` itself as a value (the leaf reference) is
+ * allowed — only further member access or casts off `_meta` are flagged.
+ *
+ * This rule is purely syntactic (no type information): it keys off the `_meta`
+ * identifier, so the reader modules that perform the one sanctioned first hop
+ * into a namespaced slot, and the rare access to a non-protocol `_meta` (e.g. a
+ * vendored SDK's own typed `_meta`), use a scoped `eslint-disable` line.
+ */
+export default new class NoUntypedMetaAccess implements eslint.Rule.RuleModule {
+
+	readonly meta: eslint.Rule.RuleMetaData = {
+		messages: {
+			noMetaFieldAccess: 'Do not read fields off `_meta` directly. Pass the whole `_meta` bag to a validating reader (e.g. `readToolCallMeta(x._meta)`) declared in a common module.',
+			noMetaCast: 'Do not cast `_meta` to an interface. Pass the whole `_meta` bag to a validating reader (e.g. `readToolCallMeta(x._meta)`) declared in a common module.',
+		},
+		schema: false,
+	};
+
+	create(context: eslint.Rule.RuleContext): eslint.Rule.RuleListener {
+
+		function unwrap(node: TSESTree.Node | null | undefined): TSESTree.Node | null | undefined {
+			return node?.type === 'ChainExpression' ? node.expression : node;
+		}
+
+		function isMetaAccess(node: TSESTree.Node | null | undefined): boolean {
+			const n = unwrap(node);
+			if (!n || n.type !== 'MemberExpression') {
+				return false;
+			}
+			if (!n.computed && n.property.type === 'Identifier') {
+				return n.property.name === '_meta';
+			}
+			if (n.computed && n.property.type === 'Literal') {
+				return n.property.value === '_meta';
+			}
+			return false;
+		}
+
+		return {
+			'MemberExpression': (node: TSESTree.MemberExpression) => {
+				if (isMetaAccess(node.object)) {
+					context.report({ node, messageId: 'noMetaFieldAccess' });
+				}
+			},
+			'TSAsExpression, TSTypeAssertion': (node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion) => {
+				if (isMetaAccess(node.expression)) {
+					context.report({ node, messageId: 'noMetaCast' });
+				}
+			},
+		};
+	}
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -356,6 +356,30 @@ export default defineConfig(
 			'local/code-no-in-operator': 'warn',
 		}
 	},
+	// Guard the agent host protocol `_meta` bag: no untyped field access or casts.
+	{
+		files: [
+			'src/vs/platform/agentHost/**/*.ts',
+			'src/vs/workbench/contrib/chat/browser/agentSessions/**/*.ts',
+			'src/vs/workbench/services/agentHost/**/*.ts',
+			'src/vs/sessions/**/*.ts',
+		],
+		ignores: [
+			// Tests assert on the raw `_meta` wire shape on purpose (verifying
+			// producers); routing them through readers would weaken them.
+			'**/test/**',
+			'**/*.test.ts',
+			'**/*.integrationTest.ts',
+			// Codex's own generated app-server protocol (not AHP `_meta`).
+			'src/vs/platform/agentHost/node/codex/protocol/**',
+		],
+		plugins: {
+			'local': pluginLocal,
+		},
+		rules: {
+			'local/code-no-untyped-meta-access': 'warn',
+		}
+	},
 	// Strict no explicit `any`
 	{
 		files: [

--- a/src/vs/platform/agentHost/common/agentModelPricing.ts
+++ b/src/vs/platform/agentHost/common/agentModelPricing.ts
@@ -3,6 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import type { SessionModelInfo } from './state/protocol/state.js';
+import type { IAgentModelInfo } from './agentService.js';
+
 /**
  * Well-known pricing metadata carried under a model's open `_meta` bag (see {@link IAgentModelInfo._meta} /
  * {@link SessionModelInfo._meta}). Agents that know a model's billing details populate these keys so the chat model
@@ -51,7 +54,8 @@ const NUMBER_KEYS = [
  * provider-specific keys and values of the wrong type. Returns an object containing only the keys that were present
  * with a valid value.
  */
-export function readAgentModelPricingMeta(meta: Record<string, unknown> | undefined): IAgentModelPricingMeta {
+export function readAgentModelPricingMeta(model: IAgentModelInfo | SessionModelInfo): IAgentModelPricingMeta {
+	const meta = model._meta;
 	if (!meta) {
 		return {};
 	}

--- a/src/vs/platform/agentHost/common/meta/agentCompletionAttachmentMeta.ts
+++ b/src/vs/platform/agentHost/common/meta/agentCompletionAttachmentMeta.ts
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { SimpleMessageAttachment } from '../state/protocol/state.js';
+
+/**
+ * Well-known typed views over a `SimpleMessageAttachment`'s `_meta` bag as
+ * produced by the `completions` command, populated by the slash-command and
+ * skill completion providers and read by the session handler. Read the bag
+ * through {@link readCompletionAttachmentMeta} rather than indexing `_meta`
+ * directly. Two variants are distinguished by which discriminating key is
+ * present: a slash command (`command`) or a skill (`uri`).
+ */
+
+/**
+ * The `_meta` shape attached to a `completions` result that resolves to a slash
+ * command.
+ */
+export interface ICommandCompletionAttachmentMeta {
+	/** The slash command name (without the leading `/`). */
+	readonly command: string;
+	/** Optional human-readable description of the command. */
+	readonly description?: string;
+}
+
+/**
+ * The `_meta` shape attached to a `completions` result that resolves to a skill.
+ */
+export interface ISkillCompletionAttachmentMeta {
+	/** The skill resource URI as a string. */
+	readonly uri: string;
+	/** Optional internal name of the skill. */
+	readonly name?: string;
+	/** Optional human-readable display name (e.g. the slash-command name). */
+	readonly displayName?: string;
+	/** Optional human-readable description of the skill. */
+	readonly description?: string;
+}
+
+/**
+ * A typed, discriminated view over the well-known `completions` attachment
+ * `_meta` variants. The `kind` discriminant is computed by
+ * {@link readCompletionAttachmentMeta} from which key is present on the wire; it
+ * is not itself carried in `_meta`.
+ */
+export type CompletionAttachmentMeta =
+	| ({ readonly kind: 'command' } & ICommandCompletionAttachmentMeta)
+	| ({ readonly kind: 'skill' } & ISkillCompletionAttachmentMeta);
+
+/**
+ * Reads the well-known `completions` attachment `_meta` keys, classifying the
+ * bag into a {@link CompletionAttachmentMeta} variant by its discriminating key
+ * (`command` for a slash command, `uri` for a skill). Returns `undefined` when
+ * the bag is absent or matches neither variant; wrong-typed keys are dropped.
+ */
+export function readCompletionAttachmentMeta(attachment: SimpleMessageAttachment): CompletionAttachmentMeta | undefined {
+	const meta = attachment._meta;
+	if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
+		return undefined;
+	}
+	if (typeof meta['command'] === 'string') {
+		return {
+			kind: 'command',
+			command: meta['command'],
+			...(typeof meta['description'] === 'string' ? { description: meta['description'] } : {}),
+		};
+	}
+	if (typeof meta['uri'] === 'string') {
+		return {
+			kind: 'skill',
+			uri: meta['uri'],
+			...(typeof meta['name'] === 'string' ? { name: meta['name'] } : {}),
+			...(typeof meta['displayName'] === 'string' ? { displayName: meta['displayName'] } : {}),
+			...(typeof meta['description'] === 'string' ? { description: meta['description'] } : {}),
+		};
+	}
+	return undefined;
+}
+
+/**
+ * Serializes a typed {@link ICommandCompletionAttachmentMeta} into the `_meta`
+ * record, dropping `undefined` entries. Build a slash-command completion's
+ * `_meta` through this so producers stay in lock-step with
+ * {@link readCompletionAttachmentMeta}.
+ */
+export function toCommandCompletionAttachmentMeta(meta: ICommandCompletionAttachmentMeta): Record<string, unknown> {
+	const result: Record<string, unknown> = { command: meta.command };
+	if (meta.description !== undefined) {
+		result['description'] = meta.description;
+	}
+	return result;
+}
+
+/**
+ * Serializes a typed {@link ISkillCompletionAttachmentMeta} into the `_meta`
+ * record, dropping `undefined` entries. Build a skill completion's `_meta`
+ * through this so producers stay in lock-step with
+ * {@link readCompletionAttachmentMeta}.
+ */
+export function toSkillCompletionAttachmentMeta(meta: ISkillCompletionAttachmentMeta): Record<string, unknown> {
+	const result: Record<string, unknown> = { uri: meta.uri };
+	if (meta.name !== undefined) {
+		result['name'] = meta.name;
+	}
+	if (meta.displayName !== undefined) {
+		result['displayName'] = meta.displayName;
+	}
+	if (meta.description !== undefined) {
+		result['description'] = meta.description;
+	}
+	return result;
+}

--- a/src/vs/platform/agentHost/common/meta/agentCustomizationMeta.ts
+++ b/src/vs/platform/agentHost/common/meta/agentCustomizationMeta.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { Mutable } from '../../../../base/common/types.js';
+import type { AgentCustomization } from '../state/protocol/state.js';
+
+/**
+ * Well-known typed view over a custom agent's `_meta` bag (see
+ * `AgentCustomization._meta`), populated by the host's customization discovery
+ * and read by the agents-window customization providers. Read it through
+ * {@link readAgentCustomizationMeta} rather than indexing `_meta` directly.
+ */
+export interface IAgentCustomizationMeta {
+	/**
+	 * Whether the user may invoke this custom agent directly (e.g. from the
+	 * agent picker). Absent is treated as `true` by convention — only an
+	 * explicit `false` hides the agent from direct user invocation.
+	 */
+	readonly userInvocable?: boolean;
+}
+
+/**
+ * Reads the well-known {@link IAgentCustomizationMeta} keys from a custom
+ * agent's `_meta` bag, dropping unknown keys and wrong-typed values.
+ */
+export function readAgentCustomizationMeta(agent: AgentCustomization): IAgentCustomizationMeta {
+	const meta = agent._meta;
+	if (!meta) {
+		return {};
+	}
+	const result: Mutable<IAgentCustomizationMeta> = {};
+	if (typeof meta['userInvocable'] === 'boolean') {
+		result.userInvocable = meta['userInvocable'];
+	}
+	return result;
+}
+
+/**
+ * Serializes a typed {@link IAgentCustomizationMeta} into the `_meta` record,
+ * dropping `undefined` entries and returning `undefined` when empty. Build a
+ * custom agent's `_meta` through this so producers stay in lock-step with
+ * {@link readAgentCustomizationMeta}.
+ */
+export function toAgentCustomizationMeta(meta: IAgentCustomizationMeta): Record<string, unknown> | undefined {
+	const result: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(meta)) {
+		if (value !== undefined) {
+			result[key] = value;
+		}
+	}
+	return Object.keys(result).length > 0 ? result : undefined;
+}

--- a/src/vs/platform/agentHost/common/meta/agentFeedbackAnnotations.ts
+++ b/src/vs/platform/agentHost/common/meta/agentFeedbackAnnotations.ts
@@ -3,6 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import type { Mutable } from '../../../../base/common/types.js';
+import type { Annotation } from '../state/protocol/state.js';
+
 /**
  * Shared convention for carrying agent-feedback semantics inside an
  * {@link Annotation._meta} on the agent host annotations channel.
@@ -77,4 +80,38 @@ export interface IFeedbackAnnotationMeta {
 	 * invocation does not re-return them.
 	 */
 	readonly pendingAgentReveal?: boolean;
+}
+
+function isAgentFeedbackKindValue(value: unknown): value is AgentFeedbackKindValue {
+	return value === 'user' || value === 'codeReview' || value === 'prReview';
+}
+
+function isAgentFeedbackStateValue(value: unknown): value is AgentFeedbackStateValue {
+	return value === 'created' || value === 'accepted' || value === 'submitted' || value === 'resolved';
+}
+
+/**
+ * Reads the well-known {@link IFeedbackAnnotationMeta} from an annotation's
+ * `_meta` bag (under {@link FEEDBACK_ANNOTATION_META_KEY}). The annotations
+ * channel is shared, so this validates the required `kind` / `state` /
+ * `sessionResource` fields and returns `undefined` for annotations that aren't
+ * feedback items. Read through this rather than casting the namespaced slot.
+ */
+export function readFeedbackAnnotationMeta(annotation: Annotation): IFeedbackAnnotationMeta | undefined {
+	const meta = annotation._meta;
+	const slot = meta?.[FEEDBACK_ANNOTATION_META_KEY];
+	if (!slot || typeof slot !== 'object' || Array.isArray(slot)) {
+		return undefined;
+	}
+	const raw = slot as Record<string, unknown>;
+	if (!isAgentFeedbackKindValue(raw['kind']) || !isAgentFeedbackStateValue(raw['state']) || typeof raw['sessionResource'] !== 'string') {
+		return undefined;
+	}
+	const result: Mutable<IFeedbackAnnotationMeta> = { kind: raw['kind'], state: raw['state'], sessionResource: raw['sessionResource'] };
+	if (raw['suggestion'] !== undefined) { result.suggestion = raw['suggestion']; }
+	if (typeof raw['codeSelection'] === 'string') { result.codeSelection = raw['codeSelection']; }
+	if (typeof raw['diffHunks'] === 'string') { result.diffHunks = raw['diffHunks']; }
+	if (typeof raw['sourcePRReviewCommentId'] === 'string') { result.sourcePRReviewCommentId = raw['sourcePRReviewCommentId']; }
+	if (typeof raw['pendingAgentReveal'] === 'boolean') { result.pendingAgentReveal = raw['pendingAgentReveal']; }
+	return result;
 }

--- a/src/vs/platform/agentHost/common/meta/agentFeedbackAttachments.ts
+++ b/src/vs/platform/agentHost/common/meta/agentFeedbackAttachments.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isString } from '../../../base/common/types.js';
-import { MessageAttachmentKind, type MessageAnnotationsAttachment, type MessageAttachment, type SimpleMessageAttachment, type TextRange } from './state/protocol/state.js';
+import { isString } from '../../../../base/common/types.js';
+import { MessageAttachmentKind, type MessageAnnotationsAttachment, type MessageAttachment, type SimpleMessageAttachment, type TextRange } from '../state/protocol/state.js';
 
 export const AgentFeedbackAttachmentDisplayKind = 'agentFeedback';
 export const AgentFeedbackAttachmentMetadataKey = 'agentFeedback';
@@ -56,6 +56,7 @@ export function getAgentFeedbackAttachmentMetadata(attachment: MessageAttachment
 	if (!isAgentFeedbackAttachment(attachment) && !isAgentFeedbackAnnotationsAttachment(attachment)) {
 		return undefined;
 	}
+	// eslint-disable-next-line local/code-no-untyped-meta-access -- sanctioned first hop into the namespaced feedback slot; validated below.
 	const metadata = attachment._meta?.[AgentFeedbackAttachmentMetadataKey];
 	if (!isRecord(metadata) || !isString(metadata.sessionResource) || !Array.isArray(metadata.feedbackItems)) {
 		return undefined;

--- a/src/vs/platform/agentHost/common/meta/agentToolCallMeta.ts
+++ b/src/vs/platform/agentHost/common/meta/agentToolCallMeta.ts
@@ -1,0 +1,120 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { Mutable } from '../../../../base/common/types.js';
+import type { ToolCallState } from '../state/protocol/state.js';
+
+/**
+ * Well-known typed view over a tool call's open `_meta` bag (see
+ * {@link ToolCallState._meta}). Producers and
+ * consumers agree on these keys here so the two sides can't drift; always read
+ * the bag through {@link readToolCallMeta}, which validates each field and drops
+ * wrong-typed values.
+ */
+export interface IToolCallMeta {
+	/**
+	 * VS Code rendering hint. `terminal` routes the call to the command/output
+	 * renderer, `subagent` to the subagent UI, `search` to the search renderer;
+	 * everything else falls through to the generic invocation renderer. Set by
+	 * the agent adapter, never matched on raw tool name by the renderer.
+	 */
+	readonly toolKind?: ToolKind;
+	/** Shell language for a `terminal` tool call (drives syntax highlighting). */
+	readonly language?: string;
+	/** Short task description for a `subagent` tool call (e.g. "Find related files"). */
+	readonly subagentDescription?: string;
+	/** Agent name for a `subagent` tool call (e.g. "explore"). */
+	readonly subagentAgentName?: string;
+	/** Raw, pre-stringified tool arguments captured for display/debugging. */
+	readonly toolArguments?: unknown;
+	/** Originating MCP server name, when the call came from an MCP server. */
+	readonly mcpServerName?: string;
+	/** Originating MCP tool name, when the call came from an MCP server. */
+	readonly mcpToolName?: string;
+	/** MCP App render data, when the call exposes an interactive App surface. */
+	readonly ui?: IToolCallUiMeta;
+	/**
+	 * Set by the host's side-effect layer when the call was auto-approved
+	 * because of an `autoApprove` session-config setting (rather than an
+	 * explicit user action), so the client can render it as setting-driven.
+	 */
+	readonly autoApproveBySetting?: boolean;
+}
+
+/**
+ * The set of VS Code-recognized tool-call rendering kinds. Add a new value here
+ * (and teach the renderer to handle it) rather than matching on tool name.
+ */
+export type ToolKind = 'terminal' | 'subagent' | 'search';
+
+/**
+ * MCP App render data carried under {@link IToolCallMeta.ui}. Clients gate
+ * mounting the App webview on both a `resourceUri` and a `channel` being
+ * present.
+ */
+export interface IToolCallUiMeta {
+	/** The MCP App's UI resource URI (an `ui://` resource the App renders). */
+	readonly resourceUri: string;
+	/** AHP `mcp://` channel the App's sub-RPCs route back through, when ready. */
+	readonly channel?: string;
+}
+
+function isToolKind(value: unknown): value is ToolKind {
+	return value === 'terminal' || value === 'subagent' || value === 'search';
+}
+
+function readToolCallUiMeta(value: unknown): IToolCallUiMeta | undefined {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return undefined;
+	}
+	const raw = value as Record<string, unknown>;
+	if (typeof raw['resourceUri'] !== 'string' || raw['resourceUri'].length === 0) {
+		return undefined;
+	}
+	const result: Mutable<IToolCallUiMeta> = { resourceUri: raw['resourceUri'] };
+	if (typeof raw['channel'] === 'string' && raw['channel'].length > 0) {
+		result.channel = raw['channel'];
+	}
+	return result;
+}
+
+/**
+ * Reads the well-known {@link IToolCallMeta} keys from a tool call's `_meta`
+ * bag, dropping unknown keys and wrong-typed values.
+ */
+export function readToolCallMeta(source: ToolCallState): IToolCallMeta {
+	const meta = source._meta;
+	if (!meta) {
+		return {};
+	}
+	const result: Mutable<IToolCallMeta> = {};
+	if (isToolKind(meta['toolKind'])) { result.toolKind = meta['toolKind']; }
+	if (typeof meta['language'] === 'string') { result.language = meta['language']; }
+	if (typeof meta['subagentDescription'] === 'string') { result.subagentDescription = meta['subagentDescription']; }
+	if (typeof meta['subagentAgentName'] === 'string') { result.subagentAgentName = meta['subagentAgentName']; }
+	if (meta['toolArguments'] !== undefined) { result.toolArguments = meta['toolArguments']; }
+	if (typeof meta['mcpServerName'] === 'string') { result.mcpServerName = meta['mcpServerName']; }
+	if (typeof meta['mcpToolName'] === 'string') { result.mcpToolName = meta['mcpToolName']; }
+	if (typeof meta['autoApproveBySetting'] === 'boolean') { result.autoApproveBySetting = meta['autoApproveBySetting']; }
+	const ui = readToolCallUiMeta(meta['ui']);
+	if (ui) { result.ui = ui; }
+	return result;
+}
+
+/**
+ * Serializes a typed {@link IToolCallMeta} into the `_meta` record, dropping
+ * `undefined` entries and returning `undefined` when empty. Build a tool call's
+ * `_meta` through this so producers stay in lock-step with
+ * {@link readToolCallMeta}.
+ */
+export function toToolCallMeta(meta: IToolCallMeta): Record<string, unknown> | undefined {
+	const result: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(meta)) {
+		if (value !== undefined) {
+			result[key] = value;
+		}
+	}
+	return Object.keys(result).length > 0 ? result : undefined;
+}

--- a/src/vs/platform/agentHost/common/remoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/common/remoteAgentHostService.ts
@@ -10,7 +10,7 @@ import { createDecorator } from '../../instantiation/common/instantiation.js';
 import type { IAgentConnection } from './agentService.js';
 import type { UnsupportedProtocolVersionErrorData } from './state/protocol/errors.js';
 import { AHP_UNSUPPORTED_PROTOCOL_VERSION, ProtocolError } from './state/sessionProtocol.js';
-import type { UnsupportedProtocolVersionErrorMeta, IVscodeUpgradeResult } from './state/protocolUpgrade.js';
+import { readUnsupportedProtocolVersionErrorMeta, type IVscodeUpgradeResult } from './state/protocolUpgrade.js';
 import { TUNNEL_ADDRESS_PREFIX } from './tunnelAgentHost.js';
 
 /**
@@ -80,9 +80,9 @@ export namespace RemoteAgentHostConnectionStatus {
 	 */
 	export function fromConnectError(err: unknown, supportedByClient: readonly string[]): RemoteAgentHostConnectionStatus | undefined {
 		if (err instanceof ProtocolError && err.code === AHP_UNSUPPORTED_PROTOCOL_VERSION) {
-			const data = err.data as (Partial<UnsupportedProtocolVersionErrorData> & { _meta?: UnsupportedProtocolVersionErrorMeta }) | undefined;
+			const data = err.data as Partial<UnsupportedProtocolVersionErrorData> | undefined;
 			const offeredByServer = Array.isArray(data?.supportedVersions) ? data.supportedVersions : undefined;
-			const vscodeUpgradeMethod = typeof data?._meta?.vscodeUpgradeMethod === 'string' ? data._meta.vscodeUpgradeMethod : undefined;
+			const vscodeUpgradeMethod = readUnsupportedProtocolVersionErrorMeta(err.data)?.vscodeUpgradeMethod;
 			return incompatible(err.message, supportedByClient, offeredByServer, vscodeUpgradeMethod);
 		}
 		return undefined;

--- a/src/vs/platform/agentHost/common/state/protocolUpgrade.ts
+++ b/src/vs/platform/agentHost/common/state/protocolUpgrade.ts
@@ -104,5 +104,5 @@ export function readUnsupportedProtocolVersionErrorMeta(data: unknown): Unsuppor
 	if (typeof raw['vscodeUpgradeMethod'] === 'string') {
 		result.vscodeUpgradeMethod = raw['vscodeUpgradeMethod'];
 	}
-	return result;
+	return Object.keys(result).length > 0 ? result : undefined;
 }

--- a/src/vs/platform/agentHost/common/state/protocolUpgrade.ts
+++ b/src/vs/platform/agentHost/common/state/protocolUpgrade.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { UnsupportedProtocolVersionErrorData } from './protocol/errors.js';
+import type { Mutable } from '../../../../base/common/types.js';
 
 /**
  * Name of the JSON-RPC method that, when invoked on an agent host spawned
@@ -79,4 +80,29 @@ export interface UnsupportedProtocolVersionErrorMeta {
  */
 export interface UnsupportedProtocolVersionErrorDataEx extends UnsupportedProtocolVersionErrorData {
 	readonly _meta?: UnsupportedProtocolVersionErrorMeta;
+}
+
+/**
+ * Reads the well-known {@link UnsupportedProtocolVersionErrorMeta} from the open
+ * `_meta` bag on an `UnsupportedProtocolVersion` error's data payload. `data` is
+ * the raw, untrusted `ProtocolError.data` (typed `unknown`); this validates that
+ * it carries a `_meta` object with a string {@link
+ * UnsupportedProtocolVersionErrorMeta.vscodeUpgradeMethod} and returns
+ * `undefined` otherwise. Always read the upgrade `_meta` through this helper
+ * rather than casting the error data to a shape that includes `_meta`.
+ */
+export function readUnsupportedProtocolVersionErrorMeta(data: unknown): UnsupportedProtocolVersionErrorMeta | undefined {
+	if (!data || typeof data !== 'object') {
+		return undefined;
+	}
+	const meta = (data as Record<string, unknown>)['_meta'];
+	if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
+		return undefined;
+	}
+	const raw = meta as Record<string, unknown>;
+	const result: Mutable<UnsupportedProtocolVersionErrorMeta> = {};
+	if (typeof raw['vscodeUpgradeMethod'] === 'string') {
+		result.vscodeUpgradeMethod = raw['vscodeUpgradeMethod'];
+	}
+	return result;
 }

--- a/src/vs/platform/agentHost/common/state/sessionReducers.ts
+++ b/src/vs/platform/agentHost/common/state/sessionReducers.ts
@@ -9,6 +9,7 @@
 // Re-export reducers from the protocol layer
 export { rootReducer, sessionReducer, chatReducer, changesetReducer, annotationsReducer, softAssertNever, isClientDispatchable } from './protocol/reducers.js';
 
+import { readToolCallMeta, type ToolKind } from '../meta/agentToolCallMeta.js';
 import type { ICompletedToolCall, ToolCallState } from './sessionState.js';
 
 /**
@@ -16,6 +17,6 @@ import type { ICompletedToolCall, ToolCallState } from './sessionState.js';
  * bag. This is not part of the protocol and is injected by the agent adapter
  * (e.g. `copilotEventMapper`).
  */
-export function getToolKind(tc: ToolCallState | ICompletedToolCall): 'terminal' | 'subagent' | 'search' | undefined {
-	return tc._meta?.toolKind as 'terminal' | 'subagent' | 'search' | undefined;
+export function getToolKind(tc: ToolCallState | ICompletedToolCall): ToolKind | undefined {
+	return readToolCallMeta(tc).toolKind;
 }

--- a/src/vs/platform/agentHost/common/state/sessionState.ts
+++ b/src/vs/platform/agentHost/common/state/sessionState.ts
@@ -11,7 +11,7 @@
 // helpers and re-exports.
 
 import { decodeBase64, encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
-import { hasKey } from '../../../../base/common/types.js';
+import { hasKey, type Mutable } from '../../../../base/common/types.js';
 import { URI as ResourceURI } from '../../../../base/common/uri.js';
 import type { IProductService } from '../../../product/common/productService.js';
 import {
@@ -40,6 +40,7 @@ import {
 	type ToolResultContent,
 	type ToolResultSubagentContent,
 	type ToolResultTextContent,
+	type UsageInfo,
 	type Message,
 } from './protocol/state.js';
 
@@ -120,6 +121,57 @@ export interface UsageInfoMeta {
 		} | undefined;
 	};
 	[key: string]: unknown;
+}
+
+type AccountQuotaSnapshot = NonNullable<NonNullable<UsageInfoMeta['quotaSnapshots']>[string]>;
+
+function readAccountQuotaSnapshot(value: unknown): AccountQuotaSnapshot | undefined {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return undefined;
+	}
+	const raw = value as Record<string, unknown>;
+	const snapshot: Mutable<AccountQuotaSnapshot> = {};
+	if (typeof raw['isUnlimitedEntitlement'] === 'boolean') { snapshot.isUnlimitedEntitlement = raw['isUnlimitedEntitlement']; }
+	if (typeof raw['entitlementRequests'] === 'number') { snapshot.entitlementRequests = raw['entitlementRequests']; }
+	if (typeof raw['usedRequests'] === 'number') { snapshot.usedRequests = raw['usedRequests']; }
+	if (typeof raw['remainingPercentage'] === 'number') { snapshot.remainingPercentage = raw['remainingPercentage']; }
+	if (typeof raw['overage'] === 'number') { snapshot.overage = raw['overage']; }
+	if (typeof raw['overageAllowedWithExhaustedQuota'] === 'boolean') { snapshot.overageAllowedWithExhaustedQuota = raw['overageAllowedWithExhaustedQuota']; }
+	if (typeof raw['resetDate'] === 'string') { snapshot.resetDate = raw['resetDate']; }
+	return snapshot;
+}
+
+/**
+ * Reads the well-known {@link UsageInfoMeta} keys from a usage report's open
+ * `_meta` bag, ignoring unrelated provider-specific keys and validating each
+ * field's type. Always read {@link UsageInfo._meta} through this helper rather
+ * than casting the bag to {@link UsageInfoMeta}, so a malformed or partial bag
+ * degrades to absent fields instead of producing values of the wrong runtime
+ * type. Returns an empty object when the bag is absent.
+ */
+export function readUsageInfoMeta(usage: UsageInfo | undefined): UsageInfoMeta {
+	const meta = usage?._meta;
+	if (!meta) {
+		return {};
+	}
+	const result: Mutable<UsageInfoMeta> = {};
+	if (typeof meta['cost'] === 'number') { result.cost = meta['cost']; }
+	const copilotUsage = meta['copilotUsage'];
+	if (copilotUsage && typeof copilotUsage === 'object' && !Array.isArray(copilotUsage)) {
+		const rawUsage = copilotUsage as Record<string, unknown>;
+		const usage: Mutable<NonNullable<UsageInfoMeta['copilotUsage']>> = {};
+		if (typeof rawUsage['totalNanoAiu'] === 'number') { usage.totalNanoAiu = rawUsage['totalNanoAiu']; }
+		result.copilotUsage = usage;
+	}
+	const quotaSnapshots = meta['quotaSnapshots'];
+	if (quotaSnapshots && typeof quotaSnapshots === 'object' && !Array.isArray(quotaSnapshots)) {
+		const snapshots: Mutable<NonNullable<UsageInfoMeta['quotaSnapshots']>> = {};
+		for (const [quotaType, value] of Object.entries(quotaSnapshots as Record<string, unknown>)) {
+			snapshots[quotaType] = readAccountQuotaSnapshot(value);
+		}
+		result.quotaSnapshots = snapshots;
+	}
+	return result;
 }
 
 export {
@@ -721,6 +773,10 @@ export interface ISessionGitState {
  * the git key is not a plain object (e.g. an array or a primitive).
  * Individual fields with wrong types are silently dropped so partial state
  * still propagates.
+ *
+ * Unlike the other typed readers, this takes the raw {@link SessionMeta} value
+ * rather than its parent {@link SessionState}: the sessions provider stores and
+ * reads a detached meta snapshot without retaining the owning state.
  */
 export function readSessionGitState(meta: SessionMeta | undefined): ISessionGitState | undefined {
 	const value = meta?.[SESSION_META_GIT_KEY];
@@ -821,7 +877,8 @@ export function hostBuildInfoFromProduct(productService: IProductService): IHost
  * key is not a plain object with a string `version`. Optional fields with wrong
  * types are silently dropped.
  */
-export function readHostBuildInfo(meta: RootMeta | undefined): IHostBuildInfo | undefined {
+export function readHostBuildInfo(state: RootState | undefined): IHostBuildInfo | undefined {
+	const meta = state?._meta;
 	const value = meta?.[ROOT_META_HOST_BUILD_KEY];
 	if (!value || typeof value !== 'object' || Array.isArray(value)) {
 		return undefined;

--- a/src/vs/platform/agentHost/node/agentHostRenameCommand.ts
+++ b/src/vs/platform/agentHost/node/agentHostRenameCommand.ts
@@ -8,6 +8,7 @@ import { localize } from '../../../nls.js';
 import type { URI } from '../common/state/protocol/common/state.js';
 import { CompletionItem, CompletionItemKind, CompletionsParams } from '../common/state/protocol/commands.js';
 import { MessageAttachmentKind } from '../common/state/protocol/state.js';
+import { toCommandCompletionAttachmentMeta } from '../common/meta/agentCompletionAttachmentMeta.js';
 import { CompletionTriggerCharacter, IAgentHostCompletionItemProvider } from './agentHostCompletions.js';
 import { extractLeadingSlashToken } from './agentHostSlashCompletion.js';
 
@@ -71,10 +72,10 @@ export class AgentHostRenameCompletionProvider implements IAgentHostCompletionIt
 			attachment: {
 				type: MessageAttachmentKind.Simple,
 				label: '/' + RENAME_SLASH_COMMAND,
-				_meta: {
+				_meta: toCommandCompletionAttachmentMeta({
 					command: RENAME_SLASH_COMMAND,
 					description: localize('agentHostSlashCommand.rename.description', "Rename this chat"),
-				},
+				}),
 			},
 		}];
 	}

--- a/src/vs/platform/agentHost/node/agentHostSkillCompletionProvider.ts
+++ b/src/vs/platform/agentHost/node/agentHostSkillCompletionProvider.ts
@@ -9,6 +9,7 @@ import { URI } from '../../../base/common/uri.js';
 import type { IAgent } from '../common/agentService.js';
 import { CompletionItem, CompletionItemKind, CompletionsParams } from '../common/state/protocol/commands.js';
 import { MessageAttachmentKind } from '../common/state/protocol/state.js';
+import { toSkillCompletionAttachmentMeta } from '../common/meta/agentCompletionAttachmentMeta.js';
 import { CustomizationType, SkillCustomization } from '../common/state/sessionState.js';
 import { CompletionTriggerCharacter, IAgentHostCompletionItemProvider } from './agentHostCompletions.js';
 import { extractWhitespaceDelimitedSlashToken } from './agentHostSlashCompletion.js';
@@ -64,12 +65,12 @@ export class AgentHostSkillCompletionProvider extends Disposable implements IAge
 				attachment: {
 					type: MessageAttachmentKind.Simple,
 					label: '/' + skill.slashCommandName,
-					_meta: {
+					_meta: toSkillCompletionAttachmentMeta({
 						uri: skill.uri,
 						name: skill.name,
 						displayName: skill.slashCommandName,
-						...(skill.description !== undefined ? { description: skill.description } : {}),
-					},
+						description: skill.description,
+					}),
 				},
 			}));
 	}

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -9,6 +9,7 @@ import { autorun, IObservable, IReader } from '../../../base/common/observable.j
 import { hasKey } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
+import { toToolCallMeta } from '../common/meta/agentToolCallMeta.js';
 import { localize } from '../../../nls.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { ILogService } from '../../log/common/log.js';
@@ -756,7 +757,7 @@ export class AgentSideEffects extends Disposable {
 			&& !!e.state.confirmationTitle;
 		if (clientShouldAutoApprove) {
 			this._toolCallAgents.set(`${sessionKey}:${e.state.toolCallId}`, agent.id);
-			effective = { ...e, state: { ...e.state, _meta: { ...toolCall?._meta, ...e.state._meta, autoApproveBySetting: true } } };
+			effective = { ...e, state: { ...e.state, _meta: { ...toolCall?._meta, ...e.state._meta, ...toToolCallMeta({ autoApproveBySetting: true }) } } };
 		} else if (autoApproval !== undefined) {
 			this._toolCallAgents.delete(`${sessionKey}:${e.state.toolCallId}`);
 			agent.respondToPermissionRequest(e.state.toolCallId, true);

--- a/src/vs/platform/agentHost/node/claude/claudePromptResolver.ts
+++ b/src/vs/platform/agentHost/node/claude/claudePromptResolver.ts
@@ -5,7 +5,7 @@
 
 import type Anthropic from '@anthropic-ai/sdk';
 import { URI } from '../../../../base/common/uri.js';
-import { isAgentFeedbackAnnotationsAttachment, renderAgentFeedbackAnnotationsAttachment } from '../../common/agentFeedbackAttachments.js';
+import { isAgentFeedbackAnnotationsAttachment, renderAgentFeedbackAnnotationsAttachment } from '../../common/meta/agentFeedbackAttachments.js';
 import { MessageAttachmentKind, type MessageAttachment } from '../../common/state/protocol/state.js';
 
 /**

--- a/src/vs/platform/agentHost/node/claude/claudeReplayMapper.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeReplayMapper.ts
@@ -22,6 +22,7 @@ import {
 	type Turn,
 } from '../../common/state/protocol/state.js';
 import { buildSubagentSessionUri } from '../../common/state/sessionState.js';
+import { readToolCallMeta } from '../../common/meta/agentToolCallMeta.js';
 import { buildClaudeToolMeta, getClaudeInvocationMessage, getClaudePastTenseMessage, getClaudeToolDisplayName, getClaudeToolInputString } from './claudeToolDisplay.js';
 import { stripClientToolNamePrefix } from './clientTools/claudeClientToolMcpServer.js';
 
@@ -302,7 +303,7 @@ class ReplayBuilder {
 		}
 		const isError = block.is_error;
 		const previousState = part.toolCall;
-		const isSubagent = previousState._meta?.toolKind === 'subagent';
+		const isSubagent = readToolCallMeta(previousState).toolKind === 'subagent';
 		const content: ToolResultContent[] = extractToolResultContent(block.content) ?? [];
 		if (isSubagent) {
 			content.push({

--- a/src/vs/platform/agentHost/node/claude/claudeSubagentSignals.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSubagentSignals.ts
@@ -5,12 +5,14 @@
 
 import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 import type { URI } from '../../../../base/common/uri.js';
+import type { Mutable } from '../../../../base/common/types.js';
+import { toToolCallMeta, type IToolCallMeta } from '../../common/meta/agentToolCallMeta.js';
 import type { AgentSignal, IAgentSubagentStartedSignal } from '../../common/agentService.js';
 import { ActionType } from '../../common/state/sessionActions.js';
 import { ResponsePartKind, ToolCallConfirmationReason } from '../../common/state/sessionState.js';
 import type { ClaudeMapperState } from './claudeMapSessionEvents.js';
 import { SUBAGENT_TOOL_NAMES, type SubagentRegistry } from './claudeSubagentRegistry.js';
-import { buildClaudeToolMeta, getClaudeInvocationMessage, getClaudeToolDisplayName, getClaudeToolInputString } from './claudeToolDisplay.js';
+import { buildClaudeToolCallMeta, buildClaudeToolMeta, getClaudeInvocationMessage, getClaudeToolDisplayName, getClaudeToolInputString } from './claudeToolDisplay.js';
 import { stripClientToolNamePrefix } from './clientTools/claudeClientToolMcpServer.js';
 
 /**
@@ -146,7 +148,10 @@ export function buildTopLevelSubagentReadyAction(
 	const agentName = typeof input?.subagent_type === 'string' ? input.subagent_type : undefined;
 	const inputJson = block.input !== undefined ? safeStringify(block.input) : undefined;
 	registry.recordSpawn(block.id, { subagentType: agentName, description });
-	const meta: Record<string, unknown> = { ...(buildClaudeToolMeta(block.name) ?? { toolKind: 'subagent' }) };
+	const meta: Mutable<IToolCallMeta> = { ...buildClaudeToolCallMeta(block.name) };
+	if (!meta.toolKind) {
+		meta.toolKind = 'subagent';
+	}
 	if (description) {
 		meta.subagentDescription = description;
 	}
@@ -163,7 +168,7 @@ export function buildTopLevelSubagentReadyAction(
 			invocationMessage: getClaudeInvocationMessage(block.name, getClaudeToolDisplayName(block.name), block.input),
 			...(inputJson !== undefined ? { toolInput: inputJson } : {}),
 			confirmed: ToolCallConfirmationReason.NotNeeded,
-			_meta: meta,
+			_meta: toToolCallMeta(meta),
 		},
 	};
 }

--- a/src/vs/platform/agentHost/node/claude/claudeToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeToolDisplay.ts
@@ -8,6 +8,7 @@ import { appendEscapedMarkdownInlineCode, escapeMarkdownLinkLabel } from '../../
 import { basename } from '../../../../base/common/resources.js';
 import { truncate } from '../../../../base/common/strings.js';
 import { URI } from '../../../../base/common/uri.js';
+import { toToolCallMeta, type IToolCallMeta, type ToolKind } from '../../common/meta/agentToolCallMeta.js';
 import type { StringOrMarkdown } from '../../common/state/protocol/state.js';
 
 /**
@@ -46,7 +47,7 @@ export type ClaudePermissionKind =
  * renderer). Mirror of
  * [`copilotToolDisplay.getToolKind`](../copilot/copilotToolDisplay.ts).
  */
-export type ClaudeToolKind = 'terminal' | 'subagent' | 'search';
+export type ClaudeToolKind = ToolKind;
 
 /**
  * Which field on the SDK's `tool_input` carries the path/url surfaced
@@ -276,6 +277,17 @@ export function getClaudeToolKind(toolName: string): ClaudeToolKind | undefined 
  * single-write pattern.
  */
 export function buildClaudeToolMeta(toolName: string): Record<string, unknown> | undefined {
+	const meta = buildClaudeToolCallMeta(toolName);
+	return meta ? toToolCallMeta(meta) : undefined;
+}
+
+/**
+ * Typed variant of {@link buildClaudeToolMeta} that returns the
+ * {@link IToolCallMeta} directly, for callers that consume the typed view
+ * rather than the serialized `_meta` bag. Returns `undefined` for tools that
+ * have no `toolKind` hint.
+ */
+export function buildClaudeToolCallMeta(toolName: string): IToolCallMeta | undefined {
 	const row = TOOL_ROWS[toolName];
 	if (!row?.toolKind) {
 		return undefined;

--- a/src/vs/platform/agentHost/node/codex/codexMapAppServerEvents.ts
+++ b/src/vs/platform/agentHost/node/codex/codexMapAppServerEvents.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { generateUuid } from '../../../../base/common/uuid.js';
+import { toToolCallMeta } from '../../common/meta/agentToolCallMeta.js';
 import { ActionType, type SessionAction, type ChatAction } from '../../common/state/sessionActions.js';
 import { MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallContributorKind, ToolResultContentType, TurnState } from '../../common/state/sessionState.js';
 import { extractForwardedErrorInfo } from '../shared/forwardedChatError.js';
@@ -316,7 +317,7 @@ export function mapItemStarted(
 				toolCallId,
 				toolName: 'shell',
 				displayName: 'Run shell command',
-				_meta: { toolKind: 'terminal' },
+				_meta: toToolCallMeta({ toolKind: 'terminal' }),
 			},
 			{
 				type: ActionType.ChatToolCallDelta,
@@ -331,7 +332,7 @@ export function mapItemStarted(
 				invocationMessage: command,
 				toolInput: command,
 				confirmed: ToolCallConfirmationReason.NotNeeded,
-				_meta: { toolKind: 'terminal' },
+				_meta: toToolCallMeta({ toolKind: 'terminal' }),
 			},
 		];
 	}
@@ -351,7 +352,7 @@ export function mapItemStarted(
 				toolCallId,
 				toolName: 'web_search',
 				displayName: 'Web search',
-				_meta: { toolKind: 'search' },
+				_meta: toToolCallMeta({ toolKind: 'search' }),
 			},
 			{
 				type: ActionType.ChatToolCallDelta,
@@ -366,7 +367,7 @@ export function mapItemStarted(
 				invocationMessage: query,
 				toolInput: query,
 				confirmed: ToolCallConfirmationReason.NotNeeded,
-				_meta: { toolKind: 'search' },
+				_meta: toToolCallMeta({ toolKind: 'search' }),
 			},
 		];
 	}

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -14,7 +14,7 @@ import { Schemas } from '../../../../base/common/network.js';
 import { isAbsolute, join } from '../../../../base/common/path.js';
 import { extUriBiasedIgnorePathCase, normalizePath } from '../../../../base/common/resources.js';
 import { splitLinesIncludeSeparators } from '../../../../base/common/strings.js';
-import { hasKey, isDefined, isObject, isString } from '../../../../base/common/types.js';
+import { hasKey, isDefined, isObject, isString, type Mutable } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { localize } from '../../../../nls.js';
@@ -28,10 +28,11 @@ import { AgentHostSandboxConfigKey, sandboxConfigSchema } from '../../common/san
 import { platformSessionSchema } from '../../common/agentHostSchema.js';
 import { AgentSignal, IMcpNotification } from '../../common/agentService.js';
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
+import { toToolCallMeta, type IToolCallMeta, type IToolCallUiMeta } from '../../common/meta/agentToolCallMeta.js';
 import { OtelData, type OtelAttributeValue } from '../../common/otlp/otlpLogEmitter.js';
 import type { LanguageModelToolInvokedClassification, LanguageModelToolInvokedEvent } from '../../../telemetry/common/languageModelToolTelemetry.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
-import { isAgentFeedbackAnnotationsAttachment, renderAgentFeedbackAnnotationsAttachment } from '../../common/agentFeedbackAttachments.js';
+import { isAgentFeedbackAnnotationsAttachment, renderAgentFeedbackAnnotationsAttachment } from '../../common/meta/agentFeedbackAttachments.js';
 import { ISessionDatabase, ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../../common/sessionDataService.js';
 import { MessageAttachmentKind, ToolCallContributorKind, type FileEdit, type MessageAttachment } from '../../common/state/protocol/state.js';
 import { ActionType, type ChatAction, type SessionAction } from '../../common/state/sessionActions.js';
@@ -342,7 +343,7 @@ export class CopilotAgentSession extends Disposable {
 	get workingDirectory(): URI | undefined { return this._workingDirectory; }
 
 	/** Tracks active tool invocations so we can produce past-tense messages on completion. */
-	private readonly _activeToolCalls = new Map<string, { toolName: string; displayName: string; parameters: Record<string, unknown> | undefined; content: ToolResultContent[]; parentToolCallId: string | undefined; startTimeMs: number; mcpServerName: string | undefined; meta: Record<string, unknown> | undefined }>();
+	private readonly _activeToolCalls = new Map<string, { toolName: string; displayName: string; parameters: Record<string, unknown> | undefined; content: ToolResultContent[]; parentToolCallId: string | undefined; startTimeMs: number; mcpServerName: string | undefined; meta: IToolCallMeta | undefined }>();
 	private readonly _parentToolCallIdsByAgentId = new Map<string, string>();
 	/** Pending permission requests awaiting a renderer-side decision. */
 	private readonly _pendingPermissions = new Map<string, DeferredPromise<boolean>>();
@@ -2140,7 +2141,7 @@ export class CopilotAgentSession extends Disposable {
 			this._currentMarkdownPartIds.delete(parentToolCallId ?? '');
 			this._currentReasoningPartIds.delete(parentToolCallId ?? '');
 
-			const meta: Record<string, unknown> = { toolKind, language: toolKind === 'terminal' ? getShellLanguage(e.data.toolName) : undefined };
+			const meta: Mutable<IToolCallMeta> = { toolKind, language: toolKind === 'terminal' ? getShellLanguage(e.data.toolName) : undefined };
 			if (subagentMeta?.description) {
 				meta.subagentDescription = subagentMeta.description;
 			}
@@ -2179,7 +2180,7 @@ export class CopilotAgentSession extends Disposable {
 				toolName: e.data.toolName,
 				displayName,
 				contributor,
-				_meta: meta,
+				_meta: toToolCallMeta(meta),
 			}, parentToolCallId);
 
 			// No client is connected to run this client tool. Fail it
@@ -2294,10 +2295,11 @@ export class CopilotAgentSession extends Disposable {
 			}
 
 			this._sendToolInvokedTelemetry(e.data.success, e.data.error?.code, tracked);
+			// eslint-disable-next-line local/code-no-untyped-meta-access -- Copilot SDK's own typed `_meta`, not the AHP protocol bag.
 			const resourceUri = e.data.toolDescription?._meta?.ui?.resourceUri;
-			let completeMeta: Record<string, unknown> | undefined = tracked.meta;
+			let completeMeta: IToolCallMeta | undefined = tracked.meta;
 			if (resourceUri) {
-				const ui: Record<string, unknown> = { resourceUri };
+				const ui: Mutable<IToolCallUiMeta> = { resourceUri };
 				if (tracked.mcpServerName) {
 					const channel = this._mcpCustomizations.channelForServer(tracked.mcpServerName);
 					if (channel !== undefined) {
@@ -2320,7 +2322,7 @@ export class CopilotAgentSession extends Disposable {
 					content: content.length > 0 ? content : undefined,
 					error: e.data.error,
 				},
-				_meta: completeMeta,
+				_meta: completeMeta ? toToolCallMeta(completeMeta) : undefined,
 			}, parentToolCallId);
 		}));
 

--- a/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider.ts
@@ -8,6 +8,7 @@ import { localize } from '../../../../nls.js';
 import { AgentSession } from '../../common/agentService.js';
 import { CompletionItem, CompletionItemKind, CompletionsParams } from '../../common/state/protocol/commands.js';
 import { MessageAttachmentKind } from '../../common/state/protocol/state.js';
+import { toCommandCompletionAttachmentMeta } from '../../common/meta/agentCompletionAttachmentMeta.js';
 import { CompletionTriggerCharacter, IAgentHostCompletionItemProvider } from '../agentHostCompletions.js';
 import { extractLeadingSlashToken } from '../agentHostSlashCompletion.js';
 
@@ -145,7 +146,7 @@ export class CopilotSlashCommandCompletionProvider implements IAgentHostCompleti
 				attachment: {
 					type: MessageAttachmentKind.Simple,
 					label: '/' + command,
-					_meta: { command, description: getCommandDescription(command) },
+					_meta: toCommandCompletionAttachmentMeta({ command, description: getCommandDescription(command) }),
 				},
 			});
 		}

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -10,6 +10,7 @@ import { isString } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
+import { toToolCallMeta } from '../../common/meta/agentToolCallMeta.js';
 import { IFileEditRecord, ISessionDatabase } from '../../common/sessionDataService.js';
 import { MessageAttachmentKind, type MessageAttachment } from '../../common/state/protocol/state.js';
 import { MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildSubagentSessionUri, type Message, type ResponsePart, type StringOrMarkdown, type ToolCallCompletedState, type ToolResultContent, type Turn } from '../../common/state/sessionState.js';
@@ -682,12 +683,12 @@ function makeCompletedToolCallPart(
 		content: content.length > 0 ? content : undefined,
 		error: d.error,
 		confirmed: ToolCallConfirmationReason.NotNeeded,
-		_meta: {
+		_meta: toToolCallMeta({
 			toolKind: info.toolKind,
 			language: info.language,
 			subagentDescription: info.subagentDescription,
 			subagentAgentName: info.subagentAgentName,
-		},
+		}),
 	};
 	return { kind: ResponsePartKind.ToolCall, toolCall: tc };
 }

--- a/src/vs/platform/agentHost/node/copilot/sessionCustomizationDiscovery.ts
+++ b/src/vs/platform/agentHost/node/copilot/sessionCustomizationDiscovery.ts
@@ -18,6 +18,7 @@ import { ILogService } from '../../../log/common/log.js';
 import type { AgentsDiscoverRequest } from './copilotRCP.js';
 import { AgentCustomization, ChildCustomization, CustomizationLoadStatus, CustomizationType, DirectoryCustomization, RuleCustomization, SkillCustomization, customizationId } from '../../common/state/sessionState.js';
 import { ChildCustomizationType } from '../../common/state/protocol/state.js';
+import { toAgentCustomizationMeta } from '../../common/meta/agentCustomizationMeta.js';
 
 /**
  * The kinds of customizations the agent host discovers from disk.
@@ -238,7 +239,7 @@ export class SessionCustomizationDiscovery extends Disposable {
 			for (const agent of agentDiscovery.agents) {
 				if (agent.path) {
 					const uri = URI.file(agent.path);
-					agents.push({ type: CustomizationType.Agent, uri: uri.toString(), id: agent.id, name: agent.name, description: agent.description, _meta: { userInvocable: agent.userInvocable } });
+					agents.push({ type: CustomizationType.Agent, uri: uri.toString(), id: agent.id, name: agent.name, description: agent.description, _meta: toAgentCustomizationMeta({ userInvocable: agent.userInvocable }) });
 				}
 			}
 

--- a/src/vs/platform/agentHost/node/shared/agentFeedbackServerTools.ts
+++ b/src/vs/platform/agentHost/node/shared/agentFeedbackServerTools.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { generateUuid } from '../../../../base/common/uuid.js';
-import { FEEDBACK_ANNOTATION_META_KEY, VIEW_UNREVIEWED_COMMENTS_TOOL_NAME, type IFeedbackAnnotationMeta } from '../../common/agentFeedbackAnnotations.js';
+import { FEEDBACK_ANNOTATION_META_KEY, readFeedbackAnnotationMeta, VIEW_UNREVIEWED_COMMENTS_TOOL_NAME, type IFeedbackAnnotationMeta } from '../../common/meta/agentFeedbackAnnotations.js';
 import { buildAnnotationsUri } from '../../common/annotationsUri.js';
 import type { AnnotationsAction } from '../../common/state/sessionActions.js';
 import { ActionType } from '../../common/state/protocol/common/actions.js';
@@ -249,7 +249,7 @@ function entryText(text: StringOrMarkdown): string {
 }
 
 function readMeta(annotation: Annotation): IFeedbackAnnotationMeta | undefined {
-	return annotation._meta?.[FEEDBACK_ANNOTATION_META_KEY] as IFeedbackAnnotationMeta | undefined;
+	return readFeedbackAnnotationMeta(annotation);
 }
 
 interface ISerializedComment {

--- a/src/vs/platform/agentHost/test/common/agentMetaReaders.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentMetaReaders.test.ts
@@ -1,0 +1,122 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { readToolCallMeta, toToolCallMeta } from '../../common/meta/agentToolCallMeta.js';
+import { readAgentCustomizationMeta, toAgentCustomizationMeta } from '../../common/meta/agentCustomizationMeta.js';
+import { readCompletionAttachmentMeta, toCommandCompletionAttachmentMeta, toSkillCompletionAttachmentMeta } from '../../common/meta/agentCompletionAttachmentMeta.js';
+import { CustomizationType, MessageAttachmentKind, ToolCallStatus, type AgentCustomization, type ToolCallState } from '../../common/state/sessionState.js';
+import type { SimpleMessageAttachment } from '../../common/state/protocol/state.js';
+
+/** Wraps a `_meta` bag in a minimal {@link ToolCallState} so the reader sees the right source type. */
+function toolCall(meta: Record<string, unknown> | undefined): ToolCallState {
+	return { status: ToolCallStatus.Streaming, toolCallId: 't', toolName: 'n', displayName: 'd', _meta: meta };
+}
+
+/** Wraps a `_meta` bag in a minimal {@link AgentCustomization}. */
+function agentCustomization(meta: Record<string, unknown> | undefined): AgentCustomization {
+	return { type: CustomizationType.Agent, id: 'a', uri: 'file:///a', name: 'n', _meta: meta };
+}
+
+/** Wraps a `_meta` bag in a minimal {@link SimpleMessageAttachment}. */
+function attachment(meta: Record<string, unknown> | undefined): SimpleMessageAttachment {
+	return { type: MessageAttachmentKind.Simple, label: 'l', _meta: meta };
+}
+
+suite('Agent host _meta readers', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('readToolCallMeta', () => {
+		test('returns empty when no _meta', () => {
+			assert.deepStrictEqual(readToolCallMeta(toolCall(undefined)), {});
+		});
+
+		test('reads valid keys and drops wrong-typed / unknown keys', () => {
+			const result = readToolCallMeta(toolCall({
+				toolKind: 'terminal',
+				language: 'bash',
+				subagentDescription: 'Find files',
+				subagentAgentName: 'explore',
+				mcpServerName: 'srv',
+				mcpToolName: 'tool',
+				autoApproveBySetting: true,
+				ui: { resourceUri: 'ui://app', channel: 'mcp://c' },
+				language2: 123,            // unknown key, ignored
+				somethingElse: 5,          // unknown key, ignored
+			}));
+			assert.deepStrictEqual(result, {
+				toolKind: 'terminal',
+				language: 'bash',
+				subagentDescription: 'Find files',
+				subagentAgentName: 'explore',
+				mcpServerName: 'srv',
+				mcpToolName: 'tool',
+				autoApproveBySetting: true,
+				ui: { resourceUri: 'ui://app', channel: 'mcp://c' },
+			});
+		});
+
+		test('drops an invalid toolKind and a malformed ui bag', () => {
+			const result = readToolCallMeta(toolCall({ toolKind: 'nope', ui: { channel: 'mcp://c' } }));
+			assert.deepStrictEqual(result, {});
+		});
+
+		test('preserves a present toolArguments value, drops undefined', () => {
+			assert.deepStrictEqual(readToolCallMeta(toolCall({ toolArguments: { a: 1 } })), { toolArguments: { a: 1 } });
+			assert.deepStrictEqual(readToolCallMeta(toolCall({ toolArguments: undefined })), {});
+		});
+
+		test('toToolCallMeta round-trips and returns undefined when empty', () => {
+			assert.strictEqual(toToolCallMeta({}), undefined);
+			const wire = toToolCallMeta({ toolKind: 'search', language: undefined });
+			assert.deepStrictEqual(wire, { toolKind: 'search' });
+			assert.deepStrictEqual(readToolCallMeta(toolCall(wire)), { toolKind: 'search' });
+		});
+	});
+
+	suite('readAgentCustomizationMeta', () => {
+		test('reads userInvocable, ignores garbage, round-trips', () => {
+			assert.deepStrictEqual(readAgentCustomizationMeta(agentCustomization(undefined)), {});
+			assert.deepStrictEqual(readAgentCustomizationMeta(agentCustomization({ userInvocable: 'yes' })), {});
+			assert.deepStrictEqual(readAgentCustomizationMeta(agentCustomization({ userInvocable: false })), { userInvocable: false });
+			assert.strictEqual(toAgentCustomizationMeta({}), undefined);
+			assert.deepStrictEqual(toAgentCustomizationMeta({ userInvocable: true }), { userInvocable: true });
+		});
+	});
+
+	suite('readCompletionAttachmentMeta', () => {
+		test('classifies a command bag', () => {
+			assert.deepStrictEqual(
+				readCompletionAttachmentMeta(attachment({ command: 'rename', description: 'Rename this chat' })),
+				{ kind: 'command', command: 'rename', description: 'Rename this chat' }
+			);
+		});
+
+		test('classifies a skill bag, dropping wrong-typed optional fields', () => {
+			assert.deepStrictEqual(
+				readCompletionAttachmentMeta(attachment({ uri: 'file:///s/SKILL.md', name: 'mon', displayName: 'mon', description: 5 })),
+				{ kind: 'skill', uri: 'file:///s/SKILL.md', name: 'mon', displayName: 'mon' }
+			);
+		});
+
+		test('returns undefined for an unrecognized or empty bag', () => {
+			assert.strictEqual(readCompletionAttachmentMeta(attachment(undefined)), undefined);
+			assert.strictEqual(readCompletionAttachmentMeta(attachment({ foo: 'bar' })), undefined);
+			assert.strictEqual(readCompletionAttachmentMeta(attachment({ command: 5 })), undefined);
+		});
+
+		test('builders produce wire bags that round-trip', () => {
+			const cmd = toCommandCompletionAttachmentMeta({ command: 'rename' });
+			assert.deepStrictEqual(cmd, { command: 'rename' });
+			assert.deepStrictEqual(readCompletionAttachmentMeta(attachment(cmd)), { kind: 'command', command: 'rename' });
+
+			const skill = toSkillCompletionAttachmentMeta({ uri: 'file:///s/SKILL.md', name: 'mon', displayName: 'mon', description: undefined });
+			assert.deepStrictEqual(skill, { uri: 'file:///s/SKILL.md', name: 'mon', displayName: 'mon' });
+			assert.deepStrictEqual(readCompletionAttachmentMeta(attachment(skill)), { kind: 'skill', uri: 'file:///s/SKILL.md', name: 'mon', displayName: 'mon' });
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/common/state/hostBuildInfoMeta.test.ts
+++ b/src/vs/platform/agentHost/test/common/state/hostBuildInfoMeta.test.ts
@@ -5,7 +5,12 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { ROOT_META_HOST_BUILD_KEY, formatHostBuildInfo, readHostBuildInfo, withHostBuildInfo, type IHostBuildInfo } from '../../../common/state/sessionState.js';
+import { ROOT_META_HOST_BUILD_KEY, formatHostBuildInfo, readHostBuildInfo, withHostBuildInfo, type IHostBuildInfo, type RootMeta, type RootState } from '../../../common/state/sessionState.js';
+
+/** Wraps a `_meta` bag in a minimal {@link RootState} so the reader sees the right source type. */
+function rootState(meta: RootMeta | undefined): RootState {
+	return { agents: [], _meta: meta };
+}
 
 suite('Host build info _meta helpers', () => {
 
@@ -15,21 +20,21 @@ suite('Host build info _meta helpers', () => {
 
 	test('round-trips through withHostBuildInfo / readHostBuildInfo', () => {
 		const meta = withHostBuildInfo(undefined, full);
-		assert.deepStrictEqual(readHostBuildInfo(meta), full);
+		assert.deepStrictEqual(readHostBuildInfo(rootState(meta)), full);
 	});
 
 	test('readHostBuildInfo rejects malformed payloads', () => {
 		assert.strictEqual(readHostBuildInfo(undefined), undefined);
-		assert.strictEqual(readHostBuildInfo({}), undefined);
-		assert.strictEqual(readHostBuildInfo({ [ROOT_META_HOST_BUILD_KEY]: 'nope' }), undefined);
-		assert.strictEqual(readHostBuildInfo({ [ROOT_META_HOST_BUILD_KEY]: [] }), undefined);
+		assert.strictEqual(readHostBuildInfo(rootState({})), undefined);
+		assert.strictEqual(readHostBuildInfo(rootState({ [ROOT_META_HOST_BUILD_KEY]: 'nope' })), undefined);
+		assert.strictEqual(readHostBuildInfo(rootState({ [ROOT_META_HOST_BUILD_KEY]: [] })), undefined);
 		// Missing required `version`.
-		assert.strictEqual(readHostBuildInfo({ [ROOT_META_HOST_BUILD_KEY]: { commit: 'x' } }), undefined);
+		assert.strictEqual(readHostBuildInfo(rootState({ [ROOT_META_HOST_BUILD_KEY]: { commit: 'x' } })), undefined);
 	});
 
 	test('readHostBuildInfo drops fields with wrong types but keeps version', () => {
 		const meta = { [ROOT_META_HOST_BUILD_KEY]: { version: '1.0.0', commit: 42, date: '2024', quality: true } };
-		assert.deepStrictEqual(readHostBuildInfo(meta), { version: '1.0.0', date: '2024' });
+		assert.deepStrictEqual(readHostBuildInfo(rootState(meta)), { version: '1.0.0', date: '2024' });
 	});
 
 	test('withHostBuildInfo preserves other keys and removes on undefined', () => {

--- a/src/vs/platform/agentHost/test/node/agentFeedbackServerTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentFeedbackServerTools.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../log/common/log.js';
-import { FEEDBACK_ANNOTATION_META_KEY } from '../../common/agentFeedbackAnnotations.js';
+import { FEEDBACK_ANNOTATION_META_KEY } from '../../common/meta/agentFeedbackAnnotations.js';
 import { ActionType } from '../../common/state/protocol/common/actions.js';
 import { Annotation, AnnotationsState, SessionStatus, SessionSummary } from '../../common/state/sessionState.js';
 import { buildAnnotationsUri } from '../../common/annotationsUri.js';

--- a/src/vs/platform/agentHost/test/node/agentHostStateManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostStateManager.test.ts
@@ -73,11 +73,11 @@ suite('AgentHostStateManager', () => {
 	test('seeds host build info into root state _meta when provided', () => {
 		const buildInfo = { version: '1.96.0', commit: 'abc1234', date: '2024-01-02T03:04:05Z', quality: 'insider' };
 		const localManager = disposables.add(new AgentHostStateManager(new NullLogService(), { hostBuildInfo: buildInfo }));
-		assert.deepStrictEqual(readHostBuildInfo(localManager.rootState._meta), buildInfo);
+		assert.deepStrictEqual(readHostBuildInfo(localManager.rootState), buildInfo);
 	});
 
 	test('omits host build info from root state _meta when not provided', () => {
-		assert.strictEqual(readHostBuildInfo(manager.rootState._meta), undefined);
+		assert.strictEqual(readHostBuildInfo(manager.rootState), undefined);
 	});
 
 	test('getSnapshot returns session snapshot after creation', () => {

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -36,7 +36,7 @@ import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { FileService } from '../../../files/common/fileService.js';
 import { IAgentMaterializeSessionEvent, AgentSession, AgentSignal, GITHUB_COPILOT_PROTECTED_RESOURCE } from '../../common/agentService.js';
-import { AgentFeedbackAttachmentDisplayKind } from '../../common/agentFeedbackAttachments.js';
+import { AgentFeedbackAttachmentDisplayKind } from '../../common/meta/agentFeedbackAttachments.js';
 import { ActionType } from '../../common/state/sessionActions.js';
 import { CustomizationLoadStatus, CustomizationType, MessageAttachmentKind, MessageKind, ResponsePartKind, ChatInputResponseKind, SessionStatus, ToolResultContentType, buildSubagentSessionUri, customizationId, type ClientPluginCustomization, type PluginCustomization } from '../../common/state/sessionState.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -21,7 +21,7 @@ import type { ClassifiedEvent, IGDPRProperty, OmitMetadata, StrictPropertyCheck 
 import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
 import { NullTelemetryServiceShape } from '../../../telemetry/common/telemetryUtils.js';
 import { AgentSession, type AgentSignal, type IAgentActionSignal, type IAgentToolPendingConfirmationSignal } from '../../common/agentService.js';
-import { AgentFeedbackAttachmentDisplayKind } from '../../common/agentFeedbackAttachments.js';
+import { AgentFeedbackAttachmentDisplayKind } from '../../common/meta/agentFeedbackAttachments.js';
 import { IDiffComputeService } from '../../common/diffComputeService.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
 import { ActionType, type ChatDeltaAction, type ChatErrorAction, type ChatInputRequestedAction, type ChatResponsePartAction, type ChatToolCallCompleteAction, type ChatToolCallReadyAction, type ChatToolCallStartAction, type ChatTurnCompleteAction } from '../../common/state/sessionActions.js';

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackItemsBackend.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackItemsBackend.ts
@@ -12,7 +12,7 @@ import { IAgentSubscription } from '../../../../platform/agentHost/common/state/
 import { ActionType } from '../../../../platform/agentHost/common/state/protocol/common/actions.js';
 import { Annotation, AnnotationEntry, AnnotationsState, StateComponents, StringOrMarkdown } from '../../../../platform/agentHost/common/state/sessionState.js';
 import { TextRange } from '../../../../platform/agentHost/common/state/protocol/common/state.js';
-import { FEEDBACK_ANNOTATION_META_KEY } from '../../../../platform/agentHost/common/agentFeedbackAnnotations.js';
+import { FEEDBACK_ANNOTATION_META_KEY, readFeedbackAnnotationMeta, type AgentFeedbackKindValue, type AgentFeedbackStateValue, type IFeedbackAnnotationMeta } from '../../../../platform/agentHost/common/meta/agentFeedbackAnnotations.js';
 import { ICodeReviewSuggestion } from '../../codeReview/browser/codeReviewService.js';
 import { IAgentHostSessionsProvider, isAgentHostProviderId } from '../../../common/agentHostSessionsProvider.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
@@ -146,15 +146,12 @@ export class InMemoryAgentFeedbackItemsBackend extends Disposable implements IAg
 // --- Annotations-backed backend -----------------------------------------------
 
 /**
- * Feedback semantics carried in an annotation's {@link Annotation._meta}.
- * Everything not expressible by the annotation's own fields lives here.
- *
- * Mirrors the shared `IFeedbackAnnotationMeta` from `agentFeedbackAnnotations.ts`
- * but types the client-only fields concretely (e.g. {@link suggestion}). The
- * namespaced {@link FEEDBACK_ANNOTATION_META_KEY} is shared so the two sides
- * cannot drift.
+ * Client-side typed view of a feedback annotation's `_meta`, resolved from the
+ * shared wire shape: {@link kind}/{@link state} as the client enums and
+ * {@link suggestion} as the concrete {@link ICodeReviewSuggestion} (the shared
+ * reader validates it only as opaque data, since its shape lives in this layer).
  */
-interface IFeedbackAnnotationMeta {
+interface IFeedbackMetaView {
 	readonly kind: AgentFeedbackKind;
 	readonly state: AgentFeedbackState;
 	readonly sessionResource: string;
@@ -163,6 +160,52 @@ interface IFeedbackAnnotationMeta {
 	readonly diffHunks?: string;
 	readonly sourcePRReviewCommentId?: string;
 	readonly pendingAgentReveal?: boolean;
+}
+
+const KIND_FROM_VALUE: Record<AgentFeedbackKindValue, AgentFeedbackKind> = {
+	user: AgentFeedbackKind.UserReview,
+	codeReview: AgentFeedbackKind.AgentReview,
+	prReview: AgentFeedbackKind.PRReview,
+};
+
+const STATE_FROM_VALUE: Record<AgentFeedbackStateValue, AgentFeedbackState> = {
+	created: AgentFeedbackState.Created,
+	accepted: AgentFeedbackState.Accepted,
+	submitted: AgentFeedbackState.Submitted,
+	resolved: AgentFeedbackState.Resolved,
+};
+
+function asCodeReviewSuggestion(suggestion: unknown): ICodeReviewSuggestion | undefined {
+	// `suggestion` is opaque client-only data this backend itself serialized from
+	// an `ICodeReviewSuggestion`; validate the shape we depend on (an `edits`
+	// array) and trust the round-tripped contents.
+	if (suggestion && typeof suggestion === 'object' && Array.isArray((suggestion as { edits?: unknown }).edits)) {
+		return suggestion as ICodeReviewSuggestion;
+	}
+	return undefined;
+}
+
+/**
+ * Resolves the shared feedback `_meta` (validated by
+ * {@link readFeedbackAnnotationMeta}) into the client-typed
+ * {@link IFeedbackMetaView}, returning `undefined` for annotations that aren't
+ * feedback items.
+ */
+function readFeedbackMeta(annotation: Annotation): IFeedbackMetaView | undefined {
+	const base = readFeedbackAnnotationMeta(annotation);
+	if (!base) {
+		return undefined;
+	}
+	return {
+		kind: KIND_FROM_VALUE[base.kind],
+		state: STATE_FROM_VALUE[base.state],
+		sessionResource: base.sessionResource,
+		suggestion: asCodeReviewSuggestion(base.suggestion),
+		codeSelection: base.codeSelection,
+		diffHunks: base.diffHunks,
+		sourcePRReviewCommentId: base.sourcePRReviewCommentId,
+		pendingAgentReveal: base.pendingAgentReveal,
+	};
 }
 
 function toTextRange(range: IRange): TextRange {
@@ -216,7 +259,7 @@ function feedbackToAnnotation(feedback: IAgentFeedback): Annotation {
 
 function annotationToFeedback(annotation: Annotation, sessionResource: URI): IAgentFeedback | undefined {
 	const entries = annotation.entries ?? [];
-	const meta = annotation._meta?.[FEEDBACK_ANNOTATION_META_KEY] as IFeedbackAnnotationMeta | undefined;
+	const meta = readFeedbackMeta(annotation);
 	// The annotations channel is generic and may carry annotations produced by
 	// other features. Only annotations that carry feedback metadata are feedback
 	// items; everything else is ignored so feedback never surfaces or mutates
@@ -419,14 +462,15 @@ export class AnnotationsAgentFeedbackItemsBackend extends Disposable implements 
 			return '';
 		}
 		const feedback = value.annotations
-			.filter(annotation => annotation._meta?.[FEEDBACK_ANNOTATION_META_KEY] !== undefined && (annotation.entries?.length ?? 0) > 0)
-			.map(annotation => ({
+			.map(annotation => ({ annotation, meta: readFeedbackMeta(annotation) }))
+			.filter(({ annotation, meta }) => meta !== undefined && (annotation.entries?.length ?? 0) > 0)
+			.map(({ annotation, meta }) => ({
 				id: annotation.id,
 				resource: annotation.resource,
 				range: annotation.range,
 				resolved: annotation.resolved,
 				entries: annotation.entries,
-				meta: annotation._meta?.[FEEDBACK_ANNOTATION_META_KEY],
+				meta,
 			}))
 			.sort((a, b) => a.id.localeCompare(b.id));
 		return JSON.stringify(feedback);

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostLogForwarder.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostLogForwarder.ts
@@ -261,7 +261,7 @@ export class RemoteAgentHostLogForwarder extends Disposable {
 		if (!rootState || rootState instanceof Error) {
 			return;
 		}
-		const buildInfo = readHostBuildInfo(rootState._meta);
+		const buildInfo = readHostBuildInfo(rootState);
 		if (!buildInfo) {
 			return;
 		}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationItemProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationItemProvider.ts
@@ -14,6 +14,7 @@ import { ICustomizationItem, ICustomizationItemAction, ICustomizationItemProvide
 import { SYNCED_CUSTOMIZATION_SCHEME } from '../../../../../services/agentHost/common/agentHostFileSystemService.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
 import { toAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
+import { readAgentCustomizationMeta } from '../../../../../../platform/agentHost/common/meta/agentCustomizationMeta.js';
 import { AICustomizationSource, AICustomizationSources } from '../../../common/aiCustomizationWorkspaceService.js';
 import { PromptsType, Target } from '../../../common/promptSyntax/promptTypes.js';
 import { AgentCustomizationContentExpander } from './agentCustomizationContentExpander.js';
@@ -118,7 +119,7 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 		}
 		let userInvocable: boolean | undefined = undefined;
 		if (child.type === CustomizationType.Agent) {
-			userInvocable = child._meta?.userInvocable !== false;
+			userInvocable = readAgentCustomizationMeta(child).userInvocable !== false;
 		}
 
 		return {
@@ -157,7 +158,7 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 			agentInstructions: { content: '', toolReferences: [] },
 			visibility: {
 				agentInvocable: true,
-				userInvocable: agent._meta?.userInvocable !== false
+				userInvocable: readAgentCustomizationMeta(agent).userInvocable !== false
 			},
 			target: Target.Undefined
 		} satisfies ICustomAgent));

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLanguageModelProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLanguageModelProvider.ts
@@ -61,7 +61,7 @@ export class AgentHostLanguageModelProvider extends Disposable implements ILangu
 		return this._models
 			.filter(m => m.policyState !== 'disabled')
 			.map(m => {
-				const pricing = readAgentModelPricingMeta(m._meta);
+				const pricing = readAgentModelPricingMeta(m);
 				const multiplierNumeric = pricing.multiplierNumeric;
 				return {
 					identifier: `${this._vendor}:${m.id}`,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -21,7 +21,9 @@ import { IPosition } from '../../../../../../editor/common/core/position.js';
 import { isLocation, type Location } from '../../../../../../editor/common/languages.js';
 import { localize } from '../../../../../../nls.js';
 import { AgentProvider, AgentSession, type IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
-import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/agentFeedbackAttachments.js';
+import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/meta/agentFeedbackAttachments.js';
+import { readToolCallMeta } from '../../../../../../platform/agentHost/common/meta/agentToolCallMeta.js';
+import { readCompletionAttachmentMeta } from '../../../../../../platform/agentHost/common/meta/agentCompletionAttachmentMeta.js';
 import { SessionConfigKey } from '../../../../../../platform/agentHost/common/sessionConfigKeys.js';
 import { IAgentSubscription, observableFromSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
 import { ChatTruncatedAction } from '../../../../../../platform/agentHost/common/state/protocol/actions.js';
@@ -159,7 +161,7 @@ function confirmedReasonToProtocol(reason: ConfirmedReason | undefined): ToolCal
 }
 
 function shouldAutoApproveClientToolCall(toolCall: ToolCallState): boolean {
-	return toolCall._meta?.autoApproveBySetting === true;
+	return readToolCallMeta(toolCall).autoApproveBySetting === true;
 }
 
 /**
@@ -591,20 +593,21 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		const attachment = raw.attachment;
 		switch (attachment.type) {
 			case MessageAttachmentKind.Simple: {
-				if (typeof attachment._meta?.command === 'string') {
+				const completionMeta = readCompletionAttachmentMeta(attachment);
+				if (completionMeta?.kind === 'command') {
 					return this._createCompletionItem(raw, text, {
 						kind: 'command',
-						command: attachment._meta.command,
-						description: typeof attachment._meta.description === 'string' ? attachment._meta.description : '',
+						command: completionMeta.command,
+						description: completionMeta.description ?? '',
 						...(attachment._meta !== undefined && { _meta: attachment._meta }),
 					});
 				}
-				if (typeof attachment._meta?.uri === 'string') {
+				if (completionMeta?.kind === 'skill') {
 					return this._createCompletionItem(raw, text, {
 						kind: 'skill',
-						uri: URI.parse(attachment._meta.uri),
-						...(typeof attachment._meta.displayName === 'string' ? { displayName: attachment._meta.displayName } : {}),
-						...(typeof attachment._meta.description === 'string' ? { description: attachment._meta.description } : {}),
+						uri: URI.parse(completionMeta.uri),
+						...(completionMeta.displayName !== undefined ? { displayName: completionMeta.displayName } : {}),
+						...(completionMeta.description !== undefined ? { description: completionMeta.description } : {}),
 						...(attachment._meta !== undefined && { _meta: attachment._meta }),
 					});
 				}
@@ -917,7 +920,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		if (turn?.state !== TurnState.Error || !turn.error) {
 			return undefined;
 		}
-		return getChatErrorDetailsFromMeta(turn.error._meta, this._chatErrorContext())
+		return getChatErrorDetailsFromMeta(turn.error, this._chatErrorContext())
 			?? { message: localize('agentHost.turnError', "Error: ({0}) {1}", turn.error.errorType, turn.error.message) };
 	}
 
@@ -1665,7 +1668,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				return;
 			}
 			if (!opts.suppressErrorMarkdown && lastTurn?.state === TurnState.Error && lastTurn.error) {
-				const forwarded = getChatErrorDetailsFromMeta(lastTurn.error._meta, this._chatErrorContext());
+				const forwarded = getChatErrorDetailsFromMeta(lastTurn.error, this._chatErrorContext());
 				const content = forwarded
 					? new MarkdownString(`\n\n${forwarded.message}`)
 					: new MarkdownString(`\n\nError: (${lastTurn.error.errorType}) ${lastTurn.error.message}`);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -92,11 +92,8 @@ function getMcpAppData(tc: ToolCallState, _sessionResource: URI): ChatMcpAppData
 		return undefined;
 	}
 	const resourceUri = ui.resourceUri;
-	if (resourceUri.length === 0) {
-		return undefined;
-	}
 	const channelValue = ui.channel;
-	if (channelValue === undefined || channelValue.length === 0) {
+	if (channelValue === undefined) {
 		// No channel yet — the App's sub-RPCs would have nowhere to go.
 		// Skip mounting until the customization reaches Ready and the
 		// producer re-emits with the channel populated.

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -8,12 +8,13 @@ import { escapeMarkdownLinkLabel, IMarkdownString, MarkdownString } from '../../
 import { marked, type Token, type Tokens, type TokensList } from '../../../../../../base/common/marked/marked.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
-import { MessageKind, ToolCallContributorKind, ToolCallStatus, TurnState, ResponsePartKind, getToolFileEdits, getToolOutputText, getToolSubagentContent, type ActiveTurn, type ICompletedToolCall, type Message, type ToolCallState, type Turn, FileEditKind, ToolResultContentType, type ToolResultContent, type UsageInfo, type UsageInfoMeta } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { MessageKind, ToolCallContributorKind, ToolCallStatus, TurnState, ResponsePartKind, getToolFileEdits, getToolOutputText, getToolSubagentContent, readUsageInfoMeta, type ActiveTurn, type ICompletedToolCall, type Message, type ToolCallState, type Turn, FileEditKind, ToolResultContentType, type ToolResultContent, type UsageInfo, type UsageInfoMeta } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { getToolKind } from '../../../../../../platform/agentHost/common/state/sessionReducers.js';
+import { readToolCallMeta } from '../../../../../../platform/agentHost/common/meta/agentToolCallMeta.js';
 import { getChatErrorDetailsFromMeta, IChatErrorContext } from '../../../common/chatErrorMessages.js';
 import { AGENT_HOST_SCHEME, toAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
-import { getAgentFeedbackAttachmentMetadata, isAgentFeedbackAnnotationsAttachment, isAgentFeedbackAttachment } from '../../../../../../platform/agentHost/common/agentFeedbackAttachments.js';
-import { isViewUnreviewedCommentsTool } from '../../../../../../platform/agentHost/common/agentFeedbackAnnotations.js';
+import { getAgentFeedbackAttachmentMetadata, isAgentFeedbackAnnotationsAttachment, isAgentFeedbackAttachment } from '../../../../../../platform/agentHost/common/meta/agentFeedbackAttachments.js';
+import { isViewUnreviewedCommentsTool } from '../../../../../../platform/agentHost/common/meta/agentFeedbackAnnotations.js';
 import { MessageAttachmentKind, type FileEdit, type MessageAttachment, type StringOrMarkdown, type TextRange } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { type ChatExternalEditKind, type ChatMcpAppData, type IChatAgentFeedbackReviewConfirmationData, type IChatExternalEdit, type IChatModifiedFilesConfirmationData, type IChatProgress, type IChatResponseErrorDetails, type IChatSearchToolInvocationData, type IChatTerminalToolInvocationData, type IChatToolInputInvocationData, type IChatToolInvocationSerialized, type IChatUsage, ToolConfirmKind } from '../../../common/chatService/chatService.js';
 import { type IChatSessionHistoryItem } from '../../../common/chatSessionsService.js';
@@ -55,17 +56,17 @@ export function parseAhpTerminalToolSessionId(id: string): { terminal: string; s
  * mapper. This is the short task description (e.g., "Find related files"),
  * NOT the agent's own description.
  */
-function getSubagentTaskDescription(tc: { _meta?: Record<string, unknown> }): string | undefined {
-	const v = tc._meta?.subagentDescription;
-	return typeof v === 'string' && v.length > 0 ? v : undefined;
+function getSubagentTaskDescription(tc: ToolCallState): string | undefined {
+	const v = readToolCallMeta(tc).subagentDescription;
+	return v && v.length > 0 ? v : undefined;
 }
 
 /**
  * Extracts the agent name from `_meta.subagentAgentName`.
  */
-function getSubagentAgentName(tc: { _meta?: Record<string, unknown> }): string | undefined {
-	const v = tc._meta?.subagentAgentName;
-	return typeof v === 'string' && v.length > 0 ? v : undefined;
+function getSubagentAgentName(tc: ToolCallState): string | undefined {
+	const v = readToolCallMeta(tc).subagentAgentName;
+	return v && v.length > 0 ? v : undefined;
 }
 
 /**
@@ -86,16 +87,16 @@ function getMcpAppData(tc: ToolCallState, _sessionResource: URI): ChatMcpAppData
 	if (tc.contributor?.kind !== ToolCallContributorKind.MCP) {
 		return undefined;
 	}
-	const ui = tc._meta?.ui;
-	if (!ui || typeof ui !== 'object') {
+	const ui = readToolCallMeta(tc).ui;
+	if (!ui) {
 		return undefined;
 	}
-	const resourceUri = (ui as { resourceUri?: unknown }).resourceUri;
-	if (typeof resourceUri !== 'string' || resourceUri.length === 0) {
+	const resourceUri = ui.resourceUri;
+	if (resourceUri.length === 0) {
 		return undefined;
 	}
-	const channelValue = (ui as { channel?: unknown }).channel;
-	if (typeof channelValue !== 'string' || channelValue.length === 0) {
+	const channelValue = ui.channel;
+	if (channelValue === undefined || channelValue.length === 0) {
 		// No channel yet — the App's sub-RPCs would have nowhere to go.
 		// Skip mounting until the customization reaches Ready and the
 		// producer re-emits with the channel populated.
@@ -183,7 +184,7 @@ export function usageInfoToChatUsage(usage: UsageInfo | undefined): IChatUsage |
 }
 
 function getCopilotCredits(usage: UsageInfo | undefined): number | undefined {
-	const meta = usage?._meta as UsageInfoMeta | undefined;
+	const meta = readUsageInfoMeta(usage);
 	const totalNanoAiu = meta?.copilotUsage?.totalNanoAiu;
 	if (typeof totalNanoAiu === 'number' && totalNanoAiu >= 0) {
 		return totalNanoAiu / 1_000_000_000;
@@ -243,7 +244,7 @@ function mapAccountQuotaSnapshot(snapshot: AccountQuotaSnapshot): IQuotaSnapshot
  * service. Returns `undefined` when no usable snapshot is present.
  */
 export function usageInfoToQuotas(usage: UsageInfo | undefined): IAgentHostQuotaUpdate | undefined {
-	const meta = usage?._meta as UsageInfoMeta | undefined;
+	const meta = readUsageInfoMeta(usage);
 	const snapshots = meta?.quotaSnapshots;
 	if (!snapshots) {
 		return undefined;
@@ -363,7 +364,7 @@ export function turnsToHistory(backendSession: URI, turns: readonly Turn[], part
 		// consistently with the live agent result.
 		let errorDetails: IChatResponseErrorDetails | undefined;
 		if (turn.state === TurnState.Error && turn.error) {
-			errorDetails = getChatErrorDetailsFromMeta(turn.error._meta, errorContext)
+			errorDetails = getChatErrorDetailsFromMeta(turn.error, errorContext)
 				?? { message: `Error: (${turn.error.errorType}) ${turn.error.message}` };
 		}
 

--- a/src/vs/workbench/contrib/chat/common/chatErrorMessages.ts
+++ b/src/vs/workbench/contrib/chat/common/chatErrorMessages.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from '../../../../nls.js';
+import type { ErrorInfo } from '../../../../platform/agentHost/common/state/protocol/state.js';
 import { ChatEntitlement } from '../../../services/chat/common/chatEntitlementService.js';
 import { ChatErrorLevel, IChatResponseErrorDetails } from './chatService/chatService.js';
 
@@ -345,7 +346,8 @@ function isForwardedChatError(value: unknown): value is IForwardedChatError {
  * pass an {@link IChatErrorContext} (resolved from `IChatEntitlementService`)
  * whose fields take precedence over the values forwarded in `_meta`.
  */
-export function getChatErrorDetailsFromMeta(meta: Record<string, unknown> | undefined, context?: IChatErrorContext): IChatResponseErrorDetails | undefined {
+export function getChatErrorDetailsFromMeta(error: ErrorInfo | undefined, context?: IChatErrorContext): IChatResponseErrorDetails | undefined {
+	const meta = error?._meta;
 	const chatError = meta?.chatError;
 	if (!isForwardedChatError(chatError)) {
 		return undefined;

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -18,7 +18,7 @@ import { Range } from '../../../../../../editor/common/core/range.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IAgentCreateSessionConfig, IAgentHostService, IAgentSessionMetadata, AgentSession } from '../../../../../../platform/agentHost/common/agentService.js';
-import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/agentFeedbackAttachments.js';
+import { AgentFeedbackAttachmentDisplayKind, AgentFeedbackAttachmentMetadataKey } from '../../../../../../platform/agentHost/common/meta/agentFeedbackAttachments.js';
 import { ActionType, isSessionAction, isChatAction, type ActionEnvelope, type IRootConfigChangedAction, type SessionAction, type ChatAction, type TerminalAction, type INotification, type IToolCallConfirmedAction, type ITurnStartedAction, type ClientAnnotationsAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import type { IStateSnapshot } from '../../../../../../platform/agentHost/common/state/sessionProtocol.js';
 import { CustomizationType, type ClientPluginCustomization, type ToolDefinition } from '../../../../../../platform/agentHost/common/state/protocol/state.js';

--- a/src/vs/workbench/contrib/chat/test/common/chatErrorMessages.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatErrorMessages.test.ts
@@ -16,6 +16,12 @@ import {
 } from '../../common/chatErrorMessages.js';
 import { ChatEntitlement } from '../../../../services/chat/common/chatEntitlementService.js';
 import { ChatErrorLevel } from '../../common/chatService/chatService.js';
+import type { ErrorInfo } from '../../../../../platform/agentHost/common/state/protocol/state.js';
+
+/** Wraps a `_meta` bag in a minimal {@link ErrorInfo} so the reader sees the right source type. */
+function errorInfo(meta: Record<string, unknown> | undefined): ErrorInfo {
+	return { errorType: 'e', message: 'm', _meta: meta };
+}
 
 suite('ChatErrorMessages', () => {
 
@@ -25,13 +31,13 @@ suite('ChatErrorMessages', () => {
 
 		test('returns undefined when no meta or no chatError', () => {
 			assert.strictEqual(getChatErrorDetailsFromMeta(undefined), undefined);
-			assert.strictEqual(getChatErrorDetailsFromMeta({}), undefined);
-			assert.strictEqual(getChatErrorDetailsFromMeta({ chatError: {} }), undefined);
-			assert.strictEqual(getChatErrorDetailsFromMeta({ chatError: { fetchError: {} } }), undefined);
+			assert.strictEqual(getChatErrorDetailsFromMeta(errorInfo(undefined)), undefined);
+			assert.strictEqual(getChatErrorDetailsFromMeta(errorInfo({ chatError: {} })), undefined);
+			assert.strictEqual(getChatErrorDetailsFromMeta(errorInfo({ chatError: { fetchError: {} } })), undefined);
 		});
 
 		test('formats a forwarded rate-limit error', () => {
-			const details = getChatErrorDetailsFromMeta({
+			const details = getChatErrorDetailsFromMeta(errorInfo({
 				chatError: {
 					fetchError: {
 						type: ChatFetchResponseType.RateLimited,
@@ -40,7 +46,7 @@ suite('ChatErrorMessages', () => {
 					},
 					copilotPlan: 'free',
 				},
-			});
+			}));
 			assert.deepStrictEqual(details, {
 				code: ChatFetchResponseType.RateLimited,
 				message: 'You\'ve hit your session rate limit. Please upgrade your plan or wait 60 seconds for your limit to reset. [Learn More](https://aka.ms/github-copilot-rate-limit-error)',
@@ -50,12 +56,12 @@ suite('ChatErrorMessages', () => {
 		});
 
 		test('context overrides the forwarded plan (free user)', () => {
-			const details = getChatErrorDetailsFromMeta({
+			const details = getChatErrorDetailsFromMeta(errorInfo({
 				chatError: {
 					fetchError: { type: ChatFetchResponseType.QuotaExceeded, capiError: { code: 'quota_exceeded' } },
 					copilotPlan: 'business',
 				},
-			}, { copilotPlan: 'free' });
+			}), { copilotPlan: 'free' });
 			assert.strictEqual(details?.message, 'You\'ve reached your monthly chat messages quota. Upgrade to Copilot Pro or wait for your allowance to renew.');
 		});
 
@@ -66,7 +72,7 @@ suite('ChatErrorMessages', () => {
 		// side is caught here instead of silently failing to render.
 		test('accepts the payload shape and every type the node layer emits', () => {
 			const nodeTypes = ['quotaExceeded', 'rateLimited', 'canceled', 'badRequest', 'agent_unauthorized', 'notFound', 'failed', 'length'];
-			const resolved = nodeTypes.map(type => getChatErrorDetailsFromMeta({
+			const resolved = nodeTypes.map(type => getChatErrorDetailsFromMeta(errorInfo({
 				chatError: {
 					fetchError: {
 						type,
@@ -78,7 +84,7 @@ suite('ChatErrorMessages', () => {
 					copilotPlan: 'free',
 					isUsageBasedBilling: false,
 				},
-			})?.code);
+			}))?.code);
 			// Every node-emitted type resolves to a defined details object whose code is
 			// the fetch type (or, for quota, the more specific capiError code).
 			assert.deepStrictEqual(resolved, ['some_code', 'rateLimited', 'canceled', 'badRequest', 'agent_unauthorized', 'notFound', 'failed', 'length']);


### PR DESCRIPTION
## What

The Agent Host Protocol (AHP) uses an open `_meta` property (`Record<string, unknown>`) on many protocol/state messages to carry well-known extra data exchanged between server and client. Until now it was read in an ad-hoc, untyped way scattered across the agent host, sessions, and chat layers. This PR centralizes and type-checks all of that access.

## Changes

- **Typed reader/builder per slot, grouped in one place.** Each well-known `_meta` slot now has a typed reader (and matching builder where we serialize) under `src/vs/platform/agentHost/common/meta/`. Nothing reads `_meta` field-by-field in an untyped way anymore.
- **Readers take the parent object, not the raw bag.** Readers like `readToolCallMeta`, `readAgentCustomizationMeta`, `readCompletionAttachmentMeta`, `readFeedbackAnnotationMeta`, `readUsageInfoMeta`, `readHostBuildInfo`, `readAgentModelPricingMeta`, and `getChatErrorDetailsFromMeta` now accept their parent (`ToolCallState`, `AgentCustomization`, `RootState`, `ErrorInfo`, `UsageInfo`, …) and read `source._meta` internally. Passing the wrong slot's bag is now a **compile error**.
  - `readSessionGitState` is a documented exception — it still takes a raw `SessionMeta` value because the sessions provider holds a detached `_meta` snapshot with no owning state object.
- **De-duplicated the feedback-annotation slot.** The sessions browser layer previously re-declared and re-validated a parallel copy of the feedback `_meta` shape. It now calls the shared validating reader and maps the validated wire shape into its client view via total enum-mapping tables, so the wire shape + validation live in exactly one place.
- **Removed a serialize-then-reparse round-trip** in the Claude subagent signal path (`claudeSubagentSignals` / `claudeToolDisplay`) in favor of a direct typed builder.
- **New enforcement rule.** Added a syntactic local ESLint rule `code-no-untyped-meta-access` (in `.eslint-plugin-local/`, wired in `eslint.config.js`) that flags member access off `x._meta` and casts of `x._meta`, scoped to the agent host / agent sessions / sessions surface. It's name-based (no type-aware lint cost) and ignores test files and vendored/generated protocols.

## Why

`_meta` is an open bag by design, which made it easy to read undocumented, unvalidated, untyped data anywhere. Centralizing the shapes, validating in one place, and making readers parent-typed gives us a single source of truth per slot, prevents cross-slot mix-ups at compile time, and the lint rule keeps new untyped access from creeping back in.

## Notes for reviewers

- This is intended to be **behavior-preserving** — it relocates and type-tightens `_meta` access rather than changing what data flows. A GPT-5.5 review pass specifically looking for regressions found none.
- Verification: `npm run typecheck-client` green, ESLint clean on the changed surface, and the affected unit suites pass (`agentMetaReaders`, `hostBuildInfoMeta`, `chatErrorMessages`, `ClaudeAgent`, `claudeSubagentSignals`, `claudeReplayMapper`, `claudeMapSessionEvents`, `stateToProgressAdapter`, `AgentFeedbackServerTools`).
- The renamed files (`agentFeedbackAnnotations.ts`, `agentFeedbackAttachments.ts` → `common/meta/`) show as rename+edit.

(Written by Copilot)