### PR TITLE
sessions: use OS-specific task overrides for local agent host tasks

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/taskCommand.ts
+++ b/src/vs/sessions/contrib/chat/browser/taskCommand.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { OperatingSystem } from '../../../../base/common/platform.js';
 import { CommandString } from '../../../../workbench/contrib/tasks/common/taskConfiguration.js';
 import { ITaskEntry } from './sessionsTasksService.js';
 
@@ -12,6 +13,18 @@ import { ITaskEntry } from './sessionsTasksService.js';
  * `linux`).
  */
 export type TaskTargetOS = 'windows' | 'osx' | 'linux';
+
+/**
+ * Maps an {@link OperatingSystem} to the matching {@link TaskTargetOS} key used
+ * to select OS-specific `command`/`args` overrides on an `ITaskEntry`.
+ */
+export function osToTaskTargetOS(os: OperatingSystem): TaskTargetOS {
+	switch (os) {
+		case OperatingSystem.Windows: return 'windows';
+		case OperatingSystem.Macintosh: return 'osx';
+		case OperatingSystem.Linux: return 'linux';
+	}
+}
 
 /**
  * Context passed to {@link resolveTaskCommand}.

--- a/src/vs/sessions/contrib/chat/browser/taskCommand.ts
+++ b/src/vs/sessions/contrib/chat/browser/taskCommand.ts
@@ -22,7 +22,9 @@ export function osToTaskTargetOS(os: OperatingSystem): TaskTargetOS {
 	switch (os) {
 		case OperatingSystem.Windows: return 'windows';
 		case OperatingSystem.Macintosh: return 'osx';
-		case OperatingSystem.Linux: return 'linux';
+		case OperatingSystem.Linux:
+		default:
+			return 'linux';
 	}
 }
 

--- a/src/vs/sessions/contrib/chat/test/browser/taskCommand.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/taskCommand.test.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { OperatingSystem } from '../../../../../base/common/platform.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ITaskEntry } from '../../browser/sessionsTasksService.js';
-import { resolveTaskCommand } from '../../browser/taskCommand.js';
+import { osToTaskTargetOS, resolveTaskCommand } from '../../browser/taskCommand.js';
 
 suite('resolveTaskCommand', () => {
 
@@ -192,5 +193,16 @@ suite('resolveTaskCommand', () => {
 		assert.strictEqual(resolveTaskCommand(task), 'make');
 		const taskNoOwn: ITaskEntry = { label: 'group', dependsOn: 'prep' };
 		assert.strictEqual(resolveTaskCommand(taskNoOwn), undefined);
+	});
+});
+
+suite('osToTaskTargetOS', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('maps each OperatingSystem to its tasks.json key', () => {
+		assert.strictEqual(osToTaskTargetOS(OperatingSystem.Windows), 'windows');
+		assert.strictEqual(osToTaskTargetOS(OperatingSystem.Macintosh), 'osx');
+		assert.strictEqual(osToTaskTargetOS(OperatingSystem.Linux), 'linux');
 	});
 });

--- a/src/vs/sessions/contrib/terminal/browser/agentHostSessionTaskRunner.ts
+++ b/src/vs/sessions/contrib/terminal/browser/agentHostSessionTaskRunner.ts
@@ -5,6 +5,7 @@
 
 import { localize } from '../../../../nls.js';
 import { Schemas } from '../../../../base/common/network.js';
+import { OS } from '../../../../base/common/platform.js';
 import { IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -14,12 +15,18 @@ import { IAgentHostTerminalService } from '../../../../workbench/contrib/termina
 import { ITerminalGroupService, ITerminalService } from '../../../../workbench/contrib/terminal/browser/terminal.js';
 import { isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
 import { ISessionTaskRunner } from '../../chat/browser/sessionTaskRunner.js';
-import { resolveTaskCommand } from '../../chat/browser/taskCommand.js';
+import { osToTaskTargetOS, resolveTaskCommand } from '../../chat/browser/taskCommand.js';
 import { ITaskEntry, ISessionsTasksService } from '../../chat/browser/sessionsTasksService.js';
 import { ISession } from '../../../services/sessions/common/session.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 
 const LOG_PREFIX = '[AgentHostSessionTaskRunner]';
+
+/**
+ * Sentinel address used for the local agent host (which runs on the same
+ * machine as the renderer). Remote hosts use their `remoteAddress` instead.
+ */
+const LOCAL_AGENT_HOST_ADDRESS = '__local__';
 
 /**
  * Task runner for sessions backed by an agent host (local or remote). Resolves
@@ -57,7 +64,14 @@ export class AgentHostSessionTaskRunner implements ISessionTaskRunner {
 			byLabel.set(entry.task.label, entry.task);
 		}
 
-		const command = resolveTaskCommand(task, { lookup: label => byLabel.get(label) });
+		const command = resolveTaskCommand(task, {
+			// The local agent host runs on the same machine as the renderer, so
+			// the renderer's OS picks the right OS-specific `command`/`args`
+			// overrides (e.g. `.bat` vs `.sh`). For remote hosts the OS is
+			// unknown here, so we fall back to the task's default command.
+			targetOS: address === LOCAL_AGENT_HOST_ADDRESS ? osToTaskTargetOS(OS) : undefined,
+			lookup: label => byLabel.get(label),
+		});
 		if (!command) {
 			this._logService.trace(`${LOG_PREFIX} Skipping task '${task.label}' — no command could be resolved.`);
 			return undefined;
@@ -87,7 +101,7 @@ export class AgentHostSessionTaskRunner implements ISessionTaskRunner {
 		if (!provider || !isAgentHostProvider(provider)) {
 			return undefined;
 		}
-		return provider.remoteAddress ?? '__local__';
+		return provider.remoteAddress ?? LOCAL_AGENT_HOST_ADDRESS;
 	}
 
 	private _getCwd(session: ISession): URI | undefined {

--- a/src/vs/sessions/contrib/terminal/test/browser/agentHostSessionTaskRunner.test.ts
+++ b/src/vs/sessions/contrib/terminal/test/browser/agentHostSessionTaskRunner.test.ts
@@ -8,6 +8,7 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { Event } from '../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { constObservable, observableValue } from '../../../../../base/common/observable.js';
+import { OS } from '../../../../../base/common/platform.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
@@ -21,6 +22,7 @@ import { IAgentHostSessionsProvider, LOCAL_AGENT_HOST_PROVIDER_ID, REMOTE_AGENT_
 import { IChat, ISession, ISessionFolder, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { ITaskEntry, ISessionsTasksService, ISessionTaskWithTarget } from '../../../chat/browser/sessionsTasksService.js';
+import { osToTaskTargetOS } from '../../../chat/browser/taskCommand.js';
 import { AgentHostSessionTaskRunner } from '../../browser/agentHostSessionTaskRunner.js';
 
 function makeSession(opts: { providerId: string; cwd?: URI }): ISession {
@@ -216,5 +218,21 @@ suite('AgentHostSessionTaskRunner', () => {
 		(await runner.runTask(top, session))?.dispose();
 
 		assert.deepStrictEqual(sentText, [{ text: 'npm run transpile && npm run dev', shouldExecute: true }]);
+	});
+
+	test('local agent-host sessions apply OS-specific command overrides', async () => {
+		const session = makeSession({ providerId: LOCAL_AGENT_HOST_PROVIDER_ID, cwd: URI.parse('file:///x') });
+		const task: ITaskEntry = {
+			label: 'Run Dev Agents',
+			type: 'shell',
+			command: './scripts/code.sh',
+			windows: { command: '.\\scripts\\code.bat' },
+			args: ['--agents'],
+		};
+
+		(await runner.runTask(task, session))?.dispose();
+
+		const expectedCommand = osToTaskTargetOS(OS) === 'windows' ? '.\\scripts\\code.bat' : './scripts/code.sh';
+		assert.deepStrictEqual(sentText, [{ text: `${expectedCommand} --agents`, shouldExecute: true }]);
 	});
 });


### PR DESCRIPTION
## What

The agent host session task runner (used by the **Run Script** action in the Agents window titlebar) always emitted the POSIX (`.sh`) command when resolving a task, ignoring the `windows`/`osx`/`linux` overrides declared in `tasks.json`.

On Windows this meant **Run and Compile Agents - OSS** ran:

```
npm run transpile-client && ./scripts/code.sh --agents ...
```

instead of the Windows variant using `.\scripts\code.bat`.

## Why

`AgentHostSessionTaskRunner.runTask` called `resolveTaskCommand(task, ...)` without a `targetOS`, so `taskCommand.ts` never selected the OS-specific `command`/`args` overrides.

## Changes

- **`taskCommand.ts`**: added an exported pure helper `osToTaskTargetOS(os)` mapping `OperatingSystem` → the `windows`/`osx`/`linux` keys used in `tasks.json`.
- **`agentHostSessionTaskRunner.ts`**: pass `targetOS` to `resolveTaskCommand`. For the **local** agent host (runs on the same machine as the renderer) it uses the renderer's OS, so on Windows the `.bat` override is picked. Remote hosts (OS unknown here) keep falling back to the task's default command. Also extracted the `__local__` sentinel into a `LOCAL_AGENT_HOST_ADDRESS` constant.
- Added unit tests for the OS mapping and for OS-specific override resolution in the runner.

## Notes for reviewers

- Remote agent hosts do not expose their OS to the renderer, so the default (POSIX) command is kept for them — a follow-up could plumb remote OS through if needed.
- The build/typecheck toolchain (`tsgo`) was not available in the dev environment, but the pre-commit hygiene hook passed.