### PR TITLE
Rename "GitHub Copilot Chat" extension to "GitHub Copilot"

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-chat",
-  "displayName": "GitHub Copilot Chat",
+  "displayName": "GitHub Copilot",
   "description": "AI chat features powered by Copilot",
   "version": "0.55.0",
   "build": "1",


### PR DESCRIPTION
Renames the `copilot-chat` extension's `displayName` from "GitHub Copilot Chat" to "GitHub Copilot".

## Changes
- `extensions/copilot/package.json`: update `displayName` to "GitHub Copilot".

## Notes
This only changes the extension display name shown in the Extensions view and Marketplace. The following were intentionally left unchanged since they are not the extension name:
- The settings category title in `package.json` ("GitHub Copilot Chat").
- The contextual message strings in `package.nls.json` that refer to "GitHub Copilot Chat".