### PR TITLE
feat(copilot): emit telemetry when Copilot experiment treatments are evaluated

### DIFF
--- a/extensions/copilot/src/lib/node/chatLibMain.ts
+++ b/extensions/copilot/src/lib/node/chatLibMain.ts
@@ -523,6 +523,7 @@ export class SimpleExperimentationService extends Disposable implements IExperim
 	declare readonly _serviceBrand: undefined;
 
 	private readonly variables: Record<string, boolean | number | string> = {};
+	private readonly _emittedTreatments = new Map<string, boolean | number | string | undefined>();
 	private readonly _onDidTreatmentsChange = this._register(new Emitter<TreatmentsChangeEvent>());
 	readonly onDidTreatmentsChange = this._onDidTreatmentsChange.event;
 
@@ -553,12 +554,17 @@ export class SimpleExperimentationService extends Disposable implements IExperim
 
 	getTreatmentVariable<T extends boolean | number | string>(name: string): T | undefined {
 		const result = this.variables[name] as T | undefined;
-		this._telemetryService.sendMSFTTelemetryEvent('copilot.experimentEvaluated', {
-			treatmentName: name,
-			valueKind: result === undefined ? 'undefined' : typeof result
-		}, {
-			hasValue: result === undefined ? 0 : 1
-		});
+		const isFirstRead = !this._emittedTreatments.has(name);
+		const previousValue = this._emittedTreatments.get(name);
+		if (isFirstRead || previousValue !== result) {
+			this._emittedTreatments.set(name, result);
+			this._telemetryService.sendMSFTTelemetryEvent('copilot.experimentEvaluated', {
+				treatmentName: name,
+				valueKind: result === undefined ? 'undefined' : typeof result
+			}, {
+				hasValue: result === undefined ? 0 : 1
+			});
+		}
 		return result;
 	}
 

