### PR TITLE
Update customizations sidebar content and behavior

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -259,7 +259,7 @@ Provider-supplied customization rows that include an explicit storage origin are
 
 The MCP Servers section combines locally known MCP servers with MCP servers reported by the active agent-host session (`IAgentHostCustomizationService.getMcpServers(activeSessionResource)`). Active-session servers are matched to known workspace, user, extension, plugin, or built-in rows by stable identifiers and display names so the row can show the active session's status, matching `MCP: List Servers`. Active-session servers that do not match any known local/runtime server are appended under an **Active Session** group and counted with the rest of the section.
 
-### Sidebar Entrypoint Mode
+### Sidebar Customizations Section
 
 The Agents sidebar `AICustomizationShortcutsWidget` appears as a collapsible, vertically resizable section below the sessions list. Its resize sash is the horizontal separator above the section and uses the same `SplitView` styling as the Checks section in the changes view, with a 4px separator and sash inset on each side. The section's expanded minimum height is 129px, while its initial and maximum height are capped to the rendered content height so the pane does not open with empty space. When collapsed, the section shrinks to its header height and shows the total customization count to the left of the hover-revealed chevron.
 

--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -59,7 +59,7 @@ src/vs/sessions/contrib/chat/browser/
 ├── customizationHarnessService.ts              # Sessions harness service (accepts any content-provider-backed session type)
 └── promptsService.ts                           # AgenticPromptsService (CLI user roots)
 src/vs/sessions/contrib/sessions/browser/
