### PR TITLE
sessions: add pull request pill to session header

### DIFF
--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -234,6 +234,29 @@
 	color: var(--vscode-chat-linesRemovedForeground);
 }
 
+/* Pull request pill rendered next to the workspace label in the meta row. */
+.chat-composite-bar-meta-pr {
+	display: inline-flex;
+	align-items: center;
+	flex-shrink: 0;
+	color: inherit;
+	font: inherit;
+	font-variant-numeric: tabular-nums;
+	cursor: pointer;
+	padding: 0 2px;
+	border-radius: var(--vscode-cornerRadius-small);
+}
+
+.chat-composite-bar-meta-pr:hover {
+	color: inherit;
+	text-decoration: none;
+}
+
+.chat-composite-bar-meta-pr:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+
 /* Tabs row */
 .chat-composite-bar-tabs-row {
 	display: flex;

--- a/src/vs/sessions/browser/parts/sessionHeader.ts
+++ b/src/vs/sessions/browser/parts/sessionHeader.ts
@@ -14,7 +14,9 @@ import { autorun, IObservable, IReader, observableSignalFromEvent } from '../../
 import { IThemeService } from '../../../platform/theme/common/themeService.js';
 import { Codicon } from '../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../base/common/themables.js';
+import { URI } from '../../../base/common/uri.js';
 import { localize } from '../../../nls.js';
+import { IOpenerService } from '../../../platform/opener/common/opener.js';
 import { IActiveSession, ISessionsManagementService } from '../../services/sessions/common/sessionsManagement.js';
 import { ISessionsListModelService } from '../../services/sessions/browser/sessionsListModelService.js';
 import { ISessionsService } from '../../services/sessions/browser/sessionsService.js';
@@ -76,6 +78,8 @@ export class SessionHeader extends Disposable {
 	private readonly _titleTextEl: HTMLElement;
 	private readonly _metaRow: HTMLElement;
 	private readonly _metaWorkspaceEl: HTMLElement;
+	private readonly _metaPrSeparatorEl: HTMLElement;
+	private readonly _metaPrEl: HTMLElement;
 	private readonly _metaSeparatorEl: HTMLElement;
 	private readonly _toolbar: MenuWorkbenchToolBar;
 	private readonly _metaToolbar: MenuWorkbenchToolBar;
@@ -85,6 +89,9 @@ export class SessionHeader extends Disposable {
 	private readonly _editingDisposables = this._register(new MutableDisposable<DisposableStore>());
 	private _renameInput: HTMLInputElement | undefined;
 	private _session: IActiveSession | undefined;
+
+	/** The pull request currently surfaced in the meta row, used by the click handler. */
+	private _currentPullRequestUri: URI | undefined;
 
 	private readonly _onDidChangeVisibility = this._register(new Emitter<boolean>());
 	readonly onDidChangeVisibility: Event<boolean> = this._onDidChangeVisibility.event;
@@ -122,6 +129,7 @@ export class SessionHeader extends Disposable {
 		@ISessionsListModelService private readonly _sessionsListModelService: ISessionsListModelService,
 		@ISessionsService private readonly _sessionsService: ISessionsService,
 		@IHoverService private readonly _hoverService: IHoverService,
+		@IOpenerService private readonly _openerService: IOpenerService,
 	) {
 		super();
 
@@ -194,6 +202,37 @@ export class SessionHeader extends Disposable {
 			this._metaWorkspaceEl,
 			() => this._buildWorkspaceHover(),
 		));
+
+		// Pull request pill: a `#<number>` link rendered next to the workspace label
+		// when the session is associated with a GitHub pull request. Activating it
+		// opens the pull request on GitHub. The leading separator is shown only when
+		// both the workspace label and the pill are visible.
+		this._metaPrSeparatorEl = $('span.chat-composite-bar-meta-separator');
+		this._metaRow.appendChild(this._metaPrSeparatorEl);
+
+		this._metaPrEl = $('a.chat-composite-bar-meta-pr');
+		this._metaPrEl.setAttribute('role', 'button');
+		this._metaPrEl.tabIndex = 0;
+		this._metaRow.appendChild(this._metaPrEl);
+
+		this._register(this._hoverService.setupManagedHover(
+			getDefaultHoverDelegate('element'),
+			this._metaPrEl,
+			() => this._currentPullRequestUri ? localize('agentSessions.openPullRequest', "Open Pull Request") : undefined,
+		));
+
+		this._register(addDisposableListener(this._metaPrEl, EventType.CLICK, e => {
+			e.preventDefault();
+			e.stopPropagation();
+			this._openPullRequest();
+		}));
+		this._register(addStandardDisposableListener(this._metaPrEl, EventType.KEY_DOWN, (e: IKeyboardEvent) => {
+			if (e.keyCode === KeyCode.Enter || e.keyCode === KeyCode.Space) {
+				e.preventDefault();
+				e.stopPropagation();
+				this._openPullRequest();
+			}
+		}));
 
 		this._metaSeparatorEl = $('span.chat-composite-bar-meta-separator');
 		this._metaRow.appendChild(this._metaSeparatorEl);
@@ -357,14 +396,25 @@ export class SessionHeader extends Disposable {
 		}
 		this._metaWorkspaceEl.style.display = hasWorkspace ? '' : 'none';
 
+		// Pull request pill — surface `#<number>` when the session's repository has an
+		// associated GitHub pull request. Clicking it opens the PR on GitHub.
+		const pullRequest = workspace?.folders[0]?.gitRepository?.gitHubInfo.read(reader)?.pullRequest;
+		this._currentPullRequestUri = pullRequest?.uri;
+		const hasPullRequest = !!pullRequest;
+		if (hasPullRequest) {
+			reset(this._metaPrEl, $('span.chat-composite-bar-meta-pr-label', undefined, `#${pullRequest.number}`));
+		}
+		this._metaPrEl.style.display = hasPullRequest ? '' : 'none';
+		this._metaPrSeparatorEl.style.display = hasWorkspace && hasPullRequest ? '' : 'none';
+
 		// Show the meta row separator/row based on whether the meta toolbar has any
 		// contributed actions. Reading the signal re-runs this on menu changes.
 		this._metaActionsSignal.read(reader);
 		const hasMetaActions = !this._metaToolbar.isEmpty();
 
-		this._metaSeparatorEl.style.display = hasWorkspace && hasMetaActions ? '' : 'none';
+		this._metaSeparatorEl.style.display = (hasWorkspace || hasPullRequest) && hasMetaActions ? '' : 'none';
 
-		this._metaRow.style.display = hasWorkspace || hasMetaActions ? '' : 'none';
+		this._metaRow.style.display = hasWorkspace || hasPullRequest || hasMetaActions ? '' : 'none';
 		this._onDidChangeHeight.fire();
 	}
 
@@ -397,6 +447,17 @@ export class SessionHeader extends Disposable {
 		}
 
 		return { markdown: md, markdownNotSupportedFallback: fallbackLines.join('\n') };
+	}
+
+	/**
+	 * Opens the pull request currently surfaced in the meta row on GitHub.
+	 */
+	private _openPullRequest(): void {
+		const uri = this._currentPullRequestUri;
+		if (!uri) {
+			return;
+		}
+		this._openerService.open(uri, { openExternal: true }).catch(onUnexpectedError);
 	}
 
 	private _setVisible(visible: boolean): void {

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/sessionHeader.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/sessionHeader.fixture.ts
@@ -1,0 +1,228 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../../../base/common/uri.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { ThemeIcon, themeColorFromId } from '../../../../../base/common/themables.js';
+import { Event } from '../../../../../base/common/event.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { IObservable, constObservable } from '../../../../../base/common/observable.js';
+// eslint-disable-next-line local/code-import-patterns
+import { IGitHubInfo, ISession, ISessionCapabilities, ISessionFileChange, ISessionFolder, ISessionGitRepository, ISessionWorkspace, SessionStatus } from '../../../../../sessions/services/sessions/common/session.js';
+// eslint-disable-next-line local/code-import-patterns
+import { IActiveSession, ISessionsManagementService } from '../../../../../sessions/services/sessions/common/sessionsManagement.js';
+// eslint-disable-next-line local/code-import-patterns
+import { ISessionsListModelService } from '../../../../../sessions/services/sessions/browser/sessionsListModelService.js';
+// eslint-disable-next-line local/code-import-patterns
+import { ISessionsService } from '../../../../../sessions/services/sessions/browser/sessionsService.js';
+// eslint-disable-next-line local/code-import-patterns
+import { SessionHeader } from '../../../../../sessions/browser/parts/sessionHeader.js';
+import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup, registerWorkbenchServices } from '../fixtureUtils.js';
+
+// eslint-disable-next-line local/code-import-patterns
+import '../../../../../sessions/browser/parts/media/chatCompositeBar.css';
+
+// ============================================================================
+// Mock helpers
+// ============================================================================
+
+interface IMockWorkspaceOptions {
+	label: string;
+	/** Whether the session runs in a worktree (folder icon vs. worktree icon). */
+	isWorktree?: boolean;
+	isVirtualWorkspace?: boolean;
+	/** Pull request associated with the session's repository, if any. */
+	pullRequest?: IGitHubInfo['pullRequest'];
+}
+
+function createMockWorkspace(options: IMockWorkspaceOptions): ISessionWorkspace {
+	const root = URI.file(`/home/user/projects/${options.label}`);
+	const gitHubInfo: IGitHubInfo | undefined = options.pullRequest
+		? { owner: 'microsoft', repo: options.label, pullRequest: options.pullRequest }
+		: undefined;
+
+	const gitRepository: ISessionGitRepository = {
+		uri: root,
+		workTreeUri: options.isWorktree ? URI.file(`/home/user/.worktrees/${options.label}`) : undefined,
+		branchName: 'feature/session-header',
+		baseBranchName: 'main',
+		hasGitHubRemote: true,
+		gitHubInfo: constObservable(gitHubInfo),
+	};
+
+	const folder: ISessionFolder = {
+		root,
+		workingDirectory: gitRepository.workTreeUri ?? root,
+		name: options.label,
+		description: undefined,
+		gitRepository,
+	};
+
+	return {
+		uri: root,
+		label: options.label,
+		icon: Codicon.folder,
+		folders: [folder],
+		requiresWorkspaceTrust: false,
+		isVirtualWorkspace: options.isVirtualWorkspace ?? false,
+	};
+}
+
+interface IMockSessionOptions {
+	title: string;
+	status?: SessionStatus;
+	isArchived?: boolean;
+	supportsRename?: boolean;
+	workspace?: ISessionWorkspace;
+	changes?: readonly ISessionFileChange[];
+}
+
+function createMockSession(options: IMockSessionOptions): IActiveSession {
+	const capabilities: ISessionCapabilities = {
+		supportsMultipleChats: false,
+		supportsRename: options.supportsRename ?? true,
+	};
+
+	return new class extends mock<IActiveSession>() {
+		override readonly sessionId = `local:${options.title}`;
+		override readonly resource = URI.parse(`vscode-session://session/${Math.random().toString(36).slice(2)}`);
+		override readonly capabilities = capabilities;
+		override readonly title: IObservable<string> = constObservable(options.title);
+		override readonly status: IObservable<SessionStatus> = constObservable(options.status ?? SessionStatus.Completed);
+		override readonly isArchived: IObservable<boolean> = constObservable(options.isArchived ?? false);
+		override readonly workspace: IObservable<ISessionWorkspace | undefined> = constObservable(options.workspace);
+		override readonly changes: IObservable<readonly ISessionFileChange[]> = constObservable(options.changes ?? []);
+		override readonly isCreated: IObservable<boolean> = constObservable(true);
+	}();
+}
+
+function createMockListModelService(): ISessionsListModelService {
+	return new class extends mock<ISessionsListModelService>() {
+		override readonly onDidChange = Event.None;
+		override isSessionRead(_session: ISession): boolean { return true; }
+		override getStatusIcon(status: SessionStatus, _isRead: boolean, isArchived: boolean, pullRequestIcon?: ThemeIcon): ThemeIcon {
+			switch (status) {
+				case SessionStatus.InProgress:
+					return { ...Codicon.sessionInProgress, color: themeColorFromId('textLink.foreground') };
+				case SessionStatus.NeedsInput:
+					return { ...Codicon.circleFilled, color: themeColorFromId('list.warningForeground') };
+				case SessionStatus.Error:
+					return { ...Codicon.error, color: themeColorFromId('errorForeground') };
+				default:
+					if (isArchived) {
+						return { ...Codicon.passFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
+					}
+					if (pullRequestIcon) {
+						return pullRequestIcon;
+					}
+					return { ...Codicon.circleSmallFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
+			}
+		}
+	}();
+}
+
+// ============================================================================
+// Render helper
+// ============================================================================
+
+function renderHeader(ctx: ComponentFixtureContext, session: IActiveSession): void {
+	const { container, disposableStore } = ctx;
+
+	const instantiationService = createEditorServices(disposableStore, {
+		colorTheme: ctx.theme,
+		additionalServices: (reg) => {
+			registerWorkbenchServices(reg);
+			reg.defineInstance(ISessionsListModelService, createMockListModelService());
+			reg.defineInstance(ISessionsManagementService, new class extends mock<ISessionsManagementService>() {
+				override readonly onDidChangeSessions = Event.None;
+				override async renameSession() { }
+			}());
+			reg.defineInstance(ISessionsService, new class extends mock<ISessionsService>() {
+				override setActive() { }
+			}());
+		},
+	});
+
+	// The session header reads `--session-view-background/foreground` (set by the
+	// hosting SessionView in production) for its surface colors, so mirror those
+	// here against the agents-window panel background.
+	container.style.width = '420px';
+	container.style.setProperty('--session-view-background', 'var(--vscode-agentsPanel-background, var(--vscode-sideBar-background))');
+	container.style.setProperty('--session-view-foreground', 'var(--vscode-agentsPanel-foreground, var(--vscode-sideBar-foreground))');
+	container.style.backgroundColor = 'var(--session-view-background)';
+
+	const header = disposableStore.add(instantiationService.createInstance(SessionHeader));
+	header.setSession(session);
+	container.appendChild(header.element);
+}
+
+const openPr: IGitHubInfo['pullRequest'] = {
+	number: 12345,
+	uri: URI.parse('https://github.com/microsoft/vscode/pull/12345'),
+	icon: { ...Codicon.gitPullRequest, color: themeColorFromId('charts.green') },
+};
+
+const draftPr: IGitHubInfo['pullRequest'] = {
+	number: 678,
+	uri: URI.parse('https://github.com/microsoft/vscode/pull/678'),
+	icon: { ...Codicon.gitPullRequestDraft, color: themeColorFromId('descriptionForeground') },
+};
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+export default defineThemedFixtureGroup({ path: 'sessions/' }, {
+
+	SessionHeader_NoPullRequest: defineComponentFixture({
+		render: (ctx) => renderHeader(ctx, createMockSession({
+			title: 'Fix login bug',
+			workspace: createMockWorkspace({ label: 'vscode' }),
+		})),
+	}),
+
+	SessionHeader_WithPullRequest: defineComponentFixture({
+		render: (ctx) => renderHeader(ctx, createMockSession({
+			title: 'Add session header PR link',
+			workspace: createMockWorkspace({ label: 'vscode', isWorktree: true, pullRequest: openPr }),
+		})),
+	}),
+
+	SessionHeader_DraftPullRequest: defineComponentFixture({
+		render: (ctx) => renderHeader(ctx, createMockSession({
+			title: 'Refactor authentication flow',
+			workspace: createMockWorkspace({ label: 'vscode', isWorktree: true, pullRequest: draftPr }),
+		})),
+	}),
+
+	SessionHeader_InProgress: defineComponentFixture({
+		render: (ctx) => renderHeader(ctx, createMockSession({
+			title: 'Investigate flaky test',
+			status: SessionStatus.InProgress,
+			workspace: createMockWorkspace({ label: 'vscode', isWorktree: true, pullRequest: openPr }),
+		})),
+	}),
+
+	SessionHeader_NeedsInput: defineComponentFixture({
+		render: (ctx) => renderHeader(ctx, createMockSession({
+			title: 'Update documentation',
+			status: SessionStatus.NeedsInput,
+			workspace: createMockWorkspace({ label: 'vscode' }),
+		})),
+	}),
+
+	SessionHeader_LongTitle: defineComponentFixture({
+		render: (ctx) => renderHeader(ctx, createMockSession({
+			title: 'Investigate and fix the flaky integration test in the notebook editor viewport rendering pipeline',
+			workspace: createMockWorkspace({ label: 'microsoft/vscode', isWorktree: true, pullRequest: openPr }),
+		})),
+	}),
+
+	SessionHeader_NoWorkspace: defineComponentFixture({
+		render: (ctx) => renderHeader(ctx, createMockSession({
+			title: 'New Session',
+		})),
+	}),
+});


### PR DESCRIPTION
Surfaces a clickable `#<number>` pill in the session header meta row when a session is associated with a GitHub pull request. Activating it opens the PR on GitHub (externally).

### What changed
- **`sessionHeader.ts`**: Renders a PR pill (an accessible, keyboard-focusable `role=button` link) between the workspace folder label and the diff-stats pill. The PR data is read reactively from `workspace.folders[0].gitRepository.gitHubInfo.pullRequest`; clicking/Enter/Space opens `pullRequest.uri` via `IOpenerService` with `openExternal: true`. Separators and meta-row visibility now account for the pill.
- **`chatCompositeBar.css`**: Styling for `.chat-composite-bar-meta-pr` (inline pill, pointer cursor, rounded corners, focus outline), consistent with the existing diff-stats pill.
- **`sessionHeader.fixture.ts`** (new): Component-explorer fixtures rendering the real `SessionHeader` across states — no PR, open PR, draft PR, in-progress, needs-input, long title, and no workspace — in dark and light themes.

### Notes for reviewers
- The feature only surfaces existing session data (a GitHub PR association), so no additional AI gating is required.
- Compile/hygiene and the component-explorer screenshots could **not** be run in this worktree because dependencies (`node_modules` / toolchain) aren't installed here. Please rely on CI for compile/hygiene and run the Component Explorer Server locally to capture the new `sessions/SessionHeader_*` baselines.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>