### PR TITLE
sessions: respect hidden editor part when switching sessions

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -272,6 +272,8 @@ The panel (terminal / debug output) is hidden by default for all sessions. Each 
 
 When `workbench.editor.useModal` is not `'all'`, each session remembers which editors were open. On session switch the previous session's open editors are saved as a named working set and the incoming session's working set is restored. Archived or deleted sessions have their working sets removed.
 
+A session also remembers whether its editor part was hidden (e.g. the user closed the Side Panel while keeping editors open). Restoring such a session keeps the editor part hidden rather than forcing it back open with the working set.
+
 This is coordinated carefully: the active session observable is updated before the workspace folders update, so `LayoutController` waits until the workspace folders reflect the new session before applying the working set (to avoid restoring editors into the wrong workspace).
 
 ---

--- a/src/vs/sessions/LAYOUT_CONTROLLER.md
+++ b/src/vs/sessions/LAYOUT_CONTROLLER.md
@@ -35,6 +35,7 @@ resource (`URI`) and persisted to workspace storage:
 | Auxiliary bar (secondary side bar) | `_viewStateBySession` | visibility + active view container |
 | Panel (terminal / debug output) | `_panelVisibilityBySession` | visibility only |
 | Editor working set | `_workingSets` | open editors in the grid editor part |
+| Editor part visibility | `_editorPartHiddenBySession` | whether the editor part was left hidden |
 
 All state flows from the `activeSession` **observable** (never events). The controller derives
 `activeSessionResourceObs`, `activeSessionIsCreatedObs`, `activeSessionHasWorkspaceObs`, and
@@ -125,13 +126,14 @@ visible state is captured, so a hidden-on-submit session opens to Changes.
 ### 3.6 Editor reveal on session switch
 
 The editor part is revealed programmatically when a session's editor working set is restored on a
-session **switch** (`_revealEditorPartForWorkingSet`, §5). It is **not** revealed on the initial
-restore after a reload (§5.2) — the editor part visibility the workbench restored is preserved, so a
-session whose editor part was hidden (e.g. by closing the Side Panel, which hides both the auxiliary
-bar and the editor part while keeping the editors open) stays hidden. The editor part visibility
-otherwise follows direct editor open/close events and the user's chevron toggle. Each session's
-saved aux-bar visibility wins on switch — a side bar the user hid for a session stays hidden when
-they return to it.
+session **switch** (`_revealEditorPartForWorkingSet`, §5) — **unless** that session left the editor part
+hidden. Each session's editor part hidden state is captured on switch-away (`_saveWorkingSet` records
+`_editorPartHiddenBySession`); a session whose editor part was hidden (e.g. by closing the Side Panel,
+which hides both the auxiliary bar and the editor part while keeping the editors open) keeps the editor
+part hidden when restored. It is also **not** revealed on the initial restore after a reload (§5.2) —
+the editor part visibility the workbench restored is preserved. The editor part visibility otherwise
+follows direct editor open/close events and the user's chevron toggle. Each session's saved aux-bar
+visibility wins on switch — a side bar the user hid for a session stays hidden when they return to it.
 
 ---
 
@@ -167,11 +169,13 @@ Using `runOnChange(activeSessionForWorkingSet, ...)`:
 
 - **Outgoing session** (skip untitled): `_saveWorkingSet` snapshots the currently open editors as a
   named working set (`session-working-set:<resource>`); sessions with no visible editors store nothing.
+  It also records whether the editor part is currently hidden in `_editorPartHiddenBySession`.
 - **Incoming session**: `_applyWorkingSet` restores its saved working set (or `'empty'`). All
-  applies are serialized through a `Sequencer`. When not in modal mode and the working set is
-  non-empty, the editor part is revealed before/after applying via `_revealEditorPartForWorkingSet`,
-  which suppresses the editor→aux-bar invariant (§3.4) so the session's saved aux-bar visibility is
-  honored.
+  applies are serialized through a `Sequencer`. When not in modal mode, the working set is
+  non-empty, **and the session did not leave the editor part hidden**, the editor part is revealed
+  before/after applying via `_revealEditorPartForWorkingSet`, which suppresses the editor→aux-bar
+  invariant (§3.4) so the session's saved aux-bar visibility is honored. A session whose
+  `_editorPartHiddenBySession` entry is `true` keeps the editor part hidden on switch.
 
 On initial load (no previous session) the controller only applies a working set if one is already
 saved for the incoming session — it never applies `'empty'`, to avoid closing editors being restored.
