### PR TITLE
sessions: keep focus in chat input when switching sessions

### DIFF
--- a/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidget.ts
@@ -55,7 +55,11 @@ export class MultiDiffEditorWidget extends Disposable {
 		return new MultiDiffEditorViewModel(model, this._instantiationService);
 	}
 
-	public setViewModel(viewModel: MultiDiffEditorViewModel | undefined): void {
+	public setViewModel(viewModel: MultiDiffEditorViewModel | undefined, options?: { readonly preserveFocus?: boolean }): void {
+		// An editor opened with `preserveFocus` (e.g. restored in the background
+		// or on a session switch) must not have its automatic first-change
+		// selection steal keyboard focus from elsewhere (such as the chat input).
+		this._widgetImpl.get().setPreserveFocusOnLoad(!!options?.preserveFocus);
 		this._viewModel.set(viewModel, undefined);
 	}
 

--- a/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
@@ -60,6 +60,15 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 	private readonly _contextKeyService;
 	private readonly _instantiationService;
 
+	/**
+	 * When `true`, the automatic "select the first change" initialization that
+	 * runs once the view model finishes loading does not move keyboard focus
+	 * into the editor. Driven by {@link setPreserveFocusOnLoad} so a
+	 * `preserveFocus` open (e.g. restored in the background or on a session
+	 * switch) does not steal focus, while a normal user-initiated open does.
+	 */
+	private _preserveFocusOnLoad = false;
+
 	constructor(
 		private readonly _element: HTMLElement,
 		private readonly _dimension: IObservable<Dimension | undefined>,
@@ -242,8 +251,14 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 					return;
 				}
 
-				// Navigate to the first change using the existing navigation logic
-				this.goToNextChange();
+				// Navigate to the first change using the existing navigation
+				// logic. Whether this also moves keyboard focus into the editor
+				// is driven by the last `setViewModel` call: an editor opened
+				// with `preserveFocus` (e.g. restored in the background or on a
+				// session switch) must not steal focus from wherever the user is
+				// (such as the chat input), while a normal user-initiated open
+				// focuses the first change so the editor is ready to use.
+				this._navigateToChange('next', !this._preserveFocusOnLoad);
 			}
 		}));
 
@@ -257,6 +272,16 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 
 	public setScrollState(scrollState: { top?: number; left?: number }): void {
 		this._scrollableElement.setScrollPosition({ scrollLeft: scrollState.left, scrollTop: scrollState.top });
+	}
+
+	/**
+	 * Controls whether the automatic first-change selection that runs once the
+	 * view model finishes loading preserves focus instead of moving it into the
+	 * editor. Set to `true` for `preserveFocus` opens so focus is not stolen
+	 * from elsewhere.
+	 */
+	public setPreserveFocusOnLoad(preserveFocus: boolean): void {
+		this._preserveFocusOnLoad = preserveFocus;
 	}
 
 	public getRootElement(): HTMLElement {
@@ -360,7 +385,7 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 		this._navigateToChange('previous');
 	}
 
