### PR TITLE
chat: open additions-only edit pills in a normal editor instead of diff

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditing.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditing.ts
@@ -3,9 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { URI } from '../../../../../base/common/uri.js';
 import { isEqual } from '../../../../../base/common/resources.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { findDiffEditorContainingCodeEditor } from '../../../../../editor/browser/widget/diffEditor/commands.js';
+import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IModifiedFileEntry } from '../../common/editing/chatEditingService.js';
 
@@ -17,4 +19,26 @@ export function isTextDiffEditorForEntry(accessor: ServicesAccessor, entry: IMod
 	const originalModel = diffEditor.getOriginalEditor().getModel();
 	const modifiedModel = diffEditor.getModifiedEditor().getModel();
 	return isEqual(originalModel?.uri, entry.originalURI) && isEqual(modifiedModel?.uri, entry.modifiedURI);
+}
+
+/**
+ * A chat file-edit represents a "pure creation" when it only adds content (no
+ * deletions) and its original version did not exist or was empty. Such an edit
+ * has nothing meaningful to diff against, so the corresponding file-edit pill
+ * should open the file in a normal editor instead of a diff editor.
+ */
+export async function isChatEditPureCreation(textModelService: ITextModelService, originalURI: URI, removed: number): Promise<boolean> {
+	if (removed !== 0) {
+		return false;
+	}
+	try {
+		const ref = await textModelService.createModelReference(originalURI);
+		try {
+			return ref.object.textEditorModel.getValueLength() === 0;
+		} finally {
+			ref.dispose();
+		}
+	} catch {
+		return false;
+	}
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
@@ -54,6 +54,7 @@ import { IChatOutputRendererService, type RenderedOutputPart } from '../../chatO
 import { allowedChatMarkdownHtmlTags } from '../chatContentMarkdownRenderer.js';
 import { IMarkdownDiffBlockData, MarkdownDiffBlockPart, parseUnifiedDiff } from './chatDiffBlockPart.js';
 import { ChatEditingActionContext } from '../../chatEditing/chatEditingActions.js';
+import { isChatEditPureCreation } from '../../chatEditing/chatEditing.js';
 import { ChatMarkdownDecorationsRenderer } from './chatMarkdownDecorationsRenderer.js';
 import { CodeBlockPart, ICodeBlockData, ICodeBlockRenderOptions } from './codeBlockPart.js';
 import './media/chatCodeBlockPill.css';
@@ -885,7 +886,7 @@ export class CollapsedCodeBlock extends ChatEditPillElement {
 			// If the change is a pure addition into a file whose original version did not
 			// exist or was empty, there is nothing meaningful to diff against. Open the
 			// file in a normal editor instead of a diff editor.
-			if (this.currentDiff.removed === 0 && await this.isOriginalEmpty(this.currentDiff.originalURI) && this.uri) {
+			if (this.uri && await isChatEditPureCreation(this.textModelService, this.currentDiff.originalURI, this.currentDiff.removed)) {
 				this.editorService.openEditor({ resource: this.uri, options }, group);
 				return;
 			}
@@ -896,23 +897,6 @@ export class CollapsedCodeBlock extends ChatEditPillElement {
 			}, group);
 		} else if (this.uri) {
 			this.editorService.openEditor({ resource: this.uri, options }, group);
-		}
-	}
-
-	/**
-	 * Resolves the original (pre-edit) snapshot and reports whether it had no
-	 * content, which is the case when the file was newly created or was empty.
-	 */
-	private async isOriginalEmpty(originalURI: URI): Promise<boolean> {
-		try {
-			const ref = await this.textModelService.createModelReference(originalURI);
-			try {
-				return ref.object.textEditorModel.getValueLength() === 0;
-			} finally {
-				ref.dispose();
-			}
-		} catch {
-			return false;
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -106,6 +106,7 @@ import { ChatImplicitContexts } from '../../attachments/chatImplicitContext.js';
 import { ImplicitContextAttachmentWidget } from '../../attachments/implicitContextAttachment.js';
 import { IChatWidget, IChatWidgetViewModelChangeEvent, ISessionTypePickerDelegate, isIChatResourceViewContext, isIChatViewViewContext, IWorkspacePickerDelegate } from '../../chat.js';
 import { ChatEditingShowChangesAction, ViewPreviousEditsAction } from '../../chatEditing/chatEditingActions.js';
+import { isChatEditPureCreation } from '../../chatEditing/chatEditing.js';
 import { resizeImage } from '../../chatImageUtils.js';
 import { ChatSessionPickerActionItem, IChatSessionPickerDelegate } from '../../chatSessions/chatSessionPickerActionItem.js';
 import { AgentHostChatInputPicker, AgentHostChatInputPickerActionViewItem } from '../../agentSessions/agentHost/agentHostChatInputPicker.js';
@@ -4228,8 +4229,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 						return;
 					}
 
-					// If there's a originalUri, open as diff editor
-					if (originalUri) {
+					// If there's a originalUri, open as diff editor. The exception is a
+					// pure creation (only additions into an empty/non-existing original),
+					// which has nothing meaningful to diff against and opens normally.
+					if (originalUri && !await isChatEditPureCreation(this.textModelResolverService, originalUri, e.element.options?.diffMeta?.removed ?? 0)) {
 						await this.editorService.openEditor({
 							original: { resource: originalUri },
 							modified: { resource: modifiedFileUri },


### PR DESCRIPTION
Fixes #322682

## What

When a chat file-edit pill represents a pure addition (only additions, no deletions) into a file whose original version did not exist or was empty (i.e. the file was newly created), clicking the pill now opens the file in a **normal editor** instead of a **diff editor**.

## Why

PR #321776 fixed this for the markdown content pill (`CollapsedCodeBlock` in `chatMarkdownContentPart.ts`), but the agent-session working-set pill in `chatInputPart.ts` still opened a diff editor. Session file changes always pass an `originalUri`, so an additions-only edit whose origin side is empty was incorrectly opened as a diff against an empty document — the case reported in #322682 (a created markdown file opening in a diff editor).

## How

- Extracted the "pure creation" check into a shared helper `isChatEditPureCreation(textModelService, originalURI, removed)` in `chatEditing.ts`. It returns `true` only when `removed === 0` and the original model resolves to empty content; resolution failures fall back to `false` (open as diff), preserving existing behavior.
- Refactored `chatMarkdownContentPart.ts` to use the shared helper (removing the now-duplicated private `isOriginalEmpty`).
- Updated the working-set list `onDidOpen` handler in `chatInputPart.ts` to skip the diff editor for pure creations, falling through to the existing "open modified file normally" path. The deletion branch and live-edit entries (which only pass `originalUri` for deletions) are unaffected.

## Notes for reviewers

The new condition only changes behavior when a change has no deletions **and** a genuinely empty original — real edits against non-empty originals continue to open in the diff editor.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
