### PR TITLE
sessions: add 'Run VS Code (Web)' agents window task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -476,6 +476,35 @@
 			}
 		},
 		{
+			"label": "Run VS Code (Web)",
+			"detail": "Run the Agents window as a web client.",
+			"type": "shell",
+			"command": "./scripts/code-server.sh",
+			"windows": {
+				"command": ".\\scripts\\code-server.bat"
+			},
+			"args": [
+				"--connection-token",
+				"dev-token",
+				"--port",
+				"8080"
+			],
+			"inAgents": true,
+			"isBackground": true,
+			"problemMatcher": {
+				"pattern": {
+					"regexp": ""
+				},
+				"background": {
+					"beginsPattern": ".*node .*",
+					"endsPattern": "Web UI available at .*"
+				}
+			},
+			"presentation": {
+				"reveal": "always"
+			}
+		},
+		{
 			"type": "npm",
 			"script": "eslint",
 			"problemMatcher": {


### PR DESCRIPTION
## What

Adds a new **"Run VS Code (Web)"** task to `.vscode/tasks.json` that surfaces in the Agents window (`inAgents: true`).

The task runs `./scripts/code-server.sh` (`.\scripts\code-server.bat` on Windows) with `--connection-token dev-token --port 8080`, starting the web client. It is a background task whose problem matcher completes once the server prints `Web UI available at …`, and it reveals the terminal so the printed localhost link is clickable.

## Why

Provides a one-click way to launch the Agents window as a web client from the Agents window run commands.

## Notes for reviewers

- JSON-only change; no source changes.
- `inAgents: true` is what surfaces the task in the Agents window run commands.