### PR TITLE
Warn when changing model/options mid-session breaks the prompt cache

### DIFF
--- a/product.json
+++ b/product.json
@@ -95,6 +95,7 @@
 		"termsStatementUrl": "https://aka.ms/github-copilot-terms-statement",
 		"privacyStatementUrl": "https://aka.ms/github-copilot-privacy-statement",
 		"skusDocumentationUrl": "https://aka.ms/github-copilot-plans",
+		"optimizeUsageDocumentationUrl": "https://aka.ms/token-usage-tips",
 		"publicCodeMatchesUrl": "https://aka.ms/github-copilot-match-public-code",
 		"managePlanUrl": "https://aka.ms/github-copilot-manage-plan",
 		"upgradePlanUrl": "https://aka.ms/github-copilot-upgrade-plan",

--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -407,6 +407,7 @@ export interface IDefaultChatAgent {
 
 	readonly documentationUrl: string;
 	readonly skusDocumentationUrl: string;
+	readonly optimizeUsageDocumentationUrl: string;
 	readonly publicCodeMatchesUrl: string;
 	readonly managePlanUrl: string;
 	readonly upgradePlanUrl: string;

--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -27,6 +27,7 @@ import { localize } from '../../../nls.js';
 import { IContextViewService } from '../../contextview/browser/contextView.js';
 import { IKeybindingService } from '../../keybinding/common/keybinding.js';
 import { IOpenerService } from '../../opener/common/opener.js';
+import { Link } from '../../opener/browser/link.js';
 import { defaultListStyles } from '../../theme/browser/defaultStyles.js';
 import { asCssVariable } from '../../theme/common/colorRegistry.js';
 import { ILayoutService } from '../../layout/browser/layoutService.js';
@@ -492,6 +493,16 @@ function getKeyboardNavigationLabel<T>(item: IActionListItem<T>): string | undef
 }
 
 /**
+ * A "Learn more" style link rendered inline in the action list header banner.
+ */
+export interface IActionListHeaderLink {
+	/** Visible link text (e.g. "Learn more"). Should be localized. */
+	readonly label: string;
+	/** Target opened via the opener service when the link is activated. */
+	readonly uri: URI;
+}
+
+/**
  * Options for configuring the action list.
  */
 export interface IActionListOptions {
@@ -600,6 +611,12 @@ export interface IActionListOptions {
 	 */
 	readonly headerIcon?: ThemeIcon;
 
+	/** Optional "Learn more" link rendered inline after {@link headerText}, opened via the opener service. */
+	readonly headerLink?: IActionListHeaderLink;
+
+	/** Optional dismiss ("x") button on the header banner; invoked on click, and the banner is removed. */
+	readonly headerDismiss?: () => void;
+
 	/**
 	 * Optional CSS class name added to the action list container, for scoped styling.
 	 */
@@ -639,7 +656,7 @@ export class ActionListWidget<T> extends Disposable {
 	private readonly _filterInput: HTMLInputElement | undefined;
 	private readonly _filterContainer: HTMLElement | undefined;
 	private readonly _footerContainer: HTMLElement | undefined;
-	private readonly _headerContainer: HTMLElement | undefined;
+	private _headerContainer: HTMLElement | undefined;
 	private readonly _filterCts = this._register(new MutableDisposable<CancellationTokenSource>());
 	private readonly _groupTitleByIndex = new Map<number, string>();
 
@@ -838,6 +855,41 @@ export class ActionListWidget<T> extends Disposable {
 			}
 			const text = dom.append(this._headerContainer, dom.$('span.action-list-header-text'));
 			text.textContent = this._options.headerText;
+
+			if (this._options.headerLink) {
+				const { label, uri } = this._options.headerLink;
+				// Trailing space so the link reads as a continuation of the banner text.
+				text.textContent += ' ';
+				this._register(this._instantiationService.createInstance(Link, text, { label, href: uri.toString(true) }, {}));
+			}
+
+			if (this._options.headerDismiss) {
+				const onDismiss = this._options.headerDismiss;
+				const dismissButton = dom.append(this._headerContainer, dom.$('span.action-list-header-dismiss'));
+				dismissButton.appendChild(dom.$(ThemeIcon.asCSSSelector(Codicon.close)));
+				dismissButton.tabIndex = 0;
+				dismissButton.setAttribute('role', 'button');
+				dismissButton.setAttribute('aria-label', localize('actionList.header.dismiss', "Dismiss"));
+				const dismiss = () => {
+					onDismiss();
+					// Refocus the widget first so removing the focused button doesn't trip close-on-blur.
+					this.focus();
+					this._headerContainer?.remove();
+					// Drop the reference so the banner no longer reserves header height, then
+					// request a re-layout so the popup shrinks to fit the remaining content.
+					this._headerContainer = undefined;
+					this._onDidRequestLayout.fire();
+				};
+				// Generic mouse-up maps to pointer events on iOS, so tap/pen activation
+				// works without extra gesture plumbing (raw 'click' is unreliable there).
+				this._register(dom.addDisposableGenericMouseUpListener(dismissButton, () => dismiss()));
+				this._register(dom.addDisposableListener(dismissButton, dom.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+					if (e.key === 'Enter' || e.key === ' ') {
+						e.preventDefault();
+						dismiss();
+					}
+				}));
+			}
 		}
 
 		this._applyFilter();

--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -530,6 +530,24 @@
 	font-size: 11px;
 }
 
