### PR TITLE
onboarding: gate experiment assignment-context id until would-show

### DIFF
--- a/src/vs/workbench/contrib/onboarding/browser/onboardingService.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/onboardingService.ts
@@ -11,13 +11,14 @@ import { autorun } from '../../../../base/common/observable.js';
 import { mainWindow } from '../../../../base/browser/window.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { ILifecycleService } from '../../../services/lifecycle/common/lifecycle.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IWorkbenchAssignmentService } from '../../../services/assignment/common/assignmentService.js';
 import { Memento } from '../../../common/memento.js';
 import { onboardingPresentationRegistry } from '../common/onboardingPresentation.js';
 import { onboardingScenarioRegistry } from '../common/onboardingRegistry.js';
-import { IOnboardingScenario, OnboardingOutcome } from '../common/onboardingScenario.js';
+import { IOnboardingRunResult, IOnboardingScenario, ONBOARDING_ASSIGNMENT_CONTEXT_PREFIX, OnboardingOutcome } from '../common/onboardingScenario.js';
 import { IOnboardingScenarioService, ONBOARDING_DEVELOPER_MODE_CONFIG, ONBOARDING_ENABLED_CONFIG } from '../common/onboardingScenarioService.js';
 
 /** Persisted "shown" state for a single scenario. */
@@ -29,11 +30,28 @@ interface IScenarioState {
 
 type OnboardingMementoData = { [scenarioId: string]: IScenarioState };
 
+/** Resolved experiment treatment state for a scenario that declares an experiment. */
+interface IExperimentState {
+	/** Both treatment flags resolved (the experiment is configured for this user). */
+	readonly active: boolean;
+	/** Value of the boolean behavior flag: `true` shows the tour (treatment), `false` is control. */
+	readonly behavior: boolean;
+	/** Value of the assignment-context id flag (the id the scorecard keys on). */
+	readonly assignmentContextId: string;
+}
+
 export class OnboardingScenarioService extends Disposable implements IOnboardingScenarioService {
 
 	declare readonly _serviceBrand: undefined;
 
 	private static readonly MEMENTO_ID = 'onboarding';
+
+	/**
+	 * Storage key for the set of assignment-context identifiers whose telemetry gate has been
+	 * opened (the user reached the onboarding moment). Persisted so the identifier keeps
+	 * flowing across reloads/relaunches until the experiment is stopped.
+	 */
+	private static readonly OPENED_IDS_STORAGE_KEY = 'onboarding.openedAssignmentContextIds';
 
 	private readonly _memento: Memento<OnboardingMementoData>;
 	private readonly _state: Partial<OnboardingMementoData>;
@@ -51,8 +69,16 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 	/** Abort signal for the scenario currently running. */
 	private _activeAbort: Emitter<void> | undefined;
 
-	/** Cached experiment treatment results for scenarios that declare one. */
-	private readonly _experimentResults = new Map<string, boolean>();
+	/** Resolved experiment treatment state, keyed by scenario id. */
+	private readonly _experimentStates = new Map<string, IExperimentState>();
+
+	/**
+	 * Assignment-context ids whose telemetry gate is open. While an onboarding id is *not* in
+	 * this set, the eagerly-registered filter excludes it from telemetry (see the prefix
+	 * constant). The set is seeded from storage and grows as users reach the onboarding moment.
+	 */
+	private readonly _openedAssignmentContextIds: Set<string>;
+	private readonly _onDidChangeOpenedIds = this._register(new Emitter<void>());
 
 	private _started = false;
 	private _stopped = false;
@@ -64,11 +90,23 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ILifecycleService private readonly lifecycleService: ILifecycleService,
 		@IWorkbenchAssignmentService private readonly assignmentService: IWorkbenchAssignmentService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
 
 		this._memento = new Memento(OnboardingScenarioService.MEMENTO_ID, this.storageService);
-		this._state = this._memento.getMemento(StorageScope.PROFILE, StorageTarget.USER);
+		this._state = this._memento.getMemento(StorageScope.APPLICATION, StorageTarget.MACHINE);
+
+		this._openedAssignmentContextIds = this._loadOpenedIds();
+
+		// Register the telemetry gate filter eagerly (in the constructor) so onboarding
+		// assignment-context ids are excluded from the very first event — before the treatment
+		// flags resolve. The filter blocks any id with the reserved onboarding prefix unless its
+		// gate has already been opened (this session or persisted from a previous one).
+		this.assignmentService.addTelemetryAssignmentFilter({
+			exclude: assignment => assignment.startsWith(ONBOARDING_ASSIGNMENT_CONTEXT_PREFIX) && !this._openedAssignmentContextIds.has(assignment),
+			onDidChange: this._onDidChangeOpenedIds.event
+		});
 
 		// On shutdown abort the active run and drain anything still queued so no
 		// fresh overlay is mounted while the window is going away.
@@ -94,7 +132,7 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 
 		this._register(onboardingScenarioRegistry.onDidChange(() => {
 			this._registerTriggerListeners();
-			this._fetchExperiments();
+			this._resolveExperiments();
 			this._evaluate();
 		}));
 
@@ -107,7 +145,7 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 		}));
 
 		this._registerTriggerListeners();
-		this._fetchExperiments();
+		this._resolveExperiments();
 		this._evaluate();
 	}
 
@@ -155,16 +193,33 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 	/**
 	 * Re-evaluate every scenario and enqueue any that are eligible to run
 	 * automatically. Idempotent: already shown / queued scenarios are skipped.
+	 *
+	 * For an experiment-active scenario, reaching eligibility *is* the "would-show"
+	 * moment: the telemetry gate is opened for the experiment's assignment-context id
+	 * (in both arms), and then only the treatment arm is enqueued to actually show the
+	 * tour. Control opens the gate but renders nothing and is not marked as shown.
 	 */
 	private _evaluate(): void {
 		if (!this._enabled || this._stopped) {
 			return;
 		}
 
-		const eligible = onboardingScenarioRegistry.getScenarios()
-			.filter(scenario => this._isAutoEligible(scenario));
+		for (const scenario of onboardingScenarioRegistry.getScenarios()) {
+			if (!this._isAutoEligible(scenario)) {
+				continue;
+			}
 
-		for (const scenario of eligible) {
+			const experiment = scenario.experiment ? this._experimentStates.get(scenario.id) : undefined;
+			if (experiment?.active) {
+				// Would-show reached: start emitting the assignment-context id from now on.
+				this._openGate(experiment.assignmentContextId);
+				if (!experiment.behavior) {
+					// Control arm: the identifier now flows, but no tour is shown and the
+					// scenario is left un-shown so the user stays eligible to see it later.
+					continue;
+				}
+			}
+
 			this._enqueue(scenario);
 		}
 	}
@@ -187,7 +242,10 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 			return false;
 		}
 
