### PR TITLE
Hide new-session tours while a modal editor is visible

### DIFF
--- a/src/vs/sessions/contrib/onboardingTours/browser/tours/newSessionTour.ts
+++ b/src/vs/sessions/contrib/onboardingTours/browser/tours/newSessionTour.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IObservable } from '../../../../../base/common/observable.js';
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { EditorPartModalContext } from '../../../../../workbench/common/contextkeys.js';
 import { ChatContextKeys } from '../../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
 import { IOnboardingScenario } from '../../../../../workbench/contrib/onboarding/common/onboardingScenario.js';
 import { ISpotlightPayload, SPOTLIGHT_PRESENTATION_KIND } from '../../../../../workbench/contrib/onboarding/browser/spotlight/spotlightTypes.js';
@@ -59,12 +61,13 @@ const newSessionPayload: ISpotlightPayload = {
  * {@link NewSessionTourContribution}, which flips it after the eligible user
  * presses the pulsing New Session button.
  * `ChatContextKeys.enabled` keeps the tour hidden when AI features are disabled.
+ * The modal-editor gate keeps the tour hidden while a modal editor is showing.
  */
 export function createNewSessionTour(signal: IObservable<boolean>): IOnboardingScenario<ISpotlightPayload> {
 	return {
 		id: NEW_SESSION_TOUR_ID,
 		seenKey: NEW_SESSION_ONBOARDING_SEEN_KEY,
-		when: ChatContextKeys.enabled,
+		when: ContextKeyExpr.and(ChatContextKeys.enabled, EditorPartModalContext.toNegated()),
 		trigger: { kind: 'observable', signal },
 		priority: 100,
 		presentation: {

--- a/src/vs/sessions/contrib/onboardingTours/browser/tours/newSessionViewTour.ts
+++ b/src/vs/sessions/contrib/onboardingTours/browser/tours/newSessionViewTour.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IObservable } from '../../../../../base/common/observable.js';
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { EditorPartModalContext } from '../../../../../workbench/common/contextkeys.js';
 import { ChatContextKeys } from '../../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
 import { IOnboardingScenario } from '../../../../../workbench/contrib/onboarding/common/onboardingScenario.js';
 import { ISpotlightPayload, SPOTLIGHT_PRESENTATION_KIND } from '../../../../../workbench/contrib/onboarding/browser/spotlight/spotlightTypes.js';
@@ -71,6 +73,7 @@ const newSessionViewPayload: ISpotlightPayload = {
  * {@link NewSessionViewTourContribution}, which flips it once an eligible
  * (brand-new) user has the new-session view open and rendered.
  * `ChatContextKeys.enabled` keeps the tour hidden when AI features are disabled.
+ * The modal-editor gate keeps the tour hidden while a modal editor is showing.
  *
  * Shares {@link NEW_SESSION_ONBOARDING_SEEN_KEY} with the pulsing-button
  * {@link createNewSessionTour} variant, so a user who has seen either tour is
@@ -80,7 +83,7 @@ export function createNewSessionViewTour(signal: IObservable<boolean>): IOnboard
 	return {
 		id: NEW_SESSION_VIEW_TOUR_ID,
 		seenKey: NEW_SESSION_ONBOARDING_SEEN_KEY,
-		when: ChatContextKeys.enabled,
+		when: ContextKeyExpr.and(ChatContextKeys.enabled, EditorPartModalContext.toNegated()),
 		trigger: { kind: 'observable', signal },
 		priority: 100,
 		presentation: {


### PR DESCRIPTION
Fixes #323453

Both new-session onboarding tours now gate their when condition on the modal editor not being visible. Combines the existing `ChatContextKeys.enabled` with `EditorPartModalContext.toNegated()` via `ContextKeyExpr.and`, so neither tour shows while a modal editor is open.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>