### PR TITLE
sessions: header diff-stats pill shows the session's default changeset

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesActions.ts
@@ -22,7 +22,6 @@ import { SessionHasChangesContext } from '../../../common/contextkeys.js';
 import { ISessionContext } from '../../../services/sessions/browser/sessionContext.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { IActiveSession } from '../../../services/sessions/common/sessionsManagement.js';
-import { BRANCH_CHANGES_CHANGESET_ID } from '../../../services/sessions/common/session.js';
 import { ChangesMultiDiffSourceResolver } from './changesMultiDiffSourceResolver.js';
 import { ISessionChangesService } from './sessionChangesService.js';
 
@@ -90,11 +89,13 @@ interface IDiffStats {
  * action, which opens the multi-file diff editor.
  *
  * The stats are read from the {@link ISessionContext} so the correct per-session changes
- * are shown even when several session views are visible at once. The counts always reflect
- * the session's **Branch Changes** changeset (the branch-vs-base diff), located by id in
- * {@link IActiveSession.changesets}, so the header is independent of whichever changeset the
- * Changes view currently has selected. When no branch changeset is present, it falls back to
- * the session's top-level {@link IActiveSession.changes}.
+ * are shown even when several session views are visible at once. The counts reflect the
+ * session's **default** changeset (branch-vs-base for a git workspace, otherwise the
+ * session's working changes), i.e. the changeset the provider marks as
+ * {@link ISessionChangeset.isDefault}, so the header shows the changes done in this session
+ * independent of whichever changeset the Changes view currently has selected. When no
+ * default changeset is present, it falls back to the session's top-level
+ * {@link IActiveSession.changes}.
  */
 export class ViewAllChangesActionViewItem extends SessionHeaderMetaActionViewItem {
 
@@ -109,8 +110,8 @@ export class ViewAllChangesActionViewItem extends SessionHeaderMetaActionViewIte
 
 		this._diffStatsObs = derivedOpts<IDiffStats>({ owner: this, equalsFn: structuralEquals }, reader => {
 			const session = sessionContext.session.read(reader);
-			const branchChangeset = session?.changesets.read(reader)?.find(c => c.id === BRANCH_CHANGES_CHANGESET_ID);
-			const changes = (branchChangeset?.changes.read(reader) ?? session?.changes.read(reader)) ?? [];
+			const defaultChangeset = session?.changesets.read(reader)?.find(c => c.isDefault.read(reader));
+			const changes = (defaultChangeset?.changes.read(reader) ?? session?.changes.read(reader)) ?? [];
 			let insertions = 0;
 			let deletions = 0;
 			for (const change of changes) {

--- a/src/vs/sessions/contrib/changes/browser/changesActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesActions.ts
@@ -90,12 +90,8 @@ interface IDiffStats {
  *
  * The stats are read from the {@link ISessionContext} so the correct per-session changes
  * are shown even when several session views are visible at once. The counts reflect the
- * session's **default** changeset (branch-vs-base for a git workspace, otherwise the
- * session's working changes), i.e. the changeset the provider marks as
- * {@link ISessionChangeset.isDefault}, so the header shows the changes done in this session
- * independent of whichever changeset the Changes view currently has selected. When no
- * default changeset is present, it falls back to the session's top-level
- * {@link IActiveSession.changes}.
+ * changeset the provider marks as {@link ISessionChangeset.isDefault}, falling back to the
+ * session's top-level {@link IActiveSession.changes} when none is default.
  */
 export class ViewAllChangesActionViewItem extends SessionHeaderMetaActionViewItem {
 

--- a/src/vs/sessions/services/sessions/common/sessionContextKeys.ts
+++ b/src/vs/sessions/services/sessions/common/sessionContextKeys.ts
@@ -107,10 +107,7 @@ export function setSessionContextKeys(session: ISession | undefined, contextKeyS
 	keys.supportsDelete.set(session?.capabilities.supportsDelete ?? false);
 	keys.workspaceIsVirtual.set(session?.workspace.read(reader)?.isVirtualWorkspace ?? true);
 
-	// Mirror the changes pill's own source — the session's default changeset
-	// (branch-vs-base for git, otherwise the working changes) — falling back to
-	// the session's changes when absent, so the diff-stats menu item is shown
-	// exactly when it renders non-zero counts.
+	// Mirror the changes pill: the default changeset, falling back to the session's changes.
 	const defaultChangeset = session?.changesets.read(reader)?.find(c => c.isDefault.read(reader));
 	let insertions = 0;
 	let deletions = 0;

--- a/src/vs/sessions/services/sessions/common/sessionContextKeys.ts
+++ b/src/vs/sessions/services/sessions/common/sessionContextKeys.ts
@@ -22,7 +22,7 @@ import {
 	SessionIdContext,
 	SessionHasMultipleCommittedChatsContext,
 } from '../../../common/contextkeys.js';
-import { BRANCH_CHANGES_CHANGESET_ID, ISession, SessionStatus } from './session.js';
+import { ISession, SessionStatus } from './session.js';
 import { IActiveSession } from './sessionsManagement.js';
 
 /**
@@ -107,13 +107,14 @@ export function setSessionContextKeys(session: ISession | undefined, contextKeyS
 	keys.supportsDelete.set(session?.capabilities.supportsDelete ?? false);
 	keys.workspaceIsVirtual.set(session?.workspace.read(reader)?.isVirtualWorkspace ?? true);
 
-	// Mirror the changes pill's own source — the Branch Changes changeset
-	// (branch-vs-base diff) — falling back to the session's changes when absent,
-	// so the diff-stats menu item is shown exactly when it renders non-zero counts.
-	const branchChangeset = session?.changesets.read(reader)?.find(c => c.id === BRANCH_CHANGES_CHANGESET_ID);
+	// Mirror the changes pill's own source — the session's default changeset
+	// (branch-vs-base for git, otherwise the working changes) — falling back to
+	// the session's changes when absent, so the diff-stats menu item is shown
+	// exactly when it renders non-zero counts.
+	const defaultChangeset = session?.changesets.read(reader)?.find(c => c.isDefault.read(reader));
 	let insertions = 0;
 	let deletions = 0;
-	for (const change of branchChangeset?.changes.read(reader) ?? session?.changes.read(reader) ?? []) {
+	for (const change of defaultChangeset?.changes.read(reader) ?? session?.changes.read(reader) ?? []) {
 		insertions += change.insertions;
 		deletions += change.deletions;
 	}


### PR DESCRIPTION
## What

The Agents window session **header diff-stats pill** (the `⊟ N files +X -Y` chip) — and the `hasChanges` context key that gates its visibility — now read the session's **default changeset** instead of looking up the branch diff by a hardcoded id.

## Why

The pill located the branch diff via the well-known `branchChanges` changeset id, falling back to the session's top-level `session.changes` when not found. The **Copilot** provider uses that id, but the **agent-host** provider ids its branch changeset by its kind (`branch`). So for agent-host sessions the lookup missed and the pill fell back to `session.changes`, which for that provider is the **Session Changes** changeset — showing the full session totals (e.g. `220 files +10877 -2387`) instead of the **Branch Changes** the Changes view displays (e.g. `+492 -140`).

## How

Read the changeset the provider marks as `isDefault` — the same one the Changes view selects by default:

- git workspace → **Branch Changes** (branch-vs-base)
- otherwise → the session's working changes

This is provider-agnostic (no hardcoded id/label), keeps the existing fallback to `session.changes` when there is no default changeset, and stays independent of whichever changeset the Changes view currently has selected.

## Notes for reviewers

- Both call sites use the same inline `changesets.find(c => c.isDefault.read(reader))` (a shared helper was added during review and then inlined back per feedback).
- No provider code changed; the agent-host changeset `id` is intentionally left as-is to avoid affecting other consumers.

## Testing

- `npm run valid-layers-check` ✅ (compiles all layers)
- Problems/type check on the changed files ✅
- Manual: for an agent-host session in a git repo, the header pill now matches the **Branch Changes** stats in the Changes view, and stays put when the Changes view changeset selection is changed.
