### PR TITLE
[Test] OSS check - distro hash bump only (expected PASS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.127.0",
-  "distro": "7abf39b86c07d094722a4b3ec9f37e78fe3d5db3",
+  "distro": "0000000000000000000000000000000000000000",
   "author": {
     "name": "Microsoft Corporation"
   },


### PR DESCRIPTION
AI Assisted Test PR - DO NOT MERGE

Validates the PR-time OSS license check (vscode-engineering #3139).

Scenario: changes only the distro hash in package.json - no dependency added or removed.

Expected: check PASSES (it only gates dependency changes; a package.json edit that does not alter deps is a no-op).

Draft test fixture. Will be closed after the check is verified.