### PR TITLE
Fix hiding Update UI during active chat sessions

### DIFF
--- a/src/vs/workbench/contrib/update/browser/updateTitleBarEntry.ts
+++ b/src/vs/workbench/contrib/update/browser/updateTitleBarEntry.ts
@@ -7,8 +7,7 @@ import * as dom from '../../../../base/browser/dom.js';
 import { BaseActionViewItem, IBaseActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { IManagedHoverContent } from '../../../../base/browser/ui/hover/hover.js';
 import { IAction, WorkbenchActionExecutedClassification, WorkbenchActionExecutedEvent } from '../../../../base/common/actions.js';
-import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
-import { Disposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
 import { isWeb } from '../../../../base/common/platform.js';
 import { localize } from '../../../../nls.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
@@ -26,12 +25,13 @@ import { InEditorZenModeContext } from '../../../common/contextkeys.js';
 import { IHostService } from '../../../services/host/browser/host.js';
 import { IChatService } from '../../chat/common/chatService/chatService.js';
 import { computeProgressPercent } from '../common/updateUtils.js';
-import { waitForState } from '../../../../base/common/observable.js';
+import { autorun } from '../../../../base/common/observable.js';
 import './media/updateTitleBarEntry.css';
 import { UpdateTooltip } from './updateTooltip.js';
 
 const UPDATE_TITLE_BAR_ACTION_ID = 'workbench.actions.updateIndicator';
 const UPDATE_TITLE_BAR_CONTEXT = new RawContextKey<boolean>('updateTitleBar', false);
+const UPDATE_TITLE_BAR_CHAT_IN_PROGRESS_CONTEXT = new RawContextKey<boolean>('updateTitleBarChatRequestInProgress', false);
 
 const DISABLED_REMINDER_LAST_SHOWN_KEY = 'update/disabledReminderLastShown';
 const DISABLED_REMINDER_PERIOD = 30 * 24 * 60 * 60 * 1000; // 30 days
@@ -63,7 +63,7 @@ registerAction2(class UpdateIndicatorTitleBarAction extends Action2 {
 			menu: [{
 				id: MenuId.TitleBarAdjacentCenter,
 				order: 0,
-				when: ContextKeyExpr.and(UPDATE_TITLE_BAR_CONTEXT, InEditorZenModeContext.negate(), ContextKeyExpr.not('inDebugMode')),
+				when: ContextKeyExpr.and(UPDATE_TITLE_BAR_CONTEXT, InEditorZenModeContext.negate(), ContextKeyExpr.not('inDebugMode'), UPDATE_TITLE_BAR_CHAT_IN_PROGRESS_CONTEXT.negate()),
 			}]
 		});
 	}
@@ -80,11 +80,10 @@ export class UpdateTitleBarContribution extends Disposable implements IWorkbench
 	private state!: State;
 	private entry: UpdateTitleBarEntry | undefined;
 	private tooltipVisible = false;
-	private readonly pendingShow = this._register(new MutableDisposable());
 
 	constructor(
 		@IActionViewItemService actionViewItemService: IActionViewItemService,
-		@IChatService private readonly chatService: IChatService,
+		@IChatService chatService: IChatService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IHostService private readonly hostService: IHostService,
@@ -100,6 +99,11 @@ export class UpdateTitleBarContribution extends Disposable implements IWorkbench
 
 		this.context = UPDATE_TITLE_BAR_CONTEXT.bindTo(contextKeyService);
 		this.tooltip = this._register(instantiationService.createInstance(UpdateTooltip));
+
+		const chatInProgressContext = UPDATE_TITLE_BAR_CHAT_IN_PROGRESS_CONTEXT.bindTo(contextKeyService);
+		this._register(autorun(reader => {
+			chatInProgressContext.set(chatService.requestInProgressObs.read(reader));
+		}));
 
 		this.state = updateService.state;
 		this._register(updateService.onStateChange((state) => {
@@ -127,7 +131,7 @@ export class UpdateTitleBarContribution extends Disposable implements IWorkbench
 					id: UPDATE_TITLE_BAR_ACTION_ID,
 					title: localize('updateIndicatorTitleBarAction', 'Update'),
 				},
-				when: item.when ? ContextKeyExpr.and(UPDATE_TITLE_BAR_CONTEXT, item.when) : UPDATE_TITLE_BAR_CONTEXT,
+				when: ContextKeyExpr.and(UPDATE_TITLE_BAR_CONTEXT, UPDATE_TITLE_BAR_CHAT_IN_PROGRESS_CONTEXT.negate(), item.when),
 			});
 			this._register(actionViewItemService.register(
 				menuId,
@@ -153,15 +157,13 @@ export class UpdateTitleBarContribution extends Disposable implements IWorkbench
 	}
 
 	private async onStateChange(startup = false) {
-		this.pendingShow.clear();
-
 		if (this.configurationService.getValue<boolean>(UPDATE_TITLE_BAR_SETTING) === false) {
 			this.context.set(false);
 			return;
 		}
 
 		if (ACTIONABLE_STATES.includes(this.state.type)) {
-			await this.setContextWhenChatIdle(true);
+			this.context.set(true);
 		} else {
 			this.context.set(false);
 		}
@@ -203,22 +205,6 @@ export class UpdateTitleBarContribution extends Disposable implements IWorkbench
 			if (this.state.type === StateType.Disabled) {
 				this.storageService.store(DISABLED_REMINDER_LAST_SHOWN_KEY, Date.now(), StorageScope.APPLICATION, StorageTarget.MACHINE);
 			}
-		}
-	}
-
-	private async setContextWhenChatIdle(value: boolean) {
-		if (!this.chatService.requestInProgressObs.get()) {
-			this.context.set(value);
-			return;
-		}
-
-		const cts = new CancellationTokenSource();
-		this.pendingShow.value = toDisposable(() => cts.dispose(true));
-		try {
-			await waitForState(this.chatService.requestInProgressObs, inProgress => !inProgress, undefined, cts.token);
-			this.context.set(value);
-		} catch {
-			// cancelled — a newer state change superseded this one
 		}
 	}
 


### PR DESCRIPTION
Fixes #312330

Before this change Update button would be hidden if update state changed during an active chat session, but it would not hide again if a new chat is started after Update button is shown.

Now Update button will hide during active chat sessions (similar to how it works with debug sessions already).
