### PR TITLE
sessions: save unstarted session drafts on navigation and exit

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -287,6 +287,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 			placeholder?: string;
 			renderSessionTypePickerInControls?: boolean;
 			supportsBackground?: boolean;
+			draftStorageKey?: string;
 		},
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IModelService private readonly modelService: IModelService,
@@ -766,6 +767,9 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 	}
 
 	private _restoreState(): void {
+		if (!this.options.draftStorageKey) {
+			return;
+		}
 		const draft = this._getDraftState();
 		if (draft) {
 			this._editor?.getModel()?.setValue(draft.inputText);
@@ -776,7 +780,10 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 	}
 
 	private _getDraftState(): IDraftState | undefined {
-		const raw = this.storageService.get(STORAGE_KEY_DRAFT_STATE, StorageScope.WORKSPACE);
+		if (!this.options.draftStorageKey) {
+			return undefined;
+		}
+		const raw = this.storageService.get(this.options.draftStorageKey, StorageScope.WORKSPACE);
 		if (!raw) {
 			return undefined;
 		}
@@ -789,17 +796,27 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 
 	private _clearDraftState(): void {
 		this._draftState = { inputText: '', attachments: [] };
-		this.storageService.store(STORAGE_KEY_DRAFT_STATE, JSON.stringify(this._draftState), StorageScope.WORKSPACE, StorageTarget.MACHINE);
+		if (this.options.draftStorageKey) {
+			this.storageService.store(this.options.draftStorageKey, JSON.stringify(this._draftState), StorageScope.WORKSPACE, StorageTarget.MACHINE);
+		}
 	}
 
 	saveState(): void {
+		if (!this.options.draftStorageKey) {
+			return;
+		}
 		if (this._draftState) {
 			const state = {
 				...this._draftState,
 				attachments: this._draftState.attachments.map(IChatRequestVariableEntry.toExport),
 			};
-			this.storageService.store(STORAGE_KEY_DRAFT_STATE, JSON.stringify(state), StorageScope.WORKSPACE, StorageTarget.MACHINE);
+			this.storageService.store(this.options.draftStorageKey, JSON.stringify(state), StorageScope.WORKSPACE, StorageTarget.MACHINE);
 		}
+	}
+
+	override dispose(): void {
+		this.saveState();
+		super.dispose();
 	}
 
 	layout(_height: number, _width: number): void {

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -121,6 +121,7 @@ export class NewChatWidget extends Disposable {
 			historyKey: constObservable(undefined), // no persisted history for the new-session view
 			renderSessionTypePickerInControls: this._renderHarnessPickerInControls,
 			supportsBackground: true,
+			draftStorageKey: 'sessions.draftState',
 		}));
 
 		this._register(this._workspacePicker.onDidSelectWorkspace(async folderUri => {


### PR DESCRIPTION
# Propose Draft State Preservation for Unstarted Session Composers

Proposes configuring a conditional `draftStorageKey` on `NewChatInputWidget` to persist the unsent draft state of unstarted session composers when navigating away from them (e.g. into active sessions) and upon application exit.

### Problem
Previously, when the user opened the "New Session" compose view in the Agents Window, typed a draft, and navigated to a previous session in the sidebar/history, the unstarted `NewChatView` was disposed without saving. Because there was no disposal save trigger, any typed draft was immediately lost. 

Additionally, both the main unstarted session composer and any in-session sub-chats (`NewChatInSessionWidget`) instantiated `NewChatInputWidget` and shared the same global storage key (`'sessions.draftState'`), which would lead to collisions.

### Solution
1. **Disposal-Safe Saving**: `NewChatInputWidget` now invokes its `saveState()` method during `dispose()`. This ensures that navigating away from an unstarted session safely commits the current draft text and attachments.
2. **Key Isolation**: Added a `draftStorageKey` property to the input widget options. 
   - `NewChatWidget` (the home screen compose view) passes `'sessions.draftState'` as its storage key, enabling saving and restoring.
   - `NewChatInSessionWidget` (the in-session sub-chats) leaves it undefined, ensuring they never read or write to the global composer draft key and eliminating draft collisions.

### Goal of this Draft PR
This PR is opened as a draft/reference implementation to demonstrate the clarified draft state management. The goal is to:
- Propose this lightweight fix to the draft state management lifecycle.
- Obtain feedback and early validation from the team regarding the approach.
- Seek guidance if a different architecture or a dedicated draft service is preferred for managing persistent unstarted drafts.

Closes #315996
