### PR TITLE
sessions: bypass renderer HTTP cache for GitHub PR polling

### DIFF
--- a/src/vs/sessions/contrib/github/PR_ICON_POLLING.md
+++ b/src/vs/sessions/contrib/github/PR_ICON_POLLING.md
@@ -151,6 +151,30 @@ observed (`reader.store.add(...)`), a non‑active session's model can be dispos
 recreated during normal list re‑renders (row recycling on tree splices) — and the recreated
 model is empty until something refreshes it.
 
+## Conditional requests must bypass the renderer HTTP cache
+
+Each refresh issues a conditional request: the model remembers the last `ETag`
+([`_pullRequestEtag`](browser/models/githubPullRequestModel.ts#L46)) and sends it as
+`If-None-Match` ([`githubApiClient.ts`](browser/githubApiClient.ts)). GitHub then answers a
+cheap `304 Not Modified` when nothing changed (which does **not** count against the API rate
+limit) or a `200` with fresh data when it does. This is what keeps per‑session polling
+affordable.
+
+The sessions window runs in a **renderer**, so `IRequestService.request` ultimately calls
+`fetch`. With the default cache mode, Chromium's HTTP cache honors GitHub's
+`Cache-Control: …, max-age=…` response and serves a **stale cached `200` body** for the
+freshness window — short‑circuiting the network entirely. Our `If-None-Match` header then
+never reaches the server, so a poll keeps seeing the old (e.g. still‑`open`) PR for as long
+as the cached entry stays fresh. Because the poll interval (60s) and GitHub's `max-age` are
+the same order of magnitude, a merged PR's new state is observed *"never or hardly ever"* and
+the icon doesn't flip to purple.
+
+The fix is to set [`disableCache: true`](browser/githubApiClient.ts) on every GitHub request
+(→ `fetch` `cache: 'no-store'`, also honored by the node request service). This stops the
+HTTP cache from serving stale bodies while **still sending our explicit `If-None-Match`
+header**, so GitHub keeps answering the cheap `304`/`200` conditionally. Net effect: polling
+is both reliable *and* rate‑limit friendly.
+
 ## Which sessions poll — and which don't
 
 There are exactly two code paths that refresh/poll PR models, both in

--- a/src/vs/sessions/contrib/github/browser/githubApiClient.ts
+++ b/src/vs/sessions/contrib/github/browser/githubApiClient.ts
@@ -108,14 +108,7 @@ export class GitHubApiClient extends Disposable {
 				...(options?.data !== undefined ? { 'Content-Type': 'application/json' } : {}),
 			},
 			data: options?.data !== undefined ? JSON.stringify(options.data) : undefined,
-			// Bypass the renderer's HTTP cache so polling always reaches GitHub.
-			// GitHub serves PR responses with a `Cache-Control` max-age, so without
-			// this the browser cache would return a stale (e.g. still-"open") body for
-			// the freshness window and our `If-None-Match` conditional request would
-			// never reach the server — making the PR icon miss state changes like a
-			// merge. We still send `If-None-Match` explicitly, so GitHub keeps
-			// answering a cheap `304 Not Modified` (which does not count against the
-			// rate limit) when nothing changed, and a fresh `200` the moment it does.
+			// Bypass the renderer HTTP cache so conditional polling reaches GitHub (see PR_ICON_POLLING.md).
 			disableCache: true,
 			callSite
 		}, CancellationToken.None);

--- a/src/vs/sessions/contrib/github/browser/githubApiClient.ts
+++ b/src/vs/sessions/contrib/github/browser/githubApiClient.ts
@@ -108,6 +108,15 @@ export class GitHubApiClient extends Disposable {
 				...(options?.data !== undefined ? { 'Content-Type': 'application/json' } : {}),
 			},
 			data: options?.data !== undefined ? JSON.stringify(options.data) : undefined,
+			// Bypass the renderer's HTTP cache so polling always reaches GitHub.
+			// GitHub serves PR responses with a `Cache-Control` max-age, so without
+			// this the browser cache would return a stale (e.g. still-"open") body for
+			// the freshness window and our `If-None-Match` conditional request would
+			// never reach the server — making the PR icon miss state changes like a
+			// merge. We still send `If-None-Match` explicitly, so GitHub keeps
+			// answering a cheap `304 Not Modified` (which does not count against the
+			// rate limit) when nothing changed, and a fresh `200` the moment it does.
+			disableCache: true,
 			callSite
 		}, CancellationToken.None);
 

