### PR TITLE
Adjust spacing and background colors in chat composite bar

### DIFF
--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -253,7 +253,7 @@
 	display: flex;
 	align-items: center;
 	height: 100%;
-	gap: 0;
+	gap: 4px;
 }
 
 .chat-composite-bar-toolbar {
@@ -296,6 +296,7 @@
 	line-height: 22px;
 	height: 26px;
 	border-radius: var(--vscode-cornerRadius-small);
+	background-color: color-mix(in srgb, var(--vscode-agentsPanel-foreground, var(--vscode-foreground)) 4%, transparent);
 	user-select: none;
 	flex-shrink: 0;
 	max-width: var(--chat-tab-max-width);
@@ -348,6 +349,7 @@
 
 .chat-composite-bar-tab:hover {
 	color: var(--chat-tab-active-foreground);
+	background-color: color-mix(in srgb, var(--vscode-agentsPanel-foreground, var(--vscode-foreground)) 8%, transparent);
 }
 
 /* Active state: background container instead of underline — mirrors auxiliarybar checked */
@@ -356,7 +358,7 @@
 }
 
 .session-view.is-active .chat-composite-bar-tab.active {
-	background-color: color-mix(in srgb, var(--vscode-agentsPanel-foreground, var(--vscode-foreground)) 5%, transparent);
+	background-color: color-mix(in srgb, var(--vscode-agentsPanel-foreground, var(--vscode-foreground)) 10%, transparent);
 }
 
 /* Reduce right padding when close button is present to avoid excess spacing */


### PR DESCRIPTION
Enhance the visual appearance of the chat composite bar by adjusting spacing and updating background colors for better clarity and usability. Test the changes by reviewing the chat composite bar in the application to ensure the new styles are applied correctly.

Addresses: https://github.com/microsoft/vscode/issues/322345
