### PR TITLE
fix editor container overflow

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -988,6 +988,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		rely on a visible focus/container outline for accessibility. */
 	border-color: var(--vscode-input-border, transparent);
 	overflow: visible;
+
+	> .chat-editor-container {
+		overflow: hidden;
+	}
 }
 
 .monaco-workbench .interactive-session .chat-input-container.working.focused {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

cc @mrleemurray i'm actually not sure when or how this happened lol. seems agent window specific. 

<img width="103" height="65" alt="Screenshot 2026-06-23 at 10 43 01 AM" src="https://github.com/user-attachments/assets/985e1e6c-d4b2-4f84-9942-013d005db3c6" />
<img width="916" height="145" alt="Screenshot 2026-06-23 at 10 42 55 AM" src="https://github.com/user-attachments/assets/9a6f922b-a396-495e-a31d-b9806b0eb632" />
