### PR TITLE
sessions: gate Copilot CLI/Claude agent-host preferences on chat.agentHost.enabled

### DIFF
--- a/src/vs/platform/agentHost/common/agentHost.config.contribution.ts
+++ b/src/vs/platform/agentHost/common/agentHost.config.contribution.ts
@@ -43,7 +43,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'chat.agents.copilotCli.hideExtensionHost': {
 			type: 'boolean',
-			description: nls.localize('chat.agents.copilotCli.hideExtensionHost', "When enabled, hides the Extension Host Copilot CLI entry from the Agents window picker."),
+			markdownDescription: nls.localize('chat.agents.copilotCli.hideExtensionHost', "When enabled, hides the Extension Host Copilot CLI entry from the Agents window picker. Requires `#{0}#`.", AgentHostEnabledSettingId),
 			default: false,
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -43,7 +43,7 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { SessionConfigKey } from '../../../../../platform/agentHost/common/sessionConfigKeys.js';
-import { ClaudePreferAgentHostAgentsSettingId } from '../../../../../platform/agentHost/common/agentService.js';
+import { AgentHostEnabledSettingId, ClaudePreferAgentHostAgentsSettingId } from '../../../../../platform/agentHost/common/agentService.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { IGitHubService } from '../../../github/browser/githubService.js';
 import { computePullRequestIcon, GitHubPullRequestState } from '../../../github/common/types.js';
@@ -1438,28 +1438,50 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	private readonly _onDidGroupMembershipChange = this._register(new Emitter<{ sessionId: string }>());
 
 	private readonly _multiChatEnabled: boolean;
-	private _claudeEnabled: boolean;
-	private _preferAgentHostClaude: boolean;
-	private _hideExtensionHostCopilotCli: boolean;
+
+	/** Whether the agent host is enabled via `chat.agentHost.enabled`. */
+	private _isAgentHostEnabled(): boolean {
+		return this.configurationService.getValue<boolean>(AgentHostEnabledSettingId) ?? false;
+	}
 
 	/**
 	 * Claude is offered by this (Copilot Chat sessions) provider only when the
 	 * underlying `claudeAgent.enabled` setting is on AND the user has not opted
 	 * the agent-host implementation in via `chat.agents.claude.preferAgentHost`.
 	 * When the latter is true, the agent host registers Claude itself and this
-	 * provider stays out of the way so the picker shows a single entry.
+	 * provider stays out of the way so the picker shows a single entry. Stepping
+	 * aside only makes sense when the agent host is enabled to register Claude in
+	 * its place, so the preference is not respected unless `chat.agentHost.enabled`
+	 * is also on.
 	 */
 	private _isClaudeAvailable(): boolean {
-		return this._claudeEnabled && !this._preferAgentHostClaude;
+		const claudeEnabled = this.configurationService.getValue<boolean>(CLAUDE_CODE_ENABLED_SETTING) ?? false;
+		if (!claudeEnabled) {
+			return false;
+		}
+		const isAgentHostEnabled = this._isAgentHostEnabled();
+		const preferAgentHost = this.configurationService.getValue<boolean>(ClaudePreferAgentHostAgentsSettingId) ?? false;
+		if (isAgentHostEnabled && preferAgentHost) {
+			return false;
+		}
+		return true;
 	}
 
 	/**
 	 * The Extension Host Copilot CLI is offered by this provider unless the user
 	 * has hidden it via `chat.agents.copilotCli.hideExtensionHost`, in which case
 	 * the Agents window picker only surfaces the Agent Host Copilot CLI entry.
+	 * Hiding it only makes sense when the agent host is enabled to surface the
+	 * Agent Host Copilot CLI in its place, so the setting is not respected unless
+	 * `chat.agentHost.enabled` is also on.
 	 */
 	private _isCopilotCliAvailable(): boolean {
-		return !this._hideExtensionHostCopilotCli;
+		const isAgentHostEnabled = this._isAgentHostEnabled();
+		const hideExtensionHost = this.configurationService.getValue<boolean>(ChatConfiguration.CopilotCliHideExtensionHostAgents) ?? false;
+		if (isAgentHostEnabled && hideExtensionHost) {
+			return false;
+		}
+		return true;
 	}
 
 	readonly browseActions: readonly ISessionWorkspaceBrowseAction[];
@@ -1483,32 +1505,17 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		super();
 
 		this._multiChatEnabled = this.configurationService.getValue<boolean>(COPILOT_MULTI_CHAT_SETTING) ?? true;
-		this._claudeEnabled = this.configurationService.getValue<boolean>(CLAUDE_CODE_ENABLED_SETTING);
-		this._preferAgentHostClaude = this.configurationService.getValue<boolean>(ClaudePreferAgentHostAgentsSettingId) ?? false;
-		this._hideExtensionHostCopilotCli = this.configurationService.getValue<boolean>(ChatConfiguration.CopilotCliHideExtensionHostAgents) ?? false;
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			const claudeEnabledChanged = e.affectsConfiguration(CLAUDE_CODE_ENABLED_SETTING);
-			const preferAgentHostChanged = e.affectsConfiguration(ClaudePreferAgentHostAgentsSettingId);
-			const hideCopilotCliChanged = e.affectsConfiguration(ChatConfiguration.CopilotCliHideExtensionHostAgents);
-			if (!claudeEnabledChanged && !preferAgentHostChanged && !hideCopilotCliChanged) {
+			const affectsSessionTypes = e.affectsConfiguration(CLAUDE_CODE_ENABLED_SETTING)
+				|| e.affectsConfiguration(ClaudePreferAgentHostAgentsSettingId)
+				|| e.affectsConfiguration(ChatConfiguration.CopilotCliHideExtensionHostAgents)
+				|| e.affectsConfiguration(AgentHostEnabledSettingId);
+			if (!affectsSessionTypes) {
 				return;
 			}
-			const wasClaudeAvailable = this._isClaudeAvailable();
-			const wasCopilotCliAvailable = this._isCopilotCliAvailable();
-			if (claudeEnabledChanged) {
-				this._claudeEnabled = this.configurationService.getValue<boolean>(CLAUDE_CODE_ENABLED_SETTING);
-			}
-			if (preferAgentHostChanged) {
-				this._preferAgentHostClaude = this.configurationService.getValue<boolean>(ClaudePreferAgentHostAgentsSettingId) ?? false;
-			}
-			if (hideCopilotCliChanged) {
-				this._hideExtensionHostCopilotCli = this.configurationService.getValue<boolean>(ChatConfiguration.CopilotCliHideExtensionHostAgents) ?? false;
-			}
-			if (this._isClaudeAvailable() !== wasClaudeAvailable || this._isCopilotCliAvailable() !== wasCopilotCliAvailable) {
-				this._onDidChangeSessionTypes.fire();
-				this._refreshSessionCache();
-			}
+			this._onDidChangeSessionTypes.fire();
+			this._refreshSessionCache();
 		}));
 
 		this.browseActions = [

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
@@ -33,7 +33,7 @@ import { ISessionChangeEvent } from '../../../../../services/sessions/common/ses
 import { GITHUB_REMOTE_FILE_SCHEME, SessionStatus } from '../../../../../services/sessions/common/session.js';
 import { ChatConfiguration, ChatPermissionLevel } from '../../../../../../workbench/contrib/chat/common/constants.js';
 import { CLAUDE_CODE_ENABLED_SETTING, CopilotChatSessionsProvider, COPILOT_PROVIDER_ID, ClaudeCodeSessionType, ICopilotChatSession } from '../../browser/copilotChatSessionsProvider.js';
-import { ClaudePreferAgentHostAgentsSettingId } from '../../../../../../platform/agentHost/common/agentService.js';
+import { AgentHostEnabledSettingId, ClaudePreferAgentHostAgentsSettingId } from '../../../../../../platform/agentHost/common/agentService.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { IUriIdentityService } from '../../../../../../platform/uriIdentity/common/uriIdentity.js';
@@ -125,7 +125,7 @@ class MockAgentSessionsModel {
 function createProvider(
 	disposables: DisposableStore,
 	model: MockAgentSessionsModel,
-	opts?: { multiChatEnabled?: boolean; claudeEnabled?: boolean; preferAgentHost?: boolean; hideCopilotCli?: boolean },
+	opts?: { multiChatEnabled?: boolean; claudeEnabled?: boolean; preferAgentHost?: boolean; hideCopilotCli?: boolean; agentHostEnabled?: boolean },
 ): CopilotChatSessionsProvider {
 	return createProviderWithConfig(disposables, model, opts).provider;
 }
@@ -133,7 +133,7 @@ function createProvider(
 function createProviderWithConfig(
 	disposables: DisposableStore,
 	model: MockAgentSessionsModel,
-	opts?: { multiChatEnabled?: boolean; claudeEnabled?: boolean; preferAgentHost?: boolean; hideCopilotCli?: boolean },
+	opts?: { multiChatEnabled?: boolean; claudeEnabled?: boolean; preferAgentHost?: boolean; hideCopilotCli?: boolean; agentHostEnabled?: boolean },
 ): { provider: CopilotChatSessionsProvider; configService: TestConfigurationService } {
 	const instantiationService = disposables.add(new TestInstantiationService());
 
@@ -141,6 +141,7 @@ function createProviderWithConfig(
 	configService.setUserConfiguration('sessions.github.copilot.multiChatSessions', opts?.multiChatEnabled ?? true);
 	configService.setUserConfiguration(CLAUDE_CODE_ENABLED_SETTING, opts?.claudeEnabled ?? true);
 	configService.setUserConfiguration(ClaudePreferAgentHostAgentsSettingId, opts?.preferAgentHost ?? false);
+	configService.setUserConfiguration(AgentHostEnabledSettingId, opts?.agentHostEnabled ?? true);
 	configService.setUserConfiguration(ChatConfiguration.CopilotCliHideExtensionHostAgents, opts?.hideCopilotCli ?? false);
 
 	instantiationService.stub(IConfigurationService, configService);
@@ -324,6 +325,16 @@ suite('CopilotChatSessionsProvider', () => {
 		assert.ok(provider.sessionTypes.some(t => t.id === ClaudeCodeSessionType.id));
 	});
 
+	test('preferAgentHost is not respected when chat.agentHost.enabled is false', () => {
+		// Yielding to the agent host's Claude only makes sense when the agent
+		// host is enabled to register it. With the agent host disabled the
+		// preference must be ignored so this provider keeps surfacing Claude;
+		// otherwise Claude would disappear entirely.
+		const provider = createProvider(disposables, model, { claudeEnabled: true, preferAgentHost: true, agentHostEnabled: false });
+		assert.strictEqual(provider.sessionTypes.length, 3);
+		assert.ok(provider.sessionTypes.some(t => t.id === ClaudeCodeSessionType.id));
+	});
+
 	test('onDidChangeSessionTypes fires when claude setting changes', () => {
 		const { provider, configService } = createProviderWithConfig(disposables, model);
 		assert.strictEqual(provider.sessionTypes.length, 3);
@@ -391,6 +402,37 @@ suite('CopilotChatSessionsProvider', () => {
 			affectedKeys: new Set([ChatConfiguration.CopilotCliHideExtensionHostAgents]),
 			change: { keys: [ChatConfiguration.CopilotCliHideExtensionHostAgents], overrides: [] },
 			affectsConfiguration: (key: string) => key === ChatConfiguration.CopilotCliHideExtensionHostAgents,
+		});
+
+		assert.ok(fired, 'onDidChangeSessionTypes should have fired');
+		assert.ok(!provider.sessionTypes.some(t => t.id === CopilotCLISessionType.id));
+	});
+
+	test('hideExtensionHost is not respected when chat.agentHost.enabled is false', () => {
+		// Hiding the Extension Host Copilot CLI only makes sense when the agent
+		// host is enabled to surface the Agent Host Copilot CLI in its place. With
+		// the agent host disabled the hide setting must be ignored so the entry
+		// stays visible.
+		const provider = createProvider(disposables, model, { hideCopilotCli: true, agentHostEnabled: false });
+		assert.ok(provider.sessionTypes.some(t => t.id === CopilotCLISessionType.id));
+	});
+
+	test('onDidChangeSessionTypes fires when chat.agentHost.enabled toggles the hide gate', () => {
+		// With the hide setting on but the agent host initially disabled, the
+		// Copilot CLI entry is visible. Enabling the agent host must live-apply
+		// the hide setting and drop the entry without a window reload.
+		const { provider, configService } = createProviderWithConfig(disposables, model, { hideCopilotCli: true, agentHostEnabled: false });
+		assert.ok(provider.sessionTypes.some(t => t.id === CopilotCLISessionType.id));
+
+		let fired = false;
+		disposables.add(provider.onDidChangeSessionTypes(() => { fired = true; }));
+
+		configService.setUserConfiguration(AgentHostEnabledSettingId, true);
+		configService.onDidChangeConfigurationEmitter.fire({
+			source: ConfigurationTarget.USER,
+			affectedKeys: new Set([AgentHostEnabledSettingId]),
+			change: { keys: [AgentHostEnabledSettingId], overrides: [] },
+			affectsConfiguration: (key: string) => key === AgentHostEnabledSettingId,
 		});
 
 		assert.ok(fired, 'onDidChangeSessionTypes should have fired');

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -12,7 +12,7 @@ import { PolicyCategory } from '../../../../base/common/policy.js';
 import '../../../../platform/agentHost/common/agentHost.config.contribution.js';
 import '../../../../platform/agentHost/browser/agentHost.config.contribution.js';
 import '../../../../platform/agentHost/common/agentHostStarter.config.contribution.js';
-import { AgentHostAhpJsonlLoggingSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostOpus48PromptEnabledSettingId, AgentHostSdkSandboxEnabledSettingId, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHostEditorSettingId } from '../../../../platform/agentHost/common/agentService.js';
+import { AgentHostAhpJsonlLoggingSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostEnabledSettingId, AgentHostOpus48PromptEnabledSettingId, AgentHostSdkSandboxEnabledSettingId, ClaudePreferAgentHostAgentsSettingId, ClaudePreferAgentHostEditorSettingId } from '../../../../platform/agentHost/common/agentService.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../../../platform/networkFilter/common/networkFilterService.js';
 import { AgentNetworkDomainSettingId } from '../../../../platform/networkFilter/common/settings.js';
 import { COPILOT_DISABLE_BYPASS_PERMISSIONS_MODE_KEY, COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_MODEL_KEY, COPILOT_STRICT_MARKETPLACES_KEY, managedSettingValue } from '../../../../platform/policy/common/copilotManagedSettings.js';
@@ -778,7 +778,7 @@ configurationRegistry.registerConfiguration({
 		},
 		[ClaudePreferAgentHostAgentsSettingId]: {
 			type: 'boolean',
-			description: nls.localize('chat.agents.claude.preferAgentHost', "When enabled, Claude sessions opened from the Agents Window run inside the agent host process instead of the GitHub Copilot Chat extension. Only one Claude implementation surfaces per window."),
+			markdownDescription: nls.localize('chat.agents.claude.preferAgentHost', "When enabled, Claude sessions opened from the Agents Window run inside the agent host process instead of the GitHub Copilot Chat extension. Only one Claude implementation surfaces per window. Requires `#{0}#`.", AgentHostEnabledSettingId),
 			default: false,
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },


### PR DESCRIPTION
## What

Make `chat.agentHost.enabled` the master gate for two agent-host preference settings consumed by the Copilot Chat sessions provider in the Agents window:

- `chat.agents.copilotCli.hideExtensionHost`
- `chat.agents.claude.preferAgentHost`

When `chat.agentHost.enabled` is **off**, these two settings are no longer respected (treated as `false`).

## Why

Both settings tell the Copilot Chat sessions provider to step aside so the **agent host** can surface its own entry in its place:

- `hideExtensionHost` hides the Extension Host Copilot CLI so only the Agent Host Copilot CLI shows.
- `preferAgentHost` (Claude) makes this provider yield so the agent host's Claude registration shows instead.

But when the agent host is disabled it never registers those replacement entries. Honoring the preferences in that state would make the Copilot CLI / Claude entries **disappear entirely** from the picker. Gating them on `chat.agentHost.enabled` keeps the entries visible until the agent host is actually enabled to take over.

## Changes

- `copilotChatSessionsProvider.ts`: `_isClaudeAvailable()` and `_isCopilotCliAvailable()` now also check `chat.agentHost.enabled` (via a small shared `_isAgentHostEnabled()` helper). Availability is computed live from configuration; the cached fields were removed and the config-change handler simply re-collects/re-sorts session types when any relevant setting changes.
- `agentHost.config.contribution.ts` / `chat.shared.contribution.ts`: updated the two setting descriptions to note they require `#chat.agentHost.enabled#`.
- Added unit tests covering that each preference is ignored while the agent host is disabled, and that toggling `chat.agentHost.enabled` live-applies the gate.

## Notes for reviewers

- This is a read-time override: the user's stored values are untouched, just ignored while the master is off.
- `chat.agentHost.defaultSessionsProvider` was already gated on `chat.agentHost.enabled` (the local agent host provider only registers when enabled), so no change was needed there.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>