-		if (scenario.experiment && this._experimentResults.get(scenario.experiment) !== true) {
+		// Experiment-driven scenarios only run once the experiment is active (both treatment
+		// flags resolved). The behavior flag does NOT gate eligibility — control still reaches
+		// the would-show moment so the gate opens for it too.
+		if (scenario.experiment && this._experimentStates.get(scenario.id)?.active !== true) {
 			return false;
 		}
 
@@ -272,14 +330,51 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 
 		const abort = new Emitter<void>();
 		this._activeAbort = abort;
+		const startTime = Date.now();
 		try {
-			const outcome = await presentation.run(scenario, { targetWindow: mainWindow, onAbort: abort.event });
-			this._recordOutcome(scenario.id, outcome);
-			return outcome;
+			const result = await presentation.run(scenario, { targetWindow: mainWindow, onAbort: abort.event });
+			this._recordOutcome(scenario.id, result.outcome);
+			this._reportOutcome(scenario, result, Date.now() - startTime);
+			return result.outcome;
 		} finally {
 			this._activeAbort = undefined;
 			abort.dispose();
 		}
+	}
+
+	/** Emit per-tour telemetry. Only ever called when a tour was actually shown. */
+	private _reportOutcome(scenario: IOnboardingScenario, result: IOnboardingRunResult, durationMs: number): void {
+		const experimentActive = !!scenario.experiment && this._experimentStates.get(scenario.id)?.active === true;
+
+		type OnboardingScenarioOutcomeEvent = {
+			scenarioId: string;
+			outcome: string;
+			dismissReason: string;
+			lastStepIndex: number;
+			stepCount: number;
+			durationMs: number;
+			experimentActive: boolean;
+		};
+		type OnboardingScenarioOutcomeClassification = {
+			owner: 'benibenj';
+			comment: 'Reports how a user progressed through an onboarding tour to evaluate onboarding effectiveness.';
+			scenarioId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The id of the onboarding scenario that ran.' };
+			outcome: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'How the tour ended: completed, skipped, dismissed or aborted.' };
+			dismissReason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The concrete action that ended the tour, e.g. skipButton, escapeKey, targetClick, completed or aborted.' };
+			lastStepIndex: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The furthest 0-based step index the user reached.' };
+			stepCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The total number of steps in the tour.' };
+			durationMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'How long the tour was on screen, in milliseconds.' };
+			experimentActive: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether an active experiment drove this run.' };
+		};
+		this.telemetryService.publicLog2<OnboardingScenarioOutcomeEvent, OnboardingScenarioOutcomeClassification>('onboarding.scenarioOutcome', {
+			scenarioId: scenario.id,
+			outcome: result.outcome,
+			dismissReason: result.dismissReason,
+			lastStepIndex: result.lastStepIndex,
+			stepCount: result.stepCount,
+			durationMs,
+			experimentActive
+		});
 	}
 
 	//#endregion
@@ -299,20 +394,85 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 		}
 	}
 
