### PR TITLE
Voice chat input fixes: transcript default off

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -485,7 +485,7 @@ configurationRegistry.registerConfiguration({
 		'agents.voice.showTranscript': {
 			type: 'boolean',
 			description: nls.localize('agents.voice.showTranscript', "Show the voice transcript overlay in the chat input area while voice mode is active."),
-			default: true,
+			default: false,
 			scope: ConfigurationScope.APPLICATION,
 			included: false,
 			tags: ['advanced'],

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -964,6 +964,25 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 					toolArgs: e.args,
 				});
 				this._setAwaitingReply();
+
+				// If the target session has a pending question/confirmation,
+				// treat the voice input as an answer rather than a new chat message.
+				// This fixes cases where the voice LLM miscategorizes a question
+				// response as a regular send_to_chat. (#8157)
+				const targetResource = this._targetSession.get();
+				if (text.trim() && targetResource) {
+					const model = this.chatService.getSession(targetResource);
+					if (model && this._hasPendingQuestionOrConfirmation(model)) {
+						this.logService.info('[voice] send_to_chat redirected as question response (pending confirmation detected)');
+						this._approveConfirmationForSession(model);
+						this.voiceClientService.sendToolResult(e.callId, 'ok');
+						this._voiceState.set('idle', undefined);
+						this._statusText.set('Hold to speak...', undefined);
+						this._sendContext();
+						return;
+					}
+				}
+
 				const sendPromise = text.trim()
 					? this._sendTranscriptionToChat(text)
 					: Promise.resolve();
@@ -2155,6 +2174,48 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			}
 			cts.dispose();
 		}, () => { cts.dispose(); });
+	}
+
+	/**
+	 * Returns true if the model has a pending question or confirmation that
+	 * should receive the next user utterance as a response.
+	 */
+	private _hasPendingQuestionOrConfirmation(model: IChatModel): boolean {
+		const lastReq = model.getRequests().at(-1);
+		if (!lastReq?.response) {
+			return false;
+		}
+		if (lastReq.response.isPendingConfirmation.get()) {
+			return true;
+		}
+		// Fallback: askQuestions-style tools that enter WaitingForConfirmation
+		// without setting isPendingConfirmation
+		for (const part of lastReq.response.response.value) {
+			if (part.kind === 'toolInvocation') {
+				const state = (part as IChatToolInvocation).state.get();
+				if (state.type === IChatToolInvocation.StateKind.WaitingForConfirmation) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Approves the pending confirmation for the session (as UserAction).
+	 */
+	private _approveConfirmationForSession(model: IChatModel): void {
+		const lastReq = model.getRequests().at(-1);
+		if (!lastReq?.response) {
+			return;
+		}
+		for (const part of lastReq.response.response.value) {
+			if (part.kind === 'toolInvocation') {
+				if (IChatToolInvocation.confirmWith(part as IChatToolInvocation, { type: ToolConfirmKind.UserAction })) {
+					break;
+				}
+			}
+		}
 	}
 
 	private _getAgentStateInfo(model: IChatModel | undefined | null): { state: string; detail?: string; last_response_summary?: string } {


### PR DESCRIPTION
Fixes microsoft/vscode-internalbacklog#8143, microsoft/vscode-internalbacklog#8142, microsoft/vscode-internalbacklog#8147

## Changes

1. **Set `agents.voice.showTranscript` default to `false`** — The transcript overlay in the chat input was confusing (looked like pending text to send, couldn't be edited, wasn't scrollable). Disabling by default resolves #8143 and #8142, and also addresses the visual confusion in #8147 where voice appeared to target the main input while editing an old message.

