### PR TITLE
sessions: show last-known PR icon instantly from a persistent cache

### DIFF
--- a/src/vs/sessions/contrib/github/PR_ICON_POLLING.md
+++ b/src/vs/sessions/contrib/github/PR_ICON_POLLING.md
@@ -49,6 +49,24 @@ Both halves of the fix are now implemented:
 The remainder of this document describes the original analysis and the alternatives that
 were considered.
 
+## Instant icon on startup (persistent cache)
+
+Even with polling, the icon for an agent‑host session is still **blank until the first live
+PR fetch completes** (a couple of seconds after startup), because the icon is derived purely
+from the live model. To avoid that empty gap, the agent‑host adapter
+([baseAgentHostSessionsProvider.ts](../providers/agentHost/browser/baseAgentHostSessionsProvider.ts))
+backs the icon with a small persistent cache —
+[`IPullRequestIconCache`](browser/pullRequestIconCache.ts):
+
+- **Read:** while `livePR` is still `undefined`, `gitHubInfo` falls back to the last‑known
+  icon from the cache, so the row shows an icon immediately on startup.
+- **Write:** once the live model resolves, the freshly computed icon is stored back into the
+  cache (a no‑op when unchanged), so the next startup can show it instantly.
+
+The cache key is the **PR link** (`gitHubInfo.pullRequest.uri`), the value is the
+`ThemeIcon`, and it is persisted via `IStorageService`. Only the 50 most recently updated
+entries are retained so the backing storage cannot grow without bound.
+
 ## Where the icon is shown
 
 The same `gitHubInfo.pullRequest.icon` value feeds two surfaces:

--- a/src/vs/sessions/contrib/github/browser/github.contribution.ts
+++ b/src/vs/sessions/contrib/github/browser/github.contribution.ts
@@ -16,6 +16,7 @@ import { ISessionsChangeEvent, ISessionsManagementService } from '../../../servi
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { GitHubPullRequestState } from '../common/types.js';
 import { GitHubService, IGitHubService } from './githubService.js';
+import { IPullRequestIconCache, PullRequestIconCache } from './pullRequestIconCache.js';
 
 import './pullRequestActions.js';
 
@@ -222,3 +223,5 @@ export class GitHubPullRequestPollingContribution extends Disposable implements 
 registerWorkbenchContribution2(GitHubPullRequestPollingContribution.ID, GitHubPullRequestPollingContribution, WorkbenchPhase.AfterRestored);
 
 registerSingleton(IGitHubService, GitHubService, InstantiationType.Delayed);
+
+registerSingleton(IPullRequestIconCache, PullRequestIconCache, InstantiationType.Delayed);

