### PR TITLE
nes-datagen: generate training data from continuous recordings

### DIFF
--- a/extensions/copilot/script/alternativeAction/index.ts
+++ b/extensions/copilot/script/alternativeAction/index.ts
@@ -46,7 +46,7 @@ async function extractFromCsv(csvContents: string): Promise<(Scoring.t | undefin
 		if (!altAction || !altAction.recording) {
 			return undefined;
 		}
-		return Processor.createScoringForAlternativeAction(altAction, coalesce([parseSuggestedEdit(obj.postProcessingOutcome.suggestedEdit)]), false);
+		return Processor.createScoring(altAction.recording.entries ?? [], altAction.recording.requestTime, coalesce([parseSuggestedEdit(obj.postProcessingOutcome.suggestedEdit)]), false);
 	});
 
 	return scoredEdits;
@@ -113,7 +113,12 @@ async function handleAlternativeActionJson(inputFilePath: string) {
 		}
 		isAccepted = data.suggestionStatus === 'accepted';
 	}
-	const scoring = Processor.createScoringForAlternativeAction(altAction, edits, isAccepted);
+	const altActionRecording = altAction.recording;
+	if (!altActionRecording) {
+		console.error('Alternative action has no recording');
+		return;
+	}
+	const scoring = Processor.createScoring(altActionRecording.entries ?? [], altActionRecording.requestTime, edits, isAccepted);
 	if (!scoring) {
 		console.error('Failed to create scoring from alternative action');
 		return;

--- a/extensions/copilot/src/extension/inlineEdits/node/continuousEnhancedTelemetrySender.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/continuousEnhancedTelemetrySender.ts
@@ -16,6 +16,48 @@ import { DebugRecorder } from './debugRecorder';
 import { NES_GH_TELEMETRY_EVENT_NAME } from './nextEditProviderTelemetry';
 
 /**
+ * The continuous-recording payload serialized into the `recording` telemetry
+ * property by {@link ContinuousEnhancedTelemetrySender._sendNow}.
+ *
+ * A continuous slice is a sliding window of recent edit activity; unlike a
+ * per-request ("alternative action") recording it has **no `requestTime`**.
+ */
+export interface IContinuousRecording {
+	/**
+	 * The recorded edit timeline for the window, or `undefined` when the
+	 * serialized entries exceed {@link
+	 * ContinuousEnhancedTelemetrySender.MAX_ENTRIES_CHARS} — only `entriesSize`
+	 * is shipped in that case.
+	 */
+	readonly entries: LogEntry[] | undefined;
+
+	/** Size, in UTF-16 code units, of the serialized entries at capture time. */
+	readonly entriesSize: number;
+
+	/**
+	 * Window start in epoch milliseconds (recorder clock). Adjacent slices can
+	 * have gaps, so consecutive windows are not necessarily contiguous.
+	 */
+	readonly windowStart: number;
+
+	/** Window end in epoch milliseconds (recorder clock). */
+	readonly windowEnd: number;
+
+	/**
+	 * Identifies the sender instance. Stable per sender lifetime; a single
+	 * extension session can span several ids (a new sender is created on
+	 * copilot-token change, etc.).
+	 */
+	readonly sessionId: string;
+
+	/**
+	 * Slice index, monotonically increasing per `sessionId`. Not necessarily
+	 * contiguous — empty slices are skipped at capture time.
+	 */
+	readonly sequenceNumber: number;
+}
+
+/**
  * Periodically sends an enhanced GH telemetry event with a fixed-length slice of recent workspace activity.
  *
  * Each event is shipped on the existing {@link NES_GH_TELEMETRY_EVENT_NAME} channel (so we reuse the existing
@@ -163,7 +205,7 @@ export class ContinuousEnhancedTelemetrySender extends Disposable {
 		const entriesSize = entriesJson.length;
 		const sequenceNumber = this._sequenceNumber++;
 
-		const recording = {
+		const recording: IContinuousRecording = {
 			entries: entriesSize > ContinuousEnhancedTelemetrySender.MAX_ENTRIES_CHARS ? undefined : entries,
 			entriesSize,
 			windowStart,

--- a/extensions/copilot/test/base/simulationOptions.ts
+++ b/extensions/copilot/test/base/simulationOptions.ts
@@ -16,12 +16,42 @@ export enum NesDatagenSampleTask {
 	CursorBoth = 'cursor-both',
 }
 
+/**
+ * Shape of the recordings in the nes-datagen input file.
+ */
+export enum NesDatagenInputFormat {
+	/** Per-request "alternative action" recordings bookmarked at the NES request time. */
+	AlternativeAction = 'alternative-action',
+	/** Continuous enhanced-telemetry slices with no request bookmark; a pivot is synthesized. */
+	Continuous = 'continuous',
+}
+
+/**
+ * How to choose the pivot in a continuous recording (only meaningful when
+ * `--input-format=continuous`). The pivot splits the timeline into context and
+ * the oracle (next user edit).
+ */
+export enum PivotStrategy {
+	/** Pick a single eligible pivot uniformly at random. */
+	Random = 'random',
+}
+
 export type NesDatagen = {
 	readonly input: string;
 	readonly output: string | undefined;
 	readonly rowOffset: number;
 	readonly workerMode: boolean;
 	readonly sampleTask: NesDatagenSampleTask;
+	/** Shape of the input recordings. */
+	readonly inputFormat: NesDatagenInputFormat;
+	/** Pivot selection strategy for continuous recordings. Ignored for alternative-action input. */
+	readonly pivotStrategy: PivotStrategy;
+	/**
+	 * Seed for the continuous pivot RNG. Resolved once (random when `--seed` is
+	 * omitted) so it can be propagated to all parallel workers for reproducible
+	 * output. Ignored for alternative-action input.
+	 */
+	readonly seed: number;
 	/** Minimum same-file lines above the request cursor for a move to count as a jump. */
 	readonly sameFileJumpMinAbove: number;
 	/** Minimum same-file lines below the request cursor for a move to count as a jump. */
@@ -195,6 +225,9 @@ export class SimulationOptions {
 				rowOffset: typeof argv['row-offset'] === 'number' ? argv['row-offset'] : 0,
 				workerMode: boolean(argv['worker'], false),
 				sampleTask: SimulationOptions.validateSampleTask(argv['sample-task']),
+				inputFormat: SimulationOptions.validateInputFormat(argv['input-format']),
+				pivotStrategy: SimulationOptions.validatePivotStrategy(argv['pivot-strategy']),
+				seed: SimulationOptions.resolveSeed(argv['seed']),
 				sameFileJumpMinAbove: typeof argv['same-file-jump-min-above'] === 'number' ? argv['same-file-jump-min-above'] : 2,
 				sameFileJumpMinBelow: typeof argv['same-file-jump-min-below'] === 'number' ? argv['same-file-jump-min-below'] : 5,
 			}
@@ -275,6 +308,14 @@ export class SimulationOptions {
 			`  --input                            Path to a JSON or JSON Lines file with training data recordings (required)`,
 			`                                     Format is inferred from the extension: .jsonl/.ndjson → JSON Lines, otherwise JSON array`,
 			`  --out                              Output path for the JSON Lines file. Default: <input-path>_output.jsonl`,
+			`  --input-format                     Shape of the input recordings (default: alternative-action)`,
+			`                                     Values: alternative-action, continuous`,
+			`                                       alternative-action → per-request recordings bookmarked at the NES request time`,
+			`                                       continuous         → continuous enhanced-telemetry slices; a pivot is synthesized`,
+			`  --pivot-strategy                   How to pick the pivot in a continuous recording (default: random; only for --input-format=continuous)`,
+			`                                     Values: random`,
+			`                                       random             → pick a single eligible pivot uniformly at random`,
+			`  --seed                             Integer seed for the continuous pivot RNG (default: random, logged for reproducibility)`,
 			`  --sample-task                      Which target to generate (default: xtab)`,
 			`                                     Values: xtab, cursor-same-file, cursor-cross-file, cursor-both`,
 			`                                       xtab               → edit-prediction sample (assistant = an edit)`,
@@ -298,6 +339,8 @@ export class SimulationOptions {
 			`  npm run simulate -- --config-file=config.json nes-datagen --input=data.json --sample-task=cursor-same-file`,
 			`  npm run simulate -- --config-file=config.json nes-datagen --input=data.json --sample-task=cursor-cross-file`,
 			`  npm run simulate -- --config-file=config.json nes-datagen --input=data.json --sample-task=cursor-both --same-file-jump-min-above=8 --same-file-jump-min-below=8`,
+			`  npm run simulate -- --config-file=config.json nes-datagen --input=continuous.jsonl --input-format=continuous`,
+			`  npm run simulate -- --config-file=config.json nes-datagen --input=continuous.jsonl --input-format=continuous --pivot-strategy=random --seed=42`,
 			``,
 		].join('\n'));
 	}
@@ -348,6 +391,49 @@ export class SimulationOptions {
 			throw new Error(`--sample-task must be one of [${allowed.join(', ')}], but got: ${value}`);
 		}
 		return value as NesDatagenSampleTask;
+	}
+
+	private static validateInputFormat(value: unknown): NesDatagenInputFormat {
+		if (value === undefined || value === null) {
+			return NesDatagenInputFormat.AlternativeAction;
+		}
+		if (typeof value !== 'string') {
+			throw new Error(`--input-format must be a string, but got: ${typeof value}`);
+		}
+		const allowed = Object.values(NesDatagenInputFormat) as string[];
+		if (!allowed.includes(value)) {
+			throw new Error(`--input-format must be one of [${allowed.join(', ')}], but got: ${value}`);
+		}
+		return value as NesDatagenInputFormat;
+	}
+
+	private static validatePivotStrategy(value: unknown): PivotStrategy {
+		if (value === undefined || value === null) {
+			return PivotStrategy.Random;
+		}
+		if (typeof value !== 'string') {
+			throw new Error(`--pivot-strategy must be a string, but got: ${typeof value}`);
+		}
+		const allowed = Object.values(PivotStrategy) as string[];
+		if (!allowed.includes(value)) {
+			throw new Error(`--pivot-strategy must be one of [${allowed.join(', ')}], but got: ${value}`);
+		}
+		return value as PivotStrategy;
+	}
+
+	/**
+	 * Resolve the continuous pivot seed. When `--seed` is omitted a random
+	 * 32-bit seed is generated so that the parent can log it and propagate it to
+	 * every worker, keeping output reproducible.
+	 */
+	private static resolveSeed(value: unknown): number {
+		if (value === undefined || value === null) {
+			return Math.floor(Math.random() * 0x100000000);
+		}
+		if (typeof value !== 'number' || !Number.isInteger(value)) {
+			throw new Error(`--seed must be an integer, but got: ${value}`);
+		}
+		return value >>> 0;
 	}
 }
 

--- a/extensions/copilot/test/pipeline/alternativeAction/processor.ts
+++ b/extensions/copilot/test/pipeline/alternativeAction/processor.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAlternativeAction } from '../../../src/extension/inlineEdits/node/nextEditProviderTelemetry';
 import { Edits } from '../../../src/platform/inlineEdits/common/dataTypes/edit';
 import { LogEntry } from '../../../src/platform/workspaceRecorder/common/workspaceLog';
 import { StringEdit, StringReplacement } from '../../../src/util/vs/editor/common/core/edits/stringEdit';
@@ -22,17 +21,22 @@ export namespace Processor {
 	}
 
 	/**
-	 * Split a recording at its NES request bookmark and resolve the active
-	 * document at that moment. Exposed so callers (in particular nes-datagen
-	 * cursor-jump detectors) can reason about what the user did *after* the request
-	 * without re-implementing the same splitting logic that
-	 * {@link createScoringForAlternativeAction} performs internally.
+	 * Split a recording at a pivot time (the NES request bookmark for
+	 * per-request recordings, or a synthesized pivot for continuous ones) and
+	 * resolve the active document at that moment. Exposed so callers (in
+	 * particular nes-datagen cursor-jump detectors and the continuous-recording
+	 * path) can reason about what the user did *after* the pivot without
+	 * re-implementing the same splitting logic that {@link createScoring}
+	 * performs internally.
 	 *
-	 * Returns `undefined` if the recording cannot be split (missing
-	 * `requestTime`, empty entries, no resolvable active document, etc.).
+	 * `requestTime` is the pivot: entries with `time <= requestTime` form the
+	 * prior portion, the rest form the post-request portion.
+	 *
+	 * Returns `undefined` if the recording cannot be split (empty entries, pivot
+	 * before all entries, no resolvable active document, etc.).
 	 */
