### PR TITLE
Validate predicted line for cross-file cursor jumps in NES

### DIFF
--- a/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
@@ -1282,11 +1282,19 @@ export class XtabProvider implements IStatelessNextEditProvider {
 				}
 
 				const targetContent = new StringText(targetTextDoc.getText());
+				const targetContentLines = targetContent.getLines();
+
+				if (prediction.lineNumber >= targetContentLines.length) { // >= because the line index is zero-based
+					tracer.trace(`Predicted cross-file cursor jump error: exceedsDocumentLines`);
+					telemetry.setNextCursorLineError('crossFile:exceedsDocumentLines');
+					return new NoNextEditReason.NoSuggestions(request.documentBeforeEdits, editWindow);
+				}
+
 				const syntheticDoc = new StatelessNextEditDocument(
 					targetDocumentId,
 					promptPieces.activeDoc.workspaceRoot,
 					LanguageId.create(targetTextDoc.languageId),
-					targetContent.getLines(),
+					targetContentLines,
 					LineEdit.empty,
 					targetContent,
 					new Edits(StringEdit, []),

--- a/extensions/copilot/src/extension/xtab/test/node/xtabProvider.spec.ts
+++ b/extensions/copilot/src/extension/xtab/test/node/xtabProvider.spec.ts
@@ -22,8 +22,10 @@ import { ILogger } from '../../../../platform/log/common/logService';
 import { FilterReason } from '../../../../platform/networking/common/openai';
 import { ISimulationTestContext } from '../../../../platform/simulationTestContext/common/simulationTestContext';
 import { TestLogService } from '../../../../platform/testing/common/testLogService';
+import { IWorkspaceService } from '../../../../platform/workspace/common/workspaceService';
 import { AsyncIterUtils } from '../../../../util/common/asyncIterableUtils';
 import { Result } from '../../../../util/common/result';
+import { createTextDocumentData } from '../../../../util/common/test/shims/textDocument';
 import { DeferredPromise } from '../../../../util/vs/base/common/async';
 import { CancellationToken, CancellationTokenSource } from '../../../../util/vs/base/common/cancellation';
 import { Emitter, Event } from '../../../../util/vs/base/common/event';
@@ -1768,6 +1770,59 @@ describe('XtabProvider integration', () => {
 			expect(finalReason.v).toBeInstanceOf(NoNextEditReason.NoSuggestions);
 			// Exactly 3 calls: main + cursor prediction + retry (no further retry)
 			expect(streamingFetcher.callCount).toBe(3);
+		});
+
+		it('cross-file cursor jump with out-of-bounds predicted line → NoSuggestions without throwing', async () => {
+			const provider = createProvider();
+			await configService.setConfig(ConfigKey.InlineEditsNextCursorPredictionEnabled, true);
+			await configService.setConfig(ConfigKey.TeamInternal.InlineEditsNextCursorPredictionModelName, 'test-model');
+
+			const lines = Array.from({ length: 30 }, (_, i) => `line ${i} content`);
+			const cursorOffset = lines.slice(0, 5).join('\n').length;
+			const request = createRequestWithEdit(lines, { insertionOffset: cursorOffset });
+
+			// 1st call (main LLM): edit-window lines unchanged → no edits → cursor jump path
+			const mainEditWindowLines = lines.slice(3, 11);
+			streamingFetcher.enqueueResponse({
+				type: ChatFetchResponseType.Success,
+				requestId: 'req-main',
+				serverRequestId: 'srv-main',
+				usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0, prompt_tokens_details: { cached_tokens: 0 } },
+				value: mainEditWindowLines.join('\n'),
+				resolvedModel: 'test-model',
+			});
+
+			// 2nd call (cursor prediction): predict a jump into another file at line 50 (0-based),
+			// which is out of bounds for the 5-line target document opened below.
+			streamingFetcher.enqueueResponse({
+				type: ChatFetchResponseType.Success,
+				requestId: 'req-cursor',
+				serverRequestId: 'srv-cursor',
+				usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0, prompt_tokens_details: { cached_tokens: 0 } },
+				value: '/test/other.ts:50',
+				resolvedModel: 'test-model',
+			});
+
+			// The cross-file jump target only has 5 lines, so the predicted line 50 is out of bounds.
+			const targetDoc = createTextDocumentData(
+				URI.file('/test/other.ts'),
+				Array.from({ length: 5 }, (_, i) => `other ${i}`).join('\n'),
+				'typescript',
+			).document;
+			const workspaceService = instaService.invokeFunction(accessor => accessor.get(IWorkspaceService));
+			const openSpy = vi.spyOn(workspaceService, 'openTextDocument').mockResolvedValue(targetDoc);
+
+			const gen = provider.provideNextEdit(request, createMockLogger(), createLogContext(), CancellationToken.None);
+			const { edits, finalReason } = await collectEdits(gen);
+
+			expect(edits.length).toBe(0);
+			expect(finalReason.v).toBeInstanceOf(NoNextEditReason.NoSuggestions);
+			// The out-of-bounds prediction must be rejected before any retry fetch happens, rather
+			// than constructing a CurrentDocument with an out-of-bounds cursor (which would throw).
+			expect(streamingFetcher.callCount).toBe(2);
+			expect(openSpy).toHaveBeenCalledOnce();
+
+			openSpy.mockRestore();
 		});
 
 		it('model fallback retry on NotFound then yields edits on second attempt', async () => {


### PR DESCRIPTION
## Why

The error telemetry dashboard flagged a 56x spike of `CurrentDocument#lineWithCursor: cursor is out of bounds` (`BugIndicatingError`) reported as an unhandled error from `GitHub.copilot-chat`. This turned out to be a false-positive "bug": it is triggered by untrusted model output, not by a real invariant violation in our code.

## Root cause

The next-edit cross-file cursor-jump path (`XtabProvider.handleCrossFilePrediction`) fed the model's predicted line number straight into a synthetic request without checking it against the target document's line count. When the model predicted an out-of-bounds line, `CurrentDocument.lineWithCursor()` threw a `BugIndicatingError`, which propagated up through `getNextEdit` and surfaced in VS Code's global unhandled-error telemetry.

The **same-file** cursor-jump path already guards against this (it returns `NoSuggestions` and records `exceedsDocumentLines`). The **cross-file** path was missing the equivalent check, and the spike correlates with the cross-file cursor-jump rollout.

## Fix

Mirror the existing same-file guard in the cross-file path: after opening the target document, if the predicted line is beyond the file's line count, return `NoSuggestions` and record `crossFile:exceedsDocumentLines` instead of throwing. This treats an out-of-bounds model prediction as a normal "no suggestion" outcome, consistent with how same-file predictions are handled.

## Testing

Added a regression test in `xtabProvider.spec.ts` that drives a cross-file prediction to an out-of-bounds line and asserts a clean `NoSuggestions` result with no retry fetch. Verified it fails without the fix (the error surfaces as an `Unexpected` reason) and passes with it. `tsgo` typecheck passes and all cursor-jump tests pass.

Fixes #318579