### PR TITLE
Agent host: simplify worktree branch and folder names

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -49,7 +49,7 @@ import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import { IAgentHostCompletions } from '../agentHostCompletions.js';
 import { IAgentHostGitService, META_DIFF_BASE_BRANCH } from '../../common/agentHostGitService.js';
 import { findMcpChildId } from '../shared/mcpCustomizationController.js';
-import { ICopilotBranchNameGenerator } from './copilotBranchNameGenerator.js';
+import { COPILOT_BRANCH_PREFIX, ICopilotBranchNameGenerator } from './copilotBranchNameGenerator.js';
 import { CopilotAgentSession, type CopilotSdkMode } from './copilotAgentSession.js';
 import { ICopilotSessionContext, projectFromCopilotContext } from './copilotGitProject.js';
 import { parsedPluginsEqual, toChildCustomizations } from './copilotPluginConverters.js';
@@ -227,7 +227,12 @@ export function getCopilotWorktreesRoot(repositoryRoot: URI): URI {
 }
 
 export function getCopilotWorktreeName(branchName: string): string {
-	return branchName.replace(/\//g, '-');
+	// Strip the `agents/` branch prefix so the worktree directory name stays
+	// concise, then flatten any remaining path separators.
+	const withoutPrefix = branchName.startsWith(COPILOT_BRANCH_PREFIX)
+		? branchName.substring(COPILOT_BRANCH_PREFIX.length)
+		: branchName;
+	return withoutPrefix.replace(/\//g, '-');
 }
 
 /**
@@ -2384,7 +2389,12 @@ export class CopilotAgent extends Disposable implements IAgent {
 		}
 
 		const worktreesRoot = getCopilotWorktreesRoot(repositoryRoot);
-		const branchName = await this._branchNameGenerator.generateBranchName({ sessionId, message: prompt, githubToken: this._githubToken });
+		const branchName = await this._branchNameGenerator.generateBranchName({
+			sessionId,
+			message: prompt,
+			githubToken: this._githubToken,
+			branchExists: branchName => this._gitService.branchExists(repositoryRoot, branchName).catch(() => false),
+		});
 		const worktree = URI.joinPath(worktreesRoot, getCopilotWorktreeName(branchName));
 		await fs.mkdir(worktreesRoot.fsPath, { recursive: true });
 		const baseBranch = typeof config.config[SessionConfigKey.Branch] === 'string' ? config.config[SessionConfigKey.Branch] as string : undefined;

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -2393,7 +2393,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 			sessionId,
 			message: prompt,
 			githubToken: this._githubToken,
-			branchExists: branchName => this._gitService.branchExists(repositoryRoot, branchName).catch(() => false),
+			// Treat a failed existence check as a collision so we fall back to a
+			// suffixed branch name rather than risk `addWorktree` failing because
+			// the branch already exists.
+			branchExists: branchName => this._gitService.branchExists(repositoryRoot, branchName).catch(() => true),
 		});
 		const worktree = URI.joinPath(worktreesRoot, getCopilotWorktreeName(branchName));
 		await fs.mkdir(worktreesRoot.fsPath, { recursive: true });

--- a/src/vs/platform/agentHost/node/copilot/copilotBranchNameGenerator.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotBranchNameGenerator.ts
@@ -19,8 +19,8 @@ export interface ICopilotBranchNameGeneratorRequest {
 	readonly signal?: AbortSignal;
 	/**
 	 * Optional predicate used to check whether a candidate branch name already
-	 * exists. When it reports a collision, a short random suffix is appended so
-	 * the generated branch name stays unique.
+	 * exists. When it reports a collision, a short suffix derived from the
+	 * session id is appended so the generated branch name stays unique.
 	 */
 	readonly branchExists?: (branchName: string) => Promise<boolean>;
 }
@@ -110,8 +110,8 @@ export class CopilotBranchNameGenerator implements ICopilotBranchNameGenerator {
 			return `${COPILOT_BRANCH_PREFIX}${request.sessionId}`;
 		}
 
-		// Prefer the bare hint and only append a short random suffix when the
-		// branch name would collide with an existing branch.
+		// Prefer the bare hint and only append a short session-id suffix when
+		// the branch name would collide with an existing branch.
 		const branchName = `${COPILOT_BRANCH_PREFIX}${branchNameHint}`;
 		if (request.branchExists && await request.branchExists(branchName)) {
 			return `${branchName}-${request.sessionId.substring(0, COPILOT_BRANCH_SESSION_ID_SUFFIX_LENGTH)}`;

--- a/src/vs/platform/agentHost/node/copilot/copilotBranchNameGenerator.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotBranchNameGenerator.ts
@@ -7,7 +7,7 @@ import { ILogService } from '../../../log/common/log.js';
 import { createDecorator } from '../../../instantiation/common/instantiation.js';
 import { ICopilotApiService, type ICopilotUtilityChatMessage } from '../shared/copilotApiService.js';
 
-const COPILOT_BRANCH_PREFIX = 'agents/';
+export const COPILOT_BRANCH_PREFIX = 'agents/';
 const COPILOT_BRANCH_SESSION_ID_SUFFIX_LENGTH = 8;
 const MAX_BRANCH_NAME_HINT_LENGTH = 48;
 const MIN_GENERATED_BRANCH_NAME_LENGTH = 8;
@@ -17,6 +17,12 @@ export interface ICopilotBranchNameGeneratorRequest {
 	readonly message?: string;
 	readonly githubToken?: string;
 	readonly signal?: AbortSignal;
+	/**
+	 * Optional predicate used to check whether a candidate branch name already
+	 * exists. When it reports a collision, a short random suffix is appended so
+	 * the generated branch name stays unique.
+	 */
+	readonly branchExists?: (branchName: string) => Promise<boolean>;
 }
 
 export const ICopilotBranchNameGenerator = createDecorator<ICopilotBranchNameGenerator>('copilotBranchNameGenerator');
@@ -36,7 +42,7 @@ export class CopilotBranchNameGenerator implements ICopilotBranchNameGenerator {
 
 	async generateBranchName(request: ICopilotBranchNameGeneratorRequest): Promise<string> {
 		const branchNameHint = (await this._generateBranchNameHint(request)) ?? getCopilotBranchNameHintFromMessage(request.message ?? '');
-		return this._buildBranchName(request.sessionId, branchNameHint);
+		return this._buildBranchName(request, branchNameHint);
 	}
 
 	private async _generateBranchNameHint(request: ICopilotBranchNameGeneratorRequest): Promise<string | undefined> {
@@ -98,8 +104,20 @@ export class CopilotBranchNameGenerator implements ICopilotBranchNameGenerator {
 		];
 	}
 
-	private _buildBranchName(sessionId: string, branchNameHint: string | undefined): string {
-		return `${COPILOT_BRANCH_PREFIX}${branchNameHint ? `${branchNameHint}-${sessionId.substring(0, COPILOT_BRANCH_SESSION_ID_SUFFIX_LENGTH)}` : sessionId}`;
+	private async _buildBranchName(request: ICopilotBranchNameGeneratorRequest, branchNameHint: string | undefined): Promise<string> {
+		if (!branchNameHint) {
+			// No usable hint - fall back to the (already unique) session id.
+			return `${COPILOT_BRANCH_PREFIX}${request.sessionId}`;
+		}
+
+		// Prefer the bare hint and only append a short random suffix when the
+		// branch name would collide with an existing branch.
+		const branchName = `${COPILOT_BRANCH_PREFIX}${branchNameHint}`;
+		if (request.branchExists && await request.branchExists(branchName)) {
+			return `${branchName}-${request.sessionId.substring(0, COPILOT_BRANCH_SESSION_ID_SUFFIX_LENGTH)}`;
+		}
+
+		return branchName;
 	}
 }
 

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -570,7 +570,7 @@ suite('CopilotAgent', () => {
 		});
 	});
 
-	test('appends a short random suffix when the branch name already exists', async () => {
+	test('appends a short session-id suffix when the branch name already exists', async () => {
 		const copilotApiService = new TestCopilotApiService();
 		copilotApiService.response = 'add-agent-host-config';
 		const generator = new CopilotBranchNameGenerator(copilotApiService, new NullLogService());
@@ -2644,7 +2644,7 @@ suite('CopilotAgent', () => {
 				//    before constructing the SDK session. Verifies that the
 				//    real production code path persists branch metadata and
 				//    queues the live announcement.
-				const expectedBranchName = `agents/add-feature-${sessionId.substring(0, 8)}`;
+				const expectedBranchName = `agents/add-feature`;
 				const workingDir = await agent.resolveWorktreeForTest({
 					workingDirectory: repositoryRoot,
 					config: { isolation: 'worktree', branch: 'main' },

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -563,15 +563,29 @@ suite('CopilotAgent', () => {
 			token: copilotApiService.utilityCalls[0]?.token,
 			promptIncludesUserText: copilotApiService.utilityCalls[0]?.request.messages.some(message => message.content.includes('Add agent host config')),
 		}, {
-			generated: 'agents/add-agent-host-config-12345678',
-			fallback: 'agents/add-agent-host-config-12345678',
+			generated: 'agents/add-agent-host-config',
+			fallback: 'agents/add-agent-host-config',
 			token: 'token',
 			promptIncludesUserText: true,
 		});
 	});
 
+	test('appends a short random suffix when the branch name already exists', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		copilotApiService.response = 'add-agent-host-config';
+		const generator = new CopilotBranchNameGenerator(copilotApiService, new NullLogService());
+
+		assert.deepStrictEqual({
+			unique: await generator.generateBranchName({ sessionId: '12345678-aaaa-bbbb-cccc-123456789abc', message: 'Add agent host config', githubToken: 'token', branchExists: async () => false }),
+			collision: await generator.generateBranchName({ sessionId: '12345678-aaaa-bbbb-cccc-123456789abc', message: 'Add agent host config', githubToken: 'token', branchExists: async name => name === 'agents/add-agent-host-config' }),
+		}, {
+			unique: 'agents/add-agent-host-config',
+			collision: 'agents/add-agent-host-config-12345678',
+		});
+	});
+
 	test('uses Git extension branch-derived worktree folder names', () => {
-		assert.strictEqual(getCopilotWorktreeName('agents/add-agent-host-config-12345678'), 'agents-add-agent-host-config-12345678');
+		assert.strictEqual(getCopilotWorktreeName('agents/add-agent-host-config-12345678'), 'add-agent-host-config-12345678');
 	});
 
 	test('keeps generated branch names short', async () => {
@@ -581,7 +595,7 @@ suite('CopilotAgent', () => {
 
 		assert.strictEqual(
 			(await generator.generateBranchName({ sessionId: '12345678-aaaa-bbbb-cccc-123456789abc', message: 'Add agent host config', githubToken: 'token' })).length,
-			'agents/'.length + 48 + '-12345678'.length,
+			'agents/'.length + 48,
 		);
 	});
 
@@ -626,7 +640,7 @@ suite('CopilotAgent', () => {
 
 		assert.strictEqual(
 			await generator.generateBranchName({ sessionId: '12345678-aaaa-bbbb-cccc-123456789abc', message: 'Add agent host config', githubToken: 'token' }),
-			'agents/add-agent-host-config-12345678',
+			'agents/add-agent-host-config',
 		);
 	});
 
@@ -637,7 +651,7 @@ suite('CopilotAgent', () => {
 
 		assert.strictEqual(
 			await generator.generateBranchName({ sessionId: '12345678-aaaa-bbbb-cccc-123456789abc', message: 'Add agent host config', githubToken: 'token' }),
-			'agents/add-agent-host-config-12345678',
+			'agents/add-agent-host-config',
 		);
 	});
 


### PR DESCRIPTION
## What

Cleans up the worktree branch/folder names generated by the Copilot agent host (`CopilotBranchNameGenerator` / `getCopilotWorktreeName`).

- **Suffix only on collision.** Previously every generated branch name was `agents/<hint>-<sessionId8>` — the session-id suffix was always appended. Now the generator produces a clean `agents/<hint>` and only appends a short suffix (first 8 chars of the session id) when the candidate branch name would collide with an existing branch. This is checked through a new optional `branchExists` predicate on `ICopilotBranchNameGeneratorRequest`, wired in `copilotAgent.ts` to `IAgentHostGitService.branchExists`.
- **Strip the prefix from the worktree folder.** The `agents/` prefix is kept on the branch name, but `getCopilotWorktreeName` now strips it so worktree directories are `<hint>` instead of `agents-<hint>`.

## Why

Generated branch/worktree names were unnecessarily verbose (e.g. `agents-<hint>-<sessionId8>`). The session-id suffix is only needed to guarantee uniqueness, so it should be conditional, and the `agents/` prefix doesn't add value in the on-disk folder name.

## Notes for reviewers

- Branch name: `agents/<hint>` (or `agents/<hint>-<sessionId8>` on collision; falls back to `agents/<sessionId>` when no hint can be derived).
- Worktree folder: `<hint>` (prefix stripped).
- The collision check runs against the full prefixed branch name.
- Tests in `copilotAgent.test.ts` updated, plus a new test covering the collision-suffix behavior.

(Written by Copilot)
