### PR TITLE
Respect chat.tools.terminal.autoApprove for agent host

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -37,7 +37,7 @@ import { encodeBase64 } from '../../../base/common/buffer.js';
 import { ILoadEstimator, LoadEstimator } from '../../../base/parts/ipc/common/ipc.net.js';
 import { TELEMETRY_CRASH_REPORTER_SETTING_ID, TELEMETRY_OLD_SETTING_ID, TELEMETRY_SETTING_ID } from '../../telemetry/common/telemetry.js';
 import { getTelemetryLevel } from '../../telemetry/common/telemetryUtils.js';
-import { AgentHostTelemetryLevelConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, SESSION_SYNC_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, GLOBAL_AUTO_APPROVE_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
+import { AgentHostTelemetryLevelConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, getAgentHostTerminalAutoApproveRulesConfig, SESSION_SYNC_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, GLOBAL_AUTO_APPROVE_SETTING_ID, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
 import type { OtlpExportLogsParams } from '../common/state/protocol/channels-otlp/notifications.js';
 import type { TelemetryCapabilities } from '../common/state/protocol/channels-otlp/state.js';
 import type { InitializeResult } from '../common/state/protocol/common/commands.js';
@@ -350,6 +350,12 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 				}
 				this._updateGlobalAutoApproveEnabled();
 			}
+			if (e.affectsConfiguration(TERMINAL_AUTO_APPROVE_SETTING_ID) || e.affectsConfiguration(TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID)) {
+				if (this._state.kind !== AgentHostClientState.Connected) {
+					return;
+				}
+				this._updateTerminalAutoApproveRules();
+			}
 		}));
 
 		// Detect silently-dead transports — see {@link _resetLivenessTimers}.
@@ -439,6 +445,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		this._updateSessionSyncEnabled();
 		this._updateTerminalAutoApproveEnabled();
 		this._updateGlobalAutoApproveEnabled();
+		this._updateTerminalAutoApproveRules();
 		this._transitionTo({ kind: AgentHostClientState.Connected });
 	}
 
@@ -1321,6 +1328,13 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		this.dispatchAction(ROOT_STATE_URI, {
 			type: ActionType.RootConfigChanged,
 			config: { [AgentHostGlobalAutoApproveEnabledConfigKey]: enabled },
+		}, this._clientId, 0);
+	}
+
+	private _updateTerminalAutoApproveRules(): void {
+		this.dispatchAction(ROOT_STATE_URI, {
+			type: ActionType.RootConfigChanged,
+			config: { [AgentHostTerminalAutoApproveRulesConfigKey]: getAgentHostTerminalAutoApproveRulesConfig(this._configurationService) },
 		}, this._clientId, 0);
 	}
 

--- a/src/vs/platform/agentHost/common/agentHostSchema.ts
+++ b/src/vs/platform/agentHost/common/agentHostSchema.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from '../../../nls.js';
+import { structuralEquals } from '../../../base/common/equals.js';
+import { ConfigurationTarget, type IConfigurationService, type IConfigurationValue } from '../../configuration/common/configuration.js';
 import type { IMcpServerConfiguration } from '../../mcp/common/mcpPlatformTypes.js';
 import { TelemetryConfiguration, TelemetryLevel } from '../../telemetry/common/telemetry.js';
 import { SessionConfigKey } from './sessionConfigKeys.js';
