### PR TITLE
feat(automations): add foundation — types, storage, scheduler, leader election

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -645,6 +645,10 @@
 			"project": "vscode-sessions"
 		},
 		{
+			"name": "vs/sessions/contrib/automations",
+			"project": "vscode-sessions"
+		},
+		{
 			"name": "vs/sessions/contrib/accountMenu",
 			"project": "vscode-sessions"
 		},

--- a/src/vs/sessions/contrib/automations/browser/automationLeaderElection.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationLeaderElection.ts
@@ -14,13 +14,13 @@ const LEADER_KEY = 'chat.automations.leader';
 
 export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 
-// 3× heartbeat interval — tolerates one missed write before failover.
+// 3x heartbeat interval. Tolerates one missed write before failover.
 export const DEFAULT_STALE_AFTER_MS = 90_000;
 
 interface ILeaderRecord {
 	readonly instanceId: string;
 	readonly heartbeatAt: number;
-	// Per-write nonce to detect TOCTOU races during leader claims.
+	// Per-write nonce to detect races during leader claims.
 	readonly nonce: string;
 }
 
@@ -129,7 +129,7 @@ export class AutomationLeaderElection extends Disposable {
 			if (typeof parsed?.instanceId !== 'string' || typeof parsed?.heartbeatAt !== 'number') {
 				return undefined;
 			}
-			// `nonce` is optional in older persisted records; coerce.
+			// `nonce` is optional in older persisted records. Coerce to empty string.
 			return { instanceId: parsed.instanceId, heartbeatAt: parsed.heartbeatAt, nonce: typeof parsed.nonce === 'string' ? parsed.nonce : '' };
 		} catch {
 			return undefined;

--- a/src/vs/sessions/contrib/automations/browser/automationLeaderElection.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationLeaderElection.ts
@@ -1,0 +1,164 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IntervalTimer } from '../../../../base/common/async.js';
+import { Disposable, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+
+const LEADER_KEY = 'chat.automations.leader';
+
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
+
+// 3× heartbeat interval — tolerates one missed write before failover.
+export const DEFAULT_STALE_AFTER_MS = 90_000;
+
+interface ILeaderRecord {
+	readonly instanceId: string;
+	readonly heartbeatAt: number;
+	// Per-write nonce to detect TOCTOU races during leader claims.
+	readonly nonce: string;
+}
+
+export interface IAutomationLeaderElectionOptions {
+	readonly heartbeatIntervalMs?: number;
+	readonly staleAfterMs?: number;
+	readonly now?: () => number;
+	readonly instanceId?: string;
+}
+
+export class AutomationLeaderElection extends Disposable {
+
+	private readonly _isLeader: ISettableObservable<boolean>;
+	readonly isLeader: IObservable<boolean>;
+
+	private readonly _instanceId: string;
+	private readonly _heartbeatIntervalMs: number;
+	private readonly _staleAfterMs: number;
+	private readonly _now: () => number;
+
+	private readonly _timer = this._register(new IntervalTimer());
+
+	constructor(
+		private readonly storageService: IStorageService,
+		private readonly logService: ILogService,
+		options: IAutomationLeaderElectionOptions = {},
+	) {
+		super();
+
+		this._instanceId = options.instanceId ?? generateUuid();
+		this._heartbeatIntervalMs = options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+		this._staleAfterMs = options.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
+		this._now = options.now ?? Date.now;
+
+		this._isLeader = observableValue<boolean>(this, false);
+		this.isLeader = this._isLeader;
+
+		this._register(toDisposable(() => this.releaseIfLeader()));
+
+		this.evaluate();
+
+		this._timer.cancelAndSet(() => this.evaluate(), this._heartbeatIntervalMs);
+	}
+
+	get instanceId(): string {
+		return this._instanceId;
+	}
+
+	/** Test-only: drive the evaluation cycle synchronously. */
+	evaluateForTesting(): void {
+		this.evaluate();
+	}
+
+	private evaluate(): void {
+		const now = this._now();
+		const current = this.readLeader();
+
+		const claimable =
+			!current ||
+			current.instanceId === this._instanceId ||
+			current.instanceId === '' ||
+			(now - current.heartbeatAt) > this._staleAfterMs;
+
+		if (!claimable) {
+			if (this._isLeader.get()) {
+				this.logService.info(`[AutomationLeaderElection] window ${this._instanceId} stood down for ${current!.instanceId}.`);
+			}
+			this._isLeader.set(false, undefined);
+			return;
+		}
+
+		// Write a nonce and verify we won by reading it back (narrows dual-leader window).
+		const nonce = generateUuid();
+		const writeOk = this.writeLeader({ instanceId: this._instanceId, heartbeatAt: now, nonce });
+		if (!writeOk) {
+			this._isLeader.set(false, undefined);
+			return;
+		}
+		const verify = this.readLeader();
+		if (verify?.instanceId === this._instanceId && verify.nonce === nonce) {
+			if (!this._isLeader.get()) {
+				this.logService.info(`[AutomationLeaderElection] window ${this._instanceId} claimed leader slot.`);
+			}
+			this._isLeader.set(true, undefined);
+		} else {
+			if (this._isLeader.get()) {
+				this.logService.info(`[AutomationLeaderElection] window ${this._instanceId} lost leader race to ${verify?.instanceId ?? '<none>'}.`);
+			}
+			this._isLeader.set(false, undefined);
+		}
+	}
+
+	private readLeader(): ILeaderRecord | undefined {
+		let raw: string | undefined;
+		try {
+			raw = this.storageService.get(LEADER_KEY, StorageScope.APPLICATION);
+		} catch (err) {
+			this.logService.warn('[AutomationLeaderElection] storage read failed', err);
+			return undefined;
+		}
+		if (!raw) {
+			return undefined;
+		}
+		try {
+			const parsed = JSON.parse(raw) as ILeaderRecord;
+			if (typeof parsed?.instanceId !== 'string' || typeof parsed?.heartbeatAt !== 'number') {
+				return undefined;
+			}
+			// `nonce` is optional in older persisted records; coerce.
+			return { instanceId: parsed.instanceId, heartbeatAt: parsed.heartbeatAt, nonce: typeof parsed.nonce === 'string' ? parsed.nonce : '' };
+		} catch {
+			return undefined;
+		}
+	}
+
+	/** Returns true if the write succeeded, false if storage threw. */
+	private writeLeader(record: ILeaderRecord): boolean {
+		try {
+			this.storageService.store(LEADER_KEY, JSON.stringify(record), StorageScope.APPLICATION, StorageTarget.MACHINE);
+			return true;
+		} catch (err) {
+			this.logService.warn('[AutomationLeaderElection] storage write failed', err);
+			return false;
+		}
+	}
+
+	// Write a tombstone on clean shutdown so the next window can claim immediately.
+	private releaseIfLeader(): void {
+		const current = this.readLeader();
+		if (current?.instanceId !== this._instanceId) {
+			return;
+		}
+		this.writeLeader({ instanceId: '', heartbeatAt: 0, nonce: '' });
+	}
+}
+
+export interface IAutomationLeaderElection extends IDisposable {
+	readonly isLeader: IObservable<boolean>;
+	readonly instanceId: string;
+	evaluateForTesting(): void;
+}

--- a/src/vs/sessions/contrib/automations/browser/automationScheduler.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationScheduler.ts
@@ -99,6 +99,7 @@ export class AutomationSchedulerCore extends Disposable {
 		if (this._store.isDisposed) {
 			return;
 		}
+		// Serialized: only one dispatch at a time — runs execute sequentially by design.
 		this._pendingRuns = this._pendingRuns.then(task).catch(err => {
 			this.logService.error('[AutomationScheduler] tick failed', err);
 		});

--- a/src/vs/sessions/contrib/automations/browser/automationScheduler.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationScheduler.ts
@@ -99,7 +99,7 @@ export class AutomationSchedulerCore extends Disposable {
 		if (this._store.isDisposed) {
 			return;
 		}
-		// Serialized: only one dispatch at a time — runs execute sequentially by design.
+		// Serialized: only one dispatch at a time. Runs execute sequentially by design.
 		this._pendingRuns = this._pendingRuns.then(task).catch(err => {
 			this.logService.error('[AutomationScheduler] tick failed', err);
 		});
@@ -192,7 +192,7 @@ export class AutomationSchedulerCore extends Disposable {
 	}
 }
 
-// DI wrapper; tests construct AutomationSchedulerCore directly.
+// DI wrapper. Tests construct AutomationSchedulerCore directly.
 export class AutomationScheduler extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'workbench.contrib.automationScheduler';

--- a/src/vs/sessions/contrib/automations/browser/automationScheduler.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationScheduler.ts
@@ -6,7 +6,7 @@
 import { IntervalTimer, raceTimeout } from '../../../../base/common/async.js';
 import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { stringHash } from '../../../../base/common/hash.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -193,24 +193,48 @@ export class AutomationScheduler extends Disposable implements IWorkbenchContrib
 
 	static readonly ID = 'workbench.contrib.automationScheduler';
 
+	private readonly _core = this._register(new MutableDisposable<AutomationSchedulerCore>());
+
 	constructor(
-		@IAutomationService automationService: IAutomationService,
-		@IAutomationRunner runner: IAutomationRunner,
-		@IStorageService storageService: IStorageService,
-		@ILogService logService: ILogService,
-		@IConfigurationService configurationService: IConfigurationService,
+		@IAutomationService private readonly _automationService: IAutomationService,
+		@IAutomationRunner private readonly _runner: IAutomationRunner,
+		@IStorageService private readonly _storageService: IStorageService,
+		@ILogService private readonly _logService: ILogService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
-		this._register(new AutomationSchedulerCore(automationService, runner, storageService, logService, {
-			isFeatureEnabled: () => configurationService.getValue<boolean>(CHAT_AUTOMATIONS_ENABLED_SETTING) === true,
+		if (this._isEnabled()) {
+			this._createCore();
+		}
+		this._register(_configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(CHAT_AUTOMATIONS_ENABLED_SETTING)) {
+				if (this._isEnabled()) {
+					this._createCore();
+				} else {
+					this._core.clear();
+				}
+			}
+		}));
+	}
+
+	private _isEnabled(): boolean {
+		return this._configurationService.getValue<boolean>(CHAT_AUTOMATIONS_ENABLED_SETTING) === true;
+	}
+
+	private _createCore(): void {
+		if (this._core.value) {
+			return;
+		}
+		this._core.value = new AutomationSchedulerCore(this._automationService, this._runner, this._storageService, this._logService, {
+			isFeatureEnabled: () => this._isEnabled(),
 			getRunTimeoutMs: () => {
-				const minutes = configurationService.getValue<number>(CHAT_AUTOMATIONS_RUN_TIMEOUT_MINUTES_SETTING);
+				const minutes = this._configurationService.getValue<number>(CHAT_AUTOMATIONS_RUN_TIMEOUT_MINUTES_SETTING);
 				const sane = typeof minutes === 'number' && Number.isFinite(minutes) && minutes >= 1
 					? minutes
 					: DEFAULT_AUTOMATIONS_RUN_TIMEOUT_MINUTES;
 				return sane * 60_000;
 			},
-		}));
+		});
 	}
 }
 

--- a/src/vs/sessions/contrib/automations/browser/automationScheduler.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationScheduler.ts
@@ -1,0 +1,227 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IntervalTimer, raceTimeout } from '../../../../base/common/async.js';
+import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
+import { stringHash } from '../../../../base/common/hash.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../base/common/observable.js';
+import { localize } from '../../../../nls.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IStorageService } from '../../../../platform/storage/common/storage.js';
+import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
+import { IAutomation } from '../../../../workbench/contrib/chat/common/automations/automation.js';
+import { IAutomationRunner } from '../../../../workbench/contrib/chat/common/automations/automationRunner.js';
+import { IAutomationService } from '../../../../workbench/contrib/chat/common/automations/automationService.js';
+import { CHAT_AUTOMATIONS_ENABLED_SETTING, CHAT_AUTOMATIONS_RUN_TIMEOUT_MINUTES_SETTING, DEFAULT_AUTOMATIONS_RUN_TIMEOUT_MINUTES } from '../../../../workbench/contrib/chat/common/automations/automationsEnabled.js';
+import { AutomationLeaderElection, IAutomationLeaderElection } from './automationLeaderElection.js';
+
+export const DEFAULT_SCHEDULER_TICK_MS = 60_000;
+
+// Stored on stale run rows on leader startup.
+export const CRASH_RECOVERY_REASON = 'Interrupted by app shutdown';
+
+export const RUN_TIMEOUT_REASON_PREFIX = 'Timed out after';
+
+export interface IAutomationSchedulerCoreOptions {
+	readonly tickIntervalMs?: number;
+	readonly now?: () => Date;
+	readonly leaderElection?: IAutomationLeaderElection;
+	readonly disableAutoTick?: boolean;
+	readonly isFeatureEnabled?: () => boolean;
+	readonly getRunTimeoutMs?: () => number;
+}
+
+export class AutomationSchedulerCore extends Disposable {
+
+	private readonly _leader: IAutomationLeaderElection;
+
+	private readonly _tickIntervalMs: number;
+	private readonly _now: () => Date;
+	private readonly _isFeatureEnabled: () => boolean;
+	private readonly _getRunTimeoutMs: () => number;
+
+	private readonly _timer = this._register(new IntervalTimer());
+	private readonly _runCts = this._register(new CancellationTokenSource());
+
+	// Reset on leadership loss so a future take-over re-runs crash recovery.
+	private _didStartupForCurrentLeadership = false;
+
+	private _pendingRuns: Promise<unknown> = Promise.resolve();
+
+	constructor(
+		private readonly automationService: IAutomationService,
+		private readonly runner: IAutomationRunner,
+		storageService: IStorageService,
+		private readonly logService: ILogService,
+		options: IAutomationSchedulerCoreOptions = {},
+	) {
+		super();
+
+		this._tickIntervalMs = options.tickIntervalMs ?? DEFAULT_SCHEDULER_TICK_MS;
+		this._now = options.now ?? (() => new Date());
+		this._isFeatureEnabled = options.isFeatureEnabled ?? (() => true);
+		this._getRunTimeoutMs = options.getRunTimeoutMs ?? (() => DEFAULT_AUTOMATIONS_RUN_TIMEOUT_MINUTES * 60_000);
+
+		this._leader = options.leaderElection ?? this._register(new AutomationLeaderElection(storageService, logService));
+
+		this._register(autorun(reader => {
+			const isLeader = this._leader.isLeader.read(reader);
+			if (!isLeader) {
+				this._didStartupForCurrentLeadership = false;
+				return;
+			}
+			this.kickoffPendingRuns(() => this.tickOnce(true));
+		}));
+
+		if (!options.disableAutoTick) {
+			this._timer.cancelAndSet(() => {
+				this.kickoffPendingRuns(() => this.tickOnce(false));
+			}, this._tickIntervalMs);
+		}
+	}
+
+	/** Test-only: run a single tick and await it. */
+	async tickForTesting(): Promise<void> {
+		this.kickoffPendingRuns(() => this.tickOnce(false));
+		await this._pendingRuns;
+	}
+
+	/** Test-only: await in-flight runs. */
+	async waitForPendingRuns(): Promise<void> {
+		await this._pendingRuns;
+	}
+
+	private kickoffPendingRuns(task: () => Promise<void>): void {
+		if (this._store.isDisposed) {
+			return;
+		}
+		this._pendingRuns = this._pendingRuns.then(task).catch(err => {
+			this.logService.error('[AutomationScheduler] tick failed', err);
+		});
+	}
+
+	private async tickOnce(isLeadershipTransition: boolean): Promise<void> {
+		if (!this._leader.isLeader.get()) {
+			return;
+		}
+
+		if (!this._isFeatureEnabled()) {
+			return;
+		}
+
+		if (!this._didStartupForCurrentLeadership) {
+			this._didStartupForCurrentLeadership = true;
+			await this.automationService.markStaleRunsFailed(CRASH_RECOVERY_REASON);
+			await this.dispatchDue('catch_up');
+			if (isLeadershipTransition) {
+				return;
+			}
+		}
+
+		await this.dispatchDue('schedule');
+	}
+
+	private async dispatchDue(trigger: 'schedule' | 'catch_up'): Promise<void> {
+		const now = this._now();
+		const due = this.automationService.automations.get().filter(a => isDue(a, now));
+		if (due.length === 0) {
+			return;
+		}
+
+		const leaderWindowId = stringHash(this._leader.instanceId, 0);
+		for (const automation of due) {
+			// Advance schedule first so a concurrent tick doesn't re-pick this row.
+			await this.automationService.advanceNextRunAt(automation.id, now);
+			await this.runOneWithTimeout(automation, trigger, leaderWindowId);
+		}
+	}
+
+	private async runOneWithTimeout(automation: IAutomation, trigger: 'schedule' | 'catch_up', leaderWindowId: number): Promise<void> {
+		const timeoutMs = this._getRunTimeoutMs();
+		const perRunCts = new CancellationTokenSource(this._runCts.token);
+		try {
+			if (timeoutMs <= 0) {
+				await this.runner.runOnce(automation, trigger, leaderWindowId, perRunCts.token);
+				return;
+			}
+
+			let timedOut = false;
+			await raceTimeout(
+				this.runner.runOnce(automation, trigger, leaderWindowId, perRunCts.token),
+				timeoutMs,
+				() => {
+					timedOut = true;
+					this.logService.warn(`[AutomationScheduler] runOnce for automation ${automation.id} timed out after ${timeoutMs}ms; cancelling.`);
+					perRunCts.cancel();
+				},
+			);
+
+			if (!timedOut) {
+				return;
+			}
+
+			// Best-effort: mark the active run row as failed so the UI doesn't show "running" forever.
+			try {
+				const active = this.automationService.getActiveRunFor(automation.id);
+				if (active) {
+					await this.automationService.updateRun(active.id, {
+						status: 'failed',
+						errorMessage: localize('automation.timedOut', "Timed out after {0} minute(s).", Math.round(timeoutMs / 60_000)),
+						completedAt: this._now().toISOString(),
+					});
+				}
+			} catch (err) {
+				this.logService.warn('[AutomationScheduler] failed to mark timed-out run as failed', err);
+			}
+		} finally {
+			perRunCts.dispose();
+		}
+	}
+
+	override dispose(): void {
+		this._runCts.cancel();
+		super.dispose();
+	}
+}
+
+// DI wrapper; tests construct AutomationSchedulerCore directly.
+export class AutomationScheduler extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.automationScheduler';
+
+	constructor(
+		@IAutomationService automationService: IAutomationService,
+		@IAutomationRunner runner: IAutomationRunner,
+		@IStorageService storageService: IStorageService,
+		@ILogService logService: ILogService,
+		@IConfigurationService configurationService: IConfigurationService,
+	) {
+		super();
+		this._register(new AutomationSchedulerCore(automationService, runner, storageService, logService, {
+			isFeatureEnabled: () => configurationService.getValue<boolean>(CHAT_AUTOMATIONS_ENABLED_SETTING) === true,
+			getRunTimeoutMs: () => {
+				const minutes = configurationService.getValue<number>(CHAT_AUTOMATIONS_RUN_TIMEOUT_MINUTES_SETTING);
+				const sane = typeof minutes === 'number' && Number.isFinite(minutes) && minutes >= 1
+					? minutes
+					: DEFAULT_AUTOMATIONS_RUN_TIMEOUT_MINUTES;
+				return sane * 60_000;
+			},
+		}));
+	}
+}
+
+function isDue(automation: IAutomation, now: Date): boolean {
+	if (!automation.enabled || !automation.nextRunAt) {
+		return false;
+	}
+	const next = Date.parse(automation.nextRunAt);
+	if (Number.isNaN(next)) {
+		return false;
+	}
+	return next <= now.getTime();
+}
+

