### PR TITLE
chat: make Send Immediately work for agent-host sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatQueueActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatQueueActions.ts
@@ -292,7 +292,7 @@ export class ChatSendPendingImmediatelyAction extends Action2 {
 
 		chatService.setPendingRequests(context.sessionResource, reordered);
 		await chatService.cancelCurrentRequestForSession(context.sessionResource, 'queueRunNext');
-		chatService.processPendingRequests(context.sessionResource);
+		chatService.processPendingRequests(context.sessionResource, true);
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -1786,8 +1786,14 @@ export interface IChatService {
 	 * storage or after an error, pending requests may be present without an
 	 * active chat message 'loop' happening. THis triggers the loop to happen
 	 * as needed. Idempotent, safe to call at any time.
+	 *
+	 * @param force When `true`, dequeues and sends the next pending request even
+	 * for agent-host managed sessions whose queue is normally drained by the
+	 * server. Used by the explicit "Send Immediately" action, which cancels the
+	 * active turn and must start the next message right away (the server only
+	 * auto-drains on natural turn completion, not on cancellation).
 	 */
-	processPendingRequests(sessionResource: URI): void;
+	processPendingRequests(sessionResource: URI, force?: boolean): void;
 	addCompleteRequest(sessionResource: URI, message: IParsedChatRequest | string, variableData: IChatRequestVariableData | undefined, attempt: number | undefined, response: IChatCompleteResponse): void;
 	setChatSessionTitle(sessionResource: URI, title: string): void;
 	getLocalSessionHistory(): Promise<IChatDetail[]>;

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -1555,10 +1555,10 @@ export class ChatService extends Disposable implements IChatService {
 		};
 	}
 
-	processPendingRequests(sessionResource: URI): void {
+	processPendingRequests(sessionResource: URI, force?: boolean): void {
 		const model = this._sessionModels.get(sessionResource);
 		if (model && !this._pendingRequests.has(sessionResource)) {
-			this.processNextPendingRequest(model);
+			this.processNextPendingRequest(model, force);
 		}
 	}
 
@@ -1574,12 +1574,20 @@ export class ChatService extends Disposable implements IChatService {
 	 * Process the next pending request from the model's queue, if any.
 	 * Called after a request completes to continue processing queued requests.
 	 * Multiple consecutive steering requests are combined into a single request.
+	 *
+	 * @param force When `true`, bypasses the server-managed queue short-circuit
+	 * so the next request is dequeued and sent even for agent-host sessions. The
+	 * "Send Immediately" action relies on this because the server only drains its
+	 * queue on natural turn completion, not after the turn is cancelled.
 	 */
-	private processNextPendingRequest(model: ChatModel): void {
+	private processNextPendingRequest(model: ChatModel, force?: boolean): void {
 		// Agent host sessions delegate queue management to the server.
 		// The server dispatches ChatTurnStarted with queuedMessageId when
 		// it consumes a queued message, so the client should not dequeue eagerly.
-		if (this._isServerManagedQueue(model.sessionResource)) {
+		// The `force` path is the exception: an explicit "Send Immediately" cancels
+		// the active turn, and the server does not auto-drain on cancellation, so
+		// the client must dequeue and send the next request itself.
+		if (!force && this._isServerManagedQueue(model.sessionResource)) {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -1080,6 +1080,85 @@ suite('ChatService', () => {
 		assert.ok(lastThree[2].includes('queued-3'));
 	});
 
+	test('processPendingRequests forces dequeue for agent-host sessions (Send Immediately)', async () => {
+		// Agent-host sessions delegate queue draining to the server, which only
+		// auto-drains on natural turn completion — not on cancellation. The
+		// "Send Immediately" action cancels the active turn, so the client must
+		// dequeue and send the next request itself via the `force` path.
+		const sessionType = 'agent-host-copilot';
+		const sessionResource = URI.from({ scheme: sessionType, path: '/session-send-immediately' });
+
+		const requestStarted = new DeferredPromise<void>();
+		const completeRequest = new DeferredPromise<void>();
+		const invokedMessages: string[] = [];
+
+		const slowAgent: IChatAgentImplementation = {
+			async invoke(request) {
+				invokedMessages.push(request.message);
+				if (invokedMessages.length === 1) {
+					requestStarted.complete();
+					await completeRequest.p;
+				}
+				return {};
+			},
+		};
+
+		const mockSessionsService = new MockChatSessionsService();
+		mockSessionsService.setContributions([{
+			type: sessionType,
+			name: 'Agent Host',
+			displayName: 'Agent Host',
+			description: 'Agent Host',
+		}]);
+		testDisposables.add(mockSessionsService.registerChatSessionContentProvider(sessionType, {
+			provideChatSessionContent: resource => Promise.resolve({
+				sessionResource: resource,
+				history: [],
+				onWillDispose: Event.None,
+				dispose: () => { },
+			}),
+		}));
+		instantiationService.stub(IChatSessionsService, mockSessionsService);
+
+		testDisposables.add(chatAgentService.registerAgent(sessionType, { ...getAgentData(sessionType), isDefault: true }));
+		testDisposables.add(chatAgentService.registerAgentImplementation(sessionType, slowAgent));
+
+		const testService = createChatService();
+		const ref = await testService.acquireOrLoadSession(sessionResource, ChatAgentLocation.Chat, CancellationToken.None);
+		assert.ok(ref);
+		testDisposables.add(ref);
+		const model = testService.getSession(sessionResource) as ChatModel;
+
+		// Start a blocking request, then queue a second while it is in progress
+		const response = await testService.sendRequest(sessionResource, 'first request', { agentId: sessionType });
+		ChatSendResult.assertSent(response);
+		await requestStarted.p;
+
+		const queued = await testService.sendRequest(sessionResource, 'queued request', { agentId: sessionType, queue: ChatRequestQueueKind.Queued });
+		assert.ok(ChatSendResult.isQueued(queued));
+		assert.strictEqual(model.getPendingRequests().length, 1);
+
+		// Cancel the active turn (as the "Send Immediately" action does)
+		await runWithFakedTimers({ useFakeTimers: true }, async () => {
+			await testService.cancelCurrentRequestForSession(sessionResource, 'queueRunNext');
+		});
+		completeRequest.complete();
+		await response.data.responseCompletePromise;
+
+		// Without force, the server-managed queue is left untouched by the client
+		testService.processPendingRequests(sessionResource);
+		await new Promise(resolve => setTimeout(resolve, 0));
+		assert.strictEqual(invokedMessages.length, 1, 'queued request must not be sent without force');
+		assert.strictEqual(model.getPendingRequests().length, 1);
+
+		// With force, the client dequeues and sends the queued request immediately
+		testService.processPendingRequests(sessionResource, true);
+		const result = await queued.deferred;
+		assert.ok(ChatSendResult.isSent(result));
+		await result.data.responseCompletePromise;
+		assert.deepStrictEqual(invokedMessages, ['first request', 'queued request']);
+	});
+
 	test('acquireOrLoadSession returns undefined when remote provider is not registered (fix for #301203)', async () => {
 		const unregisteredScheme = 'unregistered-provider';
 		const sessionResource = URI.from({ scheme: unregisteredScheme, path: '/orphaned-session' });

--- a/src/vs/workbench/contrib/chat/test/common/chatService/mockChatService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/mockChatService.ts
@@ -40,7 +40,7 @@ export class MockChatService implements IChatService {
 
 	}
 
-	processPendingRequests(sessionResource: URI): void {
+	processPendingRequests(sessionResource: URI, force?: boolean): void {
 
 	}
 


### PR DESCRIPTION
## Problem

The "Send Immediately" button is a no-op for agent-host managed sessions.

The action does three things:
1. Reorders the target message to the front of the queue
2. Cancels the current request (`ChatTurnCancelled`)
3. Calls `processPendingRequests` to start the next message

**Root cause:** `ChatService.processNextPendingRequest` short-circuits for agent-host sessions (`_isServerManagedQueue`), because those sessions normally let the *server* drain the queue. But the server only auto-drains on **natural turn completion** (`_runTurnCompleteSideEffects` runs on `ChatTurnComplete`), **not on cancellation** (`ChatTurnCancelled` just marks the turn cancelled). So after "Send Immediately" cancels the active turn, neither the server nor the client started the next message — the queued message just sat there.

## Fix

Added a `force` parameter that lets the explicit "Send Immediately" path bypass the server-managed-queue short-circuit, so the client dequeues and sends the next request itself (via the normal `_sendRequestAsync` → `_handleTurn` path, which dispatches a fresh `ChatTurnStarted`; `_syncPendingMessages` removes the message from the server queue). The automatic `.finally()` drain path keeps its no-op behavior for agent-host sessions, avoiding double-processing.

## Changes
- `chatService.ts` — `processPendingRequests(sessionResource, force?)` interface + doc
- `chatServiceImpl.ts` — thread `force` through to `processNextPendingRequest`, gate the guard on `!force`
- `chatQueueActions.ts` — `ChatSendPendingImmediatelyAction` now passes `force = true`
- `mockChatService.ts` — signature update
- `chatService.test.ts` — regression test for an `agent-host-copilot` session

## Validation
- Typecheck passes
- All 50 ChatService unit tests pass