### PR TITLE
Enable experiments for post update info

### DIFF
--- a/src/vs/platform/update/common/update.config.contribution.ts
+++ b/src/vs/platform/update/common/update.config.contribution.ts
@@ -82,6 +82,7 @@ configurationRegistry.registerConfiguration({
 		'update.showPostInstallInfo': {
 			type: 'boolean',
 			default: false,
+			experiment: { mode: 'auto' },
 			scope: ConfigurationScope.APPLICATION,
 			description: localize('showPostInstallInfo', "Show a post-install update tooltip in the title bar instead of opening the release notes editor."),
 			tags: ['usesOnlineServices']


### PR DESCRIPTION
Allows `update.showPostInstallInfo` to be controlled by configuration experiments so the post-update notification replacement can be rolled out through TAS.

The setting uses `experiment: { mode: 'auto' }`, matching the desired rollout behavior while keeping the default disabled unless an experiment treatment overrides it.