--- a/src/vs/sessions/contrib/automations/browser/automationScheduler.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationScheduler.ts
@@ -134,9 +134,12 @@ export class AutomationSchedulerCore extends Disposable {
 
 		const leaderWindowId = stringHash(this._leader.instanceId, 0);
 		for (const automation of due) {
-			// Advance schedule first so a concurrent tick doesn't re-pick this row.
-			await this.automationService.advanceNextRunAt(automation.id, now);
-			await this.runOneWithTimeout(automation, trigger, leaderWindowId);
+			try {
+				await this.automationService.advanceNextRunAt(automation.id, now);
+				await this.runOneWithTimeout(automation, trigger, leaderWindowId);
+			} catch (err) {
+				this.logService.error('[AutomationScheduler] dispatch failed for automation', automation.id, err);
+			}
 		}
 	}
 

--- a/src/vs/sessions/contrib/automations/browser/automationScheduler.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationScheduler.ts
@@ -22,7 +22,7 @@ import { AutomationLeaderElection, IAutomationLeaderElection } from './automatio
 export const DEFAULT_SCHEDULER_TICK_MS = 60_000;
 
 // Stored on stale run rows on leader startup.
-export const CRASH_RECOVERY_REASON = 'Interrupted by app shutdown';
+export const CRASH_RECOVERY_REASON = localize('automations.crashRecoveryReason', "Interrupted by app shutdown");
 
 export const RUN_TIMEOUT_REASON_PREFIX = 'Timed out after';
 

--- a/src/vs/sessions/contrib/automations/browser/automationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationService.ts
@@ -56,7 +56,7 @@ interface ISerializedAutomation {
 
 interface ISerializedLedger {
 	readonly schemaVersion: number;
-	// Optimistic-concurrency counter; 0 for legacy blobs without this field.
+	// Optimistic-concurrency counter. 0 for legacy blobs without this field.
 	readonly revision?: number;
 	readonly automations: readonly ISerializedAutomation[];
 	readonly runs: readonly IAutomationRun[];
@@ -82,7 +82,7 @@ export class AutomationService extends Disposable implements IAutomationService 
 	private _now: () => Date;
 	private readonly _runsForCache = new Map<string, IObservable<readonly IAutomationRun[]>>();
 
-	// Set when on-disk schema is newer than this build; prevents writes that would destroy data.
+	// Set when on-disk schema is newer than this build. Prevents writes that would destroy data.
 	private _unsupportedSchema = false;
 
 	private _lastSeenRevision = 0;

--- a/src/vs/sessions/contrib/automations/browser/automationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationService.ts
@@ -312,31 +312,7 @@ export class AutomationService extends Disposable implements IAutomationService 
 			return;
 		}
 
-		// Best-effort optimistic concurrency: re-read before writing to detect schema upgrades
-		// and concurrent writes from other windows.
-		let baseRevision = this._lastSeenRevision;
-		try {
-			const raw = this.storageService.get(STORAGE_KEY, StorageScope.APPLICATION);
-			if (raw) {
-				try {
-					const parsed = JSON.parse(raw) as ISerializedLedger;
-					if (typeof parsed?.schemaVersion === 'number' && parsed.schemaVersion > CURRENT_SCHEMA_VERSION) {
-						this._unsupportedSchema = true;
-						this.logService.warn(`[AutomationService] On-disk ledger upgraded to schema v${parsed.schemaVersion}; entering read-only mode and skipping write.`);
-						return;
-					}
-					const onDiskRevision = typeof parsed?.revision === 'number' ? parsed.revision : 0;
-					if (onDiskRevision > this._lastSeenRevision) {
-						this.logService.warn(`[AutomationService] Concurrent write detected (on-disk revision ${onDiskRevision} > local ${this._lastSeenRevision}); overwriting. Recent changes from another window may be lost.`);
-					}
-					baseRevision = Math.max(onDiskRevision, this._lastSeenRevision);
-				} catch { }
-			}
-		} catch (err) {
-			this.logService.warn('[AutomationService] Failed to read storage before persist; proceeding with last known revision', err);
-		}
-
-		const nextRevision = baseRevision + 1;
+		const nextRevision = this._lastSeenRevision + 1;
 		const serialized: ISerializedLedger = {
 			schemaVersion: CURRENT_SCHEMA_VERSION,
 			revision: nextRevision,

--- a/src/vs/sessions/contrib/automations/browser/automationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationService.ts
@@ -32,6 +32,8 @@ const CURRENT_SCHEMA_VERSION = 1;
 
 const MAX_RUNS_PER_AUTOMATION = 50;
 
+const VALID_ISOLATION_MODES = new Set(['worktree', 'workspace']);
+
 interface ISerializedAutomation {
 	readonly id: string;
 	readonly name: string;
@@ -154,8 +156,8 @@ export class AutomationService extends Disposable implements IAutomationService 
 			sessionTypeId: options.sessionTypeId,
 			modelId: options.modelId,
 			mode: options.mode,
-			permissionLevel: options.permissionLevel,
-			isolationMode: options.isolationMode,
+			permissionLevel: isChatPermissionLevel(options.permissionLevel) ? options.permissionLevel : undefined,
+			isolationMode: VALID_ISOLATION_MODES.has(options.isolationMode!) ? options.isolationMode : undefined,
 			branch: options.branch,
 			enabled: options.enabled ?? true,
 			createdAt: nowIso,
@@ -313,21 +315,25 @@ export class AutomationService extends Disposable implements IAutomationService 
 		// Best-effort optimistic concurrency: re-read before writing to detect schema upgrades
 		// and concurrent writes from other windows.
 		let baseRevision = this._lastSeenRevision;
-		const raw = this.storageService.get(STORAGE_KEY, StorageScope.APPLICATION);
-		if (raw) {
-			try {
-				const parsed = JSON.parse(raw) as ISerializedLedger;
-				if (typeof parsed?.schemaVersion === 'number' && parsed.schemaVersion > CURRENT_SCHEMA_VERSION) {
-					this._unsupportedSchema = true;
-					this.logService.warn(`[AutomationService] On-disk ledger upgraded to schema v${parsed.schemaVersion}; entering read-only mode and skipping write.`);
-					return;
-				}
-				const onDiskRevision = typeof parsed?.revision === 'number' ? parsed.revision : 0;
-				if (onDiskRevision > this._lastSeenRevision) {
-					this.logService.warn(`[AutomationService] Concurrent write detected (on-disk revision ${onDiskRevision} > local ${this._lastSeenRevision}); overwriting. Recent changes from another window may be lost.`);
-				}
-				baseRevision = Math.max(onDiskRevision, this._lastSeenRevision);
-			} catch { }
+		try {
+			const raw = this.storageService.get(STORAGE_KEY, StorageScope.APPLICATION);
+			if (raw) {
+				try {
+					const parsed = JSON.parse(raw) as ISerializedLedger;
+					if (typeof parsed?.schemaVersion === 'number' && parsed.schemaVersion > CURRENT_SCHEMA_VERSION) {
+						this._unsupportedSchema = true;
+						this.logService.warn(`[AutomationService] On-disk ledger upgraded to schema v${parsed.schemaVersion}; entering read-only mode and skipping write.`);
+						return;
+					}
+					const onDiskRevision = typeof parsed?.revision === 'number' ? parsed.revision : 0;
+					if (onDiskRevision > this._lastSeenRevision) {
+						this.logService.warn(`[AutomationService] Concurrent write detected (on-disk revision ${onDiskRevision} > local ${this._lastSeenRevision}); overwriting. Recent changes from another window may be lost.`);
+					}
+					baseRevision = Math.max(onDiskRevision, this._lastSeenRevision);
+				} catch { }
+			}
+		} catch (err) {
+			this.logService.warn('[AutomationService] Failed to read storage before persist; proceeding with last known revision', err);
 		}
 
 		const nextRevision = baseRevision + 1;
@@ -337,7 +343,12 @@ export class AutomationService extends Disposable implements IAutomationService 
 			automations: automations.map(serializeAutomation),
 			runs: [...runs],
 		};
-		this.storageService.store(STORAGE_KEY, JSON.stringify(serialized), StorageScope.APPLICATION, StorageTarget.MACHINE);
+		try {
+			this.storageService.store(STORAGE_KEY, JSON.stringify(serialized), StorageScope.APPLICATION, StorageTarget.MACHINE);
+		} catch (err) {
+			this.logService.warn('[AutomationService] Failed to persist ledger to storage', err);
+			return;
+		}
 		this._lastSeenRevision = nextRevision;
 	}
 
@@ -456,8 +467,8 @@ function mergeAutomation(current: IAutomation, patch: IUpdateAutomationOptions):
 		sessionTypeId: patch.sessionTypeId === null ? undefined : (patch.sessionTypeId ?? current.sessionTypeId),
 		modelId: patch.modelId === null ? undefined : (patch.modelId ?? current.modelId),
 		mode: patch.mode === null ? undefined : (patch.mode ?? current.mode),
-		permissionLevel: patch.permissionLevel === null ? undefined : (patch.permissionLevel ?? current.permissionLevel),
-		isolationMode: patch.isolationMode === null ? undefined : (patch.isolationMode ?? current.isolationMode),
+		permissionLevel: patch.permissionLevel === null ? undefined : (patch.permissionLevel && isChatPermissionLevel(patch.permissionLevel) ? patch.permissionLevel : current.permissionLevel),
+		isolationMode: patch.isolationMode === null ? undefined : (patch.isolationMode && VALID_ISOLATION_MODES.has(patch.isolationMode) ? patch.isolationMode : current.isolationMode),
 		branch: patch.branch === null ? undefined : (patch.branch ?? current.branch),
 		enabled: patch.enabled ?? current.enabled,
 	};

--- a/src/vs/sessions/contrib/automations/browser/automationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationService.ts
@@ -1,0 +1,466 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { derived, IObservable, ISettableObservable, observableValue, transaction } from '../../../../base/common/observable.js';
+import { URI, UriComponents } from '../../../../base/common/uri.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import {
+	AutomationRunTrigger,
+	IAutomation,
+	IAutomationRun,
+} from '../../../../workbench/contrib/chat/common/automations/automation.js';
+import {
+	IAutomationService,
+	ICreateAutomationOptions,
+	IUpdateAutomationOptions,
+	IUpdateAutomationRunOptions,
+} from '../../../../workbench/contrib/chat/common/automations/automationService.js';
+import { publishAutomationCreated, publishAutomationDeleted, publishAutomationUpdated } from '../../../../workbench/contrib/chat/common/automations/automationTelemetry.js';
+import { computeNextRunAt } from '../../../../workbench/contrib/chat/common/automations/schedule.js';
+import { ChatPermissionLevel, isChatPermissionLevel } from '../../../../workbench/contrib/chat/common/constants.js';
+
+// APPLICATION scope, non-roaming.
+const STORAGE_KEY = 'chat.automations.ledger';
+
+const CURRENT_SCHEMA_VERSION = 1;
+
+const MAX_RUNS_PER_AUTOMATION = 50;
+
+interface ISerializedAutomation {
+	readonly id: string;
+	readonly name: string;
+	readonly prompt: string;
+	readonly schedule: IAutomation['schedule'];
+	readonly folderUri: UriComponents;
+	readonly providerId?: string;
+	readonly sessionTypeId?: string;
+	readonly modelId?: string;
+	readonly mode?: string;
+	readonly permissionLevel?: string;
+	readonly isolationMode?: string;
+	readonly branch?: string;
+	readonly enabled: boolean;
+	readonly createdAt: string;
+	readonly updatedAt: string;
+	readonly lastRunAt?: string;
+	readonly nextRunAt?: string;
+}
+
+interface ISerializedLedger {
+	readonly schemaVersion: number;
+	// Optimistic-concurrency counter; 0 for legacy blobs without this field.
+	readonly revision?: number;
+	readonly automations: readonly ISerializedAutomation[];
+	readonly runs: readonly IAutomationRun[];
+}
+
+interface ILedger {
+	readonly automations: readonly IAutomation[];
+	readonly runs: readonly IAutomationRun[];
+}
+
+const EMPTY_LEDGER: ILedger = Object.freeze({ automations: [], runs: [] });
+
+type ReadLedgerResult =
+	| { kind: 'ledger'; ledger: ILedger; revision: number }
+	| { kind: 'unsupportedSchema' };
+
+export class AutomationService extends Disposable implements IAutomationService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _automations: ISettableObservable<readonly IAutomation[]>;
+	private readonly _runs: ISettableObservable<readonly IAutomationRun[]>;
+	private _now: () => Date;
+	private readonly _runsForCache = new Map<string, IObservable<readonly IAutomationRun[]>>();
+
+	// Set when on-disk schema is newer than this build; prevents writes that would destroy data.
+	private _unsupportedSchema = false;
+
+	private _lastSeenRevision = 0;
+
+	readonly automations: IObservable<readonly IAutomation[]>;
+	readonly runs: IObservable<readonly IAutomationRun[]>;
+
+	constructor(
+		@IStorageService private readonly storageService: IStorageService,
+		@ILogService private readonly logService: ILogService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
+	) {
+		super();
+
+		this._now = () => new Date();
+
+		const result = this.readLedger();
+		const initial = result.kind === 'ledger' ? result.ledger : EMPTY_LEDGER;
+		if (result.kind === 'ledger') {
+			this._lastSeenRevision = result.revision;
+		}
+		this._automations = observableValue<readonly IAutomation[]>(this, initial.automations);
+		this._runs = observableValue<readonly IAutomationRun[]>(this, initial.runs);
+		this.automations = this._automations;
+		this.runs = this._runs;
+
+		this._register(this.storageService.onDidChangeValue(StorageScope.APPLICATION, STORAGE_KEY, this._store)(() => {
+			this.refreshFromStorage();
+		}));
+
+		this._register(this.storageService.onWillSaveState(() => {
+			this.persist(this._automations.get(), this._runs.get());
+		}));
+	}
+
+	/** Test-only: swap in a deterministic clock used by create/update. */
+	setClockForTesting(now: () => Date): void {
+		this._now = now;
+	}
+
+	getAutomation(id: string): IAutomation | undefined {
+		return this._automations.get().find(a => a.id === id);
+	}
+
+	runsFor(automationId: string): IObservable<readonly IAutomationRun[]> {
+		let cached = this._runsForCache.get(automationId);
+		if (!cached) {
+			cached = derived(this, reader => this._runs.read(reader).filter(r => r.automationId === automationId));
+			this._runsForCache.set(automationId, cached);
+		}
+		return cached;
+	}
+
+	async createAutomation(options: ICreateAutomationOptions): Promise<IAutomation> {
+		if (this._unsupportedSchema) {
+			throw new Error('Cannot modify automations: storage was written by a newer version');
+		}
+		if (!options.folderUri) {
+			throw new Error('Automation requires a folderUri.');
+		}
+		const now = this._now();
+		const nowIso = now.toISOString();
+		const nextRun = computeNextRunAt(options.schedule, now);
+		const automation: IAutomation = Object.freeze({
+			id: generateUuid(),
+			name: options.name,
+			prompt: options.prompt,
+			schedule: options.schedule,
+			folderUri: options.folderUri,
+			providerId: options.providerId,
+			sessionTypeId: options.sessionTypeId,
+			modelId: options.modelId,
+			mode: options.mode,
+			permissionLevel: options.permissionLevel,
+			isolationMode: options.isolationMode,
+			branch: options.branch,
+			enabled: options.enabled ?? true,
+			createdAt: nowIso,
+			updatedAt: nowIso,
+			lastRunAt: undefined,
+			nextRunAt: nextRun?.toISOString(),
+		});
+		const next = [automation, ...this._automations.get()];
+		this.commit(next, this._runs.get());
+		publishAutomationCreated(this.telemetryService, automation);
+		return automation;
+	}
+
+	async updateAutomation(id: string, patch: IUpdateAutomationOptions): Promise<IAutomation> {
+		if (this._unsupportedSchema) {
+			throw new Error('Cannot modify automations: storage was written by a newer version');
+		}
+		const current = this.getAutomation(id);
+		if (!current) {
+			throw new Error(`Automation not found: ${id}`);
+		}
+		const merged = mergeAutomation(current, patch);
+		const scheduleChanged = patch.schedule !== undefined;
+		const enabledChanged = patch.enabled !== undefined;
+		const updated: IAutomation = Object.freeze({
+			...merged,
+			updatedAt: this._now().toISOString(),
+			nextRunAt: (scheduleChanged || (enabledChanged && merged.enabled))
+				? computeNextRunAt(merged.schedule, this._now())?.toISOString()
+				: merged.nextRunAt,
+		});
+		const next = this._automations.get().map(a => a.id === id ? updated : a);
+		this.commit(next, this._runs.get());
+		publishAutomationUpdated(this.telemetryService, current, updated);
+		return updated;
+	}
+
+	async deleteAutomation(id: string): Promise<void> {
+		if (this._unsupportedSchema) {
+			throw new Error('Cannot modify automations: storage was written by a newer version');
+		}
+		const existing = this.getAutomation(id);
+		const next = this._automations.get().filter(a => a.id !== id);
+		if (next.length === this._automations.get().length) {
+			return;
+		}
+		this.commit(next, this._runs.get());
+		this._runsForCache.delete(id);
+		if (existing) {
+			publishAutomationDeleted(this.telemetryService, existing);
+		}
+	}
+
+	async recordRunStart(automationId: string, trigger: AutomationRunTrigger, leaderWindowId: number): Promise<IAutomationRun> {
+		if (!this.getAutomation(automationId)) {
+			throw new Error(`Automation not found: ${automationId}`);
+		}
+		const run: IAutomationRun = Object.freeze({
+			id: generateUuid(),
+			automationId,
+			status: 'pending',
+			trigger,
+			startedAt: this._now().toISOString(),
+			leaderWindowId,
+		});
+		const nextRuns = [run, ...this._runs.get()];
+		this.commit(this._automations.get(), nextRuns);
+		return run;
+	}
+
+	async updateRun(runId: string, patch: IUpdateAutomationRunOptions): Promise<IAutomationRun | undefined> {
+		const current = this._runs.get().find(r => r.id === runId);
+		if (!current) {
+			return undefined;
+		}
+		const merged: IAutomationRun = Object.freeze({
+			...current,
+			status: patch.status ?? current.status,
+			sessionId: patch.sessionId ?? current.sessionId,
+			completedAt: patch.completedAt ?? current.completedAt,
+			errorMessage: patch.errorMessage ?? current.errorMessage,
+		});
+		const nextRuns = this._runs.get().map(r => r.id === runId ? merged : r);
+		this.commit(this._automations.get(), nextRuns);
+		return merged;
+	}
+
+	getActiveRunFor(automationId: string): IAutomationRun | undefined {
+		return this._runs.get().find(r => r.automationId === automationId && (r.status === 'pending' || r.status === 'running'));
+	}
+
+	async markStaleRunsFailed(reason: string): Promise<void> {
+		let changed = false;
+		const completedAt = this._now().toISOString();
+		const nextRuns = this._runs.get().map(r => {
+			if (r.status === 'pending' || r.status === 'running') {
+				changed = true;
+				return Object.freeze({ ...r, status: 'failed' as const, completedAt, errorMessage: reason });
+			}
+			return r;
+		});
+		if (changed) {
+			this.commit(this._automations.get(), nextRuns);
+		}
+	}
+
+	async advanceNextRunAt(id: string, now: Date = this._now()): Promise<IAutomation | undefined> {
+		const current = this.getAutomation(id);
+		if (!current) {
+			return undefined;
+		}
+		const updated: IAutomation = Object.freeze({
+			...current,
+			lastRunAt: now.toISOString(),
+			nextRunAt: computeNextRunAt(current.schedule, now)?.toISOString(),
+			updatedAt: now.toISOString(),
+		});
+		const next = this._automations.get().map(a => a.id === id ? updated : a);
+		this.commit(next, this._runs.get());
+		return updated;
+	}
+
+	//#region Persistence
+
+	private commit(automations: readonly IAutomation[], runs: readonly IAutomationRun[]): void {
+		if (this._unsupportedSchema) {
+			this.logService.warn('[AutomationService] Skipping commit; ledger has an unsupported (newer) schema version.');
+			return;
+		}
+		const trimmedRuns = trimRunsPerAutomation(runs, MAX_RUNS_PER_AUTOMATION);
+		transaction(tx => {
+			this._automations.set(automations, tx);
+			this._runs.set(trimmedRuns, tx);
+		});
+		this.persist(automations, trimmedRuns);
+	}
+
+	private persist(automations: readonly IAutomation[], runs: readonly IAutomationRun[]): void {
+		if (this._unsupportedSchema) {
+			return;
+		}
+
+		// Best-effort optimistic concurrency: re-read before writing to detect schema upgrades
+		// and concurrent writes from other windows.
+		let baseRevision = this._lastSeenRevision;
+		const raw = this.storageService.get(STORAGE_KEY, StorageScope.APPLICATION);
+		if (raw) {
+			try {
+				const parsed = JSON.parse(raw) as ISerializedLedger;
+				if (typeof parsed?.schemaVersion === 'number' && parsed.schemaVersion > CURRENT_SCHEMA_VERSION) {
+					this._unsupportedSchema = true;
+					this.logService.warn(`[AutomationService] On-disk ledger upgraded to schema v${parsed.schemaVersion}; entering read-only mode and skipping write.`);
+					return;
+				}
+				const onDiskRevision = typeof parsed?.revision === 'number' ? parsed.revision : 0;
+				if (onDiskRevision > this._lastSeenRevision) {
+					this.logService.warn(`[AutomationService] Concurrent write detected (on-disk revision ${onDiskRevision} > local ${this._lastSeenRevision}); overwriting. Recent changes from another window may be lost.`);
+				}
+				baseRevision = Math.max(onDiskRevision, this._lastSeenRevision);
+			} catch { }
+		}
+
+		const nextRevision = baseRevision + 1;
+		const serialized: ISerializedLedger = {
+			schemaVersion: CURRENT_SCHEMA_VERSION,
+			revision: nextRevision,
+			automations: automations.map(serializeAutomation),
+			runs: [...runs],
+		};
+		this.storageService.store(STORAGE_KEY, JSON.stringify(serialized), StorageScope.APPLICATION, StorageTarget.MACHINE);
+		this._lastSeenRevision = nextRevision;
+	}
+
+	private refreshFromStorage(): void {
+		const result = this.readLedger();
+		if (result.kind === 'unsupportedSchema') {
+			return;
+		}
+		this._unsupportedSchema = false;
+		this._lastSeenRevision = result.revision;
+		transaction(tx => {
+			this._automations.set(result.ledger.automations, tx);
+			this._runs.set(result.ledger.runs, tx);
+		});
+	}
+
+	private readLedger(): ReadLedgerResult {
+		const raw = this.storageService.get(STORAGE_KEY, StorageScope.APPLICATION);
+		if (!raw) {
+			return { kind: 'ledger', ledger: EMPTY_LEDGER, revision: 0 };
+		}
+		try {
+			const parsed = JSON.parse(raw) as ISerializedLedger;
+			if (typeof parsed?.schemaVersion === 'number' && parsed.schemaVersion > CURRENT_SCHEMA_VERSION) {
+				this._unsupportedSchema = true;
+				this.logService.warn(`[AutomationService] Ledger has schema v${parsed.schemaVersion}; this build only supports v${CURRENT_SCHEMA_VERSION}. Entering read-only mode.`);
+				return { kind: 'unsupportedSchema' };
+			}
+			if (parsed?.schemaVersion !== CURRENT_SCHEMA_VERSION) {
+				this.logService.warn(`[AutomationService] Unsupported ledger schema version ${parsed?.schemaVersion}; ignoring.`);
+				return { kind: 'ledger', ledger: EMPTY_LEDGER, revision: 0 };
+			}
+			const automations: IAutomation[] = [];
+			for (const entry of parsed.automations ?? []) {
+				if (!entry?.folderUri) {
+					this.logService.warn(`[AutomationService] Dropping persisted automation ${entry?.id} without a folderUri.`);
+					continue;
+				}
+				automations.push(deserializeAutomation(entry));
+			}
+			const validIds = new Set(automations.map(a => a.id));
+			const runs = (parsed.runs ?? [])
+				.filter(r => validIds.has(r.automationId))
+				.map(r => Object.freeze({ ...r }));
+			const revision = typeof parsed.revision === 'number' ? parsed.revision : 0;
+			return { kind: 'ledger', ledger: { automations, runs: trimRunsPerAutomation(runs, MAX_RUNS_PER_AUTOMATION) }, revision };
+		} catch (err) {
+			this.logService.error('[AutomationService] Failed to parse automations ledger; resetting.', err);
+			return { kind: 'ledger', ledger: EMPTY_LEDGER, revision: 0 };
+		}
+	}
+
+	//#endregion
+}
+
+function serializeAutomation(a: IAutomation): ISerializedAutomation {
+	return {
+		id: a.id,
+		name: a.name,
+		prompt: a.prompt,
+		schedule: a.schedule,
+		folderUri: a.folderUri.toJSON() as UriComponents,
+		providerId: a.providerId,
+		sessionTypeId: a.sessionTypeId,
+		modelId: a.modelId,
+		mode: a.mode,
+		permissionLevel: a.permissionLevel,
+		isolationMode: a.isolationMode,
+		branch: a.branch,
+		enabled: a.enabled,
+		createdAt: a.createdAt,
+		updatedAt: a.updatedAt,
+		lastRunAt: a.lastRunAt,
+		nextRunAt: a.nextRunAt,
+	};
+}
+
+function deserializeAutomation(s: ISerializedAutomation): IAutomation {
+	const revivedUri = URI.revive(s.folderUri);
+	const folderUri = revivedUri;
+
+	// Default to most restrictive if the persisted value is invalid.
+	const permissionLevel = isChatPermissionLevel(s.permissionLevel)
+		? s.permissionLevel
+		: ChatPermissionLevel.Default;
+
+	return Object.freeze({
+		id: s.id,
+		name: s.name,
+		prompt: s.prompt,
+		schedule: s.schedule,
+		folderUri,
+		providerId: s.providerId,
+		sessionTypeId: s.sessionTypeId,
+		modelId: s.modelId,
+		mode: s.mode,
+		permissionLevel,
+		isolationMode: s.isolationMode,
+		branch: s.branch,
+		enabled: s.enabled,
+		createdAt: s.createdAt,
+		updatedAt: s.updatedAt,
+		lastRunAt: s.lastRunAt,
+		nextRunAt: s.nextRunAt,
+	});
+}
+
+function mergeAutomation(current: IAutomation, patch: IUpdateAutomationOptions): IAutomation {
+	return {
+		...current,
+		name: patch.name ?? current.name,
+		prompt: patch.prompt ?? current.prompt,
+		schedule: patch.schedule ?? current.schedule,
+		folderUri: patch.folderUri ?? current.folderUri,
+		providerId: patch.providerId === null ? undefined : (patch.providerId ?? current.providerId),
+		sessionTypeId: patch.sessionTypeId === null ? undefined : (patch.sessionTypeId ?? current.sessionTypeId),
+		modelId: patch.modelId === null ? undefined : (patch.modelId ?? current.modelId),
+		mode: patch.mode === null ? undefined : (patch.mode ?? current.mode),
+		permissionLevel: patch.permissionLevel === null ? undefined : (patch.permissionLevel ?? current.permissionLevel),
+		isolationMode: patch.isolationMode === null ? undefined : (patch.isolationMode ?? current.isolationMode),
+		branch: patch.branch === null ? undefined : (patch.branch ?? current.branch),
+		enabled: patch.enabled ?? current.enabled,
+	};
+}
+
+function trimRunsPerAutomation(runs: readonly IAutomationRun[], max: number): readonly IAutomationRun[] {
+	const counts = new Map<string, number>();
+	const out: IAutomationRun[] = [];
+	for (const run of runs) {
+		const count = counts.get(run.automationId) ?? 0;
+		if (count >= max) {
+			continue;
+		}
+		counts.set(run.automationId, count + 1);
+		out.push(run);
+	}
+	return out.length === runs.length ? runs : out;
+}

