### PR TITLE
Agents mobile: separate top bar from filter chips for reliable taps

### DIFF
--- a/src/vs/sessions/browser/parts/mobile/media/mobileSessionFilterChips.css
+++ b/src/vs/sessions/browser/parts/mobile/media/mobileSessionFilterChips.css
@@ -12,7 +12,8 @@
 	display: flex;
 	align-items: center;
 	gap: 6px;
-	padding: 4px 10px 8px;
+	margin-top: 4px;
+	padding: 0 10px 4px;
 	flex-shrink: 0;
 }
 
@@ -40,45 +41,61 @@
 	display: inline-flex;
 	align-items: center;
 	gap: 4px;
-	padding: 4px 10px;
+	position: relative;
+	padding: 0 10px;
 	border-radius: var(--vscode-cornerRadius-circle);
-	font-size: 12px;
+	font-size: var(--vscode-agents-fontSize-label1);
 	line-height: 18px;
 	white-space: nowrap;
 	cursor: pointer;
 	-webkit-user-select: none;
 	user-select: none;
 	touch-action: manipulation;
-	min-height: 28px;
-	border: 1px solid var(--vscode-widget-border, color-mix(in srgb, var(--vscode-foreground) 15%, transparent));
+	min-height: 44px;
+	border: none;
 	background-color: transparent;
 	color: var(--vscode-foreground);
 	transition: background-color 0.1s ease, border-color 0.1s ease, color 0.1s ease;
 	flex-shrink: 0;
 }
 
+.mobile-session-filter-chip::before {
+	content: '';
+	position: absolute;
+	inset: 8px 0;
+	border-radius: var(--vscode-cornerRadius-circle);
+	border: var(--vscode-strokeThickness) solid var(--vscode-widget-border, color-mix(in srgb, var(--vscode-foreground) 15%, transparent));
+	background-color: transparent;
+	transition: background-color 0.1s ease, border-color 0.1s ease;
+}
+
 .mobile-session-filter-chip:active {
 	opacity: 0.7;
 }
 
-.mobile-session-filter-chip.active {
+.mobile-session-filter-chip.active::before {
 	background-color: var(--vscode-badge-background);
-	color: var(--vscode-badge-foreground);
 	border-color: var(--vscode-badge-background);
 }
 
+.mobile-session-filter-chip.active {
+	color: var(--vscode-badge-foreground);
+}
+
 .mobile-session-filter-chip.icon-only {
-	min-width: 32px;
-	padding: 4px 8px;
+	min-width: 44px;
+	padding: 0 8px;
 	justify-content: center;
 }
 
 .mobile-session-filter-chip .chip-icon {
-	font-size: 14px;
+	font-size: var(--vscode-codiconFontSize);
 	display: flex;
 	align-items: center;
+	position: relative;
 }
 
 .mobile-session-filter-chip .chip-label {
 	flex-shrink: 0;
+	position: relative;
 }

--- a/src/vs/sessions/browser/parts/mobile/mobileChatShell.css
+++ b/src/vs/sessions/browser/parts/mobile/mobileChatShell.css
@@ -71,20 +71,34 @@
 
 .mobile-top-bar .mobile-top-bar-button.mobile-changes-pill {
 	width: auto;
-	height: 28px;
+	min-width: 44px;
+	height: 44px;
 	padding: 0 10px;
+	position: relative;
 	border-radius: var(--vscode-cornerRadius-circle);
 	gap: 4px;
 	font-size: var(--vscode-agents-fontSize-label1);
 	line-height: 18px;
 	font-variant-numeric: tabular-nums;
-	border: 1px solid var(--vscode-widget-border, color-mix(in srgb, var(--vscode-foreground) 15%, transparent));
+	border: none;
 	background: transparent;
 	color: var(--vscode-foreground);
 }
 
+.mobile-top-bar .mobile-top-bar-button.mobile-changes-pill::before {
+	content: '';
+	position: absolute;
+	inset: 8px 0;
+	border-radius: var(--vscode-cornerRadius-circle);
+	border: var(--vscode-strokeThickness) solid var(--vscode-widget-border, color-mix(in srgb, var(--vscode-foreground) 15%, transparent));
+}
+
+.mobile-top-bar .mobile-changes-pill > span {
+	position: relative;
+}
+
 .mobile-top-bar .mobile-changes-pill .mobile-changes-pill-icon {
-	font-size: 14px;
+	font-size: var(--vscode-codiconFontSize);
 	color: var(--vscode-descriptionForeground);
 	display: flex;
 	align-items: center;
@@ -113,6 +127,10 @@
 .mobile-top-bar .mobile-session-title {
 	flex: 1;
 	min-width: 0;
+	min-height: 44px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	text-align: center;
 	font-size: 16px;
 	font-weight: var(--vscode-agents-fontWeight-semiBold);
@@ -159,6 +177,31 @@
 .mobile-top-bar.show-actions .mobile-top-bar-actions {
 	display: flex;
 	flex-direction: column;
+}
+
+.mobile-top-bar .monaco-toolbar,
+.mobile-top-bar .monaco-action-bar,
+.mobile-top-bar .monaco-action-bar > .actions-container {
+	height: 100%;
+	min-width: 0;
+	display: flex;
+	align-items: center;
+}
+
+.mobile-top-bar .monaco-action-bar .action-item.agent-host-filter-combo {
+	height: 44px;
+	padding-right: 0;
+}
+
+.mobile-top-bar .agent-host-filter-combo .agent-host-filter-dropdown {
+	height: 44px;
+	min-height: 44px;
+}
+
+.mobile-top-bar .agent-host-filter-combo .agent-host-filter-connect {
+	width: 44px;
+	height: 44px;
+	margin-left: 0;
 }
 
 /* ---- Phone Layout: Full-screen chat ---- */


### PR DESCRIPTION
Problem:\n- On phone, the Agents mobile top bar and session filter chips were vertically dense, so taps aimed at chips could land on titlebar controls.\n\nFix:\n- Add a small safe gap above the mobile filter chip row.\n- Expand top-bar controls and filter chips to 44px touch targets while keeping the visual pills compact.\n- Keep the change scoped to phone/mobile chrome CSS.\n\nVerification:\n- [x] npm run typecheck-client\n- [x] npm run valid-layers-check\n- [ ] npm run precommit (blocked locally by missing shared node_modules package: gulp-merge-json)\n- [ ] scripts/test.sh --grep "Sessions" (blocked locally by missing shared node_modules package: gulp-merge-json)\n\nPart of the Agents window mobile UX PR series.
---

## ✅ On-device verification (iOS Simulator)

Verified on an **iPhone 17 (iOS 26.4) Simulator** in mobile Safari, running a build of this branch, **signed in with a real GitHub account** and connected to a **real agent host** (the `osvaldos-macbook-pro` tunnel) — real filesystem browsing, real auth, **no mocks**.

**Filter chips are reliably tappable**

<img src="https://raw.githubusercontent.com/microsoft/vscode/13cc47740f12890a86a79e1f6b42943211f33678/.verification-shots/pr5-filter-chip-toggle.png" width="300" />

_The **Completed** filter chip is now reliably tappable and toggles to its active state — previously the chip-lane scroll handler intercepted the tap and the chips could not be actuated._
