### PR TITLE
fix(oss): carry the cached NOTICE forward through multi-build CG outages

### DIFF
--- a/build/azure-pipelines/product-quality-checks.yml
+++ b/build/azure-pipelines/product-quality-checks.yml
@@ -159,8 +159,13 @@ jobs:
       # from a prior build.
       #
       # Fallback order:
-      #   1. Most recent successful run on the CURRENT branch
-      #   2. Most recent successful run on `main`
+      #   1. Most recent run on the CURRENT branch
+      #   2. Most recent run on `main`
+      #
+      # Carry-forward: the cache download reads only the SINGLE latest build, so a
+      # sustained CG outage (>1 build) breaks the chain unless every build keeps a
+      # copy. The "Upload CG NOTICE artifact" step below runs on the fallback path
+      # too, handing the last-good NOTICE forward. Ref: builds 450982->451029.
       #
       # TODO: consider enforcing a max-age check (~30 days) on cached NOTICEs.
       # Today the only signal is the warning emitted below.
@@ -287,16 +292,26 @@ jobs:
         condition: and(succeeded(), ne(variables.CG_NOTICE_OK, 'true'))
 
       - script: |
+          set -u
+          GEN="$(Build.SourcesDirectory)/ThirdPartyNotices.generated.txt"
           echo "=== CG NOTICE artifact ==="
-          if [ -f "$(Build.SourcesDirectory)/ThirdPartyNotices.generated.txt" ]; then
-            SIZE=$(wc -c < "$(Build.SourcesDirectory)/ThirdPartyNotices.generated.txt")
-            echo "Generated file size: $SIZE bytes"
-            cp "$(Build.SourcesDirectory)/ThirdPartyNotices.generated.txt" "$(Build.ArtifactStagingDirectory)/ThirdPartyNotices.generated.txt"
-            echo "##vso[artifact.upload containerfolder=notice_output;artifactname=notice_output]$(Build.ArtifactStagingDirectory)/ThirdPartyNotices.generated.txt"
 
-            # Write a sidecar so future runs (and humans) know what this NOTICE
-            # was built from. Consumed by the "Cache: apply NOTICE fallback" step
-            # of subsequent builds when they fall back to this artifact.
+          # Publish on both paths: fresh CG success AND carry-forward (re-publishing
+          # a cached NOTICE so the chain survives a multi-build outage; see above).
+          if [ ! -f "$GEN" ] || [ "$(wc -c < "$GEN")" -le 1024 ]; then
+            echo "No usable ThirdPartyNotices.generated.txt to publish; skipping (no CG output and no cached fallback)."
+            exit 0
+          fi
+
+          SIZE=$(wc -c < "$GEN")
+          echo "Generated file size: $SIZE bytes (source: CG_NOTICE_OK=${CG_NOTICE_OK:-unset}, NOTICE_FROM_CACHE=${NOTICE_FROM_CACHE:-unset})"
+          cp "$GEN" "$(Build.ArtifactStagingDirectory)/ThirdPartyNotices.generated.txt"
+          echo "##vso[artifact.upload containerfolder=notice_output;artifactname=notice_output]$(Build.ArtifactStagingDirectory)/ThirdPartyNotices.generated.txt"
+
+          # Sidecar for the next build's fallback. Fresh run records this build's
+          # provenance; carry-forward preserves the original + appends a marker.
+          META_OUT="$(Build.ArtifactStagingDirectory)/notice-meta.txt"
+          if [ "${CG_NOTICE_OK:-}" = "true" ]; then
             {
               echo "built_at:          $(date -u +%Y-%m-%dT%H:%M:%SZ)"
               echo "source_branch:     $(Build.SourceBranch)"
@@ -304,13 +319,28 @@ jobs:
               echo "build_id:          $(Build.BuildId)"
               echo "build_number:      $(Build.BuildNumber)"
               echo "size_bytes:        $SIZE"
-            } > "$(Build.ArtifactStagingDirectory)/notice-meta.txt"
-            echo "##vso[artifact.upload containerfolder=notice_output;artifactname=notice_output]$(Build.ArtifactStagingDirectory)/notice-meta.txt"
+            } > "$META_OUT"
           else
