### PR TITLE
Style overrides: Add tests and refactor edge ownership logic for layout service

### DIFF
--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -151,20 +151,20 @@ export function getFloatingOuterEdgeOwners(layoutService: IWorkbenchLayoutServic
 	// bar that spans the full content width) is skipped and the spanning card is detected on
 	// both edges.
 	const sideBarGroup: Parts[] = [Parts.ACTIVITYBAR_PART, Parts.SIDEBAR_PART];
-	const panelPart: Parts[] = panelInLeftSequence || panelInRightSequence ? [Parts.PANEL_PART] : [];
+	const panelGroup: Parts[] = [Parts.PANEL_PART];
 	const fullOrder: Parts[] = sideBarLeft
 		? [
 			...sideBarGroup,
-			...(panelInLeftSequence ? panelPart : []),
+			...(panelInLeftSequence ? panelGroup : []),
 			Parts.EDITOR_PART,
-			...(panelInRightSequence ? panelPart : []),
+			...(panelInRightSequence ? panelGroup : []),
 			Parts.AUXILIARYBAR_PART
 		]
 		: [
 			Parts.AUXILIARYBAR_PART,
-			...(panelInLeftSequence ? panelPart : []),
+			...(panelInLeftSequence ? panelGroup : []),
 			Parts.EDITOR_PART,
-			...(panelInRightSequence ? panelPart : []),
+			...(panelInRightSequence ? panelGroup : []),
 			...[...sideBarGroup].reverse() // activity bar is outermost on the right edge
 		];
 

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -10,7 +10,7 @@ import { Part } from '../../../browser/part.js';
 import { IDimension } from '../../../../base/browser/dom.js';
 import { Direction, IViewSize } from '../../../../base/browser/ui/grid/grid.js';
 import { isMacintosh, isNative, isWeb } from '../../../../base/common/platform.js';
-import { isAuxiliaryWindow } from '../../../../base/browser/window.js';
+import { isAuxiliaryWindow, mainWindow } from '../../../../base/browser/window.js';
 import { CustomTitleBarVisibility, TitleBarSetting, getMenuBarVisibility, hasCustomTitlebar, hasNativeMenu, hasNativeTitlebar } from '../../../../platform/window/common/window.js';
 import { isFullscreen, isWCOEnabled } from '../../../../base/browser/browser.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -120,10 +120,11 @@ export function positionToString(position: Position): string {
  *
  * The horizontal order of the parts is reconstructed from the same inputs the grid
  * layout uses (mirrors `Layout.adjustPartPositions` in `src/vs/workbench/browser/layout.ts`): the activity bar and primary side bar sit
- * on `getSideBarPosition()`, the secondary side bar on the opposite side, and a
- * vertical (left/right) panel sits immediately next to the editor on its placement
- * side. The outermost *visible* part on each edge wins; the activity bar is not a
- * floating card, so it yields no owner.
+ * on `getSideBarPosition()`, the secondary side bar on the opposite side, the editor in
+ * the middle, and a vertical (left/right) panel immediately next to the editor on its
+ * placement side. The outermost *visible* part on each edge wins; the activity bar is not
+ * a floating card, so it yields no owner. A hidden editor is skipped, so a maximized side
+ * bar (which spans the full content width) is correctly detected as the owner on both edges.
  *
  * Consumed by `AbstractPaneCompositePart` (side bars and panel) and `EditorPart`
  * (main editor) so the doubled-gutter decision stays in sync between them.
@@ -142,23 +143,51 @@ export function getFloatingOuterEdgeOwners(layoutService: IWorkbenchLayoutServic
 	const panelInLeftSequence = verticalPanelVisible && panelPosition === Position.LEFT;
 	const panelInRightSequence = verticalPanelVisible && panelPosition === Position.RIGHT;
 
-	// Parts that can sit at each window edge outside the editor, ordered outermost ->
-	// innermost. The editor is the innermost terminal owner (handled in the resolver).
-	const sideBarSideParts: SINGLE_WINDOW_PARTS[] = [Parts.ACTIVITYBAR_PART, Parts.SIDEBAR_PART];
-	const auxSideParts: SINGLE_WINDOW_PARTS[] = [Parts.AUXILIARYBAR_PART];
-	const panelParts: SINGLE_WINDOW_PARTS[] = [Parts.PANEL_PART];
-	const leftOuterParts: SINGLE_WINDOW_PARTS[] = [...(sideBarLeft ? sideBarSideParts : auxSideParts), ...(panelInLeftSequence ? panelParts : [])];
-	const rightOuterParts: SINGLE_WINDOW_PARTS[] = [...(sideBarLeft ? auxSideParts : sideBarSideParts), ...(panelInRightSequence ? panelParts : [])];
+	// The full window order of the floatable parts, left -> right: the activity bar and
+	// primary side bar sit together on `getSideBarPosition()` (activity bar outermost), the
+	// secondary side bar on the opposite side, a vertical panel immediately beside the editor
+	// on its placement side, and the editor in the middle. Each edge is resolved by walking
+	// this order inward to the first *visible* card, so a hidden editor (e.g. a maximized side
+	// bar that spans the full content width) is skipped and the spanning card is detected on
+	// both edges.
+	const sideBarGroup: Parts[] = [Parts.ACTIVITYBAR_PART, Parts.SIDEBAR_PART];
+	const panelPart: Parts[] = panelInLeftSequence || panelInRightSequence ? [Parts.PANEL_PART] : [];
+	const fullOrder: Parts[] = sideBarLeft
+		? [
+			...sideBarGroup,
+			...(panelInLeftSequence ? panelPart : []),
+			Parts.EDITOR_PART,
+			...(panelInRightSequence ? panelPart : []),
+			Parts.AUXILIARYBAR_PART
+		]
+		: [
+			Parts.AUXILIARYBAR_PART,
+			...(panelInLeftSequence ? panelPart : []),
+			Parts.EDITOR_PART,
+			...(panelInRightSequence ? panelPart : []),
+			...[...sideBarGroup].reverse() // activity bar is outermost on the right edge
+		];
 
 	return {
-		left: resolveFloatingOuterOwner(layoutService, leftOuterParts),
-		right: resolveFloatingOuterOwner(layoutService, rightOuterParts)
+		left: resolveFloatingOuterOwner(layoutService, fullOrder),
+		right: resolveFloatingOuterOwner(layoutService, [...fullOrder].reverse())
 	};
 }
 
-function resolveFloatingOuterOwner(layoutService: IWorkbenchLayoutService, outerParts: SINGLE_WINDOW_PARTS[]): Parts | undefined {
-	for (const part of outerParts) {
-		if (!layoutService.isVisible(part)) {
+/**
+ * Walks the given window order (outermost -> innermost from a window edge) and returns the
+ * first visible part as the owner of that edge. The activity bar hugs the window edge but is
+ * not a floating card, so a visible activity bar yields no owner. Returns `undefined` when no
+ * visible card sits on the edge.
+ */
+function resolveFloatingOuterOwner(layoutService: IWorkbenchLayoutService, orderedParts: Parts[]): Parts | undefined {
+	for (const part of orderedParts) {
+		// The editor is the only multi-window part in this order; its main-window visibility
+		// is what matters for the main-window floating layout.
+		const visible = part === Parts.EDITOR_PART
+			? layoutService.isVisible(Parts.EDITOR_PART, mainWindow)
+			: layoutService.isVisible(part as SINGLE_WINDOW_PARTS);
+		if (!visible) {
 			continue;
 		}
 
@@ -166,8 +195,7 @@ function resolveFloatingOuterOwner(layoutService: IWorkbenchLayoutService, outer
 		return part === Parts.ACTIVITYBAR_PART ? undefined : part;
 	}
 
-	// Nothing else sits on this edge: the editor is the outermost (central) card.
-	return Parts.EDITOR_PART;
+	return undefined;
 }
 
 /**

--- a/src/vs/workbench/services/layout/test/browser/layoutService.test.ts
+++ b/src/vs/workbench/services/layout/test/browser/layoutService.test.ts
@@ -61,6 +61,10 @@ suite('LayoutService - getFloatingOuterEdgeOwners', () => {
 			// Maximized left vertical panel with the activity bar hidden: the panel spans the
 			// full width and owns both edges.
 			maximizedVerticalPanel: owners(s => { s.panelPosition = Position.LEFT; s.visibleParts = new Set([Parts.PANEL_PART]); }),
+
+			// Visible horizontal (bottom) panel: not part of the vertical order, so it owns no
+			// edge; the secondary side bar still owns the right edge.
+			horizontalPanelVisible: owners(s => { s.panelPosition = Position.BOTTOM; s.visibleParts = new Set([Parts.SIDEBAR_PART, Parts.EDITOR_PART, Parts.PANEL_PART, Parts.AUXILIARYBAR_PART]); }),
 		};
 
 		assert.deepStrictEqual(actual, {
@@ -72,6 +76,7 @@ suite('LayoutService - getFloatingOuterEdgeOwners', () => {
 			editorOnly: { left: Parts.EDITOR_PART, right: Parts.EDITOR_PART },
 			verticalPanelFull: { left: undefined, right: Parts.AUXILIARYBAR_PART },
 			maximizedVerticalPanel: { left: Parts.PANEL_PART, right: Parts.PANEL_PART },
+			horizontalPanelVisible: { left: Parts.SIDEBAR_PART, right: Parts.AUXILIARYBAR_PART },
 		});
 	});
 });

--- a/src/vs/workbench/services/layout/test/browser/layoutService.test.ts
+++ b/src/vs/workbench/services/layout/test/browser/layoutService.test.ts
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { getFloatingOuterEdgeOwners, Parts, Position } from '../../browser/layoutService.js';
+import { TestLayoutService } from '../../../../test/browser/workbenchTestServices.js';
+
+suite('LayoutService - getFloatingOuterEdgeOwners', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	class ConfigurableLayoutService extends TestLayoutService {
+		floatingPanelsEnabled = true;
+		sideBarPosition = Position.LEFT;
+		panelPosition = Position.BOTTOM;
+		visibleParts = new Set<Parts>();
+
+		override isFloatingPanelsEnabled(): boolean { return this.floatingPanelsEnabled; }
+		override getSideBarPosition(): Position { return this.sideBarPosition; }
+		override getPanelPosition(): Position { return this.panelPosition; }
+		override isVisible(part: Parts): boolean { return this.visibleParts.has(part); }
+	}
+
+	function owners(configure: (service: ConfigurableLayoutService) => void): { left: Parts | undefined; right: Parts | undefined } {
+		const service = new ConfigurableLayoutService();
+		configure(service);
+		return getFloatingOuterEdgeOwners(service);
+	}
+
+	test('edge ownership across layouts', () => {
+		const actual = {
+			// Experiment disabled: no owners regardless of layout.
+			disabled: owners(s => { s.floatingPanelsEnabled = false; s.visibleParts = new Set([Parts.AUXILIARYBAR_PART]); }),
+
+			// Default full layout (side bar left): activity bar hugs the left edge (no owner),
+			// the secondary side bar owns the right edge.
+			defaultFull: owners(s => { s.visibleParts = new Set([Parts.ACTIVITYBAR_PART, Parts.SIDEBAR_PART, Parts.EDITOR_PART, Parts.AUXILIARYBAR_PART]); }),
+
+			// Maximized aux bar with the activity bar in its default (visible) position: the
+			// activity bar still hugs the left edge, the aux bar owns the right edge.
+			maximizedAuxWithActivityBar: owners(s => { s.visibleParts = new Set([Parts.ACTIVITYBAR_PART, Parts.AUXILIARYBAR_PART]); }),
+
+			// Maximized aux bar with the activity bar not in its default position (hidden from
+			// the side column): the aux bar spans the full width and owns both edges.
+			maximizedAuxNoActivityBar: owners(s => { s.visibleParts = new Set([Parts.AUXILIARYBAR_PART]); }),
+
+			// Same, but the side bar is on the right: the aux bar still spans and owns both edges.
+			maximizedAuxNoActivityBarSideBarRight: owners(s => { s.sideBarPosition = Position.RIGHT; s.visibleParts = new Set([Parts.AUXILIARYBAR_PART]); }),
+
+			// Only the editor visible with the activity bar hidden: the editor is the sole card
+			// and owns both edges.
+			editorOnly: owners(s => { s.visibleParts = new Set([Parts.EDITOR_PART]); }),
+
+			// Full layout with a visible left vertical panel: the panel sits between the editor
+			// and the side bar, so it never reaches an edge.
+			verticalPanelFull: owners(s => { s.panelPosition = Position.LEFT; s.visibleParts = new Set([Parts.ACTIVITYBAR_PART, Parts.SIDEBAR_PART, Parts.PANEL_PART, Parts.EDITOR_PART, Parts.AUXILIARYBAR_PART]); }),
+
+			// Maximized left vertical panel with the activity bar hidden: the panel spans the
+			// full width and owns both edges.
+			maximizedVerticalPanel: owners(s => { s.panelPosition = Position.LEFT; s.visibleParts = new Set([Parts.PANEL_PART]); }),
+		};
+
+		assert.deepStrictEqual(actual, {
+			disabled: { left: undefined, right: undefined },
+			defaultFull: { left: undefined, right: Parts.AUXILIARYBAR_PART },
+			maximizedAuxWithActivityBar: { left: undefined, right: Parts.AUXILIARYBAR_PART },
+			maximizedAuxNoActivityBar: { left: Parts.AUXILIARYBAR_PART, right: Parts.AUXILIARYBAR_PART },
+			maximizedAuxNoActivityBarSideBarRight: { left: Parts.AUXILIARYBAR_PART, right: Parts.AUXILIARYBAR_PART },
+			editorOnly: { left: Parts.EDITOR_PART, right: Parts.EDITOR_PART },
+			verticalPanelFull: { left: undefined, right: Parts.AUXILIARYBAR_PART },
+			maximizedVerticalPanel: { left: Parts.PANEL_PART, right: Parts.PANEL_PART },
+		});
+	});
+});


### PR DESCRIPTION
This pull request refines the logic for determining which UI part "owns" the left and right floating edges of the workbench layout, especially in complex scenarios like maximized panels or sidebars. The main improvements include a more accurate and maintainable algorithm for edge ownership, clarifications in documentation, and the addition of comprehensive tests to ensure correctness across various layouts.

**Layout logic improvements:**

* Refactored the edge ownership algorithm in `getFloatingOuterEdgeOwners` to walk the full window order from outermost to innermost, skipping hidden parts and handling maximized scenarios where a single part spans both edges. The logic now properly skips the activity bar (which hugs the edge but is not a floating card) and handles the editor's visibility in the main window context.
* Updated `resolveFloatingOuterOwner` to use the new order and visibility checks, and to return `undefined` when no visible card sits on the edge, rather than defaulting to the editor.
* Added import of `mainWindow` to ensure correct visibility checks for multi-window parts like the editor.

**Documentation improvements:**

* Clarified and expanded comments in `layoutService.ts` to explain the new edge ownership logic, including how maximized parts and hidden editors are handled. [[1]](diffhunk://#diff-d132005d10db590379d0c566ff130fbccb332b4adf75ee6d94865b7431169d0aL123-R127) [[2]](diffhunk://#diff-d132005d10db590379d0c566ff130fbccb332b4adf75ee6d94865b7431169d0aL145-R198)

**Testing:**

* Added a comprehensive test suite `LayoutService - getFloatingOuterEdgeOwners` to cover various layout scenarios, ensuring the new logic works as intended in all relevant configurations.