### PR TITLE
Functional & accurate `languageModelToolInvoked` telemetry for Claude & Codex

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -3,10 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import type { LanguageModelToolInvokedClassification, LanguageModelToolInvokedEvent } from '../../telemetry/common/languageModelToolTelemetry.js';
 import type { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { AgentSession } from '../common/agentService.js';
 import type { MessageAttachment } from '../common/state/protocol/state.js';
 import { isAhpChatChannel, isSubagentSession, parseRequiredSessionUriFromChatUri, type ISessionWithDefaultChat } from '../common/state/sessionState.js';
+import type { ToolInvokedResult } from './agentHostToolCallTracker.js';
 
 export type AgentHostUserMessageSentSource = 'direct' | 'queued';
 
@@ -70,6 +72,15 @@ export interface IAgentHostTurnCompletedReport {
 	permissionLevel: string | undefined;
 }
 
+export interface IAgentHostToolInvokedReport {
+	provider: string;
+	session: string;
+	toolId: string;
+	toolSourceKind: string;
+	result: ToolInvokedResult;
+	invocationTimeMs: number;
+}
+
 export class AgentHostTelemetryReporter {
 
 	constructor(private readonly _telemetryService: ITelemetryService) { }
@@ -103,6 +114,22 @@ export class AgentHostTelemetryReporter {
 			result: report.result,
 			model: report.model,
 			permissionLevel: report.permissionLevel,
+		});
+	}
+
+	toolInvoked(report: IAgentHostToolInvokedReport): void {
+		// `chatSessionId` is the full session URI string (matching the value
+		// previously emitted by `CopilotAgentSession`). Action signals are keyed
+		// by their chat-channel URI, so normalize it back to the session URI.
+		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
+		this._telemetryService.publicLog2<LanguageModelToolInvokedEvent, LanguageModelToolInvokedClassification>('languageModelToolInvoked', {
+			result: report.result,
+			chatSessionId: session,
+			toolId: report.toolId,
+			toolExtensionId: undefined,
+			toolSourceKind: report.toolSourceKind,
+			invocationTimeMs: report.invocationTimeMs,
+			provider: report.provider,
 		});
 	}
 }

