### PR TITLE
sessions: default to Changes after session creation

### DIFF
--- a/src/vs/sessions/LAYOUT_CONTROLLER.md
+++ b/src/vs/sessions/LAYOUT_CONTROLLER.md
@@ -37,8 +37,8 @@ resource (`URI`) and persisted to workspace storage:
 | Editor working set | `_workingSets` | open editors in the grid editor part |
 
 All state flows from the `activeSession` **observable** (never events). The controller derives
-`activeSessionResourceObs`, `activeSessionHasChangesObs`, `activeSessionIsUntitledObs`,
-`activeSessionHasWorkspaceObs`, and `multipleSessionsVisibleObs`, then reacts with `autorun`.
+`activeSessionResourceObs`, `activeSessionIsCreatedObs`, `activeSessionHasWorkspaceObs`, and
+`multipleSessionsVisibleObs`, then reacts with `autorun`.
 
 ---
 
@@ -76,17 +76,18 @@ Skipped entirely on mobile web (`isWeb && isMobile`) to avoid disruptive auto-ex
 
 ### 3.2 Switching to — restore
 
-`_syncAuxiliaryBarVisibility(resource, hasWorkspace, isUntitled, hasChanges)` applies state in
+`_syncAuxiliaryBarVisibility(resource, hasWorkspace, isCreated)` applies state in
 strict priority order:
 
 1. **No resource / no workspace** → do nothing.
-2. **Untitled session (new-session view)** → all untitled sessions share a single state object
+2. **Uncreated session (new-session view)** → all uncreated sessions share a single state object
    (`_newSessionViewState`, persisted to workspace storage under `sessions.newSessionViewState`): if
    the user explicitly hid the aux bar on a new session it stays hidden (across switches *and*
-   reloads); otherwise the default container (§3.2 step 4) is shown. This is the **only** place the
+   reloads); otherwise the default container (§3.2 step 4) is shown. This is the main place the
    side pane is opened automatically — a new session opens it by default so the user starts with
-   Files/Changes visible.
-3. **Titled session** (existing session): the side pane is **never auto-opened**.
+   Files visible.
+3. **Created session** (existing session): the side pane is **never auto-opened** except for the
+   same-session submit transition (§3.3).
    - saved state is **hidden** *or* there is **no saved state** → hide the aux bar and stop. A
      session with no explicit "visible" choice — including one that just converted from the
      new-session view to an existing session — stays closed until the user opens it.
@@ -94,28 +95,34 @@ strict priority order:
    - saved state is **visible** but its container is gone → fall back to the default container
      (§3.2 step 4).
 4. **Default container** (`_openDefaultAuxiliaryBarContainer`), used only when the side pane is being
-   shown (untitled default, or restoring a session the user explicitly left visible):
-   - session **has changes** → open the Changes view (`CHANGES_VIEW_ID`).
-   - otherwise → open the Files container.
+   shown (new-session default, or restoring a session the user explicitly left visible):
+   - session **is created** → open the Changes view (`CHANGES_VIEW_ID`).
+   - otherwise → open the Files container (falling back to Changes if Files is hidden).
 
-### 3.3 No auto-reveal on changes
+### 3.3 New-session submit
 
-The side pane is **not** revealed when a chat turn produces new file changes. The controller does not
-track pending turns; the only automatic opening is the new-session default (§3.2 step 2). Once a
-session is an existing session the side pane stays in whatever state the user left it — they must open
-it themselves to see changes.
+When the active new session becomes created (`isCreated` changes from false to true for the same
+session), the side pane stays in whatever visibility state the user left it. If it is visible, the
+controller switches it to Changes immediately. If it is hidden, the controller records Changes as that
+session's default active container so opening the side pane later shows Changes.
 
