### PR TITLE
fix: make sure register handler when ipc emitter add listener

### DIFF
--- a/src/vs/base/parts/ipc/common/ipc.ts
+++ b/src/vs/base/parts/ipc/common/ipc.ts
@@ -680,6 +680,8 @@ export class ChannelClient implements IChannelClient, IDisposable {
 
 		const emitter = new Emitter<any>({
 			onWillAddFirstListener: () => {
+				const handler: IHandler = (res: IRawResponse) => emitter.fire((res as IRawEventFireResponse).data);
+				this.handlers.set(id, handler);
 				const doRequest = () => {
 					this.activeRequests.add(emitter);
 					this.sendRequest(request);
@@ -705,9 +707,6 @@ export class ChannelClient implements IChannelClient, IDisposable {
 				this.handlers.delete(id);
 			}
 		});
-
-		const handler: IHandler = (res: IRawResponse) => emitter.fire((res as IRawEventFireResponse).data);
-		this.handlers.set(id, handler);
 
 		return emitter.event;
 	}

--- a/src/vs/base/parts/ipc/test/common/ipc.test.ts
+++ b/src/vs/base/parts/ipc/test/common/ipc.test.ts
@@ -320,6 +320,27 @@ suite('Base IPC', function () {
 			assert.deepStrictEqual(messages, ['hello', 'world']);
 		});
 
+		test('listen to events (resubscribe)', async function () {
+			const onPong = ipcService.onPong;
+			const messages: string[] = [];
+
+			const disposable1 = onPong(msg => messages.push(msg));
+			await timeout(0);
+			assert.deepStrictEqual(messages, []);
+			service.ping('hello');
+			await timeout(0);
+			assert.deepStrictEqual(messages, ['hello']);
+			disposable1.dispose();
+
+			const disposable2 = onPong(msg => (messages as string[]).push(msg));
+			await timeout(0);
+			assert.deepStrictEqual(messages, ['hello']);
+			service.ping('world');
+			await timeout(0);
+			assert.deepStrictEqual(messages, ['hello', 'world']);
+			disposable2.dispose();
+		});
+
 		test('buffers in arrays', async function () {
 			const r = await ipcService.buffersLength([VSBuffer.alloc(2), VSBuffer.alloc(3)]);
 			return assert.strictEqual(r, 5);
@@ -441,6 +462,27 @@ suite('Base IPC', function () {
 			await timeout(0);
 
 			assert.deepStrictEqual(messages, ['hello', 'world']);
+		});
+
+		test('listen to events (resubscribe)', async function () {
+			const onPong = ipcService.onPong;
+			const messages: string[] = [];
+
+			const disposable1 = onPong(msg => messages.push(msg));
+			await timeout(0);
+			assert.deepStrictEqual(messages, []);
+			service.ping('hello');
+			await timeout(0);
+			assert.deepStrictEqual(messages, ['hello']);
+			disposable1.dispose();
+
+			const disposable2 = onPong(msg => (messages as string[]).push(msg));
+			await timeout(0);
+			assert.deepStrictEqual(messages, ['hello']);
+			service.ping('world');
+			await timeout(0);
+			assert.deepStrictEqual(messages, ['hello', 'world']);
+			disposable2.dispose();
 		});
 
 		test('marshalling uri', async function () {


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode/issues/324678

When the last listener is disposed, we will remove the handler from the map. However, we will not add the handler back to the map when re-subscribing to the emitter, so the event will not be emitted anymore. It is better register handler in `onWillAddFirstListener` and delete it in `onDidRemoveLastListener`.

example.
```
const emitter = client.listen('hello');
const dispose1 = emitter(() => {);
dispose1.dispose();
// can not receive any messages.
const dispose2 = emitter(() => {);
