### PR TITLE
sessions: suppress Fix CI action until a new commit lands on the PR

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/checksActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/checksActions.ts
@@ -21,6 +21,13 @@ import { GitHubCheckConclusion, GitHubCheckStatus, IGitHubCICheck } from '../../
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 export const hasActiveSessionFailedCIChecks = new RawContextKey<boolean>('sessions.hasActiveSessionFailedCIChecks', false);
 
+/**
+ * True when the user has already requested a CI fix for the active session's
+ * current PR head commit. Used to hide the "Fix Checks" action until a new
+ * commit lands on the PR.
+ */
+export const activeSessionCIFixRequested = new RawContextKey<boolean>('sessions.activeSessionCIFixRequested', false);
+
 /** Command that sends the `fix-ci` prompt for the active session's failed checks. */
 export const FIX_CI_CHECKS_COMMAND_ID = 'sessions.action.fixCIChecks';
 
@@ -129,6 +136,14 @@ class ActiveSessionFailedCIChecksContextContribution extends Disposable implemen
 			const checks = ciModel.checks.read(reader);
 			return getFailedChecks(checks).length > 0;
 		}));
+
+		this._register(bindContextKey(activeSessionCIFixRequested, contextKeyService, reader => {
+			const ciModel = gitHubService.activeSessionPullRequestCIObs.read(reader);
+			if (!ciModel) {
+				return false;
+			}
+			return ciModel.fixRequested.read(reader);
+		}));
 	}
 }
 
@@ -142,12 +157,12 @@ class FixCIChecksAction extends Action2 {
 			title: localize2('fixChecks', 'Fix Checks'),
 			icon: Codicon.lightbulbAutofix,
 			category: CHAT_CATEGORY,
-			precondition: ContextKeyExpr.and(ChatContextKeys.enabled, hasActiveSessionFailedCIChecks),
+			precondition: ContextKeyExpr.and(ChatContextKeys.enabled, hasActiveSessionFailedCIChecks, activeSessionCIFixRequested.negate()),
 			menu: [{
 				id: MenuId.AgentsChangesPrimaryActionSubMenu,
 				group: '5_checks',
 				order: 4,
-				when: ContextKeyExpr.and(IsSessionsWindowContext, hasActiveSessionFailedCIChecks),
+				when: ContextKeyExpr.and(IsSessionsWindowContext, hasActiveSessionFailedCIChecks, activeSessionCIFixRequested.negate()),
 			}],
 		});
 	}
@@ -188,6 +203,7 @@ class FixCIChecksAction extends Action2 {
 		}
 
 		await chatWidget.acceptInput(prompt);
+		ciModel.markFixRequested();
 	}
 }
 

--- a/src/vs/sessions/contrib/changes/browser/checksActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/checksActions.ts
@@ -202,8 +202,10 @@ class FixCIChecksAction extends Action2 {
 			return;
 		}
 
-		await chatWidget.acceptInput(prompt);
-		ciModel.markFixRequested();
+		const response = await chatWidget.acceptInput(prompt);
+		if (response) {
+			ciModel.markFixRequested();
+		}
 	}
 }
 

