### PR TITLE
sessions: add command palette entry to update an incompatible remote agent host server

### DIFF
--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -21,7 +21,7 @@ import { SnippetController2 } from '../../../../../editor/contrib/snippet/browse
 import { IEditorService } from '../../../../../workbench/services/editor/common/editorService.js';
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
-import { IRemoteAgentHostService, parseRemoteAgentHostInput, RemoteAgentHostEntryType, RemoteAgentHostInputValidationError, RemoteAgentHostsEnabledSettingId } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IRemoteAgentHostService, parseRemoteAgentHostInput, RemoteAgentHostConnectionStatus, RemoteAgentHostEntryType, RemoteAgentHostInputValidationError, RemoteAgentHostsEnabledSettingId } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { ISSHRemoteAgentHostService, SSHAuthMethod, type ISSHAgentHostConfig, type ISSHAgentHostConnection, type ISSHResolvedConfig } from '../../../../../platform/agentHost/common/sshRemoteAgentHost.js';
 import { ITunnelAgentHostService, TUNNEL_ADDRESS_PREFIX, type ITunnelInfo } from '../../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { IWSLRemoteAgentHostService, WSL_INSTALL_DOCS_URL, type IWSLDistro } from '../../../../../platform/agentHost/common/wslRemoteAgentHost.js';
@@ -37,6 +37,7 @@ import { Menus } from '../../../../browser/menus.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { IAgentHostSessionsProvider, isAgentHostProvider } from '../../../../common/agentHostSessionsProvider.js';
+import { runServerUpgrade } from './remoteHostOptions.js';
 import { SESSION_WORKSPACE_GROUP_REMOTE } from '../../../../services/sessions/common/session.js';
 import { ISessionsPartService } from '../../../../services/sessions/browser/sessionsPartService.js';
 
