### PR TITLE
sessions: show Accept/Remove buttons for PR review comments in button bar

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
@@ -260,7 +260,17 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 			));
 			actionBar.push(itemActions.editAction, { icon: true, label: false });
 
+			// Comments that can be accepted — either convertible PR review
+			// comments or `created` agent feedback — render their Accept /
+			// Remove affordances in the always-visible bottom button bar, so
+			// those actions are omitted from the hover toolbar to avoid a
+			// duplicate affordance.
+			const showActionButtonsBar = comment.canConvertToAgentFeedback
+				|| (comment.source === SessionEditorCommentSource.AgentFeedback && comment.state === AgentFeedbackState.Created);
+
 			if (comment.canConvertToAgentFeedback) {
+				// The convert ("Accept") action always lives in the bottom
+				// button bar, never in the hover toolbar.
 				itemActions.convertAction = this._eventStore.add(new Action(
 					'agentFeedback.widget.convert',
 					nls.localize('convertComment', "Accept"),
@@ -268,7 +278,6 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 					true,
 					() => this._convertToAgentFeedback(comment),
 				));
-				actionBar.push(itemActions.convertAction, { icon: true, label: false });
 			}
 			itemActions.removeAction = this._eventStore.add(new Action(
 				'agentFeedback.widget.remove',
@@ -277,11 +286,7 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 				true,
 				() => this._removeComment(comment),
 			));
-			// For created agent feedback the Remove action lives in the bottom
-			// button bar instead, so it's omitted from the hover toolbar to
-			// avoid a duplicate affordance.
-			const showRemoveInToolbar = !(comment.source === SessionEditorCommentSource.AgentFeedback && comment.state === AgentFeedbackState.Created);
-			if (showRemoveInToolbar) {
+			if (!showActionButtonsBar) {
 				actionBar.push(itemActions.removeAction, { icon: true, label: false });
 			}
 
@@ -302,7 +307,7 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 				item.appendChild(this._renderReplies(comment.replies));
 			}
 
-			if (comment.source === SessionEditorCommentSource.AgentFeedback && comment.state === AgentFeedbackState.Created) {
+			if (showActionButtonsBar) {
 				this._renderActionButtons(comment, item);
 			}
 
@@ -411,8 +416,10 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 
 	/**
 	 * Renders the Accept / Remove button bar shown at the bottom of a
-	 * `created` agent feedback comment. Clicking either button performs the
-	 * action and removes the bar.
+	 * `created` agent feedback comment or a PR review comment. Clicking either
+	 * button performs the action and removes the bar. For PR review comments
+	 * "Accept" converts the comment into agent feedback; for agent feedback it
+	 * marks the comment as accepted.
 	 */
 	private _renderActionButtons(comment: ISessionEditorComment, item: HTMLElement): void {
 		const buttonBar = $('div.agent-feedback-widget-actions-bar');
@@ -443,7 +450,11 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 		}));
 		acceptButton.label = nls.localize('acceptFeedbackButton', "Accept");
 		buttonStore.add(acceptButton.onDidClick(() => {
-			this._acceptFeedback(comment);
+			if (comment.canConvertToAgentFeedback) {
+				this._convertToAgentFeedback(comment);
+			} else {
+				this._acceptFeedback(comment);
+			}
 			dismiss();
 		}));
 

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
@@ -41,7 +41,6 @@ import { ISessionFileChange } from '../../../services/sessions/common/session.js
 
 interface ICommentItemActions {
 	editAction: Action;
-	convertAction: Action | undefined;
 	removeAction: Action;
 	addReplyAction: Action;
 }
@@ -240,7 +239,7 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 			const actionBarContainer = $('div.agent-feedback-widget-item-actions');
 			const actionBar = this._eventStore.add(new ActionBar(actionBarContainer));
 
-			const itemActions: ICommentItemActions = { editAction: undefined!, convertAction: undefined, removeAction: undefined!, addReplyAction: undefined! };
+			const itemActions: ICommentItemActions = { editAction: undefined!, removeAction: undefined!, addReplyAction: undefined! };
 
 			itemActions.addReplyAction = this._eventStore.add(new Action(
 				'agentFeedback.widget.addReply',
@@ -264,21 +263,11 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 			// comments or `created` agent feedback — render their Accept /
 			// Remove affordances in the always-visible bottom button bar, so
 			// those actions are omitted from the hover toolbar to avoid a
-			// duplicate affordance.
+			// duplicate affordance. The convert ("Accept") action is never
+			// shown in the hover toolbar.
 			const showActionButtonsBar = comment.canConvertToAgentFeedback
 				|| (comment.source === SessionEditorCommentSource.AgentFeedback && comment.state === AgentFeedbackState.Created);
 
-			if (comment.canConvertToAgentFeedback) {
-				// The convert ("Accept") action always lives in the bottom
-				// button bar, never in the hover toolbar.
-				itemActions.convertAction = this._eventStore.add(new Action(
-					'agentFeedback.widget.convert',
-					nls.localize('convertComment', "Accept"),
-					ThemeIcon.asClassName(Codicon.check),
-					true,
-					() => this._convertToAgentFeedback(comment),
-				));
-			}
 			itemActions.removeAction = this._eventStore.add(new Action(
 				'agentFeedback.widget.remove',
 				nls.localize('removeComment', "Remove"),
@@ -488,9 +477,6 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 	private _startEditing(comment: ISessionEditorComment, textContainer: HTMLElement, actions: ICommentItemActions): void {
 		// Disable all actions while editing
 		actions.editAction.enabled = false;
-		if (actions.convertAction) {
-			actions.convertAction.enabled = false;
-		}
 		actions.removeAction.enabled = false;
 		actions.addReplyAction.enabled = false;
 
@@ -549,9 +535,6 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 
 		// Disable item actions while replying so the action bar doesn't conflict.
 		actions.editAction.enabled = false;
-		if (actions.convertAction) {
-			actions.convertAction.enabled = false;
-		}
 		actions.removeAction.enabled = false;
 		actions.addReplyAction.enabled = false;
 
@@ -605,9 +588,6 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 		const cleanup = () => {
 			replyStore.dispose();
 			actions.editAction.enabled = true;
-			if (actions.convertAction) {
-				actions.convertAction.enabled = true;
-			}
 			actions.removeAction.enabled = true;
 			actions.addReplyAction.enabled = true;
 			this._activeReplyInputs.delete(comment.id);
@@ -707,9 +687,6 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 
 		// Re-enable actions
 		actions.editAction.enabled = true;
-		if (actions.convertAction) {
-			actions.convertAction.enabled = true;
-		}
 		actions.removeAction.enabled = true;
 		actions.addReplyAction.enabled = true;
 


### PR DESCRIPTION
PR review comments in the agent feedback editor widget only showed Accept/Remove in the hover action bar, unlike agent review comments which show them in an always-visible bottom button bar.

This change bases the button bar visibility on whether a comment can be accepted (`canConvertToAgentFeedback` or a `created` agent feedback comment) rather than on the comment source, so PR review comments now render the Accept/Remove button bar. The convert (`Accept`) action is no longer ever shown in the hover action bar.

Note: the `ExpandedPRReviewOnly` and `ExpandedFocusedPRReview` component fixtures now render the button bar, so their screenshot baselines will need refreshing.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>