### PR TITLE
Refactor Copilot managed-settings for maintainability

### DIFF
--- a/.github/skills/add-policy/github-managed-settings.md
+++ b/.github/skills/add-policy/github-managed-settings.md
@@ -96,8 +96,11 @@ the VS Code bag is **flattened** to dot-paths — e.g. the schema's nested
 > [Structured settings](#structured-objectarray-settings)). The *setting's* own `type` is
 > the real shape — e.g. `chat.plugins.strictMarketplaces` is `['array', 'null']`, modeling
 > the schema's array allowlist; only the bag-carrying type is `'string'`. That `'string'` is
-> **required, not cosmetic**: omitting it (or declaring the object/array type) makes the key
-> fail projection validation and silently never apply.
+> **required, not cosmetic**: `type` is a required field whose only allowed values are
+> `'string' | 'number' | 'boolean'`, so omitting it or declaring `'object'` / `'array'` is a
+> *compile* error; declaring `'number'` / `'boolean'` compiles but then fails projection
+> validation at *runtime* (the JSON-string bag value flunks `typeof value === type`), so the key
+> is dropped and silently never applies.
 
 Note the schema's `x-composition` describes the **server/runtime** layering across
 enterprise/org/user. Inside VS Code the bag has already been collapsed to a single
@@ -169,9 +172,11 @@ managed-settings key as a **string** (the JSON is carried as a string), and the
 `value` callback returns that raw string. The `{ type: 'string' }` is **mandatory and must
 be `'string'`** for these keys, not filler: `projectManagedSettings` keeps a bag value only
 when `typeof value === type`, and the native MDM watcher reads the registry/plist value as
-that type. Because the structured value travels as a JSON string, declaring `'object'` /
-`'array'` (or omitting `type`) makes the value fail that `typeof` check and get dropped, so
-the managed setting silently never applies. When the policy value is a string but the
+that type. `type` is a required field whose only allowed values are `'string' | 'number' |
+'boolean'` (`IManagedSettingPolicyDefinition` in `base/common/policy.ts`), so omitting it or
+declaring `'object'` / `'array'` is a *compile* error. Declaring `'number'` / `'boolean'`
+compiles, but because the structured value travels as a JSON string it then flunks that
+`typeof` check at *runtime* and gets dropped, so the managed setting silently never applies. When the policy value is a string but the
 setting's type is not, `PolicyConfiguration` parses it back into the typed value on read
 via its own lenient JSONC parser (`PolicyConfiguration.parse()` using a `json.visit`
 streaming visitor — *not* `JSON.parse`; see `configurations.ts`). Examples in

--- a/.github/skills/add-policy/github-managed-settings.md
+++ b/.github/skills/add-policy/github-managed-settings.md
@@ -95,7 +95,9 @@ the VS Code bag is **flattened** to dot-paths — e.g. the schema's nested
 > object/array value is carried as a JSON string in the bag and parsed back on read (see
 > [Structured settings](#structured-objectarray-settings)). The *setting's* own `type` is
 > the real shape — e.g. `chat.plugins.strictMarketplaces` is `['array', 'null']`, modeling
-> the schema's array allowlist; only the bag-carrying type is `'string'`.
+> the schema's array allowlist; only the bag-carrying type is `'string'`. That `'string'` is
+> **required, not cosmetic**: omitting it (or declaring the object/array type) makes the key
+> fail projection validation and silently never apply.
 
 Note the schema's `x-composition` describes the **server/runtime** layering across
 enterprise/org/user. Inside VS Code the bag has already been collapsed to a single
@@ -164,7 +166,12 @@ needless re-registration.
 
 For settings whose `type` is `'object'` or `'array'`, the policy still declares the
 managed-settings key as a **string** (the JSON is carried as a string), and the
-`value` callback returns that raw string. When the policy value is a string but the
+`value` callback returns that raw string. The `{ type: 'string' }` is **mandatory and must
+be `'string'`** for these keys, not filler: `projectManagedSettings` keeps a bag value only
+when `typeof value === type`, and the native MDM watcher reads the registry/plist value as
+that type. Because the structured value travels as a JSON string, declaring `'object'` /
+`'array'` (or omitting `type`) makes the value fail that `typeof` check and get dropped, so
+the managed setting silently never applies. When the policy value is a string but the
 setting's type is not, `PolicyConfiguration` parses it back into the typed value on read
 via its own lenient JSONC parser (`PolicyConfiguration.parse()` using a `json.visit`
 streaming visitor — *not* `JSON.parse`; see `configurations.ts`). Examples in

--- a/.github/skills/add-policy/github-managed-settings.md
+++ b/.github/skills/add-policy/github-managed-settings.md
@@ -81,17 +81,21 @@ the VS Code bag is **flattened** to dot-paths — e.g. the schema's nested
 | `extraKnownMarketplaces` | `{ name: { source } }`, source `github` \| `git` \| `directory` | most-restrictive-wins (higher layer is the complete allowlist) |
 | `strictKnownMarketplaces` | array of source descriptors | most-restrictive-wins (empty array = lockdown) |
 
-> **Current schema ↔ runtime divergences** (treat `managed-settings-schema.json` as the
-> API source of truth, and keep the VS Code `managedSettings` type declarations aligned
-> with what the server actually projects into the bag):
-> - `strictKnownMarketplaces`: schema models an **array** allowlist, but VS Code declares
->   `COPILOT_STRICT_MARKETPLACES_KEY` as a **boolean** flag (`{ type: 'boolean' }` on
->   `ChatStrictMarketplaces`).
+> **Current schema ↔ runtime divergence** (treat `managed-settings-schema.json` as the
+> API source of truth, and keep the VS Code `managedSettings` declarations aligned with
+> what the server actually projects into the bag):
 > - `extraKnownMarketplaces`: the schema permits source kinds `github` / `git` /
 >   `directory`, but the VS Code normalizer only accepts `github` and `git` —
 >   `directory` (and any other kind) is dropped with a warning
 >   (`managedSettings.ts` `normalizeExtraKnownMarketplaces`; `IExtraKnownMarketplaceEntry`
 >   in `base/common/managedSettings.ts` only types `github`/`git`).
+>
+> Note every **structured** key — `enabledPlugins`, `extraKnownMarketplaces`,
+> `strictKnownMarketplaces` — is declared on its policy as **`{ type: 'string' }`**: the
+> object/array value is carried as a JSON string in the bag and parsed back on read (see
+> [Structured settings](#structured-objectarray-settings)). The *setting's* own `type` is
+> the real shape — e.g. `chat.plugins.strictMarketplaces` is `['array', 'null']`, modeling
+> the schema's array allowlist; only the bag-carrying type is `'string'`.
 
 Note the schema's `x-composition` describes the **server/runtime** layering across
 enterprise/org/user. Inside VS Code the bag has already been collapsed to a single
@@ -140,6 +144,22 @@ Key rules for the `value` callback:
 - It's fine to combine with `chat_preview_features_enabled === false` (see SKILL.md's
   "GitHub Preview Features" section).
 
+For the **common pass-through case** — lock to the managed value, otherwise fall through to
+the user's setting — use the `managedSettingValue(KEY)` helper instead of hand-writing the
+callback:
+
+```ts
+import { managedSettingValue } from '../../../../platform/policy/common/copilotManagedSettings.js';
+
+value: managedSettingValue(COPILOT_ENABLED_PLUGINS_KEY),
+```
+
+Policies that combine the managed value with other conditions (like `ChatToolsAutoApprove`
+above, which also checks `chat_preview_features_enabled`) keep a custom callback. The helper
+returns a callback memoized per key (the same function reference for a given key on every call),
+preserving the policy-definition reference identity that lets `isSamePolicyDefinition` avoid
+needless re-registration.
+
 ### Structured (object/array) settings
 
 For settings whose `type` is `'object'` or `'array'`, the policy still declares the
@@ -151,8 +171,8 @@ streaming visitor — *not* `JSON.parse`; see `configurations.ts`). Examples in
 `chat.shared.contribution.ts`:
 
 ```ts
-// chat.plugins.enabledPlugins — type: 'object'
-value: (policyData) => policyData.managedSettings?.[COPILOT_ENABLED_PLUGINS_KEY],
+// chat.plugins.enabledPlugins — setting type: 'object'; managed key carried as a string
+value: managedSettingValue(COPILOT_ENABLED_PLUGINS_KEY),
 managedSettings: { [COPILOT_ENABLED_PLUGINS_KEY]: { type: 'string' } },
 ```
 
@@ -166,7 +186,23 @@ delivery slot for the managed value.
 |----------|------|
 | `flattenManagedSettings(obj)` | Flattens a nested response into dot-path scalars (used by the server adapter). |
 | `collectManagedSettingsDefinitions(policyDefinitions)` | Aggregates every policy's `managedSettings` into one `key → { type }` map. **Single source of truth** for which keys (and types) are honored; drives both the MDM watcher and the server projection. |
+| `hasManagedSettingsDefinitions(policyDefinitions)` | Cheap short-circuiting existence check (does *any* policy declare a managed key?) — used to decide whether the native MDM watcher is needed at all, without building the full aggregate. |
 | `projectManagedSettings(values, definitions, onWarn?)` | Keeps only declared keys whose runtime value **matches the declared type**. Undeclared keys and type mismatches are **dropped (validated, never coerced)**, with an optional warning. |
+| `managedSettingValue(key)` | Builds the standard pass-through `value` callback `policyData => policyData.managedSettings?.[key]`. Use for the common "lock to the managed value, else fall through" case (see [Declaring a managed setting](#declaring-a-managed-setting-on-a-policy)). |
+
+### Server-side adaptation: the structured-key descriptor table
+
+`adaptManagedSettings` (`managedSettings.ts`) normalizes the server `managed_settings`
+response into the canonical bag. Scalar leaves flatten directly; **structured** (object/array)
+keys are JSON-encoded under a single bag key. The per-key knowledge for the structured ones
+lives in **one table**, `STRUCTURED_MANAGED_SETTINGS`. Each row declares the canonical bag
+`key`, the `responseField` it consumes (a hand-maintained union kept in sync with
+`IManagedSettingsResponse`'s named fields — not compiler-enforced, because the response's index
+signature widens `keyof` to `string`; the `adaptManagedSettings` tests are the drift backstop),
+and an `encode(raw, onWarn?)` that
+normalizes the value before `JSON.stringify`. Adding a structured key is **one descriptor row**
+(plus its response-interface field and the policy declaration) — no new bespoke branch in the
+adapter.
 
 Constants (also in `copilotManagedSettings.ts`):
 
@@ -217,11 +253,14 @@ those dot-paths. No declared keys ⇒ no watcher.
    `copilotManagedSettings.ts`. It must match the server `managed_settings` API field /
    the `managed-settings-schema.json` key exactly.
 2. **Attach it to a policy** on the governing setting: add `managedSettings: { [KEY]: { type } }`
-   and a `value(policyData)` that reads `policyData.managedSettings?.[KEY]`.
-3. **If the value is structured** (object/array), declare the managed key as `'string'`,
-   return the raw JSON string from `value`, and let `PolicyConfiguration` parse it. If the
-   server response shape differs from the stored shape, normalize it in
-   `adaptManagedSettings` (server side) so the bag matches what an admin would author in MDM.
+   and a `value` callback. For a plain pass-through use `value: managedSettingValue(KEY)`;
+   only hand-write the callback when combining with another condition.
+3. **If the value is structured** (object/array), declare the managed key as `'string'` and
+   let `PolicyConfiguration` parse the JSON back on read. Then teach the **server adapter** by
+   adding one row to `STRUCTURED_MANAGED_SETTINGS` in `managedSettings.ts` (canonical `key`, the
+   `responseField` it consumes, and an `encode` that normalizes the server shape into what an
+   admin would author in MDM) plus the matching field on `IManagedSettingsResponse`. That table
+   is the single place server-side structured-key handling lives.
 4. **Keep the schema aligned.** The runtime, the server endpoint, and
    `managed-settings-schema.json` must agree on the key name and value type. The
    declaration-driven projection (`projectManagedSettings`) silently drops anything that

--- a/scripts/mock-policy-server/public/app.ts
+++ b/scripts/mock-policy-server/public/app.ts
@@ -449,6 +449,7 @@ declare const MOCK_POLICY_ENDPOINTS: import('../endpoints').EndpointDef[];
 			drafts[activeId] = editor.value;
 			saveDrafts();
 			parseEditor();
+			debouncedSave();
 			setStatus('Generated example from schema.', 'ok');
 		});
 		try {

--- a/src/vs/platform/policy/common/copilotManagedSettings.ts
+++ b/src/vs/platform/policy/common/copilotManagedSettings.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from '../../../base/common/event.js';
+import { IPolicyData } from '../../../base/common/defaultAccount.js';
 import { IManagedSettingPolicyDefinition, IManagedSettingsPolicyDefinitions, ManagedSettingValue, ManagedSettingsData } from '../../../base/common/policy.js';
 import { IStringDictionary } from '../../../base/common/collections.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
@@ -31,6 +32,27 @@ export const COPILOT_EXTRA_MARKETPLACES_KEY = 'extraKnownMarketplaces';
 
 /** Managed-settings key for the strict-marketplace allowlist (carried as a JSON-encoded array of source entries; absent = no restrictions, `[]` = lockdown). */
 export const COPILOT_STRICT_MARKETPLACES_KEY = 'strictKnownMarketplaces';
+
+const managedSettingValueCallbacks = new Map<string, (policyData: IPolicyData) => ManagedSettingValue | undefined>();
+
+/**
+ * Standard pass-through `value` callback for a managed-settings-driven policy: locks the setting
+ * to the managed value when the enterprise has set it, and returns `undefined` otherwise so the
+ * user's own setting falls through. Use for the common case; policies that combine the managed
+ * value with other conditions (e.g. `chat_preview_features_enabled`) keep a custom callback.
+ *
+ * The callback is memoized per key, so repeated calls for the same key return the SAME function
+ * reference. That reference identity is what lets `isSamePolicyDefinition` skip needless
+ * re-registration, and memoizing makes the guarantee hold regardless of where the helper is called.
+ */
+export function managedSettingValue(key: string): (policyData: IPolicyData) => ManagedSettingValue | undefined {
+	let callback = managedSettingValueCallbacks.get(key);
+	if (!callback) {
+		callback = policyData => policyData.managedSettings?.[key];
+		managedSettingValueCallbacks.set(key, callback);
+	}
+	return callback;
+}
 
 export const ICopilotManagedSettingsService = createDecorator<ICopilotManagedSettingsService>('copilotManagedSettingsService');
 
@@ -93,6 +115,21 @@ export function collectManagedSettingsDefinitions(policyDefinitions: IStringDict
 		}
 	}
 	return definitions;
+}
+
+/**
+ * Whether any policy in `policyDefinitions` declares at least one managed-settings key. Cheap
+ * existence check (short-circuits) used to decide whether the native MDM watcher is needed at all,
+ * without aggregating the full {@link collectManagedSettingsDefinitions} map.
+ */
+export function hasManagedSettingsDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): boolean {
+	for (const policyName in policyDefinitions) {
+		const policyManagedSettings = policyDefinitions[policyName].managedSettings;
+		if (policyManagedSettings && Object.keys(policyManagedSettings).length > 0) {
+			return true;
+		}
+	}
+	return false;
 }
 
 /**

--- a/src/vs/platform/policy/common/copilotManagedSettings.ts
+++ b/src/vs/platform/policy/common/copilotManagedSettings.ts
@@ -7,6 +7,7 @@ import { Event } from '../../../base/common/event.js';
 import { IPolicyData } from '../../../base/common/defaultAccount.js';
 import { IManagedSettingPolicyDefinition, IManagedSettingsPolicyDefinitions, ManagedSettingValue, ManagedSettingsData } from '../../../base/common/policy.js';
 import { IStringDictionary } from '../../../base/common/collections.js';
+import { isEmptyObject } from '../../../base/common/types.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { PolicyDefinition } from './policy.js';
 
@@ -125,7 +126,7 @@ export function collectManagedSettingsDefinitions(policyDefinitions: IStringDict
 export function hasManagedSettingsDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): boolean {
 	for (const policyName in policyDefinitions) {
 		const policyManagedSettings = policyDefinitions[policyName].managedSettings;
-		if (policyManagedSettings && Object.keys(policyManagedSettings).length > 0) {
+		if (policyManagedSettings && !isEmptyObject(policyManagedSettings)) {
 			return true;
 		}
 	}

--- a/src/vs/platform/policy/common/copilotManagedSettings.ts
+++ b/src/vs/platform/policy/common/copilotManagedSettings.ts
@@ -157,3 +157,43 @@ export function projectManagedSettings(values: ManagedSettingsData, definitions:
 	}
 	return projected;
 }
+
+/**
+ * The delivery channel that provided the active managed-settings bag. Managed settings can be
+ * delivered by more than one channel, so this names the known sources to give policy evaluation
+ * and the Policy Diagnostics report one shared vocabulary. Extend this union (and
+ * {@link selectManagedSettings}) when adding a new channel.
+ */
+export type ManagedSettingsSource =
+	/** No channel currently provides managed settings. */
+	| 'none'
+	/** GitHub `/copilot_internal/managed_settings` endpoint (server-delivered). */
+	| 'server'
+	/** Native MDM: OS registry (Windows) / managed preferences (macOS) via `@vscode/policy-watcher`. */
+	| 'nativeMdm';
+
+export interface IManagedSettingsSelection {
+	/** Which channel won. */
+	readonly source: ManagedSettingsSource;
+	/** The winning bag, or `undefined` when {@link source} is `'none'`. */
+	readonly values: ManagedSettingsData | undefined;
+}
+
+/**
+ * Select the authoritative managed-settings bag from the available delivery channels.
+ *
+ * Server-delivered settings win over native MDM and the two are never merged — managed settings
+ * have a single authoritative source. Centralizing the precedence here (rather than inlining it at
+ * each call site) keeps policy evaluation ({@link AccountPolicyService.getPolicyData}) and the
+ * Policy Diagnostics report from drifting apart, and gives one obvious place to extend when a new
+ * channel is introduced.
+ */
+export function selectManagedSettings(server: ManagedSettingsData | undefined, nativeMdm: ManagedSettingsData | undefined): IManagedSettingsSelection {
+	if (server && !isEmptyObject(server)) {
+		return { source: 'server', values: server };
+	}
+	if (nativeMdm && !isEmptyObject(nativeMdm)) {
+		return { source: 'nativeMdm', values: nativeMdm };
+	}
+	return { source: 'none', values: undefined };
+}

--- a/src/vs/platform/policy/common/copilotManagedSettingsIpc.ts
+++ b/src/vs/platform/policy/common/copilotManagedSettingsIpc.ts
@@ -6,6 +6,7 @@
 import { Emitter, Event } from '../../../base/common/event.js';
 import { IStringDictionary } from '../../../base/common/collections.js';
 import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
+import { equals } from '../../../base/common/objects.js';
 import { IChannel, IServerChannel } from '../../../base/parts/ipc/common/ipc.js';
 import { ICopilotManagedSettingsService, ManagedSettingsData } from './copilotManagedSettings.js';
 import { PolicyDefinition } from './policy.js';
@@ -66,7 +67,7 @@ export class CopilotManagedSettingsChannelClient extends Disposable implements I
 
 	private updateManagedSettings(managedSettings: ManagedSettingsData, fireEvent: boolean): void {
 		this.hasReceivedManagedSettings = true;
-		if (areManagedSettingsEqual(this._managedSettings, managedSettings)) {
+		if (equals(this._managedSettings, managedSettings)) {
 			return;
 		}
 
@@ -75,14 +76,4 @@ export class CopilotManagedSettingsChannelClient extends Disposable implements I
 			this._onDidChangeManagedSettings.fire(this._managedSettings);
 		}
 	}
-}
-
-function areManagedSettingsEqual(a: ManagedSettingsData, b: ManagedSettingsData): boolean {
-	const aKeys = Object.keys(a);
-	const bKeys = Object.keys(b);
-	if (aKeys.length !== bKeys.length) {
-		return false;
-	}
-
-	return aKeys.every(key => a[key] === b[key]);
 }