+.action-widget .action-list-header .action-list-header-dismiss {
+	flex-shrink: 0;
+	cursor: pointer;
+	color: var(--vscode-descriptionForeground);
+	font-size: 12px;
+	line-height: 16px;
+}
+
+.action-widget .action-list-header .action-list-header-dismiss:hover {
+	color: var(--vscode-foreground);
+}
+
+.action-widget .action-list-header .action-list-header-dismiss:focus-visible {
+	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+	border-radius: var(--vscode-cornerRadius-small);
+}
+
 /* Anchor for the absolutely-positioned submenu panel */
 .action-widget .actionList {
 	position: relative;

--- a/src/vs/platform/actionWidget/test/browser/actionList.test.ts
+++ b/src/vs/platform/actionWidget/test/browser/actionList.test.ts
@@ -19,7 +19,8 @@ import { IKeybindingService } from '../../../keybinding/common/keybinding.js';
 import { ILayoutService } from '../../../layout/browser/layoutService.js';
 import { IOpenerService } from '../../../opener/common/opener.js';
 import { NullOpenerService } from '../../../opener/test/common/nullOpenerService.js';
-import { ActionList, ActionListItemKind, ActionListWidget, IActionListItem } from '../../browser/actionList.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ActionList, ActionListItemKind, ActionListWidget, IActionListItem, IActionListOptions } from '../../browser/actionList.js';
 
 interface ITestActionItem {
 	readonly id: string;
@@ -36,6 +37,7 @@ function separator(label?: string): IActionListItem<ITestActionItem> {
 function createActionListWidget(disposables: ReturnType<typeof ensureNoDisposablesAreLeakedInTestSuite>, options: {
 	readonly items?: readonly IActionListItem<ITestActionItem>[];
 	readonly onFilter?: (filter: string, cancellationToken: CancellationToken) => Promise<readonly IActionListItem<ITestActionItem>[]>;
+	readonly listOptions?: Partial<IActionListOptions>;
 }): ActionListWidget<ITestActionItem> {
 	const instantiationService = disposables.add(new TestInstantiationService());
 	instantiationService.set(IKeybindingService, new MockKeybindingService());
@@ -59,12 +61,19 @@ function createActionListWidget(disposables: ReturnType<typeof ensureNoDisposabl
 		options.items ?? [action('initial')],
 		delegate,
 		undefined,
-		{ showFilter: true },
+		{ showFilter: true, ...options.listOptions },
 	));
 
 	if (widget.filterContainer) {
 		document.body.appendChild(widget.filterContainer);
 		disposables.add({ dispose: () => widget.filterContainer?.remove() });
+	}
+	// The header banner is a standalone element the caller attaches (like the
+	// filter container), so the test appends it to exercise header behaviors.
+	const headerContainer = widget.headerContainer;
+	if (headerContainer) {
+		document.body.appendChild(headerContainer);
+		disposables.add({ dispose: () => headerContainer.remove() });
 	}
 	document.body.appendChild(widget.domNode);
 	disposables.add({ dispose: () => widget.domNode.remove() });
@@ -235,4 +244,38 @@ suite('ActionListWidget', () => {
 		const listHeight = parseFloat(list.domNode.style.height);
 		assert.ok(listHeight + filterHeight + actionWidgetVerticalChromeHeight <= availableSpaceAboveAnchor);
 	}));
+
+	test('header dismiss removes the banner and requests a re-layout', () => {
+		let dismissed = false;
+		let layoutRequested = false;
+		const widget = createActionListWidget(disposables, {
+			listOptions: { headerText: 'Cache hint', headerDismiss: () => { dismissed = true; } },
+		});
+		disposables.add(widget.onDidRequestLayout(() => { layoutRequested = true; }));
+
+		const header = widget.headerContainer;
+		assert.ok(header, 'header banner should render when headerText + headerDismiss are set');
+		const dismissButton = header!.querySelector<HTMLElement>('.action-list-header-dismiss');
+		assert.ok(dismissButton, 'dismiss button should render');
+
+		dismissButton!.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+
+		assert.deepStrictEqual(
+			{ dismissed, layoutRequested, headerCleared: widget.headerContainer === undefined, headerStillInDom: header!.isConnected },
+			{ dismissed: true, layoutRequested: true, headerCleared: true, headerStillInDom: false },
+		);
+	});
+
+	test('header renders a "Learn more" link to the given uri', () => {
+		const widget = createActionListWidget(disposables, {
+			listOptions: { headerText: 'Cache hint', headerLink: { label: 'Learn more', uri: URI.parse('https://aka.ms/test') } },
+		});
+
+		const link = widget.headerContainer?.querySelector<HTMLAnchorElement>('a.monaco-link');
+		assert.ok(link, 'a "Learn more" link should render in the header');
+		assert.deepStrictEqual(
+			{ text: link!.textContent, href: link!.getAttribute('href') },
+			{ text: 'Learn more', href: 'https://aka.ms/test' },
+		);
+	});
 });

