### PR TITLE
Refactor style overrides and add editor border

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -9,7 +9,7 @@
  */
 
 /* Drop the 2px left border indicator on the active item. */
-.style-override-activityBar .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator:before {
+.style-override .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator:before {
 	border-left: none !important;
 }
 
@@ -21,7 +21,7 @@
  * (36px wide / 32px tall) layouts. The square side tracks the action height
  * (the limiting dimension), and `left` keeps it horizontally centered.
  */
-.style-override-activityBar .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator {
+.style-override .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator {
 	z-index: 0;
 	top: 0;
 	left: calc((var(--activity-bar-width, 48px) - var(--activity-bar-action-height, 48px) + 8px) / 2);
@@ -43,19 +43,19 @@
  * mirror the same tint there, scoped to `:not(.codicon)` so codicon items never
  * gain a filled background box.
  */
-.style-override-activityBar .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .action-label.codicon {
+.style-override .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .action-label.codicon {
 	color: var(--vscode-foreground) !important;
 }
 
-.style-override-activityBar .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item:not(.checked) .action-label.codicon {
+.style-override .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item:not(.checked) .action-label.codicon {
 	color: var(--vscode-descriptionForeground) !important;
 }
 
-.style-override-activityBar .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .action-label:not(.codicon) {
+.style-override .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .action-label:not(.codicon) {
 	background-color: var(--vscode-foreground) !important;
 }
 
-.style-override-activityBar .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item:not(.checked) .action-label:not(.codicon) {
+.style-override .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item:not(.checked) .action-label:not(.codicon) {
 	background-color: var(--vscode-descriptionForeground) !important;
 }
 
@@ -71,7 +71,7 @@
  * for the drop-line indicators) and on the checked item (which already shows the
  * active box).
  */
-.style-override-activityBar .activitybar > .content:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) :not(.monaco-menu) > .monaco-action-bar .action-item:not(.checked):hover::before {
+.style-override .activitybar > .content:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) :not(.monaco-menu) > .monaco-action-bar .action-item:not(.checked):hover::before {
 	content: "";
 	display: block;
 	position: absolute;

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/commandCenter.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/commandCenter.css
@@ -13,7 +13,7 @@
  * rest and only reveal the command-center active background/border on hover,
  * instead of carrying a solid fill the whole time.
  *
- * All rules are gated behind the `.style-override-commandCenter` class, which
+ * All rules are gated behind the `.style-override` class, which
  * the StyleOverridesContribution toggles onto the workbench container(s) when
  * the `workbench.experimental.modernUI` (Modern UI Update) setting is enabled.
  */
@@ -23,7 +23,7 @@
  * transparent at rest; the base stylesheet's `:hover` rule (titlebarpart.css)
  * still reveals the active background/border on hover.
  */
-.style-override-commandCenter.monaco-workbench .part.titlebar > .titlebar-container > .titlebar-center > .window-title > .command-center .action-item.command-center-center {
+.style-override.monaco-workbench .part.titlebar > .titlebar-container > .titlebar-center > .window-title > .command-center .action-item.command-center-center {
 	background-color: transparent !important;
 }
 
@@ -33,8 +33,8 @@
  * `:hover` rules already reveal the active background, and the connected
  * `session-mode` pill keeps its active fill (excluded below).
  */
-.style-override-commandCenter .agent-status-pill:not(.session-mode),
-.style-override-commandCenter .agent-status-pill .agent-status-input-area {
+.style-override .agent-status-pill:not(.session-mode),
+.style-override .agent-status-pill .agent-status-input-area {
 	background-color: transparent !important;
 }
 
@@ -45,7 +45,7 @@
  * rule still reveals the active background, and the `filtered` state keeps its
  * own active fill (excluded below).
  */
-.style-override-commandCenter .agent-status-badge-section:not(.filtered),
-.style-override-commandCenter .agent-status-command-center-toolbar {
+.style-override .agent-status-badge-section:not(.filtered),
+.style-override .agent-status-command-center-toolbar {
 	background-color: transparent !important;
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/editorBorder.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/editorBorder.css
@@ -23,8 +23,8 @@
  * Without that class these rules never apply.
  */
 
-.style-override .part.editor:not(.modal-editor-part) {
-	border: 1px solid var(--vscode-editorGroup-border, color-mix(in srgb, var(--vscode-foreground) 12%, transparent));
+.style-override .monaco-grid-view .part.editor:not(.modal-editor-part) {
+	border: var(--vscode-strokeThickness) solid var(--vscode-editorGroup-border, color-mix(in srgb, var(--vscode-foreground) 12%, transparent));
 	border-radius: var(--vscode-cornerRadius-medium, 6px);
 	box-sizing: border-box;
 	overflow: hidden;

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/editorBorder.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/editorBorder.css
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*
+ * Style-override module: "Editor Border".
+ *
+ * Frames the editor area as a distinct card by drawing a subtle 1px border with
+ * rounded corners around the whole editor part (tabs, breadcrumbs and editor
+ * body). This separates the editor from the surrounding chrome (side bar,
+ * panel, auxiliary bar) and mirrors the card-like editor treatment used in the
+ * Agents window (src/vs/sessions/browser/media/style.css).
+ *
+ * The border is drawn with `box-sizing: border-box` so it sits inside the area
+ * the grid already allocates to the editor part — no margin is added, avoiding a
+ * relayout. `overflow: hidden` clips the editor content to the rounded corners.
+ * The floating editor window part (`.modal-editor-part`) is excluded.
+ *
+ * All rules are gated behind the `.style-override` class, which the
+ * StyleOverridesContribution toggles onto the workbench container(s) when the
+ * `workbench.experimental.modernUI` (Modern UI Update) setting is enabled.
+ * Without that class these rules never apply.
+ */
+
+.style-override .part.editor:not(.modal-editor-part) {
+	border: 1px solid var(--vscode-editorGroup-border, color-mix(in srgb, var(--vscode-foreground) 12%, transparent));
+	border-radius: var(--vscode-cornerRadius-medium, 6px);
+	box-sizing: border-box;
+	overflow: hidden;
+}
+
+/*
+ * The editor part paints a separator shadow on its leading edge (via the
+ * `::after` overlay) to set itself apart from the side bar. With the explicit
+ * border above that shadow is redundant and would double up, so suppress it.
+ */
+.style-override .part.editor:not(.modal-editor-part)::after {
+	box-shadow: none;
+}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
@@ -23,7 +23,7 @@
  * across the large surface area that already consumes them. Headings, section
  * titles / tabs and badges are then mapped onto their canonical surfaces.
  *
- * All rules are gated behind the `.style-override-fontRamp` class, which the
+ * All rules are gated behind the `.style-override` class, which the
  * StyleOverridesContribution toggles onto the workbench container(s) when the
  * `workbench.experimental.modernUI` (Modern UI Update) setting is enabled. Without
  * that class these rules never apply.
@@ -36,14 +36,14 @@
  * the workbench from a single place. The tiers map as: bodyFontSize = Body 1
  * (13px), small = Label 1 (12px), xSmall = Body 2 / Label 2 (11px).
  */
-.style-override-fontRamp {
+.style-override {
 	--vscode-bodyFontSize: 13px;
 	--vscode-bodyFontSize-small: 12px;
 	--vscode-bodyFontSize-xSmall: 11px;
 }
 
 /* Anchor the workbench base font on Body 1 so inheriting surfaces follow the ramp. */
-.style-override-fontRamp.monaco-workbench {
+.style-override.monaco-workbench {
 	font-size: var(--vscode-bodyFontSize);
 }
 
@@ -52,14 +52,14 @@
  * ========================================================================== */
 
 /* Heading 1 (26px) — welcome / getting started screen title. */
-.style-override-fontRamp.monaco-workbench .part.editor > .content .gettingStartedContainer h1 {
+.style-override.monaco-workbench .part.editor > .content .gettingStartedContainer h1 {
 	font-size: 26px;
 	font-weight: 600;
 }
 
 /* Heading 2 (18px) — welcome subtitle and secondary screen titles. */
-.style-override-fontRamp.monaco-workbench .part.editor > .content .gettingStartedContainer .subtitle,
-.style-override-fontRamp.monaco-workbench .part.editor > .content .gettingStartedContainer h2 {
+.style-override.monaco-workbench .part.editor > .content .gettingStartedContainer .subtitle,
+.style-override.monaco-workbench .part.editor > .content .gettingStartedContainer h2 {
 	font-size: 18px;
 	font-weight: 600;
 }
@@ -69,13 +69,13 @@
  * ========================================================================== */
 
 /* View pane (sidebar / panel section) header titles — section title, Strong. */
-.style-override-fontRamp .monaco-pane-view .pane > .pane-header .title {
+.style-override .monaco-pane-view .pane > .pane-header .title {
 	font-size: var(--vscode-bodyFontSize-small);
 	font-weight: 600;
 }
 
 /* Part (sidebar / auxiliary bar / panel) title labels — section title, Strong. */
-.style-override-fontRamp.monaco-workbench .part > .title > .title-label h2 {
+.style-override.monaco-workbench .part > .title > .title-label h2 {
 	font-size: var(--vscode-bodyFontSize-small);
 	font-weight: 600;
 }
@@ -85,12 +85,12 @@
  * like the part title-labels so it matches the primary side bar section header
  * instead of looking like a lighter composite tab.
  */
-.style-override-fontRamp.monaco-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
+.style-override.monaco-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
 	font-weight: 600;
 }
 
 /* Editor tab labels. */
-.style-override-fontRamp.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab .tab-label {
+.style-override.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab .tab-label {
 	font-size: var(--vscode-bodyFontSize-small);
 }
 
@@ -98,8 +98,8 @@
  * Label 3 (10px) — badges and counters.
  * ========================================================================== */
 
-.style-override-fontRamp .monaco-count-badge,
-.style-override-fontRamp .monaco-action-bar .badge .badge-content {
+.style-override .monaco-count-badge,
+.style-override .monaco-action-bar .badge .badge-content {
 	font-size: 10px;
 }
 
@@ -107,13 +107,13 @@
  * Casing — replace ALL-CAPS labels with capitalized (title-case) text. The
  * underlying strings are already properly cased, so these surfaces only need
  * their `text-transform: uppercase` swapped for `capitalize`. The extra
- * `.style-override-fontRamp` ancestor raises specificity over the base rules.
+ * `.style-override` ancestor raises specificity over the base rules.
  * ========================================================================== */
 
 /* View pane (sidebar / panel section) header titles. */
-.style-override-fontRamp .monaco-pane-view .pane > .pane-header > .title,
+.style-override .monaco-pane-view .pane > .pane-header > .title,
 /* Part titles (sidebar, auxiliary bar, panel) — but never editor filenames. */
-.style-override-fontRamp.monaco-workbench .part:not(.editor) > .title > .title-label h2,
+.style-override.monaco-workbench .part:not(.editor) > .title > .title-label h2,
 /*
  * Panel / composite bar action-item labels. The font-size must land on the
  * `.action-label` (the `<a>`), not the `.action-item` (the `<li>`): the base
@@ -121,17 +121,17 @@
  * directly on the label, and a direct value always beats one inherited from the
  * parent item, so targeting the item alone leaves the visible text at 11px.
  */
-.style-override-fontRamp.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label,
-.style-override-fontRamp.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label,
+.style-override.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label,
+.style-override.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label,
 /* Notifications center header. */
-.style-override-fontRamp.monaco-workbench > .notifications-center > .notifications-center-header > .notifications-center-header-title,
+.style-override.monaco-workbench > .notifications-center > .notifications-center-header > .notifications-center-header-title,
 /* Debug call-stack session state labels. */
-.style-override-fontRamp .debug-pane .debug-call-stack .session > .state.label,
+.style-override .debug-pane .debug-call-stack .session > .state.label,
 /* Settings editor tab labels and section headers. */
-.style-override-fontRamp .settings-tabs-widget > .monaco-action-bar .action-item .action-label,
-.style-override-fontRamp .monaco-editor .settings-header-widget .title-container .title,
+.style-override .settings-tabs-widget > .monaco-action-bar .action-item .action-label,
+.style-override .monaco-editor .settings-header-widget .title-container .title,
 /* Agent sessions list header ("SESSIONS"). */
-.style-override-fontRamp .chat-viewpane.has-sessions-control .agent-sessions-container .agent-sessions-title-container {
+.style-override .chat-viewpane.has-sessions-control .agent-sessions-container .agent-sessions-title-container {
 	text-transform: capitalize;
 	font-size: var(--vscode-bodyFontSize-small);
 }
@@ -143,12 +143,12 @@
  * tab. The base rules (auxiliaryBarPart.css) paint the indicator with
  * `!important` from a `.part.auxiliarybar` selector, so the override must mirror
  * those exact selectors (including the `:not(:focus)` / `.clicked:focus` states)
- * and rely on the extra `.style-override-fontRamp` class to win on specificity.
+ * and rely on the extra `.style-override` class to win on specificity.
  */
-.style-override-fontRamp.monaco-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked:not(:focus) .active-item-indicator:before,
-.style-override-fontRamp.monaco-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked.clicked:focus .active-item-indicator:before,
-.style-override-fontRamp.monaco-workbench .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked:not(:focus) .active-item-indicator:before,
-.style-override-fontRamp.monaco-workbench .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked.clicked:focus .active-item-indicator:before {
+.style-override.monaco-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked:not(:focus) .active-item-indicator:before,
+.style-override.monaco-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked.clicked:focus .active-item-indicator:before,
+.style-override.monaco-workbench .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked:not(:focus) .active-item-indicator:before,
+.style-override.monaco-workbench .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked.clicked:focus .active-item-indicator:before {
 	border-top-color: transparent !important;
 	border-bottom-color: transparent !important;
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/keyboardFocusOnly.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/keyboardFocusOnly.css
@@ -13,7 +13,7 @@
  * outlines on `:focus:not(:focus-visible)` therefore removes mouse-click focus
  * rings and leaves keyboard focus rings intact.
  *
- * All rules are gated behind the `.style-override-keyboardFocusOnly` class, which
+ * All rules are gated behind the `.style-override` class, which
  * the StyleOverridesContribution toggles onto the workbench container(s) when the
  * `workbench.experimental.modernUI` (Modern UI Update) setting is enabled.
  *
@@ -27,9 +27,9 @@
  * `:focus` but not `:focus-visible`, so drop the row ring in that case. Keyboard
  * focus (`:focus-visible`) keeps it.
  */
-.style-override-keyboardFocusOnly .part.sidebar .monaco-list:focus:not(:focus-visible) .monaco-list-row.focused,
-.style-override-keyboardFocusOnly .part.panel .monaco-list:focus:not(:focus-visible) .monaco-list-row.focused,
-.style-override-keyboardFocusOnly .part.auxiliarybar .monaco-list:focus:not(:focus-visible) .monaco-list-row.focused {
+.style-override .part.sidebar .monaco-list:focus:not(:focus-visible) .monaco-list-row.focused,
+.style-override .part.panel .monaco-list:focus:not(:focus-visible) .monaco-list-row.focused,
+.style-override .part.auxiliarybar .monaco-list:focus:not(:focus-visible) .monaco-list-row.focused {
 	outline: 0 !important;
 }
 
@@ -40,13 +40,13 @@
  * keyboard focus. The part element is listed explicitly because a descendant
  * combinator would not match the part itself.
  */
-.style-override-keyboardFocusOnly .part.sidebar:focus:not(:focus-visible),
-.style-override-keyboardFocusOnly .part.sidebar :focus:not(:focus-visible),
-.style-override-keyboardFocusOnly .part.panel:focus:not(:focus-visible),
-.style-override-keyboardFocusOnly .part.panel :focus:not(:focus-visible),
-.style-override-keyboardFocusOnly .part.auxiliarybar:focus:not(:focus-visible),
-.style-override-keyboardFocusOnly .part.auxiliarybar :focus:not(:focus-visible),
-.style-override-keyboardFocusOnly .part.statusbar:focus:not(:focus-visible),
-.style-override-keyboardFocusOnly .part.statusbar :focus:not(:focus-visible) {
+.style-override .part.sidebar:focus:not(:focus-visible),
+.style-override .part.sidebar :focus:not(:focus-visible),
+.style-override .part.panel:focus:not(:focus-visible),
+.style-override .part.panel :focus:not(:focus-visible),
+.style-override .part.auxiliarybar:focus:not(:focus-visible),
+.style-override .part.auxiliarybar :focus:not(:focus-visible),
+.style-override .part.statusbar:focus:not(:focus-visible),
+.style-override .part.statusbar :focus:not(:focus-visible) {
 	outline-color: transparent !important;
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -9,7 +9,7 @@
  * Adjusts the internal padding of common workbench surfaces to give content
  * more breathing room.
  *
- * All rules are gated behind the `.style-override-padding` class, which the
+ * All rules are gated behind the `.style-override` class, which the
  * StyleOverridesContribution toggles onto the workbench container(s) when the
  * `workbench.experimental.modernUI` (Modern UI Update) setting is enabled.
  * Without that class these rules never apply.
@@ -32,20 +32,24 @@
  */
 
 /* Header: inset the section title / actions to line up with the rows below. */
-.style-override-padding .monaco-pane-view .pane:not(:has(> .pane-body.chat-viewpane)) > .pane-header {
+.style-override .monaco-pane-view .pane:not(:has(> .pane-body.chat-viewpane)) > .pane-header {
 	padding-left: var(--vscode-spacing-size80, 8px);
 	padding-right: var(--vscode-spacing-size80, 8px);
 }
 
 /* Body: inset each row box, leaving the scrollbar pinned to the pane edge. */
-.style-override-padding .monaco-pane-view .pane-body:not(.chat-viewpane) .monaco-list-row {
+.style-override .monaco-pane-view .pane-body:not(.chat-viewpane) .monaco-list-row {
 	left: var(--vscode-spacing-size80, 8px);
 	right: var(--vscode-spacing-size80, 8px);
 	width: auto;
 }
 
 /* Tighten the part title bar gutters: flush-left, small right inset. */
-.style-override-padding.monaco-workbench .part > .title {
+.style-override.monaco-workbench .part > .title {
 	padding-left: var(--vscode-spacing-size40, 4px);
-	padding-right: var(--vscode-spacing-size80, 8px);
+	padding-right: var(--vscode-spacing-size40, 4px);
+}
+
+.style-override.monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions {
+	padding: 0 4px;
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/paneHeaders.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/paneHeaders.css
@@ -15,7 +15,7 @@
  * inline styles by the PaneView (src/vs/base/browser/ui/splitview/paneview.ts),
  * so the resets below must use `!important` to win over those inline values.
  *
- * All rules are gated behind the `.style-override-paneHeaders` class, which the
+ * All rules are gated behind the `.style-override` class, which the
  * StyleOverridesContribution toggles onto the workbench container(s) when the
  * `workbench.experimental.modernUI` (Modern UI Update) setting is enabled.
  * Without that class these rules never apply.
@@ -25,8 +25,8 @@
  * Remove the full-width separator lines / borders (set inline by the PaneView)
  * so we can redraw them inset below.
  */
-.style-override-paneHeaders .monaco-pane-view .pane > .pane-header,
-.style-override-paneHeaders .monaco-pane-view .pane {
+.style-override .monaco-pane-view .pane > .pane-header,
+.style-override .monaco-pane-view .pane {
 	border: none !important;
 }
 
@@ -36,7 +36,7 @@
  * header border color the PaneView would, falling back across sidebar / panel
  * tokens so it is visible in both locations.
  */
-.style-override-paneHeaders .monaco-pane-view .pane > .pane-header::before {
+.style-override .monaco-pane-view .pane > .pane-header::before {
 	content: "";
 	position: absolute;
 	top: 0;
@@ -48,13 +48,13 @@
 }
 
 /* The first section in a pane has no separator above it. */
-.style-override-paneHeaders .monaco-pane-view .split-view-view:first-of-type > .pane > .pane-header::before {
+.style-override .monaco-pane-view .split-view-view:first-of-type > .pane > .pane-header::before {
 	display: none;
 }
 
-.style-override-paneHeaders .monaco-pane-view .pane,
-.style-override-paneHeaders.floating-panels .part.sidebar,
-.style-override-paneHeaders.floating-panels .part.auxiliarybar {
+.style-override .monaco-pane-view .pane,
+.style-override.floating-panels .part.sidebar,
+.style-override.floating-panels .part.auxiliarybar {
 	background-color: var(--vscode-sideBar-background, var(--vscode-panel-background)) !important;
 }
 
@@ -62,7 +62,7 @@
  * reads as part of the panel / side bar body rather than a tinted strip. The
  * inline header background from the PaneView is overridden here; the hover tint
  * below still wins via its higher specificity. */
-.style-override-paneHeaders .monaco-pane-view .pane > .pane-header {
+.style-override .monaco-pane-view .pane > .pane-header {
 	border-radius: var(--vscode-cornerRadius-medium);
 	background-color: var(--vscode-sideBar-background, var(--vscode-panel-background)) !important;
 }
@@ -75,12 +75,12 @@
  * StyleOverridesContribution triggers a relayout when this setting changes so
  * the new reservation is picked up immediately.
  */
-.style-override-paneHeaders .monaco-pane-view {
+.style-override .monaco-pane-view {
 	--pane-header-size: 28px;
 }
 
 /* Tint the header background on hover (overrides the inline header background). */
-.style-override-paneHeaders .monaco-pane-view .pane > .pane-header:hover {
+.style-override .monaco-pane-view .pane > .pane-header:hover {
 	background-color: var(--vscode-list-hoverBackground) !important;
 }
 
@@ -89,7 +89,7 @@
  * outline comes from the global `.monaco-workbench [tabindex="0"]:focus` rule.
  * `:not(:focus-visible)` keeps the visible focus ring for keyboard users.
  */
-.style-override-paneHeaders .monaco-pane-view .pane > .pane-header:focus:not(:focus-visible) {
+.style-override .monaco-pane-view .pane > .pane-header:focus:not(:focus-visible) {
 	outline: none !important;
 }
 
@@ -98,6 +98,6 @@
  * stroke right on the 1px section separator so it looks clipped. Inset it a bit
  * more so the keyboard focus ring clears the separator.
  */
-.style-override-paneHeaders .monaco-pane-view .pane > .pane-header:focus {
+.style-override .monaco-pane-view .pane > .pane-header:focus {
 	outline-offset: -2px;
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
@@ -17,7 +17,7 @@
  *   - Controls (4px): all interactable UI controls (text inputs, selects,
  *     list/tree rows, ...).
  *
- * All rules are gated behind the `.style-override-roundedCorners` class, which
+ * All rules are gated behind the `.style-override` class, which
  * the StyleOverridesContribution toggles onto the workbench container(s) when
  * the `workbench.experimental.modernUI` (Modern UI Update) setting is enabled.
  * Without that class these rules never apply.
@@ -30,7 +30,7 @@
  * as: small = controls (4px), medium = inner containers (6px), large = outer /
  * floating overlays (8px).
  */
-.style-override-roundedCorners {
+.style-override {
 	--vscode-cornerRadius-xSmall: 4px;
 	--vscode-cornerRadius-small: 4px;
 	--vscode-cornerRadius-medium: 6px;
@@ -43,30 +43,30 @@
  * ========================================================================== */
 
 /* Text inputs and find inputs */
-.style-override-roundedCorners .monaco-inputbox {
+.style-override .monaco-inputbox {
 	border-radius: var(--vscode-cornerRadius-small) !important;
 }
 
-.style-override-roundedCorners .monaco-findInput,
-.style-override-roundedCorners .monaco-findInput .monaco-inputbox {
+.style-override .monaco-findInput,
+.style-override .monaco-findInput .monaco-inputbox {
 	border-radius: var(--vscode-cornerRadius-small) !important;
 }
 
 /* Select / dropdown controls */
-.style-override-roundedCorners .monaco-select-box,
-.style-override-roundedCorners .monaco-select-box-dropdown-container {
+.style-override .monaco-select-box,
+.style-override .monaco-select-box-dropdown-container {
 	border-radius: var(--vscode-cornerRadius-small) !important;
 }
 
 /* List / tree rows (including the notification center list rows) */
-.style-override-roundedCorners .monaco-list .monaco-list-row,
-.style-override-roundedCorners .notifications-list-container .monaco-list-row {
+.style-override .monaco-list .monaco-list-row,
+.style-override .notifications-list-container .monaco-list-row {
 	border-radius: var(--vscode-cornerRadius-small) !important;
 }
 
 /* Action bar labels / keybindings (toolbar icon buttons) */
-.style-override-roundedCorners .monaco-action-bar .action-label,
-.style-override-roundedCorners .monaco-action-bar .action-item .keybinding {
+.style-override .monaco-action-bar .action-label,
+.style-override .monaco-action-bar .action-item .keybinding {
 	border-radius: var(--vscode-cornerRadius-small) !important;
 }
 
@@ -78,36 +78,36 @@
  */
 
 /* All-corners segments */
-.style-override-roundedCorners .agent-status-pill,
-.style-override-roundedCorners .agent-status-badge,
-.style-override-roundedCorners .agent-status-badge-section:only-child,
-.style-override-roundedCorners .agent-status-esc-button,
-.style-override-roundedCorners .agent-status-enter-button {
+.style-override .agent-status-pill,
+.style-override .agent-status-badge,
+.style-override .agent-status-badge-section:only-child,
+.style-override .agent-status-esc-button,
+.style-override .agent-status-enter-button {
 	border-radius: var(--vscode-cornerRadius-small) !important;
 }
 
 /* Leading-edge segments (rounded left, flat right) */
-.style-override-roundedCorners .agent-status-pill .agent-status-input-area,
-.style-override-roundedCorners .agent-status-command-center-toolbar,
-.style-override-roundedCorners .agent-status-badge-section:first-child,
-.style-override-roundedCorners .agent-status-badge-section.sparkle .action-container {
+.style-override .agent-status-pill .agent-status-input-area,
+.style-override .agent-status-command-center-toolbar,
+.style-override .agent-status-badge-section:first-child,
+.style-override .agent-status-badge-section.sparkle .action-container {
 	border-radius: var(--vscode-cornerRadius-small) 0 0 var(--vscode-cornerRadius-small) !important;
 }
 
 /* Trailing-edge segments (flat left, rounded right) */
-.style-override-roundedCorners .agent-status-badge-section:last-child,
-.style-override-roundedCorners .agent-status-badge-section.sparkle:last-child .dropdown-action-container {
+.style-override .agent-status-badge-section:last-child,
+.style-override .agent-status-badge-section.sparkle:last-child .dropdown-action-container {
 	border-radius: 0 var(--vscode-cornerRadius-small) var(--vscode-cornerRadius-small) 0 !important;
 }
 
 /* Intentional flat seams where a segment butts up against its neighbour */
-.style-override-roundedCorners .agent-status-line-separator + .agent-status-input-area,
-.style-override-roundedCorners .agent-status-pill.compact-mode .agent-status-badge-section.sparkle .action-container {
+.style-override .agent-status-line-separator + .agent-status-input-area,
+.style-override .agent-status-pill.compact-mode .agent-status-badge-section.sparkle .action-container {
 	border-radius: 0 !important;
 }
 
 /* Scrollbar sliders */
-.style-override-roundedCorners .monaco-scrollable-element > .scrollbar > .slider {
+.style-override .monaco-scrollable-element > .scrollbar > .slider {
 	border-radius: var(--vscode-cornerRadius-small) !important;
 }
 
@@ -115,7 +115,7 @@
  * The editor's own scrollbars sit flush against the viewport edge (next to the
  * minimap); rounding their sliders looks odd, so keep those square.
  */
-.style-override-roundedCorners .monaco-editor .monaco-scrollable-element > .scrollbar > .slider {
+.style-override .monaco-editor .monaco-scrollable-element > .scrollbar > .slider {
 	border-radius: 0 !important;
 }
 
@@ -124,7 +124,7 @@
  * ========================================================================== */
 
 /* Editor sticky scroll container */
-.style-override-roundedCorners .monaco-editor .sticky-widget {
+.style-override .monaco-editor .sticky-widget {
 	border-radius: var(--vscode-cornerRadius-medium) !important;
 	overflow: hidden;
 }
@@ -134,7 +134,7 @@
  * (and the focused row draws an outline) on this element, so round it to the
  * inner tier to match.
  */
-.style-override-roundedCorners .settings-editor .settings-tree-container .setting-item-contents.settings-row-inner-container {
+.style-override .settings-editor .settings-tree-container .setting-item-contents.settings-row-inner-container {
 	border-radius: var(--vscode-cornerRadius-medium) !important;
 }
 
@@ -143,21 +143,21 @@
  * ========================================================================== */
 
 /* Quick input (command palette, quick open) */
-.style-override-roundedCorners .quick-input-widget {
+.style-override .quick-input-widget {
 	border-radius: var(--vscode-cornerRadius-large) !important;
 	overflow: hidden;
 }
 
 /* Editor / workbench hover, suggest and parameter hint widgets */
-.style-override-roundedCorners .monaco-hover,
-.style-override-roundedCorners .editor-widget.suggest-widget,
-.style-override-roundedCorners .monaco-editor .parameter-hints-widget {
+.style-override .monaco-hover,
+.style-override .editor-widget.suggest-widget,
+.style-override .monaco-editor .parameter-hints-widget {
 	border-radius: var(--vscode-cornerRadius-large) !important;
 	overflow: hidden;
 }
 
 /* Context menus and general menu surfaces */
-.style-override-roundedCorners .monaco-menu .monaco-action-bar.vertical {
+.style-override .monaco-menu .monaco-action-bar.vertical {
 	border-radius: var(--vscode-cornerRadius-large) !important;
 }
 
@@ -166,7 +166,7 @@
  * children with `overflow: hidden`, so rounding the container alone gives the
  * header its top corners and the list its bottom corners in one place.
  */
-.style-override-roundedCorners .notifications-center {
+.style-override .notifications-center {
 	border-radius: var(--vscode-cornerRadius-large) !important;
 }
 
@@ -178,32 +178,32 @@
  * radius on the outer wrapper leaves a gap at the corner where the smaller
  * inner radius shows through.
  */
-.style-override-roundedCorners .notifications-toasts .notifications-list-container,
-.style-override-roundedCorners .notifications-toasts .notification-toast-container > .notification-toast,
-.style-override-roundedCorners .notifications-toasts .notification-toast-container > .notification-toast .monaco-scrollable-element,
-.style-override-roundedCorners .notifications-toasts .notification-toast-container > .notification-toast .monaco-list-row {
+.style-override .notifications-toasts .notifications-list-container,
+.style-override .notifications-toasts .notification-toast-container > .notification-toast,
+.style-override .notifications-toasts .notification-toast-container > .notification-toast .monaco-scrollable-element,
+.style-override .notifications-toasts .notification-toast-container > .notification-toast .monaco-list-row {
 	border-radius: var(--vscode-cornerRadius-large) !important;
 }
 
 /* Modal dialogs */
-.style-override-roundedCorners .monaco-dialog-box {
+.style-override .monaco-dialog-box {
 	border-radius: var(--vscode-cornerRadius-large) !important;
 	overflow: hidden;
 }
 
 /* Editor find / replace widget */
-.style-override-roundedCorners .monaco-editor .find-widget {
+.style-override .monaco-editor .find-widget {
 	border-radius: var(--vscode-cornerRadius-large) !important;
 }
 
 /* Rename input widget */
-.style-override-roundedCorners .monaco-editor .rename-box {
+.style-override .monaco-editor .rename-box {
 	border-radius: var(--vscode-cornerRadius-large) !important;
 	overflow: hidden;
 }
 
 /* Color picker widget */
-.style-override-roundedCorners .colorpicker-widget {
+.style-override .colorpicker-widget {
 	border-radius: var(--vscode-cornerRadius-large) !important;
 	overflow: hidden;
 }
@@ -211,11 +211,11 @@
 /* =============================================================================
  * Sashes — round the hover/drag affordance ends (mirrors the Agents window).
  * ========================================================================== */
-.style-override-roundedCorners .monaco-sash:before {
+.style-override .monaco-sash:before {
 	border-radius: calc(var(--vscode-sash-hover-size) / 2);
 }
 
-.style-override-roundedCorners .monaco-sash:not(.disabled) > .orthogonal-drag-handle {
+.style-override .monaco-sash:not(.disabled) > .orthogonal-drag-handle {
 	border-radius: var(--vscode-sash-size);
 }
 

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/scrollShadows.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/scrollShadows.css
@@ -20,7 +20,7 @@
  * variable, defaulted below and refined per part. The overlays are
  * non-interactive and sit above the scrolling content.
  *
- * All rules are gated behind the `.style-override-scrollShadows` class, which
+ * All rules are gated behind the `.style-override` class, which
  * the StyleOverridesContribution toggles onto the workbench container(s) when
  * the `workbench.experimental.modernUI` (Modern UI Update) setting is enabled.
  */
@@ -29,31 +29,31 @@
  * Surface colour the edges fade into. Default to the editor background, then
  * refine per part so lists in the panel / side bar fade into their own surface.
  */
-.style-override-scrollShadows {
+.style-override {
 	--scroll-shadow-surface: var(--vscode-editor-background);
 }
 
-.style-override-scrollShadows .part.panel {
+.style-override .part.panel {
 	--scroll-shadow-surface: var(--vscode-panel-background);
 }
 
-.style-override-scrollShadows .part.sidebar {
+.style-override .part.sidebar {
 	--scroll-shadow-surface: var(--vscode-sideBar-background, var(--vscode-editor-background));
 }
 
-.style-override-scrollShadows .part.auxiliarybar {
+.style-override .part.auxiliarybar {
 	--scroll-shadow-surface: var(--vscode-sideBar-background, var(--vscode-editor-background));
 }
 
 /* =============================================================================
  * Lists and trees.
  * ========================================================================== */
-.style-override-scrollShadows .monaco-list {
+.style-override .monaco-list {
 	position: relative;
 }
 
-.style-override-scrollShadows .monaco-list > .monaco-scrollable-element::before,
-.style-override-scrollShadows .monaco-list > .monaco-scrollable-element::after {
+.style-override .monaco-list > .monaco-scrollable-element::before,
+.style-override .monaco-list > .monaco-scrollable-element::after {
 	content: "";
 	position: absolute;
 	left: 0;
@@ -69,26 +69,26 @@
  * stacking context and sit below it. Scope to the editor / panel parts so the
  * fade never leaks onto inline editors such as the chat input.
  * ========================================================================== */
-.style-override-scrollShadows .part.editor .monaco-editor .editor-scrollable::before,
-.style-override-scrollShadows .part.editor .monaco-editor .editor-scrollable::after {
+.style-override .part.editor .monaco-editor .editor-scrollable::before,
+.style-override .part.editor .monaco-editor .editor-scrollable::after {
 	content: "";
 	position: absolute;
 	left: 0;
 	right: 0;
-	height: 24px;
+	height: 8px;
 	pointer-events: none;
 	/* Below the scrollbar (z-index 11) so it is never obscured, above content. */
 	z-index: 10;
 }
 
-.style-override-scrollShadows .part.editor .monaco-editor .editor-scrollable::before,
-.style-override-scrollShadows .part.panel .monaco-editor .editor-scrollable::before {
+.style-override .part.editor .monaco-editor .editor-scrollable::before,
+.style-override .part.panel .monaco-editor .editor-scrollable::before {
 	top: 0;
 	background: linear-gradient(to bottom, var(--scroll-shadow-surface), transparent);
 }
 
-.style-override-scrollShadows .part.editor .monaco-editor .editor-scrollable::after,
-.style-override-scrollShadows .part.panel .monaco-editor .editor-scrollable::after {
+.style-override .part.editor .monaco-editor .editor-scrollable::after,
+.style-override .part.panel .monaco-editor .editor-scrollable::after {
 	bottom: 0;
 	background: linear-gradient(to top, var(--scroll-shadow-surface), transparent);
 }
@@ -99,7 +99,7 @@
  * inputs, not as scrolling editor surfaces. Suppress the edge fades there so the
  * input keeps a flat background and never shows the editor-coloured rectangle.
  * ========================================================================== */
-.style-override-scrollShadows .suggest-input-container .monaco-editor .editor-scrollable::before,
-.style-override-scrollShadows .suggest-input-container .monaco-editor .editor-scrollable::after {
+.style-override .suggest-input-container .monaco-editor .editor-scrollable::before,
+.style-override .suggest-input-container .monaco-editor .editor-scrollable::after {
 	display: none;
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/statusBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/statusBar.css
@@ -13,7 +13,7 @@
  * editor foreground so it stays readable across all themes. Items that set
  * their own color (e.g. prominent, error or warning entries) keep theirs.
  */
-.style-override-statusBar .part.statusbar {
+.style-override .part.statusbar {
 	color: var(--vscode-foreground) !important;
 }
 
@@ -26,7 +26,7 @@
  * color — `--vscode-foreground` for standard items, or the kind color for
  * warning/error items — so only the background changes on hover.
  */
-.style-override-statusBar .part.statusbar > .items-container > .statusbar-item > a:hover:not(.disabled) {
+.style-override .part.statusbar > .items-container > .statusbar-item > a:hover:not(.disabled) {
 	color: inherit !important;
 }
 
@@ -43,19 +43,19 @@
  * the left (square left, round right), `.compact-right` joins on the right (square
  * right, round left), and a middle item stays square on both sides.
  */
-.style-override-statusBar .part.statusbar > .items-container > .statusbar-item,
-.style-override-statusBar .part.statusbar > .items-container > .statusbar-item > .statusbar-item-label {
+.style-override .part.statusbar > .items-container > .statusbar-item,
+.style-override .part.statusbar > .items-container > .statusbar-item > .statusbar-item-label {
 	border-radius: var(--vscode-cornerRadius-small, 4px);
 }
 
-.style-override-statusBar .part.statusbar > .items-container > .statusbar-item.compact-left,
-.style-override-statusBar .part.statusbar > .items-container > .statusbar-item.compact-left > .statusbar-item-label {
+.style-override .part.statusbar > .items-container > .statusbar-item.compact-left,
+.style-override .part.statusbar > .items-container > .statusbar-item.compact-left > .statusbar-item-label {
 	border-top-left-radius: 0;
 	border-bottom-left-radius: 0;
 }
 
-.style-override-statusBar .part.statusbar > .items-container > .statusbar-item.compact-right,
-.style-override-statusBar .part.statusbar > .items-container > .statusbar-item.compact-right > .statusbar-item-label {
+.style-override .part.statusbar > .items-container > .statusbar-item.compact-right,
+.style-override .part.statusbar > .items-container > .statusbar-item.compact-right > .statusbar-item-label {
 	border-top-right-radius: 0;
 	border-bottom-right-radius: 0;
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -9,19 +9,19 @@
  * Makes the editor tabs in the regular workbench look like the Agents window
  * tabs: transparent, rounded, borderless pills with a subtle active highlight.
  *
- * All rules are gated behind the `.style-override-tabs` class, which the
+ * All rules are gated behind the `.style-override` class, which the
  * StyleOverridesContribution toggles onto the workbench container(s) when the
  * `workbench.experimental.modernUI` (Modern UI Update) setting is enabled. Mirrors
  * the Agents window styling defined in
  * src/vs/sessions/browser/media/style.css.
  */
 
-.style-override-tabs .part.editor .title.tabs {
+.style-override .part.editor .title.tabs {
 	background-color: transparent !important;
 	--editor-group-tab-height: 26px !important;
 }
 
-.style-override-tabs .part.editor .tabs-container > .tab {
+.style-override .part.editor .tabs-container > .tab {
 	background-color: color-mix(in srgb, var(--vscode-foreground) 5%, transparent) !important;
 	border-right: none !important;
 	border-radius: var(--vscode-cornerRadius-small);
@@ -34,22 +34,22 @@
 }
 
 /* Center tabs vertically and strip the bottom border so the pills float. */
-.style-override-tabs .part.editor .tabs-and-actions-container {
+.style-override .part.editor .tabs-and-actions-container {
 	--tabs-border-bottom-color: transparent !important;
 	align-items: center;
-	padding: 4px 0;
+	padding: 4px 0 4px 4px;
 }
 
-.style-override-tabs .part.editor .tabs-container > .tab.active {
+.style-override .part.editor .tabs-container > .tab.active {
 	background-color: color-mix(in srgb, var(--vscode-foreground) 10%, transparent) !important;
 }
 
-.style-override-tabs.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-and-actions-container .tabs-container > .tab:not(.active):hover {
+.style-override.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-and-actions-container .tabs-container > .tab:not(.active):hover {
 	background-color: color-mix(in srgb, var(--vscode-foreground) 8%, transparent) !important;
 }
 
-.style-override-tabs .part.editor .tabs-container > .tab .tab-border-top-container,
-.style-override-tabs .part.editor .tabs-container > .tab .tab-border-bottom-container {
+.style-override .part.editor .tabs-container > .tab .tab-border-top-container,
+.style-override .part.editor .tabs-container > .tab .tab-border-bottom-container {
 	display: none !important;
 }
 
@@ -60,7 +60,7 @@
  * the editor tabs: normal case, 12px/600 type, a subtle background on the
  * active tab and no underline.
  */
-.style-override-tabs .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
+.style-override .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
 	text-transform: none !important;
 	padding: 0 8px;
 	border-radius: var(--vscode-cornerRadius-small);
@@ -72,24 +72,24 @@
  * does not reach the label (an explicit font-size on the element wins over the
  * inherited value), so the type must be set on the label itself.
  */
-.style-override-tabs .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
+.style-override .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
 	font-size: 12px;
 	font-weight: var(--vscode-agents-fontWeight-semiBold);
 	line-height: 22px; /* keep consistent with other 22px title/control heights */
 }
 
-.style-override-tabs .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked {
+.style-override .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked {
 	background-color: color-mix(in srgb, var(--vscode-foreground) 10%, transparent) !important;
 }
 
 /*
  * Drop the underline active indicator in favour of the pill background. The
  * default rules set the border with `!important`, so match their specificity
- * (with the extra `.style-override-tabs` class winning) for the checked and
+ * (with the extra `.style-override` class winning) for the checked and
  * focused states.
  */
-.style-override-tabs .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before,
-.style-override-tabs .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before {
+.style-override .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before,
+.style-override .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before {
 	border-top-color: transparent !important;
 	border-top-width: 0 !important;
 	border-bottom-color: transparent !important;
@@ -104,8 +104,8 @@
  * them the rounded-pill look: normal case, 12px/600 type, a subtle background
  * on the active tab and no underline indicator.
  */
-.style-override-tabs .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item,
-.style-override-tabs .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
+.style-override .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item,
+.style-override .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
 	text-transform: none !important;
 	padding: 0 8px;
 	border-radius: var(--vscode-cornerRadius-small);
@@ -115,15 +115,15 @@
  * The text lives in `.action-label`, which carries its own `font-size: 11px`
  * from the base action bar styles, so the type must be set on the label itself.
  */
-.style-override-tabs .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label,
-.style-override-tabs .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
+.style-override .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label,
+.style-override .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
 	font-size: 12px;
 	font-weight: var(--vscode-agents-fontWeight-semiBold);
 	line-height: 22px; /* keep consistent with other 22px title/control heights */
 }
 
-.style-override-tabs .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked,
-.style-override-tabs .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked {
+.style-override .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked,
+.style-override .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked {
 	background-color: color-mix(in srgb, var(--vscode-foreground) 10%, transparent) !important;
 }
 
@@ -131,20 +131,20 @@
  * Drop the underline active indicator in favour of the pill background. The
  * base rules (auxiliaryBarPart.css / paneCompositePart.css) paint the indicator
  * with `!important` from `.part.auxiliarybar` selectors, so match their
- * specificity (with the extra `.style-override-tabs` class winning) across the
+ * specificity (with the extra `.style-override` class winning) across the
  * `.title` and `.header-or-footer` checked and focused states.
  */
-.style-override-tabs .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before,
-.style-override-tabs .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before,
-.style-override-tabs .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before,
-.style-override-tabs .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before {
+.style-override .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before,
+.style-override .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before,
+.style-override .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before,
+.style-override .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before {
 	border-top-color: transparent !important;
 	border-top-width: 0 !important;
 	border-bottom-color: transparent !important;
 	border-bottom-width: 0 !important;
 }
 
-.style-override-tabs .part.editor > .content .editor-group-container > .title .tabs-container > .tab .tab-label a {
+.style-override .part.editor > .content .editor-group-container > .title .tabs-container > .tab .tab-label a {
 	font-size: 12px;
 	font-weight: var(--vscode-agents-fontWeight-semiBold);
 }
@@ -156,22 +156,22 @@
  * pill look as the editor and panel tabs: drop the underline, round the label
  * and show a subtle background on the active (checked) tab.
  */
-.style-override-tabs .settings-editor .settings-tabs-widget > .monaco-action-bar .action-item .action-label {
+.style-override .settings-editor .settings-tabs-widget > .monaco-action-bar .action-item .action-label {
 	border-radius: var(--vscode-cornerRadius-small) !important;
 	border-bottom: none !important;
 	font-weight: var(--vscode-agents-fontWeight-semiBold);
 	padding: 2px 8px !important;
 }
 
-.style-override-tabs .settings-editor .settings-tabs-widget > .monaco-action-bar .action-item .action-label.checked {
+.style-override .settings-editor .settings-tabs-widget > .monaco-action-bar .action-item .action-label.checked {
 	background-color: color-mix(in srgb, var(--vscode-foreground) 10%, transparent) !important;
 }
 
-.style-override-tabs .settings-editor .settings-tabs-widget > .monaco-action-bar .action-item .action-label.checked:not(:focus) {
+.style-override .settings-editor .settings-tabs-widget > .monaco-action-bar .action-item .action-label.checked:not(:focus) {
 	border-bottom-color: transparent !important;
 }
 
 /* Drop the underline beneath the settings header controls row. */
-.style-override-tabs .settings-editor > .settings-header > .settings-header-controls {
+.style-override .settings-editor > .settings-header > .settings-header-controls {
 	border-bottom: none !important;
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
+++ b/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
@@ -10,11 +10,12 @@ import { IWorkbenchLayoutService, LayoutSettings } from '../../../services/layou
 import { Extensions as WorkbenchExtensions, IWorkbenchContribution, IWorkbenchContributionsRegistry } from '../../../common/contributions.js';
 import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
 
-// Bundle the CSS for every style-override module. Each file gates all of its
-// rules behind a `.style-override-<id>` ancestor class, so the styles are inert
-// until the matching class is toggled onto the workbench container(s) below.
+// Bundle the CSS for every style-override module. Every file gates all of its
+// rules behind the single `.style-override` ancestor class, so the styles are
+// inert until that class is toggled onto the workbench container(s) below.
 import './media/activityBar.css';
 import './media/commandCenter.css';
+import './media/editorBorder.css';
 import './media/fontRamp.css';
 import './media/keyboardFocusOnly.css';
 import './media/padding.css';
@@ -35,14 +36,25 @@ interface IStyleOverrideModule {
 }
 
 /**
+ * The single class toggled onto the workbench container(s) when the Modern UI
+ * Update experiment is enabled. Every style-override module's CSS is gated
+ * behind this class (`.style-override ...`), so all modules are applied together
+ * as a group.
+ */
+const STYLE_OVERRIDE_CLASS = 'style-override';
+
+/**
  * The fixed catalog of built-in style-override modules. The CSS for each module
- * ships with the product (imported above) and is gated behind the
- * `.style-override-<id>` class. All modules are enabled together as part of the
- * Modern UI Update experiment (`LayoutSettings.MODERN_UI`).
+ * ships with the product (imported above) and is gated behind the shared
+ * `.style-override` class. All modules are enabled together as part of the
+ * Modern UI Update experiment (`LayoutSettings.MODERN_UI`). This catalog is
+ * retained to track per-module metadata (e.g. whether a module is
+ * layout-affecting).
  */
 const STYLE_OVERRIDE_MODULES: readonly IStyleOverrideModule[] = [
 	{ id: 'activityBar' },
 	{ id: 'commandCenter' },
+	{ id: 'editorBorder' },
 	{ id: 'fontRamp' },
 	{ id: 'keyboardFocusOnly' },
 	{ id: 'padding' },
@@ -52,10 +64,6 @@ const STYLE_OVERRIDE_MODULES: readonly IStyleOverrideModule[] = [
 	{ id: 'statusBar' },
 	{ id: 'tabs' }
 ];
-
-function classNameFor(moduleId: string): string {
-	return `style-override-${moduleId}`;
-}
 
 /**
  * A contribution that toggles the built-in CSS style-override modules on or off
@@ -67,7 +75,6 @@ export class StyleOverridesContribution extends Disposable implements IWorkbench
 
 	static readonly ID = 'workbench.contrib.styleOverrides';
 
-	private readonly knownClassNames = STYLE_OVERRIDE_MODULES.map(m => classNameFor(m.id));
 	private readonly hasLayoutAffectingModule = STYLE_OVERRIDE_MODULES.some(m => m.layoutAffecting);
 
 	/** Whether a layout-affecting module was active at the last applied selection. */
@@ -128,17 +135,13 @@ export class StyleOverridesContribution extends Disposable implements IWorkbench
 	}
 
 	private applyTo(container: HTMLElement, enabled: boolean): void {
-		for (const className of this.knownClassNames) {
-			container.classList.toggle(className, enabled);
-		}
+		container.classList.toggle(STYLE_OVERRIDE_CLASS, enabled);
 	}
 
 	override dispose(): void {
-		// Remove any classes this contribution added so it leaves no DOM state behind.
+		// Remove the class this contribution added so it leaves no DOM state behind.
 		for (const container of this.layoutService.containers) {
-			for (const className of this.knownClassNames) {
-				container.classList.remove(className);
-			}
+			container.classList.remove(STYLE_OVERRIDE_CLASS);
 		}
 		super.dispose();
 	}


### PR DESCRIPTION
Unify style override class naming under a single `.style-override` class and introduce a new editor border style to enhance visual separation of the editor area from surrounding UI elements. Update various CSS files to reflect these changes.

