### PR TITLE
sessions: drag-and-drop reordering in the sessions list

### DIFF
--- a/src/vs/sessions/SESSIONS_LIST.md
+++ b/src/vs/sessions/SESSIONS_LIST.md
@@ -85,6 +85,20 @@ A built-in find widget filters the list by session title and section label. When
 
 Pinned sessions appear in a dedicated "Pinned" section at the top. Pin state is managed by `ISessionsListModelService` and persisted locally (not synced to providers).
 
+### Manual Reordering (Drag & Drop)
+
+Regular sessions can be reordered by dragging them up or down within the list. An insertion line is shown between rows while dragging.
+
+- **Storage** — reordering stores a synthetic numeric *sort key* per session in `ISessionsListModelService` (persisted locally, not synced). It is used **only** for sorting; the provider's real `createdAt`/`updatedAt` are never modified. A separate override map is kept for each sort mode (Created vs Updated).
+- **Sort key** — on drop, the new key is the midpoint between the effective keys of the sessions immediately above and below the drop point. Dropping above the first session uses the current time (so it sorts to the top). Dropping below the last session steps below the last key.
+- **Dropping the fake value** — if a session's natural timestamp already sorts it into the dropped slot (e.g. after dragging it down and back), the stored override is removed so the list falls back to natural ordering.
+- **Grouping by Date** — the regular list is one continuous sequence, so dragging can move a session across date buckets (e.g. to the top makes it "Today").
+- **Grouping by Workspace** — reordering is restricted to within the same workspace group; drops onto another workspace are rejected.
+- **Scope** — only regular sessions reorder. Drops onto the Pinned and Done sections, section headers, and "show more" rows are rejected.
+- **Multi-selection** — dragging multiple selected sessions moves them as a contiguous block, preserving their relative order. The drag label reads `"N sessions"`. Dragging sessions into the sessions grid opens all of them.
+
+The insertion line relies on the base list widget's `drop-target-before`/`drop-target-after` feedback (colored by `list.dropBetweenBackground`). The widget converts an "after" indicator on row *i* into a "before" indicator on row *i+1*, so hovering the bottom half of the upper row and the top half of the lower row render the exact same DOM line with no shift.
+
 ### Read / Unread
 
 - Sessions start as **unread**

--- a/src/vs/sessions/browser/parts/sessionDropTarget.ts
+++ b/src/vs/sessions/browser/parts/sessionDropTarget.ts
@@ -14,6 +14,7 @@ import { activeContrastBorder } from '../../../platform/theme/common/colorRegist
 import { IThemeService, Themable } from '../../../platform/theme/common/themeService.js';
 import { EDITOR_DRAG_AND_DROP_BACKGROUND } from '../../../workbench/common/theme.js';
 import { DraggedSessionIdentifier } from '../dnd.js';
+import { ISession } from '../../services/sessions/common/session.js';
 import { ISessionsManagementService } from '../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../services/sessions/browser/sessionsService.js';
 
@@ -135,17 +136,32 @@ class SessionDropOverlay extends Themable {
 			return;
 		}
 