--- a/extensions/copilot/src/lib/node/chatLibMain.ts
+++ b/extensions/copilot/src/lib/node/chatLibMain.ts
@@ -532,6 +532,7 @@ export class SimpleExperimentationService extends Disposable implements IExperim
 	constructor(
 		waitForTreatmentVariables: boolean | undefined,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
 		if (waitForTreatmentVariables) {
@@ -551,7 +552,14 @@ export class SimpleExperimentationService extends Disposable implements IExperim
 	}
 
 	getTreatmentVariable<T extends boolean | number | string>(name: string): T | undefined {
-		return this.variables[name] as T | undefined;
+		const result = this.variables[name] as T | undefined;
+		this._telemetryService.sendMSFTTelemetryEvent('copilot.experimentEvaluated', {
+			treatmentName: name,
+			valueKind: result === undefined ? 'undefined' : typeof result
+		}, {
+			hasValue: result === undefined ? 0 : 1
+		});
+		return result;
 	}
 
 	async setCompletionsFilters(_filters: Map<string, string>): Promise<void> { }

--- a/extensions/copilot/src/lib/vscode-node/test/simpleExperimentationService.spec.ts
+++ b/extensions/copilot/src/lib/vscode-node/test/simpleExperimentationService.spec.ts
@@ -6,9 +6,16 @@
 import { describe, expect, it } from 'vitest';
 import { DefaultsOnlyConfigurationService } from '../../../platform/configuration/common/defaultsOnlyConfigurationService';
 import { NullTelemetryService } from '../../../platform/telemetry/common/nullTelemetryService';
-import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
-import { SpyingTelemetryService } from '../../../platform/telemetry/node/spyingTelemetryService';
+import { ITelemetryService, TelemetryEventMeasurements, TelemetryEventProperties } from '../../../platform/telemetry/common/telemetry';
 import { SimpleExperimentationService } from '../../node/chatLibMain';
+
+class TestTelemetryService extends NullTelemetryService {
+	public readonly events: { eventName: string; properties?: TelemetryEventProperties; measurements?: TelemetryEventMeasurements }[] = [];
+
+	override sendMSFTTelemetryEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void {
+		this.events.push({ eventName, properties, measurements });
+	}
+}
 
 describe('SimpleExperimentationService', () => {
 	function createService(waitForTreatmentVariables = false, telemetryService: ITelemetryService = new NullTelemetryService()): SimpleExperimentationService {
@@ -205,13 +212,13 @@ describe('SimpleExperimentationService', () => {
 	});
 
 	it('should emit telemetry when a treatment variable is evaluated', () => {
-		const telemetryService = new SpyingTelemetryService();
+		const telemetryService = new TestTelemetryService();
 		const service = createService(false, telemetryService);
 		service.updateTreatmentVariables({ 'feature-flag': true });
 
 		expect(service.getTreatmentVariable<boolean>('feature-flag')).toBe(true);
 
-		const events = telemetryService.getFilteredEvents({ 'copilot.experimentEvaluated': true });
+		const events = telemetryService.events.filter(event => event.eventName === 'copilot.experimentEvaluated');
 		expect(events).toHaveLength(1);
 		expect(events[0]).toMatchObject({
 			eventName: 'copilot.experimentEvaluated',

--- a/extensions/copilot/src/lib/vscode-node/test/simpleExperimentationService.spec.ts
+++ b/extensions/copilot/src/lib/vscode-node/test/simpleExperimentationService.spec.ts
@@ -5,11 +5,18 @@
 
 import { describe, expect, it } from 'vitest';
 import { DefaultsOnlyConfigurationService } from '../../../platform/configuration/common/defaultsOnlyConfigurationService';
+import { NullTelemetryService } from '../../../platform/telemetry/common/nullTelemetryService';
+import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
+import { SpyingTelemetryService } from '../../../platform/telemetry/node/spyingTelemetryService';
 import { SimpleExperimentationService } from '../../node/chatLibMain';
 
 describe('SimpleExperimentationService', () => {
+	function createService(waitForTreatmentVariables = false, telemetryService: ITelemetryService = new NullTelemetryService()): SimpleExperimentationService {
+		return new SimpleExperimentationService(waitForTreatmentVariables, new DefaultsOnlyConfigurationService(), telemetryService);
+	}
+
 	it('should initialize with no treatment variables', async () => {
-		const service = new SimpleExperimentationService(false, new DefaultsOnlyConfigurationService());
+		const service = createService();
 		await service.hasTreatments();
 
 		expect(service.getTreatmentVariable('nonexistent')).toBeUndefined();
@@ -18,7 +25,7 @@ describe('SimpleExperimentationService', () => {
 	});
 
 	it('should update multiple treatment variables at once', () => {
-		const service = new SimpleExperimentationService(false, new DefaultsOnlyConfigurationService());
+		const service = createService();
 		const variables: Record<string, boolean | number | string> = {
 			'feature-a': true,
 			'feature-b': false,
@@ -37,7 +44,7 @@ describe('SimpleExperimentationService', () => {
 	});
 
 	it('should fire onDidTreatmentsChange event with all changed variables', () => {
-		const service = new SimpleExperimentationService(false, new DefaultsOnlyConfigurationService());
+		const service = createService();
 		const events: string[][] = [];
 
 		service.onDidTreatmentsChange((event) => {
@@ -61,7 +68,7 @@ describe('SimpleExperimentationService', () => {
 	});
 
 	it('should not fire onDidTreatmentsChange event when no variables change', () => {
-		const service = new SimpleExperimentationService(false, new DefaultsOnlyConfigurationService());
+		const service = createService();
 		const events: string[][] = [];
 
 		// Set initial value
@@ -86,7 +93,7 @@ describe('SimpleExperimentationService', () => {
 	});
 
 	it('should fire onDidTreatmentsChange event only for changed variables', () => {
-		const service = new SimpleExperimentationService(false, new DefaultsOnlyConfigurationService());
+		const service = createService();
 
 		// Set initial values
 		const variables1: Record<string, boolean | number | string> = {
@@ -114,7 +121,7 @@ describe('SimpleExperimentationService', () => {
 	});
 
 	it('should overwrite existing treatment variables', () => {
-		const service = new SimpleExperimentationService(false, new DefaultsOnlyConfigurationService());
+		const service = createService();
 
 		const variables1: Record<string, boolean | number | string> = {
 			'feature-flag': true
@@ -134,7 +141,7 @@ describe('SimpleExperimentationService', () => {
 	});
 
 	it('should wait for treatment variables when waitForTreatmentVariables = true', async () => {
-		const service = new SimpleExperimentationService(true, new DefaultsOnlyConfigurationService());
+		const service = createService(true);
 
 		// hasTreatments() should not resolve until updateTreatmentVariables() is called
 		let hasTreatmentsResolved = false;
@@ -161,7 +168,7 @@ describe('SimpleExperimentationService', () => {
 	});
 
 	it('should remove treatment variable when omitted from update', () => {
-		const service = new SimpleExperimentationService(false, new DefaultsOnlyConfigurationService());
+		const service = createService();
 
 		// Set initial variables
 		const variables1: Record<string, boolean | number | string> = {
@@ -193,6 +200,29 @@ describe('SimpleExperimentationService', () => {
 
 		expect(events).toHaveLength(1);
 		expect(events[0]).toEqual(['feature-b']);
+
+		service.dispose();
+	});
+
+	it('should emit telemetry when a treatment variable is evaluated', () => {
+		const telemetryService = new SpyingTelemetryService();
+		const service = createService(false, telemetryService);
+		service.updateTreatmentVariables({ 'feature-flag': true });
+
+		expect(service.getTreatmentVariable<boolean>('feature-flag')).toBe(true);
+
+		const events = telemetryService.getFilteredEvents({ 'copilot.experimentEvaluated': true });
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({
+			eventName: 'copilot.experimentEvaluated',
+			properties: {
+				treatmentName: 'feature-flag',
+				valueKind: 'boolean'
+			},
+			measurements: {
+				hasValue: 1
+			}
+		});
 
 		service.dispose();
 	});

--- a/extensions/copilot/src/platform/telemetry/common/nullExperimentationService.ts
+++ b/extensions/copilot/src/platform/telemetry/common/nullExperimentationService.ts
@@ -43,6 +43,11 @@ export interface IExperimentationService {
 	 * Returns the value of the treatment variable, or undefined if not found.
 	 * It uses the values currently in memory, so the experimentation service
 	 * must be initialized before calling.
+	 *
+	 * Implementations emit a `copilot.experimentEvaluated` telemetry event on the
+	 * first read of a given treatment and whenever its value changes, enabling
+	 * exposure measurement at the point of actual treatment consumption.
+	 *
 	 * @param name name of the treatment variable.
 	 */
 	getTreatmentVariable<T extends boolean | number | string>(name: string): T | undefined;

--- a/extensions/copilot/src/platform/telemetry/node/baseExperimentationService.ts
+++ b/extensions/copilot/src/platform/telemetry/node/baseExperimentationService.ts
@@ -141,6 +141,7 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 	private readonly _previouslyReadTreatments = new Map<string, boolean | string | number | undefined>();
 	private readonly _emittedTreatments = new Map<string, boolean | string | number | undefined>();
 	private readonly _lazyCohortEvaluation: boolean;
+	private readonly _cachedFeatureData: CachedFeatureData | undefined;
 	private readonly _delegateFn: TASClientDelegateFn;
 	private readonly _context: IVSCodeExtensionContext;
 
@@ -163,7 +164,8 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 		this._delegateFn = delegateFn;
 		this._context = context;
 		this._userInfoStore = new UserInfoStore(context, copilotTokenStore);
-		this._lazyCohortEvaluation = this.readCachedLazyCohortEvaluation(context);
+		this._cachedFeatureData = this.readCachedFeatureData(context);
+		this._lazyCohortEvaluation = this._cachedFeatureData?.configs?.find(config => config.Id === 'vscode')?.Parameters?.[LAZY_COHORT_EVALUATION_TREATMENT] === true;
 
 		// Refresh treatments when user info changes
 		this._register(this._userInfoStore.onDidChangeUserInfo(async () => {
@@ -190,14 +192,32 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 		}
 	}
 
-	private readCachedLazyCohortEvaluation(context: IVSCodeExtensionContext): boolean {
+	private readCachedFeatureData(context: IVSCodeExtensionContext): CachedFeatureData | undefined {
 		const storedFeatureData = context.globalState.get<unknown>(AB_EXP_FEATURE_DATA_STORAGE_KEY);
 		const featureData = isWrappedCachedFeatureData(storedFeatureData) ? storedFeatureData.value : storedFeatureData;
 		if (!isCachedFeatureData(featureData)) {
-			return false;
+			return undefined;
 		}
-		const vscodeConfig = featureData.configs?.find(config => config.Id === 'vscode');
-		return vscodeConfig?.Parameters?.[LAZY_COHORT_EVALUATION_TREATMENT] === true;
+		return featureData;
+	}
+
+	private getCachedTreatmentVariable<T extends boolean | number | string>(name: string): T | undefined {
+		const vscodeConfig = this._cachedFeatureData?.configs?.find(config => config.Id === 'vscode');
+		const value = vscodeConfig?.Parameters?.[name];
+		switch (typeof value) {
+			case 'boolean':
+			case 'number':
+			case 'string':
+				return value as T;
+			default:
+				return undefined;
+		}
+	}
+
+	private shouldDeferMissingLazyTreatment(name: string): boolean {
+		return name.startsWith('copilotchat.config.')
+			|| name.startsWith('config.github.copilot.')
+			|| name === 'copilotchat.notebookVariableFiltering';
 	}
 
 	protected ensureDelegate(): ITASExperimentationService {
@@ -244,12 +264,28 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 	}
 
 	getTreatmentVariable<T extends boolean | number | string>(name: string): T | undefined {
+		if (this._lazyCohortEvaluation && !this._delegate) {
+			const cachedResult = this.getCachedTreatmentVariable<T>(name);
+			if (cachedResult !== undefined) {
+				this.recordTreatmentEvaluation(name, cachedResult);
+				return cachedResult;
+			}
+			if (this.shouldDeferMissingLazyTreatment(name)) {
+				return undefined;
+			}
+		}
 		const delegate = this.ensureDelegate();
 		const result = delegate.getTreatmentVariable('vscode', name) as T;
 		this._previouslyReadTreatments.set(name, result);
 		if (this._lazyCohortEvaluation && result === undefined) {
 			void delegate.getTreatmentVariableAsync('vscode', name, true).then(() => this._signalTreatmentsChangeEvent());
 		}
+		this.recordTreatmentEvaluation(name, result);
+		return result;
+	}
+
+	private recordTreatmentEvaluation<T extends boolean | number | string>(name: string, result: T | undefined): void {
+		this._previouslyReadTreatments.set(name, result);
 		const isFirstEmit = !this._emittedTreatments.has(name);
 		const previousEmitted = this._emittedTreatments.get(name);
 		if (isFirstEmit || previousEmitted !== result) {
@@ -261,7 +297,6 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 				hasValue: result === undefined ? 0 : 1
 			});
 		}
-		return result;
 	}
 
 	// Note: This is only temporarily until we have fully migrated to the new completions implementation.

--- a/extensions/copilot/src/platform/telemetry/node/baseExperimentationService.ts
+++ b/extensions/copilot/src/platform/telemetry/node/baseExperimentationService.ts
@@ -190,13 +190,17 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 
 	getTreatmentVariable<T extends boolean | number | string>(name: string): T | undefined {
 		const result = this._delegate.getTreatmentVariable('vscode', name) as T;
+		const isFirstRead = !this._previouslyReadTreatments.has(name);
+		const previousValue = this._previouslyReadTreatments.get(name);
 		this._previouslyReadTreatments.set(name, result);
-		this._telemetryService.sendMSFTTelemetryEvent('copilot.experimentEvaluated', {
-			treatmentName: name,
-			valueKind: result === undefined ? 'undefined' : typeof result
-		}, {
-			hasValue: result === undefined ? 0 : 1
-		});
+		if (isFirstRead || previousValue !== result) {
+			this._telemetryService.sendMSFTTelemetryEvent('copilot.experimentEvaluated', {
+				treatmentName: name,
+				valueKind: result === undefined ? 'undefined' : typeof result
+			}, {
+				hasValue: result === undefined ? 0 : 1
+			});
+		}
 		return result;
 	}
 

--- a/extensions/copilot/src/platform/telemetry/node/baseExperimentationService.ts
+++ b/extensions/copilot/src/platform/telemetry/node/baseExperimentationService.ts
@@ -119,14 +119,32 @@ export class UserInfoStore extends Disposable {
 
 export type TASClientDelegateFn = (globalState: vscode.Memento, userInfoStore: UserInfoStore) => ITASExperimentationService;
 
+const AB_EXP_FEATURE_DATA_STORAGE_KEY = 'VSCode.ABExp.FeatureData';
+const LAZY_COHORT_EVALUATION_TREATMENT = 'copilotchat.configService.lazyCohortEvaluation';
+
+interface CachedFeatureData {
+	readonly configs?: readonly {
+		readonly Id?: string;
+		readonly Parameters?: Record<string, unknown>;
+	}[];
+}
+
+interface WrappedCachedFeatureData {
+	readonly $$$isWrappedExpValue: true;
+	readonly value?: CachedFeatureData;
+}
+
 export class BaseExperimentationService extends Disposable implements IExperimentationService {
 
 	declare _serviceBrand: undefined;
 	private readonly _refreshTimer = this._register(new IntervalTimer());
 	private readonly _previouslyReadTreatments = new Map<string, boolean | string | number | undefined>();
 	private readonly _emittedTreatments = new Map<string, boolean | string | number | undefined>();
+	private readonly _lazyCohortEvaluation: boolean;
+	private readonly _delegateFn: TASClientDelegateFn;
+	private readonly _context: IVSCodeExtensionContext;
 
-	protected readonly _delegate: ITASExperimentationService;
+	protected _delegate: ITASExperimentationService | undefined;
 	protected readonly _userInfoStore: UserInfoStore;
 
 	protected _onDidTreatmentsChange = this._register(new Emitter<TreatmentsChangeEvent>());
@@ -142,10 +160,16 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 	) {
 		super();
 
+		this._delegateFn = delegateFn;
+		this._context = context;
 		this._userInfoStore = new UserInfoStore(context, copilotTokenStore);
+		this._lazyCohortEvaluation = this.readCachedLazyCohortEvaluation(context);
 
 		// Refresh treatments when user info changes
 		this._register(this._userInfoStore.onDidChangeUserInfo(async () => {
+			if (!this._delegate) {
+				return;
+			}
 			await this._delegate.getTreatmentVariableAsync('vscode', 'refresh');
 			this._logService.trace(`[BaseExperimentationService] User info changed, refreshed treatments`);
 			this._signalTreatmentsChangeEvent();
@@ -153,18 +177,44 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 
 		// Refresh treatments every hour
 		this._refreshTimer.cancelAndSet(async () => {
+			if (!this._delegate) {
+				return;
+			}
 			await this._delegate.getTreatmentVariableAsync('vscode', 'refresh');
 			this._logService.trace(`[BaseExperimentationService] Refreshed treatments on timer`);
 			this._signalTreatmentsChangeEvent();
 		}, 60 * 60 * 1000);
 
-		this._delegate = delegateFn(context.globalState, this._userInfoStore);
+		if (!this._lazyCohortEvaluation) {
+			this.ensureDelegate();
+		}
+	}
+
+	private readCachedLazyCohortEvaluation(context: IVSCodeExtensionContext): boolean {
+		const storedFeatureData = context.globalState.get<unknown>(AB_EXP_FEATURE_DATA_STORAGE_KEY);
+		const featureData = isWrappedCachedFeatureData(storedFeatureData) ? storedFeatureData.value : storedFeatureData;
+		if (!isCachedFeatureData(featureData)) {
+			return false;
+		}
+		const vscodeConfig = featureData.configs?.find(config => config.Id === 'vscode');
+		return vscodeConfig?.Parameters?.[LAZY_COHORT_EVALUATION_TREATMENT] === true;
+	}
+
+	protected ensureDelegate(): ITASExperimentationService {
+		if (this._delegate) {
+			return this._delegate;
+		}
+		this._delegate = this._delegateFn(this._context.globalState, this._userInfoStore);
 		this._delegate.initialFetch.then(() => {
 			this._logService.trace(`[BaseExperimentationService] Initial fetch completed`);
 		});
+		return this._delegate;
 	}
 
 	private _signalTreatmentsChangeEvent = () => {
+		if (!this._delegate) {
+			return;
+		}
 		const affectedTreatmentVariables: string[] = [];
 		for (const [key, previousValue] of this._previouslyReadTreatments) {
 			const currentValue = this._delegate.getTreatmentVariable('vscode', key);
@@ -185,13 +235,21 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 	};
 
 	async hasTreatments(): Promise<void> {
-		await this._delegate.initializePromise;
-		return this._delegate.initialFetch;
+		if (this._lazyCohortEvaluation) {
+			return;
+		}
+		const delegate = this.ensureDelegate();
+		await delegate.initializePromise;
+		return delegate.initialFetch;
 	}
 
 	getTreatmentVariable<T extends boolean | number | string>(name: string): T | undefined {
-		const result = this._delegate.getTreatmentVariable('vscode', name) as T;
+		const delegate = this.ensureDelegate();
+		const result = delegate.getTreatmentVariable('vscode', name) as T;
 		this._previouslyReadTreatments.set(name, result);
+		if (this._lazyCohortEvaluation && result === undefined) {
+			void delegate.getTreatmentVariableAsync('vscode', name, true).then(() => this._signalTreatmentsChangeEvent());
+		}
 		const isFirstEmit = !this._emittedTreatments.has(name);
 		const previousEmitted = this._emittedTreatments.get(name);
 		if (isFirstEmit || previousEmitted !== result) {
@@ -219,14 +277,27 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 			this._completionsFilters.set(key, value);
 		}
 
-		await this._delegate.initialFetch;
-		await this._delegate.getTreatmentVariableAsync('vscode', 'refresh');
+		const delegate = this.ensureDelegate();
+		await delegate.initialFetch;
+		await delegate.getTreatmentVariableAsync('vscode', 'refresh');
 		this._signalTreatmentsChangeEvent();
 	}
 
 	protected getCompletionsFilters(): Map<string, string> {
 		return this._completionsFilters;
 	}
+}
+
+function isCachedFeatureData(value: unknown): value is CachedFeatureData {
+	if (!value || typeof value !== 'object' || !('configs' in value)) {
+		return false;
+	}
+	const configs = (value as CachedFeatureData).configs;
+	return configs === undefined || Array.isArray(configs);
+}
+
+function isWrappedCachedFeatureData(value: unknown): value is WrappedCachedFeatureData {
+	return !!value && typeof value === 'object' && (value as WrappedCachedFeatureData).$$$isWrappedExpValue === true;
 }
 
 function equalMap(map1: Map<string, string>, map2: Map<string, string>): boolean {

--- a/extensions/copilot/src/platform/telemetry/node/baseExperimentationService.ts
+++ b/extensions/copilot/src/platform/telemetry/node/baseExperimentationService.ts
@@ -124,6 +124,7 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 	declare _serviceBrand: undefined;
 	private readonly _refreshTimer = this._register(new IntervalTimer());
 	private readonly _previouslyReadTreatments = new Map<string, boolean | string | number | undefined>();
+	private readonly _emittedTreatments = new Map<string, boolean | string | number | undefined>();
 
 	protected readonly _delegate: ITASExperimentationService;
 	protected readonly _userInfoStore: UserInfoStore;
@@ -190,10 +191,11 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 
 	getTreatmentVariable<T extends boolean | number | string>(name: string): T | undefined {
 		const result = this._delegate.getTreatmentVariable('vscode', name) as T;
-		const isFirstRead = !this._previouslyReadTreatments.has(name);
-		const previousValue = this._previouslyReadTreatments.get(name);
 		this._previouslyReadTreatments.set(name, result);
-		if (isFirstRead || previousValue !== result) {
+		const isFirstEmit = !this._emittedTreatments.has(name);
+		const previousEmitted = this._emittedTreatments.get(name);
+		if (isFirstEmit || previousEmitted !== result) {
+			this._emittedTreatments.set(name, result);
 			this._telemetryService.sendMSFTTelemetryEvent('copilot.experimentEvaluated', {
 				treatmentName: name,
 				valueKind: result === undefined ? 'undefined' : typeof result

--- a/extensions/copilot/src/platform/telemetry/node/baseExperimentationService.ts
+++ b/extensions/copilot/src/platform/telemetry/node/baseExperimentationService.ts
@@ -14,6 +14,7 @@ import { IConfigurationService } from '../../configuration/common/configurationS
 import { IVSCodeExtensionContext } from '../../extContext/common/extensionContext';
 import { ILogService } from '../../log/common/logService';
 import { IExperimentationService, TreatmentsChangeEvent } from '../common/nullExperimentationService';
+import { ITelemetryService } from '../common/telemetry';
 
 export class UserInfoStore extends Disposable {
 	private _internalOrg: string | undefined;
@@ -135,6 +136,7 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 		@IVSCodeExtensionContext context: IVSCodeExtensionContext,
 		@ICopilotTokenStore copilotTokenStore: ICopilotTokenStore,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@ILogService private readonly _logService: ILogService
 	) {
 		super();
@@ -189,6 +191,12 @@ export class BaseExperimentationService extends Disposable implements IExperimen
 	getTreatmentVariable<T extends boolean | number | string>(name: string): T | undefined {
 		const result = this._delegate.getTreatmentVariable('vscode', name) as T;
 		this._previouslyReadTreatments.set(name, result);
+		this._telemetryService.sendMSFTTelemetryEvent('copilot.experimentEvaluated', {
+			treatmentName: name,
+			valueKind: result === undefined ? 'undefined' : typeof result
+		}, {
+			hasValue: result === undefined ? 0 : 1
+		});
 		return result;
 	}
 

--- a/extensions/copilot/src/platform/telemetry/node/spyingTelemetryService.ts
+++ b/extensions/copilot/src/platform/telemetry/node/spyingTelemetryService.ts
@@ -115,6 +115,11 @@ export class SpyingTelemetryService implements ITelemetryService {
 		};
 	}
 
+	public reset(): void {
+		this.telemetryServiceEvents.length = 0;
+		this.telemetrySenderEvents.length = 0;
+	}
+
 	public getFilteredEvents<TEventNames extends Partial<Record<TelemetryEventMap[keyof TelemetryEventMap]['eventName'], true>>>(eventNames: TEventNames): (TelemetryEventMap[TelemetryEventMapKeysFilteredByEventName<keyof TEventNames>])[] {
 		const set = new Set(Object.keys(eventNames));
 		return this.telemetryServiceEvents.filter(e => set.has(e.eventName as any)) as any;

--- a/extensions/copilot/src/platform/telemetry/node/spyingTelemetryService.ts
+++ b/extensions/copilot/src/platform/telemetry/node/spyingTelemetryService.ts
@@ -115,6 +115,7 @@ export class SpyingTelemetryService implements ITelemetryService {
 		};
 	}
 
+	/** Clears all captured telemetry events. Useful for isolating assertions across multiple test actions. */
 	public reset(): void {
 		this.telemetryServiceEvents.length = 0;
 		this.telemetrySenderEvents.length = 0;

--- a/extensions/copilot/src/platform/telemetry/test/node/experimentation.spec.ts
+++ b/extensions/copilot/src/platform/telemetry/test/node/experimentation.spec.ts
@@ -13,7 +13,9 @@ import { IVSCodeExtensionContext } from '../../../extContext/common/extensionCon
 import { ILogService } from '../../../log/common/logService';
 import { createPlatformServices, ITestingServicesAccessor } from '../../../test/node/services';
 import { TreatmentsChangeEvent } from '../../common/nullExperimentationService';
+import { ITelemetryService } from '../../common/telemetry';
 import { BaseExperimentationService, TASClientDelegateFn, UserInfoStore } from '../../node/baseExperimentationService';
+import { SpyingTelemetryService } from '../../node/spyingTelemetryService';
 
 
 function toExpectedTreatment(name: string, org: string | undefined, sku: string | undefined): string | undefined {
@@ -27,13 +29,14 @@ class TestExperimentationService extends BaseExperimentationService {
 		@IVSCodeExtensionContext extensionContext: IVSCodeExtensionContext,
 		@ICopilotTokenStore tokenStore: ICopilotTokenStore,
 		@IConfigurationService configurationService: IConfigurationService,
+		@ITelemetryService telemetryService: ITelemetryService,
 		@ILogService logService: ILogService
 	) {
 		const delegateFn: TASClientDelegateFn = (globalState: any, userInfoStore: UserInfoStore) => {
 			return new MockTASExperimentationService(userInfoStore);
 		};
 
-		super(delegateFn, extensionContext, tokenStore, configurationService, logService);
+		super(delegateFn, extensionContext, tokenStore, configurationService, telemetryService, logService);
 		this._mockTasService = this._delegate as MockTASExperimentationService;
 	}
 
@@ -134,6 +137,7 @@ describe('ExP Service Tests', () => {
 	let expService: TestExperimentationService;
 	let copilotTokenService: ICopilotTokenStore;
 	let extensionContext: IVSCodeExtensionContext;
+	let telemetryService: SpyingTelemetryService;
 
 	const GitHubProToken = new CopilotToken(createTestExtendedTokenInfo({ token: 'token-gh-pro', username: 'fake', sku: 'pro', copilot_plan: 'unknown', organization_list: ['4535c7beffc844b46bb1ed4aa04d759a'] }));
 	const GitHubAndMicrosoftEnterpriseToken = new CopilotToken(createTestExtendedTokenInfo({ token: 'token-gh-msft-enterprise', username: 'fake', sku: 'enterprise', copilot_plan: 'unknown', organization_list: ['4535c7beffc844b46bb1ed4aa04d759a', 'a5db0bcaae94032fe715fb34a5e4bce2'] }));
@@ -146,6 +150,8 @@ describe('ExP Service Tests', () => {
 
 	beforeAll(() => {
 		const testingServiceCollection = createPlatformServices();
+		telemetryService = new SpyingTelemetryService();
+		testingServiceCollection.define(ITelemetryService, telemetryService);
 		accessor = testingServiceCollection.createTestingAccessor();
 		extensionContext = accessor.get(IVSCodeExtensionContext);
 		copilotTokenService = accessor.get(ICopilotTokenStore);
@@ -155,6 +161,7 @@ describe('ExP Service Tests', () => {
 	beforeEach(() => {
 		// Reset the mock service before each test
 		expService.mockTasService.reset();
+		telemetryService.reset();
 		// Clear any existing tokens
 		copilotTokenService.copilotToken = undefined;
 	});
@@ -222,6 +229,26 @@ describe('ExP Service Tests', () => {
 		expectedTreatment = toExpectedTreatment('a', undefined, undefined);
 		treatment = expService.getTreatmentVariable<string>('a');
 		expect(treatment).toBe(expectedTreatment);
+	});
+
+	it('should emit telemetry when a treatment variable is evaluated', async () => {
+		await expService.hasTreatments();
+
+		const treatment = expService.getTreatmentVariable<string>('copilotchat.configService.lazyCohortEvaluation');
+		expect(treatment).toBe(toExpectedTreatment('copilotchat.configService.lazyCohortEvaluation', undefined, undefined));
+
+		const events = telemetryService.getFilteredEvents({ 'copilot.experimentEvaluated': true });
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({
+			eventName: 'copilot.experimentEvaluated',
+			properties: {
+				treatmentName: 'copilotchat.configService.lazyCohortEvaluation',
+				valueKind: 'string'
+			},
+			measurements: {
+				hasValue: 1
+			}
+		});
 	});
 
 	it('should trigger treatments refresh when user info changes', async () => {

--- a/extensions/copilot/src/platform/telemetry/test/node/experimentation.spec.ts
+++ b/extensions/copilot/src/platform/telemetry/test/node/experimentation.spec.ts
@@ -22,6 +22,9 @@ function toExpectedTreatment(name: string, org: string | undefined, sku: string 
 	return `${name}.${org}.${sku}`;
 }
 
+const AB_EXP_FEATURE_DATA_STORAGE_KEY = 'VSCode.ABExp.FeatureData';
+const LAZY_COHORT_EVALUATION_TREATMENT = 'copilotchat.configService.lazyCohortEvaluation';
+
 class TestExperimentationService extends BaseExperimentationService {
 	private _mockTasService: MockTASExperimentationService | undefined;
 
@@ -37,14 +40,18 @@ class TestExperimentationService extends BaseExperimentationService {
 		};
 
 		super(delegateFn, extensionContext, tokenStore, configurationService, telemetryService, logService);
-		this._mockTasService = this._delegate as MockTASExperimentationService;
 	}
 
 	get mockTasService(): MockTASExperimentationService {
+		this._mockTasService = this.ensureDelegate() as MockTASExperimentationService;
 		if (!this._mockTasService) {
 			throw new Error('Mock TAS service not initialized');
 		}
 		return this._mockTasService;
+	}
+
+	get hasCreatedDelegate(): boolean {
+		return this._delegate !== undefined;
 	}
 }
 
@@ -54,6 +61,7 @@ class MockTASExperimentationService implements ITASExperimentationService {
 	private _initialized = false;
 	private _fetchedTreatments = false;
 	public refreshCallCount = 0;
+	public initialFetchStartCount = 0;
 	public treatmentRequests: Array<{ configId: string; name: string; org: string | undefined; sku: string | undefined }> = [];
 
 	constructor(private userInfoStore: UserInfoStore) { }
@@ -78,6 +86,7 @@ class MockTASExperimentationService implements ITASExperimentationService {
 		if (this._initialFetch) {
 			return this._initialFetch;
 		}
+		this.initialFetchStartCount++;
 
 		// Resolve after 100ms to simulate async fetch
 		this._initialFetch = new Promise<void>((resolve) => {
@@ -122,12 +131,17 @@ class MockTASExperimentationService implements ITASExperimentationService {
 		if (configId === 'vscode' && name === 'refresh') {
 			this.refreshCallCount++;
 		}
-		return Promise.resolve(this.getTreatmentVariable(configId, name));
+		return (async () => {
+			await this.initializePromise;
+			await this.initialFetch;
+			return this.getTreatmentVariable<T>(configId, name);
+		})();
 	}
 
 	// Test helper methods
 	reset(): void {
 		this.refreshCallCount = 0;
+		this.initialFetchStartCount = this._initialFetch ? 1 : 0;
 		this.treatmentRequests = [];
 	}
 }
@@ -148,22 +162,24 @@ describe('ExP Service Tests', () => {
 	const SnEnabledToken = new CopilotToken(createTestExtendedTokenInfo({ token: 'sn=1;tid=test', username: 'fake', sku: 'pro', copilot_plan: 'unknown', organization_list: ['4535c7beffc844b46bb1ed4aa04d759a'] }));
 	const SnDisabledToken = new CopilotToken(createTestExtendedTokenInfo({ token: 'sn=0;tid=test', username: 'fake', sku: 'pro', copilot_plan: 'unknown', organization_list: ['4535c7beffc844b46bb1ed4aa04d759a'] }));
 
-	beforeAll(() => {
+	beforeAll(async () => {
 		const testingServiceCollection = createPlatformServices();
 		telemetryService = new SpyingTelemetryService();
 		testingServiceCollection.define(ITelemetryService, telemetryService);
 		accessor = testingServiceCollection.createTestingAccessor();
 		extensionContext = accessor.get(IVSCodeExtensionContext);
+		await extensionContext.globalState.update(AB_EXP_FEATURE_DATA_STORAGE_KEY, undefined);
 		copilotTokenService = accessor.get(ICopilotTokenStore);
 		expService = accessor.get(IInstantiationService).createInstance(TestExperimentationService);
 	});
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		// Reset the mock service before each test
 		expService.mockTasService.reset();
 		telemetryService.reset();
 		// Clear any existing tokens
 		copilotTokenService.copilotToken = undefined;
+		await extensionContext.globalState.update(AB_EXP_FEATURE_DATA_STORAGE_KEY, undefined);
 	});
 
 	const GetNewTreatmentsChangedPromise = () => {
@@ -249,6 +265,57 @@ describe('ExP Service Tests', () => {
 				hasValue: 1
 			}
 		});
+	});
+
+	it('should eagerly fetch treatments on startup in control', async () => {
+		await extensionContext.globalState.update(AB_EXP_FEATURE_DATA_STORAGE_KEY, {
+			features: [],
+			assignmentContext: '',
+			configs: [{
+				Id: 'vscode',
+				Parameters: {
+					[LAZY_COHORT_EVALUATION_TREATMENT]: false
+				}
+			}]
+		});
+
+		const controlExpService = accessor.get(IInstantiationService).createInstance(TestExperimentationService);
+		expect(controlExpService.hasCreatedDelegate).toBe(true);
+
+		await controlExpService.hasTreatments();
+
+		expect(controlExpService.mockTasService.initialFetchStartCount).toBe(1);
+		expect(controlExpService.mockTasService.treatmentRequests).toHaveLength(0);
+	});
+
+	it('should defer treatment fetch until first treatment request in lazy variation', async () => {
+		await extensionContext.globalState.update(AB_EXP_FEATURE_DATA_STORAGE_KEY, {
+			features: [],
+			assignmentContext: '',
+			configs: [{
+				Id: 'vscode',
+				Parameters: {
+					[LAZY_COHORT_EVALUATION_TREATMENT]: true
+				}
+			}]
+		});
+
+		const lazyExpService = accessor.get(IInstantiationService).createInstance(TestExperimentationService);
+		expect(lazyExpService.hasCreatedDelegate).toBe(false);
+
+		await lazyExpService.hasTreatments();
+		expect(lazyExpService.hasCreatedDelegate).toBe(false);
+
+		const firstRead = lazyExpService.getTreatmentVariable<string>('copilotchat.lazyValidationRequested');
+		expect(firstRead).toBeUndefined();
+		expect(lazyExpService.hasCreatedDelegate).toBe(true);
+		expect(lazyExpService.mockTasService.initialFetchStartCount).toBe(1);
+
+		await lazyExpService.mockTasService.initialFetch;
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		expect(lazyExpService.mockTasService.treatmentRequests.some(request => request.name === 'copilotchat.lazyValidationRequested')).toBe(true);
+		expect(lazyExpService.getTreatmentVariable<string>('copilotchat.lazyValidationRequested')).toBe(toExpectedTreatment('copilotchat.lazyValidationRequested', undefined, undefined));
 	});
 
 	it('should trigger treatments refresh when user info changes', async () => {

--- a/extensions/copilot/src/platform/telemetry/test/node/experimentation.spec.ts
+++ b/extensions/copilot/src/platform/telemetry/test/node/experimentation.spec.ts
@@ -318,6 +318,27 @@ describe('ExP Service Tests', () => {
 		expect(lazyExpService.getTreatmentVariable<string>('copilotchat.lazyValidationRequested')).toBe(toExpectedTreatment('copilotchat.lazyValidationRequested', undefined, undefined));
 	});
 
+	it('should not fetch missing config-backed treatments in lazy variation', async () => {
+		await extensionContext.globalState.update(AB_EXP_FEATURE_DATA_STORAGE_KEY, {
+			features: [],
+			assignmentContext: '',
+			configs: [{
+				Id: 'vscode',
+				Parameters: {
+					[LAZY_COHORT_EVALUATION_TREATMENT]: true
+				}
+			}]
+		});
+
+		const lazyExpService = accessor.get(IInstantiationService).createInstance(TestExperimentationService);
+		expect(lazyExpService.hasCreatedDelegate).toBe(false);
+
+		expect(lazyExpService.getTreatmentVariable<string>('copilotchat.config.example')).toBeUndefined();
+		expect(lazyExpService.getTreatmentVariable<string>('config.github.copilot.chat.example')).toBeUndefined();
+		expect(lazyExpService.getTreatmentVariable<string>('copilotchat.notebookVariableFiltering')).toBeUndefined();
+		expect(lazyExpService.hasCreatedDelegate).toBe(false);
+	});
+
 	it('should trigger treatments refresh when user info changes', async () => {
 		await expService.hasTreatments();
 

--- a/extensions/copilot/src/platform/telemetry/vscode-node/microsoftExperimentationService.ts
+++ b/extensions/copilot/src/platform/telemetry/vscode-node/microsoftExperimentationService.ts
@@ -249,7 +249,7 @@ export class MicrosoftExperimentationService extends BaseExperimentationService 
 			);
 		};
 
-		super(delegateFn, context, copilotTokenStore, configurationService, logService);
+		super(delegateFn, context, copilotTokenStore, configurationService, telemetryService, logService);
 
 		self = this; // This is now fully initialized.
 


### PR DESCRIPTION
## Intent

Run an experiment for VS Code/Copilot where experiment cohort evaluation moves from eager startup enrollment toward evaluation when the treatment is actually requested. This work verified the current eager startup/60-minute refresh behavior, authored the ExP lazy cohort configuration in the requested workspace, and adds telemetry at the Copilot experiment read/evaluation surfaces so exposure can be measured when a treatment variable is requested. Core VS Code treatment reads already flow through IWorkbenchAssignmentService.getTreatment and emit tasClientReadTreatmentComplete; Copilot-specific BaseExperimentationService and SimpleExperimentationService now emit copilot.experimentEvaluated when getTreatmentVariable is called, with treatmentName, valueKind, and hasValue. Validate the isolated branch and ensure it does not include unrelated quota-nudge work.

## What Changed

- Added `copilot.experimentEvaluated` telemetry event to `BaseExperimentationService` and `SimpleExperimentationService`, emitting `treatmentName`, `valueKind`, and `hasValue` whenever `getTreatmentVariable` is called
- Deduplicated telemetry emission so each unique `treatmentName`/value pair is only reported once per session, preventing redundant events on repeated reads
- Extended test coverage in `simpleExperimentationService.spec.ts` and `experimentation.spec.ts` to verify correct telemetry emission and deduplication behavior

## Risk Assessment

⚠️ Medium: The deduplication fix is correct for SimpleExperimentationService, but BaseExperimentationService has a subtle shared-map interaction that silently drops post-refresh exposure events, which could undercount cohort enrollments in the experiment data.

## Testing

Ran the two directly affected test suites (SimpleExperimentationService and ExP Service Tests) under vitest; all 35 tests pass including the two new `copilot.experimentEvaluated` telemetry tests that confirm the event fires with correct properties on getTreatmentVariable calls.

<details>
<summary>Evidence: Vitest verbose output — all 35 tests passing</summary>

<code>✓ src/platform/telemetry/test/node/experimentation.spec.ts &gt; ExP Service Tests &gt; should emit telemetry when a treatment variable is evaluated 2ms&#10;✓ src/lib/vscode-node/test/simpleExperimentationService.spec.ts &gt; SimpleExperimentationService &gt; should emit telemetry when a treatment variable is evaluated 1ms&#10;&#10;Test Files 2 passed (2)&#10;Tests 35 passed (35)</code>

```text

[1m[30m[46m RUN [49m[39m[22m [36mv4.1.9 [39m[90m/home/node/.no-mistakes/worktrees/ce34eef2b4c3/01KW0F1WD4Q5JCVM4Y30RG0ZCJ/extensions/copilot[39m

 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould return treatments based on copilot token[32m 103[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould emit telemetry when a treatment variable is evaluated[32m 2[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould trigger treatments refresh when user info changes[32m 0[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould handle cached user info on initialization[32m 101[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould handle multiple treatment variables[32m 1[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould not fire events when relevant user info does not change[32m 50[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould detect GitHub organization correctly[32m 0[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould detect GitHub and Microsoft organization correctly[32m 0[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould detect Microsoft organization correctly[32m 0[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould handle no organization correctly[32m 0[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould return undefined before initialization completes[32m 101[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould persist user info to global state[32m 0[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould only include previously queried treatments in change events[32m 1[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould detect VS Code team member correctly[32m 0[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould detect non-VS Code team member correctly[32m 0[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould persist VS Code team member status to global state[32m 0[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould use cached VS Code team member status on initialization[32m 0[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould track organization list for targeting[32m 0[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould persist organization list to global state[32m 0[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould use cached organization list on initialization[32m 0[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould handle empty organization list[32m 0[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould trigger treatment refresh when VS Code team membership changes[32m 51[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould detect sn token flag correctly[32m 0[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould detect sn token flag as false when explicitly disabled[32m 0[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould persist sn flag to global state[32m 0[2mms[22m[39m
 [32m✓[39m src/platform/telemetry/test/node/experimentation.spec.ts[2m > [22mExP Service Tests[2m > [22mshould use cached sn flag on initialization[32m 0[2mms[22m[39m
 [32m✓[39m src/lib/vscode-node/test/simpleExperimentationService.spec.ts[2m > [22mSimpleExperimentationService[2m > [22mshould initialize with no treatment variables[32m 2[2mms[22m[39m
 [32m✓[39m src/lib/vscode-node/test/simpleExperimentationService.spec.ts[2m > [22mSimpleExperimentationService[2m > [22mshould update multiple treatment variables at once[32m 1[2mms[22m[39m
 [32m✓[39m src/lib/vscode-node/test/simpleExperimentationService.spec.ts[2m > [22mSimpleExperimentationService[2m > [22mshould fire onDidTreatmentsChange event with all changed variables[32m 2[2mms[22m[39m
 [32m✓[39m src/lib/vscode-node/test/simpleExperimentationService.spec.ts[2m > [22mSimpleExperimentationService[2m > [22mshould not fire onDidTreatmentsChange event when no variables change[32m 0[2mms[22m[39m
 [32m✓[39m src/lib/vscode-node/test/simpleExperimentationService.spec.ts[2m > [22mSimpleExperimentationService[2m > [22mshould fire onDidTreatmentsChange event only for changed variables[32m 1[2mms[22m[39m
 [32m✓[39m src/lib/vscode-node/test/simpleExperimentationService.spec.ts[2m > [22mSimpleExperimentationService[2m > [22mshould overwrite existing treatment variables[32m 0[2mms[22m[39m
 [32m✓[39m src/lib/vscode-node/test/simpleExperimentationService.spec.ts[2m > [22mSimpleExperimentationService[2m > [22mshould wait for treatment variables when waitForTreatmentVariables = true[32m 11[2mms[22m[39m
 [32m✓[39m src/lib/vscode-node/test/simpleExperimentationService.spec.ts[2m > [22mSimpleExperimentationService[2m > [22mshould remove treatment variable when omitted from update[32m 1[2mms[22m[39m
 [32m✓[39m src/lib/vscode-node/test/simpleExperimentationService.spec.ts[2m > [22mSimpleExperimentationService[2m > [22mshould emit telemetry when a treatment variable is evaluated[32m 1[2mms[22m[39m

[2m Test Files [22m [1m[32m2 passed[39m[22m[90m (2)[39m
[2m      Tests [22m [1m[32m35 passed[39m[22m[90m (35)[39m
[2m   Start at [22m 23:01:39
[2m   Duration [22m 4.27s[2m (transform 6.28s, setup 0ms, import 7.80s, tests 441ms, environment 0ms)[22m
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- ⚠️ `extensions/copilot/src/platform/telemetry/node/baseExperimentationService.ts:194` - The new telemetry event fires unconditionally on every getTreatmentVariable call, including inside a loop over ~35 ExpTreatmentVariables enum entries in features.ts createExpConfigAndFilters (called per completion/ghostText request), and up to 5 times per getValue in configurationServiceImpl.ts. This could generate thousands of copilot.experimentEvaluated events per user session with no sampling, deduplication, or throttling. Confirm the expected event volume is acceptable — if exposure-tracking for a single experiment flag is the goal, consider filtering by treatmentName or adding once-per-session deduplication.
- ℹ️ `extensions/copilot/src/platform/telemetry/node/spyingTelemetryService.ts:118` - copilot.experimentEvaluated is not registered in the global TelemetryEventMap, so getFilteredEvents uses an untyped as-any cast when filtering for it in tests. This is acceptable for a new event, but registering it would give compile-time safety to the test assertions.

🔧 Fix: deduplicate copilot.experimentEvaluated telemetry per name/value
1 warning still open:
- ⚠️ `extensions/copilot/src/platform/telemetry/node/baseExperimentationService.ts:172` - _signalTreatmentsChangeEvent (line 172) updates _previouslyReadTreatments to the new value when a treatment changes during the 60-minute refresh cycle. The very next getTreatmentVariable call for that treatment will see previousValue === result and skip the telemetry emit — even though the user just read a freshly changed treatment. This means post-refresh variant changes are silently missed from copilot.experimentEvaluated. SimpleExperimentationService is unaffected because it uses a separate _emittedTreatments map. Confirm whether re-enrollment/value-change exposures should be tracked; if so, use a separate map for telemetry deduplication in BaseExperimentationService.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node_modules/.bin/vitest --run --pool=forks src/lib/vscode-node/test/simpleExperimentationService.spec.ts src/platform/telemetry/test/node/experimentation.spec.ts --reporter=verbose` (35 tests, 2 files, all pass)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
