### PR TITLE
Include subagent credits in live session cost total

### DIFF
--- a/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
+++ b/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
@@ -10,6 +10,7 @@ import { IAuthenticationChatUpgradeService } from '../../../platform/authenticat
 import { IChatDebugFileLoggerService } from '../../../platform/chat/common/chatDebugFileLoggerService';
 import { IChatHookService, SessionStartHookInput, SessionStartHookOutput, StopHookInput, StopHookOutput, SubagentStartHookInput, SubagentStartHookOutput, SubagentStopHookInput, SubagentStopHookOutput } from '../../../platform/chat/common/chatHookService';
 import { FetchStreamSource, IResponsePart } from '../../../platform/chat/common/chatMLFetcher';
+import { IChatQuotaService } from '../../../platform/chat/common/chatQuotaService';
 import { CanceledResult, ChatFetchResponseType, ChatLocation, ChatResponse } from '../../../platform/chat/common/commonTypes';
 import { IHistoricalTurn, ISessionTranscriptService, ToolRequest } from '../../../platform/chat/common/sessionTranscriptService';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
@@ -21,7 +22,7 @@ import { IGitService } from '../../../platform/git/common/gitService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { isOpenAIContextManagementResponse, OpenAiFunctionDef } from '../../../platform/networking/common/fetch';
 import { IChatEndpoint, IMakeChatRequestOptions } from '../../../platform/networking/common/networking';
