### PR TITLE
sessions: update agent feedback submit overlay

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorActions.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorActions.ts
@@ -38,7 +38,7 @@ abstract class AgentFeedbackEditorAction extends Action2 {
 		});
 	}
 
-	override async run(accessor: ServicesAccessor): Promise<void> {
+	override async run(accessor: ServicesAccessor): Promise<boolean | void> {
 		const editorService = accessor.get(IEditorService);
 		const agentFeedbackService = accessor.get(IAgentFeedbackService);
 		const codeReviewService = accessor.get(ICodeReviewService);
@@ -67,7 +67,7 @@ abstract class AgentFeedbackEditorAction extends Action2 {
 		}
 	}
 
-	abstract runWithSession(accessor: ServicesAccessor, sessionResource: URI): Promise<void> | void;
+	abstract runWithSession(accessor: ServicesAccessor, sessionResource: URI): Promise<boolean | void> | boolean | void;
 }
 
 class SubmitFeedbackAction extends AgentFeedbackEditorAction {
@@ -88,9 +88,9 @@ class SubmitFeedbackAction extends AgentFeedbackEditorAction {
 		});
 	}
 
-	override async runWithSession(accessor: ServicesAccessor, sessionResource: URI): Promise<void> {
+	override async runWithSession(accessor: ServicesAccessor, sessionResource: URI): Promise<boolean> {
 		const agentFeedbackService = accessor.get(IAgentFeedbackService);
-		await agentFeedbackService.submitFeedback(sessionResource);
+		return agentFeedbackService.submitFeedback(sessionResource);
 	}
 }
 

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorOverlay.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorOverlay.ts
@@ -32,13 +32,10 @@ class SubmitFeedbackActionRunner extends ActionRunner {
 		super();
 	}
 
