### PR TITLE
sessions: show default open-PR icon immediately when a PR is detected

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -51,6 +51,7 @@ import { ISessionsService } from '../../../../services/sessions/browser/sessions
 import { IDeleteChatOptions, ISendRequestOptions, ISessionChangeEvent, ISessionModelPickerOptions } from '../../../../services/sessions/common/sessionsProvider.js';
 import { IGitHubService } from '../../../github/browser/githubService.js';
 import { computeLivePullRequestIcon } from '../../../github/browser/pullRequestIconStatus.js';
+import { computePullRequestIcon, GitHubPullRequestState } from '../../../github/common/types.js';
 import { IPullRequestIconCache } from '../../../github/browser/pullRequestIconCache.js';
 import { changesetFileToChange, mapProtocolStatus } from './agentHostDiffs.js';
 import { createChangesets } from './agentHostSessionChangesets.js';
@@ -455,16 +456,17 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 			const livePR = prModelRef.object.pullRequest.read(reader);
 
 			if (!livePR) {
-				// The live model hasn't been fetched yet (e.g. right after startup). Show
-				// the last known icon from the persistent cache so the row isn't icon-less
-				// while the first fetch is in flight.
-				const cachedIcon = this._pullRequestIconCache.get(prLink);
-				if (!cachedIcon) {
-					return baseGitHubInfo;
-				}
+				// The live model hasn't been fetched yet (e.g. right after a PR is first
+				// detected, or right after startup). Show the last known icon from the
+				// persistent cache, falling back to a neutral open-PR icon, so the row
+				// surfaces a PR icon immediately instead of the read/unread dot while the
+				// first fetch is in flight. The agent-host git state carries no PR state,
+				// so the live model refines it (merged/closed/draft/failing checks) within
+				// a poll cycle.
+				const icon = this._pullRequestIconCache.get(prLink) ?? computePullRequestIcon(GitHubPullRequestState.Open);
 				return {
 					...baseGitHubInfo,
-					pullRequest: { ...baseGitHubInfo.pullRequest, icon: cachedIcon }
+					pullRequest: { ...baseGitHubInfo.pullRequest, icon }
 				};
 			}
 

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -45,6 +45,7 @@ import { ILogService, NullLogService } from '../../../../../../platform/log/comm
 import { IGitHubService } from '../../../../github/browser/githubService.js';
 import { GitHubPullRequestModel } from '../../../../github/browser/models/githubPullRequestModel.js';
 import { IPullRequestIconCache, PullRequestIconCache } from '../../../../github/browser/pullRequestIconCache.js';
+import { computePullRequestIcon, GitHubPullRequestState } from '../../../../github/common/types.js';
 import { IWorkbenchEnvironmentService } from '../../../../../../workbench/services/environment/common/environmentService.js';
 
 // ---- Mock IAgentHostService -------------------------------------------------
@@ -2790,6 +2791,44 @@ suite('LocalAgentHostSessionsProvider', () => {
 		assert.strictEqual(firstReObservedNumber, 42, 'PR number stays sticky across unobserve/reobserve');
 		assert.strictEqual(gitHubService.lookupCalls, 1, 'no extra PR-number lookup on recompute');
 		sub2.dispose();
+	}));
+
+	test('surfaces a default open-PR icon immediately when a PR is detected before the live model loads', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		// A GitHub service whose live PR model is never populated (`pullRequest` stays
+		// undefined), mirroring the window right after a PR is first detected but before
+		// the first live fetch completes. Without a fallback the session list row would
+		// keep the read/unread dot instead of a PR icon until that fetch lands.
+		const gitHubService = new class extends mock<IGitHubService>() {
+			private readonly _model = { pullRequest: constObservable(undefined) } as unknown as GitHubPullRequestModel;
+			override createPullRequestModelReference = () => new ImmortalReference(this._model);
+		}();
+
+		agentHost.addSession(createSession('pr-default-icon', { summary: 'PR Session', project: { uri: URI.parse('file:///repo'), displayName: 'repo' } }));
+		const provider = createProvider(disposables, agentHost, undefined, { gitHubService });
+		provider.getSessions();
+		await timeout(0);
+		const session = provider.getSessions().find(s => s.title.get() === 'PR Session');
+		assert.ok(session);
+
+		// Force a session-state subscription and push GitHub state carrying a PR URL so
+		// the session detects the pull request while its live model is still empty.
+		provider.getSessionConfig(session!.sessionId);
+		agentHost.setSessionState('pr-default-icon', 'copilotcli', {
+			provider: 'copilotcli', title: 'PR Session', status: ProtocolSessionStatus.Idle,
+			lifecycle: SessionLifecycle.Ready,
+			activeClients: [],
+			chats: [],
+			_meta: { github: { owner: 'owner', repo: 'repo', pullRequestUrl: 'https://github.com/owner/repo/pull/42' } },
+		});
+
+		const gitHubInfoObs = session!.workspace.get()!.folders[0]!.gitRepository!.gitHubInfo;
+		const sub = autorun(reader => { gitHubInfoObs.read(reader); });
+		await timeout(0);
+
+		const pullRequest = gitHubInfoObs.get()?.pullRequest;
+		assert.strictEqual(pullRequest?.number, 42, 'PR is detected from the GitHub state URL');
+		assert.deepStrictEqual(pullRequest?.icon, computePullRequestIcon(GitHubPullRequestState.Open), 'a default open-PR icon is shown immediately while the live model is empty');
+		sub.dispose();
 	}));
 
 	// ---- replaceSessionConfig -------


### PR DESCRIPTION
## What

Agent-host sessions (local/remote agent host) carry only `owner`/`repo`/`pullRequestUrl` in their GitHub state — no PR state (open/closed/merged/draft). As a result, when a PR was first detected, the sessions **list** row's status icon stayed a read/unread dot until the live PR model was fetched asynchronously. The session **header** showed the PR pill immediately (it only needs the PR to exist), and the Copilot Chat provider already computes a synchronous icon — so only the agent-host list row lagged behind.

## Change

In `baseAgentHostSessionsProvider.ts`, when a PR is detected but the live model (and persistent icon cache) aren't ready yet, fall back to a neutral open-PR icon instead of returning no icon. The list now surfaces a PR glyph the moment a PR is detected, consistent with the header and the Copilot Chat provider. The live model then refines the icon (merged/closed/draft/failing checks/unresolved comments) within a poll cycle.

Notes for reviewers:
- The reactivity itself was never broken — the list row already reads `gitHubInfo.pullRequest.icon` reactively via an autorun. The gap was purely that the agent-host `gitHubInfo` produced `icon: undefined` until the async live fetch landed.
- The placeholder icon is not written to the persistent icon cache.
- PR polling identity (owner/repo/number) is unaffected.
- Added a unit test in `localAgentHostSessionsProvider.test.ts` asserting a detected PR with an empty live model surfaces `computePullRequestIcon(Open)` immediately.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
