### PR TITLE
agentHost: restore Copilot session PreToolUse/PostToolUse hooks

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -18,7 +18,7 @@ import type { ModelSelection, ToolDefinition } from '../../common/state/protocol
 import type { ActiveClientToolSet } from '../activeClientState.js';
 import { CopilotSessionWrapper } from './copilotSessionWrapper.js';
 import { ShellManager, createShellTools, type IUnsandboxedCommandConfirmationRequest } from './copilotShellTools.js';
-import { toSdkInstructionDirectories, toSdkMcpServers, toSdkMcpServersFromConfigMap, toSdkSessionCustomAgents, toSdkSkillDirectories } from './copilotPluginConverters.js';
+import { toSdkHooks, toSdkInstructionDirectories, toSdkMcpServers, toSdkMcpServersFromConfigMap, toSdkSessionCustomAgents, toSdkSkillDirectories } from './copilotPluginConverters.js';
 import { buildSandboxConfigForSdk, type ISdkSandboxConfig } from './sandboxConfigForSdk.js';
 import type { ITypedPermissionRequest } from './copilotToolDisplay.js';
 import type { ICopilotPluginInfo } from './copilotAgent.js';
@@ -380,6 +380,16 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			onPermissionRequest: request => runtime.handlePermissionRequest(request),
 			onUserInputRequest: (request, invocation) => runtime.handleUserInputRequest(request, invocation),
 			onElicitationRequest: context => runtime.handleElicitationRequest(context),
+			// Wire the SDK PreToolUse/PostToolUse hooks: plugin-authored hooks
+			// plus the internal edit-tracking hooks that snapshot file content
+			// before/after each edit tool so completed tool calls carry
+			// `FileEdit` results. Without this, `FileEditTracker` never records
+			// edits, so features that consume file-edit content (the Changes
+			// view's Session Files section, per-turn diff fallback) see nothing.
+			hooks: toSdkHooks(pluginsWithoutDirs.flatMap(p => p.hooks), {
+				onPreToolUse: input => runtime.handlePreToolUse(input),
+				onPostToolUse: input => runtime.handlePostToolUse(input),
+			}),
 			mcpServers: { ...toSdkMcpServersFromConfigMap(plan.snapshot.mcpServers), ...toSdkMcpServers(pluginsWithoutDirs.flatMap(p => p.mcpServers)) },
 			onExitPlanModeRequest: (request, invocation) => runtime.handleExitPlanModeRequest(request, invocation),
 			workingDirectory: plan.workingDirectory?.fsPath,


### PR DESCRIPTION
## Problem

Files created/edited **outside** the workspace during an agent-host (Copilot CLI) session — e.g. `plan.md` under `~/.copilot/session-state/<id>/` — never appear in the Changes view's **Session Files** section.

## Root cause

The Session Files feature (#323725) parses `FileEdit` content parts out of chat-state turns. For Copilot CLI those `FileEdit` parts are produced by `FileEditTracker`, which snapshots file content before/after each edit tool via the SDK `onPreToolUse`/`onPostToolUse` hooks (`runtime.handlePreToolUse` / `handlePostToolUse`).

The dependency-bump PR #323657 ("Update @github/copilot ... 1.0.66-2") accidentally **removed the `hooks:` wiring** from `CopilotSessionLauncher._buildSessionConfig`, while adding `enableFileHooks: true`. With `hooks` gone:

- `FileEditTracker` never records edits → completed tool calls carry no `FileEdit` content → Session Files (and the per-turn diff fallback) see nothing.
- Plugin-authored `PreToolUse`/`PostToolUse` hooks stop running.

Evidence from a captured session log: the `chat/toolCallComplete` action for `plan.md` contained only a `text` content part, no `fileEdit`. An older session restored in the same log still had `fileEdit` content because it was tracked before the wiring was dropped.

## Fix

Restore the `hooks: toSdkHooks(...)` wiring (plugin hooks + edit-tracking hooks) in `copilotSessionLauncher.ts`, keeping `enableFileHooks: true`. `SessionConfig['hooks']` is still a valid SDK property, so this is a clean restoration of previously-reviewed code. Added a comment explaining why the wiring must stay so a future SDK bump doesn't silently drop it again.

## Notes for reviewers

- Repo lint/compile tasks could not be run in the authoring environment (dependencies not installed there); the change is a minimal restoration matching the exact prior working signature, which is covered by `copilotPluginConverters.test.ts`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