--- a/src/vs/platform/policy/node/copilotManagedSettingsService.ts
+++ b/src/vs/platform/policy/node/copilotManagedSettingsService.ts
@@ -7,6 +7,7 @@ import { Throttler } from '../../../base/common/async.js';
 import { IStringDictionary } from '../../../base/common/collections.js';
 import { Emitter } from '../../../base/common/event.js';
 import { Disposable, MutableDisposable } from '../../../base/common/lifecycle.js';
+import { equals } from '../../../base/common/objects.js';
 import { IManagedSettingsPolicyDefinitions, ManagedSettingsData } from '../../../base/common/policy.js';
 import { ILogService } from '../../log/common/log.js';
 import { collectManagedSettingsDefinitions, ICopilotManagedSettingsService } from '../common/copilotManagedSettings.js';
@@ -52,7 +53,7 @@ export class CopilotManagedSettingsService extends Disposable implements ICopilo
 	async updatePolicyDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): Promise<ManagedSettingsData> {
 		const managedSettings = collectManagedSettingsDefinitions(policyDefinitions);
 
-		if (areManagedSettingDefinitionsEqual(this.watchedSettings, managedSettings)) {
+		if (equals(this.watchedSettings, managedSettings)) {
 			return this.managedSettings;
 		}
 
@@ -104,6 +105,13 @@ export class CopilotManagedSettingsService extends Disposable implements ICopilo
 		}));
 	}
 
