### PR TITLE
sessions: do not auto-open the side pane for existing sessions

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -238,15 +238,15 @@ All session-window contributions use `WindowVisibility.Sessions` to only appear 
 
 ## 10. Per-Session Layout State
 
-`LayoutController` (`contrib/layout/browser/sessionLayoutController.ts`) manages layout state as the user switches between sessions. All state is persisted to workspace storage so it survives restarts. This section is a summary — see **[LAYOUT_CONTROLLER.md](LAYOUT_CONTROLLER.md)** for the full specification (switch trigger, multi-session handling, auto-reveal, persistence, and invariants).
+`LayoutController` (`contrib/layout/browser/sessionLayoutController.ts`) manages layout state as the user switches between sessions. All state is persisted to workspace storage so it survives restarts. This section is a summary — see **[LAYOUT_CONTROLLER.md](LAYOUT_CONTROLLER.md)** for the full specification (switch trigger, multi-session handling, persistence, and invariants).
 
 ### Auxiliary Bar
 
 Each session independently remembers whether the auxiliary bar is visible and which view container is active. When switching to a session, the saved state is restored. When switching away, the current state is captured.
 
-**Auto-reveal on changes:** When a chat turn completes and new file changes appeared (changes count was zero when the turn was submitted, non-zero when it ends), the auxiliary bar is automatically revealed to show the Changes view. This lets the user see what the agent modified without manual intervention. On mobile the auto-reveal is suppressed to avoid disruptive layout shifts.
+**The side pane never opens automatically for existing sessions.** It is only shown when the user opens it; the controller never auto-reveals it on session switch or when a chat turn produces new file changes. A session with no explicit "visible" choice (including one that just converted from the new-session view to an existing session) keeps the side pane hidden until the user opens it.
 
-**Default view on new sessions:** An untitled session always opens the Files view. A session with a workspace but no changes defaults to the Files view; once changes exist it defaults to the Changes view.
+**Default view on new sessions:** An untitled (new-session) session opens the side pane by default — the Files view, or the Changes view once it has changes — and that choice sticks until the user changes it. When the session converts to an existing session the side pane is closed.
 
 ### Panel
 

