### PR TITLE
sessions: rename agent feedback Remove button to Delete and refine tooltips

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
@@ -430,8 +430,16 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 			this._editor.layoutOverlayWidget(this);
 		};
 
+		const isPRComment = comment.source === SessionEditorCommentSource.PRReview;
+		const acceptTooltip = isPRComment
+			? nls.localize('acceptPRFeedbackTooltip', "Share PR comment with agent")
+			: nls.localize('acceptAgentFeedbackTooltip', "Share comment with agent");
+		const deleteTooltip = isPRComment
+			? nls.localize('deletePRFeedbackTooltip', "Remove and mark as resolved on GitHub")
+			: nls.localize('deleteAgentFeedbackTooltip', "Remove agent comment");
+
 		const acceptButton = buttonStore.add(new Button(buttonBar, {
-			title: nls.localize('acceptFeedbackButton', "Accept"),
+			title: acceptTooltip,
 			buttonBackground: 'var(--vscode-charts-purple)',
 			buttonHoverBackground: 'color-mix(in srgb, var(--vscode-charts-purple) 85%, var(--vscode-foreground))',
 			buttonForeground: 'var(--vscode-button-foreground)',
@@ -448,14 +456,14 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 		}));
 
 		const removeButton = buttonStore.add(new Button(buttonBar, {
-			title: nls.localize('removeFeedbackButton', "Remove"),
+			title: deleteTooltip,
 			secondary: true,
 			buttonSecondaryBackground: 'var(--vscode-button-secondaryBackground)',
 			buttonSecondaryHoverBackground: 'var(--vscode-button-secondaryHoverBackground)',
 			buttonSecondaryForeground: 'var(--vscode-button-secondaryForeground)',
 			buttonSecondaryBorder: 'var(--vscode-button-secondaryBorder)',
 		}));
-		removeButton.label = nls.localize('removeFeedbackButton', "Remove");
+		removeButton.label = nls.localize('deleteFeedbackButton', "Delete");
 		buttonStore.add(removeButton.onDidClick(() => {
 			this._removeComment(comment);
 			dismiss();

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
@@ -455,7 +455,7 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 			dismiss();
 		}));
 
-		const removeButton = buttonStore.add(new Button(buttonBar, {
+		const deleteButton = buttonStore.add(new Button(buttonBar, {
 			title: deleteTooltip,
 			secondary: true,
 			buttonSecondaryBackground: 'var(--vscode-button-secondaryBackground)',
@@ -463,8 +463,8 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 			buttonSecondaryForeground: 'var(--vscode-button-secondaryForeground)',
 			buttonSecondaryBorder: 'var(--vscode-button-secondaryBorder)',
 		}));
-		removeButton.label = nls.localize('deleteFeedbackButton', "Delete");
-		buttonStore.add(removeButton.onDidClick(() => {
+		deleteButton.label = nls.localize('deleteFeedbackButton', "Delete");
+		buttonStore.add(deleteButton.onDidClick(() => {
 			this._removeComment(comment);
 			dismiss();
 		}));


### PR DESCRIPTION
## What

Updates the action button bar shown at the bottom of agent feedback comments in the agent feedback editor widget:

- Renames the secondary button from **"Remove"** to **"Delete"** (the primary button stays **"Accept"**).
- Adds source-aware tooltips for both buttons:
  - **PR comments** — Accept: `Share PR comment with agent`, Delete: `Remove and mark as resolved on GitHub`
  - **Agent comments** — Accept: `Share comment with agent`, Delete: `Remove agent comment`

## Why

The previous labels/tooltips didn't clearly convey what each action does. The new wording makes it explicit that accepting shares the comment with the agent, and clarifies the differing delete behavior between PR comments (resolved on GitHub) and agent comments.

## Notes for reviewers

- The source is distinguished via `comment.source === SessionEditorCommentSource.PRReview`.
- All strings are localized via `nls.localize`.
- Change is limited to `agentFeedbackEditorWidgetContribution.ts`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
