### PR TITLE
Agents mobile: keep dialog action buttons on-screen on phone

### DIFF
--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -894,10 +894,36 @@
 .agent-sessions-workbench.phone-layout .monaco-dialog-box {
 	width: calc(100% - 32px);
 	max-width: calc(100% - 32px);
+	box-sizing: border-box;
+}
+
+/* Never let the message/title clip on the right — always wrap. */
+.agent-sessions-workbench.phone-layout .monaco-dialog-box .dialog-message-row .dialog-message-container .dialog-message,
+.agent-sessions-workbench.phone-layout .monaco-dialog-box .dialog-message-row .dialog-message-container .dialog-message-detail {
+	white-space: normal;
+	overflow-wrap: anywhere;
+}
+
+/* Stack the action buttons vertically and full-width on phone so a
+ * destructive dialog's safe button (e.g. Cancel) can never be pushed
+ * off the right edge by a long primary label. This mirrors the base
+ * dialog's `.align-vertical` layout but is forced regardless of the
+ * widget's button-length heuristic. */
+.agent-sessions-workbench.phone-layout .monaco-dialog-box .dialog-buttons-row {
+	overflow: visible;
+}
+
+.agent-sessions-workbench.phone-layout .monaco-dialog-box .dialog-buttons-row .dialog-buttons {
+	flex-direction: column;
+	align-items: stretch;
+	margin-left: 0;
+	gap: 8px;
 }
 
 .agent-sessions-workbench.phone-layout .monaco-dialog-box .dialog-buttons-row .monaco-button {
 	min-height: 44px;
+	margin: 0;
+	width: 100%;
 	font-size: 16px;
 }
 


### PR DESCRIPTION
## Issue
On the Agents window in **phone layout**, confirmation dialog action buttons are laid out **horizontally** inside a `overflow: hidden` row. A destructive confirmation with a long primary label (e.g. **"Mark All as Done"**) pushes the safe button (**"Cancel"**) off the right edge of the viewport, so only the destructive action is fully visible and tappable. The title can also clip instead of wrapping.

Found while testing the Agents window on a real iOS device (iPhone, Mobile Safari) — the "Mark all sessions as done?" confirm rendered with Cancel cut off:

- title clipped: `…sessions from 'simple-ser`
- only **Mark All as Done** reachable; **Cancel** off-screen right

This is a safety problem: a destructive dialog where the safe option is unreachable.

## Fix (phone-only, CSS)
In `src/vs/sessions/browser/media/style.css`, under the existing `.phone-layout .monaco-dialog-box` rules:
- Stack the action buttons **vertically, full-width** (mirrors the base dialog's `.align-vertical` layout but forced on phone regardless of the button-length heuristic).
- Wrap the message/detail text (`white-space: normal; overflow-wrap: anywhere`).
- `box-sizing: border-box` on the dialog box.

Desktop/tablet unchanged (gated on `.phone-layout`).

## Verification
- [ ] On-device: trigger a destructive confirm (e.g. workspace group → Mark All as Done) on phone; both buttons full-width and visible, title wraps.

> Part of a series of Agents-window mobile UX fixes (separate PRs).
---

## On-device verification (pending a live session)

The full on-device environment for this branch was set up and used to verify the sibling agents-mobile PRs: an **iPhone 17 (iOS 26.4) Simulator** in mobile Safari, **signed in with a real GitHub account** and connected to a **real agent host** (the `osvaldos-macbook-pro` tunnel) — no mocks.

This change affects the **phone confirmation dialog layout**, which needs at least one session present in the list to exercise. The connected host had no sessions during this pass, and a session could not be created on-device because the iOS Simulator cannot focus the web compose editor to submit a prompt (and the seeded dev host is blocked by mixed-content over HTTPS). The verification screenshot will be added once a live session exists on the host.

The change is scoped (CSS only) and was validated by code review; the behavior was originally identified during real-device analysis of the shipped mobile layer.
