### PR TITLE
build: enforce agent SDK version pin lockstep in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -87,6 +87,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check Codex protocol client is in sync
+        run: |
+          git fetch --no-tags --depth=1 origin "$CODEX_SYNC_BASE" || true
+          node build/codex/check-protocol-sync.ts --if-changed --base "$CODEX_SYNC_BASE"
+        env:
+          CODEX_SYNC_BASE: ${{ github.event.pull_request.base.sha }}
+
       - name: Check cyclic dependencies
         run: node build/lib/checkCyclicDependencies.ts out-build
 

--- a/build/agent-sdk/README.md
+++ b/build/agent-sdk/README.md
@@ -124,6 +124,11 @@ gulp graph. As its own pipeline step:
 4. `npm install` at repo root to refresh the root lockfile.
 5. Commit all four edits together.
 
+The `test/versionSync.test.ts` build test (run by `cd build && npm run
+test` in PR CI) enforces step 3: it fails if an SDK's `agents/<sdk>`
+`package.json` pin, its `package-lock.json`, and the repo-root
+`devDependencies` pin ever fall out of lockstep.
+
 The next pipeline run rebuilds + uploads each platform tarball at the
 new content-addressed CDN path and re-stamps each `product.json` with
 the new `urlTemplate` pointing at the bumped version.

--- a/build/agent-sdk/test/versionSync.test.ts
+++ b/build/agent-sdk/test/versionSync.test.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import { suite, test } from 'node:test';
+import { fileURLToPath } from 'url';
+import { getAgentDir, getAgentMeta, getSdks } from '../common.ts';
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+/** Repo-root package.json — holds the runtime pins in `devDependencies`. */
+const ROOT_PACKAGE_JSON = path.join(THIS_DIR, '..', '..', '..', 'package.json');
+
+interface IRootPackageJson {
+	readonly devDependencies?: Readonly<Record<string, string>>;
+}
+
+function getRootDevDependencies(): Readonly<Record<string, string>> {
+	const json = JSON.parse(fs.readFileSync(ROOT_PACKAGE_JSON, 'utf8')) as IRootPackageJson;
+	return json.devDependencies ?? {};
+}
+
+/**
+ * Reads the version `npm ci` would resolve for `name` from an SDK's
+ * `package-lock.json` (the root package entry under `node_modules/<name>`).
+ * Guards against the lockfile lagging a `package.json` version bump.
+ */
+function getLockedVersion(sdk: string, name: string): string | undefined {
+	const lockPath = path.join(getAgentDir(sdk), 'package-lock.json');
+	const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as {
+		readonly packages?: Readonly<Record<string, { readonly version?: string }>>;
+	};
+	return lock.packages?.[`node_modules/${name}`]?.version;
+}
+
+suite('agent SDK version pins stay in lockstep', () => {
+	test('build pin, runtime pin, and lockfile all match for every SDK', () => {
+		const rootDevDeps = getRootDevDependencies();
+
+		const actual: Record<string, { name: string; buildPin: string; runtimePin: string | undefined; lockPin: string | undefined }> = {};
+		const expected: typeof actual = {};
+
+		for (const sdk of getSdks()) {
+			const { name, version } = getAgentMeta(sdk);
+			actual[sdk] = {
+				name,
+				buildPin: version,
+				runtimePin: rootDevDeps[name],
+				lockPin: getLockedVersion(sdk, name),
+			};
+			// The build pin (agents/<sdk>/package.json) is the source of truth;
+			// the runtime pin (root devDependencies) and lockfile MUST match it.
+			expected[sdk] = {
+				name,
+				buildPin: version,
+				runtimePin: version,
+				lockPin: version,
+			};
+		}
+
+		assert.deepStrictEqual(
+			actual,
+			expected,
+			`An agent SDK version pin drifted. The build pin in build/agent-sdk/agents/<sdk>/package.json must match the runtime pin in repo-root package.json devDependencies and the resolved version in agents/<sdk>/package-lock.json. See "Bumping an SDK version" in build/agent-sdk/README.md.`,
+		);
+	});
+});

