### PR TITLE
Cut over ThirdPartyNotices to the Component Governance generated notice

### DIFF
--- a/.github/skills/azure-pipelines/SKILL.md
+++ b/.github/skills/azure-pipelines/SKILL.md
@@ -119,6 +119,7 @@ node .github/skills/azure-pipelines/azure-pipeline.ts queue --parameter "VSCODE_
 | `VSCODE_PUBLISH` | boolean | `true` | `true`, `false` | Publish to builds.code.visualstudio.com |
 | `VSCODE_RELEASE` | boolean | `false` | `true`, `false` | Trigger release flow if successful |
 | `VSCODE_STEP_ON_IT` | boolean | `false` | `true`, `false` | Skip tests |
+| `VSCODE_USE_LEGACY_OSS_NOTICE` | boolean | `false` | `true`, `false` | Keep the legacy mixin ThirdPartyNotices.txt instead of the Component Governance notice |
 
 Example: run a quick CI-oriented validation with minimal publish/release side effects:
 

--- a/build/azure-pipelines/common/downloadNotice.ts
+++ b/build/azure-pipelines/common/downloadNotice.ts
@@ -35,7 +35,7 @@ import { Readable } from 'stream';
 import type { ReadableStream } from 'stream/web';
 import { pipeline } from 'node:stream/promises';
 import yauzl from 'yauzl';
-import { type Artifact, e, requestAZDOAPI } from './publish.ts';
+import { e, requestAZDOAPI } from './publish.ts';
 import { retry } from './retry.ts';
 
 const ARTIFACT_NAME = 'notice_output';
@@ -47,8 +47,9 @@ const TARGET_NOTICE = path.resolve('ThirdPartyNotices.txt');
 // Poll budget: 20 attempts x 30s = 10 minutes. Deliberately far below the
 // copilot 30min so a never-produced artifact degrades to fallback quickly, but
 // with generous margin over the parallel Quality stage (CG + scan + merge).
-// Observed: the Quality job completed and the poller accepted at ~attempt 10
-// (~4.5min) in builds 450470/450477, so 10min is ~2x the observed need.
+// The PRIMARY gate accepts the instant ThirdPartyNotices.new.txt appears in the
+// container listing (observed ~3-4min), so the budget is mostly safety margin;
+// the Quality-completion backstop ends the wait early if the file never lands.
 // NB: this is the OUTER artifact-availability poll. It is unrelated to the
 // inner retry() wrapper in retry.ts, which independently retries each AZDO API
 // call up to 10 times for transient network errors and emits no attempt log.
