### PR TITLE
Browser search enabled by default to match ExP

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/features/browserSearchFeatures.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/features/browserSearchFeatures.ts
@@ -7,7 +7,7 @@ import { localize } from '../../../../../nls.js';
 import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions, ConfigurationScope } from '../../../../../platform/configuration/common/configurationRegistry.js';
 import { workbenchConfigurationNodeBase } from '../../../../common/configuration.js';
-import { BROWSER_SEARCH_ENGINES, BROWSER_SEARCH_NONE, BrowserSearchEngineSettingId } from '../../common/browserSearch.js';
+import { BROWSER_SEARCH_ENGINES, BROWSER_SEARCH_NONE, BrowserSearchEngineId, BrowserSearchEngineSettingId } from '../../common/browserSearch.js';
 
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
 	...workbenchConfigurationNodeBase,
@@ -16,7 +16,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			type: 'string',
 			enum: [BROWSER_SEARCH_NONE, ...BROWSER_SEARCH_ENGINES.map(e => e.id)],
 			enumItemLabels: [localize('browser.search.engine.none', "None"), ...BROWSER_SEARCH_ENGINES.map(e => e.label)],
-			default: BROWSER_SEARCH_NONE,
+			default: BrowserSearchEngineId.Bing,
 			experiment: { mode: 'startup' },
 			markdownDescription: localize(
 				'browser.searchEngine',


### PR DESCRIPTION
ExP is already at 100%, so matching the code to the ExP