### PR TITLE
chat: fix new-session picker no-op for extension chat sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -539,6 +539,25 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 	}
 
 	private _registerMenuItems(contribution: IChatSessionsExtensionPoint, extensionDescription: IRelaxedExtensionDescription): IDisposable {
+		const disposables = new DisposableStore();
+
+		// For a non-delegating contribution (e.g. an extension-contributed
+		// editor session such as Codex), the session type picker creates a new
+		// session by invoking `openNewChatSessionExternal.<type>`. Register that
+		// command unconditionally and resolve the underlying create-submenu
+		// command lazily at execution time. Registering it eagerly (only when
+		// the create submenu already has an entry) races extension menu/command
+		// registration: if the submenu is still empty at enable time, the
+		// command is never registered and the picker click silently fails with
+		// "command not found".
+		if (!contribution.canDelegate) {
+			disposables.add(registerNewSessionExternalAction(
+				contribution.type,
+				contribution.displayName,
+				() => this._resolveCreateSubMenuCommandId(contribution.type),
+			));
+		}
+
 		// If provider registers anything for the create submenu, let it fully control the creation
 		const contextKeyService = this._contextKeyService.createOverlay([
 			['chatSessionType', contribution.type]
@@ -547,26 +566,45 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		const rawMenuActions = this._menuService.getMenuActions(MenuId.AgentSessionsCreateSubMenu, contextKeyService);
 		const menuActions = rawMenuActions.map(value => value[1]).flat();
 
-		const disposables = new DisposableStore();
-
-		// Mirror all create submenu actions into the global Chat New menu
+		// Mirror create submenu actions into the global Chat New menu. The first
+		// action of a non-delegating contribution is the "primary" create
+		// command surfaced through the external action above, so it is not
+		// mirrored here.
 		for (let i = 0; i < menuActions.length; i++) {
 			const action = menuActions[i];
 			if (action instanceof MenuItemAction) {
-				// TODO: This is an odd way to do this, but the best we can do currently
 				if (i === 0 && !contribution.canDelegate) {
-					disposables.add(registerNewSessionExternalAction(contribution.type, contribution.displayName, action.item.id));
-				} else {
-					disposables.add(MenuRegistry.appendMenuItem(MenuId.ChatNewMenu, {
-						command: action.item,
-						group: '4_externally_contributed',
-					}));
+					continue;
 				}
+				disposables.add(MenuRegistry.appendMenuItem(MenuId.ChatNewMenu, {
+					command: action.item,
+					group: '4_externally_contributed',
+				}));
 			}
 		}
 		return {
 			dispose: () => disposables.dispose()
 		};
+	}
+
+	/**
+	 * Resolves the command id of the primary create action contributed to
+	 * {@link MenuId.AgentSessionsCreateSubMenu} for the given session type, or
+	 * `undefined` when no such action is contributed (yet). Read at execution
+	 * time so it is unaffected by the ordering of extension menu registration.
+	 */
+	private _resolveCreateSubMenuCommandId(type: string): string | undefined {
+		const contextKeyService = this._contextKeyService.createOverlay([
+			['chatSessionType', type]
+		]);
+		const rawMenuActions = this._menuService.getMenuActions(MenuId.AgentSessionsCreateSubMenu, contextKeyService);
+		const menuActions = rawMenuActions.map(value => value[1]).flat();
+		for (const action of menuActions) {
+			if (action instanceof MenuItemAction) {
+				return action.item.id;
+			}
+		}
+		return undefined;
 	}
 
 	private _registerCommands(contribution: IChatSessionsExtensionPoint): IDisposable {
@@ -1422,7 +1460,7 @@ function registerNewSessionInPlaceAction(type: string, displayName: string): IDi
 	});
 }
 
