### PR TITLE
agentHost: ignore subagent mode changes so the session mode picker doesn't reset to Plan

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -2578,6 +2578,13 @@ export class CopilotAgentSession extends Disposable {
 		// before sending). The SDK and AHP share the same three modes
 		// (`interactive` / `plan` / `autopilot`), so we map directly.
 		this._register(wrapper.onSessionModeChanged(e => {
+			// Sub-agents (e.g. a `task` tool sub-agent running in plan mode)
+			// emit their own `session.mode_changed` events carrying an
+			// `agentId`.
+			if (e.agentId) {
+				this._logService.trace(`[Copilot:${sessionId}] Ignoring subagent session.mode_changed: agentId=${e.agentId}, ${e.data.previousMode} -> ${e.data.newMode}`);
+				return;
+			}
 			this._logService.info(`[Copilot:${sessionId}] session.mode_changed: ${e.data.previousMode} -> ${e.data.newMode}`);
 			const newMode = e.data.newMode;
 			if (newMode !== 'interactive' && newMode !== 'plan' && newMode !== 'autopilot') {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -3992,6 +3992,18 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual(sessionConfigUpdates.length, 0);
 		});
 
+		test('session.mode_changed from a subagent does not update the session config', async () => {
+			// Sub-agents (e.g. a `task` tool sub-agent running in plan mode)
+			// emit `session.mode_changed` carrying an `agentId`. These reflect
+			// the sub-agent's internal mode, not the root session's, and must
+			// not flip the shared session mode picker (e.g. to Plan) mid-turn.
+			const { mockSession, sessionConfigUpdates } = await createAgentSession(disposables);
+
+			mockSession.fire('session.mode_changed', { previousMode: 'interactive', newMode: 'plan' } as SessionEventPayload<'session.mode_changed'>['data'], { agentId: 'subagent-1' });
+
+			assert.strictEqual(sessionConfigUpdates.length, 0);
+		});
+
 		// ---- no automatic plan → implementation handoff -------------------
 
 		test('handleExitPlanModeRequest always surfaces the plan-review UI, even in autopilot mode', async () => {


### PR DESCRIPTION
Fixes #321960

## Problem

Asking a question in **Interactive** mode and returning to a session showed the chat input in **Plan** mode after the agent did some edits.

## Root cause

The Copilot SDK's `session.mode_changed` event carries an optional `agentId` field. Per the SDK type, it is *"absent for events from the root/main agent and session-level events"* — so a present `agentId` means the event originated from a **sub-agent** (e.g. a `task` tool sub-agent, which commonly runs in plan mode).

`CopilotAgentSession`'s `onSessionModeChanged` handler synced every `mode_changed` event into the **session-level** AHP config (`SessionConfigKey.Mode`), which drives the chat input mode picker — without checking `agentId`, unlike all the other sub-agent event handlers in the file. So when the model (running interactively) spawned a sub-agent during edits, the sub-agent's internal mode change leaked into the root session config and flipped the picker to **Plan**.

## Fix

Ignore `session.mode_changed` events that carry an `agentId`, so only root/session-level mode changes update the shared session config. This mirrors the existing sub-agent event-routing conventions in the same file.

## Validation

- `npm run typecheck-client` passes.
- Added a regression test (`session.mode_changed from a subagent does not update the session config`).
- All 146 tests in `copilotAgentSession.test.ts` pass, including the existing root-level mode-change tests.
