### PR TITLE
Populate turn timings for agent-host providers

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -15,6 +15,7 @@ import { ResourceMap } from '../../../../../../base/common/map.js';
 import { equals } from '../../../../../../base/common/objects.js';
 import { autorun, autorunPerKeyedItem, derived, IObservable, ISettableObservable, observableValue, transaction } from '../../../../../../base/common/observable.js';
 import { extUriBiasedIgnorePathCase, isEqual } from '../../../../../../base/common/resources.js';
+import { StopWatch } from '../../../../../../base/common/stopwatch.js';
 import { Mutable } from '../../../../../../base/common/types.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { IPosition } from '../../../../../../editor/common/core/position.js';
@@ -180,6 +181,15 @@ function userOriginMessage(text: string, attachments: readonly MessageAttachment
  */
 function lastTurnModelSelection(state: ISessionWithDefaultChat | undefined): ModelSelection | undefined {
 	return lastTurnMessage(state)?.model;
+}
+
+/**
+ * Whether a progress emission counts as the turn's first visible progress
+ * for time-to-first-progress telemetry. Mirrors the agent host's own
+ * definition (text delta, response part, tool call start, or reasoning).
+ */
+function isFirstVisibleProgressPart(part: IChatProgress): boolean {
+	return part.kind === 'markdownContent' || part.kind === 'thinking' || part.kind === 'toolInvocation';
 }
 
 function lastTurnMessage(state: ISessionWithDefaultChat | undefined): Message | undefined {
@@ -1124,11 +1134,27 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			}
 		}
 
-		const completedTurn = await this._handleTurn(resolvedSession, request, progress, cancellationToken);
+		// Measure turn timings on the workbench side so the core
+		// `interactiveSessionProviderInvoked` telemetry event is populated for
+		// agent-host providers. `firstProgress` mirrors the agent host's own
+		// "first visible progress" definition (text delta, response part, tool
+		// call start, or reasoning), which maps to `markdownContent`, `thinking`,
+		// and `toolInvocation` parts on this side.
+		const stopWatch = StopWatch.create(false);
+		let firstProgress: number | undefined;
+		const measuredProgress = (parts: IChatProgress[]) => {
+			if (firstProgress === undefined && parts.some(isFirstVisibleProgressPart)) {
+				firstProgress = stopWatch.elapsed();
+			}
+			progress(parts);
+		};
+
+		const completedTurn = await this._handleTurn(resolvedSession, request, measuredProgress, cancellationToken);
 		const details = this._getTurnResponseDetails(request.sessionResource, resolvedSession, completedTurn);
 		const errorDetails = this._getTurnErrorDetails(completedTurn);
 
 		return {
+			timings: { firstProgress, totalElapsed: stopWatch.elapsed() },
 			...(details ? { details } : {}),
 			...(errorDetails ? { errorDetails } : {}),
 		};

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -1134,12 +1134,8 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			}
 		}
 
-		// Measure turn timings on the workbench side so the core
-		// `interactiveSessionProviderInvoked` telemetry event is populated for
-		// agent-host providers. `firstProgress` mirrors the agent host's own
-		// "first visible progress" definition (text delta, response part, tool
-		// call start, or reasoning), which maps to `markdownContent`, `thinking`,
-		// and `toolInvocation` parts on this side.
+		// Measure turn timings so the core `interactiveSessionProviderInvoked`
+		// telemetry event is populated for agent-host providers.
 		const stopWatch = StopWatch.create(false);
 		let firstProgress: number | undefined;
 		const measuredProgress = (parts: IChatProgress[]) => {


### PR DESCRIPTION
## Problem

The core `interactiveSessionProviderInvoked` telemetry event had **null** `timeToFirstProgress` and `totalTime` for all agent-host providers (`agent-host-copilotcli`, `agent-host-claude`, `agent-host-codex`).

Core reads these from `rawResult.timings` (see [`chatServiceImpl.ts`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts#L1597)):

```ts
timeToFirstProgress: rawResult.timings?.firstProgress,
totalTime: rawResult.timings?.totalElapsed,
```

Normal extension chat agents supply those timings via `ChatAgentResponseStream`. But agent-host sessions are served by `AgentHostSessionHandler._invokeAgent`, which returned an `IChatAgentResult` with **no `timings`** — so both fields were undefined on success/error turns. (`totalTime` only appeared on *cancelled* turns, where core measures it independently with its own stopwatch.)

## Fix

Measure the turn on the workbench side in `AgentHostSessionHandler._invokeAgent`:

- A `StopWatch` wraps the `progress` sink to record `firstProgress` on the first **visible** part — `markdownContent`, `thinking`, or `toolInvocation` — mirroring the agent host's own "first visible progress" definition (text delta / response part / tool-call start / reasoning) used by its `agentHost.turnCompleted` telemetry.
- `totalElapsed` is captured at turn completion.
- The result now returns `{ timings: { firstProgress, totalElapsed } }`.

`StopWatch.create(false)` (ms resolution) is used to match the two sibling turn timers that feed the same metric (`ChatAgentResponseStream` and `AgentHostTurnTracker`).

## Verification

Verified end-to-end by launching the Agents window from sources and driving a real `agent-host-claude` turn, then reading the emitted `interactiveSessionProviderInvoked` event from the telemetry log:

```json
{
  "agent": "agent-host-claude",
  "sessionType": "agent-host-claude",
  "result": "success",
  "timeToFirstProgress": 6616,
  "totalTime": 6644
}
```

Both fields are now populated. `copilotcli` and `codex` flow through the identical `_invokeAgent` path.

## Notes

- Draft: a focused unit test is still a good follow-up (extracting the timing logic into a small `TurnTimer` with an injectable clock would make it testable without the handler's heavy dependency surface).
