### PR TITLE
sessions: drag & drop to reorder workspaces and groups in the sessions list

### DIFF
--- a/src/vs/sessions/SESSIONS_LIST.md
+++ b/src/vs/sessions/SESSIONS_LIST.md
@@ -15,6 +15,8 @@ The sessions list (`SessionsView` + `SessionsList`) displays every session known
 | `contrib/sessions/browser/views/sessionsView.ts` | `SessionsView` — ViewPane with header, new-session button, sort/group/filter persistence |
 | `contrib/sessions/browser/views/sessionsList.ts` | `SessionsList` — tree control, grouping/filtering logic, menu IDs, context keys |
 | `services/sessions/browser/sessionsListModelService.ts` | `ISessionsListModelService` — pin/read state + shared status icon (UI-only, not synced to providers) |
+| `services/sessions/browser/sessionGroupsService.ts` | `ISessionGroupsService` — user-created groups and session→group membership (UI-only) |
+| `services/sessions/browser/sessionSectionOrderService.ts` | `ISessionSectionOrderService` — manual top-level order of groups + workspace sections and workspace promotion (UI-only) |
 | `contrib/sessions/browser/views/sessionsViewActions.ts` | All registered actions (sort, group, filter, pin, archive, rename, navigate) |
 
 ---
@@ -37,15 +39,18 @@ Each session row displays:
 Sessions are organized into sections with fixed priority:
 
 ```
-1. Pinned        ← always first
-2. Regular       ← grouped by workspace or date
-3. Done/Archived ← always last
+1. Pinned        ← always first, not reorderable
+2. Groups        ← user-created groups, user-ordered (see below)
+3. Regular       ← grouped by workspace or date
+4. Done/Archived ← always last, not reorderable
 ```
 
 Two grouping modes (user-switchable):
 
