### PR TITLE
sessions: show newly started local sessions in the list immediately

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
@@ -134,7 +134,12 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 	private async tryUpdateLiveSessionItem(model: IChatModel): Promise<void> {
 		const updated = this.toChatSessionItem(await chatModelToChatDetail(model));
 		if (!updated) {
-			// The session does not (yet) qualify as a list item, e.g. it has no requests yet.
+			// The session no longer qualifies as a list item (e.g. it has no requests
+			// yet, or its requests were removed). Drop any stale item we were showing.
+			if (this._items.has(model.sessionResource)) {
+				this._items.delete(model.sessionResource);
+				this._onDidChangeChatSessionItems.fire({ removed: [model.sessionResource] });
+			}
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
@@ -132,17 +132,18 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 	}
 
 	private async tryUpdateLiveSessionItem(model: IChatModel): Promise<void> {
-		const existing = this._items.get(model.sessionResource);
-		if (!existing) {
+		const updated = this.toChatSessionItem(await chatModelToChatDetail(model));
+		if (!updated) {
+			// The session does not (yet) qualify as a list item, e.g. it has no requests yet.
 			return;
 		}
 
-		const updated = new LocalChatSessionItem(await chatModelToChatDetail(model), model);
-		if (existing.isEqual(updated)) {
+		const existing = this._items.get(updated.resource);
+		if (existing?.isEqual(updated)) {
 			return;
 		}
 
-		this._items.set(existing.resource, updated);
+		this._items.set(updated.resource, updated);
 		this._onDidChangeChatSessionItems.fire({ addedOrUpdated: [updated] });
 	}
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { timeout } from '../../../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
@@ -39,6 +40,7 @@ function createTestTiming(options?: {
 interface MockChatModel extends IChatModel {
 	setCustomTitle(title: string): void;
 	setRequestInProgress(inProgress: boolean): void;
+	addFirstRequest(): void;
 }
 
 function createMockChatModel(options: {
@@ -63,7 +65,7 @@ function createMockChatModel(options: {
 }): MockChatModel {
 	const requests: IChatRequestModel[] = [];
 
-	if (options.hasRequests !== false) {
+	const createRequest = (): IChatRequestModel => {
 		const mockResponse: Partial<IChatResponseModel> = {
 			isComplete: options.lastResponseComplete ?? true,
 			isCanceled: options.lastResponseCanceled ?? false,
@@ -78,10 +80,15 @@ function createMockChatModel(options: {
 			}
 		};
 
-		requests.push({
+		return {
 			id: 'request-1',
 			response: mockResponse as IChatResponseModel
-		} as IChatRequestModel);
+		} as IChatRequestModel;
+	};
+
+	let hasRequests = options.hasRequests !== false;
+	if (hasRequests) {
+		requests.push(createRequest());
 	}
 
 	const editingSessionEntries = options.editingSession?.entries.map(entry => ({
@@ -106,7 +113,9 @@ function createMockChatModel(options: {
 			return title;
 		},
 		sessionResource: options.sessionResource,
-		hasRequests: options.hasRequests !== false,
+		get hasRequests() {
+			return hasRequests;
+		},
 		timestamp: options.timestamp ?? Date.now(),
 		timing: createTestTiming({ created: options.timestamp }),
 		requestInProgress,
@@ -126,6 +135,14 @@ function createMockChatModel(options: {
 			}
 			requestInProgress.set(inProgress, undefined);
 			_onDidChange.fire({ kind: 'changedRequest' } as IChatChangedRequestEvent);
+		},
+		addFirstRequest: () => {
+			if (hasRequests) {
+				return;
+			}
+			hasRequests = true;
+			requests.push(createRequest());
+			_onDidChange.fire({ kind: 'addRequest' } as IChatChangeEvent);
 		},
 	} as Partial<IChatModel> as MockChatModel;
 }
@@ -576,34 +593,29 @@ suite('LocalAgentsSessionsController', () => {
 				const mockModel = createMockChatModel({
 					sessionResource,
 					hasRequests: true,
-					requestInProgress: true
+					requestInProgress: false
 				});
 
 				// Add the session first
 				mockChatService.addSession(mockModel);
-				mockChatService.setLiveSessionItems([{
-					sessionResource,
-					title: 'Test Session',
-					lastMessageDate: Date.now(),
-					isActive: true,
-					timing: createTestTiming(),
-					lastResponseState: ResponseModelState.Complete
-				}]);
+				mockChatService.setLiveSessionItems([await chatModelToChatDetail(mockModel)]);
+
+				// Flush the initial add/reconcile churn from session creation.
+				await controller.refresh(CancellationToken.None);
+				await timeout(0);
 
 				let changeEventCount = 0;
 				disposables.add(controller.onDidChangeChatSessionItems(() => {
 					changeEventCount++;
 				}));
 
-				await controller.refresh(CancellationToken.None);
-
 				const onDidChangeChatSessionItems = Event.toPromise(controller.onDidChangeChatSessionItems);
 
-				// Simulate progress change by triggering the progress listener
+				// Simulate a real progress change by toggling the in-progress state.
 				mockModel.setRequestInProgress(true);
 				await onDidChangeChatSessionItems;
 
-				assert.strictEqual(changeEventCount, 3);
+				assert.strictEqual(changeEventCount, 1);
 			});
 		});
 
@@ -670,6 +682,34 @@ suite('LocalAgentsSessionsController', () => {
 				const addedResources = fired.flatMap(d => d.addedOrUpdated ?? []).map(i => i.resource.toString());
 				assert.ok(addedResources.includes(sessionResource2.toString()), 'forked session should appear in addedOrUpdated');
 				assert.ok(!addedResources.includes(sessionResource1.toString()), 'existing session should not appear in addedOrUpdated');
+			});
+		});
+
+		test('should add a newly started session once it gets its first request', async () => {
+			return runWithFakedTimers({}, async () => {
+				const controller = createController();
+
+				const sessionResource = LocalChatSessionUri.forSession('new-session');
+				const mockModel = createMockChatModel({
+					sessionResource,
+					hasRequests: false
+				});
+
+				const fired: { addedOrUpdated?: readonly IChatSessionItem[]; removed?: readonly URI[] }[] = [];
+				disposables.add(controller.onDidChangeChatSessionItems(delta => fired.push(delta)));
+
+				// A brand new session is created without any requests yet.
+				mockChatService.addSession(mockModel);
+				await timeout(0);
+				assert.strictEqual(controller.items.length, 0, 'session without requests should not be listed yet');
+
+				// The user sends the first message, so the session now qualifies as a list item.
+				mockModel.addFirstRequest();
+				await timeout(0);
+
+				assert.strictEqual(controller.items.length, 1, 'session should appear as soon as it has a request');
+				const addedResources = fired.flatMap(d => d.addedOrUpdated ?? []).map(i => i.resource.toString());
+				assert.ok(addedResources.includes(sessionResource.toString()), 'new session should appear in addedOrUpdated without a manual refresh');
 			});
 		});
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
@@ -19,7 +19,7 @@ import { IChatService, ResponseModelState } from '../../../common/chatService/ch
 import { chatModelToChatDetail } from '../../../common/chatService/chatServiceImpl.js';
 import { ChatSessionStatus, IChatSessionItem, IChatSessionsService, localChatSessionType } from '../../../common/chatSessionsService.js';
 import { ChatEditingSessionState, ModifiedFileEntryState } from '../../../common/editing/chatEditingService.js';
-import { IChatChangedRequestEvent, IChatChangeEvent, IChatModel, IChatRequestModel, IChatResponseModel } from '../../../common/model/chatModel.js';
+import { ChatRequestRemovalReason, IChatChangedRequestEvent, IChatChangeEvent, IChatModel, IChatRequestModel, IChatResponseModel } from '../../../common/model/chatModel.js';
 import { LocalChatSessionUri } from '../../../common/model/chatUri.js';
 import { MockChatService } from '../../common/chatService/mockChatService.js';
 import { MockChatSessionsService } from '../../common/mockChatSessionsService.js';
@@ -41,6 +41,7 @@ interface MockChatModel extends IChatModel {
 	setCustomTitle(title: string): void;
 	setRequestInProgress(inProgress: boolean): void;
 	addFirstRequest(): void;
+	removeRequests(): void;
 }
 
 function createMockChatModel(options: {
@@ -141,8 +142,17 @@ function createMockChatModel(options: {
 				return;
 			}
 			hasRequests = true;
-			requests.push(createRequest());
-			_onDidChange.fire({ kind: 'addRequest' } as IChatChangeEvent);
+			const request = createRequest();
+			requests.push(request);
+			_onDidChange.fire({ kind: 'addRequest', request });
+		},
+		removeRequests: () => {
+			if (!hasRequests) {
+				return;
+			}
+			hasRequests = false;
+			const [request] = requests.splice(0, requests.length);
+			_onDidChange.fire({ kind: 'removeRequest', requestId: request.id, reason: ChatRequestRemovalReason.Removal });
 		},
 	} as Partial<IChatModel> as MockChatModel;
 }
@@ -710,6 +720,37 @@ suite('LocalAgentsSessionsController', () => {
 				assert.strictEqual(controller.items.length, 1, 'session should appear as soon as it has a request');
 				const addedResources = fired.flatMap(d => d.addedOrUpdated ?? []).map(i => i.resource.toString());
 				assert.ok(addedResources.includes(sessionResource.toString()), 'new session should appear in addedOrUpdated without a manual refresh');
+			});
+		});
+
+		test('should remove a listed session once its requests are removed', async () => {
+			return runWithFakedTimers({}, async () => {
+				const controller = createController();
+
+				const sessionResource = LocalChatSessionUri.forSession('emptied-session');
+				const mockModel = createMockChatModel({
+					sessionResource,
+					hasRequests: true
+				});
+
+				mockChatService.addSession(mockModel);
+				mockChatService.setLiveSessionItems([await chatModelToChatDetail(mockModel)]);
+				await controller.refresh(CancellationToken.None);
+				assert.strictEqual(controller.items.length, 1);
+
+				const removedResources: URI[] = [];
+				disposables.add(controller.onDidChangeChatSessionItems(delta => {
+					if (delta.removed) {
+						removedResources.push(...delta.removed);
+					}
+				}));
+
+				// All requests are removed, so the session no longer qualifies as a list item.
+				mockModel.removeRequests();
+				await timeout(0);
+
+				assert.strictEqual(controller.items.length, 0, 'session should be dropped once it has no requests');
+				assert.ok(removedResources.some(r => r.toString() === sessionResource.toString()), 'emptied session should be removed without a manual refresh');
 			});
 		});
 


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode-internalbacklog/issues/8032

## Problem

When you start a new **local** session in the editor window (an extension-host session using the original harness — not an agent-host or copilot-cli session), it does not appear in the session list right away. Clicking **Refresh** makes it show up, but it should appear as soon as the session starts.

## Root cause

Local sessions in the editor-window list are managed by `LocalAgentsSessionsController`.

1. The chat model is created **before** it has any requests. `onDidCreateModel` → `addModelListeners` runs `refresh()`, but `toChatSessionItem` filters out sessions with no requests, so the session is never added to `_items`.
2. When the first message is sent, the model's `onDidChange` fires and the autorun calls `tryUpdateLiveSessionItem`. That method early-returned whenever the item wasn't *already* in `_items` — it only ever **updated** existing items, never **added** new ones.

So a freshly started session never appeared via the live delta; only a manual refresh re-scanned and picked it up.

## Fix

`tryUpdateLiveSessionItem` now computes the session item first (reusing `toChatSessionItem`, which keeps the "ignore sessions without requests" rule consistent). If the session qualifies and isn't already present (or has changed), it's added/updated and an `addedOrUpdated` delta is fired. The session shows up as soon as it gets its first request — no manual refresh needed.

## Tests

- Added regression test: *"should add a newly started session once it gets its first request"* — a session created with no requests appears immediately (via the live delta) once it gains a request.
- Extended the mock chat model with an `addFirstRequest()` helper and a mutable `hasRequests` to model that transition.
- Made the pre-existing *"model progress changes"* test deterministic: it was calling `setRequestInProgress(true)` on an already-in-progress model (a no-op) and relied on incidental setup churn. It now flushes setup, performs a real `false→true` progress change, and asserts exactly one event fires.

All 22 controller tests pass; broader agentSessions/chatSessions suites (296 tests) pass; `typecheck-client` and eslint are clean.

(Written by Copilot)