### PR TITLE
Remove last-used session type and agent logic

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -26,7 +26,6 @@ import { ICommandService } from '../../../../../platform/commands/common/command
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IsLinuxContext, IsWindowsContext } from '../../../../../platform/contextkey/common/contextkeys.js';
-import { IStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -57,7 +56,7 @@ import { ElicitationState, IChatService, IChatToolInvocation } from '../../commo
 import { ISCMHistoryItemChangeRangeVariableEntry, ISCMHistoryItemChangeVariableEntry } from '../../common/attachments/chatVariableEntries.js';
 import { IChatRequestViewModel, IChatResponseViewModel, isRequestVM } from '../../common/model/chatViewModel.js';
 import { IChatWidgetHistoryService } from '../../common/widget/chatWidgetHistoryService.js';
-import { ChatAgentLocation, ChatConfiguration, ChatLastUsedEditorSessionTypeStorageKey, ChatModeKind, getDefaultNewChatSessionType, getNewChatEditorSessionResource } from '../../common/constants.js';
+import { ChatAgentLocation, ChatConfiguration, ChatModeKind, getDefaultNewChatSessionResource, getDefaultNewChatSessionType } from '../../common/constants.js';
 import { AICustomizationManagementCommands } from '../aiCustomization/aiCustomizationManagement.js';
 import { ILanguageModelChatSelector, ILanguageModelsService } from '../../common/languageModels.js';
 import { CopilotUsageExtensionFeatureId } from '../../common/languageModelStats.js';
@@ -579,9 +578,7 @@ export function registerChatActions() {
 	 * `local` or the chosen provider is unavailable.
 	 */
 	function getNewChatEditorSessionUri(accessor: ServicesAccessor): URI {
-		const storageService = accessor.get(IStorageService);
-		const lastUsedSessionType = storageService.get(ChatLastUsedEditorSessionTypeStorageKey, StorageScope.PROFILE);
-		return getNewChatEditorSessionResource(accessor.get(IConfigurationService), accessor.get(IChatSessionsService), lastUsedSessionType);
+		return getDefaultNewChatSessionResource(accessor.get(IConfigurationService), accessor.get(IChatSessionsService));
 	}
 
 	registerAction2(PrimaryOpenChatGlobalAction);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
@@ -11,14 +11,11 @@ import { isEqual } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ILayoutService } from '../../../../../platform/layout/browser/layoutService.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
-import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { ACTIVE_GROUP, IEditorService, type PreferredGroup } from '../../../../services/editor/common/editorService.js';
 import { IEditorGroup, IEditorGroupsService, isEditorGroup } from '../../../../services/editor/common/editorGroupsService.js';
 import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import { IChatService } from '../../common/chatService/chatService.js';
-import { localChatSessionType } from '../../common/chatSessionsService.js';
-import { ChatAgentLocation, ChatLastUsedEditorSessionTypeStorageKey } from '../../common/constants.js';
-import { getChatSessionType } from '../../common/model/chatUri.js';
+import { ChatAgentLocation } from '../../common/constants.js';
 import { ChatViewId, ChatViewPaneTarget, IChatWidget, IChatWidgetService, IQuickChatService, isIChatViewViewContext } from '../chat.js';
 import { ChatEditor, IChatEditorOptions } from '../widgetHosts/editor/chatEditor.js';
 import { ChatEditorInput } from '../widgetHosts/editor/chatEditorInput.js';
@@ -51,7 +48,6 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 		@IEditorService private readonly editorService: IEditorService,
 		@IChatService private readonly chatService: IChatService,
 		@ILogService private readonly logService: ILogService,
-		@IStorageService private readonly storageService: IStorageService,
 	) {
 		super();
 	}
@@ -237,28 +233,8 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 		}
 
 		this._lastFocusedWidget = widget;
-		this.recordLastUsedSessionType(widget);
 		this._onDidChangeFocusedWidget.fire(widget);
 		this._onDidChangeFocusedSession.fire();
