### PR TITLE
Add custom inline completion models

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -3350,7 +3350,59 @@
           "github.copilot.selectedCompletionModel": {
             "type": "string",
             "default": "",
+            "scope": "machine",
             "markdownDescription": "The currently selected completion model ID. To select from a list of available models, use the __\"Change Completions Model\"__ command or open the model picker (from the Copilot menu in the VS Code title bar, select __\"Configure Code Completions\"__ then __\"Change Completions Model\"__. The value must be a valid model ID. An empty value indicates that the default model will be used."
+          },
+          "github.copilot.customCompletionModels": {
+            "type": "array",
+            "default": [],
+            "scope": "machine",
+            "markdownDescription": "Custom OpenAI-compatible completion models available for inline code completions. Each model must provide an `id` and an endpoint `url`. URLs without an explicit completions path resolve to `/v1/completions`; URLs ending in `/vN` resolve to `/vN/completions`. Custom completion models are configured per machine because inline completions send source code to the configured endpoint.",
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "url"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "markdownDescription": "Unique model ID shown by the completions model picker."
+                },
+                "name": {
+                  "type": "string",
+                  "markdownDescription": "Display name shown by the completions model picker."
+                },
+                "model": {
+                  "type": "string",
+                  "markdownDescription": "Model name sent in the OpenAI-compatible request body. Defaults to `id`."
+                },
+                "url": {
+                  "type": "string",
+                  "markdownDescription": "OpenAI-compatible completions endpoint URL, or a base URL. URLs without an explicit completions path resolve to `/v1/completions`; URLs ending in `/vN` resolve to `/vN/completions`."
+                },
+                "tokenizer": {
+                  "type": "string",
+                  "enum": [
+                    "o200k_base",
+                    "cl100k_base"
+                  ],
+                  "default": "o200k_base",
+                  "markdownDescription": "Tokenizer used for prompt budgeting before sending requests to this model."
+                },
+                "apiKey": {
+                  "type": "string",
+                  "markdownDescription": "Optional API key sent as `Authorization: Bearer <apiKey>` when `requestHeaders` does not provide its own authorization header. This value is stored in machine settings, so use it only with endpoints you trust."
+                },
+                "requestHeaders": {
+                  "type": "object",
+                  "markdownDescription": "Optional extra request headers sent to the custom completion endpoint. Header values are stored in machine settings, so use them only with endpoints you trust.",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
           },
           "github.copilot.chat.claudeAgent.enabled": {
             "type": "boolean",

--- a/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/config.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/config.ts
@@ -45,11 +45,21 @@ export class VSCodeConfigProvider extends ConfigProvider implements IDisposable 
 	}
 
 	override getConfig<T>(key: ConfigKeyType): T {
+		if (this.shouldReadDirectly(key)) {
+			return this.config.get<T>(key) ?? getConfigDefaultForKey(key);
+		}
 		return getConfigKeyRecursively<T>(this.config, key) ?? getConfigDefaultForKey(key);
 	}
 
 	override getOptionalConfig<T>(key: ConfigKeyType): T | undefined {
+		if (this.shouldReadDirectly(key)) {
+			return this.config.get<T>(key) ?? getOptionalConfigDefaultForKey(key);
+		}
 		return getConfigKeyRecursively<T>(this.config, key) ?? getOptionalConfigDefaultForKey(key);
+	}
+
+	private shouldReadDirectly(key: ConfigKeyType): boolean {
+		return key === ConfigKey.UserSelectedCompletionModel || key === ConfigKey.CustomCompletionModels;
 	}
 
 	// Dumps config settings defined in the extension json

--- a/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/test/configProvider.test.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/test/configProvider.test.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import sinon from 'sinon';
+import { workspace, WorkspaceConfiguration } from 'vscode';
+import { ConfigKey } from '../../../lib/src/config';
+import { CopilotConfigPrefix } from '../../../lib/src/constants';
+import { VSCodeConfigProvider } from '../config';
+
+suite('VSCodeConfigProvider custom completion config', function () {
+	let sandbox: sinon.SinonSandbox;
+
+	setup(function () {
+		sandbox = sinon.createSandbox();
+	});
+
+	teardown(function () {
+		sandbox.restore();
+	});
+
+	test('reads custom completion model settings from VS Code configuration', async function () {
+		const customModels = [{
+			id: 'local-gemma',
+			url: 'http://127.0.0.1:8080',
+		}];
+		const config = {
+			[ConfigKey.CustomCompletionModels]: [],
+			[ConfigKey.UserSelectedCompletionModel]: '',
+			get: (key: string) => {
+				if (key === ConfigKey.CustomCompletionModels) {
+					return customModels;
+				}
+				if (key === ConfigKey.UserSelectedCompletionModel) {
+					return 'local-gemma';
+				}
+				return undefined;
+			},
+		} as WorkspaceConfiguration;
+		sandbox.stub(workspace, 'getConfiguration')
+			.withArgs(CopilotConfigPrefix)
+			.returns(config);
+
+		const provider = new VSCodeConfigProvider();
+		try {
+			assert.deepStrictEqual(provider.getConfig(ConfigKey.CustomCompletionModels), customModels);
+			assert.strictEqual(provider.getConfig(ConfigKey.UserSelectedCompletionModel), 'local-gemma');
+		} finally {
+			provider.dispose();
+		}
+	});
+});

--- a/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/test/modelPicker.test.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/test/modelPicker.test.ts
@@ -5,9 +5,11 @@
 
 import assert from 'assert';
 import sinon from 'sinon';
-import { commands, env } from 'vscode';
+import { commands, env, workspace } from 'vscode';
 import { SyncDescriptor } from '../../../../../../util/vs/platform/instantiation/common/descriptors';
 import { IInstantiationService, ServicesAccessor } from '../../../../../../util/vs/platform/instantiation/common/instantiation';
+import { ConfigKey } from '../../../lib/src/config';
+import { CopilotConfigPrefix } from '../../../lib/src/constants';
 import { AvailableModelsManager, ICompletionsModelManagerService } from '../../../lib/src/openai/model';
 import { ModelPickerManager } from './../modelPicker';
 import { createExtensionTestingContext } from './context';