--- a/build/codex/check-protocol-sync.ts
+++ b/build/codex/check-protocol-sync.ts
@@ -1,0 +1,204 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Verify the vendored codex app-server protocol client
+// (src/vs/platform/agentHost/node/codex/protocol/generated/**) is byte-for-byte what the
+// generation script produces for the codex version pinned in the repo-root package.json
+// devDependencies (@openai/codex). Guards against hand-edited or stale generated files:
+// the committed client must be reproducible by `npm run codex:gen-protocol`.
+//
+// Usage:
+//   node build/codex/check-protocol-sync.ts
+//       Always regenerate into a scratch dir and compare (local "is my client fresh?").
+//
+//   node build/codex/check-protocol-sync.ts --if-changed [--base <ref>]
+//       CI mode: only run when the PR touches codex generation outputs (the generated dir
+//       or codex-version.txt). `--base` defaults to origin/main.
+//
+// Never modifies the working tree. Exit codes: 0 = in sync (or skipped), 1 = drift.
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+	REPO_ROOT,
+	OUT_DIR,
+	VERSION_FILE,
+	resolveCodexBinary,
+	readBinaryVersion,
+	readPinnedVersion,
+	generate,
+} from './generate-protocol.mjs';
+
+const toPosix = (p: string): string => p.split(path.sep).join('/');
+const GENERATED_DIR_REL = toPosix(path.relative(REPO_ROOT, OUT_DIR));
+const VERSION_FILE_REL = toPosix(path.relative(REPO_ROOT, VERSION_FILE));
+
+// A PR touching any of these paths must keep the generated client in sync. Entries ending
+// in '/' match by prefix (a directory); others match exactly. The generator itself
+// (generate-protocol.mjs) is intentionally excluded: output-preserving refactors of the
+// generator should not force a regeneration; only changes to the generated output or the
+// version contract do.
+const CODEX_INPUT_PREFIXES: readonly string[] = [
+	`${GENERATED_DIR_REL}/`,
+	VERSION_FILE_REL,
+];
+
+// README.md lives inside the generated dir but is hand-authored and preserved across
+// regeneration (see `generate()` / `listFiles()`), so a doc-only edit to it must NOT
+// trigger the freshness check.
+const GENERATED_README_REL = `${GENERATED_DIR_REL}/README.md`;
+
+function readDevDepVersion(): string {
+	const pkg = JSON.parse(readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'));
+	const version: string | undefined = pkg.devDependencies?.['@openai/codex'];
+	if (!version) {
+		throw new Error('Could not find @openai/codex in repo-root package.json devDependencies.');
+	}
+	return version.trim();
+}
+
+/** Filters a list of changed repo-relative paths down to codex generation inputs. */
+export function filterCodexInputs(changedPaths: readonly string[]): string[] {
+	return changedPaths.filter(p =>
+		p !== GENERATED_README_REL &&
+		CODEX_INPUT_PREFIXES.some(prefix => (prefix.endsWith('/') ? p.startsWith(prefix) : p === prefix)));
+}
+
+/** Returns the codex generation inputs changed between `baseRef` and HEAD. */
+function changedCodexInputs(baseRef: string): string[] {
+	const run = () => spawnSync('git', ['diff', '--name-only', baseRef, 'HEAD'], { cwd: REPO_ROOT, encoding: 'utf8' });
+	let r = run();
+	if (r.status !== 0) {
+		// The base commit may be absent in a shallow CI checkout; fetch it once, then retry.
+		spawnSync('git', ['fetch', '--no-tags', '--depth=1', 'origin', baseRef], { cwd: REPO_ROOT, encoding: 'utf8' });
+		r = run();
+		if (r.status !== 0) {
+			throw new Error(`git diff against '${baseRef}' failed:\n${r.stderr}`);
+		}
+	}
+	const changed = r.stdout.split('\n').map(s => s.trim()).filter(Boolean);
+	return filterCodexInputs(changed);
+}
+
+/** Recursively lists repo-relative files under `dir`, excluding README.md. */
+export function listFiles(dir: string): string[] {
+	const out: string[] = [];
+	const walk = (d: string, rel: string): void => {
+		for (const entry of readdirSync(d, { withFileTypes: true })) {
+			if (entry.name === 'README.md') { continue; }
+			const abs = path.join(d, entry.name);
+			const r = rel ? `${rel}/${entry.name}` : entry.name;
+			if (entry.isDirectory()) { walk(abs, r); }
+			else if (entry.isFile()) { out.push(r); }
+		}
+	};
+	walk(dir, '');
+	return out.sort();
+}
+
+/**
+ * Compares two generated trees. Returns a sorted list of relative paths that differ
+ * (content mismatch, or present in only one tree). README.md is ignored.
+ */
+export function diffGeneratedTrees(committedDir: string, freshDir: string): string[] {
+	const committed = new Set(listFiles(committedDir));
+	const fresh = new Set(listFiles(freshDir));
+	const diffs: string[] = [];
+	for (const rel of committed) {
+		if (!fresh.has(rel)) {
+			diffs.push(`${rel} (committed but not produced by regeneration)`);
+			continue;
+		}
+		const a = readFileSync(path.join(committedDir, rel));
+		const b = readFileSync(path.join(freshDir, rel));
+		if (!a.equals(b)) {
+			diffs.push(`${rel} (content differs from regeneration)`);
+		}
+	}
+	for (const rel of fresh) {
+		if (!committed.has(rel)) {
+			diffs.push(`${rel} (produced by regeneration but missing from the committed client)`);
+		}
+	}
+	return diffs.sort();
+}
+
+function fail(message: string): void {
+	// allow-any-unicode-next-line
+	console.error(`\n✗ ${message}`);
+	process.exit(1);
+}
+
+function main(): void {
+	const argv = process.argv.slice(2);
+	const ifChanged = argv.includes('--if-changed');
+	let base: string | undefined;
+	const baseFlagIdx = argv.indexOf('--base');
+	if (baseFlagIdx !== -1) { base = argv[baseFlagIdx + 1]; }
+	const baseEq = argv.find(a => a.startsWith('--base='));
+	if (baseEq) { base = baseEq.slice('--base='.length); }
+
+	if (ifChanged) {
+		const ref = base || 'origin/main';
+		const changed = changedCodexInputs(ref);
+		if (changed.length === 0) {
+			console.log(`No codex protocol generation inputs changed vs ${ref}; skipping freshness check.`);
+			console.log(`(inputs: ${GENERATED_DIR_REL}/**, ${VERSION_FILE_REL})`);
+			return;
+		}
+		console.log(`Codex generation inputs changed vs ${ref}:`);
+		for (const c of changed) { console.log(`  ${c}`); }
+	}
+
+	const devDep = readDevDepVersion();
+	const bin = resolveCodexBinary();
+	const binVersion = readBinaryVersion(bin);
+	const pinned = readPinnedVersion();
+
+	console.log(`\n@openai/codex devDependency: ${devDep}`);
+	console.log(`vendored codex binary:       ${binVersion}  (${toPosix(path.relative(REPO_ROOT, bin))})`);
+	console.log(`${VERSION_FILE_REL}:          ${pinned}`);
+
+	if (binVersion !== devDep) {
+		fail(`The vendored codex binary is ${binVersion} but package.json pins @openai/codex ${devDep}. ` +
+			`Run \`npm ci\` so the freshness check regenerates with the dev-dependency version.`);
+	}
+
+	// Regenerate into a throwaway dir using the dev-dependency binary; never touch the working tree.
+	const scratch = mkdtempSync(path.join(tmpdir(), 'codex-protocol-check-'));
+	try {
+		generate(bin, scratch, binVersion);
+		const diffs = diffGeneratedTrees(OUT_DIR, scratch);
+		if (diffs.length > 0) {
+			// allow-any-unicode-next-line
+			console.error(`\n✗ The committed codex protocol client does not match \`codex app-server generate-ts\` for @openai/codex ${devDep}.`);
+			console.error(`  ${diffs.length} file(s) differ:`);
+			for (const d of diffs.slice(0, 40)) { console.error(`    ${d}`); }
+			if (diffs.length > 40) { console.error(`    …and ${diffs.length - 40} more.`); }
+			console.error(`\n  Regenerate with:  npm run codex:gen-protocol`);
+			console.error(`  (ensure ${VERSION_FILE_REL} and the @openai/codex devDependency are both ${devDep} first.)`);
+			process.exit(1);
+		}
+	} finally {
+		rmSync(scratch, { recursive: true, force: true });
+	}
+
+	if (pinned !== devDep) {
+		fail(`${VERSION_FILE_REL} is ${pinned} but the generated client matches @openai/codex ${devDep}. ` +
+			`Bump ${VERSION_FILE_REL} to ${devDep} so \`npm run codex:gen-protocol\` stays reproducible.`);
+	}
+
+	console.log(`\n✓ Codex protocol client matches \`codex app-server generate-ts\` for @openai/codex ${devDep}.`);
+}
+
+// Only run when invoked directly, not when imported by the unit tests.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	main();
+}
+
+export { CODEX_INPUT_PREFIXES };

