### PR TITLE
Refactor floating panels layout for improved edge ownership

### DIFF
--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -11,8 +11,9 @@
  * margin, border and rounded corners — echoing the agents window design. The
  * matching content dimensions are reduced in code (AbstractPaneCompositePart) so
  * the inner layout stays in sync with this CSS. The margin and the 1px border
- * must match `FLOATING_PANEL_MARGIN`, `FLOATING_AUXBAR_EXTRA_RIGHT` and the border inset
- * used there. Colors mirror the agents window (`agentsPanel.*` tokens).
+ * must match `FLOATING_PANEL_MARGIN` and the border inset used there. The outermost
+ * card on a window edge gets a doubled outer gutter (`.floating-part-outer-*`).
+ * Colors mirror the agents window (`agentsPanel.*` tokens).
  *
  * Uses `--vscode-spacing-size60` (6px); keep this in sync with
  * `FLOATING_PANEL_MARGIN` in code.
@@ -47,21 +48,17 @@
 	margin-top: 0;
 }
 
-/* Secondary side bar sits at the window edge — give it a doubled right gutter. */
-.monaco-workbench.floating-panels .part.auxiliarybar {
-	margin-right: calc(var(--vscode-spacing-size60) * 2);
-}
-
 /*
- * When the primary side bar sits at the window edge (the activity bar is not in its
- * default position) it becomes the outermost card and adopts the same doubled gutter.
- * Kept in sync with the inset reservation in `AbstractPaneCompositePart`.
+ * When a floating pane composite (primary side bar, secondary side bar or a vertical
+ * panel) is the outermost card on a window edge, it adopts a doubled outer gutter so
+ * its contents do not hug the window edge. The owning edge is toggled in code (kept in
+ * sync with the inset reservation in `AbstractPaneCompositePart`).
  */
-.monaco-workbench.floating-panels .part.sidebar.floating-sidebar-outer-left {
+.monaco-workbench.floating-panels .part.floating-part-outer-left {
 	margin-left: calc(var(--vscode-spacing-size60) * 2);
 }
 
-.monaco-workbench.floating-panels .part.sidebar.floating-sidebar-outer-right {
+.monaco-workbench.floating-panels .part.floating-part-outer-right {
 	margin-right: calc(var(--vscode-spacing-size60) * 2);
 }
 

--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -52,10 +52,36 @@
 	margin-right: calc(var(--vscode-spacing-size60) * 2);
 }
 
+/*
+ * When the primary side bar sits at the window edge (the activity bar is not in its
+ * default position) it becomes the outermost card and adopts the same doubled gutter.
+ * Kept in sync with the inset reservation in `AbstractPaneCompositePart`.
+ */
+.monaco-workbench.floating-panels .part.sidebar.floating-sidebar-outer-left {
+	margin-left: calc(var(--vscode-spacing-size60) * 2);
+}
+
+.monaco-workbench.floating-panels .part.sidebar.floating-sidebar-outer-right {
+	margin-right: calc(var(--vscode-spacing-size60) * 2);
+}
+
 /* Main editor: float like the other cards, but stay flush with the title bar. */
 .monaco-workbench.floating-panels > .monaco-grid-view .part.editor {
 	margin: var(--vscode-spacing-size60);
 	margin-top: 0;
+}
+
+/*
+ * When the editor becomes the outermost card on a side (no floating part sits
+ * between it and the window edge) it adopts the same doubled gutter the side/aux
+ * bars use. Kept in sync with the margin reservation in `EditorPart.layout`.
+ */
+.monaco-workbench.floating-panels > .monaco-grid-view .part.editor.floating-editor-flush-left {
+	margin-left: calc(var(--vscode-spacing-size60) * 2);
+}
+
+.monaco-workbench.floating-panels > .monaco-grid-view .part.editor.floating-editor-flush-right {
+	margin-right: calc(var(--vscode-spacing-size60) * 2);
 }
 
 /* The shell backdrop behind the floating cards matches the editor background. */

--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -76,11 +76,11 @@
  * between it and the window edge) it adopts the same doubled gutter the side/aux
  * bars use. Kept in sync with the margin reservation in `EditorPart.layout`.
  */
