### PR TITLE
sessions: add browser-style chat tab keybindings (Cmd+T, Cmd+Shift+T, Delete)

### DIFF
--- a/src/vs/sessions/contrib/layout/test/browser/layoutControllerTestUtils.ts
+++ b/src/vs/sessions/contrib/layout/test/browser/layoutControllerTestUtils.ts
@@ -100,6 +100,7 @@ export function makeSession(resource: URI, opts?: {
 		sticky: observableValue('sticky', false),
 		openChats: observableValue('openChats', [chat]),
 		closedChats: constObservable([]),
+		lastClosedChat: undefined,
 		visibleChatTabs: constObservable([chat]),
 	};
 }

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostSkillButtons.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostSkillButtons.test.ts
@@ -69,6 +69,7 @@ function makeActiveSession(providerId: string): IActiveSession {
 		sticky: observableValue('sticky', false),
 		openChats: observableValue('openChats', [chat]),
 		closedChats: constObservable([]),
+		lastClosedChat: undefined,
 		visibleChatTabs: constObservable([chat]),
 	} satisfies IActiveSession;
 }

--- a/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsActions.ts
@@ -15,6 +15,7 @@ import { localize, localize2 } from '../../../../nls.js';
 import { Action2, MenuRegistry, MenuId, registerAction2, MenuItemAction } from '../../../../platform/actions/common/actions.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { InputFocusedContext } from '../../../../platform/contextkey/common/contextkeys.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
@@ -396,6 +397,13 @@ registerAction2(class CloseAllSessionsAction extends Action2 {
 	}
 });
 
+// -- Chat tab navigation, new chat, & close (within the active session's tab strip) --
+
+// These chords sit just above the session-level navigation/close commands so
+// they win while a multi-chat session is focused, falling back to the
+// session-level commands when the tab strip is not shown.
+const CHAT_TAB_KEYBINDING_WEIGHT = KeybindingWeight.SessionsContrib + 10;
+
 // "New Chat" starts a new chat. Hidden once the session has more than one open
 // chat, since the chat tab strip then offers New Chat at the end of the tabs.
 const ADD_CHAT_TO_SESSION_ACTION_ID = 'sessions.chatCompositeBar.addChat';
@@ -406,6 +414,14 @@ registerAction2(class AddChatToSessionAction extends Action2 {
 			id: ADD_CHAT_TO_SESSION_ACTION_ID,
 			title: localize2('chatCompositeBar.addChat', "New Chat"),
 			icon: Codicon.add,
+			keybinding: {
+				weight: CHAT_TAB_KEYBINDING_WEIGHT,
+				// Like Cmd/Ctrl+T in a browser — opens a new chat tab within the
+				// active session. Scoped so it does not steal the shortcut outside
+				// the agents window or when the session does not support multiple chats.
+				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated(), SessionIsCreatedContext, SessionSupportsMultipleChatsContext, SessionIsArchivedContext.negate()),
+				primary: KeyMod.CtrlCmd | KeyCode.KeyT,
+			},
 			menu: {
 				id: Menus.SessionBarToolbar,
 				group: 'navigation',
@@ -415,23 +431,19 @@ registerAction2(class AddChatToSessionAction extends Action2 {
 		});
 	}
 
-	override async run(accessor: ServicesAccessor, session: IActiveSession | undefined): Promise<void> {
-		if (!session) {
-			return;
-		}
+	override async run(accessor: ServicesAccessor, session?: IActiveSession): Promise<void> {
 		const sessionsService = accessor.get(ISessionsService);
 		const sessionsPartService = accessor.get(ISessionsPartService);
-		await sessionsService.openNewChatInSession(session);
-		sessionsPartService.focusSession(session);
+		// From the menu: session is forwarded as context. From the keybinding:
+		// fall back to the active session.
+		const target = session ?? sessionsService.activeSession.get();
+		if (!target) {
+			return;
+		}
+		await sessionsService.openNewChatInSession(target);
+		sessionsPartService.focusSession(target);
 	}
 });
