### PR TITLE
Add 'credit' based description text for config `github.copilot.config.chat.agent.modelDetails.enabled`

### DIFF
--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -425,7 +425,7 @@
 	"github.copilot.config.cli.showExternalSessions": "Show sessions created by other applications.",
 	"github.copilot.config.cli.planExitMode.enabled": "Enable Plan Mode exit handling in Copilot CLI.",
 	"github.copilot.config.cli.autoModel.enabled": "Enable the Auto model option in Copilot CLI, which automatically selects the best model for each request. Requires VS Code reload.",
-	"github.copilot.config.chat.agent.modelDetails.enabled": "Show model details (model name and request multiplier) on agent chat responses when using Copilot CLI or Claude agent in VS Code. Requires VS Code reload to update already loaded sessions.",
+	"github.copilot.config.chat.agent.modelDetails.enabled": "Show model details (model name and credits used/request multiplier) on agent chat responses when using Copilot CLI or Claude agent in VS Code. Requires VS Code reload to update already loaded sessions.",
 	"github.copilot.config.cli.planCommand.enabled": "Enable the /plan command in Copilot CLI to create implementation plans before coding.",
 	"github.copilot.config.cli.lazyLoadSessionItem.enabled": "Enable lazy loading of session items in Copilot CLI. Requires VS Code reload.",
 	"github.copilot.config.cli.aiGenerateBranchNames.enabled": "Enable AI-generated branch names in Copilot CLI.",

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -425,7 +425,7 @@
 	"github.copilot.config.cli.showExternalSessions": "Show sessions created by other applications.",
 	"github.copilot.config.cli.planExitMode.enabled": "Enable Plan Mode exit handling in Copilot CLI.",
 	"github.copilot.config.cli.autoModel.enabled": "Enable the Auto model option in Copilot CLI, which automatically selects the best model for each request. Requires VS Code reload.",
-	"github.copilot.config.chat.agent.modelDetails.enabled": "Show model details (model name and credits used/request multiplier) on agent chat responses when using Copilot CLI or Claude agent in VS Code. Requires VS Code reload to update already loaded sessions.",
+	"github.copilot.config.chat.agent.modelDetails.enabled": "Show model details (model name and either credits used or request multiplier, when available) on agent chat responses when using Copilot CLI or Claude agent in VS Code. Requires VS Code reload to update already loaded sessions.",
 	"github.copilot.config.cli.planCommand.enabled": "Enable the /plan command in Copilot CLI to create implementation plans before coding.",
 	"github.copilot.config.cli.lazyLoadSessionItem.enabled": "Enable lazy loading of session items in Copilot CLI. Requires VS Code reload.",
 	"github.copilot.config.cli.aiGenerateBranchNames.enabled": "Enable AI-generated branch names in Copilot CLI.",


### PR DESCRIPTION
Fixes #323054

## Problem

The description for the config `github.copilot.config.chat.agent.modelDetails.enabled` does not mention anything about the credits, even when credits are displayed on screen.  It mentions only premium request multipliers, which may not be relevant for users in the credit model

## Fix

Edited the text to include credits also

## How to verify?

1. Open Settings
2. Search for github.copilot.config.chat.agent.modelDetails.enabled
3. See that the description mentions credits