### PR TITLE
agentHost: restore history using user turn boundaries

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -328,6 +328,9 @@ export async function mapSessionEvents(
 				const content = d.content ?? '';
 				const reasoningText = d.reasoningText;
 				const hasToolRequests = !!d.toolRequests && d.toolRequests.length > 0;
+				if (!content && !reasoningText && !hasToolRequests) {
+					break;
+				}
 				const parentToolCallId = resolveParentToolCallId(e.agentId, d.parentToolCallId);
 				// When this is the first event in a turn (no parent builder
 				// yet), seed the builder with the SDK envelope id so the

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -234,22 +234,38 @@ export async function mapSessionEvents(
 	// the most recent turn per subagent is built (subagents currently emit
 	// at most one turn per invocation).
 	const subagentBuilders = new Map<string, ITurnBuilder>();
+	const subagentTurnStates = new Map<string, TurnState>();
 	const subagentTurns = new Map<string, Turn[]>();
 	const subagentInfoByToolCallId = new Map<string, ISubagentInfo>();
 
 	let parentBuilder: ITurnBuilder | undefined;
+	let parentTurnState = TurnState.Cancelled;
+	let parentTurnAborted = false;
+
+	const flushParent = (): void => {
+		if (!parentBuilder) {
+			return;
+		}
+		turns.push(finalizeTurn(parentBuilder, parentTurnState));
+		parentBuilder = undefined;
+		parentTurnState = TurnState.Cancelled;
+		parentTurnAborted = false;
+	};
 
 	const flushSubagent = (parentToolCallId: string): void => {
 		const builder = subagentBuilders.get(parentToolCallId);
 		if (!builder) {
+			subagentTurnStates.delete(parentToolCallId);
 			return;
 		}
 		subagentBuilders.delete(parentToolCallId);
+		const state = subagentTurnStates.get(parentToolCallId) ?? TurnState.Complete;
+		subagentTurnStates.delete(parentToolCallId);
 		if (builder.responseParts.length === 0) {
 			return;
 		}
 		const list = subagentTurns.get(parentToolCallId) ?? [];
-		list.push(finalizeTurn(builder, TurnState.Complete));
+		list.push(finalizeTurn(builder, state));
 		subagentTurns.set(parentToolCallId, list);
 	};
 
@@ -258,6 +274,9 @@ export async function mapSessionEvents(
 		if (!builder) {
 			builder = newTurnBuilder(generateUuid(), '');
 			subagentBuilders.set(parentToolCallId, builder);
+			if (!subagentTurnStates.has(parentToolCallId)) {
+				subagentTurnStates.set(parentToolCallId, TurnState.Complete);
+			}
 		}
 		return builder;
 	};
@@ -314,9 +333,7 @@ export async function mapSessionEvents(
 					// `setTurnEventId` records as `event_id`) so the restored
 					// turn id round-trips back to the SDK boundary id that
 					// fork / truncate RPCs operate on.
-					if (parentBuilder) {
-						turns.push(finalizeTurn(parentBuilder, TurnState.Cancelled));
-					}
+					flushParent();
 					const turnId = e.id ?? messageId;
 					parentBuilder = newTurnBuilder(turnId, content, { attachments, model: currentModel, agent: currentAgent });
 				}
@@ -328,10 +345,13 @@ export async function mapSessionEvents(
 				const content = d.content ?? '';
 				const reasoningText = d.reasoningText;
 				const hasToolRequests = !!d.toolRequests && d.toolRequests.length > 0;
+				const parentToolCallId = resolveParentToolCallId(e.agentId, d.parentToolCallId);
 				if (!content && !reasoningText && !hasToolRequests) {
+					if (!parentToolCallId && parentBuilder && !parentTurnAborted) {
+						parentTurnState = TurnState.Complete;
+					}
 					break;
 				}
-				const parentToolCallId = resolveParentToolCallId(e.agentId, d.parentToolCallId);
 				// When this is the first event in a turn (no parent builder
 				// yet), seed the builder with the SDK envelope id so the
 				// turn id matches `turns.event_id` for fork/truncate
@@ -354,16 +374,11 @@ export async function mapSessionEvents(
 						content,
 					});
 				}
+				if (!parentToolCallId && builder === parentBuilder && !parentTurnAborted) {
+					parentTurnState = hasToolRequests ? TurnState.Cancelled : TurnState.Complete;
+				}
 				if (d.toolRequests?.length) {
 					appendFallbackToolRequests(builder, d.toolRequests, parentToolCallId);
-				}
-				// A parent assistant message without further tool requests
-				// terminates the current parent turn (no more responses
-				// expected). Subagent turns are flushed at the parent's
-				// `tool.execution_complete` instead.
-				if (!parentToolCallId && !hasToolRequests && builder === parentBuilder) {
-					turns.push(finalizeTurn(parentBuilder, TurnState.Complete));
-					parentBuilder = undefined;
 				}
 				break;
 			}
