### PR TITLE
Support Notification hooks for Copilot chat sessions

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -955,6 +955,7 @@ export default defineConfig(
 				{
 					'allowed': [
 						'onCancellationRequested',
+						'onDidRequestUserAttention',
 						'event'
 					],
 					'verbs': [

--- a/extensions/copilot/assets/prompts/skills/agent-customization/references/hooks.md
+++ b/extensions/copilot/assets/prompts/skills/agent-customization/references/hooks.md
@@ -25,6 +25,7 @@ Hooks from all configured locations are collected and executed; workspace and us
 | `SubagentStart` | Subagent starts |
 | `SubagentStop` | Subagent ends |
 | `Stop` | Agent session ends |
+| `Notification` | When the user's attention is required, e.g. a tool permission prompt or an elicitation dialog. Fire-and-forget; never blocks. |
 
 ## Configuration Format
 
@@ -55,6 +56,8 @@ Hooks receive JSON on stdin and can return JSON on stdout.
 - Common output: `continue`, `stopReason`, `systemMessage`
 - `PreToolUse` permissions are read from `hookSpecificOutput.permissionDecision` (`allow` | `ask` | `deny`)
 - `PostToolUse` output can block further processing with `decision: block`
+- `Notification` receives `{ message, title?, notification_type }` (`notification_type` is `permission_prompt`, `elicitation_dialog`, `agent_completed`, `shell_completed`, or `shell_detached_completed`; `shell_detached_completed` currently behaves the same as `shell_completed`); it is fire-and-forget and its output is ignored
+- Background shell completions can fire frequently — each one spawns a separate `Notification` hook process
 
 `PreToolUse` example output:
 

--- a/extensions/copilot/src/extension/chat/test/vscode-node/chatHookService.spec.ts
+++ b/extensions/copilot/src/extension/chat/test/vscode-node/chatHookService.spec.ts
@@ -5,7 +5,7 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { ChatHookCommand, ChatHookResult, ChatHookResultKind, ChatRequestHooks, Uri } from 'vscode';
-import { IPostToolUseHookResult, IPreToolUseHookResult } from '../../../../platform/chat/common/chatHookService';
+import { IPostToolUseHookResult, IPreToolUseHookResult, NotificationHookInput } from '../../../../platform/chat/common/chatHookService';
 import { HookCommandResultKind, IHookCommandResult } from '../../../../platform/chat/common/hookExecutor';
 import { IToolValidationResult } from '../../../tools/common/toolsService';
 import { isCompatibleHookEventName } from '../../vscode-node/chatHookService';
@@ -442,6 +442,13 @@ describe('ChatHookService.executeHook', () => {
 		expect(results).toHaveLength(1);
 		expect(results[0].resultKind).toBe('success');
 		expect(results[0].output).toBeUndefined();
+	});
+
+	it('Notification hook passes notification_type and is fire-and-forget', async () => {
+		const input: NotificationHookInput = { message: 'Permission needed', title: 'Permission needed', notification_type: 'permission_prompt' };
+		const results = await service.executeHook('Notification', { Notification: [cmd('echo hi')] }, input, 'session-1');
+		expect(results.length).toBe(1);
+		expect(service.executorCalls[0].input).toMatchObject({ hook_event_name: 'Notification', notification_type: 'permission_prompt', message: 'Permission needed' });
 	});
 });
 

--- a/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
+++ b/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
@@ -8,7 +8,7 @@ import { Raw } from '@vscode/prompt-tsx';
 import type { CancellationToken, ChatRequest, ChatResponseProgressPart, ChatResponseReferencePart, ChatResponseStream, ChatResult, LanguageModelToolInformation, Progress } from 'vscode';
 import { IAuthenticationChatUpgradeService } from '../../../platform/authentication/common/authenticationUpgrade';
 import { IChatDebugFileLoggerService } from '../../../platform/chat/common/chatDebugFileLoggerService';
-import { IChatHookService, SessionStartHookInput, SessionStartHookOutput, StopHookInput, StopHookOutput, SubagentStartHookInput, SubagentStartHookOutput, SubagentStopHookInput, SubagentStopHookOutput } from '../../../platform/chat/common/chatHookService';
+import { IChatHookService, NotificationHookInput, SessionStartHookInput, SessionStartHookOutput, StopHookInput, StopHookOutput, SubagentStartHookInput, SubagentStartHookOutput, SubagentStopHookInput, SubagentStopHookOutput } from '../../../platform/chat/common/chatHookService';
 import { FetchStreamSource, IResponsePart } from '../../../platform/chat/common/chatMLFetcher';
 import { CanceledResult, ChatFetchResponseType, ChatLocation, ChatResponse } from '../../../platform/chat/common/commonTypes';
 import { IHistoricalTurn, ISessionTranscriptService, ToolRequest } from '../../../platform/chat/common/sessionTranscriptService';
@@ -820,6 +820,15 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 					}
 				},
 			});
+
+			const notificationInput: NotificationHookInput = {
+				message: l10n.t('Subagent {0} finished', input.agent_type),
+				title: l10n.t('Subagent finished'),
+				notification_type: 'agent_completed',
+			};
+			// Fire-and-forget: the Notification hook never affects the SubagentStop result.
+			this._chatHookService.executeHook('Notification', this.options.request.hooks, notificationInput, sessionId, token)
+				.catch(error => this._logService.error('[ToolCallingLoop] Error executing Notification hook for agent_completed', error));
 
 			if (blockingReasons.size > 0) {
 				return { shouldContinue: true, reasons: [...blockingReasons] };

--- a/extensions/copilot/src/extension/intents/test/node/toolCallingLoopHooks.spec.ts
+++ b/extensions/copilot/src/extension/intents/test/node/toolCallingLoopHooks.spec.ts
@@ -5,7 +5,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CancellationToken, ChatRequest, LanguageModelToolInformation } from 'vscode';
-import { IChatHookService, SessionStartHookInput, StopHookInput, SubagentStartHookInput, SubagentStopHookInput } from '../../../../platform/chat/common/chatHookService';
+import { IChatHookService, NotificationHookInput, SessionStartHookInput, StopHookInput, SubagentStartHookInput, SubagentStopHookInput } from '../../../../platform/chat/common/chatHookService';
 import { MockChatHookService } from './mockChatHookService';
 import { NoopOTelService } from '../../../../platform/otel/common/noopOtelService';
 import { resolveOTelConfig } from '../../../../platform/otel/common/otelConfig';
@@ -1011,5 +1011,64 @@ describe('ToolCallingLoop SubagentStop hook', () => {
 			tokenSource.token
 		);
 		expect(result.shouldContinue).toBe(false);
+	});
+
+	it('should fire a fire-and-forget Notification hook with notification_type=agent_completed when a subagent stops', async () => {
+		const conversation = createTestConversation(1);
+		const request = createMockChatRequest();
+
+		const loop = instantiationService.createInstance(
+			TestToolCallingLoop,
+			{ conversation, toolCallLimit: 10, request }
+		);
+		disposables.add(loop);
+
+		await loop.testExecuteSubagentStopHook(
+			{ agent_id: 'agent-1', agent_type: 'execution', stop_hook_active: false },
+			'session-1',
+			tokenSource.token
+		);
+
+		const notificationCalls = mockChatHookService.getCallsForHook('Notification');
+		expect(notificationCalls).toHaveLength(1);
+		const input = notificationCalls[0].input as NotificationHookInput;
+		expect(input.notification_type).toBe('agent_completed');
+		expect(input.message).toContain('execution');
+		expect(input.title).toBeTruthy();
+	});
+
+	it('should still resolve the SubagentStop result normally even if the Notification hook rejects', async () => {
+		const conversation = createTestConversation(1);
+		const request = createMockChatRequest();
+
+		mockChatHookService.setHookResults('SubagentStop', [
+			{
+				resultKind: 'success',
+				output: {
+					hookSpecificOutput: {
+						hookEventName: 'SubagentStop',
+						decision: 'block',
+						reason: 'Subagent has not completed its task.',
+					},
+				},
+			},
+		]);
+		mockChatHookService.setHookError('Notification', new Error('Notification hook failed'));
+
+		const loop = instantiationService.createInstance(
+			TestToolCallingLoop,
+			{ conversation, toolCallLimit: 10, request }
+		);
+		disposables.add(loop);
+
+		const result = await loop.testExecuteSubagentStopHook(
+			{ agent_id: 'agent-1', agent_type: 'execution', stop_hook_active: false },
+			'session-1',
+			tokenSource.token
+		);
+
+		// The SubagentStop result is unaffected by the failing Notification hook.
+		expect(result.shouldContinue).toBe(true);
+		expect(result.reasons).toEqual(['Subagent has not completed its task.']);
 	});
 });