@@ -181,12 +185,12 @@ because the user closed the Side Panel) is preserved across reloads.
 
 ### 5.3 Cleanup
 
-`onDidChangeSessions` removes working sets **and** per-session view state for **archived** or
-**deleted** sessions. View-state removal is done explicitly in that handler — `_deleteWorkingSet`
-only drops the editor working set. (It must **not** drop the view state, because it is also called
-from `_saveWorkingSet` on every switch-away / shutdown; coupling the two would wipe a session's
-saved aux-bar visibility whenever it had editors but no longer does, causing the aux bar to fall
-back to the default-visible logic (§3.2) on the next reload.)
+`onDidChangeSessions` removes working sets, per-session view state, **and** the editor part hidden
+state for **archived** or **deleted** sessions. View-state and editor-part-visibility removal is done
+explicitly in that handler — `_deleteWorkingSet` only drops the editor working set. (It must **not**
+drop the view state, because it is also called from `_saveWorkingSet` on every switch-away / shutdown;
+coupling the two would wipe a session's saved aux-bar visibility whenever it had editors but no longer
+does, causing the aux bar to fall back to the default-visible logic (§3.2) on the next reload.)
 
 ---
 
@@ -194,8 +198,9 @@ back to the default-visible logic (§3.2) on the next reload.)
 
 - All per-session state serializes to the workspace-scoped key `sessions.layoutState` on
   `IStorageService.onWillSaveState` (`_saveState`), with a `StorageTarget.MACHINE` target.
-- `_saveState` captures the active session's current view state and working set (skipping untitled /
-  multi-session cases) and writes one `ISessionLayoutEntry` per known session resource.
+- `_saveState` captures the active session's current view state, working set, and editor part hidden
+  state (skipping untitled / multi-session cases) and writes one `ISessionLayoutEntry` per known
+  session resource.
 - The shared new-session view state (§3.2 step 2) is persisted separately under the workspace-scoped
   key `sessions.newSessionViewState` as an `INewSessionViewState` object, written immediately whenever
   the user toggles the aux bar on the new-session view (not on shutdown).

--- a/src/vs/sessions/LAYOUT_CONTROLLER.md
+++ b/src/vs/sessions/LAYOUT_CONTROLLER.md
@@ -169,7 +169,9 @@ Using `runOnChange(activeSessionForWorkingSet, ...)`:
 
 - **Outgoing session** (skip untitled): `_saveWorkingSet` snapshots the currently open editors as a
   named working set (`session-working-set:<resource>`); sessions with no visible editors store nothing.
-  It also records whether the editor part is currently hidden in `_editorPartHiddenBySession`.
+  It also records whether the editor part is currently hidden in `_editorPartHiddenBySession`, but only
+  while a single session is visible — in multi-session mode the editor area is shared, so its visibility
+  is not captured as a per-session choice.
 - **Incoming session**: `_applyWorkingSet` restores its saved working set (or `'empty'`). All
   applies are serialized through a `Sequencer`. When not in modal mode, the working set is
   non-empty, **and the session did not leave the editor part hidden**, the editor part is revealed

--- a/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.md
+++ b/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.md
@@ -27,7 +27,9 @@ updates that session's remembered state.
 #### B2 — Open editors
 Each session restores its own set of open editors when you activate it. Switching sessions saves the
 editors you had open and applies the target session's. New / untitled sessions, and sessions with no
-saved editors, never force the editor area open or wipe it.
+saved editors, never force the editor area open or wipe it. If you hid the editor part for a session
+(e.g. by closing the Side Panel while keeping editors open), restoring it keeps the editor part hidden
+instead of forcing it back open.
 
 ### Scenario: layout survives an app restart
 A session's remembered layout is preserved when the app is closed and restored when it reopens.
@@ -60,8 +62,10 @@ default layout instead of stale state. Open editors are still preserved.
 - **Working sets [B2]** — active only when `workbench.editor.useModal !== 'all'` (`_useModalConfigObs`).
   `activeSessionForWorkingSet` (`derivedObservableWithCache`) holds back the new session until the
   workspace folders reflect its working directory. Save/apply on switch via a serializing `Sequencer`;
