### PR TITLE
Re-enable Codex smoke test with a fast-fail native-binary pre-check

### DIFF
--- a/test/smoke/src/areas/agentsWindow/agentsWindow.test.ts
+++ b/test/smoke/src/areas/agentsWindow/agentsWindow.test.ts
@@ -905,7 +905,7 @@ export function setup(logger: Logger) {
 			},
 		});
 
-		it.skip('Test Codex session', async function () {
+		it('Test Codex session', async function () {
 			this.timeout(5 * 60 * 1000);
 
 			const app = this.app as Application;
@@ -941,6 +941,27 @@ export function setup(logger: Logger) {
 				}
 				logger.log('[Agents Window/Codex] Codex session type not available in this built product (no product.agentSdks.codex); skipping');
 				this.skip();
+			}
+
+			// Codex reports as "available" once the `@openai/codex` launcher shim
+			// resolves, but the native binary ships as a separate per-platform
+			// optional dependency that npm silently skips when its install fails.
+			// A stale `node_modules` cache can thus have the shim but no binary, so
+			// fail fast here (from source) instead of timing out at spawn time.
+			if (process.env['VSCODE_DEV'] === '1') {
+				const repoRoot = path.resolve(process.cwd(), '..', '..');
+				const platformPkgDir = path.join(repoRoot, 'node_modules', `@openai/codex-${process.platform}-${process.arch}`);
+				const binaryName = process.platform === 'win32' ? 'codex.exe' : 'codex';
+				let codexBinaryFound = false;
+				try {
+					const vendorDir = path.join(platformPkgDir, 'vendor');
+					codexBinaryFound = fs.readdirSync(vendorDir).some(triple => fs.existsSync(path.join(vendorDir, triple, 'bin', binaryName)));
+				} catch {
+					// vendor dir (or the whole platform package) is missing → treated as not found
+				}
+				if (!codexBinaryFound) {
+					throw new Error(`[Agents Window/Codex] Codex native binary missing at ${platformPkgDir}. We depend on \`@openai/codex\`, which is only a thin launcher shim; the actual native binaries ship as its per-platform optional dependencies (\`@openai/codex-<platform>-<arch>\`). \`npm install\` does not fail when an optional dependency can't be installed, so node_modules can end up with the shim but no binary — Codex then reports as "available" but has nothing to spawn. Try bumping build/.cachesalt to force a fresh \`npm ci\` that reinstalls the binary.`);
+				}
 			}
 
 			try {


### PR DESCRIPTION
## Problem

The `Agents Window (Codex) › Test Codex session` smoke test failed on Linux (temporarily skipped in #323867) with:

```
Error: Codex binary not executable: .../@openai/codex-linux-x64/.../codex (ENOENT)
```

## Root cause

`@openai/codex` (our devDependency) is only a thin launcher shim; the native binary ships as its per-platform **optional** dependency (`@openai/codex-<platform>-<arch>`). `npm install` silently ignores an optional dependency that fails to install, so a `node_modules` cache built during such a hiccup keeps the shim but loses the binary. The shim still makes Codex report as "available", so the test ran and then failed at spawn time. Because the Linux cache is written once per lockfile hash, every PR restoring that one poisoned cache failed identically.

## Verification

Running only the Codex smoke test on Linux, restoring the same shared cache:

- Broken cache key `be1f7d0d…` (binary missing) → **fails**: https://github.com/microsoft/vscode/actions/runs/28527757731
- Fresh cache (binary present) → **passes**: https://github.com/microsoft/vscode/actions/runs/28522256973

## This PR

- Re-enables the Codex session smoke test (skipped in #323867).
- Adds a from-source pre-check: if the shim is present but the native binary is missing, fail fast with an actionable message instead of a 5-minute timeout.

No cache change is needed here — main's lockfile has since rolled to a healthy cache. **If it recurs, bumping `build/.cachesalt` forces a fresh `npm ci` that reinstalls the binary.**
