### PR TITLE
Use Copilot shell exit codes for Agent Host shell execution decorations

### DIFF
--- a/src/vs/platform/agentHost/common/state/protocol/channels-chat/state.ts
+++ b/src/vs/platform/agentHost/common/state/protocol/channels-chat/state.ts
@@ -982,10 +982,21 @@ export interface ToolCallResult {
 	 *
 	 * This mirrors the `structuredContent` field of MCP `CallToolResult`.
 	 */
-	structuredContent?: Record<string, unknown>;
+	structuredContent?: ToolCallStructuredContent;
 	/** Error details if the tool failed */
 	error?: { message: string; code?: string };
 }
+
+/**
+ * Additional typed fields VS Code understands in otherwise provider-defined
+ * tool structured content.
+ */
+export type ToolCallStructuredContent = Record<string, unknown> & {
+	terminalCommand?: {
+		exitCode?: number;
+		cwd?: string;
+	};
+};
 
 /**
  * LM is streaming the tool call parameters.

--- a/src/vs/platform/agentHost/common/state/protocol/channels-chat/state.ts
+++ b/src/vs/platform/agentHost/common/state/protocol/channels-chat/state.ts
@@ -982,21 +982,10 @@ export interface ToolCallResult {
 	 *
 	 * This mirrors the `structuredContent` field of MCP `CallToolResult`.
 	 */
-	structuredContent?: ToolCallStructuredContent;
+	structuredContent?: Record<string, unknown>;
 	/** Error details if the tool failed */
 	error?: { message: string; code?: string };
 }
