### PR TITLE
Fix intermittent Apply CG NOTICE failures (gate to publishing builds + continueOnError)

### DIFF
--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -121,11 +121,13 @@ steps:
 
   # Start pulling the CG-generated NOTICE from the parallel Quality stage
   # in the background (overwrites repo-root ThirdPartyNotices.txt before packaging).
-  - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
-    displayName: Pull CG NOTICE (background)
+  # Publish builds only (CIBUILD=false) — CI test jobs never ship a notice.
+  - ${{ if ne(parameters.VSCODE_CIBUILD, true) }}:
+    - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
+      displayName: Pull CG NOTICE (background)
 
   - template: ../../common/install-builtin-extensions.yml@self
 
@@ -169,11 +171,14 @@ steps:
   # Block on the CG NOTICE download and overwrite ThirdPartyNotices.txt
   # before gulp packages it (and before any later signing/notarization).
   # Non-fatal: falls back to legacy on any problem.
-  - script: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
-    displayName: Apply CG NOTICE
+  - ${{ if ne(parameters.VSCODE_CIBUILD, true) }}:
+    - script: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
+      displayName: Apply CG NOTICE
+      # deemon --attach can exit non-zero if the background daemon died; never fail for that.
+      continueOnError: true
 
   - script: |
       set -e

--- a/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
@@ -172,11 +172,13 @@ steps:
 
   # Start pulling the CG-generated NOTICE from the parallel Quality stage
   # in the background (overwrites repo-root ThirdPartyNotices.txt before packaging).
-  - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
-    displayName: Pull CG NOTICE (background)
+  # Publish builds only (CIBUILD=false) — CI test jobs never ship a notice.
+  - ${{ if ne(parameters.VSCODE_CIBUILD, true) }}:
+    - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
+      displayName: Pull CG NOTICE (background)
 
   - template: ../../common/install-builtin-extensions.yml@self
 
@@ -221,11 +223,14 @@ steps:
 
   # Block on the CG NOTICE download and overwrite ThirdPartyNotices.txt
   # right before gulp packages it. Non-fatal: falls back to legacy on any problem.
-  - script: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
-    displayName: Apply CG NOTICE
+  - ${{ if ne(parameters.VSCODE_CIBUILD, true) }}:
+    - script: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
+      displayName: Apply CG NOTICE
+      # deemon --attach can exit non-zero if the background daemon died; never fail for that.
+      continueOnError: true
 
   - script: |
       set -e

--- a/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
+++ b/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
@@ -113,11 +113,13 @@ steps:
 
   # Start pulling the CG-generated NOTICE from the parallel Quality stage
   # in the background (overwrites repo-root ThirdPartyNotices.txt before packaging).
-  - pwsh: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
-    displayName: Pull CG NOTICE (background)
+  # Publish builds only (CIBUILD=false) — CI test jobs never ship a notice.
+  - ${{ if ne(parameters.VSCODE_CIBUILD, true) }}:
+    - pwsh: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
+      displayName: Pull CG NOTICE (background)
 
   - template: ../../common/install-builtin-extensions.yml@self
 
@@ -167,11 +169,14 @@ steps:
 
   # Block on the CG NOTICE download and overwrite ThirdPartyNotices.txt
   # right before gulp packages it. Non-fatal: falls back to legacy on any problem.
-  - pwsh: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
-    displayName: Apply CG NOTICE
+  - ${{ if ne(parameters.VSCODE_CIBUILD, true) }}:
+    - pwsh: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
+      displayName: Apply CG NOTICE
+      # deemon --attach can exit non-zero if the background daemon died; never fail for that.
+      continueOnError: true
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1


### PR DESCRIPTION
## Context

`Apply CG NOTICE` overwrites the repo-root `ThirdPartyNotices.txt` with the CG-generated notice before gulp packages it. It runs `downloadNotice.ts` via `deemon --attach`. The script is non-fatal by design (always exits 0, falls back to the legacy notice), but the `deemon --attach` wrapper exits non-zero when its background daemon is killed during the long compile/test phase — hard-failing the job. This only happens in CI **test** jobs (`VSCODE_CIBUILD=true`), which build a throwaway product and never ship a notice, so the step is pure waste there. Seen in [451901](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=451901&view=results) and [451613](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=451613&view=results) (both green on retry).

## Changes made

- **Gate both notice steps on `${{ if ne(parameters.VSCODE_CIBUILD, true) }}`** (win32/linux/darwin) — same guard already used for the other publish-only steps in these templates. Removes them from CI test jobs entirely.
- **`continueOnError: true` on `Apply CG NOTICE`** — on publishing builds where it still runs, a dead daemon degrades to the legacy notice instead of failing the build.

Publishing builds (`VSCODE_CIBUILD=false`) are unaffected — verified [451864](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=451864&view=results) (scheduled Product build) applies the CG notice in all 7 publish jobs.