### PR TITLE
Add onboarding spotlight tour for the Agents window

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -307,6 +307,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/contrib/onboarding",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/contrib/welcomePage",
 			"project": "vscode-workbench"
 		},
@@ -738,6 +742,10 @@
 		},
 		{
 			"name": "vs/sessions/contrib/editor",
+			"project": "vscode-sessions"
+		},
+		{
+			"name": "vs/sessions/contrib/onboardingTours",
 			"project": "vscode-sessions"
 		}
 	]

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -27,6 +27,7 @@ import { NoAgentHostEmptyState } from './noAgentHostEmptyState.js';
 import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { IAgentHostFilterService } from '../../../services/agentHostFilter/common/agentHostFilter.js';
 import { IChatViewOptions } from '../../../browser/parts/chatView.js';
+import { markOnboardingTarget } from '../../../../workbench/contrib/onboarding/browser/spotlight/onboardingTarget.js';
 
 // #region --- New Chat Widget ---
 
@@ -143,6 +144,9 @@ export class NewChatWidget extends Disposable {
 		this._aquariumToggle = this._register(this.aquariumService.mountToggle(element));
 
 		const workspacePickerContainer = dom.append(chatWidgetContent, dom.$('.new-session-workspace-picker-container'));
+		// Onboarding spotlight target — id is referenced by the "new session" tour
+		// in vs/sessions/contrib/onboardingTours.
+		this._register(markOnboardingTarget(workspacePickerContainer, 'sessions.newSession.workspacePicker'));
 		// On web (vscode.dev / insiders.vscode.dev) the workspace picker is
 		// scoped to the currently selected agent host. When no hosts are
 		// known there is nothing for the user to pick, so swap the picker

--- a/src/vs/sessions/contrib/onboardingTours/browser/newSessionButtonTarget.ts
+++ b/src/vs/sessions/contrib/onboardingTours/browser/newSessionButtonTarget.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
+import { IAction } from '../../../../base/common/actions.js';
+import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
+import { MenuEntryActionViewItem } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
+import { MenuItemAction } from '../../../../platform/actions/common/actions.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
+import { markOnboardingTarget } from '../../../../workbench/contrib/onboarding/browser/spotlight/onboardingTarget.js';
+import { SessionSectionToolbarMenuId } from '../../sessions/browser/views/sessionsList.js';
+
+/** Command id of the per-workspace-section "New Session" toolbar action. */
+const NEW_SESSION_COMMAND_ID = 'sessionsView.sectionNewSession';
+
+/** Onboarding target id for the "New Session" button, referenced by the tour. */
+export const SESSIONS_NEW_SESSION_BUTTON_TARGET = 'sessions.newSession.button';
+
+/**
+ * The "New Session" button is rendered by the sessions list section toolbar from
+ * a registered action, so it has no creation site we can tag directly. This view
+ * item renders like the default one and additionally marks its element as an
+ * onboarding target — registered via {@link IActionViewItemService} so it
+ * applies wherever that toolbar action is shown, without touching the renderer.
+ */
+class OnboardingNewSessionActionViewItem extends MenuEntryActionViewItem {
+
+	private readonly _tag = this._register(new MutableDisposable());
+
+	override render(container: HTMLElement): void {
+		super.render(container);
+		if (this.element) {
+			this._tag.value = markOnboardingTarget(this.element, SESSIONS_NEW_SESSION_BUTTON_TARGET);
+		}
+	}
+}
+
+class OnboardingNewSessionButtonTargetContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'sessions.contrib.onboardingTours.newSessionButtonTarget';
+
+	constructor(
+		@IActionViewItemService actionViewItemService: IActionViewItemService,
+	) {
+		super();
+		this._register(actionViewItemService.register(
+			SessionSectionToolbarMenuId,
+			NEW_SESSION_COMMAND_ID,
+			(action: IAction, options: IActionViewItemOptions, instantiationService: IInstantiationService) =>
+				instantiationService.createInstance(OnboardingNewSessionActionViewItem, action as MenuItemAction, options),
+		));
+	}
+}
+
+registerWorkbenchContribution2(OnboardingNewSessionButtonTargetContribution.ID, OnboardingNewSessionButtonTargetContribution, WorkbenchPhase.BlockRestore);

--- a/src/vs/sessions/contrib/onboardingTours/browser/newSessionTourContribution.ts
+++ b/src/vs/sessions/contrib/onboardingTours/browser/newSessionTourContribution.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { disposableTimeout } from '../../../../base/common/async.js';
+import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { observableValue } from '../../../../base/common/observable.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
+import { onboardingScenarioRegistry } from '../../../../workbench/contrib/onboarding/common/onboardingRegistry.js';
+import { ONBOARDING_DEVELOPER_MODE_CONFIG } from '../../../../workbench/contrib/onboarding/common/onboardingScenarioService.js';
+import { ISession } from '../../../services/sessions/common/session.js';
+import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+import { TOTAL_SESSIONS_KEY } from '../../sessions/browser/sessionsLifecycleTracker.js';
+import { createNewSessionTour } from './tours/newSessionTour.js';
+
+/**
+ * Registers the "new session" onboarding tour and decides *when* it should run.
+ *
+ * The tour targets brand-new users: it only triggers while the number of
+ * sessions the user has ever started (persisted by the sessions telemetry
+ * tracker under {@link TOTAL_SESSIONS_KEY}) is below {@link MAX_SESSIONS_FOR_TOUR}.
+ * When an eligible user sends a request, we wait {@link VISIBILITY_DELAY_MS} and
+ * only then flip the tour's trigger signal — and only if that session is still
+ * visible in the sessions grid (so we don't interrupt a session the user
+ * immediately closed or navigated away from). The onboarding engine handles
+ * showing the tour at most once.
+ *
+ * The `onboarding.developerMode` setting bypasses the session-count gate so the
+ * tour can be triggered on demand for testing.
+ */
+class NewSessionTourContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'sessions.contrib.onboardingTours.newSessionTour';
+
+	/** Only nudge users who are still in their first few sessions. */
+	private static readonly MAX_SESSIONS_FOR_TOUR = 3;
+	/** Delay after a request before checking the session is still visible. */
+	private static readonly VISIBILITY_DELAY_MS = 10_000;
+
+	/** Drives the tour's `observable` trigger. Flipped to `true` exactly once. */
+	private readonly _trigger = observableValue<boolean>(this, false);
+
+	private readonly _pendingCheck = this._register(new MutableDisposable());
+
+	constructor(
+		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
+		@ISessionsService private readonly sessionsService: ISessionsService,
+		@IStorageService private readonly storageService: IStorageService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+	) {
+		super();
+
+		this._register(onboardingScenarioRegistry.register(createNewSessionTour(this._trigger)));
+
+		this._register(sessionsManagementService.onDidSendRequest(e => this._onDidSendRequest(e.session)));
+	}
+
+	private _onDidSendRequest(session: ISession): void {
+		// Already triggered (or about to be shown) — nothing more to do.
+		if (this._trigger.get()) {
+			this._pendingCheck.clear();
+			return;
+		}
+
+		// The developer setting bypasses the usage-based "first few sessions"
+		// gate so the tour can be triggered on demand for testing.
+		const developerMode = this.configurationService.getValue<boolean>(ONBOARDING_DEVELOPER_MODE_CONFIG) === true;
+		if (!developerMode) {
+			const sessionsStarted = this.storageService.getNumber(TOTAL_SESSIONS_KEY, StorageScope.APPLICATION, 0);
+			if (sessionsStarted >= NewSessionTourContribution.MAX_SESSIONS_FOR_TOUR) {
+				return;
+			}
+		}
+
+		// Wait, then only trigger if the user is still looking at this session in
+		// the grid. A new request restarts the timer for the latest session.
+		this._pendingCheck.value = disposableTimeout(() => {
+			const stillVisible = this.sessionsService.visibleSessions.get().some(s => s?.sessionId === session.sessionId);
+			if (stillVisible) {
+				this._trigger.set(true, undefined);
+			}
+		}, NewSessionTourContribution.VISIBILITY_DELAY_MS);
+	}
+}
+
+registerWorkbenchContribution2(NewSessionTourContribution.ID, NewSessionTourContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/sessions/contrib/onboardingTours/browser/onboardingTours.contribution.ts
+++ b/src/vs/sessions/contrib/onboardingTours/browser/onboardingTours.contribution.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Registers the Agents window onboarding tours. The imported modules register
+// the tour targets and the tour contribution (which owns the scenario and its
+// trigger) as a side effect. The onboarding engine and the spotlight
+// presentation live in `vs/workbench/contrib/onboarding` and are booted from
+// the workbench contribution imported in the entry point.
+import './newSessionButtonTarget.js';
+import './newSessionTourContribution.js';

--- a/src/vs/sessions/contrib/onboardingTours/browser/tours/newSessionTour.ts
+++ b/src/vs/sessions/contrib/onboardingTours/browser/tours/newSessionTour.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IObservable } from '../../../../../base/common/observable.js';
+import { ChatContextKeys } from '../../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
+import { IOnboardingScenario } from '../../../../../workbench/contrib/onboarding/common/onboardingScenario.js';
+import { ISpotlightPayload, SPOTLIGHT_PRESENTATION_KIND } from '../../../../../workbench/contrib/onboarding/browser/spotlight/spotlightTypes.js';
+import { localize } from '../../../../../nls.js';
+
+/**
+ * Onboarding tour shown once the user has created their first session (the chat
+ * view is visible, not the new-session view). It teaches running sessions in
+ * parallel and the workspace/isolation options:
+ *
+ *  1. The "New Session" button in the sessions list — advancing when the user
+ *     presses it, which opens the new-session view that hosts steps 2 & 3.
+ *  2. The isolation picker (worktree vs folder).
+ *  3. The workspace picker.
+ *
+ * Each `targetId` matches a `data-onboarding-id` set via `markOnboardingTarget`:
+ *  - `sessions.newSession.button` — newSessionButtonTarget.ts (this contrib)
+ *  - `sessions.newSession.isolation` — contrib/providers/copilotChatSessions/browser/isolationPicker.ts
+ *  - `sessions.newSession.workspacePicker` — contrib/chat/browser/newChatWidget.ts
+ */
+const newSessionPayload: ISpotlightPayload = {
+	steps: [
+		{
+			id: 'newSessionButton',
+			targetId: 'sessions.newSession.button',
+			title: localize('sessions.onboarding.parallel.title', "Run Sessions in Parallel"),
+			description: localize('sessions.onboarding.parallel.description', "Start another session to work on a different task at the same time. The Agents window runs multiple sessions in parallel."),
+			placement: 'right',
+			// Advance when the user actually presses the button, which opens the
+			// new-session view that hosts the next two steps.
+			advanceOnTargetClick: true,
+		},
+		{
+			id: 'isolation',
+			targetId: 'sessions.newSession.isolation',
+			title: localize('sessions.onboarding.isolation.title', "Isolate Your Work"),
+			description: localize('sessions.onboarding.isolation.description', "Choose a worktree to work on two different tasks in the same workspace while keeping the two tasks fully isolated from each other."),
+			placement: 'above',
+		},
+		{
+			id: 'workspacePicker',
+			targetId: 'sessions.newSession.workspacePicker',
+			title: localize('sessions.onboarding.workspace.title', "Work Across Workspaces"),
+			description: localize('sessions.onboarding.workspace.description', "Pick any workspace — you can run multiple tasks in the same workspace as well as across several different workspaces at the same time."),
+			placement: 'above',
+		},
+	],
+};
+
+/**
+ * Builds the "new session" tour scenario. The provided `signal` controls *when*
+ * the tour becomes eligible — it is driven by {@link NewSessionTourContribution},
+ * which only flips it on for new users a short while after they send a request.
+ * `ChatContextKeys.enabled` keeps the tour hidden when AI features are disabled.
+ */
+export function createNewSessionTour(signal: IObservable<boolean>): IOnboardingScenario<ISpotlightPayload> {
+	return {
+		id: 'sessions.onboarding.newSession',
+		when: ChatContextKeys.enabled,
+		trigger: { kind: 'observable', signal },
+		priority: 100,
+		presentation: {
+			kind: SPOTLIGHT_PRESENTATION_KIND,
+			payload: newSessionPayload,
+		},
+	};
+}

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/isolationPicker.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/isolationPicker.ts
@@ -18,6 +18,7 @@ import { reportNewChatPickerClosed } from '../../../chat/browser/newChatPickerTe
 import { IActiveSession } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { CopilotChatSessionsProvider } from './copilotChatSessionsProvider.js';
