### PR TITLE
sessions: use secondary button border for agent feedback Remove button

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
@@ -453,7 +453,7 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 			buttonSecondaryBackground: 'var(--vscode-button-secondaryBackground)',
 			buttonSecondaryHoverBackground: 'var(--vscode-button-secondaryHoverBackground)',
 			buttonSecondaryForeground: 'var(--vscode-button-secondaryForeground)',
-			buttonSecondaryBorder: 'var(--vscode-button-border, var(--vscode-editorWidget-border, var(--vscode-widget-border)))',
+			buttonSecondaryBorder: 'var(--vscode-button-secondaryBorder)',
 		}));
 		removeButton.label = nls.localize('removeFeedbackButton', "Remove");
 		buttonStore.add(removeButton.onDidClick(() => {


### PR DESCRIPTION
## What

The `Remove` button in the agent feedback editor widget is a secondary button (next to the primary `Accept` button). Its border was set to `--vscode-button-border`, which inherits the themed/contrast border and renders blue. This swaps it to the dedicated `--vscode-button-secondaryBorder` token so it appears as a subtle gray, consistent with other secondary buttons across the UI.

## Why

A secondary button should not have a blue (primary/contrast) border. `--vscode-button-secondaryBorder` is the purpose-built token for this (a ~15% transparent foreground gray in light/dark, contrast border in HC), keeping the widget consistent with the rest of VS Code.

## Notes for reviewers

- Single-line change in `agentFeedbackEditorWidgetContribution.ts`.
- The primary `Accept` button styling is unchanged.