### PR TITLE
Experiment-control Markdown default editor in Agents window, default off

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorConfiguration.ts
+++ b/src/vs/workbench/browser/parts/editor/editorConfiguration.ts
@@ -9,13 +9,14 @@ import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions, IConfigurationNode, ConfigurationScope } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { workbenchConfigurationNodeBase } from '../../../common/configuration.js';
-import { diffEditorsAssociationsSettingId, editorsAssociationsAgentsWindowDefault, editorsAssociationsSettingId, IEditorResolverService, RegisteredEditorInfo, RegisteredEditorPriority, toRegisteredEditorPriorityInfo } from '../../../services/editor/common/editorResolverService.js';
+import { diffEditorsAssociationsSettingId, editorsAssociationsAgentsWindowDefault, editorsAssociationsSettingId, IEditorResolverService, markdownDefaultEditorAgentsWindowSettingId, RegisteredEditorInfo, RegisteredEditorPriority, toRegisteredEditorPriorityInfo } from '../../../services/editor/common/editorResolverService.js';
 import { IJSONSchemaMap } from '../../../../base/common/jsonSchema.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { coalesce } from '../../../../base/common/arrays.js';
 import { Event } from '../../../../base/common/event.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { ByteSize, getLargeFileConfirmationLimit } from '../../../../platform/files/common/files.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 
 export class DynamicEditorConfigurations extends Disposable implements IWorkbenchContribution {
 
@@ -76,7 +77,8 @@ export class DynamicEditorConfigurations extends Disposable implements IWorkbenc
 	constructor(
 		@IEditorResolverService private readonly editorResolverService: IEditorResolverService,
 		@IExtensionService extensionService: IExtensionService,
-		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService
+		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
+		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
 		super();
 
@@ -96,6 +98,13 @@ export class DynamicEditorConfigurations extends Disposable implements IWorkbenc
 
 		// Registered editors (debounced to reduce perf overhead)
 		this._register(Event.debounce(this.editorResolverService.onDidChangeEditorRegistrations, (_, e) => e)(() => this.updateDynamicEditorConfigurations()));
+
+		// Re-register when the Agents window Markdown default editor setting changes
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(markdownDefaultEditorAgentsWindowSettingId)) {
+				this.updateDynamicEditorConfigurations();
+			}
+		}));
 	}
 
 	private updateDynamicEditorConfigurations(): void {
@@ -150,6 +159,7 @@ export class DynamicEditorConfigurations extends Disposable implements IWorkbenc
 
 		// Registers setting for editorAssociations
 		const oldEditorAssociationsConfigurationNode = this.editorAssociationsConfigurationNode;
+		const markdownDefaultEditorEnabled = this.configurationService.getValue<boolean>(markdownDefaultEditorAgentsWindowSettingId) === true;
 		this.editorAssociationsConfigurationNode = {
 			...workbenchConfigurationNodeBase,
 			properties: {
@@ -163,7 +173,7 @@ export class DynamicEditorConfigurations extends Disposable implements IWorkbenc
 						}
 					},
 					agentsWindow: {
-						default: editorsAssociationsAgentsWindowDefault
+						default: editorsAssociationsAgentsWindowDefault({ markdownDefaultEditor: markdownDefaultEditorEnabled })
 					}
 				}
 			}

--- a/src/vs/workbench/services/editor/common/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/common/editorResolverService.ts
@@ -55,7 +55,7 @@ export const markdownDefaultEditorAgentsWindowSettingId = 'workbench.editor.mark
  */
 export function editorsAssociationsAgentsWindowDefault(options?: { markdownDefaultEditor?: boolean }): Record<string, string> {
 	return {
-		'*.md': options?.markdownDefaultEditor === false ? 'vscode.markdown.preview.editor' : 'vscode.markdown.editor'
+		'*.md': options?.markdownDefaultEditor === true ? 'vscode.markdown.editor' : 'vscode.markdown.preview.editor'
 	};
 }
 

--- a/src/vs/workbench/services/editor/common/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/common/editorResolverService.ts
@@ -38,18 +38,39 @@ export const editorsAssociationsSettingId = 'workbench.editorAssociations';
 export const diffEditorsAssociationsSettingId = 'workbench.diffEditorAssociations';
 
 /**
- * Default value for `workbench.editorAssociations` in the Agents window.
- * Shared so that dynamic re-registrations of the setting preserve the override.
+ * Setting that controls whether the Markdown editor is the default editor for
+ * `*.md` files in the Agents window. Gated behind an experiment so it can be
+ * rolled out gradually. Defaults to off.
  */
-export const editorsAssociationsAgentsWindowDefault: Readonly<Record<string, string>> = Object.freeze({
-	'*.md': 'vscode.markdown.editor'
-});
+export const markdownDefaultEditorAgentsWindowSettingId = 'workbench.editor.markdownDefaultEditorInAgentsWindow';
+
+/**
+ * Builds the default value for `workbench.editorAssociations` in the Agents window.
+ * Shared so that dynamic re-registrations of the setting preserve the override.
+ *
+ * Each editor association can be toggled independently. Passing `undefined`
+ * leaves the association at its enabled default, so the static registration
+ * ends up with all defaults registered. Pass `false` to fall back to the
+ * markdown preview editor for `*.md` files.
+ */
+export function editorsAssociationsAgentsWindowDefault(options?: { markdownDefaultEditor?: boolean }): Record<string, string> {
+	return {
+		'*.md': options?.markdownDefaultEditor === false ? 'vscode.markdown.preview.editor' : 'vscode.markdown.editor'
+	};
+}
 
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 
 const editorAssociationsConfigurationNode: IConfigurationNode = {
 	...workbenchConfigurationNodeBase,
 	properties: {
+		[markdownDefaultEditorAgentsWindowSettingId]: {
+			type: 'boolean',
+			default: false,
+			tags: ['experimental'],
+			experiment: { mode: 'startup' },
+			markdownDescription: localize('editor.markdownDefaultEditorInAgentsWindow', "Controls whether the Markdown editor is used as the default editor for Markdown files in the Agents window."),
+		},
 		[editorsAssociationsSettingId]: {
 			type: 'object',
 			markdownDescription: localize('editor.editorAssociations', "Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors (for example `\"*.hex\": \"hexEditor.hexedit\"`). These have precedence over the default behavior."),
@@ -57,7 +78,7 @@ const editorAssociationsConfigurationNode: IConfigurationNode = {
 				type: 'string'
 			},
 			agentsWindow: {
-				default: editorsAssociationsAgentsWindowDefault
+				default: editorsAssociationsAgentsWindowDefault()
 			}
 		},
 		[diffEditorsAssociationsSettingId]: {


### PR DESCRIPTION
Adds an experiment-controlled setting `workbench.editor.markdownDefaultEditorInAgentsWindow` that drives whether the Markdown editor is the default editor for `*.md` files in the Agents window. Default is **off**, falling back to `vscode.markdown.preview.editor`.

- Refactored `editorsAssociationsAgentsWindowDefault` into a function taking optional editor toggles.
- Dynamic re-registration on setting change.

Fixes #323438