### PR TITLE
sessions: make Sessions Part the high-priority layout view

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -60,6 +60,21 @@ The titlebar spans the full window width at the root level. Below it, a content 
 
 The **Sessions Part is the flexible ("remaining width") view** in the top-right row: it has `LayoutPriority.High` so it absorbs auxiliary bar / editor visibility changes and window resizes. The editor and auxiliary bar keep their user-set widths (`LayoutPriority.Normal` / `Low`). Making the editor the high-priority view caused its width to drift to its 300px minimum when the auxiliary bar was toggled across session switches.
 
+### 2.3 Layout Priority Model
+
+The workbench grid is built with `proportionalLayout: false` (see `createWorkbenchLayout()` in [browser/workbench.ts](src/vs/sessions/browser/workbench.ts)). In this mode the split views do **not** distribute resize deltas proportionally — instead each delta (window resize, or a part being shown/hidden) is absorbed by the highest-`LayoutPriority` view, while the others keep their established sizes. Each part therefore declares an explicit `priority`:
+
+| Part | `LayoutPriority` | Width behaviour |
+|------|------------------|-----------------|
+| Sidebar | `Low` | Fixed user-set width; never absorbs deltas. `minimumWidth` 170 (270 web), `maximumWidth` ∞, snaps closed below the minimum. |
+| Sessions Part | **`High`** | The single flexible view — grows/shrinks to absorb every horizontal delta. `minimumWidth` 300, `maximumWidth` ∞. |
+| Editor | `Normal` | Keeps its user-set width (`600` default); only resized via its own sash. |
+| Auxiliary Bar | `Low` | Keeps its user-set width (`340` default); only resized via its own sash. |
+
+**Invariant — exactly one `High` view in the horizontal chain.** A grid branch derives its priority from its children (`BranchNode.priority` in [base/browser/ui/grid/gridview.ts](src/vs/base/browser/ui/grid/gridview.ts)): `High` if any child is `High`, else `Low` if any child is `Low`, else `Normal`. The Top Right row contains a `Low` auxiliary bar, so unless the Sessions Part is `High` the whole Right Section derives to `Low`. The Content Section would then be `Sidebar (Low) | Right Section (Low)` — two equal-priority views — and with no high-priority absorber the resize delta spreads across **both**, growing the sidebar toward half the window. The Sessions Part being `High` is what lifts the Right Section to `High` so it (not the sidebar) absorbs the delta.
+
+> **Pitfall:** the `High` role must live on the Sessions Part, not the editor. It was previously on the editor, but that made the editor drift to its 300px minimum when the auxiliary bar was toggled across session switches. When moving the role, set the Sessions Part to `High` **and** the editor to `Normal` together — removing `High` from the editor without adding it to the Sessions Part leaves the chain with no `High` view and reintroduces the growing-sidebar bug.
+
 ---
 
 ## 3. Titlebar

--- a/src/vs/sessions/browser/parts/sessionsPart.ts
+++ b/src/vs/sessions/browser/parts/sessionsPart.ts
@@ -102,7 +102,7 @@ export class SessionsPart extends Part {
 		return this.layoutService.mainContainerDimension.height * 0.4;
 	}
 
-	readonly priority = LayoutPriority.Normal;
+	readonly priority = LayoutPriority.High;
 
 	constructor(
 		@IThemeService themeService: IThemeService,


### PR DESCRIPTION
## What

Sets the Agents window **Sessions Part** to `LayoutPriority.High` so it is the single flexible ("remaining width") view that absorbs horizontal layout deltas. Also documents the layout priority model in `LAYOUT.md`.

## Why

The workbench grid is built with `proportionalLayout: false`, so on window resize (or when a part is shown/hidden) the extra width is given to the highest-`LayoutPriority` view rather than spread proportionally. None of the views in the horizontal chain were `High`:

- Sidebar → `Low`
- Auxiliary Bar → `Low`
- Editor → `Normal`
- Sessions Part → `Normal`

A grid branch derives its priority from its children, so the `Low` auxiliary bar pulled the whole right section down to `Low`. That left `Sidebar (Low) | Right Section (Low)` with **no high-priority absorber**, so the resize delta spread across both and **the sessions list (sidebar) grew toward half the window** when widening the window.

### Regression

This was a half-applied change. A previous commit moved the flexible role off the editor (`High` → `Normal`) to stop the editor drifting to its 300px minimum when toggling the auxiliary bar, and updated `LAYOUT.md` to state the Sessions Part is the `High` view — but **never actually set the Sessions Part to `High`**. This PR completes that change.

## Notes for reviewers

- This does **not** reintroduce the editor-drift bug: the editor stays `Normal` (keeps its stable user-set width); the Sessions Part is the intended flex view that absorbs deltas.
- No tests assert on layout priority.
- `LAYOUT.md` now has a dedicated **§2.3 Layout Priority Model** with a per-part priority table and the "exactly one `High` view in the horizontal chain" invariant to prevent this regression recurring.

Validated with `npm run typecheck-client`, `npm run valid-layers-check`, and ESLint.