### PR TITLE
Model picker: clearer Restricted Mode copy and suppress search

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/modelPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/modelPicker.ts
@@ -160,8 +160,8 @@ export class ModelPicker extends Disposable {
 		// Re-evaluate when workspace trust changes (or finishes initializing): an
 		// untrusted workspace disables the model providers, and the shared widget
 		// then renders its Restricted Mode state. Visibility is recomputed so the
-		// picker stays visible to surface "Pick Model" + the Trust action instead
-		// of hiding as an empty picker.
+		// picker stays visible to surface the "Models" placeholder + the Trust
+		// action instead of hiding as an empty picker.
 		this._register(this._workspaceTrustManagementService.onDidChangeTrust(() => this._initModel()));
 		this._workspaceTrustManagementService.workspaceTrustInitialized.then(() => {
 			if (!this._store.isDisposed) {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker.ts
@@ -975,7 +975,7 @@ registerAction2(class extends Action2 {
 				group: 'navigation',
 				// `OpenModelPickerAction` (the "Auto" model picker) is at order 3
 				// in the same menu — sit just before it so the mode pill renders
-				// to the left of "Pick Model".
+				// to the left of the model picker.
 				order: 2,
 				// Hide the agent mode picker while a delegation (continue in) target is pending.
 				when: ContextKeyExpr.and(ChatContextKeyExprs.isAgentHostSession, ChatContextKeys.hasPendingDelegationTarget.negate()),

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -80,7 +80,7 @@ const ModelPickerSection = {
 } as const;
 
 /**
- * Id of the synthetic "Trust Workspace..." entry shown in Restricted Mode. It is
+ * Id of the synthetic "Trust Workspace to enable models..." entry shown in Restricted Mode. It is
  * a command (not a selectable model), so the accessibility provider gives it a
  * plain `menuitem` role instead of `menuitemradio`.
  */
@@ -473,8 +473,9 @@ function createManageModelsAction(commandService: ICommandService): IActionWidge
  * 4. Optional "Manage Models..." action shown in Other Models after a separator
  *
  * When `restrictedMode` is set (untrusted workspace), an explanatory "Models
- * Unavailable in Restricted Mode" header and a "Trust Workspace..." action
- * (invoking `onRequestTrust`) replace all of the above. Likewise, when
+ * unavailable while in Restricted mode" header and a "Trust Workspace to enable
+ * models..." action (invoking `onRequestTrust`) replace all of the above.
+ * Likewise, when
  * `setupRequired` is set (trusted, but Chat still needs sign-in / setup), a
  * "Sign in to use Copilot" header and a Sign In action (invoking
  * `onRequestSetup`) replace all of the above. `restrictedMode` takes precedence.
@@ -515,7 +516,7 @@ export function buildModelPickerItems(
 		// non-empty.
 		items.push({
 			kind: ActionListItemKind.Header,
-			label: localize('chat.modelPicker.restrictedMode', "Models Unavailable in Restricted Mode"),
+			label: localize('chat.modelPicker.restrictedMode', "Models unavailable while in Restricted mode"),
 		});
 		items.push({
 			item: {
@@ -523,12 +524,12 @@ export function buildModelPickerItems(
 				enabled: !!onRequestTrust,
 				checked: false,
 				class: undefined,
-				tooltip: localize('chat.modelPicker.restrictedMode.trustTooltip', "Trust the workspace to enable AI models."),
-				label: localize('chat.modelPicker.restrictedMode.trust', "Trust Workspace..."),
+				tooltip: localize('chat.modelPicker.restrictedMode.trustTooltip', "Trust the workspace to enable models."),
+				label: localize('chat.modelPicker.restrictedMode.trust', "Trust Workspace to enable models..."),
 				run: () => onRequestTrust?.()
 			},
 			kind: ActionListItemKind.Action,
-			label: localize('chat.modelPicker.restrictedMode.trust', "Trust Workspace..."),
+			label: localize('chat.modelPicker.restrictedMode.trust', "Trust Workspace to enable models..."),
 			group: { title: '', icon: ThemeIcon.fromId(Codicon.workspaceTrusted.id) },
 			disabled: !onRequestTrust,
 			hideIcon: false,
@@ -1387,9 +1388,14 @@ export class ModelPickerWidget extends Disposable {
 			}
 		}
 
+		// Hide the filter in the unavailable states (Restricted Mode / setup
+		// required): the only entries are the explanatory header and the Trust /
+		// Sign In action, so a search field would just let users filter through
+		// stale, unusable models. Shown otherwise (it also hosts the secondary
+		// heading).
+		const unavailable = this.isRestrictedMode() || this.isSetupRequired();
 		const listOptions = {
-			// Always show the filter to allow for the secondary heading to show
-			showFilter: true,
+			showFilter: !unavailable,
 			filterPlaceholder: localize('chat.modelPicker.search', "Search models"),
 			filterActions: !isUBB && manageModelsAction ? [manageModelsAction] : undefined,
 			focusFilterOnOpen: true,
@@ -1466,13 +1472,13 @@ export class ModelPickerWidget extends Disposable {
 
 		const { name, statusIcon } = this._selectedModel?.metadata || {};
 
-		// Untrusted workspace: present a normal "Pick Model" placeholder (no badge)
+		// Untrusted workspace: present a normal "Models" placeholder (no badge)
 		// rather than a dead-end label; the hover and dropdown carry the Restricted
 		// Mode explanation and the Trust Workspace action.
 		const restrictedMode = this.isRestrictedMode();
 
 		// Trusted, but Chat still needs sign-in / setup before any model is
-		// usable: present the same "Pick Model" placeholder, with the dropdown
+		// usable: present the same "Models" placeholder, with the dropdown
 		// carrying a Sign In action instead of a misleading "Auto".
 		const setupRequired = this.isSetupRequired();
 		const unavailable = restrictedMode || setupRequired;
@@ -1495,7 +1501,7 @@ export class ModelPickerWidget extends Disposable {
 			nameChildren.push(renderIcon(statusIcon));
 		}
 		const modelLabel = unavailable
-			? localize('chat.modelPicker.label', "Pick Model")
+			? localize('chat.modelPicker.modelsLabel', "Models")
 			: activating
 				? localize('chat.modelPicker.activating', "Activating...")
 				: genericNoModels
@@ -1551,7 +1557,7 @@ export class ModelPickerWidget extends Disposable {
 
 		// Aria
 		this._domNode.ariaLabel = restrictedMode
-			? localize('chat.modelPicker.ariaLabelRestricted', "Pick Model, models are unavailable in Restricted Mode")
+			? localize('chat.modelPicker.ariaLabelRestricted', "Pick Model, models unavailable while in Restricted mode")
 			: setupRequired
 				? localize('chat.modelPicker.ariaLabelSetupRequired', "Pick Model, sign in to use Copilot")
 				: localize('chat.modelPicker.ariaLabel', "Pick Model, {0}", fullLabel);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -1555,12 +1555,13 @@ export class ModelPickerWidget extends Disposable {
 			}
 		}
 
-		// Aria
+		// Aria — name the control "Models" to match the visible label; the comma
+		// separates the control name from its current value / state.
 		this._domNode.ariaLabel = restrictedMode
-			? localize('chat.modelPicker.ariaLabelRestricted', "Pick Model, models unavailable while in Restricted mode")
+			? localize('chat.modelPicker.ariaLabelRestricted', "Models, unavailable while in Restricted mode")
 			: setupRequired
-				? localize('chat.modelPicker.ariaLabelSetupRequired', "Pick Model, sign in to use Copilot")
-				: localize('chat.modelPicker.ariaLabel', "Pick Model, {0}", fullLabel);
+				? localize('chat.modelPicker.ariaLabelSetupRequired', "Models, sign in to use Copilot")
+				: localize('chat.modelPicker.ariaLabel', "Models, {0}", fullLabel);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
@@ -397,7 +397,7 @@ export function resolveConfiguredModel(
 
 /**
  * Why a model picker has no model to offer, when that is the case. Drives a
- * "Pick Model" placeholder plus a contextual action instead of a misleading
+ * "Models" placeholder plus a contextual action instead of a misleading
  * lone "Auto".
  */
 export const enum ModelPickerUnavailableReason {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
@@ -126,7 +126,7 @@ export class ModelPickerActionItem extends BaseActionViewItem {
 	/**
 	 * Whether the picker has no usable model because the workspace is untrusted
 	 * (Restricted Mode). Lets a host (e.g. the sessions picker) keep the picker
-	 * visible to surface the "Pick Model" placeholder and Trust Workspace action
+	 * visible to surface the "Models" placeholder and Trust Workspace action
 	 * instead of hiding it as an empty/no-model picker.
 	 */
 	public isRestrictedMode(): boolean {
@@ -136,7 +136,7 @@ export class ModelPickerActionItem extends BaseActionViewItem {
 	/**
 	 * Whether the picker has no usable model because Chat still needs sign-in /
 	 * setup. Like {@link isRestrictedMode}, lets a host keep the picker visible to
-	 * surface the "Pick Model" placeholder and Sign In action.
+	 * surface the "Models" placeholder and Sign In action.
 	 */
 	public isSetupRequired(): boolean {
 		return this._pickerWidget.isSetupRequired();
@@ -169,7 +169,7 @@ export class ModelPickerActionItem extends BaseActionViewItem {
 			label += ` (${keybindingLabel})`;
 		}
 		if (this._pickerWidget.isRestrictedMode()) {
-			return localize('chat.modelPicker.restrictedHover', "{0} • Models are unavailable in Restricted Mode. Trust the workspace to choose a model.", label);
+			return localize('chat.modelPicker.restrictedHover', "{0} • Models unavailable while in Restricted mode. Trust Workspace to enable models.", label);
 		}
 		if (this._pickerWidget.isSetupRequired()) {
 			return localize('chat.modelPicker.setupRequiredHover', "{0} • Sign in to GitHub Copilot to choose a model.", label);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
@@ -163,13 +163,17 @@ export class ModelPickerActionItem extends BaseActionViewItem {
 	}
 
 	private _getHoverContents(): IManagedHoverContent {
-		let label = localize('chat.modelPicker.label', "Pick Model");
+		// Keep the hover prefix in sync with the picker's visible "Models" label
+		// (the same localization key) so the hover doesn't read "Pick Model • …".
+		let label = localize('chat.modelPicker.modelsLabel', "Models");
 		const keybindingLabel = this.keybindingService.lookupKeybinding(this._action.id, this._contextKeyService)?.getLabel();
 		if (keybindingLabel) {
 			label += ` (${keybindingLabel})`;
 		}
 		if (this._pickerWidget.isRestrictedMode()) {
-			return localize('chat.modelPicker.restrictedHover', "{0} • Models unavailable while in Restricted mode. Trust Workspace to enable models.", label);
+			// Suffix avoids a leading "Models" so the hover doesn't stutter as
+			// "Models • Models unavailable…" once the prefix is "Models".
+			return localize('chat.modelPicker.restrictedHover', "{0} • Unavailable while in Restricted mode. Trust Workspace to enable models.", label);
 		}
 		if (this._pickerWidget.isSetupRequired()) {
 			return localize('chat.modelPicker.setupRequiredHover', "{0} • Sign in to GitHub Copilot to choose a model.", label);

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
@@ -266,7 +266,7 @@ suite('buildModelPickerItems', () => {
 		const items = callBuild([], { restrictedMode: true, onRequestTrust: () => { } });
 		const actions = getActionItems(items);
 		// The explanation is a non-interactive header; only Trust is selectable.
-		assert.ok(items.some(i => i.kind === ActionListItemKind.Header && i.label === 'Models Unavailable in Restricted Mode'));
+		assert.ok(items.some(i => i.kind === ActionListItemKind.Header && i.label === 'Models unavailable while in Restricted mode'));
 		assert.strictEqual(actions.length, 1);
 		assert.strictEqual(actions[0].item?.id, 'restrictedModeTrust');
 		assert.strictEqual(actions[0].item?.enabled, true);


### PR DESCRIPTION
UX follow-up to #323183: clearer Restricted Mode model picker copy, and suppress the search field in the unavailable states (nothing to search there).

<img width="318" height="117" alt="Screenshot 2026-06-26 at 12 59 58 PM" src="https://github.com/user-attachments/assets/dafbe064-7e78-49d8-b38c-4d0d7ee56af9" />


- Button: "Pick Model" → **"Models"**
- Header: → **"Models unavailable while in Restricted mode"**
- Trust action: → **"Trust Workspace to enable models..."**
- Hide the dropdown search filter while Restricted / setup-required

Addresses feedback from https://vscodeteam.slack.com/archives/C1C2M1KEZ/p1782496657211199

Relates to #322564.