--- a/src/vs/platform/agentHost/node/agentHostToolCallTracker.ts
+++ b/src/vs/platform/agentHost/node/agentHostToolCallTracker.ts
@@ -35,11 +35,16 @@ export function toolSourceKindFromContributor(contributor: ToolCallContributor |
 	if (!contributor) {
 		return 'agentHost';
 	}
-	switch (contributor.kind) {
+	// Widen to `string` so an unrecognized kind from a newer protocol version
+	// falls through to a valid telemetry value rather than `undefined`.
+	const kind: string = contributor.kind;
+	switch (kind) {
 		case ToolCallContributorKind.MCP:
 			return 'mcp';
 		case ToolCallContributorKind.Client:
 			return 'client';
+		default:
+			return kind;
 	}
 }
 

--- a/src/vs/platform/agentHost/node/agentHostToolCallTracker.ts
+++ b/src/vs/platform/agentHost/node/agentHostToolCallTracker.ts
@@ -1,0 +1,127 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { StopWatch } from '../../../base/common/stopwatch.js';
+import { ToolCallContributorKind, type ToolCallContributor, type ToolCallResult } from '../common/state/sessionState.js';
+import type { AgentHostTelemetryReporter } from './agentHostTelemetryReporter.js';
+
+export type ToolInvokedResult = 'success' | 'error' | 'userCancelled';
+
+/**
+ * Maps a completed tool call's result to the telemetry result bucket. Mirrors
+ * the derivation previously done inline in `CopilotAgentSession`: a denied,
+ * rejected, or cancelled tool call counts as `userCancelled`; any other
+ * failure counts as `error`.
+ */
+export function deriveToolInvokedResult(result: ToolCallResult): ToolInvokedResult {
+	if (result.success) {
+		return 'success';
+	}
+	const code = result.error?.code;
+	if (code === 'rejected' || code === 'denied' || code === 'cancelled') {
+		return 'userCancelled';
+	}
+	return 'error';
+}
+
+/**
+ * Maps a tool call's contributor to the telemetry `toolSourceKind`. A tool with
+ * no contributor is provided by the agent host itself; an MCP contributor maps
+ * to `mcp` and a client contributor to `client`.
+ */
+export function toolSourceKindFromContributor(contributor: ToolCallContributor | undefined): string {
+	if (!contributor) {
+		return 'agentHost';
+	}
+	switch (contributor.kind) {
+		case ToolCallContributorKind.MCP:
+			return 'mcp';
+		case ToolCallContributorKind.Client:
+			return 'client';
+	}
+}
+
+/** Per-tool-call timing state, keyed by `session:toolCallId`. */
+interface IToolCallTiming {
+	readonly stopWatch: StopWatch;
+	readonly provider: string;
+	readonly session: string;
+	readonly toolId: string;
+	readonly toolSourceKind: string;
+}
+
+/**
+ * Tracks per-tool-call timing for agent host sessions and reports a
+ * `languageModelToolInvoked` event via the provided
+ * {@link AgentHostTelemetryReporter} when a tool call completes.
+ *
+ * Lifecycle per tool call:
+ *   1. {@link toolCallStarted} — begins a stopwatch and records the tool's
+ *      name and source kind (only the start action carries these)
+ *   2. {@link toolCallCompleted} — emits the telemetry event and clears state
+ *
+ * In-flight tool calls that never complete (e.g. the turn is cancelled mid
+ * tool call) are dropped via {@link clearSession} / {@link clear} so the
+ * tracking map cannot leak.
+ */
+export class AgentHostToolCallTracker {
+
+	private readonly _toolCalls = new Map<string, IToolCallTiming>();
+
+	constructor(private readonly _reporter: AgentHostTelemetryReporter) { }
+
+	toolCallStarted(provider: string, session: string, toolCallId: string, toolName: string, contributor: ToolCallContributor | undefined): void {
+		this._toolCalls.set(this._key(session, toolCallId), {
+			stopWatch: StopWatch.create(false),
+			provider,
+			session,
+			toolId: toolName,
+			toolSourceKind: toolSourceKindFromContributor(contributor),
+		});
+	}
+
+	toolCallCompleted(session: string, toolCallId: string, result: ToolCallResult): void {
+		const key = this._key(session, toolCallId);
+		const timing = this._toolCalls.get(key);
+		if (!timing) {
+			// No matching start: either the start was never observed, or this is
+			// a duplicate completion (the entry was already consumed). Either
+			// way, do not emit so volume stays accurate.
+			return;
+		}
+		this._toolCalls.delete(key);
+
+		this._reporter.toolInvoked({
+			provider: timing.provider,
+			session: timing.session,
+			toolId: timing.toolId,
+			toolSourceKind: timing.toolSourceKind,
+			result: deriveToolInvokedResult(result),
+			invocationTimeMs: timing.stopWatch.elapsed(),
+		});
+	}
+
+	/**
+	 * Drops any in-flight (never-completed) tool calls for a session. Called
+	 * when a turn ends or a session is torn down so the tracking map cannot
+	 * leak. A no-op in the normal case where every tool call completes.
+	 */
+	clearSession(session: string): void {
+		const prefix = `${session}\0`;
+		for (const key of this._toolCalls.keys()) {
+			if (key.startsWith(prefix)) {
+				this._toolCalls.delete(key);
+			}
+		}
+	}
+
+	clear(): void {
+		this._toolCalls.clear();
+	}
+
+	private _key(session: string, toolCallId: string): string {
+		return `${session}\0${toolCallId}`;
+	}
+}

--- a/src/vs/platform/agentHost/node/agentHostToolCallTracker.ts
+++ b/src/vs/platform/agentHost/node/agentHostToolCallTracker.ts
@@ -79,7 +79,7 @@ export class AgentHostToolCallTracker {
 
 	toolCallStarted(provider: string, session: string, toolCallId: string, toolName: string, contributor: ToolCallContributor | undefined): void {
 		this._toolCalls.set(this._key(session, toolCallId), {
-			stopWatch: StopWatch.create(false),
+			stopWatch: StopWatch.create(true),
 			provider,
 			session,
 			toolId: toolName,

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -452,12 +452,11 @@ export class AgentSideEffects extends Disposable {
 
 		// Stamp the tool call start for `languageModelToolInvoked` telemetry.
 		// Only the start action carries the tool name and contributor, so the
-		// source kind must be captured here rather than on completion.
-		if (action.type === ActionType.ChatToolCallStart) {
-			const provider = agent?.id ?? this._options.getAgent(sessionKey)?.id;
-			if (provider !== undefined) {
-				this._toolCallTracker.toolCallStarted(provider, sessionKey, action.toolCallId, action.toolName, action.contributor);
-			}
+		// source kind must be captured here rather than on completion. The
+		// provider comes from the agent that emitted the signal (always present
+		// for an agent-driven tool call).
+		if (action.type === ActionType.ChatToolCallStart && agent) {
+			this._toolCallTracker.toolCallStarted(agent.id, sessionKey, action.toolCallId, action.toolName, action.contributor);
 		}
 
 		if (action.type === ActionType.ChatToolCallComplete) {

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -416,6 +416,11 @@ export class AgentSideEffects extends Disposable {
 
 		if (action.type === ActionType.ChatToolCallStart && agent) {
 			this._toolCallAgents.set(`${sessionKey}:${action.toolCallId}`, agent.id);
+			// Stamp the tool call start for `languageModelToolInvoked` telemetry.
+			// Only the start action carries the tool name and contributor, so the
+			// source kind must be captured here rather than on completion. The
+			// provider comes from the agent that emitted the signal.
+			this._toolCallTracker.toolCallStarted(agent.id, sessionKey, action.toolCallId, action.toolName, action.contributor);
 		}
 
 		const sessionScope = isAhpChatChannel(sessionKey) ? parseRequiredSessionUriFromChatUri(sessionKey) : sessionKey;
@@ -448,15 +453,6 @@ export class AgentSideEffects extends Disposable {
 			|| action.type === ActionType.ChatToolCallStart
 			|| action.type === ActionType.ChatReasoning) {
 			this._turnTracker.markFirstProgress(sessionKey, turnId);
-		}
-
-		// Stamp the tool call start for `languageModelToolInvoked` telemetry.
-		// Only the start action carries the tool name and contributor, so the
-		// source kind must be captured here rather than on completion. The
-		// provider comes from the agent that emitted the signal (always present
-		// for an agent-driven tool call).
-		if (action.type === ActionType.ChatToolCallStart && agent) {
-			this._toolCallTracker.toolCallStarted(agent.id, sessionKey, action.toolCallId, action.toolName, action.contributor);
 		}
 
 		if (action.type === ActionType.ChatToolCallComplete) {

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -49,6 +49,7 @@ import { parseRenameCommand } from './agentHostRenameCommand.js';
 import { AgentHostSessionTitleController } from './agentHostSessionTitleController.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
 import { AgentHostTelemetryReporter } from './agentHostTelemetryReporter.js';
+import { AgentHostToolCallTracker } from './agentHostToolCallTracker.js';
 import { updateAgentHostTelemetryLevelFromConfig } from './agentHostTelemetryService.js';
 import { AgentHostTurnTracker } from './agentHostTurnTracker.js';
 import { SessionPermissionManager } from './sessionPermissions.js';
@@ -123,6 +124,7 @@ export class AgentSideEffects extends Disposable {
 	private readonly _pendingSubagentSignals = new NKeyMap<IPendingSubagentSignal[], [ProtocolURI, string]>();
 	private readonly _telemetryReporter: AgentHostTelemetryReporter;
 	private readonly _turnTracker: AgentHostTurnTracker;
+	private readonly _toolCallTracker: AgentHostToolCallTracker;
 	private readonly _titleController: AgentHostSessionTitleController;
 
 	constructor(
@@ -137,6 +139,7 @@ export class AgentSideEffects extends Disposable {
 		super();
 		this._telemetryReporter = new AgentHostTelemetryReporter(this._telemetryService);
 		this._turnTracker = new AgentHostTurnTracker(this._telemetryReporter);
+		this._toolCallTracker = new AgentHostToolCallTracker(this._telemetryReporter);
 		this._permissionManager = this._register(instantiationService.createInstance(SessionPermissionManager, this._stateManager));
 		this._titleController = this._register(instantiationService.createInstance(AgentHostSessionTitleController, this._stateManager, {
 			sessionDataService: this._options.sessionDataService,
@@ -447,7 +450,22 @@ export class AgentSideEffects extends Disposable {
 			this._turnTracker.markFirstProgress(sessionKey, turnId);
 		}
 
+		// Stamp the tool call start for `languageModelToolInvoked` telemetry.
+		// Only the start action carries the tool name and contributor, so the
+		// source kind must be captured here rather than on completion.
+		if (action.type === ActionType.ChatToolCallStart) {
+			const provider = agent?.id ?? this._options.getAgent(sessionKey)?.id;
+			if (provider !== undefined) {
+				this._toolCallTracker.toolCallStarted(provider, sessionKey, action.toolCallId, action.toolName, action.contributor);
+			}
+		}
+
 		if (action.type === ActionType.ChatToolCallComplete) {
+			// Emit `languageModelToolInvoked` telemetry for the completed tool
+			// call. `action.result` carries `success`/`error.code` even after the
+			// subagent-content merge above (which only touches `result.content`).
+			this._toolCallTracker.toolCallCompleted(sessionKey, action.toolCallId, action.result);
+
 			// Drop any events that were buffered for a subagent whose
 			// `subagent_started` never arrived (e.g. the parent tool failed
 			// before the subagent was created). The actual subagent session
@@ -462,15 +480,18 @@ export class AgentSideEffects extends Disposable {
 
 		if (action.type === ActionType.ChatTurnComplete) {
 			this._turnTracker.turnCompleted(sessionKey, turnId, 'success');
+			this._toolCallTracker.clearSession(sessionKey);
 			this._runTurnCompleteSideEffects(sessionKey, turnId);
 		}
 
 		if (action.type === ActionType.ChatTurnCancelled) {
 			this._turnTracker.turnCompleted(sessionKey, turnId, 'cancelled');
+			this._toolCallTracker.clearSession(sessionKey);
 		}
 
 		if (action.type === ActionType.ChatError) {
 			this._turnTracker.turnCompleted(sessionKey, turnId, 'error');
+			this._toolCallTracker.clearSession(sessionKey);
 		}
 	}
 
@@ -634,6 +655,7 @@ export class AgentSideEffects extends Disposable {
 				});
 				this._turnTracker.turnCompleted(subagent.chatUri, turnId, 'cancelled');
 			}
+			this._toolCallTracker.clearSession(subagent.chatUri);
 		}
 		this._subagentChats.deleteAll(parentChatURI);
 		// Drop any buffered events targeted at subagents that never started.
@@ -677,6 +699,7 @@ export class AgentSideEffects extends Disposable {
 		for (const subagent of this._subagentChats.values()) {
 			if (subagent.sessionUri === parentSession) {
 				this._stateManager.removeChat(subagent.sessionUri, subagent.chatUri);
+				this._toolCallTracker.clearSession(subagent.chatUri);
 				parentChatURIs.add(subagent.parentChatUri);
 			}
 		}
@@ -843,6 +866,7 @@ export class AgentSideEffects extends Disposable {
 					throw new Error(`ChatTurnCancelled must be handled on an AHP chat channel: ${channel}`);
 				}
 				this._turnTracker.turnCompleted(channel, action.turnId, 'cancelled');
+				this._toolCallTracker.clearSession(channel);
 				// Cancel all subagent sessions for this parent
 				this.cancelSubagentSessions(channel);
 				const agent = this._options.getAgent(sessionChannel);
@@ -1219,12 +1243,14 @@ export class AgentSideEffects extends Disposable {
 				error: buildSendFailedError(err),
 			});
 			this._turnTracker.turnCompleted(turnChannel, turnId, 'error');
+			this._toolCallTracker.clearSession(turnChannel);
 		});
 	}
 
 
 	override dispose(): void {
 		this._toolCallAgents.clear();
+		this._toolCallTracker.clear();
 		super.dispose();
 	}
 }

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
@@ -22,7 +22,7 @@ import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
 import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
 import { ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
 import { ActionType } from '../../common/state/sessionActions.js';
-import { PendingMessage, ChatInputAnswer, ChatInputRequest, ChatInputResponseKind, ToolCallPendingConfirmationState, type AgentSelection, type ModelSelection, type ToolDefinition } from '../../common/state/protocol/state.js';
+import { PendingMessage, ChatInputAnswer, ChatInputRequest, ChatInputResponseKind, ToolCallContributorKind, ToolCallPendingConfirmationState, type AgentSelection, type ModelSelection, type ToolDefinition } from '../../common/state/protocol/state.js';
 import { buildDefaultChatUri, type Customization, type ToolCallResult } from '../../common/state/sessionState.js';
 import { IClaudeAgentSdkService } from './claudeAgentSdkService.js';
 import { buildClientMcpServers, buildOptions } from './claudeSdkOptions.js';
@@ -34,6 +34,7 @@ import { readClaudePermissionMode } from './claudeSessionPermissionMode.js';
 import { SessionClientToolsDiff } from './clientTools/claudeSessionClientToolsModel.js';
 import { SessionClientCustomizationsDiff } from './customizations/claudeSessionClientCustomizationsModel.js';
 import { ClaudeCustomizationWatcher, buildDiscoveredCustomizations, resolveClaudeAgentName } from './customizations/claudeSessionCustomizationDiscovery.js';
+import { findMcpChildId } from '../shared/mcpCustomizationController.js';
 import { scanClaudeDiskCustomizations } from './customizations/scan/claudeAgentSkillScan.js';
 import { scanClaudeHooks } from './customizations/scan/claudeHookScan.js';
 import { scanClaudeMcpServers } from './customizations/scan/claudeMcpScan.js';
@@ -253,6 +254,29 @@ export class ClaudeAgentSession extends Disposable {
 		};
 	}
 
+	/**
+	 * Stamps the MCP {@link ToolCallContributor} onto a `ChatToolCallStart` for
+	 * an external `mcp__<server>__<tool>` call, resolved from this session's
+	 * cached customization snapshot. Owned here because the session owns the
+	 * customization data; the stream mapper stays free of it. (The in-process
+	 * `mcp__client__` server already carries a Client contributor from the mapper.)
+	 */
+	private _enrichSignalWithMcpContributor(signal: AgentSignal): AgentSignal {
+		if (signal.kind !== 'action' || signal.action.type !== ActionType.ChatToolCallStart || signal.action.contributor !== undefined) {
+			return signal;
+		}
+		const toolName = signal.action.toolName;
+		if (!toolName.startsWith('mcp__')) {
+			return signal;
+		}
+		const serverName = toolName.split('__')[1];
+		const customizationId = serverName ? findMcpChildId(this._lastCustomizations, serverName) : undefined;
+		if (customizationId === undefined) {
+			return signal;
+		}
+		return { ...signal, action: { ...signal.action, contributor: { kind: ToolCallContributorKind.MCP, customizationId } } };
+	}
+
 	constructor(
 		readonly sessionId: string,
 		readonly sessionUri: URI,
@@ -418,7 +442,7 @@ export class ClaudeAgentSession extends Disposable {
 			await warm[Symbol.asyncDispose]();
 			throw err;
 		}
-		this._register(pipeline.onDidProduceSignal(s => this._onDidSessionProgress.fire(this._enrichSignalWithCredits(s))));
+		this._register(pipeline.onDidProduceSignal(s => this._onDidSessionProgress.fire(this._enrichSignalWithMcpContributor(this._enrichSignalWithCredits(s)))));
 		this._pipeline = pipeline;
 		// The materialize succeeded with the staged anchor applied to `Options`
 		// — clear it now so it isn't re-applied. A throw before this point (e.g.
@@ -917,6 +941,9 @@ export class ClaudeAgentSession extends Disposable {
 		return this.clientCustomizationsDiff.model.state.get().synced;
 	}
 
+	/** Snapshot of the last {@link getSessionCustomizations} result, read by {@link _enrichSignalWithMcpContributor}. */
+	private _lastCustomizations: readonly Customization[] = [];
+
 	/**
 	 * Project the union of (a) **client-pushed** customizations and
 	 * (b) the **server-side** (SDK-discovered) view (commands / agents
@@ -968,6 +995,9 @@ export class ClaudeAgentSession extends Disposable {
 			enabled: enablement.get(item.customization.id) ?? item.customization.enabled,
 		}));
 		result.push(...discoveredCustomizations);
+		// Cache for the MCP-contributor signal enrichment (see
+		// {@link _enrichSignalWithMcpContributor}).
+		this._lastCustomizations = result;
 		return result;
 	}
 

--- a/src/vs/platform/agentHost/node/claude/claudeCanUseTool.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeCanUseTool.ts
@@ -9,6 +9,7 @@ import { ChatInputResponseKind, ToolCallPendingConfirmationState, ToolCallStatus
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import { ClaudeAgentSession } from './claudeAgentSession.js';
 import { buildAskUserSessionInputQuestions, buildExitPlanModeConfirmationState, flattenAskUserAnswers, parseAskUserQuestionInput } from './claudeInteractiveTools.js';
+import { CLAUDE_PLAN_DECLINED_MESSAGE, CLAUDE_QUESTION_CANCELLED_MESSAGE, CLAUDE_USER_DECLINED_MESSAGE } from './claudeToolDenial.js';
 import { getClaudeConfirmationTitle, getClaudeInvocationMessage, getClaudePermissionKind, getClaudeToolDisplayName, getClaudeToolInputString, getClaudeToolPath, INTERACTIVE_CLAUDE_TOOLS, buildClaudeToolMeta } from './claudeToolDisplay.js';
 
 /**
@@ -147,7 +148,7 @@ async function dispatchCanUseTool(
 	});
 	return approved
 		? { behavior: 'allow', updatedInput: input }
-		: { behavior: 'deny', message: 'User declined' };
+		: { behavior: 'deny', message: CLAUDE_USER_DECLINED_MESSAGE };
 }
 
 /**
@@ -238,7 +239,7 @@ async function handleExitPlanMode(
 		});
 		return { behavior: 'allow', updatedInput: input };
 	}
-	return { behavior: 'deny', message: 'The user declined the plan, maybe ask why?' };
+	return { behavior: 'deny', message: CLAUDE_PLAN_DECLINED_MESSAGE };
 }
 
 /**
@@ -265,12 +266,12 @@ async function handleAskUserQuestion(
 		questions: buildAskUserSessionInputQuestions(askInput),
 	}, parentToolCallId);
 	if (answer.response !== ChatInputResponseKind.Accept || !answer.answers) {
-		return { behavior: 'deny', message: 'The user cancelled the question' };
+		return { behavior: 'deny', message: CLAUDE_QUESTION_CANCELLED_MESSAGE };
 	}
 
 	const answers = flattenAskUserAnswers(askInput, answer.answers);
 	if (Object.keys(answers).length === 0) {
-		return { behavior: 'deny', message: 'The user cancelled the question' };
+		return { behavior: 'deny', message: CLAUDE_QUESTION_CANCELLED_MESSAGE };
 	}
 	return { behavior: 'allow', updatedInput: { ...input, answers } };
 }

--- a/src/vs/platform/agentHost/node/claude/claudeMapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeMapSessionEvents.ts
@@ -14,6 +14,7 @@ import { buildTopLevelSubagentReadyAction, emitInnerAssistantSignals, mapSubagen
 import type { SubagentRegistry } from './claudeSubagentRegistry.js';
 import { stripClientToolNamePrefix, hasClientToolNamePrefix } from './clientTools/claudeClientToolMcpServer.js';
 import { buildClaudeToolMeta, getClaudePastTenseMessage, getClaudeToolDisplayName } from './claudeToolDisplay.js';
+import { claudeToolDenialCode } from './claudeToolDenial.js';
 import { ClaudeToolCallRegistry } from './claudeToolCallRegistry.js';
 import { ToolCallConfirmationReason, ToolCallContributorKind, type StringOrMarkdown } from '../../common/state/protocol/state.js';
 
@@ -350,6 +351,10 @@ function mapUserMessage(
 		const pastTenseMessage: StringOrMarkdown = info
 			? getClaudePastTenseMessage(info.toolName, info.displayName, info.parsedInput, !isError, resultText)
 			: `${getClaudeToolDisplayName(tracked.toolName)} finished`;
+		// A denied/cancelled tool surfaces as an `is_error` result whose content
+		// is the deny `message` we returned from `canUseTool`; classify it so the
+		// telemetry reports `userCancelled` rather than a generic error.
+		const denialCode = isError ? claudeToolDenialCode(resultText) : undefined;
 		signals.push({
 			kind: 'action',
 			resource: chat,
@@ -361,6 +366,7 @@ function mapUserMessage(
 					success: !isError,
 					pastTenseMessage,
 					content: content.length > 0 ? content : undefined,
+					...(denialCode ? { error: { message: resultText, code: denialCode } } : {}),
 				},
 			},
 		});

--- a/src/vs/platform/agentHost/node/claude/claudeToolDenial.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeToolDenial.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Deny `message` returned to the SDK when the user declines a tool
+ * permission. The SDK surfaces it as the `is_error` tool_result content.
+ */
+export const CLAUDE_USER_DECLINED_MESSAGE = 'User declined';
+/** Deny `message` when the user declines an `ExitPlanMode` plan. */
+export const CLAUDE_PLAN_DECLINED_MESSAGE = 'The user declined the plan, maybe ask why?';
+/** Deny `message` when the user cancels an `AskUserQuestion` prompt. */
+export const CLAUDE_QUESTION_CANCELLED_MESSAGE = 'The user cancelled the question';
+
+/**
+ * Classifies a failed tool's result message into a `languageModelToolInvoked`
+ * cancellation code (`denied`/`cancelled`), or `undefined` for a genuine tool
+ * error. The input is the `message` a denied `canUseTool` returns, which the
+ * SDK echoes back as the `is_error` tool_result content — so matching the
+ * known deny strings distinguishes a user cancellation from a tool failure.
+ */
+export function claudeToolDenialCode(message: string): 'denied' | 'cancelled' | undefined {
+	switch (message) {
+		case CLAUDE_USER_DECLINED_MESSAGE:
+		case CLAUDE_PLAN_DECLINED_MESSAGE:
+			return 'denied';
+		case CLAUDE_QUESTION_CANCELLED_MESSAGE:
+			return 'cancelled';
+		default:
+			return undefined;
+	}
+}

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -2130,6 +2130,11 @@ export class CodexAgent extends Disposable implements IAgent {
 		// resolve the first match. Mirrors the Claude/Copilot agents.
 		for (const session of this._sessions.values()) {
 			if (session.pendingCommandApprovals.respond(requestId, approved ? 'accept' : 'decline')) {
+				if (!approved) {
+					// Remember the decline so the tool's `item/completed` (which
+					// codex reports as a generic failure) maps to `userCancelled`.
+					session.mapState.declinedToolCalls.add(requestId);
+				}
 				return;
 			}
 		}
@@ -2331,6 +2336,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		}
 		const controller = this._getOrCreateMcpController(session);
 		controller.applyAll(inventoryToSdkServers(this._mcpInventory));
+		this._refreshMcpCustomizationIds(session, controller);
 		return controller.topLevelCustomizations();
 	}
 
@@ -2415,7 +2421,27 @@ export class CodexAgent extends Disposable implements IAgent {
 			if (session.disposed) {
 				continue;
 			}
-			this._getOrCreateMcpController(session).applyAll(servers);
+			const controller = this._getOrCreateMcpController(session);
+			controller.applyAll(servers);
+			this._refreshMcpCustomizationIds(session, controller);
+		}
+	}
+
+	/**
+	 * Refreshes the session's mapper snapshot of server name → customization id
+	 * (read when stamping the MCP contributor on tool calls). Plain data, owned
+	 * here — the mapper never reaches back into the controller. Must run on every
+	 * inventory change because MCP servers are discovered asynchronously, after a
+	 * session (and possibly its first tool call) already exists.
+	 */
+	private _refreshMcpCustomizationIds(session: ICodexSession, controller: McpCustomizationController): void {
+		const ids = session.mapState.mcpCustomizationIds;
+		ids.clear();
+		for (const serverName of this._mcpInventory.keys()) {
+			const id = controller.customizationIdForServer(serverName);
+			if (id !== undefined) {
+				ids.set(serverName, id);
+			}
 		}
 	}
 

--- a/src/vs/platform/agentHost/node/codex/codexMapAppServerEvents.ts
+++ b/src/vs/platform/agentHost/node/codex/codexMapAppServerEvents.ts
@@ -65,6 +65,21 @@ export interface ICodexSessionMapState {
 	 * answers the `item/tool/call` directly.
 	 */
 	serverToolNames: ReadonlySet<string>;
+	/**
+	 * Server name → customization id for the session's MCP servers, used to
+	 * stamp the {@link ToolCallContributorKind.MCP} contributor on `mcpToolCall`
+	 * starts so clients can correlate the call with its originating server
+	 * customization. Owned and populated by the agent (mirrors
+	 * {@link clientToolSet}); empty until the agent first applies the inventory.
+	 */
+	readonly mcpCustomizationIds: Map<string, string>;
+	/**
+	 * Tool call ids the host declined at the approval prompt. Codex reports the
+	 * resulting `item/completed` as a generic failure, so the completion handler
+	 * consults this set to emit a `userCancelled` (`error.code = 'denied'`)
+	 * result instead. Drained on completion and cleared per turn.
+	 */
+	readonly declinedToolCalls: Set<string>;
 }
 
 export interface ICodexToolCallEntry {
@@ -82,6 +97,8 @@ export function createCodexSessionMapState(serverToolNames: ReadonlySet<string> 
 		currentTurnId: undefined,
 		clientToolSet,
 		serverToolNames,
+		mcpCustomizationIds: new Map(),
+		declinedToolCalls: new Set(),
 	};
 }
 
@@ -96,6 +113,7 @@ export function resetCodexTurnMapState(state: ICodexSessionMapState): void {
 	state.itemToPartId.clear();
 	state.itemToToolCall.clear();
 	state.itemToReasoningPartId.clear();
+	state.declinedToolCalls.clear();
 }
 
 /**
@@ -417,6 +435,7 @@ export function mapItemStarted(
 		const toolCallId = generateUuid();
 		const toolName = `${params.item.server}.${params.item.tool}`;
 		const toolInput = toolInputText(params.item.arguments);
+		const customizationId = state.mcpCustomizationIds.get(params.item.server);
 		state.itemToToolCall.set(params.item.id, {
 			toolCallId,
 			turnId: params.turnId,
@@ -430,6 +449,7 @@ export function mapItemStarted(
 				toolCallId,
 				toolName,
 				displayName: params.item.tool,
+				...(customizationId ? { contributor: { kind: ToolCallContributorKind.MCP, customizationId } } : {}),
 			},
 			{
 				type: ActionType.ChatToolCallDelta,
@@ -611,12 +631,17 @@ export function mapItemCompleted(
 		clearReasoningForItem(state, params.item.id);
 		return [];
 	}
+	// Every remaining item type is a tool call. Resolve the tracked entry and
+	// drain the host-decline flag here, once, so all completion paths treat a
+	// declined tool uniformly (reported as `userCancelled` via
+	// `error.code = 'denied'`) instead of depending on which tool type completed.
+	const entry = state.itemToToolCall.get(params.item.id);
+	if (!entry) {
+		return [];
+	}
+	state.itemToToolCall.delete(params.item.id);
+	const declined = state.declinedToolCalls.delete(entry.toolCallId);
 	if (params.item.type === 'commandExecution') {
-		const entry = state.itemToToolCall.get(params.item.id);
-		if (!entry) {
-			return [];
-		}
-		state.itemToToolCall.delete(params.item.id);
 		const success = params.item.status === 'completed' && (params.item.exitCode === 0 || params.item.exitCode === null);
 		const output = params.item.aggregatedOutput ?? entry.output;
 		const command = params.item.command ?? '';
@@ -639,17 +664,13 @@ export function mapItemCompleted(
 						: undefined,
 					error: success ? undefined : {
 						message: exit !== null ? `Exit code ${exit}` : 'Command failed',
+						...(declined ? { code: 'denied' } : {}),
 					},
 				},
 			},
 		];
 	}
 	if (params.item.type === 'webSearch') {
-		const entry = state.itemToToolCall.get(params.item.id);
-		if (!entry) {
-			return [];
-		}
-		state.itemToToolCall.delete(params.item.id);
 		const query = describeWebSearch(params.item.query, params.item.action);
 		return [{
 			type: ActionType.ChatToolCallComplete,
@@ -662,11 +683,6 @@ export function mapItemCompleted(
 		}];
 	}
 	if (params.item.type === 'fileChange') {
-		const entry = state.itemToToolCall.get(params.item.id);
-		if (!entry) {
-			return [];
-		}
-		state.itemToToolCall.delete(params.item.id);
 		const output = fileChangeOutput(params.item.changes) || entry.output;
 		const success = params.item.status === 'completed';
 		const content = output ? [{ type: ToolResultContentType.Text as const, text: output }] : undefined;
@@ -674,7 +690,7 @@ export function mapItemCompleted(
 			success,
 			pastTenseMessage: success ? 'Applied file changes' : 'Failed to apply file changes',
 			content,
-			...(success ? {} : { error: { message: `Patch ${params.item.status}` } }),
+			...(success ? {} : { error: { message: `Patch ${params.item.status}`, ...(declined ? { code: 'denied' } : {}) } }),
 		};
 		return [{
 			type: ActionType.ChatToolCallComplete,
@@ -684,11 +700,6 @@ export function mapItemCompleted(
 		}];
 	}
 	if (params.item.type === 'mcpToolCall') {
-		const entry = state.itemToToolCall.get(params.item.id);
-		if (!entry) {
-			return [];
-		}
-		state.itemToToolCall.delete(params.item.id);
 		const success = params.item.status === 'completed' && !params.item.error;
 		const output = mcpToolOutput(params.item.result, params.item.error?.message) || entry.output;
 		const content = output ? [{ type: ToolResultContentType.Text as const, text: output }] : undefined;
@@ -700,16 +711,11 @@ export function mapItemCompleted(
 				success,
 				pastTenseMessage: success ? `Called ${entry.toolName}` : `Failed to call ${entry.toolName}`,
 				content,
-				...(success ? {} : { error: { message: params.item.error?.message ?? `MCP tool ${params.item.status}` } }),
+				...(success ? {} : { error: { message: params.item.error?.message ?? `MCP tool ${params.item.status}`, ...(declined ? { code: 'denied' } : {}) } }),
 			},
 		}];
 	}
 	if (params.item.type === 'dynamicToolCall') {
-		const entry = state.itemToToolCall.get(params.item.id);
-		if (!entry) {
-			return [];
-		}
-		state.itemToToolCall.delete(params.item.id);
 		const success = params.item.success === true || params.item.status === 'completed';
 		const output = dynamicToolOutput(params.item.contentItems) || entry.output;
 		const content = output ? [{ type: ToolResultContentType.Text as const, text: output }] : undefined;
@@ -722,7 +728,7 @@ export function mapItemCompleted(
 				success,
 				pastTenseMessage: serverPastTense ?? (success ? `Called ${entry.toolName}` : `Failed to call ${entry.toolName}`),
 				content,
-				...(success ? {} : { error: { message: `Dynamic tool ${params.item.status}` } }),
+				...(success ? {} : { error: { message: `Dynamic tool ${params.item.status}`, ...(declined ? { code: 'denied' } : {}) } }),
 			},
 		}];
 	}

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -23,7 +23,6 @@ import { INativeEnvironmentService } from '../../../environment/common/environme
 import { IFileService } from '../../../files/common/files.js';
 import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
 import { ILogService } from '../../../log/common/log.js';
-import { ITelemetryService } from '../../../telemetry/common/telemetry.js';
 import { AgentHostConfigKey, agentHostCustomizationConfigSchema } from '../../common/agentHostCustomizationConfig.js';
 import type { ChatInputRequestWithPlanReview, IAgentHostPlanReviewAction } from '../../common/agentHostPlanReview.js';
 import { AgentHostSandboxConfigKey, sandboxConfigSchema } from '../../common/sandboxConfigSchema.js';
@@ -32,7 +31,6 @@ import { AgentSignal, IMcpNotification, IRestoredSubagentSession } from '../../c
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
 import { toToolCallMeta, type IToolCallMeta, type IToolCallUiMeta } from '../../common/meta/agentToolCallMeta.js';
 import { OtelData, type OtelAttributeValue } from '../../common/otlp/otlpLogEmitter.js';
-import type { LanguageModelToolInvokedClassification, LanguageModelToolInvokedEvent } from '../../../telemetry/common/languageModelToolTelemetry.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { isAgentFeedbackAnnotationsAttachment, renderAgentFeedbackAnnotationsAttachment } from '../../common/meta/agentFeedbackAttachments.js';
 import { ISessionDatabase, ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../../common/sessionDataService.js';
@@ -434,7 +432,7 @@ export class CopilotAgentSession extends Disposable {
 
 	/** Tracks active tool invocations so we can produce past-tense messages on completion. */
 	/** Tracks active tool invocations so we can produce past-tense messages on completion. */
-	private readonly _activeToolCalls = new Map<string, { toolName: string; displayName: string; parameters: Record<string, unknown> | undefined; content: ToolResultContent[]; parentToolCallId: string | undefined; startTimeMs: number; mcpServerName: string | undefined; meta: IToolCallMeta | undefined }>();
+	private readonly _activeToolCalls = new Map<string, { toolName: string; displayName: string; parameters: Record<string, unknown> | undefined; content: ToolResultContent[]; parentToolCallId: string | undefined; mcpServerName: string | undefined; meta: IToolCallMeta | undefined }>();
 	/**
 	 * Maps a running subagent's `agentId` to its parent tool call id. Session-
 	 * scoped rather than per-turn: a subagent's lifetime is bounded by its
@@ -580,7 +578,6 @@ export class CopilotAgentSession extends Disposable {
 		@IFileService private readonly _fileService: IFileService,
 		@INativeEnvironmentService private readonly _environmentService: INativeEnvironmentService,
 		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
-		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
 		this.sessionId = options.rawSessionId;
@@ -795,30 +792,6 @@ export class CopilotAgentSession extends Disposable {
 			return path;
 		}
 		return join(this._workingDirectory.fsPath, path);
-	}
-
-	private _sendToolInvokedTelemetry(success: boolean, errorCode: string | undefined, toolCall: { readonly toolName: string; readonly startTimeMs: number; readonly mcpServerName: string | undefined }): void {
-		let result: LanguageModelToolInvokedEvent['result'];
-		if (success) {
-			result = 'success';
-		} else if (errorCode === 'rejected' || errorCode === 'denied' || errorCode === 'cancelled') {
-			result = 'userCancelled';
-		} else {
-			result = 'error';
-		}
-
-		const isClientTool = this._clientToolNames.has(toolCall.toolName);
-		const toolSourceKind = toolCall.mcpServerName ? 'mcp' : isClientTool ? 'client' : 'agentHost';
-		const invocationTimeMs = Date.now() - toolCall.startTimeMs;
-
-		this._telemetryService.publicLog2<LanguageModelToolInvokedEvent, LanguageModelToolInvokedClassification>('languageModelToolInvoked', {
-			result,
-			chatSessionId: this.sessionUri.toString(),
-			toolId: toolCall.toolName,
-			toolExtensionId: undefined,
-			toolSourceKind,
-			invocationTimeMs,
-		});
 	}
 
 	/**
@@ -2495,7 +2468,7 @@ export class CopilotAgentSession extends Disposable {
 				return;
 			}
 			const parentToolCallId = this._parentToolCallIdForSubagentEvent(e);
-			this._activeToolCalls.set(e.data.toolCallId, { toolName: e.data.toolName, displayName, parameters, content: [], parentToolCallId, startTimeMs: Date.now(), mcpServerName: e.data.mcpServerName, meta: undefined });
+			this._activeToolCalls.set(e.data.toolCallId, { toolName: e.data.toolName, displayName, parameters, content: [], parentToolCallId, mcpServerName: e.data.mcpServerName, meta: undefined });
 			if (isTaskCompleteTool(e.data.toolName)) {
 				const scope = parentToolCallId ?? '';
 				this._currentTurn?.markdownPartIds.delete(scope);
@@ -2635,7 +2608,6 @@ export class CopilotAgentSession extends Disposable {
 			const toolOutput = e.data.error?.message ?? e.data.result?.content;
 
 			if (isTaskCompleteTool(tracked.toolName)) {
-				this._sendToolInvokedTelemetry(e.data.success, e.data.error?.code, tracked);
 				const summary = getTaskCompleteMarkdown(tracked.parameters, toolOutput);
 				if (summary) {
 					this._emitAction({
@@ -2678,7 +2650,6 @@ export class CopilotAgentSession extends Disposable {
 				}
 			}
 
-			this._sendToolInvokedTelemetry(e.data.success, e.data.error?.code, tracked);
 			// eslint-disable-next-line local/code-no-untyped-meta-access -- Copilot SDK's own typed `_meta`, not the AHP protocol bag.
 			const resourceUri = e.data.toolDescription?._meta?.ui?.resourceUri;
 			let completeMeta: IToolCallMeta | undefined = tracked.meta;

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -431,7 +431,6 @@ export class CopilotAgentSession extends Disposable {
 	get workingDirectory(): URI | undefined { return this._workingDirectory; }
 
 	/** Tracks active tool invocations so we can produce past-tense messages on completion. */
-	/** Tracks active tool invocations so we can produce past-tense messages on completion. */
 	private readonly _activeToolCalls = new Map<string, { toolName: string; displayName: string; parameters: Record<string, unknown> | undefined; content: ToolResultContent[]; parentToolCallId: string | undefined; mcpServerName: string | undefined; meta: IToolCallMeta | undefined }>();
 	/**
 	 * Maps a running subagent's `agentId` to its parent tool call id. Session-

--- a/src/vs/platform/agentHost/test/node/agentHostToolCallTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostToolCallTelemetry.test.ts
@@ -37,6 +37,7 @@ class FakeChangesetService implements IAgentHostChangesetService {
 	computeListEntryChanges() { return undefined; }
 	refreshBranchChangeset(): void { }
 	refreshSessionChangeset(): void { }
+	refreshChangesetCatalog(): void { }
 	onWorkingDirectoryAvailable(): void { }
 	recomputeSubscribedChangesets(): void { }
 	onSessionDisposed(): void { }

--- a/src/vs/platform/agentHost/test/node/agentHostToolCallTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostToolCallTelemetry.test.ts
@@ -1,0 +1,264 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
+import { observableValue } from '../../../../base/common/observable.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { InstantiationService } from '../../../instantiation/common/instantiationService.js';
+import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
+import { ILogService, NullLogService } from '../../../log/common/log.js';
+import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
+import { AgentSession, IAgent } from '../../common/agentService.js';
+import { ActionType, type ChatAction } from '../../common/state/sessionActions.js';
+import { buildDefaultChatUri, MessageKind, SessionStatus, ToolCallContributorKind, type ToolCallContributor, type ToolCallResult } from '../../common/state/sessionState.js';
+import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
+import { AgentHostTelemetryService } from '../../node/agentHostTelemetryService.js';
+import { AgentConfigurationService, IAgentConfigurationService } from '../../node/agentConfigurationService.js';
+import { IAgentHostChangesetService } from '../../common/agentHostChangesetService.js';
+import { AgentSideEffects } from '../../node/agentSideEffects.js';
+import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
+import { createNullSessionDataService } from '../common/sessionTestHelpers.js';
+import { MockAgent } from './mockAgent.js';
+
+class FakeChangesetService implements IAgentHostChangesetService {
+	declare readonly _serviceBrand: undefined;
+	registerStaticChangesets(): void { }
+	restoreStaticChangeset(): void { }
+	parsePersistedStaticChangesets(): { session?: undefined } { return {}; }
+	applyPersistedStaticChangesets(): void { }
+	restorePersistedStaticChangesets(): { session?: undefined } { return {}; }
+	persistChangesSummary(): void { }
+	isStaticChangesetComputeActive(): boolean { return false; }
+	getListMetadataKeys() { return undefined; }
+	computeListEntryChanges() { return undefined; }
+	refreshBranchChangeset(): void { }
+	refreshSessionChangeset(): void { }
+	onWorkingDirectoryAvailable(): void { }
+	recomputeSubscribedChangesets(): void { }
+	onSessionDisposed(): void { }
+	async computeUncommittedChangeset(session: string): Promise<string> { return `${session}/changeset/uncommitted`; }
+	async computeTurnChangeset(session: string): Promise<string> { return `${session}/x`; }
+	async computeCompareTurnsChangeset(session: string): Promise<string> { return `${session}/y`; }
+	onToolCallEditsApplied(): void { }
+	onTurnComplete(): void { }
+	onSessionTruncated(): void { }
+}
+
+class CapturingTelemetryService implements ITelemetryService {
+	declare readonly _serviceBrand: undefined;
+	readonly telemetryLevel = TelemetryLevel.USAGE;
+	readonly sessionId = 'test-session';
+	readonly machineId = 'test-machine';
+	readonly sqmId = 'test-sqm';
+	readonly devDeviceId = 'test-dev-device';
+	readonly firstSessionDate = 'test-first-session-date';
+	readonly sendErrorTelemetry = false;
+	readonly events: { eventName: string; data: unknown }[] = [];
+
+	publicLog(): void { }
+	publicLog2(eventName: string, data?: unknown): void {
+		this.events.push({ eventName, data });
+	}
+	publicLogError(): void { }
+	publicLogError2(): void { }
+	setExperimentProperty(): void { }
+	setCommonProperty(): void { }
+}
+
+/**
+ * Integration tests covering the {@link AgentHostToolCallTracker} as it is
+ * driven through {@link AgentSideEffects}. These exercise the full wiring
+ * (tool-call start stamping, completion emission, dedup and the in-flight
+ * leak guard) so we cover both the tracker and its integration with the
+ * side-effect dispatch in one place.
+ */
+suite('AgentSideEffects — tool call telemetry', () => {
+
+	const disposables = new DisposableStore();
+	let stateManager: AgentHostStateManager;
+	let agent: MockAgent;
+	let sideEffects: AgentSideEffects;
+	let telemetry: CapturingTelemetryService;
+
+	const sessionUri = AgentSession.uri('mock', 'session-1');
+	const sessionKey = sessionUri.toString();
+	const defaultChatUri = buildDefaultChatUri(sessionUri);
+
+	function setupSession(): void {
+		stateManager.createSession({
+			resource: sessionKey,
+			provider: 'mock',
+			title: 'Test',
+			status: SessionStatus.Idle,
+			createdAt: new Date().toISOString(),
+			modifiedAt: new Date().toISOString(),
+		});
+		stateManager.dispatchServerAction(sessionKey, { type: ActionType.SessionReady });
+	}
+
+	function startTurn(turnId: string, text = 'hello'): void {
+		const action: ChatAction = {
+			type: ActionType.ChatTurnStarted,
+			turnId,
+			message: { text, origin: { kind: MessageKind.User } },
+		};
+		stateManager.dispatchClientAction(defaultChatUri, action, { clientId: 'test', clientSeq: 1 });
+		sideEffects.handleAction(defaultChatUri, action);
+	}
+
+	function fire(action: ChatAction): void {
+		agent.fireProgress({ kind: 'action', resource: URI.parse(defaultChatUri), action });
+	}
+
+	function toolStart(turnId: string, toolCallId: string, toolName: string, contributor?: ToolCallContributor): void {
+		fire({ type: ActionType.ChatToolCallStart, turnId, toolCallId, toolName, displayName: toolName, contributor });
+	}
+
+	function toolComplete(turnId: string, toolCallId: string, result: ToolCallResult): void {
+		fire({ type: ActionType.ChatToolCallComplete, turnId, toolCallId, result });
+	}
+
+	function toolEvents(): { eventName: string; data: Record<string, unknown> }[] {
+		return telemetry.events
+			.filter(e => e.eventName === 'languageModelToolInvoked')
+			.map(e => {
+				const data = e.data as Record<string, unknown>;
+				return {
+					eventName: e.eventName,
+					data: { ...data, invocationTimeMs: typeof data.invocationTimeMs === 'number' && data.invocationTimeMs >= 0 },
+				};
+			});
+	}
+
+	setup(() => {
+		agent = new MockAgent();
+		disposables.add(toDisposable(() => agent.dispose()));
+		stateManager = disposables.add(new AgentHostStateManager(new NullLogService()));
+		const agentList = observableValue<readonly IAgent[]>('agents', [agent]);
+		telemetry = new CapturingTelemetryService();
+
+		const logService = new NullLogService();
+		const configService = disposables.add(new AgentConfigurationService(stateManager, logService));
+		const telemetryService = disposables.add(new AgentHostTelemetryService(telemetry));
+		const instantiationService = disposables.add(new InstantiationService(new ServiceCollection(
+			[ILogService, logService],
+			[IAgentConfigurationService, configService],
+			[IAgentHostChangesetService, new FakeChangesetService()],
+			[IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE],
+			[ITelemetryService, telemetryService],
+		), /*strict*/ true));
+		sideEffects = disposables.add(instantiationService.createInstance(AgentSideEffects, stateManager, {
+			getAgent: () => agent,
+			agents: agentList,
+			sessionDataService: createNullSessionDataService(),
+			onTurnComplete: () => { },
+		}));
+		disposables.add(sideEffects.registerProgressListener(agent));
+	});
+
+	teardown(() => {
+		disposables.clear();
+	});
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('emits a successful agent-host tool invocation', () => {
+		setupSession();
+		startTurn('turn-1');
+
+		toolStart('turn-1', 'tc-1', 'bash');
+		toolComplete('turn-1', 'tc-1', { success: true, pastTenseMessage: 'ran' });
+
+		assert.deepStrictEqual(toolEvents(), [{
+			eventName: 'languageModelToolInvoked',
+			data: {
+				result: 'success',
+				chatSessionId: sessionKey,
+				toolId: 'bash',
+				toolExtensionId: undefined,
+				toolSourceKind: 'agentHost',
+				provider: 'mock',
+				invocationTimeMs: true,
+			},
+		}]);
+	});
+
+	test('emits userCancelled with mcp source kind for a denied mcp tool', () => {
+		setupSession();
+		startTurn('turn-1');
+
+		toolStart('turn-1', 'tc-mcp', 'lookup', { kind: ToolCallContributorKind.MCP, customizationId: 'c1' });
+		toolComplete('turn-1', 'tc-mcp', { success: false, pastTenseMessage: 'denied', error: { message: 'denied', code: 'denied' } });
+
+		assert.deepStrictEqual(toolEvents(), [{
+			eventName: 'languageModelToolInvoked',
+			data: {
+				result: 'userCancelled',
+				chatSessionId: sessionKey,
+				toolId: 'lookup',
+				toolExtensionId: undefined,
+				toolSourceKind: 'mcp',
+				provider: 'mock',
+				invocationTimeMs: true,
+			},
+		}]);
+	});
+
+	test('emits client source kind for a client-contributed tool', () => {
+		setupSession();
+		startTurn('turn-1');
+
+		toolStart('turn-1', 'tc-client', 'run_tests', { kind: ToolCallContributorKind.Client, clientId: 'client-1' });
+		toolComplete('turn-1', 'tc-client', { success: true, pastTenseMessage: 'ran tests' });
+
+		assert.deepStrictEqual(toolEvents(), [{
+			eventName: 'languageModelToolInvoked',
+			data: {
+				result: 'success',
+				chatSessionId: sessionKey,
+				toolId: 'run_tests',
+				toolExtensionId: undefined,
+				toolSourceKind: 'client',
+				provider: 'mock',
+				invocationTimeMs: true,
+			},
+		}]);
+	});
+
+	test('emits error for a failure without a cancellation code', () => {
+		setupSession();
+		startTurn('turn-1');
+
+		toolStart('turn-1', 'tc-err', 'bash');
+		toolComplete('turn-1', 'tc-err', { success: false, pastTenseMessage: 'boom', error: { message: 'boom' } });
+
+		assert.strictEqual(toolEvents()[0].data.result, 'error');
+	});
+
+	test('emits a single event when a tool completion is duplicated', () => {
+		setupSession();
+		startTurn('turn-1');
+
+		toolStart('turn-1', 'tc-dup', 'bash');
+		toolComplete('turn-1', 'tc-dup', { success: true, pastTenseMessage: 'ran' });
+		toolComplete('turn-1', 'tc-dup', { success: true, pastTenseMessage: 'ran' });
+
+		assert.strictEqual(toolEvents().length, 1);
+	});
+
+	test('drops an in-flight tool call when the turn is cancelled before completion', () => {
+		setupSession();
+		startTurn('turn-1');
+
+		toolStart('turn-1', 'tc-inflight', 'bash');
+		fire({ type: ActionType.ChatTurnCancelled, turnId: 'turn-1' });
+		// A late completion after the turn ended must not emit: the start entry
+		// was cleared, so there is no timing to report.
+		toolComplete('turn-1', 'tc-inflight', { success: true, pastTenseMessage: 'ran' });
+
+		assert.strictEqual(toolEvents().length, 0);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentHostToolCallTracker.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostToolCallTracker.test.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { ToolCallContributorKind, type ToolCallContributor, type ToolCallResult } from '../../common/state/sessionState.js';
+import { deriveToolInvokedResult, toolSourceKindFromContributor } from '../../node/agentHostToolCallTracker.js';
+
+function result(success: boolean, code?: string): ToolCallResult {
+	return {
+		success,
+		pastTenseMessage: 'done',
+		error: code !== undefined || !success ? { message: 'failed', code } : undefined,
+	};
+}
+
+suite('agentHostToolCallTracker', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('deriveToolInvokedResult maps success/cancel/error buckets', () => {
+		const actual = {
+			success: deriveToolInvokedResult(result(true)),
+			denied: deriveToolInvokedResult(result(false, 'denied')),
+			rejected: deriveToolInvokedResult(result(false, 'rejected')),
+			cancelled: deriveToolInvokedResult(result(false, 'cancelled')),
+			otherCode: deriveToolInvokedResult(result(false, 'timeout')),
+			noCode: deriveToolInvokedResult(result(false)),
+		};
+		assert.deepStrictEqual(actual, {
+			success: 'success',
+			denied: 'userCancelled',
+			rejected: 'userCancelled',
+			cancelled: 'userCancelled',
+			otherCode: 'error',
+			noCode: 'error',
+		});
+	});
+
+	test('toolSourceKindFromContributor maps contributor kind', () => {
+		const mcp: ToolCallContributor = { kind: ToolCallContributorKind.MCP, customizationId: 'c1' };
+		const client: ToolCallContributor = { kind: ToolCallContributorKind.Client, clientId: 'x' };
+		const actual = {
+			none: toolSourceKindFromContributor(undefined),
+			mcp: toolSourceKindFromContributor(mcp),
+			client: toolSourceKindFromContributor(client),
+		};
+		assert.deepStrictEqual(actual, {
+			none: 'agentHost',
+			mcp: 'mcp',
+			client: 'client',
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/claudeMapSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeMapSessionEvents.test.ts
@@ -12,6 +12,7 @@ import { ActionType } from '../../common/state/sessionActions.js';
 import { ResponsePartKind, ToolResultContentType } from '../../common/state/sessionState.js';
 import { ToolCallConfirmationReason, ToolCallContributorKind } from '../../common/state/protocol/state.js';
 import { ClaudeMapperState, mapSDKMessageToAgentSignals } from '../../node/claude/claudeMapSessionEvents.js';
+import { CLAUDE_USER_DECLINED_MESSAGE } from '../../node/claude/claudeToolDenial.js';
 import { encodeForwardedChatError, PROXY_ERROR_PREFIX } from '../../node/shared/forwardedChatError.js';
 import { SubagentRegistry } from '../../node/claude/claudeSubagentRegistry.js';
 import {
@@ -271,6 +272,31 @@ suite('claudeMapSessionEvents — direct mapper tests', () => {
 		assert.deepStrictEqual(log.warns, []);
 	});
 
+	test('Test 10b — a tool denied by the user maps to result.error.code = denied', () => {
+		const log = new NullLogService();
+		const state = new ClaudeMapperState();
+		const resolver = r();
+
+		mapSDKMessageToAgentSignals(makeStreamEvent(SESSION_ID, makeContentBlockStartToolUse(0, 'tu_d', 'Bash')), SESSION, TURN_ID, state, log, resolver);
+		mapSDKMessageToAgentSignals(makeStreamEvent(SESSION_ID, makeContentBlockStop(0)), SESSION, TURN_ID, state, log, resolver);
+
+		const signals = mapSDKMessageToAgentSignals(
+			makeUserToolResultMessage(SESSION_ID, 'tu_d', CLAUDE_USER_DECLINED_MESSAGE, { isError: true }),
+			SESSION,
+			TURN_ID,
+			state,
+			log,
+			r(),
+		);
+
+		const signal = signals[0];
+		if (signal.kind !== 'action' || signal.action.type !== ActionType.ChatToolCallComplete) {
+			throw new Error(`expected a ChatToolCallComplete action, got ${signal.kind}`);
+		}
+		assert.strictEqual(signal.action.result.success, false);
+		assert.deepStrictEqual(signal.action.result.error, { message: CLAUDE_USER_DECLINED_MESSAGE, code: 'denied' });
+	});
+
 	test('Test 9 — input_json_delta emits ChatToolCallDelta scoped to the open tool_use block', () => {
 		const log = new NullLogService();
 		const state = new ClaudeMapperState();
@@ -409,6 +435,10 @@ suite('claudeMapSessionEvents — direct mapper tests', () => {
 		const complete = signals[0];
 		assert.ok(complete.kind === 'action' && complete.action.type === ActionType.ChatToolCallComplete);
 		assert.strictEqual(complete.action.result.success, false);
+		// A genuine failure whose message is not one of the known deny strings
+		// must NOT be classified as a cancellation: no `error.code` is set, so
+		// telemetry reports `error` rather than `userCancelled`.
+		assert.strictEqual(complete.action.result.error?.code, undefined);
 	});
 
 	test('tool_result content as TextBlock array unwraps to ToolResultTextContent[]', () => {

--- a/src/vs/platform/agentHost/test/node/claudeToolDenial.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeToolDenial.test.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import {
+	CLAUDE_PLAN_DECLINED_MESSAGE,
+	CLAUDE_QUESTION_CANCELLED_MESSAGE,
+	CLAUDE_USER_DECLINED_MESSAGE,
+	claudeToolDenialCode,
+} from '../../node/claude/claudeToolDenial.js';
+
+suite('claudeToolDenial', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('claudeToolDenialCode classifies every known deny message and nothing else', () => {
+		// Each known deny `message` returned from `canUseTool` maps to its
+		// cancellation code; any other (genuine tool-error) message stays
+		// unclassified so telemetry reports `error` rather than `userCancelled`.
+		const classified = {
+			userDeclined: claudeToolDenialCode(CLAUDE_USER_DECLINED_MESSAGE),
+			planDeclined: claudeToolDenialCode(CLAUDE_PLAN_DECLINED_MESSAGE),
+			questionCancelled: claudeToolDenialCode(CLAUDE_QUESTION_CANCELLED_MESSAGE),
+			genuineError: claudeToolDenialCode('permission denied'),
+			empty: claudeToolDenialCode(''),
+		};
+		assert.deepStrictEqual(classified, {
+			userDeclined: 'denied',
+			planDeclined: 'denied',
+			questionCancelled: 'cancelled',
+			genuineError: undefined,
+			empty: undefined,
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/codex/codexMapAppServerEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexMapAppServerEvents.test.ts
@@ -394,6 +394,114 @@ suite('codexMapAppServerEvents', () => {
 		});
 	});
 
+	test('mcpToolCall start carries an MCP contributor when the server has a customization', () => {
+		const state = createCodexSessionMapState();
+		state.mcpCustomizationIds.set('github', 'cust-gh');
+		const startActions = mapItemStarted(state, {
+			item: {
+				type: 'mcpToolCall', id: 'mcp_c', server: 'github', tool: 'search',
+				status: 'inProgress', arguments: {}, mcpAppResourceUri: undefined,
+				pluginId: null, result: null, error: null, durationMs: null,
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0,
+		});
+		const start = startActions[0];
+		if (start.type !== ActionType.ChatToolCallStart) {
+			throw new Error('expected a ChatToolCallStart action');
+		}
+		assert.deepStrictEqual(start.contributor, { kind: ToolCallContributorKind.MCP, customizationId: 'cust-gh' });
+	});
+
+	test('mcpToolCall start carries no contributor when the server has no customization', () => {
+		const state = createCodexSessionMapState();
+		// mcpCustomizationIds is empty: the agent has not applied an MCP
+		// inventory yet, so the start must not stamp a (bogus) MCP contributor —
+		// the tool then reports the default `agentHost` source.
+		const startActions = mapItemStarted(state, {
+			item: {
+				type: 'mcpToolCall', id: 'mcp_n', server: 'github', tool: 'search',
+				status: 'inProgress', arguments: {}, mcpAppResourceUri: undefined,
+				pluginId: null, result: null, error: null, durationMs: null,
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0,
+		});
+		const start = startActions[0];
+		if (start.type !== ActionType.ChatToolCallStart) {
+			throw new Error('expected a ChatToolCallStart action');
+		}
+		assert.strictEqual(start.contributor, undefined);
+	});
+
+	test('a host-declined commandExecution reports result.error.code = denied', () => {
+		const state = createCodexSessionMapState();
+		mapItemStarted(state, {
+			item: {
+				type: 'commandExecution', id: 'cmd_d',
+				command: 'rm file', cwd: '/tmp', processId: null,
+				source: 'agent' as never, status: 'inProgress' as never,
+				commandActions: [], aggregatedOutput: null,
+				exitCode: null, durationMs: null,
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0,
+		});
+		const entry = state.itemToToolCall.get('cmd_d');
+		if (!entry) {
+			throw new Error('expected a tracked tool call');
+		}
+		// The host declined the approval (recorded by respondToPermissionRequest).
+		state.declinedToolCalls.add(entry.toolCallId);
+		const actions = mapItemCompleted(state, {
+			item: {
+				type: 'commandExecution', id: 'cmd_d',
+				command: 'rm file', cwd: '/tmp', processId: null,
+				source: 'agent' as never, status: 'failed' as never,
+				commandActions: [], aggregatedOutput: null,
+				exitCode: null, durationMs: 1,
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', completedAtMs: 0,
+		});
+		const complete = actions[0];
+		if (complete.type !== ActionType.ChatToolCallComplete) {
+			throw new Error('expected a ChatToolCallComplete action');
+		}
+		assert.strictEqual(complete.result.success, false);
+		assert.strictEqual(complete.result.error?.code, 'denied');
+	});
+
+	test('a host-declined mcpToolCall reports result.error.code = denied', () => {
+		const state = createCodexSessionMapState();
+		mapItemStarted(state, {
+			item: {
+				type: 'mcpToolCall', id: 'mcp_d', server: 'github', tool: 'search',
+				status: 'inProgress', arguments: {}, mcpAppResourceUri: undefined,
+				pluginId: null, result: null, error: null, durationMs: null,
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', startedAtMs: 0,
+		});
+		const entry = state.itemToToolCall.get('mcp_d');
+		if (!entry) {
+			throw new Error('expected a tracked tool call');
+		}
+		// The host declined the approval (recorded by respondToPermissionRequest).
+		// The decline is drained once in the shared completion prologue, so a
+		// non-command tool type is classified as a denial just like a command.
+		state.declinedToolCalls.add(entry.toolCallId);
+		const actions = mapItemCompleted(state, {
+			item: {
+				type: 'mcpToolCall', id: 'mcp_d', server: 'github', tool: 'search',
+				status: 'failed', arguments: {}, mcpAppResourceUri: undefined,
+				pluginId: null, result: null, error: null, durationMs: 1,
+			} as never,
+			threadId: 'thr_1', turnId: 'turn_a', completedAtMs: 0,
+		});
+		const complete = actions[0];
+		if (complete.type !== ActionType.ChatToolCallComplete) {
+			throw new Error('expected a ChatToolCallComplete action');
+		}
+		assert.strictEqual(complete.result.success, false);
+		assert.strictEqual(complete.result.error?.code, 'denied');
+	});
+
 	test('dynamicToolCall item carries a Client contributor when a client owns the tool', () => {
 		const toolSet = new ActiveClientToolSet();
 		toolSet.set('win-7', [{ name: 'get_magic_word' }]);
@@ -556,12 +664,14 @@ suite('codexMapAppServerEvents', () => {
 		state.itemToPartId.set('i1', 'p1');
 		state.itemToToolCall.set('i2', { toolCallId: 'tc', turnId: 'turn_a', toolName: 'shell', output: '' });
 		state.itemToReasoningPartId.set('i3', 'r1');
+		state.declinedToolCalls.add('tc-stale');
 		resetCodexTurnMapState(state);
 		assert.deepStrictEqual({
 			currentTurnId: state.currentTurnId,
 			parts: state.itemToPartId.size,
 			toolCalls: state.itemToToolCall.size,
 			reasoning: state.itemToReasoningPartId.size,
-		}, { currentTurnId: 'turn_a', parts: 0, toolCalls: 0, reasoning: 0 });
+			declined: state.declinedToolCalls.size,
+		}, { currentTurnId: 'turn_a', parts: 0, toolCalls: 0, reasoning: 0, declined: 0 });
 	});
 });

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -17,8 +17,7 @@ import { IFileService } from '../../../files/common/files.js';
 import { InstantiationService } from '../../../instantiation/common/instantiationService.js';
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
 import { ILogService, NullLogService } from '../../../log/common/log.js';
-import type { ClassifiedEvent, IGDPRProperty, OmitMetadata, StrictPropertyCheck } from '../../../telemetry/common/gdprTypings.js';
-import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
+import { ITelemetryService } from '../../../telemetry/common/telemetry.js';
 import { NullTelemetryServiceShape } from '../../../telemetry/common/telemetryUtils.js';
 import { AgentSession, type AgentSignal, type IAgentActionSignal, type IAgentToolPendingConfirmationSignal } from '../../common/agentService.js';
 import type { ChatInputRequestWithPlanReview } from '../../common/agentHostPlanReview.js';
@@ -191,32 +190,6 @@ class CapturingLogService extends NullLogService {
 		this.warnings.push({ message, args });
 		super.warn(message, ...args);
 	}
-}
-
-class RecordingTelemetryService implements ITelemetryService {
-	declare readonly _serviceBrand: undefined;
-	readonly telemetryLevel = TelemetryLevel.NONE;
-	readonly sessionId = 'someValue.sessionId';
-	readonly machineId = 'someValue.machineId';
-	readonly sqmId = 'someValue.sqmId';
-	readonly devDeviceId = 'someValue.devDeviceId';
-	readonly firstSessionDate = 'someValue.firstSessionDate';
-	readonly sendErrorTelemetry = false;
-	readonly events: Array<{ eventName: string; data: unknown }> = [];
-
-	publicLog(): void { }
-
-	publicLog2<E extends ClassifiedEvent<OmitMetadata<T>> = never, T extends IGDPRProperty = never>(eventName: string, data?: StrictPropertyCheck<T, E>): void {
-		this.events.push({ eventName, data });
-	}
-
-	publicLogError(): void { }
-
-	publicLogError2(): void { }
-
-	setExperimentProperty(): void { }
-
-	setCommonProperty(): void { }
 }
 
 // ---- Helpers ----------------------------------------------------------------
@@ -2274,125 +2247,6 @@ suite('CopilotAgentSession', () => {
 				assert.ok(!pastStr.includes('cd /repo/project'), `past-tense message should not contain stripped prefix, got: ${pastStr}`);
 				assert.ok(pastStr.includes('npm test'), `past-tense message should contain the rewritten command, got: ${pastStr}`);
 			}
-		});
-
-		test('live tool_complete emits languageModelToolInvoked telemetry', async () => {
-			const telemetryService = new RecordingTelemetryService();
-			const { mockSession } = await createAgentSession(disposables, { telemetryService });
-
-			mockSession.fire('tool.execution_start', {
-				toolCallId: 'tc-bash-telemetry',
-				toolName: 'bash',
-				arguments: { command: 'npm test' },
-			} as SessionEventPayload<'tool.execution_start'>['data']);
-			mockSession.fire('tool.execution_complete', {
-				toolCallId: 'tc-bash-telemetry',
-				success: true,
-				result: { content: 'passed' },
-			} as SessionEventPayload<'tool.execution_complete'>['data']);
-
-			mockSession.fire('tool.execution_start', {
-				toolCallId: 'tc-mcp-telemetry',
-				toolName: 'mcp_tool',
-				arguments: {},
-				mcpServerName: 'test-server',
-				mcpToolName: 'lookup',
-			} as SessionEventPayload<'tool.execution_start'>['data']);
-			mockSession.fire('tool.execution_complete', {
-				toolCallId: 'tc-mcp-telemetry',
-				success: false,
-				error: { code: 'denied', message: 'denied' },
-			} as SessionEventPayload<'tool.execution_complete'>['data']);
-
-			const normalizedEvents = telemetryService.events.map(event => {
-				const data = event.data as {
-					result: string;
-					chatSessionId: string | undefined;
-					toolId: string;
-					toolExtensionId: string | undefined;
-					toolSourceKind: string;
-					invocationTimeMs?: number;
-				};
-				return {
-					eventName: event.eventName,
-					data: {
-						...data,
-						invocationTimeMs: typeof data.invocationTimeMs === 'number' && data.invocationTimeMs >= 0,
-					},
-				};
-			});
-
-			assert.deepStrictEqual(normalizedEvents, [
-				{
-					eventName: 'languageModelToolInvoked',
-					data: {
-						result: 'success',
-						chatSessionId: AgentSession.uri('copilot', 'test-session-1').toString(),
-						toolId: 'bash',
-						toolExtensionId: undefined,
-						toolSourceKind: 'agentHost',
-						invocationTimeMs: true,
-					},
-				},
-				{
-					eventName: 'languageModelToolInvoked',
-					data: {
-						result: 'userCancelled',
-						chatSessionId: AgentSession.uri('copilot', 'test-session-1').toString(),
-						toolId: 'mcp_tool',
-						toolExtensionId: undefined,
-						toolSourceKind: 'mcp',
-						invocationTimeMs: true,
-					},
-				},
-			]);
-		});
-
-		test('client tool telemetry does not use clientId as toolExtensionId', async () => {
-			const telemetryService = new RecordingTelemetryService();
-			const tools = [{ name: 'my_tool', description: 'A test tool', inputSchema: { type: 'object', properties: {} } }] as const;
-			const activeClientToolSet = new ActiveClientToolSet();
-			activeClientToolSet.set('test-client', tools);
-			const { mockSession } = await createAgentSession(disposables, {
-				telemetryService,
-				clientSnapshot: {
-					tools,
-					plugins: [],
-					mcpServers: {},
-				},
-				activeClientToolSet,
-			});
-
-			mockSession.fire('tool.execution_start', {
-				toolCallId: 'tc-client-telemetry',
-				toolName: 'my_tool',
-				arguments: {},
-			} as SessionEventPayload<'tool.execution_start'>['data']);
-			mockSession.fire('tool.execution_complete', {
-				toolCallId: 'tc-client-telemetry',
-				success: true,
-				result: { content: 'done' },
-			} as SessionEventPayload<'tool.execution_complete'>['data']);
-
-			const [event] = telemetryService.events;
-			assert.deepStrictEqual({
-				eventName: event.eventName,
-				data: {
-					...(event.data as object),
-					invocationTimeMs: typeof (event.data as { invocationTimeMs?: number }).invocationTimeMs === 'number',
-				},
-			}, {
-				eventName: 'languageModelToolInvoked',
-				data: {
-					result: 'success',
-					chatSessionId: AgentSession.uri('copilot', 'test-session-1').toString(),
-					toolId: 'my_tool',
-					toolExtensionId: undefined,
-					toolSourceKind: 'client',
-					invocationTimeMs: true,
-				},
-			});
-
 		});
 
 		test('live task_complete emits root markdown instead of a tool call', async () => {

--- a/src/vs/platform/telemetry/common/languageModelToolTelemetry.ts
+++ b/src/vs/platform/telemetry/common/languageModelToolTelemetry.ts
@@ -21,12 +21,14 @@ export type LanguageModelToolInvokedEvent = LanguageModelToolTelemetryData & {
 	result: 'success' | 'error' | 'userCancelled';
 	prepareTimeMs?: number;
 	invocationTimeMs?: number;
+	provider?: string;
 };
 
 export type LanguageModelToolInvokedClassification = LanguageModelToolTelemetryClassification & {
 	result: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether invoking the LanguageModelTool resulted in an error.' };
 	prepareTimeMs?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Time spent in prepareToolInvocation method in milliseconds.' };
 	invocationTimeMs?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Time spent in tool invoke method in milliseconds.' };
+	provider?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The agent host provider that invoked the tool (e.g. copilot, claude, codex), if applicable.' };
 	owner: 'roblourens';
 	comment: 'Provides insight into the usage of language model tools.';
 };

--- a/src/vs/platform/telemetry/common/languageModelToolTelemetry.ts
+++ b/src/vs/platform/telemetry/common/languageModelToolTelemetry.ts
@@ -28,7 +28,7 @@ export type LanguageModelToolInvokedClassification = LanguageModelToolTelemetryC
 	result: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether invoking the LanguageModelTool resulted in an error.' };
 	prepareTimeMs?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Time spent in prepareToolInvocation method in milliseconds.' };
 	invocationTimeMs?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Time spent in tool invoke method in milliseconds.' };
-	provider?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The agent host provider that invoked the tool (e.g. copilot, claude, codex), if applicable.' };
+	provider?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The agent host provider that invoked the tool (e.g. copilotcli, claude, codex), if applicable.' };
 	owner: 'roblourens';
 	comment: 'Provides insight into the usage of language model tools.';
 };


### PR DESCRIPTION
## What

Makes the `languageModelToolInvoked` telemetry event both **functional** (it fires at all) and **accurate** (correct field values) for the Claude and Codex agent hosts.

1. **Functional** — centralizes the event in the agent-host layer so **all** providers (Copilot CLI, Claude, Codex) emit per-tool telemetry, and adds an optional `provider` field to distinguish them.
2. **Accurate** — fixes the Claude/Codex event mappers so MCP tools report `toolSourceKind: mcp` (not `agentHost`) and a user-denied tool reports `result: userCancelled` (not `error`).

## Why

The event was emitted only by `CopilotAgentSession`. The Claude and Codex agent-host sessions didn't import `ITelemetryService` and emitted **~0** tool events — the single biggest telemetry parity gap for the agent host (no per-tool volume, error rate, or invocation latency for those providers).

Once the event fired for every provider, two fields were still wrong for Claude/Codex: every MCP tool was attributed to the agent host itself, and every user cancellation was indistinguishable from a genuine tool error.

## Approach

### Functional: centralized emission

Lift the emission into the provider-agnostic `AgentSideEffects` layer, which already processes `ChatToolCallComplete` actions for every provider. Mirrors the existing `AgentHostTurnTracker` + `AgentHostTelemetryReporter` seam.

- **`AgentHostToolCallTracker`** (new) — stamps the tool start (only the start action carries tool name + contributor), emits on `ChatToolCallComplete`, computes `invocationTimeMs` via a high-resolution `StopWatch` (`performance.now`, matching the workbench emitter), with a dedup guard and per-session leak guards (turn end / cancel / error / subagent teardown / dispose). Result and `toolSourceKind` derivation are extracted into pure, unit-testable helpers.
- **`AgentHostTelemetryReporter.toolInvoked`** — emits the event with `provider` and a chat-channel→session normalized `chatSessionId` (matching the value `CopilotAgentSession` emitted before).
- **`CopilotAgentSession`** — removed the now-duplicate emission and the now-unused `ITelemetryService` dependency / `startTimeMs` tracking.
- `provider` is **optional** on the shared event type, so the in-editor workbench emitter (`languageModelToolsService`) is unaffected (its events simply have no `provider`).

### Accurate: Claude/Codex mapper fixes

Both fields are derived from the tool-call signal, so the fix lives in the provider mappers — the central `deriveToolInvokedResult` / `toolSourceKindFromContributor` helpers already key off both.

- **`toolSourceKind: mcp`** — stamp a `ToolCallContributorKind.MCP` contributor on the tool-call start. Codex carries a per-session server→customizationId map on its map state, populated by the agent whenever it applies the MCP inventory (not only at session-customization time, which raced the async inventory discovery). Claude enriches `ChatToolCallStart` signals for `mcp__` tools using the session's last customizations, keeping the MCP lookup out of the mapper.
- **`result: userCancelled`** — a denied tool now carries `error.code` so the central derivation maps it to `userCancelled` instead of `error`. Codex records the tool-call ids the host declined and drains them once in a shared completion prologue, so every tool type (command, file change, MCP, dynamic, web search) is classified uniformly. Claude classifies the `is_error` deny message via a new standalone `claudeToolDenial` helper (also breaks an import cycle and is exhaustively unit-tested); a genuine tool error keeps no code.

## Verification

- `npm run typecheck-client`, `npm run valid-layers-check` — clean.
- Unit + integration tests pass — pure-function derivation tests, `AgentSideEffects` integration tests (success / userCancelled / mcp / client / error, dedup, in-flight leak guard), and direct mapper tests for the new branches plus negative guards (no contributor without a customization; a non-deny error keeps no `code`; per-turn decline cleanup).
- **Verified live** in the Agents window across all three providers and both accuracy fixes, confirmed in the agent-host telemetry log:

  | provider | scenario | toolId | result | toolSourceKind |
  |---|---|---|---|---|
  | `copilotcli` | tool run | bash | success | agentHost |
  | `claude` | tool run | Bash | success | agentHost |
  | `codex` | tool run | shell | success | agentHost |
  | `claude` | MCP tool | _(server tool)_ | success | **mcp** |
  | `codex` | MCP tool | _(server tool)_ | success | **mcp** |
  | `claude` | **denied** tool | Write | **userCancelled** | agentHost |
  | `codex` | **denied** tool | shell | **userCancelled** | agentHost |

  Both denial runs also confirmed the deny path genuinely blocks execution (the target file/dir was never created). `invocationTimeMs` is high-resolution (`performance.now`); fast tools such as Codex's `echo` complete in well under a millisecond (a low-res `Date.now` clock floored this to `0`).

## Notes

- The Copilot CLI provider string is **`copilotcli`** (the `agent.id` for `agent-host-copilotcli`), not `copilot` — relevant for any dashboard query.
- **Behavioral divergences vs. copilot's old emission** (for @roblourens sign-off): the hidden `task_complete` pseudo-tool is no longer counted (it emits no `ChatToolCall*` actions); the "no client connected" fast-fail now emits one `error` event. Both arguably more correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