@@ -420,6 +422,89 @@ export const AgentHostGlobalAutoApproveEnabledConfigKey = 'globalAutoApproveEnab
 export const GLOBAL_AUTO_APPROVE_SETTING_ID = 'chat.tools.global.autoApprove';
 
 /**
+ * Root config key forwarded from the renderer when VS Code's
+ * `chat.tools.terminal.autoApprove` setting changes. Holds the effective
+ * terminal auto-approve rule object for agent-host shell permission checks.
+ */
+export const AgentHostTerminalAutoApproveRulesConfigKey = 'terminalAutoApproveRules';
+
+export interface IAgentHostTerminalAutoApproveRule {
+	readonly approve: boolean;
+	readonly matchCommandLine?: boolean;
+}
+
+export type AgentHostTerminalAutoApproveRuleValue = boolean | null | IAgentHostTerminalAutoApproveRule;
+export type AgentHostTerminalAutoApproveRules = Record<string, AgentHostTerminalAutoApproveRuleValue>;
+
+/**
+ * The VS Code setting IDs for terminal auto approve rules. Defined here so
+ * renderer-side agent-host clients can forward them without importing from
+ * workbench terminal contributions.
+ */
+export const TERMINAL_AUTO_APPROVE_SETTING_ID = 'chat.tools.terminal.autoApprove';
+export const TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID = 'chat.tools.terminal.ignoreDefaultAutoApproveRules';
+
+export function getAgentHostTerminalAutoApproveRulesConfig(configurationService: IConfigurationService): AgentHostTerminalAutoApproveRules {
+	const config = configurationService.getValue<AgentHostTerminalAutoApproveRules | undefined>(TERMINAL_AUTO_APPROVE_SETTING_ID);
+	const configInspectValue = configurationService.inspect<Readonly<AgentHostTerminalAutoApproveRules>>(TERMINAL_AUTO_APPROVE_SETTING_ID);
+	const ignoreDefaults = configurationService.getValue<boolean>(TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID) === true;
+	return normalizeAgentHostTerminalAutoApproveRulesConfig(config, configInspectValue, ignoreDefaults);
+}
+
+export function normalizeAgentHostTerminalAutoApproveRulesConfig(config: AgentHostTerminalAutoApproveRules | undefined, configInspectValue: IConfigurationValue<Readonly<AgentHostTerminalAutoApproveRules>>, ignoreDefaults: boolean): AgentHostTerminalAutoApproveRules {
+	if (!config) {
+		return {};
+	}
+
+	const rules: AgentHostTerminalAutoApproveRules = {};
+	for (const [key, value] of Object.entries(config)) {
+		if (ignoreDefaults && isDefaultOnlyAutoApproveRule(key, value, configInspectValue)) {
+			continue;
+		}
+		rules[key] = value;
+	}
+	return rules;
+}
+
+function isDefaultOnlyAutoApproveRule(key: string, value: AgentHostTerminalAutoApproveRuleValue, configInspectValue: IConfigurationValue<Readonly<AgentHostTerminalAutoApproveRules>>): boolean {
+	const defaultValue = configInspectValue.default?.value;
+	const isDefaultRule = hasMatchingRule(defaultValue, key, value);
+	if (!isDefaultRule) {
+		return false;
+	}
+
+	const sourceTarget = getAutoApproveRuleSourceTarget(key, value, configInspectValue);
+
+	return sourceTarget === ConfigurationTarget.DEFAULT;
+}
+
+function getAutoApproveRuleSourceTarget(key: string, value: AgentHostTerminalAutoApproveRuleValue, configInspectValue: IConfigurationValue<Readonly<AgentHostTerminalAutoApproveRules>>): ConfigurationTarget {
+	if (hasMatchingRule(configInspectValue.workspaceFolderValue, key, value)) {
+		return ConfigurationTarget.WORKSPACE_FOLDER;
+	}
+	if (hasMatchingRule(configInspectValue.workspaceValue, key, value)) {
+		return ConfigurationTarget.WORKSPACE;
+	}
+	if (hasMatchingRule(configInspectValue.userRemoteValue, key, value)) {
+		return ConfigurationTarget.USER_REMOTE;
+	}
+	if (hasMatchingRule(configInspectValue.userLocalValue, key, value)) {
+		return ConfigurationTarget.USER_LOCAL;
+	}
+	if (hasMatchingRule(configInspectValue.userValue, key, value)) {
+		return ConfigurationTarget.USER;
+	}
+	if (hasMatchingRule(configInspectValue.applicationValue, key, value)) {
+		return ConfigurationTarget.APPLICATION;
+	}
+	return ConfigurationTarget.DEFAULT;
+}
+
+function hasMatchingRule(config: Readonly<AgentHostTerminalAutoApproveRules> | undefined, key: string, value: AgentHostTerminalAutoApproveRuleValue): boolean {
+	return !!config && Object.prototype.hasOwnProperty.call(config, key) && structuralEquals(config[key], value);
+}
+
+/**
  * Root config key holding agent-host-level MCP server definitions.
  *
  * The value is a map of server name → {@link IMcpServerConfiguration}
@@ -553,7 +638,7 @@ export const platformRootSchema = createSchema({
 	[AgentHostTerminalAutoApproveEnabledConfigKey]: schemaProperty<boolean>({
 		type: 'boolean',
 		title: localize('agentHost.config.terminalAutoApproveEnabled.title', "Terminal Auto Approve"),
-		description: localize('agentHost.config.terminalAutoApproveEnabled.description', "Whether terminal auto-approve rules are allowed to apply to agent-host shell permission requests."),
+		description: localize('agentHost.config.terminalAutoApproveEnabled.description', "Whether terminal auto-approve rules forwarded by the connected client are allowed to apply to agent-host shell permission requests."),
 		default: true,
 	}),
 	[AgentHostGlobalAutoApproveEnabledConfigKey]: schemaProperty<boolean>({
@@ -561,6 +646,12 @@ export const platformRootSchema = createSchema({
 		title: localize('agentHost.config.globalAutoApproveEnabled.title', "Global Auto Approve"),
 		description: localize('agentHost.config.globalAutoApproveEnabled.description', "Whether VS Code's global auto-approve setting is enabled. When `true`, every tool call is auto-approved, equivalent to a session using Bypass Approvals."),
 		default: false,
+	}),
+	[AgentHostTerminalAutoApproveRulesConfigKey]: schemaProperty<AgentHostTerminalAutoApproveRules>({
+		type: 'object',
+		title: localize('agentHost.config.terminalAutoApproveRules.title', "Terminal Auto Approve Rules"),
+		description: localize('agentHost.config.terminalAutoApproveRules.description', "Terminal auto-approve rules forwarded by the connected client for agent-host shell permission checks."),
+		default: {},
 	}),
 	[AgentHostMcpServersConfigKey]: schemaProperty<AgentHostMcpServers>({
 		type: 'object',

--- a/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
+++ b/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
@@ -30,7 +30,7 @@ import { URI } from '../../../base/common/uri.js';
 import { AGENT_HOST_CLIENT_RESOURCE_CHANNEL, AgentHostClientResourceChannel } from '../common/agentHostClientResourceChannel.js';
 import { TELEMETRY_CRASH_REPORTER_SETTING_ID, TELEMETRY_OLD_SETTING_ID, TELEMETRY_SETTING_ID } from '../../telemetry/common/telemetry.js';
 import { getTelemetryLevel } from '../../telemetry/common/telemetryUtils.js';
-import { AgentHostTelemetryLevelConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, SESSION_SYNC_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, GLOBAL_AUTO_APPROVE_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
+import { AgentHostTelemetryLevelConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, getAgentHostTerminalAutoApproveRulesConfig, SESSION_SYNC_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, GLOBAL_AUTO_APPROVE_SETTING_ID, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
 
 /**
  * Renderer-side implementation of {@link IAgentHostService} that connects
@@ -133,6 +133,9 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 			if (e.affectsConfiguration(GLOBAL_AUTO_APPROVE_SETTING_ID)) {
 				this._updateGlobalAutoApproveEnabled();
 			}
+			if (e.affectsConfiguration(TERMINAL_AUTO_APPROVE_SETTING_ID) || e.affectsConfiguration(TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID)) {
+				this._updateTerminalAutoApproveRules();
+			}
 		}));
 
 		if (isAgentHostEnabled(this._configurationService)) {
@@ -159,6 +162,7 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 		this._updateSessionSyncEnabled();
 		this._updateTerminalAutoApproveEnabled();
 		this._updateGlobalAutoApproveEnabled();
+		this._updateTerminalAutoApproveRules();
 
 		store.add(this._proxy.onDidAction(e => {
 			const revived = revive(e) as ActionEnvelope;
@@ -219,6 +223,13 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 		this.dispatchAction(ROOT_STATE_URI, {
 			type: ActionType.RootConfigChanged,
 			config: { [AgentHostGlobalAutoApproveEnabledConfigKey]: enabled },
+		}, this.clientId, 0);
+	}
+
+	private _updateTerminalAutoApproveRules(): void {
+		this.dispatchAction(ROOT_STATE_URI, {
+			type: ActionType.RootConfigChanged,
+			config: { [AgentHostTerminalAutoApproveRulesConfigKey]: getAgentHostTerminalAutoApproveRulesConfig(this._configurationService) },
 		}, this.clientId, 0);
 	}
 

--- a/src/vs/platform/agentHost/node/commandAutoApprover.ts
+++ b/src/vs/platform/agentHost/node/commandAutoApprover.ts
@@ -446,6 +446,8 @@ function convertAutoApproveEntryToRegex(value: string): RegExp {
 //
 // Compatibility fallback for clients that do not forward the VS Code
 // `chat.tools.terminal.autoApprove` setting.
+// TODO: Remove this fallback once all agent-host clients are guaranteed to
+// forward `chat.tools.terminal.autoApprove` before shell approvals run.
 
 const DEFAULT_TERMINAL_AUTO_APPROVE_RULES: Readonly<Record<string, AgentHostTerminalAutoApproveRuleValue>> = {
 	// Safe readonly commands

--- a/src/vs/platform/agentHost/node/commandAutoApprover.ts
+++ b/src/vs/platform/agentHost/node/commandAutoApprover.ts
@@ -139,6 +139,8 @@ const transientEnvVarRegex = /^[A-Z_][A-Z0-9_]*=/i;
 export class CommandAutoApprover extends Disposable {
 
 	private _fallbackRules: IAutoApproveRules | undefined;
+	private _cachedRuleConfig: AgentHostTerminalAutoApproveRules | undefined;
+	private _cachedRules: IAutoApproveRules | undefined;
 	private _parser: Parser | undefined;
 	private _bashLanguage: Language | undefined;
 	private _queryClass: typeof Query | undefined;
@@ -352,7 +354,13 @@ export class CommandAutoApprover extends Disposable {
 			return this._fallbackRules;
 		}
 
-		return this._compileRuleEntries(ruleConfig);
+		if (this._cachedRuleConfig === ruleConfig && this._cachedRules) {
+			return this._cachedRules;
+		}
+
+		this._cachedRuleConfig = ruleConfig;
+		this._cachedRules = this._compileRuleEntries(ruleConfig);
+		return this._cachedRules;
 	}
 
 	private _compileRuleEntries(ruleConfig: Readonly<Record<string, AgentHostTerminalAutoApproveRuleValue>>): IAutoApproveRules {

--- a/src/vs/platform/agentHost/node/commandAutoApprover.ts
+++ b/src/vs/platform/agentHost/node/commandAutoApprover.ts
@@ -10,6 +10,7 @@ import { FileAccess } from '../../../base/common/network.js';
 import { escapeRegExpCharacters, regExpLeadsToEndlessLoop } from '../../../base/common/strings.js';
 import { URI } from '../../../base/common/uri.js';
 import { ILogService } from '../../log/common/log.js';
+import type { AgentHostTerminalAutoApproveRuleValue, AgentHostTerminalAutoApproveRules } from '../common/agentHostSchema.js';
 
 /**
  * Redirect destinations that do not result in a write to an arbitrary file
@@ -98,22 +99,36 @@ export interface IShouldAutoApproveOptions {
 	 * sinks (e.g. `/dev/null`) downgrades the result to `noMatch`.
 	 */
 	readonly isWriteDestApproved?: (dest: string) => boolean;
