### PR TITLE
Git - Don't have 2 commands called "Open Changes"

### DIFF
--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -16,7 +16,7 @@
 	"command.openWorktreeInNewWindow2": "Open in New Window",
 	"command.refresh": "Refresh",
 	"command.compareWithWorkspace": "Compare with Workspace",
-	"command.openChange": "Open Changes",
+	"command.openChange": "Open Change",
 	"command.openAllChanges": "Open All Changes",
 	"command.openFile": "Open File",
 	"command.openHEADFile": "Open File (HEAD)",


### PR DESCRIPTION
So far we had:

    "command.openChange": "Open Changes",
    "command.viewChanges": "Open Changes",

making the Command Pallete confusing:

<img width="250" height="132" alt="image" src="https://github.com/user-attachments/assets/11f2365d-0802-4c4d-8fc7-cad12536c611" />

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
