### PR TITLE
chat/voice: land voice answers on question carousels (fix Skipped)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -16,14 +16,15 @@ import { CommandsRegistry, ICommandService } from '../../../../../platform/comma
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IAuthenticationService } from '../../../../services/authentication/common/authentication.js';
 import { IVoiceTranscriptEntryMetadata, IVoiceTranscriptStore, IVoiceTranscriptTurn, VoiceTranscriptKind } from '../../../agentsVoice/common/voiceTranscriptStore.js';
-import { IVoiceClientService, IVoicePriorTimelineEntry, IVoiceSessionContext, IVoiceFeedbackPayload, IVoiceFeedbackTranscriptTurn } from '../../common/voiceClient/voiceClientService.js';
+import { IVoiceClientService, IVoicePriorTimelineEntry, IVoiceSessionContext, IVoiceSessionPending, IVoicePendingQuestion, IVoiceFeedbackPayload, IVoiceFeedbackTranscriptTurn } from '../../common/voiceClient/voiceClientService.js';
 import { IMicCaptureService, IPttDiagnostic } from './micCaptureService.js';
 import { ITtsPlaybackService } from './ttsPlaybackService.js';
 import { IVoiceToolDispatchService, VoiceToolDispatchService } from './voiceToolDispatchService.js';
 import { IVoicePlaybackService } from '../../common/voicePlaybackService.js';
 import { IAgentSessionsService } from '../agentSessions/agentSessionsService.js';
 import { AgentSessionStatus } from '../agentSessions/agentSessionsModel.js';
-import { IChatService, IChatToolInvocation, ToolConfirmKind, IChatModelReference } from '../../common/chatService/chatService.js';
+import { IChatService, IChatToolInvocation, ToolConfirmKind, IChatModelReference, IChatQuestion } from '../../common/chatService/chatService.js';
+import { getOptionsWithDefaultsFirst } from '../../common/chatService/chatQuestionCarouselHelpers.js';
 import { IChatModel } from '../../common/model/chatModel.js';
 import { ChatAgentLocation } from '../../common/constants.js';
 import { IWorkbenchEnvironmentService } from '../../../../services/environment/common/environmentService.js';
@@ -941,7 +942,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			}
 		}));
 
-		// Tool calls → dispatch the binary-router tools from the voice LLM.
+		// Tool calls → dispatch the router tools from the voice LLM.
 		// send_to_chat is the LLM's signal that the utterance is a task for the
 		// active coding session; the backend has already overwritten args.text
 		// with the user's verbatim final transcript, so we just forward it.
@@ -952,7 +953,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			const allowedTools = [
 				'send_to_chat',
 				'get_session_info', 'get_session_changes', 'get_session_thread',
-				'approve_confirmation', 'reject_confirmation',
+				'respond_to_session',
 				'auto_approve_session', 'revoke_auto_approve',
 				'focus_session',
 			];
@@ -982,11 +983,17 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 					toolArgs: e.args,
 				});
 				// Telemetry: tool approval/rejection via voice
-				if (e.name === 'approve_confirmation' || e.name === 'reject_confirmation') {
-					this.telemetryService.publicLog2<VoiceToolApprovalEvent, VoiceToolApprovalClassification>('voiceToolApproval', {
-						toolName: e.name,
-						approved: e.name === 'approve_confirmation',
-					});
+				if (e.name === 'respond_to_session') {
+					const response = (e.args?.['response'] && typeof e.args['response'] === 'object')
+						? e.args['response'] as Record<string, unknown>
+						: {};
+					const responseType = typeof response['type'] === 'string' ? response['type'] as string : '';
+					if (responseType === 'approve' || responseType === 'reject') {
+						this.telemetryService.publicLog2<VoiceToolApprovalEvent, VoiceToolApprovalClassification>('voiceToolApproval', {
+							toolName: e.name,
+							approved: responseType === 'approve',
+						});
+					}
 				}
 				// Exit listening mode so the response audio isn't suppressed.
 				if (this._pttHeld) {
@@ -1643,7 +1650,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	 *
 	 *   send_to_chat(text="Open a new terminal and cd into the current directory.")
 	 *   new_sessions(sessions=[{"text": "Refactor upload service"}])
-	 *   approve_confirmation(...)
+	 *   respond_to_session(response={"type":"approve"})
 	 */
 	private _renderToolCallSummary(name: string, args: Record<string, unknown> | undefined): string {
 		if (!args || Object.keys(args).length === 0) {
@@ -2088,6 +2095,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				agent_state: stateInfo.state,
 				...(stateInfo.detail ? { agent_state_detail: stateInfo.detail } : {}),
 				...(stateInfo.last_response_summary ? { last_response_summary: stateInfo.last_response_summary } : {}),
+				...(stateInfo.pending ? { pending: stateInfo.pending } : {}),
 			};
 		});
 
@@ -2110,6 +2118,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				agent_state: stateInfo.state,
 				...(stateInfo.detail ? { agent_state_detail: stateInfo.detail } : {}),
 				...(stateInfo.last_response_summary ? { last_response_summary: stateInfo.last_response_summary } : {}),
+				...(stateInfo.pending ? { pending: stateInfo.pending } : {}),
 			});
 		}
 
@@ -2157,12 +2166,13 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		}, () => { cts.dispose(); });
 	}
 
