### PR TITLE
Automations PR 2 (Runner)

### DIFF
--- a/src/vs/sessions/contrib/automations/browser/automationRunner.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationRunner.ts
@@ -1,0 +1,153 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { localize } from '../../../../nls.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { AutomationRunTrigger, IAutomation } from '../../../../workbench/contrib/chat/common/automations/automation.js';
+import { IAutomationRunner } from '../../../../workbench/contrib/chat/common/automations/automationRunner.js';
+import { IAutomationService } from '../../../../workbench/contrib/chat/common/automations/automationService.js';
+import { publishAutomationRun, publishAutomationRunError } from '../../../../workbench/contrib/chat/common/automations/automationTelemetry.js';
+import { ICreateNewSessionOptions, ISendRequestOptions, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+
+/**
+ * Sessions-layer runner that turns an automation kickoff into a chat session.
+ * The run row records the kickoff only — the session runs independently thereafter.
+ * Token is re-checked post-send so mid-flight cancellations surface as `failed`, not `completed`.
+ * Never throws; failures are recorded on the run row.
+ */
+export class AutomationRunner implements IAutomationRunner {
+
+	declare readonly _serviceBrand: undefined;
+
+	constructor(
+		@IAutomationService private readonly automationService: IAutomationService,
+		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
+		@ILogService private readonly logService: ILogService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
+		@INotificationService private readonly notificationService: INotificationService,
+	) { }
+
+	async runOnce(
+		automation: IAutomation,
+		trigger: AutomationRunTrigger,
+		leaderWindowId: number,
+		token: CancellationToken = CancellationToken.None,
+	): Promise<void> {
+		// Must not throw per IAutomationRunner contract; unexpected errors from the inner path are swallowed here.
+		try {
+			await this._runOnceInner(automation, trigger, leaderWindowId, token);
+		} catch (err) {
+			this.logService.error(`[AutomationRunner] unexpected error in runOnce for ${automation.id}`, err);
+		}
+	}
+
+	private async _runOnceInner(
+		automation: IAutomation,
+		trigger: AutomationRunTrigger,
+		leaderWindowId: number,
+		token: CancellationToken,
+	): Promise<void> {
+		if (this.automationService.getActiveRunFor(automation.id)) {
+			this.logService.trace(`[AutomationRunner] skipping ${automation.id}: active run already exists.`);
+			return;
+		}
+
+		const startTimeMs = Date.now();
+		let runId: string | undefined;
+		try {
+			const run = await this.automationService.recordRunStart(automation.id, trigger, leaderWindowId);
+			runId = run.id;
+			await this.automationService.updateRun(runId, { status: 'running' });
+
+			if (token.isCancellationRequested) {
+				await this._markCancelled(runId, trigger, automation, startTimeMs);
+				return;
+			}
+
+			const options: ISendRequestOptions = {
+				query: automation.prompt,
+				background: true,
+				source: 'automation',
+			};
+
+			const createOptions: ICreateNewSessionOptions | undefined = automation.providerId || automation.sessionTypeId || automation.modelId || automation.mode || automation.permissionLevel || automation.isolationMode || automation.branch
+				? {
+					providerId: automation.providerId,
+					sessionTypeId: automation.sessionTypeId,
+					modelId: automation.modelId,
+					modeId: automation.mode,
+					permissionLevel: automation.permissionLevel,
+					isolationMode: automation.isolationMode,
+					branch: automation.branch,
+				}
+				: undefined;
+
+			this.logService.trace(`[AutomationRunner] running ${automation.id}: provider=${createOptions?.providerId ?? '(default)'}, sessionType=${createOptions?.sessionTypeId ?? '(default)'}, model=${createOptions?.modelId ?? '(default)'}, mode=${createOptions?.modeId ?? '(default)'}, permissionLevel=${createOptions?.permissionLevel ?? '(default)'}`);
+
+			const session = await this.sessionsManagementService.createAndSendNewChatRequest(automation.folderUri, options, createOptions);
+
+			// Re-check cancellation post-send: a scheduler timeout/dispose
+			// that landed during the in-flight send should surface as
+			// `failed`/`Cancelled`, not `completed`. The session itself is
+			// already committed and continues independently — only the run
+			// row outcome is corrected here.
+			if (token.isCancellationRequested) {
+				await this._markCancelled(runId, trigger, automation, startTimeMs);
+				return;
+			}
+
+			if (session) {
+				try {
+					const chatUri = session.mainChat.get().resource;
+					const title = localize('automationRunner.sessionTitle', "{0}", automation.name);
+					await this.sessionsManagementService.renameChat(session, chatUri, title);
+				} catch (renameErr) {
+					this.logService.warn(`[AutomationRunner] renameChat failed for ${automation.id}`, renameErr);
+				}
+			}
+
+			await this.automationService.updateRun(runId, {
+				status: 'completed',
+				completedAt: new Date().toISOString(),
+				...(session ? { sessionId: session.sessionId } : {}),
+			});
+			publishAutomationRun(this.telemetryService, { trigger, automation, success: true, durationMs: Date.now() - startTimeMs });
+		} catch (err) {
+			this.logService.error(`[AutomationRunner] run for ${automation.id} failed`, err);
+			// Defensive: the error path must not propagate secondary failures to the outer caller.
+			try {
+				const errorMessage = err instanceof Error ? err.message : String(err);
+				this.notificationService.error(localize('automationRunFailed', "Automation '{0}' failed: {1}", automation.name, errorMessage));
+				if (runId) {
+					await this.automationService.updateRun(runId, {
+						status: 'failed',
+						completedAt: new Date().toISOString(),
+						errorMessage,
+					});
+				}
+				publishAutomationRun(this.telemetryService, { trigger, automation, success: false, durationMs: Date.now() - startTimeMs });
+				publishAutomationRunError(this.telemetryService, { trigger, automation });
+			} catch (innerErr) {
+				this.logService.error(`[AutomationRunner] error recording failure for ${automation.id}`, innerErr);
+			}
+		}
+	}
+
+	private async _markCancelled(runId: string, trigger: AutomationRunTrigger, automation: IAutomation, startTimeMs: number): Promise<void> {
+		try {
+			await this.automationService.updateRun(runId, {
+				status: 'failed',
+				completedAt: new Date().toISOString(),
+				errorMessage: localize('automationRunner.cancelled', "Cancelled"),
+			});
+			publishAutomationRun(this.telemetryService, { trigger, automation, success: false, durationMs: Date.now() - startTimeMs });
+		} catch (err) {
+			this.logService.error(`[AutomationRunner] error recording cancellation for ${automation.id}`, err);
+		}
+	}
+}

--- a/src/vs/sessions/contrib/automations/browser/automationRunner.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationRunner.ts
@@ -14,12 +14,7 @@ import { IAutomationService } from '../../../../workbench/contrib/chat/common/au
 import { publishAutomationRun, publishAutomationRunError } from '../../../../workbench/contrib/chat/common/automations/automationTelemetry.js';
 import { ICreateNewSessionOptions, ISendRequestOptions, ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 
-/**
- * Sessions-layer runner that turns an automation kickoff into a chat session.
- * The run row records the kickoff only — the session runs independently thereafter.
- * Token is re-checked post-send so mid-flight cancellations surface as `failed`, not `completed`.
- * Never throws; failures are recorded on the run row.
- */
+/** Sessions-layer runner. Never throws; failures are recorded on the run row. */
 export class AutomationRunner implements IAutomationRunner {
 
 	declare readonly _serviceBrand: undefined;
@@ -38,7 +33,7 @@ export class AutomationRunner implements IAutomationRunner {
 		leaderWindowId: number,
 		token: CancellationToken = CancellationToken.None,
 	): Promise<void> {
-		// Must not throw per IAutomationRunner contract; unexpected errors from the inner path are swallowed here.
+		// Must not throw per IAutomationRunner contract. Unexpected errors are swallowed here.
 		try {
 			await this._runOnceInner(automation, trigger, leaderWindowId, token);
 		} catch (err) {
@@ -60,6 +55,11 @@ export class AutomationRunner implements IAutomationRunner {
 		const startTimeMs = Date.now();
 		let runId: string | undefined;
 		try {
+			if (!this.automationService.getAutomation(automation.id)) {
+				this.logService.trace(`[AutomationRunner] skipping ${automation.id}: automation was deleted.`);
+				return;
+			}
+
 			const run = await this.automationService.recordRunStart(automation.id, trigger, leaderWindowId);
 			runId = run.id;
 			await this.automationService.updateRun(runId, { status: 'running' });
@@ -72,10 +72,10 @@ export class AutomationRunner implements IAutomationRunner {
 			const options: ISendRequestOptions = {
 				query: automation.prompt,
 				background: true,
-				source: 'automation',
+				title: automation.name?.substring(0, 100),
 			};
 
-			const createOptions: ICreateNewSessionOptions | undefined = automation.providerId || automation.sessionTypeId || automation.modelId || automation.mode || automation.permissionLevel || automation.isolationMode || automation.branch
+			const createOptions: ICreateNewSessionOptions | undefined = automation.providerId !== undefined || automation.sessionTypeId !== undefined || automation.modelId !== undefined || automation.mode !== undefined || automation.permissionLevel !== undefined || automation.isolationMode !== undefined || automation.branch !== undefined
 				? {
 					providerId: automation.providerId,
 					sessionTypeId: automation.sessionTypeId,
@@ -91,24 +91,10 @@ export class AutomationRunner implements IAutomationRunner {
 
 			const session = await this.sessionsManagementService.createAndSendNewChatRequest(automation.folderUri, options, createOptions);
 
-			// Re-check cancellation post-send: a scheduler timeout/dispose
-			// that landed during the in-flight send should surface as
-			// `failed`/`Cancelled`, not `completed`. The session itself is
-			// already committed and continues independently — only the run
-			// row outcome is corrected here.
+			// Re-check cancellation post-send so mid-flight timeouts surface as `failed`.
 			if (token.isCancellationRequested) {
 				await this._markCancelled(runId, trigger, automation, startTimeMs);
 				return;
-			}
-
-			if (session) {
-				try {
-					const chatUri = session.mainChat.get().resource;
-					const title = localize('automationRunner.sessionTitle', "{0}", automation.name);
-					await this.sessionsManagementService.renameChat(session, chatUri, title);
-				} catch (renameErr) {
-					this.logService.warn(`[AutomationRunner] renameChat failed for ${automation.id}`, renameErr);
-				}
 			}
 
 			await this.automationService.updateRun(runId, {
@@ -119,7 +105,6 @@ export class AutomationRunner implements IAutomationRunner {
 			publishAutomationRun(this.telemetryService, { trigger, automation, success: true, durationMs: Date.now() - startTimeMs });
 		} catch (err) {
 			this.logService.error(`[AutomationRunner] run for ${automation.id} failed`, err);
-			// Defensive: the error path must not propagate secondary failures to the outer caller.
 			try {
 				const errorMessage = err instanceof Error ? err.message : String(err);
 				this.notificationService.error(localize('automationRunFailed', "Automation '{0}' failed: {1}", automation.name, errorMessage));

--- a/src/vs/sessions/contrib/automations/browser/automations.contribution.ts
+++ b/src/vs/sessions/contrib/automations/browser/automations.contribution.ts
@@ -19,22 +19,12 @@ import { IAutomationRunner } from '../../../../workbench/contrib/chat/common/aut
 import { IAutomationService } from '../../../../workbench/contrib/chat/common/automations/automationService.js';
 import { publishAutomationToggled } from '../../../../workbench/contrib/chat/common/automations/automationTelemetry.js';
 import { ChatAutomationsEnabledContext, CHAT_AUTOMATIONS_ENABLED_SETTING, CHAT_AUTOMATIONS_RUN_TIMEOUT_MINUTES_SETTING, DEFAULT_AUTOMATIONS_RUN_TIMEOUT_MINUTES } from '../../../../workbench/contrib/chat/common/automations/automationsEnabled.js';
-import { CancellationToken } from '../../../../base/common/cancellation.js';
-import { IAutomation, AutomationRunTrigger } from '../../../../workbench/contrib/chat/common/automations/automation.js';
+import { AutomationRunner } from './automationRunner.js';
 import { AutomationScheduler } from './automationScheduler.js';
 import { AutomationService } from './automationService.js';
 
 registerSingleton(IAutomationService, AutomationService, InstantiationType.Delayed);
-
-// Stub runner for Layer 1. The real implementation (Layer 2) replaces this registration.
-
-class StubAutomationRunner implements IAutomationRunner {
-	declare readonly _serviceBrand: undefined;
-	async runOnce(_automation: IAutomation, _trigger: AutomationRunTrigger, _leaderWindowId: number, _token?: CancellationToken): Promise<void> {
-		// No-op: real runner is registered in Layer 2.
-	}
-}
-registerSingleton(IAutomationRunner, StubAutomationRunner, InstantiationType.Delayed);
+registerSingleton(IAutomationRunner, AutomationRunner, InstantiationType.Delayed);
 
 registerWorkbenchContribution2(AutomationScheduler.ID, AutomationScheduler, WorkbenchPhase.Eventually);
 

--- a/src/vs/sessions/contrib/automations/test/browser/automationRunner.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/automationRunner.test.ts
@@ -109,6 +109,17 @@ suite('AutomationRunner', () => {
 		assert.strictEqual(sessionsMgmt.calls[0].folderUri.toString(), FOLDER_B.toString());
 	});
 
+	test('truncates the session title to 100 characters', async () => {
+		const { service, sessionsMgmt, runner } = setup();
+		sessionsMgmt.nextSession = fakeSession('s1');
+
+		const longName = 'A'.repeat(150);
+		const a = await service.createAutomation({ name: longName, prompt: 'p', schedule: hourly(), folderUri: FOLDER_A });
+		await runner.runOnce(a, 'manual', 1);
+
+		assert.strictEqual(sessionsMgmt.calls[0].options.title, 'A'.repeat(100));
+	});
+
 	test('marks the run failed when createAndSendNewChatRequest throws', async () => {
 		const { service, sessionsMgmt, runner } = setup();
 		sessionsMgmt.nextError = new Error('provider offline');
@@ -208,6 +219,8 @@ suite('AutomationRunner', () => {
 			modelId: undefined,
 			modeId: undefined,
 			permissionLevel: undefined,
+			isolationMode: undefined,
+			branch: undefined,
 		});
 	});
 
@@ -232,6 +245,8 @@ suite('AutomationRunner', () => {
 			modelId: undefined,
 			modeId: 'agent',
 			permissionLevel: 'autopilot',
+			isolationMode: undefined,
+			branch: undefined,
 		});
 	});
 
@@ -250,8 +265,8 @@ suite('AutomationRunner', () => {
 		const { service, sessionsMgmt, runner } = setup();
 		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER_A });
 		await service.deleteAutomation(a.id);
-		// recordRunStart throws "Automation not found"; the runner must swallow
-		// it, never start a session, and produce no run rows.
+		// The runner detects the deletion via getAutomation before attempting
+		// recordRunStart, bails early, and produces no run rows.
 		await runner.runOnce(a, 'manual', 1);
 		assert.strictEqual(sessionsMgmt.calls.length, 0);
 		assert.deepStrictEqual(service.runs.get(), []);

--- a/src/vs/sessions/contrib/automations/test/browser/automationRunner.test.ts
+++ b/src/vs/sessions/contrib/automations/test/browser/automationRunner.test.ts
@@ -1,0 +1,259 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken, CancellationTokenSource } from '../../../../../base/common/cancellation.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock, upcastPartial } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { TestNotificationService } from '../../../../../platform/notification/test/common/testNotificationService.js';
+import { InMemoryStorageService } from '../../../../../platform/storage/common/storage.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { AutomationService } from '../../browser/automationService.js';
+import { IAutomationSchedule } from '../../../../../workbench/contrib/chat/common/automations/automation.js';
+import { ISession } from '../../../../services/sessions/common/session.js';
+import { ICreateNewSessionOptions, ISendRequestOptions, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { AutomationRunner } from '../../browser/automationRunner.js';
+
+function hourly(): IAutomationSchedule {
+	return { interval: 'hourly', scheduleHour: 0, scheduleMinute: 0, scheduleDay: 0 };
+}
+
+const FOLDER_A = URI.parse('file:///workspace/a');
+const FOLDER_B = URI.parse('file:///workspace/b');
+
+interface IRecordedCall {
+	readonly folderUri: URI;
+	readonly options: ISendRequestOptions;
+	readonly createOptions?: ICreateNewSessionOptions;
+}
+
+class FakeSessionsManagementService extends mock<ISessionsManagementService>() {
+
+	readonly calls: IRecordedCall[] = [];
+
+	/** Configure how the next createAndSendNewChatRequest behaves. */
+	nextSession: ISession | undefined;
+	nextError: Error | undefined;
+	/** Optional hook fired after the call is recorded, before returning/throwing. */
+	onSendHook: (() => Promise<void> | void) | undefined;
+
+	override async createAndSendNewChatRequest(
+		folderUri: URI,
+		options: ISendRequestOptions,
+		createOptions?: ICreateNewSessionOptions,
+	): Promise<ISession | undefined> {
+		this.calls.push({ folderUri, options, createOptions });
+		if (this.onSendHook) {
+			await this.onSendHook();
+		}
+		if (this.nextError) {
+			throw this.nextError;
+		}
+		return this.nextSession;
+	}
+}
+
+function fakeSession(sessionId: string): ISession {
+	return upcastPartial<ISession>({ sessionId });
+}
+
+suite('AutomationRunner', () => {
+
+	const teardown = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function setup() {
+		const storage = teardown.add(new InMemoryStorageService());
+		const log = new NullLogService();
+		const service = teardown.add(new AutomationService(storage, log, NullTelemetryService));
+		const sessionsMgmt = new FakeSessionsManagementService();
+		const runner = new AutomationRunner(service, sessionsMgmt, log, NullTelemetryService, new TestNotificationService());
+		return { service, sessionsMgmt, runner };
+	}
+
+	test('creates a session for the automation prompt and marks the run completed', async () => {
+		const { service, sessionsMgmt, runner } = setup();
+		sessionsMgmt.nextSession = fakeSession('s1');
+
+		const a = await service.createAutomation({ name: 'A', prompt: 'do the thing', schedule: hourly(), folderUri: FOLDER_A });
+		await runner.runOnce(a, 'schedule', 99);
+
+		assert.strictEqual(sessionsMgmt.calls.length, 1);
+		assert.strictEqual(sessionsMgmt.calls[0].folderUri.toString(), FOLDER_A.toString());
+		assert.strictEqual(sessionsMgmt.calls[0].options.query, 'do the thing');
+		assert.strictEqual(sessionsMgmt.calls[0].options.background, true);
+
+		const runs = service.runs.get();
+		assert.strictEqual(runs.length, 1);
+		assert.strictEqual(runs[0].status, 'completed');
+		assert.strictEqual(runs[0].sessionId, 's1');
+		assert.strictEqual(runs[0].trigger, 'schedule');
+		assert.strictEqual(runs[0].leaderWindowId, 99);
+	});
+
+	test('always uses the automation folder regardless of the current workspace', async () => {
+		const { service, sessionsMgmt, runner } = setup();
+		sessionsMgmt.nextSession = fakeSession('s1');
+
+		const a = await service.createAutomation({
+			name: 'A',
+			prompt: 'p',
+			schedule: hourly(),
+			folderUri: FOLDER_B,
+		});
+		await runner.runOnce(a, 'schedule', 1);
+
+		assert.strictEqual(sessionsMgmt.calls[0].folderUri.toString(), FOLDER_B.toString());
+	});
+
+	test('marks the run failed when createAndSendNewChatRequest throws', async () => {
+		const { service, sessionsMgmt, runner } = setup();
+		sessionsMgmt.nextError = new Error('provider offline');
+
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER_A });
+		await runner.runOnce(a, 'schedule', 1);
+
+		const runs = service.runs.get();
+		assert.strictEqual(runs.length, 1);
+		assert.strictEqual(runs[0].status, 'failed');
+		assert.strictEqual(runs[0].errorMessage, 'provider offline');
+	});
+
+	test('skips when another active run exists for the same automation', async () => {
+		const { service, sessionsMgmt, runner } = setup();
+
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER_A });
+		await service.recordRunStart(a.id, 'manual', 1);
+		await runner.runOnce(a, 'schedule', 2);
+		assert.strictEqual(sessionsMgmt.calls.length, 0);
+		const runs = service.runs.get();
+		assert.strictEqual(runs.length, 1);
+		assert.strictEqual(runs[0].status, 'pending');
+	});
+
+	test('marks the run failed when the cancellation token is already cancelled', async () => {
+		const { service, sessionsMgmt, runner } = setup();
+		const cts = new CancellationTokenSource();
+		cts.cancel();
+
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER_A });
+		await runner.runOnce(a, 'schedule', 1, cts.token);
+
+		assert.strictEqual(sessionsMgmt.calls.length, 0);
+		const runs = service.runs.get();
+		assert.strictEqual(runs.length, 1);
+		assert.strictEqual(runs[0].status, 'failed');
+		assert.strictEqual(runs[0].errorMessage, 'Cancelled');
+		cts.dispose();
+	});
+
+	test('marks the run cancelled when the token is cancelled mid-flight', async () => {
+		// Regression: previously the runner only checked the token before
+		// `createAndSendNewChatRequest`, so a cancellation that landed during
+		// the in-flight send would still stamp the run as `completed`.
+		const { service, sessionsMgmt, runner } = setup();
+		const cts = new CancellationTokenSource();
+		sessionsMgmt.nextSession = fakeSession('s-mid');
+		sessionsMgmt.onSendHook = () => {
+			cts.cancel();
+		};
+
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER_A });
+		await runner.runOnce(a, 'schedule', 1, cts.token);
+
+		assert.strictEqual(sessionsMgmt.calls.length, 1);
+		const runs = service.runs.get();
+		assert.strictEqual(runs.length, 1);
+		assert.strictEqual(runs[0].status, 'failed');
+		assert.strictEqual(runs[0].errorMessage, 'Cancelled');
+		// Even though the service returned a session, the cancellation
+		// outcome wins and the session id is not stamped onto the run.
+		assert.strictEqual(runs[0].sessionId, undefined);
+		cts.dispose();
+	});
+
+	test('completes the run even when the service returns undefined', async () => {
+		const { service, runner } = setup();
+
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER_A });
+		await runner.runOnce(a, 'schedule', 1, CancellationToken.None);
+
+		const runs = service.runs.get();
+		assert.strictEqual(runs.length, 1);
+		assert.strictEqual(runs[0].status, 'completed');
+		assert.strictEqual(runs[0].sessionId, undefined);
+	});
+
+	test('passes the captured providerId and sessionTypeId through to createAndSendNewChatRequest', async () => {
+		const { service, sessionsMgmt, runner } = setup();
+		sessionsMgmt.nextSession = fakeSession('s1');
+
+		const a = await service.createAutomation({
+			name: 'A',
+			prompt: 'p',
+			schedule: hourly(),
+			folderUri: FOLDER_A,
+			providerId: 'local-agent-host',
+			sessionTypeId: 'agent-host-copilotcli',
+		});
+		await runner.runOnce(a, 'schedule', 1);
+
+		assert.strictEqual(sessionsMgmt.calls.length, 1);
+		assert.deepStrictEqual(sessionsMgmt.calls[0].createOptions, {
+			providerId: 'local-agent-host',
+			sessionTypeId: 'agent-host-copilotcli',
+			modelId: undefined,
+			modeId: undefined,
+			permissionLevel: undefined,
+		});
+	});
+
+	test('passes captured mode and permission level through to createAndSendNewChatRequest', async () => {
+		const { service, sessionsMgmt, runner } = setup();
+		sessionsMgmt.nextSession = fakeSession('s1');
+
+		const a = await service.createAutomation({
+			name: 'A',
+			prompt: 'p',
+			schedule: hourly(),
+			folderUri: FOLDER_A,
+			mode: 'agent',
+			permissionLevel: 'autopilot',
+		});
+		await runner.runOnce(a, 'schedule', 1);
+
+		assert.strictEqual(sessionsMgmt.calls.length, 1);
+		assert.deepStrictEqual(sessionsMgmt.calls[0].createOptions, {
+			providerId: undefined,
+			sessionTypeId: undefined,
+			modelId: undefined,
+			modeId: 'agent',
+			permissionLevel: 'autopilot',
+		});
+	});
+
+	test('omits createOptions entirely when no provider/sessionType is captured', async () => {
+		const { service, sessionsMgmt, runner } = setup();
+		sessionsMgmt.nextSession = fakeSession('s1');
+
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER_A });
+		await runner.runOnce(a, 'schedule', 1);
+
+		assert.strictEqual(sessionsMgmt.calls.length, 1);
+		assert.strictEqual(sessionsMgmt.calls[0].createOptions, undefined);
+	});
+
+	test('does not throw if the automation is deleted mid-run', async () => {
+		const { service, sessionsMgmt, runner } = setup();
+		const a = await service.createAutomation({ name: 'A', prompt: 'p', schedule: hourly(), folderUri: FOLDER_A });
+		await service.deleteAutomation(a.id);
+		// recordRunStart throws "Automation not found"; the runner must swallow
+		// it, never start a session, and produce no run rows.
+		await runner.runOnce(a, 'manual', 1);
+		assert.strictEqual(sessionsMgmt.calls.length, 0);
+		assert.deepStrictEqual(service.runs.get(), []);
+	});
+});

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -2060,7 +2060,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 		const { query, attachedContext } = options;
 
