### PR TITLE
Respect terminal auto-approve setting in Agent Host default permissions

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -37,7 +37,7 @@ import { encodeBase64 } from '../../../base/common/buffer.js';
 import { ILoadEstimator, LoadEstimator } from '../../../base/parts/ipc/common/ipc.net.js';
 import { TELEMETRY_CRASH_REPORTER_SETTING_ID, TELEMETRY_OLD_SETTING_ID, TELEMETRY_SETTING_ID } from '../../telemetry/common/telemetry.js';
 import { getTelemetryLevel } from '../../telemetry/common/telemetryUtils.js';
-import { AgentHostTelemetryLevelConfigKey, AgentHostSessionSyncEnabledConfigKey, SESSION_SYNC_ENABLED_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
+import { AgentHostTelemetryLevelConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, SESSION_SYNC_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
 import type { OtlpExportLogsParams } from '../common/state/protocol/channels-otlp/notifications.js';
 import type { TelemetryCapabilities } from '../common/state/protocol/channels-otlp/state.js';
 import type { InitializeResult } from '../common/state/protocol/common/commands.js';
@@ -338,6 +338,12 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 				}
 				this._updateSessionSyncEnabled();
 			}
+			if (e.affectsConfiguration(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID)) {
+				if (this._state.kind !== AgentHostClientState.Connected) {
+					return;
+				}
+				this._updateTerminalAutoApproveEnabled();
+			}
 		}));
 
 		// Detect silently-dead transports — see {@link _resetLivenessTimers}.
@@ -425,6 +431,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		this._initializeResult = result;
 		this._updateTelemetryLevel();
 		this._updateSessionSyncEnabled();
+		this._updateTerminalAutoApproveEnabled();
 		this._transitionTo({ kind: AgentHostClientState.Connected });
 	}
 
@@ -1290,6 +1297,14 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		this.dispatchAction(ROOT_STATE_URI, {
 			type: ActionType.RootConfigChanged,
 			config: { [AgentHostSessionSyncEnabledConfigKey]: enabled },
+		}, this._clientId, 0);
+	}
+
+	private _updateTerminalAutoApproveEnabled(): void {
+		const enabled = this._configurationService.getValue<boolean>(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID) !== false;
+		this.dispatchAction(ROOT_STATE_URI, {
+			type: ActionType.RootConfigChanged,
+			config: { [AgentHostTerminalAutoApproveEnabledConfigKey]: enabled },
 		}, this._clientId, 0);
 	}
 