-	private _getAgentStateInfo(model: IChatModel | undefined | null): { state: string; detail?: string; last_response_summary?: string } {
+	private _getAgentStateInfo(model: IChatModel | undefined | null): { state: string; detail?: string; last_response_summary?: string; pending?: IVoiceSessionPending } {
 		if (!model) {
 			return { state: 'unknown' };
 		}
 
 		const lastRequest = model.getRequests().at(-1);
+		const pending = this._buildPendingPayload(lastRequest);
 		const pendingConfirmation = lastRequest?.response?.isPendingConfirmation.get();
 		if (pendingConfirmation) {
 			// Scan ALL response parts to find the most recent pending item.
@@ -2213,6 +2223,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			return {
 				state: 'waiting_for_confirmation',
 				detail: confirmDetail || pendingConfirmation.detail || '',
+				...(pending ? { pending } : {}),
 			};
 		}
 
@@ -2247,8 +2258,21 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 				return {
 					state: 'waiting_for_confirmation',
 					detail: fallbackDetail,
+					...(pending ? { pending } : {}),
 				};
 			}
+		}
+
+		// A questionCarousel / elicitation can be pending without setting
+		// ``confirmationMessages`` (so ``isPendingConfirmation`` is undefined and
+		// the toolInvocation fallback above finds nothing). If we built a
+		// structured pending payload, surface it as a confirmation-wait so the
+		// backend narrates and the user can answer by voice.
+		if (pending) {
+			const detail = pending.questions && pending.questions.length > 0
+				? `questions: ${pending.questions.map(q => q.title).filter(Boolean).join(', ')}`
+				: (pending.title ?? pending.message ?? 'needs input');
+			return { state: 'waiting_for_confirmation', detail, pending };
 		}
 
 		const incomplete = lastRequest?.response?.isIncomplete.get() ?? false;
@@ -2258,6 +2282,92 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 		const responseText = lastRequest?.response?.response.toString() ?? '';
 		return { state: 'idle', ...(responseText ? { last_response_summary: responseText } : {}) };
