### PR TITLE
Align voice mic selection with system default pattern

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -426,8 +426,6 @@ registerAction2(class extends Action2 {
 
 		const devices = await navigator.mediaDevices.enumerateDevices();
 		const allAudioInputs = devices.filter(d => d.kind === 'audioinput');
-		const defaultDevice = allAudioInputs.find(d => d.deviceId === 'default');
-		const defaultDeviceLabel = defaultDevice?.label?.replace(/^Default - /, '') || '';
 		const audioInputs = allAudioInputs.filter(d => d.deviceId !== 'default');
 
 		if (audioInputs.length === 0) {
@@ -437,32 +435,31 @@ registerAction2(class extends Action2 {
 
 		const currentDeviceId = configurationService.getValue<string>('agents.voice.microphoneDevice') || '';
 
-		const items = audioInputs.map(d => {
-			const label = d.label || nls.localize('unknownDevice', "Unknown Device ({0})", d.deviceId.slice(0, 8));
-			const isSystemDefault = label === defaultDeviceLabel;
-			const isSelected = currentDeviceId === '' ? isSystemDefault : d.deviceId === currentDeviceId;
+		type DevicePickItem = { label: string; description?: string; deviceId: string };
+		const items: DevicePickItem[] = [];
 
-			const parts: string[] = [];
-			if (isSystemDefault) {
-				parts.push(nls.localize('systemDefault', "System Default"));
-			}
-			if (isSelected) {
-				parts.push(nls.localize('current', "(current)"));
-			}
-
-			return {
-				label,
-				description: parts.length > 0 ? parts.join(' ') : undefined,
-				deviceId: d.deviceId,
-			};
+		// "System Default" entry — clears the setting so the OS default is always used
+		items.push({
+			label: nls.localize('systemDefault', "System Default"),
+			description: currentDeviceId === '' ? nls.localize('current', "(current)") : undefined,
+			deviceId: '',
 		});
+
+		for (const d of audioInputs) {
+			const label = d.label || nls.localize('unknownDevice', "Unknown Device ({0})", d.deviceId.slice(0, 8));
+			items.push({
+				label,
+				description: d.deviceId === currentDeviceId ? nls.localize('current', "(current)") : undefined,
+				deviceId: d.deviceId,
+			});
+		}
 
 		const picked = await quickInputService.pick(items, {
 			placeHolder: nls.localize('selectMic', "Select a microphone for Voice Mode"),
 		});
 
 		if (picked) {
-			const selection = picked as typeof items[number];
+			const selection = picked as DevicePickItem;
 			await configurationService.updateValue('agents.voice.microphoneDevice', selection.deviceId);
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
@@ -8,6 +8,7 @@ import { Emitter, Event } from '../../../../../base/common/event.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
 
 export const IMicCaptureService = createDecorator<IMicCaptureService>('micCaptureService');
 
@@ -127,6 +128,7 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@ILogService private readonly logService: ILogService,
 	) {
 		super();
 	}
@@ -302,9 +304,23 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 			audioConstraints.deviceId = { exact: deviceId };
 		}
 
-		const micStream = await window.navigator.mediaDevices.getUserMedia({
-			audio: audioConstraints,
-		});
+		let micStream: MediaStream;
+		try {
+			micStream = await window.navigator.mediaDevices.getUserMedia({
+				audio: audioConstraints,
+			});
+		} catch (err) {
+			if (deviceId) {
+				// Stored device may be unavailable — fall back to system default
+				this.logService.warn(`[mic] Preferred device ${deviceId} unavailable, falling back to default`, err);
+				delete audioConstraints.deviceId;
+				micStream = await window.navigator.mediaDevices.getUserMedia({
+					audio: audioConstraints,
+				});
+			} else {
+				throw err;
+			}
+		}
 		this._micStream = micStream;
 
 		if (!this._micCtx) {


### PR DESCRIPTION
## Problem
The `agents.voice.microphoneDevice` setting stores a raw device ID, but:
1. No way to reset to "System Default" once a specific device is selected
2. If the stored device ID becomes stale (device unplugged, ID changes across reboots), mic capture fails with `{ exact: deviceId }`

## Fix
- **Quick pick**: Add explicit "System Default" entry at the top that clears the setting, so users can always return to the OS default
- **Fallback**: In `micCaptureService`, catch `getUserMedia` failure when using a stored device ID and retry with system default instead of crashing
- Simplify quick pick item construction (remove fragile label-matching for default detection)

Closes microsoft/vscode-internalbacklog#8184