### PR TITLE
Support system-wide (OS global) keybindings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -332,8 +332,9 @@ function configureCommandlineSwitchesSync(cliArgs: NativeParsedArgs) {
 	// `DocumentPolicyIncludeJSCallStacksInCrashReports` - https://www.electronjs.org/docs/latest/api/web-frame-main#framecollectjavascriptcallstack-experimental
 	// `EarlyEstablishGpuChannel` - Refs https://issues.chromium.org/issues/40208065
 	// `EstablishGpuChannelAsync` - Refs https://issues.chromium.org/issues/40208065
+	// `GlobalShortcutsPortal` - Enables Electron's `globalShortcut` (system-wide keybindings) on Linux Wayland via the XDG global shortcuts portal (no-op elsewhere)
 	const featuresToEnable =
-		`NetAdapterMaxBufSizeFeature:NetAdapterMaxBufSize/8192,DocumentPolicyIncludeJSCallStacksInCrashReports,EarlyEstablishGpuChannel,EstablishGpuChannelAsync,${app.commandLine.getSwitchValue('enable-features')}`;
+		`NetAdapterMaxBufSizeFeature:NetAdapterMaxBufSize/8192,DocumentPolicyIncludeJSCallStacksInCrashReports,EarlyEstablishGpuChannel,EstablishGpuChannelAsync${process.platform === 'linux' ? ',GlobalShortcutsPortal' : ''},${app.commandLine.getSwitchValue('enable-features')}`;
 	app.commandLine.appendSwitch('enable-features', featuresToEnable);
 
 	// Following features are disabled from the runtime:

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { app, BrowserWindow, desktopCapturer, Details, GPUFeatureStatus, powerMonitor, protocol, screen as electronScreen, session, Session, systemPreferences, WebFrameMain } from 'electron';
+import { app, BrowserWindow, desktopCapturer, Details, globalShortcut, GPUFeatureStatus, powerMonitor, protocol, screen as electronScreen, session, Session, systemPreferences, WebFrameMain } from 'electron';
 import { addUNCHostToAllowlist, disableUNCAccessRestrictions } from '../../base/node/unc.js';
 import { validatedIpcMain } from '../../base/parts/ipc/electron-main/ipcMain.js';
 import { hostname, release } from 'os';
@@ -64,6 +64,7 @@ import { ILifecycleMainService, LifecycleMainPhase, ShutdownReason } from '../..
 import { ILoggerService, ILogService } from '../../platform/log/common/log.js';
 import { IMenubarMainService, MenubarMainService } from '../../platform/menubar/electron-main/menubarMainService.js';
 import { INativeHostMainService, NativeHostMainService } from '../../platform/native/electron-main/nativeHostMainService.js';
+import { GlobalKeybindingsMainService, IGlobalKeybindingsMainService } from '../../platform/globalKeybindings/electron-main/globalKeybindingsMainService.js';
 import { IMeteredConnectionService } from '../../platform/meteredConnection/common/meteredConnection.js';
 import { METERED_CONNECTION_CHANNEL } from '../../platform/meteredConnection/common/meteredConnectionIpc.js';
 import { MeteredConnectionChannel } from '../../platform/meteredConnection/electron-main/meteredConnectionChannel.js';
@@ -1129,6 +1130,9 @@ export class CodeApplication extends Disposable {
 
 		// Native Host
 		services.set(INativeHostMainService, new SyncDescriptor(NativeHostMainService, undefined, false /* proxied to other processes */));
+
+		// System-wide (OS global) keybindings
+		services.set(IGlobalKeybindingsMainService, new SyncDescriptor(GlobalKeybindingsMainService, [globalShortcut]));
 
 		// Metered Connection
 		const meteredConnectionService = new MeteredConnectionMainService(this.configurationService);

--- a/src/vs/platform/globalKeybindings/electron-main/globalKeybindingsMainService.ts
+++ b/src/vs/platform/globalKeybindings/electron-main/globalKeybindingsMainService.ts
@@ -1,0 +1,211 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../base/common/cancellation.js';
+import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
+import { createDecorator } from '../../instantiation/common/instantiation.js';
+import { ILifecycleMainService } from '../../lifecycle/electron-main/lifecycleMainService.js';
+import { ILogService } from '../../log/common/log.js';
+import { FocusMode, INativeSystemWideKeybinding } from '../../native/common/native.js';
+import { INativeRunActionInWindowRequest } from '../../window/common/window.js';
+import { ICodeWindow } from '../../window/electron-main/window.js';
+import { IWindowsMainService } from '../../windows/electron-main/windows.js';
+
+/**
+ * The subset of Electron's `globalShortcut` module that this service relies on. Injecting it as a
+ * constructor dependency (rather than importing the global directly) lets tests provide a fake.
+ */
+export interface IGlobalShortcutRegistry {
+	register(accelerator: string, callback: () => void): boolean;
+	unregister(accelerator: string): void;
+	isRegistered(accelerator: string): boolean;
+}
+
+export const IGlobalKeybindingsMainService = createDecorator<IGlobalKeybindingsMainService>('globalKeybindingsMainService');
+
+export interface IGlobalKeybindingsMainService {
+
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Replaces the set of system-wide (OS global) keybindings owned by the given window with the
+	 * provided set, reconciling the actual OS registrations. Returns the user settings labels (or
+	 * accelerators) that could not be registered, e.g. because the accelerator is already taken by
+	 * the OS or another application.
+	 */
+	updateKeybindings(windowId: number, keybindings: readonly INativeSystemWideKeybinding[]): string[];
+}
+
+export class GlobalKeybindingsMainService extends Disposable implements IGlobalKeybindingsMainService {
+
+	declare readonly _serviceBrand: undefined;
+
+	/** Per-window desired bindings, keyed by window id then by accelerator. */
+	private readonly registry = new Map<number, Map<string, INativeSystemWideKeybinding>>();
+
+	/** Accelerators this service currently owns an OS registration for. */
+	private readonly registeredAccelerators = new Set<string>();
+
+	/** Accelerators that were desired but failed to register (e.g. already taken). */
+	private readonly failedAccelerators = new Set<string>();
+
+	constructor(
+		private readonly globalShortcut: IGlobalShortcutRegistry,
+		@IWindowsMainService private readonly windowsMainService: IWindowsMainService,
+		@ILifecycleMainService lifecycleMainService: ILifecycleMainService,
+		@ILogService private readonly logService: ILogService
+	) {
+		super();
+
+		this._register(this.windowsMainService.onDidDestroyWindow(window => this.onDidDestroyWindow(window)));
+		this._register(lifecycleMainService.onWillShutdown(() => this.unregisterAll()));
+		this._register(toDisposable(() => this.unregisterAll()));
+	}
+
+	updateKeybindings(windowId: number, keybindings: readonly INativeSystemWideKeybinding[]): string[] {
+		const perWindow = new Map<string, INativeSystemWideKeybinding>();
+		for (const keybinding of keybindings) {
+			if (!this.isValid(keybinding)) {
+				this.logService.warn(`[GlobalKeybindings] ignoring invalid system-wide keybinding: ${JSON.stringify(keybinding)}`);
+				continue;
+			}
+			if (perWindow.has(keybinding.accelerator)) {
+				this.logService.warn(`[GlobalKeybindings] duplicate accelerator '${keybinding.accelerator}' in window ${windowId}, keeping first`);
+				continue;
+			}
+			perWindow.set(keybinding.accelerator, keybinding);
+		}
+
+		if (perWindow.size > 0) {
+			this.registry.set(windowId, perWindow);
+		} else {
+			this.registry.delete(windowId);
+		}
+
+		this.reconcile();
+
+		const failed: string[] = [];
+		for (const keybinding of perWindow.values()) {
+			if (this.failedAccelerators.has(keybinding.accelerator)) {
+				failed.push(keybinding.userSettingsLabel ?? keybinding.accelerator);
+			}
+		}
+		return failed;
+	}
+
+	private isValid(keybinding: INativeSystemWideKeybinding): boolean {
+		return typeof keybinding.accelerator === 'string' && keybinding.accelerator.length > 0
+			&& typeof keybinding.commandId === 'string' && keybinding.commandId.length > 0;
+	}
+
+	/**
+	 * Reconciles the OS registrations against the union of all windows' desired accelerators.
+	 * Unregisters only accelerators this service owns; never touches shortcuts owned elsewhere.
+	 */
+	private reconcile(): void {
+		const desired = new Set<string>();
+		for (const perWindow of this.registry.values()) {
+			for (const accelerator of perWindow.keys()) {
+				desired.add(accelerator);
+			}
+		}
+
+		// Unregister accelerators we own but no longer want
+		for (const accelerator of [...this.registeredAccelerators]) {
+			if (!desired.has(accelerator)) {
+				this.globalShortcut.unregister(accelerator);
+				this.registeredAccelerators.delete(accelerator);
+				this.failedAccelerators.delete(accelerator);
+			}
+		}
+
+		// Register newly desired accelerators (retries previously failed ones too)
+		for (const accelerator of desired) {
+			if (this.registeredAccelerators.has(accelerator)) {
+				continue;
+			}
+
+			let registered = false;
+			try {
+				// Register once with a stable callback that reads the CURRENT registry at fire time,
+				// so command/args are never captured from a stale snapshot.
+				registered = this.globalShortcut.register(accelerator, () => this.onTrigger(accelerator));
+			} catch (error) {
+				this.logService.error(`[GlobalKeybindings] error registering '${accelerator}'`, error);
+			}
+
+			if (registered) {
+				this.registeredAccelerators.add(accelerator);
+				this.failedAccelerators.delete(accelerator);
+			} else {
+				this.failedAccelerators.add(accelerator);
+				this.logService.warn(`[GlobalKeybindings] failed to register accelerator '${accelerator}' (already taken by the OS or another application)`);
+			}
+		}
+	}
+
+	private onTrigger(accelerator: string): void {
+		const owners: number[] = [];
+		for (const [windowId, perWindow] of this.registry) {
+			if (perWindow.has(accelerator)) {
+				owners.push(windowId);
+			}
+		}
+		if (owners.length === 0) {
+			return; // stale registration; will be unregistered on next reconcile
+		}
+
+		// Target window selection:
+		// 1. the focused window if it owns this accelerator (respect that window's own binding)
+		// 2. otherwise the deterministic winner (lowest window id) among alive owners
+		let target: ICodeWindow | undefined;
+		const focused = this.windowsMainService.getFocusedWindow();
+		if (focused && this.registry.get(focused.id)?.has(accelerator)) {
+			target = focused;
+		} else {
+			target = owners
+				.map(windowId => this.windowsMainService.getWindowById(windowId))
+				.filter((window): window is ICodeWindow => !!window)
+				.sort((a, b) => a.id - b.id)
+				.at(0);
+		}
+
+		if (!target) {
+			this.logService.warn(`[GlobalKeybindings] no live window to handle accelerator '${accelerator}'`);
+			return;
+		}
+
+		const binding = this.registry.get(target.id)?.get(accelerator);
+		if (!binding) {
+			return;
+		}
+
+		this.logService.trace(`[GlobalKeybindings] trigger '${accelerator}' -> '${binding.commandId}' in window ${target.id}`);
+
+		target.focus({ mode: FocusMode.Force });
+
+		const payload: INativeRunActionInWindowRequest = {
+			id: binding.commandId,
+			from: 'systemWideKeybinding',
+			args: binding.args === undefined ? undefined : [binding.args]
+		};
+		target.sendWhenReady('vscode:runAction', CancellationToken.None, payload);
+	}
+
+	private onDidDestroyWindow(window: ICodeWindow): void {
+		if (this.registry.delete(window.id)) {
+			this.reconcile();
+		}
+	}
+
+	private unregisterAll(): void {
+		for (const accelerator of this.registeredAccelerators) {
+			this.globalShortcut.unregister(accelerator);
+		}
+		this.registeredAccelerators.clear();
+		this.failedAccelerators.clear();
+		this.registry.clear();
+	}
+}

--- a/src/vs/platform/globalKeybindings/electron-main/globalKeybindingsMainService.ts
+++ b/src/vs/platform/globalKeybindings/electron-main/globalKeybindingsMainService.ts
@@ -8,7 +8,7 @@ import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { ILifecycleMainService } from '../../lifecycle/electron-main/lifecycleMainService.js';
 import { ILogService } from '../../log/common/log.js';
-import { FocusMode, INativeSystemWideKeybinding } from '../../native/common/native.js';
+import { INativeSystemWideKeybinding } from '../../native/common/native.js';
 import { INativeRunActionInWindowRequest } from '../../window/common/window.js';
 import { ICodeWindow } from '../../window/electron-main/window.js';
 import { IWindowsMainService } from '../../windows/electron-main/windows.js';
@@ -184,8 +184,13 @@ export class GlobalKeybindingsMainService extends Disposable implements IGlobalK
 
 		this.logService.trace(`[GlobalKeybindings] trigger '${accelerator}' -> '${binding.commandId}' in window ${target.id}`);
 
-		target.focus({ mode: FocusMode.Force });
-
+		// We deliberately do NOT focus the routing window here. A system-wide keybinding fires while
+		// VS Code is typically unfocused, and force-focusing the routing window would pull it to the
+		// foreground even when the command opens or reveals a *different* window (e.g.
+		// `workbench.action.openAgentsWindow` reveals the agents window). Pulling the routing window
+		// forward first produces a visible flicker. Instead we let the command decide what to surface
+		// and focus — matching every other `vscode:runAction` sender (menubar, touchbar, mouse), none
+		// of which force-focus. `sendWhenReady` only needs the web contents to be ready, not focused.
 		const payload: INativeRunActionInWindowRequest = {
 			id: binding.commandId,
 			from: 'systemWideKeybinding',

--- a/src/vs/platform/globalKeybindings/test/electron-main/globalKeybindingsMainService.test.ts
+++ b/src/vs/platform/globalKeybindings/test/electron-main/globalKeybindingsMainService.test.ts
@@ -1,0 +1,250 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter } from '../../../../base/common/event.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { INativeSystemWideKeybinding } from '../../../native/common/native.js';
+import { ICodeWindow } from '../../../window/electron-main/window.js';
+import { IWindowsMainService } from '../../../windows/electron-main/windows.js';
+import { ILifecycleMainService } from '../../../lifecycle/electron-main/lifecycleMainService.js';
+import { GlobalKeybindingsMainService, IGlobalShortcutRegistry } from '../../electron-main/globalKeybindingsMainService.js';
+
+class FakeGlobalShortcut implements IGlobalShortcutRegistry {
+	readonly registered = new Map<string, () => void>();
+	readonly failFor = new Set<string>();
+	unregisterCalls: string[] = [];
+
+	register(accelerator: string, callback: () => void): boolean {
+		if (this.failFor.has(accelerator)) {
+			return false;
+		}
+		this.registered.set(accelerator, callback);
+		return true;
+	}
+
+	unregister(accelerator: string): void {
+		this.unregisterCalls.push(accelerator);
+		this.registered.delete(accelerator);
+	}
+
+	isRegistered(accelerator: string): boolean {
+		return this.registered.has(accelerator);
+	}
+
+	trigger(accelerator: string): void {
+		const callback = this.registered.get(accelerator);
+		if (!callback) {
+			throw new Error(`accelerator '${accelerator}' is not registered`);
+		}
+		callback();
+	}
+}
+
+class FakeCodeWindow {
+	focusCalls = 0;
+	readonly sent: { channel: string; args: unknown[] }[] = [];
+
+	constructor(readonly id: number) { }
+
+	focus(): void {
+		this.focusCalls++;
+	}
+
+	sendWhenReady(channel: string, _token: unknown, ...args: unknown[]): void {
+		this.sent.push({ channel, args });
+	}
+}
+
+class FakeWindowsMainService {
+	private readonly _onDidDestroyWindow: Emitter<ICodeWindow>;
+	readonly onDidDestroyWindow;
+
+	focused: FakeCodeWindow | undefined;
+	readonly windows = new Map<number, FakeCodeWindow>();
+
+	constructor(store: DisposableStore) {
+		this._onDidDestroyWindow = store.add(new Emitter<ICodeWindow>());
+		this.onDidDestroyWindow = this._onDidDestroyWindow.event;
+	}
+
+	addWindow(id: number): FakeCodeWindow {
+		const window = new FakeCodeWindow(id);
+		this.windows.set(id, window);
+		return window;
+	}
+
+	getFocusedWindow(): ICodeWindow | undefined {
+		return this.focused as unknown as ICodeWindow | undefined;
+	}
+
+	getWindowById(id: number): ICodeWindow | undefined {
+		return this.windows.get(id) as unknown as ICodeWindow | undefined;
+	}
+
+	destroyWindow(window: FakeCodeWindow): void {
+		this.windows.delete(window.id);
+		this._onDidDestroyWindow.fire(window as unknown as ICodeWindow);
+	}
+}
+
+class FakeLifecycleMainService {
+	private readonly _onWillShutdown: Emitter<{ reason: number; join(id: string, promise: Promise<void>): void }>;
+	readonly onWillShutdown;
+
+	constructor(store: DisposableStore) {
+		this._onWillShutdown = store.add(new Emitter());
+		this.onWillShutdown = this._onWillShutdown.event;
+	}
+
+	shutdown(): void {
+		this._onWillShutdown.fire({ reason: 1, join: () => { } });
+	}
+}
+
+function binding(accelerator: string, commandId: string, args?: unknown, userSettingsLabel?: string): INativeSystemWideKeybinding {
+	return { accelerator, commandId, args, userSettingsLabel };
+}
+
+suite('GlobalKeybindingsMainService', () => {
+
+	const ds = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createService(shortcut = new FakeGlobalShortcut()) {
+		const store = ds.add(new DisposableStore());
+		const windows = new FakeWindowsMainService(store);
+		const lifecycle = new FakeLifecycleMainService(store);
+		const service = store.add(new GlobalKeybindingsMainService(
+			shortcut,
+			windows as unknown as IWindowsMainService,
+			lifecycle as unknown as ILifecycleMainService,
+			new NullLogService()
+		));
+		return { service, windows, lifecycle, shortcut };
+	}
+
+	test('registers desired accelerators and reports no failures', () => {
+		const { service, shortcut } = createService();
+		const failed = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a'), binding('Control+Cmd+B', 'b')]);
+
+		assert.deepStrictEqual(failed, []);
+		assert.deepStrictEqual([...shortcut.registered.keys()].sort(), ['Control+Cmd+A', 'Control+Cmd+B']);
+	});
+
+	test('reports and unregisters accelerators removed on a subsequent update', () => {
+		const { service, shortcut } = createService();
+		service.updateKeybindings(1, [binding('Control+Cmd+A', 'a'), binding('Control+Cmd+B', 'b')]);
+		service.updateKeybindings(1, [binding('Control+Cmd+A', 'a')]);
+
+		assert.deepStrictEqual([...shortcut.registered.keys()], ['Control+Cmd+A']);
+		assert.deepStrictEqual(shortcut.unregisterCalls, ['Control+Cmd+B']);
+	});
+
+	test('returns the labels that failed to register and retries them later', () => {
+		const shortcut = new FakeGlobalShortcut();
+		shortcut.failFor.add('Control+Cmd+A');
+		const { service } = createService(shortcut);
+
+		const failed = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a', undefined, 'ctrl+cmd+a')]);
+		assert.deepStrictEqual(failed, ['ctrl+cmd+a']);
+
+		// Now the accelerator becomes available; a re-sync should register it.
+		shortcut.failFor.delete('Control+Cmd+A');
+		const failedAgain = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a', undefined, 'ctrl+cmd+a')]);
+		assert.deepStrictEqual(failedAgain, []);
+		assert.ok(shortcut.isRegistered('Control+Cmd+A'));
+	});
+
+	test('deduplicates accelerators within a single window payload', () => {
+		const { service, shortcut } = createService();
+		const failed = service.updateKeybindings(1, [binding('Control+Cmd+A', 'first'), binding('Control+Cmd+A', 'second')]);
+
+		assert.deepStrictEqual(failed, []);
+		assert.strictEqual(shortcut.registered.size, 1);
+	});
+
+	test('trigger focuses the owning window and sends the run-action payload with args', () => {
+		const { service, windows, shortcut } = createService();
+		const window = windows.addWindow(1);
+		service.updateKeybindings(1, [binding('Control+Cmd+A', 'workbench.action.openAgentsWindow', { foo: 'bar' })]);
+
+		shortcut.trigger('Control+Cmd+A');
+
+		assert.strictEqual(window.focusCalls, 1);
+		assert.deepStrictEqual(window.sent, [{
+			channel: 'vscode:runAction',
+			args: [{ id: 'workbench.action.openAgentsWindow', from: 'systemWideKeybinding', args: [{ foo: 'bar' }] }]
+		}]);
+	});
+
+	test('trigger passes undefined args when the binding has none', () => {
+		const { service, windows, shortcut } = createService();
+		const window = windows.addWindow(1);
+		service.updateKeybindings(1, [binding('Control+Cmd+A', 'cmd')]);
+
+		shortcut.trigger('Control+Cmd+A');
+
+		assert.deepStrictEqual(window.sent[0].args, [{ id: 'cmd', from: 'systemWideKeybinding', args: undefined }]);
+	});
+
+	test('conflict across windows resolves to the focused owner', () => {
+		const { service, windows, shortcut } = createService();
+		const window1 = windows.addWindow(1);
+		const window2 = windows.addWindow(2);
+		service.updateKeybindings(1, [binding('Control+Cmd+A', 'from-window-1')]);
+		service.updateKeybindings(2, [binding('Control+Cmd+A', 'from-window-2')]);
+
+		windows.focused = window2;
+		shortcut.trigger('Control+Cmd+A');
+
+		assert.strictEqual(window1.sent.length, 0);
+		assert.strictEqual((window2.sent[0].args[0] as { id: string }).id, 'from-window-2');
+	});
+
+	test('conflict without a focused owner resolves deterministically to the lowest window id', () => {
+		const { service, windows, shortcut } = createService();
+		const window1 = windows.addWindow(1);
+		const window2 = windows.addWindow(2);
+		service.updateKeybindings(2, [binding('Control+Cmd+A', 'from-window-2')]);
+		service.updateKeybindings(1, [binding('Control+Cmd+A', 'from-window-1')]);
+
+		windows.focused = undefined;
+		shortcut.trigger('Control+Cmd+A');
+
+		assert.strictEqual(window2.sent.length, 0);
+		assert.strictEqual((window1.sent[0].args[0] as { id: string }).id, 'from-window-1');
+	});
+
+	test('closing a window unregisters accelerators no other window owns', () => {
+		const { service, windows, shortcut } = createService();
+		const window1 = windows.addWindow(1);
+		service.updateKeybindings(1, [binding('Control+Cmd+A', 'a')]);
+		assert.ok(shortcut.isRegistered('Control+Cmd+A'));
+
+		windows.destroyWindow(window1);
+		assert.strictEqual(shortcut.isRegistered('Control+Cmd+A'), false);
+	});
+
+	test('closing a window keeps accelerators still owned by another window', () => {
+		const { service, windows, shortcut } = createService();
+		const window1 = windows.addWindow(1);
+		windows.addWindow(2);
+		service.updateKeybindings(1, [binding('Control+Cmd+A', 'a')]);
+		service.updateKeybindings(2, [binding('Control+Cmd+A', 'a')]);
+
+		windows.destroyWindow(window1);
+		assert.ok(shortcut.isRegistered('Control+Cmd+A'));
+	});
+
+	test('shutdown unregisters all owned accelerators', () => {
+		const { service, lifecycle, shortcut } = createService();
+		service.updateKeybindings(1, [binding('Control+Cmd+A', 'a'), binding('Control+Cmd+B', 'b')]);
+
+		lifecycle.shutdown();
+		assert.strictEqual(shortcut.registered.size, 0);
+	});
+});

--- a/src/vs/platform/globalKeybindings/test/electron-main/globalKeybindingsMainService.test.ts
+++ b/src/vs/platform/globalKeybindings/test/electron-main/globalKeybindingsMainService.test.ts
@@ -167,14 +167,16 @@ suite('GlobalKeybindingsMainService', () => {
 		assert.strictEqual(shortcut.registered.size, 1);
 	});
 
-	test('trigger focuses the owning window and sends the run-action payload with args', () => {
+	test('trigger dispatches the run-action payload without force-focusing the routing window', () => {
 		const { service, windows, shortcut } = createService();
 		const window = windows.addWindow(1);
 		service.updateKeybindings(1, [binding('Control+Cmd+A', 'workbench.action.openAgentsWindow', { foo: 'bar' })]);
 
 		shortcut.trigger('Control+Cmd+A');
 
-		assert.strictEqual(window.focusCalls, 1);
+		// The command controls what is surfaced/focused (e.g. it reveals the agents window), so the
+		// routing window must NOT be pulled to the foreground — doing so would flicker the wrong window.
+		assert.strictEqual(window.focusCalls, 0);
 		assert.deepStrictEqual(window.sent, [{
 			channel: 'vscode:runAction',
 			args: [{ id: 'workbench.action.openAgentsWindow', from: 'systemWideKeybinding', args: [{ foo: 'bar' }] }]

--- a/src/vs/platform/keybinding/common/keybinding.ts
+++ b/src/vs/platform/keybinding/common/keybinding.ts
@@ -18,6 +18,12 @@ export interface IUserFriendlyKeybinding {
 	command: string;
 	args?: any;
 	when?: string;
+	/**
+	 * When `true`, the keybinding is registered as a system-wide (OS global) shortcut that fires
+	 * even when VS Code does not have focus. Desktop only; ignored on web/server. Only honored for
+	 * user `keybindings.json` entries (not extension-contributed keybindings).
+	 */
+	systemWide?: boolean;
 }
 
 export interface IKeyboardEvent {

--- a/src/vs/platform/keybinding/common/resolvedKeybindingItem.ts
+++ b/src/vs/platform/keybinding/common/resolvedKeybindingItem.ts
@@ -19,8 +19,14 @@ export class ResolvedKeybindingItem {
 	public readonly isDefault: boolean;
 	public readonly extensionId: string | null;
 	public readonly isBuiltinExtension: boolean;
+	/**
+	 * Whether this keybinding was declared as a system-wide (OS global) shortcut via
+	 * `keybindings.json`. Only ever `true` for user keybindings; defaults/extension keybindings
+	 * are always `false`.
+	 */
+	public readonly systemWide: boolean;
 
-	constructor(resolvedKeybinding: ResolvedKeybinding | undefined, command: string | null, commandArgs: any, when: ContextKeyExpression | undefined, isDefault: boolean, extensionId: string | null, isBuiltinExtension: boolean) {
+	constructor(resolvedKeybinding: ResolvedKeybinding | undefined, command: string | null, commandArgs: any, when: ContextKeyExpression | undefined, isDefault: boolean, extensionId: string | null, isBuiltinExtension: boolean, systemWide: boolean = false) {
 		this.resolvedKeybinding = resolvedKeybinding;
 		this.chords = resolvedKeybinding ? toEmptyArrayIfContainsNull(resolvedKeybinding.getDispatchChords()) : [];
 		if (resolvedKeybinding && this.chords.length === 0) {
@@ -34,6 +40,7 @@ export class ResolvedKeybindingItem {
 		this.isDefault = isDefault;
 		this.extensionId = extensionId;
 		this.isBuiltinExtension = isBuiltinExtension;
+		this.systemWide = systemWide;
 	}
 }
 

--- a/src/vs/platform/native/common/native.ts
+++ b/src/vs/platform/native/common/native.ts
@@ -88,6 +88,39 @@ export const enum FocusMode {
 	Force,
 }
 
+export interface INativeSystemWideKeybinding {
+
+	/**
+	 * The keybinding in Electron accelerator format (e.g. `Control+Cmd+A`).
+	 * See https://www.electronjs.org/docs/latest/api/accelerator.
+	 */
+	readonly accelerator: string;
+
+	/**
+	 * The command to execute when the global shortcut is triggered.
+	 */
+	readonly commandId: string;
+
+	/**
+	 * Optional command arguments as configured in `keybindings.json`. Must be JSON-serializable.
+	 */
+	readonly args?: unknown;
+
+	/**
+	 * The user settings label (e.g. `ctrl+cmd+a`) for diagnostics/notifications.
+	 */
+	readonly userSettingsLabel?: string;
+}
+
+export interface INativeSystemWideKeybindingResult {
+
+	/**
+	 * The user settings labels (or accelerators) that could not be registered, e.g. because the
+	 * accelerator is already taken by the OS or another application.
+	 */
+	readonly failed: string[];
+}
+
 export interface ICommonNativeHostService {
 
 	readonly _serviceBrand: undefined;
@@ -140,6 +173,13 @@ export interface ICommonNativeHostService {
 	openWindow(toOpen: IWindowOpenable[], options?: IOpenWindowOptions): Promise<void>;
 
 	openAgentsWindow(options?: { folderUri?: UriComponents; sessionResource?: UriComponents }): Promise<void>;
+
+	/**
+	 * Registers this window's set of system-wide (OS global) keybindings with the main process,
+	 * replacing any previously registered by this window. The shortcuts fire even when the
+	 * application is not focused. Returns the set that could not be registered.
+	 */
+	syncSystemWideKeybindings(keybindings: INativeSystemWideKeybinding[]): Promise<INativeSystemWideKeybindingResult>;
 
 	isFullScreen(options?: INativeHostOptions): Promise<boolean>;
 	toggleFullScreen(options?: INativeHostOptions): Promise<void>;

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -27,7 +27,8 @@ import { IEnvironmentMainService } from '../../environment/electron-main/environ
 import { createDecorator, IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { ILifecycleMainService, IRelaunchOptions } from '../../lifecycle/electron-main/lifecycleMainService.js';
 import { ILogService } from '../../log/common/log.js';
-import { FocusMode, ICommonNativeHostService, INativeHostOptions, IOSProperties, IOSStatistics, IStartTracingOptions, IToastOptions, IToastResult, PowerSaveBlockerType, SystemIdleState, ThermalState } from '../common/native.js';
+import { FocusMode, ICommonNativeHostService, INativeHostOptions, INativeSystemWideKeybinding, INativeSystemWideKeybindingResult, IOSProperties, IOSStatistics, IStartTracingOptions, IToastOptions, IToastResult, PowerSaveBlockerType, SystemIdleState, ThermalState } from '../common/native.js';
+import { IGlobalKeybindingsMainService } from '../../globalKeybindings/electron-main/globalKeybindingsMainService.js';
 import { IProductService } from '../../product/common/productService.js';
 import { IPartsSplash } from '../../theme/common/themeService.js';
 import { IThemeMainService } from '../../theme/electron-main/themeMainService.js';
@@ -71,7 +72,8 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IRequestService private readonly requestService: IRequestService,
 		@IProxyAuthService private readonly proxyAuthService: IProxyAuthService,
-		@IInstantiationService private readonly instantiationService: IInstantiationService
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IGlobalKeybindingsMainService private readonly globalKeybindingsMainService: IGlobalKeybindingsMainService
 	) {
 		super();
 
@@ -313,6 +315,14 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 		if (windows.length > 0) {
 			windows[0].focus();
 		}
+	}
+
+	async syncSystemWideKeybindings(windowId: number | undefined, keybindings: INativeSystemWideKeybinding[]): Promise<INativeSystemWideKeybindingResult> {
+		if (typeof windowId !== 'number') {
+			return { failed: [] };
+		}
+		const failed = this.globalKeybindingsMainService.updateKeybindings(windowId, keybindings);
+		return { failed };
 	}
 
 	async isFullScreen(windowId: number | undefined, options?: INativeHostOptions): Promise<boolean> {

--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -394,7 +394,7 @@ export interface INativeOpenFileRequest extends IOpenFileRequest {
 
 export interface INativeRunActionInWindowRequest {
 	readonly id: string;
-	readonly from: 'menu' | 'touchbar' | 'mouse';
+	readonly from: 'menu' | 'touchbar' | 'mouse' | 'systemWideKeybinding';
 	readonly args?: unknown[];
 }
 

--- a/src/vs/workbench/contrib/keybindings/electron-browser/systemWideKeybindings.contribution.ts
+++ b/src/vs/workbench/contrib/keybindings/electron-browser/systemWideKeybindings.contribution.ts
@@ -18,16 +18,10 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
 
 /**
- * Persisted answer to the one-time confirmation prompt. Absent until the user is first asked;
- * `granted` once they allow system-wide keybindings, `denied` once they decline. Declining is how a
- * user opts out of the (otherwise always-available) feature, so we honor it and never re-ask.
+ * Persisted flag recording that the user has been shown the one-time heads-up explaining that their
+ * `systemWide` keybindings are captured globally. Set once the notice has been acknowledged.
  */
-const CONSENT_STORAGE_KEY = 'systemWideKeybindings.consent';
-
-const enum SystemWideKeybindingsConsent {
-	Granted = 'granted',
-	Denied = 'denied',
-}
+const ACKNOWLEDGED_STORAGE_KEY = 'systemWideKeybindings.acknowledged';
 
 export interface ISystemWideKeybindingCandidate {
 	readonly accelerator: string;
@@ -95,7 +89,8 @@ export function selectSystemWideKeybindings(items: readonly ResolvedKeybindingIt
 /**
  * Watches the resolved keybindings for entries opted into `systemWide` and mirrors them to the
  * main process (which owns Electron's `globalShortcut`). The mechanism is always active; a one-time
- * confirmation prompt the first time such a keybinding is registered lets the user allow or decline.
+ * notice the first time such a keybinding is registered makes the user aware the combo is captured
+ * globally.
  */
 export class SystemWideKeybindingsContribution extends Disposable implements IWorkbenchContribution {
 
@@ -109,8 +104,8 @@ export class SystemWideKeybindingsContribution extends Disposable implements IWo
 	/** User settings labels whose ignored `when` clause we already warned about. */
 	private readonly warnedWhenLabels = new Set<string>();
 
-	/** Guards against showing multiple confirmation dialogs concurrently. */
-	private confirmationInFlight = false;
+	/** Guards against showing the one-time notice more than once concurrently. */
+	private noticeInFlight = false;
 
 	constructor(
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
@@ -137,13 +132,6 @@ export class SystemWideKeybindingsContribution extends Disposable implements IWo
 	}
 
 	private async sync(): Promise<void> {
-		// The user previously declined the one-time prompt: keep everything unregistered and never
-		// prompt again. Declining is how a user opts out of the always-available feature.
-		if (this.storageService.get(CONSENT_STORAGE_KEY, StorageScope.APPLICATION) === SystemWideKeybindingsConsent.Denied) {
-			await this.pushToMainProcess([]);
-			return;
-		}
-
 		const candidates = this.collectCandidates();
 
 		// Nothing to register (no valid system-wide bindings): clear any previous registrations.
@@ -152,32 +140,19 @@ export class SystemWideKeybindingsContribution extends Disposable implements IWo
 			return;
 		}
 
-		// One-time confirmation before the very first registration, to make the system-wide nature
-		// (fires while unfocused, captures the combo globally) explicit before we take the combo.
-		if (this.storageService.get(CONSENT_STORAGE_KEY, StorageScope.APPLICATION) !== SystemWideKeybindingsConsent.Granted) {
-			if (this.confirmationInFlight) {
+		// Show a one-time heads-up before the very first registration so the user is aware the combo
+		// is captured globally (fires while unfocused). Informational only - the feature stays on.
+		if (!this.storageService.getBoolean(ACKNOWLEDGED_STORAGE_KEY, StorageScope.APPLICATION, false)) {
+			if (this.noticeInFlight) {
 				return;
 			}
-			this.confirmationInFlight = true;
-			let confirmed: boolean;
+			this.noticeInFlight = true;
 			try {
-				confirmed = await this.confirmFirstRun(candidates);
+				await this.notifyFirstRun(candidates);
 			} finally {
-				this.confirmationInFlight = false;
+				this.noticeInFlight = false;
 			}
-
-			this.storageService.store(
-				CONSENT_STORAGE_KEY,
-				confirmed ? SystemWideKeybindingsConsent.Granted : SystemWideKeybindingsConsent.Denied,
-				StorageScope.APPLICATION,
-				StorageTarget.MACHINE,
-			);
-
-			if (!confirmed) {
-				// Declined: leave everything unregistered.
-				await this.pushToMainProcess([]);
-				return;
-			}
+			this.storageService.store(ACKNOWLEDGED_STORAGE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
 		}
 
 		this.warnAboutIgnoredWhenClauses(candidates);
@@ -251,16 +226,17 @@ export class SystemWideKeybindingsContribution extends Disposable implements IWo
 		});
 	}
 
-	private async confirmFirstRun(candidates: readonly ISystemWideKeybindingCandidate[]): Promise<boolean> {
+	private async notifyFirstRun(candidates: readonly ISystemWideKeybindingCandidate[]): Promise<void> {
 		const labels = candidates.map(candidate => candidate.userSettingsLabel).join(', ');
-		const { confirmed } = await this.dialogService.confirm({
-			type: Severity.Warning,
-			message: nls.localize('systemWideKeybindings.confirm.message', "Allow {0} to register system-wide keybindings?", this.productName()),
-			detail: nls.localize('systemWideKeybindings.confirm.detail', "System-wide keybindings ({0}) are captured by the operating system and trigger their command even when {1} is not focused, taking the key combination away from other applications.", labels, this.productName()),
-			primaryButton: nls.localize({ key: 'systemWideKeybindings.confirm.enable', comment: ['&& denotes a mnemonic'] }, "&&Enable"),
-			cancelButton: nls.localize('systemWideKeybindings.confirm.disable', "Disable"),
+		await this.dialogService.prompt({
+			type: Severity.Info,
+			message: nls.localize('systemWideKeybindings.notice.message', "{0} is registering system-wide keybindings", this.productName()),
+			detail: nls.localize('systemWideKeybindings.notice.detail', "The keybindings you marked with \"systemWide\" ({0}) are captured by the operating system and trigger their command even when {1} is not focused, taking the key combination away from other applications.", labels, this.productName()),
+			buttons: [{
+				label: nls.localize({ key: 'systemWideKeybindings.notice.acknowledge', comment: ['&& denotes a mnemonic'] }, "&&I Understand"),
+				run: () => { },
+			}],
 		});
-		return confirmed;
 	}
 
 	private productName(): string {

--- a/src/vs/workbench/contrib/keybindings/electron-browser/systemWideKeybindings.contribution.ts
+++ b/src/vs/workbench/contrib/keybindings/electron-browser/systemWideKeybindings.contribution.ts
@@ -1,0 +1,287 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as nls from '../../../../nls.js';
+import { RunOnceScheduler } from '../../../../base/common/async.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { equals } from '../../../../base/common/arrays.js';
+import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurationNode, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
+import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+import { ResolvedKeybindingItem } from '../../../../platform/keybinding/common/resolvedKeybindingItem.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { INativeHostService, INativeSystemWideKeybinding } from '../../../../platform/native/common/native.js';
+import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { IProductService } from '../../../../platform/product/common/productService.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
+
+/**
+ * Setting that gates system-wide (OS global) keybindings. Experimental and disabled by default;
+ * nothing is registered with the operating system until the user opts in.
+ */
+export const ENABLE_SYSTEM_WIDE_KEYBINDINGS_SETTING = 'keyboard.enableSystemWideKeybindings';
+
+const CONFIRMATION_STORAGE_KEY = 'systemWideKeybindings.confirmed';
+
+export interface ISystemWideKeybindingCandidate {
+	readonly accelerator: string;
+	readonly commandId: string;
+	readonly args: unknown;
+	readonly userSettingsLabel: string;
+	readonly hasWhen: boolean;
+}
+
+export interface ISystemWideKeybindingSelection {
+	readonly candidates: ISystemWideKeybindingCandidate[];
+	/** User settings labels (or command ids) that cannot be expressed as an Electron accelerator (chords, single modifiers). */
+	readonly unsupported: string[];
+	/** Accelerators dropped because an earlier binding already claimed them. */
+	readonly duplicates: string[];
+}
+
+/**
+ * Pure selection of the system-wide keybindings from the full set of resolved keybindings. Only
+ * user keybindings opted into `systemWide` with a single key combination (expressible as an
+ * Electron accelerator) are eligible; the first binding wins on accelerator conflicts.
+ */
+export function selectSystemWideKeybindings(items: readonly ResolvedKeybindingItem[]): ISystemWideKeybindingSelection {
+	const seen = new Set<string>();
+	const candidates: ISystemWideKeybindingCandidate[] = [];
+	const unsupported: string[] = [];
+	const duplicates: string[] = [];
+
+	for (const item of items) {
+		// Only user keybindings can ever be system-wide; skip defaults/extension bindings and removals.
+		if (!item.systemWide || item.isDefault || !item.command) {
+			continue;
+		}
+
+		const resolved = item.resolvedKeybinding;
+		if (!resolved) {
+			continue; // unbound entry (e.g. a `-` removal)
+		}
+
+		const accelerator = resolved.getElectronAccelerator();
+		if (!accelerator) {
+			// Chords and single-modifier bindings cannot be expressed as an Electron accelerator.
+			unsupported.push(resolved.getUserSettingsLabel() ?? item.command);
+			continue;
+		}
+
+		if (seen.has(accelerator)) {
+			duplicates.push(resolved.getUserSettingsLabel() ?? accelerator);
+			continue;
+		}
+		seen.add(accelerator);
+
+		candidates.push({
+			accelerator,
+			commandId: item.command,
+			args: item.commandArgs ?? undefined,
+			userSettingsLabel: resolved.getUserSettingsLabel() ?? accelerator,
+			hasWhen: !!item.when,
+		});
+	}
+
+	return { candidates, unsupported, duplicates };
+}
+
+/**
+ * Watches the resolved keybindings for entries opted into `systemWide` and mirrors them to the
+ * main process (which owns Electron's `globalShortcut`). The mechanism is gated behind an
+ * experimental, off-by-default setting and a one-time confirmation prompt.
+ */
+export class SystemWideKeybindingsContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.systemWideKeybindings';
+
+	private readonly syncScheduler: RunOnceScheduler;
+
+	/** Accelerators that failed to register on the last sync, to avoid re-notifying unchanged failures. */
+	private lastReportedFailures: string[] = [];
+
+	/** User settings labels whose ignored `when` clause we already warned about. */
+	private readonly warnedWhenLabels = new Set<string>();
+
+	/** Guards against showing multiple confirmation dialogs concurrently. */
+	private confirmationInFlight = false;
+
+	constructor(
+		@IKeybindingService private readonly keybindingService: IKeybindingService,
+		@INativeHostService private readonly nativeHostService: INativeHostService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IStorageService private readonly storageService: IStorageService,
+		@IDialogService private readonly dialogService: IDialogService,
+		@INotificationService private readonly notificationService: INotificationService,
+		@IProductService private readonly productService: IProductService,
+		@ILogService private readonly logService: ILogService,
+	) {
+		super();
+
+		this.syncScheduler = this._register(new RunOnceScheduler(() => this.sync(), 200));
+
+		// Re-sync when keybindings change (also fires on keyboard-layout changes, which affect
+		// the accelerator strings) or when the enablement setting is toggled.
+		this._register(this.keybindingService.onDidUpdateKeybindings(() => this.scheduleSync()));
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(ENABLE_SYSTEM_WIDE_KEYBINDINGS_SETTING)) {
+				this.scheduleSync();
+			}
+		}));
+
+		this.scheduleSync();
+	}
+
+	private scheduleSync(): void {
+		this.syncScheduler.schedule();
+	}
+
+	private async sync(): Promise<void> {
+		const enabled = this.configurationService.getValue(ENABLE_SYSTEM_WIDE_KEYBINDINGS_SETTING) === true;
+		const candidates = enabled ? this.collectCandidates() : [];
+
+		// Nothing to register (feature off or no valid bindings): clear any previous registrations.
+		if (candidates.length === 0) {
+			await this.pushToMainProcess([]);
+			return;
+		}
+
+		// One-time confirmation before the first registration, even though the setting is opt-in,
+		// to make the system-wide nature (fires while unfocused, captures the combo globally) explicit.
+		if (!this.storageService.getBoolean(CONFIRMATION_STORAGE_KEY, StorageScope.APPLICATION, false)) {
+			if (this.confirmationInFlight) {
+				return;
+			}
+			this.confirmationInFlight = true;
+			let confirmed: boolean;
+			try {
+				confirmed = await this.confirmFirstRun(candidates);
+			} finally {
+				this.confirmationInFlight = false;
+			}
+
+			if (!confirmed) {
+				// Decline: turn the feature back off (which re-triggers a sync that clears everything).
+				await this.configurationService.updateValue(ENABLE_SYSTEM_WIDE_KEYBINDINGS_SETTING, false);
+				return;
+			}
+
+			this.storageService.store(CONFIRMATION_STORAGE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+		}
+
+		this.warnAboutIgnoredWhenClauses(candidates);
+		await this.pushToMainProcess(candidates);
+	}
+
+	private collectCandidates(): ISystemWideKeybindingCandidate[] {
+		const { candidates, unsupported, duplicates } = selectSystemWideKeybindings(this.keybindingService.getKeybindings());
+
+		for (const label of unsupported) {
+			this.logService.warn(`[SystemWideKeybindings] '${label}' cannot be registered as a system-wide shortcut (only single key combinations are supported).`);
+		}
+		for (const label of duplicates) {
+			this.logService.warn(`[SystemWideKeybindings] duplicate system-wide accelerator for '${label}', keeping the first binding.`);
+		}
+
+		return candidates;
+	}
+
+	private warnAboutIgnoredWhenClauses(candidates: readonly ISystemWideKeybindingCandidate[]): void {
+		const newlyWarned: string[] = [];
+		for (const candidate of candidates) {
+			if (candidate.hasWhen && !this.warnedWhenLabels.has(candidate.userSettingsLabel)) {
+				this.warnedWhenLabels.add(candidate.userSettingsLabel);
+				newlyWarned.push(candidate.userSettingsLabel);
+			}
+		}
+
+		if (newlyWarned.length > 0) {
+			this.notificationService.notify({
+				severity: Severity.Warning,
+				message: nls.localize('systemWideKeybindings.whenIgnored', "The \"when\" clause is ignored for system-wide keybindings ({0}); they are always active while {1} is running.", newlyWarned.join(', '), this.productName()),
+			});
+		}
+	}
+
+	private async pushToMainProcess(candidates: readonly ISystemWideKeybindingCandidate[]): Promise<void> {
+		const payload: INativeSystemWideKeybinding[] = candidates.map(candidate => ({
+			accelerator: candidate.accelerator,
+			commandId: candidate.commandId,
+			args: candidate.args,
+			userSettingsLabel: candidate.userSettingsLabel,
+		}));
+
+		let failed: string[];
+		try {
+			const result = await this.nativeHostService.syncSystemWideKeybindings(payload);
+			failed = result.failed;
+		} catch (error) {
+			this.logService.error('[SystemWideKeybindings] failed to sync system-wide keybindings with the main process', error);
+			return;
+		}
+
+		this.reportFailures(failed);
+	}
+
+	private reportFailures(failed: string[]): void {
+		const sorted = [...failed].sort();
+		if (equals(sorted, this.lastReportedFailures)) {
+			return; // same failures as last time; don't re-notify
+		}
+		this.lastReportedFailures = sorted;
+
+		if (sorted.length === 0) {
+			return;
+		}
+
+		this.notificationService.notify({
+			severity: Severity.Warning,
+			message: nls.localize('systemWideKeybindings.registrationFailed', "Some system-wide keybindings could not be registered ({0}); the key combination may already be taken by the operating system or another application.", sorted.join(', ')),
+		});
+	}
+
+	private async confirmFirstRun(candidates: readonly ISystemWideKeybindingCandidate[]): Promise<boolean> {
+		const labels = candidates.map(candidate => candidate.userSettingsLabel).join(', ');
+		const { confirmed } = await this.dialogService.confirm({
+			type: Severity.Warning,
+			message: nls.localize('systemWideKeybindings.confirm.message', "Allow {0} to register system-wide keybindings?", this.productName()),
+			detail: nls.localize('systemWideKeybindings.confirm.detail', "System-wide keybindings ({0}) are captured by the operating system and trigger their command even when {1} is not focused, taking the key combination away from other applications.", labels, this.productName()),
+			primaryButton: nls.localize('systemWideKeybindings.confirm.enable', "&&Enable"),
+			cancelButton: nls.localize('systemWideKeybindings.confirm.disable', "Disable"),
+		});
+		return confirmed;
+	}
+
+	private productName(): string {
+		return this.productService.nameLong;
+	}
+}
+
+const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+const systemWideKeybindingsConfiguration: IConfigurationNode = {
+	id: 'keyboard',
+	order: 15,
+	type: 'object',
+	title: nls.localize('keyboardConfigurationTitle', "Keyboard"),
+	properties: {
+		[ENABLE_SYSTEM_WIDE_KEYBINDINGS_SETTING]: {
+			scope: ConfigurationScope.APPLICATION,
+			type: 'boolean',
+			default: false,
+			tags: ['experimental'],
+			markdownDescription: nls.localize('enableSystemWideKeybindings', "Controls whether keybindings marked with `\"systemWide\": true` in your keybindings are registered as system-wide (operating system global) shortcuts that fire even when the application is not focused. This is an experimental, desktop-only feature; you will be asked to confirm the first time a system-wide keybinding is registered."),
+		}
+	}
+};
+configurationRegistry.registerConfiguration(systemWideKeybindingsConfiguration);
+
+registerWorkbenchContribution2(
+	SystemWideKeybindingsContribution.ID,
+	SystemWideKeybindingsContribution,
+	WorkbenchPhase.AfterRestored,
+);

--- a/src/vs/workbench/contrib/keybindings/electron-browser/systemWideKeybindings.contribution.ts
+++ b/src/vs/workbench/contrib/keybindings/electron-browser/systemWideKeybindings.contribution.ts
@@ -251,7 +251,7 @@ export class SystemWideKeybindingsContribution extends Disposable implements IWo
 			type: Severity.Warning,
 			message: nls.localize('systemWideKeybindings.confirm.message', "Allow {0} to register system-wide keybindings?", this.productName()),
 			detail: nls.localize('systemWideKeybindings.confirm.detail', "System-wide keybindings ({0}) are captured by the operating system and trigger their command even when {1} is not focused, taking the key combination away from other applications.", labels, this.productName()),
-			primaryButton: nls.localize('systemWideKeybindings.confirm.enable', "&&Enable"),
+			primaryButton: nls.localize({ key: 'systemWideKeybindings.confirm.enable', comment: ['&& denotes a mnemonic'] }, "&&Enable"),
 			cancelButton: nls.localize('systemWideKeybindings.confirm.disable', "Disable"),
 		});
 		return confirmed;

--- a/src/vs/workbench/contrib/keybindings/electron-browser/systemWideKeybindings.contribution.ts
+++ b/src/vs/workbench/contrib/keybindings/electron-browser/systemWideKeybindings.contribution.ts
@@ -7,8 +7,6 @@ import * as nls from '../../../../nls.js';
 import { RunOnceScheduler } from '../../../../base/common/async.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { equals } from '../../../../base/common/arrays.js';
-import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurationNode, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { ResolvedKeybindingItem } from '../../../../platform/keybinding/common/resolvedKeybindingItem.js';
@@ -16,17 +14,20 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { INativeHostService, INativeSystemWideKeybinding } from '../../../../platform/native/common/native.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
-import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
 
 /**
- * Setting that gates system-wide (OS global) keybindings. Experimental and disabled by default;
- * nothing is registered with the operating system until the user opts in.
+ * Persisted answer to the one-time confirmation prompt. Absent until the user is first asked;
+ * `granted` once they allow system-wide keybindings, `denied` once they decline. Declining is how a
+ * user opts out of the (otherwise always-available) feature, so we honor it and never re-ask.
  */
-export const ENABLE_SYSTEM_WIDE_KEYBINDINGS_SETTING = 'keyboard.enableSystemWideKeybindings';
+const CONSENT_STORAGE_KEY = 'systemWideKeybindings.consent';
 
-const CONFIRMATION_STORAGE_KEY = 'systemWideKeybindings.confirmed';
+const enum SystemWideKeybindingsConsent {
+	Granted = 'granted',
+	Denied = 'denied',
+}
 
 export interface ISystemWideKeybindingCandidate {
 	readonly accelerator: string;
@@ -93,8 +94,8 @@ export function selectSystemWideKeybindings(items: readonly ResolvedKeybindingIt
 
 /**
  * Watches the resolved keybindings for entries opted into `systemWide` and mirrors them to the
- * main process (which owns Electron's `globalShortcut`). The mechanism is gated behind an
- * experimental, off-by-default setting and a one-time confirmation prompt.
+ * main process (which owns Electron's `globalShortcut`). The mechanism is always active; a one-time
+ * confirmation prompt the first time such a keybinding is registered lets the user allow or decline.
  */
 export class SystemWideKeybindingsContribution extends Disposable implements IWorkbenchContribution {
 
@@ -114,7 +115,6 @@ export class SystemWideKeybindingsContribution extends Disposable implements IWo
 	constructor(
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@INativeHostService private readonly nativeHostService: INativeHostService,
-		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IStorageService private readonly storageService: IStorageService,
 		@IDialogService private readonly dialogService: IDialogService,
 		@INotificationService private readonly notificationService: INotificationService,
@@ -126,13 +126,8 @@ export class SystemWideKeybindingsContribution extends Disposable implements IWo
 		this.syncScheduler = this._register(new RunOnceScheduler(() => this.sync(), 200));
 
 		// Re-sync when keybindings change (also fires on keyboard-layout changes, which affect
-		// the accelerator strings) or when the enablement setting is toggled.
+		// the accelerator strings).
 		this._register(this.keybindingService.onDidUpdateKeybindings(() => this.scheduleSync()));
-		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(ENABLE_SYSTEM_WIDE_KEYBINDINGS_SETTING)) {
-				this.scheduleSync();
-			}
-		}));
 
 		this.scheduleSync();
 	}
@@ -142,18 +137,24 @@ export class SystemWideKeybindingsContribution extends Disposable implements IWo
 	}
 
 	private async sync(): Promise<void> {
-		const enabled = this.configurationService.getValue(ENABLE_SYSTEM_WIDE_KEYBINDINGS_SETTING) === true;
-		const candidates = enabled ? this.collectCandidates() : [];
+		// The user previously declined the one-time prompt: keep everything unregistered and never
+		// prompt again. Declining is how a user opts out of the always-available feature.
+		if (this.storageService.get(CONSENT_STORAGE_KEY, StorageScope.APPLICATION) === SystemWideKeybindingsConsent.Denied) {
+			await this.pushToMainProcess([]);
+			return;
+		}
 
-		// Nothing to register (feature off or no valid bindings): clear any previous registrations.
+		const candidates = this.collectCandidates();
+
+		// Nothing to register (no valid system-wide bindings): clear any previous registrations.
 		if (candidates.length === 0) {
 			await this.pushToMainProcess([]);
 			return;
 		}
 
-		// One-time confirmation before the first registration, even though the setting is opt-in,
-		// to make the system-wide nature (fires while unfocused, captures the combo globally) explicit.
-		if (!this.storageService.getBoolean(CONFIRMATION_STORAGE_KEY, StorageScope.APPLICATION, false)) {
+		// One-time confirmation before the very first registration, to make the system-wide nature
+		// (fires while unfocused, captures the combo globally) explicit before we take the combo.
+		if (this.storageService.get(CONSENT_STORAGE_KEY, StorageScope.APPLICATION) !== SystemWideKeybindingsConsent.Granted) {
 			if (this.confirmationInFlight) {
 				return;
 			}
@@ -165,13 +166,18 @@ export class SystemWideKeybindingsContribution extends Disposable implements IWo
 				this.confirmationInFlight = false;
 			}
 
+			this.storageService.store(
+				CONSENT_STORAGE_KEY,
+				confirmed ? SystemWideKeybindingsConsent.Granted : SystemWideKeybindingsConsent.Denied,
+				StorageScope.APPLICATION,
+				StorageTarget.MACHINE,
+			);
+
 			if (!confirmed) {
-				// Decline: turn the feature back off (which re-triggers a sync that clears everything).
-				await this.configurationService.updateValue(ENABLE_SYSTEM_WIDE_KEYBINDINGS_SETTING, false);
+				// Declined: leave everything unregistered.
+				await this.pushToMainProcess([]);
 				return;
 			}
-
-			this.storageService.store(CONFIRMATION_STORAGE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
 		}
 
 		this.warnAboutIgnoredWhenClauses(candidates);
@@ -261,24 +267,6 @@ export class SystemWideKeybindingsContribution extends Disposable implements IWo
 		return this.productService.nameLong;
 	}
 }
-
-const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
-const systemWideKeybindingsConfiguration: IConfigurationNode = {
-	id: 'keyboard',
-	order: 15,
-	type: 'object',
-	title: nls.localize('keyboardConfigurationTitle', "Keyboard"),
-	properties: {
-		[ENABLE_SYSTEM_WIDE_KEYBINDINGS_SETTING]: {
-			scope: ConfigurationScope.APPLICATION,
-			type: 'boolean',
-			default: false,
-			tags: ['experimental'],
-			markdownDescription: nls.localize('enableSystemWideKeybindings', "Controls whether keybindings marked with `\"systemWide\": true` in your keybindings are registered as system-wide (operating system global) shortcuts that fire even when the application is not focused. This is an experimental, desktop-only feature; you will be asked to confirm the first time a system-wide keybinding is registered."),
-		}
-	}
-};
-configurationRegistry.registerConfiguration(systemWideKeybindingsConfiguration);
 
 registerWorkbenchContribution2(
 	SystemWideKeybindingsContribution.ID,

--- a/src/vs/workbench/contrib/keybindings/test/electron-browser/systemWideKeybindings.test.ts
+++ b/src/vs/workbench/contrib/keybindings/test/electron-browser/systemWideKeybindings.test.ts
@@ -1,0 +1,98 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { KeyChord, KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
+import { ResolvedKeybinding } from '../../../../../base/common/keybindings.js';
+import { OperatingSystem } from '../../../../../base/common/platform.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ResolvedKeybindingItem } from '../../../../../platform/keybinding/common/resolvedKeybindingItem.js';
+import { createUSLayoutResolvedKeybinding } from '../../../../../platform/keybinding/test/common/keybindingsTestUtils.js';
+import { selectSystemWideKeybindings } from '../../electron-browser/systemWideKeybindings.contribution.js';
+
+suite('SystemWideKeybindings selection', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function resolve(encoded: number): ResolvedKeybinding {
+		const resolved = createUSLayoutResolvedKeybinding(encoded, OperatingSystem.Macintosh);
+		assert.ok(resolved, 'expected a resolvable keybinding');
+		return resolved;
+	}
+
+	function item(resolvedKeybinding: ResolvedKeybinding | undefined, command: string | null, options?: { commandArgs?: unknown; when?: string; isDefault?: boolean; systemWide?: boolean }): ResolvedKeybindingItem {
+		return new ResolvedKeybindingItem(
+			resolvedKeybinding,
+			command,
+			options?.commandArgs,
+			options?.when ? ContextKeyExpr.deserialize(options.when) : undefined,
+			options?.isDefault ?? false,
+			null,
+			false,
+			options?.systemWide ?? false,
+		);
+	}
+
+	test('selects only user system-wide single-combo bindings and preserves args/when', () => {
+		const acceleratorBinding = resolve(KeyMod.WinCtrl | KeyMod.CtrlCmd | KeyCode.KeyA);
+
+		const selection = selectSystemWideKeybindings([
+			// eligible: user, system-wide, single combo, with args + when
+			item(acceleratorBinding, 'workbench.action.openAgentsWindow', { commandArgs: { foo: 1 }, when: 'editorFocus', systemWide: true }),
+			// ignored: not system-wide
+			item(resolve(KeyMod.CtrlCmd | KeyCode.KeyB), 'noop.notSystemWide'),
+			// ignored: default keybinding even if flagged
+			item(resolve(KeyMod.CtrlCmd | KeyCode.KeyC), 'noop.default', { isDefault: true, systemWide: true }),
+			// ignored: removal / no command
+			item(resolve(KeyMod.CtrlCmd | KeyCode.KeyD), null, { systemWide: true }),
+		]);
+
+		assert.deepStrictEqual(selection, {
+			candidates: [{
+				accelerator: 'Ctrl+Cmd+A',
+				commandId: 'workbench.action.openAgentsWindow',
+				args: { foo: 1 },
+				userSettingsLabel: 'ctrl+cmd+a',
+				hasWhen: true,
+			}],
+			unsupported: [],
+			duplicates: [],
+		});
+	});
+
+	test('reports chords / single-modifier bindings as unsupported', () => {
+		const chord = resolve(KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyC));
+
+		const selection = selectSystemWideKeybindings([
+			item(chord, 'noop.chord', { systemWide: true }),
+		]);
+
+		assert.deepStrictEqual(selection, {
+			candidates: [],
+			unsupported: ['cmd+k cmd+c'],
+			duplicates: [],
+		});
+	});
+
+	test('keeps the first binding on accelerator conflicts', () => {
+		const selection = selectSystemWideKeybindings([
+			item(resolve(KeyMod.CtrlCmd | KeyCode.KeyA), 'first.wins', { systemWide: true }),
+			item(resolve(KeyMod.CtrlCmd | KeyCode.KeyA), 'second.loses', { systemWide: true }),
+		]);
+
+		assert.deepStrictEqual(selection, {
+			candidates: [{
+				accelerator: 'Cmd+A',
+				commandId: 'first.wins',
+				args: undefined,
+				userSettingsLabel: 'cmd+a',
+				hasWhen: false,
+			}],
+			unsupported: [],
+			duplicates: ['cmd+a'],
+		});
+	});
+});

--- a/src/vs/workbench/electron-browser/actions/windowActions.ts
+++ b/src/vs/workbench/electron-browser/actions/windowActions.ts
@@ -17,7 +17,8 @@ import { getIconClasses } from '../../../editor/common/services/getIconClasses.j
 import { ICommandHandler } from '../../../platform/commands/common/commands.js';
 import { ServicesAccessor } from '../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
-import { INativeHostService } from '../../../platform/native/common/native.js';
+import { INativeHostService, FocusMode } from '../../../platform/native/common/native.js';
+import { IHostService } from '../../services/host/browser/host.js';
 import { Codicon } from '../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../base/common/themables.js';
 import { isSingleFolderWorkspaceIdentifier, isWorkspaceIdentifier } from '../../../platform/workspace/common/workspace.js';
@@ -403,6 +404,30 @@ export class SwitchToMainWindowAction extends Action2 {
 	override async run(accessor: ServicesAccessor): Promise<void> {
 		const nativeHostService = accessor.get(INativeHostService);
 		return nativeHostService.focusWindow({ targetWindowId: mainWindow.vscodeWindowId });
+	}
+}
+
+export class FocusWindowAction extends Action2 {
+
+	static readonly ID = 'workbench.action.focusWindow';
+
+	constructor() {
+		super({
+			id: FocusWindowAction.ID,
+			title: localize2('focusWindow', "Focus Window"),
+			f1: true
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const hostService = accessor.get(IHostService);
+
+		// Bring the current window to the foreground and focus it. `FocusMode.Force` is used because
+		// the application may not be active (for example when this runs from a system-wide keybinding
+		// while another app owns OS focus). This makes it usable as the first step of a `runCommands`
+		// chain that reveals the window before running a command which surfaces UI in it (e.g. Quick
+		// Open).
+		await hostService.focus(getActiveWindow(), { mode: FocusMode.Force });
 	}
 }
 

--- a/src/vs/workbench/electron-browser/desktop.contribution.ts
+++ b/src/vs/workbench/electron-browser/desktop.contribution.ts
@@ -10,7 +10,7 @@ import { IConfigurationRegistry, Extensions as ConfigurationExtensions, Configur
 import { KeyMod, KeyCode } from '../../base/common/keyCodes.js';
 import { isLinux, isMacintosh, isWindows } from '../../base/common/platform.js';
 import { ConfigureRuntimeArgumentsAction, ToggleDevToolsAction, ReloadWindowWithExtensionsDisabledAction, OpenUserDataFolderAction, ShowGPUInfoAction, ShowContentTracingAction, StopTracing, StartTracing, StartHeapTracing } from './actions/developerActions.js';
-import { ZoomResetAction, ZoomOutAction, ZoomInAction, CloseWindowAction, SwitchWindowAction, QuickSwitchWindowAction, SwitchToMainWindowAction, NewWindowTabHandler, ShowPreviousWindowTabHandler, ShowNextWindowTabHandler, MoveWindowTabToNewWindowHandler, MergeWindowTabsHandlerHandler, ToggleWindowTabsBarHandler, ToggleWindowAlwaysOnTopAction, DisableWindowAlwaysOnTopAction, EnableWindowAlwaysOnTopAction, CloseOtherWindowsAction } from './actions/windowActions.js';
+import { ZoomResetAction, ZoomOutAction, ZoomInAction, CloseWindowAction, SwitchWindowAction, QuickSwitchWindowAction, SwitchToMainWindowAction, FocusWindowAction, NewWindowTabHandler, ShowPreviousWindowTabHandler, ShowNextWindowTabHandler, MoveWindowTabToNewWindowHandler, MergeWindowTabsHandlerHandler, ToggleWindowTabsBarHandler, ToggleWindowAlwaysOnTopAction, DisableWindowAlwaysOnTopAction, EnableWindowAlwaysOnTopAction, CloseOtherWindowsAction } from './actions/windowActions.js';
 import { ContextKeyExpr } from '../../platform/contextkey/common/contextkey.js';
 import { KeybindingsRegistry, KeybindingWeight } from '../../platform/keybinding/common/keybindingsRegistry.js';
 import { CommandsRegistry } from '../../platform/commands/common/commands.js';
@@ -42,6 +42,7 @@ import product from '../../platform/product/common/product.js';
 	registerAction2(SwitchWindowAction);
 	registerAction2(QuickSwitchWindowAction);
 	registerAction2(SwitchToMainWindowAction);
+	registerAction2(FocusWindowAction);
 	registerAction2(CloseWindowAction);
 	registerAction2(CloseOtherWindowsAction);
 	registerAction2(ToggleWindowAlwaysOnTopAction);

--- a/src/vs/workbench/electron-browser/window.ts
+++ b/src/vs/workbench/electron-browser/window.ts
@@ -169,6 +169,11 @@ export class NativeWindow extends BaseWindow {
 						args.push(resource);
 					}
 				}
+			} else if (request.from === 'systemWideKeybinding') {
+				// A system-wide (OS global) keybinding runs the command with exactly the arguments
+				// configured in `keybindings.json` (already in `request.args`). We intentionally do
+				// not append a `{ from }` sentinel so that commands taking positional arguments
+				// receive the same payload they would from a regular in-window keybinding.
 			} else {
 				args.push({ from: request.from });
 			}

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -487,11 +487,11 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 			const when = item.when || undefined;
 			if (!item.keybinding) {
 				// This might be a removal keybinding item in user settings => accept it
-				result[resultLen++] = new ResolvedKeybindingItem(undefined, item.command, item.commandArgs, when, isDefault, null, false);
+				result[resultLen++] = new ResolvedKeybindingItem(undefined, item.command, item.commandArgs, when, isDefault, null, false, item.systemWide);
 			} else {
 				const resolvedKeybindings = this._keyboardMapper.resolveKeybinding(item.keybinding);
 				for (const resolvedKeybinding of resolvedKeybindings) {
-					result[resultLen++] = new ResolvedKeybindingItem(resolvedKeybinding, item.command, item.commandArgs, when, isDefault, null, false);
+					result[resultLen++] = new ResolvedKeybindingItem(resolvedKeybinding, item.command, item.commandArgs, when, isDefault, null, false, item.systemWide);
 				}
 			}
 		}
@@ -926,6 +926,11 @@ class KeybindingsJsonSchema {
 				},
 				'args': {
 					'description': nls.localize('keybindings.json.args', "Arguments to pass to the command to execute.")
+				},
+				'systemWide': {
+					'type': 'boolean',
+					'default': true,
+					'markdownDescription': nls.localize('keybindings.json.systemWide', "When `true`, registers this keybinding as a system-wide (OS global) shortcut that fires even when the application is not focused. Requires enabling `#keyboard.enableSystemWideKeybindings#`. Desktop only. Only single key combinations are supported (no chords), and any `when` clause is ignored for the global trigger.")
 				}
 			},
 			'$ref': '#/definitions/commandsSchemas'

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -930,7 +930,7 @@ class KeybindingsJsonSchema {
 				'systemWide': {
 					'type': 'boolean',
 					'default': false,
-					'markdownDescription': nls.localize('keybindings.json.systemWide', "When `true`, registers this keybinding as a system-wide (OS global) shortcut that fires even when the application is not focused. Desktop only. Only single key combinations are supported (no chords), and any `when` clause is ignored for the global trigger. The first time such a keybinding is registered you will be asked to confirm.")
+					'markdownDescription': nls.localize('keybindings.json.systemWide', "When `true`, registers this keybinding as a system-wide (OS global) shortcut that fires even when the application is not focused. Desktop only. Only single key combinations are supported (no chords), and any `when` clause is ignored for the global trigger. The first time such a keybinding is registered you will see a one-time notice.")
 				}
 			},
 			'$ref': '#/definitions/commandsSchemas'

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -930,7 +930,7 @@ class KeybindingsJsonSchema {
 				'systemWide': {
 					'type': 'boolean',
 					'default': false,
-					'markdownDescription': nls.localize('keybindings.json.systemWide', "When `true`, registers this keybinding as a system-wide (OS global) shortcut that fires even when the application is not focused. Requires enabling `#keyboard.enableSystemWideKeybindings#`. Desktop only. Only single key combinations are supported (no chords), and any `when` clause is ignored for the global trigger.")
+					'markdownDescription': nls.localize('keybindings.json.systemWide', "When `true`, registers this keybinding as a system-wide (OS global) shortcut that fires even when the application is not focused. Desktop only. Only single key combinations are supported (no chords), and any `when` clause is ignored for the global trigger. The first time such a keybinding is registered you will be asked to confirm.")
 				}
 			},
 			'$ref': '#/definitions/commandsSchemas'

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -929,7 +929,7 @@ class KeybindingsJsonSchema {
 				},
 				'systemWide': {
 					'type': 'boolean',
-					'default': true,
+					'default': false,
 					'markdownDescription': nls.localize('keybindings.json.systemWide', "When `true`, registers this keybinding as a system-wide (OS global) shortcut that fires even when the application is not focused. Requires enabling `#keyboard.enableSystemWideKeybindings#`. Desktop only. Only single key combinations are supported (no chords), and any `when` clause is ignored for the global trigger.")
 				}
 			},

--- a/src/vs/workbench/services/keybinding/common/keybindingIO.ts
+++ b/src/vs/workbench/services/keybinding/common/keybindingIO.ts
@@ -13,6 +13,7 @@ export interface IUserKeybindingItem {
 	command: string | null;
 	commandArgs?: unknown;
 	when: ContextKeyExpression | undefined;
+	systemWide: boolean;
 	_sourceKey: string | undefined; /** captures `key` field from `keybindings.json`; `this.keybinding !== null` implies `_sourceKey !== null` */
 }
 
@@ -39,6 +40,11 @@ export class KeybindingIO {
 			out.writeLine();
 			out.write(`                                     "args": ${JSON.stringify(item.commandArgs)}`);
 		}
+		if (item.systemWide) {
+			out.write(',');
+			out.writeLine();
+			out.write(`                                     "systemWide": true`);
+		}
 		out.write(' }');
 	}
 
@@ -55,11 +61,15 @@ export class KeybindingIO {
 		const commandArgs = 'args' in input && typeof input.args !== 'undefined'
 			? input.args
 			: undefined;
+		const systemWide = 'systemWide' in input && typeof input.systemWide === 'boolean'
+			? input.systemWide
+			: false;
 		return {
 			keybinding,
 			command,
 			commandArgs,
 			when,
+			systemWide,
 			_sourceKey: 'key' in input && typeof input.key === 'string' ? input.key : undefined,
 		};
 	}

--- a/src/vs/workbench/services/keybinding/test/browser/keybindingEditing.test.ts
+++ b/src/vs/workbench/services/keybinding/test/browser/keybindingEditing.test.ts
@@ -170,6 +170,13 @@ suite('KeybindingsEditing', () => {
 		assert.deepStrictEqual(await getUserKeybindings(), expected);
 	});
 
+	test('edit an user keybinding preserves systemWide on other entries', async () => {
+		await writeToKeybindingsFile({ key: 'escape', command: 'b' }, { key: 'alt+shift+g', command: 'c', systemWide: true });
+		const expected: IUserFriendlyKeybinding[] = [{ key: 'alt+c', command: 'b' }, { key: 'alt+shift+g', command: 'c', systemWide: true }];
+		await testObject.editKeybinding(aResolvedKeybindingItem({ firstChord: { keyCode: KeyCode.Escape }, command: 'b', isDefault: false }), 'alt+c', undefined);
+		assert.deepStrictEqual(await getUserKeybindings(), expected);
+	});
+
 	test('remove a default keybinding', async () => {
 		const expected: IUserFriendlyKeybinding[] = [{ key: 'alt+c', command: '-a' }];
 		await testObject.removeKeybinding(aResolvedKeybindingItem({ command: 'a', firstChord: { keyCode: KeyCode.KeyC, modifiers: { altKey: true } } }));

--- a/src/vs/workbench/services/keybinding/test/browser/keybindingEditing.test.ts
+++ b/src/vs/workbench/services/keybinding/test/browser/keybindingEditing.test.ts
@@ -170,7 +170,7 @@ suite('KeybindingsEditing', () => {
 		assert.deepStrictEqual(await getUserKeybindings(), expected);
 	});
 
-	test('edit an user keybinding preserves systemWide on other entries', async () => {
+	test('edit a user keybinding preserves systemWide on other entries', async () => {
 		await writeToKeybindingsFile({ key: 'escape', command: 'b' }, { key: 'alt+shift+g', command: 'c', systemWide: true });
 		const expected: IUserFriendlyKeybinding[] = [{ key: 'alt+c', command: 'b' }, { key: 'alt+shift+g', command: 'c', systemWide: true }];
 		await testObject.editKeybinding(aResolvedKeybindingItem({ firstChord: { keyCode: KeyCode.Escape }, command: 'b', isDefault: false }), 'alt+c', undefined);

--- a/src/vs/workbench/services/keybinding/test/browser/keybindingIO.test.ts
+++ b/src/vs/workbench/services/keybinding/test/browser/keybindingIO.test.ts
@@ -7,8 +7,9 @@ import { KeyChord, KeyCode, KeyMod, ScanCode } from '../../../../../base/common/
 import { KeyCodeChord, decodeKeybinding, ScanCodeChord, Keybinding } from '../../../../../base/common/keybindings.js';
 import { KeybindingParser } from '../../../../../base/common/keybindingParser.js';
 import { OperatingSystem } from '../../../../../base/common/platform.js';
-import { KeybindingIO } from '../../common/keybindingIO.js';
+import { KeybindingIO, OutputBuilder } from '../../common/keybindingIO.js';
 import { createUSLayoutResolvedKeybinding } from '../../../../../platform/keybinding/test/common/keybindingsTestUtils.js';
+import { ResolvedKeybindingItem } from '../../../../../platform/keybinding/common/resolvedKeybindingItem.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 
 suite('keybindingIO', () => {
@@ -157,5 +158,32 @@ suite('keybindingIO', () => {
 		const userKeybinding = <Object>JSON.parse(strJSON)[0];
 		const keybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding);
 		assert.strictEqual((keybindingItem.commandArgs as unknown as { text: string }).text, 'theText');
+	});
+
+	test('systemWide - read defaults to false when absent or invalid', () => {
+		const absent = KeybindingIO.readUserKeybindingItem(<Object>JSON.parse(`{ "key": "ctrl+cmd+a", "command": "firstcommand" }`));
+		assert.strictEqual(absent.systemWide, false);
+
+		const invalid = KeybindingIO.readUserKeybindingItem(<Object>JSON.parse(`{ "key": "ctrl+cmd+a", "command": "firstcommand", "systemWide": "yes" }`));
+		assert.strictEqual(invalid.systemWide, false);
+	});
+
+	test('systemWide - read parses boolean value', () => {
+		const item = KeybindingIO.readUserKeybindingItem(<Object>JSON.parse(`{ "key": "ctrl+cmd+a", "command": "firstcommand", "systemWide": true }`));
+		assert.strictEqual(item.systemWide, true);
+	});
+
+	test('systemWide - write/export preserves the flag (roundtrip)', () => {
+		const resolvedKeybinding = createUSLayoutResolvedKeybinding(KeyMod.CtrlCmd | KeyMod.WinCtrl | KeyCode.KeyA, OperatingSystem.Macintosh)!;
+		const item = new ResolvedKeybindingItem(resolvedKeybinding, 'workbench.action.openAgentsWindow', undefined, undefined, false, null, false, /* systemWide */ true);
+
+		const out = new OutputBuilder();
+		KeybindingIO.writeKeybindingItem(out, item);
+		const serialized = out.toString();
+		assert.ok(serialized.includes('"systemWide": true'), `expected serialized keybinding to include systemWide, got: ${serialized}`);
+
+		const readBack = KeybindingIO.readUserKeybindingItem(<Object>JSON.parse(serialized));
+		assert.strictEqual(readBack.systemWide, true);
+		assert.strictEqual(readBack.command, 'workbench.action.openAgentsWindow');
 	});
 });

--- a/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
@@ -25,7 +25,7 @@ import { InMemoryFileSystemProvider } from '../../../platform/files/common/inMem
 import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
 import { ISharedProcessService } from '../../../platform/ipc/electron-browser/services.js';
 import { NullLogService } from '../../../platform/log/common/log.js';
-import { INativeHostOptions, INativeHostService, IOSProperties, IOSStatistics, IToastOptions, IToastResult, PowerSaveBlockerType, SystemIdleState, ThermalState } from '../../../platform/native/common/native.js';
+import { INativeHostOptions, INativeHostService, INativeSystemWideKeybinding, INativeSystemWideKeybindingResult, IOSProperties, IOSStatistics, IToastOptions, IToastResult, PowerSaveBlockerType, SystemIdleState, ThermalState } from '../../../platform/native/common/native.js';
 import { IProductService } from '../../../platform/product/common/productService.js';
 import { AuthInfo, Credentials } from '../../../platform/request/common/request.js';
 import { IStorageService } from '../../../platform/storage/common/storage.js';
@@ -104,6 +104,8 @@ export class TestNativeHostService implements INativeHostService {
 	}
 
 	async openAgentsWindow(_options?: { folderUri?: UriComponents; sessionResource?: UriComponents }): Promise<void> { }
+
+	async syncSystemWideKeybindings(_keybindings: INativeSystemWideKeybinding[]): Promise<INativeSystemWideKeybindingResult> { return { failed: [] }; }
 
 	async toggleFullScreen(): Promise<void> { }
 	async isMaximized(): Promise<boolean> { return true; }

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -204,6 +204,9 @@ import './contrib/policyExport/electron-browser/policyExport.contribution.js';
 // Keybindings Export
 import './contrib/keybindingsExport/electron-browser/keybindingsExport.contribution.js';
 
+// System-wide (OS global) Keybindings
+import './contrib/keybindings/electron-browser/systemWideKeybindings.contribution.js';
+
 //#endregion
 
 


### PR DESCRIPTION
## Why

Some workflows benefit from a keybinding that works even when VS Code does not have OS focus, for example a global shortcut to open or reveal the Agents window from anywhere. Today VS Code keybindings only fire when a VS Code window is focused.

## What

Adds an opt-in `"systemWide": true` flag for entries in `keybindings.json`:

```jsonc
{
  "key": "ctrl+cmd+a",
  "command": "workbench.action.openAgentsWindow",
  "systemWide": true
}
```

When set, the shortcut is registered as an OS-global shortcut, so pressing it runs the command even while another application is focused.

Opt-in is per keybinding - there is no global on/off setting to flip. Any user keybinding that carries `"systemWide": true` is registered as a global shortcut. Because global shortcuts are captured OS-wide (they take the key combination away from other apps while VS Code is running), the first time such a binding is registered the user sees a one-time informational notice with a single "I Understand" button, so the behavior is never a surprise.

## How it works

End to end: parse the flag, thread it through the resolved keybinding model, have a renderer contribution select the opted-in bindings and sync them to the main process over a new `nativeHost` IPC, and have a new main-process service own Electron's `globalShortcut`. On trigger, the service routes the command back into a window renderer via the existing `vscode:runAction` path.

## Focus behavior

A system-wide shortcut fires while VS Code is typically unfocused, so the trigger deliberately does not pull the routing window to the foreground. The invoked command decides what to surface: `openAgentsWindow`, for instance, reveals and focuses the Agents window on its own, with no flicker of the main window.

For commands that surface UI in the current window (e.g. Quick Open) and therefore do want the window revealed, this PR also adds a generic `workbench.action.focusWindow` command that raises the current window using `FocusMode.Force` (works even when the app is not active). Users can compose it via `runCommands`:

```jsonc
{
  "key": "ctrl+cmd+p",
  "command": "runCommands",
  "args": { "commands": ["workbench.action.focusWindow", "workbench.action.quickOpen"] },
  "systemWide": true
}
```

## Changes by area (suggested review order)

Review roughly top to bottom: shared contracts first, then parsing, then the renderer, then the main process, then trigger routing, then the focus command, then tests.

**1. Shared contracts and data model**
- `platform/keybinding/common/keybinding.ts` - adds `systemWide?: boolean` to `IUserFriendlyKeybinding` (the user-facing `keybindings.json` shape), documented as desktop-only and user-keybindings-only.
- `platform/keybinding/common/resolvedKeybindingItem.ts` - carries `systemWide` on `ResolvedKeybindingItem` as a new trailing constructor arg defaulting to `false`, so defaults and extension keybindings are never system-wide.
- `platform/native/common/native.ts` - new IPC contract: `INativeSystemWideKeybinding` (accelerator, commandId, args, label), `INativeSystemWideKeybindingResult` (`failed[]`), and `syncSystemWideKeybindings(...)` on the native host service.
- `platform/window/common/window.ts` - adds `'systemWideKeybinding'` to the `INativeRunActionInWindowRequest.from` union.

**2. Parsing and serialization (`keybindings.json` <-> model)**
- `workbench/services/keybinding/common/keybindingIO.ts` - reads `systemWide` from JSON (defaults to `false` when absent/non-boolean) and writes it back out; adds the field to `IUserKeybindingItem`.
- `workbench/services/keybinding/browser/keybindingService.ts` - threads `item.systemWide` into both `ResolvedKeybindingItem` construction paths, and registers the `systemWide` property in the `keybindings.json` JSON schema (documented as desktop-only, single-combination-only, `when` ignored for the global trigger, with a one-time notice on first registration).

**3. Renderer contribution (selection + sync)**
- `workbench/contrib/keybindings/electron-browser/systemWideKeybindings.contribution.ts` - the core renderer logic. Exposes a pure `selectSystemWideKeybindings()` (filter opted-in bindings, translate to Electron accelerators, dedupe, drop unsupported chords with a warning), debounces syncing via a `RunOnceScheduler`, shows a one-time informational notice before the first registration (persisting an "acknowledged" flag in application storage so it appears only once), and calls `nativeHostService.syncSystemWideKeybindings(...)`.
- `workbench/workbench.desktop.main.ts` - registers the contribution in the desktop workbench.

**4. Main process (owns the OS globalShortcut)**
- `platform/globalKeybindings/electron-main/globalKeybindingsMainService.ts` - the heart of the feature. Owns a per-window registry, registers/unregisters accelerators via an injected `globalShortcut` (`IGlobalShortcutRegistry`, for testability), resolves cross-window conflicts deterministically, returns labels that failed to register, and on trigger routes the command to a target window via `sendWhenReady('vscode:runAction', ...)`. Cleans up on window destroy and shutdown.
- `platform/native/electron-main/nativeHostMainService.ts` - implements `syncSystemWideKeybindings` by forwarding to the service (keyed by the calling `windowId`).
- `code/electron-main/app.ts` - registers the service in DI, injecting Electron's `globalShortcut` as a constructor dependency.
- `main.ts` - enables Electron's `GlobalShortcutsPortal` feature on Linux so `globalShortcut` works under Wayland (no-op elsewhere).

**5. Trigger routing (main -> renderer -> command)**
- `workbench/electron-browser/window.ts` - handles `from: 'systemWideKeybinding'` in the `vscode:runAction` handler, running the command with exactly the configured args and intentionally not appending a `{ from }` sentinel.

**6. Focus behavior and the focusWindow command**
- `workbench/electron-browser/actions/windowActions.ts` - adds `FocusWindowAction` (`workbench.action.focusWindow`) that raises the current window via `hostService.focus(getActiveWindow(), { mode: FocusMode.Force })`.
- `workbench/electron-browser/desktop.contribution.ts` - registers the new action.

**7. Tests**
- `platform/globalKeybindings/test/electron-main/globalKeybindingsMainService.test.ts` - registration, dedupe, cross-window conflict resolution, trigger payload/routing (asserts the routing window is not force-focused), and teardown on window close/shutdown.
- `workbench/contrib/keybindings/test/electron-browser/systemWideKeybindings.test.ts` - `selectSystemWideKeybindings()` filtering, args/when handling, chord rejection, and first-wins dedupe.
- `workbench/services/keybinding/test/browser/keybindingIO.test.ts` - round-trips the `systemWide` flag.
- `workbench/services/keybinding/test/browser/keybindingEditing.test.ts` - guards against data loss: editing one entry preserves `systemWide` on others.
- `workbench/test/electron-browser/workbenchTestServices.ts` - stub for the new native host method.

## Notes for reviewers

- The feature is always active (any user keybinding with `"systemWide": true`); there is no enablement setting. The one-time informational notice makes the OS-global capture explicit before the first registration and is purely a heads-up, so there is no "off" state to get stuck in.
- Global shortcuts are a shared OS resource; the service resolves conflicts deterministically and unregisters on window close and shutdown.
- `GlobalKeybindingsMainService` takes Electron's `globalShortcut` as a constructor dependency so it stays unit-testable.
- Chorded bindings cannot be OS globals and are skipped with a warning; accelerator support follows Electron's `globalShortcut` capabilities.
- No new focusable UI surface is added (only a one-time informational notice dialog and a command palette entry), so no accessible-view work was required.