--- a/src/vs/sessions/contrib/chat/browser/modelPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/modelPicker.ts
@@ -145,6 +145,13 @@ export class ModelPicker extends Disposable {
 			showUnavailableFeatured: () => getModelPickerOptionsForSession(this._session.get(), this._sessionsProvidersService).showUnavailableFeatured,
 			showFeatured: () => getModelPickerOptionsForSession(this._session.get(), this._sessionsProvidersService).showFeatured,
 			showAutoModel: () => !!getModelPickerOptionsForSession(this._session.get(), this._sessionsProvidersService).showAutoModel,
+			isCacheWarm: () => {
+				const session = this._session.get();
+				// The session's prompt cache is warm once its first request has
+				// been sent (status leaves Untitled), matching the main-window
+				// picker which warms as soon as the first request is added.
+				return session ? session.status.get() !== SessionStatus.Untitled : false;
+			},
 		};
 
 		const pickerOptions: IChatInputPickerOptions = {

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -370,6 +370,13 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.tips.enabled', "Controls whether tips are shown above user messages in chat. New tips are added frequently, so this is a helpful way to stay up to date with the latest features."),
 			default: true,
 		},
+		'chat.cacheBreakHint.enabled': {
+			type: 'boolean',
+			scope: ConfigurationScope.APPLICATION,
+			description: nls.localize('chat.cacheBreakHint.enabled', "Controls whether the model and options pickers show a hint that switching the model or its options mid-session resets the prompt cache and may increase cost."),
+			default: false,
+			tags: ['experimental'],
+		},
 		'chat.upvoteAnimation': {
 			type: 'string',
 			enum: ['off', 'confetti', 'floatingThumbs', 'pulseWave', 'radiantLines'],

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1079,6 +1079,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				this.renderAttachedContext();
 			},
 			getModels: () => this.getModels(),
