### PR TITLE
Add settings gear action to voice mode toolbar

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -29,6 +29,7 @@ import { KeybindingWeight } from '../../../../platform/keybinding/common/keybind
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/contributions.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
 
 import { AgentsVoiceStorageKeys } from '../common/agentsVoice.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -274,6 +275,33 @@ registerAction2(class extends Action2 {
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const voiceController = accessor.get(IVoiceSessionController);
 		voiceController.disconnect();
+	}
+});
+
+// --- Voice Mode Settings ---
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'agentsVoice.openSettings',
+			title: nls.localize2('agentsVoice.openSettings', "Voice Mode Settings"),
+			icon: Codicon.settingsGear,
+			menu: {
+				id: MenuId.ChatExecute,
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('config.agents.voice.enabled', true),
+					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
+					AGENTS_VOICE_CONNECTED.isEqualTo(true),
+					AGENTS_VOICE_INITIATED_HERE.isEqualTo(true),
+				),
+				group: 'navigation',
+				order: 10
+			},
+		});
+	}
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const commandService = accessor.get(ICommandService);
+		await commandService.executeCommand('workbench.action.openSettings', '@id:agents.voice');
 	}
 });
 

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -34,6 +34,7 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
 import { AgentsVoiceStorageKeys } from '../common/agentsVoice.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
+import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import {
 	VoiceEnabledClassification, VoiceEnabledEvent,
@@ -295,13 +296,14 @@ registerAction2(class extends Action2 {
 					AGENTS_VOICE_INITIATED_HERE.isEqualTo(true),
 				),
 				group: 'navigation',
-				order: 10
+				order: -9
 			},
 		});
 	}
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const quickInputService = accessor.get(IQuickInputService);
 		const commandService = accessor.get(ICommandService);
+		const preferencesService = accessor.get(IPreferencesService);
 
 		const items = [
 			{
@@ -323,7 +325,7 @@ registerAction2(class extends Action2 {
 			if (selection.id === 'selectMic') {
 				await commandService.executeCommand('agentsVoice.selectMicrophone');
 			} else if (selection.id === 'openSettings') {
-				await commandService.executeCommand('workbench.action.openSettings', '@id:agents.voice');
+				await preferencesService.openSettings({ jsonEditor: false, query: '@id:agents.voice' });
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -300,8 +300,32 @@ registerAction2(class extends Action2 {
 		});
 	}
 	async run(accessor: ServicesAccessor): Promise<void> {
+		const quickInputService = accessor.get(IQuickInputService);
 		const commandService = accessor.get(ICommandService);
-		await commandService.executeCommand('workbench.action.openSettings', '@id:agents.voice');
+
+		const items = [
+			{
+				label: nls.localize('voiceSettings.selectMic', "$(mic) Select Microphone"),
+				id: 'selectMic',
+			},
+			{
+				label: nls.localize('voiceSettings.openSettings', "$(settings-gear) Voice Mode Settings"),
+				id: 'openSettings',
+			},
+		];
+
+		const picked = await quickInputService.pick(items, {
+			placeHolder: nls.localize('voiceSettings.placeholder', "Voice Mode"),
+		});
+
+		if (picked) {
+			const selection = picked as typeof items[number];
+			if (selection.id === 'selectMic') {
+				await commandService.executeCommand('agentsVoice.selectMicrophone');
+			} else if (selection.id === 'openSettings') {
+				await commandService.executeCommand('workbench.action.openSettings', '@id:agents.voice');
+			}
+		}
 	}
 });
 


### PR DESCRIPTION
Adds a settings gear icon to the chat execute toolbar when voice mode is connected. Clicking it opens a quick pick with two options:

- **Select Microphone** — runs the `agentsVoice.selectMicrophone` command to change mic device
- **Voice Mode Settings** — opens the Settings UI filtered to all `agents.voice.*` settings

The action:
- Uses `Codicon.settingsGear` icon
- Shows only when voice is connected and in the initiated widget