### PR TITLE
agentHost: fix subagent transcript replay + bump Claude/Codex SDKs

### DIFF
--- a/build/agent-sdk/agents/claude/package-lock.json
+++ b/build/agent-sdk/agents/claude/package-lock.json
@@ -6,26 +6,26 @@
 		"": {
 			"name": "agent-sdk-claude",
 			"dependencies": {
-				"@anthropic-ai/claude-agent-sdk": "0.3.169"
+				"@anthropic-ai/claude-agent-sdk": "0.3.187"
 			}
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk": {
-			"version": "0.3.169",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.169.tgz",
-			"integrity": "sha512-pzsd0BBnlfHwAUfKouSNwDLcCxGDq+lbPZTsIdiNSLw+AQw7mjxPxqnFwd4YH7qw+E3XhlotuihCm01XzcybPQ==",
+			"version": "0.3.187",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.187.tgz",
+			"integrity": "sha512-HHkuC3he/Wi8fX/WjfS8mJr4TFPGoAd1QyxOuTwjnyOLboGkX1H+UhBYLxHX1ouFvHnYVJglB2wsuWemVQgahQ==",
 			"license": "SEE LICENSE IN README.md",
 			"engines": {
 				"node": ">=18.0.0"
 			},
 			"optionalDependencies": {
-				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.169",
-				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.169",
-				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.169",
-				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.169",
-				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.169",
-				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.169",
-				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.169",
-				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.169"
+				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.187",
+				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.187",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.187",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.187",
+				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.187",
+				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.187",
+				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.187",
+				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.187"
 			},
 			"peerDependencies": {
 				"@anthropic-ai/sdk": ">=0.93.0",
@@ -34,9 +34,9 @@
 			}
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-			"version": "0.3.169",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.169.tgz",
-			"integrity": "sha512-5PJU3wqfvJUrgUF3H7iroxAGDyliKmq5q8kK+glERf8YZgmPeDMvQL4mGSB0Vf9RgBWS01dCen93TIsN0O8NPQ==",
+			"version": "0.3.187",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.187.tgz",
+			"integrity": "sha512-0DNzATzaRmjS/Q1T4T9SLP/VT67gRX7J4reYPnEdcTm91lJwjqOPkHr17+sv+7DoerZ421ZG38dPsQd/V67qQw==",
 			"cpu": [
 				"arm64"
 			],
@@ -47,9 +47,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-			"version": "0.3.169",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.169.tgz",
-			"integrity": "sha512-1Hzt0QYG7N/ExfPbN/C92YRc3BoDnyQMJpuWLVyI/r0NmKV/se/cZbIygbvQXs2ywoXOB/EyNj/hkVHaC1G22g==",
+			"version": "0.3.187",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.187.tgz",
+			"integrity": "sha512-Va3O8lTDa9IHq/DbSJwU63JJknNV3YCBh4PEznOHXJtyFoXHgRjrks4QQvN3baZm79avVq2sn+6tvpTz9CuY8A==",
 			"cpu": [
 				"x64"
 			],
@@ -60,9 +60,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-			"version": "0.3.169",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.169.tgz",
-			"integrity": "sha512-J0tyM4t5qxc2/xilsfHqcJv+fyEDhX66Nv+CMXq4mRbquZmMHhbZbh8ryb+BnKYXUeqKX3uoU/J+7K6/fjcY4g==",
+			"version": "0.3.187",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.187.tgz",
+			"integrity": "sha512-VEvrs3MgwckdWRNa7+2rJdyOBbCWGoRaM6OnL+/n9qi4gKlZnXZlj/90Tw9o8ttcN260Opz120/SE1fYwzu/JA==",
 			"cpu": [
 				"arm64"
 			],
@@ -76,9 +76,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-			"version": "0.3.169",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.169.tgz",
-			"integrity": "sha512-xkmyNdU6f7HXXzgR6IZym7x41bjL3rjGrXf5PAmx9PjdThy476+TrpO1evKUza1zlVmUj4tj/jYKQsV4ER7QFw==",
+			"version": "0.3.187",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.187.tgz",
+			"integrity": "sha512-XQ7w2pX0mjPYUC7ayTKiHeAbePOny/ezBATxTWt5JVDZZPfljzvHA0jyXHsN8aLphbgRUfbUpdrtt5b57Bhx5g==",
 			"cpu": [
 				"arm64"
 			],
@@ -92,9 +92,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-			"version": "0.3.169",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.169.tgz",
-			"integrity": "sha512-ktEPBwzXZagt0cntfRLlvNL0sAplt2HOCbR5iBvq2IV5dLvbEOiBjZQArIcSAN7CTQUFqkZs9HzQMdKe5QPwuQ==",
+			"version": "0.3.187",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.187.tgz",
+			"integrity": "sha512-s/Fmg29tzMrbdeCbseTpL3DlzfWineSQ3bDPvhdKw4jcsgLC1YgQhIkAyE8WlceUyhQyw82NAUgYoPwfGny6hQ==",
 			"cpu": [
 				"x64"
 			],
@@ -108,9 +108,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-			"version": "0.3.169",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.169.tgz",
-			"integrity": "sha512-Me8VW91pCKgkct/y1isjKNVt+ZPMPhHk3C7O078UO1bakHD6kuPiMtugcCsg4jmmmuuywXQIQUESRbcf0GluUg==",
+			"version": "0.3.187",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.187.tgz",
+			"integrity": "sha512-yi2/L5oztFqTDnAZl4mWOINr+r7WBot70gYUxG2jOoqdYUl6j50vG/ME605X80v+l2qBmKjSGxb5trY/6DkRzQ==",
 			"cpu": [
 				"x64"
 			],
@@ -124,9 +124,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-			"version": "0.3.169",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.169.tgz",
-			"integrity": "sha512-HL9ecP82A/H8aC896Q7ETyl+nLFkMzBHfO0yvK7Lhxbi98CEpqXn3BADTAc5pEgzkO+r18+CDmZdgjTFMvGoTw==",
+			"version": "0.3.187",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.187.tgz",
+			"integrity": "sha512-HjEl3cDRLAWKopdlrLI54fxTVWq4lZpWA4bTTBVc9UDdDj6AmJIRHKxaCCYLQRvnoswbAUF1sJmJ8EFJ+b6lfw==",
 			"cpu": [
 				"arm64"
 			],
@@ -137,9 +137,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-			"version": "0.3.169",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.169.tgz",
-			"integrity": "sha512-34pBbiKe7FNsY8LHuuTmKujmYko/cBOrKJpk9H+MOot+dSfB/FmIHq9USL17otNal5Droq9lqpezAWPBPv3lAQ==",
+			"version": "0.3.187",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.187.tgz",
+			"integrity": "sha512-FnrLhoZ8y/+gkZynL12UeQ8pWKCu6B/8myyRrYMNJRZqFw4DZlPvPCywAjFZf1e1hiXCoiSK0Orl5wzKfAeQsQ==",
 			"cpu": [
 				"x64"
 			],

--- a/build/agent-sdk/agents/claude/package.json
+++ b/build/agent-sdk/agents/claude/package.json
@@ -3,6 +3,6 @@
 	"private": true,
 	"comment": "Pinned dependency set for the build/agent-sdk claude tarball. The package-lock.json alongside is the source of truth for transitive deps — produce.ts runs `npm ci` against this directory to get byte-deterministic output across pipeline runs.",
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.169"
+		"@anthropic-ai/claude-agent-sdk": "0.3.187"
 	}
 }