-.monaco-workbench.floating-panels > .monaco-grid-view .part.editor.floating-editor-flush-left {
+.monaco-workbench.floating-panels > .monaco-grid-view .part.editor.floating-editor-outer-left {
 	margin-left: calc(var(--vscode-spacing-size60) * 2);
 }
 
-.monaco-workbench.floating-panels > .monaco-grid-view .part.editor.floating-editor-flush-right {
+.monaco-workbench.floating-panels > .monaco-grid-view .part.editor.floating-editor-outer-right {
 	margin-right: calc(var(--vscode-spacing-size60) * 2);
 }
 

--- a/src/vs/workbench/browser/part.ts
+++ b/src/vs/workbench/browser/part.ts
@@ -177,6 +177,7 @@ export abstract class Part<MementoType extends object = object> extends Componen
 	protected getRelayoutDimension(): Dimension | undefined {
 		return this._dimension;
 	}
+
 	/**
 	 * Layout title and content area in the given dimension.
 	 */

--- a/src/vs/workbench/browser/part.ts
+++ b/src/vs/workbench/browser/part.ts
@@ -161,9 +161,21 @@ export abstract class Part<MementoType extends object = object> extends Componen
 	}
 
 	private relayout() {
-		if (this.dimension && this.contentPosition) {
-			this.layout(this.dimension.width, this.dimension.height, this.contentPosition.top, this.contentPosition.left);
+		const dimension = this.getRelayoutDimension();
+		if (dimension && this.contentPosition) {
+			this.layout(dimension.width, dimension.height, this.contentPosition.top, this.contentPosition.left);
 		}
+	}
+
+	/**
+	 * The dimension to use when the part re-lays out itself in response to internal
+	 * changes (e.g. title, header or footer visibility). Subclasses that reduce the
+	 * dimension passed to {@link layout} (for example to reserve space for a floating
+	 * card margin) must override this to return the original, unreduced dimension so
+	 * the reduction is not applied repeatedly on every relayout.
+	 */
+	protected getRelayoutDimension(): Dimension | undefined {
+		return this._dimension;
 	}
 	/**
 	 * Layout title and content area in the given dimension.

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -1370,8 +1370,27 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 		// (auxiliary editor windows do not apply the matching CSS). The matching
 		// `margin` is applied in CSS (`.floating-panels .part.editor`).
 		if (this.windowId === mainWindow.vscodeWindowId && this.layoutService.isFloatingPanelsEnabled()) {
-			width = Math.max(0, width - FLOATING_PANEL_MARGIN * 2);
+
+			// When the editor becomes the outermost card on a side (no floating part
+			// sits between it and the window edge) it adopts the same doubled gutter the
+			// side/aux bars use, so its contents do not hug the window edge. The matching
+			// margins are applied in CSS via the toggled classes below.
+			const sideBarLeft = this.layoutService.getSideBarPosition() === Position.LEFT;
+			const sideBarVisible = this.layoutService.isVisible(Parts.SIDEBAR_PART);
+			const activityBarVisible = this.layoutService.isVisible(Parts.ACTIVITYBAR_PART);
+			const auxiliaryBarVisible = this.layoutService.isVisible(Parts.AUXILIARYBAR_PART);
+
+			const flushLeft = sideBarLeft ? (!sideBarVisible && !activityBarVisible) : !auxiliaryBarVisible;
+			const flushRight = sideBarLeft ? !auxiliaryBarVisible : (!sideBarVisible && !activityBarVisible);
+
+			const leftMargin = flushLeft ? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_MARGIN;
+			const rightMargin = flushRight ? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_MARGIN;
+
+			width = Math.max(0, width - leftMargin - rightMargin);
 			height = Math.max(0, height - FLOATING_PANEL_MARGIN);
+
+			this.element.classList.toggle('floating-editor-flush-left', flushLeft);
+			this.element.classList.toggle('floating-editor-flush-right', flushRight);
 		}
 
 		// Layout contents

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -24,7 +24,7 @@ import { EditorDropTarget } from './editorDropTarget.js';
 import { Color } from '../../../../base/common/color.js';
 import { CenteredViewLayout, CenteredViewState } from '../../../../base/browser/ui/centered/centeredViewLayout.js';
 import { onUnexpectedError } from '../../../../base/common/errors.js';
-import { Parts, IWorkbenchLayoutService, Position, FLOATING_PANEL_MARGIN } from '../../../services/layout/browser/layoutService.js';
+import { Parts, IWorkbenchLayoutService, Position, FLOATING_PANEL_MARGIN, getFloatingOuterEdgeOwners } from '../../../services/layout/browser/layoutService.js';
 import { DeepPartial, assertType } from '../../../../base/common/types.js';
 import { CompositeDragAndDropObserver } from '../../dnd.js';
 import { DeferredPromise, Promises } from '../../../../base/common/async.js';
@@ -1375,22 +1375,20 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 			// sits between it and the window edge) it adopts the same doubled gutter the
 			// side/aux bars use, so its contents do not hug the window edge. The matching
 			// margins are applied in CSS via the toggled classes below.
-			const sideBarLeft = this.layoutService.getSideBarPosition() === Position.LEFT;
-			const sideBarVisible = this.layoutService.isVisible(Parts.SIDEBAR_PART);
-			const activityBarVisible = this.layoutService.isVisible(Parts.ACTIVITYBAR_PART);
-			const auxiliaryBarVisible = this.layoutService.isVisible(Parts.AUXILIARYBAR_PART);
+			const owners = getFloatingOuterEdgeOwners(this.layoutService);
+			const outerLeft = owners.left === Parts.EDITOR_PART;
+			const outerRight = owners.right === Parts.EDITOR_PART;
 
-			const flushLeft = sideBarLeft ? (!sideBarVisible && !activityBarVisible) : !auxiliaryBarVisible;
-			const flushRight = sideBarLeft ? !auxiliaryBarVisible : (!sideBarVisible && !activityBarVisible);
-
-			const leftMargin = flushLeft ? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_MARGIN;
-			const rightMargin = flushRight ? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_MARGIN;
+			const leftMargin = outerLeft ? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_MARGIN;
+			const rightMargin = outerRight ? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_MARGIN;
 
 			width = Math.max(0, width - leftMargin - rightMargin);
 			height = Math.max(0, height - FLOATING_PANEL_MARGIN);
 
-			this.element.classList.toggle('floating-editor-flush-left', flushLeft);
-			this.element.classList.toggle('floating-editor-flush-right', flushRight);
+			this.element.classList.toggle('floating-editor-outer-left', outerLeft);
+			this.element.classList.toggle('floating-editor-outer-right', outerRight);
+		} else {
+			this.element.classList.remove('floating-editor-outer-left', 'floating-editor-outer-right');
 		}
 
 		// Layout contents

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -12,7 +12,7 @@ import { IPaneComposite } from '../../common/panecomposite.js';
 import { IViewDescriptorService, ViewContainerLocation } from '../../common/views.js';
 import { DisposableStore, MutableDisposable } from '../../../base/common/lifecycle.js';
 import { IView } from '../../../base/browser/ui/grid/grid.js';
-import { IWorkbenchLayoutService, Parts, SINGLE_WINDOW_PARTS, FLOATING_PANEL_MARGIN } from '../../services/layout/browser/layoutService.js';
+import { IWorkbenchLayoutService, Parts, SINGLE_WINDOW_PARTS, FLOATING_PANEL_MARGIN, Position } from '../../services/layout/browser/layoutService.js';
 import { CompositePart, ICompositePartOptions, ICompositeTitleLabel } from './compositePart.js';
 import { IPaneCompositeBarOptions, PaneCompositeBar } from './paneCompositeBar.js';
 import { Dimension, EventHelper, trackFocus, $, addDisposableListener, EventType, prepend, getWindow } from '../../../base/browser/dom.js';
@@ -137,6 +137,7 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 	private globalToolBar: MenuWorkbenchToolBar | undefined;
 	private blockOpening: DeferredPromise<PaneComposite | undefined> | undefined = undefined;
 	protected contentDimension: Dimension | undefined;
+	private floatingLayoutDimension: Dimension | undefined;
 
 	constructor(
 		readonly partId: SINGLE_WINDOW_PARTS,
@@ -599,6 +600,11 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 			return;
 		}
 
+		// Remember the dimension as provided by the grid (before the floating inset is
+		// applied) so relayouts triggered by internal changes (title/header/footer) feed
+		// back this original dimension instead of a repeatedly shrunk one.
+		this.floatingLayoutDimension = new Dimension(width, height);
+
 		// When the floating panels experiment is enabled, shrink the content to
 		// leave room for the card margin and border applied via CSS on the part.
 		const floatingInset = this.getFloatingInset();
@@ -609,6 +615,12 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 
 		this.contentDimension = new Dimension(width, height);
 
+		// Reflect whether the primary side bar sits at the window edge so the matching
+		// doubled outer gutter can be applied in CSS (kept in sync with `getFloatingInset`).
+		const outerEdge = this.getFloatingSideBarOuterEdge();
+		this.element.classList.toggle('floating-sidebar-outer-left', outerEdge === Position.LEFT);
+		this.element.classList.toggle('floating-sidebar-outer-right', outerEdge === Position.RIGHT);
+
 		// Layout contents
 		super.layout(this.contentDimension.width, this.contentDimension.height, top, left);
 
@@ -617,6 +629,24 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 
 		// Add empty pane message
 		this.layoutEmptyMessage();
+	}
+
+	/**
+	 * When the primary side bar sits directly at the window edge (the activity bar is
+	 * not in its default position) it becomes the outermost card on its side and adopts
+	 * the same doubled gutter the other floating cards use. Returns the edge that needs
+	 * the extra margin, or `undefined` when the side bar is not at the window edge.
+	 */
+	private getFloatingSideBarOuterEdge(): Position | undefined {
+		if (!this.layoutService.isFloatingPanelsEnabled() || this.partId !== Parts.SIDEBAR_PART || this.layoutService.isVisible(Parts.ACTIVITYBAR_PART)) {
+			return undefined;
+		}
+
+		return this.layoutService.getSideBarPosition();
+	}
+
+	protected override getRelayoutDimension(): Dimension | undefined {
+		return this.floatingLayoutDimension ?? super.getRelayoutDimension();
 	}
 
 	/**
@@ -635,9 +665,20 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		const borderTotal = 2; // 1px border on each side
 		const margin = FLOATING_PANEL_MARGIN;
 		const topMargin = this.partId === Parts.PANEL_PART ? margin : 0; // side bars are flush with the title bar
-		const rightMargin = this.partId === Parts.AUXILIARYBAR_PART ? margin + AbstractPaneCompositePart.FLOATING_AUXBAR_EXTRA_RIGHT : margin;
+		let leftMargin = margin;
+		let rightMargin = margin;
+		if (this.partId === Parts.AUXILIARYBAR_PART) {
+			rightMargin = margin + AbstractPaneCompositePart.FLOATING_AUXBAR_EXTRA_RIGHT;
+		} else {
+			const outerEdge = this.getFloatingSideBarOuterEdge();
+			if (outerEdge === Position.LEFT) {
+				leftMargin = margin * 2;
+			} else if (outerEdge === Position.RIGHT) {
+				rightMargin = margin * 2;
+			}
+		}
 		return {
-			width: margin + rightMargin + borderTotal,
+			width: leftMargin + rightMargin + borderTotal,
 			height: topMargin + margin + borderTotal
 		};
 	}

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -12,7 +12,7 @@ import { IPaneComposite } from '../../common/panecomposite.js';
 import { IViewDescriptorService, ViewContainerLocation } from '../../common/views.js';
 import { DisposableStore, MutableDisposable } from '../../../base/common/lifecycle.js';
 import { IView } from '../../../base/browser/ui/grid/grid.js';
-import { IWorkbenchLayoutService, Parts, SINGLE_WINDOW_PARTS, FLOATING_PANEL_MARGIN, Position, getFloatingOuterEdgeOwners } from '../../services/layout/browser/layoutService.js';
+import { IWorkbenchLayoutService, Parts, SINGLE_WINDOW_PARTS, FLOATING_PANEL_MARGIN, getFloatingOuterGutterEdges } from '../../services/layout/browser/layoutService.js';
 import { CompositePart, ICompositePartOptions, ICompositeTitleLabel } from './compositePart.js';
 import { IPaneCompositeBarOptions, PaneCompositeBar } from './paneCompositeBar.js';
 import { Dimension, EventHelper, trackFocus, $, addDisposableListener, EventType, prepend, getWindow } from '../../../base/browser/dom.js';
@@ -109,13 +109,6 @@ export interface IPaneCompositePart extends IView {
 export abstract class AbstractPaneCompositePart extends CompositePart<PaneComposite> implements IPaneCompositePart {
 
 	private static readonly MIN_COMPOSITE_BAR_WIDTH = 50;
-
-	/**
-	 * Additional right margin for the secondary side bar (it sits at the window
-	 * edge), doubling the standard margin. Must match the `margin-right` override
-	 * in `part.css`.
-	 */
-	private static readonly FLOATING_AUXBAR_EXTRA_RIGHT = FLOATING_PANEL_MARGIN;
 
 	get snap(): boolean {
 		// Always allow snapping closed
@@ -615,11 +608,12 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 
 		this.contentDimension = new Dimension(width, height);
 
-		// Reflect whether the primary side bar sits at the window edge so the matching
-		// doubled outer gutter can be applied in CSS (kept in sync with `getFloatingInset`).
-		const outerEdge = this.getFloatingSideBarOuterEdge();
-		this.element.classList.toggle('floating-sidebar-outer-left', outerEdge === Position.LEFT);
-		this.element.classList.toggle('floating-sidebar-outer-right', outerEdge === Position.RIGHT);
+		// Reflect which window edges this part is the outermost floating card on so the
+		// matching doubled outer gutter can be applied in CSS (kept in sync with
+		// `getFloatingInset`).
+		const outerGutter = this.getFloatingOuterGutterEdges();
+		this.element.classList.toggle('floating-part-outer-left', outerGutter.left);
+		this.element.classList.toggle('floating-part-outer-right', outerGutter.right);
 
 		// Layout contents
 		super.layout(this.contentDimension.width, this.contentDimension.height, top, left);
@@ -632,24 +626,13 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 	}
 
 	/**
-	 * When the primary side bar sits directly at the window edge (the activity bar is
-	 * not visible) it becomes the outermost card on its side and adopts the same doubled
-	 * gutter the other floating cards use. Returns the edge that needs the extra margin,
-	 * or `undefined` when the side bar is not at the window edge.
+	 * The window edges on which this part is the outermost floating card and therefore
+	 * adopts a doubled outer gutter, so its contents do not hug the window edge. Applies
+	 * to the primary side bar, the secondary side bar and the panel; a horizontal panel
+	 * can own both edges at once.
 	 */
-	private getFloatingSideBarOuterEdge(): Position | undefined {
-		if (this.partId !== Parts.SIDEBAR_PART) {
-			return undefined;
-		}
-
-		const owners = getFloatingOuterEdgeOwners(this.layoutService);
-		if (owners.left === Parts.SIDEBAR_PART) {
-			return Position.LEFT;
-		}
-		if (owners.right === Parts.SIDEBAR_PART) {
-			return Position.RIGHT;
-		}
-		return undefined;
+	private getFloatingOuterGutterEdges(): { left: boolean; right: boolean } {
+		return getFloatingOuterGutterEdges(this.layoutService, this.partId);
 	}
 
 	protected override getRelayoutDimension(): Dimension | undefined {
@@ -661,10 +644,9 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 	 * experiment is enabled: a margin on each side plus a 1px border on each side
 	 * (the border is drawn inside the box, as `.monaco-workbench .part` is
 	 * `box-sizing: border-box` in `part.css`). The side bars sit directly under the
-	 * title bar, so they have no top margin. A side bar that sits at the window edge
-	 * (the secondary side bar always, or the primary side bar when it is the outermost
-	 * card — see {@link getFloatingSideBarOuterEdge}) gets a doubled outer margin, so
-	 * its width inset is larger on that side.
+	 * title bar, so they have no top margin. On each window edge this part is the outermost
+	 * floating card on (see {@link getFloatingOuterGutterEdges}) it gets a doubled outer
+	 * margin, so its width inset is larger on that side.
 	 */
 	private getFloatingInset(): { width: number; height: number } {
 		if (!this.layoutService.isFloatingPanelsEnabled()) {
@@ -674,18 +656,9 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		const borderTotal = 2; // 1px border on each side
 		const margin = FLOATING_PANEL_MARGIN;
 		const topMargin = this.partId === Parts.PANEL_PART ? margin : 0; // side bars are flush with the title bar
-		let leftMargin = margin;
-		let rightMargin = margin;
-		if (this.partId === Parts.AUXILIARYBAR_PART) {
-			rightMargin = margin + AbstractPaneCompositePart.FLOATING_AUXBAR_EXTRA_RIGHT;
-		} else {
-			const outerEdge = this.getFloatingSideBarOuterEdge();
-			if (outerEdge === Position.LEFT) {
-				leftMargin = margin * 2;
-			} else if (outerEdge === Position.RIGHT) {
-				rightMargin = margin * 2;
-			}
-		}
+		const outerGutter = this.getFloatingOuterGutterEdges();
+		const leftMargin = outerGutter.left ? margin * 2 : margin;
+		const rightMargin = outerGutter.right ? margin * 2 : margin;
 		return {
 			width: leftMargin + rightMargin + borderTotal,
 			height: topMargin + margin + borderTotal

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -12,7 +12,7 @@ import { IPaneComposite } from '../../common/panecomposite.js';
 import { IViewDescriptorService, ViewContainerLocation } from '../../common/views.js';
 import { DisposableStore, MutableDisposable } from '../../../base/common/lifecycle.js';
 import { IView } from '../../../base/browser/ui/grid/grid.js';
-import { IWorkbenchLayoutService, Parts, SINGLE_WINDOW_PARTS, FLOATING_PANEL_MARGIN, Position } from '../../services/layout/browser/layoutService.js';
+import { IWorkbenchLayoutService, Parts, SINGLE_WINDOW_PARTS, FLOATING_PANEL_MARGIN, Position, getFloatingOuterEdgeOwners } from '../../services/layout/browser/layoutService.js';
 import { CompositePart, ICompositePartOptions, ICompositeTitleLabel } from './compositePart.js';
 import { IPaneCompositeBarOptions, PaneCompositeBar } from './paneCompositeBar.js';
 import { Dimension, EventHelper, trackFocus, $, addDisposableListener, EventType, prepend, getWindow } from '../../../base/browser/dom.js';
@@ -638,11 +638,18 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 	 * the extra margin, or `undefined` when the side bar is not at the window edge.
 	 */
 	private getFloatingSideBarOuterEdge(): Position | undefined {
-		if (!this.layoutService.isFloatingPanelsEnabled() || this.partId !== Parts.SIDEBAR_PART || this.layoutService.isVisible(Parts.ACTIVITYBAR_PART)) {
+		if (this.partId !== Parts.SIDEBAR_PART) {
 			return undefined;
 		}
 
-		return this.layoutService.getSideBarPosition();
+		const owners = getFloatingOuterEdgeOwners(this.layoutService);
+		if (owners.left === Parts.SIDEBAR_PART) {
+			return Position.LEFT;
+		}
+		if (owners.right === Parts.SIDEBAR_PART) {
+			return Position.RIGHT;
+		}
+		return undefined;
 	}
 
 	protected override getRelayoutDimension(): Dimension | undefined {
@@ -654,8 +661,10 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 	 * experiment is enabled: a margin on each side plus a 1px border on each side
 	 * (the border is drawn inside the box, as `.monaco-workbench .part` is
 	 * `box-sizing: border-box` in `part.css`). The side bars sit directly under the
-	 * title bar, so they have no top margin; the secondary side bar gets an extra
-	 * right margin, so its width inset is larger.
+	 * title bar, so they have no top margin. A side bar that sits at the window edge
+	 * (the secondary side bar always, or the primary side bar when it is the outermost
+	 * card — see {@link getFloatingSideBarOuterEdge}) gets a doubled outer margin, so
+	 * its width inset is larger on that side.
 	 */
 	private getFloatingInset(): { width: number; height: number } {
 		if (!this.layoutService.isFloatingPanelsEnabled()) {

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -633,9 +633,9 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 
 	/**
 	 * When the primary side bar sits directly at the window edge (the activity bar is
-	 * not in its default position) it becomes the outermost card on its side and adopts
-	 * the same doubled gutter the other floating cards use. Returns the edge that needs
-	 * the extra margin, or `undefined` when the side bar is not at the window edge.
+	 * not visible) it becomes the outermost card on its side and adopts the same doubled
+	 * gutter the other floating cards use. Returns the edge that needs the extra margin,
+	 * or `undefined` when the side bar is not at the window edge.
 	 */
 	private getFloatingSideBarOuterEdge(): Position | undefined {
 		if (this.partId !== Parts.SIDEBAR_PART) {

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -119,7 +119,7 @@ export function positionToString(position: Position): string {
  * disabled.
  *
  * The horizontal order of the parts is reconstructed from the same inputs the grid
- * layout uses (see `Layout.arrangeParts`): the activity bar and primary side bar sit
+ * layout uses (mirrors `Layout.adjustPartPositions` in `src/vs/workbench/browser/layout.ts`): the activity bar and primary side bar sit
  * on `getSideBarPosition()`, the secondary side bar on the opposite side, and a
  * vertical (left/right) panel sits immediately next to the editor on its placement
  * side. The outermost *visible* part on each edge wins; the activity bar is not a

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -118,33 +118,105 @@ export function positionToString(position: Position): string {
  * example the activity bar sits flush against that edge) or when the experiment is
  * disabled.
  *
- * Consumed by both `AbstractPaneCompositePart` (primary side bar) and `EditorPart`
- * (main editor) so the doubled-gutter decision stays in sync between them. The
- * secondary side bar can be reported as an aux-side owner, but that value is purely
- * informational: the aux bar applies its own doubled gutter unconditionally.
+ * The horizontal order of the parts is reconstructed from the same inputs the grid
+ * layout uses (see `Layout.arrangeParts`): the activity bar and primary side bar sit
+ * on `getSideBarPosition()`, the secondary side bar on the opposite side, and a
+ * vertical (left/right) panel sits immediately next to the editor on its placement
+ * side. The outermost *visible* part on each edge wins; the activity bar is not a
+ * floating card, so it yields no owner.
+ *
+ * Consumed by `AbstractPaneCompositePart` (side bars and panel) and `EditorPart`
+ * (main editor) so the doubled-gutter decision stays in sync between them.
  */
 export function getFloatingOuterEdgeOwners(layoutService: IWorkbenchLayoutService): { left: Parts | undefined; right: Parts | undefined } {
 	if (!layoutService.isFloatingPanelsEnabled()) {
 		return { left: undefined, right: undefined };
 	}
 
-	// Owner of the side the primary side bar (and activity bar) sit on.
-	let sideBarSideOwner: Parts | undefined;
-	if (layoutService.isVisible(Parts.ACTIVITYBAR_PART)) {
-		sideBarSideOwner = undefined;
-	} else if (layoutService.isVisible(Parts.SIDEBAR_PART)) {
-		sideBarSideOwner = Parts.SIDEBAR_PART;
-	} else {
-		sideBarSideOwner = Parts.EDITOR_PART;
+	const sideBarLeft = layoutService.getSideBarPosition() === Position.LEFT;
+	const panelPosition = layoutService.getPanelPosition();
+	const verticalPanelVisible = !isHorizontal(panelPosition) && layoutService.isVisible(Parts.PANEL_PART);
+
+	// A visible vertical panel sits immediately outside the editor on its placement
+	// side (between the editor and the side/aux bar on that side).
+	const panelInLeftSequence = verticalPanelVisible && panelPosition === Position.LEFT;
+	const panelInRightSequence = verticalPanelVisible && panelPosition === Position.RIGHT;
+
+	// Parts that can sit at each window edge outside the editor, ordered outermost ->
+	// innermost. The editor is the innermost terminal owner (handled in the resolver).
+	const sideBarSideParts: SINGLE_WINDOW_PARTS[] = [Parts.ACTIVITYBAR_PART, Parts.SIDEBAR_PART];
+	const auxSideParts: SINGLE_WINDOW_PARTS[] = [Parts.AUXILIARYBAR_PART];
+	const panelParts: SINGLE_WINDOW_PARTS[] = [Parts.PANEL_PART];
+	const leftOuterParts: SINGLE_WINDOW_PARTS[] = [...(sideBarLeft ? sideBarSideParts : auxSideParts), ...(panelInLeftSequence ? panelParts : [])];
+	const rightOuterParts: SINGLE_WINDOW_PARTS[] = [...(sideBarLeft ? auxSideParts : sideBarSideParts), ...(panelInRightSequence ? panelParts : [])];
+
+	return {
+		left: resolveFloatingOuterOwner(layoutService, leftOuterParts),
+		right: resolveFloatingOuterOwner(layoutService, rightOuterParts)
+	};
+}
+
+function resolveFloatingOuterOwner(layoutService: IWorkbenchLayoutService, outerParts: SINGLE_WINDOW_PARTS[]): Parts | undefined {
+	for (const part of outerParts) {
+		if (!layoutService.isVisible(part)) {
+			continue;
+		}
+
+		// The activity bar hugs the window edge but is not a floating card.
+		return part === Parts.ACTIVITYBAR_PART ? undefined : part;
 	}
 
-	// Owner of the opposite side, where the secondary side bar sits.
-	const auxSideOwner = layoutService.isVisible(Parts.AUXILIARYBAR_PART) ? Parts.AUXILIARYBAR_PART : Parts.EDITOR_PART;
+	// Nothing else sits on this edge: the editor is the outermost (central) card.
+	return Parts.EDITOR_PART;
+}
+
+/**
+ * The window edges on which the given part is the outermost floating card and should
+ * therefore receive a doubled outer gutter. A part can own both edges at once (notably
+ * a horizontal bottom/top panel that spans the full width when the bars beside it are
+ * hidden or not full-height). Convenience wrapper around {@link getFloatingOuterEdgeOwners}.
+ */
+export function getFloatingOuterGutterEdges(layoutService: IWorkbenchLayoutService, partId: Parts): { left: boolean; right: boolean } {
+	if (!layoutService.isFloatingPanelsEnabled()) {
+		return { left: false, right: false };
+	}
+
+	// A horizontal (bottom/top) panel can reach both window edges simultaneously, so it
+	// is not captured by the single-owner-per-edge model and is resolved separately.
+	if (partId === Parts.PANEL_PART && isHorizontal(layoutService.getPanelPosition())) {
+		return getFloatingHorizontalPanelOuterEdges(layoutService);
+	}
+
+	const owners = getFloatingOuterEdgeOwners(layoutService);
+	return { left: owners.left === partId, right: owners.right === partId };
+}
+
+/**
+ * Whether a visible horizontal (bottom/top) panel reaches each window edge and should
+ * therefore receive a doubled outer gutter so it aligns with the editor card above it.
+ * The panel spans underneath a bar that is not full-height, and reaches an edge whenever
+ * the bar on that side is hidden or not full-height (and, on the side bar side, the
+ * activity bar is absent). The full-height/sibling computation mirrors `Layout.arrangeParts`.
+ */
+function getFloatingHorizontalPanelOuterEdges(layoutService: IWorkbenchLayoutService): { left: boolean; right: boolean } {
+	if (!layoutService.isVisible(Parts.PANEL_PART)) {
+		return { left: false, right: false };
+	}
 
 	const sideBarLeft = layoutService.getSideBarPosition() === Position.LEFT;
+	const alignment = layoutService.getPanelAlignment();
+
+	// A bar that is a sibling of the editor is not full-height, so the panel spans
+	// underneath it to the window edge (panel is horizontal, so `isPanelVertical` is false).
+	const sideBarSiblingToEditor = !(alignment === 'center' || (sideBarLeft && alignment === 'right') || (!sideBarLeft && alignment === 'left'));
+	const auxSiblingToEditor = !(alignment === 'center' || (!sideBarLeft && alignment === 'right') || (sideBarLeft && alignment === 'left'));
+
+	const sideBarSideReached = !layoutService.isVisible(Parts.ACTIVITYBAR_PART) && (!layoutService.isVisible(Parts.SIDEBAR_PART) || sideBarSiblingToEditor);
+	const auxSideReached = !layoutService.isVisible(Parts.AUXILIARYBAR_PART) || auxSiblingToEditor;
+
 	return sideBarLeft
-		? { left: sideBarSideOwner, right: auxSideOwner }
-		: { left: auxSideOwner, right: sideBarSideOwner };
+		? { left: sideBarSideReached, right: auxSideReached }
+		: { left: auxSideReached, right: sideBarSideReached };
 }
 
 const positionsByString: { [key: string]: Position } = {

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -119,7 +119,9 @@ export function positionToString(position: Position): string {
  * disabled.
  *
  * Consumed by both `AbstractPaneCompositePart` (primary side bar) and `EditorPart`
- * (main editor) so the doubled-gutter decision stays in sync between them.
+ * (main editor) so the doubled-gutter decision stays in sync between them. The
+ * secondary side bar can be reported as an aux-side owner, but that value is purely
+ * informational: the aux bar applies its own doubled gutter unconditionally.
  */
 export function getFloatingOuterEdgeOwners(layoutService: IWorkbenchLayoutService): { left: Parts | undefined; right: Parts | undefined } {
 	if (!layoutService.isFloatingPanelsEnabled()) {
@@ -129,7 +131,7 @@ export function getFloatingOuterEdgeOwners(layoutService: IWorkbenchLayoutServic
 	// Owner of the side the primary side bar (and activity bar) sit on.
 	let sideBarSideOwner: Parts | undefined;
 	if (layoutService.isVisible(Parts.ACTIVITYBAR_PART)) {
-		sideBarSideOwner = undefined; // the activity bar hugs the edge — it is not a floating card
+		sideBarSideOwner = undefined;
 	} else if (layoutService.isVisible(Parts.SIDEBAR_PART)) {
 		sideBarSideOwner = Parts.SIDEBAR_PART;
 	} else {

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -196,7 +196,7 @@ export function getFloatingOuterGutterEdges(layoutService: IWorkbenchLayoutServi
  * therefore receive a doubled outer gutter so it aligns with the editor card above it.
  * The panel spans underneath a bar that is not full-height, and reaches an edge whenever
  * the bar on that side is hidden or not full-height (and, on the side bar side, the
- * activity bar is absent). The full-height/sibling computation mirrors `Layout.arrangeParts`.
+ * activity bar is absent). The full-height/sibling computation mirrors `Layout.adjustPartPositions`.
  */
 function getFloatingHorizontalPanelOuterEdges(layoutService: IWorkbenchLayoutService): { left: boolean; right: boolean } {
 	if (!layoutService.isVisible(Parts.PANEL_PART)) {

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -110,6 +110,41 @@ export function positionToString(position: Position): string {
 	}
 }
 
+/**
+ * Determines which window edge (left/right) is owned by the outermost floating card
+ * when the Modern UI Update experiment is enabled, and which {@link Parts} owns it.
+ * The owning part receives a doubled outer gutter so its contents do not hug the
+ * window edge. Returns `undefined` for an edge when no floating card owns it (for
+ * example the activity bar sits flush against that edge) or when the experiment is
+ * disabled.
+ *
+ * Consumed by both `AbstractPaneCompositePart` (primary side bar) and `EditorPart`
+ * (main editor) so the doubled-gutter decision stays in sync between them.
+ */
+export function getFloatingOuterEdgeOwners(layoutService: IWorkbenchLayoutService): { left: Parts | undefined; right: Parts | undefined } {
+	if (!layoutService.isFloatingPanelsEnabled()) {
+		return { left: undefined, right: undefined };
+	}
+
+	// Owner of the side the primary side bar (and activity bar) sit on.
+	let sideBarSideOwner: Parts | undefined;
+	if (layoutService.isVisible(Parts.ACTIVITYBAR_PART)) {
+		sideBarSideOwner = undefined; // the activity bar hugs the edge — it is not a floating card
+	} else if (layoutService.isVisible(Parts.SIDEBAR_PART)) {
+		sideBarSideOwner = Parts.SIDEBAR_PART;
+	} else {
+		sideBarSideOwner = Parts.EDITOR_PART;
+	}
+
+	// Owner of the opposite side, where the secondary side bar sits.
+	const auxSideOwner = layoutService.isVisible(Parts.AUXILIARYBAR_PART) ? Parts.AUXILIARYBAR_PART : Parts.EDITOR_PART;
+
+	const sideBarLeft = layoutService.getSideBarPosition() === Position.LEFT;
+	return sideBarLeft
+		? { left: sideBarSideOwner, right: auxSideOwner }
+		: { left: auxSideOwner, right: sideBarSideOwner };
+}
+
 const positionsByString: { [key: string]: Position } = {
 	[positionToString(Position.LEFT)]: Position.LEFT,
 	[positionToString(Position.RIGHT)]: Position.RIGHT,


### PR DESCRIPTION
This pull request refines the logic and styling for floating panels in the workbench, ensuring that the correct parts receive a doubled outer gutter when they are the outermost cards on a window edge. The changes make the gutter logic more robust and consistent across different panel configurations, and update both the CSS and TypeScript to reflect this. The key improvements are grouped below.

<img width="1552" height="1115" alt="image" src="https://github.com/user-attachments/assets/7537565f-7e01-4e60-8025-29060521c01d" />

<img width="1552" height="1115" alt="image" src="https://github.com/user-attachments/assets/fc79e04a-0928-4452-ab8e-80a0063ce82b" />

<img width="1552" height="1115" alt="image" src="https://github.com/user-attachments/assets/2f2ac299-5a0c-4a10-b079-05d38ff09113" />

<img width="1552" height="1115" alt="image" src="https://github.com/user-attachments/assets/ff146bae-4d0d-4780-a9d5-de6fbda2ce49" />


**Layout logic improvements:**

* Introduced `getFloatingOuterEdgeOwners` and `getFloatingOuterGutterEdges` in `layoutService.ts` to accurately determine which parts (side bar, auxiliary bar, panel, or editor) are the outermost floating cards on each window edge and should receive a doubled outer gutter. This logic replaces previous hardcoded or less flexible approaches.
* Updated `AbstractPaneCompositePart` and `EditorPart` to use these new utility functions, ensuring that the correct classes are toggled and margins are applied dynamically based on the current layout. [[1]](diffhunk://#diff-334088d7f4a68f16fd29d2f85973533e0daa1c631e39408adf41d3b6f407ae31R596-R600) [[2]](diffhunk://#diff-334088d7f4a68f16fd29d2f85973533e0daa1c631e39408adf41d3b6f407ae31R611-R617) [[3]](diffhunk://#diff-334088d7f4a68f16fd29d2f85973533e0daa1c631e39408adf41d3b6f407ae31R628-R649) [[4]](diffhunk://#diff-334088d7f4a68f16fd29d2f85973533e0daa1c631e39408adf41d3b6f407ae31L638-R663) [[5]](diffhunk://#diff-9ef2ceca71dfbda41fe00e81938e88f667381e4b23422aaab2b4047a1911f17cL1373-R1391)

**CSS and styling updates:**

* Modified `floatingPanels.css` to generalize the doubled gutter logic, applying it to any part that is the outermost card on a window edge (not just the auxiliary bar). Added new selectors and documentation for `.floating-part-outer-left`, `.floating-part-outer-right`, and corresponding editor classes. [[1]](diffhunk://#diff-96cb2d8573ce4ce529610b032f2044a61b322357bff73870ab0196ceec6f17b3L14-R16) [[2]](diffhunk://#diff-96cb2d8573ce4ce529610b032f2044a61b322357bff73870ab0196ceec6f17b3L50-R61) [[3]](diffhunk://#diff-96cb2d8573ce4ce529610b032f2044a61b322357bff73870ab0196ceec6f17b3R71-R83)

**Code cleanup and refactoring:**

* Removed the now-unnecessary `FLOATING_AUXBAR_EXTRA_RIGHT` constant and related code, as the new logic generalizes the doubled margin for all relevant parts.
* Improved relayout handling in `Part` and `AbstractPaneCompositePart` to ensure dimensions are not repeatedly shrunk by margin logic, preventing layout bugs when relayouts are triggered by internal changes. [[1]](diffhunk://#diff-897ee1b8c7895d892a0a4b3bb3b42c25f16d475a640cff8e968b52703b83c561L164-R180) [[2]](diffhunk://#diff-334088d7f4a68f16fd29d2f85973533e0daa1c631e39408adf41d3b6f407ae31R133) [[3]](diffhunk://#diff-334088d7f4a68f16fd29d2f85973533e0daa1c631e39408adf41d3b6f407ae31R596-R600) [[4]](diffhunk://#diff-334088d7f4a68f16fd29d2f85973533e0daa1c631e39408adf41d3b6f407ae31R628-R649)

**Imports and dependencies:**

* Updated imports in affected files to use the new utility functions from `layoutService.ts`. [[1]](diffhunk://#diff-9ef2ceca71dfbda41fe00e81938e88f667381e4b23422aaab2b4047a1911f17cL27-R27) [[2]](diffhunk://#diff-334088d7f4a68f16fd29d2f85973533e0daa1c631e39408adf41d3b6f407ae31L15-R15)

These changes collectively make the floating panel gutter logic more robust, maintainable, and visually consistent across the workbench.