### PR TITLE
Add mute button for local agent host continuation tip

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentDisabledInputTipContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentDisabledInputTipContribution.ts
@@ -68,8 +68,7 @@ export class LocalAgentDisabledInputTipContribution extends Disposable implement
 			}
 		}));
 		this._register(this.storageService.onDidChangeValue(StorageScope.PROFILE, LOCAL_AGENT_DISABLED_MUTE_STORAGE_KEY, this._store)(() => {
-			this._lastPostedFor = undefined;
-			this.update();
+			this.update(true);
 		}));
 		this._register(this.notificationService.onDidDismiss(id => {
 			if (id === LOCAL_AGENT_DISABLED_NOTIFICATION_ID) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentDisabledInputTipContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentDisabledInputTipContribution.ts
@@ -37,10 +37,8 @@ CommandsRegistry.registerCommand(LOCAL_AGENT_DISABLED_CONTINUE_IN_AGENT_HOST_COP
 
 CommandsRegistry.registerCommand(LOCAL_AGENT_DISABLED_MUTE_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID, (accessor: ServicesAccessor) => {
 	const storageService = accessor.get(IStorageService);
-	const notificationService = accessor.get(IChatInputNotificationService);
 
 	storageService.store(LOCAL_AGENT_DISABLED_MUTE_STORAGE_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
-	notificationService.deleteNotification(LOCAL_AGENT_DISABLED_NOTIFICATION_ID);
 });
 
 export class LocalAgentDisabledInputTipContribution extends Disposable implements IWorkbenchContribution {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentDisabledInputTipContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentDisabledInputTipContribution.ts
@@ -8,6 +8,7 @@ import { localize } from '../../../../../nls.js';
 import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { IsSessionsWindowContext } from '../../../../common/contextkeys.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { ChatConfiguration } from '../../common/constants.js';
@@ -17,17 +18,29 @@ import { IChatWidget, IChatWidgetService, isIChatResourceViewContext } from '../
 import { ChatInputNotificationSeverity, IChatInputNotificationService } from '../widget/input/chatInputNotificationService.js';
 
 const LOCAL_AGENT_DISABLED_NOTIFICATION_ID = 'chat.localAgentDisabled.continueInAgentHostCopilot';
+export const LOCAL_AGENT_DISABLED_MUTE_STORAGE_KEY = 'chat.localAgentDisabled.continueInAgentHostCopilot.muted';
 export const LOCAL_AGENT_DISABLED_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID = '_chat.localAgentDisabled.continueInAgentHostCopilot';
+export const LOCAL_AGENT_DISABLED_MUTE_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID = '_chat.localAgentDisabled.muteContinueInAgentHostCopilot';
 
 CommandsRegistry.registerCommand(LOCAL_AGENT_DISABLED_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID, async (accessor: ServicesAccessor) => {
 	const chatWidgetService = accessor.get(IChatWidgetService);
 	const chatSessionsService = accessor.get(IChatSessionsService);
+	const notificationService = accessor.get(IChatInputNotificationService);
 	const widget = chatWidgetService.lastFocusedWidget;
 	if (!widget || !chatSessionsService.getChatSessionContribution(SessionType.AgentHostCopilot)) {
 		return;
 	}
 
 	widget.input.continueInSession(SessionType.AgentHostCopilot);
+	notificationService.dismissNotification(LOCAL_AGENT_DISABLED_NOTIFICATION_ID);
+});
+
+CommandsRegistry.registerCommand(LOCAL_AGENT_DISABLED_MUTE_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID, (accessor: ServicesAccessor) => {
+	const storageService = accessor.get(IStorageService);
+	const notificationService = accessor.get(IChatInputNotificationService);
+
+	storageService.store(LOCAL_AGENT_DISABLED_MUTE_STORAGE_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
+	notificationService.deleteNotification(LOCAL_AGENT_DISABLED_NOTIFICATION_ID);
 });
 
 export class LocalAgentDisabledInputTipContribution extends Disposable implements IWorkbenchContribution {
@@ -35,12 +48,14 @@ export class LocalAgentDisabledInputTipContribution extends Disposable implement
 	static readonly ID = 'workbench.contrib.localAgentDisabledInputTip';
 
 	private _lastPostedFor: string | undefined;
+	private _dismissedForWindow = false;
 
 	constructor(
 		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@IChatInputNotificationService private readonly notificationService: IChatInputNotificationService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
+		@IStorageService private readonly storageService: IStorageService,
 	) {
 		super();
 
@@ -52,11 +67,25 @@ export class LocalAgentDisabledInputTipContribution extends Disposable implement
 				this.update(true);
 			}
 		}));
+		this._register(this.storageService.onDidChangeValue(StorageScope.PROFILE, LOCAL_AGENT_DISABLED_MUTE_STORAGE_KEY, this._store)(() => {
+			this._lastPostedFor = undefined;
+			this.update();
+		}));
+		this._register(this.notificationService.onDidDismiss(id => {
+			if (id === LOCAL_AGENT_DISABLED_NOTIFICATION_ID) {
+				this.dismissForWindow();
+			}
+		}));
 
 		this.update();
 	}
 
 	private update(resetDismissal = false): void {
+		if (this.isMuted() || this._dismissedForWindow) {
+			this.clear();
+			return;
+		}
+
 		const widget = this.chatWidgetService.lastFocusedWidget;
 		const sessionResource = widget?.viewModel?.sessionResource;
 		const key = sessionResource?.toString();
@@ -75,15 +104,31 @@ export class LocalAgentDisabledInputTipContribution extends Disposable implement
 			id: LOCAL_AGENT_DISABLED_NOTIFICATION_ID,
 			severity: ChatInputNotificationSeverity.Info,
 			message: localize('chat.localAgentDisabled.continueInAgentHostCopilot.message', "Continue using the agent host."),
-			description: localize('chat.localAgentDisabled.continueInAgentHostCopilot.description', "You can bring your local harness history into a new chat with the agent host. To keep using the local harness instead and hide this notification, set \"chat.editor.localAgent.enabled\" to true."),
+			description: localize('chat.localAgentDisabled.continueInAgentHostCopilot.description', "You can bring your local harness history into a new chat with the agent host."),
 			actions: [{
 				label: localize('chat.localAgentDisabled.continueInAgentHostCopilot.action', "Continue In Agent Host"),
 				commandId: LOCAL_AGENT_DISABLED_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID,
 			}],
 			dismissible: true,
 			autoDismissOnMessage: false,
+			mute: {
+				commandId: LOCAL_AGENT_DISABLED_MUTE_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID,
+				tooltip: localize('chat.localAgentDisabled.continueInAgentHostCopilot.mute', "Don't Show Again"),
+			},
 			sessionTypes: [localChatSessionType],
 		});
+	}
+
+	private isMuted(): boolean {
+		return this.storageService.getBoolean(LOCAL_AGENT_DISABLED_MUTE_STORAGE_KEY, StorageScope.PROFILE, false);
+	}
+
+	private dismissForWindow(): void {
+		if (this._dismissedForWindow) {
+			return;
+		}
+		this._dismissedForWindow = true;
+		this.clear();
 	}
 
 	private isEligible(widget: IChatWidget): boolean {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentDisabledInputTipContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentDisabledInputTipContribution.ts
@@ -104,7 +104,7 @@ export class LocalAgentDisabledInputTipContribution extends Disposable implement
 			id: LOCAL_AGENT_DISABLED_NOTIFICATION_ID,
 			severity: ChatInputNotificationSeverity.Info,
 			message: localize('chat.localAgentDisabled.continueInAgentHostCopilot.message', "Continue using the agent host."),
-			description: localize('chat.localAgentDisabled.continueInAgentHostCopilot.description', "You can bring your local harness history into a new chat with the agent host."),
+			description: localize('chat.localAgentDisabled.continueInAgentHostCopilot.description', "You can bring your local harness history into a new chat with the agent host. To keep using the local harness instead and hide this notification, set \"chat.editor.localAgent.enabled\" to true."),
 			actions: [{
 				label: localize('chat.localAgentDisabled.continueInAgentHostCopilot.action', "Continue In Agent Host"),
 				commandId: LOCAL_AGENT_DISABLED_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID,

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentDisabledInputTipContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentDisabledInputTipContribution.test.ts
@@ -68,12 +68,17 @@ class TestChatInputNotificationService implements IChatInputNotificationService 
 	readonly setCalls: IChatInputNotification[] = [];
 	readonly deleteCalls: string[] = [];
 	readonly dismissedCalls: string[] = [];
+	private readonly _notificationIds = new Set<string>();
 
 	setNotification(notification: IChatInputNotification): void {
+		this._notificationIds.add(notification.id);
 		this.setCalls.push(notification);
 	}
 
 	deleteNotification(id: string): void {
+		if (!this._notificationIds.delete(id)) {
+			return;
+		}
 		this.deleteCalls.push(id);
 	}
 
@@ -298,6 +303,15 @@ suite('LocalAgentDisabledInputTipContribution', () => {
 		widgetService.setFocusedWidget(createWidget());
 
 		assert.strictEqual(notificationService.setCalls.length, 0);
+	});
+
+	test('clears active tip when persistent mute changes externally', () => {
+		createTipContribution();
+		widgetService.setFocusedWidget(createWidget());
+
+		storageService.store(LOCAL_AGENT_DISABLED_MUTE_STORAGE_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
+
+		assert.deepStrictEqual(notificationService.deleteCalls, ['chat.localAgentDisabled.continueInAgentHostCopilot']);
 	});
 
 	test('mute action stores persistent profile mute and clears tip', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentDisabledInputTipContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentDisabledInputTipContribution.test.ts
@@ -326,6 +326,7 @@ suite('LocalAgentDisabledInputTipContribution', () => {
 		widgetService.setFocusedWidget(createWidget());
 
 		notificationService.dismissNotification('chat.localAgentDisabled.continueInAgentHostCopilot');
+		widgetService.setFocusedWidget(createWidget({ sessionResource: URI.from({ scheme: SessionType.AgentHostCopilot, path: '/session' }) }));
 		widgetService.setFocusedWidget(createWidget({ sessionResource: LocalChatSessionUri.forSession('other-history') }));
 
 		assert.strictEqual(notificationService.setCalls.length, 1);

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentDisabledInputTipContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentDisabledInputTipContribution.test.ts
@@ -13,9 +13,10 @@ import { ConfigurationTarget } from '../../../../../../platform/configuration/co
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { MockContextKeyService } from '../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { IStorageService, InMemoryStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
 import { IsSessionsWindowContext } from '../../../../../common/contextkeys.js';
 import { IChatWidget, IChatWidgetService, IChatWidgetViewContext } from '../../../browser/chat.js';
-import { LocalAgentDisabledInputTipContribution, LOCAL_AGENT_DISABLED_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID } from '../../../browser/agentSessions/localAgentDisabledInputTipContribution.js';
+import { LocalAgentDisabledInputTipContribution, LOCAL_AGENT_DISABLED_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID, LOCAL_AGENT_DISABLED_MUTE_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID, LOCAL_AGENT_DISABLED_MUTE_STORAGE_KEY } from '../../../browser/agentSessions/localAgentDisabledInputTipContribution.js';
 import { ChatInputNotificationSeverity, IChatInputNotification, IChatInputNotificationService } from '../../../browser/widget/input/chatInputNotificationService.js';
 import { IChatModel } from '../../../common/model/chatModel.js';
 import { LocalChatSessionUri } from '../../../common/model/chatUri.js';
@@ -60,10 +61,13 @@ class TestChatWidgetService implements IChatWidgetService {
 class TestChatInputNotificationService implements IChatInputNotificationService {
 	declare readonly _serviceBrand: undefined;
 
+	private readonly _onDidDismiss = new Emitter<string>();
+	readonly onDidDismiss = this._onDidDismiss.event;
+
 	readonly onDidChange = Event.None;
-	readonly onDidDismiss = Event.None;
 	readonly setCalls: IChatInputNotification[] = [];
 	readonly deleteCalls: string[] = [];
+	readonly dismissedCalls: string[] = [];
 
 	setNotification(notification: IChatInputNotification): void {
 		this.setCalls.push(notification);
@@ -73,7 +77,11 @@ class TestChatInputNotificationService implements IChatInputNotificationService 
 		this.deleteCalls.push(id);
 	}
 
-	dismissNotification(): void { }
+	dismissNotification(id: string): void {
+		this.dismissedCalls.push(id);
+		this._onDidDismiss.fire(id);
+	}
+
 	getActiveNotification(): IChatInputNotification | undefined { return this.setCalls.at(-1); }
 	handleMessageSent(): void { }
 }
@@ -85,6 +93,7 @@ suite('LocalAgentDisabledInputTipContribution', () => {
 	let notificationService: TestChatInputNotificationService;
 	let configurationService: TestConfigurationService;
 	let chatSessionsService: MockChatSessionsService;
+	let storageService: InMemoryStorageService;
 	let testDisposables: DisposableStore;
 
 	setup(() => {
@@ -97,6 +106,7 @@ suite('LocalAgentDisabledInputTipContribution', () => {
 		});
 		chatSessionsService = new MockChatSessionsService();
 		chatSessionsService.setContributions([createContribution(SessionType.AgentHostCopilot)]);
+		storageService = testDisposables.add(new InMemoryStorageService());
 	});
 
 	teardown(() => {
@@ -113,7 +123,7 @@ suite('LocalAgentDisabledInputTipContribution', () => {
 	}
 
 	function createTipContribution(): LocalAgentDisabledInputTipContribution {
-		const contribution = new LocalAgentDisabledInputTipContribution(widgetService, notificationService, configurationService, chatSessionsService);
+		const contribution = new LocalAgentDisabledInputTipContribution(widgetService, notificationService, configurationService, chatSessionsService, storageService);
 		testDisposables.add(contribution);
 		return contribution;
 	}
@@ -158,13 +168,18 @@ suite('LocalAgentDisabledInputTipContribution', () => {
 		assert.strictEqual(notificationService.setCalls[0].actions.length, 1);
 		assert.strictEqual(notificationService.setCalls[0].actions[0].label, 'Continue In Agent Host');
 		assert.strictEqual(notificationService.setCalls[0].actions[0].commandId, LOCAL_AGENT_DISABLED_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID);
+		assert.strictEqual(notificationService.setCalls[0].mute?.commandId, LOCAL_AGENT_DISABLED_MUTE_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID);
+		assert.strictEqual(notificationService.setCalls[0].mute?.tooltip, 'Don\'t Show Again');
 		assert.deepStrictEqual(notificationService.setCalls[0].sessionTypes, [localChatSessionType]);
 	});
 
-	test('continue action selects agent host Copilot as pending delegation target', async () => {
+	test('continue action selects agent host Copilot as pending delegation target and dismisses tip for the window', async () => {
 		const instantiationService = new TestInstantiationService();
 		instantiationService.set(IChatWidgetService, widgetService);
 		instantiationService.set(IChatSessionsService, chatSessionsService);
+		instantiationService.set(IChatInputNotificationService, notificationService);
+
+		createTipContribution();
 
 		let continuedInSession: string | undefined;
 		widgetService.setFocusedWidget(Object.assign(createWidget(), {
@@ -179,6 +194,11 @@ suite('LocalAgentDisabledInputTipContribution', () => {
 		await command.handler(instantiationService);
 
 		assert.strictEqual(continuedInSession, SessionType.AgentHostCopilot);
+		assert.deepStrictEqual(notificationService.dismissedCalls, ['chat.localAgentDisabled.continueInAgentHostCopilot']);
+
+		widgetService.setFocusedWidget(createWidget({ sessionResource: LocalChatSessionUri.forSession('other-history') }));
+
+		assert.strictEqual(notificationService.setCalls.length, 1);
 	});
 
 	test('shows tip for normal Chat view sessions', () => {
@@ -269,6 +289,47 @@ suite('LocalAgentDisabledInputTipContribution', () => {
 		fireConfigChange(ChatConfiguration.EditorDefaultProvider);
 
 		assert.strictEqual(notificationService.setCalls.length, 2);
+	});
+
+	test('does not show tip when persistently muted', () => {
+		storageService.store(LOCAL_AGENT_DISABLED_MUTE_STORAGE_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
+		createTipContribution();
+
+		widgetService.setFocusedWidget(createWidget());
+
+		assert.strictEqual(notificationService.setCalls.length, 0);
+	});
+
+	test('mute action stores persistent profile mute and clears tip', async () => {
+		const instantiationService = new TestInstantiationService();
+		instantiationService.set(IStorageService, storageService);
+		instantiationService.set(IChatInputNotificationService, notificationService);
+
+		createTipContribution();
+		widgetService.setFocusedWidget(createWidget());
+
+		const command = CommandsRegistry.getCommand(LOCAL_AGENT_DISABLED_MUTE_CONTINUE_IN_AGENT_HOST_COPILOT_COMMAND_ID);
+		assert.ok(command);
+
+		await command.handler(instantiationService);
+
+		assert.strictEqual(storageService.getBoolean(LOCAL_AGENT_DISABLED_MUTE_STORAGE_KEY, StorageScope.PROFILE, false), true);
+		assert.deepStrictEqual(notificationService.deleteCalls, ['chat.localAgentDisabled.continueInAgentHostCopilot']);
+
+		widgetService.setFocusedWidget(createWidget({ sessionResource: LocalChatSessionUri.forSession('other-history') }));
+
+		assert.strictEqual(notificationService.setCalls.length, 1);
+	});
+
+	test('dismiss button suppresses tip for current window only', () => {
+		createTipContribution();
+		widgetService.setFocusedWidget(createWidget());
+
+		notificationService.dismissNotification('chat.localAgentDisabled.continueInAgentHostCopilot');
+		widgetService.setFocusedWidget(createWidget({ sessionResource: LocalChatSessionUri.forSession('other-history') }));
+
+		assert.strictEqual(notificationService.setCalls.length, 1);
+		assert.strictEqual(storageService.getBoolean(LOCAL_AGENT_DISABLED_MUTE_STORAGE_KEY, StorageScope.PROFILE, false), false);
 	});
 
 	test('shows tip when agent host Copilot contribution registers after focus', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentDisabledInputTipContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentDisabledInputTipContribution.test.ts
@@ -68,17 +68,12 @@ class TestChatInputNotificationService implements IChatInputNotificationService 
 	readonly setCalls: IChatInputNotification[] = [];
 	readonly deleteCalls: string[] = [];
 	readonly dismissedCalls: string[] = [];
-	private readonly _notificationIds = new Set<string>();
 
 	setNotification(notification: IChatInputNotification): void {
-		this._notificationIds.add(notification.id);
 		this.setCalls.push(notification);
 	}
 
 	deleteNotification(id: string): void {
-		if (!this._notificationIds.delete(id)) {
-			return;
-		}
 		this.deleteCalls.push(id);
 	}
 
@@ -317,7 +312,6 @@ suite('LocalAgentDisabledInputTipContribution', () => {
 	test('mute action stores persistent profile mute and clears tip', async () => {
 		const instantiationService = new TestInstantiationService();
 		instantiationService.set(IStorageService, storageService);
-		instantiationService.set(IChatInputNotificationService, notificationService);
 
 		createTipContribution();
 		widgetService.setFocusedWidget(createWidget());


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/322387

- Add a profile-scoped "Don't Show Again" mute action to the local historical-session "Continue using the agent host" chat input notification.
- Align normal dismiss and "Continue In Agent Host" handling with the Agents Window handoff tip by suppressing the tip for the current window.
- Keep notification mute independent from `chat.editor.localAgent.enabled`, so hiding the tip does not change local harness behavior.
- Cover eligible display, persistent mute, window-only dismiss, continue-action dismiss, and late Agent Host Copilot registration in the existing contribution tests.

-----------------------------------------
Inspirations from:

- `IChatInputNotificationMuteAction` API shape comes from [`chatInputNotificationService.ts`](https://github.com/microsoft/vscode/blob/5fdf22408d7b6445caaa811f282efe56b2ad0092/src/vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationService.ts#L26-L55).
- Bell-slash mute rendering and command dispatch come from [`ChatInputNotificationWidget`](https://github.com/microsoft/vscode/blob/5fdf22408d7b6445caaa811f282efe56b2ad0092/src/vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationWidget.ts#L139-L156).
- Window-lifetime dismiss/open handling comes from [`AgentsHandoffInputTipContribution`](https://github.com/microsoft/vscode/blob/5fdf22408d7b6445caaa811f282efe56b2ad0092/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts#L312-L344).
- Persistent mute semantics and the "Don't Show Again" affordance come from [`AgentsHandoffInputTipContribution`](https://github.com/microsoft/vscode/blob/5fdf22408d7b6445caaa811f282efe56b2ad0092/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts#L319-L324) and its notification payload [`mute` action](https://github.com/microsoft/vscode/blob/5fdf22408d7b6445caaa811f282efe56b2ad0092/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts#L472-L476).