### PR TITLE
ci: smoke out flaky McpStdioStateHandler 'sigterm after grace' test

### DIFF
--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -318,26 +318,38 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # TEMPORARY (flaky test smoke-out): run ONLY the `McpStdioStateHandler` suite
+      # (which contains the suspected-flaky `sigterm after grace` test), repeatedly,
+      # and fail the build the moment it fails. GitHub Actions runs `run:` with
+      # `bash -eo pipefail`, so the first non-zero `test.sh` exit aborts the loop and
+      # fails the step. Revert this step to `./scripts/test.sh --tfs "Unit Tests"` when done.
       - name: 🧪 Run unit tests (Electron)
         if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
-        timeout-minutes: 15
-        run: ./scripts/test.sh --tfs "Unit Tests"
+        timeout-minutes: 60
+        run: |
+          ATTEMPTS=100
+          for i in $(seq 1 $ATTEMPTS); do
+            echo "===== sigterm-after-grace smoke-out: attempt $i/$ATTEMPTS ====="
+            ./scripts/test.sh --grep 'McpStdioStateHandler'
+          done
+          echo "All $ATTEMPTS attempts passed — could not reproduce the flake."
         env:
           DISPLAY: ":10"
 
       - name: 🧪 Run unit tests (node.js)
-        if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
+        if: false # TEMPORARY (flaky test smoke-out): disabled to focus on the Electron unit-test loop
         timeout-minutes: 15
         run: npm run test-node
 
       - name: 🧪 Run unit tests (Browser, Chromium)
-        if: ${{ inputs.browser_tests && inputs.unit_and_integration_tests }}
+        if: false # TEMPORARY (flaky test smoke-out): disabled to focus on the Electron unit-test loop
         timeout-minutes: 30
         run: npm run test-browser-no-install -- --browser chromium --tfs "Browser Unit Tests"
         env:
           DEBUG: "*browser*"
 
       - name: Compile extensions for integration tests & smoke tests
+        if: false # TEMPORARY (flaky test smoke-out): disabled to focus on the Electron unit-test loop
         run: |
           set -e
           npm run gulp \
@@ -360,31 +372,31 @@ jobs:
             compile-extension:vscode-test-resolver
 
       - name: 🧪 Run integration tests (Electron)
-        if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
+        if: false # TEMPORARY (flaky test smoke-out): disabled to focus on the Electron unit-test loop
         timeout-minutes: 20
         run: ./scripts/test-integration.sh --tfs "Integration Tests"
         env:
           DISPLAY: ":10"
 
       - name: 🧪 Run integration tests (Browser, Chromium)
-        if: ${{ inputs.browser_tests && inputs.unit_and_integration_tests }}
+        if: false # TEMPORARY (flaky test smoke-out): disabled to focus on the Electron unit-test loop
         timeout-minutes: 20
         run: ./scripts/test-web-integration.sh --browser chromium
 
       - name: 🧪 Run integration tests (Remote)
-        if: ${{ inputs.remote_tests && inputs.unit_and_integration_tests }}
+        if: false # TEMPORARY (flaky test smoke-out): disabled to focus on the Electron unit-test loop
         timeout-minutes: 20
         run: ./scripts/test-remote-integration.sh
         env:
           DISPLAY: ":10"
 
       - name: Compile smoke tests
-        if: ${{ inputs.smoke_tests }}
+        if: false # TEMPORARY (flaky test smoke-out): disabled to focus on the Electron unit-test loop
         working-directory: test/smoke
         run: npm run compile
 
       - name: Compile Copilot Chat extension for smoke tests
-        if: ${{ inputs.smoke_tests }}
+        if: false # TEMPORARY (flaky test smoke-out): disabled to focus on the Electron unit-test loop
         working-directory: extensions/copilot
         run: npm run compile
 
@@ -401,7 +413,7 @@ jobs:
       # https://github.com/anthropics/claude-agent-sdk-typescript for the SDK
       # resolution order.
       - name: Remove musl Claude binary on glibc Linux
-        if: ${{ inputs.smoke_tests }}
+        if: false # TEMPORARY (flaky test smoke-out): disabled to focus on the Electron unit-test loop
         run: rm -rf node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl
 
       - name: Diagnostics before smoke test run (processes, max_user_watches, number of opened file handles)
@@ -414,19 +426,19 @@ jobs:
         if: ${{ inputs.smoke_tests && always() }}
 
       - name: 🧪 Run smoke tests (Electron)
-        if: ${{ inputs.electron_tests && inputs.smoke_tests }}
+        if: false # TEMPORARY (flaky test smoke-out): disabled to focus on the Electron unit-test loop
         timeout-minutes: 20
         run: npm run smoketest-no-compile -- --tracing
         env:
           DISPLAY: ":10"
 
       - name: 🧪 Run smoke tests (Browser, Chromium)
-        if: ${{ inputs.browser_tests && inputs.smoke_tests }}
+        if: false # TEMPORARY (flaky test smoke-out): disabled to focus on the Electron unit-test loop
         timeout-minutes: 20
         run: npm run smoketest-no-compile -- --web --tracing --headless
 
       - name: 🧪 Run smoke tests (Remote)
-        if: ${{ inputs.remote_tests && inputs.smoke_tests }}
+        if: false # TEMPORARY (flaky test smoke-out): disabled to focus on the Electron unit-test loop
         timeout-minutes: 20
         run: npm run smoketest-no-compile -- --remote --tracing
         env:


### PR DESCRIPTION
## What

Temporarily reconfigures the **Linux / Electron** PR test workflow (`.github/workflows/pr-linux-test.yml`) to smoke out a suspected-flaky unit test:

- **Suite:** `McpStdioStateHandler`
- **Test:** `sigterm after grace` (`src/vs/workbench/contrib/mcp/test/node/mcpStdioStateHandler.test.ts`, non-Windows only)

## Why

The test has failed-then-passed-on-retry on at least 2 distinct PRs:

- [Linux / Electron run 28274391241](https://github.com/microsoft/vscode/actions/runs/28274391241/job/83778117152) — c182349f (attempt 1→2)
- [Linux / Electron run 28238317232](https://github.com/microsoft/vscode/actions/runs/28238317232/job/83658488903) — ab30aaf2 (attempt 1→2)

This PR is a **diagnostic experiment** to reproduce the flake deterministically and get proof.

## How

- The **"Run unit tests (Electron)"** step now runs only that suite via `--grep 'McpStdioStateHandler'`, looped **100×** with **fail-fast**: GitHub Actions runs `run:` blocks under `bash -eo pipefail`, so the first failing attempt aborts the loop and fails the build (e.g. "fails on attempt #6 → red build"). The `attempt N/100` banner pinpoints which iteration flaked.
- All other unit / integration / smoke and `compile-extensions` steps are gated with `if: false` so the experiment runs in isolation (and the sibling Linux Browser/Remote/Electron-Smoke jobs become fast no-ops).
- `timeout-minutes` bumped 15 → 60 for headroom across 100 Electron boots.

## Notes for reviewers

- ⚠️ **Temporary / do not merge** — this is a diagnostic change. Once the flake is reproduced, revert by restoring `./scripts/test.sh --tfs "Unit Tests"` and the original `if:` conditions.
- macOS/Windows workflows are intentionally untouched (flake observed only on Linux/Electron).
