### PR TITLE
Unpin sessions when creating or adding to a group

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -2230,6 +2230,9 @@ export class SessionsList extends Disposable implements ISessionsList {
 		if (groupSessions.length === 0) {
 			return;
 		}
+		for (const session of groupSessions) {
+			this._sessionsListModelService.unpinSession(session);
+		}
 		const group = this._sessionGroupsService.createGroup(localize('newGroupName', "New Group"), groupSessions.map(s => s.sessionId));
 		this._editingGroupId = group.id;
 		this.update();
@@ -2247,6 +2250,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 	addSessionsToGroup(sessions: ISession[], groupId: string, target?: ISession, position?: 'before' | 'after'): void {
 		const groupSessions = sessions.filter(session => !session.isArchived.get());
 		for (const session of groupSessions) {
+			this._sessionsListModelService.unpinSession(session);
 			this._sessionGroupsService.addToGroup(session.sessionId, groupId);
 		}
 		if (target && position) {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -2230,9 +2230,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		if (groupSessions.length === 0) {
 			return;
 		}
-		for (const session of groupSessions) {
-			this._sessionsListModelService.unpinSession(session);
-		}
+		this._sessionsListModelService.unpinSessions(groupSessions);
 		const group = this._sessionGroupsService.createGroup(localize('newGroupName', "New Group"), groupSessions.map(s => s.sessionId));
 		this._editingGroupId = group.id;
 		this.update();
@@ -2249,10 +2247,8 @@ export class SessionsList extends Disposable implements ISessionsList {
 
 	addSessionsToGroup(sessions: ISession[], groupId: string, target?: ISession, position?: 'before' | 'after'): void {
 		const groupSessions = sessions.filter(session => !session.isArchived.get());
-		for (const session of groupSessions) {
-			this._sessionsListModelService.unpinSession(session);
-			this._sessionGroupsService.addToGroup(session.sessionId, groupId);
-		}
+		this._sessionsListModelService.unpinSessions(groupSessions);
+		this._sessionGroupsService.addToGroup(groupSessions.map(s => s.sessionId), groupId);
 		if (target && position) {
 			this.reorderSessions(groupSessions, target, position);
 		}

--- a/src/vs/sessions/services/sessions/browser/sessionGroupsService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionGroupsService.ts
@@ -74,6 +74,12 @@ export interface ISessionGroupsService {
 	/** Add a session to a group (removing it from any previous group). */
 	addToGroup(sessionId: string, groupId: string): void;
 
+	/**
+	 * Add multiple sessions to a group at once (removing them from any previous
+	 * group), firing a single change event.
+	 */
+	addToGroup(sessionIds: Iterable<string>, groupId: string): void;
+
 	/** Remove a session from its group, if any. */
 	removeFromGroup(sessionId: string): void;
 
@@ -263,12 +269,18 @@ export class SessionGroupsService extends Disposable implements ISessionGroupsSe
 		this._onDidChange.fire({ groupsChanged: true, membershipChanged });
 	}
 
-	addToGroup(sessionId: string, groupId: string): void {
-		if (!this._groups.has(groupId) || this._membership.get(sessionId) === groupId) {
+	addToGroup(sessionIdOrIds: string | Iterable<string>, groupId: string): void {
+		if (!this._groups.has(groupId)) {
 			return;
 		}
+		const sessionIds = typeof sessionIdOrIds === 'string' ? [sessionIdOrIds] : sessionIdOrIds;
 		const membershipChanged = new Set<string>();
-		this.setMembership(sessionId, groupId, membershipChanged);
+		for (const sessionId of sessionIds) {
+			this.setMembership(sessionId, groupId, membershipChanged);
+		}
+		if (membershipChanged.size === 0) {
+			return;
+		}
 		const evicted = this.evictExcessEmptyGroups();
 		this.save();
 		this._onDidChange.fire({ groupsChanged: evicted, membershipChanged });

--- a/src/vs/sessions/services/sessions/browser/sessionsListModelService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsListModelService.ts
@@ -47,6 +47,7 @@ export interface ISessionsListModelService {
 
 	pinSession(session: ISession): void;
 	unpinSession(session: ISession): void;
+	unpinSessions(sessions: ISession[]): void;
 	isSessionPinned(session: ISession): boolean;
 
 	// -- Read/Unread --
@@ -180,6 +181,19 @@ export class SessionsListModelService extends Disposable implements ISessionsLis
 		this._pinnedSessionIds.delete(session.sessionId);
 		this.saveSet(SessionsListModelService.PINNED_SESSIONS_KEY, this._pinnedSessionIds);
 		this._onDidChange.fire({ changes: [{ sessionId: session.sessionId, kind: SessionListModelChangeKind.Pinned }] });
+	}
+
+	unpinSessions(sessions: ISession[]): void {
+		const changed: { sessionId: string; kind: SessionListModelChangeKind }[] = [];
+		for (const session of sessions) {
+			if (this._pinnedSessionIds.delete(session.sessionId)) {
+				changed.push({ sessionId: session.sessionId, kind: SessionListModelChangeKind.Pinned });
+			}
+		}
+		if (changed.length > 0) {
+			this.saveSet(SessionsListModelService.PINNED_SESSIONS_KEY, this._pinnedSessionIds);
+			this._onDidChange.fire({ changes: changed });
+		}
 	}
 
 	isSessionPinned(session: ISession): boolean {

--- a/src/vs/sessions/services/sessions/test/browser/sessionGroupsService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionGroupsService.test.ts
@@ -104,6 +104,29 @@ suite('SessionGroupsService', () => {
 		assert.deepStrictEqual(service.getSessionIdsInGroup(b.id), ['s1']);
 	});
 
+	test('addToGroup adds multiple sessions in a single change event', () => {
+		const a = service.createGroup('A');
+		let changeCount = 0;
+		disposables.add(service.onDidChange(() => changeCount++));
+
+		service.addToGroup(['s1', 's2', 's3'], a.id);
+
+		assert.deepStrictEqual(
+			[service.getSessionIdsInGroup(a.id), changeCount],
+			[['s1', 's2', 's3'], 1]
+		);
+	});
+
+	test('addToGroup with multiple sessions does not fire when none change', () => {
+		const a = service.createGroup('A', ['s1', 's2']);
+		let changeCount = 0;
+		disposables.add(service.onDidChange(() => changeCount++));
+
+		service.addToGroup(['s1', 's2'], a.id);
+
+		assert.strictEqual(changeCount, 0);
+	});
+
 	test('remove from group clears membership', () => {
 		const a = service.createGroup('A', ['s1', 's2']);
 		service.removeFromGroup('s1');

--- a/src/vs/sessions/services/sessions/test/browser/sessionsListModelService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsListModelService.test.ts
@@ -120,6 +120,34 @@ suite('SessionsListModelService', () => {
 		assert.strictEqual(service.isSessionPinned(s2), false);
 	});
 
+	test('unpinSessions unpins multiple sessions and fires once', () => {
+		const s1 = createSession('s1');
+		const s2 = createSession('s2');
+		const s3 = createSession('s3');
+		service.pinSession(s1);
+		service.pinSession(s2);
+		let changeCount = 0;
+		disposables.add(service.onDidChange(() => changeCount++));
+
+		service.unpinSessions([s1, s2, s3]);
+
+		assert.deepStrictEqual(
+			[service.isSessionPinned(s1), service.isSessionPinned(s2), changeCount],
+			[false, false, 1]
+		);
+	});
+
+	test('unpinSessions does not fire when none are pinned', () => {
+		const s1 = createSession('s1');
+		const s2 = createSession('s2');
+		let changeCount = 0;
+		disposables.add(service.onDidChange(() => changeCount++));
+
+		service.unpinSessions([s1, s2]);
+
+		assert.strictEqual(changeCount, 0);
+	});
+
 	// -- Read/Unread --
 
 	test('markRead marks session as read', () => {


### PR DESCRIPTION
Fixes #323540

When creating a group from a pinned session or adding a pinned session to an existing group, the session is now unpinned first. This keeps pinning and group membership mutually exclusive so a session does not appear in both the pinned section and a group, giving a clear visible indication that the session moved into the group.

## Changes
- `createGroupFromSessions` now unpins each session before creating the group.
- `addSessionsToGroup` now unpins each session before adding it to the group.

Both the context-menu actions (Create Group / Add to Group / Move to Group) and drag-and-drop routes flow through these methods, so all paths are covered. `unpinSession` is a no-op for sessions that are not pinned.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>