### PR TITLE
agentHost: enable TAS rollout of chat.agentHost.enabled to Stable

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -127,7 +127,6 @@ import { ElectronPtyHostStarter } from '../../platform/terminal/electron-main/el
 import { PtyHostService } from '../../platform/terminal/node/ptyHostService.js';
 import { ElectronAgentHostStarter } from '../../platform/agentHost/electron-main/electronAgentHostStarter.js';
 import { AgentHostProcessManager } from '../../platform/agentHost/node/agentHostService.js';
-import { isAgentHostEnabled } from '../../platform/agentHost/common/agentService.js';
 import { NODE_REMOTE_RESOURCE_CHANNEL_NAME, NODE_REMOTE_RESOURCE_IPC_METHOD_NAME, NodeRemoteResourceResponse, NodeRemoteResourceRouter } from '../../platform/remote/common/electronRemoteResources.js';
 import { RemoteFileSystemProxyMainHandler } from '../../platform/files/electron-main/remoteFileSystemProxyMainHandler.js';
 import { REMOTE_FILE_SYSTEM_PROXY_HANDLER_CHANNEL_NAME } from '../../platform/files/common/remoteFileSystemProxy.js';
@@ -1169,10 +1168,15 @@ export class CodeApplication extends Disposable {
 		services.set(ILocalPtyService, ptyHostService);
 
 		// Agent Host
-		if (isAgentHostEnabled(this.configurationService)) {
-			const agentHostStarter = new ElectronAgentHostStarter(this.configurationService, this.environmentMainService, this.lifecycleMainService, this.logService);
-			this._register(new AgentHostProcessManager(agentHostStarter, this.logService, this.loggerService));
-		}
+		// Always instantiate the starter + manager. They are cheap (the
+		// constructors only register an IPC listener and emitters) and the agent
+		// host utility process is spawned lazily on the first window connection
+		// request. The renderer is the gate: it only requests a connection when
+		// `chat.agentHost.enabled` resolves to `true` there (honoring experiment
+		// overrides + policy + web), which the main process cannot observe since
+		// experiment overrides are never persisted to `settings.json`.
+		const agentHostStarter = new ElectronAgentHostStarter(this.configurationService, this.environmentMainService, this.lifecycleMainService, this.logService);
+		this._register(new AgentHostProcessManager(agentHostStarter, this.logService, this.loggerService));
 
 		// External terminal
 		if (isWindows) {

--- a/src/vs/platform/agentHost/common/agentHost.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHost.config.contribution.ts
@@ -39,6 +39,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.agentHost.enabled', "When enabled, some agents run in a separate agent host process."),
 			default: !isWeb && product.quality !== 'stable',
 			tags: ['experimental', 'advanced'],
+			experiment: { mode: 'startup' },
 		},
 		'chat.agents.copilotCli.hideExtensionHost': {
 			type: 'boolean',


### PR DESCRIPTION
Prepares `chat.agentHost.enabled` for progressive (TAS-cohorted) rollout to Stable, without regressing Insiders' default-on behavior or other in-flight experiments on related editor/Agents-window settings.

Fixes microsoft/vscode-internalbacklog#8185

## What changed

**1. Add a TAS hook to the setting** — `src/vs/platform/agentHost/common/agentHost.config.contribution.ts`
- Added `experiment: { mode: 'startup' }` to `chat.agentHost.enabled`. The `default` (`!isWeb && product.quality !== 'stable'`) and `tags` are unchanged.
- This is non-disruptive: `processExperimentalSettings` only registers an override when the treatment value differs from `schema.default`. So Insiders (static default `true`) see a no-op, while a Stable cohort (static default `false`) can be flipped on by a `true` treatment. The default treatment name resolves to `config.chat.agentHost.enabled`.
- The browser-layer policy file already spreads `...existingProp`, so the new `experiment` block flows into the policy-augmented re-registration with no change there.

**2. Close the main-process spawn gap** — `src/vs/code/electron-main/app.ts`
- Always instantiate `ElectronAgentHostStarter` + `AgentHostProcessManager` (removed the `if (isAgentHostEnabled(...))` guard and the now-unused import).
- Renderer experiment overrides are never persisted to `settings.json`, so the main process can't observe them. Previously a cohorted Stable user's renderer would think the agent host is on while the main process never registered the `vscode:createAgentHostMessageChannel` IPC listener — so nothing spawned.
- The starter is already lazy and renderer-driven: its constructor only registers an IPC listener + emitters, and the utility process is spawned on the first window connection request. The renderer remains the gate — it only requests a connection when `chat.agentHost.enabled` resolves to `true` there (honoring experiment overrides, policy, and the web hard-gate).

## Why this is safe

- **Insiders**: static default stays `true`; treatment is a no-op. Existing default-on behavior preserved.
- **Stable cohort**: renderer sees override `true` → requests connection → main (now always listening) spawns the agent host.
- **Policy**: `ChatAgentHostEnabled = false` still forces the renderer value off → it never connects → nothing spawns.
- **Web**: `isAgentHostEnabled` hard-gates `!isWeb`; the main-process path is desktop-only anyway.
- **Other experiments**: related editor/Agents-window settings are independent keys and are unaffected.

## Validation

- `npm run typecheck-client` — passed
- `npm run valid-layers-check` — passed
- Precommit hygiene — passed

## Notes for reviewers

- Standing up the actual ExP treatment (`config.chat.agentHost.enabled`, audience, ramp) is an ops task, not part of this change.
- Full renderer runtime-toggle reactivity (connecting when the setting flips on without a reload) is intentionally out of scope; `localAgentHostService` connects once at construction after experiments resolve.

(Written by Copilot)
