### PR TITLE
Agents mobile: native bottom-sheet confirmation for archive-all

### DIFF
--- a/src/vs/sessions/browser/parts/mobile/media/mobilePickerSheet.css
+++ b/src/vs/sessions/browser/parts/mobile/media/mobilePickerSheet.css
@@ -251,6 +251,39 @@
 	touch-action: pan-y;
 }
 
+/* Generic building blocks for `showMobileContentSheet` bodies that present a
+ * short confirmation: a bold message, an optional muted detail line, and a
+ * vertical stack of full-width action buttons with comfortable (44pt) tap
+ * targets. Kept caller-agnostic so any confirm-style sheet can share them. */
+.mobile-content-sheet-message {
+	padding: 4px 16px 0;
+	font-size: 15px;
+	font-weight: 600;
+	line-height: 1.35;
+	overflow-wrap: anywhere;
+}
+
+.mobile-content-sheet-detail {
+	padding: 6px 16px 0;
+	font-size: 13px;
+	color: var(--vscode-descriptionForeground);
+	line-height: 1.35;
+	overflow-wrap: anywhere;
+}
+
+.mobile-content-sheet-actions {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 16px;
+}
+
+.mobile-content-sheet-actions .monaco-button {
+	min-height: 44px;
+	font-size: 16px;
+	padding: 0 12px;
+}
+
 /* iOS grouped-list section header. The HIG uses a regular-case
  * footnote-sized label in secondary color — not the uppercased small
  * caps that older Settings rows used. */

--- a/src/vs/sessions/contrib/sessions/browser/mobile/mobileArchiveConfirmSheet.ts
+++ b/src/vs/sessions/contrib/sessions/browser/mobile/mobileArchiveConfirmSheet.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { $, append, getActiveElement, isHTMLElement } from '../../../../../base/browser/dom.js';
+import { Button } from '../../../../../base/browser/ui/button/button.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { localize } from '../../../../../nls.js';
+import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
+import { IWorkbenchLayoutService } from '../../../../../workbench/services/layout/browser/layoutService.js';
+import { showMobileContentSheet } from '../../../../browser/parts/mobile/mobilePickerSheet.js';
+
+export interface IMobileArchiveConfirmOptions {
+	/** Sheet header title (single line). */
+	readonly title: string;
+	/** Bold message describing the scope of the action (wraps). */
+	readonly message: string;
+	/** Muted detail line beneath the message (wraps). */
+	readonly detail: string;
+	/** Label for the primary, destructive action button. */
+	readonly primaryLabel: string;
+}
+
+/**
+ * Phone-only confirmation for a destructive "Mark All as Done" bulk action.
+ * Presents a native bottom sheet (matching the other Agents-window mobile
+ * surfaces) with an explicit, full-width destructive action and Cancel,
+ * instead of squeezing the desktop modal dialog onto a phone.
+ *
+ * Resolves `true` only when the user taps the destructive action; any other
+ * dismissal (Cancel, backdrop tap, Escape) resolves `false`.
+ *
+ * Unlike the desktop dialog, the sheet intentionally omits the "Do not ask
+ * me again" opt-out: the persisted skip flag is shared across layouts, and
+ * letting a mis-tap permanently disable confirmation for a destructive bulk
+ * action is exactly the footgun this mobile treatment avoids.
+ */
+export async function confirmArchiveOnPhone(layoutService: IWorkbenchLayoutService, options: IMobileArchiveConfirmOptions): Promise<boolean> {
+	let confirmed = false;
+
+	// Remember what had focus so we can restore it when the sheet closes,
+	// mirroring `IDialogService.confirm`'s focus handling.
+	const previouslyFocused = getActiveElement();
+
+	await showMobileContentSheet(
+		layoutService.mainContainer,
+		options.title,
+		(body, api) => {
+			const store = new DisposableStore();
+
+			const message = append(body, $('.mobile-content-sheet-message'));
+			message.textContent = options.message;
+
+			const detail = append(body, $('.mobile-content-sheet-detail'));
+			detail.textContent = options.detail;
+
+			const actions = append(body, $('.mobile-content-sheet-actions'));
+
+			const archiveButton = store.add(new Button(actions, { ...defaultButtonStyles }));
+			archiveButton.label = options.primaryLabel;
+			store.add(archiveButton.onDidClick(() => {
+				confirmed = true;
+				api.close();
+			}));
+
+			const cancelButton = store.add(new Button(actions, { ...defaultButtonStyles, secondary: true }));
+			cancelButton.label = localize('mobileArchiveConfirm.cancel', "Cancel");
+			store.add(cancelButton.onDidClick(() => {
+				confirmed = false;
+				api.close();
+			}));
+
+			// Move focus into the modal sheet for keyboard / screen reader
+			// users, defaulting to the safe action so an accidental Enter
+			// cancels rather than performing the destructive action.
+			cancelButton.focus();
+
+			return store;
+		},
+		{ hideDoneButton: true },
+	);
+
+	if (isHTMLElement(previouslyFocused) && previouslyFocused.isConnected) {
+		previouslyFocused.focus();
+	}
+
+	return confirmed;
+}

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -33,6 +33,9 @@ import { ActiveSessionContextKeys } from '../../../changes/common/changes.js';
 import { hasActiveSessionFailedCIChecks } from '../../../changes/browser/checksActions.js';
 import { ISessionsPartService } from '../../../../services/sessions/browser/sessionsPartService.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
