### PR TITLE
Fix BYOK token and context-window limits

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -1826,6 +1826,12 @@
               "secret": true,
               "description": "API key for OpenAI",
               "title": "API Key"
+            },
+            "zeroDataRetentionEnabled": {
+              "type": "boolean",
+              "default": false,
+              "title": "Zero Data Retention",
+              "markdownDescription": "Set this to `true` if your OpenAI organization enforces Zero Data Retention (ZDR). When enabled, requests sent via the Responses API disable server-side storage (`store: false`) and never send `previous_response_id`, which a ZDR organization rejects. Applies to all models in this group."
             }
           },
           "required": [

--- a/extensions/copilot/src/extension/byok/vscode-node/openAIProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/openAIProvider.ts
@@ -3,16 +3,46 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { IConfigurationService } from '../../../platform/configuration/common/configurationService';
-import { IChatModelInformation, ModelSupportedEndpoint } from '../../../platform/endpoint/common/endpointProvider';
+import { EndpointEditToolName, IChatModelInformation, ModelSupportedEndpoint } from '../../../platform/endpoint/common/endpointProvider';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IFetcherService } from '../../../platform/networking/common/fetcherService';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
-import { BYOKKnownModels } from '../common/byokProvider';
-import { AbstractOpenAICompatibleLMProvider } from './abstractLanguageModelChatProvider';
+import { BYOKKnownModels, resolveModelInfo } from '../common/byokProvider';
+import { OpenAIEndpoint } from '../node/openAIEndpoint';
+import { AbstractOpenAICompatibleLMProvider, LanguageModelChatConfiguration, OpenAICompatibleLanguageModelChatInformation } from './abstractLanguageModelChatProvider';
+import { byokKnownModelToAPIInfoWithEffort } from './byokModelInfo';
 import { IBYOKStorageService } from './byokStorageService';
 
