### PR TITLE
Agents mobile: keep picker bottom sheet above the keyboard

### DIFF
--- a/src/vs/sessions/browser/parts/mobile/media/mobilePickerSheet.css
+++ b/src/vs/sessions/browser/parts/mobile/media/mobilePickerSheet.css
@@ -15,6 +15,7 @@
 .mobile-picker-sheet-overlay {
 	position: fixed;
 	inset: 0;
+	bottom: var(--vscode-keyboard-height, 0px);
 	z-index: 2000;
 	display: flex;
 	flex-direction: column;
@@ -40,7 +41,7 @@
 .mobile-picker-sheet {
 	position: relative;
 	width: 100%;
-	max-height: 80vh;
+	max-height: min(80vh, calc(100vh - var(--vscode-keyboard-height, 0px)));
 	display: flex;
 	flex-direction: column;
 	background: var(--vscode-menu-background, var(--vscode-editor-background));
@@ -231,6 +232,7 @@
 
 .mobile-picker-sheet-list {
 	flex: 1 1 auto;
+	min-height: 0;
 	overflow-y: auto;
 	-webkit-overflow-scrolling: touch;
 	padding: 4px 8px 12px;
@@ -246,6 +248,7 @@
  * correctly under iOS regardless of what DOM the caller puts inside. */
 .mobile-content-sheet-body {
 	flex: 1 1 auto;
+	min-height: 0;
 	overflow-y: auto;
 	-webkit-overflow-scrolling: touch;
 	touch-action: pan-y;


### PR DESCRIPTION
Part of a series of Agents mobile UX fixes.

## Problem
On iOS, mobile picker sheets with inline search auto-focus the search field, causing the soft keyboard to cover the bottom of the fixed bottom sheet. The sheet content could then scroll the drag handle, title row, Done button, and search field off the top, leaving a large white void and unstable tap targets.

## Fix
- Anchor the picker overlay above the globally maintained `--vscode-keyboard-height` while preserving safe-area padding.
- Reduce the sheet max height by the keyboard height so it fits in the visible area above the keyboard.
- Allow the list/body flex children to shrink and become the only scroll containers, keeping the header and inline search pinned.

## Verification
- [x] `npm run typecheck-client`
- [x] `npm run valid-layers-check`
- [x] Manually reviewed the scoped CSS diff for tab indentation and correctness.
---

## ✅ On-device verification (iOS Simulator)

Verified on an **iPhone 17 (iOS 26.4) Simulator** in mobile Safari, running a build of this branch, **signed in with a real GitHub account** and connected to a **real agent host** (the `osvaldos-macbook-pro` tunnel) — real filesystem browsing, real auth, **no mocks**.

**Picker sheet stays above the keyboard**

<img src="https://raw.githubusercontent.com/microsoft/vscode/13cc47740f12890a86a79e1f6b42943211f33678/.verification-shots/pr2-keyboard-aware-sheet.png" width="300" />

_Focusing the picker search field: the **Choose Workspace** header, **Done**, and the search box stay pinned and fully visible directly above the keyboard — the folder list fills the remaining space with no white void (the original bug)._