+	}
+
+	/**
+	 * Build the structured ``pending`` payload for a request: the authoritative
+	 * description of what the agent is waiting on (a questionCarousel form, a
+	 * binary tool/confirmation approval, or an elicitation) with the exact
+	 * routing ids the backend echoes back so the dispatch layer can target the
+	 * precise chat part. Scans all response parts and lets the LAST pending part
+	 * win, matching ``_getAgentStateInfo``'s chronological "newest pending" rule.
+	 */
+	private _buildPendingPayload(lastRequest: { id: string; response?: { response: { value: readonly { kind: string }[] } } } | undefined): IVoiceSessionPending | undefined {
+		const parts = lastRequest?.response?.response.value;
+		if (!lastRequest || !parts) {
+			return undefined;
+		}
+		const requestId = lastRequest.id;
+		let pending: IVoiceSessionPending | undefined;
+		parts.forEach((part, index) => {
+			if (part.kind === 'questionCarousel' && !(part as { isUsed?: boolean }).isUsed) {
+				const carousel = part as { questions?: IChatQuestion[]; resolveId?: string; message?: string | { value: string } };
+				const resolveId = carousel.resolveId;
+				pending = {
+					type: 'questions',
+					pending_id: resolveId ?? `${requestId}:carousel:${index}`,
+					request_id: requestId,
+					...(resolveId ? { resolve_id: resolveId } : {}),
+					questions: (carousel.questions ?? []).map(q => this._buildPendingQuestion(q)),
+					...(carousel.message ? { message: typeof carousel.message === 'string' ? carousel.message : carousel.message.value } : {}),
+				};
+			} else if (part.kind === 'elicitation2') {
+				const elicitation = part as { state?: IObservable<string>; title?: string | { value: string }; message?: string | { value: string } };
+				if (elicitation.state?.get() === 'pending') {
+					pending = {
+						type: 'elicitation',
+						pending_id: `${requestId}:elicitation:${index}`,
+						request_id: requestId,
+						approval_kind: 'elicitation2',
+						...(elicitation.title ? { title: typeof elicitation.title === 'string' ? elicitation.title : elicitation.title.value } : {}),
+						...(elicitation.message ? { message: typeof elicitation.message === 'string' ? elicitation.message : elicitation.message.value } : {}),
+					};
+				}
+			} else if (part.kind === 'confirmation' && !(part as { isUsed?: boolean }).isUsed) {
+				const conf = part as { title?: string; message?: string | { value: string } };
+				pending = {
+					type: 'approval',
+					pending_id: `${requestId}:confirmation:${index}`,
+					request_id: requestId,
+					approval_kind: 'confirmation',
+					...(conf.title ? { title: conf.title } : {}),
+					...(conf.message ? { message: typeof conf.message === 'string' ? conf.message : conf.message.value } : {}),
+				};
+			} else if (part.kind === 'toolInvocation') {
+				const invocation = part as IChatToolInvocation;
+				const state = invocation.state.get();
+				if (state.type === IChatToolInvocation.StateKind.WaitingForConfirmation || state.type === IChatToolInvocation.StateKind.WaitingForPostApproval) {
+					const invMsg = invocation.invocationMessage;
+					pending = {
+						type: 'approval',
+						pending_id: invocation.toolCallId,
+						request_id: requestId,
+						approval_kind: state.type === IChatToolInvocation.StateKind.WaitingForPostApproval ? 'toolPostApproval' : 'toolInvocation',
+						...(invMsg ? { title: typeof invMsg === 'string' ? invMsg : invMsg.value } : {}),
+					};
+				}
+			}
+		});
+		return pending;
+	}
+
+	private _buildPendingQuestion(question: IChatQuestion): IVoicePendingQuestion {
+		const ordered = getOptionsWithDefaultsFirst(question);
+		const options = ordered.map((entry, index) => ({
+			ordinal: index + 1,
+			label: entry.option.label,
+			value: entry.option.value,
+		}));
+		const allowFreeform = question.allowFreeformInput ?? false;
+		return {
+			id: question.id,
+			type: question.type,
+			title: question.title,
+			required: question.required ?? false,
+			allow_freeform: allowFreeform,
+			options,
+			...(allowFreeform ? { freeform_ordinal: options.length + 1 } : {}),
+		};
 	}
 
 	private _classifyPendingType(response: { response: { value: readonly { kind: string }[] } }): 'approval' | 'input' {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceTelemetry.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceTelemetry.ts
@@ -91,7 +91,7 @@ export type VoiceToolApprovalEvent = {
 export type VoiceToolApprovalClassification = {
 	owner: 'meganrogge';
 	comment: 'Fired when the voice backend approves or rejects a tool confirmation.';
-	toolName: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Name of the voice tool that was invoked (approve_confirmation, reject_confirmation).' };
+	toolName: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Name of the voice tool that was invoked (respond_to_session).' };
 	approved: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the action was an approval (true) or denial (false).' };
 };
 

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService.ts
@@ -11,8 +11,9 @@ import { InstantiationType, registerSingleton } from '../../../../../platform/in
 import { IAgentSessionsService } from '../agentSessions/agentSessionsService.js';
 import { AgentSessionStatus, getAgentChangesSummary } from '../agentSessions/agentSessionsModel.js';
 import { IChatService, IChatSendRequestOptions, IChatToolInvocation, ToolConfirmKind, IChatElicitationRequest, IChatQuestion } from '../../common/chatService/chatService.js';
-import { resolveQuestionAnswers, IBackendQuestionAnswer } from '../../common/chatService/chatQuestionCarouselHelpers.js';
+import { resolveQuestionAnswers, toCarouselAnswers, IBackendQuestionAnswer } from '../../common/chatService/chatQuestionCarouselHelpers.js';
 import { IChatModel } from '../../common/model/chatModel.js';
+import { ChatQuestionCarouselData } from '../../common/model/chatProgressTypes/chatQuestionCarouselData.js';
 import { ChatAgentLocation, ChatModeKind } from '../../common/constants.js';
 import { ILanguageModelToolsService } from '../../common/tools/languageModelToolsService.js';
 import { IVoiceToolCall } from '../../common/voiceClient/voiceClientService.js';
@@ -296,7 +297,18 @@ export class VoiceToolDispatchService implements IVoiceToolDispatchService {
 			if (invalid.length > 0) {
 				return JSON.stringify({ ok: false, reason: 'invalid_answer', questions: invalid });
 			}
-			this.chatService.notifyQuestionCarouselAnswer(request.id, resolveId || carousel.resolveId || '', answers);
+			// An empty record means the user answered nothing — dismiss as a skip
+			// (undefined) so agent-host carousels cancel rather than submit empty.
+			const answersRecord = toCarouselAnswers(answers);
+			// `dismiss` settles the carousel's completion promise, which is the ONLY
+			// resolution path for agent-host carousels (their answers flow back to the
+			// agent via ChatInputCompleted). The event below additionally drives the
+			// askQuestions / browser tools that listen for it. The UI submit path does
+			// both too (chatListRenderer handleSubmit).
+			if (carousel instanceof ChatQuestionCarouselData) {
+				carousel.dismiss(answersRecord);
+			}
+			this.chatService.notifyQuestionCarouselAnswer(request.id, resolveId || carousel.resolveId || '', answersRecord);
 			return JSON.stringify({ ok: true });
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService.ts
@@ -10,7 +10,8 @@ import { createDecorator } from '../../../../../platform/instantiation/common/in
 import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
 import { IAgentSessionsService } from '../agentSessions/agentSessionsService.js';
 import { AgentSessionStatus, getAgentChangesSummary } from '../agentSessions/agentSessionsModel.js';
-import { IChatService, IChatSendRequestOptions, IChatToolInvocation, ToolConfirmKind } from '../../common/chatService/chatService.js';
+import { IChatService, IChatSendRequestOptions, IChatToolInvocation, ToolConfirmKind, IChatElicitationRequest, IChatQuestion } from '../../common/chatService/chatService.js';
+import { resolveQuestionAnswers, IBackendQuestionAnswer } from '../../common/chatService/chatQuestionCarouselHelpers.js';
 import { IChatModel } from '../../common/model/chatModel.js';
 import { ChatAgentLocation, ChatModeKind } from '../../common/constants.js';
 import { ILanguageModelToolsService } from '../../common/tools/languageModelToolsService.js';
@@ -62,8 +63,7 @@ const ACTION_LABELS: Record<string, string> = {
 	get_session_info: localize('agentsVoice.action.getSessionInfo', "Checking sessions..."),
 	get_session_changes: localize('agentsVoice.action.getSessionChanges', "Checking changes..."),
 	get_session_thread: localize('agentsVoice.action.getSessionThread', "Checking conversation..."),
-	approve_confirmation: localize('agentsVoice.action.approve', "Approving..."),
-	reject_confirmation: localize('agentsVoice.action.reject', "Rejecting..."),
+	respond_to_session: localize('agentsVoice.action.respond', "Responding..."),
 	focus_session: localize('agentsVoice.action.focusSession', "Focusing session..."),
 	auto_approve_session: localize('agentsVoice.action.autoApprove', "Auto-approving session..."),
 	revoke_auto_approve: localize('agentsVoice.action.revokeAutoApprove', "Revoking auto-approve..."),
@@ -187,58 +187,8 @@ export class VoiceToolDispatchService implements IVoiceToolDispatchService {
 				}
 				break;
 			}
-			case 'approve_confirmation':
-			case 'reject_confirmation': {
-				const targetSessionId = argString('coding_session_id');
-				// Look up the model from agent sessions first, then regular chat sessions
-				let model: IChatModel | undefined;
-				if (targetSessionId) {
-					const agentSession = this.agentSessionsService.model.sessions
-						.find(s => !s.isArchived() && s.resource.toString() === targetSessionId);
-					model = agentSession
-						? this.chatService.getSession(agentSession.resource)
-						: undefined;
-					// Fall back to regular chat sessions
-					if (!model) {
-						for (const chatModel of this.chatService.chatModels.get()) {
-							if (chatModel.sessionResource.toString() === targetSessionId) {
-								model = chatModel;
-								break;
-							}
-						}
-					}
-					// Session not loaded — acquire it so we can confirm the tool invocation
-					if (!model && agentSession) {
-						const cts = new CancellationTokenSource();
-						const ref = await this.chatService.acquireOrLoadSession(agentSession.resource, ChatAgentLocation.Chat, cts.token, 'voice-confirm').catch(() => undefined);
-						cts.dispose();
-						if (ref) {
-							model = this.chatService.getSession(agentSession.resource);
-							ref.dispose();
-						}
-					}
-				}
-				if (!model) {
-					// Last resort: use the currently focused session
-					const res = await delegate.getCurrentSessionResource();
-					model = res ? this.chatService.getSession(res) : undefined;
-				}
-				if (model) {
-					const lastReq = model.getRequests().at(-1);
-					if (lastReq?.response) {
-						for (const part of lastReq.response.response.value) {
-							if (part.kind === 'toolInvocation') {
-								const confirmed = toolCall.name === 'approve_confirmation'
-									? IChatToolInvocation.confirmWith(part as IChatToolInvocation, { type: ToolConfirmKind.UserAction })
-									: IChatToolInvocation.confirmWith(part as IChatToolInvocation, { type: ToolConfirmKind.Denied });
-								if (confirmed) {
-									break;
-								}
-							}
-						}
-					}
-				}
-				break;
+			case 'respond_to_session': {
+				return await this._handleRespondToSession(toolCall);
 			}
 			case 'auto_approve_session': {
 				delegate.addAllAutoApprovedSessions();
@@ -270,6 +220,178 @@ export class VoiceToolDispatchService implements IVoiceToolDispatchService {
 			}
 		}
 		return 'ok';
+	}
+
+	/**
+	 * Resolve a chat model by its EXACT coding session id (agent session, then
+	 * regular chat session, acquiring the session if it isn't loaded yet). Unlike
+	 * the legacy approve/reject path there is deliberately no focused-session
+	 * fallback: ``respond_to_session`` must target the session the backend named.
+	 */
+	private async _resolveModelExact(targetSessionId: string): Promise<IChatModel | undefined> {
+		if (!targetSessionId) {
+			return undefined;
+		}
+		const agentSession = this.agentSessionsService.model.sessions
+			.find(s => !s.isArchived() && s.resource.toString() === targetSessionId);
+		let model = agentSession ? this.chatService.getSession(agentSession.resource) : undefined;
+		if (!model) {
+			for (const chatModel of this.chatService.chatModels.get()) {
+				if (chatModel.sessionResource.toString() === targetSessionId) {
+					model = chatModel;
+					break;
+				}
+			}
+		}
+		if (!model && agentSession) {
+			const cts = new CancellationTokenSource();
+			const ref = await this.chatService.acquireOrLoadSession(agentSession.resource, ChatAgentLocation.Chat, cts.token, 'voice-respond').catch(() => undefined);
+			cts.dispose();
+			if (ref) {
+				model = this.chatService.getSession(agentSession.resource);
+				ref.dispose();
+			}
+		}
+		return model;
+	}
+
+	/**
+	 * Apply a voice ``respond_to_session`` tool call: resolve the exact session +
+	 * pending part the backend named and answer it via the correct chat API
+	 * (questionCarousel answer, tool confirmation, plain confirmation resend, or
+	 * elicitation accept/reject). Returns a JSON tool result ``{ ok, reason? }``
+	 * so the backend can narrate a correction instead of silently no-op-ing.
+	 */
+	private async _handleRespondToSession(toolCall: IVoiceToolCall): Promise<string> {
+		const args = toolCall.args;
+		const str = (k: string): string => (typeof args[k] === 'string' ? args[k] as string : '');
+		const response = (args['response'] && typeof args['response'] === 'object')
+			? args['response'] as Record<string, unknown>
+			: {};
+		const responseType = typeof response['type'] === 'string' ? response['type'] as string : '';
+		const requestId = str('request_id');
+		const resolveId = str('resolve_id');
+		const approvalKind = str('approval_kind');
+
+		const model = await this._resolveModelExact(str('coding_session_id'));
+		if (!model) {
+			return JSON.stringify({ ok: false, reason: 'stale_pending' });
+		}
+		const requests = model.getRequests();
+		const request = requests.find(r => r.id === requestId) ?? requests.at(-1);
+		const parts = request?.response?.response.value;
+		if (!request || !parts) {
+			return JSON.stringify({ ok: false, reason: 'stale_pending' });
+		}
+
+		if (responseType === 'answer') {
+			const carousel = this._findCarouselPart(parts, resolveId);
+			if (!carousel) {
+				return JSON.stringify({ ok: false, reason: 'stale_pending' });
+			}
+			const backendAnswers: IBackendQuestionAnswer[] = Array.isArray(response['answers'])
+				? response['answers'] as IBackendQuestionAnswer[]
+				: [];
+			const { answers, invalid } = resolveQuestionAnswers(carousel.questions ?? [], backendAnswers);
+			if (invalid.length > 0) {
+				return JSON.stringify({ ok: false, reason: 'invalid_answer', questions: invalid });
+			}
+			this.chatService.notifyQuestionCarouselAnswer(request.id, resolveId || carousel.resolveId || '', answers);
+			return JSON.stringify({ ok: true });
+		}
+
+		if (responseType === 'approve' || responseType === 'reject') {
+			return JSON.stringify(await this._applyApproval(model, request.id, parts, approvalKind, str('pending_id'), responseType === 'approve'));
+		}
+
+		return JSON.stringify({ ok: false, reason: 'invalid_answer' });
+	}
+
+	/** Find the most recent unused questionCarousel part, optionally matching resolveId. */
+	private _findCarouselPart(
+		parts: readonly { kind: string }[],
+		resolveId: string,
+	): { questions?: IChatQuestion[]; resolveId?: string } | undefined {
+		let found: { questions?: IChatQuestion[]; resolveId?: string } | undefined;
+		for (const part of parts) {
+			if (part.kind === 'questionCarousel' && !(part as { isUsed?: boolean }).isUsed) {
+				const carousel = part as { questions?: IChatQuestion[]; resolveId?: string };
+				if (!resolveId || carousel.resolveId === resolveId) {
+					found = carousel;
+				}
+			}
+		}
+		return found;
+	}
+
+	/** Apply a binary approve/reject to the pending part identified by approvalKind. */
+	private async _applyApproval(
+		model: IChatModel,
+		requestId: string,
+		parts: readonly { kind: string }[],
+		approvalKind: string,
+		pendingId: string,
+		approve: boolean,
+	): Promise<{ ok: boolean; reason?: string }> {
+		if (approvalKind === 'elicitation2') {
+			for (const part of parts) {
+				if (part.kind === 'elicitation2') {
+					const elicitation = part as IChatElicitationRequest;
+					if (elicitation.state.get() === 'pending') {
+						if (approve) {
+							await elicitation.accept(true);
+						} else {
+							await elicitation.reject?.();
+						}
+						return { ok: true };
+					}
+				}
+			}
+			return { ok: false, reason: 'stale_pending' };
+		}
+
+		if (approvalKind === 'confirmation') {
+			for (const part of parts) {
+				if (part.kind === 'confirmation' && !(part as { isUsed?: boolean }).isUsed) {
+					const conf = part as { title?: string; data?: unknown; isUsed?: boolean };
+					const prompt = `${approve ? 'Accept' : 'Dismiss'}: "${conf.title ?? ''}"`;
+					const options: IChatSendRequestOptions = {
+						...this._agentModeOptions,
+						...(approve ? { acceptedConfirmationData: [conf.data] } : { rejectedConfirmationData: [conf.data] }),
+					};
+					await this.chatService.sendRequest(model.sessionResource, prompt, options);
+					conf.isUsed = true;
+					return { ok: true };
+				}
+			}
+			return { ok: false, reason: 'stale_pending' };
+		}
+
+		// toolInvocation / toolPostApproval — target by toolCallId, else first waiting.
+		let target: IChatToolInvocation | undefined;
+		for (const part of parts) {
+			if (part.kind === 'toolInvocation') {
+				const invocation = part as IChatToolInvocation;
+				const state = invocation.state.get();
+				const isWaiting = state.type === IChatToolInvocation.StateKind.WaitingForConfirmation
+					|| state.type === IChatToolInvocation.StateKind.WaitingForPostApproval;
+				if (!isWaiting) {
+					continue;
+				}
+				if (invocation.toolCallId === pendingId) {
+					target = invocation;
+					break;
+				}
+				if (!target) {
+					target = invocation;
+				}
+			}
+		}
+		if (!target) {
+			return { ok: false, reason: 'stale_pending' };
+		}
+		const confirmed = IChatToolInvocation.confirmWith(target, { type: approve ? ToolConfirmKind.UserAction : ToolConfirmKind.Denied });
+		return confirmed ? { ok: true } : { ok: false, reason: 'stale_pending' };
 	}
 
 	private async _gatherSessionInfo(): Promise<string> {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
@@ -22,6 +22,7 @@ import { InputBox } from '../../../../../../base/browser/ui/inputbox/inputBox.js
 import { DomScrollableElement } from '../../../../../../base/browser/ui/scrollbar/scrollableElement.js';
 import { Checkbox } from '../../../../../../base/browser/ui/toggle/toggle.js';
 import { IChatQuestion, IChatQuestionCarousel, IChatQuestionAnswerValue, IChatQuestionValidation, IChatSingleSelectAnswer, IChatMultiSelectAnswer } from '../../../common/chatService/chatService.js';
+import { IOrderedQuestionOption, getOptionsWithDefaultsFirst } from '../../../common/chatService/chatQuestionCarouselHelpers.js';
 import { ChatQuestionCarouselData } from '../../../common/model/chatProgressTypes/chatQuestionCarouselData.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
 import { IChatRendererContent, isResponseVM } from '../../../common/model/chatViewModel.js';
@@ -45,11 +46,6 @@ export interface IChatQuestionCarouselOptions {
 	onSubmit: (answers: Map<string, IChatQuestionAnswerValue> | undefined) => void;
 	shouldAutoFocus?: boolean;
 }
-
-type IOrderedQuestionOption = {
-	option: NonNullable<IChatQuestion['options']>[number];
-	originalIndex: number;
-};
 
 export class ChatQuestionCarouselPart extends Disposable implements IChatContentPart {
 	public readonly domNode: HTMLElement;
@@ -1542,28 +1538,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 	}
 
 	private getOptionsWithDefaultsFirst(question: IChatQuestion): IOrderedQuestionOption[] {
-		const options = question.options ?? [];
-		const orderedOptions = options.map((option, index) => ({ option, originalIndex: index }));
-		const defaultOptionIds = Array.isArray(question.defaultValue)
-			? question.defaultValue
-			: (typeof question.defaultValue === 'string' ? [question.defaultValue] : []);
-
-		if (defaultOptionIds.length === 0) {
-			return orderedOptions;
-		}
-
-		const defaultIds = new Set(defaultOptionIds);
-		const defaults: IOrderedQuestionOption[] = [];
-		const nonDefaults: IOrderedQuestionOption[] = [];
-		for (const item of orderedOptions) {
-			if (defaultIds.has(item.option.id)) {
-				defaults.push(item);
-			} else {
-				nonDefaults.push(item);
-			}
-		}
-
-		return [...defaults, ...nonDefaults];
+		return getOptionsWithDefaultsFirst(question);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
@@ -504,7 +504,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 	 * Returns defaults for all questions.
 	 */
 	public skip(): boolean {
-		if (this._isSkipped || !this.carousel.allowSkip) {
+		if (this._isSkipped || this.carousel.isUsed || !this.carousel.allowSkip) {
 			return false;
 		}
 
@@ -525,7 +525,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 	 * Returns undefined to signal the carousel was ignored.
 	 */
 	public ignore(): boolean {
-		if (this._isSkipped || !this.carousel.allowSkip) {
+		if (this._isSkipped || this.carousel.isUsed || !this.carousel.allowSkip) {
 			return false;
 		}
 		this._isSkipped = true;

--- a/src/vs/workbench/contrib/chat/common/chatService/chatQuestionCarouselHelpers.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatQuestionCarouselHelpers.ts
@@ -188,3 +188,14 @@ export function resolveQuestionAnswers(
 
 	return { answers, invalid };
 }
+
+/**
+ * Map a resolved answer record to the value a carousel is dismissed/completed
+ * with. An empty record means the user answered nothing (a skip): agent-host
+ * carousels treat `undefined` answers as a cancel/skip, whereas an empty object
+ * would be submitted as an (empty) accept. Returning `undefined` keeps the two
+ * intents distinct.
+ */
+export function toCarouselAnswers(answers: IChatQuestionAnswers): IChatQuestionAnswers | undefined {
+	return Object.keys(answers).length > 0 ? answers : undefined;
+}

--- a/src/vs/workbench/contrib/chat/common/chatService/chatQuestionCarouselHelpers.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatQuestionCarouselHelpers.ts
@@ -1,0 +1,190 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type {
+	IChatMultiSelectAnswer,
+	IChatQuestion,
+	IChatQuestionAnswers,
+	IChatQuestionAnswerValue,
+	IChatSingleSelectAnswer,
+} from './chatService.js';
+
+/** A question option paired with its position in the original (unordered) list. */
+export type IOrderedQuestionOption = {
+	option: { id: string; label: string; value: string };
+	originalIndex: number;
+};
+
+/**
+ * Order a question's options the way the carousel widget displays them: default
+ * option(s) first (preserving their relative order), then the rest in original
+ * order. Shared by the rendering widget and the voice serializer so the spoken
+ * ordinal a user hears matches the on-screen order.
+ */
+export function getOptionsWithDefaultsFirst(question: IChatQuestion): IOrderedQuestionOption[] {
+	const options = question.options ?? [];
+	const orderedOptions = options.map((option, index) => ({ option, originalIndex: index }));
+	const defaultOptionIds = Array.isArray(question.defaultValue)
+		? question.defaultValue
+		: (typeof question.defaultValue === 'string' ? [question.defaultValue] : []);
+
+	if (defaultOptionIds.length === 0) {
+		return orderedOptions;
+	}
+
+	const defaultIds = new Set(defaultOptionIds);
+	const defaults: IOrderedQuestionOption[] = [];
+	const nonDefaults: IOrderedQuestionOption[] = [];
+	for (const item of orderedOptions) {
+		if (defaultIds.has(item.option.id)) {
+			defaults.push(item);
+		} else {
+			nonDefaults.push(item);
+		}
+	}
+
+	return [...defaults, ...nonDefaults];
+}
+
+/** One answer as forwarded verbatim by the voice backend. */
+export interface IBackendQuestionAnswer {
+	question_id: string;
+	/** Single-choice / text / freeform value (option value, ordinal, or label). */
+	value?: string;
+	/** Multi-select values (each an option value, ordinal, or label). */
+	values?: string[];
+}
+
+/** Result of resolving backend answers against the live question parts. */
+export interface IResolvedQuestionAnswers {
+	answers: IChatQuestionAnswers;
+	/** Question ids whose answer could not be resolved to an option or freeform. */
+	invalid: string[];
+}
+
+/**
+ * Match a raw user-supplied token (an option value, a 1-based ordinal in
+ * displayed order, or a case-insensitive label) to one of a question's options.
+ */
+function matchOption(
+	ordered: IOrderedQuestionOption[],
+	raw: string,
+): { id: string; label: string; value: string } | undefined {
+	const trimmed = raw.trim();
+	const byValue = ordered.find(o => o.option.value === trimmed);
+	if (byValue) {
+		return byValue.option;
+	}
+	if (/^\d+$/.test(trimmed)) {
+		const ordinal = Number(trimmed);
+		if (ordinal >= 1 && ordinal <= ordered.length) {
+			return ordered[ordinal - 1].option;
+		}
+	}
+	const lower = trimmed.toLowerCase();
+	const byLabel = ordered.find(o => o.option.label.toLowerCase() === lower);
+	return byLabel?.option;
+}
+
+/** Either a resolved typed answer or a signal that the token(s) didn't resolve. */
+type AnswerResolution =
+	| { ok: true; answer: IChatQuestionAnswerValue }
+	| { ok: false };
+
+/** Resolve a free-text question: the raw value is taken verbatim. */
+function resolveTextAnswer(backend: IBackendQuestionAnswer): AnswerResolution {
+	return { ok: true, answer: backend.value ?? '' };
+}
+
+/** Resolve a single-select question by option match, then freeform fallback. */
+function resolveSingleSelectAnswer(
+	ordered: IOrderedQuestionOption[],
+	allowFreeform: boolean,
+	backend: IBackendQuestionAnswer,
+): AnswerResolution {
+	const raw = backend.value ?? '';
+	const opt = matchOption(ordered, raw);
+	if (opt) {
+		return { ok: true, answer: { selectedValue: opt.value } satisfies IChatSingleSelectAnswer };
+	}
+	if (allowFreeform && raw.trim() !== '') {
+		return { ok: true, answer: { freeformValue: raw } satisfies IChatSingleSelectAnswer };
+	}
+	return { ok: false };
+}
+
+/** Resolve a multi-select question, collecting matched options plus one freeform. */
+function resolveMultiSelectAnswer(
+	ordered: IOrderedQuestionOption[],
+	allowFreeform: boolean,
+	backend: IBackendQuestionAnswer,
+): AnswerResolution {
+	const rawValues = backend.values ?? (backend.value ? [backend.value] : []);
+	const selectedValues: string[] = [];
+	let freeformValue: string | undefined;
+	for (const raw of rawValues) {
+		const opt = matchOption(ordered, raw);
+		if (opt) {
+			if (!selectedValues.includes(opt.value)) {
+				selectedValues.push(opt.value);
+			}
+		} else if (allowFreeform && raw.trim() !== '') {
+			freeformValue = raw;
+		}
+	}
+	if (selectedValues.length === 0 && freeformValue === undefined) {
+		return { ok: false };
+	}
+	return {
+		ok: true,
+		answer: {
+			selectedValues,
+			...(freeformValue !== undefined ? { freeformValue } : {}),
+		} satisfies IChatMultiSelectAnswer,
+	};
+}
+
+/**
+ * Resolve the backend's verbatim answers into the typed `IChatQuestionAnswers`
+ * shape the chat carousel expects, keyed by the live question id.
+ *
+ * Resolution is deterministic: each token is matched against the question's
+ * options by value, then 1-based ordinal (in displayed order), then label. When
+ * nothing matches and the question allows freeform input the token is kept as a
+ * freeform answer; otherwise the question id is reported in `invalid` so the
+ * backend can narrate a correction instead of silently submitting a bad value.
+ */
+export function resolveQuestionAnswers(
+	questions: readonly IChatQuestion[],
+	backendAnswers: readonly IBackendQuestionAnswer[],
+): IResolvedQuestionAnswers {
+	const answers: IChatQuestionAnswers = {};
+	const invalid: string[] = [];
+	const byId = new Map(questions.map(q => [q.id, q]));
+
+	for (const backend of backendAnswers) {
+		const question = byId.get(backend.question_id);
+		if (!question) {
+			invalid.push(backend.question_id);
+			continue;
+		}
+		const ordered = getOptionsWithDefaultsFirst(question);
+		const allowFreeform = question.allowFreeformInput ?? false;
+
+		const resolved = question.type === 'text'
+			? resolveTextAnswer(backend)
+			: question.type === 'singleSelect'
+				? resolveSingleSelectAnswer(ordered, allowFreeform, backend)
+				: resolveMultiSelectAnswer(ordered, allowFreeform, backend);
+
+		if (resolved.ok) {
+			answers[question.id] = resolved.answer;
+		} else {
+			invalid.push(question.id);
+		}
+	}
+
+	return { answers, invalid };
+}

--- a/src/vs/workbench/contrib/chat/common/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/common/voiceClient/voiceClientService.ts
@@ -16,12 +16,52 @@ export interface IVoiceSessionContext {
 		agent_state: string;
 		agent_state_detail?: string;
 		last_response_summary?: string;
+		pending?: IVoiceSessionPending | null;
 	}[];
 	active_session?: {
 		id: string;
 		last_message: string | null;
 	};
 	display_locale?: string;
+}
+
+/** A selectable option within a pending question, in displayed order. */
+export interface IVoicePendingOption {
+	ordinal: number;
+	label: string;
+	value: string;
+}
+
+/** A single question in a pending questionCarousel form. */
+export interface IVoicePendingQuestion {
+	id: string;
+	type: 'text' | 'singleSelect' | 'multiSelect';
+	title: string;
+	required: boolean;
+	allow_freeform: boolean;
+	options: IVoicePendingOption[];
+	freeform_ordinal?: number;
+}
+
+/**
+ * The structured "pending" payload for a coding session: the authoritative
+ * description of what the agent is waiting on (a multi-question form, a binary
+ * approval, or an elicitation) plus the exact routing ids the backend echoes
+ * back so the client can target the precise chat part when applying an answer.
+ */
+export interface IVoiceSessionPending {
+	type: 'questions' | 'approval' | 'elicitation';
+	/** Stable fingerprint for this pending instance (draft key + narration dedup). */
+	pending_id: string;
+	/** Id of the owning chat request (IChatRequestModel.id). */
+	request_id: string;
+	/** Carousel resolveId — questions only. */
+	resolve_id?: string;
+	/** Which approval UI this is — approval/elicitation only. */
+	approval_kind?: 'toolInvocation' | 'toolPostApproval' | 'confirmation' | 'elicitation2';
+	questions?: IVoicePendingQuestion[];
+	title?: string;
+	message?: string;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatQuestionCarouselPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatQuestionCarouselPart.test.ts
@@ -534,6 +534,21 @@ suite('ChatQuestionCarouselPart', () => {
 			assert.strictEqual(result, false, 'Second skip() should return false');
 			assert.strictEqual(submittedAnswers, null, 'onSubmit should not be called again');
 		});
+
+		test('skip no-ops when the carousel was already resolved externally', () => {
+			const carousel = createMockCarousel([
+				{ id: 'q1', type: 'text', title: 'Question 1', defaultValue: 'default answer' }
+			], true);
+			createWidget(carousel);
+
+			// Simulate an external resolution (e.g. a voice answer dismissing the
+			// carousel) after the part has already rendered interactively.
+			carousel.isUsed = true;
+
+			const result = widget.skip();
+			assert.strictEqual(result, false, 'skip() must not re-submit a carousel resolved elsewhere');
+			assert.strictEqual(submittedAnswers, null, 'onSubmit should not overwrite the external answers');
+		});
 	});
 
 	suite('Ignore Functionality', () => {
@@ -570,6 +585,19 @@ suite('ChatQuestionCarouselPart', () => {
 			const result = widget.ignore();
 			assert.strictEqual(result, false, 'Second ignore() should return false');
 			assert.strictEqual(submittedAnswers, null, 'onSubmit should not be called again');
+		});
+
+		test('ignore no-ops when the carousel was already resolved externally', () => {
+			const carousel = createMockCarousel([
+				{ id: 'q1', type: 'text', title: 'Question 1' }
+			], true);
+			createWidget(carousel);
+
+			carousel.isUsed = true;
+
+			const result = widget.ignore();
+			assert.strictEqual(result, false, 'ignore() must not re-submit a carousel resolved elsewhere');
+			assert.strictEqual(submittedAnswers, null, 'onSubmit should not overwrite the external answers');
 		});
 
 		test('skip and ignore are mutually exclusive', () => {

--- a/src/vs/workbench/contrib/chat/test/common/chatQuestionCarouselHelpers.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatQuestionCarouselHelpers.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { getOptionsWithDefaultsFirst, resolveQuestionAnswers } from '../../common/chatService/chatQuestionCarouselHelpers.js';
+import { getOptionsWithDefaultsFirst, resolveQuestionAnswers, toCarouselAnswers } from '../../common/chatService/chatQuestionCarouselHelpers.js';
 import { IChatQuestion } from '../../common/chatService/chatService.js';
 
 suite('chatQuestionCarouselHelpers', () => {
@@ -98,6 +98,17 @@ suite('chatQuestionCarouselHelpers', () => {
 			const { answers, invalid } = resolveQuestionAnswers([singleSelect], [{ question_id: 'nope', value: 'x' }]);
 			assert.deepStrictEqual(answers, {});
 			assert.deepStrictEqual(invalid, ['nope']);
+		});
+	});
+
+	suite('toCarouselAnswers', () => {
+		test('returns undefined for an empty record (a skip)', () => {
+			assert.strictEqual(toCarouselAnswers({}), undefined);
+		});
+
+		test('returns the record unchanged when it has answers', () => {
+			const record = { q1: { selectedValue: 'fullstack' } };
+			assert.strictEqual(toCarouselAnswers(record), record);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/chatQuestionCarouselHelpers.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatQuestionCarouselHelpers.test.ts
@@ -1,0 +1,103 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { getOptionsWithDefaultsFirst, resolveQuestionAnswers } from '../../common/chatService/chatQuestionCarouselHelpers.js';
+import { IChatQuestion } from '../../common/chatService/chatService.js';
+
+suite('chatQuestionCarouselHelpers', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const singleSelect: IChatQuestion = {
+		id: 'q1',
+		type: 'singleSelect',
+		title: 'Project type',
+		options: [
+			{ id: 'o1', label: 'Full Stack', value: 'fullstack' },
+			{ id: 'o2', label: 'React Application', value: 'react' },
+			{ id: 'o3', label: 'Node.js Backend', value: 'node' },
+		],
+		allowFreeformInput: true,
+		required: true,
+	};
+
+	suite('getOptionsWithDefaultsFirst', () => {
+		test('moves the default option(s) to the front, preserving order', () => {
+			const ordered = getOptionsWithDefaultsFirst({ ...singleSelect, defaultValue: 'o2' });
+			assert.deepStrictEqual(ordered.map(o => o.option.id), ['o2', 'o1', 'o3']);
+		});
+
+		test('keeps original order when there is no default', () => {
+			const ordered = getOptionsWithDefaultsFirst(singleSelect);
+			assert.deepStrictEqual(ordered.map(o => o.option.id), ['o1', 'o2', 'o3']);
+		});
+	});
+
+	suite('resolveQuestionAnswers', () => {
+		test('resolves a single-select answer by option value', () => {
+			const { answers, invalid } = resolveQuestionAnswers([singleSelect], [{ question_id: 'q1', value: 'react' }]);
+			assert.deepStrictEqual(invalid, []);
+			assert.deepStrictEqual(answers['q1'], { selectedValue: 'react' });
+		});
+
+		test('resolves a single-select answer by 1-based ordinal in displayed order', () => {
+			const { answers } = resolveQuestionAnswers([singleSelect], [{ question_id: 'q1', value: '2' }]);
+			assert.deepStrictEqual(answers['q1'], { selectedValue: 'react' });
+		});
+
+		test('ordinal resolution honors defaults-first display order', () => {
+			const q = { ...singleSelect, defaultValue: 'o3' };
+			const { answers } = resolveQuestionAnswers([q], [{ question_id: 'q1', value: '1' }]);
+			assert.deepStrictEqual(answers['q1'], { selectedValue: 'node' });
+		});
+
+		test('resolves a single-select answer by case-insensitive label', () => {
+			const { answers } = resolveQuestionAnswers([singleSelect], [{ question_id: 'q1', value: 'full stack' }]);
+			assert.deepStrictEqual(answers['q1'], { selectedValue: 'fullstack' });
+		});
+
+		test('falls back to freeform when nothing matches and freeform is allowed', () => {
+			const { answers, invalid } = resolveQuestionAnswers([singleSelect], [{ question_id: 'q1', value: 'something else' }]);
+			assert.deepStrictEqual(answers['q1'], { freeformValue: 'something else' });
+			assert.deepStrictEqual(invalid, []);
+		});
+
+		test('reports invalid when nothing matches and freeform is disallowed', () => {
+			const q = { ...singleSelect, allowFreeformInput: false };
+			const { answers, invalid } = resolveQuestionAnswers([q], [{ question_id: 'q1', value: 'nope' }]);
+			assert.strictEqual(answers['q1'], undefined);
+			assert.deepStrictEqual(invalid, ['q1']);
+		});
+
+		test('passes a text answer through verbatim', () => {
+			const textQ: IChatQuestion = { id: 'q2', type: 'text', title: 'Notes', allowFreeformInput: true };
+			const { answers } = resolveQuestionAnswers([textQ], [{ question_id: 'q2', value: 'hello world' }]);
+			assert.strictEqual(answers['q2'], 'hello world');
+		});
+
+		test('resolves multi-select values and keeps an unmatched token as freeform', () => {
+			const multi: IChatQuestion = {
+				id: 'q3',
+				type: 'multiSelect',
+				title: 'Features',
+				options: [
+					{ id: 'a', label: 'Auth', value: 'auth' },
+					{ id: 'b', label: 'Billing', value: 'billing' },
+				],
+				allowFreeformInput: true,
+			};
+			const { answers } = resolveQuestionAnswers([multi], [{ question_id: 'q3', values: ['auth', '2', 'custom thing'] }]);
+			assert.deepStrictEqual(answers['q3'], { selectedValues: ['auth', 'billing'], freeformValue: 'custom thing' });
+		});
+
+		test('reports an unknown question id as invalid without throwing', () => {
+			const { answers, invalid } = resolveQuestionAnswers([singleSelect], [{ question_id: 'nope', value: 'x' }]);
+			assert.deepStrictEqual(answers, {});
+			assert.deepStrictEqual(invalid, ['nope']);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Lets voice users answer VS Code chat **question carousel** multi-question forms (and approvals) by voice. Fixes the end-to-end break where a voice-spoken selection never landed and the card showed "Skipped".

Three commits, stacked on `meganrogge/voice-mode-fixes`:

1. **`respond_to_session` answer/approval plumbing** — voice tool dispatch routes question-carousel answers and approvals back into the chat session.
2. **Complete agent-host carousels so voice answers land** — agent-host carousels resolve **only** via their completion promise (`carousel.dismiss(answers)` → `ChatInputCompleted`), not the event the voice path fired. The answer branch now calls `carousel.dismiss(toCarouselAnswers(answers))` in addition to `notifyQuestionCarouselAnswer`. An empty answer record maps to `undefined` so a genuine skip becomes Cancel rather than a truthy empty Accept. Adds a pure `toCarouselAnswers` helper + unit tests.
3. **Guard against stale skip overwrite** — after an external `dismiss()`, a later `onDidSubmitRequest` auto-skip could call `handleSubmit(defaults)` and overwrite the resolved answers. `skip()`/`ignore()` now also guard on `carousel.isUsed`. Adds 2 regression tests.

## Testing

- `tsc -p src/tsconfig.json --noEmit` — 0 errors
- eslint on changed files — 0 errors
- Added unit + regression tests for `toCarouselAnswers` and the carousel skip/ignore guards.

Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8157