### PR TITLE
Model picker: Restricted Mode takes precedence over live agent-host/BYOK models

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
@@ -420,12 +420,18 @@ export const enum ModelPickerUnavailableReason {
  * - models registered for other surfaces such as agent-host session-scoped models
  *   (live in the global registry but not offered by this picker).
  *
- * A live, picker-offered model (e.g. BYOK) always wins, so BYOK and anonymous
- * access are never shown an unavailable state. `trusted` reflects
- * `isWorkspaceTrusted()` (which is `true` when trust is disabled entirely) and is
- * only authoritative once `trustInitialized` is `true`; until then this returns
- * `undefined` to avoid a trusted workspace briefly rendering as unavailable at
- * startup. Restricted (untrusted) takes precedence over setup-required.
+ * Restricted Mode takes precedence over everything: an untrusted workspace is
+ * always reported as Restricted, even when a live picker-offered model exists,
+ * because Restricted Mode disables all model providers. This matters because a
+ * harness's session-scoped models (e.g. `claude-code`, `copilotcli`) register
+ * without a trust gate and stay live while untrusted, which would otherwise mask
+ * the Restricted state behind a misleading "Auto". In a *trusted* workspace, a
+ * live, picker-offered model (e.g. BYOK) wins over setup, so BYOK and anonymous
+ * access are never shown a setup-required state regardless of sign-in. `trusted`
+ * reflects `isWorkspaceTrusted()` (which is `true` when trust is disabled
+ * entirely) and is only authoritative once `trustInitialized` is `true`; until
+ * then this returns `undefined` to avoid a trusted workspace briefly rendering as
+ * unavailable at startup.
  */
 export function getModelPickerUnavailableReason(context: {
 	readonly trustInitialized: boolean;
@@ -437,12 +443,17 @@ export function getModelPickerUnavailableReason(context: {
 	if (!context.trustInitialized) {
 		return undefined;
 	}
+	// Restricted Mode wins over a live picker-offered model: an untrusted
+	// workspace disables every model provider, including BYOK and the harness
+	// session-scoped models that register without a trust gate. Checked before
+	// the live-model short-circuit below so untrusted always reports Restricted
+	// rather than falling back to a misleading "Auto".
+	if (!context.trusted) {
+		return ModelPickerUnavailableReason.Restricted;
+	}
 	const live = context.liveModelIds instanceof Set ? context.liveModelIds : new Set(context.liveModelIds);
 	if (context.pickerModels.some(model => live.has(model.identifier))) {
 		return undefined;
-	}
-	if (!context.trusted) {
-		return ModelPickerUnavailableReason.Restricted;
 	}
 	if (context.requiresSetup) {
 		return ModelPickerUnavailableReason.SetupRequired;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
@@ -420,10 +420,9 @@ export const enum ModelPickerUnavailableReason {
  * - models registered for other surfaces such as agent-host session-scoped models
  *   (live in the global registry but not offered by this picker).
  *
- * Restricted Mode takes precedence over everything: an untrusted workspace is
- * always reported as Restricted, even when a live picker-offered model exists,
- * because Restricted Mode disables all model providers. This matters because a
- * harness's session-scoped models (e.g. `claude-code`, `copilotcli`) register
+	 * Once trust has initialized, Restricted Mode takes precedence: an untrusted workspace is
+	 * reported as Restricted even when a live picker-offered model exists, because Restricted Mode disables all model providers. This matters because a
+	 * harness's session-scoped models (e.g. `claude-code`, `copilotcli`) register
  * without a trust gate and stay live while untrusted, which would otherwise mask
  * the Restricted state behind a misleading "Auto". In a *trusted* workspace, a
  * live, picker-offered model (e.g. BYOK) wins over setup, so BYOK and anonymous

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
@@ -443,11 +443,7 @@ export function getModelPickerUnavailableReason(context: {
 	if (!context.trustInitialized) {
 		return undefined;
 	}
-	// Restricted Mode wins over a live picker-offered model: an untrusted
-	// workspace disables every model provider, including BYOK and the harness
-	// session-scoped models that register without a trust gate. Checked before
-	// the live-model short-circuit below so untrusted always reports Restricted
-	// rather than falling back to a misleading "Auto".
+	// In Restricted Mode, report Restricted before considering live models.
 	if (!context.trusted) {
 		return ModelPickerUnavailableReason.Restricted;
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionLogic.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionLogic.test.ts
@@ -1817,12 +1817,16 @@ suite('ChatModelSelectionLogic', () => {
 			assert.strictEqual(reason({ trustInitialized: false, trusted: false, requiresSetup: true }), undefined);
 		});
 
-		test('a live, picker-offered model wins over any unavailable state (e.g. BYOK)', () => {
-			assert.strictEqual(reason({ trusted: false, requiresSetup: true, pickerModels: [gpt], liveModelIds: [gpt.identifier] }), undefined);
+		test('a live, picker-offered model wins over setup-required when trusted (e.g. BYOK)', () => {
+			assert.strictEqual(reason({ trusted: true, requiresSetup: true, pickerModels: [gpt], liveModelIds: [gpt.identifier] }), undefined);
 		});
 
-		test('stale cached models that are not live do not mask the unavailable state', () => {
-			assert.strictEqual(reason({ trusted: false, pickerModels: [gpt], liveModelIds: [] }), ModelPickerUnavailableReason.Restricted);
+		test('Restricted Mode disables even a live, picker-offered model (e.g. BYOK)', () => {
+			assert.strictEqual(reason({ trusted: false, requiresSetup: true, pickerModels: [gpt], liveModelIds: [gpt.identifier] }), ModelPickerUnavailableReason.Restricted);
+		});
+
+		test('cached models that are not live do not mask an unavailable state', () => {
+			assert.strictEqual(reason({ trusted: true, requiresSetup: true, pickerModels: [gpt], liveModelIds: [] }), ModelPickerUnavailableReason.SetupRequired);
 		});
 
 		test('models live for another surface but not offered by this picker do not mask the unavailable state', () => {
@@ -1834,7 +1838,7 @@ suite('ChatModelSelectionLogic', () => {
 		});
 
 		test('accepts a Set of live ids', () => {
-			assert.strictEqual(reason({ trusted: false, requiresSetup: true, pickerModels: [gpt], liveModelIds: new Set([gpt.identifier]) }), undefined);
+			assert.strictEqual(reason({ trusted: true, requiresSetup: true, pickerModels: [gpt], liveModelIds: new Set([gpt.identifier]) }), undefined);
 		});
 	});
 });


### PR DESCRIPTION
## What

<img width="273" height="91" alt="Screenshot 2026-06-26 at 10 51 49 AM" src="https://github.com/user-attachments/assets/920de3eb-f720-4f13-8702-cf91aa935a51" />


In an untrusted (**Restricted Mode**) workspace, the Agent Host model picker (Copilot CLI / Claude) loaded models and showed **"Auto"**, instead of the **"Pick Model" + Trust Workspace** affordance that the Local harness correctly shows.

Specifically addresses https://github.com/microsoft/vscode/issues/322564#issuecomment-4811816607.

## Why

The agent-host harnesses (`claude-code`, `copilotcli`) register their session-scoped models **without a workspace-trust gate** (`claudeCodeModels.ts`, `copilotCli.ts`), so those models stay live in Restricted Mode. `getModelPickerUnavailableReason` treated any live, picker-offered model as usable and returned "available", masking the Restricted state. General-purpose models are withheld while untrusted, which is why the Local harness behaved correctly.

## Fix

`getModelPickerUnavailableReason` now reports `Restricted` for an untrusted workspace **before** the "a live picker-offered model wins" check. A single change fixes every picker that routes through this function (chat editor input + sessions config bar).

Per design discussion, **Restricted Mode disables all models, including BYOK.** BYOK continues to work in a **trusted** workspace regardless of sign-in state, because the live-model check still runs (and beats setup-required) when trusted.

## Tests

Updated the `getModelPickerUnavailableReason` suite and added an explicit _"Restricted Mode disables even a live BYOK model"_ case.

- `ChatModelSelectionLogic`: 155 passing
- `buildModelPickerItems`: 77 passing

Relates to #322794, #322564.