--- a/src/vs/sessions/contrib/github/browser/pullRequestIconCache.ts
+++ b/src/vs/sessions/contrib/github/browser/pullRequestIconCache.ts
@@ -1,0 +1,125 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+
+export const IPullRequestIconCache = createDecorator<IPullRequestIconCache>('pullRequestIconCache');
+
+/**
+ * A small, bounded, persistent cache of the last-known pull-request status icon,
+ * keyed by the pull request's link (its `https://github.com/<owner>/<repo>/pull/<n>`
+ * URL).
+ *
+ * Sessions compute their PR icon from a live, asynchronously-fetched pull-request
+ * model, so on startup the icon is missing until the first fetch completes. This
+ * cache lets a session render its last-known icon instantly and then refine it once
+ * the live model resolves.
+ *
+ * Only the {@link MAX_CACHED_ICONS} most recently updated entries are retained so
+ * the backing storage cannot grow without bound.
+ */
+export interface IPullRequestIconCache {
+	readonly _serviceBrand: undefined;
+
+	/** The last icon stored for `prLink`, or `undefined` if none is cached. */
+	get(prLink: string): ThemeIcon | undefined;
+
+	/**
+	 * Remember `icon` as the last-known icon for `prLink`, making it the most
+	 * recently updated entry. A no-op when the icon is unchanged. Evicts the
+	 * least-recently-updated entries beyond the cap and persists the result.
+	 */
+	set(prLink: string, icon: ThemeIcon): void;
+}
+
+/** Retain only the most recently updated pull-request icons. */
+const MAX_CACHED_ICONS = 50;
+
+const STORAGE_KEY = 'sessions.github.pullRequestIconCache';
+
+interface IStoredEntry {
+	readonly link: string;
+	readonly icon: ThemeIcon;
+}
+
+export class PullRequestIconCache implements IPullRequestIconCache {
+
+	declare readonly _serviceBrand: undefined;
+
+	/**
+	 * Cached icons keyed by PR link. A `Map` preserves insertion order, which we
+	 * treat as recency: the most recently updated entry is last, so eviction
+	 * removes the first (oldest) key.
+	 */
+	private readonly _icons = new Map<string, ThemeIcon>();
+
+	constructor(
+		@IStorageService private readonly _storageService: IStorageService,
+	) {
+		this._load();
+	}
+
+	get(prLink: string): ThemeIcon | undefined {
+		return this._icons.get(prLink);
+	}
+
+	set(prLink: string, icon: ThemeIcon): void {
+		const existing = this._icons.get(prLink);
+		if (existing && ThemeIcon.isEqual(existing, icon)) {
+			// Icon unchanged: keep its current recency and avoid a redundant write.
+			return;
+		}
+
+		// Re-insert so the entry becomes the most recently updated.
+		this._icons.delete(prLink);
+		this._icons.set(prLink, icon);
+
+		// Drop the least recently updated entries beyond the cap.
+		while (this._icons.size > MAX_CACHED_ICONS) {
+			const oldest = this._icons.keys().next().value;
+			if (oldest === undefined) {
+				break;
+			}
+			this._icons.delete(oldest);
+		}
+
+		this._save();
+	}
+
+	private _load(): void {
+		const raw = this._storageService.get(STORAGE_KEY, StorageScope.APPLICATION);
+		if (!raw) {
+			return;
+		}
+
+		let entries: readonly IStoredEntry[];
+		try {
+			entries = JSON.parse(raw);
+		} catch {
+			// Corrupt cache: ignore and start fresh.
+			return;
+		}
+
+		if (!Array.isArray(entries)) {
+			return;
+		}
+
+		for (const entry of entries) {
+			if (entry && typeof entry.link === 'string' && ThemeIcon.isThemeIcon(entry.icon)) {
+				this._icons.set(entry.link, entry.icon);
+			}
+		}
+	}
+
+	private _save(): void {
+		const entries: IStoredEntry[] = [];
+		for (const [link, icon] of this._icons) {
+			entries.push({ link, icon });
+		}
+		this._storageService.store(STORAGE_KEY, JSON.stringify(entries), StorageScope.APPLICATION, StorageTarget.MACHINE);
+	}
+}

