### PR TITLE
Fix enumItemLabels in extensions.autoUpdate setting

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -138,10 +138,6 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 			'extensions.autoUpdate': {
 				type: 'string',
 				enum: ['on', 'off'],
-				enumItemLabels: [
-					localize('on', "On"),
-					localize('off', "Off"),
-				],
 				enumDescriptions: [
 					localize('extensions.autoUpdate.on', 'Download and install updates automatically only for enabled extensions.'),
 					localize('extensions.autoUpdate.off', 'Extensions are not automatically updated.'),


### PR DESCRIPTION
This pull request addresses [issue #7839](https://github.com/microsoft/vscode-internalbacklog/issues/7839) by modifying the `extensions.autoUpdate` setting in `extensions.contribution.ts`. 

### Changes made:
- Removed the `enumItemLabels` ("On"/"Off") for the `extensions.autoUpdate` setting.
- This change prevents the settings UI from displaying both the label and the value (e.g., "On on"), which was causing confusion.
- The dropdown now correctly shows the lowercase enum values ('on'/'off'), ensuring consistency with other settings.

These adjustments enhance the clarity and usability of the settings UI.