### PR TITLE
Voice mode: add send keyword for hands-free submit

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -269,17 +269,6 @@ registerAction2(class extends Action2 {
 				ContextKeyExpr.equals('config.agents.voice.enabled', true),
 				AGENTS_VOICE_CONNECTED.isEqualTo(true),
 			),
-			menu: {
-				id: MenuId.ChatExecute,
-				when: ContextKeyExpr.and(
-					ContextKeyExpr.equals('config.agents.voice.enabled', true),
-					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
-					AGENTS_VOICE_CONNECTED.isEqualTo(true),
-					AGENTS_VOICE_INITIATED_HERE.isEqualTo(true),
-				),
-				group: 'navigation',
-				order: -10
-			},
 		});
 	}
 	async run(accessor: ServicesAccessor): Promise<void> {

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -269,6 +269,17 @@ registerAction2(class extends Action2 {
 				ContextKeyExpr.equals('config.agents.voice.enabled', true),
 				AGENTS_VOICE_CONNECTED.isEqualTo(true),
 			),
+			menu: {
+				id: MenuId.ChatExecute,
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('config.agents.voice.enabled', true),
+					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
+					AGENTS_VOICE_CONNECTED.isEqualTo(true),
+					AGENTS_VOICE_INITIATED_HERE.isEqualTo(true),
+				),
+				group: 'navigation',
+				order: -10
+			},
 		});
 	}
 	async run(accessor: ServicesAccessor): Promise<void> {

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -449,7 +449,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'agents.voice.sendKeyword': {
 			type: 'string',
-			description: nls.localize('agents.voice.sendKeyword', "A keyword phrase (e.g. \"send it\") that, when spoken at the end of an utterance, triggers sending the request. Only applies when agents.voice.autoSendDelay is -1. The keyword is stripped from the sent message. Leave empty to disable."),
+			description: nls.localize('agents.voice.sendKeyword', "A keyword phrase (e.g. \"send it\") that, when spoken at the end of an utterance in toggle mode, triggers sending the request immediately. The keyword is stripped from the sent message. Leave empty to disable."),
 			default: '',
 			scope: ConfigurationScope.APPLICATION,
 			included: false,

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -449,7 +449,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'agents.voice.sendKeyword': {
 			type: 'string',
-			description: nls.localize('agents.voice.sendKeyword', "A keyword phrase (e.g. \"send it\") that, when spoken at the end of an utterance, triggers sending the request. Only applies when autoSendDelay is -1. The keyword is stripped from the sent message. Leave empty to disable."),
+			description: nls.localize('agents.voice.sendKeyword', "A keyword phrase (e.g. \"send it\") that, when spoken at the end of an utterance, triggers sending the request. Only applies when agents.voice.autoSendDelay is -1. The keyword is stripped from the sent message. Leave empty to disable."),
 			default: '',
 			scope: ConfigurationScope.APPLICATION,
 			included: false,

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -447,5 +447,13 @@ configurationRegistry.registerConfiguration({
 			included: false,
 			tags: ['advanced'],
 		},
+		'agents.voice.sendKeyword': {
+			type: 'string',
+			description: nls.localize('agents.voice.sendKeyword', "A keyword phrase (e.g. \"send it\") that, when spoken at the end of an utterance, triggers sending the request. Only applies when autoSendDelay is -1. The keyword is stripped from the sent message. Leave empty to disable."),
+			default: '',
+			scope: ConfigurationScope.APPLICATION,
+			included: false,
+			tags: ['advanced'],
+		},
 	}
 });

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -936,14 +936,28 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			if (!this._telemetryFirstTranscriptionMs && this._telemetryPttDownMs) {
 				this._telemetryFirstTranscriptionMs = Date.now();
 			}
-			this._updateUserTurn(e.text, e.committed ?? '', e.status === 'partial');
+
+			let text = e.text;
+
+			// Check for send keyword trigger (when auto-send is disabled).
+			if (this._pttToggleMode && this._pttHeld && !this._isAutoSendEnabled()) {
+				const strippedText = this._checkSendKeyword(text);
+				if (strippedText !== undefined) {
+					text = strippedText;
+					this._updateUserTurn(text, e.committed ?? '', false);
+					this._finishPtt();
+					return;
+				}
+			}
+
+			this._updateUserTurn(text, e.committed ?? '', e.status === 'partial');
 			if (e.status !== 'partial') {
 				if (!this._pttHeld) {
 					this._voiceState.set('processing', undefined);
 					this._statusText.set('Processing...', undefined);
 				}
 				// Persist the user's final transcript (local-only, no backend coordination).
-				this._persistTurn('user', e.text);
+				this._persistTurn('user', text);
 			}
 			// Restart silence countdown for auto-send in toggle mode.
 			if (this._pttToggleMode && this._pttHeld) {
@@ -1305,6 +1319,25 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	private _isAutoSendEnabled(): boolean {
 		const delayMs = this.configurationService.getValue<number>('agents.voice.autoSendDelay');
 		return typeof delayMs === 'number' && delayMs >= 0;
+	}
+
+	/**
+	 * Check if the transcript text ends with the configured send keyword.
+	 * Returns the text with the keyword stripped if found, or undefined if not.
+	 */
+	private _checkSendKeyword(text: string): string | undefined {
+		const keyword = this.configurationService.getValue<string>('agents.voice.sendKeyword');
+		if (!keyword) {
+			return undefined;
+		}
+		const trimmed = text.trimEnd();
+		const keywordLower = keyword.toLowerCase();
+		if (trimmed.toLowerCase().endsWith(keywordLower)) {
+			// Strip the keyword from the end
+			const stripped = trimmed.slice(0, trimmed.length - keyword.length).trimEnd();
+			return stripped || undefined; // return undefined if nothing left (don't send empty)
+		}
+		return undefined;
 	}
 
 	/** Re-enter listening via synthetic short tap. */

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -1003,7 +1003,12 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				'focus_session',
 			];
 			if (e.name === 'send_to_chat') {
-				const text = typeof e.args?.['text'] === 'string' ? (e.args['text'] as string) : '';
+				let text = typeof e.args?.['text'] === 'string' ? (e.args['text'] as string) : '';
+				// Strip send keyword if present (backend includes full transcript)
+				const stripped = this._checkSendKeyword(text);
+				if (stripped !== undefined) {
+					text = stripped;
+				}
 				this._statusText.set(VoiceToolDispatchService.getActionLabel(e.name), undefined);
 				this._persistEntry('agent_tool_call', this._renderToolCallSummary(e.name, e.args), {
 					toolName: e.name,

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -945,6 +945,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				if (strippedText !== undefined) {
 					text = strippedText;
 					this._updateUserTurn(text, e.committed ?? '', false);
+					this._persistTurn('user', text);
+					this._pttToggleMode = false;
 					this._finishPtt();
 					return;
 				}
@@ -1326,7 +1328,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 * Returns the text with the keyword stripped if found, or undefined if not.
 	 */
 	private _checkSendKeyword(text: string): string | undefined {
-		const keyword = this.configurationService.getValue<string>('agents.voice.sendKeyword');
+		const keyword = this.configurationService.getValue<string>('agents.voice.sendKeyword')?.trim();
 		if (!keyword) {
 			return undefined;
 		}

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -939,8 +939,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 			let text = e.text;
 
-			// Check for send keyword trigger (when auto-send is disabled).
-			if (this._pttToggleMode && this._pttHeld && !this._isAutoSendEnabled()) {
+			// Check for send keyword trigger in toggle mode.
+			if (this._pttToggleMode && this._pttHeld) {
 				const strippedText = this._checkSendKeyword(text);
 				if (strippedText !== undefined) {
 					text = strippedText;
@@ -1332,10 +1332,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		if (!keyword) {
 			return undefined;
 		}
-		const trimmed = text.trimEnd();
+		// Strip trailing punctuation that speech recognizers often append
+		const trimmed = text.trimEnd().replace(/[.,!?;:]+$/, '').trimEnd();
 		const keywordLower = keyword.toLowerCase();
 		if (trimmed.toLowerCase().endsWith(keywordLower)) {
-			// Strip the keyword from the end
 			const stripped = trimmed.slice(0, trimmed.length - keyword.length).trimEnd();
 			return stripped || undefined; // return undefined if nothing left (don't send empty)
 		}


### PR DESCRIPTION
Users can now configure a keyword phrase (e.g. "send it") via the new `agents.voice.sendKeyword` setting. When the keyword is detected at the end of the spoken transcript, it is stripped from the message and the request is submitted automatically.

This enables a fully hands-free workflow without relying on silence-based auto-send.

**How it works:**
- On each transcription event, if in toggle mode with auto-send disabled, check if transcript ends with the keyword (case-insensitive)
- If matched: strip the keyword, update the transcript display, trigger send
- If the stripped text is empty, the keyword is ignored (prevents empty sends)

**New setting:**
- `agents.voice.sendKeyword` (string, default empty/disabled, advanced)

Fixes microsoft/vscode-internalbacklog#8187