### PR TITLE
sessions: gate titlebar new-session button behind experiment + add telemetry

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -83,7 +83,7 @@ The titlebar is a standalone implementation (`TitlebarPart`) — not extending `
 
 | Section | Menu ID | Content |
 |---------|---------|---------|
-| Left | `Menus.TitleBarLeftLayout` | Toggle sidebar, new session (when sidebar hidden), agent host filter |
+| Left | `Menus.TitleBarLeftLayout` | Toggle sidebar, new session (when sidebar hidden, A/B experiment), agent host filter |
 | Center | `Menus.CommandCenter` | Session picker widget (plus `Menus.TitleBarSessionMenu` for active-session actions) |
 | Right | `Menus.TitleBarRightLayout` | Remote connections, run script (split button), Open Terminal/VS Code, toggle auxiliary bar, account widget |
 

--- a/src/vs/sessions/browser/parts/media/titlebarpart.css
+++ b/src/vs/sessions/browser/parts/media/titlebarpart.css
@@ -170,6 +170,11 @@
 	display: flex;
 }
 
+/* Give the left toolbar's actions breathing room from one another and the titlebar edges. */
+.monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-left > .left-toolbar-container .monaco-action-bar .actions-container {
+	gap: 4px;
+}
+
 /* Remove the titlebar shadow in agent sessions */
 .agent-sessions-workbench.monaco-workbench .part.titlebar {
 	box-shadow: none;

--- a/src/vs/sessions/browser/parts/media/titlebarpart.css
+++ b/src/vs/sessions/browser/parts/media/titlebarpart.css
@@ -170,7 +170,7 @@
 	display: flex;
 }
 
-/* Give the left toolbar's actions breathing room from one another and the titlebar edges. */
+/* Spacing between the left toolbar's actions. */
 .monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-left > .left-toolbar-container .monaco-action-bar .actions-container {
 	gap: 4px;
 }

--- a/src/vs/sessions/common/contextkeys.ts
+++ b/src/vs/sessions/common/contextkeys.ts
@@ -51,6 +51,12 @@ export const SessionsWelcomeVisibleContext = new RawContextKey<boolean>('session
 
 //#endregion
 
+//#region < --- Experiments --- >
+
+export const SessionsTitleBarNewSessionEnabledContext = new RawContextKey<boolean>('sessionsTitleBarNewSessionEnabled', false, localize('sessionsTitleBarNewSessionEnabled', "Whether the new-session button is shown in the titlebar when the sessions list is hidden (A/B experiment)"));
+
+//#endregion
+
 //#region < --- Workspace Picker --- >
 
 export const SessionWorkspacePickerGroupContext = new RawContextKey<string>('sessionWorkspacePickerGroup', '', localize('sessionWorkspacePickerGroup', "The currently active group tab in the session workspace picker"));

--- a/src/vs/sessions/common/sessionsTelemetry.ts
+++ b/src/vs/sessions/common/sessionsTelemetry.ts
@@ -15,7 +15,7 @@ export type SessionsInteractionButton =
 	| 'openTerminal'
 	| 'openInVSCode';
 
-export type SessionsInteractionSource = 'menu' | 'actionWidget';
+export type SessionsInteractionSource = 'menu' | 'actionWidget' | 'titleBar' | 'sidebar';
 
 type SessionsInteractionEvent = {
 	button: string;
@@ -26,7 +26,7 @@ type SessionsInteractionClassification = {
 	owner: 'osortega';
 	comment: 'Tracks user interactions with buttons in the Agents window';
 	button: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The identifier of the button that was clicked' };
-	source?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The UI surface that triggered the interaction (menu or actionWidget)' };
+	source?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The UI surface that triggered the interaction (menu, actionWidget, titleBar or sidebar)' };
 };
 
 /**

--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -40,7 +40,7 @@ import '../../sessions/browser/mobile/mobileOverlayContribution.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { EditorAreaFocusContext, SideBarVisibleContext } from '../../../../workbench/common/contextkeys.js';
 import { NEW_SESSION_ACTION_ID } from '../common/constants.js';
-import { SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
+import { SessionsTitleBarNewSessionEnabledContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
 import { Menus } from '../../../browser/menus.js';
 
 
@@ -77,7 +77,12 @@ class NewChatInSessionsWindowAction extends Action2 {
 					id: Menus.TitleBarLeftLayout,
 					group: 'navigation',
 					order: 1,
-					when: ContextKeyExpr.and(SideBarVisibleContext.toNegated(), SessionsWelcomeVisibleContext.toNegated())
+					// Surface a quick "new session" affordance in the titlebar only
+					// when the sessions list (sidebar) is hidden, since the list has
+					// its own new-session button. Gated behind an A/B experiment
+					// (SessionsTitleBarNewSessionEnabledContext) so we can measure how
+					// the affordance moves new-session metrics before rolling it out.
+					when: ContextKeyExpr.and(SideBarVisibleContext.toNegated(), SessionsWelcomeVisibleContext.toNegated(), SessionsTitleBarNewSessionEnabledContext)
 				}
 			]
 		});

--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -77,11 +77,7 @@ class NewChatInSessionsWindowAction extends Action2 {
 					id: Menus.TitleBarLeftLayout,
 					group: 'navigation',
 					order: 1,
-					// Surface a quick "new session" affordance in the titlebar only
-					// when the sessions list (sidebar) is hidden, since the list has
-					// its own new-session button. Gated behind an A/B experiment
-					// (SessionsTitleBarNewSessionEnabledContext) so we can measure how
-					// the affordance moves new-session metrics before rolling it out.
+					// Show in the titlebar only when the sidebar is hidden, gated behind an A/B experiment.
 					when: ContextKeyExpr.and(SideBarVisibleContext.toNegated(), SessionsWelcomeVisibleContext.toNegated(), SessionsTitleBarNewSessionEnabledContext)
 				}
 			]

--- a/src/vs/sessions/contrib/sessions/browser/media/newSessionActionViewItem.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/newSessionActionViewItem.css
@@ -29,14 +29,6 @@ unscoped so the widget renders identically wherever it is mounted. */
 	cursor: pointer;
 }
 
-/* When mounted in the titlebar, add breathing room from the adjacent
-sidebar toggle and the surrounding titlebar edges. */
-.sessions-titlebar-new-session-item {
-	display: inline-flex;
-	align-items: center;
-	margin: 0 4px;
-}
-
 .agent-sessions-compact-new-button.monaco-button.default-colors:hover {
 	background-color: var(--vscode-agentsNewSessionButton-hoverBackground, var(--vscode-toolbar-hoverBackground));
 }

--- a/src/vs/sessions/contrib/sessions/browser/newSessionActionViewItem.ts
+++ b/src/vs/sessions/contrib/sessions/browser/newSessionActionViewItem.ts
@@ -39,7 +39,6 @@ class NewSessionActionViewItem extends BaseActionViewItem {
 
 	constructor(
 		action: IAction,
-		private readonly inTitleBar: boolean,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IHoverService private readonly hoverService: IHoverService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
@@ -72,7 +71,8 @@ class NewSessionActionViewItem extends BaseActionViewItem {
 			if (!this.action.enabled) {
 				return;
 			}
-			logSessionsInteraction(this.telemetryService, 'newSession', this.inTitleBar ? 'titleBar' : 'sidebar');
+			const source = this.element?.closest('.part.titlebar') ? 'titleBar' : 'sidebar';
+			logSessionsInteraction(this.telemetryService, 'newSession', source);
 			this.actionRunner.run(this.action);
 		}));
 
@@ -161,12 +161,11 @@ export class NewSessionActionViewItemContribution extends Disposable implements 
 		const onDidRegister = this._register(new Emitter<void>());
 		const menus: MenuId[] = [Menus.SidebarSessionsHeader, Menus.TitleBarLeftLayout];
 		for (const menu of menus) {
-			const inTitleBar = menu === Menus.TitleBarLeftLayout;
 			this._register(actionViewItemService.register(menu, NEW_SESSION_ACTION_ID, (action, _options, instantiationService) => {
 				if (!(action instanceof MenuItemAction)) {
 					return undefined;
 				}
-				return instantiationService.createInstance(NewSessionActionViewItem, action, inTitleBar);
+				return instantiationService.createInstance(NewSessionActionViewItem, action);
 			}, onDidRegister.event));
 		}
 		onDidRegister.fire();

--- a/src/vs/sessions/contrib/sessions/browser/newSessionActionViewItem.ts
+++ b/src/vs/sessions/contrib/sessions/browser/newSessionActionViewItem.ts
@@ -15,7 +15,7 @@ import { OS } from '../../../../base/common/platform.js';
 import { localize } from '../../../../nls.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
 import { MenuId, MenuItemAction } from '../../../../platform/actions/common/actions.js';
-import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
@@ -23,7 +23,9 @@ import { asCssVariable } from '../../../../platform/theme/common/colorRegistry.j
 import { defaultButtonStyles } from '../../../../platform/theme/browser/defaultStyles.js';
 import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
 import { markOnboardingTarget } from '../../../../workbench/contrib/onboarding/browser/spotlight/onboardingTarget.js';
+import { IWorkbenchAssignmentService } from '../../../../workbench/services/assignment/common/assignmentService.js';
 import { Menus } from '../../../browser/menus.js';
+import { SessionsTitleBarNewSessionEnabledContext } from '../../../common/contextkeys.js';
 import { agentsNewSessionButtonBackground, agentsNewSessionButtonBorder, agentsNewSessionButtonForeground, agentsNewSessionButtonHoverBackground } from '../../../common/theme.js';
 import { logSessionsInteraction } from '../../../common/sessionsTelemetry.js';
 import { NEW_SESSION_ACTION_ID } from '../../chat/common/constants.js';
@@ -78,7 +80,7 @@ class NewSessionActionViewItem extends BaseActionViewItem {
 			if (!this.action.enabled) {
 				return;
 			}
-			logSessionsInteraction(this.telemetryService, 'newSession');
+			logSessionsInteraction(this.telemetryService, 'newSession', this.inTitleBar ? 'titleBar' : 'sidebar');
 			this.actionRunner.run(this.action);
 		}));
 
@@ -147,15 +149,30 @@ class NewSessionActionViewItem extends BaseActionViewItem {
  * surfaces it (the sessions sidebar header and the titlebar's left toolbar). The factory is
  * announced once right after registration so a toolbar that was built before this contribution
  * ran re-renders and picks the widget up.
+ *
+ * The titlebar entry is additionally gated behind an A/B experiment: this contribution resolves
+ * the {@link NEW_SESSION_TITLEBAR_TREATMENT} treatment and reflects it into
+ * {@link SessionsTitleBarNewSessionEnabledContext}, which the titlebar menu's `when` clause
+ * checks. The control group keeps the prior behaviour (no titlebar button) so we can measure how
+ * the affordance moves new-session metrics before rolling it out.
  */
 export class NewSessionActionViewItemContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'workbench.contrib.sessions.newSessionActionViewItem';
 
+	/** ExP treatment that, when enabled, shows the new-session button in the titlebar. */
+	private static readonly NEW_SESSION_TITLEBAR_TREATMENT = 'agentSessionsTitleBarNewSession';
+
+	private readonly titleBarEnabledContext: IContextKey<boolean>;
+
 	constructor(
 		@IActionViewItemService actionViewItemService: IActionViewItemService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IWorkbenchAssignmentService private readonly assignmentService: IWorkbenchAssignmentService,
 	) {
 		super();
+
+		this.titleBarEnabledContext = SessionsTitleBarNewSessionEnabledContext.bindTo(contextKeyService);
 
 		const onDidRegister = this._register(new Emitter<void>());
 		const menus: MenuId[] = [Menus.SidebarSessionsHeader, Menus.TitleBarLeftLayout];
@@ -169,5 +186,14 @@ export class NewSessionActionViewItemContribution extends Disposable implements 
 			}, onDidRegister.event));
 		}
 		onDidRegister.fire();
+
+		// Resolve the titlebar experiment now and whenever the assignment service refetches.
+		this._register(this.assignmentService.onDidRefetchAssignments(() => this.updateTitleBarTreatment()));
+		this.updateTitleBarTreatment();
+	}
+
+	private async updateTitleBarTreatment(): Promise<void> {
+		const enabled = await this.assignmentService.getTreatment<boolean>(NewSessionActionViewItemContribution.NEW_SESSION_TITLEBAR_TREATMENT);
+		this.titleBarEnabledContext.set(enabled === true);
 	}
 }

--- a/src/vs/sessions/contrib/sessions/browser/newSessionActionViewItem.ts
+++ b/src/vs/sessions/contrib/sessions/browser/newSessionActionViewItem.ts
@@ -16,6 +16,7 @@ import { localize } from '../../../../nls.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
 import { MenuId, MenuItemAction } from '../../../../platform/actions/common/actions.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
@@ -153,6 +154,7 @@ export class NewSessionActionViewItemContribution extends Disposable implements 
 		@IActionViewItemService actionViewItemService: IActionViewItemService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IWorkbenchAssignmentService private readonly assignmentService: IWorkbenchAssignmentService,
+		@IEnvironmentService private readonly environmentService: IEnvironmentService,
 	) {
 		super();
 
@@ -177,6 +179,11 @@ export class NewSessionActionViewItemContribution extends Disposable implements 
 	}
 
 	private async updateTitleBarTreatment(): Promise<void> {
+		// Always show in dev builds (running from sources) to ease development, regardless of the experiment.
+		if (!this.environmentService.isBuilt) {
+			this.titleBarEnabledContext.set(true);
+			return;
+		}
 		const enabled = await this.assignmentService.getTreatment<boolean>(NewSessionActionViewItemContribution.NEW_SESSION_TITLEBAR_TREATMENT);
 		this.titleBarEnabledContext.set(enabled === true);
 	}

--- a/src/vs/sessions/contrib/sessions/browser/newSessionActionViewItem.ts
+++ b/src/vs/sessions/contrib/sessions/browser/newSessionActionViewItem.ts
@@ -32,9 +32,8 @@ import { NEW_SESSION_ACTION_ID } from '../../chat/common/constants.js';
 import './media/newSessionActionViewItem.css';
 
 /**
- * Renders the new-session action ({@link NEW_SESSION_ACTION_ID}) as the compact "New" pill
- * with an inline keybinding hint. Used wherever the action is contributed — the sessions
- * sidebar header and the titlebar — so both surfaces render the exact same affordance.
+ * Renders the new-session action as the compact "New" pill, shared by the sessions sidebar
+ * header and the titlebar.
  */
 class NewSessionActionViewItem extends BaseActionViewItem {
 
@@ -68,10 +67,7 @@ class NewSessionActionViewItem extends BaseActionViewItem {
 		newSessionButton.element.classList.add('agent-sessions-compact-new-button');
 		this._register(markOnboardingTarget(newSessionButton.element, 'sessions.newSession.button'));
 		this._register(newSessionButton.onDidClick(e => {
-			// The inner button lives inside this view item's <li>, whose click
-			// listener (installed by BaseActionViewItem) would also run the action.
-			// Stop propagation so the command runs exactly once, and run through the
-			// action runner so the action's enabled state is respected.
+			// Stop propagation so the parent <li> click handler doesn't run the action twice.
 			EventHelper.stop(e, true);
 			if (!this.action.enabled) {
 				return;
@@ -141,22 +137,14 @@ class NewSessionActionViewItem extends BaseActionViewItem {
 }
 
 /**
- * Registers {@link NewSessionActionViewItem} for the new-session action in every menu that
- * surfaces it (the sessions sidebar header and the titlebar's left toolbar). The factory is
- * announced once right after registration so a toolbar that was built before this contribution
- * ran re-renders and picks the widget up.
- *
- * The titlebar entry is additionally gated behind an A/B experiment: this contribution resolves
- * the {@link NEW_SESSION_TITLEBAR_TREATMENT} treatment and reflects it into
- * {@link SessionsTitleBarNewSessionEnabledContext}, which the titlebar menu's `when` clause
- * checks. The control group keeps the prior behaviour (no titlebar button) so we can measure how
- * the affordance moves new-session metrics before rolling it out.
+ * Registers {@link NewSessionActionViewItem} in the sessions sidebar header and the titlebar.
+ * The titlebar entry is gated behind an A/B experiment via {@link SessionsTitleBarNewSessionEnabledContext}.
  */
 export class NewSessionActionViewItemContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'workbench.contrib.sessions.newSessionActionViewItem';
 
-	/** ExP treatment that, when enabled, shows the new-session button in the titlebar. */
+	/** ExP treatment that shows the new-session button in the titlebar. */
 	private static readonly NEW_SESSION_TITLEBAR_TREATMENT = 'agentSessionsTitleBarNewSession';
 
 	private readonly titleBarEnabledContext: IContextKey<boolean>;
@@ -183,7 +171,7 @@ export class NewSessionActionViewItemContribution extends Disposable implements 
 		}
 		onDidRegister.fire();
 
-		// Resolve the titlebar experiment now and whenever the assignment service refetches.
+		// Resolve the titlebar experiment now and on refetch.
 		this._register(this.assignmentService.onDidRefetchAssignments(() => this.updateTitleBarTreatment()));
 		this.updateTitleBarTreatment();
 	}

--- a/src/vs/sessions/contrib/sessions/browser/newSessionActionViewItem.ts
+++ b/src/vs/sessions/contrib/sessions/browser/newSessionActionViewItem.ts
@@ -56,10 +56,6 @@ class NewSessionActionViewItem extends BaseActionViewItem {
 			return;
 		}
 
-		if (this.inTitleBar) {
-			this.element.classList.add('sessions-titlebar-new-session-item');
-		}
-
 		const newSessionButton = this._register(new Button(this.element, {
 			...defaultButtonStyles,
 			buttonSecondaryBackground: asCssVariable(agentsNewSessionButtonBackground),

--- a/src/vs/sessions/contrib/sessions/browser/newSessionActionViewItem.ts
+++ b/src/vs/sessions/contrib/sessions/browser/newSessionActionViewItem.ts
@@ -27,7 +27,7 @@ import { IWorkbenchAssignmentService } from '../../../../workbench/services/assi
 import { Menus } from '../../../browser/menus.js';
 import { SessionsTitleBarNewSessionEnabledContext } from '../../../common/contextkeys.js';
 import { agentsNewSessionButtonBackground, agentsNewSessionButtonBorder, agentsNewSessionButtonForeground, agentsNewSessionButtonHoverBackground } from '../../../common/theme.js';
-import { logSessionsInteraction } from '../../../common/sessionsTelemetry.js';
+import { logSessionsInteraction, SessionsInteractionSource } from '../../../common/sessionsTelemetry.js';
 import { NEW_SESSION_ACTION_ID } from '../../chat/common/constants.js';
 import './media/newSessionActionViewItem.css';
 
@@ -39,6 +39,7 @@ class NewSessionActionViewItem extends BaseActionViewItem {
 
 	constructor(
 		action: IAction,
+		private readonly telemetrySource: SessionsInteractionSource,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IHoverService private readonly hoverService: IHoverService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
@@ -71,8 +72,7 @@ class NewSessionActionViewItem extends BaseActionViewItem {
 			if (!this.action.enabled) {
 				return;
 			}
-			const source = this.element?.closest('.part.titlebar') ? 'titleBar' : 'sidebar';
-			logSessionsInteraction(this.telemetryService, 'newSession', source);
+			logSessionsInteraction(this.telemetryService, 'newSession', this.telemetrySource);
 			this.actionRunner.run(this.action);
 		}));
 
@@ -161,11 +161,12 @@ export class NewSessionActionViewItemContribution extends Disposable implements 
 		const onDidRegister = this._register(new Emitter<void>());
 		const menus: MenuId[] = [Menus.SidebarSessionsHeader, Menus.TitleBarLeftLayout];
 		for (const menu of menus) {
+			const source: SessionsInteractionSource = menu === Menus.TitleBarLeftLayout ? 'titleBar' : 'sidebar';
 			this._register(actionViewItemService.register(menu, NEW_SESSION_ACTION_ID, (action, _options, instantiationService) => {
 				if (!(action instanceof MenuItemAction)) {
 					return undefined;
 				}
-				return instantiationService.createInstance(NewSessionActionViewItem, action);
+				return instantiationService.createInstance(NewSessionActionViewItem, action, source);
 			}, onDidRegister.event));
 		}
 		onDidRegister.fire();


### PR DESCRIPTION
Follow-up to #322614 addressing reviewer feedback to ship the titlebar New Session button as an A/B experiment and measure click-through.

## What changed
- **Experiment gating** — the titlebar New Session button now only shows for the `agentSessionsTitleBarNewSession` ExP treatment group. `NewSessionActionViewItemContribution` resolves the treatment (and re-resolves on `onDidRefetchAssignments`) and reflects it into the new `SessionsTitleBarNewSessionEnabledContext` context key, which the `Menus.TitleBarLeftLayout` menu `when` clause checks. The control group keeps the prior behaviour (no titlebar button), so we can see how the affordance moves new-session metrics before a wider rollout.
- **Per-surface telemetry** — the `vscodeAgents.interaction` event now records the originating surface (`titleBar` vs `sidebar`) for the new-session action, so we can count how often the button is clicked specifically from the titlebar.

## How it addresses the feedback
> like the idea and I'd love that we build our exp. Could we please do this via an experiment and see how metrics move?

Done via the `agentSessionsTitleBarNewSession` treatment — the button is off by default and only enabled for the experiment's treatment group.

> Also it would be nice to know how many times user click this button from title bar

Done — the interaction telemetry now distinguishes `titleBar` vs `sidebar` as the source.

## Validation
- `npm run typecheck-client` ✅
- `npm run valid-layers-check` ✅
- eslint on changed files ✅
- hygiene ✅