-### 3.4 Live visibility tracking
+### 3.4 No auto-reveal on changes
+
+The side pane is **not** revealed, and the active container is not changed, when a chat turn produces
+new file changes. The controller does not track pending turns or file-change counts for default
+selection; the automatic switch to Changes is driven by the created transition (§3.3). Once a session
+is created the side pane stays in whatever state the user left it.
+
+### 3.5 Live visibility tracking
 
 Aux-bar visibility is also tracked **live** (not only on session switch) via an
 `onDidChangePartVisibility` listener for `AUXILIARYBAR_PART` (skipped on mobile web and while
 multiple sessions are visible). For a titled active session it re-runs `_captureViewState`; for an
-untitled active session it updates the shared `_newSessionViewState` (§3.2 step
-2). Without this, the sync autorun — which re-evaluates whenever the session's changes/workspace
-state updates, not just on switch — would, for an untitled session, find no shared state and re-open
-the side pane the user had just hidden.
+uncreated active session it updates the shared `_newSessionViewState` (§3.2 step 2). When a created
+session with hidden saved state is opened, the saved/default active container is restored before the
+visible state is captured, so a hidden-on-submit session opens to Changes.
 
-### 3.5 Editor reveal on session switch
+### 3.6 Editor reveal on session switch
 
 The editor part is revealed programmatically when a session's editor working set is restored on a
 session **switch** (`_revealEditorPartForWorkingSet`, §5). It is **not** revealed on the initial
@@ -203,9 +210,10 @@ back to the default-visible logic (§3.2) on the next reload.)
 - **Observables, not events**, drive all session-switch logic.
 - **Multiple visible sessions** disable per-session view/panel sync and clear that state (working
   sets preserved).
-- **The side pane is never auto-opened for existing sessions** — it opens automatically only as the
-  new-session default (§3.2 step 2). An existing session with no explicit "visible" choice stays
-  closed until the user opens it.
+- **The side pane is never auto-opened for existing sessions on restore** — it opens automatically as
+  the new-session default (§3.2 step 2) and stays visible when an already-visible new session is
+  submitted (§3.3). A created session with no explicit "visible" choice stays closed until the user
+  opens it.
 - **The sessions sidebar is auto-managed on a small window (desktop, [D7])** — when the main container is
   1800px wide or narrower and both the editor and auxiliary bar are open, the sidebar is hidden; it is shown
   again once either closes or the window widens, unless the user closed it themselves. Suspended while

--- a/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.md
+++ b/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.md
@@ -36,21 +36,21 @@ When you focus a session, its side pane is restored from the state remembered ab
 The side pane is restored in this order:
 
 - **D3a — No session / no workspace** → nothing changes.
-- **D3b — A new (untitled) session** → all new sessions share one remembered side-pane state. If you
+- **D3b — A new (uncreated) session** → all new sessions share one remembered side-pane state. If you
   explicitly closed the side pane it stays closed (across switches *and* reloads); otherwise it opens
-  to the default view (D3d). This is the **only** time the side pane opens on its own.
-- **D3c — An existing session** → the side pane is **never** opened automatically. If it was closed or
-  has no remembered state it stays closed; if it was open and that view still exists it reopens; if
-  that view is gone it falls back to the default view (D3d).
-- **D3d — Default view** → Changes when the session has file changes, otherwise Files.
+  to the default view (D3d). This is the normal time the side pane opens on its own.
+- **D3c — An existing (created) session** → the side pane is **never** opened automatically on
+  restore. If it was closed or has no remembered state it stays closed; if it was open and that view
+  still exists it reopens; if that view is gone it falls back to the default view (D3d).
+- **D3d — Default view** → Files while the session is uncreated; Changes after the session is created.
 
 ### Scenario: special cases that override the remembered state
 A few transitions intentionally ignore the remembered state above.
 
 #### D4 — Submitting a new session
-When a new session becomes a real session while staying active, the side pane stays as you left it: if
-it was open it stays open and switches to **Changes** so new changes are visible as soon as they land;
-if it was closed it stays closed.
+When a new session becomes created (`isCreated` changes from false to true) while staying active, the
+side pane stays as you left it: if it was open it stays open and switches to **Changes**; if it was
+closed it stays closed, but opening it later shows **Changes**.
 
 #### D5 — Maximizing the editor
 While the editor area is maximized, the side pane always shows **Changes**, regardless of the session's
