### PR TITLE
build(oss): retry CG notice generation and widen platform poll budget

### DIFF
--- a/build/azure-pipelines/common/downloadNotice.ts
+++ b/build/azure-pipelines/common/downloadNotice.ts
@@ -44,9 +44,13 @@ const QUALITY_JOB_NAMES = ['Quality Checks', 'Quality'];
 const SHIPPING_NOTICE_NAME = 'ThirdPartyNotices.new.txt';
 const TARGET_NOTICE = path.resolve('ThirdPartyNotices.txt');
 
-// Poll budget: 20 attempts x 30s = 10 minutes. Deliberately far below the
+// Poll budget: 30 attempts x 30s = 15 minutes. Deliberately far below the
 // copilot 30min so a never-produced artifact degrades to fallback quickly, but
 // with generous margin over the parallel Quality stage (CG + scan + merge).
+// Green builds accept by attempt ~10; the extra headroom over the old 20 covers
+// a slow Quality stage (CG retries / succeededWithIssues runs take up to ~256s)
+// so a fast-compiling platform doesn't exhaust the budget and ship the legacy
+// notice while its peers ship the CG notice (observed on outage build 450982).
 // The gate accepts only once ThirdPartyNotices.new.txt has been downloaded,
 // extracted, and validated non-empty (>1KB) -- merely seeing it in the
 // container listing is NOT sufficient, because the listing entry can appear
@@ -58,7 +62,7 @@ const TARGET_NOTICE = path.resolve('ThirdPartyNotices.txt');
 // NB: this is the OUTER artifact-availability poll. It is unrelated to the
 // inner retry() wrapper in retry.ts, which independently retries each AZDO API
 // call up to 10 times for transient network errors and emits no attempt log.
-const POLL_ATTEMPTS = 20;
+const POLL_ATTEMPTS = 30;
 const POLL_INTERVAL_MS = 30_000;
 
 function log(message: string): void {

--- a/build/azure-pipelines/common/downloadNotice.ts
+++ b/build/azure-pipelines/common/downloadNotice.ts
@@ -47,10 +47,6 @@ const TARGET_NOTICE = path.resolve('ThirdPartyNotices.txt');
 // Poll budget: 30 attempts x 30s = 15 minutes. Deliberately far below the
 // copilot 30min so a never-produced artifact degrades to fallback quickly, but
 // with generous margin over the parallel Quality stage (CG + scan + merge).
-// Green builds accept by attempt ~10; the extra headroom over the old 20 covers
-// a slow Quality stage (CG retries / succeededWithIssues runs take up to ~256s)
-// so a fast-compiling platform doesn't exhaust the budget and ship the legacy
-// notice while its peers ship the CG notice (observed on outage build 450982).
 // The gate accepts only once ThirdPartyNotices.new.txt has been downloaded,
 // extracted, and validated non-empty (>1KB) -- merely seeing it in the
 // container listing is NOT sufficient, because the listing entry can appear

--- a/build/azure-pipelines/product-quality-checks.yml
+++ b/build/azure-pipelines/product-quality-checks.yml
@@ -148,10 +148,6 @@ jobs:
         displayName: "Generate ThirdPartyNotices (CG)"
         inputs:
           outputfile: $(Build.SourcesDirectory)/ThirdPartyNotices.generated.txt
-        # Retry a hard CG failure before degrading to the cached-NOTICE fallback.
-        # CG succeeds in ~15-30s, so retries add negligible wall-clock and only
-        # fire on a non-zero exit (soft "exit 0 but empty" failures are caught by
-        # the >1KB check below, not here).
         retryCountOnTaskFailure: 3
         continueOnError: true
 

--- a/build/azure-pipelines/product-quality-checks.yml
+++ b/build/azure-pipelines/product-quality-checks.yml
@@ -148,6 +148,11 @@ jobs:
         displayName: "Generate ThirdPartyNotices (CG)"
         inputs:
           outputfile: $(Build.SourcesDirectory)/ThirdPartyNotices.generated.txt
+        # Retry a hard CG failure before degrading to the cached-NOTICE fallback.
+        # CG succeeds in ~15-30s, so retries add negligible wall-clock and only
+        # fire on a non-zero exit (soft "exit 0 but empty" failures are caught by
+        # the >1KB check below, not here).
+        retryCountOnTaskFailure: 3
         continueOnError: true
 
       # =========================================================================


### PR DESCRIPTION
🤖 AI Assisted PR

Two small hardening changes to the CG-based ThirdPartyNotices pipeline:

1. **Retry CG generation** — add `retryCountOnTaskFailure: 3` to the `notice@0` step in `product-quality-checks.yml`. A transient hard failure now retries in place before degrading to the cached-NOTICE fallback. CG succeeds in ~15–30s, so retries add negligible wall-clock and only fire on a non-zero exit. (Soft "exit 0 but empty output" failures are still caught by the existing >1KB check, not by this retry.)

2. **Widen platform poll budget** — bump `POLL_ATTEMPTS` 20 → 30 in `downloadNotice.ts` (10 → 15 min). Green builds accept the NOTICE artifact by attempt ~10, but during a real CG outage a slow Quality stage pushed platform polling to ~19–20, and one platform exhausted the budget and shipped the legacy notice while its peers shipped the CG notice (build 450982). The extra headroom prevents that cross-arch mismatch. No cost on healthy builds — they still exit early.