### PR TITLE
Fix button wrapping in onboarding tour spotlight

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/accessibility/chatAccessibilityProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/accessibility/chatAccessibilityProvider.ts
@@ -24,7 +24,7 @@ import { ChatTreeItem } from '../chat.js';
 
 export const getToolConfirmationAlert = (accessor: ServicesAccessor, toolInvocation: IChatToolInvocation[]) => {
 	const keybindingService = accessor.get(IKeybindingService);
-	const contextKeyService = accessor.get(IContextKeyService);
+	const contextKeyService = accessor.get(IContextKeyService);d
 
 	const acceptKb = keybindingService.lookupKeybinding(AcceptToolConfirmationActionId, contextKeyService)?.getAriaLabel();
 	const cancelKb = keybindingService.lookupKeybinding(CancelChatActionId, contextKeyService)?.getAriaLabel();

--- a/src/vs/workbench/contrib/chat/browser/accessibility/chatAccessibilityProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/accessibility/chatAccessibilityProvider.ts
@@ -24,7 +24,7 @@ import { ChatTreeItem } from '../chat.js';
 
 export const getToolConfirmationAlert = (accessor: ServicesAccessor, toolInvocation: IChatToolInvocation[]) => {
 	const keybindingService = accessor.get(IKeybindingService);
-	const contextKeyService = accessor.get(IContextKeyService);d
+	const contextKeyService = accessor.get(IContextKeyService);
 
 	const acceptKb = keybindingService.lookupKeybinding(AcceptToolConfirmationActionId, contextKeyService)?.getAriaLabel();
 	const cancelKb = keybindingService.lookupKeybinding(CancelChatActionId, contextKeyService)?.getAriaLabel();

--- a/src/vs/workbench/contrib/onboarding/browser/media/spotlight.css
+++ b/src/vs/workbench/contrib/onboarding/browser/media/spotlight.css
@@ -130,12 +130,12 @@
 
 .spotlight-callout-actions {
 	display: flex;
-	flex-shrink: 0;
+	flex-wrap: wrap;
 	gap: var(--vscode-spacing-size80);
 }
 
 .spotlight-callout-actions .monaco-button {
-	flex-shrink: 0;
+	width: fit-content;
 	white-space: nowrap;
 }
 

--- a/src/vs/workbench/contrib/onboarding/browser/media/spotlight.css
+++ b/src/vs/workbench/contrib/onboarding/browser/media/spotlight.css
@@ -130,7 +130,13 @@
 
 .spotlight-callout-actions {
 	display: flex;
+	flex-shrink: 0;
 	gap: var(--vscode-spacing-size80);
+}
+
+.spotlight-callout-actions .monaco-button {
+	flex-shrink: 0;
+	white-space: nowrap;
 }
 
 /* Respect reduced-motion: drop the animated hole transition. */


### PR DESCRIPTION
This pull request addresses the issue of button wrapping in the onboarding tour spotlight. The changes made in `spotlight.css` ensure that none of the action buttons, including "End Tour," "Back," and "Next/Done," wrap their labels. 

Key changes include:
- Added `flex-shrink: 0` to `.spotlight-callout-actions` to prevent compression of the action buttons.
- Applied `flex-shrink: 0` and `white-space: nowrap` to each `.monaco-button` to maintain their natural width and prevent label wrapping.

These adjustments enhance the visual consistency of the onboarding tour interface.