### PR TITLE
agent host: fix remote auto-shutdown with renderer proxy

### DIFF
--- a/src/vs/server/node/agentHostChannel.ts
+++ b/src/vs/server/node/agentHostChannel.ts
@@ -13,11 +13,10 @@
 // `RemoteAgentHostProtocolClient` over IPC instead of a raw WebSocket.
 
 import { Emitter, Event } from '../../base/common/event.js';
-import { Disposable, IDisposable, MutableDisposable } from '../../base/common/lifecycle.js';
+import { Disposable, IDisposable } from '../../base/common/lifecycle.js';
 import { connectionTokenQueryName } from '../../base/common/network.js';
 import { IPCServer, IServerChannel } from '../../base/parts/ipc/common/ipc.js';
 import { ILogService } from '../../platform/log/common/log.js';
-import { IServerLifetimeService } from './serverLifetimeService.js';
 import type * as wsTypes from 'ws';
 import type * as netTypes from 'net';
 
@@ -94,8 +93,8 @@ export class UnavailableAgentHostChannel<TContext> implements IServerChannel<TCo
 /**
  * Default upstream factory: opens an AHP WebSocket to the local agent host.
  */
-const defaultUpstreamFactory = (logService: ILogService, lifetime: IServerLifetimeService): UpstreamConnectionFactory =>
-	(endpoint) => new WebSocketUpstreamConnection(endpoint, logService, lifetime);
+const defaultUpstreamFactory = (logService: ILogService): UpstreamConnectionFactory =>
+	(endpoint) => new WebSocketUpstreamConnection(endpoint, logService);
 
 class WebSocketUpstreamConnection extends Disposable implements IUpstreamConnection {
 	private readonly _onFrame = this._register(new Emitter<string>());
@@ -107,12 +106,10 @@ class WebSocketUpstreamConnection extends Disposable implements IUpstreamConnect
 	private _ws: wsTypes.WebSocket | undefined;
 	private _connectPromise: Promise<void> | undefined;
 	private _closeFired = false;
-	private readonly _lifetimeToken = this._register(new MutableDisposable());
 
 	constructor(
 		private readonly _endpoint: IAgentHostUpstreamEndpoint,
 		private readonly _logService: ILogService,
-		private readonly _serverLifetimeService: IServerLifetimeService,
 	) {
 		super();
 	}
@@ -137,7 +134,6 @@ class WebSocketUpstreamConnection extends Disposable implements IUpstreamConnect
 			const onOpen = () => {
 				cleanup();
 				this._logService.trace('[AgentHostChannel] Upstream open');
-				this._lifetimeToken.value = this._serverLifetimeService.active('AgentHostChannel');
 				socket.on('message', (data: Buffer | string) => {
 					const text = typeof data === 'string' ? data : data.toString('utf-8');
 					this._onFrame.fire(text);
@@ -196,7 +192,6 @@ class WebSocketUpstreamConnection extends Disposable implements IUpstreamConnect
 			return;
 		}
 		this._closeFired = true;
-		this._lifetimeToken.clear();
 		this._onClose.fire();
 	}
 
@@ -236,11 +231,10 @@ export class AgentHostChannel<TContext> extends Disposable implements IServerCha
 		ipcServer: IPCServer<TContext>,
 		private readonly _endpoint: IAgentHostUpstreamEndpoint,
 		private readonly _logService: ILogService,
-		serverLifetimeService: IServerLifetimeService,
 		upstreamFactory?: UpstreamConnectionFactory,
 	) {
 		super();
-		this._upstreamFactory = upstreamFactory ?? defaultUpstreamFactory(_logService, serverLifetimeService);
+		this._upstreamFactory = upstreamFactory ?? defaultUpstreamFactory(_logService);
 		this._register(ipcServer.onDidRemoveConnection(c => this._disposeCtx(c.ctx as unknown as TContext)));
 	}
 

--- a/src/vs/server/node/serverAgentHostManager.ts
+++ b/src/vs/server/node/serverAgentHostManager.ts
@@ -17,12 +17,12 @@ export const IServerAgentHostManager = createDecorator<IServerAgentHostManager>(
 
 /**
  * Server-specific agent host manager. Eagerly starts the agent host process,
- * handles crash recovery, and tracks both active agent sessions and connected
- * WebSocket clients via {@link IServerLifetimeService} to keep the server
- * alive while either signal is active.
+ * handles crash recovery, and tracks active agent sessions plus incoming
+ * WebSocket clients to the spawned standalone agent host via
+ * {@link IServerLifetimeService}.
  *
- * The lifetime token is held when active sessions > 0 OR connected clients > 0.
- * It is released only when both are zero.
+ * Renderer-to-agent-host proxy connections handled by `AgentHostChannel`
+ * deliberately do not participate here.
  */
 export interface IServerAgentHostManager {
 	readonly _serviceBrand: undefined;
@@ -46,7 +46,7 @@ export class ServerAgentHostManager extends Disposable implements IServerAgentHo
 
 	private _restartCount = 0;
 
-	/** Lifetime token held while sessions are active or clients are connected. */
+	/** Lifetime token held while sessions are active or standalone WebSocket clients are connected. */
 	private readonly _lifetimeToken = this._register(new MutableDisposable());
 
 	private _hasActiveSessions = false;
@@ -83,7 +83,6 @@ export class ServerAgentHostManager extends Disposable implements IServerAgentHo
 			// Handle unexpected exit
 			connection.store.add(connection.onDidProcessExit(e => {
 				if (!this._store.isDisposed) {
-					// Both signals are gone when the process exits
 					this._hasActiveSessions = false;
 					this._connectionCount = 0;
 					this._lifetimeToken.clear();

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -299,7 +299,6 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 				connectionToken: bridgeToken,
 			},
 			logService,
-			serverLifetimeService,
 		));
 		socketServer.registerChannel(AgentHostIpcChannels.RemoteProxy, agentHostBridge);
 		logService.info(`[AgentHostChannel] Registered IPC channel '${AgentHostIpcChannels.RemoteProxy}' (upstream: ${bridgePath ?? `${bridgeHost}:${bridgePort}`})`);

--- a/src/vs/server/test/node/agentHostChannel.test.ts
+++ b/src/vs/server/test/node/agentHostChannel.test.ts
@@ -5,12 +5,11 @@
 
 import assert from 'assert';
 import { Emitter, Event } from '../../../base/common/event.js';
-import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
+import { Disposable } from '../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
 import type { Client, IPCServer } from '../../../base/parts/ipc/common/ipc.js';
 import { NullLogService } from '../../../platform/log/common/log.js';
 import { AgentHostChannel, IAgentHostUpstreamEndpoint, IUpstreamConnection, UnavailableAgentHostChannel } from '../../node/agentHostChannel.js';
-import { IServerLifetimeService } from '../../node/serverLifetimeService.js';
 
 class FakeUpstream extends Disposable implements IUpstreamConnection {
 	private readonly _onFrame = this._register(new Emitter<string>());
@@ -61,13 +60,6 @@ class FakeIPCServer {
 	}
 }
 
-class StubServerLifetimeService implements IServerLifetimeService {
-	declare readonly _serviceBrand: undefined;
-	get hasActiveConsumers(): boolean { return false; }
-	active(_consumer: string) { return toDisposable(() => { }); }
-	delay(): void { }
-}
-
 suite('AgentHostChannel', () => {
 	const ds = ensureNoDisposablesAreLeakedInTestSuite();
 
@@ -86,7 +78,6 @@ suite('AgentHostChannel', () => {
 			ipc as unknown as IPCServer<string>,
 			{ host: 'localhost', port: '12345' },
 			new NullLogService(),
-			new StubServerLifetimeService(),
 			factory,
 		));
 		return { channel, upstreams, ipc };

--- a/src/vs/server/test/node/serverAgentHostManager.test.ts
+++ b/src/vs/server/test/node/serverAgentHostManager.test.ts
@@ -164,39 +164,24 @@ suite('ServerAgentHostManager', () => {
 		assert.strictEqual(lifetimeService.hasActiveConsumers, true);
 	});
 
-	test('acquires token when clients connect (no active sessions)', async () => {
+	test('acquires token when standalone WebSocket clients connect', async () => {
 		createManager();
 		await waitForStart();
 		fireConnectionCount(2);
 		assert.strictEqual(lifetimeService.hasActiveConsumers, true);
 	});
 
-	test('releases token only when both sessions and connections are zero', async () => {
+	test('releases token only when both sessions and standalone WebSocket connections are zero', async () => {
 		createManager();
 		await waitForStart();
 
-		// Sessions active, no connections
 		fireActiveSessions(1);
 		assert.strictEqual(lifetimeService.hasActiveConsumers, true);
 
-		// Connections appear too
 		fireConnectionCount(1);
 		assert.strictEqual(lifetimeService.hasActiveConsumers, true);
 
-		// Sessions go idle, but connections remain
 		fireActiveSessions(0);
-		assert.strictEqual(lifetimeService.hasActiveConsumers, true);
-
-		// Connections drop to zero -- now both are idle
-		fireConnectionCount(0);
-		assert.strictEqual(lifetimeService.hasActiveConsumers, false);
-	});
-
-	test('releases token only when connections drop after sessions already idle', async () => {
-		createManager();
-		await waitForStart();
-
-		fireConnectionCount(3);
 		assert.strictEqual(lifetimeService.hasActiveConsumers, true);
 
 		fireConnectionCount(0);
@@ -206,7 +191,6 @@ suite('ServerAgentHostManager', () => {
 	test('process exit resets both signals and clears token', async () => {
 		createManager();
 		await waitForStart();
-
 		fireActiveSessions(2);
 		fireConnectionCount(1);
 		assert.strictEqual(lifetimeService.hasActiveConsumers, true);


### PR DESCRIPTION
Fixes #322014

## Summary
- stop renderer-to-agent-host proxy connections from holding the remote server lifetime token
- keep standalone agent-host WebSocket clients and active agent sessions tracked through ServerAgentHostManager
- update focused server tests for the scoped shutdown behavior

## Validation
- npm run typecheck-client
- node --experimental-strip-types build/hygiene.ts src/vs/server/node/serverAgentHostManager.ts src/vs/server/node/agentHostChannel.ts src/vs/server/node/serverServices.ts src/vs/server/test/node/serverAgentHostManager.test.ts src/vs/server/test/node/agentHostChannel.test.ts
- npm run gulp compile
- ./scripts/test.sh --run src/vs/server/test/node/serverAgentHostManager.test.ts --run src/vs/server/test/node/agentHostChannel.test.ts