--- a/src/vs/sessions/contrib/github/test/browser/pullRequestIconCache.test.ts
+++ b/src/vs/sessions/contrib/github/test/browser/pullRequestIconCache.test.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { InMemoryStorageService } from '../../../../../platform/storage/common/storage.js';
+import { PullRequestIconCache } from '../../browser/pullRequestIconCache.js';
+
+suite('PullRequestIconCache', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function link(n: number): string {
+		return `https://github.com/owner/repo/pull/${n}`;
+	}
+
+	const openIcon: ThemeIcon = { id: 'git-pull-request', color: { id: 'charts.green' } };
+	const mergedIcon: ThemeIcon = { id: 'git-pull-request-done', color: { id: 'charts.purple' } };
+
+	test('stores and reads icons keyed by PR link', () => {
+		const cache = new PullRequestIconCache(store.add(new InMemoryStorageService()));
+
+		cache.set(link(1), openIcon);
+
+		assert.deepStrictEqual(cache.get(link(1)), openIcon);
+		assert.strictEqual(cache.get(link(2)), undefined);
+	});
+
+	test('persists across instances via storage', () => {
+		const storageService = store.add(new InMemoryStorageService());
+		new PullRequestIconCache(storageService).set(link(1), openIcon);
+
+		const restored = new PullRequestIconCache(storageService);
+		assert.deepStrictEqual(restored.get(link(1)), openIcon);
+	});
+
+	test('keeps only the 50 most recently updated entries', () => {
+		const cache = new PullRequestIconCache(store.add(new InMemoryStorageService()));
+
+		for (let i = 0; i < 60; i++) {
+			cache.set(link(i), { id: `icon-${i}` });
+		}
+
+		// The 10 oldest (0..9) are evicted; the 50 most recent (10..59) remain.
+		const present: boolean[] = [];
+		for (let i = 0; i < 60; i++) {
+			present.push(cache.get(link(i)) !== undefined);
+		}
+		assert.deepStrictEqual(present, [
+			...new Array(10).fill(false),
+			...new Array(50).fill(true),
+		]);
+	});
+
+	test('changing an icon refreshes its recency so it survives eviction', () => {
+		const cache = new PullRequestIconCache(store.add(new InMemoryStorageService()));
+
+		for (let i = 0; i < 50; i++) {
+			cache.set(link(i), { id: `icon-${i}` });
+		}
+
+		// Touch the oldest entry with a changed icon -> becomes most recent.
+		cache.set(link(0), mergedIcon);
+
+		// Adding one more evicts link(1) (now the oldest), not the refreshed link(0).
+		cache.set(link(50), openIcon);
+
+		assert.deepStrictEqual(cache.get(link(0)), mergedIcon);
+		assert.strictEqual(cache.get(link(1)), undefined);
+	});
+});

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -49,6 +49,7 @@ import { ISessionsService } from '../../../../services/sessions/browser/sessions
 import { ISendRequestOptions, ISessionChangeEvent, ISessionModelPickerOptions } from '../../../../services/sessions/common/sessionsProvider.js';
 import { IGitHubService } from '../../../github/browser/githubService.js';
 import { computeLivePullRequestIcon } from '../../../github/browser/pullRequestIconStatus.js';
+import { IPullRequestIconCache } from '../../../github/browser/pullRequestIconCache.js';
 import { CHANGESET_UPDATE_THROTTLE_MS } from './agentHostChangesetConstants.js';
 import { changesetFileToChange, mapProtocolStatus } from './agentHostDiffs.js';
 import { createChangesets } from './agentHostSessionChangesets.js';
@@ -343,6 +344,7 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 		private readonly _options: IAgentHostAdapterOptions,
 		@IGitHubService private readonly _gitHubService: IGitHubService,
 		@ISessionsService private readonly _sessionsService: ISessionsService,
+		@IPullRequestIconCache private readonly _pullRequestIconCache: IPullRequestIconCache,
 	) {
 		super();
 		const rawId = AgentSession.id(metadata.session);
@@ -420,19 +422,34 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 				return baseGitHubInfo;
 			}
 
+			const prLink = baseGitHubInfo.pullRequest.uri.toString();
 			const prModelRef = reader.store.add(this._gitHubService.createPullRequestModelReference(
 				baseGitHubInfo.owner, baseGitHubInfo.repo, baseGitHubInfo.pullRequest.number));
 			const livePR = prModelRef.object.pullRequest.read(reader);
 
 			if (!livePR) {
-				return baseGitHubInfo;
+				// The live model hasn't been fetched yet (e.g. right after startup). Show
+				// the last known icon from the persistent cache so the row isn't icon-less
+				// while the first fetch is in flight.
+				const cachedIcon = this._pullRequestIconCache.get(prLink);
+				if (!cachedIcon) {
+					return baseGitHubInfo;
+				}
+				return {
+					...baseGitHubInfo,
+					pullRequest: { ...baseGitHubInfo.pullRequest, icon: cachedIcon }
+				};
 			}
 
+			const icon = computeLivePullRequestIcon(reader, this._gitHubService, baseGitHubInfo.owner, baseGitHubInfo.repo, livePR);
+			// Remember the freshly computed icon so the next startup can show it instantly.
+			// The cache de-duplicates unchanged icons, so this is a no-op when nothing changed.
+			this._pullRequestIconCache.set(prLink, icon);
 			return {
 				...baseGitHubInfo,
 				pullRequest: {
 					...baseGitHubInfo.pullRequest,
-					icon: computeLivePullRequestIcon(reader, this._gitHubService, baseGitHubInfo.owner, baseGitHubInfo.repo, livePR)
+					icon
 				}
 			};
 		});

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -41,6 +41,7 @@ import { ILabelService } from '../../../../../../platform/label/common/label.js'
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { IGitHubService } from '../../../../github/browser/githubService.js';
 import { GitHubPullRequestModel } from '../../../../github/browser/models/githubPullRequestModel.js';
