### PR TITLE
Define allowScripts in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17351,9 +17351,6 @@
         "nan": "^2.23.0"
       }
     },
-    "node_modules/ssh2/node_modules/cpu-features": {
-      "optional": true
-    },
     "node_modules/stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -284,5 +284,30 @@
   },
   "optionalDependencies": {
     "windows-foreground-love": "0.6.1"
+  },
+  "allowScripts": {
+    "@parcel/watcher": true,
+    "@playwright/browser-chromium": true,
+    "@vscode/deviceid": true,
+    "@vscode/native-watchdog": true,
+    "@vscode/policy-watcher": true,
+    "@vscode/ripgrep": true,
+    "@vscode/spdlog": true,
+    "@vscode/sqlite3": true,
+    "@vscode/windows-ca-certs": true,
+    "@vscode/windows-mutex": true,
+    "@vscode/windows-process-tree": true,
+    "@vscode/windows-registry": true,
+    "bufferutil": true,
+    "es5-ext": true,
+    "fsevents": true,
+    "husky": true,
+    "kerberos": true,
+    "native-is-elevated": true,
+    "native-keymap": true,
+    "node-pty": true,
+    "ssh2": true,
+    "utf-8-validate": true,
+    "windows-foreground-love": true
   }
 }

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -1614,9 +1614,6 @@
         "nan": "^2.23.0"
       }
     },
-    "node_modules/ssh2/node_modules/cpu-features": {
-      "optional": true
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",


### PR DESCRIPTION
Modern versions of npm (12) require you to define allowScripts to run dependencies’ install scripts. In npm 11 this can already be enabled, and is recommended.

VSCode relies on install scripts, so `allowScripts` must be defined to work with modern setups of npm.

The changes to `package-lock.json` are autogenerated. They appear unrelated. Possibly this removes remnants from an inproperly resolved merge conflict.