### PR TITLE
feat: add copy button to code blocks in markdown preview

### DIFF
--- a/extensions/markdown-language-features/media/markdown.css
+++ b/extensions/markdown-language-features/media/markdown.css
@@ -428,8 +428,47 @@ pre code {
 /** Theming */
 
 pre {
+	position: relative;
 	background-color: var(--vscode-textCodeBlock-background);
 	border: 1px solid var(--vscode-widget-border);
+}
+
+/* Code block copy button */
+.code-block-copy-button {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	padding: 0;
+	border: 1px solid var(--vscode-widget-border, rgba(127, 127, 127, 0.35));
+	border-radius: 4px;
+	background-color: var(--vscode-textCodeBlock-background, var(--vscode-editor-background));
+	color: var(--vscode-editor-foreground);
+	cursor: pointer;
+	opacity: 0;
+	transition: opacity 0.15s ease;
+}
+
+pre:hover > .code-block-copy-button,
+.code-block-copy-button:focus {
+	opacity: 1;
+}
+
+.code-block-copy-button:hover {
+	background-color: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
+}
+
+.code-block-copy-button:active {
+	background-color: var(--vscode-toolbar-activeBackground, rgba(99, 102, 103, 0.31));
+}
+
+.code-block-copy-button.copied {
+	color: var(--vscode-testing-iconPassed, #73c991);
+	opacity: 1;
 }
 
 .vscode-high-contrast h1 {

--- a/extensions/markdown-language-features/preview-src/index.ts
+++ b/extensions/markdown-language-features/preview-src/index.ts
@@ -104,6 +104,7 @@ onceDocumentLoaded(() => {
 	// Restore
 	const scrollProgress = state.scrollProgress;
 	addImageContexts();
+	addCodeBlockCopyButtons();
 	applyLineChanges(lineChanges);
 	if (typeof scrollProgress === 'number' && !settings.settings.fragment) {
 		doAfterImagesLoaded(() => {
@@ -191,6 +192,82 @@ function addImageContexts() {
 		const isLocalFile = imageSource && !(isOfScheme(Schemes.http, imageSource) || isOfScheme(Schemes.https, imageSource));
 		const webviewSection = isLocalFile ? 'localImage' : 'image';
 		img.setAttribute('data-vscode-context', JSON.stringify({ webviewSection, id: img.id, 'preventDefaultContextMenuItems': true, resource: documentResource, imageSource }));
+	}
+}
+
+function createCopyIcon(): SVGElement {
+	const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+	svg.setAttribute('aria-hidden', 'true');
+	svg.setAttribute('focusable', 'false');
+	svg.setAttribute('width', '16');
+	svg.setAttribute('height', '16');
+	svg.setAttribute('viewBox', '0 0 16 16');
+	svg.setAttribute('fill', 'none');
+	const path1 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+	path1.setAttribute('d', 'M4 4H2V14H11V12H4V4Z');
+	path1.setAttribute('fill', 'currentColor');
+	const path2 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+	path2.setAttribute('fill-rule', 'evenodd');
+	path2.setAttribute('clip-rule', 'evenodd');
+	path2.setAttribute('d', 'M5 2H14V11H5V2ZM6 3H13V10H6V3Z');
+	path2.setAttribute('fill', 'currentColor');
+	svg.appendChild(path1);
+	svg.appendChild(path2);
+	return svg;
+}
+
+function createCheckIcon(): SVGElement {
+	const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+	svg.setAttribute('aria-hidden', 'true');
+	svg.setAttribute('focusable', 'false');
+	svg.setAttribute('width', '16');
+	svg.setAttribute('height', '16');
+	svg.setAttribute('viewBox', '0 0 16 16');
+	svg.setAttribute('fill', 'none');
+	const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+	path.setAttribute('d', 'M6.27 10.87L3.63 8.23L2.56 9.3L6.27 13.01L14.07 5.21L13 4.14L6.27 10.87Z');
+	path.setAttribute('fill', 'currentColor');
+	svg.appendChild(path);
+	return svg;
+}
+
+function addCodeBlockCopyButtons() {
+	const codeBlocks = document.querySelectorAll('pre > code');
+	for (const code of codeBlocks) {
+		const pre = code.parentElement!;
+
+		// Inject copy button if not already present
+		if (!pre.querySelector('.code-block-copy-button')) {
+			const button = document.createElement('button');
+			button.className = 'code-block-copy-button';
+			button.setAttribute('aria-label', 'Copy code block');
+			button.appendChild(createCopyIcon());
+			button.addEventListener('click', async (e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				const text = code.textContent ?? '';
+				try {
+					await navigator.clipboard.writeText(text);
+					button.replaceChildren(createCheckIcon());
+					button.classList.add('copied');
+					setTimeout(() => {
+						button.replaceChildren(createCopyIcon());
+						button.classList.remove('copied');
+					}, 2000);
+				} catch {
+					const selection = window.getSelection();
+					if (selection) {
+						selection.removeAllRanges();
+						const range = document.createRange();
+						range.selectNodeContents(code);
+						selection.addRange(range);
+						document.execCommand('copy');
+						selection.removeAllRanges();
+					}
+				}
+			});
+			pre.appendChild(button);
+		}
 	}
 }
 
@@ -335,6 +412,7 @@ window.addEventListener('message', async event => {
 
 			window.dispatchEvent(new CustomEvent('vscode.markdown.updateContent'));
 			addImageContexts();
+			addCodeBlockCopyButtons();
 			applyLineChanges(lineChanges);
 			break;
 		}


### PR DESCRIPTION
Adds a GitHub-style copy button that appears on hover in the top-right corner of code blocks in the markdown preview. Clicking copies the code block content to the clipboard and shows a checkmark confirmation.

fixes: https://github.com/microsoft/vscode/issues/322269
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