-  initial restore applies a saved set under `suppressEditorPartAutoVisibility()` only. Cleanup on
-  `onDidChangeSessions` (`_deleteWorkingSet` drops only the working set, never view state).
+  initial restore applies a saved set under `suppressEditorPartAutoVisibility()` only. `_saveWorkingSet`
+  also records the editor part's hidden state per session (`_editorPartHiddenBySession`) so a switch-back
+  `_applyWorkingSet` skips the editor-part reveal for a session whose editor part was left hidden.
+  Cleanup on `onDidChangeSessions` (`_deleteWorkingSet` drops only the working set, never view state).
 - **Persistence & migration [B3]** — per-session state is keyed by session `URI` and persisted to the
   workspace-scoped storage key `sessions.layoutState` (`StorageTarget.MACHINE`). `_loadState` restores
   on construction and drops corrupt data defensively; if the key is absent it migrates once from the

--- a/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.md
+++ b/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.md
@@ -63,7 +63,8 @@ default layout instead of stale state. Open editors are still preserved.
   `activeSessionForWorkingSet` (`derivedObservableWithCache`) holds back the new session until the
   workspace folders reflect its working directory. Save/apply on switch via a serializing `Sequencer`;
   initial restore applies a saved set under `suppressEditorPartAutoVisibility()` only. `_saveWorkingSet`
-  also records the editor part's hidden state per session (`_editorPartHiddenBySession`) so a switch-back
+  also records the editor part's hidden state per session (`_editorPartHiddenBySession`, only while a
+  single session is visible — the editor area is shared in multi-session mode) so a switch-back
   `_applyWorkingSet` skips the editor-part reveal for a session whose editor part was left hidden.
   Cleanup on `onDidChangeSessions` (`_deleteWorkingSet` drops only the working set, never view state).
 - **Persistence & migration [B3]** — per-session state is keyed by session `URI` and persisted to the

--- a/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
@@ -60,6 +60,7 @@ interface ISessionLayoutEntry {
 	readonly sessionResource: string;
 	readonly viewState?: ISessionViewState;
 	readonly editorWorkingSet?: IEditorWorkingSet;
+	readonly editorPartHidden?: boolean;
 }
 
 /** New unified storage key for all per-session layout state. */
@@ -83,6 +84,12 @@ export abstract class BaseLayoutController extends Disposable {
 	protected readonly _panelVisibilityBySession = new ResourceMap<boolean>();
 	protected readonly _viewStateBySession = new ResourceMap<ISessionViewState>();
 	protected readonly _workingSets = new ResourceMap<IEditorWorkingSet>();
+	/**
+	 * [B2] Whether the editor part was hidden (e.g. the user closed the Side
+	 * Panel while keeping editors open) for a session, captured on switch-away so
+	 * restoring the session's working set does not force the editor part open.
+	 */
+	protected readonly _editorPartHiddenBySession = new ResourceMap<boolean>();
 	private readonly _workingSetSequencer = new Sequencer();
 
 	protected readonly activeSessionResourceObs;
@@ -246,6 +253,7 @@ export abstract class BaseLayoutController extends Disposable {
 				for (const session of [...e.removed, ...archivedSessions]) {
 					this._deleteWorkingSet(session.resource);
 					this._viewStateBySession.delete(session.resource);
+					this._editorPartHiddenBySession.delete(session.resource);
 				}
 			}));
 		}));
@@ -413,6 +421,9 @@ export abstract class BaseLayoutController extends Disposable {
 					if (entry.editorWorkingSet) {
 						this._workingSets.set(resource, entry.editorWorkingSet);
 					}
+					if (entry.editorPartHidden !== undefined) {
+						this._editorPartHiddenBySession.set(resource, entry.editorPartHidden);
+					}
 					if (entry.viewState) {
 						this._viewStateBySession.set(resource, entry.viewState);
 					}
@@ -467,6 +478,7 @@ export abstract class BaseLayoutController extends Disposable {
 		const allResources = new ResourceMap<true>();
 		this._workingSets.forEach((_, r) => allResources.set(r, true));
 		this._viewStateBySession.forEach((_, r) => allResources.set(r, true));
+		this._editorPartHiddenBySession.forEach((_, r) => allResources.set(r, true));
 
 		if (allResources.size === 0) {
 			this._storageService.remove(SESSION_LAYOUT_STATE_KEY, StorageScope.WORKSPACE);
@@ -479,6 +491,7 @@ export abstract class BaseLayoutController extends Disposable {
 				sessionResource: resource.toString(),
 				editorWorkingSet: this._workingSets.get(resource),
 				viewState: this._viewStateBySession.get(resource),
+				editorPartHidden: this._editorPartHiddenBySession.get(resource),
 			});
 		});
 		this._storageService.store(SESSION_LAYOUT_STATE_KEY, JSON.stringify(entries), StorageScope.WORKSPACE, StorageTarget.MACHINE);
