### PR TITLE
chat: use plugin labels for plugin-scoped slash commands

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -186,7 +186,7 @@ In core VS Code, customization items contributed by the default chat extension (
 
 ### Management Editor Item Pipeline
 
-All customization sources — `IPromptsService`, extension-contributed providers, and AHP remote servers — produce items conforming to the same `ICustomizationItem` contract (defined in `customizationHarnessService.ts`). This contract carries `uri`, `type`, `name`, `description`, optional `storage`, `groupKey`, `badge`, and status fields.
+All customization sources — `IPromptsService`, extension-contributed providers, and AHP remote servers — produce items conforming to the same `ICustomizationItem` contract (defined in `customizationHarnessService.ts`). This contract carries `uri`, `type`, `name`, `description`, optional `storage`, `groupKey`, `badge`, plugin provenance (`pluginUri`/`pluginLabel`), and status fields.
 
 ```
 promptsService ──→ PromptsServiceCustomizationItemProvider ──→ ICustomizationItem[]

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -779,6 +779,7 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 					badgeTooltip: item.badgeTooltip,
 					extensionId: item.extensionId,
 					pluginUri: item.pluginUri ? URI.revive(item.pluginUri) : undefined,
+					pluginLabel: item.pluginLabel,
 					userInvocable: item.userInvocable,
 				}));
 			},

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1817,6 +1817,7 @@ export interface IChatSessionCustomizationItemDto {
 	readonly badge?: string;
 	readonly extensionId?: string;
 	readonly pluginUri?: UriComponents;
+	readonly pluginLabel?: string;
 	readonly badgeTooltip?: string;
 	readonly userInvocable?: boolean;
 }

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -852,6 +852,7 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 				badgeTooltip: item.badgeTooltip,
 				extensionId: item.extensionId,
 				pluginUri: item.pluginUri,
+				pluginLabel: item.pluginLabel,
 				userInvocable: item.userInvocable,
 			} satisfies IChatSessionCustomizationItemDto));
 		} catch (err) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationContentExpander.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationContentExpander.ts
@@ -27,7 +27,7 @@ export class AgentCustomizationContentExpander {
 	) {
 	}
 
-	async expandPluginContents(pluginUri: URI, groupKey: string, isBundleItem: boolean, source: AICustomizationSource, token: CancellationToken): Promise<readonly ICustomizationItem[]> {
+	async expandPluginContents(pluginUri: URI, groupKey: string, isBundleItem: boolean, source: AICustomizationSource, pluginLabel: string | undefined, token: CancellationToken): Promise<readonly ICustomizationItem[]> {
 		// pluginUri is already an agent-host:// URI (from toRemoteUri),
 		// so use it directly as the filesystem root.
 		const fsRoot = pluginUri;
@@ -55,9 +55,9 @@ export class AgentCustomizationContentExpander {
 					continue;
 				}
 				if (promptType === PromptsType.skill) {
-					children.push(...await this.collectFromSkillDir(stat.stat.children, pluginUri, source, groupKey, isBundleItem, token));
+					children.push(...await this.collectFromSkillDir(stat.stat.children, pluginUri, source, groupKey, isBundleItem, pluginLabel, token));
 				} else {
-					children.push(...await this.collectFromRegularDir(stat.stat.children, pluginUri, source, promptType, groupKey, isBundleItem, token));
+					children.push(...await this.collectFromRegularDir(stat.stat.children, pluginUri, source, promptType, groupKey, isBundleItem, pluginLabel, token));
 				}
 			}
 			children.sort((a, b) => `${a.type}:${a.name}`.localeCompare(`${b.type}:${b.name}`));
@@ -72,7 +72,7 @@ export class AgentCustomizationContentExpander {
 	 * Emits one item per skill subfolder that contains a SKILL.md file.
 	 * The skill metadata comes from SKILL.md frontmatter.
 	 */
-	private async collectFromSkillDir(entries: readonly { name: string; resource: URI; isDirectory: boolean }[], pluginUri: URI, source: AICustomizationSource, groupKey: string, isBundleItem: boolean, token: CancellationToken): Promise<ICustomizationItem[]> {
+	private async collectFromSkillDir(entries: readonly { name: string; resource: URI; isDirectory: boolean }[], pluginUri: URI, source: AICustomizationSource, groupKey: string, isBundleItem: boolean, pluginLabel: string | undefined, token: CancellationToken): Promise<ICustomizationItem[]> {
 		type Entry = { name: string; resource: URI; isDirectory: boolean };
 		const eligible: Entry[] = [];
 		const readMetaDataPromises = [];
@@ -113,6 +113,7 @@ export class AgentCustomizationContentExpander {
 				groupKey,
 				extensionId: undefined,
 				pluginUri: isBundleItem ? undefined : pluginUri,
+				pluginLabel: isBundleItem ? undefined : pluginLabel,
 				userInvocable
 			} satisfies ICustomizationItem);
 		}
@@ -125,7 +126,7 @@ export class AgentCustomizationContentExpander {
 	 * agents additionally surface userInvocable. Instruction (rules)
 	 * folders additionally accept `.mdc` files per the Open Plugins spec.
 	 */
-	private async collectFromRegularDir(entries: readonly { name: string; resource: URI; isDirectory: boolean }[], pluginUri: URI, source: AICustomizationSource, promptType: PromptsType, groupKey: string, isBundleItem: boolean, token: CancellationToken): Promise<ICustomizationItem[]> {
+	private async collectFromRegularDir(entries: readonly { name: string; resource: URI; isDirectory: boolean }[], pluginUri: URI, source: AICustomizationSource, promptType: PromptsType, groupKey: string, isBundleItem: boolean, pluginLabel: string | undefined, token: CancellationToken): Promise<ICustomizationItem[]> {
 		type Entry = { name: string; resource: URI; isDirectory: boolean };
 		const eligible: Entry[] = [];
 		for (const child of entries) {
@@ -162,6 +163,7 @@ export class AgentCustomizationContentExpander {
 				groupKey,
 				extensionId: undefined,
 				pluginUri: isBundleItem ? undefined : pluginUri,
+				pluginLabel: isBundleItem ? undefined : pluginLabel,
 				userInvocable: promptType === PromptsType.agent ? meta?.userInvocable : undefined,
 			} satisfies ICustomizationItem);
 		}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationItemProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationItemProvider.ts
@@ -27,15 +27,15 @@ const REMOTE_HOST_GROUP = 'remote-host';
 const REMOTE_CLIENT_GROUP = 'remote-client';
 
 
-type PluginMeta = { item: ICustomizationItem; nonce: string | undefined; status: ReturnType<typeof toStatusString>; statusMessage: string | undefined; enabled: boolean | undefined; childGroupKey: string; isBundleItem: boolean };
+type PluginMeta = { item: ICustomizationItem; nonce: string | undefined; status: ReturnType<typeof toStatusString>; statusMessage: string | undefined; enabled: boolean | undefined; childGroupKey: string; isBundleItem: boolean; pluginLabel: string | undefined };
 
 
 export class AgentCustomizationItemProvider extends Disposable implements ICustomizationItemProvider {
 	private readonly _onDidChange = this._register(new Emitter<void>());
 	readonly onDidChange: Event<void> = this._onDidChange.event;
 
-	/** Cache: pluginUri → last expansion (keyed by nonce so we re-fetch on content change). */
-	private readonly _expansionCache = new ResourceMap<{ nonce: string | undefined; children: readonly ICustomizationItem[] }>();
+	/** Cache: pluginUri → last expansion (keyed by nonce and label so we re-fetch on content or display-name changes). */
+	private readonly _expansionCache = new ResourceMap<{ nonce: string | undefined; pluginLabel: string | undefined; children: readonly ICustomizationItem[] }>();
 	private readonly _contentExpander: AgentCustomizationContentExpander;
 
 	constructor(
@@ -207,7 +207,8 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 					statusMessage: toStatusMessage(sessionCustomization.load),
 					enabled: sessionCustomization.enabled,
 					childGroupKey,
-					isBundleItem
+					isBundleItem,
+					pluginLabel: isBundleItem ? undefined : item.name,
 				} satisfies PluginMeta;
 				plugins.push(pluginMeta);
 				expandPromises.push(this._expandPluginContents(pluginMeta, token));
@@ -258,11 +259,11 @@ export class AgentCustomizationItemProvider extends Disposable implements ICusto
 	 */
 	private async _expandPluginContents(plugin: PluginMeta, token: CancellationToken): Promise<readonly ICustomizationItem[]> {
 		const cached = this._expansionCache.get(plugin.item.uri);
-		if (cached && cached.nonce === plugin.nonce) {
+		if (cached && cached.nonce === plugin.nonce && cached.pluginLabel === plugin.pluginLabel) {
 			return cached.children;
 		}
-		const children = await this._contentExpander.expandPluginContents(plugin.item.uri, plugin.childGroupKey, plugin.isBundleItem, plugin.item.source, token);
-		this._expansionCache.set(plugin.item.uri, { nonce: plugin.nonce, children });
+		const children = await this._contentExpander.expandPluginContents(plugin.item.uri, plugin.childGroupKey, plugin.isBundleItem, plugin.item.source, plugin.pluginLabel, token);
+		this._expansionCache.set(plugin.item.uri, { nonce: plugin.nonce, pluginLabel: plugin.pluginLabel, children });
 		return children;
 	}
 }
@@ -333,4 +334,3 @@ function isSyntheticBundle(customization: Customization): boolean {
 		return false;
 	}
 }
-

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/promptsServiceCustomizationItemProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/promptsServiceCustomizationItemProvider.ts
@@ -117,6 +117,7 @@ export class PromptsServiceCustomizationItemProvider implements ICustomizationIt
 					badgeTooltip: uiTooltip,
 					extensionId: skill.extension?.identifier.value,
 					pluginUri: skill.pluginUri,
+					pluginLabel: skill.pluginLabel,
 					userInvocable: skill.userInvocable
 				});
 			}
@@ -137,6 +138,7 @@ export class PromptsServiceCustomizationItemProvider implements ICustomizationIt
 							badgeTooltip: uiTooltip,
 							extensionId: file.extension?.identifier.value,
 							pluginUri: file.pluginUri,
+							pluginLabel: file.pluginLabel,
 							userInvocable: false
 						});
 					}
@@ -157,6 +159,7 @@ export class PromptsServiceCustomizationItemProvider implements ICustomizationIt
 					enabled: !disabledUris.has(command.uri),
 					extensionId: command.extension?.identifier.value,
 					pluginUri: command.pluginUri,
+					pluginLabel: command.pluginLabel,
 					userInvocable: command.userInvocable
 				});
 				if (command.extension) {

--- a/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
@@ -171,6 +171,8 @@ export interface ICustomizationItem {
 	readonly extensionId: string | undefined;
 	/** The URI of the plugin that contributed this customization, if any. */
 	readonly pluginUri: URI | undefined;
+	/** Human-readable name of the plugin that contributed this customization, if any. */
+	readonly pluginLabel?: string;
 	/** Server-reported loading status for this customization. */
 	readonly status?: 'loading' | 'loaded' | 'degraded' | 'error';
 	/** Human-readable status detail (e.g. error message or warning). */
@@ -697,7 +699,7 @@ export class CustomizationHarnessServiceBase implements ICustomizationHarnessSer
 				result.push({
 					uri: item.uri,
 					type: item.type as PromptsType.prompt | PromptsType.skill,
-					name: item.pluginUri ? getCanonicalPluginCommandId({ uri: item.pluginUri }, item.name) : item.name,
+					name: item.pluginUri ? getCanonicalPluginCommandId({ uri: item.pluginUri, label: item.pluginLabel }, item.name) : item.name,
 					description: item.description,
 					userInvocable: item.userInvocable ?? true,
 					storage: narrowStorage,

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginService.ts
@@ -72,9 +72,8 @@ export const enum AgentPluginDiscoveryPriority {
 	CopilotCli = 40,
 }
 
-export function getCanonicalPluginCommandId(plugin: { readonly uri: URI }, commandName: string): string {
-	const pluginSegment = basename(plugin.uri);
-	const prefix = normalizePluginToken(pluginSegment);
+export function getCanonicalPluginCommandId(plugin: { readonly uri: URI; readonly label?: string }, commandName: string): string {
+	const prefix = (plugin.label ? normalizePluginToken(plugin.label) : '') || normalizePluginToken(basename(plugin.uri));
 	const normalizedCommand = normalizePluginToken(commandName);
 	if (normalizedCommand.startsWith(`${prefix}:`)) {
 		return normalizedCommand;
@@ -121,4 +120,3 @@ class AgentPluginDiscoveryRegistry {
 }
 
 export const agentPluginDiscoveryRegistry = new AgentPluginDiscoveryRegistry();
-

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -153,6 +153,11 @@ export interface IPromptPathBase {
 	readonly pluginUri?: URI;
 
 	/**
+	 * Human-readable name of the contributing plugin, used for plugin-scoped slash command names.
+	 */
+	readonly pluginLabel?: string;
+
+	/**
 	 * The source that produced this prompt path.
 	 */
 	readonly source?: PromptFileSource;
@@ -351,6 +356,7 @@ export interface IChatPromptSlashCommand {
 	readonly userInvocable: boolean;
 	readonly extension?: IExtensionDescription;
 	readonly pluginUri?: URI;
+	readonly pluginLabel?: string;
 	/**
 	 * Optional session types that describe when this slash command should be offered.
 	 */
@@ -430,6 +436,10 @@ export interface IAgentSkill {
 	 * Optional plugin URI describing where this skill originated.
 	 */
 	readonly pluginUri?: URI;
+	/**
+	 * Optional plugin display name describing where this skill originated.
+	 */
+	readonly pluginLabel?: string;
 	/**
 	 * Optional extension metadata describing where this skill originated.
 	 */

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -234,6 +234,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 							type: PromptsType.hook,
 							name: getCanonicalPluginCommandId(plugin, hook.originalId),
 							pluginUri: plugin.uri,
+							pluginLabel: plugin.label,
 							source: PromptFileSource.Plugin,
 						});
 					}
@@ -264,6 +265,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 						type,
 						name: getCanonicalPluginCommandId(plugin, item.name),
 						pluginUri: plugin.uri,
+						pluginLabel: plugin.label,
 						source: PromptFileSource.Plugin,
 					});
 				}
@@ -455,7 +457,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 				// For plugin resources, ensure the canonical plugin prefix is always preserved even when the
 				// file's frontmatter overrides the name.
 				const name = promptPath.source === PromptFileSource.Plugin && promptPath.pluginUri
-					? getCanonicalPluginCommandId({ uri: promptPath.pluginUri }, rawName)
+					? getCanonicalPluginCommandId({ uri: promptPath.pluginUri, label: promptPath.pluginLabel }, rawName)
 					: rawName;
 				const description = parsedPromptFile?.header?.description ?? promptPath.description;
 				const argumentHint = parsedPromptFile?.header?.argumentHint;
@@ -573,6 +575,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 			type: promptPath.type,
 			extension: promptPath.extension,
 			pluginUri: promptPath.pluginUri,
+			pluginLabel: promptPath.pluginLabel,
 			description: promptPath.description,
 			argumentHint: argumentHint,
 			userInvocable: userInvocable ?? true,
@@ -900,6 +903,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 					disableModelInvocation: file.disableModelInvocation ?? false,
 					userInvocable: file.userInvocable ?? true,
 					pluginUri: file.promptPath.pluginUri,
+					pluginLabel: file.promptPath.pluginLabel,
 					extension: file.promptPath.extension,
 					sessionTypes: file.promptPath.sessionTypes,
 				});
@@ -1565,4 +1569,3 @@ export namespace CustomAgent {
 
 	}
 }
-

--- a/src/vs/workbench/contrib/chat/test/browser/agentHost/agentCustomizationContentExpander.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentHost/agentCustomizationContentExpander.test.ts
@@ -25,8 +25,8 @@ const REMOTE_CLIENT_GROUP = 'remote-client';
 // Helpers
 // ---------------------------------------------------------------------------
 
-function expand(expander: AgentCustomizationContentExpander, pluginUri: URI, groupKey: string, isBundleItem: boolean, source: AICustomizationSource, token: CancellationToken): Promise<readonly ICustomizationItem[]> {
-	return expander.expandPluginContents(pluginUri, groupKey, isBundleItem, source, token);
+function expand(expander: AgentCustomizationContentExpander, pluginUri: URI, groupKey: string, isBundleItem: boolean, source: AICustomizationSource, token: CancellationToken, pluginLabel?: string): Promise<readonly ICustomizationItem[]> {
+	return expander.expandPluginContents(pluginUri, groupKey, isBundleItem, source, pluginLabel, token);
 }
 
 // ---------------------------------------------------------------------------
@@ -464,7 +464,7 @@ suite('AgentCustomizationContentExpander', () => {
 			}
 		});
 
-		test('isBundleItem=true clears pluginUri on child items', async () => {
+		test('isBundleItem=true clears pluginUri and pluginLabel on child items', async () => {
 			const pluginRoot = URI.file('/plugins/bundle');
 			await mockFiles(fileService, [
 				{
@@ -477,15 +477,14 @@ suite('AgentCustomizationContentExpander', () => {
 			]);
 
 			const expander = new AgentCustomizationContentExpander(fileService, new NullLogService());
-			const bundleItems = await expand(expander, pluginRoot, REMOTE_CLIENT_GROUP, true /* isBundleItem */, AICustomizationSources.plugin, CancellationToken.None);
+			const bundleItems = await expand(expander, pluginRoot, REMOTE_CLIENT_GROUP, true /* isBundleItem */, AICustomizationSources.plugin, CancellationToken.None, 'bundle-plugin');
 
-			// Bundle items must not carry pluginUri
 			for (const item of bundleItems) {
-				assert.strictEqual(item.pluginUri, undefined, `bundle item ${item.name} must have no pluginUri`);
+				assert.deepStrictEqual({ pluginUri: item.pluginUri, pluginLabel: item.pluginLabel }, { pluginUri: undefined, pluginLabel: undefined }, `bundle item ${item.name} must have no plugin provenance`);
 			}
 		});
 
-		test('isBundleItem=false sets pluginUri to the plugin root on child items', async () => {
+		test('isBundleItem=false sets pluginUri and pluginLabel on child items', async () => {
 			const pluginRoot = URI.file('/plugins/with-uri');
 			await mockFiles(fileService, [
 				{
@@ -498,9 +497,9 @@ suite('AgentCustomizationContentExpander', () => {
 			]);
 
 			const expander = new AgentCustomizationContentExpander(fileService, new NullLogService());
-			const items = await expand(expander, pluginRoot, REMOTE_HOST_GROUP, false, AICustomizationSources.plugin, CancellationToken.None);
+			const items = await expand(expander, pluginRoot, REMOTE_HOST_GROUP, false, AICustomizationSources.plugin, CancellationToken.None, 'Datadog');
 			assert.strictEqual(items.length, 1);
-			assert.strictEqual(items[0].pluginUri?.toString(), pluginRoot.toString());
+			assert.deepStrictEqual({ pluginUri: items[0].pluginUri?.toString(), pluginLabel: items[0].pluginLabel }, { pluginUri: pluginRoot.toString(), pluginLabel: 'Datadog' });
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/customizationHarnessService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/customizationHarnessService.test.ts
@@ -405,6 +405,32 @@ suite('CustomizationHarnessService', () => {
 			]);
 		});
 
+		test('uses plugin label for plugin-scoped commands when provider plugin URI is a pinned SHA path', async () => {
+			const testSessionType = 'test-session-type';
+			const testSessionResource = URI.parse('test-session-type://session');
+			const pluginUri = URI.parse('file:///cache/agentPlugins/github/datadog/sha_b003fcad48c3a935ffe04b6218f5cf58fe2b6760');
+
+			const emitter = new Emitter<void>();
+			store.add(emitter);
+			const service = createService({
+				id: testSessionType,
+				label: 'Test Extension',
+				icon: ThemeIcon.fromId('extensions'),
+				getStorageSourceFilter: () => ({ sources: [AICustomizationSources.plugin] }),
+				itemProvider: {
+					onDidChange: emitter.event,
+					provideChatSessionCustomizations: async (_sessionResource: URI, _token: CancellationToken) => [
+						{ uri: URI.joinPath(pluginUri, 'skills', 'ddsetup', 'SKILL.md'), type: PromptsType.skill, source: 'plugin', name: 'ddsetup', description: 'Set up Datadog', extensionId: undefined, pluginUri, pluginLabel: 'datadog', userInvocable: undefined },
+					],
+				},
+			});
+
+			const commands = await service.getSlashCommands(testSessionResource, CancellationToken.None);
+			assert.deepStrictEqual(commands.map(command => ({ name: command.name, description: command.description, type: command.type })), [
+				{ name: 'datadog:ddsetup', description: 'Set up Datadog', type: PromptsType.skill },
+			]);
+		});
+
 		test('falls back to promptsService when the active harness has no provider', async () => {
 
 			const testSessionType = 'test-session-type';

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -4473,6 +4473,55 @@ suite('PromptsService', () => {
 
 			testPluginsObservable.set([], undefined);
 		});
+
+		test('plugin skill slash command prefix uses plugin label when install path is a pinned SHA', async () => {
+			testConfigService.setUserConfiguration(PromptsConfig.USE_AGENT_SKILLS, true);
+			testConfigService.setUserConfiguration(PromptsConfig.SKILLS_LOCATION_KEY, {});
+
+			const pluginUri = URI.file('/cache/agentPlugins/github/datadog/sha_b003fcad48c3a935ffe04b6218f5cf58fe2b6760');
+			const skillUri = URI.joinPath(pluginUri, 'skills', 'ddsetup', 'SKILL.md');
+			await mockFiles(fileService, [
+				{
+					path: skillUri.path,
+					contents: [
+						'---',
+						'name: "ddsetup"',
+						'description: "Set up Datadog"',
+						'---',
+						'Datadog setup skill content',
+					],
+				},
+			]);
+
+			const enablement = observableValue('testPluginEnablement', 2 /* ContributionEnablementState.EnabledProfile */);
+			const plugin: IAgentPlugin = {
+				uri: pluginUri,
+				label: 'datadog',
+				enablement,
+				remove: () => { },
+				hooks: observableValue('testPluginHooks', []),
+				commands: observableValue('testPluginCommands', []),
+				skills: observableValue<readonly IAgentPluginSkill[]>('testPluginSkills', [{ uri: skillUri, name: 'ddsetup' }]),
+				agents: observableValue('testPluginAgents', []),
+				instructions: observableValue('testPluginInstructions', []),
+				mcpServerDefinitions: observableValue('testPluginMcpServerDefinitions', []),
+			};
+
+			testPluginsObservable.set([plugin], undefined);
+
+			const slashCommands = await service.getPromptSlashCommands(CancellationToken.None);
+
+			assert.deepStrictEqual(slashCommands
+				.filter(command => command.uri.toString() === skillUri.toString())
+				.map(command => ({ name: command.name, description: command.description, type: command.type, storage: command.storage })), [{
+					name: 'datadog:ddsetup',
+					description: 'Set up Datadog',
+					type: PromptsType.skill,
+					storage: PromptsStorage.plugin,
+				}]);
+
+			testPluginsObservable.set([], undefined);
+		});
 	});
 
 	suite('hooks', () => {

--- a/src/vscode-dts/vscode.proposed.chatSessionCustomizationProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionCustomizationProvider.d.ts
@@ -107,6 +107,13 @@ declare module 'vscode' {
 		readonly pluginUri?: Uri;
 
 		/**
+		 * Human-readable name of the plugin that contributed this customization, if any.
+		 * Used to qualify plugin-scoped slash command names when `pluginUri` points to
+		 * an implementation-specific install directory.
+		 */
+		readonly pluginLabel?: string;
+
+		/**
 		 * Optional group key for display grouping. Items sharing the same
 		 * `groupKey` are placed under a shared collapsible header in the
 		 * management UI.


### PR DESCRIPTION
- Uses plugin display labels to keep slash command names stable for plugin items installed under implementation-specific SHA paths.
- Keeps customization provenance consistent across prompts, agent sessions, and harness providers so plugin-scoped commands resolve correctly.
- Fixes #322519

(Commit message generated by Copilot)