### PR TITLE
Expand agent feedback widget when revealing feedback

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
@@ -550,11 +550,7 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 		if (!feedback) {
 			return;
 		}
-		// Set the navigation anchor using the session-editor-comment id so the
-		// editor widget contribution can match the active item and expand its
-		// widget (it groups feedback under prefixed ids, see
-		// `getSessionEditorComments`). Passing the raw feedback id here would
-		// reveal the editor location but leave the widget collapsed.
+		// Anchor using the session-editor-comment id (not the raw feedback id) so the editor widget contribution matches the active item and expands its widget.
 		await this.revealSessionComment(sessionResource, toSessionEditorCommentId(SessionEditorCommentSource.AgentFeedback, feedbackId), feedback.resourceUri, feedback.range);
 	}
 

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
@@ -27,6 +27,7 @@ import { isAgentHostProviderId } from '../../../common/agentHostSessionsProvider
 import { AnnotationsAgentFeedbackItemsBackend, IAgentFeedbackItemsBackend, InMemoryAgentFeedbackItemsBackend } from './agentFeedbackItemsBackend.js';
 import { ATTACHMENT_ID_PREFIX, createAgentFeedbackVariableEntry } from './agentFeedbackAttachmentEntry.js';
 import { AgentFeedbackKind, AgentFeedbackState, type IAgentFeedback } from './agentFeedbackModel.js';
+import { SessionEditorCommentSource, toSessionEditorCommentId } from './sessionEditorComments.js';
 
 // --- Types --------------------------------------------------------------------
 
@@ -549,7 +550,12 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 		if (!feedback) {
 			return;
 		}