+	/**
+	 * Project the internal {@link IManagedSettingsPolicyDefinitions} (readonly, and free to grow
+	 * extra fields) down to the minimal `{ type }` payload the external `@vscode/policy-watcher`
+	 * native module expects. Deliberately a fresh, narrowly-typed copy rather than handing the
+	 * watcher our internal state: it decouples the two shapes so a future field on
+	 * `IManagedSettingPolicyDefinition` cannot silently leak across the native boundary.
+	 */
 	private getManagedSettingDefinitions(): Record<string, { type: 'string' | 'number' | 'boolean' }> {
 		const definitions: Record<string, { type: 'string' | 'number' | 'boolean' }> = {};
 		for (const key in this.watchedSettings) {
@@ -130,14 +138,4 @@ export class CopilotManagedSettingsService extends Disposable implements ICopilo
 			this._onDidChangeManagedSettings.fire(this.managedSettings);
 		}
 	}
-}
-
-function areManagedSettingDefinitionsEqual(a: IManagedSettingsPolicyDefinitions, b: IManagedSettingsPolicyDefinitions): boolean {
-	const aKeys = Object.keys(a);
-	const bKeys = Object.keys(b);
-	if (aKeys.length !== bKeys.length) {
-		return false;
-	}
-
-	return aKeys.every(key => a[key]?.type === b[key]?.type);
 }

--- a/src/vs/platform/policy/test/common/copilotManagedSettings.test.ts
+++ b/src/vs/platform/policy/test/common/copilotManagedSettings.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { IStringDictionary } from '../../../../base/common/collections.js';
 import { IPolicyData } from '../../../../base/common/defaultAccount.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { collectManagedSettingsDefinitions, hasManagedSettingsDefinitions, managedSettingValue, projectManagedSettings } from '../../common/copilotManagedSettings.js';
+import { collectManagedSettingsDefinitions, hasManagedSettingsDefinitions, managedSettingValue, projectManagedSettings, selectManagedSettings } from '../../common/copilotManagedSettings.js';
 import { PolicyDefinition } from '../../common/policy.js';
 
 suite('Copilot managed settings projection', () => {
@@ -106,5 +106,25 @@ suite('Copilot managed settings projection', () => {
 			msg => warnings.push(msg),
 		);
 		assert.strictEqual(warnings.length, 1);
+	});
+
+	test('selectManagedSettings: server wins over native MDM, never merged', () => {
+		const selection = selectManagedSettings(
+			{ 'permissions.x': 'server' },
+			{ 'permissions.y': 'native' },
+		);
+		assert.deepStrictEqual(selection, { source: 'server', values: { 'permissions.x': 'server' } });
+	});
+
+	test('selectManagedSettings: falls through to native MDM when server is absent or empty', () => {
+		const fromUndefined = selectManagedSettings(undefined, { 'permissions.y': 'native' });
+		const fromEmptyObject = selectManagedSettings({}, { 'permissions.y': 'native' });
+		assert.deepStrictEqual(fromUndefined, { source: 'nativeMdm', values: { 'permissions.y': 'native' } });
+		assert.deepStrictEqual(fromEmptyObject, { source: 'nativeMdm', values: { 'permissions.y': 'native' } });
+	});
+
+	test('selectManagedSettings: reports `none` with no values when every channel is empty', () => {
+		assert.deepStrictEqual(selectManagedSettings(undefined, undefined), { source: 'none', values: undefined });
+		assert.deepStrictEqual(selectManagedSettings({}, {}), { source: 'none', values: undefined });
 	});
 });

--- a/src/vs/platform/policy/test/common/copilotManagedSettings.test.ts
+++ b/src/vs/platform/policy/test/common/copilotManagedSettings.test.ts
@@ -5,8 +5,9 @@
 
 import assert from 'assert';
 import { IStringDictionary } from '../../../../base/common/collections.js';
