### PR TITLE
sessions: guard folders[0] access with optional chaining

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesViewService.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesViewService.ts
@@ -83,7 +83,7 @@ export class ChangesViewService extends Disposable implements IChangesViewServic
 
 			const activeSession = this.sessionsService.activeSession.read(reader);
 			const workspace = activeSession?.workspace.read(reader);
-			return workspace?.folders[0].gitRepository !== undefined;
+			return workspace?.folders[0]?.gitRepository !== undefined;
 		});
 
 		// Active session state

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsChangesets.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsChangesets.ts
@@ -27,7 +27,7 @@ class GitRepositoryChangesetResolver implements IChangesetResolver {
 		@IGitService private readonly _gitService: IGitService
 	) {
 		this._repositoryUriObs = derivedOpts({ equalsFn: isEqual }, reader => {
-			const gitRepository = workspace.read(reader)?.folders[0].gitRepository;
+			const gitRepository = workspace.read(reader)?.folders[0]?.gitRepository;
 			return gitRepository?.workTreeUri ?? gitRepository?.uri;
 		});
 	}
@@ -57,7 +57,7 @@ class GitHubRepositoryChangesetResolver implements IChangesetResolver {
 		@IGitHubService private readonly _gitHubService: IGitHubService
 	) {
 		this._gitHubInfoObs = derivedOpts({ equalsFn: gitHubInfoEqual }, reader => {
-			const gitRepository = workspace.read(reader)?.folders[0].gitRepository;
+			const gitRepository = workspace.read(reader)?.folders[0]?.gitRepository;
 			return gitRepository?.gitHubInfo.read(reader);
 		});
 	}
@@ -187,7 +187,7 @@ export class BranchChangesChangeset extends AbstractChangeset {
 	) {
 		super(chatsObs);
 
-		const gitRepository = workspaceObs.get()?.folders[0].gitRepository;
+		const gitRepository = workspaceObs.get()?.folders[0]?.gitRepository;
 		const branchName = gitRepository?.branchName;
 		const baseBranchName = gitRepository?.baseBranchName;
 
@@ -239,7 +239,7 @@ export class UncommittedChangesChangeset extends AbstractChangeset {
 		this.isEnabled = derived(reader => chatsObs.read(reader)[0]?.isArchived.read(reader) !== true);
 
 		const uncommittedChangesCountObs = derived(reader => {
-			const gitRepository = workspaceObs.read(reader)?.folders[0].gitRepository;
+			const gitRepository = workspaceObs.read(reader)?.folders[0]?.gitRepository;
 			return gitRepository?.uncommittedChanges ?? 0;
 		});
 


### PR DESCRIPTION
Fixes #323144

## Summary

A session workspace's `folders` array can be empty (the type is `readonly folders: ISessionFolder[]`, with no non-empty guarantee), so accessing `folders[0].gitRepository` without optional chaining throws a `TypeError` when a session has a workspace but no folders. This can crash the Changes view, the session header, and the changeset resolvers.

This change adds optional chaining to the 5 spots that diverged from the null-safe convention used everywhere else in `src/vs/sessions/` (which even guards explicitly with `workspace.folders.length > 0` in `sessionsActions.ts`).

## Changes

- `changesViewService.ts:86` — `folders[0].gitRepository` -> `folders[0]?.gitRepository`
- `copilotChatSessionsChangesets.ts` (lines 30, 60, 190, 242) — same null-safe access

## Verification

- Grep confirms no unsafe `folders[0]` accesses remain in `src/vs/sessions/`.
- `tsc -p src` produces no errors for the changed files.