### PR TITLE
Hide agent host tip if user manual selects via picker

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1604,6 +1604,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		return this.options.sessionTypePickerDelegate?.getActiveSessionProvider?.();
 	}
 
+	private getNotificationSessionType(): string | undefined {
+		return this._pendingDelegationTarget ?? this._currentSessionType ?? this.getCurrentSessionType();
+	}
+
 	private isModelValidForCurrentSession(model: ILanguageModelChatMetadataAndIdentifier): boolean {
 		return isModelValidForSession(model, this.getAllMergedModels(), this.getCurrentSessionType());
 	}
@@ -2446,6 +2450,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this.updateWidgetLockStateFromSessionType(provider);
 		this.updateAgentSessionTypeContextKey();
 		this.refreshChatSessionPickers();
+		this._notificationWidget.value?.rerender();
 	}
 
 	/**
@@ -2459,7 +2464,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			// this fallback, `_currentSessionType` stays undefined until
 			// the user creates a session and `sessionTypes`-gated
 			// notifications never render.
-			this._notificationWidget.value = this.instantiationService.createInstance(ChatInputNotificationWidget, () => this._currentSessionType ?? this.getCurrentSessionType());
+			this._notificationWidget.value = this.instantiationService.createInstance(ChatInputNotificationWidget, () => this.getNotificationSessionType());
 			this.chatInputNotificationContainer.appendChild(this._notificationWidget.value.domNode);
 		}
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputNotificationWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatInputNotificationWidget.test.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event } from '../../../../../../../base/common/event.js';
+import { IDisposable } from '../../../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
+import { ICommandEvent, ICommandService } from '../../../../../../../platform/commands/common/commands.js';
+import { SyncDescriptor } from '../../../../../../../platform/instantiation/common/descriptors.js';
+import { getSingletonServiceDescriptors } from '../../../../../../../platform/instantiation/common/extensions.js';
+import { ServiceCollection } from '../../../../../../../platform/instantiation/common/serviceCollection.js';
+import { ITelemetryService } from '../../../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../../../platform/telemetry/common/telemetryUtils.js';
+import { workbenchInstantiationService } from '../../../../../../test/browser/workbenchTestServices.js';
+import { ChatInputNotificationSeverity, IChatInputNotificationService } from '../../../../browser/widget/input/chatInputNotificationService.js';
+import { ChatInputNotificationWidget } from '../../../../browser/widget/input/chatInputNotificationWidget.js';
+import { localChatSessionType, SessionType } from '../../../../common/chatSessionsService.js';
+
+class TestCommandService implements ICommandService {
+	declare readonly _serviceBrand: undefined;
+
+	readonly onWillExecuteCommand: Event<ICommandEvent> = Event.None;
+	readonly onDidExecuteCommand: Event<ICommandEvent> = Event.None;
+
+	async executeCommand(): Promise<undefined> {
+		return undefined;
+	}
+}
+
+suite('ChatInputNotificationWidget', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createNotificationService(): IChatInputNotificationService {
+		const descriptor = getSingletonServiceDescriptors().find(([id]) => id === IChatInputNotificationService)?.[1];
+		assert.ok(descriptor);
+		const instantiationService = store.add(workbenchInstantiationService(undefined, store));
+		instantiationService.stub(ICommandService, new TestCommandService());
+		instantiationService.stub(ITelemetryService, NullTelemetryService);
+
+		const childInstantiationService = store.add(instantiationService.createChild(new ServiceCollection(
+			[IChatInputNotificationService, new SyncDescriptor(descriptor.ctor, descriptor.staticArguments)]
+		)));
+		const notificationService = childInstantiationService.get(IChatInputNotificationService);
+		store.add(notificationService as IChatInputNotificationService & IDisposable);
+		return notificationService;
+	}
+
+	test('rerender applies session type filter when pending delegation target changes', () => {
+		let currentSessionType = localChatSessionType;
+		const notificationService = createNotificationService();
+		const instantiationService = store.add(workbenchInstantiationService(undefined, store));
+		instantiationService.stub(IChatInputNotificationService, notificationService);
+		instantiationService.stub(ICommandService, new TestCommandService());
+		instantiationService.stub(ITelemetryService, NullTelemetryService);
+
+		const widget = store.add(instantiationService.createInstance(ChatInputNotificationWidget, () => currentSessionType));
+
+		notificationService.setNotification({
+			id: 'local-only',
+			severity: ChatInputNotificationSeverity.Info,
+			message: 'Local only',
+			description: undefined,
+			actions: [],
+			dismissible: false,
+			autoDismissOnMessage: false,
+			sessionTypes: [localChatSessionType],
+		});
+
+		assert.strictEqual(widget.domNode.querySelector('.chat-input-notification')?.textContent, 'Local only');
+
+		currentSessionType = SessionType.AgentHostCopilot;
+		widget.rerender();
+		assert.strictEqual(widget.domNode.querySelector('.chat-input-notification'), null);
+
+		currentSessionType = localChatSessionType;
+		widget.rerender();
+		assert.strictEqual(widget.domNode.querySelector('.chat-input-notification')?.textContent, 'Local only');
+	});
+});


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/322453

- Make chat input notifications evaluate session-type filters against the pending delegation target before the backing session resource.
- Rerender input notifications when the user changes the pending delegation target from the session picker.
- Preserve model-pool validation semantics by leaving `getCurrentSessionType()` based on the real session resource.
- Add a browser regression test covering local-only notification visibility when switching to and from Agent Host.

-----------------------------------------
Inspirations from:

- The distinction between real session resource and picker/delegate state comes from [`ChatInputPart.getCurrentSessionType`](https://github.com/microsoft/vscode/blob/33a3fa9cef60753ed1cee0ba3fabd4178049d223/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts#L1588-L1605).
- The explicit rerender hook for session-type-gated notifications comes from [`ChatInputNotificationWidget.rerender`](https://github.com/microsoft/vscode/blob/33a3fa9cef60753ed1cee0ba3fabd4178049d223/src/vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationWidget.ts#L86-L113).
- The local-only tip behavior comes from [`LocalAgentDisabledInputTipContribution`](https://github.com/microsoft/vscode/blob/33a3fa9cef60753ed1cee0ba3fabd4178049d223/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentDisabledInputTipContribution.ts#L100-L116).