### PR TITLE
ci: pre-initialize fontconfig to fix Pango threaded-FcInit crash in smoke tests

### DIFF
--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -218,6 +218,48 @@ jobs:
           FONTCONFIG_EOF
           echo "FONTCONFIG_FILE=/tmp/fonts-minimal.conf" >> "$GITHUB_ENV"
 
+      # Root-cause fix for the intermittent Electron startup SIGSEGV on Linux CI.
+      # Symbolizing the crash dumps shows the fault is a Pango concurrency bug, not
+      # a VS Code bug:
+      #
+      #   pango: fc_thread_func -> init_in_thread -> FcInit()       (pangofc-fontmap.c)
+      #   fontconfig: FcInit -> FcConfigParseAndLoadFromMemory -> _FcConfigParse
+      #   libexpat: XML_ParseBuffer -> libc (NULL deref, SIGSEGV)
+      #
+      # Pango >= 1.52's pango_fc_font_map_init() unconditionally spawns a
+      # "[pango] fontconfig" thread that runs FcInit(). That races against the
+      # Electron/Chromium main thread's own fontconfig use during startup and
+      # corrupts fontconfig's global config while it is being parsed. There is no
+      # env var to disable the Pango thread, and it is still present in Pango 1.56.
+      #
+      # Eliminate the race by initializing fontconfig once, single-threaded, from
+      # an ELF constructor that runs before main() (and therefore before any thread
+      # exists). Pango's later threaded FcInit() then finds fontconfig already
+      # initialized and returns immediately, so the concurrent parse never happens.
+      - name: Pre-initialize fontconfig to avoid Pango threaded FcInit crash
+        run: |
+          set -euo pipefail
+          cat > "$RUNNER_TEMP/fcpreinit.c" <<'CEOF'
+          #define _GNU_SOURCE
+          #include <dlfcn.h>
+
+          __attribute__((constructor))
+          static void preinit_fontconfig(void)
+          {
+            void *handle = dlopen("libfontconfig.so.1", RTLD_NOW | RTLD_GLOBAL);
+            if (handle) {
+              int (*fc_init)(void) = (int (*)(void)) dlsym(handle, "FcInit");
+              if (fc_init) {
+                fc_init();
+              }
+            }
+          }
+          CEOF
+          gcc -shared -fPIC -O2 -o "$RUNNER_TEMP/libfcpreinit.so" "$RUNNER_TEMP/fcpreinit.c" -ldl
+          echo "Built fontconfig pre-init shim at $RUNNER_TEMP/libfcpreinit.so"
+          # Preload it for every subsequent step that launches Electron/Chromium.
+          echo "LD_PRELOAD=$RUNNER_TEMP/libfcpreinit.so${LD_PRELOAD:+:$LD_PRELOAD}" >> "$GITHUB_ENV"
+
       - name: Fontconfig diagnostics and cache reset
         run: |
           set -e
@@ -253,6 +295,12 @@ jobs:
           echo ""
           echo "--- fontconfig version ---"
           fc-cache --version 2>&1 | head -1
+          echo ""
+          echo "--- fontconfig pre-init shim (LD_PRELOAD) ---"
+          echo "LD_PRELOAD=${LD_PRELOAD:-<unset>}"
+          if [ -n "${LD_PRELOAD:-}" ]; then
+            ls -l "${LD_PRELOAD%%:*}" 2>/dev/null || true
+          fi
         continue-on-error: true
 
       - name: Transpile client and extensions


### PR DESCRIPTION
## The real root cause (symbolized, with corroborating upstream reports)

The intermittent Linux `Electron-Smoke` SIGSEGV is an **upstream Pango concurrency bug**, not a VS Code bug. I pulled the crash dumps, downloaded the matching Ubuntu debug symbols, and resolved the exact frames:

```
pango:      fc_thread_func -> init_in_thread -> FcInit()        (pangofc-fontmap.c)
fontconfig: FcInit -> FcConfigParseAndLoadFromMemory -> _FcConfigParse
libexpat:   XML_ParseBuffer -> libc   (NULL deref, signal 11)
```

Pango ≥ 1.52's `pango_fc_font_map_init()` **unconditionally** spawns a `[pango] fontconfig` thread that runs `FcInit()`. That races with the Electron/Chromium main thread's own fontconfig use during startup and corrupts fontconfig's global config mid-parse. There's no env var to disable it (still present in Pango 1.56).

This is a known-bad area upstream:
- [pango#784](https://gitlab.gnome.org/GNOME/pango/-/issues/784) — *"single fontconfig thread introduces a hang … the use of `strace` makes the problem disappear. So this seems to be due to a race condition."*
- [pango#872](https://gitlab.gnome.org/GNOME/pango/-/issues/872) — the thread is an unwaited daemon, *"causing memory leaks and likely incorrect behavior."*

### Why it shows up in our CI and not "all over the internet"

It's a microsecond-wide race in *first-time* `FcInit`. To hit it you need a cold process, two threads reaching first-time `FcInit()` at the same instant, and a slow machine. Desktop apps have warm fontconfig state, fast cores, and launch once — they never land in the window. Our smoke job is a near-perfect trigger: fresh contended 4‑vCPU runners, a **wiped fontconfig cache + custom `FONTCONFIG_FILE`** (so `FcInit` re-parses cold and slow = wider window), and **~25 cold Electron starts per run**. That turns "never" into ~1%/launch, which compounds to the 8–19% per-run failure.

This also resolves the two facts that broke earlier theories: the **expat version was irrelevant** (it's the *concurrent parse*, not the parser — installing 2.8.1 still crashed identically), and **dropping the config DOCTYPE made it worse** (pure timing, not content).

## The fix

Initialize fontconfig **once, single-threaded, from an ELF constructor that runs before `main()`** (and therefore before any thread exists), via a tiny `LD_PRELOAD` shim:

```c
__attribute__((constructor))
static void preinit_fontconfig(void) {
  void *h = dlopen("libfontconfig.so.1", RTLD_NOW | RTLD_GLOBAL);
  if (h) { int (*fc_init)(void) = dlsym(h, "FcInit"); if (fc_init) fc_init(); }
}
```

Pango's later threaded `FcInit()` then finds fontconfig already initialized and returns immediately — the concurrent parse never happens, so the race is eliminated. It's ~12 lines, needs only `gcc` + `-ldl` (both present), and auto-applies to every Electron/Chromium launch in the job.

## Validation
- Workflow YAML parses; the embedded shim compiles cleanly (`-Wall -Wextra`).
- Diagnostics print `LD_PRELOAD` so the preload is verifiable from CI logs.
- The true proof is the post-merge crash rate — but unlike the earlier attempts, this fix targets the exact symbolized crashing function and is corroborated by upstream bug reports.

## Supersedes
- #322905 (merged) — fail-fast on launch crash (kept; orthogonal).
- #323001 (closed) — expat 2.8.1 install; proven ineffective (same crash).
- #323007 — launch *retry*; this PR is the real fix, so the retry can be closed (or kept as a belt-and-suspenders safety net — your call).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