@@ -49,6 +50,7 @@ export const RemoteAgentHostCommandIds = {
 	connectViaTunnel: 'workbench.action.sessions.connectViaTunnel',
 	connectViaWSL: 'workbench.action.sessions.connectViaWSL',
 	manageRemoteAgentHosts: 'workbench.action.sessions.manageRemoteAgentHosts',
+	updateRemoteAgentHost: 'workbench.action.sessions.updateRemoteAgentHost',
 } as const;
 
 registerAction2(class extends Action2 {
@@ -1175,5 +1177,67 @@ registerAction2(class extends Action2 {
 		if (result === 'back') {
 			onBack?.();
 		}
+	}
+});
+
+/**
+ * Force-update a remote agent host server that rejected our protocol
+ * version because it is running an old build. Connecting to such a host
+ * leaves it in the `incompatible` state; when the host was spawned by a
+ * VS Code CLI willing to receive upgrade signals it advertises an upgrade
+ * method, which this command invokes via the shared {@link runServerUpgrade}
+ * flow. Exposed in the command palette so the update is reachable without
+ * first opening the host's options quickpick.
+ */
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: RemoteAgentHostCommandIds.updateRemoteAgentHost,
+			title: localize2('updateRemoteAgentHost', "Update Remote Agent Host Server..."),
+			category: SessionsCategories.Sessions,
+			f1: true,
+			precondition: ContextKeyExpr.equals(`config.${RemoteAgentHostsEnabledSettingId}`, true),
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const sessionsProvidersService = accessor.get(ISessionsProvidersService);
+		const quickInputService = accessor.get(IQuickInputService);
+		const notificationService = accessor.get(INotificationService);
+		const instantiationService = accessor.get(IInstantiationService);
+
+		const upgradable = sessionsProvidersService.getProviders()
+			.filter(isAgentHostProvider)
+			.filter(provider => !!provider.remoteAddress)
+			.map(provider => {
+				const status = provider.connectionStatus?.get();
+				const method = RemoteAgentHostConnectionStatus.isIncompatible(status) ? status.vscodeUpgradeMethod : undefined;
+				return method ? { provider, method } : undefined;
+			})
+			.filter((entry): entry is { provider: IAgentHostSessionsProvider; method: string } => !!entry);
+
+		if (upgradable.length === 0) {
+			notificationService.info(localize('updateRemoteAgentHost.none', "No remote agent hosts need updating."));
+			return;
+		}
+
+		let target = upgradable[0];
+		if (upgradable.length > 1) {
+			type UpdateHostPickItem = IQuickPickItem & { entry: { provider: IAgentHostSessionsProvider; method: string } };
+			const picked = await quickInputService.pick<UpdateHostPickItem>(
+				upgradable.map(entry => ({
+					label: entry.provider.label,
+					description: entry.provider.remoteAddress,
+					entry,
+				})),
+				{ placeHolder: localize('updateRemoteAgentHost.pick', "Select a remote agent host to update") },
+			);
+			if (!picked) {
+				return;
+			}
+			target = picked.entry;
+		}
+
+		await instantiationService.invokeFunction(runServerUpgrade, target.provider, target.method);
 	}
 });

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -1206,18 +1206,27 @@ registerAction2(class extends Action2 {
 		const notificationService = accessor.get(INotificationService);
 		const instantiationService = accessor.get(IInstantiationService);
 
-		const upgradable = sessionsProvidersService.getProviders()
+		const remoteHosts = sessionsProvidersService.getProviders()
 			.filter(isAgentHostProvider)
-			.filter(provider => !!provider.remoteAddress)
+			.filter(provider => !!provider.remoteAddress);
+		let incompatibleCount = 0;
+		const upgradable = remoteHosts
 			.map(provider => {
 				const status = provider.connectionStatus?.get();
-				const method = RemoteAgentHostConnectionStatus.isIncompatible(status) ? status.vscodeUpgradeMethod : undefined;
-				return method ? { provider, method } : undefined;
+				if (!RemoteAgentHostConnectionStatus.isIncompatible(status)) {
+					return undefined;
+				}
+				incompatibleCount++;
+				return status.vscodeUpgradeMethod ? { provider, method: status.vscodeUpgradeMethod } : undefined;
 			})
 			.filter((entry): entry is { provider: IAgentHostSessionsProvider; method: string } => !!entry);
 
 		if (upgradable.length === 0) {
-			notificationService.info(localize('updateRemoteAgentHost.none', "No remote agent hosts need updating."));
+			// Distinguish "nothing is incompatible" from "incompatible hosts exist
+			// but none was spawned by a VS Code CLI that can update it in place".
+			notificationService.info(incompatibleCount > 0
+				? localize('updateRemoteAgentHost.noneUpgradable', "No remote agent hosts can be updated from here. Incompatible hosts must be updated manually, then reconnected.")
+				: localize('updateRemoteAgentHost.none', "No remote agent hosts need updating."));
 			return;
 		}
 


### PR DESCRIPTION
## What

Exposes the existing remote agent host **server upgrade** flow ("Update Server") as a command palette command: **"Update Remote Agent Host Server…"** (`workbench.action.sessions.updateRemoteAgentHost`).

## Why

When you connect to a remote agent host that's running an old build, the protocol-version handshake is rejected and the host lands in the `incompatible` state. If that host was spawned by a VS Code CLI willing to receive upgrade signals, it advertises an in-band upgrade method (`_vscodeUpgrade`). Until now that upgrade was only reachable from:

- the transient "Cannot connect to … — Update Server" notification, or
- the per-host options quickpick ("Update Server" item).

There was no command palette entry, so the update was hard to trigger on demand.

## What changed

In `src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions.ts`:

- Added command id `updateRemoteAgentHost` and registered a new `Action2`:
  - `f1: true`, `category: Sessions`, gated on the same `chat.remoteAgentHostsEnabled` precondition as the sibling remote-host commands.
- The command collects remote providers currently in the `incompatible` state that advertise an upgrade method, then:
  - shows an info message if none need updating,
  - runs the upgrade directly if exactly one,
  - shows a quickpick to choose if there are several.
- Reuses the existing shared `runServerUpgrade` flow (progress notification, restart countdown, reconnect) so behavior matches the other entry points.

Registered in `remoteAgentHostActions.ts` (loaded by both the desktop and web sessions entry points) so it's available everywhere.

## Reviewer notes

- The command can only act on hosts that advertise a CLI-managed upgrade method (incompatible hosts spawned by a willing VS Code CLI) — that's the only case where the upgrade method is known, matching exactly the existing "Update Server" capability.
- Only adds a new gated command; no behavior change to existing flows.

## Testing

Launch the CLI agent host pinned to an old build via `VSCODE_CLI_INITIAL_AH_VERSION=<old-commit-sha> code-insiders agent host`, add it as a remote agent host (it'll show as Incompatible), then run **"Update Remote Agent Host Server…"** from the command palette to drive the upgrade + reconnect.

(Written by Copilot)
