### PR TITLE
Preserve collapsed state in SCM repositories view

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmRepositoriesViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmRepositoriesViewPane.ts
@@ -797,9 +797,9 @@ export class SCMRepositoriesViewPane extends ViewPane {
 			return;
 		}
 
-		const isParentCollapsed = this.tree.hasNode(parentRepository) && this.tree.isCollapsed(parentRepository);
+		const wasParentCollapsed = this.tree.hasNode(parentRepository) && this.tree.isCollapsed(parentRepository);
 		await this.updateChildren(parentRepository);
-		if (!isParentCollapsed) {
+		if (!wasParentCollapsed && this.tree.hasNode(parentRepository) && !this.tree.isCollapsed(parentRepository)) {
 			await this.expand(parentRepository);
 		}
 	}

--- a/src/vs/workbench/contrib/scm/browser/scmRepositoriesViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmRepositoriesViewPane.ts
@@ -555,6 +555,7 @@ export class SCMRepositoriesViewPane extends ViewPane {
 		this.treeIdentityProvider = new RepositoryTreeIdentityProvider();
 		this.treeDataSource = this.instantiationService.createInstance(RepositoryTreeDataSource);
 		this._register(this.treeDataSource);
+		const expanded = Array.isArray(viewState?.expanded) ? viewState.expanded : undefined;
 
 		this.tree = this.instantiationService.createInstance(
 			WorkbenchCompressibleAsyncDataTree,
@@ -574,15 +575,18 @@ export class SCMRepositoriesViewPane extends ViewPane {
 				collapseByDefault: (e: unknown) => {
 					if (this.scmViewService.explorerEnabledConfig.get() === false) {
 						if (isSCMRepository(e) && e.provider.parentId === undefined) {
+							if (expanded) {
+								return expanded.indexOf(this.treeIdentityProvider.getId(e)) === -1;
+							}
 							return false;
 						}
 						return true;
 					}
 
 					// Explorer mode
-					if (viewState?.expanded && (isSCMRepository(e) || isSCMArtifactGroupTreeElement(e) || isSCMArtifactTreeElement(e))) {
+					if (expanded && (isSCMRepository(e) || isSCMArtifactGroupTreeElement(e) || isSCMArtifactTreeElement(e))) {
 						// Only expand repositories/artifact groups/artifacts that were expanded before
-						return viewState.expanded.indexOf(this.treeIdentityProvider.getId(e)) === -1;
+						return expanded.indexOf(this.treeIdentityProvider.getId(e)) === -1;
 					} else if (isSCMArtifactNode(e)) {
 						// Only expand artifact folders as they are compressed by default
 						return !(e.childrenCount === 1 && Iterable.first(e.children)?.element === undefined);
@@ -793,8 +797,11 @@ export class SCMRepositoriesViewPane extends ViewPane {
 			return;
 		}
 
+		const isParentCollapsed = this.tree.hasNode(parentRepository) && this.tree.isCollapsed(parentRepository);
 		await this.updateChildren(parentRepository);
-		await this.expand(parentRepository);
+		if (!isParentCollapsed) {
+			await this.expand(parentRepository);
+		}
 	}
 
 	private updateBodySize(contentHeight: number, visibleCount?: number): void {


### PR DESCRIPTION
Fixes #322318

## Summary

The SCM Repositories view currently ignores the saved tree expansion state for top-level repositories when repository explorer mode is disabled. Top-level repositories are always expanded by default, which can reveal worktree entries again after reopening the Source Control sidebar even when the stored tree state has no expanded repositories.

This change makes the non-explorer Repositories view honor the saved `scm.repositoriesViewState.expanded` list for top-level repositories when it exists. If there is no saved expanded state, the existing default behavior is preserved and top-level repositories still expand by default.

Current behavior: the worktree toggle state is not preserved.

https://github.com/user-attachments/assets/6b4ea916-210e-48f3-831e-fc2112b830df

With this PR: the worktree toggle state is preserved.

https://github.com/user-attachments/assets/d245d616-7fcd-4660-bd6d-b5e11047e525

## Validation

- `npm run typecheck-client`
- `npm run eslint -- src/vs/workbench/contrib/scm/browser/scmRepositoriesViewPane.ts`