### PR TITLE
sessions: only fire onDidChangeSessionTypes when effective session set changes

### DIFF
--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -1439,6 +1439,16 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 	private readonly _multiChatEnabled: boolean;
 
+	/**
+	 * Last known effective availability of the Claude / Copilot CLI session
+	 * types, used to fire `onDidChangeSessionTypes` only when the effective set
+	 * actually changes (the relevant settings can change without altering it,
+	 * e.g. toggling `chat.agents.claude.preferAgentHost` while the agent host is
+	 * disabled and the preference is ignored).
+	 */
+	private _claudeAvailable: boolean;
+	private _copilotCliAvailable: boolean;
+
 	/** Whether the agent host is enabled via `chat.agentHost.enabled`. */
 	private _isAgentHostEnabled(): boolean {
 		return this.configurationService.getValue<boolean>(AgentHostEnabledSettingId) ?? false;
@@ -1505,6 +1515,8 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		super();
 
 		this._multiChatEnabled = this.configurationService.getValue<boolean>(COPILOT_MULTI_CHAT_SETTING) ?? true;
+		this._claudeAvailable = this._isClaudeAvailable();
+		this._copilotCliAvailable = this._isCopilotCliAvailable();
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			const affectsSessionTypes = e.affectsConfiguration(CLAUDE_CODE_ENABLED_SETTING)
@@ -1514,6 +1526,13 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			if (!affectsSessionTypes) {
 				return;
 			}
+			const claudeAvailable = this._isClaudeAvailable();
+			const copilotCliAvailable = this._isCopilotCliAvailable();
+			if (claudeAvailable === this._claudeAvailable && copilotCliAvailable === this._copilotCliAvailable) {
+				return;
+			}
+			this._claudeAvailable = claudeAvailable;
+			this._copilotCliAvailable = copilotCliAvailable;
 			this._onDidChangeSessionTypes.fire();
 			this._refreshSessionCache();
 		}));

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
@@ -439,6 +439,28 @@ suite('CopilotChatSessionsProvider', () => {
 		assert.ok(!provider.sessionTypes.some(t => t.id === CopilotCLISessionType.id));
 	});
 
+	test('onDidChangeSessionTypes fires when chat.agentHost.enabled toggles the Claude gate', () => {
+		// With preferAgentHost on but the agent host initially disabled, this
+		// provider still surfaces Claude. Enabling the agent host must live-apply
+		// the preference and drop the Claude entry without a window reload.
+		const { provider, configService } = createProviderWithConfig(disposables, model, { claudeEnabled: true, preferAgentHost: true, agentHostEnabled: false });
+		assert.ok(provider.sessionTypes.some(t => t.id === ClaudeCodeSessionType.id));
+
+		let fired = false;
+		disposables.add(provider.onDidChangeSessionTypes(() => { fired = true; }));
+
+		configService.setUserConfiguration(AgentHostEnabledSettingId, true);
+		configService.onDidChangeConfigurationEmitter.fire({
+			source: ConfigurationTarget.USER,
+			affectedKeys: new Set([AgentHostEnabledSettingId]),
+			change: { keys: [AgentHostEnabledSettingId], overrides: [] },
+			affectsConfiguration: (key: string) => key === AgentHostEnabledSettingId,
+		});
+
+		assert.ok(fired, 'onDidChangeSessionTypes should have fired');
+		assert.ok(!provider.sessionTypes.some(t => t.id === ClaudeCodeSessionType.id));
+	});
+
 	test('toggling claude setting refreshes sessions list', () => {
 		const claudeResource = URI.from({ scheme: AgentSessionProviders.Claude, path: '/claude-session' });
 		model.addSession(createMockAgentSession(claudeResource, { providerType: AgentSessionProviders.Claude }));


### PR DESCRIPTION
Follow-up to #323567 addressing [Copilot Code Review](https://github.com/microsoft/vscode/pull/323567) feedback.

## What

- **Respect the `ISessionsProvider` event contract.** The configuration-change handler introduced in #323567 fired `onDidChangeSessionTypes` (and refreshed the session cache) for *any* change to the relevant settings, even when the effective session-type set was unchanged — e.g. toggling `chat.agents.claude.preferAgentHost` while `chat.agentHost.enabled` is off (the preference is ignored in that state). The handler now caches the effective Claude / Copilot CLI availability and only fires when it actually changes.
- **Added test coverage.** A new live-toggle test asserts that enabling `chat.agentHost.enabled` applies the Claude `preferAgentHost` gate and drops the Claude session type (mirroring the existing Copilot CLI hide-gate test).

## Why

CCR correctly pointed out that firing the change event for no-op setting changes causes unnecessary picker refreshes and violates the documented contract that the event fires when the `sessionTypes` list actually changes.

## Notes

The availability methods (`_isClaudeAvailable` / `_isCopilotCliAvailable`) still read configuration live; only the change-detection in the listener caches the effective booleans.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>