--- a/build/agent-sdk/agents/codex/package-lock.json
+++ b/build/agent-sdk/agents/codex/package-lock.json
@@ -6,13 +6,13 @@
 		"": {
 			"name": "agent-sdk-codex",
 			"dependencies": {
-				"@openai/codex": "0.135.0"
+				"@openai/codex": "0.142.0"
 			}
 		},
 		"node_modules/@openai/codex": {
-			"version": "0.135.0",
-			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0.tgz",
-			"integrity": "sha512-ID75QEYmAT1WsUQmpxPlNsL5W1a+2eeD7fP6ywdwGseiXUG8D5i16L+dzbr8MT+2oTkaVqzOdvAqVOCeV/H/Bw==",
+			"version": "0.142.0",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.0.tgz",
+			"integrity": "sha512-c7WftbRyE4zOLJV5p73mcGn4jVK3FmK84Q65hrZrXboZzLPDWRfbFedCbsIjU4PJS/kvgyMPhv7dH4/nhXzUyg==",
 			"license": "Apache-2.0",
 			"bin": {
 				"codex": "bin/codex.js"
@@ -21,19 +21,19 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@openai/codex-darwin-arm64": "npm:@openai/codex@0.135.0-darwin-arm64",
-				"@openai/codex-darwin-x64": "npm:@openai/codex@0.135.0-darwin-x64",
-				"@openai/codex-linux-arm64": "npm:@openai/codex@0.135.0-linux-arm64",
-				"@openai/codex-linux-x64": "npm:@openai/codex@0.135.0-linux-x64",
-				"@openai/codex-win32-arm64": "npm:@openai/codex@0.135.0-win32-arm64",
-				"@openai/codex-win32-x64": "npm:@openai/codex@0.135.0-win32-x64"
+				"@openai/codex-darwin-arm64": "npm:@openai/codex@0.142.0-darwin-arm64",
+				"@openai/codex-darwin-x64": "npm:@openai/codex@0.142.0-darwin-x64",
+				"@openai/codex-linux-arm64": "npm:@openai/codex@0.142.0-linux-arm64",
+				"@openai/codex-linux-x64": "npm:@openai/codex@0.142.0-linux-x64",
+				"@openai/codex-win32-arm64": "npm:@openai/codex@0.142.0-win32-arm64",
+				"@openai/codex-win32-x64": "npm:@openai/codex@0.142.0-win32-x64"
 			}
 		},
 		"node_modules/@openai/codex-darwin-arm64": {
 			"name": "@openai/codex",
-			"version": "0.135.0-darwin-arm64",
-			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-darwin-arm64.tgz",
-			"integrity": "sha512-wpNzssusKfrldVlq39+HyQh1wCyc9SQNpHdAFGKtPenrgRte4Ct8/oVsDtKWuFZsqLBFwbL4MrzrevnB63+9HA==",
+			"version": "0.142.0-darwin-arm64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.0-darwin-arm64.tgz",
+			"integrity": "sha512-jwbriCRTSNfqoGov5bNnnYAKarnNv4QfGkut8psKAajebL6VPI2ZjCxCJ1OFA5HhUQsN8GQgEjKlj6WhYcMmUA==",
 			"cpu": [
 				"arm64"
 			],
@@ -48,9 +48,9 @@
 		},
 		"node_modules/@openai/codex-darwin-x64": {
 			"name": "@openai/codex",
-			"version": "0.135.0-darwin-x64",
-			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-darwin-x64.tgz",
-			"integrity": "sha512-ZrjAqce23lbv9KfkYOhElf1lTI+SysXmyGM0FV5u4+PBCKPkkEs4eaS3H8Uig0i4bUSu1QylrOOCskzYhZ6VyQ==",
+			"version": "0.142.0-darwin-x64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.0-darwin-x64.tgz",
+			"integrity": "sha512-qwdPfW8sOBEfWw1Rt7baveUsOjrudrM7qfKNnJvHPRrwtt4jemTd22VtZ6r02kUQdLwt6Ddvs0Pwzk6QJW6PqA==",
 			"cpu": [
 				"x64"
 			],
@@ -65,9 +65,9 @@
 		},
 		"node_modules/@openai/codex-linux-arm64": {
 			"name": "@openai/codex",
-			"version": "0.135.0-linux-arm64",
-			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-linux-arm64.tgz",
-			"integrity": "sha512-dM+cv5ZL+BgIQzEIvMg9AxZ98n5lkKLgtp5zJLXWSrbCllbnUSqxYMUiWI5c1a1uBDUtkbY9fcGKXFLf+d+gyg==",
+			"version": "0.142.0-linux-arm64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.0-linux-arm64.tgz",
+			"integrity": "sha512-gX9hCK59bE0Itnous1MCrKiXTYuoGVE6oJUE0kyRSzaBD267sh9TNR3DXKbY7TsP7iAs19n8YXDJNdHZJtakSQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -82,9 +82,9 @@
 		},
 		"node_modules/@openai/codex-linux-x64": {
 			"name": "@openai/codex",
-			"version": "0.135.0-linux-x64",
-			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-linux-x64.tgz",
-			"integrity": "sha512-5EosY67yU28UJSnl/obdN2F1CDaimYbzm9SLR8dwwzkeBBnY6dHgAKJ2GTu9Nc8CmgmtVFBGzgPqehsIcueVvA==",
+			"version": "0.142.0-linux-x64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.0-linux-x64.tgz",
+			"integrity": "sha512-nywS+ogFPRhZnQnKL+jzWKzFhmjTQbYPh6n8dtQ/E+sJ3FoZVcb9a6kvHL5yjgtlCiDkP0jPDYY5AK3tDShYyw==",
 			"cpu": [
 				"x64"
 			],
@@ -99,9 +99,9 @@
 		},
 		"node_modules/@openai/codex-win32-arm64": {
 			"name": "@openai/codex",
-			"version": "0.135.0-win32-arm64",
-			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-win32-arm64.tgz",
-			"integrity": "sha512-SAeR+CUv7KWwE6eTc2UFaFjo6FpHywYfDFKrK6FqLms1rq1NPju2SoX7rhM6UEew/lUx2mdZv/LDs11s/N/Qgg==",
+			"version": "0.142.0-win32-arm64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.0-win32-arm64.tgz",
+			"integrity": "sha512-Lz8xEn7uNn0XTi8k0jApKM5P9BD7QvAH3ZbtlGi1zfSOgh1kmgpfXxaTlJF503mozdHaA2r6UA7hfTi+bI0CvQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -116,9 +116,9 @@
 		},
 		"node_modules/@openai/codex-win32-x64": {
 			"name": "@openai/codex",
-			"version": "0.135.0-win32-x64",
-			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-win32-x64.tgz",
-			"integrity": "sha512-uYwUBMbOfmVlCESJZmZsOG+cYwNFYvkMbQ+FB6C1u9RYz0m3mZeYNN0j+l1hRSyUgPMFJHzNpgNx1Usal5QZFQ==",
+			"version": "0.142.0-win32-x64",
+			"resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.0-win32-x64.tgz",
+			"integrity": "sha512-LkARkXh3NM0XA8R8hFAgjx017fadfb9RgmqLzdhO1Qt/bDVSJnmDf4cwJ2h+FWZcm9/rRk3JC/IuqBvwg/TN+Q==",
 			"cpu": [
 				"x64"
 			],

--- a/build/agent-sdk/agents/codex/package.json
+++ b/build/agent-sdk/agents/codex/package.json
@@ -3,6 +3,6 @@
 	"private": true,
 	"comment": "Pinned dependency set for the build/agent-sdk codex tarball. The package-lock.json alongside is the source of truth for transitive deps — produce.ts runs `npm ci` against this directory to get byte-deterministic output across pipeline runs.",
 	"dependencies": {
-		"@openai/codex": "0.135.0"
+		"@openai/codex": "0.142.0"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,8 +77,8 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.169",
-        "@openai/codex": "0.135.0",
+        "@anthropic-ai/claude-agent-sdk": "0.3.187",
+        "@openai/codex": "0.142.0",
         "@playwright/cli": "^0.1.9",
         "@playwright/test": "^1.56.1",
         "@stylistic/eslint-plugin-ts": "^2.8.0",
@@ -185,23 +185,23 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.169",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.169.tgz",
-      "integrity": "sha512-pzsd0BBnlfHwAUfKouSNwDLcCxGDq+lbPZTsIdiNSLw+AQw7mjxPxqnFwd4YH7qw+E3XhlotuihCm01XzcybPQ==",
+      "version": "0.3.187",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.187.tgz",
+      "integrity": "sha512-HHkuC3he/Wi8fX/WjfS8mJr4TFPGoAd1QyxOuTwjnyOLboGkX1H+UhBYLxHX1ouFvHnYVJglB2wsuWemVQgahQ==",
       "dev": true,
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.169",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.169",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.169",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.169",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.169",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.169",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.169",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.169"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.187",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.187",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.187",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.187",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.187",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.187",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.187",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.187"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -210,9 +210,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.169",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.169.tgz",
-      "integrity": "sha512-5PJU3wqfvJUrgUF3H7iroxAGDyliKmq5q8kK+glERf8YZgmPeDMvQL4mGSB0Vf9RgBWS01dCen93TIsN0O8NPQ==",
+      "version": "0.3.187",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.187.tgz",
+      "integrity": "sha512-0DNzATzaRmjS/Q1T4T9SLP/VT67gRX7J4reYPnEdcTm91lJwjqOPkHr17+sv+7DoerZ421ZG38dPsQd/V67qQw==",
       "cpu": [
         "arm64"
       ],
@@ -224,9 +224,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.169",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.169.tgz",
-      "integrity": "sha512-1Hzt0QYG7N/ExfPbN/C92YRc3BoDnyQMJpuWLVyI/r0NmKV/se/cZbIygbvQXs2ywoXOB/EyNj/hkVHaC1G22g==",
+      "version": "0.3.187",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.187.tgz",
+      "integrity": "sha512-Va3O8lTDa9IHq/DbSJwU63JJknNV3YCBh4PEznOHXJtyFoXHgRjrks4QQvN3baZm79avVq2sn+6tvpTz9CuY8A==",
       "cpu": [
         "x64"
       ],
@@ -238,13 +238,16 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.169",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.169.tgz",
-      "integrity": "sha512-J0tyM4t5qxc2/xilsfHqcJv+fyEDhX66Nv+CMXq4mRbquZmMHhbZbh8ryb+BnKYXUeqKX3uoU/J+7K6/fjcY4g==",
+      "version": "0.3.187",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.187.tgz",
+      "integrity": "sha512-VEvrs3MgwckdWRNa7+2rJdyOBbCWGoRaM6OnL+/n9qi4gKlZnXZlj/90Tw9o8ttcN260Opz120/SE1fYwzu/JA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -252,13 +255,16 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.169",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.169.tgz",
-      "integrity": "sha512-xkmyNdU6f7HXXzgR6IZym7x41bjL3rjGrXf5PAmx9PjdThy476+TrpO1evKUza1zlVmUj4tj/jYKQsV4ER7QFw==",
+      "version": "0.3.187",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.187.tgz",
+      "integrity": "sha512-XQ7w2pX0mjPYUC7ayTKiHeAbePOny/ezBATxTWt5JVDZZPfljzvHA0jyXHsN8aLphbgRUfbUpdrtt5b57Bhx5g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -266,13 +272,16 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.169",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.169.tgz",
-      "integrity": "sha512-ktEPBwzXZagt0cntfRLlvNL0sAplt2HOCbR5iBvq2IV5dLvbEOiBjZQArIcSAN7CTQUFqkZs9HzQMdKe5QPwuQ==",
+      "version": "0.3.187",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.187.tgz",
+      "integrity": "sha512-s/Fmg29tzMrbdeCbseTpL3DlzfWineSQ3bDPvhdKw4jcsgLC1YgQhIkAyE8WlceUyhQyw82NAUgYoPwfGny6hQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -280,13 +289,16 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.169",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.169.tgz",
-      "integrity": "sha512-Me8VW91pCKgkct/y1isjKNVt+ZPMPhHk3C7O078UO1bakHD6kuPiMtugcCsg4jmmmuuywXQIQUESRbcf0GluUg==",
+      "version": "0.3.187",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.187.tgz",
+      "integrity": "sha512-yi2/L5oztFqTDnAZl4mWOINr+r7WBot70gYUxG2jOoqdYUl6j50vG/ME605X80v+l2qBmKjSGxb5trY/6DkRzQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -294,9 +306,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.169",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.169.tgz",
-      "integrity": "sha512-HL9ecP82A/H8aC896Q7ETyl+nLFkMzBHfO0yvK7Lhxbi98CEpqXn3BADTAc5pEgzkO+r18+CDmZdgjTFMvGoTw==",
+      "version": "0.3.187",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.187.tgz",
+      "integrity": "sha512-HjEl3cDRLAWKopdlrLI54fxTVWq4lZpWA4bTTBVc9UDdDj6AmJIRHKxaCCYLQRvnoswbAUF1sJmJ8EFJ+b6lfw==",
       "cpu": [
         "arm64"
       ],
@@ -308,9 +320,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.169",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.169.tgz",
-      "integrity": "sha512-34pBbiKe7FNsY8LHuuTmKujmYko/cBOrKJpk9H+MOot+dSfB/FmIHq9USL17otNal5Droq9lqpezAWPBPv3lAQ==",
+      "version": "0.3.187",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.187.tgz",
+      "integrity": "sha512-FnrLhoZ8y/+gkZynL12UeQ8pWKCu6B/8myyRrYMNJRZqFw4DZlPvPCywAjFZf1e1hiXCoiSK0Orl5wzKfAeQsQ==",
       "cpu": [
         "x64"
       ],
@@ -2191,9 +2203,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.135.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0.tgz",
-      "integrity": "sha512-ID75QEYmAT1WsUQmpxPlNsL5W1a+2eeD7fP6ywdwGseiXUG8D5i16L+dzbr8MT+2oTkaVqzOdvAqVOCeV/H/Bw==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.0.tgz",
+      "integrity": "sha512-c7WftbRyE4zOLJV5p73mcGn4jVK3FmK84Q65hrZrXboZzLPDWRfbFedCbsIjU4PJS/kvgyMPhv7dH4/nhXzUyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2203,19 +2215,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.135.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.135.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.135.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.135.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.135.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.135.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.142.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.142.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.142.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.142.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.142.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.142.0-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.135.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-darwin-arm64.tgz",
-      "integrity": "sha512-wpNzssusKfrldVlq39+HyQh1wCyc9SQNpHdAFGKtPenrgRte4Ct8/oVsDtKWuFZsqLBFwbL4MrzrevnB63+9HA==",
+      "version": "0.142.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.0-darwin-arm64.tgz",
+      "integrity": "sha512-jwbriCRTSNfqoGov5bNnnYAKarnNv4QfGkut8psKAajebL6VPI2ZjCxCJ1OFA5HhUQsN8GQgEjKlj6WhYcMmUA==",
       "cpu": [
         "arm64"
       ],
@@ -2231,9 +2243,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.135.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-darwin-x64.tgz",
-      "integrity": "sha512-ZrjAqce23lbv9KfkYOhElf1lTI+SysXmyGM0FV5u4+PBCKPkkEs4eaS3H8Uig0i4bUSu1QylrOOCskzYhZ6VyQ==",
+      "version": "0.142.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.0-darwin-x64.tgz",
+      "integrity": "sha512-qwdPfW8sOBEfWw1Rt7baveUsOjrudrM7qfKNnJvHPRrwtt4jemTd22VtZ6r02kUQdLwt6Ddvs0Pwzk6QJW6PqA==",
       "cpu": [
         "x64"
       ],
@@ -2249,9 +2261,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.135.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-linux-arm64.tgz",
-      "integrity": "sha512-dM+cv5ZL+BgIQzEIvMg9AxZ98n5lkKLgtp5zJLXWSrbCllbnUSqxYMUiWI5c1a1uBDUtkbY9fcGKXFLf+d+gyg==",
+      "version": "0.142.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.0-linux-arm64.tgz",
+      "integrity": "sha512-gX9hCK59bE0Itnous1MCrKiXTYuoGVE6oJUE0kyRSzaBD267sh9TNR3DXKbY7TsP7iAs19n8YXDJNdHZJtakSQ==",
       "cpu": [
         "arm64"
       ],
@@ -2267,9 +2279,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.135.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-linux-x64.tgz",
-      "integrity": "sha512-5EosY67yU28UJSnl/obdN2F1CDaimYbzm9SLR8dwwzkeBBnY6dHgAKJ2GTu9Nc8CmgmtVFBGzgPqehsIcueVvA==",
+      "version": "0.142.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.0-linux-x64.tgz",
+      "integrity": "sha512-nywS+ogFPRhZnQnKL+jzWKzFhmjTQbYPh6n8dtQ/E+sJ3FoZVcb9a6kvHL5yjgtlCiDkP0jPDYY5AK3tDShYyw==",
       "cpu": [
         "x64"
       ],
@@ -2285,9 +2297,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.135.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-win32-arm64.tgz",
-      "integrity": "sha512-SAeR+CUv7KWwE6eTc2UFaFjo6FpHywYfDFKrK6FqLms1rq1NPju2SoX7rhM6UEew/lUx2mdZv/LDs11s/N/Qgg==",
+      "version": "0.142.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.0-win32-arm64.tgz",
+      "integrity": "sha512-Lz8xEn7uNn0XTi8k0jApKM5P9BD7QvAH3ZbtlGi1zfSOgh1kmgpfXxaTlJF503mozdHaA2r6UA7hfTi+bI0CvQ==",
       "cpu": [
         "arm64"
       ],
@@ -2303,9 +2315,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.135.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-win32-x64.tgz",
-      "integrity": "sha512-uYwUBMbOfmVlCESJZmZsOG+cYwNFYvkMbQ+FB6C1u9RYz0m3mZeYNN0j+l1hRSyUgPMFJHzNpgNx1Usal5QZFQ==",
+      "version": "0.142.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.0-win32-x64.tgz",
+      "integrity": "sha512-LkARkXh3NM0XA8R8hFAgjx017fadfb9RgmqLzdhO1Qt/bDVSJnmDf4cwJ2h+FWZcm9/rRk3JC/IuqBvwg/TN+Q==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -161,8 +161,8 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.169",
-    "@openai/codex": "0.135.0",
+    "@anthropic-ai/claude-agent-sdk": "0.3.187",
+    "@openai/codex": "0.142.0",
     "@playwright/cli": "^0.1.9",
     "@playwright/test": "^1.56.1",
     "@stylistic/eslint-plugin-ts": "^2.8.0",

--- a/src/vs/platform/agentHost/node/claude/claudeReplayMapper.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeReplayMapper.ts
@@ -112,7 +112,7 @@ interface AssistantBlock { readonly type: string; readonly text?: string; readon
 type ParsedSessionMessage =
 	| { readonly kind: 'user-text'; readonly uuid: string; readonly text: string }
 	| { readonly kind: 'user-tool-results'; readonly uuid: string; readonly results: readonly UserToolResultBlock[] }
-	| { readonly kind: 'assistant'; readonly uuid: string; readonly blocks: readonly AssistantBlock[] }
+	| { readonly kind: 'assistant'; readonly uuid: string; readonly blocks: readonly AssistantBlock[]; readonly isInner: boolean }
 	| { readonly kind: 'system-notification'; readonly uuid: string; readonly subtype: string; readonly text: string };
 
 function parseSessionMessage(msg: SessionMessage): ParsedSessionMessage | undefined {
@@ -150,7 +150,11 @@ function parseAssistantMessage(msg: SessionMessage): ParsedSessionMessage | unde
 	if (blocks === undefined || blocks.length === 0) {
 		return undefined;
 	}
-	return { kind: 'assistant', uuid: msg.uuid, blocks };
+	// Subagent transcripts (from `getSubagentMessages`) carry a
+	// `parent_tool_use_id` on every envelope and have no synthetic spawning
+	// user prompt, so they legitimately open with an assistant message —
+	// `isInner` lets the builder synthesize a turn instead of dropping it.
+	return { kind: 'assistant', uuid: msg.uuid, blocks, isInner: msg.parent_tool_use_id !== null };
 }
 
 function parseSystemMessage(msg: SessionMessage): ParsedSessionMessage | undefined {
@@ -267,9 +271,25 @@ class ReplayBuilder {
 
 	private _consumeAssistant(msg: ParsedSessionMessage & { kind: 'assistant' }): void {
 		if (this._active === undefined) {
-			// Assistant message without a preceding user message — defensive: synthesize an empty user turn keyed on the assistant's parent uuid would be wrong; just drop with a warn.
-			this._logService.warn(`[claudeReplayMapper] assistant envelope ${msg.uuid} arrived before any user message; dropping`);
-			return;
+			if (!msg.isInner) {
+				// Top-level assistant envelope without a preceding user message —
+				// anomalous; synthesizing an empty user turn would be wrong, so
+				// drop with a warn.
+				this._logService.warn(`[claudeReplayMapper] assistant envelope ${msg.uuid} arrived before any user message; dropping`);
+				return;
+			}
+			// Subagent transcript: every envelope carries `parent_tool_use_id`
+			// and the SDK omits the synthetic spawning prompt, so the transcript
+			// legitimately opens with an assistant message. Synthesize an
+			// empty-prompt turn to hold the subagent's reply instead of dropping
+			// it (which would lose the entire subagent transcript on replay).
+			this._active = {
+				id: msg.uuid,
+				userText: '',
+				responseParts: [],
+				pendingToolUseIds: new Set(),
+				toolCallParts: new Map(),
+			};
 		}
 		let textPartCounter = 0;
 		let reasoningPartCounter = 0;

--- a/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
@@ -480,6 +480,7 @@ class RoundTripQuery implements AsyncGenerator<SDKMessage, void> {
 	async interrupt(): Promise<void> { /* not used */ }
 
 	setPermissionMode(): never { throw new Error('not modeled'); }
+	setMcpPermissionModeOverride(): never { throw new Error('not modeled'); }
 	setModel(): never { throw new Error('not modeled'); }
 	setMaxThinkingTokens(): never { throw new Error('not modeled'); }
 	applyFlagSettings(): never { throw new Error('not modeled'); }

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -490,6 +490,7 @@ class FakeQuery implements AsyncGenerator<SDKMessage, void> {
 		this.recordedPermissionModes.push(mode);
 	}
 	async setModel(model?: string): Promise<void> { this.recordedModels.push(model); }
+	setMcpPermissionModeOverride(): never { throw new Error('FakeQuery: setMcpPermissionModeOverride not modeled'); }
 	setMaxThinkingTokens(): never { throw new Error('FakeQuery: setMaxThinkingTokens not modeled'); }
 	async applyFlagSettings(s: Settings): Promise<void> { this.recordedFlagSettings.push(s); }
 	initializationResult(): never { throw new Error('FakeQuery: initializationResult not modeled'); }

--- a/src/vs/platform/agentHost/test/node/claudeReplayMapper.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeReplayMapper.test.ts
@@ -267,6 +267,63 @@ suite('claudeReplayMapper', () => {
 		assert.strictEqual(turns[1].id, 'u2');
 		assert.strictEqual(turns[1].message.text, 'how about now');
 	});
+
+	test('Fixture 10: prompt-less subagent transcript (inner messages) maps to one turn', () => {
+		// A subagent transcript from `getSubagentMessages` carries a
+		// `parent_tool_use_id` on every envelope and has NO synthetic spawning
+		// user prompt, so it opens directly with an assistant message. The
+		// builder must synthesize an empty-prompt turn rather than dropping the
+		// inner assistant content (which would lose the whole transcript on
+		// replay). Shape mirrors a real captured subagent transcript.
+		const parent = 'toolu_parent';
+		const messages: SessionMessage[] = [
+			{
+				type: 'assistant', uuid: 'sa1', session_id: 'sess-1', parent_tool_use_id: parent,
+				message: { id: 'msg_sa1', role: 'assistant', content: [{ type: 'thinking', thinking: 'planning', signature: 'sig' }] },
+			},
+			{
+				type: 'assistant', uuid: 'sa2', session_id: 'sess-1', parent_tool_use_id: parent,
+				message: { id: 'msg_sa2', role: 'assistant', content: [{ type: 'tool_use', id: 'tu_inner', name: 'Bash', input: { command: 'ls' } }] },
+			},
+			{
+				type: 'user', uuid: 'sa3', session_id: 'sess-1', parent_tool_use_id: parent,
+				message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tu_inner', content: 'file-a.txt\nfile-b.txt' }] },
+			},
+			{
+				type: 'assistant', uuid: 'sa4', session_id: 'sess-1', parent_tool_use_id: parent,
+				message: { id: 'msg_sa4', role: 'assistant', content: [{ type: 'text', text: 'Done. SUBAGENT_ONLY_MARKER_xyz' }] },
+			},
+		];
+
+		const turns = mapSessionMessagesToTurns(messages, session, logService);
+
+		assert.strictEqual(turns.length, 1, 'inner assistant messages must form a single synthesized turn');
+		assert.strictEqual(turns[0].id, 'sa1', 'turn id anchors on the first inner assistant envelope');
+		assert.strictEqual(turns[0].message.text, '', 'subagent turn has no user prompt');
+		assert.strictEqual(turns[0].state, TurnState.Complete, 'tool_result drains the pending tool_use');
+		const markdown = turns[0].responseParts.filter(p => p.kind === ResponsePartKind.Markdown);
+		assert.ok(markdown.some(p => p.kind === ResponsePartKind.Markdown && p.content.includes('SUBAGENT_ONLY_MARKER_xyz')),
+			'the subagent final text (with marker) must survive replay');
+		const toolCall = turns[0].responseParts.find(p => p.kind === ResponsePartKind.ToolCall);
+		assert.ok(toolCall && toolCall.kind === ResponsePartKind.ToolCall && toolCall.toolCall.status === ToolCallStatus.Completed,
+			'inner Bash tool call must be reconstructed as Completed');
+	});
+
+	test('Fixture 10b: top-level assistant before any user message is still dropped', () => {
+		// Guard the narrow behavior: a top-level (non-inner) assistant envelope
+		// arriving before any user message remains anomalous and is dropped, so
+		// the synthesize-on-open path is scoped strictly to subagent transcripts.
+		const messages: SessionMessage[] = [
+			makeAssistantText('a1', 'orphan reply'),
+			makeUser('u1', 'hello'),
+			makeAssistantText('a2', 'world'),
+		];
+
+		const turns = mapSessionMessagesToTurns(messages, session, logService);
+
+		assert.strictEqual(turns.length, 1, 'the orphan top-level assistant must NOT synthesize a turn');
+		assert.strictEqual(turns[0].id, 'u1');
+	});
 });
 
 suite('resolveForkAnchorUuid', () => {

--- a/src/vs/platform/agentHost/test/node/claudeSdkPipeline.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeSdkPipeline.test.ts
@@ -58,6 +58,7 @@ class ImmediatelyDoneQuery implements Query {
 	async setModel(): Promise<void> { /* not exercised here */ }
 	async applyFlagSettings(_settings: Parameters<Query['applyFlagSettings']>[0]): Promise<void> { /* not exercised here */ }
 	async setPermissionMode(): Promise<void> { /* not exercised here */ }
+	async setMcpPermissionModeOverride(): Promise<{ warning?: string }> { return {}; }
 	async interrupt(): Promise<void> { /* not exercised here */ }
 	streamInput(): never { throw new Error('not modeled'); }
 	stopTask(): never { throw new Error('not modeled'); }

--- a/src/vs/platform/agentHost/test/node/protocol/testHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/testHelpers.ts
@@ -12,6 +12,7 @@ import { ActionType, type ActionEnvelope } from '../../../common/state/sessionAc
 import type { SessionAddedParams } from '../../../common/state/protocol/notifications.js';
 import { MessageKind, buildDefaultChatUri, mergeSessionWithDefaultChat, type ChatState, type ISessionWithDefaultChat, type SessionState } from '../../../common/state/sessionState.js';
 import { PROTOCOL_VERSION } from '../../../common/state/protocol/version/registry.js';
+import { AgentHostCodexAgentEnabledEnvVar } from '../../../common/agentService.js';
 import {
 	isJsonRpcNotification,
 	isJsonRpcResponse,
@@ -251,6 +252,11 @@ export async function startRealServer(options?: { readonly claudeSdkRoot?: strin
 		}
 		const child = fork(serverPath, args, {
 			stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
+			// Codex defaults to disabled; opt it in for the real-SDK suite when a
+			// codex SDK root is supplied so the provider actually registers.
+			env: options?.codexSdkRoot
+				? { ...process.env, [AgentHostCodexAgentEnabledEnvVar]: 'true' }
+				: process.env,
 		});
 
 		const timer = setTimeout(() => {


### PR DESCRIPTION
Three related changes to the agent host, grouped because the SDK bump and the replay fix were validated together.

## 1. Replay mapper: reconstruct prompt-less subagent transcripts (the bug)

`ReplayBuilder` in `claudeReplayMapper.ts` only opens a turn on a `user-text` message and drops any assistant message that arrives with no active turn. A subagent transcript returned by `getSubagentMessages` carries a `parent_tool_use_id` on every envelope and has **no synthetic spawning prompt**, so it opens directly with an assistant message. As a result every inner assistant message — including the subagent's final reply — was dropped and the subagent transcript reconstructed as **zero turns** on reopen (the `getSubagentMessages` call returned the real messages, but `mapSessionMessagesToTurns` produced 0 turns).

**Fix:** thread an `isInner` flag (set when `parent_tool_use_id !== null`) through the parsed assistant message. When there is no active turn:
- **inner (subagent) message** → synthesize an empty-prompt turn to hold the reply, then process its blocks normally;
- **top-level message** → keep the existing drop-with-warn (genuinely anomalous).

Scoped strictly to subagent transcripts; top-level replay is unchanged. Adds unit fixtures for the prompt-less subagent shape (*Fixture 10*) and the unchanged top-level drop (*Fixture 10b*).

## 2. Bump Claude (0.3.187) and Codex (0.142.0) SDKs

Updates `@anthropic-ai/claude-agent-sdk` → `0.3.187` and `@openai/codex` → `0.142.0` (root `package.json` + lockfile and both `build/agent-sdk` tarball pins). The new Claude SDK adds `setMcpPermissionModeOverride` to the `Query` interface, so the `Query` test doubles are updated to satisfy it: `ImmediatelyDoneQuery` (and the `RecordingQuery` that extends it), `FakeQuery`, and `RoundTripQuery`.

## 3. Enable the Codex provider in the real-SDK test server

`startRealServer` forwarded `--codex-sdk-root` but never set the Codex enable flag, and the Codex agent defaults to disabled — so the provider never registered and every Codex real-SDK test failed with `No agent provider registered for: codex`. The fork now sets `VSCODE_AGENT_HOST_CODEX_AGENT_ENABLED` when a codex SDK root is supplied.

## Testing

Validated against current `main`:

- **Unit** (`claudeReplayMapper`): 12 passing, incl. Fixtures 10 / 10b.
- **Real-SDK integration** (`AGENT_HOST_REAL_SDK=1` / `AGENT_HOST_REAL_CODEX=1`):
  - **Claude** `reopening a session keeps sub-agent messages out of the parent transcript (replay path)` — passes (previously reconstructed the subagent transcript empty).
  - **Copilot** same shared replay test — passes.
  - **Codex** full suite — 13 passing (provider now registers).
- Verified live in the authenticated Agents window: reopening a persisted subagent session reconstructs the nested subagent transcript, and the parent transcript does not leak the subagent's content.

## Note

The real-SDK replay test harness itself was repaired separately on `main` in #322837 (chat-channel filter + complete approval action), which is what surfaced the product bug fixed here.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>