### PR TITLE
Enhance agent selection handling for worktree sessions

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1300,14 +1300,16 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const shellManager = this._instantiationService.createInstance(ShellManager, sessionUri, workingDirectory);
 
 		let agentSession: CopilotAgentSession | undefined;
+		let agent: AgentSelection | undefined;
 		try {
-			const resolvedAgentName = provisional.agent ? await this._resolveAgentName(provisional.sessionUri, snapshot, provisional.agent) : undefined;
+			const resolvedAgent = await this._resolveAgentWhenMaterializing(provisional, snapshot, workingDirectory);
+			agent = resolvedAgent?.agent;
 			const launchPlan: CopilotSessionLaunchPlan = {
 				kind: 'create',
 				client,
 				sessionId,
 				workingDirectory,
-				resolvedAgentName,
+				resolvedAgentName: resolvedAgent?.name,
 				snapshot,
 				activeClientToolSet: activeClient.toolSet,
 				shellManager,
@@ -1329,8 +1331,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 		this._provisionalSessions.delete(sessionId);
 		await this._storeSessionMetadata(sessionUri, provisional.model, workingDirectory, customizationDirectory, project, true);
-		if (provisional.agent !== undefined) {
-			await this._storeSessionAgentMetadata(sessionUri, provisional.agent);
+		if (agent !== undefined) {
+			await this._storeSessionAgentMetadata(sessionUri, agent);
 		}
 
 		// Capture the per-session baseline (turn/0) git checkpoint so
@@ -1346,6 +1348,43 @@ export class CopilotAgent extends Disposable implements IAgent {
 		this._logService.info(`[Copilot] Session materialized: ${sessionUri.toString()}`);
 		this._onDidMaterializeSession.fire({ session: sessionUri, workingDirectory, project });
 		return agentSession;
+	}
+
+	private async _resolveAgentWhenMaterializing(provisional: IProvisionalSession, snapshot: IActiveClientSnapshot, workingDirectory: URI | undefined): Promise<{ agent: AgentSelection; name: string } | undefined> {
+		const agent = provisional.agent;
+		if (!agent) {
+			return undefined;
+		}
+		const alternativeAgent = this._getAlternativeAgentForWorktree(provisional, workingDirectory);
+
+		const [originalAgentName, alternativeAgentName] = await Promise.all([
+			this._resolveAgentName(provisional.sessionUri, snapshot, agent),
+			alternativeAgent ? this._resolveAgentName(provisional.sessionUri, snapshot, alternativeAgent) : Promise.resolve(undefined),
+		]);
+
+		if (originalAgentName) {
+			return { agent: agent, name: originalAgentName };
+		}
+		if (alternativeAgentName && alternativeAgent) {
+			this._logService.info(`[Copilot] Agent file ${agent.uri} is in the original repo; using worktree agent ${alternativeAgent?.uri}`);
+			return { agent: alternativeAgent, name: alternativeAgentName };
+		}
+		return undefined;
+	}
+	private _getAlternativeAgentForWorktree(provisional: IProvisionalSession, workingDirectory: URI | undefined): AgentSelection | undefined {
+		const agent = provisional.agent;
+		if (!agent) {
+			return undefined;
+		}
+		if (!provisional.workingDirectory || !workingDirectory) {
+			return undefined;
+		}
+		if (isEqual(provisional.workingDirectory, workingDirectory)) {
+			return undefined;
+		}
+		const agentUri = URI.parse(agent.uri);
+		const alternativeAgentUri = rebaseUnder(agentUri, provisional.workingDirectory, workingDirectory);
+		return alternativeAgentUri ? { uri: alternativeAgentUri.toString() } : undefined;
 	}
 
 	async resolveSessionConfig(params: IAgentResolveSessionConfigParams): Promise<ResolveSessionConfigResult> {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1366,7 +1366,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			return { agent: agent, name: originalAgentName };
 		}
 		if (alternativeAgentName && alternativeAgent) {
-			this._logService.info(`[Copilot] Agent file ${agent.uri} is in the original repo; using worktree agent ${alternativeAgent?.uri}`);
+			this._logService.info(`[Copilot] Agent file ${agent.uri} is in the original repo; using worktree agent ${alternativeAgent.uri}`);
 			return { agent: alternativeAgent, name: alternativeAgentName };
 		}
 		return undefined;

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -33,7 +33,7 @@ import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPlu
 import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, type AgentSignal, type IAgentActionSignal, type IAgentSessionMetadata } from '../../common/agentService.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
 import { buildDefaultChatUri, buildSubagentSessionUri, buildChatUri, CustomizationLoadStatus, MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, TurnState, customizationId, type ClientPluginCustomization, type MarkdownResponsePart, type PluginCustomization, type ToolCallResult, type Turn, RuleCustomization } from '../../common/state/sessionState.js';
-import { CustomizationType, type ModelSelection, type ToolDefinition } from '../../common/state/protocol/state.js';
+import { CustomizationType, type AgentSelection, type ModelSelection, type ToolDefinition } from '../../common/state/protocol/state.js';
 import { ActionType, type ChatAction, type IDeltaAction, type SessionAction } from '../../common/state/sessionActions.js';
 
 import { AgentConfigurationService, IAgentConfigurationService } from '../../node/agentConfigurationService.js';
@@ -3204,6 +3204,160 @@ suite('CopilotAgent', () => {
 				},
 				'skill/instruction directories sent to the SDK must resolve inside the worktree, never the original folder',
 			);
+		});
+
+
+	});
+
+	suite('custom agent worktree translation', () => {
+
+		// The new methods under test are private; reach in the same way the
+		// surrounding suites do (e.g. `customization anchoring`).
+		type AgentInternals = {
+			_getAlternativeAgentForWorktree(provisional: unknown, workingDirectory: URI | undefined): AgentSelection | undefined;
+			_resolveAgentWhenMaterializing(provisional: unknown, snapshot: IActiveClientSnapshot, workingDirectory: URI | undefined): Promise<{ agent: AgentSelection; name: string } | undefined>;
+			_resolveAgentName(sessionUri: URI, snapshot: IActiveClientSnapshot, agent: AgentSelection): Promise<string | undefined>;
+			_resolveSessionWorkingDirectory(config: unknown, sessionId: string, prompt?: string): Promise<URI | undefined>;
+			_createAgentSession(launchPlan: CopilotSessionLaunchPlan, customizationDirectory: URI | undefined, activeClient: unknown, channelUri?: URI): CopilotAgentSession;
+			_readSessionMetadata(session: URI): Promise<{ agent?: AgentSelection }>;
+		};
+
+		const repo = URI.file('/repo');
+		const worktree = URI.joinPath(URI.file('/repo.worktrees'), 'agents-x');
+		const repoAgentUri = URI.joinPath(repo, '.github', 'agents', 'agent.md').toString();
+		const worktreeAgentUri = URI.joinPath(worktree, '.github', 'agents', 'agent.md').toString();
+		const emptySnapshot: IActiveClientSnapshot = { tools: [], plugins: [], mcpServers: {} };
+
+		function provisional(workingDirectory: URI | undefined, agent: AgentSelection | undefined): unknown {
+			const sessionUri = AgentSession.uri('copilotcli', 'prov-agent');
+			return { sessionId: AgentSession.id(sessionUri), sessionUri, workingDirectory, model: undefined, agent, project: undefined };
+		}
+
+		test('_getAlternativeAgentForWorktree rewrites a repo agent path onto the worktree', async () => {
+			const agent = createTestAgent(disposables, { copilotClient: new TestCopilotClient([]) });
+			try {
+				const internals = agent as unknown as AgentInternals;
+				assert.deepStrictEqual(
+					internals._getAlternativeAgentForWorktree(provisional(repo, { uri: repoAgentUri }), worktree),
+					{ uri: worktreeAgentUri },
+				);
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('_getAlternativeAgentForWorktree returns undefined when there is nothing to translate', async () => {
+			const agent = createTestAgent(disposables, { copilotClient: new TestCopilotClient([]) });
+			try {
+				const internals = agent as unknown as AgentInternals;
+				const outsideRepoAgent: AgentSelection = { uri: URI.file('/home/me/.copilot/agents/agent.md').toString() };
+				assert.deepStrictEqual(
+					{
+						noAgent: internals._getAlternativeAgentForWorktree(provisional(repo, undefined), worktree),
+						folderIsolation: internals._getAlternativeAgentForWorktree(provisional(repo, { uri: repoAgentUri }), undefined),
+						sameWorkingDirectory: internals._getAlternativeAgentForWorktree(provisional(repo, { uri: repoAgentUri }), repo),
+						agentOutsideRepo: internals._getAlternativeAgentForWorktree(provisional(repo, outsideRepoAgent), worktree),
+					},
+					{
+						noAgent: undefined,
+						folderIsolation: undefined,
+						sameWorkingDirectory: undefined,
+						agentOutsideRepo: undefined,
+					},
+				);
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('_resolveAgentWhenMaterializing keeps the original agent for folder isolation (no worktree)', async () => {
+			const agent = createTestAgent(disposables, { copilotClient: new TestCopilotClient([]) });
+			try {
+				const internals = agent as unknown as AgentInternals;
+				internals._resolveAgentName = async (_sessionUri, _snapshot, selection) => selection.uri === repoAgentUri ? 'Repo Agent' : undefined;
+				// Folder isolation: the resolved working directory equals the
+				// user-picked folder, so there is no worktree copy to translate to
+				// and the originally selected agent is kept as-is.
+				assert.deepStrictEqual(
+					await internals._resolveAgentWhenMaterializing(provisional(repo, { uri: repoAgentUri }), emptySnapshot, repo),
+					{ agent: { uri: repoAgentUri }, name: 'Repo Agent' },
+				);
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('_resolveAgentWhenMaterializing returns undefined when no agent is selected or neither resolves', async () => {
+			const agent = createTestAgent(disposables, { copilotClient: new TestCopilotClient([]) });
+			try {
+				const internals = agent as unknown as AgentInternals;
+				internals._resolveAgentName = async () => undefined;
+				assert.deepStrictEqual(
+					{
+						noAgent: await internals._resolveAgentWhenMaterializing(provisional(repo, undefined), emptySnapshot, worktree),
+						neitherResolves: await internals._resolveAgentWhenMaterializing(provisional(repo, { uri: repoAgentUri }), emptySnapshot, worktree),
+					},
+					{ noAgent: undefined, neitherResolves: undefined },
+				);
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('materialization rewrites a repo agent to its worktree copy and persists it (no resolution stubbing)', async () => {
+			// End-to-end through real customization discovery: the same custom
+			// agent file exists in both the original repo and the worktree. The
+			// user selects the repo copy, but once the worktree is materialized
+			// discovery re-anchors there, so the persisted/launched agent must be
+			// the worktree copy — proving the translation against real resolution
+			// rather than a stubbed `_resolveAgentName`.
+			const fileService = disposables.add(new FileService(new NullLogService()));
+			disposables.add(fileService.registerProvider(Schemas.inMemory, disposables.add(new InMemoryFileSystemProvider())));
+
+			const repoFolder = URI.from({ scheme: Schemas.inMemory, path: '/repo' });
+			const worktreeFolder = URI.from({ scheme: Schemas.inMemory, path: '/repo.worktrees/agents-x' });
+			const repoAgentFile = URI.joinPath(repoFolder, '.github', 'agents', 'agent.md');
+			const worktreeAgentFile = URI.joinPath(worktreeFolder, '.github', 'agents', 'agent.md');
+			const agentContents = VSBuffer.fromString('---\nname: My Agent\ndescription: a custom agent\n---\nbody');
+			await fileService.writeFile(repoAgentFile, agentContents);
+			await fileService.writeFile(worktreeAgentFile, agentContents);
+
+			const client = new TestCopilotClient([]);
+			client.createSession = async () => new MockCopilotSession() as unknown as CopilotSession;
+
+			const sessionDataService = disposables.add(new TestSessionDataService());
+			const { agent } = createTestAgentContext(disposables, { sessionDataService, copilotClient: client, fileService });
+
+			let launchAgentName: string | undefined;
+			const internals = agent as unknown as AgentInternals;
+			internals._resolveSessionWorkingDirectory = async () => worktreeFolder;
+			const originalCreateAgentSession = internals._createAgentSession;
+			internals._createAgentSession = (launchPlan, customizationDirectory, activeClient, channelUri) => {
+				launchAgentName = launchPlan.resolvedAgentName;
+				return originalCreateAgentSession.call(agent, launchPlan, customizationDirectory, activeClient, channelUri);
+			};
+
+			try {
+				await agent.authenticate('https://api.github.com', 'token');
+				const result = await agent.createSession({
+					session: AgentSession.uri('copilotcli', 'agent-translate'),
+					workingDirectory: repoFolder,
+					agent: { uri: repoAgentFile.toString() },
+				});
+				assert.strictEqual(result.provisional, true);
+				await agent.sendMessage(result.session, URI.parse(buildDefaultChatUri(result.session)), 'hello');
+
+				// `_readSessionMetadata` reads back the exact agent field the
+				// resume path consumes, so asserting it stands in for restore.
+				const stored = await internals._readSessionMetadata(result.session);
+				assert.deepStrictEqual(
+					{ storedAgent: stored.agent, launchAgentName },
+					{ storedAgent: { uri: worktreeAgentFile.toString() }, launchAgentName: 'My Agent' },
+					'the repo agent must be rewritten to its worktree copy, both for the SDK launch and the persisted metadata the restore path reads',
+				);
+			} finally {
+				await disposeAgent(agent);
+			}
 		});
 
 	});

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -12,7 +12,7 @@ import { IMarkdownString, MarkdownString } from '../../../../../base/common/html
 import { Disposable, DisposableMap, DisposableStore, IDisposable, IReference, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { equals } from '../../../../../base/common/objects.js';
 import { constObservable, derived, derivedObservableWithCache, derivedOpts, IObservable, ISettableObservable, mapObservableArrayCached, observableFromEvent, observableValue, observableValueOpts, throttledObservable, transaction, waitForState } from '../../../../../base/common/observable.js';
-import { isEqual } from '../../../../../base/common/resources.js';
+import { isEqual, isEqualOrParent, relativePath } from '../../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { isDefined } from '../../../../../base/common/types.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -320,6 +320,11 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 	// list refresh). See `_applySessionMetaFromState` / `setMeta`.
 	private _project: IAgentSessionMetadata['project'];
 	private _workingDirectory: URI | undefined;
+	// The directory that the current `mode` custom-agent URI is rooted at. Used to
+	// compute the agent's repo-relative path so the selection can be rebased onto
+	// its worktree twin when the session relocates into an isolated worktree (see
+	// `reconcileSelectedAgent`).
+	private _agentBaseDir: URI | undefined;
 	private _meta: SessionMeta | undefined;
 	/**
 	 * Observable mirror of {@link _meta}, kept in sync with every write to
@@ -649,7 +654,103 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 			this._getAdditionalChat(chatResource)?.setAgent(agent);
 		} else {
 			this.mode.set(agent ? { id: agent.uri, kind: AGENT_MODE_KIND } : undefined, undefined);
+			// Remember which working directory the agent URI is rooted at so the
+			// selection can be rebased if the session later relocates into a worktree.
+			this._agentBaseDir = agent ? this._workingDirectory : undefined;
 		}
+	}
+
+	/**
+	 * Reconcile the selected custom-agent URI against the host's current agent
+	 * list — e.g. the session graduated with an agent picked in the original repo
+	 * but now runs in an isolated worktree, where the host reports the same agent
+	 * file under the worktree path.
+	 *
+	 * The selection is rebased by matching the agent's repo-relative path against
+	 * the available agents (which already carry the worktree root) rather than the
+	 * session's reported working directory. The working directory is unreliable
+	 * here: the worktree-pathed customizations arrive well before either the
+	 * `SessionSummary` or `SessionState` working-directory flips to the worktree,
+	 * so a working-directory-keyed rebase would miss the window and let the picker
+	 * destructively reset the selection. Deriving the worktree root from the agent
+	 * list closes that race.
+	 *
+	 * Mirrors the agent-host backend's code to rebase by relative path.
+	 * The re-point is only applied to a URI that actually exists in
+	 * the supplied agent list, so it never runs ahead of the host reporting the
+	 * worktree agents (which would otherwise re-introduce the mismatch it fixes).
+	 */
+	reconcileSelectedAgent(agents: readonly AgentCustomization[]): void {
+		const current = this.mode.get();
+		if (!current || agents.some(a => a.uri === current.id)) {
+			return; // no agent selected, or the selection is already valid
+		}
+		const base = this._agentBaseDir;
+		if (!base) {
+			return; // unknown root for the current selection — nothing to rebase against
+		}
+		const agentUri = URI.parse(current.id);
+		if (!isEqualOrParent(agentUri, base)) {
+			return; // agent lives outside the repo (e.g. a user-global agent)
+		}
+		const rel = relativePath(base, agentUri);
+		if (!rel) {
+			return;
+		}
+		const relocated = this._findRelocatedAgent(agents, agentUri, base, rel);
+		if (relocated) {
+			this.mode.set({ id: relocated.uri, kind: current.kind }, undefined);
+			this._agentBaseDir = relocated.root;
+		}
+	}
+
+	/**
+	 * Finds an available agent that is the same repo-relative file as the current
+	 * selection but rooted under a different directory (its worktree twin).
+	 *
+	 * A candidate matches when its path ends with `/<rel>` on a path-segment
+	 * boundary and the implied root (the candidate path minus that suffix) differs
+	 * from `base`. The root is re-validated with `relativePath` so only a genuine
+	 * relocation of the same file is accepted. Returns the matched agent's URI and
+	 * its derived root, or `undefined` when there is no twin.
+	 */
+	private _findRelocatedAgent(
+		agents: readonly AgentCustomization[],
+		agentUri: URI,
+		base: URI,
+		rel: string,
+	): { readonly uri: string; readonly root: URI } | undefined {
+		const suffix = `/${rel}`;
+		for (const agent of agents) {
+			const candidate = URI.parse(agent.uri);
+			if (candidate.scheme !== agentUri.scheme || candidate.authority !== agentUri.authority) {
+				continue;
+			}
+			if (!candidate.path.endsWith(suffix) || candidate.path.length === suffix.length) {
+				continue; // not the same relative file, or it sits at the filesystem root
+			}
+			const root = candidate.with({ path: candidate.path.slice(0, candidate.path.length - suffix.length) });
+			if (isEqual(root, base) || relativePath(root, candidate) !== rel) {
+				continue; // same root (would have matched exactly), or not a clean relocation
+			}
+			return { uri: agent.uri, root };
+		}
+		return undefined;
+	}
+
+	/**
+	 * Seed the selected custom agent when a session is resumed (e.g. after a
+	 * window reload). A freshly loaded adapter starts with `mode === undefined`;
+	 * the host persists the selection on the default chat's `ChatState.draft.agent`,
+	 * which the provider reads and mirrors onto `session.mode` here. Guarded to
+	 * never override a live selection (a Part 1 graduation seed or a user pick),
+	 * keeping this a resume-only hydration.
+	 */
+	hydrateSelectedAgent(agentUri: string): void {
+		if (this.mode.get() !== undefined) {
+			return;
+		}
+		this.setChatAgent(this.resource, { uri: agentUri, name: '' });
 	}
 
 	getChatModelId(chatResource: URI): string | undefined {
@@ -2820,6 +2921,18 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			const committedSession = await this._waitForNewSession(existingKeys, chatResource.scheme);
 			if (committedSession) {
 				this._preserveNewSessionConfig(newSession, committedSession.sessionId);
+				// Carry the picked custom agent onto the committed session before
+				// the replace event so the agent picker doesn't reset to the
+				// default once the active session is swapped (the picker mirrors
+				// `session.mode`, which is otherwise `undefined` on the freshly
+				// committed adapter). The host already received the agent with the
+				// first turn (see `sendOptions.modeInfo`), so update only the local
+				// mode observable here rather than re-notifying it via `setAgent`.
+				if (selectedAgent) {
+					const committedRawId = this._rawIdFromChatId(committedSession.sessionId);
+					const committedAdapter = committedRawId ? this._sessionCache.get(committedRawId) : undefined;
+					committedAdapter?.setChatAgent(committedAdapter.resource, selectedAgent);
+				}
 				// Session graduated: release the eager subscription without
 				// firing `disposeSession`. The session handler has already
 				// acquired its own subscription (chat widget was opened
@@ -2966,6 +3079,49 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		if (value && !(value instanceof Error)) {
 			this._applySessionStateUpdate(sessionId, value);
 		}
+
+		this._hydrateAgentFromDraft(connection, cached, sessionId, sessionUri, store);
+	}
+
+	/**
+	 * Resume hydration: when a session is (re)loaded and its adapter has no agent
+	 * selected, restore the persisted selection from the default chat's
+	 * `ChatState.draft.agent` and mirror it onto `session.mode` (the picker's
+	 * source of truth).
+	 *
+	 * The agent is persisted on the chat channel — the session channel
+	 * ({@link SessionState}) carries no draft — so we briefly observe the default
+	 * chat's state until its draft agent arrives. The subscription is shared and
+	 * ref-counted with the chat session handler (no extra wire cost) and lives for
+	 * the session-state store's lifetime. Hydration is one-shot: the observer
+	 * stops as soon as `mode` is set — by us here, or by a concurrent graduation
+	 * seed or user pick (guarded inside
+	 * {@link AgentHostSessionAdapter.hydrateSelectedAgent}) — so it neither leaks,
+	 * overrides a later selection, nor keeps re-running on every chat update.
+	 */
+	private _hydrateAgentFromDraft(connection: IAgentConnection, cached: AgentHostSessionAdapter, sessionId: string, sessionUri: URI, store: DisposableStore): void {
+		if (cached.mode.get() !== undefined) {
+			return;
+		}
+		const lastDefaultChat = this._lastSessionStates.get(sessionId)?.defaultChat;
+		const defaultChatUri = lastDefaultChat ? URI.parse(lastDefaultChat.toString()) : URI.parse(buildDefaultChatUri(sessionUri));
+		const chatRef = connection.getSubscription(StateComponents.Chat, defaultChatUri, 'BaseAgentHostSessionsProvider.draftAgent');
+		store.add(chatRef);
+		const listener = store.add(new MutableDisposable());
+		const tryHydrate = () => {
+			if (cached.mode.get() === undefined) {
+				const chatState = chatRef.object.value;
+				const agentUri = chatState && !(chatState instanceof Error) ? chatState.draft?.agent?.uri : undefined;
+				if (agentUri) {
+					cached.hydrateSelectedAgent(agentUri);
+				}
+			}
+			if (cached.mode.get() !== undefined) {
+				listener.clear(); // hydration is one-shot; stop observing
+			}
+		};
+		listener.value = chatRef.object.onDidChange(() => tryHydrate());
+		tryHydrate();
 	}
 
 	/**
@@ -2981,6 +3137,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		// change too — firing on all of them caused excessive picker
 		// recomputes (and a feedback loop with `setAgent`).
 		if (!previous || customizationsChanged(previous, state)) {
+			this._reconcileAgentFromState(sessionId, state);
 			this._onDidChangeCustomAgents.fire();
 			this._onDidChangeCustomizations.fire();
 		}
@@ -3022,6 +3179,25 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			this._onDidChangeCustomAgents.fire();
 			this._onDidChangeCustomizations.fire();
 		}
+	}
+
+	/**
+	 * Rebase the cached running adapter's selected agent against the host's agent
+	 * list from an AHP {@link SessionState}, before the picker is notified. A
+	 * session that has moved into an isolated worktree keeps its selection instead
+	 * of resetting to the default once the host starts reporting worktree-pathed
+	 * agents. See {@link AgentHostSessionAdapter.reconcileSelectedAgent}.
+	 */
+	private _reconcileAgentFromState(sessionId: string, state: SessionState): void {
+		const rawId = this._rawIdFromChatId(sessionId);
+		if (!rawId) {
+			return;
+		}
+		const cached = this._sessionCache.get(rawId);
+		if (!cached) {
+			return;
+		}
+		cached.reconcileSelectedAgent(getEffectiveAgents(state.customizations));
 	}
 
 	/**

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -16,7 +16,7 @@ import { AgentSession, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHo
 import type { IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
 import type { ResolveSessionConfigResult } from '../../../../../../platform/agentHost/common/state/protocol/commands.js';
 import { CustomizationLoadStatus, CustomizationType, MessageKind, SessionLifecycle, type AgentInfo, type ChangesSummary, type Customization, type RootState, type SessionConfigState, type SessionState, type SessionSummary } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
-import { buildChatUri, buildDefaultChatUri, ChangesetStatus, SessionStatus as ProtocolSessionStatus, StateComponents, type ChangesetState, type ChatSummary } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { buildChatUri, buildDefaultChatUri, ChangesetStatus, ChatState, SessionStatus as ProtocolSessionStatus, StateComponents, type ChangesetState, type ChatSummary } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { ActionType, NotificationType, type ActionEnvelope, type IRootConfigChangedAction, type ChatAction, type SessionAction, type TerminalAction, type INotification, type ClientAnnotationsAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { SessionConfigKey } from '../../../../../../platform/agentHost/common/sessionConfigKeys.js';
 import { ConfigurationTarget, IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
@@ -51,7 +51,7 @@ import { IWorkbenchEnvironmentService } from '../../../../../../workbench/servic
 
 const STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES = 'sessions.agentHost.sessionConfigPicker.selectedValues';
 
-type SubscriptionState = SessionState | ChangesetState;
+type SubscriptionState = SessionState | ChangesetState | ChatState;
 
 class MockAgentHostService extends mock<IAgentHostService>() {
 	declare readonly _serviceBrand: undefined;
@@ -233,6 +233,11 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 	setChangesetState(changesetUri: string, state: ChangesetState): void {
 		this._sessionStateValues.set(changesetUri, state);
 		this._sessionStateEmitters.get(changesetUri)?.fire(state);
+	}
+
+	setChatState(chatUri: string, state: ChatState): void {
+		this._sessionStateValues.set(chatUri, state);
+		this._sessionStateEmitters.get(chatUri)?.fire(state);
 	}
 
 	setAgents(agents: AgentInfo[]): void {
@@ -1020,6 +1025,150 @@ suite('LocalAgentHostSessionsProvider', () => {
 
 		assert.strictEqual(session!.mode.get(), undefined);
 		assert.deepStrictEqual(agentHost.dispatchedActions, []);
+	});
+
+	test('restores the selected agent from the default chat draft on resume', () => {
+		const provider = createProvider(disposables, agentHost);
+		fireSessionAdded(agentHost, 'resume-agent', { title: 'Resume Agent Session' });
+
+		const session = provider.getSessions().find(s => s.title.get() === 'Resume Agent Session');
+		assert.ok(session);
+		assert.strictEqual(session!.mode.get(), undefined);
+
+		// `getSessionConfig` opens the session-state subscription, which also opens
+		// the default chat subscription used to read the persisted draft agent.
+		provider.getSessionConfig(session!.sessionId);
+
+		const defaultChatUri = buildDefaultChatUri(AgentSession.uri('copilotcli', 'resume-agent'));
+		agentHost.setChatState(defaultChatUri, {
+			resource: defaultChatUri,
+			title: 'Resume Agent Session',
+			status: ProtocolSessionStatus.Idle,
+			modifiedAt: new Date(0).toISOString(),
+			turns: [],
+			draft: { text: '', origin: { kind: MessageKind.User }, agent: { uri: 'agent://resumed' } },
+		});
+
+		assert.deepStrictEqual(session!.mode.get(), { id: 'agent://resumed', kind: 'agent' });
+	});
+
+	test('does not override a live agent selection with the persisted draft agent', () => {
+		const provider = createProvider(disposables, agentHost);
+		fireSessionAdded(agentHost, 'resume-nooverride', { title: 'Resume No Override' });
+
+		const session = provider.getSessions().find(s => s.title.get() === 'Resume No Override');
+		assert.ok(session);
+
+		// A live pick wins; a later draft snapshot must not clobber it.
+		provider.setAgent?.(session!.sessionId, { uri: 'agent://live', name: 'live' });
+		provider.getSessionConfig(session!.sessionId);
+
+		const defaultChatUri = buildDefaultChatUri(AgentSession.uri('copilotcli', 'resume-nooverride'));
+		agentHost.setChatState(defaultChatUri, {
+			resource: defaultChatUri,
+			title: 'Resume No Override',
+			status: ProtocolSessionStatus.Idle,
+			modifiedAt: new Date(0).toISOString(),
+			turns: [],
+			draft: { text: '', origin: { kind: MessageKind.User }, agent: { uri: 'agent://resumed' } },
+		});
+
+		assert.deepStrictEqual(session!.mode.get(), { id: 'agent://live', kind: 'agent' });
+	});
+
+	test('rebases the selected agent to its worktree twin from the agent list before the working directory flips', () => {
+		const provider = createProvider(disposables, agentHost);
+		fireSessionAdded(agentHost, 'rebase-worktree', { title: 'Rebase Worktree', workingDirectory: 'file:///Users/me/vscode' });
+
+		const session = provider.getSessions().find(s => s.title.get() === 'Rebase Worktree');
+		assert.ok(session);
+
+		// A folder agent is picked while the session still runs in the repo.
+		const folderAgent = 'file:///Users/me/vscode/.github/agents/sessions.md';
+		const worktreeAgent = 'file:///Users/me/vscode.worktrees/rebase-worktree/.github/agents/sessions.md';
+		provider.setAgent?.(session!.sessionId, { uri: folderAgent, name: 'sessions' });
+
+		// The host reports the worktree-pathed agents (the folder twin is gone)
+		// well before the working directory flips to the worktree. The rebase
+		// must derive the worktree root from the agent list, not the (still
+		// folder) working directory, so the selection is re-pointed in time.
+		provider.getSessionConfig(session!.sessionId);
+		agentHost.setSessionState('rebase-worktree', 'copilotcli', {
+			provider: 'copilotcli',
+			title: 'Rebase Worktree',
+			status: ProtocolSessionStatus.Idle,
+			lifecycle: SessionLifecycle.Ready,
+			activeClients: [],
+			chats: [],
+			customizations: [{
+				type: CustomizationType.Plugin,
+				id: 'plugin://worktree',
+				uri: 'plugin://worktree',
+				name: 'worktree plugin',
+				enabled: true,
+				load: { kind: CustomizationLoadStatus.Loaded },
+				children: [{ type: CustomizationType.Agent, id: worktreeAgent, uri: worktreeAgent, name: 'sessions' }],
+			}],
+		});
+
+		assert.deepStrictEqual(session!.mode.get(), { id: worktreeAgent, kind: 'agent' });
+	});
+
+	test('leaves the selected agent untouched when the agent list has no relocated twin', () => {
+		const provider = createProvider(disposables, agentHost);
+		fireSessionAdded(agentHost, 'rebase-none', { title: 'Rebase None', workingDirectory: 'file:///Users/me/vscode' });
+
+		const session = provider.getSessions().find(s => s.title.get() === 'Rebase None');
+		assert.ok(session);
+
+		const folderAgent = 'file:///Users/me/vscode/.github/agents/sessions.md';
+		provider.setAgent?.(session!.sessionId, { uri: folderAgent, name: 'sessions' });
+
+		// An unrelated agent (different repo-relative file) must not be treated
+		// as a relocation of the selection.
+		provider.getSessionConfig(session!.sessionId);
+		agentHost.setSessionState('rebase-none', 'copilotcli', {
+			provider: 'copilotcli',
+			title: 'Rebase None',
+			status: ProtocolSessionStatus.Idle,
+			lifecycle: SessionLifecycle.Ready,
+			activeClients: [],
+			chats: [],
+			customizations: [{
+				type: CustomizationType.Plugin,
+				id: 'plugin://other',
+				uri: 'plugin://other',
+				name: 'other plugin',
+				enabled: true,
+				load: { kind: CustomizationLoadStatus.Loaded },
+				children: [{ type: CustomizationType.Agent, id: 'file:///Users/me/vscode.worktrees/rebase-none/.github/agents/other.md', uri: 'file:///Users/me/vscode.worktrees/rebase-none/.github/agents/other.md', name: 'other' }],
+			}],
+		});
+
+		assert.deepStrictEqual(session!.mode.get(), { id: folderAgent, kind: 'agent' });
+	});
+
+	test('carries the picked custom agent onto the committed session when a new session graduates', async () => {
+		// Part 1 regression: when a new (untitled) session graduates into a real
+		// running session on first send, the picked agent must travel onto the
+		// committed session's `mode`. Otherwise the picker — which mirrors
+		// `session.mode` — resets to the default the moment the active session is
+		// swapped for the freshly committed one.
+		const provider = createProvider(disposables, agentHost, undefined, {
+			openSession: true,
+			sendRequest: async (): Promise<ChatSendResult> => {
+				agentHost.addSession(createSession('graduated', { summary: 'Graduated Session' }));
+				return { kind: 'sent' as const, data: {} as ChatSendResult extends { kind: 'sent'; data: infer D } ? D : never };
+			},
+		});
+
+		const session = provider.createNewSession(URI.parse('file:///home/user/project'), provider.sessionTypes[0].id);
+		provider.setAgent?.(session.sessionId, { uri: 'agent://picked', name: 'picked' });
+
+		const chat = await provider.createNewChat(session.sessionId);
+		const committed = await provider.sendRequest(session.sessionId, chat.resource, { query: 'hello' });
+
+		assert.deepStrictEqual(committed.mode.get(), { id: 'agent://picked', kind: 'agent' });
 	});
 
 	// ---- getCustomAgents / onDidChangeCustomAgents -------


### PR DESCRIPTION
Improved the handling of agent selection during session creation and transitions between repositories and worktrees. This update ensures that the selected custom agent is correctly persisted and utilized in Copilot sessions. Added tests to verify the agent selection behavior during session resumption and worktree transitions.
Fixes microsoft/vscode#323428