--- a/src/vs/sessions/contrib/github/browser/models/githubPullRequestCIModel.ts
+++ b/src/vs/sessions/contrib/github/browser/models/githubPullRequestCIModel.ts
@@ -7,6 +7,7 @@ import { RunOnceScheduler } from '../../../../../base/common/async.js';
 import { Disposable, IDisposable, ReferenceCollection, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { IObservable, observableValue } from '../../../../../base/common/observable.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { GitHubCIOverallStatus, IGitHubCICheck } from '../../common/types.js';
 import { GitHubApiClient } from '../githubApiClient.js';
 import { computeOverallCIStatus, GitHubPRCIFetcher } from '../fetchers/githubPRCIFetcher.js';
@@ -15,12 +16,20 @@ const LOG_PREFIX = '[GitHubPullRequestCIModel]';
 const TRACE_PREFIX = '[PR-ICON-TRACE]';
 const DEFAULT_POLL_INTERVAL_MS = 60_000;
 
+/**
+ * Persisted map of `${owner}/${repo}/${prNumber}` to the PR head SHA for which
+ * the user last requested a CI fix. Used to suppress the "Fix Checks" action
+ * until a new commit lands on the PR.
+ */
+const STORAGE_KEY_FIX_REQUESTED = 'sessions.ci.fixRequested';
+
 export class GitHubPullRequestCIModelReferenceCollection extends ReferenceCollection<GitHubPullRequestCIModel> {
 	private readonly _fetcher: GitHubPRCIFetcher;
 
 	constructor(
 		apiClient: GitHubApiClient,
-		@ILogService private readonly _logService: ILogService
+		@ILogService private readonly _logService: ILogService,
+		@IStorageService private readonly _storageService: IStorageService,
 	) {
 		super();
 		this._fetcher = new GitHubPRCIFetcher(apiClient);
@@ -28,7 +37,7 @@ export class GitHubPullRequestCIModelReferenceCollection extends ReferenceCollec
 
 	protected override createReferencedObject(key: string, owner: string, repo: string, prNumber: number, headSha: string): GitHubPullRequestCIModel {
 		this._logService.trace(`${TRACE_PREFIX} [GitHubPullRequestCIModelReferenceCollection][createReferencedObject] Creating CI model for ${key}`);
-		return new GitHubPullRequestCIModel(owner, repo, prNumber, headSha, this._fetcher, this._logService);
+		return new GitHubPullRequestCIModel(owner, repo, prNumber, headSha, this._fetcher, this._logService, this._storageService);
 	}
 
 	protected override destroyReferencedObject(key: string, object: GitHubPullRequestCIModel): void {
@@ -50,10 +59,21 @@ export class GitHubPullRequestCIModel extends Disposable {
 	private readonly _overallStatus = observableValue<GitHubCIOverallStatus>(this, GitHubCIOverallStatus.Neutral);
 	readonly overallStatus: IObservable<GitHubCIOverallStatus> = this._overallStatus;
 
+	private readonly _fixRequested = observableValue<boolean>(this, false);
+	/**
+	 * Whether the user has already requested a CI fix for this PR head SHA.
+	 * Resets automatically once a new commit lands (a new model is created for
+	 * the new head SHA) so the "Fix Checks" action surfaces again.
+	 */
+	readonly fixRequested: IObservable<boolean> = this._fixRequested;
+
 	private _refreshPromise: Promise<void> | undefined = undefined;
 
 	private _pollingClientCount = 0;
 	private readonly _pollScheduler: RunOnceScheduler;
+
+	/** `${owner}/${repo}/${prNumber}` — stable across commits to the same PR. */
+	private readonly _prKey: string;
 
 	constructor(
 		readonly owner: string,
@@ -62,10 +82,50 @@ export class GitHubPullRequestCIModel extends Disposable {
 		readonly headSha: string,
 		private readonly _fetcher: GitHubPRCIFetcher,
 		private readonly _logService: ILogService,
+		private readonly _storageService: IStorageService,
 	) {
 		super();
 
+		this._prKey = `${owner}/${repo}/${prNumber}`;
+		this._fixRequested.set(this._readFixRequested(), undefined);
+
+		// Keep in sync with other windows/profiles that request a fix.
+		this._register(this._storageService.onDidChangeValue(StorageScope.PROFILE, STORAGE_KEY_FIX_REQUESTED, this._store)(() => {
+			this._fixRequested.set(this._readFixRequested(), undefined);
+		}));
+
 		this._pollScheduler = this._register(new RunOnceScheduler(() => this._poll(), DEFAULT_POLL_INTERVAL_MS));
+	}
+
+	/**
+	 * Remember that the user requested a CI fix for the current head SHA so the
+	 * "Fix Checks" action is suppressed until a new commit lands on the PR.
+	 */
+	markFixRequested(): void {
+		const map = this._readFixRequestedMap();
+		map.set(this._prKey, this.headSha);
+		this._storageService.store(STORAGE_KEY_FIX_REQUESTED, JSON.stringify(Object.fromEntries(map)), StorageScope.PROFILE, StorageTarget.USER);
+		this._fixRequested.set(true, undefined);
+	}
+
+	private _readFixRequested(): boolean {
+		return this._readFixRequestedMap().get(this._prKey) === this.headSha;
+	}
+
+	private _readFixRequestedMap(): Map<string, string> {
+		const raw = this._storageService.get(STORAGE_KEY_FIX_REQUESTED, StorageScope.PROFILE);
+		if (!raw) {
+			return new Map();
+		}
+		try {
+			const parsed = JSON.parse(raw);
+			if (parsed && typeof parsed === 'object') {
+				return new Map(Object.entries(parsed).filter((entry): entry is [string, string] => typeof entry[1] === 'string'));
+			}
+		} catch {
+			// Ignore malformed storage
+		}
+		return new Map();
 	}
 
 	/**

--- a/src/vs/sessions/contrib/github/test/browser/githubModels.test.ts
+++ b/src/vs/sessions/contrib/github/test/browser/githubModels.test.ts
@@ -502,6 +502,7 @@ suite('GitHubPullRequestCIModel', () => {
 	const store = new DisposableStore();
 	let mockFetcher: MockCIFetcher;
 	let collection: TestCIReferenceCollection;
+	let storageService: TestStorageService;
 	const logService = new NullLogService();
 
 	function acquireModel(owner: string = 'owner', repo: string = 'repo', prNumber: number = 1, headSha: string = 'abc'): GitHubPullRequestCIModel {
@@ -512,7 +513,8 @@ suite('GitHubPullRequestCIModel', () => {
 
 	setup(() => {
 		mockFetcher = new MockCIFetcher();
-		collection = new TestCIReferenceCollection(mockFetcher as unknown as GitHubPRCIFetcher, logService, store.add(new TestStorageService()));
+		storageService = store.add(new TestStorageService());
+		collection = new TestCIReferenceCollection(mockFetcher as unknown as GitHubPRCIFetcher, logService, storageService);
 	});
 
 	teardown(() => store.clear());
@@ -538,12 +540,14 @@ suite('GitHubPullRequestCIModel', () => {
 		model.markFixRequested();
 		assert.strictEqual(model.fixRequested.get(), true);
 
-		// Same PR head commit: a freshly created model sees the remembered fix.
-		const sameCommit = acquireModel('owner', 'repo', 1, 'sha-1');
-		assert.strictEqual(sameCommit.fixRequested.get(), true);
+		// A brand-new model instance for the same PR head commit reloads the
+		// remembered fix from storage (construct directly to bypass the
+		// reference collection's instance cache).
+		const reloadedSameCommit = store.add(new GitHubPullRequestCIModel('owner', 'repo', 1, 'sha-1', mockFetcher as unknown as GitHubPRCIFetcher, logService, storageService));
+		assert.strictEqual(reloadedSameCommit.fixRequested.get(), true);
 
-		// New commit on the same PR: the fix should no longer be remembered.
-		const newCommit = acquireModel('owner', 'repo', 1, 'sha-2');
+		// A new commit on the same PR: the fix should no longer be remembered.
+		const newCommit = store.add(new GitHubPullRequestCIModel('owner', 'repo', 1, 'sha-2', mockFetcher as unknown as GitHubPRCIFetcher, logService, storageService));
 		assert.strictEqual(newCommit.fixRequested.get(), false);
 	});
 

--- a/src/vs/sessions/contrib/github/test/browser/githubModels.test.ts
+++ b/src/vs/sessions/contrib/github/test/browser/githubModels.test.ts
@@ -9,6 +9,8 @@ import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
 import { NullLogService, ILogService } from '../../../../../platform/log/common/log.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { TestStorageService } from '../../../../../workbench/test/common/workbenchTestServices.js';
 import { GitHubPullRequestModel } from '../../browser/models/githubPullRequestModel.js';
 import { GitHubPullRequestReviewThreadsModel } from '../../browser/models/githubPullRequestReviewThreadsModel.js';
 import { GitHubPullRequestCIModel, GitHubPullRequestCIModelReferenceCollection, parseWorkflowRunId } from '../../browser/models/githubPullRequestCIModel.js';
@@ -510,7 +512,7 @@ suite('GitHubPullRequestCIModel', () => {
 
 	setup(() => {
 		mockFetcher = new MockCIFetcher();
-		collection = new TestCIReferenceCollection(mockFetcher as unknown as GitHubPRCIFetcher, logService);
+		collection = new TestCIReferenceCollection(mockFetcher as unknown as GitHubPRCIFetcher, logService, store.add(new TestStorageService()));
 	});
 
 	teardown(() => store.clear());
@@ -527,6 +529,22 @@ suite('GitHubPullRequestCIModel', () => {
 		const first = acquireModel();
 		const second = acquireModel();
 		assert.strictEqual(first, second);
+	});
+
+	test('fixRequested is remembered per PR head commit', () => {
+		const model = acquireModel('owner', 'repo', 1, 'sha-1');
+		assert.strictEqual(model.fixRequested.get(), false);
+
+		model.markFixRequested();
+		assert.strictEqual(model.fixRequested.get(), true);
+
+		// Same PR head commit: a freshly created model sees the remembered fix.
+		const sameCommit = acquireModel('owner', 'repo', 1, 'sha-1');
+		assert.strictEqual(sameCommit.fixRequested.get(), true);
+
+		// New commit on the same PR: the fix should no longer be remembered.
+		const newCommit = acquireModel('owner', 'repo', 1, 'sha-2');
+		assert.strictEqual(newCommit.fixRequested.get(), false);
 	});
 
 	test('refresh populates checks and computes overall status', async () => {
@@ -665,15 +683,16 @@ class TestCIReferenceCollection extends GitHubPullRequestCIModelReferenceCollect
 	constructor(
 		private readonly _testFetcher: GitHubPRCIFetcher,
 		logService: ILogService,
+		private readonly _testStorageService: IStorageService,
 	) {
 		// The base constructor instantiates a fetcher from the apiClient; pass a
 		// dummy because we override createReferencedObject below to inject the
 		// test fetcher instead.
-		super(undefined as never, logService);
+		super(undefined as never, logService, _testStorageService);
 	}
 
 	protected override createReferencedObject(_key: string, owner: string, repo: string, prNumber: number, headSha: string): GitHubPullRequestCIModel {
-		return new GitHubPullRequestCIModel(owner, repo, prNumber, headSha, this._testFetcher, new NullLogService());
+		return new GitHubPullRequestCIModel(owner, repo, prNumber, headSha, this._testFetcher, new NullLogService(), this._testStorageService);
 	}
 }
 

--- a/src/vs/sessions/contrib/github/test/browser/githubService.test.ts
+++ b/src/vs/sessions/contrib/github/test/browser/githubService.test.ts
@@ -7,6 +7,8 @@ import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { NullLogService, ILogService } from '../../../../../platform/log/common/log.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
+import { TestStorageService } from '../../../../../workbench/test/common/workbenchTestServices.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { GitHubService } from '../../browser/githubService.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -20,6 +22,7 @@ suite('GitHubService', () => {
 	setup(() => {
 		const instantiationService = store.add(new TestInstantiationService());
 		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IStorageService, store.add(new TestStorageService()));
 
 		service = store.add(instantiationService.createInstance(GitHubService));
 	});

--- a/src/vs/sessions/contrib/sessionInputBanners/browser/sessionInputBanners.ts
+++ b/src/vs/sessions/contrib/sessionInputBanners/browser/sessionInputBanners.ts
@@ -40,6 +40,8 @@ interface ICIBannerState {
 	readonly completed: number;
 	/** Number of checks still running or queued. */
 	readonly pending: number;
+	/** Whether the user already requested a CI fix for the current PR head commit. */
+	readonly fixRequested: boolean;
 }
 
 interface ICommentsBannerState {
@@ -109,7 +111,7 @@ export class SessionInputBanners extends Disposable {
 		}
 		const completed = checks.filter(check => check.status === GitHubCheckStatus.Completed).length;
 		const pending = checks.length - completed;
-		return { sessionId: session.sessionId, failed, completed, pending };
+		return { sessionId: session.sessionId, failed, completed, pending, fixRequested: ciModel.fixRequested.read(reader) };
 	});
 
 	private readonly _commentsState: IObservable<ICommentsBannerState | undefined> = derived(this, reader => {
@@ -186,11 +188,11 @@ export class SessionInputBanners extends Disposable {
 			ariaLabel: text,
 			dismissTooltip: localize('ci.dismiss', "Hide for this session"),
 			actions: [
-				{
+				...(state.fixRequested ? [] : [{
 					label: localize('ci.fixChecks', "Fix Checks"),
 					primary: true,
 					run: () => this._executeCommand(FIX_CI_CHECKS_COMMAND_ID),
-				},
+				}]),
 				{
 					label: localize('ci.revealChecks', "Reveal Checks"),
 					run: () => this._executeCommand(REVEAL_CI_CHECKS_COMMAND_ID),


### PR DESCRIPTION
Adds tracking of the PR head commit SHA for which a CI fix was requested, so the **Fix Checks** action is suppressed until a new commit lands on the PR.

## Changes
- GitHubPullRequestCIModel now exposes a persisted `fixRequested` observable and `markFixRequested()`. State is stored per PR (`owner/repo/prNumber -> headSha`) in profile storage, so it resets automatically when a new commit (new head SHA) lands and syncs across windows/profiles.
- checksActions.ts: new context key `sessions.activeSessionCIFixRequested` gates the Changes-view Fix Checks action; `run()` calls `markFixRequested()` after sending the prompt. Kept separate from `hasActiveSessionFailedCIChecks` (used by Mark as Done).
- sessionInputBanners.ts: the input banner omits the Fix Checks button once a fix was requested (still shows the failure summary + Reveal Checks).
- Added a unit test verifying the state persists per head commit and resets on a new commit.

The behavior applies no matter which button triggered the fix.