### PR TITLE
Skip Codex session smoke test

### DIFF
--- a/test/smoke/src/areas/agentsWindow/agentsWindow.test.ts
+++ b/test/smoke/src/areas/agentsWindow/agentsWindow.test.ts
@@ -905,7 +905,7 @@ export function setup(logger: Logger) {
 			},
 		});
 
-		it('Test Codex session', async function () {
+		it.skip('Test Codex session', async function () {
 			this.timeout(5 * 60 * 1000);
 
 			const app = this.app as Application;


### PR DESCRIPTION
Skips the `Agents Window (Codex) > Test Codex session` smoke test by changing `it(...)` to `it.skip(...)`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>