### PR TITLE
Remove voice mode aux window

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -25,7 +25,6 @@ import { autorun } from '../../../../base/common/observable.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import * as nls from '../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
-import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
 import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
@@ -153,48 +152,6 @@ class AgentsVoiceTelemetryContribution extends Disposable implements IWorkbenchC
 }
 
 registerWorkbenchContribution2(AgentsVoiceTelemetryContribution.ID, AgentsVoiceTelemetryContribution, WorkbenchPhase.AfterRestored);
-
-// --- Toggle Command + Menu Item ---
-
-registerAction2(class extends Action2 {
-	constructor() {
-		super({
-			id: 'agentsVoice.toggleWindow',
-			title: nls.localize2('toggleAgentsVoiceWindow', "Voice Mode"),
-			icon: Codicon.openInWindow,
-			menu: [{
-				id: MenuId.MenubarViewMenu,
-				group: '5_copilot',
-				order: 1,
-				when: ContextKeyExpr.equals('config.agents.voice.enabled', true),
-			}, {
-				id: MenuId.ChatExecute,
-				when: ContextKeyExpr.and(
-					ContextKeyExpr.equals('config.agents.voice.enabled', true),
-					AGENTS_VOICE_CONNECTED.isEqualTo(true),
-					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
-					AGENTS_VOICE_INITIATED_HERE.isEqualTo(true),
-				),
-				group: 'navigation',
-				order: 6
-			}],
-			toggled: AGENTS_VOICE_WINDOW_VISIBLE.isEqualTo(true),
-		});
-	}
-	async run(accessor: ServicesAccessor): Promise<void> {
-		const service = accessor.get(IAgentsVoiceWindowService);
-		await service.toggleWindow();
-	}
-});
-
-// Internal command: open the floating window without toggling (used by voice
-// controller to surface responses for non-visible sessions).
-CommandsRegistry.registerCommand('_agentsVoice.openWindow', async (accessor) => {
-	const service = accessor.get(IAgentsVoiceWindowService);
-	if (!service.isOpen) {
-		await service.openWindow();
-	}
-});
 
 // --- Voice mode button in Chat toolbar ---
 // Shows the voice mode icon in both idle and active states.
