### PR TITLE
build: avoid per-section Electron re-download in PR test runs

### DIFF
--- a/.github/workflows/pr-darwin-test.yml
+++ b/.github/workflows/pr-darwin-test.yml
@@ -122,6 +122,8 @@ jobs:
         if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
         timeout-minutes: 15
         run: ./scripts/test.sh --tfs "Unit Tests"
+        env:
+          VSCODE_SKIP_PRELAUNCH: '1'
 
       - name: 🧪 Run unit tests (node.js)
         if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
@@ -161,6 +163,8 @@ jobs:
         if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
         timeout-minutes: 20
         run: ./scripts/test-integration.sh --tfs "Integration Tests"
+        env:
+          VSCODE_SKIP_PRELAUNCH: '1'
 
       - name: 🧪 Run integration tests (Browser, Webkit)
         if: ${{ inputs.browser_tests && inputs.unit_and_integration_tests }}
@@ -171,6 +175,8 @@ jobs:
         if: ${{ inputs.remote_tests && inputs.unit_and_integration_tests }}
         timeout-minutes: 20
         run: ./scripts/test-remote-integration.sh
+        env:
+          VSCODE_SKIP_PRELAUNCH: '1'
 
       - name: Compile smoke tests
         if: ${{ inputs.smoke_tests }}

--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -324,6 +324,7 @@ jobs:
         run: ./scripts/test.sh --tfs "Unit Tests"
         env:
           DISPLAY: ":10"
+          VSCODE_SKIP_PRELAUNCH: '1'
 
       - name: 🧪 Run unit tests (node.js)
         if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
@@ -365,6 +366,7 @@ jobs:
         run: ./scripts/test-integration.sh --tfs "Integration Tests"
         env:
           DISPLAY: ":10"
+          VSCODE_SKIP_PRELAUNCH: '1'
 
       - name: 🧪 Run integration tests (Browser, Chromium)
         if: ${{ inputs.browser_tests && inputs.unit_and_integration_tests }}
@@ -377,6 +379,7 @@ jobs:
         run: ./scripts/test-remote-integration.sh
         env:
           DISPLAY: ":10"
+          VSCODE_SKIP_PRELAUNCH: '1'
 
       - name: Compile smoke tests
         if: ${{ inputs.smoke_tests }}

--- a/.github/workflows/pr-win32-test.yml
+++ b/.github/workflows/pr-win32-test.yml
@@ -130,6 +130,8 @@ jobs:
         timeout-minutes: 15
         shell: pwsh
         run: .\scripts\test.bat --tfs "Unit Tests"
+        env:
+          VSCODE_SKIP_PRELAUNCH: '1'
 
       - name: 🧪 Run unit tests (node.js)
         if: ${{ inputs.electron_tests && inputs.unit_and_integration_tests }}
@@ -181,6 +183,8 @@ jobs:
         timeout-minutes: 20
         shell: pwsh
         run: .\scripts\test-integration.bat --tfs "Integration Tests"
+        env:
+          VSCODE_SKIP_PRELAUNCH: '1'
 
       - name: 🧪 Run integration tests (Browser, Chromium)
         if: ${{ inputs.browser_tests && inputs.unit_and_integration_tests }}
@@ -193,6 +197,8 @@ jobs:
         timeout-minutes: 20
         shell: pwsh
         run: .\scripts\test-remote-integration.bat
+        env:
+          VSCODE_SKIP_PRELAUNCH: '1'
 
       - name: Diagnostics after integration test runs
         if: ${{ inputs.unit_and_integration_tests && always() }}

