### PR TITLE
Enterprise OTel managed-settings policy

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -99,21 +99,6 @@
             "included": false
         },
         {
-            "key": "extensions.gallery.serviceUrl",
-            "name": "ExtensionGalleryServiceUrl",
-            "category": "Extensions",
-            "minimumVersion": "1.99",
-            "localization": {
-                "description": {
-                    "key": "extensions.gallery.serviceUrl",
-                    "value": "Configure the Marketplace service URL to connect to"
-                }
-            },
-            "type": "string",
-            "default": "",
-            "included": false
-        },
-        {
             "key": "extensions.allowed",
             "name": "AllowedExtensions",
             "category": "Extensions",
@@ -157,6 +142,138 @@
             "type": "boolean",
             "default": false,
             "included": true
+        },
+        {
+            "key": "chat.agentHost.otel.enabled",
+            "name": "CopilotOtelEnabled",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.127",
+            "localization": {
+                "description": {
+                    "key": "chat.agentHost.otel.enabled.policy",
+                    "value": "Controls whether Copilot OpenTelemetry export is enabled. When managed, users cannot override the enterprise value."
+                }
+            },
+            "type": "boolean",
+            "default": false,
+            "included": true,
+            "referencedSettings": [
+                "github.copilot.chat.otel.enabled"
+            ]
+        },
+        {
+            "key": "chat.agentHost.otel.exporterType",
+            "name": "CopilotOtelProtocol",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.127",
+            "localization": {
+                "description": {
+                    "key": "chat.agentHost.otel.protocol.policy",
+                    "value": "Controls the enterprise-managed OTLP protocol for Copilot OpenTelemetry export."
+                },
+                "enumDescriptions": [
+                    {
+                        "key": "chat.agentHost.otel.protocol.policy.otlpHttp",
+                        "value": "Use OTLP over HTTP."
+                    },
+                    {
+                        "key": "chat.agentHost.otel.protocol.policy.otlpGrpc",
+                        "value": "Use OTLP over gRPC."
+                    },
+                    {
+                        "key": "chat.agentHost.otel.protocol.policy.console",
+                        "value": "Console exporter is not selected by enterprise managed settings."
+                    },
+                    {
+                        "key": "chat.agentHost.otel.protocol.policy.file",
+                        "value": "File exporter is not selected by enterprise managed settings."
+                    }
+                ]
+            },
+            "type": "string",
+            "default": "otlp-http",
+            "enum": [
+                "otlp-http",
+                "otlp-grpc",
+                "console",
+                "file"
+            ],
+            "included": true,
+            "referencedSettings": [
+                "github.copilot.chat.otel.exporterType"
+            ]
+        },
+        {
+            "key": "chat.agentHost.otel.otlpEndpoint",
+            "name": "CopilotOtelEndpoint",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.127",
+            "localization": {
+                "description": {
+                    "key": "chat.agentHost.otel.otlpEndpoint.policy",
+                    "value": "Controls the enterprise-managed OTLP collector endpoint for Copilot OpenTelemetry export."
+                }
+            },
+            "type": "string",
+            "default": "",
+            "included": true,
+            "referencedSettings": [
+                "github.copilot.chat.otel.otlpEndpoint"
+            ]
+        },
+        {
+            "key": "chat.agentHost.otel.captureContent",
+            "name": "CopilotOtelCaptureContent",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.127",
+            "localization": {
+                "description": {
+                    "key": "chat.agentHost.otel.captureContent.policy",
+                    "value": "Controls whether Copilot OpenTelemetry export captures prompt, response, and tool content."
+                }
+            },
+            "type": "boolean",
+            "default": false,
+            "included": true,
+            "referencedSettings": [
+                "github.copilot.chat.otel.captureContent"
+            ]
+        },
+        {
+            "key": "chat.agentHost.otel.outfile",
+            "name": "CopilotOtelOutfile",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.127",
+            "localization": {
+                "description": {
+                    "key": "chat.agentHost.otel.outfile.policy",
+                    "value": "Prevents local file export when enterprise-managed Copilot OpenTelemetry export is configured."
+                }
+            },
+            "type": "string",
+            "default": "",
+            "included": true,
+            "referencedSettings": [
+                "github.copilot.chat.otel.outfile"
+            ]
+        },
+        {
+            "key": "chat.agentHost.otel.dbSpanExporter.enabled",
+            "name": "CopilotOtelDbSpanExporter",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.127",
+            "localization": {
+                "description": {
+                    "key": "chat.agentHost.otel.dbSpanExporter.enabled.policy",
+                    "value": "Controls whether Copilot OpenTelemetry spans are persisted to a local SQLite database."
+                }
+            },
+            "type": "boolean",
+            "default": false,
+            "included": true,
+            "referencedSettings": [
+                "github.copilot.chat.otel.dbSpanExporter.enabled"
+            ]
         },
         {
             "key": "chat.tools.global.autoApprove",
@@ -373,50 +490,6 @@
             },
             "type": "boolean",
             "default": true,
-            "included": true
-        },
-        {
-            "key": "extensions.autoUpdate",
-            "name": "ExtensionsAutoUpdate",
-            "category": "Extensions",
-            "minimumVersion": "1.125",
-            "localization": {
-                "description": {
-                    "key": "extensions.autoUpdate",
-                    "value": "Controls the automatic update behavior of extensions. The updates are fetched from a Microsoft online service."
-                },
-                "enumDescriptions": [
-                    {
-                        "key": "extensions.autoUpdate.on",
-                        "value": "Download and install updates automatically only for enabled extensions."
-                    },
-                    {
-                        "key": "extensions.autoUpdate.off",
-                        "value": "Extensions are not automatically updated."
-                    }
-                ]
-            },
-            "type": "string",
-            "default": "on",
-            "enum": [
-                "on",
-                "off"
-            ],
-            "included": true
-        },
-        {
-            "key": "extensions.autoUpdateDelay",
-            "name": "ExtensionsAutoUpdateDelay",
-            "category": "Extensions",
-            "minimumVersion": "1.125",
-            "localization": {
-                "description": {
-                    "key": "extensions.autoUpdateDelay",
-                    "value": "Controls the delay in hours after an extension update is published before it is automatically installed. Only applies when `#extensions.autoUpdate#` is set to `on`. This delay helps avoid installing potentially problematic updates immediately after release."
-                }
-            },
-            "type": "number",
-            "default": 2,
             "included": true
         },
         {
@@ -666,7 +739,8 @@
             "default": true,
             "included": true,
             "referencedSettings": [
-                "chat.agentHost.claudeAgent.enabled"
+                "chat.agentHost.claudeAgent.enabled",
+                "sessions.chat.claudeAgent.enabled"
             ]
         }
     ]

