### PR TITLE
sessions: persist new-session aux bar visibility and fix toggle icon

### DIFF
--- a/src/vs/sessions/LAYOUT_CONTROLLER.md
+++ b/src/vs/sessions/LAYOUT_CONTROLLER.md
@@ -67,11 +67,16 @@ Skipped entirely on mobile web (`isWeb && isMobile`) to avoid disruptive auto-ex
 strict priority order:
 
 1. **No resource / no workspace** → do nothing.
-2. **Untitled session** → open the Files container (`SESSIONS_FILES_CONTAINER_ID`), leave visibility as is.
+2. **Untitled session (new-session view)** → all untitled sessions share a single state object
+   (`_newSessionViewState`, persisted to workspace storage under `sessions.newSessionViewState`): if
+   the user explicitly hid the aux bar on a new session it stays hidden (across switches *and*
+   reloads); otherwise the default container (§3.2 step 4) is shown. This is what makes hiding the aux
+   bar on one new session "stick" when the next new session is opened (each untitled session has a
+   distinct resource, so per-resource saved state can't carry the choice).
 3. **Saved state exists**:
    - was **hidden** → hide the aux bar and stop.
    - was visible with an active container → reopen that container and stop.
-4. **No saved state (first visit) — defaults**:
+4. **No saved state (first visit) — defaults** (`_openDefaultAuxiliaryBarContainer`):
    - session **has changes** → open the Changes view (`CHANGES_VIEW_ID`).
    - otherwise → open the Files container.
 
@@ -92,11 +97,12 @@ sessions are visible.
 ### 3.4 Live visibility tracking
 
 Aux-bar visibility is also tracked **live** (not only on session switch) via an
-`onDidChangePartVisibility` listener for `AUXILIARYBAR_PART` that re-runs `_captureViewState` for
-the active session (skipped on mobile web and while multiple sessions are visible). Without this,
-the sync autorun — which re-evaluates whenever the session's changes/workspace state updates, not
-just on switch — would find no saved state and re-run the default visibility logic (§3.2),
-re-revealing a side bar the user had just hidden.
+`onDidChangePartVisibility` listener for `AUXILIARYBAR_PART` (skipped on mobile web and while
+multiple sessions are visible). For a titled active session it re-runs `_captureViewState`; for an
+untitled active session it updates the shared `_newSessionViewState` (§3.2 step
+2). Without this, the sync autorun — which re-evaluates whenever the session's changes/workspace
+state updates, not just on switch — would find no saved state and re-run the default visibility logic
+(§3.2), re-revealing a side bar the user had just hidden.
 
 ### 3.5 Editor reveal on session switch
 
@@ -168,12 +174,16 @@ back to the default-visible logic (§3.2) on the next reload.)
 
 ## 6. Persistence
 
-- All state serializes to the workspace-scoped key `sessions.layoutState` on
+- All per-session state serializes to the workspace-scoped key `sessions.layoutState` on
   `IStorageService.onWillSaveState` (`_saveState`), with a `StorageTarget.MACHINE` target.
 - `_saveState` captures the active session's current view state and working set (skipping untitled /
   multi-session cases) and writes one `ISessionLayoutEntry` per known session resource.
-- `_loadState` reads `sessions.layoutState`; if absent it performs a one-time migration from the
-  legacy `sessions.workingSets` key and then removes it. Corrupted data is dropped defensively.
+- The shared new-session view state (§3.2 step 2) is persisted separately under the workspace-scoped
+  key `sessions.newSessionViewState` as an `INewSessionViewState` object, written immediately whenever
+  the user toggles the aux bar on the new-session view (not on shutdown).
+- `_loadState` reads `sessions.newSessionViewState` and `sessions.layoutState`; if the latter is
+  absent it performs a one-time migration from the legacy `sessions.workingSets` key and then removes
+  it. Corrupted data is dropped defensively.
 
 ---
 

