### PR TITLE
sessions: agent feedback gutter and scope fixes

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution.ts
@@ -12,8 +12,10 @@ import { ICodeEditorService } from '../../../../editor/browser/services/codeEdit
 import { EditorOption } from '../../../../editor/common/config/editorOptions.js';
 import { Position } from '../../../../editor/common/core/position.js';
 import { Range } from '../../../../editor/common/core/range.js';
-import { SelectionDirection } from '../../../../editor/common/core/selection.js';
+import { Selection, SelectionDirection } from '../../../../editor/common/core/selection.js';
 import { addStandardDisposableListener, getWindow, isHTMLElement, ModifierKeyEmitter } from '../../../../base/browser/dom.js';
+import { URI } from '../../../../base/common/uri.js';
+import { isEqual } from '../../../../base/common/resources.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { IAgentFeedbackService } from './agentFeedbackService.js';
 import { createAgentFeedbackContext } from './agentFeedbackEditorUtils.js';
@@ -238,10 +240,17 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 
 	static readonly ID = 'agentFeedback.editorInputContribution';
 
+	/**
+	 * Extra width (px) reserved in the line-decorations margin so the add glyph
+	 * has room to render fully, including its rounded background.
+	 */
+	private static readonly _RESERVED_GUTTER_WIDTH = 18;
+
 	private _widget: AgentFeedbackInputWidget | undefined;
 	private _visible = false;
 	private _mouseDown = false;
 	private _suppressSelectionChangeOnce = false;
+	private _reservedGutterSpace = false;
 	private _session: ISession | undefined;
 	private _pinnedRange: Range | undefined;
 	private _anchorPosition: Position | undefined;
@@ -287,11 +296,9 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 			if (this._isHoverGlyphTarget(e)) {
 				e.event.preventDefault();
 				e.event.stopPropagation();
-				this._mouseDown = true;
-				this._suppressSelectionChangeOnce = true;
 				const lineNumber = e.target.position?.lineNumber;
 				if (lineNumber !== undefined) {
-					this._showAtLine(lineNumber, true);
+					this._selectLine(lineNumber);
 				}
 				return;
 			}
@@ -368,11 +375,26 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 			return;
 		}
 
+		// Don't offer feedback on empty lines (nothing to comment on).
+		if (model.getLineFirstNonWhitespaceColumn(lineNumber) === 0) {
+			this._clearHoverGlyph();
+			return;
+		}
+
 		if (this._hoverLineNumber === lineNumber) {
 			return;
 		}
 
-		if (!this._getSessionForModel()) {
+		const session = this._getSessionForModel();
+		if (!session) {
+			this._clearHoverGlyph();
+			return;
+		}
+
+		// Don't render the add glyph on lines that already have a feedback
+		// comment, otherwise the add affordance overlaps the existing comment's
+		// gutter decoration and both become clickable on the same spot.
+		if (this._lineHasExistingFeedback(session, model.uri, lineNumber)) {
 			this._clearHoverGlyph();
 			return;
 		}
@@ -386,6 +408,13 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 				linesDecorationsClassName: `${agentFeedbackHoverGlyphClassName} line-hover`,
 			},
 		}]);
+	}
+
+	private _lineHasExistingFeedback(session: ISession, resourceUri: URI, lineNumber: number): boolean {
+		return this._agentFeedbackService.getFeedback(session.resource).some(feedback =>
+			isEqual(feedback.resourceUri, resourceUri)
+			&& lineNumber >= feedback.range.startLineNumber
+			&& lineNumber <= feedback.range.endLineNumber);
 	}
 
 	private _clearHoverGlyph(): void {
@@ -516,15 +545,63 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 		this._show(new Range(lineNumber, 1, lineNumber, model.getLineMaxColumn(lineNumber)), new Position(lineNumber, 1), true, focusInput);
 	}
 
