### PR TITLE
Treat sandbox missing file errors as access failures

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sandboxOutputAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sandboxOutputAnalyzer.ts
@@ -55,6 +55,7 @@ export class SandboxOutputAnalyzer extends Disposable implements IOutputAnalyzer
 			: '- Sandboxed execution with unrestricted network access is disabled by chat.agent.sandbox.retryWithAllowNetworkRequests. Do not set requestAllowNetwork=true.\n- If the command cannot be made to work by updating sandbox rules, immediately retry it with requestUnsandboxedExecution=true and provide requestUnsandboxedExecutionReason. Do NOT ask the user - setting this flag automatically shows a confirmation prompt to the user.';
 		return `${prefix}
 - If it would be reasonable to extend the sandbox rules, work with the user to update allowWrite for file system access problems in ${fileSystemSetting}, or to add required domains to ${AgentNetworkDomainSettingId.AllowedNetworkDomains}.
+- If the output contains 'No such file or directory', treat it as a sandbox access error and immediately retry the command with requestUnsandboxedExecution=true and provide requestUnsandboxedExecutionReason.
 ${networkRecovery}
 
 Here is the output of the command:\n`;
@@ -79,7 +80,7 @@ Here is the output of the command:\n`;
  */
 export function outputLooksSandboxBlocked(output: string): boolean {
 	const normalized = output.replace(/\n/g, ' ');
-	return /Operation not permitted|Permission denied|Read-only file system|sandbox-exec|bwrap|sandbox_violation/i.test(normalized);
+	return /Operation not permitted|Permission denied|Read-only file system|sandbox-exec|bwrap|sandbox_violation|No such file or directory/i.test(normalized);
 }
 
 /**

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sandboxOutputAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sandboxOutputAnalyzer.test.ts
@@ -57,6 +57,19 @@ suite('SandboxOutputAnalyzer', () => {
 		ok(guidance?.includes('chat.agent.sandbox.retryWithAllowNetworkRequests'));
 		ok(guidance?.includes('Do not set requestAllowNetwork=true'));
 	});
+
+	test('recommends unsandboxed execution for sandboxed missing file failures', async () => {
+		const guidance = await analyzer.analyze({
+			exitCode: 1,
+			exitResult: '/bin/bash: /tmp/test.txt: No such file or directory',
+			commandLine: 'cat /tmp/test.txt',
+			isSandboxWrapped: true,
+		});
+
+		ok(guidance?.includes('No such file or directory'));
+		ok(guidance?.includes('treat it as a sandbox access error'));
+		ok(guidance?.includes('requestUnsandboxedExecution=true'));
+	});
 });
 
 suite('outputLooksSandboxBlocked', () => {
@@ -69,6 +82,7 @@ suite('outputLooksSandboxBlocked', () => {
 		['sandbox-exec reference', 'sandbox-exec: some error occurred'],
 		['bwrap reference', 'bwrap: error setting up namespace'],
 		['sandbox_violation', 'sandbox_violation: deny(1) file-write-create /tmp/foo'],
+		['missing file in sandbox', 'Error: ENOENT: no such file or directory'],
 		['case insensitive', '/bin/bash: OPERATION NOT PERMITTED'],
 		['wrapped across lines', '/bin/bash: Operation not\npermitted'],
 	];
@@ -82,7 +96,7 @@ suite('outputLooksSandboxBlocked', () => {
 	const negatives: [string, string][] = [
 		['normal output', 'hello world'],
 		['empty output', ''],
-		['unrelated error', 'Error: ENOENT: no such file or directory'],
+		['unrelated error', 'Error: invalid configuration'],
 	];
 
 	for (const [label, output] of negatives) {


### PR DESCRIPTION
fixes #322365

## Summary
- Explicitly instruct the model to treat `No such file or directory` output from sandboxed commands as a sandbox access error.
- sandbox runtime package returns this error when denied access while reading files using commands like `cat ~/test.txt`. Model doesnt retry as the message clearly states no file found.
- Direct the model to retry those commands with `requestUnsandboxedExecution=true` and provide `requestUnsandboxedExecutionReason`.