--- a/build/codex/generate-protocol.d.mts
+++ b/build/codex/generate-protocol.d.mts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Type declarations for the (plain-JS) codex protocol generator, so the TypeScript freshness
+// check (check-protocol-sync.ts) can import its reusable pieces. The runnable logic lives in
+// generate-protocol.mjs.
+
+/** Absolute path to the repository root. */
+export declare const REPO_ROOT: string;
+
+/** Absolute path to the generated protocol client directory. */
+export declare const OUT_DIR: string;
+
+/** Absolute path to build/codex/codex-version.txt (the pinned codex version). */
+export declare const VERSION_FILE: string;
+
+/** Resolves the codex binary ($CODEX_BIN, vendored npm package, or PATH). */
+export declare function resolveCodexBinary(): string;
+
+/** Reads the `codex --version` of the given binary. */
+export declare function readBinaryVersion(bin: string): string;
+
+/** Reads the pinned version from build/codex/codex-version.txt. */
+export declare function readPinnedVersion(): string;
+
+/**
+ * Regenerates the protocol client into `outDir` using `bin`, stamping `codexVersion` into the
+ * per-file header. Wipes `outDir` first (except README.md). Output is byte-identical regardless
+ * of `outDir`, so a scratch-dir regeneration can be compared against the committed client.
+ */
+export declare function generate(bin: string, outDir: string, codexVersion: string): void;

