### PR TITLE
chore: add optional AI assistance note to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,4 +4,8 @@
 * Associate an issue with the Pull Request.
 * Ensure that the code is up-to-date with the `main` branch.
 * Include a description of the proposed changes and how to test them.
+
+Some contributors find it helpful to include a short "AI assistance" line
+here if any AI-assisted tooling was used. This is not enforced. The user
+who opens the PR is the author regardless.
 -->


### PR DESCRIPTION
Adds an opt-in (not enforced) line in the PR template suggesting that contributors mention whether AI-assisted tooling was used. The PR's human author remains the author regardless.