### PR TITLE
fix: preview editors show when disabled (#316786)

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -827,9 +827,12 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 
 		// Pin preview editor once user disables preview
 		if (event.oldPartOptions.enablePreview && !event.newPartOptions.enablePreview) {
-			if (this.model.previewEditor) {
-				this.pinEditor(this.model.previewEditor);
+			for (const editor of this.model.getEditors(EditorsOrder.SEQUENTIAL)) {
+				if (!this.model.isPinned(editor)) {
+					this.pinEditor(editor);
+				}
 			}
+			this.titleControl.openEditors(this.model.getEditors(EditorsOrder.SEQUENTIAL));
 		}
 	}
 

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -827,12 +827,13 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 
 		// Pin preview editor once user disables preview
 		if (event.oldPartOptions.enablePreview && !event.newPartOptions.enablePreview) {
-			for (const editor of this.model.getEditors(EditorsOrder.SEQUENTIAL)) {
+			const editors = this.model.getEditors(EditorsOrder.SEQUENTIAL);
+			for (const editor of editors) {
 				if (!this.model.isPinned(editor)) {
-					this.pinEditor(editor);
+					this.model.pin(editor);
 				}
 			}
-			this.titleControl.openEditors(this.model.getEditors(EditorsOrder.SEQUENTIAL));
+			this.titleControl.openEditors(editors);
 		}
 	}
 

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -61,7 +61,7 @@ import { applyDragImage } from '../../../../base/browser/ui/dnd/dnd.js';
 
 interface IEditorInputLabel {
 	readonly editor: EditorInput;
-	readonly pinned: boolean;
+	pinned: boolean;
 
 	readonly name?: string;
 	description?: string;
@@ -662,7 +662,10 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 	}
 
 	pinEditor(editor: EditorInput): void {
-		this.withTab(editor, (editor, tabIndex, tabContainer, tabLabelWidget, tabLabel) => this.redrawTabLabel(editor, tabIndex, tabContainer, tabLabelWidget, tabLabel));
+		this.withTab(editor, (editor, tabIndex, tabContainer, tabLabelWidget, tabLabel) => {
+			this.redrawTabLabel(editor, tabIndex, tabContainer, tabLabelWidget, tabLabel);
+			this.tabLabels[tabIndex].pinned = this.tabsModel.isPinned(editor);
+		});
 	}
 
 	stickEditor(editor: EditorInput): void {

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -61,6 +61,7 @@ import { applyDragImage } from '../../../../base/browser/ui/dnd/dnd.js';
 
 interface IEditorInputLabel {
 	readonly editor: EditorInput;
+	readonly pinned: boolean;
 
 	readonly name?: string;
 	description?: string;
@@ -576,7 +577,8 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 			labelA.description === labelB.description &&
 			labelA.forceDescription === labelB.forceDescription &&
 			labelA.title === labelB.title &&
-			labelA.ariaLabel === labelB.ariaLabel;
+			labelA.ariaLabel === labelB.ariaLabel &&
+			labelA.pinned === labelB.pinned;
 	}
 
 	beforeCloseEditor(editor: EditorInput): void {
@@ -1397,6 +1399,7 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		this.tabsModel.getEditors(EditorsOrder.SEQUENTIAL).forEach((editor: EditorInput, tabIndex: number) => {
 			labels.push({
 				editor,
+				pinned: this.tabsModel.isPinned(editor),
 				name: editor.getName(),
 				description: editor.getDescription(verbosity),
 				forceDescription: editor.hasCapability(EditorInputCapabilities.ForceDescription),


### PR DESCRIPTION

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #316786

When "Enable Preview Editors" is disabled, switching files can
cause preview editors to reappear with italic styling.

The code pinned only the current preview editor when the setting
changed. Other unpinned editors kept their preview state. The
title control didn't redraw. `handleOpenedEditors` couldn't
detect pinned state changes in its label comparison.

This change pins all editors when the preview setting turns off.
It adds `pinned` to `IEditorInputLabel` so the title control
redraws tabs.