### PR TITLE
chat: remember focused agent session's model as last-used

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
@@ -259,8 +259,7 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 			return;
 		}
 		this.storageService.store(ChatLastUsedEditorSessionTypeStorageKey, sessionType, StorageScope.PROFILE, StorageTarget.USER);
-		// Also remember this session's current model as the last-used model for its type, so new
-		// editors restore it even when restored sessions kept their model without an explicit pick.
+		// Also remember this session's current model as the last-used model for its type.
 		widget?.input.recordCurrentModelAsSessionTypeDefault();
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
@@ -259,6 +259,9 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 			return;
 		}
 		this.storageService.store(ChatLastUsedEditorSessionTypeStorageKey, sessionType, StorageScope.PROFILE, StorageTarget.USER);
+		// Also remember this session's current model as the last-used model for its type, so new
+		// editors restore it even when restored sessions kept their model without an explicit pick.
+		widget?.input.recordCurrentModelAsSessionTypeDefault();
 	}
 
 	register(newWidget: IChatWidget): IDisposable {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1593,14 +1593,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this._syncInputStateToModel();
 	}
 
-	/**
-	 * Records this session's resolved model as the last-used model for its session type, so a new
-	 * editor/conversation of the same type restores it via `_getRememberedSessionTypeModel`.
-	 * Unlike `setCurrentLanguageModel`, this fires when a session is merely focused (not only on
-	 * explicit picks), capturing restored sessions that take the `keep` path. Skips local sessions,
-	 * session types without their own pool, and unresolved models to avoid clobbering with a
-	 * transient "Auto" during async model-list load.
-	 */
+/**
+ * Record the focused session's resolved model as the last-used model for its session type.
+ * Skips local sessions, session types without their own pool, and unresolved/out-of-pool models.
+ */
 	public recordCurrentModelAsSessionTypeDefault(): void {
 		const sessionType = this._currentSessionType;
 		const hasOwnPool = !!sessionType && this.sessionTypeHasOwnModelPool(sessionType);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1593,10 +1593,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this._syncInputStateToModel();
 	}
 
-/**
- * Record the focused session's resolved model as the last-used model for its session type.
- * Skips local sessions, session types without their own pool, and unresolved/out-of-pool models.
- */
+	/**
+	 * Record the focused session's resolved model as the last-used model for its session type.
+	 * Skips local sessions, session types without their own pool, and unresolved/out-of-pool models.
+	 */
 	public recordCurrentModelAsSessionTypeDefault(): void {
 		const sessionType = this._currentSessionType;
 		const hasOwnPool = !!sessionType && this.sessionTypeHasOwnModelPool(sessionType);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -90,7 +90,7 @@ import { IChatEditingSession, IModifiedFileEntry, ModifiedFileEntryState } from 
 import { ILanguageModelChatMetadata, ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService } from '../../../common/languageModels.js';
 import { ChatModelConfigurationStore } from './chatModelConfigurationStore.js';
 import { IChatModelInputState, IChatRequestModeInfo, IInputModel, logChangesToStateModel } from '../../../common/model/chatModel.js';
-import { filterModelsForSession, findBestMatchingModel, findDefaultModel, hasModelsTargetingSession, isModelValidForSession, mergeModelsWithCache, resolveConfiguredModel, resolveModelFromSyncState, shouldResetModelToDefault, shouldResetOnModelListChange, shouldRestoreLateArrivingModel, shouldRestorePersistedModel } from './chatModelSelectionLogic.js';
+import { filterModelsForSession, findBestMatchingModel, findDefaultModel, hasModelsTargetingSession, isModelValidForSession, mergeModelsWithCache, resolveConfiguredModel, resolveModelFromSyncState, shouldRecordSessionTypeDefaultModel, shouldResetModelToDefault, shouldResetOnModelListChange, shouldRestoreLateArrivingModel, shouldRestorePersistedModel } from './chatModelSelectionLogic.js';
 import { chatSessionResourceToId, getChatSessionType, LocalChatSessionUri } from '../../../common/model/chatUri.js';
 import { IChatResponseViewModel, isResponseVM } from '../../../common/model/chatViewModel.js';
 import { IChatAgentService } from '../../../common/participants/chatAgents.js';
@@ -1591,6 +1591,25 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 		// Sync to model
 		this._syncInputStateToModel();
+	}
+
+	/**
+	 * Records this session's resolved model as the last-used model for its session type, so a new
+	 * editor/conversation of the same type restores it via `_getRememberedSessionTypeModel`.
+	 * Unlike `setCurrentLanguageModel`, this fires when a session is merely focused (not only on
+	 * explicit picks), capturing restored sessions that take the `keep` path. Skips local sessions,
+	 * session types without their own pool, and unresolved models to avoid clobbering with a
+	 * transient "Auto" during async model-list load.
+	 */
+	public recordCurrentModelAsSessionTypeDefault(): void {
+		const sessionType = this._currentSessionType;
+		const hasOwnPool = !!sessionType && this.sessionTypeHasOwnModelPool(sessionType);
+		const model = this._currentLanguageModel.get();
+		if (!model || !shouldRecordSessionTypeDefaultModel(sessionType, hasOwnPool, model, this.getModels())) {
+			return;
+		}
+		this.storageService.store(this.getSelectedModelStorageKey(), model.identifier, StorageScope.APPLICATION, StorageTarget.USER);
+		this.storageService.store(this.getSelectedModelIsDefaultStorageKey(), !!model.metadata.isDefaultForLocation[this.location], StorageScope.APPLICATION, StorageTarget.USER);
 	}
 
 	private checkModelSupported(): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
