### PR TITLE
Wire up browser tool_instructions for agent host prompts

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/prompts/AGENTS.md
+++ b/src/vs/platform/agentHost/node/copilot/prompts/AGENTS.md
@@ -1,0 +1,138 @@
+# Agent host system-prompt customization
+
+This directory customizes the system prompt for Copilot CLI **agent host**
+(ahp+cli) sessions. Read this before changing how the system message is built or
+adding per-model / per-tool guidance. It mirrors the Copilot extension's
+`extensions/copilot/.../prompts/node/agent/` (agentPrompts), but the agent host
+runs in its own process and cannot use prompt-tsx, so contributors return plain
+data the SDK accepts directly.
+
+## Files
+
+- `promptRegistry.ts` — `AgentHostPromptRegistry`: resolves the final
+  `SystemMessageConfig` for a session's model. Defines the `IAgentHostPrompt`
+  contributor interface and the `IAgentHostPromptContext` read-time context.
+- `systemMessage.ts` — the default message (`COPILOT_AGENT_HOST_SYSTEM_MESSAGE`),
+  shared identity text, the `fullSystemPrompt` / `sectionOverrides` builders, and
+  `describeSystemMessageConfig` (the one-line log summary).
+- `toolInstructions.ts` — the model-agnostic `tool_instructions` layer: gated
+  one-line nudges (`TOOL_INSTRUCTION_LINES`) composed into the SDK's
+  `tool_instructions` section. The browser line is the one registered today.
+- `anthropicPrompt.ts` — example per-model contributor (Claude Opus 4.8).
+- `allPrompts.ts` — side-effect import hub; importing it registers every
+  contributor into the shared `agentHostPromptRegistry`.
+
+## How the system message is built
+
+`resolveSystemMessageConfig(model, context)` runs two steps:
+
+1. **`_resolveModelConfig`** — picks the per-model (or default) config. Falls
+   back to `COPILOT_AGENT_HOST_SYSTEM_MESSAGE` when there's no model, no matching
+   contributor, or the contributor opts out for this `context`.
+2. **`_withUniversalSections`** — layers the model-agnostic sections (currently
+   just `tool_instructions`) on top, **composing** with — never clobbering — any
+   per-model override for that section.
+
+> **Launch-time freeze.** The SDK accepts a system message only at session
+> create/resume; there is no mid-session update. The prompt is resolved once per
+> (re)launch and any tool-gated content reflects the tool set at that moment. A
+> change to the session's tools/plugins is part of the launcher's restart
+> snapshot, so it re-launches and recomputes; an in-flight turn keeps the prompt
+> it launched with.
+
+There are two ways to customize, and a model can use both at once.
+
+## Lever 1 — universal, all models (`toolInstructions.ts`)
+
+Guidance for a tool that should apply to **every** model whenever that tool is in
+the session. This is what the browser line does.
+
+1. Write a `ToolInstructionLine` — a function `(hasTool) => string | undefined`
+   that returns one sentence (no surrounding newlines) when its tool is present,
+   or `undefined` to contribute nothing.
+2. Add it to `TOOL_INSTRUCTION_LINES`.
+
+```ts
+const exampleToolInstructions: ToolInstructionLine = hasTool =>
+	hasTool('someClientToolReferenceName')
+		? 'One sentence of guidance, shown only when that tool is present.'
+		: undefined;
+
+const TOOL_INSTRUCTION_LINES: readonly ToolInstructionLine[] = [browserToolInstructions, exampleToolInstructions];
+```
+
+**Caveat — `hasTool` sees CLIENT tools only.** It is `context.hasClientTool`,
+which knows only the forwarded workbench tools, addressed by their **camelCase
+`toolReferenceName`** (e.g. `openBrowserPage`, `runTask`, `getTaskOutput`) — NOT
+the extension's snake_case ids, and NOT shell / server-SDK / MCP tools (MCP is
+discovered dynamically and isn't in the launch snapshot). A
+line gated on a name that is never a client tool silently never renders. The
+default client-tool allowlist is `chat.agentHost.clientTools` (see
+`chat.shared.contribution.ts`). Broadening this context is a known follow-up.
+
+These lines compose with a per-model `tool_instructions` override (see
+`composeToolInstructions`), so Lever 1 and Lever 2 stack.
+
+## Lever 2 — per-model contributor (`promptRegistry.ts` + `allPrompts.ts`)
+
+Guidance scoped to a model or family. Implement `IAgentHostPrompt` and register
+it. Use `anthropicPrompt.ts` as the template.
+
+A contributor provides EITHER:
+
+- `resolveSectionOverrides` → `{ mode: 'customize' }` — overrides named sections,
+  keeps the SDK foundation prompt and its guardrails. **Prefer this.**
+- `resolveFullSystemPrompt` → `{ mode: 'replace' }` — owns the entire prompt and
+  **drops all SDK guardrails (including safety)**. Only for callers that truly
+  own the whole prompt. A replace contributor bypasses Lever 1, so re-include the
+  universal lines by calling `appendUniversalToolInstructions(content, hasTool)`
+  from `resolveFullSystemPrompt`.
+
+```ts
+class MyModelPrompt implements IAgentHostPrompt {
+	static readonly familyPrefixes = ['my-model'];        // or implement static matchesModel(model)
+	resolveSectionOverrides(model: ModelSelection, context: IAgentHostPromptContext) {
+		// Gate on host settings; return undefined to fall back to the default message.
+		return context.getSetting(AgentHostConfigKey.SomeFlag) === true
+			? { tool_instructions: { action: 'append', content: '\nFor this model, batch independent tool calls.' } }
+			: undefined;
+	}
+}
+agentHostPromptRegistry.registerPrompt(MyModelPrompt);   // then add `import './myModelPrompt.js'` to allPrompts.ts
+```
+
+Matching: a contributor matches a model by `static matchesModel(model)` (takes
+precedence) or by `familyPrefixes` (model-id `startsWith`). The registry resolves
+**exactly one** contributor per model (first match wins) — base + version
+layering is a known follow-up.
+
+## Reference
+
+- **Modes** (`SystemMessageConfig.mode`): `append` (foundation + text, default),
+  `customize` (override named sections), `replace` (own the whole prompt, no
+  guardrails).
+- **Sections** (`SystemMessageSection`): `identity`, `tone`, `tool_efficiency`,
+  `environment_context`, `code_change_rules`, `guidelines`, `safety`,
+  `tool_instructions`, `custom_instructions`, `runtime_instructions`,
+  `last_instructions`.
+- **Override actions** (`SectionOverride.action`): `replace`, `append`,
+  `prepend`, `remove`, or a `(content: string) => string` transform.
+
+## Gotchas
+
+- **Empty overrides = no override.** `resolveSectionOverrides` returning `{}`
+  (or `undefined`) falls back to the default message rather than emitting an
+  empty customize config that would drop the default identity.
+- **Don't mutate the shared default.** `COPILOT_AGENT_HOST_SYSTEM_MESSAGE` is a
+  shared constant; layering spreads into a fresh object, preserving any other
+  customize-mode fields (e.g. `content`). Keep it that way.
+- **Spacing is relative to the foundation.** `composeToolInstructions` pads by
+  action (`append` leads with `\n`, `prepend` trails with `\n`, `replace` owns
+  the section). When writing a section's `content` by hand, a leading `\n` keeps
+  appended text off the foundation's last line.
+- **Observability.** The launcher logs `describeSystemMessageConfig(...)` at
+  `info` (mode + overridden sections) and the full config at `trace`. Keep new
+  config shapes summarizable there.
+- **Tests.** `../../../test/node/agentHostPromptRegistry.test.ts` covers the
+  registry/wiring; `../../../test/node/toolInstructions.test.ts` covers the
+  composition/gating. Add cases there, not new harnesses.