--- a/build/lib/preLaunch.ts
+++ b/build/lib/preLaunch.ts
@@ -33,7 +33,27 @@ async function ensureNodeModules() {
 }
 
 async function getElectron() {
+	// `npm run electron` deletes and re-downloads `.build/electron` on every
+	// invocation. When preLaunch runs repeatedly (e.g. once per integration test
+	// section) this is both wasteful and a source of flaky failures on Windows,
+	// where the just-exited Electron process can still hold file locks while the
+	// directory is being removed and re-extracted. Skip the refresh when the
+	// already-present Electron matches the expected version; any detection
+	// failure falls back to a (re)download to preserve the previous behavior.
+	if (await isExpectedElectronInstalled()) {
+		return;
+	}
 	await runProcess(npm, ['run', 'electron']);
+}
+
+async function isExpectedElectronInstalled(): Promise<boolean> {
+	try {
+		const { electronVersion } = await import('./electron.ts');
+		const installedVersion = (await fs.readFile(path.join(rootDir, '.build', 'electron', 'version'), 'utf8')).trim().replace(/^v/, '');
+		return installedVersion === electronVersion;
+	} catch {
+		return false;
+	}
 }
 
 async function ensureCompiled() {

--- a/build/lib/util.ts
+++ b/build/lib/util.ts
@@ -302,7 +302,7 @@ export function rimraf(dir: string): () => Promise<void> {
 					return c();
 				}
 
-				if (err.code === 'ENOTEMPTY' && ++retries < 5) {
+				if ((err.code === 'ENOTEMPTY' || err.code === 'EBUSY' || err.code === 'EPERM') && ++retries < 5) {
 					return setTimeout(() => retry(), 10);
 				}
 

--- a/scripts/code.bat
+++ b/scripts/code.bat
@@ -7,7 +7,10 @@ pushd %~dp0\..
 
 :: Get electron, compile, built-in extensions
 if "%VSCODE_SKIP_PRELAUNCH%"=="" (
-	node build/lib/preLaunch.ts
+	node build/lib/preLaunch.ts || (
+		echo Failed to prepare VS Code for launch ^(build/lib/preLaunch.ts^). 1>&2
+		exit /b 1
+	)
 )
 
 set "NAMESHORT="


### PR DESCRIPTION
## What

Stops the GitHub Actions PR test workflows from deleting and re-downloading `.build/electron` on every test section, which intermittently fails the **Windows / Remote** job with the bare `The system cannot find the path specified.` error.

## Why

The PR test workflows run integration/smoke tests **out of sources**, so each test section launches `scripts/code.bat` → `build/lib/preLaunch.ts`. Unlike the Azure Pipelines product builds, the GitHub workflows did **not** set `VSCODE_SKIP_PRELAUNCH`, so `preLaunch` ran on every section and `getElectron()` unconditionally `rimraf`-ed and re-extracted `.build/electron` each time.

In the failing run ([job 83783207946](https://github.com/microsoft/vscode/actions/runs/28276197801/job/83783207946)), the `### TypeScript tests` section ran this re-download ~0.45s after the previous section's Electron process exited. On Windows the just-terminated executable's files are still locked, so the delete-then-re-extract churn raced the OS and produced `The system cannot find the path specified.` (Win32 `ERROR_PATH_NOT_FOUND`), failing the whole job. The two prior sections that ran the identical command moments earlier had succeeded, and `Linux/Remote` + `macOS/Remote` passed — the race is Windows-specific.

The dedicated workflow steps already prepare everything `preLaunch` would do (`Install dependencies`, `Download built-in extensions`, `Transpile client and extensions`, `Download Electron and Playwright` — the latter with a 3× retry), so the per-section prelaunch is pure redundancy and a flake source.

## Changes

- **CI fix:** set `VSCODE_SKIP_PRELAUNCH=1` on the unit/integration/remote test steps of the `win32`, `linux` and `darwin` PR workflows, matching what Azure Pipelines already does.
- **Defense in depth:** make `getElectron()` version-aware — skip the destructive re-download when the installed Electron already matches the expected `electronVersion`, falling back to a download on any detection failure (covers paths that don't set the env var, e.g. smoke/browser and local dev).
- **Observability:** `scripts/code.bat` now fails fast with a clear message when `preLaunch.ts` fails, instead of falling through to launch a missing executable (which is what turned the real failure into a contextless "path not specified" message).
- **Resilience:** `util.rimraf` now retries on `EBUSY`/`EPERM` (the Windows file-lock error codes), not just `ENOTEMPTY`.

## Notes for reviewers

- The version-aware guard reads the `version` file inside `.build/electron` and compares it to `electronVersion` from `build/lib/electron.ts`; any failure (missing file, unexpected format, import error) falls back to the original always-download behavior, so it is strictly non-regressive.
- Validated with the build typecheck (`build && npm run typecheck`) and the pre-commit hygiene hook. Full compile/integration validation is left to CI.
