### PR TITLE
agentHost: filter local AHP actions by subscription

### DIFF
--- a/src/vs/platform/agentHost/common/state/agentSubscription.ts
+++ b/src/vs/platform/agentHost/common/state/agentSubscription.ts
@@ -1081,6 +1081,24 @@ export class AgentSubscriptionManager extends Disposable {
 	}
 }
 
+/** Returns whether an action envelope targets one of the subscribed channel URIs. */
+export function isActionEnvelopeRelevantToSubscriptionUris(envelope: ActionEnvelope, subscribedUris: Iterable<string>): boolean {
+	if (isAhpRootChannel(envelope.channel)) {
+		for (const uri of subscribedUris) {
+			if (isAhpRootChannel(uri)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	for (const uri of subscribedUris) {
+		if (uri === envelope.channel) {
+			return true;
+		}
+	}
+	return false;
+}
+
 // --- Observable Adapter ------------------------------------------------------
 
 /**

--- a/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
+++ b/src/vs/platform/agentHost/electron-browser/localAgentHostService.ts
@@ -18,7 +18,7 @@ import { ILogService } from '../../log/common/log.js';
 import { AgentHostAhpJsonlLoggingSettingId, AgentHostIpcChannels, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentHostInspectInfo, IAgentHostService, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, AuthenticateParams, AuthenticateResult, IAgentHostSocketInfo, IConnectionTrackerService, isAgentHostEnabled, IMcpNotification } from '../common/agentService.js';
 import { AhpJsonlLogger } from '../common/ahpJsonlLogger.js';
 import { wrapAgentServiceWithAhpLogging } from './localAhpJsonlLogging.js';
-import { AgentSubscriptionManager, type IActiveSubscriptionInfo, type IAgentSubscription } from '../common/state/agentSubscription.js';
+import { AgentSubscriptionManager, isActionEnvelopeRelevantToSubscriptionUris, type IActiveSubscriptionInfo, type IAgentSubscription } from '../common/state/agentSubscription.js';
 import type { CompletionsParams, CompletionsResult, CreateTerminalParams, ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../common/state/protocol/commands.js';
 import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } from '../common/state/protocol/channels-changeset/commands.js';
 import { ActionType, type ActionEnvelope, type INotification, type IRootConfigChangedAction, type SessionAction, type TerminalAction, type ClientAnnotationsAction } from '../common/state/sessionActions.js';
@@ -49,6 +49,7 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 	private readonly _ahpLogger: AhpJsonlLogger | undefined;
 	private readonly _connectionTracker: IConnectionTrackerService;
 	private readonly _subscriptionManager: AgentSubscriptionManager;
+	private readonly _subscribedResources = new Map<string, number>();
 
 	private readonly _onAgentHostExit = this._register(new Emitter<number>());
 	readonly onAgentHostExit = this._onAgentHostExit.event;
@@ -157,6 +158,9 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 
 		store.add(this._proxy.onDidAction(e => {
 			const revived = revive(e) as ActionEnvelope;
+			if (!isActionEnvelopeRelevantToSubscriptionUris(revived, this._subscribedResources.keys())) {
+				return;
+			}
 			if (this._ahpLogger) {
 				const frame = { jsonrpc: '2.0' as const, method: 'action', params: e };
 				this._ahpLogger.log(frame, 's2c');
@@ -269,10 +273,33 @@ export class LocalAgentHostServiceClient extends Disposable implements IAgentHos
 		return this._proxy.shutdown();
 	}
 	private subscribe(resource: URI): Promise<IStateSnapshot> {
-		return this._proxy.subscribe(resource, this.clientId);
+		this._addSubscribedResource(resource);
+		return this._proxy.subscribe(resource, this.clientId).catch(err => {
+			this._removeSubscribedResource(resource);
+			throw err;
+		});
 	}
 	private unsubscribe(resource: URI): void {
+		this._removeSubscribedResource(resource);
 		this._proxy.unsubscribe(resource, this.clientId);
+	}
+
+	private _addSubscribedResource(resource: URI): void {
+		const key = resource.toString();
+		this._subscribedResources.set(key, (this._subscribedResources.get(key) ?? 0) + 1);
+	}
+
+	private _removeSubscribedResource(resource: URI): void {
+		const key = resource.toString();
+		const count = this._subscribedResources.get(key);
+		if (count === undefined) {
+			return;
+		}
+		if (count === 1) {
+			this._subscribedResources.delete(key);
+		} else {
+			this._subscribedResources.set(key, count - 1);
+		}
 	}
 	dispatchAction(channel: string, action: SessionAction | TerminalAction | ClientAnnotationsAction | IRootConfigChangedAction, clientId: string, clientSeq: number): void {
 		this._proxy.dispatchAction(channel, action, clientId, clientSeq);

--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -6,12 +6,14 @@
 import { disposableTimeout } from '../../../base/common/async.js';
 import { Emitter } from '../../../base/common/event.js';
 import { isJsonRpcResponse } from '../../../base/common/jsonRpcProtocol.js';
+import { Iterable } from '../../../base/common/iterator.js';
 import { Disposable, DisposableMap, DisposableStore } from '../../../base/common/lifecycle.js';
 import { hasKey } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
 import { ILogService } from '../../log/common/log.js';
 import { AHPFileSystemProvider } from '../common/agentHostFileSystemProvider.js';
 import { AgentSession, type IAgentService, type IMcpNotification } from '../common/agentService.js';
+import { isActionEnvelopeRelevantToSubscriptionUris } from '../common/state/agentSubscription.js';
 import type { CommandMap } from '../common/state/protocol/messages.js';
 import { ActionEnvelope, ActionType, INotification, isChatAction, isSessionAction, isTerminalAction, type ChatAction, type SessionAction, type TerminalAction, type IRootConfigChangedAction } from '../common/state/sessionActions.js';
 import { PROTOCOL_VERSION } from '../common/state/protocol/version/registry.js';
@@ -37,7 +39,7 @@ import {
 	type IStateSnapshot,
 	type SubscribeResult,
 } from '../common/state/sessionProtocol.js';
-import { isAhpResourceWatchChannel, isAhpRootChannel, ResponsePartKind, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, buildDefaultChatUri, isAhpChatChannel, parseChatUri, parseDefaultChatUri, type ISessionWithDefaultChat, type SessionState } from '../common/state/sessionState.js';
+import { isAhpResourceWatchChannel, ResponsePartKind, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, buildDefaultChatUri, isAhpChatChannel, parseChatUri, parseDefaultChatUri, type ISessionWithDefaultChat, type SessionState } from '../common/state/sessionState.js';
 import type { IProtocolServer, IProtocolTransport } from '../common/state/sessionTransport.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
 import {
@@ -1409,21 +1411,11 @@ export class ProtocolServerHandler extends Disposable {
 	}
 
 	private _isRelevantToClient(client: IConnectedClient, envelope: ActionEnvelope): boolean {
-		// The root channel has two equivalent string forms (`ahp-root://` and
-		// the URI-roundtripped `ahp-root:`). Treat them interchangeably so a
-		// client that subscribed with either form receives root broadcasts
-		// regardless of which form the envelope carries. See
-		// {@link isAhpRootChannel}.
-		if (isAhpRootChannel(envelope.channel)) {
-			for (const sub of client.subscriptions.values()) {
-				if (sub.kind === ChannelKind.State && isAhpRootChannel(sub.uri)) {
-					return true;
-				}
-			}
-			return false;
-		}
-		const sub = client.subscriptions.get(envelope.channel);
-		return sub?.kind === ChannelKind.State || sub?.kind === ChannelKind.ResourceWatch;
+		const subscribedUris = Iterable.map(
+			Iterable.filter(client.subscriptions.values(), sub => sub.kind === ChannelKind.State || sub.kind === ChannelKind.ResourceWatch),
+			sub => sub.uri,
+		);
+		return isActionEnvelopeRelevantToSubscriptionUris(envelope, subscribedUris);
 	}
 
 	override dispose(): void {

--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -6,7 +6,6 @@
 import { disposableTimeout } from '../../../base/common/async.js';
 import { Emitter } from '../../../base/common/event.js';
 import { isJsonRpcResponse } from '../../../base/common/jsonRpcProtocol.js';
-import { Iterable } from '../../../base/common/iterator.js';
 import { Disposable, DisposableMap, DisposableStore } from '../../../base/common/lifecycle.js';
 import { hasKey } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
@@ -39,7 +38,7 @@ import {
 	type IStateSnapshot,
 	type SubscribeResult,
 } from '../common/state/sessionProtocol.js';
-import { isAhpResourceWatchChannel, ResponsePartKind, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, buildDefaultChatUri, isAhpChatChannel, parseChatUri, parseDefaultChatUri, type ISessionWithDefaultChat, type SessionState } from '../common/state/sessionState.js';
+import { isAhpResourceWatchChannel, isAhpRootChannel, ResponsePartKind, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, buildDefaultChatUri, isAhpChatChannel, parseChatUri, parseDefaultChatUri, type ISessionWithDefaultChat, type SessionState } from '../common/state/sessionState.js';
 import type { IProtocolServer, IProtocolTransport } from '../common/state/sessionTransport.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
 import {
@@ -1411,11 +1410,22 @@ export class ProtocolServerHandler extends Disposable {
 	}
 
 	private _isRelevantToClient(client: IConnectedClient, envelope: ActionEnvelope): boolean {
-		const subscribedUris = Iterable.map(
-			Iterable.filter(client.subscriptions.values(), sub => sub.kind === ChannelKind.State || sub.kind === ChannelKind.ResourceWatch),
-			sub => sub.uri,
-		);
-		return isActionEnvelopeRelevantToSubscriptionUris(envelope, subscribedUris);
+		const sub = client.subscriptions.get(envelope.channel);
+		if (sub?.kind === ChannelKind.State || sub?.kind === ChannelKind.ResourceWatch) {
+			return true;
+		}
+		if (!isAhpRootChannel(envelope.channel)) {
+			return false;
+		}
+		return isActionEnvelopeRelevantToSubscriptionUris(envelope, this._stateAndResourceWatchUris(client));
+	}
+
+	private *_stateAndResourceWatchUris(client: IConnectedClient): Iterable<string> {
+		for (const sub of client.subscriptions.values()) {
+			if (sub.kind === ChannelKind.State || sub.kind === ChannelKind.ResourceWatch) {
+				yield sub.uri;
+			}
+		}
 	}
 
 	override dispose(): void {

--- a/src/vs/platform/agentHost/test/common/agentSubscription.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentSubscription.test.ts
@@ -10,7 +10,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { ActionType, type ActionEnvelope } from '../../common/state/sessionActions.js';
 import { MessageKind, SessionLifecycle, SessionStatus, TerminalClaimKind, TurnState, type RootState, type SessionState, type TerminalState } from '../../common/state/protocol/state.js';
 import { buildDefaultChatUri, createChatState, createDefaultChatSummary, ROOT_STATE_URI, StateComponents, type ChatState } from '../../common/state/sessionState.js';
-import { AgentSubscriptionManager, ChatStateSubscription, RootStateSubscription, SessionStateSubscription, TerminalStateSubscription } from '../../common/state/agentSubscription.js';
+import { AgentSubscriptionManager, ChatStateSubscription, isActionEnvelopeRelevantToSubscriptionUris, RootStateSubscription, SessionStateSubscription, TerminalStateSubscription } from '../../common/state/agentSubscription.js';
 
 // Helpers
 
@@ -636,6 +636,27 @@ suite('AgentSubscriptionManager', () => {
 		assert.strictEqual((ref.object.value as SessionState).summary.title, 'Routed');
 
 		ref.dispose();
+	});
+
+	test('isActionEnvelopeRelevantToSubscriptionUris filters by subscribed channel', () => {
+		assert.deepStrictEqual({
+			rootVariant: isActionEnvelopeRelevantToSubscriptionUris(
+				makeEnvelope({ type: ActionType.RootActiveSessionsChanged, activeSessions: 1 }, 1, undefined, undefined, ROOT_STATE_URI),
+				['ahp-root:'],
+			),
+			rootOnlyGetsSession: isActionEnvelopeRelevantToSubscriptionUris(
+				makeEnvelope({ type: ActionType.SessionTitleChanged, title: 'Nope' }, 2),
+				['ahp-root:'],
+			),
+			exactSession: isActionEnvelopeRelevantToSubscriptionUris(
+				makeEnvelope({ type: ActionType.SessionTitleChanged, title: 'Yep' }, 3),
+				['ahp-root:', sessionUri],
+			),
+		}, {
+			rootVariant: true,
+			rootOnlyGetsSession: false,
+			exactSession: true,
+		});
 	});
 
 	test('creating session subscription for copilot: URI', async () => {


### PR DESCRIPTION
Fix logging duplicate AHP files

## Summary
- filter local AHP action events against each client's active subscriptions before JSONL logging and state delivery
- share the action relevance helper with the remote protocol server path
- add regression coverage for root URI variants and session-channel filtering

## Validation
- npm run typecheck-client
- npm run transpile-client
- npm run valid-layers-check
- ./scripts/test.sh --grep "isActionEnvelopeRelevantToSubscriptionUris"
- ./scripts/test.sh --grep "AgentSubscriptionManager"

Note: full npm run hygiene currently fails on unrelated pre-existing design-token hygiene errors outside this change. The commit pre-commit hygiene hook passed for the staged changes. (Written by Copilot)