### PR TITLE
Add Adhoc Request Sender Mode with Tag Highlighting

### DIFF
--- a/extensions/copilot/.esbuild.mts
+++ b/extensions/copilot/.esbuild.mts
@@ -246,6 +246,7 @@ const nodeSimulationWorkbenchUIBuildOptions = {
 
 		// @ulugbekna: libs provided by node that need to be specified manually because of 'platform' is set to 'browser'
 		'fs',
+		'os',
 		'path',
 		'readline',
 		'child_process',

--- a/extensions/copilot/script/electron/simulationWorkbench.css
+++ b/extensions/copilot/script/electron/simulationWorkbench.css
@@ -193,6 +193,11 @@
 	box-shadow: 0 0 0 2pt #0000004b;
 }
 
+/* Only the focused adhoc editor should show a text caret. */
+.adhoc-request-editor .monaco-editor:not(.focused) .cursors-layer .cursor {
+	display: none !important;
+}
+
 .file-editor-draggable-border {
 	height: 5px;
 	width: 95%;

--- a/extensions/copilot/script/electron/simulationWorkbenchMain.js
+++ b/extensions/copilot/script/electron/simulationWorkbenchMain.js
@@ -33,6 +33,27 @@ function createWindow() {
 	});
 }
 
+/**
+ * Installs a standard application menu. This is required for the clipboard
+ * keyboard shortcuts (Cmd/Ctrl+C/V/X) to be delivered to the web contents -
+ * without an Edit menu containing the paste role, pasting into editors (e.g.
+ * the Monaco editors in the "Adhoc request sender" mode) does not work,
+ * especially on macOS.
+ */
+function setupApplicationMenu() {
+	/** @type {Electron.MenuItemConstructorOptions[]} */
+	const template = [];
+	if (process.platform === 'darwin') {
+		template.push({ role: 'appMenu' });
+	}
+	template.push({ role: 'fileMenu' });
+	template.push({ role: 'editMenu' });
+	template.push({ role: 'viewMenu' });
+	template.push({ role: 'windowMenu' });
+
+	electron.Menu.setApplicationMenu(electron.Menu.buildFromTemplate(template));
+}
+
 app.on('ready', () => {
 	if (process.argv.includes('--help')) {
 		console.log(`Options:
@@ -40,6 +61,7 @@ app.on('ready', () => {
   --grep=STRING      Pre-populates simulation workbench 'grep' input box.`);
 		app.quit();
 	}
+	setupApplicationMenu();
 	registerListeners();
 	createWindow();
 });

