### PR TITLE
Add policies for terminal agent sandbox settings

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -51,7 +51,10 @@
             },
             "type": "string",
             "default": "",
-            "included": false
+            "included": false,
+            "referencedSettings": [
+                "github.copilot.chat.otel.protocol"
+            ]
         },
         {
             "key": "chat.agentHost.otel.serviceName",
@@ -66,7 +69,10 @@
             },
             "type": "string",
             "default": "",
-            "included": false
+            "included": false,
+            "referencedSettings": [
+                "github.copilot.chat.otel.serviceName"
+            ]
         },
         {
             "key": "chat.agentHost.otel.resourceAttributes",
@@ -81,7 +87,10 @@
             },
             "type": "object",
             "default": {},
-            "included": false
+            "included": false,
+            "referencedSettings": [
+                "github.copilot.chat.otel.resourceAttributes"
+            ]
         },
         {
             "key": "chat.agentHost.otel.headers",
@@ -96,7 +105,10 @@
             },
             "type": "object",
             "default": {},
-            "included": false
+            "included": false,
+            "referencedSettings": [
+                "github.copilot.chat.otel.headers"
+            ]
         },
         {
             "key": "mcp.enterpriseManagedAuth.idp",
@@ -249,7 +261,10 @@
             },
             "type": "boolean",
             "default": false,
-            "included": true
+            "included": true,
+            "referencedSettings": [
+                "github.copilot.chat.otel.enabled"
+            ]
         },
         {
             "key": "chat.agentHost.otel.exporterType",
@@ -288,7 +303,10 @@
                 "console",
                 "file"
             ],
-            "included": true
+            "included": true,
+            "referencedSettings": [
+                "github.copilot.chat.otel.exporterType"
+            ]
         },
         {
             "key": "chat.agentHost.otel.otlpEndpoint",
@@ -303,7 +321,10 @@
             },
             "type": "string",
             "default": "",
-            "included": true
+            "included": true,
+            "referencedSettings": [
+                "github.copilot.chat.otel.otlpEndpoint"
+            ]
         },
         {
             "key": "chat.agentHost.otel.captureContent",
@@ -318,7 +339,10 @@
             },
             "type": "boolean",
             "default": false,
-            "included": true
+            "included": true,
+            "referencedSettings": [
+                "github.copilot.chat.otel.captureContent"
+            ]
         },
         {
             "key": "chat.agentHost.otel.outfile",
@@ -333,7 +357,10 @@
             },
             "type": "string",
             "default": "",
-            "included": true
+            "included": true,
+            "referencedSettings": [
+                "github.copilot.chat.otel.outfile"
+            ]
         },
         {
             "key": "chat.defaultModel",
@@ -686,6 +713,21 @@
             "included": true
         },
         {
+            "key": "chat.agent.sandbox.retryWithAllowNetworkRequests",
+            "name": "ChatAgentSandboxRetryWithAllowNetworkRequests",
+            "category": "IntegratedTerminal",
+            "minimumVersion": "1.128",
+            "localization": {
+                "description": {
+                    "key": "agentSandbox.retryWithAllowNetworkRequests",
+                    "value": "Controls whether agent mode terminal commands can retry in the sandbox with unrestricted network access after user confirmation. This applies only when `#chat.agent.sandbox.enabled#` is enabled and preserves file system sandboxing while relaxing network restrictions for an approved command."
+                }
+            },
+            "type": "boolean",
+            "default": true,
+            "included": true
+        },
+        {
             "key": "chat.agent.sandbox.allowAutoApprove",
             "name": "ChatAgentSandboxAllowAutoApprove",
             "category": "IntegratedTerminal",
@@ -698,6 +740,63 @@
             },
             "type": "boolean",
             "default": true,
