### PR TITLE
Fix misleading Chat model picker and Sign In affordances in untrusted (Restricted Mode) workspaces

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/modelPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/modelPicker.ts
@@ -13,11 +13,13 @@ import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextke
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { IWorkspaceTrustManagementService } from '../../../../platform/workspace/common/workspaceTrust.js';
 import { IChatInputPickerOptions } from '../../../../workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.js';
 import { resolveConfiguredModel } from '../../../../workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.js';
 import { IModelPickerDelegate, ModelPickerActionItem } from '../../../../workbench/contrib/chat/browser/widget/input/modelPickerActionItem.js';
 import { ChatConfiguration } from '../../../../workbench/contrib/chat/common/constants.js';
 import { ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService } from '../../../../workbench/contrib/chat/common/languageModels.js';
+import { IChatEntitlementService } from '../../../../workbench/services/chat/common/chatEntitlementService.js';
 import { Menus } from '../../../browser/menus.js';
 import { IsPhoneLayoutContext, SessionUsesCombinedConfigPickerContext } from '../../../common/contextkeys.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
@@ -111,6 +113,8 @@ export class ModelPicker extends Disposable {
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@INewChatModelPickerService private readonly _newChatModelPickerService: INewChatModelPickerService,
+		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
+		@IChatEntitlementService private readonly _chatEntitlementService: IChatEntitlementService,
 	) {
 		super();
 
@@ -152,6 +156,25 @@ export class ModelPicker extends Disposable {
 
 		this._initModel();
 		this._register(this._languageModelsService.onDidChangeLanguageModels(() => this._initModel()));
+
+		// Re-evaluate when workspace trust changes (or finishes initializing): an
+		// untrusted workspace disables the model providers, and the shared widget
+		// then renders its Restricted Mode state. Visibility is recomputed so the
+		// picker stays visible to surface "Pick Model" + the Trust action instead
+		// of hiding as an empty picker.
+		this._register(this._workspaceTrustManagementService.onDidChangeTrust(() => this._initModel()));
+		this._workspaceTrustManagementService.workspaceTrustInitialized.then(() => {
+			if (!this._store.isDisposed) {
+				this._initModel();
+			}
+		});
+
+		// Re-evaluate when entitlement / sentiment / anonymous access change: when
+		// Chat needs sign-in the shared widget renders a Sign In state, so the
+		// picker stays visible to surface it (e.g. after the user signs out/in).
+		this._register(this._chatEntitlementService.onDidChangeEntitlement(() => this._initModel()));
+		this._register(this._chatEntitlementService.onDidChangeSentiment(() => this._initModel()));
+		this._register(this._chatEntitlementService.onDidChangeAnonymous(() => this._initModel()));
 
 		// When the active session changes, re-init (may switch provider or
 		// session type). _initModel() calls _delegate.setModel() which already
@@ -287,12 +310,17 @@ export class ModelPicker extends Disposable {
 
 	/**
 	 * Whether the model picker should be shown for the given session. Visible
-	 * when the session has models, or when its Auto model is unavailable (so the
-	 * widget can render the "No models available" empty state). Otherwise hidden,
-	 * matching the historical behavior for providers that offer no models.
+	 * when the session has models, when its Auto model is unavailable (so the
+	 * widget can render the "No models available" empty state), or when the
+	 * workspace is untrusted / Chat still needs sign-in (so the widget can render
+	 * its Restricted Mode or Sign In state). Otherwise hidden, matching the
+	 * historical behavior for providers that offer no models.
 	 */
 	private _shouldShowPicker(session: ISession | undefined): boolean {
 		if (getModelsForSession(session, this._sessionsProvidersService).length > 0) {
+			return true;
+		}
+		if (this._modelPicker.isRestrictedMode() || this._modelPicker.isSetupRequired()) {
 			return true;
 		}
 		return !getModelPickerOptionsForSession(session, this._sessionsProvidersService).showAutoModel;

--- a/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
@@ -42,6 +42,7 @@ import { ChatEntitlement, ChatEntitlementContext, ChatEntitlementContextKeys, Ch
 import { EnablementState, IWorkbenchExtensionEnablementService } from '../../../../services/extensionManagement/common/extensionManagement.js';
 import { ExtensionUrlHandlerOverrideRegistry, IExtensionUrlHandlerOverride } from '../../../../services/extensions/browser/extensionUrlHandler.js';
 import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
+import { CONTEXT_DEFAULT_ACCOUNT_STATE, DefaultAccountStatus } from '../../../../services/accounts/browser/defaultAccount.js';
 import { IHostService } from '../../../../services/host/browser/host.js';
 import { IWorkbenchLayoutService, Parts } from '../../../../services/layout/browser/layoutService.js';
 import { InEditorZenModeContext } from '../../../../common/contextkeys.js';
@@ -370,6 +371,7 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 						when: ContextKeyExpr.and(
 							ChatContextKeys.Setup.hidden.negate(),
 							ChatContextKeys.Setup.disabledInWorkspace.negate(),
+							CONTEXT_DEFAULT_ACCOUNT_STATE.notEqualsTo(DefaultAccountStatus.Available), // hide only when signed in (a default GitHub account is present); still shown while signed out or before the account state resolves, incl. untrusted workspaces — no auth prompt
 							ChatContextKeys.Setup.completed.negate(),
 							ChatContextKeys.Entitlement.signedOut
 						)
@@ -402,6 +404,7 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 						when: ContextKeyExpr.and(
 							IsWebContext.negate(),
 							ChatContextKeys.Entitlement.signedOut,
+							CONTEXT_DEFAULT_ACCOUNT_STATE.notEqualsTo(DefaultAccountStatus.Available), // hide only when signed in (a default GitHub account is present); still shown while signed out or before the account state resolves, incl. untrusted workspaces — no auth prompt
 							ChatEntitlementContextKeys.hasByokModels.negate(),
 							ChatContextKeys.Setup.hidden.negate(),
 							ChatContextKeys.Setup.disabledInWorkspace.negate(),

--- a/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupProviders.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupProviders.ts
@@ -24,7 +24,7 @@ import { IWorkbenchEnvironmentService } from '../../../../services/environment/c
 import { nullExtensionDescription } from '../../../../services/extensions/common/extensions.js';
 import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolResult, ToolDataSource, ToolProgress } from '../../common/tools/languageModelToolsService.js';
 import { IChatAgentImplementation, IChatAgentRequest, IChatAgentResult, IChatAgentService } from '../../common/participants/chatAgents.js';
-import { ChatEntitlement, ChatEntitlementContext, IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
+import { ChatEntitlementContext, chatRequiresSetup, IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
 import { ChatModel, ChatRequestModel, IChatRequestModel, IChatRequestVariableData } from '../../common/model/chatModel.js';
 import { ChatMode } from '../../common/chatModes.js';
 import { ChatRequestAgentPart, ChatRequestToolPart } from '../../common/requestParser/chatParserTypes.js';
@@ -256,18 +256,14 @@ export class SetupAgent extends Disposable implements IChatAgentImplementation {
 	}
 
 	private async doInvoke(request: IChatAgentRequest, progress: (part: IChatProgress) => void, chatService: IChatService, languageModelsService: ILanguageModelsService, chatWidgetService: IChatWidgetService, chatAgentService: IChatAgentService, languageModelToolsService: ILanguageModelToolsService, defaultAccountService: IDefaultAccountService): Promise<IChatAgentResult> {
-		const hasByokModels = this.chatEntitlementService.hasByokModels;
-		if (
-			(!this.context.state.completed && !hasByokModels) ||				// Setup not completed (unless BYOK models are available)
-			this.context.state.disabled ||										// Extension disabled: run setup to enable
-			this.context.state.untrusted ||										// Workspace untrusted: run setup to ask for trust
-			this.context.state.entitlement === ChatEntitlement.Available ||		// Entitlement available: run setup to sign up
-			(
-				this.context.state.entitlement === ChatEntitlement.Unknown &&	// Entitlement unknown: run setup to sign in / sign up
-				!this.chatEntitlementService.anonymous &&						// unless anonymous access is enabled
-				!hasByokModels													// unless BYOK models are available
-			)
-		) {
+		if (chatRequiresSetup({
+			completed: !!this.context.state.completed,
+			disabled: !!this.context.state.disabled,
+			untrusted: !!this.context.state.untrusted,
+			entitlement: this.context.state.entitlement,
+			anonymous: this.chatEntitlementService.anonymous,
+			hasByokModels: this.chatEntitlementService.hasByokModels,
+		})) {
 			return this.doInvokeWithSetup(request, progress, chatService, languageModelsService, chatWidgetService, chatAgentService, languageModelToolsService, defaultAccountService);
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupRunner.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupRunner.ts
@@ -24,7 +24,7 @@ import { ILayoutService } from '../../../../../platform/layout/browser/layoutSer
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import product from '../../../../../platform/product/common/product.js';
 import { ITelemetryService, TelemetryLevel } from '../../../../../platform/telemetry/common/telemetry.js';
-import { IWorkspaceTrustRequestService } from '../../../../../platform/workspace/common/workspaceTrust.js';
+import { IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from '../../../../../platform/workspace/common/workspaceTrust.js';
 import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
 import { ChatEntitlement, ChatEntitlementContext, ChatEntitlementService, IChatEntitlementService, isProUser } from '../../../../services/chat/common/chatEntitlementService.js';
 import { IChatWidgetService } from '../chat.js';
@@ -32,8 +32,12 @@ import { ChatSetupController } from './chatSetupController.js';
 import { IChatSetupResult, ChatSetupAnonymous, InstallChatEvent, InstallChatClassification, ChatSetupStrategy, ChatSetupResultValue } from './chatSetup.js';
 import { GitHubPaths, IDefaultAccountService } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IHostService } from '../../../../services/host/browser/host.js';
+import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
+import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
+import { raceTimeout } from '../../../../../base/common/async.js';
 
 const defaultChat = {
+	chatExtensionId: product.defaultChatAgent?.chatExtensionId ?? '',
 	publicCodeMatchesUrl: product.defaultChatAgent?.publicCodeMatchesUrl ?? '',
 	provider: product.defaultChatAgent?.provider ?? { default: { id: '', name: '' }, enterprise: { id: '', name: '' }, apple: { id: '', name: '' }, google: { id: '', name: '' } },
 	chatRefreshTokenCommand: product.defaultChatAgent?.chatRefreshTokenCommand ?? '',
@@ -47,9 +51,7 @@ export class ChatSetup {
 	static getInstance(instantiationService: IInstantiationService, context: ChatEntitlementContext, controller: Lazy<ChatSetupController>): ChatSetup {
 		let instance = ChatSetup.instance;
 		if (!instance) {
-			instance = ChatSetup.instance = instantiationService.invokeFunction(accessor => {
-				return new ChatSetup(context, controller, accessor.get(ITelemetryService), accessor.get(IWorkbenchLayoutService), accessor.get(IKeybindingService), accessor.get(IChatEntitlementService) as ChatEntitlementService, accessor.get(ILogService), accessor.get(IChatWidgetService), accessor.get(IWorkspaceTrustRequestService), accessor.get(IMarkdownRendererService), accessor.get(IDefaultAccountService), accessor.get(IHostService));
-			});
+			instance = ChatSetup.instance = instantiationService.createInstance(ChatSetup, context, controller);
 		}
 
 		return instance;
@@ -59,7 +61,7 @@ export class ChatSetup {
 
 	private skipDialogOnce = false;
 
-	private constructor(
+	constructor(
 		private readonly context: ChatEntitlementContext,
 		private readonly controller: Lazy<ChatSetupController>,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
@@ -72,6 +74,8 @@ export class ChatSetup {
 		@IMarkdownRendererService private readonly markdownRendererService: IMarkdownRendererService,
 		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
 		@IHostService private readonly hostService: IHostService,
+		@IExtensionService private readonly extensionService: IExtensionService,
+		@IWorkspaceTrustManagementService private readonly workspaceTrustManagementService: IWorkspaceTrustManagementService,
 	) { }
 
 	skipDialog(): void {
@@ -98,6 +102,7 @@ export class ChatSetup {
 		const dialogSkipped = this.skipDialogOnce;
 		this.skipDialogOnce = false;
 
+		const wasTrusted = this.workspaceTrustManagementService.isWorkspaceTrusted();
 		const trusted = await this.workspaceTrustRequestService.requestWorkspaceTrust({
 			message: localize('chatWorkspaceTrust', "AI features are currently only supported in trusted workspaces.")
 		});
@@ -106,6 +111,15 @@ export class ChatSetup {
 			this.telemetryService.publicLog2<InstallChatEvent, InstallChatClassification>('commandCenter.chatInstall', { installResult: 'failedNotTrusted', installDuration: 0, signUpErrorCode: undefined, provider: undefined });
 
 			return { dialogSkipped, success: undefined /* canceled */ };
+		}
+
+		if (!wasTrusted) {
+			// Trust was just granted: the chat extension is (re)activating, and the
+			// entitlement only resolves once it is up. Wait for activation so the
+			// dialog decision below isn't made from a stale "signed out" entitlement
+			// (which would briefly show the sign-in dialog to an already-signed-in
+			// user). Bounded, so a genuinely signed-out / slow case still proceeds.
+			await this.whenChatExtensionActivated();
 		}
 
 		let setupStrategy: ChatSetupStrategy;
@@ -166,6 +180,46 @@ export class ChatSetup {
 		}
 
 		return { success, dialogSkipped };
+	}
+
+	/**
+	 * Whether the default chat extension has finished activating. `activationTimes`
+	 * is only set once activation completes, so `undefined` means "not yet active".
+	 */
+	private isChatExtensionActivated(): boolean {
+		const status = this.extensionService.getExtensionsStatus();
+		for (const id of Object.keys(status)) {
+			if (ExtensionIdentifier.equals(id, defaultChat.chatExtensionId)) {
+				return status[id].activationTimes !== undefined;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Resolves once the default chat extension has finished activating (bounded by
+	 * a timeout). Detection relies only on the extension lifecycle, so it never
+	 * touches the user's authentication session.
+	 */
+	private async whenChatExtensionActivated(timeoutMs = 10000): Promise<void> {
+		if (!defaultChat.chatExtensionId || this.isChatExtensionActivated()) {
+			return;
+		}
+
+		const store = new DisposableStore();
+		try {
+			await raceTimeout(new Promise<void>(resolve => {
+				const check = () => {
+					if (this.isChatExtensionActivated()) {
+						resolve();
+					}
+				};
+				store.add(this.extensionService.onDidChangeExtensionsStatus(check));
+				this.extensionService.whenInstalledExtensionsRegistered().then(check);
+			}), timeoutMs);
+		} finally {
+			store.dispose();
+		}
 	}
 
 	private async showDialog(options?: { forceSignInDialog?: boolean; forceAnonymous?: ChatSetupAnonymous; dialogIcon?: ThemeIcon; dialogTitle?: string; disableCloseButton?: boolean; onSignInStarted?: () => void }): Promise<ChatSetupStrategy> {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -16,7 +16,8 @@ import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { KeyCode } from '../../../../../../base/common/keyCodes.js';
-import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
+import { disposableTimeout } from '../../../../../../base/common/async.js';
 import { autorun, IObservable } from '../../../../../../base/common/observable.js';
 import { formatTokenCount } from '../../../../../../base/common/numbers.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
@@ -32,12 +33,15 @@ import { ITelemetryService } from '../../../../../../platform/telemetry/common/t
 import { TelemetryTrustedValue } from '../../../../../../platform/telemetry/common/telemetryUtils.js';
 import { MANAGE_CHAT_COMMAND_ID } from '../../../common/constants.js';
 import { IModelControlEntry, ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService, IModelsControlManifest } from '../../../common/languageModels.js';
-import { ChatEntitlement, IChatEntitlementService, isProUser } from '../../../../../services/chat/common/chatEntitlementService.js';
+import { ChatEntitlement, chatRequiresSetup, IChatEntitlementService, isProUser } from '../../../../../services/chat/common/chatEntitlementService.js';
 import * as semver from '../../../../../../base/common/semver/semver.js';
 import { IModelConfigurationAccess, IModelPickerDelegate } from './modelPickerActionItem.js';
+import { getModelPickerUnavailableReason, ModelPickerUnavailableReason } from './chatModelSelectionLogic.js';
+import { CHAT_SETUP_ACTION_ID } from '../../actions/chatActions.js';
 import { IUriIdentityService } from '../../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { GitHubPaths, IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IUpdateService, StateType } from '../../../../../../platform/update/common/update.js';
+import { IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
 
 function isVersionAtLeast(current: string, required: string): boolean {
 	const currentSemver = semver.coerce(current);
@@ -74,6 +78,23 @@ export function getControlModelsForEntitlement(manifest: IModelsControlManifest,
 const ModelPickerSection = {
 	Other: 'other',
 } as const;
+
+/**
+ * Id of the synthetic "Trust Workspace..." entry shown in Restricted Mode. It is
+ * a command (not a selectable model), so the accessibility provider gives it a
+ * plain `menuitem` role instead of `menuitemradio`.
+ */
+const RESTRICTED_MODE_TRUST_ACTION_ID = 'restrictedModeTrust';
+
+/**
+ * Id of the synthetic "Sign in to use Copilot..." entry shown when Chat still
+ * requires sign-in / setup. Like the Trust entry it is a command, so it gets a
+ * plain `menuitem` role.
+ */
+const SETUP_REQUIRED_SIGN_IN_ACTION_ID = 'setupRequiredSignIn';
+
+/** Synthetic command entries (Trust / Sign in) that are not selectable models. */
+const PICKER_COMMAND_ACTION_IDS: ReadonlySet<string> = new Set([RESTRICTED_MODE_TRUST_ACTION_ID, SETUP_REQUIRED_SIGN_IN_ACTION_ID]);
 
 /**
  * Returns a human-readable display name for a model vendor.
@@ -450,6 +471,13 @@ function createManageModelsAction(commandService: ICommandService): IActionWidge
  *      Compatible" group and an "AWS Bedrock" group both registered to
  *      the `customoai` vendor) renders as distinct sections.
  * 4. Optional "Manage Models..." action shown in Other Models after a separator
+ *
+ * When `restrictedMode` is set (untrusted workspace), an explanatory "Models
+ * Unavailable in Restricted Mode" header and a "Trust Workspace..." action
+ * (invoking `onRequestTrust`) replace all of the above. Likewise, when
+ * `setupRequired` is set (trusted, but Chat still needs sign-in / setup), a
+ * "Sign in to use Copilot" header and a Sign In action (invoking
+ * `onRequestSetup`) replace all of the above. `restrictedMode` takes precedence.
  */
 export function buildModelPickerItems(
 	models: ILanguageModelChatMetadataAndIdentifier[],
@@ -473,8 +501,68 @@ export function buildModelPickerItems(
 	isUBB?: boolean,
 	showAutoModel: boolean = false,
 	onConfigure?: (model: ILanguageModelChatMetadataAndIdentifier, group: string) => void,
+	restrictedMode: boolean = false,
+	onRequestTrust?: () => void,
+	setupRequired: boolean = false,
+	onRequestSetup?: () => void,
 ): IActionListItem<IActionWidgetDropdownAction>[] {
 	const items: IActionListItem<IActionWidgetDropdownAction>[] = [];
+	if (restrictedMode) {
+		// Untrusted workspace: providers are disabled, so any `models` here are
+		// stale machine-cached entries. Surface a Trust action (mirroring the
+		// send-message trust prompt) instead of a misleading lone "Auto". Checked
+		// before the empty-list branch since cached entries can make `models`
+		// non-empty.
+		items.push({
+			kind: ActionListItemKind.Header,
+			label: localize('chat.modelPicker.restrictedMode', "Models Unavailable in Restricted Mode"),
+		});
+		items.push({
+			item: {
+				id: RESTRICTED_MODE_TRUST_ACTION_ID,
+				enabled: !!onRequestTrust,
+				checked: false,
+				class: undefined,
+				tooltip: localize('chat.modelPicker.restrictedMode.trustTooltip', "Trust the workspace to enable AI models."),
+				label: localize('chat.modelPicker.restrictedMode.trust', "Trust Workspace..."),
+				run: () => onRequestTrust?.()
+			},
+			kind: ActionListItemKind.Action,
+			label: localize('chat.modelPicker.restrictedMode.trust', "Trust Workspace..."),
+			group: { title: '', icon: ThemeIcon.fromId(Codicon.workspaceTrusted.id) },
+			disabled: !onRequestTrust,
+			hideIcon: false,
+		});
+		return items;
+	}
+	if (setupRequired) {
+		// Trusted, but Chat still needs sign-in / setup before any model is
+		// usable. Surface a Sign In action (mirroring the send-message setup
+		// prompt) instead of a misleading lone "Auto". Like restricted mode this
+		// is checked before the empty-list branch since stale machine-cached
+		// entries can make `models` non-empty.
+		items.push({
+			kind: ActionListItemKind.Header,
+			label: localize('chat.modelPicker.setupRequired', "Sign in to use Copilot"),
+		});
+		items.push({
+			item: {
+				id: SETUP_REQUIRED_SIGN_IN_ACTION_ID,
+				enabled: !!onRequestSetup,
+				checked: false,
+				class: undefined,
+				tooltip: localize('chat.modelPicker.setupRequired.signInTooltip', "Sign in to GitHub Copilot to choose a model."),
+				label: localize('chat.modelPicker.setupRequired.signIn', "Sign in to use Copilot..."),
+				run: () => onRequestSetup?.()
+			},
+			kind: ActionListItemKind.Action,
+			label: localize('chat.modelPicker.setupRequired.signIn', "Sign in to use Copilot..."),
+			group: { title: '', icon: ThemeIcon.fromId(Codicon.signIn.id) },
+			disabled: !onRequestSetup,
+			hideIcon: false,
+		});
+		return items;
+	}
 	if (models.length === 0) {
 		if (!showAutoModel) {
 			// Auto is not available for this session type (e.g. the Claude agent
@@ -856,14 +944,21 @@ export function getModelPickerAccessibilityProvider() {
 			if (element.isSectionToggle) {
 				return undefined;
 			}
-			return element.kind === ActionListItemKind.Action ? !!element?.item?.checked : undefined;
+			// The Trust / Sign in entries are commands, not selectable models, so
+			// they expose no checked state.
+			if (element.kind === ActionListItemKind.Action && !(element.item?.id && PICKER_COMMAND_ACTION_IDS.has(element.item.id))) {
+				return !!element?.item?.checked;
+			}
+			return undefined;
 		},
 		getRole: (element: IActionListItem<IActionWidgetDropdownAction>) => {
 			if (element.isSectionToggle) {
 				return 'menuitem';
 			}
 			switch (element.kind) {
-				case ActionListItemKind.Action: return 'menuitemradio';
+				// The Trust / Sign in entries are commands, not model choices, so
+				// announce them as plain menuitems rather than radios.
+				case ActionListItemKind.Action: return element.item?.id && PICKER_COMMAND_ACTION_IDS.has(element.item.id) ? 'menuitem' : 'menuitemradio';
 				case ActionListItemKind.Separator: return 'separator';
 				default: return 'separator';
 			}
@@ -951,6 +1046,9 @@ export class ModelPickerWidget extends Disposable {
 	private _selectedModel: ILanguageModelChatMetadataAndIdentifier | undefined;
 	private _badge: ModelPickerBadge | undefined;
 	private _compact: IObservable<boolean> | undefined;
+	private _workspaceTrustInitialized = false;
+	private _activatingAfterTrust = false;
+	private readonly _activatingTimer = this._register(new MutableDisposable());
 
 	private _domNode: HTMLElement | undefined;
 	private _badgeIcon: HTMLElement | undefined;
@@ -981,15 +1079,53 @@ export class ModelPickerWidget extends Disposable {
 		@IUpdateService private readonly _updateService: IUpdateService,
 		@IUriIdentityService private readonly _uriIdentityService: IUriIdentityService,
 		@IDefaultAccountService private readonly _defaultAccountService: IDefaultAccountService,
+		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
+		@IWorkspaceTrustRequestService private readonly _workspaceTrustRequestService: IWorkspaceTrustRequestService,
 	) {
 		super();
 		this._register(this._languageModelsService.onDidChangeLanguageModels(() => {
+			if (this._activatingAfterTrust && this._delegate.getModels().length > 0) {
+				this._clearActivating();
+			}
 			this._renderLabel();
 		}));
+
+		// Reflect Restricted Mode immediately when trust changes. When trust is
+		// granted but no models are available yet, briefly show an "Activating..."
+		// state while the chat extension comes up and loads them, rather than a
+		// misleading "Auto" fallback.
+		this._register(this._workspaceTrustManagementService.onDidChangeTrust(trusted => {
+			if (trusted && (this._delegate.showAutoModel?.() ?? false) && this._delegate.getModels().length === 0) {
+				this._activatingAfterTrust = true;
+				this._activatingTimer.value = disposableTimeout(() => {
+					this._activatingAfterTrust = false;
+					this._renderLabel();
+				}, 15000);
+			} else {
+				this._clearActivating();
+			}
+			this._renderLabel();
+		}));
+
+		// Trust reads as untrusted until initialization resolves; gate on it so a
+		// trusted workspace doesn't briefly render as restricted at startup.
+		this._workspaceTrustManagementService.workspaceTrustInitialized.then(() => {
+			if (this._store.isDisposed) {
+				return;
+			}
+			this._workspaceTrustInitialized = true;
+			this._renderLabel();
+		});
 
 		this._register(this._entitlementService.onDidChangeUsageBasedBilling(() => {
 			this._renderLabel();
 		}));
+
+		// The setup-required state derives from entitlement / sentiment / anonymous
+		// access, so refresh the label when any of those change (e.g. after sign-in).
+		this._register(this._entitlementService.onDidChangeEntitlement(() => this._renderLabel()));
+		this._register(this._entitlementService.onDidChangeSentiment(() => this._renderLabel()));
+		this._register(this._entitlementService.onDidChangeAnonymous(() => this._renderLabel()));
 
 		// Also refresh the label when the per-editor config layer (if any) reports
 		// a change. The global service path is already covered above via
@@ -1027,6 +1163,76 @@ export class ModelPickerWidget extends Disposable {
 	setBadge(badge: ModelPickerBadge | undefined): void {
 		this._badge = badge;
 		this._updateBadge();
+	}
+
+	/**
+	 * Why the picker currently has no model to offer (untrusted vs. needs
+	 * sign-in/setup), or `undefined` when a model is available. See
+	 * {@link getModelPickerUnavailableReason}.
+	 */
+	private _unavailableReason(): ModelPickerUnavailableReason | undefined {
+		return getModelPickerUnavailableReason({
+			trustInitialized: this._workspaceTrustInitialized,
+			trusted: this._workspaceTrustManagementService.isWorkspaceTrusted(),
+			pickerModels: this._delegate.getModels(),
+			liveModelIds: this._languageModelsService.getLanguageModelIds(),
+			requiresSetup: this._requiresSetup(),
+		});
+	}
+
+	private _requiresSetup(): boolean {
+		const sentiment = this._entitlementService.sentiment;
+		return chatRequiresSetup({
+			completed: !!sentiment.completed,
+			disabled: !!sentiment.disabled,
+			// Don't derive `untrusted` from sentiment (it lags after a Trust grant): trust is handled
+			// authoritatively by the Restricted branch, which runs first, so it's false here.
+			untrusted: false,
+			entitlement: this._entitlementService.entitlement,
+			anonymous: this._entitlementService.anonymous,
+			hasByokModels: this._entitlementService.hasByokModels,
+		});
+	}
+
+	/**
+	 * Whether the picker has no usable model specifically because the workspace
+	 * is untrusted (Restricted Mode disables the chat model providers).
+	 */
+	isRestrictedMode(): boolean {
+		return this._unavailableReason() === ModelPickerUnavailableReason.Restricted;
+	}
+
+	/**
+	 * Whether the picker has no usable model because Chat still needs sign-in /
+	 * setup (and the workspace is trusted, so it is not Restricted Mode). BYOK
+	 * and anonymous access never report this state.
+	 */
+	isSetupRequired(): boolean {
+		return this._unavailableReason() === ModelPickerUnavailableReason.SetupRequired;
+	}
+
+	private _clearActivating(): void {
+		this._activatingAfterTrust = false;
+		this._activatingTimer.clear();
+	}
+
+	/**
+	 * Prompts the user to trust the workspace. On grant, providers register their
+	 * models and `onDidChangeLanguageModels` refreshes the picker.
+	 */
+	private async _requestWorkspaceTrust(): Promise<void> {
+		await this._workspaceTrustRequestService.requestWorkspaceTrust({
+			message: localize('chat.modelPicker.trustMessage', "Trusting this workspace enables AI models and chat features.")
+		});
+	}
+
+	/**
+	 * Starts the Chat setup / sign-in flow (same command as the title-bar Sign In
+	 * affordance). On completion the entitlement and model registry change, which
+	 * refreshes the picker.
+	 */
+	private _requestSetup(): void {
+		this._commandService.executeCommand(CHAT_SETUP_ACTION_ID);
 	}
 
 	render(container: HTMLElement): void {
@@ -1165,6 +1371,10 @@ export class ModelPickerWidget extends Disposable {
 			isUBB,
 			this._delegate.showAutoModel?.() ?? false,
 			onConfigure,
+			this.isRestrictedMode(),
+			() => { void this._requestWorkspaceTrust(); },
+			this.isSetupRequired(),
+			() => { this._requestSetup(); },
 		);
 
 		// Collect all hover disposables so they are properly cleaned up when the
@@ -1256,21 +1466,41 @@ export class ModelPickerWidget extends Disposable {
 
 		const { name, statusIcon } = this._selectedModel?.metadata || {};
 
-		// When Auto is unavailable for this session and there are no models to
-		// pick, surface the empty state on the button itself — overriding any
-		// stale/carried-over selection (e.g. an "Auto" model from another
-		// session type) so the label matches the dropdown's "No models
-		// available" entry.
-		const noModelsAvailable = !(this._delegate.showAutoModel?.() ?? false) && this._delegate.getModels().length === 0;
+		// Untrusted workspace: present a normal "Pick Model" placeholder (no badge)
+		// rather than a dead-end label; the hover and dropdown carry the Restricted
+		// Mode explanation and the Trust Workspace action.
+		const restrictedMode = this.isRestrictedMode();
+
+		// Trusted, but Chat still needs sign-in / setup before any model is
+		// usable: present the same "Pick Model" placeholder, with the dropdown
+		// carrying a Sign In action instead of a misleading "Auto".
+		const setupRequired = this.isSetupRequired();
+		const unavailable = restrictedMode || setupRequired;
+
+		// Just after Trust, models load asynchronously while the chat extension
+		// activates. Show a transient "Activating..." state — only when there is
+		// nothing else to display — instead of a misleading "Auto" fallback.
+		const activating = !unavailable && this._activatingAfterTrust && this._delegate.getModels().length === 0;
+
+		// Generic empty state (e.g. an agent-host session with no Auto fallback);
+		// not evaluated while unavailable/activating, which take precedence.
+		const genericNoModels = !unavailable && !activating
+			&& !(this._delegate.showAutoModel?.() ?? false)
+			&& this._delegate.getModels().length === 0;
+		const noModelsAvailable = unavailable || activating || genericNoModels;
 
 		// --- Name section ---
 		const nameChildren: (HTMLElement | string)[] = [];
 		if (statusIcon && !noModelsAvailable) {
 			nameChildren.push(renderIcon(statusIcon));
 		}
-		const modelLabel = noModelsAvailable
-			? localize('chat.modelPicker.noModels', "No models available")
-			: (name ?? localize('chat.modelPicker.auto', "Auto"));
+		const modelLabel = unavailable
+			? localize('chat.modelPicker.label', "Pick Model")
+			: activating
+				? localize('chat.modelPicker.activating', "Activating...")
+				: genericNoModels
+					? localize('chat.modelPicker.noModels', "No models available")
+					: (name ?? localize('chat.modelPicker.auto', "Auto"));
 		// In PRU mode, append the config description (e.g. thinking effort) to the button label
 		const isUBB = !!this._entitlementService.quotas.usageBasedBilling;
 		const configDescription = !isUBB && this._selectedModel && !noModelsAvailable
@@ -1320,7 +1550,11 @@ export class ModelPickerWidget extends Disposable {
 		}
 
 		// Aria
-		this._domNode.ariaLabel = localize('chat.modelPicker.ariaLabel', "Pick Model, {0}", fullLabel);
+		this._domNode.ariaLabel = restrictedMode
+			? localize('chat.modelPicker.ariaLabelRestricted', "Pick Model, models are unavailable in Restricted Mode")
+			: setupRequired
+				? localize('chat.modelPicker.ariaLabelSetupRequired', "Pick Model, sign in to use Copilot")
+				: localize('chat.modelPicker.ariaLabel', "Pick Model, {0}", fullLabel);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
@@ -394,3 +394,58 @@ export function resolveConfiguredModel(
 
 	return undefined;
 }
+
+/**
+ * Why a model picker has no model to offer, when that is the case. Drives a
+ * "Pick Model" placeholder plus a contextual action instead of a misleading
+ * lone "Auto".
+ */
+export const enum ModelPickerUnavailableReason {
+	/** The workspace is untrusted, which disables the model providers. */
+	Restricted = 'restricted',
+	/** Chat requires sign-in / setup before any model is available. */
+	SetupRequired = 'setupRequired',
+}
+
+/**
+ * Determines whether a model picker should present an "unavailable" state and,
+ * if so, why. Returns `undefined` when the picker has a usable model (or its
+ * state is not yet known), so the normal model / Auto label is shown.
+ *
+ * A model counts as usable only when it is both offered by this picker
+ * (`pickerModels`, already filtered to the picker's location / session type) AND
+ * currently live in the language model registry (`liveModelIds`). This ignores
+ * two kinds of phantom models that would otherwise mask the unavailable state:
+ * - stale cross-window machine cache entries (present in `pickerModels` but not live), and
+ * - models registered for other surfaces such as agent-host session-scoped models
+ *   (live in the global registry but not offered by this picker).
+ *
+ * A live, picker-offered model (e.g. BYOK) always wins, so BYOK and anonymous
+ * access are never shown an unavailable state. `trusted` reflects
+ * `isWorkspaceTrusted()` (which is `true` when trust is disabled entirely) and is
+ * only authoritative once `trustInitialized` is `true`; until then this returns
+ * `undefined` to avoid a trusted workspace briefly rendering as unavailable at
+ * startup. Restricted (untrusted) takes precedence over setup-required.
+ */
+export function getModelPickerUnavailableReason(context: {
+	readonly trustInitialized: boolean;
+	readonly trusted: boolean;
+	readonly pickerModels: readonly ILanguageModelChatMetadataAndIdentifier[];
+	readonly liveModelIds: Iterable<string>;
+	readonly requiresSetup: boolean;
+}): ModelPickerUnavailableReason | undefined {
+	if (!context.trustInitialized) {
+		return undefined;
+	}
+	const live = context.liveModelIds instanceof Set ? context.liveModelIds : new Set(context.liveModelIds);
+	if (context.pickerModels.some(model => live.has(model.identifier))) {
+		return undefined;
+	}
+	if (!context.trusted) {
+		return ModelPickerUnavailableReason.Restricted;
+	}
+	if (context.requiresSetup) {
+		return ModelPickerUnavailableReason.SetupRequired;
+	}
+	return undefined;
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
@@ -123,6 +123,25 @@ export class ModelPickerActionItem extends BaseActionViewItem {
 		this._pickerWidget.setEnabled(enabled);
 	}
 
+	/**
+	 * Whether the picker has no usable model because the workspace is untrusted
+	 * (Restricted Mode). Lets a host (e.g. the sessions picker) keep the picker
+	 * visible to surface the "Pick Model" placeholder and Trust Workspace action
+	 * instead of hiding it as an empty/no-model picker.
+	 */
+	public isRestrictedMode(): boolean {
+		return this._pickerWidget.isRestrictedMode();
+	}
+
+	/**
+	 * Whether the picker has no usable model because Chat still needs sign-in /
+	 * setup. Like {@link isRestrictedMode}, lets a host keep the picker visible to
+	 * surface the "Pick Model" placeholder and Sign In action.
+	 */
+	public isSetupRequired(): boolean {
+		return this._pickerWidget.isSetupRequired();
+	}
+
 	private _showPicker(): void {
 		this._pickerWidget.show(this._getAnchorElement());
 	}
@@ -132,23 +151,28 @@ export class ModelPickerActionItem extends BaseActionViewItem {
 		if (!target) {
 			return;
 		}
-		const hoverContent = this._getHoverContents();
-		if (typeof hoverContent === 'string' && hoverContent) {
-			this._managedHover.value = getBaseLayerHoverDelegate().setupManagedHover(
-				getDefaultHoverDelegate('mouse'),
-				target,
-				hoverContent
-			);
-		} else {
-			this._managedHover.clear();
-		}
+		// Use a content factory so the hover reflects the current state each time
+		// it is shown — in particular the Restricted Mode / sign-in messages, which
+		// depend on workspace trust / entitlement changing without this item being
+		// re-rendered.
+		this._managedHover.value = getBaseLayerHoverDelegate().setupManagedHover(
+			getDefaultHoverDelegate('mouse'),
+			target,
+			() => this._getHoverContents()
+		);
 	}
 
-	private _getHoverContents(): IManagedHoverContent | undefined {
+	private _getHoverContents(): IManagedHoverContent {
 		let label = localize('chat.modelPicker.label', "Pick Model");
 		const keybindingLabel = this.keybindingService.lookupKeybinding(this._action.id, this._contextKeyService)?.getLabel();
 		if (keybindingLabel) {
 			label += ` (${keybindingLabel})`;
+		}
+		if (this._pickerWidget.isRestrictedMode()) {
+			return localize('chat.modelPicker.restrictedHover', "{0} • Models are unavailable in Restricted Mode. Trust the workspace to choose a model.", label);
+		}
+		if (this._pickerWidget.isSetupRequired()) {
+			return localize('chat.modelPicker.setupRequiredHover', "{0} • Sign in to GitHub Copilot to choose a model.", label);
 		}
 		const { statusIcon, tooltip } = this._pickerWidget.selectedModel?.metadata || {};
 		return statusIcon && tooltip ? `${label} • ${tooltip}` : label;

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
@@ -114,6 +114,10 @@ function callBuild(
 		isUBB?: boolean;
 		languageModelsService?: ILanguageModelsService;
 		showAutoModel?: boolean;
+		restrictedMode?: boolean;
+		onRequestTrust?: () => void;
+		setupRequired?: boolean;
+		onRequestSetup?: () => void;
 	} = {},
 ): IActionListItem<IActionWidgetDropdownAction>[] {
 	const onSelect = () => { };
@@ -142,6 +146,11 @@ function callBuild(
 		undefined,
 		opts.isUBB,
 		opts.showAutoModel ?? true,
+		undefined,
+		opts.restrictedMode ?? false,
+		opts.onRequestTrust,
+		opts.setupRequired ?? false,
+		opts.onRequestSetup,
 	);
 }
 
@@ -165,6 +174,22 @@ suite('buildModelPickerItems', () => {
 		assert.strictEqual(provider.getRole({ kind: ActionListItemKind.Action } as IActionListItem<IActionWidgetDropdownAction>), 'menuitemradio');
 		assert.strictEqual(provider.getRole({ kind: ActionListItemKind.Separator } as IActionListItem<IActionWidgetDropdownAction>), 'separator');
 		assert.strictEqual(provider.getWidgetRole(), 'menu');
+	});
+
+	test('accessibility provider announces the Restricted Mode Trust action as a plain menuitem (not a radio)', () => {
+		const provider = getModelPickerAccessibilityProvider();
+		const trust = getActionItems(callBuild([], { restrictedMode: true, onRequestTrust: () => { } })).find(a => a.item?.id === 'restrictedModeTrust')!;
+		assert.ok(trust, 'expected a Trust Workspace action');
+		assert.strictEqual(provider.getRole(trust), 'menuitem');
+		assert.strictEqual(provider.isChecked(trust), undefined);
+	});
+
+	test('accessibility provider announces the Sign In action as a plain menuitem (not a radio)', () => {
+		const provider = getModelPickerAccessibilityProvider();
+		const signIn = getActionItems(callBuild([], { setupRequired: true, onRequestSetup: () => { } })).find(a => a.item?.id === 'setupRequiredSignIn')!;
+		assert.ok(signIn, 'expected a Sign In action');
+		assert.strictEqual(provider.getRole(signIn), 'menuitem');
+		assert.strictEqual(provider.isChecked(signIn), undefined);
 	});
 
 	test('accessibility provider includes inline source and right-aligned multiplier', () => {
@@ -235,6 +260,93 @@ suite('buildModelPickerItems', () => {
 		const actions = getActionItems(items);
 		assert.strictEqual(actions.some(a => a.item?.id === 'noModels'), false);
 		assert.strictEqual(actions.some(a => a.label === 'GPT-4o'), true);
+	});
+
+	test('restrictedMode shows an explanatory header and a Trust Workspace action instead of auto', () => {
+		const items = callBuild([], { restrictedMode: true, onRequestTrust: () => { } });
+		const actions = getActionItems(items);
+		// The explanation is a non-interactive header; only Trust is selectable.
+		assert.ok(items.some(i => i.kind === ActionListItemKind.Header && i.label === 'Models Unavailable in Restricted Mode'));
+		assert.strictEqual(actions.length, 1);
+		assert.strictEqual(actions[0].item?.id, 'restrictedModeTrust');
+		assert.strictEqual(actions[0].item?.enabled, true);
+		assert.strictEqual(actions.some(a => a.label === 'Auto'), false);
+		assert.strictEqual(actions.some(a => a.item?.id === 'manageModels'), false);
+		assert.strictEqual(actions.some(a => a.item?.id === 'noModels'), false);
+	});
+
+	test('restrictedMode Trust action is disabled without a trust callback', () => {
+		const items = callBuild([], { restrictedMode: true });
+		const trust = getActionItems(items).find(a => a.item?.id === 'restrictedModeTrust');
+		assert.strictEqual(trust?.item?.enabled, false);
+		assert.strictEqual(trust?.disabled, true);
+	});
+
+	test('restrictedMode takes precedence over showAutoModel', () => {
+		const items = callBuild([], { restrictedMode: true, showAutoModel: true });
+		const actions = getActionItems(items);
+		assert.strictEqual(actions.some(a => a.label === 'Auto'), false);
+		assert.strictEqual(actions.some(a => a.item?.id === 'restrictedModeTrust'), true);
+	});
+
+	test('restrictedMode Trust action invokes the trust callback', () => {
+		let trustRequested = 0;
+		const items = callBuild([], { restrictedMode: true, onRequestTrust: () => { trustRequested++; } });
+		const trustAction = getActionItems(items).find(a => a.item?.id === 'restrictedModeTrust');
+		assert.ok(trustAction, 'expected a Trust Workspace action');
+		trustAction!.item!.run();
+		assert.strictEqual(trustRequested, 1);
+	});
+
+	test('restrictedMode takes precedence even over cached models', () => {
+		// In Restricted Mode the picker may still receive machine-cached models
+		// from a previous trusted session; the restricted state must suppress
+		// them rather than present stale, unusable models.
+		const items = callBuild([createModel('gpt-4o', 'GPT-4o')], { restrictedMode: true });
+		const actions = getActionItems(items);
+		assert.strictEqual(actions.some(a => a.label === 'GPT-4o'), false);
+		assert.strictEqual(actions.some(a => a.item?.id === 'restrictedModeTrust'), true);
+	});
+
+	test('setupRequired shows an explanatory header and a Sign In action instead of auto', () => {
+		const items = callBuild([], { setupRequired: true, onRequestSetup: () => { } });
+		const actions = getActionItems(items);
+		assert.ok(items.some(i => i.kind === ActionListItemKind.Header && i.label === 'Sign in to use Copilot'));
+		assert.strictEqual(actions.length, 1);
+		assert.strictEqual(actions[0].item?.id, 'setupRequiredSignIn');
+		assert.strictEqual(actions[0].item?.enabled, true);
+		assert.strictEqual(actions.some(a => a.label === 'Auto'), false);
+		assert.strictEqual(actions.some(a => a.item?.id === 'manageModels'), false);
+	});
+
+	test('setupRequired Sign In action is disabled without a setup callback', () => {
+		const items = callBuild([], { setupRequired: true });
+		const signIn = getActionItems(items).find(a => a.item?.id === 'setupRequiredSignIn');
+		assert.strictEqual(signIn?.item?.enabled, false);
+		assert.strictEqual(signIn?.disabled, true);
+	});
+
+	test('setupRequired Sign In action invokes the setup callback', () => {
+		let setupRequested = 0;
+		const items = callBuild([], { setupRequired: true, onRequestSetup: () => { setupRequested++; } });
+		const signIn = getActionItems(items).find(a => a.item?.id === 'setupRequiredSignIn');
+		assert.ok(signIn, 'expected a Sign In action');
+		signIn!.item!.run();
+		assert.strictEqual(setupRequested, 1);
+	});
+
+	test('setupRequired takes precedence even over cached models', () => {
+		const items = callBuild([createModel('gpt-4o', 'GPT-4o')], { setupRequired: true });
+		const actions = getActionItems(items);
+		assert.strictEqual(actions.some(a => a.label === 'GPT-4o'), false);
+		assert.strictEqual(actions.some(a => a.item?.id === 'setupRequiredSignIn'), true);
+	});
+
+	test('restrictedMode takes precedence over setupRequired', () => {
+		const items = callBuild([], { restrictedMode: true, setupRequired: true, onRequestTrust: () => { }, onRequestSetup: () => { } });
+		const actions = getActionItems(items);
+		assert.strictEqual(actions.some(a => a.item?.id === 'restrictedModeTrust'), true);
+		assert.strictEqual(actions.some(a => a.item?.id === 'setupRequiredSignIn'), false);
 	});
 
 	test('only auto model produces auto and manage models with separator', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionLogic.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionLogic.test.ts
@@ -16,6 +16,8 @@ import {
 	isModelSupportedForInlineChat,
 	isModelSupportedForMode,
 	isModelValidForSession,
+	getModelPickerUnavailableReason,
+	ModelPickerUnavailableReason,
 	mergeModelsWithCache,
 	resolveConfiguredModel,
 	resolveModelFromSyncState,
@@ -1783,6 +1785,56 @@ suite('ChatModelSelectionLogic', () => {
 		test('returns undefined when nothing matches', () => {
 			const gpt = createModel('gpt-5', 'GPT-5', { family: 'gpt' });
 			assert.strictEqual(resolveConfiguredModel('nonexistent', [gpt]), undefined);
+		});
+	});
+
+	suite('getModelPickerUnavailableReason', () => {
+		const gpt = createModel('gpt-4o', 'GPT-4o');
+
+		function reason(opts: { trustInitialized?: boolean; trusted?: boolean; pickerModels?: ILanguageModelChatMetadataAndIdentifier[]; liveModelIds?: Iterable<string>; requiresSetup?: boolean }): ModelPickerUnavailableReason | undefined {
+			return getModelPickerUnavailableReason({
+				trustInitialized: opts.trustInitialized ?? true,
+				trusted: opts.trusted ?? true,
+				pickerModels: opts.pickerModels ?? [],
+				liveModelIds: opts.liveModelIds ?? [],
+				requiresSetup: opts.requiresSetup ?? false,
+			});
+		}
+
+		test('untrusted with no usable models is Restricted', () => {
+			assert.strictEqual(reason({ trusted: false }), ModelPickerUnavailableReason.Restricted);
+		});
+
+		test('trusted with no usable models and setup required is SetupRequired', () => {
+			assert.strictEqual(reason({ trusted: true, requiresSetup: true }), ModelPickerUnavailableReason.SetupRequired);
+		});
+
+		test('trusted with no usable models and setup not required is available (e.g. anonymous/Auto)', () => {
+			assert.strictEqual(reason({ trusted: true, requiresSetup: false }), undefined);
+		});
+
+		test('undefined until trust has initialized', () => {
+			assert.strictEqual(reason({ trustInitialized: false, trusted: false, requiresSetup: true }), undefined);
+		});
+
+		test('a live, picker-offered model wins over any unavailable state (e.g. BYOK)', () => {
+			assert.strictEqual(reason({ trusted: false, requiresSetup: true, pickerModels: [gpt], liveModelIds: [gpt.identifier] }), undefined);
+		});
+
+		test('stale cached models that are not live do not mask the unavailable state', () => {
+			assert.strictEqual(reason({ trusted: false, pickerModels: [gpt], liveModelIds: [] }), ModelPickerUnavailableReason.Restricted);
+		});
+
+		test('models live for another surface but not offered by this picker do not mask the unavailable state', () => {
+			assert.strictEqual(reason({ trusted: true, requiresSetup: true, pickerModels: [], liveModelIds: ['agentHost/claude'] }), ModelPickerUnavailableReason.SetupRequired);
+		});
+
+		test('restricted takes precedence over setup required', () => {
+			assert.strictEqual(reason({ trusted: false, requiresSetup: true }), ModelPickerUnavailableReason.Restricted);
+		});
+
+		test('accepts a Set of live ids', () => {
+			assert.strictEqual(reason({ trusted: false, requiresSetup: true, pickerModels: [gpt], liveModelIds: new Set([gpt.identifier]) }), undefined);
 		});
 	});
 });

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -57,13 +57,13 @@ interface IDefaultAccountConfig {
 
 export const DEFAULT_ACCOUNT_SIGN_IN_COMMAND = 'workbench.actions.accounts.signIn';
 
-const enum DefaultAccountStatus {
+export const enum DefaultAccountStatus {
 	Uninitialized = 'uninitialized',
 	Unavailable = 'unavailable',
 	Available = 'available',
 }
 
-const CONTEXT_DEFAULT_ACCOUNT_STATE = new RawContextKey<string>('defaultAccountStatus', DefaultAccountStatus.Uninitialized);
+export const CONTEXT_DEFAULT_ACCOUNT_STATE = new RawContextKey<string>('defaultAccountStatus', DefaultAccountStatus.Uninitialized);
 const CACHED_POLICY_DATA_KEY = 'defaultAccount.cachedPolicyData';
 const ACCOUNT_DATA_POLL_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 const MANAGED_SETTINGS_REQUEST_TIMEOUT_MS = 5000;

--- a/src/vs/workbench/services/chat/common/chatEntitlementService.ts
+++ b/src/vs/workbench/services/chat/common/chatEntitlementService.ts
@@ -157,6 +157,46 @@ export interface IChatSentiment {
 	registered?: boolean;
 }
 
+/**
+ * The inputs needed to decide whether Chat still requires the user to run setup
+ * (sign in / sign up / trust / enable) before it can service a request.
+ */
+export interface IChatSetupRequirement {
+	/** Whether the setup flow has been completed (any outcome). */
+	readonly completed: boolean;
+	/** Whether the chat extension is disabled for a reason other than trust. */
+	readonly disabled: boolean;
+	/** Whether the chat extension is disabled because the workspace is untrusted. */
+	readonly untrusted: boolean;
+	/** The user's last known or resolved entitlement. */
+	readonly entitlement: ChatEntitlement;
+	/** Whether anonymous (signed-out) Chat access is enabled. */
+	readonly anonymous: boolean;
+	/** Whether BYOK models are available. */
+	readonly hasByokModels: boolean;
+}
+
+/**
+ * Single source of truth for whether Chat still requires setup before it can
+ * service a request. Shared by the setup agent (which routes a sent message
+ * through setup) and the model picker (which surfaces a "Sign in to use Copilot"
+ * state instead of a misleading lone "Auto"). BYOK models and anonymous access
+ * intentionally satisfy the entitlement-based checks so those flows keep working.
+ */
+export function chatRequiresSetup(context: IChatSetupRequirement): boolean {
+	return (
+		(!context.completed && !context.hasByokModels) ||			// Setup not completed (unless BYOK models are available)
+		context.disabled ||											// Extension disabled: run setup to enable
+		context.untrusted ||										// Workspace untrusted: run setup to ask for trust
+		context.entitlement === ChatEntitlement.Available ||		// Entitlement available: run setup to sign up
+		(
+			context.entitlement === ChatEntitlement.Unknown &&		// Entitlement unknown: run setup to sign in / sign up
+			!context.anonymous &&									// unless anonymous access is enabled
+			!context.hasByokModels									// unless BYOK models are available
+		)
+	);
+}
+
 export interface IChatEntitlementService {
 
 	_serviceBrand: undefined;

--- a/src/vs/workbench/services/chat/test/common/chatEntitlementService.test.ts
+++ b/src/vs/workbench/services/chat/test/common/chatEntitlementService.test.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ChatEntitlement, chatRequiresSetup, IChatSetupRequirement } from '../../common/chatEntitlementService.js';
+
+suite('chatRequiresSetup', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function context(overrides: Partial<IChatSetupRequirement> = {}): IChatSetupRequirement {
+		return {
+			completed: true,
+			disabled: false,
+			untrusted: false,
+			entitlement: ChatEntitlement.Pro,
+			anonymous: false,
+			hasByokModels: false,
+			...overrides,
+		};
+	}
+
+	test('a completed, signed-up user does not require setup', () => {
+		assert.strictEqual(chatRequiresSetup(context()), false);
+	});
+
+	test('not completed requires setup', () => {
+		assert.strictEqual(chatRequiresSetup(context({ completed: false })), true);
+	});
+
+	test('not completed but BYOK models present does not require setup', () => {
+		assert.strictEqual(chatRequiresSetup(context({ completed: false, hasByokModels: true })), false);
+	});
+
+	test('disabled requires setup', () => {
+		assert.strictEqual(chatRequiresSetup(context({ disabled: true })), true);
+	});
+
+	test('untrusted requires setup', () => {
+		assert.strictEqual(chatRequiresSetup(context({ untrusted: true })), true);
+	});
+
+	test('entitlement Available requires setup (sign up)', () => {
+		assert.strictEqual(chatRequiresSetup(context({ entitlement: ChatEntitlement.Available })), true);
+	});
+
+	test('signed out (Unknown) requires setup', () => {
+		// completed: true so the result is driven by the Unknown entitlement, not the "not completed" clause.
+		assert.strictEqual(chatRequiresSetup(context({ completed: true, entitlement: ChatEntitlement.Unknown })), true);
+	});
+
+	test('signed out but anonymous access enabled does not require setup', () => {
+		// Anonymous excepts the "signed out" entitlement clause; the completed
+		// clause is satisfied because opting into anonymous completes setup.
+		assert.strictEqual(chatRequiresSetup(context({ completed: true, entitlement: ChatEntitlement.Unknown, anonymous: true })), false);
+	});
+
+	test('signed out but BYOK models present does not require setup', () => {
+		assert.strictEqual(chatRequiresSetup(context({ completed: false, entitlement: ChatEntitlement.Unknown, hasByokModels: true })), false);
+	});
+});

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
@@ -28,7 +28,7 @@ import { IPathService } from '../../../../services/path/common/pathService.js';
 import { IWorkbenchAssignmentService } from '../../../../services/assignment/common/assignmentService.js';
 import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
 import { IWorkbenchEnvironmentService } from '../../../../services/environment/common/environmentService.js';
-import { IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
+import { ChatEntitlement, IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
 import { INotebookDocumentService } from '../../../../services/notebook/common/notebookDocumentService.js';
 import { IViewDescriptorService } from '../../../../common/views.js';
 import { ISCMService } from '../../../../contrib/scm/common/scm.js';
@@ -178,7 +178,20 @@ export function registerChatFixtureServices(reg: ServiceRegistration, options: I
 		override readonly isSessionsWindow = false;
 	}());
 	reg.defineInstance(IChatSessionsService, new class extends mock<IChatSessionsService>() { override getAllChatSessionContributions() { return []; } override readonly onDidChangeSessionOptions = Event.None; override readonly onDidChangeOptionGroups = Event.None; override readonly onDidChangeAvailability = Event.None; override getCustomAgentTargetForSessionType() { return Target.Undefined; } override requiresCustomModelsForSessionType() { return false; } override supportsAutoModelForSessionType() { return false; } override getOptionGroupsForSessionType() { return []; } }());
-	reg.defineInstance(IChatEntitlementService, new class extends mock<IChatEntitlementService>() { override readonly quotas = {}; override readonly onDidChangeQuotaRemaining = Event.None; override readonly onDidChangeUsageBasedBilling = Event.None; }());
+	reg.defineInstance(IChatEntitlementService, new class extends mock<IChatEntitlementService>() {
+		override readonly quotas = {};
+		override readonly onDidChangeQuotaRemaining = Event.None;
+		override readonly onDidChangeUsageBasedBilling = Event.None;
+		override readonly onDidChangeEntitlement = Event.None;
+		override readonly onDidChangeSentiment = Event.None;
+		override readonly onDidChangeAnonymous = Event.None;
+		// A signed-in, set-up user so the picker renders normally (no Restricted /
+		// Sign In state) in fixtures.
+		override readonly entitlement = ChatEntitlement.Pro;
+		override readonly sentiment = { completed: true, installed: true };
+		override readonly anonymous = false;
+		override readonly hasByokModels = false;
+	}());
 	reg.defineInstance(IChatModeService, new MockChatModeService());
 	reg.defineInstance(ILanguageModelsService, new class extends mock<ILanguageModelsService>() { override onDidChangeLanguageModels = Event.None; override onDidChangeModelVisibility = Event.None; override getLanguageModelIds() { return []; } override getVendors() { return []; } override hasResolvedVendor() { return false; } }());
 	reg.defineInstance(ILanguageModelToolsService, new class extends mock<ILanguageModelToolsService>() { override onDidChangeTools = Event.None; override onDidPrepareToolCallBecomeUnresponsive = Event.None; override getTools() { return []; } }());

--- a/src/vs/workbench/test/browser/componentFixtures/editor/inlineChatZoneWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/editor/inlineChatZoneWidget.fixture.ts
@@ -24,7 +24,7 @@ import { IExtensionService } from '../../../../services/extensions/common/extens
 import { IDecorationsService } from '../../../../services/decorations/common/decorations.js';
 import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
 import { IWorkbenchAssignmentService } from '../../../../services/assignment/common/assignmentService.js';
-import { IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
+import { ChatEntitlement, IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
 import { IChatInputNotificationService } from '../../../../contrib/chat/browser/widget/input/chatInputNotificationService.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
 import { IChatWidgetService, IChatAccessibilityService } from '../../../../contrib/chat/browser/chat.js';
@@ -227,6 +227,14 @@ function renderInlineChatZoneWidget({ container, disposableStore, theme }: Compo
 				override readonly sentimentObs = observableValue('sentiment', { completed: true });
 				override readonly anonymousObs = observableValue('anonymous', false);
 				override readonly onDidChangeAnonymous = Event.None;
+				override readonly onDidChangeEntitlement = Event.None;
+				override readonly onDidChangeSentiment = Event.None;
+				// A signed-in, set-up user so the model picker renders normally
+				// (no Restricted / Sign In state) in this fixture.
+				override readonly sentiment = { completed: true };
+				override readonly entitlement = ChatEntitlement.Pro;
+				override readonly anonymous = false;
+				override readonly hasByokModels = false;
 				override readonly quotas = {};
 				override readonly onDidChangeQuotaRemaining = Event.None;
 				override readonly onDidChangeUsageBasedBilling = Event.None;
@@ -248,6 +256,7 @@ function renderInlineChatZoneWidget({ container, disposableStore, theme }: Compo
 				override getOptionGroupsForSessionType() { return undefined; }
 				override getCustomAgentTargetForSessionType() { return Target.Undefined; }
 				override requiresCustomModelsForSessionType() { return false; }
+				override supportsAutoModelForSessionType() { return true; }
 				override getChatSessionContribution() { return undefined; }
 				override getCapabilitiesForSessionType() { return undefined; }
 				override getSessionOptions() { return undefined; }

--- a/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
@@ -67,6 +67,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { TestConfigurationService } from '../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IContextMenuService, IContextViewService } from '../../../../platform/contextview/browser/contextView.js';
+import { IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from '../../../../platform/workspace/common/workspaceTrust.js';
 import { IDataChannelService, NullDataChannelService } from '../../../../platform/dataChannel/common/dataChannel.js';
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
@@ -731,6 +732,18 @@ export function registerWorkbenchServices(registration: ServiceRegistration): vo
 		showCombinedModeAndModelSheet: () => Promise.resolve(),
 		setImpl: () => ({ dispose: () => { } }),
 	});
+
+	// Workspace trust stubs so chat-input fixtures can instantiate the model
+	// picker (ModelPickerWidget reads workspace trust to detect Restricted Mode).
+	// Reports the workspace as trusted so the picker renders normally.
+	registration.defineInstance(IWorkspaceTrustManagementService, new class extends mock<IWorkspaceTrustManagementService>() {
+		override onDidChangeTrust = Event.None;
+		override readonly workspaceTrustInitialized = Promise.resolve();
+		override isWorkspaceTrusted() { return true; }
+	}());
+	registration.defineInstance(IWorkspaceTrustRequestService, new class extends mock<IWorkspaceTrustRequestService>() {
+		override async requestWorkspaceTrust() { return true; }
+	}());
 }
 
 


### PR DESCRIPTION
Fixes #322564
Fixes #322626

When Chat models aren't available, the picker just showed **"Auto"** — so you couldn't tell anything was wrong. Then sending a message failed with a different message (asking you to trust the workspace, or to sign in). This makes the picker show *why* there are no models and offer the matching one-click fix, across all the pickers (chat, inline, and the agents/sessions chat — they share one widget).

New look (instead of misleading "Auto" with missing models):

<img width="308" height="209" alt="trust-inline" src="https://github.com/user-attachments/assets/7d53eb90-07ca-4c91-b6d3-298151e3f9a4" />
<img width="272" height="162" alt="trust-picker" src="https://github.com/user-attachments/assets/5f7bd8c8-d995-4133-916a-cf596c5ebd36" />
<img width="311" height="176" alt="signin-picker" src="https://github.com/user-attachments/assets/5817d21e-4b47-46f6-98c7-ee5c1bf171ab" />


### What the picker shows now

- **Untrusted workspace** → button says **"Pick Model"**; dropdown explains models are unavailable in Restricted Mode and offers **"Trust Workspace…"**.
- **Signed out / needs setup** (but trusted) → button says **"Pick Model"**; dropdown offers **"Sign in to use Copilot…"**. This uses the same `chatRequiresSetup` check as the message-send path, so the picker and send can't disagree.
- **Otherwise** → normal model / "Auto", same as before.

A model only counts as available if it's both offered by this picker *and* live in the registry. That's the key fix: counting the raw global registry was wrong because it includes stale cached models and models meant for other surfaces (e.g. agent-host session models), which is what made it show a fake "Auto". **BYOK and anonymous users are unaffected** — they keep seeing their models.

### Sign In button

- Title-bar / accounts **Sign In** now hides only when you're actually signed in (gated on the workbench default-account state, no auth prompt). It still shows while signed out, including before the account state resolves and in untrusted workspaces.
- After trusting, we wait for the chat extension to activate before deciding whether to show the sign-in dialog, so already-signed-in users don't get prompted. The picker shows a brief **"Activating…"** instead of a fake "Auto".

### Testing

Unit tests for the detection + setup helpers and the picker's Restricted/Sign-In dropdown branches (incl. a11y roles). Typecheck, eslint, layer check, and the affected suites pass. Reviewed by two agents; the one bug found (a post-trust Sign In flash) is fixed.

Manually trying different states and workspaces with fresh/cleared installs!
