### PR TITLE
sessions: fix CI banner button border color

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -149,6 +149,8 @@ The chat view inside a session view is one of three kinds (`ChatViewKind` in [br
 
 Concrete implementations live under `contrib/chat/` and are obtained via `IChatViewFactory` so the `browser/` layer doesn't have to import contrib code.
 
+`ChatView` mounts session input banners directly above the chat input. The CI failures banner uses the orange accent for the card border/icon and for the primary Fix Checks button background/border.
+
 When a `ChatView` loads its chat model (`acquireOrLoadSession`), it surfaces progress on **its own** progress bar, pinned to the top of that grid leaf. This mirrors how each editor group owns its `ProgressBar` (see `EditorGroupView`): the bar is created by the leaf host `AbstractChatView`, wrapped in a `ScopedProgressIndicator` (reused from `vs/workbench`) with an always-active scope, and driven via `AbstractChatView.showProgressWhile(promise, delay)`. Concurrent loads in other visible sessions each show their own progress instead of competing for a single part-wide bar, and overlapping loads on the same leaf are joined by the indicator so the bar only hides once all have settled. A short delay avoids flashing the bar for fast (cached) loads.
 
 ### 4.2 Visibility Model

--- a/src/vs/sessions/contrib/sessionInputBanners/browser/sessionInputBannerWidget.ts
+++ b/src/vs/sessions/contrib/sessionInputBanners/browser/sessionInputBannerWidget.ts
@@ -71,9 +71,9 @@ export class SessionInputBannerWidget extends Disposable {
 			const button = this._register(new Button(actions, {
 				...defaultButtonStyles,
 				...(action.primary && banner.accent ? {
-					// Match the orange accent (border + icon) of the CI banner.
 					buttonBackground: asCssVariable(chartsOrange),
 					buttonHoverBackground: `color-mix(in srgb, ${asCssVariable(chartsOrange)} 88%, black)`,
+					buttonBorder: asCssVariable(chartsOrange),
 				} : {}),
 				...(action.primary ? {} : {
 					buttonBackground: undefined,


### PR DESCRIPTION
## Summary
- Set the accented CI input banner primary action border to the same orange token as its background.
- Document the CI input banner accent behavior in the sessions layout spec.

## Validation
- Not run, per request.