-	}
-
-	/**
-	 * Stores the session type (agent) of the last-focused user-facing chat so new chat editors can reuse it (excluding Quick Chat).
-	 */
-	private recordLastUsedSessionType(widget: IChatWidget | undefined): void {
-		const sessionResource = widget?.viewModel?.sessionResource;
-		if (!sessionResource) {
-			return;
-		}
-		if (this.quickChatService.sessionResource && isEqual(sessionResource, this.quickChatService.sessionResource)) {
-			return;
-		}
-		const sessionType = getChatSessionType(sessionResource);
-		// Only remember non-local agents to avoid clobbering the user's last-used agent.
-		if (sessionType === localChatSessionType) {
-			return;
-		}
-		this.storageService.store(ChatLastUsedEditorSessionTypeStorageKey, sessionType, StorageScope.PROFILE, StorageTarget.USER);
 	}
 
 	register(newWidget: IChatWidget): IDisposable {
@@ -277,7 +253,6 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 			newWidget.onDidFocus(() => this.setLastFocusedWidget(newWidget)),
 			newWidget.onDidChangeViewModel(({ previousSessionResource, currentSessionResource }) => {
 				if (this._lastFocusedWidget === newWidget && !isEqual(previousSessionResource, currentSessionResource)) {
-					this.recordLastUsedSessionType(newWidget);
 					this._onDidChangeFocusedSession.fire();
 				}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -907,21 +907,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			|| hasModelsTargetingSession(this.getAllMergedModels(), sessionType);
 	}
 
-	/**
-	 * Returns the persisted model for the current session type, if it exists in the current model pool.
-	 */
-	private _getRememberedSessionTypeModel(): ILanguageModelChatMetadataAndIdentifier | undefined {
-		const sessionType = this._currentSessionType;
-		if (!sessionType || !this.sessionTypeHasOwnModelPool(sessionType)) {
-			return undefined;
-		}
-		const persisted = this.storageService.get(this.getSelectedModelStorageKey(), StorageScope.APPLICATION);
-		if (!persisted) {
-			return undefined;
-		}
-		return this.getModels().find(m => m.identifier === persisted);
-	}
-
 	private initSelectedModel() {
 		// initSelectedModel is scoped to the current storage key/session type.
 		// Do not let a delayed restore from a previous session type apply later.
@@ -1343,13 +1328,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			if (!state && this._chatSessionIsEmpty) {
 				state = this._emptyInputState.read(undefined);
 				message = `syncing from empty input state for ${forSessionResource.toString()}`;
-				// Seed model/config from the last-used selection for this session type (configured default still wins).
-				const rememberedSessionTypeModel = this._getRememberedSessionTypeModel();
-				if (rememberedSessionTypeModel) {
-					const base = state ?? this.getCurrentInputState();
-					const rememberedModelConfiguration = this._modelConfigStore.getModelConfiguration(rememberedSessionTypeModel.identifier);
-					state = { ...base, selectedModel: rememberedSessionTypeModel, modelConfiguration: rememberedModelConfiguration };
-				}
 				// A configured default model (e.g. set by enterprise policy via
 				// `chat.defaultModel`) starts every NEW conversation and
 				// must win over the remembered empty-input draft model. `initSelectedModel`

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditorInput.ts
@@ -16,13 +16,12 @@ import * as nls from '../../../../../../nls.js';
 import { ConfirmResult, IDialogService } from '../../../../../../platform/dialogs/common/dialogs.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
-import { IStorageService, StorageScope } from '../../../../../../platform/storage/common/storage.js';
 import { registerIcon } from '../../../../../../platform/theme/common/iconRegistry.js';
 import { EditorInputCapabilities, IEditorIdentifier, IEditorSerializer, IUntypedEditorInput, Verbosity } from '../../../../../common/editor.js';
 import { EditorInput, IEditorCloseHandler } from '../../../../../common/editor/editorInput.js';
 import { IChatModelReference, IChatService } from '../../../common/chatService/chatService.js';
 import { IChatSessionsService, localChatSessionType } from '../../../common/chatSessionsService.js';
-import { ChatAgentLocation, ChatEditorTitleMaxLength, ChatLastUsedEditorSessionTypeStorageKey, getDefaultNewChatSessionResource, getDefaultNewChatSessionType, getNewChatEditorSessionResource } from '../../../common/constants.js';
+import { ChatAgentLocation, ChatEditorTitleMaxLength, getDefaultNewChatSessionResource, getDefaultNewChatSessionType } from '../../../common/constants.js';
 import { IChatEditingSession, ModifiedFileEntryState } from '../../../common/editing/chatEditingService.js';
 import { IChatModel } from '../../../common/model/chatModel.js';
 import { LocalChatSessionUri, getChatSessionType } from '../../../common/model/chatUri.js';
@@ -66,7 +65,6 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IStorageService private readonly storageService: IStorageService,
 	) {
 		super();
 
@@ -233,8 +231,7 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 				this.modelRef.value = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: true, debugOwner: 'ChatEditorInput#resolveNewLocalSession' });
 			}
 		} else if (!this.options.target) {
-			const lastUsedSessionType = this.storageService.get(ChatLastUsedEditorSessionTypeStorageKey, StorageScope.PROFILE);
-			const defaultResource = getNewChatEditorSessionResource(this.configurationService, this.chatSessionsService, lastUsedSessionType);
+			const defaultResource = getDefaultNewChatSessionResource(this.configurationService, this.chatSessionsService);
 			if (getChatSessionType(defaultResource) === localChatSessionType) {
 				this.modelRef.value = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: !inputType, debugOwner: 'ChatEditorInput#resolveUntitled' });
 			} else {

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -284,54 +284,6 @@ export function getDefaultNewChatSessionResource(
 		: URI.from({ scheme: defaultType, path: `/untitled-${generateUuid()}` });
 }
 
-/**
- * Storage key for the last-used non-local editor chat session type (agent), persisted at profile scope.
- */
-export const ChatLastUsedEditorSessionTypeStorageKey = 'chat.lastUsedEditorSessionType';
-
-/**
- * Resolves the session type (agent) for a new chat editor, preferring the last-used visible non-local agent when `chat.editor.defaultProvider` isn't explicitly configured.
- */
-export function getNewChatEditorSessionType(
-	configurationService: IConfigurationService,
-	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
-	lastUsedSessionType: string | undefined,
-): string {
-	const inspected = configurationService.inspect<string>(ChatConfiguration.EditorDefaultProvider);
-	const explicitlyConfigured = inspected.applicationValue !== undefined
-		|| inspected.userValue !== undefined
-		|| inspected.userLocalValue !== undefined
-		|| inspected.userRemoteValue !== undefined
-		|| inspected.workspaceValue !== undefined
-		|| inspected.workspaceFolderValue !== undefined
-		|| inspected.memoryValue !== undefined
-		|| inspected.policyValue !== undefined;
-
-	if (!explicitlyConfigured
-		&& lastUsedSessionType
-		&& lastUsedSessionType !== localChatSessionType
-		&& isVisibleEditorChatSessionType(lastUsedSessionType, configurationService, chatSessionsService)) {
-		return lastUsedSessionType;
-	}
-
-	return getDefaultNewChatSessionType(configurationService, chatSessionsService);
-}
-
-/**
- * Like {@link getDefaultNewChatSessionResource}, but prefers the user's
- * last-used session type via {@link getNewChatEditorSessionType}.
- */
-export function getNewChatEditorSessionResource(
-	configurationService: IConfigurationService,
-	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
-	lastUsedSessionType: string | undefined,
-): URI {
-	const sessionType = getNewChatEditorSessionType(configurationService, chatSessionsService, lastUsedSessionType);
-	return sessionType === localChatSessionType
-		? LocalChatSessionUri.getNewSessionUri()
-		: URI.from({ scheme: sessionType, path: `/untitled-${generateUuid()}` });
-}
-
 export function isEditorLocalAgentEnabled(configurationService: IConfigurationService): boolean {
 	return configurationService.getValue<boolean>(ChatConfiguration.EditorLocalAgentEnabled) ?? true;
 }

--- a/src/vs/workbench/contrib/chat/test/common/constants.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/constants.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { ChatConfiguration, getDefaultNewChatSessionType, getNewChatEditorSessionType, isVisibleEditorChatSessionType } from '../../common/constants.js';
+import { ChatConfiguration, getDefaultNewChatSessionType, isVisibleEditorChatSessionType } from '../../common/constants.js';
 import { localChatSessionType, SessionType, IChatSessionsExtensionPoint } from '../../common/chatSessionsService.js';
 import { MockChatSessionsService } from './mockChatSessionsService.js';
 
@@ -75,58 +75,5 @@ suite('ChatConfiguration defaults', () => {
 
 		assert.strictEqual(getDefaultNewChatSessionType(configurationService, chatSessionsService), localChatSessionType);
 		assert.strictEqual(isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService), true);
-	});
-});
-
-suite('getNewChatEditorSessionType (last-used agent)', () => {
-
-	ensureNoDisposablesAreLeakedInTestSuite();
-
-	function createChatSessionsService(...types: string[]): MockChatSessionsService {
-		const service = new MockChatSessionsService();
-		service.setContributions(types.map(type => ({
-			type,
-			name: type,
-			displayName: type,
-			description: type,
-		} satisfies IChatSessionsExtensionPoint)));
-		return service;
-	}
-
-	test('prefers a visible non-local last-used agent when the provider is not explicitly configured', () => {
-		const configurationService = new TestConfigurationService();
-		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
-
-		assert.strictEqual(getNewChatEditorSessionType(configurationService, chatSessionsService, SessionType.AgentHostCopilot), SessionType.AgentHostCopilot);
-	});
-
-	test('ignores a last-used agent whose provider is not visible/registered', () => {
-		const configurationService = new TestConfigurationService();
-		const chatSessionsService = createChatSessionsService(); // agent host not registered
-
-		assert.strictEqual(getNewChatEditorSessionType(configurationService, chatSessionsService, SessionType.AgentHostCopilot), localChatSessionType);
-	});
-
-	test('an explicitly configured local provider wins over a last-used agent', () => {
-		const configurationService = new TestConfigurationService({
-			[ChatConfiguration.EditorDefaultProvider]: 'local',
-		});
-		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
-
-		assert.strictEqual(getNewChatEditorSessionType(configurationService, chatSessionsService, SessionType.AgentHostCopilot), localChatSessionType);
-	});
-
-	test('a last-used local agent does not override the default', () => {
-		const configurationService = new TestConfigurationService();
-		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
-
-		assert.strictEqual(getNewChatEditorSessionType(configurationService, chatSessionsService, localChatSessionType), localChatSessionType);
-	});
-
-	test('falls back to the default when there is no last-used agent', () => {
-		const configurationService = new TestConfigurationService();
-		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
-
-		assert.strictEqual(getNewChatEditorSessionType(configurationService, chatSessionsService, undefined), localChatSessionType);
 	});
 });


### PR DESCRIPTION
Eliminate the last-used session type logic and related dependencies from the chat editor input, streamlining the codebase and improving maintainability. This change also removes unnecessary storage service references.

Part of https://github.com/microsoft/vscode/pull/323484