### PR TITLE
sessions: add CI failures and created-comments banners above the chat input

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -721,6 +721,10 @@
 			"project": "vscode-sessions"
 		},
 		{
+			"name": "vs/sessions/contrib/sessionInputBanners",
+			"project": "vscode-sessions"
+		},
+		{
 			"name": "vs/sessions/contrib/terminal",
 			"project": "vscode-sessions"
 		},

--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -68,6 +68,7 @@ import { PANEL_SECTION_BORDER } from '../../../../workbench/common/theme.js';
 import { EditorResourceAccessor, SideBySideEditor } from '../../../../workbench/common/editor.js';
 import { logChangesViewFileSelect, logChangesViewVersionModeChange, logChangesViewViewModeChange } from '../../../common/sessionsTelemetry.js';
 import { ChecksViewModel } from './checksViewModel.js';
+import { REVEAL_CI_CHECKS_COMMAND_ID } from './checksActions.js';
 // eslint-disable-next-line local/code-import-patterns -- TODO: move skill button constants out of providers
 import { AGENT_HOST_SKILL_BUTTON_UPDATE_PR_ID, isAgentHostSkillButtonId } from '../../providers/agentHost/browser/agentHostSkillButtons.js';
 import { ActiveSessionContextKeys, CHANGES_VIEW_CONTAINER_ID, CHANGES_VIEW_ID, ChangesContextKeys, ChangesViewMode, IsolationMode, SESSIONS_CHANGES_OPEN_SINGLE_FILE_DIFF_SETTING } from '../common/changes.js';
@@ -1125,6 +1126,18 @@ export class ChangesViewPane extends ViewPane {
 		await this._openMultiFileDiffEditor(resource);
 	}
 
+	/**
+	 * Reveal the CI checks section: expand it if collapsed and move keyboard
+	 * focus into it. No-op when there are no checks to show.
+	 */
+	revealChecks(): void {
+		if (!this.ciStatusWidget || !this.ciStatusWidget.visible) {
+			return;
+		}
+		this.ciStatusWidget.expand();
+		this.ciStatusWidget.focus();
+	}
+
 	private async _openFileItem(item: IChangesFileItem, items: IChangesFileItem[], sideBySide: boolean, preserveFocus: boolean, pinned: boolean, includeSidebar: boolean): Promise<void> {
 		const { uri: modifiedFileUri, originalUri, isDeletion } = item;
 		const currentIndex = items.indexOf(item);
@@ -1496,6 +1509,30 @@ class ChangesDiffStatsAction extends Action2 {
 	}
 }
 registerAction2(ChangesDiffStatsAction);
