### PR TITLE
chore: update macOS pgo profile for electron@42.5.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,6 @@
 disturl="https://electronjs.org/headers"
 target="42.5.0"
-ms_build_id="14500164"
+ms_build_id="14525058"
 runtime="electron"
 ignore-scripts=false
 build_from_source="true"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.128.0",
-  "distro": "9edf315ef11f6002bb6c8784bf27c81bdea7c8c1",
+  "distro": "31a128d7c2ecf6aa1ceb814ef3c75a7775d84de9",
   "author": {
     "name": "Microsoft Corporation"
   },


### PR DESCRIPTION
Brings in custom PGO profiles for macOS, followup to https://github.com/microsoft/vscode/pull/321629 which only covered linux and windows