--- a/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
@@ -43,6 +43,15 @@ interface ISessionViewState {
 }
 
 /**
+ * Shared layout state for the new-session (untitled) view. Untitled sessions
+ * each have a distinct resource, so a single value carries the user's choices
+ * across new sessions.
+ */
+interface INewSessionViewState {
+	readonly auxiliaryBarVisible: boolean;
+}
+
+/**
  * Full per-session layout state persisted to storage.
  */
 interface ISessionLayoutEntry {
@@ -55,6 +64,8 @@ interface ISessionLayoutEntry {
 const SESSION_LAYOUT_STATE_KEY = 'sessions.layoutState';
 /** Legacy key — read on startup for migration only. */
 const WORKING_SETS_STORAGE_KEY = 'sessions.workingSets';
+/** Shared layout state for the new-session (untitled) view. */
+const NEW_SESSION_VIEW_STATE_KEY = 'sessions.newSessionViewState';
 
 export class LayoutController extends Disposable {
 
@@ -65,6 +76,13 @@ export class LayoutController extends Disposable {
 	private readonly _viewStateBySession: ResourceMap<ISessionViewState>;
 	private readonly _workingSets: ResourceMap<IEditorWorkingSet>;
 	private readonly _workingSetSequencer = new Sequencer();
+
+	/**
+	 * Shared layout state for the new-session view, persisted across reloads.
+	 * `undefined` means no explicit choice yet (aux bar defaults to visible).
+	 */
+	private _newSessionViewState: INewSessionViewState | undefined;
+
 	private readonly _useModalConfigObs;
 	constructor(
 
@@ -250,7 +268,12 @@ export class LayoutController extends Disposable {
 					return;
 				}
 				const activeSession = this._sessionsService.activeSession.get();
-				if (activeSession) {
+				if (!activeSession) {
+					return;
+				}
+				if (activeSession.status.get() === SessionStatus.Untitled) {
+					this._setNewSessionViewState({ auxiliaryBarVisible: e.visible });
+				} else {
 					this._captureViewState(activeSession.resource);
 				}
 			}));
@@ -339,14 +362,27 @@ export class LayoutController extends Disposable {
 		});
 	}
 
+	private _setNewSessionViewState(state: INewSessionViewState): void {
+		this._newSessionViewState = state;
+		this._storageService.store(NEW_SESSION_VIEW_STATE_KEY, JSON.stringify(state), StorageScope.WORKSPACE, StorageTarget.MACHINE);
+	}
+
 	private _syncAuxiliaryBarVisibility(sessionResource: URI | undefined, hasWorkspace: boolean, isUntitled: boolean, hasChanges: boolean): void {
 		if (!sessionResource || !hasWorkspace) {
 			return;
 		}
 
-		// On session switch or initial load, restore the saved view state.
-		// Untitled sessions never carry meaningful saved state.
-		const savedState = isUntitled ? undefined : this._viewStateBySession.get(sessionResource);
+		// New-session view: all untitled sessions share one state.
+		if (isUntitled) {
+			if (this._newSessionViewState && !this._newSessionViewState.auxiliaryBarVisible) {
+				this._layoutService.setPartHidden(true, Parts.AUXILIARYBAR_PART);
+			} else {
+				this._openDefaultAuxiliaryBarContainer(hasChanges);
+			}
+			return;
+		}
+
+		const savedState = this._viewStateBySession.get(sessionResource);
 
 		// Honor an explicitly hidden auxiliary bar for this session.
 		if (savedState && !savedState.auxiliaryBarVisible) {
@@ -364,10 +400,12 @@ export class LayoutController extends Disposable {
 			return;
 		}
 
-		// Default for a session without a saved choice (e.g. fresh or untitled):
-		// prefer Changes when the session has changes. Otherwise show the Files
-		// pane, unless the user has hidden/unpinned it — in which case fall back to
-		// Changes rather than force-opening Files.
+		// Default for a session without a saved choice.
+		this._openDefaultAuxiliaryBarContainer(hasChanges);
+	}
+
+	/** Prefer Changes when the session has changes, otherwise Files (falling back to Changes if Files is hidden). */
+	private _openDefaultAuxiliaryBarContainer(hasChanges: boolean): void {
 		if (hasChanges || !this._isAuxiliaryBarContainerPinned(SESSIONS_FILES_CONTAINER_ID)) {
 			this._viewsService.openView(CHANGES_VIEW_ID, false);
 		} else {
@@ -382,6 +420,15 @@ export class LayoutController extends Disposable {
 	}
 
 	private _loadState(): void {
+		const newSessionRaw = this._storageService.get(NEW_SESSION_VIEW_STATE_KEY, StorageScope.WORKSPACE);
+		if (newSessionRaw) {
+			try {
+				this._newSessionViewState = JSON.parse(newSessionRaw) as INewSessionViewState;
+			} catch {
+				this._storageService.remove(NEW_SESSION_VIEW_STATE_KEY, StorageScope.WORKSPACE);
+			}
+		}
+
 		// Load from new key first
 		const raw = this._storageService.get(SESSION_LAYOUT_STATE_KEY, StorageScope.WORKSPACE);
 		if (raw) {
@@ -431,8 +478,8 @@ export class LayoutController extends Disposable {
 		const activeSession = this._sessionsService.activeSession.get();
 		const multipleVisible = this._sessionsService.visibleSessions.get().length > 1;
 
-		// Capture current state for the active session (skip when multiple sessions are visible)
-		if (activeSession && !multipleVisible) {
+		// Capture current state for the active session (skip multiple-visible and untitled).
+		if (activeSession && !multipleVisible && activeSession.status.read(undefined) !== SessionStatus.Untitled) {
 			this._captureViewState(activeSession.resource);
 		}
 

--- a/src/vs/sessions/contrib/layout/test/browser/sessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/sessionLayoutController.test.ts
@@ -120,6 +120,7 @@ suite('LayoutController', () => {
 		readonly useModal?: 'off' | 'some' | 'all';
 		readonly workspaceFolders?: readonly { readonly uri: URI }[];
 		readonly layoutState?: readonly object[];
+		readonly newSessionViewState?: { readonly auxiliaryBarVisible: boolean };
 	}
 
 	function createLayoutController(options: ICreateOptions = {}): LayoutController {
@@ -128,6 +129,9 @@ suite('LayoutController', () => {
 		storageService = store.add(new TestStorageService());
 		if (options.layoutState) {
 			storageService.store('sessions.layoutState', JSON.stringify(options.layoutState), StorageScope.WORKSPACE, 0);
+		}
+		if (options.newSessionViewState) {
+			storageService.store('sessions.newSessionViewState', JSON.stringify(options.newSessionViewState), StorageScope.WORKSPACE, 0);
 		}
 		instaService.stub(IStorageService, storageService);
 
@@ -257,6 +261,72 @@ suite('LayoutController', () => {
 		activeSessionObs.set(session, undefined);
 
 		assert.ok(openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID));
+	});
+
+	test('remembers hidden aux bar across new (untitled) sessions', () => {
+		createLayoutController();
+		const untitled1 = makeSession(URI.parse('session:untitled1'), { status: SessionStatus.Untitled });
+		const existing = makeSession(URI.parse('session:existing'));
+		const untitled2 = makeSession(URI.parse('session:untitled2'), { status: SessionStatus.Untitled });
+
+		// Open a new (untitled) session — aux bar shows the Files view.
+		activeSessionObs.set(untitled1, undefined);
+		assert.ok(openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID));
+
+		// User hides the aux bar on the new-session view.
+		partVisibility.set(Parts.AUXILIARYBAR_PART, false);
+		onDidChangePartVisibility.fire({ partId: Parts.AUXILIARYBAR_PART, visible: false });
+
+		// Switch to an existing session and back to a brand new (untitled) session.
+		activeSessionObs.set(existing, undefined);
+
+		setPartHiddenCalls = [];
+		openedViewContainers = [];
+		activeSessionObs.set(untitled2, undefined);
+
+		assert.ok(
+			setPartHiddenCalls.some(c => c.part === Parts.AUXILIARYBAR_PART && c.hidden === true),
+			'aux bar should stay hidden on the next new session'
+		);
+		assert.ok(
+			!openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID),
+			'should not re-open the Files view on the next new session'
+		);
+	});
+
+	test('persists hidden new-session aux bar to storage and restores it after reload', () => {
+		// First lifetime: user hides the aux bar on the new-session view.
+		createLayoutController();
+		const untitled1 = makeSession(URI.parse('session:untitled1'), { status: SessionStatus.Untitled });
+		activeSessionObs.set(untitled1, undefined);
+
+		partVisibility.set(Parts.AUXILIARYBAR_PART, false);
+		onDidChangePartVisibility.fire({ partId: Parts.AUXILIARYBAR_PART, visible: false });
+
+		assert.deepStrictEqual(
+			JSON.parse(storageService.get('sessions.newSessionViewState', StorageScope.WORKSPACE) ?? ''),
+			{ auxiliaryBarVisible: false },
+			'state should be persisted to storage'
+		);
+
+		store.clear();
+
+		// Second lifetime (reload): a fresh controller with the persisted state.
+		createLayoutController({ newSessionViewState: { auxiliaryBarVisible: false } });
+		const untitled2 = makeSession(URI.parse('session:untitled2'), { status: SessionStatus.Untitled });
+
+		setPartHiddenCalls = [];
+		openedViewContainers = [];
+		activeSessionObs.set(untitled2, undefined);
+
+		assert.ok(
+			setPartHiddenCalls.some(c => c.part === Parts.AUXILIARYBAR_PART && c.hidden === true),
+			'aux bar should stay hidden after reload'
+		);
+		assert.ok(
+			!openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID),
+			'should not re-open the Files view after reload'
+		);
 	});
 
 	test('does not open views when session has no workspace', () => {

--- a/src/vs/workbench/browser/contextkeys.ts
+++ b/src/vs/workbench/browser/contextkeys.ts
@@ -174,6 +174,7 @@ export class WorkbenchContextKeysHandler extends Disposable {
 
 		// Editor Area
 		this.mainEditorAreaVisibleContext = MainEditorAreaVisibleContext.bindTo(this.contextKeyService);
+		this.mainEditorAreaVisibleContext.set(this.layoutService.isVisible(Parts.EDITOR_PART, mainWindow));
 		this.editorTabsVisibleContext = EditorTabsVisibleContext.bindTo(this.contextKeyService);
 
 		// Sidebar


### PR DESCRIPTION
## What

Two related Agents window (sessions) layout fixes around the auxiliary bar / "Side Panel":

1. **Persist the new-session aux bar visibility.** The new-session view always re-showed the Files (auxiliary bar) view even after the user manually closed it. Repro: open a new session → aux bar shows → close it → switch to an existing session → open a new session again → the aux bar comes back. The cause is that each untitled session gets a distinct resource URI and per-resource saved view state was deliberately ignored for untitled sessions, so the default visibility logic always re-revealed Files. Now a shared `INewSessionViewState` object carries the user's choice across new sessions, and it is persisted to workspace storage (`sessions.newSessionViewState`) so it survives reloads.

2. **Fix the Toggle Side Panel icon on reload.** The icon showed the wrong (open) state on reload when the side panel was closed. `mainEditorAreaVisibleContext` was bound but never initialized, so it kept its default `true` when the editor area was restored hidden (no visibility-change event fires for an already-hidden part). It is now initialized to the actual editor-part visibility in the constructor, matching every other layout context key.

## Why

Both are persistence/restore correctness issues: the user's explicit layout choices (hidden aux bar on the new-session view; closed Side Panel) were not honored across session switches and window reloads.

## Notes for reviewers

- The bulk of the change is in the sessions layer (`LayoutController`). The single workbench line (`contextkeys.ts`) is required because the Toggle Side Panel icon is driven by a core context key (`AuxiliaryBarVisible OR MainEditorAreaVisible`) that cannot be corrected from the sessions layer.
- `LayoutController` spec (`LAYOUT_CONTROLLER.md`) updated to document the shared new-session state and its persistence key.
- Added a unit test covering hide-and-reload persistence; all 22 `LayoutController` tests pass. `typecheck-client` and `valid-layers-check` are green.
