### PR TITLE
Sandbox: force execution in sandbox before model elevation using ForceExecuteInSandbox setting

### DIFF
--- a/src/vs/platform/sandbox/common/settings.ts
+++ b/src/vs/platform/sandbox/common/settings.ts
@@ -10,6 +10,7 @@ export const enum AgentSandboxSettingId {
 	AgentSandboxEnabled = 'chat.agent.sandbox.enabled',
 	AgentSandboxWindowsEnabled = 'chat.agent.sandbox.enabledWindows',
 	AgentSandboxAllowUnsandboxedCommands = 'chat.agent.sandbox.allowUnsandboxedCommands',
+	AgentSandboxForceFirstExecutionInSandbox = 'chat.agent.sandbox.forceFirstExecutionInSandbox',
 	AgentSandboxRetryWithAllowNetworkRequests = 'chat.agent.sandbox.retryWithAllowNetworkRequests',
 	AgentSandboxAllowAutoApprove = 'chat.agent.sandbox.allowAutoApprove',
 	AgentSandboxLinuxFileSystem = 'chat.agent.sandbox.fileSystem.linux',

--- a/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
@@ -195,13 +195,14 @@ export class TerminalSandboxEngine extends Disposable {
 		return { allowedDomains, deniedDomains };
 	}
 
-	async wrapCommand(command: string, requestUnsandboxedExecution?: boolean, shell?: string, cwd?: URI, commandDetails?: readonly ITerminalSandboxCommand[], requestAllowNetwork?: boolean): Promise<ITerminalSandboxWrapResult> {
+	async wrapCommand(command: string, requestUnsandboxedExecution?: boolean, shell?: string, cwd?: URI, commandDetails?: readonly ITerminalSandboxCommand[], requestAllowNetwork?: boolean, forceSandboxed: boolean = false): Promise<ITerminalSandboxWrapResult> {
 		const allowUnsandboxedCommands = this._areUnsandboxedCommandsAllowed();
 		const retryWithAllowNetworkRequests = this._areRetryWithAllowNetworkRequestsAllowed();
-		const shouldInspectBlockedDomains = requestUnsandboxedExecution !== true && requestAllowNetwork !== true && (retryWithAllowNetworkRequests || allowUnsandboxedCommands);
+		const shouldInspectBlockedDomains = !forceSandboxed && requestUnsandboxedExecution !== true && requestAllowNetwork !== true && (retryWithAllowNetworkRequests || allowUnsandboxedCommands);
 		const blockedDomainResult = shouldInspectBlockedDomains ? this._getBlockedDomains(command) : { blockedDomains: [], deniedDomains: [] };
-		const requiresPreflightAllowNetwork = retryWithAllowNetworkRequests && blockedDomainResult.blockedDomains.length > 0;
-		const allowNetworkForCommand = requestUnsandboxedExecution !== true && ((requestAllowNetwork === true && retryWithAllowNetworkRequests) || requiresPreflightAllowNetwork);
+		const requiresPreflightAllowNetwork = !forceSandboxed && retryWithAllowNetworkRequests && blockedDomainResult.blockedDomains.length > 0;
+		const commandWillRunSandboxed = forceSandboxed || requestUnsandboxedExecution !== true;
+		const allowNetworkForCommand = !forceSandboxed && commandWillRunSandboxed && ((requestAllowNetwork === true && retryWithAllowNetworkRequests) || requiresPreflightAllowNetwork);
 		const normalizedCommandDetails = this._normalizeCommandDetails(commandDetails ?? []);
 		const normalizedCommandKeywords = this._normalizeCommandKeywords(normalizedCommandDetails.map(c => c.keyword));
 		const currentReadAllowListPaths = getTerminalSandboxReadAllowListForCommands(this._os, this._commandAllowListKeywords, this._commandAllowListCommandDetails);
@@ -232,7 +233,7 @@ export class TerminalSandboxEngine extends Disposable {
 
 		// If per-command network relaxation is disabled, preserve the existing
 		// unsandbox fallback for commands with statically-detected blocked domains.
-		if (!requestUnsandboxedExecution && !retryWithAllowNetworkRequests && allowUnsandboxedCommands && blockedDomainResult.blockedDomains.length > 0) {
+		if (!forceSandboxed && !requestUnsandboxedExecution && !retryWithAllowNetworkRequests && allowUnsandboxedCommands && blockedDomainResult.blockedDomains.length > 0) {
 			return {
 				command: this._wrapUnsandboxedCommand(command, shell),
 				isSandboxWrapped: false,
@@ -243,7 +244,7 @@ export class TerminalSandboxEngine extends Disposable {
 		}
 
 		// If requestUnsandboxedExecution is true, need to ensure env variables set during sandbox still apply.
-		if (requestUnsandboxedExecution && allowUnsandboxedCommands) {
+		if (!forceSandboxed && requestUnsandboxedExecution && allowUnsandboxedCommands) {
 			return {
 				command: this._wrapUnsandboxedCommand(command, shell),
 				isSandboxWrapped: false,

--- a/src/vs/platform/sandbox/common/terminalSandboxService.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxService.ts
@@ -115,8 +115,10 @@ export interface ITerminalSandboxService {
 	 * but when provided they are used to derive command-specific read/write
 	 * allow-list entries. When explicitly requested, `requestAllowNetwork`
 	 * retains sandbox execution while using a network-unrestricted config.
+	 * `forceSandboxed` prevents an initial access elevation, including both
+	 * unsandboxed execution and unrestricted network access.
 	 */
-	wrapCommand(command: string, requestUnsandboxedExecution?: boolean, shell?: string, cwd?: URI, commandDetails?: readonly ITerminalSandboxCommand[], requestAllowNetwork?: boolean): Promise<ITerminalSandboxWrapResult>;
+	wrapCommand(command: string, requestUnsandboxedExecution?: boolean, shell?: string, cwd?: URI, commandDetails?: readonly ITerminalSandboxCommand[], requestAllowNetwork?: boolean, forceSandboxed?: boolean): Promise<ITerminalSandboxWrapResult>;
 	checkFileAccess(permission: TerminalSandboxFileAccessPermission, paths: readonly string[], precheckInputs?: ITerminalSandboxPrecheckInputs): Promise<ITerminalSandboxFileAccessCheckResult>;
 	getSandboxConfigPath(forceRefresh?: boolean, precheckInputs?: ITerminalSandboxPrecheckInputs): Promise<string | undefined>;
 	getTempDir(): URI | undefined;

--- a/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
+++ b/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
@@ -255,6 +255,23 @@ suite('TerminalSandboxEngine', () => {
 		deepStrictEqual(config.network, { allowedDomains: [], deniedDomains: [] });
 	});
 
+	test('forceSandboxed keeps filesystem and network sandbox restrictions', async () => {
+		setSandboxSetting(AgentSandboxSettingId.AgentSandboxRetryWithAllowNetworkRequests, true);
+		setSandboxSetting(AgentNetworkDomainSettingId.DeniedNetworkDomains, ['example.com']);
+		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, createHost()));
+
+		const wrapped = await engine.wrapCommand('curl https://example.com', true, 'bash', undefined, undefined, true, true);
+		const configPath = await engine.getSandboxConfigPath();
+		ok(configPath, 'Config path should be defined');
+		const config = JSON.parse(createdFiles.get(configPath)!);
+
+		strictEqual(wrapped.isSandboxWrapped, true);
+		strictEqual(wrapped.requiresUnsandboxConfirmation, undefined);
+		strictEqual(wrapped.requiresAllowNetworkConfirmation, undefined);
+		deepStrictEqual(config.network, { allowedDomains: [], deniedDomains: ['example.com'] });
+		ok(config.filesystem.denyRead.includes(configPath), 'Filesystem sandbox policy should remain active');
+	});
+
 	test('blocked domains request sandboxed network access before execution when enabled', async () => {
 		setSandboxSetting(AgentSandboxSettingId.AgentSandboxRetryWithAllowNetworkRequests, true);
 		setSandboxSetting(AgentNetworkDomainSettingId.DeniedNetworkDomains, ['example.com']);

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -595,6 +595,10 @@ export interface IChatTerminalToolInvocationData {
 	requestUnsandboxedExecution?: boolean;
 	/** The model-provided reason for requesting sandbox bypass */
 	requestUnsandboxedExecutionReason?: string;
+	/** Whether an explicit unsandboxed request was deferred for an initial sandboxed execution. */
+	deferredUnsandboxedExecution?: boolean;
+	/** Whether an explicit unrestricted-network request was deferred for an initial sandboxed execution. */
+	deferredAllowNetworkRequest?: boolean;
 	/** Whether the terminal command was approved to run sandboxed with unrestricted network access */
 	requestAllowNetwork?: boolean;
 	/** The model-provided reason for requesting unrestricted network access within the sandbox */

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineRewriter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineRewriter.ts
@@ -20,6 +20,7 @@ export interface ICommandLineRewriterOptions {
 	os: OperatingSystem;
 	isBackground?: boolean;
 	requestUnsandboxedExecution?: boolean;
+	forceSandboxed?: boolean;
 	sandboxPrecheckInputs?: ITerminalSandboxPrecheckInputs;
 	requestAllowNetwork?: boolean;
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineSandboxRewriter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineSandboxRewriter.ts
@@ -24,7 +24,7 @@ export class CommandLineSandboxRewriter extends Disposable implements ICommandLi
 		}
 
 		const commandDetails = await this._parseCommandDetails(options);
-		const wrappedCommand = await this._sandboxService.wrapCommand(options.commandLine, options.requestUnsandboxedExecution, options.shell, options.cwd, commandDetails, options.requestAllowNetwork);
+		const wrappedCommand = await this._sandboxService.wrapCommand(options.commandLine, options.requestUnsandboxedExecution, options.shell, options.cwd, commandDetails, options.requestAllowNetwork, options.forceSandboxed);
 		return {
 			rewritten: wrappedCommand.command,
 			reasoning: wrappedCommand.requiresAllowNetworkConfirmation ? 'Wrapped command for sandbox execution with unrestricted network access' : wrappedCommand.requiresUnsandboxConfirmation ? 'Switched command to unsandboxed execution because the command includes a domain that is not in the sandbox allowlist' : 'Wrapped command for sandbox execution',

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -538,6 +538,18 @@ export interface IAutomaticAllowNetworkRetryOptions {
 	readonly output: string;
 }
 
+export interface IDeferredSandboxAccessRetryOptions {
+	readonly deferredUnsandboxedExecution: boolean;
+	readonly deferredAllowNetworkRequest: boolean;
+	readonly allowUnsandboxedCommands: boolean;
+	readonly retryWithAllowNetworkRequests: boolean;
+	readonly didSandboxWrapCommand: boolean;
+	readonly isPersistentSession: boolean;
+	readonly isBackgroundExecution: boolean;
+	readonly didTimeout: boolean;
+	readonly exitCode: number | undefined;
+}
+
 function shouldAutomaticallyRetrySandbox(options: IAutomaticSandboxRetryPredicateOptions): boolean {
 	return options.retryAllowed
 		&& options.didSandboxWrapCommand
@@ -576,6 +588,17 @@ export function shouldAutomaticallyRetryAllowNetworkInSandboxed(options: IAutoma
 		output: options.output,
 		outputLooksRetryable: outputLooksSandboxNetworkBlocked,
 	});
+}
+
+export function shouldRetryDeferredSandboxAccess(options: IDeferredSandboxAccessRetryOptions): boolean {
+	return (options.deferredUnsandboxedExecution && options.allowUnsandboxedCommands
+		|| options.deferredAllowNetworkRequest && options.retryWithAllowNetworkRequests)
+		&& options.didSandboxWrapCommand
+		&& !options.isPersistentSession
+		&& !options.isBackgroundExecution
+		&& !options.didTimeout
+		&& options.exitCode !== undefined
+		&& options.exitCode !== 0;
 }
 
 /**
@@ -761,6 +784,10 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 	private get _retryWithAllowNetworkRequests(): boolean {
 		return this._configurationService.getValue<boolean>(AgentSandboxSettingId.AgentSandboxRetryWithAllowNetworkRequests) === true;
+	}
+
+	private get _forceFirstExecutionInSandbox(): boolean {
+		return this._configurationService.getValue<boolean>(AgentSandboxSettingId.AgentSandboxForceFirstExecutionInSandbox) === true;
 	}
 
 	private get _allowSandboxAutoApprove(): boolean {
@@ -959,10 +986,14 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		const isSandboxEnabled = sandboxPrereqs.enabled;
 		const isSandboxAllowNetworkEnabled = isSandboxEnabled && await this._terminalSandboxService.isSandboxAllowNetworkEnabled();
 		const allowUnsandboxedCommands = this._getAllowToRunUnsandboxedCommands(args);
+		const forceFirstExecutionInSandbox = isSandboxEnabled && this._forceFirstExecutionInSandbox;
 		const explicitUnsandboxRequest = isSandboxEnabled && allowUnsandboxedCommands && args.requestUnsandboxedExecution === true;
-		const explicitAllowNetworkRequest = isSandboxEnabled && !isSandboxAllowNetworkEnabled && this._retryWithAllowNetworkRequests && !explicitUnsandboxRequest && args.requestAllowNetwork === true;
-		let requiresUnsandboxConfirmation = explicitUnsandboxRequest;
-		let requestUnsandboxedExecutionReason = explicitUnsandboxRequest ? args.requestUnsandboxedExecutionReason : undefined;
+		const deferredUnsandboxedExecution = explicitUnsandboxRequest && forceFirstExecutionInSandbox;
+		const requestedAllowNetwork = isSandboxEnabled && !isSandboxAllowNetworkEnabled && this._retryWithAllowNetworkRequests && (!explicitUnsandboxRequest || deferredUnsandboxedExecution) && args.requestAllowNetwork === true;
+		const deferredAllowNetworkRequest = requestedAllowNetwork && forceFirstExecutionInSandbox;
+		const explicitAllowNetworkRequest = requestedAllowNetwork && !deferredAllowNetworkRequest;
+		let requiresUnsandboxConfirmation = explicitUnsandboxRequest && !deferredUnsandboxedExecution;
+		let requestUnsandboxedExecutionReason = requiresUnsandboxConfirmation ? args.requestUnsandboxedExecutionReason : undefined;
 		let requiresAllowNetworkConfirmation = explicitAllowNetworkRequest;
 		let requestAllowNetworkReason = explicitAllowNetworkRequest ? args.requestAllowNetworkReason : undefined;
 
@@ -1035,6 +1066,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			requestUnsandboxedExecutionReason,
 			requestAllowNetwork: explicitAllowNetworkRequest,
 			requestAllowNetworkReason,
+			forceSandboxed: forceFirstExecutionInSandbox,
 			sandboxPrecheckInputs,
 		});
 		const rewrittenCommand: string | undefined = rewriteResult.rewrittenCommand;
@@ -1061,6 +1093,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			isBackground: executionOptions.persistentSession,
 			requestUnsandboxedExecution: requiresUnsandboxConfirmation,
 			requestUnsandboxedExecutionReason,
+			deferredUnsandboxedExecution,
+			deferredAllowNetworkRequest,
 			requestAllowNetwork: requiresAllowNetworkConfirmation,
 			requestAllowNetworkReason,
 			missingSandboxDependencies: missingDependencies,
@@ -1335,6 +1369,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		requestUnsandboxedExecutionReason?: string;
 		requestAllowNetwork: boolean;
 		requestAllowNetworkReason?: string;
+		forceSandboxed?: boolean;
 		sandboxPrecheckInputs?: ITerminalSandboxPrecheckInputs;
 	}): Promise<{
 		rewrittenCommand: string;
@@ -1364,6 +1399,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				isBackground: options.isBackground,
 				requestUnsandboxedExecution: requiresUnsandboxConfirmation,
 				requestAllowNetwork: options.requestAllowNetwork,
+				forceSandboxed: options.forceSandboxed,
 				sandboxPrecheckInputs: options.sandboxPrecheckInputs,
 			});
 			if (rewriteResult) {
@@ -1692,6 +1728,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			},
 			requestUnsandboxedExecution: requestUnsandboxedExecution || (requestAllowNetwork ? false : undefined),
 			requestUnsandboxedExecutionReason: requestUnsandboxedExecution ? rewrittenRetryReason : undefined,
+			deferredUnsandboxedExecution: undefined,
+			deferredAllowNetworkRequest: undefined,
 			requestAllowNetwork: requestAllowNetwork || undefined,
 			requestAllowNetworkReason: requestAllowNetwork ? rewrittenRetryReason : undefined,
 			terminalCommandUri: undefined,
@@ -2403,6 +2441,18 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			return altBufferResult;
 		}
 
+		const retryWithAllowNetworkRequests = isSandboxEnabled && !isSandboxAllowNetworkEnabled && this._retryWithAllowNetworkRequests;
+		const shouldRetryDeferredAccess = shouldRetryDeferredSandboxAccess({
+			deferredUnsandboxedExecution: toolSpecificData.deferredUnsandboxedExecution === true,
+			deferredAllowNetworkRequest: toolSpecificData.deferredAllowNetworkRequest === true,
+			allowUnsandboxedCommands,
+			retryWithAllowNetworkRequests,
+			didSandboxWrapCommand,
+			isPersistentSession: executionOptions.persistentSession,
+			isBackgroundExecution: isBackgroundExecution || didInputNeeded,
+			didTimeout,
+			exitCode,
+		});
 		const shouldAutoRetryUnsandboxed = shouldAutomaticallyRetryUnsandboxed({
 			allowUnsandboxedCommands,
 			didSandboxWrapCommand,
@@ -2414,7 +2464,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			output: terminalResult,
 		});
 		const shouldAutoRetryAllowNetwork = shouldAutomaticallyRetryAllowNetworkInSandboxed({
-			retryWithAllowNetworkRequests: isSandboxEnabled && !isSandboxAllowNetworkEnabled && this._retryWithAllowNetworkRequests,
+			retryWithAllowNetworkRequests,
 			didSandboxWrapCommand,
 			requestUnsandboxedExecution: args.requestUnsandboxedExecution === true,
 			requestAllowNetwork: args.requestAllowNetwork === true,
@@ -2425,11 +2475,22 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			output: terminalResult,
 		});
 
-		const automaticSandboxRetry = shouldAutoRetryAllowNetwork
-			? { retryKind: 'allowNetwork' as const, retryReason: automaticAllowNetworkRetryReason }
-			: shouldAutoRetryUnsandboxed
-				? { retryKind: 'unsandboxed' as const, retryReason: automaticUnsandboxRetryReason }
-				: undefined;
+		const shouldRetryDeferredAllowNetwork = toolSpecificData.deferredAllowNetworkRequest === true && retryWithAllowNetworkRequests;
+		const automaticSandboxRetry = shouldRetryDeferredAccess
+			? shouldRetryDeferredAllowNetwork
+				? {
+					retryKind: 'allowNetwork' as const,
+					retryReason: args.requestAllowNetworkReason ?? localize('runInTerminal.allowNetwork.deferredRetry.reason', 'The model requested unrestricted network access in the sandbox.'),
+				}
+				: {
+					retryKind: 'unsandboxed' as const,
+					retryReason: args.requestUnsandboxedExecutionReason ?? localize('runInTerminal.unsandboxed.deferredRetry.reason', 'The model requested unsandboxed execution.'),
+				}
+			: shouldAutoRetryAllowNetwork
+				? { retryKind: 'allowNetwork' as const, retryReason: automaticAllowNetworkRetryReason }
+				: shouldAutoRetryUnsandboxed
+					? { retryKind: 'unsandboxed' as const, retryReason: automaticUnsandboxRetryReason }
+					: undefined;
 		if (automaticSandboxRetry) {
 			const retryResult = await this._runAutomaticSandboxRetry({
 				...automaticSandboxRetry,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -602,6 +602,13 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 			}
 		}
 	},
+	[AgentSandboxSettingId.AgentSandboxForceFirstExecutionInSandbox]: {
+		markdownDescription: localize('agentSandbox.forceFirstExecutionInSandbox', "Controls whether agent mode terminal commands first run with the sandbox's configured restrictions before honoring a request for execution outside the sandbox or unrestricted network access. The user is prompted to approve the requested additional access only if that sandboxed command fails. This applies only when {0} is enabled.", `\`#${AgentSandboxSettingId.AgentSandboxEnabled}#\``),
+		type: 'boolean',
+		default: false,
+		tags: ['preview'],
+		restricted: true,
+	},
 	[AgentSandboxSettingId.AgentSandboxRetryWithAllowNetworkRequests]: {
 		markdownDescription: localize('agentSandbox.retryWithAllowNetworkRequests', "Controls whether agent mode terminal commands can retry in the sandbox with unrestricted network access after user confirmation. This applies only when {0} is set to `on` and preserves file system sandboxing while relaxing network restrictions for an approved command.", `\`#${AgentSandboxSettingId.AgentSandboxEnabled}#\``),
 		type: 'boolean',

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
@@ -125,8 +125,8 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 		return this._engine.getOS();
 	}
 
-	wrapCommand(command: string, requestUnsandboxedExecution?: boolean, shell?: string, cwd?: URI, commandDetails?: readonly ITerminalSandboxCommand[], requestAllowNetwork?: boolean): Promise<ITerminalSandboxWrapResult> {
-		return this._engine.wrapCommand(command, requestUnsandboxedExecution, shell, cwd, commandDetails, requestAllowNetwork);
+	wrapCommand(command: string, requestUnsandboxedExecution?: boolean, shell?: string, cwd?: URI, commandDetails?: readonly ITerminalSandboxCommand[], requestAllowNetwork?: boolean, forceSandboxed?: boolean): Promise<ITerminalSandboxWrapResult> {
+		return this._engine.wrapCommand(command, requestUnsandboxedExecution, shell, cwd, commandDetails, requestAllowNetwork, forceSandboxed);
 	}
 
 	checkFileAccess(permission: TerminalSandboxFileAccessPermission, paths: readonly string[], precheckInputs?: ITerminalSandboxPrecheckInputs): Promise<ITerminalSandboxFileAccessCheckResult> {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineSandboxRewriter.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineSandboxRewriter.test.ts
@@ -141,6 +141,29 @@ suite('CommandLineSandboxRewriter', () => {
 		deepStrictEqual(calls, ['prereqs', 'wrap:echo hello:true', 'commands:']);
 	});
 
+	test('forwards force-sandboxed execution requests', async () => {
+		const calls: string[] = [];
+		stubSandboxService({
+			wrapCommand: async (command, requestUnsandboxedExecution, _shell, _cwd, _commandDetails, _requestAllowNetwork, forceSandboxed) => {
+				calls.push(`wrap:${command}:${String(requestUnsandboxedExecution)}:${String(forceSandboxed)}`);
+				return {
+					command: `sandbox:${command}`,
+					isSandboxWrapped: true,
+				};
+			},
+			checkForSandboxingPrereqs: async () => ({ enabled: true, sandboxConfigPath: '/tmp/sandbox.json', failedCheck: undefined }),
+		});
+
+		const rewriter = store.add(instantiationService.createInstance(CommandLineSandboxRewriter, stubTreeSitterCommandParser()));
+		const result = await rewriter.rewrite({
+			...createRewriteOptions('echo hello'),
+			forceSandboxed: true,
+		});
+
+		strictEqual(result?.rewritten, 'sandbox:echo hello');
+		deepStrictEqual(calls, ['wrap:echo hello:undefined:true']);
+	});
+
 	test('forwards explicit sandboxed allow-network requests', async () => {
 		const calls: string[] = [];
 		stubSandboxService({

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -46,7 +46,7 @@ import { IToolResultCompressor } from '../../../../chat/common/tools/toolResultC
 import { ITerminalChatService, ITerminalService, type ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import { ITerminalProfileResolverService } from '../../../../terminal/common/terminal.js';
 import type { ICommandLinePresenter } from '../../browser/tools/commandLinePresenter/commandLinePresenter.js';
-import { createRunInTerminalToolData, RunInTerminalTool, shouldAutomaticallyRetryAllowNetworkInSandboxed, shouldAutomaticallyRetryUnsandboxed, type IRunInTerminalInputParams } from '../../browser/tools/runInTerminalTool.js';
+import { createRunInTerminalToolData, RunInTerminalTool, shouldAutomaticallyRetryAllowNetworkInSandboxed, shouldAutomaticallyRetryUnsandboxed, shouldRetryDeferredSandboxAccess, type IRunInTerminalInputParams } from '../../browser/tools/runInTerminalTool.js';
 import { ShellIntegrationQuality } from '../../browser/toolTerminalCreator.js';
 import { terminalChatAgentToolsConfiguration, TerminalChatAgentToolsSettingId } from '../../common/terminalChatAgentToolsConfiguration.js';
 import { AgentNetworkDomainSettingId } from '../../../../../../platform/networkFilter/common/settings.js';
@@ -793,6 +793,17 @@ suite('RunInTerminalTool', () => {
 			exitCode: 1,
 			output: 'connect: Operation not permitted',
 		};
+		const baseDeferredSandboxAccessRetryOptions = {
+			deferredUnsandboxedExecution: true,
+			deferredAllowNetworkRequest: false,
+			allowUnsandboxedCommands: true,
+			retryWithAllowNetworkRequests: true,
+			didSandboxWrapCommand: true,
+			isPersistentSession: false,
+			isBackgroundExecution: false,
+			didTimeout: false,
+			exitCode: 1,
+		};
 
 		test('should retry completed foreground sandbox commands when output indicates sandbox block', () => {
 			strictEqual(shouldAutomaticallyRetryUnsandboxed(baseRetryOptions), true);
@@ -858,6 +869,58 @@ suite('RunInTerminalTool', () => {
 			strictEqual(shouldAutomaticallyRetryUnsandboxed({
 				...baseRetryOptions,
 				output: 'regular command failure',
+			}), false);
+		});
+
+		test('should retry deferred sandbox access requests after any failed foreground sandbox execution', () => {
+			strictEqual(shouldRetryDeferredSandboxAccess(baseDeferredSandboxAccessRetryOptions), true);
+			strictEqual(shouldRetryDeferredSandboxAccess({
+				...baseDeferredSandboxAccessRetryOptions,
+				exitCode: 0,
+			}), false);
+			strictEqual(shouldRetryDeferredSandboxAccess({
+				...baseDeferredSandboxAccessRetryOptions,
+				exitCode: undefined,
+			}), false);
+			strictEqual(shouldRetryDeferredSandboxAccess({
+				...baseDeferredSandboxAccessRetryOptions,
+				deferredUnsandboxedExecution: false,
+				deferredAllowNetworkRequest: true,
+				allowUnsandboxedCommands: false,
+			}), true);
+			strictEqual(shouldRetryDeferredSandboxAccess({
+				...baseDeferredSandboxAccessRetryOptions,
+				deferredUnsandboxedExecution: false,
+				deferredAllowNetworkRequest: true,
+				retryWithAllowNetworkRequests: false,
+			}), false);
+		});
+
+		test('should not retry deferred sandbox access when it did not complete in the foreground sandbox', () => {
+			strictEqual(shouldRetryDeferredSandboxAccess({
+				...baseDeferredSandboxAccessRetryOptions,
+				deferredUnsandboxedExecution: false,
+				deferredAllowNetworkRequest: false,
+			}), false);
+			strictEqual(shouldRetryDeferredSandboxAccess({
+				...baseDeferredSandboxAccessRetryOptions,
+				allowUnsandboxedCommands: false,
+			}), false);
+			strictEqual(shouldRetryDeferredSandboxAccess({
+				...baseDeferredSandboxAccessRetryOptions,
+				didSandboxWrapCommand: false,
+			}), false);
+			strictEqual(shouldRetryDeferredSandboxAccess({
+				...baseDeferredSandboxAccessRetryOptions,
+				isPersistentSession: true,
+			}), false);
+			strictEqual(shouldRetryDeferredSandboxAccess({
+				...baseDeferredSandboxAccessRetryOptions,
+				isBackgroundExecution: true,
+			}), false);
+			strictEqual(shouldRetryDeferredSandboxAccess({
+				...baseDeferredSandboxAccessRetryOptions,
+				didTimeout: true,
 			}), false);
 		});
 
@@ -1370,6 +1433,80 @@ suite('RunInTerminalTool', () => {
 			strictEqual(actions[4].label, 'Allow Exact Command Line in this Session');
 			ok(!isSeparator(actions[10]));
 			strictEqual(actions[10].label, 'Configure Auto Approve...');
+		});
+
+		test('should defer an explicit unsandboxed execution request into the sandbox when configured', async () => {
+			setConfig(AgentSandboxSettingId.AgentSandboxForceFirstExecutionInSandbox, true);
+			sandboxEnabled = true;
+			sandboxPrereqResult = {
+				enabled: true,
+				sandboxConfigPath: '/tmp/sandbox.json',
+				failedCheck: undefined,
+			};
+			runInTerminalTool.setBackendOs(OperatingSystem.Linux);
+			let receivedForceSandboxed: boolean | undefined;
+			terminalSandboxService.wrapCommand = async (command: string, requestUnsandboxedExecution?: boolean, _shell?: string, _cwd?: URI, _details?: readonly ITerminalSandboxCommand[], _requestAllowNetwork?: boolean, forceSandboxed?: boolean) => {
+				receivedForceSandboxed = forceSandboxed;
+				return {
+					command: requestUnsandboxedExecution ? `unsandboxed:${command}` : `sandbox:${command}`,
+					isSandboxWrapped: !requestUnsandboxedExecution,
+				};
+			};
+
+			const result = await executeToolTest({
+				requestUnsandboxedExecution: true,
+				requestUnsandboxedExecutionReason: 'Needs access outside the sandbox',
+			});
+
+			assertAutoApproved(result);
+			const terminalData = result?.toolSpecificData as IChatTerminalToolInvocationData;
+			strictEqual(terminalData.commandLine.isSandboxWrapped, true);
+			strictEqual(terminalData.commandLine.toolEdited, 'sandbox:echo hello');
+			strictEqual(terminalData.requestUnsandboxedExecution, false);
+			strictEqual(terminalData.deferredUnsandboxedExecution, true);
+			strictEqual(receivedForceSandboxed, true);
+		});
+
+		test('should defer an explicit allow-network request into the sandbox when configured', async () => {
+			setConfig(AgentSandboxSettingId.AgentSandboxForceFirstExecutionInSandbox, true);
+			sandboxEnabled = true;
+			sandboxPrereqResult = {
+				enabled: true,
+				sandboxConfigPath: '/tmp/sandbox.json',
+				failedCheck: undefined,
+			};
+			runInTerminalTool.setBackendOs(OperatingSystem.Linux);
+			let receivedRequestUnsandboxedExecution: boolean | undefined;
+			let receivedRequestAllowNetwork: boolean | undefined;
+			let receivedForceSandboxed: boolean | undefined;
+			terminalSandboxService.wrapCommand = async (command: string, requestUnsandboxedExecution?: boolean, _shell?: string, _cwd?: URI, _details?: readonly ITerminalSandboxCommand[], requestAllowNetwork?: boolean, forceSandboxed?: boolean) => {
+				receivedRequestUnsandboxedExecution = requestUnsandboxedExecution;
+				receivedRequestAllowNetwork = requestAllowNetwork;
+				receivedForceSandboxed = forceSandboxed;
+				return {
+					command: requestAllowNetwork ? `network-sandbox:${command}` : `sandbox:${command}`,
+					isSandboxWrapped: true,
+					requiresAllowNetworkConfirmation: requestAllowNetwork ? true : undefined,
+				};
+			};
+
+			const result = await executeToolTest({
+				requestAllowNetwork: true,
+				requestAllowNetworkReason: 'Needs registry access while remaining sandboxed',
+			});
+
+			assertAutoApproved(result);
+			const terminalData = result?.toolSpecificData as IChatTerminalToolInvocationData;
+			strictEqual(terminalData.commandLine.isSandboxWrapped, true);
+			strictEqual(terminalData.commandLine.toolEdited, 'sandbox:echo hello');
+			strictEqual(terminalData.requestUnsandboxedExecution, false);
+			strictEqual(terminalData.deferredUnsandboxedExecution, false);
+			strictEqual(terminalData.deferredAllowNetworkRequest, true);
+			strictEqual(terminalData.requestAllowNetwork, false);
+			strictEqual(terminalData.requestAllowNetworkReason, undefined);
+			strictEqual(receivedRequestUnsandboxedExecution, false);
+			strictEqual(receivedRequestAllowNetwork, false);
+			strictEqual(receivedForceSandboxed, true);
 		});
 
 		test('should reject explicit unsandboxed execution requests when unsandboxed commands are disabled', async () => {


### PR DESCRIPTION
## Summary
- add `chat.agent.sandbox.forceFirstExecutionInSandbox` (default: `false`) to run agent terminal commands with the sandbox's configured filesystem and network restrictions before honoring an elevation request
- defer explicit unrestricted-network and unsandboxed-execution requests until a completed foreground sandboxed command fails
- after failure, prompt the user and retry with the narrowest requested elevation: unrestricted network while retaining filesystem sandboxing, or unsandboxed execution when requested

## Testing
- `npm run typecheck-client`
- `TerminalSandboxEngine` unit tests (30 passing)

Fixes #321647
