### PR TITLE
Use Accept/Remove button bar for created agent feedback comments

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
@@ -82,6 +82,7 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 	private readonly _bodyNode: HTMLElement;
 	private readonly _itemElements = new Map<string, HTMLElement>();
 	private readonly _activeReplyInputs = new Map<string, { container: HTMLElement; textarea: HTMLTextAreaElement }>();
+	private readonly _actionBarElements = new Map<string, HTMLElement>();
 
 	private _position: IOverlayWidgetPosition | null = null;
 	private _isExpanded: boolean = false;
@@ -206,6 +207,7 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 		clearNode(this._bodyNode);
 		this._itemElements.clear();
 		this._activeReplyInputs.clear();
+		this._actionBarElements.clear();
 
 		for (const comment of this._commentItems) {
 			const item = $('div.agent-feedback-widget-item');
@@ -314,7 +316,7 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 
 			this._eventStore.add(addDisposableListener(item, 'click', e => {
 				const target = e.target as HTMLElement | null;
-				if (target?.closest('.action-bar, .agent-feedback-widget-actions-bar')) {
+				if (target?.closest('.action-bar')) {
 					return;
 				}
 				// Don't trigger navigation when interacting with the reply input.
@@ -418,9 +420,17 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 		const buttonStore = new DisposableStore();
 		this._eventStore.add(buttonStore);
 
+		// Prevent clicks on the button bar from bubbling up to the item click
+		// handler (which would navigate/reveal the comment).
+		buttonStore.add(addDisposableListener(buttonBar, 'click', e => e.stopPropagation()));
+
 		const dismiss = () => {
 			buttonStore.dispose();
 			buttonBar.remove();
+			this._actionBarElements.delete(comment.id);
+			// Move focus back to the widget so keyboard/screen reader users
+			// don't lose their place when the (now removed) button is gone.
+			this._domNode.focus({ preventScroll: true });
 			this._editor.layoutOverlayWidget(this);
 		};
 
@@ -452,6 +462,7 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 		}));
 
 		item.appendChild(buttonBar);
+		this._actionBarElements.set(comment.id, buttonBar);
 	}
 
 	private _removeComment(comment: ISessionEditorComment): void {
@@ -546,7 +557,7 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 		replyContainer.appendChild(textarea);
 		// Keep the action button bar (Accept/Remove) as the very last element so
 		// the reply composer appears above it.
-		const actionsBar = itemNode.querySelector('.agent-feedback-widget-actions-bar');
+		const actionsBar = this._actionBarElements.get(comment.id);
 		if (actionsBar) {
 			itemNode.insertBefore(replyContainer, actionsBar);
 		} else {

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
@@ -31,6 +31,7 @@ import { createAgentFeedbackContext } from './agentFeedbackEditorUtils.js';
 import { ICodeReviewService, IPRReviewState } from '../../codeReview/browser/codeReviewService.js';
 import { getSessionEditorComments, groupNearbySessionEditorComments, ISessionEditorComment, SessionEditorCommentSource, toSessionEditorCommentId } from './sessionEditorComments.js';
 import { ActionBar } from '../../../../base/browser/ui/actionbar/actionbar.js';
+import { Button } from '../../../../base/browser/ui/button/button.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { IMarkdownRendererService } from '../../../../platform/markdown/browser/markdownRenderer.js';
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
@@ -267,16 +268,6 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 				));
 				actionBar.push(itemActions.convertAction, { icon: true, label: false });
 			}
-			if (comment.source === SessionEditorCommentSource.AgentFeedback && comment.state === AgentFeedbackState.Created) {
-				const acceptAction = this._eventStore.add(new Action(
-					'agentFeedback.widget.accept',
-					nls.localize('acceptComment', "Accept"),
-					ThemeIcon.asClassName(Codicon.check),
-					true,
-					() => { this._acceptFeedback(comment); return Promise.resolve(); },
-				));
-				actionBar.push(acceptAction, { icon: true, label: false });
-			}
 			itemActions.removeAction = this._eventStore.add(new Action(
 				'agentFeedback.widget.remove',
 				nls.localize('removeComment', "Remove"),
@@ -284,7 +275,13 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 				true,
 				() => this._removeComment(comment),
 			));
-			actionBar.push(itemActions.removeAction, { icon: true, label: false });
+			// For created agent feedback the Remove action lives in the bottom
+			// button bar instead, so it's omitted from the hover toolbar to
+			// avoid a duplicate affordance.
+			const showRemoveInToolbar = !(comment.source === SessionEditorCommentSource.AgentFeedback && comment.state === AgentFeedbackState.Created);
+			if (showRemoveInToolbar) {
+				actionBar.push(itemActions.removeAction, { icon: true, label: false });
+			}
 
 			itemHeader.appendChild(actionBarContainer);
 			item.appendChild(itemHeader);
@@ -303,6 +300,10 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 				item.appendChild(this._renderReplies(comment.replies));
 			}
 
+			if (comment.source === SessionEditorCommentSource.AgentFeedback && comment.state === AgentFeedbackState.Created) {
+				this._renderActionButtons(comment, item);
+			}
+
 			this._eventStore.add(addDisposableListener(item, 'mouseenter', () => {
 				this._highlightRange(comment);
 			}));
