### PR TITLE
sessions: add diagnostics for per-session PR icon polling

### DIFF
--- a/src/vs/sessions/contrib/github/browser/github.contribution.ts
+++ b/src/vs/sessions/contrib/github/browser/github.contribution.ts
@@ -22,6 +22,19 @@ import './pullRequestActions.js';
 
 const TRACE_PREFIX = '[PR-ICON-TRACE]';
 
+/**
+ * Resolved PR identity for a session's poller, or the specific stage at which
+ * resolution bailed out. Only the `ok` state keeps a PR model warm/polling; the
+ * other kinds are logged so the trace pinpoints *why* a non-active session's PR
+ * icon never refreshes (its model was never kept warm).
+ */
+type PullRequestIdentityState =
+	| { readonly kind: 'ok'; readonly owner: string; readonly repo: string; readonly prNumber: number }
+	| { readonly kind: 'archived' }
+	| { readonly kind: 'no-workspace' }
+	| { readonly kind: 'no-git-repository' }
+	| { readonly kind: 'no-pull-request' };
+
 export class GitHubPullRequestPollingContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'sessions.contrib.githubPullRequestPolling';
@@ -113,6 +126,12 @@ export class GitHubPullRequestPollingContribution extends Disposable implements 
 				this._sessionTrackers.deleteAndDispose(session.sessionId);
 			}
 		}
+
+		// Aggregate visibility: if non-active session icons aren't refreshing, the
+		// first thing to check is whether this poller even sees the sessions. A low
+		// tracked count here (e.g. 0/1 while the list shows many) means the sessions
+		// never reach the poller, so their PR models are never kept warm.
+		this._logService.trace(`${TRACE_PREFIX} [PollingContribution] onDidChangeSessions (added ${e.added.length}, changed ${e.changed.length}, removed ${e.removed.length}); now tracking ${this._sessionTrackers.size} session poller(s)`);
 	}
 
 	private _trackSession(session: ISession): void {
@@ -138,26 +157,47 @@ export class GitHubPullRequestPollingContribution extends Disposable implements 
 		// stable while the PR's live data — and therefore its computed icon —
 		// updates, so the poller doesn't churn (or feed back into itself) every
 		// time `gitHubInfo` re-derives.
-		const pullRequestIdentityObs = derivedOpts<{ readonly owner: string; readonly repo: string; readonly prNumber: number } | undefined>(
+		//
+		// When there's no identity yet we carry the *reason* (archived / no
+		// workspace / no git repository / no pull request) so the outer autorun
+		// can log precisely which stage is missing. This is the key signal for
+		// diagnosing "non-active session icons don't refresh": the shared PR
+		// model is only kept warm (and polled) once this resolves to `ok`, so a
+		// session stuck at e.g. `no-workspace` or `no-pull-request` explains why
+		// its icon never refines. Structural equality still de-dupes these stable
+		// reason objects, so the poller doesn't churn.
+		const pullRequestIdentityObs = derivedOpts<PullRequestIdentityState>(
 			{ owner: this, equalsFn: structuralEquals },
 			reader => {
 				if (session.isArchived.read(reader)) {
-					return undefined;
+					return { kind: 'archived' };
 				}
 
-				const gitHubInfo = session.workspace.read(reader)?.folders[0]?.gitRepository?.gitHubInfo.read(reader);
+				const workspace = session.workspace.read(reader);
+				if (!workspace) {
+					return { kind: 'no-workspace' };
+				}
+
+				const gitRepository = workspace.folders[0]?.gitRepository;
+				if (!gitRepository) {
+					return { kind: 'no-git-repository' };
+				}
+
+				const gitHubInfo = gitRepository.gitHubInfo.read(reader);
 				if (!gitHubInfo?.pullRequest) {
-					return undefined;
+					return { kind: 'no-pull-request' };
 				}
 
-				return { owner: gitHubInfo.owner, repo: gitHubInfo.repo, prNumber: gitHubInfo.pullRequest.number };
+				return { kind: 'ok', owner: gitHubInfo.owner, repo: gitHubInfo.repo, prNumber: gitHubInfo.pullRequest.number };
 			});
 
 		return autorun(reader => {
 			const identity = pullRequestIdentityObs.read(reader);
-			if (!identity) {
-				// No PR number yet (or archived); this autorun re-runs once it resolves.
-				this._logService.trace(`${TRACE_PREFIX} [PollingContribution] Session ${session.sessionId} has no PR identity yet (no PR number or archived); waiting`);
+			if (identity.kind !== 'ok') {
+				// Not kept warm. The `reason` disambiguates the four bail-out stages
+				// (previously logged as one generic message), so the log tells us
+				// exactly why a non-active session's PR model is never polled.
+				this._logService.trace(`${TRACE_PREFIX} [PollingContribution] Session ${session.sessionId} has no PR identity yet (reason: ${identity.kind}); NOT keeping a PR model warm. Will re-run reactively if this input changes.`);
 				return;
 			}
 


### PR DESCRIPTION
## What

Adds targeted diagnostics to `GitHubPullRequestPollingContribution` (`src/vs/sessions/contrib/github/browser/github.contribution.ts`) to pinpoint why **non-active** agent-host session PR status icons don't refresh until the session is activated.

- Introduces a discriminated `PullRequestIdentityState` (`ok` / `archived` / `no-workspace` / `no-git-repository` / `no-pull-request`) for the per-session identity derivation, and logs the **precise stage** at which a session's PR model is *not* kept warm (previously a single generic "no PR identity yet" trace collapsed all four bail-out stages together).
- Logs the **total tracked poller count** on each `onDidChangeSessions`, so we can immediately tell whether the poller even sees the sessions in the list.

## Why

Reported symptom: in the agent-host sessions list, a session's PR icon does not update while another session is active — it only refreshes when you click the session to make it active. Renderer logs show the shared PR/CI/review-thread models being **created and immediately disposed** for non-active sessions (refcount 0->1->0), and the affected PR's review threads only start polling at the moment of activation — i.e. the per-session poller is not keeping non-active sessions warm.

The reactive wiring looks correct on paper, so rather than guess at a fix, this change makes the next repro self-diagnosing: the `reason:` on the bail-out trace and the tracked-poller count will show exactly which stage fails (never tracked vs. tracked but no workspace/gitRepository/PR).

## Notes for reviewers

- **No behavior change.** Only the `ok` state starts polling, exactly as the previous `!identity` check did. Structural equality still de-dupes the (now stable) reason objects, so the poller does not churn.
- All new strings are trace-level logs under the existing `[PR-ICON-TRACE]` prefix — filter renderer logs on `[PR-ICON-TRACE] [PollingContribution]` to follow it.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
