### PR TITLE
chat: avoid layout shift when switching sessions

### DIFF
--- a/src/vs/base/browser/ui/list/list.ts
+++ b/src/vs/base/browser/ui/list/list.ts
@@ -151,6 +151,10 @@ export abstract class CachedListVirtualDelegate<T extends object> implements ILi
 		return this.cache.get(element) ?? this.estimateHeight(element);
 	}
 
+	protected getCachedHeight(element: T): number | undefined {
+		return this.cache.get(element);
+	}
+
 	protected abstract estimateHeight(element: T): number;
 	abstract getTemplateId(element: T): string;
 

--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -1630,6 +1630,7 @@ export class ListView<T> implements IListView<T> {
 				const size = item.size;
 				item.size = newSize;
 				item.lastDynamicHeightWidth = this.renderWidth;
+				this.publishDynamicHeight(item);
 				return newSize - size;
 			}
 		}
@@ -1655,7 +1656,7 @@ export class ListView<T> implements IListView<T> {
 				}
 			}
 			item.lastDynamicHeightWidth = this.renderWidth;
-			this.virtualDelegate.setDynamicHeight?.(item.element, item.size);
+			this.publishDynamicHeight(item);
 			return item.size - size;
 		}
 
@@ -1674,11 +1675,17 @@ export class ListView<T> implements IListView<T> {
 		renderer.disposeElement?.(item.element, index, row.templateData);
 
 		item.lastDynamicHeightWidth = this.renderWidth;
-		this.virtualDelegate.setDynamicHeight?.(item.element, item.size);
+		this.publishDynamicHeight(item);
 		row.domNode.remove();
 		this.cache.release(row);
 
 		return item.size - size;
+	}
+
+	private publishDynamicHeight(item: IItem<T>): void {
+		if (item.size > 0) {
+			this.virtualDelegate.setDynamicHeight?.(item.element, item.size);
+		}
 	}
 
 	getElementDomId(index: number): string {

--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -1620,12 +1620,7 @@ export class ListView<T> implements IListView<T> {
 
 	private probeDynamicHeight(index: number): number {
 		const item = this.items[index];
-		const diff = this.probeDynamicHeightForItem(item, index);
-		if (diff > 0) {
-			this.virtualDelegate.setDynamicHeight?.(item.element, item.size);
-		}
-
-		return diff;
+		return this.probeDynamicHeightForItem(item, index);
 	}
 
 	private probeDynamicHeightForItem(item: IItem<T>, index: number): number {
@@ -1660,6 +1655,7 @@ export class ListView<T> implements IListView<T> {
 				}
 			}
 			item.lastDynamicHeightWidth = this.renderWidth;
+			this.virtualDelegate.setDynamicHeight?.(item.element, item.size);
 			return item.size - size;
 		}
 
@@ -1678,6 +1674,7 @@ export class ListView<T> implements IListView<T> {
 		renderer.disposeElement?.(item.element, index, row.templateData);
 
 		item.lastDynamicHeightWidth = this.renderWidth;
+		this.virtualDelegate.setDynamicHeight?.(item.element, item.size);
 		row.domNode.remove();
 		this.cache.release(row);
 

--- a/src/vs/base/test/browser/ui/list/listView.test.ts
+++ b/src/vs/base/test/browser/ui/list/listView.test.ts
@@ -76,4 +76,31 @@ suite('ListView', function () {
 			element.remove();
 		}
 	});
+
+	test('publishes positive delegate-provided dynamic heights', function () {
+		type TestElement = { height: number };
+		const publishedHeights = new Map<TestElement, number>();
+		const delegate: IListVirtualDelegate<TestElement> = {
+			getHeight() { return 100; },
+			getTemplateId() { return 'template'; },
+			getDynamicHeight(element) { return element.height; },
+			setDynamicHeight(element, height) { publishedHeights.set(element, height); }
+		};
+		const renderer: IListRenderer<TestElement, void> = {
+			templateId: 'template',
+			renderTemplate() { },
+			renderElement() { },
+			disposeTemplate() { }
+		};
+
+		const elements: TestElement[] = [{ height: 0 }, { height: 40 }, { height: 100 }, { height: 160 }];
+		const listView = new ListView<TestElement>(document.createElement('div'), delegate, [renderer], { supportDynamicHeights: true });
+		try {
+			listView.layout(400, 200);
+			listView.splice(0, 0, elements);
+			assert.deepStrictEqual(elements.map(element => publishedHeights.get(element)), [undefined, 40, 100, 160]);
+		} finally {
+			listView.dispose();
+		}
+	});
 });

--- a/src/vs/base/test/browser/ui/list/listView.test.ts
+++ b/src/vs/base/test/browser/ui/list/listView.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { IListRenderer, IListVirtualDelegate } from '../../../../browser/ui/list/list.js';
+import { CachedListVirtualDelegate, IListRenderer, IListVirtualDelegate } from '../../../../browser/ui/list/list.js';
 import { ListView } from '../../../../browser/ui/list/listView.js';
 import { range } from '../../../../common/arrays.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../common/utils.js';
