### PR TITLE
Open created/added-only file edits in a normal editor, not a diff (fixes #322682)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatEditPillElement.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatEditPillElement.ts
@@ -14,7 +14,7 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
 import { getIconClasses } from '../../../../../../editor/common/services/getIconClasses.js';
 import { IModelService } from '../../../../../../editor/common/services/model.js';
-import { ITextModelService } from '../../../../../../editor/common/services/resolverService.js';
+import type { ITextModelService } from '../../../../../../editor/common/services/resolverService.js';
 import { FileKind } from '../../../../../../platform/files/common/files.js';
 import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatEditPillElement.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatEditPillElement.ts
@@ -14,6 +14,7 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
 import { getIconClasses } from '../../../../../../editor/common/services/getIconClasses.js';
 import { IModelService } from '../../../../../../editor/common/services/model.js';
+import { ITextModelService } from '../../../../../../editor/common/services/resolverService.js';
 import { FileKind } from '../../../../../../platform/files/common/files.js';
 import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
@@ -198,5 +199,27 @@ export class ChatEditPillElement extends Disposable {
 				persistence: { hideOnKeyDown: true },
 			}));
 		}
+	}
+}
+
+/**
+ * Resolves the given resource and reports whether it has no content, which is
+ * the case when a file was newly created or was empty before an edit.
+ *
+ * The pill consumers use this to decide whether opening a diff editor is
+ * meaningful: a pure addition into an empty (or non-existent) original has
+ * nothing to diff against, so the resulting file should open in a normal
+ * editor instead.
+ */
+export async function isResourceContentEmpty(textModelService: ITextModelService, uri: URI): Promise<boolean> {
+	try {
+		const ref = await textModelService.createModelReference(uri);
+		try {
+			return ref.object.textEditorModel.getValueLength() === 0;
+		} finally {
+			ref.dispose();
+		}
+	} catch {
+		return false;
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatExternalEditContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatExternalEditContentPart.ts
@@ -10,6 +10,7 @@ import { isEqual } from '../../../../../../base/common/resources.js';
 import { localize } from '../../../../../../nls.js';
 import { ILanguageService } from '../../../../../../editor/common/languages/language.js';
 import { IModelService } from '../../../../../../editor/common/services/model.js';
+import { ITextModelService } from '../../../../../../editor/common/services/resolverService.js';
 import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { IOpenEditorOptions } from '../../../../../../platform/editor/browser/editor.js';
@@ -18,7 +19,7 @@ import { IChatExternalEdit } from '../../../common/chatService/chatService.js';
 import { IEditSessionDiffStats } from '../../../common/editing/chatEditingService.js';
 import { IChatRendererContent } from '../../../common/model/chatViewModel.js';
 import { ChatTreeItem } from '../../chat.js';
-import { ChatEditPillElement } from './chatEditPillElement.js';
+import { ChatEditPillElement, isResourceContentEmpty } from './chatEditPillElement.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
 
 /**
@@ -33,7 +34,9 @@ import { IChatContentPart, IChatContentPartRenderContext } from './chatContentPa
  *
  * Activation (click / Enter) opens the side-by-side diff editor when both
  * `beforeContentUri` and `afterContentUri` are present, falling back to
- * opening the resulting file otherwise.
+ * opening the resulting file otherwise. A pure addition into an empty (or
+ * non-existent) original is treated as the fallback case, since there is
+ * nothing meaningful to diff against.
  */
 export class ChatExternalEditContentPart extends ChatEditPillElement implements IChatContentPart {
 
@@ -59,6 +62,7 @@ export class ChatExternalEditContentPart extends ChatEditPillElement implements 
 		@ILanguageService languageService: ILanguageService,
 		@IHoverService hoverService: IHoverService,
 		@IEditorService private readonly editorService: IEditorService,
+		@ITextModelService private readonly textModelService: ITextModelService,
 	) {
 		super(labelService, modelService, languageService, hoverService);
 
@@ -103,9 +107,16 @@ export class ChatExternalEditContentPart extends ChatEditPillElement implements 
 		}
 	}
 
-	private openEdit({ editorOptions: options, openToSide }: IOpenEditorOptions): void {
+	private async openEdit({ editorOptions: options, openToSide }: IOpenEditorOptions): Promise<void> {
 		const group = openToSide ? SIDE_GROUP : undefined;
 		if (this.edit.beforeContentUri && this.edit.afterContentUri) {
+			// If the change is a pure addition into a file whose original version did not
+			// exist or was empty, there is nothing meaningful to diff against. Open the
+			// resulting file in a normal editor instead of a diff editor.
+			if (this.edit.editKind === 'edit' && (this.edit.diff?.removed ?? 0) === 0 && await isResourceContentEmpty(this.textModelService, this.edit.beforeContentUri)) {
+				this.editorService.openEditor({ resource: this.edit.uri, options }, group);
+				return;
+			}
 			this.editorService.openEditor({
 				original: { resource: this.edit.beforeContentUri },
 				modified: { resource: this.edit.afterContentUri },

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
@@ -60,7 +60,7 @@ import './media/chatCodeBlockPill.css';
 import { IDisposableReference } from './chatCollections.js';
 import { EditorPool } from './chatContentCodePools.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
-import { ChatEditPillElement } from './chatEditPillElement.js';
+import { ChatEditPillElement, isResourceContentEmpty } from './chatEditPillElement.js';
 import { ChatExtensionsContentPart } from './chatExtensionsContentPart.js';
 import { ChatProgressSubPart } from './chatProgressContentPart.js';
 import { IncrementalDOMMorpher } from './chatIncrementalRendering/chatIncrementalRendering.js';
@@ -885,7 +885,7 @@ export class CollapsedCodeBlock extends ChatEditPillElement {
 			// If the change is a pure addition into a file whose original version did not
 			// exist or was empty, there is nothing meaningful to diff against. Open the
 			// file in a normal editor instead of a diff editor.
-			if (this.currentDiff.removed === 0 && await this.isOriginalEmpty(this.currentDiff.originalURI) && this.uri) {
+			if (this.currentDiff.removed === 0 && await isResourceContentEmpty(this.textModelService, this.currentDiff.originalURI) && this.uri) {
 				this.editorService.openEditor({ resource: this.uri, options }, group);
 				return;
 			}
@@ -896,23 +896,6 @@ export class CollapsedCodeBlock extends ChatEditPillElement {
 			}, group);
 		} else if (this.uri) {
 			this.editorService.openEditor({ resource: this.uri, options }, group);
-		}
-	}
-
-	/**
-	 * Resolves the original (pre-edit) snapshot and reports whether it had no
-	 * content, which is the case when the file was newly created or was empty.
-	 */
-	private async isOriginalEmpty(originalURI: URI): Promise<boolean> {
-		try {
-			const ref = await this.textModelService.createModelReference(originalURI);
-			try {
-				return ref.object.textEditorModel.getValueLength() === 0;
-			} finally {
-				ref.dispose();
-			}
-		} catch {
-			return false;
 		}
 	}
 


### PR DESCRIPTION
Fixes #322682

### Problem
A chat file edit pill that references a file change opened a **diff editor** even when the change was a pure addition into a newly created (empty) original — there is nothing meaningful to diff against. This already worked for the chat editing pipeline (`CollapsedCodeBlock`) and for `create` edits in the agent host pipeline, but **edited files that are only additions into an empty original** still opened in a diff editor.

### Fix
- Extracted the existing empty-origin check from `CollapsedCodeBlock` into a shared `isResourceContentEmpty` helper in `chatEditPillElement.ts`.
- Applied the same "pure addition into an empty/non-existent original ⇒ open the resulting file in a normal editor" logic to the agent host pill (`ChatExternalEditContentPart.openEdit`), gated to `editKind === 'edit'` so `rename` behavior is unchanged.

### Notes
- `create` edits already had no `beforeContentUri` and opened the file directly; `delete` is unaffected.
- `openEdit` is now async (fire-and-forget on click), matching the existing `CollapsedCodeBlock.showDiff` wiring.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>