### PR TITLE
[Test] OSS check - stale override warning (expected PASS+warn)

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
     "detect-libc": "^2.1.2",
     "http-proxy-agent": "^7.0.0",
     "https-proxy-agent": "^7.0.2",
-    "jschardet": "3.1.4",
     "katex": "^0.16.22",
     "kerberos": "2.1.1",
     "minimist": "^1.2.8",


### PR DESCRIPTION
AI Assisted Test PR - DO NOT MERGE

Validates the PR-time OSS license check (vscode-engineering #3139).

Scenario: removes jschardet (which has a cglicenses override) from the root package.json.

Expected: check PASSES but emits a stale-override warning noting the override may now be unused (authoritative removal is enforced by the build-time TPN step).

Draft test fixture. Will be closed after the check is verified.