### PR TITLE
Include Agent Host Copilot in session provider filter

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatContext.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContext.ts
@@ -337,7 +337,7 @@ class SessionReferenceContextPickerPick implements IChatContextPickerItem {
 			placeholder: localize('chatContext.sessions.placeholder', 'Select a session'),
 			picks: (async () => {
 				const picks: IChatContextPickerPickItem[] = [];
-				const sessionProviderFilter = [AgentSessionProviders.Local, AgentSessionProviders.Background, AgentSessionProviders.Claude];
+				const sessionProviderFilter = [AgentSessionProviders.Local, AgentSessionProviders.Background, AgentSessionProviders.Claude, AgentSessionProviders.AgentHostCopilot];
 				for await (const group of this._chatSessionsService.getChatSessionItems(sessionProviderFilter, CancellationToken.None)) {
 					const providerIcon = getAgentSessionProviderIcon(group.chatSessionType);
 					for (const item of group.items) {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
@@ -993,7 +993,7 @@ class BuiltinDynamicCompletions extends Disposable {
 				// User has typed #session: — fetch all sessions and show them inline
 				const allSessions: { title: string; sessionResource: URI; lastMessageDate: number; icon: ThemeIcon }[] = [];
 
-				const sessionProviderFilter = [AgentSessionProviders.Local, AgentSessionProviders.Background, AgentSessionProviders.Claude];
+				const sessionProviderFilter = [AgentSessionProviders.Local, AgentSessionProviders.Background, AgentSessionProviders.Claude, AgentSessionProviders.AgentHostCopilot];
 				for await (const group of this.chatSessionsService.getChatSessionItems(sessionProviderFilter, token)) {
 					if (token.isCancellationRequested) {
 						return;


### PR DESCRIPTION
Part of: https://github.com/microsoft/vscode/issues/315193

- Add `AgentSessionProviders.AgentHostCopilot` to the `sessionProviderFilter` used by the session-reference attachment picker so Agent Host Copilot sessions appear alongside Local, Background, and Claude.
- Add the same provider to the `#session:` completion provider filter so Agent Host Copilot sessions are offered inline when typing `#session:`.
- Keep the existing provider ordering and append `AgentHostCopilot` last so the other providers' positions are preserved.

-----------------------------------------
Inspirations from:

- The `sessionProviderFilter` shape and the picker iteration it feeds come from the session-reference picker in [`chatContext.ts`](https://github.com/microsoft/vscode/blob/6ca57e423245f0c69d60b4004283cc34a1157187/src/vs/workbench/contrib/chat/browser/actions/chatContext.ts#L340-L341).
- The matching `#session:` completion filter that this change keeps aligned comes from [`chatInputCompletions.ts`](https://github.com/microsoft/vscode/blob/6ca57e423245f0c69d60b4004283cc34a1157187/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts#L996-L997).
- The `AgentHostCopilot` provider member comes from [`AgentSessionProviders`](https://github.com/microsoft/vscode/blob/6ca57e423245f0c69d60b4004283cc34a1157187/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts#L22), backed by [`SessionType.AgentHostCopilot`](https://github.com/microsoft/vscode/blob/6ca57e423245f0c69d60b4004283cc34a1157187/src/vs/workbench/contrib/chat/common/chatSessionsService.ts#L313).