--- a/src/vs/sessions/contrib/github/test/browser/githubApiClient.test.ts
+++ b/src/vs/sessions/contrib/github/test/browser/githubApiClient.test.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { bufferToStream, VSBuffer } from '../../../../../base/common/buffer.js';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Emitter } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { IRequestContext, IRequestOptions } from '../../../../../base/parts/request/common/request.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { IRequestCompleteEvent, IRequestService } from '../../../../../platform/request/common/request.js';
+import { IAuthenticationService } from '../../../../../workbench/services/authentication/common/authentication.js';
+import { GitHubApiClient } from '../../browser/githubApiClient.js';
+
+/**
+ * Captures the options passed to {@link IRequestService.request} and returns a
+ * configurable response. Only the surface used by {@link GitHubApiClient} is
+ * implemented; the rest is unused in these tests.
+ */
+class FakeRequestService implements Partial<IRequestService> {
+	readonly _serviceBrand: undefined;
+
+	readonly onDidCompleteRequest = new Emitter<IRequestCompleteEvent>().event;
+
+	lastOptions: IRequestOptions | undefined;
+	nextResponse: IRequestContext = {
+		res: { statusCode: 304, headers: { etag: '"etag-2"' } },
+		stream: bufferToStream(VSBuffer.wrap(new Uint8Array(0))),
+	};
+
+	async request(options: IRequestOptions, _token: CancellationToken): Promise<IRequestContext> {
+		this.lastOptions = options;
+		return this.nextResponse;
+	}
+}
+
+class FakeAuthenticationService implements Partial<IAuthenticationService> {
+	readonly _serviceBrand: undefined;
+
+	async getSessions(): Promise<readonly { scopes: readonly string[]; accessToken: string }[]> {
+		return [{ scopes: ['repo'], accessToken: 'token-123' }];
+	}
+}
+
+suite('GitHubApiClient', () => {
+
+	const store = new DisposableStore();
+	let requestService: FakeRequestService;
+	let client: GitHubApiClient;
+
+	setup(() => {
+		requestService = new FakeRequestService();
+		client = store.add(new GitHubApiClient(
+			requestService as unknown as IRequestService,
+			new FakeAuthenticationService() as unknown as IAuthenticationService,
+			new NullLogService(),
+		));
+	});
+
+	teardown(() => store.clear());
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('bypasses the HTTP cache so polling always reaches GitHub', async () => {
+		await client.request('GET', '/repos/o/r/pulls/1', 'test');
+		assert.strictEqual(requestService.lastOptions?.disableCache, true);
+	});
+
+	test('sends an If-None-Match conditional request when given an etag', async () => {
+		await client.request('GET', '/repos/o/r/pulls/1', 'test', { etag: '"etag-1"' });
+
+		const headers = requestService.lastOptions?.headers;
+		assert.strictEqual(headers?.['If-None-Match'], '"etag-1"');
+		// The conditional request must still bypass the cache, otherwise a stale
+		// cached body would be returned instead of the server's 304/200.
+		assert.strictEqual(requestService.lastOptions?.disableCache, true);
+	});
+
+	test('surfaces a 304 Not Modified response without data', async () => {
+		const response = await client.request('GET', '/repos/o/r/pulls/1', 'test', { etag: '"etag-1"' });
+		assert.deepStrictEqual(
+			{ statusCode: response.statusCode, data: response.data, etag: response.etag },
+			{ statusCode: 304, data: undefined, etag: '"etag-2"' },
+		);
+	});
+});

