### PR TITLE
Add quota checkpoint to notification telemetry

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatQuotaNotification.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatQuotaNotification.ts
@@ -202,7 +202,7 @@ export class ChatQuotaNotificationContribution extends Disposable implements IWo
 
 	// --- Threshold crossing detection ----------------------------------------
 
-	private _computeQuotaWarning(): { percentUsed: number } | undefined {
+	private _computeQuotaWarning(): { percentUsed: number; threshold: number } | undefined {
 		const snapshot = this._getRelevantSnapshot();
 		if (!snapshot || snapshot.unlimited) {
 			this._prevQuotaPercentUsed = undefined;
@@ -212,7 +212,7 @@ export class ChatQuotaNotificationContribution extends Disposable implements IWo
 		const crossed = this._findCrossedThreshold(percentUsed, this._prevQuotaPercentUsed);
 		this._prevQuotaPercentUsed = percentUsed;
 		if (crossed !== undefined) {
-			return { percentUsed: Math.floor(percentUsed) };
+			return { percentUsed: Math.floor(percentUsed), threshold: crossed };
 		}
 		return undefined;
 	}
@@ -293,7 +293,7 @@ export class ChatQuotaNotificationContribution extends Disposable implements IWo
 
 	// --- Quota approaching --------------------------------------------------
 
-	private _showQuotaApproachingWarning(warning: { percentUsed: number }): void {
+	private _showQuotaApproachingWarning(warning: { percentUsed: number; threshold: number }): void {
 		this._showingExhausted = false;
 
 		const entitlement = this._chatEntitlementService.entitlement;
@@ -318,7 +318,7 @@ export class ChatQuotaNotificationContribution extends Disposable implements IWo
 
 		this._setNotification({
 			id: QUOTA_NOTIFICATION_ID,
-			telemetryId: `quotaApproaching${warning.percentUsed}`,
+			telemetryId: `quotaApproaching${warning.threshold}`,
 			severity: ChatInputNotificationSeverity.Info,
 			message: localize('quota.approaching.title', "Credits at {0}%", warning.percentUsed),
 			description,

--- a/src/vs/workbench/contrib/chat/browser/chatQuotaNotification.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatQuotaNotification.ts
@@ -318,7 +318,7 @@ export class ChatQuotaNotificationContribution extends Disposable implements IWo
 
 		this._setNotification({
 			id: QUOTA_NOTIFICATION_ID,
-			telemetryId: 'quotaApproaching',
+			telemetryId: `quotaApproaching${warning.percentUsed}`,
 			severity: ChatInputNotificationSeverity.Info,
 			message: localize('quota.approaching.title', "Credits at {0}%", warning.percentUsed),
 			description,

--- a/src/vs/workbench/contrib/chat/test/browser/chatQuotaNotification.integrationTest.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatQuotaNotification.integrationTest.ts
@@ -301,6 +301,24 @@ suite('ChatQuotaNotificationContribution integration', () => {
 		]);
 	});
 
+	test('emits quota approaching telemetry for the crossed checkpoint when usage jumps past it', () => {
+		const { instantiationService, telemetryAppender, entitlementService } = createHarness({
+			quotas: {
+				premiumChat: createQuotaSnapshot(26),
+			},
+		});
+
+		(entitlementService.service as IChatEntitlementService & { quotas: IChatEntitlementService['quotas'] }).quotas = {
+			...entitlementService.service.quotas,
+			premiumChat: createQuotaSnapshot(17),
+		};
+		entitlementService.onDidChangeQuotaRemaining.fire();
+
+		const widget = store.add(instantiationService.createInstance(ChatInputNotificationWidget, undefined));
+		assert.ok(getRenderedText(widget).includes('Credits at 83%'));
+		assertShownTelemetry(telemetryAppender, 'quotaApproaching75');
+	});
+
 	test('emits shown telemetry when the same notification id changes telemetry context', () => {
 		const { instantiationService, telemetryAppender } = createHarness();
 		const widget = store.add(instantiationService.createInstance(ChatInputNotificationWidget, undefined));

--- a/src/vs/workbench/contrib/chat/test/browser/chatQuotaNotification.integrationTest.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatQuotaNotification.integrationTest.ts
@@ -233,7 +233,7 @@ suite('ChatQuotaNotificationContribution integration', () => {
 						},
 					}),
 					expectedText: 'Credits at 75%',
-					expectedTelemetryId: 'quotaApproaching',
+					expectedTelemetryId: 'quotaApproaching75',
 					afterCreate: ({ entitlementService }) => {
 						(entitlementService.service as IChatEntitlementService & { quotas: IChatEntitlementService['quotas'] }).quotas = {
 							...entitlementService.service.quotas,


### PR DESCRIPTION
Fixes #322746

This appends the quota checkpoint percentage to quota approaching chat input notification telemetry IDs, so each checkpoint can be analyzed separately.