### PR TITLE
Fix context key references

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -6311,7 +6311,7 @@
       "chat/input/editing/sessionTitleToolbar": [
         {
           "command": "github.copilot.sessions.refreshChanges",
-          "when": "chatSessionType == copilotcli && isSessionsWindow && !sessions.isAgentHostSession",
+          "when": "sessionType == copilotcli && isSessionsWindow && !sessions.isAgentHostSession",
           "group": "9_refresh@1"
         }
       ],

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md
@@ -44,7 +44,7 @@ Decoupling these allows copilot sessions from different providers (local CLI, re
 
 ### How each ID is used
 
-- **`ISession.sessionType`** — The logical session type visible to the sessions framework. Controls session-type pickers, context keys (`activeSessionType`), and behavioral gating (e.g. `isActiveSessionBackgroundProvider`). Copilot agents share `copilotcli` so they behave consistently with local copilot sessions.
+- **`ISession.sessionType`** — The logical session type visible to the sessions framework. Controls session-type pickers, context keys (`sessionType`), and behavioral gating (e.g. `isActiveSessionBackgroundProvider`). Copilot agents share `copilotcli` so they behave consistently with local copilot sessions.
 
 - **`resource.scheme`** — The URI scheme of `ISession.resource` (e.g. `remote-myhost__3000-copilot:///abc123`). Routes `registerChatSessionContentProvider` calls to the correct `AgentHostSessionHandler` for each host. The provider's `getModels` filters available models by `session.resource.scheme` (not `session.sessionType`).
 

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewWorkbenchService.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewWorkbenchService.ts
@@ -78,7 +78,7 @@ export class BrowserViewWorkbenchService extends Disposable implements IBrowserV
 			ContextKeyExpr.and(
 				ContextKeyExpr.has(`config.${AgentHostChatToolsEnabledSettingId}`),
 				ContextKeyExpr.or(
-					ContextKeyExpr.equals('activeSessionType', localChatSessionType),
+					ContextKeyExpr.equals('sessionType', localChatSessionType),
 					ContextKeyExpr.equals('sessions.isAgentHostSession', true),
 				)
 			),


### PR DESCRIPTION
```Copilot Generated Description:``` Update context key references from `activeSessionType` to `sessionType` in multiple locations for consistency.

