### PR TITLE
Allow chat.agentHost.codexAgent.enabled to be overridden by experiment

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
@@ -59,6 +59,10 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.agentHost.codexAgent.enabled', "When enabled, the agent host registers the Codex provider (subject to the Codex SDK being reachable). Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect."),
 			default: false,
 			tags: ['experimental', 'advanced'],
+			// Allow the default to be overridden by an experiment. Uses `startup`
+			// (matching the sibling agent-host settings) since the agent host
+			// process must be restarted for a change to take effect anyway.
+			experiment: { mode: 'startup' },
 			// Owns the `Codex3PIntegration` policy; gating here disables Codex across all agent-host surfaces.
 			policy: {
 				name: 'Codex3PIntegration',


### PR DESCRIPTION
Adds `experiment: { mode: 'startup' }` to the `chat.agentHost.codexAgent.enabled` setting so its default can be overridden by an ExP.