### PR TITLE
nes-datagen: capture cross-file next edits (xtab-cross-file sample task)

### DIFF
--- a/extensions/copilot/test/base/simulationOptions.ts
+++ b/extensions/copilot/test/base/simulationOptions.ts
@@ -11,6 +11,7 @@ export const BASELINE_RUN_COUNT = 10;
 
 export enum NesDatagenSampleTask {
 	Xtab = 'xtab',
+	XtabCrossFile = 'xtab-cross-file',
 	CursorSameFile = 'cursor-same-file',
 	CursorCrossFile = 'cursor-cross-file',
 	CursorBoth = 'cursor-both',
@@ -26,6 +27,8 @@ export type NesDatagen = {
 	readonly sameFileJumpMinAbove: number;
 	/** Minimum same-file lines below the request cursor for a move to count as a jump. */
 	readonly sameFileJumpMinBelow: number;
+	/** Per-file patch block order in the label (xtab-cross-file only). */
+	readonly patchOrder?: 'first-touch' | 'anchor-first';
 };
 
 export class SimulationOptions {
@@ -197,6 +200,7 @@ export class SimulationOptions {
 				sampleTask: SimulationOptions.validateSampleTask(argv['sample-task']),
 				sameFileJumpMinAbove: typeof argv['same-file-jump-min-above'] === 'number' ? argv['same-file-jump-min-above'] : 2,
 				sameFileJumpMinBelow: typeof argv['same-file-jump-min-below'] === 'number' ? argv['same-file-jump-min-below'] : 5,
+				patchOrder: argv['patch-order'] === 'anchor-first' ? 'anchor-first' : 'first-touch',
 			}
 			: undefined;
 
@@ -276,13 +280,15 @@ export class SimulationOptions {
 			`                                     Format is inferred from the extension: .jsonl/.ndjson → JSON Lines, otherwise JSON array`,
 			`  --out                              Output path for the JSON Lines file. Default: <input-path>_output.jsonl`,
 			`  --sample-task                      Which target to generate (default: xtab)`,
-			`                                     Values: xtab, cursor-same-file, cursor-cross-file, cursor-both`,
+			`                                     Values: xtab, xtab-cross-file, cursor-same-file, cursor-cross-file, cursor-both`,
 			`                                       xtab               → edit-prediction sample (assistant = an edit)`,
+			`                                       xtab-cross-file    → multi-file edit-prediction sample (one patch block per touched file)`,
 			`                                       cursor-same-file   → next-cursor-line sample restricted to the active file`,
 			`                                       cursor-cross-file  → next-cursor-line sample for a jump to another file`,
 			`                                       cursor-both        → tries same-file first, falls back to cross-file (one sample per row)`,
 			`  --same-file-jump-min-above         Minimum lines above request cursor for a same-file move to count as a jump (default: 2)`,
 			`  --same-file-jump-min-below         Minimum lines below request cursor for a same-file move to count as a jump (default: 5)`,
+			`  --patch-order                      Per-file patch block order in the xtab-cross-file label: first-touch (default) | anchor-first`,
 			``,
 			`Global options (placed before 'nes-datagen'):`,
 			`  --config-file                      Path to a JSON config file (required for nes-datagen)`,

--- a/extensions/copilot/test/pipeline/alternativeAction/processor.ts
+++ b/extensions/copilot/test/pipeline/alternativeAction/processor.ts
@@ -81,6 +81,9 @@ export namespace Processor {
 			return undefined;
 		}
 
+		// `wholeRecording` covers documents encountered both before and after the
+		// request bookmark, so cross-file next edits (and cursor jumps) to files
+		// first opened after the request are still mapped to a path.
 		const idToFileMap = documentIndexMapping(wholeRecording);
 
 		const currentFilePath = idToFileMap.get(currentFileId);
@@ -92,7 +95,7 @@ export namespace Processor {
 
 		const currentFile = { id: currentFileId, relativePath: currentFilePath };
 
-		const nextUserEdit = getNextUserEdit(currentFile, recordingPriorToRequest, recordingAfterRequest);
+		const nextUserEdit = getNextUserEdit(currentFile, recordingPriorToRequest, recordingAfterRequest, idToFileMap);
 
 		const reconstructedRecording: Recording.t = {
 			log: recordingPriorToRequest,
@@ -173,29 +176,55 @@ export namespace Processor {
 		return fileId;
 	}
 
-	function getNextUserEdit(currentFile: { id: number; relativePath: string }, recordingBeforeRequest: LogEntry[], recordingAfterRequest: LogEntry[]): NextUserEdit.t {
+	function composeReplacements(serializedEdits: readonly ISerializedEdit[]): ISerializedEdit {
+		const composed = new Edits(
+			StringEdit,
+			serializedEdits.map(se => new StringEdit(se.map(r => new StringReplacement(new OffsetRange(r[0], r[1]), r[2]))))
+		).compose();
+		return composed.replacements.map((r): [start: number, endEx: number, text: string] => [r.replaceRange.start, r.replaceRange.endExclusive, r.newText]);
+	}
+
+	function getNextUserEdit(currentFile: { id: number; relativePath: string }, recordingBeforeRequest: LogEntry[], recordingAfterRequest: LogEntry[], idToFileMap: Map<number, string>): NextUserEdit.t {
 
 		const N_EDITS_LIMIT = 10;
 
-		const serializedEdits: ISerializedEdit[] = [];
+		// Collect post-request edits across ALL files (not just the current file),
+		// bucketed by document id in first-touch order, up to the N-edit cap. Edits
+		// to documents we have no path for are skipped because they cannot be
+		// reconstructed or labelled.
+		const editsByFileId = new Map<number, ISerializedEdit[]>();
+		const fileOrder: number[] = [];
+		let collected = 0;
 		for (const entry of recordingAfterRequest) {
-			if (entry.kind === 'changed' && 'id' in entry && entry.id === currentFile.id) {
-				serializedEdits.push(entry.edit);
+			if (entry.kind !== 'changed' || !('id' in entry) || !idToFileMap.has(entry.id)) {
+				continue;
 			}
-			if (serializedEdits.length > N_EDITS_LIMIT) {
+			let bucket = editsByFileId.get(entry.id);
+			if (!bucket) {
+				bucket = [];
+				editsByFileId.set(entry.id, bucket);
+				fileOrder.push(entry.id);
+			}
+			bucket.push(entry.edit);
+			collected++;
+			if (collected > N_EDITS_LIMIT) {
 				break;
 			}
 		}
 
-		const edits = new Edits(
-			StringEdit,
-			serializedEdits.map(se => new StringEdit(se.map(r => new StringReplacement(new OffsetRange(r[0], r[1]), r[2]))))
-		);
+		const fileEdits: NextUserEdit.FileEdit[] = fileOrder.map(id => ({
+			id,
+			relativePath: idToFileMap.get(id)!,
+			edit: composeReplacements(editsByFileId.get(id)!),
+		}));
+
+		const currentFileEdits = editsByFileId.get(currentFile.id) ?? [];
 
 		return {
-			edit: edits.compose().replacements.map(r => [r.replaceRange.start, r.replaceRange.endExclusive, r.newText] as const),
+			edit: composeReplacements(currentFileEdits),
 			relativePath: currentFile.relativePath,
-			originalOpIdx: recordingBeforeRequest.length - 1
+			originalOpIdx: recordingBeforeRequest.length - 1,
+			fileEdits,
 		};
 	}
 }

--- a/extensions/copilot/test/pipeline/alternativeAction/types.ts
+++ b/extensions/copilot/test/pipeline/alternativeAction/types.ts
@@ -21,21 +21,31 @@ export type IData = {
 };
 
 export namespace NextUserEdit {
+	export type FileEdit = {
+		/** Document id from the recording log (the `documentEncountered` id). */
+		id: number;
+		relativePath: string;
+		edit: ISerializedEdit;
+	};
+
 	export type t = {
 		edit: ISerializedEdit;
 		relativePath: string;
 		originalOpIdx: number;
+		/**
+		 * Per-file composed edits for every file touched after the request
+		 * (including the current/anchor file), in first-touch order. Enables
+		 * cross-file next-edit labels. The scalar `edit`/`relativePath` above
+		 * remain the current (anchor) file for backwards compatibility.
+		 */
+		fileEdits: FileEdit[];
 	};
 }
 
 export namespace Recording {
 	export type t = {
 		log: LogEntry[];
-		nextUserEdit: {
-			edit: ISerializedEdit;
-			relativePath: string;
-			originalOpIdx: number;
-		};
+		nextUserEdit: NextUserEdit.t;
 	};
 }
 

--- a/extensions/copilot/test/pipeline/output.ts
+++ b/extensions/copilot/test/pipeline/output.ts
@@ -123,12 +123,14 @@ export function assembleSample(
 }
 
 /**
- * Build the `xtab-cross-file` classification payload from a processed row's
- * per-file target edits (anchor + any cross-file files), in patch order.
+ * Build the `xtab-cross-file` classification payload from a row's per-file
+ * target edits (anchor + any cross-file files). Callers pass the edits already
+ * ordered per `--patch-order`, so `targetFiles`/`targetFilePaths` line up with
+ * the per-file patch blocks in the label.
  */
-export function buildXtabCrossFileClassification(processedRow: IProcessedRow): SampleClassification {
-	const anchorFilePath = processedRow.activeFilePath.replace(/\\/g, '/');
-	const targetFiles: ITargetFileMetadata[] = processedRow.targetFileEdits.map(f => ({
+export function buildXtabCrossFileClassification(anchorFilePath: string, targetFileEdits: IProcessedRow['targetFileEdits']): SampleClassification {
+	const anchor = anchorFilePath.replace(/\\/g, '/');
+	const targetFiles: ITargetFileMetadata[] = targetFileEdits.map(f => ({
 		filePath: f.relativePath.replace(/\\/g, '/'),
 		docContent: f.docContent,
 		oracleEdits: f.edit,
@@ -137,7 +139,7 @@ export function buildXtabCrossFileClassification(processedRow: IProcessedRow): S
 		task: NesDatagenSampleTask.XtabCrossFile,
 		targetFiles,
 		targetFilePaths: targetFiles.map(f => f.filePath),
-		isCrossFile: targetFiles.some(f => f.filePath !== anchorFilePath),
+		isCrossFile: targetFiles.some(f => f.filePath !== anchor),
 	};
 }
 

--- a/extensions/copilot/test/pipeline/output.ts
+++ b/extensions/copilot/test/pipeline/output.ts
@@ -16,6 +16,12 @@ export interface IMessage {
 	readonly content: string;
 }
 
+export interface ITargetFileMetadata {
+	readonly filePath: string;
+	readonly docContent: string;
+	readonly oracleEdits: readonly (readonly [start: number, endEx: number, text: string])[];
+}
+
 export interface ISampleMetadataBase {
 	readonly rowIndex: number;
 	readonly language: string;
@@ -30,13 +36,22 @@ export interface ISampleMetadataBase {
 }
 
 /**
- * Per-sample classification + cursor-jump payload. Discriminated on `task`
+ * Per-sample classification + task-specific payload. Discriminated on `task`
  * so xtab samples cannot accidentally carry a `jump` field and cursor-*
  * samples cannot omit one. `CursorBoth` is a CLI dispatch mode only — each
  * emitted sample is classified as one of the concrete cursor variants.
  */
 export type SampleClassification =
 	| { readonly task: NesDatagenSampleTask.Xtab }
+	| {
+		readonly task: NesDatagenSampleTask.XtabCrossFile;
+		/** Per-file next edits (anchor + cross-file), each with its request-time content. */
+		readonly targetFiles: readonly ITargetFileMetadata[];
+		/** Convenience list of the files touched by the label, in patch order. */
+		readonly targetFilePaths: readonly string[];
+		/** True when the label edits a file other than the anchor (`filePath`). */
+		readonly isCrossFile: boolean;
+	}
 	| {
 		readonly task: NesDatagenSampleTask.CursorSameFile;
 		readonly jump: {
@@ -105,6 +120,25 @@ export function assembleSample(
 	};
 
 	return { messages, metadata: { ...base, ...classification } };
+}
+
+/**
+ * Build the `xtab-cross-file` classification payload from a processed row's
+ * per-file target edits (anchor + any cross-file files), in patch order.
+ */
+export function buildXtabCrossFileClassification(processedRow: IProcessedRow): SampleClassification {
+	const anchorFilePath = processedRow.activeFilePath.replace(/\\/g, '/');
+	const targetFiles: ITargetFileMetadata[] = processedRow.targetFileEdits.map(f => ({
+		filePath: f.relativePath.replace(/\\/g, '/'),
+		docContent: f.docContent,
+		oracleEdits: f.edit,
+	}));
+	return {
+		task: NesDatagenSampleTask.XtabCrossFile,
+		targetFiles,
+		targetFilePaths: targetFiles.map(f => f.filePath),
+		isCrossFile: targetFiles.some(f => f.filePath !== anchorFilePath),
+	};
 }
 
 interface IStructuralValidationResult {

--- a/extensions/copilot/test/pipeline/pipeline.ts
+++ b/extensions/copilot/test/pipeline/pipeline.ts
@@ -18,7 +18,7 @@ import { NesDatagen, NesDatagenSampleTask, SimulationOptions } from '../base/sim
 import { detectCrossFileJump, detectSameFileJump } from './cursorJump/detectJump';
 import { generateCursorPromptFromRecording, installCursorJumpCapturingFetcher } from './cursorJump/cursorJumpPromptStep';
 import { generateCrossFileResponse, generateSameFileResponse } from './cursorJump/cursorJumpResponseStep';
-import { assembleSample, ISample, SampleClassification, resolveOutputPath, writeSamples } from './output';
+import { assembleSample, buildXtabCrossFileClassification, ISample, SampleClassification, resolveOutputPath, writeSamples } from './output';
 import { loadAndParseInput } from './parseInput';
 import { generatePromptFromRecording, IGeneratedPrompt } from './promptStep';
 import { IProcessedRow, parseSuggestedEdit, processAllRows } from './replayRecording';
@@ -53,6 +53,24 @@ async function applyBatchModeConfig(configService: IConfigurationService, config
 	await configService.setConfig(ConfigKey.TeamInternal.InlineEditsExtraDebounceInlineSuggestion, 0);
 }
 
+type PatchOrder = 'first-touch' | 'anchor-first';
+
+/**
+ * Order per-file edits for the combined label. `first-touch` preserves the
+ * recording order (the order files were first edited after the request);
+ * `anchor-first` moves the anchor file's block(s) to the front.
+ */
+function orderTargetFiles<T extends { readonly relativePath: string }>(files: readonly T[], anchorFilePath: string, order: PatchOrder): readonly T[] {
+	if (order !== 'anchor-first') {
+		return files;
+	}
+	const anchor = files.filter(f => f.relativePath === anchorFilePath);
+	if (anchor.length === 0) {
+		return files;
+	}
+	return [...anchor, ...files.filter(f => f.relativePath !== anchorFilePath)];
+}
+
 export type RunPipelineOptions = {
 	readonly nesDatagen: NesDatagen | undefined;
 	/**
@@ -79,7 +97,7 @@ export type RunPipelineOptions = {
  */
 export async function runInputPipeline(opts: RunPipelineOptions, log = console.log.bind(console)): Promise<void> {
 	const nesDatagenOpts = opts.nesDatagen!;
-	if (nesDatagenOpts.sampleTask !== NesDatagenSampleTask.Xtab) {
+	if (nesDatagenOpts.sampleTask !== NesDatagenSampleTask.Xtab && nesDatagenOpts.sampleTask !== NesDatagenSampleTask.XtabCrossFile) {
 		return runCursorPipeline(opts, log);
 	}
 	return runXtabPipeline(opts, log);
@@ -154,17 +172,25 @@ async function runXtabPipeline(opts: RunPipelineOptions, log: (...ps: any[]) => 
 		// Step 4: Generate responses
 		const processedByOriginalIndex = new Map(processed.map(p => [p.originalRowIndex, p]));
 		const responseInputs: IResponseGenerationInput[] = [];
+		const patchOrder: PatchOrder = nesDatagenOpts.patchOrder ?? 'first-touch';
+		const crossFile = nesDatagenOpts.sampleTask === NesDatagenSampleTask.XtabCrossFile;
 
 		for (const { originalRowIndex, prompt } of prompts) {
 			const p = processedByOriginalIndex.get(originalRowIndex);
 			if (!p) {
 				continue;
 			}
+			// `xtab` labels only the anchor file; `xtab-cross-file` labels every
+			// file touched after the request, ordered by `--patch-order`. The anchor
+			// entry shares `currentFile.relativePath` with `activeFilePath`.
+			const targets = crossFile
+				? orderTargetFiles(p.targetFileEdits, p.activeFilePath, patchOrder)
+				: p.targetFileEdits.filter(f => f.relativePath === p.activeFilePath);
+			const files = targets.map(f => ({ filePath: f.relativePath, docContent: f.docContent, edit: f.edit }));
 			responseInputs.push({
 				index: originalRowIndex,
-				oracleEdits: p.nextUserEdit?.edit,
-				docContent: p.activeDocument.value.get().value,
-				filePath: p.activeFilePath,
+				anchorFilePath: p.activeFilePath,
+				files,
 				userPrompt: prompt.user,
 			});
 		}
@@ -196,7 +222,10 @@ async function runXtabPipeline(opts: RunPipelineOptions, log: (...ps: any[]) => 
 			const modelEdits = suggestedEdit ? [suggestedEdit] as const : undefined;
 			const modelResult = generateResponse(responseFormat, modelEdits, p.activeDocument.value.get().value, p.activeFilePath, prompt.user);
 			const formattedModelResponse = 'error' in modelResult ? '' : modelResult.assistant;
-			samples.push(assembleSample(index + rowOffset, prompt, response, p, responseFormat, formattedModelResponse, { task: NesDatagenSampleTask.Xtab }));
+			const classification: SampleClassification = nesDatagenOpts.sampleTask === NesDatagenSampleTask.XtabCrossFile
+				? buildXtabCrossFileClassification(p)
+				: { task: NesDatagenSampleTask.Xtab };
+			samples.push(assembleSample(index + rowOffset, prompt, response, p, responseFormat, formattedModelResponse, classification));
 		}
 
 		const writeResult = await writeSamples(outputPath, samples);
@@ -575,6 +604,7 @@ export async function runInputPipelineParallel(opts: SimulationOptions): Promise
 				'--sample-task', nesDatagenOpts.sampleTask,
 				'--same-file-jump-min-above', String(nesDatagenOpts.sameFileJumpMinAbove),
 				'--same-file-jump-min-below', String(nesDatagenOpts.sameFileJumpMinBelow),
+				'--patch-order', nesDatagenOpts.patchOrder ?? 'first-touch',
 				'--worker',
 			];
 			if (verbose) {

--- a/extensions/copilot/test/pipeline/pipeline.ts
+++ b/extensions/copilot/test/pipeline/pipeline.ts
@@ -223,7 +223,7 @@ async function runXtabPipeline(opts: RunPipelineOptions, log: (...ps: any[]) => 
 			const modelResult = generateResponse(responseFormat, modelEdits, p.activeDocument.value.get().value, p.activeFilePath, prompt.user);
 			const formattedModelResponse = 'error' in modelResult ? '' : modelResult.assistant;
 			const classification: SampleClassification = nesDatagenOpts.sampleTask === NesDatagenSampleTask.XtabCrossFile
-				? buildXtabCrossFileClassification(p)
+				? buildXtabCrossFileClassification(p.activeFilePath, orderTargetFiles(p.targetFileEdits, p.activeFilePath, patchOrder))
 				: { task: NesDatagenSampleTask.Xtab };
 			samples.push(assembleSample(index + rowOffset, prompt, response, p, responseFormat, formattedModelResponse, classification));
 		}

--- a/extensions/copilot/test/pipeline/replayRecording.ts
+++ b/extensions/copilot/test/pipeline/replayRecording.ts
@@ -10,6 +10,7 @@ import { LogEntry } from '../../src/platform/workspaceRecorder/common/workspaceL
 import { coalesce } from '../../src/util/vs/base/common/arrays';
 import { StringText } from '../../src/util/vs/editor/common/core/text/abstractText';
 import { Processor } from './alternativeAction/processor';
+import { ISerializedEdit } from './logRecordingTypes';
 import { IInputRow } from './parseInput';
 import { applyEditsToContent } from './responseStep';
 
@@ -30,6 +31,12 @@ export interface IProcessedRow {
 		readonly relativePath: string;
 		readonly originalOpIdx: number;
 	};
+	/**
+	 * Per-file next edits (including the anchor file) with each file's
+	 * request-time content, used to build cross-file labels. Files whose content
+	 * could not be reconstructed from the replayed workspace are omitted.
+	 */
+	readonly targetFileEdits: readonly { readonly relativePath: string; readonly docContent: string; readonly edit: ISerializedEdit }[];
 	readonly recordingInfo: IRecordingInformation;
 	/**
 	 * Log entries that occurred *after* the NES request bookmark, in original
@@ -207,6 +214,27 @@ function _processRow(row: IInputRow): IProcessedRow | { error: string } {
 		return map;
 	})();
 
+	// Resolve each touched file's request-time content for cross-file edit
+	// labels, reusing the request-time content snapshot above (same source the
+	// cursor-jump cross-file detector uses). Files with no effective edit, or
+	// whose request-time content cannot be reconstructed (e.g. first observed
+	// only after the request), are dropped.
+	const targetFileEdits: { relativePath: string; docContent: string; edit: ISerializedEdit }[] = [];
+	for (const fileEdit of recording.nextUserEdit.fileEdits) {
+		if (fileEdit.edit.length === 0) {
+			continue;
+		}
+		const docContent = idToContentAtRequest.get(fileEdit.id);
+		if (docContent === undefined) {
+			continue;
+		}
+		targetFileEdits.push({
+			relativePath: fileEdit.relativePath,
+			docContent,
+			edit: fileEdit.edit,
+		});
+	}
+
 	return {
 		originalRowIndex: row.originalRowIndex,
 		row,
@@ -216,6 +244,7 @@ function _processRow(row: IInputRow): IProcessedRow | { error: string } {
 		activeDocument,
 		activeFilePath,
 		nextUserEdit: recording.nextUserEdit,
+		targetFileEdits,
 		recordingInfo,
 		recordingAfterRequest: split.recordingAfterRequest,
 		activeDocLogId: split.currentFile.id,

--- a/extensions/copilot/test/pipeline/responseStep.ts
+++ b/extensions/copilot/test/pipeline/responseStep.ts
@@ -396,12 +396,56 @@ function generateEditWindowOnlyResponse(
 	return { assistant, droppedEditCount: droppedCount };
 }
 
+/** A single target file's edit, with the request-time content it applies to. */
+export interface IResponseTargetFile {
+	readonly filePath: string;
+	readonly docContent: string;
+	readonly edit: readonly (readonly [start: number, endEx: number, text: string])[];
+}
+
 export interface IResponseGenerationInput {
 	readonly index: number;
-	readonly oracleEdits: readonly (readonly [start: number, endEx: number, text: string])[] | undefined;
-	readonly docContent: string;
-	readonly filePath: string;
+	/** The anchor file (where the suggestion was shown / the prompt window is). */
+	readonly anchorFilePath: string;
+	/** Target files to emit edits for, in the order their patch blocks should appear. */
+	readonly files: readonly IResponseTargetFile[];
 	readonly userPrompt: string;
+}
+
+/**
+ * Build the expected assistant response for one sample, combining edits across
+ * all target files. For {@link ResponseFormat.CustomDiffPatch} each file
+ * contributes a `file:line` patch block (concatenated in `files` order). Formats
+ * that cannot express multiple files fall back to the anchor file only.
+ */
+function generateResponseForInput(
+	responseFormat: ResponseFormat,
+	input: IResponseGenerationInput,
+	log?: ResponseLogger,
+): IGeneratedResponse | { error: string } {
+	const nonEmptyFiles = input.files.filter(f => f.edit.length > 0);
+	if (nonEmptyFiles.length === 0) {
+		return { error: `No edits available (files: ${input.files.map(f => f.filePath).join(', ') || 'none'})` };
+	}
+
+	if (responseFormat === ResponseFormat.CustomDiffPatch) {
+		const blocks: string[] = [];
+		for (const file of nonEmptyFiles) {
+			const result = generateResponse(responseFormat, file.edit, file.docContent, file.filePath, input.userPrompt, log);
+			if (!('error' in result) && result.assistant) {
+				blocks.push(result.assistant);
+			}
+		}
+		if (blocks.length === 0) {
+			return { error: `formatAsCustomDiffPatch produced empty result for all ${nonEmptyFiles.length} file(s)` };
+		}
+		return { assistant: blocks.join('\n') };
+	}
+
+	// Formats other than CustomDiffPatch cannot represent edits spanning
+	// multiple files, so restrict the label to the anchor file.
+	const anchor = nonEmptyFiles.find(f => f.filePath === input.anchorFilePath) ?? nonEmptyFiles[0];
+	return generateResponse(responseFormat, anchor.edit, anchor.docContent, anchor.filePath, input.userPrompt, log);
 }
 
 export function generateAllResponses(
@@ -416,12 +460,7 @@ export function generateAllResponses(
 	const errors: { index: number; error: string }[] = [];
 
 	for (const input of inputs) {
-		const result = generateResponse(
-			responseFormat,
-			input.oracleEdits, input.docContent, input.filePath,
-			input.userPrompt,
-			log,
-		);
+		const result = generateResponseForInput(responseFormat, input, log);
 		if ('error' in result) {
 			errors.push({ index: input.index, error: result.error });
 		} else {

--- a/extensions/copilot/test/pipeline/test/fixtures/xtabCrossFileFixtureData.ts
+++ b/extensions/copilot/test/pipeline/test/fixtures/xtabCrossFileFixtureData.ts
@@ -1,0 +1,127 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Fixture data for the `xtab-cross-file` end-to-end pipeline test.
+ *
+ * Each scenario produces a record in the shape `loadAndParseInput` expects
+ * ({ status, action, input, response, outcome, language }). The recordings are
+ * built so that the post-request `changed` events land in more than one
+ * document, exercising the multi-file edit label.
+ *
+ * (Synthetic stand-in for real `alternative_action` telemetry — swap in real
+ * recordings once the assertions are confirmed.)
+ */
+
+// ---------------------------------------------------------------------------
+// Scenario A – cross-file
+//   The user edits a second file (`otherA.ts`) FIRST, then the anchor file
+//   (`anchorA.ts`). First-touch order is therefore [otherA, anchorA], which
+//   differs from anchor-first order — letting the test distinguish the two
+//   `--patch-order` policies by the block order in the label.
+// ---------------------------------------------------------------------------
+
+const anchorAContent = `const a = 1;\nconst keep = 0;\n`;
+const otherAContent = `const b = 2;\nconst stay = 9;\n`;
+
+const crossFileRecordingEntries = [
+	{ kind: 'meta', data: { repoRootUri: 'file:///workspace' } },
+	{ kind: 'documentEncountered', id: 0, time: 1000000, relativePath: 'src/anchorA.ts' },
+	{ kind: 'setContent', id: 0, time: 1000001, content: anchorAContent, v: 0 },
+	{ kind: 'documentEncountered', id: 1, time: 1000002, relativePath: 'src/otherA.ts' },
+	{ kind: 'setContent', id: 1, time: 1000003, content: otherAContent, v: 0 },
+	// No-op edit on the anchor so it is the last pre-request doc touched
+	// (`determineCurrentFileId` → 0) and the replayer has a `lastId`.
+	{ kind: 'changed', id: 0, time: 1000004, edit: [[0, 0, '']], v: 1 },
+	// --- requestTime = 1000005 splits here ---
+	// Cross-file edit FIRST (otherA, id 1): rename `b` → `beta`.
+	{ kind: 'changed', id: 1, time: 1000006, edit: [[6, 7, 'beta']], v: 1 },
+	// Anchor edit SECOND (anchorA, id 0): rename `a` → `alpha`.
+	{ kind: 'changed', id: 0, time: 1000007, edit: [[6, 7, 'alpha']], v: 2 },
+];
+
+const crossFileAlternativeAction = {
+	text: anchorAContent,
+	textLength: anchorAContent.length,
+	selection: [{ start: 6, endExclusive: 7 }],
+	edits: [],
+	tags: [],
+	recording: {
+		entries: crossFileRecordingEntries,
+		entriesSize: crossFileRecordingEntries.length,
+		requestTime: 1000005,
+	},
+};
+
+const crossFileRecord = {
+	status: 'notAccepted',
+	action: JSON.stringify(crossFileAlternativeAction),
+	input: JSON.stringify([]),
+	response: '',
+	outcome: JSON.stringify({ suggestedEdit: '[6, 7) -> "alpha"', isInlineCompletion: false }),
+	language: 'typescript',
+};
+
+// ---------------------------------------------------------------------------
+// Scenario B – anchor-only
+//   The only post-request edit is in the anchor file, so the label is
+//   single-file and `isCrossFile` is false even for `xtab-cross-file`.
+// ---------------------------------------------------------------------------
+
+const soloBContent = `let x = 0;\nlet keep = 1;\n`;
+
+const sameFileRecordingEntries = [
+	{ kind: 'meta', data: { repoRootUri: 'file:///workspace' } },
+	{ kind: 'documentEncountered', id: 0, time: 2000000, relativePath: 'src/soloB.ts' },
+	{ kind: 'setContent', id: 0, time: 2000001, content: soloBContent, v: 0 },
+	{ kind: 'changed', id: 0, time: 2000002, edit: [[0, 0, '']], v: 1 },
+	// --- requestTime = 2000003 splits here ---
+	// Anchor-only edit: rename `x` → `count`.
+	{ kind: 'changed', id: 0, time: 2000004, edit: [[4, 5, 'count']], v: 2 },
+];
+
+const sameFileAlternativeAction = {
+	text: soloBContent,
+	textLength: soloBContent.length,
+	selection: [{ start: 4, endExclusive: 5 }],
+	edits: [],
+	tags: [],
+	recording: {
+		entries: sameFileRecordingEntries,
+		entriesSize: sameFileRecordingEntries.length,
+		requestTime: 2000003,
+	},
+};
+
+const sameFileRecord = {
+	status: 'notAccepted',
+	action: JSON.stringify(sameFileAlternativeAction),
+	input: JSON.stringify([]),
+	response: '',
+	outcome: JSON.stringify({ suggestedEdit: '[4, 5) -> "count"', isInlineCompletion: false }),
+	language: 'typescript',
+};
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export const xtabCrossFileFixtures = {
+	crossFile: {
+		record: crossFileRecord,
+		anchorPath: 'src/anchorA.ts',
+		otherPath: 'src/otherA.ts',
+		anchorDocContent: anchorAContent,
+		otherDocContent: otherAContent,
+	},
+	sameFile: {
+		record: sameFileRecord,
+		anchorPath: 'src/soloB.ts',
+		anchorDocContent: soloBContent,
+	},
+} as const;
+
+/** All records, in the order the pipeline will process them. */
+export const allXtabCrossFileRecords = [crossFileRecord, sameFileRecord];

--- a/extensions/copilot/test/pipeline/test/xtabCrossFilePipeline.e2e.spec.ts
+++ b/extensions/copilot/test/pipeline/test/xtabCrossFilePipeline.e2e.spec.ts
@@ -1,0 +1,172 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { NesDatagenSampleTask } from '../../base/simulationOptions';
+import { runInputPipeline, RunPipelineOptions } from '../pipeline';
+import { allXtabCrossFileRecords, xtabCrossFileFixtures } from './fixtures/xtabCrossFileFixtureData';
+
+/**
+ * End-to-end tests for the `xtab-cross-file` branch of the nes-datagen pipeline.
+ *
+ * Mirrors `pipeline.e2e.spec.ts` (the single-file Xtab branch) but feeds a
+ * recording whose post-request edits span two files, then asserts the
+ * multi-file `CustomDiffPatch` label, the `--patch-order` block ordering, and
+ * the cross-file metadata — plus that plain `xtab` collapses to the anchor file.
+ *
+ * The model is mocked / oracle-based (the label is computed from the recording),
+ * so no API key or network is required.
+ */
+
+// Reuse the Xtab e2e config (promptingStrategy=patchBased02 → CustomDiffPatch).
+const configPath = path.join(__dirname, 'fixtures', 'config.json');
+
+interface OutputSample {
+	messages: { role: 'system' | 'user' | 'assistant'; content: string }[];
+	metadata: {
+		rowIndex: number;
+		language: string;
+		strategy: string;
+		oracleEditCount: number;
+		suggestionStatus: string;
+		filePath: string;
+		docContent: string;
+		oracleEdits: [number, number, string][];
+		originalPrompt: unknown[];
+		modelResponse: string;
+		// Discriminated-union fields spread onto metadata by `assembleSample`.
+		task?: NesDatagenSampleTask;
+		targetFiles?: { filePath: string; docContent: string; oracleEdits: [number, number, string][] }[];
+		targetFilePaths?: string[];
+		isCrossFile?: boolean;
+	};
+}
+
+function parseJsonl<T>(contents: string): T[] {
+	return contents
+		.split('\n')
+		.filter(line => line.length > 0)
+		.map(line => JSON.parse(line) as T);
+}
+
+let tmpDir: string;
+let inputPath: string;
+
+beforeAll(async () => {
+	tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nes-datagen-xtab-crossfile-e2e-'));
+	inputPath = path.join(tmpDir, 'input.json');
+	await fs.writeFile(inputPath, JSON.stringify(allXtabCrossFileRecords, null, 2));
+});
+
+afterAll(async () => {
+	if (tmpDir) {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	}
+});
+
+async function run(
+	sampleTask: NesDatagenSampleTask,
+	overrides?: Partial<NonNullable<RunPipelineOptions['nesDatagen']>>,
+): Promise<OutputSample[]> {
+	const outputPath = path.join(tmpDir, `output-${sampleTask}-${overrides?.patchOrder ?? 'default'}.jsonl`);
+	const opts: RunPipelineOptions = {
+		nesDatagen: {
+			input: inputPath,
+			output: outputPath,
+			rowOffset: 0,
+			workerMode: false,
+			sampleTask,
+			sameFileJumpMinAbove: 5,
+			sameFileJumpMinBelow: 5,
+			...overrides,
+		},
+		configFile: configPath,
+		verbose: false,
+		parallelism: 1,
+	};
+	await runInputPipeline(opts, () => { });
+	const outputContents = await fs.readFile(outputPath, 'utf-8');
+	return parseJsonl<OutputSample>(outputContents);
+}
+
+const anchor = xtabCrossFileFixtures.crossFile.anchorPath; // 'src/anchorA.ts'
+const other = xtabCrossFileFixtures.crossFile.otherPath;   // 'src/otherA.ts'
+const solo = xtabCrossFileFixtures.sameFile.anchorPath;    // 'src/soloB.ts'
+
+describe('nes-datagen xtab-cross-file pipeline e2e', () => {
+
+	describe('sampleTask = xtab-cross-file (first-touch)', () => {
+		let samples: OutputSample[];
+		beforeAll(async () => { samples = await run(NesDatagenSampleTask.XtabCrossFile); });
+
+		test('emits one sample per record', () => {
+			expect(samples.length).toBe(2);
+		});
+
+		test('the cross-file record is labelled across both files in first-touch order', () => {
+			const s = samples.find(x => x.metadata.filePath.includes('anchorA'))!;
+			expect(s).toBeDefined();
+			expect(s.metadata.task).toBe(NesDatagenSampleTask.XtabCrossFile);
+			expect(s.metadata.strategy).toBe('customDiffPatch');
+			expect(s.metadata.isCrossFile).toBe(true);
+			expect(s.metadata.targetFiles?.length).toBe(2);
+			// First-touch: the cross-file (`otherA`) was edited before the anchor.
+			expect(s.metadata.targetFilePaths).toEqual([other, anchor]);
+
+			const assistant = s.messages.find(m => m.role === 'assistant')!.content;
+			expect(assistant).toContain(anchor);
+			expect(assistant).toContain(other);
+			// Label block order matches first-touch: otherA precedes anchorA.
+			expect(assistant.indexOf(other)).toBeLessThan(assistant.indexOf(anchor));
+		});
+
+		test('the anchor-only record stays single-file (isCrossFile false)', () => {
+			const s = samples.find(x => x.metadata.filePath.includes('soloB'))!;
+			expect(s).toBeDefined();
+			expect(s.metadata.task).toBe(NesDatagenSampleTask.XtabCrossFile);
+			expect(s.metadata.isCrossFile).toBe(false);
+			expect(s.metadata.targetFiles?.length).toBe(1);
+			expect(s.metadata.targetFilePaths).toEqual([solo]);
+
+			const assistant = s.messages.find(m => m.role === 'assistant')!.content;
+			expect(assistant).toContain(solo);
+		});
+	});
+
+	describe('sampleTask = xtab-cross-file (anchor-first)', () => {
+		let samples: OutputSample[];
+		beforeAll(async () => { samples = await run(NesDatagenSampleTask.XtabCrossFile, { patchOrder: 'anchor-first' }); });
+
+		test('the anchor block precedes the cross-file block in the label', () => {
+			const s = samples.find(x => x.metadata.filePath.includes('anchorA'))!;
+			const assistant = s.messages.find(m => m.role === 'assistant')!.content;
+			expect(assistant.indexOf(anchor)).toBeLessThan(assistant.indexOf(other));
+		});
+
+		test('metadata target order matches the label (anchor first)', () => {
+			const s = samples.find(x => x.metadata.filePath.includes('anchorA'))!;
+			expect(s.metadata.targetFilePaths).toEqual([anchor, other]);
+		});
+	});
+
+	describe('sampleTask = xtab (single-file, unchanged)', () => {
+		let samples: OutputSample[];
+		beforeAll(async () => { samples = await run(NesDatagenSampleTask.Xtab); });
+
+		test('the cross-file record collapses to the anchor file only', () => {
+			const s = samples.find(x => x.metadata.filePath.includes('anchorA'))!;
+			expect(s.metadata.task).toBe(NesDatagenSampleTask.Xtab);
+			expect(s.metadata.targetFiles).toBeUndefined();
+			expect(s.metadata.isCrossFile).toBeUndefined();
+
+			const assistant = s.messages.find(m => m.role === 'assistant')!.content;
+			expect(assistant).toContain(anchor);
+			expect(assistant).not.toContain(other);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Extends the `nes-datagen` simulation pipeline to produce **cross-file** next-edit
training samples via a new `xtab-cross-file` sample task. Until now the pipeline only
labeled the next edit inside the active file; this captures edits that span multiple files.

For each recording the pipeline now:
- Buckets post-request edits per document and composes per-file replacements.
- Resolves each target file's request-time content.
- Emits a multi-file CustomDiffPatch response (one `filename:line` patch block per touched file).
- Records `targetFiles` / `targetFilePaths` / `isCrossFile` in the sample metadata,
  ordered to match the response blocks.

A new `--patch-order` option (`first-touch` (default) | `anchor-first`) controls per-file
block ordering.

## What changed

Pipeline:
- `test/base/simulationOptions.ts` — `xtab-cross-file` task + `--patch-order` option, with validation and help text.
- `test/pipeline/alternativeAction/processor.ts`, `types.ts` — bucket multi-file edits into per-file `fileEdits[]`.
- `test/pipeline/replayRecording.ts` — expose each target's request-time content (`targetFileEdits`).
- `test/pipeline/responseStep.ts` — multi-file CustomDiffPatch generation (anchor-only fallback when not cross-file).
- `test/pipeline/pipeline.ts` — task dispatch + `orderTargetFiles` (first-touch / anchor-first).
- `test/pipeline/output.ts` — discriminated-union `SampleClassification` arm carrying cross-file metadata.

Tests:
- `test/pipeline/test/xtabCrossFilePipeline.e2e.spec.ts` + `test/pipeline/test/fixtures/xtabCrossFileFixtureData.ts`
  — synthetic, oracle-based e2e covering the multi-file label, `--patch-order` ordering,
  cross-file metadata, and the `xtab` single-file fallback. No model/network calls.

## How to test

From `extensions/copilot/`:

```
npx vitest run test/pipeline --pool=forks
```

All pipeline suites pass (87 passed, 1 skipped), including the new `xtab-cross-file` cases.

Generate cross-file samples from a recording:

```
npm run simulate -- --config-file=config.json nes-datagen --input=data.jsonl --sample-task=xtab-cross-file --patch-order=anchor-first
```

(`--config-file` must include `...xtabProvider.modelConfiguration`; output defaults to `<input>_output.jsonl`.)

## Notes

- Backward compatible: default sample task remains `xtab`; existing `xtab` / `cursor-*` tasks are unchanged.
- No recordings/telemetry or model config are included in this PR.