### PR TITLE
Style overrides: Update tab background colors and add shadows override module

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/shadows.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/shadows.css
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*
+ * Style-override module: "No Part Shadows".
+ *
+ * The `workbench.shadows` setting (default on) casts elevation shadows from the
+ * workbench parts onto their neighbours: the title bar, the activity bar, the
+ * editor tabs and the panel "depth" shadows that fall on the editor surface.
+ * The Modern UI look is flat, so this module neutralises those part shadows
+ * regardless of the `workbench.shadows` setting.
+ *
+ * Only the part-level shadows are suppressed. The floating-modal shadows
+ * (`--vscode-shadow-lg` / `--vscode-shadow-xl` used by hovers, dropdowns,
+ * dialogs and notifications) are intentionally left alone — these are preserved
+ * even when `workbench.shadows` is disabled.
+ *
+ * All rules are gated behind the `.style-override` class, which the
+ * StyleOverridesContribution toggles onto the workbench container(s) when the
+ * `workbench.experimental.modernUI` (Modern UI Update) setting is enabled.
+ */
+
+.style-override.monaco-workbench {
+	/*
+	 * Use zero-offset transparent shadows instead of `none` because these
+	 * variables are interpolated into multi-value box-shadow declarations.
+	 */
+	--vscode-shadow-active-tab: 0 0 0 0 transparent;
+	--vscode-shadow-depth-x: 0 0 0 0 transparent;
+	--vscode-shadow-depth-y: 0 0 0 0 transparent;
+	--vscode-shadow-sm: 0 0 0 0 transparent;
+}
+
+.style-override.monaco-workbench .part.titlebar,
+.style-override.monaco-workbench .part.activitybar,
+.style-override.monaco-workbench.nosidebar .part.activitybar,
+.style-override.monaco-workbench.activitybar-right .part.activitybar,
+.style-override.monaco-workbench .part.editor .tabs-container > .tab,
+.style-override.monaco-workbench .part.editor .tabs-container > .tab:hover:not(.active),
+.style-override.monaco-workbench .part.editor .tabs-container > .tab.active {
+	box-shadow: none !important;
+}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -41,11 +41,28 @@
 }
 
 .style-override .part.editor .tabs-container > .tab.active {
-	background-color: color-mix(in srgb, var(--vscode-foreground) 10%, transparent) !important;
+	background-color: color-mix(in srgb, var(--vscode-foreground) 18%, transparent) !important;
 }
 
 .style-override.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-and-actions-container .tabs-container > .tab:not(.active):hover {
 	background-color: color-mix(in srgb, var(--vscode-foreground) 8%, transparent) !important;
+}
+
+/*
+ * Light themes: the foreground is dark, so the same foreground-based mixes read
+ * much heavier on a light surface than on a dark one. Tone the tab backgrounds
+ * down so the pills stay subtle.
+ */
+.style-override.monaco-workbench.vs .part.editor .tabs-container > .tab {
+	background-color: color-mix(in srgb, var(--vscode-foreground) 4%, transparent) !important;
+}
+
+.style-override.monaco-workbench.vs .part.editor .tabs-container > .tab.active {
+	background-color: color-mix(in srgb, var(--vscode-foreground) 10%, transparent) !important;
+}
+
+.style-override.monaco-workbench.vs .part.editor > .content .editor-group-container > .title .tabs-and-actions-container .tabs-container > .tab:not(.active):hover {
+	background-color: color-mix(in srgb, var(--vscode-foreground) 6%, transparent) !important;
 }
 
 .style-override .part.editor .tabs-container > .tab .tab-border-top-container,
@@ -147,6 +164,19 @@
 .style-override .part.editor > .content .editor-group-container > .title .tabs-container > .tab .tab-label a {
 	font-size: 12px;
 	font-weight: var(--vscode-agents-fontWeight-semiBold);
+}
+
+/*
+ * Dim the foreground of inactive tabs so the active tab reads as the clear
+ * focal point. The active tab keeps the full `--vscode-foreground` colour
+ * (paired with the stronger active background above).
+ */
+.style-override .part.editor > .content .editor-group-container > .title .tabs-container > .tab:not(.active) .tab-label a {
+	color: color-mix(in srgb, var(--vscode-foreground) 50%, transparent) !important;
+}
+
+.style-override .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active .tab-label a {
+	color: var(--vscode-foreground) !important;
 }
 
 /*

--- a/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
+++ b/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
@@ -22,6 +22,7 @@ import './media/padding.css';
 import './media/paneHeaders.css';
 import './media/roundedCorners.css';
 import './media/scrollShadows.css';
+import './media/shadows.css';
 import './media/statusBar.css';
 import './media/tabs.css';
 
@@ -61,6 +62,7 @@ const STYLE_OVERRIDE_MODULES: readonly IStyleOverrideModule[] = [
 	{ id: 'paneHeaders', layoutAffecting: true },
 	{ id: 'roundedCorners' },
 	{ id: 'scrollShadows' },
+	{ id: 'shadows' },
 	{ id: 'statusBar' },
 	{ id: 'tabs' }
 ];


### PR DESCRIPTION
This pull request introduces a new style override module to neutralize elevation shadows in the workbench UI, and refines the appearance of editor tabs for both light and dark themes. The main goal is to support a flatter, more modern UI look when the `workbench.experimental.modernUI` setting is enabled, while ensuring better visual clarity for active and inactive tabs.

Responding to feedback:

> One thing I'm struggling with is that it's difficult to distinguish which editor tab is the active one. Can we make this a bit more obvious?

> The horizontal line that drops a shadow that is at the top and goes across the workbench makes me feel that something is off or very heavy

**Key changes:**

**Shadow suppression (Modern UI):**
* Added a new `shadows.css` module that overrides workbench part shadow variables and disables box-shadows for the title bar, activity bar, and editor tabs when the Modern UI style override is active. This ensures a flat appearance by neutralizing elevation shadows, but preserves floating-modal shadows for elements like dialogs and notifications.
* Registered the new `shadows` style override module in the style overrides contribution file, so it is loaded and available for toggling. [[1]](diffhunk://#diff-a865927f9a8f20356e381f95544db109d49d6ae661c7a60a1a50a37e329aadc2R25) [[2]](diffhunk://#diff-a865927f9a8f20356e381f95544db109d49d6ae661c7a60a1a50a37e329aadc2R65)

**Tab appearance improvements:**
* Adjusted the background color mix for active editor tabs to use a slightly stronger foreground blend (from 10% to 18%) for better emphasis in the Modern UI.
* For light themes, further tuned tab backgrounds to stay subtle and avoid heavy appearance by using lower foreground mix percentages for both active and inactive tabs.
* Dimmed the text color of inactive tabs to 50% opacity, making the active tab label stand out as the focal point, while keeping the active tab label at full foreground color.