### PR TITLE
ci: install CVE-fixed libexpat to fix fontconfig SIGSEGV in Electron smoke tests

### DIFF
--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -209,6 +209,59 @@ jobs:
           FONTCONFIG_EOF
           echo "FONTCONFIG_FILE=/tmp/fonts-minimal.conf" >> "$GITHUB_ENV"
 
+      # Root-cause fix for the intermittent startup SIGSEGV: Ubuntu 24.04 (noble)
+      # ships libexpat1 2.6.1, which intermittently NULL-derefs while fontconfig
+      # parses font config XML during Electron/Chromium startup. The crash
+      # signature is a glib worker thread: pangoft2 -> fontconfig (FcInit/parse)
+      # -> expat (XML_ParseBuffer) -> libc NULL deref, before any window appears.
+      # The CVE-specific fontconfig config tweaks above reduce but do not eliminate
+      # it (the runtime XML parse still reaches expat). The fix only exists in
+      # expat >= 2.7.5, which noble does not package yet. Rather than build from
+      # source, install the official prebuilt libexpat1 .deb (from a newer Ubuntu
+      # release) fetched via the Azure Ubuntu mirror the runner already uses: it
+      # Pre-Depends only on libc6 (>= 2.38), satisfied by noble's 2.39, so it
+      # installs cleanly and replaces the system libexpat.so.1 (ABI-stable SONAME)
+      # for every process, including Electron. Remove this step once noble ships
+      # libexpat1 >= 2.7.5.
+      - name: Install CVE-fixed libexpat to avoid fontconfig NULL-deref crash
+        run: |
+          set -euo pipefail
+          # Skip if the runner already ships a fixed expat (>= 2.7.5).
+          EXPAT_VER=$(dpkg-query -W -f='${Version}' libexpat1 2>/dev/null || echo "0")
+          if dpkg --compare-versions "$EXPAT_VER" ge "2.7.5"; then
+            echo "::warning::libexpat1 $EXPAT_VER already includes the fixes (>= 2.7.5). This step can be removed."
+            exit 0
+          fi
+
+          # libexpat1 2.8.1 (> 2.7.5) is byte-identical across Ubuntu sources, so we
+          # verify by sha256 and try the fastest/most-trusted origin first:
+          #   1. the Azure Ubuntu mirror the runner already uses (in-datacenter)
+          #   2. the canonical Ubuntu archive
+          #   3. Launchpad's permanent file store (survives pool rolls)
+          DEB="libexpat1_2.8.1-1_amd64.deb"
+          SHA256="72c8fc5de6fa9bb47a3a593d653f993cbcc4c73532f777736add653e9b141da0"
+          MIRRORS="
+          http://azure.archive.ubuntu.com/ubuntu/pool/main/e/expat/${DEB}
+          http://archive.ubuntu.com/ubuntu/pool/main/e/expat/${DEB}
+          https://launchpad.net/ubuntu/+archive/primary/+files/${DEB}
+          "
+          ok=0
+          for url in $MIRRORS; do
+            if curl -fsSL --max-time 60 --retry 3 -o "$RUNNER_TEMP/$DEB" "$url" \
+              && echo "$SHA256  $RUNNER_TEMP/$DEB" | sha256sum -c -; then
+              echo "Fetched $DEB from $url"
+              ok=1
+              break
+            fi
+            echo "Could not fetch/verify from $url, trying next source..."
+          done
+          if [ "$ok" != 1 ]; then
+            echo "Failed to fetch $DEB from all sources" >&2
+            exit 1
+          fi
+          sudo dpkg -i "$RUNNER_TEMP/$DEB"
+          echo "libexpat1 is now: $(dpkg-query -W -f='${Version}' libexpat1)"
+
       - name: Fontconfig diagnostics and cache reset
         run: |
           set -e
@@ -244,6 +297,9 @@ jobs:
           echo ""
           echo "--- fontconfig version ---"
           fc-cache --version 2>&1 | head -1
+          echo ""
+          echo "--- active libexpat1 version ---"
+          dpkg-query -W -f='${Version}\n' libexpat1 2>/dev/null || true
         continue-on-error: true
 
       - name: Transpile client and extensions

--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -144,24 +144,15 @@ jobs:
             exit 0
           fi
           echo "Installed expat: $EXPAT_VER — applying fontconfig workaround"
