### PR TITLE
agentHost: Show background agents as complete

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotSystemNotification.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSystemNotification.ts
@@ -50,7 +50,7 @@ export function buildCopilotSystemNotification(event: SessionEventPayload<'syste
 		case 'agent_idle':
 			return {
 				content,
-				messageText: localize('agentHost.copilot.systemNotification.agentIdle', "Background agent {0} is idle", kind.agentId),
+				messageText: localize('agentHost.copilot.systemNotification.agentIdle', "Background agent {0} is complete", kind.agentId),
 				startsTurn: true,
 			};
 		case 'new_inbox_message':

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -2006,7 +2006,7 @@ suite('CopilotAgentSession', () => {
 				},
 			}), {
 				content: 'Agent idle',
-				messageText: 'Background agent agent-a is idle',
+				messageText: 'Background agent agent-a is complete',
 				startsTurn: true,
 			});
 
@@ -2077,7 +2077,7 @@ suite('CopilotAgentSession', () => {
 				responseTurnId: (getActions(signals).find(a => a.type === ActionType.ChatResponsePart && a.part.kind === ResponsePartKind.Markdown) as ChatResponsePartAction | undefined)?.turnId,
 				completedTurnId: (getActions(signals).find(a => a.type === ActionType.ChatTurnComplete) as ChatTurnCompleteAction | undefined)?.turnId,
 			}, {
-				message: { text: 'Background agent agent-a is idle', origin: { kind: MessageKind.SystemNotification } },
+				message: { text: 'Background agent agent-a is complete', origin: { kind: MessageKind.SystemNotification } },
 				responseTurnId: turnStarted.turnId,
 				completedTurnId: turnStarted.turnId,
 			});


### PR DESCRIPTION
## Summary
- change the synthesized turn-start message for `agent_idle` notifications from "is idle" to "is complete"
- preserve the SDK-provided notification content shown inside an already-active turn
- update the direct system notification expectations

## Validation
- `npm run typecheck-client`
- `./scripts/test.sh --runGlob '**/copilotAgentSession.test.js' --grep 'system.notification'` (7 passing)\n- `npm run valid-layers-check`\n- `npm run precommit`\n- targeted ESLint on the changed files\n\n(Written by Copilot)