-		await this.revealSessionComment(sessionResource, feedbackId, feedback.resourceUri, feedback.range);
+		// Set the navigation anchor using the session-editor-comment id so the
+		// editor widget contribution can match the active item and expand its
+		// widget (it groups feedback under prefixed ids, see
+		// `getSessionEditorComments`). Passing the raw feedback id here would
+		// reveal the editor location but leave the widget collapsed.
+		await this.revealSessionComment(sessionResource, toSessionEditorCommentId(SessionEditorCommentSource.AgentFeedback, feedbackId), feedback.resourceUri, feedback.range);
 	}
 
 	async revealSessionComment(sessionResource: URI, commentId: string, resourceUri: URI, range: IRange): Promise<void> {

--- a/src/vs/sessions/contrib/agentFeedback/browser/sessionEditorComments.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/sessionEditorComments.ts
@@ -5,7 +5,7 @@
 
 import { IRange, Range } from '../../../../editor/common/core/range.js';
 import { URI } from '../../../../base/common/uri.js';
-import { AgentFeedbackKind, AgentFeedbackState, IAgentFeedback } from './agentFeedbackService.js';
+import { AgentFeedbackKind, AgentFeedbackState, IAgentFeedback } from './agentFeedbackModel.js';
 import { ICodeReviewSuggestion, IPRReviewComment, IPRReviewState, PRReviewStateKind } from '../../codeReview/browser/codeReviewService.js';
 
 export const enum SessionEditorCommentSource {

--- a/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackService.test.ts
+++ b/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackService.test.ts
@@ -52,7 +52,7 @@ suite('AgentFeedbackService - Ordering', () => {
 		instantiationService.stub(IEditorService, new class extends mock<IEditorService>() {
 			override onDidVisibleEditorsChange = Event.None;
 			override visibleEditorPanes = [];
-			override openEditor(..._args: any[]): Promise<any> { return Promise.resolve(undefined); }
+			override openEditor(..._args: unknown[]): Promise<undefined> { return Promise.resolve(undefined); }
 		});
 		instantiationService.stub(ISessionsManagementService, new class extends mock<ISessionsManagementService>() {
 			override getSession(_resource: URI) { return undefined; }
@@ -212,7 +212,7 @@ suite('AgentFeedbackService - Ordering', () => {
 		assert.strictEqual(comments[bearingAfter.activeIdx]?.sourceId, f1.id);
 	});
 
-
+	test('removing feedback preserves ordering', () => {
 		const f1 = service.addFeedback(session, fileA, r(30), 'A:30');
 		service.addFeedback(session, fileA, r(10), 'A:10');
 		service.addFeedback(session, fileA, r(20), 'A:20');

--- a/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackService.test.ts
+++ b/src/vs/sessions/contrib/agentFeedback/test/browser/agentFeedbackService.test.ts
@@ -12,6 +12,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/tes
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { AgentFeedbackKind, AgentFeedbackService, AgentFeedbackState, IAgentFeedbackService } from '../../browser/agentFeedbackService.js';
+import { getSessionEditorComments } from '../../browser/sessionEditorComments.js';
 import { IChatEditingService } from '../../../../../workbench/contrib/chat/common/editing/chatEditingService.js';
 import { IChatWidget, IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { IAgentFeedbackVariableEntry } from '../../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
@@ -51,6 +52,7 @@ suite('AgentFeedbackService - Ordering', () => {
 		instantiationService.stub(IEditorService, new class extends mock<IEditorService>() {
 			override onDidVisibleEditorsChange = Event.None;
 			override visibleEditorPanes = [];
+			override openEditor(..._args: any[]): Promise<any> { return Promise.resolve(undefined); }
 		});
 		instantiationService.stub(ISessionsManagementService, new class extends mock<ISessionsManagementService>() {
 			override getSession(_resource: URI) { return undefined; }
@@ -191,7 +193,26 @@ suite('AgentFeedbackService - Ordering', () => {
 		assert.strictEqual(bearing.activeIdx, 2);
 	});
 
-	test('removing feedback preserves ordering', () => {
+	test('revealFeedback anchors the matching session editor comment so its widget expands', async () => {
+		const f1 = service.addFeedback(session, fileA, r(5), 'A:5');
+		const f2 = service.addFeedback(session, fileA, r(20), 'A:20');
+
+		// The editor widget contribution expands the widget whose session
+		// editor comment matches the navigation anchor. revealFeedback must set
+		// the anchor using the prefixed session-editor-comment id (not the raw
+		// feedback id) for that match to succeed.
+		await service.revealFeedback(session, f2.id);
+
+		const comments = getSessionEditorComments(session, service.getFeedback(session));
+		const bearing = service.getNavigationBearing(session, comments);
+		assert.strictEqual(comments[bearing.activeIdx]?.sourceId, f2.id);
+
+		await service.revealFeedback(session, f1.id);
+		const bearingAfter = service.getNavigationBearing(session, comments);
+		assert.strictEqual(comments[bearingAfter.activeIdx]?.sourceId, f1.id);
+	});
+
+
 		const f1 = service.addFeedback(session, fileA, r(30), 'A:30');
 		service.addFeedback(session, fileA, r(10), 'A:10');
 		service.addFeedback(session, fileA, r(20), 'A:20');


### PR DESCRIPTION
Fixes the agent feedback widget staying collapsed when revealing a feedback item.

## Problem
`revealFeedback` opened the editor at the feedback location and set the navigation anchor, but it used the **raw** feedback id. The editor widget contribution (gentFeedbackEditorWidgetContribution.ts) decides which widget to expand by matching the navigation anchor against the **prefixed** session-editor-comment id (e.g. `agentFeedback:<id>`, built by `toSessionEditorCommentId` in `getSessionEditorComments`). Because the ids never matched, `getNavigationBearing` returned `activeIdx: -1` and `_handleNavigation` bailed out — so the editor scrolled to the location but the widget remained collapsed.

The keyboard navigation actions already worked because they pass the prefixed `comment.id`.

## Fix
`revealFeedback` now converts the raw feedback id to the session-editor-comment id before delegating to `revealSessionComment`, so the matching widget expands (and focuses the item).

## Test
Added a regression test asserting the navigation bearing resolves to the matching session-editor-comment after `revealFeedback`.