### PR TITLE
sessions: keep peer chats loaded while sending

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
@@ -119,11 +119,11 @@ sidebar list.
 2. Constructs a `NewSession` draft, stores it in `_newSessions`, and fires `onDidChangeSessionConfig`. New-session model/mode selection is seeded by the existing model/agent pickers and sent on the first message.
 3. If a connection exists and authentication is **not** pending, eagerly starts the backend session and resolves its dynamic config in parallel. While auth is pending the draft waits; `_resumeNewSessionAfterAuthenticationSettles` (driven by the `authenticationPending` observable going false) starts the backend for all pending drafts.
 
-`createNewChat(chatId)` creates the chat session model (`IChatSessionsService.getOrCreateChatSession`) so the management service can open the widget, and returns the draft's main chat.
+`createNewChat(chatId)` creates the chat session model (`IChatSessionsService.getOrCreateChatSession`) so the management service can open the widget, and returns the draft's main chat. For a committed multi-chat session, it asks the host to add a peer chat, waits for that chat to surface in the catalog, seeds its input state, and presents it as `Untitled` until its first request is sent.
 
 ## Send Flow
 
-`sendRequest(chatId, chatResource, options)`:
+`sendRequest(chatId, chatResource, options)` for a draft session:
 
 1. Requires the draft and an active connection.
 2. Builds `IChatSendRequestOptions` (agent mode from the selected custom agent or the built-in agent, selected model, attached context, and `agentHostSessionConfig` from `getCreateSessionConfig`).
@@ -131,6 +131,8 @@ sidebar list.
 4. Snapshots existing cache keys, then `IChatService.sendRequest` (which the registered `AgentHostSessionHandler` routes to the backend).
 5. Publishes a skeleton session (title seeded from the first line of the query) via `onDidChangeSessions` as `_pendingSession`.
 6. Waits for the committed backend session (`_waitForNewSession`); on arrival the draft **graduates** (releases its eager subscription without firing `disposeSession`), config is preserved, `_pendingSession` is cleared, and `onDidReplaceSession` fires from skeleton → committed session.
+
+For an already-committed session (including a newly-created peer chat), `sendRequest` loads and holds the target chat model through `IChatService.sendRequest`, applies the cached model/agent input state before dispatch, clears the draft afterwards, then clears the provider-side "new chat" flag so status returns to the host-reported value. Holding the model reference is required for peer chats opened by the lightweight new-chat composer, because no `ChatWidget` owns that model while the first message is dispatched.
 
 Running-chat `setModel` / `setAgent` calls update the active chat's cached selection and the loaded chat model's input state. `AgentHostSessionHandler` debounces `IChatModel.inputModel.state` changes back into `chat/draftChanged`, so text/attachment/model/mode drafts survive reloads and restore from `ChatState.draft` when the chat is re-opened. The agent host persists drafts in the per-session database's `chat_drafts` table, keyed by chat URI.
 

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -38,7 +38,7 @@ import { IWorkspaceTrustManagementService } from '../../../../../platform/worksp
 import { IAgentHostActiveClientService } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.js';
 import { IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { ChatMode } from '../../../../../workbench/contrib/chat/common/chatModes.js';
-import { IChatSendRequestOptions, IChatService } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { IChatSendRequestOptions, IChatService, type IChatModelReference } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatSessionFileChange, IChatSessionFileChange2, IChatSessionsService } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, ChatPermissionLevel, isChatPermissionLevel, type IChatDefaultConfiguration } from '../../../../../workbench/contrib/chat/common/constants.js';
 import { ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService } from '../../../../../workbench/contrib/chat/common/languageModels.js';
@@ -2672,14 +2672,23 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			attachedContext,
 		};
 
-		await this._updateChatSessionState(chatResource, selectedModelId, selectedAgentUri);
-
-		const result = await this._chatService.sendRequest(chatResource, query, sendOptions);
-		if (result.kind === 'rejected') {
-			throw new Error(`[${this.id}] sendRequest rejected: ${result.reason}`);
+		const modelRef = await this._chatService.acquireOrLoadSession(chatResource, ChatAgentLocation.Chat, CancellationToken.None);
+		if (!modelRef) {
+			throw new Error(`[${this.id}] Unable to load chat session ${chatResource.toString()}`);
 		}
 
-		await this._updateChatSessionState(chatResource, selectedModelId, selectedAgentUri, { clearDraft: true });
+		try {
+			this._applyChatSessionState(modelRef, selectedModelId, selectedAgentUri);
+
+			const result = await this._chatService.sendRequest(chatResource, query, sendOptions);
+			if (result.kind === 'rejected') {
+				throw new Error(`[${this.id}] sendRequest rejected: ${result.reason}`);
+			}
+
+			this._applyChatSessionState(modelRef, selectedModelId, selectedAgentUri, { clearDraft: true });
+		} finally {
+			modelRef.dispose();
+		}
 
 		// First request sent: revert to the host-reported status.
 		cached.markChatAsSent(chatResource.fragment);
@@ -2693,23 +2702,27 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			return;
 		}
 		try {
-			const inputModel = modelRef.object.inputModel;
-			if (!inputModel) {
-				return;
-			}
-			if (modelId) {
-				const languageModel = this._languageModelsService.lookupLanguageModel(modelId);
-				if (languageModel) {
-					inputModel.setState({ selectedModel: { identifier: modelId, metadata: languageModel } });
-				}
-			}
-			inputModel.setState({
-				mode: { id: agentUri ?? ChatMode.Agent.id, kind: ChatModeKind.Agent },
-				...(options?.clearDraft ? { inputText: '', attachments: [], selections: [] } : {}),
-			});
+			this._applyChatSessionState(modelRef, modelId, agentUri, options);
 		} finally {
 			modelRef.dispose();
 		}