+	/**
+	 * Effective VS Code `chat.tools.terminal.autoApprove` rules forwarded from
+	 * the renderer. When omitted, the agent host falls back to its bundled
+	 * default rules for compatibility with older clients.
+	 */
+	readonly autoApproveRules?: AgentHostTerminalAutoApproveRules;
 }
 
 interface IAutoApproveRule {
 	readonly regex: RegExp;
 }
 
+interface IAutoApproveRules {
+	readonly allowRules: IAutoApproveRule[];
+	readonly denyRules: IAutoApproveRule[];
+	readonly allowCommandLineRules: IAutoApproveRule[];
+	readonly denyCommandLineRules: IAutoApproveRule[];
+}
+
 const neverMatchRegex = /(?!.*)/;
 const transientEnvVarRegex = /^[A-Z_][A-Z0-9_]*=/i;
 
 /**
- * Auto-approves or denies shell commands based on default rules.
+ * Auto-approves or denies shell commands based on terminal auto-approve rules.
  *
  * Uses tree-sitter to parse compound commands (`foo && bar`) into
  * sub-commands that are individually checked against allow/deny lists.
- * The default rules mirror the VS Code `chat.tools.terminal.autoApprove`
- * setting defaults.
+ * The rules are normally forwarded from VS Code's
+ * `chat.tools.terminal.autoApprove` setting. A bundled default table is kept
+ * as a compatibility fallback for clients that have not forwarded rules yet.
  *
  * Tree-sitter is initialized eagerly; call {@link initialize} and await the
  * result before using {@link shouldAutoApprove} to guarantee synchronous
@@ -123,8 +138,7 @@ const transientEnvVarRegex = /^[A-Z_][A-Z0-9_]*=/i;
  */
 export class CommandAutoApprover extends Disposable {
 
-	private _allowRules: IAutoApproveRule[] | undefined;
-	private _denyRules: IAutoApproveRule[] | undefined;
+	private _fallbackRules: IAutoApproveRules | undefined;
 	private _parser: Parser | undefined;
 	private _bashLanguage: Language | undefined;
 	private _queryClass: typeof Query | undefined;
@@ -160,7 +174,7 @@ export class CommandAutoApprover extends Disposable {
 			return 'approved';
 		}
 
-		this._ensureRules();
+		const rules = this._compileRules(options?.autoApproveRules);
 
 		const parsed = this._extractSubCommands(trimmed);
 		if (!parsed) {
@@ -168,7 +182,14 @@ export class CommandAutoApprover extends Disposable {
 			return 'noMatch';
 		}
 
-		const result = this._matchSubCommands(parsed.subCommands);
+		if (this._matchesRule(trimmed, rules.denyCommandLineRules)) {
+			return 'denied';
+		}
+
+		let result = this._matchSubCommands(parsed.subCommands, rules);
+		if (result !== 'denied' && this._matchesRule(trimmed, rules.allowCommandLineRules)) {
+			result = 'approved';
+		}
 		if (result === 'approved' && parsed.unsafeWriteDests.length > 0) {
 			for (const dest of parsed.unsafeWriteDests) {
 				if (dest === undefined || !options?.isWriteDestApproved?.(dest)) {
@@ -180,7 +201,7 @@ export class CommandAutoApprover extends Disposable {
 		return result;
 	}
 
-	private _matchSubCommands(subCommands: string[]): CommandApprovalResult {
+	private _matchSubCommands(subCommands: string[], rules: IAutoApproveRules): CommandApprovalResult {
 		let allApproved = true;
 		for (const subCommand of subCommands) {
 			// Deny transient env var assignments
@@ -188,7 +209,7 @@ export class CommandAutoApprover extends Disposable {
 				return 'denied';
 			}
 
-			const result = this._matchSingleCommand(subCommand);
+			const result = this._matchSingleCommand(subCommand, rules);
 			if (result === 'denied') {
 				return 'denied';
 			}
@@ -199,22 +220,27 @@ export class CommandAutoApprover extends Disposable {
 		return allApproved ? 'approved' : 'noMatch';
 	}
 
-	private _matchSingleCommand(command: string): CommandApprovalResult {
+	private _matchSingleCommand(command: string, rules: IAutoApproveRules): CommandApprovalResult {
 		// Check deny rules first
-		for (const rule of this._denyRules!) {
-			if (rule.regex.test(command)) {
-				return 'denied';
-			}
+		if (this._matchesRule(command, rules.denyRules)) {
+			return 'denied';
 		}
 
 		// Then check allow rules
-		for (const rule of this._allowRules!) {
-			if (rule.regex.test(command)) {
-				return 'approved';
-			}
+		if (this._matchesRule(command, rules.allowRules)) {
+			return 'approved';
 		}
 
 		return 'noMatch';
+	}
+
+	private _matchesRule(command: string, rules: readonly IAutoApproveRule[]): boolean {
+		for (const rule of rules) {
+			if (rule.regex.test(command)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	// ---- Tree-sitter --------------------------------------------------------
@@ -318,25 +344,47 @@ export class CommandAutoApprover extends Disposable {
 
 	// ---- Rules --------------------------------------------------------------
 
-	private _ensureRules(): void {
-		if (this._allowRules && this._denyRules) {
-			return;
+	private _compileRules(ruleConfig: AgentHostTerminalAutoApproveRules | undefined): IAutoApproveRules {
+		if (!ruleConfig) {
+			if (!this._fallbackRules) {
+				this._fallbackRules = this._compileRuleEntries(DEFAULT_TERMINAL_AUTO_APPROVE_RULES);
+			}
+			return this._fallbackRules;
 		}
 
+		return this._compileRuleEntries(ruleConfig);
+	}
+
+	private _compileRuleEntries(ruleConfig: Readonly<Record<string, AgentHostTerminalAutoApproveRuleValue>>): IAutoApproveRules {
 		const allowRules: IAutoApproveRule[] = [];
 		const denyRules: IAutoApproveRule[] = [];
+		const allowCommandLineRules: IAutoApproveRule[] = [];
+		const denyCommandLineRules: IAutoApproveRule[] = [];
 
-		for (const [key, value] of Object.entries(DEFAULT_TERMINAL_AUTO_APPROVE_RULES)) {
+		for (const [key, value] of Object.entries(ruleConfig)) {
 			const regex = convertAutoApproveEntryToRegex(key);
 			if (value === true) {
 				allowRules.push({ regex });
 			} else if (value === false) {
 				denyRules.push({ regex });
+			} else if (value && typeof value === 'object' && typeof value.approve === 'boolean') {
+				if (value.approve) {
+					if (value.matchCommandLine === true) {
+						allowCommandLineRules.push({ regex });
+					} else {
+						allowRules.push({ regex });
+					}
+				} else {
+					if (value.matchCommandLine === true) {
+						denyCommandLineRules.push({ regex });
+					} else {
+						denyRules.push({ regex });
+					}
+				}
 			}
 		}
 
-		this._allowRules = allowRules;
-		this._denyRules = denyRules;
+		return { allowRules, denyRules, allowCommandLineRules, denyCommandLineRules };
 	}
 }
 
@@ -388,10 +436,10 @@ function convertAutoApproveEntryToRegex(value: string): RegExp {
 
 // ---- Default rules ----------------------------------------------------------
 //
-// These mirror the VS Code `chat.tools.terminal.autoApprove` setting defaults.
-// Kept in sync manually — the actual setting will be wired up later.
+// Compatibility fallback for clients that do not forward the VS Code
+// `chat.tools.terminal.autoApprove` setting.
 
-const DEFAULT_TERMINAL_AUTO_APPROVE_RULES: Readonly<Record<string, boolean>> = {
+const DEFAULT_TERMINAL_AUTO_APPROVE_RULES: Readonly<Record<string, AgentHostTerminalAutoApproveRuleValue>> = {
 	// Safe readonly commands
 	cd: true,
 	echo: true,

--- a/src/vs/platform/agentHost/node/sessionPermissions.ts
+++ b/src/vs/platform/agentHost/node/sessionPermissions.ts
@@ -15,7 +15,7 @@ import { URI } from '../../../base/common/uri.js';
 import { Promises } from '../../../base/node/pfs.js';
 import { localize } from '../../../nls.js';
 import { ILogService } from '../../log/common/log.js';
-import { AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, platformRootSchema, platformSessionSchema } from '../common/agentHostSchema.js';
+import { AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, platformRootSchema, platformSessionSchema } from '../common/agentHostSchema.js';
 import type { IAgentToolPendingConfirmationSignal } from '../common/agentService.js';
 import { SessionConfigKey } from '../common/sessionConfigKeys.js';
 import { ConfirmationOptionKind, type ConfirmationOption } from '../common/state/protocol/state.js';
@@ -282,6 +282,7 @@ export class SessionPermissionManager extends Disposable {
 				return undefined;
 			}
 			const result = this._commandAutoApprover.shouldAutoApprove(e.toolInput, {
+				autoApproveRules: this._configService.getRootValue(platformRootSchema, AgentHostTerminalAutoApproveRulesConfigKey),
 				isWriteDestApproved: (dest) => this._isShellWriteDestApproved(dest, workDir),
 			});
 			if (result === 'approved') {

--- a/src/vs/platform/agentHost/test/common/agentHostSchema.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentHostSchema.test.ts
@@ -5,7 +5,8 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { createSchema, migrateLegacyAutopilotConfig, platformSessionSchema, schemaProperty, type AutoApproveLevel, type IPermissionsValue, type SessionMode } from '../../common/agentHostSchema.js';
+import type { IConfigurationValue } from '../../../configuration/common/configuration.js';
+import { createSchema, migrateLegacyAutopilotConfig, normalizeAgentHostTerminalAutoApproveRulesConfig, platformSessionSchema, schemaProperty, type AutoApproveLevel, type IPermissionsValue, type SessionMode } from '../../common/agentHostSchema.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { JsonRpcErrorCodes, ProtocolError } from '../../common/state/sessionProtocol.js';
 
@@ -343,6 +344,44 @@ suite('agentHostSchema', () => {
 
 		test('handles undefined', () => {
 			assert.strictEqual(migrateLegacyAutopilotConfig(undefined), undefined);
+		});
+	});
+
+	// ---- terminal auto-approve rule forwarding -----------------------------
+
+	suite('normalizeAgentHostTerminalAutoApproveRulesConfig', () => {
+
+		test('keeps null entries and object rules', () => {
+			const inspectValue: IConfigurationValue<Readonly<unknown>> = {};
+			const result = normalizeAgentHostTerminalAutoApproveRulesConfig({
+				echo: null,
+				python: true,
+				'/^npm run build$/': { approve: true, matchCommandLine: true },
+				invalid: { approve: 'yes' },
+			}, inspectValue, false);
+
+			assert.deepStrictEqual(result, {
+				echo: null,
+				python: true,
+				'/^npm run build$/': { approve: true, matchCommandLine: true },
+			});
+		});
+
+		test('removes default-only entries when default rules are ignored', () => {
+			const inspectValue: IConfigurationValue<Readonly<unknown>> = {
+				default: { value: { echo: true, ls: true, python: false } },
+				user: { value: { echo: null } },
+			};
+			const result = normalizeAgentHostTerminalAutoApproveRulesConfig({
+				echo: null,
+				ls: true,
+				python: true,
+			}, inspectValue, true);
+
+			assert.deepStrictEqual(result, {
+				echo: null,
+				python: true,
+			});
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/common/agentHostSchema.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentHostSchema.test.ts
@@ -382,5 +382,20 @@ suite('agentHostSchema', () => {
 				python: true,
 			});
 		});
+
+		test('keeps entries that match defaults when they come from a non-default target', () => {
+			const inspectValue: IConfigurationValue<Readonly<AgentHostTerminalAutoApproveRules>> = {
+				default: { value: { echo: true, ls: true } },
+				userValue: { ls: true },
+			};
+			const result = normalizeAgentHostTerminalAutoApproveRulesConfig({
+				echo: true,
+				ls: true,
+			}, inspectValue, true);
+
+			assert.deepStrictEqual(result, {
+				ls: true,
+			});
+		});
 	});
 });

--- a/src/vs/platform/agentHost/test/common/agentHostSchema.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentHostSchema.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import type { IConfigurationValue } from '../../../configuration/common/configuration.js';
-import { createSchema, migrateLegacyAutopilotConfig, normalizeAgentHostTerminalAutoApproveRulesConfig, platformSessionSchema, schemaProperty, type AutoApproveLevel, type IPermissionsValue, type SessionMode } from '../../common/agentHostSchema.js';
+import { createSchema, migrateLegacyAutopilotConfig, normalizeAgentHostTerminalAutoApproveRulesConfig, platformSessionSchema, schemaProperty, type AgentHostTerminalAutoApproveRules, type AutoApproveLevel, type IPermissionsValue, type SessionMode } from '../../common/agentHostSchema.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { JsonRpcErrorCodes, ProtocolError } from '../../common/state/sessionProtocol.js';
 
@@ -352,12 +352,11 @@ suite('agentHostSchema', () => {
 	suite('normalizeAgentHostTerminalAutoApproveRulesConfig', () => {
 
 		test('keeps null entries and object rules', () => {
-			const inspectValue: IConfigurationValue<Readonly<unknown>> = {};
+			const inspectValue: IConfigurationValue<Readonly<AgentHostTerminalAutoApproveRules>> = {};
 			const result = normalizeAgentHostTerminalAutoApproveRulesConfig({
 				echo: null,
 				python: true,
 				'/^npm run build$/': { approve: true, matchCommandLine: true },
-				invalid: { approve: 'yes' },
 			}, inspectValue, false);
 
 			assert.deepStrictEqual(result, {
@@ -368,7 +367,7 @@ suite('agentHostSchema', () => {
 		});
 
 		test('removes default-only entries when default rules are ignored', () => {
-			const inspectValue: IConfigurationValue<Readonly<unknown>> = {
+			const inspectValue: IConfigurationValue<Readonly<AgentHostTerminalAutoApproveRules>> = {
 				default: { value: { echo: true, ls: true, python: false } },
 				user: { value: { echo: null } },
 			};

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -15,6 +15,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { AgentHostClientState, RemoteAgentHostProtocolClient } from '../../browser/remoteAgentHostProtocolClient.js';
 import { AgentHostPermissionMode, AgentHostResourcePermissionError, IAgentHostResourceService } from '../../common/agentHostResourceService.js';
+import { ConfigurationTarget, type IConfigurationValue } from '../../../configuration/common/configuration.js';
 import { ContentEncoding, ReconnectResultType } from '../../common/state/protocol/commands.js';
 import { AhpErrorCodes } from '../../common/state/protocol/errors.js';
 import { PROTOCOL_VERSION } from '../../common/state/protocol/version/registry.js';
@@ -26,7 +27,7 @@ import { CustomizationType, ROOT_STATE_URI, StateComponents, customizationId } f
 import type { IClientTransport, IProtocolTransport } from '../../common/state/sessionTransport.js';
 import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
 import { TelemetryLevel } from '../../../telemetry/common/telemetry.js';
-import { AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, telemetryLevelToAgentHostConfigValue } from '../../common/agentHostSchema.js';
+import { AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID } from '../../common/agentHostSchema.js';
 
 type ProtocolTransportMessage = ProtocolMessage | AhpServerNotification | JsonRpcNotification | JsonRpcResponse | JsonRpcRequest;
 
@@ -50,6 +51,10 @@ function findRootConfigNotification(messages: readonly ProtocolTransportMessage[
 	});
 	assert.ok(match, `Expected a RootConfigChanged notification carrying '${configKey}'`);
 	return match;
+}
+
+function findLastRootConfigNotification(messages: readonly ProtocolTransportMessage[], configKey: string): JsonRpcNotification {
+	return findRootConfigNotification([...messages].reverse(), configKey);
 }
 
 class TestProtocolTransport extends Disposable implements IProtocolTransport {
@@ -94,6 +99,23 @@ class CountingLogService extends NullLogService {
 
 	override warn(_message: string, ..._args: unknown[]): void {
 		this.warnCount++;
+	}
+}
+
+class TerminalAutoApproveConfigurationService extends TestConfigurationService {
+
+	constructor(
+		configuration: Record<string, unknown>,
+		private readonly _terminalAutoApproveInspectValue: IConfigurationValue<Readonly<unknown>>,
+	) {
+		super(configuration);
+	}
+
+	override inspect<T>(key: string): IConfigurationValue<T> {
+		if (key === TERMINAL_AUTO_APPROVE_SETTING_ID) {
+			return this._terminalAutoApproveInspectValue as IConfigurationValue<T>;
+		}
+		return super.inspect<T>(key);
 	}
 }
 
@@ -148,9 +170,32 @@ suite('RemoteAgentHostProtocolClient', () => {
 		};
 	}
 
-	function createClient(transport = disposables.add(new TestProtocolTransport()), permissionService = createPermissionService(), loadEstimator?: { hasHighLoad(): boolean }, logService: ILogService = new NullLogService()): { client: RemoteAgentHostProtocolClient; transport: TestProtocolTransport } {
-		const client = disposables.add(new RemoteAgentHostProtocolClient('test.example:1234', transport, loadEstimator, logService, permissionService, new TestConfigurationService()));
-		return { client, transport };
+	function createClient(transport = disposables.add(new TestProtocolTransport()), permissionService = createPermissionService(), loadEstimator?: { hasHighLoad(): boolean }, logService: ILogService = new NullLogService(), configurationService = new TestConfigurationService()): { client: RemoteAgentHostProtocolClient; transport: TestProtocolTransport; configurationService: TestConfigurationService } {
+		const client = disposables.add(new RemoteAgentHostProtocolClient('test.example:1234', transport, loadEstimator, logService, permissionService, configurationService));
+		return { client, transport, configurationService };
+	}
+
+	async function connectClient(client: RemoteAgentHostProtocolClient, transport: TestProtocolTransport): Promise<void> {
+		const connectPromise = client.connect();
+		while (transport.sentMessages.length === 0) {
+			await Promise.resolve();
+		}
+		const sent = transport.sentMessages[0] as JsonRpcRequest;
+		transport.fireMessage({
+			jsonrpc: '2.0',
+			id: sent.id,
+			result: { protocolVersion: PROTOCOL_VERSION, serverSeq: 0, snapshots: [] },
+		});
+		await connectPromise;
+	}
+
+	function fireConfigurationChange(configurationService: TestConfigurationService, settingId: string): void {
+		configurationService.onDidChangeConfigurationEmitter.fire({
+			source: ConfigurationTarget.USER,
+			affectedKeys: new Set([settingId]),
+			change: { keys: [settingId], overrides: [] },
+			affectsConfiguration: configuration => configuration === settingId,
+		});
 	}
 
 	async function assertRemoteProtocolError(promise: Promise<unknown>, expected: { code: number; message: string; data?: unknown }): Promise<void> {
@@ -512,6 +557,76 @@ suite('RemoteAgentHostProtocolClient', () => {
 					config: { [AgentHostGlobalAutoApproveEnabledConfigKey]: false },
 				},
 			},
+		});
+		const terminalAutoApproveRules = findRootConfigNotification(transport.sentMessages, AgentHostTerminalAutoApproveRulesConfigKey);
+		assert.deepStrictEqual(terminalAutoApproveRules, {
+			jsonrpc: '2.0',
+			method: 'dispatchAction',
+			params: {
+				channel: ROOT_STATE_URI,
+				clientSeq: 0,
+				action: {
+					type: ActionType.RootConfigChanged,
+					config: { [AgentHostTerminalAutoApproveRulesConfigKey]: {} },
+				},
+			},
+		});
+	});
+
+	test('forwards terminal auto-approve rules on connect', async () => {
+		const configurationService = new TestConfigurationService({
+			[TERMINAL_AUTO_APPROVE_SETTING_ID]: {
+				echo: null,
+				python: true,
+				'/^npm run build$/': { approve: true, matchCommandLine: true },
+			},
+		});
+		const { client, transport } = createClient(disposables.add(new TestProtocolTransport()), createPermissionService(), undefined, new NullLogService(), configurationService);
+
+		await connectClient(client, transport);
+
+		const terminalAutoApproveRules = findRootConfigNotification(transport.sentMessages, AgentHostTerminalAutoApproveRulesConfigKey);
+		assert.deepStrictEqual((terminalAutoApproveRules.params as { action: { config: Record<string, unknown> } }).action.config, {
+			[AgentHostTerminalAutoApproveRulesConfigKey]: {
+				echo: null,
+				python: true,
+				'/^npm run build$/': { approve: true, matchCommandLine: true },
+			},
+		});
+	});
+
+	test('redispatches terminal auto-approve rules when the rule setting changes', async () => {
+		const configurationService = new TestConfigurationService();
+		const { client, transport } = createClient(disposables.add(new TestProtocolTransport()), createPermissionService(), undefined, new NullLogService(), configurationService);
+		await connectClient(client, transport);
+		transport.sentMessages.length = 0;
+
+		await configurationService.setUserConfiguration(TERMINAL_AUTO_APPROVE_SETTING_ID, { python: true });
+		fireConfigurationChange(configurationService, TERMINAL_AUTO_APPROVE_SETTING_ID);
+
+		const terminalAutoApproveRules = findLastRootConfigNotification(transport.sentMessages, AgentHostTerminalAutoApproveRulesConfigKey);
+		assert.deepStrictEqual((terminalAutoApproveRules.params as { action: { config: Record<string, unknown> } }).action.config, {
+			[AgentHostTerminalAutoApproveRulesConfigKey]: { python: true },
+		});
+	});
+
+	test('redispatches terminal auto-approve rules when ignored defaults change', async () => {
+		const configurationService = new TerminalAutoApproveConfigurationService({
+			[TERMINAL_AUTO_APPROVE_SETTING_ID]: { echo: true, python: true },
+		}, {
+			default: { value: { echo: true } },
+			user: { value: { python: true } },
+		});
+		const { client, transport } = createClient(disposables.add(new TestProtocolTransport()), createPermissionService(), undefined, new NullLogService(), configurationService);
+		await connectClient(client, transport);
+		transport.sentMessages.length = 0;
+
+		await configurationService.setUserConfiguration(TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, true);
+		fireConfigurationChange(configurationService, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID);
+
+		const terminalAutoApproveRules = findLastRootConfigNotification(transport.sentMessages, AgentHostTerminalAutoApproveRulesConfigKey);
+		assert.deepStrictEqual((terminalAutoApproveRules.params as { action: { config: Record<string, unknown> } }).action.config, {
+			[AgentHostTerminalAutoApproveRulesConfigKey]: { python: true },
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -27,9 +27,17 @@ import { CustomizationType, ROOT_STATE_URI, StateComponents, customizationId } f
 import type { IClientTransport, IProtocolTransport } from '../../common/state/sessionTransport.js';
 import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
 import { TelemetryLevel } from '../../../telemetry/common/telemetry.js';
-import { AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID } from '../../common/agentHostSchema.js';
+import { AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, telemetryLevelToAgentHostConfigValue, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, type AgentHostTerminalAutoApproveRules } from '../../common/agentHostSchema.js';
 
 type ProtocolTransportMessage = ProtocolMessage | AhpServerNotification | JsonRpcNotification | JsonRpcResponse | JsonRpcRequest;
+type RootConfigValue = boolean | string | AgentHostTerminalAutoApproveRules | undefined;
+
+interface ITestRootConfigNotificationParams {
+	readonly action?: {
+		readonly type?: string;
+		readonly config?: Record<string, RootConfigValue>;
+	};
+}
 
 function isPingRequest(msg: ProtocolTransportMessage): msg is JsonRpcRequest & { method: 'ping' } {
 	return hasKey(msg, { method: true, id: true }) && msg.method === 'ping';
@@ -46,11 +54,17 @@ function findRootConfigNotification(messages: readonly ProtocolTransportMessage[
 		if (!hasKey(msg, { method: true }) || msg.method !== 'dispatchAction') {
 			return false;
 		}
-		const params = (msg as JsonRpcNotification).params as { action?: { type?: string; config?: Record<string, unknown> } } | undefined;
+		const params = (msg as JsonRpcNotification).params as ITestRootConfigNotificationParams | undefined;
 		return params?.action?.type === ActionType.RootConfigChanged && !!params.action.config && configKey in params.action.config;
 	});
 	assert.ok(match, `Expected a RootConfigChanged notification carrying '${configKey}'`);
 	return match;
+}
+
+function getRootConfig(notification: JsonRpcNotification): Record<string, RootConfigValue> {
+	const params = notification.params as ITestRootConfigNotificationParams | undefined;
+	assert.ok(params?.action?.config);
+	return params.action.config;
 }
 
 function findLastRootConfigNotification(messages: readonly ProtocolTransportMessage[], configKey: string): JsonRpcNotification {
@@ -105,8 +119,8 @@ class CountingLogService extends NullLogService {
 class TerminalAutoApproveConfigurationService extends TestConfigurationService {
 
 	constructor(
-		configuration: Record<string, unknown>,
-		private readonly _terminalAutoApproveInspectValue: IConfigurationValue<Readonly<unknown>>,
+		configuration: Record<string, AgentHostTerminalAutoApproveRules | boolean>,
+		private readonly _terminalAutoApproveInspectValue: IConfigurationValue<Readonly<AgentHostTerminalAutoApproveRules>>,
 	) {
 		super(configuration);
 	}
@@ -586,7 +600,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 		await connectClient(client, transport);
 
 		const terminalAutoApproveRules = findRootConfigNotification(transport.sentMessages, AgentHostTerminalAutoApproveRulesConfigKey);
-		assert.deepStrictEqual((terminalAutoApproveRules.params as { action: { config: Record<string, unknown> } }).action.config, {
+		assert.deepStrictEqual(getRootConfig(terminalAutoApproveRules), {
 			[AgentHostTerminalAutoApproveRulesConfigKey]: {
 				echo: null,
 				python: true,
@@ -605,7 +619,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 		fireConfigurationChange(configurationService, TERMINAL_AUTO_APPROVE_SETTING_ID);
 
 		const terminalAutoApproveRules = findLastRootConfigNotification(transport.sentMessages, AgentHostTerminalAutoApproveRulesConfigKey);
-		assert.deepStrictEqual((terminalAutoApproveRules.params as { action: { config: Record<string, unknown> } }).action.config, {
+		assert.deepStrictEqual(getRootConfig(terminalAutoApproveRules), {
 			[AgentHostTerminalAutoApproveRulesConfigKey]: { python: true },
 		});
 	});
@@ -625,7 +639,7 @@ suite('RemoteAgentHostProtocolClient', () => {
 		fireConfigurationChange(configurationService, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID);
 
 		const terminalAutoApproveRules = findLastRootConfigNotification(transport.sentMessages, AgentHostTerminalAutoApproveRulesConfigKey);
-		assert.deepStrictEqual((terminalAutoApproveRules.params as { action: { config: Record<string, unknown> } }).action.config, {
+		assert.deepStrictEqual(getRootConfig(terminalAutoApproveRules), {
 			[AgentHostTerminalAutoApproveRulesConfigKey]: { python: true },
 		});
 	});

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -116,6 +116,16 @@ suite('CommandAutoApprover', () => {
 			]);
 		});
 
+		test('uses forwarded terminal auto-approve rules instead of fallback defaults', () => {
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('echo hello', { autoApproveRules: {} }),
+				approver.shouldAutoApprove('rm file.txt', { autoApproveRules: {} }),
+			], [
+				'noMatch',
+				'noMatch',
+			]);
+		});
+
 		// Transient env vars
 		test('denies transient environment variable assignments', () => {
 			assert.strictEqual(approver.shouldAutoApprove('FOO=bar some-command'), 'denied');

--- a/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
+++ b/src/vs/platform/agentHost/test/node/commandAutoApprover.test.ts
@@ -100,6 +100,22 @@ suite('CommandAutoApprover', () => {
 			assert.strictEqual(approver.shouldAutoApprove('node index.js'), 'noMatch');
 		});
 
+		test('respects forwarded terminal auto-approve rule config', () => {
+			assert.deepStrictEqual([
+				approver.shouldAutoApprove('echo hello', { autoApproveRules: { echo: false } }),
+				approver.shouldAutoApprove('python script.py', { autoApproveRules: { python: true } }),
+				approver.shouldAutoApprove('echo hello', { autoApproveRules: { echo: null } }),
+				approver.shouldAutoApprove('npm run build', { autoApproveRules: { '/^npm run build$/': { approve: true, matchCommandLine: true } } }),
+				approver.shouldAutoApprove('echo hello', { autoApproveRules: { echo: true, '/^echo hello$/': { approve: false, matchCommandLine: true } } }),
+			], [
+				'denied',
+				'approved',
+				'noMatch',
+				'approved',
+				'denied',
+			]);
+		});
+
 		// Transient env vars
 		test('denies transient environment variable assignments', () => {
 			assert.strictEqual(approver.shouldAutoApprove('FOO=bar some-command'), 'denied');

--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -12,7 +12,7 @@ import { isWindows } from '../../../../base/common/platform.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../log/common/log.js';
-import { AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, platformSessionSchema } from '../../common/agentHostSchema.js';
+import { AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, platformSessionSchema } from '../../common/agentHostSchema.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { SessionStatus, ToolCallConfirmationReason, type SessionSummary } from '../../common/state/sessionState.js';
 import { AgentConfigurationService } from '../../node/agentConfigurationService.js';
@@ -154,15 +154,35 @@ suite('SessionPermissionManager', () => {
 		assert.strictEqual(result, ToolCallConfirmationReason.NotNeeded);
 	});
 
+	test('respects forwarded terminal auto-approve deny rules in default permission mode', async () => {
+		configService.updateRootConfig({ [AgentHostTerminalAutoApproveRulesConfigKey]: { echo: false } });
+
+		const result = await permissions.getAutoApproval(shellEvent('echo hello'), sessionUri);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('respects forwarded terminal auto-approve allow rules in default permission mode', async () => {
+		configService.updateRootConfig({ [AgentHostTerminalAutoApproveRulesConfigKey]: { python: true } });
+
+		const result = await permissions.getAutoApproval(shellEvent('python script.py'), sessionUri);
+		assert.strictEqual(result, ToolCallConfirmationReason.NotNeeded);
+	});
+
 	test('requires confirmation for shell commands in default permission mode when terminal auto-approve is disabled', async () => {
-		configService.updateRootConfig({ [AgentHostTerminalAutoApproveEnabledConfigKey]: false });
+		configService.updateRootConfig({
+			[AgentHostTerminalAutoApproveEnabledConfigKey]: false,
+			[AgentHostTerminalAutoApproveRulesConfigKey]: { echo: true },
+		});
 
 		const result = await permissions.getAutoApproval(shellEvent('echo hello'), sessionUri);
 		assert.strictEqual(result, undefined);
 	});
 
 	test('does not affect session bypass permission mode when terminal auto-approve is disabled', async () => {
-		configService.updateRootConfig({ [AgentHostTerminalAutoApproveEnabledConfigKey]: false });
+		configService.updateRootConfig({
+			[AgentHostTerminalAutoApproveEnabledConfigKey]: false,
+			[AgentHostTerminalAutoApproveRulesConfigKey]: { echo: false },
+		});
 		manager.setSessionConfig(sessionUri, {
 			schema: platformSessionSchema.toProtocol(),
 			values: { [SessionConfigKey.AutoApprove]: 'autoApprove' },

--- a/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionPermissions.test.ts
@@ -154,6 +154,13 @@ suite('SessionPermissionManager', () => {
 		assert.strictEqual(result, ToolCallConfirmationReason.NotNeeded);
 	});
 
+	test('uses forwarded terminal auto-approve rules as the source of truth over fallback defaults', async () => {
+		configService.updateRootConfig({ [AgentHostTerminalAutoApproveRulesConfigKey]: {} });
+
+		const result = await permissions.getAutoApproval(shellEvent('echo hello'), sessionUri);
+		assert.strictEqual(result, undefined);
+	});
+
 	test('respects forwarded terminal auto-approve deny rules in default permission mode', async () => {
 		configService.updateRootConfig({ [AgentHostTerminalAutoApproveRulesConfigKey]: { echo: false } });
 


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/322112
Coming from: https://github.com/microsoft/vscode/pull/322633  
Follow-up in future: https://github.com/microsoft/vscode/issues/322791

- Add Agent Host root-config plumbing for `chat.tools.terminal.autoApprove`.
- Forward normalized terminal auto-approve rules from both local and remote Agent Host clients, including updates when `chat.tools.terminal.autoApprove` or `chat.tools.terminal.ignoreDefaultAutoApproveRules` changes.
- Respect `null`, boolean rules, and `{ approve, matchCommandLine }` object rules in Agent Host shell approval.
- Keep `chat.tools.terminal.enableAutoApprove=false` as the top-level gate for rule-based shell approval.
- Preserve existing Agent Host safety behavior: deny rules win, parser failure prompts, unsafe write redirects still require confirmation, and bundled defaults remain only as a compatibility fallback when no forwarded rules exist.
- Mark the bundled fallback rules for removal once all Agent Host clients are guaranteed to forward the real terminal auto-approve setting before shell approvals run.
- Add coverage for rule normalization, remote forwarding, command auto-approval rule behavior, source-of-truth precedence over fallback defaults, and session permission behavior. 
/cc @justschen 



-----------------------------------------
Inspirations from:

- Terminal auto-approve setting IDs come from [`TerminalChatAgentToolsSettingId`](https://github.com/microsoft/vscode/blob/fcff1a779c023e586c6d44a18c04a04166b59f37/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts#L21-L26).
- The `chat.tools.terminal.autoApprove` value shape, including `null` and `matchCommandLine`, comes from the setting schema in [`terminalChatAgentToolsConfiguration.ts`](https://github.com/microsoft/vscode/blob/fcff1a779c023e586c6d44a18c04a04166b59f37/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts#L103-L150).
- The forwarded rule compilation mirrors the workbench run-in-terminal rule buckets in [`CommandLineAutoApprover.updateConfiguration`](https://github.com/microsoft/vscode/blob/fcff1a779c023e586c6d44a18c04a04166b59f37/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/autoApprove/commandLineAutoApprover.ts#L57-L78).
- The default-rule filtering behavior for `chat.tools.terminal.ignoreDefaultAutoApproveRules` comes from [`_mapAutoApproveConfigToRules`](https://github.com/microsoft/vscode/blob/fcff1a779c023e586c6d44a18c04a04166b59f37/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/autoApprove/commandLineAutoApprover.ts#L245-L332).