--- a/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
+++ b/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
@@ -8,7 +8,7 @@ import { Raw } from '@vscode/prompt-tsx';
 import type { ChatRequest, ChatResponseReferencePart, ChatResponseStream, ChatResult, LanguageModelToolInformation, Progress } from 'vscode';
 import { IAuthenticationService } from '../../../platform/authentication/common/authentication';
 import { IAuthenticationChatUpgradeService } from '../../../platform/authentication/common/authenticationUpgrade';
-import { IChatHookService, UserPromptSubmitHookInput, UserPromptSubmitHookOutput } from '../../../platform/chat/common/chatHookService';
+import { IChatHookService, NotificationHookInput, UserPromptSubmitHookInput, UserPromptSubmitHookOutput } from '../../../platform/chat/common/chatHookService';
 import { CanceledResult, ChatFetchError, ChatFetchResponseType, ChatLocation, ChatResponse, getErrorDetailsFromChatFetchError } from '../../../platform/chat/common/commonTypes';
 import { IConversationOptions } from '../../../platform/chat/common/conversationOptions';
 import { ISessionTranscriptService } from '../../../platform/chat/common/sessionTranscriptService';
@@ -351,6 +351,21 @@ export class DefaultIntentRequestHandler {
 			responseHandlers.push(promise);
 			return promise;
 		}, this));
