### PR TITLE
sessions: preserve new session drafts when switching

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -217,6 +217,13 @@ when one exists or showing the empty placeholder otherwise. Internal callers
 (restore fallback, archive, background reseed, and the close-session fallback)
 invoke `openNewSession()` the same way.
 
+The new-session input separately persists its text and attachments in
+workspace-scoped machine storage. `NewChatWidget` saves that draft when it is
+disposed (for example, when navigating to an existing session), and the
+replacement widget restores it when the user returns to the new-session view.
+Starting a send clears the stored draft before request dispatch and any view
+replacement.
+
 `sendNewChatRequest(session, options)` accepts a `background` flag: a background
 new-session send returns the agents window to a fresh new-session view (via
 `openNewSession`) **before** creating and sending the session, and skips the

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -112,7 +112,7 @@ export class NewChatWidget extends Disposable {
 			return session?.loading.read(reader) ?? false;
 		});
 
-		this._newChatInput = this._register(this.instantiationService.createInstance(NewChatInputWidget, {
+		const newChatInput = this.instantiationService.createInstance(NewChatInputWidget, {
 			session: this._session,
 			getContextFolderUri: () => this._getContextFolderUri(),
 			sendRequest: async ({ query, attachments, background }) => this._send(query, attachments, background),
@@ -121,8 +121,9 @@ export class NewChatWidget extends Disposable {
 			historyKey: constObservable(undefined), // no persisted history for the new-session view
 			renderSessionTypePickerInControls: this._renderHarnessPickerInControls,
 			supportsBackground: true,
-		}));
-		this._register(toDisposable(() => this._newChatInput.saveState()));
+		});
+		this._register(toDisposable(() => newChatInput.saveState()));
+		this._newChatInput = this._register(newChatInput);
 
 		this._register(this._workspacePicker.onDidSelectWorkspace(async folderUri => {
 			await this._onWorkspaceSelected(folderUri);

--- a/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatWidget.ts
@@ -5,7 +5,7 @@
 
 import './media/chatWidget.css';
 import * as dom from '../../../../base/browser/dom.js';
-import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { constObservable, derived, derivedObservableWithCache, IObservable, observableSignalFromEvent } from '../../../../base/common/observable.js';
 import { isWeb } from '../../../../base/common/platform.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -122,6 +122,7 @@ export class NewChatWidget extends Disposable {
 			renderSessionTypePickerInControls: this._renderHarnessPickerInControls,
 			supportsBackground: true,
 		}));
+		this._register(toDisposable(() => this._newChatInput.saveState()));
 
 		this._register(this._workspacePicker.onDidSelectWorkspace(async folderUri => {
 			await this._onWorkspaceSelected(folderUri);


### PR DESCRIPTION
Fix #323209

## Summary

- Preserve new-session composer text and attachments when navigating to an existing session and back.
- Restore the disposal-time draft save hook lost during the Sessions Grid refactor.
- Document the new-session draft lifecycle.

## Validation

- `npm run typecheck-client`
- `npm run valid-layers-check`
- `npm run precommit`
- `./scripts/test.sh --run src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts` (30 passing, 2 pending)

(Written by Copilot)