### PR TITLE
Voice mode: cleaner narration, Copilot-session responses, and button position

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -220,7 +220,7 @@ registerAction2(class extends Action2 {
 					AGENTS_VOICE_INITIATED_HERE.isEqualTo(true),
 				),
 				group: 'navigation',
-				order: 4
+				order: -10
 			}
 		});
 	}
@@ -246,7 +246,7 @@ registerAction2(class extends Action2 {
 					AGENTS_VOICE_CONNECTING.negate(),
 				),
 				group: 'navigation',
-				order: 4
+				order: -10
 			},
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
@@ -295,7 +295,7 @@ registerAction2(class extends Action2 {
 					AGENTS_VOICE_INITIATED_HERE.isEqualTo(true),
 				),
 				group: 'navigation',
-				order: 4
+				order: -10
 			},
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -218,6 +218,14 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	/** Model refs eagerly loaded for sessions awaiting input (no UI focus needed). */
 	private readonly _eagerModelRefs = new Map<string, IChatModelReference>();
 
+	/**
+	 * Sessions whose ``idle`` transition is being deferred until their chat
+	 * model loads, so the narration can include ``last_response_summary``.
+	 * While a session id is in this set we suppress emitting a premature,
+	 * summary-less ``idle`` to the backend (see _buildSessionContext).
+	 */
+	private readonly _pendingIdleNarration = new Set<string>();
+
 	// --- Telemetry tracking ---
 	private _telemetrySessionIndex = 0;
 	private _telemetrySessionStart: number | undefined;
