### PR TITLE
sessions: keep group/workspace order across reloads

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -1686,9 +1686,19 @@ export class SessionsList extends Disposable implements ISessionsList {
 			updateFindPatternState();
 		}));
 
-		this._register(this._sessionsManagementService.onDidChangeSessions(() => {
+		this._register(this._sessionsManagementService.onDidChangeSessions(e => {
 			if (this.visible) {
 				this.refresh();
+			}
+			// A removed session may have been the last one in its workspace.
+			// Garbage-collect manual order / promotion entries for identities
+			// that no longer exist. This runs only on removals (never on
+			// additions or the initial load) so that asynchronous session
+			// loading on a window reload can never prune the user's manual
+			// ordering of workspaces relative to groups before their sessions
+			// have loaded.
+			if (e.removed.length > 0) {
+				this._sessionSectionOrderService.retain(this.liveSectionOrderIds());
 			}
 		}));
 
@@ -1698,9 +1708,16 @@ export class SessionsList extends Disposable implements ISessionsList {
 			}
 		}));
 
-		this._register(this._sessionGroupsService.onDidChange(() => {
+		this._register(this._sessionGroupsService.onDidChange(e => {
 			if (this.visible) {
 				this.update();
+			}
+			// Garbage-collect manual order / promotion entries when groups are
+			// deleted or evicted. Group changes are user-driven and happen after
+			// sessions have loaded, so pruning here is safe (unlike at render
+			// time during the asynchronous initial load).
+			if (e.groupsChanged) {
+				this._sessionSectionOrderService.retain(this.liveSectionOrderIds());
 			}
 		}));
 
@@ -1800,10 +1817,6 @@ export class SessionsList extends Disposable implements ISessionsList {
 		const grouping = this.options.grouping();
 		const sorting = this.options.sorting();
 		const sortKeyForGrouping = (s: ISession, srt: SessionsSorting) => this._sessionsListModelService.getSortKey(s, sortingToMode(srt));
-
-		// Garbage-collect manual order/promotion entries for groups and
-		// workspaces that no longer exist (does not affect the visible order).
-		this._sessionSectionOrderService.retain(this.liveSectionOrderIds());
 
 		// Pull regular (non-pinned, non-archived) grouped sessions out of the
 		// normal date/workspace sectioning so they render under their group.
@@ -2299,14 +2312,15 @@ export class SessionsList extends Disposable implements ISessionsList {
 	 * The set of top-level reorder identities that currently exist (every group,
 	 * plus every workspace label present across all sessions, regardless of
 	 * grouping mode or capping). Used to garbage-collect stale manual order and
-	 * promotion entries.
+	 * promotion entries. Reads sessions fresh from the management service so it
+	 * reflects the latest loaded state even when the list is not visible.
 	 */
 	private liveSectionOrderIds(): Set<string> {
 		const ids = new Set<string>();
 		for (const group of this._sessionGroupsService.getGroups()) {
 			ids.add(`group:${group.id}`);
 		}
-		for (const session of this.sessions) {
+		for (const session of this._sessionsManagementService.getSessions()) {
 			ids.add(`workspace:${sessionWorkspaceLabel(session)}`);
 		}
 		return ids;


### PR DESCRIPTION
## What

Fixes the sessions list (Agents window) losing the user-defined ordering of groups and workspace sections after a window reload when grouping by workspace.

## Why

`SessionsList.update()` (the render method) called `_sessionSectionOrderService.retain(liveSectionOrderIds())` on every render. `liveSectionOrderIds()` derives workspace identities from the currently-loaded sessions, but sessions load **asynchronously** from providers. The first render(s) after a reload therefore had an incomplete/empty session set, so `retain()` pruned (and persisted the removal of) the `workspace:*` order/promotion entries before those sessions loaded. Groups load **synchronously** from `SessionGroupsService` storage, so they kept their order — which is exactly the reported symptom: groups stay ordered, but the interleaving of groups and workspaces is lost.

## How

Stop pruning at render time. Garbage-collect manual order/promotion entries only on **genuine removals**, which always happen after sessions are loaded:

- `onDidChangeSessions` — only when `removed.length > 0`
- `SessionGroupsService.onDidChange` — only when `groupsChanged`

This mirrors how `SessionGroupsService` GCs membership only on removal. `resolveOrder` is pure and already drops dead ids from the displayed result, so the display stays correct even if a stale entry briefly lingers in storage between removals. `liveSectionOrderIds()` now reads sessions fresh from the management service so GC is accurate even when the list is not visible.