+import { markOnboardingTarget } from '../../../../../workbench/contrib/onboarding/browser/spotlight/onboardingTarget.js';
 
 export type IsolationMode = 'worktree' | 'workspace';
 
@@ -100,6 +101,9 @@ export class IsolationPicker extends Disposable {
 		const slot = dom.append(container, dom.$('.sessions-chat-picker-slot'));
 		this._renderDisposables.add({ dispose: () => slot.remove() });
 		this._slotElement = slot;
+		// Onboarding spotlight target — id is referenced by the "new session" tour
+		// in vs/sessions/contrib/onboardingTours.
+		this._renderDisposables.add(markOnboardingTarget(slot, 'sessions.newSession.isolation'));
 
 		const trigger = dom.append(slot, dom.$('a.action-label'));
 		trigger.tabIndex = 0;

--- a/src/vs/sessions/contrib/sessions/browser/sessionsLifecycleTracker.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsLifecycleTracker.ts
@@ -14,7 +14,7 @@ const APP_LAUNCH_COUNT_KEY = 'agentSessions.telemetry.summary.appLaunchCount';
 /** Storage key for the per-session lifecycle stats map (JSON encoded). Exported for tests. */
 export const SESSIONS_KEY = 'agentSessions.telemetry.summary.sessions';
 /** Storage key for the cumulative number of sessions started from the Agents window across all workspaces and providers. */
-const TOTAL_SESSIONS_KEY = 'agentSessions.telemetry.totalSessions';
+export const TOTAL_SESSIONS_KEY = 'agentSessions.telemetry.totalSessions';
 /** Storage key for the cumulative number of sessions started in each workspace (JSON encoded map of workspace URI -> count). */
 const WORKSPACE_SESSIONS_KEY = 'agentSessions.telemetry.workspaceSessions';
 /** Storage key for the cumulative number of sessions started for each sessions provider (JSON encoded map of providerId -> count). */

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -481,5 +481,10 @@ import './contrib/workspace/browser/workspace.contribution.js';
 import './contrib/aquarium/browser/aquarium.contribution.js';
 import './contrib/policyBlocked/browser/policyBlocked.contribution.js';
 
+// Onboarding: the engine + spotlight presentation (from the workbench layer) and
+// the Agents window scenario data.
+import '../workbench/contrib/onboarding/browser/onboarding.contribution.js';
+import './contrib/onboardingTours/browser/onboardingTours.contribution.js';
+
 import './services/sessions/browser/sessionsManagementService.js';
 //#endregion

--- a/src/vs/workbench/contrib/onboarding/browser/media/spotlight.css
+++ b/src/vs/workbench/contrib/onboarding/browser/media/spotlight.css
@@ -1,0 +1,105 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Spotlight overlay: dim everything, cut a highlight hole, anchor a callout. */
+
+.spotlight-overlay {
+	position: fixed;
+	inset: 0;
+	/* Above dialogs (2575) so the onboarding spotlight wins over modal chrome. */
+	z-index: 2600;
+}
+
+/* Full-screen click blocker. Transparent; swallows interaction outside the hole. */
+.spotlight-blocker {
+	position: fixed;
+	inset: 0;
+	pointer-events: auto;
+}
+
+/*
+ * The highlight hole. The huge spread box-shadow paints the dim everywhere
+ * *outside* this element, while the inset ring highlights the target. Purely
+ * visual: it never intercepts pointer events.
+ */
+.spotlight-hole {
+	position: fixed;
+	border-radius: var(--vscode-cornerRadius-medium);
+	pointer-events: none;
+	/*
+	 * The dim color matches the modal scrim (.monaco-dialog-modal-block.dimmed)
+	 * and the native window-controls dim (windowImpl.ts dimColor, 0.5 black) so
+	 * the spotlight, the dimmed app and the OS-drawn controls read as one layer.
+	 */
+	box-shadow:
+		0 0 0 9999px rgba(0, 0, 0, 0.5),
+		0 0 0 2px var(--vscode-focusBorder) inset;
+	transition: top 0.2s ease, left 0.2s ease, width 0.2s ease, height 0.2s ease;
+}
+
+.spotlight-callout {
+	position: fixed;
+	box-sizing: border-box;
+	width: 320px;
+	max-width: calc(100vw - var(--vscode-spacing-size320));
+	padding: var(--vscode-spacing-size160);
+	background: var(--vscode-editorWidget-background);
+	color: var(--vscode-editorWidget-foreground);
+	border: var(--vscode-strokeThickness) solid var(--vscode-widget-border, transparent);
+	border-radius: var(--vscode-cornerRadius-large);
+	box-shadow: 0 2px 8px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.36));
+	pointer-events: auto;
+}
+
+.spotlight-callout:focus,
+.spotlight-callout:focus-visible {
+	outline: none;
+}
+
+.spotlight-callout-title {
+	margin: 0 0 var(--vscode-spacing-size80) 0;
+	font-size: var(--vscode-bodyFontSize);
+	font-weight: 600;
+}
+
+.spotlight-callout-description {
+	margin: 0;
+	font-size: var(--vscode-bodyFontSize);
+	line-height: 1.4;
+	color: var(--vscode-descriptionForeground);
+}
+
+.spotlight-callout-description p {
+	margin: 0 0 var(--vscode-spacing-size80) 0;
+}
+
+.spotlight-callout-description p:last-child {
+	margin-bottom: 0;
+}
+
+.spotlight-callout-footer {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--vscode-spacing-size120);
+	margin-top: var(--vscode-spacing-size160);
+}
+
+.spotlight-callout-counter {
+	font-size: var(--vscode-bodyFontSize-small);
+	color: var(--vscode-descriptionForeground);
+}
+
+.spotlight-callout-actions {
+	display: flex;
+	gap: var(--vscode-spacing-size80);
+}
+
+/* Respect reduced-motion: drop the animated hole transition. */
+@media (prefers-reduced-motion: reduce) {
+	.spotlight-hole {
+		transition: none;
+	}
+}

--- a/src/vs/workbench/contrib/onboarding/browser/onboarding.contribution.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/onboarding.contribution.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { localize, localize2 } from '../../../../nls.js';
+import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
+import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+import { workbenchConfigurationNodeBase } from '../../../common/configuration.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
+import { onboardingPresentationRegistry } from '../common/onboardingPresentation.js';
+import { IOnboardingScenarioService, ONBOARDING_DEVELOPER_MODE_CONFIG, ONBOARDING_ENABLED_CONFIG } from '../common/onboardingScenarioService.js';
+import { OnboardingScenarioService } from './onboardingService.js';
+import { SpotlightPresentation } from './spotlight/spotlightPresentation.js';
+
+registerSingleton(IOnboardingScenarioService, OnboardingScenarioService, InstantiationType.Delayed);
+
+/**
+ * Boots the onboarding engine after the workbench has restored: registers the
+ * built-in presentations and starts evaluating registered scenarios.
+ */
+class OnboardingContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.onboarding';
+
+	constructor(
+		@IOnboardingScenarioService onboardingService: IOnboardingScenarioService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+		const spotlight = this._register(instantiationService.createInstance(SpotlightPresentation));
+		this._register(onboardingPresentationRegistry.register(spotlight));
+		onboardingService.start();
+	}
+}
+
+registerWorkbenchContribution2(OnboardingContribution.ID, OnboardingContribution, WorkbenchPhase.AfterRestored);
+
+const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+configurationRegistry.registerConfiguration({
+	...workbenchConfigurationNodeBase,
+	properties: {
+		[ONBOARDING_ENABLED_CONFIG]: {
+			type: 'boolean',
+			default: false,
+			description: localize('onboarding.enabled', "When enabled, onboarding tours and hints may appear automatically to highlight features. Disabling this does not affect tours you start manually.")
+		},
+		[ONBOARDING_DEVELOPER_MODE_CONFIG]: {
+			type: 'boolean',
+			default: false,
+			tags: ['experimental'],
+			description: localize('onboarding.developerMode', "When enabled, onboarding tours ignore usage-based eligibility checks (such as how many sessions you have started) so they can be triggered for testing. Tours are still shown at most once; use the \"Reset Onboarding Shown State\" command to replay them.")
+		}
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.onboarding.resetShownState',
+			title: localize2('onboarding.resetShownState', "Reset Onboarding Shown State"),
+			category: Categories.Developer,
+			f1: true,
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		accessor.get(IOnboardingScenarioService).resetAll();
+	}
+});

--- a/src/vs/workbench/contrib/onboarding/browser/onboardingService.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/onboardingService.ts
@@ -44,6 +44,8 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 	/** Scenario ids currently queued or running (prevents double-scheduling). */
 	private readonly _pending = new Set<string>();
 	private readonly _queue: { scenario: IOnboardingScenario; deferred: DeferredPromise<OnboardingOutcome> }[] = [];
+	/** Deferreds for scenarios that have been dequeued and are currently running, keyed by id. */
+	private readonly _inflight = new Map<string, DeferredPromise<OnboardingOutcome>>();
 	private _pumping = false;
 
 	/** Abort signal for the scenario currently running. */
@@ -193,9 +195,16 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 			return Promise.resolve(OnboardingOutcome.Aborted);
 		}
 