+	/**
+	 * Select the whole line as a result of clicking the gutter glyph. Selecting
+	 * the line triggers the selection-change handler which opens the feedback
+	 * input automatically, so we don't open it directly here. Empty lines are
+	 * ignored as there is nothing to give feedback on.
+	 */
+	private _selectLine(lineNumber: number): void {
+		if (this._visible && this._hasInputText()) {
+			this.focusInput();
+			return;
+		}
+
+		const model = this._editor.getModel();
+		if (!model || lineNumber < 1 || lineNumber > model.getLineCount()) {
+			return;
+		}
+
+		if (model.getLineFirstNonWhitespaceColumn(lineNumber) === 0) {
+			return;
+		}
+
+		// Set the selection before focusing: the selection change while the
+		// editor is unfocused is ignored, then focusing re-evaluates the
+		// selection and opens the input for the freshly selected line.
+		this._editor.setSelection(new Selection(lineNumber, 1, lineNumber, model.getLineMaxColumn(lineNumber)));
+		this._editor.focus();
+	}
+
 	private _getSessionForModel(): ISession | undefined {
 		const model = this._editor.getModel();
 		if (!model || !this._contextKeyService.contextMatchesRules(ChatContextKeys.enabled)) {
 			this._hasAgentFeedbackSessionContext.set(false);
+			this._updateReservedGutterSpace(false);
 			return undefined;
 		}
 		const session = this._agentFeedbackService.getSessionForFile(model.uri);
 		this._hasAgentFeedbackSessionContext.set(!!session);
+		this._updateReservedGutterSpace(!!session);
 		return session;
+	}
+
+	/**
+	 * Reserve room in the line-decorations margin for the add glyph while the
+	 * editor shows a feedback-enabled file. Without this the glyph can be
+	 * clipped or fail to render where the gutter is tight (e.g. diff editors).
+	 * Mirrors how the comments feature reserves commenting-range space.
+	 */
+	private _updateReservedGutterSpace(hasSession: boolean): void {
+		if (hasSession === this._reservedGutterSpace) {
+			return;
+		}
+		this._reservedGutterSpace = hasSession;
+		const current = this._editor.getOption(EditorOption.lineDecorationsWidth);
+		const next = hasSession
+			? current + AgentFeedbackEditorInputContribution._RESERVED_GUTTER_WIDTH
+			: Math.max(0, current - AgentFeedbackEditorInputContribution._RESERVED_GUTTER_WIDTH);
+		this._editor.updateOptions({ lineDecorationsWidth: next });
 	}
 
 	/**
@@ -786,6 +863,7 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 	}
 
 	override dispose(): void {
+		this._updateReservedGutterSpace(false);
 		if (this._widget) {
 			this._editor.removeOverlayWidget(this._widget);
 			this._widget.dispose();

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
@@ -10,7 +10,8 @@ import { URI } from '../../../../base/common/uri.js';
 import { IRange } from '../../../../editor/common/core/range.js';
 import { createDecorator, IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
-import { isEqual } from '../../../../base/common/resources.js';
+import { isEqual, isEqualOrParent } from '../../../../base/common/resources.js';
+import { Schemas } from '../../../../base/common/network.js';
 import { IChatEditingService } from '../../../../workbench/contrib/chat/common/editing/chatEditingService.js';
 import { isIChatSessionFileChange2 } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
@@ -174,6 +175,8 @@ export interface IAgentFeedbackService {
 	 * Resolve the session that owns the given file resource. Returns the
 	 * session that was active when the file's editor was first opened; if the
 	 * file has never been tracked, falls back to the currently active session.
+	 * Returns `undefined` when the file is not in scope for the session (e.g.
+	 * the Output view or files outside the session's workspace folders).
 	 */
 	getSessionForFile(resourceUri: URI): ISession | undefined;
 
@@ -341,7 +344,41 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 		if (!session || session.status.get() === SessionStatus.Untitled) {
 			return undefined;
 		}
+		if (!this._isFileInSessionScope(session, resourceUri)) {
+			return undefined;
+		}
 		return session;
