### PR TITLE
sessions: pre-select archived session's folder on return to new-session view

### DIFF
--- a/src/vs/sessions/services/sessions/browser/sessionsService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsService.ts
@@ -401,12 +401,14 @@ export class SessionsService extends Disposable implements ISessionsService {
 	private _activeSessionViewListeners(activeSession: IActiveSession): IDisposable {
 		const disposables = new DisposableStore();
 
-		// When the active session becomes archived, return to the new-session view.
+		// When the active session becomes archived, return to the new-session view
+		// pre-selecting the same folder so the user stays in context.
 		let wasArchived = activeSession.isArchived.get();
 		disposables.add(autorun(reader => {
 			const isArchived = activeSession.isArchived.read(reader);
 			if (isArchived && !wasArchived) {
-				this.openNewSession();
+				const folderUri = activeSession.workspace.read(undefined)?.folders[0]?.root;
+				this.openNewSession(folderUri ? { folderUri } : undefined);
 			}
 			wasArchived = isArchived;
 		}));

--- a/src/vs/sessions/services/sessions/browser/sessionsService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsService.ts
@@ -408,7 +408,7 @@ export class SessionsService extends Disposable implements ISessionsService {
 			const isArchived = activeSession.isArchived.read(reader);
 			if (isArchived && !wasArchived) {
 				const folderUri = activeSession.workspace.read(undefined)?.folders[0]?.root;
-				this.openNewSession(folderUri ? { folderUri } : undefined);
+				this.openNewSession(folderUri ? { folderUri, providerId: activeSession.providerId, sessionTypeId: activeSession.sessionType } : undefined);
 			}
 			wasArchived = isArchived;
 		}));


### PR DESCRIPTION
## Problem

When marking a session as done (archiving) and being sent back to the New Session view, the workspace picker showed the **last user-picked folder** (from storage) instead of the **folder of the session that was just archived**.

**Steps to reproduce:**
1. Create session in folder A
2. Create session in folder B  
3. Reopen session A and mark it as done
4. **Expected:** New Session view pre-selects folder A
5. **Actual:** New Session view selects folder B

## Root Cause

In `_activeSessionViewListeners`, when the active session becomes archived, `openNewSession()` was called with no arguments. This causes a fresh `NewChatWidget` (and `WorkspacePicker`) to be created, which restores its selection from profile storage — which holds folder B (the last user-picked folder), not the folder of the session being closed.

## Fix

Pass the archived session's workspace folder URI to `openNewSession`. When `openNewSession` receives a `folderUri`, it creates a draft session for that folder and activates it. The new `NewChatWidget`'s `render()` then calls `_syncWorkspacePickerFromActiveSession()`, which finds the draft for folder A and silently syncs the workspace picker to it — keeping the user in the right context.

Falls back to the existing no-folder path when the session has no workspace.