-	export function splitRecording(altAction: IAlternativeAction): ISplitRecording | undefined {
-		const processedRecording = splitRecordingAtRequestTime(altAction);
+	export function splitRecording(entries: LogEntry[], requestTime: number): ISplitRecording | undefined {
+		const processedRecording = splitRecordingAtRequestTime(entries, requestTime);
 		if (!processedRecording) {
 			return undefined;
 		}
@@ -61,13 +65,14 @@ export namespace Processor {
 		};
 	}
 
-	export function createScoringForAlternativeAction(
-		altAction: IAlternativeAction,
+	export function createScoring(
+		entries: LogEntry[],
+		requestTime: number,
 		proposedEdits: IStringReplacement[],
 		isAccepted: boolean,
 	): Scoring.t | undefined {
 
-		const processedRecording = splitRecordingAtRequestTime(altAction);
+		const processedRecording = splitRecordingAtRequestTime(entries, requestTime);
 		if (!processedRecording) {
 			log('Could not split recording at request time');
 			return undefined;
@@ -111,24 +116,17 @@ export namespace Processor {
 		return scoring;
 	}
 
-	function splitRecordingAtRequestTime(altAction: IAlternativeAction): {
+	function splitRecordingAtRequestTime(entries: LogEntry[], requestTime: number): {
 		wholeRecording: LogEntry[];
 		recordingPriorToRequest: LogEntry[];
 		recordingAfterRequest: LogEntry[];
 	} | undefined {
 
-		if (!altAction.recording) {
+		if (!entries || entries.length === 0) {
 			return undefined;
 		}
 
-		const recording = altAction.recording.entries;
-		if (!recording || recording.length === 0) {
-			return undefined;
-		}
-
-		const requestTime = altAction.recording.requestTime;
-
-		const recordingIdxOfRequestTime = binarySearch(recording, (entry: LogEntry) => {
+		const recordingIdxOfRequestTime = binarySearch(entries, (entry: LogEntry) => {
 			if (entry.kind === 'meta') {
 				return -1;
 			} else {
@@ -141,11 +139,11 @@ export namespace Processor {
 			return undefined;
 		}
 
-		const recordingPriorToRequest = recording.slice(0, recordingIdxOfRequestTime + 1);
-		const recordingAfterRequest = recording.slice(recordingIdxOfRequestTime + 1);
+		const recordingPriorToRequest = entries.slice(0, recordingIdxOfRequestTime + 1);
+		const recordingAfterRequest = entries.slice(recordingIdxOfRequestTime + 1);
 
 		return {
-			wholeRecording: recording,
+			wholeRecording: entries,
 			recordingPriorToRequest,
 			recordingAfterRequest
 		};

--- a/extensions/copilot/test/pipeline/alternativeAction/util.ts
+++ b/extensions/copilot/test/pipeline/alternativeAction/util.ts
@@ -11,6 +11,14 @@ export function log(...args: any[]) {
 	}
 }
 
+/**
+ * Find an index `i` such that `compare(array[i]) === 0`, or — when no exact
+ * match exists — the index of the greatest element with `compare < 0`
+ * (`-1` if none). Assumes `array` is sorted ascending by `compare`.
+ *
+ * NOTE: when several elements compare equal (e.g. share a timestamp) this
+ * returns an *arbitrary* one of them, not necessarily the first or last.
+ */
 export function binarySearch<T>(
 	array: readonly T[],
 	compare: (element: T) => number

--- a/extensions/copilot/test/pipeline/continuous/continuousRecord.spec.ts
+++ b/extensions/copilot/test/pipeline/continuous/continuousRecord.spec.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from 'vitest';
+import { parseContinuousRecord } from './continuousRecord';
+
+const entries = [{ kind: 'documentEncountered', id: 0, time: 1, relativePath: 'a.ts' }];
+
+describe('parseContinuousRecord', () => {
+	it('parses a stringified recording payload', () => {
+		const recording = { entries, entriesSize: 10, windowStart: 1, windowEnd: 2, sessionId: 's', sequenceNumber: 3 };
+		const record = parseContinuousRecord({ recording: JSON.stringify(recording) }, 4);
+		expect(record).toEqual({ originalRowIndex: 4, value: recording });
+	});
+
+	it('tolerates a pre-parsed recording object (fixtures)', () => {
+		const recording = { entries, entriesSize: 10 };
+		expect(parseContinuousRecord({ recording }, 0).value.entriesSize).toBe(10);
+	});
+
+	it('throws when the recording column is missing', () => {
+		expect(() => parseContinuousRecord({}, 0)).toThrow(/Missing key/);
+	});
+
+	it('throws when entries were dropped at send time (over cap)', () => {
+		const record = { recording: JSON.stringify({ entriesSize: 999999 }) };
+		expect(() => parseContinuousRecord(record, 0)).toThrow(/entries is missing or empty/);
+	});
+
+	it('throws when entries are empty', () => {
+		const record = { recording: JSON.stringify({ entries: [], entriesSize: 0 }) };
+		expect(() => parseContinuousRecord(record, 0)).toThrow(/entries is missing or empty/);
+	});
+});

--- a/extensions/copilot/test/pipeline/continuous/continuousRecord.ts
+++ b/extensions/copilot/test/pipeline/continuous/continuousRecord.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { IContinuousRecording } from '../../../src/extension/inlineEdits/node/continuousEnhancedTelemetrySender';
+import { ErrorUtils } from '../../../src/util/common/errors';
+import type { WithRowIndex } from '../withRowIndex';
+import { streamJsonRecords } from '../streamJsonRecords';
+
+/**
+ * A single parsed continuous-recording input record (one telemetry slice),
+ * paired with its 0-based position within the input file / chunk.
+ */
+export type IContinuousRecord = WithRowIndex<IContinuousRecording>;
+
+/**
+ * Column carrying the (stringified) recording payload. Matches the telemetry
+ * property name emitted by `ContinuousEnhancedTelemetrySender`; export queries
+ * should alias the recording column to `recording`.
+ */
+const RECORDING_KEY = 'recording';
+
+/**
+ * Parse a single continuous input record.
+ *
+ * The `recording` field is, by export convention, a JSON string (the sender
+ * calls `JSON.stringify(recording)`); a pre-parsed object is also tolerated for
+ * fixtures and hand-authored inputs.
+ *
+ * Throws if the record is missing the recording column or has no usable
+ * entries — callers collect these as per-record errors rather than aborting.
+ */
+export function parseContinuousRecord(record: Record<string, unknown>, rowIndex: number): IContinuousRecord {
+	const raw = record[RECORDING_KEY];
+	if (raw === undefined || raw === null) {
+		throw new Error(`Missing key: ${RECORDING_KEY}`);
+	}
+
+	let recording: IContinuousRecording;
+	if (typeof raw === 'string') {
+		recording = JSON.parse(raw) as IContinuousRecording;
+	} else if (typeof raw === 'object') {
+		recording = raw as IContinuousRecording;
+	} else {
+		throw new Error(`'${RECORDING_KEY}' must be a JSON string or object, got ${typeof raw}`);
+	}
+
+	if (!recording.entries || recording.entries.length === 0) {
+		// `entries` is dropped when the payload exceeded the sender cap; such a
+		// slice carries no edit history and cannot produce a sample.
+		throw new Error(`recording.entries is missing or empty (entriesSize: ${recording.entriesSize ?? '?'})`);
+	}
+
+	return {
+		originalRowIndex: rowIndex,
+		value: recording,
+	};
+}
+
+/**
+ * Stream-parse a continuous-recording input file (JSON array or JSON Lines),
+ * validating each record into an {@link IContinuousRecord}. Records that fail
+ * validation are reported in `errors` (with their row index) rather than
+ * aborting the load. Mirrors `loadAndParseInput` for the alternative-action path.
+ */
+export async function loadAndParseContinuousInput(inputPath: string, verbose = false): Promise<{
+	records: IContinuousRecord[];
+	errors: WithRowIndex<Error>[];
+}> {
+	const records: IContinuousRecord[] = [];
+	const errors: WithRowIndex<Error>[] = [];
+
+	let i = 0;
+	for await (const record of streamJsonRecords<Record<string, unknown>>(inputPath)) {
+		const rowIndex = i++;
+		try {
+			records.push(parseContinuousRecord(record, rowIndex));
+		} catch (e) {
+			errors.push({ originalRowIndex: rowIndex, value: ErrorUtils.fromUnknown(e) });
+		}
+	}
+
+	if (verbose) {
+		console.log(`Read ${i} continuous records from ${inputPath}`);
+	}
+
+	return { records, errors };
+}

--- a/extensions/copilot/test/pipeline/continuous/pivotStrategy.spec.ts
+++ b/extensions/copilot/test/pipeline/continuous/pivotStrategy.spec.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from 'vitest';
+import { Random } from '../../../src/platform/inlineEdits/test/node/random';
+import { LogEntry } from '../../../src/platform/workspaceRecorder/common/workspaceLog';
+import { PivotStrategy } from '../../base/simulationOptions';
+import { deriveSeed, selectPivots } from './pivotStrategy';
+
+const ID = 0;
+
+function meta(): LogEntry {
+	return { kind: 'meta', data: { repoRootUri: 'file:///ws' } };
+}
+function encountered(time: number): LogEntry {
+	return { kind: 'documentEncountered', id: ID, time, relativePath: 'a.ts' };
+}
+function setContent(time: number): LogEntry {
+	return { kind: 'setContent', id: ID, time, content: 'x', v: 0 };
+}
+function changed(time: number): LogEntry {
+	return { kind: 'changed', id: ID, time, edit: [[0, 0, 'y']], v: 1 };
+}
+function selection(time: number): LogEntry {
+	return { kind: 'selectionChanged', id: ID, time, selection: [[0, 0]] };
+}
+
+/** A well-formed recording: meta, encounter, content, selection, then 2 later edits. */
+const recording: LogEntry[] = [meta(), encountered(1), setContent(2), selection(3), changed(4), changed(5)];
+
+describe('selectPivots (random)', () => {
+	it('selects only changed/selectionChanged entries (never framing)', () => {
+		// Indices: 0 meta, 1 documentEncountered, 2 setContent, 3 selectionChanged,
+		// 4 changed, 5 changed. Only 3 and 4 are eligible (5 is last → no oracle;
+		// 1 and 2 are framing). Sweep seeds to exercise the random choice.
+		const chosen = new Set<number>();
+		for (let seed = 0; seed < 50; seed++) {
+			const pivots = selectPivots(recording, PivotStrategy.Random, Random.create(seed));
+			expect(pivots).toHaveLength(1);
+			chosen.add(pivots[0]);
+		}
+		expect([...chosen].sort()).toEqual([3, 4]);
+	});
+
+	it('is deterministic for a given seed', () => {
+		const a = selectPivots(recording, PivotStrategy.Random, Random.create(42));
+		const b = selectPivots(recording, PivotStrategy.Random, Random.create(42));
+		expect(a).toEqual(b);
+	});
+
+	it('rejects records whose only unique-time entries are framing', () => {
+		// documentEncountered + setContent have unique times but are framing;
+		// the single changed is last, so no oracle follows it.
+		const framingOnly: LogEntry[] = [encountered(1), setContent(2), changed(3)];
+		expect(selectPivots(framingOnly, PivotStrategy.Random, Random.create(1))).toEqual([]);
+	});
+
+	it('rejects records with duplicate times (ambiguous split boundary)', () => {
+		const dup: LogEntry[] = [encountered(1), changed(1), changed(1)];
+		expect(selectPivots(dup, PivotStrategy.Random, Random.create(1))).toEqual([]);
+	});
+
+	it('rejects records with no edit after any candidate', () => {
+		const noOracle: LogEntry[] = [encountered(1), setContent(2), selection(3)];
+		expect(selectPivots(noOracle, PivotStrategy.Random, Random.create(1))).toEqual([]);
+	});
+
+	it('rejects an empty recording', () => {
+		expect(selectPivots([], PivotStrategy.Random, Random.create(1))).toEqual([]);
+	});
+});
+
+describe('deriveSeed', () => {
+	it('is deterministic and index-dependent', () => {
+		expect(deriveSeed(100, 5)).toBe(deriveSeed(100, 5));
+		expect(deriveSeed(100, 5)).not.toBe(deriveSeed(100, 6));
+		expect(deriveSeed(100, 5)).not.toBe(deriveSeed(101, 5));
+	});
+});

--- a/extensions/copilot/test/pipeline/continuous/pivotStrategy.ts
+++ b/extensions/copilot/test/pipeline/continuous/pivotStrategy.ts
@@ -1,0 +1,139 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Random } from '../../../src/platform/inlineEdits/test/node/random';
+import { LogEntry } from '../../../src/platform/workspaceRecorder/common/workspaceLog';
+import { assertNever } from '../../../src/util/vs/base/common/assert';
+import { PivotStrategy } from '../../base/simulationOptions';
+
+/**
+ * Choose pivot *times* for a recording according to `strategy`.
+ *
+ * Continuous slices (from `ContinuousEnhancedTelemetrySender`) have no NES
+ * request bookmark, so a pivot must be synthesized. A pivot splits the timeline
+ * into *context* (everything at or before the pivot) and the *oracle* (the
+ * user's next edits after the pivot).
+ *
+ * Returns the `time` of each chosen pivot entry (matching the `requestTime`
+ * semantics the downstream split expects, see `Processor.splitRecording`).
+ * Returns an empty array when no eligible pivot exists.
+ *
+ * The return type is an array so future strategies (idle-gap, every-edit, ...)
+ * can yield multiple pivots per record; `random` yields at most one.
+ */
+export function selectPivots(entries: readonly LogEntry[], strategy: PivotStrategy, rng: Random): number[] {
+	switch (strategy) {
+		case PivotStrategy.Random:
+			return selectRandomPivot(entries, rng);
+		default:
+			return assertNever(strategy);
+	}
+}
+
+function selectRandomPivot(entries: readonly LogEntry[], rng: Random): number[] {
+	const candidates = eligiblePivotIndices(entries);
+	if (candidates.length === 0) {
+		return [];
+	}
+	const idx = candidates[rng.nextIntRange(0, candidates.length)];
+	return [entryTime(entries[idx])!];
+}
+
+/**
+ * Indices `i` that are valid pivot points. An index is eligible when:
+ *
+ * - `entries[i].kind` is `changed` or `selectionChanged`. This is the key
+ *   constraint and it satisfies two requirements at once:
+ *     1. *Replayability.* The replay engine establishes the prefix's active
+ *        document only on `changed`/`selectionChanged` (see
+ *        `ObservableWorkspaceRecordingReplayer`); pivoting on framing entries
+ *        (`documentEncountered`/`setContent`/`opened`) would leave the prefix
+ *        with no active document and fail replay. Because the pivot is also the
+ *        last entry of the prefix, the split's active document (the last
+ *        id-bearing entry) and the replayer's active document coincide.
+ *     2. *In-window.* Continuous slices carry self-contained framing whose true
+ *        times can pre-date the slice window (see `DebugRecorder.getDocumentLogInRange`),
+ *        whereas `changed`/`selectionChanged` only ever come from in-window
+ *        activity. Restricting to those kinds keeps the pivot inside the window.
+ *   These are also exactly the moments a real NES request fires (after an edit
+ *   or a cursor move), so the synthesized sample mirrors production.
+ * - `entries[i].time` is *globally unique* across the recording. Uniqueness
+ *   guarantees that splitting by time lands deterministically on index `i`
+ *   (`binarySearch` returns an arbitrary index among equal-time entries), which
+ *   defends the rare case where an in-window event shares a timestamp with
+ *   framing or with another document's event.
+ * - the active document (`entries[i].id`) was introduced by a
+ *   `documentEncountered` somewhere, so its path is resolvable.
+ * - the suffix `[i+1..]` holds at least one `changed` event on that active
+ *   document — i.e. a non-empty oracle exists.
+ *
+ * @returns eligible indices in ascending order (possibly empty).
+ */
+function eligiblePivotIndices(entries: readonly LogEntry[]): number[] {
+	const n = entries.length;
+	const eligible: number[] = [];
+	if (n < 2) {
+		return eligible;
+	}
+
+	// Single forward pass to compute the set of document ids ever introduced,
+	// the last index a `changed` occurred per document id, and time frequencies.
+	const encounteredIds = new Set<number>();
+	const lastChangedIdxForId = new Map<number, number>();
+	const timeFrequency = new Map<number, number>();
+	for (let i = 0; i < n; i++) {
+		const entry = entries[i];
+		if (entry.kind === 'documentEncountered') {
+			encounteredIds.add(entry.id);
+		} else if (entry.kind === 'changed') {
+			lastChangedIdxForId.set(entry.id, i);
+		}
+
+		const time = entryTime(entry);
+		if (time !== undefined) {
+			timeFrequency.set(time, (timeFrequency.get(time) ?? 0) + 1);
+		}
+	}
+
+	for (let i = 0; i < n - 1; i++) {
+		const entry = entries[i];
+		if (entry.kind !== 'changed' && entry.kind !== 'selectionChanged') {
+			continue; // pivot must establish a replayable, in-window active document
+		}
+		if (timeFrequency.get(entry.time) !== 1) {
+			continue; // need an unambiguous, deterministic split boundary
+		}
+		if (!encounteredIds.has(entry.id)) {
+			continue; // active document must be resolvable to a path
+		}
+		const lastChangedIdx = lastChangedIdxForId.get(entry.id);
+		if (lastChangedIdx === undefined || lastChangedIdx <= i) {
+			continue; // a non-empty oracle must follow the pivot on the active doc
+		}
+		eligible.push(i);
+	}
+
+	return eligible;
+}
+
+/** The numeric event time of an entry, or `undefined` for `meta` entries. */
+function entryTime(entry: LogEntry): number | undefined {
+	return 'time' in entry ? entry.time : undefined;
+}
+
+/**
+ * Derive a per-record seed from a base seed and a record index using a
+ * splitmix32-style integer hash. This makes each record's pivot selection
+ * depend only on `(baseSeed, globalRecordIndex)` — never on how the input is
+ * chunked across parallel workers — so runs are reproducible from `--seed`
+ * regardless of `--parallelism`.
+ */
+export function deriveSeed(baseSeed: number, index: number): number {
+	let h = (baseSeed ^ (index + 0x9e3779b9)) >>> 0;
+	h = Math.imul(h ^ (h >>> 16), 0x21f0aaad) >>> 0;
+	h = Math.imul(h ^ (h >>> 15), 0x735a2d97) >>> 0;
+	h = (h ^ (h >>> 15)) >>> 0;
+	return h;
+}

--- a/extensions/copilot/test/pipeline/continuous/processContinuous.spec.ts
+++ b/extensions/copilot/test/pipeline/continuous/processContinuous.spec.ts
@@ -1,0 +1,100 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from 'vitest';
+import { LogEntry } from '../../../src/platform/workspaceRecorder/common/workspaceLog';
+import { PivotStrategy } from '../../base/simulationOptions';
+import { IContinuousRecord } from './continuousRecord';
+import { CONTINUOUS_SUGGESTION_STATUS, processContinuousRecord, processContinuousRecords } from './processContinuous';
+
+const doc = Array.from({ length: 30 }, (_, i) => `// L${String(i).padStart(2, '0')}`).join('\n') + '\n';
+
+// Window metadata the sender always ships; irrelevant to pivot/replay logic but
+// required by `IContinuousRecording`, so these tests fill it with fixed dummies.
+const META = { windowStart: 0, windowEnd: 1, sessionId: 'test', sequenceNumber: 0 };
+
+const entries: LogEntry[] = [
+	{ kind: 'meta', data: { repoRootUri: 'file:///ws' } },
+	{ kind: 'documentEncountered', id: 0, time: 1000, relativePath: 'src/x.ts' },
+	{ kind: 'setContent', id: 0, time: 1001, content: doc, v: 0 },
+	{ kind: 'selectionChanged', id: 0, time: 1002, selection: [[14, 14]] },
+	{ kind: 'changed', id: 0, time: 1004, edit: [[175, 175, 'Z']], v: 1 },
+	{ kind: 'selectionChanged', id: 0, time: 1006, selection: [[175, 175]] },
+	{ kind: 'changed', id: 0, time: 1008, edit: [[7, 7, 'Q']], v: 2 },
+];
+
+function record(): IContinuousRecord {
+	return { originalRowIndex: 0, value: { entries, entriesSize: 100, ...META } };
+}
+
+describe('processContinuousRecord', () => {
+	it('synthesizes an oracle-only row and resolves language from the active file', () => {
+		const result = processContinuousRecord(record(), 1002);
+		expect(result.isOk()).toBe(true);
+		if (result.isError()) { return; }
+		expect(result.val.row.suggestionStatus).toBe(CONTINUOUS_SUGGESTION_STATUS);
+		expect(result.val.row.activeDocumentLanguageId).toBe('typescript');
+		result.val.replayer.dispose();
+	});
+
+	it('errors when the recording has no entries', () => {
+		const empty: IContinuousRecord = { originalRowIndex: 0, value: { entries: [], entriesSize: 0, ...META } };
+		expect(processContinuousRecord(empty, 0).isError()).toBe(true);
+	});
+});
+
+describe('processContinuousRecords', () => {
+	it('produces identical pivots across runs with the same seed', () => {
+		const a = processContinuousRecords([record()], PivotStrategy.Random, 99, 0);
+		const b = processContinuousRecords([record()], PivotStrategy.Random, 99, 0);
+		expect(a.processed.length).toBe(b.processed.length);
+		expect(a.errors).toEqual(b.errors);
+		[...a.processed, ...b.processed].forEach(p => p.replayer.dispose());
+	});
+
+	it('every selected pivot is replayable (eligible ⟹ replayable)', () => {
+		// Regression guard: a pivot that `selectPivots` deems eligible must always
+		// produce a real sample, never a replay error. Sweep seeds so different
+		// eligible pivots (the in-window selectionChanged/changed entries) are hit.
+		for (let seed = 0; seed < 50; seed++) {
+			const { processed, errors } = processContinuousRecords([record()], PivotStrategy.Random, seed, 0);
+			expect(errors).toEqual([]);
+			expect(processed).toHaveLength(1);
+			processed.forEach(p => p.replayer.dispose());
+		}
+	});
+
+	it('reports a no-eligible-pivot error when no oracle follows', () => {
+		const noOracle: IContinuousRecord = {
+			originalRowIndex: 3,
+			value: { entries: entries.slice(0, 4), entriesSize: 50, ...META },
+		};
+		const { processed, errors } = processContinuousRecords([noOracle], PivotStrategy.Random, 1, 0);
+		expect(processed).toHaveLength(0);
+		expect(errors[0]).toMatchObject({ originalRowIndex: 3 });
+	});
+
+	it('isolates a throwing record so the rest of the batch still produces rows', () => {
+		// A malformed oracle edit (overlapping replacements) makes replay throw a
+		// `BugIndicatingError` from the `StringEdit` constructor. One bad record
+		// must not abort the whole batch: it should surface as a per-record error
+		// while its siblings still process — matching the alternative-action path.
+		const malformedEntries: LogEntry[] = [
+			{ kind: 'meta', data: { repoRootUri: 'file:///ws' } },
+			{ kind: 'documentEncountered', id: 0, time: 3000, relativePath: 'src/bad.ts' },
+			{ kind: 'setContent', id: 0, time: 3001, content: doc, v: 0 },
+			{ kind: 'changed', id: 0, time: 3003, edit: [[5, 5, 'A']], v: 1 },
+			{ kind: 'changed', id: 0, time: 3005, edit: [[10, 14, 'X'], [12, 16, 'Y']], v: 2 },
+		];
+		const malformed: IContinuousRecord = { originalRowIndex: 1, value: { entries: malformedEntries, entriesSize: 80, ...META } };
+		const good = (originalRowIndex: number): IContinuousRecord => ({ originalRowIndex, value: { entries, entriesSize: 100, ...META } });
+
+		const { processed, errors } = processContinuousRecords([good(0), malformed, good(2)], PivotStrategy.Random, 7, 0);
+
+		expect(processed).toHaveLength(2);
+		expect(errors.map(e => ({ originalRowIndex: e.originalRowIndex, isError: e.value instanceof Error }))).toEqual([{ originalRowIndex: 1, isError: true }]);
+		processed.forEach(p => p.replayer.dispose());
+	});
+});

--- a/extensions/copilot/test/pipeline/continuous/processContinuous.ts
+++ b/extensions/copilot/test/pipeline/continuous/processContinuous.ts
@@ -1,0 +1,162 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IAlternativeAction } from '../../../src/extension/inlineEdits/node/nextEditProviderTelemetry';
+import { Random } from '../../../src/platform/inlineEdits/test/node/random';
+import { LogEntry } from '../../../src/platform/workspaceRecorder/common/workspaceLog';
+import { ErrorUtils } from '../../../src/util/common/errors';
+import { Result } from '../../../src/util/common/result';
+import { PivotStrategy } from '../../base/simulationOptions';
+import { IInputRow } from '../parseInput';
+import { IProcessedRow, processRecordingAtPivot } from '../replayRecording';
+import { IContinuousRecord } from './continuousRecord';
+import { deriveSeed, selectPivots } from './pivotStrategy';
+import type { WithRowIndex } from '../withRowIndex';
+
+/**
+ * Sentinel `suggestionStatus` for samples synthesized from a continuous
+ * recording: no model suggestion was ever made, so the sample is oracle-only
+ * (the model edit scores 0).
+ */
+export const CONTINUOUS_SUGGESTION_STATUS = 'continuous';
+
+/**
+ * Build a synthetic {@link IInputRow} for one continuous-recording pivot.
+ *
+ * Continuous slices carry no model suggestion, prompt, or response — only the
+ * recorded edit timeline — so those fields use sentinels: an empty
+ * `suggestedEdit` produces no proposed edits, which is exactly what we want for
+ * oracle-only training data. `activeDocumentLanguageId` is filled in by the
+ * caller after replay, once the active file (and hence its language) is known.
+ */
+function synthesizeRow(record: IContinuousRecord, entries: LogEntry[], pivotTime: number, languageId: string): IInputRow {
+	const alternativeAction: IAlternativeAction = {
+		text: undefined,
+		textLength: 0,
+		selection: [],
+		edits: [],
+		tags: [CONTINUOUS_SUGGESTION_STATUS],
+		recording: {
+			entries,
+			entriesSize: record.value.entriesSize,
+			requestTime: pivotTime,
+		},
+	};
+
+	return {
+		originalRowIndex: record.originalRowIndex,
+		suggestionStatus: CONTINUOUS_SUGGESTION_STATUS,
+		alternativeAction,
+		prompt: [],
+		modelResponse: '',
+		postProcessingOutcome: { suggestedEdit: '', isInlineCompletion: false },
+		activeDocumentLanguageId: languageId,
+	};
+}
+
+/**
+ * Turn a single continuous recording into a processed row by splitting it at
+ * `pivotTime`. The returned {@link IProcessedRow} holds a live replayer that the
+ * caller must dispose.
+ *
+ * Never throws: like {@link processRow}, any unexpected error during replay
+ * (e.g. a malformed recorded edit) is caught and returned as an error `Result`,
+ * so one bad record can't abort a whole batch (see {@link processContinuousRecords}).
+ */
+export function processContinuousRecord(record: IContinuousRecord, pivotTime: number): Result<IProcessedRow, Error> {
+	try {
+		return _processContinuousRecord(record, pivotTime);
+	} catch (e: unknown) {
+		return Result.error(ErrorUtils.fromUnknown(e));
+	}
+}
+
+function _processContinuousRecord(record: IContinuousRecord, pivotTime: number): Result<IProcessedRow, Error> {
+	const entries = record.value.entries;
+	if (!entries || entries.length === 0) {
+		return Result.fromString('Continuous recording has no entries');
+	}
+
+	const result = processRecordingAtPivot({
+		row: synthesizeRow(record, entries, pivotTime, ''),
+		entries,
+		requestTime: pivotTime,
+		proposedEdits: [],
+		isAccepted: false,
+	});
+	if (result.isError()) {
+		return result;
+	}
+
+	// The replayer resolves the active document's language from its file
+	// extension; reuse that so continuous samples carry a real language id
+	// (continuous telemetry has no per-slice language column).
+	const languageId = result.val.activeDocument.languageId.get();
+	return Result.ok({
+		...result.val,
+		row: { ...result.val.row, activeDocumentLanguageId: languageId },
+	});
+}
+
+/**
+ * Process a batch of continuous recordings into processed rows.
+ *
+ * Each record's pivot selection is seeded from `deriveSeed(baseSeed, rowOffset +
+ * record.originalRowIndex)`, so output is reproducible from `--seed` and
+ * independent of how records are sharded across parallel workers.
+ *
+ * `rowOffset` is the global index of the first record in this chunk (0 for
+ * single-process runs); it is added to each record's local index to form the
+ * global record index used for seeding.
+ *
+ * Each returned `IProcessedRow` holds a live replayer that the caller must dispose.
+ */
+export function processContinuousRecords(
+	records: readonly IContinuousRecord[],
+	strategy: PivotStrategy,
+	baseSeed: number,
+	rowOffset: number,
+): {
+	processed: IProcessedRow[];
+	errors: WithRowIndex<Error>[];
+} {
+	const processed: IProcessedRow[] = [];
+	const errors: WithRowIndex<Error>[] = [];
+
+	for (const record of records) {
+		const entries = record.value.entries;
+		if (!entries || entries.length === 0) {
+			errors.push({ originalRowIndex: record.originalRowIndex, value: new Error('Continuous recording has no entries') });
+			continue;
+		}
+
+		const globalRecordIndex = rowOffset + record.originalRowIndex;
+		const rng = Random.create(deriveSeed(baseSeed, globalRecordIndex));
+
+		const pivots = selectPivots(entries, strategy, rng);
+		if (pivots.length === 0) {
+			errors.push({ originalRowIndex: record.originalRowIndex, value: new Error(`No eligible pivot found (strategy: ${strategy}, ${entries.length} entries)`) });
+			continue;
+		}
+
+		// NOTE: each materialized row is keyed downstream by `originalRowIndex`
+		// (prompt/response/output maps in pipeline.ts). The shipped `random`
+		// strategy yields at most one pivot per record, so that key stays unique.
+		// A future multi-pivot strategy (idle-gap, every-edit, ...) MUST first
+		// introduce a per-sample id (e.g. `{ originalRowIndex, pivotOrdinal }`)
+		// threaded through those maps, otherwise rows sharing a record index
+		// would overwrite each other.
+		for (const pivotTime of pivots) {
+			const result = processContinuousRecord(record, pivotTime);
+			if (result.isError()) {
+				errors.push({ originalRowIndex: record.originalRowIndex, value: result.err });
+			} else {
+				processed.push(result.val);
+			}
+		}
+	}
+
+	return { processed, errors };
+}

--- a/extensions/copilot/test/pipeline/parseInput.ts
+++ b/extensions/copilot/test/pipeline/parseInput.ts
@@ -4,7 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IAlternativeAction } from '../../src/extension/inlineEdits/node/nextEditProviderTelemetry';
+import { ErrorUtils } from '../../src/util/common/errors';
 import { streamJsonRecords } from './streamJsonRecords';
+import type { WithRowIndex } from './withRowIndex';
 
 /**
  * A single row from the JSON input.
@@ -80,10 +82,10 @@ function parseInputRecord(record: Record<string, string>, rowIndex: number): IIn
  */
 export async function loadAndParseInput(inputPath: string, verbose = false): Promise<{
 	rows: IInputRow[];
-	errors: { rowIndex: number; error: string }[];
+	errors: WithRowIndex<Error>[];
 }> {
 	const rows: IInputRow[] = [];
-	const errors: { rowIndex: number; error: string }[] = [];
+	const errors: WithRowIndex<Error>[] = [];
 
 	let i = 0;
 	for await (const record of streamJsonRecords<Record<string, string>>(inputPath)) {
@@ -92,8 +94,8 @@ export async function loadAndParseInput(inputPath: string, verbose = false): Pro
 			rows.push(parseInputRecord(record, rowIndex));
 		} catch (e) {
 			errors.push({
-				rowIndex,
-				error: e instanceof Error ? e.message : String(e),
+				originalRowIndex: rowIndex,
+				value: ErrorUtils.fromUnknown(e),
 			});
 		}
 	}

--- a/extensions/copilot/test/pipeline/pipeline.ts
+++ b/extensions/copilot/test/pipeline/pipeline.ts
@@ -73,7 +73,11 @@ export type RunPipelineOptions = {
  * continuous recordings.
  */
 interface ILoadedProcessedRows {
-	/** Number of input records read (for the `[1/5]` progress line and summary). */
+	/**
+	 * Number of input records that parsed successfully — the starting count for
+	 * the `[1/5]` progress line and the pipeline summary funnel. Parse failures
+	 * are excluded and counted separately in {@link parseErrors}.
+	 */
 	readonly recordCount: number;
 	/** Per-record parse failures. */
 	readonly parseErrors: readonly WithRowIndex<Error>[];
@@ -82,10 +86,11 @@ interface ILoadedProcessedRows {
 	/** Per-record replay/processing failures. */
 	readonly replayErrors: readonly WithRowIndex<Error>[];
 	/**
-	 * Resolve the language id for a record index, for error messages. Continuous
-	 * records have no language before replay, so this returns `'?'` for them.
+	 * Resolve the language id for a record by its `originalRowIndex` (the record's
+	 * position in the input file), for error messages. Continuous records have no
+	 * language before replay, so this returns `'?'` for them.
 	 */
-	readonly languageForRow: (rowIndex: number) => string;
+	readonly languageForRow: (originalRowIndex: number) => string;
 }
 
 /**
@@ -119,12 +124,13 @@ async function loadAndProduceProcessedRows(nesDatagenOpts: NesDatagen, verbose: 
 
 	const { rows, errors: parseErrors } = await loadAndParseInput(inputPath, verbose);
 	const { processed, errors: replayErrors } = processAllRows(rows);
+	const languageByRowIndex = new Map(rows.map(row => [row.originalRowIndex, row.activeDocumentLanguageId]));
 	return {
 		recordCount: rows.length,
 		parseErrors,
 		processed,
 		replayErrors,
-		languageForRow: (i: number) => rows[i]?.activeDocumentLanguageId ?? '?',
+		languageForRow: (originalRowIndex: number) => languageByRowIndex.get(originalRowIndex) ?? '?',
 	};
 }
 

--- a/extensions/copilot/test/pipeline/pipeline.ts
+++ b/extensions/copilot/test/pipeline/pipeline.ts
@@ -14,7 +14,9 @@ import { Limiter } from '../../src/util/vs/base/common/async';
 import { OffsetRange } from '../../src/util/vs/editor/common/core/ranges/offsetRange';
 import { StringText } from '../../src/util/vs/editor/common/core/text/abstractText';
 import { applyConfigFile, loadConfigFile } from '../base/simulationContext';
-import { NesDatagen, NesDatagenSampleTask, SimulationOptions } from '../base/simulationOptions';
+import { NesDatagen, NesDatagenInputFormat, NesDatagenSampleTask, SimulationOptions } from '../base/simulationOptions';
+import { loadAndParseContinuousInput } from './continuous/continuousRecord';
+import { processContinuousRecords } from './continuous/processContinuous';
 import { detectCrossFileJump, detectSameFileJump } from './cursorJump/detectJump';
 import { generateCursorPromptFromRecording, installCursorJumpCapturingFetcher } from './cursorJump/cursorJumpPromptStep';
 import { generateCrossFileResponse, generateSameFileResponse } from './cursorJump/cursorJumpResponseStep';
@@ -25,6 +27,7 @@ import { IProcessedRow, parseSuggestedEdit, processAllRows } from './replayRecor
 import { generateAllResponses, generateResponse, IResponseGenerationInput, applyEditsToContent } from './responseStep';
 import { streamJsonRecords } from './streamJsonRecords';
 import { openWriteStream } from './writeStream';
+import type { WithRowIndex } from './withRowIndex';
 
 function logErrors(errors: readonly { error: string }[], verbose: boolean, log: (...ps: any[]) => void): void {
 	if (errors.length > 0 && verbose) {
@@ -64,6 +67,68 @@ export type RunPipelineOptions = {
 };
 
 /**
+ * Result of the shared "parse input + replay into processed rows" front half of
+ * both pipelines. Abstracts over the input format so the xtab and cursor-jump
+ * pipelines don't need to know whether the rows came from alternative-action or
+ * continuous recordings.
+ */
+interface ILoadedProcessedRows {
+	/** Number of input records read (for the `[1/5]` progress line and summary). */
+	readonly recordCount: number;
+	/** Per-record parse failures. */
+	readonly parseErrors: readonly WithRowIndex<Error>[];
+	/** Successfully replayed rows. Each holds a live replayer the caller must dispose. */
+	readonly processed: IProcessedRow[];
+	/** Per-record replay/processing failures. */
+	readonly replayErrors: readonly WithRowIndex<Error>[];
+	/**
+	 * Resolve the language id for a record index, for error messages. Continuous
+	 * records have no language before replay, so this returns `'?'` for them.
+	 */
+	readonly languageForRow: (rowIndex: number) => string;
+}
+
+/**
+ * Parse the input and replay each recording into processed rows, dispatching on
+ * `--input-format`. This is the format-aware front half shared by both the xtab
+ * and cursor-jump pipelines.
+ *
+ * For continuous input the pivot RNG is seeded from `nesDatagenOpts.seed` and
+ * `nesDatagenOpts.rowOffset`, so output is reproducible and independent of how
+ * the input is sharded across workers.
+ */
+async function loadAndProduceProcessedRows(nesDatagenOpts: NesDatagen, verbose: boolean): Promise<ILoadedProcessedRows> {
+	const inputPath = nesDatagenOpts.input;
+
+	if (nesDatagenOpts.inputFormat === NesDatagenInputFormat.Continuous) {
+		const { records, errors: parseErrors } = await loadAndParseContinuousInput(inputPath, verbose);
+		const { processed, errors: replayErrors } = processContinuousRecords(
+			records,
+			nesDatagenOpts.pivotStrategy,
+			nesDatagenOpts.seed,
+			nesDatagenOpts.rowOffset,
+		);
+		return {
+			recordCount: records.length,
+			parseErrors,
+			processed,
+			replayErrors,
+			languageForRow: () => '?',
+		};
+	}
+
+	const { rows, errors: parseErrors } = await loadAndParseInput(inputPath, verbose);
+	const { processed, errors: replayErrors } = processAllRows(rows);
+	return {
+		recordCount: rows.length,
+		parseErrors,
+		processed,
+		replayErrors,
+		languageForRow: (i: number) => rows[i]?.activeDocumentLanguageId ?? '?',
+	};
+}
+
+/**
  * Single-process pipeline entry point. Dispatches to the xtab or cursor-jump
  * pipeline based on the configured sample task.
  *
@@ -99,17 +164,18 @@ async function runXtabPipeline(opts: RunPipelineOptions, log: (...ps: any[]) => 
 	log(`\n=== Pipeline ===`);
 	log(`  Input: ${inputPath}`);
 	log(`  Concurrency: ${concurrency}`);
+	if (nesDatagenOpts.inputFormat === NesDatagenInputFormat.Continuous) {
+		log(`  Input format: continuous (pivot-strategy: ${nesDatagenOpts.pivotStrategy}, seed: ${nesDatagenOpts.seed})`);
+	}
 
-	// Step 1: Parse input
-	const { rows, errors } = await loadAndParseInput(inputPath, verbose);
-	log(`  [1/5] Input parsed: ${rows.length} rows, ${errors.length} errors`);
-	logErrors(errors, verbose, log);
+	// Step 1+2: Parse input and replay recordings (format-aware)
+	const { recordCount, parseErrors, processed, replayErrors, languageForRow } = await loadAndProduceProcessedRows(nesDatagenOpts, verbose);
+	log(`  [1/5] Input parsed: ${recordCount} rows, ${parseErrors.length} errors`);
+	logErrors(parseErrors.map(e => ({ error: e.value.message })), verbose, log);
 
-	// Step 2: Replay recordings
-	const { processed, errors: replayErrors } = processAllRows(rows);
 	log(`  [2/5] Recordings replayed: ${processed.length} ok, ${replayErrors.length} errors`);
 	logErrors(replayErrors.map(e => ({
-		error: `[sample ${e.rowIndex + rowOffset}, ${rows[e.rowIndex]?.activeDocumentLanguageId ?? '?'}] ${e.error}`,
+		error: `[sample ${e.originalRowIndex + rowOffset}, ${languageForRow(e.originalRowIndex)}] ${e.value.message}`,
 	})), verbose, log);
 
 	// Step 3: Generate prompts
@@ -215,7 +281,7 @@ async function runXtabPipeline(opts: RunPipelineOptions, log: (...ps: any[]) => 
 		}
 
 		// Summary
-		log(`\n  Pipeline: Input(${rows.length}) → Replay(${processed.length}) → Prompt(${prompts.length}) → Response(${responses.length}) → Output(${writeResult.written})`);
+		log(`\n  Pipeline: Input(${recordCount}) → Replay(${processed.length}) → Prompt(${prompts.length}) → Response(${responses.length}) → Output(${writeResult.written})`);
 	} finally {
 		for (const p of processed) {
 			p.replayer.dispose();
@@ -241,15 +307,17 @@ async function runCursorPipeline(opts: RunPipelineOptions, log: (...ps: any[]) =
 	log(`  Sample task: ${task}`);
 	log(`  Concurrency: ${concurrency}`);
 	log(`  Same-file jump thresholds: above=${nesDatagenOpts.sameFileJumpMinAbove}, below=${nesDatagenOpts.sameFileJumpMinBelow}`);
+	if (nesDatagenOpts.inputFormat === NesDatagenInputFormat.Continuous) {
+		log(`  Input format: continuous (pivot-strategy: ${nesDatagenOpts.pivotStrategy}, seed: ${nesDatagenOpts.seed})`);
+	}
 
-	const { rows, errors } = await loadAndParseInput(inputPath, verbose);
-	log(`  [1/5] Input parsed: ${rows.length} rows, ${errors.length} errors`);
-	logErrors(errors, verbose, log);
+	const { recordCount, parseErrors, processed, replayErrors, languageForRow } = await loadAndProduceProcessedRows(nesDatagenOpts, verbose);
+	log(`  [1/5] Input parsed: ${recordCount} rows, ${parseErrors.length} errors`);
+	logErrors(parseErrors.map(e => ({ error: e.value.message })), verbose, log);
 
-	const { processed, errors: replayErrors } = processAllRows(rows);
 	log(`  [2/5] Recordings replayed: ${processed.length} ok, ${replayErrors.length} errors`);
 	logErrors(replayErrors.map(e => ({
-		error: `[sample ${e.rowIndex + rowOffset}, ${rows[e.rowIndex]?.activeDocumentLanguageId ?? '?'}] ${e.error}`,
+		error: `[sample ${e.originalRowIndex + rowOffset}, ${languageForRow(e.originalRowIndex)}] ${e.value.message}`,
 	})), verbose, log);
 
 	// Detect jumps first — many rows will be skipped here, no point capturing
@@ -428,7 +496,7 @@ async function runCursorPipeline(opts: RunPipelineOptions, log: (...ps: any[]) =
 		const writeResult = await writeSamples(outputPath, samples);
 		log(`  [5/5] Output written: ${writeResult.written} samples → ${writeResult.outputPath}`);
 
-		log(`\n  Pipeline: Input(${rows.length}) → Replay(${processed.length}) → Jumps(${jumps.size}) → Prompt(${prompts.length}) → Output(${writeResult.written})`);
+		log(`\n  Pipeline: Input(${recordCount}) → Replay(${processed.length}) → Jumps(${jumps.size}) → Prompt(${prompts.length}) → Output(${writeResult.written})`);
 	} finally {
 		for (const p of processed) {
 			p.replayer.dispose();
@@ -528,7 +596,11 @@ export async function runInputPipelineParallel(opts: SimulationOptions): Promise
 	const numWorkers = Math.max(1, Math.min(os.cpus().length, opts.parallelism, Math.ceil(totalRecords / 25)));
 
 	console.log(`\n=== Pipeline (parallel: ${numWorkers} workers) ===`);
-	console.log(`  Input: ${inputPath} (${totalRecords} rows)\n`);
+	console.log(`  Input: ${inputPath} (${totalRecords} rows)`);
+	if (nesDatagenOpts.inputFormat === NesDatagenInputFormat.Continuous) {
+		console.log(`  Input format: continuous (pivot-strategy: ${nesDatagenOpts.pivotStrategy}, seed: ${nesDatagenOpts.seed})`);
+	}
+	console.log('');
 
 	if (totalRecords === 0) {
 		console.log(`  No records to process.`);
@@ -573,6 +645,11 @@ export async function runInputPipelineParallel(opts: SimulationOptions): Promise
 				'--row-offset', String(start),
 				'--parallelism', String(opts.parallelism),
 				'--sample-task', nesDatagenOpts.sampleTask,
+				'--input-format', nesDatagenOpts.inputFormat,
+				'--pivot-strategy', nesDatagenOpts.pivotStrategy,
+				// Propagate the parent's resolved seed so every worker selects the
+				// same pivots it would in a single-process run (reproducibility).
+				'--seed', String(nesDatagenOpts.seed),
 				'--same-file-jump-min-above', String(nesDatagenOpts.sameFileJumpMinAbove),
 				'--same-file-jump-min-below', String(nesDatagenOpts.sameFileJumpMinBelow),
 				'--worker',

--- a/extensions/copilot/test/pipeline/replayRecording.spec.ts
+++ b/extensions/copilot/test/pipeline/replayRecording.spec.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from 'vitest';
+import { LogEntry } from '../../src/platform/workspaceRecorder/common/workspaceLog';
+import { IInputRow } from './parseInput';
+import { processAllRows } from './replayRecording';
+
+const doc = `const a = 1;\nconst b = 2;\n`;
+
+/**
+ * Build an {@link IInputRow} whose recording replays a pre-pivot no-op edit and
+ * then applies `oracleEdit` after the pivot. Disjoint replacements replay
+ * cleanly; overlapping replacements make replay throw, which is how we exercise
+ * the error path without any stubbing.
+ */
+function makeRow(originalRowIndex: number, oracleEdit: [number, number, string][]): IInputRow {
+	const entries: LogEntry[] = [
+		{ kind: 'meta', data: { repoRootUri: 'file:///ws' } },
+		{ kind: 'documentEncountered', id: 0, time: 1000, relativePath: 'src/a.ts' },
+		{ kind: 'setContent', id: 0, time: 1001, content: doc, v: 0 },
+		// Pre-pivot no-op edit so the replayer has a `lastId`.
+		{ kind: 'changed', id: 0, time: 1002, edit: [[0, 0, '']], v: 1 },
+		// --- requestTime 1003 splits here; the rest is the oracle ---
+		{ kind: 'changed', id: 0, time: 1004, edit: oracleEdit, v: 2 },
+	];
+	return {
+		originalRowIndex,
+		suggestionStatus: 'accepted',
+		alternativeAction: {
+			text: doc,
+			textLength: doc.length,
+			selection: [],
+			edits: [],
+			tags: [],
+			recording: { entries, entriesSize: entries.length, requestTime: 1003 },
+		},
+		prompt: [],
+		modelResponse: '',
+		postProcessingOutcome: { suggestedEdit: '', isInlineCompletion: false },
+		activeDocumentLanguageId: 'typescript',
+	};
+}
+
+describe('processAllRows', () => {
+	it('labels replay errors with the row\'s originalRowIndex, not its filtered array position', () => {
+		// Earlier parse failures make `loadAndParseInput` hand back a *sparse*
+		// `rows` array: survivors keep their true input-file `originalRowIndex`
+		// (0, 3, 5), so the failing row's index (3) differs from its position (1)
+		// in the array. The error must be labeled by index, not position.
+		const rows = [
+			makeRow(0, [[6, 7, 'x']]),                 // valid: rename `a` -> `x`
+			makeRow(3, [[0, 4, 'X'], [2, 6, 'Y']]),    // malformed: overlapping -> replay throws
+			makeRow(5, [[6, 7, 'y']]),                 // valid: rename `a` -> `y`
+		];
+
+		const { processed, errors } = processAllRows(rows);
+		try {
+			expect(processed.map(p => p.originalRowIndex)).toEqual([0, 5]);
+			expect(errors.map(e => ({ originalRowIndex: e.originalRowIndex, isError: e.value instanceof Error }))).toEqual([
+				{ originalRowIndex: 3, isError: true },
+			]);
+		} finally {
+			processed.forEach(p => p.replayer.dispose());
+		}
+	});
+});

--- a/extensions/copilot/test/pipeline/replayRecording.ts
+++ b/extensions/copilot/test/pipeline/replayRecording.ts
@@ -7,11 +7,15 @@ import { IRecordingInformation, ObservableWorkspaceRecordingReplayer } from '../
 import { DocumentId } from '../../src/platform/inlineEdits/common/dataTypes/documentId';
 import { IObservableDocument, MutableObservableWorkspace } from '../../src/platform/inlineEdits/common/observableWorkspace';
 import { LogEntry } from '../../src/platform/workspaceRecorder/common/workspaceLog';
+import { ErrorUtils } from '../../src/util/common/errors';
+import { Result } from '../../src/util/common/result';
 import { coalesce } from '../../src/util/vs/base/common/arrays';
 import { StringText } from '../../src/util/vs/editor/common/core/text/abstractText';
 import { Processor } from './alternativeAction/processor';
+import { IStringReplacement } from './alternativeAction/types';
 import { IInputRow } from './parseInput';
 import { applyEditsToContent } from './responseStep';
+import type { WithRowIndex } from './withRowIndex';
 
 /**
  * Result of processing a single input row: replayed workspace + oracle edit.
@@ -90,48 +94,75 @@ export function parseSuggestedEdit(suggestedEditStr: string): [start: number, en
 	}
 }
 
-function formatError(e: unknown): string {
-	if (e instanceof Error) {
-		if (e.message === 'An unexpected bug occurred.' && e.stack) {
-			const frames = e.stack.split('\n').slice(1, 4).map(f => f.trim()).join(' <- ');
-			return `${e.message} Stack: ${frames}`;
-		}
-		return e.message;
-	}
-	return String(e);
-}
-
 /**
  * Process a single input row: split recording at request time, replay
  * the pre-request portion and extract the oracle edit.
  */
-export function processRow(row: IInputRow): IProcessedRow | { error: string } {
+export function processRow(row: IInputRow): Result<IProcessedRow, Error> {
 	try {
 		return _processRow(row);
 	} catch (e: unknown) {
-		return { error: `Unexpected error: ${formatError(e)}` };
+		return Result.error(ErrorUtils.fromUnknown(e));
 	}
 }
 
-function _processRow(row: IInputRow): IProcessedRow | { error: string } {
+function _processRow(row: IInputRow): Result<IProcessedRow, Error> {
 	const proposedEdits = coalesce([parseSuggestedEdit(row.postProcessingOutcome.suggestedEdit)]);
 	const isAccepted = row.suggestionStatus === 'accepted';
 
-	const split = Processor.splitRecording(row.alternativeAction);
-	if (!split) {
-		const entryCount = row.alternativeAction?.recording?.entries?.length ?? 0;
-		return { error: `Could not split recording at request time (${entryCount} entries, lang: ${row.activeDocumentLanguageId})` };
+	const recording = row.alternativeAction?.recording;
+	const entries = recording?.entries;
+	if (!recording || !entries || entries.length === 0) {
+		const entryCount = entries?.length ?? 0;
+		return Result.fromString(`No recording entries to process (${entryCount} entries, lang: ${row.activeDocumentLanguageId})`);
 	}
 
-	const scoring = Processor.createScoringForAlternativeAction(
-		row.alternativeAction,
+	return processRecordingAtPivot({
+		row,
+		entries,
+		requestTime: recording.requestTime,
+		proposedEdits,
+		isAccepted,
+	});
+}
+
+/**
+ * Pivot-centric core shared by the per-request (alternative-action) and the
+ * continuous-recording paths. Splits `entries` at `requestTime`, replays the
+ * pre-pivot portion into a live workspace and extracts the oracle edit that
+ * follows the pivot.
+ *
+ * For per-request recordings the pivot is the NES request bookmark
+ * (`recording.requestTime`); for continuous recordings it is synthesized by a
+ * pivot strategy. The returned {@link IProcessedRow} holds a live replayer that
+ * the caller must dispose.
+ */
+export function processRecordingAtPivot(args: {
+	/** Input row metadata threaded through to the result; synthesized for continuous recordings. */
+	readonly row: IInputRow;
+	/** Full recording timeline (must be non-empty). */
+	readonly entries: LogEntry[];
+	/** Pivot time: entries with `time <= requestTime` are context, the rest hold the oracle. */
+	readonly requestTime: number;
+	readonly proposedEdits: IStringReplacement[];
+	readonly isAccepted: boolean;
+}): Result<IProcessedRow, Error> {
+	const { row, entries, requestTime, proposedEdits, isAccepted } = args;
+
+	const split = Processor.splitRecording(entries, requestTime);
+	if (!split) {
+		return Result.fromString(`Could not split recording at request time (${entries.length} entries, lang: ${row.activeDocumentLanguageId})`);
+	}
+
+	const scoring = Processor.createScoring(
+		entries,
+		requestTime,
 		proposedEdits,
 		isAccepted,
 	);
 
 	if (!scoring) {
-		const entryCount = row.alternativeAction?.recording?.entries?.length ?? 0;
-		return { error: `Processor.createScoringForAlternativeAction returned undefined (${entryCount} entries, lang: ${row.activeDocumentLanguageId})` };
+		return Result.fromString(`Processor.createScoring returned undefined (${entries.length} entries, lang: ${row.activeDocumentLanguageId})`);
 	}
 
 	const recording = scoring.scoringContext.recording;
@@ -145,84 +176,88 @@ function _processRow(row: IInputRow): IProcessedRow | { error: string } {
 	};
 
 	const replayer = new ObservableWorkspaceRecordingReplayer(recordingInfo);
-	let lastDocId: DocumentId;
 	try {
-		const result = replayer.replay();
-		lastDocId = result.lastDocId;
-	} catch (e) {
-		replayer.dispose();
-		return { error: `Replay failed (${recording.log.length} entries, file: ${recording.nextUserEdit?.relativePath ?? 'unknown'}): ${formatError(e)}` };
-	}
+		const { lastDocId } = replayer.replay();
 
-	const workspace = replayer.workspace;
-	const activeDocument = workspace.getDocument(lastDocId);
-	if (!activeDocument) {
-		replayer.dispose();
-		return { error: `Active document not found after replay: ${lastDocId}` };
-	}
-
-	// Prefer scoring edit URI, fall back to oracle path
-	const activeFilePath = scoring.edits[0]?.documentUri ?? recording.nextUserEdit?.relativePath ?? 'unknown';
-
-	// Compute cursor-at-request from the *last* `selectionChanged` on the
-	// active doc within the pre-request portion. Multi-cursor selections use
-	// the primary (first) range — matches `IObservableDocument._primarySelectionLine`
-	// semantics. If no selection event exists for the active doc, leave as
-	// undefined so cursor-jump detectors can skip the row.
-	const cursorAtRequest = (() => {
-		for (let i = split.recordingPriorToRequest.length - 1; i >= 0; i--) {
-			const entry = split.recordingPriorToRequest[i];
-			if (entry.kind === 'selectionChanged' && entry.id === split.currentFile.id && entry.selection.length > 0) {
-				const offset = entry.selection[0][0];
-				const content = activeDocument.value.get().value;
-				const transformer = new StringText(content).getTransformer();
-				const lineNumber = transformer.getPosition(Math.min(offset, content.length)).lineNumber - 1;
-				return { offset, lineNumber };
-			}
+		const workspace = replayer.workspace;
+		const activeDocument = workspace.getDocument(lastDocId);
+		if (!activeDocument) {
+			replayer.dispose();
+			return Result.fromString(`Active document not found after replay: ${lastDocId}`);
 		}
-		return undefined;
-	})();
 
-	// Snapshot every observed doc's content at request time. Walks the
-	// pre-request portion once applying setContent + changed events, so
-	// cross-file jump detection can resolve the target line even when the
-	// target was opened before the bookmark.
-	const idToContentAtRequest = (() => {
-		const map = new Map<number, string>();
-		for (const entry of split.recordingPriorToRequest) {
-			if (entry.kind === 'setContent') {
-				map.set(entry.id, entry.content);
-			} else if (entry.kind === 'changed') {
-				const c = map.get(entry.id);
-				if (c === undefined) {
-					continue;
+		// Prefer scoring edit URI, fall back to oracle path
+		const activeFilePath = scoring.edits[0]?.documentUri ?? recording.nextUserEdit?.relativePath ?? 'unknown';
+
+		// Compute cursor-at-request from the *last* `selectionChanged` on the
+		// active doc within the pre-request portion. Multi-cursor selections use
+		// the primary (first) range — matches `IObservableDocument._primarySelectionLine`
+		// semantics. If no selection event exists for the active doc, leave as
+		// undefined so cursor-jump detectors can skip the row.
+		const cursorAtRequest = (() => {
+			for (let i = split.recordingPriorToRequest.length - 1; i >= 0; i--) {
+				const entry = split.recordingPriorToRequest[i];
+				if (entry.kind === 'selectionChanged' && entry.id === split.currentFile.id && entry.selection.length > 0) {
+					const offset = entry.selection[0][0];
+					const content = activeDocument.value.get().value;
+					const transformer = new StringText(content).getTransformer();
+					const lineNumber = transformer.getPosition(Math.min(offset, content.length)).lineNumber - 1;
+					return { offset, lineNumber };
 				}
-				// Replacements within a single `changed` event are all relative
-				// to the same base content, so they must be applied
-				// offset-descending (as `applyEditsToContent` does) — applying
-				// ascending in-place would shift later original offsets.
-				map.set(entry.id, applyEditsToContent(c, entry.edit));
 			}
-		}
-		return map;
-	})();
+			return undefined;
+		})();
 
-	return {
-		originalRowIndex: row.originalRowIndex,
-		row,
-		replayer,
-		workspace,
-		activeDocId: lastDocId,
-		activeDocument,
-		activeFilePath,
-		nextUserEdit: recording.nextUserEdit,
-		recordingInfo,
-		recordingAfterRequest: split.recordingAfterRequest,
-		activeDocLogId: split.currentFile.id,
-		idToRelativePath: split.idToFileMap,
-		cursorAtRequest,
-		idToContentAtRequest,
-	};
+		// Snapshot every observed doc's content at request time. Walks the
+		// pre-request portion once applying setContent + changed events, so
+		// cross-file jump detection can resolve the target line even when the
+		// target was opened before the bookmark.
+		const idToContentAtRequest = (() => {
+			const map = new Map<number, string>();
+			for (const entry of split.recordingPriorToRequest) {
+				if (entry.kind === 'setContent') {
+					map.set(entry.id, entry.content);
+				} else if (entry.kind === 'changed') {
+					const c = map.get(entry.id);
+					if (c === undefined) {
+						continue;
+					}
+					// Replacements within a single `changed` event are all relative
+					// to the same base content, so they must be applied
+					// offset-descending (as `applyEditsToContent` does) — applying
+					// ascending in-place would shift later original offsets.
+					map.set(entry.id, applyEditsToContent(c, entry.edit));
+				}
+			}
+			return map;
+		})();
+
+		return Result.ok({
+			originalRowIndex: row.originalRowIndex,
+			row,
+			replayer,
+			workspace,
+			activeDocId: lastDocId,
+			activeDocument,
+			activeFilePath,
+			nextUserEdit: recording.nextUserEdit,
+			recordingInfo,
+			recordingAfterRequest: split.recordingAfterRequest,
+			activeDocLogId: split.currentFile.id,
+			idToRelativePath: split.idToFileMap,
+			cursorAtRequest,
+			idToContentAtRequest,
+		});
+	} catch (e) {
+		// `replayer.replay()` and the post-replay analysis above (cursor/content
+		// reconstruction) can throw on a malformed recording — e.g. a non-disjoint
+		// `changed` edit rejected by the `StringEdit` constructor, or
+		// `applyEditsToContent` over non-disjoint replacements. Dispose the live
+		// replayer before the error unwinds so a single bad record can't leak it;
+		// callers only dispose the replayer on the success path.
+		replayer.dispose();
+		throw e;
+	}
 }
 
 /**
@@ -231,17 +266,17 @@ function _processRow(row: IInputRow): IProcessedRow | { error: string } {
  */
 export function processAllRows(rows: readonly IInputRow[]): {
 	processed: IProcessedRow[];
-	errors: { rowIndex: number; error: string }[];
+	errors: WithRowIndex<Error>[];
 } {
 	const processed: IProcessedRow[] = [];
-	const errors: { rowIndex: number; error: string }[] = [];
+	const errors: WithRowIndex<Error>[] = [];
 
 	for (let i = 0; i < rows.length; i++) {
 		const result = processRow(rows[i]);
-		if ('error' in result) {
-			errors.push({ rowIndex: i, error: result.error });
+		if (result.isError()) {
+			errors.push({ originalRowIndex: i, value: result.err });
 		} else {
-			processed.push(result);
+			processed.push(result.val);
 		}
 	}
 

--- a/extensions/copilot/test/pipeline/replayRecording.ts
+++ b/extensions/copilot/test/pipeline/replayRecording.ts
@@ -272,9 +272,10 @@ export function processAllRows(rows: readonly IInputRow[]): {
 	const errors: WithRowIndex<Error>[] = [];
 
 	for (let i = 0; i < rows.length; i++) {
-		const result = processRow(rows[i]);
+		const row = rows[i];
+		const result = processRow(row);
 		if (result.isError()) {
-			errors.push({ originalRowIndex: i, value: result.err });
+			errors.push({ originalRowIndex: row.originalRowIndex, value: result.err });
 		} else {
 			processed.push(result.val);
 		}

--- a/extensions/copilot/test/pipeline/test/continuousPipeline.e2e.spec.ts
+++ b/extensions/copilot/test/pipeline/test/continuousPipeline.e2e.spec.ts
@@ -1,0 +1,221 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { NesDatagenInputFormat, NesDatagenSampleTask, PivotStrategy } from '../../base/simulationOptions';
+import { runInputPipeline, RunPipelineOptions } from '../pipeline';
+import { allContinuousRecords, continuousFixtures } from './fixtures/continuousFixtureData';
+
+/**
+ * End-to-end tests for the nes-datagen pipeline on the **continuous** input
+ * format (`--input-format=continuous`).
+ *
+ * These exercise the full `runInputPipeline` — continuous parse → pivot
+ * synthesis → split → replay → prompt/response generation → output — with real
+ * fixture data, mirroring `pipeline.e2e.spec.ts` for the alternative-action
+ * path. The fixtures are crafted so each valid slice has exactly one eligible
+ * pivot, making the output deterministic regardless of the pivot RNG seed.
+ */
+
+const configPath = path.join(__dirname, 'fixtures', 'config.json');
+
+let tmpDir: string;
+let inputPath: string;
+let outputPath: string;
+
+function parseJsonl<T>(contents: string): T[] {
+	return contents
+		.split('\n')
+		.filter(line => line.length > 0)
+		.map(line => JSON.parse(line) as T);
+}
+
+beforeAll(async () => {
+	tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nes-datagen-continuous-e2e-'));
+	inputPath = path.join(tmpDir, 'input.json');
+	outputPath = path.join(tmpDir, 'output.jsonl');
+	await fs.writeFile(inputPath, JSON.stringify(allContinuousRecords, null, 2));
+});
+
+afterAll(async () => {
+	if (tmpDir) {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	}
+});
+
+interface OutputSample {
+	messages: { role: 'system' | 'user' | 'assistant'; content: string }[];
+	metadata: {
+		rowIndex: number;
+		language: string;
+		suggestionStatus: string;
+		filePath: string;
+		docContent: string;
+		oracleEdits: [number, number, string][];
+	};
+}
+
+async function runContinuousPipeline(opts?: Partial<RunPipelineOptions>): Promise<{
+	samples: OutputSample[];
+	logs: string[];
+	output: string;
+}> {
+	const logs: string[] = [];
+	const log = (...args: unknown[]) => {
+		logs.push(args.map(a => typeof a === 'object' ? JSON.stringify(a) : String(a)).join(' '));
+	};
+
+	const pipelineOpts: RunPipelineOptions = {
+		nesDatagen: {
+			input: inputPath,
+			output: outputPath,
+			rowOffset: 0,
+			workerMode: false,
+			sampleTask: NesDatagenSampleTask.Xtab,
+			sameFileJumpMinAbove: 5,
+			sameFileJumpMinBelow: 5,
+			inputFormat: NesDatagenInputFormat.Continuous,
+			pivotStrategy: PivotStrategy.Random,
+			seed: 42,
+		},
+		configFile: configPath,
+		verbose: true,
+		parallelism: 1,
+		...opts,
+	};
+
+	await runInputPipeline(pipelineOpts, log);
+
+	const output = await fs.readFile(outputPath, 'utf-8');
+	return { samples: parseJsonl<OutputSample>(output), logs, output };
+}
+
+describe('nes-datagen continuous pipeline e2e', () => {
+
+	describe('full pipeline run', () => {
+		let result: Awaited<ReturnType<typeof runContinuousPipeline>>;
+
+		beforeAll(async () => {
+			result = await runContinuousPipeline();
+		});
+
+		test('produces one oracle-only sample per valid slice', () => {
+			// 2 valid slices (ts + py); the capped slice is dropped at parse.
+			expect(result.samples.length).toBe(2);
+		});
+
+		test('reports the capped (entries-dropped) slice as a parse error', () => {
+			const parseLog = result.logs.find(l => l.includes('[1/5]'));
+			expect(parseLog).toBeDefined();
+			expect(parseLog).toContain('1 errors');
+		});
+
+		test('logs the continuous input format with strategy and seed', () => {
+			const formatLog = result.logs.find(l => l.includes('Input format: continuous'));
+			expect(formatLog).toBeDefined();
+			expect(formatLog).toContain('pivot-strategy: random');
+			expect(formatLog).toContain('seed: 42');
+		});
+
+		test('every sample is tagged as a continuous (oracle-only) sample', () => {
+			for (const sample of result.samples) {
+				expect(sample.metadata.suggestionStatus).toBe('continuous');
+			}
+		});
+
+		test('resolves language and file path from the replayed slice', () => {
+			const ts = result.samples.find(s => s.metadata.language === 'typescript');
+			const py = result.samples.find(s => s.metadata.language === 'python');
+
+			expect(ts).toBeDefined();
+			expect(py).toBeDefined();
+			expect(ts!.metadata.filePath).toContain('src/math.ts');
+			expect(py!.metadata.filePath).toContain('src/greet.py');
+		});
+
+		test('extracts the post-pivot oracle edit', () => {
+			const ts = result.samples.find(s => s.metadata.language === 'typescript')!;
+			const py = result.samples.find(s => s.metadata.language === 'python')!;
+
+			expect(ts.metadata.oracleEdits.some(([, , text]) => text === 'sum')).toBe(true);
+			expect(py.metadata.oracleEdits.some(([, , text]) => text === ' -> str')).toBe(true);
+		});
+
+		test('docContent is the slice content at the pivot (pre-oracle)', () => {
+			const ts = result.samples.find(s => s.metadata.language === 'typescript')!;
+			// Context reflects the pre-pivot edit but not the oracle: the
+			// original `add` is present and has not yet been renamed to `sum`.
+			expect(ts.metadata.docContent).toContain('export function add(');
+			expect(ts.metadata.docContent).not.toContain('sum');
+		});
+
+		test('every sample carries non-empty system, user and assistant messages', () => {
+			for (const sample of result.samples) {
+				const roles = sample.messages.map(m => m.role);
+				expect(roles).toEqual(['system', 'user', 'assistant']);
+				for (const msg of sample.messages) {
+					expect(msg.content.trim().length).toBeGreaterThan(0);
+				}
+			}
+		});
+	});
+
+	test('is reproducible: two runs with the same seed produce identical output', async () => {
+		const a = await runContinuousPipeline();
+		const b = await runContinuousPipeline();
+		expect(a.output).toBe(b.output);
+	});
+
+	test('a slice whose oracle edit is malformed is isolated, not fatal', async () => {
+		// Overlapping replacements in the post-pivot `changed` make the split
+		// throw; the batch must still produce the sibling sample rather than abort.
+		const badEntries = [
+			{ kind: 'meta', data: { repoRootUri: 'file:///workspace' } },
+			{ kind: 'documentEncountered', id: 0, time: 3000, relativePath: 'src/bad.ts' },
+			{ kind: 'setContent', id: 0, time: 3001, content: 'const value = 1;\n', v: 0 },
+			// Pre-pivot edit → the only eligible pivot (a later `changed` follows).
+			{ kind: 'changed', id: 0, time: 3002, edit: [[0, 0, '// x\n']], v: 1 },
+			// Malformed oracle: the two replacements overlap.
+			{ kind: 'changed', id: 0, time: 3004, edit: [[6, 11, 'a'], [8, 13, 'b']], v: 2 },
+		];
+		const badRecord = { recording: JSON.stringify({ entries: badEntries, entriesSize: 100 }) };
+
+		const mixedInput = path.join(tmpDir, 'mixed-input.json');
+		const mixedOutput = path.join(tmpDir, 'mixed-output.jsonl');
+		await fs.writeFile(mixedInput, JSON.stringify([continuousFixtures.ts.record, badRecord]));
+
+		const logs: string[] = [];
+		await runInputPipeline(
+			{
+				nesDatagen: {
+					input: mixedInput,
+					output: mixedOutput,
+					rowOffset: 0,
+					workerMode: false,
+					sampleTask: NesDatagenSampleTask.Xtab,
+					sameFileJumpMinAbove: 5,
+					sameFileJumpMinBelow: 5,
+					inputFormat: NesDatagenInputFormat.Continuous,
+					pivotStrategy: PivotStrategy.Random,
+					seed: 42,
+				},
+				configFile: configPath,
+				verbose: true,
+				parallelism: 1,
+			},
+			(...args: unknown[]) => { logs.push(args.map(a => typeof a === 'object' ? JSON.stringify(a) : String(a)).join(' ')); },
+		);
+
+		const samples = parseJsonl<OutputSample>(await fs.readFile(mixedOutput, 'utf-8'));
+		expect(samples.length).toBe(1);
+		expect(samples[0].metadata.filePath).toContain('src/math.ts');
+
+		// The malformed slice is surfaced as a replay error, not swallowed.
+		const replayLog = logs.find(l => l.includes('[2/5]'));
+		expect(replayLog).toContain('1 errors');
+	});
+});

--- a/extensions/copilot/test/pipeline/test/cursorJumpPipeline.e2e.spec.ts
+++ b/extensions/copilot/test/pipeline/test/cursorJumpPipeline.e2e.spec.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
-import { NesDatagenSampleTask } from '../../base/simulationOptions';
+import { NesDatagenInputFormat, NesDatagenSampleTask, PivotStrategy } from '../../base/simulationOptions';
 import { runInputPipeline, RunPipelineOptions } from '../pipeline';
 import { allCursorJumpRecords, cursorJumpFixtures } from './fixtures/cursorJumpFixtureData';
 
@@ -79,6 +79,9 @@ async function runCursorPipeline(sampleTask: NesDatagenSampleTask, nesDatagenOve
 			rowOffset: 0,
 			workerMode: false,
 			sampleTask,
+			inputFormat: NesDatagenInputFormat.AlternativeAction,
+			pivotStrategy: PivotStrategy.Random,
+			seed: 0,
 			sameFileJumpMinAbove: 5,
 			sameFileJumpMinBelow: 5,
 			...nesDatagenOverrides,

--- a/extensions/copilot/test/pipeline/test/fixtures/continuousFixtureData.ts
+++ b/extensions/copilot/test/pipeline/test/fixtures/continuousFixtureData.ts
@@ -1,0 +1,116 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Fixture data for the continuous-recording nes-datagen pipeline e2e tests.
+ *
+ * Continuous slices (from `ContinuousEnhancedTelemetrySender`) carry no NES
+ * request bookmark, so the pipeline synthesizes a pivot. Each record here is
+ * shaped the way the continuous loader expects — a single `recording` column
+ * holding the stringified `IContinuousRecording` payload.
+ *
+ * Both valid recordings are crafted to have **exactly one** eligible pivot, so
+ * the produced sample is deterministic regardless of the pivot RNG seed:
+ *   - a pre-pivot `changed` (the eligible pivot) gives the NES prompt real edit
+ *     history to work from, and is itself eligible because a later `changed`
+ *     (the oracle) follows it on the same document;
+ *   - the trailing `changed` is the oracle and is itself ineligible (no edit
+ *     follows it on the active document).
+ * This exercises the real strategy → split → replay → prompt → oracle path.
+ */
+
+// ---------------------------------------------------------------------------
+// Scenario 1 – TypeScript: rename `add` → `sum`
+// ---------------------------------------------------------------------------
+
+const tsDocContent =
+	`export function add(a: number, b: number): number {\n` +
+	`\treturn a + b;\n` +
+	`}\n`;
+
+// `add` occupies offsets [16, 19) in `export function add(...`. The pre-pivot
+// edit appends a trailing newline (at the end, so it doesn't shift `add`),
+// giving the context some edit history without disturbing the oracle offsets.
+const tsEntries = [
+	{ kind: 'meta', data: { repoRootUri: 'file:///workspace' } },
+	{ kind: 'documentEncountered', id: 0, time: 1000, relativePath: 'src/math.ts' },
+	{ kind: 'setContent', id: 0, time: 1001, content: tsDocContent, v: 0 },
+	// Only eligible pivot: an in-context edit that establishes edit history.
+	{ kind: 'changed', id: 0, time: 1002, edit: [[tsDocContent.length, tsDocContent.length, '\n']], v: 1 },
+	// Oracle (post-pivot): rename `add` → `sum`.
+	{ kind: 'changed', id: 0, time: 1004, edit: [[16, 19, 'sum']], v: 2 },
+];
+
+const tsRecord = {
+	recording: JSON.stringify({
+		entries: tsEntries,
+		entriesSize: JSON.stringify(tsEntries).length,
+		windowStart: 900,
+		windowEnd: 1100,
+		sessionId: 'sess-ts',
+		sequenceNumber: 7,
+	}),
+};
+
+// ---------------------------------------------------------------------------
+// Scenario 2 – Python: add a ` -> str` return annotation
+// ---------------------------------------------------------------------------
+
+const pyDocContent =
+	`def greet(name):\n` +
+	`    return f"Hello, {name}!"\n`;
+
+// The `:` sits at offset 15 in `def greet(name):`. The pre-pivot edit appends a
+// trailing newline so the offset-15 insertion offsets stay stable.
+const pyEntries = [
+	{ kind: 'meta', data: { repoRootUri: 'file:///workspace' } },
+	{ kind: 'documentEncountered', id: 0, time: 2000, relativePath: 'src/greet.py' },
+	{ kind: 'setContent', id: 0, time: 2001, content: pyDocContent, v: 0 },
+	// Only eligible pivot: an in-context edit that establishes edit history.
+	{ kind: 'changed', id: 0, time: 2002, edit: [[pyDocContent.length, pyDocContent.length, '\n']], v: 1 },
+	// Oracle (post-pivot): insert ` -> str` before the colon.
+	{ kind: 'changed', id: 0, time: 2004, edit: [[15, 15, ' -> str']], v: 2 },
+];
+
+const pyRecord = {
+	recording: JSON.stringify({
+		entries: pyEntries,
+		entriesSize: JSON.stringify(pyEntries).length,
+		windowStart: 1900,
+		windowEnd: 2100,
+		sessionId: 'sess-py',
+		sequenceNumber: 8,
+	}),
+};
+
+// ---------------------------------------------------------------------------
+// Scenario 3 – Invalid: `entries` dropped because the payload exceeded the cap.
+//   The sender still ships the window metadata and `entriesSize`; only `entries`
+//   is omitted. Such a slice has no usable history and must be reported as a
+//   parse error rather than aborting the run.
+// ---------------------------------------------------------------------------
+
+const cappedRecord = {
+	recording: JSON.stringify({
+		entriesSize: 250_000,
+		windowStart: 2900,
+		windowEnd: 3100,
+		sessionId: 'sess-capped',
+		sequenceNumber: 9,
+	}),
+};
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export const continuousFixtures = {
+	ts: { record: tsRecord, docContent: tsDocContent },
+	py: { record: pyRecord, docContent: pyDocContent },
+	capped: { record: cappedRecord },
+} as const;
+
+/** All records in the format the continuous loader expects: a JSON array. */
+export const allContinuousRecords = [tsRecord, pyRecord, cappedRecord];

--- a/extensions/copilot/test/pipeline/test/pipeline.e2e.spec.ts
+++ b/extensions/copilot/test/pipeline/test/pipeline.e2e.spec.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
-import { NesDatagenSampleTask } from '../../base/simulationOptions';
+import { NesDatagenInputFormat, NesDatagenSampleTask, PivotStrategy } from '../../base/simulationOptions';
 import { runInputPipeline, RunPipelineOptions } from '../pipeline';
 import { allRecords, fixtures } from './fixtures/fixtureData';
 
@@ -85,7 +85,7 @@ async function runPipeline(opts?: Partial<RunPipelineOptions>): Promise<{
 			input: inputPath,
 			output: outputPath,
 			rowOffset: 0,
-			workerMode: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5,
+			workerMode: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5, inputFormat: NesDatagenInputFormat.AlternativeAction, pivotStrategy: PivotStrategy.Random, seed: 0,
 		},
 		configFile: configPath,
 		verbose: true,
@@ -263,7 +263,7 @@ describe('nes-datagen pipeline e2e', () => {
 						input: invalidInputPath,
 						output: invalidOutputPath,
 						rowOffset: 0,
-						workerMode: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5,
+						workerMode: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5, inputFormat: NesDatagenInputFormat.AlternativeAction, pivotStrategy: PivotStrategy.Random, seed: 0,
 					},
 					configFile: configPath,
 					verbose: false,
@@ -290,7 +290,7 @@ describe('nes-datagen pipeline e2e', () => {
 						input: inputPath,
 						output: outputPath,
 						rowOffset: 0,
-						workerMode: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5,
+						workerMode: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5, inputFormat: NesDatagenInputFormat.AlternativeAction, pivotStrategy: PivotStrategy.Random, seed: 0,
 					},
 					configFile: undefined,
 					verbose: false,
@@ -309,7 +309,7 @@ describe('nes-datagen pipeline e2e', () => {
 						input: inputPath,
 						output: offsetOutputPath,
 						rowOffset: 100,
-						workerMode: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5,
+						workerMode: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5, inputFormat: NesDatagenInputFormat.AlternativeAction, pivotStrategy: PivotStrategy.Random, seed: 0,
 					},
 					configFile: configPath,
 					verbose: false,

--- a/extensions/copilot/test/pipeline/test/pipeline.spec.ts
+++ b/extensions/copilot/test/pipeline/test/pipeline.spec.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs/promises';
 import path from 'path';
 import { expect, suite, test } from 'vitest';
 import { Result } from '../../../src/util/common/result';
-import { NesDatagenSampleTask } from '../../base/simulationOptions';
+import { NesDatagenInputFormat, NesDatagenSampleTask, PivotStrategy } from '../../base/simulationOptions';
 import { IInputRow } from '../parseInput';
 import { runInputPipeline, RunPipelineOptions } from '../pipeline';
 
@@ -108,7 +108,7 @@ suite.skip('from csv to input rows to pipeline', () => {
 				input: inputRowsFilePath,
 				output: path.join(fixtures, 'output.jsonl'),
 				rowOffset: 0,
-				workerMode: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5
+				workerMode: false, sampleTask: NesDatagenSampleTask.Xtab, sameFileJumpMinAbove: 5, sameFileJumpMinBelow: 5, inputFormat: NesDatagenInputFormat.AlternativeAction, pivotStrategy: PivotStrategy.Random, seed: 0
 			},
 			configFile: configFilePath,
 			verbose: true,

--- a/extensions/copilot/test/pipeline/withRowIndex.ts
+++ b/extensions/copilot/test/pipeline/withRowIndex.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * A value paired with the `originalRowIndex` identifying its source row in the
+ * input container it was read from.
+ */
+export type WithRowIndex<T> = {
+	readonly originalRowIndex: number;
+	readonly value: T;
+};


### PR DESCRIPTION
## Why

We started shipping continuous enhanced telemetry with sliding-window recordings for NES. Unlike the per-request "alternative action" recordings the datagen pipeline already understands, a continuous slice has **no `requestTime`** - there is no natural point that splits it into "edit history before" and "the edit to predict." Without such a pivot, `nes-datagen` cannot turn continuous recordings into training rows.

## What

- **Pivot strategies.** Adds a pluggable way to pick where to split a continuous recording, selectable with `--pivot-strategy`. The first strategy is `random` (seeded, so a run is reproducible). The shape leaves room for smarter strategies later.
- **Continuous pipeline module** (`test/pipeline/continuous/`): parses a continuous record, selects a pivot, replays the recording up to that pivot, and emits a processed row equivalent to what the existing per-request path produces, so downstream pipeline steps are unchanged.
- **Documented telemetry payload.** The continuous `recording` payload on `ContinuousEnhancedTelemetrySender` is now the `IContinuousRecording` interface, with each field that can be absent documented as to when and why (e.g. `entries` is dropped when it exceeds the size cap).

## Notable refactors (folded in during review)

These tidy up shared pipeline plumbing that the new code touches, rather than leaving adapters around it:

- `WithRowIndex<T>` replaces the repeated ad-hoc `{ originalRowIndex, ... }` pairs.
- Per-record processing returns `Result<IProcessedRow, Error>` instead of field-presence unions (`'error' in x`).
- Failures surface the original `Error` unchanged - no `Error -> string -> Error` round-tripping and no synthetic "Unexpected error:" prefixes.

## How to test

```
cd extensions/copilot && node_modules/.bin/vitest --run --pool=forks test/pipeline/
```

New unit and e2e specs cover pivot selection, continuous-record parsing, per-record processing (including isolating a single malformed record so the rest of the batch still produces rows), and a full continuous pipeline run. Suite: 109 passed / 1 skipped.