### PR TITLE
sessions: scope the side-pane collapse marker to the collapsed session

### DIFF
--- a/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
@@ -123,9 +123,6 @@ export abstract class BaseLayoutController extends Disposable {
 	 */
 	private _lastVisibleSidePaneParts: { readonly editor: boolean; readonly auxiliaryBar: boolean } | undefined;
 
-	/** [D9] `true` while the whole side pane is collapsed via {@link toggleSidePane}. */
-	protected _sidePaneToggledClosed = false;
-
 	private readonly _useModalConfigObs;
 	constructor(
 
@@ -353,7 +350,6 @@ export abstract class BaseLayoutController extends Disposable {
 				this._lastVisibleSidePaneParts = { editor: editorVisible, auxiliaryBar: auxiliaryBarVisible };
 				this._layoutService.setPartHidden(true, Parts.AUXILIARYBAR_PART);
 				this._layoutService.setPartHidden(true, Parts.EDITOR_PART);
-				this._sidePaneToggledClosed = true;
 			} else {
 				// Restore only the parts that were visible before hiding (default to
 				// both when there is no remembered state, e.g. after a reload).
@@ -370,7 +366,6 @@ export abstract class BaseLayoutController extends Disposable {
 				if (!this._layoutService.isVisible(Parts.EDITOR_PART, mainWindow) && !this._layoutService.isVisible(Parts.AUXILIARYBAR_PART)) {
 					this._layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
 				}
-				this._sidePaneToggledClosed = false;
 			}
 
 			// Let subclasses record the resulting side-pane state ([D2] capture is suppressed while toggling).

--- a/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/baseSessionLayoutController.ts
@@ -369,7 +369,7 @@ export abstract class BaseLayoutController extends Disposable {
 			}
 
 			// Let subclasses record the resulting side-pane state ([D2] capture is suppressed while toggling).
-			this._onSidePaneToggled();
+			this._onSidePaneToggled(isCurrentlyVisible, auxiliaryBarVisible);
 
 			return !isCurrentlyVisible;
 		} finally {
@@ -381,9 +381,11 @@ export abstract class BaseLayoutController extends Disposable {
 	 * Hook invoked at the end of {@link toggleSidePane}, while
 	 * {@link _togglingSidePane} is still set, so subclasses can record the
 	 * resulting side-pane state (which the [D2] capture listener deliberately
-	 * ignores). The base implementation does nothing.
+	 * ignores). `collapsed` is `true` when the toggle just hid the whole side
+	 * pane; `previousAuxiliaryBarVisible` is the aux bar's visibility before the
+	 * toggle. The base implementation does nothing.
 	 */
-	protected _onSidePaneToggled(): void { }
+	protected _onSidePaneToggled(_collapsed: boolean, _previousAuxiliaryBarVisible: boolean): void { }
 
 	/**
 	 * [B4] Hook that lets a subclass snapshot the active session's view state when

--- a/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.md
+++ b/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.md
@@ -161,21 +161,21 @@ defaults **on** in non-stable builds (Insiders / exploration) and **off** in sta
   entry point (the `Toggle Side Panel` action: menu item, keybinding, command-palette entry, toggled
   icon) is registered by the base controller in its constructor and calls `toggleSidePane` directly.
   The toggle hides/shows the editor area and auxiliary bar together (remembering which parts to restore
-  in `_lastVisibleSidePaneParts`) while `_togglingSidePane` is set, and sets `_sidePaneToggledClosed`
-  while the pane is collapsed. The [D2] listener skips capture while `_togglingSidePane` is set, so
-  closing or opening the whole side pane is never recorded as a per-session (created) aux-bar choice.
-  However, the **save-time** capture (`_captureViewState`, used on switch-away and shutdown) records the
-  aux bar as hidden *and* sets `auxiliaryBarHiddenByCollapse: true` while `_sidePaneToggledClosed` holds,
-  so a reload restores the side pane closed yet opening Changes (D8) still re-reveals it. The flag is
-  cleared when the pane is re-opened, on a session switch, and when the [D2] listener records a genuine
-  aux-bar change.
-- **New-session side-pane close [D9b]** — the base `toggleSidePane` calls the `_onSidePaneToggled` hook
-  at the end (still inside the `_togglingSidePane` window). The desktop controller overrides it: when
-  the active session is **uncreated** (and not multi-session / not maximized), it records the resulting
-  aux-bar visibility via `_setNewSessionViewState`, so a whole-side-pane close on a new session is
-  remembered just like hiding the aux bar alone. This is what makes a closed side pane survive both a
-  re-sync of the same new session and the creation of the next new session (D3b reads the recorded
-  state). For created sessions the hook is a no-op, preserving D9.
+  in `_lastVisibleSidePaneParts`) while `_togglingSidePane` is set. The [D2] listener skips capture
+  while `_togglingSidePane` is set, so closing or opening the whole side pane is never recorded by it.
+  Instead the `_onSidePaneToggled` hook (D9b) records the result for the **active** session: a collapse
+  writes that session's view state with `auxiliaryBarHiddenByCollapse: true`. The marker is therefore
+  scoped to the session that was actually collapsed — `_captureViewState` (save-time, on switch-away and
+  shutdown) only **preserves** an existing marker while the aux bar stays hidden and never fabricates one,
+  so an explicit aux-bar hide on another session is never mistaken for a collapse. On reload the side pane
+  is restored closed, yet opening Changes (D8) re-reveals it because the marker is present.
+- **New-session / side-pane close [D9b]** — the base `toggleSidePane` calls the `_onSidePaneToggled` hook
+  at the end (still inside the `_togglingSidePane` window). The desktop controller overrides it (skipped
+  while multi-session / maximized): for an **uncreated** session it records the resulting aux-bar
+  visibility via `_setNewSessionViewState` (so a closed side pane survives a re-sync of the same new
+  session and the creation of the next one, D3b); for a **created** session it captures the active
+  session's view state, marking `auxiliaryBarHiddenByCollapse: true` when the collapse left the aux bar
+  hidden.
 - **Responsive sidebar [D7]** — `_registerResponsiveSidebar` derives `spaceConstrained = enabled && small
   && editor visible && aux-bar visible && !multipleSessionsVisible` from the experimental setting
   `sessions.layout.autoCollapseSessionsSidebar` (`observableConfigValue`, default `product.quality !==

--- a/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.md
+++ b/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.md
@@ -163,19 +163,23 @@ defaults **on** in non-stable builds (Insiders / exploration) and **off** in sta
   The toggle hides/shows the editor area and auxiliary bar together (remembering which parts to restore
   in `_lastVisibleSidePaneParts`) while `_togglingSidePane` is set. The [D2] listener skips capture
   while `_togglingSidePane` is set, so closing or opening the whole side pane is never recorded by it.
-  Instead the `_onSidePaneToggled` hook (D9b) records the result for the **active** session: a collapse
-  writes that session's view state with `auxiliaryBarHiddenByCollapse: true`. The marker is therefore
-  scoped to the session that was actually collapsed — `_captureViewState` (save-time, on switch-away and
-  shutdown) only **preserves** an existing marker while the aux bar stays hidden and never fabricates one,
-  so an explicit aux-bar hide on another session is never mistaken for a collapse. On reload the side pane
-  is restored closed, yet opening Changes (D8) re-reveals it because the marker is present.
-- **New-session / side-pane close [D9b]** — the base `toggleSidePane` calls the `_onSidePaneToggled` hook
-  at the end (still inside the `_togglingSidePane` window). The desktop controller overrides it (skipped
-  while multi-session / maximized): for an **uncreated** session it records the resulting aux-bar
-  visibility via `_setNewSessionViewState` (so a closed side pane survives a re-sync of the same new
-  session and the creation of the next one, D3b); for a **created** session it captures the active
-  session's view state, marking `auxiliaryBarHiddenByCollapse: true` when the collapse left the aux bar
-  hidden.
+  Instead the `_onSidePaneToggled(collapsed, previousAuxiliaryBarVisible)` hook (D9b) records the result
+  for the **active** session: a full collapse of a previously-**visible** aux bar writes that session's
+  view state with `auxiliaryBarHiddenByCollapse: true`. The marker is therefore scoped to the session that
+  was actually collapsed — `_captureViewState` (save-time, on switch-away and shutdown) only **preserves**
+  an existing marker while the aux bar stays hidden and never fabricates one, so an explicit aux-bar hide
+  on another session is never mistaken for a collapse. On reload the side pane is restored closed, yet
+  opening Changes (D8) re-reveals it because the marker is present.
+- **New-session / side-pane close [D9b]** — the base `toggleSidePane` calls the
+  `_onSidePaneToggled(collapsed, previousAuxiliaryBarVisible)` hook at the end (still inside the
+  `_togglingSidePane` window). The desktop controller overrides it (skipped while multi-session /
+  maximized): for an **uncreated** session it records the resulting aux-bar visibility via
+  `_setNewSessionViewState` (so a closed side pane survives a re-sync of the same new session and the
+  creation of the next one, D3b). For a **created** session it marks `auxiliaryBarHiddenByCollapse: true`
+  **only** when the toggle fully collapsed a previously-visible aux bar; any other outcome (a re-open, or
+  collapsing an already editor-only state) just captures the resulting state, so an explicit aux-bar hide
+  — including one whose editor-only state is restored when the pane re-opens — is never turned into a
+  collapse.
 - **Responsive sidebar [D7]** — `_registerResponsiveSidebar` derives `spaceConstrained = enabled && small
   && editor visible && aux-bar visible && !multipleSessionsVisible` from the experimental setting
   `sessions.layout.autoCollapseSessionsSidebar` (`observableConfigValue`, default `product.quality !==

--- a/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
@@ -116,8 +116,6 @@ export class LayoutController extends BaseLayoutController {
 			const isSessionSwitch = previousSessionResource !== undefined && !isEqual(previousSessionResource, activeSessionResource);
 			if (isSessionSwitch) {
 				this._captureViewState(previousSessionResource!);
-				// [D9] The collapsed state belongs to the session we just left.
-				this._sidePaneToggledClosed = false;
 			}
 
 			// [D4] Submit: the same session transitions from new (uncreated) to real.
@@ -168,8 +166,6 @@ export class LayoutController extends BaseLayoutController {
 			if (this._layoutService.isEditorMaximized()) {
 				return;
 			}
-			// [D9] A genuine aux-bar change ends any collapsed-side-pane state.
-			this._sidePaneToggledClosed = false;
 			const activeSession = this._sessionsService.activeSession.get();
 			if (!activeSession) {
 				return;
@@ -361,8 +357,10 @@ export class LayoutController extends BaseLayoutController {
 	}
 
 	/**
-	 * [D9b] Records a whole-side-pane toggle on a new (uncreated) session as the
-	 * shared new-session aux-bar choice. See `desktopSessionLayoutController.md`.
+	 * [D9b] Records a whole-side-pane toggle for the active session. For an
+	 * uncreated session it updates the shared new-session choice; for a created
+	 * session it captures the resulting aux-bar state, marking a collapse-driven
+	 * hide so opening Changes later re-reveals it. See `desktopSessionLayoutController.md`.
 	 */
 	protected override _onSidePaneToggled(): void {
 		if (this.multipleSessionsVisibleObs.get()) {
@@ -372,10 +370,20 @@ export class LayoutController extends BaseLayoutController {
 			return;
 		}
 		const activeSession = this._sessionsService.activeSession.get();
-		if (!activeSession || activeSession.isCreated.get()) {
+		if (!activeSession) {
 			return;
 		}
-		this._setNewSessionViewState({ auxiliaryBarVisible: this._layoutService.isVisible(Parts.AUXILIARYBAR_PART) });
+		const auxiliaryBarVisible = this._layoutService.isVisible(Parts.AUXILIARYBAR_PART);
+		if (!activeSession.isCreated.get()) {
+			this._setNewSessionViewState({ auxiliaryBarVisible });
+			return;
+		}
+		const activeViewContainerId = this._paneCompositePartService.getActivePaneComposite(ViewContainerLocation.AuxiliaryBar)?.getId();
+		this._viewStateBySession.set(activeSession.resource, {
+			auxiliaryBarVisible,
+			auxiliaryBarActiveViewContainerId: activeViewContainerId,
+			...(!auxiliaryBarVisible ? { auxiliaryBarHiddenByCollapse: true } : {}),
+		});
 	}
 
 	// --- Auxiliary bar [D1] ---
@@ -383,8 +391,11 @@ export class LayoutController extends BaseLayoutController {
 	private _captureViewState(sessionResource: URI): void {
 		const auxiliaryBarVisible = this._layoutService.isVisible(Parts.AUXILIARYBAR_PART);
 		const activeViewContainerId = this._paneCompositePartService.getActivePaneComposite(ViewContainerLocation.AuxiliaryBar)?.getId();
-		// [D9] An aux-bar hide caused only by collapsing the whole side pane.
-		const auxiliaryBarHiddenByCollapse = !auxiliaryBarVisible && this._sidePaneToggledClosed;
+		// [D9] Preserve a collapse marker while the aux bar stays hidden; the
+		// marker is only ever set by `_onSidePaneToggled` for the session that was
+		// collapsed, so an explicit aux-bar hide is never mistaken for a collapse.
+		const previous = this._viewStateBySession.get(sessionResource);
+		const auxiliaryBarHiddenByCollapse = !auxiliaryBarVisible && previous?.auxiliaryBarHiddenByCollapse === true;
 		this._viewStateBySession.set(sessionResource, {
 			auxiliaryBarVisible,
 			auxiliaryBarActiveViewContainerId: activeViewContainerId,

--- a/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/desktopSessionLayoutController.ts
@@ -358,11 +358,13 @@ export class LayoutController extends BaseLayoutController {
 
 	/**
 	 * [D9b] Records a whole-side-pane toggle for the active session. For an
-	 * uncreated session it updates the shared new-session choice; for a created
-	 * session it captures the resulting aux-bar state, marking a collapse-driven
-	 * hide so opening Changes later re-reveals it. See `desktopSessionLayoutController.md`.
+	 * uncreated session it updates the shared new-session choice. For a created
+	 * session, only a full collapse of a previously-visible aux bar is marked as a
+	 * collapse-driven hide (so opening Changes later re-reveals it); any other
+	 * outcome just captures the resulting state, preserving an explicit aux-bar
+	 * hide. See `desktopSessionLayoutController.md`.
 	 */
-	protected override _onSidePaneToggled(): void {
+	protected override _onSidePaneToggled(collapsed: boolean, previousAuxiliaryBarVisible: boolean): void {
 		if (this.multipleSessionsVisibleObs.get()) {
 			return;
 		}
@@ -373,17 +375,22 @@ export class LayoutController extends BaseLayoutController {
 		if (!activeSession) {
 			return;
 		}
-		const auxiliaryBarVisible = this._layoutService.isVisible(Parts.AUXILIARYBAR_PART);
 		if (!activeSession.isCreated.get()) {
-			this._setNewSessionViewState({ auxiliaryBarVisible });
+			this._setNewSessionViewState({ auxiliaryBarVisible: this._layoutService.isVisible(Parts.AUXILIARYBAR_PART) });
 			return;
 		}
-		const activeViewContainerId = this._paneCompositePartService.getActivePaneComposite(ViewContainerLocation.AuxiliaryBar)?.getId();
-		this._viewStateBySession.set(activeSession.resource, {
-			auxiliaryBarVisible,
-			auxiliaryBarActiveViewContainerId: activeViewContainerId,
-			...(!auxiliaryBarVisible ? { auxiliaryBarHiddenByCollapse: true } : {}),
-		});
+		if (collapsed && previousAuxiliaryBarVisible) {
+			const activeViewContainerId = this._paneCompositePartService.getActivePaneComposite(ViewContainerLocation.AuxiliaryBar)?.getId();
+			this._viewStateBySession.set(activeSession.resource, {
+				auxiliaryBarVisible: false,
+				auxiliaryBarActiveViewContainerId: activeViewContainerId,
+				auxiliaryBarHiddenByCollapse: true,
+			});
+			return;
+		}
+		// Re-opened, or collapsed an already-hidden aux bar: capture the resulting
+		// state without fabricating a collapse marker (preserving explicit hides).
+		this._captureViewState(activeSession.resource);
 	}
 
 	// --- Auxiliary bar [D1] ---

--- a/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
@@ -883,6 +883,39 @@ suite('LayoutController (desktop)', () => {
 		assert.strictEqual(controller.getViewState(sessionExplicit.resource)?.auxiliaryBarHiddenByCollapse, undefined);
 	});
 
+	test('[D9] re-opening the side pane to editor-only does not mark an explicit aux-bar hide as a collapse', () => {
+		const workspaceFolders = [{ uri: URI.file('/repo') }];
+		const controller = createController({ useModal: 'some', workspaceFolders, revealAuxiliaryBarOnOpen: true });
+		const session = makeSession(URI.parse('session:1'));
+		harness.visibleEditorsList = [{}];
+
+		// Open Changes (editor + aux visible), then explicitly hide just the aux bar.
+		harness.activeSessionObs.set(session, undefined);
+		harness.activeEditorResource = harness.sessionChangesService.getChangesEditorResource(session.resource);
+		harness.partVisibility.set(Parts.EDITOR_PART, true);
+		harness.onDidActiveEditorChange.fire();
+		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, false);
+		harness.onDidChangePartVisibility.fire({ partId: Parts.AUXILIARYBAR_PART, visible: false });
+		assert.strictEqual(controller.getViewState(session.resource)?.auxiliaryBarHiddenByCollapse, undefined);
+
+		// Collapse the whole side pane, then re-open it: it restores the editor-only
+		// state (aux bar stays hidden because it was explicitly hidden before).
+		controller.toggleSidePane();
+		controller.toggleSidePane();
+
+		// The explicit aux-bar hide must not have become a collapse-driven hide.
+		assert.strictEqual(controller.getViewState(session.resource)?.auxiliaryBarHiddenByCollapse, undefined);
+
+		// Opening Changes must therefore not re-reveal the aux bar.
+		harness.openedViews = [];
+		harness.partVisibility.set(Parts.EDITOR_PART, true);
+		harness.onDidActiveEditorChange.fire();
+		assert.ok(
+			!harness.openedViews.includes(CHANGES_VIEW_ID),
+			'an explicit aux-bar hide must not re-reveal after a collapse + editor-only re-open'
+		);
+	});
+
 	// --- [D7] Responsive sessions sidebar ---
 
 	function setPartVisible(part: Parts, visible: boolean): void {

--- a/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/desktopSessionLayoutController.test.ts
@@ -852,6 +852,37 @@ suite('LayoutController (desktop)', () => {
 		);
 	});
 
+	test('[D9] does not turn an explicit aux-bar hide into a collapse when another session is collapsed', () => {
+		const workspaceFolders = [{ uri: URI.file('/repo') }];
+		const controller = createController({ useModal: 'some', workspaceFolders, revealAuxiliaryBarOnOpen: true });
+		const sessionExplicit = makeSession(URI.parse('session:explicit'));
+		const sessionCollapse = makeSession(URI.parse('session:collapse'));
+		harness.visibleEditorsList = [{}];
+
+		// Session A: open Changes (editor + aux visible), then explicitly hide just
+		// the aux bar while the editor stays open — an explicit aux-bar choice.
+		harness.activeSessionObs.set(sessionExplicit, undefined);
+		harness.activeEditorResource = harness.sessionChangesService.getChangesEditorResource(sessionExplicit.resource);
+		harness.partVisibility.set(Parts.EDITOR_PART, true);
+		harness.onDidActiveEditorChange.fire();
+		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, false);
+		harness.onDidChangePartVisibility.fire({ partId: Parts.AUXILIARYBAR_PART, visible: false });
+		assert.strictEqual(controller.getViewState(sessionExplicit.resource)?.auxiliaryBarHiddenByCollapse, undefined);
+
+		// Session B: collapse the whole side pane (marks B as collapse-hidden).
+		harness.activeSessionObs.set(sessionCollapse, undefined);
+		harness.partVisibility.set(Parts.EDITOR_PART, true);
+		harness.partVisibility.set(Parts.AUXILIARYBAR_PART, true);
+		controller.toggleSidePane();
+		assert.strictEqual(controller.getViewState(sessionCollapse.resource)?.auxiliaryBarHiddenByCollapse, true);
+
+		// Switching back to A captures it again — its explicit hide must remain
+		// explicit (no collapse marker leaking from session B's collapse).
+		harness.activeSessionObs.set(sessionExplicit, undefined);
+		harness.activeSessionObs.set(sessionCollapse, undefined);
+		assert.strictEqual(controller.getViewState(sessionExplicit.resource)?.auxiliaryBarHiddenByCollapse, undefined);
+	});
+
 	// --- [D7] Responsive sessions sidebar ---
 
 	function setPartVisible(part: Parts, visible: boolean): void {


### PR DESCRIPTION
## What

Follow-up to #323345 addressing two Copilot Code Review comments. The previous change derived the per-session `auxiliaryBarHiddenByCollapse` marker from a **controller-global** `_sidePaneToggledClosed` flag that was read at arbitrary save-time capture points. That was leaky:

- It required resetting the flag on **session switch**, which broke the flag invariant ("true while the side pane is collapsed") (CCR comment 1).
- It could still **clobber an explicit aux-bar hide** on a different session — if the flag was set while capturing a session that had explicitly hidden just the aux bar, that hide was turned into a collapse, causing it to wrongly re-reveal on Changes open (CCR comment 2).

## How

- Record the collapse marker for the **active** session directly in `_onSidePaneToggled` — at the moment the collapse happens, scoped to the session it happened on. For a created session, a collapse writes its view state with `auxiliaryBarHiddenByCollapse: true`; an expand writes `{ auxiliaryBarVisible: true }`.
- `_captureViewState` now only **preserves** an existing marker while the aux bar stays hidden, and never fabricates one from a global flag. An explicit aux-bar hide (no prior marker) therefore stays explicit.
- The global `_sidePaneToggledClosed` flag is no longer read anywhere, so it (and the session-switch / aux-bar-change resets that maintained it) is removed.

Net effect is identical user-facing behavior for the original fix (reload + open Changes after collapsing re-reveals the side pane), but the collapse marker can no longer leak across sessions.

## Notes for reviewers

- Behavior verified by the existing two `[D9]` reload tests, plus a new regression test: `[D9] does not turn an explicit aux-bar hide into a collapse when another session is collapsed` (verified it fails if `_captureViewState` fabricates the marker).
- Spec `desktopSessionLayoutController.md` (D9/D9b) updated to describe the scoped marker.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
