### PR TITLE
fix(oss): make cached-NOTICE fallback download match files

### DIFF
--- a/build/azure-pipelines/product-quality-checks.yml
+++ b/build/azure-pipelines/product-quality-checks.yml
@@ -200,7 +200,15 @@ jobs:
           branchName: $(Build.SourceBranch)
           allowPartiallySucceededBuilds: true
           artifactName: notice_output
-          itemPattern: "**/{ThirdPartyNotices.generated.txt,notice-meta.txt}"
+          # NB: one glob per line. DownloadBuildArtifacts@1 runs minimatch with
+          # brace expansion disabled, so a "**/{a,b}" pattern matches NOTHING and
+          # silently downloads 0 files (observed in build 450982, the first real
+          # CG outage post-cutover: the artifact downloaded but every file was
+          # excluded, so the apply-fallback step saw no cache). Multi-line plain
+          # globs are matched reliably.
+          itemPattern: |
+            **/ThirdPartyNotices.generated.txt
+            **/notice-meta.txt
           downloadPath: $(Pipeline.Workspace)/cached-notice-branch
         continueOnError: true
         condition: and(succeeded(), ne(variables.CG_NOTICE_OK, 'true'))
@@ -215,7 +223,11 @@ jobs:
           branchName: refs/heads/main
           allowPartiallySucceededBuilds: true
           artifactName: notice_output
-          itemPattern: "**/{ThirdPartyNotices.generated.txt,notice-meta.txt}"
+          # See note on the same-branch download above: brace patterns match 0
+          # files in DownloadBuildArtifacts@1. Keep one plain glob per line.
+          itemPattern: |
+            **/ThirdPartyNotices.generated.txt
+            **/notice-meta.txt
           downloadPath: $(Pipeline.Workspace)/cached-notice-main
         continueOnError: true
         condition: and(succeeded(), ne(variables.CG_NOTICE_OK, 'true'), ne(variables['Build.SourceBranch'], 'refs/heads/main'))


### PR DESCRIPTION
🤖 AI Assisted PR

## What

The cached-NOTICE fallback in the Quality stage never actually downloaded the cached NOTICE, because both `DownloadBuildArtifacts@1` steps used a brace-expansion `itemPattern`:

```yaml
itemPattern: "**/{ThirdPartyNotices.generated.txt,notice-meta.txt}"
```

`DownloadBuildArtifacts@1` runs minimatch with brace expansion **disabled**, so this pattern matches **zero** files. The `notice_output` artifact downloads, but every file is filtered out before it hits disk — and the downstream "apply NOTICE fallback" step then correctly reports "No cached NOTICE available".

## How it surfaced

Build **450982** is the first real Component Governance (`notice@0`) outage on `main` since the cutover. The fallback chain fired exactly as designed, but the same-branch download logged:

```
Pattern: **/{ThirdPartyNotices.generated.txt,notice-meta.txt}
0 matches
0 final results
Item excluded: notice_output/ThirdPartyNotices.generated.txt   ← the file was right there
```

So the build proceeded without a cached CG NOTICE even though a perfectly good one existed on the branch's previous build.

The bug has been latent since the original CG PR (#322410) — these download steps only run on a genuine CG failure, and every validation build so far had CG succeed (steps skipped), so it was never exercised until now.

## The fix

Replace the brace pattern with one plain glob per line in **both** download steps (same-branch + main-fallback):

```yaml
itemPattern: |
  **/ThirdPartyNotices.generated.txt
  **/notice-meta.txt
```

Plain globs are matched reliably by `DownloadBuildArtifacts@1`. The hardcoded download paths were already correct — only the file filter was broken.

## Validation

- Reproduced the brace-vs-plain matching difference against the exact artifact file list from build 450982.
- The build log confirms the artifact downloaded and the named file was present but excluded — so a working filter lands it at the path the apply step already expects.
- No code path changes; this only widens what the fallback download retrieves.
