### PR TITLE
fix(php): support unicode nowdoc labels

### DIFF
--- a/extensions/php/build/update-grammar.mjs
+++ b/extensions/php/build/update-grammar.mjs
@@ -66,6 +66,18 @@ function fixBadRegex(grammar) {
 	} else {
 		fail('function-call');
 	}
+
+	const heredoc = grammar.repository['heredoc'];
+	if (heredoc) {
+		const nowdocBegin = heredoc.patterns[1].begin;
+		if (nowdocBegin === "(?=<<<\\s*'([a-zA-Z_]+[a-zA-Z0-9_]*)'\\s*$)") {
+			heredoc.patterns[1].begin = "(?i)(?=<<<\\s*'([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)'\\s*$)";
+		} else {
+			fail('heredoc.nowdoc.begin');
+		}
+	} else {
+		fail('heredoc');
+	}
 }
 
 vscodeGrammarUpdater.update('KapitanOczywisty/language-php', 'grammars/php.cson', './syntaxes/php.tmLanguage.json', fixBadRegex);

--- a/extensions/php/build/update-grammar.mjs
+++ b/extensions/php/build/update-grammar.mjs
@@ -66,18 +66,6 @@ function fixBadRegex(grammar) {
 	} else {
 		fail('function-call');
 	}
-
-	const heredoc = grammar.repository['heredoc'];
-	if (heredoc) {
-		const nowdocBegin = heredoc.patterns[1].begin;
-		if (nowdocBegin === "(?=<<<\\s*'([a-zA-Z_]+[a-zA-Z0-9_]*)'\\s*$)") {
-			heredoc.patterns[1].begin = "(?i)(?=<<<\\s*'([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)'\\s*$)";
-		} else {
-			fail('heredoc.nowdoc.begin');
-		}
-	} else {
-		fail('heredoc');
-	}
 }
 
 vscodeGrammarUpdater.update('KapitanOczywisty/language-php', 'grammars/php.cson', './syntaxes/php.tmLanguage.json', fixBadRegex);

--- a/extensions/php/cgmanifest.json
+++ b/extensions/php/cgmanifest.json
@@ -6,7 +6,7 @@
 				"git": {
 					"name": "language-php",
 					"repositoryUrl": "https://github.com/KapitanOczywisty/language-php",
-					"commitHash": "cd607a522b79c457fe78bf7a1b04511d1c49f693"
+					"commitHash": "d94fd6b7dff1613d34bc0d36328f9982e65bd545"
 				}
 			},
 			"license": "MIT",

--- a/extensions/php/syntaxes/php.tmLanguage.json
+++ b/extensions/php/syntaxes/php.tmLanguage.json
@@ -1802,7 +1802,7 @@
 					]
 				},
 				{
-					"begin": "(?=<<<\\s*'([a-zA-Z_]+[a-zA-Z0-9_]*)'\\s*$)",
+					"begin": "(?i)(?=<<<\\s*'([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)'\\s*$)",
 					"end": "(?!\\G)",
 					"name": "string.unquoted.nowdoc.php",
 					"patterns": [

--- a/extensions/php/syntaxes/php.tmLanguage.json
+++ b/extensions/php/syntaxes/php.tmLanguage.json
@@ -4,7 +4,7 @@
 		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
 		"Once accepted there, we are happy to receive an update request."
 	],
-	"version": "https://github.com/KapitanOczywisty/language-php/commit/cd607a522b79c457fe78bf7a1b04511d1c49f693",
+	"version": "https://github.com/KapitanOczywisty/language-php/commit/d94fd6b7dff1613d34bc0d36328f9982e65bd545",
 	"scopeName": "source.php",
 	"patterns": [
 		{


### PR DESCRIPTION
Fixes #322943

## Summary
- allow PHP nowdoc labels to use the same Unicode identifier range as heredoc labels
- consume the generated upstream grammar from KapitanOczywisty/language-php#53 without a local updater workaround

## Verification
- Ran `npm run update-grammar` in `extensions/php`; it updated the PHP grammar version and `cgmanifest.json` to upstream merge commit `d94fd6b`.
- Re-ran the updater and confirmed it produced no additional changes.
- Asserted the generated nowdoc begin rule contains the Unicode identifier range from the upstream grammar.
- Tokenized the issue repro with `vscode-textmate`/`vscode-oniguruma` and verified `<<<'NOW📄'` is scoped as `string.unquoted.nowdoc.php`, `/* FAIL` stays inside the nowdoc string, and `function seeme()` is no longer scoped as `comment.block.php`.
- Rechecked ASCII nowdoc labels still tokenize as nowdoc.
- Ran `git diff --check`.
