### PR TITLE
agentHost: route comments tools to the main session resource

### DIFF
--- a/src/vs/platform/agentHost/node/shared/agentFeedbackServerTools.ts
+++ b/src/vs/platform/agentHost/node/shared/agentFeedbackServerTools.ts
@@ -8,7 +8,7 @@ import { FEEDBACK_ANNOTATION_META_KEY, VIEW_UNREVIEWED_COMMENTS_TOOL_NAME, type 
 import { buildAnnotationsUri } from '../../common/annotationsUri.js';
 import type { AnnotationsAction } from '../../common/state/sessionActions.js';
 import { ActionType } from '../../common/state/protocol/common/actions.js';
-import type { Annotation, AnnotationsState, StringOrMarkdown, TextRange, ToolDefinition } from '../../common/state/sessionState.js';
+import { parseChatUri, type Annotation, type AnnotationsState, type StringOrMarkdown, type TextRange, type ToolDefinition } from '../../common/state/sessionState.js';
 import type { IServerToolGroup } from './agentServerToolHost.js';
 
 /**
@@ -515,10 +515,15 @@ export const feedbackServerToolGroup: IServerToolGroup = {
 		return feedbackToolRequiresConfirmation(toolName);
 	},
 	execute(stateManager, sessionUri, toolName, rawArgs): string {
-		const annotationsUri = buildAnnotationsUri(sessionUri);
+		// A session can contain multiple chats, each addressed by its own
+		// `ahp-chat` URI but sharing the same context/workspace. Comments belong
+		// to the session as a whole, so always resolve a chat URI back to its
+		// owning session and operate on the main session's annotations channel.
+		const mainSessionUri = parseChatUri(sessionUri)?.session ?? sessionUri;
+		const annotationsUri = buildAnnotationsUri(mainSessionUri);
 		const snapshot = stateManager.getSnapshot(annotationsUri);
 		const state: AnnotationsState = (snapshot?.state as AnnotationsState | undefined) ?? { annotations: [] };
-		const outcome = applyFeedbackTool(state, sessionUri, toolName, rawArgs);
+		const outcome = applyFeedbackTool(state, mainSessionUri, toolName, rawArgs);
 		for (const action of outcome.actions) {
 			stateManager.dispatchServerAction(annotationsUri, action);
 		}

--- a/src/vs/platform/agentHost/test/node/agentFeedbackServerTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentFeedbackServerTools.test.ts
@@ -9,7 +9,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { NullLogService } from '../../../log/common/log.js';
 import { FEEDBACK_ANNOTATION_META_KEY } from '../../common/agentFeedbackAnnotations.js';
 import { ActionType } from '../../common/state/protocol/common/actions.js';
-import { Annotation, AnnotationsState, SessionStatus, SessionSummary } from '../../common/state/sessionState.js';
+import { Annotation, AnnotationsState, SessionStatus, SessionSummary, buildChatUri } from '../../common/state/sessionState.js';
 import { buildAnnotationsUri } from '../../common/annotationsUri.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 import { AgentServerToolHost } from '../../node/shared/agentServerToolHost.js';
@@ -258,6 +258,28 @@ suite('AgentFeedbackServerTools', () => {
 			const state = snapshot!.state as AnnotationsState;
 			assert.strictEqual(state.annotations.length, 1);
 			assert.strictEqual(state.annotations[0].entries[0].text, 'hello');
+		});
+
+		test('executeTool stores comments on the main session when invoked from a chat URI', () => {
+			const chatUri = buildChatUri(sessionResource, 'peer-chat-1');
+			host.executeTool(chatUri, addCommentToolName, {
+				resourceUri: fileUri,
+				range: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 2 },
+				text: 'from a peer chat',
+			});
+			// The comment must land on the main session's annotations channel,
+			// not on the individual chat's.
+			assert.strictEqual(manager.getSnapshot(buildAnnotationsUri(chatUri)), undefined);
+			const state = manager.getSnapshot(buildAnnotationsUri(sessionResource))!.state as AnnotationsState;
+			assert.strictEqual(state.annotations.length, 1);
+			const meta = state.annotations[0]._meta?.[FEEDBACK_ANNOTATION_META_KEY] as { sessionResource: string };
+			assert.deepStrictEqual({
+				text: state.annotations[0].entries[0].text,
+				sessionResource: meta.sessionResource,
+			}, {
+				text: 'from a peer chat',
+				sessionResource,
+			});
 		});
 
 		test('advertise publishes the server tools as server tools', () => {


### PR DESCRIPTION
A session in the agent host can contain multiple peer chats that share the same context/workspace, each addressed by its own `ahp-chat://<chatId>/<base64(sessionUri)>` URI.

The feedback (comments) server tools (`addComment`, `listComments`, `deleteComments`, etc.) received whichever chat URI invoked them, so comments raised from a non-default chat were stored on that individual chat's annotations channel instead of the session's. As a result they wouldn't show up as the session's comments.

## Change
In `feedbackServerToolGroup.execute`, resolve the incoming URI back to its owning session via `parseChatUri(sessionUri)?.session ?? sessionUri` before building the annotations channel URI and recording `sessionResource`. Comments now always target the main session, regardless of which chat invoked the tool. Non-chat / default-session URIs are unaffected (`parseChatUri` returns `undefined`, falling back to the original URI).

Added a unit test verifying that invoking `addComment` from a chat URI lands the annotation on the main session's channel and nothing on the chat's channel.