-          # Workaround: use a minimal fontconfig config with no <include> directives
-          # AND no <!DOCTYPE ... SYSTEM ...> external DTD reference, avoiding every
-          # expat external-entity codepath. Based on upstream fontconfig 2.15.0
-          # fonts.conf.in with <include> removed, generic family aliases inlined, and
-          # default font mappings for generic families added (from conf.d/49-sansserif.conf
-          # and DejaVu font configs).
-          #
-          # The DOCTYPE line is intentionally omitted: fontconfig feeds the referenced
-          # external DTD ("urn:fontconfig:fonts.dtd") to expat as an external PARAMETER
-          # entity, which still triggers the not-yet-backported NULL-deref CVEs
-          # (CVE-2026-32776 / CVE-2026-32778) on expat 2.6.1 even when <include> is gone.
-          # This was observed as a SIGSEGV inside libexpat (called from libfontconfig)
-          # during Chromium browser-process font init, crashing Electron at startup.
-          # fontconfig does not require the DOCTYPE, so dropping it removes the last
-          # external-entity path. Remove the whole workaround once Ubuntu backports the
-          # remaining CVE fixes (expat >= 2.7.5).
+          # Workaround: use a minimal fontconfig config with no <include> directives,
+          # avoiding the external entity parser codepath entirely. Based on upstream
+          # fontconfig 2.15.0 fonts.conf.in with <include> removed, generic family
+          # aliases inlined, and default font mappings for generic families added
+          # (from conf.d/49-sansserif.conf and DejaVu font configs).
+          # Remove once Ubuntu backports the remaining CVE fixes.
           cat > /tmp/fonts-minimal.conf << 'FONTCONFIG_EOF'
           <?xml version="1.0"?>
+          <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
           <fontconfig>
             <dir>/usr/share/fonts</dir>
             <dir>/usr/local/share/fonts</dir>


### PR DESCRIPTION
Supersedes the from-source build idea — installs a prebuilt official Ubuntu `.deb`, fetched from the **Azure Ubuntu mirror the runner already uses**. Also includes the revert of #322909 (so it works whether or not the standalone revert #322994 lands first).

## Root cause (confirmed)

Intermittent Linux `Electron-Smoke` failures are a **SIGSEGV in `libexpat` during fontconfig parsing at Electron startup**, before any window appears. Frame-pointer (RBP) backtrace from a CI crash dump (run 28188049700):

```
#0  libc.so.6        (NULL deref, fault addr 0x0)
#1-3 libexpat.so.1   (XML_ParseBuffer ...)
#4-9 libfontconfig.so.1  (FcInit / config parse)
#10 libpangoft2-1.0.so.0
#11 libglib-2.0.so.0  (worker thread)
#12 libc.so.6        (thread start)
```

Ubuntu 24.04 (noble) ships **libexpat1 2.6.1**; the relevant parser NULL-deref fixes are only in **expat ≥ 2.7.5**, which noble hasn't packaged. Earlier fontconfig-config tweaks only perturbed timing (removing the `<!DOCTYPE>` in #322909 actually *doubled* the crash rate, ~8% → ~19% — reverted here).

## Fix

Install the official prebuilt **`libexpat1` 2.8.1 `.deb`** onto the noble runner:

- Fetched from the **Azure Ubuntu mirror the runner already uses** (`azure.archive.ubuntu.com`, in-datacenter), falling back to the canonical Ubuntu archive and then Launchpad's permanent store. All three serve the **byte-identical** official build; we **pin the sha256**.
- That package `Pre-Depends: libc6 (>= 2.38)` only, and noble has libc6 **2.39**, so `dpkg -i` installs it cleanly with no dependency conflict.
- It replaces the system `libexpat.so.1` (ABI-stable SONAME) for **every** process, including the Electron browser process where the crash happens — no `LD_PRELOAD` needed.
- The step **auto-skips** once the runner ships `libexpat1 >= 2.7.5` (so it self-removes when noble backports the fix).

The minimal fontconfig config (DOCTYPE restored via the revert) is kept as secondary stabilization.

## Why not plain `apt install libexpat1` / why this source

- noble's apt pocket only carries **2.6.1**; the fix lives in newer releases (questing 2.7.1, resolute 2.7.4, stonking 2.8.1).
- `packages.microsoft.com` and `dl.google.com` (the runner's other apt origins) don't carry `libexpat1`.
- The Azure mirror is a full mirror of the Ubuntu archive, so its **pool** hosts the newer-release deb too — byte-identical to Launchpad (verified). So this *is* "use the package manager's source", just pulling a build noble's own pocket doesn't carry yet.

## Validation

- Workflow YAML parses; no duplicate steps.
- Verified the 2.8.1 deb `Pre-Depends: libc6 (>= 2.38)` (installs on noble's 2.39).
- Verified the Azure mirror, the Ubuntu archive, and Launchpad all return the deb with the **same sha256**; simulated the download+verify loop end-to-end.
- Real proof is CI crash-rate; companion PR #322905 (fail-fast launch) surfaces any residual crash quickly instead of as a 120s opaque timeout.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
