### PR TITLE
Require CODEOWNERS review for cglicenses.json and cgmanifest.json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,3 +20,9 @@ src/vs/workbench/services/extensions/common/extensionPoints.json @mjbvz @alexr00
 # Adding entries here lets a new .js/.cjs/.mjs file land in the repo;
 # review is required to make sure TypeScript is not a better choice.
 .eslint-allowed-javascript-files @alexr00 @alexdima @sbatten
+
+# OSS compliance manifests.
+# Changes to these files affect third-party notice generation and license
+# overrides; require review so dependency/license overrides aren't self-approved.
+/cglicenses.json @benvillalobos
+/cgmanifest.json @benvillalobos

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,5 +24,5 @@ src/vs/workbench/services/extensions/common/extensionPoints.json @mjbvz @alexr00
 # OSS compliance manifests.
 # Changes to these files affect third-party notice generation and license
 # overrides; require review so dependency/license overrides aren't self-approved.
-/cglicenses.json @benvillalobos
-/cgmanifest.json @benvillalobos
+/cglicenses.json @benvillalobos @Yoyokrazy
+/cgmanifest.json @benvillalobos @Yoyokrazy


### PR DESCRIPTION
🤖 AI Assisted PR

## What

Adds CODEOWNERS coverage for `cglicenses.json` and `cgmanifest.json`.

## Why

These OSS-compliance manifests currently match no rule in `.github/CODEOWNERS`, so changes to them require no designated reviewer. That allows a PR to add a third-party dependency **and** its license override (`cglicenses.json`) in one change with no independent sign-off on the override — effectively self-approving a license.

Requiring CODEOWNERS review establishes a human gate on override/manifest changes, complementing the component-governance build and the upcoming PR-time OSS license check.