@@ -482,13 +439,6 @@ configurationRegistry.registerConfiguration({
 			default: false,
 			scope: ConfigurationScope.APPLICATION,
 			restricted: true,
-			included: false,
-		},
-		'agents.voice.alwaysOnTop': {
-			type: 'boolean',
-			description: nls.localize('agents.voice.alwaysOnTop', "Keep the Voice Mode window always on top of other windows."),
-			default: true,
-			scope: ConfigurationScope.APPLICATION,
 			included: false,
 		},
 		'agents.voice.backendUrl': {

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -3,9 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// Register the Agents Voice window service singleton
-import './agentsVoiceWindowService.js';
-
 // Register voice client services
 import '../../chat/browser/voiceClient/micCaptureService.js';
 import '../../chat/browser/voiceClient/ttsPlaybackService.js';
@@ -33,7 +30,7 @@ import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/contributions.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 
-import { IAgentsVoiceWindowService, AgentsVoiceStorageKeys } from '../common/agentsVoice.js';
+import { AgentsVoiceStorageKeys } from '../common/agentsVoice.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
@@ -49,7 +46,6 @@ import { IChatWidgetService } from '../../chat/browser/chat.js';
 
 // --- Context Keys ---
 
-const AGENTS_VOICE_WINDOW_VISIBLE = new RawContextKey<boolean>('agentsVoiceWindowVisible', false);
 export const AGENTS_VOICE_WIDGET_FOCUSED = new RawContextKey<boolean>('agentsVoiceWidgetFocused', false);
 const AGENTS_VOICE_CONNECTED = new RawContextKey<boolean>('agentsVoiceConnected', false);
 const AGENTS_VOICE_CONNECTING = new RawContextKey<boolean>('agentsVoiceConnecting', false);
@@ -59,27 +55,6 @@ const AGENTS_VOICE_ACTIVE = new RawContextKey<boolean>('agentsVoiceActive', fals
 const AGENTS_VOICE_INITIATED_HERE = new RawContextKey<boolean>('agentsVoiceInitiatedHere', false);
 
 // --- Context Key Binding ---
-
-class AgentsVoiceContextKeyContribution extends Disposable implements IWorkbenchContribution {
-
-	static readonly ID = 'workbench.contrib.agentsVoiceContextKey';
-
-	constructor(
-		@IAgentsVoiceWindowService private readonly agentsVoiceWindowService: IAgentsVoiceWindowService,
-		@IContextKeyService contextKeyService: IContextKeyService,
-	) {
-		super();
-
-		const windowKey = AGENTS_VOICE_WINDOW_VISIBLE.bindTo(contextKeyService);
-		windowKey.set(this.agentsVoiceWindowService.isOpen);
-
-		this._register(this.agentsVoiceWindowService.onDidChangeOpen(isOpen => {
-			windowKey.set(isOpen);
-		}));
-	}
-}
-
-registerWorkbenchContribution2(AgentsVoiceContextKeyContribution.ID, AgentsVoiceContextKeyContribution, WorkbenchPhase.AfterRestored);
 
 // Separate contribution for voice connected state — runs later to avoid
 // forcing IVoiceSessionController instantiation too early.

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWindowService.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWindowService.ts
@@ -55,14 +55,6 @@ export class AgentsVoiceWindowService extends Disposable implements IAgentsVoice
 	 * Calls setWindowAlwaysOnTop via a registered command (Electron only).
 	 * Avoids importing INativeHostService in the browser layer.
 	 */
-	private async trySetWindowAlwaysOnTop(alwaysOnTop: boolean, targetWindowId: number): Promise<void> {
-		try {
-			await this.commandService.executeCommand('_agentsVoice.setWindowAlwaysOnTop', alwaysOnTop, targetWindowId);
-		} catch {
-			// Command not registered (e.g. web) — ignore
-		}
-	}
-
 	constructor(
 		@IAuxiliaryWindowService private readonly auxiliaryWindowService: IAuxiliaryWindowService,
 		@IStorageService private readonly storageService: IStorageService,
@@ -101,13 +93,6 @@ export class AgentsVoiceWindowService extends Disposable implements IAgentsVoice
 		mainWindow.addEventListener('beforeunload', onBeforeUnload);
 		this._register({ dispose: () => mainWindow.removeEventListener('beforeunload', onBeforeUnload) });
 
-		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration('agents.voice.alwaysOnTop') && this._window) {
-				const alwaysOnTop = this.configurationService.getValue<boolean>('agents.voice.alwaysOnTop') ?? true;
-				this.trySetWindowAlwaysOnTop(alwaysOnTop, this._window.window.vscodeWindowId);
-			}
-		}));
-
 		const wasOpen = this.storageService.getBoolean(AgentsVoiceStorageKeys.WindowOpen, StorageScope.WORKSPACE, false);
 		if (wasOpen) {
 			// Clear the stored state so it doesn't try to reopen in the future
@@ -121,11 +106,10 @@ export class AgentsVoiceWindowService extends Disposable implements IAgentsVoice
 		}
 
 		const bounds = this.loadBounds();
-		const alwaysOnTop = this.configurationService.getValue<boolean>('agents.voice.alwaysOnTop') ?? true;
 
 		const auxiliaryWindow = await this.auxiliaryWindowService.open({
 			bounds,
-			alwaysOnTop,
+			alwaysOnTop: true,
 			frameless: true,
 			transparent: false,
 			disableFullscreen: true,

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWindowService.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoiceWindowService.ts
@@ -109,9 +109,9 @@ export class AgentsVoiceWindowService extends Disposable implements IAgentsVoice
 		}));
 
 		const wasOpen = this.storageService.getBoolean(AgentsVoiceStorageKeys.WindowOpen, StorageScope.WORKSPACE, false);
