### PR TITLE
Style Overrides: Optimize layout handling for floating panels

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -1903,7 +1903,8 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			this.state.runtime.mainWindowFullscreen ? LayoutClasses.FULLSCREEN : undefined,
 			this.isShadowsDisabled() ? LayoutClasses.NO_SHADOWS : undefined,
 			this.isFloatingPanelsEnabled() ? LayoutClasses.FLOATING_PANELS : undefined,
-			`panel-position-${positionToString(this.getPanelPosition())}`
+			`panel-position-${positionToString(this.getPanelPosition())}`,
+			`panel-alignment-${this.getPanelAlignment()}`
 		]);
 	}
 
@@ -2035,7 +2036,11 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		// panel alignment requires the editor part to be visible
 		this.setAuxiliaryBarMaximized(false);
 
+		// Adjust CSS — capture old value before updating state model
+		const oldAlignmentValue = this.getPanelAlignment();
 		this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_ALIGNMENT, alignment);
+		this.mainContainer.classList.remove(`panel-alignment-${oldAlignmentValue}`);
+		this.mainContainer.classList.add(`panel-alignment-${alignment}`);
 
 		this.adjustPartPositions(this.getSideBarPosition(), alignment, this.getPanelPosition());
 

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -1902,7 +1902,8 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			!this.isVisible(Parts.STATUSBAR_PART) ? LayoutClasses.STATUSBAR_HIDDEN : undefined,
 			this.state.runtime.mainWindowFullscreen ? LayoutClasses.FULLSCREEN : undefined,
 			this.isShadowsDisabled() ? LayoutClasses.NO_SHADOWS : undefined,
-			this.isFloatingPanelsEnabled() ? LayoutClasses.FLOATING_PANELS : undefined
+			this.isFloatingPanelsEnabled() ? LayoutClasses.FLOATING_PANELS : undefined,
+			`panel-position-${positionToString(this.getPanelPosition())}`
 		]);
 	}
 
@@ -2366,6 +2367,8 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		const panelContainer = assertReturnsDefined(panelPart.getContainer());
 		panelContainer.classList.remove(oldPositionValue);
 		panelContainer.classList.add(newPositionValue);
+		this.mainContainer.classList.remove(`panel-position-${oldPositionValue}`);
+		this.mainContainer.classList.add(`panel-position-${newPositionValue}`);
 
 		// Update Styles
 		panelPart.updateStyles();

--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -144,3 +144,53 @@
 .monaco-workbench.floating-panels .activitybar > .content > .composite-bar {
 	margin-top: var(--vscode-spacing-size20);
 }
+
+/*
+ * When the status bar is hidden every floating card sits directly against the window
+ * bottom edge. Double the bottom margin (4px → 8px) to match the doubled outer gutter
+ * applied to other window-edge sides, so all gaps look consistent.
+ * Exceptions:
+ *   - Panel at TOP: its bottom faces the editor (not the window edge) — keep 4px.
+ *   - Editor when a bottom panel is visible: it abuts the panel card — keep 4px.
+ * The code-side insets in AbstractPaneCompositePart and EditorPart are kept in sync.
+ */
+.monaco-workbench.floating-panels.nostatusbar .part.panel.bottom,
+.monaco-workbench.floating-panels.nostatusbar .part.panel.left,
+.monaco-workbench.floating-panels.nostatusbar .part.panel.right,
+.monaco-workbench.floating-panels.nostatusbar .part.sidebar,
+.monaco-workbench.floating-panels.nostatusbar .part.auxiliarybar {
+	margin-bottom: calc(var(--vscode-spacing-size40) * 2);
+}
+
+.monaco-workbench.floating-panels.nostatusbar > .monaco-grid-view .part.editor {
+	margin-bottom: calc(var(--vscode-spacing-size40) * 2);
+}
+
+/*
+ * When a visible bottom panel directly abuts the sidebars and/or editor (they share
+ * the same grid row), keep the normal 4px inter-card gap instead of the doubled 8px.
+ * Which bars are in the same row as the editor depends on panel alignment:
+ *   justify  → both sidebars are in the top row (above the full-width panel)
+ *   left     → the bar on the LEFT is in the top row; the bar on the RIGHT is full-height
+ *   right    → the bar on the RIGHT is in the top row; the bar on the LEFT is full-height
+ *   center   → neither sidebar is in the top row (both span full height)
+ * Uses `.panel-alignment-*` and `.left`/`.right` position classes set in layout.ts.
+ */
+.monaco-workbench.floating-panels.nostatusbar.panel-position-bottom:not(.nopanel).panel-alignment-justify .part.sidebar,
+.monaco-workbench.floating-panels.nostatusbar.panel-position-bottom:not(.nopanel).panel-alignment-justify .part.auxiliarybar,
+.monaco-workbench.floating-panels.nostatusbar.panel-position-bottom:not(.nopanel).panel-alignment-left .part.sidebar.left,
+.monaco-workbench.floating-panels.nostatusbar.panel-position-bottom:not(.nopanel).panel-alignment-left .part.auxiliarybar.left,
+.monaco-workbench.floating-panels.nostatusbar.panel-position-bottom:not(.nopanel).panel-alignment-right .part.sidebar.right,
+.monaco-workbench.floating-panels.nostatusbar.panel-position-bottom:not(.nopanel).panel-alignment-right .part.auxiliarybar.right,
+.monaco-workbench.floating-panels.nostatusbar.panel-position-bottom:not(.nopanel) > .monaco-grid-view .part.editor {
+	margin-bottom: var(--vscode-spacing-size40);
+}
+/* Editor exception for center alignment: panel is within the editor column, so editor
+ * still faces it from above (top row) — override the above back to 4px. */
+.monaco-workbench.floating-panels.nostatusbar.panel-position-bottom:not(.nopanel).panel-alignment-center > .monaco-grid-view .part.editor {
+	margin-bottom: var(--vscode-spacing-size40);
+}
+
+.monaco-workbench.floating-panels.nostatusbar .part.activitybar {
+	margin-bottom: calc(var(--vscode-spacing-size40) * 2);
+}

