### PR TITLE
Make onboarding.developerMode a per-scenario map

### DIFF
--- a/src/vs/sessions/contrib/onboardingTours/browser/newSessionTourContribution.ts
+++ b/src/vs/sessions/contrib/onboardingTours/browser/newSessionTourContribution.ts
@@ -12,7 +12,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { onboardingScenarioRegistry } from '../../../../workbench/contrib/onboarding/common/onboardingRegistry.js';
-import { IOnboardingScenarioService, ONBOARDING_DEVELOPER_MODE_CONFIG } from '../../../../workbench/contrib/onboarding/common/onboardingScenarioService.js';
+import { isOnboardingDeveloperModeEnabled, IOnboardingScenarioService } from '../../../../workbench/contrib/onboarding/common/onboardingScenarioService.js';
 import { findOnboardingTarget, pulseOnboardingTarget } from '../../../../workbench/contrib/onboarding/browser/spotlight/onboardingTarget.js';
 import { ISession } from '../../../services/sessions/common/session.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
@@ -77,7 +77,7 @@ class NewSessionTourContribution extends Disposable implements IWorkbenchContrib
 
 		// The developer setting bypasses the usage-based "first few sessions"
 		// gate so the tour can be triggered on demand for testing.
-		const developerMode = this.configurationService.getValue<boolean>(ONBOARDING_DEVELOPER_MODE_CONFIG) === true;
+		const developerMode = isOnboardingDeveloperModeEnabled(this.configurationService, NEW_SESSION_TOUR_ID);
 		if (!developerMode) {
 			const sessionsStarted = this.storageService.getNumber(TOTAL_SESSIONS_KEY, StorageScope.APPLICATION, 0);
 			if (sessionsStarted > NewSessionTourContribution.MAX_SESSIONS_FOR_TOUR) {

--- a/src/vs/sessions/contrib/onboardingTours/browser/newSessionViewTourContribution.ts
+++ b/src/vs/sessions/contrib/onboardingTours/browser/newSessionViewTourContribution.ts
@@ -11,7 +11,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { onboardingScenarioRegistry } from '../../../../workbench/contrib/onboarding/common/onboardingRegistry.js';
-import { IOnboardingScenarioService, ONBOARDING_DEVELOPER_MODE_CONFIG } from '../../../../workbench/contrib/onboarding/common/onboardingScenarioService.js';
+import { isOnboardingDeveloperModeEnabled, IOnboardingScenarioService } from '../../../../workbench/contrib/onboarding/common/onboardingScenarioService.js';
 import { findOnboardingTarget } from '../../../../workbench/contrib/onboarding/browser/spotlight/onboardingTarget.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { TOTAL_SESSIONS_KEY } from '../../sessions/browser/sessionsLifecycleTracker.js';
@@ -102,7 +102,7 @@ class NewSessionViewTourContribution extends Disposable implements IWorkbenchCon
 	private _isEligibleUser(): boolean {
 		// The developer setting bypasses the usage-based "first few requests" gate
 		// so the tour can be triggered on demand for testing.
-		if (this.configurationService.getValue<boolean>(ONBOARDING_DEVELOPER_MODE_CONFIG) === true) {
+		if (isOnboardingDeveloperModeEnabled(this.configurationService, NEW_SESSION_VIEW_TOUR_ID)) {
 			return true;
 		}
 		const requestsSent = this.storageService.getNumber(TOTAL_SESSIONS_KEY, StorageScope.APPLICATION, 0);

--- a/src/vs/workbench/contrib/onboarding/browser/onboarding.contribution.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/onboarding.contribution.ts
@@ -46,7 +46,7 @@ function buildDeveloperModeConfigurationNode(): IConfigurationNode {
 				properties,
 				additionalProperties: { type: 'boolean' },
 				tags: ['experimental'],
-				description: localize('onboarding.developerMode', "Map of onboarding scenario/tour id to whether developer mode is enabled for it. When enabled for a scenario, that onboarding tour ignores usage-based eligibility checks (such as how many sessions you have started) and previously persisted shown state so it can be replayed once per window session for testing.")
+				description: localize('onboarding.developerMode', "Map of onboarding scenario/tour id to whether developer mode is enabled for it. When enabled for a scenario, that onboarding tour ignores usage-based eligibility checks (such as how many sessions you have started) and previously persisted shown state. The tour is still shown at most once per window session, so reload the window to show it again.")
 			}
 		}
 	};

--- a/src/vs/workbench/contrib/onboarding/browser/onboarding.contribution.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/onboarding.contribution.ts
@@ -4,21 +4,77 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IStringDictionary } from '../../../../base/common/collections.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
 import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
-import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { IConfigurationNode, IConfigurationPropertySchema, IConfigurationRegistry, Extensions as ConfigurationExtensions } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { workbenchConfigurationNodeBase } from '../../../common/configuration.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
 import { onboardingPresentationRegistry } from '../common/onboardingPresentation.js';
+import { onboardingScenarioRegistry } from '../common/onboardingRegistry.js';
 import { IOnboardingScenarioService, ONBOARDING_DEVELOPER_MODE_CONFIG, ONBOARDING_ENABLED_CONFIG } from '../common/onboardingScenarioService.js';
 import { OnboardingScenarioService } from './onboardingService.js';
 import { SpotlightPresentation } from './spotlight/spotlightPresentation.js';
 
 registerSingleton(IOnboardingScenarioService, OnboardingScenarioService, InstantiationType.Delayed);
+
+const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+
+/**
+ * Builds the configuration node for the developer-mode setting. The setting is a
+ * map of scenario/tour id to boolean; the default lists every currently
+ * registered scenario id set to `false` so the available ids are discoverable
+ * (and individually toggleable) in the settings editor.
+ */
+function buildDeveloperModeConfigurationNode(): IConfigurationNode {
+	const properties: IStringDictionary<IConfigurationPropertySchema> = {};
+	const defaultValue: IStringDictionary<boolean> = {};
+	for (const id of onboardingScenarioRegistry.getScenarios().map(scenario => scenario.id).sort()) {
+		properties[id] = { type: 'boolean', default: false };
+		defaultValue[id] = false;
+	}
+	return {
+		...workbenchConfigurationNodeBase,
+		properties: {
+			[ONBOARDING_DEVELOPER_MODE_CONFIG]: {
+				type: 'object',
+				default: defaultValue,
+				properties,
+				additionalProperties: { type: 'boolean' },
+				tags: ['experimental'],
+				description: localize('onboarding.developerMode', "Map of onboarding scenario/tour id to whether developer mode is enabled for it. When enabled for a scenario, that onboarding tour ignores usage-based eligibility checks (such as how many sessions you have started) and previously persisted shown state so it can be replayed once per window session for testing.")
+			}
+		}
+	};
+}
+
+let developerModeConfigurationNode = buildDeveloperModeConfigurationNode();
+
+configurationRegistry.registerConfiguration({
+	...workbenchConfigurationNodeBase,
+	properties: {
+		[ONBOARDING_ENABLED_CONFIG]: {
+			type: 'boolean',
+			default: false,
+			description: localize('onboarding.enabled', "When enabled, onboarding tours and hints may appear automatically to highlight features. Disabling this does not affect tours you start manually.")
+		}
+	}
+});
+configurationRegistry.registerConfiguration(developerModeConfigurationNode);
+
+/**
+ * Re-registers the developer-mode setting so its default value and per-scenario
+ * properties reflect the currently registered scenarios.
+ */
+function refreshDeveloperModeConfiguration(): void {
+	const next = buildDeveloperModeConfigurationNode();
+	configurationRegistry.updateConfigurations({ add: [next], remove: [developerModeConfigurationNode] });
+	developerModeConfigurationNode = next;
+}
 
 /**
  * Boots the onboarding engine after the workbench has restored: registers the
@@ -33,6 +89,10 @@ class OnboardingContribution extends Disposable implements IWorkbenchContributio
 		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super();
+		// Keep the developer-mode setting's default ids in sync with the scenarios
+		// registered so far (and any registered later, e.g. session tours).
+		refreshDeveloperModeConfiguration();
+		this._register(onboardingScenarioRegistry.onDidChange(() => refreshDeveloperModeConfiguration()));
 		const spotlight = this._register(instantiationService.createInstance(SpotlightPresentation));
 		this._register(onboardingPresentationRegistry.register(spotlight));
 		onboardingService.start();
@@ -40,24 +100,6 @@ class OnboardingContribution extends Disposable implements IWorkbenchContributio
 }
 
 registerWorkbenchContribution2(OnboardingContribution.ID, OnboardingContribution, WorkbenchPhase.AfterRestored);
-
-const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
-configurationRegistry.registerConfiguration({
-	...workbenchConfigurationNodeBase,
-	properties: {
-		[ONBOARDING_ENABLED_CONFIG]: {
-			type: 'boolean',
-			default: false,
-			description: localize('onboarding.enabled', "When enabled, onboarding tours and hints may appear automatically to highlight features. Disabling this does not affect tours you start manually.")
-		},
-		[ONBOARDING_DEVELOPER_MODE_CONFIG]: {
-			type: 'boolean',
-			default: false,
-			tags: ['experimental'],
-			description: localize('onboarding.developerMode', "When enabled, onboarding tours ignore usage-based eligibility checks (such as how many sessions you have started) and previously persisted shown state so they can be replayed once per window session for testing.")
-		}
-	}
-});
 
 registerAction2(class extends Action2 {
 	constructor() {

--- a/src/vs/workbench/contrib/onboarding/browser/onboardingService.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/onboardingService.ts
@@ -19,7 +19,7 @@ import { Memento } from '../../../common/memento.js';
 import { onboardingPresentationRegistry } from '../common/onboardingPresentation.js';
 import { onboardingScenarioRegistry } from '../common/onboardingRegistry.js';
 import { IOnboardingRunResult, IOnboardingScenario, ONBOARDING_ASSIGNMENT_CONTEXT_PREFIX, OnboardingOutcome } from '../common/onboardingScenario.js';
-import { IOnboardingScenarioService, ONBOARDING_DEVELOPER_MODE_CONFIG, ONBOARDING_ENABLED_CONFIG } from '../common/onboardingScenarioService.js';
+import { isOnboardingDeveloperModeEnabled, IOnboardingScenarioService, ONBOARDING_DEVELOPER_MODE_CONFIG, ONBOARDING_ENABLED_CONFIG } from '../common/onboardingScenarioService.js';
 
 /** Persisted "shown" state for a single scenario. */
 interface IScenarioState {
@@ -163,7 +163,7 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 
 	hasBeenShown(id: string): boolean {
 		const scenario = onboardingScenarioRegistry.getScenario(id);
-		return this._hasBeenShownKey(scenario ? this._seenKey(scenario) : id);
+		return this._hasBeenShownKey(scenario ? this._seenKey(scenario) : id, id);
 	}
 
 	reset(id: string): void {
@@ -185,8 +185,8 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 		return this.configurationService.getValue<boolean>(ONBOARDING_ENABLED_CONFIG) !== false;
 	}
 
-	private get _developerMode(): boolean {
-		return this.configurationService.getValue<boolean>(ONBOARDING_DEVELOPER_MODE_CONFIG) === true;
+	private _isDeveloperMode(scenarioId: string): boolean {
+		return isOnboardingDeveloperModeEnabled(this.configurationService, scenarioId);
 	}
 
 	/**
@@ -256,7 +256,7 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 			return false;
 		}
 
-		if (!scenario.repeatable && this._hasBeenShownKey(this._seenKey(scenario))) {
+		if (!scenario.repeatable && this._hasBeenShownKey(this._seenKey(scenario), scenario.id)) {
 			return false;
 		}
 
@@ -515,8 +515,8 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 		return scenario.seenKey ?? scenario.id;
 	}
 
-	private _hasBeenShownKey(key: string): boolean {
-		if (this._developerMode) {
+	private _hasBeenShownKey(key: string, scenarioId: string): boolean {
+		if (this._isDeveloperMode(scenarioId)) {
 			return this._shownSinceStart.has(key);
 		}
 		return !!this._state[key]?.shownAt;

--- a/src/vs/workbench/contrib/onboarding/common/onboardingScenarioService.ts
+++ b/src/vs/workbench/contrib/onboarding/common/onboardingScenarioService.ts
@@ -16,8 +16,10 @@ export const ONBOARDING_ENABLED_CONFIG = 'onboarding.enabled';
  * Developer/advanced setting. A map of scenario/tour id to a boolean: when a
  * scenario's flag is `true`, that scenario bypasses usage-based eligibility
  * gating (e.g. the new-session tour's "first few sessions" check) so it can be
- * triggered on demand for testing. Tours are still shown at most once per window
- * session — use the "Reset Onboarding Shown State" command to replay them.
+ * triggered on demand for testing. The scenario is still shown at most once per
+ * window session (tracked in memory, not persisted), so reload the window to
+ * replay it — the "Reset Onboarding Shown State" command only clears the
+ * persisted state and does not affect developer-mode replays.
  *
  * The default value lists every registered scenario id set to `false`, so the
  * available ids are discoverable (and toggleable) in the settings editor.

--- a/src/vs/workbench/contrib/onboarding/common/onboardingScenarioService.ts
+++ b/src/vs/workbench/contrib/onboarding/common/onboardingScenarioService.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IOnboardingScenario, OnboardingOutcome } from './onboardingScenario.js';
 
@@ -12,12 +13,32 @@ export const IOnboardingScenarioService = createDecorator<IOnboardingScenarioSer
 export const ONBOARDING_ENABLED_CONFIG = 'onboarding.enabled';
 
 /**
- * Developer/advanced setting. When enabled, onboarding tours bypass usage-based
- * eligibility gating (e.g. the new-session tour's "first few sessions" check) so
- * they can be triggered on demand for testing. Tours are still shown at most
- * once — use the "Reset Onboarding Shown State" command to replay them.
+ * Developer/advanced setting. A map of scenario/tour id to a boolean: when a
+ * scenario's flag is `true`, that scenario bypasses usage-based eligibility
+ * gating (e.g. the new-session tour's "first few sessions" check) so it can be
+ * triggered on demand for testing. Tours are still shown at most once per window
+ * session — use the "Reset Onboarding Shown State" command to replay them.
+ *
+ * The default value lists every registered scenario id set to `false`, so the
+ * available ids are discoverable (and toggleable) in the settings editor.
  */
 export const ONBOARDING_DEVELOPER_MODE_CONFIG = 'onboarding.developerMode';
+
+/**
+ * The shape of the {@link ONBOARDING_DEVELOPER_MODE_CONFIG} setting: a map of
+ * scenario/tour id to whether developer mode is enabled for that scenario.
+ */
+export type OnboardingDeveloperMode = { readonly [scenarioId: string]: boolean };
+
+/**
+ * Whether onboarding developer mode is enabled for the given scenario/tour id.
+ * Reads {@link ONBOARDING_DEVELOPER_MODE_CONFIG} and returns `true` only when the
+ * setting is an object whose entry for `scenarioId` is explicitly `true`.
+ */
+export function isOnboardingDeveloperModeEnabled(configurationService: IConfigurationService, scenarioId: string): boolean {
+	const value = configurationService.getValue<OnboardingDeveloperMode | undefined>(ONBOARDING_DEVELOPER_MODE_CONFIG);
+	return typeof value === 'object' && value !== null && value[scenarioId] === true;
+}
 
 /**
  * The presentation-agnostic onboarding engine. It decides *when* and *whether*

--- a/src/vs/workbench/contrib/onboarding/test/browser/onboardingService.test.ts
+++ b/src/vs/workbench/contrib/onboarding/test/browser/onboardingService.test.ts
@@ -173,7 +173,7 @@ suite('OnboardingScenarioService', () => {
 		first.start();
 		await timeout(0);
 
-		const { service: second, contextKeyService } = createService({ [ONBOARDING_DEVELOPER_MODE_CONFIG]: true }, undefined, storage);
+		const { service: second, contextKeyService } = createService({ [ONBOARDING_DEVELOPER_MODE_CONFIG]: { 'dev-repeat-1': true } }, undefined, storage);
 		second.start();
 		await timeout(0);
 


### PR DESCRIPTION
Change the onboarding.developerMode setting from a boolean to an object mapping scenario/tour id to a boolean, so developer mode can be toggled per scenario. The default lists every registered scenario id set to false and is kept in sync as scenarios register/unregister, making the ids discoverable in the settings editor.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