@@ -68,6 +69,20 @@ interface TimelineRecord {
 
 interface Timeline {
 	readonly records: TimelineRecord[];
+}
+
+// We need the container `data` field (which the publish.ts Artifact type omits)
+// to list the FILES inside the notice_output container artifact. For a container
+// artifact, resource.data looks like "#/<containerId>/<rootPath>".
+interface NoticeArtifact {
+	readonly name: string;
+	readonly resource: {
+		readonly downloadUrl: string;
+		readonly data?: string;
+		readonly properties: {
+			readonly artifactsize: number;
+		};
+	};
 }
 
 function installDiagnostics(): void {
@@ -100,9 +115,35 @@ function getAzdoFetchOptions() {
 	};
 }
 
-async function getPipelineArtifacts(): Promise<Artifact[]> {
-	const result = await requestAZDOAPI<{ readonly value: Artifact[] }>('artifacts');
+async function getPipelineArtifacts(): Promise<NoticeArtifact[]> {
+	const result = await requestAZDOAPI<{ readonly value: NoticeArtifact[] }>('artifacts');
 	return result.value;
+}
+
+// Lists the FILES inside a container artifact via the AZDO container-items API.
+// Container-artifact file uploads are atomic per file: a file only appears in
+// this listing AFTER its upload has finished, so seeing ThirdPartyNotices.new.txt
+// here means it is fully written and safe to download. Returns the file paths,
+// or undefined if the listing could not be retrieved (transient error) so the
+// caller can distinguish "file genuinely absent" from "could not check".
+async function listArtifactFiles(artifact: NoticeArtifact): Promise<string[] | undefined> {
+	// resource.data for a container artifact looks like: #/<containerId>/<rootPath>
+	const match = /^#\/(\d+)\/(.+)$/.exec(artifact.resource.data ?? '');
+	if (!match) {
+		return undefined;
+	}
+
+	const [, containerId, itemPath] = match;
+	const collectionUri = e('SYSTEM_COLLECTIONURI').replace(/\/$/, '');
+	const url = `${collectionUri}/_apis/resources/Containers/${containerId}?itemPath=${encodeURIComponent(itemPath)}&isShallow=false&api-version=4.1-preview.4`;
+
+	const res = await retry(() => fetch(url, getAzdoFetchOptions()));
+	if (!res.ok) {
+		throw new Error(`Container items request failed: ${res.status}`);
+	}
+
+	const body = await res.json() as { readonly value: { readonly path: string; readonly itemType: string }[] };
+	return body.value.filter(item => item.itemType === 'file').map(item => item.path);
 }
 
 async function getQualityJob(): Promise<TimelineRecord | undefined> {
@@ -110,7 +151,7 @@ async function getQualityJob(): Promise<TimelineRecord | undefined> {
 	return timeline.records.find(r => r.type === 'Job' && QUALITY_JOB_NAMES.includes(r.name));
 }
 
-async function downloadArtifact(artifact: Artifact, downloadPath: string): Promise<void> {
+async function downloadArtifact(artifact: NoticeArtifact, downloadPath: string): Promise<void> {
 	const abortController = new AbortController();
 	const timeout = setTimeout(() => abortController.abort(), 4 * 60 * 1000);
 
@@ -165,7 +206,7 @@ async function unzip(zipPath: string, outputPath: string): Promise<string[]> {
 }
 
 // Returns the artifact if it appears within the short budget, otherwise undefined.
-async function waitForArtifact(): Promise<Artifact | undefined> {
+async function waitForArtifact(): Promise<NoticeArtifact | undefined> {
 	const startTime = Date.now();
 
 	for (let index = 0; index < POLL_ATTEMPTS; index++) {
@@ -174,10 +215,9 @@ async function waitForArtifact(): Promise<Artifact | undefined> {
 		try {
 			log(`Waiting for ${ARTIFACT_NAME} artifact (attempt ${index + 1}/${POLL_ATTEMPTS}, ${elapsed}s elapsed)...`);
 
-			// Best-effort: if the Quality job has completed and clearly failed,
-			// stop early -- the artifact is not coming. continueOnError steps in
-			// the Quality stage mean a "failed" job can still upload the artifact,
-			// so we only bail on a hard, completed failure.
+			// The Quality job state is only a BACKSTOP now (see below): if it has
+			// completed and .new.txt is still absent, the file is never coming and
+			// we give up early instead of burning the whole budget.
 			const qualityJob = await getQualityJob().catch(() => undefined);
 			if (qualityJob) {
 				log(`  * Quality job: state=${qualityJob.state}, result=${qualityJob.result ?? 'n/a'}`);
@@ -188,16 +228,34 @@ async function waitForArtifact(): Promise<Artifact | undefined> {
 
 			const artifact = allArtifacts.find(a => a.name === ARTIFACT_NAME);
 			if (artifact) {
-				// IMPORTANT: the notice_output artifact is populated in TWO phases by
-				// two different Quality-stage steps -- first generated.txt + meta, then
-				// (seconds later) the shipping ThirdPartyNotices.new.txt. The artifact
-				// NAME appears after phase 1, so we must NOT accept it until the Quality
-				// job has COMPLETED, otherwise we race and download before .new.txt lands.
-				if (qualityJob && qualityJob.state === 'completed') {
-					log('  * notice_output artifact found and Quality job completed');
-					return artifact;
+				// PRIMARY GATE: accept the instant ThirdPartyNotices.new.txt actually
+				// exists inside the container artifact. The artifact is populated in
+				// TWO phases by two Quality-stage steps (first generated.txt + meta,
+				// then seconds-to-minutes later the shipping .new.txt). The artifact
+				// NAME appears after phase 1, so checking the NAME alone races. But a
+				// container file appears in the listing only after its upload finishes,
+				// so the listing is an exact, race-free readiness signal -- and it lets
+				// us accept as soon as .new.txt lands rather than waiting for the whole
+				// Quality job to finish (which observably wastes ~80s of margin).
+				const files = await listArtifactFiles(artifact).catch(() => undefined);
+				if (files === undefined) {
+					// Could not list (transient error or unexpected data shape). Do not
+					// give up; just retry next poll. The budget still bounds the wait.
+					log('  * could not list notice_output files yet; will recheck next poll');
+				} else {
+					log(`  * notice_output files: ${files.map(f => path.basename(f)).join(', ') || '(empty)'}`);
+					if (files.some(f => path.basename(f) === SHIPPING_NOTICE_NAME)) {
+						log(`  * ${SHIPPING_NOTICE_NAME} present in artifact; accepting.`);
+						return artifact;
+					}
+					// BACKSTOP: file confirmed absent AND the Quality job has finished
+					// => it is never coming. Fall back instead of polling the full budget.
+					if (qualityJob && qualityJob.state === 'completed') {
+						log(`  * Quality job completed but ${SHIPPING_NOTICE_NAME} absent from artifact; giving up.`);
+						return undefined;
+					}
+					log(`  * ${SHIPPING_NOTICE_NAME} not in artifact yet; waiting...`);
 				}
-				log('  * notice_output found but Quality job still running (uploads may be incomplete); waiting...');
 			} else if (qualityJob && qualityJob.state === 'completed') {
 				log('  * Quality job completed but no notice_output artifact; giving up.');
 				return undefined;

--- a/build/azure-pipelines/common/downloadNotice.ts
+++ b/build/azure-pipelines/common/downloadNotice.ts
@@ -1,0 +1,269 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// E-lite: Component Governance (CG) NOTICE cutover.
+//
+// During each platform compile stage this script pulls the CG-generated NOTICE
+// (produced by the parallel Quality stage as the `notice_output` artifact) and
+// overwrites the repo-root ThirdPartyNotices.txt BEFORE gulp packages it
+// (build/gulpfile.vscode.ts reads 'ThirdPartyNotices.txt' at package time).
+//
+// It clones the proven copilot VSIX background-download harness: a detached
+// `deemon` poller starts at compile start (maximum overlap) and the package
+// step attaches/blocks on it right before packaging. If the artifact is ready
+// by then the added wall-clock is near-zero; otherwise we block for at most a
+// short budget and then DEGRADE to the legacy mixin notice.
+//
+// Design notes (see oss-cutover design log):
+//   * copy-then-overwrite: mixin-quality.ts is left untouched (shared chokepoint
+//     used by 8+ pipelines). The legacy ThirdPartyNotices.txt it lays down is
+//     our guaranteed fallback, so we never ship with NO notice.
+//   * NON-FATAL: this script always exits 0. A notice problem must never break
+//     packaging during the cutover. Steady-state can flip to fatal later.
+//   * SHORT poll budget (not the copilot 30min): a missing artifact must degrade
+//     to fallback fast, otherwise the non-fatal design is defeated by a 30min hang.
+//   * Three greppable markers so a build log answers "fresh vs stale vs off":
+//       [notice-elite] RESULT=fresh     overwrote from notice_output (logs producer)
+//       [notice-elite] RESULT=fallback  artifact missing -> kept legacy notice
+//       [notice-elite] RESULT=disabled  feature flag off -> kept legacy notice
+
+import fs from 'fs';
+import path from 'path';
+import { Readable } from 'stream';
+import type { ReadableStream } from 'stream/web';
+import { pipeline } from 'node:stream/promises';
+import yauzl from 'yauzl';
+import { type Artifact, e, requestAZDOAPI } from './publish.ts';
+import { retry } from './retry.ts';
+
+const ARTIFACT_NAME = 'notice_output';
+const QUALITY_JOB_NAMES = ['Quality Checks', 'Quality'];
+// The merged, shipping NOTICE (CG + scanned extension licenses + cglicenses overrides).
+const SHIPPING_NOTICE_NAME = 'ThirdPartyNotices.new.txt';
+const TARGET_NOTICE = path.resolve('ThirdPartyNotices.txt');
+
+// Short poll budget: 10 attempts x 30s = 5 minutes. Deliberately far below the
+// copilot 30min so a never-produced artifact degrades to fallback quickly.
+const POLL_ATTEMPTS = 10;
+const POLL_INTERVAL_MS = 30_000;
+
+function log(message: string): void {
+	console.log(`[notice-elite] [${new Date().toISOString()}] ${message}`);
+}
+
+interface TimelineRecord {
+	readonly name: string;
+	readonly type: string;
+	readonly state: string;
+	readonly result: string;
+}
+
+interface Timeline {
+	readonly records: TimelineRecord[];
+}
+
+function installDiagnostics(): void {
+	process.on('uncaughtException', err => {
+		console.error('[notice-elite] Uncaught exception:', err);
+		// Non-fatal: never break packaging because of a notice problem.
+		process.exit(0);
+	});
+	process.on('unhandledRejection', reason => {
+		console.error('[notice-elite] Unhandled rejection:', reason);
+		process.exit(0);
+	});
+	for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGBREAK'] as const) {
+		process.on(signal, () => {
+			console.error(`[notice-elite] Received ${signal}, exiting.`);
+			process.exit(0);
+		});
+	}
+}
+
+function getAzdoFetchOptions() {
+	return {
+		headers: {
+			'Accept': 'application/json;api-version=5.0-preview.1',
+			'Accept-Encoding': 'gzip, deflate, br',
+			'Accept-Language': 'en-US,en;q=0.9',
+			'Referer': 'https://dev.azure.com',
+			Authorization: `Bearer ${e('SYSTEM_ACCESSTOKEN')}`
+		}
+	};
+}
+
+async function getPipelineArtifacts(): Promise<Artifact[]> {
+	const result = await requestAZDOAPI<{ readonly value: Artifact[] }>('artifacts');
+	return result.value;
+}
+
+async function getQualityJob(): Promise<TimelineRecord | undefined> {
+	const timeline = await retry(() => requestAZDOAPI<Timeline>('timeline'));
+	return timeline.records.find(r => r.type === 'Job' && QUALITY_JOB_NAMES.includes(r.name));
+}
+
+async function downloadArtifact(artifact: Artifact, downloadPath: string): Promise<void> {
+	const abortController = new AbortController();
+	const timeout = setTimeout(() => abortController.abort(), 4 * 60 * 1000);
+
+	try {
+		const res = await fetch(artifact.resource.downloadUrl, { ...getAzdoFetchOptions(), signal: abortController.signal });
+
+		if (!res.ok) {
+			throw new Error(`Unexpected status code: ${res.status}`);
+		}
+
+		await pipeline(Readable.fromWeb(res.body as ReadableStream), fs.createWriteStream(downloadPath));
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+async function unzip(zipPath: string, outputPath: string): Promise<string[]> {
+	return new Promise((resolve, reject) => {
+		yauzl.open(zipPath, { lazyEntries: true, autoClose: true }, (err, zipfile) => {
+			if (err) {
+				return reject(err);
+			}
+
+			const result: string[] = [];
+			zipfile!.on('entry', entry => {
+				if (/\/$/.test(entry.fileName)) {
+					zipfile!.readEntry();
+				} else {
+					zipfile!.openReadStream(entry, (err, istream) => {
+						if (err) {
+							return reject(err);
+						}
+
+						const filePath = path.join(outputPath, entry.fileName);
+						fs.mkdirSync(path.dirname(filePath), { recursive: true });
+
+						const ostream = fs.createWriteStream(filePath);
+						ostream.on('finish', () => {
+							result.push(filePath);
+							zipfile!.readEntry();
+						});
+						istream?.on('error', err => reject(err));
+						istream!.pipe(ostream);
+					});
+				}
+			});
+
+			zipfile!.on('close', () => resolve(result));
+			zipfile!.readEntry();
+		});
+	});
+}
+
+// Returns the artifact if it appears within the short budget, otherwise undefined.
+async function waitForArtifact(): Promise<Artifact | undefined> {
+	const startTime = Date.now();
+
+	for (let index = 0; index < POLL_ATTEMPTS; index++) {
+		const elapsed = Math.round((Date.now() - startTime) / 1000);
+
+		try {
+			log(`Waiting for ${ARTIFACT_NAME} artifact (attempt ${index + 1}/${POLL_ATTEMPTS}, ${elapsed}s elapsed)...`);
+
+			// Best-effort: if the Quality job has completed and clearly failed,
+			// stop early -- the artifact is not coming. continueOnError steps in
+			// the Quality stage mean a "failed" job can still upload the artifact,
+			// so we only bail on a hard, completed failure.
+			const qualityJob = await getQualityJob().catch(() => undefined);
+			if (qualityJob) {
+				log(`  * Quality job: state=${qualityJob.state}, result=${qualityJob.result ?? 'n/a'}`);
+			}
+
+			const allArtifacts = await retry(() => getPipelineArtifacts());
+			log(`  * Found ${allArtifacts.length} artifact(s): ${allArtifacts.map(a => a.name).join(', ') || '(none)'}`);
+
+			const artifact = allArtifacts.find(a => a.name === ARTIFACT_NAME);
+			if (artifact) {
+				log(`  * ${ARTIFACT_NAME} artifact found`);
+				return artifact;
+			}
+
+			if (qualityJob && qualityJob.state === 'completed' && !artifact) {
+				log('  * Quality job completed but no notice_output artifact; giving up.');
+				return undefined;
+			}
+
+			log(`  * Not found yet, waiting ${POLL_INTERVAL_MS / 1000}s...`);
+		} catch (err) {
+			console.error(`[notice-elite] WARNING: poll attempt failed: ${err}`);
+		}
+
+		await new Promise(c => setTimeout(c, POLL_INTERVAL_MS));
+	}
+
+	return undefined;
+}
+
+async function main(): Promise<void> {
+	installDiagnostics();
+
+	// Feature flag = instant rollback. Default ON during the cutover validation;
+	// set VSCODE_OVERWRITE_TPN=false to force the legacy mixin notice.
+	if (process.env['VSCODE_OVERWRITE_TPN'] === 'false') {
+		log('RESULT=disabled feature flag off (VSCODE_OVERWRITE_TPN=false); keeping legacy notice.');
+		return;
+	}
+
+	const artifact = await waitForArtifact();
+	if (!artifact) {
+		log(`RESULT=fallback ${ARTIFACT_NAME} artifact unavailable within budget; keeping legacy notice.`);
+		return;
+	}
+
+	const tmpDir = path.resolve('.build/tmp-notice');
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+	fs.mkdirSync(tmpDir, { recursive: true });
+	const artifactZipPath = path.join(tmpDir, 'notice_output.zip');
+
+	log('Downloading notice_output artifact...');
+	await retry(() => downloadArtifact(artifact, artifactZipPath));
+
+	log('Extracting notice_output artifact...');
+	const files = await unzip(artifactZipPath, tmpDir);
+	const shipping = files.find(f => path.basename(f) === SHIPPING_NOTICE_NAME);
+
+	if (!shipping) {
+		log(`RESULT=fallback artifact present but ${SHIPPING_NOTICE_NAME} missing; keeping legacy notice.`);
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+		return;
+	}
+
+	const size = fs.statSync(shipping).size;
+	// Guard: a tiny file means the merge produced nothing usable. Keep legacy.
+	if (size <= 1024) {
+		log(`RESULT=fallback ${SHIPPING_NOTICE_NAME} too small (${size} bytes); keeping legacy notice.`);
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+		return;
+	}
+
+	// Log provenance for legal traceability: which build/commit produced this NOTICE.
+	const metaFile = files.find(f => path.basename(f) === 'notice-meta.txt');
+	if (metaFile) {
+		log('NOTICE provenance:');
+		for (const line of fs.readFileSync(metaFile, 'utf8').split(/\r?\n/)) {
+			if (line.trim()) {
+				log(`    ${line}`);
+			}
+		}
+	}
+
+	const legacySize = fs.existsSync(TARGET_NOTICE) ? fs.statSync(TARGET_NOTICE).size : 0;
+	fs.copyFileSync(shipping, TARGET_NOTICE);
+	log(`RESULT=fresh overwrote ${TARGET_NOTICE} with CG NOTICE (${size} bytes; legacy was ${legacySize} bytes).`);
+
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+}
+
+main().catch(err => {
+	// Non-fatal: log and exit 0 so packaging proceeds with the legacy notice.
+	console.error('[notice-elite] Non-fatal error; keeping legacy notice:', err);
+	process.exitCode = 0;
+});

--- a/build/azure-pipelines/common/downloadNotice.ts
+++ b/build/azure-pipelines/common/downloadNotice.ts
@@ -350,8 +350,10 @@ async function main(): Promise<void> {
 	installDiagnostics();
 
 	// Feature flag = instant rollback. Default ON during the cutover validation;
-	// set VSCODE_OVERWRITE_TPN=false to force the legacy mixin notice.
-	if (process.env['VSCODE_OVERWRITE_TPN'] === 'false') {
+	// set VSCODE_OVERWRITE_TPN=false to force the legacy mixin notice. Check is
+	// case-insensitive on purpose so YAML casing (true/false vs True/False) can't
+	// silently break the rollback lever.
+	if ((process.env['VSCODE_OVERWRITE_TPN'] ?? '').trim().toLowerCase() === 'false') {
 		log('RESULT=disabled feature flag off (VSCODE_OVERWRITE_TPN=false); keeping legacy notice.');
 		return;
 	}

--- a/build/azure-pipelines/common/downloadNotice.ts
+++ b/build/azure-pipelines/common/downloadNotice.ts
@@ -44,9 +44,10 @@ const QUALITY_JOB_NAMES = ['Quality Checks', 'Quality'];
 const SHIPPING_NOTICE_NAME = 'ThirdPartyNotices.new.txt';
 const TARGET_NOTICE = path.resolve('ThirdPartyNotices.txt');
 
-// Short poll budget: 10 attempts x 30s = 5 minutes. Deliberately far below the
-// copilot 30min so a never-produced artifact degrades to fallback quickly.
-const POLL_ATTEMPTS = 10;
+// Short poll budget: 15 attempts x 30s = 7.5 minutes. Deliberately far below the
+// copilot 30min so a never-produced artifact degrades to fallback quickly, but
+// long enough to outlast the parallel Quality stage (CG + scan + merge).
+const POLL_ATTEMPTS = 15;
 const POLL_INTERVAL_MS = 30_000;
 
 function log(message: string): void {
@@ -182,16 +183,22 @@ async function waitForArtifact(): Promise<Artifact | undefined> {
 
 			const artifact = allArtifacts.find(a => a.name === ARTIFACT_NAME);
 			if (artifact) {
-				log(`  * ${ARTIFACT_NAME} artifact found`);
-				return artifact;
-			}
-
-			if (qualityJob && qualityJob.state === 'completed' && !artifact) {
+				// IMPORTANT: the notice_output artifact is populated in TWO phases by
+				// two different Quality-stage steps -- first generated.txt + meta, then
+				// (seconds later) the shipping ThirdPartyNotices.new.txt. The artifact
+				// NAME appears after phase 1, so we must NOT accept it until the Quality
+				// job has COMPLETED, otherwise we race and download before .new.txt lands.
+				if (qualityJob && qualityJob.state === 'completed') {
+					log('  * notice_output artifact found and Quality job completed');
+					return artifact;
+				}
+				log('  * notice_output found but Quality job still running (uploads may be incomplete); waiting...');
+			} else if (qualityJob && qualityJob.state === 'completed') {
 				log('  * Quality job completed but no notice_output artifact; giving up.');
 				return undefined;
 			}
 
-			log(`  * Not found yet, waiting ${POLL_INTERVAL_MS / 1000}s...`);
+			log(`  * Not ready yet, waiting ${POLL_INTERVAL_MS / 1000}s...`);
 		} catch (err) {
 			console.error(`[notice-elite] WARNING: poll attempt failed: ${err}`);
 		}

--- a/build/azure-pipelines/common/downloadNotice.ts
+++ b/build/azure-pipelines/common/downloadNotice.ts
@@ -47,9 +47,14 @@ const TARGET_NOTICE = path.resolve('ThirdPartyNotices.txt');
 // Poll budget: 20 attempts x 30s = 10 minutes. Deliberately far below the
 // copilot 30min so a never-produced artifact degrades to fallback quickly, but
 // with generous margin over the parallel Quality stage (CG + scan + merge).
-// The PRIMARY gate accepts the instant ThirdPartyNotices.new.txt appears in the
-// container listing (observed ~3-4min), so the budget is mostly safety margin;
-// the Quality-completion backstop ends the wait early if the file never lands.
+// The gate accepts only once ThirdPartyNotices.new.txt has been downloaded,
+// extracted, and validated non-empty (>1KB) -- merely seeing it in the
+// container listing is NOT sufficient, because the listing entry can appear
+// before the file's content has finished committing (see waitForNotice). On
+// such a mid-upload miss we keep polling rather than falling back, so a
+// fast-compiling platform can never ship the legacy notice while its peers
+// ship the CG notice. The Quality-completion backstop ends the wait early only
+// when .new.txt was never produced at all.
 // NB: this is the OUTER artifact-availability poll. It is unrelated to the
 // inner retry() wrapper in retry.ts, which independently retries each AZDO API
 // call up to 10 times for transient network errors and emits no attempt log.
@@ -121,11 +126,14 @@ async function getPipelineArtifacts(): Promise<NoticeArtifact[]> {
 }
 
 // Lists the FILES inside a container artifact via the AZDO container-items API.
-// Container-artifact file uploads are atomic per file: a file only appears in
-// this listing AFTER its upload has finished, so seeing ThirdPartyNotices.new.txt
-// here means it is fully written and safe to download. Returns the file paths,
-// or undefined if the listing could not be retrieved (transient error) so the
-// caller can distinguish "file genuinely absent" from "could not check".
+// NOTE: a file path can appear in this listing slightly BEFORE its content has
+// finished committing to the container (observed in build 450517: the listing
+// showed ThirdPartyNotices.new.txt one poll before the artifact download
+// actually yielded it). So this listing is a NECESSARY but not SUFFICIENT
+// readiness signal -- the caller must still download+extract+validate the file
+// before accepting it. Returns the file paths, or undefined if the listing
+// could not be retrieved (transient error) so the caller can distinguish "file
+// genuinely absent" from "could not check".
 async function listArtifactFiles(artifact: NoticeArtifact): Promise<string[] | undefined> {
 	// resource.data for a container artifact looks like: #/<containerId>/<rootPath>
 	const match = /^#\/(\d+)\/(.+)$/.exec(artifact.resource.data ?? '');
@@ -205,8 +213,52 @@ async function unzip(zipPath: string, outputPath: string): Promise<string[]> {
 	});
 }
 
-// Returns the artifact if it appears within the short budget, otherwise undefined.
-async function waitForArtifact(): Promise<NoticeArtifact | undefined> {
+interface ExtractedNotice {
+	readonly shippingPath: string;
+	readonly metaFile: string | undefined;
+	readonly size: number;
+}
+
+// Downloads + extracts the notice_output artifact into tmpDir and validates that
+// ThirdPartyNotices.new.txt is actually present AND non-empty (>1KB). Returns the
+// extracted notice on success, or undefined if the file is missing/too small in
+// the EXTRACTED output -- which, when the container listing claimed it was there,
+// means the content is still committing (mid-upload). The caller treats undefined
+// as "not ready yet" and re-polls; it must NEVER be treated as terminal fallback,
+// because a fast platform that hits this window would otherwise ship the legacy
+// notice while its peers ship the CG notice (the cross-arch mismatch bug).
+async function tryExtractNotice(artifact: NoticeArtifact, tmpDir: string): Promise<ExtractedNotice | undefined> {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+	fs.mkdirSync(tmpDir, { recursive: true });
+	const artifactZipPath = path.join(tmpDir, 'notice_output.zip');
+
+	log('  * downloading notice_output artifact to verify content...');
+	await retry(() => downloadArtifact(artifact, artifactZipPath));
+
+	log('  * extracting notice_output artifact...');
+	const files = await unzip(artifactZipPath, tmpDir);
+	const shipping = files.find(f => path.basename(f) === SHIPPING_NOTICE_NAME);
+
+	if (!shipping) {
+		log(`  * ${SHIPPING_NOTICE_NAME} listed but not yet in extracted output (mid-upload); will recheck next poll.`);
+		return undefined;
+	}
+
+	const size = fs.statSync(shipping).size;
+	// Guard: a tiny file means the merge produced nothing usable OR the upload is
+	// still in flight. Either way, do not accept it -- re-poll.
+	if (size <= 1024) {
+		log(`  * ${SHIPPING_NOTICE_NAME} extracted but too small (${size} bytes; mid-upload or empty merge); will recheck next poll.`);
+		return undefined;
+	}
+
+	const metaFile = files.find(f => path.basename(f) === 'notice-meta.txt');
+	return { shippingPath: shipping, metaFile, size };
+}
+
+// Returns the validated, extracted CG NOTICE if it becomes available within the
+// short budget, otherwise undefined (caller keeps the legacy notice).
+async function waitForNotice(tmpDir: string): Promise<ExtractedNotice | undefined> {
 	const startTime = Date.now();
 
 	for (let index = 0; index < POLL_ATTEMPTS; index++) {
@@ -215,9 +267,9 @@ async function waitForArtifact(): Promise<NoticeArtifact | undefined> {
 		try {
 			log(`Waiting for ${ARTIFACT_NAME} artifact (attempt ${index + 1}/${POLL_ATTEMPTS}, ${elapsed}s elapsed)...`);
 
-			// The Quality job state is only a BACKSTOP now (see below): if it has
-			// completed and .new.txt is still absent, the file is never coming and
-			// we give up early instead of burning the whole budget.
+			// The Quality job state is only a BACKSTOP (see below): if it has
+			// completed and .new.txt never even appeared in the listing, the file
+			// is never coming and we give up early instead of burning the budget.
 			const qualityJob = await getQualityJob().catch(() => undefined);
 			if (qualityJob) {
 				log(`  * Quality job: state=${qualityJob.state}, result=${qualityJob.result ?? 'n/a'}`);
@@ -228,15 +280,12 @@ async function waitForArtifact(): Promise<NoticeArtifact | undefined> {
 
 			const artifact = allArtifacts.find(a => a.name === ARTIFACT_NAME);
 			if (artifact) {
-				// PRIMARY GATE: accept the instant ThirdPartyNotices.new.txt actually
-				// exists inside the container artifact. The artifact is populated in
-				// TWO phases by two Quality-stage steps (first generated.txt + meta,
-				// then seconds-to-minutes later the shipping .new.txt). The artifact
-				// NAME appears after phase 1, so checking the NAME alone races. But a
-				// container file appears in the listing only after its upload finishes,
-				// so the listing is an exact, race-free readiness signal -- and it lets
-				// us accept as soon as .new.txt lands rather than waiting for the whole
-				// Quality job to finish (which observably wastes ~80s of margin).
+				// The notice_output container is populated in TWO phases by the
+				// Quality stage (first generated.txt + meta, then seconds-to-minutes
+				// later the shipping .new.txt). We accept ONLY once .new.txt has been
+				// downloaded, extracted, and validated non-empty -- the listing alone
+				// races against content-commit (build 450517 armhf), so on a listing
+				// hit we attempt a real download+extract and re-poll if it isn't ready.
 				const files = await listArtifactFiles(artifact).catch(() => undefined);
 				if (files === undefined) {
 					// Could not list (transient error or unexpected data shape). Do not
@@ -245,16 +294,29 @@ async function waitForArtifact(): Promise<NoticeArtifact | undefined> {
 				} else {
 					log(`  * notice_output files: ${files.map(f => path.basename(f)).join(', ') || '(empty)'}`);
 					if (files.some(f => path.basename(f) === SHIPPING_NOTICE_NAME)) {
-						log(`  * ${SHIPPING_NOTICE_NAME} present in artifact; accepting.`);
-						return artifact;
-					}
-					// BACKSTOP: file confirmed absent AND the Quality job has finished
-					// => it is never coming. Fall back instead of polling the full budget.
-					if (qualityJob && qualityJob.state === 'completed') {
-						log(`  * Quality job completed but ${SHIPPING_NOTICE_NAME} absent from artifact; giving up.`);
+						log(`  * ${SHIPPING_NOTICE_NAME} listed; verifying extracted content...`);
+						const extracted = await tryExtractNotice(artifact, tmpDir).catch(err => {
+							// A download/extract failure here (e.g. partial zip mid-upload)
+							// is NOT terminal: keep polling within budget.
+							log(`  * download/extract attempt failed (${err}); will recheck next poll.`);
+							return undefined;
+						});
+						if (extracted) {
+							log(`  * ${SHIPPING_NOTICE_NAME} extracted and validated (${extracted.size} bytes); accepting.`);
+							return extracted;
+						}
+						// Listed but not yet downloadable/valid: fall through to wait + re-poll.
+						// Deliberately NO early give-up here even if the Quality job reports
+						// "completed" -- the artifact upload is async (continueOnError) and may
+						// still be finalizing, so we let the budget bound the wait.
+					} else if (qualityJob && qualityJob.state === 'completed') {
+						// BACKSTOP: .new.txt was never even listed AND Quality finished
+						// => it is never coming. Fall back instead of polling the full budget.
+						log(`  * Quality job completed but ${SHIPPING_NOTICE_NAME} never appeared in artifact; giving up.`);
 						return undefined;
+					} else {
+						log(`  * ${SHIPPING_NOTICE_NAME} not in artifact yet; waiting...`);
 					}
-					log(`  * ${SHIPPING_NOTICE_NAME} not in artifact yet; waiting...`);
 				}
 			} else if (qualityJob && qualityJob.state === 'completed') {
 				log('  * Quality job completed but no notice_output artifact; giving up.');
@@ -269,6 +331,7 @@ async function waitForArtifact(): Promise<NoticeArtifact | undefined> {
 		await new Promise(c => setTimeout(c, POLL_INTERVAL_MS));
 	}
 
+	log(`Poll budget exhausted (${POLL_ATTEMPTS} attempts) without a valid ${SHIPPING_NOTICE_NAME}.`);
 	return undefined;
 }
 
@@ -282,43 +345,20 @@ async function main(): Promise<void> {
 		return;
 	}
 
-	const artifact = await waitForArtifact();
-	if (!artifact) {
-		log(`RESULT=fallback ${ARTIFACT_NAME} artifact unavailable within budget; keeping legacy notice.`);
-		return;
-	}
-
 	const tmpDir = path.resolve('.build/tmp-notice');
-	fs.rmSync(tmpDir, { recursive: true, force: true });
-	fs.mkdirSync(tmpDir, { recursive: true });
-	const artifactZipPath = path.join(tmpDir, 'notice_output.zip');
-
-	log('Downloading notice_output artifact...');
-	await retry(() => downloadArtifact(artifact, artifactZipPath));
-
-	log('Extracting notice_output artifact...');
-	const files = await unzip(artifactZipPath, tmpDir);
-	const shipping = files.find(f => path.basename(f) === SHIPPING_NOTICE_NAME);
-
-	if (!shipping) {
-		log(`RESULT=fallback artifact present but ${SHIPPING_NOTICE_NAME} missing; keeping legacy notice.`);
-		fs.rmSync(tmpDir, { recursive: true, force: true });
-		return;
-	}
-
-	const size = fs.statSync(shipping).size;
-	// Guard: a tiny file means the merge produced nothing usable. Keep legacy.
-	if (size <= 1024) {
-		log(`RESULT=fallback ${SHIPPING_NOTICE_NAME} too small (${size} bytes); keeping legacy notice.`);
+	const notice = await waitForNotice(tmpDir);
+	if (!notice) {
+		// Only reached on GENUINE exhaustion or a confirmed never-produced artifact
+		// -- never on a transient mid-upload miss (those re-poll inside waitForNotice).
+		log(`RESULT=fallback ${SHIPPING_NOTICE_NAME} unavailable within budget; keeping legacy notice.`);
 		fs.rmSync(tmpDir, { recursive: true, force: true });
 		return;
 	}
 
 	// Log provenance for legal traceability: which build/commit produced this NOTICE.
-	const metaFile = files.find(f => path.basename(f) === 'notice-meta.txt');
-	if (metaFile) {
+	if (notice.metaFile) {
 		log('NOTICE provenance:');
-		for (const line of fs.readFileSync(metaFile, 'utf8').split(/\r?\n/)) {
+		for (const line of fs.readFileSync(notice.metaFile, 'utf8').split(/\r?\n/)) {
 			if (line.trim()) {
 				log(`    ${line}`);
 			}
@@ -326,8 +366,8 @@ async function main(): Promise<void> {
 	}
 
 	const legacySize = fs.existsSync(TARGET_NOTICE) ? fs.statSync(TARGET_NOTICE).size : 0;
-	fs.copyFileSync(shipping, TARGET_NOTICE);
-	log(`RESULT=fresh overwrote ${TARGET_NOTICE} with CG NOTICE (${size} bytes; legacy was ${legacySize} bytes).`);
+	fs.copyFileSync(notice.shippingPath, TARGET_NOTICE);
+	log(`RESULT=fresh overwrote ${TARGET_NOTICE} with CG NOTICE (${notice.size} bytes; legacy was ${legacySize} bytes).`);
 
 	fs.rmSync(tmpDir, { recursive: true, force: true });
 }

--- a/build/azure-pipelines/common/downloadNotice.ts
+++ b/build/azure-pipelines/common/downloadNotice.ts
@@ -194,6 +194,16 @@ async function unzip(zipPath: string, outputPath: string): Promise<string[]> {
 						}
 
 						const filePath = path.join(outputPath, entry.fileName);
+
+						// Zip-slip guard: ensure the resolved entry path stays within
+						// outputPath. A crafted zip could use ../ segments to escape and
+						// overwrite repo files used later in the build.
+						const resolvedOutput = path.resolve(outputPath);
+						const resolvedTarget = path.resolve(filePath);
+						if (resolvedTarget !== resolvedOutput && !resolvedTarget.startsWith(resolvedOutput + path.sep)) {
+							return reject(new Error(`Zip entry escapes output directory (zip-slip): ${entry.fileName}`));
+						}
+
 						fs.mkdirSync(path.dirname(filePath), { recursive: true });
 
 						const ostream = fs.createWriteStream(filePath);
@@ -201,6 +211,7 @@ async function unzip(zipPath: string, outputPath: string): Promise<string[]> {
 							result.push(filePath);
 							zipfile!.readEntry();
 						});
+						ostream.on('error', err => reject(err));
 						istream?.on('error', err => reject(err));
 						istream!.pipe(ostream);
 					});

--- a/build/azure-pipelines/common/downloadNotice.ts
+++ b/build/azure-pipelines/common/downloadNotice.ts
@@ -44,10 +44,15 @@ const QUALITY_JOB_NAMES = ['Quality Checks', 'Quality'];
 const SHIPPING_NOTICE_NAME = 'ThirdPartyNotices.new.txt';
 const TARGET_NOTICE = path.resolve('ThirdPartyNotices.txt');
 
-// Short poll budget: 15 attempts x 30s = 7.5 minutes. Deliberately far below the
+// Poll budget: 20 attempts x 30s = 10 minutes. Deliberately far below the
 // copilot 30min so a never-produced artifact degrades to fallback quickly, but
-// long enough to outlast the parallel Quality stage (CG + scan + merge).
-const POLL_ATTEMPTS = 15;
+// with generous margin over the parallel Quality stage (CG + scan + merge).
+// Observed: the Quality job completed and the poller accepted at ~attempt 10
+// (~4.5min) in builds 450470/450477, so 10min is ~2x the observed need.
+// NB: this is the OUTER artifact-availability poll. It is unrelated to the
+// inner retry() wrapper in retry.ts, which independently retries each AZDO API
+// call up to 10 times for transient network errors and emits no attempt log.
+const POLL_ATTEMPTS = 20;
 const POLL_INTERVAL_MS = 30_000;
 
 function log(message: string): void {

--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -172,6 +172,7 @@ steps:
   - script: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
     displayName: Apply CG NOTICE (E-lite)
 
   - script: |

--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -124,6 +124,7 @@ steps:
   - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
     displayName: Pull CG NOTICE (background)
 
   - template: ../../common/install-builtin-extensions.yml@self

--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -119,6 +119,13 @@ steps:
   - script: node build/azure-pipelines/distro/mixin-quality.ts
     displayName: Mixin distro quality
 
+  # E-lite: start pulling the CG-generated NOTICE from the parallel Quality stage
+  # in the background (overwrites repo-root ThirdPartyNotices.txt before packaging).
+  - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    displayName: Pull CG NOTICE (background)
+
   - template: ../../common/install-builtin-extensions.yml@self
 
   - template: ../../common/agent-sdk-produce.yml@self
@@ -157,6 +164,14 @@ steps:
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     displayName: Download Copilot VSIX
+
+  # E-lite: block on the CG NOTICE download and overwrite ThirdPartyNotices.txt
+  # before gulp packages it (and before any later signing/notarization).
+  # Non-fatal: falls back to legacy on any problem.
+  - script: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    displayName: Apply CG NOTICE (E-lite)
 
   - script: |
       set -e

--- a/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
@@ -170,6 +170,13 @@ steps:
   - script: node build/azure-pipelines/distro/mixin-quality.ts
     displayName: Mixin distro quality
 
+  # E-lite: start pulling the CG-generated NOTICE from the parallel Quality stage
+  # in the background (overwrites repo-root ThirdPartyNotices.txt before packaging).
+  - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    displayName: Pull CG NOTICE (background)
+
   - template: ../../common/install-builtin-extensions.yml@self
 
   - ${{ if ne(parameters.VSCODE_ARCH, 'armhf') }}:
@@ -210,6 +217,13 @@ steps:
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     displayName: Download Copilot VSIX
+
+  # E-lite: block on the CG NOTICE download and overwrite ThirdPartyNotices.txt
+  # right before gulp packages it. Non-fatal: falls back to legacy on any problem.
+  - script: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    displayName: Apply CG NOTICE (E-lite)
 
   - script: |
       set -e

--- a/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
@@ -224,6 +224,7 @@ steps:
   - script: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
     displayName: Apply CG NOTICE (E-lite)
 
   - script: |

--- a/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
@@ -175,6 +175,7 @@ steps:
   - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
     displayName: Pull CG NOTICE (background)
 
   - template: ../../common/install-builtin-extensions.yml@self

--- a/build/azure-pipelines/product-build-template.yml
+++ b/build/azure-pipelines/product-build-template.yml
@@ -82,6 +82,10 @@ parameters:
     displayName: "Skip tests"
     type: boolean
     default: false
+  - name: VSCODE_USE_LEGACY_OSS_NOTICE
+    displayName: "Use legacy OSS Tool"
+    type: boolean
+    default: false
   - name: VSCODE_RUN_APISCAN
     type: boolean
     default: true

--- a/build/azure-pipelines/product-build-template.yml
+++ b/build/azure-pipelines/product-build-template.yml
@@ -83,7 +83,7 @@ parameters:
     type: boolean
     default: false
   - name: VSCODE_USE_LEGACY_OSS_NOTICE
-    displayName: "Use legacy OSS Tool"
+    displayName: "Use legacy OSS Notice"
     type: boolean
     default: false
   - name: VSCODE_RUN_APISCAN

--- a/build/azure-pipelines/product-build-variables.yml
+++ b/build/azure-pipelines/product-build-variables.yml
@@ -53,6 +53,9 @@ parameters:
   - name: VSCODE_STEP_ON_IT
     type: boolean
     default: false
+  - name: VSCODE_USE_LEGACY_OSS_NOTICE
+    type: boolean
+    default: false
 
 variables:
   - name: VSCODE_PRIVATE_BUILD
@@ -85,6 +88,16 @@ variables:
     value: $[counter(variables['VSCODE_PUBLISH_COUNTER_PREFIX'], 1)]
   - name: VSCODE_STEP_ON_IT
     value: ${{ eq(parameters.VSCODE_STEP_ON_IT, true) }}
+  # Derived as an explicit lowercase string literal so downloadNotice.ts's
+  # case-sensitive JS check (process.env['VSCODE_OVERWRITE_TPN'] === 'false')
+  # works. ${{ eq(...) }} would emit 'True'/'False' (capitalized) and silently
+  # fail that comparison. Checkbox on => keep legacy notice ('false' = no
+  # overwrite); off => apply CG notice ('true').
+  - name: VSCODE_OVERWRITE_TPN
+    ${{ if eq(parameters.VSCODE_USE_LEGACY_OSS_NOTICE, true) }}:
+      value: 'false'
+    ${{ else }}:
+      value: 'true'
   - name: VSCODE_BUILD_MACOS_UNIVERSAL
     value: ${{ and(eq(parameters.VSCODE_BUILD_MACOS, true), eq(parameters.VSCODE_BUILD_MACOS_ARM64, true), eq(parameters.VSCODE_BUILD_MACOS_UNIVERSAL, true)) }}
   - name: VSCODE_STAGING_BLOB_STORAGE_ACCOUNT_NAME

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -111,6 +111,10 @@ parameters:
     displayName: "Skip tests"
     type: boolean
     default: false
+  - name: VSCODE_USE_LEGACY_OSS_NOTICE
+    displayName: "Use legacy OSS Tool"
+    type: boolean
+    default: false
 
 variables:
   - name: VSCODE_PRIVATE_BUILD
@@ -143,6 +147,16 @@ variables:
     value: $[counter(variables['VSCODE_PUBLISH_COUNTER_PREFIX'], 1)]
   - name: VSCODE_STEP_ON_IT
     value: ${{ eq(parameters.VSCODE_STEP_ON_IT, true) }}
+  # Derived as an explicit lowercase string literal so downloadNotice.ts's
+  # case-sensitive JS check (process.env['VSCODE_OVERWRITE_TPN'] === 'false')
+  # works. ${{ eq(...) }} would emit 'True'/'False' (capitalized) and silently
+  # fail that comparison. Checkbox on => keep legacy notice ('false' = no
+  # overwrite); off => apply CG notice ('true').
+  - name: VSCODE_OVERWRITE_TPN
+    ${{ if eq(parameters.VSCODE_USE_LEGACY_OSS_NOTICE, true) }}:
+      value: 'false'
+    ${{ else }}:
+      value: 'true'
   - name: VSCODE_BUILD_MACOS_UNIVERSAL
     value: ${{ and(eq(parameters.VSCODE_BUILD_MACOS, true), eq(parameters.VSCODE_BUILD_MACOS_ARM64, true), eq(parameters.VSCODE_BUILD_MACOS_UNIVERSAL, true)) }}
   - name: VSCODE_STAGING_BLOB_STORAGE_ACCOUNT_NAME

--- a/build/azure-pipelines/product-quality-checks.yml
+++ b/build/azure-pipelines/product-quality-checks.yml
@@ -190,43 +190,43 @@ jobs:
         displayName: "Cache: detect whether CG NOTICE needs fallback"
         continueOnError: true
 
-      - task: DownloadPipelineArtifact@2
+      - task: DownloadBuildArtifacts@1
         displayName: "Cache: download last good NOTICE (same branch)"
         inputs:
           buildType: specific
           project: $(System.TeamProject)
-          definition: $(System.DefinitionId)
+          pipeline: $(System.DefinitionId)
           buildVersionToDownload: latestFromBranch
           branchName: $(Build.SourceBranch)
           allowPartiallySucceededBuilds: true
           artifactName: notice_output
           itemPattern: "**/{ThirdPartyNotices.generated.txt,notice-meta.txt}"
-          targetPath: $(Pipeline.Workspace)/cached-notice-branch
+          downloadPath: $(Pipeline.Workspace)/cached-notice-branch
         continueOnError: true
         condition: and(succeeded(), ne(variables.CG_NOTICE_OK, 'true'))
 
-      - task: DownloadPipelineArtifact@2
+      - task: DownloadBuildArtifacts@1
         displayName: "Cache: download last good NOTICE (main fallback)"
         inputs:
           buildType: specific
           project: $(System.TeamProject)
-          definition: $(System.DefinitionId)
+          pipeline: $(System.DefinitionId)
           buildVersionToDownload: latestFromBranch
           branchName: refs/heads/main
           allowPartiallySucceededBuilds: true
           artifactName: notice_output
           itemPattern: "**/{ThirdPartyNotices.generated.txt,notice-meta.txt}"
-          targetPath: $(Pipeline.Workspace)/cached-notice-main
+          downloadPath: $(Pipeline.Workspace)/cached-notice-main
         continueOnError: true
         condition: and(succeeded(), ne(variables.CG_NOTICE_OK, 'true'), ne(variables['Build.SourceBranch'], 'refs/heads/main'))
 
       - script: |
           set -u
           GEN="$(Build.SourcesDirectory)/ThirdPartyNotices.generated.txt"
-          BRANCH_CACHE="$(Pipeline.Workspace)/cached-notice-branch/ThirdPartyNotices.generated.txt"
-          BRANCH_META="$(Pipeline.Workspace)/cached-notice-branch/notice-meta.txt"
-          MAIN_CACHE="$(Pipeline.Workspace)/cached-notice-main/ThirdPartyNotices.generated.txt"
-          MAIN_META="$(Pipeline.Workspace)/cached-notice-main/notice-meta.txt"
+          BRANCH_CACHE="$(Pipeline.Workspace)/cached-notice-branch/notice_output/ThirdPartyNotices.generated.txt"
+          BRANCH_META="$(Pipeline.Workspace)/cached-notice-branch/notice_output/notice-meta.txt"
+          MAIN_CACHE="$(Pipeline.Workspace)/cached-notice-main/notice_output/ThirdPartyNotices.generated.txt"
+          MAIN_META="$(Pipeline.Workspace)/cached-notice-main/notice_output/notice-meta.txt"
 
           # Emit what a cached NOTICE was built from, if we have the sidecar.
           # The sidecar is written by the upload step on every successful run.
@@ -278,33 +278,27 @@ jobs:
           echo "=== CG NOTICE artifact ==="
           if [ -f "$(Build.SourcesDirectory)/ThirdPartyNotices.generated.txt" ]; then
             SIZE=$(wc -c < "$(Build.SourcesDirectory)/ThirdPartyNotices.generated.txt")
-            echo "Generated file size: $SIZE bytes (NOTICE_FROM_CACHE=$NOTICE_FROM_CACHE)"
+            echo "Generated file size: $SIZE bytes"
             cp "$(Build.SourcesDirectory)/ThirdPartyNotices.generated.txt" "$(Build.ArtifactStagingDirectory)/ThirdPartyNotices.generated.txt"
             echo "##vso[artifact.upload containerfolder=notice_output;artifactname=notice_output]$(Build.ArtifactStagingDirectory)/ThirdPartyNotices.generated.txt"
 
             # Write a sidecar so future runs (and humans) know what this NOTICE
             # was built from. Consumed by the "Cache: apply NOTICE fallback" step
             # of subsequent builds when they fall back to this artifact.
-            # Only meaningful when this run generated the NOTICE fresh; if we
-            # fell back to a cache, skip writing the sidecar so we don't
-            # mis-attribute someone else's NOTICE to this commit.
-            if [ "${NOTICE_FROM_CACHE:-false}" = "false" ]; then
-              {
-                echo "built_at:          $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-                echo "source_branch:     $(Build.SourceBranch)"
-                echo "source_commit:     $(Build.SourceVersion)"
-                echo "build_id:          $(Build.BuildId)"
-                echo "build_number:      $(Build.BuildNumber)"
-                echo "size_bytes:        $SIZE"
-              } > "$(Build.ArtifactStagingDirectory)/notice-meta.txt"
-              echo "##vso[artifact.upload containerfolder=notice_output;artifactname=notice_output]$(Build.ArtifactStagingDirectory)/notice-meta.txt"
-            else
-              echo "Skipping notice-meta.txt sidecar: NOTICE_FROM_CACHE=$NOTICE_FROM_CACHE (don't re-publish someone else's metadata as our own)"
-            fi
+            {
+              echo "built_at:          $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+              echo "source_branch:     $(Build.SourceBranch)"
+              echo "source_commit:     $(Build.SourceVersion)"
+              echo "build_id:          $(Build.BuildId)"
+              echo "build_number:      $(Build.BuildNumber)"
+              echo "size_bytes:        $SIZE"
+            } > "$(Build.ArtifactStagingDirectory)/notice-meta.txt"
+            echo "##vso[artifact.upload containerfolder=notice_output;artifactname=notice_output]$(Build.ArtifactStagingDirectory)/notice-meta.txt"
           else
-            echo "ERROR: ThirdPartyNotices.generated.txt not found (CG failed AND no cache available)"
+            echo "ERROR: ThirdPartyNotices.generated.txt not found — this step should not run without CG_NOTICE_OK=true"
           fi
         displayName: "Upload CG NOTICE artifact"
+        condition: and(succeeded(), eq(variables.CG_NOTICE_OK, 'true'))
         continueOnError: true
 
       - script: |

--- a/build/azure-pipelines/product-quality-checks.yml
+++ b/build/azure-pipelines/product-quality-checks.yml
@@ -195,7 +195,7 @@ jobs:
         inputs:
           buildType: specific
           project: $(System.TeamProject)
-          pipeline: $(System.DefinitionId)
+          definition: $(System.DefinitionId)
           buildVersionToDownload: latestFromBranch
           branchName: $(Build.SourceBranch)
           allowPartiallySucceededBuilds: true
@@ -210,7 +210,7 @@ jobs:
         inputs:
           buildType: specific
           project: $(System.TeamProject)
-          pipeline: $(System.DefinitionId)
+          definition: $(System.DefinitionId)
           buildVersionToDownload: latestFromBranch
           branchName: refs/heads/main
           allowPartiallySucceededBuilds: true

--- a/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
+++ b/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
@@ -116,6 +116,7 @@ steps:
   - pwsh: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
     displayName: Pull CG NOTICE (background)
 
   - template: ../../common/install-builtin-extensions.yml@self

--- a/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
+++ b/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
@@ -111,6 +111,13 @@ steps:
   - powershell: node build/azure-pipelines/distro/mixin-quality.ts
     displayName: Mixin distro quality
 
+  # E-lite: start pulling the CG-generated NOTICE from the parallel Quality stage
+  # in the background (overwrites repo-root ThirdPartyNotices.txt before packaging).
+  - pwsh: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    displayName: Pull CG NOTICE (background)
+
   - template: ../../common/install-builtin-extensions.yml@self
 
   - template: ../../common/agent-sdk-produce.yml@self
@@ -156,6 +163,13 @@ steps:
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     displayName: Download Copilot VSIX
+
+  # E-lite: block on the CG NOTICE download and overwrite ThirdPartyNotices.txt
+  # right before gulp packages it. Non-fatal: falls back to legacy on any problem.
+  - pwsh: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    displayName: Apply CG NOTICE (E-lite)
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1

--- a/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
+++ b/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
@@ -170,6 +170,7 @@ steps:
   - pwsh: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
     displayName: Apply CG NOTICE (E-lite)
 
   - powershell: |


### PR DESCRIPTION
🤖 AI Assisted PR

## What

Cuts over VS Code's `ThirdPartyNotices.txt` from the legacy custom OSS-license tool to the Microsoft Component Governance (CG) generated notice. During each desktop platform build, the CG-merged notice is applied over the repo-root `ThirdPartyNotices.txt` just before packaging, so shipped installers carry the CG notice.

## Why

The legacy notice is produced by a ~10-year-old custom tool that the release champion has to babysit every weekly release. Moving to CG + a thin gap-filling layer removes that recurring manual burden. CELA has approved the approach. Tracking issue: microsoft/vscode-engineering#2142.

## How

- Each desktop compile template (`product-build-{win32,linux,darwin}-compile.yml`) runs a background "Pull CG NOTICE" step then an "Apply CG NOTICE (E-lite)" step after `mixin-quality`, before the gulp package step.
- `build/azure-pipelines/common/downloadNotice.ts` polls the `notice_output` artifact for `ThirdPartyNotices.new.txt`, validates the extracted content, and overwrites the repo-root `ThirdPartyNotices.txt`. Non-fatal: a miss leaves the legacy notice in place rather than failing the build.
- `product-quality-checks.yml` gains a cache-fallback path: if CG generation fails, the last good notice is restored from build artifacts; the cache upload is guarded so only fresh CG output is ever cached.
- Gated behind `VSCODE_OVERWRITE_TPN`.

## Scope

Only the **7 desktop platforms** that bundle a notice are affected (win32 x64/arm64, linux x64/arm64/armhf, macOS x64/arm64). REH/server, web, and Alpine do not bundle a `ThirdPartyNotices.txt` and have no Apply step.

## Validation

- Published builds on this branch were pulled from the public `builds.code.visualstudio.com` channel; the embedded `ThirdPartyNotices.txt` was byte-for-byte identical (single SHA256) across all desktop platforms and matched the CG merged notice, not the legacy one.
- An accept-gate race was found and fixed during validation: the gate accepted the notice as soon as it appeared in the artifact listing, before its content finished uploading, which could let one architecture fall back to the legacy notice while others shipped CG (mixed notices in a single build). The gate now downloads, extracts, and validates the content before accepting, and re-polls on a mid-upload miss.

[Sample build](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=450682&view=results)