+	}
+
+	/**
+	 * Whether the given file belongs to the session and is therefore eligible
+	 * for agent feedback. This keeps the feedback affordances scoped to the
+	 * session's own files and excludes editors that merely happen to be open
+	 * while the session is active (e.g. user settings opened from the user
+	 * data directory, or the Output view which is not backed by a real file).
+	 */
+	private _isFileInSessionScope(session: ISession, resourceUri: URI): boolean {
+		// The Output view renders into a code editor but is not a real file the
+		// user can give feedback on, so always exclude it.
+		if (resourceUri.scheme === Schemas.outputChannel) {
+			return false;
+		}
+
+		// Files that are part of the session's changes are always in scope,
+		// regardless of where they live on disk.
+		if (session.changes.get().some(change => changeMatchesResource(change, resourceUri))) {
+			return true;
+		}
+
+		// Otherwise the file must live within one of the session's workspace
+		// folders. When the session has no workspace information we cannot make
+		// that determination, so fall back to allowing the file.
+		const workspace = session.workspace.get();
+		if (!workspace) {
+			return true;
+		}
+		return workspace.folders.some(folder =>
+			isEqualOrParent(resourceUri, folder.root) || isEqualOrParent(resourceUri, folder.workingDirectory));
 	}
 
 	addFeedback(sessionResource: URI, resourceUri: URI, range: IRange, text: string, suggestion?: ICodeReviewSuggestion, context?: IAgentFeedbackContext, sourcePRReviewCommentId?: string, kind: AgentFeedbackKind = AgentFeedbackKind.UserReview, state: AgentFeedbackState = AgentFeedbackState.Accepted): IAgentFeedback {

--- a/src/vs/sessions/contrib/agentFeedback/browser/media/agentFeedbackEditorInput.css
+++ b/src/vs/sessions/contrib/agentFeedback/browser/media/agentFeedbackEditorInput.css
@@ -102,7 +102,8 @@
 	width: var(--vscode-spacing-size200);
 	left: calc(-1 * var(--vscode-spacing-size60));
 	z-index: 10;
-	color: var(--vscode-foreground);
+	color: var(--vscode-editorGutter-commentGlyphForeground, var(--vscode-foreground));
+	background-color: var(--vscode-editorGutter-commentRangeForeground);
 	text-align: center;
 	display: flex;
 	flex-direction: row;

--- a/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackService.test.ts
+++ b/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackService.test.ts
@@ -278,10 +278,16 @@ suite('AgentFeedbackService - getSessionForFile', () => {
 		return { input };
 	}
 
-	function makeSession(resource: URI, status: SessionStatus = SessionStatus.InProgress): ISession {
+	function makeSession(resource: URI, status: SessionStatus = SessionStatus.InProgress, options?: { folders?: URI[]; changes?: URI[] }): ISession {
+		const workspace = options?.folders
+			? { folders: options.folders.map(root => ({ root, workingDirectory: root })) }
+			: undefined;
+		const changes = (options?.changes ?? []).map(uri => ({ modifiedUri: uri, originalUri: uri }));
 		return {
 			resource,
 			status: observableValue<SessionStatus>('status', status),
+			workspace: observableValue('workspace', workspace),
+			changes: observableValue('changes', changes),
 		} as unknown as ISession;
 	}
 
@@ -402,6 +408,34 @@ suite('AgentFeedbackService - getSessionForFile', () => {
 		setActiveSession(undefined);
 
 		assert.strictEqual(service.getSessionForFile(fileA), undefined);
+	});
+
+	test('does not return a session for files outside the session workspace folders', () => {
+		const wsSession = makeSession(sessionS1, SessionStatus.InProgress, { folders: [URI.file('/workspace')] });
+		sessions.set(sessionS1.toString(), wsSession);
+		setActiveSession(wsSession);
+
+		// A user-data file outside the workspace is out of scope.
+		assert.strictEqual(service.getSessionForFile(URI.file('/home/user/settings.json')), undefined);
+		// A file inside the workspace folder is in scope.
+		assert.strictEqual(service.getSessionForFile(URI.file('/workspace/a.ts'))?.resource.toString(), sessionS1.toString());
+	});
+
+	test('returns a session for files that are part of its changes even outside the workspace', () => {
+		const changed = URI.file('/outside/changed.ts');
+		const wsSession = makeSession(sessionS1, SessionStatus.InProgress, { folders: [URI.file('/workspace')], changes: [changed] });
+		sessions.set(sessionS1.toString(), wsSession);
+		setActiveSession(wsSession);
+
+		assert.strictEqual(service.getSessionForFile(changed)?.resource.toString(), sessionS1.toString());
+	});
+
+	test('does not return a session for output view resources', () => {
+		const wsSession = makeSession(sessionS1, SessionStatus.InProgress, { folders: [URI.file('/workspace')] });
+		sessions.set(sessionS1.toString(), wsSession);
+		setActiveSession(wsSession);
+
+		assert.strictEqual(service.getSessionForFile(URI.from({ scheme: 'output', path: '/workspace/foo' })), undefined);
 	});
 });
 


### PR DESCRIPTION
Addresses feedback on the agent feedback affordances in the sessions window.

### Changes

**1. Gutter `+` click selects the line**
- Clicking the gutter `+` now selects the whole line, which triggers the existing selection-change flow that opens the feedback input automatically — we no longer open the input directly from the click.
- The `+` glyph is no longer shown on empty lines (nothing to comment on).

**2. Gutter space allocation, styling, and no double glyph**
- Reserve `lineDecorationsWidth` while a feedback-enabled file is shown (mirroring the comments feature) so the `+` glyph always has room to render fully — previously it could be clipped where the gutter is tight (e.g. diff editors). The reserved space is restored on dispose.
- The `+` glyph now has a background color and rounded corners using the same comment gutter colors.
- The hover `+` is no longer rendered on lines that already have a feedback comment, preventing two overlapping clickable actions in the same gutter spot.

**3. Restrict the feedback input to the session's own files**
- `getSessionForFile` now scopes results: the Output view (`output` scheme) is excluded, files that are part of the session's changes are allowed, and otherwise the file must live within one of the session's workspace folders. This prevents the input from appearing for unrelated editors such as user settings opened from the user data directory. Falls back to allowing when the session has no workspace info.

### Tests
- Updated `agentFeedbackService.test.ts` with `workspace`/`changes` observables and added tests for in/out-of-workspace files, change files outside the workspace, and Output view resources.
