### PR TITLE
sessions: hide session picker groups when no duplicate session names

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -241,7 +241,17 @@ export class SessionTypePicker extends Disposable {
 				groups.set(groupTitle, [folderType]);
 			}
 		}
-		const showSectionHeaders = groups.size > 1;
+		// Section headers exist to disambiguate session types that share a
+		// label across providers (e.g. two providers both offering "Claude").
+		// When every type's label is unique there is nothing to disambiguate,
+		// so render a flat list without group headers even if multiple
+		// providers contribute.
+		const labelCounts = new Map<string, number>();
+		for (const { sessionType } of folderTypes) {
+			labelCounts.set(sessionType.label, (labelCounts.get(sessionType.label) ?? 0) + 1);
+		}
+		const hasDuplicateLabels = Array.from(labelCounts.values()).some(count => count > 1);
+		const showSectionHeaders = groups.size > 1 && hasDuplicateLabels;
 
 		const groupedItems: IActionListItem<ISessionTypePickerItem>[] = [];
 		for (const [groupTitle, types] of groups) {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -96,7 +96,7 @@ function normalizeSessionConfigValue(property: string, value: unknown, policyRes
 /** Copilot CLI session type */
 export const CopilotCLISessionType: ISessionType = {
 	id: 'copilotcli',
-	label: localize('copilotCLI', "Copilot CLI"),
+	label: localize('copilotCLI', "Copilot"),
 	icon: Codicon.copilot,
 };
 

--- a/test/smoke/src/areas/agentsWindow/agentsWindow.test.ts
+++ b/test/smoke/src/areas/agentsWindow/agentsWindow.test.ts
@@ -32,7 +32,7 @@ interface SessionConfig {
 }
 
 const SESSIONS: readonly SessionConfig[] = [
-	{ name: 'Copilot CLI', scenarioId: 'smoke-hello-copilot', reply: 'MOCKED_COPILOT_RESPONSE', scenarioId2: 'smoke-hello-copilot-2', reply2: 'MOCKED_COPILOT_RESPONSE_2', skipReply2: true },
+	{ name: 'Copilot', scenarioId: 'smoke-hello-copilot', reply: 'MOCKED_COPILOT_RESPONSE', scenarioId2: 'smoke-hello-copilot-2', reply2: 'MOCKED_COPILOT_RESPONSE_2', skipReply2: true },
 	{ name: 'Claude', scenarioId: 'smoke-hello-claude', reply: 'MOCKED_CLAUDE_RESPONSE', scenarioId2: 'smoke-hello-claude-2', reply2: 'MOCKED_CLAUDE_RESPONSE_2' },
 	{ name: 'Local', scenarioId: 'smoke-hello-local', reply: 'MOCKED_LOCAL_RESPONSE', scenarioId2: 'smoke-hello-local-2', reply2: 'MOCKED_LOCAL_RESPONSE_2' },
 ];
@@ -237,7 +237,7 @@ export function setup(logger: Logger) {
 					// race on when title generation lands. The sessions list also
 					// contains workspace folder group headers and historical
 					// sessions, so we can't just click the topmost row.
-					if (session.name === 'Copilot CLI') {
+					if (session.name === 'Copilot') {
 						await app.workbench.agentsWindow.activateSessionByLabel([firstPrompt, session.reply], session.reply);
 					}
 
@@ -249,8 +249,8 @@ export function setup(logger: Logger) {
 						// before sending (the workbench can auto-swap the slot to
 						// a fresh untitled session between `activateSessionByLabel`
 						// returning and the send-button click).
-						const expectedActiveLabel = session.name === 'Copilot CLI' ? session.reply : undefined;
-						const activeRowMatch = session.name === 'Copilot CLI' ? [firstPrompt, session.reply] : undefined;
+						const expectedActiveLabel = session.name === 'Copilot' ? session.reply : undefined;
+						const activeRowMatch = session.name === 'Copilot' ? [firstPrompt, session.reply] : undefined;
 						await app.workbench.agentsWindow.sendFollowUpMessage(
 							`hello again [scenario:${session.scenarioId2}]`,
 							undefined,
@@ -258,7 +258,7 @@ export function setup(logger: Logger) {
 							activeRowMatch,
 						);
 
-						const secondTurnTimeout = session.name === 'Copilot CLI' ? 180_000 : 60_000;
+						const secondTurnTimeout = session.name === 'Copilot' ? 180_000 : 60_000;
 						const text2 = await app.workbench.agentsWindow.waitForAssistantText(session.reply2, secondTurnTimeout);
 						logger.log(`Agents Window (${session.name}) response 2: ${text2}`);
 					} else {
@@ -313,7 +313,7 @@ export function setup(logger: Logger) {
 
 			await app.workbench.agentsWindow.startNewSession();
 			await app.workbench.agentsWindow.waitForNewSessionView();
-			await app.workbench.agentsWindow.selectSessionType('Copilot CLI');
+			await app.workbench.agentsWindow.selectSessionType('Copilot');
 
 			const requestsBefore = mockServer.requestCount();
 			await app.workbench.agentsWindow.submitNewSessionPrompt(`hello world [scenario:${COPILOT_SANDBOX_SCENARIO_ID}]`);


### PR DESCRIPTION
## What
In the session type picker (the "New chat with …" dropdown in the Agents window), group/section headers such as **Local Agent Host** and **Copilot Chat** are now shown only when two or more session types share the same name. When every session type name is unique, the picker renders a flat list without group headers — even when multiple providers contribute types.

## Why
Section headers exist solely to disambiguate session types that share a label across providers (e.g. two providers both offering "Claude"). When all the names are already unique, the headers add visual noise without conveying any extra information.

## How
In `SessionTypePicker._showPicker`, the `showSectionHeaders` condition changed from `groups.size > 1` to `groups.size > 1 && hasDuplicateLabels`, where `hasDuplicateLabels` is computed by counting session-type labels across the folder's types.

## Notes for reviewers
- Behavior is unchanged when duplicate names exist (headers + accessibility group labels still render).
- Scope is limited to a single file in `src/vs/sessions`.