-		const dragged = data[0];
-		if (dragged.sessionId === this.targetSessionId) {
-			return; // dropping a session next to itself is a no-op
+		// Resolve all dragged sessions (preserving drag order), skipping the
+		// target itself so dropping a session next to itself is a no-op.
+		const sessions: ISession[] = [];
+		for (const dragged of data) {
+			if (dragged.sessionId === this.targetSessionId) {
+				continue;
+			}
+			const session = this._sessionsManagementService.getSession(dragged.resource);
+			if (session) {
+				sessions.push(session);
+			}
 		}
 
-		const session = this._sessionsManagementService.getSession(dragged.resource);
-		if (!session) {
+		if (sessions.length === 0) {
 			return;
 		}
 
-		this._sessionsService.insertAt(session, this.targetSessionId, side);
+		const primary = sessions[0];
+
+		// Insert each next to the target. When dropping on the right we insert in
+		// reverse so the drag order is preserved left-to-right; only the primary
+		// (first) dragged session is activated.
+		const ordered = side === 'right' ? [...sessions].reverse() : sessions;
+		for (const session of ordered) {
+			this._sessionsService.insertAt(session, this.targetSessionId, side, session === primary);
+		}
 	}
 
 	private _positionOverlay(mousePosX: number): void {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -6,7 +6,7 @@
 import '../media/sessionsList.css';
 import * as DOM from '../../../../../base/browser/dom.js';
 import { Gesture } from '../../../../../base/browser/touch.js';
-import { IListVirtualDelegate, NotSelectableGroupId } from '../../../../../base/browser/ui/list/list.js';
+import { IListVirtualDelegate, ListDragOverEffectPosition, ListDragOverEffectType, NotSelectableGroupId } from '../../../../../base/browser/ui/list/list.js';
 import { IListStyles } from '../../../../../base/browser/ui/list/listWidget.js';
 import { IObjectTreeElement, ITreeNode, ITreeRenderer, ITreeContextMenuEvent, ObjectTreeElementCollapseState, ITreeDragAndDrop, ITreeDragOverReaction } from '../../../../../base/browser/ui/tree/tree.js';
 import { RenderIndentGuides, TreeFindMode } from '../../../../../base/browser/ui/tree/abstractTree.js';
@@ -44,7 +44,7 @@ import { HoverStyle } from '../../../../../base/browser/ui/hover/hover.js';
 import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.js';
 import { ISessionsManagementService, IActiveSession } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
-import { ISessionsListModelService } from '../../../../services/sessions/browser/sessionsListModelService.js';
+import { ISessionsListModelService, SessionSortMode } from '../../../../services/sessions/browser/sessionsListModelService.js';
 import { IWorkbenchAssignmentService } from '../../../../../workbench/services/assignment/common/assignmentService.js';
 // =============================================================================
 // TEMPORARY (tracked by https://github.com/microsoft/vscode/issues/320480)
@@ -65,7 +65,7 @@ import { IAgentHostFilterService } from '../../../../services/agentHostFilter/co
 import { LocalSelectionTransfer } from '../../../../../platform/dnd/browser/dnd.js';
 import { DraggedSessionIdentifier, SessionsDataTransfers } from '../../../../browser/dnd.js';
 import { IDragAndDropData } from '../../../../../base/browser/dnd.js';
-import { ElementsDragAndDropData } from '../../../../../base/browser/ui/list/listView.js';
+import { ElementsDragAndDropData, ListViewTargetSector } from '../../../../../base/browser/ui/list/listView.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { buildSessionHoverContent } from '../sessionHoverContent.js';
 import { SessionStatusIcon } from '../../../../browser/sessionStatusIcon.js';
@@ -92,6 +92,13 @@ export enum SessionsSorting {
 	Created = 'created',
 	Updated = 'updated',
 }
+
+function sortingToMode(sorting: SessionsSorting): SessionSortMode {
+	return sorting === SessionsSorting.Updated ? 'updated' : 'created';
+}
+
+/** Fallback spacing (ms) used when assigning synthetic sort keys past an open boundary. */
+const SORT_FALLBACK_STEP_MS = 60_000;
 
 export interface ISessionSection {
 	readonly id: string;
@@ -759,9 +766,27 @@ class SessionsAccessibilityProvider {
 
 //#region Drag and Drop
 
+/**
+ * Callbacks the sessions list provides to its drag-and-drop controller so the
+ * controller can validate and apply manual reordering without owning the list
+ * model itself.
+ */
+interface ISessionsListDndDelegate {
+	/** Whether a session may participate in reordering (regular, non-pinned, non-archived). */
+	isReorderable(session: ISession): boolean;
+	/** Whether the dragged sessions may be reordered relative to the given target. */
+	canDropOn(dragged: ISession[], target: ISession): boolean;
+	/** Apply the reorder, placing the dragged sessions before/after the target. */
+	reorder(dragged: ISession[], target: ISession, position: 'before' | 'after'): void;
+}
+
 class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<SessionListItem> {
 
 	private readonly _transfer = LocalSelectionTransfer.getInstance<DraggedSessionIdentifier>();
+
+	constructor(private readonly delegate: ISessionsListDndDelegate) {
+		super();
+	}
 
 	getDragURI(element: SessionListItem): string | null {
 		if (isSessionSection(element) || isSessionShowMore(element)) {
@@ -771,7 +796,7 @@ class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<Ses
 	}
 
 	getDragLabel(elements: SessionListItem[]): string | undefined {
-		const sessions = elements.filter((e): e is ISession => !isSessionSection(e) && !isSessionShowMore(e));
+		const sessions = this.toSessions(elements);
 		if (sessions.length === 0) {
 			return undefined;
 		}
@@ -782,8 +807,7 @@ class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<Ses
 	}
 
 	onDragStart(data: IDragAndDropData, originalEvent: DragEvent): void {
-		const elements = (data instanceof ElementsDragAndDropData ? data.elements : []) as SessionListItem[];
-		const sessions = elements.filter((e): e is ISession => !isSessionSection(e) && !isSessionShowMore(e));
+		const sessions = this.toSessions(data instanceof ElementsDragAndDropData ? data.elements as SessionListItem[] : []);
 		if (sessions.length === 0) {
 			return;
 		}
@@ -803,11 +827,62 @@ class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<Ses
 		this._transfer.clearData(DraggedSessionIdentifier.prototype);
 	}
 
-	onDragOver(): boolean | ITreeDragOverReaction {
-		return false;
+	onDragOver(data: IDragAndDropData, targetElement: SessionListItem | undefined, _targetIndex: number | undefined, targetSector: ListViewTargetSector | undefined): boolean | ITreeDragOverReaction {
+		const target = this.resolveReorderTarget(data, targetElement);
+		if (!target) {
+			return false;
+		}
+		const position = sectorToPosition(targetSector);
+		return {
+			accept: true,
+			effect: {
+				type: ListDragOverEffectType.Move,
+				position: position === 'after' ? ListDragOverEffectPosition.After : ListDragOverEffectPosition.Before,
+			},
+		};
 	}
 
-	drop(): void { }
+	drop(data: IDragAndDropData, targetElement: SessionListItem | undefined, _targetIndex: number | undefined, targetSector: ListViewTargetSector | undefined): void {
+		const target = this.resolveReorderTarget(data, targetElement);
+		if (!target) {
+			return;
+		}
+		const dragged = this.toSessions(data instanceof ElementsDragAndDropData ? data.elements as SessionListItem[] : []);
+		this.delegate.reorder(dragged, target, sectorToPosition(targetSector));
+	}
+
+	/**
+	 * Resolve the session the drop should be positioned against, or `undefined`
+	 * if the current drag is not a valid in-list reorder.
+	 */
+	private resolveReorderTarget(data: IDragAndDropData, targetElement: SessionListItem | undefined): ISession | undefined {
+		if (!targetElement || isSessionSection(targetElement) || isSessionShowMore(targetElement)) {
+			return undefined;
+		}
+		const target = targetElement;
+		if (!this.delegate.isReorderable(target)) {
+			return undefined;
+		}
+		const dragged = this.toSessions(data instanceof ElementsDragAndDropData ? data.elements as SessionListItem[] : []);
+		if (dragged.length === 0 || dragged.some(s => s.sessionId === target.sessionId)) {
+			return undefined;
+		}
+		if (dragged.some(s => !this.delegate.isReorderable(s))) {
+			return undefined;
+		}
+		if (!this.delegate.canDropOn(dragged, target)) {
+			return undefined;
+		}
+		return target;
+	}
+
+	private toSessions(elements: SessionListItem[]): ISession[] {
+		return elements.filter((e): e is ISession => !isSessionSection(e) && !isSessionShowMore(e));
+	}
+}
+
+function sectorToPosition(sector: ListViewTargetSector | undefined): 'before' | 'after' {
+	return sector !== undefined && sector >= ListViewTargetSector.CENTER_BOTTOM ? 'after' : 'before';
 }
 
 //#endregion
@@ -988,7 +1063,11 @@ export class SessionsList extends Disposable implements ISessionsList {
 			],
 			{
 				accessibilityProvider: new SessionsAccessibilityProvider(),
-				dnd: this._register(new SessionsListDragAndDrop()),
+				dnd: this._register(new SessionsListDragAndDrop({
+					isReorderable: session => this.isReorderable(session),
+					canDropOn: (dragged, target) => this.canReorderOnto(dragged, target),
+					reorder: (dragged, target, position) => this.reorderSessions(dragged, target, position),
+				})),
 				identityProvider: {
 					getId: (element: SessionListItem) => {
 						if (isSessionSection(element)) {
@@ -1222,7 +1301,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		}
 
 		const grouping = this.options.grouping();
-		const sections = groupSessionsForList(filtered, grouping, this.options.sorting(), session => this.isSessionPinned(session));
+		const sections = groupSessionsForList(filtered, grouping, this.options.sorting(), session => this.isSessionPinned(session), (s, sorting) => this._sessionsListModelService.getSortKey(s, sortingToMode(sorting)));
 
 		const hasTodaySessions = sections.some(s => s.id === 'today' && s.sessions.length > 0);
 
@@ -1455,6 +1534,77 @@ export class SessionsList extends Disposable implements ISessionsList {
 	 * the full selection is returned (clicked session first), otherwise just the
 	 * clicked session.
 	 */
+	/**
+	 * Whether a session may participate in manual reordering. Only regular
+	 * sessions reorder — pinned and archived (Done) sessions keep their fixed
+	 * sections.
+	 */
+	private isReorderable(session: ISession): boolean {
+		return !session.isArchived.get() && !this.isSessionPinned(session);
+	}
+
+	/**
+	 * Whether the dragged sessions can be reordered relative to the target.
+	 * When grouping by workspace, reordering is restricted to within the same
+	 * workspace group.
+	 */
+	private canReorderOnto(dragged: ISession[], target: ISession): boolean {
+		if (this.options.grouping() === SessionsGrouping.Workspace) {
+			const targetLabel = sessionWorkspaceLabel(target);
+			return dragged.every(s => sessionWorkspaceLabel(s) === targetLabel);
+		}
+		return true;
+	}
+
+	/**
+	 * Reorder the dragged sessions so they land as a contiguous block before or
+	 * after the target session, persisting a synthetic sort key (the midpoint of
+	 * the surrounding sessions' keys). When the dragged sessions' natural
+	 * timestamps already sort them into the dropped slot, any stored override is
+	 * dropped instead so the list falls back to natural ordering.
+	 */
+	private reorderSessions(dragged: ISession[], target: ISession, position: 'before' | 'after'): void {
+		const mode = sortingToMode(this.options.sorting());
+		const grouping = this.options.grouping();
+		const getKey = (s: ISession) => this._sessionsListModelService.getSortKey(s, mode);
+
+		// Derive neighbours from the actual visible display order (which already
+		// respects filtering and grouping) so the drop slot matches what the user
+		// sees. For workspace grouping only the target's workspace participates;
+		// for date grouping the regular list is one continuous sequence.
+		let scope = this.getVisibleSessions().filter(s => this.isReorderable(s));
+		if (grouping === SessionsGrouping.Workspace) {
+			const targetLabel = sessionWorkspaceLabel(target);
+			scope = scope.filter(s => sessionWorkspaceLabel(s) === targetLabel);
+		}
+
+		const draggedIds = new Set(dragged.map(s => s.sessionId));
+		const draggedOrdered = scope.filter(s => draggedIds.has(s.sessionId));
+		if (draggedOrdered.length === 0) {
+			return;
+		}
+		const remaining = scope.filter(s => !draggedIds.has(s.sessionId));
+
+		const targetIndex = remaining.findIndex(s => s.sessionId === target.sessionId);
+		if (targetIndex === -1) {
+			return;
+		}
+
+		const insertIndex = position === 'before' ? targetIndex : targetIndex + 1;
+		const above = remaining[insertIndex - 1];
+		const below = remaining[insertIndex];
+
+		const { set, clear } = computeReorderSortChanges({
+			draggedIds: draggedOrdered.map(s => s.sessionId),
+			naturalKeys: draggedOrdered.map(s => this._sessionsListModelService.getNaturalSortKey(s, mode)),
+			aboveKey: above ? getKey(above) : undefined,
+			belowKey: below ? getKey(below) : undefined,
+			now: Date.now(),
+			fallbackStep: SORT_FALLBACK_STEP_MS,
+		});
+		this._sessionsListModelService.applySortChanges(mode, set, clear);
+	}
+
 	private getMultiSelectedSessions(session: ISession): ISession[] {
 		const selection = this.tree.getSelection().filter((s): s is ISession => !!s && !isSessionSection(s) && !isSessionShowMore(s));
 		return selection.includes(session) ? [session, ...selection.filter(s => s !== session)] : [session];
@@ -1772,13 +1922,78 @@ function sessionMatchesFolder(session: ISession, folder: URI): boolean {
 
 //#region Sorting & Grouping Helpers
 
-export function sortSessions(sessions: ISession[], sorting: SessionsSorting): ISession[] {
-	return [...sessions].sort((a, b) => {
-		if (sorting === SessionsSorting.Updated) {
-			return b.updatedAt.get().getTime() - a.updatedAt.get().getTime();
+export function sortSessions(sessions: ISession[], sorting: SessionsSorting, getSortKey?: (session: ISession, sorting: SessionsSorting) => number): ISession[] {
+	const key = getSortKey ?? defaultSortKey;
+	return [...sessions].sort((a, b) => key(b, sorting) - key(a, sorting));
+}
+
+function defaultSortKey(session: ISession, sorting: SessionsSorting): number {
+	if (sorting === SessionsSorting.Updated) {
+		return session.updatedAt.get().getTime();
+	}
+	return session.createdAt.getTime();
+}
+
+export interface IReorderSortInput {
+	/** Dragged session ids in display (descending-key) order. */
+	readonly draggedIds: readonly string[];
+	/** Natural sort key per dragged session (same order as {@link draggedIds}). */
+	readonly naturalKeys: readonly number[];
+	/** Effective key of the neighbour above the drop point (higher), if any. */
+	readonly aboveKey: number | undefined;
+	/** Effective key of the neighbour below the drop point (lower), if any. */
+	readonly belowKey: number | undefined;
+	/** Current time, used when dropping above the first session. */
+	readonly now: number;
+	/** Spacing used when stepping past an open boundary. */
+	readonly fallbackStep: number;
+}
+
+/**
+ * Compute the manual sort-override changes for a reorder drop. Assigns the
+ * dragged block strictly-descending synthetic keys spread between the
+ * surrounding neighbours, except when the sessions' natural keys already sort
+ * them into the dropped slot — in which case any existing override is dropped.
+ */
+export function computeReorderSortChanges(input: IReorderSortInput): { set: Map<string, number>; clear: string[] } {
+	const { draggedIds, naturalKeys, aboveKey, belowKey, now, fallbackStep } = input;
+	const count = draggedIds.length;
+
+	// "Drop the fake value": when every dragged session's natural key already
+	// lands strictly inside the surrounding gap (and in descending display
+	// order), clear overrides instead of storing synthetic keys.
+	const upperFit = aboveKey ?? Number.POSITIVE_INFINITY;
+	const lowerFit = belowKey ?? Number.NEGATIVE_INFINITY;
+	let naturalFits = true;
+	for (let i = 0; i < count; i++) {
+		if (!(naturalKeys[i] < upperFit && naturalKeys[i] > lowerFit)) {
+			naturalFits = false;
+			break;
 		}
-		return b.createdAt.getTime() - a.createdAt.getTime();
-	});
+		if (i > 0 && !(naturalKeys[i] < naturalKeys[i - 1])) {
+			naturalFits = false;
+			break;
+		}
+	}
+
+	const set = new Map<string, number>();
+	const clear: string[] = [];
+	if (naturalFits) {
+		for (const id of draggedIds) {
+			clear.push(id);
+		}
+	} else {
+		// Spread `count` strictly-descending synthetic keys across the gap. An
+		// open top boundary uses the current time so the block sorts to the very
+		// top; an open bottom boundary steps below the last key.
+		const upper = aboveKey ?? now;
+		const lower = belowKey ?? (upper - (count + 1) * fallbackStep);
+		const step = (upper - lower) / (count + 1);
+		for (let i = 0; i < count; i++) {
+			set.set(draggedIds[i], upper - (i + 1) * step);
+		}
+	}
+	return { set, clear };
 }
 
 export function groupSessionsForList(
@@ -1786,8 +2001,9 @@ export function groupSessionsForList(
 	grouping: SessionsGrouping,
 	sorting: SessionsSorting,
 	isSessionPinned: (session: ISession) => boolean,
+	getSortKey?: (session: ISession, sorting: SessionsSorting) => number,
 ): ISessionSection[] {
-	const sorted = sortSessions(sessions, sorting);
+	const sorted = sortSessions(sessions, sorting, getSortKey);
 
 	// Archived always wins over pinned so done sessions stay grouped together.
 	const pinned: ISession[] = [];
@@ -1810,7 +2026,7 @@ export function groupSessionsForList(
 
 	sections.push(...(grouping === SessionsGrouping.Workspace
 		? groupByWorkspace(regular)
-		: groupByDate(regular, sorting)));
+		: groupByDate(regular, sorting, getSortKey)));
 
 	if (archived.length > 0) {
 		sections.push({ id: 'archived', label: localize('archived', "Done"), sessions: archived });
@@ -1819,11 +2035,15 @@ export function groupSessionsForList(
 	return sections;
 }
 
+/** The workspace group label a session belongs to (matches {@link groupByWorkspace}). */
+function sessionWorkspaceLabel(session: ISession): string {
+	return session.workspace.get()?.label || localize('unknown', "Unknown");
+}
+
 export function groupByWorkspace(sessions: ISession[]): ISessionSection[] {
 	const groups = new Map<string, ISession[]>();
 	for (const session of sessions) {
-		const workspace = session.workspace.get();
-		const label = workspace?.label || localize('unknown', "Unknown");
+		const label = sessionWorkspaceLabel(session);
 		let group = groups.get(label);
 		if (!group) {
 			group = [];
@@ -1852,7 +2072,8 @@ export function groupByWorkspace(sessions: ISession[]): ISessionSection[] {
 	return result;
 }
 
-export function groupByDate(sessions: ISession[], sorting: SessionsSorting): ISessionSection[] {
+export function groupByDate(sessions: ISession[], sorting: SessionsSorting, getSortKey?: (session: ISession, sorting: SessionsSorting) => number): ISessionSection[] {
+	const key = getSortKey ?? defaultSortKey;
 	const now = new Date();
 	const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
 	const startOfYesterday = startOfToday - 86_400_000;
@@ -1864,9 +2085,7 @@ export function groupByDate(sessions: ISession[], sorting: SessionsSorting): ISe
 	const older: ISession[] = [];
 
 	for (const session of sessions) {
-		const time = sorting === SessionsSorting.Updated
-			? session.updatedAt.get().getTime()
-			: session.createdAt.getTime();
+		const time = key(session, sorting);
 
 		if (time >= startOfToday) {
 			today.push(session);

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts
@@ -9,7 +9,7 @@ import { observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IChat, ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
-import { groupByWorkspace, groupSessionsForList, sortSessions, SessionsGrouping, SessionsSorting } from '../../browser/views/sessionsList.js';
+import { computeReorderSortChanges, groupByWorkspace, groupSessionsForList, sortSessions, SessionsGrouping, SessionsSorting } from '../../browser/views/sessionsList.js';
 
 function createSession(id: string, opts: {
 	workspaceLabel?: string;
@@ -185,6 +185,113 @@ suite('Sessions - SessionsList Helpers', () => {
 
 			assert.deepStrictEqual(sections.map(section => section.id), ['archived']);
 			assert.deepStrictEqual(sections[0].sessions.map(session => session.sessionId), ['archived-pinned']);
+		});
+	});
+
+	suite('computeReorderSortChanges', () => {
+		const NOW = 1_000_000;
+		const STEP = 60_000;
+
+		test('single drop between two neighbours uses the midpoint', () => {
+			const { set, clear } = computeReorderSortChanges({
+				draggedIds: ['x'],
+				naturalKeys: [10],
+				aboveKey: 100,
+				belowKey: 50,
+				now: NOW,
+				fallbackStep: STEP,
+			});
+
+			assert.deepStrictEqual([...set], [['x', 75]]);
+			assert.deepStrictEqual(clear, []);
+		});
+
+		test('drop above the first session uses the current time', () => {
+			const { set, clear } = computeReorderSortChanges({
+				draggedIds: ['x'],
+				naturalKeys: [10],
+				aboveKey: undefined,
+				belowKey: 200,
+				now: NOW,
+				fallbackStep: STEP,
+			});
+
+			assert.deepStrictEqual(clear, []);
+			const value = set.get('x')!;
+			assert.ok(value > 200 && value < NOW, `expected ${value} between 200 and ${NOW}`);
+		});
+
+		test('drop below the last session steps below the last key', () => {
+			const { set, clear } = computeReorderSortChanges({
+				draggedIds: ['x'],
+				naturalKeys: [500],
+				aboveKey: 100,
+				belowKey: undefined,
+				now: NOW,
+				fallbackStep: STEP,
+			});
+
+			assert.deepStrictEqual(clear, []);
+			assert.ok(set.get('x')! < 100);
+		});
+
+		test('drops the fake value when the natural key already fits the slot', () => {
+			const { set, clear } = computeReorderSortChanges({
+				draggedIds: ['x'],
+				naturalKeys: [75],
+				aboveKey: 100,
+				belowKey: 50,
+				now: NOW,
+				fallbackStep: STEP,
+			});
+
+			assert.deepStrictEqual([...set], []);
+			assert.deepStrictEqual(clear, ['x']);
+		});
+
+		test('multi-block gets strictly descending keys inside the gap', () => {
+			const { set, clear } = computeReorderSortChanges({
+				draggedIds: ['a', 'b', 'c'],
+				naturalKeys: [5, 4, 3],
+				aboveKey: 100,
+				belowKey: 40,
+				now: NOW,
+				fallbackStep: STEP,
+			});
+
+			assert.deepStrictEqual(clear, []);
+			const values = ['a', 'b', 'c'].map(id => set.get(id)!);
+			assert.deepStrictEqual(values, [85, 70, 55]);
+			assert.ok(values.every(v => v > 40 && v < 100));
+		});
+
+		test('multi-block clears overrides when all natural keys already fit in order', () => {
+			const { set, clear } = computeReorderSortChanges({
+				draggedIds: ['a', 'b'],
+				naturalKeys: [80, 60],
+				aboveKey: 100,
+				belowKey: 40,
+				now: NOW,
+				fallbackStep: STEP,
+			});
+
+			assert.deepStrictEqual([...set], []);
+			assert.deepStrictEqual(clear, ['a', 'b']);
+		});
+
+		test('multi-block assigns synthetic keys when natural order does not fit', () => {
+			const { set, clear } = computeReorderSortChanges({
+				draggedIds: ['a', 'b'],
+				naturalKeys: [60, 80], // ascending: does not match descending display order
+				aboveKey: 100,
+				belowKey: 40,
+				now: NOW,
+				fallbackStep: STEP,
+			});
+
+			assert.deepStrictEqual(clear, []);
+			assert.strictEqual(set.size, 2);
+			assert.ok(set.get('a')! > set.get('b')!);
 		});
 	});
 });

--- a/src/vs/sessions/services/sessions/browser/sessionsListModelService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsListModelService.ts
@@ -16,7 +16,15 @@ import { ISessionsService } from './sessionsService.js';
 export const enum SessionListModelChangeKind {
 	Pinned = 'pinned',
 	Read = 'read',
+	Sort = 'sort',
 }
+
+/**
+ * The two sort modes the sessions list supports. Mirrors the values of the
+ * (contrib-layer) `SessionsSorting` enum, kept as a plain string union here so
+ * this service stays in the services layer and never imports from contrib.
+ */
+export type SessionSortMode = 'created' | 'updated';
 
 export interface ISessionListModelChangeEvent {
 	readonly changes: ReadonlyArray<{ readonly sessionId: string; readonly kind: SessionListModelChangeKind }>;
@@ -48,6 +56,29 @@ export interface ISessionsListModelService {
 	isSessionRead(session: ISession): boolean;
 	markAllRead(sessions: ISession[]): void;
 
+	// -- Manual sort order --
+
+	/**
+	 * The effective numeric sort key for a session in the given sort mode. This
+	 * is the manually assigned override when one exists, otherwise the natural
+	 * timestamp (`createdAt` for `'created'`, `updatedAt` for `'updated'`).
+	 * Sessions are displayed in descending order of this value.
+	 */
+	getSortKey(session: ISession, mode: SessionSortMode): number;
+
+	/** The natural (non-overridden) sort key for a session in the given mode. */
+	getNaturalSortKey(session: ISession, mode: SessionSortMode): number;
+
+	/** Whether the session has a manual sort override in the given mode. */
+	hasSortOverride(sessionId: string, mode: SessionSortMode): boolean;
+
+	/**
+	 * Apply a batch of manual sort changes for a single mode. Overrides in
+	 * `set` are stored, ids in `clear` are removed (falling back to the natural
+	 * key). Fires a single {@link onDidChange} for all affected sessions.
+	 */
+	applySortChanges(mode: SessionSortMode, set: ReadonlyMap<string, number>, clear: Iterable<string>): void;
+
 	// -- Status icon --
 
 	/**
@@ -72,6 +103,7 @@ export class SessionsListModelService extends Disposable implements ISessionsLis
 
 	private static readonly PINNED_SESSIONS_KEY = 'sessionsListControl.pinnedSessions';
 	private static readonly READ_SESSIONS_KEY = 'sessionsListControl.readSessions';
+	private static readonly SORT_OVERRIDES_KEY = 'sessionsListControl.sortOverrides';
 
 	/**
 	 * Sessions created on or after this date start as unread by default.
@@ -86,6 +118,7 @@ export class SessionsListModelService extends Disposable implements ISessionsLis
 
 	private readonly _pinnedSessionIds: Set<string>;
 	private readonly _readSessionIds: Set<string>;
+	private readonly _sortOverrides: Record<SessionSortMode, Map<string, number>>;
 	private readonly _lastKnownStatus = new Map<string, SessionStatus>();
 
 	constructor(
@@ -97,6 +130,7 @@ export class SessionsListModelService extends Disposable implements ISessionsLis
 
 		this._pinnedSessionIds = this.loadSet(SessionsListModelService.PINNED_SESSIONS_KEY);
 		this._readSessionIds = this.loadSet(SessionsListModelService.READ_SESSIONS_KEY);
+		this._sortOverrides = this.loadSortOverrides();
 
 		this._register(this.sessionsManagementService.onDidChangeSessions(e => {
 			for (const session of e.removed) {
@@ -198,6 +232,41 @@ export class SessionsListModelService extends Disposable implements ISessionsLis
 		}
 	}
 
+	// -- Manual sort order --
+
+	getNaturalSortKey(session: ISession, mode: SessionSortMode): number {
+		return mode === 'updated' ? session.updatedAt.get().getTime() : session.createdAt.getTime();
+	}
+
+	getSortKey(session: ISession, mode: SessionSortMode): number {
+		const override = this._sortOverrides[mode].get(session.sessionId);
+		return override ?? this.getNaturalSortKey(session, mode);
+	}
+
+	hasSortOverride(sessionId: string, mode: SessionSortMode): boolean {
+		return this._sortOverrides[mode].has(sessionId);
+	}
+
+	applySortChanges(mode: SessionSortMode, set: ReadonlyMap<string, number>, clear: Iterable<string>): void {
+		const map = this._sortOverrides[mode];
+		const changes: { sessionId: string; kind: SessionListModelChangeKind }[] = [];
+		for (const sessionId of clear) {
+			if (map.delete(sessionId)) {
+				changes.push({ sessionId, kind: SessionListModelChangeKind.Sort });
+			}
+		}
+		for (const [sessionId, value] of set) {
+			if (map.get(sessionId) !== value) {
+				map.set(sessionId, value);
+				changes.push({ sessionId, kind: SessionListModelChangeKind.Sort });
+			}
+		}
+		if (changes.length > 0) {
+			this.saveSortOverrides();
+			this._onDidChange.fire({ changes });
+		}
+	}
+
 	// -- Status icon --
 
 	getStatusIcon(status: SessionStatus, isRead: boolean, isArchived: boolean, pullRequestIcon?: ThemeIcon): ThemeIcon {
@@ -235,6 +304,17 @@ export class SessionsListModelService extends Disposable implements ISessionsLis
 			this.saveSet(SessionsListModelService.READ_SESSIONS_KEY, this._readSessionIds);
 			changes.push({ sessionId: session.sessionId, kind: SessionListModelChangeKind.Read });
 		}
+		let sortChanged = false;
+		if (this._sortOverrides.created.delete(session.sessionId)) {
+			sortChanged = true;
+		}
+		if (this._sortOverrides.updated.delete(session.sessionId)) {
+			sortChanged = true;
+		}
+		if (sortChanged) {
+			this.saveSortOverrides();
+			changes.push({ sessionId: session.sessionId, kind: SessionListModelChangeKind.Sort });
+		}
 		if (changes.length > 0) {
 			this._onDidChange.fire({ changes });
 		}
@@ -263,6 +343,41 @@ export class SessionsListModelService extends Disposable implements ISessionsLis
 		} else {
 			this.storageService.store(key, JSON.stringify([...set]), StorageScope.PROFILE, StorageTarget.USER);
 		}
+	}
+
+	private loadSortOverrides(): Record<SessionSortMode, Map<string, number>> {
+		const result: Record<SessionSortMode, Map<string, number>> = { created: new Map(), updated: new Map() };
+		const raw = this.storageService.get(SessionsListModelService.SORT_OVERRIDES_KEY, StorageScope.PROFILE);
+		if (raw) {
+			try {
+				const parsed = JSON.parse(raw) as Partial<Record<SessionSortMode, Record<string, number>>>;
+				for (const mode of ['created', 'updated'] as const) {
+					const entries = parsed[mode];
+					if (entries) {
+						for (const [sessionId, value] of Object.entries(entries)) {
+							if (typeof value === 'number') {
+								result[mode].set(sessionId, value);
+							}
+						}
+					}
+				}
+			} catch {
+				// ignore corrupt data
+			}
+		}
+		return result;
+	}
+
+	private saveSortOverrides(): void {
+		if (this._sortOverrides.created.size === 0 && this._sortOverrides.updated.size === 0) {
+			this.storageService.remove(SessionsListModelService.SORT_OVERRIDES_KEY, StorageScope.PROFILE);
+			return;
+		}
+		const serialized = {
+			created: Object.fromEntries(this._sortOverrides.created),
+			updated: Object.fromEntries(this._sortOverrides.updated),
+		};
+		this.storageService.store(SessionsListModelService.SORT_OVERRIDES_KEY, JSON.stringify(serialized), StorageScope.PROFILE, StorageTarget.USER);
 	}
 }
 


### PR DESCRIPTION
## What

Adds drag-and-drop reordering to the sessions list in the Agents window.

- **Storage**: a synthetic numeric *sort key* is stored per session in `ISessionsListModelService` (persisted locally, not synced to providers). It is used **only** for sorting — the provider's real `createdAt`/`updatedAt` are never modified. A separate override map is kept for each sort mode (Created vs Updated).
- **Sort key**: on drop, the new key is the midpoint between the effective keys of the sessions immediately above and below the drop point. Dropping above the first session uses the current time (sorts to the top); dropping below the last session steps below the last key.
- **Dropping the fake value**: if a session's natural timestamp already sorts it into the dropped slot (e.g. after dragging it down and back), the stored override is removed so the list falls back to natural ordering.
- **Grouping by Date**: the regular list is one continuous sequence, so dragging can move a session across date buckets (e.g. to the top → "Today").
- **Grouping by Workspace**: reordering is restricted to within the same workspace group; drops onto another workspace are rejected.
- **Scope**: only regular sessions reorder. Drops onto the Pinned and Done sections, section headers, and "show more" rows are rejected.
- **Multi-selection**: dragging multiple selected sessions moves them as a contiguous block, preserving relative order (drag label reads "N sessions"). Dragging multiple sessions into the sessions grid opens all of them.

## Insertion line

The insertion line reuses the base list widget's `drop-target-before`/`drop-target-after` feedback (colored by `list.dropBetweenBackground`). The widget already converts an "after" indicator on row *i* into a "before" indicator on row *i+1*, so hovering the bottom half of the upper row and the top half of the lower row render the **exact same DOM line** with no shift. No custom CSS was needed.

## Notes for reviewers

- The key-assignment logic is extracted into a pure, unit-tested `computeReorderSortChanges` helper.
- `ISessionsListModelService` stays in the services layer; the sort mode is a plain `'created' | 'updated'` string union rather than the contrib `SessionsSorting` enum to avoid a layering violation.
- Spec updated in `src/vs/sessions/SESSIONS_LIST.md`.

## Validation

- `npm run typecheck-client` — passes
- `npm run valid-layers-check` — passes
- Unit tests — 17 passing, including 7 new `computeReorderSortChanges` cases
