### PR TITLE
NES: cache cross-file suggestions under the active document

### DIFF
--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditCache.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditCache.ts
@@ -45,10 +45,39 @@ export interface CachedEditOpts {
 	 * `rebasedEditIndex` into the bundle) can be attributed to the right model patch.
 	 */
 	patchIndices?: readonly (number | undefined)[];
+	/**
+	 * The document the cached edit actually applies to, when it differs from the
+	 * document the entry is keyed under (cross-file NES). `undefined` means the edit
+	 * targets the owning/key document (the common same-file case).
+	 *
+	 * Used to cache an `A -> suggestion-in-B` association: the entry is keyed and
+	 * gated against the active document A (content + edit window), but the edit it
+	 * carries lands in document B.
+	 */
+	targetDocId?: DocumentId;
+	/**
+	 * The target document's content at the time the cross-file edit was produced
+	 * (i.e. the content the {@link CachedEdit.edit} offsets index into). Only set
+	 * together with {@link targetDocId}. The read path must serve the edit only when
+	 * the target document's live content still equals this snapshot; otherwise the
+	 * edit's offsets are stale and would resolve against the wrong content.
+	 */
+	targetDocumentBeforeEdit?: StringText;
 }
 
 export interface CachedEdit {
 	docId: DocumentId;
+	/**
+	 * The document the cached edit actually applies to, when it differs from {@link docId}
+	 * (cross-file NES). `undefined` means the edit targets the owning/key document
+	 * {@link docId} (the common same-file case). @see CachedEditOpts.targetDocId
+	 */
+	targetDocId?: DocumentId;
+	/**
+	 * The target document's content at the time the cross-file edit was produced.
+	 * Only set together with {@link targetDocId}. @see CachedEditOpts.targetDocumentBeforeEdit
+	 */
+	targetDocumentBeforeEdit?: StringText;
 	documentBeforeEdit: StringText;
 	editWindow?: OffsetRange;
 	/**
@@ -259,7 +288,7 @@ class DocumentEditCache {
 
 	public setKthNextEdit(documentContents: StringText, editWindow: OffsetRange | undefined, nextEdit: StringReplacement, nextEdits: StringReplacement[] | undefined, userEditSince: StringEdit | undefined, subsequentN: number, source: NextEditFetchRequest, opts: CachedEditOpts): CachedEdit {
 		const key = this._getKey(documentContents.value);
-		const cachedEdit: CachedEdit = { docId: this.docId, edit: nextEdit, edits: nextEdits, detailedEdits: [], userEditSince, subsequentN, patchIndex: opts.patchIndex, patchIndices: opts.patchIndices, source, documentBeforeEdit: documentContents, editWindow, originalEditWindow: opts.originalEditWindow, cacheTime: Date.now(), isFromCursorJump: opts.isFromCursorJump, cursorOffsetAtCacheTime: opts.cursorOffset };
+		const cachedEdit: CachedEdit = { docId: this.docId, targetDocId: opts.targetDocId, targetDocumentBeforeEdit: opts.targetDocumentBeforeEdit, edit: nextEdit, edits: nextEdits, detailedEdits: [], userEditSince, subsequentN, patchIndex: opts.patchIndex, patchIndices: opts.patchIndices, source, documentBeforeEdit: documentContents, editWindow, originalEditWindow: opts.originalEditWindow, cacheTime: Date.now(), isFromCursorJump: opts.isFromCursorJump, cursorOffsetAtCacheTime: opts.cursorOffset };
 		if (userEditSince) {
 			if (!checkEditConsistency(cachedEdit.documentBeforeEdit.value, userEditSince, this._doc.value.get().value, this._logger.createSubLogger('setKthNextEdit'))) {
 				cachedEdit.userEditSince = undefined;
@@ -309,7 +338,10 @@ class DocumentEditCache {
 			// If the cursor moved farther from the edit's start line than it was at cache time,
 			// reject the cached edit so the same suggestion is not shown again.
 			// Only applies to non-rebased, non-subsequent edits.
+			// Skipped for cross-file entries: their `edit` is in the target document's
+			// coordinate space, so transforming it against this (active) document is meaningless.
 			if (cacheCursorDistanceCheck
+				&& !cachedEdit.targetDocId
 				&& cachedEdit.edit
 				&& (cachedEdit.subsequentN === undefined || cachedEdit.subsequentN === 0)
 				&& cachedEdit.cursorOffsetAtCacheTime !== undefined

--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
@@ -341,7 +341,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 
 		const nesConfigs = this.determineNesConfigs(telemetryBuilder, logContext);
 
-		const cachedEdit = this._nextEditCache.lookupNextEdit(docId, documentAtInvocationTime, selections);
+		let cachedEdit = this._nextEditCache.lookupNextEdit(docId, documentAtInvocationTime, selections);
 		if (cachedEdit?.rejected) {
 			logger.trace('cached edit was previously rejected');
 			telemetryBuilder.setStatus('previouslyRejectedCache');
@@ -353,6 +353,25 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 			}
 			const nextEditResult = new NextEditResult(logContext.requestId, cachedEdit.source, undefined);
 			return nextEditResult;
+		}
+
+		// Cross-file cache hit validity: a cross-file entry is keyed under the active document but
+		// carries an edit for a *different* target document. It can only be served while that
+		// target document is open AND still byte-identical to the snapshot the edit's offsets
+		// index into. If the target is closed, changed, or the snapshot is missing, the cached
+		// edit cannot be safely placed — so treat it as a cache miss and fall through to a fresh
+		// fetch. Returning "no edit" instead would keep re-serving this dead entry (still keyed
+		// under the unchanged active document) on every retrigger until the active document is
+		// edited, starving the active file of suggestions.
+		if (cachedEdit && cachedEdit.targetDocId && cachedEdit.targetDocId !== docId) {
+			const targetDoc = this._workspace.getDocument(cachedEdit.targetDocId);
+			const isUsable = !!targetDoc
+				&& !!cachedEdit.targetDocumentBeforeEdit
+				&& targetDoc.value.get().value === cachedEdit.targetDocumentBeforeEdit.value;
+			if (!isUsable) {
+				logger.trace(`cross-file cached edit unusable (target ${targetDoc ? 'changed' : 'not open'}); treating as cache miss and refetching`);
+				cachedEdit = undefined;
+			}
 		}
 
 		let edit: { actualEdit: StringReplacement; isFromCursorJump: boolean } | undefined;
@@ -377,7 +396,15 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 			isFromSpeculativeRequest = cachedEdit.source.isSpeculative;
 			req = cachedEdit.source;
 			logContext.setIsCachedResult(cachedEdit.source.log);
-			currentDocument = documentAtInvocationTime;
+			// A cross-file cached entry is keyed and gated under the active document, but its
+			// edit applies to a different (target) document. Its validity (target document open
+			// and unchanged) was confirmed above, so serve it against the target's live content.
+			targetDocumentId = cachedEdit.targetDocId ?? targetDocumentId;
+			if (cachedEdit.targetDocId && cachedEdit.targetDocId !== docId) {
+				currentDocument = this._workspace.getDocument(cachedEdit.targetDocId)!.value.get();
+			} else {
+				currentDocument = documentAtInvocationTime;
+			}
 			telemetryBuilder.setHeaderRequestId(req.headerRequestId);
 			telemetryBuilder.setIsFromCache();
 			telemetryBuilder.setSubsequentEditOrder(cachedEdit.rebasedEditIndex ?? cachedEdit.subsequentN);
@@ -493,6 +520,44 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 
 		logger.trace('returning next edit result');
 		return nextEditResult;
+	}
+
+	/**
+	 * Cross-file NES: when the first streamed edit targets a document other than the active
+	 * one, also cache an `activeDoc (content + edit window) -> suggestion-in-targetDoc`
+	 * association. This lets the cross-file suggestion be re-served from cache while the cursor
+	 * is still in the active document (the regular path only caches it under the target
+	 * document, which is reachable from cache only after the user jumps there).
+	 *
+	 * The entry is stored without `userEditSince`, so it is never tracked/rebased: its edit is
+	 * in the target document's coordinate space and is served by exact content match only.
+	 */
+	private _maybeCacheCrossFileEditUnderActiveDoc(
+		ithEdit: number,
+		activeDocId: DocumentId,
+		activeDocContents: StringText,
+		activeDocEditWindow: OffsetRange | undefined,
+		targetDocId: DocumentId,
+		targetDocContents: StringText,
+		nextEdit: StringReplacement,
+		streamedEdit: { readonly isFromCursorJump: boolean; readonly originalWindow?: OffsetRange; readonly patchIndex?: number },
+		source: NextEditFetchRequest,
+	): boolean {
+		if (ithEdit !== 0 || targetDocId === activeDocId) {
+			return false; // only the first streamed edit, and only when it targets a different document
+		}
+		this._nextEditCache.setKthNextEdit(
+			activeDocId,
+			activeDocContents,
+			activeDocEditWindow,
+			nextEdit,
+			0,
+			undefined, // no bundled edits: served by exact content match only
+			undefined, // no userEditSince: never tracked/rebased (edit is in target-doc coords)
+			source,
+			{ isFromCursorJump: streamedEdit.isFromCursorJump, originalEditWindow: streamedEdit.originalWindow, patchIndex: streamedEdit.patchIndex, targetDocId, targetDocumentBeforeEdit: targetDocContents }
+		);
+		return true;
 	}
 
 	private determineNesConfigs(telemetryBuilder: LlmNESTelemetryBuilder, logContext: InlineEditRequestLogContext): INesConfigs {
@@ -773,6 +838,11 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 
 		let ithEdit = -1;
 
+		// Tracks whether this stream stored a cross-file suggestion under the active document.
+		// When it did, the active document must NOT be cached as "no edit" at stream end —
+		// that would clobber the cross-file entry stored under the same key.
+		let didCacheCrossFileActiveDocEntry = false;
+
 		const processEdit = (streamedEdit: { readonly edit: LineReplacement; readonly isFromCursorJump: boolean; readonly window?: OffsetRange; readonly originalWindow?: OffsetRange; readonly targetDocument?: DocumentId; readonly patchIndex?: number }, telemetry: IStatelessNextEditTelemetry): CachedOrRebasedEdit | undefined => {
 			++ithEdit;
 			const myLogger = logger.createSubLogger('processEdit');
@@ -821,6 +891,8 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 					{ isFromCursorJump: streamedEdit.isFromCursorJump, originalEditWindow: streamedEdit.originalWindow, cursorOffset: targetDocState.docId === curDocId ? activeDocSelection?.start : undefined, patchIndex: streamedEdit.patchIndex, patchIndices: ithEdit === 0 ? targetDocState.patchIndices : undefined }
 				);
 				myLogger.trace(`populated cache for ${ithEdit}`);
+
+				didCacheCrossFileActiveDocEntry = this._maybeCacheCrossFileEditUnderActiveDoc(ithEdit, curDocId, nextEditRequest.documentBeforeEdits, streamedEdit.window, targetDocState.docId, targetDocState.docContents, nextEditReplacement, streamedEdit, req) || didCacheCrossFileActiveDocEntry;
 			}
 
 			if (!firstEdit.isSettled) {
@@ -848,7 +920,9 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 				myLogger.trace(`${statePerDoc.get(curDocId).nextEdits.length} edits returned`);
 			} else {
 				myLogger.trace(`no edit, reason: ${completionReason.kind}`);
-				if (completionReason instanceof NoNextEditReason.NoSuggestions) {
+				// Skip caching a "no edit" entry for the active document when a cross-file
+				// suggestion was already stored under the same key — doing so would clobber it.
+				if (completionReason instanceof NoNextEditReason.NoSuggestions && !didCacheCrossFileActiveDocEntry) {
 					const { documentBeforeEdits, window } = completionReason;
 					const reducedWindow = window ? computeReducedWindow(window, activeDocSelection, documentBeforeEdits) : undefined;
 					this._nextEditCache.setNoNextEdit(curDocId, documentBeforeEdits, reducedWindow, req);
@@ -1372,6 +1446,8 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 								req,
 								{ isFromCursorJump: streamedEdit.isFromCursorJump, originalEditWindow: streamedEdit.originalWindow, cursorOffset: targetDocState.docId === curDocId ? cursorOffset : undefined, patchIndex: streamedEdit.patchIndex, patchIndices: ithEdit === 0 ? targetDocState.patchIndices : undefined }
 							);
+
+							this._maybeCacheCrossFileEditUnderActiveDoc(ithEdit, curDocId, nextEditRequest.documentBeforeEdits, streamedEdit.window, targetDocState.docId, targetDocState.docContents, nextEditReplacement, streamedEdit, req);
 
 							if (!nextEditRequest.firstEdit.isSettled && cachedEdit) {
 								nextEditRequest.firstEdit.complete(Result.ok(cachedEdit));

--- a/extensions/copilot/src/extension/inlineEdits/test/node/nextEditProviderCaching.spec.ts
+++ b/extensions/copilot/src/extension/inlineEdits/test/node/nextEditProviderCaching.spec.ts
@@ -500,6 +500,15 @@ describe('NextEditProvider Caching', () => {
 		const second = await nextEditProvider.getNextEdit(docA.id, context, logContext, cancellationToken, tb2.nesBuilder);
 		tb2.dispose();
 
+		// Tear down the provider (which registers autoruns/watchers on `openDocuments` in its
+		// constructor) and the documents so each scenario run is self-contained and does not
+		// accumulate observers across the cross-file tests. Dispose the provider first so its
+		// autoruns no longer react to the documents being removed; document disposal is
+		// idempotent, so re-disposing `docB` after `disposeTargetBeforeSecondRequest` is safe.
+		nextEditProvider.dispose();
+		docA.dispose();
+		docB.dispose();
+
 		return { first, second, docBId, getCallCount };
 	}
 

--- a/extensions/copilot/src/extension/inlineEdits/test/node/nextEditProviderCaching.spec.ts
+++ b/extensions/copilot/src/extension/inlineEdits/test/node/nextEditProviderCaching.spec.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 import { outdent } from 'outdent';
 import { afterAll, assert, beforeAll, describe, expect, it } from 'vitest';
-import { IConfigurationService } from '../../../../platform/configuration/common/configurationService';
+import { ConfigKey, ExperimentBasedConfig, ExperimentBasedConfigType, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
 import { DefaultsOnlyConfigurationService } from '../../../../platform/configuration/common/defaultsOnlyConfigurationService';
+import { InMemoryConfigurationService } from '../../../../platform/configuration/test/common/inMemoryConfigurationService';
 import { IGitExtensionService } from '../../../../platform/git/common/gitExtensionService';
 import { NullGitExtensionService } from '../../../../platform/git/common/nullGitExtensionService';
 import { DocumentId } from '../../../../platform/inlineEdits/common/dataTypes/documentId';
@@ -24,6 +25,7 @@ import { mockNotebookService } from '../../../../platform/test/common/testNotebo
 import { TestWorkspaceService } from '../../../../platform/test/node/testWorkspaceService';
 import { IWorkspaceService } from '../../../../platform/workspace/common/workspaceService';
 import { Result } from '../../../../util/common/result';
+import { DeferredPromise, timeout } from '../../../../util/vs/base/common/async';
 import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
 import { DisposableStore } from '../../../../util/vs/base/common/lifecycle';
 import { URI } from '../../../../util/vs/base/common/uri';
@@ -380,5 +382,232 @@ describe('NextEditProvider Caching', () => {
 		// The first (fresh) edit must be attributed too, not just the cached ones;
 		// the split pair shares patch 0 while the final edit comes from patch 1.
 		expect(servedPatchIndices).toEqual([0, 0, 1]);
+	});
+
+	/**
+	 * Configuration that disables the cross-document cache purge (which otherwise deletes
+	 * cross-file cache entries whenever *any* document is edited, by setting
+	 * `InlineEditsTriggerOnEditorChangeAfterSeconds` to `undefined`). With the purge off, a
+	 * cross-file entry survives an edit to its target document, so the read-path staleness guard
+	 * — rather than the purge — becomes responsible for not serving the now-stale suggestion.
+	 */
+	class PurgeDisabledConfigurationService extends InMemoryConfigurationService {
+		override getExperimentBasedConfig<T extends ExperimentBasedConfigType>(key: ExperimentBasedConfig<T>, experimentationService: IExperimentationService): T {
+			if (key === ConfigKey.Advanced.InlineEditsTriggerOnEditorChangeAfterSeconds) {
+				return undefined as T;
+			}
+			return super.getExperimentBasedConfig(key, experimentationService);
+		}
+	}
+
+	/**
+	 * Stateless provider that yields a single edit targeting a *different* document than the
+	 * active one, and only on its first invocation. Later invocations yield nothing, so any
+	 * subsequently served suggestion can only originate from the cache.
+	 *
+	 * Exposes the number of times it was invoked (to distinguish a cache hit from a fresh
+	 * fetch) and a promise that resolves once the first request's stream has fully ended (so
+	 * tests can re-request only after the no-suggestions stream-end handling has run).
+	 */
+	function createCrossFileStatelessProvider(targetDocId: DocumentId, targetEdit: LineReplacement, activeDocWindow?: OffsetRange): { provider: IStatelessNextEditProvider; getCallCount: () => number; whenFirstStreamEnded: Promise<void> } {
+		let callCount = 0;
+		const firstStreamEnded = new DeferredPromise<void>();
+		const provider: IStatelessNextEditProvider = {
+			ID: 'TestCrossFileNextEditProvider',
+			provideNextEdit: async function*(request: StatelessNextEditRequest, logger: ILogger, logContext: InlineEditRequestLogContext, cancellationToken: CancellationToken) {
+				const telemetryBuilder = new StatelessNextEditTelemetryBuilder(request.headerRequestId);
+				callCount++;
+				const isFirstCall = callCount === 1;
+				try {
+					if (isFirstCall) {
+						yield new WithStatelessProviderTelemetry({ targetDocument: targetDocId, edit: targetEdit, isFromCursorJump: false, window: activeDocWindow, patchIndex: undefined }, telemetryBuilder.build(Result.ok(undefined)));
+					}
+					const noSuggestions = new NoNextEditReason.NoSuggestions(request.documentBeforeEdits, undefined);
+					return new WithStatelessProviderTelemetry(noSuggestions, telemetryBuilder.build(Result.error(noSuggestions)));
+				} finally {
+					if (isFirstCall) {
+						firstStreamEnded.complete();
+					}
+				}
+			}
+		};
+		return { provider, getCallCount: () => callCount, whenFirstStreamEnded: firstStreamEnded.p };
+	}
+
+	async function runCrossFileScenario(options?: { activeDocWindow?: OffsetRange; disposeTargetBeforeSecondRequest?: boolean; mutateTargetBeforeSecondRequest?: boolean; disableEditorChangeTrigger?: boolean }) {
+		const obsWorkspace = new MutableObservableWorkspace();
+		const obsGit = new ObservableGit(gitExtensionService);
+
+		// DocumentId is interned, so we can compute the ids before adding the documents.
+		const docAId = DocumentId.create(URI.file('/test/a.ts').toString());
+		const docBId = DocumentId.create(URI.file('/test/b.ts').toString());
+
+		// By default the shared (defaults-only) config keeps the cross-document cache purge on.
+		// Opt into the purge-disabled config to isolate the read-path staleness guard.
+		const scenarioConfigService = options?.disableEditorChangeTrigger ? new PurgeDisabledConfigurationService(new DefaultsOnlyConfigurationService()) : configService;
+
+		// Suggestion (for the non-active document B) replacing its `return 1;` line.
+		const targetEdit = new LineReplacement(new LineRange(2, 3), ['\treturn 42;']);
+		const { provider: statelessNextEditProvider, getCallCount, whenFirstStreamEnded } = createCrossFileStatelessProvider(docBId, targetEdit, options?.activeDocWindow);
+
+		const nextEditProvider: NextEditProvider = new NextEditProvider(obsWorkspace, statelessNextEditProvider, new NesHistoryContextProvider(obsWorkspace, obsGit), new NesXtabHistoryTracker(obsWorkspace, undefined, scenarioConfigService, expService), undefined, scenarioConfigService, snippyService, logService, expService, requestLogger);
+
+		const docB = obsWorkspace.addDocument({ id: docBId, initialValue: ['export function helper() {', '\treturn 1;', '}'].join('\n') });
+		const docA = obsWorkspace.addDocument({ id: docAId, initialValue: ['class Point {', '\tconstructor(', '\t\tprivate readonly x: number,', '\t) { }', '}'].join('\n') });
+
+		docB.setSelection([new OffsetRange(0, 0)], undefined);
+		// The active document's cursor sits at offset 1 — relevant to the edit-window gating tests.
+		docA.setSelection([new OffsetRange(1, 1)], undefined);
+
+		// Give document B a recent edit so it is part of the active document's history
+		// context (required for the cross-file edit to be processed against it). Append at
+		// the end so B's `return 1;` line stays put.
+		docB.applyEdit(StringEdit.insert(docB.value.get().value.length, '\n// touched'));
+		// Edit document A so it is the active document and has history ("Point" -> "Point3D").
+		docA.applyEdit(StringEdit.insert(11, '3D'));
+
+		const context: NESInlineCompletionContext = { triggerKind: 1, selectedCompletionInfo: undefined, requestUuid: generateUuid(), requestIssuedDateTime: Date.now(), earliestShownDateTime: Date.now() + 200, enforceCacheDelay: false };
+		const logContext = new InlineEditRequestLogContext(docA.id.toString(), 1, context);
+		const cancellationToken = CancellationToken.None;
+
+		const tb1 = new NextEditProviderTelemetryBuilder(gitExtensionService, mockNotebookService, workspaceService, nextEditProvider.ID, docA);
+		const first = await nextEditProvider.getNextEdit(docA.id, context, logContext, cancellationToken, tb1.nesBuilder);
+		tb1.dispose();
+
+		// Wait until the first request's stream has fully ended before re-requesting. The
+		// cross-file edit is processed synchronously (so `first` already has it), but the
+		// terminal no-suggestions handling — which clears the pending request and would clobber
+		// the active-doc cache entry via `setNoNextEdit` if not guarded — runs afterwards in the
+		// background. Draining it here makes the second request deterministically observe the
+		// post-stream-end cache state (cache hit vs. fresh fetch), so these tests are not vacuous.
+		await whenFirstStreamEnded;
+		await timeout(0);
+
+		// Optionally close the target document B before re-requesting, so the cached cross-file
+		// entry can no longer be resolved against live content.
+		if (options?.disposeTargetBeforeSecondRequest) {
+			docB.dispose();
+		}
+		// Optionally mutate the target document B so its live content no longer matches the
+		// snapshot the cross-file edit was produced against, making the cached edit stale.
+		if (options?.mutateTargetBeforeSecondRequest) {
+			docB.applyEdit(StringEdit.insert(0, '// header\n'));
+		}
+
+		// Second request with no change to the active document A: the provider is now silent,
+		// so any served suggestion must come from the cache.
+		const tb2 = new NextEditProviderTelemetryBuilder(gitExtensionService, mockNotebookService, workspaceService, nextEditProvider.ID, docA);
+		const second = await nextEditProvider.getNextEdit(docA.id, context, logContext, cancellationToken, tb2.nesBuilder);
+		tb2.dispose();
+
+		return { first, second, docBId, getCallCount };
+	}
+
+	it('re-serves a cross-file suggestion from cache while the cursor stays in the active document (surviving the no-suggestions stream end)', async () => {
+		const { first, second, docBId, getCallCount } = await runCrossFileScenario();
+
+		// Fresh: the provider produced a suggestion that targets the other document.
+		assert(first.result?.edit, 'expected a cross-file edit on the first request');
+		expect(first.result.targetDocumentId).toBe(docBId);
+
+		// Cached: re-served from the entry keyed under the active document, even though the
+		// first request's stream ended with no suggestions *for the active document* (which must
+		// not clobber the cross-file entry) and the provider no longer yields anything. It is the
+		// very same suggestion (and target), served from cache without re-invoking the provider.
+		assert(second.result?.edit, 'expected the cross-file edit to be re-served from cache');
+		expect(second.result.targetDocumentId).toBe(docBId);
+		expect(second.result.edit).toBe(first.result.edit);
+		expect(getCallCount()).toBe(1);
+	});
+
+	it('re-serves a cross-file suggestion from cache when the cursor is within the cached edit window', async () => {
+		// The active document's cursor is at offset 1, which falls inside [0, 14).
+		const { first, second, docBId, getCallCount } = await runCrossFileScenario({ activeDocWindow: new OffsetRange(0, 14) });
+
+		assert(first.result?.edit, 'expected a cross-file edit on the first request');
+		expect(first.result.targetDocumentId).toBe(docBId);
+
+		assert(second.result?.edit, 'expected the cross-file edit to be re-served from cache');
+		expect(second.result.targetDocumentId).toBe(docBId);
+		expect(second.result.edit).toBe(first.result.edit);
+		expect(getCallCount()).toBe(1);
+	});
+
+	it('does not re-serve a cross-file suggestion from cache when the cursor is outside the cached edit window', async () => {
+		// The active document's cursor is at offset 1, which is outside [20, 30). Window gating
+		// only applies to cache hits, so the fresh suggestion is unaffected.
+		const { first, second, docBId, getCallCount } = await runCrossFileScenario({ activeDocWindow: new OffsetRange(20, 30) });
+
+		assert(first.result?.edit, 'expected a cross-file edit on the first request');
+		expect(first.result.targetDocumentId).toBe(docBId);
+
+		// The cached entry is gated out by the edit window, so the second request misses the
+		// cache and falls through to a fresh fetch (a second provider call), which is silent.
+		expect(second.result?.edit).toBeUndefined();
+		expect(getCallCount()).toBe(2);
+	});
+
+	it('refetches instead of serving a stale cross-file suggestion when the target document is no longer open', async () => {
+		// Same setup as the happy path, but the target document B is closed before the second
+		// request. The only difference from the happy path (which serves from cache with a single
+		// provider call) is the closed target, so a second provider call proves the closed-target
+		// validity check turned the cache hit into a miss rather than serving an unplaceable edit.
+		const { first, second, docBId, getCallCount } = await runCrossFileScenario({ disposeTargetBeforeSecondRequest: true });
+
+		assert(first.result?.edit, 'expected a cross-file edit on the first request');
+		expect(first.result.targetDocumentId).toBe(docBId);
+
+		// The cross-file entry is found but its target document is closed, so it cannot be
+		// resolved against live content; the read path treats it as a cache miss and refetches
+		// (a second, silent provider call) instead of getting stuck re-serving the dead entry.
+		expect(second.result?.edit).toBeUndefined();
+		expect(getCallCount()).toBe(2);
+	});
+
+	it('re-serves a cross-file suggestion (with the purge disabled) while the target document is unchanged', async () => {
+		// Control for the staleness test below: with the cross-document purge disabled, the
+		// cross-file entry survives into the second request, and while the target document is
+		// unchanged it is served straight from cache (a single provider call). This isolates the
+		// staleness guard — any refetch in the sibling test must come from the content change,
+		// not from the entry being absent.
+		const { first, second, docBId, getCallCount } = await runCrossFileScenario({ disableEditorChangeTrigger: true });
+
+		assert(first.result?.edit, 'expected a cross-file edit on the first request');
+		expect(first.result.targetDocumentId).toBe(docBId);
+
+		assert(second.result?.edit, 'expected the cross-file edit to be re-served from cache');
+		expect(second.result.targetDocumentId).toBe(docBId);
+		expect(second.result.edit).toBe(first.result.edit);
+		expect(getCallCount()).toBe(1);
+	});
+
+	it('refetches instead of serving a stale cross-file suggestion when the target document changed since it was produced', async () => {
+		// Disable the cross-document purge so the cross-file entry survives the edit to B; the
+		// read-path staleness guard is then the only thing standing between a changed target and a
+		// misplaced suggestion. Paired with the unchanged-target control above, the extra provider
+		// call here is attributable to the content change rather than to a missing entry.
+		const { first, second, docBId, getCallCount } = await runCrossFileScenario({ mutateTargetBeforeSecondRequest: true, disableEditorChangeTrigger: true });
+
+		assert(first.result?.edit, 'expected a cross-file edit on the first request');
+		expect(first.result.targetDocumentId).toBe(docBId);
+
+		// The target document changed after the suggestion was produced, so the cached edit's
+		// offsets are stale and would land at the wrong location. The read path treats the hit as
+		// a cache miss and refetches (a second provider call) rather than serving a misplaced edit.
+		expect(second.result?.edit).toBeUndefined();
+		expect(getCallCount()).toBe(2);
+	});
+
+	it('does not serve a stale cross-file suggestion when the target document changed under the default (purge-enabled) configuration', async () => {
+		// In the default configuration, editing the target document B purges every cross-document
+		// cache entry (including the active-document-keyed cross-file entry) before the next
+		// request, so the stale suggestion is never re-served and the provider is consulted again.
+		const { first, second, docBId, getCallCount } = await runCrossFileScenario({ mutateTargetBeforeSecondRequest: true });
+
+		assert(first.result?.edit, 'expected a cross-file edit on the first request');
+		expect(first.result.targetDocumentId).toBe(docBId);
+
+		expect(second.result?.edit).toBeUndefined();
+		expect(getCallCount()).toBe(2);
 	});
 });


### PR DESCRIPTION
## What

Extends Next Edit Suggestion (NES) caching to support **cross-file** suggestions — a suggestion the model returns for a document _other_ than the one being edited.

Previously a cross-file suggestion was cached only under the **target** document's content (`B(content) → edit`), so it could only be re-served from cache after the user navigated to B. This change **additionally** caches it under the **active** document:

```
A(content + edit window) → edit-in-B
```

so the cross-file suggestion can be re-served from cache while the cursor is still in A — the same place it was produced.

## How

- **Cache (`nextEditCache.ts`)** — `CachedEdit`/`CachedEditOpts` gain `targetDocId?` (the document the edit applies to, when different from the key document) and `targetDocumentBeforeEdit?` (a snapshot of that document's content the edit's offsets index into). The cursor-distance rejection is skipped for cross-file entries (their edit is in the target's coordinate space), while edit-window gating — which is in the active document's coordinates — is kept.

- **Provider write path (`nextEditProvider.ts`)** — when the first streamed edit targets a different document, a small helper also stores the A‑keyed cross-file entry (exact content match only, never rebased). At stream end the active document is **no longer** cached as "no edit" when a cross-file entry was just stored under the same key, which would otherwise clobber it. Applied to both the normal and speculative paths.

- **Provider read path (`nextEditProvider.ts`)** — a cross-file cache hit is served only while its target document is **open** and **byte-identical** to the stored snapshot. Otherwise the hit is treated as a **cache miss → fresh fetch**, rather than serving a misplaced edit or getting stuck re-serving a dead entry until the active document changes.

This is always on (no config flag).

## Two invalidation layers

1. **Default config** — editing the target document already purges cross-document cache entries (the existing `InlineEditsTriggerOnEditorChangeAfterSeconds` purge, default `10`).
2. **Read-path validity guard** — additionally covers the closed-target case (closing isn't an edit, so no purge) and the purge-disabled configuration.

## Tests

7 cross-file tests in `nextEditProviderCaching.spec.ts`, assertions are behavioral (served edit + provider call-count, deterministically waiting for the first request's stream-end before re-requesting):

- re-serves on a 2nd trigger in A and survives the no-suggestions stream-end (no clobber);
- re-serves within / refetches outside the cached edit window;
- refetches when the target document is closed;
- control: with the purge disabled and the target unchanged, re-serves from cache (isolates the guard);
- refetches when the target changed — once with the purge disabled (guard fires) and once under the default config (purge fires).

## Validation

- `nextEditProviderCaching.spec.ts`: 11/11 pass; broader NES suite: 89 pass / 2 pre-existing skips.
- Typecheck (`tsgo --noEmit`) and eslint clean on all changed files.

## Out of scope

- Rebasing the active-document-keyed entry across edits in the active document (exact-match only).
- Hardening the _fresh_ cross-file path against the target changing in-flight (pre-existing; subsequent re-serves are already protected by the new guard).