### PR TITLE
Fix three typos in source comments

### DIFF
--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3130,7 +3130,7 @@ export class ChatResponseMarkdownPart {
 
 /**
  * TODO if 'vulnerabilities' is finalized, this should be merged with the base ChatResponseMarkdownPart. I just don't see how to do that while keeping
- * vulnerabilities in a seperate API proposal in a clean way.
+ * vulnerabilities in a separate API proposal in a clean way.
  */
 export class ChatResponseMarkdownWithVulnerabilitiesPart {
 	value: vscode.MarkdownString;

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1686,7 +1686,7 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 
 			if (items.some((source) => {
 				if (source.isRoot) {
-					return false; // Root folders are handled seperately
+					return false; // Root folders are handled separately
 				}
 
 				if (this.uriIdentityService.extUri.isEqual(source.resource, target.resource)) {

--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -767,7 +767,7 @@ async function _loadColorTheme(extensionResourceLoaderService: IExtensionResourc
 			// new JSON color themes format
 			for (const colorId in colors) {
 				const colorVal = colors[colorId];
-				if (colorVal === DEFAULT_COLOR_CONFIG_VALUE) { // ignore colors that are set to to default
+				if (colorVal === DEFAULT_COLOR_CONFIG_VALUE) { // ignore colors that are set to default
 					delete result.colors[colorId];
 				} else if (typeof colorVal === 'string') {
 					result.colors[colorId] = Color.fromHex(colors[colorId]);


### PR DESCRIPTION
Three single-word typo fixes in source comments. No functional change.

- `colorThemeData.ts`: "set to to default" to "set to default" (duplicate word)
- `explorerViewer.ts`: "seperately" to "separately"
- `extHostTypes.ts`: "seperate" to "separate"

Comment-only, so there's nothing to test.
