### PR TITLE
sessions: reveal the side pane when opening Changes after collapsing it

### DIFF
--- a/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
@@ -51,6 +51,8 @@ const secondarySidebarToggleOpenIcon = registerIcon('agent-secondary-sidebar-tog
 export interface ISessionViewState {
 	readonly auxiliaryBarVisible: boolean;
 	readonly auxiliaryBarActiveViewContainerId: string | undefined;
+	/** [D9] Marks an aux-bar hide caused only by collapsing the whole side pane. */
+	readonly auxiliaryBarHiddenByCollapse?: boolean;
 }
 
 /**
@@ -120,6 +122,9 @@ export abstract class BaseLayoutController extends Disposable {
 	 * re-opening restores the same parts instead of always showing both.
 	 */
 	private _lastVisibleSidePaneParts: { readonly editor: boolean; readonly auxiliaryBar: boolean } | undefined;
+
+	/** [D9] `true` while the whole side pane is collapsed via {@link toggleSidePane}. */
+	protected _sidePaneToggledClosed = false;
 
 	private readonly _useModalConfigObs;
 	constructor(
@@ -348,6 +353,7 @@ export abstract class BaseLayoutController extends Disposable {
 				this._lastVisibleSidePaneParts = { editor: editorVisible, auxiliaryBar: auxiliaryBarVisible };
 				this._layoutService.setPartHidden(true, Parts.AUXILIARYBAR_PART);
 				this._layoutService.setPartHidden(true, Parts.EDITOR_PART);
+				this._sidePaneToggledClosed = true;
 			} else {
 				// Restore only the parts that were visible before hiding (default to
 				// both when there is no remembered state, e.g. after a reload).
@@ -364,6 +370,7 @@ export abstract class BaseLayoutController extends Disposable {
 				if (!this._layoutService.isVisible(Parts.EDITOR_PART, mainWindow) && !this._layoutService.isVisible(Parts.AUXILIARYBAR_PART)) {
 					this._layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
 				}
+				this._sidePaneToggledClosed = false;
 			}
 
 			// Let subclasses record the resulting side-pane state ([D2] capture is suppressed while toggling).

--- a/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.md
+++ b/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.md
@@ -36,7 +36,8 @@ The session header's **Changes** button opens the multi-file diff editor in the 
 
 #### D8 — Opening the Changes editor shows the side pane
 When a Changes editor is opened for an existing session, the side pane opens to the **Changes** view —
-the **first** time (no remembered choice yet) and again after the whole side pane was closed (D9). If
+the **first** time (no remembered choice yet) and again after the whole side pane was closed (D9),
+including after a reload (the pane is restored closed, but opening Changes re-reveals it). If
 you explicitly closed just the side pane (while keeping the editor open), it stays closed on later
 opens (and across reloads). An already-open side pane is left on whatever view you chose. Skipped while
 the editor is maximized (D5) or multiple sessions are visible, where the side pane is managed by other
@@ -45,8 +46,10 @@ rules.
 #### D9 — Closing the whole side pane is not an aux-bar choice
 The "side pane" is the editor area together with the auxiliary bar. Closing it (e.g. from the side
 panel toggle) hides both at once. For an **existing (created)** session that is **not** remembered as a
-choice to hide the side pane, so reopening the Changes editor shows it again (D8). Only hiding the
-auxiliary bar on its own, while the editor stays open, is remembered as an explicit "closed" choice.
+choice to hide the side pane, so reopening the Changes editor shows it again (D8) — even across a reload,
+where the pane is restored closed but is marked as collapsed (not explicitly hidden) so opening Changes
+re-reveals it. Only hiding the auxiliary bar on its own, while the editor stays open, is remembered as an
+explicit "closed" choice.
 
 #### D9b — Closing the whole side pane on a new session is remembered
 For a **new (uncreated)** session, closing (or opening) the whole side pane **is** recorded as the
@@ -146,17 +149,26 @@ defaults **on** in non-stable builds (Insiders / exploration) and **off** in sta
   the editor part without firing an active-editor change. The reveal is skipped while `_togglingSidePane`
   is set so re-opening the side pane via the toggle restores exactly `_lastVisibleSidePaneParts` instead.
   It recognizes a Changes editor via `ISessionChangesService.getSessionResource` (the multi-diff source
-  URI's session), and opens `CHANGES_VIEW_ID` when that session is the active titled session and neither
-  maximize (D5) nor multi-session mode is active, unless the session's `_viewStateBySession` entry
-  explicitly has `auxiliaryBarVisible: false`, or the aux bar is already visible. The reveal flows through
-  the [D2] listener, which records `{ auxiliaryBarVisible: true }`.
+  URI's session), and opens `CHANGES_VIEW_ID` when that session is the active titled session, the editor
+  part is **visible** (a Changes editor restored on reload becomes active while the editor part is still
+  hidden — that must not auto-reveal the side pane), and neither maximize (D5) nor multi-session mode is
+  active, unless the session's `_viewStateBySession` entry records an **explicit** aux-bar hide
+  (`auxiliaryBarVisible: false` *without* `auxiliaryBarHiddenByCollapse`), or the aux bar is already
+  visible. A hide that came from collapsing the whole side pane (D9) sets `auxiliaryBarHiddenByCollapse:
+  true`, so opening a Changes editor re-reveals the aux bar even across a reload (the pane is still
+  restored closed). The reveal flows through the [D2] listener, which records `{ auxiliaryBarVisible: true }`.
 - **Side-pane close [D9]** — the side-pane toggle lives on the controller (`toggleSidePane`). Its UI
   entry point (the `Toggle Side Panel` action: menu item, keybinding, command-palette entry, toggled
   icon) is registered by the base controller in its constructor and calls `toggleSidePane` directly.
   The toggle hides/shows the editor area and auxiliary bar together (remembering which parts to restore
-  in `_lastVisibleSidePaneParts`) while `_togglingSidePane` is set. The [D2] listener skips capture
-  while that flag is set, so closing or opening the whole side pane is never recorded as a per-session
-  (created) aux-bar choice.
+  in `_lastVisibleSidePaneParts`) while `_togglingSidePane` is set, and sets `_sidePaneToggledClosed`
+  while the pane is collapsed. The [D2] listener skips capture while `_togglingSidePane` is set, so
+  closing or opening the whole side pane is never recorded as a per-session (created) aux-bar choice.
+  However, the **save-time** capture (`_captureViewState`, used on switch-away and shutdown) records the
+  aux bar as hidden *and* sets `auxiliaryBarHiddenByCollapse: true` while `_sidePaneToggledClosed` holds,
+  so a reload restores the side pane closed yet opening Changes (D8) still re-reveals it. The flag is
+  cleared when the pane is re-opened, on a session switch, and when the [D2] listener records a genuine
+  aux-bar change.
 - **New-session side-pane close [D9b]** — the base `toggleSidePane` calls the `_onSidePaneToggled` hook
   at the end (still inside the `_togglingSidePane` window). The desktop controller overrides it: when
   the active session is **uncreated** (and not multi-session / not maximized), it records the resulting

--- a/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
@@ -116,6 +116,8 @@ export class LayoutController extends BaseLayoutController {
 			const isSessionSwitch = previousSessionResource !== undefined && !isEqual(previousSessionResource, activeSessionResource);
 			if (isSessionSwitch) {
 				this._captureViewState(previousSessionResource!);
+				// [D9] The collapsed state belongs to the session we just left.
+				this._sidePaneToggledClosed = false;
 			}
 
 			// [D4] Submit: the same session transitions from new (uncreated) to real.
@@ -166,6 +168,8 @@ export class LayoutController extends BaseLayoutController {
 			if (this._layoutService.isEditorMaximized()) {
 				return;
 			}
+			// [D9] A genuine aux-bar change ends any collapsed-side-pane state.
+			this._sidePaneToggledClosed = false;
 			const activeSession = this._sessionsService.activeSession.get();
 			if (!activeSession) {
 				return;
@@ -235,13 +239,19 @@ export class LayoutController extends BaseLayoutController {
 		if (!activeSession.isCreated.get()) {
 			return;
 		}
+		// A restored Changes editor can become active while the editor part is
+		// still hidden (e.g. its working set is restored on reload). Only reveal
+		// the side pane when the user actually opened the editor (part visible).
+		if (!this._layoutService.isVisible(Parts.EDITOR_PART, mainWindow)) {
+			return;
+		}
 		const savedState = this._viewStateBySession.get(changesSessionResource);
 		if (savedState) {
-			// The user explicitly hid the aux bar for this session, or the side
-			// pane is already open (leave it on whatever view they chose). Only an
-			// "open but currently closed" state (e.g. after the side pane was
-			// closed whole, D9) falls through to re-reveal the Changes view.
-			if (!savedState.auxiliaryBarVisible || this._layoutService.isVisible(Parts.AUXILIARYBAR_PART)) {
+			// [D8] Already open, or an explicit aux-bar hide (not a D9 collapse).
+			if (this._layoutService.isVisible(Parts.AUXILIARYBAR_PART)) {
+				return;
+			}
+			if (!savedState.auxiliaryBarVisible && !savedState.auxiliaryBarHiddenByCollapse) {
 				return;
 			}
 		}
@@ -373,9 +383,12 @@ export class LayoutController extends BaseLayoutController {
 	private _captureViewState(sessionResource: URI): void {
 		const auxiliaryBarVisible = this._layoutService.isVisible(Parts.AUXILIARYBAR_PART);
 		const activeViewContainerId = this._paneCompositePartService.getActivePaneComposite(ViewContainerLocation.AuxiliaryBar)?.getId();
+		// [D9] An aux-bar hide caused only by collapsing the whole side pane.
+		const auxiliaryBarHiddenByCollapse = !auxiliaryBarVisible && this._sidePaneToggledClosed;
 		this._viewStateBySession.set(sessionResource, {
 			auxiliaryBarVisible,
 			auxiliaryBarActiveViewContainerId: activeViewContainerId,
+			...(auxiliaryBarHiddenByCollapse ? { auxiliaryBarHiddenByCollapse: true } : {}),
 		});
 	}
 

--- a/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
@@ -791,6 +791,67 @@ suite('LayoutController (desktop)', () => {
 		);
 	});
 
+	function reloadWithSidePaneToggledClosed(): void {
+		const workspaceFolders = [{ uri: URI.file('/repo') }];
+		const controller = createController({ useModal: 'some', workspaceFolders, revealAuxiliaryBarOnOpen: true });
+		const session = makeSession(URI.parse('session:1'));
+		harness.visibleEditorsList = [{}];
+		harness.activeSessionObs.set(session, undefined);
+
+		// Open the Changes editor so the editor + aux bar are both visible and the
+		// session's aux-bar visible choice is captured.
+		harness.activeEditorResource = harness.sessionChangesService.getChangesEditorResource(session.resource);
+		harness.partVisibility.set(Parts.EDITOR_PART, true);
+		harness.onDidActiveEditorChange.fire();
+		assert.deepStrictEqual(controller.getViewState(session.resource)?.auxiliaryBarVisible, true);
+
+		// User closes the whole side pane (editor + aux bar) via the toggle, then reloads.
+		controller.toggleSidePane();
+		harness.storageService.testEmitWillSaveState(WillSaveStateReason.SHUTDOWN);
+		const stored = harness.storageService.get('sessions.layoutState', StorageScope.WORKSPACE);
+		assert.ok(stored, 'state should be persisted');
+
+		store.clear();
+		createController({ useModal: 'some', workspaceFolders, layoutState: JSON.parse(stored!), revealAuxiliaryBarOnOpen: true });
+		const reloadedSession = makeSession(URI.parse('session:1'));
+
+		// Reload restores the side pane closed (both parts hidden).
+		harness.partVisibility.set(Parts.EDITOR_PART, false);
+		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, false);
+		harness.activeSessionObs.set(reloadedSession, undefined);
+		harness.activeEditorResource = harness.sessionChangesService.getChangesEditorResource(reloadedSession.resource);
+	}
+
+	test('[D9] does not auto-reveal the side pane when the Changes editor is restored on reload', () => {
+		reloadWithSidePaneToggledClosed();
+
+		// The working set restore can make the Changes editor active again while
+		// the editor part is still hidden — this must NOT auto-reveal the side pane.
+		harness.openedViews = [];
+		harness.onDidActiveEditorChange.fire();
+
+		assert.ok(
+			!harness.openedViews.includes(CHANGES_VIEW_ID),
+			'restoring the Changes editor on reload must not auto-reveal the side pane'
+		);
+	});
+
+	test('[D9] reveals the Changes view when opening Changes after reloading a session whose side pane was toggled closed', () => {
+		reloadWithSidePaneToggledClosed();
+
+		// Clicking Open Changes opens the Changes editor (revealing the editor
+		// part); the aux bar must be revealed too because the whole-pane collapse
+		// was not an explicit aux-bar-hidden choice.
+		harness.openedViews = [];
+		harness.partVisibility.set(Parts.EDITOR_PART, true);
+		harness.onDidActiveEditorChange.fire();
+
+		assert.ok(
+			harness.openedViews.includes(CHANGES_VIEW_ID),
+			'opening Changes after reload should reveal the Changes view'
+		);
+	});
+
 	// --- [D7] Responsive sessions sidebar ---
 
 	function setPartVisible(part: Parts, visible: boolean): void {


### PR DESCRIPTION
## What

In the Agents window, the per-session layout controller did not re-reveal the auxiliary bar when opening a **Changes** editor after the whole side pane had been collapsed and the window reloaded.

This tracks a new per-session `auxiliaryBarHiddenByCollapse` bit so a *collapse-driven* aux-bar hide is distinguished from an *explicit* aux-bar hide:

- **Collapse (D9):** closing the whole side pane (editor + aux bar) via the toggle hides the aux bar as a side effect. The side pane is still restored **closed** on reload, but opening a Changes editor re-reveals the aux bar.
- **Explicit hide:** hiding just the aux bar (editor stays open) is remembered and is **not** re-revealed when a Changes editor opens.

It also gates the reveal on the editor part being **visible**, so a Changes editor restored on reload (which becomes the active editor while the editor part is still hidden) does not auto-reveal the side pane; only a user-opened Changes editor (which reveals the editor part first) does.

## Why

Repro (Agents window):
1. Open a session, click **Changes** (editor + aux bar visible), open the sessions list (all four parts visible).
2. Toggle the side pane closed (hides editor + aux bar).
3. Reload the window.
4. Click **Open Changes** → previously only the editor part opened, the aux bar (Changes view) stayed closed.

Root cause: the live aux-bar capture correctly skips a whole-pane toggle, but the **save-time** capture (switch-away / shutdown) re-read the now-hidden aux bar and persisted `auxiliaryBarVisible: false`. After reload, `_revealChangesViewOnFirstOpen` treated that as an explicit hide and never revealed.

## Notes for reviewers

- The persisted `auxiliaryBarHiddenByCollapse` flag is only written when `true` (omitted otherwise) to keep stored state minimal and existing entries unchanged.
- The flag is cleared when the side pane is re-opened, on a session switch, and when the [D2] listener records a genuine aux-bar change.
- Two focused unit tests added in `desktopSessionLayoutController.test.ts`:
  - `[D9] does not auto-reveal the side pane when the Changes editor is restored on reload` (editor part hidden → no reveal).
  - `[D9] reveals the Changes view when opening Changes after reloading a session whose side pane was toggled closed` (editor part visible → reveal).
- Spec `desktopSessionLayoutController.md` (D8/D9) updated.

Depends conceptually on the editor-part restore fix in #323342 (which is what makes the editor part open at all after reload), but is independent in code.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>