### PR TITLE
BYOK: discover models for customendpoint from /models (#319968)

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -2040,8 +2040,16 @@
               "title": "API Type",
               "markdownDescription": "Default request/response format for models in this group. Individual models can override this with their own `apiType` property; when both are unset the type is inferred from the URL path."
             },
+            "url": {
+              "type": "string",
+              "pattern": "^https?://.+",
+              "patternErrorMessage": "URL must start with http:// or https://",
+              "title": "Discovery URL",
+              "markdownDescription": "Base URL of an OpenAI-compatible provider. When set, models are auto-discovered from its `/models` endpoint; `models` below refine them."
+            },
             "models": {
               "type": "array",
+              "markdownDescription": "Models for this provider. Required without a discovery `url`; otherwise they override discovered models and act as a fallback.",
               "defaultSnippets": [
                 {
                   "label": "New Model",

--- a/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { l10n, window } from 'vscode';
 import { IChatMLFetcher } from '../../../platform/chat/common/chatMLFetcher';
 import { IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { IDomainService } from '../../../platform/endpoint/common/domainService';
@@ -13,7 +14,7 @@ import { IChatWebSocketManager } from '../../../platform/networking/node/chatWeb
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { ITokenizerProvider } from '../../../platform/tokenizer/node/tokenizer';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
-import { resolveModelInfo } from '../common/byokProvider';
+import { BYOKModelCapabilities, resolveModelInfo } from '../common/byokProvider';
 import { OpenAIEndpoint } from '../node/openAIEndpoint';
 import { AbstractOpenAICompatibleLMProvider, LanguageModelChatConfiguration, OpenAICompatibleLanguageModelChatInformation } from './abstractLanguageModelChatProvider';
 import { byokKnownModelToAPIInfoWithEffort } from './byokModelInfo';
@@ -80,6 +81,90 @@ function apiTypeToSupportedEndpoints(apiType: CustomEndpointApiType): ModelSuppo
 	}
 }
 
+/** Defaults used for discovered models whose endpoint does not advertise token limits. */
+export const CUSTOM_ENDPOINT_DEFAULT_MAX_INPUT_TOKENS = 128000;
+export const CUSTOM_ENDPOINT_DEFAULT_MAX_OUTPUT_TOKENS = 16000;
+
+/**
+ * Shape of a single entry in an OpenAI-compatible `/models` (or `/v1/models`)
+ * response. Plain OpenAI only returns `id` (plus a little metadata); richer
+ * providers such as OpenRouter or vLLM add a context window and capability
+ * hints. Everything beyond `id` is optional and must be read defensively.
+ */
+interface OpenAICompatibleModelEntry {
+	id?: string;
+	name?: string;
+	display_name?: string;
+	context_length?: number;          // OpenRouter and many OpenAI-compatible servers
+	max_model_len?: number;           // vLLM
+	top_provider?: { context_length?: number; max_completion_tokens?: number };
+	architecture?: { input_modalities?: string[] };
+	supported_parameters?: string[];
+}
+
+function asPositiveNumber(value: unknown): number | undefined {
+	return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+/**
+ * Maps one OpenAI-compatible `/models` entry to {@link BYOKModelCapabilities}.
+ *
+ * Capabilities are rarely advertised (plain OpenAI `/v1/models` returns only the
+ * id), so we apply sensible defaults — tool calling ON (agent mode needs it),
+ * vision OFF — and override them only when the payload advertises the relevant
+ * fields (`supported_parameters`, `architecture.input_modalities`, a context
+ * window). Returns `undefined` for entries without a usable id so the caller
+ * skips them. Never throws on missing/oddly-typed fields.
+ */
+export function resolveCustomEndpointModelCapabilities(modelData: unknown): BYOKModelCapabilities | undefined {
+	const model = modelData as OpenAICompatibleModelEntry | null | undefined;
+	if (!model || typeof model.id !== 'string' || model.id.length === 0) {
+		return undefined;
+	}
+	const id = model.id;
+
+	const params = Array.isArray(model.supported_parameters) ? model.supported_parameters : undefined;
+	const architecture = model.architecture;
+	const inputModalities = architecture && Array.isArray(architecture.input_modalities) ? architecture.input_modalities : undefined;
+
+	const contextLength = asPositiveNumber(model.top_provider?.context_length) ?? asPositiveNumber(model.context_length) ?? asPositiveNumber(model.max_model_len);
+	const explicitOutput = asPositiveNumber(model.top_provider?.max_completion_tokens);
+
+	let maxInputTokens = CUSTOM_ENDPOINT_DEFAULT_MAX_INPUT_TOKENS;
+	let maxOutputTokens = explicitOutput ?? CUSTOM_ENDPOINT_DEFAULT_MAX_OUTPUT_TOKENS;
+	if (contextLength) {
+		// Reserve an output budget from the context window without letting it consume the whole window.
+		maxOutputTokens = Math.min(explicitOutput ?? CUSTOM_ENDPOINT_DEFAULT_MAX_OUTPUT_TOKENS, Math.max(Math.floor(contextLength / 4), 1));
+		maxInputTokens = Math.max(contextLength - maxOutputTokens, 1);
+	}
+
+	const name = typeof model.name === 'string' ? model.name : (typeof model.display_name === 'string' ? model.display_name : id);
+	// When the endpoint advertises its supported parameters we trust them; otherwise tool calling defaults ON.
+	const toolCalling = params ? params.includes('tools') : true;
+	const vision = inputModalities ? inputModalities.includes('image') : false;
+	const supportsReasoningEffort = params && (params.includes('reasoning') || params.includes('reasoning_effort'))
+		? ['low', 'medium', 'high']
+		: undefined;
+
+	return { name, toolCalling, vision, maxInputTokens, maxOutputTokens, supportsReasoningEffort };
+}
+
+/**
+ * Merges discovered models with manually-configured ones. Manual entries win on
+ * `id` collisions (so users can correct the capabilities of a discovered model),
+ * and manual-only entries are appended.
+ */
+export function mergeModelsById<T extends { id: string }>(discovered: readonly T[], manual: readonly T[]): T[] {
+	const byId = new Map<string, T>();
+	for (const model of discovered) {
+		byId.set(model.id, model);
+	}
+	for (const model of manual) {
+		byId.set(model.id, model);
+	}
+	return Array.from(byId.values());
+}
+
 export interface CustomEndpointModelProviderConfig extends LanguageModelChatConfiguration {
 	url?: string;
 	apiType?: CustomEndpointApiType;
@@ -132,10 +217,41 @@ export class CustomEndpointBYOKModelProvider extends AbstractOpenAICompatibleLMP
 		return;
 	}
 
+	private readonly _warnedDiscoveryUrls = new Set<string>();
+
+	protected override resolveModelCapabilities(modelData: unknown): BYOKModelCapabilities | undefined {
+		return resolveCustomEndpointModelCapabilities(modelData);
+	}
+
 	protected override async getAllModels(silent: boolean, apiKey: string | undefined, configuration: CustomEndpointModelProviderConfig | undefined): Promise<OpenAICompatibleLanguageModelChatInformation<CustomEndpointModelProviderConfig>[]> {
-		if (configuration?.url) {
-			return super.getAllModels(silent, apiKey, configuration);
+		const manualModels = this.getManualModels(configuration);
+
+		// Model discovery is opt-in: a group-level `url` points at an
+		// OpenAI-compatible `/models` endpoint. Without it we only have the
+		// manually-configured list.
+		if (!configuration?.url) {
+			return manualModels;
 		}
+
+		let discoveredModels: OpenAICompatibleLanguageModelChatInformation<CustomEndpointModelProviderConfig>[];
+		try {
+			discoveredModels = await super.getAllModels(silent, apiKey, configuration);
+		} catch (error) {
+			// Graceful degradation: keep the manually-configured models as a
+			// fallback and surface the failure once (unless this is a silent
+			// background refresh).
+			this._logService.error(error, `[CustomEndpoint] Model discovery failed for ${configuration.url}`);
+			if (!silent) {
+				this.notifyDiscoveryFailed(configuration.url, error);
+			}
+			return manualModels;
+		}
+
+		// Manual entries override or extend the discovered list (matched by id).
+		return mergeModelsById(discoveredModels, manualModels);
+	}
+
+	private getManualModels(configuration: CustomEndpointModelProviderConfig | undefined): OpenAICompatibleLanguageModelChatInformation<CustomEndpointModelProviderConfig>[] {
 		const models: OpenAICompatibleLanguageModelChatInformation<CustomEndpointModelProviderConfig>[] = [];
 		if (Array.isArray(configuration?.models)) {
 			for (const modelConfig of configuration.models) {
@@ -146,6 +262,24 @@ export class CustomEndpointBYOKModelProvider extends AbstractOpenAICompatibleLMP
 			}
 		}
 		return models;
+	}
+
+	/**
+	 * Shows a single non-blocking warning per discovery URL so repeated
+	 * model-picker refreshes don't spam the user. Overridable for testing.
+	 */
+	protected notifyDiscoveryFailed(url: string, error: unknown): void {
+		if (this._warnedDiscoveryUrls.has(url)) {
+			return;
+		}
+		this._warnedDiscoveryUrls.add(url);
+		const reason = error instanceof Error ? error.message : String(error);
+		this.showDiscoveryWarning(l10n.t('Custom endpoint model discovery from {0} failed: {1}. Falling back to manually configured models.', url, reason));
+	}
+
+	/** Surfaces the (already deduped) discovery-failure warning. Separated so tests can observe it without the vscode UI. */
+	protected showDiscoveryWarning(message: string): void {
+		void window.showWarningMessage(message);
 	}
 
 	protected override async createOpenAIEndPoint(model: OpenAICompatibleLanguageModelChatInformation<CustomEndpointModelProviderConfig>): Promise<OpenAIEndpoint> {

--- a/extensions/copilot/src/extension/byok/vscode-node/test/customEndpointProvider.spec.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/test/customEndpointProvider.spec.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Raw } from '@vscode/prompt-tsx';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CancellationTokenSource } from 'vscode';
 import { BlockedExtensionService, IBlockedExtensionService } from '../../../../platform/chat/common/blockedExtensionService';
 import { ChatLocation } from '../../../../platform/chat/common/commonTypes';
 import { IChatModelInformation, ModelSupportedEndpoint } from '../../../../platform/endpoint/common/endpointProvider';
@@ -14,7 +15,7 @@ import { DisposableStore } from '../../../../util/vs/base/common/lifecycle';
 import { SyncDescriptor } from '../../../../util/vs/platform/instantiation/common/descriptors';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { createExtensionUnitTestingServices } from '../../../test/node/services';
-import { CustomEndpointOAIEndpoint, hasExplicitApiPath, resolveCustomEndpointUrl } from '../customEndpointProvider';
+import { CUSTOM_ENDPOINT_DEFAULT_MAX_INPUT_TOKENS, CUSTOM_ENDPOINT_DEFAULT_MAX_OUTPUT_TOKENS, CustomEndpointBYOKModelProvider, CustomEndpointOAIEndpoint, hasExplicitApiPath, mergeModelsById, resolveCustomEndpointModelCapabilities, resolveCustomEndpointUrl } from '../customEndpointProvider';
 
 describe('CustomEndpointBYOKModelProvider', () => {
 	const disposables = new DisposableStore();
@@ -578,5 +579,232 @@ describe('CustomEndpointBYOKModelProvider', () => {
 			expect(messages[0].reasoning).toBe('I should read the README before answering.');
 			expect(messages[0].cot_summary).toBe('I should read the README before answering.');
 		});
+	});
+});
+
+describe('resolveCustomEndpointModelCapabilities', () => {
+	it('applies defaults (tools ON, vision OFF) for a minimal OpenAI entry', () => {
+		expect(resolveCustomEndpointModelCapabilities({ id: 'gpt-4o' })).toEqual({
+			name: 'gpt-4o',
+			toolCalling: true,
+			vision: false,
+			maxInputTokens: CUSTOM_ENDPOINT_DEFAULT_MAX_INPUT_TOKENS,
+			maxOutputTokens: CUSTOM_ENDPOINT_DEFAULT_MAX_OUTPUT_TOKENS,
+			supportsReasoningEffort: undefined,
+		});
+	});
+
+	it('parses OpenRouter-style rich fields (tools, vision, reasoning, context window)', () => {
+		const caps = resolveCustomEndpointModelCapabilities({
+			id: 'anthropic/claude-sonnet-4',
+			name: 'Claude Sonnet 4',
+			supported_parameters: ['tools', 'reasoning'],
+			architecture: { input_modalities: ['text', 'image'] },
+			top_provider: { context_length: 200000 },
+		});
+		expect(caps).toEqual({
+			name: 'Claude Sonnet 4',
+			toolCalling: true,
+			vision: true,
+			maxInputTokens: 184000,
+			maxOutputTokens: 16000,
+			supportsReasoningEffort: ['low', 'medium', 'high'],
+		});
+	});
+
+	it('trusts advertised supported_parameters: absence of `tools` means tool calling OFF', () => {
+		const caps = resolveCustomEndpointModelCapabilities({ id: 'm', supported_parameters: ['temperature'] });
+		expect(caps?.toolCalling).toBe(false);
+	});
+
+	it('derives a token split from a vLLM max_model_len', () => {
+		const caps = resolveCustomEndpointModelCapabilities({ id: 'm', max_model_len: 32768 });
+		expect(caps?.maxOutputTokens).toBe(8192);
+		expect(caps?.maxInputTokens).toBe(24576);
+	});
+
+	it('honors an explicit max_completion_tokens cap', () => {
+		const caps = resolveCustomEndpointModelCapabilities({ id: 'm', top_provider: { context_length: 100000, max_completion_tokens: 4096 } });
+		expect(caps?.maxOutputTokens).toBe(4096);
+		expect(caps?.maxInputTokens).toBe(95904);
+	});
+
+	it('keeps input tokens positive for a tiny context window', () => {
+		const caps = resolveCustomEndpointModelCapabilities({ id: 'm', context_length: 1000 });
+		expect(caps?.maxOutputTokens).toBe(250);
+		expect(caps?.maxInputTokens).toBe(750);
+	});
+
+	it('falls back to id for the name, and reads display_name when present', () => {
+		expect(resolveCustomEndpointModelCapabilities({ id: 'm' })?.name).toBe('m');
+		expect(resolveCustomEndpointModelCapabilities({ id: 'm', display_name: 'My Model' })?.name).toBe('My Model');
+	});
+
+	it('returns undefined for entries without a usable id', () => {
+		expect(resolveCustomEndpointModelCapabilities({})).toBeUndefined();
+		expect(resolveCustomEndpointModelCapabilities({ id: 123 })).toBeUndefined();
+		expect(resolveCustomEndpointModelCapabilities(null)).toBeUndefined();
+		expect(resolveCustomEndpointModelCapabilities(undefined)).toBeUndefined();
+	});
+});
+
+describe('mergeModelsById', () => {
+	it('lets manual entries override discovered ones by id and appends manual-only entries', () => {
+		const discovered = [{ id: 'a', src: 'd' }, { id: 'b', src: 'd' }];
+		const manual = [{ id: 'b', src: 'm' }, { id: 'c', src: 'm' }];
+		expect(mergeModelsById(discovered, manual)).toEqual([
+			{ id: 'a', src: 'd' },
+			{ id: 'b', src: 'm' },
+			{ id: 'c', src: 'm' },
+		]);
+	});
+
+	it('returns the discovered list unchanged when there are no manual entries', () => {
+		expect(mergeModelsById([{ id: 'a' }], [])).toEqual([{ id: 'a' }]);
+	});
+});
+
+describe('CustomEndpointBYOKModelProvider model discovery', () => {
+	const token = new CancellationTokenSource().token;
+
+	class TestableCustomEndpointProvider extends CustomEndpointBYOKModelProvider {
+		public readonly warnings: string[] = [];
+		protected override showDiscoveryWarning(message: string): void {
+			this.warnings.push(message);
+		}
+	}
+
+	function createLogServiceMock() {
+		const logService: any = {
+			_serviceBrand: undefined,
+			trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), show: vi.fn(),
+			createSubLogger: vi.fn(), withExtraTarget: vi.fn(),
+		};
+		logService.createSubLogger.mockReturnValue(logService);
+		logService.withExtraTarget.mockReturnValue(logService);
+		return logService;
+	}
+
+	function createProvider(fetch: (url: string, options: unknown) => Promise<unknown>): TestableCustomEndpointProvider {
+		const storage = {
+			getAPIKey: vi.fn().mockResolvedValue(undefined),
+			storeAPIKey: vi.fn().mockResolvedValue(undefined),
+			deleteAPIKey: vi.fn().mockResolvedValue(undefined),
+		};
+		return new TestableCustomEndpointProvider(
+			storage as any,
+			createLogServiceMock(),
+			{ fetch } as any,
+			{ createInstance: vi.fn().mockReturnValue({}) } as any,
+			{ isConfigured: vi.fn().mockReturnValue(false), getConfig: vi.fn(), setConfig: vi.fn() } as any,
+			{} as any,
+		);
+	}
+
+	function jsonResponse(body: unknown) {
+		return { json: async () => body };
+	}
+
+	it('discovers models from the configured /models endpoint with default capabilities', async () => {
+		const fetch = vi.fn(async (url: string) => {
+			expect(url).toBe('https://api.example.com/models');
+			return jsonResponse({ data: [{ id: 'model-a' }, { id: 'model-b' }] });
+		});
+		const provider = createProvider(fetch);
+
+		const models = await provider.provideLanguageModelChatInformation(
+			{ silent: true, configuration: { url: 'https://api.example.com', apiKey: 'k' } },
+			token,
+		);
+
+		expect(models.map(m => m.id)).toEqual(['model-a', 'model-b']);
+		expect(models[0].capabilities).toMatchObject({ toolCalling: true, imageInput: false });
+		expect(models[0].maxInputTokens).toBe(CUSTOM_ENDPOINT_DEFAULT_MAX_INPUT_TOKENS);
+		expect(models[0].maxOutputTokens).toBe(CUSTOM_ENDPOINT_DEFAULT_MAX_OUTPUT_TOKENS);
+	});
+
+	it('lets a manual entry override a discovered model and appends manual-only models', async () => {
+		const fetch = vi.fn(async () => jsonResponse({ data: [{ id: 'model-a' }, { id: 'model-b' }] }));
+		const provider = createProvider(fetch);
+
+		const models = await provider.provideLanguageModelChatInformation(
+			{
+				silent: true,
+				configuration: {
+					url: 'https://api.example.com',
+					apiKey: 'k',
+					models: [
+						{ id: 'model-a', name: 'Overridden A', url: 'https://api.example.com/v1', toolCalling: true, vision: true, maxInputTokens: 1000, maxOutputTokens: 100 },
+						{ id: 'model-c', name: 'Manual C', url: 'https://api.example.com/v1', toolCalling: false, vision: false, maxInputTokens: 2000, maxOutputTokens: 200 },
+					],
+				},
+			},
+			token,
+		);
+
+		const byId = new Map(models.map(m => [m.id, m]));
+		expect([...byId.keys()].sort()).toEqual(['model-a', 'model-b', 'model-c']);
+		// manual override wins for model-a
+		expect(byId.get('model-a')!.name).toBe('Overridden A');
+		expect(byId.get('model-a')!.capabilities).toMatchObject({ imageInput: true });
+		expect(byId.get('model-a')!.maxInputTokens).toBe(1000);
+		// discovered default remains for model-b
+		expect(byId.get('model-b')!.capabilities).toMatchObject({ imageInput: false });
+		// manual-only model-c is appended
+		expect(byId.get('model-c')!.name).toBe('Manual C');
+	});
+
+	it('falls back to manual models and warns once when discovery fails (non-silent)', async () => {
+		const fetch = vi.fn(async () => { throw new Error('boom'); });
+		const provider = createProvider(fetch);
+		const configuration = {
+			url: 'https://api.example.com',
+			apiKey: 'k',
+			models: [
+				{ id: 'fallback', name: 'Fallback', url: 'https://api.example.com/v1', toolCalling: true, vision: false, maxInputTokens: 1000, maxOutputTokens: 100 },
+			],
+		};
+
+		const first = await provider.provideLanguageModelChatInformation({ silent: false, configuration }, token);
+		const second = await provider.provideLanguageModelChatInformation({ silent: false, configuration }, token);
+
+		expect(first.map(m => m.id)).toEqual(['fallback']);
+		expect(second.map(m => m.id)).toEqual(['fallback']);
+		// warned once despite two refreshes (dedup by URL), and the message names the endpoint
+		expect(provider.warnings).toHaveLength(1);
+		expect(provider.warnings[0]).toContain('https://api.example.com');
+	});
+
+	it('does not warn on a silent refresh failure', async () => {
+		const fetch = vi.fn(async () => { throw new Error('boom'); });
+		const provider = createProvider(fetch);
+
+		const models = await provider.provideLanguageModelChatInformation(
+			{ silent: true, configuration: { url: 'https://api.example.com', apiKey: 'k', models: [] } },
+			token,
+		);
+
+		expect(models).toEqual([]);
+		expect(provider.warnings).toEqual([]);
+	});
+
+	it('returns only manual models when no discovery url is set', async () => {
+		const fetch = vi.fn(async () => { throw new Error('should not be called'); });
+		const provider = createProvider(fetch);
+
+		const models = await provider.provideLanguageModelChatInformation(
+			{
+				silent: true,
+				configuration: {
+					models: [
+						{ id: 'manual', name: 'Manual', url: 'https://api.example.com/v1', toolCalling: true, vision: false, maxInputTokens: 1000, maxOutputTokens: 100 },
+					],
+				},
+			},
+			token,
+		);
+
+		expect(models.map(m => m.id)).toEqual(['manual']);
+		expect(fetch).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
Fixes #319968

This PR adds model discovery to OpenAI-compatible custom endpoints so that users don't have to specify each model manually in `models[]`. As models can be added and removed in internal LLM gateways, this would be a huge quality-of-life improvement for us. It also makes it easier to onboard developers.

- Implement resolveCustomEndpointModelCapabilities(): map an OpenAI-compatible /models entry to capabilities (sets tool calling on / vision off by default).
- getAllModels(): discover from `url` and merge manual `models[]` over the result by id; fall back to the manual list and warn once on failure.
- Expose a top-level `url` on the customendpoint configuration schema.