+import { IPullRequestIconCache, PullRequestIconCache } from '../../../../github/browser/pullRequestIconCache.js';
 import { IWorkbenchEnvironmentService } from '../../../../../../workbench/services/environment/common/environmentService.js';
 
 // ---- Mock IAgentHostService -------------------------------------------------
@@ -321,6 +322,7 @@ function createProvider(disposables: DisposableStore, agentHostService: MockAgen
 	instantiationService.stub(IGitHubService, options?.gitHubService ?? new class extends mock<IGitHubService>() {
 		override findPullRequestNumberByHeadBranch = async () => undefined;
 	}());
+	instantiationService.stub(IPullRequestIconCache, instantiationService.createInstance(PullRequestIconCache));
 	const activeSessionObs = options?.activeSession ?? constObservable<IActiveSession | undefined>(undefined);
 	instantiationService.stub(ISessionsService, new class extends mock<ISessionsService>() {
 		override readonly activeSession: IObservable<IActiveSession | undefined> = activeSessionObs;

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
@@ -34,6 +34,7 @@ import { RemoteAgentHostSessionsProvider, type IRemoteAgentHostSessionsProviderC
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { IGitHubService } from '../../../../github/browser/githubService.js';
+import { IPullRequestIconCache, PullRequestIconCache } from '../../../../github/browser/pullRequestIconCache.js';
 import { IAgentHostActiveClientService } from '../../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.js';
 import { CopilotCLISessionType } from '../../../agentHost/browser/baseAgentHostSessionsProvider.js';
 import { IObservable, constObservable } from '../../../../../../base/common/observable.js';
@@ -223,6 +224,7 @@ function createProvider(disposables: DisposableStore, connection: MockAgentConne
 	instantiationService.stub(IGitHubService, new class extends mock<IGitHubService>() {
 		override findPullRequestNumberByHeadBranch = async () => undefined;
 	}());
+	instantiationService.stub(IPullRequestIconCache, instantiationService.createInstance(PullRequestIconCache));
 	instantiationService.stub(ISessionsService, new class extends mock<ISessionsService>() {
 		override readonly activeSession: IObservable<IActiveSession | undefined> = constObservable<IActiveSession | undefined>(undefined);
 	}());


### PR DESCRIPTION
## What

Agent-host sessions previously showed **no PR status icon on startup** until the live pull-request fetch completed a few seconds later, because the icon is derived purely from the asynchronously-fetched live PR model. There was no static fallback, so the row was icon-less during that gap.

This change shows the **last-known icon instantly from a persistent cache**, then refines it once the live fetch resolves.

## How

- New `IPullRequestIconCache` (`pullRequestIconCache.ts`) — a small singleton service:
  - **Key** = the PR link (`gitHubInfo.pullRequest.uri`), **value** = the `ThemeIcon`.
  - Backed by `IStorageService` (loaded on construction, persisted on every change).
  - Bounded LRU keyed on recency: only the **50 most recently updated** entries are retained, so storage cannot grow without bound.
  - `set()` is a no-op when the icon is unchanged, avoiding redundant writes.
- `AgentHostSessionAdapter.gitHubInfo` (used by local + remote agent-host providers):
  - **Read fallback:** while the live model is still loading, returns the cached icon so the row isn't icon-less right after startup.
  - **Write-through:** stores the freshly computed icon back once the live model resolves, so the next startup renders instantly.

Since the polling contribution already keeps `gitHubInfo` observed for every non-archived session, each session's icon is cached as soon as its live model resolves.

## Notes for reviewers

- Cache key is the PR link, as requested.
- Every icon change is written through to storage (deduped when unchanged).
- Added unit tests for the cache (persistence, PR-link keying, 50-entry eviction, recency refresh); existing local/remote agent-host provider tests stub the new service.
- `PR_ICON_POLLING.md` documents the new behavior.

## Validation

- `npm run typecheck-client` ✓
- ESLint on changed files ✓
- Pre-commit hygiene hook ✓
- Unit tests: cache (4), agent-host providers (157), GitHub polling (8), broad GitHub suite (143) ✓