-
-// -- Chat tab navigation & close (within the active session's tab strip) --
-
-// These chords sit just above the session-level navigation/close commands so
-// they win while a multi-chat session is focused, falling back to the
-// session-level commands when the tab strip is not shown.
-const CHAT_TAB_KEYBINDING_WEIGHT = KeybindingWeight.SessionsContrib + 10;
 
 function navigateChatTab(accessor: ServicesAccessor, direction: 'next' | 'previous'): void {
 	const sessionsService = accessor.get(ISessionsService);
@@ -555,7 +567,77 @@ registerAction2(class CloseChatAction extends Action2 {
 	}
 });
 
-// -- Show Chats Picker (chats within the active session) --
+registerAction2(class DeleteChatAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessions.chatCompositeBar.deleteChat',
+			title: localize2('deleteActiveChat', "Delete Chat"),
+			f1: true,
+			category: SessionsCategories.Sessions,
+			keybinding: {
+				weight: CHAT_TAB_KEYBINDING_WEIGHT,
+				// Delete / Cmd+Backspace (Mac) — mirrors the file-delete keybinding
+				// in the Explorer. Scoped so it never fires while typing in an input
+				// (chat composer, rename field, etc.) or on the session's main chat.
+				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated(), InputFocusedContext.toNegated(), SessionActiveChatIsClosableContext),
+				primary: KeyCode.Delete,
+				mac: {
+					primary: KeyMod.CtrlCmd | KeyCode.Backspace,
+					secondary: [KeyCode.Delete],
+				},
+			},
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const sessionsService = accessor.get(ISessionsService);
+		const sessionsManagementService = accessor.get(ISessionsManagementService);
+		const extUri = accessor.get(IUriIdentityService).extUri;
+		const session = sessionsService.activeSession.get();
+		if (!session) {
+			return;
+		}
+		const chat = session.activeChat.get();
+		if (!chat || extUri.isEqual(chat.resource, session.mainChat.get().resource)) {
+			return;
+		}
+		await sessionsManagementService.deleteChat(session, chat.resource);
+	}
+});
+
+registerAction2(class ReopenLastClosedChatAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessions.chatCompositeBar.reopenLastClosedChat',
+			title: localize2('chatCompositeBar.reopenLastClosedChat', "Reopen Last Closed Chat"),
+			f1: true,
+			category: SessionsCategories.Sessions,
+			precondition: SessionSupportsMultipleChatsContext,
+			keybinding: {
+				weight: CHAT_TAB_KEYBINDING_WEIGHT,
+				// Like Cmd/Ctrl+Shift+T in a browser — reopens the most recently
+				// closed chat tab. Scoped to the agents window, outside editor area.
+				when: ContextKeyExpr.and(IsSessionsWindowContext, EditorAreaFocusContext.toNegated(), SessionIsCreatedContext, SessionSupportsMultipleChatsContext),
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyT,
+			},
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const sessionsService = accessor.get(ISessionsService);
+		const sessionsPartService = accessor.get(ISessionsPartService);
+		const session = sessionsService.activeSession.get();
+		if (!session) {
+			return;
+		}
+		const lastClosed = session.lastClosedChat;
+		if (!lastClosed) {
+			return;
+		}
+		await sessionsService.openChat(session, lastClosed.resource);
+		sessionsPartService.focusSession(session);
+	}
+});
 
 // A no-input quick pick (pure switcher) over the active session's open chats,
 // each shown with a chat icon. Driven by Ctrl+Tab / Ctrl+Shift+Tab in

