### PR TITLE
best-practices: discourage getComputedStyle

### DIFF
--- a/.github/instructions/best-practices.instructions.md
+++ b/.github/instructions/best-practices.instructions.md
@@ -24,6 +24,10 @@ applyTo: src/vs/**
 - Don't hardcode URI scheme strings like `'file'`, `'untitled'`, or `'vscode-remote'`. Use the `Schemas` constants from `vs/base/common/network.ts` (e.g. `Schemas.file`, `Schemas.untitled`, `Schemas.vscodeRemote`).
 - Don't compare URIs with `===` or `uri.toString()`. Use the comparison utilities from `vs/base/common/resources.ts`: `isEqual` for equality, `isEqualOrParent` for containment, and `getComparisonKey` when a URI is used as a map/set key. These handle path-case sensitivity and fragment/authority correctly. When you need explicit control over case sensitivity, use an `ExtUri` instance (`extUri`, `extUriIgnorePathCase`, or `extUriBiasedIgnorePathCase`) instead of the bound helpers.
 
+## Styling
+
+- Avoid `getComputedStyle`. If a style value is needed in both CSS and TypeScript, prefer hardcoding the value in TypeScript and setting it directly on the DOM element, or use `setProperty` on the DOM element with a CSS variable and the value when it's needed across multiple CSS rules.
+
 ## Editor Decorations
 
 - For editor highlights, use a regular editor decoration with an `inlineClassName` or `className` plus a CSS rule.

--- a/.github/instructions/best-practices.instructions.md
+++ b/.github/instructions/best-practices.instructions.md
@@ -26,7 +26,7 @@ applyTo: src/vs/**
 
 ## Styling
 
-- Avoid `getComputedStyle`. If a style value is needed in both CSS and TypeScript, prefer hardcoding the value in TypeScript and setting it directly on the DOM element, or use `setProperty` on the DOM element with a CSS variable and the value when it's needed across multiple CSS rules.
+- Avoid `getComputedStyle`. If a style value is needed in both CSS and TypeScript, prefer hardcoding the value in TypeScript and setting it directly on the DOM element (e.g. `element.style.width = '100px'`), or set a CSS custom property via `element.style.setProperty('--my-var', value)` when the value is needed across multiple CSS rules.
 
 ## Editor Decorations
 


### PR DESCRIPTION
Adds a Styling section to the best-practices instruction file discouraging the use of getComputedStyle. When a style value is needed in both CSS and TypeScript, prefer hardcoding it in TypeScript and setting it on the DOM element, or use setProperty with a CSS variable when the value is needed across multiple CSS rules.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>