### PR TITLE
Make max results configurable

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -4351,6 +4351,24 @@
               "experimental",
               "onExp"
             ]
+          },
+          "github.copilot.chat.tools.grepSearch.defaultMaxResults": {
+            "type": "number",
+            "default": 20,
+            "markdownDescription": "%github.copilot.chat.tools.grepSearch.defaultMaxResults%",
+            "tags": [
+              "experimental",
+              "onExp"
+            ]
+          },
+          "github.copilot.chat.tools.grepSearch.maxResultsCap": {
+            "type": "number",
+            "default": 200,
+            "markdownDescription": "%github.copilot.chat.tools.grepSearch.maxResultsCap%",
+            "tags": [
+              "experimental",
+              "onExp"
+            ]
           }
         }
       },

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -279,6 +279,8 @@
 	"github.copilot.config.rateLimitAutoSwitchToAuto": "Automatically switch to the Auto model and retry when you hit a per-model rate limit.",
 	"github.copilot.tools.createNewWorkspace.userDescription": "Scaffold a new workspace in VS Code",
 	"github.copilot.chat.tools.grepSearch.outputFormat": "The output format for the grep search tool. Can be either 'grep' or 'tag'. The default is 'tag'.",
+	"github.copilot.chat.tools.grepSearch.defaultMaxResults": "The default maximum number of results to return from the grep search tool. The default is 20.",
+	"github.copilot.chat.tools.grepSearch.maxResultsCap": "The maximum number of results that can be returned from the grep search tool. The default is 200.",
 	"copilot.tools.errors.description": "Check errors for a particular file",
 	"copilot.tools.applyPatch.description": "Edit text files in the workspace",
 	"copilot.tools.findTestFiles.description": "For a source code file, find the file that contains the tests. For a test file, find the file that contains the code under test",

--- a/extensions/copilot/src/extension/tools/node/findTextInFilesTool.tsx
+++ b/extensions/copilot/src/extension/tools/node/findTextInFilesTool.tsx
@@ -41,8 +41,6 @@ interface IFindTextInFilesToolParams {
 	includeIgnoredFiles?: boolean;
 }
 
-const MaxResultsCap = 200;
-
 interface FileMatch {
 	path: string;
 	matches: vscode.TextSearchMatch2[];
@@ -99,8 +97,9 @@ export class FindTextInFilesTool implements ICopilotTool<IFindTextInFilesToolPar
 		void this.sendSearchToolTelemetry(options, globResult, outputFormat);
 
 		checkCancellation(token);
-		const askedForTooManyResults = options.input.maxResults && options.input.maxResults > MaxResultsCap;
-		const maxResults = Math.min(options.input.maxResults ?? 20, MaxResultsCap);
+		const maxResultsCap = this.getMaxResultsCap();
+		const askedForTooManyResults = options.input.maxResults && options.input.maxResults > maxResultsCap;
+		const maxResults = Math.min(options.input.maxResults ?? this.getDefaultMaxResults(), maxResultsCap);
 		const isRegExp = options.input.isRegexp ?? true;
 		const queryIsValidRegex = this.isValidRegex(options.input.query);
 		const includeIgnoredFiles = options.input.includeIgnoredFiles ?? false;
@@ -154,14 +153,14 @@ Then if you want to include those files you can call the tool again by setting "
 		if (useGrepStyle) {
 			return this.renderGrepStyle(results, options, maxResults, globResult, isRegExp, noMatchInstructions, token);
 		} else {
-			return this.renderTagStyle(results, options, maxResults, globResult, askedForTooManyResults, isRegExp, noMatchInstructions, token);
+			return this.renderTagStyle(results, options, maxResults, maxResultsCap, globResult, askedForTooManyResults, isRegExp, noMatchInstructions, token);
 		}
 	}
 