-import { nanoAiuToCredits, OpenAIContextManagementResponse } from '../../../platform/networking/common/openai';
+import { OpenAIContextManagementResponse } from '../../../platform/networking/common/openai';
 import { CopilotChatAttr, emitAgentTurnEvent, emitSessionStartEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, GitHubCopilotAttr, normalizeResponseModel, resolveWorkspaceOTelMetadata, StdAttr, stringifyToolDefinitionsForOTel, truncateForOTel, workspaceMetadataToOTelAttributes } from '../../../platform/otel/common/index';
 import { IOTelService, ISpanHandle, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
@@ -181,16 +182,6 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 	private lastModelCallId: string | undefined;
 
 	/**
-	 * Running total of Copilot credits across every model call in the current
-	 * turn. Each fetch reports the credits for that single call, but the context
-	 * usage widget and `IChatModel.sessionCost` treat the per-request value as the
-	 * whole turn, so we accumulate here and emit the running total — mirroring the
-	 * cumulative credits the agent host reports. Reset on the first iteration of a
-	 * turn ({@link runOne} with `iterationNumber === 0`).
-	 */
-	private _accumulatedCopilotCredits: number | undefined;
-
-	/**
 	 * The full {@link ToolCallingLoopFetchOptions} from the most recent fetch.
 	 * Probes reuse this wholesale (overriding only `messages` and `finishedCb`)
 	 * so that the server-side prompt cache key — which includes tool schemas,
@@ -244,6 +235,7 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 		@IFileSystemService private readonly _fileSystemService: IFileSystemService,
 		@IOTelService protected readonly _otelService: IOTelService,
 		@IGitService private readonly _gitService: IGitService,
+		@IChatQuotaService private readonly _chatQuotaService: IChatQuotaService,
 	) {
 		super();
 	}
@@ -1406,11 +1398,6 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 
 	/** Runs a single iteration of the tool calling loop. */
 	public async runOne(outputStream: ChatResponseStream | undefined, iterationNumber: number, token: CancellationToken): Promise<IToolCallSingleResult> {
-		// The first iteration of a turn starts a fresh credit total. Resetting here
-		// (rather than only in run()) keeps runOne() correct when called standalone.
-		if (iterationNumber === 0) {
-			this._accumulatedCopilotCredits = undefined;
-		}
 		let availableTools = await this.getAvailableTools(outputStream, token);
 
 		// Emit tools_available on the agent span once, before the first CHAT span
@@ -1652,18 +1639,19 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 		// Report token usage to the stream for rendering the context window widget
 		const stream = streamParticipants[streamParticipants.length - 1];
 		if (fetchResult.type === ChatFetchResponseType.Success && fetchResult.usage && stream && this.shouldReportUsageToContextWidget()) {
-			// Credits are billed per model call and a single turn can make many calls.
-			// Accumulate so the per-request usage reflects the whole turn (and the
-			// session cost sums correctly) instead of only the final call's credits.
-			const callCredits = nanoAiuToCredits(fetchResult.usage.copilot_usage?.total_nano_aiu);
-			if (callCredits !== undefined) {
-				this._accumulatedCopilotCredits = (this._accumulatedCopilotCredits ?? 0) + callCredits;
-			}
+			// Credits are billed per model call and a single turn can make many calls
+			// — including calls made by subagents this turn invoked. The quota service
+			// accumulates every call's credits under the top-level turn id (see
+			// chatMLFetcher), so reading the turn total here keeps the running
+			// `IChatModel.sessionCost` in sync with the final per-turn total (which
+			// chatParticipantRequestHandler reads from the same key) and includes
+			// subagent spend, instead of only this loop's own calls.
+			const topLevelTurnId = this.options.request.parentRequestId ?? this.turn.id;
 			stream.usage({
 				completionTokens: fetchResult.usage.completion_tokens,
 				promptTokens: fetchResult.usage.prompt_tokens,
 				outputBuffer: endpoint.maxOutputTokens,
-				copilotCredits: this._accumulatedCopilotCredits,
+				copilotCredits: this._chatQuotaService.getCreditsForTurn(topLevelTurnId),
 				promptTokenDetails,
 			});
 		}

--- a/extensions/copilot/src/extension/intents/test/node/toolCallingLoopUsage.spec.ts
+++ b/extensions/copilot/src/extension/intents/test/node/toolCallingLoopUsage.spec.ts
@@ -7,6 +7,7 @@ import { Raw } from '@vscode/prompt-tsx';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { ChatRequest, LanguageModelChat, LanguageModelToolInformation } from 'vscode';
 import { ChatFetchResponseType, ChatResponse } from '../../../../platform/chat/common/commonTypes';
+import { IChatQuotaService } from '../../../../platform/chat/common/chatQuotaService';
 import { toTextPart } from '../../../../platform/chat/common/globalStringUtils';
 import { ITestingServicesAccessor } from '../../../../platform/test/node/services';
 import { ChatResponseStreamImpl } from '../../../../util/common/chatResponseStreamImpl';
@@ -73,6 +74,14 @@ class UsageTestToolCallingLoop extends ToolCallingLoop<IToolCallingLoopOptions> 
 }
 
 class CreditsTestToolCallingLoop extends ToolCallingLoop<IToolCallingLoopOptions> {
+	// The quota service that, in production, chatMLFetcher records every call into.
+	// The test wires the same singleton here so the fake fetch can mirror that.
+	private _quota: IChatQuotaService | undefined;
+
+	public setQuota(quota: IChatQuotaService): void {
+		this._quota = quota;
+	}
+
 	protected override async buildPrompt(_buildPromptContext: IBuildPromptContext): Promise<IBuildPromptResult> {
 		return {
 			...nullRenderPromptResult(),
@@ -84,8 +93,11 @@ class CreditsTestToolCallingLoop extends ToolCallingLoop<IToolCallingLoopOptions
 		return [];
 	}
 
-	// Each model call bills 5 credits (5 * 1e9 nano-AIU).
+	// Each model call bills 5 credits (5 * 1e9 nano-AIU). Record it into the quota
+	// service under the top-level turn id, exactly as chatMLFetcher does in production.
 	protected override async fetch(): Promise<ChatResponse> {
+		const topLevelTurnId = this.options.request.parentRequestId ?? this.options.conversation.getLatestTurn().id;
+		this._quota?.setLastCopilotUsage(5_000_000_000, topLevelTurnId);
 		return {
 			type: ChatFetchResponseType.Success,
 			value: 'test-response',
@@ -201,6 +213,7 @@ describe('ToolCallingLoop usage reporting', () => {
 				request,
 			}
 		);
+		loop.setQuota(accessor.get(IChatQuotaService));
 		disposables.add(loop);
 		const stream = new UsageCapturingStream();
 
@@ -210,5 +223,31 @@ describe('ToolCallingLoop usage reporting', () => {
 		await loop.runOne(stream, 1, tokenSource.token);
 
 		expect(stream.usages.map(u => u.copilotCredits)).toEqual([5, 10]);
+	});
+
+	it('includes subagent credits recorded under the same turn in the running total', async () => {
+		const request = createMockChatRequest();
+		const conversation = createConversation(request.prompt);
+		const quota = accessor.get(IChatQuotaService);
+		// A subagent invoked during this turn records its spend under the parent turn
+		// id (chatMLFetcher keys subagent calls by the top-level turn id).
+		quota.setLastCopilotUsage(3_000_000_000, conversation.getLatestTurn().id);
+
+		const loop = instantiationService.createInstance(
+			CreditsTestToolCallingLoop,
+			{
+				conversation,
+				toolCallLimit: 1,
+				request,
+			}
+		);
+		loop.setQuota(quota);
+		disposables.add(loop);
+		const stream = new UsageCapturingStream();
+
+		await loop.runOne(stream, 0, tokenSource.token);
+
+		// The parent's own call bills 5, plus the subagent's 3 = 8.
+		expect(stream.usages.map(u => u.copilotCredits)).toEqual([8]);
 	});
 });

--- a/extensions/copilot/src/extension/mcp/vscode-node/mcpToolCallingLoop.tsx
+++ b/extensions/copilot/src/extension/mcp/vscode-node/mcpToolCallingLoop.tsx
@@ -6,6 +6,7 @@
 import type { CancellationToken, LanguageModelToolInformation, Progress } from 'vscode';
 import { IAuthenticationChatUpgradeService } from '../../../platform/authentication/common/authenticationUpgrade';
 import { IChatHookService } from '../../../platform/chat/common/chatHookService';
+import { IChatQuotaService } from '../../../platform/chat/common/chatQuotaService';
 import { ChatLocation, ChatResponse } from '../../../platform/chat/common/commonTypes';
 import { ISessionTranscriptService } from '../../../platform/chat/common/sessionTranscriptService';
 import { IConfigurationService } from '../../../platform/configuration/common/configurationService';
@@ -48,8 +49,9 @@ export class McpToolCallingLoop extends ToolCallingLoop<IMcpToolCallingLoopOptio
 		@IFileSystemService fileSystemService: IFileSystemService,
 		@IOTelService otelService: IOTelService,
 		@IGitService gitService: IGitService,
+		@IChatQuotaService chatQuotaService: IChatQuotaService,
 	) {
-		super(options, instantiationService, endpointProvider, logService, requestLogger, authenticationChatUpgradeService, telemetryService, configurationService, experimentationService, chatHookService, sessionTranscriptService, fileSystemService, otelService, gitService);
+		super(options, instantiationService, endpointProvider, logService, requestLogger, authenticationChatUpgradeService, telemetryService, configurationService, experimentationService, chatHookService, sessionTranscriptService, fileSystemService, otelService, gitService, chatQuotaService);
 	}
 
 	private async getEndpoint() {

--- a/extensions/copilot/src/extension/prompt/node/codebaseToolCalling.ts
+++ b/extensions/copilot/src/extension/prompt/node/codebaseToolCalling.ts
@@ -7,6 +7,7 @@ import { randomUUID } from 'crypto';
 import type { CancellationToken, ChatRequest, LanguageModelToolInformation, Progress } from 'vscode';
 import { IAuthenticationChatUpgradeService } from '../../../platform/authentication/common/authenticationUpgrade';
 import { IChatHookService } from '../../../platform/chat/common/chatHookService';
+import { IChatQuotaService } from '../../../platform/chat/common/chatQuotaService';
 import { ChatLocation, ChatResponse } from '../../../platform/chat/common/commonTypes';
 import { ISessionTranscriptService } from '../../../platform/chat/common/sessionTranscriptService';
 import { IConfigurationService } from '../../../platform/configuration/common/configurationService';
@@ -52,8 +53,9 @@ export class CodebaseToolCallingLoop extends ToolCallingLoop<ICodebaseToolCallin
 		@IFileSystemService fileSystemService: IFileSystemService,
 		@IOTelService otelService: IOTelService,
 		@IGitService gitService: IGitService,
+		@IChatQuotaService chatQuotaService: IChatQuotaService,
 	) {
-		super(options, instantiationService, endpointProvider, logService, requestLogger, authenticationChatUpgradeService, telemetryService, configurationService, experimentationService, chatHookService, sessionTranscriptService, fileSystemService, otelService, gitService);
+		super(options, instantiationService, endpointProvider, logService, requestLogger, authenticationChatUpgradeService, telemetryService, configurationService, experimentationService, chatHookService, sessionTranscriptService, fileSystemService, otelService, gitService, chatQuotaService);
 	}
 
 	private async getEndpoint(request: ChatRequest) {

--- a/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
+++ b/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
@@ -11,6 +11,7 @@ import { IAuthenticationChatUpgradeService } from '../../../platform/authenticat
 import { IChatHookService, UserPromptSubmitHookInput, UserPromptSubmitHookOutput } from '../../../platform/chat/common/chatHookService';
 import { CanceledResult, ChatFetchError, ChatFetchResponseType, ChatLocation, ChatResponse, getErrorDetailsFromChatFetchError } from '../../../platform/chat/common/commonTypes';
 import { IConversationOptions } from '../../../platform/chat/common/conversationOptions';
+import { IChatQuotaService } from '../../../platform/chat/common/chatQuotaService';
 import { ISessionTranscriptService } from '../../../platform/chat/common/sessionTranscriptService';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { IEditSurvivalTrackerService, IEditSurvivalTrackingSession, NullEditSurvivalTrackingSession } from '../../../platform/editSurvivalTracking/common/editSurvivalTrackerService';
@@ -615,8 +616,9 @@ class DefaultToolCallingLoop extends ToolCallingLoop<IDefaultToolLoopOptions> {
 		@IFileSystemService fileSystemService: IFileSystemService,
 		@IOTelService otelService: IOTelService,
 		@IGitService gitService: IGitService,
+		@IChatQuotaService chatQuotaService: IChatQuotaService,
 	) {
-		super(options, instantiationService, endpointProvider, logService, requestLogger, authenticationChatUpgradeService, telemetryService, configurationService, experimentationService, chatHookService, sessionTranscriptService, fileSystemService, otelService, gitService);
+		super(options, instantiationService, endpointProvider, logService, requestLogger, authenticationChatUpgradeService, telemetryService, configurationService, experimentationService, chatHookService, sessionTranscriptService, fileSystemService, otelService, gitService, chatQuotaService);
 
 		this._register(this.onDidBuildPrompt(({ result, tools, promptTokenLength, toolTokenCount }) => {
 			if (result.metadata.get(SummarizedConversationHistoryMetadata)) {

--- a/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
+++ b/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
@@ -7,6 +7,7 @@ import { randomUUID } from 'crypto';
 import type { CancellationToken, ChatRequest, ChatResponseStream, LanguageModelToolInformation, Progress } from 'vscode';
 import { IAuthenticationChatUpgradeService } from '../../../platform/authentication/common/authenticationUpgrade';
 import { IChatHookService } from '../../../platform/chat/common/chatHookService';
+import { IChatQuotaService } from '../../../platform/chat/common/chatQuotaService';
 import { ChatLocation, ChatResponse } from '../../../platform/chat/common/commonTypes';
 import { ISessionTranscriptService } from '../../../platform/chat/common/sessionTranscriptService';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
@@ -88,9 +89,10 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 		@IFileSystemService fileSystemService: IFileSystemService,
 		@IOTelService otelService: IOTelService,
 		@IGitService gitService: IGitService,
+		@IChatQuotaService chatQuotaService: IChatQuotaService,
 		@ITerminalService private readonly terminalService: ITerminalService,
 	) {
-		super(options, instantiationService, endpointProvider, logService, requestLogger, authenticationChatUpgradeService, telemetryService, configurationService, experimentationService, chatHookService, sessionTranscriptService, fileSystemService, otelService, gitService);
+		super(options, instantiationService, endpointProvider, logService, requestLogger, authenticationChatUpgradeService, telemetryService, configurationService, experimentationService, chatHookService, sessionTranscriptService, fileSystemService, otelService, gitService, chatQuotaService);
 	}
 
 	protected override createPromptContext(availableTools: LanguageModelToolInformation[], outputStream: ChatResponseStream | undefined): IBuildPromptContext {

--- a/extensions/copilot/src/extension/prompt/node/searchSubagentToolCallingLoop.ts
+++ b/extensions/copilot/src/extension/prompt/node/searchSubagentToolCallingLoop.ts
@@ -7,6 +7,7 @@ import { randomUUID } from 'crypto';
 import type { CancellationToken, ChatRequest, ChatResponseStream, LanguageModelToolInformation, Progress } from 'vscode';
 import { IAuthenticationChatUpgradeService } from '../../../platform/authentication/common/authenticationUpgrade';
 import { IChatHookService } from '../../../platform/chat/common/chatHookService';
+import { IChatQuotaService } from '../../../platform/chat/common/chatQuotaService';
 import { ChatFetchResponseType, ChatLocation, ChatResponse } from '../../../platform/chat/common/commonTypes';
 import { ISessionTranscriptService } from '../../../platform/chat/common/sessionTranscriptService';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
@@ -76,8 +77,9 @@ export class SearchSubagentToolCallingLoop extends ToolCallingLoop<ISearchSubage
 		@IFileSystemService fileSystemService: IFileSystemService,
 		@IOTelService otelService: IOTelService,
 		@IGitService gitService: IGitService,
+		@IChatQuotaService chatQuotaService: IChatQuotaService,
 	) {
-		super(options, instantiationService, endpointProvider, logService, requestLogger, authenticationChatUpgradeService, telemetryService, configurationService, experimentationService, chatHookService, sessionTranscriptService, fileSystemService, otelService, gitService);
+		super(options, instantiationService, endpointProvider, logService, requestLogger, authenticationChatUpgradeService, telemetryService, configurationService, experimentationService, chatHookService, sessionTranscriptService, fileSystemService, otelService, gitService, chatQuotaService);
 	}
 
 	protected override createPromptContext(availableTools: LanguageModelToolInformation[], outputStream: ChatResponseStream | undefined): IBuildPromptContext {


### PR DESCRIPTION
## Summary

Version 1.126 came with [session-level cost information](https://code.visualstudio.com/updates/v1_126#_session-level-cost-information) which is great! But it does not reflect the total cost when we include sub agent calls as well.

The running **Session Cost** shown in the chat context-usage widget only summed the
parent tool-calling loop's own model-call credits. Credits spent by **subagents**
(e.g. the Explore subagent) were missing from the live total — even though the
per-message footer total at the end of each turn already included them.

This makes the live total now match the final per-message total by reading the
authoritative per-turn credit total instead of a local accumulator.

## Root cause

`ToolCallingLoop` tracked a local `_accumulatedCopilotCredits` field that only
summed the credits of the calls made by that loop. Subagent loops run as separate
`ToolCallingLoop` instances with their own accumulators and are suppressed from
reporting to the context widget (`shouldReportUsageToContextWidget()` is `false`
for subagent invocations), so their spend never reached the running total.

## Fix

- Inject `IChatQuotaService` into the base `ToolCallingLoop` (and forward it through
  all subclass constructors).
- When emitting usage to the stream, read
  `IChatQuotaService.getCreditsForTurn(topLevelTurnId)` — the quota service already
  accumulates every model call (parent **and** subagent) under the top-level turn id,
  because `chatMLFetcher` records subagent calls keyed by the parent turn id.
- Remove the now-redundant `_accumulatedCopilotCredits` accumulator and its per-turn
  reset.

This keeps the live `IChatModel.sessionCost` in sync with the final per-turn total
that `chatParticipantRequestHandler` reads from the same key.

## Before / After

The message footer total already accounts for the subagent's spend; the live
**Session Cost** widget did not. (The absolute numbers differ between the two runs —
the point is the relationship between the footer total and the widget.)

**Before** — the response footer reads **5.7 credits**, but the live **Session Cost**
widget shows only **3.6 credits**: the Explore subagent's spend is missing.

<img width="298" height="515" alt="chat view" src="https://github.com/user-attachments/assets/7f04b755-eb93-436c-a979-f1c5b4888f95" />


**After** — the response footer reads **5.4 credits** and the live **Session Cost**
widget now matches at **5.4 credits**: the subagent's spend is included.


<img width="298" height="515" alt="chat view fixed" src="https://github.com/user-attachments/assets/ba116553-1c76-4606-a179-168ef16230c5" />


### Supporting context — per-call cost breakdown

The subagent (`runSubagent-Explore`) does make its own billed model calls, which the per-message total already includes:

<img width="639" height="184" alt="call details" src="https://github.com/user-attachments/assets/c6175bdb-b315-4a92-aeaf-23f1ff0d3429" />

<img width="413" height="176" alt="call total" src="https://github.com/user-attachments/assets/59ac033c-cafa-4ca4-8b0d-6d38b1f6294e" />



## Testing

- Updated `toolCallingLoopUsage.spec.ts`: the credits test now records fetches into
  `IChatQuotaService` (simulating `chatMLFetcher`) and still asserts the running
  total `[5, 10]` across iterations.
- Added a test verifying the parent loop's running total includes subagent credits
  recorded under the same turn id (`5` parent + `3` subagent = `8`).
- `npm test:unit` (vitest) for the affected spec passes (4/4).
- Copilot extension typecheck passes against latest `main`.
