### PR TITLE
sessions: open the session when using Open in VS Code

### DIFF
--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -48,7 +48,7 @@ import { IConfigurationService } from '../../configuration/common/configuration.
 import { IProxyAuthService } from './auth.js';
 import { AuthInfo, Credentials, IRequestService } from '../../request/common/request.js';
 import { randomPath } from '../../../base/common/extpath.js';
-import { CancellationTokenSource } from '../../../base/common/cancellation.js';
+import { CancellationToken, CancellationTokenSource } from '../../../base/common/cancellation.js';
 
 export interface INativeHostMainService extends AddFirstParameterToFunctions<ICommonNativeHostService, Promise<unknown> /* only methods, not events */, number | undefined /* window ID */> { }
 
@@ -275,7 +275,7 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 
 	private async doOpenWindow(windowId: number | undefined, toOpen: IWindowOpenable[], options: IOpenWindowOptions = Object.create(null)): Promise<void> {
 		if (toOpen.length > 0) {
-			await this.windowsMainService.open({
+			const windows = await this.windowsMainService.open({
 				context: OpenContext.API,
 				contextWindowId: windowId,
 				urisToOpen: toOpen,
@@ -294,6 +294,13 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 				forceProfile: options.forceProfile,
 				forceTempProfile: options.forceTempProfile,
 			});
+
+			// Hand off a chat session to the opened window so it restores both the
+			// folder and the session (e.g. the Agents window "Open in VS Code" flow).
+			const chatSessionToOpen = options.chatSessionToOpen;
+			if (chatSessionToOpen && windows.length > 0) {
+				windows[0].sendWhenReady('vscode:openChatSession', CancellationToken.None, URI.revive(chatSessionToOpen).toString());
+			}
 		}
 	}
 

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -297,8 +297,10 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 
 			// Hand off a chat session to the opened window so it restores both the
 			// folder and the session (e.g. the Agents window "Open in VS Code" flow).
+			// Only meaningful when exactly one window is opened so the session is
+			// not sent to an ambiguous target.
 			const chatSessionToOpen = options.chatSessionToOpen;
-			if (chatSessionToOpen && windows.length > 0) {
+			if (chatSessionToOpen && windows.length === 1) {
 				windows[0].sendWhenReady('vscode:openChatSession', CancellationToken.None, URI.revive(chatSessionToOpen).toString());
 			}
 		}

--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -69,6 +69,13 @@ export interface IOpenWindowOptions extends IBaseOpenWindowsOptions {
 	readonly gotoLineMode?: boolean;
 
 	readonly waitMarkerFileURI?: URI;
+
+	/**
+	 * When set, the opened window is asked to open the chat session identified
+	 * by this resource once it is ready. Used to hand off a session (e.g. from
+	 * the Agents window) so the new window restores both the folder and session.
+	 */
+	readonly chatSessionToOpen?: URI;
 }
 
 export interface IAddRemoveFoldersRequest {

--- a/src/vs/sessions/electron-browser/actions/vscodeActions.ts
+++ b/src/vs/sessions/electron-browser/actions/vscodeActions.ts
@@ -62,7 +62,11 @@ export class OpenSessionInVSCodeAction extends Action2 {
 		if (!folderUri) {
 			return nativeHostService.openWindow();
 		}
-		return nativeHostService.openWindow([{ folderUri }], { forceNewWindow: true });
+
+		// Hand off the active session so the opened window restores both the
+		// folder and the session, instead of just opening the folder.
+		const chatSessionToOpen = sessionsService.activeSession.get()?.resource;
+		return nativeHostService.openWindow([{ folderUri }], { forceNewWindow: true, chatSessionToOpen });
 	}
 
 	private getFolderUriToOpen(sessionsService: ISessionsService, sessionsProvidersService: ISessionsProvidersService, remoteAgentHostService: IRemoteAgentHostService): URI | undefined {

--- a/src/vs/sessions/electron-browser/actions/vscodeActions.ts
+++ b/src/vs/sessions/electron-browser/actions/vscodeActions.ts
@@ -63,8 +63,7 @@ export class OpenSessionInVSCodeAction extends Action2 {
 			return nativeHostService.openWindow();
 		}
 
-		// Hand off the active session so the opened window restores both the
-		// folder and the session, instead of just opening the folder.
+		// Hand off the active session so the opened window restores it too, not just the folder.
 		const chatSessionToOpen = sessionsService.activeSession.get()?.resource;
 		return nativeHostService.openWindow([{ folderUri }], { forceNewWindow: true, chatSessionToOpen });
 	}


### PR DESCRIPTION
## What

The **Open in VS Code** action in the Agents window now opens the active session in Chat in the newly opened window, in addition to opening its workspace folder.

## Why

Fixes #323200. Previously the desktop action only opened the session's workspace folder. The user then had to manually open Chat and click into the session. The web variant of the action already forwarded the session (via the `session=` query param on the `vscode://` protocol URL, handled by the `vscode:openChatSession` IPC), but the desktop action went through `nativeHostService.openWindow(...)` and had no equivalent handoff.

## How

- Added an optional `chatSessionToOpen?: URI` to `IOpenWindowOptions` (`platform/window/common/window.ts`).
- In `NativeHostMainService.doOpenWindow`, capture the opened window and, when `chatSessionToOpen` is set, send `vscode:openChatSession` with `sendWhenReady`, reusing the existing handler (`ChatCommandLineHandler`) that calls `chatWidgetService.openSession(...)`.
- `OpenSessionInVSCodeAction` (Agents window, electron-browser) now passes the active session's `resource` as `chatSessionToOpen`.

This mirrors the existing protocol-URL handoff used by the web action and the `openAgentsWindow` flow, so the opened window restores both the folder and the session.

## Notes for reviewers

- No new IPC channel is introduced; this reuses the existing `vscode:openChatSession` handler.
- Typecheck (`typecheck-client`) and ESLint on the changed files both pass.
