### PR TITLE
Respect workspace trust for the remote agent host

### DIFF
--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -531,7 +531,7 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 	// -- Workspaces ----------------------------------------------------------
 
 	static buildWorkspace(project: IAgentSessionMetadata['project'], workingDirectory: URI | undefined, providerLabel: string | undefined, gitHubInfo: IObservable<IGitHubInfo | undefined>, gitState: ISessionGitState | undefined, description?: string, branchProtectionPatterns?: readonly string[]): ISessionWorkspace | undefined {
-		return buildAgentHostSessionWorkspace(project, workingDirectory, { providerLabel, fallbackIcon: Codicon.remote, requiresWorkspaceTrust: false, description, branchProtectionPatterns, group: SESSION_WORKSPACE_GROUP_REMOTE }, gitHubInfo, gitState);
+		return buildAgentHostSessionWorkspace(project, workingDirectory, { providerLabel, fallbackIcon: Codicon.remote, requiresWorkspaceTrust: true, description, branchProtectionPatterns, group: SESSION_WORKSPACE_GROUP_REMOTE }, gitHubInfo, gitState);
 	}
 
 	private _buildWorkspaceFromUri(uri: URI): ISessionWorkspace {

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
@@ -190,7 +190,7 @@ function createSession(id: string, opts?: { provider?: string; summary?: string;
 	};
 }
 
-function createProvider(disposables: DisposableStore, connection: MockAgentConnection, overrides?: { address?: string; connectionName?: string | undefined; sendRequest?: (resource: URI, message: string, options?: IChatSendRequestOptions) => Promise<ChatSendResult>; openSession?: boolean; storageService?: IStorageService; noConnection?: boolean; isWebPlatform?: boolean }): RemoteAgentHostSessionsProvider {
+function createProvider(disposables: DisposableStore, connection: MockAgentConnection, overrides?: { address?: string; connectionName?: string | undefined; sendRequest?: (resource: URI, message: string, options?: IChatSendRequestOptions) => Promise<ChatSendResult>; openSession?: boolean; storageService?: IStorageService; noConnection?: boolean; isWebPlatform?: boolean; workspaceTrusted?: boolean }): RemoteAgentHostSessionsProvider {
 	const instantiationService = disposables.add(new TestInstantiationService());
 
 	instantiationService.stub(IFileDialogService, {});
@@ -198,8 +198,8 @@ function createProvider(disposables: DisposableStore, connection: MockAgentConne
 	instantiationService.stub(IConfigurationService, new TestConfigurationService());
 	instantiationService.stub(INotificationService, { error: () => { } });
 	instantiationService.stub(IWorkspaceTrustManagementService, new class extends mock<IWorkspaceTrustManagementService>() {
-		override isWorkspaceTrusted(): boolean { return true; }
-		override async getUriTrustInfo(uri: URI) { return { uri, trusted: true }; }
+		override isWorkspaceTrusted(): boolean { return overrides?.workspaceTrusted ?? true; }
+		override async getUriTrustInfo(uri: URI) { return { uri, trusted: overrides?.workspaceTrusted ?? true }; }
 	});
 	instantiationService.stub(IChatSessionsService, {
 		getChatSessionContribution: () => ({ type: 'remote-test-copilot', name: 'test', displayName: 'Test', description: 'test', icon: undefined }),
@@ -389,6 +389,34 @@ suite('RemoteAgentHostSessionsProvider', () => {
 		assert.strictEqual(ws.label, 'project');
 		assert.strictEqual(ws.folders.length, 1);
 		assert.strictEqual(ws.folders[0].root.toString(), uri.toString());
+	});
+
+	test('createNewSession eagerly creates the backend session in a trusted folder', async () => {
+		const provider = createProvider(disposables, connection);
+		const session = provider.createNewSession(URI.parse('vscode-agent-host://localhost__4321/home/user/trusted-project'), provider.sessionTypes[0].id);
+		provider.setAuthenticationPending(false); // eager create only runs once auth settles
+		await timeout(0); // let the eager createSession promise resolve
+
+		const rawId = session.resource.path.substring(1);
+		const expectedBackendUri = AgentSession.uri(provider.sessionTypes[0].id, rawId);
+		assert.deepStrictEqual(
+			connection.createdSessionUris.map(u => u.toString()),
+			[expectedBackendUri.toString()],
+			'eager createSession should be invoked with the client-allocated URI',
+		);
+	});
+
+	test('createNewSession does not eagerly create the backend session in an untrusted folder', async () => {
+		const provider = createProvider(disposables, connection, { workspaceTrusted: false });
+		provider.createNewSession(URI.parse('vscode-agent-host://localhost__4321/home/user/untrusted-project'), provider.sessionTypes[0].id);
+		provider.setAuthenticationPending(false); // settle auth so only trust can gate the eager create
+		await timeout(0); // let the (suppressed) eager createSession path settle
+
+		assert.deepStrictEqual(
+			connection.createdSessionUris.map(u => u.toString()),
+			[],
+			'no eager createSession should be invoked for an untrusted folder',
+		);
 	});
 
 	// ---- Browse actions -------
@@ -946,6 +974,7 @@ suite('RemoteAgentHostSessionsProvider', () => {
 		const workspace = wsSession!.workspace.get();
 		assert.ok(workspace, 'Workspace should be populated');
 		assert.strictEqual(workspace!.label, 'myrepo');
+		assert.strictEqual(workspace!.requiresWorkspaceTrust, true, 'remote session folders require workspace trust');
 	}));
 
 	test('session adapter without working directory has no workspace', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {

--- a/src/vs/workbench/services/workspaces/common/workspaceTrust.ts
+++ b/src/vs/workbench/services/workspaces/common/workspaceTrust.ts
@@ -14,6 +14,7 @@ import { InstantiationType, registerSingleton } from '../../../../platform/insta
 import { IRemoteAuthorityResolverService, ResolverResult } from '../../../../platform/remote/common/remoteAuthorityResolver.js';
 import { getRemoteAuthority } from '../../../../platform/remote/common/remoteHosts.js';
 import { isVirtualResource } from '../../../../platform/workspace/common/virtualWorkspace.js';
+import { AGENT_HOST_SCHEME } from '../../../../platform/agentHost/common/agentHostUri.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ISingleFolderWorkspaceIdentifier, isSavedWorkspace, isSingleFolderWorkspaceIdentifier, isTemporaryWorkspace, IWorkspace, IWorkspaceContextService, IWorkspaceFolder, toWorkspaceIdentifier, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
 import { WorkspaceTrustRequestOptions, IWorkspaceTrustManagementService, IWorkspaceTrustInfo, IWorkspaceTrustUriInfo, IWorkspaceTrustRequestService, IWorkspaceTrustTransitionParticipant, WorkspaceTrustUriResponse, IWorkspaceTrustEnablementService, ResourceTrustRequestOptions } from '../../../../platform/workspace/common/workspaceTrust.js';
@@ -446,7 +447,11 @@ export class WorkspaceTrustManagementService extends Disposable implements IWork
 	}
 
 	private isTrustedVirtualResource(uri: URI): boolean {
-		return isVirtualResource(uri) && uri.scheme !== 'vscode-vfs';
+		// `vscode-vfs` (e.g. GitHub Repositories) and `vscode-agent-host`
+		// (remote agent host folders) represent real, writable resources where
+		// code can run or files can change, so they must go through normal
+		// workspace trust rather than being auto-trusted as virtual resources.
+		return isVirtualResource(uri) && uri.scheme !== 'vscode-vfs' && uri.scheme !== AGENT_HOST_SCHEME;
 	}
 
 	private isTrustedByRemote(uri: URI): boolean {

--- a/src/vs/workbench/services/workspaces/test/common/workspaceTrust.test.ts
+++ b/src/vs/workbench/services/workspaces/test/common/workspaceTrust.test.ts
@@ -21,6 +21,7 @@ import { IWorkbenchEnvironmentService } from '../../../environment/common/enviro
 import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { UriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentityService.js';
 import { WorkspaceTrustEnablementService, WorkspaceTrustManagementService, WORKSPACE_TRUST_STORAGE_KEY } from '../../common/workspaceTrust.js';
+import { AGENT_HOST_SCHEME } from '../../../../../platform/agentHost/common/agentHostUri.js';
 import { TestContextService, TestStorageService, TestWorkspaceTrustEnablementService } from '../../../../test/common/workbenchTestServices.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { Mutable } from '../../../../../base/common/types.js';
@@ -129,6 +130,33 @@ suite('Workspace Trust', () => {
 			const testObject = await initializeTestObject();
 
 			assert.strictEqual(false, testObject.isWorkspaceTrusted());
+		});
+
+		test('agent host folder is not auto-trusted as a virtual resource', async () => {
+			await configurationService.setUserConfiguration('security', getUserSettings(true, true));
+			workspaceService.setWorkspace(new Workspace('empty-workspace'));
+			const testObject = await initializeTestObject();
+
+			// A regular virtual resource (e.g. github1s) is auto-trusted...
+			const virtualUri = URI.parse('vscode-test-virtual://authority/folder');
+			assert.strictEqual(true, (await testObject.getUriTrustInfo(virtualUri)).trusted);
+
+			// ...but an agent host folder is not, even though it is a virtual scheme.
+			const agentHostUri = URI.from({ scheme: AGENT_HOST_SCHEME, authority: 'my-server', path: '/Users/me/code', query: '_ah=meta' });
+			assert.strictEqual(false, (await testObject.getUriTrustInfo(agentHostUri)).trusted);
+		});
+
+		test('agent host folder trust persists and ignores the _ah query', async () => {
+			await configurationService.setUserConfiguration('security', getUserSettings(true, true));
+			workspaceService.setWorkspace(new Workspace('empty-workspace'));
+			const testObject = await initializeTestObject();
+
+			const agentHostUri = URI.from({ scheme: AGENT_HOST_SCHEME, authority: 'my-server', path: '/Users/me/code', query: '_ah=meta' });
+			await testObject.setUrisTrust([agentHostUri], true);
+
+			// The same folder with a different _ah payload resolves to the same trust entry.
+			const sameFolderDifferentMeta = URI.from({ scheme: AGENT_HOST_SCHEME, authority: 'my-server', path: '/Users/me/code', query: '_ah=other' });
+			assert.strictEqual(true, (await testObject.getUriTrustInfo(sameFolderDifferentMeta)).trusted);
 		});
 
 		async function initializeTestObject(): Promise<WorkspaceTrustManagementService> {


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode-internalbacklog/issues/8082

Follow-up to [#322308](https://github.com/microsoft/vscode/pull/322308) (local agent host workspace trust). This extends the same UI-layer trust gating to the **remote** agent host, and fixes a core bug that was silently bypassing trust for any agent-host folder.

## What this does

**1. Gate the remote agent host on workspace trust (Option B — deliberately per-host, tracked locally).**
Remote folders use stable `vscode-agent-host://<host>/<path>?_ah=…` URIs. The local `IWorkspaceTrustManagementService` already canonicalizes these (it strips the `?_ah=` query) and stores trust in its machine-scoped store, so per-host remote trust is tracked locally for free. The new-session pick path already required trust via `_buildWorkspaceFromUri`; this flips the static `buildWorkspace` (sessions reconstructed from metadata) `requiresWorkspaceTrust: false → true` so all three gates agree — the pick-time prompt, the eager-create guard, and the first-send backstop — all keyed on the remote folder URI.

**2. Stop auto-trusting `vscode-agent-host://` folders as "virtual resources".**
This is the important fix. `vscode-agent-host://` is a virtual scheme (not `file://`/`vscode-remote://`), and `WorkspaceTrustManagementService.isTrustedVirtualResource` auto-trusted **every** virtual scheme except `vscode-vfs`. As a result, all three trust gates were silently bypassed for remote agent-host folders — a remote agent could spawn over SSH with **no trust prompt** and the folder never entered the trust store. The fix excludes `AGENT_HOST_SCHEME` from `isTrustedVirtualResource`, exactly alongside the existing `vscode-vfs` carve-out, so agent-host folders go through normal workspace trust. An agent-host folder is not a safe read-only virtual FS: an agent can run commands and modify files there, so it must be trusted explicitly.

## Trust model

Trust is keyed on the canonicalized `vscode-agent-host://<host>/<path>` URI (the `_ah` payload is stripped by `getCanonicalUri`), so a remote folder is trusted **per host**, and that trust is tracked in the local machine-scoped store. The agent host process and the AHP protocol are untouched — trust remains a pure client-UI concern.

## Validation

- `npm run typecheck-client` and `npm run valid-layers-check` clean.
- Unit tests: Workspace Trust suite (9, +2 new) and RemoteAgentHostSessionsProvider suite (51, +3 new) pass.
- **Verified e2e against a real SSH remote (macbook-air):**
  - Selecting an untrusted remote folder now shows the trust modal ("An agent session will be able to read files, run commands, and make changes in this folder.").
  - **Cancel** → no session created (picker reverts to "Start by picking a workspace").
  - **Trust Folder & Continue** → session created, the agent spawns over SSH, and the store gains a real entry `vscode-agent-host://ssh__macbook-air/Users/roblou/code/vscode` (trusted).
  - Before this change, the same flow spawned the remote agent with no prompt and left the folder untrusted.

(Written by Copilot)
