### PR TITLE
sessions: attach feedback when addressing comments from input banner

### DIFF
--- a/src/vs/sessions/contrib/sessionInputBanners/browser/sessionInputBanners.ts
+++ b/src/vs/sessions/contrib/sessionInputBanners/browser/sessionInputBanners.ts
@@ -13,7 +13,6 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
-import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { SessionStatus } from '../../../services/sessions/common/session.js';
 import { IGitHubService } from '../../github/browser/githubService.js';
@@ -21,9 +20,6 @@ import { GitHubCheckStatus } from '../../github/common/types.js';
 import { FIX_CI_CHECKS_COMMAND_ID, getFailedChecks, REVEAL_CI_CHECKS_COMMAND_ID } from '../../changes/browser/checksActions.js';
 import { AgentFeedbackKind, AgentFeedbackState, IAgentFeedbackService } from '../../agentFeedback/browser/agentFeedbackService.js';
 import { ISessionInputBanner, SessionInputBannerWidget } from './sessionInputBannerWidget.js';
-
-/** Slash command run by the "Address comments" action. */
-const ACT_ON_FEEDBACK_QUERY = '/act-on-feedback';
 
 /** Persisted set of session ids whose CI banner the user dismissed. */
 const STORAGE_KEY_CI_DISMISSED = 'sessions.inputBanners.ci.dismissed';
@@ -137,7 +133,6 @@ export class SessionInputBanners extends Disposable {
 		@ISessionsService private readonly sessionsService: ISessionsService,
 		@IGitHubService private readonly gitHubService: IGitHubService,
 		@IAgentFeedbackService private readonly feedbackService: IAgentFeedbackService,
-		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IStorageService private readonly storageService: IStorageService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
@@ -224,7 +219,7 @@ export class SessionInputBanners extends Disposable {
 				{
 					label: localize('comments.address', "Address Comments"),
 					primary: true,
-					run: () => this._addressComments(state.sessionResource),
+					run: () => this._addressComments(state.sessionResource).catch(err => this.logService.error('[SessionInputBanners] Failed to address comments', err)),
 				},
 				{
 					label: localize('comments.reveal', "Reveal Comments"),
@@ -261,13 +256,22 @@ export class SessionInputBanners extends Disposable {
 		this.commandService.executeCommand(commandId).catch(err => this.logService.error('[SessionInputBanners] command failed', commandId, err));
 	}
 
-	private _addressComments(sessionResource: URI): void {
-		const widget = this.chatWidgetService.getWidgetBySessionResource(sessionResource);
-		if (!widget) {
-			this.logService.error('[SessionInputBanners] Cannot address comments: no chat widget for session', sessionResource.toString());
-			return;
+	private async _addressComments(sessionResource: URI): Promise<void> {
+		// Accept the reviewable comments surfaced in the banner so they become
+		// attachable feedback, then submit them to the agent. This mirrors the
+		// agent feedback editor overlay's Submit button: rather than sending a
+		// bare `/act-on-feedback` command, the accepted feedback items are
+		// attached to the request so the agent receives the comments.
+		const created = this.feedbackService.getFeedback(sessionResource)
+			.filter(item => item.state === AgentFeedbackState.Created && REVIEWABLE_KINDS.has(item.kind));
+		for (const item of created) {
+			this.feedbackService.acceptFeedback(sessionResource, item.id);
 		}
-		widget.acceptInput(ACT_ON_FEEDBACK_QUERY).catch(err => this.logService.error('[SessionInputBanners] Failed to send act-on-feedback', err));
+
+		const submitted = await this.feedbackService.submitFeedback(sessionResource);
+		if (!submitted) {
+			this.logService.error('[SessionInputBanners] Failed to submit feedback for session', sessionResource.toString());
+		}
 	}
 
 	private _revealComment(sessionResource: URI, commentId: string): void {


### PR DESCRIPTION
The agent feedback input banner''s **Address Comments** button now attaches the agent feedback to the chat request, matching the behavior of the **Submit** button in the agent feedback editor overlay.

## Problem
Previously, clicking **Address Comments** in the input banner sent a bare `/act-on-feedback` slash command to the chat widget without attaching any feedback items, so the agent received the command with no comment context.

## Change
`_addressComments` now:
1. Accepts the `Created` reviewable comments surfaced in the banner (transitioning them to `Accepted` so they become attachable).
2. Calls `agentFeedbackService.submitFeedback(sessionResource)`, which attaches the accepted feedback items to the `/act-on-feedback` request — exactly like the editor overlay''s Submit button.

The now-unused `IChatWidgetService` dependency, its import, and the `ACT_ON_FEEDBACK_QUERY` constant were removed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>