--- a/extensions/copilot/docs/monitoring/agent_monitoring.md
+++ b/extensions/copilot/docs/monitoring/agent_monitoring.md
@@ -76,7 +76,7 @@ Open **Settings** (`Ctrl+,`) and search for `copilot otel`:
 
 ### Environment Variables
 
-Environment variables **always take precedence** over VS Code settings.
+Enterprise managed settings, when configured by an organization, take precedence over environment variables and VS Code settings. Environment variables take precedence over user-configured VS Code settings when no enterprise policy is active.
 
 | Variable | Default | Description |
 |---|---|---|
@@ -93,6 +93,21 @@ Environment variables **always take precedence** over VS Code settings.
 | `COPILOT_OTEL_FILE_EXPORTER_PATH` | — | Write all signals to this file (JSON-lines) |
 | `COPILOT_OTEL_HTTP_INSTRUMENTATION` | `false` | Enable HTTP-level OTel instrumentation |
 | `OTEL_EXPORTER_OTLP_HEADERS` | — | Auth headers (e.g., `Authorization=Bearer token`) |
+
+### Enterprise Managed Settings
+
+Organizations can mandate OTel settings through Copilot managed settings. VS Code honors the following `telemetry.*` keys and applies them to both `github.copilot.chat.otel.*` and `chat.agentHost.otel.*` settings through enterprise policy:
+
+| Managed key | Description |
+|---|---|
+| `telemetry.enabled` | Force OTel export on or off. |
+| `telemetry.endpoint` | Lock the OTLP collector endpoint. |
+| `telemetry.protocol` | Lock the OTLP protocol (`grpc`, `http/protobuf`, or `http/json`). |
+| `telemetry.captureContent` | Force content capture on or off. |
+| `telemetry.lockCaptureContent` | When true and `captureContent` is omitted, prevents users from enabling content capture. |
+| `telemetry.dbSpanExporter.enabled` | Force local SQLite span export on or off. |
+
+When an enterprise endpoint or protocol is managed, local file export is suppressed so OTel data cannot be diverted to a file exporter instead of the managed OTLP path.
 
 ### Activation
 

--- a/extensions/copilot/docs/monitoring/agent_monitoring_arch.md
+++ b/extensions/copilot/docs/monitoring/agent_monitoring_arch.md
@@ -209,10 +209,11 @@ Both export to the same OTLP endpoint. Bridge processor sits on Provider B, forw
 
 `resolveOTelConfig()` implements layered precedence:
 
-1. `COPILOT_OTEL_*` env vars (highest)
-2. `OTEL_EXPORTER_OTLP_*` standard env vars
-3. VS Code settings (`github.copilot.chat.otel.*`)
-4. Defaults (lowest)
+1. Enterprise policy values from Copilot managed settings (highest)
+2. `COPILOT_OTEL_*` env vars
+3. `OTEL_EXPORTER_OTLP_*` standard env vars
+4. VS Code settings (`github.copilot.chat.otel.*`)
+5. Defaults (lowest)
 
 Kill switch: `telemetry.telemetryLevel === 'off'` → all OTel disabled.
 
