### PR TITLE
chat: handle duplicate agent plugin enablement

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -111,6 +111,8 @@ Remote agent hosts can also register **external harnesses** dynamically. Each re
 
 The Plugins section renders remote harness `itemProvider` entries with `type: 'plugin'` directly. This is separate from the prompt-file pipeline used for Agents, Skills, Instructions, Prompts, and Hooks.
 
+Local plugin discovery is aggregated by `IAgentPluginService` from priority-ordered discovery providers: configured paths, VS Code marketplace installs, extension-contributed plugins, and Copilot CLI installs. Each provider reports `undefined` until its initial scan completes; the service waits for every provider to complete before exposing plugins. Once ready, plugins are canonicalized into collision groups so the same plugin discovered from multiple install roots (for example a VS Code marketplace install and a Copilot CLI direct install) remains visible but only the highest-priority copy is enabled by default. Enabling one copy disables the other copies in the same collision group.
+
 ### IHarnessDescriptor
 
 Key properties on the harness descriptor:

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
@@ -243,6 +243,9 @@ export async function resolveCustomizationRefs(
 			if (syncProvider.isDisabled(plugin.uri)) {
 				continue;
 			}
+			if (!isContributionEnabled(plugin.enablement.get())) {
+				continue;
+			}
 			addPluginRef(plugin);
 		} else {
 			looseFiles.push({ uri: entry.uri, type: entry.type });

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -68,7 +68,7 @@ import { ILanguageModelToolsConfirmationService } from '../common/tools/language
 import { ILanguageModelToolsService } from '../common/tools/languageModelToolsService.js';
 import { ChatToolRiskAssessmentService, IChatToolRiskAssessmentService } from './tools/chatToolRiskAssessmentService.js';
 import { ChatGoalSummaryService, IChatGoalSummaryService } from './chatGoalSummaryService.js';
-import { agentPluginDiscoveryRegistry, IAgentPluginService } from '../common/plugins/agentPluginService.js';
+import { AgentPluginDiscoveryPriority, agentPluginDiscoveryRegistry, IAgentPluginService } from '../common/plugins/agentPluginService.js';
 import { ChatPromptFilesExtensionPointHandler } from '../common/promptSyntax/chatPromptFilesContribution.js';
 import { isTildePath, PromptsConfig } from '../common/promptSyntax/config/config.js';
 import { INSTRUCTIONS_DEFAULT_SOURCE_FOLDER, INSTRUCTION_FILE_EXTENSION, LEGACY_MODE_DEFAULT_SOURCE_FOLDER, LEGACY_MODE_FILE_EXTENSION, PROMPT_DEFAULT_SOURCE_FOLDER, PROMPT_FILE_EXTENSION, DEFAULT_SKILL_SOURCE_FOLDERS, AGENTS_SOURCE_FOLDER, AGENT_FILE_EXTENSION, SKILL_FILENAME, CLAUDE_AGENTS_SOURCE_FOLDER, DEFAULT_HOOK_FILE_PATHS, DEFAULT_INSTRUCTIONS_SOURCE_FOLDERS, COPILOT_USER_AGENTS_SOURCE_FOLDER } from '../common/promptSyntax/config/promptFileLocations.js';
@@ -2506,10 +2506,10 @@ registerPlanReviewFeedbackEditorActions();
 registerAction2(ConfigureToolSets);
 registerEditorFeature(ChatPasteProvidersFeature);
 
-agentPluginDiscoveryRegistry.register(new SyncDescriptor(ConfiguredAgentPluginDiscovery));
-agentPluginDiscoveryRegistry.register(new SyncDescriptor(MarketplaceAgentPluginDiscovery));
-agentPluginDiscoveryRegistry.register(new SyncDescriptor(ExtensionAgentPluginDiscovery));
-agentPluginDiscoveryRegistry.register(new SyncDescriptor(CopilotCliAgentPluginDiscovery));
+agentPluginDiscoveryRegistry.register(new SyncDescriptor(ConfiguredAgentPluginDiscovery), AgentPluginDiscoveryPriority.Configured);
+agentPluginDiscoveryRegistry.register(new SyncDescriptor(MarketplaceAgentPluginDiscovery), AgentPluginDiscoveryPriority.Marketplace);
+agentPluginDiscoveryRegistry.register(new SyncDescriptor(ExtensionAgentPluginDiscovery), AgentPluginDiscoveryPriority.Extension);
+agentPluginDiscoveryRegistry.register(new SyncDescriptor(CopilotCliAgentPluginDiscovery), AgentPluginDiscoveryPriority.CopilotCli);
 
 registerSingleton(IChatResponseResourceFileSystemProvider, ChatResponseResourceFileSystemProvider, InstantiationType.Delayed);
 registerSingleton(IChatTransferService, ChatTransferService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/common/enablement.ts
+++ b/src/vs/workbench/contrib/chat/common/enablement.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { IReader, ITransaction } from '../../../../base/common/observable.js';
+import { IObservable, IReader, ITransaction, transaction } from '../../../../base/common/observable.js';
 import { ObservableMemento, observableMemento } from '../../../../platform/observable/common/observableMemento.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 
@@ -119,6 +119,7 @@ export class EnablementModel extends Disposable implements IEnablementModel {
 				break;
 			}
 		}
+
 	}
 
 	remove(key: string): void {
@@ -144,5 +145,65 @@ export class EnablementModel extends Disposable implements IEnablementModel {
 		const next = new Map(current);
 		next.delete(key);
 		memento.set(next, tx);
+	}
+}
+
+export class CollisionEnablementModel implements IEnablementModel {
+
+	constructor(
+		private readonly _base: IEnablementModel,
+		private readonly _collisionGroups: IObservable<ReadonlyMap<string, readonly string[]>>,
+	) { }
+
+	readEnabled(key: string, reader?: IReader): ContributionEnablementState {
+		const baseState = this._base.readEnabled(key, reader);
+
+		if (!isContributionEnabled(baseState)) {
+			return baseState;
+		}
+
+		const group = this._collisionGroups.read(reader).get(key);
+		if (!group) {
+			return baseState;
+		}
+
+		for (const otherId of group) {
+			if (otherId === key) {
+				return baseState;
+			}
+			if (isContributionEnabled(this._base.readEnabled(otherId, reader))) {
+				return ContributionEnablementState.DisabledProfile;
+			}
+		}
+		return baseState;
+	}
+
+	setEnabled(key: string, state: ContributionEnablementState, tx?: ITransaction): void {
+		const isEnabling = state === ContributionEnablementState.EnabledProfile || state === ContributionEnablementState.EnabledWorkspace;
+		const group = isEnabling ? this._collisionGroups.get().get(key) : undefined;
+
+		if (!group) {
+			this._base.setEnabled(key, state, tx);
+			return;
+		}
+
+		const updateGroup = (innerTx: ITransaction) => {
+			this._base.setEnabled(key, state, innerTx);
+			for (const otherId of group) {
+				if (otherId !== key) {
+					this._base.setEnabled(otherId, ContributionEnablementState.DisabledWorkspace, innerTx);
+				}
+			}
+		};
+
+		if (tx) {
+			updateGroup(tx);
+		} else {
+			transaction(innerTx => updateGroup(innerTx));
+		}
+	}
+
+	remove(key: string): void {
+		this._base.remove(key);
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
+++ b/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
@@ -9,6 +9,7 @@ Agent plugins are a modular extension system that allows external packages of pr
 |------|------|
 | `agentPluginService.ts` | Core interfaces (`IAgentPlugin`, `IAgentPluginService`, `IAgentPluginDiscovery`) and the discovery registry singleton |
 | `agentPluginServiceImpl.ts` | `AgentPluginService` implementation, `AbstractAgentPluginDiscovery` base class, format adapters (Copilot / Claude / Open Plugin) |
+| `agentPluginEnablement.ts` | Plugin collision enablement, canonical plugin identity, and enterprise-policy identity helpers |
 | `agentPluginRepositoryService.ts` | `IAgentPluginRepositoryService` — abstract repository clone/pull/cache operations |
 | `pluginMarketplaceService.ts` | `IPluginMarketplaceService` — marketplace metadata, installed-plugin storage, trusted-marketplace tracking, periodic update checks |
 | `pluginInstallService.ts` | `IPluginInstallService` — install/update orchestration interface |
@@ -48,7 +49,7 @@ remove()         – Removes this plugin from its discovery source
 Main entry point consumed by the rest of the workbench:
 
 ```
-plugins          – IObservable<readonly IAgentPlugin[]>  (aggregate of all discoveries, deduped by URI)
+plugins          – IObservable<readonly IAgentPlugin[]>  (aggregate of all ready discoveries, sorted by URI)
 enablementModel  – Shared IEnablementModel for plugin enable/disable state
 ```
 
@@ -59,11 +60,11 @@ Registered as `InstantiationType.Delayed` — only instantiated when first injec
 Strategy for finding plugins from a particular source:
 
 ```
-plugins  – IObservable<readonly IAgentPlugin[]>
+plugins  – IObservable<readonly IAgentPlugin[] | undefined>
 start(enablementModel) – Begin watching the source
 ```
 
-Discoveries are registered into the global `agentPluginDiscoveryRegistry` singleton and instantiated by `AgentPluginService` on startup.
+Discoveries are registered into the global `agentPluginDiscoveryRegistry` singleton with a priority and instantiated by `AgentPluginService` on startup. A discovery reports `undefined` until its first scan completes; the service waits until every discovery has an initial result before exposing plugins.
 
 ## Discovery & Plugin Reading
 
@@ -185,8 +186,8 @@ Each `PluginSourceKind` has a strategy that knows how to compute cache paths, pr
 The entire system is built on `IObservable`:
 
 1. **Configuration observables** (`observableConfigValue`) — push changes when settings are modified.
-2. **Discovery observables** — each `IAgentPluginDiscovery` exposes an `IObservable<readonly IAgentPlugin[]>` updated on filesystem changes.
-3. **Service-level derived** — `AgentPluginService.plugins` is a `derived()` that aggregates all discovery observables, dedupes by URI, and sorts.
+2. **Discovery observables** — each `IAgentPluginDiscovery` exposes an `IObservable<readonly IAgentPlugin[] | undefined>` updated on filesystem changes after the first scan completes.
+3. **Service-level derived** — `AgentPluginService.plugins` is a `derived()` that waits for all discovery observables, aggregates their plugin lists, and sorts by URI.
 4. **Per-plugin observables** — each `IAgentPlugin` has observable properties for hooks, commands, skills, agents, and MCP definitions that update independently on file changes.
 5. **UI bindings** — views and editors use `autorun()` / `derived()` to reactively render plugin state.
 
@@ -200,8 +201,8 @@ The entire system is built on `IObservable`:
 ## Key Design Patterns
 
 - **Strategy pattern** — format adapters (`IAgentPluginFormatAdapter`) and source strategies (`IPluginSource`) allow the system to support multiple plugin formats and installation mechanisms without coupling.
-- **Discovery registry** — `agentPluginDiscoveryRegistry` decouples discovery implementations from the core service via `SyncDescriptor0<IAgentPluginDiscovery>` registration.
+- **Discovery registry** — `agentPluginDiscoveryRegistry` decouples discovery implementations from the core service via priority-ordered `SyncDescriptor0<IAgentPluginDiscovery>` registration.
 - **Disposable management** — plugin entries are tracked in a `Map` keyed by URI string, each with its own `DisposableStore` for file watchers. Removal or format changes dispose the store.
 - **Debounced refresh** — filesystem changes trigger a 200 ms `RunOnceScheduler` to batch rapid edits into a single re-read.
-- **Deduplication** — multiple discoveries may produce the same plugin URI; the service dedupes via `ResourceSet` and sorts by URI for stable ordering.
+- **Collision enablement** — multiple discoveries may produce equivalent plugins from different install roots; the service groups them by canonical identity so only the highest-priority copy is enabled by default, while enabling any copy disables the other copies in the same group.
 - **Lazy instantiation** — the service is registered as `InstantiationType.Delayed` and only created on first injection.

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginEnablement.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginEnablement.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IObservable } from '../../../../../base/common/observable.js';
-import { ILogService } from '../../../../../platform/log/common/log.js';
 import { AgentPluginDiscoveryPriority, IAgentPlugin } from './agentPluginService.js';
 import { IGitHubPluginSource, IGitUrlPluginSource, IMarketplacePlugin, INpmPluginSource, IPipPluginSource, PluginSourceKind } from './pluginMarketplaceService.js';
 import { type IMarketplaceReference } from './marketplaceReference.js';
@@ -72,20 +71,17 @@ export function getCanonicalAgentPluginCollisionGroups(discoveries: readonly IDi
 export function isAgentPluginBlockedByPolicy(
 	plugin: IAgentPlugin,
 	enabledPluginsPolicy: Record<string, boolean> | undefined,
-	logService: ILogService,
 ): boolean {
-	const identity = getPolicyIdentity(plugin);
-	if (!identity) {
-		return false;
-	}
-	const pluginId = `${identity.name}@${identity.marketplace}`;
+	const pluginId = getAgentPluginPolicyId(plugin);
 	if (enabledPluginsPolicy && Object.keys(enabledPluginsPolicy).length > 0) {
-		if (enabledPluginsPolicy[pluginId] !== true) {
-			logService.debug(`[AgentPluginService] Plugin '${pluginId}' blocked — not enabled by ChatEnabledPlugins policy`);
-			return true;
-		}
+		return pluginId !== undefined && enabledPluginsPolicy[pluginId] !== true;
 	}
 	return false;
+}
+
+export function getAgentPluginPolicyId(plugin: IAgentPlugin): string | undefined {
+	const identity = getPolicyIdentity(plugin);
+	return identity ? `${identity.name}@${identity.marketplace}` : undefined;
 }
 
 function getAgentPluginCandidates(discoveries: readonly IDiscoveredAgentPlugins[]): IAgentPluginCandidate[] {

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginEnablement.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginEnablement.ts
@@ -1,0 +1,234 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IObservable } from '../../../../../base/common/observable.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { AgentPluginDiscoveryPriority, IAgentPlugin } from './agentPluginService.js';
+import { IGitHubPluginSource, IGitUrlPluginSource, IMarketplacePlugin, INpmPluginSource, IPipPluginSource, PluginSourceKind } from './pluginMarketplaceService.js';
+import { type IMarketplaceReference } from './marketplaceReference.js';
+import { CollisionEnablementModel, IEnablementModel } from '../enablement.js';
+
+export interface IDiscoveredAgentPlugins {
+	readonly plugins: readonly IAgentPlugin[];
+	readonly priority: AgentPluginDiscoveryPriority;
+	readonly order: number;
+}
+
+interface IAgentPluginCandidate {
+	readonly plugin: IAgentPlugin;
+	readonly priority: AgentPluginDiscoveryPriority;
+	readonly order: number;
+	readonly pluginOrder: number;
+	readonly canonicalKey: string;
+}
+
+/**
+ * Path fragment that identifies a Copilot-CLI-installed plugin. Mirrored by
+ * `ConfiguredAgentPluginDiscovery._resolveEnterprisePluginId`.
+ */
+const COPILOT_CLI_INSTALL_PATH_FRAGMENT = '/.copilot/installed-plugins/';
+
+export class AgentPluginCollisionEnablementModel extends CollisionEnablementModel {
+	constructor(base: IEnablementModel, collisionGroups: IObservable<ReadonlyMap<string, readonly string[]>>) {
+		super(base, collisionGroups);
+	}
+}
+
+export function getSortedAgentPlugins(discoveries: readonly IDiscoveredAgentPlugins[]): readonly IAgentPlugin[] {
+	return getUniqueAgentPluginCandidates(discoveries)
+		.map(candidate => candidate.plugin)
+		.sort((a, b) => a.uri.toString().localeCompare(b.uri.toString()));
+}
+
+export function getCanonicalAgentPluginCollisionGroups(discoveries: readonly IDiscoveredAgentPlugins[], isBlocked?: (plugin: IAgentPlugin) => boolean): ReadonlyMap<string, readonly string[]> {
+	const candidates = getUniqueAgentPluginCandidates(discoveries);
+	const byCanonicalKey = new Map<string, string[]>();
+	for (const candidate of candidates) {
+		if (isBlocked?.(candidate.plugin)) {
+			continue;
+		}
+		let group = byCanonicalKey.get(candidate.canonicalKey);
+		if (!group) {
+			group = [];
+			byCanonicalKey.set(candidate.canonicalKey, group);
+		}
+		group.push(candidate.plugin.uri.toString());
+	}
+
+	const groups = new Map<string, readonly string[]>();
+	for (const group of byCanonicalKey.values()) {
+		if (group.length < 2) {
+			continue;
+		}
+		for (const key of group) {
+			groups.set(key, group);
+		}
+	}
+	return groups;
+}
+
+export function isAgentPluginBlockedByPolicy(
+	plugin: IAgentPlugin,
+	enabledPluginsPolicy: Record<string, boolean> | undefined,
+	logService: ILogService,
+): boolean {
+	const identity = getPolicyIdentity(plugin);
+	if (!identity) {
+		return false;
+	}
+	const pluginId = `${identity.name}@${identity.marketplace}`;
+	if (enabledPluginsPolicy && Object.keys(enabledPluginsPolicy).length > 0) {
+		if (enabledPluginsPolicy[pluginId] !== true) {
+			logService.debug(`[AgentPluginService] Plugin '${pluginId}' blocked — not enabled by ChatEnabledPlugins policy`);
+			return true;
+		}
+	}
+	return false;
+}
+
+function getAgentPluginCandidates(discoveries: readonly IDiscoveredAgentPlugins[]): IAgentPluginCandidate[] {
+	const candidates: IAgentPluginCandidate[] = [];
+	for (const discovery of discoveries) {
+		for (let pluginOrder = 0; pluginOrder < discovery.plugins.length; pluginOrder++) {
+			const plugin = discovery.plugins[pluginOrder];
+			candidates.push({
+				plugin,
+				priority: discovery.priority,
+				order: discovery.order,
+				pluginOrder,
+				canonicalKey: getCanonicalPluginIdentity(plugin),
+			});
+		}
+	}
+
+	return candidates.sort((a, b) =>
+		a.priority - b.priority
+		|| a.order - b.order
+		|| a.pluginOrder - b.pluginOrder
+		|| a.plugin.uri.toString().localeCompare(b.plugin.uri.toString())
+	);
+}
+
+function getUniqueAgentPluginCandidates(discoveries: readonly IDiscoveredAgentPlugins[]): IAgentPluginCandidate[] {
+	const unique: IAgentPluginCandidate[] = [];
+	const seen = new Set<string>();
+	for (const candidate of getAgentPluginCandidates(discoveries)) {
+		const key = candidate.plugin.uri.toString();
+		if (seen.has(key)) {
+			continue;
+		}
+		seen.add(key);
+		unique.push(candidate);
+	}
+	return unique;
+}
+
+function getCanonicalPluginIdentity(plugin: IAgentPlugin): string {
+	return getMarketplaceCanonicalIdentity(plugin.fromMarketplace)
+		?? getCopilotCliInstallCanonicalIdentity(plugin)
+		?? `uri:${plugin.uri.toString()}`;
+}
+
+function getMarketplaceCanonicalIdentity(plugin: IMarketplacePlugin | undefined): string | undefined {
+	if (!plugin) {
+		return undefined;
+	}
+
+	const normalizedName = normalizePluginIdentitySegment(plugin.name);
+	const source = plugin.sourceDescriptor;
+	switch (source.kind) {
+		case PluginSourceKind.RelativePath: {
+			if (plugin.marketplaceReference.githubRepo) {
+				return `github:${plugin.marketplaceReference.githubRepo.toLowerCase()}|${normalizedName}`;
+			}
+			return `marketplace:${plugin.marketplaceReference.canonicalId}|${normalizedName}`;
+		}
+		case PluginSourceKind.GitHub: {
+			const github = source as IGitHubPluginSource;
+			return `github:${github.repo.toLowerCase()}|${normalizedName}`;
+		}
+		case PluginSourceKind.GitUrl: {
+			const git = source as IGitUrlPluginSource;
+			return `git:${git.url.toLowerCase()}|${normalizedName}`;
+		}
+		case PluginSourceKind.Npm: {
+			const npm = source as INpmPluginSource;
+			return `npm:${npm.package.toLowerCase()}|${normalizedName}`;
+		}
+		case PluginSourceKind.Pip: {
+			const pip = source as IPipPluginSource;
+			return `pip:${pip.package.toLowerCase()}|${normalizedName}`;
+		}
+	}
+}
+
+function getCopilotCliInstallCanonicalIdentity(plugin: IAgentPlugin): string | undefined {
+	if (plugin.uri.scheme !== 'file') {
+		return undefined;
+	}
+
+	const idx = plugin.uri.path.indexOf(COPILOT_CLI_INSTALL_PATH_FRAGMENT);
+	if (idx === -1) {
+		return undefined;
+	}
+
+	const segments = plugin.uri.path.slice(idx + COPILOT_CLI_INSTALL_PATH_FRAGMENT.length).split('/').filter(s => s.length > 0);
+	if (segments.length !== 2) {
+		return undefined;
+	}
+
+	const [bucket, installName] = segments;
+	const normalizedName = normalizePluginIdentitySegment(plugin.label || installName);
+	if (bucket !== '_direct') {
+		return `copilot-cli-marketplace:${normalizePluginIdentitySegment(bucket)}|${normalizedName}`;
+	}
+
+	const match = /^(?<owner>.+)--(?<repo>.+)--(?<plugin>.+)$/.exec(installName);
+	const groups = match?.groups;
+	if (!groups) {
+		return undefined;
+	}
+
+	return `github:${groups.owner.toLowerCase()}/${groups.repo.toLowerCase()}|${normalizePluginIdentitySegment(groups.plugin)}`;
+}
+
+function normalizePluginIdentitySegment(value: string): string {
+	return value
+		.trim()
+		.toLowerCase()
+		.replace(/\s+/g, '-')
+		.replace(/[^a-z0-9_.:-]/g, '-')
+		.replace(/-+/g, '-')
+		.replace(/^[-:.]+|[-:.]+$/g, '');
+}
+
+interface IPolicyIdentity {
+	readonly name: string;
+	readonly marketplace: string;
+	readonly marketplaceReference?: IMarketplaceReference;
+}
+
+function getPolicyIdentity(plugin: IAgentPlugin): IPolicyIdentity | undefined {
+	const m = plugin.fromMarketplace;
+	if (m) {
+		return { name: m.name, marketplace: m.marketplace, marketplaceReference: m.marketplaceReference };
+	}
+	if (plugin.uri.scheme !== 'file') {
+		return undefined;
+	}
+	const idx = plugin.uri.path.indexOf(COPILOT_CLI_INSTALL_PATH_FRAGMENT);
+	if (idx === -1) {
+		return undefined;
+	}
+	const segments = plugin.uri.path.slice(idx + COPILOT_CLI_INSTALL_PATH_FRAGMENT.length).split('/').filter(s => s.length > 0);
+	if (segments.length !== 2) {
+		return undefined;
+	}
+	const [marketplace, name] = segments;
+	if (marketplace === '_direct') {
+		return undefined;
+	}
+	return { name, marketplace };
+}

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IDisposable } from '../../../../../base/common/lifecycle.js';
+import { IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { IObservable } from '../../../../../base/common/observable.js';
 import { basename } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -61,8 +61,15 @@ export interface IAgentPluginService {
 }
 
 export interface IAgentPluginDiscovery extends IDisposable {
-	readonly plugins: IObservable<readonly IAgentPlugin[]>;
+	readonly plugins: IObservable<readonly IAgentPlugin[] | undefined>;
 	start(enablementModel: IEnablementModel): void;
+}
+
+export const enum AgentPluginDiscoveryPriority {
+	Configured = 10,
+	Marketplace = 20,
+	Extension = 30,
+	CopilotCli = 40,
 }
 
 export function getCanonicalPluginCommandId(plugin: { readonly uri: URI }, commandName: string): string {
@@ -94,17 +101,24 @@ function normalizePluginToken(value: string): string {
 }
 
 class AgentPluginDiscoveryRegistry {
-	private readonly _discovery: SyncDescriptor0<IAgentPluginDiscovery>[] = [];
+	private readonly _discovery: { readonly descriptor: SyncDescriptor0<IAgentPluginDiscovery>; readonly priority: AgentPluginDiscoveryPriority; readonly order: number }[] = [];
+	private _order = 0;
 
-	register(descriptor: SyncDescriptor0<IAgentPluginDiscovery>): void {
-		this._discovery.push(descriptor);
+	register(descriptor: SyncDescriptor0<IAgentPluginDiscovery>, priority: AgentPluginDiscoveryPriority): IDisposable {
+		const registration = { descriptor, priority, order: this._order++ };
+		this._discovery.push(registration);
+		return toDisposable(() => {
+			const index = this._discovery.indexOf(registration);
+			if (index >= 0) {
+				this._discovery.splice(index, 1);
+			}
+		});
 	}
 
-	getAll(): readonly SyncDescriptor0<IAgentPluginDiscovery>[] {
-		return this._discovery;
+	getAll(): readonly { readonly descriptor: SyncDescriptor0<IAgentPluginDiscovery>; readonly priority: AgentPluginDiscoveryPriority; readonly order: number }[] {
+		return [...this._discovery].sort((a, b) => a.priority - b.priority || a.order - b.order);
 	}
 }
 
 export const agentPluginDiscoveryRegistry = new AgentPluginDiscoveryRegistry();
-
 

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -50,7 +50,7 @@ import { IPathService } from '../../../../services/path/common/pathService.js';
 import { ChatConfiguration } from '../constants.js';
 import { ContributionEnablementState, EnablementModel, IEnablementModel } from '../enablement.js';
 import { HookType } from '../promptSyntax/hookTypes.js';
-import { AgentPluginCollisionEnablementModel, getCanonicalAgentPluginCollisionGroups, getSortedAgentPlugins, IDiscoveredAgentPlugins, isAgentPluginBlockedByPolicy } from './agentPluginEnablement.js';
+import { AgentPluginCollisionEnablementModel, getAgentPluginPolicyId, getCanonicalAgentPluginCollisionGroups, getSortedAgentPlugins, IDiscoveredAgentPlugins, isAgentPluginBlockedByPolicy } from './agentPluginEnablement.js';
 import { IAgentPluginRepositoryService } from './agentPluginRepositoryService.js';
 import { AgentPluginDiscoveryPriority, agentPluginDiscoveryRegistry, IAgentPlugin, IAgentPluginDiscovery, IAgentPluginHook, IAgentPluginInstruction, IAgentPluginMcpServerDefinition, IAgentPluginService } from './agentPluginService.js';
 import { IMarketplacePlugin, IPluginMarketplaceService } from './pluginMarketplaceService.js';
@@ -129,7 +129,7 @@ export class AgentPluginService extends Disposable implements IAgentPluginServic
 				return new Map<string, readonly string[]>();
 			}
 			const policy = enabledPluginsPolicy.read(reader);
-			return getCanonicalAgentPluginCollisionGroups(discoveredPlugins, plugin => isAgentPluginBlockedByPolicy(plugin, policy, logService));
+			return getCanonicalAgentPluginCollisionGroups(discoveredPlugins, plugin => isAgentPluginBlockedByPolicy(plugin, policy));
 		});
 
 		this.enablementModel = new AgentPluginCollisionEnablementModel(baseEnablementModel, collisionGroups);
@@ -157,7 +157,10 @@ export class AgentPluginService extends Disposable implements IAgentPluginServic
 			const policy = enabledPluginsPolicy.read(reader);
 			transaction(tx => {
 				for (const plugin of plugins) {
-					setPolicyBlocked(plugin, isAgentPluginBlockedByPolicy(plugin, policy, logService), tx);
+					const blocked = isAgentPluginBlockedByPolicy(plugin, policy);
+					if (setPolicyBlocked(plugin, blocked, tx) && blocked) {
+						logService.debug(`[AgentPluginService] Plugin '${getAgentPluginPolicyId(plugin) ?? plugin.uri.toString()}' blocked — not enabled by ChatEnabledPlugins policy`);
+					}
 				}
 			});
 		}));
