### PR TITLE
fix tunnel host icon off center

### DIFF
--- a/src/vs/workbench/contrib/chat/electron-browser/media/tunnelHost.css
+++ b/src/vs/workbench/contrib/chat/electron-browser/media/tunnelHost.css
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.tunnel-host-toggle {
+.monaco-action-bar .action-item.tunnel-host-toggle {
 	display: flex;
 	align-items: center;
 	justify-content: center;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fix tunnel-host-toggle centering

before:
<img width="509" height="151" alt="Screenshot 2026-06-26 at 10 29 26 AM" src="https://github.com/user-attachments/assets/909b14dd-08c7-4082-963e-484ee2944041" />

after:
<img width="542" height="156" alt="Screenshot 2026-06-26 at 10 28 51 AM" src="https://github.com/user-attachments/assets/01bdf025-da2d-4e29-8bfc-3abfd205b7da" />