-		const existing = this._queue.find(entry => entry.scenario.id === scenario.id);
-		if (existing) {
-			return existing.deferred.p;
+		// De-duplicate against both the queue and the in-flight run so a repeated
+		// `runScenario(id)` (e.g. a command invoked while the tour is active)
+		// joins the existing run instead of scheduling a second one.
+		const queued = this._queue.find(entry => entry.scenario.id === scenario.id);
+		if (queued) {
+			return queued.deferred.p;
+		}
+		const inflight = this._inflight.get(scenario.id);
+		if (inflight) {
+			return inflight.p;
 		}
 
 		const deferred = new DeferredPromise<OnboardingOutcome>();
@@ -224,6 +233,9 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 			let entry: { scenario: IOnboardingScenario; deferred: DeferredPromise<OnboardingOutcome> } | undefined;
 			while (!this._stopped && (entry = this._queue.shift())) {
 				const { scenario, deferred } = entry;
+				// Track the running scenario so a concurrent `_enqueue` for the same
+				// id joins this run instead of scheduling another.
+				this._inflight.set(scenario.id, deferred);
 				let outcome: OnboardingOutcome;
 				try {
 					outcome = await this._runPresentation(scenario);
@@ -231,6 +243,7 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 					onUnexpectedError(error);
 					outcome = OnboardingOutcome.Aborted;
 				} finally {
+					this._inflight.delete(scenario.id);
 					this._pending.delete(scenario.id);
 				}
 				deferred.complete(outcome);

--- a/src/vs/workbench/contrib/onboarding/browser/onboardingService.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/onboardingService.ts
@@ -1,0 +1,321 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DeferredPromise } from '../../../../base/common/async.js';
+import { onUnexpectedError } from '../../../../base/common/errors.js';
+import { Emitter } from '../../../../base/common/event.js';
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../base/common/observable.js';
+import { mainWindow } from '../../../../base/browser/window.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { ILifecycleService } from '../../../services/lifecycle/common/lifecycle.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { IWorkbenchAssignmentService } from '../../../services/assignment/common/assignmentService.js';
+import { Memento } from '../../../common/memento.js';
+import { onboardingPresentationRegistry } from '../common/onboardingPresentation.js';
+import { onboardingScenarioRegistry } from '../common/onboardingRegistry.js';
+import { IOnboardingScenario, OnboardingOutcome } from '../common/onboardingScenario.js';
+import { IOnboardingScenarioService, ONBOARDING_ENABLED_CONFIG } from '../common/onboardingScenarioService.js';
+
+/** Persisted "shown" state for a single scenario. */
+interface IScenarioState {
+	readonly shownAt: number;
+	outcome?: OnboardingOutcome;
+	seenCount: number;
+}
+
+type OnboardingMementoData = { [scenarioId: string]: IScenarioState };
+
+export class OnboardingScenarioService extends Disposable implements IOnboardingScenarioService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private static readonly MEMENTO_ID = 'onboarding';
+
+	private readonly _memento: Memento<OnboardingMementoData>;
+	private readonly _state: Partial<OnboardingMementoData>;
+
+	/** Listeners for `observable` triggers, rebuilt whenever the registry changes. */
+	private readonly _triggerListeners = this._register(new DisposableStore());
+
+	/** Scenario ids currently queued or running (prevents double-scheduling). */
+	private readonly _pending = new Set<string>();
+	private readonly _queue: { scenario: IOnboardingScenario; deferred: DeferredPromise<OnboardingOutcome> }[] = [];
+	private _pumping = false;
+
+	/** Abort signal for the scenario currently running. */
+	private _activeAbort: Emitter<void> | undefined;
+
+	/** Cached experiment treatment results for scenarios that declare one. */
+	private readonly _experimentResults = new Map<string, boolean>();
+
+	private _started = false;
+	private _stopped = false;
+
+	constructor(
+		@IStorageService private readonly storageService: IStorageService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@ILifecycleService private readonly lifecycleService: ILifecycleService,
+		@IWorkbenchAssignmentService private readonly assignmentService: IWorkbenchAssignmentService,
+	) {
+		super();
+
+		this._memento = new Memento(OnboardingScenarioService.MEMENTO_ID, this.storageService);
+		this._state = this._memento.getMemento(StorageScope.PROFILE, StorageTarget.USER);
+
+		// On shutdown abort the active run and drain anything still queued so no
+		// fresh overlay is mounted while the window is going away.
+		this._register(this.lifecycleService.onWillShutdown(() => this._stop()));
+	}
+
+	private _stop(): void {
+		this._stopped = true;
+		this._activeAbort?.fire();
+
+		let entry: { scenario: IOnboardingScenario; deferred: DeferredPromise<OnboardingOutcome> } | undefined;
+		while ((entry = this._queue.shift())) {
+			this._pending.delete(entry.scenario.id);
+			entry.deferred.complete(OnboardingOutcome.Aborted);
+		}
+	}
+
+	start(): void {
+		if (this._started) {
+			return;
+		}
+		this._started = true;
+
+		this._register(onboardingScenarioRegistry.onDidChange(() => {
+			this._registerTriggerListeners();
+			this._fetchExperiments();
+			this._evaluate();
+		}));
+
+		this._register(this.contextKeyService.onDidChangeContext(() => this._evaluate()));
+
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(ONBOARDING_ENABLED_CONFIG)) {
+				this._evaluate();
+			}
+		}));
+
+		this._registerTriggerListeners();
+		this._fetchExperiments();
+		this._evaluate();
+	}
+
+	getScenarios(): readonly IOnboardingScenario[] {
+		return onboardingScenarioRegistry.getScenarios();
+	}
+
+	async runScenario(id: string): Promise<OnboardingOutcome> {
+		const scenario = onboardingScenarioRegistry.getScenario(id);
+		if (!scenario) {
+			throw new Error(`Unknown onboarding scenario '${id}'.`);
+		}
+		return this._enqueue(scenario);
+	}
+
+	hasBeenShown(id: string): boolean {
+		return !!this._state[id]?.shownAt;
+	}
+
+	reset(id: string): void {
+		delete this._state[id];
+		this._memento.saveMemento();
+	}
+
+	resetAll(): void {
+		for (const key of Object.keys(this._state)) {
+			delete this._state[key];
+		}
+		this._memento.saveMemento();
+	}
+
+	//#region Eligibility & scheduling
+
+	private get _enabled(): boolean {
+		return this.configurationService.getValue<boolean>(ONBOARDING_ENABLED_CONFIG) !== false;
+	}
+
+	/**
+	 * Re-evaluate every scenario and enqueue any that are eligible to run
+	 * automatically. Idempotent: already shown / queued scenarios are skipped.
+	 */
+	private _evaluate(): void {
+		if (!this._enabled || this._stopped) {
+			return;
+		}
+
+		const eligible = onboardingScenarioRegistry.getScenarios()
+			.filter(scenario => this._isAutoEligible(scenario));
+
+		for (const scenario of eligible) {
+			this._enqueue(scenario);
+		}
+	}
+
+	private _isAutoEligible(scenario: IOnboardingScenario): boolean {
+		// `command` triggers never run automatically.
+		if (scenario.trigger.kind === 'command') {
+			return false;
+		}
+
+		if (this._pending.has(scenario.id)) {
+			return false;
+		}
+
+		if (!scenario.repeatable && this.hasBeenShown(scenario.id)) {
+			return false;
+		}
+
+		if (scenario.when && !this.contextKeyService.contextMatchesRules(scenario.when)) {
+			return false;
+		}
+
+		if (scenario.experiment && this._experimentResults.get(scenario.experiment) !== true) {
+			return false;
+		}
+
+		if (scenario.trigger.kind === 'observable' && scenario.trigger.signal.get() !== true) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private _enqueue(scenario: IOnboardingScenario): Promise<OnboardingOutcome> {
+		if (this._stopped) {
+			return Promise.resolve(OnboardingOutcome.Aborted);
+		}
+
+		const existing = this._queue.find(entry => entry.scenario.id === scenario.id);
+		if (existing) {
+			return existing.deferred.p;
+		}
+
+		const deferred = new DeferredPromise<OnboardingOutcome>();
+		this._pending.add(scenario.id);
+		this._queue.push({ scenario, deferred });
+		// Highest priority first; stable for equal priorities.
+		this._queue.sort((a, b) => (b.scenario.priority ?? 0) - (a.scenario.priority ?? 0));
+
+		this._pump();
+		return deferred.p;
+	}
+
+	private _pump(): void {
+		if (this._pumping) {
+			return;
+		}
+		// Mark as pumping synchronously so a batch of `_enqueue` calls made in the
+		// same tick all land (and re-sort by priority) before we consume the queue.
+		this._pumping = true;
+		this._doPump();
+	}
+
+	private async _doPump(): Promise<void> {
+		await Promise.resolve(); // let the current synchronous batch of enqueues settle
+		try {
+			let entry: { scenario: IOnboardingScenario; deferred: DeferredPromise<OnboardingOutcome> } | undefined;
+			while (!this._stopped && (entry = this._queue.shift())) {
+				const { scenario, deferred } = entry;
+				let outcome: OnboardingOutcome;
+				try {
+					outcome = await this._runPresentation(scenario);
+				} catch (error) {
+					onUnexpectedError(error);
+					outcome = OnboardingOutcome.Aborted;
+				} finally {
+					this._pending.delete(scenario.id);
+				}
+				deferred.complete(outcome);
+			}
+		} finally {
+			this._pumping = false;
+		}
+	}
+
+	private async _runPresentation(scenario: IOnboardingScenario): Promise<OnboardingOutcome> {
+		const presentation = onboardingPresentationRegistry.get(scenario.presentation.kind);
+		if (!presentation) {
+			return OnboardingOutcome.Aborted;
+		}
+
+		// Mark shown the moment a scenario starts so a crash/reload won't re-trigger it.
+		this._markShown(scenario.id);
+
+		const abort = new Emitter<void>();
+		this._activeAbort = abort;
+		try {
+			const outcome = await presentation.run(scenario, { targetWindow: mainWindow, onAbort: abort.event });
+			this._recordOutcome(scenario.id, outcome);
+			return outcome;
+		} finally {
+			this._activeAbort = undefined;
+			abort.dispose();
+		}
+	}
+
+	//#endregion
+
+	//#region Triggers & experiments
+
+	private _registerTriggerListeners(): void {
+		this._triggerListeners.clear();
+		for (const scenario of onboardingScenarioRegistry.getScenarios()) {
+			if (scenario.trigger.kind === 'observable') {
+				const signal = scenario.trigger.signal;
+				this._triggerListeners.add(autorun(reader => {
+					signal.read(reader);
+					this._evaluate();
+				}));
+			}
+		}
+	}
+
+	private _fetchExperiments(): void {
+		for (const scenario of onboardingScenarioRegistry.getScenarios()) {
+			const id = scenario.experiment;
+			if (!id || this._experimentResults.has(id)) {
+				continue;
+			}
+			this._experimentResults.set(id, false);
+			this.assignmentService.getTreatment<boolean>(id).then(value => {
+				if (value === true) {
+					this._experimentResults.set(id, true);
+					this._evaluate();
+				}
+			}, error => onUnexpectedError(error));
+		}
+	}
+
+	//#endregion
+
+	//#region Persistence
+
+	private _markShown(id: string): void {
+		const previous = this._state[id];
+		const next: IScenarioState = {
+			shownAt: Date.now(),
+			outcome: previous?.outcome,
+			seenCount: (previous?.seenCount ?? 0) + 1
+		};
+		this._state[id] = next;
+		this._memento.saveMemento();
+	}
+
+	private _recordOutcome(id: string, outcome: OnboardingOutcome): void {
+		const state = this._state[id];
+		if (state) {
+			state.outcome = outcome;
+			this._memento.saveMemento();
+		}
+	}
+
+	//#endregion
+}

--- a/src/vs/workbench/contrib/onboarding/browser/spotlight/onboardingTarget.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/spotlight/onboardingTarget.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+
+/**
+ * Attribute used to mark a DOM element as an onboarding spotlight target.
+ *
+ * Components opt in by tagging their *own* element with this attribute. Tours
+ * reference the id; they never reach into another component's markup or CSS
+ * classes to locate a target (see the sessions "DOM Traversal & Intent" rule).
+ */
+export const ONBOARDING_TARGET_ATTR = 'data-onboarding-id';
+
+/**
+ * Marks `element` as the onboarding target identified by `id`.
+ *
+ * @returns A disposable that removes the attribute again.
+ */
+export function markOnboardingTarget(element: HTMLElement, id: string): IDisposable {
+	element.setAttribute(ONBOARDING_TARGET_ATTR, id);
+	return toDisposable(() => {
+		if (element.getAttribute(ONBOARDING_TARGET_ATTR) === id) {
+			element.removeAttribute(ONBOARDING_TARGET_ATTR);
+		}
+	});
+}
+
+/**
+ * Resolves the element marked with the given onboarding target id within the
+ * provided window's document. Returns `undefined` if no such element exists
+ * (e.g. the feature is not currently rendered).
+ *
+ * This is the *only* place onboarding queries the DOM, and it matches solely on
+ * the onboarding attribute — never on foreign classes or structure.
+ */
+export function findOnboardingTarget(targetWindow: Window, id: string): HTMLElement | undefined {
+	const selector = `[${ONBOARDING_TARGET_ATTR}="${CSS.escape(id)}"]`;
+	// eslint-disable-next-line no-restricted-syntax -- matching only our own onboarding attribute (never foreign classes/structure) is the whole point of this helper
+	return targetWindow.document.querySelector<HTMLElement>(selector) ?? undefined;
+}

--- a/src/vs/workbench/contrib/onboarding/browser/spotlight/spotlightOverlay.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/spotlight/spotlightOverlay.ts
@@ -6,7 +6,7 @@
 import { $, addDisposableListener, append, EventType, getActiveElement, getWindow, isHTMLElement, scheduleAtNextAnimationFrame } from '../../../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../../../base/browser/keyboardEvent.js';
 import { Button } from '../../../../../base/browser/ui/button/button.js';
-import { KeyCode } from '../../../../../base/common/keyCodes.js';
+import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
 import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { IMarkdownString, isMarkdownString } from '../../../../../base/common/htmlContent.js';
@@ -278,7 +278,7 @@ export class SpotlightOverlay extends Disposable {
 			return;
 		}
 
-		if (event.equals(KeyCode.Tab) || event.equals(KeyCode.Shift | KeyCode.Tab)) {
+		if (event.equals(KeyCode.Tab) || event.equals(KeyMod.Shift | KeyCode.Tab)) {
 			this._trapFocus(event);
 		}
 	}

--- a/src/vs/workbench/contrib/onboarding/browser/spotlight/spotlightOverlay.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/spotlight/spotlightOverlay.ts
@@ -168,17 +168,22 @@ export class SpotlightOverlay extends Disposable {
 		}));
 
 		// When the step advances by pressing the target, hide the Next button and
-		// advance on a click of the (interactive) target instead.
+		// advance on a click of the (interactive) target instead. The target is
+		// kept keyboard-reachable: it joins the focus trap (see `_collectFocusable`)
+		// and we route Tab/Esc from it through the same handler, so keyboard-only
+		// users can focus the spotlighted control and activate it to advance.
 		const advanceOnTargetClick = !!options.advanceOnTargetClick;
 		this._nextButton.element.style.display = advanceOnTargetClick ? 'none' : '';
 		if (advanceOnTargetClick) {
 			this._stepListeners.add(addDisposableListener(target, EventType.CLICK, () => this._onDidClickNext.fire()));
+			this._stepListeners.add(addDisposableListener(target, EventType.KEY_DOWN, e => this._onKeyDown(e)));
 		}
 
 		this.layout();
 
