### PR TITLE
Add `agents.voice.microphoneDevice` setting for mic selection

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -525,14 +525,14 @@ function sdkAttachmentToProtocol(
 				return {
 					type: MessageAttachmentKind.Simple,
 					label: attachment.displayName ?? 'attachment',
-					modelRepresentation: decodeBase64(attachment.data).toString(),
+					modelRepresentation: decodeBase64(attachment.data ?? '').toString(),
 				};
 			}
 			const displayKind = attachment.mimeType.startsWith('image/') ? 'image' : undefined;
 			return {
 				type: MessageAttachmentKind.EmbeddedResource,
 				label: attachment.displayName ?? 'attachment',
-				data: attachment.data,
+				data: attachment.data ?? '',
 				contentType: attachment.mimeType,
 				displayKind,
 			};

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -36,6 +36,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 
 import { IAgentsVoiceWindowService, AgentsVoiceStorageKeys } from '../common/agentsVoice.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import {
 	VoiceEnabledClassification, VoiceEnabledEvent,
@@ -385,6 +386,65 @@ registerAction2(class extends Action2 {
 	}
 });
 
+// --- Select Microphone Command ---
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'agentsVoice.selectMicrophone',
+			title: nls.localize2('agentsVoice.selectMicrophone', "Voice: Select Microphone"),
+			f1: true,
+			precondition: ContextKeyExpr.equals('config.agents.voice.enabled', true),
+		});
+	}
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const quickInputService = accessor.get(IQuickInputService);
+		const configurationService = accessor.get(IConfigurationService);
+
+		const devices = await navigator.mediaDevices.enumerateDevices();
+		const allAudioInputs = devices.filter(d => d.kind === 'audioinput');
+		const defaultDevice = allAudioInputs.find(d => d.deviceId === 'default');
+		const defaultDeviceLabel = defaultDevice?.label?.replace(/^Default - /, '') || '';
+		const audioInputs = allAudioInputs.filter(d => d.deviceId !== 'default');
+
+		if (audioInputs.length === 0) {
+			quickInputService.pick([{ label: nls.localize('noMicrophones', "No microphones found") }]);
+			return;
+		}
+
+		const currentDeviceId = configurationService.getValue<string>('agents.voice.microphoneDevice') || '';
+
+		const items = audioInputs.map(d => {
+			const label = d.label || nls.localize('unknownDevice', "Unknown Device ({0})", d.deviceId.slice(0, 8));
+			const isSystemDefault = label === defaultDeviceLabel;
+			const isSelected = currentDeviceId === '' ? isSystemDefault : d.deviceId === currentDeviceId;
+
+			const parts: string[] = [];
+			if (isSystemDefault) {
+				parts.push(nls.localize('systemDefault', "System Default"));
+			}
+			if (isSelected) {
+				parts.push(nls.localize('current', "(current)"));
+			}
+
+			return {
+				label,
+				description: parts.length > 0 ? parts.join(' ') : undefined,
+				deviceId: d.deviceId,
+			};
+		});
+
+		const picked = await quickInputService.pick(items, {
+			placeHolder: nls.localize('selectMic', "Select a microphone for Voice Mode"),
+		});
+
+		if (picked) {
+			const selection = picked as typeof items[number];
+			await configurationService.updateValue('agents.voice.microphoneDevice', selection.deviceId);
+		}
+	}
+});
+
 // --- Settings ---
 
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
@@ -441,10 +501,10 @@ configurationRegistry.registerConfiguration({
 		},
 		'agents.voice.microphoneDevice': {
 			type: 'string',
-			description: nls.localize('agents.voice.microphoneDevice', "The device ID of the microphone to use for voice mode. Leave empty to use the system default."),
+			description: nls.localize('agents.voice.microphoneDevice', "The device ID of the microphone to use for voice mode. Use the 'Voice: Select Microphone' command to pick a device."),
 			default: '',
 			scope: ConfigurationScope.APPLICATION,
-			included: false,
+			ignoreSync: true,
 		},
 	}
 });

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -439,5 +439,12 @@ configurationRegistry.registerConfiguration({
 			included: false,
 			tags: ['advanced'],
 		},
+		'agents.voice.microphoneDevice': {
+			type: 'string',
+			description: nls.localize('agents.voice.microphoneDevice', "The device ID of the microphone to use for voice mode. Leave empty to use the system default."),
+			default: '',
+			scope: ConfigurationScope.APPLICATION,
+			included: false,
+		},
 	}
 });

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
@@ -7,6 +7,7 @@ import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 
 export const IMicCaptureService = createDecorator<IMicCaptureService>('micCaptureService');
 
@@ -123,6 +124,12 @@ export interface IMicCaptureService {
 
 export class MicCaptureService extends Disposable implements IMicCaptureService {
 	declare readonly _serviceBrand: undefined;
+
+	constructor(
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+	) {
+		super();
+	}
 
 	private _window: (Window & typeof globalThis) | undefined;
 	private _micStream: MediaStream | null = null;
@@ -284,13 +291,19 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 		this._window = window;
 		if (this._isCapturing) { return; }
 
+		const deviceId = this.configurationService.getValue<string>('agents.voice.microphoneDevice');
+		const audioConstraints: MediaTrackConstraints = {
+			channelCount: 1,
+			sampleRate: 16000,
+			echoCancellation: true,
+			noiseSuppression: true,
+		};
+		if (deviceId) {
+			audioConstraints.deviceId = { exact: deviceId };
+		}
+
 		const micStream = await window.navigator.mediaDevices.getUserMedia({
-			audio: {
-				channelCount: 1,
-				sampleRate: 16000,
-				echoCancellation: true,
-				noiseSuppression: true,
-			},
+			audio: audioConstraints,
 		});
 		this._micStream = micStream;
 


### PR DESCRIPTION
Adds a new `agents.voice.microphoneDevice` setting to specify which microphone device to use for voice mode. When set, passes the deviceId as an exact constraint to getUserMedia. Empty string (default) uses the system default.

Fixes #322435

<img width="623" height="182" alt="Screenshot 2026-06-22 at 5 17 48 PM" src="https://github.com/user-attachments/assets/c6c15e41-701a-4951-8ab2-72618832fd2c" />
