### PR TITLE
sessions: keep new-session side pane closed when toggled shut

### DIFF
--- a/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.md
+++ b/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.md
@@ -79,4 +79,6 @@ default layout instead of stale state. Open editors are still preserved.
   `_panelVisibilityBySession` for every visible session; editor working sets are left untouched.
 - **Subclass hook** — `_registerViewStateManagement()` runs at the end of the base constructor for
   platform-specific auxiliary bar wiring (no-op in the base); `_captureActiveSessionViewState(resource)`
-  is the save-time hook (no-op in the base) invoked by [B4].
+  is the save-time hook (no-op in the base) invoked by [B4]; `_onSidePaneToggled()` runs at the end of
+  `toggleSidePane()` (no-op in the base) so a subclass can record the resulting side-pane state, which
+  the per-session capture listener deliberately ignores while the side pane is toggled.

--- a/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
@@ -366,11 +366,24 @@ export abstract class BaseLayoutController extends Disposable {
 				}
 			}
 
+			// Let subclasses record the resulting side-pane state. The [D2]
+			// per-session capture listener stays suppressed while `_togglingSidePane`
+			// is set, so subclasses that care must observe the change here instead.
+			this._onSidePaneToggled();
+
 			return !isCurrentlyVisible;
 		} finally {
 			this._togglingSidePane = false;
 		}
 	}