+
+/**
+ * Opens the Changes view and reveals (expands + focuses) the CI checks section.
+ * Used by the CI failures banner above the chat input.
+ */
+class RevealCIChecksAction extends Action2 {
+	static readonly ID = REVEAL_CI_CHECKS_COMMAND_ID;
+
+	constructor() {
+		super({
+			id: RevealCIChecksAction.ID,
+			title: localize2('revealChecks', 'Reveal Checks'),
+			category: CHAT_CATEGORY,
+			f1: false,
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const viewsService = accessor.get(IViewsService);
+		const view = await viewsService.openView<ChangesViewPane>(CHANGES_VIEW_ID, true);
+		view?.revealChecks();
+	}
+}
+registerAction2(RevealCIChecksAction);
 
 class ChangesDiffStatsActionItem extends ActionViewItem {
 	private readonly diffStatsObs: IObservable<{ files: number; insertions: number; deletions: number } | undefined>;

--- a/src/vs/sessions/contrib/changes/browser/checksActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/checksActions.ts
@@ -21,6 +21,12 @@ import { GitHubCheckConclusion, GitHubCheckStatus, IGitHubCICheck } from '../../
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 export const hasActiveSessionFailedCIChecks = new RawContextKey<boolean>('sessions.hasActiveSessionFailedCIChecks', false);
 
+/** Command that sends the `fix-ci` prompt for the active session's failed checks. */
+export const FIX_CI_CHECKS_COMMAND_ID = 'sessions.action.fixCIChecks';
+
+/** Command that opens the Changes view and reveals (expands + focuses) the CI checks section. */
+export const REVEAL_CI_CHECKS_COMMAND_ID = 'sessions.action.revealCIChecks';
+
 /** Slash command that invokes the built-in `fix-ci` skill. */
 const FIX_CI_QUERY = '/fix-ci';
 
@@ -128,7 +134,7 @@ class ActiveSessionFailedCIChecksContextContribution extends Disposable implemen
 
 class FixCIChecksAction extends Action2 {
 
-	static readonly ID = 'sessions.action.fixCIChecks';
+	static readonly ID = FIX_CI_CHECKS_COMMAND_ID;
 
 	constructor() {
 		super({

--- a/src/vs/sessions/contrib/changes/browser/checksWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/checksWidget.ts
@@ -395,6 +395,34 @@ export class CIStatusWidget extends Disposable {
 		this._onDidChangeHeight.fire();
 	}
 
+	/**
+	 * Expand the body if it is currently collapsed, notifying listeners so the
+	 * parent pane restores its size. No-op when already expanded.
+	 */
+	expand(): void {
+		if (!this._collapsed) {
+			return;
+		}
+		this._setCollapsed(false);
+		this._onDidToggleCollapsed.fire(false);
+		this._onDidChangeHeight.fire();
+	}
+
+	/**
+	 * Move keyboard focus into the checks list. Falls back to the header when
+	 * the body is collapsed or there is nothing to focus.
+	 */
+	focus(): void {
+		if (this._collapsed || this._checkCount === 0) {
+			this._headerNode.focus();
+			return;
+		}
+		this._list.domFocus();
+		if (this._list.length > 0 && this._list.getFocus().length === 0) {
+			this._list.setFocus([0]);
+		}
+	}
+
 	private _setCollapsed(collapsed: boolean): void {
 		this._collapsed = collapsed;
 		this._updateChevron();

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -22,6 +22,7 @@ import { IChat } from '../../../services/sessions/common/session.js';
 import { IChatViewFactory } from '../../../services/chatView/browser/chatViewFactory.js';
 import { NewChatWidget } from './newChatWidget.js';
 import { NewChatInSessionWidget } from './newChatInSessionWidget.js';
+import { SessionInputBanners } from '../../sessionInputBanners/browser/sessionInputBanners.js';
 import { AGENT_SESSIONS_SCOPED_INPUT_HISTORY_SETTING } from './sessionsChatHistory.js';
 import { activeSessionViewBackground, activeSessionViewForeground, agentsPanelBackground, inactiveSessionViewBackground, inactiveSessionViewForeground } from '../../../common/theme.js';
 import { isEqual } from '../../../../base/common/resources.js';
@@ -101,6 +102,9 @@ export class ChatView extends AbstractChatView {
 
 	private readonly _widget: ChatWidget;
 
+	/** Session banners (CI failures, created comments) shown above the chat input. */
+	private readonly _banners: SessionInputBanners;
+
 	/** Reference to the loaded chat model; disposing releases the model. */
 	private readonly _modelRef = this._register(new MutableDisposable<IChatModelReference>());
 
@@ -153,6 +157,11 @@ export class ChatView extends AbstractChatView {
 		));
 		this._widget.render(this.element);
 		this._widget.setVisible(true);
+
+		// Mount the session banners directly above the chat input.
+		this._banners = this._register(instantiationService.createInstance(SessionInputBanners));
+		this._banners.setActive(this._isActive);
+		this._ensureBannersMounted();
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(AGENT_SESSIONS_SCOPED_INPUT_HISTORY_SETTING)) {
@@ -256,7 +265,22 @@ export class ChatView extends AbstractChatView {
 	}
 
 	protected override doLayout(width: number, height: number, _top: number, _left: number): void {
+		this._ensureBannersMounted();
 		this._widget.layout(height, width);
+	}
+
+	/**
+	 * Mounts the session banners as the first child of the chat input part, so
+	 * they render above the input alongside the other above-input widgets
+	 * (notifications, goal banner, etc.). Idempotent — re-runs cheaply on layout
+	 * to recover if the chat widget rebuilds its input part DOM.
+	 */
+	private _ensureBannersMounted(): void {
+		const inputPartElement = this._widget.inputPart.element;
+		const node = this._banners.domNode;
+		if (inputPartElement.firstChild !== node) {
+			inputPartElement.insertBefore(node, inputPartElement.firstChild);
+		}
 	}
 
 	override focus(): void {
@@ -274,6 +298,7 @@ export class ChatView extends AbstractChatView {
 			return;
 		}
 		this._isActive = active;
+		this._banners.setActive(active);
 		this._widget.setStyles(this._buildStyles(active));
 	}
 }

--- a/src/vs/sessions/contrib/sessionInputBanners/browser/media/sessionInputBanners.css
+++ b/src/vs/sessions/contrib/sessionInputBanners/browser/media/sessionInputBanners.css
@@ -77,9 +77,9 @@
 	white-space: nowrap;
 }
 
-/* Transparent ghost style for secondary action buttons (e.g. "Reveal Checks"). */
+/* Outlined ghost style for secondary action buttons (e.g. "Reveal Checks"). */
 .session-input-banner .session-input-banner-action.secondary {
-	border: none;
+	border: var(--vscode-strokeThickness) solid var(--vscode-button-secondaryBackground, var(--vscode-button-border, var(--vscode-contrastBorder)));
 	background: transparent;
 	color: var(--vscode-foreground);
 	opacity: 0.8;

--- a/src/vs/sessions/contrib/sessionInputBanners/browser/media/sessionInputBanners.css
+++ b/src/vs/sessions/contrib/sessionInputBanners/browser/media/sessionInputBanners.css
@@ -23,7 +23,7 @@
 	min-width: 0;
 	box-sizing: border-box;
 	padding: 4px 6px 4px 10px;
-	border: 1px solid var(--vscode-input-border, transparent);
+	border: var(--vscode-strokeThickness) solid var(--vscode-input-border, transparent);
 	border-radius: var(--vscode-cornerRadius-small, 4px);
 	background-color: color-mix(in srgb, var(--vscode-focusBorder) 6%, var(--vscode-editorWidget-background));
 	font-size: var(--vscode-chat-font-size-body-s);
@@ -69,39 +69,25 @@
 }
 
 .session-input-banner .session-input-banner-action {
-	display: flex;
-	align-items: center;
-	gap: 4px;
-	height: 20px;
-	padding: 0 8px;
-	border: none;
-	border-radius: var(--vscode-cornerRadius-small, 4px);
 	font-size: var(--vscode-agents-fontSize-label2);
-	font-family: inherit;
-	cursor: pointer;
+	padding: 0 8px;
+	min-width: unset;
+	width: auto;
+	height: 20px;
 	white-space: nowrap;
-	color: var(--vscode-foreground);
+}
+
+/* Transparent ghost style for secondary action buttons (e.g. "Reveal Checks"). */
+.session-input-banner .session-input-banner-action.secondary {
+	border: none;
 	background: transparent;
-	outline: none;
+	color: var(--vscode-foreground);
+	opacity: 0.8;
 }
 
-.session-input-banner .session-input-banner-action:hover {
+.session-input-banner .session-input-banner-action.secondary:hover {
 	background: var(--vscode-toolbar-hoverBackground);
-}
-
-/* Primary action stands out with the button colors. */
-.session-input-banner .session-input-banner-action.primary {
-	color: var(--vscode-button-foreground);
-	background: var(--vscode-button-background);
-}
-
-.session-input-banner .session-input-banner-action.primary:hover {
-	background: var(--vscode-button-hoverBackground);
-}
-
-.session-input-banner .session-input-banner-action:focus-visible {
-	outline: 1px solid var(--vscode-focusBorder);
-	outline-offset: -1px;
+	opacity: 1;
 }
 
 /* Dismiss (x) button. */
@@ -125,6 +111,6 @@
 }
 
 .session-input-banner .session-input-banner-dismiss:focus-visible {
-	outline: 1px solid var(--vscode-focusBorder);
+	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder);
 	outline-offset: -1px;
 }

--- a/src/vs/sessions/contrib/sessionInputBanners/browser/media/sessionInputBanners.css
+++ b/src/vs/sessions/contrib/sessionInputBanners/browser/media/sessionInputBanners.css
@@ -1,0 +1,130 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Host: a vertical stack of session banners sitting directly above the chat input. */
+.session-input-banners {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+/* Collapse the host entirely when there is nothing to show so it adds no spacing. */
+.session-input-banners:not(:has(.session-input-banner)) {
+	display: none;
+}
+
+/* A single banner card. */
+.session-input-banner {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+	box-sizing: border-box;
+	padding: 4px 6px 4px 10px;
+	border: 1px solid var(--vscode-input-border, transparent);
+	border-radius: var(--vscode-cornerRadius-small, 4px);
+	background-color: color-mix(in srgb, var(--vscode-focusBorder) 6%, var(--vscode-editorWidget-background));
+	font-size: var(--vscode-chat-font-size-body-s);
+	font-family: var(--vscode-chat-font-family, inherit);
+}
+
+/* Orange accent variant (used by the CI failures banner). */
+.session-input-banner.accent-orange {
+	border-color: var(--vscode-charts-orange);
+	background-color: color-mix(in srgb, var(--vscode-charts-orange) 6%, var(--vscode-editorWidget-background));
+}
+
+/* Leading icon. */
+.session-input-banner .session-input-banner-icon {
+	flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	color: var(--vscode-icon-foreground);
+}
+
+.session-input-banner.accent-orange .session-input-banner-icon {
+	color: var(--vscode-charts-orange);
+}
+
+/* Text — single line, ellipsized when it does not fit next to the actions. */
+.session-input-banner .session-input-banner-text {
+	flex: 1 1 auto;
+	min-width: 0;
+	color: var(--vscode-foreground);
+	line-height: 18px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+/* Floating, right-aligned button bar. */
+.session-input-banner .session-input-banner-actions {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	flex-shrink: 0;
+	margin-left: auto;
+}
+
+.session-input-banner .session-input-banner-action {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	height: 20px;
+	padding: 0 8px;
+	border: none;
+	border-radius: var(--vscode-cornerRadius-small, 4px);
+	font-size: var(--vscode-agents-fontSize-label2);
+	font-family: inherit;
+	cursor: pointer;
+	white-space: nowrap;
+	color: var(--vscode-foreground);
+	background: transparent;
+	outline: none;
+}
+
+.session-input-banner .session-input-banner-action:hover {
+	background: var(--vscode-toolbar-hoverBackground);
+}
+
+/* Primary action stands out with the button colors. */
+.session-input-banner .session-input-banner-action.primary {
+	color: var(--vscode-button-foreground);
+	background: var(--vscode-button-background);
+}
+
+.session-input-banner .session-input-banner-action.primary:hover {
+	background: var(--vscode-button-hoverBackground);
+}
+
+.session-input-banner .session-input-banner-action:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
+
+/* Dismiss (x) button. */
+.session-input-banner .session-input-banner-dismiss {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	width: 20px;
+	height: 20px;
+	border: none;
+	border-radius: var(--vscode-cornerRadius-small, 4px);
+	cursor: pointer;
+	color: var(--vscode-icon-foreground);
+	background: transparent;
+	outline: none;
+}
+
+.session-input-banner .session-input-banner-dismiss:hover {
+	background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.session-input-banner .session-input-banner-dismiss:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}

--- a/src/vs/sessions/contrib/sessionInputBanners/browser/media/sessionInputBanners.css
+++ b/src/vs/sessions/contrib/sessionInputBanners/browser/media/sessionInputBanners.css
@@ -90,6 +90,16 @@
 	opacity: 1;
 }
 
+/* In the orange CI banner, the primary action matches the orange accent. */
+.session-input-banner.accent-orange .session-input-banner-action:not(.secondary) {
+	background: var(--vscode-charts-orange);
+	color: var(--vscode-button-foreground);
+}
+
+.session-input-banner.accent-orange .session-input-banner-action:not(.secondary):hover {
+	background: color-mix(in srgb, var(--vscode-charts-orange) 88%, black);
+}
+
 /* Dismiss (x) button. */
 .session-input-banner .session-input-banner-dismiss {
 	display: flex;

--- a/src/vs/sessions/contrib/sessionInputBanners/browser/sessionInputBannerWidget.ts
+++ b/src/vs/sessions/contrib/sessionInputBanners/browser/sessionInputBannerWidget.ts
@@ -5,12 +5,14 @@
 
 import './media/sessionInputBanners.css';
 import * as dom from '../../../../base/browser/dom.js';
+import { Button } from '../../../../base/browser/ui/button/button.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { ThemeIcon } from '../../../../base/common/themables.js';
+import type { ThemeIcon } from '../../../../base/common/themables.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+import { defaultButtonStyles } from '../../../../platform/theme/browser/defaultStyles.js';
 
 export interface ISessionInputBannerAction {
 	readonly label: string;
@@ -61,14 +63,26 @@ export class SessionInputBannerWidget extends Disposable {
 
 		const actions = dom.append(this.domNode, dom.$('.session-input-banner-actions'));
 		for (const action of banner.actions) {
-			const button = dom.append(actions, dom.$('button.session-input-banner-action')) as HTMLButtonElement;
-			button.type = 'button';
-			button.classList.toggle('primary', !!action.primary);
-			button.textContent = action.label;
-			this._register(dom.addDisposableListener(button, dom.EventType.CLICK, e => {
-				dom.EventHelper.stop(e, true);
-				action.run();
+			// Primary uses the prominent button colors; secondary renders as a
+			// ghost button (colors overridden to undefined so the CSS ghost
+			// styles apply), mirroring the chat input notification widget.
+			const button = this._register(new Button(actions, {
+				...defaultButtonStyles,
+				...(action.primary ? {} : {
+					buttonBackground: undefined,
+					buttonHoverBackground: undefined,
+					buttonForeground: undefined,
+					buttonSecondaryBackground: undefined,
+					buttonSecondaryHoverBackground: undefined,
+					buttonSecondaryForeground: undefined,
+					buttonSecondaryBorder: undefined,
+				}),
+				secondary: !action.primary,
 			}));
+			button.element.classList.add('session-input-banner-action');
+			button.label = action.label;
+			button.element.ariaLabel = `${banner.ariaLabel} ${action.label}`;
+			this._register(button.onDidClick(() => action.run()));
 		}
 
 		const dismiss = dom.append(this.domNode, dom.$('button.session-input-banner-dismiss')) as HTMLButtonElement;

--- a/src/vs/sessions/contrib/sessionInputBanners/browser/sessionInputBannerWidget.ts
+++ b/src/vs/sessions/contrib/sessionInputBanners/browser/sessionInputBannerWidget.ts
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import './media/sessionInputBanners.css';
+import * as dom from '../../../../base/browser/dom.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
+import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+
+export interface ISessionInputBannerAction {
+	readonly label: string;
+	/** Renders the action with the prominent button colors. */
+	readonly primary?: boolean;
+	run(): void;
+}
+
+export interface ISessionInputBanner {
+	readonly icon: ThemeIcon;
+	/** Use the orange accent (border + icon) reserved for CI failures. */
+	readonly accent: boolean;
+	/** Single-line text; ellipsized when it does not fit next to the actions. */
+	readonly text: string;
+	readonly ariaLabel: string;
+	readonly actions: readonly ISessionInputBannerAction[];
+	readonly dismissTooltip: string;
+	dismiss(): void;
+}
+
+/**
+ * A single, self-contained banner card rendered directly above the chat input.
+ * Shows a leading icon, an ellipsized line of text, a floating right-aligned
+ * button bar, and a dismiss (x) button. Purely presentational — all behavior is
+ * provided by the {@link ISessionInputBanner} passed in.
+ */
+export class SessionInputBannerWidget extends Disposable {
+
+	readonly domNode: HTMLElement;
+
+	constructor(
+		banner: ISessionInputBanner,
+		@IHoverService private readonly hoverService: IHoverService,
+	) {
+		super();
+
+		this.domNode = dom.$('.session-input-banner');
+		this.domNode.classList.toggle('accent-orange', banner.accent);
+		this.domNode.setAttribute('role', 'status');
+		this.domNode.setAttribute('aria-label', banner.ariaLabel);
+
+		const icon = dom.append(this.domNode, dom.$('.session-input-banner-icon'));
+		icon.appendChild(renderIcon(banner.icon));
+
+		const textEl = dom.append(this.domNode, dom.$('span.session-input-banner-text'));
+		textEl.textContent = banner.text;
+		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), textEl, banner.text));
+
+		const actions = dom.append(this.domNode, dom.$('.session-input-banner-actions'));
+		for (const action of banner.actions) {
+			const button = dom.append(actions, dom.$('button.session-input-banner-action')) as HTMLButtonElement;
+			button.type = 'button';
+			button.classList.toggle('primary', !!action.primary);
+			button.textContent = action.label;
+			this._register(dom.addDisposableListener(button, dom.EventType.CLICK, e => {
+				dom.EventHelper.stop(e, true);
+				action.run();
+			}));
+		}
+
+		const dismiss = dom.append(this.domNode, dom.$('button.session-input-banner-dismiss')) as HTMLButtonElement;
+		dismiss.type = 'button';
+		dismiss.setAttribute('aria-label', banner.dismissTooltip);
+		dismiss.appendChild(renderIcon(Codicon.close));
+		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), dismiss, banner.dismissTooltip));
+		this._register(dom.addDisposableListener(dismiss, dom.EventType.CLICK, e => {
+			dom.EventHelper.stop(e, true);
+			banner.dismiss();
+		}));
+	}
+}

--- a/src/vs/sessions/contrib/sessionInputBanners/browser/sessionInputBanners.ts
+++ b/src/vs/sessions/contrib/sessionInputBanners/browser/sessionInputBanners.ts
@@ -1,0 +1,253 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../base/browser/dom.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
+import { autorun, derived, IObservable, ISettableObservable, observableSignalFromEvent, observableValue } from '../../../../base/common/observable.js';
+import { localize } from '../../../../nls.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
+import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+import { IGitHubService } from '../../github/browser/githubService.js';
+import { FIX_CI_CHECKS_COMMAND_ID, getFailedChecks, REVEAL_CI_CHECKS_COMMAND_ID } from '../../changes/browser/checksActions.js';
+import { AgentFeedbackKind, AgentFeedbackState, IAgentFeedbackService } from '../../agentFeedback/browser/agentFeedbackService.js';
+import { ISessionInputBanner, SessionInputBannerWidget } from './sessionInputBannerWidget.js';
+
+/** Slash command run by the "Address comments" action. */
+const ACT_ON_FEEDBACK_QUERY = '/act-on-feedback';
+
+/** Persisted set of session ids whose CI banner the user dismissed. */
+const STORAGE_KEY_CI_DISMISSED = 'sessions.inputBanners.ci.dismissed';
+/** Persisted set of session ids whose comments banner the user dismissed. */
+const STORAGE_KEY_COMMENTS_DISMISSED = 'sessions.inputBanners.comments.dismissed';
+
+/**
+ * Feedback kinds that originate from a review the user triages (a pull request
+ * review or an in-product code review), matching the comments surfaced to the
+ * agent via the `viewUnreviewedComments` tool.
+ */
+const REVIEWABLE_KINDS: ReadonlySet<AgentFeedbackKind> = new Set([AgentFeedbackKind.PRReview, AgentFeedbackKind.AgentReview]);
+
+interface ICIBannerState {
+	readonly sessionId: string;
+	readonly failed: number;
+	readonly total: number;
+}
+
+interface ICommentsBannerState {
+	readonly sessionId: string;
+	readonly sessionResource: URI;
+	readonly count: number;
+	readonly firstCommentId: string;
+}
+
+/**
+ * Hosts the banners that render directly above the active session's chat input:
+ * a CI failures banner and a created-comments banner. Each banner can be
+ * permanently dismissed per session.
+ *
+ * The host is owned by the session's chat view and only shows content while
+ * that view is the active session (driven via {@link setActive}); the CI model
+ * and feedback are read for the active session.
+ */
+export class SessionInputBanners extends Disposable {
+
+	readonly domNode: HTMLElement;
+
+	private readonly _ciSlot: HTMLElement;
+	private readonly _commentsSlot: HTMLElement;
+
+	private readonly _ciContent = this._register(new MutableDisposable<DisposableStore>());
+	private readonly _commentsContent = this._register(new MutableDisposable<DisposableStore>());
+
+	private readonly _active = observableValue<boolean>(this, false);
+
+	private readonly _ciDismissed = observableValue<ReadonlySet<string>>(this, new Set());
+	private readonly _commentsDismissed = observableValue<ReadonlySet<string>>(this, new Set());
+
+	private _feedbackChanged!: IObservable<void>;
+
+	/** The session whose banners should be shown, or undefined when inactive. */
+	private readonly _session = derived(this, reader => this._active.read(reader) ? this.sessionsService.activeSession.read(reader) : undefined);
+
+	private readonly _ciState: IObservable<ICIBannerState | undefined> = derived(this, reader => {
+		const session = this._session.read(reader);
+		if (!session || this._ciDismissed.read(reader).has(session.sessionId)) {
+			return undefined;
+		}
+		const ciModel = this.gitHubService.activeSessionPullRequestCIObs.read(reader);
+		if (!ciModel) {
+			return undefined;
+		}
+		const checks = ciModel.checks.read(reader);
+		const failed = getFailedChecks(checks).length;
+		if (failed === 0) {
+			return undefined;
+		}
+		return { sessionId: session.sessionId, failed, total: checks.length };
+	});
+
+	private readonly _commentsState: IObservable<ICommentsBannerState | undefined> = derived(this, reader => {
+		const session = this._session.read(reader);
+		if (!session || this._commentsDismissed.read(reader).has(session.sessionId)) {
+			return undefined;
+		}
+		this._feedbackChanged.read(reader);
+		const created = this.feedbackService.getFeedback(session.resource)
+			.filter(item => item.state === AgentFeedbackState.Created && REVIEWABLE_KINDS.has(item.kind));
+		if (created.length === 0) {
+			return undefined;
+		}
+		return { sessionId: session.sessionId, sessionResource: session.resource, count: created.length, firstCommentId: created[0].id };
+	});
+
+	constructor(
+		@ISessionsService private readonly sessionsService: ISessionsService,
+		@IGitHubService private readonly gitHubService: IGitHubService,
+		@IAgentFeedbackService private readonly feedbackService: IAgentFeedbackService,
+		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
+		@ICommandService private readonly commandService: ICommandService,
+		@IStorageService private readonly storageService: IStorageService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@ILogService private readonly logService: ILogService,
+	) {
+		super();
+
+		this.domNode = dom.$('.session-input-banners');
+		this._ciSlot = dom.append(this.domNode, dom.$('.session-input-banner-slot'));
+		this._commentsSlot = dom.append(this.domNode, dom.$('.session-input-banner-slot'));
+
+		this._feedbackChanged = observableSignalFromEvent(this, this.feedbackService.onDidChangeFeedback);
+
+		// Load persisted dismissal state and keep it in sync with other windows/profiles.
+		this._ciDismissed.set(this._readDismissed(STORAGE_KEY_CI_DISMISSED), undefined);
+		this._commentsDismissed.set(this._readDismissed(STORAGE_KEY_COMMENTS_DISMISSED), undefined);
+		this._register(this.storageService.onDidChangeValue(StorageScope.PROFILE, STORAGE_KEY_CI_DISMISSED, this._store)(() => {
+			this._ciDismissed.set(this._readDismissed(STORAGE_KEY_CI_DISMISSED), undefined);
+		}));
+		this._register(this.storageService.onDidChangeValue(StorageScope.PROFILE, STORAGE_KEY_COMMENTS_DISMISSED, this._store)(() => {
+			this._commentsDismissed.set(this._readDismissed(STORAGE_KEY_COMMENTS_DISMISSED), undefined);
+		}));
+
+		this._register(autorun(reader => this._renderCIBanner(this._ciState.read(reader))));
+		this._register(autorun(reader => this._renderCommentsBanner(this._commentsState.read(reader))));
+	}
+
+	/** Marks whether the owning chat view is the active session. */
+	setActive(active: boolean): void {
+		this._active.set(active, undefined);
+	}
+
+	private _renderCIBanner(state: ICIBannerState | undefined): void {
+		const store = this._ciContent.value = new DisposableStore();
+		dom.clearNode(this._ciSlot);
+		if (!state) {
+			return;
+		}
+
+		const text = state.total === 1
+			? localize('ci.oneCheckFailed', "1 check failed")
+			: localize('ci.checksFailed', "{0} of {1} checks failed", state.failed, state.total);
+
+		this._renderBanner(this._ciSlot, store, {
+			icon: Codicon.warning,
+			accent: true,
+			text,
+			ariaLabel: text,
+			dismissTooltip: localize('ci.dismiss', "Hide for this session"),
+			actions: [
+				{
+					label: localize('ci.fixChecks', "Fix Checks"),
+					primary: true,
+					run: () => this._executeCommand(FIX_CI_CHECKS_COMMAND_ID),
+				},
+				{
+					label: localize('ci.revealChecks', "Reveal Checks"),
+					run: () => this._executeCommand(REVEAL_CI_CHECKS_COMMAND_ID),
+				},
+			],
+			dismiss: () => this._dismiss(STORAGE_KEY_CI_DISMISSED, this._ciDismissed, state.sessionId),
+		});
+	}
+
+	private _renderCommentsBanner(state: ICommentsBannerState | undefined): void {
+		const store = this._commentsContent.value = new DisposableStore();
+		dom.clearNode(this._commentsSlot);
+		if (!state) {
+			return;
+		}
+
+		const text = state.count === 1
+			? localize('comments.one', "1 comment")
+			: localize('comments.many', "{0} comments", state.count);
+
+		this._renderBanner(this._commentsSlot, store, {
+			icon: Codicon.commentDiscussion,
+			accent: false,
+			text,
+			ariaLabel: text,
+			dismissTooltip: localize('comments.dismiss', "Hide for this session"),
+			actions: [
+				{
+					label: localize('comments.address', "Address Comments"),
+					primary: true,
+					run: () => this._addressComments(state.sessionResource),
+				},
+				{
+					label: localize('comments.reveal', "Reveal Comments"),
+					run: () => this._revealComment(state.sessionResource, state.firstCommentId),
+				},
+			],
+			dismiss: () => this._dismiss(STORAGE_KEY_COMMENTS_DISMISSED, this._commentsDismissed, state.sessionId),
+		});
+	}
+
+	private _renderBanner(container: HTMLElement, store: DisposableStore, banner: ISessionInputBanner): void {
+		const widget = store.add(this.instantiationService.createInstance(SessionInputBannerWidget, banner));
+		container.appendChild(widget.domNode);
+	}
+
+	private _executeCommand(commandId: string): void {
+		this.commandService.executeCommand(commandId).catch(err => this.logService.error('[SessionInputBanners] command failed', commandId, err));
+	}
+
+	private _addressComments(sessionResource: URI): void {
+		const widget = this.chatWidgetService.getWidgetBySessionResource(sessionResource);
+		if (!widget) {
+			this.logService.error('[SessionInputBanners] Cannot address comments: no chat widget for session', sessionResource.toString());
+			return;
+		}
+		widget.acceptInput(ACT_ON_FEEDBACK_QUERY).catch(err => this.logService.error('[SessionInputBanners] Failed to send act-on-feedback', err));
+	}
+
+	private _revealComment(sessionResource: URI, commentId: string): void {
+		this.feedbackService.revealFeedback(sessionResource, commentId).catch(err => this.logService.error('[SessionInputBanners] Failed to reveal comment', err));
+	}
+
+	private _dismiss(storageKey: string, observable: ISettableObservable<ReadonlySet<string>>, sessionId: string): void {
+		const next = new Set(observable.get());
+		next.add(sessionId);
+		this.storageService.store(storageKey, JSON.stringify([...next]), StorageScope.PROFILE, StorageTarget.USER);
+		observable.set(next, undefined);
+	}
+
+	private _readDismissed(storageKey: string): ReadonlySet<string> {
+		const raw = this.storageService.get(storageKey, StorageScope.PROFILE);
+		if (!raw) {
+			return new Set();
+		}
+		try {
+			const parsed = JSON.parse(raw);
+			return Array.isArray(parsed) ? new Set(parsed.filter((id): id is string => typeof id === 'string')) : new Set();
+		} catch {
+			return new Set();
+		}
+	}
+}

--- a/src/vs/sessions/contrib/sessionInputBanners/browser/sessionInputBanners.ts
+++ b/src/vs/sessions/contrib/sessionInputBanners/browser/sessionInputBanners.ts
@@ -45,6 +45,8 @@ interface ICommentsBannerState {
 	readonly sessionId: string;
 	readonly sessionResource: URI;
 	readonly count: number;
+	/** Whether all counted comments are PR reviews, all are agent reviews, or mixed. */
+	readonly kind: 'pr' | 'agent' | 'mixed';
 	readonly firstCommentId: string;
 }
 
@@ -105,7 +107,10 @@ export class SessionInputBanners extends Disposable {
 		if (created.length === 0) {
 			return undefined;
 		}
-		return { sessionId: session.sessionId, sessionResource: session.resource, count: created.length, firstCommentId: created[0].id };
+		const allPR = created.every(item => item.kind === AgentFeedbackKind.PRReview);
+		const allAgent = created.every(item => item.kind === AgentFeedbackKind.AgentReview);
+		const kind = allPR ? 'pr' : allAgent ? 'agent' : 'mixed';
+		return { sessionId: session.sessionId, sessionResource: session.resource, count: created.length, kind, firstCommentId: created[0].id };
 	});
 
 	constructor(
@@ -184,9 +189,7 @@ export class SessionInputBanners extends Disposable {
 			return;
 		}
 
-		const text = state.count === 1
-			? localize('comments.one', "1 comment")
-			: localize('comments.many', "{0} comments", state.count);
+		const text = this._commentsBannerText(state.kind, state.count);
 
 		this._renderBanner(this._commentsSlot, store, {
 			icon: Codicon.commentDiscussion,
@@ -212,6 +215,23 @@ export class SessionInputBanners extends Disposable {
 	private _renderBanner(container: HTMLElement, store: DisposableStore, banner: ISessionInputBanner): void {
 		const widget = store.add(this.instantiationService.createInstance(SessionInputBannerWidget, banner));
 		container.appendChild(widget.domNode);
+	}
+
+	private _commentsBannerText(kind: 'pr' | 'agent' | 'mixed', count: number): string {
+		switch (kind) {
+			case 'pr':
+				return count === 1
+					? localize('comments.pr.one', "1 PR comment")
+					: localize('comments.pr.many', "{0} PR comments", count);
+			case 'agent':
+				return count === 1
+					? localize('comments.agent.one', "1 agent comment")
+					: localize('comments.agent.many', "{0} agent comments", count);
+			case 'mixed':
+				return count === 1
+					? localize('comments.one', "1 comment")
+					: localize('comments.many', "{0} comments", count);
+		}
 	}
 
 	private _executeCommand(commandId: string): void {

--- a/src/vs/sessions/contrib/sessionInputBanners/test/browser/sessionInputBanners.fixture.ts
+++ b/src/vs/sessions/contrib/sessionInputBanners/test/browser/sessionInputBanners.fixture.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup } from '../../../../../workbench/test/browser/componentFixtures/fixtureUtils.js';
+import { ISessionInputBanner, SessionInputBannerWidget } from '../../browser/sessionInputBannerWidget.js';
+
+export default defineThemedFixtureGroup({ path: 'sessions/inputBanners/' }, {
+	CIFailures: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (context) => renderBanners(context, [ciBanner(2, 5)]),
+	}),
+
+	Comments: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (context) => renderBanners(context, [commentsBanner(3)]),
+	}),
+
+	Both: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (context) => renderBanners(context, [ciBanner(1, 4), commentsBanner(1)]),
+	}),
+
+	LongTextEllipsis: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (context) => renderBanners(context, [ciBanner(12, 18)], 360),
+	}),
+});
+
+function ciBanner(failed: number, total: number): ISessionInputBanner {
+	const text = total === 1 ? '1 check failed' : `${failed} of ${total} checks failed`;
+	return {
+		icon: Codicon.warning,
+		accent: true,
+		text,
+		ariaLabel: text,
+		dismissTooltip: 'Hide for this session',
+		actions: [
+			{ label: 'Fix Checks', primary: true, run: () => console.log('Fix Checks') },
+			{ label: 'Reveal Checks', run: () => console.log('Reveal Checks') },
+		],
+		dismiss: () => console.log('Dismiss CI banner'),
+	};
+}
+
+function commentsBanner(count: number): ISessionInputBanner {
+	const text = count === 1 ? '1 comment' : `${count} comments`;
+	return {
+		icon: Codicon.commentDiscussion,
+		accent: false,
+		text,
+		ariaLabel: text,
+		dismissTooltip: 'Hide for this session',
+		actions: [
+			{ label: 'Address Comments', primary: true, run: () => console.log('Address Comments') },
+			{ label: 'Reveal Comments', run: () => console.log('Reveal Comments') },
+		],
+		dismiss: () => console.log('Dismiss comments banner'),
+	};
+}
+
+function renderBanners({ container, disposableStore, theme }: ComponentFixtureContext, banners: readonly ISessionInputBanner[], width = 480): void {
+	container.style.width = `${width}px`;
+	container.style.display = 'flex';
+	container.style.flexDirection = 'column';
+	container.style.gap = '4px';
+	container.style.padding = '8px';
+	container.style.backgroundColor = 'var(--vscode-editorWidget-background)';
+
+	const instantiationService = createEditorServices(disposableStore, { colorTheme: theme });
+
+	for (const banner of banners) {
+		const widget = disposableStore.add(instantiationService.createInstance(SessionInputBannerWidget, banner));
+		container.appendChild(widget.domNode);
+	}
+}

--- a/src/vs/sessions/contrib/sessionInputBanners/test/browser/sessionInputBanners.fixture.ts
+++ b/src/vs/sessions/contrib/sessionInputBanners/test/browser/sessionInputBanners.fixture.ts
@@ -15,12 +15,22 @@ export default defineThemedFixtureGroup({ path: 'sessions/inputBanners/' }, {
 
 	Comments: defineComponentFixture({
 		labels: { kind: 'screenshot' },
-		render: (context) => renderBanners(context, [commentsBanner(3)]),
+		render: (context) => renderBanners(context, [commentsBanner(3, 'mixed')]),
+	}),
+
+	PRComments: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (context) => renderBanners(context, [commentsBanner(2, 'pr')]),
+	}),
+
+	AgentComments: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (context) => renderBanners(context, [commentsBanner(4, 'agent')]),
 	}),
 
 	Both: defineComponentFixture({
 		labels: { kind: 'screenshot' },
-		render: (context) => renderBanners(context, [ciBanner(1, 4), commentsBanner(1)]),
+		render: (context) => renderBanners(context, [ciBanner(1, 4), commentsBanner(1, 'mixed')]),
 	}),
 
 	LongTextEllipsis: defineComponentFixture({
@@ -45,8 +55,9 @@ function ciBanner(failed: number, total: number): ISessionInputBanner {
 	};
 }
 
-function commentsBanner(count: number): ISessionInputBanner {
-	const text = count === 1 ? '1 comment' : `${count} comments`;
+function commentsBanner(count: number, kind: 'pr' | 'agent' | 'mixed'): ISessionInputBanner {
+	const noun = kind === 'pr' ? 'PR comment' : kind === 'agent' ? 'agent comment' : 'comment';
+	const text = count === 1 ? `1 ${noun}` : `${count} ${noun}s`;
 	return {
 		icon: Codicon.commentDiscussion,
 		accent: false,


### PR DESCRIPTION
## What

Adds two dismissible banners that render directly above the active session's chat input in the Agents window:

- **CI failures banner** (orange accent) - shown when the active session has at least one failed CI check. Reads "X of N checks failed" (single-line, ellipsized when it does not fit) with a floating right-aligned button bar:
  - **Fix Checks** - same as the Changes view fix-ci action (`sessions.action.fixCIChecks`).
  - **Reveal Checks** - opens the Changes view and expands + focuses the CI checks section.
- **Created-comments banner** (neutral accent, stacked below CI) - shown when the active session has reviewable (PR/Agent review) comments still in the `Created` state. Reads "N comments" with:
  - **Address Comments** - sends `/act-on-feedback` to the session chat.
  - **Reveal Comments** - opens the first comment in the editor via `IAgentFeedbackService.revealFeedback`.

Each banner has its own dismiss (x) that **permanently** hides it for that session, persisted across reloads via `IStorageService`.

## How

- The presentational card is extracted into a self-contained, fixture-friendly `SessionInputBannerWidget` (own `domNode`, data via `ISessionInputBanner`, only needs `IHoverService`).
- The reactive `SessionInputBanners` host composes the widget and drives visibility from observables (`activeSessionPullRequestCIObs`, agent feedback, per-session dismissal state).
- `ChatView` mounts the host above the input using the public `IChatWidget.inputPart.element` API (no querySelectors / DOM spelunking).
- Adds `CIStatusWidget.expand()` / `focus()`, `ChangesViewPane.revealChecks()`, and a `Reveal Checks` command.

## Notes for reviewers

- All code lives in the `vs/sessions` layer (the workbench chat input files are content-policy excluded, so the banners mount from the sessions side).
- Component Explorer fixtures added under `sessionInputBanners/test/browser/` (path `sessions/inputBanners/`): `CIFailures`, `Comments`, `Both`, `LongTextEllipsis` (Dark + Light each).
- Validation: typecheck-client, valid-layers-check, eslint, stylelint, and hygiene all pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