--- a/src/vs/platform/agentHost/common/agentHostSchema.ts
+++ b/src/vs/platform/agentHost/common/agentHostSchema.ts
@@ -391,6 +391,20 @@ export const AgentHostTelemetryLevelConfigKey = 'telemetryLevel';
 export const AgentHostSessionSyncEnabledConfigKey = 'sessionSyncEnabled';
 
 /**
+ * Root config key forwarded from the renderer when VS Code's
+ * `chat.tools.terminal.enableAutoApprove` setting changes. Controls whether
+ * agent-host shell permission checks may apply terminal auto-approve rules.
+ */
+export const AgentHostTerminalAutoApproveEnabledConfigKey = 'terminalAutoApproveEnabled';
+
+/**
+ * The VS Code setting ID for terminal auto approve enablement. Defined here so
+ * renderer-side agent-host clients can forward it without importing from
+ * workbench terminal contributions.
+ */
+export const TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID = 'chat.tools.terminal.enableAutoApprove';
+
+/**
  * Root config key holding agent-host-level MCP server definitions.
  *
  * The value is a map of server name → {@link IMcpServerConfiguration}
@@ -520,6 +534,12 @@ export const platformRootSchema = createSchema({
 		title: localize('agentHost.config.sessionSyncEnabled.title', "Session Sync"),
 		description: localize('agentHost.config.sessionSyncEnabled.description', "Whether remote session sync is enabled for the copilot-sdk CLI."),
 		default: false,
+	}),
+	[AgentHostTerminalAutoApproveEnabledConfigKey]: schemaProperty<boolean>({
+		type: 'boolean',
+		title: localize('agentHost.config.terminalAutoApproveEnabled.title', "Terminal Auto Approve"),
+		description: localize('agentHost.config.terminalAutoApproveEnabled.description', "Whether terminal auto-approve rules are allowed to apply to agent-host shell permission requests."),
+		default: true,
 	}),
 	[AgentHostMcpServersConfigKey]: schemaProperty<AgentHostMcpServers>({
 		type: 'object',

--- a/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
+++ b/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
@@ -30,7 +30,7 @@ import { URI } from '../../../base/common/uri.js';
 import { AGENT_HOST_CLIENT_RESOURCE_CHANNEL, AgentHostClientResourceChannel } from '../common/agentHostClientResourceChannel.js';
 import { TELEMETRY_CRASH_REPORTER_SETTING_ID, TELEMETRY_OLD_SETTING_ID, TELEMETRY_SETTING_ID } from '../../telemetry/common/telemetry.js';
 import { getTelemetryLevel } from '../../telemetry/common/telemetryUtils.js';
-import { AgentHostTelemetryLevelConfigKey, AgentHostSessionSyncEnabledConfigKey, SESSION_SYNC_ENABLED_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
+import { AgentHostTelemetryLevelConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, SESSION_SYNC_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
 
 /**
  * Renderer-side implementation of {@link IAgentHostService} that connects
@@ -126,6 +126,9 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 			if (e.affectsConfiguration(SESSION_SYNC_ENABLED_SETTING_ID)) {
 				this._updateSessionSyncEnabled();
 			}
+			if (e.affectsConfiguration(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID)) {
+				this._updateTerminalAutoApproveEnabled();
+			}
 		}));
 
 		if (isAgentHostEnabled(this._configurationService)) {
@@ -150,6 +153,7 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 		this._clientEventually.complete(client);
 		this._updateTelemetryLevel();
 		this._updateSessionSyncEnabled();
+		this._updateTerminalAutoApproveEnabled();
 
 		store.add(this._proxy.onDidAction(e => {
 			const revived = revive(e) as ActionEnvelope;
@@ -191,6 +195,14 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 		this.dispatchAction(ROOT_STATE_URI, {
 			type: ActionType.RootConfigChanged,
 			config: { [AgentHostSessionSyncEnabledConfigKey]: enabled },
+		}, this.clientId, 0);
+	}
+
+	private _updateTerminalAutoApproveEnabled(): void {
+		const enabled = this._configurationService.getValue<boolean>(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID) !== false;
+		this.dispatchAction(ROOT_STATE_URI, {
+			type: ActionType.RootConfigChanged,
+			config: { [AgentHostTerminalAutoApproveEnabledConfigKey]: enabled },
 		}, this.clientId, 0);
 	}
 

--- a/src/vs/platform/agentHost/node/sessionPermissions.ts
+++ b/src/vs/platform/agentHost/node/sessionPermissions.ts
@@ -15,7 +15,7 @@ import { URI } from '../../../base/common/uri.js';
 import { Promises } from '../../../base/node/pfs.js';
 import { localize } from '../../../nls.js';
 import { ILogService } from '../../log/common/log.js';
-import { platformSessionSchema } from '../common/agentHostSchema.js';
+import { AgentHostTerminalAutoApproveEnabledConfigKey, platformRootSchema, platformSessionSchema } from '../common/agentHostSchema.js';
 import type { IAgentToolPendingConfirmationSignal } from '../common/agentService.js';
 import { SessionConfigKey } from '../common/sessionConfigKeys.js';
 import { ConfirmationOptionKind, type ConfirmationOption } from '../common/state/protocol/state.js';
@@ -272,6 +272,9 @@ export class SessionPermissionManager extends Disposable {
 
 		// 5. Shell auto-approval
 		if (e.permissionKind === 'shell' && e.toolInput) {
+			if (this._configService.getRootValue(platformRootSchema, AgentHostTerminalAutoApproveEnabledConfigKey) === false) {
+				return undefined;
+			}
 			const result = this._commandAutoApprover.shouldAutoApprove(e.toolInput, {
 				isWriteDestApproved: (dest) => this._isShellWriteDestApproved(dest, workDir),
 			});

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -34,6 +34,24 @@ function isPingRequest(msg: ProtocolTransportMessage): msg is JsonRpcRequest & {
 	return hasKey(msg, { method: true, id: true }) && msg.method === 'ping';
 }
 
+/**
+ * Locate the `dispatchAction` notification that forwards a particular root
+ * config key. The connect flow sends several `RootConfigChanged` notifications
+ * (telemetry, session sync, terminal auto-approve), so matching on the config
+ * key is more robust than indexing into `sentMessages` by position.
+ */
+function findRootConfigNotification(messages: readonly ProtocolTransportMessage[], configKey: string): JsonRpcNotification {
+	const match = messages.find((msg): msg is JsonRpcNotification => {
+		if (!hasKey(msg, { method: true }) || msg.method !== 'dispatchAction') {
+			return false;
+		}
+		const params = (msg as JsonRpcNotification).params as { action?: { type?: string; config?: Record<string, unknown> } } | undefined;
+		return params?.action?.type === ActionType.RootConfigChanged && !!params.action.config && configKey in params.action.config;
+	});
+	assert.ok(match, `Expected a RootConfigChanged notification carrying '${configKey}'`);
+	return match;
+}
+
 class TestProtocolTransport extends Disposable implements IProtocolTransport {
 	private readonly _onMessage = this._register(new Emitter<ProtocolMessage>());
 	readonly onMessage = this._onMessage.event;
@@ -469,13 +487,17 @@ suite('RemoteAgentHostProtocolClient', () => {
 				},
 			},
 		});
