### PR TITLE
Wire up universal tool_instructions for agent host prompts

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -40,7 +40,7 @@ import { MessageKind, ResponsePartKind, ChatInputAnswerState, ChatInputAnswerVal
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import type { IExitPlanModeResponse } from './copilotAgent.js';
 import { CopilotSessionWrapper } from './copilotSessionWrapper.js';
-import type { CopilotSessionLaunchPlan, IActiveClientSnapshot, ICopilotSessionLauncher, ICopilotSessionRuntime } from './copilotSessionLauncher.js';
+import { clientToolNamesFromSnapshot, type CopilotSessionLaunchPlan, type IActiveClientSnapshot, type ICopilotSessionLauncher, type ICopilotSessionRuntime } from './copilotSessionLauncher.js';
 import { ActiveClientState } from '../activeClientState.js';
 import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
 import { buildCopilotSystemNotification } from './copilotSystemNotification.js';
@@ -562,7 +562,7 @@ export class CopilotAgentSession extends Disposable {
 		this._serverToolHost = options.serverToolHost;
 
 		this._appliedSnapshot = options.clientSnapshot ?? { tools: [], plugins: [], mcpServers: {} };
-		this._clientToolNames = new Set(this._appliedSnapshot.tools.map(t => t.name));
+		this._clientToolNames = clientToolNamesFromSnapshot(this._appliedSnapshot);
 		// Share the agent's live ActiveClientState when provided so clientId
 		// changes are observed at stamp time. Standalone / test construction
 		// seeds a private instance with the applied tools and no owning client.

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -8,7 +8,7 @@ import { coalesce } from '../../../../base/common/arrays.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IFileService } from '../../../files/common/files.js';
-import { ILogService } from '../../../log/common/log.js';
+import { ILogService, LogLevel } from '../../../log/common/log.js';
 import { AgentHostConfigKey, agentHostCustomizationConfigSchema } from '../../common/agentHostCustomizationConfig.js';
 import { AgentHostSessionSyncEnabledConfigKey, platformRootSchema, type AgentHostMcpServers } from '../../common/agentHostSchema.js';
 import { AgentHostSandboxConfigKey, sandboxConfigSchema } from '../../common/sandboxConfigSchema.js';
@@ -322,14 +322,18 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 		const clientToolNames = clientToolNamesFromSnapshot(plan.snapshot);
 		const promptContext: IAgentHostPromptContext = {
 			getSetting: key => this._configurationService.getRootValue(agentHostCustomizationConfigSchema, key),
-			hasTool: name => clientToolNames.has(name),
+			hasClientTool: name => clientToolNames.has(name),
 		};
 		// Resolved once per (re)launch — the SDK has no mid-session system-message
 		// update, so this reflects the model/tools/settings at launch time. Log a
 		// summary at info for prompt observability; the full config at trace.
 		const systemMessage = agentHostPromptRegistry.resolveSystemMessageConfig(model, promptContext);
 		this._logService.info(`[Copilot:${plan.sessionId}] Resolved system message: ${describeSystemMessageConfig(systemMessage)}`);
-		this._logService.trace(`[Copilot:${plan.sessionId}] System message config: ${JSON.stringify(systemMessage, (_key, value) => typeof value === 'function' ? '[transform fn]' : value)}`);
+		if (this._logService.getLevel() <= LogLevel.Trace) {
+			// Guarded: a `replace`-mode prompt's content can be multiple KB, so only
+			// serialize it when trace output is actually emitted.
+			this._logService.trace(`[Copilot:${plan.sessionId}] System message config: ${JSON.stringify(systemMessage, (_key, value) => typeof value === 'function' ? '[transform fn]' : value)}`);
+		}
 		return {
 			clientName: 'vscode',
 			enableMcpApps: true,

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -23,6 +23,7 @@ import { buildSandboxConfigForSdk, type ISdkSandboxConfig } from './sandboxConfi
 import type { ITypedPermissionRequest } from './copilotToolDisplay.js';
 import type { ICopilotPluginInfo } from './copilotAgent.js';
 import { agentHostPromptRegistry, type IAgentHostPromptContext } from './prompts/promptRegistry.js';
+import { describeSystemMessageConfig } from './prompts/systemMessage.js';
 import './prompts/allPrompts.js';
 
 export const ThinkingLevelConfigKey = 'thinkingLevel';
@@ -62,6 +63,16 @@ export interface IActiveClientSnapshot {
 	readonly tools: readonly ToolDefinition[];
 	readonly plugins: readonly ICopilotPluginInfo[];
 	readonly mcpServers: AgentHostMcpServers;
+}
+
+/**
+ * The set of client-tool names the agent sees for a snapshot — each tool's
+ * `ToolDefinition.name` (the camelCase `toolReferenceName`). Used both to gate
+ * tool-specific prompt sections at launch and to route client tool calls during
+ * the session, so the two stay derived from one definition.
+ */
+export function clientToolNamesFromSnapshot(snapshot: IActiveClientSnapshot): ReadonlySet<string> {
+	return new Set(snapshot.tools.map(tool => tool.name));
 }
 
 export interface ICopilotSessionRuntime {
@@ -306,9 +317,19 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 		const skillDirectories = toSdkSkillDirectories(pluginsWithoutDirs.flatMap(p => p.skills));
 		const instructionDirectories = toSdkInstructionDirectories(plugins.flatMap(p => p.instructions));
 		const model = plan.kind === 'create' ? plan.model : plan.fallback.model;
+		// Client tools (browser tools, tasks, etc.) are addressed by the name the
+		// agent sees them under; used to gate tool-specific prompt sections.
+		const clientToolNames = clientToolNamesFromSnapshot(plan.snapshot);
 		const promptContext: IAgentHostPromptContext = {
 			getSetting: key => this._configurationService.getRootValue(agentHostCustomizationConfigSchema, key),
+			hasTool: name => clientToolNames.has(name),
 		};
+		// Resolved once per (re)launch — the SDK has no mid-session system-message
+		// update, so this reflects the model/tools/settings at launch time. Log a
+		// summary at info for prompt observability; the full config at trace.
+		const systemMessage = agentHostPromptRegistry.resolveSystemMessageConfig(model, promptContext);
+		this._logService.info(`[Copilot:${plan.sessionId}] Resolved system message: ${describeSystemMessageConfig(systemMessage)}`);
+		this._logService.trace(`[Copilot:${plan.sessionId}] System message config: ${JSON.stringify(systemMessage, (_key, value) => typeof value === 'function' ? '[transform fn]' : value)}`);
 		return {
 			clientName: 'vscode',
 			enableMcpApps: true,
@@ -325,7 +346,7 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			customAgents,
 			skillDirectories,
 			instructionDirectories,
-			systemMessage: agentHostPromptRegistry.resolveSystemMessageConfig(model, promptContext),
+			systemMessage,
 			pluginDirectories: coalesce(plugins.map(p => p.pluginDir))
 				.filter(d => d.scheme === Schemas.file).map(d => d.fsPath),
 			tools: [...shellTools, ...runtime.createClientSdkTools(), ...runtime.createServerSdkTools()],

--- a/src/vs/platform/agentHost/node/copilot/prompts/promptRegistry.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/promptRegistry.ts
@@ -30,13 +30,19 @@ export interface IAgentHostPromptContext {
 	getSetting<K extends keyof CustomizationConfigDefinition & string>(key: K): SchemaValue<CustomizationConfigDefinition[K]> | undefined;
 
 	/**
-	 * Returns whether a tool is available in the session, addressed by the name
-	 * the agent sees it under (client tools use their camelCase
-	 * `toolReferenceName`). The agent-host equivalent of the Copilot extension
-	 * inspecting its available tool set, used to gate tool-specific instructions
-	 * on the tool actually being present.
+	 * Returns whether a *client* tool is available in the session, addressed by
+	 * the camelCase `toolReferenceName` the agent sees it under (e.g.
+	 * `openBrowserPage`). Used to gate tool-specific instructions on the tool
+	 * being present, the agent-host equivalent of the Copilot extension
+	 * inspecting its tool set.
+	 *
+	 * Scope: client tools only (the forwarded workbench tools). It does NOT see
+	 * shell tools, server-SDK tools, or MCP-provided tools — those aren't in the
+	 * session snapshot at launch (MCP is discovered dynamically). A line that
+	 * gates on one of those names silently resolves to `false`; broadening this
+	 * is the context-enrichment follow-up.
 	 */
-	hasTool(name: string): boolean;
+	hasClientTool(name: string): boolean;
 }
 
 /**
@@ -176,9 +182,10 @@ export class AgentHostPromptRegistry {
 	 * Only `customize`-mode configs carry section overrides, so this is a no-op
 	 * for a contributor's full `replace` prompt (which owns the entire system
 	 * message and intentionally drops the SDK foundation) and for `append` mode.
-	 * A `replace` contributor that wants the universal guidance embeds it itself
-	 * via {@link universalToolInstructions}, mirroring how the extension's
-	 * full-prompt models inline the same lines.
+	 * A `replace` contributor that wants the universal guidance re-includes it
+	 * itself by calling `appendUniversalToolInstructions` (in `toolInstructions.ts`)
+	 * from its `resolveFullSystemPrompt`, mirroring how the extension's full-prompt
+	 * models inline the same lines.
 	 *
 	 * A per-model `tool_instructions` override is composed with — not overwritten
 	 * by — the universal lines (see {@link resolveToolInstructionsOverride}).
@@ -187,7 +194,7 @@ export class AgentHostPromptRegistry {
 		if (config.mode !== 'customize') {
 			return config;
 		}
-		const toolInstructions = resolveToolInstructionsOverride(name => context.hasTool(name), config.sections?.tool_instructions);
+		const toolInstructions = resolveToolInstructionsOverride(name => context.hasClientTool(name), config.sections?.tool_instructions);
 		if (!toolInstructions) {
 			return config;
 		}

--- a/src/vs/platform/agentHost/node/copilot/prompts/promptRegistry.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/promptRegistry.ts
@@ -8,6 +8,7 @@ import { agentHostCustomizationConfigSchema } from '../../../common/agentHostCus
 import type { SchemaValue } from '../../../common/agentHostSchema.js';
 import type { ModelSelection } from '../../../common/state/protocol/state.js';
 import { COPILOT_AGENT_HOST_SYSTEM_MESSAGE, fullSystemPrompt, sectionOverrides } from './systemMessage.js';
+import { resolveToolInstructionsOverride } from './toolInstructions.js';
 
 type CustomizationConfigDefinition = typeof agentHostCustomizationConfigSchema.definition;
 
@@ -27,6 +28,15 @@ export interface IAgentHostPromptContext {
 	 * {@link agentHostCustomizationConfigSchema}.
 	 */
 	getSetting<K extends keyof CustomizationConfigDefinition & string>(key: K): SchemaValue<CustomizationConfigDefinition[K]> | undefined;
+
+	/**
+	 * Returns whether a tool is available in the session, addressed by the name
+	 * the agent sees it under (client tools use their camelCase
+	 * `toolReferenceName`). The agent-host equivalent of the Copilot extension
+	 * inspecting its available tool set, used to gate tool-specific instructions
+	 * on the tool actually being present.
+	 */
+	hasTool(name: string): boolean;
 }
 
 /**
@@ -109,7 +119,24 @@ export class AgentHostPromptRegistry {
 	}
 
 	/**
-	 * Resolves the {@link SystemMessageConfig} for a session's model.
+	 * Resolves the {@link SystemMessageConfig} for a session's model: the
+	 * per-model (or default) config from {@link _resolveModelConfig}, with the
+	 * model-agnostic section overrides from {@link _withUniversalSections}
+	 * layered on top.
+	 *
+	 * Lifetime: the SDK accepts a system message only at session create/resume
+	 * (there is no mid-session update), so this is resolved once per (re)launch
+	 * and any tool-gated content reflects the tool set at that moment. A change
+	 * to the session's tools/plugins is part of the launcher's restart-detection
+	 * snapshot, so it re-launches the session and recomputes this; an in-flight
+	 * turn keeps the prompt it launched with.
+	 */
+	resolveSystemMessageConfig(model: ModelSelection | undefined, context: IAgentHostPromptContext): SystemMessageConfig {
+		return this._withUniversalSections(this._resolveModelConfig(model, context), context);
+	}
+
+	/**
+	 * Resolves the per-model config, before universal sections are layered on.
 	 *
 	 * Falls back to {@link COPILOT_AGENT_HOST_SYSTEM_MESSAGE} when the model is
 	 * unknown (e.g. server-side "Auto" selection where no model is chosen at
@@ -117,7 +144,7 @@ export class AgentHostPromptRegistry {
 	 * contributor opts out for the current {@link context} (e.g. a setting that
 	 * gates it is disabled).
 	 */
-	resolveSystemMessageConfig(model: ModelSelection | undefined, context: IAgentHostPromptContext): SystemMessageConfig {
+	private _resolveModelConfig(model: ModelSelection | undefined, context: IAgentHostPromptContext): SystemMessageConfig {
 		if (!model) {
 			return COPILOT_AGENT_HOST_SYSTEM_MESSAGE;
 		}
@@ -138,6 +165,35 @@ export class AgentHostPromptRegistry {
 			return sectionOverrides(sections);
 		}
 		return COPILOT_AGENT_HOST_SYSTEM_MESSAGE;
+	}
+
+	/**
+	 * Layers section overrides that apply to EVERY model on top of the per-model
+	 * (or default) config. Currently this is only the `tool_instructions` section
+	 * (see {@link resolveToolInstructionsOverride}), which the agent host wants
+	 * for all models rather than gating per-model like the Opus prompt.
+	 *
+	 * Only `customize`-mode configs carry section overrides, so this is a no-op
+	 * for a contributor's full `replace` prompt (which owns the entire system
+	 * message and intentionally drops the SDK foundation) and for `append` mode.
+	 * A `replace` contributor that wants the universal guidance embeds it itself
+	 * via {@link universalToolInstructions}, mirroring how the extension's
+	 * full-prompt models inline the same lines.
+	 *
+	 * A per-model `tool_instructions` override is composed with — not overwritten
+	 * by — the universal lines (see {@link resolveToolInstructionsOverride}).
+	 */
+	private _withUniversalSections(config: SystemMessageConfig, context: IAgentHostPromptContext): SystemMessageConfig {
+		if (config.mode !== 'customize') {
+			return config;
+		}
+		const toolInstructions = resolveToolInstructionsOverride(name => context.hasTool(name), config.sections?.tool_instructions);
+		if (!toolInstructions) {
+			return config;
+		}
+		// Spread into a fresh object so the shared `COPILOT_AGENT_HOST_SYSTEM_MESSAGE`
+		// constant (returned by the fallback paths above) is never mutated.
+		return sectionOverrides({ ...config.sections, tool_instructions: toolInstructions });
 	}
 }
 

--- a/src/vs/platform/agentHost/node/copilot/prompts/systemMessage.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/systemMessage.ts
@@ -67,7 +67,10 @@ export function describeSystemMessageConfig(config: SystemMessageConfig): string
 			const action = override?.action;
 			return `${name}:${typeof action === 'function' ? 'transform' : action}`;
 		});
-		return `mode=customize sections=[${parts.join(', ')}]`;
+		// The customize convenience `content` is appended after all sections; note
+		// it so the summary doesn't understate what was sent.
+		const content = config.content ? ` +content(length ${config.content.length})` : '';
+		return `mode=customize sections=[${parts.join(', ')}]${content}`;
 	}
 	return `mode=append (content length ${config.content?.length ?? 0})`;
 }

