### PR TITLE
[Test] OSS check - missing license coverage (expected FAIL)

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "detect-libc": "^2.1.2",
     "http-proxy-agent": "^7.0.0",
     "https-proxy-agent": "^7.0.2",
+    "oss-check-fixture-nolicense": "1.0.0",
     "jschardet": "3.1.4",
     "katex": "^0.16.22",
     "kerberos": "2.1.1",


### PR DESCRIPTION
AI Assisted Test PR - DO NOT MERGE

Validates the PR-time OSS license check (vscode-engineering #3139).

Scenario: adds oss-check-fixture-nolicense@1.0.0 - a package with no ClearlyDefined coverage and no LICENSE - and no cglicenses override.

Expected: check FAILS with a clear message to add a cglicenses.json override.

Draft test fixture. Will be closed after the check is verified.