### PR TITLE
[Experimental] Chat generative-UI webview inset + transport (inline A2UI primitives)

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -562,6 +562,12 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 				revivedProgress.uri = this._uriIdentityService.asCanonicalUri(revivedProgress.uri);
 			}
 
+			if (revivedProgress.kind === 'generativeUIRuntimeInset') {
+				// Revive the runtime asset URI from its serialized UriComponents so the
+				// model carries a real URI for the inset renderer (Phase 1).
+				revivedProgress.runtimeUri = URI.revive(revivedProgress.runtimeUri);
+			}
+
 			if (responsePartHandle !== undefined) {
 
 				if (revivedProgress.kind === 'progressTask') {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1906,6 +1906,14 @@ export type IDocumentContextDto = {
 	ranges: IRange[];
 };
 
+export interface IChatGenerativeUIInsetDto {
+	kind: 'generativeUIRuntimeInset';
+	surfaceId: string;
+	runtimeUri: UriComponents;
+	initialDoc?: object;
+	version: number;
+}
+
 export type IChatProgressDto =
 	| Dto<Exclude<IChatProgress, IChatTask | IChatNotebookEdit>>
 	| IChatTaskDto
@@ -1914,7 +1922,8 @@ export type IChatProgressDto =
 	| IChatResponseClearToPreviousToolInvocationDto
 	| IChatBeginToolInvocationDto
 	| IChatUpdateToolInvocationDto
-	| IChatUsageDto;
+	| IChatUsageDto
+	| IChatGenerativeUIInsetDto;
 
 export interface ExtHostUrlsShape {
 	$handleExternalUri(handle: number, uri: UriComponents): Promise<void>;

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -383,6 +383,20 @@ export class ChatAgentResponseStream {
 					_report(dto);
 					return this;
 				},
+				generativeUI(surfaceId, runtimeUri, initialDoc?, version?) {
+					throwIfDone(this.generativeUI);
+					checkProposedApiEnabled(that._extension, 'chatParticipantAdditions');
+
+					const dto: IChatProgressDto = {
+						kind: 'generativeUIRuntimeInset',
+						surfaceId,
+						runtimeUri: runtimeUri.toJSON?.() ?? runtimeUri,
+						initialDoc,
+						version: version ?? 1
+					};
+					_report(dto);
+					return this;
+				},
 				push(part) {
 					throwIfDone(this.push);
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetPart.ts
@@ -145,7 +145,7 @@ export class ChatGenerativeUIInsetPart extends Disposable implements IChatConten
 		// Strict CSP: only the bundled runtime script (served from the webview
 		// resource authority) may run; no inline handlers, no remote scripts.
 		return `<!DOCTYPE html><html><head>
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${webviewGenericCspSource}; style-src 'unsafe-inline';">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${webviewGenericCspSource}; style-src 'unsafe-inline'; img-src ${webviewGenericCspSource} https: data:;">
 </head><body><div id="root"></div><script src="${runtimeSrc}"></script></body></html>`;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetPart.ts
@@ -107,6 +107,34 @@ export class ChatGenerativeUIInsetPart extends Disposable implements IChatConten
 		const surfaceId = this._content.surfaceId;
 		registerInset(surfaceId, this);
 		this._register({ dispose: () => deregisterInset(surfaceId, this) });
+
+		// The chat list virtualizes rows: when this inset scrolls out of the
+		// viewport its webview is dismounted, and when it scrolls back the
+		// webview is not re-initialized on its own — it would render blank.
+		// Mirror ChatMcpAppSubPart: re-initialize the webview whenever the part
+		// becomes visible again. (`onDidRemount()` below covers the explicit
+		// remount path the renderer drives.)
+		this._register(context.onDidChangeVisibility(visible => {
+			if (visible) {
+				this._remount();
+			}
+		}));
+	}
+
+	/**
+	 * Called by the chat content renderer when this part is re-attached to the
+	 * DOM after virtualization detached it. Re-initialize the webview so it
+	 * does not render blank after scrolling away and back.
+	 */
+	onDidRemount(): void {
+		this._remount();
+	}
+
+	private _remount(): void {
+		// Reloads the webview HTML, so the runtime re-boots and re-fires READY;
+		// the existing onMessage READY handler then re-posts RENDER(initialDoc),
+		// repainting the inset. No defensive re-RENDER is needed here.
+		this._webview.reinitializeAfterDismount();
 	}
 
 	public postToInset(msg: HostToInsetMessage): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetPart.ts
@@ -61,7 +61,16 @@ export class ChatGenerativeUIInsetPart extends Disposable implements IChatConten
 		}));
 		this._webview.mountTo(this.domNode, dom.getWindow(this.domNode));
 
