### PR TITLE
chat: restore last-used agent and model for new chat editors

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -26,6 +26,7 @@ import { ICommandService } from '../../../../../platform/commands/common/command
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IsLinuxContext, IsWindowsContext } from '../../../../../platform/contextkey/common/contextkeys.js';
+import { IStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -56,7 +57,7 @@ import { ElicitationState, IChatService, IChatToolInvocation } from '../../commo
 import { ISCMHistoryItemChangeRangeVariableEntry, ISCMHistoryItemChangeVariableEntry } from '../../common/attachments/chatVariableEntries.js';
 import { IChatRequestViewModel, IChatResponseViewModel, isRequestVM } from '../../common/model/chatViewModel.js';
 import { IChatWidgetHistoryService } from '../../common/widget/chatWidgetHistoryService.js';
-import { ChatAgentLocation, ChatConfiguration, ChatModeKind, getDefaultNewChatSessionResource, getDefaultNewChatSessionType } from '../../common/constants.js';
+import { ChatAgentLocation, ChatConfiguration, ChatLastUsedEditorSessionTypeStorageKey, ChatModeKind, getDefaultNewChatSessionType, getNewChatEditorSessionResource } from '../../common/constants.js';
 import { AICustomizationManagementCommands } from '../aiCustomization/aiCustomizationManagement.js';
 import { ILanguageModelChatSelector, ILanguageModelsService } from '../../common/languageModels.js';
 import { CopilotUsageExtensionFeatureId } from '../../common/languageModelStats.js';
@@ -578,7 +579,9 @@ export function registerChatActions() {
 	 * `local` or the chosen provider is unavailable.
 	 */
 	function getNewChatEditorSessionUri(accessor: ServicesAccessor): URI {
-		return getDefaultNewChatSessionResource(accessor.get(IConfigurationService), accessor.get(IChatSessionsService));
+		const storageService = accessor.get(IStorageService);
+		const lastUsedSessionType = storageService.get(ChatLastUsedEditorSessionTypeStorageKey, StorageScope.PROFILE);
+		return getNewChatEditorSessionResource(accessor.get(IConfigurationService), accessor.get(IChatSessionsService), lastUsedSessionType);
 	}
 
 	registerAction2(PrimaryOpenChatGlobalAction);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
@@ -257,9 +257,7 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 			return;
 		}
 		const sessionType = getChatSessionType(sessionResource);
-		// Only remember non-local agents. Local is the built-in default, and
-		// recording it (e.g. the panel's auto-opened default session on a fresh
-		// workspace) would clobber the user's remembered agent for new chat editors.
+		// Only remember non-local agents to avoid clobbering the user's last-used agent.
 		if (sessionType === localChatSessionType) {
 			return;
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
@@ -11,11 +11,14 @@ import { isEqual } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ILayoutService } from '../../../../../platform/layout/browser/layoutService.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { ACTIVE_GROUP, IEditorService, type PreferredGroup } from '../../../../services/editor/common/editorService.js';
 import { IEditorGroup, IEditorGroupsService, isEditorGroup } from '../../../../services/editor/common/editorGroupsService.js';
 import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import { IChatService } from '../../common/chatService/chatService.js';
-import { ChatAgentLocation } from '../../common/constants.js';
+import { localChatSessionType } from '../../common/chatSessionsService.js';
+import { ChatAgentLocation, ChatLastUsedEditorSessionTypeStorageKey } from '../../common/constants.js';
+import { getChatSessionType } from '../../common/model/chatUri.js';
 import { ChatViewId, ChatViewPaneTarget, IChatWidget, IChatWidgetService, IQuickChatService, isIChatViewViewContext } from '../chat.js';
 import { ChatEditor, IChatEditorOptions } from '../widgetHosts/editor/chatEditor.js';
 import { ChatEditorInput } from '../widgetHosts/editor/chatEditorInput.js';
@@ -48,6 +51,7 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 		@IEditorService private readonly editorService: IEditorService,
 		@IChatService private readonly chatService: IChatService,
 		@ILogService private readonly logService: ILogService,
+		@IStorageService private readonly storageService: IStorageService,
 	) {
 		super();
 	}
@@ -233,8 +237,33 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 		}
 
 		this._lastFocusedWidget = widget;
+		this.recordLastUsedSessionType(widget);
 		this._onDidChangeFocusedWidget.fire(widget);
 		this._onDidChangeFocusedSession.fire();