+	}
+
+	private _applyChatSessionState(modelRef: IChatModelReference, modelId: string | undefined, agentUri: string | undefined, options?: { readonly clearDraft?: boolean }): void {
+		const inputModel = modelRef.object.inputModel;
+		if (!inputModel) {
+			return;
+		}
+		if (modelId) {
+			const languageModel = this._languageModelsService.lookupLanguageModel(modelId);
+			if (languageModel) {
+				inputModel.setState({ selectedModel: { identifier: modelId, metadata: languageModel } });
+			}
+		}
+		inputModel.setState({
+			mode: { id: agentUri ?? ChatMode.Agent.id, kind: ChatModeKind.Agent },
+			...(options?.clearDraft ? { inputText: '', attachments: [], selections: [] } : {}),
+		});
 	}
 
 	private async _sendNewSessionRequest(newSession: NewSession, chatId: string, chatResource: URI, options: ISendRequestOptions): Promise<ISession> {

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -1893,6 +1893,60 @@ suite('LocalAgentHostSessionsProvider', () => {
 			});
 		});
 
+		test('sendRequest keeps a peer chat model loaded while dispatching', async () => {
+			const loadedResources = new Set<string>();
+			const disposedResources: string[] = [];
+			const sendSawLoaded: boolean[] = [];
+			const provider = createProvider(disposables, agentHost, undefined, {
+				acquireOrLoadSession: async resource => {
+					const resourceKey = resource.toString();
+					loadedResources.add(resourceKey);
+					const inputModel = new class extends mock<IInputModel>() {
+						override readonly state = constObservable<IChatModelInputState | undefined>(undefined);
+						override setState(_state: Partial<IChatModelInputState>): void { }
+						override clearState(): void { }
+						override toJSON(): undefined { return undefined; }
+					}();
+					const chatModel = new class extends mock<IChatModel>() {
+						override readonly inputModel = inputModel;
+					}();
+					return {
+						object: chatModel,
+						dispose() {
+							loadedResources.delete(resourceKey);
+							disposedResources.push(resourceKey);
+						},
+					} satisfies IChatModelReference;
+				},
+				sendRequest: async (resource): Promise<ChatSendResult> => {
+					sendSawLoaded.push(loadedResources.has(resource.toString()));
+					return { kind: 'sent' as const, data: {} as ChatSendResult extends { kind: 'sent'; data: infer D } ? D : never };
+				},
+			});
+			const session = setupMultiChatSession(provider, 'multi-send-peer');
+			const sessionUri = AgentSession.uri('copilotcli', 'multi-send-peer').toString();
+			const defaultChat = buildDefaultChatUri(sessionUri);
+			const peerChat = buildChatUri(sessionUri, 'peer-1');
+			agentHost.setSessionState('multi-send-peer', 'copilotcli', makeState([
+				makeChatSummary(defaultChat, ''),
+				makeChatSummary(peerChat, 'Peer'),
+			], { defaultChat }));
+			const peer = session.chats.get().find(c => c.resource.fragment === 'peer-1');
+			assert.ok(peer);
+
+			await provider.sendRequest(session.sessionId, peer.resource, { query: 'hello' });
+
+			assert.deepStrictEqual({
+				sendSawLoaded,
+				loadedResources: [...loadedResources],
+				disposedResources,
+			}, {
+				sendSawLoaded: [true],
+				loadedResources: [],
+				disposedResources: [peer.resource.toString()],
+			});
+		});
+
 		test('setModel updates the active peer chat model without changing the default chat model', () => {
 			const activeSession = observableValue<IActiveSession | undefined>('test.activeSession', undefined);
 			const provider = createProvider(disposables, agentHost, undefined, { activeSession });


### PR DESCRIPTION
## Summary
- keep agent-host peer chat models loaded while dispatching the first request
- reuse the same input-state application helper before and after sending
- add a regression test for the peer-chat send lifetime
- update the agent-host sessions provider docs for the committed peer-chat send flow

## Validation
- Editor diagnostics for touched TS files: clean
- `git diff --check`: clean
- User manually confirmed the scenario works
- Not run: `npm run typecheck-client`, `npm run valid-layers-check`, focused unit tests (npm/node are not available on PATH in this environment)