+import { IPolicyData } from '../../../../base/common/defaultAccount.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { collectManagedSettingsDefinitions, projectManagedSettings } from '../../common/copilotManagedSettings.js';
+import { collectManagedSettingsDefinitions, hasManagedSettingsDefinitions, managedSettingValue, projectManagedSettings } from '../../common/copilotManagedSettings.js';
 import { PolicyDefinition } from '../../common/policy.js';
 
 suite('Copilot managed settings projection', () => {
@@ -37,6 +38,40 @@ suite('Copilot managed settings projection', () => {
 
 	test('collectManagedSettingsDefinitions returns empty when nothing is declared', () => {
 		assert.deepStrictEqual(collectManagedSettingsDefinitions({ P: { type: 'string' } }), {});
+	});
+
+	test('hasManagedSettingsDefinitions detects whether any policy declares a managed key', () => {
+		assert.deepStrictEqual(
+			{
+				withKeys: hasManagedSettingsDefinitions(definitions),
+				none: hasManagedSettingsDefinitions({ P: { type: 'string' } }),
+				empty: hasManagedSettingsDefinitions({}),
+			},
+			{ withKeys: true, none: false, empty: false },
+		);
+	});
+
+	test('managedSettingValue locks to the managed value when set, else undefined', () => {
+		const value = managedSettingValue('permissions.disableBypassPermissionsMode');
+		assert.deepStrictEqual(
+			{
+				set: value({ managedSettings: { 'permissions.disableBypassPermissionsMode': 'disable' } } as IPolicyData),
+				otherKey: value({ managedSettings: { 'other.key': 'x' } } as IPolicyData),
+				noBag: value({} as IPolicyData),
+			},
+			{ set: 'disable', otherKey: undefined, noBag: undefined },
+		);
+	});
+
+	test('managedSettingValue returns the same memoized callback per key (stable reference identity)', () => {
+		assert.strictEqual(
+			managedSettingValue('permissions.disableBypassPermissionsMode'),
+			managedSettingValue('permissions.disableBypassPermissionsMode'),
+		);
+		assert.notStrictEqual(
+			managedSettingValue('permissions.disableBypassPermissionsMode'),
+			managedSettingValue('some.other.key'),
+		);
 	});
 
 	test('projectManagedSettings keeps declared+typed keys, drops undeclared and type-mismatched', () => {

--- a/src/vs/sessions/electron-browser/sessions.main.ts
+++ b/src/vs/sessions/electron-browser/sessions.main.ts
@@ -50,6 +50,7 @@ import { IUserDataProfilesService, reviveProfile } from '../../platform/userData
 import { UserDataProfilesService } from '../../platform/userDataProfile/common/userDataProfileIpc.js';
 import { PolicyChannelClient } from '../../platform/policy/common/policyIpc.js';
 import { CopilotManagedSettingsChannelClient } from '../../platform/policy/common/copilotManagedSettingsIpc.js';
+import { ICopilotManagedSettingsService } from '../../platform/policy/common/copilotManagedSettings.js';
 import { IPolicyService } from '../../platform/policy/common/policy.js';
 import { UserDataProfileService } from '../../workbench/services/userDataProfile/common/userDataProfileService.js';
 import { IUserDataProfileService } from '../../workbench/services/userDataProfile/common/userDataProfile.js';
@@ -219,6 +220,7 @@ export class SessionsMain extends Disposable {
 		let policyService: IPolicyService;
 		const policyChannel = this.configuration.policiesData ? this._register(new PolicyChannelClient(this.configuration.policiesData, mainProcessService.getChannel('policy'))) : undefined;
 		const copilotManagedSettings = this._register(new CopilotManagedSettingsChannelClient(mainProcessService.getChannel('copilotManagedSettings')));
+		serviceCollection.set(ICopilotManagedSettingsService, copilotManagedSettings);
 		const accountPolicy = this._register(new AccountPolicyService(logService, defaultAccountService, policyChannel, copilotManagedSettings));
 		if (policyChannel) {
 			policyService = this._register(new MultiplexPolicyService([policyChannel, accountPolicy], logService));

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -49,6 +49,10 @@ import { IPolicyService } from '../../../platform/policy/common/policy.js';
 import { ICopilotManagedSettingsService, ManagedSettingsSource, projectManagedSettings, selectManagedSettings } from '../../../platform/policy/common/copilotManagedSettings.js';
 import { IManagedSettingPolicyDefinition, ManagedSettingsData } from '../../../base/common/policy.js';
 import { APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, IAccountPolicyGateService } from '../../services/policies/common/accountPolicyService.js';
+import { adaptManagedSettings, IManagedSettingsResponse } from '../../services/accounts/browser/managedSettings.js';
+import { isObject } from '../../../base/common/types.js';
+import * as json from '../../../base/common/json.js';
+import { getParseErrorMessage } from '../../../base/common/jsonErrorMessages.js';
 
 class InspectContextKeysAction extends Action2 {
 
@@ -812,46 +816,43 @@ class PolicyDiagnosticsAction extends Action2 {
 			const selection = selectManagedSettings(serverManagedSettings, nativeManagedSettings);
 
 			content += `**Active source**: ${managedSettingsSourceLabel(selection.source)}\n\n`;
-			content += 'Managed settings can arrive from more than one channel. The GitHub server API takes precedence over native MDM and the channels are never merged, so exactly one channel is active at a time.\n\n';
 
-			// --- GitHub server API channel ---
+			// Collect non-fatal issues from every managed-settings parsing/normalization callback
+			// (adapt, projection, JSON payload) so the report explains *why* a key was dropped.
+			// jsonc-style: accumulate every error instead of failing on the first.
+			const parseErrors: { stage: string; message: string }[] = [];
+
 			content += '### GitHub Server API\n\n';
-			content += 'Endpoint: `/copilot_internal/managed_settings`\n\n';
 			content += '| Property | Value |\n';
 			content += '|----------|-------|\n';
+			content += '| Endpoint | `/copilot_internal/managed_settings` |\n';
 			const fetchStatus = defaultAccountService.managedSettingsFetchStatus;
-			content += `| Last fetch (most recent attempt) | ${fetchStatus === null ? '*not yet fetched*' : `\`${fetchStatus}\``} |\n`;
+			content += `| Last fetch | ${fetchStatus === null ? '*never*' : `\`${fetchStatus}\``} |\n`;
 			const fetchedAt = defaultAccountService.managedSettingsFetchedAt;
 			content += `| Last successful fetch | ${fetchedAt ? new Date(fetchedAt).toLocaleString() : '*n/a*'} |\n`;
-			content += `| Active | ${selection.source === 'server' ? 'yes' : 'no'} |\n`;
-			content += '\n';
+			content += `| Active | ${selection.source === 'server' ? 'yes' : 'no'} |\n\n`;
 
 			const rawResponse = defaultAccountService.managedSettingsRawResponse;
+			if (isObject(rawResponse)) {
+				adaptManagedSettings(rawResponse as IManagedSettingsResponse, message => parseErrors.push({ stage: 'adapt', message }));
+			}
 			if (rawResponse !== null && rawResponse !== undefined) {
-				content += 'Raw response captured on the last *successful* fetch. A more recent failed fetch (for example a `404` above) leaves this value stale and does NOT apply it, so it can disagree with the effective bag below:\n\n';
-				content += '```json\n';
-				content += JSON.stringify(rawResponse, null, 2);
-				content += '\n```\n\n';
+				content += '**Raw response** (last successful fetch)\n\n';
+				content += '```json\n' + JSON.stringify(rawResponse, null, 2) + '\n```\n\n';
 			}
 
-			content += 'Normalized bag (server response flattened to dot-path keys):\n\n';
-			content += '```json\n';
-			content += JSON.stringify(serverManagedSettings ?? {}, null, 2);
-			content += '\n```\n\n';
+			content += '**Normalized bag**\n\n';
+			content += '```json\n' + JSON.stringify(serverManagedSettings ?? {}, null, 2) + '\n```\n\n';
 
-			// --- Native MDM channel ---
 			content += '### Native MDM\n\n';
-			content += 'OS registry (Windows) / managed preferences (macOS)\n\n';
-			if (copilotManagedSettingsService === undefined) {
-				content += '*Not available in this window (desktop only).*\n\n';
-			} else {
-				content += `Active: ${selection.source === 'nativeMdm' ? 'yes' : 'no'}\n\n`;
-				content += '```json\n';
-				content += JSON.stringify(nativeManagedSettings ?? {}, null, 2);
-				content += '\n```\n\n';
+			content += '| Property | Value |\n';
+			content += '|----------|-------|\n';
+			content += `| Available | ${copilotManagedSettingsService ? 'yes' : 'no (desktop only)'} |\n`;
+			content += `| Active | ${selection.source === 'nativeMdm' ? 'yes' : 'no'} |\n\n`;
+			if (copilotManagedSettingsService) {
+				content += '```json\n' + JSON.stringify(nativeManagedSettings ?? {}, null, 2) + '\n```\n\n';
 			}
 
-			// --- Effective bag after selection + projection ---
 			// Mirror AccountPolicyService: project the winning bag onto the keys declared by policies
 			// so the report shows exactly what reaches `policy.value(...)`.
 			const declaredDefinitions: Record<string, IManagedSettingPolicyDefinition> = {};
@@ -861,12 +862,32 @@ class PolicyDiagnosticsAction extends Action2 {
 					Object.assign(declaredDefinitions, declared);
 				}
 			}
-			const effective = projectManagedSettings({ ...selection.values }, declaredDefinitions);
-			content += '### Effective (after selection and projection)\n\n';
-			content += 'The bag passed to `policy.value(...)`: the active source projected onto the keys declared by policies. Undeclared keys and type mismatches are dropped.\n\n';
-			content += '```json\n';
-			content += JSON.stringify(effective, null, 2);
-			content += '\n```\n\n';
+			const effective = projectManagedSettings({ ...selection.values }, declaredDefinitions, message => parseErrors.push({ stage: 'project', message }));
+
+			// JSON payloads (the strings PolicyConfiguration parses back into typed values), checked
+			// with the same jsonc parser and error messages so malformed values surface here too.
+			for (const [key, value] of Object.entries(effective)) {
+				if (typeof value === 'string' && /^\s*[{[]/.test(value)) {
+					const jsonErrors: json.ParseError[] = [];
+					json.parse(value, jsonErrors);
+					for (const e of jsonErrors) {
+						parseErrors.push({ stage: 'parse', message: `${key} @ offset ${e.offset}: ${getParseErrorMessage(e.error)}` });
+					}
+				}
+			}
+
+			content += '### Effective\n\n';
+			content += '```json\n' + JSON.stringify(effective, null, 2) + '\n```\n\n';
+
+			content += `### Parse Errors (${parseErrors.length})\n\n`;
+			if (parseErrors.length > 0) {
+				content += '| Stage | Message |\n';
+				content += '|-------|---------|\n';
+				for (const { stage, message } of parseErrors) {
+					content += `| ${stage} | ${message.replace(/\|/g, '\\|')} |\n`;
+				}
+				content += '\n';
+			}
 		} catch (error) {
 			content += `*Error rendering managed settings diagnostics: ${error}*\n\n`;
 		}

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -46,7 +46,7 @@ import { IDefaultAccountService } from '../../../platform/defaultAccount/common/
 import { IAuthenticationService } from '../../services/authentication/common/authentication.js';
 import { IAuthenticationAccessService } from '../../services/authentication/browser/authenticationAccessService.js';
 import { IPolicyService } from '../../../platform/policy/common/policy.js';
-import { ICopilotManagedSettingsService, ManagedSettingsSource, projectManagedSettings, selectManagedSettings } from '../../../platform/policy/common/copilotManagedSettings.js';
+import { COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_STRICT_MARKETPLACES_KEY, ICopilotManagedSettingsService, ManagedSettingsSource, projectManagedSettings, selectManagedSettings } from '../../../platform/policy/common/copilotManagedSettings.js';
 import { IManagedSettingPolicyDefinition, ManagedSettingsData } from '../../../base/common/policy.js';
 import { APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, IAccountPolicyGateService } from '../../services/policies/common/accountPolicyService.js';
 import { adaptManagedSettings, IManagedSettingsResponse } from '../../services/accounts/browser/managedSettings.js';
@@ -680,6 +680,11 @@ function managedSettingsSourceLabel(source: ManagedSettingsSource): string {
 	}
 }
 
+/** Render a value as a fenced JSON code block for the diagnostics report. */
+function jsonBlock(value: unknown): string {
+	return '```json\n' + JSON.stringify(value ?? {}, null, 2) + '\n```\n\n';
+}
+
 class PolicyDiagnosticsAction extends Action2 {
 
 	constructor() {
@@ -835,14 +840,12 @@ class PolicyDiagnosticsAction extends Action2 {
 			const rawResponse = defaultAccountService.managedSettingsRawResponse;
 			if (isObject(rawResponse)) {
 				adaptManagedSettings(rawResponse as IManagedSettingsResponse, message => parseErrors.push({ stage: 'adapt', message }));
-			}
-			if (rawResponse !== null && rawResponse !== undefined) {
 				content += '**Raw response** (last successful fetch)\n\n';
-				content += '```json\n' + JSON.stringify(rawResponse, null, 2) + '\n```\n\n';
+				content += jsonBlock(rawResponse);
 			}
 
 			content += '**Normalized bag**\n\n';
-			content += '```json\n' + JSON.stringify(serverManagedSettings ?? {}, null, 2) + '\n```\n\n';
+			content += jsonBlock(serverManagedSettings);
 
 			content += '### Native MDM\n\n';
 			content += '| Property | Value |\n';
@@ -850,7 +853,7 @@ class PolicyDiagnosticsAction extends Action2 {
 			content += `| Available | ${copilotManagedSettingsService ? 'yes' : 'no (desktop only)'} |\n`;
 			content += `| Active | ${selection.source === 'nativeMdm' ? 'yes' : 'no'} |\n\n`;
 			if (copilotManagedSettingsService) {
-				content += '```json\n' + JSON.stringify(nativeManagedSettings ?? {}, null, 2) + '\n```\n\n';
+				content += jsonBlock(nativeManagedSettings);
 			}
 
 			// Mirror AccountPolicyService: project the winning bag onto the keys declared by policies
@@ -862,22 +865,25 @@ class PolicyDiagnosticsAction extends Action2 {
 					Object.assign(declaredDefinitions, declared);
 				}
 			}
-			const effective = projectManagedSettings({ ...selection.values }, declaredDefinitions, message => parseErrors.push({ stage: 'project', message }));
+			const effective = projectManagedSettings(selection.values ?? {}, declaredDefinitions, message => parseErrors.push({ stage: 'project', message }));
 
-			// JSON payloads (the strings PolicyConfiguration parses back into typed values), checked
-			// with the same jsonc parser and error messages so malformed values surface here too.
-			for (const [key, value] of Object.entries(effective)) {
-				if (typeof value === 'string' && /^\s*[{[]/.test(value)) {
-					const jsonErrors: json.ParseError[] = [];
-					json.parse(value, jsonErrors);
-					for (const e of jsonErrors) {
-						parseErrors.push({ stage: 'parse', message: `${key} @ offset ${e.offset}: ${getParseErrorMessage(e.error)}` });
-					}
+			// JSON payloads: the structured keys carry a JSON string that PolicyConfiguration parses
+			// back into the object/array-typed setting on read. Re-parse exactly those keys with the
+			// same jsonc parser so a malformed value surfaces here instead of being silently rejected.
+			for (const key of [COPILOT_ENABLED_PLUGINS_KEY, COPILOT_STRICT_MARKETPLACES_KEY, COPILOT_EXTRA_MARKETPLACES_KEY]) {
+				const value = effective[key];
+				if (typeof value !== 'string') {
+					continue;
+				}
+				const jsonErrors: json.ParseError[] = [];
+				json.parse(value, jsonErrors);
+				for (const e of jsonErrors) {
+					parseErrors.push({ stage: 'parse', message: `${key} @ offset ${e.offset}: ${getParseErrorMessage(e.error)}` });
 				}
 			}
 
 			content += '### Effective\n\n';
-			content += '```json\n' + JSON.stringify(effective, null, 2) + '\n```\n\n';
+			content += jsonBlock(effective);
 
 			content += `### Parse Errors (${parseErrors.length})\n\n`;
 			if (parseErrors.length > 0) {

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -46,6 +46,8 @@ import { IDefaultAccountService } from '../../../platform/defaultAccount/common/
 import { IAuthenticationService } from '../../services/authentication/common/authentication.js';
 import { IAuthenticationAccessService } from '../../services/authentication/browser/authenticationAccessService.js';
 import { IPolicyService } from '../../../platform/policy/common/policy.js';
+import { ICopilotManagedSettingsService, ManagedSettingsSource, projectManagedSettings, selectManagedSettings } from '../../../platform/policy/common/copilotManagedSettings.js';
+import { IManagedSettingPolicyDefinition, ManagedSettingsData } from '../../../base/common/policy.js';
 import { APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, IAccountPolicyGateService } from '../../services/policies/common/accountPolicyService.js';
 
 class InspectContextKeysAction extends Action2 {
@@ -665,6 +667,15 @@ class StopTrackDisposables extends Action2 {
 	}
 }
 
+/** Human-readable label for a managed-settings {@link ManagedSettingsSource} in the diagnostics report. */
+function managedSettingsSourceLabel(source: ManagedSettingsSource): string {
+	switch (source) {
+		case 'server': return 'GitHub Server API';
+		case 'nativeMdm': return 'Native MDM';
+		case 'none': return 'None (no managed settings active)';
+	}
+}
+
 class PolicyDiagnosticsAction extends Action2 {
 
 	constructor() {
@@ -685,6 +696,15 @@ class PolicyDiagnosticsAction extends Action2 {
 		const authenticationAccessService = accessor.get(IAuthenticationAccessService);
 		const policyService = accessor.get(IPolicyService);
 		const accountPolicyGateService = accessor.get(IAccountPolicyGateService);
+		// Native MDM is a desktop-only channel (registered via the main process); it is absent in
+		// web windows. Resolve it now, synchronously, because the accessor is only valid before the
+		// first `await` below.
+		let copilotManagedSettingsService: ICopilotManagedSettingsService | undefined;
+		try {
+			copilotManagedSettingsService = accessor.get(ICopilotManagedSettingsService);
+		} catch {
+			// no native MDM channel in this window
+		}
 
 		const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 
@@ -783,30 +803,69 @@ class PolicyDiagnosticsAction extends Action2 {
 		content += '## Managed Settings\n\n';
 		try {
 			const policyData = defaultAccountService.policyData;
+			const serverManagedSettings = policyData?.managedSettings;
 
+			const nativeManagedSettings: ManagedSettingsData | undefined = copilotManagedSettingsService?.managedSettings;
+
+			// Reuse the same precedence as policy evaluation so this report can never drift from the
+			// source AccountPolicyService actually applies.
+			const selection = selectManagedSettings(serverManagedSettings, nativeManagedSettings);
+
+			content += `**Active source**: ${managedSettingsSourceLabel(selection.source)}\n\n`;
+			content += 'Managed settings can arrive from more than one channel. The GitHub server API takes precedence over native MDM and the channels are never merged, so exactly one channel is active at a time.\n\n';
+
+			// --- GitHub server API channel ---
+			content += '### GitHub Server API\n\n';
+			content += 'Endpoint: `/copilot_internal/managed_settings`\n\n';
 			content += '| Property | Value |\n';
 			content += '|----------|-------|\n';
 			const fetchStatus = defaultAccountService.managedSettingsFetchStatus;
-			const fetchStatusDisplay = fetchStatus === null ? '*not yet fetched*' : `\`${fetchStatus}\``;
-			content += `| Last fetch | ${fetchStatusDisplay} |\n`;
+			content += `| Last fetch (most recent attempt) | ${fetchStatus === null ? '*not yet fetched*' : `\`${fetchStatus}\``} |\n`;
 			const fetchedAt = defaultAccountService.managedSettingsFetchedAt;
-			content += `| Fetched at | ${fetchedAt ? new Date(fetchedAt).toLocaleString() : '*n/a*'} |\n`;
+			content += `| Last successful fetch | ${fetchedAt ? new Date(fetchedAt).toLocaleString() : '*n/a*'} |\n`;
+			content += `| Active | ${selection.source === 'server' ? 'yes' : 'no'} |\n`;
 			content += '\n';
 
 			const rawResponse = defaultAccountService.managedSettingsRawResponse;
 			if (rawResponse !== null && rawResponse !== undefined) {
-				content += '### Raw Response\n\n';
+				content += 'Raw response captured on the last *successful* fetch. A more recent failed fetch (for example a `404` above) leaves this value stale and does NOT apply it, so it can disagree with the effective bag below:\n\n';
 				content += '```json\n';
 				content += JSON.stringify(rawResponse, null, 2);
 				content += '\n```\n\n';
 			}
 
-			content += '### Processed (after projection)\n\n';
-			const managedSettingsData = {
-				managedSettings: policyData?.managedSettings,
-			};
+			content += 'Normalized bag (server response flattened to dot-path keys):\n\n';
 			content += '```json\n';
-			content += JSON.stringify(managedSettingsData, null, 2);
+			content += JSON.stringify(serverManagedSettings ?? {}, null, 2);
+			content += '\n```\n\n';
+
+			// --- Native MDM channel ---
+			content += '### Native MDM\n\n';
+			content += 'OS registry (Windows) / managed preferences (macOS)\n\n';
+			if (copilotManagedSettingsService === undefined) {
+				content += '*Not available in this window (desktop only).*\n\n';
+			} else {
+				content += `Active: ${selection.source === 'nativeMdm' ? 'yes' : 'no'}\n\n`;
+				content += '```json\n';
+				content += JSON.stringify(nativeManagedSettings ?? {}, null, 2);
+				content += '\n```\n\n';
+			}
+
+			// --- Effective bag after selection + projection ---
+			// Mirror AccountPolicyService: project the winning bag onto the keys declared by policies
+			// so the report shows exactly what reaches `policy.value(...)`.
+			const declaredDefinitions: Record<string, IManagedSettingPolicyDefinition> = {};
+			for (const property of [...Object.values(configurationRegistry.getConfigurationProperties()), ...Object.values(configurationRegistry.getExcludedConfigurationProperties())]) {
+				const declared = property.policy?.managedSettings;
+				if (declared) {
+					Object.assign(declaredDefinitions, declared);
+				}
+			}
+			const effective = projectManagedSettings({ ...selection.values }, declaredDefinitions);
+			content += '### Effective (after selection and projection)\n\n';
+			content += 'The bag passed to `policy.value(...)`: the active source projected onto the keys declared by policies. Undeclared keys and type mismatches are dropped.\n\n';
+			content += '```json\n';
+			content += JSON.stringify(effective, null, 2);
 			content += '\n```\n\n';
 		} catch (error) {
 			content += `*Error rendering managed settings diagnostics: ${error}*\n\n`;

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -685,6 +685,9 @@ function jsonBlock(value: unknown): string {
 	return '```json\n' + JSON.stringify(value ?? {}, null, 2) + '\n```\n\n';
 }
 
+/** Header row + separator for the report's two-column `Property | Value` tables. */
+const PROPERTY_VALUE_TABLE_HEADER = '| Property | Value |\n|----------|-------|\n';
+
 class PolicyDiagnosticsAction extends Action2 {
 
 	constructor() {
@@ -705,14 +708,14 @@ class PolicyDiagnosticsAction extends Action2 {
 		const authenticationAccessService = accessor.get(IAuthenticationAccessService);
 		const policyService = accessor.get(IPolicyService);
 		const accountPolicyGateService = accessor.get(IAccountPolicyGateService);
-		// Native MDM is a desktop-only channel (registered via the main process); it is absent in
-		// web windows. Resolve it now, synchronously, because the accessor is only valid before the
-		// first `await` below.
+		// Native MDM is a desktop-only channel, registered in the renderer service collection on
+		// desktop and Agents windows but absent in web. Resolve it now, synchronously, because the
+		// accessor is only valid before the first `await` below.
 		let copilotManagedSettingsService: ICopilotManagedSettingsService | undefined;
 		try {
 			copilotManagedSettingsService = accessor.get(ICopilotManagedSettingsService);
 		} catch {
-			// no native MDM channel in this window
+			// no native MDM channel in this window (e.g. web)
 		}
 
 		const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
@@ -720,8 +723,7 @@ class PolicyDiagnosticsAction extends Action2 {
 		let content = '# VS Code Policy Diagnostics\n\n';
 		content += '*WARNING: This file may contain sensitive information.*\n\n';
 		content += '## System Information\n\n';
-		content += '| Property | Value |\n';
-		content += '|----------|-------|\n';
+		content += PROPERTY_VALUE_TABLE_HEADER;
 		content += `| Generated | ${new Date().toISOString()} |\n`;
 		content += `| Product | ${productService.nameLong} ${productService.version} |\n`;
 		content += `| Commit | ${productService.commit || 'n/a'} |\n\n`;
@@ -755,8 +757,7 @@ class PolicyDiagnosticsAction extends Action2 {
 				content += `**Account Label**: ${accountLabel}\n\n`;
 
 				content += '### Detailed Account Properties\n\n';
-				content += '| Property | Value |\n';
-				content += '|----------|-------|\n';
+				content += PROPERTY_VALUE_TABLE_HEADER;
 
 				// Iterate through all properties of the account object
 				for (const [key, value] of Object.entries(account)) {
@@ -791,8 +792,7 @@ class PolicyDiagnosticsAction extends Action2 {
 		try {
 			const gateInfo = accountPolicyGateService.gateInfo;
 			const approvedOrgsRaw = policyService.getPolicyValue(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME);
-			content += '| Property | Value |\n';
-			content += '|----------|-------|\n';
+			content += PROPERTY_VALUE_TABLE_HEADER;
 			content += `| State | \`${gateInfo.state}\` |\n`;
 			content += `| Reason | ${gateInfo.reason ? `\`${gateInfo.reason}\`` : '*n/a*'} |\n`;
 			content += `| ${APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME} | ${approvedOrgsRaw !== undefined ? `\`${String(approvedOrgsRaw)}\`` : '*not set*'} |\n`;
@@ -828,8 +828,7 @@ class PolicyDiagnosticsAction extends Action2 {
 			const parseErrors: { stage: string; message: string }[] = [];
 
 			content += '### GitHub Server API\n\n';
-			content += '| Property | Value |\n';
-			content += '|----------|-------|\n';
+			content += PROPERTY_VALUE_TABLE_HEADER;
 			content += '| Endpoint | `/copilot_internal/managed_settings` |\n';
 			const fetchStatus = defaultAccountService.managedSettingsFetchStatus;
 			content += `| Last fetch | ${fetchStatus === null ? '*never*' : `\`${fetchStatus}\``} |\n`;
@@ -848,9 +847,8 @@ class PolicyDiagnosticsAction extends Action2 {
 			content += jsonBlock(serverManagedSettings);
 
 			content += '### Native MDM\n\n';
-			content += '| Property | Value |\n';
-			content += '|----------|-------|\n';
-			content += `| Available | ${copilotManagedSettingsService ? 'yes' : 'no (desktop only)'} |\n`;
+			content += PROPERTY_VALUE_TABLE_HEADER;
+			content += `| Available | ${copilotManagedSettingsService ? 'yes' : 'no'} |\n`;
 			content += `| Active | ${selection.source === 'nativeMdm' ? 'yes' : 'no'} |\n\n`;
 			if (copilotManagedSettingsService) {
 				content += jsonBlock(nativeManagedSettings);

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -15,7 +15,7 @@ import '../../../../platform/agentHost/common/agentHostStarter.config.contributi
 import { AgentHostAhpJsonlLoggingSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostOpus48PromptEnabledSettingId, AgentHostSdkSandboxEnabledSettingId, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHostEditorSettingId } from '../../../../platform/agentHost/common/agentService.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../../../platform/networkFilter/common/networkFilterService.js';
 import { AgentNetworkDomainSettingId } from '../../../../platform/networkFilter/common/settings.js';
-import { COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_STRICT_MARKETPLACES_KEY } from '../../../../platform/policy/common/copilotManagedSettings.js';
+import { COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_STRICT_MARKETPLACES_KEY, managedSettingValue } from '../../../../platform/policy/common/copilotManagedSettings.js';
 import { AgentSandboxEnabledValue, AgentSandboxSettingId } from '../../../../platform/sandbox/common/settings.js';
 import { registerEditorFeature } from '../../../../editor/common/editorFeatures.js';
 import * as nls from '../../../../nls.js';
@@ -993,7 +993,7 @@ configurationRegistry.registerConfiguration({
 				name: 'ChatEnabledPlugins',
 				category: PolicyCategory.InteractiveSession,
 				minimumVersion: '1.122',
-				value: (policyData) => policyData.managedSettings?.[COPILOT_ENABLED_PLUGINS_KEY],
+				value: managedSettingValue(COPILOT_ENABLED_PLUGINS_KEY),
 				managedSettings: {
 					[COPILOT_ENABLED_PLUGINS_KEY]: { type: 'string' },
 				},
@@ -1038,7 +1038,7 @@ configurationRegistry.registerConfiguration({
 				name: 'ChatExtraMarketplaces',
 				category: PolicyCategory.InteractiveSession,
 				minimumVersion: '1.122',
-				value: (policyData) => policyData.managedSettings?.[COPILOT_EXTRA_MARKETPLACES_KEY],
+				value: managedSettingValue(COPILOT_EXTRA_MARKETPLACES_KEY),
 				managedSettings: {
 					[COPILOT_EXTRA_MARKETPLACES_KEY]: { type: 'string' },
 				},
@@ -1079,7 +1079,7 @@ configurationRegistry.registerConfiguration({
 				name: 'ChatStrictMarketplaces',
 				category: PolicyCategory.InteractiveSession,
 				minimumVersion: '1.122',
-				value: (policyData) => policyData.managedSettings?.[COPILOT_STRICT_MARKETPLACES_KEY],
+				value: managedSettingValue(COPILOT_STRICT_MARKETPLACES_KEY),
 				managedSettings: {
 					[COPILOT_STRICT_MARKETPLACES_KEY]: { type: 'string' },
 				},

--- a/src/vs/workbench/electron-browser/desktop.main.ts
+++ b/src/vs/workbench/electron-browser/desktop.main.ts
@@ -53,6 +53,7 @@ import { IUserDataProfilesService, reviveProfile } from '../../platform/userData
 import { UserDataProfilesService } from '../../platform/userDataProfile/common/userDataProfileIpc.js';
 import { PolicyChannelClient } from '../../platform/policy/common/policyIpc.js';
 import { CopilotManagedSettingsChannelClient } from '../../platform/policy/common/copilotManagedSettingsIpc.js';
+import { ICopilotManagedSettingsService } from '../../platform/policy/common/copilotManagedSettings.js';
 import { IPolicyService } from '../../platform/policy/common/policy.js';
 import { UserDataProfileService } from '../services/userDataProfile/common/userDataProfileService.js';
 import { IUserDataProfileService } from '../services/userDataProfile/common/userDataProfile.js';
@@ -220,6 +221,7 @@ export class DesktopMain extends Disposable {
 		let policyService: IPolicyService;
 		const policyChannel = this.configuration.policiesData ? this._register(new PolicyChannelClient(this.configuration.policiesData, mainProcessService.getChannel('policy'))) : undefined;
 		const copilotManagedSettings = this._register(new CopilotManagedSettingsChannelClient(mainProcessService.getChannel('copilotManagedSettings')));
+		serviceCollection.set(ICopilotManagedSettingsService, copilotManagedSettings);
 		const accountPolicy = this._register(new AccountPolicyService(logService, defaultAccountService, policyChannel, copilotManagedSettings));
 		if (policyChannel) {
 			policyService = this._register(new MultiplexPolicyService([policyChannel, accountPolicy], logService));

--- a/src/vs/workbench/services/accounts/browser/managedSettings.ts
+++ b/src/vs/workbench/services/accounts/browser/managedSettings.ts
@@ -36,6 +36,47 @@ export interface IManagedSettingsResponse {
 }
 
 /**
+ * Descriptor for a structured (object/array) managed setting: one carried across both delivery
+ * channels as a canonical JSON string under a single key. This table is the single place that
+ * knows how to turn a server `managed_settings` response field into that canonical value, so
+ * adding a structured key is one row here (plus its {@link IManagedSettingsResponse} field — the
+ * `responseField` union is hand-maintained in sync with the interface's named fields, not
+ * compiler-enforced, because the response's index signature widens `keyof` to `string`; the
+ * `adaptManagedSettings` tests are the drift backstop — and the policy declaration that reads
+ * the bag key).
+ */
+interface IStructuredManagedSetting {
+	/** Canonical managed-settings bag key (the dot-path constant) the JSON string is stored under. */
+	readonly key: string;
+	/** Server response field this descriptor consumes; excluded from the scalar flatten and fed to `encode`. */
+	readonly responseField: 'enabledPlugins' | 'extraKnownMarketplaces' | 'strictKnownMarketplaces';
+	/**
+	 * Normalize the raw server value into the canonical pre-stringify shape an admin authors via
+	 * native MDM. Return `undefined` to omit the key (absent or malformed value). Note an empty
+	 * array (the `strictKnownMarketplaces` lockdown case) is returned as-is, not omitted.
+	 */
+	readonly encode: (value: unknown, onWarn?: (msg: string) => void) => unknown;
+}
+
+const STRUCTURED_MANAGED_SETTINGS: readonly IStructuredManagedSetting[] = [
+	{
+		key: COPILOT_ENABLED_PLUGINS_KEY,
+		responseField: 'enabledPlugins',
+		encode: value => isObject(value) ? value : undefined,
+	},
+	{
+		key: COPILOT_STRICT_MARKETPLACES_KEY,
+		responseField: 'strictKnownMarketplaces',
+		encode: value => Array.isArray(value) ? value : undefined,
+	},
+	{
+		key: COPILOT_EXTRA_MARKETPLACES_KEY,
+		responseField: 'extraKnownMarketplaces',
+		encode: (value, onWarn) => extraKnownMarketplacesToConfigDict(normalizeExtraKnownMarketplaces(value, onWarn)),
+	},
+];
+
+/**
  * Adapt the `managed_settings` API response into the `managedSettings` slice of
  * {@link IPolicyData} that the policy framework consumes. This is the single
  * server-side normalizer: it encodes the response into the SAME canonical
@@ -47,12 +88,11 @@ export interface IManagedSettingsResponse {
  *
  * - Scalar leaves (`permissions.*` and any forward-compatible scalar keys) are
  *   flattened into dot-separated keys.
- * - Structured settings (`enabledPlugins`, `extraKnownMarketplaces`,
- *   `strictKnownMarketplaces`) are carried as canonical JSON strings under a
- *   single key each — the same shape an admin authors via native MDM.
- *   `PolicyConfiguration` parses the JSON back into the object-typed setting on
- *   read. `extraKnownMarketplaces` is normalized from the API's
- *   `Record<id, { source }>` map to the `{ [name]: url-or-shorthand }` dict.
+ * - Structured settings (declared in {@link STRUCTURED_MANAGED_SETTINGS}) are
+ *   carried as canonical JSON strings under a single key each — the same shape an
+ *   admin authors via native MDM. `PolicyConfiguration` parses the JSON back into
+ *   the object-typed setting on read. `extraKnownMarketplaces` is normalized from
+ *   the API's `Record<id, { source }>` map to the `{ [name]: url-or-shorthand }` dict.
  *
  * Malformed marketplace entries are dropped (with an optional warning via
  * {@link onWarn}) rather than throwing, so a bad enterprise settings file degrades
@@ -61,21 +101,21 @@ export interface IManagedSettingsResponse {
  * Exported for unit-testing the shape transformation independently of network I/O.
  */
 export function adaptManagedSettings(response: IManagedSettingsResponse, onWarn?: (msg: string) => void): Partial<IPolicyData> {
-	const { enabledPlugins, extraKnownMarketplaces, strictKnownMarketplaces, ...rest } = response;
-
-	const managedSettings: Record<string, ManagedSettingValue> = { ...flattenManagedSettings(rest) };
-
-	if (isObject(enabledPlugins)) {
-		managedSettings[COPILOT_ENABLED_PLUGINS_KEY] = JSON.stringify(enabledPlugins);
+	// Spread + delete (not for..in + assignment) so the scalar remainder keeps exact `{ ...rest }`
+	// semantics: it never triggers the inherited `__proto__` setter for a server-sent own
+	// `__proto__` key, matching the original destructuring rest.
+	const scalarRest: Record<string, unknown> = { ...response };
+	for (const setting of STRUCTURED_MANAGED_SETTINGS) {
+		delete scalarRest[setting.responseField];
 	}
 
-	if (Array.isArray(strictKnownMarketplaces)) {
-		managedSettings[COPILOT_STRICT_MARKETPLACES_KEY] = JSON.stringify(strictKnownMarketplaces);
-	}
+	const managedSettings: Record<string, ManagedSettingValue> = { ...flattenManagedSettings(scalarRest) };
 
-	const marketplaceDict = extraKnownMarketplacesToConfigDict(normalizeExtraKnownMarketplaces(extraKnownMarketplaces, onWarn));
-	if (marketplaceDict) {
-		managedSettings[COPILOT_EXTRA_MARKETPLACES_KEY] = JSON.stringify(marketplaceDict);
+	for (const setting of STRUCTURED_MANAGED_SETTINGS) {
+		const encoded = setting.encode(response[setting.responseField], onWarn);
+		if (encoded !== undefined) {
+			managedSettings[setting.key] = JSON.stringify(encoded);
+		}
 	}
 
 	return { managedSettings };
@@ -87,7 +127,7 @@ export function adaptManagedSettings(response: IManagedSettingsResponse, onWarn?
  * source discriminator, and any `ref`. Malformed or off-spec entries are dropped
  * (with an optional warning via {@link onWarn}).
  */
-function normalizeExtraKnownMarketplaces(value: IManagedSettingsResponse['extraKnownMarketplaces'], onWarn?: (msg: string) => void): IExtraKnownMarketplaceEntry[] | undefined {
+function normalizeExtraKnownMarketplaces(value: unknown, onWarn?: (msg: string) => void): IExtraKnownMarketplaceEntry[] | undefined {
 	if (!isObject(value)) {
 		return undefined;
 	}

--- a/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
@@ -140,6 +140,18 @@ suite('adaptManagedSettings', () => {
 		});
 	});
 
+	test('resilience: a primitive own `__proto__` scalar is dropped, never pollutes the result', () => {
+		// The reviewer-flagged case. flattenManagedSettings only assigns at the bare `__proto__`
+		// key when the value is a PRIMITIVE, where the inherited `__proto__` setter is a no-op, so
+		// the value is simply dropped (no prototype mutation), matching the original `...rest`.
+		const response = JSON.parse('{"permissions":{"x":1},"__proto__":true}') as IManagedSettingsResponse;
+		assert.deepStrictEqual(adaptManagedSettings(response), {
+			managedSettings: {
+				'permissions.x': 1,
+			},
+		});
+	});
+
 	test('resilience: malformed marketplace entries are skipped, valid entries still processed', () => {
 		const warnings: string[] = [];
 		const result = adaptManagedSettings({

--- a/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
@@ -126,6 +126,20 @@ suite('adaptManagedSettings', () => {
 		});
 	});
 
+	test('resilience: a server-sent own `__proto__` key is carried like any scalar, never applied to the prototype', () => {
+		// JSON.parse (not an object literal) yields an OWN enumerable `__proto__` data property.
+		// The scalar remainder must keep `{ ...rest }` semantics: copy it as data (so it flattens
+		// to `__proto__.polluted`) rather than assigning through the inherited `__proto__` setter
+		// (which would swap the prototype and instead surface the inherited `polluted` key).
+		const response = JSON.parse('{"permissions":{"x":1},"__proto__":{"polluted":true}}') as IManagedSettingsResponse;
+		assert.deepStrictEqual(adaptManagedSettings(response), {
+			managedSettings: {
+				'permissions.x': 1,
+				'__proto__.polluted': true,
+			},
+		});
+	});
+
 	test('resilience: malformed marketplace entries are skipped, valid entries still processed', () => {
 		const warnings: string[] = [];
 		const result = adaptManagedSettings({

--- a/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
@@ -169,6 +169,19 @@ suite('adaptManagedSettings', () => {
 		assert.strictEqual(warnings.length, 2);
 	});
 
+	test('resilience: extraKnownMarketplaces github entry missing "repo" is skipped with a warning', () => {
+		const warnings: string[] = [];
+		const result = adaptManagedSettings({
+			extraKnownMarketplaces: {
+				'example-key': { source: { source: 'github' } } as IManagedSettingsResponse['extraKnownMarketplaces'] extends Record<string, infer V> ? V : never,
+			},
+		} as IManagedSettingsResponse, msg => warnings.push(msg));
+		assert.deepStrictEqual(
+			{ result, warned: warnings.length, mentionsRepo: warnings.some(w => w.includes('requires "repo"')) },
+			{ result: { managedSettings: {} }, warned: 1, mentionsRepo: true }
+		);
+	});
+
 	test('resilience: a marketplace string array (wrong format) is treated as missing, no throw', () => {
 		assert.deepStrictEqual(adaptManagedSettings({
 			extraKnownMarketplaces: ['https://plugins.acme.com'] as unknown as IManagedSettingsResponse['extraKnownMarketplaces'],

--- a/src/vs/workbench/services/policies/common/accountPolicyService.ts
+++ b/src/vs/workbench/services/policies/common/accountPolicyService.ts
@@ -11,7 +11,7 @@ import { localize } from '../../../../nls.js';
 import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { ICopilotManagedSettingsService, collectManagedSettingsDefinitions, hasManagedSettingsDefinitions, projectManagedSettings } from '../../../../platform/policy/common/copilotManagedSettings.js';
+import { ICopilotManagedSettingsService, collectManagedSettingsDefinitions, hasManagedSettingsDefinitions, projectManagedSettings, selectManagedSettings } from '../../../../platform/policy/common/copilotManagedSettings.js';
 import { AbstractPolicyService, getRestrictedPolicyValue, IPolicyService, PolicyDefinition, PolicyValue } from '../../../../platform/policy/common/policy.js';
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 
@@ -180,20 +180,17 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 	private getPolicyData(managedSettings?: ManagedSettingsData): IPolicyData | undefined {
 		const accountPolicyData = this.defaultAccountService.policyData ?? undefined;
 		const nativeManagedSettings = managedSettings ?? this.copilotManagedSettingsService?.managedSettings;
-		const hasNativeManagedSettings = nativeManagedSettings && Object.keys(nativeManagedSettings).length > 0;
-		if (!accountPolicyData && !hasNativeManagedSettings) {
-			return undefined;
-		}
 
 		// Single authoritative source: server-delivered managed settings win over native MDM.
 		// See `.github/skills/add-policy/github-managed-settings.md` for the precedence rationale.
-		const serverManagedSettings = accountPolicyData?.managedSettings;
-		const hasServerManagedSettings = serverManagedSettings && Object.keys(serverManagedSettings).length > 0;
-		const winningManagedSettings = hasServerManagedSettings ? serverManagedSettings : nativeManagedSettings;
+		const selection = selectManagedSettings(accountPolicyData?.managedSettings, nativeManagedSettings);
+		if (!accountPolicyData && selection.source === 'none') {
+			return undefined;
+		}
 
 		const declaredManagedSettings = collectManagedSettingsDefinitions(this.policyDefinitions);
 		const managedSettingsData = projectManagedSettings(
-			{ ...winningManagedSettings },
+			{ ...selection.values },
 			declaredManagedSettings,
 			msg => this.logService.warn(`[AccountPolicy] ${msg}`)
 		);

--- a/src/vs/workbench/services/policies/common/accountPolicyService.ts
+++ b/src/vs/workbench/services/policies/common/accountPolicyService.ts
@@ -11,7 +11,7 @@ import { localize } from '../../../../nls.js';
 import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { ICopilotManagedSettingsService, collectManagedSettingsDefinitions, projectManagedSettings } from '../../../../platform/policy/common/copilotManagedSettings.js';
+import { ICopilotManagedSettingsService, collectManagedSettingsDefinitions, hasManagedSettingsDefinitions, projectManagedSettings } from '../../../../platform/policy/common/copilotManagedSettings.js';
 import { AbstractPolicyService, getRestrictedPolicyValue, IPolicyService, PolicyDefinition, PolicyValue } from '../../../../platform/policy/common/policy.js';
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 
@@ -170,7 +170,7 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 	}
 
 	private async updateCopilotManagedSettingDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): Promise<ManagedSettingsData | undefined> {
-		if (!this.copilotManagedSettingsService || !hasManagedSettingsPolicyDefinitions(policyDefinitions)) {
+		if (!this.copilotManagedSettingsService || !hasManagedSettingsDefinitions(policyDefinitions)) {
 			return this.copilotManagedSettingsService?.managedSettings;
 		}
 
@@ -243,16 +243,6 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 
 		return { state: AccountPolicyGateState.Satisfied, approvedOrganizations: approvedOrgs };
 	}
-}
-
-function hasManagedSettingsPolicyDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): boolean {
-	for (const policyName in policyDefinitions) {
-		const policyManagedSettings = policyDefinitions[policyName].managedSettings;
-		if (policyManagedSettings && Object.keys(policyManagedSettings).length > 0) {
-			return true;
-		}
-	}
-	return false;
 }
 
 function parseApprovedOrganizations(raw: PolicyValue | undefined): string[] {


### PR DESCRIPTION
## Why

The Copilot enterprise managed-settings code (native MDM plus the GitHub server channel, both feeding one canonical `IPolicyData.managedSettings` bag) had accumulated per-key duplication: each structured object/array setting carried its own hand-written branch in the server adapter, there were two near-identical deep-equality helpers, and a private "does any policy declare a managed setting" check was duplicated across files. A few doc comments also overstated compile-time guarantees. This refactor consolidates that surface so adding a managed-settings key touches one place, with no behavior change.

## What

- **Single descriptor table for structured settings.** `adaptManagedSettings` now drives object/array encoding from one `STRUCTURED_MANAGED_SETTINGS` table (`key` + `responseField` + `encode`) instead of three bespoke branches. Adding a structured key is one row.
- **Consolidated equality.** Replaced the two bespoke `areManagedSettings*Equal` helpers with the shared deep `equals` (the records are flat, so it is exactly equivalent).
- **Shared helpers.** Added `hasManagedSettingsDefinitions` (replacing a private duplicate in `accountPolicyService`) and `managedSettingValue(key)` for the common "lock to the managed value, else fall through" policy callback.
- **Docs.** Updated the `add-policy` skill doc to match.

## Maintainability review (3-model council)

Folded in findings from a GPT-5.5 / Gemini 3.1 Pro / Sonnet 4.6 review:

- **Behavior-preservation fix (the important one):** the scalar remainder in `adaptManagedSettings` is now built with `{ ...response }` + `delete` rather than `for..in` + assignment. The latter would route a server-sent own `__proto__` key through the inherited `__proto__` setter, diverging from the original destructuring `...rest`. Added a regression test that locks this in.
- `managedSettingValue` is memoized per key, so the policy-definition reference identity that `isSamePolicyDefinition` relies on is a real guarantee rather than an accident of where the helper is called.
- Corrected JSDoc and skill wording that claimed `responseField` is compiler-checked against the response interface; the response's index signature defeats `keyof`, so the union is hand-maintained and the adapter tests are the drift backstop.

## Risk and testing

Strictly behavior-preserving. This is security-sensitive enterprise-lockdown code, so no functional change is intended. `npm run typecheck-client` is clean and all four managed-settings suites pass (50 tests, including the new `__proto__` and memoization cases):

```
src/vs/platform/policy/test/common/copilotManagedSettings.test.ts
src/vs/platform/policy/test/node/copilotManagedSettingsService.test.ts
src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
```