### PR TITLE
uses kind instead of constructor.name to make tests work with esbuild.

### DIFF
--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -1199,13 +1199,13 @@ suite('ChatService', () => {
 
 		const model = testService.getSession(sessionResource) as ChatModel;
 		assert.deepStrictEqual(model.getRequests()[0].message.parts.map(part => ({
-			type: part.constructor.name,
+			kind: part.kind,
 			text: part instanceof ChatRequestSlashPromptPart ? part.name : undefined,
 		})), [
-			{ type: 'ChatRequestAgentPart', text: undefined },
-			{ type: 'ChatRequestTextPart', text: undefined },
-			{ type: 'ChatRequestSlashPromptPart', text: 'skill' },
-			{ type: 'ChatRequestTextPart', text: undefined },
+			{ kind: 'agent', text: undefined },
+			{ kind: 'text', text: undefined },
+			{ kind: 'prompt', text: 'skill' },
+			{ kind: 'text', text: undefined },
 		]);
 	});
 
@@ -1294,11 +1294,11 @@ suite('ChatService', () => {
 
 		const model = testService.getSession(sessionResource) as ChatModel;
 		assert.deepStrictEqual(model.getRequests()[0].message.parts.map(part => ({
-			type: part.constructor.name,
+			kind: part.kind,
 			text: part instanceof ChatRequestSlashPromptPart ? part.name : undefined,
 		})), [
-			{ type: 'ChatRequestSlashPromptPart', text: 'skill' },
-			{ type: 'ChatRequestTextPart', text: undefined },
+			{ kind: 'prompt', text: 'skill' },
+			{ kind: 'text', text: undefined },
 		]);
 	});
 
@@ -1337,11 +1337,11 @@ suite('ChatService', () => {
 		testDisposables.add(ref);
 
 		assert.deepStrictEqual(ref.object.getRequests()[0].message.parts.map(part => ({
-			type: part.constructor.name,
+			kind: part.kind,
 			text: part instanceof ChatRequestSlashPromptPart ? part.name : undefined,
 		})), [
-			{ type: 'ChatRequestSlashPromptPart', text: 'skill' },
-			{ type: 'ChatRequestTextPart', text: undefined },
+			{ kind: 'prompt', text: 'skill' },
+			{ kind: 'text', text: undefined },
 		]);
 	});
 


### PR DESCRIPTION
FYI @roblourens

constructor.name should only be used for debug text. Minification and mangling might change it in production.