### PR TITLE
sessions: surface un-accepted PR review comments to the agent

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedback.contribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedback.contribution.ts
@@ -18,6 +18,7 @@ import { IsSessionsWindowContext } from '../../../../workbench/common/contextkey
 import { AgentFeedbackService, AgentFeedbackState, IAgentFeedbackService } from './agentFeedbackService.js';
 import { AgentFeedbackAttachmentContribution } from './agentFeedbackAttachment.js';
 import { AgentFeedbackPRThreadResolverContribution } from './agentFeedbackPRThreadResolver.js';
+import { AgentFeedbackPRReviewSeederContribution } from './agentFeedbackPRReviewSeeder.js';
 import { AgentFeedbackAttachmentWidget } from './agentFeedbackAttachmentWidget.js';
 import { AgentFeedbackEditorOverlay } from './agentFeedbackEditorOverlay.js';
 import { hasActiveSessionAgentFeedback, registerAgentFeedbackEditorActions, submitActiveSessionFeedbackActionId } from './agentFeedbackEditorActions.js';
@@ -82,6 +83,7 @@ registerWorkbenchContribution2(ActiveSessionFeedbackContextContribution.ID, Acti
 registerWorkbenchContribution2(AgentFeedbackEditorOverlay.ID, AgentFeedbackEditorOverlay, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(AgentFeedbackAttachmentContribution.ID, AgentFeedbackAttachmentContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(AgentFeedbackPRThreadResolverContribution.ID, AgentFeedbackPRThreadResolverContribution, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(AgentFeedbackPRReviewSeederContribution.ID, AgentFeedbackPRReviewSeederContribution, WorkbenchPhase.AfterRestored);
 
 registerAgentFeedbackEditorActions();
 

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackItemsBackend.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackItemsBackend.ts
@@ -37,6 +37,15 @@ export interface IAgentFeedbackItemsBackend {
 	/** Returns the feedback items for a session in stable display order. */
 	getItems(sessionResource: URI): readonly IAgentFeedback[];
 
+	/**
+	 * Whether {@link getItems} reflects the authoritative item set for the
+	 * session. For the in-memory backend this is always `true`; for the
+	 * annotations-backed backend it is `false` until the session's annotations
+	 * snapshot has been received, so callers that seed items (e.g. mirroring PR
+	 * review comments) can avoid acting on a transiently-empty list.
+	 */
+	hasLoaded(sessionResource: URI): boolean;
+
 	/** Adds a new feedback item or replaces an existing one with the same id. */
 	upsert(feedback: IAgentFeedback): void;
 
@@ -93,6 +102,11 @@ export class InMemoryAgentFeedbackItemsBackend extends Disposable implements IAg
 
 	getItems(sessionResource: URI): readonly IAgentFeedback[] {
 		return orderFeedbackItems(this._bySession.get(sessionResource.toString()) ?? []);
+	}
+
+	hasLoaded(_sessionResource: URI): boolean {
+		// In-memory state is always authoritative; there is nothing to await.
+		return true;
 	}
 
 	upsert(feedback: IAgentFeedback): void {
@@ -321,6 +335,13 @@ export class AnnotationsAgentFeedbackItemsBackend extends Disposable implements 
 	 * spurious feedback-items change (which would bump recency / navigation).
 	 */
 	private readonly _signatureBySession = new Map<string, string>();
+	/**
+	 * Sessions whose annotations snapshot has been received. Used to fire
+	 * {@link onDidChangeItems} exactly once when loading completes (even when the
+	 * loaded feedback set is empty), so consumers that seed feedback can wait for
+	 * the authoritative set before acting.
+	 */
+	private readonly _loadedBySession = new Set<string>();
 
 	constructor(
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
@@ -341,6 +362,14 @@ export class AnnotationsAgentFeedbackItemsBackend extends Disposable implements 
 			return orderFeedbackItems(this._decode(channel.subscription, sessionResource));
 		}
 		return orderFeedbackItems(this._cacheBySession.get(sessionResource.toString()) ?? []);
+	}
+
+	hasLoaded(sessionResource: URI): boolean {
+		// Only authoritative once the session's annotations snapshot has been
+		// received; until then `getItems` falls back to the (possibly empty)
+		// local cache and must not be treated as the full item set.
+		const channel = this._ensureChannel(sessionResource);
+		return channel ? this._hasSnapshot(channel.subscription) : false;
 	}
 
 	upsert(feedback: IAgentFeedback): void {
@@ -442,6 +471,15 @@ export class AnnotationsAgentFeedbackItemsBackend extends Disposable implements 
 		if (!channel) {
 			return;
 		}
+		// Fire once when the snapshot first arrives so consumers learn that the
+		// feedback set is now authoritative, even if it is empty (and thus has
+		// the same — empty — signature as before loading).
+		if (this._hasSnapshot(channel.subscription) && !this._loadedBySession.has(key)) {
+			this._loadedBySession.add(key);
+			this._signatureBySession.set(key, this._feedbackSignature(channel.subscription));
+			this._onDidChangeItems.fire(sessionResource);
+			return;
+		}
 		const signature = this._feedbackSignature(channel.subscription);
 		if (this._signatureBySession.get(key) === signature) {
 			return;
@@ -510,6 +548,7 @@ export class AnnotationsAgentFeedbackItemsBackend extends Disposable implements 
 		this._sessionResourceByKey.delete(key);
 		this._cacheBySession.delete(key);
 		this._signatureBySession.delete(key);
+		this._loadedBySession.delete(key);
 	}
 
 	private _ensureChannel(sessionResource: URI): ITrackedChannel | undefined {
@@ -540,6 +579,9 @@ export class AnnotationsAgentFeedbackItemsBackend extends Disposable implements 
 			subscription: ref.object,
 		};
 		this._signatureBySession.set(key, this._feedbackSignature(ref.object));
+		if (this._hasSnapshot(ref.object)) {
+			this._loadedBySession.add(key);
+		}
 		store.add(ref.object.onDidChange(() => this._onAnnotationsChange(sessionResource)));
 
 		this._channels.set(key, store);

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackPRReviewSeeder.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackPRReviewSeeder.ts
@@ -1,0 +1,147 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { autorun, observableSignalFromEvent } from '../../../../base/common/observable.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
+import { isAgentHostProviderId } from '../../../common/agentHostSessionsProvider.js';
+import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+import { ICodeReviewService, IPRReviewComment, PRReviewStateKind } from '../../codeReview/browser/codeReviewService.js';
+import { AgentFeedbackKind, AgentFeedbackState, IAgentFeedback, IAgentFeedbackService } from './agentFeedbackService.js';
+
+/**
+ * Mirrors un-accepted pull request review comments onto the active agent-host
+ * session's feedback (annotations) channel as {@link AgentFeedbackState.Created}
+ * {@link AgentFeedbackKind.PRReview} items.
+ *
+ * PR review comments otherwise live only client-side in
+ * {@link ICodeReviewService} and are invisible to the agent. The agent-host
+ * `listComments` tool surfaces a "there are N pull request comments which the
+ * user has not reviewed yet" note and the `viewUnreviewedComments` tool reveals
+ * them, but both read ONLY annotations of a reviewable kind in the `created`
+ * state. Seeding a mirror annotation per PR comment is what makes those tools
+ * aware of the comments so the user can reveal and accept them.
+ *
+ * The mirror carries {@link IAgentFeedback.sourcePRReviewCommentId} (the GitHub
+ * review thread id) so it can be deduplicated against the raw PR comment in the
+ * editor (see `getSessionEditorComments`) and so resolving the agent feedback
+ * resolves the originating GitHub thread (see
+ * {@link import('./agentFeedbackPRThreadResolver.js').AgentFeedbackPRThreadResolverContribution}).
+ *
+ * Seeding is keyed off the session resource (the same key every other feedback
+ * operation uses), so a session's comments stay on one annotations channel even
+ * when it contains multiple chats.
+ *
+ * Only the active session is seeded: {@link ICodeReviewService} loads PR review
+ * threads exclusively for the active session, so no PR comment data exists for
+ * background sessions to mirror. Because mirrors are persisted as annotations on
+ * the server, a session keeps its mirrors after it stops being active.
+ */
+export class AgentFeedbackPRReviewSeederContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.agentFeedbackPRReviewSeeder';
+
+	constructor(
+		@IAgentFeedbackService private readonly _agentFeedbackService: IAgentFeedbackService,
+		@ICodeReviewService private readonly _codeReviewService: ICodeReviewService,
+		@ISessionsService private readonly _sessionsService: ISessionsService,
+	) {
+		super();
+
+		// Re-evaluate when the feedback set changes so seeding waits for the
+		// session's annotations snapshot (and reacts to mirrors being accepted,
+		// removed, or to a comment's mirror disappearing).
+		const feedbackChanged = observableSignalFromEvent(this, this._agentFeedbackService.onDidChangeFeedback);
+
+		this._register(autorun(reader => {
+			const activeSession = this._sessionsService.activeSession.read(reader);
+			if (!activeSession || !isAgentHostProviderId(activeSession.providerId)) {
+				return;
+			}
+			const sessionResource = activeSession.resource;
+			const prReviewState = this._codeReviewService.getPRReviewState(sessionResource).read(reader);
+			feedbackChanged.read(reader);
+			if (prReviewState.kind !== PRReviewStateKind.Loaded) {
+				return;
+			}
+			this._sync(sessionResource, prReviewState.comments);
+		}));
+	}
+
+	private _sync(sessionResource: URI, comments: readonly IPRReviewComment[]): void {
+		// Only act once the authoritative feedback set is available; seeding off
+		// a transiently-empty list would create duplicate mirrors on reload.
+		if (!this._agentFeedbackService.hasLoadedFeedback(sessionResource)) {
+			return;
+		}
+
+		const feedback = this._agentFeedbackService.getFeedback(sessionResource);
+		const mirroredSourceIds = new Set<string>();
+		const createdMirrorBySource = new Map<string, IAgentFeedback>();
+		// Extra created mirrors that share a source with one already seen. These
+		// arise from a benign race (a second seed dispatched before the first
+		// echoed back, or two windows seeding the same session) and are collapsed
+		// to a single mirror below.
+		const duplicateCreatedMirrors: IAgentFeedback[] = [];
+		for (const item of feedback) {
+			if (item.kind === AgentFeedbackKind.PRReview && item.sourcePRReviewCommentId) {
+				mirroredSourceIds.add(item.sourcePRReviewCommentId);
+				if (item.state === AgentFeedbackState.Created) {
+					if (createdMirrorBySource.has(item.sourcePRReviewCommentId)) {
+						duplicateCreatedMirrors.push(item);
+					} else {
+						createdMirrorBySource.set(item.sourcePRReviewCommentId, item);
+					}
+				}
+			}
+		}
+		for (const duplicate of duplicateCreatedMirrors) {
+			this._agentFeedbackService.removeFeedback(sessionResource, duplicate.id);
+		}
+
+		for (const comment of comments) {
+			const createdMirror = createdMirrorBySource.get(comment.id);
+			if (createdMirror) {
+				// Keep an existing un-accepted mirror in sync with edits to the
+				// upstream comment body so the agent reads the latest text.
+				if (createdMirror.text !== comment.body) {
+					this._agentFeedbackService.updateFeedback(sessionResource, createdMirror.id, comment.body);
+				}
+				continue;
+			}
+			// A mirror the user already accepted/submitted supersedes the raw PR
+			// comment; only seed a new created mirror when none exists yet.
+			if (!mirroredSourceIds.has(comment.id)) {
+				this._agentFeedbackService.addFeedback(
+					sessionResource,
+					comment.uri,
+					comment.range,
+					comment.body,
+					undefined,
+					undefined,
+					comment.id,
+					AgentFeedbackKind.PRReview,
+					AgentFeedbackState.Created,
+				);
+			}
+		}
+
+		// Drop mirrors whose PR comment is gone (resolved upstream, converted to
+		// a separate accepted item from the editor, or dismissed) while still
+		// un-accepted; accepted/submitted mirrors are kept since the user acted
+		// on them.
+		const liveSourceIds = new Set(comments.map(comment => comment.id));
+		for (const item of feedback) {
+			if (item.kind === AgentFeedbackKind.PRReview
+				&& item.state === AgentFeedbackState.Created
+				&& item.sourcePRReviewCommentId
+				&& !liveSourceIds.has(item.sourcePRReviewCommentId)
+			) {
+				this._agentFeedbackService.removeFeedback(sessionResource, item.id);
+			}
+		}
+	}
+}

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackReviewCommands.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackReviewCommands.ts
@@ -7,6 +7,7 @@ import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
 import { AgentFeedbackReviewCommandId, IChatAgentFeedbackReviewComment } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { ICodeReviewService } from '../../codeReview/browser/codeReviewService.js';
 import { AgentFeedbackKind, AgentFeedbackState, IAgentFeedbackService } from './agentFeedbackService.js';
 
 /**
@@ -58,7 +59,16 @@ export function registerAgentFeedbackReviewCommands(): void {
 
 	CommandsRegistry.registerCommand(AgentFeedbackReviewCommandId.Delete, (accessor, sessionResource: UriComponents, commentId: string): void => {
 		const feedbackService = accessor.get(IAgentFeedbackService);
-		feedbackService.removeFeedback(URI.revive(sessionResource), commentId);
+		const codeReviewService = accessor.get(ICodeReviewService);
+		const resource = URI.revive(sessionResource);
+		// Suppress the originating PR comment first (before removing the mirror)
+		// so the PR-review seeder does not immediately re-create the mirror the
+		// user just deleted.
+		const item = feedbackService.getFeedback(resource).find(f => f.id === commentId);
+		if (item?.kind === AgentFeedbackKind.PRReview && item.sourcePRReviewCommentId) {
+			codeReviewService.dismissPRReviewComment(resource, item.sourcePRReviewCommentId);
+		}
+		feedbackService.removeFeedback(resource, commentId);
 	});
 
 	CommandsRegistry.registerCommand(AgentFeedbackReviewCommandId.Accept, (accessor, sessionResource: UriComponents, commentIds: readonly string[]): void => {

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
@@ -162,6 +162,15 @@ export interface IAgentFeedbackService {
 	getFeedback(sessionResource: URI): readonly IAgentFeedback[];
 
 	/**
+	 * Whether {@link getFeedback} reflects the authoritative item set for the
+	 * session. For agent-host sessions this is `false` until the session's
+	 * annotations snapshot has been received; for other sessions it is always
+	 * `true`. Callers that seed feedback from another source must wait for this
+	 * to avoid acting on a transiently-empty list.
+	 */
+	hasLoadedFeedback(sessionResource: URI): boolean;
+
+	/**
 	 * Resolve the session that owns the given file resource. Returns the
 	 * session that was active when the file's editor was first opened; if the
 	 * file has never been tracked, falls back to the currently active session.
@@ -438,6 +447,10 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 
 	getFeedback(sessionResource: URI): readonly IAgentFeedback[] {
 		return this._backendForSession(sessionResource).getItems(sessionResource);
+	}
+
+	hasLoadedFeedback(sessionResource: URI): boolean {
+		return this._backendForSession(sessionResource).hasLoaded(sessionResource);
 	}
 
 	getMostRecentSessionForResource(resourceUri: URI): URI | undefined {

--- a/src/vs/sessions/contrib/agentFeedback/browser/nullAgentFeedbackService.contribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/nullAgentFeedbackService.contribution.ts
@@ -48,6 +48,7 @@ class NullAgentFeedbackService extends Disposable implements IAgentFeedbackServi
 	setFeedbackResolved(_sessionResource: URI, _feedbackId: string, _resolved: boolean): void { }
 	addReply(_sessionResource: URI, _feedbackId: string, _replyText: string): void { }
 	getFeedback(_sessionResource: URI): readonly IAgentFeedback[] { return []; }
+	hasLoadedFeedback(_sessionResource: URI): boolean { return true; }
 	getSessionForFile(_resourceUri: URI): undefined { return undefined; }
 	getMostRecentSessionForResource(_resourceUri: URI): URI | undefined { return undefined; }
 	async revealFeedback(_sessionResource: URI, _feedbackId: string): Promise<void> { }

--- a/src/vs/sessions/contrib/agentFeedback/browser/sessionEditorComments.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/sessionEditorComments.ts
@@ -48,9 +48,27 @@ export function getSessionEditorComments(
 ): readonly ISessionEditorComment[] {
 	const comments: ISessionEditorComment[] = [];
 
+	// PR review comments are mirrored onto the feedback channel as `created`
+	// `prReview` items so the agent can see them (see
+	// `agentFeedbackPRReviewSeeder.ts`). Deduplicate the two representations by
+	// the originating PR thread id: while a mirror is still `created` the raw PR
+	// comment is shown (preserving its native actions) and the mirror is hidden;
+	// once the user accepts the mirror it supersedes the raw PR comment.
+	const supersededPRCommentIds = new Set<string>();
+	for (const item of agentFeedbackItems) {
+		if (item.kind === AgentFeedbackKind.PRReview && item.sourcePRReviewCommentId && item.state !== AgentFeedbackState.Created) {
+			supersededPRCommentIds.add(item.sourcePRReviewCommentId);
+		}
+	}
+
 	for (const item of agentFeedbackItems) {
 		// Resolved feedback is hidden from the editor UI.
 		if (item.state === AgentFeedbackState.Resolved) {
+			continue;
+		}
+		// Hide the still-unaccepted PR review mirror; the raw PR comment is
+		// shown instead.
+		if (item.kind === AgentFeedbackKind.PRReview && item.state === AgentFeedbackState.Created && item.sourcePRReviewCommentId) {
 			continue;
 		}
 		comments.push({
@@ -70,6 +88,11 @@ export function getSessionEditorComments(
 	}
 
 	for (const item of getPRReviewComments(prReviewState)) {
+		// Hide raw PR comments that the user has already accepted into agent
+		// feedback (shown via the accepted mirror above).
+		if (supersededPRCommentIds.has(item.id)) {
+			continue;
+		}
 		comments.push({
 			id: toSessionEditorCommentId(SessionEditorCommentSource.PRReview, item.id),
 			sourceId: item.id,

--- a/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackPRReviewSeeder.test.ts
+++ b/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackPRReviewSeeder.test.ts
@@ -1,0 +1,182 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { IRange, Range } from '../../../../../editor/common/core/range.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { generateUuid } from '../../../../../base/common/uuid.js';
+import { LOCAL_AGENT_HOST_PROVIDER_ID } from '../../../../common/agentHostSessionsProvider.js';
+import { IActiveSession } from '../../../../services/sessions/common/sessionsManagement.js';
+import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
+import { ICodeReviewService, ICodeReviewSuggestion, IPRReviewComment, IPRReviewState, PRReviewStateKind } from '../../../codeReview/browser/codeReviewService.js';
+import { IAgentFeedbackContext } from '../../browser/agentFeedbackEditorUtils.js';
+import { AgentFeedbackKind, AgentFeedbackState, IAgentFeedback, IAgentFeedbackService } from '../../browser/agentFeedbackService.js';
+import { AgentFeedbackPRReviewSeederContribution } from '../../browser/agentFeedbackPRReviewSeeder.js';
+
+suite('AgentFeedbackPRReviewSeederContribution', () => {
+
+	const store = new DisposableStore();
+	const session = URI.parse('local-agent-host:/session-1');
+	const fileA = URI.file('/workspace/a.ts');
+
+	let feedbackItems: IAgentFeedback[];
+	let loaded: boolean;
+	let onDidChangeFeedback: Emitter<{ sessionResource: URI; feedbackItems: readonly IAgentFeedback[] }>;
+	let prReviewState: ISettableObservable<IPRReviewState>;
+	let activeSession: ISettableObservable<IActiveSession | undefined>;
+
+	function prComment(id: string, line: number, body: string): IPRReviewComment {
+		return { id, uri: fileA, range: new Range(line, 1, line, 1), body, author: 'reviewer' };
+	}
+
+	function setComments(...comments: IPRReviewComment[]): void {
+		prReviewState.set({ kind: PRReviewStateKind.Loaded, comments }, undefined);
+	}
+
+	function mirrors(): { sourceId: string | undefined; state: AgentFeedbackState; text: string }[] {
+		return feedbackItems
+			.filter(i => i.kind === AgentFeedbackKind.PRReview)
+			.map(i => ({ sourceId: i.sourcePRReviewCommentId, state: i.state, text: i.text }));
+	}
+
+	function makeActiveSession(providerId: string): IActiveSession {
+		return new class extends mock<IActiveSession>() {
+			override readonly resource = session;
+			override readonly providerId = providerId;
+		};
+	}
+
+	setup(() => {
+		feedbackItems = [];
+		loaded = true;
+		onDidChangeFeedback = store.add(new Emitter());
+		prReviewState = observableValue<IPRReviewState>('prReviewState', { kind: PRReviewStateKind.None });
+		activeSession = observableValue<IActiveSession | undefined>('activeSession', makeActiveSession(LOCAL_AGENT_HOST_PROVIDER_ID));
+
+		const feedbackService = new class extends mock<IAgentFeedbackService>() {
+			override onDidChangeFeedback = onDidChangeFeedback.event;
+			override hasLoadedFeedback(): boolean { return loaded; }
+			override getFeedback(): readonly IAgentFeedback[] { return feedbackItems; }
+			override addFeedback(sessionResource: URI, resourceUri: URI, range: IRange, text: string, _suggestion?: ICodeReviewSuggestion, _context?: IAgentFeedbackContext, sourcePRReviewCommentId?: string, _kind?: AgentFeedbackKind, state: AgentFeedbackState = AgentFeedbackState.Accepted): IAgentFeedback {
+				const feedback: IAgentFeedback = { id: generateUuid(), text, resourceUri, range, sessionResource, kind: AgentFeedbackKind.PRReview, sourcePRReviewCommentId, state };
+				feedbackItems.push(feedback);
+				onDidChangeFeedback.fire({ sessionResource, feedbackItems });
+				return feedback;
+			}
+			override removeFeedback(_sessionResource: URI, feedbackId: string): void {
+				const idx = feedbackItems.findIndex(i => i.id === feedbackId);
+				if (idx >= 0) {
+					feedbackItems.splice(idx, 1);
+					onDidChangeFeedback.fire({ sessionResource: session, feedbackItems });
+				}
+			}
+			override updateFeedback(_sessionResource: URI, feedbackId: string, newText: string): void {
+				const idx = feedbackItems.findIndex(i => i.id === feedbackId);
+				if (idx >= 0) {
+					feedbackItems[idx] = { ...feedbackItems[idx], text: newText };
+					onDidChangeFeedback.fire({ sessionResource: session, feedbackItems });
+				}
+			}
+		};
+		const codeReviewService = new class extends mock<ICodeReviewService>() {
+			override getPRReviewState() { return prReviewState; }
+		};
+		const sessionsService = new class extends mock<ISessionsService>() {
+			override activeSession = activeSession;
+		};
+
+		store.add(new AgentFeedbackPRReviewSeederContribution(feedbackService, codeReviewService, sessionsService));
+	});
+
+	teardown(() => store.clear());
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('seeds a created PR-review mirror for each un-accepted PR comment', () => {
+		setComments(prComment('thread-1', 5, 'Fix this'), prComment('thread-2', 9, 'And this'));
+
+		assert.deepStrictEqual(mirrors(), [
+			{ sourceId: 'thread-1', state: AgentFeedbackState.Created, text: 'Fix this' },
+			{ sourceId: 'thread-2', state: AgentFeedbackState.Created, text: 'And this' },
+		]);
+	});
+
+	test('does not duplicate mirrors when the PR review state re-emits', () => {
+		setComments(prComment('thread-1', 5, 'Fix this'));
+		setComments(prComment('thread-1', 5, 'Fix this'), prComment('thread-2', 9, 'And this'));
+
+		assert.deepStrictEqual(mirrors().map(m => m.sourceId), ['thread-1', 'thread-2']);
+	});
+
+	test('refreshes a created mirror when the upstream comment body changes', () => {
+		setComments(prComment('thread-1', 5, 'Fix this'));
+		setComments(prComment('thread-1', 5, 'Fix this differently'));
+
+		assert.deepStrictEqual(mirrors(), [
+			{ sourceId: 'thread-1', state: AgentFeedbackState.Created, text: 'Fix this differently' },
+		]);
+	});
+
+	test('does not refresh an accepted mirror when the upstream comment body changes', () => {
+		setComments(prComment('thread-1', 5, 'Fix this'));
+		feedbackItems[0] = { ...feedbackItems[0], state: AgentFeedbackState.Accepted };
+		setComments(prComment('thread-1', 5, 'Fix this differently'));
+
+		assert.deepStrictEqual(mirrors(), [
+			{ sourceId: 'thread-1', state: AgentFeedbackState.Accepted, text: 'Fix this' },
+		]);
+	});
+
+	test('removes a created mirror when its PR comment disappears', () => {
+		setComments(prComment('thread-1', 5, 'Fix this'), prComment('thread-2', 9, 'And this'));
+		setComments(prComment('thread-1', 5, 'Fix this'));
+
+		assert.deepStrictEqual(mirrors().map(m => m.sourceId), ['thread-1']);
+	});
+
+	test('keeps an accepted mirror even after its PR comment disappears', () => {
+		setComments(prComment('thread-1', 5, 'Fix this'));
+		// Simulate the user accepting the mirror.
+		feedbackItems[0] = { ...feedbackItems[0], state: AgentFeedbackState.Accepted };
+		setComments();
+
+		assert.deepStrictEqual(mirrors(), [
+			{ sourceId: 'thread-1', state: AgentFeedbackState.Accepted, text: 'Fix this' },
+		]);
+	});
+
+	test('collapses duplicate created mirrors for the same PR comment', () => {
+		// Two windows (or a benign echo race) seeded the same comment twice.
+		feedbackItems.push(
+			{ id: 'mirror-a', text: 'Fix this', resourceUri: fileA, range: new Range(5, 1, 5, 1), sessionResource: session, kind: AgentFeedbackKind.PRReview, sourcePRReviewCommentId: 'thread-1', state: AgentFeedbackState.Created },
+			{ id: 'mirror-b', text: 'Fix this', resourceUri: fileA, range: new Range(5, 1, 5, 1), sessionResource: session, kind: AgentFeedbackKind.PRReview, sourcePRReviewCommentId: 'thread-1', state: AgentFeedbackState.Created },
+		);
+		setComments(prComment('thread-1', 5, 'Fix this'));
+
+		assert.deepStrictEqual(mirrors().map(m => m.sourceId), ['thread-1']);
+	});
+
+	test('does not seed until the feedback set has loaded', () => {
+		loaded = false;
+		setComments(prComment('thread-1', 5, 'Fix this'));
+		assert.deepStrictEqual(mirrors(), []);
+
+		// Once loaded, a feedback change re-evaluates and seeds.
+		loaded = true;
+		onDidChangeFeedback.fire({ sessionResource: session, feedbackItems });
+		assert.deepStrictEqual(mirrors().map(m => m.sourceId), ['thread-1']);
+	});
+
+	test('does not seed for non-agent-host sessions', () => {
+		activeSession.set(makeActiveSession('copilot-chat'), undefined);
+		setComments(prComment('thread-1', 5, 'Fix this'));
+
+		assert.deepStrictEqual(mirrors(), []);
+	});
+});

--- a/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackPRReviewSeeder.test.ts
+++ b/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackPRReviewSeeder.test.ts
@@ -5,7 +5,6 @@
 
 import assert from 'assert';
 import { Emitter } from '../../../../../base/common/event.js';
-import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { IRange, Range } from '../../../../../editor/common/core/range.js';
@@ -22,7 +21,7 @@ import { AgentFeedbackPRReviewSeederContribution } from '../../browser/agentFeed
 
 suite('AgentFeedbackPRReviewSeederContribution', () => {
 
-	const store = new DisposableStore();
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
 	const session = URI.parse('local-agent-host:/session-1');
 	const fileA = URI.file('/workspace/a.ts');
 
@@ -62,8 +61,8 @@ suite('AgentFeedbackPRReviewSeederContribution', () => {
 
 		const feedbackService = new class extends mock<IAgentFeedbackService>() {
 			override onDidChangeFeedback = onDidChangeFeedback.event;
-			override hasLoadedFeedback(): boolean { return loaded; }
-			override getFeedback(): readonly IAgentFeedback[] { return feedbackItems; }
+			override hasLoadedFeedback(_sessionResource: URI): boolean { return loaded; }
+			override getFeedback(_sessionResource: URI): readonly IAgentFeedback[] { return feedbackItems; }
 			override addFeedback(sessionResource: URI, resourceUri: URI, range: IRange, text: string, _suggestion?: ICodeReviewSuggestion, _context?: IAgentFeedbackContext, sourcePRReviewCommentId?: string, _kind?: AgentFeedbackKind, state: AgentFeedbackState = AgentFeedbackState.Accepted): IAgentFeedback {
 				const feedback: IAgentFeedback = { id: generateUuid(), text, resourceUri, range, sessionResource, kind: AgentFeedbackKind.PRReview, sourcePRReviewCommentId, state };
 				feedbackItems.push(feedback);
@@ -86,7 +85,7 @@ suite('AgentFeedbackPRReviewSeederContribution', () => {
 			}
 		};
 		const codeReviewService = new class extends mock<ICodeReviewService>() {
-			override getPRReviewState() { return prReviewState; }
+			override getPRReviewState(_sessionResource: URI) { return prReviewState; }
 		};
 		const sessionsService = new class extends mock<ISessionsService>() {
 			override activeSession = activeSession;
@@ -94,9 +93,6 @@ suite('AgentFeedbackPRReviewSeederContribution', () => {
 
 		store.add(new AgentFeedbackPRReviewSeederContribution(feedbackService, codeReviewService, sessionsService));
 	});
-
-	teardown(() => store.clear());
-	ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('seeds a created PR-review mirror for each un-accepted PR comment', () => {
 		setComments(prComment('thread-1', 5, 'Fix this'), prComment('thread-2', 9, 'And this'));

--- a/src/vs/sessions/contrib/agentFeedback/test/browser/sessionEditorComments.test.ts
+++ b/src/vs/sessions/contrib/agentFeedback/test/browser/sessionEditorComments.test.ts
@@ -129,4 +129,32 @@ suite('SessionEditorComments', () => {
 
 		assert.deepStrictEqual(comments.map(comment => comment.sourceId), ['feedback-accepted']);
 	});
+
+	test('hides a created PR-review mirror and shows the raw PR comment instead', () => {
+		const prState: IPRReviewState = {
+			kind: PRReviewStateKind.Loaded,
+			comments: [
+				{ id: 'pr-thread-1', uri: fileA, range: new Range(5, 1, 5, 1), body: 'Please fix this', author: 'reviewer' },
+			],
+		};
+		const comments = getSessionEditorComments(session, [
+			{ id: 'mirror-1', text: 'Please fix this', resourceUri: fileA, range: new Range(5, 1, 5, 1), sessionResource: session, kind: AgentFeedbackKind.PRReview, sourcePRReviewCommentId: 'pr-thread-1', state: AgentFeedbackState.Created },
+		], prState);
+
+		assert.deepStrictEqual(comments.map(c => `${c.source}:${c.sourceId}`), ['prReview:pr-thread-1']);
+	});
+
+	test('shows an accepted PR-review mirror and hides the superseded raw PR comment', () => {
+		const prState: IPRReviewState = {
+			kind: PRReviewStateKind.Loaded,
+			comments: [
+				{ id: 'pr-thread-1', uri: fileA, range: new Range(5, 1, 5, 1), body: 'Please fix this', author: 'reviewer' },
+			],
+		};
+		const comments = getSessionEditorComments(session, [
+			{ id: 'mirror-1', text: 'Please fix this', resourceUri: fileA, range: new Range(5, 1, 5, 1), sessionResource: session, kind: AgentFeedbackKind.PRReview, sourcePRReviewCommentId: 'pr-thread-1', state: AgentFeedbackState.Accepted },
+		], prState);
+
+		assert.deepStrictEqual(comments.map(c => `${c.source}:${c.sourceId}`), ['agentFeedback:mirror-1']);
+	});
 });

--- a/src/vs/sessions/contrib/codeReview/browser/codeReviewService.ts
+++ b/src/vs/sessions/contrib/codeReview/browser/codeReviewService.ts
@@ -72,6 +72,16 @@ export interface ICodeReviewService {
 	 * cleaned up.
 	 */
 	markPRReviewCommentConverted(sessionResource: URI, commentId: string): void;
+
+	/**
+	 * Dismiss a PR review comment so it no longer appears in the review state.
+	 * Used when the user deletes the comment's pending agent-feedback mirror
+	 * from the `viewUnreviewedComments` confirmation: without suppressing the
+	 * source comment the mirror would be seeded again. Like
+	 * {@link markPRReviewCommentConverted} this is a local, in-memory filter that
+	 * does not touch GitHub and is reset when the session is cleaned up.
+	 */
+	dismissPRReviewComment(sessionResource: URI, commentId: string): void;
 }
 
 // --- Implementation ----------------------------------------------------------
@@ -85,7 +95,11 @@ export class CodeReviewService extends Disposable implements ICodeReviewService 
 	declare readonly _serviceBrand: undefined;
 
 	private readonly _prReviewBySession = new Map<string, IPRSessionReviewData>();
-	/** PR review comment IDs that have been converted to agent feedback (per session). */
+	/**
+	 * PR review comment IDs that have been locally handled — converted to agent
+	 * feedback or dismissed from the `viewUnreviewedComments` confirmation — and
+	 * are therefore hidden from the PR review state (per session).
+	 */
 	private readonly _convertedPRCommentsBySession = new Map<string, Set<string>>();
 
 	constructor(
@@ -198,6 +212,19 @@ export class CodeReviewService extends Disposable implements ICodeReviewService 
 	}
 
 	markPRReviewCommentConverted(sessionResource: URI, commentId: string): void {
+		this._suppressPRReviewComment(sessionResource, commentId);
+	}
+
+	dismissPRReviewComment(sessionResource: URI, commentId: string): void {
+		this._suppressPRReviewComment(sessionResource, commentId);
+	}
+
+	/**
+	 * Hide a PR review comment from the session's review state and remember it
+	 * so the projection autorun keeps filtering it. Shared by
+	 * {@link markPRReviewCommentConverted} and {@link dismissPRReviewComment}.
+	 */
+	private _suppressPRReviewComment(sessionResource: URI, commentId: string): void {
 		const key = sessionResource.toString();
 		let converted = this._convertedPRCommentsBySession.get(key);
 		if (!converted) {

--- a/src/vs/sessions/contrib/codeReview/test/browser/codeReviewService.test.ts
+++ b/src/vs/sessions/contrib/codeReview/test/browser/codeReviewService.test.ts
@@ -258,23 +258,23 @@ suite('CodeReviewService', () => {
 		}
 	});
 
-	test('resolvePRReviewThread uses dedicated review threads model', async () => {
+	test('dismissPRReviewComment filters the comment from the loaded review state', async () => {
 		sessionsManagement.addSession(session);
 		sessionsManagement.setGitHubInfo(session, makeGitHubInfo());
+		gitHubService.reviewThreadsFetcher.nextThreads = [makePRThread('thread-100', 'src/a.ts'), makePRThread('thread-200', 'src/b.ts')];
 
-		await service.resolvePRReviewThread(session, 'thread-100');
+		sessionsManagement.setActiveSession(sessionsManagement.getSession(session));
+		await tick();
+		await gitHubService.getReviewThreadsModel('owner', 'repo', 1).refresh();
+		await tick();
 
-		assert.deepStrictEqual({
-			getPullRequestCalls: gitHubService.getPullRequestCalls,
-			getPullRequestReviewThreadsCalls: gitHubService.getPullRequestReviewThreadsCalls,
-			legacyResolveThreadCalls: gitHubService.legacyFetcher.resolveThreadCalls,
-			reviewResolveThreadCalls: gitHubService.reviewThreadsFetcher.resolveThreadCalls,
-		}, {
-			getPullRequestCalls: 0,
-			getPullRequestReviewThreadsCalls: 1,
-			legacyResolveThreadCalls: [],
-			reviewResolveThreadCalls: [{ threadId: 'thread-100' }],
-		});
+		service.dismissPRReviewComment(session, 'thread-100');
+
+		const state = service.getPRReviewState(session).get();
+		assert.deepStrictEqual(
+			state.kind === PRReviewStateKind.Loaded ? state.comments.map(c => c.id) : state.kind,
+			['thread-200'],
+		);
 	});
 });
 

--- a/src/vs/sessions/contrib/codeReview/test/browser/codeReviewService.test.ts
+++ b/src/vs/sessions/contrib/codeReview/test/browser/codeReviewService.test.ts
@@ -258,6 +258,25 @@ suite('CodeReviewService', () => {
 		}
 	});
 
+	test('resolvePRReviewThread uses dedicated review threads model', async () => {
+		sessionsManagement.addSession(session);
+		sessionsManagement.setGitHubInfo(session, makeGitHubInfo());
+
+		await service.resolvePRReviewThread(session, 'thread-100');
+
+		assert.deepStrictEqual({
+			getPullRequestCalls: gitHubService.getPullRequestCalls,
+			getPullRequestReviewThreadsCalls: gitHubService.getPullRequestReviewThreadsCalls,
+			legacyResolveThreadCalls: gitHubService.legacyFetcher.resolveThreadCalls,
+			reviewResolveThreadCalls: gitHubService.reviewThreadsFetcher.resolveThreadCalls,
+		}, {
+			getPullRequestCalls: 0,
+			getPullRequestReviewThreadsCalls: 1,
+			legacyResolveThreadCalls: [],
+			reviewResolveThreadCalls: [{ threadId: 'thread-100' }],
+		});
+	});
+
 	test('dismissPRReviewComment filters the comment from the loaded review state', async () => {
 		sessionsManagement.addSession(session);
 		sessionsManagement.setGitHubInfo(session, makeGitHubInfo());

--- a/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
@@ -603,6 +603,7 @@ export function createEditorServices(disposables: DisposableStore, options?: Cre
 		acceptFeedback: () => { },
 		addReply: () => { },
 		getFeedback: () => [],
+		hasLoadedFeedback: () => true,
 		getSessionForFile: () => undefined,
 		getMostRecentSessionForResource: () => undefined,
 		revealFeedback: async () => { },


### PR DESCRIPTION
Fixes #322172

## Problem  When working with agent feedback in an agent-host session, un-accepted **PR review comments** were invisible to the agent. The agent-host `listComments` tool appends a note ("there are N pull request comments which the user has not reviewed yet") and the `viewUnreviewedComments` tool reveals those comments — but both read **only** agent-feedback annotations whose `_meta` is `kind: 'prReview'` + `state: 'created'`.  Un-accepted PR review comments lived only client-side in `CodeReviewService` (`prReviewState`, keyed by session resource) and were never written to the session's annotations channel. So the note always said zero and `viewUnreviewedComments` returned nothing. (The channel-key resolution itself is fine: the server already normalizes peer-chat URIs to the owning session, and the client resolves the channel via `session.sessionId`, so a session's comments stay on one channel across multiple chats.)  ## Fix  Add `AgentFeedbackPRReviewSeederContribution`, which mirrors the active agent-host session's un-accepted PR review comments onto the feedback annotations channel as `created` `prReview` items, **keyed by the session resource** (the same key every other feedback op uses). Each mirror carries `sourcePRReviewCommentId` so it can be de-duplicated against the raw PR comment in the editor and so resolving it resolves the originating GitHub thread.  The seeder is idempotent and self-healing: - seeds a `created` mirror for each PR comment that has none; - refreshes a `created` mirror's text when the upstream comment body changes; - collapses duplicate `created` mirrors for the same source (benign echo race / two windows); - removes a `created` mirror when its source PR comment disappears (resolved upstream, converted, or dismissed), while keeping accepted/submitted mirrors.  Supporting changes: - `IAgentFeedbackItemsBackend.hasLoaded` / `IAgentFeedbackService.hasLoadedFeedback` (+ a one-time "snapshot loaded" event) so the seeder waits for the authoritative annotations snapshot before acting — avoiding duplicate mirrors on reload. - `ICodeReviewService.dismissPRReviewComment`: deleting a comment from the `viewUnreviewedComments` confirmation now suppresses the source PR comment so the seeder does not immediately recreate the mirror. - `getSessionEditorComments` de-duplicates the two representations in the editor: a still-`created` mirror is hidden (raw PR comment shown with its native actions); once accepted/submitted the mirror supersedes the raw comment.  ## Notes for reviewers  - Only the **active** session is seeded by design — `CodeReviewService` only loads PR review threads for the active session, and mirrors persist as server-side annotations so they survive a session going inactive. This is documented in the seeder. - A rubber-duck review was run; findings (stale mirror content, non-sticky delete, active-session rationale) were addressed, plus a self-healing duplicate-collapse for the snapshot-echo race. - Tests added: seeder behavior (`agentFeedbackPRReviewSeeder.test.ts`), editor de-dup (`sessionEditorComments.test.ts`), and `dismissPRReviewComment` (`codeReviewService.test.ts`). - :warning: Hygiene/compile and the test suites could not be executed in the authoring environment (no `node_modules`/build tooling). All changed files pass language-server diagnostics; please run the agentFeedback/codeReview unit tests in CI/locally before merging.  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com> 