### PR TITLE
git: allow direct editing of staged files in diff editor

### DIFF
--- a/extensions/git/src/fileSystemProvider.ts
+++ b/extensions/git/src/fileSystemProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { workspace, Uri, Disposable, Event, EventEmitter, window, FileSystemProvider, FileChangeEvent, FileStat, FileType, FileChangeType, FileSystemError, LogOutputChannel } from 'vscode';
+import { workspace, Uri, Disposable, Event, EventEmitter, window, FileSystemProvider, FileChangeEvent, FileStat, FileType, FileChangeType, FileSystemError, FilePermission, LogOutputChannel } from 'vscode';
 import { debounce, throttle } from './decorators';
 import { fromGitUri, toGitUri } from './uri';
 import { Model, ModelChangeEvent, OriginalResourceChangeEvent } from './model';
@@ -54,7 +54,7 @@ export class GitFileSystemProvider implements FileSystemProvider {
 		this.disposables.push(
 			model.onDidChangeRepository(this.onDidChangeRepository, this),
 			model.onDidChangeOriginalResource(this.onDidChangeOriginalResource, this),
-			workspace.registerFileSystemProvider('git', this, { isReadonly: true, isCaseSensitive: true }),
+			workspace.registerFileSystemProvider('git', this, { isReadonly: false, isCaseSensitive: true }),
 			new Disposable(() => clearInterval(cleanupHandle)),
 		);
 	}
@@ -69,13 +69,15 @@ export class GitFileSystemProvider implements FileSystemProvider {
 			return;
 		}
 
-		const diffOriginalResourceUri = toGitUri(uri, '~',);
+		const diffOriginalResourceUri = toGitUri(uri, '~');
 		const quickDiffOriginalResourceUri = toGitUri(uri, '', { replaceFileExtension: true });
+		const indexResourceUri = toGitUri(uri, '');
 
 		this.mtime = new Date().getTime();
 		this._onDidChangeFile.fire([
 			{ type: FileChangeType.Changed, uri: diffOriginalResourceUri },
-			{ type: FileChangeType.Changed, uri: quickDiffOriginalResourceUri }
+			{ type: FileChangeType.Changed, uri: quickDiffOriginalResourceUri },
+			{ type: FileChangeType.Changed, uri: indexResourceUri }
 		]);
 	}
 
@@ -170,14 +172,17 @@ export class GitFileSystemProvider implements FileSystemProvider {
 			throw FileSystemError.FileNotFound();
 		}
 
+		// '~' and '' both refer to the staging area (index) and should be writable
+		const permissions = (ref !== '~' && ref !== '') ? FilePermission.Readonly : undefined;
+
 		try {
 			const details = await repository.getObjectDetails(sanitizeRef(ref, path, submoduleOf, repository), path);
-			return { type: FileType.File, size: details.size, mtime: this.mtime, ctime: 0 };
+			return { type: FileType.File, size: details.size, mtime: this.mtime, ctime: 0, permissions };
 		} catch {
 			// Empty tree
 			if (ref === await repository.getEmptyTree()) {
 				this.logger.warn(`[GitFileSystemProvider][stat] Empty tree - ${uri.toString()}`);
-				return { type: FileType.File, size: 0, mtime: this.mtime, ctime: 0 };
+				return { type: FileType.File, size: 0, mtime: this.mtime, ctime: 0, permissions };
 			}
 
 			// File does not exist in git. This could be because the file is untracked or ignored
@@ -242,8 +247,21 @@ export class GitFileSystemProvider implements FileSystemProvider {
 		}
 	}
 
-	writeFile(): void {
-		throw new Error('Method not implemented.');
+	async writeFile(uri: Uri, content: Uint8Array, _options: { create: boolean; overwrite: boolean }): Promise<void> {
+		const { ref, path } = fromGitUri(uri);
+
+		// Allow writes to the staging area: '~' (quasi-ref) and '' (direct index ref)
+		if (ref !== '~' && ref !== '') {
+			throw FileSystemError.NoPermissions(uri);
+		}
+
+		const repository = await this.getOrOpenRepository(uri);
+
+		if (!repository) {
+			throw FileSystemError.FileNotFound();
+		}
+
+		await repository.stageRaw(Uri.file(path), content);
 	}
 
 	delete(): void {

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1310,7 +1310,7 @@ export class Repository implements Disposable {
 			await this.repository.stage(resource.fsPath, data);
 
 			this._onDidChangeOriginalResource.fire(resource);
-			this.closeDiffEditors([], [...resource.fsPath]);
+			this.closeDiffEditors([], [resource.fsPath]);
 		});
 	}
 