-		this._register(this._webview.onMessage(({ message }) => this._onDidPostMessage.fire(message as InsetToHostMessage)));
+		this._register(this._webview.onMessage(({ message }) => {
+			const msg = message as InsetToHostMessage;
+			// When the runtime signals it has mounted, push the initial document so
+			// it has something to render. (Post-render updates arrive via STATE_DELTA
+			// through the registry/command path.)
+			if (msg.type === 'READY' && this._content.initialDoc !== undefined) {
+				this.postToInset({ type: 'RENDER', doc: this._content.initialDoc as object });
+			}
+			this._onDidPostMessage.fire(msg);
+		}));
 		this._register(autorun(reader => {
 			const size = this._webview.intrinsicContentSize.read(reader);
 			if (size) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetPart.ts
@@ -9,6 +9,7 @@ import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../../../base/common/observable.js';
 import { dirname } from '../../../../../../base/common/resources.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { IWebviewService, WebviewContentPurpose, IWebviewElement } from '../../../../webview/browser/webview.js';
 import { asWebviewUri, webviewGenericCspSource } from '../../../../webview/common/webview.js';
 import { IChatGenerativeUIInset } from '../../../common/model/chatModel.js';
@@ -36,6 +37,7 @@ export class ChatGenerativeUIInsetPart extends Disposable implements IChatConten
 		private readonly _content: IChatGenerativeUIInset,
 		context: IChatContentPartRenderContext,
 		@IWebviewService webviewService: IWebviewService,
+		@ICommandService private readonly _commandService: ICommandService,
 	) {
 		super();
 		this.domNode = dom.append(context.container, dom.$('div.a2ui-inset'));
@@ -68,6 +70,20 @@ export class ChatGenerativeUIInsetPart extends Disposable implements IChatConten
 			// through the registry/command path.)
 			if (msg.type === 'READY' && this._content.initialDoc !== undefined) {
 				this.postToInset({ type: 'RENDER', doc: this._content.initialDoc as object });
+			}
+			// Forward inset interactions back to the extension for routing. The
+			// extension registers `_a2ui.routeInteraction` (mirrors the reverse
+			// `_a2ui.postToSurface` convention); core hardcodes the string because
+			// it must not import the extension/runtime packages. Wrapped in a
+			// try/catch and a rejection handler because the command may be
+			// unregistered (extension not installed/activated yet).
+			if (msg.type === 'INTERACTION') {
+				try {
+					this._commandService.executeCommand('_a2ui.routeInteraction', this._content.surfaceId, msg)
+						.then(undefined, () => { /* extension not listening — ignore */ });
+				} catch {
+					/* command not registered — ignore */
+				}
 			}
 			this._onDidPostMessage.fire(msg);
 		}));

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetPart.ts
@@ -7,8 +7,10 @@ import * as dom from '../../../../../../base/browser/dom.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../../../base/common/observable.js';
+import { dirname } from '../../../../../../base/common/resources.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { IWebviewService, WebviewContentPurpose, IWebviewElement } from '../../../../webview/browser/webview.js';
+import { asWebviewUri, webviewGenericCspSource } from '../../../../webview/common/webview.js';
 import { IChatGenerativeUIInset } from '../../../common/model/chatModel.js';
 import { IChatRendererContent } from '../../../common/model/chatViewModel.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
@@ -49,6 +51,10 @@ export class ChatGenerativeUIInsetPart extends Disposable implements IChatConten
 				allowScripts: true,
 				allowForms: true,
 				allowMultipleAPIAcquire: true,
+				// The runtime bundle lives on disk next to the extension; allow the
+				// webview to load local resources from its containing directory so the
+				// `<script src>` (rewritten via asWebviewUri) actually resolves.
+				localResourceRoots: [dirname(this._content.runtimeUri)],
 			},
 			extension: undefined,
 		}));
@@ -62,7 +68,12 @@ export class ChatGenerativeUIInsetPart extends Disposable implements IChatConten
 			}
 		}));
 
