### PR TITLE
chat: update tunnel host toggle dimensions to 22px with 0 padding

### DIFF
--- a/src/vs/workbench/contrib/chat/electron-browser/media/tunnelHost.css
+++ b/src/vs/workbench/contrib/chat/electron-browser/media/tunnelHost.css
@@ -8,9 +8,9 @@
 	align-items: center;
 	justify-content: center;
 	box-sizing: border-box;
-	width: 24px;
-	height: 24px;
-	padding: 4px;
+	width: 22px;
+	height: 22px;
+	padding: 0;
 	cursor: pointer;
 	color: var(--vscode-icon-foreground);
 	border-radius: var(--vscode-cornerRadius-small);


### PR DESCRIPTION
Update the tunnel host toggle CSS class to use 22px width and height with 0 padding instead of 24px with 4px padding for better visual proportions.