### PR TITLE
Agents mobile: UX improvements to open workspace action

### DIFF
--- a/src/vs/sessions/browser/parts/mobile/media/mobilePickerSheet.css
+++ b/src/vs/sessions/browser/parts/mobile/media/mobilePickerSheet.css
@@ -236,6 +236,97 @@
 	padding: 4px 8px 12px;
 }
 
+/* Static items (e.g. recents) wrapper. `display: contents` so the
+ * wrapper itself adds no box; the search flow toggles it to
+ * `display: none` while a query is active to hide recents. */
+.mobile-picker-sheet-static {
+	display: contents;
+}
+
+/* Pinned primary action region between the search input and the list.
+ * Holds a single prominent confirm button that stays put as the list
+ * scrolls. Hidden (via inline `display: none`) when no action is set. */
+.mobile-picker-sheet-pinned {
+	flex-shrink: 0;
+	padding: 0 8px 4px;
+}
+
+/* Filled primary action button — the single confirm affordance (e.g.
+ * "Open this folder"). Uses the workbench button tokens so it reads as
+ * the primary call to action and themes correctly. */
+.mobile-picker-sheet-primary-action {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	width: 100%;
+	min-height: 56px;
+	padding: 10px 12px;
+	margin: 2px 0;
+	border: none;
+	border-radius: var(--vscode-cornerRadius-xLarge);
+	/* Emphasized but lightweight: a low-opacity `textLink-foreground` tint
+	 * rather than a saturated filled button, so the action reads as the
+	 * primary choice while staying consistent with the muted rows below. */
+	background: color-mix(in srgb, var(--vscode-textLink-foreground) 14%, transparent);
+	color: var(--vscode-textLink-foreground);
+	font-family: inherit;
+	font-size: 16px;
+	text-align: left;
+	cursor: pointer;
+	touch-action: manipulation;
+	-webkit-tap-highlight-color: transparent;
+}
+
+.mobile-picker-sheet-primary-action:focus {
+	outline: none;
+}
+
+.mobile-picker-sheet-primary-action:focus-visible {
+	outline: 2px solid var(--vscode-focusBorder);
+	outline-offset: -2px;
+}
+
+.mobile-picker-sheet-primary-action:active {
+	background: color-mix(in srgb, var(--vscode-textLink-foreground) 22%, transparent);
+}
+
+.mobile-picker-sheet-primary-action-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 36px;
+	height: 36px;
+	border-radius: var(--vscode-cornerRadius-large);
+	/* Accent-tinted tile with an accent glyph: emphasized without the
+	 * glare of a solid white tile, and it fills the 36px slot so the icon
+	 * column lines up with the folder rows below. */
+	background: color-mix(in srgb, var(--vscode-textLink-foreground) 22%, transparent);
+	color: var(--vscode-textLink-foreground);
+	flex-shrink: 0;
+}
+
+.mobile-picker-sheet-primary-action-icon-glyph {
+	font-size: 18px;
+	line-height: 1;
+}
+
+.mobile-picker-sheet-primary-action-text {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.mobile-picker-sheet-primary-action-label {
+	font-size: 16px;
+	font-weight: 600;
+	line-height: 1.2;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 /* Body container for the shell-only `showMobileContentSheet` variant.
  * Where the picker sheet builds its own scrollable list of rows
  * (`.mobile-picker-sheet-list`) inside the sheet flex column, the
@@ -380,6 +471,24 @@
 
 .mobile-picker-sheet-check-glyph {
 	font-size: 14px;
+	line-height: 1;
+}
+
+/* Trailing chevron for navigational rows (tap drills deeper). Muted so
+ * it reads as a navigation affordance, not a selection state. */
+.mobile-picker-sheet-chevron {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 20px;
+	height: 20px;
+	color: var(--vscode-descriptionForeground);
+	flex-shrink: 0;
+	opacity: 0.8;
+}
+
+.mobile-picker-sheet-chevron-glyph {
+	font-size: 16px;
 	line-height: 1;
 }
 

--- a/src/vs/sessions/browser/parts/mobile/media/mobilePickerSheet.css
+++ b/src/vs/sessions/browser/parts/mobile/media/mobilePickerSheet.css
@@ -306,7 +306,7 @@
 }
 
 .mobile-picker-sheet-primary-action-icon-glyph {
-	font-size: 18px;
+	font-size: 16px;
 	line-height: 1;
 }
 

--- a/src/vs/sessions/browser/parts/mobile/mobilePickerSheet.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobilePickerSheet.ts
@@ -29,6 +29,13 @@ export interface IMobilePickerSheetItem {
 	readonly checked?: boolean;
 	readonly disabled?: boolean;
 	/**
+	 * When true, the row is rendered with a trailing chevron to signal
+	 * that tapping it navigates deeper (drill-down) rather than selecting
+	 * a final value. Navigational rows never show the radio checkmark and
+	 * are excluded from the in-section radio toggle.
+	 */
+	readonly navigates?: boolean;
+	/**
 	 * Optional section title shown above this row. When set, a divider is
 	 * inserted above the row (for sections after the first) and the title
 	 * text is rendered as a small uppercase label. Pass an empty string
@@ -82,8 +89,7 @@ export interface IMobilePickerSheetOptions {
 	/**
 	 * Called when a row is tapped and {@link stayOpenOnSelect} is true.
 	 * Callers should write-through the selection (e.g.
-	 * `provider.setSessionConfigValue`) and optionally update the
-	 * sheet's visual state via {@link IMobilePickerSheetController}.
+	 * `provider.setSessionConfigValue`).
 	 *
 	 * If the callback returns a string, that string is injected into
 	 * the search input and a new query is triggered — use this for
@@ -97,6 +103,25 @@ export interface IMobilePickerSheetOptions {
 	 * Ignored when `stayOpenOnSelect` is false.
 	 */
 	readonly onDidSelect?: (id: string) => string | typeof MOBILE_PICKER_SHEET_CONFIRM | void;
+
+	/**
+	 * Optional override for the dismiss button label (defaults to "Done").
+	 * Use "Cancel" for sheets where rows self-confirm on tap and the
+	 * header button is purely a dismiss affordance.
+	 */
+	readonly doneLabel?: string;
+}
+
+/**
+ * A pinned, single primary action rendered above the scrollable list.
+ * Tapping it runs {@link run} and then closes the sheet. Produced by
+ * {@link IMobilePickerSheetSearchSource.getPrimaryAction} for the current
+ * query.
+ */
+export interface IMobilePickerSheetPrimaryAction {
+	readonly label: string;
+	readonly icon?: ThemeIcon;
+	readonly run: () => void;
 }
 
 export interface IMobilePickerSheetHeaderAction {
@@ -123,6 +148,13 @@ export interface IMobilePickerSheetSearchSource {
 	readonly emptyMessage?: string;
 	/** Loads the result rows for the given query. */
 	loadItems(query: string, token: CancellationToken): Promise<readonly IMobilePickerSheetItem[]>;
+	/**
+	 * Optional pinned primary action for the given query, rendered above
+	 * the result list. Return `undefined` to hide it. Called on every
+	 * query change, so the action can track the browse state (e.g. an
+	 * "Open this folder" button that follows the folder being browsed).
+	 */
+	getPrimaryAction?(query: string): IMobilePickerSheetPrimaryAction | undefined;
 }
 
 /**
@@ -218,6 +250,7 @@ export function showMobilePickerSheet(
 		const shell: IMobileSheetShell = buildMobileSheetShell(workbenchContainer, title, {
 			caption: options?.caption,
 			headerActions: options?.headerActions,
+			doneLabel: options?.doneLabel,
 			onDismiss: () => finish(undefined),
 			onHeaderAction: actionId => finish(`${MOBILE_PICKER_SHEET_HEADER_ACTION_PREFIX}${actionId}`),
 		});
@@ -238,6 +271,40 @@ export function showMobilePickerSheet(
 			searchInput.setAttribute('aria-label', options.search.ariaLabel ?? options.search.placeholder);
 		}
 
+		// -- Pinned primary action -------------------------------------
+		// Optional single, prominent confirm action that sits above the
+		// scrollable list and stays put as the list scrolls. Refreshed
+		// from `search.getPrimaryAction(query)` on every query change;
+		// tapping it runs the action and closes the sheet.
+		const pinnedContainer = DOM.append(sheet, $('div.mobile-picker-sheet-pinned'));
+		pinnedContainer.style.display = 'none';
+		const pinnedStore = disposables.add(new DisposableStore());
+		const setPrimaryAction = (action: IMobilePickerSheetPrimaryAction | undefined) => {
+			pinnedStore.clear();
+			DOM.clearNode(pinnedContainer);
+			if (!action) {
+				pinnedContainer.style.display = 'none';
+				return;
+			}
+			pinnedContainer.style.display = '';
+			const btn = DOM.append(pinnedContainer, $('button.mobile-picker-sheet-primary-action', { type: 'button' })) as HTMLButtonElement;
+			btn.setAttribute('aria-label', action.label);
+			if (action.icon) {
+				const iconSlot = DOM.append(btn, $('span.mobile-picker-sheet-primary-action-icon'));
+				const iconGlyph = DOM.append(iconSlot, $('span.mobile-picker-sheet-primary-action-icon-glyph'));
+				iconGlyph.classList.add(...ThemeIcon.asClassNameArray(action.icon));
+			}
+			const textCol = DOM.append(btn, $('span.mobile-picker-sheet-primary-action-text'));
+			DOM.append(textCol, $('span.mobile-picker-sheet-primary-action-label')).textContent = action.label;
+			// Plain `click` only (no Gesture/Tap) so the action runs
+			// exactly once on touch-tap; `run` is not idempotent.
+			pinnedStore.add(DOM.addDisposableListener(btn, DOM.EventType.CLICK, (e: MouseEvent) => {
+				e.preventDefault();
+				action.run();
+				finish(undefined);
+			}));
+		};
+
 		// -- Items list ------------------------------------------------
 		const list = DOM.append(sheet, $('div.mobile-picker-sheet-list'));
 		list.setAttribute('role', 'list');
@@ -251,7 +318,7 @@ export function showMobilePickerSheet(
 
 		// Registry of rendered rows keyed by section index, used to
 		// toggle checkmarks within a section on tap.
-		const rowsBySection = new Map<number, { row: HTMLButtonElement; checkSlot: HTMLElement; id: string }[]>();
+		const rowsBySection = new Map<number, IMobilePickerSheetRowRef[]>();
 
 		// Mutable reference so handleRowTap can trigger a search-query
 		// update when onDidSelect returns a drill-down string. Populated
@@ -261,10 +328,15 @@ export function showMobilePickerSheet(
 		const handleRowTap = options?.stayOpenOnSelect && options.onDidSelect
 			? (id: string, _row: HTMLElement, sectionIndex: number) => {
 				// Update visual: uncheck all rows in the same section,
-				// then check the tapped row.
+				// then check the tapped row. Skipped for navigational
+				// rows (drill-down) — they don't carry a radio checkmark.
 				const sectionRows = rowsBySection.get(sectionIndex);
-				if (sectionRows) {
+				const targetEntry = sectionRows?.find(entry => entry.id === id);
+				if (sectionRows && !targetEntry?.navigates) {
 					for (const entry of sectionRows) {
+						if (!entry.checkSlot) {
+							continue;
+						}
 						const isTarget = entry.id === id;
 						entry.row.classList.toggle('checked', isTarget);
 						entry.row.setAttribute('aria-current', isTarget ? 'true' : 'false');
@@ -285,9 +357,13 @@ export function showMobilePickerSheet(
 			}
 			: (id: string, _row: HTMLElement, _sectionIndex: number) => { finish(id); };
 
+		// Static items live in their own container so the search flow can
+		// hide them while the user is browsing/searching (a non-empty
+		// query), keeping recents from cluttering search results.
+		const staticContainer = DOM.append(list, $('div.mobile-picker-sheet-static'));
 		const renderState: IRenderState = { firstRow: undefined, firstCheckedRow: undefined, sectionCount: 0 };
 		for (const item of items) {
-			renderRow(list, item, renderState, handleRowTap, disposables, rowsBySection);
+			renderRow(staticContainer, item, renderState, handleRowTap, disposables, rowsBySection);
 		}
 
 		// -- Dynamic search results -----------------------------------
@@ -314,6 +390,10 @@ export function showMobilePickerSheet(
 
 			const renderResults = async (query: string): Promise<void> => {
 				cancelInflight();
+				// Recents (static items) are only relevant at the root.
+				// Once the user types or drills into a path, hide them so
+				// the list shows just the search results.
+				staticContainer.style.display = query ? 'none' : '';
 				const tokens = new CancellationTokenSource();
 				currentQueryTokens = tokens;
 				DOM.clearNode(resultsContainer);
@@ -329,6 +409,10 @@ export function showMobilePickerSheet(
 				if (tokens.token.isCancellationRequested || resolved) {
 					return;
 				}
+				// Refresh the pinned primary action for the live query
+				// (only after the cancellation check so stale queries
+				// don't leave a mismatched action behind).
+				setPrimaryAction(search.getPrimaryAction?.(query));
 				DOM.clearNode(resultsContainer);
 
 				const localState: IRenderState = { firstRow: undefined, firstCheckedRow: undefined, sectionCount: 0 };
@@ -662,6 +746,18 @@ interface IRenderState {
 }
 
 /**
+ * A rendered row registered per section so `stayOpenOnSelect` mode can
+ * toggle the radio checkmark within a section on tap. Navigational rows
+ * have no {@link checkSlot} and are skipped by the toggle.
+ */
+interface IMobilePickerSheetRowRef {
+	readonly row: HTMLButtonElement;
+	readonly checkSlot?: HTMLElement;
+	readonly id: string;
+	readonly navigates?: boolean;
+}
+
+/**
  * Append a single picker row (and any preceding section divider) to the
  * given list element. Wires up touch/click handlers so taps invoke
  * {@link onTap}. Shared between the static items list and the dynamic
@@ -673,7 +769,7 @@ function renderRow(
 	state: IRenderState,
 	onTap: (id: string, row: HTMLButtonElement, sectionIndex: number) => void,
 	disposables: DisposableStore,
-	rowsBySection?: Map<number, { row: HTMLButtonElement; checkSlot: HTMLElement; id: string }[]>,
+	rowsBySection?: Map<number, IMobilePickerSheetRowRef[]>,
 ): void {
 	if (item.sectionTitle !== undefined) {
 		if (state.sectionCount > 0) {
@@ -719,23 +815,32 @@ function renderRow(
 		DOM.append(textCol, $('span.mobile-picker-sheet-description')).textContent = item.description;
 	}
 
-	// Trailing checkmark for the currently-selected row. Same child-span
-	// pattern as the icon slot so flex centering wins over codicon's
-	// `display: inline-block`.
-	const checkSlot = DOM.append(row, $('span.mobile-picker-sheet-check'));
-	if (item.checked) {
-		const checkGlyph = DOM.append(checkSlot, $('span.mobile-picker-sheet-check-glyph'));
-		checkGlyph.classList.add(...ThemeIcon.asClassNameArray(Codicon.check));
+	// Trailing affordance. Navigational rows show a chevron (tap drills
+	// deeper); selectable rows show a checkmark when active. Same
+	// child-span pattern as the icon slot so flex centering wins over
+	// codicon's `display: inline-block`.
+	let checkSlot: HTMLElement | undefined;
+	if (item.navigates && !item.checked) {
+		const chevronSlot = DOM.append(row, $('span.mobile-picker-sheet-chevron'));
+		const chevronGlyph = DOM.append(chevronSlot, $('span.mobile-picker-sheet-chevron-glyph'));
+		chevronGlyph.classList.add(...ThemeIcon.asClassNameArray(Codicon.chevronRight));
+	} else {
+		checkSlot = DOM.append(row, $('span.mobile-picker-sheet-check'));
+		if (item.checked) {
+			const checkGlyph = DOM.append(checkSlot, $('span.mobile-picker-sheet-check-glyph'));
+			checkGlyph.classList.add(...ThemeIcon.asClassNameArray(Codicon.check));
+		}
 	}
 
 	// Register this row so `stayOpenOnSelect` mode can toggle
 	// checkmarks within the same section on tap.
 	if (rowsBySection) {
+		const entry: IMobilePickerSheetRowRef = { row, checkSlot, id: item.id, navigates: item.navigates };
 		const sectionRows = rowsBySection.get(state.sectionCount);
 		if (sectionRows) {
-			sectionRows.push({ row, checkSlot, id: item.id });
+			sectionRows.push(entry);
 		} else {
-			rowsBySection.set(state.sectionCount, [{ row, checkSlot, id: item.id }]);
+			rowsBySection.set(state.sectionCount, [entry]);
 		}
 	}
 

--- a/src/vs/sessions/browser/parts/mobile/mobilePickerSheet.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobilePickerSheet.ts
@@ -376,6 +376,18 @@ export function showMobilePickerSheet(
 			const resultsContainer = DOM.append(list, $('div.mobile-picker-sheet-search-results'));
 			let currentQueryTokens: CancellationTokenSource | undefined;
 			let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+			const searchSectionBase = renderState.sectionCount + 1;
+			const pruneSearchRows = () => {
+				for (const key of [...rowsBySection.keys()]) {
+					if (key >= searchSectionBase) {
+						rowsBySection.delete(key);
+					}
+				}
+			};
+			// Row listeners for search results are scoped here (not to the
+			// sheet-lifetime store) and cleared on each re-render so we
+			// don't accumulate handlers bound to detached rows.
+			const searchRowsStore = disposables.add(new DisposableStore());
 
 			const cancelInflight = () => {
 				currentQueryTokens?.cancel();
@@ -397,6 +409,8 @@ export function showMobilePickerSheet(
 				const tokens = new CancellationTokenSource();
 				currentQueryTokens = tokens;
 				DOM.clearNode(resultsContainer);
+				pruneSearchRows();
+				searchRowsStore.clear();
 				const status = DOM.append(resultsContainer, $('div.mobile-picker-sheet-search-status'));
 				status.textContent = localize('mobilePickerSheet.searching', "Searching…");
 
@@ -415,7 +429,7 @@ export function showMobilePickerSheet(
 				setPrimaryAction(search.getPrimaryAction?.(query));
 				DOM.clearNode(resultsContainer);
 
-				const localState: IRenderState = { firstRow: undefined, firstCheckedRow: undefined, sectionCount: 0 };
+				const localState: IRenderState = { firstRow: undefined, firstCheckedRow: undefined, sectionCount: searchSectionBase };
 				if (search.resultsSectionTitle) {
 					const sectionTitle = DOM.append(resultsContainer, $('div.mobile-picker-sheet-section-title'));
 					sectionTitle.textContent = search.resultsSectionTitle;
@@ -426,7 +440,7 @@ export function showMobilePickerSheet(
 					return;
 				}
 				for (const item of results) {
-					renderRow(resultsContainer, item, localState, handleRowTap, disposables, rowsBySection);
+					renderRow(resultsContainer, item, localState, handleRowTap, searchRowsStore, rowsBySection);
 				}
 			};
 

--- a/src/vs/sessions/browser/parts/mobile/mobilePickerSheet.ts
+++ b/src/vs/sessions/browser/parts/mobile/mobilePickerSheet.ts
@@ -90,9 +90,13 @@ export interface IMobilePickerSheetOptions {
 	 * drill-down navigation where tapping a folder replaces the query
 	 * with `folderName/` to list its children.
 	 *
+	 * If the callback returns {@link MOBILE_PICKER_SHEET_CONFIRM}, the
+	 * tapped row is treated as confirmed: the sheet resolves with that
+	 * row's id and closes immediately.
+	 *
 	 * Ignored when `stayOpenOnSelect` is false.
 	 */
-	readonly onDidSelect?: (id: string) => string | void;
+	readonly onDidSelect?: (id: string) => string | typeof MOBILE_PICKER_SHEET_CONFIRM | void;
 }
 
 export interface IMobilePickerSheetHeaderAction {
@@ -174,6 +178,11 @@ export interface IMobileContentSheetOptions {
  * regular row selections.
  */
 export const MOBILE_PICKER_SHEET_HEADER_ACTION_PREFIX = 'headerAction:';
+
+/**
+ * Return from `onDidSelect` to confirm the tapped row and close the sheet while `stayOpenOnSelect` is enabled.
+ */
+export const MOBILE_PICKER_SHEET_CONFIRM = Symbol('mobilePickerSheetConfirm');
 
 /**
  * Show a phone-friendly bottom sheet for picker-style choices.
@@ -266,10 +275,12 @@ export function showMobilePickerSheet(
 						}
 					}
 				}
-				const drillDown = options.onDidSelect!(id);
-				if (typeof drillDown === 'string' && searchInput && setSearchQuery) {
-					searchInput.value = drillDown;
-					setSearchQuery(drillDown);
+				const selectResult = options.onDidSelect!(id);
+				if (selectResult === MOBILE_PICKER_SHEET_CONFIRM) {
+					finish(id);
+				} else if (typeof selectResult === 'string' && searchInput && setSearchQuery) {
+					searchInput.value = selectResult;
+					setSearchQuery(selectResult);
 				}
 			}
 			: (id: string, _row: HTMLElement, _sectionIndex: number) => { finish(id); };

--- a/src/vs/sessions/contrib/chat/browser/mobile/mobileWorkspacePickerSheet.ts
+++ b/src/vs/sessions/contrib/chat/browser/mobile/mobileWorkspacePickerSheet.ts
@@ -18,9 +18,6 @@ import { ISessionWorkspaceBrowseAction } from '../../../../services/sessions/com
 /** Prefix used for ids of dynamically-loaded folder rows in the sheet. */
 const SEARCH_RESULT_ID_PREFIX = 'searchResult:';
 
-/** Id for the synthetic row that confirms the currently browsed folder. */
-const USE_CURRENT_FOLDER_ID = 'useFolder:';
-
 /**
  * Plan for translating an action-widget picker entry into mobile sheet
  * rows. Each plan entry pairs the row(s) we'll show in the bottom sheet
@@ -228,15 +225,6 @@ export async function showMobileWorkspacePickerSheet(
 				}
 				const flattened = results.flat();
 				const sheetItems: IMobilePickerSheetItem[] = [];
-				if (currentFolder?.query === query) {
-					folderRunById.set(USE_CURRENT_FOLDER_ID, currentFolder.run);
-					sheetItems.push({
-						id: USE_CURRENT_FOLDER_ID,
-						label: localize('mobileWorkspacePicker.openCurrentFolder', "Open “{0}”", currentFolder.label),
-						icon: Codicon.folderOpened,
-						checked: true,
-					});
-				}
 				flattened.forEach((entry, idx) => {
 					const id = `${SEARCH_RESULT_ID_PREFIX}${idx}`;
 					const folderUri = entry.workspace.folders[0]?.root;
@@ -250,21 +238,29 @@ export async function showMobileWorkspacePickerSheet(
 						label: entry.workspace.label,
 						description: entry.workspace.description,
 						icon: entry.workspace.icon,
+						navigates: true,
 					});
 				});
 				return sheetItems;
+			},
+			// The pinned "Select this folder" action follows the folder
+			// we drilled into (when the live query still matches it),
+			// instead of mixing a confirm row into the navigable list.
+			getPrimaryAction: (query) => {
+				if (currentFolder?.query !== query) {
+					return undefined;
+				}
+				const folder = currentFolder;
+				return {
+					label: localize('mobileWorkspacePicker.selectCurrentFolder', "Select '{0}'", folder.label),
+					icon: Codicon.arrowRight,
+					run: folder.run,
+				};
 			},
 		}
 		: undefined;
 
 	triggerElement.setAttribute('aria-expanded', 'true');
-
-	// Track the last-tapped folder from search results so Done can
-	// dispatch it. In `stayOpenOnSelect` mode, row taps don't close
-	// the sheet — instead they apply the selection and let the user
-	// browse further. The workspace-picker-specific rows (recents)
-	// dispatch immediately on tap since those are confirmed choices.
-	let lastSearchFolderRun: (() => void) | undefined;
 
 	try {
 		await showMobilePickerSheet(
@@ -276,27 +272,20 @@ export async function showMobileWorkspacePickerSheet(
 				search,
 				caption: localize('mobileWorkspacePicker.caption', "Search to browse folders on the host"),
 				stayOpenOnSelect: true,
+				doneLabel: localize('mobileWorkspacePicker.cancel', "Cancel"),
 				onDidSelect: (id) => {
 					if (id.startsWith(MOBILE_PICKER_SHEET_HEADER_ACTION_PREFIX)) {
 						const idx = Number(id.slice(MOBILE_PICKER_SHEET_HEADER_ACTION_PREFIX.length));
 						headerBrowseActions[idx]?.invoke();
 						return;
 					}
-					if (id === USE_CURRENT_FOLDER_ID) {
-						const run = folderRunById.get(id);
-						if (run) {
-							run();
-							lastSearchFolderRun = undefined;
-							return MOBILE_PICKER_SHEET_CONFIRM;
-						}
-						return;
-					}
 					if (id.startsWith(SEARCH_RESULT_ID_PREFIX)) {
+						// Drill down: build a path query from the current
+						// query prefix + this folder's name, e.g.
+						// "projects/" → "projects/subfolder/". Tapping a
+						// folder navigates into it; the pinned "Open this
+						// folder" action confirms the current level.
 						const run = folderRunById.get(id);
-						lastSearchFolderRun = run;
-						// Drill down: build a path query from the
-						// current query prefix + this folder's name,
-						// e.g. "projects/" → "projects/subfolder/".
 						const folderName = folderLabelById.get(id);
 						if (folderName) {
 							// Compute the prefix up to (and including)
@@ -312,22 +301,18 @@ export async function showMobileWorkspacePickerSheet(
 						}
 						return;
 					}
-					// Recent workspace row — dispatch immediately (it
-					// sets the workspace on the session).
+					// Recent workspace row — dispatch immediately and
+					// close (recents are confirmed choices).
 					const row = rows.find(r => r.sheetItem.id === id);
 					if (row) {
 						row.run();
-						lastSearchFolderRun = undefined;
 						currentFolder = undefined;
+						return MOBILE_PICKER_SHEET_CONFIRM;
 					}
 					return;
 				},
 			},
 		);
-
-		// Done was tapped — if the last selection was a search folder,
-		// dispatch it now. Recent rows were already dispatched on tap.
-		lastSearchFolderRun?.();
 	} finally {
 		triggerElement.setAttribute('aria-expanded', 'false');
 		triggerElement.focus();

--- a/src/vs/sessions/contrib/chat/browser/mobile/mobileWorkspacePickerSheet.ts
+++ b/src/vs/sessions/contrib/chat/browser/mobile/mobileWorkspacePickerSheet.ts
@@ -6,7 +6,7 @@
 import { ActionListItemKind, IActionListItem } from '../../../../../platform/actionWidget/browser/actionList.js';
 import { IWorkbenchLayoutService } from '../../../../../workbench/services/layout/browser/layoutService.js';
 import { isPhoneLayout } from '../../../../browser/parts/mobile/mobileLayout.js';
-import { IMobilePickerSheetHeaderAction, IMobilePickerSheetItem, IMobilePickerSheetSearchSource, MOBILE_PICKER_SHEET_HEADER_ACTION_PREFIX, showMobilePickerSheet } from '../../../../browser/parts/mobile/mobilePickerSheet.js';
+import { IMobilePickerSheetHeaderAction, IMobilePickerSheetItem, IMobilePickerSheetSearchSource, MOBILE_PICKER_SHEET_CONFIRM, MOBILE_PICKER_SHEET_HEADER_ACTION_PREFIX, showMobilePickerSheet } from '../../../../browser/parts/mobile/mobilePickerSheet.js';
 import { localize } from '../../../../../nls.js';
 import { IWorkspacePickerItem } from '../sessionWorkspacePicker.js';
 import { SubmenuAction, IAction } from '../../../../../base/common/actions.js';
@@ -18,6 +18,9 @@ import { ISessionWorkspaceBrowseAction } from '../../../../services/sessions/com
 /** Prefix used for ids of dynamically-loaded folder rows in the sheet. */
 const SEARCH_RESULT_ID_PREFIX = 'searchResult:';
 
+/** Id for the synthetic row that confirms the currently browsed folder. */
+const USE_CURRENT_FOLDER_ID = 'useFolder:';
+
 /**
  * Plan for translating an action-widget picker entry into mobile sheet
  * rows. Each plan entry pairs the row(s) we'll show in the bottom sheet
@@ -25,6 +28,12 @@ const SEARCH_RESULT_ID_PREFIX = 'searchResult:';
  */
 type MobilePickerRow = {
 	readonly sheetItem: IMobilePickerSheetItem;
+	readonly run: () => void;
+};
+
+type BrowsedFolder = {
+	readonly query: string;
+	readonly label: string;
 	readonly run: () => void;
 };
 
@@ -192,6 +201,7 @@ export async function showMobileWorkspacePickerSheet(
 	// the sheet can resolve folder taps back to a provider selection.
 	const folderRunById = new Map<string, () => void>();
 	const folderLabelById = new Map<string, string>();
+	let currentFolder: BrowsedFolder | undefined;
 	// Track the current search query so drill-down can append to it.
 	let currentSearchQuery = '';
 	const search: IMobilePickerSheetSearchSource | undefined = inlineFolderActions.length > 0
@@ -218,6 +228,15 @@ export async function showMobileWorkspacePickerSheet(
 				}
 				const flattened = results.flat();
 				const sheetItems: IMobilePickerSheetItem[] = [];
+				if (currentFolder?.query === query) {
+					folderRunById.set(USE_CURRENT_FOLDER_ID, currentFolder.run);
+					sheetItems.push({
+						id: USE_CURRENT_FOLDER_ID,
+						label: localize('mobileWorkspacePicker.openCurrentFolder', "Open “{0}”", currentFolder.label),
+						icon: Codicon.folderOpened,
+						checked: true,
+					});
+				}
 				flattened.forEach((entry, idx) => {
 					const id = `${SEARCH_RESULT_ID_PREFIX}${idx}`;
 					const folderUri = entry.workspace.folders[0]?.root;
@@ -263,8 +282,18 @@ export async function showMobileWorkspacePickerSheet(
 						headerBrowseActions[idx]?.invoke();
 						return;
 					}
+					if (id === USE_CURRENT_FOLDER_ID) {
+						const run = folderRunById.get(id);
+						if (run) {
+							run();
+							lastSearchFolderRun = undefined;
+							return MOBILE_PICKER_SHEET_CONFIRM;
+						}
+						return;
+					}
 					if (id.startsWith(SEARCH_RESULT_ID_PREFIX)) {
-						lastSearchFolderRun = folderRunById.get(id);
+						const run = folderRunById.get(id);
+						lastSearchFolderRun = run;
 						// Drill down: build a path query from the
 						// current query prefix + this folder's name,
 						// e.g. "projects/" → "projects/subfolder/".
@@ -275,7 +304,11 @@ export async function showMobileWorkspacePickerSheet(
 							// append the tapped folder name + `/`.
 							const lastSlash = currentSearchQuery.lastIndexOf('/');
 							const prefix = lastSlash >= 0 ? currentSearchQuery.slice(0, lastSlash + 1) : '';
-							return `${prefix}${folderName}/`;
+							const query = `${prefix}${folderName}/`;
+							if (run) {
+								currentFolder = { query, label: folderName, run };
+							}
+							return query;
 						}
 						return;
 					}
@@ -285,6 +318,7 @@ export async function showMobileWorkspacePickerSheet(
 					if (row) {
 						row.run();
 						lastSearchFolderRun = undefined;
+						currentFolder = undefined;
 					}
 					return;
 				},


### PR DESCRIPTION
## Problem

This is part of a series of Agents mobile UX fixes. In the mobile workspace picker, tapping a folder drills into its children and removes the visible checked state for the folder that Done would select, making folder selection hard to discover.

## Fix

- Add a reusable mobile picker confirm-close sentinel for `stayOpenOnSelect` rows.
- Prepend an explicit checked `Open “{folder}”` row when browsing inside a folder.
- Keep child-folder drill-down and Done confirmation behavior unchanged.

## Verification

- [x] `npm run typecheck-client`
- [x] `npm run valid-layers-check`
- [ ] `scripts/test.sh --grep "mobile workspace picker"` (blocked: shared `node_modules` is missing `gulp-merge-json`; per task constraints, did not run `npm install`)
---

## ✅ On-device verification (iOS Simulator)

Verified on an **iPhone 17 (iOS 26.4) Simulator** in mobile Safari, running a build of this branch, **signed in with a real GitHub account** and connected to a **real agent host** (the `osvaldos-macbook-pro` tunnel) — real filesystem browsing, real auth, **no mocks**.

**Explicit "Open this folder" action**

<img src="https://raw.githubusercontent.com/microsoft/vscode/13cc47740f12890a86a79e1f6b42943211f33678/.verification-shots/pr3-open-this-folder.png" width="300" /> <img src="https://raw.githubusercontent.com/microsoft/vscode/13cc47740f12890a86a79e1f6b42943211f33678/.verification-shots/pr3-open-folder-simpleserver.png" width="300" />

_Browsing into a folder now surfaces an explicit **Open "<folder>"** action row at the top of the list, so the currently-browsed folder can be selected as the workspace instead of being forced to drill deeper. Shown for `Applications` and for a real `simple-server.worktrees` dev folder (real host contents)._