-		if (wasOpen && this.configurationService.getValue<boolean>('agents.voice.enabled')) {
-			const reopenTimeout = setTimeout(() => this.openWindow(), 1000);
-			this._register({ dispose: () => clearTimeout(reopenTimeout) });
+		if (wasOpen) {
+			// Clear the stored state so it doesn't try to reopen in the future
+			this.storageService.store(AgentsVoiceStorageKeys.WindowOpen, false, StorageScope.WORKSPACE, StorageTarget.MACHINE);
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -218,16 +218,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	/** Model refs eagerly loaded for sessions awaiting input (no UI focus needed). */
 	private readonly _eagerModelRefs = new Map<string, IChatModelReference>();
 
-	// Sessions whose ``idle`` transition is deferred until their chat model
-	// finishes loading. Copilot (remote agent host) sessions don't keep their
-	// model resident, so when they complete a turn the no-model fallbacks know
-	// only the coarse ``Completed`` status and cannot produce a
-	// ``last_response_summary`` — the text voice narrates. While a session is in
-	// this set we keep reporting its prior (in-progress) state so the BE doesn't
-	// narrate a summary-less completion; once the model loads the autorun emits
-	// the transition together with the response summary.
-	private readonly _pendingIdleNarration = new Set<string>();
-
 	// --- Telemetry tracking ---
 	private _telemetrySessionIndex = 0;
 	private _telemetrySessionStart: number | undefined;
@@ -673,12 +663,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 				// Reactive session context autorun
 				const sessionChangeListener = this.agentSessionsService.model.onDidChangeSessions(() => {
-					// Check state changes first: this lets a Copilot/remote session
-					// that just completed mark its idle transition as deferred
-					// (and start loading its model) BEFORE we publish context, so
-					// we don't ship a summary-less ``idle`` the BE would narrate.
-					this._checkSessionStateChanges();
 					this._sendContext();
+					// Also check state changes for sessions without a loaded model
+					this._checkSessionStateChanges();
 				});
 				const autorunDisposable = autorun(reader => {
 					const agentSessions = this.agentSessionsService.model.sessions.filter(s => !s.isArchived());
@@ -690,9 +677,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 					// --- Helper: subscribe to a chat model's observables and detect state changes ---
 					const processModel = (model: IChatModel, resource: URI, label: string) => {
 						const sessionId = resource.toString();
-						// The model is loaded now, so any deferred idle narration for
-						// this session can proceed via the normal transition below.
-						this._pendingIdleNarration.delete(sessionId);
 						const lastReq = model.lastRequestObs.read(reader);
 						if (lastReq?.response) {
 							lastReq.response.isIncomplete.read(reader);
@@ -764,11 +748,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 							}
 
 							const prev = this._prevSessionStates.get(sessionId);
-							if (this._deferIdleNarrationUntilModelLoaded(s.resource, currentState, prev)) {
-								// Wait for the model to load; the autorun re-runs on
-								// chatModels change and narrates with the summary.
-								continue;
-							}
 							const isStateTransition = prev !== undefined && prev.state !== currentState && currentState !== 'unknown';
 							if (isStateTransition) {
 								const cancelExpiry = this._userCancelledSessions.get(sessionId);
@@ -1091,7 +1070,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._confirmationFlushWatchdogs.clear();
 		for (const ref of this._eagerModelRefs.values()) { ref.dispose(); }
 		this._eagerModelRefs.clear();
-		this._pendingIdleNarration.clear();
 		this._userLogin = undefined;
 		this._lastPersistedTurnId = undefined;
 		this._pendingPriorTimeline = [];
@@ -1419,6 +1397,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 					return undefined;
 				});
 				if (result && result.kind !== 'rejected') {
+					// Surface response in floating window
+					this._watchResponseForFloatingWindow(target);
+					// Open the floating window so user can see the response
+					this.commandService.executeCommand('_agentsVoice.openWindow').catch(() => { /* ignore */ });
 					// Keep the session model loaded until the response completes
 					// so the autorun can observe state transitions and trigger narration.
 					const model = this.chatService.getSession(target);
@@ -1486,6 +1468,73 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			// Ensure the chat view is visible so the user sees/hears the response
 			this.commandService.executeCommand('workbench.panel.chat.view.copilot.focus').catch(() => { /* ignore */ });
 		}
+	}
+
+	/**
+	 * Watch a session's latest response and surface it in the floating window
+	 * transcript. Called when voice sends to a non-visible session so the user
+	 * can see the reply without switching the chat panel.
+	 */
+	private _watchResponseForFloatingWindow(sessionResource: URI): void {
+		const model = this.chatService.getSession(sessionResource);
+		if (!model) {
+			return;
+		}
+
+		// Seed the state cache so the delta mechanism sees thinking→idle as a transition
+		// and includes last_response_summary in the patch.
+		this._prevSessionStates.set(sessionResource.toString(), { state: 'thinking', detail: '' });
+		this._sendContext();
+
+		const disposables = new DisposableStore();
+		let lastText = '';
+
+		const updateFromResponse = () => {
+			const lastReq = model.lastRequest;
+			const response = lastReq?.response;
+			if (!response) {
+				return;
+			}
+
+			const markdown = response.response.getMarkdown();
+			// Only first ~200 chars for the floating window transcript preview
+			const previewText = markdown.length > 200 ? markdown.slice(0, 200) + '…' : markdown;
+			if (previewText && previewText !== lastText) {
+				const isFirst = lastText === '';
+				lastText = previewText;
+				this._setAssistantTurn(previewText, { startNewTurn: isFirst });
+			}
+
+			if (response.isComplete || response.isCanceled) {
+				// Notify the voice backend of the state transition so it can
+				// narrate the response for this non-focused session.
+				this._prevSessionStates.set(sessionResource.toString(), { state: 'idle', detail: '' });
+				this._sendContext();
+				this.voiceClientService.flushSessionContext();
+				disposables.dispose();
+			}
+		};
+
+		// Listen for response changes
+		const checkResponse = () => {
+			const lastReq = model.lastRequest;
+			if (lastReq?.response) {
+				disposables.add(lastReq.response.onDidChange(() => updateFromResponse()));
+				updateFromResponse();
+			}
+		};
+
+		// The response may not exist yet — listen for model changes
+		disposables.add(model.onDidChange(e => {
+			if (e.kind === 'addResponse') {
+				checkResponse();
+			}
+		}));
+		checkResponse();
+
+		// Safety: dispose after 5 minutes in case the response never completes
+		const timeout = setTimeout(() => disposables.dispose(), 5 * 60 * 1000);
+		disposables.add({ dispose: () => clearTimeout(timeout) });
 	}
 
 	// --- Transcript buffer helpers ---
@@ -1930,8 +1979,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			let detail: string | undefined;
 			let lastResponseSummary: string | undefined;
 			if (model) {
-				// Model resident: any deferred idle narration can proceed below.
-				this._pendingIdleNarration.delete(sessionId);
 				const info = this._getAgentStateInfo(model);
 				currentState = info.state;
 				detail = info.detail;
@@ -1947,10 +1994,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			}
 
 			const prev = this._prevSessionStates.get(sessionId);
-			if (!model && this._deferIdleNarrationUntilModelLoaded(s.resource, currentState, prev)) {
-				// Defer until the model loads; the autorun narrates with summary.
-				continue;
-			}
 			const isStateChange = prev !== undefined && prev.state !== currentState && currentState !== 'unknown';
 			const isDetailChange = !isStateChange && prev !== undefined && currentState === 'waiting_for_confirmation' && (detail ?? '') !== prev.detail;
 			if (isStateChange || isDetailChange) {
@@ -2037,18 +2080,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			const model = this.chatService.getSession(s.resource);
 			const isActive = s.resource.toString() === targetSessionId;
 			if (!model) {
-				let fallbackState = s.status === AgentSessionStatus.InProgress ? 'thinking'
+				const fallbackState = s.status === AgentSessionStatus.InProgress ? 'thinking'
 					: s.status === AgentSessionStatus.NeedsInput ? 'waiting_for_confirmation'
 						: s.status === AgentSessionStatus.Completed ? 'idle'
 							: 'unknown';
-				// While a completed session's model is still loading, keep
-				// reporting its prior (in-progress) state so the BE doesn't
-				// narrate the completion before ``last_response_summary`` is
-				// available. The autorun ships the real idle + summary once the
-				// model loads. See ``_pendingIdleNarration``.
-				if (fallbackState === 'idle' && this._pendingIdleNarration.has(s.resource.toString())) {
-					fallbackState = this._prevSessionStates.get(s.resource.toString())?.state ?? fallbackState;
-				}
 				return {
 					id: s.resource.toString(),
 					is_active: isActive,
@@ -2108,43 +2143,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	}
 
 	/**
-	 * Decide whether to defer recording an ``idle`` transition for a session
-	 * whose chat model is not currently loaded.
-	 *
-	 * Copilot (remote agent host) sessions don't keep their model resident the
-	 * way local sessions do, so when they finish a turn the no-model fallbacks
-	 * only know the coarse ``Completed`` status and cannot produce a
-	 * ``last_response_summary`` — the text voice narrates. The result was that
-	 * responses on Copilot sessions were never spoken, only local ones.
-	 *
-	 * When such a session transitions into ``idle`` we eagerly load its model and
-	 * mark it pending so the context keeps reporting its prior state. Loading the
-	 * model mutates ``chatService.chatModels``, which re-runs the narration
-	 * autorun; that pass sees the still-pending ``thinking → idle`` transition and
-	 * emits it together with the freshly available ``last_response_summary``.
-	 *
-	 * Returns ``true`` when the caller should defer (skip recording) this
-	 * transition.
-	 */
-	private _deferIdleNarrationUntilModelLoaded(resource: URI, currentState: string, prev: { readonly state: string } | undefined): boolean {
-		if (currentState !== 'idle' || prev === undefined || prev.state === 'idle') {
-			return false;
-		}
-		if (this.chatService.getSession(resource)) {
-			return false;
-		}
-		const key = resource.toString();
-		this._pendingIdleNarration.add(key);
-		this._ensureModelLoaded(resource);
-		this.logService.info(`[voice] deferring idle narration for unloaded session ${key.slice(-32)} until model loads`);
-		return true;
-	}
-
-	/**
-	 * Eagerly load a chat model for a session that needs input or has just
-	 * completed but hasn't been opened in the UI yet. Once loaded, the autorun
-	 * observables re-fire with full confirmation detail / response summary so the
-	 * backend can narrate properly.
+	 * Eagerly load a chat model for a session that needs input but hasn't been
+	 * opened in the UI yet. Once loaded, the autorun observables will re-fire
+	 * with full confirmation detail so the backend can narrate properly.
 	 */
 	private _ensureModelLoaded(resource: URI): void {
 		const key = resource.toString();
@@ -2157,22 +2158,12 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			if (ref) {
 				if (!this._isConnected.get()) {
 					ref.dispose();
-					this._pendingIdleNarration.delete(key);
 				} else {
 					this._eagerModelRefs.set(key, ref);
 				}
-			} else {
-				// Load resolved without a session — drop any deferred idle so the
-				// session falls back to a plain (summary-less) idle next pass
-				// instead of being stuck reporting its prior state forever.
-				this._pendingIdleNarration.delete(key);
 			}
 			cts.dispose();
-		}, () => {
-			// Load failed — stop deferring so the session isn't stuck.
-			this._pendingIdleNarration.delete(key);
-			cts.dispose();
-		});
+		}, () => { cts.dispose(); });
 	}
 
 	private _getAgentStateInfo(model: IChatModel | undefined | null): { state: string; detail?: string; last_response_summary?: string } {
@@ -2274,11 +2265,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			return { state: 'thinking' };
 		}
 
-		// Use only the markdown prose of the reply for narration. ``toString()``
-		// also folds in tool-invocation text (e.g. ``manageTodoList`` updates),
-		// which caused voice to constantly narrate todo-list changes the user
-		// never asked to hear. ``getMarkdown()`` keeps just what the agent said.
-		const responseText = lastRequest?.response?.response.getMarkdown().trim() ?? '';
+		const responseText = lastRequest?.response?.response.toString() ?? '';
 		return { state: 'idle', ...(responseText ? { last_response_summary: responseText } : {}) };
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -1397,10 +1397,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 					return undefined;
 				});
 				if (result && result.kind !== 'rejected') {
-					// Surface response in floating window
-					this._watchResponseForFloatingWindow(target);
-					// Open the floating window so user can see the response
-					this.commandService.executeCommand('_agentsVoice.openWindow').catch(() => { /* ignore */ });
 					// Keep the session model loaded until the response completes
 					// so the autorun can observe state transitions and trigger narration.
 					const model = this.chatService.getSession(target);
@@ -1468,73 +1464,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			// Ensure the chat view is visible so the user sees/hears the response
 			this.commandService.executeCommand('workbench.panel.chat.view.copilot.focus').catch(() => { /* ignore */ });
 		}
