### PR TITLE
Fix misleading Chat model picker and Sign In affordances in untrusted (Restricted Mode) workspaces

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/modelPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/modelPicker.ts
@@ -12,6 +12,7 @@ import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextke
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { IWorkspaceTrustManagementService } from '../../../../platform/workspace/common/workspaceTrust.js';
 import { IChatInputPickerOptions } from '../../../../workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.js';
 import { IModelPickerDelegate, ModelPickerActionItem } from '../../../../workbench/contrib/chat/browser/widget/input/modelPickerActionItem.js';
 import { ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService } from '../../../../workbench/contrib/chat/common/languageModels.js';
@@ -107,6 +108,7 @@ export class ModelPicker extends Disposable {
 		@IStorageService private readonly _storageService: IStorageService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@INewChatModelPickerService private readonly _newChatModelPickerService: INewChatModelPickerService,
+		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
 	) {
 		super();
 
@@ -148,6 +150,18 @@ export class ModelPicker extends Disposable {
 
 		this._initModel();
 		this._register(this._languageModelsService.onDidChangeLanguageModels(() => this._initModel()));
+
+		// Re-evaluate when workspace trust changes (or finishes initializing): an
+		// untrusted workspace disables the model providers, and the shared widget
+		// then renders its Restricted Mode state. Visibility is recomputed so the
+		// picker stays visible to surface "Pick Model" + the Trust action instead
+		// of hiding as an empty picker.
+		this._register(this._workspaceTrustManagementService.onDidChangeTrust(() => this._initModel()));
+		this._workspaceTrustManagementService.workspaceTrustInitialized.then(() => {
+			if (!this._store.isDisposed) {
+				this._initModel();
+			}
+		});
 
 		// When the active session changes, re-init (may switch provider or
 		// session type). _initModel() calls _delegate.setModel() which already
@@ -263,12 +277,17 @@ export class ModelPicker extends Disposable {
 
 	/**
 	 * Whether the model picker should be shown for the given session. Visible
-	 * when the session has models, or when its Auto model is unavailable (so the
-	 * widget can render the "No models available" empty state). Otherwise hidden,
-	 * matching the historical behavior for providers that offer no models.
+	 * when the session has models, when its Auto model is unavailable (so the
+	 * widget can render the "No models available" empty state), or when the
+	 * workspace is untrusted (so the widget can render its Restricted Mode state
+	 * with a Trust action). Otherwise hidden, matching the historical behavior
+	 * for providers that offer no models.
 	 */
 	private _shouldShowPicker(session: ISession | undefined): boolean {
 		if (getModelsForSession(session, this._sessionsProvidersService).length > 0) {
+			return true;
+		}
+		if (this._modelPicker.isRestrictedMode()) {
 			return true;
 		}
 		return !getModelPickerOptionsForSession(session, this._sessionsProvidersService).showAutoModel;

--- a/src/vs/sessions/contrib/chat/browser/modelPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/modelPicker.ts
@@ -16,6 +16,7 @@ import { IWorkspaceTrustManagementService } from '../../../../platform/workspace
 import { IChatInputPickerOptions } from '../../../../workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.js';
 import { IModelPickerDelegate, ModelPickerActionItem } from '../../../../workbench/contrib/chat/browser/widget/input/modelPickerActionItem.js';
 import { ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService } from '../../../../workbench/contrib/chat/common/languageModels.js';
+import { IChatEntitlementService } from '../../../../workbench/services/chat/common/chatEntitlementService.js';
 import { Menus } from '../../../browser/menus.js';
 import { IsPhoneLayoutContext, ActiveSessionUsesCombinedConfigPickerContext } from '../../../common/contextkeys.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
@@ -109,6 +110,7 @@ export class ModelPicker extends Disposable {
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@INewChatModelPickerService private readonly _newChatModelPickerService: INewChatModelPickerService,
 		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
+		@IChatEntitlementService private readonly _chatEntitlementService: IChatEntitlementService,
 	) {
 		super();
 
@@ -162,6 +164,13 @@ export class ModelPicker extends Disposable {
 				this._initModel();
 			}
 		});
+
+		// Re-evaluate when entitlement / sentiment / anonymous access change: when
+		// Chat needs sign-in the shared widget renders a Sign In state, so the
+		// picker stays visible to surface it (e.g. after the user signs out/in).
+		this._register(this._chatEntitlementService.onDidChangeEntitlement(() => this._initModel()));
+		this._register(this._chatEntitlementService.onDidChangeSentiment(() => this._initModel()));
+		this._register(this._chatEntitlementService.onDidChangeAnonymous(() => this._initModel()));
 
 		// When the active session changes, re-init (may switch provider or
 		// session type). _initModel() calls _delegate.setModel() which already
@@ -279,15 +288,15 @@ export class ModelPicker extends Disposable {
 	 * Whether the model picker should be shown for the given session. Visible
 	 * when the session has models, when its Auto model is unavailable (so the
 	 * widget can render the "No models available" empty state), or when the
-	 * workspace is untrusted (so the widget can render its Restricted Mode state
-	 * with a Trust action). Otherwise hidden, matching the historical behavior
-	 * for providers that offer no models.
+	 * workspace is untrusted / Chat still needs sign-in (so the widget can render
+	 * its Restricted Mode or Sign In state). Otherwise hidden, matching the
+	 * historical behavior for providers that offer no models.
 	 */
 	private _shouldShowPicker(session: ISession | undefined): boolean {
 		if (getModelsForSession(session, this._sessionsProvidersService).length > 0) {
 			return true;
 		}
-		if (this._modelPicker.isRestrictedMode()) {
+		if (this._modelPicker.isRestrictedMode() || this._modelPicker.isSetupRequired()) {
 			return true;
 		}
 		return !getModelPickerOptionsForSession(session, this._sessionsProvidersService).showAutoModel;

--- a/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
@@ -98,6 +98,7 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 		this.registerGrowthSession(chatEntitlementService);
 		this.registerActions(context, requests, controller);
 		this.registerSignInTitleBarEntry(actionViewItemService);
+		this.registerActivatingContext();
 		this.registerUrlLinkHandler();
 		this.checkExtensionInstallation(context);
 	}
@@ -371,6 +372,7 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 							ChatContextKeys.Setup.hidden.negate(),
 							ChatContextKeys.Setup.disabledInWorkspace.negate(),
 							ChatContextKeys.Setup.untrusted.negate(), // sign-in is not the blocker in an untrusted workspace — trust is
+							ChatContextKeys.Setup.activating.negate(), // wait until the extension is up before claiming "signed out"
 							ChatContextKeys.Setup.completed.negate(),
 							ChatContextKeys.Entitlement.signedOut
 						)
@@ -404,6 +406,7 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 							IsWebContext.negate(),
 							ChatContextKeys.Entitlement.signedOut,
 							ChatContextKeys.Setup.untrusted.negate(), // sign-in is not the blocker in an untrusted workspace — trust is
+							ChatContextKeys.Setup.activating.negate(), // wait until the extension is up before claiming "signed out"
 							ChatEntitlementContextKeys.hasByokModels.negate(),
 							ChatContextKeys.Setup.hidden.negate(),
 							ChatContextKeys.Setup.disabledInWorkspace.negate(),
@@ -656,6 +659,35 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 			SIGN_IN_TITLE_BAR_ACTION_ID,
 			(action, options) => new SignInTitleBarEntry(action, options)
 		));
+	}
+
+	/**
+	 * Tracks whether the default chat extension is still activating, so sign-in
+	 * affordances can be suppressed until the entitlement can actually be resolved
+	 * (it reads as "signed out" until the extension is up). This relies only on the
+	 * extension lifecycle and never touches the user's authentication session.
+	 *
+	 * Important: once activation completes (`activationTimes` set) — or fails
+	 * (`runtimeErrors`) — this returns `false`, so a signed-out user with an
+	 * activated extension still sees the Sign In button.
+	 */
+	private registerActivatingContext(): void {
+		const activatingContextKey = ChatContextKeys.Setup.activating.bindTo(this.contextKeyService);
+		const update = () => activatingContextKey.set(this.isChatExtensionActivating());
+		this._register(this.extensionService.onDidChangeExtensionsStatus(() => update()));
+		this._register(this.extensionService.onDidChangeExtensions(() => update()));
+		update();
+	}
+
+	private isChatExtensionActivating(): boolean {
+		const status = this.extensionService.getExtensionsStatus();
+		for (const id of Object.keys(status)) {
+			if (ExtensionIdentifier.equals(id, defaultChat.chatExtensionId)) {
+				// Registered (enabled) but activation has neither completed nor failed.
+				return status[id].activationTimes === undefined && status[id].runtimeErrors.length === 0;
+			}
+		}
+		return false;
 	}
 
 	private registerUrlLinkHandler(): void {

--- a/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
@@ -370,6 +370,7 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 						when: ContextKeyExpr.and(
 							ChatContextKeys.Setup.hidden.negate(),
 							ChatContextKeys.Setup.disabledInWorkspace.negate(),
+							ChatContextKeys.Setup.untrusted.negate(), // sign-in is not the blocker in an untrusted workspace — trust is
 							ChatContextKeys.Setup.completed.negate(),
 							ChatContextKeys.Entitlement.signedOut
 						)
@@ -402,6 +403,7 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 						when: ContextKeyExpr.and(
 							IsWebContext.negate(),
 							ChatContextKeys.Entitlement.signedOut,
+							ChatContextKeys.Setup.untrusted.negate(), // sign-in is not the blocker in an untrusted workspace — trust is
 							ChatEntitlementContextKeys.hasByokModels.negate(),
 							ChatContextKeys.Setup.hidden.negate(),
 							ChatContextKeys.Setup.disabledInWorkspace.negate(),

--- a/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
@@ -42,6 +42,7 @@ import { ChatEntitlement, ChatEntitlementContext, ChatEntitlementContextKeys, Ch
 import { EnablementState, IWorkbenchExtensionEnablementService } from '../../../../services/extensionManagement/common/extensionManagement.js';
 import { ExtensionUrlHandlerOverrideRegistry, IExtensionUrlHandlerOverride } from '../../../../services/extensions/browser/extensionUrlHandler.js';
 import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
+import { CONTEXT_DEFAULT_ACCOUNT_STATE, DefaultAccountStatus } from '../../../../services/accounts/browser/defaultAccount.js';
 import { IHostService } from '../../../../services/host/browser/host.js';
 import { IWorkbenchLayoutService, Parts } from '../../../../services/layout/browser/layoutService.js';
 import { InEditorZenModeContext } from '../../../../common/contextkeys.js';
@@ -98,7 +99,6 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 		this.registerGrowthSession(chatEntitlementService);
 		this.registerActions(context, requests, controller);
 		this.registerSignInTitleBarEntry(actionViewItemService);
-		this.registerActivatingContext();
 		this.registerUrlLinkHandler();
 		this.checkExtensionInstallation(context);
 	}
@@ -371,8 +371,7 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 						when: ContextKeyExpr.and(
 							ChatContextKeys.Setup.hidden.negate(),
 							ChatContextKeys.Setup.disabledInWorkspace.negate(),
-							ChatContextKeys.Setup.untrusted.negate(), // sign-in is not the blocker in an untrusted workspace — trust is
-							ChatContextKeys.Setup.activating.negate(), // wait until the extension is up before claiming "signed out"
+							CONTEXT_DEFAULT_ACCOUNT_STATE.isEqualTo(DefaultAccountStatus.Unavailable), // only when actually signed out (resolves even in untrusted workspaces, no auth prompt)
 							ChatContextKeys.Setup.completed.negate(),
 							ChatContextKeys.Entitlement.signedOut
 						)
@@ -405,8 +404,7 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 						when: ContextKeyExpr.and(
 							IsWebContext.negate(),
 							ChatContextKeys.Entitlement.signedOut,
-							ChatContextKeys.Setup.untrusted.negate(), // sign-in is not the blocker in an untrusted workspace — trust is
-							ChatContextKeys.Setup.activating.negate(), // wait until the extension is up before claiming "signed out"
+							CONTEXT_DEFAULT_ACCOUNT_STATE.isEqualTo(DefaultAccountStatus.Unavailable), // only when actually signed out (resolves even in untrusted workspaces, no auth prompt)
 							ChatEntitlementContextKeys.hasByokModels.negate(),
 							ChatContextKeys.Setup.hidden.negate(),
 							ChatContextKeys.Setup.disabledInWorkspace.negate(),
@@ -659,35 +657,6 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 			SIGN_IN_TITLE_BAR_ACTION_ID,
 			(action, options) => new SignInTitleBarEntry(action, options)
 		));
-	}
-
-	/**
-	 * Tracks whether the default chat extension is still activating, so sign-in
-	 * affordances can be suppressed until the entitlement can actually be resolved
-	 * (it reads as "signed out" until the extension is up). This relies only on the
-	 * extension lifecycle and never touches the user's authentication session.
-	 *
-	 * Important: once activation completes (`activationTimes` set) — or fails
-	 * (`runtimeErrors`) — this returns `false`, so a signed-out user with an
-	 * activated extension still sees the Sign In button.
-	 */
-	private registerActivatingContext(): void {
-		const activatingContextKey = ChatContextKeys.Setup.activating.bindTo(this.contextKeyService);
-		const update = () => activatingContextKey.set(this.isChatExtensionActivating());
-		this._register(this.extensionService.onDidChangeExtensionsStatus(() => update()));
-		this._register(this.extensionService.onDidChangeExtensions(() => update()));
-		update();
-	}
-
-	private isChatExtensionActivating(): boolean {
-		const status = this.extensionService.getExtensionsStatus();
-		for (const id of Object.keys(status)) {
-			if (ExtensionIdentifier.equals(id, defaultChat.chatExtensionId)) {
-				// Registered (enabled) but activation has neither completed nor failed.
-				return status[id].activationTimes === undefined && status[id].runtimeErrors.length === 0;
-			}
-		}
-		return false;
 	}
 
 	private registerUrlLinkHandler(): void {

--- a/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
@@ -371,7 +371,7 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 						when: ContextKeyExpr.and(
 							ChatContextKeys.Setup.hidden.negate(),
 							ChatContextKeys.Setup.disabledInWorkspace.negate(),
-							CONTEXT_DEFAULT_ACCOUNT_STATE.isEqualTo(DefaultAccountStatus.Unavailable), // only when actually signed out (resolves even in untrusted workspaces, no auth prompt)
+							CONTEXT_DEFAULT_ACCOUNT_STATE.notEqualsTo(DefaultAccountStatus.Available), // hide only when signed in (a default GitHub account is present); still shown while signed out or before the account state resolves, incl. untrusted workspaces — no auth prompt
 							ChatContextKeys.Setup.completed.negate(),
 							ChatContextKeys.Entitlement.signedOut
 						)
@@ -404,7 +404,7 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 						when: ContextKeyExpr.and(
 							IsWebContext.negate(),
 							ChatContextKeys.Entitlement.signedOut,
-							CONTEXT_DEFAULT_ACCOUNT_STATE.isEqualTo(DefaultAccountStatus.Unavailable), // only when actually signed out (resolves even in untrusted workspaces, no auth prompt)
+							CONTEXT_DEFAULT_ACCOUNT_STATE.notEqualsTo(DefaultAccountStatus.Available), // hide only when signed in (a default GitHub account is present); still shown while signed out or before the account state resolves, incl. untrusted workspaces — no auth prompt
 							ChatEntitlementContextKeys.hasByokModels.negate(),
 							ChatContextKeys.Setup.hidden.negate(),
 							ChatContextKeys.Setup.disabledInWorkspace.negate(),

--- a/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupProviders.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupProviders.ts
@@ -24,7 +24,7 @@ import { IWorkbenchEnvironmentService } from '../../../../services/environment/c
 import { nullExtensionDescription } from '../../../../services/extensions/common/extensions.js';
 import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolResult, ToolDataSource, ToolProgress } from '../../common/tools/languageModelToolsService.js';
 import { IChatAgentImplementation, IChatAgentRequest, IChatAgentResult, IChatAgentService } from '../../common/participants/chatAgents.js';
-import { ChatEntitlement, ChatEntitlementContext, IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
+import { ChatEntitlementContext, chatRequiresSetup, IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
 import { ChatModel, ChatRequestModel, IChatRequestModel, IChatRequestVariableData } from '../../common/model/chatModel.js';
 import { ChatMode } from '../../common/chatModes.js';
 import { ChatRequestAgentPart, ChatRequestToolPart } from '../../common/requestParser/chatParserTypes.js';
@@ -256,18 +256,14 @@ export class SetupAgent extends Disposable implements IChatAgentImplementation {
 	}
 
 	private async doInvoke(request: IChatAgentRequest, progress: (part: IChatProgress) => void, chatService: IChatService, languageModelsService: ILanguageModelsService, chatWidgetService: IChatWidgetService, chatAgentService: IChatAgentService, languageModelToolsService: ILanguageModelToolsService, defaultAccountService: IDefaultAccountService): Promise<IChatAgentResult> {
-		const hasByokModels = this.chatEntitlementService.hasByokModels;
-		if (
-			(!this.context.state.completed && !hasByokModels) ||				// Setup not completed (unless BYOK models are available)
-			this.context.state.disabled ||										// Extension disabled: run setup to enable
-			this.context.state.untrusted ||										// Workspace untrusted: run setup to ask for trust
-			this.context.state.entitlement === ChatEntitlement.Available ||		// Entitlement available: run setup to sign up
-			(
-				this.context.state.entitlement === ChatEntitlement.Unknown &&	// Entitlement unknown: run setup to sign in / sign up
-				!this.chatEntitlementService.anonymous &&						// unless anonymous access is enabled
-				!hasByokModels													// unless BYOK models are available
-			)
-		) {
+		if (chatRequiresSetup({
+			completed: !!this.context.state.completed,
+			disabled: !!this.context.state.disabled,
+			untrusted: !!this.context.state.untrusted,
+			entitlement: this.context.state.entitlement,
+			anonymous: this.chatEntitlementService.anonymous,
+			hasByokModels: this.chatEntitlementService.hasByokModels,
+		})) {
 			return this.doInvokeWithSetup(request, progress, chatService, languageModelsService, chatWidgetService, chatAgentService, languageModelToolsService, defaultAccountService);
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupRunner.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupRunner.ts
@@ -24,7 +24,7 @@ import { ILayoutService } from '../../../../../platform/layout/browser/layoutSer
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import product from '../../../../../platform/product/common/product.js';
 import { ITelemetryService, TelemetryLevel } from '../../../../../platform/telemetry/common/telemetry.js';
-import { IWorkspaceTrustRequestService } from '../../../../../platform/workspace/common/workspaceTrust.js';
+import { IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from '../../../../../platform/workspace/common/workspaceTrust.js';
 import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
 import { ChatEntitlement, ChatEntitlementContext, ChatEntitlementService, IChatEntitlementService, isProUser } from '../../../../services/chat/common/chatEntitlementService.js';
 import { IChatWidgetService } from '../chat.js';
@@ -32,8 +32,12 @@ import { ChatSetupController } from './chatSetupController.js';
 import { IChatSetupResult, ChatSetupAnonymous, InstallChatEvent, InstallChatClassification, ChatSetupStrategy, ChatSetupResultValue } from './chatSetup.js';
 import { GitHubPaths, IDefaultAccountService } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IHostService } from '../../../../services/host/browser/host.js';
+import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
+import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
+import { raceTimeout } from '../../../../../base/common/async.js';
 
 const defaultChat = {
+	chatExtensionId: product.defaultChatAgent?.chatExtensionId ?? '',
 	publicCodeMatchesUrl: product.defaultChatAgent?.publicCodeMatchesUrl ?? '',
 	provider: product.defaultChatAgent?.provider ?? { default: { id: '', name: '' }, enterprise: { id: '', name: '' }, apple: { id: '', name: '' }, google: { id: '', name: '' } },
 	chatRefreshTokenCommand: product.defaultChatAgent?.chatRefreshTokenCommand ?? '',
@@ -48,7 +52,7 @@ export class ChatSetup {
 		let instance = ChatSetup.instance;
 		if (!instance) {
 			instance = ChatSetup.instance = instantiationService.invokeFunction(accessor => {
-				return new ChatSetup(context, controller, accessor.get(ITelemetryService), accessor.get(IWorkbenchLayoutService), accessor.get(IKeybindingService), accessor.get(IChatEntitlementService) as ChatEntitlementService, accessor.get(ILogService), accessor.get(IChatWidgetService), accessor.get(IWorkspaceTrustRequestService), accessor.get(IMarkdownRendererService), accessor.get(IDefaultAccountService), accessor.get(IHostService));
+				return new ChatSetup(context, controller, accessor.get(ITelemetryService), accessor.get(IWorkbenchLayoutService), accessor.get(IKeybindingService), accessor.get(IChatEntitlementService) as ChatEntitlementService, accessor.get(ILogService), accessor.get(IChatWidgetService), accessor.get(IWorkspaceTrustRequestService), accessor.get(IMarkdownRendererService), accessor.get(IDefaultAccountService), accessor.get(IHostService), accessor.get(IExtensionService), accessor.get(IWorkspaceTrustManagementService));
 			});
 		}
 
@@ -72,6 +76,8 @@ export class ChatSetup {
 		@IMarkdownRendererService private readonly markdownRendererService: IMarkdownRendererService,
 		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
 		@IHostService private readonly hostService: IHostService,
+		@IExtensionService private readonly extensionService: IExtensionService,
+		@IWorkspaceTrustManagementService private readonly workspaceTrustManagementService: IWorkspaceTrustManagementService,
 	) { }
 
 	skipDialog(): void {
@@ -98,6 +104,7 @@ export class ChatSetup {
 		const dialogSkipped = this.skipDialogOnce;
 		this.skipDialogOnce = false;
 
+		const wasTrusted = this.workspaceTrustManagementService.isWorkspaceTrusted();
 		const trusted = await this.workspaceTrustRequestService.requestWorkspaceTrust({
 			message: localize('chatWorkspaceTrust', "AI features are currently only supported in trusted workspaces.")
 		});
@@ -106,6 +113,15 @@ export class ChatSetup {
 			this.telemetryService.publicLog2<InstallChatEvent, InstallChatClassification>('commandCenter.chatInstall', { installResult: 'failedNotTrusted', installDuration: 0, signUpErrorCode: undefined, provider: undefined });
 
 			return { dialogSkipped, success: undefined /* canceled */ };
+		}
+
+		if (!wasTrusted) {
+			// Trust was just granted: the chat extension is (re)activating, and the
+			// entitlement only resolves once it is up. Wait for activation so the
+			// dialog decision below isn't made from a stale "signed out" entitlement
+			// (which would briefly show the sign-in dialog to an already-signed-in
+			// user). Bounded, so a genuinely signed-out / slow case still proceeds.
+			await this.whenChatExtensionActivated();
 		}
 
 		let setupStrategy: ChatSetupStrategy;
@@ -166,6 +182,46 @@ export class ChatSetup {
 		}
 
 		return { success, dialogSkipped };
+	}
+
+	/**
+	 * Whether the default chat extension has finished activating. `activationTimes`
+	 * is only set once activation completes, so `undefined` means "not yet active".
+	 */
+	private isChatExtensionActivated(): boolean {
+		const status = this.extensionService.getExtensionsStatus();
+		for (const id of Object.keys(status)) {
+			if (ExtensionIdentifier.equals(id, defaultChat.chatExtensionId)) {
+				return status[id].activationTimes !== undefined;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Resolves once the default chat extension has finished activating (bounded by
+	 * a timeout). Detection relies only on the extension lifecycle, so it never
+	 * touches the user's authentication session.
+	 */
+	private async whenChatExtensionActivated(timeoutMs = 10000): Promise<void> {
+		if (!defaultChat.chatExtensionId || this.isChatExtensionActivated()) {
+			return;
+		}
+
+		const store = new DisposableStore();
+		try {
+			await raceTimeout(new Promise<void>(resolve => {
+				const check = () => {
+					if (this.isChatExtensionActivated()) {
+						resolve();
+					}
+				};
+				store.add(this.extensionService.onDidChangeExtensionsStatus(check));
+				this.extensionService.whenInstalledExtensionsRegistered().then(check);
+			}), timeoutMs);
+		} finally {
+			store.dispose();
+		}
 	}
 
 	private async showDialog(options?: { forceSignInDialog?: boolean; forceAnonymous?: ChatSetupAnonymous; dialogIcon?: ThemeIcon; dialogTitle?: string; disableCloseButton?: boolean; onSignInStarted?: () => void }): Promise<ChatSetupStrategy> {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -36,6 +36,7 @@ import { IModelControlEntry, ILanguageModelChatMetadataAndIdentifier, ILanguageM
 import { ChatEntitlement, IChatEntitlementService, isProUser } from '../../../../../services/chat/common/chatEntitlementService.js';
 import * as semver from '../../../../../../base/common/semver/semver.js';
 import { IModelConfigurationAccess, IModelPickerDelegate } from './modelPickerActionItem.js';
+import { isRestrictedModeState } from './chatModelSelectionLogic.js';
 import { IUriIdentityService } from '../../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { GitHubPaths, IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IUpdateService, StateType } from '../../../../../../platform/update/common/update.js';
@@ -1101,17 +1102,17 @@ export class ModelPickerWidget extends Disposable {
 	}
 
 	/**
-	 * Whether the picker is empty specifically because the workspace is untrusted
-	 * (Restricted Mode disables the chat model providers). Uses the *live* model
-	 * registry, not the delegate's list, which can include machine-cached models
-	 * from a previous trusted session. `isWorkspaceTrusted()` is `true` when trust
-	 * is disabled entirely, and is only authoritative once
-	 * `workspaceTrustInitialized` resolves.
+	 * Whether the picker has no usable model specifically because the workspace
+	 * is untrusted (Restricted Mode disables the chat model providers). See
+	 * {@link isRestrictedModeState} for how "usable" is determined.
 	 */
 	isRestrictedMode(): boolean {
-		return this._workspaceTrustInitialized
-			&& !this._workspaceTrustManagementService.isWorkspaceTrusted()
-			&& this._languageModelsService.getLanguageModelIds().length === 0;
+		return isRestrictedModeState(
+			this._workspaceTrustInitialized,
+			this._workspaceTrustManagementService.isWorkspaceTrusted(),
+			this._delegate.getModels(),
+			this._languageModelsService.getLanguageModelIds(),
+		);
 	}
 
 	private _clearActivating(): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -1185,7 +1185,15 @@ export class ModelPickerWidget extends Disposable {
 		return chatRequiresSetup({
 			completed: !!sentiment.completed,
 			disabled: !!sentiment.disabled,
-			untrusted: !!sentiment.untrusted,
+			// Workspace trust is handled authoritatively and synchronously via the
+			// Restricted branch of getModelPickerUnavailableReason (which checks
+			// isWorkspaceTrusted() and takes precedence). The picker only consults
+			// setup-required once the workspace is already trusted, so `untrusted`
+			// is definitionally false here. We must NOT read it from `sentiment`,
+			// which lags after a Trust grant (it stays true until the chat
+			// extension reactivates) — otherwise a just-trusted, already signed-in
+			// user would briefly see the "Sign in" state instead of "Activating...".
+			untrusted: false,
 			entitlement: this._entitlementService.entitlement,
 			anonymous: this._entitlementService.anonymous,
 			hasByokModels: this._entitlementService.hasByokModels,

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -79,6 +79,13 @@ const ModelPickerSection = {
 } as const;
 
 /**
+ * Id of the synthetic "Trust Workspace..." entry shown in Restricted Mode. It is
+ * a command (not a selectable model), so the accessibility provider gives it a
+ * plain `menuitem` role instead of `menuitemradio`.
+ */
+const RESTRICTED_MODE_TRUST_ACTION_ID = 'restrictedModeTrust';
+
+/**
  * Returns a human-readable display name for a model vendor.
  * Looks up the registered provider descriptor's displayName first,
  * then falls back to capitalizing the raw vendor id.
@@ -496,7 +503,7 @@ export function buildModelPickerItems(
 		});
 		items.push({
 			item: {
-				id: 'restrictedModeTrust',
+				id: RESTRICTED_MODE_TRUST_ACTION_ID,
 				enabled: !!onRequestTrust,
 				checked: false,
 				class: undefined,
@@ -893,14 +900,21 @@ export function getModelPickerAccessibilityProvider() {
 			if (element.isSectionToggle) {
 				return undefined;
 			}
-			return element.kind === ActionListItemKind.Action ? !!element?.item?.checked : undefined;
+			// The Restricted Mode Trust action is a command, not a selectable
+			// model, so it exposes no checked state.
+			if (element.kind === ActionListItemKind.Action && element.item?.id !== RESTRICTED_MODE_TRUST_ACTION_ID) {
+				return !!element?.item?.checked;
+			}
+			return undefined;
 		},
 		getRole: (element: IActionListItem<IActionWidgetDropdownAction>) => {
 			if (element.isSectionToggle) {
 				return 'menuitem';
 			}
 			switch (element.kind) {
-				case ActionListItemKind.Action: return 'menuitemradio';
+				// The Restricted Mode Trust action is a command, not a model
+				// choice, so announce it as a plain menuitem rather than a radio.
+				case ActionListItemKind.Action: return element.item?.id === RESTRICTED_MODE_TRUST_ACTION_ID ? 'menuitem' : 'menuitemradio';
 				case ActionListItemKind.Separator: return 'separator';
 				default: return 'separator';
 			}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -16,7 +16,8 @@ import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { KeyCode } from '../../../../../../base/common/keyCodes.js';
-import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
+import { disposableTimeout } from '../../../../../../base/common/async.js';
 import { autorun, IObservable } from '../../../../../../base/common/observable.js';
 import { formatTokenCount } from '../../../../../../base/common/numbers.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
@@ -452,7 +453,7 @@ function createManageModelsAction(commandService: ICommandService): IActionWidge
  *      the `customoai` vendor) renders as distinct sections.
  * 4. Optional "Manage Models..." action shown in Other Models after a separator
  *
- * When `restrictedMode` is set (untrusted workspace), a disabled "Models
+ * When `restrictedMode` is set (untrusted workspace), an explanatory "Models
  * Unavailable in Restricted Mode" header and a "Trust Workspace..." action
  * (invoking `onRequestTrust`) replace all of the above.
  */
@@ -489,25 +490,13 @@ export function buildModelPickerItems(
 		// before the empty-list branch since cached entries can make `models`
 		// non-empty.
 		items.push({
-			item: {
-				id: 'restrictedModeInfo',
-				enabled: false,
-				checked: false,
-				class: undefined,
-				tooltip: localize('chat.modelPicker.restrictedMode.tooltip', "Models are unavailable in Restricted Mode."),
-				label: localize('chat.modelPicker.restrictedMode', "Models Unavailable in Restricted Mode"),
-				run: () => { }
-			},
-			kind: ActionListItemKind.Action,
+			kind: ActionListItemKind.Header,
 			label: localize('chat.modelPicker.restrictedMode', "Models Unavailable in Restricted Mode"),
-			group: { title: '', icon: ThemeIcon.fromId(Codicon.workspaceUntrusted.id) },
-			disabled: true,
-			hideIcon: false,
 		});
 		items.push({
 			item: {
 				id: 'restrictedModeTrust',
-				enabled: true,
+				enabled: !!onRequestTrust,
 				checked: false,
 				class: undefined,
 				tooltip: localize('chat.modelPicker.restrictedMode.trustTooltip', "Trust the workspace to enable AI models."),
@@ -517,6 +506,7 @@ export function buildModelPickerItems(
 			kind: ActionListItemKind.Action,
 			label: localize('chat.modelPicker.restrictedMode.trust', "Trust Workspace..."),
 			group: { title: '', icon: ThemeIcon.fromId(Codicon.workspaceTrusted.id) },
+			disabled: !onRequestTrust,
 			hideIcon: false,
 		});
 		return items;
@@ -998,6 +988,8 @@ export class ModelPickerWidget extends Disposable {
 	private _badge: ModelPickerBadge | undefined;
 	private _compact: IObservable<boolean> | undefined;
 	private _workspaceTrustInitialized = false;
+	private _activatingAfterTrust = false;
+	private readonly _activatingTimer = this._register(new MutableDisposable());
 
 	private _domNode: HTMLElement | undefined;
 	private _badgeIcon: HTMLElement | undefined;
@@ -1033,11 +1025,26 @@ export class ModelPickerWidget extends Disposable {
 	) {
 		super();
 		this._register(this._languageModelsService.onDidChangeLanguageModels(() => {
+			if (this._activatingAfterTrust && this._delegate.getModels().length > 0) {
+				this._clearActivating();
+			}
 			this._renderLabel();
 		}));
 
-		// Reflect Restricted Mode immediately when trust changes.
-		this._register(this._workspaceTrustManagementService.onDidChangeTrust(() => {
+		// Reflect Restricted Mode immediately when trust changes. When trust is
+		// granted but no models are available yet, briefly show an "Activating..."
+		// state while the chat extension comes up and loads them, rather than a
+		// misleading "Auto" fallback.
+		this._register(this._workspaceTrustManagementService.onDidChangeTrust(trusted => {
+			if (trusted && (this._delegate.showAutoModel?.() ?? false) && this._delegate.getModels().length === 0) {
+				this._activatingAfterTrust = true;
+				this._activatingTimer.value = disposableTimeout(() => {
+					this._activatingAfterTrust = false;
+					this._renderLabel();
+				}, 15000);
+			} else {
+				this._clearActivating();
+			}
 			this._renderLabel();
 		}));
 
@@ -1105,6 +1112,11 @@ export class ModelPickerWidget extends Disposable {
 		return this._workspaceTrustInitialized
 			&& !this._workspaceTrustManagementService.isWorkspaceTrusted()
 			&& this._languageModelsService.getLanguageModelIds().length === 0;
+	}
+
+	private _clearActivating(): void {
+		this._activatingAfterTrust = false;
+		this._activatingTimer.clear();
 	}
 
 	/**
@@ -1351,12 +1363,17 @@ export class ModelPickerWidget extends Disposable {
 		// Mode explanation and the Trust Workspace action.
 		const restrictedMode = this.isRestrictedMode();
 
+		// Just after Trust, models load asynchronously while the chat extension
+		// activates. Show a transient "Activating..." state — only when there is
+		// nothing else to display — instead of a misleading "Auto" fallback.
+		const activating = !restrictedMode && this._activatingAfterTrust && this._delegate.getModels().length === 0;
+
 		// Generic empty state (e.g. an agent-host session with no Auto fallback);
-		// not evaluated while restricted, which takes precedence.
-		const genericNoModels = !restrictedMode
+		// not evaluated while restricted/activating, which take precedence.
+		const genericNoModels = !restrictedMode && !activating
 			&& !(this._delegate.showAutoModel?.() ?? false)
 			&& this._delegate.getModels().length === 0;
-		const noModelsAvailable = restrictedMode || genericNoModels;
+		const noModelsAvailable = restrictedMode || activating || genericNoModels;
 
 		// --- Name section ---
 		const nameChildren: (HTMLElement | string)[] = [];
@@ -1365,9 +1382,11 @@ export class ModelPickerWidget extends Disposable {
 		}
 		const modelLabel = restrictedMode
 			? localize('chat.modelPicker.label', "Pick Model")
-			: genericNoModels
-				? localize('chat.modelPicker.noModels', "No models available")
-				: (name ?? localize('chat.modelPicker.auto', "Auto"));
+			: activating
+				? localize('chat.modelPicker.activating', "Activating...")
+				: genericNoModels
+					? localize('chat.modelPicker.noModels', "No models available")
+					: (name ?? localize('chat.modelPicker.auto', "Auto"));
 		// In PRU mode, append the config description (e.g. thinking effort) to the button label
 		const isUBB = !!this._entitlementService.quotas.usageBasedBilling;
 		const configDescription = !isUBB && this._selectedModel && !noModelsAvailable

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -38,6 +38,7 @@ import { IModelConfigurationAccess, IModelPickerDelegate } from './modelPickerAc
 import { IUriIdentityService } from '../../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { GitHubPaths, IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IUpdateService, StateType } from '../../../../../../platform/update/common/update.js';
+import { IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
 
 function isVersionAtLeast(current: string, required: string): boolean {
 	const currentSemver = semver.coerce(current);
@@ -450,6 +451,10 @@ function createManageModelsAction(commandService: ICommandService): IActionWidge
  *      Compatible" group and an "AWS Bedrock" group both registered to
  *      the `customoai` vendor) renders as distinct sections.
  * 4. Optional "Manage Models..." action shown in Other Models after a separator
+ *
+ * When `restrictedMode` is set (untrusted workspace), a disabled "Models
+ * Unavailable in Restricted Mode" header and a "Trust Workspace..." action
+ * (invoking `onRequestTrust`) replace all of the above.
  */
 export function buildModelPickerItems(
 	models: ILanguageModelChatMetadataAndIdentifier[],
@@ -473,8 +478,49 @@ export function buildModelPickerItems(
 	isUBB?: boolean,
 	showAutoModel: boolean = false,
 	onConfigure?: (model: ILanguageModelChatMetadataAndIdentifier, group: string) => void,
+	restrictedMode: boolean = false,
+	onRequestTrust?: () => void,
 ): IActionListItem<IActionWidgetDropdownAction>[] {
 	const items: IActionListItem<IActionWidgetDropdownAction>[] = [];
+	if (restrictedMode) {
+		// Untrusted workspace: providers are disabled, so any `models` here are
+		// stale machine-cached entries. Surface a Trust action (mirroring the
+		// send-message trust prompt) instead of a misleading lone "Auto". Checked
+		// before the empty-list branch since cached entries can make `models`
+		// non-empty.
+		items.push({
+			item: {
+				id: 'restrictedModeInfo',
+				enabled: false,
+				checked: false,
+				class: undefined,
+				tooltip: localize('chat.modelPicker.restrictedMode.tooltip', "Models are unavailable in Restricted Mode."),
+				label: localize('chat.modelPicker.restrictedMode', "Models Unavailable in Restricted Mode"),
+				run: () => { }
+			},
+			kind: ActionListItemKind.Action,
+			label: localize('chat.modelPicker.restrictedMode', "Models Unavailable in Restricted Mode"),
+			group: { title: '', icon: ThemeIcon.fromId(Codicon.workspaceUntrusted.id) },
+			disabled: true,
+			hideIcon: false,
+		});
+		items.push({
+			item: {
+				id: 'restrictedModeTrust',
+				enabled: true,
+				checked: false,
+				class: undefined,
+				tooltip: localize('chat.modelPicker.restrictedMode.trustTooltip', "Trust the workspace to enable AI models."),
+				label: localize('chat.modelPicker.restrictedMode.trust', "Trust Workspace..."),
+				run: () => onRequestTrust?.()
+			},
+			kind: ActionListItemKind.Action,
+			label: localize('chat.modelPicker.restrictedMode.trust', "Trust Workspace..."),
+			group: { title: '', icon: ThemeIcon.fromId(Codicon.workspaceTrusted.id) },
+			hideIcon: false,
+		});
+		return items;
+	}
 	if (models.length === 0) {
 		if (!showAutoModel) {
 			// Auto is not available for this session type (e.g. the Claude agent
@@ -951,6 +997,7 @@ export class ModelPickerWidget extends Disposable {
 	private _selectedModel: ILanguageModelChatMetadataAndIdentifier | undefined;
 	private _badge: ModelPickerBadge | undefined;
 	private _compact: IObservable<boolean> | undefined;
+	private _workspaceTrustInitialized = false;
 
 	private _domNode: HTMLElement | undefined;
 	private _badgeIcon: HTMLElement | undefined;
@@ -981,11 +1028,28 @@ export class ModelPickerWidget extends Disposable {
 		@IUpdateService private readonly _updateService: IUpdateService,
 		@IUriIdentityService private readonly _uriIdentityService: IUriIdentityService,
 		@IDefaultAccountService private readonly _defaultAccountService: IDefaultAccountService,
+		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
+		@IWorkspaceTrustRequestService private readonly _workspaceTrustRequestService: IWorkspaceTrustRequestService,
 	) {
 		super();
 		this._register(this._languageModelsService.onDidChangeLanguageModels(() => {
 			this._renderLabel();
 		}));
+
+		// Reflect Restricted Mode immediately when trust changes.
+		this._register(this._workspaceTrustManagementService.onDidChangeTrust(() => {
+			this._renderLabel();
+		}));
+
+		// Trust reads as untrusted until initialization resolves; gate on it so a
+		// trusted workspace doesn't briefly render as restricted at startup.
+		this._workspaceTrustManagementService.workspaceTrustInitialized.then(() => {
+			if (this._store.isDisposed) {
+				return;
+			}
+			this._workspaceTrustInitialized = true;
+			this._renderLabel();
+		});
 
 		this._register(this._entitlementService.onDidChangeUsageBasedBilling(() => {
 			this._renderLabel();
@@ -1027,6 +1091,30 @@ export class ModelPickerWidget extends Disposable {
 	setBadge(badge: ModelPickerBadge | undefined): void {
 		this._badge = badge;
 		this._updateBadge();
+	}
+
+	/**
+	 * Whether the picker is empty specifically because the workspace is untrusted
+	 * (Restricted Mode disables the chat model providers). Uses the *live* model
+	 * registry, not the delegate's list, which can include machine-cached models
+	 * from a previous trusted session. `isWorkspaceTrusted()` is `true` when trust
+	 * is disabled entirely, and is only authoritative once
+	 * `workspaceTrustInitialized` resolves.
+	 */
+	isRestrictedMode(): boolean {
+		return this._workspaceTrustInitialized
+			&& !this._workspaceTrustManagementService.isWorkspaceTrusted()
+			&& this._languageModelsService.getLanguageModelIds().length === 0;
+	}
+
+	/**
+	 * Prompts the user to trust the workspace. On grant, providers register their
+	 * models and `onDidChangeLanguageModels` refreshes the picker.
+	 */
+	private async _requestWorkspaceTrust(): Promise<void> {
+		await this._workspaceTrustRequestService.requestWorkspaceTrust({
+			message: localize('chat.modelPicker.trustMessage', "Trusting this workspace enables AI models and chat features.")
+		});
 	}
 
 	render(container: HTMLElement): void {
@@ -1165,6 +1253,8 @@ export class ModelPickerWidget extends Disposable {
 			isUBB,
 			this._delegate.showAutoModel?.() ?? false,
 			onConfigure,
+			this.isRestrictedMode(),
+			() => { void this._requestWorkspaceTrust(); },
 		);
 
 		// Collect all hover disposables so they are properly cleaned up when the
@@ -1256,21 +1346,28 @@ export class ModelPickerWidget extends Disposable {
 
 		const { name, statusIcon } = this._selectedModel?.metadata || {};
 
-		// When Auto is unavailable for this session and there are no models to
-		// pick, surface the empty state on the button itself — overriding any
-		// stale/carried-over selection (e.g. an "Auto" model from another
-		// session type) so the label matches the dropdown's "No models
-		// available" entry.
-		const noModelsAvailable = !(this._delegate.showAutoModel?.() ?? false) && this._delegate.getModels().length === 0;
+		// Untrusted workspace: present a normal "Pick Model" placeholder (no badge)
+		// rather than a dead-end label; the hover and dropdown carry the Restricted
+		// Mode explanation and the Trust Workspace action.
+		const restrictedMode = this.isRestrictedMode();
+
+		// Generic empty state (e.g. an agent-host session with no Auto fallback);
+		// not evaluated while restricted, which takes precedence.
+		const genericNoModels = !restrictedMode
+			&& !(this._delegate.showAutoModel?.() ?? false)
+			&& this._delegate.getModels().length === 0;
+		const noModelsAvailable = restrictedMode || genericNoModels;
 
 		// --- Name section ---
 		const nameChildren: (HTMLElement | string)[] = [];
 		if (statusIcon && !noModelsAvailable) {
 			nameChildren.push(renderIcon(statusIcon));
 		}
-		const modelLabel = noModelsAvailable
-			? localize('chat.modelPicker.noModels', "No models available")
-			: (name ?? localize('chat.modelPicker.auto', "Auto"));
+		const modelLabel = restrictedMode
+			? localize('chat.modelPicker.label', "Pick Model")
+			: genericNoModels
+				? localize('chat.modelPicker.noModels', "No models available")
+				: (name ?? localize('chat.modelPicker.auto', "Auto"));
 		// In PRU mode, append the config description (e.g. thinking effort) to the button label
 		const isUBB = !!this._entitlementService.quotas.usageBasedBilling;
 		const configDescription = !isUBB && this._selectedModel && !noModelsAvailable
@@ -1320,7 +1417,9 @@ export class ModelPickerWidget extends Disposable {
 		}
 
 		// Aria
-		this._domNode.ariaLabel = localize('chat.modelPicker.ariaLabel', "Pick Model, {0}", fullLabel);
+		this._domNode.ariaLabel = restrictedMode
+			? localize('chat.modelPicker.ariaLabelRestricted', "Pick Model, models are unavailable in Restricted Mode")
+			: localize('chat.modelPicker.ariaLabel', "Pick Model, {0}", fullLabel);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -33,10 +33,11 @@ import { ITelemetryService } from '../../../../../../platform/telemetry/common/t
 import { TelemetryTrustedValue } from '../../../../../../platform/telemetry/common/telemetryUtils.js';
 import { MANAGE_CHAT_COMMAND_ID } from '../../../common/constants.js';
 import { IModelControlEntry, ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService, IModelsControlManifest } from '../../../common/languageModels.js';
-import { ChatEntitlement, IChatEntitlementService, isProUser } from '../../../../../services/chat/common/chatEntitlementService.js';
+import { ChatEntitlement, chatRequiresSetup, IChatEntitlementService, isProUser } from '../../../../../services/chat/common/chatEntitlementService.js';
 import * as semver from '../../../../../../base/common/semver/semver.js';
 import { IModelConfigurationAccess, IModelPickerDelegate } from './modelPickerActionItem.js';
-import { isRestrictedModeState } from './chatModelSelectionLogic.js';
+import { getModelPickerUnavailableReason, ModelPickerUnavailableReason } from './chatModelSelectionLogic.js';
+import { CHAT_SETUP_ACTION_ID } from '../../actions/chatActions.js';
 import { IUriIdentityService } from '../../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { GitHubPaths, IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IUpdateService, StateType } from '../../../../../../platform/update/common/update.js';
@@ -84,6 +85,16 @@ const ModelPickerSection = {
  * plain `menuitem` role instead of `menuitemradio`.
  */
 const RESTRICTED_MODE_TRUST_ACTION_ID = 'restrictedModeTrust';
+
+/**
+ * Id of the synthetic "Sign in to use Copilot..." entry shown when Chat still
+ * requires sign-in / setup. Like the Trust entry it is a command, so it gets a
+ * plain `menuitem` role.
+ */
+const SETUP_REQUIRED_SIGN_IN_ACTION_ID = 'setupRequiredSignIn';
+
+/** Synthetic command entries (Trust / Sign in) that are not selectable models. */
+const PICKER_COMMAND_ACTION_IDS: ReadonlySet<string> = new Set([RESTRICTED_MODE_TRUST_ACTION_ID, SETUP_REQUIRED_SIGN_IN_ACTION_ID]);
 
 /**
  * Returns a human-readable display name for a model vendor.
@@ -463,7 +474,10 @@ function createManageModelsAction(commandService: ICommandService): IActionWidge
  *
  * When `restrictedMode` is set (untrusted workspace), an explanatory "Models
  * Unavailable in Restricted Mode" header and a "Trust Workspace..." action
- * (invoking `onRequestTrust`) replace all of the above.
+ * (invoking `onRequestTrust`) replace all of the above. Likewise, when
+ * `setupRequired` is set (trusted, but Chat still needs sign-in / setup), a
+ * "Sign in to use Copilot" header and a Sign In action (invoking
+ * `onRequestSetup`) replace all of the above. `restrictedMode` takes precedence.
  */
 export function buildModelPickerItems(
 	models: ILanguageModelChatMetadataAndIdentifier[],
@@ -489,6 +503,8 @@ export function buildModelPickerItems(
 	onConfigure?: (model: ILanguageModelChatMetadataAndIdentifier, group: string) => void,
 	restrictedMode: boolean = false,
 	onRequestTrust?: () => void,
+	setupRequired: boolean = false,
+	onRequestSetup?: () => void,
 ): IActionListItem<IActionWidgetDropdownAction>[] {
 	const items: IActionListItem<IActionWidgetDropdownAction>[] = [];
 	if (restrictedMode) {
@@ -515,6 +531,34 @@ export function buildModelPickerItems(
 			label: localize('chat.modelPicker.restrictedMode.trust', "Trust Workspace..."),
 			group: { title: '', icon: ThemeIcon.fromId(Codicon.workspaceTrusted.id) },
 			disabled: !onRequestTrust,
+			hideIcon: false,
+		});
+		return items;
+	}
+	if (setupRequired) {
+		// Trusted, but Chat still needs sign-in / setup before any model is
+		// usable. Surface a Sign In action (mirroring the send-message setup
+		// prompt) instead of a misleading lone "Auto". Like restricted mode this
+		// is checked before the empty-list branch since stale machine-cached
+		// entries can make `models` non-empty.
+		items.push({
+			kind: ActionListItemKind.Header,
+			label: localize('chat.modelPicker.setupRequired', "Sign in to use Copilot"),
+		});
+		items.push({
+			item: {
+				id: SETUP_REQUIRED_SIGN_IN_ACTION_ID,
+				enabled: !!onRequestSetup,
+				checked: false,
+				class: undefined,
+				tooltip: localize('chat.modelPicker.setupRequired.signInTooltip', "Sign in to GitHub Copilot to choose a model."),
+				label: localize('chat.modelPicker.setupRequired.signIn', "Sign in to use Copilot..."),
+				run: () => onRequestSetup?.()
+			},
+			kind: ActionListItemKind.Action,
+			label: localize('chat.modelPicker.setupRequired.signIn', "Sign in to use Copilot..."),
+			group: { title: '', icon: ThemeIcon.fromId(Codicon.signIn.id) },
+			disabled: !onRequestSetup,
 			hideIcon: false,
 		});
 		return items;
@@ -900,9 +944,9 @@ export function getModelPickerAccessibilityProvider() {
 			if (element.isSectionToggle) {
 				return undefined;
 			}
-			// The Restricted Mode Trust action is a command, not a selectable
-			// model, so it exposes no checked state.
-			if (element.kind === ActionListItemKind.Action && element.item?.id !== RESTRICTED_MODE_TRUST_ACTION_ID) {
+			// The Trust / Sign in entries are commands, not selectable models, so
+			// they expose no checked state.
+			if (element.kind === ActionListItemKind.Action && !(element.item?.id && PICKER_COMMAND_ACTION_IDS.has(element.item.id))) {
 				return !!element?.item?.checked;
 			}
 			return undefined;
@@ -912,9 +956,9 @@ export function getModelPickerAccessibilityProvider() {
 				return 'menuitem';
 			}
 			switch (element.kind) {
-				// The Restricted Mode Trust action is a command, not a model
-				// choice, so announce it as a plain menuitem rather than a radio.
-				case ActionListItemKind.Action: return element.item?.id === RESTRICTED_MODE_TRUST_ACTION_ID ? 'menuitem' : 'menuitemradio';
+				// The Trust / Sign in entries are commands, not model choices, so
+				// announce them as plain menuitems rather than radios.
+				case ActionListItemKind.Action: return element.item?.id && PICKER_COMMAND_ACTION_IDS.has(element.item.id) ? 'menuitem' : 'menuitemradio';
 				case ActionListItemKind.Separator: return 'separator';
 				default: return 'separator';
 			}
@@ -1077,6 +1121,12 @@ export class ModelPickerWidget extends Disposable {
 			this._renderLabel();
 		}));
 
+		// The setup-required state derives from entitlement / sentiment / anonymous
+		// access, so refresh the label when any of those change (e.g. after sign-in).
+		this._register(this._entitlementService.onDidChangeEntitlement(() => this._renderLabel()));
+		this._register(this._entitlementService.onDidChangeSentiment(() => this._renderLabel()));
+		this._register(this._entitlementService.onDidChangeAnonymous(() => this._renderLabel()));
+
 		// Also refresh the label when the per-editor config layer (if any) reports
 		// a change. The global service path is already covered above via
 		// `onDidChangeLanguageModels` which fires from `setModelConfiguration`.
@@ -1116,17 +1166,47 @@ export class ModelPickerWidget extends Disposable {
 	}
 
 	/**
+	 * Why the picker currently has no model to offer (untrusted vs. needs
+	 * sign-in/setup), or `undefined` when a model is available. See
+	 * {@link getModelPickerUnavailableReason}.
+	 */
+	private _unavailableReason(): ModelPickerUnavailableReason | undefined {
+		return getModelPickerUnavailableReason({
+			trustInitialized: this._workspaceTrustInitialized,
+			trusted: this._workspaceTrustManagementService.isWorkspaceTrusted(),
+			pickerModels: this._delegate.getModels(),
+			liveModelIds: this._languageModelsService.getLanguageModelIds(),
+			requiresSetup: this._requiresSetup(),
+		});
+	}
+
+	private _requiresSetup(): boolean {
+		const sentiment = this._entitlementService.sentiment;
+		return chatRequiresSetup({
+			completed: !!sentiment.completed,
+			disabled: !!sentiment.disabled,
+			untrusted: !!sentiment.untrusted,
+			entitlement: this._entitlementService.entitlement,
+			anonymous: this._entitlementService.anonymous,
+			hasByokModels: this._entitlementService.hasByokModels,
+		});
+	}
+
+	/**
 	 * Whether the picker has no usable model specifically because the workspace
-	 * is untrusted (Restricted Mode disables the chat model providers). See
-	 * {@link isRestrictedModeState} for how "usable" is determined.
+	 * is untrusted (Restricted Mode disables the chat model providers).
 	 */
 	isRestrictedMode(): boolean {
-		return isRestrictedModeState(
-			this._workspaceTrustInitialized,
-			this._workspaceTrustManagementService.isWorkspaceTrusted(),
-			this._delegate.getModels(),
-			this._languageModelsService.getLanguageModelIds(),
-		);
+		return this._unavailableReason() === ModelPickerUnavailableReason.Restricted;
+	}
+
+	/**
+	 * Whether the picker has no usable model because Chat still needs sign-in /
+	 * setup (and the workspace is trusted, so it is not Restricted Mode). BYOK
+	 * and anonymous access never report this state.
+	 */
+	isSetupRequired(): boolean {
+		return this._unavailableReason() === ModelPickerUnavailableReason.SetupRequired;
 	}
 
 	private _clearActivating(): void {
@@ -1142,6 +1222,15 @@ export class ModelPickerWidget extends Disposable {
 		await this._workspaceTrustRequestService.requestWorkspaceTrust({
 			message: localize('chat.modelPicker.trustMessage', "Trusting this workspace enables AI models and chat features.")
 		});
+	}
+
+	/**
+	 * Starts the Chat setup / sign-in flow (same command as the title-bar Sign In
+	 * affordance). On completion the entitlement and model registry change, which
+	 * refreshes the picker.
+	 */
+	private _requestSetup(): void {
+		this._commandService.executeCommand(CHAT_SETUP_ACTION_ID);
 	}
 
 	render(container: HTMLElement): void {
@@ -1282,6 +1371,8 @@ export class ModelPickerWidget extends Disposable {
 			onConfigure,
 			this.isRestrictedMode(),
 			() => { void this._requestWorkspaceTrust(); },
+			this.isSetupRequired(),
+			() => { this._requestSetup(); },
 		);
 
 		// Collect all hover disposables so they are properly cleaned up when the
@@ -1378,24 +1469,30 @@ export class ModelPickerWidget extends Disposable {
 		// Mode explanation and the Trust Workspace action.
 		const restrictedMode = this.isRestrictedMode();
 
+		// Trusted, but Chat still needs sign-in / setup before any model is
+		// usable: present the same "Pick Model" placeholder, with the dropdown
+		// carrying a Sign In action instead of a misleading "Auto".
+		const setupRequired = this.isSetupRequired();
+		const unavailable = restrictedMode || setupRequired;
+
 		// Just after Trust, models load asynchronously while the chat extension
 		// activates. Show a transient "Activating..." state — only when there is
 		// nothing else to display — instead of a misleading "Auto" fallback.
-		const activating = !restrictedMode && this._activatingAfterTrust && this._delegate.getModels().length === 0;
+		const activating = !unavailable && this._activatingAfterTrust && this._delegate.getModels().length === 0;
 
 		// Generic empty state (e.g. an agent-host session with no Auto fallback);
-		// not evaluated while restricted/activating, which take precedence.
-		const genericNoModels = !restrictedMode && !activating
+		// not evaluated while unavailable/activating, which take precedence.
+		const genericNoModels = !unavailable && !activating
 			&& !(this._delegate.showAutoModel?.() ?? false)
 			&& this._delegate.getModels().length === 0;
-		const noModelsAvailable = restrictedMode || activating || genericNoModels;
+		const noModelsAvailable = unavailable || activating || genericNoModels;
 
 		// --- Name section ---
 		const nameChildren: (HTMLElement | string)[] = [];
 		if (statusIcon && !noModelsAvailable) {
 			nameChildren.push(renderIcon(statusIcon));
 		}
-		const modelLabel = restrictedMode
+		const modelLabel = unavailable
 			? localize('chat.modelPicker.label', "Pick Model")
 			: activating
 				? localize('chat.modelPicker.activating', "Activating...")
@@ -1453,7 +1550,9 @@ export class ModelPickerWidget extends Disposable {
 		// Aria
 		this._domNode.ariaLabel = restrictedMode
 			? localize('chat.modelPicker.ariaLabelRestricted', "Pick Model, models are unavailable in Restricted Mode")
-			: localize('chat.modelPicker.ariaLabel', "Pick Model, {0}", fullLabel);
+			: setupRequired
+				? localize('chat.modelPicker.ariaLabelSetupRequired', "Pick Model, sign in to use Copilot")
+				: localize('chat.modelPicker.ariaLabel', "Pick Model, {0}", fullLabel);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
@@ -326,32 +326,56 @@ export function shouldRestoreLateArrivingModel(
 }
 
 /**
- * Whether a model picker is in Restricted Mode: the workspace is untrusted and
- * the picker has no usable model, so it should surface a "Pick Model" placeholder
- * and a Trust Workspace action instead of a misleading lone "Auto".
+ * Why a model picker has no model to offer, when that is the case. Drives a
+ * "Pick Model" placeholder plus a contextual action instead of a misleading
+ * lone "Auto".
+ */
+export const enum ModelPickerUnavailableReason {
+	/** The workspace is untrusted, which disables the model providers. */
+	Restricted = 'restricted',
+	/** Chat requires sign-in / setup before any model is available. */
+	SetupRequired = 'setupRequired',
+}
+
+/**
+ * Determines whether a model picker should present an "unavailable" state and,
+ * if so, why. Returns `undefined` when the picker has a usable model (or its
+ * state is not yet known), so the normal model / Auto label is shown.
  *
  * A model counts as usable only when it is both offered by this picker
  * (`pickerModels`, already filtered to the picker's location / session type) AND
  * currently live in the language model registry (`liveModelIds`). This ignores
- * two kinds of phantom models that would otherwise mask Restricted Mode:
+ * two kinds of phantom models that would otherwise mask the unavailable state:
  * - stale cross-window machine cache entries (present in `pickerModels` but not live), and
  * - models registered for other surfaces such as agent-host session-scoped models
  *   (live in the global registry but not offered by this picker).
  *
- * `trusted` reflects `isWorkspaceTrusted()` (which is `true` when trust is
- * disabled entirely) and is only authoritative once `trustInitialized` is `true`;
- * until then this returns `false` to avoid a trusted workspace briefly rendering
- * as restricted at startup.
+ * A live, picker-offered model (e.g. BYOK) always wins, so BYOK and anonymous
+ * access are never shown an unavailable state. `trusted` reflects
+ * `isWorkspaceTrusted()` (which is `true` when trust is disabled entirely) and is
+ * only authoritative once `trustInitialized` is `true`; until then this returns
+ * `undefined` to avoid a trusted workspace briefly rendering as unavailable at
+ * startup. Restricted (untrusted) takes precedence over setup-required.
  */
-export function isRestrictedModeState(
-	trustInitialized: boolean,
-	trusted: boolean,
-	pickerModels: readonly ILanguageModelChatMetadataAndIdentifier[],
-	liveModelIds: Iterable<string>,
-): boolean {
-	if (!trustInitialized || trusted) {
-		return false;
+export function getModelPickerUnavailableReason(context: {
+	readonly trustInitialized: boolean;
+	readonly trusted: boolean;
+	readonly pickerModels: readonly ILanguageModelChatMetadataAndIdentifier[];
+	readonly liveModelIds: Iterable<string>;
+	readonly requiresSetup: boolean;
+}): ModelPickerUnavailableReason | undefined {
+	if (!context.trustInitialized) {
+		return undefined;
 	}
-	const live = liveModelIds instanceof Set ? liveModelIds : new Set(liveModelIds);
-	return !pickerModels.some(model => live.has(model.identifier));
+	const live = context.liveModelIds instanceof Set ? context.liveModelIds : new Set(context.liveModelIds);
+	if (context.pickerModels.some(model => live.has(model.identifier))) {
+		return undefined;
+	}
+	if (!context.trusted) {
+		return ModelPickerUnavailableReason.Restricted;
+	}
+	if (context.requiresSetup) {
+		return ModelPickerUnavailableReason.SetupRequired;
+	}
+	return undefined;
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
@@ -324,3 +324,34 @@ export function shouldRestoreLateArrivingModel(
 	);
 	return result.shouldRestore;
 }
+
+/**
+ * Whether a model picker is in Restricted Mode: the workspace is untrusted and
+ * the picker has no usable model, so it should surface a "Pick Model" placeholder
+ * and a Trust Workspace action instead of a misleading lone "Auto".
+ *
+ * A model counts as usable only when it is both offered by this picker
+ * (`pickerModels`, already filtered to the picker's location / session type) AND
+ * currently live in the language model registry (`liveModelIds`). This ignores
+ * two kinds of phantom models that would otherwise mask Restricted Mode:
+ * - stale cross-window machine cache entries (present in `pickerModels` but not live), and
+ * - models registered for other surfaces such as agent-host session-scoped models
+ *   (live in the global registry but not offered by this picker).
+ *
+ * `trusted` reflects `isWorkspaceTrusted()` (which is `true` when trust is
+ * disabled entirely) and is only authoritative once `trustInitialized` is `true`;
+ * until then this returns `false` to avoid a trusted workspace briefly rendering
+ * as restricted at startup.
+ */
+export function isRestrictedModeState(
+	trustInitialized: boolean,
+	trusted: boolean,
+	pickerModels: readonly ILanguageModelChatMetadataAndIdentifier[],
+	liveModelIds: Iterable<string>,
+): boolean {
+	if (!trustInitialized || trusted) {
+		return false;
+	}
+	const live = liveModelIds instanceof Set ? liveModelIds : new Set(liveModelIds);
+	return !pickerModels.some(model => live.has(model.identifier));
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
@@ -133,6 +133,15 @@ export class ModelPickerActionItem extends BaseActionViewItem {
 		return this._pickerWidget.isRestrictedMode();
 	}
 
+	/**
+	 * Whether the picker has no usable model because Chat still needs sign-in /
+	 * setup. Like {@link isRestrictedMode}, lets a host keep the picker visible to
+	 * surface the "Pick Model" placeholder and Sign In action.
+	 */
+	public isSetupRequired(): boolean {
+		return this._pickerWidget.isSetupRequired();
+	}
+
 	private _showPicker(): void {
 		this._pickerWidget.show(this._getAnchorElement());
 	}
@@ -143,8 +152,9 @@ export class ModelPickerActionItem extends BaseActionViewItem {
 			return;
 		}
 		// Use a content factory so the hover reflects the current state each time
-		// it is shown — in particular the Restricted Mode message, which depends
-		// on workspace trust changing without this item being re-rendered.
+		// it is shown — in particular the Restricted Mode / sign-in messages, which
+		// depend on workspace trust / entitlement changing without this item being
+		// re-rendered.
 		this._managedHover.value = getBaseLayerHoverDelegate().setupManagedHover(
 			getDefaultHoverDelegate('mouse'),
 			target,
@@ -160,6 +170,9 @@ export class ModelPickerActionItem extends BaseActionViewItem {
 		}
 		if (this._pickerWidget.isRestrictedMode()) {
 			return localize('chat.modelPicker.restrictedHover', "{0} • Models are unavailable in Restricted Mode. Trust the workspace to choose a model.", label);
+		}
+		if (this._pickerWidget.isSetupRequired()) {
+			return localize('chat.modelPicker.setupRequiredHover', "{0} • Sign in to GitHub Copilot to choose a model.", label);
 		}
 		const { statusIcon, tooltip } = this._pickerWidget.selectedModel?.metadata || {};
 		return statusIcon && tooltip ? `${label} • ${tooltip}` : label;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
@@ -132,23 +132,24 @@ export class ModelPickerActionItem extends BaseActionViewItem {
 		if (!target) {
 			return;
 		}
-		const hoverContent = this._getHoverContents();
-		if (typeof hoverContent === 'string' && hoverContent) {
-			this._managedHover.value = getBaseLayerHoverDelegate().setupManagedHover(
-				getDefaultHoverDelegate('mouse'),
-				target,
-				hoverContent
-			);
-		} else {
-			this._managedHover.clear();
-		}
+		// Use a content factory so the hover reflects the current state each time
+		// it is shown — in particular the Restricted Mode message, which depends
+		// on workspace trust changing without this item being re-rendered.
+		this._managedHover.value = getBaseLayerHoverDelegate().setupManagedHover(
+			getDefaultHoverDelegate('mouse'),
+			target,
+			() => this._getHoverContents()
+		);
 	}
 
-	private _getHoverContents(): IManagedHoverContent | undefined {
+	private _getHoverContents(): IManagedHoverContent {
 		let label = localize('chat.modelPicker.label', "Pick Model");
 		const keybindingLabel = this.keybindingService.lookupKeybinding(this._action.id, this._contextKeyService)?.getLabel();
 		if (keybindingLabel) {
 			label += ` (${keybindingLabel})`;
+		}
+		if (this._pickerWidget.isRestrictedMode()) {
+			return localize('chat.modelPicker.restrictedHover', "{0} • Models are unavailable in Restricted Mode. Trust the workspace to choose a model.", label);
 		}
 		const { statusIcon, tooltip } = this._pickerWidget.selectedModel?.metadata || {};
 		return statusIcon && tooltip ? `${label} • ${tooltip}` : label;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
@@ -123,6 +123,16 @@ export class ModelPickerActionItem extends BaseActionViewItem {
 		this._pickerWidget.setEnabled(enabled);
 	}
 
+	/**
+	 * Whether the picker has no usable model because the workspace is untrusted
+	 * (Restricted Mode). Lets a host (e.g. the sessions picker) keep the picker
+	 * visible to surface the "Pick Model" placeholder and Trust Workspace action
+	 * instead of hiding it as an empty/no-model picker.
+	 */
+	public isRestrictedMode(): boolean {
+		return this._pickerWidget.isRestrictedMode();
+	}
+
 	private _showPicker(): void {
 		this._pickerWidget.show(this._getAnchorElement());
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
@@ -242,17 +242,24 @@ suite('buildModelPickerItems', () => {
 		assert.strictEqual(actions.some(a => a.label === 'GPT-4o'), true);
 	});
 
-	test('restrictedMode shows an explanatory entry and a Trust Workspace action instead of auto', () => {
-		const items = callBuild([], { restrictedMode: true });
+	test('restrictedMode shows an explanatory header and a Trust Workspace action instead of auto', () => {
+		const items = callBuild([], { restrictedMode: true, onRequestTrust: () => { } });
 		const actions = getActionItems(items);
-		assert.strictEqual(actions.length, 2);
-		assert.strictEqual(actions[0].item?.id, 'restrictedModeInfo');
-		assert.strictEqual(actions[0].item?.enabled, false);
-		assert.strictEqual(actions[1].item?.id, 'restrictedModeTrust');
-		assert.strictEqual(actions[1].item?.enabled, true);
+		// The explanation is a non-interactive header; only Trust is selectable.
+		assert.ok(items.some(i => i.kind === ActionListItemKind.Header && i.label === 'Models Unavailable in Restricted Mode'));
+		assert.strictEqual(actions.length, 1);
+		assert.strictEqual(actions[0].item?.id, 'restrictedModeTrust');
+		assert.strictEqual(actions[0].item?.enabled, true);
 		assert.strictEqual(actions.some(a => a.label === 'Auto'), false);
 		assert.strictEqual(actions.some(a => a.item?.id === 'manageModels'), false);
 		assert.strictEqual(actions.some(a => a.item?.id === 'noModels'), false);
+	});
+
+	test('restrictedMode Trust action is disabled without a trust callback', () => {
+		const items = callBuild([], { restrictedMode: true });
+		const trust = getActionItems(items).find(a => a.item?.id === 'restrictedModeTrust');
+		assert.strictEqual(trust?.item?.enabled, false);
+		assert.strictEqual(trust?.disabled, true);
 	});
 
 	test('restrictedMode takes precedence over showAutoModel', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
@@ -172,6 +172,14 @@ suite('buildModelPickerItems', () => {
 		assert.strictEqual(provider.getWidgetRole(), 'menu');
 	});
 
+	test('accessibility provider announces the Restricted Mode Trust action as a plain menuitem (not a radio)', () => {
+		const provider = getModelPickerAccessibilityProvider();
+		const trust = getActionItems(callBuild([], { restrictedMode: true, onRequestTrust: () => { } })).find(a => a.item?.id === 'restrictedModeTrust')!;
+		assert.ok(trust, 'expected a Trust Workspace action');
+		assert.strictEqual(provider.getRole(trust), 'menuitem');
+		assert.strictEqual(provider.isChecked(trust), undefined);
+	});
+
 	test('accessibility provider includes inline source and right-aligned multiplier', () => {
 		const provider = getModelPickerAccessibilityProvider();
 		assert.strictEqual(provider.getAriaLabel({

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
@@ -116,6 +116,8 @@ function callBuild(
 		showAutoModel?: boolean;
 		restrictedMode?: boolean;
 		onRequestTrust?: () => void;
+		setupRequired?: boolean;
+		onRequestSetup?: () => void;
 	} = {},
 ): IActionListItem<IActionWidgetDropdownAction>[] {
 	const onSelect = () => { };
@@ -147,6 +149,8 @@ function callBuild(
 		undefined,
 		opts.restrictedMode ?? false,
 		opts.onRequestTrust,
+		opts.setupRequired ?? false,
+		opts.onRequestSetup,
 	);
 }
 
@@ -178,6 +182,14 @@ suite('buildModelPickerItems', () => {
 		assert.ok(trust, 'expected a Trust Workspace action');
 		assert.strictEqual(provider.getRole(trust), 'menuitem');
 		assert.strictEqual(provider.isChecked(trust), undefined);
+	});
+
+	test('accessibility provider announces the Sign In action as a plain menuitem (not a radio)', () => {
+		const provider = getModelPickerAccessibilityProvider();
+		const signIn = getActionItems(callBuild([], { setupRequired: true, onRequestSetup: () => { } })).find(a => a.item?.id === 'setupRequiredSignIn')!;
+		assert.ok(signIn, 'expected a Sign In action');
+		assert.strictEqual(provider.getRole(signIn), 'menuitem');
+		assert.strictEqual(provider.isChecked(signIn), undefined);
 	});
 
 	test('accessibility provider includes inline source and right-aligned multiplier', () => {
@@ -294,6 +306,47 @@ suite('buildModelPickerItems', () => {
 		const actions = getActionItems(items);
 		assert.strictEqual(actions.some(a => a.label === 'GPT-4o'), false);
 		assert.strictEqual(actions.some(a => a.item?.id === 'restrictedModeTrust'), true);
+	});
+
+	test('setupRequired shows an explanatory header and a Sign In action instead of auto', () => {
+		const items = callBuild([], { setupRequired: true, onRequestSetup: () => { } });
+		const actions = getActionItems(items);
+		assert.ok(items.some(i => i.kind === ActionListItemKind.Header && i.label === 'Sign in to use Copilot'));
+		assert.strictEqual(actions.length, 1);
+		assert.strictEqual(actions[0].item?.id, 'setupRequiredSignIn');
+		assert.strictEqual(actions[0].item?.enabled, true);
+		assert.strictEqual(actions.some(a => a.label === 'Auto'), false);
+		assert.strictEqual(actions.some(a => a.item?.id === 'manageModels'), false);
+	});
+
+	test('setupRequired Sign In action is disabled without a setup callback', () => {
+		const items = callBuild([], { setupRequired: true });
+		const signIn = getActionItems(items).find(a => a.item?.id === 'setupRequiredSignIn');
+		assert.strictEqual(signIn?.item?.enabled, false);
+		assert.strictEqual(signIn?.disabled, true);
+	});
+
+	test('setupRequired Sign In action invokes the setup callback', () => {
+		let setupRequested = 0;
+		const items = callBuild([], { setupRequired: true, onRequestSetup: () => { setupRequested++; } });
+		const signIn = getActionItems(items).find(a => a.item?.id === 'setupRequiredSignIn');
+		assert.ok(signIn, 'expected a Sign In action');
+		signIn!.item!.run();
+		assert.strictEqual(setupRequested, 1);
+	});
+
+	test('setupRequired takes precedence even over cached models', () => {
+		const items = callBuild([createModel('gpt-4o', 'GPT-4o')], { setupRequired: true });
+		const actions = getActionItems(items);
+		assert.strictEqual(actions.some(a => a.label === 'GPT-4o'), false);
+		assert.strictEqual(actions.some(a => a.item?.id === 'setupRequiredSignIn'), true);
+	});
+
+	test('restrictedMode takes precedence over setupRequired', () => {
+		const items = callBuild([], { restrictedMode: true, setupRequired: true, onRequestTrust: () => { }, onRequestSetup: () => { } });
+		const actions = getActionItems(items);
+		assert.strictEqual(actions.some(a => a.item?.id === 'restrictedModeTrust'), true);
+		assert.strictEqual(actions.some(a => a.item?.id === 'setupRequiredSignIn'), false);
 	});
 
 	test('only auto model produces auto and manage models with separator', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
@@ -114,6 +114,8 @@ function callBuild(
 		isUBB?: boolean;
 		languageModelsService?: ILanguageModelsService;
 		showAutoModel?: boolean;
+		restrictedMode?: boolean;
+		onRequestTrust?: () => void;
 	} = {},
 ): IActionListItem<IActionWidgetDropdownAction>[] {
 	const onSelect = () => { };
@@ -142,6 +144,9 @@ function callBuild(
 		undefined,
 		opts.isUBB,
 		opts.showAutoModel ?? true,
+		undefined,
+		opts.restrictedMode ?? false,
+		opts.onRequestTrust,
 	);
 }
 
@@ -235,6 +240,45 @@ suite('buildModelPickerItems', () => {
 		const actions = getActionItems(items);
 		assert.strictEqual(actions.some(a => a.item?.id === 'noModels'), false);
 		assert.strictEqual(actions.some(a => a.label === 'GPT-4o'), true);
+	});
+
+	test('restrictedMode shows an explanatory entry and a Trust Workspace action instead of auto', () => {
+		const items = callBuild([], { restrictedMode: true });
+		const actions = getActionItems(items);
+		assert.strictEqual(actions.length, 2);
+		assert.strictEqual(actions[0].item?.id, 'restrictedModeInfo');
+		assert.strictEqual(actions[0].item?.enabled, false);
+		assert.strictEqual(actions[1].item?.id, 'restrictedModeTrust');
+		assert.strictEqual(actions[1].item?.enabled, true);
+		assert.strictEqual(actions.some(a => a.label === 'Auto'), false);
+		assert.strictEqual(actions.some(a => a.item?.id === 'manageModels'), false);
+		assert.strictEqual(actions.some(a => a.item?.id === 'noModels'), false);
+	});
+
+	test('restrictedMode takes precedence over showAutoModel', () => {
+		const items = callBuild([], { restrictedMode: true, showAutoModel: true });
+		const actions = getActionItems(items);
+		assert.strictEqual(actions.some(a => a.label === 'Auto'), false);
+		assert.strictEqual(actions.some(a => a.item?.id === 'restrictedModeTrust'), true);
+	});
+
+	test('restrictedMode Trust action invokes the trust callback', () => {
+		let trustRequested = 0;
+		const items = callBuild([], { restrictedMode: true, onRequestTrust: () => { trustRequested++; } });
+		const trustAction = getActionItems(items).find(a => a.item?.id === 'restrictedModeTrust');
+		assert.ok(trustAction, 'expected a Trust Workspace action');
+		trustAction!.item!.run();
+		assert.strictEqual(trustRequested, 1);
+	});
+
+	test('restrictedMode takes precedence even over cached models', () => {
+		// In Restricted Mode the picker may still receive machine-cached models
+		// from a previous trusted session; the restricted state must suppress
+		// them rather than present stale, unusable models.
+		const items = callBuild([createModel('gpt-4o', 'GPT-4o')], { restrictedMode: true });
+		const actions = getActionItems(items);
+		assert.strictEqual(actions.some(a => a.label === 'GPT-4o'), false);
+		assert.strictEqual(actions.some(a => a.item?.id === 'restrictedModeTrust'), true);
 	});
 
 	test('only auto model produces auto and manage models with separator', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionLogic.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionLogic.test.ts
@@ -16,7 +16,8 @@ import {
 	isModelSupportedForInlineChat,
 	isModelSupportedForMode,
 	isModelValidForSession,
-	isRestrictedModeState,
+	getModelPickerUnavailableReason,
+	ModelPickerUnavailableReason,
 	mergeModelsWithCache,
 	resolveModelFromSyncState,
 	shouldResetModelToDefault,
@@ -1734,37 +1735,53 @@ suite('ChatModelSelectionLogic', () => {
 		});
 	});
 
-	suite('isRestrictedModeState', () => {
+	suite('getModelPickerUnavailableReason', () => {
 		const gpt = createModel('gpt-4o', 'GPT-4o');
 
-		test('untrusted with no usable models is restricted', () => {
-			assert.strictEqual(isRestrictedModeState(true, false, [], []), true);
+		function reason(opts: { trustInitialized?: boolean; trusted?: boolean; pickerModels?: ILanguageModelChatMetadataAndIdentifier[]; liveModelIds?: Iterable<string>; requiresSetup?: boolean }): ModelPickerUnavailableReason | undefined {
+			return getModelPickerUnavailableReason({
+				trustInitialized: opts.trustInitialized ?? true,
+				trusted: opts.trusted ?? true,
+				pickerModels: opts.pickerModels ?? [],
+				liveModelIds: opts.liveModelIds ?? [],
+				requiresSetup: opts.requiresSetup ?? false,
+			});
+		}
+
+		test('untrusted with no usable models is Restricted', () => {
+			assert.strictEqual(reason({ trusted: false }), ModelPickerUnavailableReason.Restricted);
 		});
 
-		test('trusted is never restricted', () => {
-			assert.strictEqual(isRestrictedModeState(true, true, [], []), false);
+		test('trusted with no usable models and setup required is SetupRequired', () => {
+			assert.strictEqual(reason({ trusted: true, requiresSetup: true }), ModelPickerUnavailableReason.SetupRequired);
 		});
 
-		test('not restricted until trust has initialized', () => {
-			assert.strictEqual(isRestrictedModeState(false, false, [], []), false);
+		test('trusted with no usable models and setup not required is available (e.g. anonymous/Auto)', () => {
+			assert.strictEqual(reason({ trusted: true, requiresSetup: false }), undefined);
 		});
 
-		test('untrusted with a live, picker-offered model is not restricted (e.g. BYOK)', () => {
-			assert.strictEqual(isRestrictedModeState(true, false, [gpt], [gpt.identifier]), false);
+		test('undefined until trust has initialized', () => {
+			assert.strictEqual(reason({ trustInitialized: false, trusted: false, requiresSetup: true }), undefined);
 		});
 
-		test('stale cached models that are not live do not mask Restricted Mode', () => {
-			// `gpt` is offered by the picker (e.g. from the cross-window cache) but is not in the live registry.
-			assert.strictEqual(isRestrictedModeState(true, false, [gpt], []), true);
+		test('a live, picker-offered model wins over any unavailable state (e.g. BYOK)', () => {
+			assert.strictEqual(reason({ trusted: false, requiresSetup: true, pickerModels: [gpt], liveModelIds: [gpt.identifier] }), undefined);
 		});
 
-		test('models live for another surface but not offered by this picker do not mask Restricted Mode', () => {
-			// An agent-host session-scoped model is live in the global registry, but the picker does not offer it.
-			assert.strictEqual(isRestrictedModeState(true, false, [], ['agentHost/claude']), true);
+		test('stale cached models that are not live do not mask the unavailable state', () => {
+			assert.strictEqual(reason({ trusted: false, pickerModels: [gpt], liveModelIds: [] }), ModelPickerUnavailableReason.Restricted);
+		});
+
+		test('models live for another surface but not offered by this picker do not mask the unavailable state', () => {
+			assert.strictEqual(reason({ trusted: true, requiresSetup: true, pickerModels: [], liveModelIds: ['agentHost/claude'] }), ModelPickerUnavailableReason.SetupRequired);
+		});
+
+		test('restricted takes precedence over setup required', () => {
+			assert.strictEqual(reason({ trusted: false, requiresSetup: true }), ModelPickerUnavailableReason.Restricted);
 		});
 
 		test('accepts a Set of live ids', () => {
-			assert.strictEqual(isRestrictedModeState(true, false, [gpt], new Set([gpt.identifier])), false);
+			assert.strictEqual(reason({ trusted: false, requiresSetup: true, pickerModels: [gpt], liveModelIds: new Set([gpt.identifier]) }), undefined);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionLogic.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionLogic.test.ts
@@ -16,6 +16,7 @@ import {
 	isModelSupportedForInlineChat,
 	isModelSupportedForMode,
 	isModelValidForSession,
+	isRestrictedModeState,
 	mergeModelsWithCache,
 	resolveModelFromSyncState,
 	shouldResetModelToDefault,
@@ -1730,6 +1731,40 @@ suite('ChatModelSelectionLogic', () => {
 				true,
 				'reset fallback should not be a BYOK model',
 			);
+		});
+	});
+
+	suite('isRestrictedModeState', () => {
+		const gpt = createModel('gpt-4o', 'GPT-4o');
+
+		test('untrusted with no usable models is restricted', () => {
+			assert.strictEqual(isRestrictedModeState(true, false, [], []), true);
+		});
+
+		test('trusted is never restricted', () => {
+			assert.strictEqual(isRestrictedModeState(true, true, [], []), false);
+		});
+
+		test('not restricted until trust has initialized', () => {
+			assert.strictEqual(isRestrictedModeState(false, false, [], []), false);
+		});
+
+		test('untrusted with a live, picker-offered model is not restricted (e.g. BYOK)', () => {
+			assert.strictEqual(isRestrictedModeState(true, false, [gpt], [gpt.identifier]), false);
+		});
+
+		test('stale cached models that are not live do not mask Restricted Mode', () => {
+			// `gpt` is offered by the picker (e.g. from the cross-window cache) but is not in the live registry.
+			assert.strictEqual(isRestrictedModeState(true, false, [gpt], []), true);
+		});
+
+		test('models live for another surface but not offered by this picker do not mask Restricted Mode', () => {
+			// An agent-host session-scoped model is live in the global registry, but the picker does not offer it.
+			assert.strictEqual(isRestrictedModeState(true, false, [], ['agentHost/claude']), true);
+		});
+
+		test('accepts a Set of live ids', () => {
+			assert.strictEqual(isRestrictedModeState(true, false, [gpt], new Set([gpt.identifier])), false);
 		});
 	});
 });

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -57,13 +57,13 @@ interface IDefaultAccountConfig {
 
 export const DEFAULT_ACCOUNT_SIGN_IN_COMMAND = 'workbench.actions.accounts.signIn';
 
-const enum DefaultAccountStatus {
+export enum DefaultAccountStatus {
 	Uninitialized = 'uninitialized',
 	Unavailable = 'unavailable',
 	Available = 'available',
 }
 
-const CONTEXT_DEFAULT_ACCOUNT_STATE = new RawContextKey<string>('defaultAccountStatus', DefaultAccountStatus.Uninitialized);
+export const CONTEXT_DEFAULT_ACCOUNT_STATE = new RawContextKey<string>('defaultAccountStatus', DefaultAccountStatus.Uninitialized);
 const CACHED_POLICY_DATA_KEY = 'defaultAccount.cachedPolicyData';
 const ACCOUNT_DATA_POLL_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 const MANAGED_SETTINGS_REQUEST_TIMEOUT_MS = 5000;

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -57,7 +57,7 @@ interface IDefaultAccountConfig {
 
 export const DEFAULT_ACCOUNT_SIGN_IN_COMMAND = 'workbench.actions.accounts.signIn';
 
-export enum DefaultAccountStatus {
+export const enum DefaultAccountStatus {
 	Uninitialized = 'uninitialized',
 	Unavailable = 'unavailable',
 	Available = 'available',

--- a/src/vs/workbench/services/chat/common/chatEntitlementService.ts
+++ b/src/vs/workbench/services/chat/common/chatEntitlementService.ts
@@ -157,6 +157,46 @@ export interface IChatSentiment {
 	registered?: boolean;
 }
 
+/**
+ * The inputs needed to decide whether Chat still requires the user to run setup
+ * (sign in / sign up / trust / enable) before it can service a request.
+ */
+export interface IChatSetupRequirement {
+	/** Whether the setup flow has been completed (any outcome). */
+	readonly completed: boolean;
+	/** Whether the chat extension is disabled for a reason other than trust. */
+	readonly disabled: boolean;
+	/** Whether the chat extension is disabled because the workspace is untrusted. */
+	readonly untrusted: boolean;
+	/** The user's last known or resolved entitlement. */
+	readonly entitlement: ChatEntitlement;
+	/** Whether anonymous (signed-out) Chat access is enabled. */
+	readonly anonymous: boolean;
+	/** Whether BYOK models are available. */
+	readonly hasByokModels: boolean;
+}
+
+/**
+ * Single source of truth for whether Chat still requires setup before it can
+ * service a request. Shared by the setup agent (which routes a sent message
+ * through setup) and the model picker (which surfaces a "Sign in to use Copilot"
+ * state instead of a misleading lone "Auto"). BYOK models and anonymous access
+ * intentionally satisfy the entitlement-based checks so those flows keep working.
+ */
+export function chatRequiresSetup(context: IChatSetupRequirement): boolean {
+	return (
+		(!context.completed && !context.hasByokModels) ||			// Setup not completed (unless BYOK models are available)
+		context.disabled ||											// Extension disabled: run setup to enable
+		context.untrusted ||										// Workspace untrusted: run setup to ask for trust
+		context.entitlement === ChatEntitlement.Available ||		// Entitlement available: run setup to sign up
+		(
+			context.entitlement === ChatEntitlement.Unknown &&		// Entitlement unknown: run setup to sign in / sign up
+			!context.anonymous &&									// unless anonymous access is enabled
+			!context.hasByokModels									// unless BYOK models are available
+		)
+	);
+}
+
 export interface IChatEntitlementService {
 
 	_serviceBrand: undefined;

--- a/src/vs/workbench/services/chat/common/chatEntitlementService.ts
+++ b/src/vs/workbench/services/chat/common/chatEntitlementService.ts
@@ -41,6 +41,7 @@ export namespace ChatEntitlementContextKeys {
 		disabled: new RawContextKey<boolean>('chatSetupDisabled', false, true),  	// True when the chat extension is disabled due to any other reason than workspace trust.
 		disabledInWorkspace: new RawContextKey<boolean>('chatSetupDisabledInWorkspace', false, true),	// True when chat is disabled at the workspace level via settings.
 		untrusted: new RawContextKey<boolean>('chatSetupUntrusted', false, true),  	// True when the chat extension is disabled due to workspace trust.
+		activating: new RawContextKey<boolean>('chatSetupActivating', false, true),	// True while the chat extension is activating (entitlement not yet resolved).
 		later: new RawContextKey<boolean>('chatSetupLater', false, true),  			// True when the user wants to finish setup later.
 		registered: new RawContextKey<boolean>('chatSetupRegistered', false, true), // True when the user has registered as Free or Pro user.
 		completed: new RawContextKey<boolean>('chatSetupCompleted', false, true)	// True when the user has completed the setup flow, regardless of the outcome.

--- a/src/vs/workbench/services/chat/common/chatEntitlementService.ts
+++ b/src/vs/workbench/services/chat/common/chatEntitlementService.ts
@@ -41,7 +41,6 @@ export namespace ChatEntitlementContextKeys {
 		disabled: new RawContextKey<boolean>('chatSetupDisabled', false, true),  	// True when the chat extension is disabled due to any other reason than workspace trust.
 		disabledInWorkspace: new RawContextKey<boolean>('chatSetupDisabledInWorkspace', false, true),	// True when chat is disabled at the workspace level via settings.
 		untrusted: new RawContextKey<boolean>('chatSetupUntrusted', false, true),  	// True when the chat extension is disabled due to workspace trust.
-		activating: new RawContextKey<boolean>('chatSetupActivating', false, true),	// True while the chat extension is activating (entitlement not yet resolved).
 		later: new RawContextKey<boolean>('chatSetupLater', false, true),  			// True when the user wants to finish setup later.
 		registered: new RawContextKey<boolean>('chatSetupRegistered', false, true), // True when the user has registered as Free or Pro user.
 		completed: new RawContextKey<boolean>('chatSetupCompleted', false, true)	// True when the user has completed the setup flow, regardless of the outcome.

--- a/src/vs/workbench/services/chat/test/common/chatEntitlementService.test.ts
+++ b/src/vs/workbench/services/chat/test/common/chatEntitlementService.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ChatEntitlement, chatRequiresSetup, IChatSetupRequirement } from '../../common/chatEntitlementService.js';
+
+suite('chatRequiresSetup', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function context(overrides: Partial<IChatSetupRequirement> = {}): IChatSetupRequirement {
+		return {
+			completed: true,
+			disabled: false,
+			untrusted: false,
+			entitlement: ChatEntitlement.Pro,
+			anonymous: false,
+			hasByokModels: false,
+			...overrides,
+		};
+	}
+
+	test('a completed, signed-up user does not require setup', () => {
+		assert.strictEqual(chatRequiresSetup(context()), false);
+	});
+
+	test('not completed requires setup', () => {
+		assert.strictEqual(chatRequiresSetup(context({ completed: false })), true);
+	});
+
+	test('not completed but BYOK models present does not require setup', () => {
+		assert.strictEqual(chatRequiresSetup(context({ completed: false, hasByokModels: true })), false);
+	});
+
+	test('disabled requires setup', () => {
+		assert.strictEqual(chatRequiresSetup(context({ disabled: true })), true);
+	});
+
+	test('untrusted requires setup', () => {
+		assert.strictEqual(chatRequiresSetup(context({ untrusted: true })), true);
+	});
+
+	test('entitlement Available requires setup (sign up)', () => {
+		assert.strictEqual(chatRequiresSetup(context({ entitlement: ChatEntitlement.Available })), true);
+	});
+
+	test('signed out (Unknown) requires setup', () => {
+		assert.strictEqual(chatRequiresSetup(context({ completed: false, entitlement: ChatEntitlement.Unknown })), true);
+	});
+
+	test('signed out but anonymous access enabled does not require setup', () => {
+		// Anonymous excepts the "signed out" entitlement clause; the completed
+		// clause is satisfied because opting into anonymous completes setup.
+		assert.strictEqual(chatRequiresSetup(context({ completed: true, entitlement: ChatEntitlement.Unknown, anonymous: true })), false);
+	});
+
+	test('signed out but BYOK models present does not require setup', () => {
+		assert.strictEqual(chatRequiresSetup(context({ completed: false, entitlement: ChatEntitlement.Unknown, hasByokModels: true })), false);
+	});
+});

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
@@ -29,7 +29,7 @@ import { IPathService } from '../../../../services/path/common/pathService.js';
 import { IWorkbenchAssignmentService } from '../../../../services/assignment/common/assignmentService.js';
 import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
 import { IWorkbenchEnvironmentService } from '../../../../services/environment/common/environmentService.js';
-import { IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
+import { ChatEntitlement, IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
 import { INotebookDocumentService } from '../../../../services/notebook/common/notebookDocumentService.js';
 import { IViewDescriptorService } from '../../../../common/views.js';
 import { ISCMService } from '../../../../contrib/scm/common/scm.js';
@@ -181,7 +181,20 @@ export function registerChatFixtureServices(reg: ServiceRegistration, options: I
 		override readonly isSessionsWindow = false;
 	}());
 	reg.defineInstance(IChatSessionsService, new class extends mock<IChatSessionsService>() { override getAllChatSessionContributions() { return []; } override readonly onDidChangeSessionOptions = Event.None; override readonly onDidChangeOptionGroups = Event.None; override readonly onDidChangeAvailability = Event.None; override getCustomAgentTargetForSessionType() { return Target.Undefined; } override requiresCustomModelsForSessionType() { return false; } override supportsAutoModelForSessionType() { return false; } override getOptionGroupsForSessionType() { return []; } }());
-	reg.defineInstance(IChatEntitlementService, new class extends mock<IChatEntitlementService>() { override readonly quotas = {}; override readonly onDidChangeQuotaRemaining = Event.None; override readonly onDidChangeUsageBasedBilling = Event.None; }());
+	reg.defineInstance(IChatEntitlementService, new class extends mock<IChatEntitlementService>() {
+		override readonly quotas = {};
+		override readonly onDidChangeQuotaRemaining = Event.None;
+		override readonly onDidChangeUsageBasedBilling = Event.None;
+		override readonly onDidChangeEntitlement = Event.None;
+		override readonly onDidChangeSentiment = Event.None;
+		override readonly onDidChangeAnonymous = Event.None;
+		// A signed-in, set-up user so the picker renders normally (no Restricted /
+		// Sign In state) in fixtures.
+		override readonly entitlement = ChatEntitlement.Pro;
+		override readonly sentiment = { completed: true, installed: true };
+		override readonly anonymous = false;
+		override readonly hasByokModels = false;
+	}());
 	reg.defineInstance(IChatModeService, new MockChatModeService());
 	reg.defineInstance(ILanguageModelsService, new class extends mock<ILanguageModelsService>() { override onDidChangeLanguageModels = Event.None; override onDidChangeModelVisibility = Event.None; override getLanguageModelIds() { return []; } override getVendors() { return []; } override hasResolvedVendor() { return false; } }());
 	reg.defineInstance(ILanguageModelToolsService, new class extends mock<ILanguageModelToolsService>() { override onDidChangeTools = Event.None; override onDidPrepareToolCallBecomeUnresponsive = Event.None; override getTools() { return []; } }());

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
@@ -20,6 +20,7 @@ import { ISharedWebContentExtractorService } from '../../../../../platform/webCo
 import { IAccessibleViewService } from '../../../../../platform/accessibility/browser/accessibleView.js';
 import { IMarkdownRendererService, MarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
 import { IWorkspace, IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from '../../../../../platform/workspace/common/workspaceTrust.js';
 import { IDecorationsService } from '../../../../services/decorations/common/decorations.js';
 import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
 import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
@@ -126,6 +127,8 @@ export function registerChatFixtureServices(reg: ServiceRegistration, options: I
 	reg.defineInstance(IPathService, new class extends mock<IPathService>() { }());
 	reg.defineInstance(IWorkbenchAssignmentService, new class extends mock<IWorkbenchAssignmentService>() { override async getCurrentExperiments() { return []; } override async getTreatment() { return undefined; } override onDidRefetchAssignments = Event.None; }());
 	reg.defineInstance(IWorkspaceContextService, new class extends mock<IWorkspaceContextService>() { override onDidChangeWorkspaceFolders = Event.None; override getWorkspace(): IWorkspace { return { id: '', folders: [], configuration: undefined }; } }());
+	reg.defineInstance(IWorkspaceTrustManagementService, new class extends mock<IWorkspaceTrustManagementService>() { override onDidChangeTrust = Event.None; override readonly workspaceTrustInitialized = Promise.resolve(); override isWorkspaceTrusted() { return true; } }());
+	reg.defineInstance(IWorkspaceTrustRequestService, new class extends mock<IWorkspaceTrustRequestService>() { override async requestWorkspaceTrust() { return true; } }());
 	reg.defineInstance(IWorkbenchLayoutService, new class extends mock<IWorkbenchLayoutService>() { override onDidChangePartVisibility = Event.None; override onDidChangeWindowMaximized = Event.None; override isVisible() { return true; } }());
 	reg.defineInstance(IViewDescriptorService, new class extends mock<IViewDescriptorService>() { override onDidChangeLocation = Event.None; }());
 	reg.defineInstance(INotebookDocumentService, new class extends mock<INotebookDocumentService>() { }());


### PR DESCRIPTION
Fixes #322564
Fixes #322626

tl;dr: new look has "Pick a Model" + info about Workspace Trust, while before this just said "Auto" and it wasn't clear the user needed to trust the workspace. Adopts the behavior of the chat+send button: on first send, if untrusted, prompt for trust.

<img width="299" height="182" alt="Screenshot 2026-06-23 at 6 43 39 PM" src="https://github.com/user-attachments/assets/dadd5f08-24c9-42b1-9def-b3fa63d18afb" />

<img width="306" height="213" alt="Screenshot 2026-06-23 at 6 43 54 PM" src="https://github.com/user-attachments/assets/7c262790-4112-4638-b856-43544d9fa4a4" />


Fixes the confusing Chat experience in untrusted (Restricted Mode) workspaces, where the model providers and entitlement aren't available until the workspace is trusted and the extension activates.

### Model picker reflects Restricted Mode
Previously the picker fell back to a lone **"Auto"** entry, so users couldn't tell whether they were missing models.
- Button shows a neutral **"Pick Model"** placeholder (no fake "Auto").
- Dropdown shows a non-interactive **"Models Unavailable in Restricted Mode"** header + an enabled **"Trust Workspace…"** action (`requestWorkspaceTrust()`), mirroring the prompt shown when sending a message.
- Applies across **all** model pickers — single chat and inline chat (via `chatInputPart`) and the **sessions/agents chat** — which all share `ModelPickerWidget`.

### Robust detection (`isRestrictedModeState`)
A workspace is treated as restricted only when it is untrusted **and** the picker has no usable model. A model counts as usable only when it is **both** offered by this picker (`delegate.getModels()`, already filtered to the picker's location/session) **and** live in the language model registry. This deliberately ignores two phantom sources that previously masked the state and made the picker show "Auto":
- stale **cross-window machine cache** entries (present in the delegate list, but not live), and
- models registered for **other surfaces** — e.g. agent-host session-scoped models that the Agent Host registers into the *global* registry but that this picker doesn't offer (this is what made the agents/sessions picker show "Auto" in an untrusted workspace).

Detection is gated on `workspaceTrustInitialized` to avoid a restricted flash at startup. The sessions picker also stays visible (instead of hiding itself) when restricted so it can surface the Trust action, and re-evaluates on workspace-trust changes.

### No misleading "signed out" state during/after Trust
After granting Trust, the entitlement reads "signed out" until the extension finishes activating, which briefly surfaced a Sign In button and a "Sign in to use GitHub Copilot" modal to already-signed-in users.
- **Title-bar/accounts Sign In** keeps its existing signed-out trigger and adds the workbench **default-account state** as a *hide-when-signed-in* guard (`defaultAccountStatus !== available`). The button is shown whenever the user is not signed in — including before the account state resolves — and hidden only when a default GitHub account is positively present. This resolves from auth sessions independent of workspace trust and the extension, so it correctly hides for a signed-in user even in untrusted workspaces and while the extension is still activating, and still shows for a genuinely signed-out user (including untrusted). No auth is probed by this code.
- **Setup modal** (`chatSetupRunner`): after Trust from an untrusted workspace, waits for the chat extension to finish activating (via `IExtensionService` status only) before deciding whether to show the sign-in dialog, so existing Pro/Free users skip it.
- **Model picker** shows a transient **"Activating…"** state after Trust while models load (only when there's nothing else to display).

### Testing
- Unit tests for `isRestrictedModeState` in `chatModelSelectionLogic.test.ts` (untrusted vs. trusted, pre-trust-init, live BYOK model, and the stale-cache / agent-host masking cases) plus the restricted dropdown in `chatModelPicker.test.ts` (header/Trust action, precedence over cache, Trust callback, disabled-without-callback).
- `npm run typecheck-client`, eslint, `npm run valid-layers-check`, and the picker suites (145 selection-logic + 70 builder + 76 picker) all pass; hygiene hook.
- Restricted-mode picker behavior confirmed in a dev build: an untrusted workspace now shows **"Pick Model"** (+ Trust action) instead of "Auto". All pickers share `ModelPickerWidget`, so single, inline, and agents chat are covered by the same fix.
- Sign In button behavior confirmed in a dev build: shown when signed out, hidden when signed in (including untrusted workspaces).
- ⚠️ The post-Trust setup-modal gating still wants runtime verification with a signed-in Copilot account (draft).