-	override async run(action: IAction, context?: unknown): Promise<void> {
-		if (!action.enabled) {
-			return super.run(action, context);
-		}
+	protected override async runAction(action: IAction, context?: unknown): Promise<void> {
 		const editorToClose = action.id === submitFeedbackActionId ? this._editorGroup.activeEditor : undefined;
-		await super.run(action, context);
-		if (editorToClose && this._editorGroup.contains(editorToClose)) {
+		const didSubmit = await action.run(context);
+		if (didSubmit === true && editorToClose && this._editorGroup.contains(editorToClose)) {
 			await this._editorGroup.closeEditor(editorToClose);
 		}
 	}

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorOverlay.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorOverlay.ts
@@ -5,9 +5,9 @@
 
 import './media/agentFeedbackEditorOverlay.css';
 import { Disposable, DisposableMap, DisposableStore, combinedDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
-import { autorun, observableFromEvent, observableSignalFromEvent, observableValue } from '../../../../base/common/observable.js';
+import { autorun, observableFromEvent, observableSignalFromEvent, observableValue, type IObservable } from '../../../../base/common/observable.js';
 import { ActionViewItem, IBaseActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
-import { IAction } from '../../../../base/common/actions.js';
+import { ActionRunner, IAction } from '../../../../base/common/actions.js';
 import { Event } from '../../../../base/common/event.js';
 import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -24,7 +24,25 @@ import { localize } from '../../../../nls.js';
 import { getActiveResourceCandidates } from './agentFeedbackEditorUtils.js';
 import { Menus } from '../../../browser/menus.js';
 import { ICodeReviewService } from '../../codeReview/browser/codeReviewService.js';
-import { getSessionEditorComments, hasAcceptedAgentFeedbackComments } from './sessionEditorComments.js';
+import { getAcceptedAgentFeedbackCommentCount, getSessionEditorComments } from './sessionEditorComments.js';
+
+class SubmitFeedbackActionRunner extends ActionRunner {
+
+	constructor(private readonly _editorGroup: IEditorGroup) {
+		super();
+	}
+
+	override async run(action: IAction, context?: unknown): Promise<void> {
+		if (!action.enabled) {
+			return super.run(action, context);
+		}
+		const editorToClose = action.id === submitFeedbackActionId ? this._editorGroup.activeEditor : undefined;
+		await super.run(action, context);
+		if (editorToClose && this._editorGroup.contains(editorToClose)) {
+			await this._editorGroup.closeEditor(editorToClose);
+		}
+	}
+}
 
 class AgentFeedbackActionViewItem extends ActionViewItem {
 
@@ -32,10 +50,16 @@ class AgentFeedbackActionViewItem extends ActionViewItem {
 		action: IAction,
 		options: IBaseActionViewItemOptions,
 		private readonly _keybindingService: IKeybindingService,
+		private readonly _acceptedFeedbackCount?: IObservable<number>,
+		private readonly _editorGroup?: IEditorGroup,
 		private readonly _primaryActionIds: readonly string[] = [submitFeedbackActionId],
 	) {
 		const isIconOnly = action.id === navigatePreviousFeedbackActionId || action.id === navigateNextFeedbackActionId;
 		super(undefined, action, { ...options, icon: isIconOnly, label: !isIconOnly, keybindingNotRenderedWithLabel: true });
+
+		if (this._editorGroup && this._action.id === submitFeedbackActionId) {
+			this.actionRunner = this._register(new SubmitFeedbackActionRunner(this._editorGroup));
+		}
 	}
 
 	override render(container: HTMLElement): void {
@@ -43,14 +67,39 @@ class AgentFeedbackActionViewItem extends ActionViewItem {
 		if (this._primaryActionIds.includes(this._action.id)) {
 			this.element?.classList.add('primary');
 		}
+
+		const acceptedFeedbackCount = this._acceptedFeedbackCount;
+		if (this._action.id === submitFeedbackActionId && acceptedFeedbackCount) {
+			this._store.add(autorun(r => {
+				acceptedFeedbackCount.read(r);
+				this.updateLabel();
+				this.updateTooltip();
+			}));
+		}
+	}
+
+	protected override updateLabel(): void {
+		if (this._action.id === submitFeedbackActionId && this.label) {
+			this.label.textContent = this._getSubmitLabel();
+			return;
+		}
+		super.updateLabel();
 	}
 
 	protected override getTooltip(): string | undefined {
-		const value = super.getTooltip();
+		const value = this._action.id === submitFeedbackActionId ? this._getSubmitLabel() : super.getTooltip();
 		if (!value || this.options.keybinding) {
 			return value;
 		}
 		return this._keybindingService.appendKeybinding(value, this._action.id);
+	}
+
+	private _getSubmitLabel(): string {
+		const acceptedFeedbackCount = this._acceptedFeedbackCount?.get();
+		if (acceptedFeedbackCount === undefined) {
+			return this._action.label;
+		}
+		return localize('agentFeedback.submitCountShort', 'Submit {0}', acceptedFeedbackCount);
 	}
 }
 
@@ -60,6 +109,7 @@ export class AgentFeedbackOverlayWidget extends Disposable {
 	private readonly _toolbarNode: HTMLElement;
 	private readonly _showStore = this._store.add(new DisposableStore());
 	private readonly _navigationBearings = observableValue<{ activeIdx: number; totalCount: number }>(this, { activeIdx: -1, totalCount: 0 });
+	private readonly _acceptedFeedbackCount = observableValue<number>(this, 0);
 
 	constructor(
 		@IInstantiationService private readonly _instaService: IInstantiationService,
@@ -78,9 +128,10 @@ export class AgentFeedbackOverlayWidget extends Disposable {
 		return this._domNode;
 	}
 
-	show(navigationBearings: { activeIdx: number; totalCount: number }): void {
+	show(navigationBearings: { activeIdx: number; totalCount: number }, acceptedFeedbackCount: number, editorGroup?: IEditorGroup): void {
 		this._showStore.clear();
 		this._navigationBearings.set(navigationBearings, undefined);
+		this._acceptedFeedbackCount.set(acceptedFeedbackCount, undefined);
 
 		if (!this._domNode.contains(this._toolbarNode)) {
 			this._domNode.appendChild(this._toolbarNode);
@@ -120,7 +171,7 @@ export class AgentFeedbackOverlayWidget extends Disposable {
 					};
 				}
 
-				return new AgentFeedbackActionViewItem(action, options, this._keybindingService);
+				return new AgentFeedbackActionViewItem(action, options, this._keybindingService, this._acceptedFeedbackCount, editorGroup);
 			},
 		}));
 		this._showStore.add(toDisposable(() => this._toolbarNode.remove()));
@@ -129,6 +180,7 @@ export class AgentFeedbackOverlayWidget extends Disposable {
 	hide(): void {
 		this._showStore.clear();
 		this._navigationBearings.set({ activeIdx: -1, totalCount: 0 }, undefined);
+		this._acceptedFeedbackCount.set(0, undefined);
 		this._toolbarNode.remove();
 	}
 }
@@ -183,7 +235,7 @@ class AgentFeedbackOverlayController {
 
 			const candidates = getActiveResourceCandidates(group.activeEditorPane?.input);
 			let navigationBearings = undefined;
-			let hasAgentFeedback = false;
+			let acceptedFeedbackCount = 0;
 			for (const candidate of candidates) {
 				const sessionResource = agentFeedbackService.getSessionForFile(candidate)?.resource;
 				if (!sessionResource) {
@@ -197,7 +249,7 @@ class AgentFeedbackOverlayController {
 				);
 				if (comments.length > 0) {
 					navigationBearings = agentFeedbackService.getNavigationBearing(sessionResource, comments);
-					hasAgentFeedback = hasAcceptedAgentFeedbackComments(comments);
+					acceptedFeedbackCount = getAcceptedAgentFeedbackCommentCount(comments);
 					break;
 				}
 			}
@@ -210,8 +262,8 @@ class AgentFeedbackOverlayController {
 			}
 
 			hasCommentsContext.set(true);
-			hasAgentFeedbackContext.set(hasAgentFeedback);
-			widget.show(navigationBearings);
+			hasAgentFeedbackContext.set(acceptedFeedbackCount > 0);
+			widget.show(navigationBearings, acceptedFeedbackCount, group);
 			show();
 		}));
 	}

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
@@ -223,9 +223,9 @@ export interface IAgentFeedbackService {
 
 	/**
 	 * Submit the currently accumulated accepted feedback for the session to the
-	 * agent and mark those items as submitted.
+	 * agent and mark those items as submitted. Returns whether the feedback was submitted.
 	 */
-	submitFeedback(sessionResource: URI): Promise<void>;
+	submitFeedback(sessionResource: URI): Promise<boolean>;
 
 	/**
 	 * Add a feedback item and then submit the feedback. Waits for the
@@ -661,11 +661,11 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 		return session ? isAgentHostProviderId(session.providerId) : false;
 	}
 
-	async submitFeedback(sessionResource: URI): Promise<void> {
+	async submitFeedback(sessionResource: URI): Promise<boolean> {
 		const widget = this._chatWidgetService.getWidgetBySessionResource(sessionResource);
 		if (!widget) {
 			this._logService.error('[AgentFeedback] submitFeedback: no chat widget found for session', sessionResource.toString());
-			return;
+			return false;
 		}
 
 		// Agent-host sessions don't keep a reactive feedback attachment in the
@@ -687,13 +687,13 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 				await widget.acceptInput('/act-on-feedback');
 			} catch (err) {
 				this._logService.error('[AgentFeedback] Failed to submit feedback', err);
-				return;
+				return false;
 			} finally {
 				widget.attachmentModel.delete(attachmentId);
 			}
 
 			this.markFeedbackSubmitted(sessionResource);
-			return;
+			return true;
 		}
 
 		// Send first so the accepted feedback is still attached to the request,
@@ -704,10 +704,11 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 			await widget.acceptInput('/act-on-feedback');
 		} catch (err) {
 			this._logService.error('[AgentFeedback] Failed to submit feedback', err);
-			return;
+			return false;
 		}
 
 		this.markFeedbackSubmitted(sessionResource);
+		return true;
 	}
 
 	markFeedbackSubmitted(sessionResource: URI): void {

--- a/src/vs/sessions/contrib/agentFeedback/browser/nullAgentFeedbackService.contribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/nullAgentFeedbackService.contribution.ts
@@ -59,7 +59,7 @@ class NullAgentFeedbackService extends Disposable implements IAgentFeedbackServi
 	getNavigationBearing(_sessionResource: URI): IAgentFeedbackNavigationBearing { return { activeIdx: -1, totalCount: 0 }; }
 	clearFeedback(): void { }
 	markFeedbackSubmitted(): void { }
-	async submitFeedback(): Promise<void> { }
+	async submitFeedback(): Promise<boolean> { return false; }
 	async addFeedbackAndSubmit(): Promise<void> { }
 }
 

--- a/src/vs/sessions/contrib/agentFeedback/browser/sessionEditorComments.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/sessionEditorComments.ts
@@ -187,6 +187,10 @@ export function toSessionEditorCommentId(source: SessionEditorCommentSource, sou
 	return `${source}:${sourceId}`;
 }
 
+export function getAcceptedAgentFeedbackCommentCount(comments: readonly ISessionEditorComment[]): number {
+	return comments.filter(comment => comment.source === SessionEditorCommentSource.AgentFeedback && comment.state === AgentFeedbackState.Accepted).length;
+}
+
 export function hasAcceptedAgentFeedbackComments(comments: readonly ISessionEditorComment[]): boolean {
-	return comments.some(comment => comment.source === SessionEditorCommentSource.AgentFeedback && comment.state === AgentFeedbackState.Accepted);
+	return getAcceptedAgentFeedbackCommentCount(comments) > 0;
 }

--- a/src/vs/sessions/contrib/agentFeedback/browser/sessionEditorComments.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/sessionEditorComments.ts
@@ -188,9 +188,15 @@ export function toSessionEditorCommentId(source: SessionEditorCommentSource, sou
 }
 
 export function getAcceptedAgentFeedbackCommentCount(comments: readonly ISessionEditorComment[]): number {
-	return comments.filter(comment => comment.source === SessionEditorCommentSource.AgentFeedback && comment.state === AgentFeedbackState.Accepted).length;
+	let count = 0;
+	for (const comment of comments) {
+		if (comment.source === SessionEditorCommentSource.AgentFeedback && comment.state === AgentFeedbackState.Accepted) {
+			count++;
+		}
+	}
+	return count;
 }
 
 export function hasAcceptedAgentFeedbackComments(comments: readonly ISessionEditorComment[]): boolean {
-	return getAcceptedAgentFeedbackCommentCount(comments) > 0;
+	return comments.some(comment => comment.source === SessionEditorCommentSource.AgentFeedback && comment.state === AgentFeedbackState.Accepted);
 }

--- a/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackEditorOverlayWidget.fixture.ts
+++ b/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackEditorOverlayWidget.fixture.ts
@@ -19,6 +19,7 @@ interface INavigationBearings {
 interface IFixtureOptions {
 	readonly navigationBearings: INavigationBearings;
 	readonly hasAgentFeedbackActions?: boolean;
+	readonly acceptedFeedbackCount?: number;
 }
 
 class FixtureMenuService implements IMenuService {
@@ -77,7 +78,10 @@ function renderWidget(context: ComponentFixtureContext, options: IFixtureOptions
 	});
 
 	const widget = scopedDisposables.add(instantiationService.createInstance(AgentFeedbackOverlayWidget));
-	widget.show(options.navigationBearings);
+	widget.show(
+		options.navigationBearings,
+		options.acceptedFeedbackCount ?? (options.hasAgentFeedbackActions === false ? 0 : options.navigationBearings.totalCount),
+	);
 	context.container.appendChild(widget.getDomNode());
 }
 

--- a/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
@@ -615,7 +615,7 @@ export function createEditorServices(disposables: DisposableStore, options?: Cre
 		getNavigationBearing: () => ({ activeIdx: -1, totalCount: 0 }),
 		clearFeedback: () => { },
 		markFeedbackSubmitted: () => { },
-		submitFeedback: async () => { },
+		submitFeedback: async () => false,
 		addFeedbackAndSubmit: async () => { },
 		setFeedbackResolved: async () => { },
 	});


### PR DESCRIPTION
Fixes #322693

## Summary - show the accepted feedback count in the editor overlay submit button - close the editor that owns the overlay after submitting feedback - update the overlay component fixture to render the counted submit label  ## Validation - Not run per request.