### PR TITLE
chat: fix Plugins customizations tab stuck on marketplace (#321891)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Codicon } from '../../../../../base/common/codicons.js';
-import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { localize, localize2 } from '../../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
@@ -45,6 +45,15 @@ export class ManagePluginsAction extends Action2 {
 	}
 }
 
+interface IInstallFromSourceActionOptions {
+	/**
+	 * When `true`, suppresses revealing the installed plugin in the Extensions
+	 * viewlet after a successful install. Used when the action is invoked from a
+	 * surface that presents its own installed view (e.g. the customizations editor).
+	 */
+	readonly skipReveal?: boolean;
+}
+
 class InstallFromSourceAction extends Action2 {
 	static readonly ID = 'workbench.action.chat.installPluginFromSource';
 
@@ -69,7 +78,7 @@ class InstallFromSourceAction extends Action2 {
 		});
 	}
 
-	async run(accessor: ServicesAccessor): Promise<void> {
+	async run(accessor: ServicesAccessor, options?: IInstallFromSourceActionOptions): Promise<boolean> {
 		const quickInputService = accessor.get(IQuickInputService);
 		const pluginInstallService = accessor.get(IPluginInstallService);
 		const extensionsWorkbenchService = accessor.get(IExtensionsWorkbenchService);
@@ -85,56 +94,64 @@ class InstallFromSourceAction extends Action2 {
 			inputBox.validationMessage = undefined;
 		}));
 