--- a/src/vs/sessions/contrib/automations/browser/automationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationService.ts
@@ -254,6 +254,9 @@ export class AutomationService extends Disposable implements IAutomationService 
 	}
 
 	async markStaleRunsFailed(reason: string): Promise<void> {
+		if (this._unsupportedSchema) {
+			throw new Error('Cannot modify automations: storage was written by a newer version');
+		}
 		let changed = false;
 		const completedAt = this._now().toISOString();
 		const nextRuns = this._runs.get().map(r => {
@@ -269,6 +272,9 @@ export class AutomationService extends Disposable implements IAutomationService 
 	}
 
 	async advanceNextRunAt(id: string, now: Date = this._now()): Promise<IAutomation | undefined> {
+		if (this._unsupportedSchema) {
+			throw new Error('Cannot modify automations: storage was written by a newer version');
+		}
 		const current = this.getAutomation(id);
 		if (!current) {
 			return undefined;

--- a/src/vs/sessions/contrib/automations/browser/automationService.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationService.ts
@@ -210,6 +210,9 @@ export class AutomationService extends Disposable implements IAutomationService 
 	}
 
 	async recordRunStart(automationId: string, trigger: AutomationRunTrigger, leaderWindowId: number): Promise<IAutomationRun> {
+		if (this._unsupportedSchema) {
+			throw new Error('Cannot modify automations: storage was written by a newer version');
+		}
 		if (!this.getAutomation(automationId)) {
 			throw new Error(`Automation not found: ${automationId}`);
 		}
@@ -227,6 +230,9 @@ export class AutomationService extends Disposable implements IAutomationService 
 	}
 
 	async updateRun(runId: string, patch: IUpdateAutomationRunOptions): Promise<IAutomationRun | undefined> {
+		if (this._unsupportedSchema) {
+			throw new Error('Cannot modify automations: storage was written by a newer version');
+		}
 		const current = this._runs.get().find(r => r.id === runId);
 		if (!current) {
 			return undefined;

--- a/src/vs/sessions/contrib/automations/browser/automations.contribution.ts
+++ b/src/vs/sessions/contrib/automations/browser/automations.contribution.ts
@@ -36,7 +36,7 @@ class StubAutomationRunner implements IAutomationRunner {
 }
 registerSingleton(IAutomationRunner, StubAutomationRunner, InstantiationType.Delayed);
 
-registerWorkbenchContribution2(AutomationScheduler.ID, AutomationScheduler, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(AutomationScheduler.ID, AutomationScheduler, WorkbenchPhase.Eventually);
 
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
 	id: 'chat',

--- a/src/vs/sessions/contrib/automations/browser/automations.contribution.ts
+++ b/src/vs/sessions/contrib/automations/browser/automations.contribution.ts
@@ -26,7 +26,7 @@ import { AutomationService } from './automationService.js';
 
 registerSingleton(IAutomationService, AutomationService, InstantiationType.Delayed);
 
-// Stub runner for Layer 1 — the real implementation (Layer 2) replaces this registration.
+// Stub runner for Layer 1. The real implementation (Layer 2) replaces this registration.
 
 class StubAutomationRunner implements IAutomationRunner {
 	declare readonly _serviceBrand: undefined;

--- a/src/vs/sessions/contrib/automations/browser/automations.contribution.ts
+++ b/src/vs/sessions/contrib/automations/browser/automations.contribution.ts
@@ -52,6 +52,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			type: 'number',
 			default: DEFAULT_AUTOMATIONS_RUN_TIMEOUT_MINUTES,
 			minimum: 1,
+			scope: ConfigurationScope.MACHINE,
 			tags: ['preview'],
 			description: localize('chat.automations.runTimeoutMinutes', "Maximum number of minutes a scheduled automation run is allowed to take before the scheduler cancels it and marks it failed. Prevents a single hung run from permanently blocking subsequent scheduled runs."),
 		},

--- a/src/vs/sessions/contrib/automations/browser/automations.contribution.ts
+++ b/src/vs/sessions/contrib/automations/browser/automations.contribution.ts
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { localize, localize2 } from '../../../../nls.js';
+import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { ConfigurationTarget, IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
+import { ChatContextKeys } from '../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
+import { IAutomationRunner } from '../../../../workbench/contrib/chat/common/automations/automationRunner.js';
+import { IAutomationService } from '../../../../workbench/contrib/chat/common/automations/automationService.js';
+import { publishAutomationToggled } from '../../../../workbench/contrib/chat/common/automations/automationTelemetry.js';
+import { ChatAutomationsEnabledContext, CHAT_AUTOMATIONS_ENABLED_SETTING, CHAT_AUTOMATIONS_RUN_TIMEOUT_MINUTES_SETTING, DEFAULT_AUTOMATIONS_RUN_TIMEOUT_MINUTES } from '../../../../workbench/contrib/chat/common/automations/automationsEnabled.js';
+import { AutomationScheduler } from './automationScheduler.js';
+import { AutomationService } from './automationService.js';
+
+registerSingleton(IAutomationService, AutomationService, InstantiationType.Delayed);
+
+// Stub runner for Layer 1 — the real implementation (Layer 2) replaces this registration.
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { IAutomation, AutomationRunTrigger } from '../../../../workbench/contrib/chat/common/automations/automation.js';
+
+class StubAutomationRunner implements IAutomationRunner {
+	declare readonly _serviceBrand: undefined;
+	async runOnce(_automation: IAutomation, _trigger: AutomationRunTrigger, _leaderWindowId: number, _token?: CancellationToken): Promise<void> {
+		// No-op: real runner is registered in Layer 2.
+	}
+}
+registerSingleton(IAutomationRunner, StubAutomationRunner, InstantiationType.Delayed);
+
+registerWorkbenchContribution2(AutomationScheduler.ID, AutomationScheduler, WorkbenchPhase.AfterRestored);
+
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	id: 'chat',
+	properties: {
+		[CHAT_AUTOMATIONS_ENABLED_SETTING]: {
+			type: 'boolean',
+			default: false,
+			scope: ConfigurationScope.MACHINE,
+			tags: ['preview'],
+			description: localize('chat.automations.enabled', "Enables the Automations feature: scheduling agent sessions to run on a cadence. When disabled, the Automations entry in the Customizations sidebar, the Automations section in the Customizations editor, and the Automation option in the new-session composer are hidden, and scheduled automations are not dispatched."),
+		},
+		[CHAT_AUTOMATIONS_RUN_TIMEOUT_MINUTES_SETTING]: {
+			type: 'number',
+			default: DEFAULT_AUTOMATIONS_RUN_TIMEOUT_MINUTES,
+			minimum: 1,
+			tags: ['preview'],
+			description: localize('chat.automations.runTimeoutMinutes', "Maximum number of minutes a scheduled automation run is allowed to take before the scheduler cancels it and marks it failed. Prevents a single hung run from permanently blocking subsequent scheduled runs."),
+		},
+	},
+});
+
+// Mirrors the setting into a context key for menu `when` clauses.
+class ChatAutomationsEnabledContextContribution extends Disposable implements IWorkbenchContribution {
+	static readonly ID = 'workbench.contrib.chatAutomationsEnabledContext';
+
+	constructor(
+		@IConfigurationService configurationService: IConfigurationService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+	) {
+		super();
+		const key = ChatAutomationsEnabledContext.bindTo(contextKeyService);
+		const update = () => key.set(configurationService.getValue<boolean>(CHAT_AUTOMATIONS_ENABLED_SETTING) === true);
+		update();
+		this._register(configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(CHAT_AUTOMATIONS_ENABLED_SETTING)) {
+				update();
+			}
+		}));
+	}
+}
+
+registerWorkbenchContribution2(ChatAutomationsEnabledContextContribution.ID, ChatAutomationsEnabledContextContribution, WorkbenchPhase.BlockStartup);
+
+registerAction2(class ToggleChatAutomationsAction extends Action2 {
+	static readonly ID = 'chat.automations.toggleEnabled';
+
+	constructor() {
+		super({
+			id: ToggleChatAutomationsAction.ID,
+			title: localize2('toggleChatAutomations', "Toggle Automations"),
+			category: localize2('chatCategory', "Chat"),
+			f1: true,
+			precondition: ChatContextKeys.enabled,
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const configurationService = accessor.get(IConfigurationService);
+		const telemetryService = accessor.get(ITelemetryService);
+		const current = configurationService.getValue<boolean>(CHAT_AUTOMATIONS_ENABLED_SETTING) === true;
+		const next = !current;
+		await configurationService.updateValue(CHAT_AUTOMATIONS_ENABLED_SETTING, next, ConfigurationTarget.USER);
+		publishAutomationToggled(telemetryService, next);
+	}
+});

--- a/src/vs/sessions/contrib/automations/browser/automations.contribution.ts
+++ b/src/vs/sessions/contrib/automations/browser/automations.contribution.ts
@@ -19,14 +19,14 @@ import { IAutomationRunner } from '../../../../workbench/contrib/chat/common/aut
 import { IAutomationService } from '../../../../workbench/contrib/chat/common/automations/automationService.js';
 import { publishAutomationToggled } from '../../../../workbench/contrib/chat/common/automations/automationTelemetry.js';
 import { ChatAutomationsEnabledContext, CHAT_AUTOMATIONS_ENABLED_SETTING, CHAT_AUTOMATIONS_RUN_TIMEOUT_MINUTES_SETTING, DEFAULT_AUTOMATIONS_RUN_TIMEOUT_MINUTES } from '../../../../workbench/contrib/chat/common/automations/automationsEnabled.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { IAutomation, AutomationRunTrigger } from '../../../../workbench/contrib/chat/common/automations/automation.js';
 import { AutomationScheduler } from './automationScheduler.js';
 import { AutomationService } from './automationService.js';
 
 registerSingleton(IAutomationService, AutomationService, InstantiationType.Delayed);
 
 // Stub runner for Layer 1 — the real implementation (Layer 2) replaces this registration.
-import { CancellationToken } from '../../../../base/common/cancellation.js';
-import { IAutomation, AutomationRunTrigger } from '../../../../workbench/contrib/chat/common/automations/automation.js';
 
 class StubAutomationRunner implements IAutomationRunner {
 	declare readonly _serviceBrand: undefined;

--- a/src/vs/sessions/contrib/automations/test/browser/automationLeaderElection.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/automationLeaderElection.test.ts
@@ -97,7 +97,7 @@ suite('AutomationLeaderElection', () => {
 		assert.ok(raw, 'tombstone should be present after release');
 		const parsed = JSON.parse(raw!);
 		assert.strictEqual(parsed.instanceId, '');
-		// Any subsequent claim — even at the same wall clock — should
+		// Any subsequent claim, even at the same wall clock, should
 		// succeed without waiting for staleAfterMs.
 		const b = createElection(storage, () => 1_000, 'window-b');
 		assert.strictEqual(b.isLeader.get(), true);

--- a/src/vs/sessions/contrib/automations/test/browser/automationLeaderElection.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/automationLeaderElection.test.ts
@@ -1,0 +1,157 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { InMemoryStorageService } from '../../../../../platform/storage/common/storage.js';
+import { AutomationLeaderElection } from '../../browser/automationLeaderElection.js';
+
+suite('AutomationLeaderElection', () => {
+
+	const teardown = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createElection(storage: InMemoryStorageService, now: () => number, instanceId: string) {
+		return teardown.add(new AutomationLeaderElection(storage, new NullLogService(), {
+			now,
+			instanceId,
+			heartbeatIntervalMs: 60_000_000, // disable real timer for tests
+			staleAfterMs: 90_000,
+		}));
+	}
+
+	test('a single window claims leadership immediately on construction', () => {
+		const storage = teardown.add(new InMemoryStorageService());
+		const now = 1_000;
+		const election = createElection(storage, () => now, 'window-a');
+		assert.strictEqual(election.isLeader.get(), true);
+	});
+
+	test('two windows on the same storage elect exactly one leader', () => {
+		const storage = teardown.add(new InMemoryStorageService());
+		const now = 1_000;
+		const a = createElection(storage, () => now, 'window-a');
+		const b = createElection(storage, () => now, 'window-b');
+		// First constructed claims first; B sees a fresh heartbeat
+		// from A and stands down.
+		assert.strictEqual(a.isLeader.get(), true);
+		assert.strictEqual(b.isLeader.get(), false);
+	});
+
+	test('loser takes over once the leaders heartbeat goes stale', () => {
+		const storage = teardown.add(new InMemoryStorageService());
+		let now = 1_000;
+		const a = createElection(storage, () => now, 'window-a');
+		const b = createElection(storage, () => now, 'window-b');
+		assert.strictEqual(a.isLeader.get(), true);
+		assert.strictEqual(b.isLeader.get(), false);
+
+		// Advance clock past the stale threshold without ticking A.
+		now += 91_000;
+		b.evaluateForTesting();
+		assert.strictEqual(b.isLeader.get(), true);
+	});
+
+	test('leader keeps refreshing its own heartbeat on every evaluation', () => {
+		const storage = teardown.add(new InMemoryStorageService());
+		let now = 1_000;
+		const a = createElection(storage, () => now, 'window-a');
+		assert.strictEqual(a.isLeader.get(), true);
+
+		now += 50_000;
+		a.evaluateForTesting();
+		// Should still be leader because we re-wrote the heartbeat
+		// before another window could see it as stale.
+		assert.strictEqual(a.isLeader.get(), true);
+	});
+
+	test('disposing the leader clears the slot so the next window does not wait', () => {
+		const storage = teardown.add(new InMemoryStorageService());
+		const now = 1_000;
+		const a = createElection(storage, () => now, 'window-a');
+		assert.strictEqual(a.isLeader.get(), true);
+
+		a.dispose();
+		const b = createElection(storage, () => now, 'window-b');
+		assert.strictEqual(b.isLeader.get(), true);
+	});
+
+	test('corrupt leader record is treated as empty and reclaimed', () => {
+		const storage = teardown.add(new InMemoryStorageService());
+		// StorageScope.APPLICATION is -1
+		storage.store('chat.automations.leader', 'not json', -1, 1);
+		const a = createElection(storage, () => 1_000, 'window-a');
+		assert.strictEqual(a.isLeader.get(), true);
+	});
+
+	test('tombstone left on dispose is treated as immediately claimable', () => {
+		const storage = teardown.add(new InMemoryStorageService());
+		const a = createElection(storage, () => 1_000, 'window-a');
+		assert.strictEqual(a.isLeader.get(), true);
+		a.dispose();
+		// After dispose we should see a tombstone (empty instanceId)
+		// in storage, not a removed key.
+		const raw = storage.get('chat.automations.leader', -1);
+		assert.ok(raw, 'tombstone should be present after release');
+		const parsed = JSON.parse(raw!);
+		assert.strictEqual(parsed.instanceId, '');
+		// Any subsequent claim — even at the same wall clock — should
+		// succeed without waiting for staleAfterMs.
+		const b = createElection(storage, () => 1_000, 'window-b');
+		assert.strictEqual(b.isLeader.get(), true);
+	});
+
+	test('readback after writeLeader detects a competing concurrent write and stands down', () => {
+		// Custom storage that injects a competitor write immediately
+		// after every store() to LEADER_KEY. This simulates two windows
+		// reading the slot as claimable, both writing, with the second
+		// write landing after ours (the TOCTOU window in evaluate()).
+		class RacyStorage extends InMemoryStorageService {
+			competitor: string | undefined;
+			override store(key: string, value: any, scope: any, target: any, external = false): void {
+				super.store(key, value, scope, target, external);
+				if (key === 'chat.automations.leader' && this.competitor !== undefined) {
+					super.store(key, this.competitor, scope, target, external);
+				}
+			}
+		}
+		const storage = teardown.add(new RacyStorage());
+		storage.competitor = JSON.stringify({ instanceId: 'window-b', heartbeatAt: 1_000, nonce: 'b-nonce' });
+		const a = createElection(storage, () => 1_000, 'window-a');
+		// Even though A claimed the slot, the readback saw B's record
+		// instead of A's nonce, so A must NOT be leader.
+		assert.strictEqual(a.isLeader.get(), false);
+	});
+
+	test('survives a throwing storage read by leaving leadership unset', () => {
+		class ThrowingStorage extends InMemoryStorageService {
+			override get(key: string, scope: any, fallbackValue?: string): any {
+				if (key === 'chat.automations.leader') {
+					throw new Error('storage unavailable');
+				}
+				return super.get(key, scope, fallbackValue as string);
+			}
+		}
+		const storage = teardown.add(new ThrowingStorage());
+		const a = createElection(storage, () => 1_000, 'window-a');
+		// readLeader threw, the claim path can't validate via readback,
+		// so we should not be leader.
+		assert.strictEqual(a.isLeader.get(), false);
+	});
+
+	test('survives a throwing storage write by not declaring leadership', () => {
+		class ThrowingStorage extends InMemoryStorageService {
+			override store(key: string, value: any, scope: any, target: any, external = false): void {
+				if (key === 'chat.automations.leader') {
+					throw new Error('storage unavailable');
+				}
+				super.store(key, value, scope, target, external);
+			}
+		}
+		const storage = teardown.add(new ThrowingStorage());
+		const a = createElection(storage, () => 1_000, 'window-a');
+		assert.strictEqual(a.isLeader.get(), false);
+	});
+});

--- a/src/vs/sessions/contrib/automations/test/browser/automationScheduler.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/automationScheduler.test.ts
@@ -264,7 +264,7 @@ suite('AutomationSchedulerCore', () => {
 		enabled = true;
 		await core.tickForTesting();
 
-		// The in-flight run must still be running — the feature toggle
+		// The in-flight run must still be running. The feature toggle
 		// must NOT have re-triggered crash recovery.
 		const after = service.runs.get().find(r => r.id === inFlight.id);
 		assert.strictEqual(after?.status, 'running', 'feature-toggle off/on must not fail in-flight runs');

--- a/src/vs/sessions/contrib/automations/test/browser/automationScheduler.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/automationScheduler.test.ts
@@ -1,0 +1,345 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { DeferredPromise } from '../../../../../base/common/async.js';
+import { IObservable, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { InMemoryStorageService } from '../../../../../platform/storage/common/storage.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { IAutomationLeaderElection } from '../../browser/automationLeaderElection.js';
+import { IAutomationRunner } from '../../../../../workbench/contrib/chat/common/automations/automationRunner.js';
+import { AutomationSchedulerCore, CRASH_RECOVERY_REASON, RUN_TIMEOUT_REASON_PREFIX } from '../../browser/automationScheduler.js';
+import { AutomationService } from '../../browser/automationService.js';
+import { AutomationRunTrigger, IAutomation, IAutomationSchedule } from '../../../../../workbench/contrib/chat/common/automations/automation.js';
+
+const FOLDER = URI.parse('file:///workspace');
+
+class FakeLeaderElection implements IAutomationLeaderElection {
+	private readonly _isLeader: ISettableObservable<boolean>;
+	readonly isLeader: IObservable<boolean>;
+	readonly instanceId = 'fake-leader-window';
+
+	constructor(initial = true) {
+		this._isLeader = observableValue<boolean>(this, initial);
+		this.isLeader = this._isLeader;
+	}
+
+	set(value: boolean): void {
+		this._isLeader.set(value, undefined);
+	}
+
+	evaluateForTesting(): void { /* no-op */ }
+	dispose(): void { /* no-op */ }
+}
+
+interface RecordedRun {
+	readonly automationId: string;
+	readonly trigger: AutomationRunTrigger;
+}
+
+class RecordingRunner implements IAutomationRunner {
+	declare readonly _serviceBrand: undefined;
+
+	readonly runs: RecordedRun[] = [];
+
+	async runOnce(
+		automation: IAutomation,
+		trigger: AutomationRunTrigger,
+		_leaderWindowId: number,
+		_token?: CancellationToken,
+	): Promise<void> {
+		this.runs.push({ automationId: automation.id, trigger });
+	}
+}
+
+function hourly(): IAutomationSchedule {
+	return { interval: 'hourly', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 };
+}
+
+const T0 = new Date('2025-06-01T00:00:00Z');
+const T_PAST_DUE = new Date('2025-06-01T02:00:00Z');
+const T_TOMORROW = new Date('2025-06-02T04:00:00Z');
+
+suite('AutomationSchedulerCore', () => {
+
+	const teardown = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function setup() {
+		const storage = teardown.add(new InMemoryStorageService());
+		const log = new NullLogService();
+		const service = teardown.add(new AutomationService(storage, log, NullTelemetryService));
+		const runner = new RecordingRunner();
+		// Start as non-leader so individual tests can seed automations
+		// before triggering the leader's catch-up pass.
+		const leader = new FakeLeaderElection(false);
+
+		let now = T0;
+		service.setClockForTesting(() => now);
+		const core = teardown.add(new AutomationSchedulerCore(service, runner, storage, log, {
+			leaderElection: leader,
+			disableAutoTick: true,
+			now: () => now,
+		}));
+
+		return {
+			service, runner, leader, core,
+			setNow: (d: Date) => { now = d; },
+		};
+	}
+
+	test('does not run anything if there are no automations', async () => {
+		const { core, runner, leader } = setup();
+		leader.set(true);
+		await core.waitForPendingRuns();
+		await core.tickForTesting();
+		assert.deepStrictEqual(runner.runs, []);
+	});
+
+	test('on becoming leader, runs catch-up for due automations exactly once', async () => {
+		const { core, runner, service, leader, setNow } = setup();
+		setNow(T0);
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER });
+		// nextRunAt is T0+1h; advance the clock past it so the row is due.
+		setNow(T_PAST_DUE);
+		leader.set(true);
+		await core.waitForPendingRuns();
+
+		assert.strictEqual(runner.runs.length, 1);
+		assert.strictEqual(runner.runs[0].automationId, a.id);
+		assert.strictEqual(runner.runs[0].trigger, 'catch_up');
+	});
+
+	test('subsequent scheduled ticks use trigger=schedule', async () => {
+		const { core, runner, service, leader, setNow } = setup();
+		setNow(T0);
+		await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER });
+		setNow(T_PAST_DUE);
+		leader.set(true);
+		await core.waitForPendingRuns();
+		assert.strictEqual(runner.runs.length, 1, 'first run should be catch-up');
+
+		// Advance well past the freshly-computed next slot and tick again.
+		setNow(T_TOMORROW);
+		await core.tickForTesting();
+
+		assert.strictEqual(runner.runs.length, 2);
+		assert.strictEqual(runner.runs[1].trigger, 'schedule');
+	});
+
+	test('disabled automations are not dispatched', async () => {
+		const { core, runner, service, leader, setNow } = setup();
+		setNow(T0);
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER });
+		await service.updateAutomation(a.id, { enabled: false });
+		setNow(T_PAST_DUE);
+		leader.set(true);
+		await core.waitForPendingRuns();
+		await core.tickForTesting();
+		assert.deepStrictEqual(runner.runs, []);
+	});
+
+	test('advances nextRunAt so the same automation is not picked up again on the next tick', async () => {
+		const { core, runner, service, leader, setNow } = setup();
+		setNow(T0);
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER });
+		setNow(T_PAST_DUE);
+		leader.set(true);
+		await core.waitForPendingRuns();
+		assert.strictEqual(runner.runs.length, 1);
+
+		// Tick again immediately - nextRunAt was advanced, so the
+		// automation is no longer due at the same `now`.
+		await core.tickForTesting();
+		assert.strictEqual(runner.runs.length, 1);
+
+		const updated = service.getAutomation(a.id);
+		assert.ok(updated?.nextRunAt);
+		const next = Date.parse(updated!.nextRunAt!);
+		assert.ok(next > T_PAST_DUE.getTime(), 'nextRunAt should be after the tick that just fired');
+	});
+
+	test('does nothing while not leader', async () => {
+		const { core, runner, service, leader, setNow } = setup();
+		setNow(T0);
+		await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER });
+		setNow(T_PAST_DUE);
+		await core.waitForPendingRuns();
+		await core.tickForTesting();
+		assert.strictEqual(runner.runs.length, 0);
+
+		leader.set(true);
+		await core.waitForPendingRuns();
+		assert.strictEqual(runner.runs.length, 1);
+		assert.strictEqual(runner.runs[0].trigger, 'catch_up');
+	});
+
+	test('on becoming leader, fails any leftover pending/running runs as crash recovery', async () => {
+		const storage = teardown.add(new InMemoryStorageService());
+		const log = new NullLogService();
+		const firstService = teardown.add(new AutomationService(storage, log, NullTelemetryService));
+		firstService.setClockForTesting(() => T0);
+		const a = await firstService.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER });
+		const run = await firstService.recordRunStart(a.id, 'manual', 1);
+		firstService.dispose();
+
+		const service = teardown.add(new AutomationService(storage, log, NullTelemetryService));
+		service.setClockForTesting(() => T0);
+		const runner = new RecordingRunner();
+		const leader = new FakeLeaderElection(true);
+		const core = teardown.add(new AutomationSchedulerCore(service, runner, storage, log, {
+			leaderElection: leader,
+			disableAutoTick: true,
+			now: () => T0,
+		}));
+		await core.waitForPendingRuns();
+
+		const recovered = service.runs.get().find(r => r.id === run.id);
+		assert.strictEqual(recovered?.status, 'failed');
+		assert.strictEqual(recovered?.errorMessage, CRASH_RECOVERY_REASON);
+	});
+
+	test('losing then regaining leadership re-runs catch-up', async () => {
+		const { core, runner, service, leader, setNow } = setup();
+		setNow(T0);
+		await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER });
+		setNow(T_PAST_DUE);
+		leader.set(true);
+		await core.waitForPendingRuns();
+		assert.strictEqual(runner.runs[0].trigger, 'catch_up');
+
+		// Lose leadership.
+		leader.set(false);
+		await core.waitForPendingRuns();
+
+		// Make the row due again.
+		setNow(T_TOMORROW);
+
+		// Regain it - we should see another catch-up.
+		leader.set(true);
+		await core.waitForPendingRuns();
+		assert.strictEqual(runner.runs.length, 2);
+		assert.strictEqual(runner.runs[1].trigger, 'catch_up');
+	});
+
+	test('toggling the feature setting off then on does not crash-recover in-progress runs', async () => {
+		// Reproduce the bug where disabling the feature reset the
+		// per-leadership startup flag, causing a subsequent re-enable
+		// tick to call markStaleRunsFailed and incorrectly fail any
+		// runs that were active across the toggle.
+		const storage = teardown.add(new InMemoryStorageService());
+		const log = new NullLogService();
+		const service = teardown.add(new AutomationService(storage, log, NullTelemetryService));
+		service.setClockForTesting(() => T0);
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER });
+		const inFlight = await service.recordRunStart(a.id, 'schedule', 1);
+
+		const runner = new RecordingRunner();
+		const leader = new FakeLeaderElection(true);
+		let enabled = true;
+		const core = teardown.add(new AutomationSchedulerCore(service, runner, storage, log, {
+			leaderElection: leader,
+			disableAutoTick: true,
+			now: () => T0,
+			isFeatureEnabled: () => enabled,
+		}));
+		// First tick (as leader, feature ON) does startup recovery,
+		// which by design fails the in-flight row. Tests below only
+		// care that the *next* enable→disable→enable cycle does not
+		// repeat that recovery.
+		await core.waitForPendingRuns();
+		// Reset the row back to running so we can observe whether the
+		// toggle re-triggers recovery. Note: updateRun's patch
+		// semantics treat undefined fields as "no change", so we
+		// cannot clear errorMessage from here; assert only on status.
+		await service.updateRun(inFlight.id, { status: 'running' });
+
+		enabled = false;
+		await core.tickForTesting();
+		enabled = true;
+		await core.tickForTesting();
+
+		// The in-flight run must still be running — the feature toggle
+		// must NOT have re-triggered crash recovery.
+		const after = service.runs.get().find(r => r.id === inFlight.id);
+		assert.strictEqual(after?.status, 'running', 'feature-toggle off/on must not fail in-flight runs');
+	});
+
+	test('runOneWithTimeout: a hung run is cancelled, marked failed, and the next due automation still fires', async () => {
+		const storage = teardown.add(new InMemoryStorageService());
+		const log = new NullLogService();
+		const service = teardown.add(new AutomationService(storage, log, NullTelemetryService));
+
+		let now = T0;
+		service.setClockForTesting(() => now);
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER });
+		const b = await service.createAutomation({ name: 'B', prompt: 'q', schedule: hourly(), folderUri: FOLDER });
+
+		// A runner whose first invocation hangs until we release it,
+		// AND that creates a run row (mimicking the real runner) so
+		// the timeout path has something to mark as failed. Dispatch
+		// order is not guaranteed to match creation order, so the
+		// runner records which automation it hung on.
+		let hungAutomationId: string | undefined;
+		class HangingRunner implements IAutomationRunner {
+			declare readonly _serviceBrand: undefined;
+			readonly hung = new DeferredPromise<void>();
+			calls = 0;
+			cancelObserved = false;
+			async runOnce(automation: IAutomation, trigger: AutomationRunTrigger, leaderWindowId: number, token?: CancellationToken): Promise<void> {
+				this.calls++;
+				if (this.calls === 1) {
+					hungAutomationId = automation.id;
+					await service.recordRunStart(automation.id, trigger, leaderWindowId);
+					const listener = token?.onCancellationRequested(() => { this.cancelObserved = true; });
+					try {
+						await this.hung.p;
+					} finally {
+						listener?.dispose();
+					}
+					return;
+				}
+				await service.recordRunStart(automation.id, trigger, leaderWindowId);
+			}
+		}
+		const runner = new HangingRunner();
+		const leader = new FakeLeaderElection(false);
+
+		// Use a very short timeout so the test finishes quickly.
+		const core = teardown.add(new AutomationSchedulerCore(service, runner, storage, log, {
+			leaderElection: leader,
+			disableAutoTick: true,
+			now: () => now,
+			getRunTimeoutMs: () => 50,
+		}));
+
+		now = T_PAST_DUE;
+		leader.set(true);
+		await core.waitForPendingRuns();
+
+		// Both A and B should have been dispatched (the second was
+		// not blocked by the first's hang). The hung automation's run
+		// row must be failed with the timeout reason; the runner must
+		// have observed cancellation.
+		assert.strictEqual(runner.calls, 2, 'both A and B should have been dispatched');
+		assert.strictEqual(runner.cancelObserved, true, 'runner should observe cancellation on timeout');
+		assert.ok(hungAutomationId, 'runner should have recorded a hung automation id');
+		const otherId = hungAutomationId === a.id ? b.id : a.id;
+		const hungRun = service.runs.get().find(r => r.automationId === hungAutomationId);
+		assert.strictEqual(hungRun?.status, 'failed');
+		assert.ok(hungRun?.errorMessage?.startsWith(RUN_TIMEOUT_REASON_PREFIX), `expected timeout marker, got: ${hungRun?.errorMessage}`);
+		// The non-hung automation's row should NOT have been touched
+		// by the timeout path.
+		const otherRun = service.runs.get().find(r => r.automationId === otherId);
+		assert.notStrictEqual(otherRun?.status, 'failed');
+
+		// Cleanup: release the hung promise so the runner can exit.
+		runner.hung.complete();
+		await core.waitForPendingRuns();
+	});
+});

