### PR TITLE
Agents mobile: surface new-session affordance on workspace group headers

### DIFF
--- a/src/vs/sessions/SESSIONS_LIST.md
+++ b/src/vs/sessions/SESSIONS_LIST.md
@@ -113,6 +113,7 @@ The insertion line relies on the base list widget's `drop-target-before`/`drop-t
 - **Keyboard shortcuts** — `Ctrl/Cmd+1..9` opens sessions by index; `Ctrl+Alt+-` / `Ctrl+Alt+Shift+-` for back/forward navigation
 - **Mobile** — opening a session also closes the sidebar drawer
 - **Mobile group collapse** — workspace and group headers only collapse/expand from the chevron button, which stays visible on phone so opening the first session row does not share a touch target with the header band
+- **Mobile workspace new session** — workspace section headers keep the New Session (`+`) action visible on phone so creating a workspace-scoped session does not depend on hover discovery
 
 ### Mobile
 
@@ -120,6 +121,7 @@ On phone layout (`IsPhoneLayoutContext`):
 
 - Session rows are taller for touch targets; inline toolbars are always visible (no hover)
 - Workspace/group collapse chevrons are always visible and are the only phone tap target for collapsing a section
+- Workspace section headers always show the New Session (`+`) action with a 44px touch target; other header actions remain hover/focus revealed
 - A **filter chips** row appears below the header with status toggles (Completed, In Progress, Failed) and a Sort chip
 - Sort/Group options open as a **bottom sheet** instead of a menu
 

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -422,6 +422,25 @@
 .agent-sessions-workbench.phone-layout .sessions-list-control .monaco-list-row .session-section .session-section-chevron.collapsible {
 	display: flex;
 	align-items: center;
+	justify-content: center;
+	width: calc(var(--vscode-spacing-size400) + var(--vscode-spacing-size40));
+	height: calc(var(--vscode-spacing-size400) + var(--vscode-spacing-size40));
+}
+
+.agent-sessions-workbench.phone-layout .sessions-list-control .monaco-list-row .session-section:not(.session-group) .session-section-toolbar:has(.codicon-plus) {
+	display: block;
+}
+
+.agent-sessions-workbench.phone-layout .sessions-list-control .monaco-list-row:not(:hover):not(.focused) .session-section .session-section-toolbar .action-item.menu-entry:not(:has(.codicon-plus)) {
+	display: none;
+}
+
+.agent-sessions-workbench.phone-layout .sessions-list-control .monaco-list-row .session-section .session-section-toolbar .action-item.menu-entry:has(.codicon-plus) > .action-label {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: calc(var(--vscode-spacing-size400) + var(--vscode-spacing-size40));
+	height: calc(var(--vscode-spacing-size400) + var(--vscode-spacing-size40));
 }
 
 .sessions-list-control {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -168,6 +168,7 @@ class SessionsTreeDelegate implements IListVirtualDelegate<SessionListItem> {
 	 */
 	private static readonly ITEM_HEIGHT_PHONE = 76;
 	private static readonly SECTION_HEIGHT = 26;
+	private static readonly SECTION_HEIGHT_PHONE = 44;
 	private static readonly SHOW_MORE_HEIGHT = 26;
 
 	constructor(
@@ -177,7 +178,7 @@ class SessionsTreeDelegate implements IListVirtualDelegate<SessionListItem> {
 
 	getHeight(element: SessionListItem): number {
 		if (isSessionSection(element) || isSessionGroupItem(element)) {
-			return SessionsTreeDelegate.SECTION_HEIGHT;
+			return this._isPhone() ? SessionsTreeDelegate.SECTION_HEIGHT_PHONE : SessionsTreeDelegate.SECTION_HEIGHT;
 		}
 		if (isSessionShowMore(element)) {
 			return SessionsTreeDelegate.SHOW_MORE_HEIGHT;
@@ -1546,23 +1547,20 @@ export class SessionsList extends Disposable implements ISessionsList {
 			}
 		}));
 
-		// React to phone <-> desktop viewport transitions: refresh heights
-		// for all known sessions so the virtual list reserves the correct
-		// space for the new layout. Iterates `this.sessions` (all known
-		// sessions) — a phone/desktop transition is a rare event so the
-		// extra work over filtered-out sessions is negligible. Relies on
-		// the `IsPhoneLayoutContext` reactive signal already maintained by
-		// the agents workbench.
+		const updateNodeHeights = (node: ITreeNode<SessionListItem | null, FuzzyScore | undefined>): void => {
+			if (node.element) {
+				this.tree.updateElementHeight(node.element, delegate.getHeight(node.element));
+			}
+			for (const child of node.children) {
+				updateNodeHeights(child);
+			}
+		};
 		const phoneKeys = new Set<string>([IsPhoneLayoutContext.key]);
 		this._register(this.contextKeyService.onDidChangeContext(e => {
 			if (!e.affectsSome(phoneKeys)) {
 				return;
 			}
-			for (const session of this.sessions) {
-				if (this.tree.hasElement(session)) {
-					this.tree.updateElementHeight(session, delegate.getHeight(session));
-				}
-			}
+			updateNodeHeights(this.tree.getNode());
 		}));
 
 		this._register(this.tree.onContextMenu(e => this.onContextMenu(e)));


### PR DESCRIPTION
## Summary
- STACKS on PR #322813 (group-collapse) and is part of the Agents mobile UX series.
- Makes the workspace section header New Session (+) action visible at rest on phone layout, preserving desktop/tablet hover-reveal behavior.
- Keeps other section header actions hover/focus revealed and sizes the visible plus/chevron controls to 44px touch targets.
- Documents the phone behavior in SESSIONS_LIST.md.

## Verification
- [x] npm run typecheck-client
- [x] npm run valid-layers-check
- [x] git diff --check
- [x] Council review completed; fixed the viewport-transition height refresh issue it found.
- [ ] ./scripts/test.sh --run src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts (blocked locally: missing shared node_modules package gulp-merge-json; no npm install per task constraints)
---

## On-device verification (pending a live session)

The full on-device environment for this branch was set up and used to verify the sibling agents-mobile PRs: an **iPhone 17 (iOS 26.4) Simulator** in mobile Safari, **signed in with a real GitHub account** and connected to a **real agent host** (the `osvaldos-macbook-pro` tunnel) — no mocks.

This change affects the **session list workspace group headers**, which needs at least one session present in the list to exercise. The connected host had no sessions during this pass, and a session could not be created on-device because the iOS Simulator cannot focus the web compose editor to submit a prompt (and the seeded dev host is blocked by mixed-content over HTTPS). The verification screenshot will be added once a live session exists on the host.

The change is scoped (small TS + CSS) and was validated by code review; the behavior was originally identified during real-device analysis of the shipped mobile layer.
