### PR TITLE
sessions: fix PR hover padding and horizontal scrollbar

### DIFF
--- a/src/vs/sessions/contrib/github/browser/media/pullRequestHover.css
+++ b/src/vs/sessions/contrib/github/browser/media/pullRequestHover.css
@@ -8,7 +8,7 @@
 	display: flex;
 	flex-direction: column;
 	width: 520px;
-	max-width: calc(100vw - var(--vscode-spacing-size320));
+	max-width: 100%;
 	color: var(--vscode-editorHoverWidget-foreground);
 }
 
@@ -39,6 +39,7 @@
 	font-size: var(--vscode-agents-fontSize-heading2, 18px);
 	font-weight: var(--vscode-agents-fontWeight-semiBold, 600);
 	line-height: 1.25;
+	overflow-wrap: anywhere;
 }
 
 .sessions-pr-hover-description {
@@ -47,11 +48,12 @@
 	-webkit-line-clamp: 3;
 	line-clamp: 3;
 	overflow: hidden;
-	padding: var(--vscode-spacing-size120) var(--vscode-spacing-size160);
+	padding: var(--vscode-spacing-size120) var(--vscode-spacing-size160) 0 var(--vscode-spacing-size160);
 	border-top: var(--vscode-strokeThickness) solid var(--vscode-editorHoverWidget-border);
 	font-size: var(--vscode-agents-fontSize-body1);
 	line-height: 1.4;
 	color: var(--vscode-descriptionForeground);
+	overflow-wrap: anywhere;
 }
 
 .sessions-pr-hover-branches {
@@ -59,7 +61,7 @@
 	align-items: center;
 	gap: var(--vscode-spacing-size80);
 	min-width: 0;
-	padding: 0 var(--vscode-spacing-size160) var(--vscode-spacing-size120);
+	padding: var(--vscode-spacing-size120) var(--vscode-spacing-size160);
 }
 
 .sessions-pr-hover-branch {


### PR DESCRIPTION
## What

Fixes layout issues in the GitHub PR metadata hover shown in the sessions header.

- **Description padding**: now `var(--vscode-spacing-size120) var(--vscode-spacing-size160) 0 var(--vscode-spacing-size160)` (no bottom padding).
- **Branch row padding**: now `var(--vscode-spacing-size120) var(--vscode-spacing-size160)` — adds top padding instead of `0`.
- **Horizontal scrollbar**: The hover element was fixed at `width: 520px`, but the hover widget caps its contents at `max-width: var(--vscode-hover-maxWidth, 500px)`. Since 520 > 500, the content overflowed and the hover showed a horizontal scrollbar. Changed `max-width` from `calc(100vw - var(--vscode-spacing-size320))` to `100%` so the hover fits the space it is given.

## Why

The hover previously rendered with a horizontal scrollbar because its fixed width exceeded the hover widget's max content width. It now renders cleanly within the available space.

## Notes for reviewers

- CSS-only change in `src/vs/sessions/contrib/github/browser/media/pullRequestHover.css`.
- Also added `overflow-wrap: anywhere` to the title and description to guard against long unbreakable words/URLs re-introducing overflow.