--- a/extensions/copilot/test/base/simulationOptions.ts
+++ b/extensions/copilot/test/base/simulationOptions.ts
@@ -110,6 +110,13 @@ export class SimulationOptions {
 
 	public readonly modelConfigFile: string | undefined;
 
+	/**
+	 * Path to a JSON file describing an adhoc chat request to send (used by the
+	 * simulation workbench "Adhoc request sender" mode). The file contains
+	 * `{ system: string; user: string; model: string }`.
+	 */
+	public readonly adhocRequestFile: string | undefined;
+
 	protected constructor(processArgv: readonly string[]) {
 		const argv = minimist(processArgv.slice(2));
 		this.argv = argv;
@@ -195,6 +202,7 @@ export class SimulationOptions {
 
 		this.configFile = argv['config-file'];
 		this.modelConfigFile = argv['model-config-file'];
+		this.adhocRequestFile = argv['adhoc-request-file'];
 	}
 
 	public printHelp(): void {

--- a/extensions/copilot/test/simulation/shared/sharedTypes.ts
+++ b/extensions/copilot/test/simulation/shared/sharedTypes.ts
@@ -274,6 +274,43 @@ export type Output = IDetectedTestOutput
 	| IDeviceCodeCallbackOutput
 	;
 
+/**
+ * Describes a single adhoc chat request sent from the simulation workbench
+ * "Adhoc request sender" mode. Serialized to a temp file and passed to the
+ * simulation CLI via `--adhoc-request-file`.
+ */
+export interface IAdhocRequest {
+	readonly system: string;
+	readonly user: string;
+	readonly model: string;
+}
+
+export enum AdhocResponseType {
+	/** A streamed chunk of the response text. */
+	delta = 'adhocResponseDelta',
+	/** The final, full response text. */
+	done = 'adhocResponseDone',
+	/** The request failed. */
+	error = 'adhocResponseError',
+}
+
+export interface IAdhocResponseDelta {
+	readonly type: AdhocResponseType.delta;
+	readonly value: string;
+}
+
+export interface IAdhocResponseDone {
+	readonly type: AdhocResponseType.done;
+	readonly value: string;
+}
+
+export interface IAdhocResponseError {
+	readonly type: AdhocResponseType.error;
+	readonly value: string;
+}
+
+export type AdhocResponseOutput = IAdhocResponseDelta | IAdhocResponseDone | IAdhocResponseError;
+
 export interface IRange {
 	readonly start: IPosition;
 	readonly end: IPosition;

--- a/extensions/copilot/test/simulation/workbench/components/adhocRequestEditor.tsx
+++ b/extensions/copilot/test/simulation/workbench/components/adhocRequestEditor.tsx
@@ -180,7 +180,6 @@ export const AdhocRequestEditor = (({ value, languageId, readOnly, initialHeight
 			}
 			myEditor.dispose();
 		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	React.useEffect(() => {

--- a/extensions/copilot/test/simulation/workbench/components/adhocRequestEditor.tsx
+++ b/extensions/copilot/test/simulation/workbench/components/adhocRequestEditor.tsx
@@ -1,0 +1,231 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { clipboard } from 'electron';
+import type * as monaco from 'monaco-editor';
+import * as React from 'react';
+import { monacoModule } from '../utils/utils';
+import { DraggableBottomBorder } from './draggableBottomBorder';
+
+/**
+ * Matches a prompt tag like `<|recently_viewed_code_snippets|>` or its closing
+ * form `<|/recently_viewed_code_snippets|>`. The capture group is the tag name
+ * without the leading slash, so an opening tag and its matching closing tag
+ * resolve to the same name (and therefore the same color).
+ */
+const TAG_REGEX = /<\|\/?([^|\n]+)\|>/g;
+
+// Distinct tag names are assigned a stable, ever-increasing index the first time
+// they are seen. The index drives the hue via the golden angle, which keeps
+// successive colors far apart so different tags get visually distinct colors
+// (and the same name always maps to the same color).
+const tagIndexByName = new Map<string, number>();
+const injectedTagIndices = new Set<number>();
+let tagStyleElement: HTMLStyleElement | undefined;
+
+const GOLDEN_ANGLE_DEGREES = 137.50776;
+
+/**
+ * Returns a CSS class that tints the background based on the tag name, lazily
+ * injecting the corresponding style rule. The tint uses low alpha so the tag
+ * text stays readable on both light and dark themes.
+ */
+function tagDecorationClassName(tagName: string): string {
+	let index = tagIndexByName.get(tagName);
+	if (index === undefined) {
+		index = tagIndexByName.size;
+		tagIndexByName.set(tagName, index);
+	}
+	const className = `adhoc-tag-hl-${index}`;
+	if (!injectedTagIndices.has(index)) {
+		injectedTagIndices.add(index);
+		if (!tagStyleElement) {
+			tagStyleElement = document.createElement('style');
+			document.head.appendChild(tagStyleElement);
+		}
+		const hue = Math.round((index * GOLDEN_ANGLE_DEGREES) % 360);
+		tagStyleElement.appendChild(document.createTextNode(
+			`.${className} { background-color: hsla(${hue}, 70%, 55%, 0.3); border-radius: 3px; }`
+		));
+	}
+	return className;
+}
+
+type Props = {
+	value: string;
+	languageId?: string;
+	readOnly?: boolean;
+	initialHeight?: number;
+	autoFocus?: boolean;
+	onChange?: (value: string) => void;
+};
+
+/**
+ * A simple Monaco-based editor that can be editable or read-only, used by the
+ * "Adhoc request sender" mode. Unlike {@link Editor}, it supports two-way
+ * binding via `value`/`onChange` and a fixed (resizable) height.
+ */
+export const AdhocRequestEditor = (({ value, languageId, readOnly, initialHeight, autoFocus, onChange }: Props) => {
+	const containerRef = React.useRef<HTMLDivElement | null>(null);
+	const [editor, setEditor] = React.useState<monaco.editor.IStandaloneCodeEditor | null>(null);
+	const [height, setHeight] = React.useState<number>(initialHeight ?? 160);
+	const [isFocused, setIsFocused] = React.useState(false);
+
+	// Keep the latest onChange in a ref so the model listener never goes stale.
+	const onChangeRef = React.useRef(onChange);
+	onChangeRef.current = onChange;
+
+	// Set while applying an external value so we don't echo it back through onChange.
+	const isApplyingExternalValueRef = React.useRef(false);
+
+	const monaco = monacoModule.value;
+
+	React.useEffect(() => {
+		if (!containerRef.current) {
+			return;
+		}
+		const myEditor = monaco.editor.create(containerRef.current, {
+			automaticLayout: true,
+			model: monaco.editor.createModel(value, languageId ?? 'plaintext'),
+			minimap: { enabled: false },
+			readOnly: readOnly ?? false,
+			scrollBeyondLastLine: false,
+			wordWrap: 'on',
+			lineNumbers: 'off',
+			folding: false,
+			overviewRulerLanes: 0,
+			padding: { top: 6, bottom: 6 },
+		});
+		setEditor(myEditor);
+
+		// Chromium blocks programmatic clipboard reads (`document.execCommand('paste')`),
+		// which is what Monaco's built-in Cmd/Ctrl+V keybinding uses, so paste silently
+		// fails inside the editor. Intercept the shortcut in the capture phase on the
+		// container (an ancestor of all Monaco DOM) - this runs before Monaco sees the
+		// keystroke - and paste from Electron's clipboard directly instead.
+		const container = containerRef.current;
+		const handlePasteShortcut = (e: KeyboardEvent) => {
+			const isPasteShortcut = (e.metaKey || e.ctrlKey) && !e.altKey && (e.code === 'KeyV' || e.key === 'v' || e.key === 'V');
+			if (!isPasteShortcut) {
+				return;
+			}
+			if (myEditor.getOption(monaco.editor.EditorOption.readOnly)) {
+				return;
+			}
+			const selections = myEditor.getSelections();
+			if (!selections || selections.length === 0) {
+				return;
+			}
+			e.preventDefault();
+			e.stopPropagation();
+			const text = clipboard.readText();
+			if (!text) {
+				return;
+			}
+			myEditor.pushUndoStop();
+			myEditor.executeEdits('electron-clipboard-paste', selections.map(selection => ({ range: selection, text, forceMoveMarkers: true })));
+			myEditor.pushUndoStop();
+		};
+		container.addEventListener('keydown', handlePasteShortcut, /* capture */ true);
+
+		// Track focus so the focused editor can show a blue halo.
+		const focusListener = myEditor.onDidFocusEditorText(() => setIsFocused(true));
+		const blurListener = myEditor.onDidBlurEditorText(() => setIsFocused(false));
+
+		// Highlight prompt tags like `<|name|>` / `<|/name|>`, coloring by tag name.
+		const tagDecorations = myEditor.createDecorationsCollection();
+		const updateTagDecorations = () => {
+			const model = myEditor.getModel();
+			if (!model) {
+				return;
+			}
+			const text = model.getValue();
+			const decorations: monaco.editor.IModelDeltaDecoration[] = [];
+			TAG_REGEX.lastIndex = 0;
+			let match: RegExpExecArray | null;
+			while ((match = TAG_REGEX.exec(text)) !== null) {
+				const start = model.getPositionAt(match.index);
+				const end = model.getPositionAt(match.index + match[0].length);
+				decorations.push({
+					range: new monaco.Range(start.lineNumber, start.column, end.lineNumber, end.column),
+					options: { inlineClassName: tagDecorationClassName(match[1]) },
+				});
+			}
+			tagDecorations.set(decorations);
+		};
+		updateTagDecorations();
+
+		const listener = myEditor.onDidChangeModelContent(() => {
+			updateTagDecorations();
+			if (isApplyingExternalValueRef.current) {
+				return;
+			}
+			onChangeRef.current?.(myEditor.getValue());
+		});
+
+		if (autoFocus) {
+			myEditor.focus();
+		}
+
+		return () => {
+			container.removeEventListener('keydown', handlePasteShortcut, /* capture */ true);
+			focusListener.dispose();
+			blurListener.dispose();
+			listener.dispose();
+			const model = myEditor.getModel();
+			if (model) {
+				model.dispose();
+			}
+			myEditor.dispose();
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	React.useEffect(() => {
+		if (!editor) {
+			return;
+		}
+		const model = editor.getModel();
+		if (!model) {
+			return;
+		}
+		if (languageId && model.getLanguageId() !== languageId) {
+			monaco.editor.setModelLanguage(model, languageId);
+		}
+		if (model.getValue() !== value) {
+			isApplyingExternalValueRef.current = true;
+			try {
+				if (readOnly) {
+					model.setValue(value);
+					// Keep the response editor scrolled to the latest streamed content.
+					editor.revealLine(model.getLineCount(), monaco.editor.ScrollType.Immediate);
+				} else {
+					// Preserve undo stack / cursor for editable editors.
+					editor.executeEdits('external', [{ range: model.getFullModelRange(), text: value }]);
+				}
+			} finally {
+				isApplyingExternalValueRef.current = false;
+			}
+		}
+	}, [editor, value, languageId, readOnly]);
+
+	return (
+		<div>
+			<div
+				className='file-editor-container adhoc-request-editor'
+				style={{
+					height: `${height}px`,
+					position: 'relative',
+					// Show a blue halo around the editor that currently has focus.
+					// When unfocused, fall back to the default ring from the CSS class.
+					boxShadow: isFocused ? '0 0 0 2px #0078d4, 0 0 6px 2px rgba(0, 120, 212, 0.45)' : undefined,
+					transition: 'box-shadow 0.1s ease-in-out',
+				}}
+				ref={containerRef}
+			/>
+			<DraggableBottomBorder height={height} setHeight={setHeight} />
+		</div>
+	);
+});

--- a/extensions/copilot/test/simulation/workbench/components/adhocRequestEditor.tsx
+++ b/extensions/copilot/test/simulation/workbench/components/adhocRequestEditor.tsx
@@ -155,10 +155,23 @@ export const AdhocRequestEditor = (({ value, languageId, readOnly, initialHeight
 			}
 			tagDecorations.set(decorations);
 		};
+		// Coalesce rescans across bursts of content changes (e.g. a streamed
+		// response) into at most one per frame, so we don't re-scan the whole
+		// document on every keystroke/delta.
+		let pendingTagDecorationsFrame: number | undefined;
+		const scheduleTagDecorationsUpdate = () => {
+			if (pendingTagDecorationsFrame !== undefined) {
+				return;
+			}
+			pendingTagDecorationsFrame = requestAnimationFrame(() => {
+				pendingTagDecorationsFrame = undefined;
+				updateTagDecorations();
+			});
+		};
 		updateTagDecorations();
 
 		const listener = myEditor.onDidChangeModelContent(() => {
-			updateTagDecorations();
+			scheduleTagDecorationsUpdate();
 			if (isApplyingExternalValueRef.current) {
 				return;
 			}
@@ -170,6 +183,9 @@ export const AdhocRequestEditor = (({ value, languageId, readOnly, initialHeight
 		}
 
 		return () => {
+			if (pendingTagDecorationsFrame !== undefined) {
+				cancelAnimationFrame(pendingTagDecorationsFrame);
+			}
 			container.removeEventListener('keydown', handlePasteShortcut, /* capture */ true);
 			focusListener.dispose();
 			blurListener.dispose();

--- a/extensions/copilot/test/simulation/workbench/components/adhocRequestView.tsx
+++ b/extensions/copilot/test/simulation/workbench/components/adhocRequestView.tsx
@@ -1,0 +1,115 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Button, Field, Input, MessageBar, MessageBarBody, MessageBarTitle, Spinner, Text } from '@fluentui/react-components';
+import { Play16Regular, Stop16Regular } from '@fluentui/react-icons';
+import * as mobx from 'mobx';
+import * as mobxlite from 'mobx-react-lite';
+import * as React from 'react';
+import { AdhocRequestOptions } from '../stores/adhocRequestOptions';
+import { AdhocRequestSender, AdhocRequestState } from '../stores/adhocRequestSender';
+import { AdhocRequestEditor } from './adhocRequestEditor';
+
+type Props = {
+	adhocRequestOptions: AdhocRequestOptions;
+	adhocRequestSender: AdhocRequestSender;
+};
+
+export const AdhocRequestView = mobxlite.observer(({ adhocRequestOptions, adhocRequestSender }: Props) => {
+
+	const isRunning = adhocRequestSender.state === AdhocRequestState.Running;
+
+	const handleModelChange = React.useCallback((e: React.FormEvent<HTMLInputElement>) => {
+		mobx.runInAction(() => {
+			adhocRequestOptions.model.value = (e.target as HTMLInputElement).value;
+		});
+	}, [adhocRequestOptions.model]);
+
+	const handleSystemChange = React.useCallback((value: string) => {
+		mobx.runInAction(() => {
+			adhocRequestOptions.systemMessage.value = value;
+		});
+	}, [adhocRequestOptions.systemMessage]);
+
+	const handleUserChange = React.useCallback((value: string) => {
+		mobx.runInAction(() => {
+			adhocRequestOptions.userMessage.value = value;
+		});
+	}, [adhocRequestOptions.userMessage]);
+
+	const handleSendStop = React.useCallback(() => {
+		if (isRunning) {
+			adhocRequestSender.cancel();
+		} else {
+			adhocRequestSender.send({
+				system: adhocRequestOptions.systemMessage.value,
+				user: adhocRequestOptions.userMessage.value,
+				model: adhocRequestOptions.model.value,
+			});
+		}
+	}, [isRunning, adhocRequestSender, adhocRequestOptions]);
+
+	const canSend = adhocRequestOptions.model.value.trim().length > 0 && adhocRequestOptions.userMessage.value.trim().length > 0;
+
+	return (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: '12px', padding: '8px 12px' }}>
+			<div style={{ display: 'flex', alignItems: 'end', gap: '12px' }}>
+				<Field label='Model' style={{ minWidth: '280px' }}>
+					<Input
+						placeholder='e.g. gpt-4.1'
+						value={adhocRequestOptions.model.value}
+						onChange={handleModelChange}
+						disabled={isRunning}
+					/>
+				</Field>
+				<Button
+					appearance={isRunning ? 'secondary' : 'primary'}
+					icon={isRunning ? <Stop16Regular /> : <Play16Regular />}
+					iconPosition='before'
+					onClick={handleSendStop}
+					disabled={!isRunning && !canSend}
+				>
+					{isRunning ? 'Stop' : 'Send'}
+				</Button>
+				{isRunning && <Spinner size='tiny' label='Sending…' />}
+			</div>
+
+			<Field label='System message'>
+				<AdhocRequestEditor
+					value={adhocRequestOptions.systemMessage.value}
+					languageId='markdown'
+					onChange={handleSystemChange}
+				/>
+			</Field>
+
+			<Field label='User message'>
+				<AdhocRequestEditor
+					value={adhocRequestOptions.userMessage.value}
+					languageId='markdown'
+					autoFocus
+					onChange={handleUserChange}
+				/>
+			</Field>
+
+			<div>
+				<Text weight='semibold'>Response</Text>
+				{adhocRequestSender.state === AdhocRequestState.Error && adhocRequestSender.error !== undefined && (
+					<MessageBar intent='error' layout='singleline'>
+						<MessageBarBody>
+							<MessageBarTitle>Request failed</MessageBarTitle>
+							<pre style={{ whiteSpace: 'pre-wrap', margin: 0 }}>{adhocRequestSender.error}</pre>
+						</MessageBarBody>
+					</MessageBar>
+				)}
+				<AdhocRequestEditor
+					value={adhocRequestSender.response}
+					languageId='markdown'
+					readOnly
+					initialHeight={280}
+				/>
+			</div>
+		</div>
+	);
+});

--- a/extensions/copilot/test/simulation/workbench/components/app.tsx
+++ b/extensions/copilot/test/simulation/workbench/components/app.tsx
@@ -9,6 +9,8 @@ import * as mobx from 'mobx';
 import * as mobxlite from 'mobx-react-lite';
 import * as React from 'react';
 import { InitArgs } from '../initArgs';
+import { AdhocRequestOptions } from '../stores/adhocRequestOptions';
+import { AdhocRequestSender } from '../stores/adhocRequestSender';
 import { AMLProvider } from '../stores/amlSimulations';
 import { NesExternalOptions } from '../stores/nesExternalOptions';
 import { RunnerOptions } from '../stores/runnerOptions';
@@ -18,6 +20,8 @@ import { SimulationStorage, SimulationStorageValue } from '../stores/simulationS
 import { ISimulationTest, SimulationTestsProvider } from '../stores/simulationTestsProvider';
 import { useLocalStorageState } from '../stores/storage';
 import { TestSource } from '../stores/testSource';
+import { WorkbenchModeValue } from '../stores/workbenchMode';
+import { AdhocRequestView } from './adhocRequestView';
 import { ContextMenu, ContextMenuProvider } from './contextMenu';
 import { Scorecard } from './scorecard';
 import { ScorecardByLanguage } from './scorecardByLanguage';
@@ -28,9 +32,12 @@ import { Toolbar } from './toolbar';
 type Props = {
 	initArgs: InitArgs | undefined;
 	testsProvider: SimulationTestsProvider;
+	workbenchMode: WorkbenchModeValue;
 	runner: SimulationRunner;
 	runnerOptions: RunnerOptions;
 	nesExternalOptions: NesExternalOptions;
+	adhocRequestOptions: AdhocRequestOptions;
+	adhocRequestSender: AdhocRequestSender;
 	simulationRunsProvider: SimulationRunsProvider;
 	amlProvider: AMLProvider;
 	displayOptions: DisplayOptions;
@@ -39,17 +46,15 @@ type Props = {
 export type ThemeKind = 'light' | 'dark';
 
 export const App = mobxlite.observer(
-	({ initArgs, testsProvider, runner, runnerOptions, nesExternalOptions, simulationRunsProvider, amlProvider, displayOptions }: Props) => {
+	({ initArgs, testsProvider, workbenchMode, runner, runnerOptions, nesExternalOptions, adhocRequestOptions, adhocRequestSender, simulationRunsProvider, amlProvider, displayOptions }: Props) => {
 
 		const [theme, setTheme] = useLocalStorageState<ThemeKind>('appTheme', undefined, 'light');
 
 		const [filterer, setFilterer] = React.useState<TestFilterer | undefined>(undefined);
 
-		const displayedTests = filterer
-			? filterer.filter(testsProvider.tests)
-			: testsProvider.tests;
-
 		const toggleTheme = React.useCallback(() => setTheme(theme === 'dark' ? 'light' : 'dark'), [theme]);
+
+		const isAdhocRequest = workbenchMode.value === 'adhocRequest';
 
 		return (
 			<FluentProvider theme={theme === 'light' ? webLightTheme : webDarkTheme} style={{ minHeight: 'inherit' }}>
@@ -64,39 +69,75 @@ export const App = mobxlite.observer(
 							simulationRunsProvider={simulationRunsProvider}
 							simulationTestsProvider={testsProvider}
 							amlProvider={amlProvider}
+							workbenchMode={workbenchMode}
 							testSource={testsProvider.testSource}
 							onFiltererChange={setFilterer}
 							allLanguageIds={testsProvider.allLanguageIds}
 							theme={theme}
 							toggleTheme={toggleTheme}
 						/>
-						{testsProvider.testSource.value === TestSource.External && (
-							<Scorecard amlProvider={amlProvider} />
+						{isAdhocRequest ? (
+							<AdhocRequestView adhocRequestOptions={adhocRequestOptions} adhocRequestSender={adhocRequestSender} />
+						) : (
+							<TestsView
+								testsProvider={testsProvider}
+								runner={runner}
+								runnerOptions={runnerOptions}
+								nesExternalOptions={nesExternalOptions}
+								amlProvider={amlProvider}
+								displayOptions={displayOptions}
+								filterer={filterer}
+							/>
 						)}
-						{testsProvider.testSource.value === TestSource.External && (
-							<ScorecardByLanguage amlProvider={amlProvider} />
-						)}
-						{(testsProvider.testSource.value === TestSource.Local || testsProvider.testSource.value === TestSource.NesExternal) && <TerminationMessageBar runner={runner} />}
-						<div style={{ margin: '5px', display: 'flex', justifyContent: 'space-between' }}>
-							<div style={{ textAlign: 'left' }}>
-								<TestsInfo tests={testsProvider.tests} displayedTests={displayedTests} />
-							</div>
-							<div style={{ textAlign: 'right' }}>
-								<Checkbox
-									label='Expand prompts'
-									defaultChecked={displayOptions.expandPrompts.value}
-									onChange={mobx.action(() => displayOptions.expandPrompts.value = !displayOptions.expandPrompts.value)}
-								/>
-								<DisplayToggle displayOptions={displayOptions} />
-							</div>
-						</div>
-						<TestList tests={displayedTests} runner={runner} runnerOptions={runnerOptions} nesExternalOptions={nesExternalOptions} testSource={testsProvider.testSource} displayOptions={displayOptions} />
 					</div>
 				</ContextMenuProvider>
 			</FluentProvider>
 		);
 	}
 );
+
+type TestsViewProps = {
+	testsProvider: SimulationTestsProvider;
+	runner: SimulationRunner;
+	runnerOptions: RunnerOptions;
+	nesExternalOptions: NesExternalOptions;
+	amlProvider: AMLProvider;
+	displayOptions: DisplayOptions;
+	filterer: TestFilterer | undefined;
+};
+
+const TestsView = mobxlite.observer(({ testsProvider, runner, runnerOptions, nesExternalOptions, amlProvider, displayOptions, filterer }: TestsViewProps) => {
+
+	const displayedTests = filterer
+		? filterer.filter(testsProvider.tests)
+		: testsProvider.tests;
+
+	return (
+		<>
+			{testsProvider.testSource.value === TestSource.External && (
+				<Scorecard amlProvider={amlProvider} />
+			)}
+			{testsProvider.testSource.value === TestSource.External && (
+				<ScorecardByLanguage amlProvider={amlProvider} />
+			)}
+			{(testsProvider.testSource.value === TestSource.Local || testsProvider.testSource.value === TestSource.NesExternal) && <TerminationMessageBar runner={runner} />}
+			<div style={{ margin: '5px', display: 'flex', justifyContent: 'space-between' }}>
+				<div style={{ textAlign: 'left' }}>
+					<TestsInfo tests={testsProvider.tests} displayedTests={displayedTests} />
+				</div>
+				<div style={{ textAlign: 'right' }}>
+					<Checkbox
+						label='Expand prompts'
+						defaultChecked={displayOptions.expandPrompts.value}
+						onChange={mobx.action(() => displayOptions.expandPrompts.value = !displayOptions.expandPrompts.value)}
+					/>
+					<DisplayToggle displayOptions={displayOptions} />
+				</div>
+			</div>
+			<TestList tests={displayedTests} runner={runner} runnerOptions={runnerOptions} nesExternalOptions={nesExternalOptions} testSource={testsProvider.testSource} displayOptions={displayOptions} />
+		</>
+	);
+});
 
 const TerminationMessageBar = mobxlite.observer(({ runner }: { runner: SimulationRunner }) =>
 	runner.terminationReason === undefined

--- a/extensions/copilot/test/simulation/workbench/components/toolbar.tsx
+++ b/extensions/copilot/test/simulation/workbench/components/toolbar.tsx
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Select, ToggleButton, Tooltip } from '@fluentui/react-components';
+import { Select, Text, ToggleButton, Tooltip } from '@fluentui/react-components';
 import { WeatherMoon20Regular, WeatherSunny20Regular } from '@fluentui/react-icons';
 import * as mobx from 'mobx';
 import * as mobxlite from 'mobx-react-lite';
@@ -16,6 +16,7 @@ import { SimulationRunsProvider } from '../stores/simulationBaseline';
 import { SimulationRunner } from '../stores/simulationRunner';
 import { SimulationTestsProvider } from '../stores/simulationTestsProvider';
 import { TestSource, TestSourceValue } from '../stores/testSource';
+import { WorkbenchModeValue } from '../stores/workbenchMode';
 import { AMLModeToolbar } from './amlModeToolbar';
 import { ThemeKind } from './app';
 import { LocalModeToolbar } from './localModeToolbar';
@@ -30,6 +31,7 @@ type ToolbarProps = {
 	amlProvider: AMLProvider;
 	simulationRunsProvider: SimulationRunsProvider;
 	simulationTestsProvider: SimulationTestsProvider;
+	workbenchMode: WorkbenchModeValue;
 	testSource: TestSourceValue;
 	onFiltererChange: (filter: TestFilterer | undefined) => void;
 	allLanguageIds: readonly string[];
@@ -46,6 +48,7 @@ export const Toolbar = mobxlite.observer(
 		amlProvider,
 		simulationRunsProvider,
 		simulationTestsProvider,
+		workbenchMode,
 		testSource,
 		onFiltererChange,
 		allLanguageIds,
@@ -54,6 +57,13 @@ export const Toolbar = mobxlite.observer(
 	}: ToolbarProps) => {
 
 		const toolbarContent = (() => {
+			if (workbenchMode.value === 'adhocRequest') {
+				return (
+					<div className='toolbar' style={{ display: 'flex', alignItems: 'center' }}>
+						<Text size={400}>Adhoc request sender</Text>
+					</div>
+				);
+			}
 			switch (testSource.value) {
 				case TestSource.Local:
 					return (
@@ -93,7 +103,7 @@ export const Toolbar = mobxlite.observer(
 				{toolbarContent}
 				<div style={{ display: 'flex', justifyContent: 'end', maxHeight: '35px' }}>
 					<ThemeToggler theme={theme} toggleTheme={toggleTheme} />
-					<ModeToggler testSource={testSource} onFiltererChange={onFiltererChange} />
+					<ModeToggler workbenchMode={workbenchMode} testSource={testSource} onFiltererChange={onFiltererChange} />
 				</div>
 			</div>
 		);
@@ -110,25 +120,39 @@ const ThemeToggler = ({ theme, toggleTheme }: { theme: ThemeKind; toggleTheme: (
 	</Tooltip>
 );
 
-const testSourceOptions: { value: string; label: string; source: TestSource }[] = [
+const ADHOC_REQUEST_OPTION = 'adhocRequest';
+
+/**
+ * Options for the workbench mode selector. The test-source entries put the
+ * workbench into 'tests' mode and select a {@link TestSource}; the adhoc entry
+ * switches to the standalone "Adhoc request sender" mode.
+ */
+const modeOptions: { value: string; label: string; source?: TestSource }[] = [
 	{ value: String(TestSource.Local), label: 'Local', source: TestSource.Local },
 	{ value: String(TestSource.NesExternal), label: 'NES External', source: TestSource.NesExternal },
 	{ value: String(TestSource.External), label: 'AML', source: TestSource.External },
+	{ value: ADHOC_REQUEST_OPTION, label: 'Adhoc Request' },
 ];
 
-const ModeToggler = ({ testSource, onFiltererChange }: { testSource: TestSourceValue; onFiltererChange: (filter: TestFilterer | undefined) => void }) => (
+const ModeToggler = ({ workbenchMode, testSource, onFiltererChange }: { workbenchMode: WorkbenchModeValue; testSource: TestSourceValue; onFiltererChange: (filter: TestFilterer | undefined) => void }) => (
 	<Select
 		style={{ marginLeft: '8px', minWidth: '140px' }}
-		value={String(testSource.value)}
+		value={workbenchMode.value === 'adhocRequest' ? ADHOC_REQUEST_OPTION : String(testSource.value)}
 		onChange={mobx.action((_e, data) => {
-			const selected = testSourceOptions.find(o => o.value === data.value);
-			if (selected) {
-				testSource.value = selected.source;
-				onFiltererChange(undefined);
+			const selected = modeOptions.find(o => o.value === data.value);
+			if (!selected) {
+				return;
 			}
+			if (selected.source === undefined) {
+				workbenchMode.value = 'adhocRequest';
+			} else {
+				workbenchMode.value = 'tests';
+				testSource.value = selected.source;
+			}
+			onFiltererChange(undefined);
 		})}
 	>
-		{testSourceOptions.map(o => (
+		{modeOptions.map(o => (
 			<option key={o.value} value={o.value}>{o.label}</option>
 		))}
 	</Select>

--- a/extensions/copilot/test/simulation/workbench/simulationWorkbench.tsx
+++ b/extensions/copilot/test/simulation/workbench/simulationWorkbench.tsx
@@ -10,6 +10,8 @@ import { render } from 'react-dom';
 import { Disposable } from '../../../src/util/vs/base/common/lifecycle';
 import { App, DisplayOptions } from './components/app';
 import { InitArgs, parseInitEventArgs as parseProcessArgv } from './initArgs';
+import { AdhocRequestOptions } from './stores/adhocRequestOptions';
+import { AdhocRequestSender } from './stores/adhocRequestSender';
 import { AMLProvider } from './stores/amlSimulations';
 import { NesExternalOptions } from './stores/nesExternalOptions';
 import { RunnerOptions } from './stores/runnerOptions';
@@ -18,17 +20,21 @@ import { SimulationRunner } from './stores/simulationRunner';
 import { SimulationStorage } from './stores/simulationStorage';
 import { SimulationTestsProvider } from './stores/simulationTestsProvider';
 import { TestSource, TestSourceValue } from './stores/testSource';
+import { WorkbenchMode, WorkbenchModeValue } from './stores/workbenchMode';
 import { REPO_ROOT, monacoModule } from './utils/utils';
 
 
 class SimulationWorkbench extends Disposable {
 	private readonly storage: SimulationStorage;
+	private readonly workbenchMode: WorkbenchModeValue;
 	private readonly testSource: TestSourceValue;
 	private readonly simulationRunsProvider: SimulationRunsProvider;
 	private readonly amlProvider: AMLProvider;
 	private readonly runner: SimulationRunner;
 	private readonly runnerOptions: RunnerOptions;
 	private readonly nesExternalOptions: NesExternalOptions;
+	private readonly adhocRequestOptions: AdhocRequestOptions;
+	private readonly adhocRequestSender: AdhocRequestSender;
 	private readonly tests: SimulationTestsProvider;
 	private readonly displayOptions: DisplayOptions;
 
@@ -36,10 +42,18 @@ class SimulationWorkbench extends Disposable {
 		super();
 
 		this.storage = new SimulationStorage();
+		this.workbenchMode = this.storage.bind<WorkbenchMode>('workbenchMode', 'tests');
 		this.testSource = this.storage.bind('testSource', TestSource.Local);
+		// Sanitize a possibly stale `testSource` from earlier builds where the adhoc
+		// request mode was (incorrectly) modeled as a `TestSource` member.
+		if (this.testSource.value !== TestSource.Local && this.testSource.value !== TestSource.External && this.testSource.value !== TestSource.NesExternal) {
+			this.testSource.value = TestSource.Local;
+		}
 		this.amlProvider = this._register(new AMLProvider(this.storage));
 		this.runnerOptions = new RunnerOptions(this.storage);
 		this.nesExternalOptions = new NesExternalOptions(this.storage);
+		this.adhocRequestOptions = new AdhocRequestOptions(this.storage);
+		this.adhocRequestSender = new AdhocRequestSender();
 		this.runner = this._register(new SimulationRunner(this.storage, this.runnerOptions));
 		this.simulationRunsProvider = this._register(new SimulationRunsProvider(this.storage, this.runner));
 		this.tests = this._register(new SimulationTestsProvider(this.testSource, this.runner, this.simulationRunsProvider, this.amlProvider, this.nesExternalOptions));
@@ -54,9 +68,12 @@ class SimulationWorkbench extends Disposable {
 			<App
 				initArgs={initArgs}
 				testsProvider={this.tests}
+				workbenchMode={this.workbenchMode}
 				runner={this.runner}
 				runnerOptions={this.runnerOptions}
 				nesExternalOptions={this.nesExternalOptions}
+				adhocRequestOptions={this.adhocRequestOptions}
+				adhocRequestSender={this.adhocRequestSender}
 				simulationRunsProvider={this.simulationRunsProvider}
 				amlProvider={this.amlProvider}
 				displayOptions={this.displayOptions}

--- a/extensions/copilot/test/simulation/workbench/stores/adhocRequestOptions.ts
+++ b/extensions/copilot/test/simulation/workbench/stores/adhocRequestOptions.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { SimulationStorage, SimulationStorageValue } from './simulationStorage';
+
+/**
+ * Persisted inputs for the "Adhoc request sender" mode in the simulation workbench.
+ */
+export class AdhocRequestOptions {
+
+	/** The system message to send. */
+	public readonly systemMessage: SimulationStorageValue<string>;
+
+	/** The user message to send. */
+	public readonly userMessage: SimulationStorageValue<string>;
+
+	/** The model name (e.g. `gpt-4.1`) to send the request to. */
+	public readonly model: SimulationStorageValue<string>;
+
+	constructor(storage: SimulationStorage) {
+		this.systemMessage = new SimulationStorageValue(storage, 'adhocRequestSystemMessage', '');
+		this.userMessage = new SimulationStorageValue(storage, 'adhocRequestUserMessage', '');
+		this.model = new SimulationStorageValue(storage, 'adhocRequestModel', '');
+	}
+}

--- a/extensions/copilot/test/simulation/workbench/stores/adhocRequestSender.ts
+++ b/extensions/copilot/test/simulation/workbench/stores/adhocRequestSender.ts
@@ -1,0 +1,125 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as mobx from 'mobx';
+import * as os from 'os';
+import * as path from 'path';
+import { CancellationTokenSource } from '../../../../src/util/vs/base/common/cancellation';
+import { AdhocResponseOutput, AdhocResponseType, IAdhocRequest } from '../../shared/sharedTypes';
+import { spawnSimulationFromMainProcess } from '../utils/simulationExec';
+
+export const enum AdhocRequestState {
+	Idle,
+	Running,
+	Done,
+	Error,
+}
+
+/**
+ * Sends an adhoc chat request by spawning the simulation CLI and streaming the
+ * response back. Used by the "Adhoc request sender" mode in the workbench.
+ */
+export class AdhocRequestSender {
+
+	@mobx.observable
+	public state: AdhocRequestState = AdhocRequestState.Idle;
+
+	/** The accumulated response text streamed from the model. */
+	@mobx.observable
+	public response: string = '';
+
+	/** The error message, set when {@link state} is {@link AdhocRequestState.Error}. */
+	@mobx.observable
+	public error: string | undefined = undefined;
+
+	private cancellationTokenSource: CancellationTokenSource | undefined;
+
+	constructor() {
+		mobx.makeObservable(this);
+	}
+
+	public async send(request: IAdhocRequest): Promise<void> {
+		if (this.state === AdhocRequestState.Running) {
+			return;
+		}
+
+		const cancellationTokenSource = new CancellationTokenSource();
+		this.cancellationTokenSource = cancellationTokenSource;
+
+		mobx.runInAction(() => {
+			this.state = AdhocRequestState.Running;
+			this.response = '';
+			this.error = undefined;
+		});
+
+		const requestFilePath = path.join(os.tmpdir(), `adhoc-request-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+
+		try {
+			await fs.promises.writeFile(requestFilePath, JSON.stringify(request), { encoding: 'utf8', mode: 0o600 });
+
+			const stream = spawnSimulationFromMainProcess<AdhocResponseOutput>(
+				{ args: [`--adhoc-request-file=${requestFilePath}`], ignoreNonJSONLines: true },
+				cancellationTokenSource.token
+			);
+
+			for await (const output of stream) {
+				if (cancellationTokenSource.token.isCancellationRequested) {
+					break;
+				}
+				this.interpretOutput(output);
+			}
+		} catch (err) {
+			if (!cancellationTokenSource.token.isCancellationRequested) {
+				mobx.runInAction(() => {
+					this.state = AdhocRequestState.Error;
+					this.error = err instanceof Error ? (err.stack ?? err.message) : String(err);
+				});
+			}
+		} finally {
+			fs.promises.unlink(requestFilePath).catch(() => { /* best effort cleanup */ });
+			// Only finalize if this send is still the current one. A superseded send
+			// (the user hit Stop then Send again) must not clobber the newer request's
+			// state or cancellation token source.
+			if (this.cancellationTokenSource === cancellationTokenSource) {
+				this.cancellationTokenSource = undefined;
+				mobx.runInAction(() => {
+					if (this.state === AdhocRequestState.Running) {
+						// Stream ended without an explicit done/error message.
+						this.state = this.error !== undefined ? AdhocRequestState.Error : AdhocRequestState.Done;
+					}
+				});
+			}
+		}
+	}
+
+	public cancel(): void {
+		this.cancellationTokenSource?.cancel();
+		this.cancellationTokenSource = undefined;
+		mobx.runInAction(() => {
+			if (this.state === AdhocRequestState.Running) {
+				this.state = AdhocRequestState.Idle;
+			}
+		});
+	}
+
+	private interpretOutput(output: AdhocResponseOutput): void {
+		mobx.runInAction(() => {
+			switch (output.type) {
+				case AdhocResponseType.delta:
+					this.response += output.value;
+					return;
+				case AdhocResponseType.done:
+					this.response = output.value;
+					this.state = AdhocRequestState.Done;
+					return;
+				case AdhocResponseType.error:
+					this.error = output.value;
+					this.state = AdhocRequestState.Error;
+					return;
+			}
+		});
+	}
+}

--- a/extensions/copilot/test/simulation/workbench/stores/adhocRequestSender.ts
+++ b/extensions/copilot/test/simulation/workbench/stores/adhocRequestSender.ts
@@ -80,9 +80,13 @@ export class AdhocRequestSender {
 			}
 		} finally {
 			fs.promises.unlink(requestFilePath).catch(() => { /* best effort cleanup */ });
-			// Only finalize if this send is still the current one. A superseded send
-			// (the user hit Stop then Send again) must not clobber the newer request's
-			// state or cancellation token source.
+			// Always dispose this send's token source to avoid leaking its
+			// cancellation listeners across repeated Send/Stop cycles, regardless of
+			// whether this send is still the current one.
+			cancellationTokenSource.dispose();
+			// Only finalize shared state if this send is still the current one. A
+			// superseded send (the user hit Stop then Send again) must not clobber the
+			// newer request's state or cancellation token source.
 			if (this.cancellationTokenSource === cancellationTokenSource) {
 				this.cancellationTokenSource = undefined;
 				mobx.runInAction(() => {

--- a/extensions/copilot/test/simulation/workbench/stores/workbenchMode.ts
+++ b/extensions/copilot/test/simulation/workbench/stores/workbenchMode.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { SimulationStorageValue } from './simulationStorage';
+
+/**
+ * The top-level mode of the simulation workbench. This is independent of
+ * {@link TestSource} (which is purely about where simulation tests come from):
+ * the workbench can either be showing tests or the standalone "Adhoc request
+ * sender" utility.
+ */
+export type WorkbenchMode = 'tests' | 'adhocRequest';
+
+export type WorkbenchModeValue = SimulationStorageValue<WorkbenchMode>;

--- a/extensions/copilot/test/simulationMain.ts
+++ b/extensions/copilot/test/simulationMain.ts
@@ -548,6 +548,35 @@ async function listChatModels(skipCache: boolean = false) {
 }
 
 /**
+ * Validates and normalizes a parsed adhoc request JSON object. Returns a focused
+ * error message instead of letting `.trim()`/`toTextParts()` throw on malformed
+ * input (missing/`null` fields, wrong types, etc.).
+ */
+function validateAdhocRequest(raw: unknown): { ok: true; request: IAdhocRequest } | { ok: false; error: string } {
+	if (typeof raw !== 'object' || raw === null) {
+		return { ok: false, error: 'Invalid adhoc request: expected a JSON object.' };
+	}
+	const obj = raw as Record<string, unknown>;
+	if (typeof obj.model !== 'string' || obj.model.trim().length === 0) {
+		return { ok: false, error: 'Invalid adhoc request: "model" must be a non-empty string.' };
+	}
+	if (typeof obj.user !== 'string' || obj.user.trim().length === 0) {
+		return { ok: false, error: 'Invalid adhoc request: "user" must be a non-empty string.' };
+	}
+	if (obj.system !== undefined && typeof obj.system !== 'string') {
+		return { ok: false, error: 'Invalid adhoc request: "system" must be a string when provided.' };
+	}
+	return {
+		ok: true,
+		request: {
+			model: obj.model,
+			user: obj.user,
+			system: typeof obj.system === 'string' ? obj.system : '',
+		},
+	};
+}
+
+/**
  * Sends a single adhoc chat request (used by the simulation workbench
  * "Adhoc request sender" mode) and streams the response back as JSONL on
  * stdout. The request is described by a JSON file at {@link requestFilePath}.
@@ -557,21 +586,24 @@ async function sendAdhocRequest(requestFilePath: string): Promise<void> {
 		process.stdout.write(JSON.stringify(output) + '\n');
 	};
 
-	let request: IAdhocRequest;
+	let parsed: unknown;
 	try {
-		request = JSON.parse(await fs.promises.readFile(requestFilePath, 'utf8')) as IAdhocRequest;
+		parsed = JSON.parse(await fs.promises.readFile(requestFilePath, 'utf8'));
 	} catch (err) {
 		printAdhocOutput({ type: AdhocResponseType.error, value: `Failed to read adhoc request file: ${err instanceof Error ? err.message : String(err)}` });
 		return;
 	}
 
+	const validation = validateAdhocRequest(parsed);
+	if (!validation.ok) {
+		printAdhocOutput({ type: AdhocResponseType.error, value: validation.error });
+		return;
+	}
+	const request = validation.request;
+
 	const disposables = new DisposableStore();
 	try {
 		const model = request.model.trim();
-		if (!model) {
-			printAdhocOutput({ type: AdhocResponseType.error, value: 'No model specified.' });
-			return;
-		}
 
 		const testingServiceCollection = createExtensionUnitTestingServices(disposables);
 		// The unit-testing services bind a mock chat fetcher; override it with the

--- a/extensions/copilot/test/simulationMain.ts
+++ b/extensions/copilot/test/simulationMain.ts
@@ -10,6 +10,7 @@ dotenv.config();
 import 'source-map-support/register';
 
 // Load other imports
+import { Raw } from '@vscode/prompt-tsx';
 import * as fs from 'fs';
 import minimist from 'minimist';
 import { createConnection } from 'net';
@@ -17,17 +18,27 @@ import * as path from 'path';
 import * as v8 from 'v8';
 import type * as vscodeType from 'vscode';
 import { SimpleRPC } from '../src/extension/onboardDebug/node/copilotDebugWorker/rpc';
+import { ChatMLFetcherImpl } from '../src/extension/prompt/node/chatMLFetcher';
 import { ISimulationModelConfig, createExtensionUnitTestingServices } from '../src/extension/test/node/services';
+import { IChatMLFetcher } from '../src/platform/chat/common/chatMLFetcher';
+import { ChatFetchResponseType, ChatLocation } from '../src/platform/chat/common/commonTypes';
+import { toTextParts } from '../src/platform/chat/common/globalStringUtils';
 import { CHAT_MODEL } from '../src/platform/configuration/common/configurationService';
 import { IEndpointProvider, ModelSupportedEndpoint } from '../src/platform/endpoint/common/endpointProvider';
+import { createProxyXtabEndpoint } from '../src/platform/endpoint/node/proxyXtabEndpoint';
 import { IModelConfig } from '../src/platform/endpoint/test/node/openaiCompatibleEndpoint';
 import { fileSystemServiceReadAsJSON } from '../src/platform/filesystem/common/fileSystemService';
 import { LogLevel } from '../src/platform/log/common/logService';
+import { IChatEndpoint } from '../src/platform/networking/common/networking';
 import { ParserWithCaching } from '../src/platform/parser/node/parserWithCaching';
 import { structureComputer } from '../src/platform/parser/node/structure';
 import { NullTelemetryService } from '../src/platform/telemetry/common/nullTelemetryService';
 import { TokenizerProvider } from '../src/platform/tokenizer/node/tokenizer';
 import { assert } from '../src/util/vs/base/common/assert';
+import { CancellationToken } from '../src/util/vs/base/common/cancellation';
+import { DisposableStore } from '../src/util/vs/base/common/lifecycle';
+import { SyncDescriptor } from '../src/util/vs/platform/instantiation/common/descriptors';
+import { IInstantiationService } from '../src/util/vs/platform/instantiation/common/instantiation';
 import { Cache } from './base/cache';
 import { IChatMLCache } from './base/cachingChatMLFetcher';
 import { usedResourceCaches } from './base/cachingResourceFetcher';
@@ -48,7 +59,7 @@ import { runInputPipeline, runInputPipelineParallel } from './pipeline/pipeline'
 import { ITestDiscoveryOptions, discoverTests } from './simulation/externalScenarios';
 import { discoverCoffeTests } from './simulation/nesCoffeTests';
 import { discoverNesTests } from './simulation/nesExternalTests';
-import { OLD_BASELINE_FILENAME, OutputType, PRODUCED_BASELINE_FILENAME, REPORT_FILENAME, RUN_METADATA, SCORECARD_FILENAME, SIMULATION_FOLDER_NAME, generateOutputFolderName } from './simulation/shared/sharedTypes';
+import { AdhocResponseOutput, AdhocResponseType, IAdhocRequest, OLD_BASELINE_FILENAME, OutputType, PRODUCED_BASELINE_FILENAME, REPORT_FILENAME, RUN_METADATA, SCORECARD_FILENAME, SIMULATION_FOLDER_NAME, generateOutputFolderName } from './simulation/shared/sharedTypes';
 import { logger } from './simulationLogger';
 import { IInitParams, IInitResult, IRunTestParams, IRunTestResult } from './testExecutionInExtension';
 import { GroupedScores, ITestResult, SimulationTestContext, executeTestOnce, executeTests } from './testExecutor';
@@ -105,6 +116,9 @@ async function run(opts: SimulationOptions): Promise<RunResult> {
 			return opts.printTrainHelp();
 		case opts.help:
 			return opts.printHelp();
+		case !!opts.adhocRequestFile:
+			await sendAdhocRequest(opts.adhocRequestFile!);
+			return;
 		case opts.listModels:
 			await listChatModels(opts.modelCacheMode === CacheMode.Disable);
 			return;
@@ -531,6 +545,86 @@ async function listChatModels(skipCache: boolean = false) {
 
 	console.table(tableData);
 	return;
+}
+
+/**
+ * Sends a single adhoc chat request (used by the simulation workbench
+ * "Adhoc request sender" mode) and streams the response back as JSONL on
+ * stdout. The request is described by a JSON file at {@link requestFilePath}.
+ */
+async function sendAdhocRequest(requestFilePath: string): Promise<void> {
+	const printAdhocOutput = (output: AdhocResponseOutput) => {
+		process.stdout.write(JSON.stringify(output) + '\n');
+	};
+
+	let request: IAdhocRequest;
+	try {
+		request = JSON.parse(await fs.promises.readFile(requestFilePath, 'utf8')) as IAdhocRequest;
+	} catch (err) {
+		printAdhocOutput({ type: AdhocResponseType.error, value: `Failed to read adhoc request file: ${err instanceof Error ? err.message : String(err)}` });
+		return;
+	}
+
+	const disposables = new DisposableStore();
+	try {
+		const model = request.model.trim();
+		if (!model) {
+			printAdhocOutput({ type: AdhocResponseType.error, value: 'No model specified.' });
+			return;
+		}
+
+		const testingServiceCollection = createExtensionUnitTestingServices(disposables);
+		// The unit-testing services bind a mock chat fetcher; override it with the
+		// real implementation so the request actually hits the model endpoint.
+		testingServiceCollection.define(IChatMLFetcher, new SyncDescriptor(ChatMLFetcherImpl));
+		const accessor = testingServiceCollection.createTestingAccessor();
+		const endpointProvider = accessor.get(IEndpointProvider);
+		const instantiationService = accessor.get(IInstantiationService);
+
+		// Prefer a registered chat endpoint (e.g. `gpt-4.1`, `claude-sonnet-4.5`).
+		let endpoint: IChatEndpoint | undefined;
+		try {
+			const allEndpoints = await endpointProvider.getAllChatEndpoints();
+			endpoint = allEndpoints.find(e => e.model === model) ?? allEndpoints.find(e => e.family === model);
+		} catch {
+			// Ignore and fall back to the proxy endpoint below.
+		}
+		if (!endpoint) {
+			// Otherwise send the model name directly against the proxy endpoint, the
+			// same way `xtabProvider` does. This allows targeting models that aren't
+			// registered chat endpoints (e.g. NES models like `copilot-nes-oct`).
+			endpoint = createProxyXtabEndpoint(instantiationService, model);
+		}
+
+		const messages: Raw.ChatMessage[] = [];
+		if (request.system.trim().length > 0) {
+			messages.push({ role: Raw.ChatRole.System, content: toTextParts(request.system) });
+		}
+		messages.push({ role: Raw.ChatRole.User, content: toTextParts(request.user) });
+
+		const response = await endpoint.makeChatRequest2({
+			debugName: 'adhoc-request',
+			messages,
+			finishedCb: async (_text, _index, delta) => {
+				if (delta.text) {
+					printAdhocOutput({ type: AdhocResponseType.delta, value: delta.text });
+				}
+				return undefined;
+			},
+			location: ChatLocation.Other,
+			userInitiatedRequest: true,
+		}, CancellationToken.None);
+
+		if (response.type === ChatFetchResponseType.Success) {
+			printAdhocOutput({ type: AdhocResponseType.done, value: response.value });
+		} else {
+			printAdhocOutput({ type: AdhocResponseType.error, value: `${response.type}: ${response.reason}` });
+		}
+	} catch (err) {
+		printAdhocOutput({ type: AdhocResponseType.error, value: err instanceof Error ? (err.stack ?? err.message) : String(err) });
+	} finally {
+		disposables.dispose();
+	}
 }
 
 function createSimulationTestContext(


### PR DESCRIPTION
This pull request introduces a new mode in the simulation workbench called "Adhoc Request Sender," which allows users to send requests with a dedicated editor interface. Key changes include:

- **New Components**: Added `AdhocRequestEditor` and `AdhocRequestView` for user input and model response display.
- **State Management**: Created stores for managing adhoc request options and sender logic.
- **Tag Highlighting**: Implemented highlighting for tags in the editor (e.g., `<|tag|>`), ensuring consistent colors for the same tag name and distinct colors for different tags.
- **Refactoring**: Updated existing components and stores to accommodate the new mode without interfering with the test source functionality.

This feature enhances the simulation workbench by providing a streamlined interface for adhoc requests while ensuring a visually distinct representation of tags for better user experience.