### PR TITLE
editor: don't lay out the editor part during state restore before it is shown

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -1533,8 +1533,16 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 		// Recreate grid widget from state
 		this.doCreateGridControlWithState(gridState, activeGroupId, editorGroupViewsToReuse, options);
 
-		// Layout
-		this.doLayout(this._contentDimension);
+		// Layout, but only if the part has already been laid out at least once.
+		// When restoring a working set into an editor part that has never been
+		// shown (e.g. on reload with the editor area hidden), `_contentDimension`
+		// is still undefined; laying out here would throw and abort before the
+		// `onDidAddGroup` events below are fired (leaving the restored groups
+		// unregistered with the editor service). The grid is laid out later when
+		// the part is first shown.
+		if (this._contentDimension) {
+			this.doLayout(this._contentDimension);
+		}
 
 		// Update container
 		this.updateContainer();

--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -2040,6 +2040,42 @@ suite('EditorGroupsService', () => {
 		assert.strictEqual(part.activeGroup.isEmpty, true);
 	});
 
+	test('working sets - apply state when the part has never been laid out does not throw and registers restored groups', async function () {
+		const [part] = await createPart();
+
+		const input = createTestFileEditorInput(URI.file('foo/bar'), TEST_EDITOR_INPUT_ID);
+		const input2 = createTestFileEditorInput(URI.file('foo/bar2'), TEST_EDITOR_INPUT_ID);
+
+		await part.activeGroup.openEditor(input, { pinned: true });
+		await part.sideGroup.openEditor(input2, { pinned: true });
+
+		const state = part.createState();
+
+		for (const group of part.groups) {
+			await group.closeAllEditors();
+		}
+
+		// Simulate an editor part that has never been laid out (e.g. it stayed
+		// hidden since the window opened, like the Agents window editor area
+		// after a reload with the side pane closed). In that state
+		// `_contentDimension` is still undefined and laying out during the
+		// restore would throw, aborting before the `onDidAddGroup` events fire.
+		(part as unknown as { _contentDimension: unknown })._contentDimension = undefined;
+
+		let addedGroups = 0;
+		const listener = part.onDidAddGroup(() => addedGroups++);
+
+		// Must not throw, must restore the groups, and must fire `onDidAddGroup`
+		// for them so listeners (e.g. the editor service) register them.
+		await part.applyState(state);
+		listener.dispose();
+
+		assert.strictEqual(part.count, 2);
+		assert.strictEqual(part.groups[0].contains(input), true);
+		assert.strictEqual(part.groups[1].contains(input2), true);
+		assert.ok(addedGroups >= 2, `expected at least 2 onDidAddGroup events, got ${addedGroups}`);
+	});
+
 	test('context key provider', async function () {
 		const disposables = new DisposableStore();
 

--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -2073,7 +2073,7 @@ suite('EditorGroupsService', () => {
 		assert.strictEqual(part.count, 2);
 		assert.strictEqual(part.groups[0].contains(input), true);
 		assert.strictEqual(part.groups[1].contains(input2), true);
-		assert.ok(addedGroups >= 2, `expected at least 2 onDidAddGroup events, got ${addedGroups}`);
+		assert.strictEqual(addedGroups, 2, `expected exactly 2 onDidAddGroup events, got ${addedGroups}`);
 	});
 
 	test('context key provider', async function () {


### PR DESCRIPTION
## What

`EditorPart.doApplyGridState` called `this.doLayout(this._contentDimension)` unconditionally while applying an editor working set (state restore). When the editor part has **never been laid out** — `_contentDimension` is still `undefined` — that call throws (`Cannot read properties of undefined (reading 'width')`) and aborts the method **before** the `onDidAddGroup` events are fired for the recreated groups.

As a result, the restored editor groups are never registered with `IEditorService` (its `onDidAddGroup` → `registerGroupListeners` never runs), so their `onWillOpenEditor` has no listeners.

This guards the layout call so it only runs when the part already has a content dimension. The grid is laid out later when the part is first shown.

## Why

In the **Agents window**, the editor part can stay hidden across a reload (e.g. the user closed the whole side pane). On reload the per-session layout controller restores the session's editor working set into that still-hidden, never-laid-out editor part, hitting the crash above. Because the restored group was never registered with the editor service, the Agents window's `onWillOpenEditor`-driven editor-part reveal never fired — so clicking **Changes** opened the editor into an orphaned group without ever revealing the editor part.

Repro (Agents window):
1. Open a session, click **Changes** (editor + aux bar visible), open the sessions list (all four parts visible).
2. Toggle the side pane closed (hides editor + aux bar).
3. Reload the window.
4. Click **Changes** → editor part did not open.

## Notes for reviewers

- The fix mirrors the existing defensive `!this._contentDimension` guard already used elsewhere in `editorPart.ts` (e.g. `updateTopRightGroupContextKey`).
- Low risk for the main workbench: the main editor part is always laid out at startup, so `_contentDimension` is defined there and behavior is unchanged. This only affects the case where state is applied into a part that has never been shown.
- Added a regression unit test in `editorGroupsService.test.ts` that applies state into a never-laid-out part and asserts it does not throw and still fires `onDidAddGroup` for the restored groups (verified it fails with the original `TypeError` without the fix).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>