### PR TITLE
Disconnect voice mode when mic permission is denied

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -1214,6 +1214,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			// Disconnect entirely so the user isn't stuck in a connected state
 			// with no way to record. The notification from micCaptureService
 			// tells them how to fix permissions.
+			if (this._pttMaxDurationTimer) {
+				clearTimeout(this._pttMaxDurationTimer);
+				this._pttMaxDurationTimer = undefined;
+			}
 			this.disconnect();
 		});
 		this.ttsPlaybackService.stopPlayback();

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -1211,6 +1211,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this._pttHeld = false;
 			this._statusText.set('Microphone denied', undefined);
 			this._voiceState.set('error', undefined);
+			// Disconnect entirely so the user isn't stuck in a connected state
+			// with no way to record. The notification from micCaptureService
+			// tells them how to fix permissions.
+			this.disconnect();
 		});
 		this.ttsPlaybackService.stopPlayback();
 		this._voiceState.set('listening', undefined);


### PR DESCRIPTION
When `getUserMedia` fails (e.g. `NotAllowedError` because mic permissions are disabled), the voice session was left in a connected state with no way to record — the user was stuck.

Now calls `disconnect()` after the error so the UI fully resets. Combined with the notification from #322621, the user sees an error message explaining how to fix permissions and the voice mode cleanly exits.

Related: microsoft/vscode-internalbacklog#8058