@@ -84,6 +84,24 @@ export function hasModelsTargetingSession(
 }
 
 /**
+ * Decide whether a focused session's current model should be recorded as the last-used model for
+ * its session type. Only records non-local sessions that own a model pool and whose model is
+ * resolved and present in the pool, so a transient "Auto" during async model-list load cannot
+ * clobber the remembered selection.
+ */
+export function shouldRecordSessionTypeDefaultModel(
+	sessionType: string | undefined,
+	hasOwnPool: boolean,
+	model: ILanguageModelChatMetadataAndIdentifier | undefined,
+	models: ILanguageModelChatMetadataAndIdentifier[],
+): boolean {
+	if (!sessionType || sessionType === 'local' || !hasOwnPool || !model) {
+		return false;
+	}
+	return models.some(m => m.identifier === model.identifier);
+}
+
+/**
  * Check if a model is valid for the current session's model pool.
  * If the session has targeted models, the model must target that session type.
  * If no models target this session, the model must not be session-specific.

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionLogic.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionLogic.test.ts
@@ -21,6 +21,7 @@ import {
 	mergeModelsWithCache,
 	resolveConfiguredModel,
 	resolveModelFromSyncState,
+	shouldRecordSessionTypeDefaultModel,
 	shouldResetModelToDefault,
 	shouldResetOnModelListChange,
 	shouldRestoreLateArrivingModel,
@@ -1839,6 +1840,36 @@ suite('ChatModelSelectionLogic', () => {
 
 		test('accepts a Set of live ids', () => {
 			assert.strictEqual(reason({ trusted: true, requiresSetup: true, pickerModels: [gpt], liveModelIds: new Set([gpt.identifier]) }), undefined);
+		});
+	});
+
+	suite('shouldRecordSessionTypeDefaultModel', () => {
+		const sessionType = 'agent-host-copilotcli';
+		const opus = createSessionModel('claude-opus-4.8', 'Opus 4.8', sessionType);
+		const pool = [opus];
+
+		test('records a resolved non-local model present in the pool', () => {
+			assert.strictEqual(shouldRecordSessionTypeDefaultModel(sessionType, true, opus, pool), true);
+		});
+
+		test('skips local sessions', () => {
+			assert.strictEqual(shouldRecordSessionTypeDefaultModel('local', true, opus, pool), false);
+		});
+
+		test('skips when session type has no own pool', () => {
+			assert.strictEqual(shouldRecordSessionTypeDefaultModel(sessionType, false, opus, pool), false);
+		});
+
+		test('skips when no model is resolved (transient Auto during load)', () => {
+			assert.strictEqual(shouldRecordSessionTypeDefaultModel(sessionType, true, undefined, pool), false);
+		});
+
+		test('skips when the model is not in the pool', () => {
+			assert.strictEqual(shouldRecordSessionTypeDefaultModel(sessionType, true, opus, []), false);
+		});
+
+		test('skips when there is no session type', () => {
+			assert.strictEqual(shouldRecordSessionTypeDefaultModel(undefined, true, opus, pool), false);
 		});
 	});
 });


### PR DESCRIPTION
### Problem

New chat **editors** for agent-host session types (e.g. Copilot Agent Host) default the model picker to **Auto** even when every open editor of that type is on a non-Auto model (e.g. Opus 4.8).

Follow-up to the #322792 fix. The per-agent last-used key `chat.currentLanguageModel.<location>.<sessionType>` is only written by `setCurrentLanguageModel`, i.e. on explicit user picks. Sessions restored to a model that already matches their saved state take the `_syncFromModel` **keep** path and never call it — so the visible Opus editors never record Opus. The key keeps the last *explicit* value (`auto`), and a fresh editor with no session state reads that and shows Auto.

### Fix

Record the **focused session's resolved model** as the last-used model for its type, at the same focus chokepoint that already records the last-used agent (`ChatWidgetService.recordLastUsedSessionType`). Storage-key knowledge stays inside `ChatInputPart` via `recordCurrentModelAsSessionTypeDefault()`.

Guarded to only write when:
- the session type owns its own model pool,
- the model is resolved and present in the pool (avoids transient `auto` during async load),
- the session isn't local.

### Tests
- New `shouldRecordSessionTypeDefaultModel` pure function + 6 unit cases (record vs. local / no-pool / unresolved / not-in-pool / no-type).
- `typecheck-client` and `eslint` clean.

### Notes
- Diagnostic `[ModelPickerDbg]` logging from the prior research is left as-is.

Fixes https://github.com/microsoft/vscode/issues/322792