### PR TITLE
sessions: manage side pane and responsive sidebar in the layout controller

### DIFF
--- a/src/vs/sessions/browser/layoutActions.ts
+++ b/src/vs/sessions/browser/layoutActions.ts
@@ -14,20 +14,14 @@ import { Menus } from './menus.js';
 import { ServicesAccessor } from '../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../platform/keybinding/common/keybindingsRegistry.js';
 import { registerIcon } from '../../platform/theme/common/iconRegistry.js';
-import { AuxiliaryBarVisibleContext, IsAuxiliaryWindowContext, IsSessionsWindowContext, IsTopRightEditorGroupContext, IsWindowAlwaysOnTopContext, MainEditorAreaVisibleContext, SideBarVisibleContext } from '../../workbench/common/contextkeys.js';
+import { AuxiliaryBarVisibleContext, IsAuxiliaryWindowContext, IsSessionsWindowContext, IsTopRightEditorGroupContext, IsWindowAlwaysOnTopContext, SideBarVisibleContext } from '../../workbench/common/contextkeys.js';
 import { IWorkbenchLayoutService, Parts } from '../../workbench/services/layout/browser/layoutService.js';
-import { IEditorGroupsService } from '../../workbench/services/editor/common/editorGroupsService.js';
 import { SessionsWelcomeVisibleContext } from '../common/contextkeys.js';
-import { logSidePanelToggle } from '../common/sessionsTelemetry.js';
-import { ITelemetryService } from '../../platform/telemetry/common/telemetry.js';
-import { mainWindow } from '../../base/browser/window.js';
 
 // Register Icons
 const panelCloseIcon = registerIcon('agent-panel-close', Codicon.close, localize('agentPanelCloseIcon', "Icon to close the panel."));
 const sidebarToggleClosedIcon = registerIcon('agent-sidebar-toggle-closed', Codicon.layoutSidebarLeftOff, localize('agentSidebarToggleClosedIcon', "Icon for the sessions sidebar when closed."));
 const sidebarToggleOpenIcon = registerIcon('agent-sidebar-toggle-open', Codicon.layoutSidebarLeft, localize('agentSidebarToggleOpenIcon', "Icon for the sessions sidebar when open."));
-const secondarySidebarToggleClosedIcon = registerIcon('agent-secondary-sidebar-toggle-closed', Codicon.layoutSidebarRightOff, localize('agentSecondarySidebarToggleClosedIcon', "Icon for the sessions secondary sidebar when closed."));
-const secondarySidebarToggleOpenIcon = registerIcon('agent-secondary-sidebar-toggle-open', Codicon.layoutSidebarRight, localize('agentSecondarySidebarToggleOpenIcon', "Icon for the sessions secondary sidebar when open."));
 
 class ToggleSidebarVisibilityAction extends Action2 {
 
@@ -76,93 +70,7 @@ class ToggleSidebarVisibilityAction extends Action2 {
 	}
 }
 
-class ToggleSidePanelAction extends Action2 {
-
-	static readonly ID = 'workbench.action.agentToggleSidePanel';
-
-	// Remembers which parts were visible when the side panel was last hidden, so
-	// re-opening restores the same parts instead of always showing both.
-	private _lastVisibleParts: { readonly editor: boolean; readonly auxiliaryBar: boolean } | undefined;
-
-	constructor() {
-		super({
-			id: ToggleSidePanelAction.ID,
-			title: localize2('toggleSecondarySidebar', 'Toggle Side Panel'),
-			icon: secondarySidebarToggleClosedIcon,
-			toggled: {
-				condition: ContextKeyExpr.or(AuxiliaryBarVisibleContext, MainEditorAreaVisibleContext)!,
-				icon: secondarySidebarToggleOpenIcon,
-			},
-			metadata: {
-				description: localize('openAndCloseSidePanel', 'Open/Show and Close/Hide the Side Panel (editor area and auxiliary bar)'),
-			},
-			category: Categories.View,
-			f1: true,
-			keybinding: {
-				weight: KeybindingWeight.SessionsContrib,
-				primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyB
-			},
-			menu: [
-				{
-					id: Menus.TitleBarSessionMenu,
-					group: 'navigation',
-					order: 11, // After Open in VS Code (7), Run Script (8), and Open Terminal (10)
-					when: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated())
-				}
-			]
-		});
-	}
-
-	run(accessor: ServicesAccessor): void {
-		const layoutService = accessor.get(IWorkbenchLayoutService);
-		const editorGroupService = accessor.get(IEditorGroupsService);
-		const telemetryService = accessor.get(ITelemetryService);
-
-		// The "side panel" is the editor area together with the auxiliary bar.
-		// Treat it as visible when *either* part is visible so the toggle always
-		// closes both, instead of just revealing the auxiliary bar on top of an
-		// already-visible editor area.
-		const editorVisible = layoutService.isVisible(Parts.EDITOR_PART, mainWindow);
-		const auxiliaryBarVisible = layoutService.isVisible(Parts.AUXILIARYBAR_PART);
-		const isCurrentlyVisible = editorVisible || auxiliaryBarVisible;
-
-		// When hiding and unhiding editor part and auxiliary bar, hiding must be done
-		// in the opposite order than showing for sizing to restore correct dimensions.
-		if (isCurrentlyVisible) {
-			// Remember what was visible so re-opening restores exactly these parts.
-			this._lastVisibleParts = { editor: editorVisible, auxiliaryBar: auxiliaryBarVisible };
-			layoutService.setPartHidden(true, Parts.AUXILIARYBAR_PART);
-			layoutService.setPartHidden(true, Parts.EDITOR_PART);
-		} else {
-			// Restore only the parts that were visible before hiding (default to
-			// both when there is no remembered state, e.g. after a reload).
-			const restore = this._lastVisibleParts ?? { editor: true, auxiliaryBar: true };
-			const hasEditors = editorGroupService.groups.some(group => !group.isEmpty);
-			if (restore.editor && hasEditors) {
-				layoutService.setPartHidden(false, Parts.EDITOR_PART);
-			}
-			if (restore.auxiliaryBar) {
-				layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
-			}
-			// Ensure the toggle always has a visible effect (e.g. the remembered
-			// state was editor-only but there are no editors to show now).
-			if (!layoutService.isVisible(Parts.EDITOR_PART, mainWindow) && !layoutService.isVisible(Parts.AUXILIARYBAR_PART)) {
-				layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
-			}
-		}
-
-		logSidePanelToggle(telemetryService, !isCurrentlyVisible);
-
-		// Announce visibility change to screen readers
-		const alertMessage = isCurrentlyVisible
-			? localize('sidePanelHidden', "Side Panel hidden")
-			: localize('sidePanelVisible', "Side Panel shown");
-		alert(alertMessage);
-	}
-}
-
 registerAction2(ToggleSidebarVisibilityAction);
-registerAction2(ToggleSidePanelAction);
 
 // The editor-title secondary side bar toggle reuses the core `workbench.action.toggleAuxiliaryBar`
 // command (registered by the workbench auxiliary bar part, which is also loaded in the agents

--- a/src/vs/sessions/contrib/changes/browser/changes.contribution.ts
+++ b/src/vs/sessions/contrib/changes/browser/changes.contribution.ts
@@ -6,20 +6,24 @@
 import { Codicon } from '../../../../base/common/codicons.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js';
 import { IViewContainersRegistry, ViewContainerLocation, IViewsRegistry, Extensions as ViewContainerExtensions, WindowEnablement } from '../../../../workbench/common/views.js';
 import { CHANGES_VIEW_CONTAINER_ID, CHANGES_VIEW_ID, SESSIONS_CHANGES_OPEN_SINGLE_FILE_DIFF_SETTING } from '../common/changes.js';
 import { ChangesViewPane, ChangesViewPaneContainer } from './changesView.js';
 import { IsPhoneLayoutContext } from '../../../common/contextkeys.js';
