### PR TITLE
AHP: opt into SDK managed-settings self-fetch

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -65,7 +65,7 @@ type CopilotSessionLaunchConfig = ResumeSessionConfig & {
 	 * it on `SessionConfigBase`; it is forwarded to `createSession` and read by the
 	 * runtime at runtime regardless of the published SDK's static type.
 	 */
-	readonly selfFetchManagedSettings?: boolean;
+	readonly enableManagedSettings?: boolean;
 };
 
 /**
@@ -421,7 +421,7 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			// the session's gitHubToken to call /copilot_internal/managed_settings
 			// and enforces the result fail-closed before the first turn.
 			// Typed locally on CopilotSessionLaunchConfig pending the SDK type update.
-			selfFetchManagedSettings: true,
+			enableManagedSettings: true,
 		};
 	}
 }

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -59,6 +59,13 @@ type PostToolUseHookInput = Parameters<NonNullable<SessionHooks['onPostToolUse']
 type CopilotSessionLaunchConfig = ResumeSessionConfig & {
 	readonly pluginDirectories?: string[];
 	readonly remoteSession?: 'export';
+	/**
+	 * Opt the runtime into self-fetching enterprise managed settings at session
+	 * bootstrap. Declared locally until the published `@github/copilot-sdk` carries
+	 * it on `SessionConfigBase`; it is forwarded to `createSession` and read by the
+	 * runtime at runtime regardless of the published SDK's static type.
+	 */
+	readonly selfFetchManagedSettings?: boolean;
 };
 
 /**
@@ -409,6 +416,12 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			// session must opt in via `remoteSession` to actually export
 			// events. Without this, sessions default to "off".
 			remoteSession: this._configurationService.getRootValue(platformRootSchema, AgentHostSessionSyncEnabledConfigKey) === true ? 'export' : undefined,
+			// Opt the runtime into self-fetching enterprise managed settings
+			// (bypass-permissions policy) at session bootstrap. The runtime uses
+			// the session's gitHubToken to call /copilot_internal/managed_settings
+			// and enforces the result fail-closed before the first turn.
+			// Typed locally on CopilotSessionLaunchConfig pending the SDK type update.
+			selfFetchManagedSettings: true,
 		};
 	}
 }


### PR DESCRIPTION
## AHP: opt into SDK managed-settings self-fetch

see https://github.com/github/copilot-sdk-internal/issues/206

The Agent Host session launcher passes `enableManagedSettings: true` when creating a Copilot SDK session, so the runtime self-fetches and enforces enterprise managed settings (bypass-permissions policy) using the session's GitHub token — no enforcement logic lives in VS Code.

- `src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts` — set `enableManagedSettings: true` in `_buildSessionConfig`. Typed via the SDK's `SessionConfigBase` (see SDK PR).

### Related PRs
- **Runtime** (implements + enforces): github/copilot-agent-runtime#11604
- **SDK** (forwards the flag): https://github.com/github/copilot-sdk/pull/1925

---
:warning: Draft — part of a 3-repo change (runtime + SDK + VS Code).
