### PR TITLE
Disable semantic_search on BYOK/custom endpoints

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -245,12 +245,16 @@ export const getAgentTools = async (accessor: ServicesAccessor, request: vscode.
 	allowTools[ToolName.CoreRunTest] = await testService.hasAnyTests();
 	allowTools[ToolName.CoreRunTask] = tasksService.getTasks().length > 0;
 
-	// The specialized subagents must only run when
-	// the main agent is on CAPI.
+	// The specialized subagents and semantic search only work when the main
+	// agent is on CAPI. semantic_search relies on embeddings that require a
+	// Copilot token source, so on BYOK / custom endpoints it can abort the chat
+	// turn (e.g. when the GitHub auth provider is unavailable). Keep it off
+	// there. See https://github.com/microsoft/vscode/issues/322525.
 	if (!isCAPIEndpoint(model)) {
 		allowTools[ToolName.SearchSubagent] = false;
 		allowTools[ToolName.ExploreSubagent] = false;
 		allowTools[ToolName.ExecutionSubagent] = false;
+		allowTools[ToolName.Codebase] = false;
 	} else {
 		const searchSubagentEnabled = configurationService.getExperimentBasedConfig(ConfigKey.Advanced.SearchSubagentToolEnabled, experimentationService);
 		const exploreAgentEnabled = configurationService.getExperimentBasedConfig(ConfigKey.ExploreAgentEnabled, experimentationService);

--- a/extensions/copilot/src/extension/intents/node/test/searchSubagentGating.spec.ts
+++ b/extensions/copilot/src/extension/intents/node/test/searchSubagentGating.spec.ts
@@ -109,4 +109,19 @@ describe('getAgentTools search subagent gating', () => {
 		expect(hasTool(tools, ToolName.SearchSubagent)).toBe(false);
 		expect(hasTool(tools, ToolName.ExploreSubagent)).toBe(false);
 	});
+
+	test('exposes semantic_search when the model is a CAPI endpoint', async () => {
+		const request = new TestChatRequest('how does foo work');
+		const tools = await instantiationService.invokeFunction(getAgentTools, request, userEndpoint);
+		expect(hasTool(tools, ToolName.Codebase)).toBe(true);
+	});
+
+	test('hides semantic_search when the model is a BYOK / custom endpoint', async () => {
+		// A BYOK / custom endpoint is identified by a string URL rather than CAPI request metadata.
+		const byokEndpoint = instantiationService.createInstance(MockEndpoint, 'gpt-5');
+		(byokEndpoint as { urlOrRequestMetadata: string }).urlOrRequestMetadata = 'https://localhost:8080/v1/chat/completions';
+		const request = new TestChatRequest('how does foo work');
+		const tools = await instantiationService.invokeFunction(getAgentTools, request, byokEndpoint);
+		expect(hasTool(tools, ToolName.Codebase)).toBe(false);
+	});
 });


### PR DESCRIPTION
Fixes #322525

## Problem

When using a BYOK / custom (non‑CAPI) endpoint — e.g. a local `llama.cpp` model — and the GitHub Authentication Provider extension is disabled (`--disable-extension vscode.github-authentication`), invoking the `semantic_search` tool aborts the whole chat turn:

## Fix

Gate `semantic_search` (`ToolName.Codebase`) off for non‑CAPI endpoints, alongside the specialized subagents that are already restricted to CAPI in `getAgentTools`. Because this is applied through the `getEnabledTools` filter callback, it takes precedence over a manual tool‑picker enablement (the exact repro in the issue), so the tool is never offered when it can't work.