@@ -313,7 +314,7 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 
 			this._eventStore.add(addDisposableListener(item, 'click', e => {
 				const target = e.target as HTMLElement | null;
-				if (target?.closest('.action-bar')) {
+				if (target?.closest('.action-bar, .agent-feedback-widget-actions-bar')) {
 					return;
 				}
 				// Don't trigger navigation when interacting with the reply input.
@@ -406,6 +407,53 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 		return repliesNode;
 	}
 
+	/**
+	 * Renders the Accept / Remove button bar shown at the bottom of a
+	 * `created` agent feedback comment. Clicking either button performs the
+	 * action and removes the bar.
+	 */
+	private _renderActionButtons(comment: ISessionEditorComment, item: HTMLElement): void {
+		const buttonBar = $('div.agent-feedback-widget-actions-bar');
+
+		const buttonStore = new DisposableStore();
+		this._eventStore.add(buttonStore);
+
+		const dismiss = () => {
+			buttonStore.dispose();
+			buttonBar.remove();
+			this._editor.layoutOverlayWidget(this);
+		};
+
+		const acceptButton = buttonStore.add(new Button(buttonBar, {
+			title: nls.localize('acceptFeedbackButton', "Accept"),
+			buttonBackground: 'var(--vscode-charts-purple)',
+			buttonHoverBackground: 'color-mix(in srgb, var(--vscode-charts-purple) 85%, var(--vscode-foreground))',
+			buttonForeground: 'var(--vscode-button-foreground)',
+			buttonBorder: 'var(--vscode-charts-purple)',
+		}));
+		acceptButton.label = nls.localize('acceptFeedbackButton', "Accept");
+		buttonStore.add(acceptButton.onDidClick(() => {
+			this._acceptFeedback(comment);
+			dismiss();
+		}));
+
+		const removeButton = buttonStore.add(new Button(buttonBar, {
+			title: nls.localize('removeFeedbackButton', "Remove"),
+			secondary: true,
+			buttonSecondaryBackground: 'var(--vscode-button-secondaryBackground)',
+			buttonSecondaryHoverBackground: 'var(--vscode-button-secondaryHoverBackground)',
+			buttonSecondaryForeground: 'var(--vscode-button-secondaryForeground)',
+			buttonSecondaryBorder: 'var(--vscode-button-border, var(--vscode-editorWidget-border, var(--vscode-widget-border)))',
+		}));
+		removeButton.label = nls.localize('removeFeedbackButton', "Remove");
+		buttonStore.add(removeButton.onDidClick(() => {
+			this._removeComment(comment);
+			dismiss();
+		}));
+
+		item.appendChild(buttonBar);
+	}
+
 	private _removeComment(comment: ISessionEditorComment): void {
 		if (comment.source === SessionEditorCommentSource.PRReview) {
 			this._codeReviewService.resolvePRReviewThread(this._sessionResource!, comment.sourceId);
@@ -496,7 +544,14 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 			textarea.value = initialText;
 		}
 		replyContainer.appendChild(textarea);
-		itemNode.appendChild(replyContainer);
+		// Keep the action button bar (Accept/Remove) as the very last element so
+		// the reply composer appears above it.
+		const actionsBar = itemNode.querySelector('.agent-feedback-widget-actions-bar');
+		if (actionsBar) {
+			itemNode.insertBefore(replyContainer, actionsBar);
+		} else {
+			itemNode.appendChild(replyContainer);
+		}
 		this._activeReplyInputs.set(comment.id, { container: replyContainer, textarea });
 
 		// Ensure the draft store has an entry so subsequent rebuilds know to

--- a/src/vs/sessions/contrib/agentFeedback/browser/media/agentFeedbackEditorWidget.css
+++ b/src/vs/sessions/contrib/agentFeedback/browser/media/agentFeedbackEditorWidget.css
@@ -358,3 +358,18 @@
 	color: var(--vscode-input-placeholderForeground);
 	opacity: 1;
 }
+
+/* Accept / Remove action button bar shown for created agent feedback */
+.agent-feedback-widget-actions-bar {
+	display: flex;
+	gap: 6px;
+	margin-top: 4px;
+}
+
+.agent-feedback-widget-actions-bar .monaco-button {
+	flex: 1;
+	padding: 2px 10px;
+	width: auto;
+	font-size: var(--vscode-agents-fontSize-label2);
+	line-height: 18px;
+}


### PR DESCRIPTION
Replaces the hover-toolbar Accept action on agent feedback comments with a dedicated Accept / Remove button bar at the bottom of the comment.

## Changes
- Removed the **Accept** action from the comment hover toolbar.
- Added an Accept / Remove button bar rendered at the bottom of the comment (after replies and the reply composer). It is only shown for agent feedback in the `Created` state.
- Clicking either button performs the action and removes the button bar.
- The **Accept** (primary) button uses the badge color (`--vscode-charts-purple`) used by PR Review / Agent Review badges for its background, border and hover, instead of the default blue. The **Remove** (secondary) button has a border color.
- The Remove action is omitted from the hover toolbar for `Created` agent feedback to avoid a duplicate affordance (it lives in the button bar instead).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>