### PR TITLE
Add handling for editor frame border width in modern UI layout

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -1394,16 +1394,11 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 			width = Math.max(0, width - leftMargin - rightMargin);
 			height = Math.max(0, height - FLOATING_PANEL_MARGIN);
 
-			// In modern UI the editor area is framed as a card with a 1px border on every
-			// side (see `styleOverrides/media/editorBorder.css`). That border uses
-			// `box-sizing: border-box` so it paints inside the part without forcing a
-			// relayout, but the editor contents (grid, tabs and any webview overlays
-			// anchored to the editor) are laid out at the full part size and would
-			// otherwise overflow — and be clipped by — the right and bottom border,
-			// leaving an inconsistent gap around the content. Reserve the border
-			// thickness on each axis so the contents sit inside the frame symmetrically.
-			width = Math.max(0, width - EDITOR_FRAME_BORDER_WIDTH * 2);
-			height = Math.max(0, height - EDITOR_FRAME_BORDER_WIDTH * 2);
+			// Reserve space for the Modern UI editor border (styleOverrides/media/editorBorder.css) so content doesn't get clipped.
+			if (!this.element.classList.contains('modal-editor-part')) {
+				width = Math.max(0, width - EDITOR_FRAME_BORDER_WIDTH * 2);
+				height = Math.max(0, height - EDITOR_FRAME_BORDER_WIDTH * 2);
+			}
 
 			this.element.classList.toggle('floating-editor-outer-left', outerLeft);
 			this.element.classList.toggle('floating-editor-outer-right', outerRight);

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -37,6 +37,15 @@ import { ServiceCollection } from '../../../../platform/instantiation/common/ser
 import { EditorAreaFocusContext, EditorPartMaximizedEditorGroupContext, EditorPartMultipleEditorGroupsContext, EditorTabsVisibleContext, IsTopRightEditorGroupContext } from '../../../common/contextkeys.js';
 import { mainWindow } from '../../../../base/browser/window.js';
 
+/**
+ * The width (in pixels) of the editor card border drawn on every side when the
+ * Modern UI Update experiment is enabled (`styleOverrides/media/editorBorder.css`).
+ * The editor reserves this thickness when laying out its contents so they sit
+ * inside the frame instead of overflowing (and being clipped by) the border.
+ * Keep in sync with the `--vscode-strokeThickness` (1px) token used there.
+ */
+const EDITOR_FRAME_BORDER_WIDTH = 1;
+
 export interface IEditorPartUIState {
 	readonly serializedGrid: ISerializedGrid;
 	readonly activeGroup: GroupIdentifier;
@@ -1384,6 +1393,17 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 
 			width = Math.max(0, width - leftMargin - rightMargin);
 			height = Math.max(0, height - FLOATING_PANEL_MARGIN);
+
+			// In modern UI the editor area is framed as a card with a 1px border on every
+			// side (see `styleOverrides/media/editorBorder.css`). That border uses
+			// `box-sizing: border-box` so it paints inside the part without forcing a
+			// relayout, but the editor contents (grid, tabs and any webview overlays
+			// anchored to the editor) are laid out at the full part size and would
+			// otherwise overflow — and be clipped by — the right and bottom border,
+			// leaving an inconsistent gap around the content. Reserve the border
+			// thickness on each axis so the contents sit inside the frame symmetrically.
+			width = Math.max(0, width - EDITOR_FRAME_BORDER_WIDTH * 2);
+			height = Math.max(0, height - EDITOR_FRAME_BORDER_WIDTH * 2);
 
 			this.element.classList.toggle('floating-editor-outer-left', outerLeft);
 			this.element.classList.toggle('floating-editor-outer-right', outerRight);


### PR DESCRIPTION
This pull request introduces a layout adjustment to ensure that editor content is not clipped by the border when the Modern UI Update experiment is enabled. A constant is defined for the border width, and the editor's layout logic is updated to reserve space for the border on all sides.

**Editor border and layout adjustments:**

* Added a constant `EDITOR_FRAME_BORDER_WIDTH` (set to 1px) to represent the border thickness used by the Modern UI Update, ensuring consistency with the CSS variable `--vscode-strokeThickness`.
* Updated the editor layout logic to subtract the border width from both the width and height when the editor is not modal, preventing content from being clipped by the border.