### PR TITLE
Skip CG NOTICE steps on CI test builds

### DIFF
--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -121,11 +121,15 @@ steps:
 
   # Start pulling the CG-generated NOTICE from the parallel Quality stage
   # in the background (overwrites repo-root ThirdPartyNotices.txt before packaging).
-  - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
-    displayName: Pull CG NOTICE (background)
+  # Only on publishing builds (CIBUILD=false): CI test jobs build a throwaway
+  # product and never ship a notice, so generating/applying it there is wasted
+  # work (and the sole source of the deemon-attach flakiness).
+  - ${{ if ne(parameters.VSCODE_CIBUILD, true) }}:
+    - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
+      displayName: Pull CG NOTICE (background)
 
   - template: ../../common/install-builtin-extensions.yml@self
 
@@ -169,11 +173,13 @@ steps:
   # Block on the CG NOTICE download and overwrite ThirdPartyNotices.txt
   # before gulp packages it (and before any later signing/notarization).
   # Non-fatal: falls back to legacy on any problem.
-  - script: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
-    displayName: Apply CG NOTICE
+  # Only on publishing builds (CIBUILD=false): see Pull CG NOTICE above.
+  - ${{ if ne(parameters.VSCODE_CIBUILD, true) }}:
+    - script: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
+      displayName: Apply CG NOTICE
 
   - script: |
       set -e

--- a/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
@@ -172,11 +172,15 @@ steps:
 
   # Start pulling the CG-generated NOTICE from the parallel Quality stage
   # in the background (overwrites repo-root ThirdPartyNotices.txt before packaging).
-  - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
-    displayName: Pull CG NOTICE (background)
+  # Only on publishing builds (CIBUILD=false): CI test jobs build a throwaway
+  # product and never ship a notice, so generating/applying it there is wasted
+  # work (and the sole source of the deemon-attach flakiness).
+  - ${{ if ne(parameters.VSCODE_CIBUILD, true) }}:
+    - script: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
+      displayName: Pull CG NOTICE (background)
 
   - template: ../../common/install-builtin-extensions.yml@self
 
@@ -221,11 +225,13 @@ steps:
 
   # Block on the CG NOTICE download and overwrite ThirdPartyNotices.txt
   # right before gulp packages it. Non-fatal: falls back to legacy on any problem.
-  - script: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
-    displayName: Apply CG NOTICE
+  # Only on publishing builds (CIBUILD=false): see Pull CG NOTICE above.
+  - ${{ if ne(parameters.VSCODE_CIBUILD, true) }}:
+    - script: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
+      displayName: Apply CG NOTICE
 
   - script: |
       set -e

--- a/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
+++ b/build/azure-pipelines/win32/steps/product-build-win32-compile.yml
@@ -113,11 +113,15 @@ steps:
 
   # Start pulling the CG-generated NOTICE from the parallel Quality stage
   # in the background (overwrites repo-root ThirdPartyNotices.txt before packaging).
-  - pwsh: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
-    displayName: Pull CG NOTICE (background)
+  # Only on publishing builds (CIBUILD=false): CI test jobs build a throwaway
+  # product and never ship a notice, so generating/applying it there is wasted
+  # work (and the sole source of the deemon-attach flakiness).
+  - ${{ if ne(parameters.VSCODE_CIBUILD, true) }}:
+    - pwsh: npx deemon --detach --wait -- node build/azure-pipelines/common/downloadNotice.ts
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
+      displayName: Pull CG NOTICE (background)
 
   - template: ../../common/install-builtin-extensions.yml@self
 
@@ -167,11 +171,13 @@ steps:
 
   # Block on the CG NOTICE download and overwrite ThirdPartyNotices.txt
   # right before gulp packages it. Non-fatal: falls back to legacy on any problem.
-  - pwsh: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
-    displayName: Apply CG NOTICE
+  # Only on publishing builds (CIBUILD=false): see Pull CG NOTICE above.
+  - ${{ if ne(parameters.VSCODE_CIBUILD, true) }}:
+    - pwsh: npx deemon --attach -- node build/azure-pipelines/common/downloadNotice.ts
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        VSCODE_OVERWRITE_TPN: $(VSCODE_OVERWRITE_TPN)
+      displayName: Apply CG NOTICE
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1


### PR DESCRIPTION
## Context

The `Pull CG NOTICE (background)` and `Apply CG NOTICE` steps in the compile templates exist to overwrite the repo-root `ThirdPartyNotices.txt` with the Component Governance–generated notice right before gulp packages the product. That only matters for a build that actually **ships** the packaged product.

CI test jobs don't ship anything. With `VSCODE_CIBUILD=true`, `product-build.yml` spins up three jobs — **Electron Tests**, **Browser Tests**, **Remote Tests** — that compile and build a client/server purely to run tests against, then discard it. Generating and applying the CG notice in those jobs is wasted work.

It's also the source of an intermittent failure: the background `deemon` daemon started by `Pull CG NOTICE` has to survive the entire long compile + test phase, and when it gets killed mid-job the `deemon --attach` in `Apply CG NOTICE` exits non-zero and fails the job. Seen in builds 451901 and 451613 (both green on retry once the daemon survived). `downloadNotice.ts` itself is non-fatal by design — the failure comes entirely from the attach wrapper running in a job that never needed the notice.

## Changes made

- Gate both `Pull CG NOTICE (background)` and `Apply CG NOTICE` behind `${{ if ne(parameters.VSCODE_CIBUILD, true) }}` in all three compile templates (win32 / linux / darwin). This is the same guard already used for the other publish-only steps in these files (Wait for CLI artifact, Generate Group Policy, Download Explorer dll, Prepare appx).
- Both the detach and the attach are gated by the identical condition, so they stay paired — never one without the other.
- Publishing builds (`VSCODE_CIBUILD=false`) are unaffected: the notice is still pulled and applied exactly as before.

Net effect: the CG NOTICE steps stop running in the Electron/Browser/Remote Tests jobs entirely, removing both the wasted work and the failure surface. Publishing builds keep shipping the CG notice.

## References

- Builds 451901, 451613
