### PR TITLE
Document OSS NOTICE cutover

### DIFF
--- a/.github/instructions/oss-third-party-notices.instructions.md
+++ b/.github/instructions/oss-third-party-notices.instructions.md
@@ -1,10 +1,12 @@
 ---
-applyTo: 'build/azure-pipelines/oss/**'
+applyTo: 'build/azure-pipelines/{oss/**,common/downloadNotice.ts,{win32,linux,darwin}/steps/product-build-*-compile.yml}'
 ---
 
 # VS Code OSS Third-Party-Notices pipeline
 
-This directory contains the thin VS Code-specific layer around Component Governance (CG) for producing OSS third-party notices. The goal is to replace the legacy custom OSS tool with CG plus a gap-filling scanner, so release owners do not need to babysit `ThirdPartyNotices.txt` every release. The generated output should be at least as good as the legacy tool: CG provides the base NOTICE, the local scanner fills known CG gaps, and human-authored overrides cover the small set that automation cannot safely resolve.
+This directory contains the thin VS Code-specific layer around Component Governance (CG) for producing OSS third-party notices. It replaces the legacy custom OSS tool with CG plus a gap-filling scanner, so release owners do not need to babysit `ThirdPartyNotices.txt` every release. The generated output should be at least as good as the legacy tool: CG provides the base NOTICE, the local scanner fills known CG gaps, and human-authored overrides cover the small set that automation cannot safely resolve.
+
+The pipeline has two halves: **generation** (this `oss/` directory — CG + scanner + merge, producing the `notice_output` artifact) and **application** (the cutover that swaps the merged notice into the shipped product — see "Applying the NOTICE (cutover)" below).
 
 ## Architecture
 
@@ -33,6 +35,45 @@ In `product-quality-checks.yml`:
 5. `scan-licenses.js` runs with `--repo`, `--cg`, and `--output`.
 6. `merge-notices.js` runs with `--cg`, `--extensions`, `--cglicenses`, and `--output`.
 7. The generated CG file, scanner file, final merged file, and optional cache metadata are uploaded under `notice_output`.
