### PR TITLE
inline edit: remove noisy outcome transition console warning

### DIFF
--- a/extensions/copilot/src/platform/inlineEdits/common/inlineEditLogContext.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/inlineEditLogContext.ts
@@ -412,18 +412,7 @@ export class InlineEditRequestLogContext {
 
 	private _outcome: LogContextOutcome = 'pending';
 
-	/**
-	 * Sets the outcome, warning if already set (i.e., not `pending`).
-	 * Use direct `this._outcome = ...` assignment to bypass the guard
-	 * (e.g., in `setIsCachedResult` which intentionally overrides any inherited outcome).
-	 */
 	private _setOutcome(outcome: LogContextOutcome): void {
-		// 'reusedInFlight' is an intermediate state set when joining an in-flight
-		// request (before the result arrives), so it can legitimately transition
-		// to the final outcome (skipped, errored, etc.) just like 'pending'.
-		if (this._outcome !== 'pending' && this._outcome !== 'reusedInFlight') {
-			console.warn(`[InlineEditRequestLogContext] outcome transition from '${this._outcome}' to '${outcome}' (request #${this.requestId})`);
-		}
 		this._outcome = outcome;
 	}
 
@@ -465,9 +454,7 @@ export class InlineEditRequestLogContext {
 	}
 
 	public markAsPreviouslyRejected() {
-		// Direct assignment — bypasses _setOutcome guard because this transition
-		// legitimately overrides 'succeeded' when a fetched edit turns out to be rejected.
-		this._outcome = 'previouslyRejected';
+		this._setOutcome('previouslyRejected');
 		this._isVisible = true;
 		this.fireDidChange();
 	}


### PR DESCRIPTION
Fixes #322547

## Problem

The Copilot extension was flooding the VS Code extension-host developer console with warnings during normal inline-edit (NES) usage:

```
[Extension Host] [InlineEditRequestLogContext] outcome transition from 'skipped' to 'skipped' (request #5)
```

## Root cause

In `inlineEditLogContext.ts`, `_setOutcome()` carried an invariant check intended to catch an *illegal* overwrite of one final outcome by a *different* one. However, it also fired for harmless **no-op self-transitions** (e.g. `'skipped'` → `'skipped'`), which happen legitimately because more than one code path can mark the same request as skipped/cancelled (e.g. `GotCancelled` → `setIsSkipped()`, and `setError()` with a `FetchCancellationError` also maps to `'skipped'`). Setting the same value twice is behaviorally harmless but logged on every occurrence.

## Fix

Remove the `console.warn` and its guard, leaving `_setOutcome` as a plain setter. `markAsPreviouslyRejected()` now routes through `_setOutcome` for consistency (identical behavior now that the guard is gone), and its stale comment referencing the removed guard was dropped.

The unrelated `markCompleted called twice` warning is intentionally left untouched.

## Validation

Dependencies are not installed in the authoring environment, so the extension typecheck/build was not run here; the change only deletes lines and is type-safe by inspection (`'previouslyRejected'` is a valid `LogContextOutcome`). CI will validate.