-	private _navigateToChange(direction: 'next' | 'previous'): void {
+	private _navigateToChange(direction: 'next' | 'previous', focusEditor: boolean = true): void {
 		const viewItems = this._viewItems.get();
 		if (viewItems.length === 0) {
 			return;
@@ -371,7 +396,7 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 
 		// Start with first file if no active item
 		if (currentIndex === -1) {
-			this._goToFile(0, 'first');
+			this._goToFile(0, 'first', focusEditor);
 			return;
 		}
 
@@ -395,10 +420,10 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 
 		// Move to next/previous file
 		const nextIndex = (currentIndex + (direction === 'next' ? 1 : -1) + viewItems.length) % viewItems.length;
-		this._goToFile(nextIndex, direction === 'next' ? 'first' : 'last');
+		this._goToFile(nextIndex, direction === 'next' ? 'first' : 'last', focusEditor);
 	}
 
-	private _goToFile(index: number, position: 'first' | 'last'): void {
+	private _goToFile(index: number, position: 'first' | 'last', focusEditor: boolean = true): void {
 		const item = this._viewItems.get()[index];
 		if (item.viewModel.collapsed.get()) {
 			item.viewModel.collapsed.set(false, undefined);
@@ -417,7 +442,9 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 				modifiedEditor.revealLineInCenter(lastChange.modified.startLineNumber);
 			}
 		}
-		editor?.focus();
+		if (focusEditor) {
+			editor?.focus();
+		}
 	}
 
 	private render(reader: IReader | undefined) {

--- a/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
@@ -500,7 +500,13 @@ export abstract class BaseLayoutController extends Disposable {
 	// --- Editor working sets [B2] ---
 
 	private async _applyWorkingSet(sessionResource: URI | undefined, options?: { readonly isInitialRestore?: boolean }): Promise<void> {
-		const preserveFocus = this._layoutService.hasFocus(Parts.PANEL_PART);
+		// Restoring a session's editor working set must never pull keyboard focus
+		// into the editor area. Focus during a session switch is owned by the
+		// switch itself (it moves focus into the active session's chat input, or
+		// leaves it on the panel); letting the editor restore grab focus would
+		// steal it from the chat input whenever the target session has editors
+		// open.
+		const preserveFocus = true;
 		const workingSet: IEditorWorkingSet | 'empty' = sessionResource
 			? (this._workingSets.get(sessionResource) ?? 'empty')
 			: 'empty';

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -1610,7 +1610,15 @@ export class SessionsList extends Disposable implements ISessionsList {
 			}
 			if (!isSessionSection(element) && !isSessionGroupItem(element)) {
 				this.markRead(element);
-				this.options.onSessionOpen(element.resource, e.editorOptions.preserveFocus ?? false, e.sideBySide);
+				// A deliberate left mouse click on a session should move keyboard
+				// focus into the chat input so the user can start typing right
+				// away. A single click always reports `preserveFocus: true`, so
+				// detect the mouse click explicitly. Keyboard navigation keeps
+				// `preserveFocus` as reported so browsing the list never steals
+				// focus from it.
+				const isLeftClick = DOM.isMouseEvent(e.browserEvent) && e.browserEvent.button === 0;
+				const preserveFocus = isLeftClick ? false : (e.editorOptions.preserveFocus ?? false);
+				this.options.onSessionOpen(element.resource, preserveFocus, e.sideBySide);
 			}
 		}));
 

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditor.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditor.ts
@@ -94,7 +94,7 @@ export class MultiDiffEditor extends AbstractEditorWithViewState<IMultiDiffEdito
 		await super.setInput(input, options, context, token);
 		this._viewModel = await input.getViewModel();
 		this._contentOverlay?.updateResource(input.resource);
-		this._multiDiffEditorWidget!.setViewModel(this._viewModel);
+		this._multiDiffEditorWidget!.setViewModel(this._viewModel, { preserveFocus: options?.preserveFocus });
 
 		const viewState = this.loadEditorViewState(input, context);
 		if (viewState) {


### PR DESCRIPTION
## What

Fixes keyboard focus landing in the editor instead of the chat input when switching sessions in the Agents window.

When switching to a session, focus should land in the chat input so the user can start typing immediately. Three paths were stealing it:

1. **List click** (`sessionsList.ts`): a single mouse click on a session always reports `preserveFocus: true` (the tree's single-click default), so `openSession` never moved focus into the chat input. A deliberate left mouse click now opens with `preserveFocus: false`; keyboard navigation keeps its reported value so list browsing never steals focus.

2. **Editor working-set restore** (`baseSessionLayoutController.ts`): restoring a session's editor working set derived `preserveFocus` from panel focus, so switching to a session with editors open moved focus into the editor area. It now always preserves focus — the session switch itself owns focus direction.

3. **Multi-diff editor auto-select** (`multiDiffEditorWidgetImpl.ts` + widget + pane): the Changes view auto-selected the first change on load via `goToNextChange()`, which focuses the diff editor. This ran whenever the view model loaded (including background/session-switch restores) and stole focus. The auto-initialization now reveals/selects the first change without moving focus when the editor is opened with `preserveFocus`, driven by the editor's open option.

## Why

Reported issue: switching sessions (e.g. via keybinding or clicking the list) moved focus to the editor part instead of the chat input when the target session had an editor open.

## Reviewer notes

- The multi-diff change is shared core editor code. It is gated on the editor's `preserveFocus` open option, so the regular VS Code window is unaffected: normal user opens (e.g. SCM "Open Changes") still auto-focus the first file, and explicit "Go to Next/Previous Change" commands still focus. Only background/restore/session-switch opens (which already pass `preserveFocus: true`) now avoid stealing focus. Notebook multi-diff callers pass no option and keep the previous behavior.
- Verified manually in the Agents window (with and without an editor / Changes view open) and confirmed regular-window multi-diff focus behavior is preserved.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
