### PR TITLE
Support Responses API in Azure BYOK

### DIFF
--- a/extensions/copilot/src/extension/byok/vscode-node/azureProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/azureProvider.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import { CancellationToken, LanguageModelChatMessage, LanguageModelChatMessage2, LanguageModelResponsePart2, Progress, ProvideLanguageModelChatResponseOptions } from 'vscode';
 import { AzureAuthMode, ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
-import { isEndpointEditToolName } from '../../../platform/endpoint/common/endpointProvider';
+import { isEndpointEditToolName, ModelSupportedEndpoint } from '../../../platform/endpoint/common/endpointProvider';
 import { IVSCodeExtensionContext } from '../../../platform/extContext/common/extensionContext';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IFetcherService } from '../../../platform/networking/common/fetcherService';
@@ -43,6 +43,19 @@ export function resolveAzureUrl(modelId: string, url: string): string {
 	} else {
 		throw new Error(`Unrecognized Azure deployment URL: ${url}`);
 	}
+}
+
+/**
+ * Determines the `supported_endpoints` for a resolved Azure BYOK URL. When the URL targets the
+ * Responses API, both Chat Completions and Responses are advertised so a Responses-shaped body
+ * (`input`) is sent; otherwise `undefined` preserves the default Chat Completions behavior. This
+ * keeps the Entra auth path consistent with the API-key path (issue #318114).
+ */
+export function azureSupportedEndpointsForUrl(url: string): ModelSupportedEndpoint[] | undefined {
+	if (url.includes('/responses')) {
+		return [ModelSupportedEndpoint.ChatCompletions, ModelSupportedEndpoint.Responses];
+	}
+	return undefined;
 }
 
 export class AzureBYOKModelProvider extends AbstractCustomOAIBYOKModelProvider {
@@ -119,6 +132,13 @@ export class AzureBYOKModelProvider extends AbstractCustomOAIBYOKModelProvider {
 			zeroDataRetentionEnabled: modelConfiguration?.zeroDataRetentionEnabled
 		};
 		const modelInfo = resolveModelInfo(model.id, this._name, undefined, modelCapabilities);
+		// Mirror the API-key path (customOAIProvider.createOpenAIEndPoint): when the resolved Azure URL
+		// targets the Responses API, mark the endpoint accordingly so a Responses-shaped body (`input`) is
+		// sent instead of a Chat Completions body (`messages`), which Azure Responses rejects (issue #318114).
+		const supportedEndpoints = azureSupportedEndpointsForUrl(url);
+		if (supportedEndpoints) {
+			modelInfo.supported_endpoints = supportedEndpoints;
+		}
 
 		const openAIChatEndpoint = this._instantiationService.createInstance(
 			AzureOpenAIEndpoint,

--- a/extensions/copilot/src/extension/byok/vscode-node/azureProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/azureProvider.ts
@@ -52,7 +52,17 @@ export function resolveAzureUrl(modelId: string, url: string): string {
  * keeps the Entra auth path consistent with the API-key path (issue #318114).
  */
 export function azureSupportedEndpointsForUrl(url: string): ModelSupportedEndpoint[] | undefined {
-	if (url.includes('/responses')) {
+	let pathname: string;
+	try {
+		pathname = new URL(url).pathname;
+	} catch {
+		// Tolerate malformed URLs by preserving the default Chat Completions behavior.
+		return undefined;
+	}
+	// Match the final path segment so a deployment named "responses" (e.g.
+	// `/openai/deployments/responses/chat/completions`) is not misclassified. Compare
+	// case-insensitively to tolerate APIM vanity routes that may use different casing.
+	if (pathname.replace(/\/$/, '').toLowerCase().endsWith('/responses')) {
 		return [ModelSupportedEndpoint.ChatCompletions, ModelSupportedEndpoint.Responses];
 	}
 	return undefined;

--- a/extensions/copilot/src/extension/byok/vscode-node/test/azureProvider.spec.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/test/azureProvider.spec.ts
@@ -80,11 +80,17 @@ describe('AzureBYOKModelProvider', () => {
 			expect({
 				responses: azureSupportedEndpointsForUrl('https://my-resource.openai.azure.com/openai/responses?api-version=2025-04-01-preview'),
 				apimResponses: azureSupportedEndpointsForUrl('https://my-apim.azure-api.net/openai/responses'),
+				mixedCaseResponses: azureSupportedEndpointsForUrl('https://my-apim.azure-api.net/openai/Responses'),
 				chatCompletions: azureSupportedEndpointsForUrl('https://my-resource.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2025-01-01-preview'),
+				deploymentNamedResponses: azureSupportedEndpointsForUrl('https://my-resource.openai.azure.com/openai/deployments/responses/chat/completions?api-version=2025-01-01-preview'),
+				malformed: azureSupportedEndpointsForUrl('not a url'),
 			}).toEqual({
 				responses: [ModelSupportedEndpoint.ChatCompletions, ModelSupportedEndpoint.Responses],
 				apimResponses: [ModelSupportedEndpoint.ChatCompletions, ModelSupportedEndpoint.Responses],
+				mixedCaseResponses: [ModelSupportedEndpoint.ChatCompletions, ModelSupportedEndpoint.Responses],
 				chatCompletions: undefined,
+				deploymentNamedResponses: undefined,
+				malformed: undefined,
 			});
 		});
 	});

--- a/extensions/copilot/src/extension/byok/vscode-node/test/azureProvider.spec.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/test/azureProvider.spec.ts
@@ -5,10 +5,11 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BlockedExtensionService, IBlockedExtensionService } from '../../../../platform/chat/common/blockedExtensionService';
+import { ModelSupportedEndpoint } from '../../../../platform/endpoint/common/endpointProvider';
 import { DisposableStore } from '../../../../util/vs/base/common/lifecycle';
 import { SyncDescriptor } from '../../../../util/vs/platform/instantiation/common/descriptors';
 import { createExtensionUnitTestingServices } from '../../../test/node/services';
-import { resolveAzureUrl } from '../azureProvider';
+import { azureSupportedEndpointsForUrl, resolveAzureUrl } from '../azureProvider';
 
 describe('AzureBYOKModelProvider', () => {
 	const disposables = new DisposableStore();
@@ -62,9 +63,29 @@ describe('AzureBYOKModelProvider', () => {
 			expect(result).toBe('https://my-endpoint.models.ai.azure.com/v1/chat/completions');
 		});
 
+		it('should preserve an explicit APIM /responses URL behind a vanity domain', () => {
+			const url = 'https://my-apim.azure-api.net/openai/responses?api-version=2025-04-01-preview';
+			const result = resolveAzureUrl('gpt-4', url);
+			expect(result).toBe(url);
+		});
+
 		it('should throw error for unrecognized Azure URL', () => {
 			const url = 'https://unknown.example.com';
 			expect(() => resolveAzureUrl('gpt-4', url)).toThrow('Unrecognized Azure deployment URL');
+		});
+	});
+
+	describe('azureSupportedEndpointsForUrl', () => {
+		it('marks Responses (and Chat Completions) for /responses URLs and leaves Chat Completions URLs unmarked', () => {
+			expect({
+				responses: azureSupportedEndpointsForUrl('https://my-resource.openai.azure.com/openai/responses?api-version=2025-04-01-preview'),
+				apimResponses: azureSupportedEndpointsForUrl('https://my-apim.azure-api.net/openai/responses'),
+				chatCompletions: azureSupportedEndpointsForUrl('https://my-resource.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2025-01-01-preview'),
+			}).toEqual({
+				responses: [ModelSupportedEndpoint.ChatCompletions, ModelSupportedEndpoint.Responses],
+				apimResponses: [ModelSupportedEndpoint.ChatCompletions, ModelSupportedEndpoint.Responses],
+				chatCompletions: undefined,
+			});
 		});
 	});
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/318114

When using an Azure BYOK model with **Entra auth** and a **Responses API**  URL (e.g. behind APIM), VS Code was sending
Chat Completions request bodies (`messages`) instead of Responses bodies (`input`), which Azure rejects with:
> Unsupported parameter: 'messages'. In the Responses API, this parameter has moved to 'input'. 

### Cause
The Entra auth path in `azureProvider.ts` builds its `modelInfo` manually and never set `supported_endpoints`, so the endpoint defaulted to Chat
Completions. The API-key path already marked Responses URLs correctly.

### Fix
Extracted a small testable helper `azureSupportedEndpointsForUrl(url)` that returns `[ChatCompletions, Responses]` for `/responses` URLs (including APIM vanity domains) and `undefined` otherwise. The Entra path now applies it to `modelInfo.supported_endpoints`, mirroring the existing API-key behavior.