-- **By Workspace** (default) — one section per workspace label, sorted alphabetically. "Unknown" workspace sorts last.
-- **By Date** — sections: Today, Yesterday, Last 7 Days, Older.
+- **By Workspace** (default) — user groups and one section per workspace label share a single, freely-reorderable user-managed order below Pinned. By default groups come first and workspaces are alphabetical ("Unknown" workspace last) until the user drags them.
+- **By Date** — user groups form a contiguous, user-ordered block directly below Pinned; the non-grouped sessions follow in the fixed date sections (Today, Yesterday, Last 7 Days, Older). Groups never mix into the date sections.
+
+User groups are **fully user-managed**: their order is owned by `ISessionSectionOrderService`, defaults to newest-first, and is shared across both grouping modes (it no longer derives from the recency of a group's member sessions).
 
 Archived sessions always go to the "Done" section regardless of grouping mode. Archive wins over pin — an archived session is never shown in Pinned.
 
@@ -87,7 +92,11 @@ Pinned sessions appear in a dedicated "Pinned" section at the top. Pin state is 
 
 ### Manual Reordering (Drag & Drop)
 
-Regular sessions can be reordered by dragging them up or down within the list. Pinned sessions can be reordered within the Pinned section. An insertion line is shown between rows while dragging.
+Two things can be reordered by dragging: **sessions** (within a section/group) and **top-level headers** (user groups and workspace sections). An insertion line is shown between rows/headers while dragging.
+
+#### Reordering sessions
+
+Regular sessions can be reordered by dragging them up or down within the list. Pinned sessions can be reordered within the Pinned section.
 
 - **Storage** — reordering stores a synthetic numeric *sort key* per session in `ISessionsListModelService` (persisted locally, not synced). It is used **only** for sorting; the provider's real `createdAt`/`updatedAt` are never modified. A separate override map is kept for each sort mode (Created vs Updated).
 - **Sort key** — on drop, the new key is the midpoint between the effective keys of the sessions immediately above and below the drop point. Dropping above the first session uses the current time (so it sorts to the top). Dropping below the last session steps below the last key.
@@ -98,6 +107,16 @@ Regular sessions can be reordered by dragging them up or down within the list. P
 - **User groups** — dropping a non-archived session on a group header adds or moves it into the group and lets it sort naturally. Dropping it on a session inside the group shows an insertion line for the exact slot and highlights only the group header to indicate the receiving group.
 - **Scope** — archived (Done) sessions do not reorder or move into groups. Drops onto the Done section, unsupported section headers, and "show more" rows are rejected.
 - **Multi-selection** — dragging multiple selected sessions moves them as a contiguous block, preserving their relative order. The drag label reads `"N sessions"`. Dragging sessions into the sessions grid opens all of them.
+
+#### Reordering groups and workspaces
+
+Dragging a **group header** or a **workspace section header** over another reorderable header shows an insertion line above/below it and moves the dragged header to that slot on drop.
+
+- **Storage** — the top-level order is owned by `ISessionSectionOrderService` (persisted locally, not synced) as a flat list of identities (`group:<id>` and `workspace:<label>`). Identities the user has never moved fall back to the list's default order, so new groups/workspaces appear in their natural place until dragged. Stale identities (deleted groups, vanished workspaces) are garbage-collected.
+- **By Workspace** — groups and workspace sections share one order and can be freely intermixed. Dragging a workspace also **promotes** it so it stays visible (escapes the "+N more workspaces" capping).
+- **By Date** — only group headers are draggable; they reorder within the groups block. Workspace order changes made in the other mode are preserved. The date sections are fixed and are not drop targets.
+- **Invariants** — the Pinned section is always first and the Done section always last; neither (nor the date sections, nor "show more" rows) is draggable or a valid header drop target.
+- **Shared order** — the relative order of groups is the same in both grouping modes, and also drives the "Add to Group" / "Move to Group" menu order.
 
 The insertion line relies on the base list widget's `drop-target-before`/`drop-target-after` feedback (colored by `list.dropBetweenBackground`). The widget converts an "after" indicator on row *i* into a "before" indicator on row *i+1*, so hovering the bottom half of the upper row and the top half of the lower row render the exact same DOM line with no shift.
 

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -47,6 +47,7 @@ import { ISessionsManagementService, IActiveSession } from '../../../../services
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 import { ISessionsListModelService, SessionSortMode } from '../../../../services/sessions/browser/sessionsListModelService.js';
 import { ISessionGroup, ISessionGroupsService } from '../../../../services/sessions/browser/sessionGroupsService.js';
+import { ISessionSectionOrderService } from '../../../../services/sessions/browser/sessionSectionOrderService.js';
 import { InputBox } from '../../../../../base/browser/ui/inputbox/inputBox.js';
 import { IWorkbenchAssignmentService } from '../../../../../workbench/services/assignment/common/assignmentService.js';
 // =============================================================================
@@ -988,8 +989,8 @@ interface ISessionsListDndDelegate {
 	pinSessions(sessions: ISession[], target: ISession | undefined, position: 'before' | 'after' | undefined): void;
 	/** Highlight only the header that will receive the dragged sessions. */
 	setDropTargetHeader(header: ISessionDropTargetHeader | undefined): void;
-	/** Reorder the dragged group before/after the target group. */
-	reorderGroup(draggedGroupId: string, targetGroupId: string, position: 'before' | 'after'): void;
+	/** Reorder a top-level header (group or workspace section) before/after another. */
+	reorderSection(draggedId: string, targetId: string, position: 'before' | 'after', isWorkspace: boolean): void;
 }
 
 interface ISessionDropTargetHeader {
@@ -1008,6 +1009,14 @@ interface ISessionAddToGroupDropTarget extends ISessionMembershipDropTarget {
 	readonly groupId: string;
 }
 
+/** A top-level header (group or workspace section) currently being dragged to reorder. */
+interface IDraggedHeader {
+	/** The reorder identity (`group:<id>` or `workspace:<label>`). */
+	readonly id: string;
+	/** Whether the dragged header is a workspace section (vs. a user group). */
+	readonly isWorkspace: boolean;
+}
+
 class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<SessionListItem> {
 
 	private readonly _transfer = LocalSelectionTransfer.getInstance<DraggedSessionIdentifier>();
@@ -1020,7 +1029,12 @@ class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<Ses
 		if (isSessionGroupItem(element)) {
 			return `sessionGroup:${element.group.id}`;
 		}
-		if (isSessionSection(element) || isSessionShowMore(element)) {
+		if (isSessionSection(element)) {
+			// Only workspace sections are reorderable; Pinned, Done and the date
+			// sections stay fixed and are therefore not draggable.
+			return element.id.startsWith('workspace:') ? `sessionWorkspace:${element.id}` : null;
+		}
+		if (isSessionShowMore(element)) {
 			return null;
 		}
 		return element.resource.toString();
@@ -1030,6 +1044,10 @@ class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<Ses
 		const groupItem = elements.find(isSessionGroupItem);
 		if (groupItem) {
 			return groupItem.group.name;
+		}
+		const workspaceSection = elements.find((e): e is ISessionSection => isSessionSection(e) && e.id.startsWith('workspace:'));
+		if (workspaceSection) {
+			return workspaceSection.label;
 		}
 		const sessions = this.toSessions(elements);
 		if (sessions.length === 0) {
@@ -1064,10 +1082,10 @@ class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<Ses
 	}
 
 	onDragOver(data: IDragAndDropData, targetElement: SessionListItem | undefined, _targetIndex: number | undefined, targetSector: ListViewTargetSector | undefined): boolean | ITreeDragOverReaction {
-		const draggedGroup = this.draggedGroup(data);
-		if (draggedGroup) {
+		const draggedHeader = this.draggedHeader(data);
+		if (draggedHeader) {
 			this.delegate.setDropTargetHeader(undefined);
-			return this.onGroupDragOver(draggedGroup, targetElement, targetSector);
+			return this.onHeaderDragOver(draggedHeader, targetElement, targetSector);
 		}
 
 		const pinTarget = this.resolvePinTarget(data, targetElement, targetSector);
@@ -1100,10 +1118,13 @@ class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<Ses
 	drop(data: IDragAndDropData, targetElement: SessionListItem | undefined, _targetIndex: number | undefined, targetSector: ListViewTargetSector | undefined): void {
 		this.delegate.setDropTargetHeader(undefined);
 		try {
-			const draggedGroup = this.draggedGroup(data);
-			if (draggedGroup) {
-				if (targetElement && isSessionGroupItem(targetElement) && targetElement.group.id !== draggedGroup.id) {
-					this.delegate.reorderGroup(draggedGroup.id, targetElement.group.id, sectorToPosition(targetSector));
+			const draggedHeader = this.draggedHeader(data);
+			if (draggedHeader) {
+				if (targetElement) {
+					const targetRef = this.headerRefOf(targetElement);
+					if (targetRef && targetRef !== draggedHeader.id) {
+						this.delegate.reorderSection(draggedHeader.id, targetRef, sectorToPosition(targetSector), draggedHeader.isWorkspace);
+					}
 				}
 				return;
 			}
@@ -1130,8 +1151,12 @@ class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<Ses
 		}
 	}
 
-	private onGroupDragOver(draggedGroup: ISessionGroup, targetElement: SessionListItem | undefined, targetSector: ListViewTargetSector | undefined): boolean | ITreeDragOverReaction {
-		if (!targetElement || !isSessionGroupItem(targetElement) || targetElement.group.id === draggedGroup.id) {
+	private onHeaderDragOver(draggedHeader: IDraggedHeader, targetElement: SessionListItem | undefined, targetSector: ListViewTargetSector | undefined): boolean | ITreeDragOverReaction {
+		if (!targetElement) {
+			return false;
+		}
+		const targetRef = this.headerRefOf(targetElement);
+		if (!targetRef || targetRef === draggedHeader.id) {
 			return false;
 		}
 		const position = sectorToPosition(targetSector);
@@ -1252,12 +1277,31 @@ class SessionsListDragAndDrop extends Disposable implements ITreeDragAndDrop<Ses
 		};
 	}
 
-	private draggedGroup(data: IDragAndDropData): ISessionGroup | undefined {
+	private draggedHeader(data: IDragAndDropData): IDraggedHeader | undefined {
 		if (!(data instanceof ElementsDragAndDropData)) {
 			return undefined;
 		}
-		const groupItem = (data.elements as SessionListItem[]).find(isSessionGroupItem);
-		return groupItem?.group;
+		const elements = data.elements as SessionListItem[];
+		const groupItem = elements.find(isSessionGroupItem);
+		if (groupItem) {
+			return { id: `group:${groupItem.group.id}`, isWorkspace: false };
+		}
+		const workspaceSection = elements.find((e): e is ISessionSection => isSessionSection(e) && e.id.startsWith('workspace:'));
+		if (workspaceSection) {
+			return { id: workspaceSection.id, isWorkspace: true };
+		}
+		return undefined;
+	}
+
+	/** The reorder identity of a top-level header element, or `undefined` when it is not reorderable. */
+	private headerRefOf(element: SessionListItem): string | undefined {
+		if (isSessionGroupItem(element)) {
+			return `group:${element.group.id}`;
+		}
+		if (isSessionSection(element) && element.id.startsWith('workspace:')) {
+			return element.id;
+		}
+		return undefined;
 	}
 
 	private draggedSessions(data: IDragAndDropData): ISession[] {
@@ -1378,6 +1422,13 @@ export class SessionsList extends Disposable implements ISessionsList {
 	private _sectionRenderer!: SessionSectionRenderer;
 	private _dropTargetHeader: ISessionDropTargetHeader | undefined;
 
+	/**
+	 * Snapshot of the currently-rendered reorderable top-level headers (groups
+	 * and, in workspace mode, workspace sections) in display order, by reorder
+	 * identity. Captured each render and used as the basis for drag-reorder math.
+	 */
+	private _topLevelOrder: string[] = [];
+
 	private readonly _onDidUpdate = this._register(new Emitter<void>());
 	readonly onDidUpdate: Event<void> = this._onDidUpdate.event;
 
@@ -1393,6 +1444,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		@ISessionsService private readonly _sessionsService: ISessionsService,
 		@ISessionsListModelService private readonly _sessionsListModelService: ISessionsListModelService,
 		@ISessionGroupsService private readonly _sessionGroupsService: ISessionGroupsService,
+		@ISessionSectionOrderService private readonly _sessionSectionOrderService: ISessionSectionOrderService,
 		@IAgentHostFilterService private readonly _agentHostFilterService: IAgentHostFilterService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
@@ -1478,7 +1530,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 					addSessionsToGroup: (sessions, groupId, target, position) => this.addSessionsToGroup(sessions, groupId, target, position),
 					pinSessions: (sessions, target, position) => this.pinSessions(sessions, target, position),
 					setDropTargetHeader: header => this.setDropTargetHeader(header),
-					reorderGroup: (draggedGroupId, targetGroupId, position) => this.reorderGroup(draggedGroupId, targetGroupId, position),
+					reorderSection: (draggedId, targetId, position, isWorkspace) => this.reorderSection(draggedId, targetId, position, isWorkspace),
 				})),
 				identityProvider: {
 					getId: (element: SessionListItem) => {
@@ -1650,6 +1702,12 @@ export class SessionsList extends Disposable implements ISessionsList {
 			}
 		}));
 
+		this._register(this._sessionSectionOrderService.onDidChange(() => {
+			if (this.visible) {
+				this.update();
+			}
+		}));
+
 		this._register(this._agentHostFilterService.onDidChange(() => {
 			if (this.visible) {
 				this.update();
@@ -1734,9 +1792,11 @@ export class SessionsList extends Disposable implements ISessionsList {
 
 		const grouping = this.options.grouping();
 		const sorting = this.options.sorting();
-		const mode = sortingToMode(sorting);
-		const sortKeyOf = (s: ISession) => this._sessionsListModelService.getSortKey(s, mode);
 		const sortKeyForGrouping = (s: ISession, srt: SessionsSorting) => this._sessionsListModelService.getSortKey(s, sortingToMode(srt));
+
+		// Garbage-collect manual order/promotion entries for groups and
+		// workspaces that no longer exist (does not affect the visible order).
+		this._sessionSectionOrderService.retain(this.liveSectionOrderIds());
 
 		// Pull regular (non-pinned, non-archived) grouped sessions out of the
 		// normal date/workspace sectioning so they render under their group.
@@ -1768,18 +1828,19 @@ export class SessionsList extends Disposable implements ISessionsList {
 
 		const forSections = groupedRegularIds.size > 0 ? filtered.filter(s => !groupedRegularIds.has(s.sessionId)) : filtered;
 
-		// Build the group blocks with members sorted by the normal sort logic and
-		// a representative key (manual override, else the best member key) used to
-		// place the group among the other top-level items.
-		const groupItems: { item: ISessionGroupItem; repKey: number }[] = [];
+		// Build the group blocks with members sorted by the normal sort logic.
+		// Groups are fully user-managed: their order is owned by the section-order
+		// service (defaulting to newest-first), independent of their members'
+		// recency, and is shared across both grouping modes.
+		const groupItemsById = new Map<string, ISessionGroupItem>();
 		for (const [groupId, members] of groupedMembers) {
 			const group = this._sessionGroupsService.getGroup(groupId)!;
 			const sortedMembers = sortSessions(members, sorting, sortKeyForGrouping);
-			const naturalRep = sortedMembers.length > 0 ? Math.max(...sortedMembers.map(sortKeyOf)) : group.createdAt;
-			const repKey = group.sortKeyOverride ?? naturalRep;
-			groupItems.push({ item: { group, sessions: sortedMembers, editing: group.id === this._editingGroupId }, repKey });
+			groupItemsById.set(groupId, { group, sessions: sortedMembers, editing: group.id === this._editingGroupId });
 		}
-		groupItems.sort((a, b) => b.repKey - a.repKey);
+		const defaultGroupIds = [...groupItemsById.values()]
+			.sort((a, b) => b.group.createdAt - a.group.createdAt)
+			.map(item => `group:${item.group.id}`);
 
 		const sections = groupSessionsForList(forSections, grouping, sorting, session => this.isSessionPinned(session), (s, srt) => this._sessionsListModelService.getSortKey(s, sortingToMode(srt)));
 
@@ -1826,7 +1887,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 				}
 
 				for (const section of workspaceSections) {
-					if (!meetsCriteria(section) && section.id !== fallbackId) {
+					if (!meetsCriteria(section) && section.id !== fallbackId && !this._sessionSectionOrderService.isPromoted(section.id)) {
 						moreFolderSectionIds.add(section.id);
 					}
 				}
@@ -1892,63 +1953,65 @@ export class SessionsList extends Disposable implements ISessionsList {
 			};
 		};
 
-		const sectionRepKey = (section: ISessionSection): number =>
-			section.sessions.length > 0 ? Math.max(...section.sessions.map(sortKeyOf)) : Number.NEGATIVE_INFINITY;
-
 		const pinnedSection = sections.find(s => s.id === 'pinned');
 		if (pinnedSection) {
 			children.push(renderSection(pinnedSection));
 		}
 
+		const renderGroupById = (id: string): void => {
+			const groupItem = groupItemsById.get(id.slice('group:'.length));
+			if (groupItem) {
+				children.push(renderGroup(groupItem));
+			}
+		};
+
 		if (grouping === SessionsGrouping.Date) {
-			// Interleave groups among the date sections by representative key so a
-			// group sorts to wherever its most-recent member would place it.
-			// Pinned stays at the top, Done (archived) stays at the bottom.
-			type Block = { key: number; render: () => IObjectTreeElement<SessionListItem> };
-			const blocks: Block[] = [];
+			// Groups form a contiguous, fully user-ordered block right below the
+			// Pinned section. They no longer interleave with the date sections by
+			// recency and never mix into Today/Yesterday/etc. Pinned stays at the
+			// top, Done (archived) stays at the bottom.
+			const resolvedGroupIds = this._sessionSectionOrderService.resolveOrder(defaultGroupIds);
+			this._topLevelOrder = resolvedGroupIds;
+			for (const id of resolvedGroupIds) {
+				renderGroupById(id);
+			}
 			for (const section of sections) {
 				if (section.id === 'pinned' || section.id === 'archived') {
 					continue;
 				}
-				blocks.push({ key: sectionRepKey(section), render: () => renderSection(section) });
-			}
-			for (const groupItem of groupItems) {
-				blocks.push({ key: groupItem.repKey, render: () => renderGroup(groupItem.item) });
-			}
-			blocks.sort((a, b) => b.key - a.key);
-			for (const block of blocks) {
-				children.push(block.render());
+				children.push(renderSection(section));
 			}
 			const archived = sections.find(s => s.id === 'archived');
 			if (archived) {
 				children.push(renderSection(archived));
 			}
 		} else {
-			// Workspace grouping: groups render as a block right after Pinned and
-			// before the (alphabetical) workspace sections, sorted among
-			// themselves by representative key.
-			for (const groupItem of groupItems) {
-				children.push(renderGroup(groupItem.item));
-			}
+			// Workspace grouping: groups and (primary) workspace sections share one
+			// freely-reorderable, user-managed order right below Pinned. Groups
+			// default above workspaces; workspaces default to their alphabetical
+			// order. Pinned stays first, Done last, and hidden ("+N more")
+			// workspaces are appended below the ordered block.
+			const workspaceSections = sections.filter(s => s.id.startsWith('workspace:'));
+			const sectionById = new Map(workspaceSections.map(s => [s.id, s] as const));
+			const primaryWorkspaceIds = workspaceSections
+				.filter(s => !moreFolderSectionIds.has(s.id))
+				.map(s => s.id);
 
-			const moreFolderSections: ISessionSection[] = [];
-			// The archived ("Done") section should always appear after the
-			// "more workspaces" toggle (both collapsed and expanded states)
-			// so it remains the very last group in the list.
-			let archivedSection: ISessionSection | undefined;
-			for (const section of sections) {
-				if (section.id === 'pinned') {
-					continue;
-				}
-				if (moreFolderSectionIds.has(section.id)) {
-					moreFolderSections.push(section);
-				} else if (partitionFolders && section.id === 'archived') {
-					archivedSection = section;
+			const defaultOrder = [...defaultGroupIds, ...primaryWorkspaceIds];
+			const resolvedIds = this._sessionSectionOrderService.resolveOrder(defaultOrder);
+			this._topLevelOrder = resolvedIds;
+			for (const id of resolvedIds) {
+				if (id.startsWith('group:')) {
+					renderGroupById(id);
 				} else {
-					children.push(renderSection(section));
+					const section = sectionById.get(id);
+					if (section) {
+						children.push(renderSection(section));
+					}
 				}
 			}
 
+			const moreFolderSections = workspaceSections.filter(s => moreFolderSectionIds.has(s.id));
 			if (moreFolderSections.length > 0) {
 				if (this.expandedMoreFolders) {
 					for (const section of moreFolderSections) {
@@ -1963,6 +2026,9 @@ export class SessionsList extends Disposable implements ISessionsList {
 					});
 				}
 			}
+
+			// The archived ("Done") section is always the very last entry.
+			const archivedSection = sections.find(s => s.id === 'archived');
 			if (archivedSection) {
 				children.push(renderSection(archivedSection));
 			}
@@ -2197,68 +2263,47 @@ export class SessionsList extends Disposable implements ISessionsList {
 	}
 
 	/**
-	 * Reorder a group so it lands before/after the target group, persisting a
-	 * synthetic sort key spread between the surrounding groups' representative
-	 * keys. Reuses the session reorder math for a single-item block.
+	 * Reorder a top-level header (group or workspace section) so it lands
+	 * before/after the target header. The new order is persisted to the
+	 * section-order service. When the dragged header is a workspace it is also
+	 * promoted so it stays visible (escapes the "+N more workspaces" capping).
 	 */
-	private reorderGroup(draggedGroupId: string, targetGroupId: string, position: 'before' | 'after'): void {
-		const order = this.getGroupsInDisplayOrder();
-		const repKey = (groupId: string): number => {
-			const group = this._sessionGroupsService.getGroup(groupId);
-			if (group?.sortKeyOverride !== undefined) {
-				return group.sortKeyOverride;
-			}
-			const mode = sortingToMode(this.options.sorting());
-			const memberKeys = this._sessionGroupsService.getSessionIdsInGroup(groupId)
-				.map(id => this.sessions.find(s => s.sessionId === id))
-				.filter((s): s is ISession => !!s)
-				.map(s => this._sessionsListModelService.getSortKey(s, mode));
-			return memberKeys.length > 0 ? Math.max(...memberKeys) : (group?.createdAt ?? Date.now());
-		};
-
-		const remaining = order.filter(g => g.id !== draggedGroupId);
-		const targetIndex = remaining.findIndex(g => g.id === targetGroupId);
-		if (targetIndex === -1) {
-			return;
-		}
-		const insertIndex = position === 'before' ? targetIndex : targetIndex + 1;
-		const above = remaining[insertIndex - 1];
-		const below = remaining[insertIndex];
-
-		const { set, clear } = computeReorderSortChanges({
-			draggedIds: [draggedGroupId],
-			naturalKeys: [repKey(draggedGroupId)],
-			aboveKey: above ? repKey(above.id) : undefined,
-			belowKey: below ? repKey(below.id) : undefined,
-			now: Date.now(),
-			fallbackStep: SORT_FALLBACK_STEP_MS,
-		});
-		for (const id of clear) {
-			this._sessionGroupsService.setGroupSortKey(id, undefined);
-		}
-		for (const [id, value] of set) {
-			this._sessionGroupsService.setGroupSortKey(id, value);
-		}
+	private reorderSection(draggedId: string, targetId: string, position: 'before' | 'after', isWorkspace: boolean): void {
+		this._sessionSectionOrderService.reorder(this._topLevelOrder, draggedId, targetId, position, isWorkspace ? draggedId : undefined);
 	}
 
 	/**
-	 * Groups in their current top-to-bottom display order, computed from member
-	 * representative keys (and manual overrides). Used to keep the "Add to Group"
-	 * menu and group reordering consistent with the list.
+	 * Groups in their current top-to-bottom display order. Groups are fully
+	 * user-managed (see {@link ISessionSectionOrderService}); the order defaults
+	 * to newest-first and is shared with the list. Used to keep the "Add to
+	 * Group" / "Move to Group" menu consistent with the rendered order.
 	 */
 	getGroupsInDisplayOrder(): ISessionGroup[] {
-		const mode = sortingToMode(this.options.sorting());
-		const repKey = (group: ISessionGroup): number => {
-			if (group.sortKeyOverride !== undefined) {
-				return group.sortKeyOverride;
-			}
-			const memberKeys = this._sessionGroupsService.getSessionIdsInGroup(group.id)
-				.map(id => this.sessions.find(s => s.sessionId === id))
-				.filter((s): s is ISession => !!s)
-				.map(s => this._sessionsListModelService.getSortKey(s, mode));
-			return memberKeys.length > 0 ? Math.max(...memberKeys) : group.createdAt;
-		};
-		return this._sessionGroupsService.getGroups().sort((a, b) => repKey(b) - repKey(a));
+		const groups = this._sessionGroupsService.getGroups();
+		const byId = new Map(groups.map(g => [`group:${g.id}`, g] as const));
+		const defaultIds = [...groups]
+			.sort((a, b) => b.createdAt - a.createdAt)
+			.map(g => `group:${g.id}`);
+		return this._sessionSectionOrderService.resolveOrder(defaultIds)
+			.map(id => byId.get(id))
+			.filter((g): g is ISessionGroup => !!g);
+	}
+
+	/**
+	 * The set of top-level reorder identities that currently exist (every group,
+	 * plus every workspace label present across all sessions, regardless of
+	 * grouping mode or capping). Used to garbage-collect stale manual order and
+	 * promotion entries.
+	 */
+	private liveSectionOrderIds(): Set<string> {
+		const ids = new Set<string>();
+		for (const group of this._sessionGroupsService.getGroups()) {
+			ids.add(`group:${group.id}`);
+		}
+		for (const session of this.sessions) {
+			ids.add(`workspace:${sessionWorkspaceLabel(session)}`);
+		}
+		return ids;
 	}
 
 	private setDropTargetHeader(header: ISessionDropTargetHeader | undefined): void {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -2280,7 +2280,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 	 */
 	getGroupsInDisplayOrder(): ISessionGroup[] {
 		const groups = this._sessionGroupsService.getGroups();
-		const byId = new Map(groups.map(g => [`group:${g.id}`, g] as const));
+		const byId = new Map<string, ISessionGroup>(groups.map(g => [`group:${g.id}`, g]));
 		const defaultIds = [...groups]
 			.sort((a, b) => b.createdAt - a.createdAt)
 			.map(g => `group:${g.id}`);

--- a/src/vs/sessions/services/sessions/browser/sessionGroupsService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionGroupsService.ts
@@ -13,23 +13,17 @@ import { ISessionsManagementService } from '../common/sessionsManagement.js';
 
 /**
  * A user-created group of sessions in the sessions list. Groups render like
- * section headers and can be reordered, renamed and deleted. Membership of a
- * session in a group is tracked separately (see {@link ISessionGroupsService}).
+ * section headers and can be reordered, renamed and deleted. Their order is
+ * owned by the section-order service and is fully user-managed; this type only
+ * carries identity, name and creation time. Membership of a session in a group
+ * is tracked separately (see {@link ISessionGroupsService}).
  */
 export interface ISessionGroup {
 	/** Stable identifier (uuid). */
 	readonly id: string;
 	/** User-provided display name. */
 	readonly name: string;
-	/**
-	 * Manual sort-key override applied when the user drags a group to reorder
-	 * it. `undefined` means the group falls back to its natural placement (the
-	 * best/highest sort key among its members). Expressed in the same numeric
-	 * space as session sort keys (timestamps) so groups interleave with the
-	 * date/workspace sections. Higher values sort higher in the list.
-	 */
-	readonly sortKeyOverride: number | undefined;
-	/** Creation timestamp (ms). Used to evict the oldest empty group. */
+	/** Creation timestamp (ms). Used to evict the oldest empty group and as the default order (newest first). */
 	readonly createdAt: number;
 }
 
@@ -88,12 +82,6 @@ export interface ISessionGroupsService {
 
 	/** The session ids that belong to the given group. */
 	getSessionIdsInGroup(groupId: string): string[];
-
-	/**
-	 * Persist a manual sort-key override for a group (or clear it with
-	 * `undefined`). Used when the user drags a group to reorder it.
-	 */
-	setGroupSortKey(groupId: string, sortKeyOverride: number | undefined): void;
 }
 
 export const ISessionGroupsService = createDecorator<ISessionGroupsService>('sessionGroupsService');
@@ -158,7 +146,7 @@ export class SessionGroupsService extends Disposable implements ISessionGroupsSe
 	}
 
 	createGroup(name: string, memberSessionIds?: Iterable<string>): ISessionGroup {
-		const group: ISessionGroup = { id: generateUuid(), name, sortKeyOverride: undefined, createdAt: Date.now() };
+		const group: ISessionGroup = { id: generateUuid(), name, createdAt: Date.now() };
 		this._groups.set(group.id, group);
 
 		const membershipChanged = new Set<string>();
@@ -233,16 +221,6 @@ export class SessionGroupsService extends Disposable implements ISessionGroupsSe
 		return result;
 	}
 
-	setGroupSortKey(groupId: string, sortKeyOverride: number | undefined): void {
-		const group = this._groups.get(groupId);
-		if (!group || group.sortKeyOverride === sortKeyOverride) {
-			return;
-		}
-		this._groups.set(groupId, { ...group, sortKeyOverride });
-		this.save();
-		this._onDidChange.fire({ groupsChanged: true, membershipChanged: new Set() });
-	}
-
 	// -- Helpers --
 
 	private setMembership(sessionId: string, groupId: string, changed: Set<string>): void {
@@ -279,24 +257,12 @@ export class SessionGroupsService extends Disposable implements ISessionGroupsSe
 	}
 
 	/**
-	 * Sort groups for display as a stable baseline: groups with a manual
-	 * `sortKeyOverride` first (highest key first), then the rest by creation
-	 * time (newest first). The list view computes the final interleaved
-	 * placement using member sort keys; this baseline is used where member keys
-	 * are not available (e.g. the "Add to Group" menu fallback).
+	 * Sort groups for display as a stable baseline: newest first (by creation
+	 * time). The final user-managed order is applied by the section-order
+	 * service; this baseline is used where that order is not available.
 	 */
 	private sortGroups(groups: ISessionGroup[]): ISessionGroup[] {
-		return groups.sort((a, b) => {
-			const aHas = a.sortKeyOverride !== undefined;
-			const bHas = b.sortKeyOverride !== undefined;
-			if (aHas && bHas) {
-				return b.sortKeyOverride! - a.sortKeyOverride!;
-			}
-			if (aHas !== bHas) {
-				return aHas ? -1 : 1;
-			}
-			return b.createdAt - a.createdAt;
-		});
+		return groups.sort((a, b) => b.createdAt - a.createdAt);
 	}
 
 	// -- Storage --
@@ -314,7 +280,6 @@ export class SessionGroupsService extends Disposable implements ISessionGroupsSe
 						this._groups.set(group.id, {
 							id: group.id,
 							name: group.name,
-							sortKeyOverride: typeof group.sortKeyOverride === 'number' ? group.sortKeyOverride : undefined,
 							createdAt: typeof group.createdAt === 'number' ? group.createdAt : Date.now(),
 						});
 					}
@@ -343,18 +308,6 @@ export class SessionGroupsService extends Disposable implements ISessionGroupsSe
 		};
 		this.storageService.store(SessionGroupsService.STORAGE_KEY, JSON.stringify(state), StorageScope.PROFILE, StorageTarget.USER);
 	}
-}
-
-/**
- * Best (highest) sort key among a group's currently-visible members, used to
- * place the group among the other top-level list items. Returns `undefined`
- * when the group has no visible members.
- */
-export function groupSortKey(memberKeys: readonly number[]): number | undefined {
-	if (memberKeys.length === 0) {
-		return undefined;
-	}
-	return Math.max(...memberKeys);
 }
 
 registerSingleton(ISessionGroupsService, SessionGroupsService, InstantiationType.Delayed);

--- a/src/vs/sessions/services/sessions/browser/sessionSectionOrderService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionSectionOrderService.ts
@@ -1,0 +1,258 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+
+/**
+ * Service that owns the manual top-level ordering of the sessions list: the
+ * order of user-created groups and workspace sections relative to each other.
+ *
+ * The order is stored as a flat list of opaque identities (the sessions list
+ * uses `group:<id>` for groups and `workspace:<label>` for workspace sections).
+ * It is purely local (persisted to profile storage) and not synced to
+ * providers. Identities the user has never moved fall back to a caller-provided
+ * default order, so newly created groups / discovered workspaces appear in their
+ * natural place until the user drags them.
+ *
+ * Workspaces additionally carry a *promotion* flag: once the user drags a
+ * workspace it is promoted so it stays visible (escapes the "+N more workspaces"
+ * capping) even if it would otherwise be hidden.
+ */
+export interface ISessionSectionOrderService {
+	readonly _serviceBrand: undefined;
+
+	/** Fires when the manual order or promotion set changes. */
+	readonly onDidChange: Event<void>;
+
+	/**
+	 * Resolve the final top-to-bottom display order for `defaultOrderedIds`
+	 * (the live identities to show, in their natural/default order). Identities
+	 * with a persisted manual position keep it; not-yet-seen identities are
+	 * woven in at their default position. Pure: never mutates or persists.
+	 */
+	resolveOrder(defaultOrderedIds: readonly string[]): string[];
+
+	/**
+	 * Apply a manual reorder. `visibleOrder` is the current resolved order of
+	 * the reorderable identities the user sees; the dragged identity is moved
+	 * before/after the target within it and the result is merged into the
+	 * persisted order, preserving the relative position of identities that are
+	 * not currently visible (e.g. hidden workspaces, or the other grouping
+	 * mode's entries). When `promoteId` is given that identity is recorded as
+	 * user-promoted.
+	 */
+	reorder(visibleOrder: readonly string[], draggedId: string, targetId: string, position: 'before' | 'after', promoteId?: string): void;
+
+	/** Whether the identity has been explicitly promoted (moved) by the user. */
+	isPromoted(id: string): boolean;
+
+	/**
+	 * Drop stored order/promotion entries that are not in `liveIds`. Persists
+	 * (without firing {@link onDidChange}, since the visible order is unaffected)
+	 * only when something was actually removed. Used to garbage-collect stale
+	 * identities such as deleted groups or vanished workspaces.
+	 */
+	retain(liveIds: Iterable<string>): void;
+}
+
+export const ISessionSectionOrderService = createDecorator<ISessionSectionOrderService>('sessionSectionOrderService');
+
+interface ISerializedState {
+	readonly order: readonly string[];
+	readonly promoted: readonly string[];
+}
+
+export class SessionSectionOrderService extends Disposable implements ISessionSectionOrderService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private static readonly STORAGE_KEY = 'sessionsListControl.sectionOrder';
+
+	private readonly _onDidChange = this._register(new Emitter<void>());
+	readonly onDidChange: Event<void> = this._onDidChange.event;
+
+	private _order: string[] = [];
+	private _promoted = new Set<string>();
+
+	constructor(
+		@IStorageService private readonly storageService: IStorageService,
+	) {
+		super();
+		this.load();
+	}
+
+	resolveOrder(defaultOrderedIds: readonly string[]): string[] {
+		return resolveSectionOrder(this._order, defaultOrderedIds);
+	}
+
+	reorder(visibleOrder: readonly string[], draggedId: string, targetId: string, position: 'before' | 'after', promoteId?: string): void {
+		const visibleAfter = spliceSectionOrder(visibleOrder, draggedId, targetId, position);
+		if (!visibleAfter) {
+			return;
+		}
+		const next = mergeSectionOrder(this._order, visibleAfter);
+		const orderChanged = !arraysEqual(next, this._order);
+		const promoteChanged = promoteId !== undefined && !this._promoted.has(promoteId);
+		if (!orderChanged && !promoteChanged) {
+			return;
+		}
+		this._order = next;
+		if (promoteId !== undefined) {
+			this._promoted.add(promoteId);
+		}
+		this.save();
+		this._onDidChange.fire();
+	}
+
+	isPromoted(id: string): boolean {
+		return this._promoted.has(id);
+	}
+
+	retain(liveIds: Iterable<string>): void {
+		const live = liveIds instanceof Set ? liveIds : new Set(liveIds);
+		const order = this._order.filter(id => live.has(id));
+		const promoted = [...this._promoted].filter(id => live.has(id));
+		if (order.length === this._order.length && promoted.length === this._promoted.size) {
+			return;
+		}
+		this._order = order;
+		this._promoted = new Set(promoted);
+		this.save();
+	}
+
+	// -- Storage --
+
+	private load(): void {
+		const raw = this.storageService.get(SessionSectionOrderService.STORAGE_KEY, StorageScope.PROFILE);
+		if (!raw) {
+			return;
+		}
+		try {
+			const parsed = JSON.parse(raw) as Partial<ISerializedState>;
+			if (Array.isArray(parsed.order)) {
+				this._order = parsed.order.filter((id): id is string => typeof id === 'string');
+			}
+			if (Array.isArray(parsed.promoted)) {
+				this._promoted = new Set(parsed.promoted.filter((id): id is string => typeof id === 'string'));
+			}
+		} catch {
+			// ignore corrupt data
+		}
+	}
+
+	private save(): void {
+		if (this._order.length === 0 && this._promoted.size === 0) {
+			this.storageService.remove(SessionSectionOrderService.STORAGE_KEY, StorageScope.PROFILE);
+			return;
+		}
+		const state: ISerializedState = { order: this._order, promoted: [...this._promoted] };
+		this.storageService.store(SessionSectionOrderService.STORAGE_KEY, JSON.stringify(state), StorageScope.PROFILE, StorageTarget.USER);
+	}
+}
+
+//#region Pure helpers (exported for testing)
+
+/**
+ * Combine a persisted manual order with a default order. Identities present in
+ * `persisted` keep their relative manual order; identities only in
+ * `defaultOrderedIds` are inserted at their default position (after their
+ * nearest preceding default neighbour that is already placed). Stale persisted
+ * identities not in `defaultOrderedIds` are dropped from the result.
+ */
+export function resolveSectionOrder(persisted: readonly string[], defaultOrderedIds: readonly string[]): string[] {
+	const live = new Set(defaultOrderedIds);
+	const result: string[] = persisted.filter(id => live.has(id));
+	const placed = new Set(result);
+	for (let i = 0; i < defaultOrderedIds.length; i++) {
+		const id = defaultOrderedIds[i];
+		if (placed.has(id)) {
+			continue;
+		}
+		let insertAt = 0;
+		for (let j = i - 1; j >= 0; j--) {
+			const idx = result.indexOf(defaultOrderedIds[j]);
+			if (idx !== -1) {
+				insertAt = idx + 1;
+				break;
+			}
+		}
+		result.splice(insertAt, 0, id);
+		placed.add(id);
+	}
+	return result;
+}
+
+/**
+ * Move `draggedId` before/after `targetId` within `order`. Returns the new
+ * array, or `undefined` when the target is not present.
+ */
+export function spliceSectionOrder(order: readonly string[], draggedId: string, targetId: string, position: 'before' | 'after'): string[] | undefined {
+	const without = order.filter(id => id !== draggedId);
+	const targetIndex = without.indexOf(targetId);
+	if (targetIndex === -1) {
+		return undefined;
+	}
+	const insertIndex = position === 'before' ? targetIndex : targetIndex + 1;
+	without.splice(insertIndex, 0, draggedId);
+	return without;
+}
+
+/**
+ * Merge a new order for a subset of identities (`visibleAfter`) into the full
+ * persisted order. Identities not in `visibleAfter` keep their relative
+ * position by staying anchored to the visible identity they previously
+ * followed (or the head, if they preceded all visible identities).
+ */
+export function mergeSectionOrder(persisted: readonly string[], visibleAfter: readonly string[]): string[] {
+	const scope = new Set(visibleAfter);
+	const head: string[] = [];
+	const trailing = new Map<string, string[]>();
+	let lastInScope: string | undefined;
+	for (const id of persisted) {
+		if (scope.has(id)) {
+			lastInScope = id;
+			continue;
+		}
+		if (lastInScope === undefined) {
+			head.push(id);
+		} else {
+			let arr = trailing.get(lastInScope);
+			if (!arr) {
+				arr = [];
+				trailing.set(lastInScope, arr);
+			}
+			arr.push(id);
+		}
+	}
+	const result: string[] = [...head];
+	for (const id of visibleAfter) {
+		result.push(id);
+		const t = trailing.get(id);
+		if (t) {
+			result.push(...t);
+		}
+	}
+	return result;
+}
+
+function arraysEqual(a: readonly string[], b: readonly string[]): boolean {
+	if (a.length !== b.length) {
+		return false;
+	}
+	for (let i = 0; i < a.length; i++) {
+		if (a[i] !== b[i]) {
+			return false;
+		}
+	}
+	return true;
+}
+
+//#endregion
+
+registerSingleton(ISessionSectionOrderService, SessionSectionOrderService, InstantiationType.Delayed);

--- a/src/vs/sessions/services/sessions/test/browser/sessionGroupsService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionGroupsService.test.ts
@@ -14,7 +14,7 @@ import { TestInstantiationService } from '../../../../../platform/instantiation/
 import { mock } from '../../../../../base/test/common/mock.js';
 import { IChat, ISession, SessionStatus } from '../../common/session.js';
 import { ISessionsChangeEvent, ISessionsManagementService } from '../../common/sessionsManagement.js';
-import { groupSortKey, SessionGroupsService } from '../../browser/sessionGroupsService.js';
+import { SessionGroupsService } from '../../browser/sessionGroupsService.js';
 
 function createSession(id: string): ISession {
 	return {
@@ -138,15 +138,6 @@ suite('SessionGroupsService', () => {
 		assert.strictEqual(service.getGroups().filter(g => service.getSessionIdsInGroup(g.id).length === 0).length, 3);
 	});
 
-	test('setGroupSortKey overrides placement and persists', () => {
-		const a = service.createGroup('A', ['s1']);
-		service.setGroupSortKey(a.id, 12345);
-		assert.strictEqual(service.getGroup(a.id)?.sortKeyOverride, 12345);
-
-		const reloaded = disposables.add(instantiationService.createInstance(SessionGroupsService));
-		assert.strictEqual(reloaded.getGroup(a.id)?.sortKeyOverride, 12345);
-	});
-
 	test('state persists across reload', () => {
 		const a = service.createGroup('Persisted', ['s1', 's2']);
 
@@ -154,10 +145,5 @@ suite('SessionGroupsService', () => {
 		assert.strictEqual(reloaded.getGroup(a.id)?.name, 'Persisted');
 		assert.strictEqual(reloaded.getGroupOfSession('s1'), a.id);
 		assert.strictEqual(reloaded.getGroupOfSession('s2'), a.id);
-	});
-
-	test('groupSortKey returns the highest member key', () => {
-		assert.strictEqual(groupSortKey([10, 50, 30]), 50);
-		assert.strictEqual(groupSortKey([]), undefined);
 	});
 });

--- a/src/vs/sessions/services/sessions/test/browser/sessionSectionOrderService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionSectionOrderService.test.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { mergeSectionOrder, resolveSectionOrder, spliceSectionOrder } from '../../browser/sessionSectionOrderService.js';
+
+suite('SessionSectionOrder Helpers', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('resolveSectionOrder', () => {
+
+		test('falls back to default order when nothing is persisted', () => {
+			assert.deepStrictEqual(resolveSectionOrder([], ['a', 'b', 'c']), ['a', 'b', 'c']);
+		});
+
+		test('applies the persisted order for live ids', () => {
+			assert.deepStrictEqual(resolveSectionOrder(['c', 'a', 'b'], ['a', 'b', 'c']), ['c', 'a', 'b']);
+		});
+
+		test('drops persisted ids that are no longer live', () => {
+			assert.deepStrictEqual(resolveSectionOrder(['x', 'c', 'a'], ['a', 'c']), ['c', 'a']);
+		});
+
+		test('weaves not-yet-seen ids in at their default position', () => {
+			// 'b' is new and defaults between 'a' and 'c'; persisted order is c,a.
+			assert.deepStrictEqual(resolveSectionOrder(['c', 'a'], ['a', 'b', 'c']), ['c', 'a', 'b']);
+		});
+
+		test('inserts a new leading default before the persisted block', () => {
+			assert.deepStrictEqual(resolveSectionOrder(['b', 'c'], ['a', 'b', 'c']), ['a', 'b', 'c']);
+		});
+	});
+
+	suite('spliceSectionOrder', () => {
+
+		test('moves before the target', () => {
+			assert.deepStrictEqual(spliceSectionOrder(['a', 'b', 'c'], 'c', 'a', 'before'), ['c', 'a', 'b']);
+		});
+
+		test('moves after the target', () => {
+			assert.deepStrictEqual(spliceSectionOrder(['a', 'b', 'c'], 'a', 'c', 'after'), ['b', 'c', 'a']);
+		});
+
+		test('returns undefined when the target is missing', () => {
+			assert.strictEqual(spliceSectionOrder(['a', 'b'], 'a', 'z', 'before'), undefined);
+		});
+	});
+
+	suite('mergeSectionOrder', () => {
+
+		test('uses the visible order directly when nothing else is persisted', () => {
+			assert.deepStrictEqual(mergeSectionOrder([], ['b', 'a']), ['b', 'a']);
+		});
+
+		test('keeps out-of-scope ids anchored to their visible predecessor', () => {
+			// 'w1' (out of scope) followed 'g1' in the persisted order; reordering
+			// the groups g1/g2 must keep 'w1' trailing g1.
+			const persisted = ['g1', 'w1', 'g2'];
+			const visibleAfter = ['g2', 'g1'];
+			assert.deepStrictEqual(mergeSectionOrder(persisted, visibleAfter), ['g2', 'g1', 'w1']);
+		});
+
+		test('keeps out-of-scope ids that precede all visible ids at the head', () => {
+			const persisted = ['w1', 'g1', 'g2'];
+			const visibleAfter = ['g2', 'g1'];
+			assert.deepStrictEqual(mergeSectionOrder(persisted, visibleAfter), ['w1', 'g2', 'g1']);
+		});
+	});
+});

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -464,6 +464,7 @@ import './contrib/providers/localChatSessions/browser/localChatSessions.contribu
 import './contrib/sessions/browser/sessions.contribution.js';
 import './services/sessions/browser/sessionsListModelService.js';
 import './services/sessions/browser/sessionGroupsService.js';
+import './services/sessions/browser/sessionSectionOrderService.js';
 import './services/agentHostFilter/browser/agentHostFilterService.js';
 import './contrib/sessions/browser/customizationsToolbar.contribution.js';
 import './contrib/changes/browser/changes.contribution.js';


### PR DESCRIPTION
## What

Adds drag & drop reordering of **workspace section headers** and **user-group headers** in the Agents window sessions list. Dragging a group/workspace header over another shows an insertion line above/below it to position it there.

### Behavior
- **By Workspace:** user groups and workspace sections share **one freely-intermixable, user-managed order** below Pinned. Groups default above workspaces; workspaces default alphabetical ("Unknown" last) until dragged. Dragging a workspace **promotes** it so it stays visible (escapes the "+N more workspaces" capping).
- **By Date:** user groups form a **contiguous, user-ordered block** directly below Pinned and never mix into the fixed date sections (Today/Yesterday/...). Only group headers are draggable in this mode.
- **Invariants:** Pinned is always first and Done always last; neither (nor the date sections, nor "show more" rows) is draggable or a valid drop target.
- **Groups are now fully user-managed:** their order no longer derives from member-session recency and is **shared across both grouping modes** (it also drives the "Add to Group" / "Move to Group" menu order).

## How
- New `ISessionSectionOrderService` (`services/sessions/browser/sessionSectionOrderService.ts`) owns the manual top-level order as an explicit list of identities (`group:<id>` / `workspace:<label>`) plus a promoted-workspaces set. Persisted locally (profile storage), not synced. Includes pure, unit-tested helpers (`resolveSectionOrder`, `spliceSectionOrder`, `mergeSectionOrder`) and stale-identity garbage collection.
- `sessionsList.ts`: generalized the DnD from group-only to any reorderable header (`reorderSection` + `IDraggedHeader`), made workspace headers draggable, and rewrote both render branches to use the resolved order (capturing a display-order snapshot for the drop math and applying workspace promotion to the capping).
- Removed the obsolete `sortKeyOverride` / `setGroupSortKey` / `groupSortKey` member-recency mechanism from `sessionGroupsService.ts`.
- Updated `SESSIONS_LIST.md` and added/adjusted unit tests.

## Notes for reviewers
- Design replaces an earlier numeric "midpoint sort key" approach with an explicit ordered-id list, which avoids mixed numeric-key-domain fragility and makes promotion independent of ordering.
- **Not validated locally** (no `npm install` in this environment): `npm run typecheck-client`, the sessions unit tests, and hygiene/lint were **not** run. IDE language-service diagnostics were clean across all touched files. Relying on CI for validation.
- Follow-up (not in this PR): keyboard-accessible reordering — kept parity with the existing DnD-only reordering for sessions; recommend adding "Move Up/Down" for sessions and headers together in a separate change.