-
-/**
- * Additional typed fields VS Code understands in otherwise provider-defined
- * tool structured content.
- */
-export type ToolCallStructuredContent = Record<string, unknown> & {
-	terminalCommand?: {
-		exitCode?: number;
-		cwd?: string;
-	};
-};
 
 /**
  * LM is streaming the tool call parameters.
@@ -1234,4 +1223,3 @@ export type ToolResultContent =
 	| ToolResultFileEditContent
 	| ToolResultTerminalContent
 	| ToolResultSubagentContent;
-

--- a/src/vs/platform/agentHost/common/state/sessionState.ts
+++ b/src/vs/platform/agentHost/common/state/sessionState.ts
@@ -78,6 +78,7 @@ export {
 	type ToolCallPendingResultConfirmationState,
 	type ToolCallResponsePart,
 	type ToolCallResult,
+	type ToolCallStructuredContent,
 	type ToolCallRunningState,
 	type ToolCallState,
 	type ToolCallStreamingState,

--- a/src/vs/platform/agentHost/common/state/sessionState.ts
+++ b/src/vs/platform/agentHost/common/state/sessionState.ts
@@ -78,7 +78,6 @@ export {
 	type ToolCallPendingResultConfirmationState,
 	type ToolCallResponsePart,
 	type ToolCallResult,
-	type ToolCallStructuredContent,
 	type ToolCallRunningState,
 	type ToolCallState,
 	type ToolCallStreamingState,

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { CopilotSession, ExitPlanModeRequest, MessageOptions, PermissionRequestResult, SessionConfig, Tool, ToolResultObject, McpServerStatus as SdkMcpServerStatus } from '@github/copilot-sdk';
+import type { CopilotSession, ExitPlanModeRequest, MessageOptions, PermissionRequestResult, SessionConfig, Tool, ToolExecutionCompleteContentTerminal, ToolExecutionCompleteData, ToolResultObject, McpServerStatus as SdkMcpServerStatus } from '@github/copilot-sdk';
 import { DeferredPromise, raceTimeout } from '../../../../base/common/async.js';
 import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter } from '../../../../base/common/event.js';
@@ -38,7 +38,7 @@ import { isAgentFeedbackAnnotationsAttachment, renderAgentFeedbackAnnotationsAtt
 import { ISessionDatabase, ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../../common/sessionDataService.js';
 import { MessageAttachmentKind, ToolCallContributorKind, type FileEdit, type MessageAttachment } from '../../common/state/protocol/state.js';
 import { ActionType, type ChatAction, type SessionAction } from '../../common/state/sessionActions.js';
-import { MessageKind, ResponsePartKind, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, buildSubagentSessionUri, getToolSubagentContent, type PendingMessage, type ChatInputAnswer, type ChatInputOption, type ChatInputQuestion, type ChatInputRequest, type ToolCallResult, type ToolResultContent, type Turn, type UsageInfo, type UsageInfoMeta } from '../../common/state/sessionState.js';
+import { MessageKind, ResponsePartKind, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, buildSubagentSessionUri, getToolSubagentContent, type PendingMessage, type ChatInputAnswer, type ChatInputOption, type ChatInputQuestion, type ChatInputRequest, type ToolCallResult, type ToolCallStructuredContent, type ToolResultContent, type Turn, type UsageInfo, type UsageInfoMeta } from '../../common/state/sessionState.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import type { IExitPlanModeResponse } from './copilotAgent.js';
 import { CopilotSessionWrapper } from './copilotSessionWrapper.js';
@@ -401,6 +401,61 @@ class CopilotTurn {
 
 	markCompleted(): void { this._state = 'completed'; }
 	markAborted(): void { this._state = 'aborted'; }
+}
+
+function getSdkTerminalContent(result: ToolExecutionCompleteData['result']): ToolExecutionCompleteContentTerminal | undefined {
+	const content = result?.contents?.find(content => content.type === 'terminal');
+	return content?.type === 'terminal' ? content : undefined;
+}
+
+// function getSdkTerminalExitCodeFromText(text: string): number | undefined {
+// 	const lastLine = text.trimEnd().split(/\r?\n/).at(-1)?.trim();
+// 	const match = lastLine?.match(/^<(?:shellId: \S+ completed|exited) with exit code (-?\d+)>$/);
+// 	return match ? Number(match[1]) : undefined;
+// }
+
+function getSdkStructuredTerminalCommand(result: ToolExecutionCompleteData['result']): ToolCallStructuredContent['terminalCommand'] | undefined {
+	const terminalCommand = result?.structuredContent?.terminalCommand;
+	if (!isObject(terminalCommand)) {
+		return undefined;
+	}
+
+	const exitCode = Reflect.get(terminalCommand, 'exitCode');
+	const cwd = Reflect.get(terminalCommand, 'cwd');
+	if (typeof exitCode !== 'number' && typeof cwd !== 'string') {
+		return undefined;
+	}
+
+	return {
+		...(typeof exitCode === 'number' ? { exitCode } : {}),
+		...(typeof cwd === 'string' ? { cwd } : {}),
+	};
+}
+
+function getSdkTerminalCommand(result: ToolExecutionCompleteData['result']): ToolCallStructuredContent['terminalCommand'] | undefined {
+	const terminalContent = getSdkTerminalContent(result);
+	const structuredTerminalCommand = getSdkStructuredTerminalCommand(result);
+	const exitCode = terminalContent?.exitCode ?? structuredTerminalCommand?.exitCode;
+	const cwd = terminalContent?.cwd ?? structuredTerminalCommand?.cwd;
+	if (exitCode === undefined && cwd === undefined) {
+		return undefined;
+	}
+
+	return {
+		...(exitCode !== undefined ? { exitCode } : {}),
+		...(cwd !== undefined ? { cwd } : {}),
+	};
+}
+
+function getSdkTerminalStructuredContent(result: ToolExecutionCompleteData['result']): ToolCallStructuredContent | undefined {
+	const terminalCommand = getSdkTerminalCommand(result);
+	if (!result?.structuredContent && !terminalCommand) {
+		return undefined;
+	}
+
+	return terminalCommand
+		? { ...(result?.structuredContent ?? {}), terminalCommand }
+		: result?.structuredContent;
 }
 
 /**
@@ -2516,7 +2571,12 @@ export class CopilotAgentSession extends Disposable {
 			this._logService.info(`[Copilot:${sessionId}] Tool completed: ${e.data.toolCallId}`);
 			this._activeToolCalls.delete(e.data.toolCallId);
 			const displayName = tracked.displayName;
-			const toolOutput = e.data.error?.message ?? e.data.result?.content;
+			const terminalContent = getSdkTerminalContent(e.data.result);
+			const toolOutput = e.data.error?.message ?? terminalContent?.text ?? e.data.result?.content;
+			const structuredContent = getSdkTerminalStructuredContent(e.data.result);
+			if (isShellTool(tracked.toolName)) {
+				this._logService.info(`[Copilot:${sessionId}] Shell tool terminal result API fields: toolCallId=${e.data.toolCallId}, terminalContentExitCode=${terminalContent?.exitCode ?? '<missing>'}, structuredTerminalCommand=${safeStringify(structuredContent?.terminalCommand)}, contents=${safeStringify(e.data.result?.contents)}, structuredContent=${safeStringify(e.data.result?.structuredContent)}, contentTail=${safeStringify(e.data.result?.content?.slice(-200))}`);
+			}
 
 			if (isTaskCompleteTool(tracked.toolName)) {
 				this._sendToolInvokedTelemetry(e.data.success, e.data.error?.code, tracked);
@@ -2588,6 +2648,7 @@ export class CopilotAgentSession extends Disposable {
 					success: e.data.success,
 					pastTenseMessage: getPastTenseMessage(tracked.toolName, displayName, tracked.parameters, e.data.success),
 					content: content.length > 0 ? content : undefined,
+					structuredContent,
 					error: e.data.error,
 				},
 				_meta: completeMeta ? toToolCallMeta(completeMeta) : undefined,

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -38,7 +38,7 @@ import { isAgentFeedbackAnnotationsAttachment, renderAgentFeedbackAnnotationsAtt
 import { ISessionDatabase, ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../../common/sessionDataService.js';
 import { MessageAttachmentKind, ToolCallContributorKind, type FileEdit, type MessageAttachment } from '../../common/state/protocol/state.js';
 import { ActionType, type ChatAction, type SessionAction } from '../../common/state/sessionActions.js';
-import { MessageKind, ResponsePartKind, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, buildSubagentSessionUri, getToolSubagentContent, type PendingMessage, type ChatInputAnswer, type ChatInputOption, type ChatInputQuestion, type ChatInputRequest, type ToolCallResult, type ToolCallStructuredContent, type ToolResultContent, type Turn, type UsageInfo, type UsageInfoMeta } from '../../common/state/sessionState.js';
+import { MessageKind, ResponsePartKind, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind, ChatInputResponseKind, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, buildSubagentSessionUri, getToolSubagentContent, type PendingMessage, type ChatInputAnswer, type ChatInputOption, type ChatInputQuestion, type ChatInputRequest, type ToolCallResult, type ToolResultContent, type Turn, type UsageInfo, type UsageInfoMeta } from '../../common/state/sessionState.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import type { IExitPlanModeResponse } from './copilotAgent.js';
 import { CopilotSessionWrapper } from './copilotSessionWrapper.js';
@@ -144,6 +144,11 @@ type SessionHooks = NonNullable<SessionConfig['hooks']>;
 type PreToolUseHookInput = Parameters<NonNullable<SessionHooks['onPreToolUse']>>[0];
 type PostToolUseHookInput = Parameters<NonNullable<SessionHooks['onPostToolUse']>>[0];
 type ToolUseHookInput = PreToolUseHookInput | PostToolUseHookInput;
+
+interface ISdkTerminalCommandStructuredContent {
+	readonly exitCode?: number;
+	readonly cwd?: string;
+}
 
 function getToolCommand(input: ToolUseHookInput): string | undefined {
 	const command = isObject(input.toolArgs) ? Reflect.get(input.toolArgs, 'command') : undefined;
@@ -414,8 +419,8 @@ function getSdkTerminalContent(result: ToolExecutionCompleteData['result']): Too
 // 	return match ? Number(match[1]) : undefined;
 // }
 
-function getSdkStructuredTerminalCommand(result: ToolExecutionCompleteData['result']): ToolCallStructuredContent['terminalCommand'] | undefined {
-	const terminalCommand = result?.structuredContent?.terminalCommand;
+function getSdkStructuredTerminalCommand(result: ToolExecutionCompleteData['result']): ISdkTerminalCommandStructuredContent | undefined {
+	const terminalCommand = result?.structuredContent?.['terminalCommand'];
 	if (!isObject(terminalCommand)) {
 		return undefined;
 	}
@@ -432,7 +437,7 @@ function getSdkStructuredTerminalCommand(result: ToolExecutionCompleteData['resu
 	};
 }
 
-function getSdkTerminalCommand(result: ToolExecutionCompleteData['result']): ToolCallStructuredContent['terminalCommand'] | undefined {
+function getSdkTerminalCommand(result: ToolExecutionCompleteData['result']): ISdkTerminalCommandStructuredContent | undefined {
 	const terminalContent = getSdkTerminalContent(result);
 	const structuredTerminalCommand = getSdkStructuredTerminalCommand(result);
 	const exitCode = terminalContent?.exitCode ?? structuredTerminalCommand?.exitCode;
@@ -447,7 +452,7 @@ function getSdkTerminalCommand(result: ToolExecutionCompleteData['result']): Too
 	};
 }
 
-function getSdkTerminalStructuredContent(result: ToolExecutionCompleteData['result']): ToolCallStructuredContent | undefined {
+function getSdkTerminalStructuredContent(result: ToolExecutionCompleteData['result']): Record<string, unknown> | undefined {
 	const terminalCommand = getSdkTerminalCommand(result);
 	if (!result?.structuredContent && !terminalCommand) {
 		return undefined;
@@ -2575,7 +2580,7 @@ export class CopilotAgentSession extends Disposable {
 			const toolOutput = e.data.error?.message ?? terminalContent?.text ?? e.data.result?.content;
 			const structuredContent = getSdkTerminalStructuredContent(e.data.result);
 			if (isShellTool(tracked.toolName)) {
-				this._logService.info(`[Copilot:${sessionId}] Shell tool terminal result API fields: toolCallId=${e.data.toolCallId}, terminalContentExitCode=${terminalContent?.exitCode ?? '<missing>'}, structuredTerminalCommand=${safeStringify(structuredContent?.terminalCommand)}, contents=${safeStringify(e.data.result?.contents)}, structuredContent=${safeStringify(e.data.result?.structuredContent)}, contentTail=${safeStringify(e.data.result?.content?.slice(-200))}`);
+				this._logService.info(`[Copilot:${sessionId}] Shell tool terminal result API fields: toolCallId=${e.data.toolCallId}, terminalContentExitCode=${terminalContent?.exitCode ?? '<missing>'}, structuredTerminalCommand=${safeStringify(structuredContent?.['terminalCommand'])}, contents=${safeStringify(e.data.result?.contents)}, structuredContent=${safeStringify(e.data.result?.structuredContent)}, contentTail=${safeStringify(e.data.result?.content?.slice(-200))}`);
 			}
 
 			if (isTaskCompleteTool(tracked.toolName)) {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { CopilotSession, ExitPlanModeRequest, MessageOptions, PermissionRequestResult, SessionConfig, Tool, ToolExecutionCompleteContentTerminal, ToolExecutionCompleteData, ToolResultObject, McpServerStatus as SdkMcpServerStatus } from '@github/copilot-sdk';
+import type { CopilotSession, ExitPlanModeRequest, MessageOptions, PermissionRequestResult, SessionConfig, Tool, ToolResultObject, McpServerStatus as SdkMcpServerStatus } from '@github/copilot-sdk';
 import { DeferredPromise, raceTimeout } from '../../../../base/common/async.js';
 import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter } from '../../../../base/common/event.js';
@@ -144,11 +144,6 @@ type SessionHooks = NonNullable<SessionConfig['hooks']>;
 type PreToolUseHookInput = Parameters<NonNullable<SessionHooks['onPreToolUse']>>[0];
 type PostToolUseHookInput = Parameters<NonNullable<SessionHooks['onPostToolUse']>>[0];
 type ToolUseHookInput = PreToolUseHookInput | PostToolUseHookInput;
-
-interface ISdkTerminalCommandStructuredContent {
-	readonly exitCode?: number;
-	readonly cwd?: string;
-}
 
 function getToolCommand(input: ToolUseHookInput): string | undefined {
 	const command = isObject(input.toolArgs) ? Reflect.get(input.toolArgs, 'command') : undefined;
@@ -408,59 +403,22 @@ class CopilotTurn {
 	markAborted(): void { this._state = 'aborted'; }
 }
 
-function getSdkTerminalContent(result: ToolExecutionCompleteData['result']): ToolExecutionCompleteContentTerminal | undefined {
-	const content = result?.contents?.find(content => content.type === 'terminal');
-	return content?.type === 'terminal' ? content : undefined;
+function getSdkTerminalExitCodeFromText(text: string | undefined): number | undefined {
+	if (text === undefined) {
+		return undefined;
+	}
+
+	// TODO: github issue https://github.com/github/copilot-sdk/issues/1803
+	// Use structured shell exit metadata once the SDK exposes it. Current shell
+	// tool completions only carry the exit code in this trailing status footer.
+	const lastLine = text.trimEnd().split(/\r?\n/).at(-1)?.trim();
+	const match = lastLine?.match(/^<(?:shellId: \S+ completed|command with id: \S+ exited|exited) with exit code (-?\d+)>$/);
+	return match ? Number(match[1]) : undefined;
 }
 
-// function getSdkTerminalExitCodeFromText(text: string): number | undefined {
-// 	const lastLine = text.trimEnd().split(/\r?\n/).at(-1)?.trim();
-// 	const match = lastLine?.match(/^<(?:shellId: \S+ completed|exited) with exit code (-?\d+)>$/);
-// 	return match ? Number(match[1]) : undefined;
-// }
-
-function getSdkStructuredTerminalCommand(result: ToolExecutionCompleteData['result']): ISdkTerminalCommandStructuredContent | undefined {
-	const terminalCommand = result?.structuredContent?.['terminalCommand'];
-	if (!isObject(terminalCommand)) {
-		return undefined;
-	}
-
-	const exitCode = Reflect.get(terminalCommand, 'exitCode');
-	const cwd = Reflect.get(terminalCommand, 'cwd');
-	if (typeof exitCode !== 'number' && typeof cwd !== 'string') {
-		return undefined;
-	}
-
-	return {
-		...(typeof exitCode === 'number' ? { exitCode } : {}),
-		...(typeof cwd === 'string' ? { cwd } : {}),
-	};
-}
-
-function getSdkTerminalCommand(result: ToolExecutionCompleteData['result']): ISdkTerminalCommandStructuredContent | undefined {
-	const terminalContent = getSdkTerminalContent(result);
-	const structuredTerminalCommand = getSdkStructuredTerminalCommand(result);
-	const exitCode = terminalContent?.exitCode ?? structuredTerminalCommand?.exitCode;
-	const cwd = terminalContent?.cwd ?? structuredTerminalCommand?.cwd;
-	if (exitCode === undefined && cwd === undefined) {
-		return undefined;
-	}
-
-	return {
-		...(exitCode !== undefined ? { exitCode } : {}),
-		...(cwd !== undefined ? { cwd } : {}),
-	};
-}
-
-function getSdkTerminalStructuredContent(result: ToolExecutionCompleteData['result']): Record<string, unknown> | undefined {
-	const terminalCommand = getSdkTerminalCommand(result);
-	if (!result?.structuredContent && !terminalCommand) {
-		return undefined;
-	}
-
-	return terminalCommand
-		? { ...(result?.structuredContent ?? {}), terminalCommand }
-		: result?.structuredContent;
+function getSdkTerminalStructuredContentFromText(text: string | undefined): Record<string, unknown> | undefined {
+	const exitCode = getSdkTerminalExitCodeFromText(text);
+	return exitCode === undefined ? undefined : { terminalCommand: { exitCode } };
 }
 
 /**
@@ -2576,12 +2534,8 @@ export class CopilotAgentSession extends Disposable {
 			this._logService.info(`[Copilot:${sessionId}] Tool completed: ${e.data.toolCallId}`);
 			this._activeToolCalls.delete(e.data.toolCallId);
 			const displayName = tracked.displayName;
-			const terminalContent = getSdkTerminalContent(e.data.result);
-			const toolOutput = e.data.error?.message ?? terminalContent?.text ?? e.data.result?.content;
-			const structuredContent = getSdkTerminalStructuredContent(e.data.result);
-			if (isShellTool(tracked.toolName)) {
-				this._logService.info(`[Copilot:${sessionId}] Shell tool terminal result API fields: toolCallId=${e.data.toolCallId}, terminalContentExitCode=${terminalContent?.exitCode ?? '<missing>'}, structuredTerminalCommand=${safeStringify(structuredContent?.['terminalCommand'])}, contents=${safeStringify(e.data.result?.contents)}, structuredContent=${safeStringify(e.data.result?.structuredContent)}, contentTail=${safeStringify(e.data.result?.content?.slice(-200))}`);
-			}
+			const toolOutput = e.data.error?.message ?? e.data.result?.content;
+			const structuredContent = isShellTool(tracked.toolName) ? getSdkTerminalStructuredContentFromText(e.data.result?.content) : e.data.result?.structuredContent;
 
 			if (isTaskCompleteTool(tracked.toolName)) {
 				this._sendToolInvokedTelemetry(e.data.success, e.data.error?.code, tracked);

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -13,7 +13,7 @@ import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
 import { toToolCallMeta } from '../../common/meta/agentToolCallMeta.js';
 import { IFileEditRecord, ISessionDatabase } from '../../common/sessionDataService.js';
 import { MessageAttachmentKind, type MessageAttachment } from '../../common/state/protocol/state.js';
-import { MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildSubagentSessionUri, type Message, type ResponsePart, type StringOrMarkdown, type ToolCallCompletedState, type ToolCallStructuredContent, type ToolResultContent, type Turn } from '../../common/state/sessionState.js';
+import { MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildSubagentSessionUri, type Message, type ResponsePart, type StringOrMarkdown, type ToolCallCompletedState, type ToolResultContent, type Turn } from '../../common/state/sessionState.js';
 import { getInvocationMessage, getPastTenseMessage, getShellLanguage, getSubagentMetadata, getTaskCompleteMarkdown, getToolDisplayName, getToolInputString, getToolKind, isEditTool, isHiddenTool, isTaskCompleteTool, synthesizeSkillToolCall } from './copilotToolDisplay.js';
 import { buildSessionDbUri } from '../shared/fileEditTracker.js';
 import { getMediaMime } from '../../../../base/common/mime.js';
@@ -24,6 +24,11 @@ function tryStringify(value: unknown): string | undefined {
 	} catch {
 		return undefined;
 	}
+}
+
+interface ISdkTerminalCommandStructuredContent {
+	readonly exitCode?: number;
+	readonly cwd?: string;
 }
 
 function getSdkTerminalContent(result: ToolExecutionCompleteData['result']): ToolExecutionCompleteContentTerminal | undefined {
@@ -37,8 +42,8 @@ function getSdkTerminalContent(result: ToolExecutionCompleteData['result']): Too
 // 	return match ? Number(match[1]) : undefined;
 // }
 
-function getSdkStructuredTerminalCommand(result: ToolExecutionCompleteData['result']): ToolCallStructuredContent['terminalCommand'] | undefined {
-	const terminalCommand = result?.structuredContent?.terminalCommand;
+function getSdkStructuredTerminalCommand(result: ToolExecutionCompleteData['result']): ISdkTerminalCommandStructuredContent | undefined {
+	const terminalCommand = result?.structuredContent?.['terminalCommand'];
 	if (!isObject(terminalCommand)) {
 		return undefined;
 	}
@@ -55,7 +60,7 @@ function getSdkStructuredTerminalCommand(result: ToolExecutionCompleteData['resu
 	};
 }
 
-function getSdkTerminalCommand(result: ToolExecutionCompleteData['result']): ToolCallStructuredContent['terminalCommand'] | undefined {
+function getSdkTerminalCommand(result: ToolExecutionCompleteData['result']): ISdkTerminalCommandStructuredContent | undefined {
 	const terminalContent = getSdkTerminalContent(result);
 	const structuredTerminalCommand = getSdkStructuredTerminalCommand(result);
 	const exitCode = terminalContent?.exitCode ?? structuredTerminalCommand?.exitCode;
@@ -70,7 +75,7 @@ function getSdkTerminalCommand(result: ToolExecutionCompleteData['result']): Too
 	};
 }
 
-function getSdkTerminalStructuredContent(result: ToolExecutionCompleteData['result']): ToolCallStructuredContent | undefined {
+function getSdkTerminalStructuredContent(result: ToolExecutionCompleteData['result']): Record<string, unknown> | undefined {
 	const terminalCommand = getSdkTerminalCommand(result);
 	if (!result?.structuredContent && !terminalCommand) {
 		return undefined;

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -3,17 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { AssistantMessageToolRequest, Attachment, SessionEvent, ToolExecutionCompleteData } from '@github/copilot-sdk';
+import type { AssistantMessageToolRequest, Attachment, SessionEvent, ToolExecutionCompleteContentTerminal, ToolExecutionCompleteData } from '@github/copilot-sdk';
 import { decodeBase64 } from '../../../../base/common/buffer.js';
 import { basename } from '../../../../base/common/path.js';
-import { isString } from '../../../../base/common/types.js';
+import { isObject, isString } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
 import { toToolCallMeta } from '../../common/meta/agentToolCallMeta.js';
 import { IFileEditRecord, ISessionDatabase } from '../../common/sessionDataService.js';
 import { MessageAttachmentKind, type MessageAttachment } from '../../common/state/protocol/state.js';
-import { MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildSubagentSessionUri, type Message, type ResponsePart, type StringOrMarkdown, type ToolCallCompletedState, type ToolResultContent, type Turn } from '../../common/state/sessionState.js';
+import { MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildSubagentSessionUri, type Message, type ResponsePart, type StringOrMarkdown, type ToolCallCompletedState, type ToolCallStructuredContent, type ToolResultContent, type Turn } from '../../common/state/sessionState.js';
 import { getInvocationMessage, getPastTenseMessage, getShellLanguage, getSubagentMetadata, getTaskCompleteMarkdown, getToolDisplayName, getToolInputString, getToolKind, isEditTool, isHiddenTool, isTaskCompleteTool, synthesizeSkillToolCall } from './copilotToolDisplay.js';
 import { buildSessionDbUri } from '../shared/fileEditTracker.js';
 import { getMediaMime } from '../../../../base/common/mime.js';
@@ -24,6 +24,61 @@ function tryStringify(value: unknown): string | undefined {
 	} catch {
 		return undefined;
 	}
+}
+
+function getSdkTerminalContent(result: ToolExecutionCompleteData['result']): ToolExecutionCompleteContentTerminal | undefined {
+	const content = result?.contents?.find(content => content.type === 'terminal');
+	return content?.type === 'terminal' ? content : undefined;
+}
+
+// function getSdkTerminalExitCodeFromText(text: string): number | undefined {
+// 	const lastLine = text.trimEnd().split(/\r?\n/).at(-1)?.trim();
+// 	const match = lastLine?.match(/^<(?:shellId: \S+ completed|exited) with exit code (-?\d+)>$/);
+// 	return match ? Number(match[1]) : undefined;
+// }
+
+function getSdkStructuredTerminalCommand(result: ToolExecutionCompleteData['result']): ToolCallStructuredContent['terminalCommand'] | undefined {
+	const terminalCommand = result?.structuredContent?.terminalCommand;
+	if (!isObject(terminalCommand)) {
+		return undefined;
+	}
+
+	const exitCode = Reflect.get(terminalCommand, 'exitCode');
+	const cwd = Reflect.get(terminalCommand, 'cwd');
+	if (typeof exitCode !== 'number' && typeof cwd !== 'string') {
+		return undefined;
+	}
+
+	return {
+		...(typeof exitCode === 'number' ? { exitCode } : {}),
+		...(typeof cwd === 'string' ? { cwd } : {}),
+	};
+}
+
+function getSdkTerminalCommand(result: ToolExecutionCompleteData['result']): ToolCallStructuredContent['terminalCommand'] | undefined {
+	const terminalContent = getSdkTerminalContent(result);
+	const structuredTerminalCommand = getSdkStructuredTerminalCommand(result);
+	const exitCode = terminalContent?.exitCode ?? structuredTerminalCommand?.exitCode;
+	const cwd = terminalContent?.cwd ?? structuredTerminalCommand?.cwd;
+	if (exitCode === undefined && cwd === undefined) {
+		return undefined;
+	}
+
+	return {
+		...(exitCode !== undefined ? { exitCode } : {}),
+		...(cwd !== undefined ? { cwd } : {}),
+	};
+}
+
+function getSdkTerminalStructuredContent(result: ToolExecutionCompleteData['result']): ToolCallStructuredContent | undefined {
+	const terminalCommand = getSdkTerminalCommand(result);
+	if (!result?.structuredContent && !terminalCommand) {
+		return undefined;
+	}
+
+	return terminalCommand
+		? { ...(result?.structuredContent ?? {}), terminalCommand }
+		: result?.structuredContent;
 }
 
 /**
@@ -558,7 +613,8 @@ function makeCompletedToolCallPart(
 	storedEdits: Map<string, IFileEditRecord[]> | undefined,
 	subagent: ISubagentInfo | undefined,
 ): ResponsePart {
-	const toolOutput = d.error?.message ?? d.result?.content;
+	const terminalContent = getSdkTerminalContent(d.result);
+	const toolOutput = d.error?.message ?? terminalContent?.text ?? d.result?.content;
 	const content: ToolResultContent[] = [];
 	if (toolOutput !== undefined) {
 		content.push({ type: ToolResultContentType.Text, text: toolOutput });
@@ -611,6 +667,7 @@ function makeCompletedToolCallPart(
 		success: d.success,
 		pastTenseMessage: getPastTenseMessage(info.toolName, info.displayName, info.parameters, d.success),
 		content: content.length > 0 ? content : undefined,
+		structuredContent: getSdkTerminalStructuredContent(d.result),
 		error: d.error,
 		confirmed: ToolCallConfirmationReason.NotNeeded,
 		_meta: toToolCallMeta({

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { AssistantMessageToolRequest, Attachment, SessionEvent, ToolExecutionCompleteContentTerminal, ToolExecutionCompleteData } from '@github/copilot-sdk';
+import type { AssistantMessageToolRequest, Attachment, SessionEvent, ToolExecutionCompleteData } from '@github/copilot-sdk';
 import { decodeBase64 } from '../../../../base/common/buffer.js';
 import { basename } from '../../../../base/common/path.js';
-import { isObject, isString } from '../../../../base/common/types.js';
+import { isString } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
@@ -14,7 +14,7 @@ import { toToolCallMeta } from '../../common/meta/agentToolCallMeta.js';
 import { IFileEditRecord, ISessionDatabase } from '../../common/sessionDataService.js';
 import { MessageAttachmentKind, type MessageAttachment } from '../../common/state/protocol/state.js';
 import { MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildSubagentSessionUri, type Message, type ResponsePart, type StringOrMarkdown, type ToolCallCompletedState, type ToolResultContent, type Turn } from '../../common/state/sessionState.js';
-import { getInvocationMessage, getPastTenseMessage, getShellLanguage, getSubagentMetadata, getTaskCompleteMarkdown, getToolDisplayName, getToolInputString, getToolKind, isEditTool, isHiddenTool, isTaskCompleteTool, synthesizeSkillToolCall } from './copilotToolDisplay.js';
+import { getInvocationMessage, getPastTenseMessage, getShellLanguage, getSubagentMetadata, getTaskCompleteMarkdown, getToolDisplayName, getToolInputString, getToolKind, isEditTool, isHiddenTool, isShellTool, isTaskCompleteTool, synthesizeSkillToolCall } from './copilotToolDisplay.js';
 import { buildSessionDbUri } from '../shared/fileEditTracker.js';
 import { getMediaMime } from '../../../../base/common/mime.js';
 
@@ -26,64 +26,22 @@ function tryStringify(value: unknown): string | undefined {
 	}
 }
 
-interface ISdkTerminalCommandStructuredContent {
-	readonly exitCode?: number;
-	readonly cwd?: string;
-}
-
-function getSdkTerminalContent(result: ToolExecutionCompleteData['result']): ToolExecutionCompleteContentTerminal | undefined {
-	const content = result?.contents?.find(content => content.type === 'terminal');
-	return content?.type === 'terminal' ? content : undefined;
-}
-
-// function getSdkTerminalExitCodeFromText(text: string): number | undefined {
-// 	const lastLine = text.trimEnd().split(/\r?\n/).at(-1)?.trim();
-// 	const match = lastLine?.match(/^<(?:shellId: \S+ completed|exited) with exit code (-?\d+)>$/);
-// 	return match ? Number(match[1]) : undefined;
-// }
-
-function getSdkStructuredTerminalCommand(result: ToolExecutionCompleteData['result']): ISdkTerminalCommandStructuredContent | undefined {
-	const terminalCommand = result?.structuredContent?.['terminalCommand'];
-	if (!isObject(terminalCommand)) {
+function getSdkTerminalExitCodeFromText(text: string | undefined): number | undefined {
+	if (text === undefined) {
 		return undefined;
 	}
 
-	const exitCode = Reflect.get(terminalCommand, 'exitCode');
-	const cwd = Reflect.get(terminalCommand, 'cwd');
-	if (typeof exitCode !== 'number' && typeof cwd !== 'string') {
-		return undefined;
-	}
-
-	return {
-		...(typeof exitCode === 'number' ? { exitCode } : {}),
-		...(typeof cwd === 'string' ? { cwd } : {}),
-	};
+	// TODO: github issue https://github.com/github/copilot-sdk/issues/1803
+	// Use structured shell exit metadata once the SDK exposes it. Current shell
+	// tool completions only carry the exit code in this trailing status footer.
+	const lastLine = text.trimEnd().split(/\r?\n/).at(-1)?.trim();
+	const match = lastLine?.match(/^<(?:shellId: \S+ completed|command with id: \S+ exited|exited) with exit code (-?\d+)>$/);
+	return match ? Number(match[1]) : undefined;
 }
 
-function getSdkTerminalCommand(result: ToolExecutionCompleteData['result']): ISdkTerminalCommandStructuredContent | undefined {
-	const terminalContent = getSdkTerminalContent(result);
-	const structuredTerminalCommand = getSdkStructuredTerminalCommand(result);
-	const exitCode = terminalContent?.exitCode ?? structuredTerminalCommand?.exitCode;
-	const cwd = terminalContent?.cwd ?? structuredTerminalCommand?.cwd;
-	if (exitCode === undefined && cwd === undefined) {
-		return undefined;
-	}
-
-	return {
-		...(exitCode !== undefined ? { exitCode } : {}),
-		...(cwd !== undefined ? { cwd } : {}),
-	};
-}
-
-function getSdkTerminalStructuredContent(result: ToolExecutionCompleteData['result']): Record<string, unknown> | undefined {
-	const terminalCommand = getSdkTerminalCommand(result);
-	if (!result?.structuredContent && !terminalCommand) {
-		return undefined;
-	}
-
-	return terminalCommand
-		? { ...(result?.structuredContent ?? {}), terminalCommand }
-		: result?.structuredContent;
+function getSdkTerminalStructuredContentFromText(text: string | undefined): Record<string, unknown> | undefined {
+	const exitCode = getSdkTerminalExitCodeFromText(text);
+	return exitCode === undefined ? undefined : { terminalCommand: { exitCode } };
 }
 
 /**
@@ -618,8 +576,7 @@ function makeCompletedToolCallPart(
 	storedEdits: Map<string, IFileEditRecord[]> | undefined,
 	subagent: ISubagentInfo | undefined,
 ): ResponsePart {
-	const terminalContent = getSdkTerminalContent(d.result);
-	const toolOutput = d.error?.message ?? terminalContent?.text ?? d.result?.content;
+	const toolOutput = d.error?.message ?? d.result?.content;
 	const content: ToolResultContent[] = [];
 	if (toolOutput !== undefined) {
 		content.push({ type: ToolResultContentType.Text, text: toolOutput });
@@ -672,7 +629,7 @@ function makeCompletedToolCallPart(
 		success: d.success,
 		pastTenseMessage: getPastTenseMessage(info.toolName, info.displayName, info.parameters, d.success),
 		content: content.length > 0 ? content : undefined,
-		structuredContent: getSdkTerminalStructuredContent(d.result),
+		structuredContent: isShellTool(info.toolName) ? getSdkTerminalStructuredContentFromText(d.result?.content) : d.result?.structuredContent,
 		error: d.error,
 		confirmed: ToolCallConfirmationReason.NotNeeded,
 		_meta: toToolCallMeta({

--- a/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { AgentSession } from '../../common/agentService.js';
-import { ResponsePartKind, type ResponsePart } from '../../common/state/sessionState.js';
+import { ResponsePartKind, ToolCallStatus, ToolResultContentType, type ResponsePart } from '../../common/state/sessionState.js';
 import { mapSessionEvents } from '../../node/copilot/mapSessionEvents.js';
 import { toSessionEvents, type ISessionEvent } from './copilotTestEvents.js';
 
@@ -67,6 +67,97 @@ suite('mapSessionEvents — task_complete rendering', () => {
 		assert.deepStrictEqual(partKinds(turns[0].responseParts), [
 			{ kind: ResponsePartKind.ToolCall },
 		]);
+	});
+
+	test('SDK terminal content maps to text output and structured command status', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', data: { interactionId: 'm1', content: 'run bad command' } },
+			{ type: 'assistant.message', data: { messageId: 'm2', content: '', toolRequests: [{ toolCallId: 'tc-1', name: 'bash' }] } },
+			{ type: 'tool.execution_start', data: { toolCallId: 'tc-1', toolName: 'bash', arguments: { command: 'bad_cmd' } } },
+			{
+				type: 'tool.execution_complete',
+				data: {
+					toolCallId: 'tc-1',
+					success: true,
+					result: {
+						content: 'model-facing output',
+						contents: [{ type: 'terminal', text: 'bad_cmd: command not found', exitCode: 127, cwd: '/workspace' }],
+						structuredContent: { terminalCommand: { cwd: '/workspace' } },
+					},
+				},
+			},
+		];
+
+		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+		const toolPart = turns[0].responseParts.find(part => part.kind === ResponsePartKind.ToolCall);
+
+		assert.ok(toolPart);
+		assert.strictEqual(toolPart.kind, ResponsePartKind.ToolCall);
+		assert.strictEqual(toolPart.toolCall.status, ToolCallStatus.Completed);
+		assert.deepStrictEqual(toolPart.toolCall.content, [
+			{ type: ToolResultContentType.Text, text: 'bad_cmd: command not found' },
+		]);
+		assert.deepStrictEqual(toolPart.toolCall.structuredContent, {
+			terminalCommand: { cwd: '/workspace', exitCode: 127 },
+		});
+	});
+
+	test('SDK terminal content without exitCode preserves cwd but does not derive status from shell footer', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', data: { interactionId: 'm1', content: 'run bad command' } },
+			{ type: 'assistant.message', data: { messageId: 'm2', content: '', toolRequests: [{ toolCallId: 'tc-1', name: 'bash' }] } },
+			{ type: 'tool.execution_start', data: { toolCallId: 'tc-1', toolName: 'bash', arguments: { command: 'ecjo hi' } } },
+			{
+				type: 'tool.execution_complete',
+				data: {
+					toolCallId: 'tc-1',
+					success: true,
+					result: {
+						content: 'model-facing output',
+						contents: [{ type: 'terminal', text: '/bin/bash: ecjo: command not found\n<shellId: 0 completed with exit code 127>', cwd: '/workspace' }],
+					},
+				},
+			},
+		];
+
+		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+		const toolPart = turns[0].responseParts.find(part => part.kind === ResponsePartKind.ToolCall);
+
+		assert.ok(toolPart);
+		assert.strictEqual(toolPart.kind, ResponsePartKind.ToolCall);
+		assert.strictEqual(toolPart.toolCall.status, ToolCallStatus.Completed);
+		assert.deepStrictEqual(toolPart.toolCall.structuredContent, {
+			terminalCommand: { cwd: '/workspace' },
+		});
+	});
+
+	test('SDK shell result content does not derive command status from shell footer', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', data: { interactionId: 'm1', content: 'run bad command' } },
+			{ type: 'assistant.message', data: { messageId: 'm2', content: '', toolRequests: [{ toolCallId: 'tc-1', name: 'bash' }] } },
+			{ type: 'tool.execution_start', data: { toolCallId: 'tc-1', toolName: 'bash', arguments: { command: 'ecjo hi' } } },
+			{
+				type: 'tool.execution_complete',
+				data: {
+					toolCallId: 'tc-1',
+					success: true,
+					result: {
+						content: '/bin/bash: ecjo: command not found\n<shellId: 0 completed with exit code 127>',
+					},
+				},
+			},
+		];
+
+		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+		const toolPart = turns[0].responseParts.find(part => part.kind === ResponsePartKind.ToolCall);
+
+		assert.ok(toolPart);
+		assert.strictEqual(toolPart.kind, ResponsePartKind.ToolCall);
+		assert.strictEqual(toolPart.toolCall.status, ToolCallStatus.Completed);
+		assert.deepStrictEqual(toolPart.toolCall.content, [
+			{ type: ToolResultContentType.Text, text: '/bin/bash: ecjo: command not found\n<shellId: 0 completed with exit code 127>' },
+		]);
+		assert.strictEqual(toolPart.toolCall.structuredContent, undefined);
 	});
 });
 

--- a/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
@@ -69,69 +69,7 @@ suite('mapSessionEvents — task_complete rendering', () => {
 		]);
 	});
 
-	test('SDK terminal content maps to text output and structured command status', async () => {
-		const events: ISessionEvent[] = [
-			{ type: 'user.message', data: { interactionId: 'm1', content: 'run bad command' } },
-			{ type: 'assistant.message', data: { messageId: 'm2', content: '', toolRequests: [{ toolCallId: 'tc-1', name: 'bash' }] } },
-			{ type: 'tool.execution_start', data: { toolCallId: 'tc-1', toolName: 'bash', arguments: { command: 'bad_cmd' } } },
-			{
-				type: 'tool.execution_complete',
-				data: {
-					toolCallId: 'tc-1',
-					success: true,
-					result: {
-						content: 'model-facing output',
-						contents: [{ type: 'terminal', text: 'bad_cmd: command not found', exitCode: 127, cwd: '/workspace' }],
-						structuredContent: { terminalCommand: { cwd: '/workspace' } },
-					},
-				},
-			},
-		];
-
-		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
-		const toolPart = turns[0].responseParts.find(part => part.kind === ResponsePartKind.ToolCall);
-
-		assert.ok(toolPart);
-		assert.strictEqual(toolPart.kind, ResponsePartKind.ToolCall);
-		assert.strictEqual(toolPart.toolCall.status, ToolCallStatus.Completed);
-		assert.deepStrictEqual(toolPart.toolCall.content, [
-			{ type: ToolResultContentType.Text, text: 'bad_cmd: command not found' },
-		]);
-		assert.deepStrictEqual(toolPart.toolCall.structuredContent, {
-			terminalCommand: { cwd: '/workspace', exitCode: 127 },
-		});
-	});
-
-	test('SDK terminal content without exitCode preserves cwd but does not derive status from shell footer', async () => {
-		const events: ISessionEvent[] = [
-			{ type: 'user.message', data: { interactionId: 'm1', content: 'run bad command' } },
-			{ type: 'assistant.message', data: { messageId: 'm2', content: '', toolRequests: [{ toolCallId: 'tc-1', name: 'bash' }] } },
-			{ type: 'tool.execution_start', data: { toolCallId: 'tc-1', toolName: 'bash', arguments: { command: 'ecjo hi' } } },
-			{
-				type: 'tool.execution_complete',
-				data: {
-					toolCallId: 'tc-1',
-					success: true,
-					result: {
-						content: 'model-facing output',
-						contents: [{ type: 'terminal', text: '/bin/bash: ecjo: command not found\n<shellId: 0 completed with exit code 127>', cwd: '/workspace' }],
-					},
-				},
-			},
-		];
-
-		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
-		const toolPart = turns[0].responseParts.find(part => part.kind === ResponsePartKind.ToolCall);
-
-		assert.ok(toolPart);
-		assert.strictEqual(toolPart.kind, ResponsePartKind.ToolCall);
-		assert.strictEqual(toolPart.toolCall.status, ToolCallStatus.Completed);
-		assert.deepStrictEqual(toolPart.toolCall.structuredContent, {
-			terminalCommand: { cwd: '/workspace' },
-		});
-	});
-
-	test('SDK shell result content does not derive command status from shell footer', async () => {
+	test('SDK shell result content derives command status from shell footer', async () => {
 		const events: ISessionEvent[] = [
 			{ type: 'user.message', data: { interactionId: 'm1', content: 'run bad command' } },
 			{ type: 'assistant.message', data: { messageId: 'm2', content: '', toolRequests: [{ toolCallId: 'tc-1', name: 'bash' }] } },
@@ -156,6 +94,35 @@ suite('mapSessionEvents — task_complete rendering', () => {
 		assert.strictEqual(toolPart.toolCall.status, ToolCallStatus.Completed);
 		assert.deepStrictEqual(toolPart.toolCall.content, [
 			{ type: ToolResultContentType.Text, text: '/bin/bash: ecjo: command not found\n<shellId: 0 completed with exit code 127>' },
+		]);
+		assert.deepStrictEqual(toolPart.toolCall.structuredContent, {
+			terminalCommand: { exitCode: 127 },
+		});
+	});
+
+	test('SDK shell result content without exit footer does not fabricate command status', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', data: { interactionId: 'm1', content: 'run shell command' } },
+			{ type: 'assistant.message', data: { messageId: 'm2', content: '', toolRequests: [{ toolCallId: 'tc-1', name: 'bash' }] } },
+			{ type: 'tool.execution_start', data: { toolCallId: 'tc-1', toolName: 'bash', arguments: { command: 'echo hi' } } },
+			{
+				type: 'tool.execution_complete',
+				data: {
+					toolCallId: 'tc-1',
+					success: true,
+					result: { content: 'hi' },
+				},
+			},
+		];
+
+		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+		const toolPart = turns[0].responseParts.find(part => part.kind === ResponsePartKind.ToolCall);
+
+		assert.ok(toolPart);
+		assert.strictEqual(toolPart.kind, ResponsePartKind.ToolCall);
+		assert.strictEqual(toolPart.toolCall.status, ToolCallStatus.Completed);
+		assert.deepStrictEqual(toolPart.toolCall.content, [
+			{ type: ToolResultContentType.Text, text: 'hi' },
 		]);
 		assert.strictEqual(toolPart.toolCall.structuredContent, undefined);
 	});

--- a/src/vs/workbench/contrib/chat/browser/actions/chatContext.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContext.ts
@@ -337,7 +337,7 @@ class SessionReferenceContextPickerPick implements IChatContextPickerItem {
 			placeholder: localize('chatContext.sessions.placeholder', 'Select a session'),
 			picks: (async () => {
 				const picks: IChatContextPickerPickItem[] = [];
-				const sessionProviderFilter = [AgentSessionProviders.Local, AgentSessionProviders.Background, AgentSessionProviders.Claude];
+				const sessionProviderFilter = [AgentSessionProviders.Local, AgentSessionProviders.Background, AgentSessionProviders.Claude, AgentSessionProviders.AgentHostCopilot];
 				for await (const group of this._chatSessionsService.getChatSessionItems(sessionProviderFilter, CancellationToken.None)) {
 					const providerIcon = getAgentSessionProviderIcon(group.chatSessionType);
 					for (const item of group.items) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -51,7 +51,8 @@ import {
 } from '../../../common/attachments/chatVariableEntries.js';
 import { coerceImageBuffer } from '../../../common/chatImageExtraction.js';
 import { ChatRequestQueueKind, ConfirmedReason, ElicitationState, IChatProgress, IChatQuestion, IChatQuestionAnswers, IChatService, IChatToolInvocation, ToolConfirmKind, formatCopilotCredits, type IChatMultiSelectAnswer, type IChatPlanReviewResult, type IChatQuestionAnswerValue, type IChatResponseErrorDetails, type IChatSingleSelectAnswer, type IChatTerminalToolInvocationData } from '../../../common/chatService/chatService.js';
-import { IChatSession, IChatSessionContentProvider, IChatSessionHistoryItem, IChatSessionItem, IChatSessionRequestHistoryItem, type IChatInputCompletionItem, type IChatInputCompletionsParams, type IChatInputCompletionsResult, type IChatSessionServerRequest } from '../../../common/chatSessionsService.js';
+import { IChatDebugService } from '../../../common/chatDebugService.js';
+import { IChatSession, IChatSessionContentProvider, IChatSessionHistoryItem, IChatSessionItem, IChatSessionRequestHistoryItem, IChatSessionsService, type IChatInputCompletionItem, type IChatInputCompletionsParams, type IChatInputCompletionsResult, type IChatSessionServerRequest } from '../../../common/chatSessionsService.js';
 import { IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../common/constants.js';
 import { IChatEditingService } from '../../../common/editing/chatEditingService.js';
@@ -70,6 +71,7 @@ import { IAgentHostActiveClientService } from './agentHostActiveClientService.js
 import { IAgentHostSessionWorkingDirectoryResolver } from './agentHostSessionWorkingDirectoryResolver.js';
 import { IAgentHostNewSessionFolderService } from './agentHostNewSessionFolderService.js';
 import { AgentHostSnapshotController } from './agentHostSnapshotController.js';
+import { AgentHostSessionReferenceAttachmentDisplayKind, toSessionReferenceAttachmentMeta, toSessionReferenceDebugTranscript, toSessionReferenceHistoryTranscript, toSessionReferenceModelRepresentation } from './agentHostSessionReferenceAttachment.js';
 import { toolDataToDefinition } from './agentHostToolUtils.js';
 import { IAgentHostUntitledProvisionalSessionService } from './agentHostUntitledProvisionalSessionService.js';
 import { activeTurnToProgress, completedToolCallToEditParts, completedToolCallToSerialized, finalizeToolInvocation, getTerminalContentUri, isSubagentTool, makeAhpTerminalToolSessionId, messageToVariableData, parseAhpTerminalToolSessionId, rawMarkdownToString, stringOrMarkdownToString, toolCallStateToInvocation, turnsToHistory, updateRunningToolSpecificData, usageInfoToChatUsage, usageInfoToQuotas, type IToolCallFileEdit, type TurnModelLookup } from './stateToProgressAdapter.js';
@@ -595,6 +597,8 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		@IAgentHostActiveClientService private readonly _activeClientService: IAgentHostActiveClientService,
 		@IChatEntitlementService private readonly _chatEntitlementService: IChatEntitlementService,
 		@IWorkspaceTrustRequestService private readonly _workspaceTrustRequestService: IWorkspaceTrustRequestService,
+		@IChatSessionsService private readonly _chatSessionsService: IChatSessionsService,
+		@IChatDebugService private readonly _chatDebugService: IChatDebugService,
 	) {
 		super();
 		this._config = config;
@@ -1444,7 +1448,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		this._clientDispatchedTurnIds.add(turnId);
 		const chatKey = this._resolveChatUri(request.sessionResource).toString();
 		const turnChannel = this._resolveTurnDispatchChannel(request.sessionResource);
-		const messageAttachments = await this._convertVariablesToAttachments(request);
+		const messageAttachments = await this._convertVariablesToAttachments(request, cancellationToken);
 		if (cancellationToken.isCancellationRequested) {
 			return;
 		}
@@ -3416,8 +3420,24 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		return !!await this._workspaceTrustRequestService.requestResourcesTrust({ uri: workingDirectory, message });
 	}
 
-	private _convertVariablesToAttachments(request: IChatAgentRequest): MessageAttachment[] {
-		return this._variableEntriesToAttachments(request.variables.variables, request.sessionResource, request.message);
+	private async _convertVariablesToAttachments(request: IChatAgentRequest, token: CancellationToken): Promise<MessageAttachment[]> {
+		if (!request.variables.variables.some(v => v.kind === 'sessionReference' && v.value instanceof URI)) {
+			return this._variableEntriesToAttachments(request.variables.variables, request.sessionResource, request.message);
+		}
+
+		const attachments: MessageAttachment[] = [];
+		for (const v of request.variables.variables) {
+			const attachment = await this._convertVariableToAttachmentAsync(v, request.sessionResource, request.message, token);
+			if (Array.isArray(attachment)) {
+				attachments.push(...attachment);
+			} else if (attachment) {
+				attachments.push(attachment);
+			}
+		}
+		if (attachments.length > 0) {
+			this._logService.trace(`[AgentHost] Converted ${attachments.length} attachments from ${request.variables.variables.length} variables`);
+		}
+		return attachments;
 	}
 
 	private _variableEntriesToAttachments(variables: readonly IChatRequestVariableEntry[], sessionResource: URI, messageText?: string): MessageAttachment[] {
@@ -3434,6 +3454,15 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			this._logService.trace(`[AgentHost] Converted ${attachments.length} attachments from ${variables.length} variables`);
 		}
 		return attachments;
+	}
+
+	private async _convertVariableToAttachmentAsync(v: IChatRequestVariableEntry, sessionResource: URI, messageText: string | undefined, token: CancellationToken): Promise<MessageAttachment | MessageAttachment[] | undefined> {
+		if (v.kind === 'sessionReference' && v.value instanceof URI) {
+			const referenceRange = this._toAttachmentReferenceRange(messageText, v.range);
+			const modelRepresentation = await this._toSessionReferenceModelRepresentation(v.name, v.value, token);
+			return this._toSessionReferenceAttachment(v, v.value, modelRepresentation, referenceRange);
+		}
+		return this._convertVariableToAttachment(v, sessionResource, messageText);
 	}
 
 	private _convertVariableToAttachment(v: IChatRequestVariableEntry, sessionResource: URI, messageText?: string): MessageAttachment | MessageAttachment[] | undefined {
@@ -3467,6 +3496,9 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		if (isAgentFeedbackVariableEntry(v)) {
 			return this._toAgentFeedbackAttachment(v);
 		}
+		if (v.kind === 'sessionReference' && v.value instanceof URI) {
+			return this._toSessionReferenceAttachment(v, v.value, toSessionReferenceModelRepresentation(v.name, v.value), referenceRange);
+		}
 		// Pasted code, prompt text, and free-form string entries: surface their
 		// textual representation as an opaque attachment.
 		if (v.kind === 'paste') {
@@ -3486,6 +3518,50 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			return this._toSimpleAttachment(v.name, undefined, v._meta, 'skill', referenceRange);
 		}
 		return undefined;
+	}
+
+	private _toSessionReferenceAttachment(v: IChatRequestVariableEntry, sessionResource: URI, modelRepresentation: string, range?: MessageAttachment['range']): MessageAttachment {
+		return this._toSimpleAttachment(
+			v.name,
+			modelRepresentation,
+			{ ...(v._meta ?? {}), ...toSessionReferenceAttachmentMeta(sessionResource) },
+			AgentHostSessionReferenceAttachmentDisplayKind,
+			range
+		);
+	}
+
+	private async _toSessionReferenceModelRepresentation(label: string, sessionResource: URI, token: CancellationToken): Promise<string> {
+		let transcript: string | undefined;
+		try {
+			const session = await this._chatSessionsService.getOrCreateChatSession(sessionResource, token);
+			transcript = toSessionReferenceHistoryTranscript(session.history);
+		} catch (err) {
+			if (!isCancellationError(err) && !token.isCancellationRequested) {
+				this._logService.warn(`[AgentHost] Failed to hydrate attached session ${sessionResource.toString()}`, err);
+			}
+		}
+		if (!transcript && !token.isCancellationRequested) {
+			// Some referenced sessions only expose transcript content through debug/provider events.
+			transcript = await this._renderSessionReferenceDebugTranscript(sessionResource);
+		}
+		return toSessionReferenceModelRepresentation(label, sessionResource, transcript);
+	}
+
+	// Fallback for referenced sessions whose transcript is only exposed through debug/provider events.
+	// Happens when you send/complete message in one session then immediately navigate and try to reference that session in differnt session.
+	private async _renderSessionReferenceDebugTranscript(sessionResource: URI): Promise<string | undefined> {
+		let transcript = await toSessionReferenceDebugTranscript(this._chatDebugService.getEvents(sessionResource), eventId => this._chatDebugService.resolveEvent(eventId));
+		if (transcript) {
+			return transcript;
+		}
+
+		try {
+			await this._chatDebugService.invokeProviders(sessionResource);
+			transcript = await toSessionReferenceDebugTranscript(this._chatDebugService.getEvents(sessionResource), eventId => this._chatDebugService.resolveEvent(eventId));
+		} catch (err) {
+			this._logService.warn(`[AgentHost] Failed to hydrate attached session debug events ${sessionResource.toString()}`, err);
+		}
+		return transcript;
 	}
 
 	private _toResourceAttachment(uri: URI, label: string, displayKind: string, sessionResource: URI, _meta: Record<string, unknown> | undefined, range?: MessageAttachment['range']): MessageAttachment | undefined {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionReferenceAttachment.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionReferenceAttachment.ts
@@ -1,0 +1,190 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../../../../base/common/uri.js';
+import { type SimpleMessageAttachment } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
+import { type IChatRequestSessionReferenceVariableEntry } from '../../../common/attachments/chatVariableEntries.js';
+import { type IChatDebugEvent, type IChatDebugMessageSection, type IChatDebugResolvedEventContent } from '../../../common/chatDebugService.js';
+import { type IChatProgress } from '../../../common/chatService/chatService.js';
+import { type IChatSessionHistoryItem } from '../../../common/chatSessionsService.js';
+import { chatSessionResourceToId } from '../../../common/model/chatUri.js';
+
+export const AgentHostSessionReferenceAttachmentDisplayKind = 'sessionReference';
+export const AgentHostSessionReferenceAttachmentMetadataKey = 'vscode.agentHost.sessionReference';
+
+interface IAgentHostSessionReferenceAttachmentMetadata {
+	readonly sessionResource: string;
+	readonly sessionID: string;
+}
+
+export function toSessionReferenceModelRepresentation(label: string, sessionResource: URI, transcript?: string): string {
+	const sessionID = chatSessionResourceToId(sessionResource);
+	const header = [
+		`Attached chat session: ${label}`,
+		`Session ID: ${sessionID}`,
+		`Session URI: ${sessionResource.toString()}`,
+	].join('\n');
+	if (!transcript) {
+		return header;
+	}
+	return [
+		header,
+		'',
+		'Attached session transcript:',
+		transcript,
+	].join('\n');
+}
+
+export function toSessionReferenceHistoryTranscript(history: readonly IChatSessionHistoryItem[]): string | undefined {
+	const blocks: string[] = [];
+	for (const item of history) {
+		if (item.type === 'request') {
+			const prompt = item.prompt.trim();
+			if (prompt) {
+				blocks.push(`User:\n${prompt}`);
+			}
+			continue;
+		}
+
+		const response = toSessionReferenceResponse(item.parts);
+		if (response) {
+			blocks.push(`Assistant:\n${response}`);
+		}
+		if (item.errorDetails?.message) {
+			blocks.push(`Assistant error:\n${item.errorDetails.message}`);
+		}
+	}
+
+	return toSessionReferenceTranscript(blocks);
+}
+
+export async function toSessionReferenceDebugTranscript(events: readonly IChatDebugEvent[], resolveEvent: (eventId: string) => Promise<IChatDebugResolvedEventContent | undefined>): Promise<string | undefined> {
+	const blocks: string[] = [];
+	for (const event of events) {
+		if (event.kind === 'userMessage') {
+			const message = toSessionReferenceDebugMessage(event.message, event.sections);
+			if (message) {
+				blocks.push(`User:\n${message}`);
+			}
+		} else if (event.kind === 'agentResponse') {
+			const message = toSessionReferenceDebugMessage(event.message, event.sections);
+			if (message) {
+				blocks.push(`Assistant:\n${message}`);
+			}
+		} else if (event.kind === 'modelTurn' && event.id) {
+			const resolved = await resolveEvent(event.id);
+			if (resolved?.kind === 'modelTurn') {
+				const message = toSessionReferenceDebugSections(resolved.sections);
+				if (message) {
+					blocks.push(`Assistant:\n${message}`);
+				}
+			}
+		}
+	}
+
+	return toSessionReferenceTranscript(blocks);
+}
+
+export function toSessionReferenceAttachmentMeta(sessionResource: URI): Record<string, unknown> {
+	return {
+		[AgentHostSessionReferenceAttachmentMetadataKey]: {
+			sessionResource: sessionResource.toString(),
+			sessionID: chatSessionResourceToId(sessionResource),
+		} satisfies IAgentHostSessionReferenceAttachmentMetadata,
+	};
+}
+
+export function restoreSessionReferenceVariableEntryFromAttachment(attachment: SimpleMessageAttachment): IChatRequestSessionReferenceVariableEntry | undefined {
+	if (attachment.displayKind !== AgentHostSessionReferenceAttachmentDisplayKind) {
+		return undefined;
+	}
+
+	const metadata = getSessionReferenceAttachmentMetadata(attachment);
+	if (!metadata) {
+		return undefined;
+	}
+
+	try {
+		const sessionResource = URI.parse(metadata.sessionResource);
+		return {
+			kind: 'sessionReference',
+			id: sessionResource.toString(),
+			name: attachment.label,
+			value: sessionResource,
+			_meta: attachment._meta,
+		};
+	} catch {
+		return undefined;
+	}
+}
+
+function getSessionReferenceAttachmentMetadata(attachment: SimpleMessageAttachment): IAgentHostSessionReferenceAttachmentMetadata | undefined {
+	const meta = attachment._meta;
+	if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
+		return undefined;
+	}
+	const metadata = meta[AgentHostSessionReferenceAttachmentMetadataKey];
+	if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+		return undefined;
+	}
+	const raw = metadata as Record<string, unknown>;
+	const sessionResource = raw['sessionResource'];
+	if (typeof sessionResource !== 'string') {
+		return undefined;
+	}
+	const sessionID = raw['sessionID'];
+	if (typeof sessionID !== 'string') {
+		return undefined;
+	}
+	return {
+		sessionResource,
+		sessionID,
+	};
+}
+
+function toSessionReferenceTranscript(blocks: readonly string[]): string | undefined {
+	const transcript = blocks.join('\n\n').trim();
+	return transcript || undefined;
+}
+
+function toSessionReferenceResponse(parts: readonly IChatProgress[]): string | undefined {
+	const chunks: string[] = [];
+	for (const part of parts) {
+		switch (part.kind) {
+			case 'markdownContent':
+			case 'markdownVuln':
+			case 'progressMessage':
+			case 'warning':
+			case 'info':
+				if (part.content.value.trim()) {
+					chunks.push(part.content.value.trim());
+				}
+				break;
+			case 'progressTaskResult':
+				if (part.content?.value.trim()) {
+					chunks.push(part.content.value.trim());
+				}
+				break;
+		}
+	}
+	const response = chunks.join('\n\n').trim();
+	return response || undefined;
+}
+
+function toSessionReferenceDebugMessage(message: string, sections: readonly IChatDebugMessageSection[]): string | undefined {
+	const renderedSections = toSessionReferenceDebugSections(sections);
+	if (renderedSections) {
+		return renderedSections;
+	}
+	const trimmedMessage = message.trim();
+	return trimmedMessage || undefined;
+}
+
+function toSessionReferenceDebugSections(sections: readonly IChatDebugMessageSection[] | undefined): string | undefined {
+	const chunks = sections
+		?.map(section => section.content.trim())
+		.filter(content => !!content);
+	return chunks?.length ? chunks.join('\n\n') : undefined;
+}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -25,7 +25,7 @@ import { AgentHostCompletionReferenceKind, restorePasteVariableEntryFromAttachme
 import { type IToolConfirmationMessages, type IToolData, type IToolResult, type IToolResultInputOutputDetails, ToolDataSource, ToolInvocationPresentation } from '../../../common/tools/languageModelToolsService.js';
 import { MCP } from '../../../../mcp/common/modelContextProtocol.js';
 import { basename, isEqual } from '../../../../../../base/common/resources.js';
-import { hasKey, type Mutable } from '../../../../../../base/common/types.js';
+import { hasKey, isObject, type Mutable } from '../../../../../../base/common/types.js';
 import { localize } from '../../../../../../nls.js';
 import type { IRange } from '../../../../../../editor/common/core/range.js';
 
@@ -644,11 +644,32 @@ function getTerminalOutput(tc: ToolCallState) {
 	return { text: text.replace(/\r?\n/g, '\r\n') };
 }
 
+interface ITerminalCommandStructuredContent {
+	readonly exitCode?: number;
+	readonly cwd?: string;
+}
+
+function readTerminalCommandStructuredContent(structuredContent: Record<string, unknown> | undefined): ITerminalCommandStructuredContent | undefined {
+	const terminalCommand = structuredContent?.['terminalCommand'];
+	if (!isObject(terminalCommand)) {
+		return undefined;
+	}
+	const exitCode = Reflect.get(terminalCommand, 'exitCode');
+	const cwd = Reflect.get(terminalCommand, 'cwd');
+	if (typeof exitCode !== 'number' && typeof cwd !== 'string') {
+		return undefined;
+	}
+	return {
+		...(typeof exitCode === 'number' ? { exitCode } : {}),
+		...(typeof cwd === 'string' ? { cwd } : {}),
+	};
+}
+
 function getTerminalCommandState(tc: ToolCallState, fallbackSuccess?: boolean): IChatTerminalToolInvocationData['terminalCommandState'] | undefined {
 	const structuredContent = tc.status === ToolCallStatus.Completed || tc.status === ToolCallStatus.PendingResultConfirmation
 		? tc.structuredContent
 		: undefined;
-	const terminalCommand = structuredContent?.terminalCommand;
+	const terminalCommand = readTerminalCommandStructuredContent(structuredContent);
 	if (terminalCommand !== undefined) {
 		if (terminalCommand.exitCode !== undefined) {
 			return { exitCode: terminalCommand.exitCode };

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -28,6 +28,7 @@ import { basename, isEqual } from '../../../../../../base/common/resources.js';
 import { hasKey, isObject, type Mutable } from '../../../../../../base/common/types.js';
 import { localize } from '../../../../../../nls.js';
 import type { IRange } from '../../../../../../editor/common/core/range.js';
+import { restoreSessionReferenceVariableEntryFromAttachment } from './agentHostSessionReferenceAttachment.js';
 
 /**
  * Constructs a terminal tool session ID from a terminal URI and backend session.
@@ -528,6 +529,12 @@ function messageAttachmentToVariableEntry(attachment: MessageAttachment, connect
 	}
 
 	const modelRepresentation = attachment.type === MessageAttachmentKind.Simple ? attachment.modelRepresentation : undefined;
+	if (attachment.type === MessageAttachmentKind.Simple) {
+		const sessionReferenceEntry = restoreSessionReferenceVariableEntryFromAttachment(attachment);
+		if (sessionReferenceEntry) {
+			return sessionReferenceEntry;
+		}
+	}
 	const pasteEntry = restorePasteVariableEntryFromAttachment({
 		label: attachment.label,
 		displayKind: attachment.displayKind,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -644,6 +644,21 @@ function getTerminalOutput(tc: ToolCallState) {
 	return { text: text.replace(/\r?\n/g, '\r\n') };
 }
 
+function getTerminalCommandState(tc: ToolCallState, fallbackSuccess?: boolean): IChatTerminalToolInvocationData['terminalCommandState'] | undefined {
+	const structuredContent = tc.status === ToolCallStatus.Completed || tc.status === ToolCallStatus.PendingResultConfirmation
+		? tc.structuredContent
+		: undefined;
+	const terminalCommand = structuredContent?.terminalCommand;
+	if (terminalCommand !== undefined) {
+		if (terminalCommand.exitCode !== undefined) {
+			return { exitCode: terminalCommand.exitCode };
+		}
+		return undefined;
+	}
+
+	return fallbackSuccess === undefined ? undefined : { exitCode: fallbackSuccess ? 0 : 1 };
+}
+
 function getTerminalLanguage(tc: ToolCallState) {
 	return tc.toolName === 'powershell' ? 'powershell' : 'shellscript';
 }
@@ -892,9 +907,10 @@ export function completedToolCallToSerialized(tc: ICompletedToolCall, subAgentIn
 
 	let toolSpecificData: IChatTerminalToolInvocationData | IChatSearchToolInvocationData | IChatToolInputInvocationData | undefined;
 	if (isTerminal) {
+		const terminalCommandState = getTerminalCommandState(tc, isSuccess);
 		toolSpecificData = {
 			...buildTerminalToolSpecificData(tc, sessionResource),
-			terminalCommandState: { exitCode: isSuccess ? 0 : 1 },
+			...(terminalCommandState ? { terminalCommandState } : {}),
 		};
 	} else if (getToolKind(tc) === 'search') {
 		toolSpecificData = { kind: 'search' };
@@ -1420,10 +1436,11 @@ export function finalizeToolInvocation(invocation: ChatToolInvocation, tc: ToolC
 
 	if (isTerminal && (isCompleted || isCancelled)) {
 		const existing = invocation.toolSpecificData?.kind === 'terminal' ? invocation.toolSpecificData : undefined;
+		const terminalCommandState = getTerminalCommandState(tc, isCompleted && tc.success);
 		invocation.presentation = undefined;
 		invocation.toolSpecificData = {
 			...buildTerminalToolSpecificData(tc, backendSession, existing),
-			terminalCommandState: { exitCode: isCompleted && tc.success ? 0 : 1 },
+			...(terminalCommandState ? { terminalCommandState } : {}),
 		};
 	} else if (isCompleted && tc.pastTenseMessage) {
 		invocation.pastTenseMessage = stringOrMarkdownToString(tc.pastTenseMessage, connectionAuthority);

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -32,9 +32,10 @@ import { ChatEntitlement, IChatEntitlementService } from '../../../../../service
 import { IChatAgentData, IChatAgentImplementation, IChatAgentRequest, IChatAgentService } from '../../../common/participants/chatAgents.js';
 import { ChatAgentLocation } from '../../../common/constants.js';
 import { ChatRequestQueueKind, ElicitationState, IChatService, IChatMarkdownContent, IChatProgress, IChatTerminalToolInvocationData, IChatToolInputInvocationData, IChatToolInvocation, IChatToolInvocationSerialized, IChatUsage, ToolConfirmKind } from '../../../common/chatService/chatService.js';
+import { IChatDebugService, type IChatDebugEvent } from '../../../common/chatDebugService.js';
 import { IChatEditingService } from '../../../common/editing/chatEditingService.js';
 import { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
-import { IChatSessionsService, type IChatSessionItemController, type IChatSessionRequestHistoryItem, type IChatSessionsExtensionPoint } from '../../../common/chatSessionsService.js';
+import { IChatSessionsService, type IChatSession, type IChatSessionItemController, type IChatSessionRequestHistoryItem, type IChatSessionsExtensionPoint } from '../../../common/chatSessionsService.js';
 import { ILanguageModelsService, type ILanguageModelChatMetadata } from '../../../common/languageModels.js';
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
@@ -78,6 +79,7 @@ import type { IChatModel, IChatPendingRequest, IChatRequestModel } from '../../.
 import { convertBufferToScreenshotVariable } from '../../../browser/attachments/chatScreenshotContext.js';
 import { AgentHostCompletionReferenceKind, ChatPasteAttachmentMetadata, toAgentHostCompletionVariableEntry } from '../../../common/attachments/chatVariableEntries.js';
 import { messageAttachmentsToVariableData } from '../../../browser/agentSessions/agentHost/stateToProgressAdapter.js';
+import { AgentHostSessionReferenceAttachmentDisplayKind, AgentHostSessionReferenceAttachmentMetadataKey, toSessionReferenceModelRepresentation } from '../../../browser/agentSessions/agentHost/agentHostSessionReferenceAttachment.js';
 
 // ---- Mock agent host service ------------------------------------------------
 
@@ -469,7 +471,7 @@ class MockChatWidgetService extends mock<IChatWidgetService>() {
 
 // ---- Helpers ----------------------------------------------------------------
 
-function createTestServices(disposables: DisposableStore, workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined; isNewSession?: (sessionResource: URI) => boolean }, authServiceOverride?: Partial<IAuthenticationService>, languageModels?: ReadonlyMap<string, ILanguageModelChatMetadata>, provisionalServiceOverride?: Partial<IAgentHostUntitledProvisionalSessionService>, isSessionsWindow = false) {
+function createTestServices(disposables: DisposableStore, workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined; isNewSession?: (sessionResource: URI) => boolean }, authServiceOverride?: Partial<IAuthenticationService>, languageModels?: ReadonlyMap<string, ILanguageModelChatMetadata>, provisionalServiceOverride?: Partial<IAgentHostUntitledProvisionalSessionService>, isSessionsWindow = false, chatSessionsServiceOverride?: Partial<IChatSessionsService>, chatDebugServiceOverride?: Partial<IChatDebugService>) {
 	const instantiationService = disposables.add(new TestInstantiationService());
 
 	const agentHostService = new MockAgentHostService();
@@ -516,6 +518,13 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 			chatSessionContributions.push(contribution);
 			return toDisposable(() => { });
 		},
+		...chatSessionsServiceOverride,
+	});
+	instantiationService.stub(IChatDebugService, {
+		getEvents: () => [],
+		invokeProviders: async () => { },
+		resolveEvent: async () => undefined,
+		...chatDebugServiceOverride,
 	});
 	instantiationService.stub(IDefaultAccountService, { onDidChangeDefaultAccount: Event.None, getDefaultAccount: async () => null });
 	instantiationService.stub(IAuthenticationService, { onDidChangeSessions: Event.None, ...authServiceOverride });
@@ -667,8 +676,8 @@ function createSessionListController(disposables: DisposableStore, instantiation
 	return disposables.add(instantiationService.createInstance(AgentHostSessionListController, sessionType, provider, sessionListStore, description, 'local'));
 }
 
-function createContribution(disposables: DisposableStore, opts?: { authServiceOverride?: Partial<IAuthenticationService>; workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined; isNewSession?: (sessionResource: URI) => boolean }; languageModels?: ReadonlyMap<string, ILanguageModelChatMetadata>; provisionalServiceOverride?: Partial<IAgentHostUntitledProvisionalSessionService> }) {
-	const { instantiationService, agentHostService, chatAgentService, chatWidgetService, chatService, openerService, trustController } = createTestServices(disposables, opts?.workingDirectoryResolver, opts?.authServiceOverride, opts?.languageModels, opts?.provisionalServiceOverride);
+function createContribution(disposables: DisposableStore, opts?: { authServiceOverride?: Partial<IAuthenticationService>; workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined; isNewSession?: (sessionResource: URI) => boolean }; languageModels?: ReadonlyMap<string, ILanguageModelChatMetadata>; provisionalServiceOverride?: Partial<IAgentHostUntitledProvisionalSessionService>; chatSessionsServiceOverride?: Partial<IChatSessionsService>; chatDebugServiceOverride?: Partial<IChatDebugService> }) {
+	const { instantiationService, agentHostService, chatAgentService, chatWidgetService, chatService, openerService, trustController } = createTestServices(disposables, opts?.workingDirectoryResolver, opts?.authServiceOverride, opts?.languageModels, opts?.provisionalServiceOverride, undefined, opts?.chatSessionsServiceOverride, opts?.chatDebugServiceOverride);
 
 	const listController = createSessionListController(disposables, instantiationService, agentHostService);
 	const sessionHandler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
@@ -1142,6 +1151,53 @@ suite('AgentHostChatContribution', () => {
 				language: undefined,
 				pastedLines: undefined,
 				fileName: undefined,
+			}]);
+		});
+
+		test('restores session reference simple attachments as session reference variable entries', () => {
+			const sessionResource = URI.from({ scheme: 'copilotcli', path: '/session-123' });
+			const variableData = messageAttachmentsToVariableData([{
+				type: MessageAttachmentKind.Simple,
+				label: 'Review session',
+				displayKind: AgentHostSessionReferenceAttachmentDisplayKind,
+				modelRepresentation: toSessionReferenceModelRepresentation('Review session', sessionResource),
+				_meta: {
+					[AgentHostSessionReferenceAttachmentMetadataKey]: {
+						sessionResource: sessionResource.toString(),
+						sessionID: sessionResource.toString(),
+					},
+				},
+			}], 'test');
+
+			assert.deepStrictEqual(variableData?.variables.map(variable => ({
+				kind: variable.kind,
+				id: variable.id,
+				name: variable.name,
+				value: URI.isUri(variable.value) ? variable.value.toString() : variable.value,
+			})), [{
+				kind: 'sessionReference',
+				id: sessionResource.toString(),
+				name: 'Review session',
+				value: sessionResource.toString(),
+			}]);
+		});
+
+		test('session reference simple attachments without metadata restore as generic variable entries', () => {
+			const variableData = messageAttachmentsToVariableData([{
+				type: MessageAttachmentKind.Simple,
+				label: 'Review session',
+				displayKind: AgentHostSessionReferenceAttachmentDisplayKind,
+				modelRepresentation: 'session text',
+			}], 'test');
+
+			assert.deepStrictEqual(variableData?.variables.map(variable => ({
+				kind: variable.kind,
+				name: variable.name,
+				value: variable.value,
+			})), [{
+				kind: 'generic',
+				name: 'Review session',
+				value: 'session text',
 			}]);
 		});
 	});
@@ -4322,6 +4378,198 @@ suite('AgentHostChatContribution', () => {
 			assert.deepStrictEqual(turnAction.message.attachments, [
 				{ type: MessageAttachmentKind.Resource, uri: URI.file('/workspace/test.ts').toString(), label: 'test.ts', displayKind: 'document', _meta: { provider: 'fs', score: 0.42 } },
 			]);
+		}));
+
+		test('session reference variable becomes a simple attachment', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
+			const sessionReference = URI.from({ scheme: 'copilotcli', path: '/session-123' });
+
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
+				message: 'continue #review',
+				variables: {
+					variables: [
+						upcastPartial({
+							kind: 'sessionReference',
+							id: sessionReference.toString(),
+							name: 'Review session',
+							value: sessionReference,
+							range: { start: 9, endExclusive: 16 },
+							_meta: { source: 'test' },
+						}),
+					],
+				},
+			});
+			fire({ type: 'chat/turnComplete', session, turnId } as ChatAction);
+			await turnPromise;
+
+			assert.strictEqual(agentHostService.turnActions.length, 1);
+			const turnAction = agentHostService.turnActions[0].action as ITurnStartedAction;
+			assert.deepStrictEqual(turnAction.message.attachments, [{
+				type: MessageAttachmentKind.Simple,
+				label: 'Review session',
+				modelRepresentation: toSessionReferenceModelRepresentation('Review session', sessionReference),
+				displayKind: AgentHostSessionReferenceAttachmentDisplayKind,
+				range: {
+					start: { line: 0, character: 9 },
+					end: { line: 0, character: 16 },
+				},
+				_meta: {
+					source: 'test',
+					[AgentHostSessionReferenceAttachmentMetadataKey]: {
+						sessionResource: sessionReference.toString(),
+						sessionID: sessionReference.toString(),
+					},
+				},
+			}]);
+		}));
+
+		test('session reference attachment includes hydrated session transcript when available', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const sessionReference = URI.from({ scheme: 'agent-host-copilotcli', path: '/referenced-session' });
+			const referencedSession = upcastPartial<IChatSession>({
+				sessionResource: sessionReference,
+				onWillDispose: Event.None,
+				history: [
+					{
+						type: 'request',
+						prompt: 'What did we decide about the terminal output?',
+						participant: 'agent-host-copilot',
+					},
+					{
+						type: 'response',
+						participant: 'agent-host-copilot',
+						parts: [{
+							kind: 'markdownContent',
+							content: { value: 'We decided to preserve the rendered output and avoid duplicate stale chunks.' },
+						}],
+					},
+				],
+				dispose: () => { },
+			});
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables, {
+				chatSessionsServiceOverride: {
+					getOrCreateChatSession: async resource => {
+						assert.strictEqual(resource.toString(), sessionReference.toString());
+						return referencedSession;
+					},
+				},
+			});
+
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
+				message: 'continue #review',
+				variables: {
+					variables: [
+						upcastPartial({
+							kind: 'sessionReference',
+							id: sessionReference.toString(),
+							name: 'Review session',
+							value: sessionReference,
+						}),
+					],
+				},
+			});
+			fire({ type: 'chat/turnComplete', session, turnId } as ChatAction);
+			await turnPromise;
+
+			assert.strictEqual(agentHostService.turnActions.length, 1);
+			const turnAction = agentHostService.turnActions[0].action as ITurnStartedAction;
+			const attachment = turnAction.message.attachments?.[0];
+			assert.strictEqual(attachment?.type, MessageAttachmentKind.Simple);
+			assert.strictEqual(attachment.label, 'Review session');
+			assert.strictEqual(attachment.displayKind, AgentHostSessionReferenceAttachmentDisplayKind);
+			assert.ok(attachment.modelRepresentation?.includes('Attached session transcript:'));
+			assert.ok(attachment.modelRepresentation?.includes('User:\nWhat did we decide about the terminal output?'));
+			assert.ok(attachment.modelRepresentation?.includes('Assistant:\nWe decided to preserve the rendered output and avoid duplicate stale chunks.'));
+		}));
+
+		test('session reference attachment falls back to debug events when chat history is empty', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const sessionReference = URI.from({ scheme: 'agent-host-copilotcli', path: '/debug-session' });
+			const referencedSession = upcastPartial<IChatSession>({
+				sessionResource: sessionReference,
+				onWillDispose: Event.None,
+				history: [],
+				dispose: () => { },
+			});
+			let invoked = false;
+			const debugEvents: IChatDebugEvent[] = [
+				{
+					kind: 'userMessage',
+					id: 'user-1',
+					sessionResource: sessionReference,
+					created: new Date(0),
+					message: 'Fastest car in the world?',
+					sections: [],
+				},
+				{
+					kind: 'modelTurn',
+					id: 'assistant-1',
+					sessionResource: sessionReference,
+					created: new Date(1),
+					requestName: 'copilotcli',
+				},
+			];
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables, {
+				chatSessionsServiceOverride: {
+					getOrCreateChatSession: async resource => {
+						assert.strictEqual(resource.toString(), sessionReference.toString());
+						return referencedSession;
+					},
+				},
+				chatDebugServiceOverride: {
+					getEvents: resource => invoked && resource?.toString() === sessionReference.toString() ? debugEvents : [],
+					invokeProviders: async resource => {
+						assert.strictEqual(resource.toString(), sessionReference.toString());
+						invoked = true;
+					},
+					resolveEvent: async eventId => eventId === 'assistant-1'
+						? {
+							kind: 'modelTurn',
+							requestName: 'copilotcli',
+							sections: [{ name: 'Response', content: 'The session answered that the current production-car record belongs to the Koenigsegg Jesko Absolut.' }],
+						}
+						: undefined,
+				},
+			});
+
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
+				message: 'continue #review',
+				variables: {
+					variables: [
+						upcastPartial({
+							kind: 'sessionReference',
+							id: sessionReference.toString(),
+							name: 'Review session',
+							value: sessionReference,
+						}),
+					],
+				},
+			});
+			fire({ type: 'chat/turnComplete', session, turnId } as ChatAction);
+			await turnPromise;
+
+			const turnAction = agentHostService.turnActions[0].action as ITurnStartedAction;
+			const attachment = turnAction.message.attachments?.[0];
+			assert.strictEqual(attachment?.type, MessageAttachmentKind.Simple);
+			assert.ok(attachment.modelRepresentation?.includes('User:\nFastest car in the world?'));
+			assert.ok(attachment.modelRepresentation?.includes('Assistant:\nThe session answered that the current production-car record belongs to the Koenigsegg Jesko Absolut.'));
+		}));
+
+		test('malformed session reference variable is dropped', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
+
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
+				message: 'continue this',
+				variables: {
+					variables: [
+						upcastPartial({ kind: 'sessionReference', id: 'bad-session', name: 'Bad session', value: 'not a uri' as never }),
+					],
+				},
+			});
+			fire({ type: 'chat/turnComplete', session, turnId } as ChatAction);
+			await turnPromise;
+
+			assert.strictEqual(agentHostService.turnActions.length, 1);
+			const turnAction = agentHostService.turnActions[0].action as ITurnStartedAction;
+			assert.strictEqual(turnAction.message.attachments, undefined);
 		}));
 
 		test('agent feedback variable becomes a simple attachment when no annotations channel is known', () => runWithFakedTimers({ useFakeTimers: true }, async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -431,6 +431,33 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(termData.terminalCommandState, undefined);
 		});
 
+		test('built-in terminal tool in history falls back to tool success without structured status', () => {
+			const turn = createTurn({
+				responseParts: [{
+					kind: ResponsePartKind.ToolCall, toolCall: createCompletedToolCall({
+						toolName: 'bash',
+						toolInput: 'echo hi',
+						_meta: { toolKind: 'terminal' },
+						content: [
+							{ type: ToolResultContentType.Text, text: 'hi' },
+						],
+						success: true,
+					})
+				} as ToolCallResponsePart],
+			});
+
+			const history = turnsToHistory(URI.file('/'), [turn], 'p');
+			const response = history[1];
+			assert.strictEqual(response.type, 'response');
+			if (response.type !== 'response') { return; }
+			const serialized = response.parts[0] as IChatToolInvocationSerialized;
+
+			assert.ok(serialized.toolSpecificData);
+			assert.strictEqual(serialized.toolSpecificData.kind, 'terminal');
+			const termData = serialized.toolSpecificData as { kind: 'terminal'; terminalCommandState?: { exitCode?: number } };
+			assert.strictEqual(termData.terminalCommandState?.exitCode, 0);
+		});
+
 		test('terminal tool call in history does not set pastTenseMessage (avoids duplicate render)', () => {
 			const turn = createTurn({
 				responseParts: [{
@@ -942,6 +969,35 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(termData.terminalCommandOutput?.text, 'bad_cmd: command not found');
 			assert.strictEqual(termData.terminalCommandState?.exitCode, 127);
 			assert.strictEqual(termData.terminalCommandUri, undefined);
+		});
+
+		test('finalizes built-in terminal tool with success fallback when structured status is missing', () => {
+			const tc = createToolCallState({
+				toolName: 'bash',
+				toolInput: 'echo hi',
+				_meta: { toolKind: 'terminal' },
+			});
+			const invocation = toolCallStateToInvocation(tc);
+
+			finalizeToolInvocation(invocation, {
+				status: ToolCallStatus.Completed,
+				toolCallId: 'tc-1',
+				toolName: 'bash',
+				displayName: 'Run Shell Command',
+				invocationMessage: 'Running `echo hi`',
+				toolInput: 'echo hi',
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+				success: true,
+				pastTenseMessage: 'Ran `echo hi`',
+				content: [
+					{ type: ToolResultContentType.Text, text: 'hi' },
+				],
+			});
+
+			assert.ok(invocation.toolSpecificData);
+			assert.strictEqual(invocation.toolSpecificData.kind, 'terminal');
+			const termData = invocation.toolSpecificData as { kind: 'terminal'; terminalCommandState?: { exitCode?: number } };
+			assert.strictEqual(termData.terminalCommandState?.exitCode, 0);
 		});
 
 		test('normalizes LF line endings to CRLF in terminal output for xterm rendering', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -373,6 +373,64 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(termData.terminalCommandState.exitCode, 0);
 		});
 
+		test('built-in terminal tool in history uses structured command exit code', () => {
+			const turn = createTurn({
+				responseParts: [{
+					kind: ResponsePartKind.ToolCall, toolCall: createCompletedToolCall({
+						toolName: 'bash',
+						toolInput: 'bad_cmd',
+						_meta: { toolKind: 'terminal' },
+						content: [
+							{ type: ToolResultContentType.Text, text: 'bad_cmd: command not found' },
+						],
+						structuredContent: { terminalCommand: { exitCode: 127, cwd: '/workspace' } },
+						success: true,
+					})
+				} as ToolCallResponsePart],
+			});
+
+			const history = turnsToHistory(URI.file('/'), [turn], 'p');
+			const response = history[1];
+			assert.strictEqual(response.type, 'response');
+			if (response.type !== 'response') { return; }
+			const serialized = response.parts[0] as IChatToolInvocationSerialized;
+
+			assert.ok(serialized.toolSpecificData);
+			assert.strictEqual(serialized.toolSpecificData.kind, 'terminal');
+			const termData = serialized.toolSpecificData as { kind: 'terminal'; terminalCommandOutput?: { text: string }; terminalCommandState?: { exitCode?: number }; terminalCommandUri?: URI };
+			assert.strictEqual(termData.terminalCommandOutput?.text, 'bad_cmd: command not found');
+			assert.strictEqual(termData.terminalCommandState?.exitCode, 127);
+			assert.strictEqual(termData.terminalCommandUri, undefined, 'SDK terminal snapshot must not create an AHP terminal URI');
+		});
+
+		test('built-in terminal tool in history does not fabricate exit code when structured status is incomplete', () => {
+			const turn = createTurn({
+				responseParts: [{
+					kind: ResponsePartKind.ToolCall, toolCall: createCompletedToolCall({
+						toolName: 'bash',
+						toolInput: 'long_running_command',
+						_meta: { toolKind: 'terminal' },
+						content: [
+							{ type: ToolResultContentType.Text, text: 'still running' },
+						],
+						structuredContent: { terminalCommand: { cwd: '/workspace' } },
+						success: true,
+					})
+				} as ToolCallResponsePart],
+			});
+
+			const history = turnsToHistory(URI.file('/'), [turn], 'p');
+			const response = history[1];
+			assert.strictEqual(response.type, 'response');
+			if (response.type !== 'response') { return; }
+			const serialized = response.parts[0] as IChatToolInvocationSerialized;
+
+			assert.ok(serialized.toolSpecificData);
+			assert.strictEqual(serialized.toolSpecificData.kind, 'terminal');
+			const termData = serialized.toolSpecificData as { kind: 'terminal'; terminalCommandState?: { exitCode?: number } };
+			assert.strictEqual(termData.terminalCommandState, undefined);
+		});
+
 		test('terminal tool call in history does not set pastTenseMessage (avoids duplicate render)', () => {
 			const turn = createTurn({
 				responseParts: [{
@@ -852,6 +910,38 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(termData.terminalCommandOutput.text, 'output text');
 			assert.strictEqual(termData.terminalCommandState.exitCode, 0);
 			assert.strictEqual(IChatToolInvocation.resultDetails(invocation), undefined);
+		});
+
+		test('finalizes built-in terminal tool with structured non-zero exit code', () => {
+			const tc = createToolCallState({
+				toolName: 'bash',
+				toolInput: 'bad_cmd',
+				_meta: { toolKind: 'terminal' },
+			});
+			const invocation = toolCallStateToInvocation(tc);
+
+			finalizeToolInvocation(invocation, {
+				status: ToolCallStatus.Completed,
+				toolCallId: 'tc-1',
+				toolName: 'bash',
+				displayName: 'Run Shell Command',
+				invocationMessage: 'Running `bad_cmd`',
+				toolInput: 'bad_cmd',
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+				success: true,
+				pastTenseMessage: 'Ran `bad_cmd`',
+				content: [
+					{ type: ToolResultContentType.Text, text: 'bad_cmd: command not found' },
+				],
+				structuredContent: { terminalCommand: { exitCode: 127, cwd: '/workspace' } },
+			});
+
+			assert.ok(invocation.toolSpecificData);
+			assert.strictEqual(invocation.toolSpecificData.kind, 'terminal');
+			const termData = invocation.toolSpecificData as { kind: 'terminal'; terminalCommandOutput?: { text: string }; terminalCommandState?: { exitCode?: number }; terminalCommandUri?: URI };
+			assert.strictEqual(termData.terminalCommandOutput?.text, 'bad_cmd: command not found');
+			assert.strictEqual(termData.terminalCommandState?.exitCode, 127);
+			assert.strictEqual(termData.terminalCommandUri, undefined);
 		});
 
 		test('normalizes LF line endings to CRLF in terminal output for xterm rendering', () => {


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/322163
Important Related: https://github.com/github/copilot-sdk/issues/1803

- Temporarily parse (until 1803 gets resolved) the Copilot shell tool's trailing `<... exit code N>` footer while the SDK does not expose structured shell exit metadata.
- Store the parsed shell exit code as `structuredContent.terminalCommand.exitCode` for Agent Host tool completion state.
- Use that real exit code when rendering chat terminal command decorations: `0` stays success, non-zero becomes error, and missing exit code remains unknown.
- Preserve the existing compatibility fallback to `tool.success` only when no terminal command status exists.
- Keep SDK `result.contents` / terminal content blocks out of this path until the SDK API shape is fixed.

-----------------------------------------
Inspirations from:

- Terminal decoration success/error/default semantics come from [`DecorationAddon._getDecorationCssColor`](https://github.com/microsoft/vscode/blob/c95c7ab70733c29cc031dc4fb09a73c5b38398ec/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts#L609-L616).
- Chat terminal invocation state shape comes from [`IChatTerminalToolInvocationData.terminalCommandState`](https://github.com/microsoft/vscode/blob/c95c7ab70733c29cc031dc4fb09a73c5b38398ec/src/vs/workbench/contrib/chat/common/chatService/chatService.ts#L621-L625).