### PR TITLE
Add AH copilot SDK customization test

### DIFF
--- a/src/vs/platform/agentHost/test/node/protocol/copilotRealSdk.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/copilotRealSdk.integrationTest.ts
@@ -218,13 +218,15 @@ defineSharedRealSdkTests(COPILOT_CONFIG);
 				},
 			},
 		});
+		client.clearReceived();
 		dispatchTurn(client, sessionUri, 'turn-customizations', 'hello', 2);
 
-		await client.waitForNotification(n => isActionNotification(n, 'chat/turnComplete'), 120_000);
+		const [customizationsNotif] = await Promise.all([
+			client.waitForNotification(n => isActionNotification(n, ActionType.SessionCustomizationsChanged) && getActionEnvelope(n).channel === sessionUri, 120_000),
+			client.waitForNotification(n => isActionNotification(n, 'chat/turnComplete') && getActionEnvelope(n).channel === buildDefaultChatUri(sessionUri), 120_000),
+		]);
 
-		const customizationNotifications = client.receivedNotifications(n => isActionNotification(n, ActionType.SessionCustomizationsChanged));
-		assert.ok(customizationNotifications.length === 1, 'expected one session/customizationsChanged notification');
-		const customizationsAction = getActionEnvelope(customizationNotifications[customizationNotifications.length - 1]).action as SessionCustomizationsChangedAction;
+		const customizationsAction = getActionEnvelope(customizationsNotif).action as SessionCustomizationsChangedAction;
 		const directories = customizationsAction.customizations.filter((customization): customization is DirectoryCustomization => customization.type === CustomizationType.Directory);
 		const expectChildType = (directoryUri: string, expectedType: CustomizationType, expectedName: string): void => {
 			const directory = directories.find(customization => customization.uri === directoryUri);

--- a/src/vs/platform/agentHost/test/node/protocol/copilotRealSdk.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/copilotRealSdk.integrationTest.ts
@@ -23,12 +23,12 @@
  */
 
 import assert from 'assert';
-import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from '../../../../../base/common/path.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { MessageAttachmentKind, buildDefaultChatUri, ToolCallConfirmationReason, type MessageAttachment } from '../../../common/state/sessionState.js';
-import { ActionType, type ChatUsageAction } from '../../../common/state/sessionActions.js';
+import { CustomizationType, MessageAttachmentKind, buildDefaultChatUri, ToolCallConfirmationReason, type DirectoryCustomization, type MessageAttachment } from '../../../common/state/sessionState.js';
+import { ActionType, SessionCustomizationsChangedAction, type ChatUsageAction } from '../../../common/state/sessionActions.js';
 import {
 	createRealSession, defineSharedRealSdkTests, dispatchTurn, driveTurnWithAttachmentsToCompletion,
 	type IRealSdkProviderConfig,
@@ -162,6 +162,93 @@ defineSharedRealSdkTests(COPILOT_CONFIG);
 		const result = await driveTurnWithAttachmentsToCompletion(client, sessionUri, 'turn-blob-attachment', prompt, attachments, 1);
 
 		assert.match(result.responseText, /\bsubtract\b/i, `expected the model to identify the attached blob function; got: ${JSON.stringify(result.responseText)}`);
+	});
+
+	test('detects workspace agents, instructions, skills, and hooks via session/customizationsChanged after hello', async function () {
+		this.timeout(180_000);
+
+		const workspaceDir = await mkdtemp(`${tmpdir()}/ahp-customizations-test-`);
+		tempDirs.push(workspaceDir);
+		const githubDir = join(workspaceDir, '.github');
+		const agentsDir = join(githubDir, 'agents');
+		const instructionsDir = join(githubDir, 'instructions');
+		const skillsDir = join(githubDir, 'skills', 'hello-skill');
+		const hooksDir = join(githubDir, 'hooks');
+
+		await Promise.all([
+			mkdir(agentsDir, { recursive: true }),
+			mkdir(instructionsDir, { recursive: true }),
+			mkdir(skillsDir, { recursive: true }),
+			mkdir(hooksDir, { recursive: true }),
+		]);
+		await Promise.all([
+			writeFile(join(agentsDir, 'hello.agent.md'), [
+				'---',
+				'name: Hello Agent',
+				'description: Handles hello requests',
+				'---',
+				'You are a test agent.',
+			].join('\n')),
+			writeFile(join(instructionsDir, 'policy.instructions.md'), [
+				'---',
+				'applyTo:',
+				'  - "**/*"',
+				'---',
+				'Prefer short answers.',
+			].join('\n')),
+			writeFile(join(skillsDir, 'SKILL.md'), [
+				'---',
+				'name: Hello Skill',
+				'description: Says hello',
+				'---',
+				'Return a greeting.',
+			].join('\n')),
+			writeFile(join(hooksDir, 'pre-tool.json'), JSON.stringify({ PreToolUse: [] }, undefined, 2)),
+		]);
+
+		const sessionUri = await createRealSession(client, COPILOT_CONFIG, 'real-sdk-customizations', createdSessions, URI.file(workspaceDir).toString());
+		client.dispatch({
+			channel: sessionUri,
+			clientSeq: 1,
+			action: {
+				type: ActionType.SessionActiveClientSet,
+				activeClient: {
+					clientId: 'real-sdk-customizations-client',
+					tools: [],
+				},
+			},
+		});
+		dispatchTurn(client, sessionUri, 'turn-customizations', 'hello', 2);
+
+		await client.waitForNotification(n => isActionNotification(n, 'chat/turnComplete'), 120_000);
+
+		const customizationNotifications = client.receivedNotifications(n => isActionNotification(n, ActionType.SessionCustomizationsChanged));
+		assert.ok(customizationNotifications.length === 1, 'expected one session/customizationsChanged notification');
+		const customizationsAction = getActionEnvelope(customizationNotifications[customizationNotifications.length - 1]).action as SessionCustomizationsChangedAction;
+		const directories = customizationsAction.customizations.filter((customization): customization is DirectoryCustomization => customization.type === CustomizationType.Directory);
+		const discoveredDirectoryUris = new Set(directories.map(customization => customization.uri));
+		assert.ok(discoveredDirectoryUris.has(URI.file(agentsDir).toString()), `expected ${URI.file(agentsDir).toString()} in discovered customization directories`);
+		assert.ok(discoveredDirectoryUris.has(URI.file(instructionsDir).toString()), `expected ${URI.file(instructionsDir).toString()} in discovered customization directories`);
+		assert.ok(discoveredDirectoryUris.has(URI.file(join(githubDir, 'skills')).toString()), `expected ${URI.file(join(githubDir, 'skills')).toString()} in discovered customization directories`);
+		assert.ok(discoveredDirectoryUris.has(URI.file(hooksDir).toString()), `expected ${URI.file(hooksDir).toString()} in discovered customization directories`);
+
+		const expectChildType = (directoryUri: string, expectedType: CustomizationType, expectedName: string): void => {
+			const directory = directories.find(customization => customization.uri === directoryUri);
+			assert.ok(directory, `expected discovered directory ${directoryUri}`);
+			const matchingChildren = directory.children?.filter(child => child.type === expectedType) ?? [];
+			assert.ok(
+				matchingChildren.length > 0,
+				`expected ${directoryUri} to contain a ${expectedType} customization`,
+			);
+			assert.ok(
+				matchingChildren.some(child => child.name === expectedName),
+				`expected ${directoryUri} to contain ${expectedType} named ${expectedName}`,
+			);
+		};
+		expectChildType(URI.file(agentsDir).toString(), CustomizationType.Agent, 'Hello Agent');
+		expectChildType(URI.file(instructionsDir).toString(), CustomizationType.Rule, 'policy');
+		expectChildType(URI.file(join(githubDir, 'skills')).toString(), CustomizationType.Skill, 'Hello Skill');
+		expectChildType(URI.file(hooksDir).toString(), CustomizationType.Hook, 'pre-tool.json');
 	});
 
 	test('strips redundant `cd <workingDirectory> &&` prefix from shell tool calls', async function () {

--- a/src/vs/platform/agentHost/test/node/protocol/copilotRealSdk.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/copilotRealSdk.integrationTest.ts
@@ -226,23 +226,13 @@ defineSharedRealSdkTests(COPILOT_CONFIG);
 		assert.ok(customizationNotifications.length === 1, 'expected one session/customizationsChanged notification');
 		const customizationsAction = getActionEnvelope(customizationNotifications[customizationNotifications.length - 1]).action as SessionCustomizationsChangedAction;
 		const directories = customizationsAction.customizations.filter((customization): customization is DirectoryCustomization => customization.type === CustomizationType.Directory);
-		const discoveredDirectoryUris = new Set(directories.map(customization => customization.uri));
-		assert.ok(discoveredDirectoryUris.has(URI.file(agentsDir).toString()), `expected ${URI.file(agentsDir).toString()} in discovered customization directories`);
-		assert.ok(discoveredDirectoryUris.has(URI.file(instructionsDir).toString()), `expected ${URI.file(instructionsDir).toString()} in discovered customization directories`);
-		assert.ok(discoveredDirectoryUris.has(URI.file(join(githubDir, 'skills')).toString()), `expected ${URI.file(join(githubDir, 'skills')).toString()} in discovered customization directories`);
-		assert.ok(discoveredDirectoryUris.has(URI.file(hooksDir).toString()), `expected ${URI.file(hooksDir).toString()} in discovered customization directories`);
-
 		const expectChildType = (directoryUri: string, expectedType: CustomizationType, expectedName: string): void => {
 			const directory = directories.find(customization => customization.uri === directoryUri);
 			assert.ok(directory, `expected discovered directory ${directoryUri}`);
-			const matchingChildren = directory.children?.filter(child => child.type === expectedType) ?? [];
+			const matchingChildren = directory.children?.filter(child => child.type === expectedType && child.name === expectedName) ?? [];
 			assert.ok(
-				matchingChildren.length > 0,
-				`expected ${directoryUri} to contain a ${expectedType} customization`,
-			);
-			assert.ok(
-				matchingChildren.some(child => child.name === expectedName),
-				`expected ${directoryUri} to contain ${expectedType} named ${expectedName}`,
+				matchingChildren.length === 1,
+				`expected ${directoryUri} to contain a ${expectedType} customization with name ${expectedName}; got: ${JSON.stringify(directory.children)}`,
 			);
 		};
 		expectChildType(URI.file(agentsDir).toString(), CustomizationType.Agent, 'Hello Agent');


### PR DESCRIPTION
Introduce a test for the AH copilot SDK that verifies the detection of workspace agents, instructions, skills, and hooks through session customizations. This test sets up a temporary workspace and checks for the expected customizations after a session is initiated.

