### PR TITLE
Expose the score function in Monaco editor

### DIFF
--- a/build/monaco/monaco.d.ts.recipe
+++ b/build/monaco/monaco.d.ts.recipe
@@ -132,7 +132,7 @@ declare namespace monaco.languages {
 
 #include(vs/editor/common/textModelEditSource.js): EditDeltaInfo
 #include(vs/base/common/glob.js): IRelativePattern
-#include(vs/editor/common/languageSelector.js): LanguageSelector, LanguageFilter
+#include(vs/editor/common/languageSelector.js): LanguageSelector, LanguageFilter, score
 #includeAll(vs/editor/standalone/browser/standaloneLanguages.js;languages.=>;editorCommon.=>editor.;model.=>editor.;IMarkerData=>editor.IMarkerData):
 #includeAll(vs/editor/common/languages/languageConfiguration.js):
 #includeAll(vs/editor/common/languages.js;IMarkerData=>editor.IMarkerData;ISingleEditOperation=>editor.ISingleEditOperation;model.=>editor.;ThemeIcon=>editor.ThemeIcon): Token

--- a/src/vs/editor/common/languageSelector.ts
+++ b/src/vs/editor/common/languageSelector.ts
@@ -26,7 +26,7 @@ export interface LanguageFilter {
 
 export type LanguageSelector = string | LanguageFilter | ReadonlyArray<string | LanguageFilter>;
 
-export function score(selector: LanguageSelector | undefined, candidateUri: URI, candidateLanguage: string, candidateIsSynchronized: boolean, candidateNotebookUri: URI | undefined, candidateNotebookType: string | undefined): number {
+export function score(selector: LanguageSelector | undefined, candidateUri: URI, candidateLanguage: string, candidateIsSynchronized: boolean = true, candidateNotebookUri?: URI | undefined, candidateNotebookType?: string | undefined): number {
 
 	if (Array.isArray(selector)) {
 		// array -> take max individual value

--- a/src/vs/editor/standalone/browser/standaloneLanguages.ts
+++ b/src/vs/editor/standalone/browser/standaloneLanguages.ts
@@ -14,7 +14,7 @@ import { ILanguageExtensionPoint, ILanguageService } from '../../common/language
 import { LanguageConfiguration } from '../../common/languages/languageConfiguration.js';
 import { ILanguageConfigurationService } from '../../common/languages/languageConfigurationRegistry.js';
 import { ModesRegistry } from '../../common/languages/modesRegistry.js';
-import { LanguageSelector } from '../../common/languageSelector.js';
+import { LanguageSelector, score } from '../../common/languageSelector.js';
 import * as model from '../../common/model.js';
 import { ILanguageFeaturesService } from '../../common/services/languageFeatures.js';
 import * as standaloneEnums from '../../common/standalone/standaloneEnums.js';
@@ -760,6 +760,8 @@ export function createMonacoLanguagesAPI(): typeof monaco.languages {
 		onLanguageEncountered: <any>onLanguageEncountered,
 		// eslint-disable-next-line local/code-no-any-casts
 		getEncodedLanguageId: <any>getEncodedLanguageId,
+		// eslint-disable-next-line local/code-no-any-casts
+		score: <any>score,
 
 		// provider methods
 		// eslint-disable-next-line local/code-no-any-casts

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6600,6 +6600,8 @@ declare namespace monaco.languages {
 		readonly isBuiltin?: boolean;
 	}
 
+	export function score(selector: LanguageSelector | undefined, candidateUri: Uri, candidateLanguage: string, candidateIsSynchronized?: boolean, candidateNotebookUri?: Uri | undefined, candidateNotebookType?: string | undefined): number;
+
 	/**
 	 * Register information about a new language.
 	 */


### PR DESCRIPTION
The `score` function is useful for filtering models in Monaco editor. This is also useful in functionality outside of the core.

Example use cases are [`monaco-marker-data-provider`](https://github.com/remcohaszing/monaco-marker-data-provider), and a worker synchronization library I’m working on.