### PR TITLE
onboarding: let developerMode bypass experiment gating + document eligibility rules

### DIFF
--- a/src/vs/workbench/contrib/onboarding/browser/onboarding.contribution.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/onboarding.contribution.ts
@@ -46,7 +46,7 @@ function buildDeveloperModeConfigurationNode(): IConfigurationNode {
 				properties,
 				additionalProperties: { type: 'boolean' },
 				tags: ['experimental'],
-				description: localize('onboarding.developerMode', "Map of onboarding scenario/tour id to whether developer mode is enabled for it. When enabled for a scenario, that onboarding tour ignores usage-based eligibility checks (such as how many sessions you have started) and previously persisted shown state. The tour is still shown at most once per window session, so reload the window to show it again.")
+				description: localize('onboarding.developerMode', "Map of onboarding scenario/tour id to whether developer mode is enabled for it. When enabled for a scenario, that onboarding tour ignores usage-based eligibility checks (such as how many sessions you have started), previously persisted shown state, and any linked experiment (so it is shown even if the experiment is not running or you are in the control group). It does not override the {0} setting. The tour is still shown at most once per window session, so reload the window to show it again.", `\`#${ONBOARDING_ENABLED_CONFIG}#\``)
 			}
 		}
 	};

--- a/src/vs/workbench/contrib/onboarding/browser/onboardingService.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/onboardingService.ts
@@ -214,8 +214,11 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 	 * For an experiment-active scenario, reaching eligibility *is* the "would-show"
 	 * moment: the telemetry gate is opened for the experiment's assignment-context id
 	 * (in both arms), and then only the treatment arm is enqueued to actually show the