@@ -98,6 +100,18 @@ suite('ModelPickerManager unit tests', function () {
 		// Test that we updated the user configuration with the selected model
 		assert(setModelStub.calledOnce, 'setUserSelectedCompletionModel should be called once');
 		assert.strictEqual(setModelStub.firstCall.args[0], secondItem.modelId);
+	});
+
+	test('custom completion model selection writes global user setting', async function () {
+		const updateStub = sandbox.stub().resolves();
+		sandbox.stub(workspace, 'getConfiguration')
+			.withArgs(CopilotConfigPrefix)
+			.returns({ update: updateStub } as unknown as ReturnType<typeof workspace.getConfiguration>);
+
+		await modelPicker.setUserSelectedCompletionModel('model-b');
+
+		assert(updateStub.calledOnce, 'configuration update should be called once');
+		assert.deepStrictEqual(updateStub.firstCall.args, [ConfigKey.UserSelectedCompletionModel, 'model-b', true]);
 	});
 
 	test('selecting the learn more link tries to open the learn more url', async function () {

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/config.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/config.ts
@@ -14,6 +14,7 @@ export { packageJson };
 export const ConfigKey = {
 	Enable: 'enable',
 	UserSelectedCompletionModel: 'selectedCompletionModel',
+	CustomCompletionModels: 'customCompletionModels',
 
 	ShowEditorCompletions: 'editor.showEditorCompletions',
 	EnableAutoCompletions: 'editor.enableAutoCompletions',
@@ -298,6 +299,7 @@ const configDefaults = new Map<ConfigKeyType, unknown>([
 	// These are defaults from package.json
 	[ConfigKey.Enable, { '*': true, 'plaintext': false, 'markdown': false, 'scminput': false }],
 	[ConfigKey.UserSelectedCompletionModel, ''],
+	[ConfigKey.CustomCompletionModels, []],
 
 	// These are advanced defaults from package.json
 	[ConfigKey.DebugOverrideEngineLegacy, ''],

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/experiments/features.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/experiments/features.ts
@@ -13,7 +13,8 @@ import {
 	DEFAULT_SUFFIX_MATCH_THRESHOLD
 } from '../../../prompt/src/prompt';
 import { CopilotToken, ICompletionsCopilotTokenManager } from '../auth/copilotTokenManager';
-import { BlockMode } from '../config';
+import { BlockMode, ConfigKey, getConfig } from '../config';
+import { ICompletionsModelManagerService } from '../openai/model';
 import { TelemetryData, TelemetryWithExp } from '../telemetry';
 import { createCompletionsFilters } from './defaultExpFilters';
 import { ExpConfig, ExpTreatmentVariables, ExpTreatmentVariableValue } from './expConfig';
@@ -81,7 +82,7 @@ export class Features implements ICompletionsFeaturesService {
 			throw new Error('updateExPValuesAndAssignments should not be called with TelemetryWithExp');
 		}
 
-		const token = this.copilotTokenManager.token ?? await this.copilotTokenManager.getToken();
+		const token = await this.getTokenForExpFilters();
 		const { filters, exp } = this.createExpConfigAndFilters(token);
 
 		return new TelemetryWithExp(telemetryData.properties, telemetryData.measurements, telemetryData.issuedTime, {
@@ -101,7 +102,24 @@ export class Features implements ICompletionsFeaturesService {
 		return await this.updateExPValuesAndAssignments(filtersInfo, telemetryData);
 	}
 
-	private createExpConfigAndFilters(token: CopilotToken) {
+	private async getTokenForExpFilters(): Promise<Omit<CopilotToken, 'token'> | undefined> {
+		if (this.isCustomCompletionModelSelected()) {
+			return this.copilotTokenManager.getLastToken();
+		}
+		return this.copilotTokenManager.token ?? await this.copilotTokenManager.getToken();
+	}
+
+	private isCustomCompletionModelSelected(): boolean {
+		const selectedCompletionModel = this.instantiationService.invokeFunction(getConfig<string>, ConfigKey.UserSelectedCompletionModel);
+		if (!selectedCompletionModel) {
+			return false;
+		}
+		return this.instantiationService.invokeFunction(accessor =>
+			accessor.get(ICompletionsModelManagerService).getGenericCompletionModels().find(model => model.modelId === selectedCompletionModel)?.custom === true
+		);
+	}
+
+	private createExpConfigAndFilters(token: Omit<CopilotToken, 'token'> | undefined) {
 
 		const exp2: Partial<Record<ExpTreatmentVariables, ExpTreatmentVariableValue>> = {};
 		for (const varName of Object.values<ExpTreatmentVariables>(ExpTreatmentVariables)) {
@@ -128,7 +146,7 @@ export class Features implements ICompletionsFeaturesService {
 
 	/** Get the entries from this.assignments corresponding to given settings. */
 	async getFallbackExpAndFilters(): Promise<{ filters: FilterSettings; exp: ExpConfig }> {
-		const token = this.copilotTokenManager.token ?? await this.copilotTokenManager.getToken();
+		const token = await this.getTokenForExpFilters();
 		return this.createExpConfigAndFilters(token);
 	}
 

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/experiments/test/features.test.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/experiments/test/features.test.ts
@@ -4,10 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { ICompletionModelInformation } from '../../../../../../../platform/endpoint/common/endpointProvider';
+import { TokenizerType } from '../../../../../../../util/common/tokenizer';
 import { ServicesAccessor } from '../../../../../../../util/vs/platform/instantiation/common/instantiation';
+import { ICompletionsCopilotTokenManager, CopilotToken } from '../../auth/copilotTokenManager';
+import { ConfigKey, ICompletionsConfigProvider, InMemoryConfigProvider } from '../../config';
+import { AvailableModelsManager, ICompletionsModelManagerService } from '../../openai/model';
 import { extractRepoInfoInBackground } from '../../prompt/repository';
 import { TelemetryData } from '../../telemetry';
 import { createLibTestingContext } from '../../test/context';
+import { FakeCopilotTokenManager } from '../../test/copilotTokenManager';
+import { Filter } from '../filters';
 import { makeFsUri } from '../../util/uri';
 import { ICompletionsFeaturesService } from '../featuresService';
 
@@ -48,4 +55,96 @@ suite('updateExPValuesAndAssignments', function () {
 		assert.deepStrictEqual(filters['X-Copilot-Repository'], undefined);
 		assert.deepStrictEqual(filters['X-Copilot-FileType'], undefined);
 	});
+
+	test('selected custom completion model does not require a Copilot token', async function () {
+		const serviceCollection = createLibTestingContext();
+		serviceCollection.define(ICompletionsCopilotTokenManager, new ThrowingCopilotTokenManager());
+		const customAccessor = serviceCollection.createTestingAccessor();
+		const configProvider = customAccessor.get(ICompletionsConfigProvider) as InMemoryConfigProvider;
+		configProvider.setConfig(ConfigKey.CustomCompletionModels, [{
+			id: 'local-model',
+			url: 'http://127.0.0.1:11434/v1',
+		}]);
+		configProvider.setConfig(ConfigKey.UserSelectedCompletionModel, 'local-model');
+
+		const featuresService = customAccessor.get(ICompletionsFeaturesService);
+		const telemetry = await featuresService.updateExPValuesAndAssignments();
+
+		const filters = telemetry.filtersAndExp.filters.toHeaders();
+		assert.strictEqual(filters[Filter.CopilotEngine], 'local-model');
+		assert.strictEqual(filters[Filter.CopilotTrackingId], undefined);
+	});
+
+	test('selected custom completion model collision uses Copilot token path', async function () {
+		const serviceCollection = createLibTestingContext();
+		const tokenManager = new TrackingCopilotTokenManager();
+		serviceCollection.define(ICompletionsCopilotTokenManager, tokenManager);
+		const customAccessor = serviceCollection.createTestingAccessor();
+		const configProvider = customAccessor.get(ICompletionsConfigProvider) as InMemoryConfigProvider;
+		configProvider.setConfig(ConfigKey.CustomCompletionModels, [{
+			id: 'gpt-41-copilot',
+			url: 'http://127.0.0.1:11434/v1',
+		}]);
+		configProvider.setConfig(ConfigKey.UserSelectedCompletionModel, 'gpt-41-copilot');
+		const modelManager = customAccessor.get(ICompletionsModelManagerService) as AvailableModelsManager;
+		modelManager.fetchedModelData = [hostedCompletionModel('gpt-41-copilot')];
+
+		const featuresService = customAccessor.get(ICompletionsFeaturesService);
+		await featuresService.updateExPValuesAndAssignments();
+
+		assert.strictEqual(tokenManager.getTokenCalled, true);
+	});
 });
+
+class ThrowingCopilotTokenManager implements ICompletionsCopilotTokenManager {
+	declare _serviceBrand: undefined;
+
+	get token(): CopilotToken | undefined {
+		throw new Error('Unexpected token getter call');
+	}
+
+	primeToken(): Promise<boolean> {
+		throw new Error('Unexpected primeToken call');
+	}
+
+	getToken(): Promise<CopilotToken> {
+		throw new Error('Unexpected getToken call');
+	}
+
+	resetToken(): void { }
+
+	getLastToken(): Omit<CopilotToken, 'token'> | undefined {
+		return undefined;
+	}
+}
+
+class TrackingCopilotTokenManager extends FakeCopilotTokenManager {
+	getTokenCalled = false;
+
+	override get token(): CopilotToken | undefined {
+		return undefined;
+	}
+
+	override async getToken(): Promise<CopilotToken> {
+		this.getTokenCalled = true;
+		return super.getToken();
+	}
+}
+
+function hostedCompletionModel(id: string): ICompletionModelInformation {
+	return {
+		id,
+		vendor: 'github',
+		name: id,
+		model_picker_enabled: true,
+		preview: false,
+		is_chat_default: false,
+		is_chat_fallback: false,
+		version: '1',
+		capabilities: {
+			type: 'completion',
+			family: id,
+			tokenizer: TokenizerType.O200K,
+		},
+	};
+}

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/ghostText/test/streamedCompletionSplitter.test.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/ghostText/test/streamedCompletionSplitter.test.ts
@@ -26,7 +26,7 @@ class FakeCompletionsFetchService implements ICompletionsFetchService {
 	constructor(private readonly completionTexts: string[], private readonly annotations?: CopilotNamedAnnotationList) { }
 	async fetch(
 		_url: string,
-		_secretKey: string,
+		_secretKey: string | undefined,
 		_params: Completions.ModelParams,
 		_requestId: string,
 		_ct: CancellationToken,

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/openai/customCompletionModels.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/openai/customCompletionModels.ts
@@ -1,0 +1,173 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ServicesAccessor } from '../../../../../../util/vs/platform/instantiation/common/instantiation';
+import { TokenizerName } from '../../../prompt/src/tokenization';
+import { ConfigKey, getConfig } from '../config';
+
+export interface CustomCompletionModelConfig {
+	id: string;
+	name?: string;
+	model?: string;
+	url: string;
+	tokenizer?: TokenizerName;
+	apiKey?: string;
+	requestHeaders?: Record<string, string>;
+}
+
+export function getCustomCompletionModels(accessor: ServicesAccessor): CustomCompletionModelConfig[] {
+	const value = getConfig<unknown>(accessor, ConfigKey.CustomCompletionModels);
+	if (!Array.isArray(value)) {
+		return [];
+	}
+	return value
+		.map(toCustomCompletionModel)
+		.filter(model => model !== undefined);
+}
+
+export function getCustomCompletionModel(accessor: ServicesAccessor, modelId: string): CustomCompletionModelConfig | undefined {
+	return getCustomCompletionModels(accessor).find(model => model.id === modelId);
+}
+
+export function resolveCustomCompletionModelUrl(model: CustomCompletionModelConfig): string {
+	const parsed = parseUrl(model.url);
+	if (!parsed) {
+		return resolveCustomCompletionModelUrlString(model.url);
+	}
+
+	const path = parsed.pathname.replace(/\/+$/, '');
+	if (hasExplicitCompletionsPath(path)) {
+		parsed.pathname = path;
+		return parsed.toString();
+	}
+
+	if (/\/v\d+$/.test(path)) {
+		parsed.pathname = `${path}/completions`;
+	} else {
+		parsed.pathname = `${path}/v1/completions`;
+	}
+
+	return parsed.toString();
+}
+
+export function getCustomCompletionModelHeaders(model: CustomCompletionModelConfig): Record<string, string> {
+	const headers = { ...sanitizeHeaders(model.requestHeaders) };
+	const authorization = model.apiKey ? sanitizeHeaderValue(`Bearer ${model.apiKey}`) : undefined;
+	if (authorization && !hasAuthorizationHeader(headers)) {
+		headers.Authorization = authorization;
+	}
+	return headers;
+}
+
+function toCustomCompletionModel(value: unknown): CustomCompletionModelConfig | undefined {
+	if (!value || typeof value !== 'object') {
+		return undefined;
+	}
+
+	const candidate = value as Record<string, unknown>;
+	const id = readNonEmptyString(candidate.id);
+	const url = readNonEmptyString(candidate.url);
+	if (!id || !url) {
+		return undefined;
+	}
+
+	const name = readNonEmptyString(candidate.name);
+	const model = readNonEmptyString(candidate.model);
+	const apiKey = readNonEmptyString(candidate.apiKey);
+	const tokenizer = readTokenizer(candidate.tokenizer);
+	const requestHeaders = sanitizeHeaders(candidate.requestHeaders);
+
+	return {
+		id,
+		url,
+		...(name ? { name } : {}),
+		...(model ? { model } : {}),
+		...(apiKey ? { apiKey } : {}),
+		...(tokenizer ? { tokenizer } : {}),
+		...(Object.keys(requestHeaders).length > 0 ? { requestHeaders } : {}),
+	};
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+	if (typeof value !== 'string') {
+		return undefined;
+	}
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readTokenizer(value: unknown): TokenizerName | undefined {
+	if (value === TokenizerName.cl100k || value === TokenizerName.o200k || value === TokenizerName.mock) {
+		return value;
+	}
+	return undefined;
+}
+
+function sanitizeHeaders(value: unknown): Record<string, string> {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return {};
+	}
+
+	const headers: Record<string, string> = {};
+	for (const [key, headerValue] of Object.entries(value)) {
+		const headerName = key.trim();
+		if (!isValidHeaderName(headerName) || typeof headerValue !== 'string') {
+			continue;
+		}
+		const sanitizedValue = sanitizeHeaderValue(headerValue);
+		if (sanitizedValue === undefined) {
+			continue;
+		}
+		headers[headerName] = sanitizedValue;
+	}
+	return headers;
+}
+
+function isValidHeaderName(value: string): boolean {
+	return value.length > 0 && /^[!#$%&'*+\-.0-9A-Z^_`a-z|~]+$/.test(value);
+}
+
+function sanitizeHeaderValue(value: string): string | undefined {
+	const trimmed = value.trim();
+	if (trimmed.length === 0 || trimmed.length > 8192 || /[\x00-\x1F\x7F]/.test(trimmed)) {
+		return undefined;
+	}
+	return trimmed;
+}
+
+function hasAuthorizationHeader(headers: Record<string, string>): boolean {
+	return Object.keys(headers).some(key => {
+		const lowerKey = key.toLowerCase();
+		return lowerKey === 'authorization' || lowerKey === 'api-key' || lowerKey === 'x-api-key' || lowerKey === 'x-goog-api-key' || lowerKey === 'apikey';
+	});
+}
+
+function hasExplicitCompletionsPath(url: string): boolean {
+	return /\/completions\/?$/.test(url);
+}
+
+function parseUrl(url: string): URL | undefined {
+	try {
+		return new URL(url);
+	} catch {
+		return undefined;
+	}
+}
+
+function resolveCustomCompletionModelUrlString(url: string): string {
+	if (hasExplicitCompletionsPath(url)) {
+		return url;
+	}
+
+	if (url.endsWith('/')) {
+		url = url.slice(0, -1);
+	}
+
+	if (/\/v\d+$/.test(url)) {
+		return `${url}/completions`;
+	}
+
+	return `${url}/v1/completions`;
+}

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/openai/fetch.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/openai/fetch.ts
@@ -39,6 +39,8 @@ import {
 import { delay } from '../util/async';
 import { ICompletionsRuntimeModeService } from '../util/runtimeMode';
 import { getKey } from '../util/unknown';
+import { getCustomCompletionModel, getCustomCompletionModelHeaders, resolveCustomCompletionModelUrl } from './customCompletionModels';
+import { ICompletionsModelManagerService } from './model';
 import {
 	APIChoice,
 	APIJsonData,
@@ -68,6 +70,8 @@ type BaseFetchRequest = {
  * API request.
  */
 type CompletionFetchRequestFields = {
+	/** Model name to send to an OpenAI-compatible completions endpoint. */
+	model?: string;
 	/** The prompt suffix to send to the model. */
 	suffix: string;
 	/** Whether to stream back a response in SSE format. Always true: non streaming requests are not supported by this proxy */
@@ -353,7 +357,8 @@ export class LiveOpenAIFetcher extends OpenAIFetcher {
 			return { type: 'canceled', reason: this.#disabledReason };
 		}
 		const endpoint = 'completions';
-		const copilotToken = this.copilotTokenManager.token ?? await this.copilotTokenManager.getToken();
+		const customCompletionModel = this.getResolvedCustomCompletionModel(params.engineModelId);
+		const copilotToken = customCompletionModel ? undefined : this.copilotTokenManager.token ?? await this.copilotTokenManager.getToken();
 
 		const request: CompletionRequest = {
 			prompt: params.prompt.prefix,
@@ -366,6 +371,9 @@ export class LiveOpenAIFetcher extends OpenAIFetcher {
 			stream: true, // Always true: non streaming requests are not supported by this proxy
 			extra: params.extra,
 		} satisfies CompletionRequest;
+		if (customCompletionModel) {
+			request.model = customCompletionModel.model ?? customCompletionModel.id;
+		}
 
 		{
 
@@ -401,7 +409,9 @@ export class LiveOpenAIFetcher extends OpenAIFetcher {
 			const telemetryExp = baseTelemetryData;
 			const uiKind = params.uiKind;
 			const headers = params.headers;
-			const uri = this.instantiationService.invokeFunction(getProxyEngineUrl, copilotToken, engineModelId, endpoint);
+			const uri = customCompletionModel
+				? resolveCustomCompletionModelUrl(customCompletionModel)
+				: this.instantiationService.invokeFunction(getProxyEngineUrl, copilotToken!, engineModelId, endpoint);
 
 			const telemetryData = telemetryExp.extendedBy(
 				{
@@ -427,19 +437,27 @@ export class LiveOpenAIFetcher extends OpenAIFetcher {
 			let fullHeaders: Record<string, string>;
 
 			{
-				fullHeaders = {
-					...headers,
-					...this.instantiationService.invokeFunction(editorVersionHeaders),
-				};
+				if (customCompletionModel) {
+					fullHeaders = {
+						...headers,
+						...getCustomCompletionModelHeaders(customCompletionModel),
+						'X-Request-Id': ourRequestId,
+					};
+				} else {
+					fullHeaders = {
+						...headers,
+						...this.instantiationService.invokeFunction(editorVersionHeaders),
+					};
 
-				fullHeaders['Openai-Organization'] = 'github-copilot';
-				fullHeaders['X-Request-Id'] = ourRequestId;
-				fullHeaders['VScode-SessionId'] = this.envService.sessionId;
-				fullHeaders['VScode-MachineId'] = this.envService.machineId;
-				fullHeaders['X-GitHub-Api-Version'] = apiVersion;
+					fullHeaders['Openai-Organization'] = 'github-copilot';
+					fullHeaders['X-Request-Id'] = ourRequestId;
+					fullHeaders['VScode-SessionId'] = this.envService.sessionId;
+					fullHeaders['VScode-MachineId'] = this.envService.machineId;
+					fullHeaders['X-GitHub-Api-Version'] = apiVersion;
 
-				if (intent) {
-					fullHeaders['OpenAI-Intent'] = intent;
+					if (intent) {
+						fullHeaders['OpenAI-Intent'] = intent;
+					}
 				}
 			}
 
@@ -447,7 +465,7 @@ export class LiveOpenAIFetcher extends OpenAIFetcher {
 			const cancelToken = cancel ?? CancellationToken.None;
 			const res = await this.fetchService.fetch(
 				uri,
-				copilotToken.token,
+				copilotToken?.token,
 				request,
 				ourRequestId,
 				cancelToken,
@@ -459,7 +477,7 @@ export class LiveOpenAIFetcher extends OpenAIFetcher {
 					return this.fetchService.disconnectAll().then(() => {
 						return this.fetchService.fetch(
 							uri,
-							copilotToken.token,
+							copilotToken?.token,
 							request,
 							ourRequestId,
 							cancelToken,
@@ -790,12 +808,31 @@ export class LiveOpenAIFetcher extends OpenAIFetcher {
 		}
 	}
 
+	private getResolvedCustomCompletionModel(modelId: string) {
+		const modelItem = this.instantiationService.invokeFunction(accessor =>
+			accessor.get(ICompletionsModelManagerService).getGenericCompletionModels().find(model => model.modelId === modelId)
+		);
+		if (!modelItem?.custom) {
+			return undefined;
+		}
+		return this.instantiationService.invokeFunction(getCustomCompletionModel, modelId);
+	}
+
 	async handleError(
 		statusReporter: ICompletionsStatusReporter,
 		telemetryData: TelemetryData,
 		response: { status: number; text(): Promise<string>; headers: IHeaders },
-		copilotToken: CopilotToken
+		copilotToken: CopilotToken | undefined
 	): Promise<CompletionError> {
+		if (!copilotToken) {
+			const reason = `custom completion endpoint returned ${response.status}`;
+			statusReporter.setWarning(reason);
+			telemetryData.properties.error = reason;
+			telemetryData.properties.status = String(response.status);
+			this.instantiationService.invokeFunction(telemetry, 'request.shownWarning', telemetryData);
+			return { type: 'failed', reason };
+		}
+
 		const text = await response.text();
 		if (response.status === 402) {
 			this.#disabledReason = 'monthly free code completions exhausted';

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/openai/fetch.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/openai/fetch.ts
@@ -504,10 +504,12 @@ export class LiveOpenAIFetcher extends OpenAIFetcher {
 						this.instantiationService.invokeFunction(telemetry, 'request.cancel', telemetryData);
 						return { type: 'canceled', reason: 'during fetch request' };
 					} else if (err instanceof Completions.UnsuccessfulResponse) {
-						const modelRequestId = getRequestId(err.headers);
-						telemetryData.extendWithRequestId(modelRequestId);
-						if (modelRequestId.serverExperiments) {
-							this.instantiationService.invokeFunction(accessor => accessor.get(ITelemetryService).setSharedProperty('capi.assignmentcontext', modelRequestId.serverExperiments));
+						if (!customCompletionModel) {
+							const modelRequestId = getRequestId(err.headers);
+							telemetryData.extendWithRequestId(modelRequestId);
+							if (modelRequestId.serverExperiments) {
+								this.instantiationService.invokeFunction(accessor => accessor.get(ITelemetryService).setSharedProperty('capi.assignmentcontext', modelRequestId.serverExperiments));
+							}
 						}
 						const totalTimeMs = requestSw.elapsed();
 						telemetryData.measurements.totalTimeMs = totalTimeMs;
@@ -567,10 +569,12 @@ export class LiveOpenAIFetcher extends OpenAIFetcher {
 				{
 					// This ID is hopefully the one the same as ourRequestId, but it is not guaranteed.
 					// If they are different then we will override the original one we set in telemetryData above.
-					const modelRequestId = responseStream.requestId;
-					telemetryData.extendWithRequestId(modelRequestId);
-					if (modelRequestId.serverExperiments) {
-						this.instantiationService.invokeFunction(accessor => accessor.get(ITelemetryService).setSharedProperty('capi.assignmentcontext', modelRequestId.serverExperiments));
+					if (!customCompletionModel) {
+						const modelRequestId = responseStream.requestId;
+						telemetryData.extendWithRequestId(modelRequestId);
+						if (modelRequestId.serverExperiments) {
+							this.instantiationService.invokeFunction(accessor => accessor.get(ITelemetryService).setSharedProperty('capi.assignmentcontext', modelRequestId.serverExperiments));
+						}
 					}
 
 					// TODO: Add response length (requires parsing)
@@ -608,7 +612,7 @@ export class LiveOpenAIFetcher extends OpenAIFetcher {
 				return {
 					type: 'success',
 					choices: postProcessChoices(choices),
-					getProcessingTime: () => getProcessingTime(responseStream.headers),
+					getProcessingTime: () => customCompletionModel ? 0 : getProcessingTime(responseStream.headers),
 				};
 
 			} finally {

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/openai/model.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/openai/model.ts
@@ -16,7 +16,8 @@ import { ConfigKey, getConfig } from '../config';
 import { ICompletionsFeaturesService } from '../experiments/featuresService';
 import { ICompletionsLogTargetService, LogLevel } from '../logger';
 import { TelemetryWithExp } from '../telemetry';
-import { CompletionHeaders } from './fetch';
+import { getCustomCompletionModels } from './customCompletionModels';
+import type { CompletionHeaders } from './fetch';
 
 export const ICompletionsModelManagerService = createServiceIdentifier<ICompletionsModelManagerService>('ICompletionsModelManagerService');
 export interface ICompletionsModelManagerService {
@@ -34,6 +35,7 @@ export class AvailableModelsManager extends Disposable implements ICompletionsMo
 	fetchedModelData: ICompletionModelInformation[] = [];
 	customModels: string[] = [];
 	editorPreviewFeaturesDisabled: boolean = false;
+	private readonly _loggedIgnoredCustomCompletionModelIds = new Set<string>();
 	private readonly _onDidChangeModels = this._register(new Emitter<void>());
 	readonly onDidChangeModels = this._onDidChangeModels.event;
 
@@ -93,8 +95,34 @@ export class AvailableModelsManager extends Disposable implements ICompletionsMo
 			this.fetchedModelData,
 			this.editorPreviewFeaturesDisabled
 		);
+		const hostedModels = AvailableModelsManager.mapCompletionModels(filteredResult);
+		const hostedModelIds = new Set(hostedModels.map(model => model.modelId));
+		const modelIds = new Set(hostedModelIds);
+		const customModels: ModelItem[] = [];
+		for (const model of this._instantiationService.invokeFunction(getCustomCompletionModels)) {
+			if (modelIds.has(model.id)) {
+				const collisionType = hostedModelIds.has(model.id) ? 'hosted' : 'custom';
+				const logKey = `${collisionType}:${model.id}`;
+				if (!this._loggedIgnoredCustomCompletionModelIds.has(logKey)) {
+					this._loggedIgnoredCustomCompletionModelIds.add(logKey);
+					this._logService.logIt(LogLevel.INFO, `Ignoring custom completion model ${model.id} because it conflicts with a ${collisionType} completion model.`);
+				}
+				continue;
+			}
+			modelIds.add(model.id);
+			customModels.push({
+				modelId: model.id,
+				label: model.name ?? model.id,
+				preview: false,
+				tokenizer: model.tokenizer ?? TokenizerName.o200k,
+				custom: true,
+			});
+		}
 
-		return AvailableModelsManager.mapCompletionModels(filteredResult);
+		return [
+			...hostedModels,
+			...customModels,
+		];
 	}
 
 	getTokenizerForModel(modelId: string): TokenizerName {
@@ -133,9 +161,10 @@ export class AvailableModelsManager extends Disposable implements ICompletionsMo
 
 	getCurrentModelRequestInfo(featureSettings: TelemetryWithExp | undefined = undefined): ModelRequestInfo {
 		const defaultModelId = this.getDefaultModelId();
+		const genericModelItems = this.getGenericCompletionModels();
 		let userSelectedCompletionModel = this._instantiationService.invokeFunction(getUserSelectedModelConfiguration);
 		if (userSelectedCompletionModel) {
-			const genericModels = this.getGenericCompletionModels().map(model => model.modelId);
+			const genericModels = genericModelItems.map(model => model.modelId);
 			if (!genericModels.includes(userSelectedCompletionModel)) {
 				if (genericModels.length > 0) {
 					this._logService.logIt(
@@ -167,6 +196,10 @@ export class AvailableModelsManager extends Disposable implements ICompletionsMo
 				return new ModelRequestInfo(customEngine, 'exp');
 			}
 
+			if (genericModelItems.find(model => model.modelId === userSelectedCompletionModel)?.custom) {
+				return new ModelRequestInfo(userSelectedCompletionModel, 'custommodel');
+			}
+
 			return new ModelRequestInfo(userSelectedCompletionModel, 'modelpicker');
 		}
 
@@ -187,6 +220,7 @@ export interface ModelItem {
 	label: string;
 	preview: boolean;
 	tokenizer: string;
+	custom?: boolean;
 }
 
 export type ModelChoiceSourceTelemetryValue =

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/openai/test/fetch.test.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/openai/test/fetch.test.ts
@@ -6,9 +6,10 @@
 import * as assert from 'assert';
 import * as Sinon from 'sinon';
 import { Completions, ICompletionsFetchService } from '../../../../../../../platform/nesFetch/common/completionsFetchService';
+import { CompletionsFetchService } from '../../../../../../../platform/nesFetch/node/completionsFetchServiceImpl';
 import { ResponseStream } from '../../../../../../../platform/nesFetch/common/responseStream';
 import { ICompletionModelInformation } from '../../../../../../../platform/endpoint/common/endpointProvider';
-import { HeadersImpl } from '../../../../../../../platform/networking/common/fetcherService';
+import { FetchOptions, HeadersImpl, Response } from '../../../../../../../platform/networking/common/fetcherService';
 import { TestingServiceCollection } from '../../../../../../../platform/test/node/services';
 import { TokenizerType } from '../../../../../../../util/common/tokenizer';
 import { Result } from '../../../../../../../util/common/result';
@@ -293,7 +294,13 @@ suite('"Fetch" unit tests', function () {
 		mockFetchService.nextResult = Result.error(new Completions.UnsuccessfulResponse(
 			401,
 			'status text',
-			new HeadersImpl({}),
+			new HeadersImpl({
+				'x-request-id': 'custom-request-id',
+				'x-github-request-id': 'custom-github-request-id',
+				'X-Copilot-Experiment': 'custom-experiment',
+				'x-copilot-api-exp-assignment-context': 'custom-assignment',
+				'azureml-model-deployment': 'custom-deployment',
+			}),
 			() => Promise.resolve('missing local key')
 		));
 		const serviceCollectionClone = serviceCollection.clone();
@@ -331,6 +338,172 @@ suite('"Fetch" unit tests', function () {
 		const telemetryJson = JSON.stringify(reporter.events);
 		assert.strictEqual(telemetryJson.includes('missing local key'), false);
 		assert.strictEqual(telemetryJson.includes('custom completion endpoint returned 401'), true);
+		assert.strictEqual(telemetryJson.includes('custom-request-id'), false);
+		assert.strictEqual(telemetryJson.includes('custom-github-request-id'), false);
+		assert.strictEqual(telemetryJson.includes('custom-experiment'), false);
+		assert.strictEqual(telemetryJson.includes('custom-assignment'), false);
+		assert.strictEqual(telemetryJson.includes('custom-deployment'), false);
+	});
+
+	test('custom completion success responses do not propagate custom endpoint request IDs', async function () {
+		const maliciousHeaders = new HeadersImpl({
+			'x-request-id': 'custom-request-id',
+			'x-github-request-id': 'custom-github-request-id',
+			'X-Copilot-Experiment': 'custom-experiment',
+			'x-copilot-api-exp-assignment-context': 'custom-assignment',
+			'azureml-model-deployment': 'custom-deployment',
+		});
+		const responseBody = `data: ${JSON.stringify({
+			choices: [{
+				index: 0,
+				finish_reason: 'stop',
+				logprobs: null,
+				text: ' completion',
+			}],
+			system_fingerprint: 'custom-system',
+			object: 'text_completion',
+		})}\n\ndata: [DONE]\n\n`;
+		const fetcherService = {
+			fetch: async (_url: string, _options: FetchOptions) => Response.fromText(200, 'OK', maliciousHeaders, responseBody, 'test-stub'),
+			makeAbortController: () => {
+				const abortController = new AbortController();
+				return {
+					signal: abortController.signal,
+					abort: () => abortController.abort(),
+				};
+			},
+			disconnectAll: async () => undefined,
+		};
+		const completionsFetchService = new CompletionsFetchService(
+			{} as any,
+			fetcherService as any,
+			{ addEntry() { } } as any,
+		);
+
+		const result = await completionsFetchService.fetch(
+			'http://127.0.0.1:8080/v1/completions',
+			undefined,
+			{
+				prompt: 'const value = ',
+				suffix: ';',
+				stream: true,
+				max_tokens: 16,
+				n: 1,
+				temperature: 0,
+				top_p: 1,
+				stop: [],
+				extra: {},
+			},
+			generateUuid(),
+			CancellationToken.None,
+		);
+
+		assert.strictEqual(result.isOk(), true);
+		if (result.isError()) {
+			throw new Error('expected custom completion request to succeed');
+		}
+		assert.deepStrictEqual(result.val.requestId, {
+			headerRequestId: '',
+			gitHubRequestId: '',
+			completionId: '',
+			created: 0,
+			serverExperiments: '',
+			deploymentId: '',
+		});
+
+		const choices = LiveOpenAIFetcher.convertStreamToApiChoices(
+			result.val,
+			() => undefined,
+			TelemetryWithExp.createEmptyConfigForTesting(),
+			CancellationToken.None,
+		);
+		const collectedChoices = [];
+		for await (const choice of choices) {
+			collectedChoices.push(choice);
+		}
+
+		assert.strictEqual(collectedChoices.length, 1);
+		assert.strictEqual(collectedChoices[0].completionText, ' completion');
+		assert.strictEqual(collectedChoices[0].requestId.headerRequestId, '');
+		assert.strictEqual(collectedChoices[0].requestId.gitHubRequestId, '');
+		assert.strictEqual(collectedChoices[0].requestId.serverExperiments, '');
+		assert.strictEqual(collectedChoices[0].requestId.deploymentId, '');
+	});
+
+	test('custom completion success responses ignore custom endpoint processing time headers', async function () {
+		const maliciousHeaders = new HeadersImpl({
+			'openai-processing-ms': '98765',
+		});
+		async function* completions() {
+			yield {
+				choices: [{
+					index: 0,
+					finish_reason: null,
+					logprobs: null,
+					text: ' completion',
+				}],
+				system_fingerprint: 'custom-system',
+				object: 'text_completion',
+				usage: undefined,
+			};
+		}
+		const mockResponse = Response.fromText(200, 'OK', maliciousHeaders, '', 'test-stub');
+		const responseStream = new ResponseStream(
+			mockResponse,
+			completions(),
+			{
+				headerRequestId: '',
+				gitHubRequestId: '',
+				completionId: '',
+				created: 0,
+				serverExperiments: '',
+				deploymentId: '',
+			},
+			maliciousHeaders,
+		);
+		const mockFetchService = new MockCompletionsFetchService();
+		mockFetchService.nextResult = Result.ok(responseStream);
+		const serviceCollectionClone = serviceCollection.clone();
+		serviceCollectionClone.define(ICompletionsFetchService, mockFetchService);
+		const accessor = serviceCollectionClone.createTestingAccessor();
+		const configProvider = accessor.get(ICompletionsConfigProvider) as InMemoryConfigProvider;
+		configProvider.setConfig(ConfigKey.CustomCompletionModels, [{
+			id: 'local-gemma',
+			url: 'http://127.0.0.1:8080',
+		}]);
+
+		const openAIFetcher = accessor.get(IInstantiationService).createInstance(LiveOpenAIFetcher);
+		const result = await openAIFetcher.fetchAndStreamCompletions(
+			{
+				prompt: {
+					prefix: 'const value = ',
+					suffix: ';',
+					isFimEnabled: true,
+				},
+				languageId: 'typescript',
+				repoInfo: undefined,
+				engineModelId: 'local-gemma',
+				count: 1,
+				uiKind: CopilotUiKind.GhostText,
+				ourRequestId: generateUuid(),
+				extra: {},
+			},
+			TelemetryWithExp.createEmptyConfigForTesting(),
+			() => undefined
+		);
+
+		assert.strictEqual(result.type, 'success');
+		if (result.type !== 'success') {
+			throw new Error('expected custom completion request to succeed');
+		}
+		assert.strictEqual(result.getProcessingTime(), 0);
+
+		const collectedChoices = [];
+		for await (const choice of result.choices) {
+			collectedChoices.push(choice);
+		}
+		assert.strictEqual(collectedChoices.length, 1);
+		assert.strictEqual(collectedChoices[0].completionText, ' completion');
 	});
 
 	test('custom completion model IDs that collide with hosted models use the hosted completion route', async function () {

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/openai/test/fetch.test.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/openai/test/fetch.test.ts
@@ -7,8 +7,10 @@ import * as assert from 'assert';
 import * as Sinon from 'sinon';
 import { Completions, ICompletionsFetchService } from '../../../../../../../platform/nesFetch/common/completionsFetchService';
 import { ResponseStream } from '../../../../../../../platform/nesFetch/common/responseStream';
+import { ICompletionModelInformation } from '../../../../../../../platform/endpoint/common/endpointProvider';
 import { HeadersImpl } from '../../../../../../../platform/networking/common/fetcherService';
 import { TestingServiceCollection } from '../../../../../../../platform/test/node/services';
+import { TokenizerType } from '../../../../../../../util/common/tokenizer';
 import { Result } from '../../../../../../../util/common/result';
 import { CancellationToken } from '../../../../../../../util/vs/base/common/cancellation';
 import { generateUuid } from '../../../../../../../util/vs/base/common/uuid';
@@ -16,6 +18,7 @@ import { SyncDescriptor } from '../../../../../../../util/vs/platform/instantiat
 import { IInstantiationService, ServicesAccessor } from '../../../../../../../util/vs/platform/instantiation/common/instantiation';
 import { CancellationTokenSource } from '../../../../types/src';
 import { ICompletionsCopilotTokenManager } from '../../auth/copilotTokenManager';
+import { ConfigKey, ICompletionsConfigProvider, InMemoryConfigProvider } from '../../config';
 import { ICompletionsStatusReporter, StatusChangedEvent, StatusReporter } from '../../progress';
 import { TelemetryWithExp } from '../../telemetry';
 import { createLibTestingContext } from '../../test/context';
@@ -28,6 +31,7 @@ import {
 	LiveOpenAIFetcher, sanitizeRequestOptionTelemetry
 } from '../fetch';
 import { SyntheticCompletions } from '../fetch.fake';
+import { AvailableModelsManager, ICompletionsModelManagerService } from '../model';
 
 suite('"Fetch" unit tests', function () {
 	let accessor: ServicesAccessor;
@@ -241,6 +245,136 @@ suite('"Fetch" unit tests', function () {
 		assert.strictEqual(recordingFetchService.lastHeaders?.['Host'], 'bla');
 	});
 
+	test('custom completion models route to the configured endpoint without Copilot bearer auth', async function () {
+		const recordingFetchService = new MockCompletionsFetchService();
+		const params: CompletionParams = {
+			prompt: {
+				prefix: 'function add(a, b) {',
+				suffix: '\n}',
+				isFimEnabled: true,
+			},
+			languageId: 'javascript',
+			repoInfo: undefined,
+			engineModelId: 'local-gemma',
+			count: 1,
+			uiKind: CopilotUiKind.GhostText,
+			ourRequestId: generateUuid(),
+			extra: {},
+		};
+		const serviceCollectionClone = serviceCollection.clone();
+		serviceCollectionClone.define(ICompletionsFetchService, recordingFetchService);
+		const accessor = serviceCollectionClone.createTestingAccessor();
+		const configProvider = accessor.get(ICompletionsConfigProvider) as InMemoryConfigProvider;
+		configProvider.setConfig(ConfigKey.CustomCompletionModels, [{
+			id: 'local-gemma',
+			model: 'gemma-4-e4b-it-qat',
+			url: 'http://127.0.0.1:8080',
+			requestHeaders: {
+				'X-Local-Model': '1',
+			},
+		}]);
+
+		const openAIFetcher = accessor.get(IInstantiationService).createInstance(LiveOpenAIFetcher);
+		await openAIFetcher.fetchAndStreamCompletions(
+			params,
+			TelemetryWithExp.createEmptyConfigForTesting(),
+			() => undefined
+		);
+
+		assert.strictEqual(recordingFetchService.lastUrl, 'http://127.0.0.1:8080/v1/completions');
+		assert.strictEqual(recordingFetchService.lastSecretKey, undefined);
+		assert.strictEqual(recordingFetchService.lastParams?.model, 'gemma-4-e4b-it-qat');
+		assert.strictEqual(recordingFetchService.lastHeaders?.['X-Local-Model'], '1');
+		assert.strictEqual(recordingFetchService.lastHeaders?.['Openai-Organization'], undefined);
+	});
+
+	test('custom completion model auth errors do not reset Copilot token', async function () {
+		const mockFetchService = new MockCompletionsFetchService();
+		mockFetchService.nextResult = Result.error(new Completions.UnsuccessfulResponse(
+			401,
+			'status text',
+			new HeadersImpl({}),
+			() => Promise.resolve('missing local key')
+		));
+		const serviceCollectionClone = serviceCollection.clone();
+		serviceCollectionClone.define(ICompletionsFetchService, mockFetchService);
+		const accessor = serviceCollectionClone.createTestingAccessor();
+		const configProvider = accessor.get(ICompletionsConfigProvider) as InMemoryConfigProvider;
+		configProvider.setConfig(ConfigKey.CustomCompletionModels, [{
+			id: 'local-gemma',
+			url: 'http://127.0.0.1:8080',
+		}]);
+		resetSpy.resetHistory();
+		const openAIFetcher = accessor.get(IInstantiationService).createInstance(LiveOpenAIFetcher);
+
+		const { reporter, result } = await withInMemoryTelemetry(accessor, () => openAIFetcher.fetchAndStreamCompletions(
+			{
+				prompt: {
+					prefix: 'const value = ',
+					suffix: ';',
+					isFimEnabled: true,
+				},
+				languageId: 'typescript',
+				repoInfo: undefined,
+				engineModelId: 'local-gemma',
+				count: 1,
+				uiKind: CopilotUiKind.GhostText,
+				ourRequestId: generateUuid(),
+				extra: {},
+			},
+			TelemetryWithExp.createEmptyConfigForTesting(),
+			() => undefined
+		));
+
+		assert.deepStrictEqual(result, { type: 'failed', reason: 'custom completion endpoint returned 401' });
+		assert.strictEqual(resetSpy.called, false);
+		const telemetryJson = JSON.stringify(reporter.events);
+		assert.strictEqual(telemetryJson.includes('missing local key'), false);
+		assert.strictEqual(telemetryJson.includes('custom completion endpoint returned 401'), true);
+	});
+
+	test('custom completion model IDs that collide with hosted models use the hosted completion route', async function () {
+		const recordingFetchService = new MockCompletionsFetchService();
+		const serviceCollectionClone = serviceCollection.clone();
+		serviceCollectionClone.define(ICompletionsFetchService, recordingFetchService);
+		const accessor = serviceCollectionClone.createTestingAccessor();
+		const configProvider = accessor.get(ICompletionsConfigProvider) as InMemoryConfigProvider;
+		configProvider.setConfig(ConfigKey.CustomCompletionModels, [{
+			id: 'gpt-41-copilot',
+			url: 'http://127.0.0.1:8080',
+			requestHeaders: {
+				'X-Local-Model': '1',
+			},
+		}]);
+		const modelManager = accessor.get(ICompletionsModelManagerService) as AvailableModelsManager;
+		modelManager.fetchedModelData = [hostedCompletionModel('gpt-41-copilot')];
+
+		const openAIFetcher = accessor.get(IInstantiationService).createInstance(LiveOpenAIFetcher);
+		await openAIFetcher.fetchAndStreamCompletions(
+			{
+				prompt: {
+					prefix: 'function add(a, b) {',
+					suffix: '\n}',
+					isFimEnabled: true,
+				},
+				languageId: 'javascript',
+				repoInfo: undefined,
+				engineModelId: 'gpt-41-copilot',
+				count: 1,
+				uiKind: CopilotUiKind.GhostText,
+				ourRequestId: generateUuid(),
+				extra: {},
+			},
+			TelemetryWithExp.createEmptyConfigForTesting(),
+			() => undefined
+		);
+
+		assert.notStrictEqual(recordingFetchService.lastSecretKey, undefined);
+		assert.strictEqual(recordingFetchService.lastParams?.model, undefined);
+		assert.strictEqual(recordingFetchService.lastHeaders?.['X-Local-Model'], undefined);
+		assert.ok(recordingFetchService.lastUrl?.includes('/gpt-41-copilot/'));
+	});
+
 });
 
 suite('Telemetry sent on fetch', function () {
@@ -426,17 +560,21 @@ class MockCompletionsFetchService implements ICompletionsFetchService {
 	declare _serviceBrand: undefined;
 
 	nextResult: Result<ResponseStream, Completions.CompletionsFetchFailure> | undefined;
+	lastUrl: string | undefined;
+	lastSecretKey: string | undefined;
 	lastParams: Completions.ModelParams | undefined;
 	lastHeaders: Record<string, string> | undefined;
 
 	async fetch(
-		_url: string,
-		_secretKey: string,
+		url: string,
+		secretKey: string | undefined,
 		params: Completions.ModelParams,
 		_requestId: string,
 		_ct: CancellationToken,
 		headerOverrides?: Record<string, string>
 	): Promise<Result<ResponseStream, Completions.CompletionsFetchFailure>> {
+		this.lastUrl = url;
+		this.lastSecretKey = secretKey;
 		this.lastParams = params;
 		this.lastHeaders = headerOverrides;
 		if (this.nextResult) {
@@ -449,4 +587,22 @@ class MockCompletionsFetchService implements ICompletionsFetchService {
 	}
 
 	async disconnectAll() { }
+}
+
+function hostedCompletionModel(id: string): ICompletionModelInformation {
+	return {
+		id,
+		vendor: 'github',
+		name: id,
+		model_picker_enabled: true,
+		preview: false,
+		is_chat_default: false,
+		is_chat_fallback: false,
+		version: '1',
+		capabilities: {
+			type: 'completion',
+			family: id,
+			tokenizer: TokenizerType.O200K,
+		},
+	};
 }

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/openai/test/model.test.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/openai/test/model.test.ts
@@ -1,0 +1,289 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ICompletionModelInformation } from '../../../../../../../platform/endpoint/common/endpointProvider';
+import { TokenizerType } from '../../../../../../../util/common/tokenizer';
+import { ServicesAccessor } from '../../../../../../../util/vs/platform/instantiation/common/instantiation';
+import { TokenizerName } from '../../../../prompt/src/tokenization';
+import { ConfigKey, ICompletionsConfigProvider, InMemoryConfigProvider } from '../../config';
+import { ICompletionsLogTargetService, LogLevel } from '../../logger';
+import { createLibTestingContext } from '../../test/context';
+import { getCustomCompletionModelHeaders, resolveCustomCompletionModelUrl } from '../customCompletionModels';
+import { AvailableModelsManager, ICompletionsModelManagerService } from '../model';
+
+suite('AvailableModelsManager', function () {
+	let accessor: ServicesAccessor;
+	let manager: AvailableModelsManager;
+	let configProvider: InMemoryConfigProvider;
+
+	setup(function () {
+		const serviceCollection = createLibTestingContext();
+		accessor = serviceCollection.createTestingAccessor();
+		manager = accessor.get(ICompletionsModelManagerService) as AvailableModelsManager;
+		manager.fetchedModelData = [hostedCompletionModel()];
+		configProvider = accessor.get(ICompletionsConfigProvider) as InMemoryConfigProvider;
+	});
+
+	test('includes custom completion models in generic completion models', function () {
+		configProvider.setConfig(ConfigKey.CustomCompletionModels, [{
+			id: 'local-gemma',
+			name: 'Local Gemma',
+			url: 'http://127.0.0.1:8080',
+			tokenizer: TokenizerName.cl100k,
+		}]);
+
+		const models = manager.getGenericCompletionModels();
+
+		assert.deepStrictEqual(models.map(model => ({
+			modelId: model.modelId,
+			label: model.label,
+			tokenizer: model.tokenizer,
+			custom: model.custom,
+		})), [
+			{
+				modelId: 'gpt-41-copilot',
+				label: 'GPT 4.1 Copilot',
+				tokenizer: TokenizerName.o200k,
+				custom: undefined,
+			},
+			{
+				modelId: 'local-gemma',
+				label: 'Local Gemma',
+				tokenizer: TokenizerName.cl100k,
+				custom: true,
+			},
+		]);
+		assert.strictEqual(manager.getTokenizerForModel('local-gemma'), TokenizerName.cl100k);
+	});
+
+	test('preserves a selected custom completion model', function () {
+		configProvider.setConfig(ConfigKey.CustomCompletionModels, [{
+			id: 'local-gemma',
+			url: 'http://127.0.0.1:8080',
+		}]);
+		configProvider.setConfig(ConfigKey.UserSelectedCompletionModel, 'local-gemma');
+
+		const requestInfo = manager.getCurrentModelRequestInfo();
+
+		assert.strictEqual(requestInfo.modelId, 'local-gemma');
+		assert.strictEqual(requestInfo.modelChoiceSource, 'custommodel');
+	});
+
+	test('ignores custom completion models that collide with hosted model IDs', function () {
+		manager.fetchedModelData = [
+			hostedCompletionModel('gpt-41-copilot', 'GPT 4.1 Copilot'),
+			hostedCompletionModel('gpt-5-copilot', 'GPT 5 Copilot'),
+		];
+		configProvider.setConfig(ConfigKey.CustomCompletionModels, [{
+			id: 'gpt-5-copilot',
+			name: 'Shadowed Custom Model',
+			url: 'http://127.0.0.1:8080',
+		}]);
+		configProvider.setConfig(ConfigKey.UserSelectedCompletionModel, 'gpt-5-copilot');
+
+		const models = manager.getGenericCompletionModels();
+		const requestInfo = manager.getCurrentModelRequestInfo();
+
+		assert.deepStrictEqual(models.map(model => ({
+			modelId: model.modelId,
+			custom: model.custom,
+		})), [
+			{
+				modelId: 'gpt-41-copilot',
+				custom: undefined,
+			},
+			{
+				modelId: 'gpt-5-copilot',
+				custom: undefined,
+			},
+		]);
+		assert.strictEqual(requestInfo.modelId, 'gpt-5-copilot');
+		assert.strictEqual(requestInfo.modelChoiceSource, 'modelpicker');
+	});
+
+	test('ignores duplicate custom completion model IDs', function () {
+		configProvider.setConfig(ConfigKey.CustomCompletionModels, [
+			{
+				id: 'local-gemma',
+				name: 'Local Gemma',
+				url: 'http://127.0.0.1:8080',
+				tokenizer: TokenizerName.cl100k,
+			},
+			{
+				id: 'local-gemma',
+				name: 'Shadowed Local Gemma',
+				url: 'http://127.0.0.1:9090',
+			},
+		]);
+
+		const models = manager.getGenericCompletionModels();
+
+		assert.deepStrictEqual(models.map(model => ({
+			modelId: model.modelId,
+			label: model.label,
+			tokenizer: model.tokenizer,
+			custom: model.custom,
+		})), [
+			{
+				modelId: 'gpt-41-copilot',
+				label: 'GPT 4.1 Copilot',
+				tokenizer: TokenizerName.o200k,
+				custom: undefined,
+			},
+			{
+				modelId: 'local-gemma',
+				label: 'Local Gemma',
+				tokenizer: TokenizerName.cl100k,
+				custom: true,
+			},
+		]);
+	});
+
+	test('logs ignored custom completion model ID collisions once', function () {
+		const serviceCollection = createLibTestingContext();
+		const logService = new TestLogService();
+		serviceCollection.define(ICompletionsLogTargetService, logService);
+		const accessor = serviceCollection.createTestingAccessor();
+		const manager = accessor.get(ICompletionsModelManagerService) as AvailableModelsManager;
+		manager.fetchedModelData = [hostedCompletionModel()];
+		const configProvider = accessor.get(ICompletionsConfigProvider) as InMemoryConfigProvider;
+		configProvider.setConfig(ConfigKey.CustomCompletionModels, [{
+			id: 'gpt-41-copilot',
+			url: 'http://127.0.0.1:8080',
+		}]);
+
+		manager.getGenericCompletionModels();
+		manager.getGenericCompletionModels();
+
+		const ignoredCollisionLogs = logService.entries.filter(entry =>
+			entry.level === LogLevel.INFO &&
+			entry.category.includes('Ignoring custom completion model gpt-41-copilot')
+		);
+		assert.strictEqual(ignoredCollisionLogs.length, 1);
+	});
+});
+
+suite('Custom completion model helpers', function () {
+	test('resolves custom completion model URLs', function () {
+		assert.strictEqual(resolveCustomCompletionModelUrl({
+			id: 'base',
+			url: 'http://127.0.0.1:8080',
+		}), 'http://127.0.0.1:8080/v1/completions');
+		assert.strictEqual(resolveCustomCompletionModelUrl({
+			id: 'versioned',
+			url: 'http://127.0.0.1:8080/v1',
+		}), 'http://127.0.0.1:8080/v1/completions');
+		assert.strictEqual(resolveCustomCompletionModelUrl({
+			id: 'explicit',
+			url: 'http://127.0.0.1:8080/v1/completions',
+		}), 'http://127.0.0.1:8080/v1/completions');
+		assert.strictEqual(resolveCustomCompletionModelUrl({
+			id: 'trailing',
+			url: 'http://127.0.0.1:8080/',
+		}), 'http://127.0.0.1:8080/v1/completions');
+		assert.strictEqual(resolveCustomCompletionModelUrl({
+			id: 'path',
+			url: 'http://127.0.0.1:8080/api',
+		}), 'http://127.0.0.1:8080/api/v1/completions');
+		assert.strictEqual(resolveCustomCompletionModelUrl({
+			id: 'query',
+			url: 'http://127.0.0.1:8080/v1/completions?api-version=1',
+		}), 'http://127.0.0.1:8080/v1/completions?api-version=1');
+	});
+
+	test('sanitizes custom completion model headers', function () {
+		const headers = getCustomCompletionModelHeaders({
+			id: 'local-gemma',
+			url: 'http://127.0.0.1:8080',
+			apiKey: 'secret-key',
+			requestHeaders: {
+				'Authorization': 'Token existing',
+				'X-Good': '  value  ',
+				'Bad Header': 'bad',
+				'X-Control': 'line\nbreak',
+				'X-Empty': '   ',
+			},
+		});
+
+		assert.deepStrictEqual(headers, {
+			Authorization: 'Token existing',
+			'X-Good': 'value',
+		});
+	});
+
+	test('uses custom completion model api key when no auth header is configured', function () {
+		const headers = getCustomCompletionModelHeaders({
+			id: 'local-gemma',
+			url: 'http://127.0.0.1:8080',
+			apiKey: 'secret-key',
+			requestHeaders: {
+				'X-Good': 'value',
+			},
+		});
+
+		assert.deepStrictEqual(headers, {
+			'X-Good': 'value',
+			Authorization: 'Bearer secret-key',
+		});
+	});
+
+	test('does not add custom completion model api key with invalid header characters', function () {
+		const headers = getCustomCompletionModelHeaders({
+			id: 'local-gemma',
+			url: 'http://127.0.0.1:8080',
+			apiKey: 'secret\nkey',
+			requestHeaders: {
+				'X-Good': 'value',
+			},
+		});
+
+		assert.deepStrictEqual(headers, {
+			'X-Good': 'value',
+		});
+	});
+
+	test('does not add custom completion model api key when lowercase auth header is configured', function () {
+		const headers = getCustomCompletionModelHeaders({
+			id: 'local-gemma',
+			url: 'http://127.0.0.1:8080',
+			apiKey: 'secret-key',
+			requestHeaders: {
+				authorization: 'Token existing',
+			},
+		});
+
+		assert.deepStrictEqual(headers, {
+			authorization: 'Token existing',
+		});
+	});
+});
+
+function hostedCompletionModel(id = 'gpt-41-copilot', name = 'GPT 4.1 Copilot'): ICompletionModelInformation {
+	return {
+		id,
+		vendor: 'github',
+		name,
+		model_picker_enabled: true,
+		preview: false,
+		is_chat_default: false,
+		is_chat_fallback: false,
+		version: '1',
+		capabilities: {
+			type: 'completion',
+			family: 'gpt-41-copilot',
+			tokenizer: TokenizerType.O200K,
+		},
+	};
+}
+
+class TestLogService implements ICompletionsLogTargetService {
+	declare _serviceBrand: undefined;
+	readonly entries: { level: LogLevel; category: string; extra: unknown[] }[] = [];
+
+	logIt(level: LogLevel, category: string, ...extra: unknown[]): void {
+		this.entries.push({ level, category, extra });
+	}
+}

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/test/fetcher.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/test/fetcher.ts
@@ -182,7 +182,7 @@ export class StaticCompletionsFetchService implements ICompletionsFetchService {
 	constructor(private readonly fetcher: FakeFetcher) { }
 	async fetch(
 		url: string,
-		_secretKey: string,
+		_secretKey: string | undefined,
 		params: Completions.ModelParams,
 		requestId: string,
 		ct: CancellationToken,

--- a/extensions/copilot/src/extension/completions/vscode-node/completionsCoreContribution.ts
+++ b/extensions/copilot/src/extension/completions/vscode-node/completionsCoreContribution.ts
@@ -10,6 +10,7 @@ import { IExperimentationService } from '../../../platform/telemetry/common/null
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
 import { autorun, observableFromEvent } from '../../../util/vs/base/common/observableInternal';
 import { registerUnificationCommands } from '../../completions-core/vscode-node/completionsServiceBridges';
+import { ICompletionsModelManagerService } from '../../completions-core/vscode-node/lib/src/openai/model';
 import { ICopilotInlineCompletionItemProviderService } from '../common/copilotInlineCompletionItemProviderService';
 import { unificationStateObservable } from './completionsUnificationContribution';
 
@@ -21,24 +22,34 @@ export class CompletionsCoreContribution extends Disposable {
 		@ICopilotInlineCompletionItemProviderService _copilotInlineCompletionItemProviderService: ICopilotInlineCompletionItemProviderService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IExperimentationService experimentationService: IExperimentationService,
-		@IAuthenticationService private readonly authenticationService: IAuthenticationService
+		@IAuthenticationService private readonly authenticationService: IAuthenticationService,
 	) {
 		super();
 
+		const modelManagerService = _copilotInlineCompletionItemProviderService.getOrCreateInstantiationService()
+			.invokeFunction(accessor => accessor.get(ICompletionsModelManagerService));
 		const unificationState = unificationStateObservable(this);
+		const customCompletionModels = configurationService.getConfigObservable(ConfigKey.customCompletionModels);
+		const selectedCompletionsModel = configurationService.getConfigObservable(ConfigKey.selectedCompletionsModel);
+		const completionModelsChanged = observableFromEvent(this, modelManagerService.onDidChangeModels, () => undefined);
 
 		this._register(autorun(reader => {
 			const unificationStateValue = unificationState.read(reader);
 			const configEnabled = configurationService.getExperimentBasedConfigObservable<boolean>(ConfigKey.TeamInternal.InlineEditsEnableGhCompletionsProvider, experimentationService).read(reader);
 			const extensionUnification = unificationStateValue?.extensionUnification ?? false;
 			const copilotToken = this._copilotToken.read(reader);
+			customCompletionModels.read(reader);
+			completionModelsChanged.read(reader);
+			const hasSelectedCustomCompletionModel = isSelectedCustomCompletionModel(
+				selectedCompletionsModel.read(reader),
+				modelManagerService.getGenericCompletionModels()
+			);
 
 			let hasInstantiatedProvider = false;
-			// Completions require a Copilot token to call the completions endpoint, so don't
-			// register the provider in air-gapped / signed-out scenarios — it would just fail
-			// with GitHubLoginFailedError on every keystroke.
-			const wantsProvider = unificationStateValue?.codeUnification || extensionUnification || configEnabled || copilotToken?.isNoAuthUser;
-			if (wantsProvider && copilotToken) {
+			// GitHub-hosted completions require a Copilot token. Custom completion endpoints
+			// can be used independently, so allow the provider when a custom model is selected.
+			const wantsProvider = unificationStateValue?.codeUnification || extensionUnification || configEnabled || copilotToken?.isNoAuthUser || hasSelectedCustomCompletionModel;
+			if (wantsProvider && (copilotToken || hasSelectedCustomCompletionModel)) {
 				const provider = _copilotInlineCompletionItemProviderService.getOrCreateProvider();
 				reader.store.add(
 					languages.registerInlineCompletionItemProvider(
@@ -64,7 +75,20 @@ export class CompletionsCoreContribution extends Disposable {
 
 		this._register(autorun(reader => {
 			const token = this._copilotToken.read(reader);
-			void commands.executeCommand('setContext', 'github.copilot.activated', token !== undefined);
+			customCompletionModels.read(reader);
+			completionModelsChanged.read(reader);
+			const hasSelectedCustomCompletionModel = isSelectedCustomCompletionModel(
+				selectedCompletionsModel.read(reader),
+				modelManagerService.getGenericCompletionModels()
+			);
+			void commands.executeCommand('setContext', 'github.copilot.activated', token !== undefined || hasSelectedCustomCompletionModel);
 		}));
 	}
+}
+
+function isSelectedCustomCompletionModel(selectedCompletionsModel: string, completionModels: readonly { modelId: string; custom?: boolean }[]): boolean {
+	if (!selectedCompletionsModel) {
+		return false;
+	}
+	return completionModels.find(model => model.modelId === selectedCompletionsModel)?.custom === true;
 }

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -953,6 +953,7 @@ export namespace ConfigKey {
 		'scminput': false
 	});
 	export const selectedCompletionsModel = defineSetting<string>('selectedCompletionModel', ConfigType.Simple, '');
+	export const customCompletionModels = defineSetting<readonly unknown[]>('customCompletionModels', ConfigType.Simple, []);
 
 	export const RateLimitAutoSwitchToAuto = defineSetting<boolean>('chat.rateLimitAutoSwitchToAuto', ConfigType.Simple, false, vBoolean());
 

--- a/extensions/copilot/src/platform/nesFetch/common/completionsFetchService.ts
+++ b/extensions/copilot/src/platform/nesFetch/common/completionsFetchService.ts
@@ -88,7 +88,7 @@ export interface ICompletionsFetchService {
 
 	fetch(
 		url: string,
-		secretKey: string,
+		secretKey: string | undefined,
 		params: Completions.ModelParams,
 		requestId: string,
 		ct: CancellationToken,

--- a/extensions/copilot/src/platform/nesFetch/node/completionsFetchServiceImpl.ts
+++ b/extensions/copilot/src/platform/nesFetch/node/completionsFetchServiceImpl.ts
@@ -147,7 +147,7 @@ export class CompletionsFetchService implements ICompletionsFetchService {
 				statusText: response.statusText,
 				headers: response.headers,
 				body: responseStream,
-				requestId: getRequestId(response.headers),
+				requestId: getRequestIdForRequest(response.headers, isCopilotHostedRequest),
 				response,
 			});
 
@@ -331,4 +331,18 @@ async function collectAsyncIterableToString(iterable: AsyncIterable<string>): Pr
 		parts.push(part);
 	}
 	return parts.join('');
+}
+
+function getRequestIdForRequest(headers: IHeaders, isCopilotHostedRequest: boolean): RequestId {
+	if (isCopilotHostedRequest) {
+		return getRequestId(headers);
+	}
+	return {
+		headerRequestId: '',
+		gitHubRequestId: '',
+		completionId: '',
+		created: 0,
+		serverExperiments: '',
+		deploymentId: '',
+	};
 }

--- a/extensions/copilot/src/platform/nesFetch/node/completionsFetchServiceImpl.ts
+++ b/extensions/copilot/src/platform/nesFetch/node/completionsFetchServiceImpl.ts
@@ -46,7 +46,7 @@ export class CompletionsFetchService implements ICompletionsFetchService {
 
 	public async fetch(
 		url: string,
-		secretKey: string,
+		secretKey: string | undefined,
 		params: IFetchRequestParams,
 		requestId: string,
 		ct: CancellationToken,
@@ -69,7 +69,7 @@ export class CompletionsFetchService implements ICompletionsFetchService {
 			})
 		};
 
-		const fetchResponse = await this._fetchFromUrl(url, options, ct);
+		const fetchResponse = await this._fetchFromUrl(url, options, ct, !!secretKey);
 
 		if (fetchResponse.isError()) {
 			this._logCompletionsRequest(url, params, requestId, startTimeMs, fetchResponse);
@@ -101,7 +101,7 @@ export class CompletionsFetchService implements ICompletionsFetchService {
 		}
 	}
 
-	protected async _fetchFromUrl(url: string, options: Completions.Internal.FetchOptions, ct: CancellationToken): Promise<Result<FetchResponse, Completions.CompletionsFetchFailure>> {
+	protected async _fetchFromUrl(url: string, options: Completions.Internal.FetchOptions, ct: CancellationToken, isCopilotHostedRequest = true): Promise<Result<FetchResponse, Completions.CompletionsFetchFailure>> {
 
 		const fetchAbortCtl = this.fetcherService.makeAbortController();
 
@@ -121,12 +121,12 @@ export class CompletionsFetchService implements ICompletionsFetchService {
 
 			const response = await this.fetcherService.fetch(url, request);
 
-			if (response.status === 200 && this.authService.copilotToken?.isFreeUser && this.authService.copilotToken?.isChatQuotaExceeded) {
+			if (isCopilotHostedRequest && response.status === 200 && this.authService.copilotToken?.isFreeUser && this.authService.copilotToken?.isChatQuotaExceeded) {
 				this.authService.resetCopilotToken();
 			}
 
 			if (response.status !== 200) {
-				if (response.status === 402) {
+				if (isCopilotHostedRequest && response.status === 402) {
 					// When we receive a 402, we have exceed the free tier quota
 					// This is stored on the token so let's refresh it
 					if (!this.authService.copilotToken?.isCompletionsQuotaExceeded) {
@@ -286,19 +286,20 @@ export class CompletionsFetchService implements ICompletionsFetchService {
 
 	private getHeaders(
 		requestId: string,
-		secretKey: string,
+		secretKey: string | undefined,
 		headerOverrides: Record<string, string> = {},
 	): Record<string, string> {
 		const headers: Record<string, string> = {
 			'Content-Type': 'application/json',
-			'x-policy-id': 'nil',
-			Authorization: 'Bearer ' + secretKey,
 			'X-Request-Id': requestId,
-			'X-GitHub-Api-Version': '2025-04-01',
-			...headerOverrides,
 		};
+		if (secretKey) {
+			headers['x-policy-id'] = 'nil';
+			headers.Authorization = 'Bearer ' + secretKey;
+			headers['X-GitHub-Api-Version'] = '2025-04-01';
+		}
 
-		return headers;
+		return { ...headers, ...headerOverrides };
 	}
 }
 


### PR DESCRIPTION
## Summary

This adds support for custom inline-completion models in the Copilot extension while leaving the existing hosted Copilot completion path unchanged.

- adds `github.copilot.customCompletionModels` for OpenAI-compatible completion endpoints
- stores custom completion model config and selected completion model as machine-scoped settings so workspaces cannot redirect inline-completion prompts to arbitrary endpoints
- includes configured custom models in the inline completion model picker
- preserves selected custom completion model IDs when they resolve to valid non-colliding custom entries
- routes custom inline completion requests to the configured endpoint without adding a Copilot bearer token
- keeps hosted model IDs authoritative when a custom model ID collides with a hosted model ID
- supports local/no-auth endpoints as well as explicit API keys or request headers, with settings text noting these values are stored in machine settings
- allows the custom inline completion provider path to initialize without requiring a Copilot token when a selected model is resolved as custom

## Validation

- `npm run compile`
- `npm run test:completions-core -- --grep "custom completion"` (16 passing)
- `npm run test:completions-core -- "V:\ollama-pr-smoke.test.ts"` using Ollama Cloud `qwen3-coder-next:cloud` through an OpenAI-compatible local Ollama endpoint
- live Extension Development Host smoke test in VS Code Insiders with `qwen3-coder-next:cloud`, confirming a ghost-text inline completion is produced in the editor
- Claude Code review iterations completed; final focused pass returned `No actionable issues found.`