### PR TITLE
chat: require double tildes for strikethrough

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentMarkdownRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentMarkdownRenderer.ts
@@ -8,6 +8,7 @@ import { IRenderedMarkdown, MarkdownRenderOptions } from '../../../../../base/br
 import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { type MarkedExtension } from '../../../../../base/common/marked/marked.js';
 import { IMarkdownRenderer, IMarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
 import { ILanguageService } from '../../../../../editor/common/languages/language.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -22,6 +23,19 @@ const _remoteImageDisallowed = () => false;
 const nonPlainTextMarkdownSyntax = /[\\`*_[\]<>|&$~]/;
 const gfmAutolink = /\b(?:https?:\/\/|www\.)/i;
 const blockMarkdownSyntax = /(^|\n)\s{0,3}(?:#{1,6}\s|>\s?|[-+]\s|\d+[.)]\s|---+\s*$)/;
+
+const literalSingleTildeExtension: MarkedExtension = {
+	extensions: [{
+		name: 'literalSingleTilde',
+		level: 'inline',
+		tokenizer: source => {
+			if (source[0] === '~' && source[1] !== '~') {
+				return { type: 'text', raw: '~', text: '~' };
+			}
+			return undefined;
+		},
+	}]
+};
 
 function renderPlainTextMarkdown(markdown: IMarkdownString, outElement?: HTMLElement): IRenderedMarkdown | undefined {
 	const value = markdown.value;
@@ -83,6 +97,9 @@ export const allowedChatMarkdownHtmlTags = Object.freeze([
 export function getChatMarkdownRenderOptions(options?: MarkdownRenderOptions): MarkdownRenderOptions {
 	return {
 		...options,
+		markedExtensions: options?.markedExtensions?.includes(literalSingleTildeExtension)
+			? options.markedExtensions
+			: [...(options?.markedExtensions ?? []), literalSingleTildeExtension],
 		sanitizerConfig: {
 			replaceWithPlaintext: true,
 			allowedTags: {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentMarkdownRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentMarkdownRenderer.ts
@@ -20,8 +20,9 @@ import { AGENT_HOST_SCHEME } from '../../../../../platform/agentHost/common/agen
 
 const _remoteImageDisallowed = () => false;
 
-const nonPlainTextMarkdownSyntax = /[\\`*_[\]<>|&$~]/;
+const nonPlainTextMarkdownSyntax = /[\\`*_[\]<>|&$]/;
 const gfmAutolink = /\b(?:https?:\/\/|www\.)/i;
+const gfmStrikethrough = /~~/;
 const blockMarkdownSyntax = /(^|\n)\s{0,3}(?:#{1,6}\s|>\s?|[-+]\s|\d+[.)]\s|---+\s*$)/;
 
 const literalSingleTildeExtension: MarkedExtension = {
@@ -39,7 +40,7 @@ const literalSingleTildeExtension: MarkedExtension = {
 
 function renderPlainTextMarkdown(markdown: IMarkdownString, outElement?: HTMLElement): IRenderedMarkdown | undefined {
 	const value = markdown.value;
-	if (!value || value.includes('\n') || nonPlainTextMarkdownSyntax.test(value) || gfmAutolink.test(value) || blockMarkdownSyntax.test(value)) {
+	if (!value || value.includes('\n') || nonPlainTextMarkdownSyntax.test(value) || gfmAutolink.test(value) || gfmStrikethrough.test(value) || blockMarkdownSyntax.test(value)) {
 		return undefined;
 	}
 

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatMarkdownRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatMarkdownRenderer.test.ts
@@ -53,6 +53,19 @@ suite('ChatMarkdownRenderer', () => {
 		});
 	});
 
+	test('only renders strikethrough with double tildes', () => {
+		const md = new MarkdownString('Keep ~single tildes~ but strike ~~double tildes~~.');
+		const result = store.add(testRenderer.render(md, { markedOptions: { gfm: true } }));
+
+		assert.deepStrictEqual({
+			outerHTML: result.element.outerHTML,
+			textContent: result.element.textContent,
+		}, {
+			outerHTML: '<div class="rendered-markdown"><p>Keep ~single tildes~ but strike <del>double tildes</del>.</p></div>',
+			textContent: 'Keep ~single tildes~ but strike double tildes.',
+		});
+	});
+
 	test('supportHtml with one-line markdown', async () => {
 		const md = new MarkdownString('**hello**');
 		md.supportHtml = true;

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatMarkdownRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatMarkdownRenderer.test.ts
@@ -25,16 +25,16 @@ suite('ChatMarkdownRenderer', () => {
 		await assertSnapshot(result.element.textContent);
 	});
 
-	test('plain text fast path preserves rendered markdown shape', () => {
-		const md = new MarkdownString('Hello, world. This is plain.', { isTrusted: true, supportHtml: true, supportThemeIcons: true });
+	test('plain text fast path preserves rendered markdown shape and single tildes', () => {
+		const md = new MarkdownString('Hello, ~world~. This is plain.', { isTrusted: true, supportHtml: true, supportThemeIcons: true });
 		const result = store.add(testRenderer.render(md));
 
 		assert.deepStrictEqual({
 			outerHTML: result.element.outerHTML,
 			textContent: result.element.textContent,
 		}, {
-			outerHTML: '<div class="rendered-markdown"><p>Hello, world. This is plain.</p></div>',
-			textContent: 'Hello, world. This is plain.',
+			outerHTML: '<div class="rendered-markdown"><p>Hello, ~world~. This is plain.</p></div>',
+			textContent: 'Hello, ~world~. This is plain.',
 		});
 	});
 


### PR DESCRIPTION
## Summary

- treat single tildes in chat Markdown as literal text
- preserve GFM strikethrough for double tildes
- compose the override with existing Marked extensions and add regression coverage

## Testing

- `npm run typecheck-client`
- `npm run precommit`
- `scripts/test.sh --runGlob '**/chatMarkdownRenderer.test.js'` (16 passing)

Fixes #323198

(Written by Copilot)