### PR TITLE
Fix Copilot sanity tests

### DIFF
--- a/extensions/copilot/script/setup/getEnv.mts
+++ b/extensions/copilot/script/setup/getEnv.mts
@@ -58,7 +58,6 @@ async function fetchSecrets(): Promise<{ [key: string]: string | undefined }> {
 
 	if (!process.stdin.isTTY) { // only in automation
 		secrets['GITHUB_OAUTH_TOKEN'] = await fetchSecret(keyVaultClient, 'capi-oauth-pipeline-token');
-		secrets['VSCODE_COPILOT_CHAT_TOKEN'] = await fetchSecret(keyVaultClient, 'copilot-token');
 		secrets['BLACKBIRD_EMBEDDINGS_KEY'] = await fetchSecret(keyVaultClient, 'vsc-aoai-key');
 		secrets['BLACKBIRD_REDIS_CACHE_KEY'] = await fetchSecret(keyVaultClient, 'blackbird-redis-cache-key');
 

--- a/extensions/copilot/src/extension/byok/node/test/openAIEndpoint.spec.ts
+++ b/extensions/copilot/src/extension/byok/node/test/openAIEndpoint.spec.ts
@@ -246,8 +246,19 @@ describe('OpenAIEndpoint - Reasoning Properties', () => {
 
 	describe('Responses API mode (useResponsesApi = true)', () => {
 		it('should preserve reasoning object when thinking is supported', () => {
+			const modelWithReasoningEffort = {
+				...modelMetadata,
+				capabilities: {
+					...modelMetadata.capabilities,
+					supports: {
+						...modelMetadata.capabilities.supports,
+						reasoning_effort: ['low', 'medium', 'high']
+					}
+				}
+			};
+
 			const endpoint = instaService.createInstance(OpenAIEndpoint,
-				modelMetadata,
+				modelWithReasoningEffort,
 				'test-api-key',
 				'https://api.openai.com/v1/chat/completions');
 

--- a/extensions/copilot/src/extension/test/vscode-node/sanity.sanity-test.ts
+++ b/extensions/copilot/src/extension/test/vscode-node/sanity.sanity-test.ts
@@ -89,7 +89,7 @@ suite('Copilot Chat Sanity Test', function () {
 		});
 	});
 
-	test.skip('E2E Production Panel Chat Test', async function () {
+	test('E2E Production Panel Chat Test', async function () {
 		assert.ok(realInstaAccessor, 'Instantiation service accessor is not available');
 
 		await realInstaAccessor.invokeFunction(async (accessor) => {
@@ -120,7 +120,7 @@ suite('Copilot Chat Sanity Test', function () {
 	 * Runs tools outside of a real chat session which is unusual but lets us spy more
 	 * Uses an empty window with no folder open
 	 */
-	test.skip('E2E Production agent mode', async function () {
+	test('E2E Production agent mode', async function () {
 		assert.ok(realInstaAccessor, 'Instantiation service accessor is not available');
 
 		await realInstaAccessor.invokeFunction(async (accessor) => {
@@ -187,7 +187,7 @@ suite('Copilot Chat Sanity Test', function () {
 		});
 	});
 
-	test.skip('Slash Commands work properly', async function () {
+	test('Slash Commands work properly', async function () {
 		assert.ok(realInstaAccessor);
 
 		await realInstaAccessor.invokeFunction(async (accessor) => {

--- a/extensions/copilot/src/platform/endpoint/node/modelMetadataFetcher.ts
+++ b/extensions/copilot/src/platform/endpoint/node/modelMetadataFetcher.ts
@@ -175,7 +175,10 @@ export class ModelMetadataFetcher extends Disposable implements IModelMetadataFe
 		await this._taskSingler.getOrCreate(ModelMetadataFetcher.ALL_MODEL_KEY, this._fetchModels.bind(this));
 		const resolvedModel = this._copilotUtilityModel;
 		if (!resolvedModel || !isChatModelInformation(resolvedModel)) {
-			throw new Error(await this._getErrorMessage('Unable to resolve Copilot utility chat model (server did not mark a chat fallback model)'));
+			// If the model fetch itself failed (e.g. an expired token returning HTTP 401), surface that
+			// underlying error rather than the misleading "no fallback model" message, which only makes
+			// sense when the fetch succeeded but the server genuinely marked no chat fallback.
+			throw this._lastFetchError ?? new Error(await this._getErrorMessage('Unable to resolve Copilot utility chat model (server did not mark a chat fallback model)'));
 		}
 		return resolvedModel;
 	}
@@ -184,7 +187,7 @@ export class ModelMetadataFetcher extends Disposable implements IModelMetadataFe
 		await this._taskSingler.getOrCreate(ModelMetadataFetcher.ALL_MODEL_KEY, this._fetchModels.bind(this));
 		const resolvedModel = this._familyMap.get(family)?.[0];
 		if (!resolvedModel || !isChatModelInformation(resolvedModel)) {
-			throw new Error(await this._getErrorMessage(`Unable to resolve chat model with CAPI family selection: ${family}`));
+			throw this._lastFetchError ?? new Error(await this._getErrorMessage(`Unable to resolve chat model with CAPI family selection: ${family}`));
 		}
 		return resolvedModel;
 	}
@@ -220,7 +223,7 @@ export class ModelMetadataFetcher extends Disposable implements IModelMetadataFe
 		await this._taskSingler.getOrCreate(ModelMetadataFetcher.ALL_MODEL_KEY, this._fetchModels.bind(this));
 		const resolvedModel = this._familyMap.get(family)?.[0];
 		if (!resolvedModel || !isEmbeddingModelInformation(resolvedModel)) {
-			throw new Error(await this._getErrorMessage(`Unable to resolve embeddings model with family selection: ${family}`));
+			throw this._lastFetchError ?? new Error(await this._getErrorMessage(`Unable to resolve embeddings model with family selection: ${family}`));
 		}
 		return resolvedModel;
 	}

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -159,7 +159,7 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 	const effort = endpoint.supportsReasoningEffort?.length
 		? (effortFromSetting || options.modelCapabilities?.reasoningEffort || 'medium')
 		: undefined;
-	const summary = 'off';
+	const summary: string | undefined = undefined;
 	const persistentCoTEnabled = configService.getExperimentBasedConfig(ConfigKey.ResponsesApiPersistentCoTEnabled, expService)
 		&& (isGpt54(endpoint) || isGpt55(endpoint) || isHiddenModelM(endpoint));
 	if (effort || summary || persistentCoTEnabled) {

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -378,7 +378,7 @@ describe('createResponsesRequestBody', () => {
 
 		const body = instantiationService.invokeFunction(servicesAccessor => createResponsesRequestBody(servicesAccessor, createRequestOptions([], false), endpoint.model, endpoint));
 
-		expect(body.reasoning).toEqual({ effort: 'medium', summary: 'off', context: 'all_turns' });
+		expect(body.reasoning).toEqual({ effort: 'medium', context: 'all_turns' });
 
 		accessor.dispose();
 		services.dispose();


### PR DESCRIPTION
## Problem

The Copilot **sanity tests** have been failing in product builds (e.g. 452247, 452261, 452262) with:

```
Error: Unable to resolve Copilot utility chat model (server did not mark a chat fallback model)
    at ModelMetadataFetcher.getCopilotUtilityModel
```

### Root cause

The sanity tests resolve their Copilot token via `getOrCreateTestingCopilotTokenManager`, which prefers `VSCODE_COPILOT_CHAT_TOKEN` (set in `getEnv.mts` from the `copilot-token` Key Vault secret) over `GITHUB_OAUTH_TOKEN`.

`copilot-token` is a **pre-minted** Copilot token refreshed out-of-band by a separate scheduled pipeline. That refresher reads a GitHub OAuth secret that was rotated/removed during a security incident, so it started failing — leaving `copilot-token` stale and **expired**. `StaticExtendedTokenInfoCopilotTokenManager` returns that token verbatim (no expiry check/refresh), so CAPI `GET /models` returns **`401 IDE token expired`**, no model is resolved, and the code throws the misleading *"server did not mark a chat fallback model"* error.

Once the token issue was resolved, a second, independent failure surfaced ([build 452375](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=452375&view=results)) — a `400 invalid_request_body` from the model:

```
Error: Sorry, your request failed. Please try again.
Reason: Request Failed: 400 {"error":{"message":"Invalid value: 'off'. Supported values are: 'concise', 'detailed', and 'auto'.","code":"invalid_request_body"}}
```

## Changes

1. **Token resolution** (`getEnv.mts`): stop setting `VSCODE_COPILOT_CHAT_TOKEN` from the static `copilot-token` secret. The tests fall through to `GITHUB_OAUTH_TOKEN` (`capi-oauth-pipeline-token`) and mint a **fresh, self-refreshing** Copilot token on demand — no dependency on the external refresher, and the OAuth token stays out of eval-agent code paths.

2. **Better diagnostics** (`modelMetadataFetcher.ts`): surface the underlying model-fetch error (e.g. the `401 token expired`) from the resolve methods instead of the misleading "server did not mark a chat fallback model" message.

3. **Re-enable sanity tests** (`sanity.sanity-test.ts`): un-skip the three tests temporarily skipped in #323684.

4. **Fix invalid reasoning summary value** (`responsesApi.ts` + spec): #323639 disabled Responses API reasoning summaries by hard-coding `reasoning.summary = 'off'`, but the Responses API only accepts `concise`/`detailed`/`auto` (or omitting the field to disable). `gpt-5.3-codex` — the current chat-fallback/utility model the sanity tests use — rejects `'off'` with the `400 invalid_request_body` shown above. This surfaced once the token fix let the tests actually reach the model. Set `summary` to `undefined` so the field is omitted (summaries stay disabled, as intended). The regression was introduced by #323639; note that #323639 is not in `release/1.127`, so this part is a `main`-only fix.

## Verification

- Replayed the two-step flow with `capi-oauth-pipeline-token`: token exchange → 200, `/models` → 200 with a model marked `is_chat_fallback`.
- Replayed with the stale `copilot-token`: `/models` → 401 "IDE token expired".
- [Build 452375](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=452375&view=results) confirmed the token fix works end-to-end (tests reach the model); the remaining `400 'off'` failure is addressed by change #4.
- `responsesApi.spec.ts` unit tests pass (45/45); hygiene precommit passed.

## Notes

Follow-ups (separate, owned by evals/security): remove the GitHub OAuth token dependency from eval runs and restrict the eval service principals from vault-wide read on `copilot-automation`.