### PR TITLE
Style Overrides: Adjust padding for activity bar and panel titles

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -262,6 +262,7 @@
 	box-sizing: border-box;
 	height: 24px;
 	line-height: 24px;
+	margin-bottom: 4px;
 }
 
 .style-override.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label::before,
@@ -284,6 +285,7 @@
 	height: 24px;
 	padding: 0;
 	width: 24px;
+	margin-bottom: 4px;
 }
 
 .style-override.monaco-workbench .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .active-item-indicator,
@@ -302,3 +304,7 @@
 	gap: 4px;
 }
 
+.style-override.monaco-workbench .pane-composite-part > .title.has-composite-bar > .title-actions .monaco-action-bar .action-item,
+.style-override.monaco-workbench .pane-composite-part > .title.has-composite-bar > .global-actions .monaco-action-bar .action-item {
+	margin-bottom: 4px;
+}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -89,6 +89,8 @@
 }
 
 .style-override.monaco-workbench .part.basepanel.bottom .composite.title,
-.style-override.monaco-workbench .part.basepanel.top .composite.title {
+.style-override.monaco-workbench .part.basepanel.top .composite.title,
+.style-override.monaco-workbench .part.basepanel.left .composite.title,
+.style-override.monaco-workbench .part.basepanel.right .composite.title {
 	padding-right: 0;
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -77,6 +77,7 @@
 .style-override.monaco-workbench .chat-viewpane.has-sessions-control .agent-sessions-container {
 	.agent-sessions-title-container {
 		padding-left: 12px;
+		padding-right: 0;
 	}
 }
 

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -86,3 +86,8 @@
 .style-override.monaco-workbench .activitybar:not(.top):not(.bottom) > .content > :not(.composite-bar):last-child {
 	margin-bottom: calc(var(--vscode-spacing-size20, 2px) + var(--vscode-strokeThickness, 1px));
 }
+
+.style-override.monaco-workbench .part.basepanel.bottom .composite.title,
+.style-override.monaco-workbench .part.basepanel.top .composite.title {
+	padding-right: 0;
+}


### PR DESCRIPTION
This pull request introduces several small CSS adjustments to improve the visual consistency and spacing of UI elements in the workbench, particularly around the activity bar, panel titles, and chat session controls.

**Activity Bar and Panel Spacing Adjustments:**
* Added a `margin-bottom: 4px;` to various `.action-item` elements in the activity bar and pane composite titles for improved vertical spacing. [[1]](diffhunk://#diff-c718522311de21a7658a924bbd223350855e39acf9ddd9e1c4eaffa8f76a34dbR265) [[2]](diffhunk://#diff-c718522311de21a7658a924bbd223350855e39acf9ddd9e1c4eaffa8f76a34dbR288) [[3]](diffhunk://#diff-c718522311de21a7658a924bbd223350855e39acf9ddd9e1c4eaffa8f76a34dbR307-R310)

**Panel Title and Chat Session Padding Fixes:**
* Set `padding-right: 0;` for `.composite.title` elements in all panel positions to standardize panel header padding.
* Added `padding-right: 0;` to the `.agent-sessions-title-container` in chat view panes for consistent alignment.