### PR TITLE
Persist multi-root folder picker choice to new agent-host chats

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.ts
@@ -636,6 +636,7 @@ export class AgentHostChatInputPicker extends Disposable {
 		const sessionResource = this._widget.viewModel?.sessionResource;
 		return (sessionResource && this._newSessionFolderService.getFolder(sessionResource))
 			?? (sessionResource && this._workingDirectoryResolver.resolve(sessionResource))
+			?? this._newSessionFolderService.getDefaultFolder()
 			?? this._workspaceContextService.getWorkspace().folders[0]?.uri;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem.ts
@@ -121,10 +121,13 @@ export class AgentHostFolderPickerActionItem extends ChatInputPickerActionViewIt
 				return stored;
 			}
 			// The stored folder is no longer part of the workspace (folders
-			// changed); drop the stale selection and fall back to the first folder.
+			// changed); drop the stale selection and fall back below.
 			this._newSessionFolderService.clear(sessionResource!);
 		}
-		return folders[0]?.uri;
+		// No explicit choice for this session yet: default to the folder the
+		// user last picked in this window (if still valid) so a new chat keeps
+		// the previous selection instead of resetting to the first folder.
+		return this._newSessionFolderService.getDefaultFolder() ?? folders[0]?.uri;
 	}
 
 	protected override renderLabel(element: HTMLElement): IDisposable | null {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostGenericConfigChips.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostGenericConfigChips.ts
@@ -146,6 +146,7 @@ export class AgentHostGenericConfigChips extends Disposable {
 		const sessionResource = this._widget.viewModel?.sessionResource;
 		return (sessionResource && this._newSessionFolderService.getFolder(sessionResource))
 			?? (sessionResource && this._workingDirectoryResolver.resolve(sessionResource))
+			?? this._newSessionFolderService.getDefaultFolder()
 			?? this._workspaceContextService.getWorkspace().folders[0]?.uri;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostNewSessionFolderService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostNewSessionFolderService.ts
@@ -9,6 +9,7 @@ import { ResourceMap } from '../../../../../../base/common/map.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { createDecorator } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
+import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
 
 export const IAgentHostNewSessionFolderService = createDecorator<IAgentHostNewSessionFolderService>('agentHostNewSessionFolderService');
@@ -47,6 +48,16 @@ export interface IAgentHostNewSessionFolderService {
 	 * Forget any choice recorded for the given session resource.
 	 */
 	clear(sessionResource: URI): void;
+
+	/**
+	 * The most recently chosen folder in this window (across all sessions),
+	 * provided it is still a current workspace folder, or `undefined` if the
+	 * user has never made an explicit choice (or it is no longer in the
+	 * workspace). Unlike {@link getFolder} this is a window-level "sticky"
+	 * default that survives session disposal, so a new chat defaults to the
+	 * folder the user last picked instead of resetting to the first folder.
+	 */
+	getDefaultFolder(): URI | undefined;
 }
 
 export class AgentHostNewSessionFolderService extends Disposable implements IAgentHostNewSessionFolderService {
@@ -54,18 +65,27 @@ export class AgentHostNewSessionFolderService extends Disposable implements IAge
 
 	private readonly _folders = new ResourceMap<URI>();
 
+	/**
+	 * The most recently chosen folder in this window. Window-level "sticky"
+	 * default that, unlike {@link _folders}, is not cleared on session
+	 * disposal so a new chat can default to the user's last folder choice.
+	 */
+	private _defaultFolder: URI | undefined;
+
 	private readonly _onDidChangeFolder = this._register(new Emitter<URI>());
 	readonly onDidChangeFolder = this._onDidChangeFolder.event;
 
 	constructor(
 		@IChatService chatService: IChatService,
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 	) {
 		super();
 
 		// Forget a session's chosen folder once the session is disposed. This
 		// bounds the store to live sessions while keeping the choice available
 		// for the session's whole lifetime (so the Folder chip keeps showing
-		// the right folder after the session has started).
+		// the right folder after the session has started). The window-level
+		// default ({@link _defaultFolder}) is intentionally left untouched.
 		this._register(chatService.onDidDisposeSession(e => {
 			for (const sessionResource of e.sessionResources) {
 				this.clear(sessionResource);
@@ -78,6 +98,7 @@ export class AgentHostNewSessionFolderService extends Disposable implements IAge
 	}
 
 	setFolder(sessionResource: URI, folder: URI): void {
+		this._defaultFolder = folder;
 		const existing = this._folders.get(sessionResource);
 		if (existing?.toString() === folder.toString()) {
 			return;
@@ -90,6 +111,14 @@ export class AgentHostNewSessionFolderService extends Disposable implements IAge
 		if (this._folders.delete(sessionResource)) {
 			this._onDidChangeFolder.fire(sessionResource);
 		}
+	}
+
+	getDefaultFolder(): URI | undefined {
+		const stored = this._defaultFolder;
+		if (stored && this._workspaceContextService.getWorkspace().folders.some(folder => folder.uri.toString() === stored.toString())) {
+			return stored;
+		}
+		return undefined;
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostNewSessionFolderService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostNewSessionFolderService.ts
@@ -6,6 +6,7 @@
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../../../base/common/map.js';
+import { extUriBiasedIgnorePathCase } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { createDecorator } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
@@ -115,7 +116,7 @@ export class AgentHostNewSessionFolderService extends Disposable implements IAge
 
 	getDefaultFolder(): URI | undefined {
 		const stored = this._defaultFolder;
-		if (stored && this._workspaceContextService.getWorkspace().folders.some(folder => folder.uri.toString() === stored.toString())) {
+		if (stored && this._workspaceContextService.getWorkspace().folders.some(folder => extUriBiasedIgnorePathCase.isEqual(folder.uri, stored))) {
 			return stored;
 		}
 		return undefined;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -3362,6 +3362,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		return this._config.resolveWorkingDirectory?.(sessionResource)
 			?? this._newSessionFolderService.getFolder(sessionResource)
 			?? this._workingDirectoryResolver.resolve(sessionResource)
+			?? this._newSessionFolderService.getDefaultFolder()
 			?? this._workspaceContextService.getWorkspace().folders[0]?.uri;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
@@ -99,6 +99,7 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 		// `_createAndSubscribe` path with no user selections.
 		if (request.untitledResource) {
 			const workingDirectory = this._newSessionFolderService.getFolder(request.untitledResource)
+				?? this._newSessionFolderService.getDefaultFolder()
 				?? this._workspaceContextService.getWorkspace().folders[0]?.uri;
 			// Carry the chosen folder forward onto the real resource so the
 			// handler's working-directory resolution stays consistent after the

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -615,7 +615,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 		disposeSession: async () => { },
 		...provisionalServiceOverride,
 	} as Partial<IAgentHostUntitledProvisionalSessionService> as IAgentHostUntitledProvisionalSessionService);
-	const newSessionFolderService = disposables.add(new AgentHostNewSessionFolderService(chatService as Partial<IChatService> as IChatService));
+	const newSessionFolderService = disposables.add(new AgentHostNewSessionFolderService(chatService as Partial<IChatService> as IChatService, instantiationService.get(IWorkspaceContextService)));
 	instantiationService.stub(IAgentHostNewSessionFolderService, newSessionFolderService);
 	const customizationsByType = new Map<string, IObservable<readonly ClientPluginCustomization[]>>();
 	const seedActiveClient = (sessionType: string, entry: { customizations: IObservable<readonly ClientPluginCustomization[]> }): IDisposable => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostNewSessionFolderService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostNewSessionFolderService.test.ts
@@ -9,6 +9,7 @@ import { Emitter } from '../../../../../../base/common/event.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
+import { IWorkspaceContextService, IWorkspaceFolder, IWorkspace } from '../../../../../../platform/workspace/common/workspace.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { AgentHostNewSessionFolderService } from '../../../browser/agentSessions/agentHost/agentHostNewSessionFolderService.js';
 
@@ -18,19 +19,28 @@ suite('AgentHostNewSessionFolderService', () => {
 	let service: AgentHostNewSessionFolderService;
 	let cleanup: DisposableStore;
 	let onDidDisposeSession: Emitter<{ readonly sessionResources: readonly URI[]; readonly reason: 'cleared' }>;
+	let workspaceFolders: URI[];
 
 	setup(() => {
 		onDidDisposeSession = ds.add(new Emitter<{ readonly sessionResources: readonly URI[]; readonly reason: 'cleared' }>());
 		const chatService = new class extends mock<IChatService>() {
 			override readonly onDidDisposeSession = onDidDisposeSession.event;
 		};
-		service = ds.add(new AgentHostNewSessionFolderService(chatService));
+		workspaceFolders = [folderA, folderB];
+		const workspaceContextService = new class extends mock<IWorkspaceContextService>() {
+			override getWorkspace(): IWorkspace {
+				return { folders: workspaceFolders.map(uri => ({ uri } as IWorkspaceFolder)) } as IWorkspace;
+			}
+		};
+		service = ds.add(new AgentHostNewSessionFolderService(chatService, workspaceContextService));
 		cleanup = ds.add(new DisposableStore());
 	});
 
 	const sessionA = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-a' });
+	const sessionB = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-b' });
 	const folderA = URI.file('/repoA');
 	const folderB = URI.file('/repoB');
+	const folderC = URI.file('/repoC');
 
 	test('set/get/clear round-trips and fires onDidChange on real changes only', () => {
 		const changes: string[] = [];
@@ -71,6 +81,40 @@ suite('AgentHostNewSessionFolderService', () => {
 		}, {
 			afterDispose: undefined,
 			changes: [sessionA.toString(), sessionA.toString()],
+		});
+	});
+
+	test('getDefaultFolder returns the last chosen folder and survives session disposal', () => {
+		assert.strictEqual(service.getDefaultFolder(), undefined, 'no default before any choice');
+
+		service.setFolder(sessionA, folderA);
+		const afterFirst = service.getDefaultFolder()?.toString();
+
+		service.setFolder(sessionB, folderB);
+		const afterSecond = service.getDefaultFolder()?.toString();
+
+		// Disposing a session forgets its per-session choice but keeps the
+		// window-level default sticky so a new chat reuses the last folder.
+		onDidDisposeSession.fire({ sessionResources: [sessionB], reason: 'cleared' });
+		const afterDispose = service.getDefaultFolder()?.toString();
+
+		assert.deepStrictEqual({ afterFirst, afterSecond, afterDispose }, {
+			afterFirst: folderA.toString(),
+			afterSecond: folderB.toString(),
+			afterDispose: folderB.toString(),
+		});
+	});
+
+	test('getDefaultFolder drops a default no longer in the workspace', () => {
+		service.setFolder(sessionA, folderC);
+		const whileWorkspaceLacksFolder = service.getDefaultFolder();
+
+		workspaceFolders = [folderA, folderB, folderC];
+		const afterFolderAdded = service.getDefaultFolder()?.toString();
+
+		assert.deepStrictEqual({ whileWorkspaceLacksFolder, afterFolderAdded }, {
+			whileWorkspaceLacksFolder: undefined,
+			afterFolderAdded: folderC.toString(),
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostNewSessionFolderService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostNewSessionFolderService.test.ts
@@ -105,7 +105,7 @@ suite('AgentHostNewSessionFolderService', () => {
 		});
 	});
 
-	test('getDefaultFolder drops a default no longer in the workspace', () => {
+	test('getDefaultFolder hides a default not in the workspace and surfaces it once present', () => {
 		service.setFolder(sessionA, folderC);
 		const whileWorkspaceLacksFolder = service.getDefaultFolder();
 


### PR DESCRIPTION
Fixes #321453

## Problem

For agent-host (AHP) chat sessions in the editor in a multi-root workspace: pick a folder in the Folder picker, send a message, then click **New chat** — the picker resets to the first folder instead of remembering your choice.

## Root cause

The chosen working folder is stored in `AgentHostNewSessionFolderService`, **keyed by the session's untitled compose resource**. Clicking *New chat* mints a *new* compose resource, so `getFolder(newResource)` returns `undefined` and every working-directory resolution site falls back to `workspace.folders[0]`.

## Fix

Add a window-level **sticky default folder** to `IAgentHostNewSessionFolderService`:

- `setFolder` records the latest choice as the default.
- New `getDefaultFolder()` returns it, validated against the current workspace folders (a folder removed from the workspace is dropped).
- It is intentionally **not** cleared on session disposal, so it persists across new chats for the window's lifetime.

All resolution sites now fall back to `getDefaultFolder()` before `folders[0]` — both the *display* sites (picker, working-dir chip / provisional) and the *actual cwd* sites (materialization in the list controller + the session handler) — so the picker and the session the new chat actually runs in stay consistent.

## Validation

- `npm run typecheck-client` ✓
- `npm run valid-layers-check` ✓
- Unit tests: folder-service suite (2 new tests) ✓ and full `AgentHost` suite (1081 passing) ✓, including the existing multi-root folder-picker tests.

(Written by Copilot)