### PR TITLE
Gate Debug Local Agent Host action on chat.agentHost.enabled

### DIFF
--- a/src/vs/workbench/contrib/chat/electron-browser/actions/debugAgentHostAction.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/actions/debugAgentHostAction.ts
@@ -8,7 +8,8 @@ import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions
 import { localize, localize2 } from '../../../../../nls.js';
 import { Categories } from '../../../../../platform/action/common/actionCommonCategories.js';
 import { Action2 } from '../../../../../platform/actions/common/actions.js';
-import { IAgentHostService } from '../../../../../platform/agentHost/common/agentService.js';
+import { AgentHostEnabledSettingId, IAgentHostService } from '../../../../../platform/agentHost/common/agentService.js';
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { INativeHostService } from '../../../../../platform/native/common/native.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
@@ -23,7 +24,10 @@ export class DebugAgentHostInDevToolsAction extends Action2 {
 			category: Categories.Developer,
 			f1: true,
 			icon: Codicon.debugStart,
-			precondition: ChatContextKeys.enabled,
+			precondition: ContextKeyExpr.and(
+				ChatContextKeys.enabled,
+				ContextKeyExpr.equals(`config.${AgentHostEnabledSettingId}`, true),
+			),
 		});
 	}
 


### PR DESCRIPTION
The **Debug Local Agent Host Process In Dev Tools** command (`workbench.action.chat.debugAgentHostInDevTools`) was only gated on `ChatContextKeys.enabled`, so it showed up in the command palette even when the local agent host was disabled.

It now also requires `config.chat.agentHost.enabled`, matching the gating already used by the other local-agent-host developer actions (`ExportAgentHostDebugLogsAction`, `ExportAgentTracesDbAction`).

This command is genuinely local-only — it calls `IAgentHostService.getInspectInfo` on the in-process local agent host — so gating purely on `chat.agentHost.enabled` is correct here. The sessions-side **Export Agent Host Debug Logs** action is intentionally left alone: its `OR(IsSessionsWindow, config.chat.agentHost.enabled)` precondition also covers *remote* agent host sessions (`RemoteAgentHostSessionsProvider`, gated on the separate `chat.remoteAgentHosts.*` settings), so it must stay available in the Agents window regardless of `chat.agentHost.enabled`.

(Written by Copilot)