### PR TITLE
chat: show active session MCP status

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -255,6 +255,10 @@ Counts shown in the sidebar (per-link badges and the header total in `AICustomiz
 
 Provider-supplied customization rows that include an explicit storage origin are treated as authoritative even when no local URI inference is available. In particular, `storage: PromptsStorage.plugin` keeps AHP remote host plugin customizations out of the User group when no local `pluginUri` exists, and `storage: BUILTIN_STORAGE` keeps provider-supplied built-ins in the Built-in group.
 
+### MCP Active Session Status
+
+The MCP Servers section combines locally known MCP servers with MCP servers reported by the active agent-host session (`IAgentHostCustomizationService.getMcpServers(activeSessionResource)`). Active-session servers are matched to known workspace, user, extension, plugin, or built-in rows by stable identifiers and display names so the row can show the active session's status, matching `MCP: List Servers`. Active-session servers that do not match any known local/runtime server are appended under an **Active Session** group and counted with the rest of the section.
+
 ### Sidebar Entrypoint Mode
 
 The Agents sidebar `AICustomizationShortcutsWidget` supports three entrypoint modes via `sessions.customizations.sidebarMode`: `welcome` (default) keeps the per-category sidebar rows but opens the AI Customization management editor welcome page, `section` restores per-category deep linking, and `single` replaces the per-category rows with one Customizations entry that opens the welcome page. All modes keep the active customization harness in sync with the active session before opening the editor.

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -43,6 +43,9 @@ import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { IAICustomizationWorkspaceService } from '../../common/aiCustomizationWorkspaceService.js';
 import { CustomizationGroupHeaderRenderer, ICustomizationGroupHeaderEntry, CUSTOMIZATION_GROUP_HEADER_HEIGHT, CUSTOMIZATION_GROUP_HEADER_HEIGHT_WITH_SEPARATOR } from './customizationGroupHeaderRenderer.js';
 import { AgentPluginItemKind, IAgentPluginItem } from '../agentPluginEditor/agentPluginItems.js';
+import { ICustomizationHarnessService } from '../../common/customizationHarnessService.js';
+import { IAgentHostCustomizationService } from '../agentSessions/agentHost/agentHostCustomizationService.js';
+import { McpServerStatus } from '../../../../../platform/agentHost/common/state/protocol/state.js';
 
 const $ = DOM.$;
 
@@ -64,7 +67,7 @@ function getPluginUriFromCollectionId(collectionId: string | undefined): string 
  * Represents a collapsible group header in the MCP server list.
  */
 interface IMcpGroupHeaderEntry extends ICustomizationGroupHeaderEntry {
-	readonly scope: LocalMcpServerScope | 'builtin' | 'plugin' | 'extension';
+	readonly scope: LocalMcpServerScope | 'builtin' | 'plugin' | 'extension' | 'active-session';
 }
 
 /**
@@ -73,6 +76,13 @@ interface IMcpGroupHeaderEntry extends ICustomizationGroupHeaderEntry {
 interface IMcpServerItemEntry {
 	readonly type: 'server-item';
 	readonly server: IWorkbenchMcpServer;
+	readonly activeSessionServer?: AgentHostMcpServer;
+	readonly localServer?: IMcpServer;
+}
+
+interface IMcpSessionServerItemEntry {
+	readonly type: 'session-server-item';
+	readonly server: AgentHostMcpServer;
 }
 
 /**
@@ -84,9 +94,15 @@ interface IMcpBuiltinItemEntry {
 	readonly label: string;
 	readonly description: string;
 	readonly collectionId?: string;
+	readonly activeSessionServer?: AgentHostMcpServer;
+	readonly localServer?: IMcpServer;
 }
 
-type IMcpListEntry = IMcpGroupHeaderEntry | IMcpServerItemEntry | IMcpBuiltinItemEntry;
+type AgentHostMcpServer = ReturnType<IAgentHostCustomizationService['getMcpServers']>[number];
+
+type IMcpListEntry = IMcpGroupHeaderEntry | IMcpServerItemEntry | IMcpSessionServerItemEntry | IMcpBuiltinItemEntry;
+
+type McpStatusKind = McpConnectionState.Kind | McpServerStatus | 'disabled';
 
 /**
  * Delegate for the MCP server list.
@@ -109,6 +125,9 @@ class McpServerItemDelegate implements IListVirtualDelegate<IMcpListEntry> {
 		if (element.type === 'builtin-item') {
 			return 'mcpServerItem';
 		}
+		if (element.type === 'session-server-item') {
+			return 'mcpServerItem';
+		}
 		const server = element.server;
 		return server.gallery && !server.local ? 'mcpGalleryItem' : 'mcpServerItem';
 	}
@@ -126,11 +145,10 @@ interface IMcpServerItemTemplateData {
 /**
  * Renderer for local MCP server list items.
  */
-class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpBuiltinItemEntry, IMcpServerItemTemplateData> {
+class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpSessionServerItemEntry | IMcpBuiltinItemEntry, IMcpServerItemTemplateData> {
 	readonly templateId = 'mcpServerItem';
 
 	constructor(
-		@IMcpService private readonly mcpService: IMcpService,
 		@IAICustomizationWorkspaceService private readonly workspaceService: IAICustomizationWorkspaceService,
 		@IAgentPluginService private readonly agentPluginService: IAgentPluginService,
 		@IHoverService private readonly hoverService: IHoverService,
@@ -153,11 +171,12 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpB
 		return { container, typeIcon, name, description, status, disposables: new DisposableStore() };
 	}
 
-	renderElement(element: IMcpServerItemEntry | IMcpBuiltinItemEntry, index: number, templateData: IMcpServerItemTemplateData): void {
+	renderElement(element: IMcpServerItemEntry | IMcpSessionServerItemEntry | IMcpBuiltinItemEntry, index: number, templateData: IMcpServerItemTemplateData): void {
 		templateData.disposables.clear();
 
 		if (element.type === 'builtin-item') {
 			templateData.container.classList.add('builtin');
+			templateData.container.classList.toggle('has-detail', false);
 			templateData.name.textContent = formatDisplayName(element.label);
 			if (element.description) {
 				templateData.description.textContent = truncateToFirstLine(element.description);
@@ -165,7 +184,7 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpB
 			} else {
 				templateData.description.style.display = 'none';
 			}
-			templateData.status.style.display = 'none';
+			this.updateKnownServerStatus(templateData, element.localServer, element.activeSessionServer);
 
 			// Add hover with plugin provenance for plugin-sourced builtin items
 			const pluginUriStr = getPluginUriFromCollectionId(element.collectionId);
@@ -181,6 +200,15 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpB
 					return { content: element.label, appearance: { compact: true, skipFadeInAnimation: true } };
 				}));
 			}
+			return;
+		}
+
+		if (element.type === 'session-server-item') {
+			templateData.container.classList.remove('builtin');
+			templateData.container.classList.toggle('has-detail', false);
+			templateData.name.textContent = formatDisplayName(element.server.name);
+			templateData.description.style.display = 'none';
+			this.updateActiveSessionStatus(templateData, element.server);
 			return;
 		}
 
@@ -200,55 +228,214 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpB
 			templateData.description.style.display = 'none';
 		}
 
-		// Find the server from IMcpService to get connection state
-		const server = this.mcpService.servers.get().find(s => s.definition.id === element.server.id);
+		if (element.activeSessionServer) {
+			this.updateKnownServerStatus(templateData, element.localServer, element.activeSessionServer);
+		} else if (this.workspaceService.isSessionsWindow) {
+			this.updateKnownServerStatus(templateData, element.localServer, undefined);
+		} else {
+			templateData.disposables.add(autorun(reader => {
+				const disabled = element.localServer ? isContributionDisabled(element.localServer.enablement.read(reader)) : false;
+				const connectionState = element.localServer?.connectionState.read(reader);
+				templateData.container.classList.toggle('disabled', disabled);
+				this.updateStatus(templateData.status, disabled ? 'disabled' : connectionState?.state);
+			}));
+		}
+	}
+
+	private updateKnownServerStatus(templateData: IMcpServerItemTemplateData, localServer: IMcpServer | undefined, activeSessionServer: AgentHostMcpServer | undefined): void {
 		templateData.disposables.add(autorun(reader => {
-			const disabled = server ? isContributionDisabled(server.enablement.read(reader)) : false;
-			const connectionState = server?.connectionState.read(reader);
-			templateData.container.classList.toggle('disabled', disabled);
-			this.updateStatus(templateData.status, disabled ? 'disabled' : connectionState?.state);
+			const localDisabled = localServer ? isContributionDisabled(localServer.enablement.read(reader)) : false;
+			templateData.container.classList.toggle('disabled', localDisabled || activeSessionServer?.enabled === false);
+			this.updateStatus(templateData.status, localDisabled ? 'disabled' : activeSessionServer ? (activeSessionServer.enabled ? activeSessionServer.status : 'disabled') : undefined);
 		}));
 	}
 
-	private updateStatus(statusElement: HTMLElement, state: McpConnectionState.Kind | 'disabled' | undefined): void {
+	private updateActiveSessionStatus(templateData: IMcpServerItemTemplateData, server: AgentHostMcpServer | undefined): void {
+		const disabled = server?.enabled === false;
+		templateData.container.classList.toggle('disabled', disabled);
+		this.updateStatus(templateData.status, disabled ? 'disabled' : server?.status);
+	}
+
+	private updateStatus(statusElement: HTMLElement, state: McpStatusKind | undefined): void {
 		statusElement.className = 'mcp-server-status';
 
-		if (this.workspaceService.isSessionsWindow) {
-			// In sessions window, CLI manages MCP servers — hide status
+		const presentation = getMcpStatusPresentation(state);
+		if (!presentation) {
 			statusElement.style.display = 'none';
 			return;
 		}
 
 		statusElement.style.display = '';
-		if (state === 'disabled') {
-			statusElement.textContent = localize('disabled', "Disabled");
-			statusElement.classList.add('disabled');
-			return;
-		}
-		switch (state) {
-			case McpConnectionState.Kind.Running:
-				statusElement.textContent = localize('running', "Running");
-				statusElement.classList.add('running');
-				break;
-			case McpConnectionState.Kind.Starting:
-				statusElement.textContent = localize('starting', "Starting");
-				statusElement.classList.add('starting');
-				break;
-			case McpConnectionState.Kind.Error:
-				statusElement.textContent = localize('error', "Error");
-				statusElement.classList.add('error');
-				break;
-			case McpConnectionState.Kind.Stopped:
-			default:
-				statusElement.textContent = localize('stopped', "Stopped");
-				statusElement.classList.add('stopped');
-				break;
-		}
+		statusElement.textContent = presentation.label;
+		statusElement.classList.add(presentation.className);
 	}
 
 	disposeTemplate(templateData: IMcpServerItemTemplateData): void {
 		templateData.disposables.dispose();
 	}
+}
+
+function getMcpStatusPresentation(state: McpStatusKind | undefined): { label: string; className: string } | undefined {
+	if (state === undefined) {
+		return undefined;
+	}
+	if (state === 'disabled') {
+		return { label: localize('disabled', "Disabled"), className: 'disabled' };
+	}
+	switch (state) {
+		case McpConnectionState.Kind.Running:
+		case McpServerStatus.Ready:
+			return { label: localize('running', "Running"), className: 'running' };
+		case McpConnectionState.Kind.Starting:
+		case McpServerStatus.Starting:
+			return { label: localize('starting', "Starting"), className: 'starting' };
+		case McpServerStatus.AuthRequired:
+			return { label: localize('authRequired', "Authentication required"), className: 'auth-required' };
+		case McpConnectionState.Kind.Error:
+		case McpServerStatus.Error:
+			return { label: localize('error', "Error"), className: 'error' };
+		case McpConnectionState.Kind.Stopped:
+		case McpServerStatus.Stopped:
+		default:
+			return { label: localize('stopped', "Stopped"), className: 'stopped' };
+	}
+}
+
+function getMcpStatusKind(entry: IMcpServerItemEntry | IMcpSessionServerItemEntry | IMcpBuiltinItemEntry): McpStatusKind | undefined {
+	if (entry.type !== 'session-server-item' && entry.localServer && isContributionDisabled(entry.localServer.enablement.get())) {
+		return 'disabled';
+	}
+	const activeSessionServer = entry.type === 'session-server-item' ? entry.server : entry.activeSessionServer;
+	if (!activeSessionServer) {
+		return undefined;
+	}
+	return activeSessionServer.enabled ? activeSessionServer.status : 'disabled';
+}
+
+function getMcpEntryAriaLabel(element: IMcpListEntry): string {
+	if (element.type === 'group-header') {
+		return localize('mcpGroupAriaLabel', "{0}, {1} items, {2}", element.label, element.count, element.collapsed ? localize('collapsed', "collapsed") : localize('expanded', "expanded"));
+	}
+	const label = element.type === 'session-server-item'
+		? element.server.name
+		: element.type === 'builtin-item'
+			? element.label
+			: element.server.label;
+	const status = getMcpStatusPresentation(getMcpStatusKind(element));
+	return status
+		? localize('mcpServerAriaLabelWithStatus', "{0}, {1}", label, status.label)
+		: label;
+}
+
+function normalizeMcpMatchKey(value: string | undefined): string | undefined {
+	const key = value?.trim().toLowerCase();
+	return key || undefined;
+}
+
+function getUniqueMcpMatchKeys(values: readonly (string | undefined)[]): string[] {
+	const keys = new Set<string>();
+	for (const value of values) {
+		const key = normalizeMcpMatchKey(value);
+		if (key) {
+			keys.add(key);
+		}
+	}
+	return [...keys];
+}
+
+class ActiveSessionMcpServerMatcher {
+	private readonly byKey = new Map<string, AgentHostMcpServer[]>();
+	private readonly matchedIds = new Set<string>();
+
+	constructor(private readonly servers: readonly AgentHostMcpServer[]) {
+		for (const server of servers) {
+			for (const key of getUniqueMcpMatchKeys([server.id, server.name])) {
+				let bucket = this.byKey.get(key);
+				if (!bucket) {
+					bucket = [];
+					this.byKey.set(key, bucket);
+				}
+				bucket.push(server);
+			}
+		}
+	}
+
+	take(keys: readonly (string | undefined)[]): AgentHostMcpServer | undefined {
+		for (const key of getUniqueMcpMatchKeys(keys)) {
+			const matches = this.byKey.get(key);
+			const match = matches?.find(server => !this.matchedIds.has(server.id));
+			if (match) {
+				this.matchedIds.add(match.id);
+				return match;
+			}
+		}
+		return undefined;
+	}
+
+	unmatched(query: string): AgentHostMcpServer[] {
+		return this.servers.filter(server => !this.matchedIds.has(server.id) && matchesActiveSessionServerQuery(server, query));
+	}
+}
+
+class LocalMcpServerMatcher {
+	private readonly byKey = new Map<string, IMcpServer>();
+
+	constructor(servers: readonly IMcpServer[]) {
+		for (const server of servers) {
+			for (const key of getRuntimeServerMatchKeys(server)) {
+				this.byKey.set(key, server);
+			}
+		}
+	}
+
+	find(keys: readonly (string | undefined)[]): IMcpServer | undefined {
+		for (const key of getUniqueMcpMatchKeys(keys)) {
+			const server = this.byKey.get(key);
+			if (server) {
+				return server;
+			}
+		}
+		return undefined;
+	}
+}
+
+function matchesActiveSessionServerQuery(server: AgentHostMcpServer, query: string): boolean {
+	if (!query) {
+		return true;
+	}
+	return server.name.toLowerCase().includes(query);
+}
+
+function getWorkbenchServerMatchKeys(server: IWorkbenchMcpServer): string[] {
+	return getUniqueMcpMatchKeys([server.id, server.name, server.label]);
+}
+
+function getRuntimeServerMatchKeys(server: IMcpServer): string[] {
+	return getUniqueMcpMatchKeys([server.definition.id, server.definition.label]);
+}
+
+function getActiveSessionServerOptionsAction(commandService: ICommandService, sessionResource: URI, server: AgentHostMcpServer): Action {
+	return new Action(
+		'mcpServer.activeSession.options',
+		localize('activeSessionMcpServerOptions', "Server Options"),
+		undefined,
+		true,
+		async () => {
+			await commandService.executeCommand(McpCommandIds.AgentHostServerOptions, sessionResource, server.id);
+		}
+	);
+}
+
+function createBuiltinEntry(server: IMcpServer, activeSessionServer?: AgentHostMcpServer): IMcpBuiltinItemEntry {
+	return {
+		type: 'builtin-item',
+		id: `builtin-${server.definition.id}`,
+		label: server.definition.label,
+		description: '',
+		collectionId: server.collection.id,
+		activeSessionServer,
+		localServer: server,
+	};
 }
 
 interface IMcpGalleryItemTemplateData {
@@ -373,6 +560,7 @@ export class McpListWidget extends Disposable {
 
 	private filteredServers: IWorkbenchMcpServer[] = [];
 	private filteredBuiltinCount = 0;
+	private filteredActiveSessionCount = 0;
 	private displayEntries: IMcpListEntry[] = [];
 	private galleryServers: IWorkbenchMcpServer[] = [];
 	private searchQuery: string = '';
@@ -399,6 +587,8 @@ export class McpListWidget extends Disposable {
 		@IAgentPluginService private readonly agentPluginService: IAgentPluginService,
 		@IDialogService private readonly dialogService: IDialogService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@ICustomizationHarnessService private readonly customizationHarnessService: ICustomizationHarnessService,
+		@IAgentHostCustomizationService private readonly agentHostCustomizationService: IAgentHostCustomizationService,
 	) {
 		super();
 		this.element = $('.mcp-list-widget');
@@ -557,10 +747,7 @@ export class McpListWidget extends Disposable {
 				horizontalScrolling: false,
 				accessibilityProvider: {
 					getAriaLabel: (element: IMcpListEntry) => {
-						if (element.type === 'group-header') {
-							return localize('mcpGroupAriaLabel', "{0}, {1} items, {2}", element.label, element.count, element.collapsed ? localize('collapsed', "collapsed") : localize('expanded', "expanded"));
-						}
-						return element.type === 'builtin-item' ? element.label : element.server.label;
+						return getMcpEntryAriaLabel(element);
 					},
 					getWidgetAriaLabel() {
 						return localize('mcpServersListAriaLabel', "MCP Servers");
@@ -593,6 +780,8 @@ export class McpListWidget extends Disposable {
 					if (isGallery || server.description) {
 						this._onDidSelectServer.fire(server);
 					}
+				} else if (e.element.type === 'session-server-item') {
+					this.openActiveSessionServerOptions(e.element.server);
 				}
 				// builtin-item: no action on click (read-only)
 			}
@@ -609,6 +798,17 @@ export class McpListWidget extends Disposable {
 		}));
 		this._register(autorun(reader => {
 			this.mcpService.servers.read(reader);
+			if (!this.browseMode) {
+				this.refresh();
+			}
+		}));
+		this._register(autorun(reader => {
+			this.customizationHarnessService.activeSessionResource.read(reader);
+			if (!this.browseMode) {
+				this.refresh();
+			}
+		}));
+		this._register(this.agentHostCustomizationService.onDidChangeCustomizations(() => {
 			if (!this.browseMode) {
 				this.refresh();
 			}
@@ -746,6 +946,9 @@ export class McpListWidget extends Disposable {
 
 	private filterServers(): void {
 		const query = this.searchQuery.toLowerCase().trim();
+		const activeSessionResource = this.customizationHarnessService.activeSessionResource.get();
+		const activeSessionMatcher = new ActiveSessionMcpServerMatcher(this.agentHostCustomizationService.getMcpServers(activeSessionResource));
+		const localServerMatcher = new LocalMcpServerMatcher(this.mcpService.servers.get());
 
 		if (query) {
 			this.filteredServers = this.mcpWorkbenchService.local.filter(server =>
@@ -762,38 +965,24 @@ export class McpListWidget extends Disposable {
 			.filter(s => !localIds.has(s.definition.id))
 			.filter(s => !query || s.definition.label.toLowerCase().includes(query));
 
-		// Show empty state only when there are no servers at all (not when filtered to empty)
-		if (this.filteredServers.length === 0 && builtinServers.length === 0) {
-			this.emptyContainer.style.display = 'flex';
-			this.listContainer.style.display = 'none';
-
-			if (this.searchQuery.trim()) {
-				// Search with no results
-				this.emptyText.textContent = localize('noMatchingServers', "No servers match '{0}'", this.searchQuery);
-				this.emptySubtext.textContent = localize('tryDifferentSearch', "Try a different search term");
-			} else {
-				// No servers configured
-				this.emptyText.textContent = localize('noMcpServers', "No MCP servers configured");
-				this.emptySubtext.textContent = localize('addMcpServer', "Add an MCP server configuration to get started");
-			}
-		} else {
-			this.emptyContainer.style.display = 'none';
-			this.listContainer.style.display = '';
-		}
-
 		// Group servers by scope
-		const groups: { scope: LocalMcpServerScope; label: string; icon: ThemeIcon; description: string; servers: IWorkbenchMcpServer[] }[] = [
+		const groups: { scope: LocalMcpServerScope; label: string; icon: ThemeIcon; description: string; servers: Array<{ server: IWorkbenchMcpServer; activeSessionServer?: AgentHostMcpServer; localServer?: IMcpServer }> }[] = [
 			{ scope: LocalMcpServerScope.Workspace, label: localize('workspaceGroup', "Workspace"), icon: workspaceIcon, description: localize('workspaceGroupDescription', "MCP servers configured in your workspace settings, shared with your team via version control."), servers: [] },
 			{ scope: LocalMcpServerScope.User, label: localize('userGroup', "User"), icon: userIcon, description: localize('userGroupDescription', "MCP servers configured in your user settings. Private to you and available across all projects."), servers: [] },
 		];
 
 		for (const server of this.filteredServers) {
+			const entry = {
+				server,
+				activeSessionServer: activeSessionMatcher.take(getWorkbenchServerMatchKeys(server)),
+				localServer: localServerMatcher.find(getWorkbenchServerMatchKeys(server)),
+			};
 			const scope = server.local?.scope;
 			if (scope === LocalMcpServerScope.Workspace) {
-				groups[0].servers.push(server);
+				groups[0].servers.push(entry);
 			} else {
 				// User, RemoteUser, or unknown → group under User
-				groups[1].servers.push(server);
+				groups[1].servers.push(entry);
 			}
 		}
 
@@ -817,8 +1006,8 @@ export class McpListWidget extends Disposable {
 				collapsed,
 			});
 			if (!collapsed) {
-				for (const server of group.servers) {
-					entries.push({ type: 'server-item', server });
+				for (const { server, activeSessionServer, localServer } of group.servers) {
+					entries.push({ type: 'server-item', server, activeSessionServer, localServer });
 				}
 			}
 			isFirst = false;
@@ -828,18 +1017,60 @@ export class McpListWidget extends Disposable {
 		// Servers from the Copilot extension (github.copilot / github.copilot-chat)
 		// are treated as built-in; servers from other extensions go under "Extensions".
 		const collectionSources = new Map(this.mcpRegistry.collections.get().map(c => [c.id, c.source]));
-		const pluginServers: IMcpServer[] = [];
-		const extensionServers: IMcpServer[] = [];
-		const otherBuiltinServers: IMcpServer[] = [];
+		const pluginServers: Array<{ server: IMcpServer; activeSessionServer?: AgentHostMcpServer }> = [];
+		const extensionServers: Array<{ server: IMcpServer; activeSessionServer?: AgentHostMcpServer }> = [];
+		const otherBuiltinServers: Array<{ server: IMcpServer; activeSessionServer?: AgentHostMcpServer }> = [];
 		for (const server of builtinServers) {
+			const entry = { server, activeSessionServer: activeSessionMatcher.take(getRuntimeServerMatchKeys(server)) };
 			const source = collectionSources.get(server.collection.id);
 			if (server.collection.id.startsWith(PLUGIN_COLLECTION_PREFIX)) {
-				pluginServers.push(server);
+				pluginServers.push(entry);
 			} else if (source instanceof ExtensionIdentifier && !isCopilotExtension(source)) {
-				extensionServers.push(server);
+				extensionServers.push(entry);
 			} else {
-				otherBuiltinServers.push(server);
+				otherBuiltinServers.push(entry);
 			}
+		}
+		const activeSessionOnlyServers = activeSessionMatcher.unmatched(query);
+
+		// Show empty state only when there are no servers at all (not when filtered to empty)
+		if (this.filteredServers.length === 0 && builtinServers.length === 0 && activeSessionOnlyServers.length === 0) {
+			this.emptyContainer.style.display = 'flex';
+			this.listContainer.style.display = 'none';
+
+			if (this.searchQuery.trim()) {
+				// Search with no results
+				this.emptyText.textContent = localize('noMatchingServers', "No servers match '{0}'", this.searchQuery);
+				this.emptySubtext.textContent = localize('tryDifferentSearch', "Try a different search term");
+			} else {
+				// No servers configured
+				this.emptyText.textContent = localize('noMcpServers', "No MCP servers configured");
+				this.emptySubtext.textContent = localize('addMcpServer', "Add an MCP server configuration to get started");
+			}
+		} else {
+			this.emptyContainer.style.display = 'none';
+			this.listContainer.style.display = '';
+		}
+
+		if (activeSessionOnlyServers.length > 0) {
+			const collapsed = this.collapsedGroups.has('active-session');
+			entries.push({
+				type: 'group-header',
+				id: 'mcp-group-active-session',
+				scope: 'active-session',
+				label: localize('activeSessionGroup', "Active Session"),
+				icon: mcpServerIcon,
+				count: activeSessionOnlyServers.length,
+				isFirst,
+				description: localize('activeSessionGroupDescription', "MCP servers reported by the active session."),
+				collapsed,
+			});
+			if (!collapsed) {
+				for (const server of activeSessionOnlyServers) {
+					entries.push({ type: 'session-server-item', server });
+				}
+			}
+			isFirst = false;
 		}
 
 		if (pluginServers.length > 0) {
@@ -856,14 +1087,8 @@ export class McpListWidget extends Disposable {
 				collapsed,
 			});
 			if (!collapsed) {
-				for (const server of pluginServers) {
-					entries.push({
-						type: 'builtin-item',
-						id: `builtin-${server.definition.id}`,
-						label: server.definition.label,
-						description: '',
-						collectionId: server.collection.id,
-					});
+				for (const { server, activeSessionServer } of pluginServers) {
+					entries.push(createBuiltinEntry(server, activeSessionServer));
 				}
 			}
 			isFirst = false;
@@ -883,14 +1108,8 @@ export class McpListWidget extends Disposable {
 				collapsed,
 			});
 			if (!collapsed) {
-				for (const server of extensionServers) {
-					entries.push({
-						type: 'builtin-item',
-						id: `builtin-${server.definition.id}`,
-						label: server.definition.label,
-						description: '',
-						collectionId: server.collection.id,
-					});
+				for (const { server, activeSessionServer } of extensionServers) {
+					entries.push(createBuiltinEntry(server, activeSessionServer));
 				}
 			}
 			isFirst = false;
@@ -910,14 +1129,8 @@ export class McpListWidget extends Disposable {
 				collapsed,
 			});
 			if (!collapsed) {
-				for (const server of otherBuiltinServers) {
-					entries.push({
-						type: 'builtin-item',
-						id: `builtin-${server.definition.id}`,
-						label: server.definition.label,
-						description: '',
-						collectionId: server.collection.id,
-					});
+				for (const { server, activeSessionServer } of otherBuiltinServers) {
+					entries.push(createBuiltinEntry(server, activeSessionServer));
 				}
 			}
 			isFirst = false;
@@ -928,6 +1141,7 @@ export class McpListWidget extends Disposable {
 
 		// Compute sidebar badge directly from the data arrays (same source as group headers)
 		this.filteredBuiltinCount = builtinServers.length;
+		this.filteredActiveSessionCount = activeSessionOnlyServers.length;
 		this._onDidChangeItemCount.fire(this.itemCount);
 	}
 
@@ -936,7 +1150,7 @@ export class McpListWidget extends Disposable {
 	 * (the same source used to build group headers).
 	 */
 	get itemCount(): number {
-		return this.filteredServers.length + this.filteredBuiltinCount;
+		return this.filteredServers.length + this.filteredBuiltinCount + this.filteredActiveSessionCount;
 	}
 
 	/**
@@ -1036,11 +1250,26 @@ export class McpListWidget extends Disposable {
 		}
 	}
 
+	private openActiveSessionServerOptions(server: AgentHostMcpServer): void {
+		void this.commandService.executeCommand(McpCommandIds.AgentHostServerOptions, this.customizationHarnessService.activeSessionResource.get(), server.id);
+	}
+
 	/**
 	 * Handles context menu for MCP server items.
 	 */
 	private onContextMenu(e: IListContextMenuEvent<IMcpListEntry>): void {
 		if (!e.element) {
+			return;
+		}
+
+		if (e.element.type === 'session-server-item') {
+			const disposables = new DisposableStore();
+			const optionsAction = disposables.add(getActiveSessionServerOptionsAction(this.commandService, this.customizationHarnessService.activeSessionResource.get(), e.element.server));
+			this.contextMenuService.showContextMenu({
+				getAnchor: () => e.anchor,
+				getActions: () => [optionsAction],
+				onHide: () => disposables.dispose(),
+			});
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -301,18 +301,23 @@ function getMcpStatusPresentation(state: McpStatusKind | undefined): { label: st
 	}
 }
 
-function getMcpStatusKind(entry: IMcpServerItemEntry | IMcpSessionServerItemEntry | IMcpBuiltinItemEntry): McpStatusKind | undefined {
-	if (entry.type !== 'session-server-item' && entry.localServer && isContributionDisabled(entry.localServer.enablement.get())) {
+function getMcpStatusKind(entry: IMcpServerItemEntry | IMcpSessionServerItemEntry | IMcpBuiltinItemEntry, isSessionsWindow: boolean): McpStatusKind | undefined {
+	if (entry.type === 'session-server-item') {
+		return entry.server.enabled ? entry.server.status : 'disabled';
+	}
+	if (entry.localServer && isContributionDisabled(entry.localServer.enablement.get())) {
 		return 'disabled';
 	}
-	const activeSessionServer = entry.type === 'session-server-item' ? entry.server : entry.activeSessionServer;
-	if (!activeSessionServer) {
-		return undefined;
+	if (entry.activeSessionServer) {
+		return entry.activeSessionServer.enabled ? entry.activeSessionServer.status : 'disabled';
 	}
-	return activeSessionServer.enabled ? activeSessionServer.status : 'disabled';
+	if (entry.type === 'server-item' && !isSessionsWindow) {
+		return entry.localServer?.connectionState.get().state;
+	}
+	return undefined;
 }
 
-function getMcpEntryAriaLabel(element: IMcpListEntry): string {
+function getMcpEntryAriaLabel(element: IMcpListEntry, isSessionsWindow: boolean): string {
 	if (element.type === 'group-header') {
 		return localize('mcpGroupAriaLabel', "{0}, {1} items, {2}", element.label, element.count, element.collapsed ? localize('collapsed', "collapsed") : localize('expanded', "expanded"));
 	}
@@ -321,7 +326,7 @@ function getMcpEntryAriaLabel(element: IMcpListEntry): string {
 		: element.type === 'builtin-item'
 			? element.label
 			: element.server.label;
-	const status = getMcpStatusPresentation(getMcpStatusKind(element));
+	const status = getMcpStatusPresentation(getMcpStatusKind(element, isSessionsWindow));
 	return status
 		? localize('mcpServerAriaLabelWithStatus', "{0}, {1}", label, status.label)
 		: label;
@@ -589,6 +594,7 @@ export class McpListWidget extends Disposable {
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ICustomizationHarnessService private readonly customizationHarnessService: ICustomizationHarnessService,
 		@IAgentHostCustomizationService private readonly agentHostCustomizationService: IAgentHostCustomizationService,
+		@IAICustomizationWorkspaceService private readonly workspaceService: IAICustomizationWorkspaceService,
 	) {
 		super();
 		this.element = $('.mcp-list-widget');
@@ -747,7 +753,7 @@ export class McpListWidget extends Disposable {
 				horizontalScrolling: false,
 				accessibilityProvider: {
 					getAriaLabel: (element: IMcpListEntry) => {
-						return getMcpEntryAriaLabel(element);
+						return getMcpEntryAriaLabel(element, this.workspaceService.isSessionsWindow);
 					},
 					getWidgetAriaLabel() {
 						return localize('mcpServersListAriaLabel', "MCP Servers");

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -1119,6 +1119,11 @@
 	color: var(--vscode-editor-background);
 }
 
+.mcp-server-item .mcp-server-status.auth-required {
+	background-color: color-mix(in srgb, var(--vscode-terminal-ansiYellow) 50%, transparent);
+	color: var(--vscode-editor-background);
+}
+
 .mcp-server-item .mcp-server-status.error {
 	background-color: color-mix(in srgb, var(--vscode-terminal-ansiRed) 50%, transparent);
 	color: var(--vscode-editor-background);

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
@@ -58,12 +58,14 @@ import { TestConfigurationService } from '../../../../../platform/configuration/
 import { mcpAccessConfig, McpAccessValue } from '../../../../../platform/mcp/common/mcpManagement.js';
 import { McpServerType } from '../../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { ChatConfiguration } from '../../../../contrib/chat/common/constants.js';
-import { IMcpWorkbenchService, IWorkbenchMcpServer, IMcpService, McpServerInstallState } from '../../../../contrib/mcp/common/mcpTypes.js';
+import { IMcpWorkbenchService, IWorkbenchMcpServer, IMcpService, McpConnectionState, McpServerInstallState } from '../../../../contrib/mcp/common/mcpTypes.js';
 import { IMcpRegistry } from '../../../../contrib/mcp/common/mcpRegistryTypes.js';
 import { IWorkbenchLocalMcpServer, LocalMcpServerScope } from '../../../../services/mcp/common/mcpWorkbenchManagementService.js';
 import { McpListWidget } from '../../../../contrib/chat/browser/aiCustomization/mcpListWidget.js';
 import { PluginListWidget } from '../../../../contrib/chat/browser/aiCustomization/pluginListWidget.js';
 import { IIterativePager } from '../../../../../base/common/paging.js';
+import { IAgentHostCustomizationService } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService.js';
+import { McpServerStatus } from '../../../../../platform/agentHost/common/state/protocol/state.js';
 // eslint-disable-next-line local/code-import-patterns
 import { IAgentFeedbackService } from '../../../../../sessions/contrib/agentFeedback/browser/agentFeedbackService.js';
 // eslint-disable-next-line local/code-import-patterns
@@ -116,6 +118,20 @@ function createMockAICustomizationItemsModel(): IAICustomizationItemsModel {
 		override getCount(_section: ItemsModelSection): IObservable<number> { return constObservable(0); }
 		override getPluginCount(): IObservable<number> { return constObservable(0); }
 		override async whenSectionLoaded(_section: ItemsModelSection): Promise<void> { }
+	}();
+}
+
+type FixtureAgentHostMcpServer = ReturnType<IAgentHostCustomizationService['getMcpServers']>[number];
+
+function createMockAgentHostCustomizationService(mcpServers: readonly FixtureAgentHostMcpServer[] = []): IAgentHostCustomizationService {
+	return new class extends mock<IAgentHostCustomizationService>() {
+		override readonly onDidChangeCustomAgents = Event.None;
+		override readonly onDidChangeCustomizations = Event.None;
+		override getCustomAgents() { return []; }
+		override getCustomizations() { return []; }
+		override getWorkingDirectory() { return undefined; }
+		override getMcpServers() { return mcpServers; }
+		override addMcpServer() { }
 	}();
 }
 
@@ -442,7 +458,14 @@ const mcpUserServers = [
 	makeLocalMcpServer('mcp-puppeteer', 'Puppeteer', LocalMcpServerScope.User, 'Browser automation'),
 ];
 const mcpRuntimeServers = [
-	{ definition: { id: 'github-copilot-mcp', label: 'GitHub Copilot' }, collection: { id: 'ext.github.copilot/mcp', label: 'ext.github.copilot/mcp' }, enablement: constObservable(2), connectionState: constObservable({ state: 2 }) },
+	{ definition: { id: 'github-copilot-mcp', label: 'GitHub Copilot' }, collection: { id: 'ext.github.copilot/mcp', label: 'ext.github.copilot/mcp' }, enablement: constObservable(ContributionEnablementState.EnabledProfile), connectionState: constObservable({ state: McpConnectionState.Kind.Running }) },
+	{ definition: { id: 'mcp-web-search', label: 'Web Search' }, collection: { id: 'user-mcp', label: 'User MCP' }, enablement: constObservable(ContributionEnablementState.DisabledProfile), connectionState: constObservable({ state: McpConnectionState.Kind.Stopped }) },
+];
+
+const activeSessionMcpServers: FixtureAgentHostMcpServer[] = [
+	{ id: 'mcp-top-level:fixture:session:component-explorer', name: 'component-explorer', enabled: true, status: McpServerStatus.Ready, setEnabled() { } },
+	{ id: 'mcp-top-level:fixture:session:Remote Browser', name: 'Remote Browser', enabled: true, status: McpServerStatus.AuthRequired, setEnabled() { } },
+	{ id: 'mcp-top-level:fixture:session:Remote Search', name: 'Remote Search', enabled: true, status: McpServerStatus.Error, setEnabled() { } },
 ];
 
 interface IRenderEditorOptions {
@@ -455,6 +478,7 @@ interface IRenderEditorOptions {
 	readonly width?: number;
 	readonly height?: number;
 	readonly skillUIIntegrations?: ReadonlyMap<string, string>;
+	readonly activeSessionMcpServers?: readonly FixtureAgentHostMcpServer[];
 	/** When true, simulates clicking the first list row to enter the embedded editor / detail view. */
 	readonly openFirstItem?: boolean;
 	readonly openItemLabel?: string;
@@ -617,6 +641,7 @@ async function renderEditor(ctx: ComponentFixtureContext, options: IRenderEditor
 				override getSkillUIIntegrations() { return skillUIIntegrations; }
 			}());
 			reg.defineInstance(ICustomizationHarnessService, harnessService);
+			reg.defineInstance(IAgentHostCustomizationService, createMockAgentHostCustomizationService(options.activeSessionMcpServers));
 			// AICustomizationItemsModel is the single source of truth for items
 			// in the editor. Register the real implementation — it will resolve
 			// items via the mock prompts service / harness service above.
@@ -860,6 +885,7 @@ async function renderMcpBrowseMode(ctx: ComponentFixtureContext): Promise<void> 
 				override getActiveDescriptor() { return createVSCodeHarnessDescriptor([PromptsStorage.extension, BUILTIN_STORAGE]); }
 				override registerExternalHarness() { return { dispose() { } }; }
 			}());
+			reg.defineInstance(IAgentHostCustomizationService, createMockAgentHostCustomizationService());
 		},
 	});
 
@@ -1079,6 +1105,7 @@ function renderMcpDisabled(ctx: ComponentFixtureContext, byPolicy: boolean): voi
 				override getActiveDescriptor() { return createVSCodeHarnessDescriptor([PromptsStorage.extension, BUILTIN_STORAGE]); }
 				override registerExternalHarness() { return { dispose() { } }; }
 			}());
+			reg.defineInstance(IAgentHostCustomizationService, createMockAgentHostCustomizationService());
 		},
 	});
 
@@ -1300,6 +1327,16 @@ export default defineThemedFixtureGroup({ path: 'chat/aiCustomizations/' }, {
 		render: ctx => renderEditor(ctx, {
 			sessionResource: localSessionResource,
 			selectedSection: AICustomizationManagementSection.McpServers,
+		}),
+	}),
+
+	McpServersTabActiveSession: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: ctx => renderEditor(ctx, {
+			sessionResource: localSessionResource,
+			isSessionsWindow: true,
+			selectedSection: AICustomizationManagementSection.McpServers,
+			activeSessionMcpServers,
 		}),
 	}),
 


### PR DESCRIPTION
Fixes #308073

## Summary
- merge active agent-host MCP server state into the Customizations MCP Servers list
- show active-session statuses on matching local/runtime servers and add unmatched servers under an Active Session group
- keep disabled installed servers visibly Disabled even when they are not published by the agent host
- add fixture coverage for matched, session-only, and disabled installed MCP server rows

## Validation
- npm run typecheck-client
- ./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationListWidget.test.ts --run src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationItemsModel.test.ts --run src/vs/workbench/contrib/chat/test/browser/aiCustomization/applyStorageSourceFilter.test.ts
- npm run valid-layers-check
- node --experimental-strip-types build/hygiene.ts src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts src/vs/sessions/AI_CUSTOMIZATIONS.md
- npm run precommit