@@ -39,5 +39,41 @@ suite('ListView', function () {
 		assert.strictEqual(templatesCount, 10, 'some templates have been allocated');
 		listView.dispose();
 		assert.strictEqual(templatesCount, 0, 'all templates have been disposed');
+	});
+
+	test('publishes freshly measured dynamic heights', function () {
+		const element = document.createElement('div');
+		element.style.height = '200px';
+		element.style.width = '200px';
+		document.body.appendChild(element);
+
+		type TestElement = { height: number };
+		const delegate = new class extends CachedListVirtualDelegate<TestElement> {
+			protected estimateHeight() { return 100; }
+			getTemplateId() { return 'template'; }
+			hasDynamicHeight() { return true; }
+			getMeasuredHeight(element: TestElement) { return this.getCachedHeight(element); }
+		};
+		const renderer: IListRenderer<TestElement, HTMLElement> = {
+			templateId: 'template',
+			renderTemplate(container) {
+				const content = document.createElement('div');
+				container.appendChild(content);
+				return content;
+			},
+			renderElement(element, _index, templateData) { templateData.style.height = `${element.height}px`; },
+			disposeTemplate() { }
+		};
+
+		const elements: TestElement[] = [{ height: 40 }, { height: 100 }, { height: 160 }];
+		const listView = new ListView<TestElement>(element, delegate, [renderer], { supportDynamicHeights: true });
+		try {
+			listView.layout(200, 200);
+			listView.splice(0, 0, elements);
+			assert.deepStrictEqual(elements.map(element => delegate.getMeasuredHeight(element)), [40, 100, 160]);
+		} finally {
+			listView.dispose();
+			element.remove();
+		}
 	});
 });

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -3592,6 +3592,10 @@ export class ChatListDelegate extends CachedListVirtualDelegate<ChatTreeItem> {
 	hasDynamicHeight(element: ChatTreeItem): boolean {
 		return true;
 	}
+
+	getMeasuredHeight(element: ChatTreeItem): number | undefined {
+		return this.getCachedHeight(element);
+	}
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
@@ -176,6 +176,7 @@ export class ChatListWidget extends Disposable {
 	//#region Private fields
 
 	private readonly _tree: WorkbenchObjectTree<ChatTreeItem, FuzzyScore>;
+	private readonly _delegate: ChatListDelegate;
 	private readonly _renderer: ChatListItemRenderer;
 
 	private _viewModel: IChatViewModel | undefined;
@@ -297,7 +298,7 @@ export class ChatListWidget extends Disposable {
 		));
 
 		// Create delegate
-		const delegate = scopedInstantiationService.createInstance(
+		this._delegate = scopedInstantiationService.createInstance(
 			ChatListDelegate,
 			options.defaultElementHeight ?? 200
 		);
@@ -364,7 +365,7 @@ export class ChatListWidget extends Disposable {
 			WorkbenchObjectTree<ChatTreeItem, FuzzyScore>,
 			'ChatList',
 			this._container,
-			delegate,
+			this._delegate,
 			[this._renderer],
 			{
 				identityProvider: { getId: (e: ChatTreeItem) => e.id },
@@ -531,6 +532,8 @@ export class ChatListWidget extends Disposable {
 		const items = this._viewModel.getItems();
 		this._lastItem = items.at(-1);
 		this._lastItemIdContextKey.set(this._lastItem ? [this._lastItem.id] : []);
+		const previousItem = items.at(-2);
+		const needsInitialPreviousItemHeight = (isRequestVM(previousItem) || isResponseVM(previousItem)) && previousItem.currentRenderedHeight === undefined;
 
 		const treeItems: ITreeElement<ChatTreeItem>[] = items.map(item => ({
 			element: item,
@@ -572,6 +575,10 @@ export class ChatListWidget extends Disposable {
 				}
 			});
 		});
+
+		if (needsInitialPreviousItemHeight) {
+			this.updateLastItemMinHeight();
+		}
 	}
 
 	/**
@@ -876,7 +883,7 @@ export class ChatListWidget extends Disposable {
 			const maxRequestShownHeight = 200;
 			const secondToLastItemHeight = Math.min(
 				(isRequestVM(secondToLastItem) || isResponseVM(secondToLastItem)) ?
-					secondToLastItem.currentRenderedHeight ?? 150 : 150,
+					secondToLastItem.currentRenderedHeight ?? this._delegate.getMeasuredHeight(secondToLastItem) ?? 150 : 150,
 				maxRequestShownHeight);
 			const lastItemMinHeight = Math.max(contentHeight - (secondToLastItemHeight + 10), 0);
 			this._container.style.setProperty('--chat-current-response-min-height', lastItemMinHeight + 'px');


### PR DESCRIPTION
## Summary

- publish every freshly measured dynamic list-row height to the delegate cache, including rows that shrink from their estimate
- use the cached request height to compute the final response minimum height before the initial ResizeObserver report
- preserve the existing deferred initial height-change behavior without adding another DOM measurement

## Validation

- `npm run typecheck-client`
- focused ListView, ObjectTree, and ChatListRenderer tests: 17 passing
- `npm run valid-layers-check`
- hygiene checks
- 10 alternating live session switches between short and long requests; geometry was final by the first new frame with no later shifts or ResizeObserver loop warnings

(Written by Copilot)