+
+	/**
+	 * Hook invoked at the end of {@link toggleSidePane}, while
+	 * {@link _togglingSidePane} is still set, so subclasses can record the
+	 * resulting side-pane state (which the [D2] capture listener deliberately
+	 * ignores). The base implementation does nothing.
+	 */
+	protected _onSidePaneToggled(): void { }
 
 	/**
 	 * [B4] Hook that lets a subclass snapshot the active session's view state when

--- a/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
@@ -366,9 +366,7 @@ export abstract class BaseLayoutController extends Disposable {
 				}
 			}
 
-			// Let subclasses record the resulting side-pane state. The [D2]
-			// per-session capture listener stays suppressed while `_togglingSidePane`
-			// is set, so subclasses that care must observe the change here instead.
+			// Let subclasses record the resulting side-pane state ([D2] capture is suppressed while toggling).
 			this._onSidePaneToggled();
 
 			return !isCurrentlyVisible;

--- a/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.md
+++ b/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.md
@@ -44,9 +44,16 @@ rules.
 
 #### D9 — Closing the whole side pane is not an aux-bar choice
 The "side pane" is the editor area together with the auxiliary bar. Closing it (e.g. from the side
-panel toggle) hides both at once. That is **not** remembered as a choice to hide the side pane for the
-session, so reopening the Changes editor shows it again (D8). Only hiding the auxiliary bar on its own,
-while the editor stays open, is remembered as an explicit "closed" choice.
+panel toggle) hides both at once. For an **existing (created)** session that is **not** remembered as a
+choice to hide the side pane, so reopening the Changes editor shows it again (D8). Only hiding the
+auxiliary bar on its own, while the editor stays open, is remembered as an explicit "closed" choice.
+
+#### D9b — Closing the whole side pane on a new session is remembered
+For a **new (uncreated)** session, closing (or opening) the whole side pane **is** recorded as the
+shared new-session side-pane choice (D3b). This means once you close the side pane while composing a
+new session, it stays closed: it is not re-opened when that same new session re-syncs (e.g. once it
+gains its workspace, un-maximizes, or collapses back from a multi-session view), nor when the next new
+session is created. Suspended while multiple sessions are visible or the editor is maximized (D5).
 
 ### Scenario: returning to a session
 When you focus a session, its side pane is restored from the state remembered above.
@@ -149,7 +156,14 @@ defaults **on** in non-stable builds (Insiders / exploration) and **off** in sta
   The toggle hides/shows the editor area and auxiliary bar together (remembering which parts to restore
   in `_lastVisibleSidePaneParts`) while `_togglingSidePane` is set. The [D2] listener skips capture
   while that flag is set, so closing or opening the whole side pane is never recorded as a per-session
-  aux-bar choice.
+  (created) aux-bar choice.
+- **New-session side-pane close [D9b]** — the base `toggleSidePane` calls the `_onSidePaneToggled` hook
+  at the end (still inside the `_togglingSidePane` window). The desktop controller overrides it: when
+  the active session is **uncreated** (and not multi-session / not maximized), it records the resulting
+  aux-bar visibility via `_setNewSessionViewState`, so a whole-side-pane close on a new session is
+  remembered just like hiding the aux bar alone. This is what makes a closed side pane survive both a
+  re-sync of the same new session and the creation of the next new session (D3b reads the recorded
+  state). For created sessions the hook is a no-op, preserving D9.
 - **Responsive sidebar [D7]** — `_registerResponsiveSidebar` derives `spaceConstrained = enabled && small
   && editor visible && aux-bar visible && !multipleSessionsVisible` from the experimental setting
   `sessions.layout.autoCollapseSessionsSidebar` (`observableConfigValue`, default `product.quality !==

--- a/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
@@ -351,12 +351,8 @@ export class LayoutController extends BaseLayoutController {
 	}
 
 	/**
-	 * [D9b] Closing or opening the whole side pane on a new (uncreated) session is
-	 * recorded as the shared new-session aux-bar choice, so a later restore (D3b)
-	 * never re-opens an aux bar the user closed — neither when the same new
-	 * session re-syncs (e.g. once it gains a workspace) nor when the next new
-	 * session is created. For created sessions this stays a non-choice (D9), so
-	 * reopening the Changes editor reveals the side pane again (D8).
+	 * [D9b] Records a whole-side-pane toggle on a new (uncreated) session as the
+	 * shared new-session aux-bar choice. See `desktopSessionLayoutController.md`.
 	 */
 	protected override _onSidePaneToggled(): void {
 		if (this.multipleSessionsVisibleObs.get()) {

--- a/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
@@ -350,6 +350,28 @@ export class LayoutController extends BaseLayoutController {
 		this._captureViewState(sessionResource);
 	}
 
+	/**
+	 * [D9b] Closing or opening the whole side pane on a new (uncreated) session is
+	 * recorded as the shared new-session aux-bar choice, so a later restore (D3b)
+	 * never re-opens an aux bar the user closed — neither when the same new
+	 * session re-syncs (e.g. once it gains a workspace) nor when the next new
+	 * session is created. For created sessions this stays a non-choice (D9), so
+	 * reopening the Changes editor reveals the side pane again (D8).
+	 */
+	protected override _onSidePaneToggled(): void {
+		if (this.multipleSessionsVisibleObs.get()) {
+			return;
+		}
+		if (this._layoutService.isEditorMaximized()) {
+			return;
+		}
+		const activeSession = this._sessionsService.activeSession.get();
+		if (!activeSession || activeSession.isCreated.get()) {
+			return;
+		}
+		this._setNewSessionViewState({ auxiliaryBarVisible: this._layoutService.isVisible(Parts.AUXILIARYBAR_PART) });
+	}
+
 	// --- Auxiliary bar [D1] ---
 
 	private _captureViewState(sessionResource: URI): void {

--- a/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
@@ -422,6 +422,77 @@ suite('LayoutController (desktop)', () => {
 		);
 	});
 
+	// --- [D9b] Closing the whole side pane on a new (uncreated) session ---
+
+	test('[D9b] closing the whole side pane on a new session keeps it closed for the next new session', () => {
+		const controller = createController();
+		const untitled1 = makeSession(URI.parse('session:untitled1'), { status: SessionStatus.Untitled });
+		const existing = makeSession(URI.parse('session:existing'));
+		const untitled2 = makeSession(URI.parse('session:untitled2'), { status: SessionStatus.Untitled });
+
+		// Open a new (untitled) session — aux bar shows the Files view.
+		harness.activeSessionObs.set(untitled1, undefined);
+		assert.ok(harness.openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID));
+
+		// User closes the whole side pane (editor + aux bar) via the toggle.
+		harness.partVisibility.set(Parts.EDITOR_PART, true);
+		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, true);
+		controller.toggleSidePane();
+
+		// The closed state is recorded for the shared new-session view.
+		assert.deepStrictEqual(
+			JSON.parse(harness.storageService.get('sessions.newSessionViewState', StorageScope.WORKSPACE) ?? ''),
+			{ auxiliaryBarVisible: false },
+			'closing the whole side pane on a new session should record the closed choice'
+		);
+
+		// Switch via an existing session to the next new (untitled) session.
+		harness.activeSessionObs.set(existing, undefined);
+		harness.setPartHiddenCalls = [];
+		harness.openedViewContainers = [];
+		harness.activeSessionObs.set(untitled2, undefined);
+
+		assert.ok(
+			harness.setPartHiddenCalls.some(c => c.part === Parts.AUXILIARYBAR_PART && c.hidden === true),
+			'aux bar should stay hidden on the next new session'
+		);
+		assert.ok(
+			!harness.openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID),
+			'should not re-open the Files view on the next new session'
+		);
+	});
+
+	test('[D9b] closing the whole side pane while composing a new session does not reopen it when the session re-syncs', () => {
+		const controller = createController();
+		const untitled = makeSession(URI.parse('session:untitled'), { status: SessionStatus.Untitled });
+		const other = makeSession(URI.parse('session:other'), { status: SessionStatus.Untitled });
+
+		// Compose a new session — aux bar shows the Files view.
+		harness.activeSessionObs.set(untitled, undefined);
+		assert.ok(harness.openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID));
+
+		// User closes the whole side pane while still composing the new session.
+		harness.partVisibility.set(Parts.EDITOR_PART, true);
+		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, true);
+		controller.toggleSidePane();
+
+		// The same uncreated session re-syncs (e.g. a multi-session view collapses
+		// back to it). This must not reopen the aux bar the user just closed.
+		harness.visibleSessionsObs.set([untitled, other], undefined);
+		harness.setPartHiddenCalls = [];
+		harness.openedViewContainers = [];
+		harness.visibleSessionsObs.set([untitled], undefined);
+
+		assert.ok(
+			!harness.openedViewContainers.includes(SESSIONS_FILES_CONTAINER_ID),
+			'should not reopen the Files view when the same new session re-syncs'
+		);
+		assert.ok(
+			harness.setPartHiddenCalls.some(c => c.part === Parts.AUXILIARYBAR_PART && c.hidden === true),
+			'aux bar should stay hidden when the same new session re-syncs'
+		);
+	});
+
 	// --- [D8] First Changes editor open ---
 
 	test('[D8] reveals the Changes view the first time a Changes editor is opened, then remembers the choice', () => {


### PR DESCRIPTION
## What

Closing the whole **Side Pane** (editor + auxiliary bar, via the title-bar toggle or <kbd>Ctrl/Cmd+Alt+B</kbd>) on a **new (uncreated)** session is now remembered, so the aux bar is not re-opened automatically.

This fixes two scenarios in the Agents window layout controller:

1. If the side pane is closed for a new session, it no longer gets re-opened automatically when the next new session is created.
2. If the side pane is closed while composing a new session, it no longer gets re-opened when that same session re-syncs (e.g. once it gains its workspace, un-maximizes, or collapses back from a multi-session view) — only the user opening it brings it back.

## Why

`toggleSidePane()` runs under `_togglingSidePane`, so the per-session capture listener (D2) deliberately skips it. For new sessions that meant the shared `_newSessionViewState` stayed `undefined`, and the restore rule **D3b** treats `undefined` as "default = open" and re-opened the aux bar on the next sync.

Hiding the aux bar *alone* was already remembered correctly; only the whole-side-pane toggle path was unrecorded.

## How

- **Base controller**: added a no-op `_onSidePaneToggled()` hook, called at the end of `toggleSidePane()` while `_togglingSidePane` is still set, so subclasses can record the resulting side-pane state that the D2 listener ignores.
- **Desktop controller**: overrides the hook to record the actual aux-bar visibility via `_setNewSessionViewState` for **uncreated** sessions (skipped while multi-session or maximized). For **created** sessions the hook is a no-op, preserving the existing **D9** behaviour (reopening the Changes editor re-reveals the pane).

## Notes for reviewers

- Added two `[D9b]` unit tests covering both scenarios (both fail on the old code, pass with the fix). All 54 layout-controller tests pass; `typecheck-client` is clean.
- Updated the `desktopSessionLayoutController.md` (new **D9b** rule + impl note) and `baseSessionLayoutController.md` (documented the new hook) specs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>