### PR TITLE
Add session grouping support to the sessions list

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -437,6 +437,38 @@
 	}
 }
 
+/* Session groups: render like sections, with an inline name editor and a
+   whole-group highlight while a session is dragged into the group. */
+.session-group {
+	.session-group-input {
+		flex: 1 1 auto;
+		min-width: 0;
+		display: none;
+
+		.monaco-inputbox {
+			width: 100%;
+			height: 20px;
+			line-height: 18px;
+		}
+
+		.monaco-inputbox .input {
+			padding: 0 4px;
+			font-size: var(--vscode-agents-fontSize-label2, 11px);
+		}
+	}
+}
+
+.session-group.session-group-editing .session-group-input {
+	display: block;
+}
+
+/* While dragging a session into a group, the tree applies `.drop-target` to the
+   group header and every member row (subtree feedback). Highlight them as one
+   block without an insertion line. */
+.sessions-list-control .monaco-list-row.drop-target {
+	background-color: var(--vscode-list-dropBackground) !important;
+}
+
 @keyframes session-needs-input-pulse {
 
 	0%,

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -437,8 +437,8 @@
 	}
 }
 
-/* Session groups: render like sections, with an inline name editor and a
-   whole-group highlight while a session is dragged into the group. */
+/* Session groups: render like sections, with an inline name editor and a */
+/* whole-group highlight while a session is dragged into the group. */
 .session-group {
 	.session-group-input {
 		flex: 1 1 auto;
@@ -462,9 +462,9 @@
 	display: block;
 }
 
-/* While dragging a session into a group, the tree applies `.drop-target` to the
-   group header and every member row (subtree feedback). Highlight them as one
-   block without an insertion line. */
+/* While dragging a session into a group, the tree applies `.drop-target` to the */
+/* group header and every member row (subtree feedback). Highlight them as one */
+/* block without an insertion line. */
 .sessions-list-control .monaco-list-row.drop-target {
 	background-color: var(--vscode-list-dropBackground) !important;
 }

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -81,8 +81,6 @@ export const SessionItemToolbarMenuId = new MenuId('SessionItemToolbar');
 export const SessionItemContextMenuId = MenuId.SessionItemContextMenu;
 export const SessionSectionToolbarMenuId = new MenuId('SessionSectionToolbar');
 export const SessionGroupToolbarMenuId = new MenuId('SessionGroupToolbar');
-/** Submenu listing the existing groups a session can be added/moved to. */
-export const SessionAddToGroupSubmenuId = new MenuId('SessionAddToGroupSubmenu');
 export const IsSessionPinnedContext = new RawContextKey<boolean>('sessionItem.isPinned', false);
 export const SessionItemHasBranchNameContext = new RawContextKey<boolean>('sessionItem.hasBranchName', false);
 /** Whether the focused session item currently belongs to a user group. */
@@ -2035,11 +2033,14 @@ export class SessionsList extends Disposable implements ISessionsList {
 
 	// -- Groups --
 
-	/** Create a new group containing the given sessions and start renaming it. */
+	/**
+	 * Create a new group containing the given sessions and start renaming it.
+	 * All selected sessions become members — pinned and archived (Done) sessions
+	 * keep their membership and continue to render in their own sections, but
+	 * return to the group once unpinned/restored.
+	 */
 	createGroupFromSessions(sessions: ISession[]): void {
-		const reorderable = sessions.filter(s => this.isReorderable(s));
-		const members = reorderable.length > 0 ? reorderable : sessions;
-		const group = this._sessionGroupsService.createGroup(localize('newGroupName', "New Group"), members.map(s => s.sessionId));
+		const group = this._sessionGroupsService.createGroup(localize('newGroupName', "New Group"), sessions.map(s => s.sessionId));
 		this._editingGroupId = group.id;
 		this.update();
 	}

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -8,7 +8,7 @@ import * as DOM from '../../../../../base/browser/dom.js';
 import { Gesture } from '../../../../../base/browser/touch.js';
 import { IListVirtualDelegate, ListDragOverEffectPosition, ListDragOverEffectType, NotSelectableGroupId } from '../../../../../base/browser/ui/list/list.js';
 import { IListStyles } from '../../../../../base/browser/ui/list/listWidget.js';
-import { IObjectTreeElement, ITreeNode, ITreeRenderer, ITreeContextMenuEvent, ObjectTreeElementCollapseState, ITreeDragAndDrop, ITreeDragOverReaction } from '../../../../../base/browser/ui/tree/tree.js';
+import { IObjectTreeElement, ITreeNode, ITreeRenderer, ITreeContextMenuEvent, ObjectTreeElementCollapseState, ITreeDragAndDrop, ITreeDragOverReaction, TreeDragOverBubble } from '../../../../../base/browser/ui/tree/tree.js';
 import { RenderIndentGuides, TreeFindMode } from '../../../../../base/browser/ui/tree/abstractTree.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
@@ -20,6 +20,7 @@ import { IObservable, IReader, autorun, observableSignalFromEvent, observableVal
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { fromNow } from '../../../../../base/common/date.js';
+import { KeyCode } from '../../../../../base/common/keyCodes.js';
 import { localize } from '../../../../../nls.js';
 import { MenuId, IMenuService, MenuItemAction } from '../../../../../platform/actions/common/actions.js';
 import { MenuWorkbenchToolBar } from '../../../../../platform/actions/browser/toolbar.js';
@@ -32,19 +33,21 @@ import { IInstantiationService } from '../../../../../platform/instantiation/com
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
 import { WorkbenchObjectTree } from '../../../../../platform/list/browser/listService.js';
-import { IStyleOverride, defaultButtonStyles, defaultFindWidgetStyles, defaultToggleStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
+import { IStyleOverride, defaultButtonStyles, defaultFindWidgetStyles, defaultInputBoxStyles, defaultToggleStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { GITHUB_REMOTE_FILE_SCHEME, ISession, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { AgentSessionApprovalModel, IAgentSessionApprovalInfo } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
 import { Button } from '../../../../../base/browser/ui/button/button.js';
 import { IMarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
-import { Action, ActionRunner, IAction, Separator } from '../../../../../base/common/actions.js';
+import { Action, ActionRunner, IAction, Separator, SubmenuAction } from '../../../../../base/common/actions.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { HoverStyle } from '../../../../../base/browser/ui/hover/hover.js';
 import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.js';
 import { ISessionsManagementService, IActiveSession } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 import { ISessionsListModelService, SessionSortMode } from '../../../../services/sessions/browser/sessionsListModelService.js';
+import { ISessionGroup, ISessionGroupsService } from '../../../../services/sessions/browser/sessionGroupsService.js';
+import { InputBox } from '../../../../../base/browser/ui/inputbox/inputBox.js';
 import { IWorkbenchAssignmentService } from '../../../../../workbench/services/assignment/common/assignmentService.js';
 // =============================================================================
 // TEMPORARY (tracked by https://github.com/microsoft/vscode/issues/320480)
@@ -77,8 +80,13 @@ const SESSION_SECTION_FOCUS_FROM_POINTER_CLASS = 'session-section-focus-from-poi
 export const SessionItemToolbarMenuId = new MenuId('SessionItemToolbar');
 export const SessionItemContextMenuId = MenuId.SessionItemContextMenu;
 export const SessionSectionToolbarMenuId = new MenuId('SessionSectionToolbar');
+export const SessionGroupToolbarMenuId = new MenuId('SessionGroupToolbar');
+/** Submenu listing the existing groups a session can be added/moved to. */
+export const SessionAddToGroupSubmenuId = new MenuId('SessionAddToGroupSubmenu');
 export const IsSessionPinnedContext = new RawContextKey<boolean>('sessionItem.isPinned', false);
 export const SessionItemHasBranchNameContext = new RawContextKey<boolean>('sessionItem.hasBranchName', false);
+/** Whether the focused session item currently belongs to a user group. */
+export const SessionItemInGroupContext = new RawContextKey<boolean>('sessionItem.inGroup', false);
 export const SessionSectionTypeContext = new RawContextKey<string>('sessionSection.type', '');
 
 //#region Types
@@ -106,6 +114,17 @@ export interface ISessionSection {
 	readonly sessions: ISession[];
 }
 
+/**
+ * A user-created group rendered as a section-like header. Carries the backing
+ * {@link ISessionGroup} plus its currently-visible member sessions and whether
+ * the header should render its inline name editor.
+ */
+export interface ISessionGroupItem {
+	readonly group: ISessionGroup;
+	readonly sessions: ISession[];
+	readonly editing: boolean;
+}
+
 export interface ISessionShowMore {
 	readonly showMore: true;
 	readonly kind: 'sessions' | 'folders';
@@ -114,14 +133,22 @@ export interface ISessionShowMore {
 	readonly remainingCount: number;
 }
 
-export type SessionListItem = ISession | ISessionSection | ISessionShowMore;
+export type SessionListItem = ISession | ISessionSection | ISessionGroupItem | ISessionShowMore;
+
+function isSessionGroupItem(item: SessionListItem): item is ISessionGroupItem {
+	return 'group' in item;
+}
 
 function isSessionSection(item: SessionListItem): item is ISessionSection {
-	return 'sessions' in item && Array.isArray((item as ISessionSection).sessions);
+	return !isSessionGroupItem(item) && 'sessions' in item && Array.isArray((item as ISessionSection).sessions);
 }
 
 function isSessionShowMore(item: SessionListItem): item is ISessionShowMore {
 	return 'showMore' in item && (item as ISessionShowMore).showMore === true;
+}
+
+function isSessionItem(item: SessionListItem): item is ISession {
+	return !isSessionGroupItem(item) && !isSessionSection(item) && !isSessionShowMore(item);
 }
 
 const SHOW_MORE_FOLDERS_LABEL = '__more_folders__';
@@ -150,7 +177,7 @@ class SessionsTreeDelegate implements IListVirtualDelegate<SessionListItem> {
 	) { }
 
 	getHeight(element: SessionListItem): number {
-		if (isSessionSection(element)) {
+		if (isSessionSection(element) || isSessionGroupItem(element)) {
 			return SessionsTreeDelegate.SECTION_HEIGHT;
 		}
 		if (isSessionShowMore(element)) {
@@ -168,10 +195,13 @@ class SessionsTreeDelegate implements IListVirtualDelegate<SessionListItem> {
 	}
 
 	hasDynamicHeight(element: SessionListItem): boolean {
-		return !!this._approvalModel && !isSessionSection(element) && !isSessionShowMore(element);
+		return !!this._approvalModel && isSessionItem(element);
 	}
 
 	getTemplateId(element: SessionListItem): string {
+		if (isSessionGroupItem(element)) {
+			return SessionGroupRenderer.TEMPLATE_ID;
+		}
 		if (isSessionSection(element)) {
 			return SessionSectionRenderer.TEMPLATE_ID;
 		}
@@ -292,7 +322,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 
 	renderElement(node: ITreeNode<SessionListItem, FuzzyScore>, _index: number, template: ISessionItemTemplate): void {
 		const element = node.element;
-		if (isSessionSection(element) || isSessionShowMore(element)) {
+		if (!isSessionItem(element)) {
 			return;
 		}
 		this.renderSession(element, template, createMatches(node.filterData));
@@ -699,6 +729,156 @@ class SessionSectionRenderer implements ITreeRenderer<SessionListItem, FuzzyScor
 
 //#endregion
 
+//#region Session Group Renderer
+
+interface ISessionGroupTemplate {
+	readonly container: HTMLElement;
+	readonly label: HTMLElement;
+	readonly inputContainer: HTMLElement;
+	readonly count: HTMLElement;
+	readonly toolbar: MenuWorkbenchToolBar;
+	readonly chevron: HTMLElement;
+	readonly contextKeyService: IContextKeyService;
+	readonly disposables: DisposableStore;
+	readonly elementDisposables: DisposableStore;
+}
+
+/**
+ * Callbacks the group renderer uses to commit or cancel inline renaming.
+ */
+interface ISessionGroupRendererDelegate {
+	commitEdit(group: ISessionGroup, name: string): void;
+	cancelEdit(group: ISessionGroup): void;
+}
+
+class SessionGroupRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, ISessionGroupTemplate> {
+	static readonly TEMPLATE_ID = 'session-group';
+	readonly templateId = SessionGroupRenderer.TEMPLATE_ID;
+
+	private readonly templatesByElement = new WeakMap<ISessionGroupItem, ISessionGroupTemplate>();
+
+	constructor(
+		private readonly delegate: ISessionGroupRendererDelegate,
+		private readonly instantiationService: IInstantiationService,
+		private readonly contextKeyService: IContextKeyService,
+	) { }
+
+	renderTemplate(container: HTMLElement): ISessionGroupTemplate {
+		const disposables = new DisposableStore();
+
+		container.classList.add('session-section', 'session-group');
+		const label = DOM.append(container, $('span.session-section-label'));
+		const inputContainer = DOM.append(container, $('.session-group-input'));
+		const count = DOM.append(container, $('span.session-section-count'));
+		const toolbarContainer = DOM.append(container, $('.session-section-toolbar'));
+		const chevron = DOM.append(container, $('span.session-section-chevron'));
+		chevron.setAttribute('aria-hidden', 'true');
+
+		const contextKeyService = disposables.add(this.contextKeyService.createScoped(container));
+		const scopedInstantiationService = disposables.add(this.instantiationService.createChild(new ServiceCollection([IContextKeyService, contextKeyService])));
+		const toolbar = disposables.add(scopedInstantiationService.createInstance(MenuWorkbenchToolBar, toolbarContainer, SessionGroupToolbarMenuId, {
+			menuOptions: { shouldForwardArgs: true },
+		}));
+
+		return { container, label, inputContainer, count, toolbar, chevron, contextKeyService, disposables, elementDisposables: disposables.add(new DisposableStore()) };
+	}
+
+	renderElement(node: ITreeNode<SessionListItem, FuzzyScore>, _index: number, template: ISessionGroupTemplate): void {
+		const element = node.element;
+		if (!isSessionGroupItem(element)) {
+			return;
+		}
+		template.elementDisposables.clear();
+		this.templatesByElement.set(element, template);
+
+		template.label.textContent = element.group.name;
+		template.count.textContent = String(element.sessions.length);
+		this.updateChevron(template, node.collapsible, node.collapsed);
+		template.toolbar.context = element;
+
+		template.container.classList.toggle('session-group-editing', element.editing);
+		if (element.editing) {
+			this.renderInput(element, template);
+		} else {
+			template.inputContainer.style.display = 'none';
+			template.label.style.display = '';
+		}
+	}
+
+	private renderInput(element: ISessionGroupItem, template: ISessionGroupTemplate): void {
+		template.label.style.display = 'none';
+		template.inputContainer.style.display = '';
+		DOM.clearNode(template.inputContainer);
+
+		const input = template.elementDisposables.add(new InputBox(template.inputContainer, undefined, {
+			inputBoxStyles: defaultInputBoxStyles,
+			ariaLabel: localize('sessionGroupName', "Group name"),
+		}));
+		input.value = element.group.name;
+		input.focus();
+		input.select();
+
+		let done = false;
+		const commit = () => {
+			if (done) {
+				return;
+			}
+			done = true;
+			this.delegate.commitEdit(element.group, input.value.trim());
+		};
+		const cancel = () => {
+			if (done) {
+				return;
+			}
+			done = true;
+			this.delegate.cancelEdit(element.group);
+		};
+
+		template.elementDisposables.add(DOM.addStandardDisposableListener(input.inputElement, DOM.EventType.KEY_DOWN, e => {
+			if (e.equals(KeyCode.Enter)) {
+				e.preventDefault();
+				e.stopPropagation();
+				commit();
+			} else if (e.equals(KeyCode.Escape)) {
+				e.preventDefault();
+				e.stopPropagation();
+				cancel();
+			}
+		}));
+		template.elementDisposables.add(DOM.addDisposableListener(input.inputElement, DOM.EventType.BLUR, () => commit()));
+	}
+
+	/** Forwarded from the owning list when the group's collapse state toggles. */
+	updateCollapseState(element: ISessionGroupItem, collapsed: boolean): void {
+		const template = this.templatesByElement.get(element);
+		if (template) {
+			this.updateChevron(template, true, collapsed);
+		}
+	}
+
+	private updateChevron(template: ISessionGroupTemplate, collapsible: boolean, collapsed: boolean): void {
+		template.chevron.className = 'session-section-chevron';
+		if (collapsible) {
+			template.chevron.classList.add('collapsible');
+			const icon = collapsed ? Codicon.chevronRight : Codicon.chevronDown;
+			template.chevron.classList.add(...ThemeIcon.asClassNameArray(icon));
+		}
+	}
+
+	disposeElement(node: ITreeNode<SessionListItem, FuzzyScore>, _index: number, template: ISessionGroupTemplate): void {
+		if (isSessionGroupItem(node.element)) {
+			this.templatesByElement.delete(node.element);
+		}
+		template.elementDisposables.clear();
+	}
+
+	disposeTemplate(template: ISessionGroupTemplate): void {
+		template.disposables.dispose();
+	}
+}
+
+//#endregion
+
 //#region Show More Renderer
 
 class SessionShowMoreRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, HTMLElement> {
@@ -741,6 +921,9 @@ class SessionsAccessibilityProvider {
 	}
 
 	getAriaLabel(element: SessionListItem): string | null {
+		if (isSessionGroupItem(element)) {
+			return `${element.group.name}, ${element.sessions.length}`;
+		}
 		if (isSessionSection(element)) {
 			return `${element.label}, ${element.sessions.length}`;
 		}
@@ -778,6 +961,12 @@ interface ISessionsListDndDelegate {
 	canDropOn(dragged: ISession[], target: ISession): boolean;
 	/** Apply the reorder, placing the dragged sessions before/after the target. */
 	reorder(dragged: ISession[], target: ISession, position: 'before' | 'after'): void;
+	/** The id of the group the session belongs to, or `undefined`. */
+	getGroupIdOfSession(session: ISession): string | undefined;
+	/** Add the given sessions to the group. */
+	addSessionsToGroup(sessions: ISession[], groupId: string): void;
+	/** Reorder the dragged group before/after the target group. */
+	reorderGroup(draggedGroupId: string, targetGroupId: string, position: 'before' | 'after'): void;
 }
 
 class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<SessionListItem> {
@@ -789,6 +978,9 @@ class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<Ses
 	}
 
 	getDragURI(element: SessionListItem): string | null {
+		if (isSessionGroupItem(element)) {
+			return `sessionGroup:${element.group.id}`;
+		}
 		if (isSessionSection(element) || isSessionShowMore(element)) {
 			return null;
 		}
@@ -796,6 +988,10 @@ class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<Ses
 	}
 
 	getDragLabel(elements: SessionListItem[]): string | undefined {
+		const groupItem = elements.find(isSessionGroupItem);
+		if (groupItem) {
+			return groupItem.group.name;
+		}
 		const sessions = this.toSessions(elements);
 		if (sessions.length === 0) {
 			return undefined;
@@ -828,6 +1024,25 @@ class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<Ses
 	}
 
 	onDragOver(data: IDragAndDropData, targetElement: SessionListItem | undefined, _targetIndex: number | undefined, targetSector: ListViewTargetSector | undefined): boolean | ITreeDragOverReaction {
+		const draggedGroup = this.draggedGroup(data);
+		if (draggedGroup) {
+			return this.onGroupDragOver(draggedGroup, targetElement, targetSector);
+		}
+
+		// Adding sessions to a group: when the drop target lives in a group the
+		// dragged sessions don't already belong to, highlight the whole group
+		// (header + members) without an insertion line and accept the drop.
+		const addToGroupId = this.resolveAddToGroupTarget(data, targetElement);
+		if (addToGroupId !== undefined) {
+			if (targetElement && isSessionGroupItem(targetElement)) {
+				// Bubble the feedback down across the group and all its members.
+				return { accept: true, bubble: TreeDragOverBubble.Down, effect: { type: ListDragOverEffectType.Move, position: ListDragOverEffectPosition.Over } };
+			}
+			// Target is a member session: bubble up so the parent group (and its
+			// whole subtree) receives the highlight.
+			return { accept: true, bubble: TreeDragOverBubble.Up };
+		}
+
 		const target = this.resolveReorderTarget(data, targetElement);
 		if (!target) {
 			return false;
@@ -843,6 +1058,21 @@ class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<Ses
 	}
 
 	drop(data: IDragAndDropData, targetElement: SessionListItem | undefined, _targetIndex: number | undefined, targetSector: ListViewTargetSector | undefined): void {
+		const draggedGroup = this.draggedGroup(data);
+		if (draggedGroup) {
+			if (targetElement && isSessionGroupItem(targetElement) && targetElement.group.id !== draggedGroup.id) {
+				this.delegate.reorderGroup(draggedGroup.id, targetElement.group.id, sectorToPosition(targetSector));
+			}
+			return;
+		}
+
+		const addToGroupId = this.resolveAddToGroupTarget(data, targetElement);
+		if (addToGroupId !== undefined) {
+			const dragged = this.toSessions(data instanceof ElementsDragAndDropData ? data.elements as SessionListItem[] : []);
+			this.delegate.addSessionsToGroup(dragged, addToGroupId);
+			return;
+		}
+
 		const target = this.resolveReorderTarget(data, targetElement);
 		if (!target) {
 			return;
@@ -851,12 +1081,57 @@ class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<Ses
 		this.delegate.reorder(dragged, target, sectorToPosition(targetSector));
 	}
 
+	private onGroupDragOver(draggedGroup: ISessionGroup, targetElement: SessionListItem | undefined, targetSector: ListViewTargetSector | undefined): boolean | ITreeDragOverReaction {
+		if (!targetElement || !isSessionGroupItem(targetElement) || targetElement.group.id === draggedGroup.id) {
+			return false;
+		}
+		const position = sectorToPosition(targetSector);
+		return {
+			accept: true,
+			effect: {
+				type: ListDragOverEffectType.Move,
+				position: position === 'after' ? ListDragOverEffectPosition.After : ListDragOverEffectPosition.Before,
+			},
+		};
+	}
+
+	/**
+	 * The group id the dragged sessions should be added to, or `undefined` if
+	 * the current drag is not an add-to-group operation. Returns a group id only
+	 * when the target belongs to a group and at least one dragged session is not
+	 * already a member of that group.
+	 */
+	private resolveAddToGroupTarget(data: IDragAndDropData, targetElement: SessionListItem | undefined): string | undefined {
+		if (!targetElement) {
+			return undefined;
+		}
+		let groupId: string | undefined;
+		if (isSessionGroupItem(targetElement)) {
+			groupId = targetElement.group.id;
+		} else if (isSessionItem(targetElement)) {
+			groupId = this.delegate.getGroupIdOfSession(targetElement);
+		}
+		if (groupId === undefined) {
+			return undefined;
+		}
+		const dragged = this.toSessions(data instanceof ElementsDragAndDropData ? data.elements as SessionListItem[] : []);
+		if (dragged.length === 0) {
+			return undefined;
+		}
+		// Only an add-to-group drop when at least one dragged session isn't
+		// already in this group; otherwise fall through to within-group reorder.
+		if (dragged.every(s => this.delegate.getGroupIdOfSession(s) === groupId)) {
+			return undefined;
+		}
+		return groupId;
+	}
+
 	/**
 	 * Resolve the session the drop should be positioned against, or `undefined`
 	 * if the current drag is not a valid in-list reorder.
 	 */
 	private resolveReorderTarget(data: IDragAndDropData, targetElement: SessionListItem | undefined): ISession | undefined {
-		if (!targetElement || isSessionSection(targetElement) || isSessionShowMore(targetElement)) {
+		if (!targetElement || !isSessionItem(targetElement)) {
 			return undefined;
 		}
 		const target = targetElement;
@@ -876,8 +1151,16 @@ class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<Ses
 		return target;
 	}
 
+	private draggedGroup(data: IDragAndDropData): ISessionGroup | undefined {
+		if (!(data instanceof ElementsDragAndDropData)) {
+			return undefined;
+		}
+		const groupItem = (data.elements as SessionListItem[]).find(isSessionGroupItem);
+		return groupItem?.group;
+	}
+
 	private toSessions(elements: SessionListItem[]): ISession[] {
-		return elements.filter((e): e is ISession => !isSessionSection(e) && !isSessionShowMore(e));
+		return elements.filter(isSessionItem);
 	}
 }
 
@@ -938,6 +1221,10 @@ export interface ISessionsList {
 	isWorkspaceGroupCapped(): boolean;
 	setOpenWindowSourceFolder(folder: URI | undefined): void;
 	collapseAllSections(): void;
+	createGroupFromSessions(sessions: ISession[]): void;
+	beginRenameGroup(groupId: string): void;
+	addSessionsToGroup(sessions: ISession[], groupId: string): void;
+	getGroupsInDisplayOrder(): ISessionGroup[];
 }
 
 export class SessionsList extends Disposable implements ISessionsList {
@@ -980,6 +1267,10 @@ export class SessionsList extends Disposable implements ISessionsList {
 	private hasFindPattern = false;
 	private suspendCollapseStatePersistence = false;
 
+	/** The group whose header is currently showing its inline name editor. */
+	private _editingGroupId: string | undefined;
+	private _groupRenderer!: SessionGroupRenderer;
+
 	private readonly _onDidUpdate = this._register(new Emitter<void>());
 	readonly onDidUpdate: Event<void> = this._onDidUpdate.event;
 
@@ -994,6 +1285,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
 		@ISessionsService private readonly _sessionsService: ISessionsService,
 		@ISessionsListModelService private readonly _sessionsListModelService: ISessionsListModelService,
+		@ISessionGroupsService private readonly _sessionGroupsService: ISessionGroupsService,
 		@IAgentHostFilterService private readonly _agentHostFilterService: IAgentHostFilterService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
@@ -1044,6 +1336,11 @@ export class SessionsList extends Disposable implements ISessionsList {
 
 		const showMoreRenderer = new SessionShowMoreRenderer();
 		const sectionRenderer = new SessionSectionRenderer(true /* hideSectionCount */, instantiationService, contextKeyService);
+		const groupRenderer = new SessionGroupRenderer({
+			commitEdit: (group, name) => this.commitGroupEdit(group, name),
+			cancelEdit: group => this.cancelGroupEdit(group),
+		}, instantiationService, contextKeyService);
+		this._groupRenderer = groupRenderer;
 
 		// Read (don't bind) `IsPhoneLayoutContext` from the parent context so we
 		// observe the workbench's value rather than shadowing it with a fresh
@@ -1059,6 +1356,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 			[
 				sessionRenderer,
 				sectionRenderer,
+				groupRenderer,
 				showMoreRenderer,
 			],
 			{
@@ -1067,9 +1365,15 @@ export class SessionsList extends Disposable implements ISessionsList {
 					isReorderable: session => this.isReorderable(session),
 					canDropOn: (dragged, target) => this.canReorderOnto(dragged, target),
 					reorder: (dragged, target, position) => this.reorderSessions(dragged, target, position),
+					getGroupIdOfSession: session => this._sessionGroupsService.getGroupOfSession(session.sessionId),
+					addSessionsToGroup: (sessions, groupId) => this.addSessionsToGroup(sessions, groupId),
+					reorderGroup: (draggedGroupId, targetGroupId, position) => this.reorderGroup(draggedGroupId, targetGroupId, position),
 				})),
 				identityProvider: {
 					getId: (element: SessionListItem) => {
+						if (isSessionGroupItem(element)) {
+							return `group:${element.group.id}`;
+						}
 						if (isSessionSection(element)) {
 							return `section:${element.id}`;
 						}
@@ -1079,6 +1383,9 @@ export class SessionsList extends Disposable implements ISessionsList {
 						return element.resource.toString();
 					},
 					getGroupId: (element: SessionListItem) => {
+						if (isSessionGroupItem(element)) {
+							return NotSelectableGroupId;
+						}
 						if (isSessionSection(element)) {
 							return NotSelectableGroupId;
 						}
@@ -1105,6 +1412,9 @@ export class SessionsList extends Disposable implements ISessionsList {
 				},
 				keyboardNavigationLabelProvider: {
 					getKeyboardNavigationLabel: (element: SessionListItem) => {
+						if (isSessionGroupItem(element)) {
+							return element.group.name;
+						}
 						if (isSessionSection(element)) {
 							return element.label;
 						}
@@ -1138,7 +1448,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 				this.update();
 				return;
 			}
-			if (!isSessionSection(element)) {
+			if (!isSessionSection(element) && !isSessionGroupItem(element)) {
 				this.markRead(element);
 				this.options.onSessionOpen(element.resource, e.editorOptions.preserveFocus ?? false, e.sideBySide);
 			}
@@ -1173,7 +1483,12 @@ export class SessionsList extends Disposable implements ISessionsList {
 
 		this._register(this.tree.onDidChangeCollapseState(e => {
 			const element = e.node.element;
-			if (element && isSessionSection(element)) {
+			if (element && isSessionGroupItem(element)) {
+				this._groupRenderer.updateCollapseState(element, e.node.collapsed);
+				if (!this.suspendCollapseStatePersistence) {
+					this.saveSectionCollapseState(`group:${element.group.id}`, e.node.collapsed);
+				}
+			} else if (element && isSessionSection(element)) {
 				sectionRenderer.updateCollapseState(element, e.node.collapsed);
 				if (!this.suspendCollapseStatePersistence) {
 					this.saveSectionCollapseState(element.id, e.node.collapsed);
@@ -1213,6 +1528,12 @@ export class SessionsList extends Disposable implements ISessionsList {
 		}));
 
 		this._register(this._sessionsListModelService.onDidChange(() => {
+			if (this.visible) {
+				this.update();
+			}
+		}));
+
+		this._register(this._sessionGroupsService.onDidChange(() => {
 			if (this.visible) {
 				this.update();
 			}
@@ -1301,7 +1622,55 @@ export class SessionsList extends Disposable implements ISessionsList {
 		}
 
 		const grouping = this.options.grouping();
-		const sections = groupSessionsForList(filtered, grouping, this.options.sorting(), session => this.isSessionPinned(session), (s, sorting) => this._sessionsListModelService.getSortKey(s, sortingToMode(sorting)));
+		const sorting = this.options.sorting();
+		const mode = sortingToMode(sorting);
+		const sortKeyOf = (s: ISession) => this._sessionsListModelService.getSortKey(s, mode);
+		const sortKeyForGrouping = (s: ISession, srt: SessionsSorting) => this._sessionsListModelService.getSortKey(s, sortingToMode(srt));
+
+		// Pull regular (non-pinned, non-archived) grouped sessions out of the
+		// normal date/workspace sectioning so they render under their group.
+		// Pinned and archived sessions keep their precedence and stay in their
+		// sections even when they belong to a group (their membership is
+		// retained so they return to the group once unpinned/restored).
+		const groupedMembers = new Map<string, ISession[]>();
+		const groupedRegularIds = new Set<string>();
+		for (const s of filtered) {
+			if (s.isArchived.get() || this.isSessionPinned(s)) {
+				continue;
+			}
+			const groupId = this._sessionGroupsService.getGroupOfSession(s.sessionId);
+			if (groupId !== undefined && this._sessionGroupsService.getGroup(groupId)) {
+				let members = groupedMembers.get(groupId);
+				if (!members) {
+					members = [];
+					groupedMembers.set(groupId, members);
+				}
+				members.push(s);
+				groupedRegularIds.add(s.sessionId);
+			}
+		}
+		// Keep a group being renamed visible even if it currently has no visible
+		// members, so its inline name editor stays on screen.
+		if (this._editingGroupId && this._sessionGroupsService.getGroup(this._editingGroupId) && !groupedMembers.has(this._editingGroupId)) {
+			groupedMembers.set(this._editingGroupId, []);
+		}
+
+		const forSections = groupedRegularIds.size > 0 ? filtered.filter(s => !groupedRegularIds.has(s.sessionId)) : filtered;
+
+		// Build the group blocks with members sorted by the normal sort logic and
+		// a representative key (manual override, else the best member key) used to
+		// place the group among the other top-level items.
+		const groupItems: { item: ISessionGroupItem; repKey: number }[] = [];
+		for (const [groupId, members] of groupedMembers) {
+			const group = this._sessionGroupsService.getGroup(groupId)!;
+			const sortedMembers = sortSessions(members, sorting, sortKeyForGrouping);
+			const naturalRep = sortedMembers.length > 0 ? Math.max(...sortedMembers.map(sortKeyOf)) : group.createdAt;
+			const repKey = group.sortKeyOverride ?? naturalRep;
+			groupItems.push({ item: { group, sessions: sortedMembers, editing: group.id === this._editingGroupId }, repKey });
+		}
+		groupItems.sort((a, b) => b.repKey - a.repKey);
+
+		const sections = groupSessionsForList(forSections, grouping, sorting, session => this.isSessionPinned(session), (s, srt) => this._sessionsListModelService.getSortKey(s, sortingToMode(srt)));
 
 		const hasTodaySessions = sections.some(s => s.id === 'today' && s.sessions.length > 0);
 
@@ -1403,37 +1772,89 @@ export class SessionsList extends Disposable implements ISessionsList {
 			};
 		};
 
-		const moreFolderSections: ISessionSection[] = [];
-		// The archived ("Done") section should always appear after the
-		// "more workspaces" toggle (both collapsed and expanded states)
-		// so it remains the very last group in the list.
-		let archivedSection: ISessionSection | undefined;
-		for (const section of sections) {
-			if (moreFolderSectionIds.has(section.id)) {
-				moreFolderSections.push(section);
-			} else if (partitionFolders && section.id === 'archived') {
-				archivedSection = section;
-			} else {
-				children.push(renderSection(section));
-			}
+		const renderGroup = (groupItem: ISessionGroupItem): IObjectTreeElement<SessionListItem> => {
+			return {
+				element: groupItem,
+				collapsible: true,
+				collapsed: this.getSavedCollapseState(`group:${groupItem.group.id}`) ?? ObjectTreeElementCollapseState.PreserveOrExpanded,
+				children: groupItem.sessions.map(session => ({ element: session as SessionListItem })),
+			};
+		};
+
+		const sectionRepKey = (section: ISessionSection): number =>
+			section.sessions.length > 0 ? Math.max(...section.sessions.map(sortKeyOf)) : Number.NEGATIVE_INFINITY;
+
+		const pinnedSection = sections.find(s => s.id === 'pinned');
+		if (pinnedSection) {
+			children.push(renderSection(pinnedSection));
 		}
 
-		if (moreFolderSections.length > 0) {
-			if (this.expandedMoreFolders) {
-				for (const section of moreFolderSections) {
+		if (grouping === SessionsGrouping.Date) {
+			// Interleave groups among the date sections by representative key so a
+			// group sorts to wherever its most-recent member would place it.
+			// Pinned stays at the top, Done (archived) stays at the bottom.
+			type Block = { key: number; render: () => IObjectTreeElement<SessionListItem> };
+			const blocks: Block[] = [];
+			for (const section of sections) {
+				if (section.id === 'pinned' || section.id === 'archived') {
+					continue;
+				}
+				blocks.push({ key: sectionRepKey(section), render: () => renderSection(section) });
+			}
+			for (const groupItem of groupItems) {
+				blocks.push({ key: groupItem.repKey, render: () => renderGroup(groupItem.item) });
+			}
+			blocks.sort((a, b) => b.key - a.key);
+			for (const block of blocks) {
+				children.push(block.render());
+			}
+			const archived = sections.find(s => s.id === 'archived');
+			if (archived) {
+				children.push(renderSection(archived));
+			}
+		} else {
+			// Workspace grouping: groups render as a block right after Pinned and
+			// before the (alphabetical) workspace sections, sorted among
+			// themselves by representative key.
+			for (const groupItem of groupItems) {
+				children.push(renderGroup(groupItem.item));
+			}
+
+			const moreFolderSections: ISessionSection[] = [];
+			// The archived ("Done") section should always appear after the
+			// "more workspaces" toggle (both collapsed and expanded states)
+			// so it remains the very last group in the list.
+			let archivedSection: ISessionSection | undefined;
+			for (const section of sections) {
+				if (section.id === 'pinned') {
+					continue;
+				}
+				if (moreFolderSectionIds.has(section.id)) {
+					moreFolderSections.push(section);
+				} else if (partitionFolders && section.id === 'archived') {
+					archivedSection = section;
+				} else {
 					children.push(renderSection(section));
 				}
-				children.push({
-					element: { showMore: true as const, kind: 'folders' as const, mode: 'less' as const, sectionLabel: SHOW_MORE_FOLDERS_LABEL, remainingCount: 0 },
-				});
-			} else {
-				children.push({
-					element: { showMore: true as const, kind: 'folders' as const, mode: 'more' as const, sectionLabel: SHOW_MORE_FOLDERS_LABEL, remainingCount: moreFolderSections.length },
-				});
 			}
-		}
-		if (archivedSection) {
-			children.push(renderSection(archivedSection));
+
+			if (moreFolderSections.length > 0) {
+				if (this.expandedMoreFolders) {
+					for (const section of moreFolderSections) {
+						children.push(renderSection(section));
+					}
+					children.push({
+						element: { showMore: true as const, kind: 'folders' as const, mode: 'less' as const, sectionLabel: SHOW_MORE_FOLDERS_LABEL, remainingCount: 0 },
+					});
+				} else {
+					children.push({
+						element: { showMore: true as const, kind: 'folders' as const, mode: 'more' as const, sectionLabel: SHOW_MORE_FOLDERS_LABEL, remainingCount: moreFolderSections.length },
+					});
+				}
+			}
+			if (archivedSection) {
+				children.push(renderSection(archivedSection));
+			}
 		}
 
 		this.tree.setChildren(null, children);
@@ -1545,10 +1966,14 @@ export class SessionsList extends Disposable implements ISessionsList {
 
 	/**
 	 * Whether the dragged sessions can be reordered relative to the target.
-	 * When grouping by workspace, reordering is restricted to within the same
-	 * workspace group.
+	 * Reordering stays within the same scope: dragged sessions must share the
+	 * target's group membership, and (when grouping by workspace) its workspace.
 	 */
 	private canReorderOnto(dragged: ISession[], target: ISession): boolean {
+		const targetGroup = this._sessionGroupsService.getGroupOfSession(target.sessionId);
+		if (dragged.some(s => this._sessionGroupsService.getGroupOfSession(s.sessionId) !== targetGroup)) {
+			return false;
+		}
 		if (this.options.grouping() === SessionsGrouping.Workspace) {
 			const targetLabel = sessionWorkspaceLabel(target);
 			return dragged.every(s => sessionWorkspaceLabel(s) === targetLabel);
@@ -1571,9 +1996,12 @@ export class SessionsList extends Disposable implements ISessionsList {
 		// Derive neighbours from the actual visible display order (which already
 		// respects filtering and grouping) so the drop slot matches what the user
 		// sees. For workspace grouping only the target's workspace participates;
-		// for date grouping the regular list is one continuous sequence.
+		// for date grouping the regular list is one continuous sequence. When the
+		// target belongs to a group, reordering stays within that group's members.
+		const targetGroup = this._sessionGroupsService.getGroupOfSession(target.sessionId);
 		let scope = this.getVisibleSessions().filter(s => this.isReorderable(s));
-		if (grouping === SessionsGrouping.Workspace) {
+		scope = scope.filter(s => this._sessionGroupsService.getGroupOfSession(s.sessionId) === targetGroup);
+		if (targetGroup === undefined && grouping === SessionsGrouping.Workspace) {
 			const targetLabel = sessionWorkspaceLabel(target);
 			scope = scope.filter(s => sessionWorkspaceLabel(s) === targetLabel);
 		}
@@ -1605,8 +2033,113 @@ export class SessionsList extends Disposable implements ISessionsList {
 		this._sessionsListModelService.applySortChanges(mode, set, clear);
 	}
 
+	// -- Groups --
+
+	/** Create a new group containing the given sessions and start renaming it. */
+	createGroupFromSessions(sessions: ISession[]): void {
+		const reorderable = sessions.filter(s => this.isReorderable(s));
+		const members = reorderable.length > 0 ? reorderable : sessions;
+		const group = this._sessionGroupsService.createGroup(localize('newGroupName', "New Group"), members.map(s => s.sessionId));
+		this._editingGroupId = group.id;
+		this.update();
+	}
+
+	/** Begin inline renaming of the group's header. */
+	beginRenameGroup(groupId: string): void {
+		if (!this._sessionGroupsService.getGroup(groupId)) {
+			return;
+		}
+		this._editingGroupId = groupId;
+		this.update();
+	}
+
+	addSessionsToGroup(sessions: ISession[], groupId: string): void {
+		for (const session of sessions) {
+			this._sessionGroupsService.addToGroup(session.sessionId, groupId);
+		}
+	}
+
+	private commitGroupEdit(group: ISessionGroup, name: string): void {
+		this._editingGroupId = undefined;
+		const trimmed = name.trim();
+		if (trimmed) {
+			this._sessionGroupsService.renameGroup(group.id, trimmed);
+		}
+		this.update();
+	}
+
+	private cancelGroupEdit(_group: ISessionGroup): void {
+		this._editingGroupId = undefined;
+		this.update();
+	}
+
+	/**
+	 * Reorder a group so it lands before/after the target group, persisting a
+	 * synthetic sort key spread between the surrounding groups' representative
+	 * keys. Reuses the session reorder math for a single-item block.
+	 */
+	private reorderGroup(draggedGroupId: string, targetGroupId: string, position: 'before' | 'after'): void {
+		const order = this.getGroupsInDisplayOrder();
+		const repKey = (groupId: string): number => {
+			const group = this._sessionGroupsService.getGroup(groupId);
+			if (group?.sortKeyOverride !== undefined) {
+				return group.sortKeyOverride;
+			}
+			const mode = sortingToMode(this.options.sorting());
+			const memberKeys = this._sessionGroupsService.getSessionIdsInGroup(groupId)
+				.map(id => this.sessions.find(s => s.sessionId === id))
+				.filter((s): s is ISession => !!s)
+				.map(s => this._sessionsListModelService.getSortKey(s, mode));
+			return memberKeys.length > 0 ? Math.max(...memberKeys) : (group?.createdAt ?? Date.now());
+		};
+
+		const remaining = order.filter(g => g.id !== draggedGroupId);
+		const targetIndex = remaining.findIndex(g => g.id === targetGroupId);
+		if (targetIndex === -1) {
+			return;
+		}
+		const insertIndex = position === 'before' ? targetIndex : targetIndex + 1;
+		const above = remaining[insertIndex - 1];
+		const below = remaining[insertIndex];
+
+		const { set, clear } = computeReorderSortChanges({
+			draggedIds: [draggedGroupId],
+			naturalKeys: [repKey(draggedGroupId)],
+			aboveKey: above ? repKey(above.id) : undefined,
+			belowKey: below ? repKey(below.id) : undefined,
+			now: Date.now(),
+			fallbackStep: SORT_FALLBACK_STEP_MS,
+		});
+		for (const id of clear) {
+			this._sessionGroupsService.setGroupSortKey(id, undefined);
+		}
+		for (const [id, value] of set) {
+			this._sessionGroupsService.setGroupSortKey(id, value);
+		}
+	}
+
+	/**
+	 * Groups in their current top-to-bottom display order, computed from member
+	 * representative keys (and manual overrides). Used to keep the "Add to Group"
+	 * menu and group reordering consistent with the list.
+	 */
+	getGroupsInDisplayOrder(): ISessionGroup[] {
+		const mode = sortingToMode(this.options.sorting());
+		const repKey = (group: ISessionGroup): number => {
+			if (group.sortKeyOverride !== undefined) {
+				return group.sortKeyOverride;
+			}
+			const memberKeys = this._sessionGroupsService.getSessionIdsInGroup(group.id)
+				.map(id => this.sessions.find(s => s.sessionId === id))
+				.filter((s): s is ISession => !!s)
+				.map(s => this._sessionsListModelService.getSortKey(s, mode));
+			return memberKeys.length > 0 ? Math.max(...memberKeys) : group.createdAt;
+		};
+		return this._sessionGroupsService.getGroups().sort((a, b) => repKey(b) - repKey(a));
+	}
+
 	private getMultiSelectedSessions(session: ISession): ISession[] {
-		const selection = this.tree.getSelection().filter((s): s is ISession => !!s && !isSessionSection(s) && !isSessionShowMore(s));
+		const selection = this.tree.getSelection().filter((s): s is ISession => !!s && isSessionItem(s));
 		return selection.includes(session) ? [session, ...selection.filter(s => s !== session)] : [session];
 	}
 
@@ -1616,13 +2149,20 @@ export class SessionsList extends Disposable implements ISessionsList {
 			return;
 		}
 
+		if (isSessionGroupItem(element)) {
+			this.showGroupContextMenu(element, e.anchor);
+			return;
+		}
+
 		const selectedSessions = this.getMultiSelectedSessions(element);
 
+		const inGroup = this._sessionGroupsService.getGroupOfSession(element.sessionId) !== undefined;
 		const contextOverlay: [string, boolean | string][] = [
 			[IsSessionPinnedContext.key, this.isSessionPinned(element)],
 			[SessionIsArchivedContext.key, element.isArchived.get()],
 			[SessionIsReadContext.key, this.isSessionRead(element)],
 			[SessionItemHasBranchNameContext.key, !!element.workspace.get()?.folders[0]?.gitRepository?.branchName?.trim()],
+			[SessionItemInGroupContext.key, inGroup],
 			[ChatSessionTypeContext.key, element.sessionType],
 			[ChatSessionProviderIdContext.key, element.providerId],
 			[ChatSessionSupportsRenameContext.key, element.capabilities.supportsRename ?? false],
@@ -1648,12 +2188,66 @@ export class SessionsList extends Disposable implements ISessionsList {
 		};
 
 		this.contextMenuService.showContextMenu({
-			getActions: () => Separator.join(...menu.getActions({ arg: selectedSessions, shouldForwardArgs: true }).map(([, actions]) => actions.map(wrapForExtensions))),
+			getActions: () => {
+				const base = Separator.join(...menu.getActions({ arg: selectedSessions, shouldForwardArgs: true }).map(([, actions]) => actions.map(wrapForExtensions)));
+				const groupActions = this.getGroupSessionActions(selectedSessions);
+				return groupActions.length > 0 ? [...base, new Separator(), ...groupActions] : base;
+			},
 			getAnchor: () => e.anchor,
 			getKeyBinding: (action) => this.keybindingService.lookupKeybinding(action.id) ?? undefined,
 		});
 
 		menu.dispose();
+	}
+
+	/**
+	 * Build the group-related context menu actions for the given session(s):
+	 * "Create Group", an "Add to Group"/"Move to Group" submenu listing the
+	 * groups in display order, and "Remove from Group" when applicable.
+	 */
+	private getGroupSessionActions(selected: ISession[]): IAction[] {
+		const actions: IAction[] = [];
+
+		actions.push(new Action('sessions.createGroup', localize('createGroupAction', "Create Group"), undefined, true, async () => {
+			this.createGroupFromSessions(selected);
+		}));
+
+		const currentGroupIds = new Set(selected.map(s => this._sessionGroupsService.getGroupOfSession(s.sessionId)));
+		const currentGroupId = currentGroupIds.size === 1 ? [...currentGroupIds][0] : undefined;
+
+		const targetGroups = this.getGroupsInDisplayOrder().filter(g => g.id !== currentGroupId);
+		if (targetGroups.length > 0) {
+			const subActions = targetGroups.map(g => new Action(`sessions.addToGroup.${g.id}`, g.name, undefined, true, async () => {
+				this.addSessionsToGroup(selected, g.id);
+			}));
+			const label = currentGroupId !== undefined ? localize('moveToGroupAction', "Move to Group") : localize('addToGroupAction', "Add to Group");
+			actions.push(new SubmenuAction('sessions.addToGroupSubmenu', label, subActions));
+		}
+
+		if (currentGroupId !== undefined) {
+			actions.push(new Action('sessions.removeFromGroup', localize('removeFromGroupAction', "Remove from Group"), undefined, true, async () => {
+				for (const session of selected) {
+					this._sessionGroupsService.removeFromGroup(session.sessionId);
+				}
+			}));
+		}
+
+		return actions;
+	}
+
+	private showGroupContextMenu(groupItem: ISessionGroupItem, anchor: ITreeContextMenuEvent<SessionListItem>['anchor']): void {
+		const actions: IAction[] = [
+			new Action('sessions.renameGroupAction', localize('renameGroupAction', "Rename..."), undefined, true, async () => {
+				this.beginRenameGroup(groupItem.group.id);
+			}),
+			new Action('sessions.deleteGroupAction', localize('deleteGroupAction', "Delete Group"), undefined, true, async () => {
+				this._sessionGroupsService.deleteGroup(groupItem.group.id);
+			}),
+		];
+		this.contextMenuService.showContextMenu({
+			getActions: () => actions,
+			getAnchor: () => anchor,
+		});
 	}
 
 	resetSectionCollapseState(): void {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -21,8 +21,9 @@ import { CLOSE_MOBILE_SIDEBAR_DRAWER_COMMAND_ID } from '../../../../browser/work
 import { EditorsVisibleContext, EditorAreaFocusContext, IsSessionsWindowContext } from '../../../../../workbench/common/contextkeys.js';
 import { SessionsCategories } from '../../../../common/categories.js';
 import { ChatSessionSupportsDeleteContext, ChatSessionSupportsRenameContext, IsActiveSessionArchivedContext, IsNewChatSessionContext, SessionIsArchivedContext, SessionIsCreatedContext, SessionIsReadContext } from '../../../../common/contextkeys.js';
-import { SessionItemToolbarMenuId, SessionItemContextMenuId, SessionSectionToolbarMenuId, SessionSectionTypeContext, IsSessionPinnedContext, SessionsGrouping, SessionsSorting, ISessionSection } from './sessionsList.js';
+import { SessionItemToolbarMenuId, SessionItemContextMenuId, SessionSectionToolbarMenuId, SessionGroupToolbarMenuId, SessionSectionTypeContext, IsSessionPinnedContext, SessionsGrouping, SessionsSorting, ISessionSection, ISessionGroupItem } from './sessionsList.js';
 import { ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
+import { ISessionGroupsService } from '../../../../services/sessions/browser/sessionGroupsService.js';
 import { IsWorkspaceGroupCappedContext, SessionsViewFilterOptionsSubMenu, SessionsViewFilterSubMenu, SessionsViewGroupingContext, SessionsViewId, SessionsView, SessionsViewSortingContext, openSessionToTheSide } from './sessionsView.js';
 import { Menus } from '../../../../browser/menus.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
@@ -537,6 +538,52 @@ registerAction2(class ArchiveSectionAction extends Action2 {
 		for (const session of context.sessions) {
 			await sessionsManagementService.archiveSession(session);
 		}
+	}
+});
+
+//  Group Header Actions
+
+registerAction2(class RenameGroupAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessionsView.renameGroup',
+			title: localize2('renameGroup', "Rename"),
+			icon: Codicon.edit,
+			menu: [{
+				id: SessionGroupToolbarMenuId,
+				group: 'navigation',
+				order: 0,
+			}]
+		});
+	}
+	run(accessor: ServicesAccessor, context?: ISessionGroupItem): void {
+		if (!context) {
+			return;
+		}
+		const viewsService = accessor.get(IViewsService);
+		const view = viewsService.getViewWithId<SessionsView>(SessionsViewId);
+		view?.sessionsControl?.beginRenameGroup(context.group.id);
+	}
+});
+
+registerAction2(class DeleteGroupAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessionsView.deleteGroup',
+			title: localize2('deleteGroup', "Delete Group"),
+			icon: Codicon.trash,
+			menu: [{
+				id: SessionGroupToolbarMenuId,
+				group: 'navigation',
+				order: 1,
+			}]
+		});
+	}
+	run(accessor: ServicesAccessor, context?: ISessionGroupItem): void {
+		if (!context) {
+			return;
+		}
+		accessor.get(ISessionGroupsService).deleteGroup(context.group.id);
 	}
 });
 

--- a/src/vs/sessions/services/sessions/browser/sessionGroupsService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionGroupsService.ts
@@ -66,7 +66,7 @@ export interface ISessionGroupsService {
 	getGroup(groupId: string): ISessionGroup | undefined;
 
 	/**
-	 * Create a new group with an optional name. Returns the created group. When
+	 * Create a new group with the given name. Returns the created group. When
 	 * `memberSessionIds` are given they are added to the new group.
 	 */
 	createGroup(name: string, memberSessionIds?: Iterable<string>): ISessionGroup;
@@ -142,9 +142,9 @@ export class SessionGroupsService extends Disposable implements ISessionGroupsSe
 				}
 			}
 			if (changed.size > 0) {
-				this.evictExcessEmptyGroups();
+				const evicted = this.evictExcessEmptyGroups();
 				this.save();
-				this._onDidChange.fire({ groupsChanged: false, membershipChanged: changed });
+				this._onDidChange.fire({ groupsChanged: evicted, membershipChanged: changed });
 			}
 		}));
 	}
@@ -205,18 +205,18 @@ export class SessionGroupsService extends Disposable implements ISessionGroupsSe
 		}
 		const membershipChanged = new Set<string>();
 		this.setMembership(sessionId, groupId, membershipChanged);
-		this.evictExcessEmptyGroups();
+		const evicted = this.evictExcessEmptyGroups();
 		this.save();
-		this._onDidChange.fire({ groupsChanged: false, membershipChanged });
+		this._onDidChange.fire({ groupsChanged: evicted, membershipChanged });
 	}
 
 	removeFromGroup(sessionId: string): void {
 		if (!this._membership.delete(sessionId)) {
 			return;
 		}
-		this.evictExcessEmptyGroups();
+		const evicted = this.evictExcessEmptyGroups();
 		this.save();
-		this._onDidChange.fire({ groupsChanged: false, membershipChanged: new Set([sessionId]) });
+		this._onDidChange.fire({ groupsChanged: evicted, membershipChanged: new Set([sessionId]) });
 	}
 
 	getGroupOfSession(sessionId: string): string | undefined {
@@ -263,15 +263,19 @@ export class SessionGroupsService extends Disposable implements ISessionGroupsSe
 
 	/**
 	 * Keep at most {@link MAX_EMPTY_GROUPS} groups with no members, evicting the
-	 * oldest empty groups (by `createdAt`) beyond that cap.
+	 * oldest empty groups (by `createdAt`) beyond that cap. Returns whether any
+	 * group was deleted.
 	 */
-	private evictExcessEmptyGroups(): void {
+	private evictExcessEmptyGroups(): boolean {
 		const empty = [...this._groups.values()]
 			.filter(group => !this.hasMembers(group.id))
 			.sort((a, b) => a.createdAt - b.createdAt);
+		let deleted = false;
 		for (let i = 0; i < empty.length - SessionGroupsService.MAX_EMPTY_GROUPS; i++) {
 			this._groups.delete(empty[i].id);
+			deleted = true;
 		}
+		return deleted;
 	}
 
 	/**

--- a/src/vs/sessions/services/sessions/browser/sessionGroupsService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionGroupsService.ts
@@ -1,0 +1,356 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { ISessionsManagementService } from '../common/sessionsManagement.js';
+
+/**
+ * A user-created group of sessions in the sessions list. Groups render like
+ * section headers and can be reordered, renamed and deleted. Membership of a
+ * session in a group is tracked separately (see {@link ISessionGroupsService}).
+ */
+export interface ISessionGroup {
+	/** Stable identifier (uuid). */
+	readonly id: string;
+	/** User-provided display name. */
+	readonly name: string;
+	/**
+	 * Manual sort-key override applied when the user drags a group to reorder
+	 * it. `undefined` means the group falls back to its natural placement (the
+	 * best/highest sort key among its members). Expressed in the same numeric
+	 * space as session sort keys (timestamps) so groups interleave with the
+	 * date/workspace sections. Higher values sort higher in the list.
+	 */
+	readonly sortKeyOverride: number | undefined;
+	/** Creation timestamp (ms). Used to evict the oldest empty group. */
+	readonly createdAt: number;
+}
+
+export interface ISessionGroupsChangeEvent {
+	/** Groups added, removed, renamed or reordered. */
+	readonly groupsChanged: boolean;
+	/** Session ids whose group membership changed. */
+	readonly membershipChanged: ReadonlySet<string>;
+}
+
+/**
+ * Service that owns user-created session groups and the mapping of sessions to
+ * groups. State is purely local (persisted to profile storage) and not synced
+ * to providers.
+ *
+ * A session belongs to at most one group. Group membership is independent of
+ * where the session renders: a grouped session that becomes pinned or archived
+ * is rendered in the Pinned/Done section but retains its membership, so it
+ * returns to the group once unpinned/restored.
+ */
+export interface ISessionGroupsService {
+	readonly _serviceBrand: undefined;
+
+	/** Fires when groups or membership change. */
+	readonly onDidChange: Event<ISessionGroupsChangeEvent>;
+
+	/**
+	 * All groups in display order (including currently-empty ones). The list
+	 * view omits groups with no visible members when rendering.
+	 */
+	getGroups(): ISessionGroup[];
+
+	/** Look up a group by id (including currently-empty groups). */
+	getGroup(groupId: string): ISessionGroup | undefined;
+
+	/**
+	 * Create a new group with an optional name. Returns the created group. When
+	 * `memberSessionIds` are given they are added to the new group.
+	 */
+	createGroup(name: string, memberSessionIds?: Iterable<string>): ISessionGroup;
+
+	/** Rename an existing group. No-op if the group does not exist. */
+	renameGroup(groupId: string, name: string): void;
+
+	/** Delete a group and remove all of its members' membership. */
+	deleteGroup(groupId: string): void;
+
+	/** Add a session to a group (removing it from any previous group). */
+	addToGroup(sessionId: string, groupId: string): void;
+
+	/** Remove a session from its group, if any. */
+	removeFromGroup(sessionId: string): void;
+
+	/** The id of the group the session belongs to, or `undefined`. */
+	getGroupOfSession(sessionId: string): string | undefined;
+
+	/** The session ids that belong to the given group. */
+	getSessionIdsInGroup(groupId: string): string[];
+
+	/**
+	 * Persist a manual sort-key override for a group (or clear it with
+	 * `undefined`). Used when the user drags a group to reorder it.
+	 */
+	setGroupSortKey(groupId: string, sortKeyOverride: number | undefined): void;
+}
+
+export const ISessionGroupsService = createDecorator<ISessionGroupsService>('sessionGroupsService');
+
+interface ISerializedState {
+	readonly groups: readonly ISessionGroup[];
+	/** sessionId -> groupId */
+	readonly membership: Readonly<Record<string, string>>;
+}
+
+export class SessionGroupsService extends Disposable implements ISessionGroupsService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private static readonly STORAGE_KEY = 'sessionsListControl.groups';
+
+	/**
+	 * Maximum number of empty groups (no members) retained in storage. When a
+	 * new empty group would exceed this, the oldest empty group is evicted.
+	 */
+	private static readonly MAX_EMPTY_GROUPS = 3;
+
+	private readonly _onDidChange = this._register(new Emitter<ISessionGroupsChangeEvent>());
+	readonly onDidChange: Event<ISessionGroupsChangeEvent> = this._onDidChange.event;
+
+	private readonly _groups = new Map<string, ISessionGroup>();
+	/** sessionId -> groupId */
+	private readonly _membership = new Map<string, string>();
+
+	constructor(
+		@IStorageService private readonly storageService: IStorageService,
+		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
+	) {
+		super();
+
+		this.load();
+
+		this._register(this.sessionsManagementService.onDidChangeSessions(e => {
+			if (e.removed.length === 0) {
+				return;
+			}
+			const changed = new Set<string>();
+			for (const session of e.removed) {
+				if (this._membership.delete(session.sessionId)) {
+					changed.add(session.sessionId);
+				}
+			}
+			if (changed.size > 0) {
+				this.evictExcessEmptyGroups();
+				this.save();
+				this._onDidChange.fire({ groupsChanged: false, membershipChanged: changed });
+			}
+		}));
+	}
+
+	getGroups(): ISessionGroup[] {
+		return this.sortGroups([...this._groups.values()]);
+	}
+
+	getGroup(groupId: string): ISessionGroup | undefined {
+		return this._groups.get(groupId);
+	}
+
+	createGroup(name: string, memberSessionIds?: Iterable<string>): ISessionGroup {
+		const group: ISessionGroup = { id: generateUuid(), name, sortKeyOverride: undefined, createdAt: Date.now() };
+		this._groups.set(group.id, group);
+
+		const membershipChanged = new Set<string>();
+		if (memberSessionIds) {
+			for (const sessionId of memberSessionIds) {
+				this.setMembership(sessionId, group.id, membershipChanged);
+			}
+		}
+
+		this.evictExcessEmptyGroups();
+		this.save();
+		this._onDidChange.fire({ groupsChanged: true, membershipChanged });
+		return group;
+	}
+
+	renameGroup(groupId: string, name: string): void {
+		const group = this._groups.get(groupId);
+		if (!group || group.name === name) {
+			return;
+		}
+		this._groups.set(groupId, { ...group, name });
+		this.save();
+		this._onDidChange.fire({ groupsChanged: true, membershipChanged: new Set() });
+	}
+
+	deleteGroup(groupId: string): void {
+		if (!this._groups.delete(groupId)) {
+			return;
+		}
+		const membershipChanged = new Set<string>();
+		for (const [sessionId, gid] of this._membership) {
+			if (gid === groupId) {
+				this._membership.delete(sessionId);
+				membershipChanged.add(sessionId);
+			}
+		}
+		this.save();
+		this._onDidChange.fire({ groupsChanged: true, membershipChanged });
+	}
+
+	addToGroup(sessionId: string, groupId: string): void {
+		if (!this._groups.has(groupId) || this._membership.get(sessionId) === groupId) {
+			return;
+		}
+		const membershipChanged = new Set<string>();
+		this.setMembership(sessionId, groupId, membershipChanged);
+		this.evictExcessEmptyGroups();
+		this.save();
+		this._onDidChange.fire({ groupsChanged: false, membershipChanged });
+	}
+
+	removeFromGroup(sessionId: string): void {
+		if (!this._membership.delete(sessionId)) {
+			return;
+		}
+		this.evictExcessEmptyGroups();
+		this.save();
+		this._onDidChange.fire({ groupsChanged: false, membershipChanged: new Set([sessionId]) });
+	}
+
+	getGroupOfSession(sessionId: string): string | undefined {
+		return this._membership.get(sessionId);
+	}
+
+	getSessionIdsInGroup(groupId: string): string[] {
+		const result: string[] = [];
+		for (const [sessionId, gid] of this._membership) {
+			if (gid === groupId) {
+				result.push(sessionId);
+			}
+		}
+		return result;
+	}
+
+	setGroupSortKey(groupId: string, sortKeyOverride: number | undefined): void {
+		const group = this._groups.get(groupId);
+		if (!group || group.sortKeyOverride === sortKeyOverride) {
+			return;
+		}
+		this._groups.set(groupId, { ...group, sortKeyOverride });
+		this.save();
+		this._onDidChange.fire({ groupsChanged: true, membershipChanged: new Set() });
+	}
+
+	// -- Helpers --
+
+	private setMembership(sessionId: string, groupId: string, changed: Set<string>): void {
+		if (this._membership.get(sessionId) !== groupId) {
+			this._membership.set(sessionId, groupId);
+			changed.add(sessionId);
+		}
+	}
+
+	private hasMembers(groupId: string): boolean {
+		for (const gid of this._membership.values()) {
+			if (gid === groupId) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Keep at most {@link MAX_EMPTY_GROUPS} groups with no members, evicting the
+	 * oldest empty groups (by `createdAt`) beyond that cap.
+	 */
+	private evictExcessEmptyGroups(): void {
+		const empty = [...this._groups.values()]
+			.filter(group => !this.hasMembers(group.id))
+			.sort((a, b) => a.createdAt - b.createdAt);
+		for (let i = 0; i < empty.length - SessionGroupsService.MAX_EMPTY_GROUPS; i++) {
+			this._groups.delete(empty[i].id);
+		}
+	}
+
+	/**
+	 * Sort groups for display as a stable baseline: groups with a manual
+	 * `sortKeyOverride` first (highest key first), then the rest by creation
+	 * time (newest first). The list view computes the final interleaved
+	 * placement using member sort keys; this baseline is used where member keys
+	 * are not available (e.g. the "Add to Group" menu fallback).
+	 */
+	private sortGroups(groups: ISessionGroup[]): ISessionGroup[] {
+		return groups.sort((a, b) => {
+			const aHas = a.sortKeyOverride !== undefined;
+			const bHas = b.sortKeyOverride !== undefined;
+			if (aHas && bHas) {
+				return b.sortKeyOverride! - a.sortKeyOverride!;
+			}
+			if (aHas !== bHas) {
+				return aHas ? -1 : 1;
+			}
+			return b.createdAt - a.createdAt;
+		});
+	}
+
+	// -- Storage --
+
+	private load(): void {
+		const raw = this.storageService.get(SessionGroupsService.STORAGE_KEY, StorageScope.PROFILE);
+		if (!raw) {
+			return;
+		}
+		try {
+			const parsed = JSON.parse(raw) as Partial<ISerializedState>;
+			if (Array.isArray(parsed.groups)) {
+				for (const group of parsed.groups) {
+					if (group && typeof group.id === 'string' && typeof group.name === 'string') {
+						this._groups.set(group.id, {
+							id: group.id,
+							name: group.name,
+							sortKeyOverride: typeof group.sortKeyOverride === 'number' ? group.sortKeyOverride : undefined,
+							createdAt: typeof group.createdAt === 'number' ? group.createdAt : Date.now(),
+						});
+					}
+				}
+			}
+			if (parsed.membership && typeof parsed.membership === 'object') {
+				for (const [sessionId, groupId] of Object.entries(parsed.membership)) {
+					if (typeof groupId === 'string' && this._groups.has(groupId)) {
+						this._membership.set(sessionId, groupId);
+					}
+				}
+			}
+		} catch {
+			// ignore corrupt data
+		}
+	}
+
+	private save(): void {
+		if (this._groups.size === 0) {
+			this.storageService.remove(SessionGroupsService.STORAGE_KEY, StorageScope.PROFILE);
+			return;
+		}
+		const state: ISerializedState = {
+			groups: [...this._groups.values()],
+			membership: Object.fromEntries(this._membership),
+		};
+		this.storageService.store(SessionGroupsService.STORAGE_KEY, JSON.stringify(state), StorageScope.PROFILE, StorageTarget.USER);
+	}
+}
+
+/**
+ * Best (highest) sort key among a group's currently-visible members, used to
+ * place the group among the other top-level list items. Returns `undefined`
+ * when the group has no visible members.
+ */
+export function groupSortKey(memberKeys: readonly number[]): number | undefined {
+	if (memberKeys.length === 0) {
+		return undefined;
+	}
+	return Math.max(...memberKeys);
+}
+
+registerSingleton(ISessionGroupsService, SessionGroupsService, InstantiationType.Delayed);

--- a/src/vs/sessions/services/sessions/test/browser/sessionGroupsService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionGroupsService.test.ts
@@ -1,0 +1,163 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { Emitter } from '../../../../../base/common/event.js';
+import { constObservable, observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IStorageService, InMemoryStorageService } from '../../../../../platform/storage/common/storage.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { IChat, ISession, SessionStatus } from '../../common/session.js';
+import { ISessionsChangeEvent, ISessionsManagementService } from '../../common/sessionsManagement.js';
+import { groupSortKey, SessionGroupsService } from '../../browser/sessionGroupsService.js';
+
+function createSession(id: string): ISession {
+	return {
+		sessionId: id,
+		resource: URI.parse(`session://${id}`),
+		providerId: 'test',
+		sessionType: 'test',
+		icon: Codicon.account,
+		createdAt: new Date(),
+		workspace: observableValue(`workspace-${id}`, undefined),
+		title: observableValue(`title-${id}`, id),
+		updatedAt: observableValue(`updatedAt-${id}`, new Date()),
+		status: observableValue(`status-${id}`, SessionStatus.Completed),
+		changesets: observableValue(`changesets-${id}`, []),
+		changes: observableValue(`changes-${id}`, []),
+		modelId: observableValue(`modelId-${id}`, undefined),
+		mode: observableValue(`mode-${id}`, undefined),
+		loading: observableValue(`loading-${id}`, false),
+		isArchived: observableValue(`isArchived-${id}`, false),
+		isRead: observableValue(`isRead-${id}`, true),
+		description: observableValue(`description-${id}`, undefined),
+		lastTurnEnd: observableValue(`lastTurnEnd-${id}`, undefined),
+		chats: observableValue<readonly IChat[]>(`chats-${id}`, []),
+		mainChat: constObservable<IChat>(undefined!),
+		capabilities: { supportsMultipleChats: false },
+	};
+}
+
+suite('SessionGroupsService', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+	let service: SessionGroupsService;
+	let storageService: InMemoryStorageService;
+	let sessionsChangedEmitter: Emitter<ISessionsChangeEvent>;
+	let instantiationService: TestInstantiationService;
+
+	setup(() => {
+		instantiationService = disposables.add(new TestInstantiationService());
+		storageService = disposables.add(new InMemoryStorageService());
+		instantiationService.stub(IStorageService, storageService);
+		sessionsChangedEmitter = disposables.add(new Emitter<ISessionsChangeEvent>());
+		instantiationService.stub(ISessionsManagementService, {
+			...mock<ISessionsManagementService>(),
+			onDidChangeSessions: sessionsChangedEmitter.event,
+		});
+		service = disposables.add(instantiationService.createInstance(SessionGroupsService));
+	});
+
+	test('create group with members and look up membership', () => {
+		const group = service.createGroup('Group A', ['s1', 's2']);
+
+		assert.strictEqual(service.getGroup(group.id)?.name, 'Group A');
+		assert.strictEqual(service.getGroupOfSession('s1'), group.id);
+		assert.strictEqual(service.getGroupOfSession('s2'), group.id);
+		assert.deepStrictEqual(service.getSessionIdsInGroup(group.id).sort(), ['s1', 's2']);
+	});
+
+	test('a session belongs to at most one group; adding moves it', () => {
+		const a = service.createGroup('A', ['s1']);
+		const b = service.createGroup('B');
+
+		service.addToGroup('s1', b.id);
+
+		assert.strictEqual(service.getGroupOfSession('s1'), b.id);
+		assert.deepStrictEqual(service.getSessionIdsInGroup(a.id), []);
+		assert.deepStrictEqual(service.getSessionIdsInGroup(b.id), ['s1']);
+	});
+
+	test('remove from group clears membership', () => {
+		const a = service.createGroup('A', ['s1', 's2']);
+		service.removeFromGroup('s1');
+
+		assert.strictEqual(service.getGroupOfSession('s1'), undefined);
+		assert.deepStrictEqual(service.getSessionIdsInGroup(a.id), ['s2']);
+	});
+
+	test('rename group', () => {
+		const a = service.createGroup('A');
+		service.renameGroup(a.id, 'Renamed');
+		assert.strictEqual(service.getGroup(a.id)?.name, 'Renamed');
+	});
+
+	test('delete group removes group and membership', () => {
+		const a = service.createGroup('A', ['s1', 's2']);
+		service.deleteGroup(a.id);
+
+		assert.strictEqual(service.getGroup(a.id), undefined);
+		assert.strictEqual(service.getGroupOfSession('s1'), undefined);
+		assert.strictEqual(service.getGroupOfSession('s2'), undefined);
+	});
+
+	test('membership is cleaned up when a session is removed', () => {
+		const a = service.createGroup('A', ['s1', 's2']);
+		const session = createSession('s1');
+		sessionsChangedEmitter.fire({ added: [], removed: [session], changed: [] });
+
+		assert.strictEqual(service.getGroupOfSession('s1'), undefined);
+		assert.deepStrictEqual(service.getSessionIdsInGroup(a.id), ['s2']);
+	});
+
+	test('empty groups are capped at 3, evicting the oldest', () => {
+		// Four empty groups created in order; the oldest (g1) should be evicted.
+		const g1 = service.createGroup('1');
+		const g2 = service.createGroup('2');
+		const g3 = service.createGroup('3');
+		const g4 = service.createGroup('4');
+
+		const ids = service.getGroups().map(g => g.id);
+		assert.strictEqual(ids.includes(g1.id), false);
+		assert.deepStrictEqual([g2, g3, g4].map(g => ids.includes(g.id)), [true, true, true]);
+	});
+
+	test('non-empty groups are never evicted by the empty cap', () => {
+		const kept = service.createGroup('kept', ['s1']);
+		service.createGroup('e1');
+		service.createGroup('e2');
+		service.createGroup('e3');
+		service.createGroup('e4');
+
+		assert.strictEqual(service.getGroup(kept.id)?.name, 'kept');
+		assert.strictEqual(service.getGroups().filter(g => service.getSessionIdsInGroup(g.id).length === 0).length, 3);
+	});
+
+	test('setGroupSortKey overrides placement and persists', () => {
+		const a = service.createGroup('A', ['s1']);
+		service.setGroupSortKey(a.id, 12345);
+		assert.strictEqual(service.getGroup(a.id)?.sortKeyOverride, 12345);
+
+		const reloaded = disposables.add(instantiationService.createInstance(SessionGroupsService));
+		assert.strictEqual(reloaded.getGroup(a.id)?.sortKeyOverride, 12345);
+	});
+
+	test('state persists across reload', () => {
+		const a = service.createGroup('Persisted', ['s1', 's2']);
+
+		const reloaded = disposables.add(instantiationService.createInstance(SessionGroupsService));
+		assert.strictEqual(reloaded.getGroup(a.id)?.name, 'Persisted');
+		assert.strictEqual(reloaded.getGroupOfSession('s1'), a.id);
+		assert.strictEqual(reloaded.getGroupOfSession('s2'), a.id);
+	});
+
+	test('groupSortKey returns the highest member key', () => {
+		assert.strictEqual(groupSortKey([10, 50, 30]), 50);
+		assert.strictEqual(groupSortKey([]), undefined);
+	});
+});

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -463,6 +463,7 @@ import './contrib/providers/copilotChatSessions/browser/copilotChatSessions.cont
 import './contrib/providers/localChatSessions/browser/localChatSessions.contribution.js';
 import './contrib/sessions/browser/sessions.contribution.js';
 import './services/sessions/browser/sessionsListModelService.js';
+import './services/sessions/browser/sessionGroupsService.js';
 import './services/agentHostFilter/browser/agentHostFilterService.js';
 import './contrib/sessions/browser/customizationsToolbar.contribution.js';
 import './contrib/changes/browser/changes.contribution.js';


### PR DESCRIPTION
Adds support for grouping sessions together in the sessions list (Agents window).

## What's included
- **New `ISessionGroupsService`** (`services/sessions/browser/sessionGroupsService.ts`): owns user-created groups and a `sessionId → groupId` membership map (one group per session). Persists to profile storage, cleans up membership when sessions are removed, and caps empty groups at 3 (evicting the oldest).
- **Group rendering**: a new `ISessionGroupItem` list-item type and `SessionGroupRenderer` that renders like a section header, with an inline name editor (on create/rename) and a hover toolbar (Rename/Delete).
- **Placement & sorting**: grouped sessions are pulled out of the normal Date/Workspace sections. In Date mode groups interleave among the date sections by their best member's sort key; in Workspace mode they render as a block after Pinned. Members are sorted by the normal logic. Pinned/Done take precedence — a pinned/archived session renders in those sections but keeps its membership and returns to the group when unpinned/restored.
- **Drag & drop**: dropping a session onto a group adds it, highlighting the whole group (header + members) with no insertion line; dragging a group header reorders groups. Within-group reordering is scoped to the group.
- **Context menus**: "Create Group", an "Add to Group"/"Move to Group" submenu (groups in list order), and "Remove from Group" on session items; Rename/Delete on group headers.
- Group collapse state and ordering are persisted; reloading the window keeps groups and their sessions.

## Validation
- `typecheck-client`, `valid-layers-check`, ESLint all pass.
- New service unit tests (11) and existing SessionsList helper tests (17) pass.

## Open design decisions (confirmed during implementation)
1. Groups interleave among Date/Workspace sections by best member key; Pinned top, Done bottom.
2. Pinning/Done moves a session into those sections but retains group membership.
3. One group per session; groups apply in both grouping modes.
4. Empty groups hidden but kept in storage, capped at 3 (evict oldest).
5. "Create Group" seeds the new group with the selected session(s) and focuses the inline name input.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>