--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -166,6 +166,7 @@
  * applied to other window-edge sides, so all gaps look consistent.
  * Exceptions:
  *   - Panel at TOP: its bottom faces the editor (not the window edge) — keep 4px.
+ *     `.part.panel.top` is intentionally absent from the selector list below.
  *   - Editor when a bottom panel is visible: it abuts the panel card — keep 4px.
  * The code-side insets in AbstractPaneCompositePart and EditorPart are kept in sync.
  */

--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -200,11 +200,6 @@
 .monaco-workbench.floating-panels.nostatusbar.panel-position-bottom:not(.nopanel) > .monaco-grid-view .part.editor {
 	margin-bottom: var(--vscode-spacing-size40);
 }
-/* Editor exception for center alignment: panel is within the editor column, so editor
- * still faces it from above (top row) — override the above back to 4px. */
-.monaco-workbench.floating-panels.nostatusbar.panel-position-bottom:not(.nopanel).panel-alignment-center > .monaco-grid-view .part.editor {
-	margin-bottom: var(--vscode-spacing-size40);
-}
 
 .monaco-workbench.floating-panels.nostatusbar .part.activitybar {
 	margin-bottom: calc(var(--vscode-spacing-size40) * 2);

--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -63,7 +63,7 @@
 	margin-top: var(--vscode-spacing-size40);
 }
 
-/* Panel at top position: also flush with the title bar (no top margin), like the side bars.
+/* Panels in top/left/right positions are flush with the title bar (no top margin).
  * The panel element itself carries the position class (e.g. `.top`). */
 .monaco-workbench.floating-panels .part.panel.top,
 .monaco-workbench.floating-panels .part.panel.left,

--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -48,6 +48,14 @@
 	margin-top: 0;
 }
 
+/* Panel at top position: also flush with the title bar (no top margin), like the side bars.
+ * The panel element itself carries the position class (e.g. `.top`). */
+.monaco-workbench.floating-panels .part.panel.top,
+.monaco-workbench.floating-panels .part.panel.left,
+.monaco-workbench.floating-panels .part.panel.right {
+	margin-top: 0;
+}
+
 /*
  * When a floating pane composite (primary side bar, secondary side bar or a vertical
  * panel) is the outermost card on a window edge, it adopts a doubled outer gutter so
@@ -66,6 +74,13 @@
 .monaco-workbench.floating-panels > .monaco-grid-view .part.editor {
 	margin: var(--vscode-spacing-size40);
 	margin-top: 0;
+}
+
+/* When the panel is at the top and visible the editor sits below it — give it a top margin
+ * so the inter-card gap matches the gaps between the other floating cards.
+ * Requires `.panel-position-top` on `.monaco-workbench` (set in layout.ts). */
+.monaco-workbench.floating-panels.panel-position-top:not(.nopanel) > .monaco-grid-view .part.editor {
+	margin-top: var(--vscode-spacing-size40);
 }
 
 /*

--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -48,6 +48,21 @@
 	margin-top: 0;
 }
 
+/*
+ * When panel is at TOP and sidebars are in the same grid row as the editor (sibling),
+ * give them a top margin matching the editor's gap from the panel. Alignment determines
+ * which bars are sibling — mirrors adjustPartPositions() in layout.ts.
+ * Uses `.panel-alignment-*` and `.left`/`.right` classes set in layout.ts.
+ */
+.monaco-workbench.floating-panels.panel-position-top:not(.nopanel).panel-alignment-justify .part.sidebar,
+.monaco-workbench.floating-panels.panel-position-top:not(.nopanel).panel-alignment-justify .part.auxiliarybar,
+.monaco-workbench.floating-panels.panel-position-top:not(.nopanel).panel-alignment-left .part.sidebar.left,
+.monaco-workbench.floating-panels.panel-position-top:not(.nopanel).panel-alignment-left .part.auxiliarybar.left,
+.monaco-workbench.floating-panels.panel-position-top:not(.nopanel).panel-alignment-right .part.sidebar.right,
+.monaco-workbench.floating-panels.panel-position-top:not(.nopanel).panel-alignment-right .part.auxiliarybar.right {
+	margin-top: var(--vscode-spacing-size40);
+}
+
 /* Panel at top position: also flush with the title bar (no top margin), like the side bars.
  * The panel element itself carries the position class (e.g. `.top`). */
 .monaco-workbench.floating-panels .part.panel.top,

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -1395,7 +1395,13 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 			// When the panel is positioned above the editor and visible, the editor is no longer
 			// adjacent to the title bar — reserve a top margin to match the inter-card gaps.
 			const panelAtTop = this.layoutService.isVisible(Parts.PANEL_PART) && this.layoutService.getPanelPosition() === Position.TOP;
