### PR TITLE
Fix Open Host Settings command from the command palette

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSettings.contribution.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSettings.contribution.ts
@@ -13,6 +13,7 @@ import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { IEditorService } from '../../../../../workbench/services/editor/common/editorService.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../workbench/common/contributions.js';
 import { ISession } from '../../../../services/sessions/common/session.js';
+import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 import { SessionProviderIdContext } from '../../../../common/contextkeys.js';
 import { SessionItemContextMenuId } from '../../../sessions/browser/views/sessionsList.js';
 import { agentHostSettingsUri, AGENT_HOST_SETTINGS_SCHEME, AgentHostSettingsFileSystemProvider, AgentHostSettingsSchemaRegistrar } from './agentHostSettingsFileSystemProvider.js';
@@ -60,11 +61,13 @@ registerAction2(class OpenHostSettingsAction extends Action2 {
 				order: 2,
 				when: ContextKeyExpr.regex(SessionProviderIdContext.key, ANY_AGENT_HOST_PROVIDER_RE),
 			}],
+			precondition: ContextKeyExpr.regex(SessionProviderIdContext.key, ANY_AGENT_HOST_PROVIDER_RE),
 			f1: true
 		});
 	}
 	async run(accessor: ServicesAccessor, context?: ISession | ISession[]): Promise<void> {
-		const session = Array.isArray(context) ? context[0] : context;
+		const sessionsService = accessor.get(ISessionsService);
+		const session = (Array.isArray(context) ? context[0] : context) ?? sessionsService.activeSession.get();
 		if (!session) {
 			return;
 		}


### PR DESCRIPTION
Follow-up to #323044.

The "Open Host Settings" command only worked from the session context menu, which passes a session argument. When invoked from the Command Palette there was no argument, so `run` returned early and did nothing.

This PR:
- Falls back to the active session (`ISessionsService.activeSession`) when no context is passed, so the palette invocation opens host settings for the active session.
- Gates the command on the active session being an agent host provider via a `precondition`, so it is only enabled in the palette when relevant.

(Written by Copilot)