### PR TITLE
Style overrides: Add sash handles style override for improved UI visibility

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/sashHandles.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/sashHandles.css
@@ -44,7 +44,7 @@
 	top: 50%;
 	left: 50%;
 	transform: translate(-50%, -50%);
-	box-shadow: 0 -6px currentColor, 0 6px currentColor;
+	box-shadow: 0 -7px currentColor, 0 7px currentColor;
 	color: color-mix(in srgb, var(--vscode-foreground) 30%, transparent);
 }
 
@@ -53,7 +53,7 @@
 	left: 50%;
 	top: 50%;
 	transform: translate(-50%, -50%);
-	box-shadow: -6px 0 currentColor, 6px 0 currentColor;
+	box-shadow: -7px 0 currentColor, 7px 0 currentColor;
 	color: color-mix(in srgb, var(--vscode-foreground) 30%, transparent);
 }
 

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/sashHandles.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/sashHandles.css
@@ -77,3 +77,13 @@
 .style-override.nosidebar .monaco-sash.vertical::after {
 	content: none;
 }
+
+@media (forced-colors: active) {
+	.style-override .monaco-sash:not(.disabled)::after,
+	.style-override .monaco-sash.vertical:not(.disabled)::after,
+	.style-override .monaco-sash.horizontal:not(.disabled)::after {
+		background: CanvasText;
+		color: CanvasText;
+		opacity: 1;
+	}
+}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/sashHandles.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/sashHandles.css
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*
+ * Style-override module: "Sash Handles".
+ *
+ * With the Modern UI floating-panel treatment the workbench parts read as
+ * separate cards with a gap between them, which hides where one part ends and
+ * the next begins. Sashes are invisible until hovered, so the resize boundary
+ * is hard to find. This module gives every inter-panel sash a persistent,
+ * low-contrast grip — three small dots — so users can see where parts meet and
+ * where to grab to resize. The grip is suppressed for sashes within a part
+ * (editor splits, tree/view resizers) so only the boundaries between top-level
+ * parts are marked. On hover/active the grip fades out in favour of the
+ * existing full-length highlight (see base sash.css), so behaviour while
+ * dragging is unchanged.
+ *
+ * All rules are gated behind the `.style-override` class, which the
+ * StyleOverridesContribution toggles onto the workbench container(s) when the
+ * `workbench.experimental.modernUI` (Modern UI Update) setting is enabled.
+ * Without that class these rules never apply.
+ */
+
+/* Persistent grip handle, centered on the sash, drawn via the spare pseudo. */
+.style-override .monaco-sash:not(.disabled)::after {
+	content: '';
+	position: absolute;
+	pointer-events: none;
+	width: 3px;
+	height: 3px;
+	border-radius: 50%;
+	background: color-mix(in srgb, var(--vscode-foreground) 30%, transparent);
+	opacity: 0.5;
+}
+
+.monaco-enable-motion .style-override .monaco-sash:not(.disabled)::after {
+	transition: opacity 0.1s ease-out;
+}
+
+/* Vertical sash: three dots stacked vertically, centered. */
+.style-override .monaco-sash.vertical:not(.disabled)::after {
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	box-shadow: 0 -6px currentColor, 0 6px currentColor;
+	color: color-mix(in srgb, var(--vscode-foreground) 30%, transparent);
+}
+
+/* Horizontal sash: three dots in a row, centered. */
+.style-override .monaco-sash.horizontal:not(.disabled)::after {
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	box-shadow: -6px 0 currentColor, 6px 0 currentColor;
+	color: color-mix(in srgb, var(--vscode-foreground) 30%, transparent);
+}
+
+/* While hovering/dragging, defer to the base full-length highlight. */
+.style-override .monaco-sash.hover:not(.disabled)::after,
+.style-override .monaco-sash.active:not(.disabled)::after {
+	opacity: 0;
+}
+
+/* Only mark boundaries between top-level parts. Sashes inside a part (editor
+ * splits, tree/view resizers) live within `.part`, so suppress their grip. */
+.style-override .part .monaco-sash::after {
+	content: none;
+}
+
+/* Hide grips for collapsed parts so a flush boundary isn't marked (and the
+ * panel grip can't be clipped by the status bar). The workbench container
+ * carries `nopanel`/`nosidebar` when those parts are hidden: the panel sash is
+ * horizontal, the primary side bar sash is vertical. */
+.style-override.nopanel .monaco-sash.horizontal::after,
+.style-override.nosidebar .monaco-sash.vertical::after {
+	content: none;
+}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/sashHandles.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/sashHandles.css
@@ -28,8 +28,8 @@
 	content: '';
 	position: absolute;
 	pointer-events: none;
-	width: 3px;
-	height: 3px;
+	width: 4px;
+	height: 4px;
 	border-radius: 50%;
 	background: color-mix(in srgb, var(--vscode-foreground) 30%, transparent);
 	opacity: 0.5;

--- a/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
+++ b/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
@@ -21,6 +21,7 @@ import './media/keyboardFocusOnly.css';
 import './media/padding.css';
 import './media/paneHeaders.css';
 import './media/roundedCorners.css';
+import './media/sashHandles.css';
 import './media/scrollShadows.css';
 import './media/shadows.css';
 import './media/statusBar.css';
@@ -62,6 +63,7 @@ const STYLE_OVERRIDE_MODULES: readonly IStyleOverrideModule[] = [
 	{ id: 'padding' },
 	{ id: 'paneHeaders', layoutAffecting: true },
 	{ id: 'roundedCorners' },
+	{ id: 'sashHandles' },
 	{ id: 'scrollShadows' },
 	{ id: 'shadows' },
 	{ id: 'statusBar' },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/324215

This pull request adds a new style override module to visually enhance the resize sashes between top-level panels in the workbench. The main improvement is a persistent, low-contrast grip (three small dots) displayed on sashes between panels, making it easier for users to locate and interact with resize boundaries in the Modern UI. The grip is context-aware, only appearing for inter-panel sashes and fading out on hover or drag.

<img width="1840" height="1132" alt="image" src="https://github.com/user-attachments/assets/f3cba3ad-f484-4049-8604-9fbbc4b085d0" />

**New "Sash Handles" style override:**

* Added a new CSS file, `sashHandles.css`, which introduces a persistent, low-contrast grip (three dots) on inter-panel sashes, improving their visibility and usability. The grip only appears when the Modern UI style override is enabled, and is suppressed for sashes inside parts, for collapsed panels/sidebars, and during hover or drag actions.
* Registered and imported the new `sashHandles` style override module in the style overrides contribution, ensuring it is loaded and available when the Modern UI is active. [[1]](diffhunk://#diff-a865927f9a8f20356e381f95544db109d49d6ae661c7a60a1a50a37e329aadc2R24) [[2]](diffhunk://#diff-a865927f9a8f20356e381f95544db109d49d6ae661c7a60a1a50a37e329aadc2R66)