--- a/src/vs/sessions/contrib/automations/test/browser/automationService.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/automationService.test.ts
@@ -67,7 +67,7 @@ suite('AutomationService', () => {
 				name: 'X',
 				prompt: 'p',
 				schedule: dailySchedule(),
-				// Cast to bypass type check — simulates a runtime caller
+				// Cast to bypass type check. Simulates a runtime caller
 				// forgetting the required field.
 				folderUri: undefined as unknown as URI,
 			}),
@@ -187,7 +187,7 @@ suite('AutomationService', () => {
 		const { service } = createService();
 		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
 		const b = await service.createAutomation({ name: 'B', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
-		// Push 60 runs for a (cap is 50) and 5 for b — each automation's
+		// Push 60 runs for a (cap is 50) and 5 for b. Each automation's
 		// history should be bounded independently.
 		for (let i = 0; i < 60; i++) {
 			await service.recordRunStart(a.id, 'manual', 1);
@@ -261,7 +261,7 @@ suite('AutomationService', () => {
 		storage.store('chat.automations.ledger', JSON.stringify({ schemaVersion: 999, revision: 99, automations: [], runs: [] }), -1, 1);
 
 		// The onDidChangeValue refresh must NOT clear our observables to
-		// empty — we keep displaying what we last knew about.
+		// empty. We keep displaying what we last knew about.
 		assert.strictEqual(service.automations.get().length, 1);
 	});
 

--- a/src/vs/sessions/contrib/automations/test/browser/automationService.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/automationService.test.ts
@@ -1,0 +1,341 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { InMemoryStorageService } from '../../../../../platform/storage/common/storage.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { AutomationService } from '../../browser/automationService.js';
+import { IAutomationSchedule } from '../../../../../workbench/contrib/chat/common/automations/automation.js';
+
+const FOLDER = URI.parse('file:///workspace');
+
+function dailySchedule(hour = 9, minute = 0): IAutomationSchedule {
+	return { interval: 'daily', scheduleHour: hour, scheduleMinute: minute, scheduleDay: 0 };
+}
+
+suite('AutomationService', () => {
+
+	const teardown = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createService(storage?: InMemoryStorageService): { service: AutomationService; storage: InMemoryStorageService } {
+		const sharedStorage = teardown.add(storage ?? new InMemoryStorageService());
+		const service = teardown.add(new AutomationService(sharedStorage, new NullLogService(), NullTelemetryService));
+		return { service, storage: sharedStorage };
+	}
+
+	test('starts with an empty ledger when nothing is persisted', () => {
+		const { service } = createService();
+		assert.deepStrictEqual(service.automations.get(), []);
+		assert.deepStrictEqual(service.runs.get(), []);
+	});
+
+	test('createAutomation appends an entry and computes nextRunAt for non-manual schedules', async () => {
+		const { service } = createService();
+		const a = await service.createAutomation({
+			name: 'Daily review',
+			prompt: 'Summarize what changed',
+			schedule: dailySchedule(),
+			folderUri: FOLDER,
+		});
+		assert.strictEqual(service.automations.get().length, 1);
+		assert.strictEqual(service.automations.get()[0].id, a.id);
+		assert.ok(a.nextRunAt, 'daily schedule should produce a nextRunAt');
+		assert.strictEqual(a.enabled, true);
+	});
+
+	test('createAutomation with manual schedule leaves nextRunAt undefined', async () => {
+		const { service } = createService();
+		const a = await service.createAutomation({
+			name: 'Manual',
+			prompt: 'p',
+			schedule: { interval: 'manual', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 },
+			folderUri: FOLDER,
+		});
+		assert.strictEqual(a.nextRunAt, undefined);
+	});
+
+	test('createAutomation throws when folderUri is missing', async () => {
+		const { service } = createService();
+		await assert.rejects(
+			() => service.createAutomation({
+				name: 'X',
+				prompt: 'p',
+				schedule: dailySchedule(),
+				// Cast to bypass type check — simulates a runtime caller
+				// forgetting the required field.
+				folderUri: undefined as unknown as URI,
+			}),
+			/folderUri/,
+		);
+	});
+
+	test('updateAutomation recomputes nextRunAt when the schedule changes', async () => {
+		const { service } = createService();
+		const a = await service.createAutomation({
+			name: 'A',
+			prompt: 'p',
+			schedule: dailySchedule(9, 0),
+			folderUri: FOLDER,
+		});
+		const before = a.nextRunAt;
+		const b = await service.updateAutomation(a.id, { schedule: dailySchedule(10, 30) });
+		assert.notStrictEqual(b.nextRunAt, before);
+	});
+
+	test('updateAutomation keeps nextRunAt when only the name changes', async () => {
+		const { service } = createService();
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
+		const b = await service.updateAutomation(a.id, { name: 'B' });
+		assert.strictEqual(b.nextRunAt, a.nextRunAt);
+		assert.strictEqual(b.name, 'B');
+	});
+
+	test('updateAutomation can clear modelId/mode/permissionLevel by passing null but keeps folderUri', async () => {
+		const { service } = createService();
+		const a = await service.createAutomation({
+			name: 'A', prompt: 'p', schedule: dailySchedule(),
+			folderUri: FOLDER,
+			modelId: 'gpt-4',
+			mode: 'agent',
+			permissionLevel: 'autopilot',
+		});
+		const b = await service.updateAutomation(a.id, { modelId: null, mode: null, permissionLevel: null });
+		assert.strictEqual(b.modelId, undefined);
+		assert.strictEqual(b.mode, undefined);
+		assert.strictEqual(b.permissionLevel, undefined);
+		assert.strictEqual(b.folderUri.toString(), FOLDER.toString());
+	});
+
+	test('updateAutomation switches folder when a new folderUri is provided', async () => {
+		const { service } = createService();
+		const other = URI.parse('file:///other');
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
+		const b = await service.updateAutomation(a.id, { folderUri: other });
+		assert.strictEqual(b.folderUri.toString(), other.toString());
+	});
+
+	test('deleteAutomation removes the entry and orphan runs are dropped on reload', async () => {
+		const sharedStorage = teardown.add(new InMemoryStorageService());
+		const firstService = teardown.add(new AutomationService(sharedStorage, new NullLogService(), NullTelemetryService));
+		const a = await firstService.createAutomation({ name: 'A', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
+		await firstService.recordRunStart(a.id, 'manual', 1);
+		assert.strictEqual(firstService.runs.get().length, 1);
+		await firstService.deleteAutomation(a.id);
+		// Deleting commits a new ledger, which triggers a reload that
+		// drops the now-orphaned run so the ledger does not grow forever.
+		assert.deepStrictEqual(firstService.automations.get(), []);
+		assert.strictEqual(firstService.runs.get().length, 0);
+		firstService.dispose();
+
+		const secondService = teardown.add(new AutomationService(sharedStorage, new NullLogService(), NullTelemetryService));
+		assert.deepStrictEqual(secondService.automations.get(), []);
+		assert.strictEqual(secondService.runs.get().length, 0);
+	});
+
+	test('recordRunStart inserts a pending run; updateRun applies a patch', async () => {
+		const { service } = createService();
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
+		const run = await service.recordRunStart(a.id, 'schedule', 42);
+		assert.strictEqual(run.status, 'pending');
+		assert.strictEqual(run.leaderWindowId, 42);
+		const updated = await service.updateRun(run.id, { status: 'completed', sessionId: 'sess-1', completedAt: new Date().toISOString() });
+		assert.strictEqual(updated?.status, 'completed');
+		assert.strictEqual(updated?.sessionId, 'sess-1');
+	});
+
+	test('getActiveRunFor returns the first pending or running run for an automation', async () => {
+		const { service } = createService();
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
+		assert.strictEqual(service.getActiveRunFor(a.id), undefined);
+		const run = await service.recordRunStart(a.id, 'schedule', 1);
+		assert.strictEqual(service.getActiveRunFor(a.id)?.id, run.id);
+		await service.updateRun(run.id, { status: 'completed' });
+		assert.strictEqual(service.getActiveRunFor(a.id), undefined);
+	});
+
+	test('markStaleRunsFailed moves pending and running rows to failed', async () => {
+		const { service } = createService();
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
+		const r1 = await service.recordRunStart(a.id, 'schedule', 1);
+		const r2 = await service.recordRunStart(a.id, 'schedule', 1);
+		await service.updateRun(r1.id, { status: 'running' });
+		await service.markStaleRunsFailed('Interrupted');
+		const all = service.runs.get();
+		assert.deepStrictEqual(all.find(r => r.id === r1.id)?.status, 'failed');
+		assert.deepStrictEqual(all.find(r => r.id === r2.id)?.status, 'failed');
+		assert.strictEqual(all.find(r => r.id === r1.id)?.errorMessage, 'Interrupted');
+	});
+
+	test('runsFor filters to a single automation', async () => {
+		const { service } = createService();
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
+		const b = await service.createAutomation({ name: 'B', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
+		await service.recordRunStart(a.id, 'schedule', 1);
+		await service.recordRunStart(b.id, 'schedule', 1);
+		await service.recordRunStart(a.id, 'manual', 1);
+		assert.strictEqual(service.runsFor(a.id).get().length, 2);
+		assert.strictEqual(service.runsFor(b.id).get().length, 1);
+	});
+
+	test('recordRunStart caps retained runs per automation', async () => {
+		const { service } = createService();
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
+		const b = await service.createAutomation({ name: 'B', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
+		// Push 60 runs for a (cap is 50) and 5 for b — each automation's
+		// history should be bounded independently.
+		for (let i = 0; i < 60; i++) {
+			await service.recordRunStart(a.id, 'manual', 1);
+		}
+		for (let i = 0; i < 5; i++) {
+			await service.recordRunStart(b.id, 'manual', 1);
+		}
+		assert.strictEqual(service.runsFor(a.id).get().length, 50);
+		assert.strictEqual(service.runsFor(b.id).get().length, 5);
+	});
+
+	test('persists across service restarts via shared storage', async () => {
+		const sharedStorage = teardown.add(new InMemoryStorageService());
+		const firstService = teardown.add(new AutomationService(sharedStorage, new NullLogService(), NullTelemetryService));
+		const a = await firstService.createAutomation({ name: 'A', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
+		await firstService.recordRunStart(a.id, 'manual', 7);
+		firstService.dispose();
+
+		const secondService = teardown.add(new AutomationService(sharedStorage, new NullLogService(), NullTelemetryService));
+		assert.strictEqual(secondService.automations.get().length, 1);
+		assert.strictEqual(secondService.automations.get()[0].id, a.id);
+		assert.strictEqual(secondService.runs.get().length, 1);
+	});
+
+	test('two services on the same storage stay in sync via onDidChangeValue', async () => {
+		const sharedStorage = teardown.add(new InMemoryStorageService());
+		const windowA = teardown.add(new AutomationService(sharedStorage, new NullLogService(), NullTelemetryService));
+		const windowB = teardown.add(new AutomationService(sharedStorage, new NullLogService(), NullTelemetryService));
+
+		assert.deepStrictEqual(windowB.automations.get(), []);
+		const created = await windowA.createAutomation({ name: 'X', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
+
+		// In-memory storage fires onDidChangeValue synchronously, so windowB
+		// should already see the new automation.
+		assert.strictEqual(windowB.automations.get().length, 1);
+		assert.strictEqual(windowB.automations.get()[0].id, created.id);
+	});
+
+	test('reading a ledger with a future schema version freezes observables and refuses to write', async () => {
+		const storage = teardown.add(new InMemoryStorageService());
+		const futureLedger = JSON.stringify({ schemaVersion: 999, revision: 7, automations: [], runs: [] });
+		// StorageScope.APPLICATION is -1
+		storage.store('chat.automations.ledger', futureLedger, -1, 1);
+		const service = teardown.add(new AutomationService(storage, new NullLogService(), NullTelemetryService));
+
+		// Observables remain empty (no prior in-memory state to preserve)
+		// but the service is now in read-only mode.
+		assert.deepStrictEqual(service.automations.get(), []);
+		assert.deepStrictEqual(service.runs.get(), []);
+
+		// A subsequent mutation must be rejected (read-only mode) and must not
+		// destroy the on-disk newer ledger.
+		await assert.rejects(
+			() => service.createAutomation({ name: 'A', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER }),
+			/newer version/,
+		);
+
+		// In-memory state is also unchanged because the mutation was rejected
+		// before any commit.
+		assert.deepStrictEqual(service.automations.get(), []);
+
+		assert.strictEqual(storage.get('chat.automations.ledger', -1), futureLedger);
+	});
+
+	test('refreshFromStorage preserves in-memory state when storage flips to an unsupported schema', async () => {
+		const storage = teardown.add(new InMemoryStorageService());
+		const service = teardown.add(new AutomationService(storage, new NullLogService(), NullTelemetryService));
+		await service.createAutomation({ name: 'Local', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
+		assert.strictEqual(service.automations.get().length, 1);
+
+		storage.store('chat.automations.ledger', JSON.stringify({ schemaVersion: 999, revision: 99, automations: [], runs: [] }), -1, 1);
+
+		// The onDidChangeValue refresh must NOT clear our observables to
+		// empty — we keep displaying what we last knew about.
+		assert.strictEqual(service.automations.get().length, 1);
+	});
+
+	test('persist bumps the revision counter on every write', async () => {
+		const storage = teardown.add(new InMemoryStorageService());
+		const service = teardown.add(new AutomationService(storage, new NullLogService(), NullTelemetryService));
+		await service.createAutomation({ name: 'A', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
+		const rev1 = JSON.parse(storage.get('chat.automations.ledger', -1)!).revision;
+		await service.createAutomation({ name: 'B', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
+		const rev2 = JSON.parse(storage.get('chat.automations.ledger', -1)!).revision;
+		assert.strictEqual(typeof rev1, 'number');
+		assert.ok(rev2 > rev1, `expected ${rev2} > ${rev1}`);
+	});
+
+	test('persist absorbs a higher on-disk revision (concurrent-write detection)', async () => {
+		const storage = teardown.add(new InMemoryStorageService());
+		const service = teardown.add(new AutomationService(storage, new NullLogService(), NullTelemetryService));
+		await service.createAutomation({ name: 'A', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
+		const baseline = JSON.parse(storage.get('chat.automations.ledger', -1)!);
+		// Simulate another window having advanced the revision behind our
+		// back. The service must not write a stale-or-equal revision.
+		storage.store('chat.automations.ledger', JSON.stringify({ ...baseline, revision: 5000 }), -1, 1);
+		await service.createAutomation({ name: 'B', prompt: 'p', schedule: dailySchedule(), folderUri: FOLDER });
+		const after = JSON.parse(storage.get('chat.automations.ledger', -1)!);
+		assert.ok(after.revision > 5000, `expected revision > 5000, got ${after.revision}`);
+	});
+
+	test('reading a corrupt ledger leaves observables empty without throwing', () => {
+		const storage = teardown.add(new InMemoryStorageService());
+		storage.store('chat.automations.ledger', 'not json', -1, 1);
+		const service = teardown.add(new AutomationService(storage, new NullLogService(), NullTelemetryService));
+		assert.deepStrictEqual(service.automations.get(), []);
+	});
+
+	test('persisted automations without folderUri are dropped on load', () => {
+		const storage = teardown.add(new InMemoryStorageService());
+		const ledger = {
+			schemaVersion: 1,
+			automations: [
+				{ id: 'orphan', name: 'Old', prompt: 'p', schedule: { interval: 'daily', scheduleHour: 9, scheduleMinute: 0, scheduleDay: 0 }, enabled: true, createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' },
+				{ id: 'keep', name: 'Valid', prompt: 'p', schedule: { interval: 'daily', scheduleHour: 9, scheduleMinute: 0, scheduleDay: 0 }, folderUri: FOLDER.toJSON(), enabled: true, createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' },
+			],
+			runs: [
+				{ id: 'r-orphan', automationId: 'orphan', status: 'completed', trigger: 'manual', startedAt: '2024-01-01T00:00:00Z', leaderWindowId: 1 },
+				{ id: 'r-keep', automationId: 'keep', status: 'completed', trigger: 'manual', startedAt: '2024-01-01T00:00:00Z', leaderWindowId: 1 },
+			],
+		};
+		storage.store('chat.automations.ledger', JSON.stringify(ledger), -1, 1);
+		const service = teardown.add(new AutomationService(storage, new NullLogService(), NullTelemetryService));
+		assert.strictEqual(service.automations.get().length, 1);
+		assert.strictEqual(service.automations.get()[0].id, 'keep');
+		assert.strictEqual(service.runs.get().length, 1);
+		assert.strictEqual(service.runs.get()[0].id, 'r-keep');
+	});
+
+	test('round-trips a folderUri through persistence', async () => {
+		const sharedStorage = teardown.add(new InMemoryStorageService());
+		const firstService = teardown.add(new AutomationService(sharedStorage, new NullLogService(), NullTelemetryService));
+		const uri = URI.parse('file:///workspace/project');
+		await firstService.createAutomation({ name: 'A', prompt: 'p', schedule: dailySchedule(), folderUri: uri });
+
+		const secondService = teardown.add(new AutomationService(sharedStorage, new NullLogService(), NullTelemetryService));
+		const reloaded = secondService.automations.get()[0];
+		assert.strictEqual(reloaded.folderUri.toString(), uri.toString());
+	});
+
+	test('disposal does not interfere with later in-store reads', () => {
+		// Just verifies the no-leaked-disposables invariant indirectly: create
+		// a service and let teardown clean it up. Failure surfaces as a
+		// leaked-disposable assertion at suite teardown.
+		const store = new DisposableStore();
+		const storage = store.add(new InMemoryStorageService());
+		const service = store.add(new AutomationService(storage, new NullLogService(), NullTelemetryService));
+		assert.deepStrictEqual(service.automations.get(), []);
+		store.dispose();
+	});
+});

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -482,6 +482,7 @@ import './contrib/chatDebug/browser/chatDebug.contribution.js';
 import './contrib/workspace/browser/workspace.contribution.js';
 import './contrib/aquarium/browser/aquarium.contribution.js';
 import './contrib/policyBlocked/browser/policyBlocked.contribution.js';
+import './contrib/automations/browser/automations.contribution.js';
 
 // Onboarding: the engine + spotlight presentation (from the workbench layer) and
 // the Agents window scenario data.

--- a/src/vs/workbench/contrib/chat/common/automations/automation.ts
+++ b/src/vs/workbench/contrib/chat/common/automations/automation.ts
@@ -1,0 +1,106 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../../../base/common/uri.js';
+
+/**
+ * How often an automation runs. `hourly` fires every hour from creation/update;
+ * `daily`/`weekly` fire at the configured local-time hour/minute (and day-of-week).
+ */
+export type AutomationInterval = 'manual' | 'hourly' | 'daily' | 'weekly';
+
+/**
+ * Describes the cadence at which an automation should fire.
+ *
+ * Times are stored in local-time wall-clock values. The scheduler converts
+ * them to UTC when computing concrete run instants so DST transitions are
+ * handled correctly.
+ */
+export interface IAutomationSchedule {
+	readonly interval: AutomationInterval;
+
+	/** Hour-of-day, 0-23. Ignored for `manual` and `hourly`. */
+	readonly scheduleHour: number;
+
+	/** Minute-of-hour, 0-59. Ignored for `manual` and `hourly`. */
+	readonly scheduleMinute: number;
+
+	/** Day-of-week, 0 (Sunday) through 6 (Saturday). Only used for `weekly`. */
+	readonly scheduleDay: number;
+}
+
+/**
+ * A single scheduled automation. Identity is the immutable `id`; everything
+ * else may be edited by the user.
+ */
+export interface IAutomation {
+	readonly id: string;
+	readonly name: string;
+	readonly prompt: string;
+	readonly schedule: IAutomationSchedule;
+
+	/** Workspace folder for the spawned session. Required. */
+	readonly folderUri: URI;
+
+	/**
+	 * Sessions provider for the scheduled run (e.g. `local-agent-host`). Omitted
+	 * on automations predating the picker; the runner then falls back to the
+	 * workspace default provider.
+	 */
+	readonly providerId?: string;
+
+	/** Session type to create within {@link providerId}, captured alongside it. */
+	readonly sessionTypeId?: string;
+
+	/** Optional language model identifier to seed the new session with. */
+	readonly modelId?: string;
+
+	/** Optional chat mode (`agent`/`ask`/`edit`). Defaults to provider's default; custom modes unsupported. */
+	readonly mode?: string;
+
+	/** Optional permission level (`default`/`autoApprove`/`autopilot`). Overrides only for scheduled runs; defaults to provider's default. */
+	readonly permissionLevel?: string;
+
+	/** Optional worktree isolation mode (`worktree` or `workspace`). */
+	readonly isolationMode?: string;
+
+	/** Optional git branch for isolated runs. */
+	readonly branch?: string;
+
+	readonly enabled: boolean;
+
+	/** ISO-8601 UTC timestamp. */
+	readonly createdAt: string;
+	readonly updatedAt: string;
+	readonly lastRunAt?: string;
+
+	/** ISO-8601 UTC timestamp; `undefined` when interval is `manual`. */
+	readonly nextRunAt?: string;
+}
+
+export type AutomationRunStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+/**
+ * What kicked off a run. `catch_up` fires once at startup for a due-time that
+ * passed while VS Code was closed.
+ */
+export type AutomationRunTrigger = 'schedule' | 'catch_up' | 'manual';
+
+export interface IAutomationRun {
+	readonly id: string;
+	readonly automationId: string;
+	readonly status: AutomationRunStatus;
+	readonly trigger: AutomationRunTrigger;
+
+	/** Session identifier assigned by ISessionsManagementService, if any. */
+	readonly sessionId?: string;
+
+	readonly startedAt: string;
+	readonly completedAt?: string;
+	readonly errorMessage?: string;
+
+	/** Window that claimed this run; the leader-election guard uses it to avoid duplicate execution across windows. */
+	readonly leaderWindowId: number;
+}

--- a/src/vs/workbench/contrib/chat/common/automations/automationDialogService.ts
+++ b/src/vs/workbench/contrib/chat/common/automations/automationDialogService.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IAutomation } from './automation.js';
+import { ICreateAutomationOptions, IUpdateAutomationOptions } from './automationService.js';
+
+export interface IShowAutomationDialogOptions {
+	readonly existing?: IAutomation;
+}
+
+export type IAutomationDialogResult =
+	| { readonly kind: 'create'; readonly value: ICreateAutomationOptions }
+	| { readonly kind: 'update'; readonly id: string; readonly value: IUpdateAutomationOptions };
+
+export const IAutomationDialogService = createDecorator<IAutomationDialogService>('automationDialogService');
+
+/**
+ * Bridges the workbench Automations UI (list widget) to the Sessions-layer
+ * dialog implementation without a cross-layer import: the widget depends only
+ * on this interface, while {@link AutomationDialogService} (sessions) provides it.
+ */
+export interface IAutomationDialogService {
+	readonly _serviceBrand: undefined;
+	showAutomationDialog(options: IShowAutomationDialogOptions): Promise<IAutomationDialogResult | undefined>;
+}

--- a/src/vs/workbench/contrib/chat/common/automations/automationRunner.ts
+++ b/src/vs/workbench/contrib/chat/common/automations/automationRunner.ts
@@ -19,7 +19,7 @@ export interface IAutomationRunner {
 
 	/**
 	 * Runs `automation` once (skips if another run for it is already in flight).
-	 * Never throws — failures are recorded on the run row in {@link IAutomationService}.
+	 * Never throws. Failures are recorded on the run row in {@link IAutomationService}.
 	 */
 	runOnce(
 		automation: IAutomation,

--- a/src/vs/workbench/contrib/chat/common/automations/automationRunner.ts
+++ b/src/vs/workbench/contrib/chat/common/automations/automationRunner.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
+import { AutomationRunTrigger, IAutomation } from './automation.js';
+
+export const IAutomationRunner = createDecorator<IAutomationRunner>('automationRunner');
+
+/**
+ * Runs a single automation: claim the per-automation slot, record the run,
+ * drive the chat session, report success/failure to {@link IAutomationService}.
+ * Implemented in the sessions layer via `ISessionsManagementService`.
+ */
+export interface IAutomationRunner {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Runs `automation` once (skips if another run for it is already in flight).
+	 * Never throws — failures are recorded on the run row in {@link IAutomationService}.
+	 */
+	runOnce(
+		automation: IAutomation,
+		trigger: AutomationRunTrigger,
+		leaderWindowId: number,
+		token?: CancellationToken,
+	): Promise<void>;
+}

--- a/src/vs/workbench/contrib/chat/common/automations/automationService.ts
+++ b/src/vs/workbench/contrib/chat/common/automations/automationService.ts
@@ -59,7 +59,7 @@ export interface IUpdateAutomationRunOptions {
 
 /**
  * Persistent store for automations and their run history, and the single
- * mutation point — scheduler, runner, and UI all flow through it to keep
+ * mutation point. Scheduler, runner, and UI all flow through it to keep
  * cross-window propagation, persistence, and observables consistent.
  */
 export interface IAutomationService {

--- a/src/vs/workbench/contrib/chat/common/automations/automationService.ts
+++ b/src/vs/workbench/contrib/chat/common/automations/automationService.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IObservable } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IAutomation, IAutomationRun, AutomationRunTrigger, IAutomationSchedule } from './automation.js';
+
+export const IAutomationService = createDecorator<IAutomationService>('automationService');
+
+/**
+ * Input for `createAutomation`. The service fills in `id`, timestamps, and
+ * `nextRunAt`. `folderUri` is required.
+ */
+export interface ICreateAutomationOptions {
+	readonly name: string;
+	readonly prompt: string;
+	readonly schedule: IAutomationSchedule;
+	readonly folderUri: URI;
+	readonly providerId?: string;
+	readonly sessionTypeId?: string;
+	readonly modelId?: string;
+	readonly mode?: string;
+	readonly permissionLevel?: string;
+	readonly isolationMode?: string;
+	readonly branch?: string;
+	readonly enabled?: boolean;
+}
+
+/**
+ * Patch for `updateAutomation`. Absent fields are unchanged. Pass `null` for
+ * `providerId`/`sessionTypeId`/`modelId`/`mode`/`permissionLevel` to clear them;
+ * `folderUri` cannot be cleared.
+ */
+export interface IUpdateAutomationOptions {
+	readonly name?: string;
+	readonly prompt?: string;
+	readonly schedule?: IAutomationSchedule;
+	readonly folderUri?: URI;
+	readonly providerId?: string | null;
+	readonly sessionTypeId?: string | null;
+	readonly modelId?: string | null;
+	readonly mode?: string | null;
+	readonly permissionLevel?: string | null;
+	readonly isolationMode?: string | null;
+	readonly branch?: string | null;
+	readonly enabled?: boolean;
+}
+
+/** Patch for `updateRun`. Absent fields are unchanged. */
+export interface IUpdateAutomationRunOptions {
+	readonly status?: IAutomationRun['status'];
+	readonly sessionId?: string;
+	readonly completedAt?: string;
+	readonly errorMessage?: string;
+}
+
+/**
+ * Persistent store for automations and their run history, and the single
+ * mutation point — scheduler, runner, and UI all flow through it to keep
+ * cross-window propagation, persistence, and observables consistent.
+ */
+export interface IAutomationService {
+	readonly _serviceBrand: undefined;
+
+	/** All defined automations, newest first. */
+	readonly automations: IObservable<readonly IAutomation[]>;
+
+	/** All recorded runs across all automations, newest first. */
+	readonly runs: IObservable<readonly IAutomationRun[]>;
+
+	/** Snapshot accessor (no observable dependency). */
+	getAutomation(id: string): IAutomation | undefined;
+
+	/** Runs for a single automation, newest first. */
+	runsFor(automationId: string): IObservable<readonly IAutomationRun[]>;
+
+	createAutomation(options: ICreateAutomationOptions): Promise<IAutomation>;
+	updateAutomation(id: string, patch: IUpdateAutomationOptions): Promise<IAutomation>;
+	deleteAutomation(id: string): Promise<void>;
+
+	/** Records a new run as `pending`. Throws if the automation does not exist. */
+	recordRunStart(automationId: string, trigger: AutomationRunTrigger, leaderWindowId: number): Promise<IAutomationRun>;
+
+	/** Applies a patch to a run; returns the updated run or `undefined` if not found. */
+	updateRun(runId: string, patch: IUpdateAutomationRunOptions): Promise<IAutomationRun | undefined>;
+
+	/** Most recent `pending`/`running` run for an automation, or `undefined`. Backs the runner's per-automation claim. */
+	getActiveRunFor(automationId: string): IAutomationRun | undefined;
+
+	/** Marks all stuck (`pending`/`running`) runs failed. Called on startup to recover from crashes. */
+	markStaleRunsFailed(reason: string): Promise<void>;
+
+	/**
+	 * Sets `lastRunAt = now` and recomputes `nextRunAt`. Called right after
+	 * dispatch so the same automation isn't picked up twice on the next tick.
+	 */
+	advanceNextRunAt(id: string, now?: Date): Promise<IAutomation | undefined>;
+}

--- a/src/vs/workbench/contrib/chat/common/automations/automationSessionTypes.ts
+++ b/src/vs/workbench/contrib/chat/common/automations/automationSessionTypes.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../../../base/common/uri.js';
+import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
+
+/**
+ * A (provider, session-type) choice an automation can target. Captured at
+ * creation and reused on every run, independent of the workspace default.
+ */
+export interface IAutomationSessionTypeChoice {
+	readonly providerId: string;
+	readonly sessionTypeId: string;
+	/** Human-readable label suitable for display in a dropdown. */
+	readonly label: string;
+	/** Optional sub-label distinguishing duplicates (e.g. a remote host). */
+	readonly description?: string;
+}
+
+export const IAutomationSessionTypeProvider = createDecorator<IAutomationSessionTypeProvider>('automationSessionTypeProvider');
+
+/**
+ * Bridges the workbench-side Automations UI to whichever layer knows which
+ * session types exist (the Sessions layer wraps
+ * `ISessionsManagementService.getSessionTypesForFolder`).
+ */
+export interface IAutomationSessionTypeProvider {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Lists the session types the user can pick from for a given folder.
+	 * Returns an empty array when nothing is registered or no provider
+	 * can serve the folder.
+	 */
+	getSessionTypesForFolder(folderUri: URI): readonly IAutomationSessionTypeChoice[];
+}

--- a/src/vs/workbench/contrib/chat/common/automations/automationTelemetry.ts
+++ b/src/vs/workbench/contrib/chat/common/automations/automationTelemetry.ts
@@ -12,7 +12,7 @@ import { AutomationInterval, AutomationRunTrigger, IAutomation } from './automat
  * Events capture cadence (`intervalKind`, `trigger`) and low-cardinality
  * enum values (`permissionLevel`, `isolationMode`) only.
  * Prompt text, automation names, folder URIs, and model identifiers are
- * never sent — they are user content / workspace-specific information.
+ * never sent. They are user content / workspace-specific information.
  */
 
 type AutomationCreateEvent = {

--- a/src/vs/workbench/contrib/chat/common/automations/automationTelemetry.ts
+++ b/src/vs/workbench/contrib/chat/common/automations/automationTelemetry.ts
@@ -1,0 +1,172 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { AutomationInterval, AutomationRunTrigger, IAutomation } from './automation.js';
+
+/**
+ * GDPR-classified telemetry events for the Automations feature.
+ *
+ * Events are intentionally coarse: cadence (`intervalKind`, `trigger`) and
+ * presence flags (`hasModelId`, `hasMode`, `hasPermissionLevel`) only.
+ * Prompt text, automation names, folder URIs, and model identifiers are
+ * never sent — they are user content / workspace-specific information.
+ */
+
+type AutomationCreateEvent = {
+	intervalKind: AutomationInterval;
+	hasProviderId: boolean;
+	hasSessionTypeId: boolean;
+	hasModelId: boolean;
+	hasMode: boolean;
+	hasPermissionLevel: boolean;
+	enabled: boolean;
+};
+
+type AutomationCreateClassification = {
+	intervalKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Cadence the user picked (manual/hourly/daily/weekly).' };
+	hasProviderId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether a sessions provider was captured.' };
+	hasSessionTypeId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether a session type was captured.' };
+	hasModelId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether a language model id was captured.' };
+	hasMode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether a chat mode was captured.' };
+	hasPermissionLevel: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether a permission level was captured.' };
+	enabled: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the automation was created in the enabled state.' };
+	owner: 'benvillalobos';
+	comment: 'Tracks Automations feature adoption and which optional fields users configure.';
+};
+
+export function publishAutomationCreated(telemetryService: ITelemetryService, automation: IAutomation): void {
+	telemetryService.publicLog2<AutomationCreateEvent, AutomationCreateClassification>('automation.create', {
+		intervalKind: automation.schedule.interval,
+		hasProviderId: !!automation.providerId,
+		hasSessionTypeId: !!automation.sessionTypeId,
+		hasModelId: !!automation.modelId,
+		hasMode: !!automation.mode,
+		hasPermissionLevel: !!automation.permissionLevel,
+		enabled: automation.enabled,
+	});
+}
+
+type AutomationUpdateEvent = {
+	intervalKind: AutomationInterval;
+	scheduleChanged: boolean;
+	enabledChanged: boolean;
+	enabled: boolean;
+};
+
+type AutomationUpdateClassification = {
+	intervalKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Cadence after the update.' };
+	scheduleChanged: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the schedule itself changed (interval/time/day).' };
+	enabledChanged: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the enabled flag flipped.' };
+	enabled: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Enabled state after the update.' };
+	owner: 'benvillalobos';
+	comment: 'Tracks how often users edit Automations and which fields they touch.';
+};
+
+export function publishAutomationUpdated(telemetryService: ITelemetryService, before: IAutomation, after: IAutomation): void {
+	telemetryService.publicLog2<AutomationUpdateEvent, AutomationUpdateClassification>('automation.update', {
+		intervalKind: after.schedule.interval,
+		scheduleChanged: before.schedule.interval !== after.schedule.interval
+			|| before.schedule.scheduleHour !== after.schedule.scheduleHour
+			|| before.schedule.scheduleMinute !== after.schedule.scheduleMinute
+			|| before.schedule.scheduleDay !== after.schedule.scheduleDay,
+		enabledChanged: before.enabled !== after.enabled,
+		enabled: after.enabled,
+	});
+}
+
+type AutomationDeleteEvent = {
+	intervalKind: AutomationInterval;
+};
+
+type AutomationDeleteClassification = {
+	intervalKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Cadence of the deleted automation.' };
+	owner: 'benvillalobos';
+	comment: 'Tracks Automations deletion.';
+};
+
+export function publishAutomationDeleted(telemetryService: ITelemetryService, automation: IAutomation): void {
+	telemetryService.publicLog2<AutomationDeleteEvent, AutomationDeleteClassification>('automation.delete', {
+		intervalKind: automation.schedule.interval,
+	});
+}
+
+type AutomationRunEvent = {
+	trigger: AutomationRunTrigger;
+	intervalKind: AutomationInterval;
+	success: boolean;
+	durationMs: number;
+	hasModelId: boolean;
+	hasMode: boolean;
+	hasPermissionLevel: boolean;
+};
+
+type AutomationRunClassification = {
+	trigger: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'What kicked off the run (schedule/catch_up/manual).' };
+	intervalKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Cadence of the automation that ran.' };
+	success: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the run completed without error.' };
+	durationMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Wall-clock duration of the run kickoff (recordRunStart through completed/failed).' };
+	hasModelId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether a language model id was applied to the run.' };
+	hasMode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether a chat mode was applied to the run.' };
+	hasPermissionLevel: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether a permission level was applied to the run.' };
+	owner: 'benvillalobos';
+	comment: 'Tracks Automations run outcomes and timing.';
+};
+
+export function publishAutomationRun(telemetryService: ITelemetryService, args: {
+	trigger: AutomationRunTrigger;
+	automation: IAutomation;
+	success: boolean;
+	durationMs: number;
+}): void {
+	telemetryService.publicLog2<AutomationRunEvent, AutomationRunClassification>('automation.run', {
+		trigger: args.trigger,
+		intervalKind: args.automation.schedule.interval,
+		success: args.success,
+		durationMs: Math.max(0, Math.round(args.durationMs)),
+		hasModelId: !!args.automation.modelId,
+		hasMode: !!args.automation.mode,
+		hasPermissionLevel: !!args.automation.permissionLevel,
+	});
+}
+
+type AutomationRunErrorEvent = {
+	trigger: AutomationRunTrigger;
+	intervalKind: AutomationInterval;
+	// TODO: classify error types (e.g. 'network', 'auth', 'timeout') instead of raw messages
+};
+
+type AutomationRunErrorClassification = {
+	trigger: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'What kicked off the failed run (schedule/catch_up/manual).' };
+	intervalKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Cadence of the automation that failed.' };
+	owner: 'benvillalobos';
+	comment: 'Tracks Automations run failures for reliability.';
+};
+
+export function publishAutomationRunError(telemetryService: ITelemetryService, args: {
+	trigger: AutomationRunTrigger;
+	automation: IAutomation;
+}): void {
+	telemetryService.publicLogError2<AutomationRunErrorEvent, AutomationRunErrorClassification>('automation.runError', {
+		trigger: args.trigger,
+		intervalKind: args.automation.schedule.interval,
+	});
+}
+
+type AutomationToggleEvent = {
+	enabled: boolean;
+};
+
+type AutomationToggleClassification = {
+	enabled: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the user enabled (1) or disabled (0) the Automations feature.' };
+	owner: 'benvillalobos';
+	comment: 'Tracks adoption of the Automations feature toggle.';
+};
+
+export function publishAutomationToggled(telemetryService: ITelemetryService, enabled: boolean): void {
+	telemetryService.publicLog2<AutomationToggleEvent, AutomationToggleClassification>('automation.toggle', {
+		enabled,
+	});
+}

--- a/src/vs/workbench/contrib/chat/common/automations/automationTelemetry.ts
+++ b/src/vs/workbench/contrib/chat/common/automations/automationTelemetry.ts
@@ -9,42 +9,33 @@ import { AutomationInterval, AutomationRunTrigger, IAutomation } from './automat
 /**
  * GDPR-classified telemetry events for the Automations feature.
  *
- * Events are intentionally coarse: cadence (`intervalKind`, `trigger`) and
- * presence flags (`hasModelId`, `hasMode`, `hasPermissionLevel`) only.
+ * Events capture cadence (`intervalKind`, `trigger`) and low-cardinality
+ * enum values (`permissionLevel`, `isolationMode`) only.
  * Prompt text, automation names, folder URIs, and model identifiers are
  * never sent — they are user content / workspace-specific information.
  */
 
 type AutomationCreateEvent = {
 	intervalKind: AutomationInterval;
-	hasProviderId: boolean;
-	hasSessionTypeId: boolean;
-	hasModelId: boolean;
-	hasMode: boolean;
-	hasPermissionLevel: boolean;
+	permissionLevel: string;
+	isolationMode: string;
 	enabled: boolean;
 };
 
 type AutomationCreateClassification = {
 	intervalKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Cadence the user picked (manual/hourly/daily/weekly).' };
-	hasProviderId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether a sessions provider was captured.' };
-	hasSessionTypeId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether a session type was captured.' };
-	hasModelId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether a language model id was captured.' };
-	hasMode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether a chat mode was captured.' };
-	hasPermissionLevel: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether a permission level was captured.' };
+	permissionLevel: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Permission level chosen (default/autoApprove/autopilot).' };
+	isolationMode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode chosen (workspace/worktree).' };
 	enabled: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the automation was created in the enabled state.' };
 	owner: 'benvillalobos';
-	comment: 'Tracks Automations feature adoption and which optional fields users configure.';
+	comment: 'Tracks Automations feature adoption and which options users configure.';
 };
 
 export function publishAutomationCreated(telemetryService: ITelemetryService, automation: IAutomation): void {
 	telemetryService.publicLog2<AutomationCreateEvent, AutomationCreateClassification>('automation.create', {
 		intervalKind: automation.schedule.interval,
-		hasProviderId: !!automation.providerId,
-		hasSessionTypeId: !!automation.sessionTypeId,
-		hasModelId: !!automation.modelId,
-		hasMode: !!automation.mode,
-		hasPermissionLevel: !!automation.permissionLevel,
+		permissionLevel: automation.permissionLevel ?? '',
+		isolationMode: automation.isolationMode ?? '',
 		enabled: automation.enabled,
 	});
 }
@@ -98,9 +89,8 @@ type AutomationRunEvent = {
 	intervalKind: AutomationInterval;
 	success: boolean;
 	durationMs: number;
-	hasModelId: boolean;
-	hasMode: boolean;
-	hasPermissionLevel: boolean;
+	permissionLevel: string;
+	isolationMode: string;
 };
 
 type AutomationRunClassification = {
@@ -108,9 +98,8 @@ type AutomationRunClassification = {
 	intervalKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Cadence of the automation that ran.' };
 	success: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the run completed without error.' };
 	durationMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Wall-clock duration of the run kickoff (recordRunStart through completed/failed).' };
-	hasModelId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether a language model id was applied to the run.' };
-	hasMode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether a chat mode was applied to the run.' };
-	hasPermissionLevel: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether a permission level was applied to the run.' };
+	permissionLevel: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Permission level applied to the run (default/autoApprove/autopilot).' };
+	isolationMode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Isolation mode applied to the run (workspace/worktree).' };
 	owner: 'benvillalobos';
 	comment: 'Tracks Automations run outcomes and timing.';
 };
@@ -126,9 +115,8 @@ export function publishAutomationRun(telemetryService: ITelemetryService, args: 
 		intervalKind: args.automation.schedule.interval,
 		success: args.success,
 		durationMs: Math.max(0, Math.round(args.durationMs)),
-		hasModelId: !!args.automation.modelId,
-		hasMode: !!args.automation.mode,
-		hasPermissionLevel: !!args.automation.permissionLevel,
+		permissionLevel: args.automation.permissionLevel ?? '',
+		isolationMode: args.automation.isolationMode ?? '',
 	});
 }
 

--- a/src/vs/workbench/contrib/chat/common/automations/automationsEnabled.ts
+++ b/src/vs/workbench/contrib/chat/common/automations/automationsEnabled.ts
@@ -6,7 +6,7 @@
 import { RawContextKey } from '../../../../../platform/contextkey/common/contextkey.js';
 
 /**
- * Gates the entire Automations feature — sidebar entry, editor section,
+ * Gates the entire Automations feature: sidebar entry, editor section,
  * session composer option, and scheduled execution. Default `false`.
  */
 export const CHAT_AUTOMATIONS_ENABLED_SETTING = 'chat.automations.enabled';

--- a/src/vs/workbench/contrib/chat/common/automations/automationsEnabled.ts
+++ b/src/vs/workbench/contrib/chat/common/automations/automationsEnabled.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { RawContextKey } from '../../../../../platform/contextkey/common/contextkey.js';
+
+/**
+ * Gates the entire Automations feature — sidebar entry, editor section,
+ * session composer option, and scheduled execution. Default `false`.
+ */
+export const CHAT_AUTOMATIONS_ENABLED_SETTING = 'chat.automations.enabled';
+
+/** Per-run timeout in minutes. Hung runs are cancelled and marked failed so they don't block the dispatch chain. */
+export const CHAT_AUTOMATIONS_RUN_TIMEOUT_MINUTES_SETTING = 'chat.automations.runTimeoutMinutes';
+
+/** Default for {@link CHAT_AUTOMATIONS_RUN_TIMEOUT_MINUTES_SETTING}. */
+export const DEFAULT_AUTOMATIONS_RUN_TIMEOUT_MINUTES = 30;
+
+/** Context key mirroring {@link CHAT_AUTOMATIONS_ENABLED_SETTING}, for `when` clauses on menus/commands. */
+export const ChatAutomationsEnabledContext = new RawContextKey<boolean>('chatAutomationsEnabled', false, {
+	type: 'boolean',
+	description: 'True when the chat Automations feature is enabled via the chat.automations.enabled setting.',
+});

--- a/src/vs/workbench/contrib/chat/common/automations/schedule.ts
+++ b/src/vs/workbench/contrib/chat/common/automations/schedule.ts
@@ -1,0 +1,95 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IAutomationSchedule } from './automation.js';
+import { localize } from '../../../../../nls.js';
+
+export const DAYS_OF_WEEK: readonly string[] = [
+	localize('automation.day.sun', "Sunday"),
+	localize('automation.day.mon', "Monday"),
+	localize('automation.day.tue', "Tuesday"),
+	localize('automation.day.wed', "Wednesday"),
+	localize('automation.day.thu', "Thursday"),
+	localize('automation.day.fri', "Friday"),
+	localize('automation.day.sat', "Saturday"),
+];
+
+/**
+ * Computes the next fire time for a schedule. Daily/weekly times are
+ * local wall-clock (not UTC) so DST transitions don't shift them.
+ * Day advances use `Date` constructor overflow, not milliseconds, to
+ * avoid skipping spring-forward days. Returns `undefined` for `manual`.
+ */
+export function computeNextRunAt(schedule: IAutomationSchedule, now: Date): Date | undefined {
+	const { interval, scheduleHour, scheduleMinute, scheduleDay } = schedule;
+
+	switch (interval) {
+		case 'manual':
+			return undefined;
+
+		case 'hourly':
+			return new Date(now.getTime() + 60 * 60 * 1000);
+
+		case 'daily': {
+			if (!isValidHourMinute(scheduleHour, scheduleMinute)) {
+				return undefined;
+			}
+			const today = buildLocalDate(now.getFullYear(), now.getMonth(), now.getDate(), scheduleHour, scheduleMinute);
+			if (today.getTime() > now.getTime()) {
+				return today;
+			}
+			// Advance by calendar date, not milliseconds, so spring-forward
+			// days are not skipped (a `+ 24 * 60 * 60 * 1000` jump on the
+			// DST day can land on the day after the target).
+			return buildLocalDate(now.getFullYear(), now.getMonth(), now.getDate() + 1, scheduleHour, scheduleMinute);
+		}
+
+		case 'weekly': {
+			if (!isValidHourMinute(scheduleHour, scheduleMinute)) {
+				return undefined;
+			}
+			if (!Number.isInteger(scheduleDay) || scheduleDay < 0 || scheduleDay > 6) {
+				return undefined;
+			}
+			const currentDay = now.getDay();
+			let daysAhead = scheduleDay - currentDay;
+			const sameDayButPassed = daysAhead === 0 && (now.getHours() > scheduleHour ||
+				(now.getHours() === scheduleHour && now.getMinutes() >= scheduleMinute));
+			if (daysAhead < 0 || sameDayButPassed) {
+				daysAhead += 7;
+			}
+			return buildLocalDate(now.getFullYear(), now.getMonth(), now.getDate() + daysAhead, scheduleHour, scheduleMinute);
+		}
+
+		default:
+			return undefined;
+	}
+}
+
+function isValidHourMinute(hour: number, minute: number): boolean {
+	return Number.isInteger(hour) && hour >= 0 && hour <= 23
+		&& Number.isInteger(minute) && minute >= 0 && minute <= 59;
+}
+
+/**
+ * Builds a Date for a specific local wall-clock time. If the requested time
+ * falls in a DST spring-forward gap (e.g. 2:30 AM on a day that jumps from
+ * 2:00 to 3:00), shifts forward in 1-hour increments until a valid time is
+ * found. Ambiguous fall-back times are resolved to the first occurrence,
+ * matching JavaScript's default behavior.
+ */
+function buildLocalDate(year: number, monthIndex: number, day: number, hour: number, minute: number): Date {
+	const candidate = new Date(year, monthIndex, day, hour, minute, 0, 0);
+	if (candidate.getHours() === hour && candidate.getMinutes() === minute) {
+		return candidate;
+	}
+	for (let shift = 1; shift <= 3; shift++) {
+		const shifted = new Date(year, monthIndex, day, hour + shift, minute, 0, 0);
+		if (shifted.getHours() === (hour + shift) % 24 && shifted.getMinutes() === minute) {
+			return shifted;
+		}
+	}
+	return candidate;
+}

--- a/src/vs/workbench/contrib/chat/test/common/automations/schedule.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/automations/schedule.test.ts
@@ -109,7 +109,7 @@ suite('Automations - computeNextRunAt', () => {
 		const now = localDate(2026, 3, 7, 23, 30); // Saturday March 7, 23:30
 		const next = computeNextRunAt(schedule, now);
 		assert.ok(next);
-		// Next run must be Sunday March 8, not Monday March 9. `buildLocalDate`
+		// Next run must be Sunday March 8, not Monday March 9. `localDate`
 		// may shift 02:30 forward into the DST gap on actual DST hosts, but
 		// the *date* must land on the 8th, never the 9th.
 		assert.strictEqual(next.getDate(), 8, `expected next.getDate()===8, got ${next.toString()}`);

--- a/src/vs/workbench/contrib/chat/test/common/automations/schedule.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/automations/schedule.test.ts
@@ -1,0 +1,134 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { IAutomationSchedule } from '../../../common/automations/automation.js';
+import { computeNextRunAt } from '../../../common/automations/schedule.js';
+
+/**
+ * Builds a local-time `Date` from year/month/day/hour/minute. Used so test
+ * fixtures read as wall-clock instants regardless of the host timezone.
+ */
+function localDate(year: number, month: number, day: number, hour = 0, minute = 0): Date {
+	return new Date(year, month - 1, day, hour, minute, 0, 0);
+}
+
+suite('Automations - computeNextRunAt', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('manual schedules never produce a next-run', () => {
+		const schedule: IAutomationSchedule = { interval: 'manual', scheduleHour: 9, scheduleMinute: 0, scheduleDay: 0 };
+		assert.strictEqual(computeNextRunAt(schedule, localDate(2026, 6, 1, 12, 0)), undefined);
+	});
+
+	test('hourly schedules return now + 1h regardless of wall-clock fields', () => {
+		const schedule: IAutomationSchedule = { interval: 'hourly', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 };
+		const now = localDate(2026, 6, 1, 12, 30);
+		const next = computeNextRunAt(schedule, now);
+		assert.ok(next);
+		assert.strictEqual(next.getTime() - now.getTime(), 60 * 60 * 1000);
+	});
+
+	test('daily: when target time is later today, returns today at that time', () => {
+		const schedule: IAutomationSchedule = { interval: 'daily', scheduleHour: 9, scheduleMinute: 0, scheduleDay: 0 };
+		const now = localDate(2026, 6, 1, 8, 0);
+		assert.deepStrictEqual(computeNextRunAt(schedule, now), localDate(2026, 6, 1, 9, 0));
+	});
+
+	test('daily: when target time has passed, returns tomorrow at that time', () => {
+		const schedule: IAutomationSchedule = { interval: 'daily', scheduleHour: 9, scheduleMinute: 0, scheduleDay: 0 };
+		const now = localDate(2026, 6, 1, 10, 0);
+		assert.deepStrictEqual(computeNextRunAt(schedule, now), localDate(2026, 6, 2, 9, 0));
+	});
+
+	test('daily: when target equals now, returns tomorrow (strict >)', () => {
+		const schedule: IAutomationSchedule = { interval: 'daily', scheduleHour: 9, scheduleMinute: 0, scheduleDay: 0 };
+		const now = localDate(2026, 6, 1, 9, 0);
+		assert.deepStrictEqual(computeNextRunAt(schedule, now), localDate(2026, 6, 2, 9, 0));
+	});
+
+	test('daily: rolls into next month at month boundary', () => {
+		const schedule: IAutomationSchedule = { interval: 'daily', scheduleHour: 9, scheduleMinute: 30, scheduleDay: 0 };
+		const now = localDate(2026, 6, 30, 23, 0);
+		assert.deepStrictEqual(computeNextRunAt(schedule, now), localDate(2026, 7, 1, 9, 30));
+	});
+
+	test('weekly: same weekday and time in the future returns today', () => {
+		// 2026-06-01 is a Monday (getDay() === 1)
+		const schedule: IAutomationSchedule = { interval: 'weekly', scheduleHour: 9, scheduleMinute: 0, scheduleDay: 1 };
+		const now = localDate(2026, 6, 1, 7, 0);
+		assert.deepStrictEqual(computeNextRunAt(schedule, now), localDate(2026, 6, 1, 9, 0));
+	});
+
+	test('weekly: same weekday but time already passed returns next week', () => {
+		const schedule: IAutomationSchedule = { interval: 'weekly', scheduleHour: 9, scheduleMinute: 0, scheduleDay: 1 };
+		const now = localDate(2026, 6, 1, 10, 0);
+		assert.deepStrictEqual(computeNextRunAt(schedule, now), localDate(2026, 6, 8, 9, 0));
+	});
+
+	test('weekly: future weekday this week', () => {
+		// Now = Mon (1). Target = Fri (5).
+		const schedule: IAutomationSchedule = { interval: 'weekly', scheduleHour: 9, scheduleMinute: 0, scheduleDay: 5 };
+		const now = localDate(2026, 6, 1, 7, 0);
+		assert.deepStrictEqual(computeNextRunAt(schedule, now), localDate(2026, 6, 5, 9, 0));
+	});
+
+	test('weekly: past weekday this week wraps to next week', () => {
+		// Now = Thu (4). Target = Mon (1).
+		const schedule: IAutomationSchedule = { interval: 'weekly', scheduleHour: 9, scheduleMinute: 0, scheduleDay: 1 };
+		const now = localDate(2026, 6, 4, 7, 0);
+		assert.deepStrictEqual(computeNextRunAt(schedule, now), localDate(2026, 6, 8, 9, 0));
+	});
+
+	test('rejects invalid hour, minute, or day for daily/weekly', () => {
+		const now = localDate(2026, 6, 1, 12, 0);
+		assert.strictEqual(computeNextRunAt({ interval: 'daily', scheduleHour: 24, scheduleMinute: 0, scheduleDay: 0 }, now), undefined);
+		assert.strictEqual(computeNextRunAt({ interval: 'daily', scheduleHour: -1, scheduleMinute: 0, scheduleDay: 0 }, now), undefined);
+		assert.strictEqual(computeNextRunAt({ interval: 'daily', scheduleHour: 9, scheduleMinute: 60, scheduleDay: 0 }, now), undefined);
+		assert.strictEqual(computeNextRunAt({ interval: 'weekly', scheduleHour: 9, scheduleMinute: 0, scheduleDay: 7 }, now), undefined);
+		assert.strictEqual(computeNextRunAt({ interval: 'weekly', scheduleHour: 9, scheduleMinute: 0, scheduleDay: -1 }, now), undefined);
+	});
+
+	test('hourly ignores hour/minute fields (still produces a next-run with junk values)', () => {
+		const now = localDate(2026, 6, 1, 12, 0);
+		const schedule: IAutomationSchedule = { interval: 'hourly', scheduleHour: 99, scheduleMinute: 99, scheduleDay: 99 };
+		const next = computeNextRunAt(schedule, now);
+		assert.ok(next);
+		assert.strictEqual(next.getTime() - now.getTime(), 60 * 60 * 1000);
+	});
+
+	test('daily: spring-forward day is not skipped', () => {
+		// 2026-03-08 02:30 local is in the spring-forward gap in US timezones
+		// (clock jumps 02:00 → 03:00). Even outside DST timezones the test
+		// asserts the calendar-date semantics: starting 23:30 the day before,
+		// `tomorrow` must be the *next calendar day*, not the day after that.
+		const schedule: IAutomationSchedule = { interval: 'daily', scheduleHour: 2, scheduleMinute: 30, scheduleDay: 0 };
+		const now = localDate(2026, 3, 7, 23, 30); // Saturday March 7, 23:30
+		const next = computeNextRunAt(schedule, now);
+		assert.ok(next);
+		// Next run must be Sunday March 8, not Monday March 9. `buildLocalDate`
+		// may shift 02:30 forward into the DST gap on actual DST hosts, but
+		// the *date* must land on the 8th, never the 9th.
+		assert.strictEqual(next.getDate(), 8, `expected next.getDate()===8, got ${next.toString()}`);
+		assert.strictEqual(next.getMonth(), 2);
+	});
+
+	test('weekly: spring-forward across the boundary lands on the correct calendar day', () => {
+		// Weekly on Sunday 02:30, now = Saturday March 7 23:30.
+		const schedule: IAutomationSchedule = { interval: 'weekly', scheduleHour: 2, scheduleMinute: 30, scheduleDay: 0 };
+		const now = localDate(2026, 3, 7, 23, 30);
+		const next = computeNextRunAt(schedule, now);
+		assert.ok(next);
+		assert.strictEqual(next.getDate(), 8);
+		assert.strictEqual(next.getDay(), 0); // Sunday
+	});
+
+	test('rejects unknown intervals', () => {
+		const now = localDate(2026, 6, 1, 12, 0);
+		const schedule = { interval: 'bogus', scheduleHour: 9, scheduleMinute: 0, scheduleDay: 0 } as unknown as IAutomationSchedule;
+		assert.strictEqual(computeNextRunAt(schedule, now), undefined);
+	});
+});


### PR DESCRIPTION
# Automations PR 1 (Foundation)

## Context

This is the first PR in a 4-part stack that adds **Automations** to VS Code, scheduled agentic tasks that run Copilot prompts against a workspace on a recurring cadence (manual, hourly, daily, weekly). Local-only for now.

This PR lays the infrastructure: types, persistent storage, a multi-window-safe scheduler with leader election, and the runner contract.

Gated behind `chat.automations.enabled` (machine-scoped).

## Architecture

```mermaid
classDiagram
    class IAutomation {
        +id: string
        +name: string
        +prompt: string
        +schedule: IAutomationSchedule
        +enabled: boolean
        +folderUri: URI
        +nextRunAt?: Date
    }

    class AutomationService {
        +automations: IObservable~IAutomation[]~
        +runs: IObservable~IAutomationRun[]~
        +create() / update() / delete()
        +recordRunStart() / updateRun()
        -storage: IStorageService
    }

    class AutomationScheduler {
        -tick every 60s (leader only)
        +dispatchDue(trigger)
        +markStaleRunsFailed()
        -runOneWithTimeout()
    }

    class AutomationLeaderElection {
        +isLeader: IObservable~boolean~
        -heartbeat every 30s
        -stale threshold: 90s
        -TOCTOU nonce guard
    }

    class IAutomationRunner {
        +runOnce(automation, trigger, windowId, token)
    }

    AutomationScheduler --> AutomationLeaderElection : checks leadership
    AutomationScheduler --> AutomationService : reads due automations
    AutomationScheduler --> IAutomationRunner : dispatches runs
    AutomationService --> IStorageService : persists (APPLICATION scope)
```

## Scheduler Flow

```mermaid
sequenceDiagram
    participant S as Scheduler (60s tick)
    participant L as LeaderElection
    participant AS as AutomationService
    participant R as Runner

    S->>L: isLeader?
    alt not leader
        S-->>S: skip tick
    else leader
        S->>AS: get enabled automations where nextRunAt ≤ now
        loop each due automation
            S->>AS: advanceNextRunAt(id) [preemptive bump]
            S->>R: runOnce(automation, trigger, token)
            R->>AS: recordRunStart → updateRun(running)
            R-->>R: send prompt via sessions layer
            R->>AS: updateRun(completed/failed)
        end
    end
```

Includes tests for schedule math (DST edge cases, all cadences).

## Design Decisions

- Multiple VS Code instances will elect a "leader" to be the one dispatching automated runs
- On crash, recovery on leadership marks stale runs as failed and fires catch-up for overdue automations.
- Default timeout of 30 minutes per run