### PR TITLE
test: always log failed requests and console errors in web smoke tests

### DIFF
--- a/test/automation/src/playwrightBrowser.ts
+++ b/test/automation/src/playwrightBrowser.ts
@@ -131,17 +131,26 @@ async function launchBrowser(options: LaunchOptions, endpoint: string) {
 	const page = await measureAndLog(() => context.newPage(), 'context.newPage()', logger);
 	await measureAndLog(() => page.setViewportSize({ width: 1440, height: 900 }), 'page.setViewportSize', logger);
 
+	// Always log failed requests and console errors/warnings (even without
+	// `--verbose`) so that hard-to-reproduce startup stalls can be root caused
+	// from CI logs. A stalled or aborted module fetch can prevent the workbench
+	// from rendering (e.g. `.monaco-workbench` never appears) without producing
+	// a page error, crash or HTTP error response, making it otherwise invisible.
+	context.on('requestfailed', e => logger.log(`Playwright (Browser): context.on('requestfailed') [${e.failure()?.errorText} for ${e.url()}]`));
+	page.on('requestfailed', e => logger.log(`Playwright (Browser): page.on('requestfailed') [${e.failure()?.errorText} for ${e.url()}]`));
+	page.on('console', e => {
+		if (options.verbose || e.type() === 'error' || e.type() === 'warning') {
+			logger.log(`Playwright (Browser): window.on('console') [${e.text()}]`);
+		}
+	});
+
 	if (options.verbose) {
 		context.on('page', () => logger.log(`Playwright (Browser): context.on('page')`));
-		context.on('requestfailed', e => logger.log(`Playwright (Browser): context.on('requestfailed') [${e.failure()?.errorText} for ${e.url()}]`));
-
-		page.on('console', e => logger.log(`Playwright (Browser): window.on('console') [${e.text()}]`));
 		page.on('dialog', () => logger.log(`Playwright (Browser): page.on('dialog')`));
 		page.on('domcontentloaded', () => logger.log(`Playwright (Browser): page.on('domcontentloaded')`));
 		page.on('load', () => logger.log(`Playwright (Browser): page.on('load')`));
 		page.on('popup', () => logger.log(`Playwright (Browser): page.on('popup')`));
 		page.on('framenavigated', () => logger.log(`Playwright (Browser): page.on('framenavigated')`));
-		page.on('requestfailed', e => logger.log(`Playwright (Browser): page.on('requestfailed') [${e.failure()?.errorText} for ${e.url()}]`));
 	}
 
 	page.on('pageerror', async (error) => logger.log(`Playwright (Browser) ERROR: page error: ${error}`));


### PR DESCRIPTION
## Why

While investigating a `macOS / Browser` smoke test failure, the only error was:

```
VSCode Smoke Tests (Web) > Preferences
  "before all" hook: Error: Timeout: get element '.monaco-workbench' after 20 seconds.
```

The web workbench renderer stalled during its initial client-side bootstrap — it never opened the `ManagementConnection` to the server, never installed the smoke-test driver, and never rendered `.monaco-workbench`. Crucially there was **no** page error, crash, or HTTP 4xx response (all of which are already logged unconditionally), so nothing in the CI logs explained the hang.

The most likely culprit for this failure class — a stalled or aborted module fetch from the dev server — would surface as a Playwright `requestfailed` event. But `requestfailed` and `console` listeners were only registered under `--verbose`, which the smoke tests don't pass, so that evidence was discarded.

## What

In `test/automation/src/playwrightBrowser.ts`, move the high-signal diagnostics out of the `--verbose` block so they are always captured:

- `context.on('requestfailed')` and `page.on('requestfailed')` — always logged.
- `page.on('console')` — always logs `error`/`warning` messages; full console output stays behind `--verbose` to avoid log bloat.

The chatty lifecycle events (`context.on('page')`, `dialog`, `domcontentloaded`, `load`, `popup`, `framenavigated`) remain gated behind `--verbose`. Existing unconditional `pageerror`/`crash`/HTTP-4xx logging is untouched.

## Effect

Next time a web smoke test stalls before `.monaco-workbench` renders, the runner log will contain any failed network requests and renderer console errors, making the failure root-causable instead of a silent 20s timeout.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
