### PR TITLE
terminal: Ensure terminals persist when outputLocation is terminal

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -2881,6 +2881,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		if (!terminalsToDispose || terminalsToDispose.size === 0) {
 			return;
 		}
+		const shouldPreserveTerminalsForOutputLocation = this._configurationService.getValue(TerminalChatAgentToolsSettingId.OutputLocation) === 'terminal';
 
 		this._logService.debug(`RunInTerminalTool: Cleaning up ${terminalsToDispose.size} terminal(s) for ended chat session ${chatSessionResource}`);
 
@@ -2891,10 +2892,11 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			// Only dispose if the terminal is still hidden from the user. Once
 			// the user reveals it (via the terminal panel or the outputLocation
 			// setting), it joins foregroundInstances and should persist so they
-			// can inspect/interact with it. This prevents user-revealed
-			// terminals from being destroyed when switching between sessions.
-			if (this._terminalService.foregroundInstances.includes(terminal)) {
-				this._logService.debug(`RunInTerminalTool: Skipping disposal of user-revealed terminal ${terminal.instanceId} for session ${chatSessionResource}`);
+			// can inspect/interact with it. Also preserve terminals when the user
+			// explicitly configured outputLocation=terminal, since these are
+			// intended to remain available outside of chat session lifetime.
+			if (this._terminalService.foregroundInstances.includes(terminal) || shouldPreserveTerminalsForOutputLocation) {
+				this._logService.debug(`RunInTerminalTool: Skipping disposal of preserved terminal ${terminal.instanceId} for session ${chatSessionResource}`);
 				continue;
 			}
 			// Skip redundant map walks in onDidDispose since this session has already been removed.
@@ -2906,8 +2908,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		const terminalToRemove: string[] = [];
 		for (const [termId, execution] of RunInTerminalTool._activeExecutions.entries()) {
 			if (terminalsToDispose.has(execution.instance)) {
-				// Skip active executions for terminals that were preserved above
-				if (this._terminalService.foregroundInstances.includes(execution.instance)) {
+				// Skip active executions for terminals that were preserved above.
+				if (this._terminalService.foregroundInstances.includes(execution.instance) || shouldPreserveTerminalsForOutputLocation) {
 					continue;
 				}
 				execution.dispose();

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -2679,6 +2679,27 @@ suite('RunInTerminalTool', () => {
 			(instantiationService.get(ITerminalService).foregroundInstances as ITerminalInstance[]).length = 0;
 		});
 
+		test('should preserve terminals when output location is terminal', () => {
+			setConfig(TerminalChatAgentToolsSettingId.OutputLocation, 'terminal');
+
+			const sessionId = 'test-session-output-location-terminal';
+			const mockTerminal1 = createMockTerminal(33333);
+			const mockTerminal2 = createMockTerminal(44444);
+
+			let terminal1Disposed = false;
+			let terminal2Disposed = false;
+			mockTerminal1.dispose = () => { terminal1Disposed = true; };
+			mockTerminal2.dispose = () => { terminal2Disposed = true; };
+
+			const sessionResource = LocalChatSessionUri.forSession(sessionId);
+			runInTerminalTool.sessionTerminalInstances.set(sessionResource, new Set([mockTerminal1, mockTerminal2]));
+
+			chatServiceDisposeEmitter.fire({ sessionResources: [sessionResource], reason: 'cleared' });
+
+			strictEqual(terminal1Disposed, false, 'Terminal should persist when output location is terminal');
+			strictEqual(terminal2Disposed, false, 'Terminal should persist when output location is terminal');
+		});
+
 		test('should handle disposal of non-existent session gracefully', () => {
 			strictEqual(runInTerminalTool.sessionTerminalAssociations.size, 0, 'No associations should exist initially');
 			chatServiceDisposeEmitter.fire({ sessionResources: [LocalChatSessionUri.forSession('non-existent-session')], reason: 'cleared' });


### PR DESCRIPTION
Fixes #322380

## What changed
- Preserve `run_in_terminal` terminals during chat-session cleanup when `chat.tools.terminal.outputLocation` is set to `terminal`
- Keep associated active executions intact for preserved terminals
- Add a regression test that verifies terminals are not disposed on session clear when output location is `terminal`

## Why
With `outputLocation: terminal`, users expect terminals to stay available beyond chat-session cleanup. Previously, hidden terminals could still be disposed when the session was cleared.

## Validation
- `npm run typecheck-client`
- `./scripts/test.sh --grep "should preserve terminals when output location is terminal" --runGlob "**/runInTerminalTool.test.js"`
- `npm run hygiene` (reports existing baseline issues outside this change)
