### PR TITLE
smoke: write remote server exit diagnostics to a file

### DIFF
--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -5,6 +5,7 @@
 
 import './bootstrap-server.js'; // this MUST come before other imports as it changes global state
 import * as path from 'node:path';
+import * as fs from 'node:fs';
 import * as http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import * as os from 'node:os';
@@ -166,7 +167,10 @@ function sanitizeStringArg(val: unknown): string | undefined {
  * `Unknown reconnection token` reconnection failures). The handlers tell apart a
  * self-exit (`beforeExit`), an external kill (`signal`) and a crash
  * (`uncaughtExceptionMonitor`). Gated behind the `VSCODE_SERVER_EXIT_DIAGNOSTICS`
- * env var (set by the smoke tests) so it adds no product noise.
+ * env var (set by the smoke tests) so it adds no product noise. Lines are
+ * appended synchronously to a `server-exit-diagnostics.log` file in the server's
+ * `--logsPath` directory so they survive process teardown (an async stdio write
+ * from an `exit` handler does not).
  */
 function installServerProcessExitDiagnostics(): void {
 	if (!process.env['VSCODE_SERVER_EXIT_DIAGNOSTICS']) {
@@ -174,12 +178,35 @@ function installServerProcessExitDiagnostics(): void {
 	}
 
 	const startTime = Date.now();
+
+	// Append diagnostics synchronously to a file rather than relying on
+	// `console.error`: a process `exit` handler cannot flush an async pipe write
+	// (the server's stdio is piped through the test resolver, and on Windows
+	// additionally through a `cmd.exe`/batch wrapper) before the process dies,
+	// so the exit-time lines we care about most were being dropped. A synchronous
+	// `fs.appendFileSync` survives teardown. We target the server's `--logsPath`
+	// directory because it is captured as a smoke test artifact.
+	const rawLogsPath: unknown = parsedArgs['logsPath'];
+	const logsPath = typeof rawLogsPath === 'string' ? rawLogsPath : os.tmpdir();
+	const diagnosticsFile = path.join(logsPath, 'server-exit-diagnostics.log');
+	try {
+		fs.mkdirSync(logsPath, { recursive: true });
+	} catch {
+		// best effort: the directory is normally created by the server already
+	}
+
 	const log = (message: string) => {
-		// Use `console.error` so the line survives even if stdout is in a
-		// broken-pipe state. The test resolver forwards the server's stdio into
-		// its own output channel, so this ends up in the captured smoke logs.
+		const line = `[server-exit-diagnostics][${new Date().toISOString()}][pid:${process.pid}][+${Date.now() - startTime}ms] ${message}`;
+		// File write is authoritative and survives process teardown.
 		try {
-			console.error(`[server-exit-diagnostics][${new Date().toISOString()}][pid:${process.pid}][+${Date.now() - startTime}ms] ${message}`);
+			fs.appendFileSync(diagnosticsFile, `${line}\n`);
+		} catch {
+			// ignore logging failures while the process is tearing down
+		}
+		// Also mirror to stderr so the line is visible live in the test
+		// resolver's captured output channel during normal operation.
+		try {
+			console.error(line);
 		} catch {
 			// ignore logging failures while the process is tearing down
 		}

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -186,8 +186,7 @@ function installServerProcessExitDiagnostics(): void {
 	// so the exit-time lines we care about most were being dropped. A synchronous
 	// `fs.appendFileSync` survives teardown. We target the server's `--logsPath`
 	// directory because it is captured as a smoke test artifact.
-	const rawLogsPath: unknown = parsedArgs['logsPath'];
-	const logsPath = typeof rawLogsPath === 'string' ? rawLogsPath : os.tmpdir();
+	const logsPath = sanitizeStringArg(parsedArgs['logsPath']) || os.tmpdir();
 	const diagnosticsFile = path.join(logsPath, 'server-exit-diagnostics.log');
 	try {
 		fs.mkdirSync(logsPath, { recursive: true });

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -167,10 +167,11 @@ function sanitizeStringArg(val: unknown): string | undefined {
  * `Unknown reconnection token` reconnection failures). The handlers tell apart a
  * self-exit (`beforeExit`), an external kill (`signal`) and a crash
  * (`uncaughtExceptionMonitor`). Gated behind the `VSCODE_SERVER_EXIT_DIAGNOSTICS`
- * env var (set by the smoke tests) so it adds no product noise. Lines are
- * appended synchronously to a `server-exit-diagnostics.log` file in the server's
- * `--logsPath` directory so they survive process teardown (an async stdio write
- * from an `exit` handler does not).
+	 * env var (set by the smoke tests) so it adds no product noise. Lines are
+	 * appended synchronously to a `server-exit-diagnostics.log` file in the server's
+	 * `--logsPath` directory (falling back to `os.tmpdir()` when `--logsPath` is not
+	 * provided) so they survive process teardown (an async stdio write from an
+	 * `exit` handler does not).
  */
 function installServerProcessExitDiagnostics(): void {
 	if (!process.env['VSCODE_SERVER_EXIT_DIAGNOSTICS']) {

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -167,11 +167,11 @@ function sanitizeStringArg(val: unknown): string | undefined {
  * `Unknown reconnection token` reconnection failures). The handlers tell apart a
  * self-exit (`beforeExit`), an external kill (`signal`) and a crash
  * (`uncaughtExceptionMonitor`). Gated behind the `VSCODE_SERVER_EXIT_DIAGNOSTICS`
-	 * env var (set by the smoke tests) so it adds no product noise. Lines are
-	 * appended synchronously to a `server-exit-diagnostics.log` file in the server's
-	 * `--logsPath` directory (falling back to `os.tmpdir()` when `--logsPath` is not
-	 * provided) so they survive process teardown (an async stdio write from an
-	 * `exit` handler does not).
+ * env var (set by the smoke tests) so it adds no product noise. Lines are
+ * appended synchronously to a `server-exit-diagnostics.log` file in the server's
+ * `--logsPath` directory (falling back to `os.tmpdir()` when `--logsPath` is not
+ * provided) so they survive process teardown (an async stdio write from an
+ * `exit` handler does not).
  */
 function installServerProcessExitDiagnostics(): void {
 	if (!process.env['VSCODE_SERVER_EXIT_DIAGNOSTICS']) {
@@ -195,18 +195,16 @@ function installServerProcessExitDiagnostics(): void {
 		// best effort: the directory is normally created by the server already
 	}
 
+	// Write only to the file, never to stdout/stderr. The whole point of these
+	// diagnostics is to capture *why* the server's stdio pipe dies, so writing
+	// to that same (potentially broken) pipe is exactly what we must avoid: a
+	// failed `console.error` write throws `EPIPE`, which Node promotes to an
+	// uncaught exception, which re-enters the `uncaughtExceptionMonitor` handler
+	// below — an infinite loop that produced a 386MB log in one CI run.
 	const log = (message: string) => {
 		const line = `[server-exit-diagnostics][${new Date().toISOString()}][pid:${process.pid}][+${Date.now() - startTime}ms] ${message}`;
-		// File write is authoritative and survives process teardown.
 		try {
 			fs.appendFileSync(diagnosticsFile, `${line}\n`);
-		} catch {
-			// ignore logging failures while the process is tearing down
-		}
-		// Also mirror to stderr so the line is visible live in the test
-		// resolver's captured output channel during normal operation.
-		try {
-			console.error(line);
 		} catch {
 			// ignore logging failures while the process is tearing down
 		}
@@ -231,8 +229,21 @@ function installServerProcessExitDiagnostics(): void {
 	// `uncaughtExceptionMonitor` is observational: it runs before the process
 	// crashes but does NOT prevent the default crash, so the real failure mode
 	// is preserved. It also fires for unhandled rejections that get promoted to
-	// uncaught exceptions by Node's default policy.
-	process.on('uncaughtExceptionMonitor', (err, origin) => log(`'uncaughtExceptionMonitor' (origin: ${origin}): ${err?.stack || err}`));
+	// uncaught exceptions by Node's default policy. Guard against re-entrancy:
+	// if logging an exception were to itself throw (and get promoted to another
+	// uncaught exception), we must not recurse into this handler forever.
+	let handlingUncaughtException = false;
+	process.on('uncaughtExceptionMonitor', (err, origin) => {
+		if (handlingUncaughtException) {
+			return;
+		}
+		handlingUncaughtException = true;
+		try {
+			log(`'uncaughtExceptionMonitor' (origin: ${origin}): ${err?.stack || err}`);
+		} finally {
+			handlingUncaughtException = false;
+		}
+	});
 
 	const signals: NodeJS.Signals[] = ['SIGTERM', 'SIGINT', 'SIGHUP', 'SIGBREAK', 'SIGQUIT'];
 	for (const signal of signals) {

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -195,18 +195,39 @@ function installServerProcessExitDiagnostics(): void {
 		// best effort: the directory is normally created by the server already
 	}
 
-	// Write only to the file, never to stdout/stderr. The whole point of these
-	// diagnostics is to capture *why* the server's stdio pipe dies, so writing
-	// to that same (potentially broken) pipe is exactly what we must avoid: a
-	// failed `console.error` write throws `EPIPE`, which Node promotes to an
-	// uncaught exception, which re-enters the `uncaughtExceptionMonitor` handler
-	// below — an infinite loop that produced a 386MB log in one CI run.
+	// The file write is authoritative: it is synchronous (so it survives process
+	// teardown) and goes to a captured smoke artifact. We additionally mirror to
+	// stderr for live visibility in the test resolver's output channel, but that
+	// mirror is dangerous precisely because these diagnostics fire when the
+	// server's stdio pipe is dying: a write to a broken pipe throws `EPIPE`
+	// synchronously and/or emits an async `error` event, either of which Node
+	// promotes to an uncaught exception — which re-enters the
+	// `uncaughtExceptionMonitor` handler below and loops (one CI run produced a
+	// 386MB log this way). We therefore make the mirror best-effort and latch it
+	// off after the first failure, and attach an `error` handler so async pipe
+	// errors are swallowed rather than crashing the process.
+	let mirrorToStderr = true;
+	try {
+		process.stderr.on('error', () => { mirrorToStderr = false; });
+	} catch {
+		mirrorToStderr = false;
+	}
+
 	const log = (message: string) => {
 		const line = `[server-exit-diagnostics][${new Date().toISOString()}][pid:${process.pid}][+${Date.now() - startTime}ms] ${message}`;
 		try {
 			fs.appendFileSync(diagnosticsFile, `${line}\n`);
 		} catch {
 			// ignore logging failures while the process is tearing down
+		}
+		if (mirrorToStderr) {
+			try {
+				process.stderr.write(`${line}\n`);
+			} catch {
+				// Broken pipe during teardown: stop mirroring so we can never
+				// throw (and thus loop) on subsequent diagnostics.
+				mirrorToStderr = false;
+			}
 		}
 	};
 


### PR DESCRIPTION
## Why

Remote smoke tests intermittently fail (notably **Windows / Remote**) when the test-resolver server process exits unexpectedly ~2s after a client connects. Its exit drops the renderer's management socket (`code: 1006`); the reconnect loop re-resolves the authority, which spawns a *fresh* server with a *new* connection token, so the old reconnection token is rejected (`Unknown reconnection token (never seen)`) → permanent failure → the whole suite times out. Build [451044](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=451044) failed this way (Language Features suite, 4 timeouts).

#322697 added opt-in server exit diagnostics to capture *why* the server exits, gated behind `VSCODE_SERVER_EXIT_DIAGNOSTICS` (set only by the smoke runner). But in build 451044 those diagnostics produced **24 `installed` lines and zero `exit` / `beforeExit` / signal lines** — including for the server that demonstrably died. The exit cause was still undiagnosable.

The reason: the diagnostics logged via `console.error` to stderr. On Windows the server's stdio is piped through the test resolver and additionally through a `cmd.exe` / `code-server.bat` wrapper. A process `exit` handler cannot flush an async pipe write before the process dies, so the exit-time lines — the ones we care about most — were dropped.

## What

Within the already env-gated `installServerProcessExitDiagnostics()` in `src/server-main.ts`:

- Write each diagnostic line **synchronously** with `fs.appendFileSync` into a `server-exit-diagnostics.log` file under the server's `--logsPath` directory (which is captured as a smoke-test artifact). A synchronous write completes before teardown, so `exit` / signal / `uncaughtExceptionMonitor` lines survive.
- Still mirror each line to `console.error` for live visibility in the test resolver's output channel during normal operation.

No change to `code-server.bat`/`.sh` or any `vs/server` product code. The function remains gated behind `VSCODE_SERVER_EXIT_DIAGNOSTICS`, so the shipped product is unaffected.

## Validation

- `eslint src/server-main.ts` passes; `npm run typecheck-client` passes; pre-commit hygiene hook passes.
- This is a **draft** to exercise the remote smoke tests in CI and confirm the new `server-exit-diagnostics.log` file appears in the artifact with exit-path lines next time a server exits.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