+
+## Applying the NOTICE (cutover)
+
+Generation (above) produces the merged `ThirdPartyNotices.new.txt` in the `notice_output` artifact. **Application** is the cutover that makes that file the one VS Code actually ships, replacing the legacy mixin notice.
+
+Consumer script: `build/azure-pipelines/common/downloadNotice.ts` (read its header comment for the full design rationale).
+
+How it works, per desktop platform compile template (`build/azure-pipelines/{win32,linux,darwin}/steps/product-build-*-compile.yml`):
+
+1. **Pull CG NOTICE (background)** — at compile start, `deemon --detach` launches `downloadNotice.ts` as a detached poller. It polls the parallel Quality stage's `notice_output` artifact while compilation runs, so the wait overlaps work already happening.
+2. **Apply CG NOTICE** — right before gulp packages the app, `deemon --attach` blocks on that poller. It downloads, extracts, validates the merged notice, and **overwrites the repo-root `ThirdPartyNotices.txt`**. `build/gulpfile.vscode.ts` then packages whatever file is at that path → the CG notice ships.
+
+Only the 7 desktop targets that bundle a notice run these steps (win32 x64/arm64, darwin universal, linux x64/arm64/armhf). REH/server/web/alpine are unaffected.
+
+### Fallback chain (never fail the build)
+
+`downloadNotice.ts` is **non-fatal — it always exits 0.** A notice problem must never break packaging. The outcomes, in order:
+
+1. **CG fresh** — the `notice_output` artifact is present and valid → overwrite with it.
+2. **Cached CG** — if CG generation failed upstream, the Quality stage substitutes the last good `ThirdPartyNotices.generated.txt` (same branch, then `main`) before the artifact is published — so the consumer still gets a CG notice.
+3. **Legacy** — if no usable artifact is available, the legacy mixin notice that `mixin-quality.ts` already laid down is left in place. `mixin-quality.ts` is deliberately left untouched (it's a shared chokepoint used by 8+ pipelines), which is what guarantees we never ship with *no* notice.
+
+The accept-gate validates the *extracted content* (file present AND non-trivial) inside the poll loop — it does not trust the artifact listing alone. A mid-upload miss re-polls rather than falling back, which prevents a "mixed notice" race where one platform ships legacy while its siblings ship CG.
+
+### Rollback lever
+
+A queue-time checkbox **"Use legacy OSS Notice"** (parameter `VSCODE_USE_LEGACY_OSS_NOTICE`, default `false`) is the instant rollback. When checked, it derives `VSCODE_OVERWRITE_TPN=false`, and `downloadNotice.ts` skips the overwrite so the legacy notice ships — no code change or redeploy needed.
+
+> ⚠️ `downloadNotice.ts` normalizes the flag with `.trim().toLowerCase()` before comparing, so YAML casing (`true`/`false` vs `True`/`False`) can't break the rollback lever. The pipeline still derives `VSCODE_OVERWRITE_TPN` as a lowercase string literal (`'true'`/`'false'`) for clarity. See the comment in `product-build-variables.yml`.
+
+### Diagnosing a build
+
+`downloadNotice.ts` logs three greppable markers so a build log answers "did the cutover work?":
+
+- `[notice-cutover] RESULT=fresh` — overwrote from `notice_output` (the happy path).
+- `[notice-cutover] RESULT=fallback` — artifact missing → kept the legacy notice.
+- `[notice-cutover] RESULT=disabled` — feature flag off → kept the legacy notice.
+
+To confirm a shipped artifact carries the CG notice, the root `resources/app/ThirdPartyNotices.txt` should be the large CG-merged file (multi-MB) rather than the ~3 MB legacy notice. Validate *intra-build* parity — all platforms in one build should produce a byte-identical notice (same SHA-256) — rather than checking against a fixed byte count, since CG's exact output size varies run-to-run.
 
 ## Script reference
 

--- a/build/azure-pipelines/common/downloadNotice.ts
+++ b/build/azure-pipelines/common/downloadNotice.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// E-lite: Component Governance (CG) NOTICE cutover.
+// Component Governance (CG) NOTICE cutover.
 //
 // During each platform compile stage this script pulls the CG-generated NOTICE
 // (produced by the parallel Quality stage as the `notice_output` artifact) and
@@ -16,7 +16,7 @@
 // by then the added wall-clock is near-zero; otherwise we block for at most a
 // short budget and then DEGRADE to the legacy mixin notice.
 //
-// Design notes (see oss-cutover design log):
+// Design notes:
 //   * copy-then-overwrite: mixin-quality.ts is left untouched (shared chokepoint
 //     used by 8+ pipelines). The legacy ThirdPartyNotices.txt it lays down is
 //     our guaranteed fallback, so we never ship with NO notice.
@@ -25,9 +25,9 @@
 //   * SHORT poll budget (not the copilot 30min): a missing artifact must degrade
 //     to fallback fast, otherwise the non-fatal design is defeated by a 30min hang.
 //   * Three greppable markers so a build log answers "fresh vs stale vs off":
-//       [notice-elite] RESULT=fresh     overwrote from notice_output (logs producer)
-//       [notice-elite] RESULT=fallback  artifact missing -> kept legacy notice
-//       [notice-elite] RESULT=disabled  feature flag off -> kept legacy notice
+//       [notice-cutover] RESULT=fresh     overwrote from notice_output (logs producer)
+//       [notice-cutover] RESULT=fallback  artifact missing -> kept legacy notice
+//       [notice-cutover] RESULT=disabled  feature flag off -> kept legacy notice
 
 import fs from 'fs';
 import path from 'path';
@@ -62,7 +62,7 @@ const POLL_ATTEMPTS = 20;
 const POLL_INTERVAL_MS = 30_000;
 
 function log(message: string): void {
-	console.log(`[notice-elite] [${new Date().toISOString()}] ${message}`);
+	console.log(`[notice-cutover] [${new Date().toISOString()}] ${message}`);
 }
 
 interface TimelineRecord {
@@ -92,17 +92,17 @@ interface NoticeArtifact {
 
 function installDiagnostics(): void {
 	process.on('uncaughtException', err => {
-		console.error('[notice-elite] Uncaught exception:', err);
+		console.error('[notice-cutover] Uncaught exception:', err);
 		// Non-fatal: never break packaging because of a notice problem.
 		process.exit(0);
 	});
 	process.on('unhandledRejection', reason => {
-		console.error('[notice-elite] Unhandled rejection:', reason);
+		console.error('[notice-cutover] Unhandled rejection:', reason);
 		process.exit(0);
 	});
 	for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGBREAK'] as const) {
 		process.on(signal, () => {
-			console.error(`[notice-elite] Received ${signal}, exiting.`);
+			console.error(`[notice-cutover] Received ${signal}, exiting.`);
 			process.exit(0);
 		});
 	}
@@ -336,7 +336,7 @@ async function waitForNotice(tmpDir: string): Promise<ExtractedNotice | undefine
 
 			log(`  * Not ready yet, waiting ${POLL_INTERVAL_MS / 1000}s...`);
 		} catch (err) {
-			console.error(`[notice-elite] WARNING: poll attempt failed: ${err}`);
+			console.error(`[notice-cutover] WARNING: poll attempt failed: ${err}`);
 		}
 
 		await new Promise(c => setTimeout(c, POLL_INTERVAL_MS));
@@ -387,6 +387,6 @@ async function main(): Promise<void> {
 
 main().catch(err => {
 	// Non-fatal: log and exit 0 so packaging proceeds with the legacy notice.
-	console.error('[notice-elite] Non-fatal error; keeping legacy notice:', err);
+	console.error('[notice-cutover] Non-fatal error; keeping legacy notice:', err);
 	process.exitCode = 0;
 });

--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -119,7 +119,7 @@ steps:
   - script: node build/azure-pipelines/distro/mixin-quality.ts
     displayName: Mixin distro quality
 
-  # E-lite: start pulling the CG-generated NOTICE from the parallel Quality stage
+  # Start pulling the CG-generated NOTICE from the parallel Quality stage
   # in the background (overwrites repo-root ThirdPartyNotices.txt before packaging).
   - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
     env:
@@ -166,14 +166,14 @@ steps:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     displayName: Download Copilot VSIX
 
-  # E-lite: block on the CG NOTICE download and overwrite ThirdPartyNotices.txt
+  # Block on the CG NOTICE download and overwrite ThirdPartyNotices.txt
   # before gulp packages it (and before any later signing/notarization).
   # Non-fatal: falls back to legacy on any problem.
   - script: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
-    displayName: Apply CG NOTICE (E-lite)
+    displayName: Apply CG NOTICE
 
   - script: |
       set -e

--- a/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
@@ -170,7 +170,7 @@ steps:
   - script: node build/azure-pipelines/distro/mixin-quality.ts
     displayName: Mixin distro quality
 
-  # E-lite: start pulling the CG-generated NOTICE from the parallel Quality stage
+  # Start pulling the CG-generated NOTICE from the parallel Quality stage
   # in the background (overwrites repo-root ThirdPartyNotices.txt before packaging).
   - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
     env:
@@ -219,13 +219,13 @@ steps:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     displayName: Download Copilot VSIX
 
-  # E-lite: block on the CG NOTICE download and overwrite ThirdPartyNotices.txt
+  # Block on the CG NOTICE download and overwrite ThirdPartyNotices.txt
   # right before gulp packages it. Non-fatal: falls back to legacy on any problem.
   - script: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
-    displayName: Apply CG NOTICE (E-lite)
+    displayName: Apply CG NOTICE
 
   - script: |
       set -e

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -112,7 +112,7 @@ parameters:
     type: boolean
     default: false
   - name: VSCODE_USE_LEGACY_OSS_NOTICE
-    displayName: "Use legacy OSS Tool"
+    displayName: "Use legacy OSS Notice"
     type: boolean
     default: false
 

--- a/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
+++ b/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
@@ -111,7 +111,7 @@ steps:
   - powershell: node build/azure-pipelines/distro/mixin-quality.ts
     displayName: Mixin distro quality
 
-  # E-lite: start pulling the CG-generated NOTICE from the parallel Quality stage
+  # Start pulling the CG-generated NOTICE from the parallel Quality stage
   # in the background (overwrites repo-root ThirdPartyNotices.txt before packaging).
   - pwsh: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
     env:
@@ -165,13 +165,13 @@ steps:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     displayName: Download Copilot VSIX
 
-  # E-lite: block on the CG NOTICE download and overwrite ThirdPartyNotices.txt
+  # Block on the CG NOTICE download and overwrite ThirdPartyNotices.txt
   # right before gulp packages it. Non-fatal: falls back to legacy on any problem.
   - pwsh: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
-    displayName: Apply CG NOTICE (E-lite)
+    displayName: Apply CG NOTICE
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1


### PR DESCRIPTION
🤖 AI Assisted PR

## What

Follow-up documentation + cleanup for the OSS third-party-notices pipeline now that Component Governance (CG) generates and applies the shipped `ThirdPartyNotices.txt`.

- **Document the "apply" half of the pipeline.** The OSS instructions previously only covered generation (the `oss/` directory). This adds an **"Applying the NOTICE"** section covering the consumer script (`downloadNotice.ts`) and the per-platform compile-template steps: the Pull/Apply flow, the fallback chain, the rollback toggle, and the build-log markers. `applyTo` is broadened so edits to the consumer/templates surface this doc.
- **Tidy internal labels in shipped code.** Rename the build-log marker prefix to `[notice-cutover]` and drop a stale internal codename from the consumer/template comments and step display names, so the code carries only self-describing labels.
- **Unify the toggle label.** `product-build.yml`'s queue-time checkbox now reads **"Use legacy OSS Notice"**, matching `product-build-template.yml` and `product-build-variables.yml`.

## Why

The generation half was documented; the application half wasn't. This closes that gap and makes the shipped log markers and comments self-describing for anyone debugging a build.

## Risk

Low. Documentation, comments, log-string prefixes, and a display-name string only — no behavioral change to packaging or the fallback path.
