### PR TITLE
Agent host: open sessions in editor windows

### DIFF
--- a/src/vs/sessions/browser/actions/vscodeActions.ts
+++ b/src/vs/sessions/browser/actions/vscodeActions.ts
@@ -4,8 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Codicon } from '../../../base/common/codicons.js';
-import { Schemas } from '../../../base/common/network.js';
-import { URI } from '../../../base/common/uri.js';
 import { ServicesAccessor } from '../../../editor/browser/editorExtensions.js';
 import { localize2 } from '../../../nls.js';
 import { Action2 } from '../../../platform/actions/common/actions.js';
@@ -25,7 +23,7 @@ import { Disposable } from '../../../base/common/lifecycle.js';
 import { IActionViewItemService } from '../../../platform/actions/browser/actionViewItemService.js';
 import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
 import { IWorkbenchContribution } from '../../../workbench/common/contributions.js';
-import { resolveRemoteAuthority } from '../openInVSCodeUtils.js';
+import { getOpenInVSCodeUri, getVSCodeProtocolScheme, resolveRemoteAuthority } from '../openInVSCodeUtils.js';
 import { OpenInVSCodeTitleBarWidget } from '../widget/openInVSCodeWidget.js';
 
 export class OpenInVSCodeAction extends Action2 {
@@ -55,21 +53,11 @@ export class OpenInVSCodeAction extends Action2 {
 		const sessionsService = accessor.get(ISessionsService);
 		const sessionsProvidersService = accessor.get(ISessionsProvidersService);
 		const remoteAgentHostService = accessor.get(IRemoteAgentHostService);
-
-		const scheme = productService.quality === 'stable'
-			? 'vscode'
-			: productService.quality === 'exploration'
-				? 'vscode-exploration'
-				: productService.quality === 'insider'
-					? 'vscode-insiders'
-					: productService.urlProtocol;
-
-		const params = new URLSearchParams();
-		params.set('windowId', '_blank');
+		const scheme = getVSCodeProtocolScheme(productService);
 
 		const activeSession = sessionsService.activeSession.get();
 		if (!activeSession) {
-			await openerService.open(URI.from({ scheme, query: params.toString() }), { openExternal: true });
+			await openerService.open(getOpenInVSCodeUri(scheme, undefined, undefined, undefined), { openExternal: true });
 			return;
 		}
 
@@ -78,7 +66,7 @@ export class OpenInVSCodeAction extends Action2 {
 		const rawFolderUri = workspace?.isVirtualWorkspace ? undefined : folder?.workingDirectory;
 
 		if (!rawFolderUri) {
-			await openerService.open(URI.from({ scheme, query: params.toString() }), { openExternal: true });
+			await openerService.open(getOpenInVSCodeUri(scheme, undefined, undefined, undefined), { openExternal: true });
 			return;
 		}
 
@@ -86,23 +74,7 @@ export class OpenInVSCodeAction extends Action2 {
 		const remoteAuthority = resolveRemoteAuthority(
 			activeSession.providerId, sessionsProvidersService, remoteAgentHostService);
 
-		params.set('session', activeSession.resource.toString());
-
-		if (remoteAuthority) {
-			await openerService.open(URI.from({
-				scheme,
-				authority: Schemas.vscodeRemote,
-				path: `/${remoteAuthority}${folderUri.path}`,
-				query: params.toString(),
-			}), { openExternal: true });
-		} else {
-			await openerService.open(URI.from({
-				scheme,
-				authority: Schemas.file,
-				path: folderUri.path,
-				query: params.toString(),
-			}), { openExternal: true });
-		}
+		await openerService.open(getOpenInVSCodeUri(scheme, folderUri, remoteAuthority, activeSession.resource), { openExternal: true });
 	}
 }
 

--- a/src/vs/sessions/browser/openInVSCodeUtils.ts
+++ b/src/vs/sessions/browser/openInVSCodeUtils.ts
@@ -7,6 +7,9 @@ import { IRemoteAgentHostService, IRemoteAgentHostSSHConnection, RemoteAgentHost
 import { ISessionsProvidersService } from '../services/sessions/browser/sessionsProvidersService.js';
 import { isAgentHostProvider } from '../common/agentHostSessionsProvider.js';
 import { encodeHex, VSBuffer } from '../../base/common/buffer.js';
+import { Schemas } from '../../base/common/network.js';
+import { IProductService } from '../../platform/product/common/productService.js';
+import { URI } from '../../base/common/uri.js';
 
 /**
  * Resolves the VS Code remote authority for the given session provider,
@@ -65,4 +68,46 @@ export function sshAuthorityString(connection: IRemoteAgentHostSSHConnection): s
 
 	const json = JSON.stringify(obj);
 	return encodeHex(VSBuffer.fromString(json));
+}
+
+export function getVSCodeProtocolScheme(productService: Pick<IProductService, 'quality' | 'urlProtocol'>): string {
+	switch (productService.quality) {
+		case 'stable':
+			return 'vscode';
+		case 'exploration':
+			return 'vscode-exploration';
+		case 'insider':
+			return 'vscode-insiders';
+		default:
+			return productService.urlProtocol;
+	}
+}
+
+export function getOpenInVSCodeUri(scheme: string, folderUri: URI | undefined, remoteAuthority: string | undefined, sessionResource: URI | undefined): URI {
+	const params = new URLSearchParams();
+	params.set('windowId', '_blank');
+
+	if (sessionResource) {
+		params.set('session', sessionResource.toString());
+	}
+
+	if (!folderUri) {
+		return URI.from({ scheme, query: params.toString() });
+	}
+
+	if (remoteAuthority) {
+		return URI.from({
+			scheme,
+			authority: Schemas.vscodeRemote,
+			path: `/${remoteAuthority}${folderUri.path}`,
+			query: params.toString(),
+		});
+	}
+
+	return URI.from({
+		scheme,
+		authority: Schemas.file,
+		path: folderUri.path,
+		query: params.toString(),
+	});
 }

--- a/src/vs/sessions/electron-browser/actions/vscodeActions.ts
+++ b/src/vs/sessions/electron-browser/actions/vscodeActions.ts
@@ -6,8 +6,6 @@
 import { Codicon } from '../../../base/common/codicons.js';
 import { getWindowId } from '../../../base/browser/dom.js';
 import { mainWindow } from '../../../base/browser/window.js';
-import { Schemas } from '../../../base/common/network.js';
-import { URI } from '../../../base/common/uri.js';
 import { ServicesAccessor } from '../../../editor/browser/editorExtensions.js';
 import { localize2 } from '../../../nls.js';
 import { Action2 } from '../../../platform/actions/common/actions.js';
@@ -16,6 +14,8 @@ import { IRemoteAgentHostService } from '../../../platform/agentHost/common/remo
 import { KeyCode, KeyMod } from '../../../base/common/keyCodes.js';
 import { ContextKeyExpr } from '../../../platform/contextkey/common/contextkey.js';
 import { KeybindingWeight } from '../../../platform/keybinding/common/keybindingsRegistry.js';
+import { IOpenerService } from '../../../platform/opener/common/opener.js';
+import { IProductService } from '../../../platform/product/common/productService.js';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry.js';
 import { IsAuxiliaryWindowContext } from '../../../workbench/common/contextkeys.js';
 import { IsPhoneLayoutContext, SessionsWelcomeVisibleContext } from '../../common/contextkeys.js';
@@ -28,7 +28,7 @@ import { OpenInVSCodeTitleBarWidget } from '../../browser/widget/openInVSCodeWid
 import { IActionViewItemService } from '../../../platform/actions/browser/actionViewItemService.js';
 import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
-import { resolveRemoteAuthority } from '../../browser/openInVSCodeUtils.js';
+import { getOpenInVSCodeUri, getVSCodeProtocolScheme, resolveRemoteAuthority } from '../../browser/openInVSCodeUtils.js';
 import { INativeHostService } from '../../../platform/native/common/native.js';
 
 export class OpenSessionInVSCodeAction extends Action2 {
@@ -53,41 +53,30 @@ export class OpenSessionInVSCodeAction extends Action2 {
 		const telemetryService = accessor.get(ITelemetryService);
 		logSessionsInteraction(telemetryService, 'openInVSCode');
 
+		const openerService = accessor.get(IOpenerService);
+		const productService = accessor.get(IProductService);
 		const sessionsService = accessor.get(ISessionsService);
 		const sessionsProvidersService = accessor.get(ISessionsProvidersService);
 		const remoteAgentHostService = accessor.get(IRemoteAgentHostService);
-		const nativeHostService = accessor.get(INativeHostService);
+		const scheme = getVSCodeProtocolScheme(productService);
 
-		const folderUri = this.getFolderUriToOpen(sessionsService, sessionsProvidersService, remoteAgentHostService);
-		if (!folderUri) {
-			return nativeHostService.openWindow();
-		}
-		return nativeHostService.openWindow([{ folderUri }], { forceNewWindow: true });
-	}
-
-	private getFolderUriToOpen(sessionsService: ISessionsService, sessionsProvidersService: ISessionsProvidersService, remoteAgentHostService: IRemoteAgentHostService): URI | undefined {
 		const activeSession = sessionsService.activeSession.get();
 		if (!activeSession) {
-			return undefined;
+			await openerService.open(getOpenInVSCodeUri(scheme, undefined, undefined, undefined), { openExternal: true });
+			return;
 		}
 
 		const workspace = activeSession.workspace.get();
-		const rawFolderUri = workspace?.folders[0]?.workingDirectory;
+		const folder = workspace?.folders[0];
+		const rawFolderUri = workspace?.isVirtualWorkspace ? undefined : folder?.workingDirectory;
 		if (!rawFolderUri) {
-			return undefined;
+			await openerService.open(getOpenInVSCodeUri(scheme, undefined, undefined, undefined), { openExternal: true });
+			return;
 		}
 
-		if (rawFolderUri.scheme !== AGENT_HOST_SCHEME) {
-			return rawFolderUri;
-		}
-
+		const folderUri = rawFolderUri.scheme === AGENT_HOST_SCHEME ? fromAgentHostUri(rawFolderUri) : rawFolderUri;
 		const remoteAuthority = resolveRemoteAuthority(activeSession.providerId, sessionsProvidersService, remoteAgentHostService);
-		if (!remoteAuthority) {
-			return rawFolderUri;
-		}
-
-		const agentHostUri = fromAgentHostUri(rawFolderUri);
-		return agentHostUri.with({ authority: remoteAuthority, scheme: Schemas.vscodeRemote });
+		await openerService.open(getOpenInVSCodeUri(scheme, folderUri, remoteAuthority, activeSession.resource), { openExternal: true });
 	}
 }
 

--- a/src/vs/sessions/electron-browser/actions/vscodeActions.ts
+++ b/src/vs/sessions/electron-browser/actions/vscodeActions.ts
@@ -55,6 +55,7 @@ export class OpenSessionInVSCodeAction extends Action2 {
 
 		const openerService = accessor.get(IOpenerService);
 		const productService = accessor.get(IProductService);
+		const nativeHostService = accessor.get(INativeHostService);
 		const sessionsService = accessor.get(ISessionsService);
 		const sessionsProvidersService = accessor.get(ISessionsProvidersService);
 		const remoteAgentHostService = accessor.get(IRemoteAgentHostService);
@@ -68,9 +69,14 @@ export class OpenSessionInVSCodeAction extends Action2 {
 
 		const workspace = activeSession.workspace.get();
 		const folder = workspace?.folders[0];
-		const rawFolderUri = workspace?.isVirtualWorkspace ? undefined : folder?.workingDirectory;
+		const rawFolderUri = folder?.workingDirectory;
 		if (!rawFolderUri) {
 			await openerService.open(getOpenInVSCodeUri(scheme, undefined, undefined, undefined), { openExternal: true });
+			return;
+		}
+
+		if (workspace?.isVirtualWorkspace) {
+			await nativeHostService.openWindow([{ folderUri: rawFolderUri }], { forceNewWindow: true });
 			return;
 		}
 

--- a/src/vs/sessions/test/browser/resolveRemoteAuthority.test.ts
+++ b/src/vs/sessions/test/browser/resolveRemoteAuthority.test.ts
@@ -5,9 +5,10 @@
 
 import assert from 'assert';
 import { decodeHex } from '../../../base/common/buffer.js';
+import { URI } from '../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
 import { IRemoteAgentHostEntry, IRemoteAgentHostService, getEntryAddress, RemoteAgentHostEntryType } from '../../../platform/agentHost/common/remoteAgentHostService.js';
-import { resolveRemoteAuthority, sshAuthorityString } from '../../browser/openInVSCodeUtils.js';
+import { getOpenInVSCodeUri, getVSCodeProtocolScheme, resolveRemoteAuthority, sshAuthorityString } from '../../browser/openInVSCodeUtils.js';
 import { ISessionsProvidersService } from '../../services/sessions/browser/sessionsProvidersService.js';
 
 suite('resolveRemoteAuthority', () => {
@@ -229,5 +230,58 @@ suite('sshAuthorityString', () => {
 			hostName: 'actualhost',
 		});
 		assert.strictEqual(result, 'actualhost');
+	});
+});
+
+suite('Open in Editor URI', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('preserves the session resource when opening a local workspace', () => {
+		const uri = getOpenInVSCodeUri(
+			getVSCodeProtocolScheme({ quality: 'insider', urlProtocol: 'vscode-insiders' }),
+			URI.file('/workspace'),
+			undefined,
+			URI.parse('agent-host-copilotcli:/session-id'),
+		);
+
+		assert.deepStrictEqual({
+			scheme: uri.scheme,
+			authority: uri.authority,
+			path: uri.path,
+			params: Object.fromEntries(new URLSearchParams(uri.query)),
+		}, {
+			scheme: 'vscode-insiders',
+			authority: 'file',
+			path: '/workspace',
+			params: {
+				windowId: '_blank',
+				session: 'agent-host-copilotcli:/session-id',
+			},
+		});
+	});
+
+	test('uses the remote workspace protocol URI', () => {
+		const uri = getOpenInVSCodeUri(
+			getVSCodeProtocolScheme({ quality: 'stable', urlProtocol: 'vscode' }),
+			URI.file('/workspace'),
+			'ssh-remote+host',
+			URI.parse('agent-host-copilotcli:/session-id'),
+		);
+
+		assert.deepStrictEqual({
+			scheme: uri.scheme,
+			authority: uri.authority,
+			path: uri.path,
+			params: Object.fromEntries(new URLSearchParams(uri.query)),
+		}, {
+			scheme: 'vscode',
+			authority: 'vscode-remote',
+			path: '/ssh-remote+host/workspace',
+			params: {
+				windowId: '_blank',
+				session: 'agent-host-copilotcli:/session-id',
+			},
+		});
 	});
 });


### PR DESCRIPTION
Fix #323381

## Summary
- Route desktop Agents window **Open in Editor** through the existing VS Code protocol URL path.
- Include the active Agent Host session resource so the Editor window restores the chat alongside its worktree.
- Share protocol-URI construction between browser and Electron actions, with local and remote coverage.

## Validation
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `./scripts/test.sh --runGlob '**/resolveRemoteAuthority.test.js'`\n- `node --experimental-strip-types build/hygiene.ts ...`\n\n(Written by Copilot)