--- a/src/vs/sessions/LAYOUT_CONTROLLER.md
+++ b/src/vs/sessions/LAYOUT_CONTROLLER.md
@@ -41,8 +41,8 @@ When more than one session is visible at once (the Sessions Part grid shows seve
 **all per-session sync is suppressed**:
 
 - The aux-bar / panel sync autoruns bail out early (`multipleSessionsVisibleObs`).
-- A dedicated autorun **clears** `_viewStateBySession`, `_panelVisibilityBySession`, and
-  `_pendingTurnStateByResource` for every visible session.
+- A dedicated autorun **clears** `_viewStateBySession` and `_panelVisibilityBySession` for every
+  visible session.
 
 This guarantees that after collapsing back to a single session the **default visibility logic**
 (§3.2) runs again instead of restoring stale single-session state. Editor working sets are *not*
@@ -70,29 +70,27 @@ strict priority order:
 2. **Untitled session (new-session view)** → all untitled sessions share a single state object
    (`_newSessionViewState`, persisted to workspace storage under `sessions.newSessionViewState`): if
    the user explicitly hid the aux bar on a new session it stays hidden (across switches *and*
-   reloads); otherwise the default container (§3.2 step 4) is shown. This is what makes hiding the aux
-   bar on one new session "stick" when the next new session is opened (each untitled session has a
-   distinct resource, so per-resource saved state can't carry the choice).
-3. **Saved state exists**:
-   - was **hidden** → hide the aux bar and stop.
-   - was visible with an active container → reopen that container and stop.
-4. **No saved state (first visit) — defaults** (`_openDefaultAuxiliaryBarContainer`):
+   reloads); otherwise the default container (§3.2 step 4) is shown. This is the **only** place the
+   side pane is opened automatically — a new session opens it by default so the user starts with
+   Files/Changes visible.
+3. **Titled session** (existing session): the side pane is **never auto-opened**.
+   - saved state is **hidden** *or* there is **no saved state** → hide the aux bar and stop. A
+     session with no explicit "visible" choice — including one that just converted from the
+     new-session view to an existing session — stays closed until the user opens it.
+   - saved state is **visible** with a still-pinned active container → reopen that container.
+   - saved state is **visible** but its container is gone → fall back to the default container
+     (§3.2 step 4).
+4. **Default container** (`_openDefaultAuxiliaryBarContainer`), used only when the side pane is being
+   shown (untitled default, or restoring a session the user explicitly left visible):
    - session **has changes** → open the Changes view (`CHANGES_VIEW_ID`).
    - otherwise → open the Files container.
 
-### 3.3 Auto-reveal on new changes
+### 3.3 No auto-reveal on changes
 
-A separate autorun watches for turn completion (also skipped on mobile web). When a chat request
-is submitted (`onDidSubmitRequest`), the controller records `IPendingTurnState`
-(`hadChangesBeforeSend`, `submittedAt`) for the session. When that session's `lastTurnEnd`
-advances past `submittedAt`:
-
-- if there were **no** changes before the turn but there **are** changes now, the aux bar is
-  revealed (`setPartHidden(false, AUXILIARYBAR_PART)`) and the session's saved view state is
-  cleared so it stays visible on the next switch.
-
-This only applies to the single-visible-session case; the pending state is dropped when multiple
-sessions are visible.
+The side pane is **not** revealed when a chat turn produces new file changes. The controller does not
+track pending turns; the only automatic opening is the new-session default (§3.2 step 2). Once a
+session is an existing session the side pane stays in whatever state the user left it — they must open
+it themselves to see changes.
 
 ### 3.4 Live visibility tracking
 
@@ -101,8 +99,8 @@ Aux-bar visibility is also tracked **live** (not only on session switch) via an
 multiple sessions are visible). For a titled active session it re-runs `_captureViewState`; for an
 untitled active session it updates the shared `_newSessionViewState` (§3.2 step
 2). Without this, the sync autorun — which re-evaluates whenever the session's changes/workspace
-state updates, not just on switch — would find no saved state and re-run the default visibility logic
-(§3.2), re-revealing a side bar the user had just hidden.
+state updates, not just on switch — would, for an untitled session, find no shared state and re-open
+the side pane the user had just hidden.
 
 ### 3.5 Editor reveal on session switch
 
@@ -192,5 +190,7 @@ back to the default-visible logic (§3.2) on the next reload.)
 - **Observables, not events**, drive all session-switch logic.
 - **Multiple visible sessions** disable per-session view/panel sync and clear that state (working
   sets preserved).
-- **Default visibility** (§3.2 step 4) only applies when a session has no saved aux-bar state.
+- **The side pane is never auto-opened for existing sessions** — it opens automatically only as the
+  new-session default (§3.2 step 2). An existing session with no explicit "visible" choice stays
+  closed until the user opens it.
 - Working-set save/apply waits for **workspace folders** to catch up with the active session.

--- a/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
@@ -15,7 +15,6 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { observableConfigValue } from '../../../../platform/observable/common/platformObservableUtils.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
-import { IChatService } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { ViewContainerLocation } from '../../../../workbench/common/views.js';
 import { IEditorGroupsService, IEditorWorkingSet } from '../../../../workbench/services/editor/common/editorGroupsService.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
@@ -28,11 +27,6 @@ import { ISessionsService } from '../../../services/sessions/browser/sessionsSer
 import { SessionStatus } from '../../../services/sessions/common/session.js';
 import { CHANGES_VIEW_ID } from '../../changes/common/changes.js';
 import { SESSIONS_FILES_CONTAINER_ID } from '../../files/browser/files.contribution.js';
