### PR TITLE
Revert explorer paste hasResources guard (#323002) on main

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -1132,7 +1132,7 @@ export const pasteFileHandler = async (accessor: ServicesAccessor, fileList?: Fi
 	const hostService = accessor.get(IHostService);
 
 	const context = explorerService.getContext(false);
-	const hasNativeFilesToPaste = fileList !== undefined && fileList.length > 0;
+	const hasNativeFilesToPaste = fileList && fileList.length > 0;
 	const confirmPasteNative = hasNativeFilesToPaste && configurationService.getValue<boolean>('explorer.confirmPasteNative');
 
 	const toPaste = await getFilesToPaste(fileList, clipboardService, hostService);

--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -333,15 +333,12 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 			}
 		}));
 
-		// Native file paste: only handle when clipboardService has no resources (avoids double-paste from keybinding path)
+		// Support for paste of files into explorer
 		this._register(DOM.addDisposableListener(DOM.getWindow(this.container), DOM.EventType.PASTE, async event => {
 			if (!this.hasFocus() || this.readonlyContext.get()) {
 				return;
 			}
 			if (event.clipboardData?.files?.length) {
-				if (await this.clipboardService.hasResources()) {
-					return;
-				}
 				await this.commandService.executeCommand('filesExplorer.paste', event.clipboardData?.files);
 			}
 		}));


### PR DESCRIPTION
Restores pasting files copied from an external OS file explorer into the Explorer, which regressed in 1.127.0 (#323858).

The guard added by #323002 read `event.clipboardData.files` after awaiting `clipboardService.hasResources()`. The clipboard `DataTransfer` is only valid during synchronous paste-event dispatch, so after the await the file list was empty and external pastes did nothing. The guard was only needed to counter the double-paste from #320685 (native OS file writes); this reverts to the simple listener on main.

Not reverted on release/1.127 since that release already shipped.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
