### PR TITLE
Disable idle session eviction in agent host

### DIFF
--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -29,7 +29,7 @@ import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } f
 import { AhpErrorCodes, AHP_SESSION_NOT_FOUND, ContentEncoding, JSON_RPC_INTERNAL_ERROR, ProtocolError, ResourceChangeType, ResourceType, ResourceWriteMode, type CreateResourceWatchParams, type CreateResourceWatchResult, type DirectoryEntry, type ResourceCopyParams, type ResourceCopyResult, type ResourceDeleteParams, type ResourceDeleteResult, type ResourceListResult, type ResourceMkdirParams, type ResourceMkdirResult, type ResourceMoveParams, type ResourceMoveResult, type ResourceReadResult, type ResourceResolveParams, type ResourceResolveResult, type ResourceWatchState, type ResourceWriteParams, type ResourceWriteResult, type IStateSnapshot } from '../common/state/sessionProtocol.js';
 import { ChangesSummary, MessageAttachmentKind, type Message, type MessageAttachment, type MessageResourceAttachment } from '../common/state/protocol/state.js';
 import type { ChatPendingMessageSetAction, ChatTurnStartedAction } from '../common/state/protocol/actions.js';
-import { ISessionGitHubState, ISessionGitState, ResponsePartKind, SESSION_META_GITHUB_KEY, SESSION_META_GIT_KEY, SessionStatus, ToolCallStatus, ToolResultContentType, buildDefaultChatUri, buildResourceWatchChannelUri, buildSubagentSessionUriPrefix, hostBuildInfoFromProduct, isAhpChatChannel, isSubagentSession, parseDefaultChatUri, parseRequiredSessionUriFromChatUri, parseResourceWatchChannelUri, parseSubagentSessionUri, readSessionGitState, withSessionGitHubState, withSessionGitState, type SessionConfigState, type SessionSummary, type ToolResultSubagentContent, type Turn } from '../common/state/sessionState.js';
+import { ISessionGitHubState, ISessionGitState, ResponsePartKind, SESSION_META_GITHUB_KEY, SESSION_META_GIT_KEY, SessionStatus, ToolCallStatus, ToolResultContentType, buildDefaultChatUri, buildResourceWatchChannelUri, hostBuildInfoFromProduct, isAhpChatChannel, isSubagentSession, parseDefaultChatUri, parseRequiredSessionUriFromChatUri, parseResourceWatchChannelUri, parseSubagentSessionUri, readSessionGitState, withSessionGitHubState, withSessionGitState, type SessionConfigState, type SessionSummary, type ToolResultSubagentContent, type Turn } from '../common/state/sessionState.js';
 import { IProductService } from '../../product/common/productService.js';
 import { AgentConfigurationService, IAgentConfigurationService } from './agentConfigurationService.js';
 import { AgentHostTerminalManager, type IAgentHostTerminalManager } from './agentHostTerminalManager.js';