-	}
-
-	/**
-	 * Watch a session's latest response and surface it in the floating window
-	 * transcript. Called when voice sends to a non-visible session so the user
-	 * can see the reply without switching the chat panel.
-	 */
-	private _watchResponseForFloatingWindow(sessionResource: URI): void {
-		const model = this.chatService.getSession(sessionResource);
-		if (!model) {
-			return;
-		}
-
-		// Seed the state cache so the delta mechanism sees thinking→idle as a transition
-		// and includes last_response_summary in the patch.
-		this._prevSessionStates.set(sessionResource.toString(), { state: 'thinking', detail: '' });
-		this._sendContext();
-
-		const disposables = new DisposableStore();
-		let lastText = '';
-
-		const updateFromResponse = () => {
-			const lastReq = model.lastRequest;
-			const response = lastReq?.response;
-			if (!response) {
-				return;
-			}
-
-			const markdown = response.response.getMarkdown();
-			// Only first ~200 chars for the floating window transcript preview
-			const previewText = markdown.length > 200 ? markdown.slice(0, 200) + '…' : markdown;
-			if (previewText && previewText !== lastText) {
-				const isFirst = lastText === '';
-				lastText = previewText;
-				this._setAssistantTurn(previewText, { startNewTurn: isFirst });
-			}
-
-			if (response.isComplete || response.isCanceled) {
-				// Notify the voice backend of the state transition so it can
-				// narrate the response for this non-focused session.
-				this._prevSessionStates.set(sessionResource.toString(), { state: 'idle', detail: '' });
-				this._sendContext();
-				this.voiceClientService.flushSessionContext();
-				disposables.dispose();
-			}
-		};
-
-		// Listen for response changes
-		const checkResponse = () => {
-			const lastReq = model.lastRequest;
-			if (lastReq?.response) {
-				disposables.add(lastReq.response.onDidChange(() => updateFromResponse()));
-				updateFromResponse();
-			}
-		};
-
-		// The response may not exist yet — listen for model changes
-		disposables.add(model.onDidChange(e => {
-			if (e.kind === 'addResponse') {
-				checkResponse();
-			}
-		}));
-		checkResponse();
-
-		// Safety: dispose after 5 minutes in case the response never completes
-		const timeout = setTimeout(() => disposables.dispose(), 5 * 60 * 1000);
-		disposables.add({ dispose: () => clearTimeout(timeout) });
 	}
 
 	// --- Transcript buffer helpers ---

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -218,6 +218,16 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	/** Model refs eagerly loaded for sessions awaiting input (no UI focus needed). */
 	private readonly _eagerModelRefs = new Map<string, IChatModelReference>();
 