@@ -62,8 +62,9 @@ forced Changes view never shrinks the editor permanently.
 A running session can produce new file changes at any time.
 
 #### D6 — New changes never open the side pane
-When a chat turn produces new file changes for an existing session, the side pane is **not** opened
-automatically — it stays as you left it. Only a new session opens it (D3b).
+When a chat turn produces new file changes, the side pane is **not** opened automatically and the
+active view is not switched automatically — it stays as you left it. Only a new session opens it
+(D3b), and only the created transition switches it to Changes (D4).
 
 ### Scenario: a cramped (small) window
 On a small window there isn't room for the sessions sidebar, the editor, and the side pane all at once.
@@ -94,19 +95,22 @@ defaults **on** in non-stable builds (Insiders / exploration) and **off** in sta
   `_captureActiveSessionViewState`.
 - **Live tracking [D2]** — `onDidChangePartVisibility` listener for `AUXILIARYBAR_PART`, skipped while
   multiple sessions are visible or the editor is maximized; updates `_captureViewState` (titled) or
-  `_newSessionViewState` (untitled).
-- **Restore [D3]** — `_syncAuxiliaryBarVisibility(resource, hasWorkspace, isUntitled, hasChanges)`.
-  Untitled sessions (D3b) share `_newSessionViewState`, persisted under `sessions.newSessionViewState`.
-  `_openDefaultAuxiliaryBarContainer` / `_isAuxiliaryBarContainerPinned` implement D3c/D3d.
+  `_newSessionViewState` (uncreated). When a created session is revealed from hidden saved state, the
+  saved/default active container is restored before capture.
+- **Restore [D3]** — `_syncAuxiliaryBarVisibility(resource, hasWorkspace, isCreated)`.
+  Uncreated sessions (D3b) share `_newSessionViewState`, persisted under
+  `sessions.newSessionViewState`. `_openDefaultAuxiliaryBarContainer` /
+  `_isAuxiliaryBarContainerPinned` implement D3c/D3d.
 - **New-session submit [D4]** — `_onNewSessionSubmitted` keeps the aux bar as left, switches an open one
-  to Changes, and persists the resulting state so later syncs don't revert to the default.
+  to Changes, and records Changes as the active container even when hidden so opening the side pane
+  later starts on Changes.
 - **Editor maximized [D5]** — driven from the sync autorun via `editorMaximizedObs`
   (`IAgentWorkbenchLayoutService.isEditorMaximized()`); forced visibility is never captured (D2). The
   sessions workbench (`setEditorMaximized` in `browser/workbench.ts`) snapshots the editor part size +
   surrounding part visibility on maximize and restores them on un-maximize, so the editor returns to
   its previous width.