+import { ISessionChangesService, SessionChangesService } from './sessionChangesService.js';
 import './changesActions.js';
 import './changesViewActions.js';
 import './checksActions.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
-import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { ChangesViewService } from './changesViewService.js';
 import { IChangesViewService } from '../common/changesViewService.js';
+
+registerSingleton(ISessionChangesService, SessionChangesService, InstantiationType.Delayed);
+
 
 const changesViewIcon = registerIcon('changes-view-icon', Codicon.gitCompare, localize2('changesViewIcon', 'View icon for the Changes view.').value);
 

--- a/src/vs/sessions/contrib/changes/browser/changesActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesActions.ts
@@ -16,7 +16,6 @@ import { Action2, MenuItemAction, registerAction2 } from '../../../../platform/a
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
-import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
 import { Menus } from '../../../browser/menus.js';
 import { SessionHeaderMetaActionViewItem } from '../../../browser/parts/sessionHeaderMetaActionViewItem.js';
 import { SessionHasChangesContext } from '../../../common/contextkeys.js';
@@ -24,8 +23,8 @@ import { ISessionContext } from '../../../services/sessions/browser/sessionConte
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { IActiveSession } from '../../../services/sessions/common/sessionsManagement.js';
 import { BRANCH_CHANGES_CHANGESET_ID } from '../../../services/sessions/common/session.js';
-import { CHANGES_VIEW_ID } from '../common/changes.js';
-import { ChangesMultiDiffSourceResolver, getChangesMultiDiffSourceUri } from './changesMultiDiffSourceResolver.js';
+import { ChangesMultiDiffSourceResolver } from './changesMultiDiffSourceResolver.js';
+import { ISessionChangesService } from './sessionChangesService.js';
 
 // --- View All Changes action
 