+
+		if (this.request.onDidRequestUserAttention) {
+			store.add(this.request.onDidRequestUserAttention(e => {
+				const input: NotificationHookInput = { message: e.message, title: e.title, notification_type: e.notificationType };
+				// Fire-and-forget: Notification hooks never block the request.
+				void this._chatHookService.executeHook('Notification', this.request.hooks, input, this.conversation.sessionId, this.token);
+			}));
+		}
+
+		if (this.request.notification) {
+			const n = this.request.notification;
+			const input: NotificationHookInput = { message: n.message, title: n.title, notification_type: n.notificationType };
+			// Fire-and-forget: Notification hooks never block the request.
+			void this._chatHookService.executeHook('Notification', this.request.hooks, input, this.conversation.sessionId, this.token);
+		}
 
 		try {
 			// Execute start hooks first (SessionStart/SubagentStart), then UserPromptSubmit

--- a/extensions/copilot/src/extension/prompt/node/test/defaultIntentRequestHandler.spec.ts
+++ b/extensions/copilot/src/extension/prompt/node/test/defaultIntentRequestHandler.spec.ts
@@ -6,7 +6,8 @@
 
 import { Raw, RenderPromptResult } from '@vscode/prompt-tsx';
 import { afterEach, beforeEach, expect, suite, test, vi } from 'vitest';
-import type { ChatLanguageModelToolReference, ChatPromptReference, ChatRequest, ExtendedChatResponsePart, LanguageModelChat } from 'vscode';
+import type { ChatHookType, ChatLanguageModelToolReference, ChatPromptReference, ChatRequest, ChatRequestHooks, ChatRequestNotification, ChatRequestUserAttention, ExtendedChatResponsePart, LanguageModelChat } from 'vscode';
+import { IChatHookService } from '../../../../platform/chat/common/chatHookService';
 import { IChatMLFetcher } from '../../../../platform/chat/common/chatMLFetcher';
 import { toTextPart } from '../../../../platform/chat/common/globalStringUtils';
 import { StaticChatMLFetcher } from '../../../../platform/chat/test/common/staticChatMLFetcher';
@@ -20,6 +21,7 @@ import { NullWorkspaceFileIndex } from '../../../../platform/workspaceChunkSearc
 import { IWorkspaceFileIndex } from '../../../../platform/workspaceChunkSearch/node/workspaceFileIndex';
 import { ChatResponseStreamImpl } from '../../../../util/common/chatResponseStreamImpl';
 import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
+import { Emitter } from '../../../../util/vs/base/common/event';
 import { isObject, isUndefinedOrNull } from '../../../../util/vs/base/common/types';
 import { generateUuid } from '../../../../util/vs/base/common/uuid';
 import { SyncDescriptor } from '../../../../util/vs/platform/instantiation/common/descriptors';
@@ -138,6 +140,13 @@ suite('defaultIntentRequestHandler', () => {
 		sessionId = generateUuid();
 		sessionResource = Uri.parse(`test://session/${this.sessionId}`);
 		hasHooksEnabled = false;
+		hooks?: ChatRequestHooks;
+		notification?: ChatRequestNotification;
+		private readonly _onDidRequestUserAttention = new Emitter<ChatRequestUserAttention>();
+		readonly onDidRequestUserAttention = this._onDidRequestUserAttention.event;
+		fireUserAttention(e: ChatRequestUserAttention): void {
+			this._onDidRequestUserAttention.fire(e);
+		}
 	}
 
 	const responseStream = new ChatResponseStreamImpl(p => response.push(p), () => { }, undefined, undefined, undefined, () => Promise.resolve(undefined));
@@ -189,6 +198,136 @@ suite('defaultIntentRequestHandler', () => {
 		// Wait for event loop to finish as we often fire off telemetry without properly awaiting it as it doesn't matter when it is sent
 		await new Promise(setImmediate);
 		expect(getDerandomizedTelemetry()).toMatchSnapshot();
+	});
+
+	test('runs the Notification hook when the editor signals user attention, fire-and-forget', async () => {
+		const executeHookCalls: { hookType: ChatHookType; hooks: ChatRequestHooks | undefined; input: unknown }[] = [];
+		// Tracks whether the (always-rejecting) Notification hook promise was actually
+		// rejected, without leaving it as an unhandled rejection (the production code
+		// fires it with `void`, the same way it would in the real extension).
+		let notificationHookRejected = false;
+		const hookService: IChatHookService = {
+			_serviceBrand: undefined,
+			logConfiguredHooks: () => { },
+			executeHook: (hookType, hooks, input) => {
+				executeHookCalls.push({ hookType, hooks, input });
+				if (hookType === 'Notification') {
+					const rejection = Promise.reject(new Error('Notification hook failed'));
+					rejection.catch(() => { notificationHookRejected = true; });
+					return rejection;
+				}
+				return Promise.resolve([]);
+			},
+			executePreToolUseHook: async () => undefined,
+			executePostToolUseHook: async () => undefined,
+		};
+
+		const services = createExtensionUnitTestingServices();
+		telemetry = new SpyingTelemetryService();
+		chatResponse = [];
+		fetcher = new StaticChatMLFetcher(chatResponse);
+		services.define(ITelemetryService, telemetry);
+		services.define(IChatMLFetcher, fetcher);
+		services.define(IWorkspaceFileIndex, new SyncDescriptor(NullWorkspaceFileIndex));
+		services.define(IChatHookService, hookService);
+
+		accessor = services.createTestingAccessor();
+		endpoint = accessor.get(IInstantiationService).createInstance(MockEndpoint, undefined);
+
+		const request = new TestChatRequest();
+		request.hooks = { sentinel: true } as unknown as ChatRequestHooks;
+
+		const handler = makeHandler({ request });
+		chatResponse[0] = 'some response here :)';
+		promptResult = {
+			...nullRenderPromptResult(),
+			messages: [{ role: Raw.ChatRole.User, content: [toTextPart('hello world!')] }],
+		};
+
+		const resultPromise = handler.getResult();
+
+		// Let the handler progress through intent invocation and confirmation handling
+		// (real awaited promises) up to where runWithToolCalling registers the subscription.
+		await new Promise(setImmediate);
+		await new Promise(setImmediate);
+
+		request.fireUserAttention({ notificationType: 'permission_prompt', message: 'Permission needed', title: 'Permission needed' });
+
+		// Fire-and-forget: a rejecting Notification hook must not interrupt the request.
+		const result = await resultPromise;
+		expect(result).not.toHaveProperty('errorDetails');
+		await new Promise(setImmediate);
+		expect(notificationHookRejected).toBe(true);
+
+		const notificationCalls = executeHookCalls.filter(c => c.hookType === 'Notification');
+		expect(notificationCalls).toHaveLength(1);
+		expect(notificationCalls[0].hooks).toBe(request.hooks);
+		expect(notificationCalls[0].input).toEqual({
+			notification_type: 'permission_prompt',
+			message: 'Permission needed',
+			title: 'Permission needed',
+		});
+	});
+
+	test('runs the Notification hook when the request carries a notification descriptor, fire-and-forget', async () => {
+		const executeHookCalls: { hookType: ChatHookType; hooks: ChatRequestHooks | undefined; input: unknown }[] = [];
+		// Tracks whether the (always-rejecting) Notification hook promise was actually
+		// rejected, without leaving it as an unhandled rejection (the production code
+		// fires it with `void`, the same way it would in the real extension).
+		let notificationHookRejected = false;
+		const hookService: IChatHookService = {
+			_serviceBrand: undefined,
+			logConfiguredHooks: () => { },
+			executeHook: (hookType, hooks, input) => {
+				executeHookCalls.push({ hookType, hooks, input });
+				if (hookType === 'Notification') {
+					const rejection = Promise.reject(new Error('Notification hook failed'));
+					rejection.catch(() => { notificationHookRejected = true; });
+					return rejection;
+				}
+				return Promise.resolve([]);
+			},
+			executePreToolUseHook: async () => undefined,
+			executePostToolUseHook: async () => undefined,
+		};
+
+		const services = createExtensionUnitTestingServices();
+		telemetry = new SpyingTelemetryService();
+		chatResponse = [];
+		fetcher = new StaticChatMLFetcher(chatResponse);
+		services.define(ITelemetryService, telemetry);
+		services.define(IChatMLFetcher, fetcher);
+		services.define(IWorkspaceFileIndex, new SyncDescriptor(NullWorkspaceFileIndex));
+		services.define(IChatHookService, hookService);
+
+		accessor = services.createTestingAccessor();
+		endpoint = accessor.get(IInstantiationService).createInstance(MockEndpoint, undefined);
+
+		const request = new TestChatRequest();
+		request.hooks = { sentinel: true } as unknown as ChatRequestHooks;
+		request.notification = { notificationType: 'shell_completed', message: 'Command completed', title: 'Command completed' };
+
+		const handler = makeHandler({ request });
+		chatResponse[0] = 'some response here :)';
+		promptResult = {
+			...nullRenderPromptResult(),
+			messages: [{ role: Raw.ChatRole.User, content: [toTextPart('hello world!')] }],
+		};
+
+		// Fire-and-forget: a rejecting Notification hook must not interrupt the request.
+		const result = await handler.getResult();
+		expect(result).not.toHaveProperty('errorDetails');
+		await new Promise(setImmediate);
+		expect(notificationHookRejected).toBe(true);
+
+		const notificationCalls = executeHookCalls.filter(c => c.hookType === 'Notification');
+		expect(notificationCalls).toHaveLength(1);
+		expect(notificationCalls[0].hooks).toBe(request.hooks);
+		expect(notificationCalls[0].input).toEqual({
+			notification_type: 'shell_completed',
+			message: 'Command completed',
+			title: 'Command completed',
+		});
 	});
 
 	test('propagates resolvedModel into result metadata from a successful response', async () => {

--- a/extensions/copilot/src/platform/chat/common/chatHookService.ts
+++ b/extensions/copilot/src/platform/chat/common/chatHookService.ts
@@ -290,4 +290,16 @@ export interface PreCompactHookInput {
 	readonly custom_instructions?: string;
 }
 
+/**
+ * Input passed to the Notification hook. Notification hooks are fire-and-forget.
+ */
+export interface NotificationHookInput {
+	/** Human-readable notification text. */
+	readonly message: string;
+	/** Short title (e.g. "Permission needed"). */
+	readonly title?: string;
+	/** Notification kind, e.g. 'permission_prompt' or 'elicitation_dialog'. */
+	readonly notification_type: string;
+}
+
 //#endregion

--- a/extensions/copilot/src/util/common/test/shims/chatTypes.ts
+++ b/extensions/copilot/src/util/common/test/shims/chatTypes.ts
@@ -60,7 +60,7 @@ export class ChatResponseThinkingProgressPart {
 	}
 }
 
-export type ChatHookType = 'SessionStart' | 'UserPromptSubmit' | 'PreToolUse' | 'PostToolUse' | 'SubagentStart' | 'SubagentStop' | 'Stop';
+export type ChatHookType = 'SessionStart' | 'UserPromptSubmit' | 'PreToolUse' | 'PostToolUse' | 'SubagentStart' | 'SubagentStop' | 'Stop' | 'Notification';
 
 export class ChatResponseHookPart {
 	hookType: ChatHookType;

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -411,6 +411,9 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 			setYieldRequested: (requestId, value) => {
 				this._proxy.$setYieldRequested(requestId, value);
 			},
+			notifyUserAttention: (requestId, attention) => {
+				this._proxy.$notifyUserAttention(requestId, attention);
+			},
 			provideFollowups: async (request, result, history, token): Promise<IChatFollowup[]> => {
 				if (!this._agents.get(handle)?.hasFollowups) {
 					return [];

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1746,6 +1746,7 @@ export interface ExtHostChatAgentsShape2 {
 	$provideSourceFolders(handle: number, sessionResource: UriComponents, type: string, token: CancellationToken): Promise<IChatSessionCustomizationSourceFolderDto[] | undefined>;
 	$setRequestTools(requestId: string, tools: UserSelectedTools): void;
 	$setYieldRequested(requestId: string, value: boolean): void;
+	$notifyUserAttention(requestId: string, attention: { notificationType: string; message: string; title?: string }): void;
 	$acceptActiveChatSession(sessionResource: UriComponents | undefined): void;
 	$onDidChangeCustomAgents(): void;
 	$onDidChangeInstructions(): void;

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -472,6 +472,7 @@ interface InFlightChatRequest {
 	extension: IRelaxedExtensionDescription;
 	hooks?: ChatRequestHooks;
 	yieldRequested: boolean;
+	userAttention: Emitter<vscode.ChatRequestUserAttention>;
 }
 
 export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsShape2 {
@@ -970,6 +971,11 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 		}
 	}
 
+	$notifyUserAttention(requestId: string, attention: { notificationType: string; message: string; title?: string }): void {
+		const request = [...this._inFlightRequests].find(r => r.requestId === requestId);
+		request?.userAttention.fire(attention);
+	}
+
 	async $invokeAgent(handle: number, requestDto: Dto<IChatAgentRequest>, context: { history: IChatAgentHistoryEntryDto[]; chatSessionContext?: IChatSessionContextDto }, token: CancellationToken): Promise<IChatAgentInvokeResult | undefined> {
 		const agent = this._agents.get(handle);
 		if (!agent) {
@@ -1003,7 +1009,12 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 				agent.extension,
 				this._logService
 			);
-			inFlightRequest = { requestId: requestDto.requestId, extRequest, extension: agent.extension, hooks: request.hooks, yieldRequested: false };
+			const userAttention = sessionDisposables.add(new Emitter<vscode.ChatRequestUserAttention>());
+			if (isProposedApiEnabled(agent.extension, 'chatParticipantAdditions')) {
+				(extRequest as { onDidRequestUserAttention?: vscode.Event<vscode.ChatRequestUserAttention> }).onDidRequestUserAttention = userAttention.event;
+			}
+
+			inFlightRequest = { requestId: requestDto.requestId, extRequest, extension: agent.extension, hooks: request.hooks, yieldRequested: false, userAttention };
 			this._inFlightRequests.add(inFlightRequest);
 
 

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -3465,6 +3465,7 @@ export namespace ChatAgentRequest {
 			hasHooksEnabled: request.hasHooksEnabled ?? false,
 			hooks: request.hooks ? ChatRequestHooksConverter.to(request.hooks) : undefined,
 			isSystemInitiated: request.isSystemInitiated,
+			notification: request.notification,
 		};
 
 		if (!isProposedApiEnabled(extension, 'chatParticipantPrivate')) {

--- a/src/vs/workbench/api/test/common/extHostChatAgents2.test.ts
+++ b/src/vs/workbench/api/test/common/extHostChatAgents2.test.ts
@@ -4,18 +4,32 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import type * as vscode from 'vscode';
 import { DeferredPromise } from '../../../../base/common/async.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
-import { URI } from '../../../../base/common/uri.js';
+import { mock } from '../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../../platform/log/common/log.js';
+import { URI } from '../../../../base/common/uri.js';
 import { ChatAgentLocation } from '../../../contrib/chat/common/constants.js';
 import { IChatAgentRequest } from '../../../contrib/chat/common/participants/chatAgents.js';
+import { ILanguageModelChatInfoOptions } from '../../../contrib/chat/common/languageModels.js';
 import { nullExtensionDescription } from '../../../services/extensions/common/extensions.js';
-import { ChatAgentResponseStream } from '../../common/extHostChatAgents2.js';
-import { CommandsConverter } from '../../common/extHostCommands.js';
-import { IChatAgentProgressShape, IChatProgressDto } from '../../common/extHost.protocol.js';
+import { IExtHostAuthentication } from '../../common/extHostAuthentication.js';
+import { IExtHostFileSystemInfo } from '../../common/extHostFileSystemInfo.js';
+import { ExtHostDocumentsAndEditors, IExtHostDocumentsAndEditors } from '../../common/extHostDocumentsAndEditors.js';
+import { ChatAgentResponseStream, ExtHostChatAgents2 } from '../../common/extHostChatAgents2.js';
+import { ExtHostChatSessions } from '../../common/extHostChatSessions.js';
+import { CommandsConverter, ExtHostCommands } from '../../common/extHostCommands.js';
+import { ExtHostDiagnostics } from '../../common/extHostDiagnostics.js';
+import { ExtHostDocuments } from '../../common/extHostDocuments.js';
+import { ExtHostLanguageModels } from '../../common/extHostLanguageModels.js';
+import { ExtHostLanguageModelTools } from '../../common/extHostLanguageModelTools.js';
+import { IChatAgentProgressShape, IChatProgressDto, MainThreadLanguageModelToolsShape } from '../../common/extHost.protocol.js';
+import { IExtHostTelemetry } from '../../common/extHostTelemetry.js';
 import { ChatResponseAnchorPart } from '../../common/extHostTypes.js';
+import { AnyCallRPCProtocol } from './testRPCProtocol.js';
 
 suite('ExtHostChatAgents2', function () {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
@@ -68,5 +82,124 @@ suite('ExtHostChatAgents2', function () {
 		assert.strictEqual(progressChunk.kind, 'inlineReference');
 		assert.ok(progressChunk.resolveId);
 		assert.strictEqual(resolvedHandle, progressChunk.resolveId);
+	});
+
+	suite('$notifyUserAttention', function () {
+		let agents: ExtHostChatAgents2;
+		let languageModels: ExtHostLanguageModels;
+		let registeredHandle: number | undefined;
+
+		setup(function () {
+			registeredHandle = undefined;
+			const rpcProtocol = AnyCallRPCProtocol<MainThreadLanguageModelToolsShape>({
+				$getTools: () => Promise.resolve([]),
+				$registerAgent: (handle: number) => { registeredHandle = handle; }
+			} as unknown as MainThreadLanguageModelToolsShape);
+			const logService = new NullLogService();
+
+			const commands = new ExtHostCommands(rpcProtocol, logService, new class extends mock<IExtHostTelemetry>() { });
+			const documentsAndEditors = new ExtHostDocumentsAndEditors(rpcProtocol, logService);
+			const documents = disposables.add(new ExtHostDocuments(rpcProtocol, documentsAndEditors));
+			languageModels = disposables.add(new ExtHostLanguageModels(rpcProtocol, logService, new class extends mock<IExtHostAuthentication>() { }));
+			const diagnostics = new ExtHostDiagnostics(rpcProtocol, logService, new class extends mock<IExtHostFileSystemInfo>() { }, new class extends mock<IExtHostDocumentsAndEditors>() {
+				override getDocument() { return undefined; }
+			});
+			const tools = new ExtHostLanguageModelTools(rpcProtocol, languageModels);
+			const chatSessions = disposables.add(new ExtHostChatSessions(commands, languageModels, rpcProtocol, logService));
+
+			agents = disposables.add(new ExtHostChatAgents2(rpcProtocol, logService, commands, documents, documentsAndEditors, languageModels, diagnostics, tools, chatSessions));
+		});
+
+		test('fires onDidRequestUserAttention on the in-flight request', async function () {
+			// Register a fake model provider so `getLanguageModelByIdentifier` can resolve the
+			// `userSelectedModelId` below without a real main-thread round trip: our test drives
+			// `$provideLanguageModelChatInfo` directly, mirroring what the (stubbed) main thread
+			// would normally trigger via `$selectChatModels`.
+			const modelInfo: vscode.LanguageModelChatInformation = {
+				id: 'test-model',
+				name: 'Test Model',
+				family: 'test-family',
+				version: '1.0',
+				maxInputTokens: 100,
+				maxOutputTokens: 100,
+				capabilities: {}
+			};
+			disposables.add(languageModels.registerLanguageModelChatProvider(nullExtensionDescription, 'test-vendor', {
+				provideLanguageModelChatInformation: () => [modelInfo],
+				provideLanguageModelChatResponse: () => { throw new Error('not implemented'); },
+				provideTokenCount: () => { throw new Error('not implemented'); }
+			}));
+			const options: ILanguageModelChatInfoOptions = { silent: true };
+			const [{ identifier: modelIdentifier }] = await languageModels.$provideLanguageModelChatInfo('test-vendor', options, CancellationToken.None);
+
+			const receivedAttentions: vscode.ChatRequestUserAttention[] = [];
+			const extension = { ...nullExtensionDescription, enabledApiProposals: ['chatParticipantAdditions'] };
+			const requestDto: IChatAgentRequest = {
+				sessionResource: URI.parse('chat-session:/test'),
+				requestId: 'requestId',
+				agentId: 'agentId',
+				message: '',
+				variables: { variables: [] },
+				location: ChatAgentLocation.Chat,
+				userSelectedModelId: modelIdentifier
+			};
+			const requestHandler: vscode.ChatExtendedRequestHandler = (request) => {
+				disposables.add(request.onDidRequestUserAttention!(attention => receivedAttentions.push(attention)));
+				// Simulate the (later-wired) main thread calling `$notifyUserAttention` while the
+				// request is still in flight, e.g. to surface a tool permission prompt.
+				agents.$notifyUserAttention(requestDto.requestId, { notificationType: 'permission_prompt', message: 'm', title: 't' });
+				return {};
+			};
+			agents.createChatAgent(extension, 'agentId', requestHandler);
+
+			await agents.$invokeAgent(0, requestDto, { history: [] }, CancellationToken.None);
+
+			assert.deepStrictEqual(receivedAttentions, [{ notificationType: 'permission_prompt', message: 'm', title: 't' }]);
+		});
+
+		test('threads request.notification through to vscode.ChatRequest', async function () {
+			const modelInfo: vscode.LanguageModelChatInformation = {
+				id: 'test-model',
+				name: 'Test Model',
+				family: 'test-family',
+				version: '1.0',
+				maxInputTokens: 100,
+				maxOutputTokens: 100,
+				capabilities: {}
+			};
+			disposables.add(languageModels.registerLanguageModelChatProvider(nullExtensionDescription, 'test-vendor', {
+				provideLanguageModelChatInformation: () => [modelInfo],
+				provideLanguageModelChatResponse: () => { throw new Error('not implemented'); },
+				provideTokenCount: () => { throw new Error('not implemented'); }
+			}));
+			const options: ILanguageModelChatInfoOptions = { silent: true };
+			const [{ identifier: modelIdentifier }] = await languageModels.$provideLanguageModelChatInfo('test-vendor', options, CancellationToken.None);
+
+			const extension = { ...nullExtensionDescription, enabledApiProposals: ['chatParticipantAdditions'] };
+			const requestDto: IChatAgentRequest = {
+				sessionResource: URI.parse('chat-session:/test'),
+				requestId: 'requestId',
+				agentId: 'agentId',
+				message: '',
+				variables: { variables: [] },
+				location: ChatAgentLocation.Chat,
+				userSelectedModelId: modelIdentifier,
+				notification: { notificationType: 'shell_completed', message: 'm', title: 't' }
+			};
+			let receivedNotification: vscode.ChatRequestNotification | undefined;
+			const requestHandler: vscode.ChatExtendedRequestHandler = (request) => {
+				receivedNotification = request.notification;
+				return {};
+			};
+
+			// `createChatAgent` assigns handles from a process-wide static pool. `setup` wires
+			// `$registerAgent` (see above) to capture the handle it was just given.
+			agents.createChatAgent(extension, 'agentId', requestHandler);
+			assert.ok(registeredHandle !== undefined, 'expected $registerAgent to be called');
+
+			await agents.$invokeAgent(registeredHandle!, requestDto, { history: [] }, CancellationToken.None);
+
+			assert.deepStrictEqual(receivedNotification, { notificationType: 'shell_completed', message: 'm', title: 't' });
+		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -660,9 +660,19 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 					return toolResult;
 				}
 
-				if (preparedInvocation?.confirmationMessages?.title) {
+				const confirmationTitle = preparedInvocation?.confirmationMessages?.title;
+				if (confirmationTitle) {
 					if (!IChatToolInvocation.executionConfirmedOrDenied(toolInvocation) && !autoConfirmed) {
 						this.playAccessibilitySignal([toolInvocation], dto.context?.sessionResource);
+						if (model && dto.chatRequestId) {
+							const confirmationMessage = preparedInvocation?.confirmationMessages?.message;
+							model.notifyUserAttention(
+								dto.chatRequestId,
+								'permission_prompt',
+								renderAsPlaintext(confirmationMessage ?? confirmationTitle),
+								renderAsPlaintext(confirmationTitle),
+							);
+						}
 					}
 					const userConfirmed = await IChatToolInvocation.awaitConfirmation(toolInvocation, token);
 					this._logToolApprovalTelemetry(tool, dto, userConfirmed);

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -1678,6 +1678,12 @@ export interface IChatSendRequestOptions {
 	terminalExecutionId?: string;
 
 	/**
+	 * When set, the editor initiated this request to surface a status notification
+	 * (e.g. a background terminal command completed). Delivered to the agent as request metadata.
+	 */
+	notification?: { notificationType: string; message: string; title?: string };
+
+	/**
 	 * When set, the chat service will collect automatic instructions
 	 * (for example `.instructions.md` files and skills) asynchronously after showing
 	 * the request in the UI, rather than blocking the UI on collection.

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -1340,6 +1340,7 @@ export class ChatService extends Disposable implements IChatService {
 							hooks: collectedHooks,
 							hasHooksEnabled: !!collectedHooks && Object.values(collectedHooks).some(arr => arr.length > 0),
 							isSystemInitiated: options?.isSystemInitiated,
+							notification: options?.notification,
 							workingDirectory: model.workingDirectory,
 						};
 
@@ -1409,6 +1410,15 @@ export class ChatService extends Disposable implements IChatService {
 						if (pendingRequest.requestId) {
 							this.telemetryService.publicLog2<ChatPendingRequestChangeEvent, ChatPendingRequestChangeClassification>(ChatPendingRequestChangeEventName, { action: 'add', source: 'sendRequestId', requestId: pendingRequest.requestId, chatSessionId: chatSessionResourceToId(sessionResource) });
 						}
+					}
+
+					if (request) {
+						const requestId = request.id;
+						store.add(model.onDidRequestUserAttention(e => {
+							if (e.requestId === requestId) {
+								this.chatAgentService.notifyUserAttention(agent.id, e.requestId, { notificationType: e.notificationType, message: e.message, title: e.title });
+							}
+						}));
 					}
 
 					// Check for disabled Claude Code hooks and notify the user once per workspace.

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -1629,6 +1629,16 @@ export interface IChatModel extends IDisposable {
 
 	readonly onDidChangePendingRequests: Event<void>;
 	getPendingRequests(): readonly IChatPendingRequest[];
+
+	readonly onDidRequestUserAttention: Event<IChatUserAttention>;
+	notifyUserAttention(requestId: string, notificationType: string, message: string, title?: string): void;
+}
+
+export interface IChatUserAttention {
+	readonly requestId: string;
+	readonly notificationType: string;
+	readonly message: string;
+	readonly title?: string;
 }
 
 export interface ISerializableChatsData {
@@ -2169,6 +2179,13 @@ export class ChatModel extends Disposable implements IChatModel {
 	private readonly _pendingRequests: IChatPendingRequest[] = [];
 	private readonly _onDidChangePendingRequests = this._register(new Emitter<void>());
 	readonly onDidChangePendingRequests = this._onDidChangePendingRequests.event;
+
+	private readonly _onDidRequestUserAttention = this._register(new Emitter<IChatUserAttention>());
+	readonly onDidRequestUserAttention: Event<IChatUserAttention> = this._onDidRequestUserAttention.event;
+
+	notifyUserAttention(requestId: string, notificationType: string, message: string, title?: string): void {
+		this._onDidRequestUserAttention.fire({ requestId, notificationType, message, title });
+	}
 
 	private _requests: ChatRequestModel[];
 
@@ -2885,6 +2902,12 @@ export class ChatModel extends Disposable implements IChatModel {
 
 		if (request.response.isComplete) {
 			throw new Error('acceptResponseProgress: Adding progress to a completed response');
+		}
+
+		if (progress.kind === 'elicitation2') {
+			const message = typeof progress.message === 'string' ? progress.message : progress.message.value;
+			const title = typeof progress.title === 'string' ? progress.title : progress.title.value;
+			this.notifyUserAttention(request.id, 'elicitation_dialog', message, title);
 		}
 
 		if (progress.kind === 'usage') {

--- a/src/vs/workbench/contrib/chat/common/participants/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/participants/chatAgents.ts
@@ -92,6 +92,7 @@ export interface IChatAgentImplementation {
 	invoke(request: IChatAgentRequest, progress: (parts: IChatProgress[]) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult>;
 	setRequestTools?(requestId: string, tools: UserSelectedTools): void;
 	setYieldRequested?(requestId: string, value: boolean): void;
+	notifyUserAttention?(requestId: string, attention: { notificationType: string; message: string; title?: string }): void;
 	provideFollowups?(request: IChatAgentRequest, result: IChatAgentResult, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatFollowup[]>;
 	provideChatTitle?: (history: IChatAgentHistoryEntry[], token: CancellationToken) => Promise<string | undefined>;
 	provideChatSummary?: (history: IChatAgentHistoryEntry[], token: CancellationToken) => Promise<string | undefined>;
@@ -192,6 +193,12 @@ export interface IChatAgentRequest {
 	 * When true, this request was initiated by the system rather than the user.
 	 */
 	isSystemInitiated?: boolean;
+
+	/**
+	 * When set, the editor initiated this request to surface a status notification
+	 * (e.g. a background terminal command completed). Delivered to the agent as request metadata.
+	 */
+	notification?: { notificationType: string; message: string; title?: string };
 }
 
 export interface IChatQuestion {
@@ -254,6 +261,7 @@ export interface IChatAgentService {
 	invokeAgent(agent: string, request: IChatAgentRequest, progress: (parts: IChatProgress[]) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult>;
 	setRequestTools(agent: string, requestId: string, tools: UserSelectedTools): void;
 	setYieldRequested(agent: string, requestId: string, value: boolean): void;
+	notifyUserAttention(agent: string, requestId: string, attention: { notificationType: string; message: string; title?: string }): void;
 	getFollowups(id: string, request: IChatAgentRequest, result: IChatAgentResult, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatFollowup[]>;
 	getChatTitle(id: string, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<string | undefined>;
 	getChatSummary(id: string, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<string | undefined>;
@@ -558,6 +566,15 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 		data.impl.setYieldRequested?.(requestId, value);
 	}
 
+	notifyUserAttention(id: string, requestId: string, attention: { notificationType: string; message: string; title?: string }): void {
+		const data = this._agents.get(id);
+		if (!data?.impl) {
+			return;
+		}
+
+		data.impl.notifyUserAttention?.(requestId, attention);
+	}
+
 	async getFollowups(id: string, request: IChatAgentRequest, result: IChatAgentResult, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatFollowup[]> {
 		const data = this._agents.get(id);
 		if (!data?.impl?.provideFollowups) {
@@ -674,6 +691,10 @@ export class MergedChatAgent implements IChatAgent {
 
 	setYieldRequested(requestId: string, value: boolean): void {
 		this.impl.setYieldRequested?.(requestId, value);
+	}
+
+	notifyUserAttention(requestId: string, attention: { notificationType: string; message: string; title?: string }): void {
+		this.impl.notifyUserAttention?.(requestId, attention);
 	}
 
 	async provideFollowups(request: IChatAgentRequest, result: IChatAgentResult, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatFollowup[]> {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/hookTypes.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/hookTypes.ts
@@ -19,6 +19,7 @@ export enum HookType {
 	SubagentStart = 'SubagentStart',
 	SubagentStop = 'SubagentStop',
 	Stop = 'Stop',
+	Notification = 'Notification',
 	ErrorOccurred = 'ErrorOccurred',
 }
 
@@ -38,6 +39,7 @@ export const HOOKS_BY_TARGET: Record<Target, Record<string, HookType>> = {
 		'SubagentStart': HookType.SubagentStart,
 		'SubagentStop': HookType.SubagentStop,
 		'Stop': HookType.Stop,
+		'Notification': HookType.Notification,
 	},
 	// see https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-hooks#types-of-hooks
 	[Target.GitHubCopilot]: {
@@ -60,6 +62,7 @@ export const HOOKS_BY_TARGET: Record<Target, Record<string, HookType>> = {
 		'SubagentStart': HookType.SubagentStart,
 		'SubagentStop': HookType.SubagentStop,
 		'Stop': HookType.Stop,
+		'Notification': HookType.Notification,
 	},
 	// if no target, just list all known hook types.
 	[Target.Undefined]: Object.fromEntries(
@@ -110,6 +113,10 @@ export const HOOK_METADATA: { [key in HookType]: IHookTypeMeta } = {
 	[HookType.Stop]: {
 		label: nls.localize('hookType.stop.label', "Stop"),
 		description: nls.localize('hookType.stop.description', "Executed when the agent stops.")
+	},
+	[HookType.Notification]: {
+		label: nls.localize('hookType.notification.label', "Notification"),
+		description: nls.localize('hookType.notification.description', "Executed when the agent needs the user's attention, such as a permission prompt or elicitation dialog.")
 	},
 	[HookType.SessionEnd]: {
 		label: nls.localize('hookType.sessionEnd.label', "Session End"),

--- a/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
@@ -133,13 +133,24 @@ function registerToolForTest(service: LanguageModelToolsService, store: any, id:
 	};
 }
 
-function stubGetSession(chatService: MockChatService, sessionId: string, options?: { requestId?: string; capture?: { invocation?: any }; modeInfo?: { permissionLevel?: ChatPermissionLevel } }): IChatModel {
+interface IUserAttentionCall {
+	requestId: string;
+	notificationType: string;
+	message: string;
+	title?: string;
+}
+
+function stubGetSession(chatService: MockChatService, sessionId: string, options?: { requestId?: string; capture?: { invocation?: any }; modeInfo?: { permissionLevel?: ChatPermissionLevel }; userAttentionCalls?: IUserAttentionCall[] }): IChatModel {
 	const requestId = options?.requestId ?? 'requestId';
 	const capture = options?.capture;
+	const userAttentionCalls = options?.userAttentionCalls;
 	const fakeModel = {
 		sessionId,
 		sessionResource: LocalChatSessionUri.forSession(sessionId),
 		getRequests: () => [{ id: requestId, modelId: 'test-model', modeInfo: options?.modeInfo }],
+		notifyUserAttention: (notifyRequestId: string, notificationType: string, message: string, title?: string) => {
+			userAttentionCalls?.push({ requestId: notifyRequestId, notificationType, message, title });
+		},
 	} as ChatModel;
 	chatService.addSession(fakeModel);
 	chatService.appendProgress = (request, progress) => {
@@ -589,6 +600,74 @@ suite('LanguageModelToolsService', () => {
 		const result = await promise;
 		assert.strictEqual(invoked, true, 'invoke should have run after confirmation');
 		assert.strictEqual(result.content[0].value, 'ran');
+	});
+
+	test('chat invocation notifies user attention with permission_prompt when a confirmation is shown', async () => {
+		const toolData: IToolData = {
+			id: 'testToolNotifyAttention',
+			modelDescription: 'Test Tool',
+			displayName: 'Test Tool',
+			source: ToolDataSource.Internal,
+		};
+
+		const tool = registerToolForTest(service, store, toolData.id, {
+			prepareToolInvocation: async () => ({ confirmationMessages: { title: 'Confirm Attention', message: 'Proceed with attention?' } }),
+			invoke: async () => ({ content: [{ kind: 'text', value: 'ran' }] }),
+		}, toolData);
+
+		const sessionId = 'sessionId-notify-attention';
+		const capture: { invocation?: any } = {};
+		const userAttentionCalls: IUserAttentionCall[] = [];
+		stubGetSession(chatService, sessionId, { requestId: 'requestId-notify-attention', capture, userAttentionCalls });
+
+		const dto = tool.makeDto({ x: 1 }, { sessionId });
+		dto.chatRequestId = 'requestId-notify-attention';
+
+		const promise = service.invokeTool(dto, async () => 0, CancellationToken.None);
+		const published = await waitForPublishedInvocation(capture);
+		assert.ok(published, 'expected ChatToolInvocation to be published');
+
+		assert.strictEqual(userAttentionCalls.length, 1, 'notifyUserAttention should have been called once');
+		const call = userAttentionCalls[0];
+		assert.strictEqual(call.notificationType, 'permission_prompt');
+		assert.strictEqual(call.requestId, 'requestId-notify-attention');
+		assert.ok(call.message, 'message should be non-empty');
+		assert.ok(call.title, 'title should be non-empty');
+
+		IChatToolInvocation.confirmWith(published, { type: ToolConfirmKind.UserAction });
+		await promise;
+	});
+
+	test('chat invocation does not notify user attention when auto-confirmed', async () => {
+		const { service: testService, chatService: testChatService } = createTestToolsService(store, {
+			configureServices: config => {
+				config.setUserConfiguration('chat.tools.global.autoApprove', true);
+			}
+		});
+
+		const toolData: IToolData = {
+			id: 'testToolNotifyAttentionAutoApprove',
+			modelDescription: 'Test Tool',
+			displayName: 'Test Tool',
+			source: ToolDataSource.Internal,
+		};
+
+		const tool = registerToolForTest(testService, store, toolData.id, {
+			prepareToolInvocation: async () => ({ confirmationMessages: { title: 'Confirm Attention', message: 'Proceed with attention?' } }),
+			invoke: async () => ({ content: [{ kind: 'text', value: 'ran' }] }),
+		}, toolData);
+
+		const sessionId = 'sessionId-notify-attention-auto';
+		const userAttentionCalls: IUserAttentionCall[] = [];
+		stubGetSession(testChatService, sessionId, { requestId: 'requestId-notify-attention-auto', userAttentionCalls });
+
+		const dto = tool.makeDto({ x: 1 }, { sessionId });
+		dto.chatRequestId = 'requestId-notify-attention-auto';
+
+		const result = await testService.invokeTool(dto, async () => 0, CancellationToken.None);
+
+		assert.strictEqual(result.content[0].value, 'ran');
+		assert.strictEqual(userAttentionCalls.length, 0, 'notifyUserAttention should not be called when auto-confirmed');
 	});
 
 	test('selectedCustomButton is passed to tool invoke when user selects a custom button', async () => {

--- a/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
@@ -26,10 +26,10 @@ import { TestExtensionService, TestStorageService } from '../../../../../test/co
 import { CellUri } from '../../../../notebook/common/notebookCommon.js';
 import { IChatRequestImplicitVariableEntry, IChatRequestStringVariableEntry, IChatRequestFileEntry, StringChatContextValue } from '../../../common/attachments/chatVariableEntries.js';
 import { ChatAgentService, IChatAgentService } from '../../../common/participants/chatAgents.js';
-import { ChatModel, ChatRequestModel, ChatResponseResource, IChatRequestModeInfo, IExportableChatData, ISerializableChatData1, ISerializableChatData2, ISerializableChatData3, ISerializableChatModelInputState, isExportableSessionData, isSerializableSessionData, normalizeSerializableChatData, Response, serializeSendOptions } from '../../../common/model/chatModel.js';
+import { ChatModel, ChatRequestModel, ChatResponseResource, IChatRequestModeInfo, IChatUserAttention, IExportableChatData, ISerializableChatData1, ISerializableChatData2, ISerializableChatData3, ISerializableChatModelInputState, isExportableSessionData, isSerializableSessionData, normalizeSerializableChatData, Response, serializeSendOptions } from '../../../common/model/chatModel.js';
 import { ChatToolInvocation } from '../../../common/model/chatProgressTypes/chatToolInvocation.js';
 import { ChatRequestTextPart } from '../../../common/requestParser/chatParserTypes.js';
-import { ChatRequestQueueKind, IChatService, IChatTerminalToolInvocationData, IChatToolInvocation, ResponseModelState } from '../../../common/chatService/chatService.js';
+import { ChatRequestQueueKind, ElicitationState, IChatElicitationRequest, IChatService, IChatTerminalToolInvocationData, IChatToolInvocation, ResponseModelState } from '../../../common/chatService/chatService.js';
 import { ToolDataSource } from '../../../common/tools/languageModelToolsService.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../common/constants.js';
 import { MockChatService } from '../chatService/mockChatService.js';
@@ -88,8 +88,48 @@ suite('ChatModel', () => {
 
 		assert.strictEqual(model.isImported, false);
 		assert.strictEqual(model.sessionId, 'existing-session');
-		assert.strictEqual(model.timestamp, now - 1000);
-		assert.strictEqual(model.customTitle, 'My Chat');
+	});
+
+	test('notifyUserAttention fires onDidRequestUserAttention with the request id', () => {
+		const exportedData: IExportableChatData = {
+			initialLocation: ChatAgentLocation.Chat,
+			requests: [],
+			responderUsername: 'bot',
+		};
+
+		const model = testDisposables.add(instantiationService.createInstance(
+			ChatModel,
+			{ value: exportedData, serializer: undefined! },
+			{ initialLocation: ChatAgentLocation.Chat, canUseTools: true }
+		));
+
+		const events: IChatUserAttention[] = [];
+		testDisposables.add(model.onDidRequestUserAttention(e => events.push(e)));
+		model.notifyUserAttention('req-1', 'permission_prompt', 'Permission needed', 'Permission needed');
+		assert.deepStrictEqual(events, [{ requestId: 'req-1', notificationType: 'permission_prompt', message: 'Permission needed', title: 'Permission needed' }]);
+	});
+
+	test('acceptResponseProgress fires onDidRequestUserAttention for elicitation2 progress', async function () {
+		const model = testDisposables.add(instantiationService.createInstance(ChatModel, undefined, { initialLocation: ChatAgentLocation.Chat, canUseTools: true }));
+		const text = 'hello';
+		const request = model.addRequest({ text, parts: [new ChatRequestTextPart(new OffsetRange(0, text.length), new Range(1, text.length, 1, text.length), text)] }, { variables: [] }, 0);
+
+		const events: IChatUserAttention[] = [];
+		testDisposables.add(model.onDidRequestUserAttention(e => events.push(e)));
+
+		const elicitation = {
+			kind: 'elicitation2',
+			title: 'Confirm action',
+			message: 'Please provide input',
+			acceptButtonLabel: 'OK',
+			rejectButtonLabel: undefined,
+			state: observableValue('state', ElicitationState.Pending),
+			accept: async () => { },
+		} satisfies Partial<IChatElicitationRequest> as IChatElicitationRequest;
+
+		model.acceptResponseProgress(request, elicitation);
+
+		assert.deepStrictEqual(events, [{ requestId: request.id, notificationType: 'elicitation_dialog', message: 'Please provide input', title: 'Confirm action' }]);
 	});
 
 	test('initialization with invalid data', async () => {

--- a/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
@@ -125,7 +125,7 @@ suite('ChatModel', () => {
 			rejectButtonLabel: undefined,
 			state: observableValue('state', ElicitationState.Pending),
 			accept: async () => { },
-		} satisfies Partial<IChatElicitationRequest> as IChatElicitationRequest;
+		} satisfies Partial<IChatElicitationRequest> as unknown as IChatElicitationRequest;
 
 		model.acceptResponseProgress(request, elicitation);
 

--- a/src/vs/workbench/contrib/chat/test/common/model/mockChatModel.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/mockChatModel.ts
@@ -8,7 +8,7 @@ import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { IObservable, observableValue } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { IChatEditingSession } from '../../../common/editing/chatEditingService.js';
-import { IChatChangeEvent, IChatModel, IChatPendingRequest, IChatRequestModel, IChatRequestNeedsInputInfo, IExportableChatData, IExportableRepoData, IInputModel, ISerializableChatData } from '../../../common/model/chatModel.js';
+import { IChatChangeEvent, IChatModel, IChatPendingRequest, IChatRequestModel, IChatRequestNeedsInputInfo, IChatUserAttention, IExportableChatData, IExportableRepoData, IInputModel, ISerializableChatData } from '../../../common/model/chatModel.js';
 import { ChatAgentLocation } from '../../../common/constants.js';
 import { IChatSessionContext, IChatSessionTiming } from '../../../common/chatService/chatService.js';
 
@@ -71,6 +71,8 @@ export class MockChatModel extends Disposable implements IChatModel {
 	setWorkingDirectory(uri: URI | undefined): void { this.workingDirectory = uri; }
 	readonly onDidChangePendingRequests: Event<void> = this._register(new Emitter<void>()).event;
 	getPendingRequests(): readonly IChatPendingRequest[] { return []; }
+	readonly onDidRequestUserAttention: Event<IChatUserAttention> = this._register(new Emitter<IChatUserAttention>()).event;
+	notifyUserAttention(requestId: string, notificationType: string, message: string, title?: string): void { }
 	toExport(): IExportableChatData {
 		return {
 			initialLocation: this.initialLocation,

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/hookCompatibility.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/hookCompatibility.test.ts
@@ -5,12 +5,20 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { HookType } from '../../../common/promptSyntax/hookTypes.js';
+import { HookType, HOOKS_BY_TARGET, HOOK_METADATA } from '../../../common/promptSyntax/hookTypes.js';
+import { toHookType } from '../../../common/promptSyntax/hookSchema.js';
+import { Target } from '../../../common/promptSyntax/promptTypes.js';
 import { parseCopilotHooks, parseHooksFromFile, HookSourceFormat } from '../../../common/promptSyntax/hookCompatibility.js';
 import { URI } from '../../../../../../base/common/uri.js';
 
 suite('HookCompatibility', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('Notification is a recognized VS Code hook type', () => {
+		assert.strictEqual(toHookType('Notification'), HookType.Notification);
+		assert.strictEqual(HOOKS_BY_TARGET[Target.VSCode]['Notification'], HookType.Notification);
+		assert.ok(HOOK_METADATA[HookType.Notification].label.length > 0);
+	});
 
 	suite('parseCopilotHooks', () => {
 		const workspaceRoot = URI.file('/workspace');

--- a/src/vs/workbench/contrib/chat/test/common/voiceChatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/voiceChatService.test.ts
@@ -74,6 +74,7 @@ suite('VoiceChat', () => {
 		invokeAgent(id: string, request: IChatAgentRequest, progress: (part: IChatProgress[]) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult> { throw new Error(); }
 		setRequestTools(agent: string, requestId: string, tools: UserSelectedTools): void { }
 		setYieldRequested(agent: string, requestId: string, value: boolean): void { }
+		notifyUserAttention(agent: string, requestId: string, attention: { notificationType: string; message: string; title?: string }): void { }
 		getFollowups(id: string, request: IChatAgentRequest, result: IChatAgentResult, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatFollowup[]> { throw new Error(); }
 		getActivatedAgents(): IChatAgent[] { return agents; }
 		getAgents(): IChatAgent[] { return agents; }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -3156,6 +3156,11 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				isSystemInitiated: true,
 				systemInitiatedLabel: localize('terminalCommandCompleted', "{0} completed", commandDisplay),
 				terminalExecutionId: termId,
+				notification: {
+					notificationType: 'shell_completed',
+					title: localize('terminalCommandCompleted.title', "Command completed"),
+					message: localize('terminalCommandCompleted.message', "{0} completed{1}", commandDisplay, exitCodeText),
+				},
 			}).catch(e => {
 				this._logService.warn(`RunInTerminalTool: Failed to send completion notification for terminal ${termId}`, e);
 			});

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -2644,6 +2644,44 @@ suite('RunInTerminalTool', () => {
 		strictEqual(capturedSteeringRequests[0].options?.agentIdSilent, previousAgentId, 'Completion notification should continue with the previous request agent');
 	});
 
+	test('should attach a shell_completed notification descriptor to background completion steering requests', async () => {
+		const termId = 'test-completion-notification-term';
+		const sessionResource = LocalChatSessionUri.forSession('test-completion-notification-session');
+		const commandFinishedEmitter = new Emitter<{ exitCode: number | undefined }>();
+		const terminalDisposedEmitter = new Emitter<void>();
+		const inputDataEmitter = new Emitter<string>();
+
+		const terminalInstance = {
+			capabilities: {
+				get: (cap: TerminalCapability) => cap === TerminalCapability.CommandDetection ? { onCommandFinished: commandFinishedEmitter.event } : undefined,
+			},
+			dispose: () => { },
+			onDisposed: terminalDisposedEmitter.event,
+			onDidInputData: inputDataEmitter.event,
+		} as unknown as ITerminalInstance;
+
+		(runInTerminalTool.constructor as unknown as { _activeExecutions: Map<string, { getOutput(): string; dispose(): void; instance: ITerminalInstance }> })._activeExecutions.set(termId, {
+			getOutput: () => 'done',
+			dispose: () => { },
+			instance: terminalInstance,
+		});
+
+		const toolSpecificData = { kind: 'terminal', commandLine: { original: 'npm test' }, language: 'bash' } as IChatTerminalToolInvocationData;
+		// eslint-disable-next-line @typescript-eslint/naming-convention
+		(runInTerminalTool as unknown as { _registerCompletionNotification: (terminal: ITerminalInstance, termId: string, session: URI, commandName: string, toolSpecificData: IChatTerminalToolInvocationData) => void })
+			._registerCompletionNotification(terminalInstance, termId, sessionResource, 'npm test', toolSpecificData);
+		await new Promise<void>(resolve => setTimeout(resolve, 0));
+
+		commandFinishedEmitter.fire({ exitCode: 0 });
+
+		strictEqual(capturedSteeringRequests.length, 1, 'Expected a completion steering notification');
+		const notification = capturedSteeringRequests[0].options?.notification;
+		ok(notification, 'Completion steering request should carry a notification descriptor');
+		strictEqual(notification?.notificationType, 'shell_completed', 'Background completion should report shell_completed');
+		ok(!!notification?.message, 'Notification should have a non-empty message');
+		ok(!!notification?.title, 'Notification should have a non-empty title');
+	});
+
 	test('should dedupe rapid repeated background input-needed notifications', () => {
 		const termId = 'test-input-needed-term';
 		const sessionResource = LocalChatSessionUri.forSession('test-input-needed-session');

--- a/src/vscode-dts/vscode.proposed.chatHooks.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatHooks.d.ts
@@ -8,7 +8,7 @@ declare module 'vscode' {
 	/**
 	 * The type of hook to execute.
 	 */
-	export type ChatHookType = 'SessionStart' | 'SessionEnd' | 'UserPromptSubmit' | 'PreToolUse' | 'PostToolUse' | 'PreCompact' | 'SubagentStart' | 'SubagentStop' | 'Stop' | 'ErrorOccurred';
+	export type ChatHookType = 'SessionStart' | 'SessionEnd' | 'UserPromptSubmit' | 'PreToolUse' | 'PostToolUse' | 'PreCompact' | 'SubagentStart' | 'SubagentStop' | 'Stop' | 'Notification' | 'ErrorOccurred';
 
 	/**
 	 * A resolved hook command ready for execution.
@@ -80,6 +80,50 @@ declare module 'vscode' {
 		 * Only present when hooks are enabled.
 		 */
 		readonly hooks?: ChatRequestHooks;
+	}
+
+	/**
+	 * Describes a dialog that requires the user's attention during a chat request,
+	 * such as a tool permission prompt or an elicitation dialog.
+	 */
+	export interface ChatRequestUserAttention {
+		/** The kind of attention required, e.g. 'permission_prompt' or 'elicitation_dialog'. */
+		readonly notificationType: string;
+		/** Human-readable message describing what is being asked. */
+		readonly message: string;
+		/** Optional short title. */
+		readonly title?: string;
+	}
+
+	export interface ChatRequest {
+		/**
+		 * Fires when the editor surfaces a dialog (e.g. a tool permission prompt or an
+		 * elicitation dialog) that requires the user's attention for this request.
+		 * Only present when the `chatParticipantAdditions` proposal is enabled.
+		 */
+		readonly onDidRequestUserAttention?: Event<ChatRequestUserAttention>;
+	}
+
+	/**
+	 * Describes a status notification that initiated a chat request, such as a
+	 * background terminal command completing.
+	 */
+	export interface ChatRequestNotification {
+		/** The kind of notification, e.g. 'shell_completed' or 'shell_detached_completed'. */
+		readonly notificationType: string;
+		/** Human-readable message describing the notification. */
+		readonly message: string;
+		/** Optional short title. */
+		readonly title?: string;
+	}
+
+	export interface ChatRequest {
+		/**
+		 * Present when the editor initiated this request to surface a status notification
+		 * (e.g. a background terminal command completed). Available to extensions that
+		 * enable the `chatParticipantAdditions` proposal.
+		 */
+		readonly notification?: ChatRequestNotification;
 	}
 
 	/**


### PR DESCRIPTION
Support Notification hooks for copilot chat sessions. This implements all types detailed on https://docs.github.com/en/copilot/reference/hooks-reference#notification-hook with the exception of `agent_idle`, as that is meaningless unless there is agent<->agent communication channels, which aren't currently supported in the copilot UI.

Related Issue: https://github.com/microsoft/vscode/issues/317195

While not the precise mechism they were looking for, the hooks being supported do allow users to write tools to provide the notifications they want on their own. 