### PR TITLE
Use StorageService for mic device selection, show error on permission denied

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -354,48 +354,48 @@ registerAction2(class extends Action2 {
 	}
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const quickInputService = accessor.get(IQuickInputService);
-		const configurationService = accessor.get(IConfigurationService);
+		const storageService = accessor.get(IStorageService);
 
 		const devices = await navigator.mediaDevices.enumerateDevices();
-		const allAudioInputs = devices.filter(d => d.kind === 'audioinput');
-		const defaultDevice = allAudioInputs.find(d => d.deviceId === 'default');
-		const defaultDeviceLabel = defaultDevice?.label?.replace(/^Default - /, '') || '';
-		const audioInputs = allAudioInputs.filter(d => d.deviceId !== 'default');
+		const audioInputs = devices.filter(d => d.kind === 'audioinput' && d.deviceId !== 'default');
 
 		if (audioInputs.length === 0) {
 			quickInputService.pick([{ label: nls.localize('noMicrophones', "No microphones found") }]);
 			return;
 		}
 
-		const currentDeviceId = configurationService.getValue<string>('agents.voice.microphoneDevice') || '';
+		const currentDeviceId = storageService.get(AgentsVoiceStorageKeys.MicrophoneDevice, StorageScope.APPLICATION, '');
 
-		const items = audioInputs.map(d => {
-			const label = d.label || nls.localize('unknownDevice', "Unknown Device ({0})", d.deviceId.slice(0, 8));
-			const isSystemDefault = label === defaultDeviceLabel;
-			const isSelected = currentDeviceId === '' ? isSystemDefault : d.deviceId === currentDeviceId;
+		type DevicePickItem = { label: string; description?: string; deviceId: string };
+		const items: DevicePickItem[] = [];
 
-			const parts: string[] = [];
-			if (isSystemDefault) {
-				parts.push(nls.localize('systemDefault', "System Default"));
-			}
-			if (isSelected) {
-				parts.push(nls.localize('current', "(current)"));
-			}
-
-			return {
-				label,
-				description: parts.length > 0 ? parts.join(' ') : undefined,
-				deviceId: d.deviceId,
-			};
+		// "System Default" entry — clears the stored device so the OS default is always used
+		items.push({
+			label: nls.localize('systemDefault', "System Default"),
+			description: currentDeviceId === '' ? nls.localize('current', "(current)") : undefined,
+			deviceId: '',
 		});
+
+		for (const d of audioInputs) {
+			const label = d.label || nls.localize('unknownDevice', "Unknown Device ({0})", d.deviceId.slice(0, 8));
+			items.push({
+				label,
+				description: d.deviceId === currentDeviceId ? nls.localize('current', "(current)") : undefined,
+				deviceId: d.deviceId,
+			});
+		}
 
 		const picked = await quickInputService.pick(items, {
 			placeHolder: nls.localize('selectMic', "Select a microphone for Voice Mode"),
 		});
 
 		if (picked) {
-			const selection = picked as typeof items[number];
-			await configurationService.updateValue('agents.voice.microphoneDevice', selection.deviceId);
+			const selection = picked as DevicePickItem;
+			if (selection.deviceId) {
+				storageService.store(AgentsVoiceStorageKeys.MicrophoneDevice, selection.deviceId, StorageScope.APPLICATION, StorageTarget.MACHINE);
+			} else {
+				storageService.remove(AgentsVoiceStorageKeys.MicrophoneDevice, StorageScope.APPLICATION);
+			}
 		}
 	}
 });
@@ -446,13 +446,6 @@ configurationRegistry.registerConfiguration({
 			scope: ConfigurationScope.APPLICATION,
 			included: false,
 			tags: ['advanced'],
-		},
-		'agents.voice.microphoneDevice': {
-			type: 'string',
-			markdownDescription: nls.localize('agents.voice.microphoneDevice.markdownDescription', "The device ID of the microphone to use for voice mode. Run the `Voice: Select Microphone` command to pick a device."),
-			default: '',
-			scope: ConfigurationScope.APPLICATION,
-			ignoreSync: true,
 		},
 	}
 });

--- a/src/vs/workbench/contrib/agentsVoice/common/agentsVoice.ts
+++ b/src/vs/workbench/contrib/agentsVoice/common/agentsVoice.ts
@@ -22,6 +22,7 @@ export const enum AgentsVoiceStorageKeys {
 	WindowBounds = 'agentsVoice.windowBounds',
 	TranscriptIndex = 'agentsVoice.transcriptIndex',
 	OnboardingCompleted = 'agentsVoice.onboardingCompleted',
+	MicrophoneDevice = 'agentsVoice.microphoneDevice',
 }
 
 export const IAgentsVoiceWindowService = createDecorator<IAgentsVoiceWindowService>('agentsVoiceWindowService');

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
@@ -10,6 +10,7 @@ import { InstantiationType, registerSingleton } from '../../../../../platform/in
 import { IStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
 import { INotificationService, Severity } from '../../../../../platform/notification/common/notification.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
+import { localize } from '../../../../../nls.js';
 import { AgentsVoiceStorageKeys } from '../../../../contrib/agentsVoice/common/agentsVoice.js';
 
 export const IMicCaptureService = createDecorator<IMicCaptureService>('micCaptureService');
@@ -320,16 +321,16 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 			if (isDeviceError) {
 				this.logService.warn(`[mic] Preferred device ${deviceId.slice(0, 8)}… unavailable, falling back to default`);
 				delete audioConstraints.deviceId;
-				micStream = await window.navigator.mediaDevices.getUserMedia({
-					audio: audioConstraints,
-				});
-			} else if (err instanceof DOMException && err.name === 'NotAllowedError') {
-				this.notificationService.notify({
-					severity: Severity.Error,
-					message: 'Microphone access was denied. Grant microphone permission in your system settings to use Voice Mode.',
-				});
-				throw err;
+				try {
+					micStream = await window.navigator.mediaDevices.getUserMedia({
+						audio: audioConstraints,
+					});
+				} catch (retryErr) {
+					this._notifyMicPermissionDenied(retryErr);
+					throw retryErr;
+				}
 			} else {
+				this._notifyMicPermissionDenied(err);
 				throw err;
 			}
 		}