-		const terminalAutoApproveEnabled = transport.sentMessages[3] as JsonRpcNotification;
-		assert.deepStrictEqual(terminalAutoApproveEnabled.params, {
-			channel: ROOT_STATE_URI,
-			clientSeq: 0,
-			action: {
-				type: ActionType.RootConfigChanged,
-				config: { [AgentHostTerminalAutoApproveEnabledConfigKey]: true },
+		const terminalAutoApproveEnabled = findRootConfigNotification(transport.sentMessages, AgentHostTerminalAutoApproveEnabledConfigKey);
+		assert.deepStrictEqual(terminalAutoApproveEnabled, {
+			jsonrpc: '2.0',
+			method: 'dispatchAction',
+			params: {
+				channel: ROOT_STATE_URI,
+				clientSeq: 0,
+				action: {
+					type: ActionType.RootConfigChanged,
+					config: { [AgentHostTerminalAutoApproveEnabledConfigKey]: true },
+				},
 			},
 		});
 	});

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -26,7 +26,7 @@ import { CustomizationType, ROOT_STATE_URI, StateComponents, customizationId } f
 import type { IClientTransport, IProtocolTransport } from '../../common/state/sessionTransport.js';
 import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
 import { TelemetryLevel } from '../../../telemetry/common/telemetry.js';
-import { AgentHostTelemetryLevelConfigKey, telemetryLevelToAgentHostConfigValue } from '../../common/agentHostSchema.js';
+import { AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, telemetryLevelToAgentHostConfigValue } from '../../common/agentHostSchema.js';
 
 type ProtocolTransportMessage = ProtocolMessage | AhpServerNotification | JsonRpcNotification | JsonRpcResponse | JsonRpcRequest;
 
@@ -467,6 +467,15 @@ suite('RemoteAgentHostProtocolClient', () => {
 					type: ActionType.RootConfigChanged,
 					config: { [AgentHostTelemetryLevelConfigKey]: telemetryLevelToAgentHostConfigValue(TelemetryLevel.USAGE) },
 				},
+			},
+		});
+		const terminalAutoApproveEnabled = transport.sentMessages[3] as JsonRpcNotification;
+		assert.deepStrictEqual(terminalAutoApproveEnabled.params, {
+			channel: ROOT_STATE_URI,
+			clientSeq: 0,
+			action: {
+				type: ActionType.RootConfigChanged,
+				config: { [AgentHostTerminalAutoApproveEnabledConfigKey]: true },
 			},
 		});
 	});

--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -12,7 +12,7 @@ import { isWindows } from '../../../../base/common/platform.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../log/common/log.js';
-import { platformSessionSchema } from '../../common/agentHostSchema.js';
+import { AgentHostTerminalAutoApproveEnabledConfigKey, platformSessionSchema } from '../../common/agentHostSchema.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { SessionStatus, ToolCallConfirmationReason, type SessionSummary } from '../../common/state/sessionState.js';
 import { AgentConfigurationService } from '../../node/agentConfigurationService.js';
