### PR TITLE
Style overrides: Adjust styling for chat view and agent sessions

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
@@ -152,16 +152,11 @@
  * Chat view title — the conversation title (e.g. "hello") shown in the chat
  * view header. It is dynamic text (user / model generated), so respect its real
  * casing rather than forcing ALL-CAPS like the base rule
- * (chatViewTitleControl.css) does. Only the first letter of the sentence is
- * capitalized so it reads as a title without distorting the rest of the text.
+ * (chatViewTitleControl.css) does.
  */
 .style-override .chat-viewpane .chat-view-title-container .chat-view-title-label {
 	text-transform: none;
 	font-size: var(--vscode-bodyFontSize-small);
-}
-
-.style-override .chat-viewpane .chat-view-title-container .chat-view-title-label::first-letter {
-	text-transform: uppercase;
 }
 
 /*

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
@@ -149,6 +149,22 @@
 }
 
 /*
+ * Chat view title — the conversation title (e.g. "hello") shown in the chat
+ * view header. It is dynamic text (user / model generated), so respect its real
+ * casing rather than forcing ALL-CAPS like the base rule
+ * (chatViewTitleControl.css) does. Only the first letter of the sentence is
+ * capitalized so it reads as a title without distorting the rest of the text.
+ */
+.style-override .chat-viewpane .chat-view-title-container .chat-view-title-label {
+	text-transform: none;
+	font-size: var(--vscode-bodyFontSize-small);
+}
+
+.style-override .chat-viewpane .chat-view-title-container .chat-view-title-label::first-letter {
+	text-transform: uppercase;
+}
+
+/*
  * Drop the active-tab underline on the auxiliary bar composite header so a
  * single-composite header (e.g. the secondary side bar "Chat") reads as a plain
  * section title that matches the primary side bar, rather than a highlighted

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -58,3 +58,9 @@
 .style-override.monaco-workbench .part > .title > .title-label {
 	padding-left: var(--vscode-spacing-size80, 8px);
 }
+
+.style-override.monaco-workbench .agent-sessions-viewer {
+	.pane-body & .monaco-scrollable-element {
+		padding: 0px 10px;
+	}
+}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -61,6 +61,12 @@
 
 .style-override.monaco-workbench .agent-sessions-viewer {
 	.pane-body & .monaco-scrollable-element {
-		padding: 0px 10px;
+		padding: 0px 6px;
+	}
+}
+
+.style-override.monaco-workbench .chat-viewpane {
+	.agent-session-item .agent-session-title-toolbar .actions-container {
+		gap: 4px;
 	}
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -59,10 +59,8 @@
 	padding-left: var(--vscode-spacing-size80, 8px);
 }
 
-.style-override.monaco-workbench .agent-sessions-viewer {
-	.pane-body & .monaco-scrollable-element {
-		padding: 0px 6px;
-	}
+.style-override.monaco-workbench .pane-body .agent-sessions-viewer .monaco-scrollable-element {
+	padding: 0 6px;
 }
 
 .style-override.monaco-workbench .chat-viewpane {

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -34,7 +34,7 @@
 /* Header: inset the section title / actions to line up with the rows below. */
 .style-override .monaco-pane-view .pane:not(:has(> .pane-body.chat-viewpane)) > .pane-header {
 	padding-left: var(--vscode-spacing-size80, 8px);
-	padding-right: var(--vscode-spacing-size80, 8px);
+	padding-right: var(--vscode-spacing-size40, 4px);
 }
 
 /* Body: inset each row box, leaving the scrollbar pinned to the pane edge. */
@@ -69,4 +69,8 @@
 	.agent-session-item .agent-session-title-toolbar .actions-container {
 		gap: 4px;
 	}
+}
+
+.style-override.monaco-workbench .monaco-pane-view .pane > .pane-header > .actions {
+	margin-right: 0px;
 }


### PR DESCRIPTION
This pull request makes several style adjustments to improve the appearance and readability of the chat view and related UI components in the workbench. The main changes focus on refining text casing for chat titles, adjusting padding for better alignment, and fine-tuning spacing in action toolbars.

**Chat view title improvements:**

* Ensured the chat view title (`.chat-view-title-label`) displays with natural casing, only capitalizing the first letter, and set its font size to match small body text, making dynamic conversation titles more readable and less visually distorted.

**Padding and spacing adjustments:**

* Reduced the right padding of pane headers to better align section titles and actions with the content below, improving visual consistency.
* Added specific padding to `.agent-sessions-viewer` scrollable elements and set a 4px gap between actions in the `.agent-session-title-toolbar` for a more compact and visually pleasing layout.
* Removed extra right margin from pane header action containers to streamline the header appearance.