### PR TITLE
sessions: move remote connections toggle to titlebar

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -85,7 +85,7 @@ The titlebar is a standalone implementation (`TitlebarPart`) — not extending `
 |---------|---------|---------|
 | Left | `Menus.TitleBarLeftLayout` | Toggle sidebar, agent host filter |
 | Center | `Menus.CommandCenter` | Session picker widget (plus `Menus.TitleBarSessionMenu` for active-session actions) |
-| Right | `Menus.TitleBarRightLayout` | Run script (split button), Open Terminal/VS Code, toggle auxiliary bar, account widget |
+| Right | `Menus.TitleBarRightLayout` | Remote connections, run script (split button), Open Terminal/VS Code, toggle auxiliary bar, account widget |
 
 No menubar, no editor actions, no `WindowTitle` dependency.
 
@@ -107,6 +107,12 @@ When multiple remote agent hosts are known, a dropdown pill in the left toolbar 
 ### Account Widget (Right)
 
 Shows the signed-in GitHub profile image (falls back to the account codicon). Clicking opens a combined account and Copilot status panel with sign-in/sign-out and settings actions.
+
+### Remote Connections (Right)
+
+The remote connections toggle is a global titlebar action (`Menus.TitleBarRightLayout`) rather than a per-chat input action. This keeps tunnel hosting state visually scoped to the Agents window as a whole, so users do not interpret it as a setting that must be enabled separately for each chat session.
+
+This Agents-window placement is intentionally different from the main editor window: outside the Agents window the same toggle remains in `MenuId.ChatInputSecondary` for agent-host chat inputs. Keep both menu items mutually exclusive with `IsSessionsWindowContext` so the editor window keeps its chat-input affordance while the Agents window shows only the titlebar affordance.
 
 ---
 

--- a/src/vs/sessions/contrib/tunnelHost/electron-browser/tunnelHost.contribution.ts
+++ b/src/vs/sessions/contrib/tunnelHost/electron-browser/tunnelHost.contribution.ts
@@ -5,136 +5,45 @@
 
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { localize, localize2 } from '../../../../nls.js';
-import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
-import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
-import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
-import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
-import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
-import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
-import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
-import { Registry } from '../../../../platform/registry/common/platform.js';
+import { localize } from '../../../../nls.js';
+import { IActionViewItemService, type IActionViewItemFactory } from '../../../../platform/actions/browser/actionViewItemService.js';
+import { MenuRegistry } from '../../../../platform/actions/common/actions.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
-import { IOutputService } from '../../../../workbench/services/output/common/output.js';
+import { IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { ChatContextKeys } from '../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
-import { ChatAgentLocation } from '../../../../workbench/contrib/chat/common/constants.js';
-import { ITunnelHostService } from '../common/tunnelHost.js';
-import { TUNNEL_HOST_LOG_ID } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
-import { CONFIGURATION_KEY_MICROSOFT_AUTH, SHOW_TUNNEL_HOST_OUTPUT_ID, TunnelHostService } from './tunnelHostService.js';
-import { ToggleRemoteConnectionsActionViewItem } from './toggleRemoteConnectionsActionViewItem.js';
+import { ITunnelHostService } from '../../../../workbench/contrib/chat/common/tunnelHost.js';
+import { ToggleRemoteConnectionsActionViewItem } from '../../../../workbench/contrib/chat/electron-browser/toggleRemoteConnectionsActionViewItem.js';
+import { TOGGLE_SHARING_ID, TUNNEL_HOST_SHARING_KEY } from '../../../../workbench/contrib/chat/electron-browser/tunnelHost.contribution.js';
+import { Menus } from '../../../browser/menus.js';
 
-const TUNNEL_HOST_SHARING_KEY = 'tunnelHostSharing';
-const TUNNEL_HOST_SHARING_CONTEXT = new RawContextKey<boolean>(TUNNEL_HOST_SHARING_KEY, false);
-const TOGGLE_SHARING_ID = 'sessions.tunnelHost.toggleSharing';
+MenuRegistry.appendMenuItem(Menus.TitleBarRightLayout, {
+	command: {
+		id: TOGGLE_SHARING_ID,
+		title: localize('toggleSharing', "Allow Remote Connections"),
+		icon: Codicon.radioTower,
+		toggled: ContextKeyExpr.equals(TUNNEL_HOST_SHARING_KEY, true),
+	},
+	group: 'navigation',
+	order: 90,
+	when: ContextKeyExpr.and(ChatContextKeys.enabled, IsSessionsWindowContext, IsAuxiliaryWindowContext.toNegated())
+});
 
-const CATEGORY = localize2('tunnelHost.category', 'Remote Connections');
+class SessionsTunnelHostTitlebarContribution extends Disposable implements IWorkbenchContribution {
 
-// Register the renderer-side service
-registerSingleton(ITunnelHostService, TunnelHostService, InstantiationType.Delayed);
-
-/**
- * Contribution that manages the tunnel host sharing context key
- * and registers the toggle action in the sessions titlebar.
- */
-class TunnelHostContribution extends Disposable implements IWorkbenchContribution {
-
-	static readonly ID = 'workbench.contrib.tunnelHost';
-
-	private readonly _sharingContext: IContextKey<boolean>;
+	static readonly ID = 'workbench.contrib.sessionsTunnelHostTitlebar';
 
 	constructor(
-		@IContextKeyService contextKeyService: IContextKeyService,
 		@ITunnelHostService tunnelHostService: ITunnelHostService,
 		@IActionViewItemService actionViewItemService: IActionViewItemService,
 	) {
 		super();
 
-		this._sharingContext = TUNNEL_HOST_SHARING_CONTEXT.bindTo(contextKeyService);
-
-		// Keep context key in sync with service state
-		this._register(tunnelHostService.onDidChangeStatus(() => {
-			this._sharingContext.set(tunnelHostService.isSharing);
-		}));
-
-		// Register custom action view item with pulse, hover, and toast
-		this._register(actionViewItemService.register(
-			MenuId.ChatInputSecondary,
-			TOGGLE_SHARING_ID,
-			(action, _options, instaService) => instaService.createInstance(ToggleRemoteConnectionsActionViewItem, action),
-			tunnelHostService.onDidChangeStatus,
-		));
+		const viewItemFactory: IActionViewItemFactory = (action, _options, instantiationService) => {
+			return instantiationService.createInstance(ToggleRemoteConnectionsActionViewItem, action);
+		};
+		this._register(actionViewItemService.register(Menus.TitleBarRightLayout, TOGGLE_SHARING_ID, viewItemFactory, tunnelHostService.onDidChangeStatus));
 	}
 }
 
-// Register the toggle action
-registerAction2(class ToggleRemoteConnectionsAction extends Action2 {
-	constructor() {
-		super({
-			id: TOGGLE_SHARING_ID,
-			title: localize2("toggleSharing", "Allow Remote Connections"),
-			category: CATEGORY,
-			icon: Codicon.radioTower,
-			toggled: ContextKeyExpr.equals(TUNNEL_HOST_SHARING_KEY, true),
-			menu: {
-				id: MenuId.ChatInputSecondary,
-				order: 10,
-				group: 'navigation',
-				when: ContextKeyExpr.and(
-					ChatContextKeys.enabled,
-					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
-					ChatContextKeys.inQuickChat.negate(),
-					ContextKeyExpr.regex(ChatContextKeys.lockedCodingAgentId.key, /^agent-host-/),
-				)
-			}
-		});
-	}
-
-	async run(accessor: ServicesAccessor): Promise<void> {
-		const tunnelHostService = accessor.get(ITunnelHostService);
-		const notificationService = accessor.get(INotificationService);
-
-		try {
-			if (tunnelHostService.isSharing) {
-				await tunnelHostService.stopSharing();
-			} else {
-				await tunnelHostService.startSharing();
-			}
-		} catch (err) {
-			notificationService.notify({
-				severity: Severity.Error,
-				message: localize('tunnelHost.error', "Failed to toggle remote connections: {0}", String(err)),
-			});
-		}
-	}
-});
-
-// Register the show output action
-registerAction2(class ShowTunnelHostOutputAction extends Action2 {
-	constructor() {
-		super({
-			id: SHOW_TUNNEL_HOST_OUTPUT_ID,
-			title: localize2('showTunnelHostOutput', "Show Remote Connections Output"),
-			category: CATEGORY,
-		});
-	}
-
-	async run(accessor: ServicesAccessor): Promise<void> {
-		const outputService = accessor.get(IOutputService);
-		await outputService.showChannel(TUNNEL_HOST_LOG_ID);
-	}
-});
-
-registerWorkbenchContribution2(TunnelHostContribution.ID, TunnelHostContribution, WorkbenchPhase.AfterRestored);
-
-Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
-	type: 'object',
-	properties: {
-		[CONFIGURATION_KEY_MICROSOFT_AUTH]: {
-			description: localize('tunnelHost.enableMicrosoftAuth', "Enable Microsoft account authentication for agent host tunnels. When disabled, only GitHub authentication is used."),
-			type: 'boolean',
-			scope: ConfigurationScope.APPLICATION,
-			default: false,
-			tags: ['usesOnlineServices'],
-		},
-	}
-});
+registerWorkbenchContribution2(SessionsTunnelHostTitlebarContribution.ID, SessionsTunnelHostTitlebarContribution, WorkbenchPhase.BlockRestore);

--- a/src/vs/sessions/contrib/tunnelHost/test/electron-browser/tunnelHost.contribution.test.ts
+++ b/src/vs/sessions/contrib/tunnelHost/test/electron-browser/tunnelHost.contribution.test.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { isIMenuItem, MenuId, MenuRegistry } from '../../../../../platform/actions/common/actions.js';
+import type { ContextKeyExpression, ContextKeyValue } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ChatContextKeys } from '../../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
+import { IsAuxiliaryWindowContext, IsSessionsWindowContext, RemoteNameContext } from '../../../../../workbench/common/contextkeys.js';
+import { Menus } from '../../../../browser/menus.js';
+
+import '../../electron-browser/tunnelHost.contribution.js';
+
+suite('Sessions - Tunnel Host Contribution', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('remote connections toggle is in Agents titlebar and non-Agents chat input', () => {
+		const findToggle = (menu: MenuId) => MenuRegistry.getMenuItems(menu)
+			.filter(isIMenuItem)
+			.find(item => item.command.id === 'sessions.tunnelHost.toggleSharing');
+
+		const summarize = (menu: MenuId) => {
+			const item = findToggle(menu);
+			return item && {
+				group: item.group,
+				order: item.order,
+				icon: ThemeIcon.isThemeIcon(item.command.icon) ? item.command.icon.id : undefined,
+			};
+		};
+
+		assert.deepStrictEqual({
+			titlebar: summarize(Menus.TitleBarRightLayout),
+			chatInput: summarize(MenuId.ChatInputSecondary),
+		}, {
+			titlebar: { group: 'navigation', order: 90, icon: Codicon.radioTower.id },
+			chatInput: { group: 'navigation', order: 10, icon: Codicon.radioTower.id },
+		});
+
+		const titlebarToggle = findToggle(Menus.TitleBarRightLayout);
+		const chatInputToggle = findToggle(MenuId.ChatInputSecondary);
+		if (!titlebarToggle?.when || !chatInputToggle?.when) {
+			assert.fail('remote connections menu items should have when clauses');
+		}
+
+		const evalWhen = (when: ContextKeyExpression, values: Record<string, ContextKeyValue>) => {
+			return when.evaluate({ getValue: <T extends ContextKeyValue = ContextKeyValue>(key: string) => values[key] as T });
+		};
+		const agentHostChat = {
+			[ChatContextKeys.enabled.key]: true,
+			[ChatContextKeys.chatIsAgentHostSession.key]: true,
+			[IsAuxiliaryWindowContext.key]: false,
+			[RemoteNameContext.key]: '',
+		};
+
+		assert.deepStrictEqual({
+			agentsTitlebar: evalWhen(titlebarToggle.when, { ...agentHostChat, [IsSessionsWindowContext.key]: true }),
+			editorTitlebar: evalWhen(titlebarToggle.when, { ...agentHostChat, [IsSessionsWindowContext.key]: false }),
+			agentsChatInput: evalWhen(chatInputToggle.when, { ...agentHostChat, [IsSessionsWindowContext.key]: true }),
+			editorChatInput: evalWhen(chatInputToggle.when, { ...agentHostChat, [IsSessionsWindowContext.key]: false }),
+			remoteEditorChatInput: evalWhen(chatInputToggle.when, { ...agentHostChat, [IsSessionsWindowContext.key]: false, [RemoteNameContext.key]: 'ssh-remote' }),
+		}, {
+			agentsTitlebar: true,
+			editorTitlebar: false,
+			agentsChatInput: false,
+			editorChatInput: true,
+			remoteEditorChatInput: false,
+		});
+	});
+});

--- a/src/vs/workbench/contrib/chat/common/tunnelHost.ts
+++ b/src/vs/workbench/contrib/chat/common/tunnelHost.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from '../../../../base/common/event.js';
-import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { ITunnelHostInfo } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 
 export const ITunnelHostService = createDecorator<ITunnelHostService>('tunnelHostService');
 

--- a/src/vs/workbench/contrib/chat/electron-browser/media/tunnelHost.css
+++ b/src/vs/workbench/contrib/chat/electron-browser/media/tunnelHost.css
@@ -6,12 +6,20 @@
 .tunnel-host-toggle {
 	display: flex;
 	align-items: center;
-	gap: 4px;
-	height: 16px;
-	padding: 3px 6px;
+	justify-content: center;
+	box-sizing: border-box;
+	width: 24px;
+	height: 24px;
+	padding: 4px;
 	cursor: pointer;
 	color: var(--vscode-icon-foreground);
 	border-radius: var(--vscode-cornerRadius-small);
+}
+
+.tunnel-host-toggle:has(.tunnel-host-toast.visible) {
+	gap: 4px;
+	width: auto;
+	padding: 4px 6px;
 }
 
 .tunnel-host-toggle:hover {
@@ -19,7 +27,7 @@
 }
 
 .tunnel-host-toggle:focus-visible {
-	outline: 1px solid var(--vscode-focusBorder);
+	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder);
 	outline-offset: -1px;
 }
 

--- a/src/vs/workbench/contrib/chat/electron-browser/toggleRemoteConnectionsActionViewItem.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/toggleRemoteConnectionsActionViewItem.ts
@@ -5,24 +5,19 @@
 
 import './media/tunnelHost.css';
 import * as dom from '../../../../base/browser/dom.js';
+import { IManagedHover, IManagedHoverContent } from '../../../../base/browser/ui/hover/hover.js';
+import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { renderLabelWithIcons } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { BaseActionViewItem } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
-import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
+import { disposableTimeout } from '../../../../base/common/async.js';
 import { IAction } from '../../../../base/common/actions.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
-import { disposableTimeout } from '../../../../base/common/async.js';
 import { localize } from '../../../../nls.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { ITunnelHostService } from '../common/tunnelHost.js';
 import { SHOW_TUNNEL_HOST_OUTPUT_ID } from './tunnelHostService.js';
-import { IManagedHover, IManagedHoverContent } from '../../../../base/browser/ui/hover/hover.js';
 
-/**
- * Custom action view item for the toggle remote connections button.
- * Provides pulse animation while connecting, hover with tunnel status,
- * and a brief toast message after enabling.
- */
 export class ToggleRemoteConnectionsActionViewItem extends BaseActionViewItem {
 
 	private _iconElement: HTMLElement | undefined;
@@ -55,14 +50,11 @@ export class ToggleRemoteConnectionsActionViewItem extends BaseActionViewItem {
 		this.element.tabIndex = 0;
 		this.element.role = 'button';
 
-		// Icon
 		this._iconElement = dom.append(this.element, dom.$('span.tunnel-host-icon'));
 		this._iconElement.append(...renderLabelWithIcons(`$(${Codicon.radioTower.id})`));
 
-		// Toast text (initially hidden)
 		this._toastElement = dom.append(this.element, dom.$('span.tunnel-host-toast'));
 
-		// Hover
 		const hoverDelegate = getDefaultHoverDelegate('element');
 		this._hover = this._register(this._hoverService.setupManagedHover(
 			hoverDelegate, this.element, this._getHoverContent()
@@ -79,18 +71,12 @@ export class ToggleRemoteConnectionsActionViewItem extends BaseActionViewItem {
 		const isSharing = this._tunnelHostService.isSharing;
 		const isConnecting = this._tunnelHostService.isConnecting;
 
-		// Toggle CSS classes for visual state
 		this.element.classList.toggle('sharing', isSharing);
 		this.element.classList.toggle('connecting', isConnecting);
-
-		// Update hover content
 		this._hover?.update(this._getHoverContent());
-
-		// Update ARIA
 		this.element.setAttribute('aria-label', this._getAriaLabel());
 		this.element.setAttribute('aria-pressed', String(isSharing));
 
-		// Show toast when transitioning to sharing
 		if (isSharing && !this._wasSharing && !isConnecting) {
 			this._showToast();
 		} else if (!isSharing && this._wasSharing) {
@@ -151,9 +137,5 @@ export class ToggleRemoteConnectionsActionViewItem extends BaseActionViewItem {
 			return localize('tunnelHost.hover.enabled', "Remote session access is enabled");
 		}
 		return localize('tunnelHost.hover.idle', "Allow remote session access");
-	}
-
-	override dispose(): void {
-		super.dispose();
 	}
 }

--- a/src/vs/workbench/contrib/chat/electron-browser/tunnelHost.contribution.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/tunnelHost.contribution.ts
@@ -1,0 +1,130 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../base/common/codicons.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { localize, localize2 } from '../../../../nls.js';
+import { IActionViewItemService, type IActionViewItemFactory } from '../../../../platform/actions/browser/actionViewItemService.js';
+import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+import { IsSessionsWindowContext, RemoteNameContext } from '../../../common/contextkeys.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
+import { IOutputService } from '../../../services/output/common/output.js';
+import { ChatContextKeyExprs, ChatContextKeys } from '../common/actions/chatContextKeys.js';
+import { ITunnelHostService } from '../common/tunnelHost.js';
+import { CONFIGURATION_KEY_MICROSOFT_AUTH, SHOW_TUNNEL_HOST_OUTPUT_ID, TunnelHostService } from './tunnelHostService.js';
+import { TUNNEL_HOST_LOG_ID } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
+import { ToggleRemoteConnectionsActionViewItem } from './toggleRemoteConnectionsActionViewItem.js';
+
+export const TUNNEL_HOST_SHARING_KEY = 'tunnelHostSharing';
+export const TUNNEL_HOST_SHARING_CONTEXT = new RawContextKey<boolean>(TUNNEL_HOST_SHARING_KEY, false);
+export const TOGGLE_SHARING_ID = 'sessions.tunnelHost.toggleSharing';
+
+const CATEGORY = localize2('tunnelHost.category', 'Remote Connections');
+
+registerSingleton(ITunnelHostService, TunnelHostService, InstantiationType.Delayed);
+
+class TunnelHostContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.tunnelHost';
+
+	private readonly _sharingContext: IContextKey<boolean>;
+
+	constructor(
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@ITunnelHostService tunnelHostService: ITunnelHostService,
+		@IActionViewItemService actionViewItemService: IActionViewItemService,
+	) {
+		super();
+
+		this._sharingContext = TUNNEL_HOST_SHARING_CONTEXT.bindTo(contextKeyService);
+		this._sharingContext.set(tunnelHostService.isSharing);
+
+		this._register(tunnelHostService.onDidChangeStatus(() => {
+			this._sharingContext.set(tunnelHostService.isSharing);
+		}));
+
+		const viewItemFactory: IActionViewItemFactory = (action, _options, instantiationService) => {
+			return instantiationService.createInstance(ToggleRemoteConnectionsActionViewItem, action);
+		};
+		this._register(actionViewItemService.register(MenuId.ChatInputSecondary, TOGGLE_SHARING_ID, viewItemFactory, tunnelHostService.onDidChangeStatus));
+	}
+}
+
+registerAction2(class ToggleRemoteConnectionsAction extends Action2 {
+	constructor() {
+		super({
+			id: TOGGLE_SHARING_ID,
+			title: localize2('toggleSharing', "Allow Remote Connections"),
+			category: CATEGORY,
+			icon: Codicon.radioTower,
+			toggled: ContextKeyExpr.equals(TUNNEL_HOST_SHARING_KEY, true),
+			menu: {
+				id: MenuId.ChatInputSecondary,
+				order: 10,
+				group: 'navigation',
+				when: ContextKeyExpr.and(
+					ChatContextKeys.enabled,
+					IsSessionsWindowContext.toNegated(),
+					RemoteNameContext.isEqualTo(''),
+					ChatContextKeyExprs.isAgentHostSession,
+				)
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const tunnelHostService = accessor.get(ITunnelHostService);
+		const notificationService = accessor.get(INotificationService);
+
+		try {
+			if (tunnelHostService.isSharing) {
+				await tunnelHostService.stopSharing();
+			} else {
+				await tunnelHostService.startSharing();
+			}
+		} catch (err) {
+			notificationService.notify({
+				severity: Severity.Error,
+				message: localize('tunnelHost.error', "Failed to toggle remote connections: {0}", String(err)),
+			});
+		}
+	}
+});
+
+registerAction2(class ShowTunnelHostOutputAction extends Action2 {
+	constructor() {
+		super({
+			id: SHOW_TUNNEL_HOST_OUTPUT_ID,
+			title: localize2('showTunnelHostOutput', "Show Remote Connections Output"),
+			category: CATEGORY,
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const outputService = accessor.get(IOutputService);
+		await outputService.showChannel(TUNNEL_HOST_LOG_ID);
+	}
+});
+
+registerWorkbenchContribution2(TunnelHostContribution.ID, TunnelHostContribution, WorkbenchPhase.AfterRestored);
+
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	type: 'object',
+	properties: {
+		[CONFIGURATION_KEY_MICROSOFT_AUTH]: {
+			description: localize('tunnelHost.enableMicrosoftAuth', "Enable Microsoft account authentication for agent host tunnels. When disabled, only GitHub authentication is used."),
+			type: 'boolean',
+			scope: ConfigurationScope.APPLICATION,
+			default: false,
+			tags: ['usesOnlineServices'],
+		},
+	}
+});

--- a/src/vs/workbench/contrib/chat/electron-browser/tunnelHostService.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/tunnelHostService.ts
@@ -3,15 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { joinPath } from '../../../../base/common/resources.js';
-import { Emitter, Event } from '../../../../base/common/event.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
-import { ProxyChannel } from '../../../../base/parts/ipc/common/ipc.js';
-import { IAuthenticationService } from '../../../../workbench/services/authentication/common/authentication.js';
-import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
-import { ISharedProcessService } from '../../../../platform/ipc/electron-browser/services.js';
-import { ILogger, ILoggerService } from '../../../../platform/log/common/log.js';
-import { IProductService } from '../../../../platform/product/common/productService.js';
 import { localize } from '../../../../nls.js';
 import {
 	ITunnelAgentHostHostingService,
@@ -22,6 +13,15 @@ import {
 } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { IAgentHostService } from '../../../../platform/agentHost/common/agentService.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
+import { ISharedProcessService } from '../../../../platform/ipc/electron-browser/services.js';
+import { ILogger, ILoggerService } from '../../../../platform/log/common/log.js';
+import { IProductService } from '../../../../platform/product/common/productService.js';
+import { ProxyChannel } from '../../../../base/parts/ipc/common/ipc.js';
+import { joinPath } from '../../../../base/common/resources.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IAuthenticationService } from '../../../services/authentication/common/authentication.js';
 import { ITunnelHostService } from '../common/tunnelHost.js';
 
 export const CONFIGURATION_KEY_MICROSOFT_AUTH = 'remote.tunnels.access.enableMicrosoftAuth';
@@ -54,8 +54,6 @@ export class TunnelHostService extends Disposable implements ITunnelHostService 
 	) {
 		super();
 
-		// Register a renderer-side logger so that the output channel
-		// created in the shared process is visible in the workbench UI
 		this._logger = this._register(loggerService.createLogger(
 			joinPath(environmentService.logsHome, `${TUNNEL_HOST_LOG_ID}.log`),
 			{ id: TUNNEL_HOST_LOG_ID, name: localize('tunnelHost.outputChannel', "Remote Connections") },
@@ -65,14 +63,12 @@ export class TunnelHostService extends Disposable implements ITunnelHostService 
 			sharedProcessService.getChannel(TUNNEL_HOST_CHANNEL),
 		);
 
-		// Listen for status changes from the shared process
 		this._register(this._mainService.onDidChangeStatus((status: TunnelHostStatus) => {
 			this._isSharing = status.active;
 			this._sharingInfo = status.active ? status.info : undefined;
 			this._onDidChangeStatus.fire();
 		}));
 
-		// Restore status on construction
 		this._mainService.getStatus().then(status => {
 			this._isSharing = status.active;
 			this._sharingInfo = status.active ? status.info : undefined;
@@ -101,11 +97,11 @@ export class TunnelHostService extends Disposable implements ITunnelHostService 
 		try {
 			const auth = await this._getToken(false);
 			if (!auth) {
-				this._logger.warn(`No auth token available for tunnel hosting`);
+				this._logger.warn('No auth token available for tunnel hosting');
 				throw new Error(localize('tunnelHost.noAuth', "No authentication token available. Please sign in and try again."));
 			}
 
-			this._logger.info(`Starting tunnel hosting...`);
+			this._logger.info('Starting tunnel hosting...');
 
 			const socketInfo = await this._agentHostService.startWebSocketServer();
 			const info = await this._mainService.startHosting(auth.token, auth.provider, socketInfo);
@@ -118,14 +114,12 @@ export class TunnelHostService extends Disposable implements ITunnelHostService 
 	}
 
 	async stopSharing(): Promise<void> {
-		this._logger.info(`Stopping tunnel hosting...`);
+		this._logger.info('Stopping tunnel hosting...');
 		await this._mainService.stopHosting();
 		this._isSharing = false;
 		this._sharingInfo = undefined;
 		this._onDidChangeStatus.fire();
 	}
-
-	// ---- Auth helpers (reused from TunnelAgentHostService) -------------------
 
 	private _getEnabledProviders(): readonly ('github' | 'microsoft')[] {
 		const microsoftEnabled = this._configurationService.getValue<boolean>(CONFIGURATION_KEY_MICROSOFT_AUTH);
@@ -135,7 +129,6 @@ export class TunnelHostService extends Disposable implements ITunnelHostService 
 	private async _getToken(silent: boolean): Promise<{ token: string; provider: 'github' | 'microsoft' } | undefined> {
 		const enabledProviders = this._getEnabledProviders();
 
-		// Try the last known provider first
 		if (this._lastAuthProvider && enabledProviders.includes(this._lastAuthProvider)) {
 			const result = await this._getTokenForProvider(this._lastAuthProvider, silent);
 			if (result) {
@@ -143,7 +136,6 @@ export class TunnelHostService extends Disposable implements ITunnelHostService 
 			}
 		}
 
-		// Try enabled providers silently
 		for (const provider of enabledProviders) {
 			if (provider === this._lastAuthProvider) {
 				continue;
@@ -154,7 +146,6 @@ export class TunnelHostService extends Disposable implements ITunnelHostService 
 			}
 		}
 
-		// If not silent, try interactively with each enabled provider
 		if (!silent) {
 			for (const provider of enabledProviders) {
 				const result = await this._getTokenForProvider(provider, false);
@@ -182,10 +173,8 @@ export class TunnelHostService extends Disposable implements ITunnelHostService 
 		}
 
 		try {
-			// Try exact scope match first
 			let sessions = await this._authenticationService.getSessions(provider, scopes, {}, true);
 
-			// Fall back: find any session whose scopes are a superset
 			if (sessions.length === 0) {
 				const allSessions = await this._authenticationService.getSessions(provider, undefined, {}, true);
 				const requestedSet = new Set(scopes);
@@ -213,7 +202,6 @@ export class TunnelHostService extends Disposable implements ITunnelHostService 
 				}
 			}
 
-			// Interactive fallback: create a new session
 			if (sessions.length === 0 && !silent) {
 				const session = await this._authenticationService.createSession(provider, scopes, { activateImmediate: true });
 				sessions = [session];
@@ -232,11 +220,4 @@ export class TunnelHostService extends Disposable implements ITunnelHostService 
 		return undefined;
 	}
 
-	override dispose(): void {
-		// Best-effort cleanup — stop hosting when the window closes
-		if (this._isSharing) {
-			this.stopSharing().catch(() => { /* ignore */ });
-		}
-		super.dispose();
-	}
 }

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -184,6 +184,7 @@ import './contrib/remoteTunnel/electron-browser/remoteTunnel.contribution.js';
 
 // Chat
 import './contrib/chat/electron-browser/chat.contribution.js';
+import './contrib/chat/electron-browser/tunnelHost.contribution.js';
 
 // Copilot Voice
 import './contrib/agentsVoice/electron-browser/agentsVoiceNativeCommands.js';


### PR DESCRIPTION
Fixes #320114\n\n## Summary\n- move the Remote Connections radio tower toggle to the Agents window titlebar\n- keep the main editor window chat-input toggle for local agent-host chats\n- share the tunnel-host service/action from the workbench chat layer so both windows load the right affordance\n- hide the toggle on mobile Agents window and remote editor windows\n\n## Validation\n- npm run typecheck-client\n- npm run valid-layers-check\n- node build/next/index.ts transpile --out out && ./scripts/test.sh --run src/vs/sessions/contrib/tunnelHost/test/electron-browser/tunnelHost.contribution.test.ts\n- node --experimental-strip-types build/hygiene.ts <changed files>\n- npm run precommit\n- git diff --check