### PR TITLE
Add codicon styling for auxiliary bar action items

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -291,6 +291,7 @@
 	display: none;
 }
 
+.style-override.monaco-workbench .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .codicon,
 .style-override.monaco-workbench .pane-composite-part.basepanel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .codicon {
 	font-weight: var(--vscode-agents-fontWeight-regular);
 }


### PR DESCRIPTION
Introduce codicon styling for action items in the auxiliary bar to enhance visual consistency. This change improves the overall appearance of the action items within the activity bar.