-function registerNewSessionExternalAction(type: string, displayName: string, commandId: string): IDisposable {
+function registerNewSessionExternalAction(type: string, displayName: string, resolveCommandId: () => string | undefined): IDisposable {
 	return registerAction2(class NewChatSessionExternalAction extends Action2 {
 		constructor() {
 			super({
@@ -1435,6 +1473,10 @@ function registerNewSessionExternalAction(type: string, displayName: string, com
 		}
 		async run(accessor: ServicesAccessor): Promise<void> {
 			const commandService = accessor.get(ICommandService);
+			const commandId = resolveCommandId();
+			if (!commandId) {
+				return;
+			}
 			await commandService.executeCommand(commandId);
 		}
 	});

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -541,15 +541,11 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 	private _registerMenuItems(contribution: IChatSessionsExtensionPoint, extensionDescription: IRelaxedExtensionDescription): IDisposable {
 		const disposables = new DisposableStore();
 
-		// For a non-delegating contribution (e.g. an extension-contributed
-		// editor session such as Codex), the session type picker creates a new
-		// session by invoking `openNewChatSessionExternal.<type>`. Register that
-		// command unconditionally and resolve the underlying create-submenu
-		// command lazily at execution time. Registering it eagerly (only when
-		// the create submenu already has an entry) races extension menu/command
-		// registration: if the submenu is still empty at enable time, the
-		// command is never registered and the picker click silently fails with
-		// "command not found".
+		// A non-delegating contribution (e.g. the Codex editor session) creates
+		// a new session via `openNewChatSessionExternal.<type>`. Register it
+		// eagerly and resolve the create command lazily, so it survives the race
+		// where the extension's create-submenu entry isn't registered yet at
+		// enable time.
 		if (!contribution.canDelegate) {
 			disposables.add(registerNewSessionExternalAction(
 				contribution.type,
@@ -566,21 +562,16 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		const rawMenuActions = this._menuService.getMenuActions(MenuId.AgentSessionsCreateSubMenu, contextKeyService);
 		const menuActions = rawMenuActions.map(value => value[1]).flat();
 
-		// Mirror create submenu actions into the global Chat New menu. The first
-		// action of a non-delegating contribution is the "primary" create
-		// command surfaced through the external action above, so it is not
-		// mirrored here.
-		for (let i = 0; i < menuActions.length; i++) {
-			const action = menuActions[i];
-			if (action instanceof MenuItemAction) {
-				if (i === 0 && !contribution.canDelegate) {
-					continue;
-				}
-				disposables.add(MenuRegistry.appendMenuItem(MenuId.ChatNewMenu, {
-					command: action.item,
-					group: '4_externally_contributed',
-				}));
-			}
+		// Mirror create submenu actions into the global Chat New menu. For a
+		// non-delegating contribution the first action is the primary create
+		// command, already surfaced through the external action above, so skip it.
+		const menuItemActions = menuActions.filter((action): action is MenuItemAction => action instanceof MenuItemAction);
+		const actionsToMirror = contribution.canDelegate ? menuItemActions : menuItemActions.slice(1);
+		for (const action of actionsToMirror) {
+			disposables.add(MenuRegistry.appendMenuItem(MenuId.ChatNewMenu, {
+				command: action.item,
+				group: '4_externally_contributed',
+			}));
 		}
 		return {
 			dispose: () => disposables.dispose()
@@ -1473,8 +1464,10 @@ function registerNewSessionExternalAction(type: string, displayName: string, res
 		}
 		async run(accessor: ServicesAccessor): Promise<void> {
 			const commandService = accessor.get(ICommandService);
+			const logService = accessor.get(ILogService);
 			const commandId = resolveCommandId();
 			if (!commandId) {
+				logService.warn(`[ChatSessionsService] No create command contributed to '${MenuId.AgentSessionsCreateSubMenu.id}' for chat session type '${type}'; cannot open a new session.`);
 				return;
 			}
 			await commandService.executeCommand(commandId);


### PR DESCRIPTION
## now

https://github.com/user-attachments/assets/572a8e6a-44eb-4888-835a-0cc5ba5de72b

## before

https://github.com/user-attachments/assets/2ffb296c-3caa-4ad6-82ff-02ce9b1f2c99






## Problem

Selecting an extension-contributed, non-delegating chat session in the new-session "harness" picker (e.g. **Codex** from the `openai.chatgpt` extension) does nothing — the selection doesn't change and no session opens.

The picker creates such a session by invoking `workbench.action.chat.openNewChatSessionExternal.<type>`. That command was only registered when `_registerMenuItems` happened to find an entry in `MenuId.AgentSessionsCreateSubMenu` **at the moment the contribution was enabled**. That snapshot races extension menu/command registration: for Codex the submenu is still empty at enable time, so the external command is never registered and never retried.

Clicking the entry then rejects with `command '...openai-codex' not found` (visible in the renderer log, not the extension output channel) and `_run` doesn't surface it, so the click silently no-ops.

```
[error] command 'workbench.action.chat.openNewChatSessionExternal.openai-codex' not found:
  Error: command 'workbench.action.chat.openNewChatSessionExternal.openai-codex' not found
```

## Fix

In `chatSessions.contribution.ts`:

- Register `openNewChatSessionExternal.<type>` **unconditionally** for non-delegating contributions, instead of only when the create submenu already has an entry.
- Resolve the underlying create-submenu command **lazily at execution time** (new `_resolveCreateSubMenuCommandId`), so it is unaffected by the ordering of extension menu/command registration.
- The action no-ops gracefully when no create command is contributed (instead of rejecting with "command not found").

The global Chat New menu mirroring behavior is preserved (the primary create action is still surfaced via the external command and is not duplicated into the menu).

## Result

Clicking **Codex** now reliably runs the extension's "New Codex Agent" command, opening a new Codex editor tab — the extension's intended behavior. Other harnesses (Local/Cloud/Copilot CLI, which are `canDelegate: true`) are unaffected.

## Testing

Verified manually in a dev build with the `openai.chatgpt` extension installed (`--enable-proposed-api openai.chatgpt`): Codex now opens its editor on click, and the `command ... not found` error no longer appears in the renderer log.
