### PR TITLE
sessions: persist closed chats across session switch

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -224,6 +224,24 @@ replacement widget restores it when the user returns to the new-session view.
 Starting a send clears the stored draft before request dispatch and any view
 replacement.
 
+Per-session view state (the last active chat, the set of closed chats, grid
+order, stickiness, and which slot was active) is held in `SessionsService`'s
+`_sessionStates` map and serialized to workspace-scoped machine storage. The
+grid order / stickiness / active-slot flags are snapshotted from the live grid
+at save time (`onWillSaveState`), the last active chat is tracked reactively,
+and the closed-chat set is maintained **deterministically** in
+`closeChat`/`openChat` (`_setChatClosedState`) — adding the chat's resource when
+it is closed and removing it when reopened. This matters because switching to
+another session disposes the previous session's `VisibleSession` wrapper (and
+its in-memory closed set) before the next storage flush; keeping
+`_sessionStates` current means switching back re-seeds the wrapper
+(`_restoreClosedChats`) with the right closed chats, so closed tabs stay hidden
+across both reloads and session switches. The set is updated on the close/open
+action itself rather than derived from the `closedChats` observable (which
+intersects with the session's *loaded* chats), so it never depends on chats
+having loaded or on autorun timing. Stale URIs for chats that were later deleted
+are harmless: restore intersects the persisted set with the live chat list.
+
 `sendNewChatRequest(session, options)` accepts a `background` flag: a background
 new-session send returns the agents window to a fresh new-session view (via
 `openNewSession`) **before** creating and sending the session, and skips the

--- a/src/vs/sessions/services/sessions/browser/sessionsService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsService.ts
@@ -430,7 +430,10 @@ export class SessionsService extends Disposable implements ISessionsService {
 		// Track active chat changes to persist per-session state. The visible /
 		// active / sticky flags are snapshotted from the live grid at save time
 		// (see `_snapshotVisibleSessionStates`); here we only remember the last
-		// active chat so reopening the session restores its selected chat.
+		// active chat so reopening the session restores its selected chat. The
+		// closed-chat set is persisted deterministically in `closeChat`/`openChat`
+		// instead (see `_setChatClosedState`), so it never depends on chats being
+		// loaded or on autorun timing.
 		disposables.add(autorun(reader => {
 			const chat = activeSession.activeChat.read(reader);
 			if (chat && chat.status.read(undefined) !== SessionStatus.Untitled) {
@@ -579,6 +582,7 @@ export class SessionsService extends Disposable implements ISessionsService {
 				// Opening a chat also un-hides it if it was previously closed.
 				this._visibility.openChat(session, chat);
 				this._visibility.setActiveChat(session, chat);
+				this._setChatClosedState(session, chat, false);
 			}
 		}
 
@@ -594,6 +598,33 @@ export class SessionsService extends Disposable implements ISessionsService {
 		// Closing hides the chat from the tab strip; it stays reopenable from the
 		// session header's chats dropdown.
 		this._visibility.closeChat(session, chat);
+		this._setChatClosedState(session, chat, true);
+	}
+
+	/**
+	 * Persist a chat's closed/open state into the session's stored view state so
+	 * it survives switching the session out of the grid (which disposes its
+	 * wrapper) and reloads. Done synchronously on the close/open action rather
+	 * than reactively from `closedChats`, which would depend on the session's
+	 * chats being loaded. The main chat can never be closed and is ignored.
+	 */
+	private _setChatClosedState(session: ISession, chat: IChat, closed: boolean): void {
+		if (this.uriIdentityService.extUri.isEqual(chat.resource, session.mainChat.get().resource)) {
+			return;
+		}
+		const existing = this._sessionStates.get(session.resource);
+		const closedSet = new Set(existing?.closedChatResources ?? []);
+		const chatResource = chat.resource.toString();
+		if (closed) {
+			closedSet.add(chatResource);
+		} else if (!closedSet.delete(chatResource)) {
+			return; // nothing changed (chat was not closed)
+		}
+		this._sessionStates.set(session.resource, {
+			...existing,
+			sessionResource: session.resource.toString(),
+			closedChatResources: [...closedSet],
+		});
 	}
 
 	async openSession(sessionResource: URI, options?: { preserveFocus?: boolean }): Promise<void> {
@@ -830,12 +861,15 @@ export class SessionsService extends Disposable implements ISessionsService {
 			}
 
 			// Keep the in-memory record up to date so the session's last active
-			// chat is remembered while reopening it within this window.
+			// chat is remembered while reopening it within this window. The
+			// closed-chat set is maintained deterministically by
+			// `_setChatClosedState`; prefer it over the live (loaded-chats only)
+			// `closedChats` so a not-yet-loaded session does not drop its set.
 			const existing = this._sessionStates.get(session.resource);
 			const state: ISessionState = {
 				sessionResource: session.resource.toString(),
 				activeChatResource: session.activeChat.get()?.resource.toString() ?? existing?.activeChatResource,
-				closedChatResources: session.closedChats.get().map(c => c.resource.toString()),
+				closedChatResources: existing?.closedChatResources ?? session.closedChats.get().map(c => c.resource.toString()),
 				visibleOrder: index,
 				isSticky: session.sticky.get(),
 				isActive: session.sessionId === activeId,

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -1171,6 +1171,109 @@ suite('SessionsManagementService', () => {
 			await assert.rejects(() => service.forkChatInSession(session, URI.parse('test:///source'), 'turn-1'), /does not support forking into a chat/);
 		});
 	});
+
+	suite('closed chats persistence', () => {
+
+		function chat(id: string, status: SessionStatus = SessionStatus.Completed): IChat {
+			return { ...stubChat, resource: URI.parse(`test:///chat/${id}`), title: constObservable(id), status: constObservable(status) };
+		}
+
+		function multiChatSession(id: string, chats: IChat[]): ISession {
+			return stubSession({
+				sessionId: id,
+				providerId: 'test',
+				chats: constObservable(chats),
+				mainChat: constObservable(chats[0]),
+				capabilities: { supportsMultipleChats: true },
+			});
+		}
+
+		function setup(sessions: ISession[]) {
+			const provider = new class extends TestSessionsProvider {
+				constructor() { super(sessions[0]); }
+				override getSessions(): ISession[] { return sessions; }
+			};
+			return createSessionsManagementService(sessions[0], disposables, provider);
+		}
+
+		const closedTitles = (view: SessionsService) =>
+			(view.activeSession.get()?.closedChats.get() ?? []).map(c => c.title.get());
+
+		test('a chat closed in one session stays closed after switching away and back', async () => {
+			const sessionA = multiChatSession('A', [chat('mainA'), chat('b')]);
+			const sessionB = multiChatSession('B', [chat('mainB')]);
+			const { view } = setup([sessionA, sessionB]);
+
+			await view.openSession(sessionA.resource);
+			const activeA = view.activeSession.get()!;
+			const chatB = sessionA.chats.get().find(c => c.title.get() === 'b')!;
+			await view.closeChat(activeA, chatB);
+			assert.deepStrictEqual(closedTitles(view), ['b']);
+
+			// Switching away disposes session A's wrapper (and its in-memory closed
+			// set); switching back must restore the closed chat from persisted state.
+			await view.openSession(sessionB.resource);
+			await view.openSession(sessionA.resource);
+
+			assert.deepStrictEqual(closedTitles(view), ['b']);
+		});
+
+		test('closing the middle of three chats persists across a switch', async () => {
+			const sessionA = multiChatSession('A', [chat('c1'), chat('c2'), chat('c3')]);
+			const sessionB = multiChatSession('B', [chat('mainB')]);
+			const { view } = setup([sessionA, sessionB]);
+
+			await view.openSession(sessionA.resource);
+			const activeA = view.activeSession.get()!;
+			const middle = sessionA.chats.get().find(c => c.title.get() === 'c2')!;
+			await view.closeChat(activeA, middle);
+
+			await view.openSession(sessionB.resource);
+			await view.openSession(sessionA.resource);
+
+			const reActiveA = view.activeSession.get()!;
+			assert.deepStrictEqual({
+				open: reActiveA.openChats.get().map(c => c.title.get()),
+				closed: reActiveA.closedChats.get().map(c => c.title.get()),
+			}, {
+				open: ['c1', 'c3'],
+				closed: ['c2'],
+			});
+		});
+
+		test('closing the active chat persists across a switch', async () => {
+			const sessionA = multiChatSession('A', [chat('mainA'), chat('b')]);
+			const sessionB = multiChatSession('B', [chat('mainB')]);
+			const { view } = setup([sessionA, sessionB]);
+
+			await view.openSession(sessionA.resource);
+			const chatB = sessionA.chats.get().find(c => c.title.get() === 'b')!;
+			await view.openChat(sessionA, chatB.resource);
+			await view.closeChat(view.activeSession.get()!, chatB);
+
+			await view.openSession(sessionB.resource);
+			await view.openSession(sessionA.resource);
+
+			assert.deepStrictEqual(closedTitles(view), ['b']);
+		});
+
+		test('reopening a closed chat is also persisted across a switch', async () => {
+			const sessionA = multiChatSession('A', [chat('mainA'), chat('b')]);
+			const sessionB = multiChatSession('B', [chat('mainB')]);
+			const { view } = setup([sessionA, sessionB]);
+
+			await view.openSession(sessionA.resource);
+			const activeA = view.activeSession.get()!;
+			const chatB = sessionA.chats.get().find(c => c.title.get() === 'b')!;
+			await view.closeChat(activeA, chatB);
+			await view.openChat(sessionA, chatB.resource); // reopen
+
+			await view.openSession(sessionB.resource);
+			await view.openSession(sessionA.resource);
+
+			assert.deepStrictEqual(closedTitles(view), []);
+		});
+	});
 });
 
 /**


### PR DESCRIPTION
## What
Closed (hidden) chats in the Agents window reappeared in the tab strip when you closed a chat, switched the visible session to another session, and switched back. This persists the closed-chat state so closed tabs stay hidden across session switches (and reloads), with only one session visible at a time.

## Why
Closed-chat state lived in the VisibleSession wrapper's in-memory set and was only written to storage at save time (onWillSaveState) for visible sessions. Switching the session out of the grid disposes its wrapper before any flush, and reopening rebuilt it from stale state — so the closed set was lost. A first attempt persisted the set reactively from the closedChats observable, but that derivation is closedURIs intersected with loadedChats, so it depended on chats being loaded and on autorun timing, and still failed when a session's chats were re-resolving on switch-back.

## How
- Maintain the closed-chat set deterministically in SessionsService.closeChat/openChat via _setChatClosedState — add the chat URI on close, remove on reopen. Independent of loaded chats / autorun timing.
- Save-time snapshot prefers the explicitly maintained set over the loaded-chats-only closedChats, so a not-yet-loaded session does not drop it.
- Added a "closed chats persistence" test suite (incl. close-the-middle-of-three-chats repro). These fail without the fix.
- Updated SESSIONS.md.

Validated: tsgo typecheck, eslint, layers check, and the new tests pass; tests fail without the fix.