-		// Move focus into the callout for keyboard users.
-		(advanceOnTargetClick ? this._skipButton : this._nextButton).focus();
+		// Move focus to the spotlighted control (so keyboard users can activate it
+		// to advance) or, otherwise, into the callout's primary action.
+		(advanceOnTargetClick ? target : this._nextButton.element).focus();
 	}
 
 	/** Recompute the hole and callout positions for the current target. */
@@ -286,8 +291,17 @@ export class SpotlightOverlay extends Disposable {
 
 		const active = getActiveElement();
 		const currentIndex = focusable.findIndex(element => element === active);
-		const delta = event.shiftKey ? -1 : 1;
-		const nextIndex = (currentIndex + delta + focusable.length) % focusable.length;
+
+		// When focus isn't currently on a tracked element (e.g. it landed on the
+		// callout container itself), start from the appropriate end so Tab goes to
+		// the first element and Shift+Tab to the last.
+		let nextIndex: number;
+		if (currentIndex === -1) {
+			nextIndex = event.shiftKey ? focusable.length - 1 : 0;
+		} else {
+			const delta = event.shiftKey ? -1 : 1;
+			nextIndex = (currentIndex + delta + focusable.length) % focusable.length;
+		}
 
 		event.preventDefault();
 		event.stopPropagation();
@@ -295,12 +309,15 @@ export class SpotlightOverlay extends Disposable {
 	}
 
 	/**
-	 * The focusable elements inside the callout, in DOM order: any interactive
-	 * content rendered in the (possibly markdown) description first, then the
-	 * visible action buttons. Querying the description ensures links inside a
-	 * markdown body remain keyboard-reachable despite `aria-modal`.
+	 * The focusable elements participating in the focus trap, in DOM order: the
+	 * spotlighted target (when the step advances by pressing it), then any
+	 * interactive content in the (possibly markdown) description, then the visible
+	 * action buttons. Including the target keeps the spotlighted control
+	 * keyboard-reachable, and querying the description keeps markdown links
+	 * reachable despite `aria-modal`.
 	 */
 	private _collectFocusable(): HTMLElement[] {
+		const target = (this._options.advanceOnTargetClick && this._target) ? [this._target] : [];
 		const descriptionFocusables = Array.from(
 			// eslint-disable-next-line no-restricted-syntax -- querying our own callout description subtree for focusable markdown content (e.g. links)
 			this._description.querySelectorAll<HTMLElement>('a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])')
@@ -308,7 +325,7 @@ export class SpotlightOverlay extends Disposable {
 		const buttons = [this._skipButton, this._backButton, this._nextButton]
 			.filter(button => button.element.style.display !== 'none')
 			.map(button => button.element);
-		return [...descriptionFocusables, ...buttons];
+		return [...target, ...descriptionFocusables, ...buttons];
 	}
 
 	private _scheduleLayout(): void {

--- a/src/vs/workbench/contrib/onboarding/browser/spotlight/spotlightOverlay.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/spotlight/spotlightOverlay.ts
@@ -1,0 +1,337 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { $, addDisposableListener, append, EventType, getActiveElement, getWindow, isHTMLElement, scheduleAtNextAnimationFrame } from '../../../../../base/browser/dom.js';
+import { StandardKeyboardEvent } from '../../../../../base/browser/keyboardEvent.js';
+import { Button } from '../../../../../base/browser/ui/button/button.js';
+import { KeyCode } from '../../../../../base/common/keyCodes.js';
+import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { IMarkdownString, isMarkdownString } from '../../../../../base/common/htmlContent.js';
+import { AnchorAlignment, AnchorAxisAlignment, AnchorPosition, IRect, layout2d } from '../../../../../base/common/layout.js';
+import { renderMarkdown } from '../../../../../base/browser/markdownRenderer.js';
+import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
+import { localize } from '../../../../../nls.js';
+import { SpotlightPlacement } from './spotlightTypes.js';
+import '../media/spotlight.css';
+
+/** Default padding (px) added around the target when cutting the highlight hole. */
+const DEFAULT_HOLE_PADDING = 6;
+
+/** Content rendered inside the spotlight callout for a single step. */
+export interface ISpotlightContent {
+	readonly title: string;
+	readonly description: string | IMarkdownString;
+	/** Zero-based index of the current step. */
+	readonly stepIndex: number;
+	/** Total number of steps in the tour. */
+	readonly stepCount: number;
+	/** Whether a "Back" action should be offered. */
+	readonly canGoBack: boolean;
+	/** Whether this is the final step (the primary button becomes "Done"). */
+	readonly isLastStep: boolean;
+}
+
+/** Options controlling how a step is shown. */
+export interface ISpotlightShowOptions {
+	readonly placement?: SpotlightPlacement;
+	readonly allowTargetInteraction?: boolean;
+	readonly padding?: number;
+	/**
+	 * When set, the step advances (fires `onDidClickNext`) when the user clicks
+	 * the spotlighted target itself. The "Next" button is hidden and the target
+	 * is kept interactive so the user can press it to continue.
+	 */
+	readonly advanceOnTargetClick?: boolean;
+}
+
+/**
+ * A pure-DOM spotlight overlay: dims the window, cuts a highlight hole around a
+ * target element and shows an anchored callout. It owns no VS Code services so
+ * it can be unit-tested and reused. Scheduling and content come from the
+ * spotlight presentation.
+ */
+export class SpotlightOverlay extends Disposable {
+
+	private readonly _root: HTMLElement;
+	private readonly _blocker: HTMLElement;
+	private readonly _hole: HTMLElement;
+	private readonly _callout: HTMLElement;
+
+	private readonly _title: HTMLElement;
+	private readonly _description: HTMLElement;
+	private readonly _counter: HTMLElement;
+	private readonly _descriptionRenderStore = this._register(new DisposableStore());
+
+	private readonly _backButton: Button;
+	private readonly _nextButton: Button;
+	private readonly _skipButton: Button;
+
+	/** Listeners scoped to the currently shown step (re-layout sources). */
+	private readonly _stepListeners = this._register(new DisposableStore());
+
+	private readonly _onDidClickNext = this._register(new Emitter<void>());
+	readonly onDidClickNext: Event<void> = this._onDidClickNext.event;
+
+	private readonly _onDidClickPrevious = this._register(new Emitter<void>());
+	readonly onDidClickPrevious: Event<void> = this._onDidClickPrevious.event;
+
+	private readonly _onDidSkip = this._register(new Emitter<void>());
+	readonly onDidSkip: Event<void> = this._onDidSkip.event;
+
+	private _target: HTMLElement | undefined;
+	private _options: ISpotlightShowOptions = {};
+	private _previousFocus: HTMLElement | undefined;
+	private _scheduledLayout: IDisposable | undefined;
+
+	constructor(
+		private readonly _container: HTMLElement,
+		private readonly _resizeObserverCtor: typeof ResizeObserver = getWindow(_container).ResizeObserver,
+	) {
+		super();
+
+		this._root = append(this._container, $('.spotlight-overlay'));
+		this._root.style.display = 'none';
+
+		this._blocker = append(this._root, $('.spotlight-blocker'));
+		this._hole = append(this._root, $('.spotlight-hole'));
+
+		this._callout = append(this._root, $('.spotlight-callout'));
+		this._callout.setAttribute('role', 'dialog');
+		this._callout.setAttribute('aria-modal', 'true');
+		this._callout.tabIndex = -1;
+
+		const header = append(this._callout, $('.spotlight-callout-header'));
+		this._title = append(header, $('h2.spotlight-callout-title'));
+		this._title.id = 'spotlight-callout-title';
+		this._callout.setAttribute('aria-labelledby', this._title.id);
+
+		this._description = append(this._callout, $('.spotlight-callout-description'));
+		this._description.id = 'spotlight-callout-description';
+		this._callout.setAttribute('aria-describedby', this._description.id);
+
+		const footer = append(this._callout, $('.spotlight-callout-footer'));
+		this._counter = append(footer, $('.spotlight-callout-counter'));
+		const actions = append(footer, $('.spotlight-callout-actions'));
+
+		this._skipButton = this._register(new Button(actions, { ...defaultButtonStyles, secondary: true }));
+		this._skipButton.label = localize('spotlight.skip', "Skip");
+		this._register(this._skipButton.onDidClick(() => this._onDidSkip.fire()));
+
+		this._backButton = this._register(new Button(actions, { ...defaultButtonStyles, secondary: true }));
+		this._backButton.label = localize('spotlight.back', "Back");
+		this._register(this._backButton.onDidClick(() => this._onDidClickPrevious.fire()));
+
+		this._nextButton = this._register(new Button(actions, { ...defaultButtonStyles }));
+		this._nextButton.label = localize('spotlight.next', "Next");
+		this._register(this._nextButton.onDidClick(() => this._onDidClickNext.fire()));
+
+		// Keyboard handling on the callout: Esc skips, focus is trapped within.
+		this._register(addDisposableListener(this._callout, EventType.KEY_DOWN, e => this._onKeyDown(e)));
+
+		this._register({ dispose: () => this._restoreFocus() });
+	}
+
+	/** Show `content` spotlighting `target`. */
+	show(target: HTMLElement, content: ISpotlightContent, options: ISpotlightShowOptions = {}): void {
+		const isFirstShow = this._root.style.display === 'none';
+		if (isFirstShow) {
+			this._previousFocus = isHTMLElement(getActiveElement()) ? getActiveElement() as HTMLElement : undefined;
+		}
+
+		this._target = target;
+		this._options = options;
+		this._renderContent(content);
+
+		this._root.style.display = '';
+
+		// Rebuild the per-step re-layout listeners.
+		this._stepListeners.clear();
+		const targetWindow = getWindow(this._container);
+
+		const observer = new this._resizeObserverCtor(() => this._scheduleLayout());
+		observer.observe(target);
+		observer.observe(this._container);
+		this._stepListeners.add({ dispose: () => observer.disconnect() });
+
+		this._stepListeners.add(addDisposableListener(targetWindow, EventType.RESIZE, () => this._scheduleLayout()));
+		this._stepListeners.add(addDisposableListener(targetWindow, EventType.SCROLL, () => this._scheduleLayout(), true));
+
+		// Cancel any pending scheduled frame when the step changes. Registered
+		// once here (not per schedule) so high-frequency scroll/resize events
+		// don't accumulate no-op disposables in `_stepListeners`.
+		this._stepListeners.add(toDisposable(() => {
+			this._scheduledLayout?.dispose();
+			this._scheduledLayout = undefined;
+		}));
+
+		// When the step advances by pressing the target, hide the Next button and
+		// advance on a click of the (interactive) target instead.
+		const advanceOnTargetClick = !!options.advanceOnTargetClick;
+		this._nextButton.element.style.display = advanceOnTargetClick ? 'none' : '';
+		if (advanceOnTargetClick) {
+			this._stepListeners.add(addDisposableListener(target, EventType.CLICK, () => this._onDidClickNext.fire()));
+		}
+
+		this.layout();
+
+		// Move focus into the callout for keyboard users.
+		(advanceOnTargetClick ? this._skipButton : this._nextButton).focus();
+	}
+
+	/** Recompute the hole and callout positions for the current target. */
+	layout(): void {
+		const target = this._target;
+		if (!target || this._root.style.display === 'none') {
+			return;
+		}
+
+		const targetWindow = getWindow(this._container);
+		const viewportWidth = targetWindow.document.documentElement.clientWidth;
+		const viewportHeight = targetWindow.document.documentElement.clientHeight;
+
+		const rect = target.getBoundingClientRect();
+		const padding = this._options.padding ?? DEFAULT_HOLE_PADDING;
+		const holeLeft = Math.max(0, rect.left - padding);
+		const holeTop = Math.max(0, rect.top - padding);
+		const holeWidth = Math.min(viewportWidth - holeLeft, rect.width + padding * 2);
+		const holeHeight = Math.min(viewportHeight - holeTop, rect.height + padding * 2);
+
+		this._hole.style.left = `${holeLeft}px`;
+		this._hole.style.top = `${holeTop}px`;
+		this._hole.style.width = `${holeWidth}px`;
+		this._hole.style.height = `${holeHeight}px`;
+
+		// When the target is interactive (explicitly, or because the step advances
+		// on a target click), cut the hole out of the click blocker so events
+		// inside it reach the underlying element.
+		if (this._options.allowTargetInteraction || this._options.advanceOnTargetClick) {
+			const right = holeLeft + holeWidth;
+			const bottom = holeTop + holeHeight;
+			this._blocker.style.clipPath = `path(evenodd, 'M0 0 H${viewportWidth} V${viewportHeight} H0 Z M${holeLeft} ${holeTop} H${right} V${bottom} H${holeLeft} Z')`;
+		} else {
+			this._blocker.style.clipPath = '';
+		}
+
+		this._layoutCallout({ top: holeTop, left: holeLeft, width: holeWidth, height: holeHeight }, viewportWidth, viewportHeight);
+	}
+
+	private _layoutCallout(anchor: IRect, viewportWidth: number, viewportHeight: number): void {
+		const viewport: IRect = { top: 0, left: 0, width: viewportWidth, height: viewportHeight };
+		const view = { width: this._callout.offsetWidth, height: this._callout.offsetHeight };
+
+		const { anchorAxisAlignment, anchorPosition, anchorAlignment } = this._resolvePlacement(this._options.placement ?? 'auto');
+		const result = layout2d(viewport, view, anchor, { anchorAxisAlignment, anchorPosition, anchorAlignment });
+
+		this._callout.style.top = `${result.top}px`;
+		this._callout.style.left = `${result.left}px`;
+	}
+
+	private _resolvePlacement(placement: SpotlightPlacement): { anchorAxisAlignment: AnchorAxisAlignment; anchorPosition: AnchorPosition; anchorAlignment: AnchorAlignment } {
+		switch (placement) {
+			case 'above':
+				return { anchorAxisAlignment: AnchorAxisAlignment.VERTICAL, anchorPosition: AnchorPosition.ABOVE, anchorAlignment: AnchorAlignment.LEFT };
+			case 'left':
+				return { anchorAxisAlignment: AnchorAxisAlignment.HORIZONTAL, anchorPosition: AnchorPosition.BELOW, anchorAlignment: AnchorAlignment.RIGHT };
+			case 'right':
+				return { anchorAxisAlignment: AnchorAxisAlignment.HORIZONTAL, anchorPosition: AnchorPosition.BELOW, anchorAlignment: AnchorAlignment.LEFT };
+			case 'below':
+			case 'auto':
+			default:
+				return { anchorAxisAlignment: AnchorAxisAlignment.VERTICAL, anchorPosition: AnchorPosition.BELOW, anchorAlignment: AnchorAlignment.LEFT };
+		}
+	}
+
+	private _renderContent(content: ISpotlightContent): void {
+		this._title.textContent = content.title;
+
+		this._descriptionRenderStore.clear();
+		this._description.replaceChildren();
+		if (isMarkdownString(content.description)) {
+			const rendered = this._descriptionRenderStore.add(renderMarkdown(content.description));
+			this._description.appendChild(rendered.element);
+		} else {
+			this._description.textContent = content.description;
+		}
+
+		this._counter.textContent = localize('spotlight.counter', "{0} of {1}", content.stepIndex + 1, content.stepCount);
+
+		this._backButton.element.style.display = content.canGoBack ? '' : 'none';
+		this._nextButton.label = content.isLastStep
+			? localize('spotlight.done', "Done")
+			: localize('spotlight.next', "Next");
+	}
+
+	private _onKeyDown(e: KeyboardEvent): void {
+		const event = new StandardKeyboardEvent(e);
+		if (event.equals(KeyCode.Escape)) {
+			event.stopPropagation();
+			event.preventDefault();
+			this._onDidSkip.fire();
+			return;
+		}
+
+		if (event.equals(KeyCode.Tab) || event.equals(KeyCode.Shift | KeyCode.Tab)) {
+			this._trapFocus(event);
+		}
+	}
+
+	private _trapFocus(event: StandardKeyboardEvent): void {
+		const focusable = this._collectFocusable();
+		if (focusable.length === 0) {
+			return;
+		}
+
+		const active = getActiveElement();
+		const currentIndex = focusable.findIndex(element => element === active);
+		const delta = event.shiftKey ? -1 : 1;
+		const nextIndex = (currentIndex + delta + focusable.length) % focusable.length;
+
+		event.preventDefault();
+		event.stopPropagation();
+		focusable[nextIndex].focus();
+	}
+
+	/**
+	 * The focusable elements inside the callout, in DOM order: any interactive
+	 * content rendered in the (possibly markdown) description first, then the
+	 * visible action buttons. Querying the description ensures links inside a
+	 * markdown body remain keyboard-reachable despite `aria-modal`.
+	 */
+	private _collectFocusable(): HTMLElement[] {
+		const descriptionFocusables = Array.from(
+			// eslint-disable-next-line no-restricted-syntax -- querying our own callout description subtree for focusable markdown content (e.g. links)
+			this._description.querySelectorAll<HTMLElement>('a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])')
+		);
+		const buttons = [this._skipButton, this._backButton, this._nextButton]
+			.filter(button => button.element.style.display !== 'none')
+			.map(button => button.element);
+		return [...descriptionFocusables, ...buttons];
+	}
+
+	private _scheduleLayout(): void {
+		if (this._scheduledLayout) {
+			return;
+		}
+		const targetWindow = getWindow(this._container);
+		this._scheduledLayout = scheduleAtNextAnimationFrame(targetWindow, () => {
+			this._scheduledLayout = undefined;
+			this.layout();
+		});
+	}
+
+	private _restoreFocus(): void {
+		const previous = this._previousFocus;
+		this._previousFocus = undefined;
+		if (previous && previous.isConnected) {
+			previous.focus();
+		}
+	}
+
+	override dispose(): void {
+		this._root.remove();
+		super.dispose();
+	}
+}

--- a/src/vs/workbench/contrib/onboarding/browser/spotlight/spotlightPresentation.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/spotlight/spotlightPresentation.ts
@@ -1,0 +1,156 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { timeout } from '../../../../../base/common/async.js';
+import { onUnexpectedError } from '../../../../../base/common/errors.js';
+import { Disposable, DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
+import { IHostService } from '../../../../services/host/browser/host.js';
+import { IOnboardingPresentation, IOnboardingRunContext } from '../../common/onboardingPresentation.js';
+import { IOnboardingScenario, OnboardingOutcome } from '../../common/onboardingScenario.js';
+import { findOnboardingTarget } from './onboardingTarget.js';
+import { ISpotlightContent, SpotlightOverlay } from './spotlightOverlay.js';
+import { ISpotlightPayload, ISpotlightStep, SPOTLIGHT_PRESENTATION_KIND } from './spotlightTypes.js';
+
+/** How long to wait for a step's target element to appear before skipping it. */
+const TARGET_RESOLVE_TIMEOUT = 2000;
+const TARGET_POLL_INTERVAL = 50;
+
+type StepAction = 'next' | 'back' | 'skip' | 'abort';
+
+/**
+ * Renders {@link ISpotlightPayload} scenarios: it dims the window (including the
+ * native window controls), walks the steps, and shows an anchored callout for
+ * each. Implements the engine's {@link IOnboardingPresentation} contract so the
+ * scenario engine can drive it without knowing anything about spotlights.
+ */
+export class SpotlightPresentation extends Disposable implements IOnboardingPresentation {
+
+	readonly kind = SPOTLIGHT_PRESENTATION_KIND;
+
+	constructor(
+		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
+		@IHostService private readonly hostService: IHostService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+	) {
+		super();
+	}
+
+	async run(scenario: IOnboardingScenario, context: IOnboardingRunContext): Promise<OnboardingOutcome> {
+		const payload = scenario.presentation.payload as ISpotlightPayload;
+		const steps = payload?.steps ?? [];
+		if (steps.length === 0) {
+			return OnboardingOutcome.Completed;
+		}
+
+		const store = new DisposableStore();
+		try {
+			const container = this.layoutService.getContainer(context.targetWindow);
+			const overlay = store.add(new SpotlightOverlay(container));
+
+			// Dim the native window controls overlay in sync with the dim layer.
+			this.hostService.setWindowDimmed(context.targetWindow, true);
+			store.add(toDisposable(() => this.hostService.setWindowDimmed(context.targetWindow, false)));
+
+			let aborted = false;
+			store.add(context.onAbort(() => { aborted = true; }));
+
+			// Keep the callout glued to the target as the workbench re-layouts.
+			store.add(this.layoutService.onDidLayoutContainer(() => overlay.layout()));
+
+			let index = 0;
+			let direction: 1 | -1 = 1;
+
+			while (index >= 0 && index < steps.length && !aborted) {
+				const step = steps[index];
+
+				if (step.when && !this.contextKeyService.contextMatchesRules(step.when)) {
+					index += direction;
+					continue;
+				}
+
+				try {
+					await step.onBeforeShow?.();
+				} catch (error) {
+					onUnexpectedError(error);
+				}
+				if (aborted) {
+					break;
+				}
+
+				const target = await this._resolveTarget(context.targetWindow, step.targetId);
+				if (aborted) {
+					break;
+				}
+				if (!target) {
+					index += direction;
+					continue;
+				}
+
+				const action = await this._runStep(overlay, context, step, target, index, steps.length);
+				switch (action) {
+					case 'next':
+						direction = 1;
+						index++;
+						break;
+					case 'back':
+						direction = -1;
+						index--;
+						break;
+					case 'skip':
+						return OnboardingOutcome.Skipped;
+					case 'abort':
+						return OnboardingOutcome.Aborted;
+				}
+			}
+
+			return aborted ? OnboardingOutcome.Aborted : OnboardingOutcome.Completed;
+		} finally {
+			store.dispose();
+		}
+	}
+
+	private async _resolveTarget(targetWindow: Window, targetId: string): Promise<HTMLElement | undefined> {
+		const deadline = Date.now() + TARGET_RESOLVE_TIMEOUT;
+		let element = findOnboardingTarget(targetWindow, targetId);
+		while (!element && Date.now() < deadline) {
+			await timeout(TARGET_POLL_INTERVAL);
+			element = findOnboardingTarget(targetWindow, targetId);
+		}
+		return element;
+	}
+
+	private _runStep(overlay: SpotlightOverlay, context: IOnboardingRunContext, step: ISpotlightStep, target: HTMLElement, index: number, stepCount: number): Promise<StepAction> {
+		return new Promise<StepAction>(resolve => {
+			const stepStore = new DisposableStore();
+			const done = (action: StepAction) => {
+				stepStore.dispose();
+				resolve(action);
+			};
+
+			stepStore.add(overlay.onDidClickNext(() => done('next')));
+			stepStore.add(overlay.onDidClickPrevious(() => done('back')));
+			stepStore.add(overlay.onDidSkip(() => done('skip')));
+			stepStore.add(context.onAbort(() => done('abort')));
+
+			const content: ISpotlightContent = {
+				title: step.title,
+				description: step.description,
+				stepIndex: index,
+				stepCount,
+				canGoBack: index > 0,
+				isLastStep: index === stepCount - 1,
+			};
+
+			overlay.show(target, content, {
+				placement: step.placement,
+				allowTargetInteraction: step.allowTargetInteraction,
+				advanceOnTargetClick: step.advanceOnTargetClick,
+				padding: step.padding,
+			});
+		});
+	}
+}

--- a/src/vs/workbench/contrib/onboarding/browser/spotlight/spotlightTypes.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/spotlight/spotlightTypes.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
+import { ContextKeyExpression } from '../../../../../platform/contextkey/common/contextkey.js';
+
+/** The presentation `kind` handled by the spotlight presentation. */
+export const SPOTLIGHT_PRESENTATION_KIND = 'spotlight';
+
+/** Preferred placement of the callout relative to the spotlighted target. */
+export type SpotlightPlacement = 'above' | 'below' | 'left' | 'right' | 'auto';
+
+/**
+ * A single step in a spotlight tour. Steps are pure data; the spotlight
+ * presentation turns them into the dim overlay, the cut-out highlight and the
+ * anchored callout.
+ */
+export interface ISpotlightStep {
+	/** Stable identifier (unique within the tour). */
+	readonly id: string;
+
+	/**
+	 * The `data-onboarding-id` of the element to spotlight. Resolved on demand
+	 * via {@link findOnboardingTarget} so steps work even if the element is not
+	 * yet rendered when the tour starts.
+	 */
+	readonly targetId: string;
+
+	/** Callout heading (localized). */
+	readonly title: string;
+
+	/** Callout body (localized string or markdown). */
+	readonly description: string | IMarkdownString;
+
+	/** Preferred placement of the callout. Defaults to `'auto'`. */
+	readonly placement?: SpotlightPlacement;
+
+	/** When present and unsatisfied, the step is skipped. */
+	readonly when?: ContextKeyExpression;
+
+	/** Allow the spotlighted element to remain interactive. Defaults to `false`. */
+	readonly allowTargetInteraction?: boolean;
+
+	/**
+	 * When set, the step advances when the user clicks the spotlighted target
+	 * itself (rather than a "Next" button). The target is kept interactive.
+	 */
+	readonly advanceOnTargetClick?: boolean;
+
+	/** Extra padding (px) around the target when cutting the highlight hole. */
+	readonly padding?: number;
+
+	/**
+	 * Optional hook run just before the step is shown, e.g. to open the view
+	 * that hosts the target. Awaited before the target is resolved.
+	 */
+	readonly onBeforeShow?: () => Promise<void> | void;
+}
+
+/**
+ * The payload of a spotlight scenario: an ordered list of steps.
+ */
+export interface ISpotlightPayload {
+	readonly steps: readonly ISpotlightStep[];
+}

--- a/src/vs/workbench/contrib/onboarding/common/onboardingPresentation.ts
+++ b/src/vs/workbench/contrib/onboarding/common/onboardingPresentation.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../../../base/common/event.js';
+import { IDisposable } from '../../../../base/common/lifecycle.js';
+import { IOnboardingScenario, OnboardingOutcome } from './onboardingScenario.js';
+
+/**
+ * Context handed to a presentation for a single scenario run. Exposes only what
+ * a presentation needs without leaking engine internals.
+ */
+export interface IOnboardingRunContext {
+	/** The window hosting the UI the scenario targets (usually the main window). */
+	readonly targetWindow: Window;
+
+	/**
+	 * Fires when the engine wants the presentation to abort the current run
+	 * (e.g. the application is shutting down). The presentation should resolve
+	 * its `run` promise with {@link OnboardingOutcome.Aborted}.
+	 */
+	readonly onAbort: Event<void>;
+}
+
+/**
+ * A presentation renders a scenario. The engine is presentation-agnostic: it
+ * looks up a presentation by {@link IOnboardingScenario.presentation} `kind`
+ * and delegates rendering to it. New onboarding styles (spotlight, banner,
+ * modal, checklist, ...) are added by registering additional presentations.
+ */
+export interface IOnboardingPresentation {
+	/** The kind this presentation handles, e.g. `'spotlight'`. */
+	readonly kind: string;
+
+	/**
+	 * Render the scenario and resolve with the outcome once the user (or the
+	 * engine) ends the run. Implementations must clean up all UI/listeners
+	 * regardless of how the run ends.
+	 */
+	run(scenario: IOnboardingScenario, context: IOnboardingRunContext): Promise<OnboardingOutcome>;
+}
+
+/**
+ * Registry mapping a presentation `kind` to its implementation.
+ */
+export interface IOnboardingPresentationRegistry {
+	/** Register a presentation. Throws if the kind is already registered. */
+	register(presentation: IOnboardingPresentation): IDisposable;
+	/** Look up a presentation by kind. */
+	get(kind: string): IOnboardingPresentation | undefined;
+}
+
+class OnboardingPresentationRegistry implements IOnboardingPresentationRegistry {
+
+	private readonly _presentations = new Map<string, IOnboardingPresentation>();
+
+	register(presentation: IOnboardingPresentation): IDisposable {
+		const kind = presentation.kind;
+		if (this._presentations.has(kind)) {
+			throw new Error(`An onboarding presentation with kind '${kind}' is already registered.`);
+		}
+		this._presentations.set(kind, presentation);
+		return {
+			dispose: () => {
+				if (this._presentations.get(kind) === presentation) {
+					this._presentations.delete(kind);
+				}
+			}
+		};
+	}
+
+	get(kind: string): IOnboardingPresentation | undefined {
+		return this._presentations.get(kind);
+	}
+}
+
+/**
+ * Global presentation registry. Presentations register here (typically from the
+ * workbench contribution), and the engine resolves them when running scenarios.
+ */
+export const onboardingPresentationRegistry: IOnboardingPresentationRegistry = new OnboardingPresentationRegistry();

--- a/src/vs/workbench/contrib/onboarding/common/onboardingRegistry.ts
+++ b/src/vs/workbench/contrib/onboarding/common/onboardingRegistry.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { IDisposable } from '../../../../base/common/lifecycle.js';
+import { IOnboardingScenario } from './onboardingScenario.js';
+
+/**
+ * Registry of onboarding scenarios. Feature areas register their scenarios here
+ * (pure data); the engine reads from it to decide what to run.
+ */
+export interface IOnboardingScenarioRegistry {
+	/** Register a scenario. Throws if a scenario with the same id already exists. */
+	register(scenario: IOnboardingScenario): IDisposable;
+	/** All currently registered scenarios. */
+	getScenarios(): readonly IOnboardingScenario[];
+	/** Look up a single scenario by id. */
+	getScenario(id: string): IOnboardingScenario | undefined;
+	/** Fires when scenarios are added or removed. */
+	readonly onDidChange: Event<void>;
+}
+
+class OnboardingScenarioRegistry implements IOnboardingScenarioRegistry {
+
+	private readonly _scenarios = new Map<string, IOnboardingScenario>();
+
+	private readonly _onDidChange = new Emitter<void>();
+	readonly onDidChange: Event<void> = this._onDidChange.event;
+
+	register(scenario: IOnboardingScenario): IDisposable {
+		const id = scenario.id;
+		if (this._scenarios.has(id)) {
+			throw new Error(`An onboarding scenario with id '${id}' is already registered.`);
+		}
+		this._scenarios.set(id, scenario);
+		this._onDidChange.fire();
+		return {
+			dispose: () => {
+				if (this._scenarios.get(id) === scenario) {
+					this._scenarios.delete(id);
+					this._onDidChange.fire();
+				}
+			}
+		};
+	}
+
+	getScenarios(): readonly IOnboardingScenario[] {
+		return Array.from(this._scenarios.values());
+	}
+
+	getScenario(id: string): IOnboardingScenario | undefined {
+		return this._scenarios.get(id);
+	}
+}
+
+/**
+ * Global scenario registry. Scenario data files register here on import.
+ */
+export const onboardingScenarioRegistry: IOnboardingScenarioRegistry = new OnboardingScenarioRegistry();

--- a/src/vs/workbench/contrib/onboarding/common/onboardingScenario.ts
+++ b/src/vs/workbench/contrib/onboarding/common/onboardingScenario.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IObservable } from '../../../../base/common/observable.js';
+import { ContextKeyExpression } from '../../../../platform/contextkey/common/contextkey.js';
+
+/**
+ * Describes when an onboarding scenario becomes eligible to run automatically.
+ */
+export type OnboardingTrigger =
+	/** Eligible as soon as the scenario's `when` clause is satisfied. */
+	| { readonly kind: 'auto' }
+	/** Only started explicitly via a command (never runs automatically). */
+	| { readonly kind: 'command'; readonly commandId: string }
+	/** Eligible whenever the provided observable yields `true`. */
+	| { readonly kind: 'observable'; readonly signal: IObservable<boolean> };
+
+/**
+ * A reference to a registered {@link IOnboardingPresentation} together with the
+ * opaque payload that presentation understands (e.g. spotlight steps).
+ */
+export interface IOnboardingPresentationRef<TPayload = unknown> {
+	/** The presentation kind, e.g. `'spotlight'`. */
+	readonly kind: string;
+	/** Presentation-specific data. The engine never inspects this. */
+	readonly payload: TPayload;
+}
+
+/**
+ * A declarative onboarding scenario. Scenarios are pure data: they describe
+ * *when* onboarding should happen and *which* presentation renders it, but not
+ * *how* it is rendered (that is the presentation's job).
+ */
+export interface IOnboardingScenario<TPayload = unknown> {
+	/** Stable identifier. Used as the persistence key for "shown once" state. */
+	readonly id: string;
+
+	/** Eligibility gate. AND-ed with the engine's own checks. */
+	readonly when?: ContextKeyExpression;
+
+	/** How the scenario becomes eligible to run automatically. */
+	readonly trigger: OnboardingTrigger;
+
+	/** Higher priority scenarios run first when several are eligible at once. Default `0`. */
+	readonly priority?: number;
+
+	/** The presentation that renders this scenario plus its payload. */
+	readonly presentation: IOnboardingPresentationRef<TPayload>;
+
+	/** Optional experiment treatment id that must be enabled for the scenario to run. */
+	readonly experiment?: string;
+
+	/** When `true`, the scenario runs on every eligible session instead of once per user. */
+	readonly repeatable?: boolean;
+}
+
+/**
+ * The result of running a scenario's presentation.
+ */
+export const enum OnboardingOutcome {
+	/** The user reached the end of the scenario. */
+	Completed = 'completed',
+	/** The user explicitly skipped the scenario. */
+	Skipped = 'skipped',
+	/** The scenario was dismissed (e.g. closed without an explicit skip). */
+	Dismissed = 'dismissed',
+	/** The scenario was aborted by the engine (e.g. window shutdown, target lost). */
+	Aborted = 'aborted'
+}

--- a/src/vs/workbench/contrib/onboarding/common/onboardingScenarioService.ts
+++ b/src/vs/workbench/contrib/onboarding/common/onboardingScenarioService.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { IOnboardingScenario, OnboardingOutcome } from './onboardingScenario.js';
+
+export const IOnboardingScenarioService = createDecorator<IOnboardingScenarioService>('onboardingScenarioService');
+
+/** Global setting that enables/disables *automatic* onboarding scenarios. */
+export const ONBOARDING_ENABLED_CONFIG = 'onboarding.enabled';
+
+/**
+ * Developer/advanced setting. When enabled, onboarding tours bypass usage-based
+ * eligibility gating (e.g. the new-session tour's "first few sessions" check) so
+ * they can be triggered on demand for testing. Tours are still shown at most
+ * once — use the "Reset Onboarding Shown State" command to replay them.
+ */
+export const ONBOARDING_DEVELOPER_MODE_CONFIG = 'onboarding.developerMode';
+
+/**
+ * The presentation-agnostic onboarding engine. It decides *when* and *whether*
+ * a scenario runs (eligibility, scheduling, once-per-user persistence) and
+ * delegates *how* it is rendered to a registered presentation.
+ */
+export interface IOnboardingScenarioService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Begin watching scenario eligibility. Automatic scenarios may start as soon
+	 * as they become eligible. Safe to call multiple times (no-op after first).
+	 */
+	start(): void;
+
+	/**
+	 * Run a scenario on demand, bypassing the once-per-user gate and the global
+	 * `onboarding.enabled` setting. Used by command triggers and the (future)
+	 * tutorial page. Still serialized with any in-flight scenario.
+	 */
+	runScenario(id: string): Promise<OnboardingOutcome>;
+
+	/**
+	 * All registered scenarios (across presentation kinds). Useful for a tutorial
+	 * page that lists everything the user can replay.
+	 */
+	getScenarios(): readonly IOnboardingScenario[];
+
+	/** Whether the scenario has already been shown to the user. */
+	hasBeenShown(id: string): boolean;
+
+	/** Clear the "shown" state for a single scenario (developer/testing aid). */
+	reset(id: string): void;
+
+	/** Clear the "shown" state for all scenarios (developer/testing aid). */
+	resetAll(): void;
+}

--- a/src/vs/workbench/contrib/onboarding/test/browser/onboardingService.test.ts
+++ b/src/vs/workbench/contrib/onboarding/test/browser/onboardingService.test.ts
@@ -45,7 +45,10 @@ class BlockingUntilAbortPresentation implements IOnboardingPresentation {
 	run(scenario: IOnboardingScenario, context: IOnboardingRunContext): Promise<OnboardingOutcome> {
 		this.runs.push(scenario.id);
 		return new Promise<OnboardingOutcome>(resolve => {
-			context.onAbort(() => resolve(OnboardingOutcome.Aborted));
+			const listener = context.onAbort(() => {
+				listener.dispose();
+				resolve(OnboardingOutcome.Aborted);
+			});
 		});
 	}
 }

--- a/src/vs/workbench/contrib/onboarding/test/browser/onboardingService.test.ts
+++ b/src/vs/workbench/contrib/onboarding/test/browser/onboardingService.test.ts
@@ -203,6 +203,37 @@ suite('OnboardingScenarioService', () => {
 		assert.deepStrictEqual({ runs: presentation.runs, outcome }, { runs: ['manual-1'], outcome: OnboardingOutcome.Completed });
 	});
 
+	test('runScenario joins an in-flight run instead of starting a second one', async () => {
+		let release!: () => void;
+		const gate = new Promise<void>(resolve => { release = resolve; });
+		const kind = uniqueKind();
+		const runs: string[] = [];
+		const presentation: IOnboardingPresentation = {
+			kind,
+			async run(scenario: IOnboardingScenario): Promise<OnboardingOutcome> {
+				runs.push(scenario.id);
+				await gate;
+				return OnboardingOutcome.Completed;
+			}
+		};
+		registerPresentation(presentation);
+		registerScenario({ id: 'inflight-1', trigger: { kind: 'command', commandId: 'noop' }, presentation: { kind, payload: undefined } });
+
+		const { service } = createService();
+		service.start();
+
+		const first = service.runScenario('inflight-1');
+		await timeout(0);
+		// Second call while the first run is still in-flight must not start again.
+		const second = service.runScenario('inflight-1');
+		await timeout(0);
+
+		release();
+		const [a, b] = await Promise.all([first, second]);
+
+		assert.deepStrictEqual({ runs, a, b }, { runs: ['inflight-1'], a: OnboardingOutcome.Completed, b: OnboardingOutcome.Completed });
+	});
+
 	test('resetAll clears shown state so the scenario can run again', async () => {
 		const presentation = new RecordingPresentation(uniqueKind());
 		registerPresentation(presentation);

--- a/src/vs/workbench/contrib/onboarding/test/browser/onboardingService.test.ts
+++ b/src/vs/workbench/contrib/onboarding/test/browser/onboardingService.test.ts
@@ -1,0 +1,289 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { timeout } from '../../../../../base/common/async.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { observableValue } from '../../../../../base/common/observable.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { ContextKeyExpr, IContextKey, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyService } from '../../../../../platform/contextkey/browser/contextKeyService.js';
+import { InMemoryStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
+import { Memento } from '../../../../common/memento.js';
+import { IWorkbenchAssignmentService } from '../../../../services/assignment/common/assignmentService.js';
+import { NullWorkbenchAssignmentService } from '../../../../services/assignment/test/common/nullAssignmentService.js';
+import { TestLifecycleService } from '../../../../test/common/workbenchTestServices.js';
+import { OnboardingScenarioService } from '../../browser/onboardingService.js';
+import { IOnboardingPresentation, IOnboardingRunContext, onboardingPresentationRegistry } from '../../common/onboardingPresentation.js';
+import { onboardingScenarioRegistry } from '../../common/onboardingRegistry.js';
+import { IOnboardingScenario, OnboardingOutcome } from '../../common/onboardingScenario.js';
+import { ONBOARDING_ENABLED_CONFIG } from '../../common/onboardingScenarioService.js';
+
+/** Records every scenario it renders, then resolves with a fixed outcome. */
+class RecordingPresentation implements IOnboardingPresentation {
+	readonly runs: string[] = [];
+	constructor(
+		readonly kind: string,
+		private readonly outcome: OnboardingOutcome = OnboardingOutcome.Completed,
+		private readonly onRun?: () => void,
+	) { }
+	async run(scenario: IOnboardingScenario, _context: IOnboardingRunContext): Promise<OnboardingOutcome> {
+		this.runs.push(scenario.id);
+		this.onRun?.();
+		return this.outcome;
+	}
+}
+
+/** Blocks until the engine aborts the run (used to test shutdown behaviour). */
+class BlockingUntilAbortPresentation implements IOnboardingPresentation {
+	readonly runs: string[] = [];
+	constructor(readonly kind: string) { }
+	run(scenario: IOnboardingScenario, context: IOnboardingRunContext): Promise<OnboardingOutcome> {
+		this.runs.push(scenario.id);
+		return new Promise<OnboardingOutcome>(resolve => {
+			context.onAbort(() => resolve(OnboardingOutcome.Aborted));
+		});
+	}
+}
+
+suite('OnboardingScenarioService', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	teardown(() => {
+		// The Memento maintains a static cache keyed by id; clear it so each test
+		// starts with fresh persisted state instead of leaking across tests.
+		Memento.clear(StorageScope.PROFILE);
+	});
+
+	let idSeed = 0;
+	function uniqueKind(): string { return `test-presentation-${idSeed++}`; }
+
+	function createService(configValues: Record<string, unknown> = {}, assignment?: IWorkbenchAssignmentService): { service: OnboardingScenarioService; contextKeyService: IContextKeyService; config: TestConfigurationService; lifecycle: TestLifecycleService } {
+		const store = disposables;
+		const storage = store.add(new InMemoryStorageService());
+		const config = new TestConfigurationService(configValues);
+		const contextKeyService = store.add(new ContextKeyService(config));
+		const lifecycle = store.add(new TestLifecycleService());
+		const service = store.add(new OnboardingScenarioService(
+			storage,
+			contextKeyService,
+			config as unknown as IConfigurationService,
+			lifecycle,
+			assignment ?? new NullWorkbenchAssignmentService(),
+		));
+		return { service, contextKeyService, config, lifecycle };
+	}
+
+	function registerPresentation(presentation: IOnboardingPresentation): void {
+		disposables.add(onboardingPresentationRegistry.register(presentation));
+	}
+
+	function registerScenario(scenario: IOnboardingScenario): void {
+		disposables.add(onboardingScenarioRegistry.register(scenario));
+	}
+
+	test('runs an eligible auto scenario exactly once and marks it shown', async () => {
+		const presentation = new RecordingPresentation(uniqueKind());
+		registerPresentation(presentation);
+		registerScenario({ id: 'auto-1', trigger: { kind: 'auto' }, presentation: { kind: presentation.kind, payload: undefined } });
+
+		const { service } = createService();
+		service.start();
+		await timeout(0);
+
+		// Re-evaluating (e.g. another start) must not run it again.
+		service.start();
+		await timeout(0);
+
+		assert.deepStrictEqual(
+			{ runs: presentation.runs, shown: service.hasBeenShown('auto-1') },
+			{ runs: ['auto-1'], shown: true }
+		);
+	});
+
+	test('does not run automatically when onboarding.enabled is false', async () => {
+		const presentation = new RecordingPresentation(uniqueKind());
+		registerPresentation(presentation);
+		registerScenario({ id: 'disabled-1', trigger: { kind: 'auto' }, presentation: { kind: presentation.kind, payload: undefined } });
+
+		const { service } = createService({ [ONBOARDING_ENABLED_CONFIG]: false });
+		service.start();
+		await timeout(0);
+
+		assert.deepStrictEqual(presentation.runs, []);
+	});
+
+	test('respects the when clause and reacts to context changes', async () => {
+		const presentation = new RecordingPresentation(uniqueKind());
+		registerPresentation(presentation);
+		registerScenario({
+			id: 'when-1',
+			when: ContextKeyExpr.equals('onboardingTestReady', true),
+			trigger: { kind: 'auto' },
+			presentation: { kind: presentation.kind, payload: undefined }
+		});
+
+		const { service, contextKeyService } = createService();
+		service.start();
+		await timeout(0);
+		assert.deepStrictEqual(presentation.runs, [], 'should not run while when is unsatisfied');
+
+		const key: IContextKey<boolean> = contextKeyService.createKey('onboardingTestReady', false);
+		key.set(true);
+		await timeout(0);
+
+		assert.deepStrictEqual(presentation.runs, ['when-1']);
+	});
+
+	test('runs higher-priority scenarios before lower-priority ones', async () => {
+		const order: string[] = [];
+		const presentation = new RecordingPresentation(uniqueKind(), OnboardingOutcome.Completed);
+		// Track ordering via the recorder's runs array which is appended in run().
+		registerPresentation(presentation);
+		registerScenario({ id: 'low', priority: 1, trigger: { kind: 'auto' }, presentation: { kind: presentation.kind, payload: undefined } });
+		registerScenario({ id: 'high', priority: 10, trigger: { kind: 'auto' }, presentation: { kind: presentation.kind, payload: undefined } });
+
+		const { service } = createService();
+		service.start();
+		await timeout(0);
+		order.push(...presentation.runs);
+
+		assert.deepStrictEqual(order, ['high', 'low']);
+	});
+
+	test('observable triggers start the scenario when the signal turns true', async () => {
+		const presentation = new RecordingPresentation(uniqueKind());
+		registerPresentation(presentation);
+		const signal = observableValue<boolean>('onboardingTestSignal', false);
+		registerScenario({ id: 'observable-1', trigger: { kind: 'observable', signal }, presentation: { kind: presentation.kind, payload: undefined } });
+
+		const { service } = createService();
+		service.start();
+		await timeout(0);
+		assert.deepStrictEqual(presentation.runs, [], 'should not run while signal is false');
+
+		signal.set(true, undefined);
+		await timeout(0);
+
+		assert.deepStrictEqual(presentation.runs, ['observable-1']);
+	});
+
+	test('command-triggered scenarios never run automatically', async () => {
+		const presentation = new RecordingPresentation(uniqueKind());
+		registerPresentation(presentation);
+		registerScenario({ id: 'command-1', trigger: { kind: 'command', commandId: 'noop' }, presentation: { kind: presentation.kind, payload: undefined } });
+
+		const { service } = createService();
+		service.start();
+		await timeout(0);
+
+		assert.deepStrictEqual(presentation.runs, []);
+	});
+
+	test('runScenario runs manually even when disabled and already shown', async () => {
+		const presentation = new RecordingPresentation(uniqueKind());
+		registerPresentation(presentation);
+		registerScenario({ id: 'manual-1', trigger: { kind: 'auto' }, presentation: { kind: presentation.kind, payload: undefined } });
+
+		const { service } = createService({ [ONBOARDING_ENABLED_CONFIG]: false });
+		service.start();
+		await timeout(0);
+		assert.deepStrictEqual(presentation.runs, [], 'disabled: should not auto-run');
+
+		const outcome = await service.runScenario('manual-1');
+
+		assert.deepStrictEqual({ runs: presentation.runs, outcome }, { runs: ['manual-1'], outcome: OnboardingOutcome.Completed });
+	});
+
+	test('resetAll clears shown state so the scenario can run again', async () => {
+		const presentation = new RecordingPresentation(uniqueKind());
+		registerPresentation(presentation);
+		registerScenario({ id: 'reset-1', trigger: { kind: 'auto' }, presentation: { kind: presentation.kind, payload: undefined } });
+
+		const { service } = createService();
+		service.start();
+		await timeout(0);
+
+		service.resetAll();
+		assert.strictEqual(service.hasBeenShown('reset-1'), false);
+	});
+
+	test('experiment gate blocks the scenario until the treatment is enabled', async () => {
+		const presentation = new RecordingPresentation(uniqueKind());
+		registerPresentation(presentation);
+
+		class DisabledExperimentAssignmentService extends NullWorkbenchAssignmentService {
+			override async getTreatment<T extends string | number | boolean>(_name: string): Promise<T | undefined> {
+				return undefined;
+			}
+		}
+
+		registerScenario({ id: 'exp-off', experiment: 'exp.disabled', trigger: { kind: 'auto' }, presentation: { kind: presentation.kind, payload: undefined } });
+
+		const { service } = createService({}, new DisabledExperimentAssignmentService());
+		service.start();
+		await timeout(0);
+
+		assert.deepStrictEqual(presentation.runs, []);
+	});
+
+	test('experiment gate allows the scenario once the treatment resolves true', async () => {
+		const presentation = new RecordingPresentation(uniqueKind());
+		registerPresentation(presentation);
+
+		class EnabledExperimentAssignmentService extends NullWorkbenchAssignmentService {
+			override async getTreatment<T extends string | number | boolean>(_name: string): Promise<T | undefined> {
+				return true as T;
+			}
+		}
+
+		registerScenario({ id: 'exp-on', experiment: 'exp.enabled', trigger: { kind: 'auto' }, presentation: { kind: presentation.kind, payload: undefined } });
+
+		const { service } = createService({}, new EnabledExperimentAssignmentService());
+		service.start();
+		// Allow the async treatment fetch + re-evaluation to settle.
+		await timeout(0);
+		await timeout(0);
+
+		assert.deepStrictEqual(presentation.runs, ['exp-on']);
+	});
+
+	test('shutdown aborts the active scenario and never starts queued ones', async () => {
+		const active = new BlockingUntilAbortPresentation(uniqueKind());
+		const queued = new RecordingPresentation(uniqueKind());
+		registerPresentation(active);
+		registerPresentation(queued);
+		// `active` has higher priority so it runs first and blocks; `queued` waits.
+		registerScenario({ id: 'active', priority: 10, trigger: { kind: 'auto' }, presentation: { kind: active.kind, payload: undefined } });
+		registerScenario({ id: 'queued', priority: 1, trigger: { kind: 'auto' }, presentation: { kind: queued.kind, payload: undefined } });
+
+		const { service, lifecycle } = createService();
+		service.start();
+		await timeout(0);
+		// Only the active (blocking) scenario should have started.
+		assert.deepStrictEqual({ active: active.runs, queued: queued.runs }, { active: ['active'], queued: [] });
+
+		lifecycle.fireShutdown();
+		await timeout(0);
+
+		// The queued scenario must never have been presented.
+		assert.deepStrictEqual({ active: active.runs, queued: queued.runs }, { active: ['active'], queued: [] });
+	});
+
+	test('service starts and disposes without leaking', () => {
+		const store = new DisposableStore();
+		const storage = store.add(new InMemoryStorageService());
+		const config = new TestConfigurationService();
+		const contextKeyService = store.add(new ContextKeyService(config));
+		const lifecycle = store.add(new TestLifecycleService());
+		const service = store.add(new OnboardingScenarioService(storage, contextKeyService, config as unknown as IConfigurationService, lifecycle, new NullWorkbenchAssignmentService()));
+		service.start();
+		store.dispose();
+		assert.ok(true);
+	});
+});

--- a/src/vs/workbench/contrib/onboarding/test/browser/spotlightOverlay.test.ts
+++ b/src/vs/workbench/contrib/onboarding/test/browser/spotlightOverlay.test.ts
@@ -183,7 +183,11 @@ suite('SpotlightOverlay', () => {
 		// With the link focused, Shift+Tab should cycle to the last button (Next),
 		// proving the link participates in the trap rather than being skipped.
 		link!.focus();
-		callout.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9 /* Tab */, shiftKey: true, bubbles: true, cancelable: true } as KeyboardEventInit));
+		const event = new KeyboardEvent('keydown', { shiftKey: true, bubbles: true, cancelable: true });
+		// The KeyboardEvent constructor does not honor `keyCode` from the init dict
+		// in all engines, so set it explicitly (StandardKeyboardEvent reads keyCode).
+		Object.defineProperty(event, 'keyCode', { get: () => 9 /* Tab */ });
+		callout.dispatchEvent(event);
 
 		assert.strictEqual(mainWindow.document.activeElement, getButtons(container).at(-1));
 	});

--- a/src/vs/workbench/contrib/onboarding/test/browser/spotlightOverlay.test.ts
+++ b/src/vs/workbench/contrib/onboarding/test/browser/spotlightOverlay.test.ts
@@ -1,0 +1,201 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { $ } from '../../../../../base/browser/dom.js';
+import { mainWindow } from '../../../../../base/browser/window.js';
+import { MarkdownString } from '../../../../../base/common/htmlContent.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ISpotlightContent, SpotlightOverlay } from '../../browser/spotlight/spotlightOverlay.js';
+
+/** Minimal fake ResizeObserver so the widget can be tested without real layout churn. */
+class FakeResizeObserver implements ResizeObserver {
+	readonly observed: Element[] = [];
+	constructor(private readonly _callback: ResizeObserverCallback) { }
+	observe(target: Element): void { this.observed.push(target); }
+	unobserve(): void { }
+	disconnect(): void { }
+	trigger(): void { this._callback([], this); }
+}
+
+suite('SpotlightOverlay', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createContainer(): HTMLElement {
+		const container = $('div.test-spotlight-container');
+		mainWindow.document.body.appendChild(container);
+		disposables.add({ dispose: () => container.remove() });
+		return container;
+	}
+
+	function createTarget(container: HTMLElement, left: number, top: number, width: number, height: number): HTMLElement {
+		const target = $('div.test-spotlight-target');
+		target.style.position = 'fixed';
+		target.style.left = `${left}px`;
+		target.style.top = `${top}px`;
+		target.style.width = `${width}px`;
+		target.style.height = `${height}px`;
+		container.appendChild(target);
+		return target;
+	}
+
+	function content(overrides: Partial<ISpotlightContent> = {}): ISpotlightContent {
+		return {
+			title: 'My Title',
+			description: 'My description',
+			stepIndex: 1,
+			stepCount: 3,
+			canGoBack: true,
+			isLastStep: false,
+			...overrides
+		};
+	}
+
+	function getButtons(container: HTMLElement): HTMLElement[] {
+		return Array.from(container.getElementsByClassName('monaco-button')) as HTMLElement[];
+	}
+
+	test('show renders content and positions the hole around the target (+padding)', () => {
+		const container = createContainer();
+		const overlay = disposables.add(new SpotlightOverlay(container, FakeResizeObserver as unknown as typeof ResizeObserver));
+		const target = createTarget(container, 100, 50, 200, 40);
+
+		overlay.show(target, content());
+
+		const root = container.getElementsByClassName('spotlight-overlay')[0] as HTMLElement;
+		const hole = container.getElementsByClassName('spotlight-hole')[0] as HTMLElement;
+
+		assert.deepStrictEqual({
+			visible: root.style.display !== 'none',
+			title: container.getElementsByClassName('spotlight-callout-title')[0].textContent,
+			description: container.getElementsByClassName('spotlight-callout-description')[0].textContent,
+			counter: container.getElementsByClassName('spotlight-callout-counter')[0].textContent,
+			holeLeft: hole.style.left,
+			holeTop: hole.style.top,
+			holeWidth: hole.style.width,
+			holeHeight: hole.style.height,
+		}, {
+			visible: true,
+			title: 'My Title',
+			description: 'My description',
+			counter: '2 of 3',
+			holeLeft: '94px',
+			holeTop: '44px',
+			holeWidth: '212px',
+			holeHeight: '52px',
+		});
+	});
+
+	test('Next / Back / Skip buttons fire the corresponding events', () => {
+		const container = createContainer();
+		const overlay = disposables.add(new SpotlightOverlay(container, FakeResizeObserver as unknown as typeof ResizeObserver));
+		const target = createTarget(container, 0, 0, 50, 50);
+
+		const fired: string[] = [];
+		disposables.add(overlay.onDidSkip(() => fired.push('skip')));
+		disposables.add(overlay.onDidClickPrevious(() => fired.push('back')));
+		disposables.add(overlay.onDidClickNext(() => fired.push('next')));
+
+		overlay.show(target, content());
+
+		// Buttons are appended in order: Skip, Back, Next.
+		const [skip, back, next] = getButtons(container);
+		skip.click();
+		back.click();
+		next.click();
+
+		assert.deepStrictEqual(fired, ['skip', 'back', 'next']);
+	});
+
+	test('advanceOnTargetClick hides Next and advances when the target is clicked', () => {
+		const container = createContainer();
+		const overlay = disposables.add(new SpotlightOverlay(container, FakeResizeObserver as unknown as typeof ResizeObserver));
+		const target = createTarget(container, 100, 100, 80, 30);
+
+		let advanced = 0;
+		disposables.add(overlay.onDidClickNext(() => advanced++));
+
+		overlay.show(target, content(), { advanceOnTargetClick: true });
+
+		const [, , next] = getButtons(container);
+		const blocker = container.getElementsByClassName('spotlight-blocker')[0] as HTMLElement;
+		target.click();
+
+		assert.deepStrictEqual({
+			nextHidden: next.style.display === 'none',
+			interactive: blocker.style.clipPath.includes('evenodd'),
+			advanced
+		}, { nextHidden: true, interactive: true, advanced: 1 });
+	});
+
+	test('Back button is hidden when canGoBack is false and Next becomes Done on the last step', () => {
+		const container = createContainer();
+		const overlay = disposables.add(new SpotlightOverlay(container, FakeResizeObserver as unknown as typeof ResizeObserver));
+		const target = createTarget(container, 0, 0, 50, 50);
+
+		overlay.show(target, content({ canGoBack: false, isLastStep: true }));
+
+		const [, back, next] = getButtons(container);
+		assert.deepStrictEqual({ backHidden: back.style.display === 'none', nextLabel: next.textContent }, { backHidden: true, nextLabel: 'Done' });
+	});
+
+	test('allowTargetInteraction cuts a hole out of the click blocker', () => {
+		const container = createContainer();
+		const overlay = disposables.add(new SpotlightOverlay(container, FakeResizeObserver as unknown as typeof ResizeObserver));
+		const target = createTarget(container, 100, 100, 80, 30);
+		const blocker = () => container.getElementsByClassName('spotlight-blocker')[0] as HTMLElement;
+
+		overlay.show(target, content(), { allowTargetInteraction: false });
+		assert.strictEqual(blocker().style.clipPath, '');
+
+		overlay.show(target, content(), { allowTargetInteraction: true });
+		assert.ok(blocker().style.clipPath.includes('evenodd'), 'expected an evenodd clip-path');
+	});
+
+	test('observes the target and container for re-layout', () => {
+		const container = createContainer();
+		const observers: FakeResizeObserver[] = [];
+		const ctor = class extends FakeResizeObserver {
+			constructor(cb: ResizeObserverCallback) { super(cb); observers.push(this); }
+		};
+		const overlay = disposables.add(new SpotlightOverlay(container, ctor as unknown as typeof ResizeObserver));
+		const target = createTarget(container, 0, 0, 50, 50);
+
+		overlay.show(target, content());
+
+		assert.deepStrictEqual(observers.length === 1 ? observers[0].observed.includes(target) && observers[0].observed.includes(container) : false, true);
+	});
+
+	test('focus trap includes links rendered in a markdown description', () => {
+		const container = createContainer();
+		const overlay = disposables.add(new SpotlightOverlay(container, FakeResizeObserver as unknown as typeof ResizeObserver));
+		const target = createTarget(container, 0, 0, 50, 50);
+
+		overlay.show(target, content({ description: new MarkdownString('See [the docs](https://example.com) for more.') }));
+
+		const callout = container.getElementsByClassName('spotlight-callout')[0] as HTMLElement;
+		const link = callout.getElementsByTagName('a')[0] as HTMLAnchorElement | undefined;
+		assert.ok(link, 'expected a link to be rendered from the markdown description');
+
+		// With the link focused, Shift+Tab should cycle to the last button (Next),
+		// proving the link participates in the trap rather than being skipped.
+		link!.focus();
+		callout.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9 /* Tab */, shiftKey: true, bubbles: true, cancelable: true } as KeyboardEventInit));
+
+		assert.strictEqual(mainWindow.document.activeElement, getButtons(container).at(-1));
+	});
+
+	test('dispose removes the overlay from the DOM', () => {
+		const container = createContainer();
+		const overlay = new SpotlightOverlay(container, FakeResizeObserver as unknown as typeof ResizeObserver);
+		const target = createTarget(container, 0, 0, 50, 50);
+		overlay.show(target, content());
+
+		overlay.dispose();
+
+		assert.strictEqual(container.getElementsByClassName('spotlight-overlay').length, 0);
+	});
+});

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -391,6 +391,9 @@ import './contrib/welcomeViews/common/newFile.contribution.js';
 // Welcome Onboarding
 import './contrib/welcomeOnboarding/browser/welcomeOnboarding.contribution.js';
 