-		let installing = false;
-		store.add(inputBox.onDidHide(() => {
-			if (!installing) {
-				store.dispose();
-			}
-		}));
+		return new Promise<boolean>(resolve => {
+			let installing = false;
+			let installed = false;
+			store.add(toDisposable(() => resolve(installed)));
 
-		store.add(inputBox.onDidAccept(async () => {
-			const source = inputBox.value.trim();
-			if (!source) {
-				return;
-			}
-
-			// Quick format validation keeps the input box open for correction.
-			const validationError = pluginInstallService.validatePluginSource(source);
-			if (validationError) {
-				inputBox.validationMessage = validationError;
-				return;
-			}
-
-			// Show busy state and prevent concurrent installs.
-			inputBox.busy = true;
-			inputBox.enabled = false;
-			installing = true;
-			try {
-				// Hide the input box so it doesn't conflict with trust/progress dialogs.
-				inputBox.hide();
-
-				const result = await pluginInstallService.installPluginFromValidatedSource(source);
-				if (!result.success) {
-					if (result.message) {
-						// Re-open with the error so the user can correct their input.
-						inputBox.validationMessage = result.message;
-					}
-					inputBox.show();
-				} else {
-					const ref = parseMarketplaceReference(source);
-					if (ref) {
-						extensionsWorkbenchService.openSearch(`@agentPlugins ${ref.displayLabel}`);
-					}
+			store.add(inputBox.onDidHide(() => {
+				if (!installing) {
 					store.dispose();
 				}
-			} finally {
-				installing = false;
-				if (!store.isDisposed) {
-					inputBox.busy = false;
-					inputBox.enabled = true;
+			}));
+
+			store.add(inputBox.onDidAccept(async () => {
+				const source = inputBox.value.trim();
+				if (!source) {
+					return;
 				}
-			}
-		}));
+
+				// Quick format validation keeps the input box open for correction.
+				const validationError = pluginInstallService.validatePluginSource(source);
+				if (validationError) {
+					inputBox.validationMessage = validationError;
+					return;
+				}
+
+				// Show busy state and prevent concurrent installs.
+				inputBox.busy = true;
+				inputBox.enabled = false;
+				installing = true;
+				try {
+					// Hide the input box so it doesn't conflict with trust/progress dialogs.
+					inputBox.hide();
+
+					const result = await pluginInstallService.installPluginFromValidatedSource(source);
+					if (!result.success) {
+						if (result.message) {
+							// Re-open with the error so the user can correct their input.
+							inputBox.validationMessage = result.message;
+						}
+						inputBox.show();
+					} else {
+						installed = true;
+						if (!options?.skipReveal) {
+							const ref = parseMarketplaceReference(source);
+							if (ref) {
+								extensionsWorkbenchService.openSearch(`@agentPlugins ${ref.displayLabel}`);
+							}
+						}
+						store.dispose();
+					}
+				} finally {
+					installing = false;
+					if (!store.isDisposed) {
+						inputBox.busy = false;
+						inputBox.enabled = true;
+					}
+				}
+			}));
+		});
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
@@ -46,11 +46,7 @@ export class ManagePluginsAction extends Action2 {
 }
 
 interface IInstallFromSourceActionOptions {
-	/**
-	 * When `true`, suppresses revealing the installed plugin in the Extensions
-	 * viewlet after a successful install. Used when the action is invoked from a
-	 * surface that presents its own installed view (e.g. the customizations editor).
-	 */
+	/** When `true`, do not reveal the installed plugin in the Extensions viewlet after install. */
 	readonly skipReveal?: boolean;
 }
 
@@ -143,6 +139,13 @@ class InstallFromSourceAction extends Action2 {
 						}
 						store.dispose();
 					}
+				} catch (e) {
+					// An unexpected failure (e.g. cancelled trust prompt) would otherwise
+					// leave the hidden input box and awaited promise stuck. Re-show it with
+					// the error so the user can retry or cancel.
+					const detail = e instanceof Error ? e.message : String(e);
+					inputBox.validationMessage = localize('installFromSourceFailed', "Failed to install plugin: {0}", detail);
+					inputBox.show();
 				} finally {
 					installing = false;
 					if (!store.isDisposed) {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
@@ -437,6 +437,7 @@ export class PluginListWidget extends Disposable {
 	private readonly disabledLinkListener = this._register(new MutableDisposable());
 	private buttonContainer!: HTMLElement;
 	private browseButton!: Button;
+	private backButton!: Button;
 	private addButtonContainer!: HTMLElement;
 	private addButtonSimple!: Button;
 	private addButton!: ButtonWithDropdown;
@@ -554,6 +555,15 @@ export class PluginListWidget extends Disposable {
 
 		// Button container (Browse Marketplace + Add actions + Create Plugin)
 		this.buttonContainer = DOM.append(this.searchAndButtonContainer, $('.list-button-group'));
+
+		// Back button (visible only in marketplace browse mode)
+		const backButtonContainer = DOM.append(this.buttonContainer, $('.list-add-button-container'));
+		const backToInstalledLabel = localize('backToInstalledPlugins', "Back to installed plugins");
+		this.backButton = this._register(new Button(backButtonContainer, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: backToInstalledLabel, ariaLabel: backToInstalledLabel }));
+		this.backButton.label = `$(${Codicon.arrowLeft.id}) ${localize('pluginBrowseBack', "Back")}`;
+		this.backButton.element.classList.add('list-add-button');
+		backButtonContainer.style.display = 'none';
+		this._register(this.backButton.onDidClick(() => this.toggleBrowseMode(false)));
 
 		const browseButtonContainer = DOM.append(this.buttonContainer, $('.list-add-button-container'));
 		const browseMarketplaceLabel = localize('browseMarketplace', "Browse Marketplace");
@@ -843,7 +853,14 @@ export class PluginListWidget extends Disposable {
 				label: localize('installFromSource', "Install Plugin from Source"),
 				tooltip: localize('installFromSource', "Install Plugin from Source"),
 				icon: Codicon.add,
-				run: () => this.commandService.executeCommand('workbench.action.chat.installPluginFromSource'),
+				run: async () => {
+					const installed = await this.commandService.executeCommand<boolean>('workbench.action.chat.installPluginFromSource', { skipReveal: true });
+					// Return to the installed list so the newly installed plugin is
+					// visible — source-installed plugins may not appear in the marketplace.
+					if (installed && this.browseMode) {
+						this.exitBrowseMode();
+					}
+				},
 			},
 		];
 	}
@@ -893,6 +910,7 @@ export class PluginListWidget extends Disposable {
 		this.searchQuery = '';
 
 		this.browseButton.element.parentElement!.style.display = browse ? 'none' : '';
+		this.backButton.element.parentElement!.style.display = browse ? '' : 'none';
 
 		this.searchInput.setPlaceHolder(browse
 			? localize('searchMarketplacePlaceholder', "Search plugin marketplace...")

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
@@ -558,7 +558,7 @@ export class PluginListWidget extends Disposable {
 
 		// Back button (visible only in marketplace browse mode)
 		const backButtonContainer = DOM.append(this.buttonContainer, $('.list-add-button-container'));
-		const backToInstalledLabel = localize('backToInstalledPlugins', "Back to installed plugins");
+		const backToInstalledLabel = localize('backToInstalledPlugins', "Back to Installed Plugins");
 		this.backButton = this._register(new Button(backButtonContainer, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: backToInstalledLabel, ariaLabel: backToInstalledLabel }));
 		this.backButton.label = `$(${Codicon.arrowLeft.id}) ${localize('pluginBrowseBack', "Back")}`;
 		this.backButton.element.classList.add('list-add-button');


### PR DESCRIPTION
Fixes #321891

In the Customizations dialog, the Plugins tab could get stuck on the marketplace ("Browse Marketplace") view with no way to return to installed plugins, and installing via "Install Plugin from Source" gave no feedback in the dialog.

The Plugins widget was modeled on the MCP Servers widget but was missing two things the MCP widget already has: a **Back button** to leave browse mode, and a path to return to the installed view after an install.

## Changes

- **`pluginListWidget.ts`** — Add a **Back button** (mirroring `mcpListWidget.ts`) that is shown only in marketplace browse mode, so users can return to the installed plugins list. Previously browse mode merely hid the "Browse Marketplace" button with no replacement.
- **`pluginListWidget.ts` + `chatPluginActions.ts`** — The "Install Plugin from Source" add action now **awaits the install and exits browse mode on success**, so the newly installed plugin is revealed in the installed list (source-installed plugins may not appear in the marketplace). `InstallFromSourceAction.run` was refactored to await the full flow, return a `boolean` success, and accept a `skipReveal` option that suppresses the Extensions-viewlet redirect when invoked from the dialog.

The sidebar/overview counter is already driven reactively by `getPluginCount()` → `IAgentPluginService.plugins`, so it updates on its own once the widget returns to the installed view.

## Notes for reviewers

- Legacy callers (F1 command and the `InstalledAgentPlugins` view-title menu) are unchanged: `skipReveal` defaults off, and they ignore the new return value.
- `npm run typecheck-client` and `npm run valid-layers-check` both pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>