### PR TITLE
Fix parseLineAndColumnAware mistaking hex/exponential path segments for line numbers

### DIFF
--- a/src/vs/base/common/extpath.ts
+++ b/src/vs/base/common/extpath.ts
@@ -7,7 +7,6 @@ import { CharCode } from './charCode.js';
 import { isAbsolute, join, normalize, posix, sep } from './path.js';
 import { isWindows } from './platform.js';
 import { equalsIgnoreCase, rtrim, startsWithIgnoreCase } from './strings.js';
-import { isNumber } from './types.js';
 
 export function isPathSeparator(code: number) {
 	return code === CharCode.Slash || code === CharCode.Backslash;
@@ -366,6 +365,12 @@ export interface IPathWithLineAndColumn {
 	column?: number;
 }
 
+// Strictly decimal digits only: `Number(segment)` is too loose here and would also
+// accept hex/octal/binary/exponential notation or padded values (e.g. "0x10", "1e3",
+// " 33"), which can legitimately be part of a file path and should not be mistaken
+// for a line or column.
+const lineOrColumnSegmentRegex = /^[0-9]+$/;
+
 export function parseLineAndColumnAware(rawPath: string): IPathWithLineAndColumn {
 	const segments = rawPath.split(':'); // C:\file.txt:<line>:<column>
 
@@ -374,13 +379,12 @@ export function parseLineAndColumnAware(rawPath: string): IPathWithLineAndColumn
 	let column: number | undefined;
 
 	for (const segment of segments) {
-		const segmentAsNumber = Number(segment);
-		if (!isNumber(segmentAsNumber)) {
+		if (!lineOrColumnSegmentRegex.test(segment)) {
 			path = path ? [path, segment].join(':') : segment; // a colon can well be part of a path (e.g. C:\...)
 		} else if (line === undefined) {
-			line = segmentAsNumber;
+			line = Number(segment);
 		} else if (column === undefined) {
-			column = segmentAsNumber;
+			column = Number(segment);
 		}
 	}
 

--- a/src/vs/base/test/common/extpath.test.ts
+++ b/src/vs/base/test/common/extpath.test.ts
@@ -202,6 +202,24 @@ suite('Paths', () => {
 		assert.strictEqual(res.path, '/foo/bar:abb');
 		assert.strictEqual(res.line, undefined);
 		assert.strictEqual(res.column, undefined);
+
+		// segments that `Number()` would coerce into a valid number (hex, exponential, ...)
+		// must still be treated as part of the path, not as line/column. A file can be
+		// legally named e.g. `report:0x10` without the `0x10` part being mistaken for a line.
+		res = extpath.parseLineAndColumnAware('/foo/report:0x10');
+		assert.strictEqual(res.path, '/foo/report:0x10');
+		assert.strictEqual(res.line, undefined);
+		assert.strictEqual(res.column, undefined);
+
+		res = extpath.parseLineAndColumnAware('/foo/report:0x10:33');
+		assert.strictEqual(res.path, '/foo/report:0x10');
+		assert.strictEqual(res.line, 33);
+		assert.strictEqual(res.column, 1);
+
+		res = extpath.parseLineAndColumnAware('/foo/bar:1e3');
+		assert.strictEqual(res.path, '/foo/bar:1e3');
+		assert.strictEqual(res.line, undefined);
+		assert.strictEqual(res.column, undefined);
 	});
 
 	test('randomPath', () => {

--- a/src/vs/base/test/common/extpath.test.ts
+++ b/src/vs/base/test/common/extpath.test.ts
@@ -203,9 +203,7 @@ suite('Paths', () => {
 		assert.strictEqual(res.line, undefined);
 		assert.strictEqual(res.column, undefined);
 
-		// segments that `Number()` would coerce into a valid number (hex, exponential, ...)
-		// must still be treated as part of the path, not as line/column. A file can be
-		// legally named e.g. `report:0x10` without the `0x10` part being mistaken for a line.
+		// segments `Number()` would coerce (hex, exponential, ...) must stay part of the path, not line/column
 		res = extpath.parseLineAndColumnAware('/foo/report:0x10');
 		assert.strictEqual(res.path, '/foo/report:0x10');
 		assert.strictEqual(res.line, undefined);


### PR DESCRIPTION
\`parseLineAndColumnAware\` (used by the \`--goto FILE:LINE(:COLUMN)\` CLI flag) decides whether a colon-delimited segment is a line/column by coercing it with \`Number()\` and checking it's not NaN. That's too permissive: \`Number("0x10")\` is 16 and \`Number("1e3")\` is 1000, so a file legitimately named something like \`report:0x10\` gets its \`0x10\` segment silently swallowed as line 16 instead of staying part of the path.

Swapped the check for a strict \`/^[0-9]+$/\` regex so only plain decimal digit segments are treated as line/column, and added a few test cases covering hex- and exponential-looking segments. Existing behavior (plain line/column parsing, Windows drive letters like \`C:\foo\bar:33\`) is unaffected since those segments were never matched by the loose check either.