@@ -377,8 +392,10 @@ export async function mapSessionEvents(
 				break;
 			}
 			case 'tool.execution_start': {
-				// Already collected in the first pass; no per-event work
-				// needed here. Hidden tools are filtered above.
+				const parentToolCallId = resolveParentToolCallId(e.agentId, e.data.parentToolCallId);
+				if (!parentToolCallId && parentBuilder) {
+					parentTurnState = TurnState.Cancelled;
+				}
 				break;
 			}
 			case 'tool.execution_complete': {
@@ -403,9 +420,8 @@ export async function mapSessionEvents(
 							content: summary,
 						});
 					}
-					if (!parentToolCallId && d.success && builder === parentBuilder) {
-						turns.push(finalizeTurn(parentBuilder, TurnState.Complete));
-						parentBuilder = undefined;
+					if (!parentToolCallId && d.success && builder === parentBuilder && !parentTurnAborted) {
+						parentTurnState = TurnState.Complete;
 					}
 					continue;
 				}
@@ -425,7 +441,12 @@ export async function mapSessionEvents(
 			}
 			case 'skill.invoked': {
 				const synth = synthesizeSkillToolCall(e.data, e.id);
-				const builder = parentBuilder ?? (parentBuilder = newTurnBuilder(generateUuid(), ''));
+				const parentToolCallId = resolveParentToolCallId(e.agentId, undefined);
+				const builder = targetBuilderFor(parentToolCallId)
+					?? (parentBuilder = newTurnBuilder(generateUuid(), ''));
+				if (!parentToolCallId && builder === parentBuilder) {
+					parentTurnState = TurnState.Cancelled;
+				}
 				builder.responseParts.push({
 					kind: ResponsePartKind.ToolCall,
 					toolCall: {
@@ -441,16 +462,22 @@ export async function mapSessionEvents(
 				});
 				break;
 			}
+			case 'abort': {
+				const parentToolCallId = resolveParentToolCallId(e.agentId, undefined);
+				if (parentToolCallId) {
+					subagentTurnStates.set(parentToolCallId, TurnState.Cancelled);
+				} else if (parentBuilder) {
+					parentTurnState = TurnState.Cancelled;
+					parentTurnAborted = true;
+				}
+				break;
+			}
 			default:
 				break;
 		}
 	}
 
-	// Drain any unfinished turns.
-	if (parentBuilder) {
-		turns.push(finalizeTurn(parentBuilder, TurnState.Cancelled));
-		parentBuilder = undefined;
-	}
+	flushParent();
 	for (const parentToolCallId of [...subagentBuilders.keys()]) {
 		flushSubagent(parentToolCallId);
 	}
@@ -476,6 +503,9 @@ export async function mapSessionEvents(
 						id: generateUuid(),
 						content: summary,
 					});
+				}
+				if (!parentToolCallId && completion?.success && builder === parentBuilder && !parentTurnAborted) {
+					parentTurnState = TurnState.Complete;
 				}
 				continue;
 			}