+import { IWorkbenchLayoutService } from '../../../../../workbench/services/layout/browser/layoutService.js';
+import { isPhoneLayout } from '../../../../browser/parts/mobile/mobileLayout.js';
+import { confirmArchiveOnPhone } from '../mobile/mobileArchiveConfirmSheet.js';
 
 const CLOSE_SESSION_COMMAND_ID = 'sessionsViewPane.closeSession';
 registerAction2(class CloseSessionAction extends Action2 {
@@ -514,24 +517,37 @@ registerAction2(class ArchiveSectionAction extends Action2 {
 		const sessionsManagementService = accessor.get(ISessionsManagementService);
 		const dialogService = accessor.get(IDialogService);
 		const storageService = accessor.get(IStorageService);
+		const layoutService = accessor.get(IWorkbenchLayoutService);
 
 		const skipConfirmation = storageService.getBoolean(ConfirmArchiveStorageKey, StorageScope.PROFILE, false);
 		if (!skipConfirmation) {
-			const confirmed = await dialogService.confirm({
-				message: getArchiveSectionConfirmationMessage(context),
-				detail: localize('archiveSectionSessions.detail', "You can restore sessions later if needed from the sessions view."),
-				primaryButton: localize('archiveSectionSessions.archive', "Mark All as Done"),
-				checkbox: {
-					label: localize('doNotAskAgain', "Do not ask me again")
+			if (isPhoneLayout(layoutService)) {
+				const confirmed = await confirmArchiveOnPhone(layoutService, {
+					title: localize('archiveSectionSheet.title', "Mark All as Done"),
+					message: getArchiveSectionConfirmationMessage(context),
+					detail: localize('archiveSectionSessions.detail', "You can restore sessions later if needed from the sessions view."),
+					primaryLabel: localize('archiveSectionSessions.archive', "Mark All as Done"),
+				});
+				if (!confirmed) {
+					return;
 				}
-			});
+			} else {
+				const confirmed = await dialogService.confirm({
+					message: getArchiveSectionConfirmationMessage(context),
+					detail: localize('archiveSectionSessions.detail', "You can restore sessions later if needed from the sessions view."),
+					primaryButton: localize('archiveSectionSessions.archive', "Mark All as Done"),
+					checkbox: {
+						label: localize('doNotAskAgain', "Do not ask me again")
+					}
+				});
 
-			if (!confirmed.confirmed) {
-				return;
-			}
+				if (!confirmed.confirmed) {
+					return;
+				}
 
-			if (confirmed.checkboxChecked) {
-				storageService.store(ConfirmArchiveStorageKey, true, StorageScope.PROFILE, StorageTarget.USER);
+				if (confirmed.checkboxChecked) {
+					storageService.store(ConfirmArchiveStorageKey, true, StorageScope.PROFILE, StorageTarget.USER);
+				}
 			}
 		}
 


### PR DESCRIPTION
## Problem

On the Agents window **phone layout**, the destructive **"Mark All as Done"** bulk-archive confirmation reused the desktop modal dialog. On a phone that dialog rendered with the safe **Cancel** button pushed off-screen (only the destructive action was reachable) — a real safety problem. A prior attempt patched the desktop dialog with phone-only CSS, but that's a band-aid on a desktop idiom and still isn't genuinely mobile-friendly.

## Change

Route the confirmation through the existing **`showMobileContentSheet`** primitive when `isPhoneLayout()` is true — the same native bottom-sheet pattern already used by the workspace / mode / session-type / permission pickers. The sheet has:

- a wrapping message + detail,
- a **full-width** primary "Mark All as Done" action and an explicit **Cancel**, both with **44px** tap targets,
- backdrop / Escape / Cancel → no-op; only the primary action archives.

Desktop / tablet keep the existing `IDialogService.confirm` dialog (gated on `isPhoneLayout`).

The sheet builder lives in its own file under the feature's `mobile/` folder (`mobileArchiveConfirmSheet.ts`), mirroring the other mobile sheet builders (e.g. `mobileWorkspacePickerSheet.ts`). It takes plain strings (title/message/detail/primary label) rather than a section model, so it's reusable for other destructive bulk confirmations.

### Deliberate behavior note
The phone sheet **omits the "Do not ask me again" opt-out**. That flag is persisted in shared `PROFILE` storage, so a single mis-tap on the cramped phone dialog could permanently disable confirmation for a destructive bulk action. The sheet still respects the flag if it was already set elsewhere.

## Files

| File | Change |
| ---- | ------ |
| `sessions/contrib/sessions/browser/mobile/mobileArchiveConfirmSheet.ts` | **New.** `confirmArchiveOnPhone(...)` — native bottom-sheet confirm built on `showMobileContentSheet`. |
| `sessions/contrib/sessions/browser/views/sessionsViewActions.ts` | `ArchiveSectionAction` branches on `isPhoneLayout` and delegates to the sheet helper; desktop dialog unchanged. |
| `sessions/browser/parts/mobile/media/mobilePickerSheet.css` | Generic, caller-agnostic `.mobile-content-sheet-message/detail/actions` helpers (full-width buttons, 44px targets). |

## Verification
- `typecheck-client`, `stylelint`, and `valid-layers-check` pass; merges cleanly into `main`.
- Layout measured at 390px (with real `button.css`): full-width sheet, wrapping message, two equal full-width buttons at 44px.

## Follow-up
On current `main` there is now a second archive-all action — `MarkAllSessionsInGroupAsDoneAction` (group header) — that still uses the desktop dialog and is not phone-aware. When this series is rebased onto latest `main`, the same `confirmArchiveOnPhone` helper should be applied there too.

> Replaces the CSS-only approach in #322803.