-├── aiCustomizationShortcutsWidget.ts           # Sidebar shortcuts widget with header overview action
+├── aiCustomizationShortcutsWidget.ts           # Resizable sidebar shortcuts widget with overview + section links
 └── customizationsToolbar.contribution.ts       # Sidebar customization links
 ```
 
@@ -261,7 +261,9 @@ The MCP Servers section combines locally known MCP servers with MCP servers repo
 
 ### Sidebar Entrypoint Mode
 
-The Agents sidebar `AICustomizationShortcutsWidget` supports three entrypoint modes via `sessions.customizations.sidebarMode`: `welcome` (default) keeps the per-category sidebar rows but opens the AI Customization management editor welcome page, `section` restores per-category deep linking, and `single` replaces the per-category rows with one Customizations entry that opens the welcome page. All modes keep the active customization harness in sync with the active session before opening the editor.
+The Agents sidebar `AICustomizationShortcutsWidget` appears as a non-collapsible, vertically resizable section below the sessions list. Its resize sash is the horizontal separator above the section and uses the same `SplitView` styling as the Checks section in the changes view, with a 4px separator and sash inset on each side. The section's minimum height is 129px, while its initial and maximum height are capped to the rendered content height so the pane does not open with empty space.
+
+The first sidebar entry is `Overview`, which opens the AI Customization management editor welcome page. The remaining per-category rows deep-link directly to their corresponding management editor section. The `sessions.customizations.sidebarMode` setting still supports `single`, which replaces the per-category rows with one Customizations entry that opens the welcome page; the legacy `welcome` and `section` values both render the overview-plus-category list. All modes keep the active customization harness in sync with the active session before opening the editor.
 
 ### Item Badges
 

--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -261,9 +261,9 @@ The MCP Servers section combines locally known MCP servers with MCP servers repo
 
 ### Sidebar Entrypoint Mode
 
-The Agents sidebar `AICustomizationShortcutsWidget` appears as a non-collapsible, vertically resizable section below the sessions list. Its resize sash is the horizontal separator above the section and uses the same `SplitView` styling as the Checks section in the changes view, with a 4px separator and sash inset on each side. The section's minimum height is 129px, while its initial and maximum height are capped to the rendered content height so the pane does not open with empty space.
+The Agents sidebar `AICustomizationShortcutsWidget` appears as a collapsible, vertically resizable section below the sessions list. Its resize sash is the horizontal separator above the section and uses the same `SplitView` styling as the Checks section in the changes view, with a 4px separator and sash inset on each side. The section's expanded minimum height is 129px, while its initial and maximum height are capped to the rendered content height so the pane does not open with empty space. When collapsed, the section shrinks to its header height and shows the total customization count to the left of the hover-revealed chevron.
 
-The first sidebar entry is `Overview`, which opens the AI Customization management editor welcome page. The remaining per-category rows deep-link directly to their corresponding management editor section. The `sessions.customizations.sidebarMode` setting still supports `single`, which replaces the per-category rows with one Customizations entry that opens the welcome page; the legacy `welcome` and `section` values both render the overview-plus-category list. All modes keep the active customization harness in sync with the active session before opening the editor.
+The first sidebar entry is `Overview`, which opens the AI Customization management editor welcome page. The remaining per-category rows deep-link directly to their corresponding management editor section. All entries keep the active customization harness in sync with the active session before opening the editor.
 
 ### Item Badges
 

--- a/src/vs/sessions/contrib/changes/browser/media/checksWidget.css
+++ b/src/vs/sessions/contrib/changes/browser/media/checksWidget.css
@@ -27,15 +27,15 @@
 }
 
 .ci-status-widget-header:hover {
-	padding-right: 28px;
+	padding-right: 32px;
 }
 
 .ci-status-widget-header:focus-visible {
-	padding-right: 28px;
+	padding-right: 32px;
 }
 
 .ci-status-widget-header.collapsed {
-	padding-right: 28px;
+	padding-right: 32px;
 }
 
 /* Hover/keyboard focus promote the title to the strong foreground instead of
@@ -58,15 +58,16 @@
 /* Chevron — right-aligned, visible on hover, keyboard focus, or when collapsed */
 .ci-status-widget-header .group-chevron {
 	position: absolute;
-	right: 8px;
+	right: 4px;
 	top: 50%;
 	transform: translateY(-50%);
-	width: 16px;
-	height: 16px;
+	width: 22px;
+	height: 22px;
+	border-radius: var(--vscode-cornerRadius-small);
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	font-size: 16px;
+	font-size: var(--vscode-codiconFontSize-compact, 12px);
 	visibility: hidden;
 	opacity: 0;
 }
@@ -76,6 +77,10 @@
 .ci-status-widget-header.collapsed .group-chevron {
 	visibility: visible;
 	opacity: 0.7;
+}
+
+.ci-status-widget-header .group-chevron:hover {
+	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
 /* Title - single line, overflow ellipsis */

--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -7,28 +7,25 @@ import '../../../browser/media/sidebarActionButton.css';
 import './media/customizationsToolbar.css';
 import * as DOM from '../../../../base/browser/dom.js';
 import { Codicon } from '../../../../base/common/codicons.js';
-import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { Emitter } from '../../../../base/common/event.js';
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { autorun, derived } from '../../../../base/common/observable.js';
-import { ThemeIcon } from '../../../../base/common/themables.js';
+import { ScrollbarVisibility } from '../../../../base/common/scrollable.js';
 import { localize } from '../../../../nls.js';
 import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { Button } from '../../../../base/browser/ui/button/button.js';
+import { DomScrollableElement } from '../../../../base/browser/ui/scrollbar/scrollableElement.js';
 import { defaultButtonStyles } from '../../../../platform/theme/browser/defaultStyles.js';
 import { IMcpService } from '../../../../workbench/contrib/mcp/common/mcpTypes.js';
 import { IAICustomizationItemsModel } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemsModel.js';
 import { ICustomizationHarnessService } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
-import { CUSTOMIZATION_ITEMS, SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING, SessionsCustomizationsSidebarMode } from './customizationsToolbar.contribution.js';
+import { CUSTOMIZATION_ITEMS, openCustomizationOverviewPage, SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING, SessionsCustomizationsSidebarMode } from './customizationsToolbar.contribution.js';
 import { Menus } from '../../../browser/menus.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
-import { AICustomizationManagementEditor } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.js';
-import { AICustomizationManagementEditorInput } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 const $ = DOM.$;
-
-const CUSTOMIZATIONS_COLLAPSED_KEY = 'agentSessions.customizationsCollapsed';
 
 export interface IAICustomizationShortcutsWidgetOptions {
 	readonly onDidChangeLayout?: () => void;
@@ -36,18 +33,24 @@ export interface IAICustomizationShortcutsWidgetOptions {
 
 export class AICustomizationShortcutsWidget extends Disposable {
 
-	private _headerButton: Button | undefined;
 	private _singleButton: Button | undefined;
 	private _renderDisposables = this._register(new DisposableStore());
 	private _wrapper: HTMLElement | undefined;
 	private _options: IAICustomizationShortcutsWidgetOptions | undefined;
 	private _renderedSingle: boolean | undefined;
+	private _scrollableElement: DomScrollableElement | undefined;
+	private _toolbar: MenuWorkbenchToolBar | undefined;
+	private _rootElement: HTMLElement | undefined;
+	private _headerElement: HTMLElement | undefined;
+	private _toolbarContentElement: HTMLElement | undefined;
+
+	private readonly _onDidChangeHeight = this._register(new Emitter<void>());
+	readonly onDidChangeHeight = this._onDidChangeHeight.event;
 
 	constructor(
 		container: HTMLElement,
 		options: IAICustomizationShortcutsWidgetOptions | undefined,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IStorageService private readonly storageService: IStorageService,
 		@IMcpService private readonly mcpService: IMcpService,
 		@IAICustomizationItemsModel private readonly itemsModel: IAICustomizationItemsModel,
 		@ICustomizationHarnessService private readonly harnessService: ICustomizationHarnessService,
@@ -67,9 +70,8 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		this._renderForCurrentMode();
 
 		// Re-render only when crossing the single<->non-single boundary. The
-		// `welcome` and `section` modes produce identical DOM (only click
-		// behavior differs, resolved at click-time in the contribution), so
-		// toggling between them needs no re-render.
+		// `welcome` and `section` modes produce identical DOM; both render
+		// overview-plus-section entries. Only `single` changes presentation.
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING)) {
 				const isSingle = this._readMode() === SessionsCustomizationsSidebarMode.Single;
@@ -94,8 +96,12 @@ export class AICustomizationShortcutsWidget extends Disposable {
 			return;
 		}
 		this._renderDisposables.clear();
-		this._headerButton = undefined;
 		this._singleButton = undefined;
+		this._scrollableElement = undefined;
+		this._toolbar = undefined;
+		this._rootElement = undefined;
+		this._headerElement = undefined;
+		this._toolbarContentElement = undefined;
 		DOM.clearNode(this._wrapper);
 
 		const mode = this._readMode();
@@ -110,8 +116,10 @@ export class AICustomizationShortcutsWidget extends Disposable {
 
 	private _renderSingleEntry(parent: HTMLElement): void {
 		const container = DOM.append(parent, $('.ai-customization-toolbar.single-entry'));
+		this._rootElement = container;
 
 		const buttonContainer = DOM.append(container, $('.customization-link-button-container'));
+		this._toolbarContentElement = buttonContainer;
 		const button = this._renderDisposables.add(new Button(buttonContainer, {
 			...defaultButtonStyles,
 			secondary: true,
@@ -150,7 +158,7 @@ export class AICustomizationShortcutsWidget extends Disposable {
 			const hidden = new Set(this.harnessService.getActiveDescriptor().hiddenSections ?? []);
 			let total = 0;
 			for (const config of CUSTOMIZATION_ITEMS) {
-				if (hidden.has(config.section)) {
+				if (config.section && hidden.has(config.section)) {
 					continue;
 				}
 				if (config.modelSection) {
@@ -166,101 +174,71 @@ export class AICustomizationShortcutsWidget extends Disposable {
 	}
 
 	private async _openWelcomePage(): Promise<void> {
-		const sessionResource = this.sessionsService.activeSession.get()?.resource;
-		if (sessionResource) {
-			this.harnessService.setActiveSession(sessionResource);
-		}
-
-		const input = AICustomizationManagementEditorInput.getOrCreate();
-		const editor = await this.editorService.openEditor(input, { pinned: true });
-		if (editor instanceof AICustomizationManagementEditor) {
-			editor.showWelcomePage();
-		}
+		await openCustomizationOverviewPage(this.editorService, this.harnessService, this.sessionsService);
 	}
 
 	private _render(parent: HTMLElement, options: IAICustomizationShortcutsWidgetOptions | undefined): void {
-		// Get initial collapsed state
-		const isCollapsed = this.storageService.getBoolean(CUSTOMIZATIONS_COLLAPSED_KEY, StorageScope.PROFILE, false);
-
 		const container = DOM.append(parent, $('.ai-customization-toolbar'));
-		if (isCollapsed) {
-			container.classList.add('collapsed');
-		}
+		this._rootElement = container;
 
 		// Header
 		const header = DOM.append(container, $('.ai-customization-header'));
-		header.classList.toggle('collapsed', isCollapsed);
-
-		const headerButtonContainer = DOM.append(header, $('.customization-link-button-container'));
-		const headerButton = this._renderDisposables.add(new Button(headerButtonContainer, {
-			...defaultButtonStyles,
-			secondary: true,
-			title: false,
-			supportIcons: true,
-			buttonSecondaryBackground: 'transparent',
-			buttonSecondaryHoverBackground: undefined,
-			buttonSecondaryForeground: undefined,
-			buttonSecondaryBorder: undefined,
-		}));
-		headerButton.element.classList.add('customization-link-button', 'sidebar-action-button');
-		headerButton.element.setAttribute('aria-expanded', String(!isCollapsed));
-		headerButton.label = localize('customizations', "Customizations");
-		this._headerButton = headerButton;
-
-		// Total count + chevron live inside the single header button.
-		const headerTotalCount = DOM.append(headerButton.element, $('span.ai-customization-header-total.hidden'));
-		const chevron = DOM.append(headerButton.element, $('.ai-customization-chevron'));
-		chevron.classList.add(...ThemeIcon.asClassNameArray(isCollapsed ? Codicon.chevronRight : Codicon.chevronDown));
+		this._headerElement = header;
+		const headerLabel = DOM.append(header, $('span.ai-customization-header-label'));
+		headerLabel.textContent = localize('customizations', "Customizations");
 
 		// Toolbar container
-		const toolbarContainer = DOM.append(container, $('.ai-customization-toolbar-content.sidebar-action-list'));
+		const scrollContent = $('.ai-customization-toolbar-content-scrollable');
+		const toolbarContainer = DOM.append(scrollContent, $('.ai-customization-toolbar-content.sidebar-action-list'));
+		this._toolbarContentElement = toolbarContainer;
+		const scrollableElement = this._renderDisposables.add(new DomScrollableElement(scrollContent, {
+			horizontal: ScrollbarVisibility.Hidden,
+			vertical: ScrollbarVisibility.Auto,
+			useShadows: false,
+		}));
+		this._scrollableElement = scrollableElement;
+		DOM.append(container, scrollableElement.getDomNode());
 
 		const toolbar = this._renderDisposables.add(this.instantiationService.createInstance(MenuWorkbenchToolBar, toolbarContainer, Menus.SidebarCustomizations, {
 			hiddenItemStrategy: HiddenItemStrategy.NoHide,
 			toolbarOptions: { primaryGroup: () => true },
 			telemetrySource: 'sidebarCustomizations',
 		}));
+		this._toolbar = toolbar;
 
 		// Re-layout when toolbar items change (e.g., Plugins item appearing after extension activation)
 		this._renderDisposables.add(toolbar.onDidChangeMenuItems(() => {
+			this._scrollableElement?.scanDomNode();
+			this._onDidChangeHeight.fire();
 			options?.onDidChangeLayout?.();
 		}));
+	}
 
-		// Header total = sum of the same counts shown by each visible sidebar
-		// link (CUSTOMIZATION_ITEMS). This guarantees the header value equals
-		// the sum of the per-link badges by construction — and excludes
-		// sections like Prompts that the editor exposes but the sidebar does
-		// not surface, plus any sections the active harness hides via
-		// `hiddenSections` (e.g. Claude doesn't show Prompts; AHP doesn't
-		// show MCP Servers).
-		const totalCount = this._totalCount();
-		this._renderDisposables.add(autorun(reader => {
-			const value = totalCount.read(reader);
-			headerTotalCount.classList.toggle('hidden', value === 0);
-			headerTotalCount.textContent = `${value}`;
-		}));
+	get desiredHeight(): number {
+		const root = this._rootElement;
+		const content = this._toolbarContentElement;
+		if (!root || !content) {
+			return 0;
+		}
 
-		// Toggle collapse on header click
-		const transitionListener = this._renderDisposables.add(new MutableDisposable());
-		const toggleCollapse = () => {
-			const collapsed = container.classList.toggle('collapsed');
-			header.classList.toggle('collapsed', collapsed);
-			this.storageService.store(CUSTOMIZATIONS_COLLAPSED_KEY, collapsed, StorageScope.PROFILE, StorageTarget.USER);
-			headerButton.element.setAttribute('aria-expanded', String(!collapsed));
-			chevron.classList.remove(...ThemeIcon.asClassNameArray(Codicon.chevronRight), ...ThemeIcon.asClassNameArray(Codicon.chevronDown));
-			chevron.classList.add(...ThemeIcon.asClassNameArray(collapsed ? Codicon.chevronRight : Codicon.chevronDown));
+		const rootStyles = DOM.getWindow(root).getComputedStyle(root);
+		const paddingTop = parseFloat(rootStyles.paddingTop);
+		const paddingBottom = parseFloat(rootStyles.paddingBottom);
+		const rootVerticalPadding = (Number.isFinite(paddingTop) ? paddingTop : 0) + (Number.isFinite(paddingBottom) ? paddingBottom : 0);
+		const headerHeight = this._headerElement?.offsetHeight ?? 0;
+		const height = Math.ceil(rootVerticalPadding + headerHeight + content.scrollHeight);
+		return Number.isFinite(height) ? height : 0;
+	}
 
-			// Re-layout after the transition
-			transitionListener.value = DOM.addDisposableListener(toolbarContainer, 'transitionend', () => {
-				transitionListener.clear();
-				options?.onDidChangeLayout?.();
-			});
-		};
-
-		this._renderDisposables.add(headerButton.onDidClick(() => toggleCollapse()));
+	layout(_height: number, _width: number): void {
+		this._scrollableElement?.scanDomNode();
 	}
 
 	focus(): void {
-		(this._singleButton ?? this._headerButton)?.element.focus();
+		if (this._singleButton) {
+			this._singleButton.element.focus();
+			return;
+		}
+		this._toolbar?.focus();
 	}
 }

--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -128,7 +128,6 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		const header = DOM.append(container, $('.ai-customization-header'));
 		this._headerElement = header;
 		header.setAttribute('role', 'button');
-		header.setAttribute('aria-label', localize('toggleCustomizations', "Toggle Customizations"));
 		header.setAttribute('aria-expanded', 'true');
 		header.tabIndex = 0;
 
@@ -137,6 +136,7 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		this._headerTotalCountElement = DOM.append(header, $('span.ai-customization-header-total-count.hidden'));
 
 		this._chevronElement = DOM.append(header, $('span.ai-customization-chevron'));
+		this._chevronElement.setAttribute('aria-hidden', 'true');
 		this._updateChevron();
 
 		const totalCount = this._totalCount();
@@ -206,6 +206,9 @@ export class AICustomizationShortcutsWidget extends Disposable {
 	}
 
 	private _setCollapsed(collapsed: boolean): void {
+		if (collapsed && this._scrollableDomNode?.contains(DOM.getActiveElement())) {
+			this._headerElement?.focus();
+		}
 		this._collapsed = collapsed;
 		this._headerElement?.classList.toggle('collapsed', collapsed);
 		this._headerElement?.setAttribute('aria-expanded', String(!collapsed));
@@ -240,6 +243,10 @@ export class AICustomizationShortcutsWidget extends Disposable {
 	}
 
 	focus(): void {
+		if (this._collapsed) {
+			this._headerElement?.focus();
+			return;
+		}
 		this._toolbar?.focus();
 	}
 }

--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -11,21 +11,18 @@ import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { autorun, derived } from '../../../../base/common/observable.js';
 import { ScrollbarVisibility } from '../../../../base/common/scrollable.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize } from '../../../../nls.js';
 import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { Button } from '../../../../base/browser/ui/button/button.js';
 import { DomScrollableElement } from '../../../../base/browser/ui/scrollbar/scrollableElement.js';
-import { defaultButtonStyles } from '../../../../platform/theme/browser/defaultStyles.js';
 import { IMcpService } from '../../../../workbench/contrib/mcp/common/mcpTypes.js';
 import { IAICustomizationItemsModel } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemsModel.js';
 import { ICustomizationHarnessService } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
-import { CUSTOMIZATION_ITEMS, openCustomizationOverviewPage, SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING, SessionsCustomizationsSidebarMode } from './customizationsToolbar.contribution.js';
+import { CUSTOMIZATION_ITEMS } from './customizationsToolbar.contribution.js';
 import { Menus } from '../../../browser/menus.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
-import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 const $ = DOM.$;
+const CUSTOMIZATIONS_VERTICAL_PADDING = 6;
 
 export interface IAICustomizationShortcutsWidgetOptions {
 	readonly onDidChangeLayout?: () => void;
@@ -33,19 +30,34 @@ export interface IAICustomizationShortcutsWidgetOptions {
 
 export class AICustomizationShortcutsWidget extends Disposable {
 
-	private _singleButton: Button | undefined;
 	private _renderDisposables = this._register(new DisposableStore());
 	private _wrapper: HTMLElement | undefined;
 	private _options: IAICustomizationShortcutsWidgetOptions | undefined;
-	private _renderedSingle: boolean | undefined;
 	private _scrollableElement: DomScrollableElement | undefined;
 	private _toolbar: MenuWorkbenchToolBar | undefined;
-	private _rootElement: HTMLElement | undefined;
 	private _headerElement: HTMLElement | undefined;
+	private _headerTotalCountElement: HTMLElement | undefined;
+	private _chevronElement: HTMLElement | undefined;
 	private _toolbarContentElement: HTMLElement | undefined;
+	private _scrollableDomNode: HTMLElement | undefined;
+	private _rootVerticalPadding = 0;
+	private _headerTotalCount = 0;
+	private _collapsed = false;
 
 	private readonly _onDidChangeHeight = this._register(new Emitter<void>());
 	readonly onDidChangeHeight = this._onDidChangeHeight.event;
+
+	private readonly _onDidToggleCollapsed = this._register(new Emitter<boolean>());
+	readonly onDidToggleCollapsed = this._onDidToggleCollapsed.event;
+
+	get collapsed(): boolean {
+		return this._collapsed;
+	}
+
+	get collapsedHeight(): number {
+		const headerHeight = this._headerElement?.offsetHeight ?? 30;
+		return this._rootVerticalPadding + headerHeight;
+	}
 
 	constructor(
 		container: HTMLElement,
@@ -54,9 +66,6 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		@IMcpService private readonly mcpService: IMcpService,
 		@IAICustomizationItemsModel private readonly itemsModel: IAICustomizationItemsModel,
 		@ICustomizationHarnessService private readonly harnessService: ICustomizationHarnessService,
-		@IConfigurationService private readonly configurationService: IConfigurationService,
-		@IEditorService private readonly editorService: IEditorService,
-		@ISessionsService private readonly sessionsService: ISessionsService,
 	) {
 		super();
 
@@ -68,27 +77,6 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		this._wrapper = DOM.append(container, $('.ai-customization-shortcuts-widget'));
 		this._options = options;
 		this._renderForCurrentMode();
-
-		// Re-render only when crossing the single<->non-single boundary. The
-		// `welcome` and `section` modes produce identical DOM; both render
-		// overview-plus-section entries. Only `single` changes presentation.
-		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING)) {
-				const isSingle = this._readMode() === SessionsCustomizationsSidebarMode.Single;
-				if (isSingle !== this._renderedSingle) {
-					this._renderForCurrentMode();
-					this._options?.onDidChangeLayout?.();
-				}
-			}
-		}));
-	}
-
-	private _readMode(): SessionsCustomizationsSidebarMode {
-		const value = this.configurationService.getValue<string>(SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING);
-		if (value === SessionsCustomizationsSidebarMode.Section || value === SessionsCustomizationsSidebarMode.Single) {
-			return value;
-		}
-		return SessionsCustomizationsSidebarMode.Welcome;
 	}
 
 	private _renderForCurrentMode(): void {
@@ -96,59 +84,18 @@ export class AICustomizationShortcutsWidget extends Disposable {
 			return;
 		}
 		this._renderDisposables.clear();
-		this._singleButton = undefined;
 		this._scrollableElement = undefined;
 		this._toolbar = undefined;
-		this._rootElement = undefined;
 		this._headerElement = undefined;
+		this._headerTotalCountElement = undefined;
+		this._chevronElement = undefined;
 		this._toolbarContentElement = undefined;
+		this._scrollableDomNode = undefined;
+		this._rootVerticalPadding = 0;
+		this._headerTotalCount = 0;
+		this._collapsed = false;
 		DOM.clearNode(this._wrapper);
-
-		const mode = this._readMode();
-		const isSingle = mode === SessionsCustomizationsSidebarMode.Single;
-		this._renderedSingle = isSingle;
-		if (isSingle) {
-			this._renderSingleEntry(this._wrapper);
-		} else {
-			this._render(this._wrapper, this._options);
-		}
-	}
-
-	private _renderSingleEntry(parent: HTMLElement): void {
-		const container = DOM.append(parent, $('.ai-customization-toolbar.single-entry'));
-		this._rootElement = container;
-
-		const buttonContainer = DOM.append(container, $('.customization-link-button-container'));
-		this._toolbarContentElement = buttonContainer;
-		const button = this._renderDisposables.add(new Button(buttonContainer, {
-			...defaultButtonStyles,
-			secondary: true,
-			title: false,
-			supportIcons: true,
-			buttonSecondaryBackground: 'transparent',
-			buttonSecondaryHoverBackground: undefined,
-			buttonSecondaryForeground: undefined,
-			buttonSecondaryBorder: undefined,
-		}));
-		button.element.classList.add('customization-link-button', 'sidebar-action-button', 'customization-single-entry-button');
-		button.label = `$(${Codicon.symbolColor.id}) ${localize('customizations', "Customizations")}`;
-		this._singleButton = button;
-
-		// Total count badge driven by the same observables as per-section badges.
-		const countContainer = DOM.append(button.element, $('span.customization-link-counts'));
-		const totalCount = this._totalCount();
-		this._renderDisposables.add(autorun(reader => {
-			const value = totalCount.read(reader);
-			countContainer.textContent = '';
-			countContainer.classList.toggle('hidden', value === 0);
-			if (value > 0) {
-				const badge = DOM.append(countContainer, $('span.source-count-badge'));
-				const num = DOM.append(badge, $('span.source-count-num'));
-				num.textContent = `${value}`;
-			}
-		}));
-
-		this._renderDisposables.add(button.onDidClick(() => this._openWelcomePage()));
+		this._render(this._wrapper, this._options);
 	}
 
 	private _totalCount() {
@@ -173,19 +120,38 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		});
 	}
 
-	private async _openWelcomePage(): Promise<void> {
-		await openCustomizationOverviewPage(this.editorService, this.harnessService, this.sessionsService);
-	}
-
 	private _render(parent: HTMLElement, options: IAICustomizationShortcutsWidgetOptions | undefined): void {
 		const container = DOM.append(parent, $('.ai-customization-toolbar'));
-		this._rootElement = container;
+		this._setRootPadding(container, CUSTOMIZATIONS_VERTICAL_PADDING, CUSTOMIZATIONS_VERTICAL_PADDING);
 
 		// Header
 		const header = DOM.append(container, $('.ai-customization-header'));
 		this._headerElement = header;
+		header.setAttribute('role', 'button');
+		header.setAttribute('aria-label', localize('toggleCustomizations', "Toggle Customizations"));
+		header.setAttribute('aria-expanded', 'true');
+		header.tabIndex = 0;
+
 		const headerLabel = DOM.append(header, $('span.ai-customization-header-label'));
 		headerLabel.textContent = localize('customizations', "Customizations");
+		this._headerTotalCountElement = DOM.append(header, $('span.ai-customization-header-total-count.hidden'));
+
+		this._chevronElement = DOM.append(header, $('span.ai-customization-chevron'));
+		this._updateChevron();
+
+		const totalCount = this._totalCount();
+		this._renderDisposables.add(autorun(reader => {
+			this._headerTotalCount = totalCount.read(reader);
+			this._renderHeaderTotalCount();
+		}));
+
+		this._renderDisposables.add(DOM.addDisposableListener(header, DOM.EventType.CLICK, () => this._toggleCollapsed()));
+		this._renderDisposables.add(DOM.addDisposableListener(header, DOM.EventType.KEY_DOWN, e => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				this._toggleCollapsed();
+			}
+		}));
 
 		// Toolbar container
 		const scrollContent = $('.ai-customization-toolbar-content-scrollable');
@@ -197,7 +163,7 @@ export class AICustomizationShortcutsWidget extends Disposable {
 			useShadows: false,
 		}));
 		this._scrollableElement = scrollableElement;
-		DOM.append(container, scrollableElement.getDomNode());
+		this._scrollableDomNode = DOM.append(container, scrollableElement.getDomNode());
 
 		const toolbar = this._renderDisposables.add(this.instantiationService.createInstance(MenuWorkbenchToolBar, toolbarContainer, Menus.SidebarCustomizations, {
 			hiddenItemStrategy: HiddenItemStrategy.NoHide,
@@ -215,30 +181,65 @@ export class AICustomizationShortcutsWidget extends Disposable {
 	}
 
 	get desiredHeight(): number {
-		const root = this._rootElement;
 		const content = this._toolbarContentElement;
-		if (!root || !content) {
+		if (!content) {
 			return 0;
 		}
+		if (this._collapsed) {
+			return this.collapsedHeight;
+		}
 
-		const rootStyles = DOM.getWindow(root).getComputedStyle(root);
-		const paddingTop = parseFloat(rootStyles.paddingTop);
-		const paddingBottom = parseFloat(rootStyles.paddingBottom);
-		const rootVerticalPadding = (Number.isFinite(paddingTop) ? paddingTop : 0) + (Number.isFinite(paddingBottom) ? paddingBottom : 0);
 		const headerHeight = this._headerElement?.offsetHeight ?? 0;
-		const height = Math.ceil(rootVerticalPadding + headerHeight + content.scrollHeight);
+		const height = Math.ceil(this._rootVerticalPadding + headerHeight + content.scrollHeight);
 		return Number.isFinite(height) ? height : 0;
 	}
 
+	private _setRootPadding(element: HTMLElement, top: number, bottom: number): void {
+		element.style.padding = `${top}px 0 ${bottom}px 0`;
+		this._rootVerticalPadding = top + bottom;
+	}
+
+	private _toggleCollapsed(): void {
+		this._setCollapsed(!this._collapsed);
+		this._onDidToggleCollapsed.fire(this._collapsed);
+		this._onDidChangeHeight.fire();
+	}
+
+	private _setCollapsed(collapsed: boolean): void {
+		this._collapsed = collapsed;
+		this._headerElement?.classList.toggle('collapsed', collapsed);
+		this._headerElement?.setAttribute('aria-expanded', String(!collapsed));
+		if (this._scrollableDomNode) {
+			this._scrollableDomNode.style.display = collapsed ? 'none' : '';
+		}
+		this._updateChevron();
+		this._renderHeaderTotalCount();
+	}
+
+	private _updateChevron(): void {
+		if (!this._chevronElement) {
+			return;
+		}
+		this._chevronElement.className = 'ai-customization-chevron';
+		this._chevronElement.classList.add(...ThemeIcon.asClassNameArray(this._collapsed ? Codicon.chevronRight : Codicon.chevronDown));
+	}
+
+	private _renderHeaderTotalCount(): void {
+		if (!this._headerTotalCountElement) {
+			return;
+		}
+		this._headerTotalCountElement.textContent = this._headerTotalCount > 0 ? `${this._headerTotalCount}` : '';
+		this._headerTotalCountElement.classList.toggle('hidden', !this._collapsed || this._headerTotalCount === 0);
+	}
+
 	layout(_height: number, _width: number): void {
+		if (this._collapsed) {
+			return;
+		}
 		this._scrollableElement?.scanDomNode();
 	}
 
 	focus(): void {
-		if (this._singleButton) {
-			this._singleButton.element.focus();
-			return;
-		}
 		this._toolbar?.focus();
 	}
 }

--- a/src/vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution.ts
+++ b/src/vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution.ts
@@ -5,6 +5,7 @@
 
 import '../../../browser/media/sidebarActionButton.css';
 import './media/customizationsToolbar.css';
+import { Codicon } from '../../../../base/common/codicons.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize, localize2 } from '../../../../nls.js';
@@ -29,10 +30,10 @@ import { Button } from '../../../../base/browser/ui/button/button.js';
 import { defaultButtonStyles } from '../../../../platform/theme/browser/defaultStyles.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
 import { AICustomizationManagementSection } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
+import { ChatContextKeys } from '../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
 import { ICustomizationHarnessService } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
 import { ISession } from '../../../services/sessions/common/session.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 
@@ -49,9 +50,9 @@ export const SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING = 'sessions.customizat
  * See {@link SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING}.
  */
 export enum SessionsCustomizationsSidebarMode {
-	/** One item per category; click opens the welcome page. */
+	/** Overview item plus one item per category; category clicks deep-link. */
 	Welcome = 'welcome',
-	/** One item per category; click deep-links to that category. */
+	/** Overview item plus one item per category; category clicks deep-link. */
 	Section = 'section',
 	/** A single "Customizations" entry that opens the welcome page. */
 	Single = 'single',
@@ -69,8 +70,8 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 				SessionsCustomizationsSidebarMode.Single,
 			],
 			enumDescriptions: [
-				localize('sessions.customizations.sidebarMode.welcome', "Show one item per customization category. Clicking a category opens the Customizations welcome page."),
-				localize('sessions.customizations.sidebarMode.section', "Show one item per customization category. Clicking a category deep-links to that category's section in the Customizations editor."),
+				localize('sessions.customizations.sidebarMode.welcome', "Show an Overview item followed by one item per customization category. Clicking a category deep-links to that category's section in the Customizations editor."),
+				localize('sessions.customizations.sidebarMode.section', "Show an Overview item followed by one item per customization category. Clicking a category deep-links to that category's section in the Customizations editor."),
 				localize('sessions.customizations.sidebarMode.single', "Show a single \"Customizations\" entry instead of one item per category. Clicking it opens the Customizations welcome page."),
 			],
 			description: localize('sessions.customizations.sidebarMode', "Controls how the Customizations section in the Agents sidebar is presented and what happens when an entry is clicked."),
@@ -83,7 +84,7 @@ export interface ICustomizationItemConfig {
 	readonly id: string;
 	readonly label: string;
 	readonly icon: ThemeIcon;
-	readonly section: typeof AICustomizationManagementSection[keyof typeof AICustomizationManagementSection];
+	readonly section?: typeof AICustomizationManagementSection[keyof typeof AICustomizationManagementSection];
 	/** If set, count comes from `IAICustomizationItemsModel.getCount(modelSection)`. */
 	readonly modelSection?: ItemsModelSection;
 	readonly isMcp?: boolean;
@@ -100,6 +101,12 @@ export interface ICustomizationItemConfig {
 function customizationSectionVisibleKey(section: string): string {
 	return `sessionsCustomizationSectionVisible.${section}`;
 }
+
+const CUSTOMIZATION_OVERVIEW_ITEM: ICustomizationItemConfig = {
+	id: 'sessions.customization.overview',
+	label: localize('overview', "Overview"),
+	icon: Codicon.home,
+};
 
 export const CUSTOMIZATION_ITEMS: ICustomizationItemConfig[] = [
 	{
@@ -152,6 +159,32 @@ export const CUSTOMIZATION_ITEMS: ICustomizationItemConfig[] = [
 		isTools: true,
 	},
 ];
+
+export async function openCustomizationOverviewPage(editorService: IEditorService, harnessService: ICustomizationHarnessService, sessionsService: ISessionsService): Promise<void> {
+	const sessionResource = sessionsService.activeSession.get()?.resource;
+	if (sessionResource) {
+		harnessService.setActiveSession(sessionResource);
+	}
+
+	const input = AICustomizationManagementEditorInput.getOrCreate();
+	const pane = await editorService.openEditor(input, { pinned: true });
+	if (pane instanceof AICustomizationManagementEditor) {
+		pane.showWelcomePage();
+	}
+}
+
+async function openCustomizationSectionPage(editorService: IEditorService, harnessService: ICustomizationHarnessService, sessionsService: ISessionsService, section: typeof AICustomizationManagementSection[keyof typeof AICustomizationManagementSection]): Promise<void> {
+	const sessionResource = sessionsService.activeSession.get()?.resource;
+	if (sessionResource) {
+		harnessService.setActiveSession(sessionResource);
+	}
+
+	const input = AICustomizationManagementEditorInput.getOrCreate();
+	const pane = await editorService.openEditor(input, { pinned: true });
+	if (pane instanceof AICustomizationManagementEditor) {
+		pane.selectSectionById(section);
+	}
+}
 
 /**
  * Custom ActionViewItem for each customization link in the toolbar.
@@ -265,6 +298,9 @@ export class CustomizationsToolbarContribution extends Disposable implements IWo
 		// don't support a customization type don't surface its row.
 		const visibilityKeys = new Map<string, IContextKey<boolean>>();
 		for (const config of CUSTOMIZATION_ITEMS) {
+			if (!config.section) {
+				continue;
+			}
 			const key = new RawContextKey<boolean>(customizationSectionVisibleKey(config.section), true).bindTo(contextKeyService);
 			visibilityKeys.set(config.section, key);
 		}
@@ -274,17 +310,50 @@ export class CustomizationsToolbarContribution extends Disposable implements IWo
 			const descriptor = harnessService.getActiveDescriptor();
 			const hidden = new Set(descriptor.hiddenSections ?? []);
 			for (const config of CUSTOMIZATION_ITEMS) {
+				if (!config.section) {
+					continue;
+				}
 				visibilityKeys.get(config.section)!.set(!hidden.has(config.section));
 			}
 		}));
 
+		this._register(actionViewItemService.register(Menus.SidebarCustomizations, CUSTOMIZATION_OVERVIEW_ITEM.id, (action, options) => {
+			return instantiationService.createInstance(CustomizationLinkViewItem, action, options, CUSTOMIZATION_OVERVIEW_ITEM);
+		}, undefined));
+
+		this._register(registerAction2(class extends Action2 {
+			constructor() {
+				super({
+					id: CUSTOMIZATION_OVERVIEW_ITEM.id,
+					title: localize2('overviewAction', '{0}', CUSTOMIZATION_OVERVIEW_ITEM.label),
+					menu: {
+						id: Menus.SidebarCustomizations,
+						group: 'navigation',
+						order: 0,
+						when: ChatContextKeys.enabled,
+					}
+				});
+			}
+			async run(accessor: ServicesAccessor): Promise<void> {
+				await openCustomizationOverviewPage(
+					accessor.get(IEditorService),
+					accessor.get(ICustomizationHarnessService),
+					accessor.get(ISessionsService),
+				);
+			}
+		}));
+
 		for (const [index, config] of CUSTOMIZATION_ITEMS.entries()) {
+			if (!config.section) {
+				continue;
+			}
+			const section = config.section;
 			// Register the custom ActionViewItem for this action
 			this._register(actionViewItemService.register(Menus.SidebarCustomizations, config.id, (action, options) => {
 				return instantiationService.createInstance(CustomizationLinkViewItem, action, options, config);
 			}, undefined));
 
-			const sectionVisibleWhen = ContextKeyExpr.has(customizationSectionVisibleKey(config.section));
+			const sectionVisibleWhen = ContextKeyExpr.has(customizationSectionVisibleKey(section));
 
 			// Register the action with menu item
 			this._register(registerAction2(class extends Action2 {
@@ -296,7 +365,7 @@ export class CustomizationsToolbarContribution extends Disposable implements IWo
 							id: Menus.SidebarCustomizations,
 							group: 'navigation',
 							order: index + 1,
-							when: sectionVisibleWhen,
+							when: ContextKeyExpr.and(ChatContextKeys.enabled, sectionVisibleWhen),
 						}
 					});
 				}
@@ -304,22 +373,7 @@ export class CustomizationsToolbarContribution extends Disposable implements IWo
 					const editorService = accessor.get(IEditorService);
 					const harnessService = accessor.get(ICustomizationHarnessService);
 					const sessionsService = accessor.get(ISessionsService);
-					const configurationService = accessor.get(IConfigurationService);
-					const sessionResource = sessionsService.activeSession.get()?.resource;
-					if (sessionResource) {
-						harnessService.setActiveSession(sessionResource);
-					}
-					const input = AICustomizationManagementEditorInput.getOrCreate();
-					const pane = await editorService.openEditor(input, { pinned: true });
-					if (pane instanceof AICustomizationManagementEditor) {
-						const mode = configurationService.getValue<string>(SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING);
-						if (mode === SessionsCustomizationsSidebarMode.Section) {
-							pane.selectSectionById(config.section);
-						} else {
-							// 'welcome' (default) and 'single' both land on the welcome page.
-							pane.showWelcomePage();
-						}
-					}
+					await openCustomizationSectionPage(editorService, harnessService, sessionsService, section);
 				}
 			}));
 		}

--- a/src/vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution.ts
+++ b/src/vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution.ts
@@ -8,7 +8,7 @@ import './media/customizationsToolbar.css';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
-import { localize, localize2 } from '../../../../nls.js';
+import { localize } from '../../../../nls.js';
 import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
 import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
@@ -34,51 +34,6 @@ import { ChatContextKeys } from '../../../../workbench/contrib/chat/common/actio
 import { ICustomizationHarnessService } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
 import { ISession } from '../../../services/sessions/common/session.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
-import { Registry } from '../../../../platform/registry/common/platform.js';
-import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
-
-/**
- * Setting key that controls how the Customizations section in the Agents
- * sidebar is presented and what happens when an entry is clicked.
- *
- * This setting is registered (and only meaningful) in the Agents app.
- */
-export const SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING = 'sessions.customizations.sidebarMode';
-
-/**
- * Presentation/click behavior for the Customizations section in the Agents sidebar.
- * See {@link SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING}.
- */
-export enum SessionsCustomizationsSidebarMode {
-	/** Overview item plus one item per category; category clicks deep-link. */
-	Welcome = 'welcome',
-	/** Overview item plus one item per category; category clicks deep-link. */
-	Section = 'section',
-	/** A single "Customizations" entry that opens the welcome page. */
-	Single = 'single',
-}
-
-Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
-	id: 'sessions',
-	properties: {
-		[SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING]: {
-			type: 'string',
-			tags: ['preview'],
-			enum: [
-				SessionsCustomizationsSidebarMode.Welcome,
-				SessionsCustomizationsSidebarMode.Section,
-				SessionsCustomizationsSidebarMode.Single,
-			],
-			enumDescriptions: [
-				localize('sessions.customizations.sidebarMode.welcome', "Show an Overview item followed by one item per customization category. Clicking a category deep-links to that category's section in the Customizations editor."),
-				localize('sessions.customizations.sidebarMode.section', "Show an Overview item followed by one item per customization category. Clicking a category deep-links to that category's section in the Customizations editor."),
-				localize('sessions.customizations.sidebarMode.single', "Show a single \"Customizations\" entry instead of one item per category. Clicking it opens the Customizations welcome page."),
-			],
-			description: localize('sessions.customizations.sidebarMode', "Controls how the Customizations section in the Agents sidebar is presented and what happens when an entry is clicked."),
-			default: SessionsCustomizationsSidebarMode.Welcome,
-		},
-	},
-});
 
 export interface ICustomizationItemConfig {
 	readonly id: string;
@@ -325,7 +280,7 @@ export class CustomizationsToolbarContribution extends Disposable implements IWo
 			constructor() {
 				super({
 					id: CUSTOMIZATION_OVERVIEW_ITEM.id,
-						title: CUSTOMIZATION_OVERVIEW_ITEM.label,
+					title: CUSTOMIZATION_OVERVIEW_ITEM.label,
 					menu: {
 						id: Menus.SidebarCustomizations,
 						group: 'navigation',
@@ -360,7 +315,7 @@ export class CustomizationsToolbarContribution extends Disposable implements IWo
 				constructor() {
 					super({
 						id: config.id,
-						title: localize2('customizationAction', '{0}', config.label),
+						title: config.label,
 						menu: {
 							id: Menus.SidebarCustomizations,
 							group: 'navigation',

--- a/src/vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution.ts
+++ b/src/vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution.ts
@@ -325,7 +325,7 @@ export class CustomizationsToolbarContribution extends Disposable implements IWo
 			constructor() {
 				super({
 					id: CUSTOMIZATION_OVERVIEW_ITEM.id,
-					title: localize2('overviewAction', '{0}', CUSTOMIZATION_OVERVIEW_ITEM.label),
+						title: CUSTOMIZATION_OVERVIEW_ITEM.label,
 					menu: {
 						id: Menus.SidebarCustomizations,
 						group: 'navigation',

--- a/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
@@ -15,7 +15,6 @@
 	height: 100%;
 	min-height: 0;
 	position: relative;
-	padding: 6px 0;
 	box-sizing: border-box;
 	overflow: hidden;
 	font-size: var(--vscode-agents-fontSize-label1, 12px);
@@ -47,18 +46,72 @@
 	display: flex;
 	align-items: center;
 	flex-shrink: 0;
+	gap: var(--vscode-spacing-size40, 4px);
 	-webkit-user-select: none;
 	user-select: none;
 	padding: 6px 10px;
 	font-size: var(--vscode-agents-fontSize-label1, 12px);
 	font-weight: var(--vscode-agents-fontWeight-semiBold);
 	color: var(--vscode-foreground);
+	border-radius: var(--vscode-cornerRadius-medium);
+	cursor: pointer;
+}
+
+.ai-customization-toolbar .ai-customization-header:hover .ai-customization-header-label,
+.ai-customization-toolbar .ai-customization-header:focus-visible .ai-customization-header-label {
+	color: var(--vscode-strongForeground);
+}
+
+.ai-customization-toolbar .ai-customization-header:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
+
+.ai-customization-toolbar .ai-customization-header:focus:not(:focus-visible) {
+	outline: none !important;
 }
 
 .ai-customization-toolbar .ai-customization-header-label {
+	flex: 1;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.ai-customization-toolbar .ai-customization-header-total-count {
+	color: var(--vscode-descriptionForeground);
+	font-size: var(--vscode-agents-fontSize-label2, 11px);
+	font-weight: var(--vscode-agents-fontWeight-regular);
+	line-height: 1;
+}
+
+.ai-customization-toolbar .ai-customization-header-total-count.hidden {
+	display: none;
+}
+
+.ai-customization-toolbar .ai-customization-chevron {
+	flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--vscode-descriptionForeground);
+	font-size: var(--vscode-codiconFontSize-compact, 12px);
+	width: 22px;
+	height: 22px;
+	border-radius: var(--vscode-cornerRadius-small);
+	visibility: hidden;
+	opacity: 0;
+}
+
+.ai-customization-toolbar .ai-customization-header:hover .ai-customization-chevron,
+.ai-customization-toolbar .ai-customization-header:focus-visible .ai-customization-chevron,
+.ai-customization-toolbar .ai-customization-header.collapsed .ai-customization-chevron {
+	visibility: visible;
+	opacity: 0.7;
+}
+
+.ai-customization-toolbar .ai-customization-chevron:hover {
+	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
 /* Button container - fills available space. Per-item containers are inset
@@ -136,18 +189,4 @@
 .ai-customization-toolbar .ai-customization-toolbar-content {
 	overflow: hidden;
 	padding-bottom: 2px;
-}
-
-/* Single-entry mode: a single "Customizations" sidebar link replaces the
-	per-subtype toolbar list. Reuses .customization-link-button-container /
-	.customization-link-button styles for visual parity with the per-link rows. */
-.ai-customization-toolbar.single-entry {
-	padding: 6px 0 10px 0;
-}
-
-/* Disable the shared `flex: 1` so the single entry doesn't stretch to fill
-	the flex-column toolbar. Width is handled by the inherited `margin: 0 10px`
-	and the parent's default `align-items: stretch`. */
-.ai-customization-toolbar.single-entry .customization-link-button-container {
-	flex: none;
 }

--- a/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
@@ -3,23 +3,22 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 /* AI Customization section - pinned to bottom */
+.ai-customization-shortcuts-widget {
+	height: 100%;
+	min-height: 0;
+	overflow: hidden;
+}
+
 .ai-customization-toolbar {
 	display: flex;
 	flex-direction: column;
-	flex-shrink: 0;
+	height: 100%;
+	min-height: 0;
 	position: relative;
 	padding: 6px 0;
-}
-
-.ai-customization-toolbar::before {
-	content: '';
-	position: absolute;
-	top: 0;
-	left: 10px;
-	right: 10px;
-	height: 1px;
-	background-color: var(--vscode-agentsPanel-border, transparent);
-	pointer-events: none;
+	box-sizing: border-box;
+	overflow: hidden;
+	font-size: var(--vscode-agents-fontSize-label1, 12px);
 }
 
 /* Make the toolbar, action bar, and items fill full width and stack vertically */
@@ -43,49 +42,27 @@
 	width: 100%;
 }
 
-/* Customization header - clickable for collapse */
+/* Customization header */
 .ai-customization-toolbar .ai-customization-header {
 	display: flex;
 	align-items: center;
+	flex-shrink: 0;
 	-webkit-user-select: none;
 	user-select: none;
+	padding: 6px 10px;
+	font-size: var(--vscode-agents-fontSize-label1, 12px);
+	font-weight: var(--vscode-agents-fontWeight-semiBold);
+	color: var(--vscode-foreground);
 }
 
-/* Chevron mirrors the sessions list section headers: hidden by default,
-	revealed on hover/keyboard focus or whenever the section is collapsed. */
-.ai-customization-toolbar .ai-customization-chevron {
-	flex-shrink: 0;
-	opacity: 0;
+.ai-customization-toolbar .ai-customization-header-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
-.ai-customization-toolbar .ai-customization-header:hover .ai-customization-chevron,
-.ai-customization-toolbar .ai-customization-header .customization-link-button:focus-visible .ai-customization-chevron,
-.ai-customization-toolbar .ai-customization-header.collapsed .ai-customization-chevron {
-	opacity: 0.7;
-}
-
-.ai-customization-toolbar .ai-customization-header-total {
-	display: none;
-	opacity: 0.7;
-	font-size: var(--vscode-agents-fontSize-label2, 11px);
-	font-weight: var(--vscode-agents-fontWeight-regular);
-	line-height: 1;
-	margin-left: auto;
-}
-
-.ai-customization-toolbar .ai-customization-header-total + .ai-customization-chevron {
-	margin-left: 6px;
-}
-
-.ai-customization-toolbar .ai-customization-header.collapsed .customization-link-button .ai-customization-header-total:not(.hidden) {
-	display: inline;
-}
-
-/* Button container - fills available space.
-	Per-item containers are inset 10px so they sit inside the toolbar's
-	rounded edge. The header container intentionally overrides this to
-	span the full panel width so its hover background extends edge to
-	edge — see the override directly below. */
+/* Button container - fills available space. Per-item containers are inset
+	10px so they sit inside the toolbar's rounded edge. */
 .ai-customization-toolbar .customization-link-button-container {
 	overflow: hidden;
 	min-width: 0;
@@ -93,18 +70,10 @@
 	margin: 0 10px;
 }
 
-/* Header container spans full width so the hover background reaches the
-	panel edges. The header button itself re-introduces matching internal
-	padding so its label and chevron align with the per-item icons and
-	counts below. */
-.ai-customization-toolbar .ai-customization-header .customization-link-button-container {
-	margin: 0;
-	border-radius: var(--vscode-cornerRadius-medium);
-}
-
 /* Button needs relative positioning for counts overlay */
 .ai-customization-toolbar .customization-link-button {
 	position: relative;
+	font-size: var(--vscode-agents-fontSize-label1, 12px);
 }
 
 /* Icons use the standard icon foreground color. */
@@ -116,35 +85,6 @@
 	default toolbar hover used by `.sidebar-action-button`. */
 .ai-customization-toolbar .customization-link-button.sidebar-action-button:hover {
 	background-color: var(--vscode-list-hoverBackground);
-}
-
-/* The header behaves like the sessions list section labels: no background
-	fill on hover — instead the label switches to the strong foreground. */
-.ai-customization-toolbar .ai-customization-header .customization-link-button.sidebar-action-button:hover {
-	background-color: transparent;
-	color: var(--vscode-strongForeground);
-}
-
-/* Only surface the focus border for keyboard navigation, not on pointer
-	clicks (matches the section header focus behaviour). */
-.ai-customization-toolbar .ai-customization-header .customization-link-button:focus:not(:focus-visible) {
-	outline: none !important;
-}
-
-/* Customizations header label uses heavier weight and lays out the
-	label on the left with the chevron pushed to the right. The header
-	button spans the full panel width (see container override above) so
-	its internal `padding-left: 10px` matches the per-item container's
-	`margin-left: 10px` — keeping the "Customizations" label aligned
-	with the per-item icons. The right padding is tuned visually so the
-	chevron lines up with the per-item count numbers (which use
-	`right: 14px` inside their 10px-inset container). */
-.ai-customization-toolbar .ai-customization-header .customization-link-button {
-	font-weight: var(--vscode-agents-fontWeight-semiBold);
-	justify-content: space-between;
-	gap: 0;
-	padding: 6px 16px 6px 10px;
-	border-radius: var(--vscode-cornerRadius-medium);
 }
 
 /* Counts - floating right inside the per-item link button. Tuned to
@@ -181,17 +121,21 @@
 	opacity: 0.8;
 }
 
-/* Collapsed state */
-.ai-customization-toolbar .ai-customization-toolbar-content {
-	max-height: 500px;
-	overflow: hidden;
-	transition: max-height 0.2s ease-out;
-	padding-bottom: 2px;
+.ai-customization-toolbar > .monaco-scrollable-element {
+	flex: 1;
+	min-height: 0;
 }
 
-.ai-customization-toolbar.collapsed .ai-customization-toolbar-content {
-	max-height: 0;
-	padding-bottom: 0;
+.ai-customization-toolbar .ai-customization-toolbar-content-scrollable {
+	height: 100%;
+	min-height: 100%;
+	overflow: hidden;
+	width: 100%;
+}
+
+.ai-customization-toolbar .ai-customization-toolbar-content {
+	overflow: hidden;
+	padding-bottom: 2px;
 }
 
 /* Single-entry mode: a single "Customizations" sidebar link replaces the

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsViewPane.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsViewPane.css
@@ -12,6 +12,22 @@
 		overflow: hidden;
 	}
 
+	.agent-sessions-sidebar-splitview-container {
+		flex: 1;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	.agent-sessions-sidebar-splitview-container .monaco-split-view2.separator-border.vertical > .monaco-scrollable-element > .split-view-container > .split-view-view:not(:first-child)::before {
+		left: var(--vscode-spacing-size40, 4px);
+		width: calc(100% - (2 * var(--vscode-spacing-size40, 4px)));
+	}
+
+	.agent-sessions-sidebar-splitview-container .monaco-split-view2.vertical > .sash-container > .monaco-sash.horizontal {
+		left: var(--vscode-spacing-size40, 4px) !important;
+		width: calc(100% - (2 * var(--vscode-spacing-size40, 4px))) !important;
+	}
+
 	/* Section headers - more prominent than time-based groupings */
 	.agent-sessions-header {
 		font-size: var(--vscode-agents-fontSize-body2);
@@ -40,7 +56,6 @@
 		flex: 1;
 		overflow: hidden;
 		min-height: 0;
-		margin-bottom: 6px;
 	}
 
 	.agent-sessions-header {
@@ -154,6 +169,11 @@
 	.agent-sessions-control-container {
 		flex: 1;
 		overflow: hidden;
+	}
+
+	.agent-sessions-customizations-section {
+		overflow: hidden;
+		min-height: 0;
 	}
 }
 .agent-sessions-workbench.shell-gradient-background .agent-sessions-viewpane {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
@@ -324,8 +324,8 @@ export class SessionsView extends ViewPane {
 
 		const customizationsPane: IView = {
 			element: customizationsSection,
-			minimumSize: CUSTOMIZATIONS_MIN_HEIGHT,
-			get maximumSize() { return Math.max(CUSTOMIZATIONS_MIN_HEIGHT, customizationsWidget.desiredHeight); },
+			get minimumSize() { return customizationsWidget.collapsed ? customizationsWidget.collapsedHeight : CUSTOMIZATIONS_MIN_HEIGHT; },
+			get maximumSize() { return customizationsWidget.collapsed ? customizationsWidget.collapsedHeight : Math.max(CUSTOMIZATIONS_MIN_HEIGHT, customizationsWidget.desiredHeight); },
 			onDidChange: Event.map(Event.any(customizationsWidget.onDidChangeHeight, customizationsSizeChange.event), () => this.getCustomizationsPaneHeight()),
 			layout: height => {
 				customizationsSection.style.height = `${height}px`;
@@ -335,6 +335,23 @@ export class SessionsView extends ViewPane {
 
 		this.sidebarSplitView.addView(sessionsPane, Sizing.Distribute, 0, true);
 		this.sidebarSplitView.addView(customizationsPane, this.getCustomizationsPaneHeight(), 1, true);
+
+		let savedCustomizationsPaneHeight = this.getCustomizationsPaneHeight();
+		this._register(customizationsWidget.onDidToggleCollapsed(collapsed => {
+			if (!this.sidebarSplitView) {
+				return;
+			}
+			if (collapsed) {
+				const currentSize = this.sidebarSplitView.getViewSize(1);
+				if (currentSize > customizationsWidget.collapsedHeight) {
+					savedCustomizationsPaneHeight = currentSize;
+				}
+				this.sidebarSplitView.resizeView(1, customizationsWidget.collapsedHeight);
+			} else {
+				this.sidebarSplitView.resizeView(1, savedCustomizationsPaneHeight);
+			}
+			this.layoutSidebarSplitView();
+		}));
 
 		const updateSplitViewStyles = () => {
 			const borderColor = this.themeService.getColorTheme().getColor(PANEL_SECTION_BORDER);
@@ -559,6 +576,9 @@ export class SessionsView extends ViewPane {
 	}
 
 	private getCustomizationsPaneHeight(): number {
+		if (this._customizationsWidget?.collapsed) {
+			return this._customizationsWidget.collapsedHeight;
+		}
 		const desiredHeight = this._customizationsWidget?.desiredHeight ?? 0;
 		return Math.max(CUSTOMIZATIONS_MIN_HEIGHT, Number.isFinite(desiredHeight) ? desiredHeight : 0);
 	}

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
@@ -6,8 +6,12 @@
 import '../media/sessionsViewPane.css';
 import * as DOM from '../../../../../base/browser/dom.js';
 import { onUnexpectedError } from '../../../../../base/common/errors.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
 import { autorun } from '../../../../../base/common/observable.js';
 import { isWeb } from '../../../../../base/common/platform.js';
+import { Orientation } from '../../../../../base/browser/ui/sash/sash.js';
+import { IView, Sizing, SplitView } from '../../../../../base/browser/ui/splitview/splitview.js';
+import { Color } from '../../../../../base/common/color.js';
 import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../../../workbench/common/contextkeys.js';
 import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
@@ -30,6 +34,7 @@ import { agentsBackground } from '../../../../common/theme.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { IHostService } from '../../../../../workbench/services/host/browser/host.js';
 import { IWorkbenchLayoutService, Parts } from '../../../../../workbench/services/layout/browser/layoutService.js';
+import { PANEL_SECTION_BORDER } from '../../../../../workbench/common/theme.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../../../platform/actions/browser/toolbar.js';
@@ -43,6 +48,8 @@ const $ = DOM.$;
 export const SessionsViewId = 'sessions.workbench.view.sessionsView';
 const GROUPING_STORAGE_KEY = 'sessionsViewPane.grouping';
 const SORTING_STORAGE_KEY = 'sessionsViewPane.sorting';
+const CUSTOMIZATIONS_MIN_HEIGHT = 129;
+const SESSIONS_SECTION_MIN_HEIGHT = 120;
 
 /**
  * Place the given session in the sessions grid to the right of the last
@@ -68,6 +75,8 @@ export const IsWorkspaceGroupCappedContext = new RawContextKey<boolean>('session
 export class SessionsView extends ViewPane {
 
 	private viewPaneContainer: HTMLElement | undefined;
+	private sidebarSplitViewContainer: HTMLElement | undefined;
+	private sidebarSplitView: SplitView | undefined;
 	private sessionsControlContainer: HTMLElement | undefined;
 	private findWidgetContainer: HTMLElement | undefined;
 	private headerRow: HTMLElement | undefined;
@@ -82,6 +91,9 @@ export class SessionsView extends ViewPane {
 	private sortingContextKey: IContextKey | undefined;
 	private workspaceGroupCappedContextKey: IContextKey<boolean> | undefined;
 	private readonly filterContextKeys = new Map<string, { key: IContextKey<boolean>; getDefault: () => boolean }>();
+	private currentBodyHeight = 0;
+	private currentBodyWidth = 0;
+	private didInitializeCustomizationsPaneSize = false;
 
 	constructor(
 		options: IViewPaneOptions,
@@ -148,9 +160,10 @@ export class SessionsView extends ViewPane {
 
 	private createControls(parent: HTMLElement): void {
 		const sessionsContainer = DOM.append(parent, $('.agent-sessions-container'));
+		this.sidebarSplitViewContainer = DOM.append(sessionsContainer, $('.agent-sessions-sidebar-splitview-container'));
 
 		// Sessions section (top, fills available space)
-		const sessionsSection = DOM.append(sessionsContainer, $('.agent-sessions-section'));
+		const sessionsSection = DOM.append(this.sidebarSplitViewContainer, $('.agent-sessions-section'));
 
 		// Sessions content container
 		const sessionsContent = DOM.append(sessionsSection, $('.agent-sessions-content'));
@@ -283,15 +296,52 @@ export class SessionsView extends ViewPane {
 			}));
 		}
 
-		// AI Customization toolbar (bottom, fixed height)
-		this._customizationsWidget = this._register(this.instantiationService.createInstance(AICustomizationShortcutsWidget, sessionsContainer, {
+		const customizationsSection = DOM.append(this.sidebarSplitViewContainer, $('.agent-sessions-customizations-section'));
+		const customizationsSizeChange = this._register(new Emitter<void>());
+
+		const customizationsWidget = this._customizationsWidget = this._register(this.instantiationService.createInstance(AICustomizationShortcutsWidget, customizationsSection, {
 			onDidChangeLayout: () => {
-				if (this.viewPaneContainer) {
-					const { offsetHeight, offsetWidth } = this.viewPaneContainer;
-					this.layoutBody(offsetHeight, offsetWidth);
-				}
+				customizationsSizeChange.fire();
+				this.layoutSidebarSplitView();
 			},
 		}));
+
+		this.sidebarSplitView = this._register(new SplitView(this.sidebarSplitViewContainer, {
+			orientation: Orientation.VERTICAL,
+			proportionalLayout: false,
+		}));
+
+		const sessionsPane: IView = {
+			element: sessionsSection,
+			minimumSize: SESSIONS_SECTION_MIN_HEIGHT,
+			maximumSize: Number.POSITIVE_INFINITY,
+			onDidChange: Event.None,
+			layout: height => {
+				sessionsSection.style.height = `${height}px`;
+				this.sessionsControl?.layout(this.sessionsControlContainer?.offsetHeight ?? 0, this.currentBodyWidth);
+			},
+		};
+
+		const customizationsPane: IView = {
+			element: customizationsSection,
+			minimumSize: CUSTOMIZATIONS_MIN_HEIGHT,
+			get maximumSize() { return Math.max(CUSTOMIZATIONS_MIN_HEIGHT, customizationsWidget.desiredHeight); },
+			onDidChange: Event.map(Event.any(customizationsWidget.onDidChangeHeight, customizationsSizeChange.event), () => this.getCustomizationsPaneHeight()),
+			layout: height => {
+				customizationsSection.style.height = `${height}px`;
+				this._customizationsWidget?.layout(height, this.currentBodyWidth);
+			},
+		};
+
+		this.sidebarSplitView.addView(sessionsPane, Sizing.Distribute, 0, true);
+		this.sidebarSplitView.addView(customizationsPane, this.getCustomizationsPaneHeight(), 1, true);
+
+		const updateSplitViewStyles = () => {
+			const borderColor = this.themeService.getColorTheme().getColor(PANEL_SECTION_BORDER);
+			this.sidebarSplitView?.style({ separatorBorder: borderColor ?? Color.transparent });
+		};
+		updateSplitViewStyles();
+		this._register(this.themeService.onDidColorThemeChange(updateSplitViewStyles));
 
 		// Agent Host toolbar (bottom, below customizations). Only rendered
 		// in the sessions window on web desktop layouts: electron has no
@@ -306,13 +356,12 @@ export class SessionsView extends ViewPane {
 		))) {
 			this._register(this.instantiationService.createInstance(AgentHostShortcutsWidget, sessionsContainer, {
 				onDidChangeLayout: () => {
-					if (this.viewPaneContainer) {
-						const { offsetHeight, offsetWidth } = this.viewPaneContainer;
-						this.layoutBody(offsetHeight, offsetWidth);
-					}
+					this.layoutSidebarSplitView();
 				},
 			}));
 		}
+
+		this._register(DOM.scheduleAtNextAnimationFrame(DOM.getWindow(parent), () => this.layoutSidebarSplitView()));
 	}
 
 	focusCustomizations(): void {
@@ -477,13 +526,41 @@ export class SessionsView extends ViewPane {
 	protected override layoutBody(height: number, width: number): void {
 		super.layoutBody(height, width);
 
+		this.currentBodyHeight = height;
+		this.currentBodyWidth = width;
 		this.updateHeaderLayout();
+		this.layoutSidebarSplitView();
 
-		if (!this.sessionsControl || !this.sessionsControlContainer) {
+		if (this.sidebarSplitView || !this.sessionsControl || !this.sessionsControlContainer) {
 			return;
 		}
 
 		this.sessionsControl.layout(this.sessionsControlContainer.offsetHeight, width);
+	}
+
+	private layoutSidebarSplitView(): void {
+		if (!this.sidebarSplitView || !this.sidebarSplitViewContainer) {
+			return;
+		}
+
+		const height = this.sidebarSplitViewContainer.offsetHeight || this.currentBodyHeight || this.viewPaneContainer?.offsetHeight || 0;
+		if (height <= 0) {
+			return;
+		}
+
+		if (this.sidebarSplitViewContainer.offsetHeight === 0) {
+			this.sidebarSplitViewContainer.style.height = `${height}px`;
+		}
+		this.sidebarSplitView.layout(height);
+		if (!this.didInitializeCustomizationsPaneSize) {
+			this.didInitializeCustomizationsPaneSize = true;
+			this.sidebarSplitView.resizeView(1, this.getCustomizationsPaneHeight());
+		}
+	}
+
+	private getCustomizationsPaneHeight(): number {
+		const desiredHeight = this._customizationsWidget?.desiredHeight ?? 0;
+		return Math.max(CUSTOMIZATIONS_MIN_HEIGHT, Number.isFinite(desiredHeight) ? desiredHeight : 0);
 	}
 
 	override focus(): void {

--- a/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
@@ -8,12 +8,12 @@ import { Emitter, Event } from '../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { derived, IObservable, observableValue } from '../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { IActionViewItemFactory, IActionViewItemService } from '../../../../../platform/actions/browser/actionViewItemService.js';
 import { IMenu, IMenuActionOptions, IMenuService, isIMenuItem, MenuId, MenuItemAction, MenuRegistry, SubmenuItemAction } from '../../../../../platform/actions/common/actions.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { IStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
 import { IMcpServer, IMcpService } from '../../../../../workbench/contrib/mcp/common/mcpTypes.js';
 import { IAgentPluginService } from '../../../../../workbench/contrib/chat/common/plugins/agentPluginService.js';
 import { ILanguageModelToolsService, IToolSet } from '../../../../../workbench/contrib/chat/common/tools/languageModelToolsService.js';
@@ -24,7 +24,7 @@ import { getChatSessionType } from '../../../../../workbench/contrib/chat/common
 import { AICustomizationManagementSection, AICustomizationSources } from '../../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
 import { IAICustomizationListItem } from '../../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.js';
 import { AICustomizationShortcutsWidget } from '../../browser/aiCustomizationShortcutsWidget.js';
-import { CUSTOMIZATION_ITEMS, CustomizationLinkViewItem, SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING, SessionsCustomizationsSidebarMode } from '../../browser/customizationsToolbar.contribution.js';
+import { CUSTOMIZATION_ITEMS, CustomizationLinkViewItem, ICustomizationItemConfig, SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING, SessionsCustomizationsSidebarMode } from '../../browser/customizationsToolbar.contribution.js';
 import { IEditorService } from '../../../../../workbench/services/editor/common/editorService.js';
 import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup, registerWorkbenchServices } from '../../../../../workbench/test/browser/componentFixtures/fixtureUtils.js';
 import { Menus } from '../../../../browser/menus.js';
@@ -43,11 +43,17 @@ import '../../../../../platform/theme/common/colors/inputColors.js';
 // ============================================================================
 
 const menuRegistrations = new DisposableStore();
-for (const [index, config] of CUSTOMIZATION_ITEMS.entries()) {
+const OVERVIEW_ITEM: ICustomizationItemConfig = {
+	id: 'sessions.customization.overview',
+	label: 'Overview',
+	icon: Codicon.home,
+};
+const SIDEBAR_ITEMS = [OVERVIEW_ITEM, ...CUSTOMIZATION_ITEMS];
+for (const [index, config] of SIDEBAR_ITEMS.entries()) {
 	menuRegistrations.add(MenuRegistry.appendMenuItem(Menus.SidebarCustomizations, {
 		command: { id: config.id, title: config.label },
 		group: 'navigation',
-		order: index + 1,
+		order: index,
 	}));
 }
 
@@ -173,8 +179,9 @@ function createMockHarnessService(hiddenSections: readonly string[] = []): ICust
 // Render helper
 // ============================================================================
 
-function renderWidget(ctx: ComponentFixtureContext, options?: { mcpServerCount?: number; collapsed?: boolean; counts?: ICustomizationCounts; hiddenSections?: readonly string[]; mode?: SessionsCustomizationsSidebarMode }): void {
+function renderWidget(ctx: ComponentFixtureContext, options?: { mcpServerCount?: number; counts?: ICustomizationCounts; hiddenSections?: readonly string[]; mode?: SessionsCustomizationsSidebarMode; height?: number }): void {
 	ctx.container.style.width = '300px';
+	ctx.container.style.height = `${options?.height ?? 260}px`;
 	ctx.container.style.backgroundColor = 'var(--vscode-sideBar-background)';
 
 	const actionViewItemService = new FixtureActionViewItemService();
@@ -216,24 +223,10 @@ function renderWidget(ctx: ComponentFixtureContext, options?: { mcpServerCount?:
 	});
 
 	// Register view item factories from the real CustomizationLinkViewItem
-	for (const config of CUSTOMIZATION_ITEMS) {
+	for (const config of SIDEBAR_ITEMS) {
 		ctx.disposableStore.add(actionViewItemService.register(Menus.SidebarCustomizations, config.id, (action, options) => {
 			return instantiationService.createInstance(CustomizationLinkViewItem, action, options, config);
 		}));
-	}
-
-	// Override storage to set initial collapsed state
-	if (options?.collapsed) {
-		const storageService = instantiationService.get(IStorageService);
-		instantiationService.set(IStorageService, new class extends mock<IStorageService>() {
-			override getBoolean(key: string, scope: StorageScope, fallbackValue?: boolean) {
-				if (key === 'agentSessions.customizationsCollapsed') {
-					return true;
-				}
-				return storageService.getBoolean(key, scope, fallbackValue!);
-			}
-			override store() { }
-		}());
 	}
 
 	ctx.disposableStore.add(
@@ -252,9 +245,9 @@ export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 		render: (ctx) => renderWidget(ctx),
 	}),
 
-	Collapsed: defineComponentFixture({
+	MinimumHeight: defineComponentFixture({
 		labels: { kind: 'screenshot' },
-		render: (ctx) => renderWidget(ctx, { collapsed: true }),
+		render: (ctx) => renderWidget(ctx, { height: 129 }),
 	}),
 
 	WithMcpServers: defineComponentFixture({
@@ -262,9 +255,9 @@ export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 		render: (ctx) => renderWidget(ctx, { mcpServerCount: 3 }),
 	}),
 
-	CollapsedWithMcpServers: defineComponentFixture({
+	MinimumHeightWithMcpServers: defineComponentFixture({
 		labels: { kind: 'screenshot' },
-		render: (ctx) => renderWidget(ctx, { mcpServerCount: 3, collapsed: true }),
+		render: (ctx) => renderWidget(ctx, { mcpServerCount: 3, height: 129 }),
 	}),
 
 	WithCounts: defineComponentFixture({

--- a/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
@@ -12,8 +12,6 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { IActionViewItemFactory, IActionViewItemService } from '../../../../../platform/actions/browser/actionViewItemService.js';
 import { IMenu, IMenuActionOptions, IMenuService, isIMenuItem, MenuId, MenuItemAction, MenuRegistry, SubmenuItemAction } from '../../../../../platform/actions/common/actions.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
-import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IMcpServer, IMcpService } from '../../../../../workbench/contrib/mcp/common/mcpTypes.js';
 import { IAgentPluginService } from '../../../../../workbench/contrib/chat/common/plugins/agentPluginService.js';
 import { ILanguageModelToolsService, IToolSet } from '../../../../../workbench/contrib/chat/common/tools/languageModelToolsService.js';
@@ -24,7 +22,7 @@ import { getChatSessionType } from '../../../../../workbench/contrib/chat/common
 import { AICustomizationManagementSection, AICustomizationSources } from '../../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
 import { IAICustomizationListItem } from '../../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.js';
 import { AICustomizationShortcutsWidget } from '../../browser/aiCustomizationShortcutsWidget.js';
-import { CUSTOMIZATION_ITEMS, CustomizationLinkViewItem, ICustomizationItemConfig, SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING, SessionsCustomizationsSidebarMode } from '../../browser/customizationsToolbar.contribution.js';
+import { CUSTOMIZATION_ITEMS, CustomizationLinkViewItem, ICustomizationItemConfig } from '../../browser/customizationsToolbar.contribution.js';
 import { IEditorService } from '../../../../../workbench/services/editor/common/editorService.js';
 import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup, registerWorkbenchServices } from '../../../../../workbench/test/browser/componentFixtures/fixtureUtils.js';
 import { Menus } from '../../../../browser/menus.js';
@@ -179,17 +177,12 @@ function createMockHarnessService(hiddenSections: readonly string[] = []): ICust
 // Render helper
 // ============================================================================
 
-function renderWidget(ctx: ComponentFixtureContext, options?: { mcpServerCount?: number; counts?: ICustomizationCounts; hiddenSections?: readonly string[]; mode?: SessionsCustomizationsSidebarMode; height?: number }): void {
+function renderWidget(ctx: ComponentFixtureContext, options?: { mcpServerCount?: number; counts?: ICustomizationCounts; hiddenSections?: readonly string[]; height?: number }): void {
 	ctx.container.style.width = '300px';
 	ctx.container.style.height = `${options?.height ?? 260}px`;
 	ctx.container.style.backgroundColor = 'var(--vscode-sideBar-background)';
 
 	const actionViewItemService = new FixtureActionViewItemService();
-
-	const configurationService = new TestConfigurationService();
-	if (options?.mode !== undefined) {
-		configurationService.setUserConfiguration(SESSIONS_CUSTOMIZATIONS_SIDEBAR_MODE_SETTING, options.mode);
-	}
 
 	const instantiationService = createEditorServices(ctx.disposableStore, {
 		colorTheme: ctx.theme,
@@ -198,7 +191,6 @@ function renderWidget(ctx: ComponentFixtureContext, options?: { mcpServerCount?:
 			// Register overrides AFTER registerWorkbenchServices so they take priority
 			reg.defineInstance(IMenuService, new FixtureMenuService());
 			reg.defineInstance(IActionViewItemService, actionViewItemService);
-			reg.defineInstance(IConfigurationService, configurationService);
 			reg.defineInstance(IEditorService, new class extends mock<IEditorService>() {
 				override readonly onDidActiveEditorChange = Event.None;
 				override readonly onDidVisibleEditorsChange = Event.None;
@@ -268,39 +260,4 @@ export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 		}),
 	}),
 
-	// --- Sidebar mode variations ---
-
-	ModeWelcome: defineComponentFixture({
-		labels: { kind: 'screenshot' },
-		render: (ctx) => renderWidget(ctx, {
-			mode: SessionsCustomizationsSidebarMode.Welcome,
-			mcpServerCount: 2,
-			counts: { agents: 2, skills: 30, instructions: 16, hooks: 4 },
-		}),
-	}),
-
-	ModeSection: defineComponentFixture({
-		labels: { kind: 'screenshot' },
-		render: (ctx) => renderWidget(ctx, {
-			mode: SessionsCustomizationsSidebarMode.Section,
-			mcpServerCount: 2,
-			counts: { agents: 2, skills: 30, instructions: 16, hooks: 4 },
-		}),
-	}),
-
-	ModeSingle: defineComponentFixture({
-		labels: { kind: 'screenshot' },
-		render: (ctx) => renderWidget(ctx, {
-			mode: SessionsCustomizationsSidebarMode.Single,
-			mcpServerCount: 2,
-			counts: { agents: 2, skills: 30, instructions: 16, hooks: 4 },
-		}),
-	}),
-
-	ModeSingleEmpty: defineComponentFixture({
-		labels: { kind: 'screenshot' },
-		render: (ctx) => renderWidget(ctx, {
-			mode: SessionsCustomizationsSidebarMode.Single,
-		}),
-	}),
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/321166

Addresses bug where the Customizations sidebar list items, when clicked, do not open their associated Customizations modal page.

This is accomplished by rethinking Customizations sidebar a bit to match the behavior of the Checks section UI that is displayed in chat sessions that have PRs with CI tasks.

Specific changes:

- Customizations section is collapsible and resizable
  - Min height visually matches Checks section min height
  - Initial height and max height are the total height of content
- Added an "Overview" list item to access the Overview page directly
- Change Customizations label font size to match Checks (i.e. make it smaller by 1px)
- Remove `sessions.customizations.sidebarMode` setting and associated code for "single" option

https://github.com/user-attachments/assets/3c68c126-0c85-4e38-a96c-1978585587eb

https://github.com/user-attachments/assets/b2c0f4b5-7c3e-4413-a397-bd13ed14bcb4