@@ -1209,6 +1209,13 @@ export class AgentService extends Disposable implements IAgentService {
 	 * rehydrate the session via {@link restoreSession}.
 	 */
 	private _maybeEvictIdleSession(resource: URI): void {
+		// Idle-session eviction is disabled while we investigate issues where
+		// cached session state is dropped while clients still expect it to be
+		// observable. Keeping the cached state in memory prevents spurious
+		// re-restores and state loss.
+		return;
+
+		/*
 		const key = resource.toString();
 		if (this._resourceSubscribers.has(resource)) {
 			return;
@@ -1245,6 +1252,7 @@ export class AgentService extends Disposable implements IAgentService {
 			this._stateManager.removeSession(cachedKey);
 		}
 		this._stateManager.removeSession(evictionTargetKey);
+		*/
 	}
 
 	// Returns true when a changeset is safe to drop from the in-memory cache.

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -1201,18 +1201,20 @@ export class AgentService extends Disposable implements IAgentService {
 	}
 
 	/**
-	 * If `resource` names an idle session and no client is still subscribed to
-	 * it (or, for a subagent URI, no sibling subagent under the same parent is
-	 * still subscribed), drop its cached state from the state manager. Subagent
-	 * URIs evict the parent session entry; the parent owns the materialized
-	 * turn tree that backs every subagent view. The next subscribe will
-	 * rehydrate the session via {@link restoreSession}.
+	 * Eviction is currently disabled: this is a no-op that keeps cached session
+	 * state in memory. When re-enabled, it should drop cached state for an idle
+	 * session that has no remaining subscribers (walking up subagent ancestry
+	 * and evicting the root session entry), allowing the session to be
+	 * rehydrated later via {@link restoreSession}.
 	 */
 	private _maybeEvictIdleSession(resource: URI): void {
 		// Idle-session eviction is disabled while we investigate issues where
 		// cached session state is dropped while clients still expect it to be
 		// observable. Keeping the cached state in memory prevents spurious
 		// re-restores and state loss.
+		// TODO: re-enable eviction or add an LRU cap to avoid unbounded memory
+		// growth in long-lived agent-host processes.
+		void resource;
 		return;
 
 		/*

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -2659,7 +2659,9 @@ suite('AgentService (node dispatcher)', () => {
 			assert.ok(service.stateManager.getSessionState(sessionResource.toString()), 'active-turn session must not be evicted');
 		});
 
-		test('a restored idle session is evicted when its last subscriber drops', async () => {
+		test('a restored idle session is NOT evicted when its last subscriber drops', async () => {
+			// Idle-session eviction is currently disabled; the cached state should
+			// remain in memory after the last subscriber drops.
 			service.registerProvider(copilotAgent);
 			const { session } = await copilotAgent.createSession();
 			const sessions = await copilotAgent.listSessions();
@@ -2674,10 +2676,12 @@ suite('AgentService (node dispatcher)', () => {
 
 			service.unsubscribe(sessionResource, 'client-1');
 
-			assert.strictEqual(service.stateManager.getSessionState(sessionResource.toString()), undefined, 'restored idle session should be evicted');
+			assert.ok(service.stateManager.getSessionState(sessionResource.toString()), 'restored idle session should stay cached while eviction is disabled');
 		});
 
 		test('multiple subscribers keep a restored session alive until all drop', async () => {
+			// With idle eviction disabled, the session state remains cached even
+			// after every subscriber drops.
 			service.registerProvider(copilotAgent);
 			const { session } = await copilotAgent.createSession();
 			const sessions = await copilotAgent.listSessions();
@@ -2695,7 +2699,7 @@ suite('AgentService (node dispatcher)', () => {
 			assert.ok(service.stateManager.getSessionState(sessionResource.toString()), 'still subscribed by client-2');
 
 			service.unsubscribe(sessionResource, 'client-2');
-			assert.strictEqual(service.stateManager.getSessionState(sessionResource.toString()), undefined, 'evicted after last subscriber');
+			assert.ok(service.stateManager.getSessionState(sessionResource.toString()), 'session stays cached after all subscribers drop while eviction is disabled');
 		});
 
 		test('subagent subscriber pins the parent session against eviction', async () => {
@@ -2725,10 +2729,10 @@ suite('AgentService (node dispatcher)', () => {
 			assert.ok(service.stateManager.getSessionState(sessionResource.toString()), 'parent must stay while child is subscribed');
 			assert.ok(service.stateManager.getSessionState(childUri.toString()), 'child still present');
 
-			// Child drops — both can now be evicted
+			// Child drops — with idle eviction disabled, both stay cached.
 			service.unsubscribe(childUri, 'client-child');
-			assert.strictEqual(service.stateManager.getSessionState(sessionResource.toString()), undefined, 'parent evicted after subagent drops');
-			assert.strictEqual(service.stateManager.getSessionState(childUri.toString()), undefined, 'child also evicted with parent');
+			assert.ok(service.stateManager.getSessionState(sessionResource.toString()), 'parent stays cached after subagent drops while eviction is disabled');
+			assert.ok(service.stateManager.getSessionState(childUri.toString()), 'child stays cached after subagent drops while eviction is disabled');
 		});
 
 		test('nested subagent subscriber pins ancestor session against eviction', async () => {
@@ -2760,10 +2764,9 @@ suite('AgentService (node dispatcher)', () => {
 			assert.ok(service.stateManager.getSessionState(childUri.toString()), 'intermediate child still present');
 		});
 
-		test('depth-2 subagent eviction evicts the root session state', async () => {
-			// Regression: when a depth-2 subagent URI unsubscribes the eviction
-			// must reach all the way to the root, not stop at the intermediate
-			// parent and leave root state cached indefinitely.
+		test('depth-2 subagent unsubscribe does NOT evict the root session state', async () => {
+			// Idle-session eviction is currently disabled, so the root state
+			// should remain cached after the depth-2 subscriber drops.
 			service.registerProvider(copilotAgent);
 			const { session } = await copilotAgent.createSession();
 			const sessions = await copilotAgent.listSessions();
@@ -2781,7 +2784,7 @@ suite('AgentService (node dispatcher)', () => {
 			service.addSubscriber(nestedUri, 'client-nested');
 			service.unsubscribe(nestedUri, 'client-nested');
 
-			assert.strictEqual(service.stateManager.getSessionState(sessionResource.toString()), undefined, 'root state must be evicted when no subscribers remain');
+			assert.ok(service.stateManager.getSessionState(sessionResource.toString()), 'root state stays cached when no subscribers remain while eviction is disabled');
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -2679,7 +2679,7 @@ suite('AgentService (node dispatcher)', () => {
 			assert.ok(service.stateManager.getSessionState(sessionResource.toString()), 'restored idle session should stay cached while eviction is disabled');
 		});
 
-		test('multiple subscribers keep a restored session alive until all drop', async () => {
+		test('restored session stays cached after all subscribers drop', async () => {
 			// With idle eviction disabled, the session state remains cached even
 			// after every subscriber drops.
 			service.registerProvider(copilotAgent);


### PR DESCRIPTION
Idle-session eviction in `_maybeEvictIdleSession` is causing issues where cached session state is dropped while clients still expect it to be observable. This change disables the eviction path for now while we investigate, and updates the related tests to expect state to remain cached after the last subscriber drops.

(Written by Copilot)