### PR TITLE
sessions: close modal editor on Escape when sidebar has focus

### DIFF
--- a/src/vs/platform/editor/common/editor.ts
+++ b/src/vs/platform/editor/common/editor.ts
@@ -7,6 +7,7 @@ import { equals } from '../../../base/common/arrays.js';
 import { Event } from '../../../base/common/event.js';
 import { IDisposable } from '../../../base/common/lifecycle.js';
 import { URI } from '../../../base/common/uri.js';
+import { IContextKeyService } from '../../contextkey/common/contextkey.js';
 import { IUriIdentityService } from '../../uriIdentity/common/uriIdentity.js';
 import { IRectangle } from '../../window/common/window.js';
 
@@ -426,9 +427,13 @@ export interface IModalEditorSidebar {
 	 * @param container The DOM element to render into.
 	 * @param onDidLayout An event that fires when the sidebar is
 	 * 		laid out with the available dimensions.
+	 * @param contextKeyService A context key service scoped to the modal
+	 * 		that content should descend from (e.g. when creating lists/trees)
+	 * 		so that modal-level context keys remain active while the content
+	 * 		has focus.
 	 * @returns A disposable to clean up when the modal closes.
 	 */
-	readonly render: (container: unknown /* HTMLElement */, onDidLayout: Event<{ readonly height: number; readonly width: number }>) => IDisposable;
+	readonly render: (container: unknown /* HTMLElement */, onDidLayout: Event<{ readonly height: number; readonly width: number }>, contextKeyService: IContextKeyService) => IDisposable;
 }
 
 /**

--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -958,6 +958,7 @@ export class ChangesViewPane extends ViewPane {
 	private renderSidebarList(
 		container: HTMLElement,
 		onDidLayout: Event<{ readonly height: number; readonly width: number }>,
+		contextKeyService: IContextKeyService,
 		items: IChangesFileItem[],
 		openFileItem: (item: IChangesFileItem, items: IChangesFileItem[], sideBySide: boolean, preserveFocus: boolean, pinned: boolean, includeSidebar: boolean) => void,
 	): IDisposable {
@@ -975,7 +976,7 @@ export class ChangesViewPane extends ViewPane {
 		const countBadge = disposables.add(new CountBadge(headerNode, { count: items.length }, defaultCountBadgeStyles));
 		countBadge.setCount(items.length);
 
-		const tree = this.createChangesTree(container, Event.None, disposables, () => tree.getSelection().filter(item => !!item && isChangesFileItem(item)));
+		const tree = this.createChangesTree(container, Event.None, disposables, () => tree.getSelection().filter(item => !!item && isChangesFileItem(item)), contextKeyService);
 
 		if (viewMode === ChangesViewMode.Tree) {
 			tree.setChildren(null, buildTreeChildren(items, this.getTreeRootInfo(items)));
@@ -1032,14 +1033,24 @@ export class ChangesViewPane extends ViewPane {
 		onDidChangeVisibility: Event<boolean>,
 		disposables: DisposableStore,
 		getSelection?: () => IChangesFileItem[],
+		contextKeyService?: IContextKeyService,
 	): WorkbenchCompressibleObjectTree<ChangesTreeElement> {
+		// When a scoped context key service is provided (e.g. when rendering into
+		// the modal editor sidebar), create the tree with an instantiation service
+		// that uses it so the tree's context descends from the modal. This keeps
+		// modal-level context keys (e.g. `editorPartModal`) active while the tree
+		// has focus.
+		const treeInstantiationService = contextKeyService
+			? disposables.add(this.instantiationService.createChild(new ServiceCollection([IContextKeyService, contextKeyService])))
+			: this.instantiationService;
+
 		const resourceLabels = disposables.add(this.instantiationService.createInstance(ResourceLabels, { onDidChangeVisibility }));
 		const actionRunner = disposables.add(new ChangesViewActionRunner(
 			() => this.viewModel.activeSessionResourceObs.get(),
 			() => this.getSessionDiscardRef(),
 			getSelection ?? (() => this.getTreeSelection()),
 		));
-		return disposables.add(this.instantiationService.createInstance(
+		return disposables.add(treeInstantiationService.createInstance(
 			WorkbenchCompressibleObjectTree<ChangesTreeElement>,
 			'ChangesViewTree',
 			container,
@@ -1119,8 +1130,8 @@ export class ChangesViewPane extends ViewPane {
 		const currentIndex = items.indexOf(item);
 
 		const sidebar = includeSidebar ? {
-			render: (container: unknown, onDidLayout: Event<{ readonly height: number; readonly width: number }>) => {
-				return this.renderSidebarList(container as HTMLElement, onDidLayout, items, this._openFileItem.bind(this));
+			render: (container: unknown, onDidLayout: Event<{ readonly height: number; readonly width: number }>, contextKeyService: IContextKeyService) => {
+				return this.renderSidebarList(container as HTMLElement, onDidLayout, contextKeyService, items, this._openFileItem.bind(this));
 			}
 		} : undefined;
 

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -20,7 +20,7 @@ import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextke
 import { EditorResolution, IEditorOptions, IResourceEditorInput, ITextEditorOptions } from '../../../../platform/editor/common/editor.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight, KeybindingsRegistry } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
-import { IListService, IOpenEvent } from '../../../../platform/list/browser/listService.js';
+import { IListService, IOpenEvent, RawWorkbenchListFocusContextKey, WorkbenchTreeFindOpen, WorkbenchTreeStickyScrollFocused } from '../../../../platform/list/browser/listService.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
@@ -1579,12 +1579,20 @@ function registerModalEditorCommands(): void {
 				precondition: EditorPartModalContext,
 				keybinding: [{
 					primary: KeyCode.Escape,
-					weight: KeybindingWeight.WorkbenchContrib + 10, // higher when no text editor is focused...
-					when: EditorContextKeys.focus.toNegated()
+					weight: KeybindingWeight.WorkbenchContrib + 10, // higher when no text editor or list/tree is focused...
+					when: ContextKeyExpr.and(EditorContextKeys.focus.toNegated(), RawWorkbenchListFocusContextKey.negate())
 				}, {
 					primary: KeyCode.Escape,
 					weight: KeybindingWeight.EditorContrib - 1, // ...lower to prevent accidental close when text editor is focused
 					when: EditorContextKeys.focus
+				}, {
+					primary: KeyCode.Escape,
+					// When a list/tree is focused, still close the modal, but yield to the
+					// list/tree's own `Escape` features that should close first (the find
+					// widget and sticky scroll). The selection is intentionally not cleared
+					// first so a single `Escape` closes the modal.
+					weight: KeybindingWeight.WorkbenchContrib + 1,
+					when: ContextKeyExpr.and(RawWorkbenchListFocusContextKey, WorkbenchTreeFindOpen.negate(), WorkbenchTreeStickyScrollFocused.negate())
 				}],
 				menu: {
 					id: MenuId.ModalEditorTitle,

--- a/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
@@ -149,6 +149,7 @@ export class ModalEditorPart {
 		@IHostService private readonly hostService: IHostService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 	) {
 	}
 
@@ -159,6 +160,14 @@ export class ModalEditorPart {
 		const modalElement = $('.monaco-modal-editor-block');
 		this.layoutService.mainContainer.appendChild(modalElement);
 		disposables.add(toDisposable(() => modalElement.remove()));
+
+		// Context key service scoped to the entire modal element so that the
+		// modal-level context keys (e.g. `editorPartModal`) are active when focus
+		// is anywhere inside the modal. Both the editor part and the sidebar
+		// content are wired up to descend from this service so that commands like
+		// closing the modal on `Escape` work regardless of which area has focus
+		// (e.g. the sidebar changes tree).
+		const modalContextKeyService = disposables.add(this.contextKeyService.createScoped(modalElement));
 
 		disposables.add(addDisposableListener(modalElement, EventType.MOUSE_DOWN, e => {
 			if (e.target === modalElement) {
@@ -262,7 +271,7 @@ export class ModalEditorPart {
 		const actionBarContainer = append(headerElement, $('div.modal-editor-action-container'));
 
 		// Sidebar
-		const sidebarResult = this.createSidebar(editorPartContainer, headerElement, options?.sidebar, disposables);
+		const sidebarResult = this.createSidebar(editorPartContainer, headerElement, options?.sidebar, modalContextKeyService, disposables);
 		if (sidebarResult) {
 			if (sidebarResult.isVisible()) {
 				editorPartContainer.classList.add('has-sidebar');
@@ -270,8 +279,12 @@ export class ModalEditorPart {
 			disposables.add(sidebarResult.onDidResize(() => layoutModal()));
 		}
 
-		// Create the editor part
-		const editorPart = disposables.add(this.instantiationService.createInstance(
+		// Create the editor part (scoped to the modal context key service so that
+		// the editor area also descends from it)
+		const modalInstantiationService = disposables.add(this.instantiationService.createChild(new ServiceCollection(
+			[IContextKeyService, modalContextKeyService]
+		)));
+		const editorPart = disposables.add(modalInstantiationService.createInstance(
 			ModalEditorPartImpl,
 			mainWindow.vscodeWindowId,
 			this.editorPartsView,
@@ -728,7 +741,7 @@ export class ModalEditorPart {
 		};
 	}
 
-	private createSidebar(container: HTMLElement, headerElement: HTMLElement, content: IModalEditorSidebar | undefined, disposables: DisposableStore): IModalEditorSidebarController | undefined {
+	private createSidebar(container: HTMLElement, headerElement: HTMLElement, content: IModalEditorSidebar | undefined, modalContextKeyService: IContextKeyService, disposables: DisposableStore): IModalEditorSidebarController | undefined {
 		if (!content) {
 			return undefined;
 		}
@@ -741,10 +754,15 @@ export class ModalEditorPart {
 		sidebarContainer.style.width = `${sidebarWidth}px`;
 		setVisibility(visible, sidebarContainer);
 
+		// Context key service scoped to the sidebar container, descending from the
+		// modal context key service so that content rendered here (e.g. the changes
+		// tree) inherits the modal-level context keys.
+		const sidebarContextKeyService = disposables.add(modalContextKeyService.createScoped(sidebarContainer));
+
 		// Let the caller render content
 		const onDidLayoutEmitter = disposables.add(new Emitter<{ readonly height: number; readonly width: number }>());
 		const contentDisposable = disposables.add(new MutableDisposable());
-		contentDisposable.value = content.render(sidebarContainer, onDidLayoutEmitter.event);
+		contentDisposable.value = content.render(sidebarContainer, onDidLayoutEmitter.event, sidebarContextKeyService);
 
 		// Sash for resizing sidebar.
 		// Prefer the measured header height so the sash aligns with the real chrome
@@ -820,7 +838,7 @@ export class ModalEditorPart {
 			updateContent: (newContent: IModalEditorSidebar) => {
 				contentDisposable.clear();
 				sidebarContainer.textContent = '';
-				contentDisposable.value = newContent.render(sidebarContainer, onDidLayoutEmitter.event);
+				contentDisposable.value = newContent.render(sidebarContainer, onDidLayoutEmitter.event, sidebarContextKeyService);
 			},
 		};
 	}
@@ -894,10 +912,10 @@ class ModalEditorPartImpl extends EditorPart implements IModalEditorPart {
 		@IStorageService storageService: IStorageService,
 		@IWorkbenchLayoutService layoutService: IWorkbenchLayoutService,
 		@IHostService hostService: IHostService,
-		@IContextKeyService contextKeyService: IContextKeyService,
+		@IContextKeyService private readonly modalContextKeyService: IContextKeyService,
 	) {
 		const id = ModalEditorPartImpl.COUNTER++;
-		super(editorPartsView, `workbench.parts.modalEditor.${id}`, localize('modalEditorPart', "Modal Editor Area"), windowId, instantiationService, themeService, configurationService, storageService, layoutService, hostService, contextKeyService);
+		super(editorPartsView, `workbench.parts.modalEditor.${id}`, localize('modalEditorPart', "Modal Editor Area"), windowId, instantiationService, themeService, configurationService, storageService, layoutService, hostService, modalContextKeyService);
 
 		this._maximized = options?.maximized ?? false;
 		this._size = options?.size;
@@ -994,21 +1012,28 @@ class ModalEditorPartImpl extends EditorPart implements IModalEditorPart {
 	}
 
 	protected override handleContextKeys(): void {
-		const isModalEditorPartContext = EditorPartModalContext.bindTo(this.scopedContextKeyService);
+
+		// Bind the modal-level context keys to the modal context key service which
+		// is scoped to the entire modal element (not just the editor part
+		// container). This keeps them active when focus is anywhere inside the
+		// modal, including the sidebar (e.g. the changes tree). Otherwise commands
+		// like closing the modal on `Escape` would not fire while the sidebar has
+		// focus.
+		const isModalEditorPartContext = EditorPartModalContext.bindTo(this.modalContextKeyService);
 		isModalEditorPartContext.set(true);
 
-		const isMaximizedContext = EditorPartModalMaximizedContext.bindTo(this.scopedContextKeyService);
+		const isMaximizedContext = EditorPartModalMaximizedContext.bindTo(this.modalContextKeyService);
 		isMaximizedContext.set(this._maximized);
 		this._register(this.onDidChangeMaximized(maximized => isMaximizedContext.set(maximized)));
 
-		const hasNavigationContext = EditorPartModalNavigationContext.bindTo(this.scopedContextKeyService);
+		const hasNavigationContext = EditorPartModalNavigationContext.bindTo(this.modalContextKeyService);
 		hasNavigationContext.set(!!this._navigation && this._navigation.total > 1);
 		this._register(this.onDidChangeNavigation(navigation => hasNavigationContext.set(!!navigation && navigation.total > 1)));
 
-		const sidebarContext = EditorPartModalSidebarContext.bindTo(this.scopedContextKeyService);
+		const sidebarContext = EditorPartModalSidebarContext.bindTo(this.modalContextKeyService);
 		sidebarContext.set(this._hasSidebar);
 
-		const sidebarVisibleContext = EditorPartModalSidebarVisibleContext.bindTo(this.scopedContextKeyService);
+		const sidebarVisibleContext = EditorPartModalSidebarVisibleContext.bindTo(this.modalContextKeyService);
 		sidebarVisibleContext.set(this._hasSidebar && !this._sidebarHidden);
 		this._register(this.onDidToggleSidebar(() => sidebarVisibleContext.set(this._hasSidebar && !this._sidebarHidden)));
 

--- a/src/vs/workbench/test/browser/parts/editor/modalEditorSidebar.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/modalEditorSidebar.test.ts
@@ -8,6 +8,7 @@ import { Emitter, Event } from '../../../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IModalEditorPartOptions, IModalEditorSidebar } from '../../../../../platform/editor/common/editor.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 
 const MODAL_MIN_WIDTH = 400;
 const MODAL_SIDEBAR_MIN_WIDTH = 160;
@@ -25,6 +26,8 @@ class TestModalEditorSidebarHost extends Disposable {
 	private readonly _onDidLayout = this._register(new Emitter<{ readonly height: number; readonly width: number }>());
 
 	private readonly contentDisposable = this._register(new MutableDisposable());
+
+	private readonly contextKeyService = this._register(new MockContextKeyService());
 
 	private _sidebarWidth = MODAL_SIDEBAR_DEFAULT_WIDTH;
 	get sidebarWidth(): number { return this._sidebarWidth; }
@@ -82,7 +85,7 @@ class TestModalEditorSidebarHost extends Disposable {
 
 	private renderContent(content: IModalEditorSidebar): void {
 		this._renderCount++;
-		this.contentDisposable.value = content.render({} /* stub container */, this._onDidLayout.event);
+		this.contentDisposable.value = content.render({} /* stub container */, this._onDidLayout.event, this.contextKeyService);
 	}
 
 	// --- resize (mirrors sash logic) ----------------------------------------