+            "included": true
+        },
+        {
+            "key": "chat.agent.sandbox.fileSystem.linux",
+            "name": "ChatAgentSandboxLinuxFileSystem",
+            "category": "IntegratedTerminal",
+            "minimumVersion": "1.128",
+            "localization": {
+                "description": {
+                    "key": "agentSandbox.linuxFileSystemSetting",
+                    "value": "Note: this setting is applicable only when `#chat.agent.sandbox.enabled#` is enabled. Controls file system access in sandbox on Linux. Paths do not support glob patterns, only literal paths (ex: ./src/, ~/.ssh, .env). **bubblewrap** and **socat** should be installed for this setting to work."
+                }
+            },
+            "type": "object",
+            "default": {
+                "denyRead": [],
+                "allowRead": [],
+                "allowWrite": [],
+                "denyWrite": []
+            },
+            "included": true
+        },
+        {
+            "key": "chat.agent.sandbox.fileSystem.mac",
+            "name": "ChatAgentSandboxMacFileSystem",
+            "category": "IntegratedTerminal",
+            "minimumVersion": "1.128",
+            "localization": {
+                "description": {
+                    "key": "agentSandbox.macFileSystemSetting",
+                    "value": "Note: this setting is applicable only when `#chat.agent.sandbox.enabled#` is enabled. Controls file system access in sandbox on macOS. Paths also support git-style glob patterns(ex: *.ts, ./src, ./src/**/*.ts, file?.txt)."
+                }
+            },
+            "type": "object",
+            "default": {
+                "denyRead": [],
+                "allowRead": [],
+                "allowWrite": [],
+                "denyWrite": []
+            },
+            "included": true
+        },
+        {
+            "key": "chat.agent.sandbox.advanced.runtime",
+            "name": "ChatAgentSandboxAdvancedRuntime",
+            "category": "IntegratedTerminal",
+            "minimumVersion": "1.128",
+            "localization": {
+                "description": {
+                    "key": "agentSandbox.runtimeSetting",
+                    "value": "Note: this setting is applicable only when `#chat.agent.sandbox.enabled#` is enabled. Key/value pairs are passed through to the root of the sandbox runtime configuration."
+                }
+            },
+            "type": "object",
+            "default": {
+                "enableWeakerNestedSandbox": false
+            },
             "included": true
         },
         {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -5,12 +5,12 @@
 
 import type { IStringDictionary } from '../../../../../base/common/collections.js';
 import type { IJSONSchema } from '../../../../../base/common/jsonSchema.js';
+import { PolicyCategory } from '../../../../../base/common/policy.js';
 import { localize } from '../../../../../nls.js';
 import { type IConfigurationPropertySchema } from '../../../../../platform/configuration/common/configurationRegistry.js';
 import { AgentSandboxEnabledValue, AgentSandboxSettingId } from '../../../../../platform/sandbox/common/settings.js';
 import { TerminalSettingId } from '../../../../../platform/terminal/common/terminal.js';
 import { terminalProfileBaseProperties } from '../../../../../platform/terminal/common/terminalPlatformConfiguration.js';
-import { PolicyCategory } from '../../../../../base/common/policy.js';
 
 /**
  * Default idle silence timeout in milliseconds. Used as both the configuration
@@ -81,6 +81,9 @@ const terminalChatAgentProfileSchema: IJSONSchema = {
 		...terminalProfileBaseProperties,
 	}
 };
+
+const defaultPosixSandboxFileSystemPolicyValue = JSON.stringify({ denyRead: [], allowRead: [], allowWrite: [], denyWrite: [] });
+const defaultSandboxAdvancedRuntimePolicyValue = JSON.stringify({ enableWeakerNestedSandbox: false });
 
 export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 	[TerminalChatAgentToolsSettingId.EnableAutoApprove]: {
@@ -546,6 +549,8 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 			name: 'ChatAgentSandboxEnabled',
 			category: PolicyCategory.IntegratedTerminal,
 			minimumVersion: '1.116',
+			value: policyData => policyData.chat_preview_features_enabled === false ? AgentSandboxEnabledValue.Off : undefined,
+			restrictedValue: AgentSandboxEnabledValue.Off,
 			localization: {
 				description: {
 					key: 'agentSandbox.enabledSetting',
@@ -589,6 +594,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 			name: 'ChatAgentSandboxAllowNetwork',
 			category: PolicyCategory.IntegratedTerminal,
 			minimumVersion: '1.127',
+			value: policyData => policyData.chat_preview_features_enabled === false ? false : undefined,
 			localization: {
 				description: {
 					key: 'agentSandbox.allowNetwork',
@@ -607,6 +613,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 			name: 'ChatAgentSandboxAllowUnsandboxedCommands',
 			category: PolicyCategory.IntegratedTerminal,
 			minimumVersion: '1.116',
+			value: policyData => policyData.chat_preview_features_enabled === false ? false : undefined,
 			localization: {
 				description: {
 					key: 'agentSandbox.allowUnsandboxedCommands',
@@ -620,7 +627,19 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		type: 'boolean',
 		default: true,
 		tags: ['preview'],
-		restricted: true
+		restricted: true,
+		policy: {
+			name: 'ChatAgentSandboxRetryWithAllowNetworkRequests',
+			category: PolicyCategory.IntegratedTerminal,
+			minimumVersion: '1.128',
+			value: policyData => policyData.chat_preview_features_enabled === false ? false : undefined,
+			localization: {
+				description: {
+					key: 'agentSandbox.retryWithAllowNetworkRequests',
+					value: localize('agentSandbox.retryWithAllowNetworkRequests', "Controls whether agent mode terminal commands can retry in the sandbox with unrestricted network access after user confirmation. This applies only when {0} is enabled and preserves file system sandboxing while relaxing network restrictions for an approved command.", `\`#${AgentSandboxSettingId.AgentSandboxEnabled}#\``),
+				}
+			}
+		}
 	},
 	[AgentSandboxSettingId.AgentSandboxAllowAutoApprove]: {
 		markdownDescription: localize('agentSandbox.allowAutoApprove', "Controls whether agent mode terminal commands that run inside the sandbox are auto-approved. When disabled, the run in terminal tool uses the existing approval flow. This applies only when {0} is enabled.", `\`#${AgentSandboxSettingId.AgentSandboxEnabled}#\``),
@@ -632,6 +651,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 			name: 'ChatAgentSandboxAllowAutoApprove',
 			category: PolicyCategory.IntegratedTerminal,
 			minimumVersion: '1.116',
+			value: policyData => policyData.chat_preview_features_enabled === false ? false : undefined,
 			localization: {
 				description: {
 					key: 'agentSandbox.allowAutoApprove',
@@ -677,6 +697,19 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		},
 		tags: ['preview'],
 		restricted: true,
+		policy: {
+			name: 'ChatAgentSandboxLinuxFileSystem',
+			category: PolicyCategory.IntegratedTerminal,
+			minimumVersion: '1.128',
+			value: policyData => policyData.chat_preview_features_enabled === false ? defaultPosixSandboxFileSystemPolicyValue : undefined,
+			restrictedValue: defaultPosixSandboxFileSystemPolicyValue,
+			localization: {
+				description: {
+					key: 'agentSandbox.linuxFileSystemSetting',
+					value: localize('agentSandbox.linuxFileSystemSetting', "Note: this setting is applicable only when {0} is enabled. Controls file system access in sandbox on Linux. Paths do not support glob patterns, only literal paths (ex: ./src/, ~/.ssh, .env). **bubblewrap** and **socat** should be installed for this setting to work.", `\`#${AgentSandboxSettingId.AgentSandboxEnabled}#\``),
+				}
+			}
+		},
 	},
 	[TerminalChatAgentToolsSettingId.AgentSandboxMacFileSystem]: {
 		markdownDescription: localize('agentSandbox.macFileSystemSetting', "Note: this setting is applicable only when {0} is enabled. Controls file system access in sandbox on macOS. Paths also support git-style glob patterns(ex: *.ts, ./src, ./src/**/*.ts, file?.txt).", `\`#${AgentSandboxSettingId.AgentSandboxEnabled}#\``),
