### PR TITLE
Render Auto model discount and tooltip in the agent-host model picker

### DIFF
--- a/src/vs/platform/agentHost/common/agentModelPricing.ts
+++ b/src/vs/platform/agentHost/common/agentModelPricing.ts
@@ -35,6 +35,8 @@ export interface IAgentModelPricingMeta {
 	readonly longContextOutputCost?: number;
 	/** Coarse price bucket (e.g. `low`, `medium`, `high`) for an at-a-glance tag. */
 	readonly priceCategory?: string;
+	/** Whole-number percentage discount (0-100) for the synthetic `auto` model; shown as a "{n}% discount" detail. */
+	readonly discountPercent?: number;
 }
 
 const NUMBER_KEYS = [
@@ -47,6 +49,7 @@ const NUMBER_KEYS = [
 	'longContextCacheCost',
 	'longContextCacheWriteCost',
 	'longContextOutputCost',
+	'discountPercent',
 ] as const satisfies readonly (keyof IAgentModelPricingMeta)[];
 
 /**

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -147,6 +147,8 @@ interface ICopilotModelBilling {
 	readonly multiplier?: number;
 	/** Coarse price bucket surfaced as a tag in the model picker hover. */
 	readonly priceCategory?: string;
+	/** Whole-number percentage discount (0-100) for the synthetic `auto` model; rendered as a "{n}% discount" detail. */
+	readonly discountPercent?: number;
 	readonly tokenPrices?: {
 		/** Default-tier prices, expressed as credits per 1M tokens. */
 		readonly contextMax?: number;
@@ -746,6 +748,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const billing = modelInfo?.billing;
 		const tokenPrices = billing?.tokenPrices;
 		const longContext = tokenPrices?.longContext;
+		// Narrow through ICopilotModelBilling: discountPercent may lag the installed SDK type.
+		const discountPercent = (billing as ICopilotModelBilling | undefined)?.discountPercent;
 
 		const differsFromDefault = (longValue: number | undefined, defaultValue: number | undefined): number | undefined =>
 			longValue !== undefined && longValue !== defaultValue ? longValue : undefined;
@@ -761,6 +765,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			longContextCacheWriteCost: differsFromDefault(longContext?.cachePrice, tokenPrices?.cachePrice),
 			longContextOutputCost: differsFromDefault(longContext?.outputPrice, tokenPrices?.outputPrice),
 			priceCategory: typeof modelInfo?.modelPickerPriceCategory === 'string' ? modelInfo.modelPickerPriceCategory : undefined,
+			discountPercent: typeof discountPercent === 'number' ? discountPercent : undefined,
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLanguageModelProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLanguageModelProvider.ts
@@ -67,7 +67,9 @@ export class AgentHostLanguageModelProvider extends Disposable implements ILangu
 				// "Auto" advertises the auto-mode discount (detail) + description (tooltip). microsoft/vscode#321778, #321659.
 				const isAuto = m.id === 'auto';
 				const discountPercent = pricing.discountPercent;
-				const detail = isAuto && typeof discountPercent === 'number' && discountPercent > 0
+				// Guard against a non-finite or out-of-range value from the open `_meta` bag so we never render
+				// nonsense like "Infinity% discount"; the documented range is a whole number in (0, 100].
+				const detail = isAuto && typeof discountPercent === 'number' && discountPercent > 0 && discountPercent <= 100
 					? localize('agentHost.auto.discount', "{0}% discount", discountPercent)
 					: undefined;
 				const tooltip = isAuto

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLanguageModelProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLanguageModelProvider.ts
@@ -6,6 +6,7 @@
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { localize } from '../../../../../../nls.js';
 import { ConfigSchema, SessionModelInfo } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { readAgentModelPricingMeta } from '../../../../../../platform/agentHost/common/agentModelPricing.js';
 import { nullExtensionDescription } from '../../../../../services/extensions/common/extensions.js';
@@ -63,6 +64,15 @@ export class AgentHostLanguageModelProvider extends Disposable implements ILangu
 			.map(m => {
 				const pricing = readAgentModelPricingMeta(m);
 				const multiplierNumeric = pricing.multiplierNumeric;
+				// "Auto" advertises the auto-mode discount (detail) + description (tooltip). microsoft/vscode#321778, #321659.
+				const isAuto = m.id === 'auto';
+				const discountPercent = pricing.discountPercent;
+				const detail = isAuto && typeof discountPercent === 'number' && discountPercent > 0
+					? localize('agentHost.auto.discount', "{0}% discount", discountPercent)
+					: undefined;
+				const tooltip = isAuto
+					? localize('agentHost.auto.tooltip', "Auto selects the best model based on your request complexity and model performance.")
+					: undefined;
 				return {
 					identifier: `${this._vendor}:${m.id}`,
 					metadata: {
@@ -72,6 +82,8 @@ export class AgentHostLanguageModelProvider extends Disposable implements ILangu
 						vendor: this._vendor,
 						version: '1.0',
 						family: m.id,
+						...(tooltip !== undefined && { tooltip }),
+						...(detail !== undefined && { detail }),
 						maxInputTokens: m.maxContextWindow ?? 0,
 						maxOutputTokens: 0,
 						isDefaultForLocation: {},

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostLanguageModelProvider.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostLanguageModelProvider.test.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { SessionModelInfo } from '../../../../../../platform/agentHost/common/state/protocol/channels-root/state.js';
+import { AgentHostLanguageModelProvider } from '../../../browser/agentSessions/agentHost/agentHostLanguageModelProvider.js';
+
+suite('AgentHostLanguageModelProvider', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function makeModel(id: string, meta?: Record<string, unknown>): SessionModelInfo {
+		return { id, provider: 'copilotcli', name: id === 'auto' ? 'Auto' : id, ...(meta && { _meta: meta }) };
+	}
+
+	function createProvider(): AgentHostLanguageModelProvider {
+		return store.add(new AgentHostLanguageModelProvider('agent-host-copilotcli', 'copilotcli'));
+	}
+
+	test('renders the auto-mode discount as the Auto model detail (and a tooltip)', async () => {
+		const provider = createProvider();
+		provider.updateModels([makeModel('auto', { discountPercent: 10 }), makeModel('gpt-5')]);
+
+		const infos = await provider.provideLanguageModelChatInfo(undefined, CancellationToken.None);
+		const auto = infos.find(m => m.metadata.id === 'auto');
+		const concrete = infos.find(m => m.metadata.id === 'gpt-5');
+
+		assert.strictEqual(auto?.metadata.detail, '10% discount');
+		assert.ok(auto?.metadata.tooltip && auto.metadata.tooltip.length > 0, 'Auto should have a tooltip');
+
+		// Concrete models get neither the discount detail nor the Auto tooltip.
+		assert.strictEqual(concrete?.metadata.detail, undefined);
+		assert.strictEqual(concrete?.metadata.tooltip, undefined);
+	});
+
+	test('shows the Auto tooltip but no detail when there is no positive discount', async () => {
+		const provider = createProvider();
+
+		// The realistic cold-open case: the runtime omits billing, so there is no discount to show.
+		provider.updateModels([makeModel('auto')]);
+		let auto = (await provider.provideLanguageModelChatInfo(undefined, CancellationToken.None)).find(m => m.metadata.id === 'auto');
+		assert.strictEqual(auto?.metadata.detail, undefined, 'absent discount → no detail');
+		assert.ok(auto?.metadata.tooltip && auto.metadata.tooltip.length > 0, 'Auto still has a tooltip');
+
+		// Guard: a literal 0 must not render a misleading "0% discount".
+		provider.updateModels([makeModel('auto', { discountPercent: 0 })]);
+		auto = (await provider.provideLanguageModelChatInfo(undefined, CancellationToken.None)).find(m => m.metadata.id === 'auto');
+		assert.strictEqual(auto?.metadata.detail, undefined, 'discountPercent 0 → no detail');
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostLanguageModelProvider.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostLanguageModelProvider.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { SessionModelInfo } from '../../../../../../platform/agentHost/common/state/protocol/channels-root/state.js';
+import { SessionModelInfo } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { AgentHostLanguageModelProvider } from '../../../browser/agentSessions/agentHost/agentHostLanguageModelProvider.js';
 
 suite('AgentHostLanguageModelProvider', () => {


### PR DESCRIPTION

Fixes #321778 

 **Depends on** the paired runtime PR github/copilot-agent-runtime#10973, which adds `billing.discountPercent` to `models.list`. 