--- a/src/vs/platform/agentHost/node/copilot/prompts/systemMessage.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/systemMessage.ts
@@ -49,3 +49,25 @@ export function fullSystemPrompt(content: string): SystemMessageConfig {
 export function sectionOverrides(sections: Partial<Record<SystemMessageSection, SectionOverride>>): SystemMessageConfig {
 	return { mode: 'customize', sections };
 }
+
+/**
+ * One-line, log-friendly summary of a resolved {@link SystemMessageConfig} —
+ * the mode plus, for `customize`, which sections are overridden and with what
+ * action (e.g. `mode=customize sections=[identity:replace, tool_instructions:append]`).
+ *
+ * Keeps prompt observability cheap at `info` level without dumping full prompt
+ * text on every session launch (log the whole config at `trace` for that).
+ */
+export function describeSystemMessageConfig(config: SystemMessageConfig): string {
+	if (config.mode === 'replace') {
+		return `mode=replace (content length ${config.content.length})`;
+	}
+	if (config.mode === 'customize') {
+		const parts = Object.entries(config.sections ?? {}).map(([name, override]) => {
+			const action = override?.action;
+			return `${name}:${typeof action === 'function' ? 'transform' : action}`;
+		});
+		return `mode=customize sections=[${parts.join(', ')}]`;
+	}
+	return `mode=append (content length ${config.content?.length ?? 0})`;
+}

--- a/src/vs/platform/agentHost/node/copilot/prompts/toolInstructions.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/toolInstructions.ts
@@ -61,9 +61,8 @@ export function universalToolInstructions(hasTool: (name: string) => boolean, li
  * @param existing the per-model contributor's `tool_instructions` override, if any.
  */
 export function composeToolInstructions(existing: SectionOverride | undefined, content: string): SectionOverride {
-	// No per-model override: append our lines to the SDK foundation section. The
-	// leading newline keeps the appended text on its own line rather than running
-	// on from the foundation content.
+	// No per-model override: append after the SDK foundation section, led by a
+	// newline so it doesn't run on from the foundation content.
 	if (!existing) {
 		return { action: 'append', content: `\n${content}` };
 	}
@@ -72,10 +71,18 @@ export function composeToolInstructions(existing: SectionOverride | undefined, c
 	if (existing.action === 'remove' || typeof existing.action === 'function') {
 		return existing;
 	}
-	// String action (`append` | `prepend` | `replace`): fold our lines into the
-	// contributor's content so its instructions are preserved, not clobbered.
+	// Fold our lines into the contributor's content (preserve it, don't clobber),
+	// then pad relative to the foundation by where this action places the content:
+	// `append` sits after it (lead with a newline), `prepend` sits before it (trail
+	// with a newline), `replace` owns the section (no foundation adjacency, so no
+	// padding — and no leading newline even when the contributor's content is empty).
 	const base = existing.content ?? '';
-	return { action: existing.action, content: base ? `${base}\n${content}` : `\n${content}` };
+	const merged = base ? `${base}\n${content}` : content;
+	switch (existing.action) {
+		case 'append': return { action: 'append', content: `\n${merged}` };
+		case 'prepend': return { action: 'prepend', content: `${merged}\n` };
+		default: return { action: existing.action, content: merged };
+	}
 }
 
 /**
@@ -99,12 +106,16 @@ export function resolveToolInstructionsOverride(hasTool: (name: string) => boole
  * system prompt's `content`.
  *
  * A `replace`-mode contributor owns its whole prompt and so is skipped by the
- * registry's universal `tool_instructions` layer; calling this from
- * `resolveFullSystemPrompt` gives such a contributor the same gated guidance by
- * construction, mirroring how the extension's full-prompt models inline it. Returns
- * `content` unchanged when no line applies.
+ * registry's universal `tool_instructions` layer. When such a contributor is
+ * added, calling this from its `resolveFullSystemPrompt` re-includes the same
+ * gated guidance (separated by a blank line), mirroring how the extension's
+ * full-prompt models inline it. No `resolveFullSystemPrompt` contributor exists
+ * yet, so this currently has no production caller. Returns `content` unchanged
+ * when no line applies.
+ *
+ * @param lines defaults to the registered {@link TOOL_INSTRUCTION_LINES}.
  */
-export function appendUniversalToolInstructions(content: string, hasTool: (name: string) => boolean): string {
-	const extra = universalToolInstructions(hasTool);
+export function appendUniversalToolInstructions(content: string, hasTool: (name: string) => boolean, lines: readonly ToolInstructionLine[] = TOOL_INSTRUCTION_LINES): string {
+	const extra = universalToolInstructions(hasTool, lines);
 	return extra === undefined ? content : `${content}\n\n${extra}`;
 }

--- a/src/vs/platform/agentHost/node/copilot/prompts/toolInstructions.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/toolInstructions.ts
@@ -1,0 +1,110 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { SectionOverride } from '@github/copilot-sdk';
+import { coalesce } from '../../../../../base/common/arrays.js';
+
+/**
+ * Model-agnostic guidance for the `tool_instructions` system-prompt section.
+ *
+ * This is the agent-host home for the Copilot extension's `toolUseInstructions`
+ * pattern (`defaultAgentInstructions.tsx` and the per-model agent prompts): a
+ * sequence of one-line nudges, each gated on the relevant tool being present in
+ * the session, composed into the single SDK `tool_instructions` section. The
+ * agent host sees client tools under their camelCase `toolReferenceName`, so a
+ * line's gate and any tool name it mentions use that form (NOT the extension's
+ * snake_case ids).
+ *
+ * To add guidance for a tool, write a {@link ToolInstructionLine} and add it to
+ * {@link TOOL_INSTRUCTION_LINES}. For example, a browser line would gate on
+ * `openBrowserPage` (plus an agentic browser tool) being present and return a
+ * sentence such as "Use the browser tools (...) for front-end tasks". No lines
+ * are registered yet — concrete tool hookups land in follow-up changes; this
+ * module is the wiring they plug into.
+ */
+
+/**
+ * A single gated tool-instructions line. Returns its content (a single
+ * sentence, no surrounding newlines) when the session exposes the tools it
+ * applies to, or `undefined` to contribute nothing. Mirrors one gated `<>…</>`
+ * fragment in the extension's `toolUseInstructions` block.
+ *
+ * @param hasTool predicate for whether a tool name is available in the session.
+ */
+type ToolInstructionLine = (hasTool: (name: string) => boolean) => string | undefined;
+
+/**
+ * The registered tool-instruction lines, in render order. Empty until concrete
+ * tool hookups are added — add new per-tool guidance here.
+ */
+const TOOL_INSTRUCTION_LINES: readonly ToolInstructionLine[] = [];
+
+/**
+ * Composes the applicable `lines` into a single block (one line each), or
+ * `undefined` when none apply to the session.
+ *
+ * @param lines defaults to the registered {@link TOOL_INSTRUCTION_LINES};
+ * overridable so the composition can be exercised in isolation.
+ */
+export function universalToolInstructions(hasTool: (name: string) => boolean, lines: readonly ToolInstructionLine[] = TOOL_INSTRUCTION_LINES): string | undefined {
+	const rendered = coalesce(lines.map(line => line(hasTool)));
+	return rendered.length > 0 ? rendered.join('\n') : undefined;
+}
+
+/**
+ * Folds universal tool-instructions `content` into a per-model contributor's
+ * `existing` `tool_instructions` override (if any), so a contributor's section
+ * is preserved rather than clobbered.
+ *
+ * @param existing the per-model contributor's `tool_instructions` override, if any.
+ */
+export function composeToolInstructions(existing: SectionOverride | undefined, content: string): SectionOverride {
+	// No per-model override: append our lines to the SDK foundation section. The
+	// leading newline keeps the appended text on its own line rather than running
+	// on from the foundation content.
+	if (!existing) {
+		return { action: 'append', content: `\n${content}` };
+	}
+	// A `remove` or transform-function override is a deliberate, non-composable
+	// choice by the contributor; preserve it untouched rather than fight it.
+	if (existing.action === 'remove' || typeof existing.action === 'function') {
+		return existing;
+	}
+	// String action (`append` | `prepend` | `replace`): fold our lines into the
+	// contributor's content so its instructions are preserved, not clobbered.
+	const base = existing.content ?? '';
+	return { action: existing.action, content: base ? `${base}\n${content}` : `\n${content}` };
+}
+
+/**
+ * Resolves the `tool_instructions` {@link SectionOverride} for a session,
+ * composing the universal lines with any override a per-model contributor
+ * already set for that section.
+ *
+ * Returns `undefined` when no universal lines apply — the caller then keeps the
+ * contributor's `existing` override (if any) untouched.
+ *
+ * @param existing the per-model contributor's `tool_instructions` override, if any.
+ * @param lines defaults to the registered {@link TOOL_INSTRUCTION_LINES}.
+ */
+export function resolveToolInstructionsOverride(hasTool: (name: string) => boolean, existing: SectionOverride | undefined, lines: readonly ToolInstructionLine[] = TOOL_INSTRUCTION_LINES): SectionOverride | undefined {
+	const content = universalToolInstructions(hasTool, lines);
+	return content === undefined ? undefined : composeToolInstructions(existing, content);
+}
+
+/**
+ * Appends the universal tool-instruction lines to a full (`replace`-mode)
+ * system prompt's `content`.
+ *
+ * A `replace`-mode contributor owns its whole prompt and so is skipped by the
+ * registry's universal `tool_instructions` layer; calling this from
+ * `resolveFullSystemPrompt` gives such a contributor the same gated guidance by
+ * construction, mirroring how the extension's full-prompt models inline it. Returns
+ * `content` unchanged when no line applies.
+ */
+export function appendUniversalToolInstructions(content: string, hasTool: (name: string) => boolean): string {
+	const extra = universalToolInstructions(hasTool);
+	return extra === undefined ? content : `${content}\n\n${extra}`;
+}

--- a/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
@@ -13,9 +13,16 @@ import { COPILOT_AGENT_HOST_SYSTEM_MESSAGE } from '../../node/copilot/prompts/sy
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import '../../node/copilot/prompts/allPrompts.js';
 
-/** Builds a prompt context backed by an in-memory bag of customization settings. */
-function context(settings: SchemaValues<typeof agentHostCustomizationConfigSchema.definition> = {}): IAgentHostPromptContext {
-	return { getSetting: key => settings[key] };
+/**
+ * Builds a prompt context backed by an in-memory bag of customization settings
+ * and an optional set of available tool names.
+ */
+function context(settings: SchemaValues<typeof agentHostCustomizationConfigSchema.definition> = {}, tools: readonly string[] = []): IAgentHostPromptContext {
+	const toolNames = new Set(tools);
+	return {
+		getSetting: key => settings[key],
+		hasTool: name => toolNames.has(name),
+	};
 }
 
 suite('AgentHostPromptRegistry', () => {
@@ -120,6 +127,46 @@ suite('AgentHostPromptRegistry', () => {
 			assert.strictEqual(resolveOpus(undefined), COPILOT_AGENT_HOST_SYSTEM_MESSAGE);
 			assert.strictEqual(resolveOpus(false), COPILOT_AGENT_HOST_SYSTEM_MESSAGE);
 			assert.strictEqual(resolveOpus(true).mode, 'customize');
+		});
+	});
+
+	suite('universal tool instructions wiring', () => {
+		// No tool-instruction lines are registered yet (concrete tool hookups land
+		// in follow-up changes), so the universal layer is currently a no-op. These
+		// guard the wiring; the composition/gating itself is covered in
+		// toolInstructions.test.ts.
+
+		test('is a no-op while no tool-instruction lines are registered', () => {
+			const registry = new AgentHostPromptRegistry();
+			assert.deepStrictEqual(registry.resolveSystemMessageConfig({ id: 'm' }, context({}, ['anyTool'])), COPILOT_AGENT_HOST_SYSTEM_MESSAGE);
+		});
+
+		test('leaves a per-model tool_instructions override untouched', () => {
+			const registry = new AgentHostPromptRegistry();
+			registry.registerPrompt(class {
+				static readonly familyPrefixes = ['claude'];
+				resolveSectionOverrides(): Partial<Record<SystemMessageSection, SectionOverride>> {
+					return { tool_instructions: { action: 'append', content: 'Always prefer ripgrep.' } };
+				}
+			});
+			assert.deepStrictEqual(
+				registry.resolveSystemMessageConfig({ id: 'claude-x' }, context({}, ['anyTool'])),
+				{ mode: 'customize', sections: { tool_instructions: { action: 'append', content: 'Always prefer ripgrep.' } } }
+			);
+		});
+
+		test('leaves a full replace prompt untouched', () => {
+			const registry = new AgentHostPromptRegistry();
+			registry.registerPrompt(class {
+				static readonly familyPrefixes = ['gpt-5'];
+				resolveFullSystemPrompt(): string {
+					return 'FULL PROMPT';
+				}
+			});
+			assert.deepStrictEqual(
+				registry.resolveSystemMessageConfig({ id: 'gpt-5-mini' }, context({}, ['anyTool'])),
+				{ mode: 'replace', content: 'FULL PROMPT' }
+			);
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
@@ -21,7 +21,7 @@ function context(settings: SchemaValues<typeof agentHostCustomizationConfigSchem
 	const toolNames = new Set(tools);
 	return {
 		getSetting: key => settings[key],
-		hasTool: name => toolNames.has(name),
+		hasClientTool: name => toolNames.has(name),
 	};
 }
 
@@ -152,20 +152,6 @@ suite('AgentHostPromptRegistry', () => {
 			assert.deepStrictEqual(
 				registry.resolveSystemMessageConfig({ id: 'claude-x' }, context({}, ['anyTool'])),
 				{ mode: 'customize', sections: { tool_instructions: { action: 'append', content: 'Always prefer ripgrep.' } } }
-			);
-		});
-
-		test('leaves a full replace prompt untouched', () => {
-			const registry = new AgentHostPromptRegistry();
-			registry.registerPrompt(class {
-				static readonly familyPrefixes = ['gpt-5'];
-				resolveFullSystemPrompt(): string {
-					return 'FULL PROMPT';
-				}
-			});
-			assert.deepStrictEqual(
-				registry.resolveSystemMessageConfig({ id: 'gpt-5-mini' }, context({}, ['anyTool'])),
-				{ mode: 'replace', content: 'FULL PROMPT' }
 			);
 		});
 	});

--- a/src/vs/platform/agentHost/test/node/toolInstructions.test.ts
+++ b/src/vs/platform/agentHost/test/node/toolInstructions.test.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import type { SectionOverride } from '@github/copilot-sdk';
+import { appendUniversalToolInstructions, composeToolInstructions, resolveToolInstructionsOverride, universalToolInstructions } from '../../node/copilot/prompts/toolInstructions.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+
+/** Builds a `hasTool` predicate backed by the given available tool names. */
+function hasTools(...names: string[]): (name: string) => boolean {
+	const set = new Set(names);
+	return name => set.has(name);
+}
+
+/** A gated tool-instruction line that renders `use <tool>` when `tool` is present. */
+function lineFor(tool: string): (hasTool: (name: string) => boolean) => string | undefined {
+	return hasTool => hasTool(tool) ? `use ${tool}` : undefined;
+}
+
+suite('toolInstructions', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('universalToolInstructions', () => {
+		test('joins applicable lines in order and drops gated-out ones', () => {
+			assert.strictEqual(universalToolInstructions(hasTools('a', 'c'), [lineFor('a'), lineFor('b'), lineFor('c')]), 'use a\nuse c');
+		});
+
+		test('returns undefined when no line applies (including the empty registry)', () => {
+			assert.strictEqual(universalToolInstructions(hasTools('x'), [lineFor('a')]), undefined);
+			assert.strictEqual(universalToolInstructions(hasTools('a')), undefined);
+		});
+	});
+
+	suite('composeToolInstructions', () => {
+		test('appends to the foundation section when there is no per-model override', () => {
+			assert.deepStrictEqual(composeToolInstructions(undefined, 'LINE'), { action: 'append', content: '\nLINE' });
+		});
+
+		test('folds into a per-model string override, preserving its action', () => {
+			assert.deepStrictEqual(composeToolInstructions({ action: 'append', content: 'A' }, 'LINE'), { action: 'append', content: 'A\nLINE' });
+			assert.deepStrictEqual(composeToolInstructions({ action: 'replace', content: 'OWN' }, 'LINE'), { action: 'replace', content: 'OWN\nLINE' });
+			assert.deepStrictEqual(composeToolInstructions({ action: 'prepend', content: 'P' }, 'LINE'), { action: 'prepend', content: 'P\nLINE' });
+		});
+
+		test('preserves a remove or transform-function override untouched', () => {
+			const transform = (s: string) => s;
+			assert.deepStrictEqual(composeToolInstructions({ action: 'remove' }, 'LINE'), { action: 'remove' });
+			assert.deepStrictEqual(composeToolInstructions({ action: transform }, 'LINE'), { action: transform });
+		});
+	});
+
+	suite('resolveToolInstructionsOverride', () => {
+		test('returns undefined (keep existing) when no line applies', () => {
+			const existing: SectionOverride = { action: 'append', content: 'A' };
+			assert.strictEqual(resolveToolInstructionsOverride(hasTools('x'), existing, [lineFor('a')]), undefined);
+		});
+
+		test('composes the rendered lines with the existing override', () => {
+			assert.deepStrictEqual(
+				resolveToolInstructionsOverride(hasTools('a'), { action: 'append', content: 'A' }, [lineFor('a')]),
+				{ action: 'append', content: 'A\nuse a' }
+			);
+		});
+	});
+
+	suite('appendUniversalToolInstructions', () => {
+		test('returns the prompt unchanged while no lines apply (empty registry)', () => {
+			assert.strictEqual(appendUniversalToolInstructions('FULL PROMPT', hasTools('a')), 'FULL PROMPT');
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/toolInstructions.test.ts
+++ b/src/vs/platform/agentHost/test/node/toolInstructions.test.ts
@@ -39,10 +39,19 @@ suite('toolInstructions', () => {
 			assert.deepStrictEqual(composeToolInstructions(undefined, 'LINE'), { action: 'append', content: '\nLINE' });
 		});
 
-		test('folds into a per-model string override, preserving its action', () => {
-			assert.deepStrictEqual(composeToolInstructions({ action: 'append', content: 'A' }, 'LINE'), { action: 'append', content: 'A\nLINE' });
-			assert.deepStrictEqual(composeToolInstructions({ action: 'replace', content: 'OWN' }, 'LINE'), { action: 'replace', content: 'OWN\nLINE' });
-			assert.deepStrictEqual(composeToolInstructions({ action: 'prepend', content: 'P' }, 'LINE'), { action: 'prepend', content: 'P\nLINE' });
+		test('folds into a per-model string override, preserving action and foundation spacing', () => {
+			const overrides: SectionOverride[] = [
+				{ action: 'append', content: 'A' },   // sits after foundation → leads with a newline
+				{ action: 'prepend', content: 'P' },  // sits before foundation → trails with a newline
+				{ action: 'replace', content: 'OWN' },// owns the section → no padding
+				{ action: 'replace', content: '' },   // empty replace → no spurious leading newline
+			];
+			assert.deepStrictEqual(overrides.map(o => composeToolInstructions(o, 'LINE')), [
+				{ action: 'append', content: '\nA\nLINE' },
+				{ action: 'prepend', content: 'P\nLINE\n' },
+				{ action: 'replace', content: 'OWN\nLINE' },
+				{ action: 'replace', content: 'LINE' },
+			]);
 		});
 
 		test('preserves a remove or transform-function override untouched', () => {
@@ -61,7 +70,7 @@ suite('toolInstructions', () => {
 		test('composes the rendered lines with the existing override', () => {
 			assert.deepStrictEqual(
 				resolveToolInstructionsOverride(hasTools('a'), { action: 'append', content: 'A' }, [lineFor('a')]),
-				{ action: 'append', content: 'A\nuse a' }
+				{ action: 'append', content: '\nA\nuse a' }
 			);
 		});
 	});
@@ -69,6 +78,10 @@ suite('toolInstructions', () => {
 	suite('appendUniversalToolInstructions', () => {
 		test('returns the prompt unchanged while no lines apply (empty registry)', () => {
 			assert.strictEqual(appendUniversalToolInstructions('FULL PROMPT', hasTools('a')), 'FULL PROMPT');
+		});
+
+		test('appends the rendered lines after a blank line when a line applies', () => {
+			assert.strictEqual(appendUniversalToolInstructions('FULL PROMPT', hasTools('a'), [lineFor('a')]), 'FULL PROMPT\n\nuse a');
 		});
 	});
 });


### PR DESCRIPTION
Adds the plumbing for model-agnostic `tool_instructions` system-prompt guidance in the Copilot CLI agent host, gated on whether a client tool is present in the session. No instruction lines are registered yet; concrete per-tool hookups land in follow-ups. Also logs the resolved system message at launch (summary at info, full config at trace).