-export class OAIBYOKLMProvider extends AbstractOpenAICompatibleLMProvider {
+type OpenAIApiType = 'chat-completions' | 'responses';
+
+interface _OpenAIModelConfig {
+	name: string;
+	url?: string;
+	apiType?: OpenAIApiType;
+	maxInputTokens: number;
+	maxOutputTokens: number;
+	toolCalling: boolean;
+	vision: boolean;
+	thinking?: boolean;
+	streaming?: boolean;
+	editTools?: EndpointEditToolName[];
+	requestHeaders?: Record<string, string>;
+	zeroDataRetentionEnabled?: boolean;
+	supportsReasoningEffort?: string[];
+	reasoningEffortFormat?: 'chat-completions' | 'responses';
+}
+
+export interface OpenAIModelConfig extends _OpenAIModelConfig {
+	id: string;
+}
+
+export interface OpenAIModelProviderConfig extends LanguageModelChatConfiguration {
+	url?: string;
+	models?: OpenAIModelConfig[];
+}
+
+export class OAIBYOKLMProvider extends AbstractOpenAICompatibleLMProvider<OpenAIModelProviderConfig> {
 
 	public static readonly providerName = 'OpenAI';
 	public static readonly providerId = this.providerName.toLowerCase();
@@ -43,6 +73,48 @@ export class OAIBYOKLMProvider extends AbstractOpenAICompatibleLMProvider {
 		return 'https://api.openai.com/v1';
 	}
 
+	protected override async getAllModels(silent: boolean, apiKey: string | undefined, configuration: OpenAIModelProviderConfig | undefined): Promise<OpenAICompatibleLanguageModelChatInformation<OpenAIModelProviderConfig>[]> {
+		// When the user explicitly configures models (e.g. through `chatLanguageModels.json`), honor
+		// those per-model capabilities instead of discovering models and substituting built-in
+		// metadata. Otherwise configured `maxInputTokens`/`maxOutputTokens` are silently ignored.
+		// See issue #322216.
+		if (Array.isArray(configuration?.models) && configuration.models.length > 0) {
+			return configuration.models.map(modelConfig => ({
+				...byokKnownModelToAPIInfoWithEffort(this._name, modelConfig.id, modelConfig),
+				url: modelConfig.url ?? this.getModelsBaseUrl()
+			}));
+		}
+		return super.getAllModels(silent, apiKey, configuration);
+	}
+
+	protected override async createOpenAIEndPoint(model: OpenAICompatibleLanguageModelChatInformation<OpenAIModelProviderConfig>): Promise<OpenAIEndpoint> {
+		const modelConfiguration = model.configuration?.models?.find(m => m.id === model.id);
+		if (modelConfiguration) {
+			const apiType: OpenAIApiType = modelConfiguration.apiType ?? (model.url.includes('/responses') ? 'responses' : 'chat-completions');
+			const url = resolveOpenAIUrl(model.url, apiType);
+			const modelCapabilities = {
+				maxInputTokens: model.maxInputTokens,
+				maxOutputTokens: model.maxOutputTokens,
+				toolCalling: !!model.capabilities?.toolCalling || false,
+				vision: !!model.capabilities?.imageInput || false,
+				name: model.name,
+				url,
+				thinking: modelConfiguration.thinking ?? false,
+				streaming: modelConfiguration.streaming,
+				requestHeaders: modelConfiguration.requestHeaders,
+				zeroDataRetentionEnabled: modelConfiguration.zeroDataRetentionEnabled,
+				supportsReasoningEffort: modelConfiguration.supportsReasoningEffort,
+				reasoningEffortFormat: modelConfiguration.reasoningEffortFormat
+			};
+			const modelInfo = resolveModelInfo(model.id, this._name, undefined, modelCapabilities);
+			modelInfo.supported_endpoints = apiType === 'responses'
+				? [ModelSupportedEndpoint.ChatCompletions, ModelSupportedEndpoint.Responses]
+				: [ModelSupportedEndpoint.ChatCompletions];
+			return this._instantiationService.createInstance(OpenAIEndpoint, modelInfo, model.configuration?.apiKey ?? '', url);
+		}
+		return super.createOpenAIEndPoint(model);
+	}
+
 	protected override getModelInfo(modelId: string, modelUrl: string): IChatModelInformation {
 		const modelInfo = super.getModelInfo(modelId, modelUrl);
 		modelInfo.supported_endpoints = [
@@ -51,4 +123,25 @@ export class OAIBYOKLMProvider extends AbstractOpenAICompatibleLMProvider {
 		];
 		return modelInfo;
 	}
+}
+
+/**
+ * Resolves the request URL for a configured OpenAI model. If the URL already
+ * targets an explicit API path it is used as-is; otherwise the appropriate
+ * path is appended based on the API type (defaulting the version segment to
+ * `/v1` when missing).
+ */
+function resolveOpenAIUrl(url: string, apiType: OpenAIApiType): string {
+	if (url.includes('/responses') || url.includes('/chat/completions')) {
+		return url;
+	}
+	if (url.endsWith('/')) {
+		url = url.slice(0, -1);
+	}
+	const path = apiType === 'responses' ? '/responses' : '/chat/completions';
+	const versionPattern = /\/v\d+$/;
+	if (versionPattern.test(url)) {
+		return `${url}${path}`;
+	}
+	return `${url}/v1${path}`;
 }

--- a/extensions/copilot/src/extension/byok/vscode-node/openAIProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/openAIProvider.ts
@@ -40,6 +40,12 @@ export interface OpenAIModelConfig extends _OpenAIModelConfig {
 export interface OpenAIModelProviderConfig extends LanguageModelChatConfiguration {
 	url?: string;
 	models?: OpenAIModelConfig[];
+	/**
+	 * Enables Zero Data Retention for every model in this provider group. ZDR organizations
+	 * reject `previous_response_id` and server-side storage, so when set the Responses API path
+	 * is forced into stateless mode (`store: false`, no marker reuse).
+	 */
+	zeroDataRetentionEnabled?: boolean;
 }
 
 export class OAIBYOKLMProvider extends AbstractOpenAICompatibleLMProvider<OpenAIModelProviderConfig> {
@@ -88,6 +94,8 @@ export class OAIBYOKLMProvider extends AbstractOpenAICompatibleLMProvider<OpenAI
 	}
 
 	protected override async createOpenAIEndPoint(model: OpenAICompatibleLanguageModelChatInformation<OpenAIModelProviderConfig>): Promise<OpenAIEndpoint> {
+		// Zero Data Retention is configured per provider group and applies to every model in it.
+		const groupZeroDataRetention = !!model.configuration?.zeroDataRetentionEnabled;
 		const modelConfiguration = model.configuration?.models?.find(m => m.id === model.id);
 		if (modelConfiguration) {
 			const apiType: OpenAIApiType = modelConfiguration.apiType ?? (model.url.includes('/responses') ? 'responses' : 'chat-completions');
@@ -102,7 +110,7 @@ export class OAIBYOKLMProvider extends AbstractOpenAICompatibleLMProvider<OpenAI
 				thinking: modelConfiguration.thinking ?? false,
 				streaming: modelConfiguration.streaming,
 				requestHeaders: modelConfiguration.requestHeaders,
-				zeroDataRetentionEnabled: modelConfiguration.zeroDataRetentionEnabled,
+				zeroDataRetentionEnabled: modelConfiguration.zeroDataRetentionEnabled || groupZeroDataRetention,
 				supportsReasoningEffort: modelConfiguration.supportsReasoningEffort,
 				reasoningEffortFormat: modelConfiguration.reasoningEffortFormat
 			};
@@ -112,7 +120,13 @@ export class OAIBYOKLMProvider extends AbstractOpenAICompatibleLMProvider<OpenAI
 				: [ModelSupportedEndpoint.ChatCompletions];
 			return this._instantiationService.createInstance(OpenAIEndpoint, modelInfo, model.configuration?.apiKey ?? '', url);
 		}
-		return super.createOpenAIEndPoint(model);
+		// Discovered models still honor the group-level Zero Data Retention setting.
+		const modelInfo = this.getModelInfo(model.id, model.url);
+		modelInfo.zeroDataRetentionEnabled = groupZeroDataRetention;
+		const url = modelInfo.supported_endpoints?.includes(ModelSupportedEndpoint.Responses)
+			? `${model.url}/responses`
+			: `${model.url}/chat/completions`;
+		return this._instantiationService.createInstance(OpenAIEndpoint, modelInfo, model.configuration?.apiKey ?? '', url);
 	}
 
 	protected override getModelInfo(modelId: string, modelUrl: string): IChatModelInformation {
@@ -131,7 +145,7 @@ export class OAIBYOKLMProvider extends AbstractOpenAICompatibleLMProvider<OpenAI
  * path is appended based on the API type (defaulting the version segment to
  * `/v1` when missing).
  */
-function resolveOpenAIUrl(url: string, apiType: OpenAIApiType): string {
+export function resolveOpenAIUrl(url: string, apiType: OpenAIApiType): string {
 	if (url.includes('/responses') || url.includes('/chat/completions')) {
 		return url;
 	}

--- a/extensions/copilot/src/extension/byok/vscode-node/openRouterProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/openRouterProvider.ts
@@ -25,6 +25,13 @@ interface OpenRouterModelData {
 	architecture?: {
 		input_modalities?: string[];
 	};
+	/**
+	 * The model's maximum context length across providers. OpenRouter reports
+	 * this at the top level, while `top_provider.context_length` reflects only
+	 * the currently-routed provider and is frequently smaller. Prefer this value
+	 * so the model's full context window is exposed. See issue #316402.
+	 */
+	context_length?: number;
 	top_provider: {
 		context_length: number;
 	};
@@ -73,11 +80,14 @@ export class OpenRouterLMProvider extends AbstractOpenAICompatibleLMProvider {
 		const supportsReasoningEffort = supportedParameters.includes('reasoning') || supportedParameters.includes('reasoning_effort')
 			? ['low', 'medium', 'high']
 			: undefined;
+		// Prefer the model-level `context_length` (max across providers) and fall back to the
+		// currently-routed provider's value. See issue #316402.
+		const contextLength = openRouterModelData.context_length ?? openRouterModelData.top_provider.context_length;
 		return {
 			name: openRouterModelData.name,
 			toolCalling: supportedParameters.includes('tools'),
 			vision: openRouterModelData.architecture?.input_modalities?.includes('image') ?? false,
-			maxInputTokens: openRouterModelData.top_provider.context_length - 16000,
+			maxInputTokens: contextLength - 16000,
 			maxOutputTokens: 16000,
 			supportsReasoningEffort
 		};

--- a/extensions/copilot/src/extension/byok/vscode-node/test/openAIProvider.spec.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/test/openAIProvider.spec.ts
@@ -1,0 +1,138 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it, vi } from 'vitest';
+import { DefaultsOnlyConfigurationService } from '../../../../platform/configuration/common/defaultsOnlyConfigurationService';
+import { IFetcherService } from '../../../../platform/networking/common/fetcherService';
+import { NullExperimentationService } from '../../../../platform/telemetry/common/nullExperimentationService';
+import { TestLogService } from '../../../../platform/testing/common/testLogService';
+import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
+import { BYOKKnownModels } from '../../common/byokProvider';
+import type { IBYOKStorageService } from '../byokStorageService';
+import { OAIBYOKLMProvider, OpenAIModelProviderConfig, resolveOpenAIUrl } from '../openAIProvider';
+
+function createStorageService(): IBYOKStorageService {
+	return {
+		getAPIKey: vi.fn().mockResolvedValue(undefined),
+		storeAPIKey: vi.fn().mockResolvedValue(undefined),
+		deleteAPIKey: vi.fn().mockResolvedValue(undefined),
+		getStoredModelConfigs: vi.fn().mockResolvedValue({}),
+		saveModelConfig: vi.fn().mockResolvedValue(undefined),
+		removeModelConfig: vi.fn().mockResolvedValue(undefined),
+	} as unknown as IBYOKStorageService;
+}
+
+function createProvider(): OAIBYOKLMProvider {
+	return new OAIBYOKLMProvider(
+		{} as BYOKKnownModels,
+		createStorageService(),
+		{} as unknown as IFetcherService,
+		new TestLogService(),
+		{ createInstance: vi.fn() } as unknown as IInstantiationService,
+		new DefaultsOnlyConfigurationService(),
+		new NullExperimentationService(),
+	);
+}
+
+function createProviderWithSpy(): { provider: OAIBYOKLMProvider; createInstance: ReturnType<typeof vi.fn> } {
+	const createInstance = vi.fn();
+	const provider = new OAIBYOKLMProvider(
+		{} as BYOKKnownModels,
+		createStorageService(),
+		{} as unknown as IFetcherService,
+		new TestLogService(),
+		{ createInstance } as unknown as IInstantiationService,
+		new DefaultsOnlyConfigurationService(),
+		new NullExperimentationService(),
+	);
+	return { provider, createInstance };
+}
+
+function createModel(configuration: OpenAIModelProviderConfig): unknown {
+	return {
+		id: 'gpt-4o',
+		name: 'GPT-4o',
+		family: 'gpt-4o',
+		version: '1.0.0',
+		maxInputTokens: 128000,
+		maxOutputTokens: 16000,
+		capabilities: { toolCalling: true, imageInput: false },
+		configuration,
+		url: 'https://api.openai.com/v1',
+	};
+}
+
+async function resolveEndpointModelInfo(configuration: OpenAIModelProviderConfig): Promise<{ zeroDataRetentionEnabled?: boolean }> {
+	const { provider, createInstance } = createProviderWithSpy();
+	await (provider as unknown as { createOpenAIEndPoint(model: unknown): Promise<unknown> }).createOpenAIEndPoint(createModel(configuration));
+	const lastCall = createInstance.mock.lastCall as unknown[];
+	return lastCall[1] as { zeroDataRetentionEnabled?: boolean };
+}
+
+describe('resolveOpenAIUrl', () => {
+	it.each<[string, 'chat-completions' | 'responses', string]>([
+		['https://api.openai.com/v1/chat/completions', 'chat-completions', 'https://api.openai.com/v1/chat/completions'],
+		['https://api.openai.com/v1/responses', 'responses', 'https://api.openai.com/v1/responses'],
+		['https://api.openai.com/v1', 'chat-completions', 'https://api.openai.com/v1/chat/completions'],
+		['https://api.openai.com/v1', 'responses', 'https://api.openai.com/v1/responses'],
+		['https://api.openai.com/v1/', 'chat-completions', 'https://api.openai.com/v1/chat/completions'],
+		['https://example.com/openai', 'chat-completions', 'https://example.com/openai/v1/chat/completions'],
+		['https://example.com/openai', 'responses', 'https://example.com/openai/v1/responses'],
+	])('resolves request URL for %s with API type %s', (url, apiType, expected) => {
+		expect(resolveOpenAIUrl(url, apiType)).toEqual(expected);
+	});
+});
+
+describe('OAIBYOKLMProvider.getAllModels', () => {
+	it('honors configured per-model limits instead of running discovery', async () => {
+		const configuration: OpenAIModelProviderConfig = {
+			apiKey: 'k_test',
+			models: [
+				{ id: 'gpt-4o', name: 'GPT-4o', maxInputTokens: 100000, maxOutputTokens: 16000, toolCalling: true, vision: true },
+				{ id: 'o3', name: 'o3', url: 'https://custom.example.com/v1', maxInputTokens: 200000, maxOutputTokens: 65536, toolCalling: true, vision: false },
+			],
+		};
+
+		const models = await (createProvider() as unknown as {
+			getAllModels(silent: boolean, apiKey: string | undefined, configuration: OpenAIModelProviderConfig | undefined): Promise<{ id: string; maxInputTokens: number; maxOutputTokens: number; url: string; capabilities?: { toolCalling?: boolean; imageInput?: boolean } }[]>;
+		}).getAllModels(true, 'k_test', configuration);
+
+		expect(models.map(model => ({
+			id: model.id,
+			maxInputTokens: model.maxInputTokens,
+			maxOutputTokens: model.maxOutputTokens,
+			url: model.url,
+			toolCalling: model.capabilities?.toolCalling,
+			vision: model.capabilities?.imageInput,
+		}))).toEqual([
+			{ id: 'gpt-4o', maxInputTokens: 100000, maxOutputTokens: 16000, url: 'https://api.openai.com/v1', toolCalling: true, vision: true },
+			{ id: 'o3', maxInputTokens: 200000, maxOutputTokens: 65536, url: 'https://custom.example.com/v1', toolCalling: true, vision: false },
+		]);
+	});
+});
+
+describe('OAIBYOKLMProvider zero data retention', () => {
+	it('applies the group-level flag to discovered models', async () => {
+		const modelInfo = await resolveEndpointModelInfo({ apiKey: 'k_test', zeroDataRetentionEnabled: true });
+
+		expect(modelInfo.zeroDataRetentionEnabled).toBe(true);
+	});
+
+	it('leaves discovered models without zero data retention when the group flag is unset', async () => {
+		const modelInfo = await resolveEndpointModelInfo({ apiKey: 'k_test' });
+
+		expect(modelInfo.zeroDataRetentionEnabled).toBe(false);
+	});
+
+	it('applies the group-level flag to explicitly configured models', async () => {
+		const modelInfo = await resolveEndpointModelInfo({
+			apiKey: 'k_test',
+			zeroDataRetentionEnabled: true,
+			models: [{ id: 'gpt-4o', name: 'GPT-4o', maxInputTokens: 128000, maxOutputTokens: 16000, toolCalling: true, vision: false }],
+		});
+
+		expect(modelInfo.zeroDataRetentionEnabled).toBe(true);
+	});
+});

--- a/extensions/copilot/src/extension/byok/vscode-node/test/openRouterProvider.spec.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/test/openRouterProvider.spec.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it, vi } from 'vitest';
+import { DefaultsOnlyConfigurationService } from '../../../../platform/configuration/common/defaultsOnlyConfigurationService';
+import { IFetcherService } from '../../../../platform/networking/common/fetcherService';
+import { NullExperimentationService } from '../../../../platform/telemetry/common/nullExperimentationService';
+import { TestLogService } from '../../../../platform/testing/common/testLogService';
+import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
+import { BYOKModelCapabilities } from '../../common/byokProvider';
+import type { IBYOKStorageService } from '../byokStorageService';
+import { OpenRouterLMProvider } from '../openRouterProvider';
+
+function createStorageService(): IBYOKStorageService {
+	return {
+		getAPIKey: vi.fn().mockResolvedValue(undefined),
+		storeAPIKey: vi.fn().mockResolvedValue(undefined),
+		deleteAPIKey: vi.fn().mockResolvedValue(undefined),
+		getStoredModelConfigs: vi.fn().mockResolvedValue({}),
+		saveModelConfig: vi.fn().mockResolvedValue(undefined),
+		removeModelConfig: vi.fn().mockResolvedValue(undefined),
+	} as unknown as IBYOKStorageService;
+}
+
+function createProvider(): OpenRouterLMProvider {
+	return new OpenRouterLMProvider(
+		createStorageService(),
+		{} as unknown as IFetcherService,
+		new TestLogService(),
+		{ createInstance: vi.fn() } as unknown as IInstantiationService,
+		new DefaultsOnlyConfigurationService(),
+		new NullExperimentationService(),
+	);
+}
+
+function resolveModelCapabilities(modelData: unknown): BYOKModelCapabilities | undefined {
+	return (createProvider() as unknown as { resolveModelCapabilities(data: unknown): BYOKModelCapabilities | undefined }).resolveModelCapabilities(modelData);
+}
+
+describe('OpenRouterLMProvider.resolveModelCapabilities', () => {
+	it('prefers the model-level context_length over the routed provider value', () => {
+		const capabilities = resolveModelCapabilities({
+			id: 'openai/gpt-4o',
+			name: 'GPT-4o',
+			supported_parameters: ['tools'],
+			context_length: 200000,
+			top_provider: { context_length: 32000 },
+		});
+
+		expect(capabilities?.maxInputTokens).toBe(200000 - 16000);
+	});
+
+	it('falls back to the routed provider context_length when the model-level value is absent', () => {
+		const capabilities = resolveModelCapabilities({
+			id: 'openai/gpt-4o',
+			name: 'GPT-4o',
+			supported_parameters: ['tools'],
+			top_provider: { context_length: 32000 },
+		});
+
+		expect(capabilities?.maxInputTokens).toBe(32000 - 16000);
+	});
+});

--- a/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -65,8 +65,9 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 	}
 
 	get maxOutputTokens(): number {
-		// The VS Code API doesn't expose max output tokens, use a reasonable default
-		return 8192;
+		// Prefer the provider-declared max output tokens when available, otherwise fall back to a
+		// reasonable default. See issue #321761.
+		return this.languageModel.maxOutputTokens ?? 8192;
 	}
 
 	get urlOrRequestMetadata(): string {

--- a/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
@@ -64,9 +64,29 @@ describe('ExtensionContributedChatEndpoint', () => {
 
 		expect(capturedOptions.map(options => options.modelOptions?._telemetryTurn)).toEqual([undefined, undefined, undefined, undefined, undefined, undefined]);
 	});
+
+	it('uses the provider-declared maxOutputTokens when available', () => {
+		const endpoint = new ExtensionContributedChatEndpoint(
+			createLanguageModel(() => { }, { maxOutputTokens: 4096 }),
+			createInstantiationService(),
+			new NoopOTelService(resolveOTelConfig({ env: {}, extensionVersion: '1.0.0', sessionId: 'test' })),
+		);
+
+		expect(endpoint.maxOutputTokens).toBe(4096);
+	});
+
+	it('falls back to the default maxOutputTokens when the model does not declare one', () => {
+		const endpoint = new ExtensionContributedChatEndpoint(
+			createLanguageModel(() => { }),
+			createInstantiationService(),
+			new NoopOTelService(resolveOTelConfig({ env: {}, extensionVersion: '1.0.0', sessionId: 'test' })),
+		);
+
+		expect(endpoint.maxOutputTokens).toBe(8192);
+	});
 });
 
-function createLanguageModel(captureOptions: (options: vscode.LanguageModelChatRequestOptions) => void): vscode.LanguageModelChat {
+function createLanguageModel(captureOptions: (options: vscode.LanguageModelChatRequestOptions) => void, overrides?: Partial<vscode.LanguageModelChat>): vscode.LanguageModelChat {
 	return {
 		id: 'test-model',
 		name: 'Test Model',
@@ -82,7 +102,8 @@ function createLanguageModel(captureOptions: (options: vscode.LanguageModelChatR
 					yield new vscode.LanguageModelTextPart('hello');
 				})()
 			};
-		})
+		}),
+		...overrides,
 	} as unknown as vscode.LanguageModelChat;
 }
 