--- a/src/vs/platform/agentHost/node/copilot/prompts/AGENTS.md
+++ b/src/vs/platform/agentHost/node/copilot/prompts/AGENTS.md
@@ -84,9 +84,10 @@ A contributor provides EITHER:
   keeps the SDK foundation prompt and its guardrails. **Prefer this.**
 - `resolveFullSystemPrompt` → `{ mode: 'replace' }` — owns the entire prompt and
   **drops all SDK guardrails (including safety)**. Only for callers that truly
-  own the whole prompt. A replace contributor bypasses Lever 1, so re-include the
-  universal lines by calling `appendUniversalToolInstructions(content, hasTool)`
-  from `resolveFullSystemPrompt`.
+  own the whole prompt. A replace contributor bypasses Lever 1, so it must inline
+  any universal guidance itself (`universalToolInstructions(hasTool)` renders the
+  same gated lines; add a small replace-mode helper alongside it when the first
+  such contributor lands).
 
 ```ts
 class MyModelPrompt implements IAgentHostPrompt {

--- a/src/vs/platform/agentHost/node/copilot/prompts/promptRegistry.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/promptRegistry.ts
@@ -183,7 +183,7 @@ export class AgentHostPromptRegistry {
 	 * for a contributor's full `replace` prompt (which owns the entire system
 	 * message and intentionally drops the SDK foundation) and for `append` mode.
 	 * A `replace` contributor that wants the universal guidance re-includes it
-	 * itself by calling `appendUniversalToolInstructions` (in `toolInstructions.ts`)
+	 * itself by rendering `universalToolInstructions` (in `toolInstructions.ts`)
 	 * from its `resolveFullSystemPrompt`, mirroring how the extension's full-prompt
 	 * models inline the same lines.
 	 *

--- a/src/vs/platform/agentHost/node/copilot/prompts/promptRegistry.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/promptRegistry.ts
@@ -198,9 +198,7 @@ export class AgentHostPromptRegistry {
 		if (!toolInstructions) {
 			return config;
 		}
-		// Spread into a fresh object so the shared `COPILOT_AGENT_HOST_SYSTEM_MESSAGE`
-		// constant (returned by the fallback paths above) is never mutated.
-		return sectionOverrides({ ...config.sections, tool_instructions: toolInstructions });
+		return { ...config, sections: { ...config.sections, tool_instructions: toolInstructions } };
 	}
 }
 

--- a/src/vs/platform/agentHost/node/copilot/prompts/toolInstructions.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/toolInstructions.ts
@@ -5,6 +5,7 @@
 
 import type { SectionOverride } from '@github/copilot-sdk';
 import { coalesce } from '../../../../../base/common/arrays.js';
+import { BrowserChatToolReferenceName, browserChatToolReferenceNames } from '../../../../browserView/common/browserChatToolReferenceNames.js';
 
 /**
  * Model-agnostic guidance for the `tool_instructions` system-prompt section.
@@ -18,11 +19,10 @@ import { coalesce } from '../../../../../base/common/arrays.js';
  * snake_case ids).
  *
  * To add guidance for a tool, write a {@link ToolInstructionLine} and add it to
- * {@link TOOL_INSTRUCTION_LINES}. For example, a browser line would gate on
- * `openBrowserPage` (plus an agentic browser tool) being present and return a
- * sentence such as "Use the browser tools (...) for front-end tasks". No lines
- * are registered yet — concrete tool hookups land in follow-up changes; this
- * module is the wiring they plug into.
+ * {@link TOOL_INSTRUCTION_LINES}. The browser guidance ({@link browserToolInstructions})
+ * is the first such hookup: it gates on `openBrowserPage` (plus an agentic browser
+ * tool) being present and returns the extension's "Use the browser tools (...)"
+ * sentence.
  */
 
 /**
@@ -36,10 +36,34 @@ import { coalesce } from '../../../../../base/common/arrays.js';
 type ToolInstructionLine = (hasTool: (name: string) => boolean) => string | undefined;
 
 /**
- * The registered tool-instruction lines, in render order. Empty until concrete
- * tool hookups are added — add new per-tool guidance here.
+ * Browser tools other than `openBrowserPage` — the agent-host equivalent of the
+ * Copilot extension's `agenticBrowserTools`. Derived from the full reference-name
+ * list so it stays in sync as browser tools are added or removed.
  */
-const TOOL_INSTRUCTION_LINES: readonly ToolInstructionLine[] = [];
+const agenticBrowserToolNames = browserChatToolReferenceNames.filter(name => name !== BrowserChatToolReferenceName.OpenBrowserPage);
+
+/**
+ * Front-end guidance for the integrated browser tools, ported from the Copilot
+ * extension's `defaultAgentInstructions`/per-model prompts. Emitted only when the
+ * page-opening tool AND at least one agentic browser tool are available, naming
+ * the first available agentic tool as the example (the rest are covered by "etc.").
+ */
+const browserToolInstructions: ToolInstructionLine = hasTool => {
+	if (!hasTool(BrowserChatToolReferenceName.OpenBrowserPage)) {
+		return undefined;
+	}
+	const companion = agenticBrowserToolNames.find(hasTool);
+	if (!companion) {
+		return undefined;
+	}
+	return `Use the browser tools (${BrowserChatToolReferenceName.OpenBrowserPage}, ${companion}, etc.) when beneficial for front-end tasks, such as when visualizing or validating UI changes.`;
+};
+
+/**
+ * The registered tool-instruction lines, in render order. Add new per-tool
+ * guidance here.
+ */
+const TOOL_INSTRUCTION_LINES: readonly ToolInstructionLine[] = [browserToolInstructions];
 
 /**
  * Composes the applicable `lines` into a single block (one line each), or

--- a/src/vs/platform/agentHost/node/copilot/prompts/toolInstructions.ts
+++ b/src/vs/platform/agentHost/node/copilot/prompts/toolInstructions.ts
@@ -84,7 +84,7 @@ export function universalToolInstructions(hasTool: (name: string) => boolean, li
  *
  * @param existing the per-model contributor's `tool_instructions` override, if any.
  */
-export function composeToolInstructions(existing: SectionOverride | undefined, content: string): SectionOverride {
+function composeToolInstructions(existing: SectionOverride | undefined, content: string): SectionOverride {
 	// No per-model override: append after the SDK foundation section, led by a
 	// newline so it doesn't run on from the foundation content.
 	if (!existing) {
@@ -123,23 +123,4 @@ export function composeToolInstructions(existing: SectionOverride | undefined, c
 export function resolveToolInstructionsOverride(hasTool: (name: string) => boolean, existing: SectionOverride | undefined, lines: readonly ToolInstructionLine[] = TOOL_INSTRUCTION_LINES): SectionOverride | undefined {
 	const content = universalToolInstructions(hasTool, lines);
 	return content === undefined ? undefined : composeToolInstructions(existing, content);
-}
-
-/**
- * Appends the universal tool-instruction lines to a full (`replace`-mode)
- * system prompt's `content`.
- *
- * A `replace`-mode contributor owns its whole prompt and so is skipped by the
- * registry's universal `tool_instructions` layer. When such a contributor is
- * added, calling this from its `resolveFullSystemPrompt` re-includes the same
- * gated guidance (separated by a blank line), mirroring how the extension's
- * full-prompt models inline it. No `resolveFullSystemPrompt` contributor exists
- * yet, so this currently has no production caller. Returns `content` unchanged
- * when no line applies.
- *
- * @param lines defaults to the registered {@link TOOL_INSTRUCTION_LINES}.
- */
-export function appendUniversalToolInstructions(content: string, hasTool: (name: string) => boolean, lines: readonly ToolInstructionLine[] = TOOL_INSTRUCTION_LINES): string {
-	const extra = universalToolInstructions(hasTool, lines);
-	return extra === undefined ? content : `${content}\n\n${extra}`;
 }

--- a/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPromptRegistry.test.ts
@@ -10,6 +10,7 @@ import type { SchemaValues } from '../../common/agentHostSchema.js';
 import type { ModelSelection } from '../../common/state/protocol/state.js';
 import { AgentHostPromptRegistry, agentHostPromptRegistry, type IAgentHostPromptContext } from '../../node/copilot/prompts/promptRegistry.js';
 import { COPILOT_AGENT_HOST_SYSTEM_MESSAGE } from '../../node/copilot/prompts/systemMessage.js';
+import { BrowserChatToolReferenceName } from '../../../browserView/common/browserChatToolReferenceNames.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import '../../node/copilot/prompts/allPrompts.js';
 
@@ -131,17 +132,46 @@ suite('AgentHostPromptRegistry', () => {
 	});
 
 	suite('universal tool instructions wiring', () => {
-		// No tool-instruction lines are registered yet (concrete tool hookups land
-		// in follow-up changes), so the universal layer is currently a no-op. These
-		// guard the wiring; the composition/gating itself is covered in
-		// toolInstructions.test.ts.
+		// The browser line is the registered universal tool-instruction (see
+		// toolInstructions.ts). These guard that the registry layers it end-to-end;
+		// the composition/gating itself is covered in toolInstructions.test.ts.
+		const BROWSER_LINE = 'Use the browser tools (openBrowserPage, readPage, etc.) when beneficial for front-end tasks, such as when visualizing or validating UI changes.';
+		const browserTools = [BrowserChatToolReferenceName.OpenBrowserPage, BrowserChatToolReferenceName.ReadPage];
 
-		test('is a no-op while no tool-instruction lines are registered', () => {
+		test('is a no-op when the session exposes no matching tools', () => {
 			const registry = new AgentHostPromptRegistry();
 			assert.deepStrictEqual(registry.resolveSystemMessageConfig({ id: 'm' }, context({}, ['anyTool'])), COPILOT_AGENT_HOST_SYSTEM_MESSAGE);
 		});
 
-		test('leaves a per-model tool_instructions override untouched', () => {
+		test('layers the browser tool_instructions onto the default config when browser tools are present', () => {
+			const registry = new AgentHostPromptRegistry();
+			assert.deepStrictEqual(
+				registry.resolveSystemMessageConfig({ id: 'm' }, context({}, browserTools)),
+				{
+					mode: 'customize',
+					sections: {
+						identity: COPILOT_AGENT_HOST_SYSTEM_MESSAGE.sections.identity,
+						tool_instructions: { action: 'append', content: `\n${BROWSER_LINE}` },
+					},
+				}
+			);
+		});
+
+		test('composes the browser line with a per-model tool_instructions override', () => {
+			const registry = new AgentHostPromptRegistry();
+			registry.registerPrompt(class {
+				static readonly familyPrefixes = ['claude'];
+				resolveSectionOverrides(): Partial<Record<SystemMessageSection, SectionOverride>> {
+					return { tool_instructions: { action: 'append', content: 'Always prefer ripgrep.' } };
+				}
+			});
+			assert.deepStrictEqual(
+				registry.resolveSystemMessageConfig({ id: 'claude-x' }, context({}, browserTools)),
+				{ mode: 'customize', sections: { tool_instructions: { action: 'append', content: `\nAlways prefer ripgrep.\n${BROWSER_LINE}` } } }
+			);
+		});
+
+		test('leaves a per-model tool_instructions override untouched when no browser tools are present', () => {
 			const registry = new AgentHostPromptRegistry();
 			registry.registerPrompt(class {
 				static readonly familyPrefixes = ['claude'];

--- a/src/vs/platform/agentHost/test/node/toolInstructions.test.ts
+++ b/src/vs/platform/agentHost/test/node/toolInstructions.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import type { SectionOverride } from '@github/copilot-sdk';
-import { appendUniversalToolInstructions, composeToolInstructions, resolveToolInstructionsOverride, universalToolInstructions } from '../../node/copilot/prompts/toolInstructions.js';
+import { resolveToolInstructionsOverride, universalToolInstructions } from '../../node/copilot/prompts/toolInstructions.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 
 /** Builds a `hasTool` predicate backed by the given available tool names. */
@@ -49,9 +49,16 @@ suite('toolInstructions', () => {
 		});
 	});
 
-	suite('composeToolInstructions', () => {
-		test('appends to the foundation section when there is no per-model override', () => {
-			assert.deepStrictEqual(composeToolInstructions(undefined, 'LINE'), { action: 'append', content: '\nLINE' });
+	// `composeToolInstructions` is module-private; its composition/spacing
+	// behavior is exercised here through the public `resolveToolInstructionsOverride`
+	// (injecting synthetic lines via the `lines` seam).
+	suite('resolveToolInstructionsOverride', () => {
+		test('returns undefined (keep existing) when no line applies', () => {
+			assert.strictEqual(resolveToolInstructionsOverride(hasTools('x'), { action: 'append', content: 'A' }, [lineFor('a')]), undefined);
+		});
+
+		test('with no per-model override, appends the rendered line after the foundation section', () => {
+			assert.deepStrictEqual(resolveToolInstructionsOverride(hasTools('a'), undefined, [lineFor('a')]), { action: 'append', content: '\nuse a' });
 		});
 
 		test('folds into a per-model string override, preserving action and foundation spacing', () => {
@@ -61,42 +68,18 @@ suite('toolInstructions', () => {
 				{ action: 'replace', content: 'OWN' },// owns the section → no padding
 				{ action: 'replace', content: '' },   // empty replace → no spurious leading newline
 			];
-			assert.deepStrictEqual(overrides.map(o => composeToolInstructions(o, 'LINE')), [
-				{ action: 'append', content: '\nA\nLINE' },
-				{ action: 'prepend', content: 'P\nLINE\n' },
-				{ action: 'replace', content: 'OWN\nLINE' },
-				{ action: 'replace', content: 'LINE' },
+			assert.deepStrictEqual(overrides.map(o => resolveToolInstructionsOverride(hasTools('a'), o, [lineFor('a')])), [
+				{ action: 'append', content: '\nA\nuse a' },
+				{ action: 'prepend', content: 'P\nuse a\n' },
+				{ action: 'replace', content: 'OWN\nuse a' },
+				{ action: 'replace', content: 'use a' },
 			]);
 		});
 
 		test('preserves a remove or transform-function override untouched', () => {
 			const transform = (s: string) => s;
-			assert.deepStrictEqual(composeToolInstructions({ action: 'remove' }, 'LINE'), { action: 'remove' });
-			assert.deepStrictEqual(composeToolInstructions({ action: transform }, 'LINE'), { action: transform });
-		});
-	});
-
-	suite('resolveToolInstructionsOverride', () => {
-		test('returns undefined (keep existing) when no line applies', () => {
-			const existing: SectionOverride = { action: 'append', content: 'A' };
-			assert.strictEqual(resolveToolInstructionsOverride(hasTools('x'), existing, [lineFor('a')]), undefined);
-		});
-
-		test('composes the rendered lines with the existing override', () => {
-			assert.deepStrictEqual(
-				resolveToolInstructionsOverride(hasTools('a'), { action: 'append', content: 'A' }, [lineFor('a')]),
-				{ action: 'append', content: '\nA\nuse a' }
-			);
-		});
-	});
-
-	suite('appendUniversalToolInstructions', () => {
-		test('returns the prompt unchanged while no lines apply (default registry, no matching tools)', () => {
-			assert.strictEqual(appendUniversalToolInstructions('FULL PROMPT', hasTools('a')), 'FULL PROMPT');
-		});
-
-		test('appends the rendered lines after a blank line when a line applies', () => {
-			assert.strictEqual(appendUniversalToolInstructions('FULL PROMPT', hasTools('a'), [lineFor('a')]), 'FULL PROMPT\n\nuse a');
+			assert.deepStrictEqual(resolveToolInstructionsOverride(hasTools('a'), { action: 'remove' }, [lineFor('a')]), { action: 'remove' });
+			assert.deepStrictEqual(resolveToolInstructionsOverride(hasTools('a'), { action: transform }, [lineFor('a')]), { action: transform });
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/toolInstructions.test.ts
+++ b/src/vs/platform/agentHost/test/node/toolInstructions.test.ts
@@ -28,9 +28,24 @@ suite('toolInstructions', () => {
 			assert.strictEqual(universalToolInstructions(hasTools('a', 'c'), [lineFor('a'), lineFor('b'), lineFor('c')]), 'use a\nuse c');
 		});
 
-		test('returns undefined when no line applies (including the empty registry)', () => {
+		test('returns undefined when no line applies (including the default registry when its lines do not apply)', () => {
 			assert.strictEqual(universalToolInstructions(hasTools('x'), [lineFor('a')]), undefined);
 			assert.strictEqual(universalToolInstructions(hasTools('a')), undefined);
+		});
+
+		test('renders the registered browser line from the default registry only when openBrowserPage + an agentic browser tool are present', () => {
+			assert.deepStrictEqual(
+				[
+					universalToolInstructions(hasTools('openBrowserPage', 'readPage')),
+					universalToolInstructions(hasTools('openBrowserPage')),
+					universalToolInstructions(hasTools('readPage')),
+				],
+				[
+					'Use the browser tools (openBrowserPage, readPage, etc.) when beneficial for front-end tasks, such as when visualizing or validating UI changes.',
+					undefined,
+					undefined,
+				]
+			);
 		});
 	});
 
@@ -76,7 +91,7 @@ suite('toolInstructions', () => {
 	});
 
 	suite('appendUniversalToolInstructions', () => {
-		test('returns the prompt unchanged while no lines apply (empty registry)', () => {
+		test('returns the prompt unchanged while no lines apply (default registry, no matching tools)', () => {
 			assert.strictEqual(appendUniversalToolInstructions('FULL PROMPT', hasTools('a')), 'FULL PROMPT');
 		});
 

--- a/src/vs/platform/browserView/common/browserChatToolReferenceNames.ts
+++ b/src/vs/platform/browserView/common/browserChatToolReferenceNames.ts
@@ -5,6 +5,10 @@
 
 /**
  * Tool reference names for the integrated browser tools.
+ *
+ * Lives in `platform` (rather than next to the `workbench/contrib/browserView`
+ * tools that produce them) so the Copilot agent host — which cannot import from
+ * `workbench` — can gate its browser tool instructions on the same names.
  */
 export const BrowserChatToolReferenceName = {
 	OpenBrowserPage: 'openBrowserPage',

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/clickBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/clickBrowserTool.ts
@@ -10,7 +10,7 @@ import { localize } from '../../../../../nls.js';
 import { IPlaywrightService } from '../../../../../platform/browserView/common/playwrightService.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { createBrowserPageLink, DEFAULT_ELEMENT_LABEL, errorResult, getSessionId, playwrightInvoke } from './browserToolHelpers.js';
-import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
+import { BrowserChatToolReferenceName } from '../../../../../platform/browserView/common/browserChatToolReferenceNames.js';
 import { OpenPageToolId } from './openBrowserTool.js';
 
 export const ClickBrowserToolData: IToolData = {

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/dragElementTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/dragElementTool.ts
@@ -10,7 +10,7 @@ import { localize } from '../../../../../nls.js';
 import { IPlaywrightService } from '../../../../../platform/browserView/common/playwrightService.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { createBrowserPageLink, DEFAULT_ELEMENT_LABEL, errorResult, getSessionId, playwrightInvoke } from './browserToolHelpers.js';
-import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
+import { BrowserChatToolReferenceName } from '../../../../../platform/browserView/common/browserChatToolReferenceNames.js';
 import { OpenPageToolId } from './openBrowserTool.js';
 
 export const DragElementToolData: IToolData = {

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/handleDialogBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/handleDialogBrowserTool.ts
@@ -10,7 +10,7 @@ import { localize } from '../../../../../nls.js';
 import { IPlaywrightService } from '../../../../../platform/browserView/common/playwrightService.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { createBrowserPageLink, errorResult, getSessionId } from './browserToolHelpers.js';
-import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
+import { BrowserChatToolReferenceName } from '../../../../../platform/browserView/common/browserChatToolReferenceNames.js';
 import { OpenPageToolId } from './openBrowserTool.js';
 
 export const HandleDialogBrowserToolData: IToolData = {

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/hoverElementTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/hoverElementTool.ts
@@ -10,7 +10,7 @@ import { localize } from '../../../../../nls.js';
 import { IPlaywrightService } from '../../../../../platform/browserView/common/playwrightService.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { createBrowserPageLink, DEFAULT_ELEMENT_LABEL, errorResult, getSessionId, playwrightInvoke } from './browserToolHelpers.js';
-import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
+import { BrowserChatToolReferenceName } from '../../../../../platform/browserView/common/browserChatToolReferenceNames.js';
 import { OpenPageToolId } from './openBrowserTool.js';
 
 export const HoverElementToolData: IToolData = {

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/navigateBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/navigateBrowserTool.ts
@@ -12,7 +12,7 @@ import { IPlaywrightService } from '../../../../../platform/browserView/common/p
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { IAgentNetworkFilterService } from '../../../../../platform/networkFilter/common/networkFilterService.js';
 import { createBrowserPageLink, errorResult, getSessionId, playwrightInvoke, remoteUrlRewriteNotice, rewriteRemoteLocalhostUrl } from './browserToolHelpers.js';
-import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
+import { BrowserChatToolReferenceName } from '../../../../../platform/browserView/common/browserChatToolReferenceNames.js';
 import { IBrowserViewWorkbenchService } from '../../common/browserView.js';
 import { IRemoteExplorerService } from '../../../../services/remote/common/remoteExplorerService.js';
 import { OpenPageToolId } from './openBrowserTool.js';

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/openBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/openBrowserTool.ts
@@ -23,7 +23,7 @@ import { IChatRequestModel } from '../../../chat/common/model/chatModel.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { BrowserViewSharingState, IBrowserViewWorkbenchService } from '../../common/browserView.js';
 import { BrowserEditorInput } from '../../common/browserEditorInput.js';
-import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
+import { BrowserChatToolReferenceName } from '../../../../../platform/browserView/common/browserChatToolReferenceNames.js';
 import { createBrowserPageLink, findExistingPagesByHost, getExistingPagesResult, getSessionId, remoteUrlRewriteNotice, rewriteRemoteLocalhostUrl } from './browserToolHelpers.js';
 import { IRemoteExplorerService } from '../../../../services/remote/common/remoteExplorerService.js';
 

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/readBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/readBrowserTool.ts
@@ -10,7 +10,7 @@ import { localize } from '../../../../../nls.js';
 import { IPlaywrightService } from '../../../../../platform/browserView/common/playwrightService.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { createBrowserPageLink, errorResult, getSessionId } from './browserToolHelpers.js';
-import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
+import { BrowserChatToolReferenceName } from '../../../../../platform/browserView/common/browserChatToolReferenceNames.js';
 import { OpenPageToolId } from './openBrowserTool.js';
 
 export const ReadBrowserToolData: IToolData = {

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/runPlaywrightCodeTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/runPlaywrightCodeTool.ts
@@ -10,7 +10,7 @@ import { localize } from '../../../../../nls.js';
 import { IPlaywrightService } from '../../../../../platform/browserView/common/playwrightService.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { errorResult, getSessionId, invokeFunctionResultToToolResult } from './browserToolHelpers.js';
-import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
+import { BrowserChatToolReferenceName } from '../../../../../platform/browserView/common/browserChatToolReferenceNames.js';
 import { OpenPageToolId } from './openBrowserTool.js';
 
 export const RunPlaywrightCodeToolData: IToolData = {

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/screenshotBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/screenshotBrowserTool.ts
@@ -21,7 +21,7 @@ import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation,
 import { IBrowserViewModel, IBrowserViewWorkbenchService } from '../../common/browserView.js';
 import { BrowserEditorInput } from '../../common/browserEditorInput.js';
 import { errorResult, getSessionId, playwrightInvokeRaw } from './browserToolHelpers.js';
-import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
+import { BrowserChatToolReferenceName } from '../../../../../platform/browserView/common/browserChatToolReferenceNames.js';
 import { OpenPageToolId } from './openBrowserTool.js';
 import { ReadBrowserToolData } from './readBrowserTool.js';
 

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/typeBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/typeBrowserTool.ts
@@ -13,7 +13,7 @@ import { localize } from '../../../../../nls.js';
 import { IPlaywrightService } from '../../../../../platform/browserView/common/playwrightService.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { createBrowserPageLink, errorResult, getSessionId, playwrightInvoke } from './browserToolHelpers.js';
-import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
+import { BrowserChatToolReferenceName } from '../../../../../platform/browserView/common/browserChatToolReferenceNames.js';
 import { OpenPageToolId } from './openBrowserTool.js';
 
 export const TypeBrowserToolData: IToolData = {

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -208,7 +208,7 @@ import { ExploreAgentDefaultModel } from './exploreAgentDefaultModel.js';
 import { PlanAgentDefaultModel } from './planAgentDefaultModel.js';
 import { UtilityModelContribution, UtilitySmallModelContribution } from './utilityModelContribution.js';
 import { ChatImageCarouselService, IChatImageCarouselService } from './chatImageCarouselService.js';
-import { browserChatToolReferenceNames } from '../../browserView/common/browserChatToolReferenceNames.js';
+import { browserChatToolReferenceNames } from '../../../../platform/browserView/common/browserChatToolReferenceNames.js';
 
 CommandsRegistry.registerCommand('_chat.notifyQuestionCarouselAnswer', (accessor: ServicesAccessor, resolveId: string, answers?: import('../common/chatService/chatService.js').IChatQuestionAnswers) => {
 	accessor.get(IChatService).notifyQuestionCarouselAnswer('', resolveId, answers);


### PR DESCRIPTION
## What

Ports the Copilot extension's `toolUseInstructions` browser guidance into the agent host (Copilot CLI / ahp+cli) prompt system as a model-agnostic, tool-gated `tool_instructions` system-prompt line.

- Adds `browserToolInstructions` to `TOOL_INSTRUCTION_LINES` in `toolInstructions.ts`. It gates on `openBrowserPage` **and** at least one agentic browser companion tool being present, naming the first available companion as the example.
- Relocates `browserChatToolReferenceNames.ts` from `workbench/contrib/browserView/common/` to `platform/browserView/common/` so the agent host (which lives in `platform` and cannot import from `workbench`) can gate on the same reference names. All consumers (10 browser tools + `chat.shared.contribution.ts`) updated to the new import path.
- Adds `AGENTS.md` documenting the agent-host prompt-customization subsystem (levers, sections, gotchas).
- Drops the unused `appendUniversalToolInstructions` replace-mode helper (no production caller) and makes `composeToolInstructions` module-private; tests now exercise composition through the public `resolveToolInstructionsOverride`.