-- **No auto-reveal [D6]** — the sync logic never opens the side pane in response to changes for a titled
-  session; only D3b opens it.
+- **No auto-reveal [D6]** — the sync logic never opens the side pane or switches the active container
+  in response to file changes; only D3b opens it, and D4 switches it to Changes.
 - **Responsive sidebar [D7]** — `_registerResponsiveSidebar` derives `spaceConstrained = enabled && small
   && editor visible && aux-bar visible && !multipleSessionsVisible` from the experimental setting
   `sessions.layout.autoCollapseSessionsSidebar` (`observableConfigValue`, default `product.quality !==

--- a/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
@@ -12,7 +12,6 @@ import product from '../../../../platform/product/common/product.js';
 import { StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ViewContainerLocation } from '../../../../workbench/common/views.js';
 import { Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
-import { SessionStatus } from '../../../services/sessions/common/session.js';
 import { CHANGES_VIEW_CONTAINER_ID, CHANGES_VIEW_ID } from '../../changes/common/changes.js';
 import { SESSIONS_FILES_CONTAINER_ID } from '../../files/browser/files.contribution.js';
 import { BaseLayoutController } from './baseSessionLayoutController.js';
@@ -45,7 +44,7 @@ export const RESPONSIVE_SIDEBAR_SETTING = 'sessions.layout.autoCollapseSessionsS
  * {@link BaseLayoutController}, it manages the per-session auxiliary bar
  * visibility and active view container.
  *
- * Its behaviour is enumerated as rules **D1-D6** in
+ * Its behaviour is enumerated as rules **D1-D7** in
  * [desktopSessionLayoutController.md](./desktopSessionLayoutController.md).
  */
 export class LayoutController extends BaseLayoutController {
@@ -68,20 +67,9 @@ export class LayoutController extends BaseLayoutController {
 	protected override _registerViewStateManagement(): void {
 		this._loadNewSessionViewState();
 
-		const activeSessionHasChangesObs = derived<boolean>(reader => {
+		const activeSessionIsCreatedObs = derived<boolean>(reader => {
 			const activeSession = this._sessionsService.activeSession.read(reader);
-			if (!activeSession) {
-				return false;
-			}
-			const changes = activeSession.changes.read(reader);
-			return changes.length > 0;
-		});
-
-		const activeSessionIsUntitledObs = derived<boolean>(reader => {
-			const activeSession = this._sessionsService.activeSession.read(reader);
-			const activeSessionStatus = activeSession?.status.read(reader);
-
-			return activeSessionStatus === SessionStatus.Untitled;
+			return activeSession?.isCreated.read(reader) ?? false;
 		});
 
 		const activeSessionHasWorkspaceObs = derived<boolean>(reader => {
@@ -95,11 +83,11 @@ export class LayoutController extends BaseLayoutController {
 
 		// Switch between sessions — sync auxiliary bar
 		let previousSessionResource: URI | undefined;
-		let previousIsUntitled = false;
+		let previousIsCreated = false;
 		this._register(autorun(reader => {
 			const editorMaximized = editorMaximizedObs.read(reader);
 			const activeSessionResource = this.activeSessionResourceObs.read(reader);
-			const isUntitled = activeSessionIsUntitledObs.read(reader);
+			const isCreated = activeSessionIsCreatedObs.read(reader);
 
 			// [D5] While the editor area is maximized, always show the Changes view
 			// regardless of the session's saved/previous state. The forced visibility
@@ -107,18 +95,17 @@ export class LayoutController extends BaseLayoutController {
 			// re-runs this autorun and restores the session's real state.
 			if (editorMaximized) {
 				previousSessionResource = activeSessionResource;
-				previousIsUntitled = isUntitled;
+				previousIsCreated = isCreated;
 				this._viewsService.openView(CHANGES_VIEW_ID, false);
 				return;
 			}
 
 			const activeSessionHasWorkspace = activeSessionHasWorkspaceObs.read(reader);
-			const activeSessionHasChanges = activeSessionHasChangesObs.read(reader);
 			const multipleVisible = this.multipleSessionsVisibleObs.read(reader);
 
 			if (multipleVisible) {
 				previousSessionResource = activeSessionResource;
-				previousIsUntitled = isUntitled;
+				previousIsCreated = isCreated;
 				return;
 			}
 
@@ -128,11 +115,15 @@ export class LayoutController extends BaseLayoutController {
 				this._captureViewState(previousSessionResource!);
 			}
 
-			// [D4] Submit: the same session transitions from new (untitled) to real.
-			const isSubmit = !isSessionSwitch && previousIsUntitled && !isUntitled && activeSessionResource !== undefined;
+			// [D4] Submit: the same session transitions from new (uncreated) to real.
+			const isSubmit = previousSessionResource !== undefined
+				&& !isSessionSwitch
+				&& !previousIsCreated
+				&& isCreated
+				&& activeSessionResource !== undefined;
 
 			previousSessionResource = activeSessionResource;
-			previousIsUntitled = isUntitled;
+			previousIsCreated = isCreated;
 
 			if (isSubmit) {
 				this._withSessionLayoutRestore(() => this._onNewSessionSubmitted(activeSessionResource!));
@@ -140,7 +131,9 @@ export class LayoutController extends BaseLayoutController {
 			}
 
 			// [D3] Restore the session's auxiliary bar state.
-			this._withSessionLayoutRestore(() => this._syncAuxiliaryBarVisibility(activeSessionResource, activeSessionHasWorkspace, isUntitled, activeSessionHasChanges));
+			this._withSessionLayoutRestore(() =>
+				this._syncAuxiliaryBarVisibility(activeSessionResource, activeSessionHasWorkspace, isCreated)
+			);
 		}));
 
 		// [D2] Track auxiliary bar visibility changes by the user so that hiding the
@@ -161,9 +154,12 @@ export class LayoutController extends BaseLayoutController {
 			if (!activeSession) {
 				return;
 			}
-			if (activeSession.status.get() === SessionStatus.Untitled) {
+			if (!activeSession.isCreated.get()) {
 				this._setNewSessionViewState({ auxiliaryBarVisible: e.visible });
 			} else {
+				if (e.visible && this._restoreSavedAuxiliaryBarContainerOnReveal(activeSession.resource)) {
+					return;
+				}
 				this._captureViewState(activeSession.resource);
 			}
 		}));
@@ -283,7 +279,7 @@ export class LayoutController extends BaseLayoutController {
 	}
 
 	/**
-	 * [D4] When a new (untitled) session is submitted it becomes a real session
+	 * [D4] When a new (uncreated) session is submitted it becomes a real session
 	 * while staying active. Keep the auxiliary bar as the user left it: if open,
 	 * keep it open and switch to the Changes view; if closed, keep it closed. The
 	 * resulting state is persisted so later syncs don't fall back to hidden.
@@ -292,7 +288,7 @@ export class LayoutController extends BaseLayoutController {
 		const auxiliaryBarVisible = this._layoutService.isVisible(Parts.AUXILIARYBAR_PART);
 		this._viewStateBySession.set(sessionResource, {
 			auxiliaryBarVisible,
-			auxiliaryBarActiveViewContainerId: auxiliaryBarVisible ? CHANGES_VIEW_CONTAINER_ID : undefined,
+			auxiliaryBarActiveViewContainerId: CHANGES_VIEW_CONTAINER_ID,
 		});
 		if (auxiliaryBarVisible) {
 			return this._viewsService.openView(CHANGES_VIEW_ID, false);
@@ -300,19 +296,19 @@ export class LayoutController extends BaseLayoutController {
 	}
 
 	// [D3] Restore the auxiliary bar in strict priority order.
-	private _syncAuxiliaryBarVisibility(sessionResource: URI | undefined, hasWorkspace: boolean, isUntitled: boolean, hasChanges: boolean): void | Promise<unknown> {
+	private _syncAuxiliaryBarVisibility(sessionResource: URI | undefined, hasWorkspace: boolean, isCreated: boolean): void | Promise<unknown> {
 		// [D3a] No resource / no workspace → do nothing.
 		if (!sessionResource || !hasWorkspace) {
 			return;
 		}
 
-		// [D3b] New-session view: all untitled sessions share one state.
-		if (isUntitled) {
+		// [D3b] New-session view: all uncreated sessions share one state.
+		if (!isCreated) {
 			if (this._newSessionViewState && !this._newSessionViewState.auxiliaryBarVisible) {
 				this._layoutService.setPartHidden(true, Parts.AUXILIARYBAR_PART);
 				return;
 			}
-			return this._openDefaultAuxiliaryBarContainer(hasChanges);
+			return this._openDefaultAuxiliaryBarContainer(false);
 		}
 
 		const savedState = this._viewStateBySession.get(sessionResource);
@@ -329,16 +325,32 @@ export class LayoutController extends BaseLayoutController {
 			return this._viewsService.openViewContainer(savedContainerId, false);
 		}
 
-		return this._openDefaultAuxiliaryBarContainer(hasChanges);
+		return this._openDefaultAuxiliaryBarContainer(true);
 	}
 
-	/** [D3d] Prefer Changes when the session has changes, otherwise Files (falling back to Changes if Files is hidden). */
-	private _openDefaultAuxiliaryBarContainer(hasChanges: boolean): Promise<unknown> {
-		if (hasChanges || !this._isAuxiliaryBarContainerPinned(SESSIONS_FILES_CONTAINER_ID)) {
+	/** [D3d] Prefer Changes for created sessions and Files for new sessions. */
+	private _openDefaultAuxiliaryBarContainer(isCreated: boolean): Promise<unknown> {
+		if (isCreated || !this._isAuxiliaryBarContainerPinned(SESSIONS_FILES_CONTAINER_ID)) {
 			return this._viewsService.openView(CHANGES_VIEW_ID, false);
 		} else {
 			return this._viewsService.openViewContainer(SESSIONS_FILES_CONTAINER_ID, false);
 		}
+	}
+
+	private _restoreSavedAuxiliaryBarContainerOnReveal(sessionResource: URI): boolean {
+		const savedState = this._viewStateBySession.get(sessionResource);
+		if (!savedState || savedState.auxiliaryBarVisible) {
+			return false;
+		}
+
+		this._viewStateBySession.set(sessionResource, { ...savedState, auxiliaryBarVisible: true });
+		const savedContainerId = savedState.auxiliaryBarActiveViewContainerId;
+		if (savedContainerId && this._isAuxiliaryBarContainerPinned(savedContainerId)) {
+			void this._viewsService.openViewContainer(savedContainerId, false);
+		} else {
+			void this._openDefaultAuxiliaryBarContainer(true);
+		}
+		return true;
 	}
 
 	private _isAuxiliaryBarContainerPinned(containerId: string): boolean {

--- a/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
@@ -343,11 +343,15 @@ export class LayoutController extends BaseLayoutController {
 			return false;
 		}
 
-		this._viewStateBySession.set(sessionResource, { ...savedState, auxiliaryBarVisible: true });
 		const savedContainerId = savedState.auxiliaryBarActiveViewContainerId;
 		if (savedContainerId && this._isAuxiliaryBarContainerPinned(savedContainerId)) {
+			this._viewStateBySession.set(sessionResource, { ...savedState, auxiliaryBarVisible: true });
 			void this._viewsService.openViewContainer(savedContainerId, false);
 		} else {
+			this._viewStateBySession.set(sessionResource, {
+				auxiliaryBarVisible: true,
+				auxiliaryBarActiveViewContainerId: CHANGES_VIEW_CONTAINER_ID,
+			});
 			void this._openDefaultAuxiliaryBarContainer(true);
 		}
 		return true;

--- a/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
@@ -23,9 +23,15 @@ suite('LayoutController (desktop)', () => {
 	const store = new DisposableStore();
 	let harness: ITestLayoutHarness;
 
-	function createController(options: ICreateOptions = {}): LayoutController {
+	class TestLayoutController extends LayoutController {
+		getViewState(sessionResource: URI) {
+			return this._viewStateBySession.get(sessionResource);
+		}
+	}
+
+	function createController(options: ICreateOptions = {}): TestLayoutController {
 		harness = createTestHarness(store, options);
-		return store.add(harness.instaService.createInstance(LayoutController));
+		return store.add(harness.instaService.createInstance(TestLayoutController));
 	}
 
 	teardown(() => store.clear());
@@ -249,6 +255,35 @@ suite('LayoutController (desktop)', () => {
 			harness.openedViewContainers.includes(CHANGES_VIEW_CONTAINER_ID),
 			'Changes should be the active view when the side pane is opened later'
 		);
+	});
+
+	test('[D4] records Changes when a hidden side pane falls back from an invalid saved container', () => {
+		const session = makeSession(URI.parse('session:1'));
+		const controller = createController({
+			layoutState: [{
+				sessionResource: session.resource.toString(),
+				viewState: {
+					auxiliaryBarVisible: false,
+					auxiliaryBarActiveViewContainerId: 'missing.view',
+				},
+			}],
+		});
+		harness.activeSessionObs.set(session, undefined);
+
+		harness.openedViews = [];
+		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, true);
+		harness.onDidChangePartVisibility.fire({ partId: Parts.AUXILIARYBAR_PART, visible: true });
+
+		assert.deepStrictEqual({
+			openedChanges: harness.openedViews.includes(CHANGES_VIEW_ID),
+			viewState: controller.getViewState(session.resource),
+		}, {
+			openedChanges: true,
+			viewState: {
+				auxiliaryBarVisible: true,
+				auxiliaryBarActiveViewContainerId: CHANGES_VIEW_CONTAINER_ID,
+			},
+		});
 	});
 
 	test('[D4] remembers Files when the user chooses it after the session is submitted', () => {

--- a/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
@@ -67,7 +67,7 @@ suite('LayoutController (desktop)', () => {
 		assert.ok(harness.openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID));
 	});
 
-	test('[D3d] shows changes for untitled session with changes', () => {
+	test('[D3d] keeps Files as the default for an uncreated session with changes', () => {
 		createController();
 		const session = makeSession(URI.parse('session:1'), {
 			status: SessionStatus.Untitled,
@@ -75,7 +75,13 @@ suite('LayoutController (desktop)', () => {
 		});
 		harness.activeSessionObs.set(session, undefined);
 
-		assert.ok(harness.openedViews.includes(CHANGES_VIEW_ID));
+		assert.deepStrictEqual({
+			openedFiles: harness.openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID),
+			openedChanges: harness.openedViews.includes(CHANGES_VIEW_ID),
+		}, {
+			openedFiles: true,
+			openedChanges: false,
+		});
 	});
 
 	test('[D3d] does not force-open Files when the Files pane is hidden', () => {
@@ -180,7 +186,7 @@ suite('LayoutController (desktop)', () => {
 
 	test('[D4] keeps the open side pane and shows Changes when a new session is submitted', () => {
 		createController();
-		const session = makeSession(URI.parse('session:1'), { status: SessionStatus.Untitled });
+		const session = makeSession(URI.parse('session:1'), { status: SessionStatus.Untitled, isCreated: false });
 		harness.activeSessionObs.set(session, undefined);
 
 		assert.ok(harness.openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID));
@@ -189,7 +195,7 @@ suite('LayoutController (desktop)', () => {
 		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, true);
 		harness.setPartHiddenCalls = [];
 		harness.openedViews = [];
-		(session.status as ISettableObservable<SessionStatus>).set(SessionStatus.InProgress, undefined);
+		(session.isCreated as ISettableObservable<boolean>).set(true, undefined);
 
 		assert.ok(
 			!harness.setPartHiddenCalls.some(c => c.part === Parts.AUXILIARYBAR_PART && c.hidden === true),
@@ -203,7 +209,7 @@ suite('LayoutController (desktop)', () => {
 
 	test('[D4] keeps the side pane closed when a new session is submitted with the aux bar hidden', () => {
 		createController();
-		const session = makeSession(URI.parse('session:1'), { status: SessionStatus.Untitled });
+		const session = makeSession(URI.parse('session:1'), { status: SessionStatus.Untitled, isCreated: false });
 		harness.activeSessionObs.set(session, undefined);
 
 		// User hides the aux bar on the new-session view.
@@ -212,7 +218,7 @@ suite('LayoutController (desktop)', () => {
 
 		harness.setPartHiddenCalls = [];
 		harness.openedViews = [];
-		(session.status as ISettableObservable<SessionStatus>).set(SessionStatus.InProgress, undefined);
+		(session.isCreated as ISettableObservable<boolean>).set(true, undefined);
 
 		assert.ok(
 			!harness.setPartHiddenCalls.some(c => c.part === Parts.AUXILIARYBAR_PART && c.hidden === false),
@@ -222,6 +228,51 @@ suite('LayoutController (desktop)', () => {
 			!harness.openedViews.includes(CHANGES_VIEW_ID),
 			'Changes view should not be shown when the aux bar is hidden'
 		);
+	});
+
+	test('[D4] shows Changes when a hidden side pane is opened after the session is submitted', () => {
+		createController();
+		const session = makeSession(URI.parse('session:1'), { status: SessionStatus.Untitled, isCreated: false });
+		harness.activeSessionObs.set(session, undefined);
+
+		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, false);
+		harness.onDidChangePartVisibility.fire({ partId: Parts.AUXILIARYBAR_PART, visible: false });
+
+		(session.isCreated as ISettableObservable<boolean>).set(true, undefined);
+
+		harness.openedViewContainers = [];
+		harness.activePaneCompositeId = SESSIONS_FILES_CONTAINER_ID;
+		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, true);
+		harness.onDidChangePartVisibility.fire({ partId: Parts.AUXILIARYBAR_PART, visible: true });
+
+		assert.ok(
+			harness.openedViewContainers.includes(CHANGES_VIEW_CONTAINER_ID),
+			'Changes should be the active view when the side pane is opened later'
+		);
+	});
+
+	test('[D4] remembers Files when the user chooses it after the session is submitted', () => {
+		createController();
+		const session1 = makeSession(URI.parse('session:1'), { status: SessionStatus.Untitled, isCreated: false });
+		const session2 = makeSession(URI.parse('session:2'));
+		harness.activeSessionObs.set(session1, undefined);
+
+		(session1.isCreated as ISettableObservable<boolean>).set(true, undefined);
+		harness.activePaneCompositeId = SESSIONS_FILES_CONTAINER_ID;
+
+		harness.activeSessionObs.set(session2, undefined);
+
+		harness.openedViews = [];
+		harness.openedViewContainers = [];
+		harness.activeSessionObs.set(session1, undefined);
+
+		assert.deepStrictEqual({
+			openedFiles: harness.openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID),
+			openedChanges: harness.openedViews.includes(CHANGES_VIEW_ID),
+		}, {
+			openedFiles: true,
+			openedChanges: false,
+		});
 	});
 
 	// --- [D2] Live visibility tracking (new-session shared state) ---

--- a/src/vs/sessions/contrib/layout/test/browser/layoutControllerTestUtils.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/layoutControllerTestUtils.ts
@@ -35,15 +35,17 @@ export function makeChange(filePath: string): ISessionFileChange {
 
 export function makeSession(resource: URI, opts?: {
 	status?: SessionStatus;
+	isCreated?: boolean;
 	changes?: readonly ISessionFileChange[];
 	workspace?: ISessionWorkspace;
 }): IActiveSession {
+	const status = observableValue('status', opts?.status ?? SessionStatus.Completed);
 	const chat: IChat = {
 		resource,
 		createdAt: new Date(),
 		title: observableValue('title', 'Test'),
 		updatedAt: observableValue('updatedAt', new Date()),
-		status: observableValue('status', opts?.status ?? SessionStatus.Completed),
+		status,
 		checkpoints: observableValue('checkpoints', undefined),
 		changes: observableValue('changes', opts?.changes ?? []),
 		modelId: observableValue('modelId', undefined),
@@ -91,7 +93,9 @@ export function makeSession(resource: URI, opts?: {
 		activeChat: observableValue('activeChat', chat),
 		mainChat: constObservable(chat),
 		capabilities: { supportsMultipleChats: false },
-		isCreated: observableValue('isCreated', true),
+		isCreated: opts?.isCreated === undefined
+			? status.map(status => status !== SessionStatus.Untitled)
+			: observableValue('isCreated', opts.isCreated),
 		sticky: observableValue('sticky', false),
 		openChats: observableValue('openChats', [chat]),
 		closedChats: constObservable([]),


### PR DESCRIPTION
## Summary
- Keep new/uncreated sessions defaulting to the Files view
- Switch created sessions to Changes as the default aux view when the first request marks the session created
- Preserve per-session user choices such as switching back to Files, including across session restores

## Testing
- Not run (per instruction)