--- a/build/codex/generate-protocol.mjs
+++ b/build/codex/generate-protocol.mjs
@@ -19,7 +19,7 @@ import { spawnSync } from 'node:child_process';
 import { mkdtempSync, readdirSync, readFileSync, writeFileSync, statSync, rmSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -27,9 +27,6 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const VERSION_FILE = path.join(REPO_ROOT, 'build', 'codex', 'codex-version.txt');
 const OUT_DIR = path.join(REPO_ROOT, 'src', 'vs', 'platform', 'agentHost', 'node', 'codex', 'protocol', 'generated');
 const FORMATTER = path.join(REPO_ROOT, 'build', 'lib', 'formatter.ts');
-
-const args = process.argv.slice(2);
-const noVersionCheck = args.includes('--no-version-check');
 
 function resolveCodexBinary() {
 	if (process.env.CODEX_BIN) {
@@ -151,6 +148,7 @@ function generate(bin, outDir, codexVersion) {
 }
 
 function main() {
+	const noVersionCheck = process.argv.slice(2).includes('--no-version-check');
 	const bin = resolveCodexBinary();
 	const binVersion = readBinaryVersion(bin);
 	const pinnedVersion = readPinnedVersion();
@@ -173,4 +171,10 @@ function main() {
 	console.log(`\nWrote ${count} files to ${path.relative(REPO_ROOT, OUT_DIR)}`);
 }
 
-main();
+// Only generate when invoked directly (e.g. `npm run codex:gen-protocol`), not when
+// imported by the freshness check (build/codex/check-protocol-sync.ts).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	main();
+}
+
+export { REPO_ROOT, OUT_DIR, VERSION_FILE, resolveCodexBinary, readBinaryVersion, readPinnedVersion, generate };

--- a/build/codex/test/checkProtocolSync.test.ts
+++ b/build/codex/test/checkProtocolSync.test.ts
@@ -1,0 +1,96 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { suite, test, afterEach } from 'node:test';
+import { CODEX_INPUT_PREFIXES, diffGeneratedTrees, filterCodexInputs, listFiles } from '../check-protocol-sync.ts';
+
+const GENERATED_DIR = 'src/vs/platform/agentHost/node/codex/protocol/generated';
+
+const scratchDirs: string[] = [];
+function makeDir(tree: Readonly<Record<string, string>>): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-check-test-'));
+	scratchDirs.push(root);
+	for (const [rel, content] of Object.entries(tree)) {
+		const abs = path.join(root, rel);
+		fs.mkdirSync(path.dirname(abs), { recursive: true });
+		fs.writeFileSync(abs, content);
+	}
+	return root;
+}
+
+afterEach(() => {
+	while (scratchDirs.length) {
+		fs.rmSync(scratchDirs.pop()!, { recursive: true, force: true });
+	}
+});
+
+suite('codex protocol freshness check helpers', () => {
+	test('CODEX_INPUT_PREFIXES targets the generated dir and version pin', () => {
+		assert.deepStrictEqual(CODEX_INPUT_PREFIXES, [
+			`${GENERATED_DIR}/`,
+			'build/codex/codex-version.txt',
+		]);
+	});
+
+	test('filterCodexInputs keeps only codex generation inputs', () => {
+		const changed = [
+			`${GENERATED_DIR}/index.ts`,
+			`${GENERATED_DIR}/nested/Thing.ts`,
+			`${GENERATED_DIR}/README.md`,
+			'build/codex/codex-version.txt',
+			'build/codex/generate-protocol.mjs',
+			'build/codex/check-protocol-sync.ts',
+			'src/vs/platform/agentHost/node/codex/codexAgent.ts',
+			'package.json',
+			'README.md',
+		];
+		assert.deepStrictEqual(filterCodexInputs(changed), [
+			`${GENERATED_DIR}/index.ts`,
+			`${GENERATED_DIR}/nested/Thing.ts`,
+			'build/codex/codex-version.txt',
+		]);
+	});
+
+	test('listFiles lists files recursively, sorted, excluding README.md', () => {
+		const dir = makeDir({
+			'index.ts': 'a',
+			'README.md': 'ignored',
+			'nested/Thing.ts': 'b',
+			'nested/deep/Other.ts': 'c',
+		});
+		assert.deepStrictEqual(listFiles(dir), ['index.ts', 'nested/Thing.ts', 'nested/deep/Other.ts']);
+	});
+
+	test('diffGeneratedTrees reports content, missing, and extra files (README ignored)', () => {
+		const committed = makeDir({
+			'index.ts': 'export const a = 1;',
+			'Same.ts': 'same',
+			'Changed.ts': 'old',
+			'OnlyCommitted.ts': 'gone',
+			'README.md': 'committed readme',
+		});
+		const fresh = makeDir({
+			'index.ts': 'export const a = 1;',
+			'Same.ts': 'same',
+			'Changed.ts': 'new',
+			'OnlyFresh.ts': 'added',
+			'README.md': 'different readme',
+		});
+		assert.deepStrictEqual(diffGeneratedTrees(committed, fresh), [
+			'Changed.ts (content differs from regeneration)',
+			'OnlyCommitted.ts (committed but not produced by regeneration)',
+			'OnlyFresh.ts (produced by regeneration but missing from the committed client)',
+		]);
+	});
+
+	test('diffGeneratedTrees returns no differences for identical trees', () => {
+		const tree = { 'index.ts': 'x', 'nested/Thing.ts': 'y', 'README.md': 'whatever' };
+		assert.deepStrictEqual(diffGeneratedTrees(makeDir(tree), makeDir(tree)), []);
+	});
+});

--- a/build/package.json
+++ b/build/package.json
@@ -69,7 +69,7 @@
     "pretypecheck": "npm run copy-policy-dto",
     "typecheck": "cd .. && npx tsgo --project build/tsconfig.json",
     "watch": "npm run typecheck -- --watch",
-    "test": "node --test '{lib,next}/**/*.test.ts'"
+    "test": "node --test '{lib,next,agent-sdk}/**/*.test.ts'"
   },
   "optionalDependencies": {
     "tree-sitter-typescript": "^0.23.2",

--- a/build/package.json
+++ b/build/package.json
@@ -69,7 +69,7 @@
     "pretypecheck": "npm run copy-policy-dto",
     "typecheck": "cd .. && npx tsgo --project build/tsconfig.json",
     "watch": "npm run typecheck -- --watch",
-    "test": "node --test '{lib,next,agent-sdk}/**/*.test.ts'"
+    "test": "node --test '{lib,next,agent-sdk,codex}/**/*.test.ts'"
   },
   "optionalDependencies": {
     "tree-sitter-typescript": "^0.23.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "build-fast-extensions": "npm run gulp copy-codicons compile-extensions compile-extension-media",
     "typecheck-client": "tsgo --project ./src/tsconfig.json --noEmit --skipLibCheck",
     "codex:gen-protocol": "node build/codex/generate-protocol.mjs",
+    "codex:check-protocol": "node build/codex/check-protocol-sync.ts",
     "watch": "npm-run-all2 -lp watch-client-transpile watch-client watch-extensions watch-copilot",
     "watch-transpile": "npm-run-all2 -lp watch-client-transpile watch-extensions watch-copilot",
     "watchd": "deemon npm run watch",

--- a/src/vs/platform/agentHost/node/codex/protocol/generated/README.md
+++ b/src/vs/platform/agentHost/node/codex/protocol/generated/README.md
@@ -32,3 +32,17 @@ The generator looks for codex in this order:
 1. `$CODEX_BIN` environment variable
 2. `node_modules/@openai/codex-<platform>-<arch>/.../bin/codex` (vendored via npm)
 3. `which codex` (PATH fallback)
+
+## CI freshness check
+
+A PR CI step (`build/codex/check-protocol-sync.ts`, wired into the "Compile &
+Hygiene" job) guards against hand-edited or stale bindings. When a PR changes
+this `generated/` directory or `build/codex/codex-version.txt`, the step
+regenerates the client from the `@openai/codex` dev-dependency binary into a
+scratch dir and fails if the committed files differ. PRs that touch neither are
+skipped. Run it locally with:
+
+```sh
+npm run codex:check-protocol
+```
+


### PR DESCRIPTION
## Summary

Two CI safeguards that keep agent-SDK version pins honest. Both run inside the existing **Compile & Hygiene** PR job — no new job.

### 1. Agent SDK version pin lockstep

A build-script unit test fails when an agent SDK's version drifts between the runtime pin (root `package.json` devDependencies), the build pin (`build/agent-sdk/agents/<sdk>/package.json`), and the lockfile. Previously this was a manual procedure documented in `build/agent-sdk/README.md`.

- `build/agent-sdk/test/versionSync.test.ts` — asserts build pin == runtime pin == lockfile for every SDK.
- `build/package.json` — extend the test glob to `{lib,next,agent-sdk,codex}`.
- `build/agent-sdk/README.md` — note the enforcement.

### 2. Codex generated protocol client freshness

Fails when the committed Codex protocol client (`src/vs/platform/agentHost/node/codex/protocol/generated/**`) no longer matches what the generator produces for the pinned **dev-dependency** `@openai/codex` — **only when a PR changes the generated client or the version pin**, so unrelated PRs are unaffected.

- `build/codex/check-protocol-sync.ts` — gates on a `git diff <base> HEAD` touching the generated dir or `codex-version.txt` (generated `README.md` excluded — preserved across regen), regenerates into a scratch dir with the dev-dep binary, byte-compares against the committed client, and asserts the pin matches. Never touches the working tree.
- `build/codex/generate-protocol.mjs` (+ `generate-protocol.d.mts`) — export the reusable generator pieces; only run `main()` when invoked directly.
- `build/codex/test/checkProtocolSync.test.ts` — unit tests for the gate + tree-diff helpers.
- `.github/workflows/pr.yml`, root `package.json`, generated `README.md` — wire in and document the check.

## Verification (instrumented CI runs on this PR)

Both checks were proven end-to-end by pushing throwaway drift commits and reverting them.

**Version pin lockstep** (`test-build-scripts` inside Compile & Hygiene):

| Scenario | Result | Run |
|----------|--------|-----|
| In lockstep → test passes | ✅ pass | [run](https://github.com/microsoft/vscode/actions/runs/29090156350/job/86353554706) |
| Drift probe (bump claude build pin `0.3.198`→`0.3.199`) → `An agent SDK version pin drifted` | ❌ fail | [run](https://github.com/microsoft/vscode/actions/runs/29092128209/job/86359745267) |

**Codex client freshness** (gated step in Compile & Hygiene):

| Scenario | Result | Run |
|----------|--------|-----|
| Clean PR (no gated inputs changed) → skips | ✅ pass | [run](https://github.com/microsoft/vscode/actions/runs/29088802054/job/86348892006) |
| Drift probe (edit under `protocol/generated/`) → `654 file(s) differ` | ❌ fail | [run](https://github.com/microsoft/vscode/actions/runs/29089239352/job/86350406287) |
| Revert → back to green | ✅ pass | [run](https://github.com/microsoft/vscode/actions/runs/29089674351/job/86351808951) |
| Rebased on latest `main` → still green | ✅ pass | [run](https://github.com/microsoft/vscode/actions/runs/29090156350/job/86353554706) |

Each throwaway drift commit was reverted; the PR head is back to a clean, matched state.
