### PR TITLE
editor: show editor layout actions in single tab mode

### DIFF
--- a/src/vs/workbench/browser/parts/editor/singleEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/singleEditorTabsControl.ts
@@ -359,11 +359,12 @@ export class SingleEditorTabsControl extends EditorTabsControl {
 		}
 	}
 
-	protected override prepareEditorLayoutActions(): IToolbarActions {
-		return {
-			primary: [],
-			secondary: []
-		};
+	protected override prepareEditorLayoutActions(editorActions: IToolbarActions): IToolbarActions {
+		// Surface the editor layout actions (`MenuId.EditorTitleLayout`) even when tabs are
+		// shown as a single tab. This menu is only populated by the Agents window (e.g. the
+		// Maximize/Restore Editor Area actions), so showing it here has no effect on the
+		// regular workbench where the menu is empty.
+		return editorActions;
 	}
 
 	getHeight(): number {


### PR DESCRIPTION
## What

`SingleEditorTabsControl.prepareEditorLayoutActions` now returns the resolved editor layout actions instead of an empty set.

## Why

The Agents (sessions) window contributes its editor-area layout controls — **Maximize Editor Area**, **Restore Editor Area**, **Close Editor Area**, **Open in Modal Editor**, and the secondary side bar toggle — to the `MenuId.EditorTitleLayout` menu.

That menu is rendered by the editor tabs control. When `workbench.editor.showTabs` is set to `single`, the active control is `SingleEditorTabsControl`, which overrode `prepareEditorLayoutActions()` to always return empty actions. As a result, the Maximize Editor option (and the rest of the layout group) disappeared in single-tab mode.

## Notes for reviewers

This has **no visible effect on the regular VS Code editor window**:

- `MenuId.EditorTitleLayout` is only populated by the Agents window (`src/vs/sessions/`); there are no core or extension contributions to it.
- Extensions cannot target it — the extension menu contribution points expose only `editor/title`, the modal editor title, and `editor/title/run`.
- When the menu is empty, the layout toolbar renders nothing and its separator is explicitly hidden.

So in the standard workbench this is effectively a no-op, while the Agents window now shows the Maximize/Restore/Close/Modal layout actions even with `showTabs: single`.