-		this._webview.setHtml(this._buildHtml(this._content.runtimeUri.toString()));
+		// Rewrite the on-disk runtime URI into a webview-loadable URI. Core webviews
+		// cannot load `file:` URIs directly; resources must be requested through the
+		// `vscode-resource`/`vscode-cdn` authority (served by the webview service
+		// worker) and the source directory must be in `localResourceRoots` (above).
+		const runtimeSrc = asWebviewUri(this._content.runtimeUri).toString(true);
+		this._webview.setHtml(this._buildHtml(runtimeSrc));
 	}
 
 	public postToInset(msg: HostToInsetMessage): void {
@@ -70,9 +81,10 @@ export class ChatGenerativeUIInsetPart extends Disposable implements IChatConten
 	}
 
 	private _buildHtml(runtimeSrc: string): string {
-		// Strict CSP: only the bundled runtime script may run; no inline handlers, no remote scripts.
+		// Strict CSP: only the bundled runtime script (served from the webview
+		// resource authority) may run; no inline handlers, no remote scripts.
 		return `<!DOCTYPE html><html><head>
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${runtimeSrc}; style-src 'unsafe-inline';">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${webviewGenericCspSource}; style-src 'unsafe-inline';">
 </head><body><div id="root"></div><script src="${runtimeSrc}"></script></body></html>`;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetPart.ts
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../../../base/browser/dom.js';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../../../base/common/observable.js';
+import { generateUuid } from '../../../../../../base/common/uuid.js';
+import { IWebviewService, WebviewContentPurpose, IWebviewElement } from '../../../../webview/browser/webview.js';
+import { IChatGenerativeUIInset } from '../../../common/model/chatModel.js';
+import { IChatRendererContent } from '../../../common/model/chatViewModel.js';
+import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
+
+// Wire-protocol message shapes (mirrors @copilot/a2ui-runtime/src/protocol.ts; core must not import the runtime package).
+type HostToInsetMessage = { type: 'RENDER' | 'STATE_DELTA' | 'DISPOSE';[k: string]: unknown };
+type InsetToHostMessage = { type: 'READY' | 'INTERACTION' | 'RESIZE';[k: string]: unknown };
+
+/**
+ * Renders an interactive generative-UI webview inset inside a chat message bubble.
+ * This is a generic, business-logic-free pipe: it hosts a webview, loads the
+ * bundled runtime asset, relays messages in/out, tracks intrinsic height, and
+ * applies a strict CSP. All A2UI/MCP semantics live outside core.
+ */
+export class ChatGenerativeUIInsetPart extends Disposable implements IChatContentPart {
+	public domNode: HTMLElement;
+	private readonly _webview: IWebviewElement;
+	private readonly _onDidPostMessage = this._register(new Emitter<InsetToHostMessage>());
+	public readonly onDidPostMessage: Event<InsetToHostMessage> = this._onDidPostMessage.event;
+
+	constructor(
+		private readonly _content: IChatGenerativeUIInset,
+		context: IChatContentPartRenderContext,
+		@IWebviewService webviewService: IWebviewService,
+	) {
+		super();
+		this.domNode = dom.append(context.container, dom.$('div.a2ui-inset'));
+
+		this._webview = this._register(webviewService.createWebviewElement({
+			origin: 'a2ui-' + generateUuid(),
+			title: 'Generative UI',
+			options: {
+				purpose: WebviewContentPurpose.ChatOutputItem,
+				enableFindWidget: false,
+				retainContextWhenHidden: true,
+			},
+			contentOptions: {
+				allowScripts: true,
+				allowForms: true,
+				allowMultipleAPIAcquire: true,
+			},
+			extension: undefined,
+		}));
+		this._webview.mountTo(this.domNode, dom.getWindow(this.domNode));
+
+		this._register(this._webview.onMessage(({ message }) => this._onDidPostMessage.fire(message as InsetToHostMessage)));
+		this._register(autorun(reader => {
+			const size = this._webview.intrinsicContentSize.read(reader);
+			if (size) {
+				this.domNode.style.height = `${size.height}px`;
+			}
+		}));
+
+		this._webview.setHtml(this._buildHtml(this._content.runtimeUri.toString()));
+	}
+
+	public postToInset(msg: HostToInsetMessage): void {
+		this._webview.postMessage(msg);
+	}
+
+	private _buildHtml(runtimeSrc: string): string {
+		// Strict CSP: only the bundled runtime script may run; no inline handlers, no remote scripts.
+		return `<!DOCTYPE html><html><head>
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${runtimeSrc}; style-src 'unsafe-inline';">
+</head><body><div id="root"></div><script src="${runtimeSrc}"></script></body></html>`;
+	}
+
+	hasSameContent(other: IChatRendererContent): boolean {
+		return other.kind === 'generativeUIRuntimeInset'
+			&& other.surfaceId === this._content.surfaceId
+			&& other.version === this._content.version;
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetPart.ts
@@ -8,14 +8,13 @@ import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../../../base/common/observable.js';
 import { dirname } from '../../../../../../base/common/resources.js';
-import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { IWebviewService, WebviewContentPurpose, IWebviewElement } from '../../../../webview/browser/webview.js';
 import { asWebviewUri, webviewGenericCspSource } from '../../../../webview/common/webview.js';
 import { IChatGenerativeUIInset } from '../../../common/model/chatModel.js';
 import { IChatRendererContent } from '../../../common/model/chatViewModel.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
-import { deregisterInset, registerInset } from './chatGenerativeUIInsetRegistry.js';
+import { deregisterInset, getInsetReplay, registerInset, seedInsetInitialDoc } from './chatGenerativeUIInsetRegistry.js';
 
 // Wire-protocol message shapes (mirrors @copilot/a2ui-runtime/src/protocol.ts; core must not import the runtime package).
 type HostToInsetMessage = { type: 'RENDER' | 'STATE_DELTA' | 'DISPOSE';[k: string]: unknown };
@@ -43,7 +42,11 @@ export class ChatGenerativeUIInsetPart extends Disposable implements IChatConten
 		this.domNode = dom.append(context.container, dom.$('div.a2ui-inset'));
 
 		this._webview = this._register(webviewService.createWebviewElement({
-			origin: 'a2ui-' + generateUuid(),
+			// Stable origin keyed by surfaceId (not a fresh uuid): when the chat
+			// list recycles this row, the part is disposed and reconstructed, and
+			// a stable origin lets the new webview reuse the same storage
+			// partition as the prior one for this surface.
+			origin: 'a2ui-' + this._content.surfaceId,
 			title: 'Generative UI',
 			options: {
 				purpose: WebviewContentPurpose.ChatOutputItem,
@@ -65,11 +68,16 @@ export class ChatGenerativeUIInsetPart extends Disposable implements IChatConten
 
 		this._register(this._webview.onMessage(({ message }) => {
 			const msg = message as InsetToHostMessage;
-			// When the runtime signals it has mounted, push the initial document so
-			// it has something to render. (Post-render updates arrive via STATE_DELTA
-			// through the registry/command path.)
-			if (msg.type === 'READY' && this._content.initialDoc !== undefined) {
-				this.postToInset({ type: 'RENDER', doc: this._content.initialDoc as object });
+			// When the runtime signals it has mounted, replay the surface's full
+			// recorded state — the latest RENDER plus every STATE_DELTA since —
+			// so it reaches CURRENT state, not just the initial document. This
+			// fires on first boot, on `reinitializeAfterDismount`, and on the
+			// fresh webview of a part reconstructed after scroll-out; replaying
+			// RENDER (a full render) before the deltas keeps it idempotent.
+			if (msg.type === 'READY') {
+				for (const replayMsg of getInsetReplay(this._content.surfaceId)) {
+					this.postToInset(replayMsg);
+				}
 			}
 			// Forward inset interactions back to the extension for routing. The
 			// extension registers `_a2ui.routeInteraction` (mirrors the reverse
@@ -103,8 +111,13 @@ export class ChatGenerativeUIInsetPart extends Disposable implements IChatConten
 
 		// Register in the cross-fork transport registry so the extension can push
 		// post-render messages (STATE_DELTA / DISPOSE) to THIS inset by surfaceId
-		// via the `_a2ui.postToSurface` command. Deregister on dispose.
+		// via the `_a2ui.postToSurface` command. Deregister on dispose. Also seed
+		// our initialDoc into the surface's replay state: it's posted to our own
+		// webview directly (above, on READY) rather than through the command, so
+		// the registry would otherwise never learn it and a part recreated after
+		// scroll-out could not rebuild.
 		const surfaceId = this._content.surfaceId;
+		seedInsetInitialDoc(surfaceId, this._content.initialDoc);
 		registerInset(surfaceId, this);
 		this._register({ dispose: () => deregisterInset(surfaceId, this) });
 
@@ -113,7 +126,8 @@ export class ChatGenerativeUIInsetPart extends Disposable implements IChatConten
 		// webview is not re-initialized on its own — it would render blank.
 		// Mirror ChatMcpAppSubPart: re-initialize the webview whenever the part
 		// becomes visible again. (`onDidRemount()` below covers the explicit
-		// remount path the renderer drives.)
+		// remount path the renderer drives.) On the resulting READY the handler
+		// above replays the surface's full recorded state.
 		this._register(context.onDidChangeVisibility(visible => {
 			if (visible) {
 				this._remount();
@@ -132,8 +146,9 @@ export class ChatGenerativeUIInsetPart extends Disposable implements IChatConten
 
 	private _remount(): void {
 		// Reloads the webview HTML, so the runtime re-boots and re-fires READY;
-		// the existing onMessage READY handler then re-posts RENDER(initialDoc),
-		// repainting the inset. No defensive re-RENDER is needed here.
+		// the existing onMessage READY handler then replays the surface's full
+		// recorded state (RENDER + deltas), repainting the inset at its current
+		// state. No defensive re-RENDER is needed here.
 		this._webview.reinitializeAfterDismount();
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetPart.ts
@@ -14,6 +14,7 @@ import { asWebviewUri, webviewGenericCspSource } from '../../../../webview/commo
 import { IChatGenerativeUIInset } from '../../../common/model/chatModel.js';
 import { IChatRendererContent } from '../../../common/model/chatViewModel.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
+import { deregisterInset, registerInset } from './chatGenerativeUIInsetRegistry.js';
 
 // Wire-protocol message shapes (mirrors @copilot/a2ui-runtime/src/protocol.ts; core must not import the runtime package).
 type HostToInsetMessage = { type: 'RENDER' | 'STATE_DELTA' | 'DISPOSE';[k: string]: unknown };
@@ -74,6 +75,13 @@ export class ChatGenerativeUIInsetPart extends Disposable implements IChatConten
 		// worker) and the source directory must be in `localResourceRoots` (above).
 		const runtimeSrc = asWebviewUri(this._content.runtimeUri).toString(true);
 		this._webview.setHtml(this._buildHtml(runtimeSrc));
+
+		// Register in the cross-fork transport registry so the extension can push
+		// post-render messages (STATE_DELTA / DISPOSE) to THIS inset by surfaceId
+		// via the `_a2ui.postToSurface` command. Deregister on dispose.
+		const surfaceId = this._content.surfaceId;
+		registerInset(surfaceId, this);
+		this._register({ dispose: () => deregisterInset(surfaceId, this) });
 	}
 
 	public postToInset(msg: HostToInsetMessage): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetPart.ts
@@ -5,9 +5,11 @@
 
 import * as dom from '../../../../../../base/browser/dom.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { hash } from '../../../../../../base/common/hash.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../../../base/common/observable.js';
 import { dirname } from '../../../../../../base/common/resources.js';
+import { localize } from '../../../../../../nls.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { IWebviewService, WebviewContentPurpose, IWebviewElement } from '../../../../webview/browser/webview.js';
 import { asWebviewUri, webviewGenericCspSource } from '../../../../webview/common/webview.js';
@@ -40,14 +42,22 @@ export class ChatGenerativeUIInsetPart extends Disposable implements IChatConten
 	) {
 		super();
 		this.domNode = dom.append(context.container, dom.$('div.a2ui-inset'));
+		// First-step accessibility: announce the inset as a labelled group so the
+		// interactive region is discoverable. A fuller accessible-view provider
+		// (exposing the rendered document's semantics to screen readers) is a
+		// known follow-up.
+		this.domNode.setAttribute('role', 'group');
+		this.domNode.setAttribute('aria-label', localize('chat.generativeUIInset.aria', "Interactive generative UI"));
 
 		this._webview = this._register(webviewService.createWebviewElement({
 			// Stable origin keyed by surfaceId (not a fresh uuid): when the chat
 			// list recycles this row, the part is disposed and reconstructed, and
 			// a stable origin lets the new webview reuse the same storage
-			// partition as the prior one for this surface.
-			origin: 'a2ui-' + this._content.surfaceId,
-			title: 'Generative UI',
+			// partition as the prior one for this surface. The surfaceId is
+			// untrusted (cross-fork) and could collide with the raw-string scheme,
+			// so derive a short stable hash rather than embedding it directly.
+			origin: 'a2ui-' + hash(this._content.surfaceId).toString(16),
+			title: localize('chat.generativeUIInset.title', "Generative UI"),
 			options: {
 				purpose: WebviewContentPurpose.ChatOutputItem,
 				enableFindWidget: false,

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetRegistry.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetRegistry.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CommandsRegistry } from '../../../../../../platform/commands/common/commands.js';
+import type { ChatGenerativeUIInsetPart } from './chatGenerativeUIInsetPart.js';
+
+// Wire-protocol message shape (mirrors the HostToInsetMessage in chatGenerativeUIInsetPart.ts
+// and @copilot/a2ui-runtime/src/protocol.ts; core must not import the runtime package).
+type HostToInsetMessage = { type: 'RENDER' | 'STATE_DELTA' | 'DISPOSE';[k: string]: unknown };
+
+/**
+ * Module-level registry of live generative-UI insets, keyed by `surfaceId`.
+ *
+ * This is the cross-fork transport target: the extension pushes post-render
+ * messages (STATE_DELTA / DISPOSE) to a SPECIFIC already-rendered inset by
+ * invoking the `_a2ui.postToSurface` command (below), which looks the inset up
+ * here and forwards the message.
+ *
+ * A module map (rather than a workbench service) mirrors the existing
+ * `_chat.resizeImage` pattern in `chatImageUtils.ts` and is the simplest
+ * dispose-safe option: each `ChatGenerativeUIInsetPart` registers itself on
+ * construction and deregisters on dispose.
+ */
+const insets = new Map<string, ChatGenerativeUIInsetPart>();
+
+/**
+ * Register an inset under its `surfaceId`. Last writer wins: if a surface with
+ * the same id is already registered (e.g. a re-render before the prior part was
+ * disposed), the new part replaces it. Deregistration is guarded so a stale
+ * part disposing later cannot evict a newer part registered under the same id.
+ */
+export function registerInset(surfaceId: string, inset: ChatGenerativeUIInsetPart): void {
+	insets.set(surfaceId, inset);
+}
+
+/**
+ * Deregister an inset. No-op unless the currently-registered part for
+ * `surfaceId` is exactly `inset` — this makes "last wins" safe against a stale
+ * part disposing after a newer part has taken over the same surfaceId.
+ */
+export function deregisterInset(surfaceId: string, inset: ChatGenerativeUIInsetPart): void {
+	if (insets.get(surfaceId) === inset) {
+		insets.delete(surfaceId);
+	}
+}
+
+/**
+ * INTERNAL command (underscore = not in the command palette).
+ *
+ * Dumb pipe: look up the inset registered for `surfaceId` and forward `msg` to
+ * it via `postToInset`. No A2UI logic lives here. No-op if the surface is gone
+ * (the inset was disposed) so a late push after teardown is harmless.
+ */
+CommandsRegistry.registerCommand('_a2ui.postToSurface', (_accessor, surfaceId: string, msg: HostToInsetMessage): void => {
+	insets.get(surfaceId)?.postToInset(msg);
+});

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetRegistry.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetRegistry.ts
@@ -26,6 +26,33 @@ type HostToInsetMessage = { type: 'RENDER' | 'STATE_DELTA' | 'DISPOSE';[k: strin
 const insets = new Map<string, ChatGenerativeUIInsetPart>();
 
 /**
+ * Replayable transport state for a surface, kept alive independently of any
+ * `ChatGenerativeUIInsetPart`.
+ *
+ * The chat list virtualizes rows: when an inset scrolls far enough offscreen
+ * its content part (and webview) is DISPOSED, and scrolling back constructs a
+ * fresh part with a brand-new webview. The live document state, however, only
+ * ever lived inside that webview — the chat model carries just `initialDoc`,
+ * and all post-render updates arrive as transient `STATE_DELTA` messages. So a
+ * recreated (or reloaded) inset could previously only restore `initialDoc`,
+ * losing every accumulated delta and rendering blank.
+ *
+ * We therefore record the minimal sequence needed to rebuild current state —
+ * the latest full `RENDER` document plus the ordered `STATE_DELTA`s applied
+ * since — and replay it whenever a webview (re)mounts. `RENDER` is a full
+ * document render, so replaying `RENDER` then every delta is idempotent: it can
+ * run on each READY without double-applying.
+ */
+interface IInsetSurfaceState {
+	/** Latest full-render document for the surface, or `undefined` if none yet. */
+	initialDoc: unknown | undefined;
+	/** Ordered `STATE_DELTA` messages applied since the latest `RENDER`. */
+	readonly deltas: HostToInsetMessage[];
+}
+
+const surfaceStates = new Map<string, IInsetSurfaceState>();
+
+/**
  * Register an inset under its `surfaceId`. Last writer wins: if a surface with
  * the same id is already registered (e.g. a re-render before the prior part was
  * disposed), the new part replaces it. Deregistration is guarded so a stale
@@ -39,6 +66,10 @@ export function registerInset(surfaceId: string, inset: ChatGenerativeUIInsetPar
  * Deregister an inset. No-op unless the currently-registered part for
  * `surfaceId` is exactly `inset` — this makes "last wins" safe against a stale
  * part disposing after a newer part has taken over the same surfaceId.
+ *
+ * Note: this deliberately does NOT drop the surface's replay state — that must
+ * survive part disposal so the next part (after scroll-back) can rebuild. State
+ * is cleared only on an explicit `DISPOSE` message (surface teardown).
  */
 export function deregisterInset(surfaceId: string, inset: ChatGenerativeUIInsetPart): void {
 	if (insets.get(surfaceId) === inset) {
@@ -47,12 +78,84 @@ export function deregisterInset(surfaceId: string, inset: ChatGenerativeUIInsetP
 }
 
 /**
+ * Seed the initial document for a surface the first time a part renders it.
+ * The part's own first `RENDER(initialDoc)` is posted directly to its webview
+ * (not through {@link postToSurface}), so the registry would otherwise never
+ * learn it. Does not clobber state already accumulated from earlier renders of
+ * the same surface (e.g. a later push raced ahead of a scroll-back re-render).
+ */
+export function seedInsetInitialDoc(surfaceId: string, initialDoc: unknown): void {
+	if (initialDoc === undefined) {
+		return;
+	}
+	const state = surfaceStates.get(surfaceId);
+	if (!state) {
+		surfaceStates.set(surfaceId, { initialDoc, deltas: [] });
+	} else if (state.initialDoc === undefined) {
+		state.initialDoc = initialDoc;
+	}
+}
+
+/**
+ * The ordered messages a freshly-(re)mounted inset must replay to reach the
+ * surface's current state: the latest `RENDER` (if any) followed by every
+ * `STATE_DELTA` recorded since. Empty if the surface has no known state.
+ */
+export function getInsetReplay(surfaceId: string): HostToInsetMessage[] {
+	const state = surfaceStates.get(surfaceId);
+	if (!state) {
+		return [];
+	}
+	const replay: HostToInsetMessage[] = [];
+	if (state.initialDoc !== undefined) {
+		replay.push({ type: 'RENDER', doc: state.initialDoc });
+	}
+	replay.push(...state.deltas);
+	return replay;
+}
+
+/**
+ * Fold a host→inset message into the surface's replay state. `RENDER` replaces
+ * the document and drops superseded deltas (bounding growth); `STATE_DELTA`
+ * appends; `DISPOSE` discards the surface entirely.
+ */
+function recordSurfaceMessage(surfaceId: string, msg: HostToInsetMessage): void {
+	switch (msg.type) {
+		case 'RENDER': {
+			const state = surfaceStates.get(surfaceId);
+			if (state) {
+				state.initialDoc = msg.doc;
+				state.deltas.length = 0;
+			} else {
+				surfaceStates.set(surfaceId, { initialDoc: msg.doc, deltas: [] });
+			}
+			break;
+		}
+		case 'STATE_DELTA': {
+			let state = surfaceStates.get(surfaceId);
+			if (!state) {
+				state = { initialDoc: undefined, deltas: [] };
+				surfaceStates.set(surfaceId, state);
+			}
+			state.deltas.push(msg);
+			break;
+		}
+		case 'DISPOSE': {
+			surfaceStates.delete(surfaceId);
+			break;
+		}
+	}
+}
+
+/**
  * INTERNAL command (underscore = not in the command palette).
  *
- * Dumb pipe: look up the inset registered for `surfaceId` and forward `msg` to
- * it via `postToInset`. No A2UI logic lives here. No-op if the surface is gone
- * (the inset was disposed) so a late push after teardown is harmless.
+ * Dumb pipe: record `msg` into the surface's replay state (so a part recreated
+ * after scroll-out can rebuild) and forward it to the live inset (if any) via
+ * `postToInset`. No A2UI logic lives here. Forwarding is a no-op if the surface
+ * is offscreen/disposed, which is harmless — the recorded state carries it.
  */
 CommandsRegistry.registerCommand('_a2ui.postToSurface', (_accessor, surfaceId: string, msg: HostToInsetMessage): void => {
+	recordSurfaceMessage(surfaceId, msg);
 	insets.get(surfaceId)?.postToInset(msg);
 });

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetRegistry.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatGenerativeUIInsetRegistry.ts
@@ -11,6 +11,16 @@ import type { ChatGenerativeUIInsetPart } from './chatGenerativeUIInsetPart.js';
 type HostToInsetMessage = { type: 'RENDER' | 'STATE_DELTA' | 'DISPOSE';[k: string]: unknown };
 
 /**
+ * Upper bound on the number of `STATE_DELTA` messages recorded per surface
+ * between full `RENDER`s. Deltas accumulate until a `RENDER` (which clears
+ * them) or `DISPOSE` arrives; without a cap a long-lived surface that only ever
+ * receives deltas would grow this list without limit. When exceeded we drop the
+ * oldest deltas (the latest `RENDER` is preserved separately as `initialDoc`,
+ * and the most recent deltas dominate current state).
+ */
+const MAX_RECORDED_DELTAS = 1000;
+
+/**
  * Module-level registry of live generative-UI insets, keyed by `surfaceId`.
  *
  * This is the cross-fork transport target: the extension pushes post-render
@@ -138,6 +148,12 @@ function recordSurfaceMessage(surfaceId: string, msg: HostToInsetMessage): void 
 				surfaceStates.set(surfaceId, state);
 			}
 			state.deltas.push(msg);
+			// Bound unbounded growth: a surface that only ever receives deltas
+			// (no intervening RENDER) would otherwise accumulate forever. Drop the
+			// oldest deltas once over the cap; the most recent ones dominate state.
+			if (state.deltas.length > MAX_RECORDED_DELTAS) {
+				state.deltas.splice(0, state.deltas.length - MAX_RECORDED_DELTAS);
+			}
 			break;
 		}
 		case 'DISPOSE': {
@@ -147,6 +163,9 @@ function recordSurfaceMessage(surfaceId: string, msg: HostToInsetMessage): void 
 	}
 }
 
+/** Recognized host→inset message types accepted by {@link postToSurface}. */
+const VALID_MESSAGE_TYPES = new Set<HostToInsetMessage['type']>(['RENDER', 'STATE_DELTA', 'DISPOSE']);
+
 /**
  * INTERNAL command (underscore = not in the command palette).
  *
@@ -154,8 +173,21 @@ function recordSurfaceMessage(surfaceId: string, msg: HostToInsetMessage): void 
  * after scroll-out can rebuild) and forward it to the live inset (if any) via
  * `postToInset`. No A2UI logic lives here. Forwarding is a no-op if the surface
  * is offscreen/disposed, which is harmless — the recorded state carries it.
+ *
+ * The payload is untrusted (the caller is a separate fork's extension), so the
+ * message shape is validated before it is recorded or forwarded: it must be an
+ * object with a recognized `type`; anything else is ignored.
+ *
+ * NOTE (scoping): this command is keyed by `surfaceId` ALONE — it does not
+ * verify that the caller owns the targeted surface or session. Full owner/
+ * session scoping (e.g. a per-surface capability token issued at render time
+ * and required on every push) is a known follow-up and intentionally out of
+ * scope for this change.
  */
 CommandsRegistry.registerCommand('_a2ui.postToSurface', (_accessor, surfaceId: string, msg: HostToInsetMessage): void => {
+	if (typeof msg !== 'object' || msg === null || !VALID_MESSAGE_TYPES.has((msg as HostToInsetMessage).type)) {
+		return;
+	}
 	recordSurfaceMessage(surfaceId, msg);
 	insets.get(surfaceId)?.postToInset(msg);
 });

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -85,6 +85,7 @@ import { ChatErrorContentPart } from './chatContentParts/chatErrorContentPart.js
 import { ChatPlanReviewPart } from './chatContentParts/chatPlanReviewPart.js';
 import { ChatQuestionCarouselPart } from './chatContentParts/chatQuestionCarouselPart.js';
 import { ChatExtensionsContentPart } from './chatContentParts/chatExtensionsContentPart.js';
+import { ChatGenerativeUIInsetPart } from './chatContentParts/chatGenerativeUIInsetPart.js';
 import { ChatMarkdownContentPart, codeblockHasClosingBackticks } from './chatContentParts/chatMarkdownContentPart.js';
 import { ChatMcpServersInteractionContentPart } from './chatContentParts/chatMcpServersInteractionContentPart.js';
 import { ChatDisabledClaudeHooksContentPart } from './chatContentParts/chatDisabledClaudeHooksContentPart.js';
@@ -2484,6 +2485,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				return this.renderExternalEdit(content, context, templateData);
 			} else if (content.kind === 'autoModeResolution') {
 				return this.instantiationService.createInstance(ChatAutoModeResolutionContentPart, content, context, this.chatContentMarkdownRenderer);
+			} else if (content.kind === 'generativeUIRuntimeInset') {
+				return this.instantiationService.createInstance(ChatGenerativeUIInsetPart, content, context);
 			}
 
 			return this.renderNoContent(other => content.kind === other.kind);

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -27,7 +27,7 @@ import { IChatRequestVariableValue } from '../attachments/chatVariables.js';
 import { ReadonlyChatSessionOptionsMap } from '../chatSessionsService.js';
 import { ChatAgentLocation, ChatModeKind } from '../constants.js';
 import { IChatEditingSession } from '../editing/chatEditingService.js';
-import { IChatModel, IChatRequestModeInfo, IChatRequestModel, IChatRequestVariableData, IChatResponseModel, IExportableChatData, ISerializableChatData } from '../model/chatModel.js';
+import { IChatGenerativeUIInset, IChatModel, IChatRequestModeInfo, IChatRequestModel, IChatRequestVariableData, IChatResponseModel, IExportableChatData, ISerializableChatData } from '../model/chatModel.js';
 import type { IChatModelReferenceDebugSnapshot } from '../model/chatModelStore.js';
 import { IChatAgentCommand, IChatAgentData, IChatAgentResult, UserSelectedTools } from '../participants/chatAgents.js';
 import { HookTypeValue } from '../promptSyntax/hookTypes.js';
@@ -1319,7 +1319,8 @@ export type IChatProgress =
 	| IChatHookPart
 	| IChatExternalToolInvocationUpdate
 	| IChatDisabledClaudeHooksPart
-	| IChatAutoModeResolutionPart;
+	| IChatAutoModeResolutionPart
+	| IChatGenerativeUIInset;
 
 export interface IChatFollowup {
 	kind: 'reply';

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -232,7 +232,7 @@ export interface IChatGenerativeUIInset {
 	/** Resource URI of the bundled a2ui-runtime asset to load into the inset webview. */
 	runtimeUri: URI;
 	/** Optional initial A2UI document to RENDER once the inset signals READY. */
-	initialDoc?: unknown;
+	initialDoc?: object;
 	version: number;
 }
 

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -223,7 +223,18 @@ export type IChatProgressResponseContent =
 	| IChatClearToPreviousToolInvocation
 	| IChatMcpServersStarting
 	| IChatMcpServersStartingSerialized
-	| IChatDisabledClaudeHooksPart;
+	| IChatDisabledClaudeHooksPart
+	| IChatGenerativeUIInset;
+
+export interface IChatGenerativeUIInset {
+	kind: 'generativeUIRuntimeInset';
+	surfaceId: string;
+	/** Resource URI of the bundled a2ui-runtime asset to load into the inset webview. */
+	runtimeUri: URI;
+	/** Optional initial A2UI document to RENDER once the inset signals READY. */
+	initialDoc?: unknown;
+	version: number;
+}
 
 export type IChatProgressResponseContentSerialized = Exclude<IChatProgressResponseContent,
 	| IChatToolInvocation
@@ -617,6 +628,7 @@ class AbstractResponse implements IResponse {
 				case 'planReview':
 				case 'disabledClaudeHooks':
 				case 'autoModeResolution':
+				case 'generativeUIRuntimeInset':
 					// Ignore
 					continue;
 				case 'toolInvocation':

--- a/src/vs/workbench/contrib/chat/common/model/chatSessionOperationLog.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatSessionOperationLog.ts
@@ -63,6 +63,7 @@ const responsePartSchema = Adapt.v<IChatProgressResponseContent, SerializedChatR
 				case 'multiDiffData':
 				case 'mcpServersStarting':
 				case 'thinking':
+				case 'generativeUIRuntimeInset':
 					return objectsEqual(a, b);
 
 				// Static types that won't change after being pushed can use strict equality.

--- a/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
@@ -16,7 +16,7 @@ import { IChatRequestVariableEntry } from '../attachments/chatVariableEntries.js
 import { ChatAgentVoteDirection, ChatRequestQueueKind, IChatCodeCitation, IChatContentReference, IChatDisabledClaudeHooksPart, IChatFollowup, IChatMcpServersStarting, IChatPlanReview, IChatProgressMessage, IChatQuestionCarousel, IChatResponseErrorDetails, IChatTask, IChatUsage, IChatUsedContext } from '../chatService/chatService.js';
 import { getFullyQualifiedId, IChatAgentCommand, IChatAgentData, IChatAgentNameService, IChatAgentResult } from '../participants/chatAgents.js';
 import { IParsedChatRequest } from '../requestParser/chatParserTypes.js';
-import { IChatModel, IChatProgressRenderableResponseContent, IChatRequestDisablement, IChatRequestModel, IChatResponseModel, IChatTextEditGroup, IResponse } from './chatModel.js';
+import { IChatGenerativeUIInset, IChatModel, IChatProgressRenderableResponseContent, IChatRequestDisablement, IChatRequestModel, IChatResponseModel, IChatTextEditGroup, IResponse } from './chatModel.js';
 import { ChatStreamStatsTracker, IChatStreamStats } from './chatStreamStats.js';
 import { countWords } from './chatWordCounter.js';
 
@@ -203,7 +203,7 @@ export interface IChatChangesSummaryPart {
 /**
  * Type for content parts rendered by IChatListRenderer (not necessarily in the model)
  */
-export type IChatRendererContent = IChatProgressRenderableResponseContent | IChatReferences | IChatCodeCitations | IChatErrorDetailsPart | IChatChangesSummaryPart | IChatWorkingProgress | IChatMcpServersStarting | IChatQuestionCarousel | IChatPlanReview | IChatDisabledClaudeHooksPart;
+export type IChatRendererContent = IChatProgressRenderableResponseContent | IChatReferences | IChatCodeCitations | IChatErrorDetailsPart | IChatChangesSummaryPart | IChatWorkingProgress | IChatMcpServersStarting | IChatQuestionCarousel | IChatPlanReview | IChatDisabledClaudeHooksPart | IChatGenerativeUIInset;
 
 export interface IChatResponseViewModel {
 	readonly model: IChatResponseModel;

--- a/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
@@ -684,6 +684,15 @@ declare module 'vscode' {
 		 */
 		updateToolInvocation(toolCallId: string, streamData: ChatToolInvocationStreamData): void;
 
+		/**
+		 * Render a generative UI inset backed by an A2UI runtime asset.
+		 * @param surfaceId Identifier correlating this inset with later updates.
+		 * @param runtimeUri Resource URI of the bundled a2ui-runtime asset to load into the inset webview.
+		 * @param initialDoc Optional initial A2UI document to render once the inset signals ready.
+		 * @param version Schema/runtime version for the inset. Defaults to `1`.
+		 */
+		generativeUI(surfaceId: string, runtimeUri: Uri, initialDoc?: object, version?: number): void;
+
 		push(part: ExtendedChatResponsePart): void;
 
 		clearToPreviousToolInvocation(reason: ChatResponseClearToPreviousToolInvocationReason): void;


### PR DESCRIPTION
> **Experimental — sharing for feedback and discussion.** These are the **core enabling primitives** for an inline generative-UI feature whose logic lives in a companion `microsoft/vscode-copilot-chat` PR; this side is intentionally a generic, business-logic-free pipe. Feedback welcome and happy to iterate toward merge — or use any part of it however's useful.

## What this adds

Primitives that let a chat participant render an **interactive webview surface inside a chat message bubble** and exchange messages with it — used by a companion extension PR to render agent-authored "A2UI" documents and stream live MCP data.

All A2UI/MCP semantics live in the extension; core stays a dumb, reusable transport.

## Try it / where to start (developer kit)

Everything you need to understand and use this lives in the runtime repo — **[MichaelDanCurtis/a2ui-runtime](https://github.com/MichaelDanCurtis/a2ui-runtime)**:

- **Guide & full component reference** — the repo `README.md` + `docs/` (document format, every component + props, the binding model, the four capabilities, extending the catalog, and the security model).
- **Typed authoring SDK** — compose documents in code with autocomplete, e.g. `doc(card({ title: 'Sales' }, chart({ kind: 'area', bind: 'series' })))`, instead of hand-writing JSON.
- **Live examples gallery** — `npm install && npm run build`, then open `gallery/index.html` to see every component plus the interaction round-trip, live data, and panel/multi-view features rendering (no VS Code needed).

To exercise the whole feature end-to-end inside VS Code, pair this PR with the companion extension PR (linked below).

## Changes (core)

- **`ChatGenerativeUIInsetPart`** (`chatContentParts/chatGenerativeUIInsetPart.ts`) — a chat content part that hosts an `IWebviewElement` inside a bubble: loads an extension-provided runtime asset, relays messages in/out, tracks intrinsic height, applies a strict CSP (`default-src 'none'`; script only from the webview source; `img-src https: data:`). Adapted from the existing `ChatMcpAppModel` webview-inset pattern.
- **Transport registry + commands** (`chatGenerativeUIInsetRegistry.ts`) — `_a2ui.postToSurface` (host → inset, by surfaceId) and the extension-registered `_a2ui.routeInteraction` (inset → extension). Internal, underscore-prefixed.
- **`generativeUI` on `chatParticipantAdditions`** — rides the existing enabled proposal rather than inventing a new one; the chat model carries a `generativeUIRuntimeInset` content part through the ext-host DTO → main-thread → view-model → renderer chain.
- **State persistence + replay** — the registry records the latest `RENDER` + ordered `STATE_DELTA`s per surface so the inset survives the chat list disposing/recreating its row on scroll (replays full state on each webview `READY`; stable per-surface webview origin). Fixes a blank-after-scroll regression.

## Companion PR

The consumer (the `render_a2ui` tool, surface manager, MCP pipe, panel host) is in **microsoft/vscode-copilot-chat** (linked in a comment). The webview runtime this loads — component catalog, typed authoring SDK, and a live examples gallery — lives at **[MichaelDanCurtis/a2ui-runtime](https://github.com/MichaelDanCurtis/a2ui-runtime)**.

## Notes

`npm run typecheck-client` clean for the changed files. Rebased onto current `main` — mergeable, no conflicts. Shared as a working reference for the inset/transport approach; feedback and iteration welcome.
