### PR TITLE
AH: fix steered/queued messages sending immediately

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatQueueActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatQueueActions.ts
@@ -262,37 +262,13 @@ export class ChatSendPendingImmediatelyAction extends Action2 {
 
 	override async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
 		const chatService = accessor.get(IChatService);
-		const widgetService = accessor.get(IChatWidgetService);
 		const [context] = args;
 
 		if (!isRequestVM(context) || !context.pendingKind) {
 			return;
 		}
 
-		const widget = widgetService.getWidgetBySessionResource(context.sessionResource);
-		const model = widget?.viewModel?.model;
-		if (!model) {
-			return;
-		}
-
-		const pendingRequests = model.getPendingRequests();
-		const targetIndex = pendingRequests.findIndex(r => r.request.id === context.id);
-		if (targetIndex === -1) {
-			return;
-		}
-
-		// Keep the target item's kind (queued vs steering)
-		const targetRequest = pendingRequests[targetIndex];
-
-		// Reorder: move target to front, keep others in their relative order
-		const reordered = [
-			{ requestId: targetRequest.request.id, kind: targetRequest.kind },
-			...pendingRequests.filter((_, i) => i !== targetIndex).map(r => ({ requestId: r.request.id, kind: r.kind }))
-		];
-
-		chatService.setPendingRequests(context.sessionResource, reordered);
-		await chatService.cancelCurrentRequestForSession(context.sessionResource, 'queueRunNext');
-		chatService.processPendingRequests(context.sessionResource);
+		await chatService.sendPendingRequestImmediately(context.sessionResource, context.id);
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -1789,12 +1789,10 @@ export interface IChatService {
 	 */
 	processPendingRequests(sessionResource: URI): void;
 	/**
-	 * Sends a single pending (queued or steering) request immediately,
-	 * cancelling the in-flight request for the session first. For local
-	 * sessions the targeted message is moved to the front of the queue and
-	 * dequeued; for server-managed (agent host) sessions, where the queue is
-	 * drained by the server and not on cancel, the message is removed from the
-	 * queue and re-sent as a normal turn once the active turn is cancelled.
+	 * Cancels the in-flight request and immediately sends a single pending
+	 * (queued or steering) request. Local sessions move it to the front and
+	 * dequeue it; server-managed (agent host) sessions re-send it as a normal
+	 * turn, since the server does not drain its queue on cancellation.
 	 */
 	sendPendingRequestImmediately(sessionResource: URI, requestId: string): Promise<void>;
 	addCompleteRequest(sessionResource: URI, message: IParsedChatRequest | string, variableData: IChatRequestVariableData | undefined, attempt: number | undefined, response: IChatCompleteResponse): void;

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -1788,6 +1788,15 @@ export interface IChatService {
 	 * as needed. Idempotent, safe to call at any time.
 	 */
 	processPendingRequests(sessionResource: URI): void;
+	/**
+	 * Sends a single pending (queued or steering) request immediately,
+	 * cancelling the in-flight request for the session first. For local
+	 * sessions the targeted message is moved to the front of the queue and
+	 * dequeued; for server-managed (agent host) sessions, where the queue is
+	 * drained by the server and not on cancel, the message is removed from the
+	 * queue and re-sent as a normal turn once the active turn is cancelled.
+	 */
+	sendPendingRequestImmediately(sessionResource: URI, requestId: string): Promise<void>;
 	addCompleteRequest(sessionResource: URI, message: IParsedChatRequest | string, variableData: IChatRequestVariableData | undefined, attempt: number | undefined, response: IChatCompleteResponse): void;
 	setChatSessionTitle(sessionResource: URI, title: string): void;
 	getLocalSessionHistory(): Promise<IChatDetail[]>;

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -1930,12 +1930,12 @@ export class ChatService extends Disposable implements IChatService {
 		}
 
 		if (this._isServerManagedQueue(sessionResource)) {
-			// Agent host sessions drain their queue on the server, and the
-			// server intentionally does not consume pending messages on
-			// cancellation. So the local reorder/process dance is a no-op and
-			// the message would be dropped. Instead, remove the targeted
-			// message from the queue (clearing it server-side) and re-send it
-			// as a normal turn once the active turn has been cancelled.
+			// Agent host queues are drained by the server, which intentionally
+			// skips pending messages on cancellation. So remove the message
+			// (clearing it server-side) and re-send it as a normal turn after
+			// cancelling. Remove before sending to avoid the server also
+			// auto-draining it (double send); restore it on failure so a
+			// rejected re-send doesn't silently drop the message.
 			const message = target.request.message.text;
 			const attachedContext = target.request.variableData.variables.slice();
 			const sendOptions: IChatSendRequestOptions = {
@@ -1943,11 +1943,6 @@ export class ChatService extends Disposable implements IChatService {
 				queue: undefined,
 				attachedContext,
 			};
-			// Remove before sending so the server does not also auto-drain the
-			// same message when the cancelled turn settles (which would send it
-			// twice). The trade-off is that a failed re-send would otherwise
-			// drop the message entirely, so on failure we restore it to the
-			// queue with its original kind rather than losing it silently.
 			this.removePendingRequest(sessionResource, requestId);
 			await this.cancelCurrentRequestForSession(sessionResource, 'queueRunNext');
 			let result: ChatSendResult | undefined;
@@ -1963,9 +1958,8 @@ export class ChatService extends Disposable implements IChatService {
 			return;
 		}
 
-		// Local sessions: move the targeted message to the front (keeping its
-		// kind), cancel the in-flight request, then let the queue processor
-		// dequeue and send it.
+		// Local sessions: move the target to the front (keeping its kind),
+		// cancel the in-flight request, and let the queue processor send it.
 		const reordered = [
 			{ requestId: target.request.id, kind: target.kind },
 			...pendingRequests.filter(r => r.request.id !== requestId).map(r => ({ requestId: r.request.id, kind: r.kind })),

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -1917,6 +1917,49 @@ export class ChatService extends Disposable implements IChatService {
 		}
 	}
 
+	async sendPendingRequestImmediately(sessionResource: URI, requestId: string): Promise<void> {
+		const model = this._sessionModels.get(sessionResource) as ChatModel | undefined;
+		if (!model) {
+			return;
+		}
+
+		const pendingRequests = model.getPendingRequests();
+		const target = pendingRequests.find(r => r.request.id === requestId);
+		if (!target) {
+			return;
+		}
+
+		if (this._isServerManagedQueue(sessionResource)) {
+			// Agent host sessions drain their queue on the server, and the
+			// server intentionally does not consume pending messages on
+			// cancellation. So the local reorder/process dance is a no-op and
+			// the message would be dropped. Instead, remove the targeted
+			// message from the queue (clearing it server-side) and re-send it
+			// as a normal turn once the active turn has been cancelled.
+			const message = target.request.message.text;
+			const sendOptions: IChatSendRequestOptions = {
+				...target.sendOptions,
+				queue: undefined,
+				attachedContext: target.request.variableData.variables.slice(),
+			};
+			this.removePendingRequest(sessionResource, requestId);
+			await this.cancelCurrentRequestForSession(sessionResource, 'queueRunNext');
+			await this.sendRequest(sessionResource, message, sendOptions);
+			return;
+		}
+
+		// Local sessions: move the targeted message to the front (keeping its
+		// kind), cancel the in-flight request, then let the queue processor
+		// dequeue and send it.
+		const reordered = [
+			{ requestId: target.request.id, kind: target.kind },
+			...pendingRequests.filter(r => r.request.id !== requestId).map(r => ({ requestId: r.request.id, kind: r.kind })),
+		];
+		this.setPendingRequests(sessionResource, reordered);
+		await this.cancelCurrentRequestForSession(sessionResource, 'queueRunNext');
+		this.processPendingRequests(sessionResource);
+	}
+
 	public hasSessions(): boolean {
 		return this._chatSessionStore.hasSessions();
 	}

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -1937,14 +1937,29 @@ export class ChatService extends Disposable implements IChatService {
 			// message from the queue (clearing it server-side) and re-send it
 			// as a normal turn once the active turn has been cancelled.
 			const message = target.request.message.text;
+			const attachedContext = target.request.variableData.variables.slice();
 			const sendOptions: IChatSendRequestOptions = {
 				...target.sendOptions,
 				queue: undefined,
-				attachedContext: target.request.variableData.variables.slice(),
+				attachedContext,
 			};
+			// Remove before sending so the server does not also auto-drain the
+			// same message when the cancelled turn settles (which would send it
+			// twice). The trade-off is that a failed re-send would otherwise
+			// drop the message entirely, so on failure we restore it to the
+			// queue with its original kind rather than losing it silently.
 			this.removePendingRequest(sessionResource, requestId);
 			await this.cancelCurrentRequestForSession(sessionResource, 'queueRunNext');
-			await this.sendRequest(sessionResource, message, sendOptions);
+			let result: ChatSendResult | undefined;
+			try {
+				result = await this.sendRequest(sessionResource, message, sendOptions);
+			} catch (err) {
+				this.logService.error('sendPendingRequestImmediately: re-send failed', err);
+			}
+			if (!result || result.kind === 'rejected') {
+				this.info('sendPendingRequestImmediately', `Re-send was not accepted (${result?.kind ?? 'error'}); restoring pending message to the queue`);
+				await this.sendRequest(sessionResource, message, { ...sendOptions, attachedContext, queue: target.kind });
+			}
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -975,6 +975,120 @@ suite('ChatService', () => {
 		assert.ok(invokedMessages[1].includes('queued request'));
 	});
 
+	test('sendPendingRequestImmediately cancels current and sends the queued message on local sessions', async () => {
+		const firstStarted = new DeferredPromise<void>();
+		const secondInvoked = new DeferredPromise<void>();
+		const invokedMessages: string[] = [];
+
+		const slowAgent: IChatAgentImplementation = {
+			async invoke(request, progress, history, token) {
+				invokedMessages.push(request.message);
+				if (invokedMessages.length === 1) {
+					firstStarted.complete();
+					await new Promise<void>(resolve => {
+						const listener = token.onCancellationRequested(() => { listener.dispose(); resolve(); });
+					});
+				} else {
+					secondInvoked.complete();
+				}
+				return {};
+			},
+		};
+
+		testDisposables.add(chatAgentService.registerAgent('slowAgent', { ...getAgentData('slowAgent'), isDefault: true }));
+		testDisposables.add(chatAgentService.registerAgentImplementation('slowAgent', slowAgent));
+
+		const testService = createChatService();
+		const modelRef = testDisposables.add(startSessionModel(testService));
+		const model = modelRef.object;
+
+		const response = await testService.sendRequest(model.sessionResource, 'first request', { agentId: 'slowAgent' });
+		ChatSendResult.assertSent(response);
+		await firstStarted.p;
+
+		const queued = await testService.sendRequest(model.sessionResource, 'queued message', { agentId: 'slowAgent', queue: ChatRequestQueueKind.Queued });
+		assert.ok(ChatSendResult.isQueued(queued));
+
+		const pendingId = model.getPendingRequests()[0].request.id;
+		await testService.sendPendingRequestImmediately(model.sessionResource, pendingId);
+		await secondInvoked.p;
+
+		assert.strictEqual(invokedMessages.length, 2);
+		assert.ok(invokedMessages[1].includes('queued message'));
+		assert.strictEqual(model.getPendingRequests().length, 0);
+	});
+
+	test('sendPendingRequestImmediately re-sends a steering message as a turn on agent host sessions', async () => {
+		const sessionType = 'agent-host-copilot';
+		const sessionResource = URI.from({ scheme: sessionType, path: '/session-send-immediately' });
+
+		const mockSessionsService = new MockChatSessionsService();
+		mockSessionsService.setContributions([{
+			type: sessionType,
+			name: 'Agent Host',
+			displayName: 'Agent Host',
+			description: 'Agent Host',
+		}]);
+		testDisposables.add(mockSessionsService.registerChatSessionContentProvider(sessionType, {
+			provideChatSessionContent: resource => Promise.resolve({
+				sessionResource: resource,
+				history: [],
+				onWillDispose: Event.None,
+				dispose: () => { },
+			}),
+		}));
+		instantiationService.stub(IChatSessionsService, mockSessionsService);
+
+		const firstStarted = new DeferredPromise<void>();
+		const secondInvoked = new DeferredPromise<void>();
+		const invokedMessages: string[] = [];
+
+		const slowAgent: IChatAgentImplementation = {
+			async invoke(request, progress, history, token) {
+				invokedMessages.push(request.message);
+				if (invokedMessages.length === 1) {
+					firstStarted.complete();
+					await new Promise<void>(resolve => {
+						const listener = token.onCancellationRequested(() => { listener.dispose(); resolve(); });
+					});
+				} else {
+					secondInvoked.complete();
+				}
+				return {};
+			},
+		};
+
+		testDisposables.add(chatAgentService.registerAgent(sessionType, { ...getAgentData(sessionType), isDefault: true }));
+		testDisposables.add(chatAgentService.registerAgentImplementation(sessionType, slowAgent));
+
+		const testService = createChatService();
+		const ref = await testService.acquireOrLoadSession(sessionResource, ChatAgentLocation.Chat, CancellationToken.None);
+		assert.ok(ref);
+		testDisposables.add(ref);
+
+		const response = await testService.sendRequest(sessionResource, 'first request', { agentId: sessionType });
+		ChatSendResult.assertSent(response);
+		await firstStarted.p;
+
+		// Queue a steering message while the first turn is in progress. On agent
+		// host sessions the queue is server-managed, so it stays pending here.
+		const steering = await testService.sendRequest(sessionResource, 'steering message', { agentId: sessionType, queue: ChatRequestQueueKind.Steering });
+		assert.ok(ChatSendResult.isQueued(steering));
+
+		const model = testService.getSession(sessionResource) as ChatModel;
+		assert.strictEqual(model.getPendingRequests().length, 1);
+		const pendingId = model.getPendingRequests()[0].request.id;
+
+		// Send Immediately must cancel the current turn AND actually send the
+		// steering message (the previous behavior dropped it).
+		await testService.sendPendingRequestImmediately(sessionResource, pendingId);
+		await secondInvoked.p;
+
+		assert.strictEqual(invokedMessages.length, 2);
+		assert.ok(invokedMessages[1].includes('steering message'));
+		assert.strictEqual(model.getPendingRequests().length, 0);
+	});
+
 	test('race condition: processNextPendingRequest dequeues before commit handler runs', async () => {
 		// This reproduces the race where:
 		// 1. Request 1 completes → .finally() calls processNextPendingRequest immediately

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -1070,8 +1070,7 @@ suite('ChatService', () => {
 		ChatSendResult.assertSent(response);
 		await firstStarted.p;
 
-		// Queue a steering message while the first turn is in progress. On agent
-		// host sessions the queue is server-managed, so it stays pending here.
+		// Steering stays pending here since agent host queues are server-managed.
 		const steering = await testService.sendRequest(sessionResource, 'steering message', { agentId: sessionType, queue: ChatRequestQueueKind.Steering });
 		assert.ok(ChatSendResult.isQueued(steering));
 
@@ -1079,8 +1078,7 @@ suite('ChatService', () => {
 		assert.strictEqual(model.getPendingRequests().length, 1);
 		const pendingId = model.getPendingRequests()[0].request.id;
 
-		// Send Immediately must cancel the current turn AND actually send the
-		// steering message (the previous behavior dropped it).
+		// Must cancel the current turn AND send the steering message (was dropped before).
 		await testService.sendPendingRequestImmediately(sessionResource, pendingId);
 		await secondInvoked.p;
 

--- a/src/vs/workbench/contrib/chat/test/common/chatService/mockChatService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/mockChatService.ts
@@ -143,6 +143,10 @@ export class MockChatService implements IChatService {
 
 	setPendingRequests(_sessionResource: URI, _requests: readonly { requestId: string; kind: ChatRequestQueueKind }[]): void { }
 
+	sendPendingRequestImmediately(_sessionResource: URI, _requestId: string): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+
 	addCompleteRequest(): void { }
 
 	async getLocalSessionHistory(): Promise<IChatDetail[]> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fix a bug where for steering messages and queued messages, when sending immediately, it would cause the request to stop and not send the next message.

before:
https://github.com/user-attachments/assets/dd28a722-3067-4228-8065-1f50fa2303af

https://github.com/user-attachments/assets/f42691ec-ecfc-464f-a22a-6578e2afc6d4


after

https://github.com/user-attachments/assets/a5c33078-3346-41de-af65-4bee5db8fdfe


