### PR TITLE
fix: Add selection to next Find match does not work with Regex Find Mode

### DIFF
--- a/src/vs/editor/contrib/multicursor/browser/multicursor.ts
+++ b/src/vs/editor/contrib/multicursor/browser/multicursor.ts
@@ -286,7 +286,7 @@ export class MultiCursorSession {
 		//  - and the search string is non-empty
 		if (!editor.hasTextFocus() && findState.isRevealed && findState.searchString.length > 0) {
 			// Find widget owns what is searched for
-			return new MultiCursorSession(editor, findController, false, findState.searchString, findState.wholeWord, findState.matchCase, null);
+			return new MultiCursorSession(editor, findController, false, findState.searchString, findState.wholeWord, findState.matchCase, findState.isRegex, null);
 		}
 
 		// Otherwise, the selection gives the search text, and the find widget gives the search settings
@@ -322,7 +322,7 @@ export class MultiCursorSession {
 			searchText = editor.getModel().getValueInRange(s).replace(/\r\n/g, '\n');
 		}
 
-		return new MultiCursorSession(editor, findController, isDisconnectedFromFindController, searchText, wholeWord, matchCase, currentMatch);
+		return new MultiCursorSession(editor, findController, isDisconnectedFromFindController, searchText, wholeWord, matchCase, false, currentMatch);
 	}
 
 	constructor(
@@ -332,6 +332,7 @@ export class MultiCursorSession {
 		public readonly searchText: string,
 		public readonly wholeWord: boolean,
 		public readonly matchCase: boolean,
+		public readonly isRegex: boolean,
 		public currentMatch: Selection | null
 	) { }
 
@@ -378,7 +379,7 @@ export class MultiCursorSession {
 
 		const allSelections = this._editor.getSelections();
 		const lastAddedSelection = allSelections[allSelections.length - 1];
-		const nextMatch = this._editor.getModel().findNextMatch(this.searchText, lastAddedSelection.getEndPosition(), false, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false);
+		const nextMatch = this._editor.getModel().findNextMatch(this.searchText, lastAddedSelection.getEndPosition(), this.isRegex, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false);
 
 		if (!nextMatch) {
 			return null;
@@ -429,7 +430,7 @@ export class MultiCursorSession {
 
 		const allSelections = this._editor.getSelections();
 		const lastAddedSelection = allSelections[allSelections.length - 1];
-		const previousMatch = this._editor.getModel().findPreviousMatch(this.searchText, lastAddedSelection.getStartPosition(), false, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false);
+		const previousMatch = this._editor.getModel().findPreviousMatch(this.searchText, lastAddedSelection.getStartPosition(), this.isRegex, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false);
 
 		if (!previousMatch) {
 			return null;
@@ -446,9 +447,9 @@ export class MultiCursorSession {
 
 		const editorModel = this._editor.getModel();
 		if (searchScope) {
-			return editorModel.findMatches(this.searchText, searchScope, false, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false, Constants.MAX_SAFE_SMALL_INTEGER);
+			return editorModel.findMatches(this.searchText, searchScope, this.isRegex, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false, Constants.MAX_SAFE_SMALL_INTEGER);
 		}
-		return editorModel.findMatches(this.searchText, true, false, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false, Constants.MAX_SAFE_SMALL_INTEGER);
+		return editorModel.findMatches(this.searchText, true, this.isRegex, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false, Constants.MAX_SAFE_SMALL_INTEGER);
 	}
 }
 

--- a/src/vs/editor/contrib/multicursor/test/browser/multicursor.test.ts
+++ b/src/vs/editor/contrib/multicursor/test/browser/multicursor.test.ts
@@ -265,8 +265,8 @@ suite('Multicursor selection', () => {
 		});
 	});
 
-	function testMulticursor(text: string[], callback: (editor: ITestCodeEditor, findController: CommonFindController) => void): void {
-		withTestCodeEditor(text, { serviceCollection: serviceCollection }, (editor) => {
+	function testMulticursor(text: string[], callback: (editor: ITestCodeEditor, findController: CommonFindController) => void, options?: { hasTextFocus?: boolean }): void {
+		withTestCodeEditor(text, { serviceCollection: serviceCollection, hasTextFocus: options?.hasTextFocus }, (editor) => {
 			const findController = editor.registerAndInstantiateContribution(CommonFindController.ID, CommonFindController);
 			const multiCursorSelectController = editor.registerAndInstantiateContribution(MultiCursorSelectionController.ID, MultiCursorSelectionController);
 
@@ -277,12 +277,59 @@ suite('Multicursor selection', () => {
 		});
 	}
 
-	function testAddSelectionToNextFindMatchAction(text: string[], callback: (editor: ITestCodeEditor, action: AddSelectionToNextFindMatchAction, findController: CommonFindController) => void): void {
+	function testAddSelectionToNextFindMatchAction(text: string[], callback: (editor: ITestCodeEditor, action: AddSelectionToNextFindMatchAction, findController: CommonFindController) => void, options?: { hasTextFocus?: boolean }): void {
 		testMulticursor(text, (editor, findController) => {
 			const action = new AddSelectionToNextFindMatchAction();
 			callback(editor, action, findController);
-		});
+		}, options);
 	}
+
+	test('AddSelectionToNextFindMatchAction works with regex find mode (#107090)', () => {
+		const text = [
+			'abc pizza',
+			'abc house',
+			'abc bar'
+		];
+		// Run with focus outside the editor (i.e. in the find widget). The find
+		// widget only owns the search - and so only applies its regex option - on
+		// that path. With editor focus the session would expand the cursor's word
+		// and search literally, so the regex option would never be exercised and
+		// this test would pass even with the bug present.
+		testAddSelectionToNextFindMatchAction(text, (editor, action, findController) => {
+			editor.setSelection(new Selection(1, 1, 1, 1));
+			// 'a.c' as a regex matches 'abc' on every line. As a literal string it
+			// matches nothing, so if isRegex is not forwarded no match is found and
+			// the selections never expand.
+			findController.getState().change({ searchString: 'a.c', isRegex: true, isRevealed: true }, false);
+
+			action.run(null!, editor);
+			assert.deepStrictEqual(editor.getSelections(), [
+				new Selection(1, 1, 1, 4),
+			]);
+
+			action.run(null!, editor);
+			assert.deepStrictEqual(editor.getSelections(), [
+				new Selection(1, 1, 1, 4),
+				new Selection(2, 1, 2, 4),
+			]);
+
+			action.run(null!, editor);
+			assert.deepStrictEqual(editor.getSelections(), [
+				new Selection(1, 1, 1, 4),
+				new Selection(2, 1, 2, 4),
+				new Selection(3, 1, 3, 4),
+			]);
+
+			// All matches are now selected; running again wraps around and adds no
+			// new selection.
+			action.run(null!, editor);
+			assert.deepStrictEqual(editor.getSelections(), [
+				new Selection(1, 1, 1, 4),
+				new Selection(2, 1, 2, 4),
+				new Selection(3, 1, 3, 4),
+			]);
+		}, { hasTextFocus: false });
+	});
 
 	test('AddSelectionToNextFindMatchAction starting with single collapsed selection', () => {
 		const text = [


### PR DESCRIPTION
## Summary

The "Add Selection to Next Find Match" (Ctrl+D) feature is implemented by `MultiCursorSession` in `src/vs/editor/contrib/multicursor/browser/multicursor.ts`. When the find widget owns the search (focus is in the find widget, the widget is revealed, and the search string is non-empty), the session uses the find...


## Root cause

The "Add Selection to Next Find Match" (Ctrl+D) feature is implemented by
`MultiCursorSession` in `src/vs/editor/contrib/multicursor/browser/multicursor.ts`.

When the find widget owns the search (focus is in the find widget, the widget is
revealed, and the search string is non-empty), the session uses the find widget's
search string and its `wholeWord` / `matchCase` options. However, the model lookups
in `_getNextMatch`, `_getPreviousMatch`, and `selectAll` all passed the `isRegex`
argument to `findNextMatch` / `findPreviousMatch` / `findMatches` as a hardcoded
`false`. As a result, a regex pattern coming from the find widget was always treated
as literal text, so no further matches were found and no cursor was added.


## What changed

File: `src/vs/editor/contrib/multicursor/browser/multicursor.ts`

- Added an `isRegex` field to `MultiCursorSession` (constructor parameter).
- In `MultiCursorSession.create`, pass `findState.isRegex` when the find widget owns
 the search, and `false` for the selection-owned case (the search text there is the
 literal selected text, so regex must stay off, which also matches the existing
 `isRegexOverride: FindOptionOverride.False` behavior for the disconnected case).
- Replaced the hardcoded `false` isRegex argument with `this.isRegex` in the
 `findNextMatch`, `findPreviousMatch`, and the two `findMatches` calls.

File: `src/vs/editor/contrib/multicursor/test/browser/multicursor.test.ts`

- Added a regression test "AddSelectionToNextFindMatchAction works with regex find
 mode (#107090)" that turns on regex mode in the find controller with pattern `a.c`
 and verifies that each `Ctrl+D` adds the next regex match as a new selection.


## Issue

Fixes #107090

Issue: https://github.com/microsoft/vscode/issues/107090


## Diffstat

```
.../contrib/multicursor/browser/multicursor.ts | 13 +++++-----
 .../multicursor/test/browser/multicursor.test.ts | 30 ++++++++++++++++++++++
 2 files changed, 37 insertions(+), 6 deletions(-)
```


## Testing


- Ran the relevant tests and linter for the changed files while developing.

- Kept the change minimal and focused on this one issue.


## AI assistance


I used GitHub Copilot to help write parts of this change. I've reviewed and tested it myself, I understand what it does, and I'll follow up on any review feedback.