### PR TITLE
Revert "ci: drop external DTD from minimal fontconfig to avoid expat NULL-deref crash (#322909)"

### DIFF
--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -145,7 +145,7 @@ jobs:
           fi
           echo "Installed expat: $EXPAT_VER — applying fontconfig workaround"
           # Workaround: use a minimal fontconfig config with no <include> directives,
-          # avoiding the external entity parser codepath entirely. Based on upstream
+          # which avoids pulling in additional external files via <include>. Based on upstream
           # fontconfig 2.15.0 fonts.conf.in with <include> removed, generic family
           # aliases inlined, and default font mappings for generic families added
           # (from conf.d/49-sansserif.conf and DejaVu font configs).

--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -144,24 +144,15 @@ jobs:
             exit 0
           fi
           echo "Installed expat: $EXPAT_VER — applying fontconfig workaround"
-          # Workaround: use a minimal fontconfig config with no <include> directives
-          # AND no <!DOCTYPE ... SYSTEM ...> external DTD reference, avoiding every
-          # expat external-entity codepath. Based on upstream fontconfig 2.15.0
-          # fonts.conf.in with <include> removed, generic family aliases inlined, and
-          # default font mappings for generic families added (from conf.d/49-sansserif.conf
-          # and DejaVu font configs).
-          #
-          # The DOCTYPE line is intentionally omitted: fontconfig feeds the referenced
-          # external DTD ("urn:fontconfig:fonts.dtd") to expat as an external PARAMETER
-          # entity, which still triggers the not-yet-backported NULL-deref CVEs
-          # (CVE-2026-32776 / CVE-2026-32778) on expat 2.6.1 even when <include> is gone.
-          # This was observed as a SIGSEGV inside libexpat (called from libfontconfig)
-          # during Chromium browser-process font init, crashing Electron at startup.
-          # fontconfig does not require the DOCTYPE, so dropping it removes the last
-          # external-entity path. Remove the whole workaround once Ubuntu backports the
-          # remaining CVE fixes (expat >= 2.7.5).
+          # Workaround: use a minimal fontconfig config with no <include> directives,
+          # avoiding the external entity parser codepath entirely. Based on upstream
+          # fontconfig 2.15.0 fonts.conf.in with <include> removed, generic family
+          # aliases inlined, and default font mappings for generic families added
+          # (from conf.d/49-sansserif.conf and DejaVu font configs).
+          # Remove once Ubuntu backports the remaining CVE fixes.
           cat > /tmp/fonts-minimal.conf << 'FONTCONFIG_EOF'
           <?xml version="1.0"?>
+          <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
           <fontconfig>
             <dir>/usr/share/fonts</dir>
             <dir>/usr/local/share/fonts</dir>


### PR DESCRIPTION
Reverts the fontconfig change from #322909.

## Why revert

The change was intended to reduce the intermittent fontconfig/expat SIGSEGV that crashes Electron at smoke-test launch. **It did the opposite.**

Measured on the `pr.yml` workflow (the `Linux / Electron-Smoke` job specifically), around the merge of #322909 (2026-06-25 13:06 UTC):

| | smoke failures / completed | rate |
|---|---|---|
| **Before** merge | 1 / 13 | ~8% |
| **After** merge | 8 / 43 | ~19% |

The failure rate roughly doubled.

## What the dump actually shows

I pulled a crash dump from an after-merge failure (run 28188049700, `Language Features` suite) and walked the **frame-pointer (RBP) chain** — more reliable than the heuristic stack scan used to justify #322909:

```
#0  libc.so.6           (NULL deref, fault addr 0x0)
#1  libexpat.so.1
#2  libexpat.so.1
#3  libexpat.so.1
#4  libfontconfig.so.1
#5  libfontconfig.so.1
#6  libfontconfig.so.1
#7  libfontconfig.so.1
#8  libfontconfig.so.1
#9  libfontconfig.so.1
#10 libpangoft2-1.0.so.0
#11 libglib-2.0.so.0
#12 libc.so.6
```

It's the **same** `pango → fontconfig → expat → libc` NULL-deref as before, just more frequent. The original "external parameter entity via DOCTYPE" theory doesn't hold: the minimal config without the DOCTYPE parses *less* XML than the system config, yet crashes *more*. That points at a flaky race / heap issue in the expat 2.6.1 + fontconfig stack that removing the DOCTYPE perturbed, not a deterministic content bug.

## Net

Restore the previous (lower) crash rate now. The durable fix is still getting `libexpat >= 2.7.5` onto the runner — the workaround step already auto-disables itself when it detects that version. That will be pursued separately.

Companion harness PR #322905 (fail fast on launch crash) stays in; it doesn't affect crash frequency, only how quickly/clearly a crash is surfaced.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