@@ -410,6 +411,15 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 		source.connect(processor);
 		processor.connect(ctx.destination);
 		this._isCapturing = true;
+	}
+
+	private _notifyMicPermissionDenied(err: unknown): void {
+		if (err instanceof DOMException && err.name === 'NotAllowedError') {
+			this.notificationService.notify({
+				severity: Severity.Error,
+				message: localize('mic.permissionDenied', "Microphone access was denied. Grant microphone permission in your system settings to use Voice Mode."),
+			});
+		}
 	}
 
 	stopCapture(): void {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
@@ -7,7 +7,10 @@ import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
+import { INotificationService, Severity } from '../../../../../platform/notification/common/notification.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { AgentsVoiceStorageKeys } from '../../../../contrib/agentsVoice/common/agentsVoice.js';
 
 export const IMicCaptureService = createDecorator<IMicCaptureService>('micCaptureService');
 
@@ -126,7 +129,9 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 	declare readonly _serviceBrand: undefined;
 
 	constructor(
-		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IStorageService private readonly storageService: IStorageService,
+		@INotificationService private readonly notificationService: INotificationService,
+		@ILogService private readonly logService: ILogService,
 	) {
 		super();
 	}
@@ -291,7 +296,7 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 		this._window = window;
 		if (this._isCapturing) { return; }
 
-		const deviceId = this.configurationService.getValue<string>('agents.voice.microphoneDevice');
+		const deviceId = this.storageService.get(AgentsVoiceStorageKeys.MicrophoneDevice, StorageScope.APPLICATION);
 		const audioConstraints: MediaTrackConstraints = {
 			channelCount: 1,
 			sampleRate: 16000,
@@ -302,9 +307,32 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 			audioConstraints.deviceId = { exact: deviceId };
 		}
 
-		const micStream = await window.navigator.mediaDevices.getUserMedia({
-			audio: audioConstraints,
-		});
+		let micStream: MediaStream;
+		try {
+			micStream = await window.navigator.mediaDevices.getUserMedia({
+				audio: audioConstraints,
+			});
+		} catch (err) {
+			// If the stored device is unavailable (unplugged/stale ID), fall back
+			// to system default. Only retry on device-specific errors.
+			const isDeviceError = deviceId && err instanceof DOMException &&
+				(err.name === 'OverconstrainedError' || err.name === 'NotFoundError');
+			if (isDeviceError) {
+				this.logService.warn(`[mic] Preferred device ${deviceId.slice(0, 8)}… unavailable, falling back to default`);
+				delete audioConstraints.deviceId;
+				micStream = await window.navigator.mediaDevices.getUserMedia({
+					audio: audioConstraints,
+				});
+			} else if (err instanceof DOMException && err.name === 'NotAllowedError') {
+				this.notificationService.notify({
+					severity: Severity.Error,
+					message: 'Microphone access was denied. Grant microphone permission in your system settings to use Voice Mode.',
+				});
+				throw err;
+			} else {
+				throw err;
+			}
+		}
 		this._micStream = micStream;
 
 		if (!this._micCtx) {


### PR DESCRIPTION
## Changes

### 1. Replace setting with StorageService (#8184)
The `agents.voice.microphoneDevice` configuration setting stored a raw device ID, but this is a machine-local runtime choice, not a user preference that should sync. Following the pattern used by debug (`StorageScope.WORKSPACE` + `StorageTarget.MACHINE`), mic selection now uses `StorageService` with `StorageScope.APPLICATION` + `StorageTarget.MACHINE`.

- Adds `AgentsVoiceStorageKeys.MicrophoneDevice` storage key
- Removes `agents.voice.microphoneDevice` setting registration
- Adds explicit **System Default** entry at top of mic quick pick to reset to OS default
- Falls back to system default when stored device ID is stale (`OverconstrainedError` / `NotFoundError`)

### 2. Show notification on mic permission denied (#8058)
When mic permission is denied (`NotAllowedError`), the user was silently stuck in a connecting state with no indication of what went wrong. Now shows a notification explaining that microphone permission needs to be granted in system settings.

Fixes microsoft/vscode-internalbacklog#8184
Fixes microsoft/vscode-internalbacklog#8058