### PR TITLE
feat: update @github/copilot version to 1.0.64 across all package files

### DIFF
--- a/extensions/copilot/package-lock.json
+++ b/extensions/copilot/package-lock.json
@@ -13,7 +13,7 @@
         "@anthropic-ai/claude-agent-sdk": "0.2.112",
         "@anthropic-ai/sdk": "^0.82.0",
         "@github/blackbird-external-ingest-utils": "^0.3.0",
-        "@github/copilot": "^1.0.64-1",
+        "@github/copilot": "^1.0.64",
         "@google/genai": "^1.22.0",
         "@humanwhocodes/gitignore-to-minimatch": "1.0.2",
         "@microsoft/tiktokenizer": "^1.0.10",
@@ -2948,9 +2948,9 @@
       "license": "MIT"
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.64-1.tgz",
-      "integrity": "sha512-lojV4Cb7oT4VJnYPEKBRH8KI3W43Q4Lh0Pc+V6sej+xjPJkoqwm68sNKn73/p3wXPBSTVTzPeCm9WhIisgf1Jw==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.64.tgz",
+      "integrity": "sha512-Dch34NNBWjWlkEUxrC4CkDFunQs5cRmkEEO/PR6Lqj23zzwDwzJUxWA/6K28EokfoPhc9hLyPsCbS9rQ9v2TFA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "detect-libc": "^2.1.2"
@@ -2959,20 +2959,20 @@
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.64-1",
-        "@github/copilot-darwin-x64": "1.0.64-1",
-        "@github/copilot-linux-arm64": "1.0.64-1",
-        "@github/copilot-linux-x64": "1.0.64-1",
-        "@github/copilot-linuxmusl-arm64": "1.0.64-1",
-        "@github/copilot-linuxmusl-x64": "1.0.64-1",
-        "@github/copilot-win32-arm64": "1.0.64-1",
-        "@github/copilot-win32-x64": "1.0.64-1"
+        "@github/copilot-darwin-arm64": "1.0.64",
+        "@github/copilot-darwin-x64": "1.0.64",
+        "@github/copilot-linux-arm64": "1.0.64",
+        "@github/copilot-linux-x64": "1.0.64",
+        "@github/copilot-linuxmusl-arm64": "1.0.64",
+        "@github/copilot-linuxmusl-x64": "1.0.64",
+        "@github/copilot-win32-arm64": "1.0.64",
+        "@github/copilot-win32-x64": "1.0.64"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.64-1.tgz",
-      "integrity": "sha512-MQHZT9LhmCiq+ogO1E8cPCWrurZ6x+r9lPJfYUSnOyMO+EHbREpiJwOOChxtLHgL2/tKJSZdId2pg3tDgUlcsw==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.64.tgz",
+      "integrity": "sha512-2+ma5M0kwfSytB1Js8vl16ffZ4oCntgs0hFqeZ/zyV3ZQ4cNmDokxa/VLYGyOIQD0oeTZyZdcDJiGrlsYhoYgw==",
       "cpu": [
         "arm64"
       ],
@@ -2986,9 +2986,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.64-1.tgz",
-      "integrity": "sha512-kOQY7CvI7He0eO3ObQAHePWdkNLWAOegCSzUqUmdcpa1SNVqbZ3GBMsQ7uAZQip2cQxnGZ7pS1v6tKQ0HJdkYw==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.64.tgz",
+      "integrity": "sha512-mwjZ0/HZ7loXnahkqhy7LXvNVzq12eghoawd+M2d7kiHMR5yAHK6XA++6kKFj3vZnDanjau+wyvTx0z++mQ3LA==",
       "cpu": [
         "x64"
       ],