--- a/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
+++ b/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
@@ -125,6 +125,7 @@ function makeAgentSession(opts: {
 		sticky: observableValue('test.sticky', false),
 		openChats: observableValue('test.openChats', [chat]),
 		closedChats: constObservable([]),
+		lastClosedChat: undefined,
 		visibleChatTabs: constObservable([chat]),
 	} satisfies TestActiveSession;
 	return session;

--- a/src/vs/sessions/services/sessions/browser/visibleSessions.ts
+++ b/src/vs/sessions/services/sessions/browser/visibleSessions.ts
@@ -136,7 +136,17 @@ export class VisibleSession extends Disposable implements IActiveSession {
 	}
 
 	get lastClosedChat(): IChat | undefined {
-		return this._closedChatOrder.at(-1);
+		// Filter out stale entries whose chat has since been deleted from the session.
+		const currentChats = this._session.chats.get();
+		const closed = this._closedChatUris.get();
+		for (let i = this._closedChatOrder.length - 1; i >= 0; i--) {
+			const chat = this._closedChatOrder[i];
+			const uri = chat.resource.toString();
+			if (closed.has(uri) && currentChats.some(c => c.resource.toString() === uri)) {
+				return chat;
+			}
+		}
+		return undefined;
 	}
 
 	setSticky(value: boolean): void {

--- a/src/vs/sessions/services/sessions/browser/visibleSessions.ts
+++ b/src/vs/sessions/services/sessions/browser/visibleSessions.ts
@@ -43,6 +43,8 @@ export class VisibleSession extends Disposable implements IActiveSession {
 
 	/** Resource strings of chats that have been closed (hidden from the tab strip). */
 	private readonly _closedChatUris: ISettableObservable<ReadonlySet<string>>;
+	/** Append-only list tracking close order; last element is the most recently closed. */
+	private readonly _closedChatOrder: IChat[] = [];
 	readonly openChats: IObservable<readonly IChat[]>;
 	readonly closedChats: IObservable<readonly IChat[]>;
 	readonly visibleChatTabs: IObservable<readonly IChat[]>;
@@ -108,6 +110,7 @@ export class VisibleSession extends Disposable implements IActiveSession {
 		}
 		const next = new Set(closed);
 		next.add(chatUri);
+		this._closedChatOrder.push(chat);
 		transaction(tx => {
 			this._closedChatUris.set(next, tx);
 			// If the closed chat was active, fall back to another open chat.
@@ -126,6 +129,14 @@ export class VisibleSession extends Disposable implements IActiveSession {
 		const next = new Set(closed);
 		next.delete(chat.resource.toString());
 		this._closedChatUris.set(next, undefined);
+		const idx = this._closedChatOrder.findLastIndex(c => c.resource.toString() === chat.resource.toString());
+		if (idx !== -1) {
+			this._closedChatOrder.splice(idx, 1);
+		}
+	}
+
+	get lastClosedChat(): IChat | undefined {
+		return this._closedChatOrder.at(-1);
 	}
 
 	setSticky(value: boolean): void {

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -119,6 +119,9 @@ export interface IActiveSession extends ISession {
 	/** The closed (hidden from the tab strip) but still reopenable chats. Deleted chats drop out. */
 	readonly closedChats: IObservable<readonly IChat[]>;
 
+	/** The most recently closed chat, or `undefined` if none. */
+	readonly lastClosedChat: IChat | undefined;
+
 	/**
 	 * The chats shown as tabs in the tab strip: {@link openChats} with tool-origin
 	 * chats (subagents) hidden, in the provider's order.

--- a/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
@@ -123,6 +123,7 @@ class MockSessionStore implements ISessionsManagementService {
 				activeChat: observableValue<IChat>(`test.activeChat-${session.sessionId}`, activeChat),
 				openChats: session.chats,
 				closedChats: constObservable([]),
+				lastClosedChat: undefined,
 				visibleChatTabs: session.chats,
 			};
 			this.activeSession.set(active, undefined);

--- a/src/vs/sessions/services/sessions/test/browser/sessionsListModelService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsListModelService.test.ts
@@ -390,7 +390,7 @@ suite('SessionsListModelService', () => {
 		service.markRead(session);
 
 		// Make session the active one
-		activeSession.set({ ...session, activeChat: constObservable(session.mainChat.get()), isCreated: constObservable(true), sticky: constObservable(false), openChats: session.chats, closedChats: constObservable([]), visibleChatTabs: session.chats }, undefined);
+		activeSession.set({ ...session, activeChat: constObservable(session.mainChat.get()), isCreated: constObservable(true), sticky: constObservable(false), openChats: session.chats, closedChats: constObservable([]), lastClosedChat: undefined, visibleChatTabs: session.chats }, undefined);
 
 		// Seed the last-known status as InProgress
 		sessionsChangedEmitter.fire({ added: [], removed: [], changed: [session] });

--- a/src/vs/sessions/services/sessions/test/browser/visibleSessions.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/visibleSessions.test.ts
@@ -1022,6 +1022,50 @@ suite('VisibleSession - open/close chats', () => {
 			active: 'main',
 		});
 	});
+
+	test('lastClosedChat returns the most recently closed chat regardless of creation order', () => {
+		// B was created before C, but if C is closed first and then B,
+		// lastClosedChat should return B (not C, which closedChats.at(-1) would wrongly give).
+		const [main, b, c] = [makeChat('main'), makeChat('b'), makeChat('c')];
+		const { visible } = createSession([main, b, c]);
+
+		visible.closeChat(c); // close C first
+		visible.closeChat(b); // close B last
+
+		assert.strictEqual(visible.lastClosedChat?.title.get(), 'b');
+	});
+
+	test('lastClosedChat updates after reopening the last-closed chat', () => {
+		const [main, b, c] = [makeChat('main'), makeChat('b'), makeChat('c')];
+		const { visible } = createSession([main, b, c]);
+
+		visible.closeChat(b);
+		visible.closeChat(c);
+		assert.strictEqual(visible.lastClosedChat?.title.get(), 'c');
+
+		visible.openChat(c); // reopen C — B is now the last closed
+		assert.strictEqual(visible.lastClosedChat?.title.get(), 'b');
+	});
+
+	test('lastClosedChat returns undefined when no chats are closed', () => {
+		const [main, b] = [makeChat('main'), makeChat('b')];
+		const { visible } = createSession([main, b]);
+
+		assert.strictEqual(visible.lastClosedChat, undefined);
+	});
+
+	test('lastClosedChat skips deleted chats and returns the next valid one', () => {
+		const [main, b, c] = [makeChat('main'), makeChat('b'), makeChat('c')];
+		const { visible, chatsObs } = createSession([main, b, c]);
+
+		visible.closeChat(b);
+		visible.closeChat(c);
+		// Delete C from the session (simulates permanent deletion)
+		chatsObs.set([main, b], undefined);
+
+		// C is gone; lastClosedChat should fall back to B
+		assert.strictEqual(visible.lastClosedChat?.title.get(), 'b');
+	});
 });
 
 suite('VisibleSession - visibleChatTabs', () => {


### PR DESCRIPTION
## Summary

Adds three keybindings to the Agents window that mirror familiar browser tab management shortcuts:

| Shortcut | Action |
|---|---|
| `Cmd+T` / `Ctrl+T` | **New Chat** — opens a new chat within the active session |
| `Cmd+Shift+T` / `Ctrl+Shift+T` | **Reopen Last Closed Chat** — reopens the most recently closed chat tab |
| `Delete` / `Cmd+Backspace` (Mac) | **Delete Chat** — permanently deletes the active non-main chat (with confirmation) |

## Implementation Details

- All keybindings are scoped to `IsSessionsWindowContext && !EditorAreaFocusContext` so they only fire in the Agents window outside the editor area.
- `Cmd+T` additionally requires `SessionSupportsMultipleChatsContext` and `!SessionIsArchivedContext`.
- `Delete`/`Cmd+Backspace` additionally requires `InputFocusedContext.toNegated()` to prevent accidental deletion while typing in the chat composer or any input field.
- `CHAT_TAB_KEYBINDING_WEIGHT` was moved before `AddChatToSessionAction` so it can be shared by all tab-management actions.
- **Reopen Last Closed Chat correctness**: `closedChats` is ordered by chat creation order, not close time. Added `_closedChatOrder: IChat[]` to `VisibleSession` (appended on close, spliced on reopen) and exposed `lastClosedChat` on `IActiveSession` so the reopen action always targets the truly most-recently-closed chat.
- **New Chat fallback**: `AddChatToSessionAction.run` now falls back to `activeSession` when invoked via keybinding (no session context arg), matching the pattern used by `CloseChatAction`.