### PR TITLE
sessions: reveal new chat session group when created

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -2233,6 +2233,21 @@ export class SessionsList extends Disposable implements ISessionsList {
 		const group = this._sessionGroupsService.createGroup(localize('newGroupName', "New Group"), groupSessions.map(s => s.sessionId));
 		this._editingGroupId = group.id;
 		this.update();
+		this.revealGroup(group.id);
+	}
+
+	/** Scroll the group's header into view so its inline name editor is visible. */
+	private revealGroup(groupId: string): void {
+		const root = this.tree.getNode();
+		for (const node of root.children) {
+			const element = node.element;
+			if (element && isSessionGroupItem(element) && element.group.id === groupId) {
+				if (this.tree.hasElement(element) && this.tree.getRelativeTop(element) === null) {
+					this.tree.reveal(element, 0.5);
+				}
+				return;
+			}
+		}
 	}
 
 	/** Begin inline renaming of the group's header. */


### PR DESCRIPTION
When creating a new group in the sessions list, the group header (with its focused inline name editor) was not scrolled into view, so it could be created off-screen.

This change reveals the newly created group's header after the tree rebuilds, mirroring the existing session `reveal` pattern: it centers the header in the viewport only when it isn't already visible.

Fixes #323528