### PR TITLE
sessions: always use close icon for chat tab close button

### DIFF
--- a/src/vs/sessions/browser/parts/chatCompositeBar.ts
+++ b/src/vs/sessions/browser/parts/chatCompositeBar.ts
@@ -306,7 +306,7 @@ export class ChatCompositeBar extends Disposable {
 			const closeAction = this._tabDisposables.add(new Action(
 				'chatCompositeBar.closeChat',
 				isDraft ? localize('deleteDraftChat', "Delete Chat") : localize('closeChat', "Close"),
-				ThemeIcon.asClassName(isDraft ? Codicon.trash : Codicon.close),
+				ThemeIcon.asClassName(Codicon.close),
 				true,
 				async () => {
 					if (!this._session) {


### PR DESCRIPTION
## What

Always use the close icon (`Codicon.close`) for the chat tab close button in the agent sessions window, instead of showing a trash icon for draft chat tabs.

## Why

Previously, draft chat tabs displayed a trash/delete icon while committed chat tabs showed a close icon. This made the tab strip visually inconsistent. The icon is now uniform across all chat tabs.

## Notes for reviewers

- The destructive "Delete Chat" label (for accessibility/screen readers) and the delete-without-confirmation behavior for untitled drafts are unchanged — only the icon changes.
- Single-line change in `src/vs/sessions/browser/parts/chatCompositeBar.ts`.