@@ -715,6 +748,19 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		},
 		tags: ['preview'],
 		restricted: true,
+		policy: {
+			name: 'ChatAgentSandboxMacFileSystem',
+			category: PolicyCategory.IntegratedTerminal,
+			minimumVersion: '1.128',
+			value: policyData => policyData.chat_preview_features_enabled === false ? defaultPosixSandboxFileSystemPolicyValue : undefined,
+			restrictedValue: defaultPosixSandboxFileSystemPolicyValue,
+			localization: {
+				description: {
+					key: 'agentSandbox.macFileSystemSetting',
+					value: localize('agentSandbox.macFileSystemSetting', "Note: this setting is applicable only when {0} is enabled. Controls file system access in sandbox on macOS. Paths also support git-style glob patterns(ex: *.ts, ./src, ./src/**/*.ts, file?.txt).", `\`#${AgentSandboxSettingId.AgentSandboxEnabled}#\``),
+				}
+			}
+		},
 	},
 	[TerminalChatAgentToolsSettingId.AgentSandboxWindowsFileSystem]: {
 		markdownDescription: localize('agentSandbox.windowsFileSystemSetting', "Note: this setting is applicable only when {0} is enabled. Controls file system access in sandbox on Windows. Paths do not support glob patterns, only literal paths (ex: C:\\src, C:\\Users\\me\\.ssh, .env).", `\`#${AgentSandboxSettingId.AgentSandboxEnabled}#\``),
@@ -762,6 +808,19 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		additionalProperties: true,
 		tags: ['preview'],
 		restricted: true,
+		policy: {
+			name: 'ChatAgentSandboxAdvancedRuntime',
+			category: PolicyCategory.IntegratedTerminal,
+			minimumVersion: '1.128',
+			value: policyData => policyData.chat_preview_features_enabled === false ? defaultSandboxAdvancedRuntimePolicyValue : undefined,
+			restrictedValue: defaultSandboxAdvancedRuntimePolicyValue,
+			localization: {
+				description: {
+					key: 'agentSandbox.runtimeSetting',
+					value: localize('agentSandbox.runtimeSetting', "Note: this setting is applicable only when {0} is enabled. Key/value pairs are passed through to the root of the sandbox runtime configuration.", `\`#${AgentSandboxSettingId.AgentSandboxEnabled}#\``),
+				}
+			}
+		},
 	},
 	[TerminalChatAgentToolsSettingId.PreventShellHistory]: {
 		type: 'boolean',


### PR DESCRIPTION
Fixes #323643

## Summary
- Add enterprise policy registrations for additional terminal agent sandbox settings.
- Restrict sandbox-related settings to safe disabled/default values when `chat_preview_features_enabled` is false.
- Add default serialized policy values for filesystem and advanced runtime sandbox settings.
- Regenerate `build/lib/policies/policyData.jsonc` with the new policy entries.

## Testing
- Ran precommit hygiene via `git commit` hook.
- Checked diagnostics for `src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts` and `src/vs/workbench/contrib/policyExport/test/node/policyExport.integrationTest.ts` (no errors).
- Ran `./scripts/test.sh --run src/vs/workbench/contrib/policyExport/test/node/policyExport.integrationTest.ts` (`2 passing`).