@@ -196,11 +199,16 @@ interface PluginEntry extends IAgentPlugin {
  * for any {@link IAgentPlugin}; entries without a settable observable (e.g. test
  * doubles) are ignored.
  */
-function setPolicyBlocked(plugin: IAgentPlugin, blocked: boolean, tx: ITransaction): void {
+function setPolicyBlocked(plugin: IAgentPlugin, blocked: boolean, tx: ITransaction): boolean {
 	const obs = plugin.policyBlocked as ISettableObservable<boolean> | undefined;
 	if (obs && typeof obs.set === 'function') {
+		if (obs.get() === blocked) {
+			return false;
+		}
 		obs.set(blocked, tx);
+		return true;
 	}
+	return false;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -9,9 +9,8 @@ import { Iterable } from '../../../../../base/common/iterator.js';
 import { parse as parseJSONC } from '../../../../../base/common/json.js';
 import { untildify } from '../../../../../base/common/labels.js';
 import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
-import { ResourceSet } from '../../../../../base/common/map.js';
 import { equals } from '../../../../../base/common/objects.js';
-import { autorun, derived, derivedOpts, IObservable, ISettableObservable, ITransaction, observableFromEvent, ObservablePromise, observableSignal, observableValue, transaction } from '../../../../../base/common/observable.js';
+import { autorun, derived, derivedOpts, IObservable, IReader, ISettableObservable, ITransaction, observableFromEvent, ObservablePromise, observableSignal, observableValue, transaction } from '../../../../../base/common/observable.js';
 import {
 	posix,
 	win32
@@ -51,10 +50,10 @@ import { IPathService } from '../../../../services/path/common/pathService.js';
 import { ChatConfiguration } from '../constants.js';
 import { ContributionEnablementState, EnablementModel, IEnablementModel } from '../enablement.js';
 import { HookType } from '../promptSyntax/hookTypes.js';
+import { AgentPluginCollisionEnablementModel, getCanonicalAgentPluginCollisionGroups, getSortedAgentPlugins, IDiscoveredAgentPlugins, isAgentPluginBlockedByPolicy } from './agentPluginEnablement.js';
 import { IAgentPluginRepositoryService } from './agentPluginRepositoryService.js';
-import { agentPluginDiscoveryRegistry, IAgentPlugin, IAgentPluginDiscovery, IAgentPluginHook, IAgentPluginInstruction, IAgentPluginMcpServerDefinition, IAgentPluginService } from './agentPluginService.js';
+import { AgentPluginDiscoveryPriority, agentPluginDiscoveryRegistry, IAgentPlugin, IAgentPluginDiscovery, IAgentPluginHook, IAgentPluginInstruction, IAgentPluginMcpServerDefinition, IAgentPluginService } from './agentPluginService.js';
 import { IMarketplacePlugin, IPluginMarketplaceService } from './pluginMarketplaceService.js';
-import { type IMarketplaceReference } from './marketplaceReference.js';
 
 // Re-export shared helpers so existing consumers (including tests) continue to work.
 export { shellQuotePluginRootInCommand, resolveMcpServersMap, convertBareEnvVarsToVsCodeSyntax } from '../../../../../platform/agentPlugins/common/pluginParsers.js';
@@ -102,16 +101,15 @@ export class AgentPluginService extends Disposable implements IAgentPluginServic
 	) {
 		super();
 
-		this.enablementModel = this._register(new EnablementModel('agentPlugins.enablement', storageService));
+		const baseEnablementModel = this._register(new EnablementModel('agentPlugins.enablement', storageService));
 
 		const pluginsEnabled = observableConfigValue(ChatConfiguration.PluginsEnabled, true, configurationService);
 
-		const discoveries: IAgentPluginDiscovery[] = [];
-		for (const descriptor of agentPluginDiscoveryRegistry.getAll()) {
-			const discovery = instantiationService.createInstance(descriptor);
+		const discoveries: IAgentPluginDiscoveryWithPriority[] = [];
+		for (const registration of agentPluginDiscoveryRegistry.getAll()) {
+			const discovery = instantiationService.createInstance(registration.descriptor);
 			this._register(discovery);
-			discoveries.push(discovery);
-			discovery.start(this.enablementModel);
+			discoveries.push({ discovery, priority: registration.priority, order: registration.order });
 		}
 
 		// Policy-driven enforcement, applied after discovery so that enterprise
@@ -122,11 +120,33 @@ export class AgentPluginService extends Disposable implements IAgentPluginServic
 			() => configurationService.inspect<Record<string, boolean>>(ChatConfiguration.EnabledPlugins).policyValue,
 		);
 
+		const collisionGroups = derived(reader => {
+			if (!pluginsEnabled.read(reader)) {
+				return new Map<string, readonly string[]>();
+			}
+			const discoveredPlugins = readDiscoveredAgentPlugins(discoveries, reader);
+			if (!discoveredPlugins) {
+				return new Map<string, readonly string[]>();
+			}
+			const policy = enabledPluginsPolicy.read(reader);
+			return getCanonicalAgentPluginCollisionGroups(discoveredPlugins, plugin => isAgentPluginBlockedByPolicy(plugin, policy, logService));
+		});
+
+		this.enablementModel = new AgentPluginCollisionEnablementModel(baseEnablementModel, collisionGroups);
+
+		for (const { discovery } of discoveries) {
+			discovery.start(this.enablementModel);
+		}
+
 		this.plugins = derived(read => {
 			if (!pluginsEnabled.read(read)) {
 				return [];
 			}
-			return this._dedupeAndSort(discoveries.flatMap(d => d.plugins.read(read)));
+			const discoveredPlugins = readDiscoveredAgentPlugins(discoveries, read);
+			if (!discoveredPlugins) {
+				return [];
+			}
+			return getSortedAgentPlugins(discoveredPlugins);
 		});
 
 		// Mark policy-blocked plugins rather than hiding them: a blocked plugin
@@ -137,60 +157,29 @@ export class AgentPluginService extends Disposable implements IAgentPluginServic
 			const policy = enabledPluginsPolicy.read(reader);
 			transaction(tx => {
 				for (const plugin of plugins) {
-					setPolicyBlocked(plugin, this._isBlockedByPolicy(plugin, policy, logService), tx);
+					setPolicyBlocked(plugin, isAgentPluginBlockedByPolicy(plugin, policy, logService), tx);
 				}
 			});
 		}));
 	}