--- a/src/vs/platform/agentHost/test/node/copilotTestEvents.ts
+++ b/src/vs/platform/agentHost/test/node/copilotTestEvents.ts
@@ -72,6 +72,8 @@ export interface ISessionEventMessage {
 export interface ISessionEventSkillInvoked {
 	type: 'skill.invoked';
 	id?: string;
+	/** Envelope-level sub-agent instance id. */
+	agentId?: string;
 	data: {
 		name: string;
 		path?: string;
@@ -91,6 +93,15 @@ export interface ISessionEventSubagentStarted {
 	};
 }
 
+export interface ISessionEventAbort {
+	type: 'abort';
+	/** Envelope-level sub-agent instance id. */
+	agentId?: string;
+	data: {
+		reason: string;
+	};
+}
+
 /** Minimal event shape for session history mapping. */
 export type ISessionEvent =
 	| ISessionEventToolStart
@@ -98,6 +109,7 @@ export type ISessionEvent =
 	| ISessionEventMessage
 	| ISessionEventSubagentStarted
 	| ISessionEventSkillInvoked
+	| ISessionEventAbort
 	| { type: string; data?: unknown };
 
 /**

--- a/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
@@ -53,6 +53,27 @@ suite('mapSessionEvents — history replay', () => {
 		]);
 	});
 
+	test('fallback task_complete marks the turn complete', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', data: { interactionId: 'm1', content: 'finish the task' } },
+			{ type: 'assistant.message', data: { messageId: 'm2', content: 'All done.', toolRequests: [{ toolCallId: 'tc-1', name: 'task_complete', arguments: { summary: 'Finished.' } }] } },
+			{ type: 'tool.execution_complete', data: { toolCallId: 'tc-1', success: true } },
+		];
+
+		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+
+		assert.deepStrictEqual(turns.map(turn => ({
+			state: turn.state,
+			parts: partKinds(turn.responseParts),
+		})), [{
+			state: TurnState.Complete,
+			parts: [
+				{ kind: ResponsePartKind.Markdown, content: 'All done.' },
+				{ kind: ResponsePartKind.Markdown, content: '\n\n**Task completed:** Finished.' },
+			],
+		}]);
+	});
+
 	test('a regular tool still renders as a tool call', async () => {
 		const events: ISessionEvent[] = [
 			{ type: 'user.message', data: { interactionId: 'm1', content: 'hi' } },
@@ -112,14 +133,91 @@ suite('mapSessionEvents — history replay', () => {
 		});
 	});
 
-	test('ignores empty assistant messages between model rounds', async () => {
+	test('uses top-level user messages as turn boundaries', async () => {
 		const events: ISessionEvent[] = [
-			{ type: 'user.message', id: 'user-event', data: { interactionId: 'interaction-1', content: 'Investigate this issue' } },
-			{ type: 'assistant.message', id: 'tool-round', data: { interactionId: 'interaction-1', content: 'I will investigate.', toolRequests: [{ toolCallId: 'tc-1', name: 'bash' }] } },
+			{ type: 'user.message', id: 'user-event-1', data: { interactionId: 'interaction-1', content: 'Investigate this issue' } },
+			{ type: 'assistant.message', id: 'initial-round', data: { interactionId: 'interaction-1', content: 'I found a likely cause.', toolRequests: [] } },
+			{ type: 'assistant.message', id: 'tool-round', data: { interactionId: 'interaction-2', content: 'I will verify it.', toolRequests: [{ toolCallId: 'tc-1', name: 'bash' }] } },
 			{ type: 'tool.execution_start', data: { toolCallId: 'tc-1', toolName: 'bash', arguments: { command: 'echo investigating' } } },
 			{ type: 'tool.execution_complete', data: { toolCallId: 'tc-1', success: true, result: { content: 'investigating\n' } } },
-			{ type: 'assistant.message', id: 'empty-round', data: { interactionId: 'interaction-1', content: '', toolRequests: [], reasoningOpaque: 'opaque-reasoning' } },
-			{ type: 'assistant.message', id: 'final-round', data: { interactionId: 'interaction-1', content: 'Investigation complete.', toolRequests: [] } },
+			{ type: 'assistant.message', id: 'empty-round', data: { interactionId: 'interaction-2', content: '', toolRequests: [], reasoningOpaque: 'opaque-reasoning' } },
+			{ type: 'assistant.message', id: 'final-round', data: { interactionId: 'interaction-2', content: 'Investigation complete.', toolRequests: [] } },
+			{ type: 'user.message', id: 'user-event-2', data: { interactionId: 'interaction-3', content: 'Thanks' } },
+			{ type: 'assistant.message', id: 'acknowledgement', data: { interactionId: 'interaction-3', content: 'You are welcome.', toolRequests: [] } },
+		];
+
+		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+
+		assert.deepStrictEqual(turns.map(turn => ({
+			id: turn.id,
+			message: turn.message.text,
+			state: turn.state,
+			parts: partKinds(turn.responseParts),
+		})), [
+			{
+				id: 'user-event-1',
+				message: 'Investigate this issue',
+				state: TurnState.Complete,
+				parts: [
+					{ kind: ResponsePartKind.Markdown, content: 'I found a likely cause.' },
+					{ kind: ResponsePartKind.Markdown, content: 'I will verify it.' },
+					{ kind: ResponsePartKind.ToolCall },
+					{ kind: ResponsePartKind.Markdown, content: 'Investigation complete.' },
+				],
+			},
+			{
+				id: 'user-event-2',
+				message: 'Thanks',
+				state: TurnState.Complete,
+				parts: [
+					{ kind: ResponsePartKind.Markdown, content: 'You are welcome.' },
+				],
+			},
+		]);
+	});
+
+	test('synthetic user messages do not start a new turn', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', id: 'user-event-1', data: { interactionId: 'interaction-1', content: 'Use the skill' } },
+			{ type: 'assistant.message', data: { interactionId: 'interaction-1', content: 'I will use it.', toolRequests: [] } },
+			{ type: 'user.message', id: 'synthetic-event', data: { interactionId: 'interaction-2', content: 'Injected skill content', source: 'skill' } },
+			{ type: 'assistant.message', data: { interactionId: 'interaction-2', content: 'The skill is complete.', toolRequests: [] } },
+			{ type: 'user.message', id: 'user-event-2', data: { interactionId: 'interaction-3', content: 'Thanks' } },
+			{ type: 'assistant.message', data: { interactionId: 'interaction-3', content: 'You are welcome.', toolRequests: [] } },
+		];
+
+		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+
+		assert.deepStrictEqual(turns.map(turn => ({
+			id: turn.id,
+			message: turn.message.text,
+			parts: partKinds(turn.responseParts),
+		})), [
+			{
+				id: 'user-event-1',
+				message: 'Use the skill',
+				parts: [
+					{ kind: ResponsePartKind.Markdown, content: 'I will use it.' },
+					{ kind: ResponsePartKind.Markdown, content: 'The skill is complete.' },
+				],
+			},
+			{
+				id: 'user-event-2',
+				message: 'Thanks',
+				parts: [
+					{ kind: ResponsePartKind.Markdown, content: 'You are welcome.' },
+				],
+			},
+		]);
+	});
+
+	test('terminal empty assistant message completes a tool-only turn', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', id: 'user-event', data: { interactionId: 'interaction-1', content: 'Close out the todos' } },
+			{ type: 'assistant.message', data: { interactionId: 'interaction-1', content: '', toolRequests: [{ toolCallId: 'tc-1', name: 'todo' }] } },
+			{ type: 'tool.execution_start', data: { toolCallId: 'tc-1', toolName: 'todo', arguments: { status: 'done' } } },
+			{ type: 'tool.execution_complete', data: { toolCallId: 'tc-1', success: true } },
+			{ type: 'assistant.message', data: { interactionId: 'interaction-1', content: '', toolRequests: [] } },
 		];
 
 		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
@@ -131,12 +229,53 @@ suite('mapSessionEvents — history replay', () => {
 			parts: partKinds(turn.responseParts),
 		})), [{
 			id: 'user-event',
-			message: 'Investigate this issue',
+			message: 'Close out the todos',
 			state: TurnState.Complete,
 			parts: [
-				{ kind: ResponsePartKind.Markdown, content: 'I will investigate.' },
 				{ kind: ResponsePartKind.ToolCall },
-				{ kind: ResponsePartKind.Markdown, content: 'Investigation complete.' },
+			],
+		}]);
+	});
+
+	test('tool-only turn without a terminal assistant message remains cancelled', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', id: 'user-event', data: { interactionId: 'interaction-1', content: 'Run the command' } },
+			{ type: 'assistant.message', data: { interactionId: 'interaction-1', content: '', toolRequests: [{ toolCallId: 'tc-1', name: 'bash' }] } },
+			{ type: 'tool.execution_start', data: { toolCallId: 'tc-1', toolName: 'bash', arguments: { command: 'echo done' } } },
+			{ type: 'tool.execution_complete', data: { toolCallId: 'tc-1', success: true, result: { content: 'done\n' } } },
+		];
+
+		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+
+		assert.deepStrictEqual(turns.map(turn => ({
+			state: turn.state,
+			parts: partKinds(turn.responseParts),
+		})), [{
+			state: TurnState.Cancelled,
+			parts: [
+				{ kind: ResponsePartKind.ToolCall },
+			],
+		}]);
+	});
+
+	test('abort remains terminal for the turn', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', data: { interactionId: 'interaction-1', content: 'Wait for the task' } },
+			{ type: 'assistant.message', data: { interactionId: 'interaction-1', content: 'The task is complete.', toolRequests: [] } },
+			{ type: 'abort', data: { reason: 'user initiated' } },
+			{ type: 'assistant.message', data: { interactionId: 'interaction-2', content: 'Late completion.', toolRequests: [] } },
+		];
+
+		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+
+		assert.deepStrictEqual(turns.map(turn => ({
+			state: turn.state,
+			parts: partKinds(turn.responseParts),
+		})), [{
+			state: TurnState.Cancelled,
+			parts: [
+				{ kind: ResponsePartKind.Markdown, content: 'The task is complete.' },
+				{ kind: ResponsePartKind.Markdown, content: 'Late completion.' },
 			],
 		}]);
 	});
@@ -192,5 +331,88 @@ suite('mapSessionEvents — subagent routing', () => {
 			{ kind: ResponsePartKind.ToolCall },
 			{ kind: ResponsePartKind.Markdown, content: 'Subagent is done.' },
 		]);
+	});
+
+	test('routes subagent skill events into the subagent transcript', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', data: { interactionId: 'm1', content: 'spawn a subagent' } },
+			{ type: 'assistant.message', data: { messageId: 'm2', content: '', toolRequests: [{ toolCallId: 'tc-task', name: 'task' }] } },
+			{ type: 'tool.execution_start', data: { toolCallId: 'tc-task', toolName: 'task', arguments: { description: 'explore', agentName: 'explore' } } },
+			{ type: 'subagent.started', agentId: 'agent-1', data: { toolCallId: 'tc-task', agentName: 'explore', agentDisplayName: 'Explore', agentDescription: 'Explores' } },
+			{ type: 'skill.invoked', agentId: 'agent-1', data: { name: 'research', path: '/skills/research' } },
+			{ type: 'tool.execution_complete', data: { toolCallId: 'tc-task', success: true } },
+			{ type: 'assistant.message', data: { messageId: 'm3', content: 'The subagent finished.' } },
+		];
+
+		const { turns, subagentTurnsByToolCallId } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+
+		assert.deepStrictEqual({
+			parentState: turns[0].state,
+			parentParts: partKinds(turns[0].responseParts),
+			subagentParts: partKinds(subagentTurnsByToolCallId.get('tc-task')?.[0].responseParts ?? []),
+		}, {
+			parentState: TurnState.Complete,
+			parentParts: [
+				{ kind: ResponsePartKind.ToolCall },
+				{ kind: ResponsePartKind.Markdown, content: 'The subagent finished.' },
+			],
+			subagentParts: [
+				{ kind: ResponsePartKind.ToolCall },
+			],
+		});
+	});
+
+	test('subagent abort marks the subagent turn cancelled', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', data: { interactionId: 'm1', content: 'spawn a subagent' } },
+			{ type: 'assistant.message', data: { messageId: 'm2', content: '', toolRequests: [{ toolCallId: 'tc-task', name: 'task' }] } },
+			{ type: 'tool.execution_start', data: { toolCallId: 'tc-task', toolName: 'task', arguments: { description: 'explore', agentName: 'explore' } } },
+			{ type: 'subagent.started', agentId: 'agent-1', data: { toolCallId: 'tc-task', agentName: 'explore', agentDisplayName: 'Explore', agentDescription: 'Explores' } },
+			{ type: 'assistant.message', agentId: 'agent-1', data: { messageId: 'm3', content: 'Partial result.' } },
+			{ type: 'abort', agentId: 'agent-1', data: { reason: 'user initiated' } },
+			{ type: 'tool.execution_complete', data: { toolCallId: 'tc-task', success: false } },
+			{ type: 'assistant.message', data: { messageId: 'm4', content: 'The subagent was cancelled.' } },
+		];
+
+		const { turns, subagentTurnsByToolCallId } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+		const subagentTurn = subagentTurnsByToolCallId.get('tc-task')?.[0];
+
+		assert.deepStrictEqual({
+			parentState: turns[0].state,
+			subagentState: subagentTurn?.state,
+			subagentParts: partKinds(subagentTurn?.responseParts ?? []),
+		}, {
+			parentState: TurnState.Complete,
+			subagentState: TurnState.Cancelled,
+			subagentParts: [
+				{ kind: ResponsePartKind.Markdown, content: 'Partial result.' },
+			],
+		});
+	});
+
+	test('subagent abort before its first response remains cancelled', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', data: { interactionId: 'm1', content: 'spawn a subagent' } },
+			{ type: 'assistant.message', data: { messageId: 'm2', content: '', toolRequests: [{ toolCallId: 'tc-task', name: 'task' }] } },
+			{ type: 'tool.execution_start', data: { toolCallId: 'tc-task', toolName: 'task', arguments: { description: 'explore', agentName: 'explore' } } },
+			{ type: 'subagent.started', agentId: 'agent-1', data: { toolCallId: 'tc-task', agentName: 'explore', agentDisplayName: 'Explore', agentDescription: 'Explores' } },
+			{ type: 'abort', agentId: 'agent-1', data: { reason: 'user initiated' } },
+			{ type: 'assistant.message', agentId: 'agent-1', data: { messageId: 'm3', content: 'Late partial result.' } },
+			{ type: 'tool.execution_complete', data: { toolCallId: 'tc-task', success: false } },
+			{ type: 'assistant.message', data: { messageId: 'm4', content: 'The subagent was cancelled.' } },
+		];
+
+		const { subagentTurnsByToolCallId } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+		const subagentTurn = subagentTurnsByToolCallId.get('tc-task')?.[0];
+
+		assert.deepStrictEqual({
+			state: subagentTurn?.state,
+			parts: partKinds(subagentTurn?.responseParts ?? []),
+		}, {
+			state: TurnState.Cancelled,
+			parts: [
+				{ kind: ResponsePartKind.Markdown, content: 'Late partial result.' },
+			],
+		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
@@ -6,11 +6,11 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { AgentSession } from '../../common/agentService.js';
-import { MessageAttachmentKind, ResponsePartKind, type ResponsePart } from '../../common/state/sessionState.js';
+import { MessageAttachmentKind, ResponsePartKind, TurnState, type ResponsePart } from '../../common/state/sessionState.js';
 import { mapSessionEvents } from '../../node/copilot/mapSessionEvents.js';
 import { toSessionEvents, type ISessionEvent } from './copilotTestEvents.js';
 
-suite('mapSessionEvents — task_complete rendering', () => {
+suite('mapSessionEvents — history replay', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
@@ -110,6 +110,35 @@ suite('mapSessionEvents — task_complete rendering', () => {
 				label: 'example.ts',
 			}],
 		});
+	});
+
+	test('ignores empty assistant messages between model rounds', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', id: 'user-event', data: { interactionId: 'interaction-1', content: 'Investigate this issue' } },
+			{ type: 'assistant.message', id: 'tool-round', data: { interactionId: 'interaction-1', content: 'I will investigate.', toolRequests: [{ toolCallId: 'tc-1', name: 'bash' }] } },
+			{ type: 'tool.execution_start', data: { toolCallId: 'tc-1', toolName: 'bash', arguments: { command: 'echo investigating' } } },
+			{ type: 'tool.execution_complete', data: { toolCallId: 'tc-1', success: true, result: { content: 'investigating\n' } } },
+			{ type: 'assistant.message', id: 'empty-round', data: { interactionId: 'interaction-1', content: '', toolRequests: [], reasoningOpaque: 'opaque-reasoning' } },
+			{ type: 'assistant.message', id: 'final-round', data: { interactionId: 'interaction-1', content: 'Investigation complete.', toolRequests: [] } },
+		];
+
+		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+
+		assert.deepStrictEqual(turns.map(turn => ({
+			id: turn.id,
+			message: turn.message.text,
+			state: turn.state,
+			parts: partKinds(turn.responseParts),
+		})), [{
+			id: 'user-event',
+			message: 'Investigate this issue',
+			state: TurnState.Complete,
+			parts: [
+				{ kind: ResponsePartKind.Markdown, content: 'I will investigate.' },
+				{ kind: ResponsePartKind.ToolCall },
+				{ kind: ResponsePartKind.Markdown, content: 'Investigation complete.' },
+			],
+		}]);
 	});
 });
 


### PR DESCRIPTION
## Summary
- reconstruct Copilot SDK history using real top-level user messages as chat turn boundaries
- keep markdown, tool calls, and multiple model rounds in one restored response
- preserve completion and cancellation state for terminal empty messages, task completion, aborts, and subagent activity

## Testing
- `npm run typecheck-client`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts`
- `npm run valid-layers-check`
- `npm run precommit`
- replayed the production mapper across 1,859 captured local session histories; 15 pre-existing malformed base64 attachment histories were the only failures

Fixes [#323283](https://github.com/microsoft/vscode/issues/323283).

(Written by Copilot)
