### PR TITLE
smoke: add remote server process exit diagnostics

### DIFF
--- a/extensions/vscode-test-resolver/src/extension.ts
+++ b/extensions/vscode-test-resolver/src/extension.ts
@@ -228,8 +228,14 @@ export function activate(context: vscode.ExtensionContext) {
 				processError(`server failed with error:\n${error.message}`);
 				extHostProcess = undefined;
 			});
-			extHostProcess.on('close', (code: number) => {
-				processError(`server closed unexpectedly.\nError code: ${code}`);
+			extHostProcess.on('exit', (code: number | null, signal: NodeJS.Signals | null) => {
+				// Logged separately from 'close' so we capture the signal (if any)
+				// that terminated the server. A non-null signal indicates the
+				// server was killed externally rather than exiting on its own.
+				outputChannel.appendLine(`[${new Date().toISOString()}] server process exited (code: ${code}, signal: ${signal}).`);
+			});
+			extHostProcess.on('close', (code: number | null, signal: NodeJS.Signals | null) => {
+				processError(`server closed unexpectedly.\nError code: ${code}, signal: ${signal}`);
 				extHostProcess = undefined;
 			});
 			context.subscriptions.push({

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -49,6 +49,8 @@ if (shouldSpawnCli) {
 		mod.spawnCli();
 	});
 } else {
+	installServerProcessExitDiagnostics();
+
 	let _remoteExtensionHostAgentServer: IServerAPI | null = null;
 	let _remoteExtensionHostAgentServerPromise: Promise<IServerAPI> | null = null;
 	const getRemoteExtensionHostAgentServer = () => {
@@ -156,6 +158,68 @@ function sanitizeStringArg(val: unknown): string | undefined {
 		val = val.pop(); // take the last item
 	}
 	return typeof val === 'string' ? val : undefined;
+}
+
+/**
+ * Records why/when the remote server process exits, to help debug unexpected
+ * server exits in the remote smoke tests (which surface to the client as
+ * `Unknown reconnection token` reconnection failures). The handlers tell apart a
+ * self-exit (`beforeExit`), an external kill (`signal`) and a crash
+ * (`uncaughtExceptionMonitor`). Gated behind the `VSCODE_SERVER_EXIT_DIAGNOSTICS`
+ * env var (set by the smoke tests) so it adds no product noise.
+ */
+function installServerProcessExitDiagnostics(): void {
+	if (!process.env['VSCODE_SERVER_EXIT_DIAGNOSTICS']) {
+		return;
+	}
+
+	const startTime = Date.now();
+	const log = (message: string) => {
+		// Use `console.error` so the line survives even if stdout is in a
+		// broken-pipe state. The test resolver forwards the server's stdio into
+		// its own output channel, so this ends up in the captured smoke logs.
+		try {
+			console.error(`[server-exit-diagnostics][${new Date().toISOString()}][pid:${process.pid}][+${Date.now() - startTime}ms] ${message}`);
+		} catch {
+			// ignore logging failures while the process is tearing down
+		}
+	};
+
+	const describeState = (): string => {
+		try {
+			const processWithResources = process as NodeJS.Process & { getActiveResourcesInfo?(): string[] };
+			const activeResources = processWithResources.getActiveResourcesInfo?.() ?? [];
+			const memory = process.memoryUsage();
+			return `uptime=${process.uptime().toFixed(3)}s rss=${Math.round(memory.rss / 1024 / 1024)}MB activeResources=[${activeResources.join(', ')}]`;
+		} catch (err) {
+			return `(failed to collect process state: ${err})`;
+		}
+	};
+
+	log(`installed. ppid=${process.ppid} platform=${process.platform} node=${process.version} argv=${JSON.stringify(process.argv.slice(2))}`);
+
+	process.on('beforeExit', code => log(`'beforeExit' (code: ${code}) — event loop drained, process will exit on its own. ${describeState()}`));
+	process.on('exit', code => log(`'exit' (code: ${code}). ${describeState()}`));
+
+	// `uncaughtExceptionMonitor` is observational: it runs before the process
+	// crashes but does NOT prevent the default crash, so the real failure mode
+	// is preserved. It also fires for unhandled rejections that get promoted to
+	// uncaught exceptions by Node's default policy.
+	process.on('uncaughtExceptionMonitor', (err, origin) => log(`'uncaughtExceptionMonitor' (origin: ${origin}): ${err?.stack || err}`));
+
+	const signals: NodeJS.Signals[] = ['SIGTERM', 'SIGINT', 'SIGHUP', 'SIGBREAK', 'SIGQUIT'];
+	for (const signal of signals) {
+		try {
+			process.on(signal, () => {
+				log(`received signal '${signal}' — terminating. ${describeState()}`);
+				// Preserve default termination semantics after logging.
+				const signalNumber = (os.constants.signals as Record<string, number>)[signal];
+				process.exit(typeof signalNumber === 'number' ? 128 + signalNumber : 1);
+			});
+		} catch {
+			// Not all signals can be listened to on all platforms (e.g. SIGBREAK).
+		}
+	}
 }
 
 /**

--- a/test/automation/src/electron.ts
+++ b/test/automation/src/electron.ts
@@ -77,6 +77,10 @@ export async function resolveElectronConfiguration(options: LaunchOptions): Prom
 			env['TESTRESOLVER_DATA_FOLDER'] = remoteDataDir;
 		}
 		env['TESTRESOLVER_LOGS_FOLDER'] = join(logsPath, 'server');
+		// Exercise the remote server's exit diagnostics (see `installServerProcessExitDiagnostics`
+		// in server-main.ts) so unexpected server exits are explained in the captured logs,
+		// even when running smoke tests locally (where `isCI` is false).
+		env['VSCODE_SERVER_EXIT_DIAGNOSTICS'] = '1';
 		if (options.verbose) {
 			env['TESTRESOLVER_LOG_LEVEL'] = 'trace';
 		}


### PR DESCRIPTION
## Why

Remote smoke tests (notably **Windows / Remote**) intermittently fail with a **"Cannot reconnect. Please reload the window."** dialog. Investigating run [28086496057](https://github.com/microsoft/vscode/actions/runs/28086496057/job/83153645697), the chain is:

1. The remote server process exits unexpectedly (~2s after a client connects, `server closed unexpectedly. Error code: 0`).
2. Its exit tears down the test-resolver proxy, dropping the renderer's management socket (`code: 1006`).
3. The reconnect loop re-resolves the authority, which spawns a **fresh** server with a **new** connection token, so the old per-connection reconnection token is rejected: `Unknown reconnection token (never seen)` → permanent failure.

The root *trigger* — **why the server exits** — is currently undiagnosable: the server logs nothing on the way out, and the test resolver only captured the exit `code` (not the `signal`), which `shell:true` + `code-server.bat` can mask.

## What

Add **opt-in** diagnostics, gated behind the `VSCODE_SERVER_EXIT_DIAGNOSTICS` env var so the product is never affected:

- **`src/server-main.ts`** — `installServerProcessExitDiagnostics()` logs `beforeExit` / `exit` / signals / `uncaughtExceptionMonitor` plus uptime, RSS and active handles. These distinguish the possible causes next time:
  - `beforeExit` → the event loop drained (something released all handles) — a *self* exit;
  - a `signal` log → the process was killed externally;
  - `uncaughtExceptionMonitor` → a crash / promoted unhandled rejection (observational only — does not change crash behaviour).
- **`extensions/vscode-test-resolver/src/extension.ts`** — log the child's `exit`/`close` **signal** (not just the code).
- **`test/automation/src/electron.ts`** — set `VSCODE_SERVER_EXIT_DIAGNOSTICS=1` for remote smoke runs so the path is exercised locally and in CI.

## Notes for reviewers

- This is a **diagnostics-only** change to catch the next occurrence; it does not attempt to fix the trigger.
- Pure no-op unless `VSCODE_SERVER_EXIT_DIAGNOSTICS` is set.
- The env var propagates the same way the existing `TESTRESOLVER_*` vars do (launcher env → extension host `process.env` → test resolver `getNewEnv()` → spawned server).

Opening as a draft to see the change exercised by the PR smoke checks.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>