-	private _fetchExperiments(): void {
+	/**
+	 * Resolve the two experiment treatment flags for each scenario that declares an experiment.
+	 * The experiment is only active when both resolve: the boolean to a boolean and the id to a
+	 * non-empty string that starts with {@link ONBOARDING_ASSIGNMENT_CONTEXT_PREFIX}. Resolved
+	 * once per scenario; re-evaluation is triggered when an experiment becomes active.
+	 */
+	private _resolveExperiments(): void {
 		for (const scenario of onboardingScenarioRegistry.getScenarios()) {
-			const id = scenario.experiment;
-			if (!id || this._experimentResults.has(id)) {
+			const experiment = scenario.experiment;
+			if (!experiment || this._experimentStates.has(scenario.id)) {
 				continue;
 			}
-			this._experimentResults.set(id, false);
-			this.assignmentService.getTreatment<boolean>(id).then(value => {
-				if (value === true) {
-					this._experimentResults.set(id, true);
+			// Seed an inactive state so the scenario is not eligible until both flags resolve.
+			this._experimentStates.set(scenario.id, { active: false, behavior: false, assignmentContextId: '' });
+			Promise.all([
+				this.assignmentService.getTreatment<boolean>(experiment.behaviorFlag),
+				this.assignmentService.getTreatment<string>(experiment.assignmentContextIdFlag)
+			]).then(([behavior, assignmentContextId]) => {
+				const hasBehavior = typeof behavior === 'boolean';
+				const hasId = typeof assignmentContextId === 'string' && assignmentContextId.length > 0;
+
+				// Defensively require the reserved prefix. The eager telemetry gate only blocks
+				// ids that start with it, so an id missing the prefix would never be gated and
+				// would leak into telemetry from the very first event — silently corrupting the
+				// scorecard baseline. Catch the misconfiguration loudly and treat the experiment
+				// as inactive rather than running it with an ungated id.
+				const hasValidId = hasId && assignmentContextId!.startsWith(ONBOARDING_ASSIGNMENT_CONTEXT_PREFIX);
+				if (hasId && !hasValidId) {
+					onUnexpectedError(new Error(`Onboarding experiment for scenario '${scenario.id}' resolved an assignment-context id '${assignmentContextId}' that does not start with the required '${ONBOARDING_ASSIGNMENT_CONTEXT_PREFIX}' prefix; treating the experiment as inactive.`));
+				}
+
+				const active = hasBehavior && hasValidId;
+				this._experimentStates.set(scenario.id, {
+					active,
+					behavior: behavior === true,
+					assignmentContextId: active ? assignmentContextId! : ''
+				});
+				if (active) {
 					this._evaluate();
 				}
 			}, error => onUnexpectedError(error));
 		}
+	}
+
+	//#endregion
+
+	//#region Telemetry gate
+
+	private _loadOpenedIds(): Set<string> {
+		const raw = this.storageService.get(OnboardingScenarioService.OPENED_IDS_STORAGE_KEY, StorageScope.APPLICATION);
+		if (!raw) {
+			return new Set<string>();
+		}
+		try {
+			const parsed = JSON.parse(raw);
+			return Array.isArray(parsed) ? new Set<string>(parsed.filter((id): id is string => typeof id === 'string')) : new Set<string>();
+		} catch (error) {
+			onUnexpectedError(error);
+			return new Set<string>();
+		}
+	}
+
+	/**
+	 * Open the telemetry gate for an assignment-context id: from now on (and after reload) the
+	 * id is no longer filtered out, so every event carries it. Idempotent.
+	 */
+	private _openGate(assignmentContextId: string): void {
+		if (!assignmentContextId || this._openedAssignmentContextIds.has(assignmentContextId)) {
+			return;
+		}
+		this._openedAssignmentContextIds.add(assignmentContextId);
+		this.storageService.store(
+			OnboardingScenarioService.OPENED_IDS_STORAGE_KEY,
+			JSON.stringify(Array.from(this._openedAssignmentContextIds)),
+			StorageScope.APPLICATION,
+			StorageTarget.MACHINE
+		);
+		// Recompute the filtered assignment context so the id starts flowing immediately.
+		this._onDidChangeOpenedIds.fire();
 	}
 
 	//#endregion

--- a/src/vs/workbench/contrib/onboarding/browser/onboardingService.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/onboardingService.ts
@@ -334,7 +334,11 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 		try {
 			const result = await presentation.run(scenario, { targetWindow: mainWindow, onAbort: abort.event });
 			this._recordOutcome(scenario.id, result.outcome);
-			this._reportOutcome(scenario, result, Date.now() - startTime);
+			// Only emit outcome telemetry when a tour was genuinely displayed; a degenerate
+			// run that rendered nothing (no steps / all steps skipped) must not pollute metrics.
+			if (result.shown) {
+				this._reportOutcome(scenario, result, Date.now() - startTime);
+			}
 			return result.outcome;
 		} finally {
 			this._activeAbort = undefined;
@@ -342,7 +346,7 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 		}
 	}
 
-	/** Emit per-tour telemetry. Only ever called when a tour was actually shown. */
+	/** Emit per-tour telemetry. Only called when a tour was actually shown. */
 	private _reportOutcome(scenario: IOnboardingScenario, result: IOnboardingRunResult, durationMs: number): void {
 		const experimentActive = !!scenario.experiment && this._experimentStates.get(scenario.id)?.active === true;
 

--- a/src/vs/workbench/contrib/onboarding/browser/spotlight/spotlightOverlay.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/spotlight/spotlightOverlay.ts
@@ -15,7 +15,14 @@ import { renderMarkdown } from '../../../../../base/browser/markdownRenderer.js'
 import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { localize } from '../../../../../nls.js';
 import { SpotlightPlacement } from './spotlightTypes.js';
+import { OnboardingDismissReason } from '../../common/onboardingScenario.js';
 import '../media/spotlight.css';
+
+/** How the user advanced to the next step. */
+export type SpotlightAdvanceSource = 'button' | 'target';
+
+/** Why a step ended in a skip: the Skip button or the Escape key. */
+export type SpotlightSkipReason = OnboardingDismissReason.SkipButton | OnboardingDismissReason.EscapeKey;
 
 /** Default padding (px) added around the target when cutting the highlight hole. */
 const DEFAULT_HOLE_PADDING = 6;
@@ -77,14 +84,14 @@ export class SpotlightOverlay extends Disposable {
 	/** Listeners scoped to the currently shown step (re-layout sources). */
 	private readonly _stepListeners = this._register(new DisposableStore());
 
-	private readonly _onDidClickNext = this._register(new Emitter<void>());
-	readonly onDidClickNext: Event<void> = this._onDidClickNext.event;
+	private readonly _onDidClickNext = this._register(new Emitter<SpotlightAdvanceSource>());
+	readonly onDidClickNext: Event<SpotlightAdvanceSource> = this._onDidClickNext.event;
 
 	private readonly _onDidClickPrevious = this._register(new Emitter<void>());
 	readonly onDidClickPrevious: Event<void> = this._onDidClickPrevious.event;
 
-	private readonly _onDidSkip = this._register(new Emitter<void>());
-	readonly onDidSkip: Event<void> = this._onDidSkip.event;
+	private readonly _onDidSkip = this._register(new Emitter<SpotlightSkipReason>());
+	readonly onDidSkip: Event<SpotlightSkipReason> = this._onDidSkip.event;
 
 	private _target: HTMLElement | undefined;
 	private _options: ISpotlightShowOptions = {};
@@ -131,7 +138,7 @@ export class SpotlightOverlay extends Disposable {
 
 		this._skipButton = this._register(new Button(actions, { ...defaultButtonStyles, secondary: true }));
 		this._skipButton.label = localize('spotlight.skip', "Skip");
-		this._register(this._skipButton.onDidClick(() => this._onDidSkip.fire()));
+		this._register(this._skipButton.onDidClick(() => this._onDidSkip.fire(OnboardingDismissReason.SkipButton)));
 
 		this._backButton = this._register(new Button(actions, { ...defaultButtonStyles, secondary: true }));
 		this._backButton.label = localize('spotlight.back', "Back");
@@ -139,7 +146,7 @@ export class SpotlightOverlay extends Disposable {
 
 		this._nextButton = this._register(new Button(actions, { ...defaultButtonStyles }));
 		this._nextButton.label = localize('spotlight.next', "Next");
-		this._register(this._nextButton.onDidClick(() => this._onDidClickNext.fire()));
+		this._register(this._nextButton.onDidClick(() => this._onDidClickNext.fire('button')));
 
 		// Keyboard handling on the callout: Esc skips, focus is trapped within.
 		this._register(addDisposableListener(this._callout, EventType.KEY_DOWN, e => this._onKeyDown(e)));
@@ -188,7 +195,7 @@ export class SpotlightOverlay extends Disposable {
 		const advanceOnTargetClick = !!options.advanceOnTargetClick;
 		this._nextButton.element.style.display = advanceOnTargetClick ? 'none' : '';
 		if (advanceOnTargetClick) {
-			this._stepListeners.add(addDisposableListener(target, EventType.CLICK, () => this._onDidClickNext.fire()));
+			this._stepListeners.add(addDisposableListener(target, EventType.CLICK, () => this._onDidClickNext.fire('target')));
 			this._stepListeners.add(addDisposableListener(target, EventType.KEY_DOWN, e => this._onKeyDown(e)));
 		}
 
@@ -361,7 +368,7 @@ export class SpotlightOverlay extends Disposable {
 		if (event.equals(KeyCode.Escape)) {
 			event.stopPropagation();
 			event.preventDefault();
-			this._onDidSkip.fire();
+			this._onDidSkip.fire(OnboardingDismissReason.EscapeKey);
 			return;
 		}
 

--- a/src/vs/workbench/contrib/onboarding/browser/spotlight/spotlightPresentation.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/spotlight/spotlightPresentation.ts
@@ -10,7 +10,7 @@ import { IContextKeyService } from '../../../../../platform/contextkey/common/co
 import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
 import { IHostService } from '../../../../services/host/browser/host.js';
 import { IOnboardingPresentation, IOnboardingRunContext } from '../../common/onboardingPresentation.js';
-import { IOnboardingScenario, OnboardingOutcome } from '../../common/onboardingScenario.js';
+import { IOnboardingRunResult, IOnboardingScenario, OnboardingDismissReason, OnboardingOutcome } from '../../common/onboardingScenario.js';
 import { findOnboardingTarget } from './onboardingTarget.js';
 import { ISpotlightContent, SpotlightOverlay } from './spotlightOverlay.js';
 import { ISpotlightPayload, ISpotlightStep, SPOTLIGHT_PRESENTATION_KIND } from './spotlightTypes.js';
@@ -20,7 +20,12 @@ const TARGET_RESOLVE_TIMEOUT = 2000;
 const TARGET_POLL_INTERVAL = 50;
 const TARGET_ANIMATION_SETTLE_TIMEOUT = 600;
 
-type StepAction = 'next' | 'back' | 'skip' | 'abort';
+/** The terminal action of a single step, carrying the data needed for telemetry. */
+type StepEnd =
+	| { readonly action: 'next'; readonly via: 'button' | 'target' }
+	| { readonly action: 'back' }
+	| { readonly action: 'skip'; readonly reason: OnboardingDismissReason.SkipButton | OnboardingDismissReason.EscapeKey }
+	| { readonly action: 'abort' };
 
 /**
  * Renders {@link ISpotlightPayload} scenarios: it dims the window (including the
@@ -40,12 +45,17 @@ export class SpotlightPresentation extends Disposable implements IOnboardingPres
 		super();
 	}
 
-	async run(scenario: IOnboardingScenario, context: IOnboardingRunContext): Promise<OnboardingOutcome> {
+	async run(scenario: IOnboardingScenario, context: IOnboardingRunContext): Promise<IOnboardingRunResult> {
 		const payload = scenario.presentation.payload as ISpotlightPayload;
 		const steps = payload?.steps ?? [];
-		if (steps.length === 0) {
-			return OnboardingOutcome.Completed;
+		const stepCount = steps.length;
+		if (stepCount === 0) {
+			return { outcome: OnboardingOutcome.Completed, dismissReason: OnboardingDismissReason.Completed, lastStepIndex: 0, stepCount: 0 };
 		}
+
+		// Furthest step the user actually saw (0-based). Stays at the last shown
+		// step regardless of how the run ends, for telemetry.
+		let lastStepIndex = 0;
 
 		const store = new DisposableStore();
 		try {
@@ -67,7 +77,7 @@ export class SpotlightPresentation extends Disposable implements IOnboardingPres
 			let index = 0;
 			let direction: 1 | -1 = 1;
 
-			while (index >= 0 && index < steps.length && !aborted) {
+			while (index >= 0 && index < stepCount && !aborted) {
 				const step = steps[index];
 
 				if (step.when && !this.contextKeyService.contextMatchesRules(step.when)) {
@@ -98,9 +108,16 @@ export class SpotlightPresentation extends Disposable implements IOnboardingPres
 					break;
 				}
 
-				const action = await this._runStep(overlay, context, step, target, index, steps.length);
-				switch (action) {
+				lastStepIndex = Math.max(lastStepIndex, index);
+
+				const end = await this._runStep(overlay, context, step, target, index, stepCount);
+				switch (end.action) {
 					case 'next':
+						if (index === stepCount - 1) {
+							// Advancing past the final step completes the tour.
+							const dismissReason = end.via === 'target' ? OnboardingDismissReason.TargetClick : OnboardingDismissReason.Completed;
+							return { outcome: OnboardingOutcome.Completed, dismissReason, lastStepIndex, stepCount };
+						}
 						direction = 1;
 						index++;
 						break;
@@ -109,13 +126,15 @@ export class SpotlightPresentation extends Disposable implements IOnboardingPres
 						index--;
 						break;
 					case 'skip':
-						return OnboardingOutcome.Skipped;
+						return { outcome: OnboardingOutcome.Skipped, dismissReason: end.reason, lastStepIndex, stepCount };
 					case 'abort':
-						return OnboardingOutcome.Aborted;
+						return { outcome: OnboardingOutcome.Aborted, dismissReason: OnboardingDismissReason.Aborted, lastStepIndex, stepCount };
 				}
 			}
 
-			return aborted ? OnboardingOutcome.Aborted : OnboardingOutcome.Completed;
+			return aborted
+				? { outcome: OnboardingOutcome.Aborted, dismissReason: OnboardingDismissReason.Aborted, lastStepIndex, stepCount }
+				: { outcome: OnboardingOutcome.Completed, dismissReason: OnboardingDismissReason.Completed, lastStepIndex, stepCount };
 		} finally {
 			store.dispose();
 		}
@@ -154,18 +173,18 @@ export class SpotlightPresentation extends Disposable implements IOnboardingPres
 		return animations;
 	}
 
-	private _runStep(overlay: SpotlightOverlay, context: IOnboardingRunContext, step: ISpotlightStep, target: HTMLElement, index: number, stepCount: number): Promise<StepAction> {
-		return new Promise<StepAction>(resolve => {
+	private _runStep(overlay: SpotlightOverlay, context: IOnboardingRunContext, step: ISpotlightStep, target: HTMLElement, index: number, stepCount: number): Promise<StepEnd> {
+		return new Promise<StepEnd>(resolve => {
 			const stepStore = new DisposableStore();
-			const done = (action: StepAction) => {
+			const done = (end: StepEnd) => {
 				stepStore.dispose();
-				resolve(action);
+				resolve(end);
 			};
 
-			stepStore.add(overlay.onDidClickNext(() => done('next')));
-			stepStore.add(overlay.onDidClickPrevious(() => done('back')));
-			stepStore.add(overlay.onDidSkip(() => done('skip')));
-			stepStore.add(context.onAbort(() => done('abort')));
+			stepStore.add(overlay.onDidClickNext(via => done({ action: 'next', via })));
+			stepStore.add(overlay.onDidClickPrevious(() => done({ action: 'back' })));
+			stepStore.add(overlay.onDidSkip(reason => done({ action: 'skip', reason })));
+			stepStore.add(context.onAbort(() => done({ action: 'abort' })));
 
 			const content: ISpotlightContent = {
 				title: step.title,

--- a/src/vs/workbench/contrib/onboarding/browser/spotlight/spotlightPresentation.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/spotlight/spotlightPresentation.ts
@@ -50,12 +50,15 @@ export class SpotlightPresentation extends Disposable implements IOnboardingPres
 		const steps = payload?.steps ?? [];
 		const stepCount = steps.length;
 		if (stepCount === 0) {
-			return { outcome: OnboardingOutcome.Completed, dismissReason: OnboardingDismissReason.Completed, lastStepIndex: 0, stepCount: 0 };
+			return { outcome: OnboardingOutcome.Completed, shown: false, dismissReason: OnboardingDismissReason.Completed, lastStepIndex: 0, stepCount: 0 };
 		}
 
 		// Furthest step the user actually saw (0-based). Stays at the last shown
 		// step regardless of how the run ends, for telemetry.
 		let lastStepIndex = 0;
+		// Whether at least one step was actually rendered. Stays `false` if every step is
+		// skipped (missing target / unsatisfied `when`) so nothing was ever displayed.
+		let shown = false;
 
 		const store = new DisposableStore();
 		try {
@@ -109,6 +112,7 @@ export class SpotlightPresentation extends Disposable implements IOnboardingPres
 				}
 
 				lastStepIndex = Math.max(lastStepIndex, index);
+				shown = true;
 
 				const end = await this._runStep(overlay, context, step, target, index, stepCount);
 				switch (end.action) {
@@ -116,7 +120,7 @@ export class SpotlightPresentation extends Disposable implements IOnboardingPres
 						if (index === stepCount - 1) {
 							// Advancing past the final step completes the tour.
 							const dismissReason = end.via === 'target' ? OnboardingDismissReason.TargetClick : OnboardingDismissReason.Completed;
-							return { outcome: OnboardingOutcome.Completed, dismissReason, lastStepIndex, stepCount };
+							return { outcome: OnboardingOutcome.Completed, shown, dismissReason, lastStepIndex, stepCount };
 						}
 						direction = 1;
 						index++;
@@ -126,15 +130,15 @@ export class SpotlightPresentation extends Disposable implements IOnboardingPres
 						index--;
 						break;
 					case 'skip':
-						return { outcome: OnboardingOutcome.Skipped, dismissReason: end.reason, lastStepIndex, stepCount };
+						return { outcome: OnboardingOutcome.Skipped, shown, dismissReason: end.reason, lastStepIndex, stepCount };
 					case 'abort':
-						return { outcome: OnboardingOutcome.Aborted, dismissReason: OnboardingDismissReason.Aborted, lastStepIndex, stepCount };
+						return { outcome: OnboardingOutcome.Aborted, shown, dismissReason: OnboardingDismissReason.Aborted, lastStepIndex, stepCount };
 				}
 			}
 
 			return aborted
-				? { outcome: OnboardingOutcome.Aborted, dismissReason: OnboardingDismissReason.Aborted, lastStepIndex, stepCount }
-				: { outcome: OnboardingOutcome.Completed, dismissReason: OnboardingDismissReason.Completed, lastStepIndex, stepCount };
+				? { outcome: OnboardingOutcome.Aborted, shown, dismissReason: OnboardingDismissReason.Aborted, lastStepIndex, stepCount }
+				: { outcome: OnboardingOutcome.Completed, shown, dismissReason: OnboardingDismissReason.Completed, lastStepIndex, stepCount };
 		} finally {
 			store.dispose();
 		}

--- a/src/vs/workbench/contrib/onboarding/common/onboardingPresentation.ts
+++ b/src/vs/workbench/contrib/onboarding/common/onboardingPresentation.ts
@@ -5,7 +5,7 @@
 
 import { Event } from '../../../../base/common/event.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
-import { IOnboardingScenario, OnboardingOutcome } from './onboardingScenario.js';
+import { IOnboardingRunResult, IOnboardingScenario } from './onboardingScenario.js';
 
 /**
  * Context handed to a presentation for a single scenario run. Exposes only what
@@ -18,7 +18,7 @@ export interface IOnboardingRunContext {
 	/**
 	 * Fires when the engine wants the presentation to abort the current run
 	 * (e.g. the application is shutting down). The presentation should resolve
-	 * its `run` promise with {@link OnboardingOutcome.Aborted}.
+	 * its `run` promise with an aborted result.
 	 */
 	readonly onAbort: Event<void>;
 }
@@ -34,11 +34,11 @@ export interface IOnboardingPresentation {
 	readonly kind: string;
 
 	/**
-	 * Render the scenario and resolve with the outcome once the user (or the
+	 * Render the scenario and resolve with the result once the user (or the
 	 * engine) ends the run. Implementations must clean up all UI/listeners
 	 * regardless of how the run ends.
 	 */
-	run(scenario: IOnboardingScenario, context: IOnboardingRunContext): Promise<OnboardingOutcome>;
+	run(scenario: IOnboardingScenario, context: IOnboardingRunContext): Promise<IOnboardingRunResult>;
 }
 
 /**

--- a/src/vs/workbench/contrib/onboarding/common/onboardingScenario.ts
+++ b/src/vs/workbench/contrib/onboarding/common/onboardingScenario.ts
@@ -29,6 +29,62 @@ export interface IOnboardingPresentationRef<TPayload = unknown> {
 }
 
 /**
+ * Reserved prefix that every onboarding experiment's **assignment-context identifier** must
+ * use (for example `onb-newsession-2026q3`).
+ *
+ * ### Why this exists
+ * The experimentation platform stamps every telemetry event with the user's assignment
+ * context as soon as the assignments are fetched at startup. For onboarding experiments we
+ * must *not* emit the identifier until the user actually reaches the point where the
+ * onboarding would be shown — otherwise the scorecard counts activity from before the
+ * experiment could have had any effect.
+ *
+ * The treatment flags that tell the client *which* identifier belongs to a given tour resolve
+ * asynchronously, after the assignment context has already been committed to telemetry, so
+ * they are too late to block the very first events. This prefix solves that race: because it
+ * is a *static, well-known* string, the client can pre-emptively exclude **any**
+ * assignment-context entry that starts with it from the very first event, and then
+ * selectively unblock the one specific identifier once the user reaches the onboarding moment.
+ *
+ * ### Contract for experiment authors
+ * - Every onboarding experiment configured in ExP MUST set its assignment-context identifier
+ *   to a value beginning with this prefix.
+ * - That same value MUST be returned by the experiment's
+ *   {@link IOnboardingExperiment.assignmentContextIdFlag} treatment flag.
+ *
+ * The engine enforces this defensively: an id that lacks the prefix is rejected (the experiment
+ * is treated as inactive and the misconfiguration is reported via `onUnexpectedError`) so a bad
+ * id can never leak into telemetry ungated. A prefixed id that is never claimed by a registered
+ * tour simply stays blocked forever.
+ */
+export const ONBOARDING_ASSIGNMENT_CONTEXT_PREFIX = 'onb-';
+
+/**
+ * Experiment configuration for an onboarding scenario. The two treatment flag *names* are
+ * resolved against the experimentation service; the experiment is only considered **active**
+ * when *both* resolve: the boolean to a boolean and the id to a non-empty string that starts
+ * with {@link ONBOARDING_ASSIGNMENT_CONTEXT_PREFIX}. If either flag is missing or the id lacks
+ * the required prefix, the scenario is treated as if it had no experiment and does not run.
+ */
+export interface IOnboardingExperiment {
+	/**
+	 * Name of the boolean treatment flag that decides the *experience*: `true` shows the tour
+	 * (treatment arm), `false` does not (control arm). In both arms the assignment-context
+	 * identifier starts flowing once the user reaches the onboarding moment.
+	 */
+	readonly behaviorFlag: string;
+
+	/**
+	 * Name of the string treatment flag whose value is this experiment's assignment-context
+	 * identifier — the exact entry that appears inside the telemetry `abexp.assignmentcontext`
+	 * property and that the scorecard keys on. The value MUST start with
+	 * {@link ONBOARDING_ASSIGNMENT_CONTEXT_PREFIX}; an id without the prefix is rejected (the
+	 * experiment is treated as inactive) so it can never leak into telemetry ungated.
+	 */
+	readonly assignmentContextIdFlag: string;
+}
+
+/**
  * A declarative onboarding scenario. Scenarios are pure data: they describe
  * *when* onboarding should happen and *which* presentation renders it, but not
  * *how* it is rendered (that is the presentation's job).
@@ -49,8 +105,12 @@ export interface IOnboardingScenario<TPayload = unknown> {
 	/** The presentation that renders this scenario plus its payload. */
 	readonly presentation: IOnboardingPresentationRef<TPayload>;
 
-	/** Optional experiment treatment id that must be enabled for the scenario to run. */
-	readonly experiment?: string;
+	/**
+	 * Optional experiment that gates and measures this scenario. When present, the scenario
+	 * only runs if the experiment is active (both treatment flags set). See
+	 * {@link IOnboardingExperiment}.
+	 */
+	readonly experiment?: IOnboardingExperiment;
 
 	/** When `true`, the scenario runs on every eligible session instead of once per user. */
 	readonly repeatable?: boolean;
@@ -68,4 +128,40 @@ export const enum OnboardingOutcome {
 	Dismissed = 'dismissed',
 	/** The scenario was aborted by the engine (e.g. window shutdown, target lost). */
 	Aborted = 'aborted'
+}
+
+/**
+ * The concrete mechanism that ended a scenario run. Refines {@link OnboardingOutcome} with
+ * the specific user action, primarily for telemetry (e.g. distinguishing the Skip button
+ * from the Escape key).
+ */
+export const enum OnboardingDismissReason {
+	/** The user reached and advanced past the final step. */
+	Completed = 'completed',
+	/** The user pressed the Skip button. */
+	SkipButton = 'skipButton',
+	/** The user pressed the Escape key. */
+	EscapeKey = 'escapeKey',
+	/** The user advanced by clicking the highlighted target on the final step. */
+	TargetClick = 'targetClick',
+	/** The engine aborted the run (window shutdown, target lost, ...). */
+	Aborted = 'aborted'
+}
+
+/**
+ * Rich result returned by a presentation's `run`, carrying the outcome plus the data the
+ * engine needs to emit per-tour telemetry (how far the user got and how the run ended).
+ */
+export interface IOnboardingRunResult {
+	/** Coarse engine-level outcome. */
+	readonly outcome: OnboardingOutcome;
+
+	/** Concrete reason/mechanism that ended the run. */
+	readonly dismissReason: OnboardingDismissReason;
+
+	/** Furthest 0-based step index the user reached (`0` if the first step never showed). */
+	readonly lastStepIndex: number;
+
+	/** Total number of steps the scenario declared. */
+	readonly stepCount: number;
 }

--- a/src/vs/workbench/contrib/onboarding/common/onboardingScenario.ts
+++ b/src/vs/workbench/contrib/onboarding/common/onboardingScenario.ts
@@ -64,7 +64,9 @@ export const ONBOARDING_ASSIGNMENT_CONTEXT_PREFIX = 'onb-';
  * resolved against the experimentation service; the experiment is only considered **active**
  * when *both* resolve: the boolean to a boolean and the id to a non-empty string that starts
  * with {@link ONBOARDING_ASSIGNMENT_CONTEXT_PREFIX}. If either flag is missing or the id lacks
- * the required prefix, the scenario is treated as if it had no experiment and does not run.
+ * the required prefix, the experiment is **inactive** and the scenario does not run
+ * automatically (it can still be started explicitly via a command/`runScenario`, which
+ * bypasses experiment gating and does not open the telemetry gate).
  */
 export interface IOnboardingExperiment {
 	/**
@@ -155,6 +157,14 @@ export const enum OnboardingDismissReason {
 export interface IOnboardingRunResult {
 	/** Coarse engine-level outcome. */
 	readonly outcome: OnboardingOutcome;
+
+	/**
+	 * Whether the presentation actually displayed anything to the user. `false` for a
+	 * degenerate run that rendered no UI (e.g. a scenario with no steps, or every step
+	 * skipped because its target/`when` was unavailable). The engine only emits outcome
+	 * telemetry when a tour was genuinely shown.
+	 */
+	readonly shown: boolean;
 
 	/** Concrete reason/mechanism that ended the run. */
 	readonly dismissReason: OnboardingDismissReason;

--- a/src/vs/workbench/contrib/onboarding/test/browser/onboardingService.test.ts
+++ b/src/vs/workbench/contrib/onboarding/test/browser/onboardingService.test.ts
@@ -15,7 +15,7 @@ import { ContextKeyExpr, IContextKey, IContextKeyService } from '../../../../../
 import { ContextKeyService } from '../../../../../platform/contextkey/browser/contextKeyService.js';
 import { InMemoryStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
-import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { NullTelemetryService, NullTelemetryServiceShape } from '../../../../../platform/telemetry/common/telemetryUtils.js';
 import { Memento } from '../../../../common/memento.js';
 import { IAssignmentFilter, IWorkbenchAssignmentService } from '../../../../services/assignment/common/assignmentService.js';
 import { NullWorkbenchAssignmentService } from '../../../../services/assignment/test/common/nullAssignmentService.js';
@@ -30,7 +30,30 @@ function completedResult(outcome: OnboardingOutcome = OnboardingOutcome.Complete
 	const dismissReason = outcome === OnboardingOutcome.Skipped ? OnboardingDismissReason.SkipButton
 		: outcome === OnboardingOutcome.Aborted ? OnboardingDismissReason.Aborted
 			: OnboardingDismissReason.Completed;
-	return { outcome, dismissReason, lastStepIndex: 0, stepCount: 1 };
+	return { outcome, shown: true, dismissReason, lastStepIndex: 0, stepCount: 1 };
+}
+
+/** A result for a degenerate run that rendered nothing (no steps / all steps skipped). */
+function notShownResult(): IOnboardingRunResult {
+	return { outcome: OnboardingOutcome.Completed, shown: false, dismissReason: OnboardingDismissReason.Completed, lastStepIndex: 0, stepCount: 0 };
+}
+
+/** Captures the names of `publicLog2` telemetry events. */
+class CapturingTelemetryService extends NullTelemetryServiceShape {
+	readonly events: string[] = [];
+	override publicLog2(eventName?: string): void {
+		if (eventName) {
+			this.events.push(eventName);
+		}
+	}
+}
+
+/** A presentation that resolves with a fixed run result. */
+class FixedResultPresentation implements IOnboardingPresentation {
+	constructor(readonly kind: string, private readonly result: IOnboardingRunResult) { }
+	async run(_scenario: IOnboardingScenario, _context: IOnboardingRunContext): Promise<IOnboardingRunResult> {
+		return this.result;
+	}
 }
 
 /** Records every scenario it renders, then resolves with a fixed outcome. */
@@ -97,7 +120,7 @@ suite('OnboardingScenarioService', () => {
 	let idSeed = 0;
 	function uniqueKind(): string { return `test-presentation-${idSeed++}`; }
 
-	function createService(configValues: Record<string, unknown> = {}, assignment?: IWorkbenchAssignmentService, storage = disposables.add(new InMemoryStorageService())): { service: OnboardingScenarioService; contextKeyService: IContextKeyService; config: TestConfigurationService; lifecycle: TestLifecycleService } {
+	function createService(configValues: Record<string, unknown> = {}, assignment?: IWorkbenchAssignmentService, storage = disposables.add(new InMemoryStorageService()), telemetry: ITelemetryService = NullTelemetryService as unknown as ITelemetryService): { service: OnboardingScenarioService; contextKeyService: IContextKeyService; config: TestConfigurationService; lifecycle: TestLifecycleService } {
 		const store = disposables;
 		const config = new TestConfigurationService(configValues);
 		const contextKeyService = store.add(new ContextKeyService(config));
@@ -108,7 +131,7 @@ suite('OnboardingScenarioService', () => {
 			config as unknown as IConfigurationService,
 			lifecycle,
 			assignment ?? new NullWorkbenchAssignmentService(),
-			NullTelemetryService as unknown as ITelemetryService,
+			telemetry,
 		));
 		return { service, contextKeyService, config, lifecycle };
 	}
@@ -296,6 +319,24 @@ suite('OnboardingScenarioService', () => {
 
 		service.resetAll();
 		assert.strictEqual(service.hasBeenShown('reset-1'), false);
+	});
+
+	test('emits scenarioOutcome telemetry when a tour is shown but not when nothing is rendered', async () => {
+		const shownKind = uniqueKind();
+		const notShownKind = uniqueKind();
+		registerPresentation(new FixedResultPresentation(shownKind, completedResult()));
+		registerPresentation(new FixedResultPresentation(notShownKind, notShownResult()));
+		registerScenario({ id: 'tele-shown', trigger: { kind: 'auto' }, presentation: { kind: shownKind, payload: undefined } });
+		registerScenario({ id: 'tele-notshown', trigger: { kind: 'auto' }, presentation: { kind: notShownKind, payload: undefined } });
+
+		const telemetry = new CapturingTelemetryService();
+		const { service } = createService({}, undefined, undefined, telemetry as unknown as ITelemetryService);
+		service.start();
+		await timeout(0);
+		await timeout(0);
+
+		// One event for the shown tour; none for the degenerate run that rendered nothing.
+		assert.deepStrictEqual(telemetry.events, ['onboarding.scenarioOutcome']);
 	});
 
 	test('experiment-driven scenario does not run unless both treatment flags are set', async () => {

--- a/src/vs/workbench/contrib/onboarding/test/browser/onboardingService.test.ts
+++ b/src/vs/workbench/contrib/onboarding/test/browser/onboardingService.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import { timeout } from '../../../../../base/common/async.js';
+import { errorHandler, setUnexpectedErrorHandler } from '../../../../../base/common/errors.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { observableValue } from '../../../../../base/common/observable.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
@@ -13,15 +14,24 @@ import { TestConfigurationService } from '../../../../../platform/configuration/
 import { ContextKeyExpr, IContextKey, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ContextKeyService } from '../../../../../platform/contextkey/browser/contextKeyService.js';
 import { InMemoryStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
 import { Memento } from '../../../../common/memento.js';
-import { IWorkbenchAssignmentService } from '../../../../services/assignment/common/assignmentService.js';
+import { IAssignmentFilter, IWorkbenchAssignmentService } from '../../../../services/assignment/common/assignmentService.js';
 import { NullWorkbenchAssignmentService } from '../../../../services/assignment/test/common/nullAssignmentService.js';
 import { TestLifecycleService } from '../../../../test/common/workbenchTestServices.js';
 import { OnboardingScenarioService } from '../../browser/onboardingService.js';
 import { IOnboardingPresentation, IOnboardingRunContext, onboardingPresentationRegistry } from '../../common/onboardingPresentation.js';
 import { onboardingScenarioRegistry } from '../../common/onboardingRegistry.js';
-import { IOnboardingScenario, OnboardingOutcome } from '../../common/onboardingScenario.js';
+import { IOnboardingRunResult, IOnboardingScenario, OnboardingDismissReason, OnboardingOutcome } from '../../common/onboardingScenario.js';
 import { ONBOARDING_DEVELOPER_MODE_CONFIG, ONBOARDING_ENABLED_CONFIG } from '../../common/onboardingScenarioService.js';
+
+function completedResult(outcome: OnboardingOutcome = OnboardingOutcome.Completed): IOnboardingRunResult {
+	const dismissReason = outcome === OnboardingOutcome.Skipped ? OnboardingDismissReason.SkipButton
+		: outcome === OnboardingOutcome.Aborted ? OnboardingDismissReason.Aborted
+			: OnboardingDismissReason.Completed;
+	return { outcome, dismissReason, lastStepIndex: 0, stepCount: 1 };
+}
 
 /** Records every scenario it renders, then resolves with a fixed outcome. */
 class RecordingPresentation implements IOnboardingPresentation {
@@ -31,10 +41,10 @@ class RecordingPresentation implements IOnboardingPresentation {
 		private readonly outcome: OnboardingOutcome = OnboardingOutcome.Completed,
 		private readonly onRun?: () => void,
 	) { }
-	async run(scenario: IOnboardingScenario, _context: IOnboardingRunContext): Promise<OnboardingOutcome> {
+	async run(scenario: IOnboardingScenario, _context: IOnboardingRunContext): Promise<IOnboardingRunResult> {
 		this.runs.push(scenario.id);
 		this.onRun?.();
-		return this.outcome;
+		return completedResult(this.outcome);
 	}
 }
 
@@ -42,14 +52,35 @@ class RecordingPresentation implements IOnboardingPresentation {
 class BlockingUntilAbortPresentation implements IOnboardingPresentation {
 	readonly runs: string[] = [];
 	constructor(readonly kind: string) { }
-	run(scenario: IOnboardingScenario, context: IOnboardingRunContext): Promise<OnboardingOutcome> {
+	run(scenario: IOnboardingScenario, context: IOnboardingRunContext): Promise<IOnboardingRunResult> {
 		this.runs.push(scenario.id);
-		return new Promise<OnboardingOutcome>(resolve => {
+		return new Promise<IOnboardingRunResult>(resolve => {
 			const listener = context.onAbort(() => {
 				listener.dispose();
-				resolve(OnboardingOutcome.Aborted);
+				resolve(completedResult(OnboardingOutcome.Aborted));
 			});
 		});
+	}
+}
+
+/**
+ * Assignment service test double that returns canned treatments and records the registered
+ * telemetry filter so tests can assert which assignment-context ids would be excluded.
+ */
+class FakeAssignmentService extends NullWorkbenchAssignmentService {
+	private readonly _filters: IAssignmentFilter[] = [];
+	constructor(private readonly treatments: Record<string, string | number | boolean>) {
+		super();
+	}
+	override async getTreatment<T extends string | number | boolean>(name: string): Promise<T | undefined> {
+		return this.treatments[name] as T | undefined;
+	}
+	override addTelemetryAssignmentFilter(filter: IAssignmentFilter): void {
+		this._filters.push(filter);
+	}
+	/** True when the given assignment-context id is currently excluded from telemetry. */
+	isExcluded(assignment: string): boolean {
+		return this._filters.some(f => f.exclude(assignment));
 	}
 }
 
@@ -60,7 +91,7 @@ suite('OnboardingScenarioService', () => {
 	teardown(() => {
 		// The Memento maintains a static cache keyed by id; clear it so each test
 		// starts with fresh persisted state instead of leaking across tests.
-		Memento.clear(StorageScope.PROFILE);
+		Memento.clear(StorageScope.APPLICATION);
 	});
 
 	let idSeed = 0;
@@ -77,6 +108,7 @@ suite('OnboardingScenarioService', () => {
 			config as unknown as IConfigurationService,
 			lifecycle,
 			assignment ?? new NullWorkbenchAssignmentService(),
+			NullTelemetryService as unknown as ITelemetryService,
 		));
 		return { service, contextKeyService, config, lifecycle };
 	}
@@ -229,10 +261,10 @@ suite('OnboardingScenarioService', () => {
 		const runs: string[] = [];
 		const presentation: IOnboardingPresentation = {
 			kind,
-			async run(scenario: IOnboardingScenario): Promise<OnboardingOutcome> {
+			async run(scenario: IOnboardingScenario): Promise<IOnboardingRunResult> {
 				runs.push(scenario.id);
 				await gate;
-				return OnboardingOutcome.Completed;
+				return completedResult();
 			}
 		};
 		registerPresentation(presentation);
@@ -266,44 +298,158 @@ suite('OnboardingScenarioService', () => {
 		assert.strictEqual(service.hasBeenShown('reset-1'), false);
 	});
 
-	test('experiment gate blocks the scenario until the treatment is enabled', async () => {
+	test('experiment-driven scenario does not run unless both treatment flags are set', async () => {
 		const presentation = new RecordingPresentation(uniqueKind());
 		registerPresentation(presentation);
+		registerScenario({
+			id: 'exp-off',
+			experiment: { behaviorFlag: 'exp.show', assignmentContextIdFlag: 'exp.id' },
+			trigger: { kind: 'auto' },
+			presentation: { kind: presentation.kind, payload: undefined }
+		});
 
-		class DisabledExperimentAssignmentService extends NullWorkbenchAssignmentService {
-			override async getTreatment<T extends string | number | boolean>(_name: string): Promise<T | undefined> {
-				return undefined;
-			}
-		}
-
-		registerScenario({ id: 'exp-off', experiment: 'exp.disabled', trigger: { kind: 'auto' }, presentation: { kind: presentation.kind, payload: undefined } });
-
-		const { service } = createService({}, new DisabledExperimentAssignmentService());
+		// Only one of the two flags resolves -> treated as not configured -> does not run.
+		const { service } = createService({}, new FakeAssignmentService({ 'exp.show': true }));
 		service.start();
+		await timeout(0);
 		await timeout(0);
 
 		assert.deepStrictEqual(presentation.runs, []);
 	});
 
-	test('experiment gate allows the scenario once the treatment resolves true', async () => {
+	test('an assignment-context id without the reserved prefix is rejected as inactive', async () => {
 		const presentation = new RecordingPresentation(uniqueKind());
 		registerPresentation(presentation);
+		// Misconfigured id: would never be gated by the prefix filter, so it must not run.
+		const assignment = new FakeAssignmentService({ 'exp.show': true, 'exp.id': 'newsession-2026q3' });
+		registerScenario({
+			id: 'exp-badid',
+			experiment: { behaviorFlag: 'exp.show', assignmentContextIdFlag: 'exp.id' },
+			trigger: { kind: 'auto' },
+			presentation: { kind: presentation.kind, payload: undefined }
+		});
 
-		class EnabledExperimentAssignmentService extends NullWorkbenchAssignmentService {
-			override async getTreatment<T extends string | number | boolean>(_name: string): Promise<T | undefined> {
-				return true as T;
-			}
+		const origErrorHandler = errorHandler.getUnexpectedErrorHandler();
+		const errors: unknown[] = [];
+		setUnexpectedErrorHandler(error => errors.push(error));
+		try {
+			const { service } = createService({}, assignment);
+			service.start();
+			await timeout(0);
+			await timeout(0);
+
+			assert.deepStrictEqual(
+				{ runs: presentation.runs, shown: service.hasBeenShown('exp-badid'), reported: errors.length === 1 },
+				{ runs: [], shown: false, reported: true }
+			);
+		} finally {
+			setUnexpectedErrorHandler(origErrorHandler);
 		}
+	});
 
-		registerScenario({ id: 'exp-on', experiment: 'exp.enabled', trigger: { kind: 'auto' }, presentation: { kind: presentation.kind, payload: undefined } });
+	test('treatment arm shows the tour and opens the telemetry gate', async () => {
+		const presentation = new RecordingPresentation(uniqueKind());
+		registerPresentation(presentation);
+		const assignment = new FakeAssignmentService({ 'exp.show': true, 'exp.id': 'onb-tour-q3' });
+		registerScenario({
+			id: 'exp-treat',
+			experiment: { behaviorFlag: 'exp.show', assignmentContextIdFlag: 'exp.id' },
+			trigger: { kind: 'auto' },
+			presentation: { kind: presentation.kind, payload: undefined }
+		});
 
-		const { service } = createService({}, new EnabledExperimentAssignmentService());
+		// Before resolution the id is blocked from telemetry by the prefix filter.
+		const { service } = createService({}, assignment);
+		assert.strictEqual(assignment.isExcluded('onb-tour-q3'), true, 'blocked before would-show');
+
 		service.start();
-		// Allow the async treatment fetch + re-evaluation to settle.
 		await timeout(0);
 		await timeout(0);
 
-		assert.deepStrictEqual(presentation.runs, ['exp-on']);
+		assert.deepStrictEqual(
+			{ runs: presentation.runs, shown: service.hasBeenShown('exp-treat'), excluded: assignment.isExcluded('onb-tour-q3') },
+			{ runs: ['exp-treat'], shown: true, excluded: false }
+		);
+	});
+
+	test('control arm opens the gate but shows nothing and stays eligible', async () => {
+		const presentation = new RecordingPresentation(uniqueKind());
+		registerPresentation(presentation);
+		const assignment = new FakeAssignmentService({ 'exp.show': false, 'exp.id': 'onb-tour-q3' });
+		registerScenario({
+			id: 'exp-control',
+			experiment: { behaviorFlag: 'exp.show', assignmentContextIdFlag: 'exp.id' },
+			trigger: { kind: 'auto' },
+			presentation: { kind: presentation.kind, payload: undefined }
+		});
+
+		const { service } = createService({}, assignment);
+		service.start();
+		await timeout(0);
+		await timeout(0);
+
+		// No tour shown, not marked shown (re-eligible later), but the id now flows.
+		assert.deepStrictEqual(
+			{ runs: presentation.runs, shown: service.hasBeenShown('exp-control'), excluded: assignment.isExcluded('onb-tour-q3') },
+			{ runs: [], shown: false, excluded: false }
+		);
+	});
+
+	test('an opened gate persists so the id keeps flowing after a reload', async () => {
+		const presentation = new RecordingPresentation(uniqueKind());
+		registerPresentation(presentation);
+		const storage = disposables.add(new InMemoryStorageService());
+		registerScenario({
+			id: 'exp-persist',
+			experiment: { behaviorFlag: 'exp.show', assignmentContextIdFlag: 'exp.id' },
+			trigger: { kind: 'auto' },
+			presentation: { kind: presentation.kind, payload: undefined }
+		});
+
+		// First "session": control reaches would-show and opens the gate.
+		const first = createService({}, new FakeAssignmentService({ 'exp.show': false, 'exp.id': 'onb-tour-q3' }), storage);
+		first.service.start();
+		await timeout(0);
+		await timeout(0);
+
+		// Second "session" (reload) with a fresh service + assignment service: the persisted
+		// gate must immediately allow the id, even before any would-show this session.
+		const secondAssignment = new FakeAssignmentService({ 'exp.show': false, 'exp.id': 'onb-tour-q3' });
+		createService({}, secondAssignment, storage);
+
+		assert.strictEqual(secondAssignment.isExcluded('onb-tour-q3'), false);
+	});
+
+	test('a second experiment with a new id is blocked for a user who already saw the tour', async () => {
+		const presentation = new RecordingPresentation(uniqueKind());
+		registerPresentation(presentation);
+		const storage = disposables.add(new InMemoryStorageService());
+		const kind = presentation.kind;
+
+		// Experiment 1: treatment. The user sees the tour and is marked shown.
+		disposables.add(onboardingScenarioRegistry.register({
+			id: 'tour',
+			experiment: { behaviorFlag: 'exp.show', assignmentContextIdFlag: 'exp.id' },
+			trigger: { kind: 'auto' },
+			presentation: { kind, payload: undefined }
+		}));
+		const first = createService({}, new FakeAssignmentService({ 'exp.show': true, 'exp.id': 'onb-tour-2026q3' }), storage);
+		first.service.start();
+		await timeout(0);
+		await timeout(0);
+		assert.strictEqual(first.service.hasBeenShown('tour'), true);
+
+		// Experiment 2 (new id) in a reload: already shown -> not eligible -> id stays blocked.
+		const secondAssignment = new FakeAssignmentService({ 'exp.show': true, 'exp.id': 'onb-tour-2027q1' });
+		const second = createService({}, secondAssignment, storage);
+		second.service.start();
+		await timeout(0);
+		await timeout(0);
+
+		assert.deepStrictEqual(
+			{ shown: second.service.hasBeenShown('tour'), excludedNew: secondAssignment.isExcluded('onb-tour-2027q1') },
+			{ shown: true, excludedNew: true }
+		);
 	});
 
 	test('shutdown aborts the active scenario and never starts queued ones', async () => {
@@ -334,7 +480,7 @@ suite('OnboardingScenarioService', () => {
 		const config = new TestConfigurationService();
 		const contextKeyService = store.add(new ContextKeyService(config));
 		const lifecycle = store.add(new TestLifecycleService());
-		const service = store.add(new OnboardingScenarioService(storage, contextKeyService, config as unknown as IConfigurationService, lifecycle, new NullWorkbenchAssignmentService()));
+		const service = store.add(new OnboardingScenarioService(storage, contextKeyService, config as unknown as IConfigurationService, lifecycle, new NullWorkbenchAssignmentService(), NullTelemetryService as unknown as ITelemetryService));
 		service.start();
 		store.dispose();
 		assert.ok(true);


### PR DESCRIPTION
## Problem

Onboarding experiments attach their assignment-context identifier to **every** telemetry event from application startup — long before the user has seen (or been eligible to see) the onboarding experience. Because scorecards are computed from tagged telemetry, this pollutes the A/B baseline with a window of pre-onboarding activity the experiment could not have influenced, weakening retention/success signals for both arms.

## Approach

An onboarding scenario can now declare an experiment with **two pre-determined ExP treatment flags**:

- `behaviorFlag` (boolean) — `true` shows the tour (**treatment**), `false` does not (**control**).
- `assignmentContextIdFlag` (string) — the identifier the scorecard keys on. It must begin with the reserved **`onb-`** prefix.

How it works:

1. **Eager gate.** A telemetry assignment filter is registered in the service constructor and blocks **any** `onb-`-prefixed id from the very first event — solving the race where treatment flags resolve after the assignment context is already committed.
2. **Active only when fully configured.** The experiment is active only when both flags resolve *and* the id carries the `onb-` prefix. A non-empty id missing the prefix is **rejected** (treated as inactive) and reported via `onUnexpectedError`, so a misconfiguration can never leak an ungated id.
3. **Would-show opens the gate.** When the user reaches the point where the tour would show (eligibility met, not already shown), the gate opens for that id — in **both** arms — and the decision is persisted (`APPLICATION`/`MACHINE`) so it survives reload/relaunch until the experiment stops. Treatment then shows the tour; control shows nothing and stays eligible.
4. **Re-run safety.** The discriminator is simply *did the user actually see the tour*. Treatment users are marked shown (so a later experiment's new id can't re-enroll them); control users remain eligible to take part in a future experiment with a different id.

## Telemetry

Adds `onboarding.scenarioOutcome` (emitted only when a tour is actually shown): `scenarioId`, `outcome`, `dismissReason` (skipButton / escapeKey / targetClick / completed / aborted), `lastStepIndex`, `stepCount`, `durationMs`, `experimentActive`. The spotlight presentation now threads the dismiss reason and furthest step reached through its run result.

## Notes

- The existing `newSessionTour` was intentionally **not** placed behind an experiment.
- On-demand `runScenario` (command/replay) bypasses gating and does not open the telemetry gate.

## Tests

`onboardingService.test.ts` covers: both-flags-required, prefix rejection, treatment-shows-and-opens-gate, control-opens-gate-but-no-show-and-stays-eligible, gate persists across reload, and re-run contamination. Validated with `npm run typecheck-client` (clean) and the onboarding + spotlight unit tests (passing in Chromium).
