### PR TITLE
Close diff/multi-diff editor on agent feedback submit

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorOverlay.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorOverlay.ts
@@ -35,7 +35,7 @@ class SubmitFeedbackActionRunner extends ActionRunner {
 	protected override async runAction(action: IAction, context?: unknown): Promise<void> {
 		const editorToClose = action.id === submitFeedbackActionId ? this._editorGroup.activeEditor : undefined;
 		const didSubmit = await action.run(context);
-		if (didSubmit === true && editorToClose && this._editorGroup.contains(editorToClose)) {
+		if (didSubmit === true && editorToClose) {
 			await this._editorGroup.closeEditor(editorToClose);
 		}
 	}


### PR DESCRIPTION
Pressing **Submit** in the agent feedback editor overlay now closes the overlay group's active editor regardless of editor type.

### Problem
The overlay shows for diff editors and multi-diff editors that contain a session file, but pressing Submit did not close those editors — only plain file editors closed.

### Fix
In SubmitFeedbackActionRunner.runAction, drop the 	his._editorGroup.contains(editorToClose) guard so the captured active editor of the overlay's group is closed once submission succeeds. This covers single-file diff and multi-diff editors the same as plain file editors.