--- a/src/vs/sessions/contrib/github/test/browser/githubApiClient.test.ts
+++ b/src/vs/sessions/contrib/github/test/browser/githubApiClient.test.ts
@@ -12,7 +12,7 @@ import { IRequestContext, IRequestOptions } from '../../../../../base/parts/requ
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { IRequestCompleteEvent, IRequestService } from '../../../../../platform/request/common/request.js';
-import { IAuthenticationService } from '../../../../../workbench/services/authentication/common/authentication.js';
+import { AuthenticationSession, IAuthenticationService } from '../../../../../workbench/services/authentication/common/authentication.js';
 import { GitHubApiClient } from '../../browser/githubApiClient.js';
 
 /**
@@ -41,8 +41,13 @@ class FakeRequestService extends Disposable implements Partial<IRequestService> 
 class FakeAuthenticationService implements Partial<IAuthenticationService> {
 	readonly _serviceBrand: undefined;
 
-	async getSessions(): Promise<readonly { scopes: readonly string[]; accessToken: string }[]> {
-		return [{ scopes: ['repo'], accessToken: 'token-123' }];
+	async getSessions(): Promise<readonly AuthenticationSession[]> {
+		return [{
+			id: 'session-1',
+			accessToken: 'token-123',
+			account: { id: 'account-1', label: 'octocat' },
+			scopes: ['repo'],
+		}];
 	}
 }
 

--- a/src/vs/sessions/contrib/github/test/browser/githubApiClient.test.ts
+++ b/src/vs/sessions/contrib/github/test/browser/githubApiClient.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { bufferToStream, VSBuffer } from '../../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Emitter } from '../../../../../base/common/event.js';
-import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { IRequestContext, IRequestOptions } from '../../../../../base/parts/request/common/request.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
@@ -20,10 +20,11 @@ import { GitHubApiClient } from '../../browser/githubApiClient.js';
  * configurable response. Only the surface used by {@link GitHubApiClient} is
  * implemented; the rest is unused in these tests.
  */
-class FakeRequestService implements Partial<IRequestService> {
+class FakeRequestService extends Disposable implements Partial<IRequestService> {
 	readonly _serviceBrand: undefined;
 
-	readonly onDidCompleteRequest = new Emitter<IRequestCompleteEvent>().event;
+	private readonly _onDidCompleteRequest = this._register(new Emitter<IRequestCompleteEvent>());
+	readonly onDidCompleteRequest = this._onDidCompleteRequest.event;
 
 	lastOptions: IRequestOptions | undefined;
 	nextResponse: IRequestContext = {
@@ -47,22 +48,18 @@ class FakeAuthenticationService implements Partial<IAuthenticationService> {
 
 suite('GitHubApiClient', () => {
 
-	const store = new DisposableStore();
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
 	let requestService: FakeRequestService;
 	let client: GitHubApiClient;
 
 	setup(() => {
-		requestService = new FakeRequestService();
+		requestService = store.add(new FakeRequestService());
 		client = store.add(new GitHubApiClient(
 			requestService as unknown as IRequestService,
 			new FakeAuthenticationService() as unknown as IAuthenticationService,
 			new NullLogService(),
 		));
 	});
-
-	teardown(() => store.clear());
-
-	ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('bypasses the HTTP cache so polling always reaches GitHub', async () => {
 		await client.request('GET', '/repos/o/r/pulls/1', 'test');


### PR DESCRIPTION
## What

Set `disableCache: true` on every GitHub API request made by the sessions window's `GitHubApiClient`, so PR polling always reaches GitHub instead of being served a stale response by the renderer's HTTP cache.

## Why

PR status icons in the sessions list are computed from a live `GitHubPullRequestModel` that is polled (~60s) with a conditional `If-None-Match` request, so GitHub can answer a cheap `304 Not Modified` (which does not count against the rate limit) when nothing changed, or `200` with fresh data when it does.

However, the sessions window runs in a **renderer**, so `IRequestService.request` ultimately calls `fetch` with the default cache mode. GitHub serves PR responses with a `Cache-Control: ..., max-age=...` header, so Chromium''s HTTP cache returned a **stale cached `200` body** during the freshness window - short-circuiting the network so our explicit `If-None-Match` header never reached the server. Because the poll interval and GitHub''s `max-age` are the same order of magnitude, a PR''s new state (e.g. **merged**) was observed "never or hardly ever", and the icon never updated.

## Fix

`disableCache: true` maps to `fetch`''s `cache: ''no-store''` (and is honored by the node request service too). It stops the HTTP cache from serving stale bodies while **still sending `If-None-Match`**, so GitHub keeps answering the cheap conditional `304`/`200`. Net effect: polling is both reliable *and* rate-limit friendly.

This is applied at the single choke point (`GitHubApiClient._request`) through which all PR / reviews / CI / review-thread / repository / PR-number requests flow.

## Notes for reviewers

- New focused tests in `githubApiClient.test.ts` lock in cache-bypass, `If-None-Match` passthrough, and `304` handling.
- `PR_ICON_POLLING.md` documents the cache/ETag interaction and the fix.
- The same `disableCache` pattern is already used elsewhere for polling requests (e.g. `emergencyAlert`, `chatEntitlementService`, `defaultAccount`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