+}
 
-	/**
-	 * Determines whether a plugin is blocked by enterprise policy:
-	 * - If `chat.plugins.enabledPlugins` (policy-managed via `ChatEnabledPlugins`)
-	 *   is set, only plugins whose ID appears with value `true` are allowed.
-	 *
-	 * Marketplace trust (`chat.plugins.strictMarketplaces`) is enforced at
-	 * install time only, already-installed plugins are not
-	 * retroactively unloaded.
-	 *
-	 * Plugins without a marketplace provenance (e.g. user-configured filesystem
-	 * paths from `chat.pluginLocations`) are never blocked — they are user-side
-	 * concerns outside the enterprise enforcement boundary.
-	 */
-	private _isBlockedByPolicy(
-		plugin: IAgentPlugin,
-		enabledPluginsPolicy: Record<string, boolean> | undefined,
-		logService: ILogService,
-	): boolean {
-		const identity = getPolicyIdentity(plugin);
-		if (!identity) {
-			return false;
+interface IAgentPluginDiscoveryWithPriority {
+	readonly discovery: IAgentPluginDiscovery;
+	readonly priority: AgentPluginDiscoveryPriority;
+	readonly order: number;
+}
+
+function readDiscoveredAgentPlugins(discoveries: readonly IAgentPluginDiscoveryWithPriority[], reader: IReader): readonly IDiscoveredAgentPlugins[] | undefined {
+	const result: IDiscoveredAgentPlugins[] = [];
+	for (const { discovery, priority, order } of discoveries) {
+		const plugins = discovery.plugins.read(reader);
+		if (!plugins) {
+			return undefined;
 		}
-		const pluginId = `${identity.name}@${identity.marketplace}`;
-		if (enabledPluginsPolicy && Object.keys(enabledPluginsPolicy).length > 0) {
-			if (enabledPluginsPolicy[pluginId] !== true) {
-				logService.debug(`[AgentPluginService] Plugin '${pluginId}' blocked — not enabled by ChatEnabledPlugins policy`);
-				return true;
-			}
-		}
-		return false;
+		result.push({ plugins, priority, order });
 	}
-
-	private _dedupeAndSort(plugins: readonly IAgentPlugin[]): readonly IAgentPlugin[] {
-		const unique: IAgentPlugin[] = [];
-		const seen = new ResourceSet();
-
-		for (const plugin of plugins) {
-			if (seen.has(plugin.uri)) {
-				continue;
-			}
-
-			seen.add(plugin.uri);
-			unique.push(plugin);
-		}
-
-		unique.sort((a, b) => a.uri.toString().localeCompare(b.uri.toString()));
-		return unique;
-	}
+	return result;
 }
 
 /**
@@ -212,48 +201,6 @@ function setPolicyBlocked(plugin: IAgentPlugin, blocked: boolean, tx: ITransacti
 	if (obs && typeof obs.set === 'function') {
 		obs.set(blocked, tx);
 	}
-}
-
-/**
- * The policy-relevant identity of a plugin, used to gate against
- * `chat.plugins.enabledPlugins` and `chat.plugins.strictMarketplaces`. Returns
- * `undefined` for plugins that aren't subject to enterprise policy (e.g.
- * user-configured filesystem entries, extension-contributed plugins).
- */
-interface IPolicyIdentity {
-	readonly name: string;
-	readonly marketplace: string;
-	readonly marketplaceReference?: IMarketplaceReference;
-}
-
-/** Path fragment that identifies a Copilot-CLI-installed plugin. Mirrored by `_resolveEnterprisePluginId`. */
-const COPILOT_CLI_INSTALL_PATH_FRAGMENT = '/.copilot/installed-plugins/';
-
-function getPolicyIdentity(plugin: IAgentPlugin): IPolicyIdentity | undefined {
-	const m = plugin.fromMarketplace;
-	if (m) {
-		return { name: m.name, marketplace: m.marketplace, marketplaceReference: m.marketplaceReference };
-	}
-	// Copilot-CLI-installed plugins live at `~/.copilot/installed-plugins/<marketplace>/<plugin>/`.
-	// We honor enterprise policy for those by deriving the identity from the install path,
-	// using the same convention as `_resolveEnterprisePluginId`. The reserved `_direct` bucket
-	// means "not from a marketplace" and is therefore not gated.
-	if (plugin.uri.scheme !== 'file') {
-		return undefined;
-	}
-	const idx = plugin.uri.path.indexOf(COPILOT_CLI_INSTALL_PATH_FRAGMENT);
-	if (idx === -1) {
-		return undefined;
-	}
-	const segments = plugin.uri.path.slice(idx + COPILOT_CLI_INSTALL_PATH_FRAGMENT.length).split('/').filter(s => s.length > 0);
-	if (segments.length !== 2) {
-		return undefined;
-	}
-	const [marketplace, name] = segments;
-	if (marketplace === '_direct') {
-		return undefined;
-	}
-	return { name, marketplace };
 }
 
 /**
@@ -294,8 +241,8 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 
 	private readonly _pluginEntries = new Map<string, { plugin: PluginEntry; store: DisposableStore; format: IPluginFormatConfig }>();
 
-	private readonly _plugins = observableValue<readonly IAgentPlugin[]>('discoveredAgentPlugins', []);
-	public readonly plugins: IObservable<readonly IAgentPlugin[]> = this._plugins;
+	private readonly _plugins = observableValue<readonly IAgentPlugin[] | undefined>('discoveredAgentPlugins', undefined);
+	public readonly plugins: IObservable<readonly IAgentPlugin[] | undefined> = this._plugins;
 
 	private _discoverVersion = 0;
 	protected _enablementModel!: IEnablementModel;
@@ -1114,6 +1061,8 @@ export class ExtensionAgentPluginDiscovery extends AbstractAgentPluginDiscovery 
 			this._rebuildWhenKeys();
 			scheduler.schedule();
 		});
+
+		scheduler.schedule();
 	}
 
 	private _rebuildWhenKeys(): void {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/resolveCustomizationRefs.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/resolveCustomizationRefs.test.ts
@@ -254,6 +254,23 @@ suite('resolveCustomizationRefs - built-in skills', () => {
 		assert.deepStrictEqual(refs, []);
 	});
 
+	test('omits plugins with prompt-file contributions that are disabled by enablement', async () => {
+		const pluginUri = URI.file('/plugins/prompt-disabled');
+		const promptFile = URI.file('/plugins/prompt-disabled/skills/foo/SKILL.md');
+		const refs = await resolveCustomizationRefs(
+			makeFileService(),
+			makePromptsService(new Map([
+				[`${PromptsType.skill}/${PromptsStorage.plugin}`, [makePromptPath(promptFile, PromptsType.skill, PromptsStorage.plugin)]],
+			])),
+			new FakeSyncProvider(),
+			makeAgentPluginService([makePlugin(pluginUri, { enabled: false })]),
+			makeMcpService(),
+			new FakeBundler() as unknown as SyncedCustomizationBundler,
+			SessionType.CopilotCLI,
+		);
+		assert.deepStrictEqual(refs, []);
+	});
+
 	test('omits MCP-only plugins that the user opted out of syncing', async () => {
 		const pluginUri = URI.file('/plugins/mcp-opted-out');
 		const refs = await resolveCustomizationRefs(

--- a/src/vs/workbench/contrib/chat/test/common/plugins/agentPluginEnablement.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/agentPluginEnablement.test.ts
@@ -1,0 +1,142 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { observableValue } from '../../../../../../base/common/observable.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { ContributionEnablementState, IEnablementModel, isContributionEnabled } from '../../../common/enablement.js';
+import { AgentPluginCollisionEnablementModel, getCanonicalAgentPluginCollisionGroups, getSortedAgentPlugins, IDiscoveredAgentPlugins } from '../../../common/plugins/agentPluginEnablement.js';
+import { AgentPluginDiscoveryPriority, IAgentPlugin } from '../../../common/plugins/agentPluginService.js';
+import { IMarketplacePlugin, MarketplaceType, parseMarketplaceReference, PluginSourceKind } from '../../../common/plugins/pluginMarketplaceService.js';
+
+suite('AgentPlugin enablement', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function makePlugin(uri: URI, label: string, fromMarketplace?: IMarketplacePlugin): IAgentPlugin {
+		return {
+			uri,
+			label,
+			enablement: observableValue('testPluginEnablement', ContributionEnablementState.EnabledProfile),
+			hooks: observableValue('testPluginHooks', []),
+			commands: observableValue('testPluginCommands', []),
+			skills: observableValue('testPluginSkills', []),
+			agents: observableValue('testPluginAgents', []),
+			instructions: observableValue('testPluginInstructions', []),
+			mcpServerDefinitions: observableValue('testPluginMcpServerDefinitions', []),
+			fromMarketplace,
+		};
+	}
+
+	function makeMarketplacePlugin(): IMarketplacePlugin {
+		const marketplaceReference = parseMarketplaceReference('microsoft/vscode-team-kit');
+		assert.ok(marketplaceReference);
+		return {
+			name: 'model-council',
+			description: '',
+			version: '',
+			source: 'model-council',
+			sourceDescriptor: { kind: PluginSourceKind.RelativePath, path: 'model-council' },
+			marketplace: 'microsoft/vscode-team-kit',
+			marketplaceReference,
+			marketplaceType: MarketplaceType.Copilot,
+		};
+	}
+
+	function makeTestEnablementModel(): IEnablementModel {
+		const state = new Map<string, ContributionEnablementState>();
+		return {
+			readEnabled: key => state.get(key) ?? ContributionEnablementState.EnabledProfile,
+			setEnabled: (key, value) => state.set(key, value),
+			remove: key => state.delete(key),
+		};
+	}
+
+	test('colliding marketplace and Copilot CLI direct installs use priority-ordered enablement', () => {
+		const marketplaceUri = URI.file('/Users/test/.vscode-insiders/agent-plugins/github.com/microsoft/vscode-team-kit/model-council');
+		const copilotCliDirectUri = URI.file('/Users/test/.copilot/installed-plugins/_direct/microsoft--vscode-team-kit--model-council');
+		const discoveries: IDiscoveredAgentPlugins[] = [
+			{
+				priority: AgentPluginDiscoveryPriority.CopilotCli,
+				order: 3,
+				plugins: [makePlugin(copilotCliDirectUri, 'model-council')],
+			},
+			{
+				priority: AgentPluginDiscoveryPriority.Marketplace,
+				order: 1,
+				plugins: [makePlugin(marketplaceUri, 'model-council', makeMarketplacePlugin())],
+			},
+		];
+
+		const plugins = getSortedAgentPlugins(discoveries);
+		const collisionGroups = observableValue('pluginCollisionGroups', getCanonicalAgentPluginCollisionGroups(discoveries));
+		const enablementModel = new AgentPluginCollisionEnablementModel(makeTestEnablementModel(), collisionGroups);
+
+		enablementModel.setEnabled(copilotCliDirectUri.toString(), ContributionEnablementState.EnabledWorkspace);
+
+		assert.deepStrictEqual({
+			plugins: plugins.map(plugin => plugin.uri.toString()),
+			marketplaceInitiallyEnabled: isContributionEnabled(new AgentPluginCollisionEnablementModel(makeTestEnablementModel(), collisionGroups).readEnabled(marketplaceUri.toString())),
+			copilotCliInitiallyEnabled: isContributionEnabled(new AgentPluginCollisionEnablementModel(makeTestEnablementModel(), collisionGroups).readEnabled(copilotCliDirectUri.toString())),
+			marketplaceAfterEnablingCli: enablementModel.readEnabled(marketplaceUri.toString()),
+			copilotCliAfterEnablingCli: enablementModel.readEnabled(copilotCliDirectUri.toString()),
+		}, {
+			plugins: [copilotCliDirectUri.toString(), marketplaceUri.toString()],
+			marketplaceInitiallyEnabled: true,
+			copilotCliInitiallyEnabled: false,
+			marketplaceAfterEnablingCli: ContributionEnablementState.DisabledWorkspace,
+			copilotCliAfterEnablingCli: ContributionEnablementState.EnabledWorkspace,
+		});
+	});
+
+	test('policy-blocked duplicate does not suppress allowed duplicate', () => {
+		const marketplaceUri = URI.file('/Users/test/.vscode-insiders/agent-plugins/github.com/microsoft/vscode-team-kit/model-council');
+		const copilotCliDirectUri = URI.file('/Users/test/.copilot/installed-plugins/_direct/microsoft--vscode-team-kit--model-council');
+		const discoveries: IDiscoveredAgentPlugins[] = [
+			{
+				priority: AgentPluginDiscoveryPriority.Marketplace,
+				order: 1,
+				plugins: [makePlugin(marketplaceUri, 'model-council', makeMarketplacePlugin())],
+			},
+			{
+				priority: AgentPluginDiscoveryPriority.CopilotCli,
+				order: 3,
+				plugins: [makePlugin(copilotCliDirectUri, 'model-council')],
+			},
+		];
+
+		const collisionGroups = observableValue(
+			'pluginCollisionGroups',
+			getCanonicalAgentPluginCollisionGroups(discoveries, plugin => plugin.uri.toString() === marketplaceUri.toString()),
+		);
+		const enablementModel = new AgentPluginCollisionEnablementModel(makeTestEnablementModel(), collisionGroups);
+
+		assert.ok(isContributionEnabled(enablementModel.readEnabled(copilotCliDirectUri.toString())));
+	});
+
+	test('same-URI duplicates collapse before collision grouping', () => {
+		const sharedUri = URI.file('/Users/test/.copilot/installed-plugins/team/model-council');
+		const discoveries: IDiscoveredAgentPlugins[] = [
+			{
+				priority: AgentPluginDiscoveryPriority.Configured,
+				order: 0,
+				plugins: [makePlugin(sharedUri, 'model-council')],
+			},
+			{
+				priority: AgentPluginDiscoveryPriority.CopilotCli,
+				order: 3,
+				plugins: [makePlugin(sharedUri, 'model-council')],
+			},
+		];
+
+		assert.deepStrictEqual({
+			plugins: getSortedAgentPlugins(discoveries).map(plugin => plugin.uri.toString()),
+			collisionGroupCount: getCanonicalAgentPluginCollisionGroups(discoveries).size,
+		}, {
+			plugins: [sharedUri.toString()],
+			collisionGroupCount: 0,
+		});
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/common/plugins/agentPluginFormatDetection.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/agentPluginFormatDetection.test.ts
@@ -97,6 +97,12 @@ suite('AgentPlugin format detection', () => {
 		));
 	}
 
+	function getDiscoveredPlugins(discovery: TestPluginDiscovery) {
+		const plugins = discovery.plugins.get();
+		assert.ok(plugins, 'Expected plugin discovery to have completed');
+		return plugins;
+	}
+
 	async function writeFile(path: string, content: string): Promise<void> {
 		const uri = URI.from({ scheme: Schemas.inMemory, path });
 		await fileService.writeFile(uri, VSBuffer.fromString(content));
@@ -105,6 +111,13 @@ suite('AgentPlugin format detection', () => {
 	function pluginUri(path: string): URI {
 		return URI.from({ scheme: Schemas.inMemory, path });
 	}
+
+	test('starts unresolved until first refresh completes', () => {
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+
+		assert.strictEqual(discovery.plugins.get(), undefined);
+	});
 
 	test('detects Open Plugin format when .plugin/plugin.json exists', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		const uri = pluginUri('/plugins/my-open-plugin');
@@ -115,7 +128,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		// Verify the plugin read commands from the standard commands/ directory
@@ -132,7 +145,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 		await waitForState(plugins[0].commands, cmds => cmds.length > 0);
 		assert.strictEqual(plugins[0].commands.get()[0].name, 'greet');
@@ -147,7 +160,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 		await waitForState(plugins[0].commands, cmds => cmds.length > 0);
 		assert.strictEqual(plugins[0].commands.get()[0].name, 'run');
@@ -166,7 +179,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.deepStrictEqual(plugins.map(p => p.label), ['Slide Creator']);
 	}));
 
@@ -184,7 +197,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([missingUri, blankUri, nonStringUri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.deepStrictEqual(
 			plugins.map(p => p.label).sort(),
 			['blank-name', 'missing-name', 'non-string-name'],
@@ -213,7 +226,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].mcpServerDefinitions, defs => defs.length > 0);
@@ -235,7 +248,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].mcpServerDefinitions, defs => defs.length > 0);
@@ -256,7 +269,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].mcpServerDefinitions, defs => defs.length > 0);
@@ -273,7 +286,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].skills, s => s.length > 0);
@@ -290,7 +303,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].skills, s => s.length > 0);
@@ -310,7 +323,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].skills, s => s.length > 0);
@@ -329,7 +342,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].agents, a => a.length > 0);
@@ -349,7 +362,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].skills, s => s.length >= 2);
@@ -372,7 +385,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].skills, s => s.length > 0);
@@ -396,7 +409,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].commands, c => c.length >= 3);
@@ -419,7 +432,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].agents, a => a.length >= 2);
@@ -441,7 +454,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		// Only default skills/ directory should be scanned; the traversal path is rejected.
@@ -463,7 +476,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].commands, c => c.length > 0);
@@ -485,7 +498,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 		assert.strictEqual(plugins[0].label, 'no-manifest');
 
@@ -515,7 +528,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 		await waitForState(plugins[0].hooks, h => h.length > 0);
 		assert.strictEqual(plugins[0].hooks.get().length, 1);
@@ -536,7 +549,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 		await waitForState(plugins[0].hooks, h => h.length > 0);
 		assert.strictEqual(plugins[0].hooks.get().length, 1);
@@ -558,7 +571,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 		await waitForState(plugins[0].hooks, h => h.length > 0);
 		assert.strictEqual(plugins[0].hooks.get().length, 1);
@@ -580,7 +593,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 		await waitForState(plugins[0].mcpServerDefinitions, d => d.length > 0);
 		assert.strictEqual(plugins[0].mcpServerDefinitions.get()[0].name, 'custom-server');
@@ -604,7 +617,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		// When inline mcpServers is an object in the manifest, it is treated as
@@ -638,7 +651,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 		await waitForState(plugins[0].hooks, h => h.length > 0);
 
@@ -662,7 +675,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].commands, c => c.length >= 2);
@@ -685,7 +698,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].commands, c => c.length >= 2);
@@ -708,7 +721,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].agents, a => a.length >= 2);
@@ -730,7 +743,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].skills, s => s.length > 0);
@@ -756,7 +769,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 		await waitForState(plugins[0].hooks, h => h.length > 0);
 		assert.strictEqual(plugins[0].hooks.get().length, 1);
@@ -778,7 +791,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 		await waitForState(plugins[0].mcpServerDefinitions, d => d.length > 0);
 		assert.strictEqual(plugins[0].mcpServerDefinitions.get()[0].name, 'custom-server');
@@ -794,7 +807,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].instructions, i => i.length >= 2);
@@ -815,7 +828,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].instructions, i => i.length >= 3);
@@ -838,7 +851,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].instructions, i => i.length >= 2);
@@ -861,7 +874,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].instructions, i => i.length === 1 && i[0].name === 'visible');
@@ -880,7 +893,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].instructions, i => i.length > 0);
@@ -902,7 +915,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].instructions, i => i.length > 0);
@@ -930,7 +943,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].mcpServerDefinitions, d => d.length > 0);
@@ -960,7 +973,7 @@ suite('AgentPlugin format detection', () => {
 		discovery.start(mockEnablementModel);
 		await discovery.setSourcesAndRefresh([uri]);
 
-		const plugins = discovery.plugins.get();
+		const plugins = getDiscoveredPlugins(discovery);
 		assert.strictEqual(plugins.length, 1);
 
 		await waitForState(plugins[0].mcpServerDefinitions, d => d.length > 0);

--- a/src/vs/workbench/contrib/mcp/common/mcpService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpService.ts
@@ -6,14 +6,14 @@
 import { RunOnceScheduler } from '../../../../base/common/async.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { Disposable, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
-import { autorun, derived, IObservable, IReader, ISettableObservable, ITransaction, observableValue, transaction } from '../../../../base/common/observable.js';
+import { autorun, derived, IObservable, ISettableObservable, observableValue, transaction } from '../../../../base/common/observable.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { mcpAutoStartConfig, McpAutoStartValue } from '../../../../platform/mcp/common/mcpManagement.js';
 import { observableConfigValue } from '../../../../platform/observable/common/platformObservableUtils.js';
 import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
-import { ContributionEnablementState, EnablementModel, IEnablementModel, isContributionEnabled } from '../../chat/common/enablement.js';
+import { CollisionEnablementModel, EnablementModel, isContributionEnabled } from '../../chat/common/enablement.js';
 import { McpCollisionBehavior, mcpServerCollisionBehaviorSection } from './mcpConfiguration.js';
 import { IMcpRegistry } from './mcpRegistryTypes.js';
 import { McpPrefixGenerator, McpServer, McpServerMetadataCache } from './mcpServer.js';
@@ -248,21 +248,19 @@ function defsEqual(server: IMcpServer, def: { serverDefinition: McpServerDefinit
  *
  * When collision behavior is `suffix`, delegates everything unchanged.
  */
-export class McpCollisionEnablementModel implements IEnablementModel {
+export class McpCollisionEnablementModel extends CollisionEnablementModel {
 
 	/**
 	 * For each server definition ID, the list of all definition IDs that share
 	 * the same (case-insensitive) label, in priority order (lowest collection
 	 * order first). Empty when collision behavior is `suffix`.
 	 */
-	private readonly _collisionGroups: IObservable<ReadonlyMap<string, readonly string[]>>;
-
 	constructor(
-		private readonly _base: EnablementModel,
+		base: EnablementModel,
 		registry: IMcpRegistry,
 		collisionBehavior: IObservable<McpCollisionBehavior>,
 	) {
-		this._collisionGroups = derived(reader => {
+		const collisionGroups = derived(reader => {
 			if (collisionBehavior.read(reader) !== McpCollisionBehavior.Disable) {
 				return new Map<string, string[]>();
 			}
@@ -294,61 +292,6 @@ export class McpCollisionEnablementModel implements IEnablementModel {
 
 			return groups;
 		});
-	}
-
-	readEnabled(key: string, reader?: IReader): ContributionEnablementState {
-		const baseState = this._base.readEnabled(key, reader);
-
-		if (!isContributionEnabled(baseState)) {
-			return baseState;
-		}
-
-		const group = this._collisionGroups.read(reader).get(key);
-		if (!group) {
-			return baseState;
-		}
-
-		// This server is enabled and in a collision group. Only allow it
-		// to stay enabled if no higher-priority server in the group is
-		// also enabled.
-		for (const otherId of group) {
-			if (otherId === key) {
-				return baseState;
-			}
-			if (isContributionEnabled(this._base.readEnabled(otherId, reader))) {
-				return ContributionEnablementState.DisabledProfile;
-			}
-		}
-		return baseState;
-	}
-
-	setEnabled(key: string, state: ContributionEnablementState, tx?: ITransaction): void {
-		const isEnabling = state === ContributionEnablementState.EnabledProfile || state === ContributionEnablementState.EnabledWorkspace;
-		const group = isEnabling ? this._collisionGroups.get().get(key) : undefined;
-
-		if (!group) {
-			this._base.setEnabled(key, state, tx);
-			return;
-		}
-
-		// Enabling a colliding server: disable all others in the group atomically
-		const updateGroup = (innerTx: ITransaction) => {
-			this._base.setEnabled(key, state, innerTx);
-			for (const otherId of group) {
-				if (otherId !== key) {
-					this._base.setEnabled(otherId, ContributionEnablementState.DisabledWorkspace, innerTx);
-				}
-			}
-		};
-
-		if (tx) {
-			updateGroup(tx);
-		} else {
-			transaction(innerTx => updateGroup(innerTx));
-		}
-	}
-
-	remove(key: string): void {
-		this._base.remove(key);
+		super(base, collisionGroups);
 	}
 }


### PR DESCRIPTION
Fixes #322180

This updates agent plugin discovery and enablement so duplicate plugins from different install roots are handled consistently. Discovery providers now report an initial loading state and are processed in deterministic priority order. Equivalent plugins remain visible, but collision enablement keeps only the highest-priority copy enabled by default and enabling one disables its duplicates.

Also extracts reusable collision enablement, reuses it for MCP, and prevents disabled plugin refs from being synced to agent host sessions.

Validation:
- npm run typecheck-client
- ./scripts/test.sh --run src/vs/workbench/contrib/chat/test/common/plugins/agentPluginEnablement.test.ts --run src/vs/workbench/contrib/chat/test/common/plugins/agentPluginFormatDetection.test.ts --run src/vs/workbench/contrib/chat/test/browser/agentSessions/resolveCustomizationRefs.test.ts --run src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts --grep "AgentPlugin enablement|AgentPlugin format detection|resolveCustomizationRefs - built-in skills|Server Label Collision Enablement"
- npm run valid-layers-check
- node --experimental-strip-types build/hygiene.ts <touched files>