@@ -53,7 +52,7 @@ class ViewAllChangesAction extends Action2 {
 	override async run(accessor: ServicesAccessor, session?: IActiveSession): Promise<void> {
 		const editorService = accessor.get(IEditorService);
 		const sessionsService = accessor.get(ISessionsService);
-		const viewsService = accessor.get(IViewsService);
+		const sessionChangesService = accessor.get(ISessionChangesService);
 
 		// The clicked session is forwarded as the argument by the session header,
 		// which has already promoted it to be the active session. Fall back to the
@@ -63,17 +62,11 @@ class ViewAllChangesAction extends Action2 {
 			return;
 		}
 
-		// Reveal the Changes view in the auxiliary bar (the 3rd pane). The user
-		// expects clicking Changes to bring back the side pane even if they had
-		// previously closed it, so always reveal it here rather than relying on the
-		// per-session saved visibility.
-		await viewsService.openView(CHANGES_VIEW_ID, false);
-
 		// Open the multi-file diff editor in the editor part. The resource list is
 		// resolved reactively via the `ChangesMultiDiffSourceResolver` registered as
 		// a workbench contribution.
 		await editorService.openEditor({
-			multiDiffSource: getChangesMultiDiffSourceUri(sessionResource),
+			multiDiffSource: sessionChangesService.getChangesEditorResource(sessionResource),
 			label: localize('sessions.changes.title', 'Session Changes'),
 		});
 	}

--- a/src/vs/sessions/contrib/changes/browser/changesMultiDiffSourceResolver.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesMultiDiffSourceResolver.ts
@@ -13,43 +13,7 @@ import { isIChatSessionFileChange2 } from '../../../../workbench/contrib/chat/co
 import { IMultiDiffSourceResolver, IMultiDiffSourceResolverService, IResolvedMultiDiffSource, MultiDiffEditorItem } from '../../../../workbench/contrib/multiDiffEditor/browser/multiDiffSourceResolverService.js';
 import { ISessionFileChange } from '../../../services/sessions/common/session.js';
 import { IChangesViewService } from '../common/changesViewService.js';
-
-const CHANGES_MULTI_DIFF_SOURCE_SCHEME = 'changes-multi-diff-source';
-
-interface ChangesMultiDiffUriFields {
-	readonly sessionResource: string;
-}
-
-/**
- * Build the multi-diff source URI for a session. The URI is used to identify
- * the multi-diff editor so subsequent opens with the same session reuse the
- * same input while the resource list updates reactively.
- */
-export function getChangesMultiDiffSourceUri(sessionResource: URI): URI {
-	return URI.from({
-		scheme: CHANGES_MULTI_DIFF_SOURCE_SCHEME,
-		query: JSON.stringify({ sessionResource: sessionResource.toString() } satisfies ChangesMultiDiffUriFields),
-	});
-}
-
-function parseUri(uri: URI): { sessionResource: URI } | undefined {
-	if (uri.scheme !== CHANGES_MULTI_DIFF_SOURCE_SCHEME) {
-		return undefined;
-	}
-
-	let query: ChangesMultiDiffUriFields;
-	try {
-		query = JSON.parse(uri.query) as ChangesMultiDiffUriFields;
-	} catch {
-		return undefined;
-	}
-
-	if (typeof query !== 'object' || query === null || typeof query.sessionResource !== 'string') {
-		return undefined;
-	}
-
-	return { sessionResource: URI.parse(query.sessionResource) };
-}
+import { ISessionChangesService } from './sessionChangesService.js';
 
 function compareChanges(a: ISessionFileChange, b: ISessionFileChange): number {
 	const aPath = isIChatSessionFileChange2(a) ? a.uri.fsPath : a.modifiedUri.fsPath;
@@ -62,17 +26,18 @@ export class ChangesMultiDiffSourceResolver extends Disposable implements IMulti
 	constructor(
 		@IChangesViewService private readonly changesViewService: IChangesViewService,
 		@IMultiDiffSourceResolverService multiDiffSourceResolverService: IMultiDiffSourceResolverService,
+		@ISessionChangesService private readonly _sessionChangesService: ISessionChangesService,
 	) {
 		super();
 		this._register(multiDiffSourceResolverService.registerResolver(this));
 	}
 
 	canHandleUri(uri: URI): boolean {
-		return parseUri(uri) !== undefined;
+		return this._sessionChangesService.getSessionResource(uri) !== undefined;
 	}
 
 	async resolveDiffSource(uri: URI): Promise<IResolvedMultiDiffSource> {
-		const parsed = parseUri(uri)!;
+		const sessionResource = this._sessionChangesService.getSessionResource(uri)!;
 
 		const changesObs = derivedObservableWithCache<readonly ISessionFileChange[]>({
 			owner: this,
@@ -82,7 +47,7 @@ export class ChangesMultiDiffSourceResolver extends Disposable implements IMulti
 			}
 
 			const activeSessionResource = this.changesViewService.activeSessionResourceObs.read(reader);
-			if (!activeSessionResource || !isEqual(activeSessionResource, parsed.sessionResource)) {
+			if (!activeSessionResource || !isEqual(activeSessionResource, sessionResource)) {
 				return lastValue ?? [];
 			}
 

--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -56,7 +56,7 @@ import { IExtensionService } from '../../../../workbench/services/extensions/com
 import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { IMultiDiffEditorOptions } from '../../../../editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.js';
 import { getChangesEditorLabels } from './changesEditorLabels.js';
-import { getChangesMultiDiffSourceUri } from './changesMultiDiffSourceResolver.js';
+import { ISessionChangesService } from './sessionChangesService.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { CIStatusWidget } from './checksWidget.js';
 import { GITHUB_REMOTE_FILE_SCHEME, ISessionChangesetOperation, SessionChangesetOperationScope, SessionChangesetOperationStatus, SessionStatus } from '../../../services/sessions/common/session.js';
@@ -400,6 +400,7 @@ export class ChangesViewPane extends ViewPane {
 		@ILabelService private readonly labelService: ILabelService,
 		@ILogService private readonly logService: ILogService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
+		@ISessionChangesService private readonly sessionChangesService: ISessionChangesService,
 	) {
 		super({ ...options, titleMenuId: MenuId.ChatEditingSessionTitleToolbar }, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, hoverService);
 
@@ -1236,7 +1237,7 @@ export class ChangesViewPane extends ViewPane {
 		// list is resolved via `SessionsMultiDiffSourceResolver` and updates
 		// reactively as `activeSessionChangesObs` changes.
 		await this.editorService.openEditor({
-			multiDiffSource: getChangesMultiDiffSourceUri(sessionResource),
+			multiDiffSource: this.sessionChangesService.getChangesEditorResource(sessionResource),
 			label: localize('sessions.changes.title', 'Session Changes'),
 			options,
 		});

--- a/src/vs/sessions/contrib/changes/browser/sessionChangesService.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionChangesService.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../../base/common/uri.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+
+export const ISessionChangesService = createDecorator<ISessionChangesService>('sessionChangesService');
+
+/**
+ * Owns the identity of a session's **Changes** (multi-file diff) editor. It is
+ * the single source of truth for the `changes-multi-diff-source:` resource that
+ * the multi-diff editor is opened with, so callers don't have to know the URI
+ * shape: the session header action and the Changes view open the editor with
+ * {@link getChangesEditorResource}, the layout controller recognizes the active
+ * editor as a Changes editor with {@link getSessionResource}, and the
+ * multi-diff source resolver uses both.
+ */
+export interface ISessionChangesService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Build the multi-diff source URI that identifies the Changes editor for a
+	 * session. Opening an editor with this resource shows the session's changes;
+	 * reusing the same URI reuses the same editor input while the resource list
+	 * updates reactively.
+	 */
+	getChangesEditorResource(sessionResource: URI): URI;
+
+	/**
+	 * If the given editor resource identifies a session Changes editor (one built
+	 * by {@link getChangesEditorResource}), return the session it belongs to;
+	 * otherwise `undefined`.
+	 */
+	getSessionResource(editorResource: URI): URI | undefined;
+}
+
+const CHANGES_MULTI_DIFF_SOURCE_SCHEME = 'changes-multi-diff-source';
+
+interface IChangesMultiDiffUriFields {
+	readonly sessionResource: string;
+}
+
+export class SessionChangesService implements ISessionChangesService {
+
+	declare readonly _serviceBrand: undefined;
+
+	getChangesEditorResource(sessionResource: URI): URI {
+		return URI.from({
+			scheme: CHANGES_MULTI_DIFF_SOURCE_SCHEME,
+			query: JSON.stringify({ sessionResource: sessionResource.toString() } satisfies IChangesMultiDiffUriFields),
+		});
+	}
+
+	getSessionResource(editorResource: URI): URI | undefined {
+		if (editorResource.scheme !== CHANGES_MULTI_DIFF_SOURCE_SCHEME) {
+			return undefined;
+		}
+
+		let fields: IChangesMultiDiffUriFields;
+		try {
+			fields = JSON.parse(editorResource.query) as IChangesMultiDiffUriFields;
+		} catch {
+			return undefined;
+		}
+
+		if (typeof fields !== 'object' || fields === null || typeof fields.sessionResource !== 'string') {
+			return undefined;
+		}
+
+		return URI.parse(fields.sessionResource);
+	}
+}

--- a/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
@@ -4,25 +4,44 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { mainWindow } from '../../../../base/browser/window.js';
+import { alert } from '../../../../base/browser/ui/aria/aria.js';
 import { isThenable, Sequencer } from '../../../../base/common/async.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { autorun, derived, derivedObservableWithCache, derivedOpts, observableFromEvent, runOnChange } from '../../../../base/common/observable.js';
 import { isEqual } from '../../../../base/common/resources.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../base/common/map.js';
 import { URI } from '../../../../base/common/uri.js';
+import { localize, localize2 } from '../../../../nls.js';
+import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
+import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { observableConfigValue } from '../../../../platform/observable/common/platformObservableUtils.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { AuxiliaryBarVisibleContext, IsAuxiliaryWindowContext, MainEditorAreaVisibleContext } from '../../../../workbench/common/contextkeys.js';
 import { IEditorGroupsService, IEditorWorkingSet } from '../../../../workbench/services/editor/common/editorGroupsService.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
 import { Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { IPaneCompositePartService } from '../../../../workbench/services/panecomposite/browser/panecomposite.js';
 import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
 import { IAgentWorkbenchLayoutService } from '../../../browser/workbench.js';
+import { Menus } from '../../../browser/menus.js';
+import { SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
+import { logSidePanelToggle } from '../../../common/sessionsTelemetry.js';
+import { ISessionChangesService } from '../../changes/browser/sessionChangesService.js';
 import { IActiveSession, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { SessionStatus } from '../../../services/sessions/common/session.js';
+
+const secondarySidebarToggleClosedIcon = registerIcon('agent-secondary-sidebar-toggle-closed', Codicon.layoutSidebarRightOff, localize('agentSecondarySidebarToggleClosedIcon', "Icon for the sessions secondary sidebar when closed."));
+const secondarySidebarToggleOpenIcon = registerIcon('agent-secondary-sidebar-toggle-open', Codicon.layoutSidebarRight, localize('agentSecondarySidebarToggleOpenIcon', "Icon for the sessions secondary sidebar when open."));
 
 /**
  * Per-session view state: auxiliary bar visibility and active view container.
@@ -81,6 +100,20 @@ export abstract class BaseLayoutController extends Disposable {
 		return this._restoringSessionLayoutDepth > 0;
 	}
 
+	/**
+	 * [D9] `true` while {@link toggleSidePane} hides/shows the editor + auxiliary
+	 * bar together. The desktop controller's per-session aux-bar capture skips
+	 * this window, so toggling the whole side pane is never recorded as an
+	 * aux-bar choice.
+	 */
+	protected _togglingSidePane = false;
+
+	/**
+	 * Remembers which parts were visible when the side pane was last hidden, so
+	 * re-opening restores the same parts instead of always showing both.
+	 */
+	private _lastVisibleSidePaneParts: { readonly editor: boolean; readonly auxiliaryBar: boolean } | undefined;
+
 	private readonly _useModalConfigObs;
 	constructor(
 
@@ -91,9 +124,10 @@ export abstract class BaseLayoutController extends Disposable {
 		@IPaneCompositePartService protected readonly _paneCompositePartService: IPaneCompositePartService,
 		@IStorageService protected readonly _storageService: IStorageService,
 		@IConfigurationService protected readonly _configurationService: IConfigurationService,
-		@IEditorService private readonly _editorService: IEditorService,
+		@IEditorService protected readonly _editorService: IEditorService,
 		@IEditorGroupsService private readonly _editorGroupsService: IEditorGroupsService,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		@ISessionChangesService protected readonly _sessionChangesService: ISessionChangesService,
 	) {
 		super();
 
@@ -216,8 +250,62 @@ export abstract class BaseLayoutController extends Disposable {
 			}));
 		}));
 
+		// Side-pane toggle UI (menu item, keybinding, command-palette entry).
+		this._register(this._registerSidePaneToggleAction());
+
 		// Platform-specific auxiliary bar / view-state management.
 		this._registerViewStateManagement();
+	}
+
+	/**
+	 * Registers the `Toggle Side Panel` action (menu item, keybinding,
+	 * command-palette entry). The action delegates straight to `toggleSidePane()`,
+	 * so no command/service indirection is needed; the controller owns the toggle
+	 * behaviour and its memory.
+	 */
+	private _registerSidePaneToggleAction(): IDisposable {
+		const that = this;
+		return registerAction2(class extends Action2 {
+			constructor() {
+				super({
+					id: 'workbench.action.agentToggleSidePanel',
+					title: localize2('toggleSecondarySidebar', 'Toggle Side Panel'),
+					icon: secondarySidebarToggleClosedIcon,
+					toggled: {
+						condition: ContextKeyExpr.or(AuxiliaryBarVisibleContext, MainEditorAreaVisibleContext)!,
+						icon: secondarySidebarToggleOpenIcon,
+					},
+					metadata: {
+						description: localize('openAndCloseSidePanel', 'Open/Show and Close/Hide the Side Panel (editor area and auxiliary bar)'),
+					},
+					category: Categories.View,
+					f1: true,
+					keybinding: {
+						weight: KeybindingWeight.SessionsContrib,
+						primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyB
+					},
+					menu: [
+						{
+							id: Menus.TitleBarSessionMenu,
+							group: 'navigation',
+							order: 11, // After Open in VS Code (7), Run Script (8), and Open Terminal (10)
+							when: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated())
+						}
+					]
+				});
+			}
+
+			run(accessor: ServicesAccessor): void {
+				const nowVisible = that.toggleSidePane();
+
+				logSidePanelToggle(accessor.get(ITelemetryService), nowVisible);
+
+				// Announce visibility change to screen readers
+				alert(nowVisible
+					? localize('sidePanelVisible', "Side Panel shown")
+					: localize('sidePanelHidden', "Side Panel hidden"));
+			}
+		});
 	}
 
 	/**
@@ -226,6 +314,55 @@ export abstract class BaseLayoutController extends Disposable {
 	 * implementation does nothing.
 	 */
 	protected _registerViewStateManagement(): void { }
+
+	/**
+	 * Toggle the **side pane** — the editor area together with the auxiliary bar.
+	 * Closing it hides both; re-opening restores exactly the parts that were
+	 * visible when it was last closed (defaulting to both). The whole operation
+	 * runs under {@link _togglingSidePane} so the desktop controller does not
+	 * record it as a per-session aux-bar choice ([D9]). Returns `true` if the
+	 * side pane is now visible.
+	 */
+	toggleSidePane(): boolean {
+		this._togglingSidePane = true;
+		try {
+			// Treat the side pane as visible when *either* part is visible so the
+			// toggle always closes both, instead of just revealing the auxiliary
+			// bar on top of an already-visible editor area.
+			const editorVisible = this._layoutService.isVisible(Parts.EDITOR_PART, mainWindow);
+			const auxiliaryBarVisible = this._layoutService.isVisible(Parts.AUXILIARYBAR_PART);
+			const isCurrentlyVisible = editorVisible || auxiliaryBarVisible;
+
+			// When hiding and unhiding the editor part and auxiliary bar, hiding
+			// must be done in the opposite order than showing for sizing to restore
+			// correct dimensions.
+			if (isCurrentlyVisible) {
+				this._lastVisibleSidePaneParts = { editor: editorVisible, auxiliaryBar: auxiliaryBarVisible };
+				this._layoutService.setPartHidden(true, Parts.AUXILIARYBAR_PART);
+				this._layoutService.setPartHidden(true, Parts.EDITOR_PART);
+			} else {
+				// Restore only the parts that were visible before hiding (default to
+				// both when there is no remembered state, e.g. after a reload).
+				const restore = this._lastVisibleSidePaneParts ?? { editor: true, auxiliaryBar: true };
+				const hasEditors = this._editorGroupsService.groups.some(group => !group.isEmpty);
+				if (restore.editor && hasEditors) {
+					this._layoutService.setPartHidden(false, Parts.EDITOR_PART);
+				}
+				if (restore.auxiliaryBar) {
+					this._layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
+				}
+				// Ensure the toggle always has a visible effect (e.g. the remembered
+				// state was editor-only but there are no editors to show now).
+				if (!this._layoutService.isVisible(Parts.EDITOR_PART, mainWindow) && !this._layoutService.isVisible(Parts.AUXILIARYBAR_PART)) {
+					this._layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
+				}
+			}
+
+			return !isCurrentlyVisible;
+		} finally {
+			this._togglingSidePane = false;
+		}
+	}
 
 	/**
 	 * [B4] Hook that lets a subclass snapshot the active session's view state when

--- a/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.md
+++ b/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.md
@@ -27,7 +27,26 @@ On leaving a session, its current side-pane state is captured for that session.
 
 #### D2 — Immediately when you toggle it
 Opening or closing the side pane is captured right away, not only when you switch sessions. This is
-suspended while multiple sessions are visible or while the editor is maximized (D5).
+suspended while multiple sessions are visible, while the editor is maximized (D5), while the
+controller hides the side pane to restore a session's remembered state (so a restore-driven hide is
+never recorded as a new choice), and when the whole side pane is closed at once (D9).
+
+### Scenario: opening the Changes editor
+The session header's **Changes** button opens the multi-file diff editor in the editor area.
+
+#### D8 — Opening the Changes editor shows the side pane
+When a Changes editor is opened for an existing session, the side pane opens to the **Changes** view —
+the **first** time (no remembered choice yet) and again after the whole side pane was closed (D9). If
+you explicitly closed just the side pane (while keeping the editor open), it stays closed on later
+opens (and across reloads). An already-open side pane is left on whatever view you chose. Skipped while
+the editor is maximized (D5) or multiple sessions are visible, where the side pane is managed by other
+rules.
+
+#### D9 — Closing the whole side pane is not an aux-bar choice
+The "side pane" is the editor area together with the auxiliary bar. Closing it (e.g. from the side
+panel toggle) hides both at once. That is **not** remembered as a choice to hide the side pane for the
+session, so reopening the Changes editor shows it again (D8). Only hiding the auxiliary bar on its own,
+while the editor stays open, is remembered as an explicit "closed" choice.
 
 ### Scenario: returning to a session
 When you focus a session, its side pane is restored from the state remembered above.
@@ -94,9 +113,11 @@ defaults **on** in non-stable builds (Insiders / exploration) and **off** in sta
   `auxiliaryBarActiveViewContainerId`; also used by the base save-time hook (B4) via
   `_captureActiveSessionViewState`.
 - **Live tracking [D2]** — `onDidChangePartVisibility` listener for `AUXILIARYBAR_PART`, skipped while
-  multiple sessions are visible or the editor is maximized; updates `_captureViewState` (titled) or
-  `_newSessionViewState` (uncreated). When a created session is revealed from hidden saved state, the
-  saved/default active container is restored before capture.
+  multiple sessions are visible, the editor is maximized, `_togglingSidePane` is set (the side-pane
+  toggle, D9), or `_hidingAuxiliaryBarForRestore` is set (the restore-driven hide routes through
+  `_hideAuxiliaryBarForRestore`); updates `_captureViewState` (created) or `_setNewSessionViewState`
+  (uncreated). When a created session is revealed from hidden saved state, the saved/default active
+  container is restored before capture (`_restoreSavedAuxiliaryBarContainerOnReveal`).
 - **Restore [D3]** — `_syncAuxiliaryBarVisibility(resource, hasWorkspace, isCreated)`.
   Uncreated sessions (D3b) share `_newSessionViewState`, persisted under
   `sessions.newSessionViewState`. `_openDefaultAuxiliaryBarContainer` /
@@ -111,16 +132,36 @@ defaults **on** in non-stable builds (Insiders / exploration) and **off** in sta
   its previous width.
 - **No auto-reveal [D6]** — the sync logic never opens the side pane or switches the active container
   in response to file changes; only D3b opens it, and D4 switches it to Changes.
+- **First Changes open [D8]** — `_revealChangesViewOnFirstOpen`, registered on
+  `IEditorService.onDidActiveEditorChange` **and** on `onDidChangePartVisibility` for `EDITOR_PART`
+  becoming visible. The latter covers re-clicking the **Changes** button after the whole side pane was
+  closed (D9): the Changes editor is still the active editor (only hidden), so re-opening it re-reveals
+  the editor part without firing an active-editor change. The reveal is skipped while `_togglingSidePane`
+  is set so re-opening the side pane via the toggle restores exactly `_lastVisibleSidePaneParts` instead.
+  It recognizes a Changes editor via `ISessionChangesService.getSessionResource` (the multi-diff source
+  URI's session), and opens `CHANGES_VIEW_ID` when that session is the active titled session and neither
+  maximize (D5) nor multi-session mode is active, unless the session's `_viewStateBySession` entry
+  explicitly has `auxiliaryBarVisible: false`, or the aux bar is already visible. The reveal flows through
+  the [D2] listener, which records `{ auxiliaryBarVisible: true }`.
+- **Side-pane close [D9]** — the side-pane toggle lives on the controller (`toggleSidePane`). Its UI
+  entry point (the `Toggle Side Panel` action: menu item, keybinding, command-palette entry, toggled
+  icon) is registered by the base controller in its constructor and calls `toggleSidePane` directly.
+  The toggle hides/shows the editor area and auxiliary bar together (remembering which parts to restore
+  in `_lastVisibleSidePaneParts`) while `_togglingSidePane` is set. The [D2] listener skips capture
+  while that flag is set, so closing or opening the whole side pane is never recorded as a per-session
+  aux-bar choice.
 - **Responsive sidebar [D7]** — `_registerResponsiveSidebar` derives `spaceConstrained = enabled && small
   && editor visible && aux-bar visible && !multipleSessionsVisible` from the experimental setting
   `sessions.layout.autoCollapseSessionsSidebar` (`observableConfigValue`, default `product.quality !==
   'stable'`), `onDidLayoutMainContainer` (width `<= SMALL_WINDOW_MAX_WIDTH`, 1800) and
   `onDidChangePartVisibility`. An autorun acts only on real transitions of that derived (skipped while the
-  editor is maximized): constrained → `_setSidebarAutoHidden(true)`, un-constrained →
-  `_setSidebarAutoHidden(false)` unless `_userClosedSidebar`. A separate `onDidChangePartVisibility`
-  listener for `SIDEBAR_PART` records manual toggles into `_userClosedSidebar` (a manual open clears it),
-  guarded by `_applyingAutoSidebar` so the controller's own toggles aren't mistaken for user intent;
-  maximize's own sidebar enter/restore toggles self-cancel through this listener. While restoring a
+  editor is maximized): constrained → if `_setSidebarAutoHidden(true)` actually hid a visible sidebar it sets
+  `_sidebarAutoHidden`, un-constrained → `_setSidebarAutoHidden(false)` only when `_sidebarAutoHidden` (i.e. the
+  controller hid it). A separate `onDidChangePartVisibility` listener for `SIDEBAR_PART` clears
+  `_sidebarAutoHidden` on any manual toggle so the user keeps control, guarded by `_applyingAutoSidebar` so the
+  controller's own toggles aren't mistaken for user intent; maximize's own sidebar enter/restore toggles
+  self-cancel through this listener. Because only controller-driven hides are auto-reverted, a sidebar that was
+  already closed before a reload (in-memory `_sidebarAutoHidden` resets to `false`) is never auto-revealed. While restoring a
   session's layout the autorun re-baselines instead of reacting. The restore epoch lives in the base
   controller (`_withSessionLayoutRestore` / `_isRestoringSessionLayout`) and wraps **both** the desktop
   [D3] aux-bar restore (`_onNewSessionSubmitted`, `_syncAuxiliaryBarVisibility`) **and** the base [B2]

--- a/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
@@ -99,7 +99,7 @@ export class LayoutController extends BaseLayoutController {
 			if (editorMaximized) {
 				previousSessionResource = activeSessionResource;
 				previousIsCreated = isCreated;
-				this._viewsService.openView(CHANGES_VIEW_ID, false);
+				void this._viewsService.openView(CHANGES_VIEW_ID, false);
 				return;
 			}
 
@@ -245,7 +245,7 @@ export class LayoutController extends BaseLayoutController {
 				return;
 			}
 		}
-		this._viewsService.openView(CHANGES_VIEW_ID, false);
+		void this._viewsService.openView(CHANGES_VIEW_ID, false);
 	}
 
 	/**

--- a/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
@@ -44,7 +44,7 @@ export const RESPONSIVE_SIDEBAR_SETTING = 'sessions.layout.autoCollapseSessionsS
  * {@link BaseLayoutController}, it manages the per-session auxiliary bar
  * visibility and active view container.
  *
- * Its behaviour is enumerated as rules **D1-D7** in
+ * Its behaviour is enumerated as rules **D1-D9** in
  * [desktopSessionLayoutController.md](./desktopSessionLayoutController.md).
  */
 export class LayoutController extends BaseLayoutController {
@@ -57,12 +57,15 @@ export class LayoutController extends BaseLayoutController {
 	 */
 	private _newSessionViewState: INewSessionViewState | undefined;
 
-	/** [D7] `true` once the user manually closed the sidebar; suppresses auto-open until they open it again. */
-	private _userClosedSidebar = false;
+	/** [D7] `true` while the sidebar is hidden because the controller auto-hid it (space constrained); only such hides are auto-reverted. */
+	private _sidebarAutoHidden = false;
 	/** [D7] Guards the manual-toggle listener while the controller itself toggles the sidebar. */
 	private _applyingAutoSidebar = false;
 	/** [D7] Last computed space-constrained state, so the autorun only acts on real transitions. */
 	private _previousSpaceConstrained = false;
+
+	/** [D2/D8] `true` while the controller hides the side pane to restore a session's remembered state, so the hide isn't captured as a user choice. */
+	private _hidingAuxiliaryBarForRestore = false;
 
 	protected override _registerViewStateManagement(): void {
 		this._loadNewSessionViewState();
@@ -142,6 +145,19 @@ export class LayoutController extends BaseLayoutController {
 			if (e.partId !== Parts.AUXILIARYBAR_PART) {
 				return;
 			}
+			// [D9] Toggling the whole side pane (editor + aux bar together) hides or
+			// shows the aux bar as a side effect, not as a per-session choice, so
+			// don't record it.
+			if (this._togglingSidePane) {
+				return;
+			}
+			// A restore-driven hide replays the remembered state rather than
+			// reacting to a user action, so don't record it as a new per-session
+			// choice (this keeps "no remembered choice yet" meaningful for the
+			// first-time Changes reveal, D8).
+			if (this._hidingAuxiliaryBarForRestore) {
+				return;
+			}
 			if (this.multipleSessionsVisibleObs.get()) {
 				return;
 			}
@@ -164,10 +180,73 @@ export class LayoutController extends BaseLayoutController {
 			}
 		}));
 
+		// [D8] Reveal the Changes view in the side pane the first time a Changes
+		// editor is opened for an existing session; afterwards respect the
+		// remembered per-session choice (D1/D2/D3).
+		this._register(this._editorService.onDidActiveEditorChange(() => this._revealChangesViewOnFirstOpen()));
+
+		// [D8] Re-opening the Changes editor while it is already the active editor
+		// (e.g. after the whole side pane was closed, which only hides the editor
+		// part) re-reveals the editor part without firing an active-editor change,
+		// so also react to the editor part becoming visible.
+		this._register(this._layoutService.onDidChangePartVisibility(e => {
+			if (e.partId === Parts.EDITOR_PART && e.visible) {
+				this._revealChangesViewOnFirstOpen();
+			}
+		}));
+
 		this._registerResponsiveSidebar();
 	}
 
-	// --- Responsive sessions sidebar [D7] ---
+	/**
+	 * [D8] When a Changes (multi-diff) editor is opened (becomes active, or its
+	 * editor part is re-revealed) for an existing session, show the Changes view
+	 * in the side pane unless the user explicitly hid the aux bar for that
+	 * session. This reveals it the first time (no remembered choice) and again
+	 * after the whole side pane was closed (D9, which keeps the remembered choice
+	 * "open"), but respects an explicit aux-bar-hidden choice. The reveal is
+	 * captured by [D2]. Skipped while a side-pane toggle is in progress (so the
+	 * toggle restores exactly the remembered parts, D9), while the editor is
+	 * maximized (D5) or while multiple sessions are visible, where the side pane
+	 * is managed by other rules.
+	 */
+	private _revealChangesViewOnFirstOpen(): void {
+		// A side-pane toggle restores exactly the remembered parts; don't let the
+		// editor part it reveals force the Changes view open (D9).
+		if (this._togglingSidePane) {
+			return;
+		}
+		const activeEditorResource = this._editorService.activeEditor?.resource;
+		if (!activeEditorResource) {
+			return;
+		}
+		const changesSessionResource = this._sessionChangesService.getSessionResource(activeEditorResource);
+		if (!changesSessionResource) {
+			return;
+		}
+		if (this.multipleSessionsVisibleObs.get() || this._layoutService.isEditorMaximized()) {
+			return;
+		}
+		const activeSession = this._sessionsService.activeSession.get();
+		if (!activeSession || !isEqual(activeSession.resource, changesSessionResource)) {
+			return;
+		}
+		// Uncreated (untitled) sessions share the new-session side-pane state (D3b/D4).
+		if (!activeSession.isCreated.get()) {
+			return;
+		}
+		const savedState = this._viewStateBySession.get(changesSessionResource);
+		if (savedState) {
+			// The user explicitly hid the aux bar for this session, or the side
+			// pane is already open (leave it on whatever view they chose). Only an
+			// "open but currently closed" state (e.g. after the side pane was
+			// closed whole, D9) falls through to re-reveal the Changes view.
+			if (!savedState.auxiliaryBarVisible || this._layoutService.isVisible(Parts.AUXILIARYBAR_PART)) {
+				return;
+			}
+		}
+		this._viewsService.openView(CHANGES_VIEW_ID, false);
+	}
 
 	/**
 	 * On a small window, auto-hide the sessions sidebar while both the editor and
@@ -228,26 +307,34 @@ export class LayoutController extends BaseLayoutController {
 			this._previousSpaceConstrained = constrained;
 
 			if (constrained) {
-				this._setSidebarAutoHidden(true);
-			} else if (!this._userClosedSidebar) {
+				// Only remember an auto-hide when we actually hid a visible sidebar; a
+				// sidebar that was already closed (e.g. by the user, including before a
+				// reload) must not be auto-revealed when space is no longer constrained.
+				if (this._setSidebarAutoHidden(true)) {
+					this._sidebarAutoHidden = true;
+				}
+			} else if (this._sidebarAutoHidden) {
 				this._setSidebarAutoHidden(false);
+				this._sidebarAutoHidden = false;
 			}
 		}));
 
-		// Track manual sidebar toggles: a manual close suppresses auto-open, a manual
-		// open resumes auto-management. Maximize toggles the sidebar too, but its
-		// enter/restore pair self-cancels here, so it needs no special handling.
+		// A manual sidebar toggle hands control back to the user: stop tracking the
+		// sidebar as auto-hidden so a later un-constrain neither reopens a sidebar the
+		// user closed nor re-hides one they opened. Maximize toggles the sidebar too,
+		// but its enter/restore pair self-cancels here, so it needs no special handling.
 		this._register(this._layoutService.onDidChangePartVisibility(e => {
 			if (e.partId !== Parts.SIDEBAR_PART || this._applyingAutoSidebar) {
 				return;
 			}
-			this._userClosedSidebar = !e.visible;
+			this._sidebarAutoHidden = false;
 		}));
 	}
 
-	private _setSidebarAutoHidden(hidden: boolean): void {
+	/** Returns `true` when the sidebar visibility was actually changed. */
+	private _setSidebarAutoHidden(hidden: boolean): boolean {
 		if (this._layoutService.isVisible(Parts.SIDEBAR_PART) === !hidden) {
-			return;
+			return false;
 		}
 		this._applyingAutoSidebar = true;
 		try {
@@ -255,6 +342,7 @@ export class LayoutController extends BaseLayoutController {
 		} finally {
 			this._applyingAutoSidebar = false;
 		}
+		return true;
 	}
 
 	// [B4] Snapshot the active session's aux-bar state when persisting.
@@ -305,7 +393,7 @@ export class LayoutController extends BaseLayoutController {
 		// [D3b] New-session view: all uncreated sessions share one state.
 		if (!isCreated) {
 			if (this._newSessionViewState && !this._newSessionViewState.auxiliaryBarVisible) {
-				this._layoutService.setPartHidden(true, Parts.AUXILIARYBAR_PART);
+				this._hideAuxiliaryBarForRestore();
 				return;
 			}
 			return this._openDefaultAuxiliaryBarContainer(false);
@@ -315,7 +403,7 @@ export class LayoutController extends BaseLayoutController {
 
 		// [D3c] Existing sessions are never auto-opened: hide unless explicitly left visible.
 		if (!savedState || !savedState.auxiliaryBarVisible) {
-			this._layoutService.setPartHidden(true, Parts.AUXILIARYBAR_PART);
+			this._hideAuxiliaryBarForRestore();
 			return;
 		}
 
@@ -355,6 +443,21 @@ export class LayoutController extends BaseLayoutController {
 			void this._openDefaultAuxiliaryBarContainer(true);
 		}
 		return true;
+	}
+
+	/**
+	 * [D2/D8] Hide the side pane as part of restoring a session's remembered
+	 * state. The synchronous guard makes the [D2] listener ignore the resulting
+	 * visibility change so a restore-driven hide is never recorded as a new
+	 * per-session choice.
+	 */
+	private _hideAuxiliaryBarForRestore(): void {
+		this._hidingAuxiliaryBarForRestore = true;
+		try {
+			this._layoutService.setPartHidden(true, Parts.AUXILIARYBAR_PART);
+		} finally {
+			this._hidingAuxiliaryBarForRestore = false;
+		}
 	}
 
 	private _isAuxiliaryBarContainerPinned(containerId: string): boolean {

--- a/src/vs/sessions/contrib/layout/browser/sessions.layout.contribution.ts
+++ b/src/vs/sessions/contrib/layout/browser/sessions.layout.contribution.ts
@@ -15,10 +15,12 @@ import { MobileLayoutController } from './mobileSessionLayoutController.js';
 // Contribute the layout controller for the current platform. The web bundle
 // serves both the web desktop and the web phone layouts, so the choice is made
 // at runtime; the native desktop bundle always uses the desktop controller.
+// Registered at `BlockRestore` so the controller is in place before the window
+// restores its UI, getting the side-pane layout right without a visible flash.
 if (isWeb && isMobile) {
-	registerWorkbenchContribution2(MobileLayoutController.ID, MobileLayoutController, WorkbenchPhase.AfterRestored);
+	registerWorkbenchContribution2(MobileLayoutController.ID, MobileLayoutController, WorkbenchPhase.BlockRestore);
 } else {
-	registerWorkbenchContribution2(LayoutController.ID, LayoutController, WorkbenchPhase.AfterRestored);
+	registerWorkbenchContribution2(LayoutController.ID, LayoutController, WorkbenchPhase.BlockRestore);
 }
 
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({

--- a/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
@@ -422,6 +422,101 @@ suite('LayoutController (desktop)', () => {
 		);
 	});
 
+	// --- [D8] First Changes editor open ---
+
+	test('[D8] reveals the Changes view the first time a Changes editor is opened, then remembers the choice', () => {
+		createController({ revealAuxiliaryBarOnOpen: true });
+		const session = makeSession(URI.parse('session:1'));
+		harness.activeSessionObs.set(session, undefined);
+
+		// First open of the Changes editor reveals the Changes view in the side pane.
+		harness.openedViews = [];
+		harness.activeEditorResource = harness.sessionChangesService.getChangesEditorResource(session.resource);
+		harness.onDidActiveEditorChange.fire();
+		assert.ok(harness.openedViews.includes(CHANGES_VIEW_ID), 'first Changes open should reveal the Changes view');
+
+		// User hides only the side pane (aux bar) while the editor stays open; the choice is remembered.
+		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, false);
+		harness.onDidChangePartVisibility.fire({ partId: Parts.AUXILIARYBAR_PART, visible: false });
+
+		// Opening the Changes editor again respects the remembered closed choice.
+		harness.openedViews = [];
+		harness.onDidActiveEditorChange.fire();
+		assert.ok(!harness.openedViews.includes(CHANGES_VIEW_ID), 'later Changes opens should not re-reveal the side pane');
+	});
+
+	test('[D9] closing the whole side pane is not remembered, so reopening Changes reveals it again', () => {
+		const controller = createController({ revealAuxiliaryBarOnOpen: true });
+		const session = makeSession(URI.parse('session:1'));
+		harness.activeSessionObs.set(session, undefined);
+
+		// The first Changes open reveals the side pane (captured as open).
+		harness.openedViews = [];
+		harness.activeEditorResource = harness.sessionChangesService.getChangesEditorResource(session.resource);
+		harness.partVisibility.set(Parts.EDITOR_PART, true);
+		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, true);
+		harness.onDidActiveEditorChange.fire();
+		assert.ok(harness.openedViews.includes(CHANGES_VIEW_ID), 'first Changes open should reveal the Changes view');
+
+		// User closes the whole side pane via the controller-owned toggle, which
+		// hides the editor and aux bar together. This must not be remembered as a
+		// per-session aux-bar choice.
+		controller.toggleSidePane();
+
+		// Re-clicking Changes re-reveals the (still-active, just hidden) editor part
+		// without firing an active-editor change; the side pane opens again (the
+		// close was not remembered as an aux-bar choice).
+		harness.openedViews = [];
+		harness.partVisibility.set(Parts.EDITOR_PART, true);
+		harness.onDidChangePartVisibility.fire({ partId: Parts.EDITOR_PART, visible: true });
+		assert.ok(harness.openedViews.includes(CHANGES_VIEW_ID), 'reopening Changes after closing the whole side pane should reveal the Changes view again');
+	});
+
+	test('[D9] reopening the side pane restores the parts that were visible when it was closed', () => {
+		const controller = createController();
+		harness.partVisibility.set(Parts.EDITOR_PART, true);
+		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, true);
+
+		// Closing hides both parts.
+		const visibleAfterClose = controller.toggleSidePane();
+		assert.strictEqual(visibleAfterClose, false, 'side pane should be hidden after closing');
+		assert.ok(harness.setPartHiddenCalls.some(c => c.part === Parts.AUXILIARYBAR_PART && c.hidden === true), 'aux bar should be hidden');
+		assert.ok(harness.setPartHiddenCalls.some(c => c.part === Parts.EDITOR_PART && c.hidden === true), 'editor should be hidden');
+
+		// Reopening restores both parts that were visible before.
+		harness.setPartHiddenCalls.length = 0;
+		const visibleAfterOpen = controller.toggleSidePane();
+		assert.strictEqual(visibleAfterOpen, true, 'side pane should be visible after reopening');
+		assert.ok(harness.setPartHiddenCalls.some(c => c.part === Parts.EDITOR_PART && c.hidden === false), 'editor should be restored');
+		assert.ok(harness.setPartHiddenCalls.some(c => c.part === Parts.AUXILIARYBAR_PART && c.hidden === false), 'aux bar should be restored');
+	});
+
+	test('[D8] does not reveal the Changes view for an untitled session', () => {
+		createController();
+		const untitled = makeSession(URI.parse('session:untitled'), { status: SessionStatus.Untitled });
+		harness.activeSessionObs.set(untitled, undefined);
+
+		harness.openedViews = [];
+		harness.activeEditorResource = harness.sessionChangesService.getChangesEditorResource(untitled.resource);
+		harness.onDidActiveEditorChange.fire();
+
+		assert.ok(!harness.openedViews.includes(CHANGES_VIEW_ID), 'untitled sessions are governed by D3b/D4, not D8');
+	});
+
+	test('[D8] does not reveal the Changes view while multiple sessions are visible', () => {
+		createController();
+		const a = makeSession(URI.parse('session:a'));
+		const b = makeSession(URI.parse('session:b'));
+		harness.visibleSessionsObs.set([a, b], undefined);
+		harness.activeSessionObs.set(a, undefined);
+
+		harness.openedViews = [];
+		harness.activeEditorResource = harness.sessionChangesService.getChangesEditorResource(a.resource);
+		harness.onDidActiveEditorChange.fire();
+
+		assert.ok(!harness.openedViews.includes(CHANGES_VIEW_ID), 'multi-session mode manages the side pane separately');
+	});
+
 	// --- [D5] Editor maximized ---
 
 	test('[D5] shows the Changes view when the editor area is maximized', () => {
@@ -611,6 +706,7 @@ suite('LayoutController (desktop)', () => {
 		assert.ok(stored, 'state should be persisted');
 
 		// Reload: a fresh controller restores from the persisted state.
+		store.clear();
 		createController({ useModal: 'some', workspaceFolders, layoutState: JSON.parse(stored!) });
 		const reloadedSession1 = makeSession(URI.parse('session:1'));
 		harness.setPartHiddenCalls = [];
@@ -706,6 +802,31 @@ suite('LayoutController (desktop)', () => {
 		setPartVisible(Parts.AUXILIARYBAR_PART, false);
 
 		assert.deepStrictEqual(sidebarHiddenCalls(), [true, false]);
+	});
+
+	test('[D7] does not auto-show the sidebar the user closed before reloading', () => {
+		// Simulate the restored state after a reload: the sidebar and the whole side
+		// pane (editor + aux bar) are hidden, on a small window. The controller only
+		// auto-reveals a sidebar it auto-hid, so a sidebar the user closed before the
+		// reload (already hidden here) must stay closed.
+		const controller = createController({
+			mainContainerWidth: 800,
+			initialPartVisibility: new Map<Parts, boolean>([
+				[Parts.SIDEBAR_PART, false],
+				[Parts.EDITOR_PART, false],
+				[Parts.AUXILIARYBAR_PART, false],
+			]),
+		});
+		harness.setPartHiddenCalls = [];
+
+		// Open the side pane (becomes space constrained), then close it again.
+		controller.toggleSidePane();
+		controller.toggleSidePane();
+
+		assert.ok(
+			!sidebarHiddenCalls().includes(false),
+			'sidebar must not be auto-shown when it was closed before the reload'
+		);
 	});
 
 	test('[D7] does not manage the sidebar while the editor is maximized', () => {

--- a/src/vs/sessions/contrib/layout/test/browser/layoutControllerTestUtils.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/layoutControllerTestUtils.ts
@@ -24,6 +24,7 @@ import { IViewsService } from '../../../../../workbench/services/views/common/vi
 import { IActiveSession, ISessionsChangeEvent, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 import { IChat, ISessionFileChange, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
+import { ISessionChangesService, SessionChangesService } from '../../../changes/browser/sessionChangesService.js';
 import { CHANGES_VIEW_CONTAINER_ID } from '../../../changes/common/changes.js';
 import { SESSIONS_FILES_CONTAINER_ID } from '../../../files/browser/files.contribution.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
@@ -112,6 +113,10 @@ export interface ICreateOptions {
 	readonly responsiveSidebar?: boolean;
 	/** [D7] When set, `openView`/`openViewContainer` reveal the auxiliary bar (mirroring production) so navigation reveals can be exercised. */
 	readonly revealAuxiliaryBarOnOpen?: boolean;
+	/** Initial main container width (defaults to 2000). Set below `SMALL_WINDOW_MAX_WIDTH` to start space-constrained. */
+	readonly mainContainerWidth?: number;
+	/** Initial part visibility overrides applied before the controller is constructed (mirrors restored layout after a reload). */
+	readonly initialPartVisibility?: ReadonlyMap<Parts, boolean>;
 }
 
 /**
@@ -127,6 +132,7 @@ export interface ITestLayoutHarness {
 	onDidChangeSessions: Emitter<ISessionsChangeEvent>;
 	onDidChangePartVisibility: Emitter<IPartVisibilityChangeEvent>;
 	onDidChangeEditorMaximized: Emitter<void>;
+	onDidActiveEditorChange: Emitter<void>;
 	onDidLayoutMainContainer: Emitter<IDimension>;
 	mainContainerWidth: number;
 	editorMaximized: boolean;
@@ -137,6 +143,8 @@ export interface ITestLayoutHarness {
 	activePaneCompositeId: string | undefined;
 	pinnedAuxiliaryBarContainerIds: string[];
 	visibleEditorsList: readonly unknown[];
+	activeEditorResource: URI | undefined;
+	readonly sessionChangesService: ISessionChangesService;
 }
 
 export function createTestHarness(store: DisposableStore, options: ICreateOptions = {}): ITestLayoutHarness {
@@ -167,13 +175,15 @@ export function createTestHarness(store: DisposableStore, options: ICreateOption
 		onDidChangeSessions: store.add(new Emitter<ISessionsChangeEvent>()),
 		onDidChangePartVisibility: store.add(new Emitter<IPartVisibilityChangeEvent>()),
 		onDidChangeEditorMaximized: store.add(new Emitter<void>()),
+		onDidActiveEditorChange: store.add(new Emitter<void>()),
 		onDidLayoutMainContainer: store.add(new Emitter<IDimension>()),
-		mainContainerWidth: 2000,
+		mainContainerWidth: options.mainContainerWidth ?? 2000,
 		editorMaximized: false,
 		partVisibility: new Map<Parts, boolean>([
 			[Parts.AUXILIARYBAR_PART, true],
 			[Parts.PANEL_PART, false],
 			[Parts.EDITOR_PART, true],
+			...(options.initialPartVisibility ?? []),
 		]),
 		openedViewContainers: [],
 		openedViews: [],
@@ -181,6 +191,8 @@ export function createTestHarness(store: DisposableStore, options: ICreateOption
 		activePaneCompositeId: undefined,
 		pinnedAuxiliaryBarContainerIds: [SESSIONS_FILES_CONTAINER_ID, CHANGES_VIEW_CONTAINER_ID],
 		visibleEditorsList: [],
+		activeEditorResource: undefined,
+		sessionChangesService: new SessionChangesService(),
 	};
 
 	instaService.stub(ISessionsManagementService, new class extends mock<ISessionsManagementService>() {
@@ -191,6 +203,8 @@ export function createTestHarness(store: DisposableStore, options: ICreateOption
 		override readonly activeSession = harness.activeSessionObs;
 		override readonly visibleSessions = harness.visibleSessionsObs;
 	});
+
+	instaService.stub(ISessionChangesService, harness.sessionChangesService);
 
 	instaService.stub(IWorkbenchLayoutService, new class extends mock<IWorkbenchLayoutService>() {
 		override isVisible(part: Parts): boolean {
@@ -252,9 +266,18 @@ export function createTestHarness(store: DisposableStore, options: ICreateOption
 
 	instaService.stub(IEditorService, new class extends mock<IEditorService>() {
 		override get visibleEditors() { return harness.visibleEditorsList as IEditorService['visibleEditors']; }
+		override readonly onDidActiveEditorChange = harness.onDidActiveEditorChange.event;
+		override get activeEditor() {
+			if (!harness.activeEditorResource) {
+				return undefined;
+			}
+			const editor = { resource: harness.activeEditorResource };
+			return editor as IEditorService['activeEditor'];
+		}
 	});
 
 	instaService.stub(IEditorGroupsService, new class extends mock<IEditorGroupsService>() {
+		override get groups() { return [{ isEmpty: false }] as unknown as IEditorGroupsService['groups']; }
 		override saveWorkingSet(name: string): IEditorWorkingSet { return { id: name, name }; }
 		override async applyWorkingSet() { return true; }
 		override deleteWorkingSet() { }


### PR DESCRIPTION
## What

Consolidates side-pane and responsive-sidebar management into the session layout controller and fixes a sidebar-reveal bug after a window reload.

### Changes

- **Move the `Toggle Side Panel` action into the layout controller.** The action (and its "which parts were visible" memory) previously lived in `layoutActions.ts`. It now lives with the controller (`baseSessionLayoutController.ts`), registered when the contribution starts, so the side-pane visibility memory is owned by the component that manages the layout. `toggleSidePane()` is exposed for this.
- **Introduce `ISessionChangesService`** (`sessionChangesService.ts`) to own the `changes-multi-diff-source:` URI build/parse (identity), used alongside the upstream `IChangesViewService`. Updates `changesMultiDiffSourceResolver.ts`, `changesActions.ts`, and `changes.contribution.ts` to consume both services.
- **Fix the responsive sidebar reveal bug after reload (D7).** Previously the un-constrain auto-reveal was gated on an in-memory `_userClosedSidebar` flag that resets to `false` on reload, so closing the side pane after a reload wrongly revealed a sidebar the user had closed. The controller now tracks `_sidebarAutoHidden` and only auto-reveals a sidebar **it** auto-hid. After a reload the sidebar is already hidden, so the controller never "owns" that hidden state and leaves it closed.

## Why

Keeping the side-pane toggle and its memory inside the layout controller makes the responsive behavior coherent and lets the controller correctly distinguish controller-driven hides from user/reload state.

## Reviewer notes

- New regression test: `[D7] does not auto-show the sidebar the user closed before reloading`, plus new test-harness options `mainContainerWidth` and `initialPartVisibility`. Verified the test fails without the fix and passes with it.
- Validated: `typecheck-client` clean, 50 LayoutController tests passing, `valid-layers-check` clean, eslint clean, pre-commit hygiene passing.
- The spec doc `desktopSessionLayoutController.md` (D1-D9) was updated to describe the `_sidebarAutoHidden` behavior.