@@ -663,9 +671,11 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 				// Reactive session context autorun
 				const sessionChangeListener = this.agentSessionsService.model.onDidChangeSessions(() => {
-					this._sendContext();
-					// Also check state changes for sessions without a loaded model
+					// Check state changes first so any deferred idle narration is
+					// registered (and premature idle suppressed) before we flush
+					// the session context to the backend.
 					this._checkSessionStateChanges();
+					this._sendContext();
 				});
 				const autorunDisposable = autorun(reader => {
 					const agentSessions = this.agentSessionsService.model.sessions.filter(s => !s.isArchived());
@@ -677,6 +687,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 					// --- Helper: subscribe to a chat model's observables and detect state changes ---
 					const processModel = (model: IChatModel, resource: URI, label: string) => {
 						const sessionId = resource.toString();
+						// The model is now resident so its idle transition will carry a
+						// proper summary; drop any pending deferral/suppression.
+						this._pendingIdleNarration.delete(sessionId);
 						const lastReq = model.lastRequestObs.read(reader);
 						if (lastReq?.response) {
 							lastReq.response.isIncomplete.read(reader);
@@ -749,6 +762,18 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 							const prev = this._prevSessionStates.get(sessionId);
 							const isStateTransition = prev !== undefined && prev.state !== currentState && currentState !== 'unknown';
+
+							// Remote/Copilot sessions don't keep their model resident, so a
+							// coarse ``idle`` transition would carry no last_response_summary
+							// and the backend would narrate an empty completion. Defer the
+							// transition: eagerly load the model and let the autorun re-fire
+							// with the summary once it resolves. Do not record the idle state
+							// yet so the transition is still detected after the model loads.
+							if (isStateTransition && currentState === 'idle') {
+								this._deferIdleNarrationUntilModelLoaded(s.resource);
+								continue;
+							}
+
 							if (isStateTransition) {
 								const cancelExpiry = this._userCancelledSessions.get(sessionId);
 								if (cancelExpiry) {
@@ -1070,6 +1095,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._confirmationFlushWatchdogs.clear();
 		for (const ref of this._eagerModelRefs.values()) { ref.dispose(); }
 		this._eagerModelRefs.clear();
+		this._pendingIdleNarration.clear();
 		this._userLogin = undefined;
 		this._lastPersistedTurnId = undefined;
 		this._pendingPriorTimeline = [];
@@ -1983,6 +2009,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				currentState = info.state;
 				detail = info.detail;
 				lastResponseSummary = info.last_response_summary;
+				// Model is resident now; drop any pending idle deferral/suppression.
+				this._pendingIdleNarration.delete(sessionId);
 			} else {
 				currentState = s.status === AgentSessionStatus.InProgress ? 'thinking'
 					: s.status === AgentSessionStatus.NeedsInput ? 'waiting_for_confirmation'
@@ -1996,6 +2024,14 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			const prev = this._prevSessionStates.get(sessionId);
 			const isStateChange = prev !== undefined && prev.state !== currentState && currentState !== 'unknown';
 			const isDetailChange = !isStateChange && prev !== undefined && currentState === 'waiting_for_confirmation' && (detail ?? '') !== prev.detail;
+
+			// Defer summary-less idle transitions for remote/Copilot sessions until
+			// their model loads (see _deferIdleNarrationUntilModelLoaded).
+			if (!model && currentState === 'idle' && isStateChange) {
+				this._deferIdleNarrationUntilModelLoaded(s.resource);
+				continue;
+			}
+
 			if (isStateChange || isDetailChange) {
 				const cancelExpiry = this._userCancelledSessions.get(sessionId);
 				if (cancelExpiry) {
@@ -2080,12 +2116,22 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			const model = this.chatService.getSession(s.resource);
 			const isActive = s.resource.toString() === targetSessionId;
 			if (!model) {
-				const fallbackState = s.status === AgentSessionStatus.InProgress ? 'thinking'
+				const sessionIdStr = s.resource.toString();
+				let fallbackState = s.status === AgentSessionStatus.InProgress ? 'thinking'
 					: s.status === AgentSessionStatus.NeedsInput ? 'waiting_for_confirmation'
 						: s.status === AgentSessionStatus.Completed ? 'idle'
 							: 'unknown';
+				// If this idle transition is deferred until the model loads, keep
+				// reporting the prior state so the backend doesn't narrate a
+				// premature, summary-less completion. See _pendingIdleNarration.
+				if (fallbackState === 'idle' && this._pendingIdleNarration.has(sessionIdStr)) {
+					const prev = this._prevSessionStates.get(sessionIdStr);
+					if (prev?.state) {
+						fallbackState = prev.state;
+					}
+				}
 				return {
-					id: s.resource.toString(),
+					id: sessionIdStr,
 					is_active: isActive,
 					agent_state: fallbackState,
 				};
@@ -2158,12 +2204,28 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			if (ref) {
 				if (!this._isConnected.get()) {
 					ref.dispose();
+					this._pendingIdleNarration.delete(key);
 				} else {
 					this._eagerModelRefs.set(key, ref);
 				}
+			} else {
+				// Load failed; stop suppressing the coarse idle for this session.
+				this._pendingIdleNarration.delete(key);
 			}
 			cts.dispose();
-		}, () => { cts.dispose(); });
+		}, () => { this._pendingIdleNarration.delete(key); cts.dispose(); });
+	}
+
+	/**
+	 * Defer narrating a session's ``idle`` transition until its chat model is
+	 * resident, so the narration can include ``last_response_summary``. Remote/
+	 * Copilot sessions don't keep their model loaded, so without this the
+	 * backend would only ever see a summary-less completion. Eagerly loads the
+	 * model; once it resolves the autorun re-fires and narrates with the summary.
+	 */
+	private _deferIdleNarrationUntilModelLoaded(resource: URI): void {
+		this._pendingIdleNarration.add(resource.toString());
+		this._ensureModelLoaded(resource);
 	}
 
 	private _getAgentStateInfo(model: IChatModel | undefined | null): { state: string; detail?: string; last_response_summary?: string } {
@@ -2265,7 +2327,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			return { state: 'thinking' };
 		}
 
-		const responseText = lastRequest?.response?.response.toString() ?? '';
+		const responseText = lastRequest?.response?.response.getMarkdown().trim() ?? '';
 		return { state: 'idle', ...(responseText ? { last_response_summary: responseText } : {}) };
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -218,6 +218,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	/** Model refs eagerly loaded for sessions awaiting input (no UI focus needed). */
 	private readonly _eagerModelRefs = new Map<string, IChatModelReference>();
 
+	/** Sessions with an in-flight eager model load, to dedupe concurrent loads. */
+	private readonly _eagerModelLoading = new Set<string>();
+
 	/**
 	 * Sessions whose ``idle`` transition is being deferred until their chat
 	 * model loads, so the narration can include ``last_response_summary``.
@@ -1095,6 +1098,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._confirmationFlushWatchdogs.clear();
 		for (const ref of this._eagerModelRefs.values()) { ref.dispose(); }
 		this._eagerModelRefs.clear();
+		this._eagerModelLoading.clear();
 		this._pendingIdleNarration.clear();
 		this._userLogin = undefined;
 		this._lastPersistedTurnId = undefined;
@@ -2195,16 +2199,25 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 */
 	private _ensureModelLoaded(resource: URI): void {
 		const key = resource.toString();
-		if (this._eagerModelRefs.has(key) || this.chatService.getSession(resource)) {
+		// Skip if already loaded, resident in the UI, or a load is in flight.
+		// The in-flight guard prevents repeated onDidChangeSessions/autorun
+		// cycles from starting concurrent loads whose refs would overwrite each
+		// other in _eagerModelRefs and leak the prior ref.
+		if (this._eagerModelRefs.has(key) || this._eagerModelLoading.has(key) || this.chatService.getSession(resource)) {
 			return;
 		}
 		this.logService.info(`[voice] eagerly loading model for session ${key.slice(-32)}`);
+		this._eagerModelLoading.add(key);
 		const cts = new CancellationTokenSource();
 		this.chatService.acquireOrLoadSession(resource, ChatAgentLocation.Chat, cts.token, 'VoiceSessionController#eagerLoad').then(ref => {
+			this._eagerModelLoading.delete(key);
 			if (ref) {
-				if (!this._isConnected.get()) {
+				const existing = this._eagerModelRefs.get(key);
+				if (!this._isConnected.get() || existing) {
 					ref.dispose();
-					this._pendingIdleNarration.delete(key);
+					if (!this._isConnected.get()) {
+						this._pendingIdleNarration.delete(key);
+					}
 				} else {
 					this._eagerModelRefs.set(key, ref);
 				}
@@ -2213,7 +2226,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				this._pendingIdleNarration.delete(key);
 			}
 			cts.dispose();
-		}, () => { this._pendingIdleNarration.delete(key); cts.dispose(); });
+		}, () => { this._eagerModelLoading.delete(key); this._pendingIdleNarration.delete(key); cts.dispose(); });
 	}
 
 	/**


### PR DESCRIPTION
This splits out three voice-mode fixes into a dedicated PR (previously intermixed with the aux-window-removal work).

### 1. Stop narrating todo-list / tool activity
`_getAgentStateInfo` built `last_response_summary` (the text the voice backend narrates) from `response.toString()`, which folds in tool-invocation text, `manageTodoList` updates. So every todo update got read aloud.

Now it uses `response.getMarkdown().trim()`, which returns only the assistant's markdown response and excludes tool invocations.

### 2. Hear responses for Copilot (remote) sessions, not just local
Remote/Copilot sessions don't keep their `IChatModel` resident, so when such a session completed we only had a coarse `AgentSessionStatus` with no `last_response_summary` — nothing useful to speak.

When an unloaded session transitions to `idle`, we now eagerly load its model and **defer** recording/narrating the transition (suppressing the premature, summary-less `idle`) until the model loads. The autorun then re-emits the transition with the actual response summary. A new `_pendingIdleNarration` set tracks these deferred sessions so `_buildSessionContext` keeps reporting the prior state until the summary is available; load failures clear the deferral so we fall back gracefully.

### 3. Move the voice-mode button to the leftmost position
The three voice-mode `MenuId.ChatExecute` entries (`connecting`, `startVoiceInChat`, `pttStopInChat`) were at `order: 4` (rightmost, next to Send). They are now `order: -10` so the voice button sits to the left of all other input buttons in every state.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8183