### PR TITLE
Update Copilot agent host descriptions

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -520,7 +520,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		return {
 			provider: 'copilotcli',
 			displayName: 'Copilot',
-			description: 'Copilot SDK agent running in a dedicated process',
+			description: 'Copilot SDK agent running in the local agent host process',
 		};
 	}
 

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -574,7 +574,7 @@ suite('CopilotAgent', () => {
 			assert.deepStrictEqual(agent.getDescriptor(), {
 				provider: 'copilotcli',
 				displayName: 'Copilot',
-				description: 'Copilot SDK agent running in a dedicated process',
+				description: 'Copilot SDK agent running in the local agent host process',
 			});
 		} finally {
 			await disposeAgent(agent);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
@@ -190,7 +190,7 @@ export function getAgentSessionProviderDescription(provider: AgentSessionTarget)
 		case AgentSessionProviders.Growth:
 			return localize('chat.session.providerDescription.growth', "Learn about Copilot features.");
 		case AgentSessionProviders.AgentHostCopilot:
-			return 'Run a Copilot SDK agent in a dedicated process.';
+			return 'Run a Copilot SDK agent in the local agent host process.';
 		default:
 			return '';
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -708,7 +708,7 @@ function createContribution(disposables: DisposableStore, opts?: { authServiceOv
 		agentId: 'agent-host-copilot',
 		sessionType: 'agent-host-copilot',
 		fullName: 'Agent Host - Copilot',
-		description: 'Copilot SDK agent running in a dedicated process',
+		description: 'Copilot SDK agent running in the local agent host process',
 		connection: agentHostService,
 		connectionAuthority: 'local',
 		isNewSession: sessionResource => listController.isNewSession(sessionResource),


### PR DESCRIPTION
Update both Copilot SDK agent descriptions to clarify that they run in the local agent host process.

Update the matching descriptor test expectations.

Tests: VS Code - Build; focused CopilotAgent and AgentHostChatContribution tests (285 passed).

(Written by Copilot)