### PR TITLE
Fix compact chat response summary styling

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -3045,7 +3045,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .chat-file-changes-label {
-	color: var(--vscode-interactive-session-foreground);
 	user-select: none;
 }
 

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
@@ -59,8 +59,8 @@
 }
 
 /* List / tree rows (including the notification center list rows) */
-.style-override .monaco-list .monaco-list-row,
-.style-override .notifications-list-container .monaco-list-row {
+.style-override .monaco-list .monaco-list-row:not(.separator),
+.style-override .notifications-list-container .monaco-list-row:not(.separator) {
 	border-radius: var(--vscode-cornerRadius-small) !important;
 }
 
@@ -231,4 +231,3 @@
 .style-override .monaco-sash:not(.disabled) > .orthogonal-drag-handle {
 	border-radius: var(--vscode-sash-size);
 }
-


### PR DESCRIPTION
## Summary

- keep action widget separator rows flat when the Modern UI rounded-corners override is enabled
- use the faded chat header foreground for the file-change summary and brighten it on hover or keyboard focus

## Testing

- targeted hygiene/stylelint
- `git diff --check`
- verified the file-change label inherits `descriptionForeground` normally and `foreground` on hover/focus
- verified separator rows are excluded without changing interactive list-row styling