@@ -539,12 +552,17 @@ export abstract class BaseLayoutController extends Disposable {
 				return;
 			}
 
-			if (!isModal && !this._layoutService.isVisible(Parts.EDITOR_PART, mainWindow)) {
+			// The user may have hidden the editor part for this session (e.g. by
+			// closing the Side Panel while keeping editors open). Restore it as
+			// left instead of forcing the editor part back open on switch.
+			const editorPartHidden = sessionResource ? this._editorPartHiddenBySession.get(sessionResource) === true : false;
+
+			if (!isModal && !editorPartHidden && !this._layoutService.isVisible(Parts.EDITOR_PART, mainWindow)) {
 				this._revealEditorPartForWorkingSet();
 			}
 
 			const result = await this._editorGroupsService.applyWorkingSet(workingSet, { preserveFocus });
-			if (!isModal && result && !this._layoutService.isVisible(Parts.EDITOR_PART, mainWindow)) {
+			if (!isModal && !editorPartHidden && result && !this._layoutService.isVisible(Parts.EDITOR_PART, mainWindow)) {
 				this._revealEditorPartForWorkingSet();
 			}
 		});
@@ -552,6 +570,10 @@ export abstract class BaseLayoutController extends Disposable {
 
 	private _saveWorkingSet(sessionResource: URI): void {
 		this._deleteWorkingSet(sessionResource);
+
+		// Remember the editor part's hidden state so restoring the session does
+		// not force it back open (see _applyWorkingSet).
+		this._editorPartHiddenBySession.set(sessionResource, !this._layoutService.isVisible(Parts.EDITOR_PART, mainWindow));
 
 		if (this._editorService.visibleEditors.length > 0) {
 			const workingSetName = `session-working-set:${sessionResource.toString()}`;

--- a/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
@@ -572,8 +572,12 @@ export abstract class BaseLayoutController extends Disposable {
 		this._deleteWorkingSet(sessionResource);
 
 		// Remember the editor part's hidden state so restoring the session does
-		// not force it back open (see _applyWorkingSet).
-		this._editorPartHiddenBySession.set(sessionResource, !this._layoutService.isVisible(Parts.EDITOR_PART, mainWindow));
+		// not force it back open (see _applyWorkingSet). Skipped while multiple
+		// sessions are visible: the editor area is shared across them, so its
+		// visibility is not a per-session choice.
+		if (this._sessionsService.visibleSessions.get().length <= 1) {
+			this._editorPartHiddenBySession.set(sessionResource, !this._layoutService.isVisible(Parts.EDITOR_PART, mainWindow));
+		}
 
 		if (this._editorService.visibleEditors.length > 0) {
 			const workingSetName = `session-working-set:${sessionResource.toString()}`;

--- a/src/vs/sessions/contrib/layout/test/browser/baseSessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/baseSessionLayoutController.test.ts
@@ -98,6 +98,35 @@ suite('BaseLayoutController', () => {
 		);
 	});
 
+	test('[B2] does not reveal the editor part on switch when the session left it hidden', async () => {
+		const workspaceFolders = [{ uri: URI.file('/repo') }];
+		createController({ useModal: 'some', workspaceFolders });
+
+		const session1 = makeSession(URI.parse('session:1'));
+		const session2 = makeSession(URI.parse('session:2'));
+
+		// Session 1 keeps editors open but the user hid the editor part (e.g. by
+		// closing the Side Panel).
+		harness.visibleEditorsList = [{}];
+		harness.activeSessionObs.set(session1, undefined);
+		await timeout(0);
+		harness.partVisibility.set(Parts.EDITOR_PART, false);
+
+		// Switch away (captures session 1's working set + hidden editor part)…
+		harness.activeSessionObs.set(session2, undefined);
+		await timeout(0);
+
+		// …and back: the working set is restored but the editor part stays hidden.
+		harness.setPartHiddenCalls = [];
+		harness.activeSessionObs.set(session1, undefined);
+		await timeout(0);
+
+		assert.ok(
+			!harness.setPartHiddenCalls.some(c => c.part === Parts.EDITOR_PART && c.hidden === false),
+			'editor part should stay hidden when the session left it hidden'
+		);
+	});
+
 	// --- [B3] Persistence & migration / [B4] Save ---
 
 	test('[B3] migrates legacy sessions.workingSets key and [B4] persists to sessions.layoutState', () => {

--- a/src/vs/sessions/contrib/layout/test/browser/baseSessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/baseSessionLayoutController.test.ts
@@ -127,6 +127,30 @@ suite('BaseLayoutController', () => {
 		);
 	});
 
+	test('[B2][B5] does not capture the editor part hidden state while multiple sessions are visible', () => {
+		const workspaceFolders = [{ uri: URI.file('/repo') }];
+		createController({ useModal: 'some', workspaceFolders });
+
+		const session1 = makeSession(URI.parse('session:1'));
+		const session2 = makeSession(URI.parse('session:2'));
+
+		// Two sessions visible at once: the editor area is shared, so its
+		// visibility is not a per-session choice.
+		harness.visibleEditorsList = [{}];
+		harness.visibleSessionsObs.set([session1, session2], undefined);
+		harness.activeSessionObs.set(session1, undefined);
+		harness.partVisibility.set(Parts.EDITOR_PART, false);
+
+		// Persist on shutdown.
+		harness.storageService.testEmitWillSaveState(WillSaveStateReason.SHUTDOWN);
+
+		const stored = harness.storageService.get('sessions.layoutState', StorageScope.WORKSPACE);
+		assert.ok(stored, 'layout state should be written');
+		const entry = JSON.parse(stored!).find((e: any) => e.sessionResource === 'session:1');
+		assert.ok(entry, 'session 1 entry should be persisted');
+		assert.strictEqual(entry.editorPartHidden, undefined, 'editor part hidden state must not be captured while multiple sessions are visible');
+	});
+
 	// --- [B3] Persistence & migration / [B4] Save ---
 
 	test('[B3] migrates legacy sessions.workingSets key and [B4] persists to sessions.layoutState', () => {


### PR DESCRIPTION
## What

In the Agents window, the per-session layout now remembers when the user hid the **editor part** for a session (for example by closing the Side Panel via *Toggle Side Panel*, which hides both the editor part and the auxiliary bar while keeping editors open). Returning to such a session keeps the editor part hidden instead of forcing it back open.

## Why

**Repro:**
1. Open session A with only the editor part visible (not the aux bar).
2. Close the side pane using the *Toggle Side Panel* action.
3. Switch to session B.
4. Switch back to session A.

**Bug:** The editor part was made visible again.

**Root cause:** `BaseLayoutController._applyWorkingSet` always revealed the editor part on a session switch whenever the restored working set was non-empty. It never tracked whether the user had deliberately hidden the editor part for that session.

## How

- Added a per-session map `_editorPartHiddenBySession` (keyed by session `URI`).
- `_saveWorkingSet` (runs on switch-away and shutdown) records whether the editor part is currently hidden.
- `_applyWorkingSet` skips the editor-part reveal when the session's recorded state is hidden.
- Persisted the new state through the existing `sessions.layoutState` storage (`ISessionLayoutEntry.editorPartHidden`, in `_loadState`/`_saveState`) and cleaned it up for archived/deleted sessions.

This mirrors the existing "don't reveal on reload" behaviour and is symmetric to how aux-bar visibility is already remembered per session.

## Tests

- Added regression test `[B2] does not reveal the editor part on switch when the session left it hidden`.
- All 51 layout-controller unit tests pass; `valid-layers-check` passes.

## Notes for reviewers

Spec docs were updated to stay in sync: `baseSessionLayoutController.md` (B2), `LAYOUT_CONTROLLER.md` (state table, §3.6/§5.2/§5.3/§6), and `LAYOUT.md` §10.