+	// Sessions whose ``idle`` transition is deferred until their chat model
+	// finishes loading. Copilot (remote agent host) sessions don't keep their
+	// model resident, so when they complete a turn the no-model fallbacks know
+	// only the coarse ``Completed`` status and cannot produce a
+	// ``last_response_summary`` — the text voice narrates. While a session is in
+	// this set we keep reporting its prior (in-progress) state so the BE doesn't
+	// narrate a summary-less completion; once the model loads the autorun emits
+	// the transition together with the response summary.
+	private readonly _pendingIdleNarration = new Set<string>();
+
 	// --- Telemetry tracking ---
 	private _telemetrySessionIndex = 0;
 	private _telemetrySessionStart: number | undefined;
@@ -663,9 +673,12 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 				// Reactive session context autorun
 				const sessionChangeListener = this.agentSessionsService.model.onDidChangeSessions(() => {
-					this._sendContext();
-					// Also check state changes for sessions without a loaded model
+					// Check state changes first: this lets a Copilot/remote session
+					// that just completed mark its idle transition as deferred
+					// (and start loading its model) BEFORE we publish context, so
+					// we don't ship a summary-less ``idle`` the BE would narrate.
 					this._checkSessionStateChanges();
+					this._sendContext();
 				});
 				const autorunDisposable = autorun(reader => {
 					const agentSessions = this.agentSessionsService.model.sessions.filter(s => !s.isArchived());
@@ -677,6 +690,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 					// --- Helper: subscribe to a chat model's observables and detect state changes ---
 					const processModel = (model: IChatModel, resource: URI, label: string) => {
 						const sessionId = resource.toString();
+						// The model is loaded now, so any deferred idle narration for
+						// this session can proceed via the normal transition below.
+						this._pendingIdleNarration.delete(sessionId);
 						const lastReq = model.lastRequestObs.read(reader);
 						if (lastReq?.response) {
 							lastReq.response.isIncomplete.read(reader);
@@ -748,6 +764,11 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 							}
 
 							const prev = this._prevSessionStates.get(sessionId);
+							if (this._deferIdleNarrationUntilModelLoaded(s.resource, currentState, prev)) {
+								// Wait for the model to load; the autorun re-runs on
+								// chatModels change and narrates with the summary.
+								continue;
+							}
 							const isStateTransition = prev !== undefined && prev.state !== currentState && currentState !== 'unknown';
 							if (isStateTransition) {
 								const cancelExpiry = this._userCancelledSessions.get(sessionId);
@@ -1070,6 +1091,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._confirmationFlushWatchdogs.clear();
 		for (const ref of this._eagerModelRefs.values()) { ref.dispose(); }
 		this._eagerModelRefs.clear();
+		this._pendingIdleNarration.clear();
 		this._userLogin = undefined;
 		this._lastPersistedTurnId = undefined;
 		this._pendingPriorTimeline = [];
@@ -1908,6 +1930,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			let detail: string | undefined;
 			let lastResponseSummary: string | undefined;
 			if (model) {
+				// Model resident: any deferred idle narration can proceed below.
+				this._pendingIdleNarration.delete(sessionId);
 				const info = this._getAgentStateInfo(model);
 				currentState = info.state;
 				detail = info.detail;
@@ -1923,6 +1947,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			}
 
 			const prev = this._prevSessionStates.get(sessionId);
+			if (!model && this._deferIdleNarrationUntilModelLoaded(s.resource, currentState, prev)) {
+				// Defer until the model loads; the autorun narrates with summary.
+				continue;
+			}
 			const isStateChange = prev !== undefined && prev.state !== currentState && currentState !== 'unknown';
 			const isDetailChange = !isStateChange && prev !== undefined && currentState === 'waiting_for_confirmation' && (detail ?? '') !== prev.detail;
 			if (isStateChange || isDetailChange) {
@@ -2009,10 +2037,18 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			const model = this.chatService.getSession(s.resource);
 			const isActive = s.resource.toString() === targetSessionId;
 			if (!model) {
-				const fallbackState = s.status === AgentSessionStatus.InProgress ? 'thinking'
+				let fallbackState = s.status === AgentSessionStatus.InProgress ? 'thinking'
 					: s.status === AgentSessionStatus.NeedsInput ? 'waiting_for_confirmation'
 						: s.status === AgentSessionStatus.Completed ? 'idle'
 							: 'unknown';
+				// While a completed session's model is still loading, keep
+				// reporting its prior (in-progress) state so the BE doesn't
+				// narrate the completion before ``last_response_summary`` is
+				// available. The autorun ships the real idle + summary once the
+				// model loads. See ``_pendingIdleNarration``.
+				if (fallbackState === 'idle' && this._pendingIdleNarration.has(s.resource.toString())) {
+					fallbackState = this._prevSessionStates.get(s.resource.toString())?.state ?? fallbackState;
+				}
 				return {
 					id: s.resource.toString(),
 					is_active: isActive,
@@ -2072,9 +2108,43 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	}
 
 	/**
-	 * Eagerly load a chat model for a session that needs input but hasn't been
-	 * opened in the UI yet. Once loaded, the autorun observables will re-fire
-	 * with full confirmation detail so the backend can narrate properly.
+	 * Decide whether to defer recording an ``idle`` transition for a session
+	 * whose chat model is not currently loaded.
+	 *
+	 * Copilot (remote agent host) sessions don't keep their model resident the
+	 * way local sessions do, so when they finish a turn the no-model fallbacks
+	 * only know the coarse ``Completed`` status and cannot produce a
+	 * ``last_response_summary`` — the text voice narrates. The result was that
+	 * responses on Copilot sessions were never spoken, only local ones.
+	 *
+	 * When such a session transitions into ``idle`` we eagerly load its model and
+	 * mark it pending so the context keeps reporting its prior state. Loading the
+	 * model mutates ``chatService.chatModels``, which re-runs the narration
+	 * autorun; that pass sees the still-pending ``thinking → idle`` transition and
+	 * emits it together with the freshly available ``last_response_summary``.
+	 *
+	 * Returns ``true`` when the caller should defer (skip recording) this
+	 * transition.
+	 */
+	private _deferIdleNarrationUntilModelLoaded(resource: URI, currentState: string, prev: { readonly state: string } | undefined): boolean {
+		if (currentState !== 'idle' || prev === undefined || prev.state === 'idle') {
+			return false;
+		}
+		if (this.chatService.getSession(resource)) {
+			return false;
+		}
+		const key = resource.toString();
+		this._pendingIdleNarration.add(key);
+		this._ensureModelLoaded(resource);
+		this.logService.info(`[voice] deferring idle narration for unloaded session ${key.slice(-32)} until model loads`);
+		return true;
+	}
+
+	/**
+	 * Eagerly load a chat model for a session that needs input or has just
+	 * completed but hasn't been opened in the UI yet. Once loaded, the autorun
+	 * observables re-fire with full confirmation detail / response summary so the
+	 * backend can narrate properly.
 	 */
 	private _ensureModelLoaded(resource: URI): void {
 		const key = resource.toString();
@@ -2087,12 +2157,22 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			if (ref) {
 				if (!this._isConnected.get()) {
 					ref.dispose();
+					this._pendingIdleNarration.delete(key);
 				} else {
 					this._eagerModelRefs.set(key, ref);
 				}
+			} else {
+				// Load resolved without a session — drop any deferred idle so the
+				// session falls back to a plain (summary-less) idle next pass
+				// instead of being stuck reporting its prior state forever.
+				this._pendingIdleNarration.delete(key);
 			}
 			cts.dispose();
-		}, () => { cts.dispose(); });
+		}, () => {
+			// Load failed — stop deferring so the session isn't stuck.
+			this._pendingIdleNarration.delete(key);
+			cts.dispose();
+		});
 	}
 
 	private _getAgentStateInfo(model: IChatModel | undefined | null): { state: string; detail?: string; last_response_summary?: string } {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -2194,7 +2194,11 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			return { state: 'thinking' };
 		}
 
-		const responseText = lastRequest?.response?.response.toString() ?? '';
+		// Use only the markdown prose of the reply for narration. ``toString()``
+		// also folds in tool-invocation text (e.g. ``manageTodoList`` updates),
+		// which caused voice to constantly narrate todo-list changes the user
+		// never asked to hear. ``getMarkdown()`` keeps just what the agent said.
+		const responseText = lastRequest?.response?.response.getMarkdown().trim() ?? '';
 		return { state: 'idle', ...(responseText ? { last_response_summary: responseText } : {}) };
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -72,7 +72,6 @@ import { IHostService } from '../../../../../services/host/browser/host.js';
 import { IMicCaptureService } from '../../voiceClient/micCaptureService.js';
 import { ITtsPlaybackService } from '../../voiceClient/ttsPlaybackService.js';
 import { IVoiceSessionController } from '../../voiceClient/voiceSessionController.js';
-import { IAgentsVoiceWindowService } from '../../../../agentsVoice/common/agentsVoice.js';
 import { IAgentTitleBarStatusService } from '../../agentSessions/experiments/agentTitleBarStatusService.js';
 import { IVoicePlaybackService } from '../../../common/voicePlaybackService.js';
 import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
@@ -140,7 +139,6 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 		@IMicCaptureService private readonly micCaptureService: IMicCaptureService,
 		@ITtsPlaybackService private readonly ttsPlaybackService: ITtsPlaybackService,
 		@IVoiceSessionController private readonly voiceSessionController: IVoiceSessionController,
-		@IAgentsVoiceWindowService private readonly agentsVoiceWindowService: IAgentsVoiceWindowService,
 		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@IAgentTitleBarStatusService _agentTitleBarStatusService: IAgentTitleBarStatusService,
 		@IVoicePlaybackService _voicePlaybackService: IVoicePlaybackService,
@@ -558,16 +556,6 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 			const visible = turns.filter(t => t.text.length > 0 || (t.speaker === 'user' && t.isPartial));
 
 			if (!connected) {
-				transcriptOverlayNode.style.display = 'none';
-				transcriptOverlayNode.classList.remove('has-transcript');
-				return;
-			}
-
-			// If aux window is open and voice is targeting a different session,
-			// don't show transcript in the chat input — it's shown in aux window instead.
-			const targetSession = this.voiceSessionController.targetSession.read(reader);
-			const currentSession = this._widget?.viewModel?.sessionResource;
-			if (this.agentsVoiceWindowService.isOpen && targetSession && currentSession && targetSession.toString() !== currentSession.toString()) {
 				transcriptOverlayNode.style.display = 'none';
 				transcriptOverlayNode.classList.remove('has-transcript');
 				return;


### PR DESCRIPTION
Remove the auxiliary floating window for voice mode. The voice mode UI now lives entirely in the chat panel view pane.

## Changes
- Remove `agentsVoice.toggleWindow` and `_agentsVoice.openWindow` commands
- Remove `_watchResponseForFloatingWindow` method from voice session controller
- Remove `agents.voice.alwaysOnTop` setting registration
- Disable auto-reopen logic in window service (clears stored state instead)
- Clean up unused imports

The window service itself remains registered (to avoid DI breakage) but has no entry points.

Fixes microsoft/vscode-internalbacklog#8182