--- a/src/vs/workbench/api/common/extHostLanguageModels.ts
+++ b/src/vs/workbench/api/common/extHostLanguageModels.ts
@@ -446,6 +446,7 @@ export class ExtHostLanguageModels implements ExtHostLanguageModelsShape {
 				editToolsHint: model.metadata.capabilities?.editTools,
 			},
 			maxInputTokens: model.metadata.maxInputTokens,
+			maxOutputTokens: model.metadata.maxOutputTokens,
 			countTokens(text, token) {
 				if (!that._localModels.has(modelId)) {
 					throw extHostTypes.LanguageModelError.NotFound(modelId);

--- a/src/vscode-dts/vscode.proposed.languageModelCapabilities.d.ts
+++ b/src/vscode-dts/vscode.proposed.languageModelCapabilities.d.ts
@@ -9,6 +9,15 @@ declare module 'vscode' {
 
 	export interface LanguageModelChat {
 		/**
+		 * The maximum number of tokens the model can produce in a single response.
+		 *
+		 * This mirrors the stable {@link LanguageModelChat.maxInputTokens} but for output. It is
+		 * provided by the model provider and allows consumers (e.g. other extensions routing
+		 * requests through this model) to size requests correctly instead of assuming a default.
+		 */
+		readonly maxOutputTokens?: number;
+
+		/**
 		 * The capabilities of the language model.
 		 */
 		readonly capabilities: {


### PR DESCRIPTION
Three BYOK bugs where models reported or used the wrong token / context-window limits:

#321761 — ExtensionContributedChatEndpoint.maxOutputTokens was hardcoded to 8192. Adds maxOutputTokens to the languageModelCapabilities proposed API, surfaces it on the extHost API object, and consumes it in extChatEndpoint.ts (return this.languageModel.maxOutputTokens ?? 8192).

#322216 — vendor: openai ignored configured per-model maxInputTokens/maxOutputTokens and instead ran discovery against built-in known-model metadata (huge windows). The provider now honors an explicitly configured models array, falling back to discovery only when none is given.

#316402 — OpenRouter context window was taken from top_provider.context_length (the routed provider, often smaller). Now prefers the model's top-level context_length with top_provider.context_length as fallback.