-            echo "ERROR: ThirdPartyNotices.generated.txt not found — this step should not run without CG_NOTICE_OK=true"
+            case "${NOTICE_FROM_CACHE:-}" in
+              branch) SRC_META="$(Pipeline.Workspace)/cached-notice-branch/notice_output/notice-meta.txt" ;;
+              main)   SRC_META="$(Pipeline.Workspace)/cached-notice-main/notice_output/notice-meta.txt" ;;
+              *)      SRC_META="" ;;
+            esac
+            if [ -n "$SRC_META" ] && [ -f "$SRC_META" ]; then
+              cp "$SRC_META" "$META_OUT"
+            else
+              echo "original_provenance: unavailable (cached NOTICE predates the notice-meta.txt sidecar)" > "$META_OUT"
+            fi
+            {
+              echo "carried_forward_by_build:    $(Build.BuildId)"
+              echo "carried_forward_by_number:   $(Build.BuildNumber)"
+              echo "carried_forward_at:          $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+              echo "carried_forward_reason:      CG NOTICE generation failed; re-published last-good NOTICE to keep the cache chain alive."
+            } >> "$META_OUT"
           fi
-        displayName: "Upload CG NOTICE artifact"
-        condition: and(succeeded(), eq(variables.CG_NOTICE_OK, 'true'))
+          echo "##vso[artifact.upload containerfolder=notice_output;artifactname=notice_output]$META_OUT"
+        displayName: "Upload CG NOTICE artifact (fresh or carried-forward)"
+        condition: and(succeeded(), or(eq(variables.CG_NOTICE_OK, 'true'), in(variables.NOTICE_FROM_CACHE, 'branch', 'main')))
         continueOnError: true
 
       - script: |


### PR DESCRIPTION
🤖 AI Assisted PR

## Problem

The cached-NOTICE fallback breaks during a **sustained** Component Governance (CG) outage — exactly when it matters most.

`DownloadBuildArtifacts@1` picks the **single latest build** on the branch, then looks inside its `notice_output` artifact for `ThirdPartyNotices.generated.txt`. The task cannot search backwards for a build that actually contains the file. Meanwhile, `Upload CG NOTICE artifact` only ran when CG **succeeded** — so a build that fell back to the cache published **no** `generated.txt`.

Result: once CG is down for more than one consecutive build, every recent build's artifact lacks `generated.txt`, and the fallback download finds nothing.

Observed live across builds **450982 → 451005 → 451029** (all on `main`):

```
Download from the specified build: #451005
Pattern: **/ThirdPartyNotices.generated.txt → 0 matches
Item excluded: notice_output/ThirdPartyNotices.extensions.txt
Item excluded: notice_output/ThirdPartyNotices.new.txt        ← no generated.txt at all
```

The last genuinely-good NOTICE (build 450967) was just three builds back, but unreachable.

> Note: this is the follow-up to #322979, which fixed a separate bug (brace `itemPattern` matched 0 files). That fix is confirmed working here — the patterns now expand individually — which is what exposed this deeper chain-rot issue.

## Fix

Re-publish the NOTICE on the **carry-forward** path too. When a build applies a cached NOTICE (CG failed but a cached `generated.txt` was found), upload that NOTICE as **this** build's own `generated.txt`. The last-good NOTICE is then handed forward build-to-build for the entire outage, until CG recovers.

- `Upload CG NOTICE artifact` now runs on CG success **or** a cache fallback (`NOTICE_FROM_CACHE in (branch, main)`).
- The carried-forward `notice-meta.txt` **preserves the original provenance** (so legal traceability still points at the build that truly generated the CG NOTICE) and appends a `carried_forward_by_*` marker.
- Total-failure path (no CG output and no cache) still publishes nothing — unchanged.

## Validation

- Traced the artifact contents and CG/upload status across builds 450967 (CG ✅, upload ✅) and 450982/451005/451029 (CG ❌, upload skipped) — confirming the chain breaks precisely because failed builds upload no `generated.txt`.
- Condition logic verified across all three states: CG success (`eq` arm), cache hit (`in` arm), total failure (neither — skipped, nothing to publish).
- YAML parses clean.
