### PR TITLE
BYOK: support custom endpoint model options

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -2139,6 +2139,30 @@
                     "additionalProperties": {
                       "type": "string"
                     }
+                  },
+                  "modelOptions": {
+                    "type": "object",
+                    "markdownDescription": "Sampling parameters to send with requests to this model. These override Copilot's defaults but are overridden by explicit per-request values. Set a property to `null` to omit it and use the model server's default.",
+                    "properties": {
+                      "temperature": {
+                        "type": [
+                          "number",
+                          "null"
+                        ],
+                        "minimum": 0,
+                        "markdownDescription": "Sampling temperature. Set to `null` to omit the parameter."
+                      },
+                      "top_p": {
+                        "type": [
+                          "number",
+                          "null"
+                        ],
+                        "minimum": 0,
+                        "maximum": 1,
+                        "markdownDescription": "Nucleus sampling probability. Set to `null` to omit the parameter."
+                      }
+                    },
+                    "additionalProperties": false
                   }
                 },
                 "required": [

--- a/extensions/copilot/src/extension/byok/common/byokProvider.ts
+++ b/extensions/copilot/src/extension/byok/common/byokProvider.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import type { Disposable, LanguageModelChatInformation, LanguageModelDataPart, LanguageModelTextPart, LanguageModelThinkingPart, LanguageModelToolCallPart, LanguageModelToolResultPart } from 'vscode';
 import { CopilotToken } from '../../../platform/authentication/common/copilotToken';
-import { EndpointEditToolName, IChatModelInformation, ModelSupportedEndpoint } from '../../../platform/endpoint/common/endpointProvider';
+import { EndpointEditToolName, IChatModelInformation, IChatModelRequestOptions, ModelSupportedEndpoint } from '../../../platform/endpoint/common/endpointProvider';
 import { TokenizerType } from '../../../util/common/tokenizer';
 
 export const enum BYOKAuthType {
@@ -56,6 +56,7 @@ export interface BYOKModelCapabilities {
 	streaming?: boolean;
 	editTools?: EndpointEditToolName[];
 	requestHeaders?: Record<string, string>;
+	modelOptions?: IChatModelRequestOptions;
 	supportedEndpoints?: ModelSupportedEndpoint[];
 	zeroDataRetentionEnabled?: boolean;
 	supportsReasoningEffort?: string[];
@@ -128,6 +129,7 @@ export function resolveModelInfo(modelId: string, providerName: string, knownMod
 		model_picker_enabled: true,
 		supported_endpoints: knownModelInfo?.supportedEndpoints,
 		zeroDataRetentionEnabled: knownModelInfo?.zeroDataRetentionEnabled,
+		modelOptions: knownModelInfo?.modelOptions,
 		reasoningEffortFormat: knownModelInfo?.reasoningEffortFormat
 	};
 	if (knownModelInfo?.requestHeaders && Object.keys(knownModelInfo.requestHeaders).length > 0) {

--- a/extensions/copilot/src/extension/byok/common/test/byokProvider.spec.ts
+++ b/extensions/copilot/src/extension/byok/common/test/byokProvider.spec.ts
@@ -71,6 +71,21 @@ describe('resolveModelInfo', () => {
 		expect(info.capabilities.supports.reasoning_effort).toBeUndefined();
 		expect(info.reasoningEffortFormat).toBeUndefined();
 	});
+
+	it('propagates configured model options into chat-endpoint inputs', () => {
+		const info = resolveModelInfo('m1', 'TestProvider', undefined, {
+			...baseCapabilities,
+			modelOptions: {
+				temperature: null,
+				top_p: 0.95,
+			},
+		});
+
+		expect(info.modelOptions).toEqual({
+			temperature: null,
+			top_p: 0.95,
+		});
+	});
 });
 
 describe('isClientBYOKAllowed', () => {

--- a/extensions/copilot/src/extension/byok/node/openAIEndpoint.ts
+++ b/extensions/copilot/src/extension/byok/node/openAIEndpoint.ts
@@ -265,10 +265,10 @@ export class OpenAIEndpoint extends ChatEndpoint {
 				body.previous_response_id = undefined;
 			}
 			this._applyReasoningEffort(body, options);
-			return body;
+			return this._applyConfiguredModelOptions(body, options);
 		} else if (this.useMessagesApi) {
 			// Delegate to base ChatEndpoint for Messages API dispatch
-			return super.createRequestBody(options);
+			return this._applyConfiguredModelOptions(super.createRequestBody(options), options);
 		} else {
 			// Handle Chat Completions: provide callback for thinking data processing
 			const supportsThinking = !!this.modelMetadata.capabilities.supports.thinking;
@@ -290,8 +290,32 @@ export class OpenAIEndpoint extends ChatEndpoint {
 			};
 			const body = createCapiRequestBody(options, this.model, callback);
 			this._applyReasoningEffort(body, options);
+			return this._applyConfiguredModelOptions(body, options);
+		}
+	}
+
+	private _applyConfiguredModelOptions(body: IEndpointBody, options: ICreateEndpointBodyOptions): IEndpointBody {
+		const modelOptions = this.modelMetadata.modelOptions;
+		if (!modelOptions) {
 			return body;
 		}
+
+		for (const key of ['temperature', 'top_p'] as const) {
+			const requestValue = options.requestOptions?.[key];
+			if (requestValue !== undefined) {
+				body[key] = requestValue;
+				continue;
+			}
+
+			const configuredValue = modelOptions[key];
+			if (configuredValue === null) {
+				delete body[key];
+			} else if (configuredValue !== undefined) {
+				body[key] = configuredValue;
+			}
+		}
+
+		return body;
 	}
 
 	/**

--- a/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
@@ -6,7 +6,7 @@
 import { IChatMLFetcher } from '../../../platform/chat/common/chatMLFetcher';
 import { IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { IDomainService } from '../../../platform/endpoint/common/domainService';
-import { EndpointEditToolName, IChatModelInformation, ModelSupportedEndpoint } from '../../../platform/endpoint/common/endpointProvider';
+import { EndpointEditToolName, IChatModelInformation, IChatModelRequestOptions, ModelSupportedEndpoint } from '../../../platform/endpoint/common/endpointProvider';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IFetcherService } from '../../../platform/networking/common/fetcherService';
 import { IChatWebSocketManager } from '../../../platform/networking/node/chatWebSocketManager';
@@ -98,6 +98,7 @@ interface _CustomEndpointModelConfig {
 	streaming?: boolean;
 	editTools?: EndpointEditToolName[];
 	requestHeaders?: Record<string, string>;
+	modelOptions?: IChatModelRequestOptions;
 	zeroDataRetentionEnabled?: boolean;
 	supportsReasoningEffort?: string[];
 	reasoningEffortFormat?: 'chat-completions' | 'responses';
@@ -159,6 +160,7 @@ export class CustomEndpointBYOKModelProvider extends AbstractOpenAICompatibleLMP
 			thinking: modelConfiguration?.thinking ?? false,
 			streaming: modelConfiguration?.streaming,
 			requestHeaders: modelConfiguration?.requestHeaders,
+			modelOptions: modelConfiguration?.modelOptions,
 			zeroDataRetentionEnabled: modelConfiguration?.zeroDataRetentionEnabled,
 			supportsReasoningEffort: modelConfiguration?.supportsReasoningEffort,
 			reasoningEffortFormat: modelConfiguration?.reasoningEffortFormat

--- a/extensions/copilot/src/extension/byok/vscode-node/test/customEndpointProvider.spec.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/test/customEndpointProvider.spec.ts
@@ -6,6 +6,7 @@
 import { Raw } from '@vscode/prompt-tsx';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { BlockedExtensionService, IBlockedExtensionService } from '../../../../platform/chat/common/blockedExtensionService';
+import { ChatLocation } from '../../../../platform/chat/common/commonTypes';
 import { IChatModelInformation, ModelSupportedEndpoint } from '../../../../platform/endpoint/common/endpointProvider';
 import { ITestingServicesAccessor } from '../../../../platform/test/node/services';
 import { TokenizerType } from '../../../../util/common/tokenizer';
@@ -276,6 +277,180 @@ describe('CustomEndpointBYOKModelProvider', () => {
 				'https://api.example.com/v1/chat/completions');
 
 			expect(endpoint.ownsAuthorization).toBe(true);
+		});
+
+		it('issue #321514: applies configured model options over default sampling parameters', () => {
+			const metadata: IChatModelInformation = {
+				...makeMetadata(undefined),
+				modelOptions: {
+					temperature: 1,
+					top_p: 0.95,
+				},
+			};
+			const endpoint = instaService.createInstance(CustomEndpointOAIEndpoint,
+				metadata,
+				'test-api-key',
+				'https://api.example.com/v1/chat/completions');
+			const body = endpoint.createRequestBody({
+				debugName: 'test',
+				messages: [{
+					role: Raw.ChatRole.User,
+					content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Hello' }]
+				}],
+				requestId: 'test-req-custom-model-options',
+				postOptions: {
+					temperature: 0.1,
+					top_p: 1,
+					stream: true,
+				},
+				finishedCb: undefined,
+				location: ChatLocation.Other,
+			});
+
+			expect({
+				temperature: body.temperature,
+				topP: body.top_p,
+			}).toEqual({
+				temperature: 1,
+				topP: 0.95,
+			});
+		});
+
+		it('omits sampling parameters configured as null', () => {
+			const metadata: IChatModelInformation = {
+				...makeMetadata(undefined),
+				modelOptions: {
+					temperature: null,
+					top_p: null,
+				},
+			};
+			const endpoint = instaService.createInstance(CustomEndpointOAIEndpoint,
+				metadata,
+				'test-api-key',
+				'https://api.example.com/v1/chat/completions');
+			const body = endpoint.createRequestBody({
+				debugName: 'test',
+				messages: [{
+					role: Raw.ChatRole.User,
+					content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Hello' }]
+				}],
+				requestId: 'test-req-omitted-model-options',
+				postOptions: {
+					temperature: 0.1,
+					top_p: 1,
+					stream: true,
+				},
+				finishedCb: undefined,
+				location: ChatLocation.Other,
+			});
+
+			expect({
+				temperature: body.temperature,
+				topP: body.top_p,
+			}).toEqual({
+				temperature: undefined,
+				topP: undefined,
+			});
+		});
+
+		it('keeps explicit per-request sampling parameters ahead of configured model options', () => {
+			const metadata: IChatModelInformation = {
+				...makeMetadata(undefined),
+				modelOptions: {
+					temperature: 1,
+					top_p: null,
+				},
+			};
+			const endpoint = instaService.createInstance(CustomEndpointOAIEndpoint,
+				metadata,
+				'test-api-key',
+				'https://api.example.com/v1/chat/completions');
+			const body = endpoint.createRequestBody({
+				debugName: 'test',
+				messages: [{
+					role: Raw.ChatRole.User,
+					content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Hello' }]
+				}],
+				requestId: 'test-req-explicit-model-options',
+				requestOptions: {
+					temperature: 0.7,
+					top_p: 0.9,
+				},
+				postOptions: {
+					temperature: 0.1,
+					top_p: 1,
+					stream: true,
+				},
+				finishedCb: undefined,
+				location: ChatLocation.Other,
+			});
+
+			expect({
+				temperature: body.temperature,
+				topP: body.top_p,
+			}).toEqual({
+				temperature: 0.7,
+				topP: 0.9,
+			});
+		});
+
+		it('applies configured model options to Responses and Messages API bodies', () => {
+			const results = [
+				{
+					supportedEndpoints: [ModelSupportedEndpoint.Responses],
+					url: 'https://api.example.com/v1/responses',
+				},
+				{
+					supportedEndpoints: [ModelSupportedEndpoint.Messages],
+					url: 'https://api.example.com/v1/messages',
+				},
+			].map(({ supportedEndpoints, url }) => {
+				const metadata: IChatModelInformation = {
+					...makeMetadata(supportedEndpoints),
+					modelOptions: {
+						temperature: 1,
+						top_p: 0.95,
+					},
+				};
+				const endpoint = instaService.createInstance(CustomEndpointOAIEndpoint,
+					metadata,
+					'test-api-key',
+					url);
+				const body = endpoint.createRequestBody({
+					debugName: 'test',
+					messages: [{
+						role: Raw.ChatRole.User,
+						content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Hello' }]
+					}],
+					requestId: `test-req-${endpoint.apiType}-model-options`,
+					postOptions: {
+						temperature: 0.1,
+						top_p: 1,
+						stream: true,
+					},
+					finishedCb: undefined,
+					location: ChatLocation.Other,
+				});
+
+				return {
+					apiType: endpoint.apiType,
+					temperature: body.temperature,
+					topP: body.top_p,
+				};
+			});
+
+			expect(results).toEqual([
+				{
+					apiType: 'responses',
+					temperature: 1,
+					topP: 0.95,
+				},
+				{
+					apiType: 'messages',
+					temperature: 1,
+					topP: 0.95,
+				},
+			]);
 		});
 
 		it('replaces default Bearer with user-supplied Authorization header on Chat Completions endpoints', () => {

--- a/extensions/copilot/src/platform/endpoint/common/endpointProvider.ts
+++ b/extensions/copilot/src/platform/endpoint/common/endpointProvider.ts
@@ -19,6 +19,11 @@ export type CustomModel = {
 
 export type EndpointEditToolName = 'find-replace' | 'multi-find-replace' | 'apply-patch' | 'code-rewrite';
 
+export interface IChatModelRequestOptions {
+	temperature?: number | null;
+	top_p?: number | null;
+}
+
 const allEndpointEditToolNames: ReadonlySet<EndpointEditToolName> = new Set([
 	'find-replace',
 	'multi-find-replace',
@@ -127,6 +132,7 @@ export type IChatModelInformation = IModelAPIResponse & {
 	capabilities: IChatModelCapabilities;
 	urlOrRequestMetadata?: string | RequestMetadata;
 	requestHeaders?: Readonly<Record<string, string>>;
+	modelOptions?: Readonly<IChatModelRequestOptions>;
 	zeroDataRetentionEnabled?: boolean;
 	/**
 	 * BYOK-only override that forces the body shape used when forwarding the reasoning effort to the model.


### PR DESCRIPTION
## Summary
- Honor configured `temperature` and `top_p` for BYOK custom endpoints.
- Allow `null` to omit parameters and use provider defaults.
- Add regression coverage.

Fixes #321514