@@ -23,6 +23,7 @@ suite('SessionPermissionManager', () => {
 
 	const disposables = new DisposableStore();
 	let manager: AgentHostStateManager;
+	let configService: AgentConfigurationService;
 	let permissions: SessionPermissionManager;
 
 	// Real (symlink-resolved) temp directories so that the symlink-resolution
@@ -49,6 +50,10 @@ suite('SessionPermissionManager', () => {
 		return { toolCallId: 'tc-1', session: URI.parse(sessionUri), permissionKind: 'write', permissionPath };
 	}
 
+	function shellEvent(commandLine: string): IToolApprovalEvent {
+		return { toolCallId: 'tc-shell', session: URI.parse(sessionUri), permissionKind: 'shell', toolInput: commandLine };
+	}
+
 	setup(async () => {
 		// Prefer the CI runner temp dir (a plain long path) over `os.tmpdir()`,
 		// which on Windows CI is an 8.3 short path (`C:\Users\RUNNER~1\...`) that
@@ -64,7 +69,7 @@ suite('SessionPermissionManager', () => {
 		outsideDir = realpathSync(mkdtempSync(join(baseTmp, 'sesperm-out-')));
 
 		manager = disposables.add(new AgentHostStateManager(new NullLogService()));
-		const configService = disposables.add(new AgentConfigurationService(manager, new NullLogService()));
+		configService = disposables.add(new AgentConfigurationService(manager, new NullLogService()));
 		permissions = disposables.add(new SessionPermissionManager(manager, configService, new NullLogService()));
 		await permissions.initialize();
 
@@ -142,5 +147,28 @@ suite('SessionPermissionManager', () => {
 			sessionUri,
 		);
 		assert.deepStrictEqual([inside, outside], [ToolCallConfirmationReason.NotNeeded, undefined]);
+	});
+
+	test('auto-approves shell commands in default permission mode when terminal auto-approve is enabled', async () => {
+		const result = await permissions.getAutoApproval(shellEvent('echo hello'), sessionUri);
+		assert.strictEqual(result, ToolCallConfirmationReason.NotNeeded);
+	});
+
+	test('requires confirmation for shell commands in default permission mode when terminal auto-approve is disabled', async () => {
+		configService.updateRootConfig({ [AgentHostTerminalAutoApproveEnabledConfigKey]: false });
+
+		const result = await permissions.getAutoApproval(shellEvent('echo hello'), sessionUri);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('does not affect session bypass permission mode when terminal auto-approve is disabled', async () => {
+		configService.updateRootConfig({ [AgentHostTerminalAutoApproveEnabledConfigKey]: false });
+		manager.setSessionConfig(sessionUri, {
+			schema: platformSessionSchema.toProtocol(),
+			values: { [SessionConfigKey.AutoApprove]: 'autoApprove' },
+		});
+
+		const result = await permissions.getAutoApproval(shellEvent('echo hello'), sessionUri);
+		assert.strictEqual(result, ToolCallConfirmationReason.Setting);
 	});
 });


### PR DESCRIPTION
Part of: https://github.com/microsoft/vscode/issues/322112

- Add an Agent Host root-config key for `chat.tools.terminal.enableAutoApprove`.
- Forward terminal auto-approve enablement from local and remote Agent Host clients on connect and config changes.
- Gate Agent Host shell auto-approval on the forwarded setting in default permission mode.
- Preserve session bypass behavior: `SessionConfigKey.AutoApprove` still auto-approves shell requests even when terminal auto-approve is disabled.
- Add tests for root-config forwarding and default-vs-bypass shell permission behavior.

-----------------------------------------
Inspirations from:

- Root-config key naming and setting-ID forwarding follow the existing session-sync config pattern: [`AgentHostSessionSyncEnabledConfigKey`](https://github.com/microsoft/vscode/blob/d2892d5d78c807971730e3976d893c13b5224051/src/vs/platform/agentHost/common/agentHostSchema.ts#L391-L414).
- Remote Agent Host setting forwarding follows [`RemoteAgentHostProtocolClient._updateSessionSyncEnabled`](https://github.com/microsoft/vscode/blob/d2892d5d78c807971730e3976d893c13b5224051/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts#L1288-L1294).
- Local Agent Host setting forwarding follows [`LocalAgentHostServiceClient._updateSessionSyncEnabled`](https://github.com/microsoft/vscode/blob/d2892d5d78c807971730e3976d893c13b5224051/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts#L189-L195).
- Shell permission gating plugs into the existing default shell auto-approval path in [`SessionPermissionManager.getAutoApproval`](https://github.com/microsoft/vscode/blob/d2892d5d78c807971730e3976d893c13b5224051/src/vs/platform/agentHost/node/sessionPermissions.ts#L242-L282).
- Session bypass behavior is preserved according to [`SessionPermissionManager.isSessionAutoApproveEnabled`](https://github.com/microsoft/vscode/blob/d2892d5d78c807971730e3976d893c13b5224051/src/vs/platform/agentHost/node/sessionPermissions.ts#L291-L293).