@@ -3002,11 +3002,14 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.64-1.tgz",
-      "integrity": "sha512-hIfuO7Q+pWs0SKfIRYqT+CjMaupudnhp4RMS6XoJ5s/e33rvpj2tkTkXYlHJo1PMDI823vvbqgpEdr+KeewMwg==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.64.tgz",
+      "integrity": "sha512-Krg/3ZWxXB7Dw4VOLZEZrYmqc39Yvz9M1K9SPOfjpEy2SFnF/KVLaFt/6E1uYdjgvJ7BmocfVcFYp0hUmy5Axw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -3018,11 +3021,14 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.64-1.tgz",
-      "integrity": "sha512-VHaE62pha0rDDvuNN3bd97gf0EZ+EJebstM1ejHsMYoPT1IOUkYEXlNfGGHY+GfUGYxAiy/+Uew4xw5mJyy/Sw==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.64.tgz",
+      "integrity": "sha512-2k9FGppYnxHLwVH+TVCf13JfjSlvS15wsZM5xYxEFlqL/CIBvTK7yn5p7M+P1dWoTUpCmavKG3601BtHPenrRg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -3034,11 +3040,14 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-arm64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.64-1.tgz",
-      "integrity": "sha512-L/YrZPotRujAP0QERq+DlkR1SLr7abbTSz/56JqKKOqEdjKZPdQW1bUlhL/w1CZg1gXlTNUsNVyKz/fUfrEBgw==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.64.tgz",
+      "integrity": "sha512-C+EYoMvmlUxR0YYxLkD3nwn940y0zId8z+pPl9rFO6f9heMGXYCwCZL2i2c3GW6CvGgZF6Wbzw1Kk0Gvw46F2w==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -3050,11 +3059,14 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-x64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.64-1.tgz",
-      "integrity": "sha512-AGMjXqR128oyjiJhoI6Gd7JP5ddWkib+P4YH/JoHm05iNn23ZYl4tSc0XihHzeyMI1ix7Aacn8UINYB7lGOGOA==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.64.tgz",
+      "integrity": "sha512-VSTGl7dGQDhH2ACeyYq1hYhAsMUbumpqeVe+CGo/u7fKOMrTNMTR5SB3s+zsHCskKZkJkZ2gsUWROCiDBsThEg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -3066,9 +3078,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.64-1.tgz",
-      "integrity": "sha512-vvv+gnemi9WKaxF41zz7Xmq6a493n8Yjps5UFaOY6a3WR222kKXZXfOpeRvIYsDgnIPHGBHIj1TBOmnHQT4V4w==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.64.tgz",
+      "integrity": "sha512-16gb2T0rQ3QI/rs7mJa3xSks0/ZFrFKoMro3tvgM/c89J/5PTpykpLIuD2Zhl1cC3FqaFzcSYzdupxu82Aj2tQ==",
       "cpu": [
         "arm64"
       ],
@@ -3082,9 +3094,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.64-1.tgz",
-      "integrity": "sha512-mcHvD0fjGDuqr/YXzy8mKuDmah1F+qjPujxoFuGmabmTJZ33cSIJ3nq7RRvxZNIdp8YJ57NkbcW30WvIcOeJ3w==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.64.tgz",
+      "integrity": "sha512-Ki+St5eggcATHdPLc58RGrOuCX+igblD3/TmlQ8WTHmZxcyuKJl9RNzui3ioVi7ntLmKWriW5r/VH/DTHVKT8g==",
       "cpu": [
         "x64"
       ],

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -7086,7 +7086,7 @@
     "@anthropic-ai/claude-agent-sdk": "0.2.112",
     "@anthropic-ai/sdk": "^0.82.0",
     "@github/blackbird-external-ingest-utils": "^0.3.0",
-    "@github/copilot": "^1.0.64-1",
+    "@github/copilot": "^1.0.64",
     "@google/genai": "^1.22.0",
     "@humanwhocodes/gitignore-to-minimatch": "1.0.2",
     "@microsoft/tiktokenizer": "^1.0.10",