-			height = Math.max(0, height - FLOATING_PANEL_MARGIN - (panelAtTop ? FLOATING_PANEL_MARGIN : 0));
+			// When the status bar is hidden, the editor is at the window bottom edge — double the
+			// margin. Exception: when a bottom panel is visible the editor's bottom faces the panel
+			// card (not the window edge), so keep the normal inter-card gap.
+			const panelAtBottom = this.layoutService.isVisible(Parts.PANEL_PART) && this.layoutService.getPanelPosition() === Position.BOTTOM;
+			const bottomEditorMargin = !this.layoutService.isVisible(Parts.STATUSBAR_PART, mainWindow) && !panelAtBottom
+				? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_MARGIN;
+			height = Math.max(0, height - (panelAtTop ? FLOATING_PANEL_MARGIN : 0) - bottomEditorMargin);
 
 			// Reserve space for the Modern UI editor border (styleOverrides/media/editorBorder.css) so content doesn't get clipped.
 			if (!this.element.classList.contains('modal-editor-part')) {

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -1392,17 +1392,8 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 			const rightMargin = outerRight ? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_MARGIN;
 
 			width = Math.max(0, width - leftMargin - rightMargin);
-			// When the panel is positioned above the editor and visible, the editor is no longer
-			// adjacent to the title bar — reserve a top margin to match the inter-card gaps.
-			const panelVisible = this.layoutService.isVisible(Parts.PANEL_PART);
-			const panelAtTop = panelVisible && this.layoutService.getPanelPosition() === Position.TOP;
-			// When the status bar is hidden, the editor is at the window bottom edge — double the
-			// margin. Exception: when a bottom panel is visible the editor's bottom faces the panel
-			// card (not the window edge), so keep the normal inter-card gap.
-			const panelAtBottom = panelVisible && this.layoutService.getPanelPosition() === Position.BOTTOM;
-			const bottomEditorMargin = !this.layoutService.isVisible(Parts.STATUSBAR_PART, mainWindow) && !panelAtBottom
-				? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_MARGIN;
-			height = Math.max(0, height - (panelAtTop ? FLOATING_PANEL_MARGIN : 0) - bottomEditorMargin);
+			const { topMargin, bottomMargin } = this.getFloatingPanelHeightInsets();
+			height = Math.max(0, height - topMargin - bottomMargin);
 
 			// Reserve space for the Modern UI editor border (styleOverrides/media/editorBorder.css) so content doesn't get clipped.
 			if (!this.element.classList.contains('modal-editor-part')) {
@@ -1421,6 +1412,26 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 
 		// Layout editor container
 		this.doLayout(Dimension.lift(contentAreaSize), top, left);
+	}
+
+	/**
+	 * Returns the top and bottom margins (in pixels) to subtract from the editor height
+	 * when the floating panels experiment is active. Accounts for panel position (a top
+	 * panel pushes the editor down) and status bar visibility (hidden status bar means
+	 * the editor is at the window bottom edge and gets a doubled bottom margin).
+	 */
+	private getFloatingPanelHeightInsets(): { topMargin: number; bottomMargin: number } {
+		const panelVisible = this.layoutService.isVisible(Parts.PANEL_PART);
+		// When the panel is positioned above the editor and visible, the editor is no longer
+		// adjacent to the title bar — reserve a top margin to match the inter-card gaps.
+		const panelAtTop = panelVisible && this.layoutService.getPanelPosition() === Position.TOP;
+		// When the status bar is hidden, the editor is at the window bottom edge — double the
+		// margin. Exception: when a bottom panel is visible the editor's bottom faces the panel
+		// card (not the window edge), so keep the normal inter-card gap.
+		const panelAtBottom = panelVisible && this.layoutService.getPanelPosition() === Position.BOTTOM;
+		const bottomMargin = !this.layoutService.isVisible(Parts.STATUSBAR_PART, mainWindow) && !panelAtBottom
+			? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_MARGIN;
+		return { topMargin: panelAtTop ? FLOATING_PANEL_MARGIN : 0, bottomMargin };
 	}
 
 	private doLayout(dimension: Dimension, top = this.top, left = this.left): void {

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -1394,11 +1394,12 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 			width = Math.max(0, width - leftMargin - rightMargin);
 			// When the panel is positioned above the editor and visible, the editor is no longer
 			// adjacent to the title bar — reserve a top margin to match the inter-card gaps.
-			const panelAtTop = this.layoutService.isVisible(Parts.PANEL_PART) && this.layoutService.getPanelPosition() === Position.TOP;
+			const panelVisible = this.layoutService.isVisible(Parts.PANEL_PART);
+			const panelAtTop = panelVisible && this.layoutService.getPanelPosition() === Position.TOP;
 			// When the status bar is hidden, the editor is at the window bottom edge — double the
 			// margin. Exception: when a bottom panel is visible the editor's bottom faces the panel
 			// card (not the window edge), so keep the normal inter-card gap.
-			const panelAtBottom = this.layoutService.isVisible(Parts.PANEL_PART) && this.layoutService.getPanelPosition() === Position.BOTTOM;
+			const panelAtBottom = panelVisible && this.layoutService.getPanelPosition() === Position.BOTTOM;
 			const bottomEditorMargin = !this.layoutService.isVisible(Parts.STATUSBAR_PART, mainWindow) && !panelAtBottom
 				? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_MARGIN;
 			height = Math.max(0, height - (panelAtTop ? FLOATING_PANEL_MARGIN : 0) - bottomEditorMargin);

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -1392,7 +1392,10 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 			const rightMargin = outerRight ? FLOATING_PANEL_MARGIN * 2 : FLOATING_PANEL_MARGIN;
 
 			width = Math.max(0, width - leftMargin - rightMargin);
-			height = Math.max(0, height - FLOATING_PANEL_MARGIN);
+			// When the panel is positioned above the editor and visible, the editor is no longer
+			// adjacent to the title bar — reserve a top margin to match the inter-card gaps.
+			const panelAtTop = this.layoutService.isVisible(Parts.PANEL_PART) && this.layoutService.getPanelPosition() === Position.TOP;
+			height = Math.max(0, height - FLOATING_PANEL_MARGIN - (panelAtTop ? FLOATING_PANEL_MARGIN : 0));
 
 			// Reserve space for the Modern UI editor border (styleOverrides/media/editorBorder.css) so content doesn't get clipped.
 			if (!this.element.classList.contains('modal-editor-part')) {

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -657,9 +657,25 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		const borderTotal = 2; // 1px border on each side
 		const margin = FLOATING_PANEL_MARGIN;
 		// Only the bottom-positioned panel needs a top margin (the gap between the editor and the
-		// panel card). Side bars and panels in all other positions are flush with the title bar.
+		// panel card). Side bars and panels in all other positions are flush with the title bar —
+		// unless a sidebar is in the same grid row as the editor with panel at TOP, in which case
+		// it needs a top margin matching the editor's gap (mirrors adjustPartPositions() logic).
 		const isBottomPanel = this.partId === Parts.PANEL_PART && this.layoutService.getPanelPosition() === Position.BOTTOM;
-		const topMargin = isBottomPanel ? margin : 0;
+		let topMargin = isBottomPanel ? margin : 0;
+
+		if (topMargin === 0 &&
+			this.layoutService.isVisible(Parts.PANEL_PART) &&
+			this.layoutService.getPanelPosition() === Position.TOP &&
+			(this.partId === Parts.SIDEBAR_PART || this.partId === Parts.AUXILIARYBAR_PART)) {
+			const alignment = this.layoutService.getPanelAlignment();
+			const sideBarOnLeft = this.layoutService.getSideBarPosition() === Position.LEFT;
+			const isSiblingToEditor = this.partId === Parts.SIDEBAR_PART
+				? !(alignment === 'center' || (sideBarOnLeft && alignment === 'right') || (!sideBarOnLeft && alignment === 'left'))
+				: !(alignment === 'center' || (!sideBarOnLeft && alignment === 'right') || (sideBarOnLeft && alignment === 'left'));
+			if (isSiblingToEditor) {
+				topMargin = margin;
+			}
+		}
 		// When status bar is hidden, cards at the window bottom edge get a doubled bottom margin.
 		// Whether a sidebar/aux bar faces the window edge or a bottom panel row depends on panel
 		// alignment — this mirrors the sideBarSiblingToEditor / auxiliaryBarSiblingToEditor logic

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -650,6 +650,48 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 	}
 
 	/**
+	 * Returns the top margin (in pixels) this part should receive when floating panels
+	 * are enabled. Only the bottom-panel and sibling side bars (when the panel is at the
+	 * top) need a top margin; all other parts sit flush with the title bar.
+	 */
+	private getFloatingPartTopMargin(panelVisible: boolean, margin: number): number {
+		// Bottom panel: always needs a top margin (the gap between editor and the panel card).
+		if (this.partId === Parts.PANEL_PART && this.layoutService.getPanelPosition() === Position.BOTTOM) {
+			return margin;
+		}
+		// Sidebar / aux bar that is in the same grid row as the editor (sibling) and the panel
+		// is at the top: needs a top margin matching the editor's gap from the panel card.
+		if (panelVisible &&
+			this.layoutService.getPanelPosition() === Position.TOP &&
+			(this.partId === Parts.SIDEBAR_PART || this.partId === Parts.AUXILIARYBAR_PART) &&
+			this.isSidebarSiblingToEditor()) {
+			return margin;
+		}
+		return 0;
+	}
+
+	/**
+	 * Returns whether this part's bottom edge faces the window edge rather than another
+	 * floating card. When the status bar is hidden and this returns `true`, a doubled
+	 * bottom margin is applied so the outer gap matches the doubled side gutters.
+	 */
+	private isFloatingPartAtWindowBottomEdge(panelVisible: boolean): boolean {
+		// Panel at TOP: its bottom faces the editor card, not the window edge.
+		if (this.partId === Parts.PANEL_PART && this.layoutService.getPanelPosition() === Position.TOP) {
+			return false;
+		}
+		// A sidebar/aux bar that is a sibling to the editor sits above a bottom panel row,
+		// so its bottom faces the panel card rather than the window edge.
+		const panelAtBottom = panelVisible && this.layoutService.getPanelPosition() === Position.BOTTOM;
+		if (panelAtBottom &&
+			(this.partId === Parts.SIDEBAR_PART || this.partId === Parts.AUXILIARYBAR_PART) &&
+			this.isSidebarSiblingToEditor()) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
 	 * Amount (in pixels) to subtract from each axis when the floating panels
 	 * experiment is enabled: a margin on each side plus a 1px border on each side
 	 * (the border is drawn inside the box, as `.monaco-workbench .part` is
@@ -666,36 +708,8 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		const borderTotal = 2; // 1px border on each side
 		const margin = FLOATING_PANEL_MARGIN;
 		const panelVisible = this.layoutService.isVisible(Parts.PANEL_PART);
-		// Only the bottom-positioned panel needs a top margin (the gap between the editor and the
-		// panel card). Side bars and panels in all other positions are flush with the title bar —
-		// unless a sidebar is in the same grid row as the editor with panel at TOP, in which case
-		// it needs a top margin matching the editor's gap (mirrors adjustPartPositions() logic).
-		const isBottomPanel = this.partId === Parts.PANEL_PART && this.layoutService.getPanelPosition() === Position.BOTTOM;
-		let topMargin = isBottomPanel ? margin : 0;
-
-		if (topMargin === 0 &&
-			panelVisible &&
-			this.layoutService.getPanelPosition() === Position.TOP &&
-			(this.partId === Parts.SIDEBAR_PART || this.partId === Parts.AUXILIARYBAR_PART)) {
-			if (this.isSidebarSiblingToEditor()) {
-				topMargin = margin;
-			}
-		}
-		// When status bar is hidden, cards at the window bottom edge get a doubled bottom margin.
-		// Whether a sidebar/aux bar faces the window edge or a bottom panel row depends on panel
-		// alignment — this mirrors the sideBarSiblingToEditor / auxiliaryBarSiblingToEditor logic
-		// in adjustPartPositions() in layout.ts.
-		const panelAtBottom = panelVisible && this.layoutService.getPanelPosition() === Position.BOTTOM;
-		let isAtWindowBottom =
-			!(this.partId === Parts.PANEL_PART && this.layoutService.getPanelPosition() === Position.TOP); // panel at TOP: bottom faces editor
-
-		if (isAtWindowBottom && panelAtBottom &&
-			(this.partId === Parts.SIDEBAR_PART || this.partId === Parts.AUXILIARYBAR_PART)) {
-			if (this.isSidebarSiblingToEditor()) {
-				isAtWindowBottom = false;
-			}
-		}
-
+		const topMargin = this.getFloatingPartTopMargin(panelVisible, margin);
+		const isAtWindowBottom = this.isFloatingPartAtWindowBottomEdge(panelVisible);
 		const bottomMargin = !this.layoutService.isVisible(Parts.STATUSBAR_PART, getWindow(this.element)) && isAtWindowBottom
 			? margin * 2 : margin;
 		const outerGutter = this.getFloatingOuterGutterEdges();

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -12,7 +12,7 @@ import { IPaneComposite } from '../../common/panecomposite.js';
 import { IViewDescriptorService, ViewContainerLocation } from '../../common/views.js';
 import { DisposableStore, MutableDisposable } from '../../../base/common/lifecycle.js';
 import { IView } from '../../../base/browser/ui/grid/grid.js';
-import { IWorkbenchLayoutService, Parts, Position, SINGLE_WINDOW_PARTS, FLOATING_PANEL_MARGIN, getFloatingOuterGutterEdges } from '../../services/layout/browser/layoutService.js';
+import { IWorkbenchLayoutService, Parts, Position, SINGLE_WINDOW_PARTS, FLOATING_PANEL_MARGIN, getFloatingOuterGutterEdges, getFloatingSidebarSiblingToEditorStatus } from '../../services/layout/browser/layoutService.js';
 import { mainWindow } from '../../../base/browser/window.js';
 import { CompositePart, ICompositePartOptions, ICompositeTitleLabel } from './compositePart.js';
 import { IPaneCompositeBarOptions, PaneCompositeBar } from './paneCompositeBar.js';
@@ -643,15 +643,11 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 	/**
 	 * Returns true when this sidebar/aux bar is in the same grid row as the editor
 	 * (a sibling), meaning it abuts the panel above or below rather than the window edge.
-	 * Mirrors the sideBarSiblingToEditor / auxiliaryBarSiblingToEditor formula in
-	 * adjustPartPositions() in layout.ts.
+	 * Delegates to the shared formula exported from layoutService.ts.
 	 */
 	private isSidebarSiblingToEditor(): boolean {
-		const alignment = this.layoutService.getPanelAlignment();
-		const sideBarOnLeft = this.layoutService.getSideBarPosition() === Position.LEFT;
-		return this.partId === Parts.SIDEBAR_PART
-			? !(alignment === 'center' || (sideBarOnLeft && alignment === 'right') || (!sideBarOnLeft && alignment === 'left'))
-			: !(alignment === 'center' || (!sideBarOnLeft && alignment === 'right') || (sideBarOnLeft && alignment === 'left'));
+		const { sideBar, auxBar } = getFloatingSidebarSiblingToEditorStatus(this.layoutService);
+		return this.partId === Parts.SIDEBAR_PART ? sideBar : auxBar;
 	}
 
 	/**

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -641,6 +641,20 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 	}
 
 	/**
+	 * Returns true when this sidebar/aux bar is in the same grid row as the editor
+	 * (a sibling), meaning it abuts the panel above or below rather than the window edge.
+	 * Mirrors the sideBarSiblingToEditor / auxiliaryBarSiblingToEditor formula in
+	 * adjustPartPositions() in layout.ts.
+	 */
+	private isSidebarSiblingToEditor(): boolean {
+		const alignment = this.layoutService.getPanelAlignment();
+		const sideBarOnLeft = this.layoutService.getSideBarPosition() === Position.LEFT;
+		return this.partId === Parts.SIDEBAR_PART
+			? !(alignment === 'center' || (sideBarOnLeft && alignment === 'right') || (!sideBarOnLeft && alignment === 'left'))
+			: !(alignment === 'center' || (!sideBarOnLeft && alignment === 'right') || (sideBarOnLeft && alignment === 'left'));
+	}
+
+	/**
 	 * Amount (in pixels) to subtract from each axis when the floating panels
 	 * experiment is enabled: a margin on each side plus a 1px border on each side
 	 * (the border is drawn inside the box, as `.monaco-workbench .part` is
@@ -667,12 +681,7 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 			this.layoutService.isVisible(Parts.PANEL_PART) &&
 			this.layoutService.getPanelPosition() === Position.TOP &&
 			(this.partId === Parts.SIDEBAR_PART || this.partId === Parts.AUXILIARYBAR_PART)) {
-			const alignment = this.layoutService.getPanelAlignment();
-			const sideBarOnLeft = this.layoutService.getSideBarPosition() === Position.LEFT;
-			const isSiblingToEditor = this.partId === Parts.SIDEBAR_PART
-				? !(alignment === 'center' || (sideBarOnLeft && alignment === 'right') || (!sideBarOnLeft && alignment === 'left'))
-				: !(alignment === 'center' || (!sideBarOnLeft && alignment === 'right') || (sideBarOnLeft && alignment === 'left'));
-			if (isSiblingToEditor) {
+			if (this.isSidebarSiblingToEditor()) {
 				topMargin = margin;
 			}
 		}
@@ -686,14 +695,7 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 
 		if (isAtWindowBottom && panelAtBottom &&
 			(this.partId === Parts.SIDEBAR_PART || this.partId === Parts.AUXILIARYBAR_PART)) {
-			const alignment = this.layoutService.getPanelAlignment();
-			const sideBarOnLeft = this.layoutService.getSideBarPosition() === Position.LEFT;
-			// isSiblingToEditor mirrors adjustPartPositions: sidebar/aux is in the same row as the
-			// editor (and therefore faces the panel below, not the window edge).
-			const isSiblingToEditor = this.partId === Parts.SIDEBAR_PART
-				? !(alignment === 'center' || (sideBarOnLeft && alignment === 'right') || (!sideBarOnLeft && alignment === 'left'))
-				: !(alignment === 'center' || (!sideBarOnLeft && alignment === 'right') || (sideBarOnLeft && alignment === 'left'));
-			if (isSiblingToEditor) {
+			if (this.isSidebarSiblingToEditor()) {
 				isAtWindowBottom = false;
 			}
 		}

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -13,7 +13,6 @@ import { IViewDescriptorService, ViewContainerLocation } from '../../common/view
 import { DisposableStore, MutableDisposable } from '../../../base/common/lifecycle.js';
 import { IView } from '../../../base/browser/ui/grid/grid.js';
 import { IWorkbenchLayoutService, Parts, Position, SINGLE_WINDOW_PARTS, FLOATING_PANEL_MARGIN, getFloatingOuterGutterEdges, getFloatingSidebarSiblingToEditorStatus } from '../../services/layout/browser/layoutService.js';
-import { mainWindow } from '../../../base/browser/window.js';
 import { CompositePart, ICompositePartOptions, ICompositeTitleLabel } from './compositePart.js';
 import { IPaneCompositeBarOptions, PaneCompositeBar } from './paneCompositeBar.js';
 import { Dimension, EventHelper, trackFocus, $, addDisposableListener, EventType, prepend, getWindow } from '../../../base/browser/dom.js';
@@ -697,7 +696,7 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 			}
 		}
 
-		const bottomMargin = !this.layoutService.isVisible(Parts.STATUSBAR_PART, mainWindow) && isAtWindowBottom
+		const bottomMargin = !this.layoutService.isVisible(Parts.STATUSBAR_PART, getWindow(this.element)) && isAtWindowBottom
 			? margin * 2 : margin;
 		const outerGutter = this.getFloatingOuterGutterEdges();
 		const leftMargin = outerGutter.left ? margin * 2 : margin;

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -666,6 +666,7 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 
 		const borderTotal = 2; // 1px border on each side
 		const margin = FLOATING_PANEL_MARGIN;
+		const panelVisible = this.layoutService.isVisible(Parts.PANEL_PART);
 		// Only the bottom-positioned panel needs a top margin (the gap between the editor and the
 		// panel card). Side bars and panels in all other positions are flush with the title bar —
 		// unless a sidebar is in the same grid row as the editor with panel at TOP, in which case
@@ -674,7 +675,7 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		let topMargin = isBottomPanel ? margin : 0;
 
 		if (topMargin === 0 &&
-			this.layoutService.isVisible(Parts.PANEL_PART) &&
+			panelVisible &&
 			this.layoutService.getPanelPosition() === Position.TOP &&
 			(this.partId === Parts.SIDEBAR_PART || this.partId === Parts.AUXILIARYBAR_PART)) {
 			if (this.isSidebarSiblingToEditor()) {
@@ -685,7 +686,7 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		// Whether a sidebar/aux bar faces the window edge or a bottom panel row depends on panel
 		// alignment — this mirrors the sideBarSiblingToEditor / auxiliaryBarSiblingToEditor logic
 		// in adjustPartPositions() in layout.ts.
-		const panelAtBottom = this.layoutService.isVisible(Parts.PANEL_PART) && this.layoutService.getPanelPosition() === Position.BOTTOM;
+		const panelAtBottom = panelVisible && this.layoutService.getPanelPosition() === Position.BOTTOM;
 		let isAtWindowBottom =
 			!(this.partId === Parts.PANEL_PART && this.layoutService.getPanelPosition() === Position.TOP); // panel at TOP: bottom faces editor
 

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -13,6 +13,7 @@ import { IViewDescriptorService, ViewContainerLocation } from '../../common/view
 import { DisposableStore, MutableDisposable } from '../../../base/common/lifecycle.js';
 import { IView } from '../../../base/browser/ui/grid/grid.js';
 import { IWorkbenchLayoutService, Parts, Position, SINGLE_WINDOW_PARTS, FLOATING_PANEL_MARGIN, getFloatingOuterGutterEdges } from '../../services/layout/browser/layoutService.js';
+import { mainWindow } from '../../../base/browser/window.js';
 import { CompositePart, ICompositePartOptions, ICompositeTitleLabel } from './compositePart.js';
 import { IPaneCompositeBarOptions, PaneCompositeBar } from './paneCompositeBar.js';
 import { Dimension, EventHelper, trackFocus, $, addDisposableListener, EventType, prepend, getWindow } from '../../../base/browser/dom.js';
@@ -659,12 +660,36 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		// panel card). Side bars and panels in all other positions are flush with the title bar.
 		const isBottomPanel = this.partId === Parts.PANEL_PART && this.layoutService.getPanelPosition() === Position.BOTTOM;
 		const topMargin = isBottomPanel ? margin : 0;
+		// When status bar is hidden, cards at the window bottom edge get a doubled bottom margin.
+		// Whether a sidebar/aux bar faces the window edge or a bottom panel row depends on panel
+		// alignment — this mirrors the sideBarSiblingToEditor / auxiliaryBarSiblingToEditor logic
+		// in adjustPartPositions() in layout.ts.
+		const panelAtBottom = this.layoutService.isVisible(Parts.PANEL_PART) && this.layoutService.getPanelPosition() === Position.BOTTOM;
+		let isAtWindowBottom =
+			!(this.partId === Parts.PANEL_PART && this.layoutService.getPanelPosition() === Position.TOP); // panel at TOP: bottom faces editor
+
+		if (isAtWindowBottom && panelAtBottom &&
+			(this.partId === Parts.SIDEBAR_PART || this.partId === Parts.AUXILIARYBAR_PART)) {
+			const alignment = this.layoutService.getPanelAlignment();
+			const sideBarOnLeft = this.layoutService.getSideBarPosition() === Position.LEFT;
+			// isSiblingToEditor mirrors adjustPartPositions: sidebar/aux is in the same row as the
+			// editor (and therefore faces the panel below, not the window edge).
+			const isSiblingToEditor = this.partId === Parts.SIDEBAR_PART
+				? !(alignment === 'center' || (sideBarOnLeft && alignment === 'right') || (!sideBarOnLeft && alignment === 'left'))
+				: !(alignment === 'center' || (!sideBarOnLeft && alignment === 'right') || (sideBarOnLeft && alignment === 'left'));
+			if (isSiblingToEditor) {
+				isAtWindowBottom = false;
+			}
+		}
+
+		const bottomMargin = !this.layoutService.isVisible(Parts.STATUSBAR_PART, mainWindow) && isAtWindowBottom
+			? margin * 2 : margin;
 		const outerGutter = this.getFloatingOuterGutterEdges();
 		const leftMargin = outerGutter.left ? margin * 2 : margin;
 		const rightMargin = outerGutter.right ? margin * 2 : margin;
 		return {
 			width: leftMargin + rightMargin + borderTotal,
-			height: topMargin + margin + borderTotal
+			height: topMargin + bottomMargin + borderTotal
 		};
 	}
 

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -12,7 +12,7 @@ import { IPaneComposite } from '../../common/panecomposite.js';
 import { IViewDescriptorService, ViewContainerLocation } from '../../common/views.js';
 import { DisposableStore, MutableDisposable } from '../../../base/common/lifecycle.js';
 import { IView } from '../../../base/browser/ui/grid/grid.js';
-import { IWorkbenchLayoutService, Parts, SINGLE_WINDOW_PARTS, FLOATING_PANEL_MARGIN, getFloatingOuterGutterEdges } from '../../services/layout/browser/layoutService.js';
+import { IWorkbenchLayoutService, Parts, Position, SINGLE_WINDOW_PARTS, FLOATING_PANEL_MARGIN, getFloatingOuterGutterEdges } from '../../services/layout/browser/layoutService.js';
 import { CompositePart, ICompositePartOptions, ICompositeTitleLabel } from './compositePart.js';
 import { IPaneCompositeBarOptions, PaneCompositeBar } from './paneCompositeBar.js';
 import { Dimension, EventHelper, trackFocus, $, addDisposableListener, EventType, prepend, getWindow } from '../../../base/browser/dom.js';
@@ -655,7 +655,10 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 
 		const borderTotal = 2; // 1px border on each side
 		const margin = FLOATING_PANEL_MARGIN;
-		const topMargin = this.partId === Parts.PANEL_PART ? margin : 0; // side bars are flush with the title bar
+		// Only the bottom-positioned panel needs a top margin (the gap between the editor and the
+		// panel card). Side bars and panels in all other positions are flush with the title bar.
+		const isBottomPanel = this.partId === Parts.PANEL_PART && this.layoutService.getPanelPosition() === Position.BOTTOM;
+		const topMargin = isBottomPanel ? margin : 0;
 		const outerGutter = this.getFloatingOuterGutterEdges();
 		const leftMargin = outerGutter.left ? margin * 2 : margin;
 		const rightMargin = outerGutter.right ? margin * 2 : margin;

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -220,6 +220,24 @@ export function getFloatingOuterGutterEdges(layoutService: IWorkbenchLayoutServi
 }
 
 /**
+ * Whether the primary sidebar and auxiliary bar are each in the same grid row as the
+ * editor (sibling to the editor) for a horizontal panel. A bar that is a sibling is not
+ * full-height; it sits above or below the panel row rather than spanning the full height.
+ * Mirrors the sideBarSiblingToEditor / auxiliaryBarSiblingToEditor formula used in
+ * adjustPartPositions() in layout.ts.
+ */
+export function getFloatingSidebarSiblingToEditorStatus(
+	layoutService: IWorkbenchLayoutService
+): { sideBar: boolean; auxBar: boolean } {
+	const alignment = layoutService.getPanelAlignment();
+	const sideBarOnLeft = layoutService.getSideBarPosition() === Position.LEFT;
+	return {
+		sideBar: !(alignment === 'center' || (sideBarOnLeft && alignment === 'right') || (!sideBarOnLeft && alignment === 'left')),
+		auxBar: !(alignment === 'center' || (!sideBarOnLeft && alignment === 'right') || (sideBarOnLeft && alignment === 'left')),
+	};
+}
+
+/**
  * Whether a visible horizontal (bottom/top) panel reaches each window edge and should
  * therefore receive a doubled outer gutter so it aligns with the editor card above it.
  * The panel spans underneath a bar that is not full-height, and reaches an edge whenever
@@ -232,12 +250,7 @@ function getFloatingHorizontalPanelOuterEdges(layoutService: IWorkbenchLayoutSer
 	}
 
 	const sideBarLeft = layoutService.getSideBarPosition() === Position.LEFT;
-	const alignment = layoutService.getPanelAlignment();
-
-	// A bar that is a sibling of the editor is not full-height, so the panel spans
-	// underneath it to the window edge (panel is horizontal, so `isPanelVertical` is false).
-	const sideBarSiblingToEditor = !(alignment === 'center' || (sideBarLeft && alignment === 'right') || (!sideBarLeft && alignment === 'left'));
-	const auxSiblingToEditor = !(alignment === 'center' || (!sideBarLeft && alignment === 'right') || (sideBarLeft && alignment === 'left'));
+	const { sideBar: sideBarSiblingToEditor, auxBar: auxSiblingToEditor } = getFloatingSidebarSiblingToEditorStatus(layoutService);
 
 	const sideBarSideReached = !layoutService.isVisible(Parts.ACTIVITYBAR_PART) && (!layoutService.isVisible(Parts.SIDEBAR_PART) || sideBarSiblingToEditor);
 	const auxSideReached = !layoutService.isVisible(Parts.AUXILIARYBAR_PART) || auxSiblingToEditor;

--- a/src/vs/workbench/services/layout/test/browser/layoutService.test.ts
+++ b/src/vs/workbench/services/layout/test/browser/layoutService.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { getFloatingOuterEdgeOwners, Parts, Position } from '../../browser/layoutService.js';
+import { getFloatingOuterEdgeOwners, getFloatingSidebarSiblingToEditorStatus, PanelAlignment, Parts, Position } from '../../browser/layoutService.js';
 import { TestLayoutService } from '../../../../test/browser/workbenchTestServices.js';
 
 suite('LayoutService - getFloatingOuterEdgeOwners', () => {
@@ -77,6 +77,55 @@ suite('LayoutService - getFloatingOuterEdgeOwners', () => {
 			verticalPanelFull: { left: undefined, right: Parts.AUXILIARYBAR_PART },
 			maximizedVerticalPanel: { left: Parts.PANEL_PART, right: Parts.PANEL_PART },
 			horizontalPanelVisible: { left: Parts.SIDEBAR_PART, right: Parts.AUXILIARYBAR_PART },
+		});
+	});
+});
+
+suite('LayoutService - getFloatingSidebarSiblingToEditorStatus', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	class SiblingStatusLayoutService extends TestLayoutService {
+		sideBarPosition = Position.LEFT;
+		panelAlignment: PanelAlignment = 'center';
+
+		override getSideBarPosition(): Position { return this.sideBarPosition; }
+		override getPanelAlignment(): PanelAlignment { return this.panelAlignment; }
+	}
+
+	function siblingStatus(configure: (s: SiblingStatusLayoutService) => void): { sideBar: boolean; auxBar: boolean } {
+		const s = new SiblingStatusLayoutService();
+		configure(s);
+		return getFloatingSidebarSiblingToEditorStatus(s);
+	}
+
+	test('sibling-to-editor status across alignment and sidebar-position combinations', () => {
+		const actual = {
+			// center: neither bar is a sibling (both span full height)
+			centerLeft: siblingStatus(s => { s.sideBarPosition = Position.LEFT; s.panelAlignment = 'center'; }),
+			centerRight: siblingStatus(s => { s.sideBarPosition = Position.RIGHT; s.panelAlignment = 'center'; }),
+			// justify: both bars are siblings (panel spans the full width)
+			justifyLeft: siblingStatus(s => { s.sideBarPosition = Position.LEFT; s.panelAlignment = 'justify'; }),
+			justifyRight: siblingStatus(s => { s.sideBarPosition = Position.RIGHT; s.panelAlignment = 'justify'; }),
+			// left alignment, sidebar on LEFT: sidebar IS sibling, aux bar is NOT
+			leftAlignSidebarLeft: siblingStatus(s => { s.sideBarPosition = Position.LEFT; s.panelAlignment = 'left'; }),
+			// left alignment, sidebar on RIGHT: sidebar is NOT sibling, aux bar IS
+			leftAlignSidebarRight: siblingStatus(s => { s.sideBarPosition = Position.RIGHT; s.panelAlignment = 'left'; }),
+			// right alignment, sidebar on LEFT: sidebar is NOT sibling, aux bar IS
+			rightAlignSidebarLeft: siblingStatus(s => { s.sideBarPosition = Position.LEFT; s.panelAlignment = 'right'; }),
+			// right alignment, sidebar on RIGHT: sidebar IS sibling, aux bar is NOT
+			rightAlignSidebarRight: siblingStatus(s => { s.sideBarPosition = Position.RIGHT; s.panelAlignment = 'right'; }),
+		};
+
+		assert.deepStrictEqual(actual, {
+			centerLeft: { sideBar: false, auxBar: false },
+			centerRight: { sideBar: false, auxBar: false },
+			justifyLeft: { sideBar: true, auxBar: true },
+			justifyRight: { sideBar: true, auxBar: true },
+			leftAlignSidebarLeft: { sideBar: true, auxBar: false },
+			leftAlignSidebarRight: { sideBar: false, auxBar: true },
+			rightAlignSidebarLeft: { sideBar: false, auxBar: true },
+			rightAlignSidebarRight: { sideBar: true, auxBar: false },
 		});
 	});
 });

--- a/src/vs/workbench/services/layout/test/browser/layoutService.test.ts
+++ b/src/vs/workbench/services/layout/test/browser/layoutService.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { getFloatingOuterEdgeOwners, getFloatingSidebarSiblingToEditorStatus, PanelAlignment, Parts, Position } from '../../browser/layoutService.js';
+import { getFloatingOuterEdgeOwners, getFloatingSidebarSiblingToEditorStatus, type PanelAlignment, Parts, Position } from '../../browser/layoutService.js';
 import { TestLayoutService } from '../../../../test/browser/workbenchTestServices.js';
 
 suite('LayoutService - getFloatingOuterEdgeOwners', () => {


### PR DESCRIPTION
This pull request improves the layout and margin logic for floating panels in the workbench, ensuring consistent gaps and visual alignment between UI elements (panel, editor, sidebars, auxiliary bar), especially when panels are at the top or bottom and the status bar is hidden. It introduces a shared utility for determining when sidebars/auxiliary bars are "siblings" to the editor (i.e., in the same grid row), and updates both layout logic and CSS to use this. The changes also add targeted tests for the new utility.

**Layout logic and utilities:**

* Added `getFloatingSidebarSiblingToEditorStatus` to centralize the logic for determining when the sidebar/auxiliary bar is a sibling to the editor, used throughout layout calculations for consistent margin and positioning behavior. [[1]](diffhunk://#diff-d132005d10db590379d0c566ff130fbccb332b4adf75ee6d94865b7431169d0aR222-R239) [[2]](diffhunk://#diff-d132005d10db590379d0c566ff130fbccb332b4adf75ee6d94865b7431169d0aL235-R253)
* Updated margin and layout calculations in `editorPart.ts` and `paneCompositePart.ts` to use the new sibling status utility, ensuring correct top/bottom margins depending on panel position, visibility, and status bar state. [[1]](diffhunk://#diff-9ef2ceca71dfbda41fe00e81938e88f667381e4b23422aaab2b4047a1911f17cL1395-R1405) [[2]](diffhunk://#diff-334088d7f4a68f16fd29d2f85973533e0daa1c631e39408adf41d3b6f407ae31L658-R707) [[3]](diffhunk://#diff-334088d7f4a68f16fd29d2f85973533e0daa1c631e39408adf41d3b6f407ae31R643-R652)
* Updated main container and panel classes to reflect current panel position and alignment, enabling more precise CSS targeting. [[1]](diffhunk://#diff-078b5d27a2efa14fa7a778b52365c0cb1f26a34779ff90b81c26712cdd670da3L1905-R1907) [[2]](diffhunk://#diff-078b5d27a2efa14fa7a778b52365c0cb1f26a34779ff90b81c26712cdd670da3R2039-R2043) [[3]](diffhunk://#diff-078b5d27a2efa14fa7a778b52365c0cb1f26a34779ff90b81c26712cdd670da3R2375-R2376)

**CSS and visual consistency:**

* Added and refined CSS rules in `floatingPanels.css` to apply correct margins to sidebars, auxiliary bars, panels, and editor depending on panel position, alignment, and status bar visibility. This ensures consistent inter-card gaps and doubled gutters at window edges when the status bar is hidden. [[1]](diffhunk://#diff-96cb2d8573ce4ce529610b032f2044a61b322357bff73870ab0196ceec6f17b3R51-R73) [[2]](diffhunk://#diff-96cb2d8573ce4ce529610b032f2044a61b322357bff73870ab0196ceec6f17b3R94-R100) [[3]](diffhunk://#diff-96cb2d8573ce4ce529610b032f2044a61b322357bff73870ab0196ceec6f17b3R162-R207)

**Testing:**

* Added comprehensive unit tests for the new `getFloatingSidebarSiblingToEditorStatus` utility, covering all combinations of sidebar position and panel alignment. [[1]](diffhunk://#diff-087163ab29a6afa6880d0f53428b8ebe8463b8e0a42c69b2c384d04039cd3054L8-R8) [[2]](diffhunk://#diff-087163ab29a6afa6880d0f53428b8ebe8463b8e0a42c69b2c384d04039cd3054R83-R131)