+// Onboarding (scenario engine)
+import './contrib/onboarding/browser/onboarding.contribution.js';
+
 // Call Hierarchy
 import './contrib/callHierarchy/browser/callHierarchy.contribution.js';
 


### PR DESCRIPTION
## Onboarding spotlight tour (Agents window)

Adds a reusable, presentation-agnostic onboarding system and a first spotlight tour for the Agents window.

### Architecture
- **Engine** (`vs/workbench/contrib/onboarding`): scenario + presentation registries and `OnboardingScenarioService` — eligibility, priority queue (one at a time), reactive triggers (context keys / observables), once-per-user persistence (`Memento`, PROFILE/USER), shutdown drain. Presentation-agnostic.
- **Spotlight presentation** (`.../browser/spotlight`): pure-DOM `SpotlightOverlay` (box-shadow dim + masked highlight + `layout2d`-anchored callout, focus trap, reduced-motion, injectable `ResizeObserver`) and `SpotlightPresentation` (step loop, WCO dimming via `IHostService.setWindowDimmed`, `advanceOnTargetClick`).
- **Scenario data** (`vs/sessions/contrib/onboardingTours`): the "new session" tour — highlights running sessions in parallel (advances on button press), the isolation picker (worktree vs folder), and the workspace picker. Targets are tagged with `data-onboarding-id` via `markOnboardingTarget` (the New Session button via `IActionViewItemService`).

### Triggering
The tour is driven by an observable from a gating contribution: on a sent request, if the user has started `< 3` sessions (read from the telemetry tracker's stored count), it waits 10s and only triggers if the session is still visible in the grid.

### Settings / commands
- `onboarding.enabled` — gates automatic tours.
- `onboarding.developerMode` (experimental) — bypasses usage-based gating so tours can be triggered for testing.
- Developer command: **Reset Onboarding Shown State**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>