### PR TITLE
Add sshd to devcontainer features

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -9,6 +9,11 @@
       "version": "1.5.0",
       "resolved": "ghcr.io/devcontainers/features/rust@sha256:0c55e65f2e3df736e478f26ee4d5ed41bae6b54dac1318c443e31444c8ed283c",
       "integrity": "sha256:0c55e65f2e3df736e478f26ee4d5ed41bae6b54dac1318c443e31444c8ed283c"
+    },
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/sshd@sha256:f5251b8e4325f68f7280973c6cd65daff414449c66f240621502d4e8e74eb7ee",
+      "integrity": "sha256:f5251b8e4325f68f7280973c6cd65daff414449c66f240621502d4e8e74eb7ee"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,9 +6,7 @@
 	"features": {
 		"ghcr.io/devcontainers/features/desktop-lite:": {},
 		"ghcr.io/devcontainers/features/rust:": {},
-		"ghcr.io/devcontainers/features/sshd:1": {
-			"version": "latest"
-		}
+		"ghcr.io/devcontainers/features/sshd:1": {}
 	},
 	"containerEnv": {
 		"DISPLAY": "" // Allow the Dev Containers extension to set DISPLAY, post-create.sh will add it back in ~/.bashrc and ~/.zshrc if not set.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,10 @@
 	},
 	"features": {
 		"ghcr.io/devcontainers/features/desktop-lite:": {},
-		"ghcr.io/devcontainers/features/rust:": {}
+		"ghcr.io/devcontainers/features/rust:": {},
+		"ghcr.io/devcontainers/features/sshd:1": {
+			"version": "latest"
+		}
 	},
 	"containerEnv": {
 		"DISPLAY": "" // Allow the Dev Containers extension to set DISPLAY, post-create.sh will add it back in ~/.bashrc and ~/.zshrc if not set.


### PR DESCRIPTION
Adds the devcontainers sshd feature so GitHub Codespaces built from this devcontainer can be accessed with 

gh codespace ssh

This is especially useful when a local agent does vscode development against a remote codespace.