### PR TITLE
fix rounded separator in action widget

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -83,8 +83,8 @@
 	border-top: 1px solid var(--vscode-editorHoverWidget-border);
 	color: var(--vscode-descriptionForeground);
 	font-size: 12px;
-	margin: 4px 0px;
-	width: 100%;
+	margin: 4px 6px;
+	width: calc(100% - 12px);
 	cursor: default;
 	-webkit-user-select: none;
 	user-select: none;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

before:
<img width="338" height="536" alt="Screenshot 2026-06-26 at 11 50 38 AM" src="https://github.com/user-attachments/assets/e05c5911-c429-4cde-bb98-7ef8d39dc981" />


after
<img width="244" height="214" alt="Screenshot 2026-06-26 at 6 24 34 PM" src="https://github.com/user-attachments/assets/c53bf845-4a5a-4910-91b1-35fd8648761c" />

and i feel like i need to clarify that guzzlord IS a pokemon....
<img width="400" height="400" alt="799-Guzzlord" src="https://github.com/user-attachments/assets/8fb34efb-03a7-4031-8d0a-bd01e2ec0526" />
