### PR TITLE
chat: add full path + branch tooltip to agent-host folder picker chip

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem.ts
@@ -6,6 +6,10 @@
 import * as dom from '../../../../../../base/browser/dom.js';
 import { renderLabelWithIcons } from '../../../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { IActionProvider } from '../../../../../../base/browser/ui/dropdown/dropdown.js';
+import { getDefaultHoverDelegate } from '../../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
+import { IManagedHoverTooltipMarkdownString } from '../../../../../../base/browser/ui/hover/hover.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
+import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { basename } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
@@ -14,9 +18,11 @@ import { MenuItemAction } from '../../../../../../platform/actions/common/action
 import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
 import { IActionWidgetDropdownAction, IActionWidgetDropdownActionProvider, IActionWidgetDropdownOptions } from '../../../../../../platform/actionWidget/browser/actionWidgetDropdown.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
+import { ISCMService } from '../../../../scm/common/scm.js';
 import type { IChatWidget } from '../../chat.js';
 import { ChatInputPickerActionViewItem, IChatInputPickerOptions } from '../../widget/input/chatInputPickerActionItem.js';
 import { IAgentHostNewSessionFolderService } from './agentHostNewSessionFolderService.js';
@@ -33,6 +39,8 @@ import { IAgentHostNewSessionFolderService } from './agentHostNewSessionFolderSe
  */
 export class AgentHostFolderPickerActionItem extends ChatInputPickerActionViewItem {
 
+	private _hoverSetup = false;
+
 	constructor(
 		action: MenuItemAction,
 		private readonly _widget: IChatWidget,
@@ -43,6 +51,8 @@ export class AgentHostFolderPickerActionItem extends ChatInputPickerActionViewIt
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@IAgentHostNewSessionFolderService private readonly _newSessionFolderService: IAgentHostNewSessionFolderService,
+		@ISCMService private readonly _scmService: ISCMService,
+		@IHoverService private readonly _hoverService: IHoverService,
 	) {
 		const actionProvider: IActionWidgetDropdownActionProvider = {
 			getActions: () => {
@@ -128,5 +138,63 @@ export class AgentHostFolderPickerActionItem extends ChatInputPickerActionViewIt
 			dom.$('span.chat-input-picker-label', undefined, label),
 		);
 		return null;
+	}
+
+	override render(container: HTMLElement): void {
+		super.render(container);
+
+		// The chip often shows a disabled folder name — the working directory is
+		// fixed once the session starts — so a plain folder name alone doesn't
+		// explain what it represents. Surface a descriptive hover with the full
+		// folder path and current git branch, mirroring the agents window's
+		// session header. Set up once with a content factory so the hover always
+		// reflects the latest selection/branch at the time it is shown.
+		if (this.element && !this._hoverSetup) {
+			this._hoverSetup = true;
+			this._register(this._hoverService.setupManagedHover(
+				getDefaultHoverDelegate('element'),
+				this.element,
+				() => this._buildHoverContent(),
+			));
+		}
+	}
+
+	/**
+	 * Builds the hover content for the folder chip: the full folder path and,
+	 * when the folder maps to a git repository, the current branch name.
+	 * Returns `undefined` when no folder is selected so no hover is shown.
+	 */
+	private _buildHoverContent(): IManagedHoverTooltipMarkdownString | undefined {
+		const selected = this._selectedFolder();
+		if (!selected) {
+			return undefined;
+		}
+
+		const md = new MarkdownString('', { supportThemeIcons: true });
+		const fallbackLines: string[] = [];
+
+		md.appendMarkdown(`$(${Codicon.folder.id}) `);
+		md.appendText(selected.fsPath);
+		fallbackLines.push(selected.fsPath);
+
+		const branch = this._branchName(selected);
+		if (branch) {
+			md.appendMarkdown('\n\n$(git-branch) ');
+			md.appendText(branch);
+			fallbackLines.push(branch);
+		}
+
+		return { markdown: md, markdownNotSupportedFallback: fallbackLines.join('\n') };
+	}
+
+	/**
+	 * Resolves the current git branch name for the given folder via the SCM
+	 * service, or `undefined` when the folder has no associated repository or
+	 * branch information.
+	 */
+	private _branchName(folderUri: URI): string | undefined {
+		const repository = this._scmService.getRepository(folderUri);
+		const historyProvider = repository?.provider.historyProvider.get();
+		return historyProvider?.historyItemRef.get()?.name.trim() || undefined;
 	}
 }


### PR DESCRIPTION
### What

Adds a descriptive hover to the agent-host **Folder** picker chip in the Copilot Chat secondary input toolbar (`AgentHostFolderPickerActionItem`). The hover now shows:

- the **full folder path**, and
- the current **git branch** (when the folder maps to an SCM repository).

This mirrors the rich workspace tooltip already shown under the chat title in the Agents Window session header (`sessionHeader._buildWorkspaceHover()`).

### Why

Fixes #322139. Once an agent-host session starts, its working directory is fixed, so the folder chip stays visible but **disabled** — showing just a bare folder name with no tooltip, so it isn't clear what it represents.

Root cause: the chip overrides `renderLabel()` without wiring a hover, and the base `updateTooltip()` lifecycle creates none here because the `MenuItemAction` tooltip defaults to the empty string (and `getTooltip()` uses `??`, which does not fall back on an empty string). The result was a chip with no tooltip at all.

### How

- Inject `ISCMService` (branch lookup) and `IHoverService` (per the repo guideline to prefer `IHoverService` for tooltips).
- `_branchName(uri)` reads the branch via the established workbench path used by `chatRepoInfo.ts`: `scmService.getRepository(uri)` -> `provider.historyProvider.get()` -> `historyItemRef.get()?.name`.
- `_buildHoverContent()` builds an `IManagedHoverTooltipMarkdownString` (folder path + branch) with a plain-text fallback.
- The hover is wired **once** in `render()` with a content **factory**, so it always reflects the latest selection/branch when shown, and works even while the chip is disabled (no `pointer-events: none` on the disabled state). A `_hoverSetup` guard prevents duplicate registration; the empty base tooltip means there is no competing hover.

### Notes for reviewers

- **Worktree name is intentionally omitted.** The session-header tooltip also distinguishes worktrees, but worktree data only exists in the `extensions/git` extension, not core workbench. For this multi-root folder picker those are plain root folders, so full path + branch is the meaningful, fully-reachable subset.
- The per-item `tooltip: folder.uri.fsPath` inside the open dropdown list is unchanged.
- Single-file change. Validated with `typecheck-client`, `valid-layers-check`, `eslint`, and `hygiene` (the changed file is clean; the chat -> scm import is an existing pattern).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