+			isCacheWarm: () => (this._widget?.viewModel?.model.getRequests().length ?? 0) > 0,
 			useGroupedModelPicker: () => {
 				// Agent-host session types (local and remote) reuse the same
 				// grouped/featured model picker as the default chat session, so

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -23,13 +23,15 @@ import { formatTokenCount } from '../../../../../../base/common/numbers.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { localize } from '../../../../../../nls.js';
-import { ActionListItemKind, IActionListItem } from '../../../../../../platform/actionWidget/browser/actionList.js';
+import { ActionListItemKind, IActionListHeaderLink, IActionListItem } from '../../../../../../platform/actionWidget/browser/actionList.js';
 import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
 import { IActionWidgetDropdownAction } from '../../../../../../platform/actionWidget/browser/actionWidgetDropdown.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { TelemetryTrustedValue } from '../../../../../../platform/telemetry/common/telemetryUtils.js';
 import { MANAGE_CHAT_COMMAND_ID } from '../../../common/constants.js';
 import { IModelControlEntry, ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService, IModelsControlManifest } from '../../../common/languageModels.js';
@@ -95,6 +97,12 @@ const SETUP_REQUIRED_SIGN_IN_ACTION_ID = 'setupRequiredSignIn';
 
 /** Synthetic command entries (Trust / Sign in) that are not selectable models. */
 const PICKER_COMMAND_ACTION_IDS: ReadonlySet<string> = new Set([RESTRICTED_MODE_TRUST_ACTION_ID, SETUP_REQUIRED_SIGN_IN_ACTION_ID]);
+
+/** Storage key remembering that the user dismissed the cache-break hint. */
+const CACHE_BREAK_HINT_DISMISSED_STORAGE_KEY = 'chat.cacheBreakHintDismissed';
+
+/** Setting gating the cache-break hint, so it can be toggled / run as an experiment. */
+const CACHE_BREAK_HINT_ENABLED_SETTING = 'chat.cacheBreakHint.enabled';
 
 /**
  * Returns a human-readable display name for a model vendor.
@@ -1048,6 +1056,8 @@ export class ModelPickerWidget extends Disposable {
 		@IDefaultAccountService private readonly _defaultAccountService: IDefaultAccountService,
 		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
 		@IWorkspaceTrustRequestService private readonly _workspaceTrustRequestService: IWorkspaceTrustRequestService,
+		@IStorageService private readonly _storageService: IStorageService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
 		this._register(this._languageModelsService.onDidChangeLanguageModels(() => {
@@ -1266,6 +1276,45 @@ export class ModelPickerWidget extends Disposable {
 		}));
 	}
 
+	/** The "Learn more" header link for cache-break hints; `undefined` when the product has no URL. */
+	private getCacheBreakLearnMoreLink(): IActionListHeaderLink | undefined {
+		const url = this._productService.defaultChatAgent?.optimizeUsageDocumentationUrl;
+		return url ? { label: localize('chat.cacheBreak.learnMore', "Learn more"), uri: URI.parse(url) } : undefined;
+	}
+
+	private isCacheBreakHintEnabled(): boolean {
+		return this._configurationService.getValue<boolean>(CACHE_BREAK_HINT_ENABLED_SETTING) === true;
+	}
+
+	private isCacheBreakHintDismissed(): boolean {
+		return this._storageService.getBoolean(CACHE_BREAK_HINT_DISMISSED_STORAGE_KEY, StorageScope.APPLICATION, false);
+	}
+
+	private dismissCacheBreakHint(): void {
+		this._storageService.store(CACHE_BREAK_HINT_DISMISSED_STORAGE_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
+	}
+
+	/**
+	 * Whether a picker should show the cache-break hint: the feature is enabled,
+	 * not dismissed, and the session's cache is warm. When `excludeAutoModel` is
+	 * set (the model picker), the hint is suppressed for the Auto model, since
+	 * Auto routes each request dynamically so "switching models" does not apply.
+	 * The options picker passes `false`: changing reasoning effort / context size
+	 * resets the cache even under Auto, which only routes the model.
+	 */
+	private shouldShowCacheBreakHint(excludeAutoModel: boolean): boolean {
+		if (!this.isCacheBreakHintEnabled() || this.isCacheBreakHintDismissed()) {
+			return false;
+		}
+		if (!(this._delegate.isCacheWarm?.() ?? false)) {
+			return false;
+		}
+		if (excludeAutoModel && !!this._selectedModel && isAutoModel(this._selectedModel)) {
+			return false;
+		}
+		return true;
+	}
+
 	show(anchor?: HTMLElement): void {
 		const anchorElement = anchor ?? this._domNode;
 		if (!anchorElement || this._domNode?.classList.contains('disabled')) {
@@ -1359,7 +1408,12 @@ export class ModelPickerWidget extends Disposable {
 		// stale, unusable models. Shown otherwise (it also hosts the secondary
 		// heading).
 		const unavailable = this.isRestrictedMode() || this.isSetupRequired();
+		const showCacheBreakHint = this.shouldShowCacheBreakHint(/* excludeAutoModel */ true);
 		const listOptions = {
+			headerText: showCacheBreakHint ? localize('chat.modelPicker.cacheBreakHint', "Switching models mid-session resets the prompt cache and may increase cost.") : undefined,
+			headerIcon: showCacheBreakHint ? Codicon.info : undefined,
+			headerLink: showCacheBreakHint ? this.getCacheBreakLearnMoreLink() : undefined,
+			headerDismiss: showCacheBreakHint ? () => this.dismissCacheBreakHint() : undefined,
 			showFilter: !unavailable,
 			filterPlaceholder: localize('chat.modelPicker.search', "Search models"),
 			focusFilterOnOpen: true,
@@ -1689,6 +1743,8 @@ export class ModelPickerWidget extends Disposable {
 
 		this._configButton.setAttribute('aria-expanded', 'true');
 
+		const showCacheBreakHint = this.shouldShowCacheBreakHint(/* excludeAutoModel */ false);
+
 		this._actionWidgetService.show(
 			'ChatModelConfigPicker',
 			false,
@@ -1705,8 +1761,10 @@ export class ModelPickerWidget extends Disposable {
 				getWidgetRole: () => 'menu' as const,
 			},
 			{
-				headerText: localize('chat.config.costHint', "Non-default options may increase cost"),
-				headerIcon: Codicon.info,
+				headerText: showCacheBreakHint ? localize('chat.config.cacheBreakHint', "Changing these options mid-session resets the prompt cache and may increase cost.") : undefined,
+				headerIcon: showCacheBreakHint ? Codicon.info : undefined,
+				headerLink: showCacheBreakHint ? this.getCacheBreakLearnMoreLink() : undefined,
+				headerDismiss: showCacheBreakHint ? () => this.dismissCacheBreakHint() : undefined,
 			}
 		);
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
@@ -63,6 +63,14 @@ export interface IModelPickerDelegate {
 	 */
 	getChatSessionId?(): string | undefined;
 	/**
+	 * UI hint flag controlling whether the picker shows the cache-break hint.
+	 * Returns `true` when the session has likely warmed the prompt cache (e.g. it
+	 * has sent a request), inferred from request history / session status rather
+	 * than the provider's actual cache state — so it does not account for cache
+	 * expiry or a cache that was already reset. Defaults to `false` when omitted.
+	 */
+	isCacheWarm?(): boolean;
+	/**
 	 * Per-editor model configuration access. When omitted, the picker reads and
 	 * writes configuration through the global {@link ILanguageModelsService}.
 	 */


### PR DESCRIPTION
## Summary
First pass at https://github.com/microsoft/vscode/issues/319750 
Surfaces a cache-break cost hint in the chat model/options pickers so users know when switching their selection mid-session would reset the warm prompt cache (costing more and running slower).

The prompt cache is keyed on the request prefix, so changing the model, reasoning effort, context size, mode, or enabled tool set between turns of the same session invalidates the cache the previous turn warmed up. Previously there was no signal to the user that a change carried this cost.

## Setting
The hint is gated by the new **`chat.cacheBreakHint.enabled`** setting (application-scoped, tagged `experimental`). It is **off by default** — users must opt in to see the hint. Users can also dismiss the hint inline via the "×" on the banner, which suppresses it persistently.

<img width="470" height="299" alt="image" src="https://github.com/user-attachments/assets/25b93d1d-435b-4b09-9734-43a5688cfd8f" />
<img width="471" height="482" alt="image" src="https://github.com/user-attachments/assets/62209911-56d4-48b7-8440-551aa27a9f0e" />
