### PR TITLE
Cherry-pick agent host client tool fixes to 1.127

### DIFF
--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -1090,7 +1090,7 @@ export interface IAgent {
 	sessionConfigCompletions(params: IAgentSessionConfigCompletionsParams): Promise<SessionConfigCompletionsResult>;
 
 	/** Send a user message into a chat within an existing session. */
-	sendMessage(session: URI, chat: URI, prompt: string, attachments?: readonly MessageAttachment[], turnId?: string): Promise<void>;
+	sendMessage(session: URI, chat: URI, prompt: string, attachments?: readonly MessageAttachment[], turnId?: string, senderClientId?: string): Promise<void>;
 
 	/**
 	 * Create an additional chat within an existing session, backed by a new

--- a/src/vs/platform/agentHost/common/state/sessionState.ts
+++ b/src/vs/platform/agentHost/common/state/sessionState.ts
@@ -619,6 +619,11 @@ export function buildDefaultChatUri(sessionUri: ProtocolURI | ResourceURI): stri
 
 const SUBAGENT_CHAT_ID = 'subagent';
 
+export function isSubagentChatUri(uri: ProtocolURI | ResourceURI): boolean {
+	const parsed = typeof uri === 'string' ? ResourceURI.parse(uri) : uri;
+	return parsed.scheme === AHP_CHAT_SCHEME && parsed.authority === SUBAGENT_CHAT_ID;
+}
+
 export function buildSubagentChatUri(sessionUri: ProtocolURI | ResourceURI, toolCallId: string): string {
 	const session = typeof sessionUri === 'string' ? sessionUri : sessionUri.toString();
 	const encoded = encodeBase64(VSBuffer.fromString(session), false, true);

--- a/src/vs/platform/agentHost/node/activeClientState.ts
+++ b/src/vs/platform/agentHost/node/activeClientState.ts
@@ -123,12 +123,14 @@ export class ActiveClientToolSet {
 	}
 
 	/**
-	 * The `clientId` that owns the merged tool named `toolName` (the
-	 * first-inserted contributor of that name), or `undefined` when no active
-	 * client provides it. Used to stamp client tool calls with their owning
-	 * client at invocation time.
+	 * The `clientId` that owns the tool named `toolName`, or `undefined` when
+	 * no active client provides it. When `preferredClientId` currently provides
+	 * the tool it wins; otherwise the first-inserted contributor wins.
 	 */
-	ownerOf(toolName: string): string | undefined {
+	ownerOf(toolName: string, preferredClientId?: string): string | undefined {
+		if (preferredClientId && this.get(preferredClientId).some(tool => tool.name === toolName)) {
+			return preferredClientId;
+		}
 		for (const [clientId, tools] of this._byClient) {
 			if (tools.some(tool => tool.name === toolName)) {
 				return clientId;

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -1282,7 +1282,7 @@ export class AgentService extends Disposable implements IAgentService {
 		if (action.type === ActionType.RootConfigChanged) {
 			this._configurationService.persistRootConfig();
 		}
-		this._sideEffects.handleAction(channel, action);
+		this._sideEffects.handleAction(channel, action, clientId);
 	}
 
 	private _needsAsyncRewrite(channel: string, action: SessionAction | ChatAction | TerminalAction | ClientAnnotationsAction | IRootConfigChangedAction): action is ChatTurnStartedAction | ChatPendingMessageSetAction {

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -744,7 +744,7 @@ export class AgentSideEffects extends Disposable {
 		);
 	}
 
-	handleAction(channel: ProtocolURI, action: StateAction): void {
+	handleAction(channel: ProtocolURI, action: StateAction, clientId?: string): void {
 		const chatChannel = isAhpChatChannel(channel) ? channel : undefined;
 		const sessionChannel = chatChannel ? parseRequiredSessionUriFromChatUri(chatChannel) : channel;
 		switch (action.type) {
@@ -790,6 +790,7 @@ export class AgentSideEffects extends Disposable {
 					chat: channel,
 					message: action.message,
 					turnId: action.turnId,
+					senderClientId: clientId,
 				});
 				break;
 			}
@@ -1142,6 +1143,7 @@ export class AgentSideEffects extends Disposable {
 			chat: session,
 			message: msg.message,
 			turnId,
+			senderClientId: undefined,
 		});
 	}
 
@@ -1169,8 +1171,9 @@ export class AgentSideEffects extends Disposable {
 		chat: ProtocolURI;
 		message: Message;
 		turnId: string;
+		senderClientId: string | undefined;
 	}): Promise<void> {
-		const { agent, sessionChannel, turnChannel, chat, message, turnId } = options;
+		const { agent, sessionChannel, turnChannel, chat, message, turnId, senderClientId } = options;
 
 		const sessionUri = URI.parse(sessionChannel);
 		const chatUri = URI.parse(chat);
@@ -1192,7 +1195,7 @@ export class AgentSideEffects extends Disposable {
 
 		await Promise.all(selectionUpdates);
 
-		await agent.sendMessage(URI.parse(sessionChannel), chatUri, message.text, message.attachments, turnId).catch(err => {
+		await agent.sendMessage(URI.parse(sessionChannel), chatUri, message.text, message.attachments, turnId, senderClientId).catch(err => {
 			const errCode = (err as { code?: number })?.code;
 			this._logService.error(`[AgentSideEffects] sendMessage failed for session=${turnChannel}: code=${errCode}, message=${err instanceof Error ? err.message : String(err)}, type=${err?.constructor?.name}`, err);
 			this._stateManager.dispatchServerAction(turnChannel, {

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -28,6 +28,7 @@ import {
 	getToolFileEdits,
 	isAhpChatChannel,
 	isDefaultChatUri,
+	isSubagentChatUri,
 	MessageKind,
 	parseChatUri,
 	parseRequiredSessionUriFromChatUri,
@@ -165,7 +166,7 @@ export class AgentSideEffects extends Disposable {
 				}
 				const sessionChannel = parseRequiredSessionUriFromChatUri(envelope.channel);
 				const agent = this._options.getAgent(sessionChannel);
-				agent?.onClientToolCallComplete(URI.parse(sessionChannel), URI.parse(envelope.channel), action.toolCallId, action.result);
+				agent?.onClientToolCallComplete(URI.parse(sessionChannel), URI.parse(this._toolCallCompletionChat(envelope.channel)), action.toolCallId, action.result);
 			}
 			if (envelope.action.type === ActionType.ChatDraftChanged) {
 				this._persistChatDraft(envelope.channel, envelope.action.draft);
@@ -700,6 +701,20 @@ export class AgentSideEffects extends Disposable {
 		return undefined;
 	}
 
+	private _toolCallCompletionChat(chatChannel: ProtocolURI): ProtocolURI {
+		if (!isSubagentChatUri(chatChannel)) {
+			return chatChannel;
+		}
+
+		for (const subagent of this._subagentChats.values()) {
+			if (subagent.chatUri === chatChannel) {
+				return this._toolCallCompletionChat(subagent.parentChatUri);
+			}
+		}
+
+		return chatChannel;
+	}
+
 	// ---- Side-effect handlers --------------------------------------------------
 
 	/**
@@ -934,7 +949,7 @@ export class AgentSideEffects extends Disposable {
 					break; // Not a chat channel; ignore.
 				}
 				const agent = this._options.getAgent(sessionChannel);
-				agent?.onClientToolCallComplete(URI.parse(sessionChannel), URI.parse(chatChannel), action.toolCallId, action.result);
+				agent?.onClientToolCallComplete(URI.parse(sessionChannel), URI.parse(this._toolCallCompletionChat(chatChannel)), action.toolCallId, action.result);
 				break;
 			}
 		}

--- a/src/vs/platform/agentHost/node/claude/clientTools/claudeSessionClientToolsModel.ts
+++ b/src/vs/platform/agentHost/node/claude/clientTools/claudeSessionClientToolsModel.ts
@@ -52,9 +52,9 @@ export class SessionClientToolsModel {
 		}
 	}
 
-	/** The `clientId` that owns the merged tool named `toolName`, or `undefined`. */
-	ownerOf(toolName: string): string | undefined {
-		return this._toolSet.ownerOf(toolName);
+	/** The `clientId` that owns the tool named `toolName`, or `undefined`. */
+	ownerOf(toolName: string, preferredClientId?: string): string | undefined {
+		return this._toolSet.ownerOf(toolName, preferredClientId);
 	}
 }
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1484,16 +1484,9 @@ export class CopilotAgent extends Disposable implements IAgent {
 		// keyed by the chat URI. Mirrors the routing in `sendMessage`.
 		if (!isDefaultChatUri(chat)) {
 			this._chatSessions.get(chat.toString())?.handleClientToolCallComplete(toolCallId, result);
-			return;
+		} else {
+			this._sessions.get(AgentSession.id(session))?.handleClientToolCallComplete(toolCallId, result);
 		}
-		// Default chat (and subagents): walk up the subagent chain to reach the
-		// root SDK session entry, since `_sessions` is keyed by root session ids.
-		let target = session;
-		let parsed;
-		while ((parsed = parseSubagentSessionUri(target))) {
-			target = parsed.parentSession;
-		}
-		this._sessions.get(AgentSession.id(target))?.handleClientToolCallComplete(toolCallId, result);
 	}
 
 	setCustomizationEnabled(uri: string, enabled: boolean): void {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1505,7 +1505,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		}
 	}
 
-	async sendMessage(session: URI, chat: URI, prompt: string, attachments?: readonly MessageAttachment[], turnId?: string): Promise<void> {
+	async sendMessage(session: URI, chat: URI, prompt: string, attachments?: readonly MessageAttachment[], turnId?: string, senderClientId?: string): Promise<void> {
 		// Additional (non-default) chats are backed by their own SDK
 		// conversation tracked in `_chatSessions`, keyed by the chat URI.
 		if (!isDefaultChatUri(chat)) {
@@ -1514,9 +1514,9 @@ export class CopilotAgent extends Disposable implements IAgent {
 				throw new Error(`[Copilot] sendMessage for unknown chat: ${chat.toString()}`);
 			}
 			if (turnId) {
-				entry.resetTurnState(turnId);
+				entry.resetTurnState(turnId, senderClientId);
 			}
-			await entry.send(prompt, attachments, turnId, this._resolveSdkMode(session));
+			await entry.send(prompt, attachments, turnId, this._resolveSdkMode(session), senderClientId);
 			return;
 		}
 		const sessionId = AgentSession.id(session);
@@ -1554,7 +1554,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			// next text/reasoning chunk (and any host-emitted announcement)
 			// allocates a fresh response part.
 			if (turnId) {
-				entry.resetTurnState(turnId);
+				entry.resetTurnState(turnId, senderClientId);
 			}
 
 			// Emit any pending first-turn announcement (e.g. worktree
@@ -1570,7 +1570,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 			try {
 				const sdkMode = this._resolveSdkMode(session);
-				await entry.send(prompt, attachments, turnId, sdkMode);
+				await entry.send(prompt, attachments, turnId, sdkMode, senderClientId);
 			} catch (err) {
 				const errCode = (err as { code?: number })?.code;
 				const errMsg = err instanceof Error ? err.message : String(err);

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -400,7 +400,7 @@ class CopilotTurn {
 	/** Current reasoning response part IDs for this turn, keyed by `parentToolCallId ?? ''`. */
 	readonly reasoningPartIds = new Map<string, string>();
 
-	constructor(readonly id: string) { }
+	constructor(readonly id: string, readonly senderClientId: string | undefined) { }
 
 	get state(): CopilotTurnState { return this._state; }
 	get isPending(): boolean { return this._state === 'pending'; }
@@ -769,8 +769,8 @@ export class CopilotAgentSession extends Disposable {
 	 * from a previous turn so the next text/reasoning chunk allocates a new
 	 * response part. The turn becomes `running` on the first SDK event.
 	 */
-	resetTurnState(turnId: string): void {
-		this._currentTurn = new CopilotTurn(turnId);
+	resetTurnState(turnId: string, senderClientId?: string): void {
+		this._currentTurn = new CopilotTurn(turnId, senderClientId);
 	}
 
 	private _completeActiveTurn(): void {
@@ -995,6 +995,10 @@ export class CopilotAgentSession extends Disposable {
 				binaryResultsForLlm: binaryResults?.length ? binaryResults : undefined,
 			});
 		}
+
+		// Still pending permission, so this call may have errored while getting permission.
+		// Go ahead and allow the call which will immediately see the buffered value.
+		this.respondToPermissionRequest(toolCallId, true);
 	}
 
 	/**
@@ -1038,12 +1042,12 @@ export class CopilotAgentSession extends Disposable {
 
 	// ---- session operations -------------------------------------------------
 
-	async send(prompt: string, attachments?: readonly MessageAttachment[], turnId?: string, mode?: CopilotSdkMode): Promise<void> {
+	async send(prompt: string, attachments?: readonly MessageAttachment[], turnId?: string, mode?: CopilotSdkMode, senderClientId?: string): Promise<void> {
 		if (turnId && this._currentTurn?.id !== turnId) {
 			// Establish the `pending` turn for this message. Callers normally
 			// call `resetTurnState` just before `send()`; this covers the
 			// direct-send path and is a no-op when the turn already exists.
-			this.resetTurnState(turnId);
+			this.resetTurnState(turnId, senderClientId);
 		}
 		this._logService.info(`[Copilot:${this.sessionId}] sendMessage called: "${prompt.substring(0, 100)}${prompt.length > 100 ? '...' : ''}" (${attachments?.length ?? 0} attachments)`);
 
@@ -2503,7 +2507,7 @@ export class CopilotAgentSession extends Disposable {
 
 			let contributor: { readonly kind: ToolCallContributorKind.Client; readonly clientId: string } | { readonly kind: ToolCallContributorKind.MCP; readonly customizationId: string } | undefined;
 			const isClientTool = this._clientToolNames.has(e.data.toolName);
-			const ownerClientId = isClientTool ? this._activeClientToolSet.ownerOf(e.data.toolName) : undefined;
+			const ownerClientId = isClientTool ? this._activeClientToolSet.ownerOf(e.data.toolName, this._currentTurn?.senderClientId) : undefined;
 			if (ownerClientId) {
 				contributor = { kind: ToolCallContributorKind.Client, clientId: ownerClientId };
 			} else if (e.data.mcpServerName) {

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -249,6 +249,26 @@ suite('AgentSideEffects', () => {
 			assert.deepStrictEqual(agent.sendMessageCalls, [{ session: URI.parse(sessionUri.toString()), prompt: 'hello world', attachments: undefined, chat: URI.parse(defaultChatUri) }]);
 		});
 
+		test('passes the dispatching client id to sendMessage', async () => {
+			setupSession();
+			const action: ChatAction = {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				message: { text: 'hello world', origin: { kind: MessageKind.User } },
+			};
+			sideEffects.handleAction(defaultChatUri, action, 'client-B');
+
+			await waitForSendMessageCalls(1);
+
+			assert.deepStrictEqual(agent.sendMessageCalls, [{
+				session: URI.parse(sessionUri.toString()),
+				prompt: 'hello world',
+				attachments: undefined,
+				chat: URI.parse(defaultChatUri),
+				senderClientId: 'client-B',
+			}]);
+		});
+
 		test('logs telemetry when sending a direct user message', () => {
 			setupSession();
 			const activeClientAction: SessionAction = {

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -1921,6 +1921,35 @@ suite('AgentSideEffects', () => {
 				[{ session: sessionUri.toString(), chat: peerChatUri, toolCallId: 'tc-peer' }],
 			);
 		});
+
+		test('forwards parent peer chat URI for a subagent-chat completion', () => {
+			setupSession();
+			const peerChatUri = buildChatUri(sessionUri.toString(), 'peer-subagent-parent');
+			stateManager.addChat(sessionUri.toString(), peerChatUri);
+			startTurn('turn-peer', peerChatUri);
+			disposables.add(sideEffects.registerProgressListener(agent));
+
+			agent.fireProgress({
+				kind: 'subagent_started',
+				chat: URI.parse(peerChatUri),
+				toolCallId: 'tc-parent',
+				agentName: 'explore',
+				agentDisplayName: 'Explore',
+			});
+
+			const subagentChatUri = buildSubagentChatUri(sessionUri.toString(), 'tc-parent');
+			sideEffects.handleAction(subagentChatUri, {
+				type: ActionType.ChatToolCallComplete,
+				turnId: 'turn-subagent',
+				toolCallId: 'tc-inner',
+				result: { success: true, pastTenseMessage: 'done' },
+			});
+
+			assert.deepStrictEqual(
+				agent.clientToolCallCompleteCalls.map(c => ({ session: c.session.toString(), chat: c.chat?.toString(), toolCallId: c.toolCallId })),
+				[{ session: sessionUri.toString(), chat: peerChatUri, toolCallId: 'tc-inner' }],
+			);
+		});
 	});
 
 	// ---- Session-level auto-approve (config) ----------------------------

--- a/src/vs/platform/agentHost/test/node/clientTools/claudeSessionClientToolsModel.test.ts
+++ b/src/vs/platform/agentHost/test/node/clientTools/claudeSessionClientToolsModel.test.ts
@@ -120,6 +120,21 @@ suite('SessionClientToolsDiff', () => {
 		assert.strictEqual(diff.model.ownerOf('shared'), 'c1', 'first-inserted client wins the shared name');
 	});
 
+	test('ownerOf prefers the requested client when it provides the shared tool', () => {
+		const diff = disposables.add(new SessionClientToolsDiff());
+		diff.model.setTools('c1', [tool({ name: 'shared', description: 'from c1' })]);
+		diff.model.setTools('c2', [tool({ name: 'shared', description: 'from c2' })]);
+		assert.deepStrictEqual({
+			defaultOwner: diff.model.ownerOf('shared'),
+			preferredOwner: diff.model.ownerOf('shared', 'c2'),
+			missingPreferredOwner: diff.model.ownerOf('shared', 'missing'),
+		}, {
+			defaultOwner: 'c1',
+			preferredOwner: 'c2',
+			missingPreferredOwner: 'c1',
+		});
+	});
+
 	test('removeClient drops that client and re-flips dirty when the merged set changes', () => {
 		const diff = disposables.add(new SessionClientToolsDiff());
 		diff.model.setTools('c1', [tool({ name: 'a' })]);

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -32,7 +32,7 @@ import { AgentHostConfigKey } from '../../common/agentHostCustomizationConfig.js
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, type AgentSignal, type IAgentActionSignal, type IAgentSessionMetadata } from '../../common/agentService.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
-import { buildDefaultChatUri, buildSubagentSessionUri, buildChatUri, CustomizationLoadStatus, MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, customizationId, type ClientPluginCustomization, type MarkdownResponsePart, type PluginCustomization, type ToolCallResult, type Turn, RuleCustomization } from '../../common/state/sessionState.js';
+import { buildDefaultChatUri, buildChatUri, CustomizationLoadStatus, MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, customizationId, type ClientPluginCustomization, type MarkdownResponsePart, type PluginCustomization, type ToolCallResult, type Turn, RuleCustomization } from '../../common/state/sessionState.js';
 import { CustomizationType, ToolCallContributorKind, type AgentSelection, type ModelSelection, type ToolDefinition } from '../../common/state/protocol/state.js';
 import { ActionType, type ChatAction, type IDeltaAction, type SessionAction } from '../../common/state/sessionActions.js';
 
@@ -2202,50 +2202,6 @@ suite('CopilotAgent', () => {
 				agent.onClientToolCallComplete(sessionUri, defaultChat, 'tc-top', result);
 
 				assert.deepStrictEqual(calls, [{ toolCallId: 'tc-top', result }]);
-			} finally {
-				await disposeAgent(agent);
-			}
-		});
-
-		test('routes a subagent session URI to its parent session entry', async () => {
-			// Regression: client-tool completions for tools running inside a
-			// subagent are dispatched against the subagent session URI by
-			// the renderer. The agent must resolve that to the parent
-			// session entry — only the parent owns the SDK session and the
-			// pending deferred for the tool call.
-			const agent = createTestAgent(disposables);
-			try {
-				const parentUri = AgentSession.uri('copilotcli', 'session-parent');
-				const defaultChat = URI.parse(buildDefaultChatUri(parentUri));
-				const { calls } = installStubSession(agent, AgentSession.id(parentUri));
-
-				const subagentUri = URI.parse(buildSubagentSessionUri(parentUri.toString(), 'tc-parent'));
-				const result: ToolCallResult = { success: true, pastTenseMessage: 'subagent tool done' };
-				agent.onClientToolCallComplete(subagentUri, defaultChat, 'tc-inner', result);
-
-				assert.deepStrictEqual(calls, [{ toolCallId: 'tc-inner', result }]);
-			} finally {
-				await disposeAgent(agent);
-			}
-		});
-
-		test('routes a nested subagent session URI (depth > 1) to the root session entry', async () => {
-			// Regression for depth > 1: a nested subagent URI like
-			// `copilot:/root/subagent/tc1/subagent/tc2` must walk all the way
-			// to the root session entry in `_sessions`, not stop at the
-			// intermediate parent `copilot:/root/subagent/tc1`.
-			const agent = createTestAgent(disposables);
-			try {
-				const rootUri = AgentSession.uri('copilotcli', 'session-root');
-				const defaultChat = URI.parse(buildDefaultChatUri(rootUri));
-				const { calls } = installStubSession(agent, AgentSession.id(rootUri));
-
-				const subagentUri = URI.parse(buildSubagentSessionUri(rootUri.toString(), 'tc-parent'));
-				const nestedUri = URI.parse(buildSubagentSessionUri(subagentUri.toString(), 'tc-nested'));
-				const result: ToolCallResult = { success: true, pastTenseMessage: 'nested done' };
-				agent.onClientToolCallComplete(nestedUri, defaultChat, 'tc-inner', result);
-
-				assert.deepStrictEqual(calls, [{ toolCallId: 'tc-inner', result }]);
 			} finally {
 				await disposeAgent(agent);
 			}

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -3,14 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { CopilotClient, CopilotSession, ModelInfo, SessionEventHandler, SessionEventPayload, SessionEventType, TypedSessionEventHandler } from '@github/copilot-sdk';
+import type { CopilotClient, CopilotSession, ModelInfo, SessionEvent, SessionEventHandler, SessionEventPayload, SessionEventType, TypedSessionEventHandler } from '@github/copilot-sdk';
 import type Anthropic from '@anthropic-ai/sdk';
 import type { CCAModel } from '@vscode/copilot-api';
 import assert from 'assert';
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import { VSBuffer } from '../../../../base/common/buffer.js';
-import { DeferredPromise } from '../../../../base/common/async.js';
+import { DeferredPromise, timeout } from '../../../../base/common/async.js';
 import { isCancellationError } from '../../../../base/common/errors.js';
 import { Disposable, type DisposableStore, type IDisposable, type IReference } from '../../../../base/common/lifecycle.js';
 import { Event } from '../../../../base/common/event.js';
@@ -32,8 +32,8 @@ import { AgentHostConfigKey } from '../../common/agentHostCustomizationConfig.js
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, type AgentSignal, type IAgentActionSignal, type IAgentSessionMetadata } from '../../common/agentService.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
-import { buildDefaultChatUri, buildSubagentSessionUri, buildChatUri, CustomizationLoadStatus, MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, TurnState, customizationId, type ClientPluginCustomization, type MarkdownResponsePart, type PluginCustomization, type ToolCallResult, type Turn, RuleCustomization } from '../../common/state/sessionState.js';
-import { CustomizationType, type AgentSelection, type ModelSelection, type ToolDefinition } from '../../common/state/protocol/state.js';
+import { buildDefaultChatUri, buildSubagentSessionUri, buildChatUri, CustomizationLoadStatus, MessageKind, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, customizationId, type ClientPluginCustomization, type MarkdownResponsePart, type PluginCustomization, type ToolCallResult, type Turn, RuleCustomization } from '../../common/state/sessionState.js';
+import { CustomizationType, ToolCallContributorKind, type AgentSelection, type ModelSelection, type ToolDefinition } from '../../common/state/protocol/state.js';
 import { ActionType, type ChatAction, type IDeltaAction, type SessionAction } from '../../common/state/sessionActions.js';
 
 import { AgentConfigurationService, IAgentConfigurationService } from '../../node/agentConfigurationService.js';
@@ -49,6 +49,7 @@ import { CopilotAgentSession } from '../../node/copilot/copilotAgentSession.js';
 import { CopilotBranchNameGenerator, ICopilotBranchNameGenerator, getCopilotBranchNameHintFromMessage, normalizeCopilotBranchName } from '../../node/copilot/copilotBranchNameGenerator.js';
 import type { CopilotSessionLaunchPlan, IActiveClientSnapshot } from '../../node/copilot/copilotSessionLauncher.js';
 import { ShellManager } from '../../node/copilot/copilotShellTools.js';
+import { registerPendingEditContentProvider } from '../../node/copilot/pendingEditContentStore.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { createNullSessionDataService } from '../common/sessionTestHelpers.js';
 import { ActiveClientToolSet } from '../../node/activeClientState.js';
@@ -307,11 +308,38 @@ interface IFakeAgentSession {
 
 class MockCopilotSession {
 	readonly sessionId = 'test-session-1';
+	private readonly _handlers = new Set<SessionEventHandler>();
+	private readonly _typedHandlers = new Map<SessionEventType, Set<(event: SessionEventPayload<SessionEventType>) => void>>();
 
 	on(_handler: SessionEventHandler): () => void;
 	on<K extends SessionEventType>(_eventType: K, _handler: TypedSessionEventHandler<K>): () => void;
-	on<K extends SessionEventType>(_eventTypeOrHandler: K | SessionEventHandler, _handler?: TypedSessionEventHandler<K>): () => void {
-		return () => { };
+	on<K extends SessionEventType>(eventTypeOrHandler: K | SessionEventHandler, handler?: TypedSessionEventHandler<K>): () => void {
+		if (typeof eventTypeOrHandler === 'function') {
+			this._handlers.add(eventTypeOrHandler);
+			return () => this._handlers.delete(eventTypeOrHandler);
+		}
+		if (!handler) {
+			throw new Error(`Missing handler for ${eventTypeOrHandler}`);
+		}
+		let handlers = this._typedHandlers.get(eventTypeOrHandler);
+		if (!handlers) {
+			handlers = new Set();
+			this._typedHandlers.set(eventTypeOrHandler, handlers);
+		}
+		const typedHandler = handler as (event: SessionEventPayload<SessionEventType>) => void;
+		handlers.add(typedHandler);
+		return () => handlers.delete(typedHandler);
+	}
+
+	emit<K extends SessionEventType>(event: SessionEventPayload<K>): void {
+		const sessionEvent = event as SessionEvent;
+		for (const handler of this._handlers) {
+			handler(sessionEvent);
+		}
+		const typedEvent = event as SessionEventPayload<SessionEventType>;
+		for (const handler of this._typedHandlers.get(event.type) ?? []) {
+			handler(typedEvent);
+		}
 	}
 
 	async send(): Promise<string> { return ''; }
@@ -474,24 +502,25 @@ function createTestAgent(disposables: Pick<DisposableStore, 'add'>, options?: { 
 
 type CopilotCreateSessionOptions = Parameters<CopilotClient['createSession']>[0];
 
-function createAgentSessionThroughAgent(agent: CopilotAgent, instantiationService: IInstantiationService): { readonly session: CopilotAgentSession; readonly createOptions: () => CopilotCreateSessionOptions | undefined } {
+function createAgentSessionThroughAgent(agent: CopilotAgent, instantiationService: IInstantiationService, options?: { readonly mockSession?: MockCopilotSession; readonly activeClientToolSet?: ActiveClientToolSet; readonly snapshot?: IActiveClientSnapshot }): { readonly session: CopilotAgentSession; readonly createOptions: () => CopilotCreateSessionOptions | undefined } {
 	const sessionUri = AgentSession.uri('copilotcli', 'test-session-1');
 	const shellManager = instantiationService.createInstance(ShellManager, sessionUri, undefined);
 	let createOptions: CopilotCreateSessionOptions | undefined;
+	const mockSession = options?.mockSession ?? new MockCopilotSession();
 	const launchPlan: CopilotSessionLaunchPlan = {
 		kind: 'create',
 		client: {
 			createSession: async options => {
 				createOptions = options;
-				return new MockCopilotSession() as unknown as CopilotSession;
+				return mockSession as unknown as CopilotSession;
 			},
-			resumeSession: async () => new MockCopilotSession() as unknown as CopilotSession,
+			resumeSession: async () => mockSession as unknown as CopilotSession,
 		},
-		activeClientToolSet: new ActiveClientToolSet(),
+		activeClientToolSet: options?.activeClientToolSet ?? new ActiveClientToolSet(),
 		sessionId: 'test-session-1',
 		workingDirectory: undefined,
 		resolvedAgentName: undefined,
-		snapshot: { tools: [], plugins: [], mcpServers: {} },
+		snapshot: options?.snapshot ?? { tools: [], plugins: [], mcpServers: {} },
 		shellManager,
 		githubToken: 'token',
 		model: undefined,
@@ -1262,6 +1291,96 @@ suite('CopilotAgent', () => {
 			} else {
 				process.env['XDG_STATE_HOME'] = previousXdgStateHome;
 			}
+			await disposeAgent(agent);
+		}
+	});
+
+	test('client tool call contributor prefers the message sender when it provides the tool', async () => {
+		const sessionDataService = disposables.add(new TestSessionDataService());
+		const { agent, instantiationService } = createTestAgentContext(disposables, { environmentServiceRegistration: 'native', sessionDataService });
+		const actions: (SessionAction | ChatAction)[] = [];
+		disposables.add(agent.onDidSessionProgress(signal => {
+			if (signal.kind === 'action') {
+				actions.push(signal.action);
+			}
+		}));
+		const activeClientToolSet = new ActiveClientToolSet();
+		const sharedTool: ToolDefinition = { name: 'shared', description: 'Shared tool', inputSchema: { type: 'object', properties: {} } };
+		activeClientToolSet.set('client-A', [sharedTool]);
+		activeClientToolSet.set('client-B', [sharedTool]);
+		const mockSession = new MockCopilotSession();
+		const createdSession = createAgentSessionThroughAgent(agent, instantiationService, {
+			mockSession,
+			activeClientToolSet,
+			snapshot: { tools: activeClientToolSet.merged(), plugins: [], mcpServers: {} },
+		});
+		const agentSession = disposables.add(createdSession.session);
+		try {
+			await agentSession.initializeSession();
+			agentSession.resetTurnState('turn-1', 'client-B');
+
+			mockSession.emit({
+				type: 'tool.execution_start',
+				data: { toolCallId: 'tool-1', toolName: 'shared', arguments: {} },
+			} as SessionEventPayload<'tool.execution_start'>);
+
+			const toolStart = actions.find(action => action.type === ActionType.ChatToolCallStart);
+			assert.deepStrictEqual(toolStart?.type === ActionType.ChatToolCallStart ? toolStart.contributor : undefined, {
+				kind: ToolCallContributorKind.Client,
+				clientId: 'client-B',
+			});
+		} finally {
+			await disposeAgent(agent);
+		}
+	});
+
+	test('client tool completion unblocks a pending permission request', async () => {
+		const sessionDataService = disposables.add(new TestSessionDataService());
+		const { agent, instantiationService, fileService } = createTestAgentContext(disposables, { environmentServiceRegistration: 'native', sessionDataService });
+		disposables.add(registerPendingEditContentProvider(fileService));
+		const createdSession = createAgentSessionThroughAgent(agent, instantiationService);
+		const agentSession = disposables.add(createdSession.session);
+		const pendingEditContentUri = new DeferredPromise<URI>();
+		disposables.add(agent.onDidSessionProgress(signal => {
+			if (signal.kind === 'pending_confirmation') {
+				const uri = signal.state.edits?.items[0]?.after?.content.uri;
+				if (uri) {
+					pendingEditContentUri.complete(URI.parse(uri));
+				}
+			}
+		}));
+		try {
+			await agentSession.initializeSession();
+			const onPermissionRequest = createdSession.createOptions()?.onPermissionRequest;
+			assert.ok(onPermissionRequest);
+
+			const permissionRequestResult = onPermissionRequest({
+				kind: 'write',
+				toolCallId: 'tool-1',
+				canOfferSessionApproval: false,
+				diff: '--- a/file.txt\n+++ b/file.txt\n@@ -0,0 +1 @@\n+after',
+				fileName: URI.file('/workspace/file.txt').fsPath,
+				intention: 'write file',
+				newFileContents: 'after',
+			}, { sessionId: 'test-session-1' });
+			const editContentUri = await pendingEditContentUri.p;
+
+			agentSession.handleClientToolCallComplete('tool-1', {
+				success: false,
+				pastTenseMessage: 'Client tool failed',
+				content: [{ type: ToolResultContentType.Text, text: 'failed before approval' }],
+				error: { message: 'failed before approval' },
+			});
+			await timeout(0);
+
+			assert.deepStrictEqual({
+				permissionResult: await permissionRequestResult,
+				pendingEditContentExists: await fileService.exists(editContentUri),
+			}, {
+				permissionResult: { kind: 'approve-once' },
+				pendingEditContentExists: false,
+			});
+		} finally {
 			await disposeAgent(agent);
 		}
 	});

--- a/src/vs/platform/agentHost/test/node/mockAgent.ts
+++ b/src/vs/platform/agentHost/test/node/mockAgent.ts
@@ -37,6 +37,7 @@ interface IMockSendMessageCall {
 	readonly prompt: string;
 	readonly attachments?: readonly MessageAttachment[];
 	readonly chat?: URI;
+	readonly senderClientId?: string;
 }
 
 /**
@@ -133,8 +134,8 @@ export class MockAgent implements IAgent {
 		return { items: [] };
 	}
 
-	async sendMessage(session: URI, chat: URI, prompt: string, attachments?: readonly MessageAttachment[], turnId?: string): Promise<void> {
-		const call = { session, prompt, attachments, chat };
+	async sendMessage(session: URI, chat: URI, prompt: string, attachments?: readonly MessageAttachment[], turnId?: string, senderClientId?: string): Promise<void> {
+		const call = { session, prompt, attachments, chat, ...(senderClientId ? { senderClientId } : {}) };
 		this.sendMessageCalls.push(call);
 		this._onDidSendMessage.fire(call);
 		if (turnId) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -2278,25 +2278,29 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			if (cts.token.isCancellationRequested) {
 				return;
 			}
-			if (!approvedDispatched) {
-				if (err !== undefined && !isCancellationError(err)) {
-					this._logService.warn(`[AgentHost] Client tool rejected pre-execution: ${toolName}`, err);
-				}
-				return;
-			}
+
 			if (err !== undefined) {
 				if (!isCancellationError(err)) {
-					this._logService.warn(`[AgentHost] Client tool invocation failed: ${toolName}`, err);
+					if (!approvedDispatched) {
+						this._logService.warn(`[AgentHost] Client tool rejected pre-execution: ${toolName}`, err);
+					} else {
+						this._logService.warn(`[AgentHost] Client tool invocation failed: ${toolName}`, err);
+					}
 				}
-				const message = err instanceof Error ? err.message : String(err);
-				result = { content: [], toolResultError: message };
+
+				result = { content: [], toolResultError: err instanceof Error ? err.message : String(err) };
 			}
-			this._dispatchAction(opts.backendSession, {
-				type: ActionType.ChatToolCallComplete,
-				turnId: opts.turnId,
-				toolCallId,
-				result: toolResultToProtocol(result ?? { content: [] }, toolName),
-			}, opts.chatURI);
+
+			const protocolToolCall = part$.get().toolCall;
+			const isProtocolToolCallComplete = protocolToolCall.status === ToolCallStatus.Completed || protocolToolCall.status === ToolCallStatus.Cancelled;
+			if (!isProtocolToolCallComplete) {
+				this._dispatchAction(opts.backendSession, {
+					type: ActionType.ChatToolCallComplete,
+					turnId: opts.turnId,
+					toolCallId,
+					result: toolResultToProtocol(result ?? { content: [] }, toolName),
+				}, opts.chatURI);
+			}
 		};
 
 		// React to part$ updates: route external cancellation, and try to

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
 import { timeout } from '../../../../../../base/common/async.js';
 import { VSBuffer } from '../../../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { CancellationError } from '../../../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { DisposableStore, IReference, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../../base/common/uri.js';
@@ -241,7 +242,7 @@ suite('AgentHostClientTools', () => {
 
 	suite('client tools registration', () => {
 
-		function createMockToolsService(disposables: DisposableStore, tools: IToolData[], options?: { requireConfirmation?: boolean }) {
+		function createMockToolsService(disposables: DisposableStore, tools: IToolData[], options?: { requireConfirmation?: boolean; throwBeforeConfirmation?: Error }) {
 			const onDidChangeTools = disposables.add(new Emitter<void>());
 			const pendingToolCalls = new Map<string, ChatToolInvocation>();
 			const begunToolCalls: ChatToolInvocation[] = [];
@@ -260,6 +261,9 @@ suite('AgentHostClientTools', () => {
 					invokedToolCalls.push(invocation);
 					const toolInvocation = pendingToolCalls.get(invocation.chatStreamToolCallId ?? invocation.callId);
 					pendingToolCalls.delete(invocation.chatStreamToolCallId ?? invocation.callId);
+					if (options?.throwBeforeConfirmation) {
+						throw options.throwBeforeConfirmation;
+					}
 					if (options?.requireConfirmation && toolInvocation) {
 						toolInvocation.transitionFromStreaming({
 							invocationMessage: 'Run Task',
@@ -418,7 +422,7 @@ suite('AgentHostClientTools', () => {
 		function createHandlerWithMocks(
 			disposables: DisposableStore,
 			tools: IToolData[],
-			toolServiceOptions?: { requireConfirmation?: boolean },
+			toolServiceOptions?: { requireConfirmation?: boolean; throwBeforeConfirmation?: Error },
 		) {
 			const instantiationService = disposables.add(new TestInstantiationService());
 			const connection = new MockAgentHostConnection();
@@ -554,6 +558,63 @@ suite('AgentHostClientTools', () => {
 			source: ToolDataSource.Internal,
 		};
 
+		async function provideSessionWithReadyRunTaskTool(handler: AgentHostSessionHandler, connection: MockAgentHostConnection): Promise<void> {
+			const sessionResource = URI.parse('agent-host-copilot:/session-1');
+			const backendSession = AgentSession.uri('copilot', 'session-1').toString();
+
+			connection.applySessionAction(URI.parse(buildDefaultChatUri(backendSession)), {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				message: { text: 'run the task', origin: { kind: MessageKind.User } },
+			} as ChatAction);
+			connection.applySessionAction(URI.parse(buildDefaultChatUri(backendSession)), {
+				type: ActionType.ChatToolCallStart,
+				turnId: 'turn-1',
+				toolCallId: 'tool-call-1',
+				toolName: 'runTask',
+				displayName: 'Run Task',
+				contributor: { kind: ToolCallContributorKind.Client, clientId: connection.clientId },
+			} as ChatAction);
+			connection.applySessionAction(URI.parse(buildDefaultChatUri(backendSession)), {
+				type: ActionType.ChatToolCallReady,
+				turnId: 'turn-1',
+				toolCallId: 'tool-call-1',
+				invocationMessage: 'Run Task',
+				toolInput: '{"task":"build"}',
+				confirmationTitle: 'Run Task',
+			} as ChatAction);
+
+			await handler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			await timeout(0);
+			await timeout(0);
+		}
+
+		function getToolCallConfirmationAndCompletionActions(connection: MockAgentHostConnection) {
+			return connection.dispatchedActions
+				.filter(entry => isChatAction(entry.action)
+					&& (entry.action.type === ActionType.ChatToolCallConfirmed || entry.action.type === ActionType.ChatToolCallComplete)
+					&& entry.action.toolCallId === 'tool-call-1')
+				.map(entry => {
+					if (entry.action.type === ActionType.ChatToolCallConfirmed) {
+						return {
+							type: entry.action.type,
+							approved: entry.action.approved,
+							success: undefined,
+							error: undefined,
+						};
+					}
+					if (entry.action.type === ActionType.ChatToolCallComplete) {
+						return {
+							type: entry.action.type,
+							approved: undefined,
+							success: entry.action.result.success,
+							error: entry.action.result.error?.message,
+						};
+					}
+					throw new Error(`Unexpected action type: ${entry.action.type}`);
+				});
+		}
+
 		test('maps tool data to protocol definitions', async () => {
 			const { connection } = createHandlerWithMocks(disposables, [testRunTestsTool, testRunTaskTool, testUnlistedTool]);
 
@@ -625,6 +686,32 @@ suite('AgentHostClientTools', () => {
 			assert.ok(connection.dispatchedActions.some(entry => isChatAction(entry.action)
 				&& entry.action.type === ActionType.ChatToolCallComplete
 				&& entry.action.toolCallId === 'tool-call-1'));
+		});
+
+		test('reports client tool prepare failures before confirmation as failed completion', async () => {
+			const { handler, connection } = createHandlerWithMocks(disposables, [testRunTaskTool], { throwBeforeConfirmation: new Error('prepare failed') });
+
+			await provideSessionWithReadyRunTaskTool(handler, connection);
+
+			assert.deepStrictEqual(getToolCallConfirmationAndCompletionActions(connection), [{
+				type: ActionType.ChatToolCallComplete,
+				approved: undefined,
+				success: false,
+				error: 'prepare failed',
+			}]);
+		});
+
+		test('reports client tool cancellation before confirmation as failed completion when protocol call is not terminal', async () => {
+			const { handler, connection } = createHandlerWithMocks(disposables, [testRunTaskTool], { throwBeforeConfirmation: new CancellationError() });
+
+			await provideSessionWithReadyRunTaskTool(handler, connection);
+
+			assert.deepStrictEqual(getToolCallConfirmationAndCompletionActions(connection), [{
+				type: ActionType.ChatToolCallComplete,
+				approved: undefined,
+				success: false,
+				error: 'Canceled',
+			}]);
 		});
 
 		test('auto-approves client tool confirmation as a setting when the agent host marks the call', async () => {


### PR DESCRIPTION
Cherry-picks the agent host client tool fixes for the 1.127 release branch.

Includes fixes from main:
- #323526 - Fix agent host client tool stalls
- #323575 - Fix subagent client tool completion routing

These changes prevent client tool calls from stalling when multiple clients provide the same tool, when prepare/permission paths fail, and when subagent client tool completions are emitted on subagent chat channels.