-
-interface IPendingTurnState {
-	readonly hadChangesBeforeSend: boolean;
-	readonly submittedAt: number;
-}
 
 /**
  * Per-session view state: auxiliary bar visibility and active view container.
@@ -71,7 +65,6 @@ export class LayoutController extends Disposable {
 
 	static readonly ID = 'workbench.contrib.sessionsLayoutController';
 
-	private readonly _pendingTurnStateByResource = new ResourceMap<IPendingTurnState>();
 	private readonly _panelVisibilityBySession = new ResourceMap<boolean>();
 	private readonly _viewStateBySession: ResourceMap<ISessionViewState>;
 	private readonly _workingSets: ResourceMap<IEditorWorkingSet>;
@@ -89,7 +82,6 @@ export class LayoutController extends Disposable {
 		@IAgentWorkbenchLayoutService private readonly _layoutService: IAgentWorkbenchLayoutService,
 		@ISessionsManagementService private readonly _sessionManagementService: ISessionsManagementService,
 		@ISessionsService private readonly _sessionsService: ISessionsService,
-		@IChatService private readonly _chatService: IChatService,
 		@IViewsService private readonly _viewsService: IViewsService,
 		@IPaneCompositePartService private readonly _paneCompositePartService: IPaneCompositePartService,
 		@IStorageService private readonly _storageService: IStorageService,
@@ -153,7 +145,6 @@ export class LayoutController extends Disposable {
 				}
 				this._viewStateBySession.delete(session.resource);
 				this._panelVisibilityBySession.delete(session.resource);
-				this._pendingTurnStateByResource.delete(session.resource);
 			}
 		}));
 
@@ -192,53 +183,6 @@ export class LayoutController extends Disposable {
 			}
 			this._syncPanelVisibility(activeSessionResource);
 		}));
-
-		// When a turn is completed, check if there were changes before the turn and
-		// if there are changes after the turn. If there were no changes before the
-		// turn and there are changes after the turn, show the auxiliary bar.
-		// Skip on mobile to avoid disruptive auto-expand on narrow viewports.
-		if (!(isWeb && isMobile)) {
-			this._register(autorun((reader) => {
-				const activeSession = this._sessionsService.activeSession.read(reader);
-				const activeSessionHasChanges = activeSessionHasChangesObs.read(reader);
-				if (!activeSession) {
-					return;
-				}
-
-				const pendingTurnState = this._pendingTurnStateByResource.get(activeSession.resource);
-				if (!pendingTurnState) {
-					return;
-				}
-
-				if (multipleSessionsVisibleObs.read(reader)) {
-					return;
-				}
-
-				const lastTurnEnd = activeSession.lastTurnEnd.read(reader);
-				const turnCompleted = !!lastTurnEnd && lastTurnEnd.getTime() >= pendingTurnState.submittedAt;
-				if (!turnCompleted) {
-					return;
-				}
-
-				if (!pendingTurnState.hadChangesBeforeSend && activeSessionHasChanges) {
-					this._layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
-					// Clear saved view state so the aux bar stays visible on next switch
-					this._viewStateBySession.delete(activeSession.resource);
-				}
-
-				this._pendingTurnStateByResource.delete(activeSession.resource);
-			}));
-
-			this._register(this._chatService.onDidSubmitRequest(({ chatSessionResource }) => {
-				if (multipleSessionsVisibleObs.get()) {
-					return;
-				}
-				this._pendingTurnStateByResource.set(chatSessionResource, {
-					hadChangesBeforeSend: activeSessionHasChangesObs.get(),
-					submittedAt: Date.now(),
-				});
-			}));
-		}
 
 		// Track panel visibility changes by the user
 		this._register(this._layoutService.onDidChangePartVisibility(e => {
@@ -384,23 +328,19 @@ export class LayoutController extends Disposable {
 
 		const savedState = this._viewStateBySession.get(sessionResource);
 
-		// Honor an explicitly hidden auxiliary bar for this session.
-		if (savedState && !savedState.auxiliaryBarVisible) {
+		// Existing sessions are never auto-opened: hide unless explicitly left visible.
+		if (!savedState || !savedState.auxiliaryBarVisible) {
 			this._layoutService.setPartHidden(true, Parts.AUXILIARYBAR_PART);
 			return;
 		}
 
-		// Restore the user's last explicit auxiliary bar choice (Files, Changes or
-		// any other pane), but only if that pane is still pinned. If it was hidden /
-		// unpinned (e.g. the user hid the Files tab) we skip it and fall through to
-		// the default below rather than force-opening a hidden pane.
-		const savedContainerId = savedState?.auxiliaryBarActiveViewContainerId;
+		// Restore the user's last explicit choice, but only if that pane is still pinned.
+		const savedContainerId = savedState.auxiliaryBarActiveViewContainerId;
 		if (savedContainerId && this._isAuxiliaryBarContainerPinned(savedContainerId)) {
 			this._viewsService.openViewContainer(savedContainerId, false);
 			return;
 		}
 
-		// Default for a session without a saved choice.
 		this._openDefaultAuxiliaryBarContainer(hasChanges);
 	}
 

--- a/src/vs/sessions/contrib/layout/test/browser/sessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/sessionLayoutController.test.ts
@@ -16,7 +16,6 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { IStorageService, StorageScope, WillSaveStateReason } from '../../../../../platform/storage/common/storage.js';
 import { IWorkspace, IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
-import { IChatService } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { ViewContainerLocation } from '../../../../../workbench/common/views.js';
 import { IEditorGroupsService, IEditorWorkingSet } from '../../../../../workbench/services/editor/common/editorGroupsService.js';
 import { IEditorService } from '../../../../../workbench/services/editor/common/editorService.js';
@@ -106,7 +105,6 @@ suite('LayoutController', () => {
 	let activeSessionObs: ReturnType<typeof observableValue<IActiveSession | undefined>>;
 	let onDidChangeSessions: Emitter<ISessionsChangeEvent>;
 	let onDidChangePartVisibility: Emitter<IPartVisibilityChangeEvent>;
-	let onDidSubmitRequest: Emitter<{ chatSessionResource: URI }>;
 	let storageService: TestStorageService;
 	let partVisibility: Map<Parts, boolean>;
 	let openedViewContainers: string[];
@@ -153,11 +151,6 @@ suite('LayoutController', () => {
 		instaService.stub(ISessionsService, new class extends mock<ISessionsService>() {
 			override readonly activeSession = activeSessionObs;
 			override readonly visibleSessions = constObservable([]);
-		});
-
-		onDidSubmitRequest = store.add(new Emitter<{ chatSessionResource: URI }>());
-		instaService.stub(IChatService, new class extends mock<IChatService>() {
-			override readonly onDidSubmitRequest = onDidSubmitRequest.event;
 		});
 
 		partVisibility = new Map<Parts, boolean>([
@@ -241,22 +234,30 @@ suite('LayoutController', () => {
 
 	// --- Auxiliary bar view state ---
 
-	test('shows files view for session with workspace and no changes', () => {
+	test('hides side pane for existing session without saved state', () => {
 		createLayoutController();
 		const session = makeSession(URI.parse('session:1'));
 		activeSessionObs.set(session, undefined);
 
-		assert.ok(openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID));
+		assert.ok(
+			setPartHiddenCalls.some(c => c.part === Parts.AUXILIARYBAR_PART && c.hidden === true),
+			'side pane should be hidden'
+		);
+		assert.ok(!openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID), 'should not auto-open the Files view');
 	});
 
-	test('shows changes view for session with changes', () => {
+	test('does not auto-open side pane for existing session with changes', () => {
 		createLayoutController();
 		const session = makeSession(URI.parse('session:1'), {
 			changes: [makeChange('/file.ts')],
 		});
 		activeSessionObs.set(session, undefined);
 
-		assert.ok(openedViews.includes(CHANGES_VIEW_ID));
+		assert.ok(
+			setPartHiddenCalls.some(c => c.part === Parts.AUXILIARYBAR_PART && c.hidden === true),
+			'side pane should be hidden'
+		);
+		assert.ok(!openedViews.includes(CHANGES_VIEW_ID), 'should not auto-open the Changes view');
 	});
 
 	test('shows files view for untitled session', () => {
@@ -265,6 +266,22 @@ suite('LayoutController', () => {
 		activeSessionObs.set(session, undefined);
 
 		assert.ok(openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID));
+	});
+
+	test('closes the side pane when an untitled session converts to an existing session', () => {
+		createLayoutController();
+		const session = makeSession(URI.parse('session:1'), { status: SessionStatus.Untitled });
+		activeSessionObs.set(session, undefined);
+
+		assert.ok(openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID));
+
+		setPartHiddenCalls = [];
+		(session.status as ISettableObservable<SessionStatus>).set(SessionStatus.InProgress, undefined);
+
+		assert.ok(
+			setPartHiddenCalls.some(c => c.part === Parts.AUXILIARYBAR_PART && c.hidden === true),
+			'side pane should be closed after the session converts to an existing session'
+		);
 	});
 
 	test('remembers hidden aux bar across new (untitled) sessions', () => {
@@ -391,9 +408,10 @@ suite('LayoutController', () => {
 		const session2 = makeSession(URI.parse('session:2'));
 
 		activeSessionObs.set(session1, undefined);
-		// The active container must also be pinned for it to be restored.
 		activePaneCompositeId = 'some.custom.view';
 		pinnedAuxiliaryBarContainerIds = [...pinnedAuxiliaryBarContainerIds, 'some.custom.view'];
+		partVisibility.set(Parts.AUXILIARYBAR_PART, true);
+		onDidChangePartVisibility.fire({ partId: Parts.AUXILIARYBAR_PART, visible: true });
 
 		activeSessionObs.set(session2, undefined);
 
@@ -411,10 +429,11 @@ suite('LayoutController', () => {
 		const session1 = makeSession(URI.parse('session:1'), { changes: [makeChange('/file.ts')] });
 		const session2 = makeSession(URI.parse('session:2'));
 
-		// The user explicitly selects the (pinned) Files pane for session 1.
+		// The user explicitly opens the (pinned) Files pane for session 1.
 		activeSessionObs.set(session1, undefined);
 		activePaneCompositeId = SESSIONS_FILES_CONTAINER_ID;
-
+		partVisibility.set(Parts.AUXILIARYBAR_PART, true);
+		onDidChangePartVisibility.fire({ partId: Parts.AUXILIARYBAR_PART, visible: true });
 		activeSessionObs.set(session2, undefined);
 
 		openedViewContainers = [];
@@ -446,7 +465,7 @@ suite('LayoutController', () => {
 		createLayoutController();
 		// User has hidden / unpinned the Files pane.
 		pinnedAuxiliaryBarContainerIds = [CHANGES_VIEW_CONTAINER_ID];
-		const session = makeSession(URI.parse('session:1'));
+		const session = makeSession(URI.parse('session:1'), { status: SessionStatus.Untitled });
 
 		activeSessionObs.set(session, undefined);
 
@@ -552,55 +571,6 @@ suite('LayoutController', () => {
 		assert.strictEqual(panelCall!.hidden, false, 'panel should be visible for session 1');
 	});
 
-	// --- Turn completion ---
-
-	test('shows aux bar when turn completes with new changes', () => {
-		createLayoutController();
-		const session = makeSession(URI.parse('session:1'));
-		activeSessionObs.set(session, undefined);
-
-		onDidSubmitRequest.fire({ chatSessionResource: session.resource });
-
-		(session.changes as ISettableObservable<readonly ISessionFileChange[]>).set([makeChange('/file.ts')], undefined);
-		(session.lastTurnEnd as ISettableObservable<Date | undefined>).set(new Date(), undefined);
-
-		assert.ok(
-			setPartHiddenCalls.some(c => c.part === Parts.AUXILIARYBAR_PART && c.hidden === false),
-			'aux bar should be shown after turn with new changes'
-		);
-	});
-
-	test('clears saved state when turn produces new changes', () => {
-		createLayoutController();
-		const session1 = makeSession(URI.parse('session:1'));
-		const session2 = makeSession(URI.parse('session:2'));
-
-		activeSessionObs.set(session1, undefined);
-		partVisibility.set(Parts.AUXILIARYBAR_PART, false);
-
-		activeSessionObs.set(session2, undefined);
-		activeSessionObs.set(session1, undefined);
-
-		onDidSubmitRequest.fire({ chatSessionResource: session1.resource });
-		(session1.changes as ISettableObservable<readonly ISessionFileChange[]>).set([makeChange('/new.ts')], undefined);
-		(session1.lastTurnEnd as ISettableObservable<Date | undefined>).set(new Date(), undefined);
-
-		activeSessionObs.set(session2, undefined);
-
-		setPartHiddenCalls = [];
-		openedViews = [];
-		activeSessionObs.set(session1, undefined);
-
-		assert.ok(
-			openedViews.includes(CHANGES_VIEW_ID),
-			'should show changes view since saved state was cleared after turn with new changes'
-		);
-		assert.ok(
-			!setPartHiddenCalls.some(c => c.part === Parts.AUXILIARYBAR_PART && c.hidden === true),
-			'aux bar should not be hidden since saved state was cleared'
-		);
-	});
-
 	// --- Storage persistence ---
 
 	test('persists state to sessions.layoutState key', () => {
@@ -621,7 +591,7 @@ suite('LayoutController', () => {
 		const session1Entry = parsed.find((e: any) => e.sessionResource === 'session:1');
 		assert.ok(session1Entry, 'session 1 entry should exist');
 		assert.deepStrictEqual(session1Entry.viewState, {
-			auxiliaryBarVisible: true,
+			auxiliaryBarVisible: false,
 			auxiliaryBarActiveViewContainerId: 'custom.view',
 		});
 	});
@@ -714,9 +684,6 @@ suite('LayoutController', () => {
 		instaService.stub(ISessionsService, new class extends mock<ISessionsService>() {
 			override readonly activeSession = activeSession;
 			override readonly visibleSessions = constObservable([]);
-		});
-		instaService.stub(IChatService, new class extends mock<IChatService>() {
-			override readonly onDidSubmitRequest = Event.None;
 		});
 		instaService.stub(IWorkbenchLayoutService, new class extends mock<IWorkbenchLayoutService>() {
 			override isVisible() { return true; }


### PR DESCRIPTION
## What

Changes the Agents window `LayoutController` so the auxiliary bar (side pane) is **no longer opened automatically for existing sessions**. It now only opens when the user opens it.

- **New (untitled) sessions** still open the side pane by default (Files, or Changes once changes exist), and that choice sticks until the user changes it.
- When a new session **converts to an existing session**, the side pane is closed.
- An existing session with no explicit "visible" choice stays closed until the user opens it; once opened, its choice is remembered and restored on switch.

## Why

The previous behavior auto-revealed the side pane on session switch (default Files/Changes) and again whenever a chat turn produced new file changes. This was disruptive — the pane kept reappearing after the user closed it. Now the side pane only auto-opens as the new-session default; everything else is user-driven.

## Changes

- `contrib/layout/browser/sessionLayoutController.ts`
  - `_syncAuxiliaryBarVisibility`: existing sessions are hidden unless explicitly left visible (no default-open).
  - Removed the auto-reveal-on-new-changes flow: the `onDidSubmitRequest` listener, the turn-completion `autorun`, `IPendingTurnState`, `_pendingTurnStateByResource`, and the now-unused `IChatService` dependency/import.
- Updated unit tests in `contrib/layout/test/browser/sessionLayoutController.test.ts` to cover the new behavior (existing sessions hidden, untitled→existing conversion closes the pane, explicit user-open is remembered) and removed the obsolete turn-completion tests.
- Synced the specs `LAYOUT.md` (§10) and `LAYOUT_CONTROLLER.md` (§2, §3.2, §3.3, §3.4, §7).

## Notes for reviewers

`tsgo` typecheck and the layers checker pass. The behavior is unchanged on mobile web (already skipped there).