### PR TITLE
chat: Hide debug log export for Agent Host sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatOpenAgentDebugPanelAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatOpenAgentDebugPanelAction.ts
@@ -119,7 +119,7 @@ export function registerChatOpenAgentDebugPanelAction() {
 				icon: Codicon.chatExport,
 				f1: true,
 				category: Categories.Developer,
-				precondition: ChatContextKeys.enabled,
+				precondition: ContextKeyExpr.and(ChatContextKeys.enabled, ChatContextKeys.chatIsAgentHostSession.negate()),
 				menu: [{
 					id: MenuId.EditorTitle,
 					group: 'navigation',


### PR DESCRIPTION
## Summary
- hide **Export Agent Debug Log...** while an Agent Host-backed chat session is focused
- keep the command available for regular chat sessions
- avoid confusion with **Export Agent Host Debug Logs...**

## Validation
- `npm run typecheck-client`
- `npm run precommit`
- `npm run valid-layers-check`

(Written by Copilot)