### PR TITLE
build: keep Linux smoke test data off the small OS root disk

### DIFF
--- a/build/azure-pipelines/linux/steps/product-build-linux-test.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-test.yml
@@ -110,10 +110,11 @@ steps:
 
   - script: |
       set -e
+      df -h
       ps -ef
       cat /proc/sys/fs/inotify/max_user_watches
       lsof | wc -l
-    displayName: Diagnostics before smoke test run (processes, max_user_watches, number of opened file handles)
+    displayName: Diagnostics before smoke test run (disk space, processes, max_user_watches, number of opened file handles)
     continueOnError: true
     condition: succeededOrFailed()
 
@@ -121,6 +122,12 @@ steps:
     - script: |
         set -e
         npm run smoketest-no-compile -- --tracing --build "$(agent.builddirectory)/VSCode-linux-$(VSCODE_ARCH)"
+      env:
+        # Keep the smoke test data dir (user-data, extensions, workspace and the
+        # Copilot CLI session state under `os.tmpdir()`) on the large work volume
+        # instead of the small OS root disk (`/tmp`), which has filled up and
+        # crashed the agent worker with "No space left on device".
+        TMPDIR: $(Agent.TempDirectory)
       timeoutInMinutes: 20
       displayName: 🧪 Run smoke tests (Electron)
 
@@ -128,6 +135,7 @@ steps:
     - script: npm run smoketest-no-compile -- --web --tracing --headless
       env:
         VSCODE_REMOTE_SERVER_PATH: $(agent.builddirectory)/vscode-server-linux-$(VSCODE_ARCH)-web
+        TMPDIR: $(Agent.TempDirectory)
       timeoutInMinutes: 20
       displayName: 🧪 Run smoke tests (Browser, Chromium)
 
@@ -137,15 +145,19 @@ steps:
         APP_PATH=$(agent.builddirectory)/VSCode-linux-$(VSCODE_ARCH)
         VSCODE_REMOTE_SERVER_PATH="$(agent.builddirectory)/vscode-server-linux-$(VSCODE_ARCH)" \
         npm run smoketest-no-compile -- --tracing --remote --build "$APP_PATH"
+      env:
+        TMPDIR: $(Agent.TempDirectory)
       timeoutInMinutes: 20
       displayName: 🧪 Run smoke tests (Remote)
 
   - script: |
       set -e
+      df -h
+      du -sh "$(Agent.TempDirectory)"/vscsmoke-* /tmp/vscsmoke-* 2>/dev/null || true
       ps -ef
       cat /proc/sys/fs/inotify/max_user_watches
       lsof | wc -l
-    displayName: Diagnostics after smoke test run (processes, max_user_watches, number of opened file handles)
+    displayName: Diagnostics after smoke test run (disk space, processes, max_user_watches, number of opened file handles)
     continueOnError: true
     condition: succeededOrFailed()
 


### PR DESCRIPTION
## Problem

The **Linux (X64)** smoke test steps intermittently exhaust the agent's **OS root disk**. When `/` fills, the Azure agent **worker** itself crashes while writing its own diagnostic log:

```
##[error]Unhandled exception. System.IO.IOException: No space left on device : '/usr/local/vss-agent/4.274.1/_diag/Worker_*.log'
```

Because the worker dies mid-step (not the test), the job can't cancel cleanly and **hangs until timeout** — i.e. the step appears to "run forever", while the other OS legs are fine. Example: [run 20260625.13 (insider)](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=450828&view=logs&j=dcea01d9-8513-5a47-c936-5baceabd8c97), step "🧪 Run smoke tests (Electron)". This is the same recurring "Linux out of space" class of failure seen previously on the `1es-ubuntu-22.04-x64` pool.

## Root cause

Smoke **logs** and **crashes** already live under `.build/` on the large work volume (`/mnt/...`), so they're fine. But the smoke **data dir** is rooted at `os.tmpdir()`:

```ts
// test/smoke/src/main.ts
const testDataPath = path.join(os.tmpdir(), `vscsmoke-${getTestTypeSuffix()}`);
```

On the Linux agents `os.tmpdir()` resolves to `/tmp` on the **small OS root disk**, and `testDataPath` holds the user-data dir, extensions dir, workspace, the copied stable build, and — newly significant — the **Copilot CLI / agent-host session state** (`XDG_STATE_HOME` is pinned under the per-run `userDataDir`). The chat-session smoke tests spawn real Copilot CLI / Claude / Codex SDK processes, so this directory can grow large during the run and tip the small disk over.

## Fix (mitigation)

- Point `TMPDIR` at `$(Agent.TempDirectory)` (on the large work volume) for the **Electron**, **Browser** and **Remote** smoke steps, so `os.tmpdir()`/`testDataPath` no longer lands on `/`. Node's `os.tmpdir()` honours `$TMPDIR`, and the smoke harness's own setup/teardown rimraf of `testDataPath` continues to work unchanged.
- Add `df -h` to the **before/after** diagnostics steps and dump the smoke data dir sizes afterwards, so the next occurrence of disk pressure is immediately visible (which mount, which dir).

This is a mitigation that lives in this repo and unblocks CI now. The **proper fix is infrastructure**: increase the OS-disk size / SKU of the `1es-ubuntu-22.04-x64` 1ES hosted pool — that has to be requested from the pool owner / 1ES team and is tracked separately.

## Notes / validation
- YAML validated locally (`js-yaml` load OK); passes repo hygiene precommit.
- Assumption: `$(Agent.TempDirectory)` is on the same large volume as `_work` (`/mnt/...`) on these agents — the new `df -h` output will confirm this in the first run.
