### PR TITLE
sessions: validate persisted new-session view state shape

### DIFF
--- a/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
@@ -423,7 +423,12 @@ export class LayoutController extends Disposable {
 		const newSessionRaw = this._storageService.get(NEW_SESSION_VIEW_STATE_KEY, StorageScope.WORKSPACE);
 		if (newSessionRaw) {
 			try {
-				this._newSessionViewState = JSON.parse(newSessionRaw) as INewSessionViewState;
+				const parsed = JSON.parse(newSessionRaw);
+				if (parsed && typeof parsed.auxiliaryBarVisible === 'boolean') {
+					this._newSessionViewState = { auxiliaryBarVisible: parsed.auxiliaryBarVisible };
+				} else {
+					this._storageService.remove(NEW_SESSION_VIEW_STATE_KEY, StorageScope.WORKSPACE);
+				}
 			} catch {
 				this._storageService.remove(NEW_SESSION_VIEW_STATE_KEY, StorageScope.WORKSPACE);
 			}

--- a/src/vs/sessions/contrib/layout/test/browser/sessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/sessionLayoutController.test.ts
@@ -121,6 +121,7 @@ suite('LayoutController', () => {
 		readonly workspaceFolders?: readonly { readonly uri: URI }[];
 		readonly layoutState?: readonly object[];
 		readonly newSessionViewState?: { readonly auxiliaryBarVisible: boolean };
+		readonly newSessionViewStateRaw?: string;
 	}
 
 	function createLayoutController(options: ICreateOptions = {}): LayoutController {
@@ -132,6 +133,9 @@ suite('LayoutController', () => {
 		}
 		if (options.newSessionViewState) {
 			storageService.store('sessions.newSessionViewState', JSON.stringify(options.newSessionViewState), StorageScope.WORKSPACE, 0);
+		}
+		if (options.newSessionViewStateRaw !== undefined) {
+			storageService.store('sessions.newSessionViewState', options.newSessionViewStateRaw, StorageScope.WORKSPACE, 0);
 		}
 		instaService.stub(IStorageService, storageService);
 
@@ -326,6 +330,28 @@ suite('LayoutController', () => {
 		assert.ok(
 			!openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID),
 			'should not re-open the Files view after reload'
+		);
+	});
+
+	test('ignores malformed persisted new-session state and does not force-hide the aux bar', () => {
+		// Persisted object is missing the `auxiliaryBarVisible` boolean.
+		createLayoutController({ newSessionViewStateRaw: JSON.stringify({ foo: 'bar' }) });
+		const untitled = makeSession(URI.parse('session:untitled'), { status: SessionStatus.Untitled });
+
+		activeSessionObs.set(untitled, undefined);
+
+		assert.ok(
+			!setPartHiddenCalls.some(c => c.part === Parts.AUXILIARYBAR_PART && c.hidden === true),
+			'malformed state must not force-hide the aux bar'
+		);
+		assert.ok(
+			openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID),
+			'should fall back to the default Files view'
+		);
+		assert.strictEqual(
+			storageService.get('sessions.newSessionViewState', StorageScope.WORKSPACE),
+			undefined,
+			'malformed state should be removed from storage'
 		);
 	});
 


### PR DESCRIPTION
Follow-up to #322541 addressing Copilot Code Review feedback that landed after that PR was auto-merged.

## What
`LayoutController._loadState` parsed the persisted `sessions.newSessionViewState` with a type cast but no shape validation. A missing or non-boolean `auxiliaryBarVisible` would make `!undefined === true` force-hide the auxiliary bar on the new-session view.

## Fix
- Validate that the parsed value has a boolean `auxiliaryBarVisible` before accepting it; otherwise remove the corrupted key from storage (matching the existing `catch` behavior).
- Added a unit test covering the malformed-shape case.

## Validation
- 23 LayoutController tests pass
- Typecheck clean