### PR TITLE
Add title bar style override for macOS

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/titlebar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/titlebar.css
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*
+ * Style-override module: "Title Bar".
+ *
+ * Adds a small amount of top padding to the title-bar left/center/right
+ * containers so their items read as vertically centered. Scoped to macOS for
+ * now. All rules are gated behind the `.style-override` class, which the
+ * StyleOverridesContribution toggles onto the workbench container(s) when the
+ * Modern UI Update setting is enabled.
+ */
+.style-override.monaco-workbench.mac .part.titlebar > .titlebar-container > .titlebar-left,
+.style-override.monaco-workbench.mac .part.titlebar > .titlebar-container > .titlebar-center,
+.style-override.monaco-workbench.mac .part.titlebar > .titlebar-container > .titlebar-right {
+	padding-top: 2px;
+}

--- a/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
+++ b/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
@@ -25,6 +25,7 @@ import './media/scrollShadows.css';
 import './media/shadows.css';
 import './media/statusBar.css';
 import './media/tabs.css';
+import './media/titlebar.css';
 
 interface IStyleOverrideModule {
 	readonly id: string;
@@ -64,7 +65,8 @@ const STYLE_OVERRIDE_MODULES: readonly IStyleOverrideModule[] = [
 	{ id: 'scrollShadows' },
 	{ id: 'shadows' },
 	{ id: 'statusBar' },
-	{ id: 'tabs' }
+	{ id: 'tabs' },
+	{ id: 'titlebar' }
 ];
 
 /**


### PR DESCRIPTION
Introduce a style override for the title bar on macOS to enhance vertical alignment of items. This change adds padding to the title bar containers and integrates the new styles into the existing style override module. Testing involves enabling the Modern UI Update setting to see the effect on the title bar.

