### PR TITLE
agent host: model client connection state as a discriminated union

### DIFF
--- a/src/vs/platform/agentHost/node/protocolServerHandler.ts
+++ b/src/vs/platform/agentHost/node/protocolServerHandler.ts
@@ -199,27 +199,47 @@ interface IConnectedClient {
  * at the end. When the last transport disconnects, the record is retained
  * (until pruned) so the tool-call disconnect-grace machinery can compute the
  * remaining window and hold any armed timeouts.
+ *
+ * A client is in exactly one of two states, which makes the core invariant
+ * unrepresentable in the wrong shape: a client either has one or more live
+ * transports ({@link IActiveClientRecord}, never any disconnect-grace timers)
+ * or has no transport and is within its disconnect-grace window
+ * ({@link IGraceClientRecord}, never any connections). Transitions happen only
+ * in {@link ProtocolServerHandler._attachConnection} (→ active, which disposes
+ * any grace timers) and the transport `onClose` handler (→ grace, once the last
+ * transport is gone).
  */
-interface IClientRecord {
+type IClientRecord = IActiveClientRecord | IGraceClientRecord;
+
+interface IActiveClientRecord {
+	readonly state: 'active';
 	/**
-	 * All live transports for this client, oldest first. The active connection
-	 * is the last entry (most recent wins). Older entries are kept so that if a
+	 * Live transports for this client, oldest first. The active connection is
+	 * the last entry (most recent wins). Older entries are kept so that if a
 	 * reconnecting client registers `A`, then `B`, then `B` closes first, we can
-	 * fall back to `A` instead of treating the client as disconnected.
+	 * fall back to `A` instead of treating the client as disconnected. Never
+	 * empty: removing the last transport promotes the record to a grace record.
 	 */
 	readonly connections: IConnectedClient[];
+}
+
+interface IGraceClientRecord {
+	readonly state: 'grace';
 	/**
-	 * Epoch ms when the client last had no live transports. `undefined` while at
-	 * least one connection is active, or when the client has never connected.
-	 * Drives the disconnect-timeout grace window for disconnected records only.
+	 * Epoch ms when the client last had a live transport, or when this record
+	 * was created for a never-connected orphan tool-call stamp. Pins the grace
+	 * clock so re-arms triggered by later orphaned tool calls shrink the
+	 * remaining window instead of resetting it. Drives the disconnect-timeout
+	 * delay (residual window from this instant).
 	 */
-	lastSeenAt: number | undefined;
+	lastSeenAt: number;
 	/**
 	 * Pending tool-call disconnect timeouts owned by this client, keyed by
 	 * session URI. Armed when the client owns a pending client tool call but is
 	 * not connected; fires a failing completion if it does not (re)connect
-	 * within the grace window. Disposing an entry (or the whole map) clears the
-	 * underlying timer.
+	 * within the grace window. Reconnecting promotes the record to active and
+	 * disposes these timers (the grace window no longer applies once a transport
+	 * is live). Disposing an entry (or the whole map) clears the timer.
 	 */
 	readonly disconnectTimeouts: DisposableMap<string>;
 }
@@ -443,7 +463,7 @@ export class ProtocolServerHandler extends Disposable {
 
 		disposables.add(transport.onClose(() => {
 			const record = client ? this._clients.get(client.clientId) : undefined;
-			if (client && record) {
+			if (client && record?.state === 'active') {
 				const connectionIndex = record.connections.indexOf(client);
 				if (connectionIndex !== -1) {
 					const subscriptionCount = client.subscriptions.size;
@@ -452,7 +472,7 @@ export class ProtocolServerHandler extends Disposable {
 					this._rejectPendingReverseRequestsForConnection(client);
 					if (record.connections.length === 0) {
 						this._logService.info(`[ProtocolServer] Client disconnected: ${client.clientId}, subscriptions=${subscriptionCount}`);
-						record.lastSeenAt = Date.now();
+						this._clients.set(client.clientId, { state: 'grace', lastSeenAt: Date.now(), disconnectTimeouts: new DisposableMap() });
 						this._handleClientDisconnected(client.clientId);
 						this._onDidChangeConnectionCount.fire(this._connectedClientCount);
 					}
@@ -501,11 +521,7 @@ export class ProtocolServerHandler extends Disposable {
 			subscriptions: new Map(),
 			disposables,
 		};
-		const record = this._ensureClientRecord(params.clientId);
-		record.connections.push(client);
-		record.lastSeenAt = undefined;
-		this._pruneClientRecords();
-		this._onDidChangeConnectionCount.fire(this._connectedClientCount);
+		this._attachConnection(params.clientId, client);
 
 		this._registerClientFileSystemAuthority(params.clientId, disposables);
 
@@ -618,11 +634,7 @@ export class ProtocolServerHandler extends Disposable {
 			subscriptions: new Map(),
 			disposables,
 		};
-		const record = this._ensureClientRecord(params.clientId);
-		record.connections.push(client);
-		record.lastSeenAt = undefined;
-		this._pruneClientRecords();
-		this._onDidChangeConnectionCount.fire(this._connectedClientCount);
+		this._attachConnection(params.clientId, client);
 
 		// Re-establish the reverse-RPC filesystem authority for this client.
 		// The prior transport's `onClose` disposed the previous registration,
@@ -741,7 +753,7 @@ export class ProtocolServerHandler extends Disposable {
 	private _reconcileActiveClientsAfterReconnect(client: IConnectedClient): void {
 		const record = this._clients.get(client.clientId);
 		const resubscribed = new Set<string>();
-		for (const connection of record?.connections ?? [client]) {
+		for (const connection of record?.state === 'active' ? record.connections : [client]) {
 			for (const sub of connection.subscriptions.values()) {
 				if (sub.kind === ChannelKind.State) {
 					resubscribed.add(sub.uri);
@@ -849,21 +861,24 @@ export class ProtocolServerHandler extends Disposable {
 
 	/**
 	 * Arm (or re-arm) the per-(clientId, session) timeout that fails pending
-	 * client tool calls owned by `clientId` if it does not reconnect and
-	 * resubscribe. The delay is the remaining grace measured from when the
-	 * client disconnected — so a client that disconnected a while before the
-	 * call was issued gets the residual window rather than a fresh one, and a
-	 * stamp from a long-dead client fails promptly. A client never seen at all
-	 * has its grace clock pinned to the first arm, so re-arms triggered by later
-	 * orphaned tool calls in the same session shrink the remaining window
-	 * instead of resetting it.
+	 * client tool calls owned by `clientId` if it does not reconnect before the
+	 * grace window elapses. Only meaningful for a client with no live transport:
+	 * a connected client is handled by {@link _attachConnection}, which disposes
+	 * any armed timers, so this is a no-op when the client is active. The delay
+	 * is the remaining grace measured from when the client disconnected — so a
+	 * client that disconnected a while before the call was issued gets the
+	 * residual window rather than a fresh one, and a stamp from a long-dead
+	 * client fails promptly. A never-connected client has its grace clock pinned
+	 * to the first arm, so re-arms triggered by later orphaned tool calls in the
+	 * same session shrink the remaining window instead of resetting it.
 	 */
 	private _startClientToolCallDisconnectTimeout(clientId: string, session: string): void {
-		this._clearClientToolCallDisconnectTimeout(clientId, session);
-		const record = this._ensureClientRecord(clientId);
-		if (record.lastSeenAt === undefined) {
-			record.lastSeenAt = Date.now();
+		const record = this._ensureGraceRecord(clientId);
+		if (!record) {
+			// Client is connected; the grace machinery does not apply.
+			return;
 		}
+		record.disconnectTimeouts.deleteAndDispose(session);
 		const elapsed = Date.now() - record.lastSeenAt;
 		const delay = Math.max(0, CLIENT_TOOL_CALL_DISCONNECT_TIMEOUT - elapsed);
 		record.disconnectTimeouts.set(session, disposableTimeout(() => {
@@ -885,7 +900,7 @@ export class ProtocolServerHandler extends Disposable {
 		const orphanOwners = new Set<string>();
 		for (const { clientId } of this._pendingClientToolCalls(state)) {
 			const ownerRecord = this._clients.get(clientId);
-			if (!ownerRecord || ownerRecord.connections.length === 0) {
+			if (ownerRecord?.state !== 'active') {
 				orphanOwners.add(clientId);
 			}
 		}
@@ -895,28 +910,56 @@ export class ProtocolServerHandler extends Disposable {
 	}
 
 	/**
-	 * Get the existing per-client record or create an empty one. A freshly
-	 * created record has no connections and `lastSeenAt === undefined`.
+	 * Register a freshly connected (or reconnected) transport for `clientId`,
+	 * promoting the record to {@link IActiveClientRecord}. Promoting a grace
+	 * record back to active disposes its pending disconnect timers: the
+	 * disconnect-grace window only applies while the client has no live
+	 * transport. This is the single place that maintains the "active records
+	 * hold no grace timers" invariant.
 	 */
-	private _ensureClientRecord(clientId: string): IClientRecord {
-		let record = this._clients.get(clientId);
-		if (!record) {
-			record = { connections: [], lastSeenAt: undefined, disconnectTimeouts: new DisposableMap() };
-			this._clients.set(clientId, record);
+	private _attachConnection(clientId: string, client: IConnectedClient): void {
+		const existing = this._clients.get(clientId);
+		if (existing?.state === 'active') {
+			existing.connections.push(client);
+		} else {
+			existing?.disconnectTimeouts.dispose();
+			this._clients.set(clientId, { state: 'active', connections: [client] });
 		}
-		return record;
+		this._pruneClientRecords();
+		this._onDidChangeConnectionCount.fire(this._connectedClientCount);
+	}
+
+	/**
+	 * Return the existing grace record for `clientId`, creating one for a
+	 * never-connected client (an orphan tool-call stamp). Returns `undefined`
+	 * when the client is currently active — the grace machinery does not apply
+	 * to a connected client. A newly created record pins its grace clock to now.
+	 */
+	private _ensureGraceRecord(clientId: string): IGraceClientRecord | undefined {
+		const record = this._clients.get(clientId);
+		if (record?.state === 'active') {
+			return undefined;
+		}
+		if (record) {
+			return record;
+		}
+		const created: IGraceClientRecord = { state: 'grace', lastSeenAt: Date.now(), disconnectTimeouts: new DisposableMap() };
+		this._clients.set(clientId, created);
+		return created;
 	}
 
 	private _getActiveClient(clientId: string): IConnectedClient | undefined {
-		const connections = this._clients.get(clientId)?.connections;
-		return connections?.[connections.length - 1];
+		return this._getActiveClientFromRecord(this._clients.get(clientId));
 	}
 
-	private _getActiveClientFromRecord(record: IClientRecord): IConnectedClient | undefined {
+	private _getActiveClientFromRecord(record: IClientRecord | undefined): IConnectedClient | undefined {
+		if (record?.state !== 'active') {
+			return undefined;
+		}
 		return record.connections[record.connections.length - 1];
 	}
 
-	private _releaseClientSubscriptions(client: IConnectedClient, record: IClientRecord): void {
+	private _releaseClientSubscriptions(client: IConnectedClient, record: IActiveClientRecord): void {
 		for (const sub of client.subscriptions.values()) {
 			if (sub.kind === ChannelKind.State) {
 				if (this._hasSubscriptionInOtherConnection(record, client, sub.uri)) {
@@ -931,6 +974,9 @@ export class ProtocolServerHandler extends Disposable {
 	}
 
 	private _hasSubscriptionInOtherConnection(record: IClientRecord, client: IConnectedClient, uri: string): boolean {
+		if (record.state !== 'active') {
+			return false;
+		}
 		for (const other of record.connections) {
 			if (other !== client && other.subscriptions.has(uri)) {
 				return true;
@@ -939,11 +985,11 @@ export class ProtocolServerHandler extends Disposable {
 		return false;
 	}
 
-	/** Number of records that currently hold a live connection. */
+	/** Number of clients that currently have a live connection. */
 	private get _connectedClientCount(): number {
 		let count = 0;
 		for (const record of this._clients.values()) {
-			if (record.connections.length > 0) {
+			if (record.state === 'active') {
 				count++;
 			}
 		}
@@ -951,26 +997,30 @@ export class ProtocolServerHandler extends Disposable {
 	}
 
 	/**
-	 * Drop disconnected, timer-less client records whose last-seen time is
-	 * stale beyond the retention window (10× the disconnect timeout), plus
-	 * never-connected placeholder records (e.g. a stamp from a long-dead
-	 * client) once their timeouts have fired. Bounds {@link _clients} without
-	 * tracking liveness precisely — a pruned-then-resurfacing stamp simply
-	 * falls back to the full grace window.
+	 * Drop grace records whose timers have all fired and whose last-seen time is
+	 * stale beyond the retention window (10× the disconnect timeout). This
+	 * covers both genuinely-disconnected clients and never-connected orphan
+	 * stamps. Bounds {@link _clients} without tracking liveness precisely — a
+	 * pruned-then-resurfacing stamp simply falls back to the full grace window.
+	 * Active records are never pruned; they persist until their last transport
+	 * closes.
 	 */
 	private _pruneClientRecords(): void {
 		const cutoff = Date.now() - CLIENT_TOOL_CALL_DISCONNECT_TIMEOUT * 10;
 		for (const [clientId, record] of this._clients) {
-			if (record.connections.length === 0
+			if (record.state === 'grace'
 				&& record.disconnectTimeouts.size === 0
-				&& (record.lastSeenAt === undefined || record.lastSeenAt < cutoff)) {
+				&& record.lastSeenAt < cutoff) {
 				this._clients.delete(clientId);
 			}
 		}
 	}
 
 	private _clearClientToolCallDisconnectTimeout(clientId: string, session: string): void {
-		this._clients.get(clientId)?.disconnectTimeouts.deleteAndDispose(session);
+		const record = this._clients.get(clientId);
+		if (record?.state === 'grace') {
+			record.disconnectTimeouts.deleteAndDispose(session);
+		}
 	}
 
 	private _completeDisconnectedClientToolCalls(clientId: string, session: string): void {
@@ -1492,10 +1542,13 @@ export class ProtocolServerHandler extends Disposable {
 
 	override dispose(): void {
 		for (const record of this._clients.values()) {
-			for (const connection of [...record.connections]) {
-				connection.disposables.dispose();
+			if (record.state === 'active') {
+				for (const connection of [...record.connections]) {
+					connection.disposables.dispose();
+				}
+			} else {
+				record.disconnectTimeouts.dispose();
 			}
-			record.disconnectTimeouts.dispose();
 		}
 		this._clients.clear();
 		for (const [, pending] of this._pendingReverseRequests) {


### PR DESCRIPTION
## Summary

Refactors `IClientRecord` in `ProtocolServerHandler` into a discriminated union so the core liveness invariant is enforced by the type system rather than by convention.

Previously a single record shape carried `connections`, `lastSeenAt`, and `disconnectTimeouts` together, with an unwritten rule that **a record holding live connections must never hold armed tool-call disconnect-grace timers**. A reconnect that pushed a transport without disposing those timers could violate that rule, leaving a grace timer armed against a client that is actually connected.

This makes the bad state unrepresentable:

- **`IActiveClientRecord`** (`state: 'active'`) — one or more live transports, never any grace timers.
- **`IGraceClientRecord`** (`state: 'grace'`) — no transport, may hold armed timers, with a non-optional `lastSeenAt`.

Transitions are funneled through two places:
- **`_attachConnection` (→ active)** — promoting a grace record disposes its disconnect timers (the grace window only applies while the client has no live transport).
- **transport `onClose` (→ grace)** — demotes once the last transport is gone and arms the grace timer.

All record access now branches on `state`, so callers — including the recently added reconnect-reconciliation path (`_reconcileActiveClientsAfterReconnect`) — can no longer read `connections` off a disconnected record by accident.

### Background

This came out of investigating dogfood reports of the browser tools failing with `Client <id> disconnected before completing <tool>` against live clients. The disconnect-grace machinery has since been reworked upstream (multiple active clients per session, reconnect reconciliation, subscription filtering); this change is the type-safety hardening of that area and is **behaviour-preserving** on top of it.

## Validation

- `npm run typecheck-client` ✅
- Hygiene ✅
- Full `ProtocolServerHandler` suite (66 tests) passes unchanged — genuine-disconnect, overlapping-transport, never-connected, orphaned-stamp, and reconnect cases.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>