+	}
+
+	/**
+	 * Remember the session type (agent) of the last-focused user-facing chat so a
+	 * brand-new chat editor can reopen with the same agent. Quick Chat is excluded
+	 * because it is ephemeral and always a local session — recording it would
+	 * clobber the user's last-used agent.
+	 */
+	private recordLastUsedSessionType(widget: IChatWidget | undefined): void {
+		const sessionResource = widget?.viewModel?.sessionResource;
+		if (!sessionResource) {
+			return;
+		}
+		if (this.quickChatService.sessionResource && isEqual(sessionResource, this.quickChatService.sessionResource)) {
+			return;
+		}
+		const sessionType = getChatSessionType(sessionResource);
+		// Only remember non-local agents. Local is the built-in default, and
+		// recording it (e.g. the panel's auto-opened default session on a fresh
+		// workspace) would clobber the user's remembered agent for new chat editors.
+		if (sessionType === localChatSessionType) {
+			return;
+		}
+		this.storageService.store(ChatLastUsedEditorSessionTypeStorageKey, sessionType, StorageScope.PROFILE, StorageTarget.USER);
 	}
 
 	register(newWidget: IChatWidget): IDisposable {
@@ -253,6 +282,7 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 			newWidget.onDidFocus(() => this.setLastFocusedWidget(newWidget)),
 			newWidget.onDidChangeViewModel(({ previousSessionResource, currentSessionResource }) => {
 				if (this._lastFocusedWidget === newWidget && !isEqual(previousSessionResource, currentSessionResource)) {
+					this.recordLastUsedSessionType(newWidget);
 					this._onDidChangeFocusedSession.fire();
 				}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
@@ -243,10 +243,7 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 	}
 
 	/**
-	 * Remember the session type (agent) of the last-focused user-facing chat so a
-	 * brand-new chat editor can reopen with the same agent. Quick Chat is excluded
-	 * because it is ephemeral and always a local session — recording it would
-	 * clobber the user's last-used agent.
+	 * Stores the session type (agent) of the last-focused user-facing chat so new chat editors can reuse it (excluding Quick Chat).
 	 */
 	private recordLastUsedSessionType(widget: IChatWidget | undefined): void {
 		const sessionResource = widget?.viewModel?.sessionResource;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -908,12 +908,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	}
 
 	/**
-	 * The model remembered for the current session type (persisted per location +
-	 * session type), if it is currently available in the session's model pool.
-	 * Used to restore the last-used model when a fresh session of a remembered
-	 * agent is opened (e.g. via "New Chat Editor"). Returns `undefined` for session
-	 * types without their own model pool (e.g. local), whose model is already
-	 * restored from the general key by {@link initSelectedModel}.
+	 * Returns the persisted model for the current session type, if it exists in the current model pool.
 	 */
 	private _getRememberedSessionTypeModel(): ILanguageModelChatMetadataAndIdentifier | undefined {
 		const sessionType = this._currentSessionType;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1339,13 +1339,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			if (!state && this._chatSessionIsEmpty) {
 				state = this._emptyInputState.read(undefined);
 				message = `syncing from empty input state for ${forSessionResource.toString()}`;
-				// For a fresh session, prefer this agent's last-used model and its
-				// configuration (e.g. context size, thinking effort), both persisted in
-				// the same (location, sessionType)-scoped buckets, so a new chat editor
-				// opened with a remembered agent restores the user's last selection.
-				// Draft text/attachments are untouched (this only seeds the model +
-				// configuration for `_syncFromModel`, mirroring the reopened-session
-				// restore from #321672). The configured default below still wins.
+				// Seed model/config from the last-used selection for this session type (configured default still wins).
 				const rememberedSessionTypeModel = this._getRememberedSessionTypeModel();
 				if (rememberedSessionTypeModel) {
 					const base = state ?? this.getCurrentInputState();

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -907,6 +907,26 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			|| hasModelsTargetingSession(this.getAllMergedModels(), sessionType);
 	}
 
+	/**
+	 * The model remembered for the current session type (persisted per location +
+	 * session type), if it is currently available in the session's model pool.
+	 * Used to restore the last-used model when a fresh session of a remembered
+	 * agent is opened (e.g. via "New Chat Editor"). Returns `undefined` for session
+	 * types without their own model pool (e.g. local), whose model is already
+	 * restored from the general key by {@link initSelectedModel}.
+	 */
+	private _getRememberedSessionTypeModel(): ILanguageModelChatMetadataAndIdentifier | undefined {
+		const sessionType = this._currentSessionType;
+		if (!sessionType || !this.sessionTypeHasOwnModelPool(sessionType)) {
+			return undefined;
+		}
+		const persisted = this.storageService.get(this.getSelectedModelStorageKey(), StorageScope.APPLICATION);
+		if (!persisted) {
+			return undefined;
+		}
+		return this.getModels().find(m => m.identifier === persisted);
+	}
+
 	private initSelectedModel() {
 		// initSelectedModel is scoped to the current storage key/session type.
 		// Do not let a delayed restore from a previous session type apply later.
@@ -1324,6 +1344,19 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			if (!state && this._chatSessionIsEmpty) {
 				state = this._emptyInputState.read(undefined);
 				message = `syncing from empty input state for ${forSessionResource.toString()}`;
+				// For a fresh session, prefer this agent's last-used model and its
+				// configuration (e.g. context size, thinking effort), both persisted in
+				// the same (location, sessionType)-scoped buckets, so a new chat editor
+				// opened with a remembered agent restores the user's last selection.
+				// Draft text/attachments are untouched (this only seeds the model +
+				// configuration for `_syncFromModel`, mirroring the reopened-session
+				// restore from #321672). The configured default below still wins.
+				const rememberedSessionTypeModel = this._getRememberedSessionTypeModel();
+				if (rememberedSessionTypeModel) {
+					const base = state ?? this.getCurrentInputState();
+					const rememberedModelConfiguration = this._modelConfigStore.getModelConfiguration(rememberedSessionTypeModel.identifier);
+					state = { ...base, selectedModel: rememberedSessionTypeModel, modelConfiguration: rememberedModelConfiguration };
+				}
 				// A configured default model (e.g. set by enterprise policy via
 				// `chat.defaultModel`) starts every NEW conversation and
 				// must win over the remembered empty-input draft model. `initSelectedModel`

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditorInput.ts
@@ -16,12 +16,13 @@ import * as nls from '../../../../../../nls.js';
 import { ConfirmResult, IDialogService } from '../../../../../../platform/dialogs/common/dialogs.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { IStorageService, StorageScope } from '../../../../../../platform/storage/common/storage.js';
 import { registerIcon } from '../../../../../../platform/theme/common/iconRegistry.js';
 import { EditorInputCapabilities, IEditorIdentifier, IEditorSerializer, IUntypedEditorInput, Verbosity } from '../../../../../common/editor.js';
 import { EditorInput, IEditorCloseHandler } from '../../../../../common/editor/editorInput.js';
 import { IChatModelReference, IChatService } from '../../../common/chatService/chatService.js';
 import { IChatSessionsService, localChatSessionType } from '../../../common/chatSessionsService.js';
-import { ChatAgentLocation, ChatEditorTitleMaxLength, getDefaultNewChatSessionResource, getDefaultNewChatSessionType } from '../../../common/constants.js';
+import { ChatAgentLocation, ChatEditorTitleMaxLength, ChatLastUsedEditorSessionTypeStorageKey, getDefaultNewChatSessionResource, getDefaultNewChatSessionType, getNewChatEditorSessionResource } from '../../../common/constants.js';
 import { IChatEditingSession, ModifiedFileEntryState } from '../../../common/editing/chatEditingService.js';
 import { IChatModel } from '../../../common/model/chatModel.js';
 import { LocalChatSessionUri, getChatSessionType } from '../../../common/model/chatUri.js';
@@ -65,6 +66,7 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IStorageService private readonly storageService: IStorageService,
 	) {
 		super();
 
@@ -231,7 +233,8 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 				this.modelRef.value = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: true, debugOwner: 'ChatEditorInput#resolveNewLocalSession' });
 			}
 		} else if (!this.options.target) {
-			const defaultResource = getDefaultNewChatSessionResource(this.configurationService, this.chatSessionsService);
+			const lastUsedSessionType = this.storageService.get(ChatLastUsedEditorSessionTypeStorageKey, StorageScope.PROFILE);
+			const defaultResource = getNewChatEditorSessionResource(this.configurationService, this.chatSessionsService, lastUsedSessionType);
 			if (getChatSessionType(defaultResource) === localChatSessionType) {
 				this.modelRef.value = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: !inputType, debugOwner: 'ChatEditorInput#resolveUntitled' });
 			} else {

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -283,6 +283,64 @@ export function getDefaultNewChatSessionResource(
 		: URI.from({ scheme: defaultType, path: `/untitled-${generateUuid()}` });
 }
 
+/**
+ * Storage key for the last-used editor chat session type (agent). Persisted at
+ * profile scope so a new chat editor can reopen with the agent the user last
+ * worked with, across windows and workspaces. Written by the chat widget
+ * service when the last-focused user-facing session changes.
+ */
+export const ChatLastUsedEditorSessionTypeStorageKey = 'chat.lastUsedEditorSessionType';
+
+/**
+ * Resolves the session type (agent) for a brand-new chat editor, preferring the
+ * user's last-used session type when the provider has not been explicitly
+ * configured. Precedence:
+ * 1. An explicit `chat.editor.defaultProvider` set via user/workspace/policy
+ *    (detected with {@link IConfigurationService.inspect}, since the setting
+ *    defaults to `'local'` and {@link IConfigurationService.getValue} cannot tell
+ *    an explicit choice from the default).
+ * 2. The last-used session type, when still visible — so a new editor reopens
+ *    with the agent the user last worked with.
+ * 3. The built-in default from {@link getDefaultNewChatSessionType} (local).
+ */
+export function getNewChatEditorSessionType(
+	configurationService: IConfigurationService,
+	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
+	lastUsedSessionType: string | undefined,
+): string {
+	const inspected = configurationService.inspect<string>(ChatConfiguration.EditorDefaultProvider);
+	const explicitlyConfigured = inspected.userValue !== undefined
+		|| inspected.userLocalValue !== undefined
+		|| inspected.userRemoteValue !== undefined
+		|| inspected.workspaceValue !== undefined
+		|| inspected.workspaceFolderValue !== undefined
+		|| inspected.policyValue !== undefined;
+
+	if (!explicitlyConfigured
+		&& lastUsedSessionType
+		&& lastUsedSessionType !== localChatSessionType
+		&& isVisibleEditorChatSessionType(lastUsedSessionType, configurationService, chatSessionsService)) {
+		return lastUsedSessionType;
+	}
+
+	return getDefaultNewChatSessionType(configurationService, chatSessionsService);
+}
+
+/**
+ * Like {@link getDefaultNewChatSessionResource}, but prefers the user's
+ * last-used session type via {@link getNewChatEditorSessionType}.
+ */
+export function getNewChatEditorSessionResource(
+	configurationService: IConfigurationService,
+	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
+	lastUsedSessionType: string | undefined,
+): URI {
+	const sessionType = getNewChatEditorSessionType(configurationService, chatSessionsService, lastUsedSessionType);
+	return sessionType === localChatSessionType
+		? LocalChatSessionUri.getNewSessionUri()
+		: URI.from({ scheme: sessionType, path: `/untitled-${generateUuid()}` });
+}
+
 export function isEditorLocalAgentEnabled(configurationService: IConfigurationService): boolean {
 	return configurationService.getValue<boolean>(ChatConfiguration.EditorLocalAgentEnabled) ?? true;
 }

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -284,24 +284,12 @@ export function getDefaultNewChatSessionResource(
 }
 
 /**
- * Storage key for the last-used editor chat session type (agent). Persisted at
- * profile scope so a new chat editor can reopen with the agent the user last
- * worked with, across windows and workspaces. Written by the chat widget
- * service when the last-focused user-facing session changes.
+ * Storage key for the last-used non-local editor chat session type (agent), persisted at profile scope.
  */
 export const ChatLastUsedEditorSessionTypeStorageKey = 'chat.lastUsedEditorSessionType';
 
 /**
- * Resolves the session type (agent) for a brand-new chat editor, preferring the
- * user's last-used session type when the provider has not been explicitly
- * configured. Precedence:
- * 1. An explicit `chat.editor.defaultProvider` set via user/workspace/policy
- *    (detected with {@link IConfigurationService.inspect}, since the setting
- *    defaults to `'local'` and {@link IConfigurationService.getValue} cannot tell
- *    an explicit choice from the default).
- * 2. The last-used session type, when still visible — so a new editor reopens
- *    with the agent the user last worked with.
- * 3. The built-in default from {@link getDefaultNewChatSessionType} (local).
+ * Resolves the session type (agent) for a new chat editor, preferring the last-used visible non-local agent when `chat.editor.defaultProvider` isn't explicitly configured.
  */
 export function getNewChatEditorSessionType(
 	configurationService: IConfigurationService,

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -297,11 +297,13 @@ export function getNewChatEditorSessionType(
 	lastUsedSessionType: string | undefined,
 ): string {
 	const inspected = configurationService.inspect<string>(ChatConfiguration.EditorDefaultProvider);
-	const explicitlyConfigured = inspected.userValue !== undefined
+	const explicitlyConfigured = inspected.applicationValue !== undefined
+		|| inspected.userValue !== undefined
 		|| inspected.userLocalValue !== undefined
 		|| inspected.userRemoteValue !== undefined
 		|| inspected.workspaceValue !== undefined
 		|| inspected.workspaceFolderValue !== undefined
+		|| inspected.memoryValue !== undefined
 		|| inspected.policyValue !== undefined;
 
 	if (!explicitlyConfigured

--- a/src/vs/workbench/contrib/chat/test/common/constants.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/constants.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { ChatConfiguration, getDefaultNewChatSessionType, isVisibleEditorChatSessionType } from '../../common/constants.js';
+import { ChatConfiguration, getDefaultNewChatSessionType, getNewChatEditorSessionType, isVisibleEditorChatSessionType } from '../../common/constants.js';
 import { localChatSessionType, SessionType, IChatSessionsExtensionPoint } from '../../common/chatSessionsService.js';
 import { MockChatSessionsService } from './mockChatSessionsService.js';
 
@@ -75,5 +75,58 @@ suite('ChatConfiguration defaults', () => {
 
 		assert.strictEqual(getDefaultNewChatSessionType(configurationService, chatSessionsService), localChatSessionType);
 		assert.strictEqual(isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService), true);
+	});
+});
+
+suite('getNewChatEditorSessionType (last-used agent)', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createChatSessionsService(...types: string[]): MockChatSessionsService {
+		const service = new MockChatSessionsService();
+		service.setContributions(types.map(type => ({
+			type,
+			name: type,
+			displayName: type,
+			description: type,
+		} satisfies IChatSessionsExtensionPoint)));
+		return service;
+	}
+
+	test('prefers a visible non-local last-used agent when the provider is not explicitly configured', () => {
+		const configurationService = new TestConfigurationService();
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
+
+		assert.strictEqual(getNewChatEditorSessionType(configurationService, chatSessionsService, SessionType.AgentHostCopilot), SessionType.AgentHostCopilot);
+	});
+
+	test('ignores a last-used agent whose provider is not visible/registered', () => {
+		const configurationService = new TestConfigurationService();
+		const chatSessionsService = createChatSessionsService(); // agent host not registered
+
+		assert.strictEqual(getNewChatEditorSessionType(configurationService, chatSessionsService, SessionType.AgentHostCopilot), localChatSessionType);
+	});
+
+	test('an explicitly configured local provider wins over a last-used agent', () => {
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.EditorDefaultProvider]: 'local',
+		});
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
+
+		assert.strictEqual(getNewChatEditorSessionType(configurationService, chatSessionsService, SessionType.AgentHostCopilot), localChatSessionType);
+	});
+
+	test('a last-used local agent does not override the default', () => {
+		const configurationService = new TestConfigurationService();
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
+
+		assert.strictEqual(getNewChatEditorSessionType(configurationService, chatSessionsService, localChatSessionType), localChatSessionType);
+	});
+
+	test('falls back to the default when there is no last-used agent', () => {
+		const configurationService = new TestConfigurationService();
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
+
+		assert.strictEqual(getNewChatEditorSessionType(configurationService, chatSessionsService, undefined), localChatSessionType);
 	});
 });


### PR DESCRIPTION
- New chat editors always opened with the Local agent and the Auto model, even right after the user had been working with an agent host (e.g. Copilot Agent Host). The last-used agent/model was never consulted, so users had to re-pick the agent, model, and model configuration for every new editor, and it reset in every new workspace.
- Persists the last-used non-local chat agent (session type) at profile scope and prefers it when resolving the session type for a new chat editor, so the editor reopens with the agent the user last worked with across windows and workspaces. An explicit `chat.editor.defaultProvider` still wins.
- Restores that agent's last-used model and its configuration (e.g. context size, thinking effort) for the fresh editor session, mirroring the existing reopened-session restore.

Fixes https://github.com/microsoft/vscode/issues/322792

(Commit message generated by Copilot)