@@ -222,6 +223,7 @@ The resolved config records *how* OTel was enabled in `OTelConfig.enabledVia` (u
 
 | `enabledVia` | Trigger |
 |---|---|
+| `policy` | Enterprise policy enabled OTel, e.g. `telemetry.enabled=true` or managed `telemetry.endpoint` |
 | `envVar` | `COPILOT_OTEL_ENABLED=true` |
 | `setting` | `github.copilot.chat.otel.enabled` is `true` |
 | `otlpEndpointEnvVar` | `OTEL_EXPORTER_OTLP_ENDPOINT` is set without an explicit enable |

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -5273,6 +5273,9 @@
             "type": "boolean",
             "default": false,
             "scope": "application",
+            "policyReference": {
+              "name": "CopilotOtelEnabled"
+            },
             "markdownDescription": "Enable OpenTelemetry trace/metric/log emission for Copilot Chat operations. Configurable in user settings only. Env var `COPILOT_OTEL_ENABLED` takes precedence. Requires window reload.",
             "tags": [
               "advanced"
@@ -5288,6 +5291,9 @@
             ],
             "default": "otlp-http",
             "scope": "application",
+            "policyReference": {
+              "name": "CopilotOtelProtocol"
+            },
             "markdownDescription": "OTel exporter type for Copilot Chat telemetry. Configurable in user settings only. Requires window reload.",
             "tags": [
               "advanced"
@@ -5297,6 +5303,9 @@
             "type": "string",
             "default": "http://localhost:4318",
             "scope": "application",
+            "policyReference": {
+              "name": "CopilotOtelEndpoint"
+            },
             "markdownDescription": "OTLP collector endpoint URL for Copilot Chat OTel data. Configurable in user settings only. Env var `OTEL_EXPORTER_OTLP_ENDPOINT` takes precedence. Requires window reload.",
             "tags": [
               "advanced"
@@ -5306,6 +5315,9 @@
             "type": "boolean",
             "default": false,
             "scope": "application",
+            "policyReference": {
+              "name": "CopilotOtelCaptureContent"
+            },
             "markdownDescription": "Capture input/output messages, system instructions, and tool definitions in OTel telemetry. **Contains potentially sensitive data.** Configurable in user settings only. Env var `COPILOT_OTEL_CAPTURE_CONTENT` takes precedence. Requires window reload.",
             "tags": [
               "advanced"
@@ -5325,6 +5337,9 @@
             "type": "string",
             "default": "",
             "scope": "application",
+            "policyReference": {
+              "name": "CopilotOtelOutfile"
+            },
             "markdownDescription": "File path for file-based OTel exporter output (JSON-lines). When set, overrides exporter type to `file`. Configurable in user settings only. Requires window reload.",
             "tags": [
               "advanced"
@@ -5334,6 +5349,9 @@
             "type": "boolean",
             "default": false,
             "scope": "application",
+            "policyReference": {
+              "name": "CopilotOtelDbSpanExporter"
+            },
             "markdownDescription": "Enable SQLite DB span exporter. Persists OTel spans to a local SQLite database. Automatically enables OTel when set to true. Configurable in user settings only. Requires window reload.",
             "tags": [
               "advanced"

--- a/extensions/copilot/src/extension/extension/vscode-node/services.ts
+++ b/extensions/copilot/src/extension/extension/vscode-node/services.ts
@@ -289,6 +289,7 @@ export function registerServices(builder: IInstantiationServiceBuilder, extensio
 
 	// OTel service — resolve config from env + settings, create appropriate impl
 	const otelSettings = workspace.getConfiguration('github.copilot.chat.otel');
+	const policyValue = <T>(key: string): T | undefined => (otelSettings.inspect<T>(key) as { policyValue?: T } | undefined)?.policyValue;
 	const otelConfig = resolveOTelConfig({
 		env: process.env,
 		settingEnabled: otelSettings.get<boolean>('enabled'),
@@ -298,6 +299,12 @@ export function registerServices(builder: IInstantiationServiceBuilder, extensio
 		settingMaxAttributeSizeChars: otelSettings.get<number>('maxAttributeSizeChars'),
 		settingOutfile: otelSettings.get<string>('outfile') || undefined,
 		settingDbSpanExporter: otelSettings.get<boolean>('dbSpanExporter.enabled'),
+		policyEnabled: policyValue<boolean>('enabled'),
+		policyExporterType: policyValue<'otlp-grpc' | 'otlp-http' | 'console' | 'file'>('exporterType'),
+		policyOtlpEndpoint: policyValue<string>('otlpEndpoint'),
+		policyCaptureContent: policyValue<boolean>('captureContent'),
+		policyOutfile: policyValue<string>('outfile'),
+		policyDbSpanExporter: policyValue<boolean>('dbSpanExporter.enabled'),
 		extensionVersion: extensionContext.extension.packageJSON.version ?? '0.0.0',
 		sessionId: env.sessionId,
 	});

--- a/extensions/copilot/src/platform/otel/common/otelConfig.ts
+++ b/extensions/copilot/src/platform/otel/common/otelConfig.ts
@@ -5,7 +5,7 @@
 
 export type OTelExporterType = 'otlp-grpc' | 'otlp-http' | 'console' | 'file';
 
-export type OTelEnabledVia = 'envVar' | 'setting' | 'otlpEndpointEnvVar' | 'dbSpanExporterOnly' | 'disabled';
+export type OTelEnabledVia = 'policy' | 'envVar' | 'setting' | 'otlpEndpointEnvVar' | 'dbSpanExporterOnly' | 'disabled';
 
 /** Default OTLP endpoint used when no env var or setting overrides it. */
 export const DEFAULT_OTLP_ENDPOINT = 'http://localhost:4318';
@@ -87,6 +87,12 @@ export interface OTelConfigInput {
 	settingMaxAttributeSizeChars?: number;
 	settingOutfile?: string;
 	settingDbSpanExporter?: boolean;
+	policyEnabled?: boolean;
+	policyExporterType?: OTelExporterType;
+	policyOtlpEndpoint?: string;
+	policyCaptureContent?: boolean;
+	policyOutfile?: string;
+	policyDbSpanExporter?: boolean;
 	extensionVersion: string;
 	sessionId: string;
 	vscodeTelemetryLevel?: string;
@@ -94,10 +100,11 @@ export interface OTelConfigInput {
 
 /**
  * Resolve OTel configuration with layered precedence:
- * 1. COPILOT_OTEL_* env vars (highest)
- * 2. OTEL_EXPORTER_OTLP_* standard env vars
- * 3. VS Code settings
- * 4. Defaults (lowest)
+ * 1. Enterprise policy values from managed settings (highest)
+ * 2. COPILOT_OTEL_* env vars
+ * 3. OTEL_EXPORTER_OTLP_* standard env vars
+ * 4. VS Code settings
+ * 5. Defaults (lowest)
  */
 export function resolveOTelConfig(input: OTelConfigInput): OTelConfig {
 	const { env } = input;
@@ -107,20 +114,23 @@ export function resolveOTelConfig(input: OTelConfigInput): OTelConfig {
 		return createDisabledConfig(input);
 	}
 
-	// SQLite DB span exporter: setting > default(false)
-	const dbSpanExporter = input.settingDbSpanExporter ?? false;
+	// SQLite DB span exporter: policy > setting > default(false)
+	const dbSpanExporter = input.policyDbSpanExporter ?? input.settingDbSpanExporter ?? false;
 
-	// Determine if enabled: env > setting > dbSpanExporter > default(false)
+	const policyMandatesOtlp = input.policyOtlpEndpoint !== undefined || input.policyExporterType !== undefined;
+	const policyEndpointEnables = input.policyOtlpEndpoint !== undefined ? true : undefined;
+
+	// Determine if enabled: policy > env > setting > policy endpoint > dbSpanExporter > default(false)
 	// When dbSpanExporter is on, OTel must be enabled for the SDK pipeline to work.
-	const enabled = (envBool(env['COPILOT_OTEL_ENABLED'])
+	const enabledSignal = input.policyEnabled
+		?? envBool(env['COPILOT_OTEL_ENABLED'])
 		?? input.settingEnabled
-		?? (!!env['OTEL_EXPORTER_OTLP_ENDPOINT']))
-		|| dbSpanExporter;
+		?? policyEndpointEnables
+		?? (!!env['OTEL_EXPORTER_OTLP_ENDPOINT']);
+	const enabled = input.policyEnabled === false ? false : enabledSignal || dbSpanExporter;
 
 	// OTel was explicitly enabled if the user/env turned it on, not just dbSpanExporter
-	const enabledExplicitly = (envBool(env['COPILOT_OTEL_ENABLED'])
-		?? input.settingEnabled
-		?? (!!env['OTEL_EXPORTER_OTLP_ENDPOINT'])) === true;
+	const enabledExplicitly = enabled && enabledSignal === true;
 
 	if (!enabled) {
 		return createDisabledConfig(input);
@@ -128,7 +138,9 @@ export function resolveOTelConfig(input: OTelConfigInput): OTelConfig {
 
 	// Determine how OTel was enabled for telemetry tracking
 	let enabledVia: OTelEnabledVia;
-	if (envBool(env['COPILOT_OTEL_ENABLED']) === true) {
+	if (input.policyEnabled === true || (input.policyEnabled === undefined && input.policyOtlpEndpoint !== undefined)) {
+		enabledVia = 'policy';
+	} else if (envBool(env['COPILOT_OTEL_ENABLED']) === true) {
 		enabledVia = 'envVar';
 	} else if (input.settingEnabled === true) {
 		enabledVia = 'setting';
@@ -138,23 +150,36 @@ export function resolveOTelConfig(input: OTelConfigInput): OTelConfig {
 		enabledVia = 'dbSpanExporterOnly';
 	}
 
-	// Protocol: env > inferred from exporter type > default
-	const rawProtocol = env['OTEL_EXPORTER_OTLP_PROTOCOL'] ?? env['COPILOT_OTEL_PROTOCOL'];
+	// Protocol: policy > env > default
+	const rawProtocol = input.policyExporterType === 'otlp-grpc'
+		? 'grpc'
+		: input.policyExporterType === 'otlp-http'
+			? 'http'
+			: env['OTEL_EXPORTER_OTLP_PROTOCOL'] ?? env['COPILOT_OTEL_PROTOCOL'];
 	const protocol: 'grpc' | 'http' = rawProtocol === 'grpc' ? 'grpc' : 'http';
 
-	// Endpoint: COPILOT_OTEL env > OTEL env > setting > default
-	const rawEndpoint = env['COPILOT_OTEL_ENDPOINT']
+	// Endpoint: policy > COPILOT_OTEL env > OTEL env > setting > default
+	const rawEndpoint = input.policyOtlpEndpoint
+		?? env['COPILOT_OTEL_ENDPOINT']
 		?? env['OTEL_EXPORTER_OTLP_ENDPOINT']
 		?? input.settingOtlpEndpoint
 		?? DEFAULT_OTLP_ENDPOINT;
 	const otlpEndpoint = parseOtlpEndpoint(rawEndpoint, protocol) ?? DEFAULT_OTLP_ENDPOINT;
 
-	// File exporter path
-	const fileExporterPath = env['COPILOT_OTEL_FILE_EXPORTER_PATH'] ?? input.settingOutfile;
+	// File exporter path. Enterprise OTLP policy suppresses file export diversion.
+	const fileExporterPath = input.policyOutfile !== undefined
+		? input.policyOutfile || undefined
+		: policyMandatesOtlp
+			? undefined
+			: env['COPILOT_OTEL_FILE_EXPORTER_PATH'] ?? input.settingOutfile;
 
 	// Exporter type
 	let exporterType: OTelExporterType;
-	if (fileExporterPath) {
+	if (input.policyExporterType) {
+		exporterType = input.policyExporterType;
+	} else if (policyMandatesOtlp) {
+		exporterType = 'otlp-http';
+	} else if (fileExporterPath) {
 		exporterType = 'file';
 	} else if (input.settingExporterType) {
 		exporterType = input.settingExporterType;
@@ -162,8 +187,9 @@ export function resolveOTelConfig(input: OTelConfigInput): OTelConfig {
 		exporterType = protocol === 'grpc' ? 'otlp-grpc' : 'otlp-http';
 	}
 
-	// Content capture
-	const captureContent = envBool(env['COPILOT_OTEL_CAPTURE_CONTENT'])
+	// Content capture: policy > env > setting > default(false)
+	const captureContent = input.policyCaptureContent
+		?? envBool(env['COPILOT_OTEL_CAPTURE_CONTENT'])
 		?? input.settingCaptureContent
 		?? false;
 

--- a/extensions/copilot/src/platform/otel/common/test/otelConfig.spec.ts
+++ b/extensions/copilot/src/platform/otel/common/test/otelConfig.spec.ts
@@ -52,6 +52,25 @@ describe('resolveOTelConfig', () => {
 		expect(config.enabled).toBe(false);
 	});
 
+	it('enterprise policy enabled overrides env COPILOT_OTEL_ENABLED=false', () => {
+		const config = resolveOTelConfig(makeInput({
+			env: { 'COPILOT_OTEL_ENABLED': 'false' },
+			policyEnabled: true,
+		}));
+		expect(config.enabled).toBe(true);
+		expect(config.enabledVia).toBe('policy');
+	});
+
+	it('enterprise policy enabled=false disables even when dbSpanExporter is on', () => {
+		const config = resolveOTelConfig(makeInput({
+			policyEnabled: false,
+			policyDbSpanExporter: true,
+		}));
+		expect(config.enabled).toBe(false);
+		expect(config.enabledVia).toBe('disabled');
+		expect(config.dbSpanExporter).toBe(false);
+	});
+
 	it('disables when vscodeTelemetryLevel is off', () => {
 		const config = resolveOTelConfig(makeInput({
 			env: { 'COPILOT_OTEL_ENABLED': 'true' },
@@ -72,12 +91,37 @@ describe('resolveOTelConfig', () => {
 		expect(config.fileExporterPath).toBe('/tmp/otel.jsonl');
 	});
 
+	it('enterprise policy endpoint prevents env file exporter diversion', () => {
+		const config = resolveOTelConfig(makeInput({
+			env: {
+				'COPILOT_OTEL_ENABLED': 'true',
+				'COPILOT_OTEL_FILE_EXPORTER_PATH': '/tmp/otel.jsonl',
+			},
+			policyOtlpEndpoint: 'https://collector.example.com',
+		}));
+		expect(config.enabled).toBe(true);
+		expect(config.enabledVia).toBe('policy');
+		expect(config.exporterType).toBe('otlp-http');
+		expect(config.fileExporterPath).toBeUndefined();
+		expect(config.otlpEndpoint).toBe('https://collector.example.com/');
+	});
+
 	it('uses VS Code setting for exporter type', () => {
 		const config = resolveOTelConfig(makeInput({
 			settingEnabled: true,
 			settingExporterType: 'console',
 		}));
 		expect(config.exporterType).toBe('console');
+	});
+
+	it('enterprise policy exporter type overrides VS Code exporter type', () => {
+		const config = resolveOTelConfig(makeInput({
+			settingEnabled: true,
+			settingExporterType: 'console',
+			policyExporterType: 'otlp-grpc',
+		}));
+		expect(config.exporterType).toBe('otlp-grpc');
+		expect(config.otlpProtocol).toBe('grpc');
 	});
 
 	it('resolves COPILOT_OTEL_CAPTURE_CONTENT', () => {
@@ -97,6 +141,17 @@ describe('resolveOTelConfig', () => {
 				'COPILOT_OTEL_CAPTURE_CONTENT': 'false',
 			},
 			settingCaptureContent: true,
+		}));
+		expect(config.captureContent).toBe(false);
+	});
+
+	it('enterprise policy captureContent overrides env', () => {
+		const config = resolveOTelConfig(makeInput({
+			env: {
+				'COPILOT_OTEL_ENABLED': 'true',
+				'COPILOT_OTEL_CAPTURE_CONTENT': 'true',
+			},
+			policyCaptureContent: false,
 		}));
 		expect(config.captureContent).toBe(false);
 	});

--- a/src/vs/platform/agentHost/OTEL.md
+++ b/src/vs/platform/agentHost/OTEL.md
@@ -134,7 +134,7 @@ src/vs/platform/otel/
 
 ## Settings → Env Var Translation
 
-`buildAgentHostOTelEnv()` ([common/agentService.ts](common/agentService.ts)) is the single translation point. The starter (`electronAgentHostStarter.ts` / `nodeAgentHostStarter.ts`) reads settings, calls `buildAgentHostOTelEnv(settings, parentEnv)`, and merges the result into the spawned process's environment. Parent-env values always win.
+`buildAgentHostOTelEnv()` ([common/agentService.ts](common/agentService.ts)) is the single translation point. The starter (`electronAgentHostStarter.ts` / `nodeAgentHostStarter.ts`) reads settings and policy values, calls `buildAgentHostOTelEnv(settings, parentEnv, policySettings)`, and merges the result into the spawned process's environment. Parent-env values win over user settings; enterprise policy values win over inherited env and can clear inherited OTel endpoint/file/DB signals.
 
 | Setting | Env var |
 |---|---|

--- a/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHostStarter.config.contribution.ts
@@ -4,8 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as nls from '../../../nls.js';
+import { IPolicyData } from '../../../base/common/defaultAccount.js';
 import { PolicyCategory } from '../../../base/common/policy.js';
 import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../configuration/common/configurationRegistry.js';
+import { COPILOT_OTEL_CAPTURE_CONTENT_KEY, COPILOT_OTEL_DB_SPAN_EXPORTER_ENABLED_KEY, COPILOT_OTEL_ENABLED_KEY, COPILOT_OTEL_ENDPOINT_KEY, COPILOT_OTEL_LOCK_CAPTURE_CONTENT_KEY, COPILOT_OTEL_PROTOCOL_KEY, managedSettingValue } from '../../policy/common/copilotManagedSettings.js';
 import product from '../../product/common/product.js';
 import { Registry } from '../../registry/common/platform.js';
 import {
@@ -39,6 +41,34 @@ import {
 //     (renderer registration for the settings UI).
 
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+
+function managedOTelProtocolValue(policyData: IPolicyData): string | undefined {
+	const protocol = policyData.managedSettings?.[COPILOT_OTEL_PROTOCOL_KEY];
+	if (protocol === 'grpc') {
+		return 'otlp-grpc';
+	}
+	if (protocol === 'http/protobuf' || protocol === 'http/json') {
+		return 'otlp-http';
+	}
+	return undefined;
+}
+
+function managedOTelCaptureContentValue(policyData: IPolicyData): boolean | undefined {
+	const captureContent = policyData.managedSettings?.[COPILOT_OTEL_CAPTURE_CONTENT_KEY];
+	if (typeof captureContent === 'boolean') {
+		return captureContent;
+	}
+	return policyData.managedSettings?.[COPILOT_OTEL_LOCK_CAPTURE_CONTENT_KEY] === true ? false : undefined;
+}
+
+function managedOTelOutfileValue(policyData: IPolicyData): string | undefined {
+	const managedSettings = policyData.managedSettings;
+	if (managedSettings?.[COPILOT_OTEL_ENDPOINT_KEY] !== undefined || managedSettings?.[COPILOT_OTEL_PROTOCOL_KEY] !== undefined) {
+		return '';
+	}
+	return undefined;
+}
+
 configurationRegistry.registerConfiguration({
 	id: 'chatAgentHostStarter',
 	title: nls.localize('chatAgentHostStarterConfigurationTitle', "Chat Agent Host Starter"),
@@ -101,6 +131,21 @@ configurationRegistry.registerConfiguration({
 			default: false,
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental', 'advanced'],
+			policy: {
+				name: 'CopilotOtelEnabled',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.127',
+				value: managedSettingValue(COPILOT_OTEL_ENABLED_KEY),
+				managedSettings: {
+					[COPILOT_OTEL_ENABLED_KEY]: { type: 'boolean' },
+				},
+				localization: {
+					description: {
+						key: 'chat.agentHost.otel.enabled.policy',
+						value: nls.localize('chat.agentHost.otel.enabled.policy', "Controls whether Copilot OpenTelemetry export is enabled. When managed, users cannot override the enterprise value."),
+					}
+				},
+			},
 		},
 		[AgentHostOTelExporterTypeSettingId]: {
 			type: 'string',
@@ -109,6 +154,27 @@ configurationRegistry.registerConfiguration({
 			default: 'otlp-http',
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental', 'advanced'],
+			policy: {
+				name: 'CopilotOtelProtocol',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.127',
+				value: managedOTelProtocolValue,
+				managedSettings: {
+					[COPILOT_OTEL_PROTOCOL_KEY]: { type: 'string' },
+				},
+				localization: {
+					description: {
+						key: 'chat.agentHost.otel.protocol.policy',
+						value: nls.localize('chat.agentHost.otel.protocol.policy', "Controls the enterprise-managed OTLP protocol for Copilot OpenTelemetry export."),
+					},
+					enumDescriptions: [
+						{ key: 'chat.agentHost.otel.protocol.policy.otlpHttp', value: nls.localize('chat.agentHost.otel.protocol.policy.otlpHttp', "Use OTLP over HTTP."), },
+						{ key: 'chat.agentHost.otel.protocol.policy.otlpGrpc', value: nls.localize('chat.agentHost.otel.protocol.policy.otlpGrpc', "Use OTLP over gRPC."), },
+						{ key: 'chat.agentHost.otel.protocol.policy.console', value: nls.localize('chat.agentHost.otel.protocol.policy.console', "Console exporter is not selected by enterprise managed settings."), },
+						{ key: 'chat.agentHost.otel.protocol.policy.file', value: nls.localize('chat.agentHost.otel.protocol.policy.file', "File exporter is not selected by enterprise managed settings."), },
+					],
+				},
+			},
 		},
 		[AgentHostOTelOtlpEndpointSettingId]: {
 			type: 'string',
@@ -116,6 +182,21 @@ configurationRegistry.registerConfiguration({
 			default: '',
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental', 'advanced'],
+			policy: {
+				name: 'CopilotOtelEndpoint',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.127',
+				value: managedSettingValue(COPILOT_OTEL_ENDPOINT_KEY),
+				managedSettings: {
+					[COPILOT_OTEL_ENDPOINT_KEY]: { type: 'string' },
+				},
+				localization: {
+					description: {
+						key: 'chat.agentHost.otel.otlpEndpoint.policy',
+						value: nls.localize('chat.agentHost.otel.otlpEndpoint.policy', "Controls the enterprise-managed OTLP collector endpoint for Copilot OpenTelemetry export."),
+					}
+				},
+			},
 		},
 		[AgentHostOTelCaptureContentSettingId]: {
 			type: 'boolean',
@@ -123,6 +204,22 @@ configurationRegistry.registerConfiguration({
 			default: false,
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental', 'advanced'],
+			policy: {
+				name: 'CopilotOtelCaptureContent',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.127',
+				value: managedOTelCaptureContentValue,
+				managedSettings: {
+					[COPILOT_OTEL_CAPTURE_CONTENT_KEY]: { type: 'boolean' },
+					[COPILOT_OTEL_LOCK_CAPTURE_CONTENT_KEY]: { type: 'boolean' },
+				},
+				localization: {
+					description: {
+						key: 'chat.agentHost.otel.captureContent.policy',
+						value: nls.localize('chat.agentHost.otel.captureContent.policy', "Controls whether Copilot OpenTelemetry export captures prompt, response, and tool content."),
+					}
+				},
+			},
 		},
 		[AgentHostOTelOutfileSettingId]: {
 			type: 'string',
@@ -130,6 +227,22 @@ configurationRegistry.registerConfiguration({
 			default: '',
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental', 'advanced'],
+			policy: {
+				name: 'CopilotOtelOutfile',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.127',
+				value: managedOTelOutfileValue,
+				managedSettings: {
+					[COPILOT_OTEL_ENDPOINT_KEY]: { type: 'string' },
+					[COPILOT_OTEL_PROTOCOL_KEY]: { type: 'string' },
+				},
+				localization: {
+					description: {
+						key: 'chat.agentHost.otel.outfile.policy',
+						value: nls.localize('chat.agentHost.otel.outfile.policy', "Prevents local file export when enterprise-managed Copilot OpenTelemetry export is configured."),
+					}
+				},
+			},
 		},
 		[AgentHostOTelDbSpanExporterEnabledSettingId]: {
 			type: 'boolean',
@@ -137,6 +250,21 @@ configurationRegistry.registerConfiguration({
 			default: false,
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental', 'advanced'],
+			policy: {
+				name: 'CopilotOtelDbSpanExporter',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.127',
+				value: managedSettingValue(COPILOT_OTEL_DB_SPAN_EXPORTER_ENABLED_KEY),
+				managedSettings: {
+					[COPILOT_OTEL_DB_SPAN_EXPORTER_ENABLED_KEY]: { type: 'boolean' },
+				},
+				localization: {
+					description: {
+						key: 'chat.agentHost.otel.dbSpanExporter.enabled.policy',
+						value: nls.localize('chat.agentHost.otel.dbSpanExporter.enabled.policy', "Controls whether Copilot OpenTelemetry spans are persisted to a local SQLite database."),
+					}
+				},
+			},
 		},
 	}
 });

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -346,6 +346,7 @@ export interface IAgentHostOTelSettings {
 export function buildAgentHostOTelEnv(
 	settings: IAgentHostOTelSettings,
 	inheritedEnv: Readonly<Record<string, string | undefined>>,
+	policySettings: IAgentHostOTelSettings = {},
 ): Record<string, string> {
 	const out: Record<string, string> = {};
 	const setIfMissing = (key: string, value: string | undefined): void => {
@@ -353,6 +354,11 @@ export function buildAgentHostOTelEnv(
 			return;
 		}
 		out[key] = value;
+	};
+	const setPolicy = (key: string, value: string | undefined): void => {
+		if (value !== undefined) {
+			out[key] = value;
+		}
 	};
 	if (settings.enabled) {
 		setIfMissing(AgentHostOTelEnvVars.Enabled, 'true');
@@ -365,6 +371,33 @@ export function buildAgentHostOTelEnv(
 	}
 	if (settings.dbSpanExporterEnabled) {
 		setIfMissing(AgentHostOTelEnvVars.DbSpanExporterEnabled, 'true');
+	}
+
+	if (policySettings.enabled !== undefined) {
+		setPolicy(AgentHostOTelEnvVars.Enabled, policySettings.enabled ? 'true' : 'false');
+		if (!policySettings.enabled) {
+			setPolicy(AgentHostOTelEnvVars.OtlpEndpoint, '');
+			setPolicy(AgentHostOTelEnvVars.OtlpEndpointAlt, '');
+			setPolicy(AgentHostOTelEnvVars.FilePath, '');
+			setPolicy(AgentHostOTelEnvVars.DbSpanExporterEnabled, 'false');
+		}
+	}
+	if (policySettings.exporterType !== undefined) {
+		setPolicy(AgentHostOTelEnvVars.ExporterType, policySettings.exporterType);
+		setPolicy(AgentHostOTelEnvVars.FilePath, '');
+	}
+	if (policySettings.otlpEndpoint !== undefined) {
+		setPolicy(AgentHostOTelEnvVars.OtlpEndpoint, policySettings.otlpEndpoint);
+		setPolicy(AgentHostOTelEnvVars.FilePath, '');
+	}
+	if (policySettings.outfile !== undefined) {
+		setPolicy(AgentHostOTelEnvVars.FilePath, policySettings.outfile);
+	}
+	if (policySettings.captureContent !== undefined) {
+		setPolicy(AgentHostOTelEnvVars.CaptureContent, policySettings.captureContent ? 'true' : 'false');
+	}
+	if (policySettings.dbSpanExporterEnabled !== undefined) {
+		setPolicy(AgentHostOTelEnvVars.DbSpanExporterEnabled, policySettings.dbSpanExporterEnabled ? 'true' : 'false');
 	}
 	return out;
 }

--- a/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
@@ -79,7 +79,9 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 
 		// Translate `chat.agentHost.otel.*` settings into the env vars consumed by
 		// the agent host process. Any value already present on `process.env` wins
-		// (developer override) — see `buildAgentHostOTelEnv` for the precedence.
+		// for user settings, while enterprise policy values win over inherited env —
+		// see `buildAgentHostOTelEnv` for the precedence.
+		const policyValue = <T>(key: string): T | undefined => this._configurationService.inspect<T>(key).policyValue;
 		const otelEnv = buildAgentHostOTelEnv({
 			enabled: this._configurationService.getValue<boolean>(AgentHostOTelEnabledSettingId),
 			exporterType: this._configurationService.getValue<string>(AgentHostOTelExporterTypeSettingId),
@@ -87,7 +89,14 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 			captureContent: this._configurationService.getValue<boolean>(AgentHostOTelCaptureContentSettingId),
 			outfile: this._configurationService.getValue<string>(AgentHostOTelOutfileSettingId),
 			dbSpanExporterEnabled: this._configurationService.getValue<boolean>(AgentHostOTelDbSpanExporterEnabledSettingId),
-		}, process.env);
+		}, process.env, {
+			enabled: policyValue<boolean>(AgentHostOTelEnabledSettingId),
+			exporterType: policyValue<string>(AgentHostOTelExporterTypeSettingId),
+			otlpEndpoint: policyValue<string>(AgentHostOTelOtlpEndpointSettingId),
+			captureContent: policyValue<boolean>(AgentHostOTelCaptureContentSettingId),
+			outfile: policyValue<string>(AgentHostOTelOutfileSettingId),
+			dbSpanExporterEnabled: policyValue<boolean>(AgentHostOTelDbSpanExporterEnabledSettingId),
+		});
 
 		const args = [
 			'--logsPath', this._environmentMainService.logsHome.with({ scheme: Schemas.file }).fsPath,

--- a/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
@@ -88,7 +88,9 @@ export class NodeAgentHostStarter extends Disposable implements IAgentHostStarte
 
 		// Translate `chat.agentHost.otel.*` settings into the env vars consumed by
 		// the agent host process. Any value already present on `process.env` wins
-		// (developer override) — see `buildAgentHostOTelEnv`.
+		// for user settings, while enterprise policy values win over inherited env —
+		// see `buildAgentHostOTelEnv`.
+		const policyValue = <T>(key: string): T | undefined => this._configurationService.inspect<T>(key).policyValue;
 		const otelEnv = buildAgentHostOTelEnv({
 			enabled: this._configurationService.getValue<boolean>(AgentHostOTelEnabledSettingId),
 			exporterType: this._configurationService.getValue<string>(AgentHostOTelExporterTypeSettingId),
@@ -96,7 +98,14 @@ export class NodeAgentHostStarter extends Disposable implements IAgentHostStarte
 			captureContent: this._configurationService.getValue<boolean>(AgentHostOTelCaptureContentSettingId),
 			outfile: this._configurationService.getValue<string>(AgentHostOTelOutfileSettingId),
 			dbSpanExporterEnabled: this._configurationService.getValue<boolean>(AgentHostOTelDbSpanExporterEnabledSettingId),
-		}, process.env);
+		}, process.env, {
+			enabled: policyValue<boolean>(AgentHostOTelEnabledSettingId),
+			exporterType: policyValue<string>(AgentHostOTelExporterTypeSettingId),
+			otlpEndpoint: policyValue<string>(AgentHostOTelOtlpEndpointSettingId),
+			captureContent: policyValue<boolean>(AgentHostOTelCaptureContentSettingId),
+			outfile: policyValue<string>(AgentHostOTelOutfileSettingId),
+			dbSpanExporterEnabled: policyValue<boolean>(AgentHostOTelDbSpanExporterEnabledSettingId),
+		});
 		Object.assign(env, otelEnv);
 
 		// Forward WebSocket server configuration to the child process via env vars

--- a/src/vs/platform/agentHost/test/node/otel/agentHostOTelService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/otel/agentHostOTelService.integrationTest.ts
@@ -20,7 +20,7 @@ import {
 } from '../../../../otel/node/otlp/otlpJsonTypes.js';
 import { IAgentHostOTelService } from '../../../common/otel/agentHostOTelService.js';
 import { AgentHostOTelService, readAgentHostOTelEnv } from '../../../node/otel/agentHostOTelService.js';
-import { AgentHostOTelSpansDbSubPath } from '../../../common/agentService.js';
+import { AgentHostOTelEnvVars, AgentHostOTelSpansDbSubPath, buildAgentHostOTelEnv } from '../../../common/agentService.js';
 
 interface IPostResponse {
 	statusCode: number;
@@ -164,6 +164,35 @@ suite('platform/agentHost - AgentHostOTelService (integration)', () => {
 			OTEL_EXPORTER_OTLP_HEADERS: 'authorization=Bearer xyz,x-tenant=acme',
 		});
 		deepStrictEqual(cfg.headers, { authorization: 'Bearer xyz', 'x-tenant': 'acme' });
+	});
+
+	test('buildAgentHostOTelEnv: policy endpoint wins over inherited file exporter env', () => {
+		deepStrictEqual(buildAgentHostOTelEnv({}, {
+			[AgentHostOTelEnvVars.Enabled]: 'true',
+			[AgentHostOTelEnvVars.FilePath]: '/tmp/otel.jsonl',
+		}, {
+			otlpEndpoint: 'https://collector.example.com',
+		}), {
+			[AgentHostOTelEnvVars.OtlpEndpoint]: 'https://collector.example.com',
+			[AgentHostOTelEnvVars.FilePath]: '',
+		});
+	});
+
+	test('buildAgentHostOTelEnv: policy disabled clears inherited OTel enablement signals', () => {
+		deepStrictEqual(buildAgentHostOTelEnv({}, {
+			[AgentHostOTelEnvVars.Enabled]: 'true',
+			[AgentHostOTelEnvVars.OtlpEndpoint]: 'https://env.example.com',
+			[AgentHostOTelEnvVars.FilePath]: '/tmp/otel.jsonl',
+			[AgentHostOTelEnvVars.DbSpanExporterEnabled]: 'true',
+		}, {
+			enabled: false,
+		}), {
+			[AgentHostOTelEnvVars.Enabled]: 'false',
+			[AgentHostOTelEnvVars.OtlpEndpoint]: '',
+			[AgentHostOTelEnvVars.OtlpEndpointAlt]: '',
+			[AgentHostOTelEnvVars.FilePath]: '',
+			[AgentHostOTelEnvVars.DbSpanExporterEnabled]: 'false',
+		});
 	});
 
 	test('getSdkTelemetryConfig: returns undefined when fully disabled', async () => {

--- a/src/vs/platform/policy/common/copilotManagedSettings.ts
+++ b/src/vs/platform/policy/common/copilotManagedSettings.ts
@@ -34,6 +34,24 @@ export const COPILOT_EXTRA_MARKETPLACES_KEY = 'extraKnownMarketplaces';
 /** Managed-settings key for the strict-marketplace allowlist (carried as a JSON-encoded array of source entries; absent = no restrictions, `[]` = lockdown). */
 export const COPILOT_STRICT_MARKETPLACES_KEY = 'strictKnownMarketplaces';
 
+/** Managed-settings key for enterprise OTel enablement. */
+export const COPILOT_OTEL_ENABLED_KEY = 'telemetry.enabled';
+
+/** Managed-settings key for the enterprise OTLP collector endpoint. */
+export const COPILOT_OTEL_ENDPOINT_KEY = 'telemetry.endpoint';
+
+/** Managed-settings key for the enterprise OTLP protocol (`grpc`, `http/protobuf`, or `http/json`). */
+export const COPILOT_OTEL_PROTOCOL_KEY = 'telemetry.protocol';
+
+/** Managed-settings key for enterprise OTel content capture. */
+export const COPILOT_OTEL_CAPTURE_CONTENT_KEY = 'telemetry.captureContent';
+
+/** Managed-settings key that prevents users from enabling OTel content capture themselves. */
+export const COPILOT_OTEL_LOCK_CAPTURE_CONTENT_KEY = 'telemetry.lockCaptureContent';
+
+/** Managed-settings key for enterprise OTel local DB span export enablement. */
+export const COPILOT_OTEL_DB_SPAN_EXPORTER_ENABLED_KEY = 'telemetry.dbSpanExporter.enabled';
+
 const managedSettingValueCallbacks = new Map<string, (policyData: IPolicyData) => ManagedSettingValue | undefined>();
 
 /**

--- a/src/vs/workbench/services/accounts/browser/managedSettings.ts
+++ b/src/vs/workbench/services/accounts/browser/managedSettings.ts
@@ -31,6 +31,16 @@ export interface IManagedSettingsResponse {
 		| { readonly source: 'git'; readonly url: string; readonly ref?: string };
 	}>;
 	readonly strictKnownMarketplaces?: readonly IStrictMarketplaceSource[];
+	readonly telemetry?: {
+		readonly enabled?: boolean;
+		readonly endpoint?: string;
+		readonly protocol?: 'grpc' | 'http/protobuf' | 'http/json';
+		readonly captureContent?: boolean;
+		readonly lockCaptureContent?: boolean;
+		readonly dbSpanExporter?: {
+			readonly enabled?: boolean;
+		};
+	};
 	/** Any unknown keys in the response are accepted for forward compatibility. */
 	readonly [key: string]: unknown;
 }

--- a/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
@@ -112,6 +112,28 @@ suite('adaptManagedSettings', () => {
 		});
 	});
 
+	test('flattens telemetry scalar settings into dot-path managed settings', () => {
+		assert.deepStrictEqual(adaptManagedSettings({
+			telemetry: {
+				enabled: true,
+				endpoint: 'https://collector.example.com:4318',
+				protocol: 'http/protobuf',
+				captureContent: false,
+				lockCaptureContent: true,
+				dbSpanExporter: { enabled: false },
+			},
+		}), {
+			managedSettings: {
+				'telemetry.enabled': true,
+				'telemetry.endpoint': 'https://collector.example.com:4318',
+				'telemetry.protocol': 'http/protobuf',
+				'telemetry.captureContent': false,
+				'telemetry.lockCaptureContent': true,
+				'telemetry.dbSpanExporter.enabled': false,
+			},
+		});
+	});
+
 	test('resilience: unknown scalar keys flatten into the bag alongside structured keys', () => {
 		assert.deepStrictEqual(adaptManagedSettings({
 			enabledPlugins: { 'p@m': true },


### PR DESCRIPTION
Adds enterprise managed-settings policies for OpenTelemetry, covering both VS Code OTel surfaces without introducing a new settings namespace.

## What
- `chat.agentHost.otel.*` settings own the OTel policies; the Copilot extension's `github.copilot.chat.otel.*` settings reference them via `policyReference` (same pattern as `Claude3PIntegration`).
- Managed-settings keys, aligned with the CLI/control-plane `telemetry` schema: `telemetry.enabled`, `telemetry.endpoint`, `telemetry.protocol`, `telemetry.captureContent`, `telemetry.lockCaptureContent`.
- Enterprise policy values take precedence over env vars and user settings. A managed endpoint/protocol suppresses file-exporter diversion so telemetry can't be redirected to a local file.

## Notes
- Server delivery of the `telemetry` block is tracked separately (github/agent-control-plane#658, github/copilot-agent-runtime#10735); until that ships, validate via the mock policy server or native MDM.
- `headers` / `resourceAttributes` / `serviceName` from the shared schema are not enforced in VS Code yet (follow-up).

## Test
- Unit/integration: managed-settings adapter, OTel config precedence, agent-host env fanout, policy export catalog.