@@ -1318,7 +1318,7 @@ export class Repository implements Disposable {
 		await this.run(Operation.Stage, async () => {
 			await this.repository.stage(resource.fsPath, data);
 			this._onDidChangeOriginalResource.fire(resource);
-			this.closeDiffEditors([], [...resource.fsPath]);
+			this.closeDiffEditors([], [resource.fsPath]);
 		});
 	}
 

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1314,6 +1314,14 @@ export class Repository implements Disposable {
 		});
 	}
 
+	async stageRaw(resource: Uri, data: Uint8Array): Promise<void> {
+		await this.run(Operation.Stage, async () => {
+			await this.repository.stage(resource.fsPath, data);
+			this._onDidChangeOriginalResource.fire(resource);
+			this.closeDiffEditors([], [...resource.fsPath]);
+		});
+	}
+
 	async revert(resources: Uri[]): Promise<void> {
 		await this.run(
 			Operation.RevertFiles(!this.optimisticUpdateEnabled()),

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -32,7 +32,7 @@ import { isEqual } from '../../../../base/common/resources.js';
 import { Dimension } from '../../../../base/browser/dom.js';
 import { multibyteAwareBtoa } from '../../../../base/common/strings.js';
 import { ByteSize, FileOperationError, FileOperationResult, IFileService, TooLargeFileOperationError } from '../../../../platform/files/common/files.js';
-import { IMarkdownString } from '../../../../base/common/htmlContent.js';
+import type { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { IBoundarySashes } from '../../../../base/browser/ui/sash/sash.js';
 import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
 import { StopWatch } from '../../../../base/common/stopwatch.js';
@@ -165,7 +165,9 @@ export class TextDiffEditor extends AbstractTextEditor<IDiffEditorViewState> imp
 			if (modifiedUri && this.fileService.hasProvider(modifiedUri)) {
 				try {
 					const stat = await this.fileService.stat(modifiedUri);
-					modifiedIsReadonly = stat.readonly;
+					if (stat.readonly) {
+						modifiedIsReadonly = stat.readonly;
+					}
 				} catch { /* use model's isReadonly() as fallback */ }
 			}
 			this._cachedOriginalEditable = !resolvedDiffEditorModel.originalModel?.isReadonly();

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -32,6 +32,7 @@ import { isEqual } from '../../../../base/common/resources.js';
 import { Dimension } from '../../../../base/browser/dom.js';
 import { multibyteAwareBtoa } from '../../../../base/common/strings.js';
 import { ByteSize, FileOperationError, FileOperationResult, IFileService, TooLargeFileOperationError } from '../../../../platform/files/common/files.js';
+import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { IBoundarySashes } from '../../../../base/browser/ui/sash/sash.js';
 import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
 import { StopWatch } from '../../../../base/common/stopwatch.js';
@@ -46,6 +47,11 @@ export class TextDiffEditor extends AbstractTextEditor<IDiffEditorViewState> imp
 	private diffEditorControl: IDiffEditor | undefined = undefined;
 
 	private inputLifecycleStopWatch: StopWatch | undefined = undefined;
+
+	// Cached original-side editable state, derived from the model's isReadonly() in setInput.
+	// Used by getConfigurationOverrides/updateReadonly to avoid re-evaluating via the editor input
+	// (which can't distinguish per-file readonly when the provider-level readonly flag is false).
+	private _cachedOriginalEditable: boolean = false;
 
 	override get scopedContextKeyService(): IContextKeyService | undefined {
 		if (!this.diffEditorControl) {
@@ -104,6 +110,9 @@ export class TextDiffEditor extends AbstractTextEditor<IDiffEditorViewState> imp
 		// Cleanup previous things associated with the input
 		this.inputLifecycleStopWatch = undefined;
 
+		// Reset until we resolve the model and know the actual original editable state
+		this._cachedOriginalEditable = false;
+
 		// Set input and resolve
 		await super.setInput(input, options, context, token);
 
@@ -151,9 +160,18 @@ export class TextDiffEditor extends AbstractTextEditor<IDiffEditorViewState> imp
 			// was already asked for being readonly or not. The rationale is that
 			// a resolved model might have more specific information about being
 			// readonly or not that the input did not have.
+			let modifiedIsReadonly: boolean | IMarkdownString = resolvedDiffEditorModel.modifiedModel?.isReadonly() ?? true;
+			const modifiedUri = input.modified.resource;
+			if (modifiedUri && this.fileService.hasProvider(modifiedUri)) {
+				try {
+					const stat = await this.fileService.stat(modifiedUri);
+					modifiedIsReadonly = stat.readonly;
+				} catch { /* use model's isReadonly() as fallback */ }
+			}
+			this._cachedOriginalEditable = !resolvedDiffEditorModel.originalModel?.isReadonly();
 			control.updateOptions({
-				...this.getReadonlyConfiguration(resolvedDiffEditorModel.modifiedModel?.isReadonly()),
-				originalEditable: !resolvedDiffEditorModel.originalModel?.isReadonly()
+				...this.getReadonlyConfiguration(modifiedIsReadonly),
+				originalEditable: this._cachedOriginalEditable
 			});
 
 			control.handleInitialized();
@@ -284,7 +302,7 @@ export class TextDiffEditor extends AbstractTextEditor<IDiffEditorViewState> imp
 		return {
 			...super.getConfigurationOverrides(configuration),
 			...this.getReadonlyConfiguration(this.input?.isReadonly()),
-			originalEditable: this.input instanceof DiffEditorInput && !this.input.original.isReadonly(),
+			originalEditable: this._cachedOriginalEditable,
 			lineDecorationsWidth: '2ch'
 		};
 	}
@@ -293,7 +311,7 @@ export class TextDiffEditor extends AbstractTextEditor<IDiffEditorViewState> imp
 		if (input instanceof DiffEditorInput) {
 			this.diffEditorControl?.updateOptions({
 				...this.getReadonlyConfiguration(input.isReadonly()),
-				originalEditable: !input.original.isReadonly(),
+				originalEditable: this._cachedOriginalEditable,
 			});
 		} else {
 			super.updateReadonly(input);

--- a/src/vs/workbench/services/textfile/browser/textFileService.ts
+++ b/src/vs/workbench/services/textfile/browser/textFileService.ts
@@ -379,6 +379,16 @@ export abstract class AbstractTextFileService extends Disposable implements ITex
 			if (model) {
 				return await model.save(options) ? resource : undefined;
 			}
+
+			// For resources with a file service provider but no TextFileEditorModel
+			// (e.g. git:// staging area files), write the current model content directly
+			if (this.fileService.hasProvider(resource)) {
+				const textModel = this.modelService.getModel(resource);
+				if (textModel) {
+					await this.fileService.writeFile(resource, VSBuffer.fromString(textModel.getValue()));
+					return resource;
+				}
+			}
 		}
 
 		return undefined;

--- a/src/vs/workbench/services/textfile/browser/textFileService.ts
+++ b/src/vs/workbench/services/textfile/browser/textFileService.ts
@@ -385,7 +385,7 @@ export abstract class AbstractTextFileService extends Disposable implements ITex
 			if (this.fileService.hasProvider(resource)) {
 				const textModel = this.modelService.getModel(resource);
 				if (textModel) {
-					await this.fileService.writeFile(resource, VSBuffer.fromString(textModel.getValue()));
+					await this.fileService.writeFile(resource, VSBuffer.fromString(textModel.getValue()), { unlock: options?.writeUnlock });
 					return resource;
 				}
 			}


### PR DESCRIPTION
Fixes #263110

  ## What this PR does

  Allows users to directly type and edit the content of staged files in the diff editor (right/modified side), and save changes back
  to the git index with Ctrl+S.

  Previously, the right side of the staged file diff editor was always read-only because:
  1. The git:// file system provider was registered with `isReadonly: true` (provider-level readonly)
  2. `stat()` returned `FilePermission.Readonly` for `ref=''` (the index direct reference used on the staged diff right side)
  3. `textFileService.save()` had no path for custom-scheme URIs without a `TextFileEditorModel`

  ## Changes

  - **`extensions/git/src/fileSystemProvider.ts`**: Register with `isReadonly: false` and allow `stat()`/`writeFile()` for `ref=''`.
  Fire a file change event for the index URI after writes so the editor reloads with the latest index content.
  - **`extensions/git/src/repository.ts`**: Add `stageRaw(resource, data: Uint8Array)` to write raw bytes directly to the git index
  via `git hash-object --stdin -w` + `git update-index --cacheinfo`.
  - **`src/vs/workbench/browser/parts/editor/textDiffEditor.ts`**: Derive the modified-side readonly state from `fileService.stat()`
  instead of the model's hardcoded `isReadonly()`. Cache `originalEditable` from the model to prevent the original (HEAD) side from
  becoming editable.
  - **`src/vs/workbench/services/textfile/browser/textFileService.ts`**: Add a fallback save path for custom-scheme URIs that have a
  file provider but no `TextFileEditorModel`, so Ctrl+S correctly triggers a write through the provider.

  ## How to test

  1. Open a repository with staged changes (`git add` some edits)
  2. In the Source Control panel, click a file under **Staged Changes** to open the diff editor
  3. Click into the right (modified) side — it should be editable (no "Read-only" indicator)
  4. Make edits and press **Ctrl+S**
  5. Verify the change is reflected in the index: `git diff --cached` 