### PR TITLE
smoke: retry Electron launch to survive intermittent fontconfig startup crash

### DIFF
--- a/test/automation/src/application.ts
+++ b/test/automation/src/application.ts
@@ -88,11 +88,33 @@ export class Application {
 	private async _start(workspaceOrFolder = this._workspacePathOrFolder, extraArgs: string[] = []): Promise<void> {
 		this._workspacePathOrFolder = workspaceOrFolder;
 
-		// Launch Code...
-		const code = await this.startApplication(extraArgs);
+		// The Electron process can intermittently crash during startup on Linux CI
+		// (a native SIGSEGV in the system fontconfig/pango font-initialization path,
+		// unrelated to VS Code, that fails the launch). This is a rare,
+		// nondeterministic startup race, so retry the launch a few times before
+		// giving up — a fresh relaunch almost always succeeds.
+		const maxAttempts = 3;
+		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+			try {
 
-		// ...and make sure the window is ready to interact
-		await measureAndLog(() => this.checkWindowReady(code), 'Application#checkWindowReady()', this.logger);
+				// Launch Code...
+				const code = await this.startApplication(extraArgs);
+
+				// ...and make sure the window is ready to interact
+				await measureAndLog(() => this.checkWindowReady(code), 'Application#checkWindowReady()', this.logger);
+
+				return;
+			} catch (error) {
+				this.logger.log(`Application#start(): attempt ${attempt} of ${maxAttempts} to launch the application failed: ${error}`);
+
+				// Tear down the crashed/half-started instance before retrying
+				await this.stop();
+
+				if (attempt === maxAttempts) {
+					throw error;
+				}
+			}
+		}
 	}
 
 	async stop(): Promise<void> {

--- a/test/automation/src/playwrightElectron.ts
+++ b/test/automation/src/playwrightElectron.ts
@@ -60,6 +60,9 @@ async function launchElectron(configuration: IElectronConfiguration, options: La
 		try {
 			window = await measureAndLog(() => electron.waitForEvent('window', { timeout: LAUNCH_TIMEOUT }), 'playwright-electron#firstWindow', logger);
 		} catch (error) {
+			// The process may still be alive (e.g. hung) but produced no window;
+			// close it so a retried launch does not leave a stray Electron behind.
+			await electron.close().catch(() => { /* best effort */ });
 			throw enrichLaunchError(error, options);
 		}
 	}

--- a/test/smoke/src/utils.ts
+++ b/test/smoke/src/utils.ts
@@ -88,6 +88,10 @@ export function suiteCrashPath(options: ApplicationOptions, suiteName: string): 
 
 function installAppBeforeHandler(optionsTransform?: (opts: ApplicationOptions) => ApplicationOptions) {
 	before(async function () {
+		// Allow enough time for the application launch to be retried a few times in
+		// case of an intermittent Electron startup crash (see Application#start()).
+		this.timeout(5 * 60 * 1000);
+
 		const suiteName = this.test?.parent?.title ?? 'unknown';
 
 		this.app = createApp({


### PR DESCRIPTION
## The expat upgrade did not work — here's why, and the fix that will

PR #323001 installed libexpat 2.8.1 and **it still crashed** ([run 28192795744](https://github.com/microsoft/vscode/actions/runs/28192795744/job/83511550358)). I pulled the new crash dumps and walked the frame-pointer (RBP) stack:

```
#0  libc.so.6 +0x48806          (NULL deref — identical in every dump)
#1  libexpat.so.1 +0x1d9f3      (2.8.1 — offsets CHANGED, so the new lib IS loaded)
#2  libexpat.so.1 +0xa107
#3-8 libfontconfig.so.1 +0x2f6c9 / +0x3022d / +0x30479 / +0x173cd / +0x121c1 / +0x176bd   (IDENTICAL to the 2.6.1 dumps)
#9  libpangoft2-1.0.so.0 +0xc225
#10 libglib-2.0.so.0 +0x8be62   (glib worker thread)
```

The expat offsets moved (proving 2.8.1 was actually loaded in the crashing process), but the crash is unchanged. **expat is exonerated.** The constant factors are **libfontconfig + libc + the pango worker-thread init** (`pango init_in_thread → FcInit`). fontconfig hands expat a bad/NULL pointer (or a race corrupts it) and *any* expat version faithfully derefs it. This is a **nondeterministic startup race in the system font stack**, not an application bug and not fixable by swapping expat. (It also explains the earlier "less XML made it worse" result — timing, not content.)

## Fix: retry the launch

The crash happens **at launch, before any window**, and is rare *per launch* (~0.8%). But a smoke run does ~25 launches, so it compounds into the ~8–19% *per-run* failure we've been seeing. Retrying the launch collapses that to near-zero with effectively zero overhead on the normal path (retries almost never trigger).

- `Application#start()`: retry launch + window-ready up to 3×, tearing down the crashed instance between attempts.
- `playwrightElectron`: close the Electron app if it produced no window, so a retried launch doesn't leak a stray process.
- smoke `installAppBeforeHandler`: widen the before-hook timeout to accommodate retries.

This pairs with the already-merged fail-fast launch error (#322905): a crashed launch now fails in ~60s instead of hanging to the 120s hook timeout, which is what makes the retries affordable.

## Why retry instead of "fix the crash"

The fault is in **system libraries** (fontconfig/pango/glib) during Electron startup on the CI image — an environment/infra flake, not VS Code code. Retrying a known-infra-flaky startup is standard practice and idiomatic here (the harness already retries the Electron download, app exit, etc.). The underlying fontconfig/pango race can be chased separately (e.g. a newer libfontconfig), but retry makes CI green regardless of root cause.

## Supersedes / related
- #322905 (merged) — fail-fast on launch crash.
- #322994 — revert of the DOCTYPE change that regressed crash rate (keep).
- #323001 — expat 2.8.1 install: **does not fix the crash**, recommend closing.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
