### PR TITLE
Add info logs to diagnose stuck "running" session status

### DIFF
--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -1106,7 +1106,7 @@ export class AgentService extends Disposable implements IAgentService {
 		if (!targetState || targetState.activeTurn !== undefined) {
 			return;
 		}
-		this._logService.trace(`[AgentService] Evicting idle session: ${evictionTargetKey} (triggered by unsubscribe of ${key})`);
+		this._logService.info(`[AgentService] Evicting idle session: ${evictionTargetKey} (triggered by unsubscribe of ${key})`);
 		// Also evict any sibling subagent entries cached under the parent: their
 		// authoritative state is the parent's turn tree, and dropping the parent
 		// would leave them orphaned.

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -805,7 +805,7 @@ export class AgentSideEffects extends Disposable {
 
 				const state = this._stateManager.getSessionState(channel);
 				if (!state) {
-					this._logService.info(`[AgentSideEffects] Turn started for session not in state manager: ${channel} — status/summary updates will be dropped`);
+					this._logService.info(`[AgentSideEffects] Turn started for session not in state manager: ${channel}, turnId=${action.turnId} - status/summary updates may be dropped unless the session is restored`);
 				}
 				this._titleController.seedTitleFromFirstMessage(channel, action.message.text, chatChannel);
 

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -804,6 +804,9 @@ export class AgentSideEffects extends Disposable {
 				}
 
 				const state = this._stateManager.getSessionState(channel);
+				if (!state) {
+					this._logService.info(`[AgentSideEffects] Turn started for session not in state manager: ${channel} — status/summary updates will be dropped`);
+				}
 				this._titleController.seedTitleFromFirstMessage(channel, action.message.text, chatChannel);
 
 				const agent = this._options.getAgent(channel);


### PR DESCRIPTION
## Problem

A background agent session can keep showing as **running** in the UI after the agent has clearly completed. The mechanism: when an idle, unsubscribed session is evicted from the AHP state manager (`AgentService._maybeEvictIdleSession`) but the Copilot agent still holds a cached SDK session, the agent runs the next turn directly without re-registering the session in AHP state. At turn end, status/summary updates are dispatched against a session the state manager no longer knows about and are silently dropped — leaving the session badge stuck on "running".

This was painful to diagnose from a standard log capture because the key lifecycle event (idle-session eviction) is only logged at `trace`, while its inverse (`Restored session …`) is logged at `info`. You could see sessions enter memory but not leave.

## Changes

Two info-level logs that would have turned this into a quick diagnosis, both genuine lifecycle events (not per-token noise):

1. **Promote idle-session eviction from `trace` → `info`** (`AgentService`). Mirrors the existing info-level `Restored session …` log so the in-memory session lifecycle (`restore → evict → restore → …`) is reconstructable from info logs alone.
2. **Log the desync at turn start** (`AgentSideEffects`, `ChatTurnStarted` handler). When a turn runs for a session absent from the state manager, log it at the moment it occurs — pinpointing cause→effect rather than only surfacing later as the collateral "unknown session" warnings at turn end. This fires only in the buggy case, so it adds essentially no noise.

These do not change behavior; they only surface existing state transitions. The actual root-cause fix (keeping the SDK session cache and AHP state in sync) is intentionally out of scope here.

(Written by Copilot)