### PR TITLE
Focus feedback input after clicking glyph margin add button

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution.ts
@@ -571,6 +571,12 @@ export class AgentFeedbackEditorInputContribution extends Disposable implements 
 		// selection and opens the input for the freshly selected line.
 		this._editor.setSelection(new Selection(lineNumber, 1, lineNumber, model.getLineMaxColumn(lineNumber)));
 		this._editor.focus();
+
+		// Focusing the editor synchronously opens the input via the
+		// selection-change handler, so move focus into it now that it is
+		// visible. This lets the user type feedback immediately after clicking
+		// the gutter glyph without having to click the input first.
+		this.focusInput();
 	}
 
 	private _getSessionForModel(): ISession | undefined {


### PR DESCRIPTION
When using the glyph margin add feedback button for the agent feedback feature, clicking it selects the line which opens the feedback input. This change additionally moves focus into the input so the user can start typing immediately without having to click into it first.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>