### PR TITLE
Move Add File as Context action to far right of editor title in sessions window

### DIFF
--- a/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
+++ b/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
@@ -307,7 +307,7 @@ class AddFileAsContextAction extends Action2 {
 			menu: {
 				id: MenuId.EditorTitle,
 				group: 'navigation',
-				order: 1,
+				order: 100000, // towards the far right, mirroring Split Editor Right in the regular window
 				when: precondition
 			}
 		});


### PR DESCRIPTION
Aligns the `Add File as Context` action in the editor title (agents/sessions window) with how `Split Editor Right` appears at the far right of the editor title in the regular window.

The action was contributed to `MenuId.EditorTitle` in the `navigation` group with `order: 1`, placing it at the far left. This bumps the order to `100000` (mirroring `SPLIT_ORDER` used by Split Editor Right in the regular window) so it sits at the far right of the toolbar.

No collisions: in the sessions window the split editor action is moved to the overflow (...) menu, and the close button convention (`CLOSE_ORDER = 1000000`) still sits further right.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>