### PR DESCRIPTION
Close the modal editor on `Escape` when focus is inside the modal sidebar (e.g. the Changes Tree in the Sessions window).

## Problem

The _Close Modal Editor_ command is gated on the `editorPartModal` context key. That key was bound to the editor part's context key service, which is scoped to the **editor grid container** only. Context-key resolution in VS Code is **parent-chain based** (not DOM based), and the sidebar tree is created with the Changes view's instantiation service, so its context parent chain never included the modal. As a result `editorPartModal` was invisible while the sidebar had focus and pressing `Escape` did not close the modal.

## Fix

- **`modalEditorPart.ts`**: Create a single context key service scoped to the entire modal element (`.monaco-modal-editor-block`). The editor part is now instantiated via a child instantiation service that injects this service, and the modal-level context keys (`editorPartModal`, etc.) are bound on it. The sidebar gets a child context key service (scoped to the sidebar container) passed into the `render` callback.
- **`editor.ts`**: `IModalEditorSidebar.render` now receives the modal-scoped `IContextKeyService`.
- **`changesView.ts`**: The sidebar Changes Tree is created with an instantiation service that uses the provided context key service, so the tree''s context descends from the modal. The row-action renderer stays on the Changes view''s instantiation service so its menu context keys are preserved.
- **`editorCommands.ts`**: Added an `Escape` keybinding for the close command when a list/tree is focused. It still closes the modal on a single press, but yields to the tree''s own `Escape` features that should close first (the find widget and sticky scroll).

## Notes for reviewers

- Other `Escape`-handled features (tree find widget, sticky scroll) still close first; the modal close yields to them via the `treeFindOpen` / `treestickyScrollFocused` negations.
- The list selection is intentionally **not** cleared first, so a single `Escape` closes the modal.
- Validated with a full `tsc` type check of `./src/tsconfig.json` and ESLint on the modified files.

closes https://github.com/microsoft/vscode/issues/320013