--- a/extensions/copilot/script/postinstall.ts
+++ b/extensions/copilot/script/postinstall.ts
@@ -212,7 +212,9 @@ async function copyCopilotCliPrebuildFiles(copilotCliSourceDir: string) {
 				if (fs.statSync(src).isFile()) {
 					const normalizedSrc = src.split(path.sep).join(path.posix.sep);
 					return src.endsWith('computer.node')
+						|| src.includes('opilot Computer Use.app')
 						|| src.endsWith('runtime.node')
+						|| src.endsWith('computer-use-mcp')
 						|| src.endsWith('cli-native.node')
 						// node-pty natives: pty.node (+ spawn-helper) on Unix,
 						// conpty.node and its companions on Windows. `endsWith('pty.node')`

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/vscode-node/test/copilotCLISDKUpgrade.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/vscode-node/test/copilotCLISDKUpgrade.spec.ts
@@ -50,7 +50,11 @@ describe('CopilotCLI SDK Upgrade', function () {
 			path.join('prebuilds', 'darwin-arm64', 'spawn-helper'),
 			path.join('prebuilds', 'darwin-x64', 'spawn-helper'),
 			// computer use
-			path.join('prebuilds', 'darwin-arm64', 'computer.node'),
+			path.join('prebuilds', 'darwin-arm64', 'Copilot Computer Use.app/Contents/CodeResources'),
+			path.join('prebuilds', 'darwin-arm64', 'Copilot Computer Use.app/Contents/MacOS/Copilot Computer Use'),
+			path.join('prebuilds', 'darwin-arm64', 'Copilot Computer Use.app/Contents/Resources/icon.icns'),
+			path.join('prebuilds', 'darwin-arm64', 'Copilot Computer Use.app/Contents/Resources/Assets.car'),
+			path.join('prebuilds', 'darwin-arm64', 'computer-use-mcp'),
 			path.join('prebuilds', 'darwin-x64', 'computer.node'),
 			path.join('prebuilds', 'linux-arm64', 'computer.node'),
 			path.join('prebuilds', 'linux-x64', 'computer.node'),
@@ -77,7 +81,11 @@ describe('CopilotCLI SDK Upgrade', function () {
 			path.join('prebuilds', 'win32-x64', 'runtime.node'),
 			// Second copy of native prebuilds re-shipped by the @github/copilot/sdk subpackage
 			// (previously hidden by a broad sdk/prebuilds/** exclusion that masked the node-pty files we used to shim in at test setup).
-			path.join('sdk', 'prebuilds', 'darwin-arm64', 'computer.node'),
+			path.join('sdk', 'prebuilds', 'darwin-arm64', 'Copilot Computer Use.app/Contents/CodeResources'),
+			path.join('sdk', 'prebuilds', 'darwin-arm64', 'Copilot Computer Use.app/Contents/MacOS/Copilot Computer Use'),
+			path.join('sdk', 'prebuilds', 'darwin-arm64', 'Copilot Computer Use.app/Contents/Resources/icon.icns'),
+			path.join('sdk', 'prebuilds', 'darwin-arm64', 'Copilot Computer Use.app/Contents/Resources/Assets.car'),
+			path.join('sdk', 'prebuilds', 'darwin-arm64', 'computer-use-mcp'),
 			path.join('sdk', 'prebuilds', 'darwin-x64', 'computer.node'),
 			path.join('sdk', 'prebuilds', 'linux-arm64', 'computer.node'),
 			path.join('sdk', 'prebuilds', 'linux-x64', 'computer.node'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",
-        "@github/copilot": "^1.0.64-1",
+        "@github/copilot": "^1.0.64",
         "@github/copilot-sdk": "^1.0.3",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
@@ -1085,9 +1085,9 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.64-1.tgz",
-      "integrity": "sha512-lojV4Cb7oT4VJnYPEKBRH8KI3W43Q4Lh0Pc+V6sej+xjPJkoqwm68sNKn73/p3wXPBSTVTzPeCm9WhIisgf1Jw==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.64.tgz",
+      "integrity": "sha512-Dch34NNBWjWlkEUxrC4CkDFunQs5cRmkEEO/PR6Lqj23zzwDwzJUxWA/6K28EokfoPhc9hLyPsCbS9rQ9v2TFA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "detect-libc": "^2.1.2"
@@ -1096,20 +1096,20 @@
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.64-1",
-        "@github/copilot-darwin-x64": "1.0.64-1",
-        "@github/copilot-linux-arm64": "1.0.64-1",
-        "@github/copilot-linux-x64": "1.0.64-1",
-        "@github/copilot-linuxmusl-arm64": "1.0.64-1",
-        "@github/copilot-linuxmusl-x64": "1.0.64-1",
-        "@github/copilot-win32-arm64": "1.0.64-1",
-        "@github/copilot-win32-x64": "1.0.64-1"
+        "@github/copilot-darwin-arm64": "1.0.64",
+        "@github/copilot-darwin-x64": "1.0.64",
+        "@github/copilot-linux-arm64": "1.0.64",
+        "@github/copilot-linux-x64": "1.0.64",
+        "@github/copilot-linuxmusl-arm64": "1.0.64",
+        "@github/copilot-linuxmusl-x64": "1.0.64",
+        "@github/copilot-win32-arm64": "1.0.64",
+        "@github/copilot-win32-x64": "1.0.64"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.64-1.tgz",
-      "integrity": "sha512-MQHZT9LhmCiq+ogO1E8cPCWrurZ6x+r9lPJfYUSnOyMO+EHbREpiJwOOChxtLHgL2/tKJSZdId2pg3tDgUlcsw==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.64.tgz",
+      "integrity": "sha512-2+ma5M0kwfSytB1Js8vl16ffZ4oCntgs0hFqeZ/zyV3ZQ4cNmDokxa/VLYGyOIQD0oeTZyZdcDJiGrlsYhoYgw==",
       "cpu": [
         "arm64"
       ],
@@ -1123,9 +1123,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.64-1.tgz",
-      "integrity": "sha512-kOQY7CvI7He0eO3ObQAHePWdkNLWAOegCSzUqUmdcpa1SNVqbZ3GBMsQ7uAZQip2cQxnGZ7pS1v6tKQ0HJdkYw==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.64.tgz",
+      "integrity": "sha512-mwjZ0/HZ7loXnahkqhy7LXvNVzq12eghoawd+M2d7kiHMR5yAHK6XA++6kKFj3vZnDanjau+wyvTx0z++mQ3LA==",
       "cpu": [
         "x64"
       ],
@@ -1139,11 +1139,14 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.64-1.tgz",
-      "integrity": "sha512-hIfuO7Q+pWs0SKfIRYqT+CjMaupudnhp4RMS6XoJ5s/e33rvpj2tkTkXYlHJo1PMDI823vvbqgpEdr+KeewMwg==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.64.tgz",
+      "integrity": "sha512-Krg/3ZWxXB7Dw4VOLZEZrYmqc39Yvz9M1K9SPOfjpEy2SFnF/KVLaFt/6E1uYdjgvJ7BmocfVcFYp0hUmy5Axw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -1155,11 +1158,14 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.64-1.tgz",
-      "integrity": "sha512-VHaE62pha0rDDvuNN3bd97gf0EZ+EJebstM1ejHsMYoPT1IOUkYEXlNfGGHY+GfUGYxAiy/+Uew4xw5mJyy/Sw==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.64.tgz",
+      "integrity": "sha512-2k9FGppYnxHLwVH+TVCf13JfjSlvS15wsZM5xYxEFlqL/CIBvTK7yn5p7M+P1dWoTUpCmavKG3601BtHPenrRg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -1171,11 +1177,14 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-arm64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.64-1.tgz",
-      "integrity": "sha512-L/YrZPotRujAP0QERq+DlkR1SLr7abbTSz/56JqKKOqEdjKZPdQW1bUlhL/w1CZg1gXlTNUsNVyKz/fUfrEBgw==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.64.tgz",
+      "integrity": "sha512-C+EYoMvmlUxR0YYxLkD3nwn940y0zId8z+pPl9rFO6f9heMGXYCwCZL2i2c3GW6CvGgZF6Wbzw1Kk0Gvw46F2w==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -1187,11 +1196,14 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-x64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.64-1.tgz",
-      "integrity": "sha512-AGMjXqR128oyjiJhoI6Gd7JP5ddWkib+P4YH/JoHm05iNn23ZYl4tSc0XihHzeyMI1ix7Aacn8UINYB7lGOGOA==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.64.tgz",
+      "integrity": "sha512-VSTGl7dGQDhH2ACeyYq1hYhAsMUbumpqeVe+CGo/u7fKOMrTNMTR5SB3s+zsHCskKZkJkZ2gsUWROCiDBsThEg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -1226,9 +1238,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.64-1.tgz",
-      "integrity": "sha512-vvv+gnemi9WKaxF41zz7Xmq6a493n8Yjps5UFaOY6a3WR222kKXZXfOpeRvIYsDgnIPHGBHIj1TBOmnHQT4V4w==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.64.tgz",
+      "integrity": "sha512-16gb2T0rQ3QI/rs7mJa3xSks0/ZFrFKoMro3tvgM/c89J/5PTpykpLIuD2Zhl1cC3FqaFzcSYzdupxu82Aj2tQ==",
       "cpu": [
         "arm64"
       ],
@@ -1242,9 +1254,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.64-1.tgz",
-      "integrity": "sha512-mcHvD0fjGDuqr/YXzy8mKuDmah1F+qjPujxoFuGmabmTJZ33cSIJ3nq7RRvxZNIdp8YJ57NkbcW30WvIcOeJ3w==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.64.tgz",
+      "integrity": "sha512-Ki+St5eggcATHdPLc58RGrOuCX+igblD3/TmlQ8WTHmZxcyuKJl9RNzui3ioVi7ntLmKWriW5r/VH/DTHVKT8g==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",
-    "@github/copilot": "^1.0.64-1",
+    "@github/copilot": "^1.0.64",
     "@github/copilot-sdk": "^1.0.3",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -8,7 +8,7 @@
       "name": "vscode-reh",
       "version": "0.0.0",
       "dependencies": {
-        "@github/copilot": "^1.0.64-1",
+        "@github/copilot": "^1.0.64",
         "@github/copilot-sdk": "^1.0.3",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.64-1.tgz",
-      "integrity": "sha512-lojV4Cb7oT4VJnYPEKBRH8KI3W43Q4Lh0Pc+V6sej+xjPJkoqwm68sNKn73/p3wXPBSTVTzPeCm9WhIisgf1Jw==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.64.tgz",
+      "integrity": "sha512-Dch34NNBWjWlkEUxrC4CkDFunQs5cRmkEEO/PR6Lqj23zzwDwzJUxWA/6K28EokfoPhc9hLyPsCbS9rQ9v2TFA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "detect-libc": "^2.1.2"
@@ -71,20 +71,20 @@
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.64-1",
-        "@github/copilot-darwin-x64": "1.0.64-1",
-        "@github/copilot-linux-arm64": "1.0.64-1",
-        "@github/copilot-linux-x64": "1.0.64-1",
-        "@github/copilot-linuxmusl-arm64": "1.0.64-1",
-        "@github/copilot-linuxmusl-x64": "1.0.64-1",
-        "@github/copilot-win32-arm64": "1.0.64-1",
-        "@github/copilot-win32-x64": "1.0.64-1"
+        "@github/copilot-darwin-arm64": "1.0.64",
+        "@github/copilot-darwin-x64": "1.0.64",
+        "@github/copilot-linux-arm64": "1.0.64",
+        "@github/copilot-linux-x64": "1.0.64",
+        "@github/copilot-linuxmusl-arm64": "1.0.64",
+        "@github/copilot-linuxmusl-x64": "1.0.64",
+        "@github/copilot-win32-arm64": "1.0.64",
+        "@github/copilot-win32-x64": "1.0.64"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.64-1.tgz",
-      "integrity": "sha512-MQHZT9LhmCiq+ogO1E8cPCWrurZ6x+r9lPJfYUSnOyMO+EHbREpiJwOOChxtLHgL2/tKJSZdId2pg3tDgUlcsw==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.64.tgz",
+      "integrity": "sha512-2+ma5M0kwfSytB1Js8vl16ffZ4oCntgs0hFqeZ/zyV3ZQ4cNmDokxa/VLYGyOIQD0oeTZyZdcDJiGrlsYhoYgw==",
       "cpu": [
         "arm64"
       ],
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.64-1.tgz",
-      "integrity": "sha512-kOQY7CvI7He0eO3ObQAHePWdkNLWAOegCSzUqUmdcpa1SNVqbZ3GBMsQ7uAZQip2cQxnGZ7pS1v6tKQ0HJdkYw==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.64.tgz",
+      "integrity": "sha512-mwjZ0/HZ7loXnahkqhy7LXvNVzq12eghoawd+M2d7kiHMR5yAHK6XA++6kKFj3vZnDanjau+wyvTx0z++mQ3LA==",
       "cpu": [
         "x64"
       ],
@@ -114,11 +114,14 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.64-1.tgz",
-      "integrity": "sha512-hIfuO7Q+pWs0SKfIRYqT+CjMaupudnhp4RMS6XoJ5s/e33rvpj2tkTkXYlHJo1PMDI823vvbqgpEdr+KeewMwg==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.64.tgz",
+      "integrity": "sha512-Krg/3ZWxXB7Dw4VOLZEZrYmqc39Yvz9M1K9SPOfjpEy2SFnF/KVLaFt/6E1uYdjgvJ7BmocfVcFYp0hUmy5Axw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -130,11 +133,14 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.64-1.tgz",
-      "integrity": "sha512-VHaE62pha0rDDvuNN3bd97gf0EZ+EJebstM1ejHsMYoPT1IOUkYEXlNfGGHY+GfUGYxAiy/+Uew4xw5mJyy/Sw==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.64.tgz",
+      "integrity": "sha512-2k9FGppYnxHLwVH+TVCf13JfjSlvS15wsZM5xYxEFlqL/CIBvTK7yn5p7M+P1dWoTUpCmavKG3601BtHPenrRg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -146,11 +152,14 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-arm64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.64-1.tgz",
-      "integrity": "sha512-L/YrZPotRujAP0QERq+DlkR1SLr7abbTSz/56JqKKOqEdjKZPdQW1bUlhL/w1CZg1gXlTNUsNVyKz/fUfrEBgw==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.64.tgz",
+      "integrity": "sha512-C+EYoMvmlUxR0YYxLkD3nwn940y0zId8z+pPl9rFO6f9heMGXYCwCZL2i2c3GW6CvGgZF6Wbzw1Kk0Gvw46F2w==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -162,11 +171,14 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-x64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.64-1.tgz",
-      "integrity": "sha512-AGMjXqR128oyjiJhoI6Gd7JP5ddWkib+P4YH/JoHm05iNn23ZYl4tSc0XihHzeyMI1ix7Aacn8UINYB7lGOGOA==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.64.tgz",
+      "integrity": "sha512-VSTGl7dGQDhH2ACeyYq1hYhAsMUbumpqeVe+CGo/u7fKOMrTNMTR5SB3s+zsHCskKZkJkZ2gsUWROCiDBsThEg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -201,9 +213,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.64-1.tgz",
-      "integrity": "sha512-vvv+gnemi9WKaxF41zz7Xmq6a493n8Yjps5UFaOY6a3WR222kKXZXfOpeRvIYsDgnIPHGBHIj1TBOmnHQT4V4w==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.64.tgz",
+      "integrity": "sha512-16gb2T0rQ3QI/rs7mJa3xSks0/ZFrFKoMro3tvgM/c89J/5PTpykpLIuD2Zhl1cC3FqaFzcSYzdupxu82Aj2tQ==",
       "cpu": [
         "arm64"
       ],
@@ -217,9 +229,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.64-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.64-1.tgz",
-      "integrity": "sha512-mcHvD0fjGDuqr/YXzy8mKuDmah1F+qjPujxoFuGmabmTJZ33cSIJ3nq7RRvxZNIdp8YJ57NkbcW30WvIcOeJ3w==",
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.64.tgz",
+      "integrity": "sha512-Ki+St5eggcATHdPLc58RGrOuCX+igblD3/TmlQ8WTHmZxcyuKJl9RNzui3ioVi7ntLmKWriW5r/VH/DTHVKT8g==",
       "cpu": [
         "x64"
       ],

--- a/remote/package.json
+++ b/remote/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@github/copilot": "^1.0.64-1",
+    "@github/copilot": "^1.0.64",
     "@github/copilot-sdk": "^1.0.3",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",


### PR DESCRIPTION
- Updated the version of @github/copilot from 1.0.64-1 to 1.0.64 in package.json and package-lock.json files in the extensions/copilot and remote directories.
- Adjusted the integrity hashes and resolved URLs in package-lock.json to reflect the new version.
- Modified postinstall.ts to include additional files related to "Copilot Computer Use.app" and "computer-use-mcp".
- Updated test specifications in copilotCLISDKUpgrade.spec.ts to include paths for the new app structure.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
