### PR TITLE
ci: drop external DTD from minimal fontconfig to avoid expat NULL-deref crash

### DIFF
--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -144,15 +144,24 @@ jobs:
             exit 0
           fi
           echo "Installed expat: $EXPAT_VER — applying fontconfig workaround"
-          # Workaround: use a minimal fontconfig config with no <include> directives,
-          # avoiding the external entity parser codepath entirely. Based on upstream
-          # fontconfig 2.15.0 fonts.conf.in with <include> removed, generic family
-          # aliases inlined, and default font mappings for generic families added
-          # (from conf.d/49-sansserif.conf and DejaVu font configs).
-          # Remove once Ubuntu backports the remaining CVE fixes.
+          # Workaround: use a minimal fontconfig config with no <include> directives
+          # AND no <!DOCTYPE ... SYSTEM ...> external DTD reference, avoiding every
+          # expat external-entity codepath. Based on upstream fontconfig 2.15.0
+          # fonts.conf.in with <include> removed, generic family aliases inlined, and
+          # default font mappings for generic families added (from conf.d/49-sansserif.conf
+          # and DejaVu font configs).
+          #
+          # The DOCTYPE line is intentionally omitted: fontconfig feeds the referenced
+          # external DTD ("urn:fontconfig:fonts.dtd") to expat as an external PARAMETER
+          # entity, which still triggers the not-yet-backported NULL-deref CVEs
+          # (CVE-2026-32776 / CVE-2026-32778) on expat 2.6.1 even when <include> is gone.
+          # This was observed as a SIGSEGV inside libexpat (called from libfontconfig)
+          # during Chromium browser-process font init, crashing Electron at startup.
+          # fontconfig does not require the DOCTYPE, so dropping it removes the last
+          # external-entity path. Remove the whole workaround once Ubuntu backports the
+          # remaining CVE fixes (expat >= 2.7.5).
           cat > /tmp/fonts-minimal.conf << 'FONTCONFIG_EOF'
           <?xml version="1.0"?>
-          <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
           <fontconfig>
             <dir>/usr/share/fonts</dir>
             <dir>/usr/local/share/fonts</dir>


### PR DESCRIPTION
## What

Removes the external DTD declaration from the minimal fontconfig config that the Linux smoke-test job installs as a workaround for the expat 2.6.1 NULL-deref CVEs.

```diff
  <?xml version="1.0"?>
- <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
  <fontconfig>
```

## Why

The job already sets `FONTCONFIG_FILE=/tmp/fonts-minimal.conf` with `<include>` removed to avoid the expat external-entity crash path. But a flaky smoke-test failure ([run 28140700565](https://github.com/microsoft/vscode/actions/runs/28140700565/job/83337233535), `Linux / Electron-Smoke`) still crashed with that workaround active.

I pulled the crash-dump artifact and walked the minidump. The faulting thread was a **SIGSEGV (NULL deref, fault address 0x0)** with this native stack:

```
libc.so.6
libfontconfig.so.1   (config parsing)
libexpat.so.1        (XML / external-entity parsing)
...Chromium browser-process font-init frames...
```

i.e. the crash is in **libexpat called from libfontconfig during Chromium's browser-process font initialization at startup** — not in VS Code/Chromium logic. The dump confirms `FONTCONFIG_FILE=/tmp/fonts-minimal.conf` was in effect and the minimal config was loaded.

The remaining trigger is the `<!DOCTYPE … SYSTEM "urn:fontconfig:fonts.dtd">` line: fontconfig feeds that DTD to expat as an external **parameter** entity, which still hits the not-yet-backported `CVE-2026-32776` / `CVE-2026-32778` NULL-deref paths on expat 2.6.1 even after `<include>` was removed. fontconfig does not require the DOCTYPE, so dropping it removes the last external-entity codepath.

## Validation

- Workflow YAML parses (PyYAML `safe_load`).
- The generated config (DOCTYPE removed) parses as valid XML; the diagnostics step's `ElementTree.parse` does not fetch external DTDs, so it is unaffected.

## Notes for reviewers

- This is a mitigation. The durable fix is shipping `libexpat >= 2.7.5` on the runner; the step already auto-disables the whole workaround when it detects that version.
- Companion harness PR #322905 makes such a launch crash fail fast with an actionable error instead of a 120s opaque Mocha `before all` hook timeout.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
