### PR TITLE
sessions: header changes pill opens the default changeset

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesActions.ts
@@ -22,6 +22,7 @@ import { SessionHasChangesContext } from '../../../common/contextkeys.js';
 import { ISessionContext } from '../../../services/sessions/browser/sessionContext.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { IActiveSession } from '../../../services/sessions/common/sessionsManagement.js';
+import { IChangesViewService } from '../common/changesViewService.js';
 import { ChangesMultiDiffSourceResolver } from './changesMultiDiffSourceResolver.js';
 import { ISessionChangesService } from './sessionChangesService.js';
 
@@ -52,6 +53,7 @@ class ViewAllChangesAction extends Action2 {
 		const editorService = accessor.get(IEditorService);
 		const sessionsService = accessor.get(ISessionsService);
 		const sessionChangesService = accessor.get(ISessionChangesService);
+		const changesViewService = accessor.get(IChangesViewService);
 
 		// The clicked session is forwarded as the argument by the session header,
 		// which has already promoted it to be the active session. Fall back to the
@@ -60,6 +62,11 @@ class ViewAllChangesAction extends Action2 {
 		if (!sessionResource) {
 			return;
 		}
+
+		// The header pill reflects the session's default changeset, so reset any
+		// Changes-view selection to the default before opening so the diff editor
+		// (a shared per-session resource) shows the same changes as the pill.
+		changesViewService.setChangesetId(undefined);
 
 		// Open the multi-file diff editor in the editor part. The resource list is
 		// resolved reactively via the `ChangesMultiDiffSourceResolver` registered as


### PR DESCRIPTION
## What

The Agents window session **header diff-stats pill** now opens the **default changeset** when activated, matching the stats it displays.

## Why

The pill's label reflects the session's **default** changeset (`isDefault`). But activating the pill opens the shared per-session multi-diff editor, whose file list comes from the Changes view's `activeSessionChangesObs` — which is **selected-or-default**. So after the user manually picks a different changeset in the Changes view (e.g. Uncommitted Changes, Last Turn), the pill's label (default changeset stats) and the diff it opened (selected changeset) could disagree.

## How

Reset the Changes view changeset selection to the default (`setChangesetId(undefined)`) before opening the diff editor. This keeps the pill, the diff editor, and the Changes view panel all aligned on the default changeset.

## Notes for reviewers

- Follow-up to #323101, which fixed the pill's displayed stats to read the default changeset; this aligns what the pill *opens* with what it *shows*.
- The Changes view already resets the selection to the default on every active-session change, so this only affects the case where the user changed the selection within the current session and then clicks the header pill.

## Testing

- `npm run valid-layers-check` ✅ (compiles all layers)
- Problems/type check on the changed file ✅
- Manual: select a non-default changeset in the Changes view, then click the header pill — the opened diff now matches the pill's stats (the default changeset).