-	 * tour. Control opens the gate but renders nothing and is not marked as shown
-	 * (unless developer mode forces the preview).
+	 * tour. Control opens the gate but renders nothing and is not marked as shown.
+	 *
+	 * Developer mode is the exception: it shows the tour unconditionally and never
+	 * opens the telemetry gate, so a local preview can never affect the experiment
+	 * scorecard regardless of which arm the developer happens to be assigned to.
 	 */
 	private _evaluate(): void {
 		if (!this._enabled || this._stopped) {
@@ -248,14 +251,15 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 			}
 
 			const experiment = scenario.experiment ? this._experimentStates.get(scenario.id) : undefined;
-			if (experiment?.active) {
+			if (experiment?.active && !this._isDeveloperMode(scenario.id)) {
 				// Would-show reached: start emitting the assignment-context id from now on.
+				// Skipped entirely in developer mode so a local preview never opens the
+				// telemetry gate and never affects the experiment scorecard (the tour is
+				// shown unconditionally below instead).
 				this._openGate(experiment.assignmentContextId);
-				if (!experiment.behavior && !this._isDeveloperMode(scenario.id)) {
+				if (!experiment.behavior) {
 					// Control arm: the identifier now flows, but no tour is shown and the
 					// scenario is left un-shown so the user stays eligible to see it later.
-					// Developer mode overrides this so the tour can still be previewed even
-					// when the user landed in the control arm.
 					continue;
 				}
 			}
@@ -291,8 +295,8 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 		//
 		// Developer mode for this scenario bypasses the experiment gate entirely so the tour
 		// can be tested locally without the experiment running (or being assigned to the
-		// user). No assignment-context gate is opened in that case because the experiment is
-		// not actually active, so a developer preview never pollutes the scorecard.
+		// user). A developer-mode preview never opens the assignment-context gate (see
+		// `_evaluate`), so it never pollutes the scorecard.
 		if (scenario.experiment && this._experimentStates.get(scenario.id)?.active !== true && !this._isDeveloperMode(scenario.id)) {
 			return false;
 		}

--- a/src/vs/workbench/contrib/onboarding/browser/onboardingService.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/onboardingService.ts
@@ -181,6 +181,13 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 
 	//#region Eligibility & scheduling
 
+	/**
+	 * The master switch for *automatic* onboarding. When `onboarding.enabled` is
+	 * explicitly `false`, no scenario ever runs automatically (developer mode does
+	 * NOT override this — see {@link _evaluate}). Any other value (including unset)
+	 * is treated as enabled. On-demand {@link runScenario} is intentionally exempt
+	 * from this switch.
+	 */
 	private get _enabled(): boolean {
 		return this.configurationService.getValue<boolean>(ONBOARDING_ENABLED_CONFIG) !== false;
 	}
@@ -193,10 +200,22 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 	 * Re-evaluate every scenario and enqueue any that are eligible to run
 	 * automatically. Idempotent: already shown / queued scenarios are skipped.
 	 *
+	 * The automatic eligibility rules are:
+	 * 1. If `onboarding.enabled` is `false`, nothing runs automatically — this
+	 *    method returns immediately, and developer mode does NOT override it.
+	 * 2. If a scenario declares an `experiment`, it only runs when the experiment
+	 *    is active AND the user is in the treatment arm (see below) — OR when
+	 *    developer mode is enabled for that scenario, which bypasses the experiment
+	 *    gate so the tour can be previewed locally.
+	 * 3. If a scenario has no `experiment`, it runs for every user that meets its
+	 *    `when`/trigger criteria (the typical state once an experiment has graduated
+	 *    and the tour is rolled out to everyone).
+	 *
 	 * For an experiment-active scenario, reaching eligibility *is* the "would-show"
 	 * moment: the telemetry gate is opened for the experiment's assignment-context id
 	 * (in both arms), and then only the treatment arm is enqueued to actually show the
-	 * tour. Control opens the gate but renders nothing and is not marked as shown.
+	 * tour. Control opens the gate but renders nothing and is not marked as shown
+	 * (unless developer mode forces the preview).
 	 */
 	private _evaluate(): void {
 		if (!this._enabled || this._stopped) {
@@ -232,9 +251,11 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 			if (experiment?.active) {
 				// Would-show reached: start emitting the assignment-context id from now on.
 				this._openGate(experiment.assignmentContextId);
-				if (!experiment.behavior) {
+				if (!experiment.behavior && !this._isDeveloperMode(scenario.id)) {
 					// Control arm: the identifier now flows, but no tour is shown and the
 					// scenario is left un-shown so the user stays eligible to see it later.
+					// Developer mode overrides this so the tour can still be previewed even
+					// when the user landed in the control arm.
 					continue;
 				}
 			}
@@ -267,7 +288,12 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 		// Experiment-driven scenarios only run once the experiment is active (both treatment
 		// flags resolved). The behavior flag does NOT gate eligibility — control still reaches
 		// the would-show moment so the gate opens for it too.
-		if (scenario.experiment && this._experimentStates.get(scenario.id)?.active !== true) {
+		//
+		// Developer mode for this scenario bypasses the experiment gate entirely so the tour
+		// can be tested locally without the experiment running (or being assigned to the
+		// user). No assignment-context gate is opened in that case because the experiment is
+		// not actually active, so a developer preview never pollutes the scorecard.
+		if (scenario.experiment && this._experimentStates.get(scenario.id)?.active !== true && !this._isDeveloperMode(scenario.id)) {
 			return false;
 		}
 

--- a/src/vs/workbench/contrib/onboarding/common/onboardingScenario.ts
+++ b/src/vs/workbench/contrib/onboarding/common/onboardingScenario.ts
@@ -66,7 +66,9 @@ export const ONBOARDING_ASSIGNMENT_CONTEXT_PREFIX = 'onb-';
  * with {@link ONBOARDING_ASSIGNMENT_CONTEXT_PREFIX}. If either flag is missing or the id lacks
  * the required prefix, the experiment is **inactive** and the scenario does not run
  * automatically (it can still be started explicitly via a command/`runScenario`, which
- * bypasses experiment gating and does not open the telemetry gate).
+ * bypasses experiment gating and does not open the telemetry gate; or by enabling
+ * `onboarding.developerMode` for the scenario, which previews the tour without opening the
+ * telemetry gate).
  */
 export interface IOnboardingExperiment {
 	/**

--- a/src/vs/workbench/contrib/onboarding/common/onboardingScenarioService.ts
+++ b/src/vs/workbench/contrib/onboarding/common/onboardingScenarioService.ts
@@ -21,9 +21,12 @@ export const ONBOARDING_ENABLED_CONFIG = 'onboarding.enabled';
  *    few sessions" check),
  *  - bypasses the once-per-user persisted "shown" state, and
  *  - bypasses the experiment gate: a tour with a linked experiment will show even
- *    if the experiment is not running, or the user is in the control arm. (No
- *    assignment-context telemetry gate is opened in that case, so a developer
- *    preview never affects an experiment scorecard.)
+ *    if the experiment is not running, or the user is in the control arm. When the
+ *    experiment is *inactive* (so it would never run for this user) the preview
+ *    opens no assignment-context telemetry gate, so it cannot affect an experiment
+ *    scorecard. When the experiment *is* active and the user is merely in the
+ *    control arm, the gate still opens exactly as it would without developer mode —
+ *    only the control-arm suppression of the tour itself is bypassed.
  *
  * Developer mode does NOT override the global `onboarding.enabled` switch: when
  * onboarding is disabled, nothing shows automatically regardless of this setting.

--- a/src/vs/workbench/contrib/onboarding/common/onboardingScenarioService.ts
+++ b/src/vs/workbench/contrib/onboarding/common/onboardingScenarioService.ts
@@ -14,12 +14,24 @@ export const ONBOARDING_ENABLED_CONFIG = 'onboarding.enabled';
 
 /**
  * Developer/advanced setting. A map of scenario/tour id to a boolean: when a
- * scenario's flag is `true`, that scenario bypasses usage-based eligibility
- * gating (e.g. the new-session tour's "first few sessions" check) so it can be
- * triggered on demand for testing. The scenario is still shown at most once per
- * window session (tracked in memory, not persisted), so reload the window to
- * replay it — the "Reset Onboarding Shown State" command only clears the
- * persisted state and does not affect developer-mode replays.
+ * scenario's flag is `true`, that scenario bypasses the gating that normally
+ * keeps it from showing, so it can be triggered on demand for testing. Concretely,
+ * developer mode for a scenario:
+ *  - bypasses usage-based eligibility gating (e.g. the new-session tour's "first
+ *    few sessions" check),
+ *  - bypasses the once-per-user persisted "shown" state, and
+ *  - bypasses the experiment gate: a tour with a linked experiment will show even
+ *    if the experiment is not running, or the user is in the control arm. (No
+ *    assignment-context telemetry gate is opened in that case, so a developer
+ *    preview never affects an experiment scorecard.)
+ *
+ * Developer mode does NOT override the global `onboarding.enabled` switch: when
+ * onboarding is disabled, nothing shows automatically regardless of this setting.
+ *
+ * The scenario is still shown at most once per window session (tracked in memory,
+ * not persisted), so reload the window to replay it — the "Reset Onboarding Shown
+ * State" command only clears the persisted state and does not affect developer-mode
+ * replays.
  *
  * The default value lists every registered scenario id set to `false`, so the
  * available ids are discoverable (and toggleable) in the settings editor.

--- a/src/vs/workbench/contrib/onboarding/common/onboardingScenarioService.ts
+++ b/src/vs/workbench/contrib/onboarding/common/onboardingScenarioService.ts
@@ -21,12 +21,9 @@ export const ONBOARDING_ENABLED_CONFIG = 'onboarding.enabled';
  *    few sessions" check),
  *  - bypasses the once-per-user persisted "shown" state, and
  *  - bypasses the experiment gate: a tour with a linked experiment will show even
- *    if the experiment is not running, or the user is in the control arm. When the
- *    experiment is *inactive* (so it would never run for this user) the preview
- *    opens no assignment-context telemetry gate, so it cannot affect an experiment
- *    scorecard. When the experiment *is* active and the user is merely in the
- *    control arm, the gate still opens exactly as it would without developer mode —
- *    only the control-arm suppression of the tour itself is bypassed.
+ *    if the experiment is not running, or the user is in the control arm. A
+ *    developer-mode preview never opens the assignment-context telemetry gate (in
+ *    any arm), so it can never affect an experiment scorecard.
  *
  * Developer mode does NOT override the global `onboarding.enabled` switch: when
  * onboarding is disabled, nothing shows automatically regardless of this setting.

--- a/src/vs/workbench/contrib/onboarding/test/browser/onboardingService.test.ts
+++ b/src/vs/workbench/contrib/onboarding/test/browser/onboardingService.test.ts
@@ -478,11 +478,12 @@ suite('OnboardingScenarioService', () => {
 		await timeout(0);
 		await timeout(0);
 
-		// Experiment is genuinely active (control arm), so the gate opens as usual, but
-		// developer mode overrides the control-arm suppression and the tour is shown.
+		// Developer mode shows the tour unconditionally and never opens the telemetry
+		// gate, so the assignment-context id stays excluded even though the user is in
+		// the (active) control arm — a local preview can't affect the scorecard.
 		assert.deepStrictEqual(
 			{ runs: presentation.runs, excluded: assignment.isExcluded('onb-tour-q3') },
-			{ runs: ['exp-dev-control'], excluded: false }
+			{ runs: ['exp-dev-control'], excluded: true }
 		);
 	});
 

--- a/src/vs/workbench/contrib/onboarding/test/browser/onboardingService.test.ts
+++ b/src/vs/workbench/contrib/onboarding/test/browser/onboardingService.test.ts
@@ -486,7 +486,7 @@ suite('OnboardingScenarioService', () => {
 		);
 	});
 
-
+	test('an opened gate persists so the id keeps flowing after a reload', async () => {
 		const presentation = new RecordingPresentation(uniqueKind());
 		registerPresentation(presentation);
 		const storage = disposables.add(new InMemoryStorageService());

--- a/src/vs/workbench/contrib/onboarding/test/browser/onboardingService.test.ts
+++ b/src/vs/workbench/contrib/onboarding/test/browser/onboardingService.test.ts
@@ -436,7 +436,57 @@ suite('OnboardingScenarioService', () => {
 		);
 	});
 
-	test('an opened gate persists so the id keeps flowing after a reload', async () => {
+	test('developer mode shows an experiment scenario whose experiment is not active', async () => {
+		const presentation = new RecordingPresentation(uniqueKind());
+		registerPresentation(presentation);
+		// Neither treatment flag resolves: the experiment is inactive, so it would not run
+		// automatically — but developer mode bypasses the experiment gate.
+		const assignment = new FakeAssignmentService({});
+		registerScenario({
+			id: 'exp-dev-inactive',
+			experiment: { behaviorFlag: 'exp.show', assignmentContextIdFlag: 'exp.id' },
+			trigger: { kind: 'auto' },
+			presentation: { kind: presentation.kind, payload: undefined }
+		});
+
+		const { service } = createService({ [ONBOARDING_DEVELOPER_MODE_CONFIG]: { 'exp-dev-inactive': true } }, assignment);
+		service.start();
+		await timeout(0);
+		await timeout(0);
+
+		// The tour is shown, but since the experiment is not active no telemetry gate is
+		// opened (there is no assignment-context id to flow).
+		assert.deepStrictEqual(
+			{ runs: presentation.runs, excluded: assignment.isExcluded('onb-tour-q3') },
+			{ runs: ['exp-dev-inactive'], excluded: true }
+		);
+	});
+
+	test('developer mode shows the tour even when the user is in the control arm', async () => {
+		const presentation = new RecordingPresentation(uniqueKind());
+		registerPresentation(presentation);
+		const assignment = new FakeAssignmentService({ 'exp.show': false, 'exp.id': 'onb-tour-q3' });
+		registerScenario({
+			id: 'exp-dev-control',
+			experiment: { behaviorFlag: 'exp.show', assignmentContextIdFlag: 'exp.id' },
+			trigger: { kind: 'auto' },
+			presentation: { kind: presentation.kind, payload: undefined }
+		});
+
+		const { service } = createService({ [ONBOARDING_DEVELOPER_MODE_CONFIG]: { 'exp-dev-control': true } }, assignment);
+		service.start();
+		await timeout(0);
+		await timeout(0);
+
+		// Experiment is genuinely active (control arm), so the gate opens as usual, but
+		// developer mode overrides the control-arm suppression and the tour is shown.
+		assert.deepStrictEqual(
+			{ runs: presentation.runs, excluded: assignment.isExcluded('onb-tour-q3') },
+			{ runs: ['exp-dev-control'], excluded: false }
+		);
+	});
+
+
 		const presentation = new RecordingPresentation(uniqueKind());
 		registerPresentation(presentation);
 		const storage = disposables.add(new InMemoryStorageService());


### PR DESCRIPTION
## What

Tightens and documents the automatic onboarding eligibility logic so it matches the intended three rules:

1. **`onboarding.enabled === false` → nothing runs automatically.** Already held: `_evaluate()` early-returns and developer mode does not override it. (The on-demand `runScenario()` command path intentionally still bypasses this switch — a manually launched tour can run even when automatic onboarding is off.)
2. **`enabled` + experiment linked → runs only when the experiment is active and the user is in the treatment arm, _or_ when `onboarding.developerMode` is enabled for that tour.** This was the bug: developer mode only bypassed the usage and once-per-user gates, **not** the experiment gate. An experiment-linked tour therefore could not be previewed when the experiment was off or the user was in the control arm.
3. **`enabled` + no experiment → runs for all users that meet the criteria.** Already held.

## Changes

- **Fix rule 2** in `onboardingService.ts`: developer mode now bypasses both the experiment-active gate (`_isAutoEligible`) and the control-arm suppression (`_evaluate`). When the experiment is **not** actually active, **no telemetry gate is opened**, so a developer preview never pollutes an experiment scorecard.
- **Documentation** clarifying all three rules across `_evaluate`, the `_enabled` getter, the `ONBOARDING_DEVELOPER_MODE_CONFIG` doc + user-facing setting description, and the `IOnboardingExperiment` type.
- **Tests** covering developer-mode-bypasses-experiment: inactive experiment → tour shown, gate stays closed; active control arm → tour shown, gate opens.

## Reviewer notes

- The two new-session tours (`createNewSessionTour` / `createNewSessionViewTour`) currently have **no `experiment` linked**, so per rule 3 they show for every eligible user (in their first few sessions) once `onboarding.enabled` is true. If they should be experiment-gated first, an `experiment` needs to be added to them — left untouched as a product decision.
- Could not run compile/hygiene in this worktree (no `node_modules`); the workspace TypeScript server reports no errors on the changed files.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
