### PR TITLE
Gate Claude3PIntegration behind editor preview policy

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -174,6 +174,24 @@
             "included": true
         },
         {
+            "key": "chat.agentHost.claudeAgent.enabled",
+            "name": "Claude3PIntegration",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.113",
+            "localization": {
+                "description": {
+                    "key": "chat.agentHost.claudeAgent.enabled.policy",
+                    "value": "Enable Claude Agent sessions in VS Code. Start and resume agentic coding sessions powered by Anthropic Claude Agent SDK directly in the editor. Uses your existing Copilot subscription."
+                }
+            },
+            "type": "boolean",
+            "default": true,
+            "included": true,
+            "referencedSettings": [
+                "github.copilot.chat.claudeAgent.enabled"
+            ]
+        },
+        {
             "key": "chat.tools.global.autoApprove",
             "name": "ChatToolsAutoApprove",
             "category": "InteractiveSession",
@@ -665,24 +683,6 @@
             "type": "boolean",
             "default": true,
             "included": true
-        },
-        {
-            "key": "github.copilot.chat.claudeAgent.enabled",
-            "name": "Claude3PIntegration",
-            "category": "InteractiveSession",
-            "minimumVersion": "1.113",
-            "localization": {
-                "description": {
-                    "key": "github.copilot.chat.claudeAgent.enabled",
-                    "value": "Enable Claude Agent sessions in VS Code. Start and resume agentic coding sessions powered by Anthropic Claude Agent SDK directly in the editor. Uses your existing Copilot subscription."
-                }
-            },
-            "type": "boolean",
-            "default": true,
-            "included": true,
-            "referencedSettings": [
-                "chat.agentHost.claudeAgent.enabled"
-            ]
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.127.0",
-  "distro": "0d726028b9bf2f38975a035474182955e771bccd",
+  "distro": "7abf39b86c07d094722a4b3ec9f37e78fe3d5db3",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/src/vs/base/common/policy.ts
+++ b/src/vs/base/common/policy.ts
@@ -144,3 +144,18 @@ export interface IPolicyReference {
 	/** The name of the owning {@link IPolicy} this setting attaches to. */
 	readonly name: PolicyName;
 }
+
+/**
+ * A `product.json` `extensionConfigurationPolicy` entry that attaches its setting to a policy
+ * *owned* by an in-code setting, instead of declaring a full owner {@link IPolicy}. This mirrors the
+ * in-code `policyReference` configuration field, so the same indirection can be expressed from
+ * `product.json` — where the owner's runtime behaviour (notably its `value` callback) cannot live.
+ *
+ * An `extensionConfigurationPolicy` entry is therefore either a full {@link IPolicy} (the setting
+ * "parents"/owns the policy, the current syntax) or this reference wrapper.
+ */
+export interface IExtensionConfigurationPolicyReference {
+
+	/** Pointer to the owning {@link IPolicy} declared by an in-code setting. */
+	readonly policyReference: IPolicyReference;
+}

--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -5,7 +5,7 @@
 
 import { IStringDictionary } from './collections.js';
 import { PlatformName } from './platform.js';
-import { IPolicy } from './policy.js';
+import { IExtensionConfigurationPolicyReference, IPolicy } from './policy.js';
 
 export interface IBuiltInExtension {
 	readonly name: string;
@@ -257,7 +257,14 @@ export interface IProductConfiguration {
 
 	readonly remoteDefaultExtensionsIfInstalledLocally?: string[];
 
-	readonly extensionConfigurationPolicy?: IStringDictionary<IPolicy>;
+	/**
+	 * Maps an extension-contributed setting key to either a full enterprise {@link IPolicy}
+	 * (the setting owns/"parents" the policy — the original syntax) or an
+	 * {@link IExtensionConfigurationPolicyReference} (`{ policyReference: { name } }`), attaching the
+	 * setting to a policy owned by an in-code setting. References let a `product.json`-provided
+	 * setting be governed by a policy whose `value` callback — which JSON cannot carry — lives in code.
+	 */
+	readonly extensionConfigurationPolicy?: IStringDictionary<IPolicy | IExtensionConfigurationPolicyReference>;
 
 	readonly onboardingKeymaps?: readonly IProductOnboardingKeymap[];
 	readonly onboardingThemes?: readonly IProductOnboardingTheme[];

--- a/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
@@ -49,9 +49,22 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.agentHost.claudeAgent.enabled', "When enabled, the agent host registers the Claude provider (subject to the Claude SDK being reachable). Independent of `#chat.agents.claude.preferAgentHost#` and `#chat.editor.claude.preferAgentHost#`, which choose which integration surfaces Claude. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect."),
 			default: true,
 			tags: ['experimental', 'advanced'],
-			// References the `Claude3PIntegration` policy (owned by `github.copilot.chat.claudeAgent.enabled`) so disabling Claude applies across surfaces.
-			policyReference: {
+			// Owns the `Claude3PIntegration` policy; gating here disables Claude across all surfaces.
+			// The user-facing copilot-chat setting `github.copilot.chat.claudeAgent.enabled` attaches
+			// to this policy via a `policyReference` declared in the distro `product.json`. Ownership
+			// lives here (not in `product.json`) so the policy can carry a `value` callback that honors
+			// the account-side editor preview-features flag.
+			policy: {
 				name: 'Claude3PIntegration',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.113',
+				value: (policyData) => policyData.chat_preview_features_enabled === false ? false : undefined,
+				localization: {
+					description: {
+						key: 'chat.agentHost.claudeAgent.enabled.policy',
+						value: nls.localize('chat.agentHost.claudeAgent.enabled.policy', "Enable Claude Agent sessions in VS Code. Start and resume agentic coding sessions powered by Anthropic Claude Agent SDK directly in the editor. Uses your existing Copilot subscription."),
+					}
+				}
 			},
 		},
 		[AgentHostCodexAgentEnabledSettingId]: {

--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -11,7 +11,7 @@ import { ExtensionsRegistry, IExtensionPointUser } from '../../services/extensio
 import { IConfigurationNode, IConfigurationRegistry, Extensions, validateProperty, ConfigurationScope, OVERRIDE_PROPERTY_REGEX, IConfigurationDefaults, configurationDefaultsSchemaId, IConfigurationDelta, getDefaultValue, getAllConfigurationProperties, parseScope, EXTENSION_UNIFICATION_EXTENSION_IDS, overrideIdentifiersFromKey } from '../../../platform/configuration/common/configurationRegistry.js';
 import { IJSONContributionRegistry, Extensions as JSONExtensions } from '../../../platform/jsonschemas/common/jsonContributionRegistry.js';
 import { workspaceSettingsSchemaId, launchSchemaId, tasksSchemaId, mcpSchemaId } from '../../services/configuration/common/configuration.js';
-import { isObject, isUndefined } from '../../../base/common/types.js';
+import { hasKey, isObject, isUndefined } from '../../../base/common/types.js';
 import { ExtensionIdentifierMap, IExtensionManifest } from '../../../platform/extensions/common/extensions.js';
 import { IStringDictionary } from '../../../base/common/collections.js';
 import { Extensions as ExtensionFeaturesExtensions, IExtensionFeatureTableRenderer, IExtensionFeaturesRegistry, IRenderedData, IRowData, ITableData } from '../../services/extensionManagement/common/extensionFeatures.js';
@@ -307,8 +307,16 @@ configurationExtPoint.setHandler((extensions, { added, removed }) => {
 					extension.collector.error(nls.localize('invalid.property', "configuration.properties property '{0}' must be an object", key));
 					continue;
 				}
-				if (extensionConfigurationPolicy?.[key]) {
-					propertyConfiguration.policy = extensionConfigurationPolicy?.[key];
+				const policyEntry = extensionConfigurationPolicy?.[key];
+				if (policyEntry) {
+					// A reference entry carries a `policyReference` pointer; a full (owner/"parent")
+					// entry declares the policy inline. References attach this setting to a policy
+					// *owned* by an in-code setting (whose `value` callback JSON cannot carry).
+					if (hasKey(policyEntry, { policyReference: true })) {
+						propertyConfiguration.policyReference = policyEntry.policyReference;
+					} else {
+						propertyConfiguration.policy = policyEntry;
+					}
 				}
 				if (propertyConfiguration.tags?.some(tag => tag.toLowerCase() === 'onexp')) {
 					propertyConfiguration.experiment = {

--- a/src/vs/workbench/contrib/policyExport/electron-browser/policyExport.contribution.ts
+++ b/src/vs/workbench/contrib/policyExport/electron-browser/policyExport.contribution.ts
@@ -20,12 +20,22 @@ import { VSBuffer } from '../../../../base/common/buffer.js';
 import { PolicyCategory, PolicyCategoryData } from '../../../../base/common/policy.js';
 import { ExportedPolicyDataDto } from '../common/policyDto.js';
 import { join } from '../../../../base/common/path.js';
+import { hasKey } from '../../../../base/common/types.js';
 
 interface ExtensionConfigurationPolicyEntry {
 	readonly name: string;
 	readonly category: string;
 	readonly minimumVersion: `${number}.${number}`;
 	readonly description: string;
+}
+
+/**
+ * A reference-shaped entry in the distro `extensionConfigurationPolicy`: the extension setting
+ * attaches to a policy *owned* by an in-code setting (which provides the catalog metadata and the
+ * `value` callback) via a `policyReference` pointer.
+ */
+interface ExtensionConfigurationPolicyReferenceEntry {
+	readonly policyReference: { readonly name: string };
 }
 
 export class PolicyExportContribution extends Disposable implements IWorkbenchContribution {
@@ -109,16 +119,35 @@ export class PolicyExportContribution extends Disposable implements IWorkbenchCo
 				// Checks DISTRO_PRODUCT_JSON env var (for testing),
 				// then falls back to fetching from GitHub API with GITHUB_TOKEN.
 				const distroProduct = await this.getDistroProductJson();
-				const extensionPolicies = distroProduct['extensionConfigurationPolicy'] as Record<string, ExtensionConfigurationPolicyEntry> | undefined;
+				const extensionPolicies = distroProduct['extensionConfigurationPolicy'] as Record<string, ExtensionConfigurationPolicyEntry | ExtensionConfigurationPolicyReferenceEntry> | undefined;
+				// Reference-shaped product entries (extension settings attaching to an in-code-owned
+				// policy), collected by owning policy name so they can be linked below.
+				const productReferencesByPolicyName = new Map<string, string[]>();
 				if (extensionPolicies) {
 					const existingKeys = new Set(policyData.policies.map(p => p.key));
 					let added = 0;
+					let referenced = 0;
 					for (const [key, entry] of Object.entries(extensionPolicies)) {
 						if (existingKeys.has(key)) {
 							continue;
 						}
-						if (!entry.description || !entry.category) {
-							throw new Error(`Extension policy '${key}' is missing required 'description' or 'category' field.`);
+						// A reference entry carries a `policyReference` pointer; the owner — and its
+						// `value` callback — is declared by an in-code setting. Link it below instead
+						// of merging it as an owner.
+						if (hasKey(entry, { policyReference: true })) {
+							const ownerName = entry.policyReference?.name;
+							if (!ownerName) {
+								throw new Error(`Extension policy reference '${key}' is missing required 'policyReference.name' field.`);
+							}
+							const list = productReferencesByPolicyName.get(ownerName) ?? [];
+							list.push(key);
+							productReferencesByPolicyName.set(ownerName, list);
+							referenced++;
+							continue;
+						}
+						// Owner ("parent") entry: full catalog metadata is required.
+						if (!entry.name || !entry.category || !entry.description) {
+							throw new Error(`Extension policy '${key}' is missing required 'name', 'category', or 'description' field.`);
 						}
 						policyData.policies.push({
 							key,
@@ -134,23 +163,43 @@ export class PolicyExportContribution extends Disposable implements IWorkbenchCo
 						});
 						added++;
 					}
-					this.log(`Merged ${added} extension configuration policies.`);
+					this.log(`Merged ${added} extension configuration policies (${referenced} references).`);
 				}
 
 				// Link policyReference settings and enforce type match (same value is applied verbatim).
+				// References come from both in-code settings (`getPolicyReferenceConfigurations`) and
+				// reference-shaped distro product entries collected above.
 				const policyReferenceConfigurations = configurationRegistry.getPolicyReferenceConfigurations();
+				const linkedProductReferenceNames = new Set<string>();
 				let linkedReferences = 0;
 				for (const policy of policyData.policies) {
-					const references = policyReferenceConfigurations.get(policy.name);
-					if (references && references.size > 0) {
+					const references = new Set<string>(policyReferenceConfigurations.get(policy.name) ?? []);
+					const productReferences = productReferencesByPolicyName.get(policy.name);
+					if (productReferences) {
+						for (const productRefKey of productReferences) {
+							references.add(productRefKey);
+						}
+						linkedProductReferenceNames.add(policy.name);
+					}
+					if (references.size > 0) {
 						for (const referenceKey of references) {
 							const referenceType = configurationProperties[referenceKey]?.type;
-							if (referenceType !== policy.type) {
+							// Extension-contributed reference settings are not registered in the
+							// headless export process, so their type cannot be validated here; only
+							// enforce the type match for settings present in the registry.
+							if (referenceType !== undefined && referenceType !== policy.type) {
 								throw new Error(`Policy '${policy.name}': setting '${referenceKey}' (type '${referenceType}') declares a 'policyReference' to a policy of type '${policy.type}'. A 'policyReference' must match the owning setting's type.`);
 							}
 						}
 						policy.referencedSettings = [...references].sort();
 						linkedReferences += references.size;
+					}
+				}
+				// A reference must point at an owner. An unmatched product reference means the
+				// in-code owner was not loaded/registered — surface it rather than silently dropping.
+				for (const policyName of productReferencesByPolicyName.keys()) {
+					if (!linkedProductReferenceNames.has(policyName)) {
+						throw new Error(`Extension policy reference to '${policyName}' has no owning policy. Ensure an in-code setting declares 'policy: { name: '${policyName}', ... }'.`);
 					}
 				}
 				this.log(`Linked ${linkedReferences} referenced settings across ${policyData.policies.length} policies.`);

--- a/src/vs/workbench/contrib/policyExport/test/node/extensionPolicyFixture.json
+++ b/src/vs/workbench/contrib/policyExport/test/node/extensionPolicyFixture.json
@@ -19,10 +19,9 @@
 			"description": "Enables the code review agent."
 		},
 		"github.copilot.chat.claudeAgent.enabled": {
-			"name": "Claude3PIntegration",
-			"minimumVersion": "1.113",
-			"category": "InteractiveSession",
-			"description": "Enable Claude Agent sessions in VS Code. Start and resume agentic coding sessions powered by Anthropic Claude Agent SDK directly in the editor. Uses your existing Copilot subscription."
+			"policyReference": {
+				"name": "Claude3PIntegration"
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Problem

The `Claude3PIntegration` enterprise policy was **owned by the copilot-chat extension setting** `github.copilot.chat.claudeAgent.enabled` via the distro `product.json` `extensionConfigurationPolicy` block. Because `product.json` is pure JSON, that owner cannot carry a `value(policyData)` callback, so the policy only responded to OS/MDM admin policy and **never honored the account-side preview-features flag** `chat_preview_features_enabled` (sourced from the Copilot token's `editor_preview_features`).

By contrast, **Codex works**: its core setting `chat.agentHost.codexAgent.enabled` owns `Codex3PIntegration` in code with a `value` callback gating on `chat_preview_features_enabled`.

## Fix — flip ownership (mirror Codex)

- The in-code core setting `chat.agentHost.claudeAgent.enabled` now **owns** `Claude3PIntegration` with the preview-features `value` callback.
- The extension setting `github.copilot.chat.claudeAgent.enabled` attaches via a **`policyReference`** declared from `product.json`.

## `extensionConfigurationPolicy` now supports both forms

An `extensionConfigurationPolicy` entry can be **either**:

1. **Owner / "parent" syntax** (existing, unchanged) — the setting owns the policy inline:
   ```json
   "github.copilot.nextEditSuggestions.enabled": {
       "name": "CopilotNextEditSuggestions",
       "category": "InteractiveSession",
       "minimumVersion": "1.99",
       "description": "…"
   }
   ```
2. **Reference syntax** (new) — the setting attaches to a policy owned by an in-code setting, mirroring the in-code `policyReference` configuration field:
   ```json
   "github.copilot.chat.claudeAgent.enabled": {
       "policyReference": { "name": "Claude3PIntegration" }
   }
   ```

`configurationExtensionPoint` and the policy exporter detect the `policyReference` key to route an entry to `.policy` vs `.policyReference`. The exporter links reference entries into the owner's `referencedSettings` and skips type validation for settings not registered in the headless export process.

Implementation:

- New `IExtensionConfigurationPolicyReference` type; `extensionConfigurationPolicy` widened to `IStringDictionary<IPolicy | IExtensionConfigurationPolicyReference>`.
- Regenerates `policyData.jsonc` and updates the export test fixture.

## Net effect

- The admin `Claude3PIntegration` ADMX/plist is still generated (now from the in-code owner).
- Preview-features gating now applies to **both** the editor surface (`github.copilot.chat.claudeAgent.enabled`) and the agent-host surface (`chat.agentHost.claudeAgent.enabled`).

## Distro change (merged)

The companion distro change — microsoft/vscode-distro#1434, which turns the claude `extensionConfigurationPolicy` entry into a `policyReference` — has **merged to `main`**. This PR bumps `package.json` `"distro"` to `7abf39b86c07d094722a4b3ec9f37e78fe3d5db3` to pick it up, so it is now self-contained.

## Validation

Verified end-to-end via the Policy Inspector diagnostics:

- With the account's `editor_preview_features_enabled: false` (→ `chat_preview_features_enabled: false`), **both** `chat.agentHost.claudeAgent.enabled` and `github.copilot.chat.claudeAgent.enabled` resolve to `false` via **AccountPolicyService** — i.e. the account-side preview-features flag is now honored (the original bug), matching Codex.
- A native **MDM** policy (`CopilotNextEditSuggestions`, an owner-syntax `extensionConfigurationPolicy` entry) still applies via `PolicyChannelClient`, confirming the existing owner path is **not regressed** and both forms coexist.