### PR TITLE
 Fix: Session title rename not persisting after reload

### DIFF
--- a/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts
@@ -5,7 +5,7 @@
 
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
-import { Disposable, DisposableMap, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { autorun, constObservable, IObservable, IReader, ISettableObservable, observableFromEvent, observableValue, transaction } from '../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
@@ -357,11 +357,19 @@ class LocalSession extends Disposable {
 	 * replace any prior subscription. Disposed automatically with the session.
 	 */
 	trackModel(model: IChatModel, onChange: () => void): void {
-		this._modelTracker.value = autorun(reader => {
+		const store = new DisposableStore();
+		store.add(autorun(reader => {
 			const inProgress = model.requestInProgress.read(reader);
 			this._status.set(inProgress ? SessionStatus.InProgress : SessionStatus.Completed, undefined);
 			onChange();
-		});
+		}));
+		// setCustomTitle fires onDidChange, not an observable signal
+		store.add(model.onDidChange(e => {
+			if (e.kind === 'setCustomTitle') {
+				onChange();
+			}
+		}));
+		this._modelTracker.value = store;
 	}
 
 	setMode(mode: IChatMode | undefined): void {
@@ -436,6 +444,13 @@ export class LocalChatSessionsProvider extends Disposable implements ISessionsPr
 		// subsequent messages directly (not via our sendRequest).
 		this._register(this.chatService.onDidSubmitRequest(e => {
 			const session = this._sessionCache.get(e.chatSessionResource.toString());
+			if (session) {
+				this._syncSessionFromModel(session);
+			}
+		}));
+
+		this._register(this.chatService.onDidCreateModel(model => {
+			const session = this._findSessionByResource(model.sessionResource);
 			if (session) {
 				this._syncSessionFromModel(session);
 			}

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -1970,7 +1970,7 @@ export function normalizeSerializableChatData(raw: ISerializableChatDataIn): ISe
 		};
 	}
 
-	return raw;
+	return { ...raw, customTitle: raw.customTitle };
 }
 
 function normalizeOldFields(raw: ISerializableChatDataIn): void {

--- a/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
@@ -10,6 +10,7 @@ import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { revive } from '../../../../../base/common/marshalling.js';
 import { isEqual, joinPath } from '../../../../../base/common/resources.js';
+import { hasKey } from '../../../../../base/common/types.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -628,7 +629,16 @@ export class ChatSessionStore extends Disposable {
 	public async readSession(sessionId: string): Promise<ISerializedChatDataReference | undefined> {
 		return await this.storeQueue.queue(async () => {
 			const storageLocation = this.getStorageLocation(sessionId);
-			return this.readSessionFromLocation(storageLocation.flat, storageLocation.log, sessionId);
+			const result = await this.readSessionFromLocation(storageLocation.flat, storageLocation.log, sessionId);
+			if (result && hasKey(result.value, { customTitle: true })) {
+				// Rename updates the index but not the file — index title may be newer
+				const indexTitle = this.internalGetIndex().entries[sessionId]?.title;
+				const fileTitle = result.value.customTitle;
+				if (indexTitle && fileTitle && indexTitle !== fileTitle) {
+					result.value.customTitle = indexTitle;
+				}
+			}
+			return result;
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
@@ -631,11 +631,17 @@ export class ChatSessionStore extends Disposable {
 			const storageLocation = this.getStorageLocation(sessionId);
 			const result = await this.readSessionFromLocation(storageLocation.flat, storageLocation.log, sessionId);
 			if (result && hasKey(result.value, { customTitle: true })) {
-				// Rename updates the index but not the file — index title may be newer
+				// The index is the source of truth for metadata like the title.
+				// setSessionTitle writes only to the index; the file's customTitle
+				// is updated lazily by storeSessions, so it can be stale.
 				const indexTitle = this.internalGetIndex().entries[sessionId]?.title;
-				const fileTitle = result.value.customTitle;
-				if (indexTitle && fileTitle && indexTitle !== fileTitle) {
-					result.value.customTitle = indexTitle;
+				if (indexTitle) {
+					const computedTitle = ChatModel.getDefaultTitle(result.value.requests) || localize('newChat', "New Chat");
+					if (indexTitle !== computedTitle) {
+						result.value.customTitle = indexTitle;
+					} else {
+						result.value.customTitle = undefined;
+					}
 				}
 			}
 			return result;

--- a/src/vs/workbench/contrib/chat/test/common/model/chatSessionStore.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatSessionStore.test.ts
@@ -227,6 +227,40 @@ suite('ChatSessionStore', () => {
 		assert.notStrictEqual(folder1.toString(), folder2.toString());
 	});
 
+	suite('readSession index-title sync', () => {
+		test('readSession applies renamed title from index when file is stale', async () => {
+			const store = createChatSessionStore();
+			const model = testDisposables.add(createMockChatModel(LocalChatSessionUri.forSession('session-1')));
+
+			// Store session — file gets customTitle: undefined, index gets title: "New Chat"
+			await store.storeSessions([model]);
+
+			// Rename via index only (simulates user rename before storeSessions runs)
+			await store.setSessionTitle('session-1', 'My Renamed');
+
+			// readSession should pick up the renamed title from the index
+			const result = await store.readSession('session-1');
+			assert.ok(result);
+			assert.strictEqual((result.value as ISerializableChatData3).customTitle, 'My Renamed');
+		});
+
+		test('readSession clears customTitle when index title matches computed default', async () => {
+			const store = createChatSessionStore();
+			const model = testDisposables.add(createMockChatModel(LocalChatSessionUri.forSession('session-1'), { customTitle: 'My Custom Title' }));
+
+			// Store session — file gets customTitle: "My Custom Title"
+			await store.storeSessions([model]);
+
+			// Reset title to the computed default via index
+			await store.setSessionTitle('session-1', 'New Chat');
+
+			// readSession should clear customTitle since index matches computed default
+			const result = await store.readSession('session-1');
+			assert.ok(result);
+			assert.strictEqual((result.value as ISerializableChatData3).customTitle, undefined);
+		});
+	});
+
 	suite('transferred sessions', () => {
 		function createSingleFolderWorkspace(folderUri: URI): Workspace {
 			const folder = new WorkspaceFolder({ uri: folderUri, index: 0, name: 'test' });


### PR DESCRIPTION
## Fix: Session title rename not persisting after reload

Renaming a chat session title (e.g. via the sidebar) does not survive a window reload, and the renamed title is not reflected immediately in the UI. Close #283514, #318442, #322566

### Root cause

`setSessionTitle` in [ChatSessionStore](https://github.com/microsoft/vscode/blob/f0b9006a8e2f175f978d325dc2c5d05b11e147fb/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts#L503) updates only the in-memory index, not the session data file. The file is written later by `storeSessions`. If the window is reloaded before `storeSessions` runs, `readSession` reads the old title from the file, and the rename is lost.

Additionally, `setCustomTitle` on the chat model fires `model.onDidChange` (not an observable signal), so the sessions framework in [LocalChatSessionsProvider](https://github.com/microsoft/vscode/blob/main/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts) never hears about it, so the renamed title is not reflected in the sidebar.

### Changes

**[chatSessionStore.ts](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts)** — After reading session data from disk, compare the file's `customTitle` with the index title. If they differ, prefer the index title. This closes the gap between the index (updated immediately on rename) and the file (updated lazily by `storeSessions`).

**[localChatSessionsProvider.ts](https://github.com/microsoft/vscode/blob/main/src/vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider.ts)** — Two changes:
1. `trackModel` now subscribes to `model.onDidChange` for `setCustomTitle` events in addition to the existing `autorun`, so title changes are picked up without delay.
2. Listen to `chatService.onDidCreateModel` to wire up title/status tracking when a model is created (e.g. when the user opens a session), ensuring renames propagate to the sessions framework.

### Testing

1. Open a chat session, send a message.
2. Rename the session title via the sidebar.
3. Reload the window — the renamed title should persist.
4. Rename while the session is closed — the title should update in the sidebar immediately when the session is opened.

Written with GitHub Copilot + MiMo-V2.5-Pro

CC: @osortega 