### PR TITLE
Fix flaky ClaudeCustomizationWatcher debounce tests

### DIFF
--- a/src/vs/platform/agentHost/test/node/customizations/claudeSessionCustomizationDiscovery.test.ts
+++ b/src/vs/platform/agentHost/test/node/customizations/claudeSessionCustomizationDiscovery.test.ts
@@ -208,33 +208,45 @@ suite('claudeSessionCustomizationDiscovery', () => {
 	});
 
 	suite('ClaudeCustomizationWatcher', () => {
+		// Debounce wide enough that a burst of edits reliably lands in a single
+		// window even on a loaded CI machine; `settle` then waits a clear
+		// multiple of it so the one debounced fire is always counted before we
+		// assert. The burst itself is issued concurrently so the change events
+		// cluster inside one window rather than racing the debounce.
+		const debounceMs = 20;
+		const settle = () => timeout(debounceMs * 6);
+
 		test('fires once (debounced) for changes under watched roots and ignores unrelated edits', async () => {
-			const watcher = disposables.add(new ClaudeCustomizationWatcher(workspace, userHome, fileService, new NullLogService(), 5));
+			const watcher = disposables.add(new ClaudeCustomizationWatcher(workspace, userHome, fileService, new NullLogService(), debounceMs));
 			let fires = 0;
 			disposables.add(watcher.onDidChange(() => { fires++; }));
 
 			// An unrelated edit in the workspace root must NOT trigger a refresh.
 			await seed('/workspace/unrelated.txt', 'x');
-			await timeout(40);
+			await settle();
 			assert.strictEqual(fires, 0);
 
 			// A burst of edits across the watched roots collapses to a single fire:
 			// a user-scope agent, a project-scope skill, and the sibling `.mcp.json`.
-			await seed('/home/.claude/agents/a.md', 'a');
-			await seed('/workspace/.claude/skills/s/SKILL.md', 's');
-			await seed('/workspace/.mcp.json', '{}');
-			await timeout(40);
+			await Promise.all([
+				seed('/home/.claude/agents/a.md', 'a'),
+				seed('/workspace/.claude/skills/s/SKILL.md', 's'),
+				seed('/workspace/.mcp.json', '{}'),
+			]);
+			await settle();
 			assert.strictEqual(fires, 1);
 		});
 
 		test('fires for a root-level CLAUDE.md / CLAUDE.local.md edit', async () => {
-			const watcher = disposables.add(new ClaudeCustomizationWatcher(workspace, userHome, fileService, new NullLogService(), 5));
+			const watcher = disposables.add(new ClaudeCustomizationWatcher(workspace, userHome, fileService, new NullLogService(), debounceMs));
 			let fires = 0;
 			disposables.add(watcher.onDidChange(() => { fires++; }));
 
-			await seed('/workspace/CLAUDE.md', '# memory');
-			await seed('/workspace/CLAUDE.local.md', '# personal');
-			await timeout(40);
+			await Promise.all([
+				seed('/workspace/CLAUDE.md', '# memory'),
+				seed('/workspace/CLAUDE.local.md', '# personal'),
+			]);
+			await settle();
 			assert.strictEqual(fires, 1);
 		});
 	});


### PR DESCRIPTION
### Problem

`claudeSessionCustomizationDiscovery.test.ts` › `ClaudeCustomizationWatcher` intermittently failed on CI (`AssertionError: Expected values to be strictly equal` on `assert.strictEqual(fires, 1)`).

The tests drove a **5 ms** debounce and asserted an exact fire count after a fixed **40 ms** wait, with the burst of edits issued as separate sequentially-`await`ed writes. On a loaded CI runner the change events could spread beyond the 5 ms window, so the debounce fired more than once and the "collapses to a single fire" assertion failed. (Unrelated to any product change — surfaced as a flake on an unrelated PR's CI.)

### Fix

- Issue the burst **concurrently** (`Promise.all`) so the change events cluster inside one debounce window instead of racing it.
- Widen the test debounce **5 ms → 20 ms** for CI headroom, and `settle` for a clear multiple of it (`debounceMs * 6`) before asserting.
- Apply the same treatment to the sibling `CLAUDE.md` / `CLAUDE.local.md` test, which had the same latent race.

Behaviour under test is unchanged — only the timing margins are made robust.

### Testing

Ran the suite 6× locally — 2 passing each time, deterministic:
```
✔ fires once (debounced) for changes under watched roots and ignores unrelated edits
✔ fires for a root-level CLAUDE.md / CLAUDE.local.md edit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)