-	private async renderTagStyle(results: vscode.TextSearchResult2[], options: vscode.LanguageModelToolInvocationOptions<IFindTextInFilesToolParams>, maxResults: number, globResult: InputGlobResult | undefined, askedForTooManyResults: boolean | number | undefined, isRegExp: boolean, noMatchInstructions: string | undefined, token: CancellationToken): Promise<vscode.ExtendedLanguageModelToolResult> {
+	private async renderTagStyle(results: vscode.TextSearchResult2[], options: vscode.LanguageModelToolInvocationOptions<IFindTextInFilesToolParams>, maxResults: number, maxResultsCap: number, globResult: InputGlobResult | undefined, askedForTooManyResults: boolean | number | undefined, isRegExp: boolean, noMatchInstructions: string | undefined, token: CancellationToken): Promise<vscode.ExtendedLanguageModelToolResult> {
 		const prompt = await renderPromptElementJSON(this.instantiationService,
 			FindTextInFilesResult,
-			{ textResults: results, maxResults, askedForTooManyResults: Boolean(askedForTooManyResults), noMatchInstructions },
+			{ textResults: results, maxResults, maxResultsCap, askedForTooManyResults: Boolean(askedForTooManyResults), noMatchInstructions },
 			options.tokenizationOptions,
 			token);
 
@@ -451,12 +450,21 @@ Then if you want to include those files you can call the tool again by setting "
 		const expFlag = this.configurationService.getExperimentBasedConfig(ConfigKey.GrepSearchOutputFormat, this.experimentationService);
 		return expFlag === 'grep' ? 'grep' : 'tag';
 	}
+
+	private getDefaultMaxResults(): number {
+		return this.configurationService.getExperimentBasedConfig(ConfigKey.GrepSearchDefaultMaxResults, this.experimentationService);
+	}
+
+	private getMaxResultsCap(): number {
+		return this.configurationService.getExperimentBasedConfig(ConfigKey.GrepSearchMaxResultsCap, this.experimentationService);
+	}
 }
 
 ToolRegistry.registerTool(FindTextInFilesTool);
 export interface FindTextInFilesResultProps extends BasePromptElementProps {
 	textResults: vscode.TextSearchResult2[];
 	maxResults: number;
+	maxResultsCap: number;
 	askedForTooManyResults?: boolean;
 	noMatchInstructions?: string;
 }
@@ -479,7 +487,7 @@ export class FindTextInFilesResult extends PromptElement<FindTextInFilesResultPr
 		const resultCountToDisplay = Math.min(numResults, this.props.maxResults);
 		const numResultsText = numResults === 1 ? '1 match' : `${resultCountToDisplay} matches`;
 		const maxResultsText = numResults > this.props.maxResults ? ` (more results are available)` : '';
-		const maxResultsTooLargeText = this.props.askedForTooManyResults ? ` (maxResults capped at ${MaxResultsCap})` : '';
+		const maxResultsTooLargeText = this.props.askedForTooManyResults ? ` (maxResults capped at ${this.props.maxResultsCap})` : '';
 		return <>
 			{<TextChunk priority={20}>{numResultsText}{maxResultsText}{maxResultsTooLargeText}</TextChunk>}
 			{textMatches.flatMap(result => {

--- a/extensions/copilot/src/extension/tools/node/findTextInFilesTool.tsx
+++ b/extensions/copilot/src/extension/tools/node/findTextInFilesTool.tsx
@@ -452,11 +452,13 @@ Then if you want to include those files you can call the tool again by setting "
 	}
 
 	private getDefaultMaxResults(): number {
-		return this.configurationService.getExperimentBasedConfig(ConfigKey.GrepSearchDefaultMaxResults, this.experimentationService);
+		const result =  this.configurationService.getExperimentBasedConfig(ConfigKey.GrepSearchDefaultMaxResults, this.experimentationService);
+		return Number.isFinite(result) ? Math.floor(result) : 20;
 	}
 
 	private getMaxResultsCap(): number {
-		return this.configurationService.getExperimentBasedConfig(ConfigKey.GrepSearchMaxResultsCap, this.experimentationService);
+		const result = this.configurationService.getExperimentBasedConfig(ConfigKey.GrepSearchMaxResultsCap, this.experimentationService);
+		return Number.isFinite(result) ? Math.floor(result) : 200;
 	}
 }
 

--- a/extensions/copilot/src/extension/tools/node/test/findTextInFilesResult.spec.tsx
+++ b/extensions/copilot/src/extension/tools/node/test/findTextInFilesResult.spec.tsx
@@ -30,7 +30,7 @@ suite('FindTextInFilesResult', () => {
 		const clz = class extends PromptElement {
 			render() {
 				return <UserMessage>
-					<FindTextInFilesResult textResults={results} maxResults={20} />
+					<FindTextInFilesResult textResults={results} maxResults={20} maxResultsCap={200} />
 				</UserMessage>;
 			}
 		};

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -1104,6 +1104,8 @@ export namespace ConfigKey {
 
 	/** grep_search configs */
 	export const GrepSearchOutputFormat = defineSetting<'grep' | 'tag'>('chat.tools.grepSearch.outputFormat', ConfigType.ExperimentBased, 'tag');
+	export const GrepSearchDefaultMaxResults = defineSetting<number>('chat.tools.grepSearch.defaultMaxResults', ConfigType.ExperimentBased, 20);
+	export const GrepSearchMaxResultsCap = defineSetting<number>('chat.tools.grepSearch.maxResultsCap', ConfigType.ExperimentBased, 200);
 }
 
 export function getAllConfigKeys(): string[] {


### PR DESCRIPTION
Introduce configuration options for maximum results in the Find Text in Files tool. This change allows users to set a custom maximum results cap and a default value, enhancing flexibility and usability. Adjustments made to ensure the tool respects these configurations during operation.