-		session.setTitle(query.split('\n')[0].substring(0, 100) || localize('new session', "New Session"));
+		session.setTitle((options.title || query.split('\n')[0]).substring(0, 100) || localize('new session', "New Session"));
 		session.setStatus(SessionStatus.InProgress);
 		this._sessionCache.set(session.resource.toString(), session);
 		this._invalidateGroupingCaches();

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -470,37 +470,38 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 	 * Create a new session for the given folder and send a chat request to it,
 	 * without navigating into the started session. The started session appears
 	 * in the sessions list once the provider commits it, while the user's
-	 * current view is left untouched.
+	 * current view is left untouched. Returns the committed session,
+	 * or `undefined` if the service was disposed during the send.
 	 *
 	 * Unlike {@link sendNewChatRequest} with `background`, this does not go
 	 * through the new-session composer: it creates a fresh session purely for
 	 * this request and never sets it as pending/active. Intended for callers
 	 * outside the composer that want to kick off a session programmatically.
 	 *
-	 * If the send fails, the stranded draft is disposed through its provider and
-	 * the error is rethrown so the caller can react.
+	 * If the send or any configuration setter fails, the stranded draft is
+	 * disposed through its provider and the error is rethrown.
 	 */
 	async createAndSendNewChatRequest(folderUri: URI, options: ISendRequestOptions, createOptions?: ICreateNewSessionOptions): Promise<ISession | undefined> {
 		const { provider, sessionTypeId } = this._resolveProviderForNewSession(folderUri, createOptions);
 		const session = provider.createNewSession(folderUri, sessionTypeId);
 
-		if (createOptions?.modelId) {
-			provider.setModel(session.sessionId, createOptions.modelId);
-		}
-		if (createOptions?.modeId) {
-			provider.setMode?.(session.sessionId, createOptions.modeId);
-		}
-		if (createOptions?.permissionLevel) {
-			provider.setPermissionLevel?.(session.sessionId, createOptions.permissionLevel);
-		}
-		if (createOptions?.isolationMode) {
-			provider.setIsolationMode?.(session.sessionId, createOptions.isolationMode);
-		}
-		if (createOptions?.branch) {
-			provider.setBranch?.(session.sessionId, createOptions.branch);
-		}
-
 		try {
+			if (createOptions?.modelId) {
+				provider.setModel(session.sessionId, createOptions.modelId);
+			}
+			if (createOptions?.modeId) {
+				provider.setMode?.(session.sessionId, createOptions.modeId);
+			}
+			if (createOptions?.permissionLevel) {
+				provider.setPermissionLevel?.(session.sessionId, createOptions.permissionLevel);
+			}
+			if (createOptions?.isolationMode) {
+				provider.setIsolationMode?.(session.sessionId, createOptions.isolationMode);
+			}
+			if (createOptions?.branch) {
+				provider.setBranch?.(session.sessionId, createOptions.branch);
+			}
+
 			return await this._sendNewChatRequestInBackground(provider, session, options);
 		} catch (e) {
 			// The send never committed, so the draft is stranded. Dispose it

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -480,12 +480,28 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 	 * If the send fails, the stranded draft is disposed through its provider and
 	 * the error is rethrown so the caller can react.
 	 */
-	async createAndSendNewChatRequest(folderUri: URI, options: ISendRequestOptions, createOptions?: ICreateNewSessionOptions): Promise<void> {
+	async createAndSendNewChatRequest(folderUri: URI, options: ISendRequestOptions, createOptions?: ICreateNewSessionOptions): Promise<ISession | undefined> {
 		const { provider, sessionTypeId } = this._resolveProviderForNewSession(folderUri, createOptions);
 		const session = provider.createNewSession(folderUri, sessionTypeId);
 
+		if (createOptions?.modelId) {
+			provider.setModel(session.sessionId, createOptions.modelId);
+		}
+		if (createOptions?.modeId) {
+			provider.setMode?.(session.sessionId, createOptions.modeId);
+		}
+		if (createOptions?.permissionLevel) {
+			provider.setPermissionLevel?.(session.sessionId, createOptions.permissionLevel);
+		}
+		if (createOptions?.isolationMode) {
+			provider.setIsolationMode?.(session.sessionId, createOptions.isolationMode);
+		}
+		if (createOptions?.branch) {
+			provider.setBranch?.(session.sessionId, createOptions.branch);
+		}
+
 		try {
-			await this._sendNewChatRequestInBackground(provider, session, options);
+			return await this._sendNewChatRequestInBackground(provider, session, options);
 		} catch (e) {
 			// The send never committed, so the draft is stranded. Dispose it
 			// through its provider to release the eager backend session before
@@ -511,7 +527,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 	 * Providers are multi-new-session aware, so the graduating session and a
 	 * concurrently reseeded composer draft coexist without conflict.
 	 */
-	private async _sendNewChatRequestInBackground(provider: ISessionsProvider, session: ISession, options: ISendRequestOptions): Promise<void> {
+	private async _sendNewChatRequestInBackground(provider: ISessionsProvider, session: ISession, options: ISendRequestOptions): Promise<ISession | undefined> {
 		// Notify listeners (e.g., telemetry) that a send is starting so they can
 		// prewarm caches whose result is consumed when `onDidSendRequest` fires.
 		this._onWillSendRequest.fire(session);
@@ -530,10 +546,11 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 			this._pendingSendChatResources.delete(chatResourceKey);
 		}
 		if (this._store.isDisposed) {
-			return;
+			return undefined;
 		}
 		this._onDidStartSession.fire(updatedSession);
 		this._onDidSendRequest.fire({ session: updatedSession, chat, isNewSession: true, isNewChat: true, options });
+		return updatedSession;
 	}
 
 	async sendRequest(session: ISession, chat: IChat, options: ISendRequestOptions): Promise<void> {

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -56,33 +56,32 @@ export interface ICreateNewSessionOptions {
 	readonly sessionTypeId?: string;
 	/**
 	 * Optional model identifier to apply to the new session via
-	 * {@link ISessionsProvider.setModel}. Ignored if the chosen provider
-	 * does not recognise the id.
+	 * {@link ISessionsProvider.setModel}. If the provider throws, the
+	 * stranded draft is disposed and the error propagates.
 	 */
 	readonly modelId?: string;
 	/**
 	 * Optional chat mode identifier (typically a value from `ChatModeKind`)
-	 * to apply via {@link ISessionsProvider.setMode}. Ignored if the chosen
-	 * provider does not support setting a mode or does not recognise the id.
+	 * to apply via {@link ISessionsProvider.setMode}. Skipped if the
+	 * provider does not implement the setter.
 	 */
 	readonly modeId?: string;
 	/**
 	 * Optional permission level (typically a value from
 	 * `ChatPermissionLevel`) to apply via
-	 * {@link ISessionsProvider.setPermissionLevel}. Ignored if the chosen
-	 * provider does not support permission gating or does not recognise the
-	 * value.
+	 * {@link ISessionsProvider.setPermissionLevel}. Skipped if the provider
+	 * does not implement the setter.
 	 */
 	readonly permissionLevel?: string;
 	/**
 	 * Optional worktree isolation mode (`worktree` or `workspace`) to apply
-	 * via {@link ISessionsProvider.setIsolationMode}. Ignored if the chosen
-	 * provider does not support isolation.
+	 * via {@link ISessionsProvider.setIsolationMode}. Skipped if the
+	 * provider does not implement the setter.
 	 */
 	readonly isolationMode?: string;
 	/**
 	 * Optional git branch to apply via {@link ISessionsProvider.setBranch}.
-	 * Ignored if the chosen provider does not support branch selection.
+	 * Skipped if the provider does not implement the setter.
 	 */
 	readonly branch?: string;
 }
@@ -340,8 +339,9 @@ export interface ISessionsManagementService {
 	 * The started session appears in the sessions list once the provider
 	 * commits it, while the user's current view is left untouched. Intended for
 	 * callers outside the new-session composer that want to kick off a session
-	 * programmatically. Rejects (after disposing the stranded draft) if the send
-	 * fails.
+	 * programmatically. Returns the committed session, or `undefined` if the
+	 * service was disposed during the send. Rejects (after disposing the
+	 * stranded draft) if the send fails.
 	 */
 	createAndSendNewChatRequest(folderUri: URI, options: ISendRequestOptions, createOptions?: ICreateNewSessionOptions): Promise<ISession | undefined>;
 

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -54,6 +54,37 @@ export interface ICreateNewSessionOptions {
 	 * chosen provider advertises for the folder URI.
 	 */
 	readonly sessionTypeId?: string;
+	/**
+	 * Optional model identifier to apply to the new session via
+	 * {@link ISessionsProvider.setModel}. Ignored if the chosen provider
+	 * does not recognise the id.
+	 */
+	readonly modelId?: string;
+	/**
+	 * Optional chat mode identifier (typically a value from `ChatModeKind`)
+	 * to apply via {@link ISessionsProvider.setMode}. Ignored if the chosen
+	 * provider does not support setting a mode or does not recognise the id.
+	 */
+	readonly modeId?: string;
+	/**
+	 * Optional permission level (typically a value from
+	 * `ChatPermissionLevel`) to apply via
+	 * {@link ISessionsProvider.setPermissionLevel}. Ignored if the chosen
+	 * provider does not support permission gating or does not recognise the
+	 * value.
+	 */
+	readonly permissionLevel?: string;
+	/**
+	 * Optional worktree isolation mode (`worktree` or `workspace`) to apply
+	 * via {@link ISessionsProvider.setIsolationMode}. Ignored if the chosen
+	 * provider does not support isolation.
+	 */
+	readonly isolationMode?: string;
+	/**
+	 * Optional git branch to apply via {@link ISessionsProvider.setBranch}.
+	 * Ignored if the chosen provider does not support branch selection.
+	 */
+	readonly branch?: string;
 }
 
 /**
@@ -312,7 +343,7 @@ export interface ISessionsManagementService {
 	 * programmatically. Rejects (after disposing the stranded draft) if the send
 	 * fails.
 	 */
-	createAndSendNewChatRequest(folderUri: URI, options: ISendRequestOptions, createOptions?: ICreateNewSessionOptions): Promise<void>;
+	createAndSendNewChatRequest(folderUri: URI, options: ISendRequestOptions, createOptions?: ICreateNewSessionOptions): Promise<ISession | undefined>;
 
 	/**
 	 * Send a request for an existing chat within a session.

--- a/src/vs/sessions/services/sessions/common/sessionsProvider.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsProvider.ts
@@ -27,8 +27,8 @@ export interface ISendRequestOptions {
 	readonly query: string;
 	/** Optional attached context entries. */
 	readonly attachedContext?: IChatRequestVariableEntry[];
-	/** Optional source identifier for telemetry/bookkeeping (e.g. `'automation'`). */
-	readonly source?: string;
+	/** Optional display title for the new session. */
+	readonly title?: string;
 }
 
 /**

--- a/src/vs/sessions/services/sessions/common/sessionsProvider.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsProvider.ts
@@ -27,6 +27,8 @@ export interface ISendRequestOptions {
 	readonly query: string;
 	/** Optional attached context entries. */
 	readonly attachedContext?: IChatRequestVariableEntry[];
+	/** Optional source identifier for telemetry/bookkeeping (e.g. `'automation'`). */
+	readonly source?: string;
 }
 
 /**
@@ -224,6 +226,34 @@ export interface ISessionsProvider {
 	 * @param modelId The ID of the model to set for the session.
 	 */
 	setModel(sessionId: string, modelId: string): void;
+
+	/**
+	 * Set the chat mode for a session.
+	 * @param sessionId The ID of the session.
+	 * @param modeId The mode identifier to set.
+	 */
+	setMode?(sessionId: string, modeId: string): void;
+
+	/**
+	 * Set the permission level for a session.
+	 * @param sessionId The ID of the session.
+	 * @param level The permission level to set.
+	 */
+	setPermissionLevel?(sessionId: string, level: string): void;
+
+	/**
+	 * Set the isolation mode for a session.
+	 * @param sessionId The ID of the session.
+	 * @param mode The isolation mode to set.
+	 */
+	setIsolationMode?(sessionId: string, mode: string): void;
+
+	/**
+	 * Set the git branch for a session.
+	 * @param sessionId The ID of the session.
+	 * @param branch The branch name to set.
+	 */
+	setBranch?(sessionId: string, branch: string): void;
 
 	/**
 	 * Archive a session.

--- a/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionNavigation.test.ts
@@ -203,7 +203,7 @@ class MockSessionStore implements ISessionsManagementService {
 	discardNewSession(): void { throw new Error('not implemented'); }
 	unsetNewSession(): void { throw new Error('not implemented'); }
 	sendNewChatRequest(_session: ISession, _options: ISendRequestOptions): Promise<void> { throw new Error('not implemented'); }
-	createAndSendNewChatRequest(_folderUri: URI, _options: ISendRequestOptions, _createOptions?: ICreateNewSessionOptions): Promise<void> { throw new Error('not implemented'); }
+	createAndSendNewChatRequest(_folderUri: URI, _options: ISendRequestOptions, _createOptions?: ICreateNewSessionOptions): Promise<ISession | undefined> { throw new Error('not implemented'); }
 	sendRequest(_session: ISession, _chat: IChat, _options: ISendRequestOptions): Promise<void> { throw new Error('not implemented'); }
 	openNewChatInSession(_session: ISession): Promise<void> { throw new Error('not implemented'); }
 	openPreviousSession(): Promise<void> { throw new Error('not implemented'); }

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -27,7 +27,7 @@ import { IChat, ISession, ISessionType, ISessionWorkspace, SessionStatus } from 
 import { ILanguageModelChatMetadataAndIdentifier } from '../../../../../workbench/contrib/chat/common/languageModels.js';
 import { ISessionChangeEvent, ISendRequestOptions, ISessionModelPickerOptions, ISessionsProvider } from '../../common/sessionsProvider.js';
 import { SessionsManagementService } from '../../browser/sessionsManagementService.js';
-import { ISessionsManagementService } from '../../common/sessionsManagement.js';
+import { ISessionsManagementService, ICreateNewSessionOptions } from '../../common/sessionsManagement.js';
 import { SessionsService } from '../../browser/sessionsService.js';
 import { ISessionsPartService } from '../../browser/sessionsPartService.js';
 import { ISessionsProvidersService } from '../../browser/sessionsProvidersService.js';
@@ -149,7 +149,7 @@ class TestSessionsProvider extends mock<ISessionsProvider>() {
 	override getModels(): readonly ILanguageModelChatMetadataAndIdentifier[] { return []; }
 	override getModelPickerOptions(): ISessionModelPickerOptions { return { useGroupedModelPicker: true, showFeatured: true, showUnavailableFeatured: false, showManageModelsAction: false }; }
 	override readonly onDidChangeModels = Event.None;
-	override setModel(): void { }
+	override setModel(_sessionId: string, _modelId: string): void { }
 	override async archiveSession(): Promise<void> { }
 	override async unarchiveSession(): Promise<void> { }
 	override async deleteSession(): Promise<void> { }
@@ -826,6 +826,93 @@ suite('SessionsManagementService', () => {
 		// The request was sent, but the user's view was not navigated into the session.
 		assert.strictEqual(sendRequestStarted, true);
 		assert.strictEqual(view.activeSession.get(), undefined);
+	});
+
+	test('createAndSendNewChatRequest invokes configuration setters from createOptions', async () => {
+		const chat: IChat = { ...stubChat, resource: URI.parse('test:///chat') };
+		const session = stubSession({
+			sessionId: 's1',
+			providerId: 'test',
+			chats: constObservable([chat]),
+			mainChat: constObservable(chat),
+		});
+		const calls: string[] = [];
+		const provider = new class extends TestSessionsProvider {
+			override resolveWorkspace(): ISessionWorkspace { return { folderUri: URI.parse('test:///folder') } as unknown as ISessionWorkspace; }
+			override setModel(_sessionId: string, _modelId: string): void { calls.push(`setModel:${_modelId}`); }
+			override setMode(_sessionId: string, _modeId: string): void { calls.push(`setMode:${_modeId}`); }
+			override setPermissionLevel(_sessionId: string, _level: string): void { calls.push(`setPermissionLevel:${_level}`); }
+			override setIsolationMode(_sessionId: string, _mode: string): void { calls.push(`setIsolationMode:${_mode}`); }
+			override setBranch(_sessionId: string, _branch: string): void { calls.push(`setBranch:${_branch}`); }
+			override async sendRequest(_sessionId: string, _chatResource: URI, _options: ISendRequestOptions): Promise<ISession> { return session; }
+		}(session);
+		const { service } = createSessionsManagementService(session, disposables, provider);
+
+		const createOptions: ICreateNewSessionOptions = {
+			modelId: 'gpt-4o',
+			modeId: 'agent',
+			permissionLevel: 'allowedTools',
+			isolationMode: 'worktree',
+			branch: 'main',
+		};
+		const result = await service.createAndSendNewChatRequest(URI.parse('test:///folder'), { query: 'hi' }, createOptions);
+
+		assert.strictEqual(result?.sessionId, 's1');
+		assert.deepStrictEqual(calls, [
+			'setModel:gpt-4o',
+			'setMode:agent',
+			'setPermissionLevel:allowedTools',
+			'setIsolationMode:worktree',
+			'setBranch:main',
+		]);
+	});
+
+	test('createAndSendNewChatRequest disposes stranded draft when a setter throws', async () => {
+		const chat: IChat = { ...stubChat, resource: URI.parse('test:///chat') };
+		const session = stubSession({
+			sessionId: 's1',
+			providerId: 'test',
+			chats: constObservable([chat]),
+			mainChat: constObservable(chat),
+		});
+		let deleted = false;
+		const provider = new class extends TestSessionsProvider {
+			override resolveWorkspace(): ISessionWorkspace { return { folderUri: URI.parse('test:///folder') } as unknown as ISessionWorkspace; }
+			override setModel(): void { throw new Error('model not found'); }
+			override deleteNewSession(): void { deleted = true; }
+			override async sendRequest(_sessionId: string, _chatResource: URI, _options: ISendRequestOptions): Promise<ISession> { return session; }
+		}(session);
+		const { service } = createSessionsManagementService(session, disposables, provider);
+
+		await assert.rejects(
+			() => service.createAndSendNewChatRequest(URI.parse('test:///folder'), { query: 'hi' }, { modelId: 'bad' }),
+			/model not found/,
+		);
+		assert.strictEqual(deleted, true);
+	});
+
+	test('createAndSendNewChatRequest returns undefined when service is disposed mid-send', async () => {
+		const chat: IChat = { ...stubChat, resource: URI.parse('test:///chat') };
+		const session = stubSession({
+			sessionId: 's1',
+			providerId: 'test',
+			chats: constObservable([chat]),
+			mainChat: constObservable(chat),
+		});
+		const serviceRef: { current?: ISessionsManagementService } = {};
+		const provider = new class extends TestSessionsProvider {
+			override resolveWorkspace(): ISessionWorkspace { return { folderUri: URI.parse('test:///folder') } as unknown as ISessionWorkspace; }
+			override async sendRequest(_sessionId: string, _chatResource: URI, _options: ISendRequestOptions): Promise<ISession> {
+				// Dispose the service while the send is in-flight.
+				(serviceRef.current as unknown as { dispose(): void }).dispose();
+				return session;
+			}
+		}(session);
+		const { service } = createSessionsManagementService(session, disposables, provider);
+		serviceRef.current = service;
+
+		const result = await service.createAndSendNewChatRequest(URI.parse('test:///folder'), { query: 'hi' });
+		assert.strictEqual(result, undefined);
 	});
 
 	test('discardNewSession fires onDidDiscardNewSession with the discarded draft', () => {


### PR DESCRIPTION
## Context

Second PR in the 4-part Automations stack. Builds on PR 1 (Foundation) which has been merged to main.

This PR implements the **AutomationRunner**, the execution engine that bridges the automation data layer (PR 1) to the sessions layer. When the scheduler decides an automation is due, the runner creates a chat session, configures it, sends the prompt, and records the outcome.

## Architecture

```mermaid
classDiagram
    class AutomationRunner {
        +runOnce(automation, trigger, windowId, token)
        -_runOnceInner()
        -_markCancelled()
    }

    class ISessionsManagementService {
        +createAndSendNewChatRequest(folderUri, options, createOptions)
        -_resolveProviderForNewSession()
        -_sendNewChatRequestInBackground()
    }

    class ISessionsProvider {
        +createNewSession(folderUri, sessionTypeId)
        +setModel(sessionId, modelId)
        +setMode?(sessionId, modeId)
        +setPermissionLevel?(sessionId, level)
        +setIsolationMode?(sessionId, mode)
        +setBranch?(sessionId, branch)
        +sendRequest(sessionId, chatResource, options)
    }

    class AutomationService {
        +recordRunStart()
        +updateRun()
        Data layer (from PR 1)
    }

    AutomationRunner --> ISessionsManagementService : creates session + sends prompt
    AutomationRunner --> AutomationService : records run start/completion/failure
    ISessionsManagementService --> ISessionsProvider : configures + dispatches
```

## Execution Flow

```mermaid
sequenceDiagram
    participant Sch as Scheduler
    participant R as AutomationRunner
    participant AS as AutomationService
    participant SM as SessionsManagementService
    participant P as Provider

    Sch->>R: runOnce(automation, trigger, token)
    R->>AS: recordRunStart(automationId, trigger)
    R->>SM: createAndSendNewChatRequest(folderUri, options, createOptions)
    SM->>P: createNewSession(folderUri, sessionTypeId)
    SM->>P: setModel / setMode / setPermissionLevel / setIsolationMode / setBranch
    SM->>P: sendRequest(sessionId, chatResource, options)
    P-->>SM: session
    SM-->>R: session
    alt cancelled mid-flight
        R->>AS: updateRun(failed, "Cancelled")
    else success
        R->>AS: updateRun(completed, sessionId)
    else error
        R->>AS: updateRun(failed, errorMessage)
        R->>Notification: show error to user
    end
```

## What's New

**New file:** `src/vs/sessions/contrib/automations/browser/automationRunner.ts`
- Implements `IAutomationRunner` (interface from PR 1).
- Creates sessions programmatically via `createAndSendNewChatRequest`.
- Handles mid-flight cancellation by re-checking the token post-send.
- Reports telemetry on success and failure.

**Sessions layer extensions:**
- `ISessionsManagementService.createAndSendNewChatRequest()` for programmatic session creation without the composer UI. Cleans up stranded sessions on failure.
- `ISessionsProvider` gains 4 optional setters: `setMode?`, `setPermissionLevel?`, `setIsolationMode?`, `setBranch?`. These were previously only callable through the concrete provider class from UI widgets.
- `ISendRequestOptions.title` lets callers pre-name the session so it shows a meaningful title during launch.

**Telemetry:** Refactored to report actual enum values (permissionLevel, isolationMode) instead of boolean flags.

