### PR TITLE
agentHost: fix real SDK integration tests

### DIFF
--- a/src/vs/platform/agentHost/test/node/protocol/realSdkTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/realSdkTestHelpers.ts
@@ -26,7 +26,7 @@ import { PROTOCOL_VERSION } from '../../../common/state/protocol/version/registr
 import {
 	MessageKind,
 	ResponsePartKind, ROOT_STATE_URI, ChatInputAnswerState, ChatInputAnswerValueKind, ChatInputQuestionKind,
-	ChatInputResponseKind, ToolResultContentType, ToolCallConfirmationReason, ToolCallCancellationReason, buildDefaultChatUri, isSubagentSession,
+	ChatInputResponseKind, ToolResultContentType, ToolCallConfirmationReason, ToolCallCancellationReason, buildDefaultChatUri, buildSubagentSessionUri, parseChatUri,
 	type MessageAttachment, type ChatInputAnswer, type ChatInputRequest, type ISessionWithDefaultChat, type SessionState, type TerminalState,
 	type ToolResultContent, type ToolResultSubagentContent,
 } from '../../../common/state/sessionState.js';
@@ -175,7 +175,7 @@ export async function createRealSession(
 /** Dispatch a turn with the given user message text. */
 export function dispatchTurn(c: TestProtocolClient, session: string, turnId: string, text: string, clientSeq: number): void {
 	c.dispatch({
-		channel: session,
+		channel: buildDefaultChatUri(session),
 		clientSeq,
 		action: {
 			type: ActionType.ChatTurnStarted,
@@ -188,7 +188,7 @@ export function dispatchTurn(c: TestProtocolClient, session: string, turnId: str
 /** Dispatch a turn with the given user message text and attachments. */
 export function dispatchTurnWithAttachments(c: TestProtocolClient, session: string, turnId: string, text: string, attachments: readonly MessageAttachment[], clientSeq: number): void {
 	c.dispatch({
-		channel: session,
+		channel: buildDefaultChatUri(session),
 		clientSeq,
 		action: {
 			type: ActionType.ChatTurnStarted,
@@ -315,7 +315,7 @@ async function driveTurn(c: TestProtocolClient, session: string, turnId: string,
 			if (!action.confirmed) {
 				sawPendingConfirmation = true;
 				c.dispatch({
-					channel: session,
+					channel: buildDefaultChatUri(session),
 					clientSeq: nextClientSeq++,
 					action: {
 						type: ActionType.ChatToolCallConfirmed,
@@ -333,7 +333,7 @@ async function driveTurn(c: TestProtocolClient, session: string, turnId: string,
 			sawInputRequest = true;
 			const action = getActionEnvelope(notification).action as ChatInputRequestedAction;
 			c.dispatch({
-				channel: session,
+				channel: buildDefaultChatUri(session),
 				clientSeq: nextClientSeq++,
 				action: {
 					type: ActionType.ChatInputCompleted,
@@ -658,7 +658,7 @@ export function defineSharedRealSdkTests(config: IRealSdkProviderConfig): void {
 				}
 				const action = getActionEnvelope(next).action as { toolCallId: string };
 				client.dispatch({
-					channel: sessionUri,
+					channel: buildDefaultChatUri(sessionUri),
 					clientSeq: nextSeq++,
 					action: {
 						type: ActionType.ChatToolCallConfirmed,
@@ -856,7 +856,7 @@ export function defineSharedRealSdkTests(config: IRealSdkProviderConfig): void {
 			const toolReadyAction = getActionEnvelope(toolReadyNotif).action as { confirmed?: string };
 			if (!toolReadyAction.confirmed) {
 				client.dispatch({
-					channel: addedSummary.resource,
+					channel: buildDefaultChatUri(addedSummary.resource),
 					clientSeq: 4,
 					action: {
 						type: ActionType.ChatToolCallConfirmed,
@@ -952,15 +952,15 @@ export function defineSharedRealSdkTests(config: IRealSdkProviderConfig): void {
 
 			const parentContent = (getActionEnvelope(subagentContentNotif).action as { content: readonly ToolResultContent[] }).content;
 			const subagentRef = parentContent.find((c): c is ToolResultSubagentContent => c.type === ToolResultContentType.Subagent)!;
-			const subagentSessionUri = subagentRef.resource as unknown as string;
-			assert.ok(typeof subagentSessionUri === 'string' && isSubagentSession(subagentSessionUri),
-				`subagent session URI should be subagent-shaped, got: ${JSON.stringify(subagentSessionUri)}`);
-			const subagentChatUri = buildDefaultChatUri(subagentSessionUri);
+			const subagentChatUri = subagentRef.resource as unknown as string;
+			const parsedSubagentChat = parseChatUri(subagentChatUri);
+			assert.ok(
+				parsedSubagentChat?.session === sessionUri && parsedSubagentChat.chatId.startsWith('subagent/'),
+				`subagent resource should be a subagent chat of the parent session, got: ${JSON.stringify(subagentChatUri)}`,
+			);
 
-			await client.call<SubscribeResult>('subscribe', { channel: subagentSessionUri });
 			// The subagent's conversation contents (its inner tool calls) are
-			// emitted on its own default chat channel; subscribe so we observe
-			// them separately from the parent.
+			// emitted on the chat channel carried by the tool result.
 			await client.call<SubscribeResult>('subscribe', { channel: subagentChatUri });
 
 			await client.waitForNotification(n => {
@@ -1059,12 +1059,15 @@ export function defineSharedRealSdkTests(config: IRealSdkProviderConfig): void {
 
 			const parentContent = (getActionEnvelope(subagentContentNotif).action as { content: readonly ToolResultContent[] }).content;
 			const subagentRef = parentContent.find((c): c is ToolResultSubagentContent => c.type === ToolResultContentType.Subagent)!;
-			const subagentSessionUri = subagentRef.resource as unknown as string;
-			assert.ok(typeof subagentSessionUri === 'string' && isSubagentSession(subagentSessionUri),
-				`subagent session URI should be subagent-shaped, got: ${JSON.stringify(subagentSessionUri)}`);
-			const subagentChatUri = buildDefaultChatUri(subagentSessionUri);
+			const subagentChatUri = subagentRef.resource as unknown as string;
+			const parsedSubagentChat = parseChatUri(subagentChatUri);
+			assert.ok(
+				parsedSubagentChat?.session === sessionUri && parsedSubagentChat.chatId.startsWith('subagent/'),
+				`subagent resource should be a subagent chat of the parent session, got: ${JSON.stringify(subagentChatUri)}`,
+			);
+			const subagentToolCallId = parsedSubagentChat.chatId.slice('subagent/'.length);
+			const replaySubagentSessionUri = buildSubagentSessionUri(sessionUri, subagentToolCallId);
 
-			await client.call<SubscribeResult>('subscribe', { channel: subagentSessionUri });
 			await client.call<SubscribeResult>('subscribe', { channel: subagentChatUri });
 
 			await client.waitForNotification(n =>
@@ -1073,17 +1076,20 @@ export function defineSharedRealSdkTests(config: IRealSdkProviderConfig): void {
 			approvalsActive = false;
 			await approvalLoop;
 
-			// Force a reopen: drop every subscription on the session and its
-			// sub-agent so the agent host evicts the cached, live-built state, then
-			// re-fetch — which rebuilds the turns from the persisted SDK event log
-			// through `mapSessionEvents` (the path the regression lived in). The
-			// parent-session unsubscribe is sent last so it triggers eviction.
-			for (const channel of [buildDefaultChatUri(subagentSessionUri), subagentSessionUri, buildDefaultChatUri(sessionUri), sessionUri]) {
+			// Force a reopen: drop the subagent chat and parent-session
+			// subscriptions so the agent host evicts the cached, live-built state,
+			// then re-fetch — which rebuilds the turns from the persisted SDK event
+			// log through `mapSessionEvents` (the path the regression lived in).
+			// The parent-session unsubscribe is sent last so it triggers eviction.
+			for (const channel of [subagentChatUri, buildDefaultChatUri(sessionUri), sessionUri]) {
 				client.notify('unsubscribe', { channel });
 			}
 
 			const reopenedParent = await fetchSessionWithChat(client, sessionUri);
-			const reopenedSubagent = await fetchSessionWithChat(client, subagentSessionUri);
+			// Persisted SDK replay still restores subagents through their derived
+			// session resource, while the live path exposes the dedicated chat
+			// resource above.
+			const reopenedSubagent = await fetchSessionWithChat(client, replaySubagentSessionUri);
 
 			const assistantText = (turns: ISessionWithDefaultChat['turns']): string =>
 				turns.map(t => t.responseParts.map(p => p.kind === ResponsePartKind.Markdown ? p.content : '').join('')).join('\n');


### PR DESCRIPTION
## Summary
- route real SDK chat actions through default chat channels
- update subagent assertions for live chat resources
- preserve persisted replay coverage through derived subagent session resources

## Testing
- `npm run typecheck-client`
- `npm run precommit`
- `AGENT_HOST_REAL_SDK=1 ./scripts/test-integration.sh --run src/vs/platform/agentHost/test/node/protocol/copilotRealSdk.integrationTest.ts` (13 passing, 1 pending)

(Written by Copilot)