### PR TITLE
Disable GitHub Copilot utility models by default for BYOK models

### DIFF
--- a/extensions/copilot/src/extension/chatInputNotification/vscode-node/byokUtilityModel.contribution.ts
+++ b/extensions/copilot/src/extension/chatInputNotification/vscode-node/byokUtilityModel.contribution.ts
@@ -16,9 +16,8 @@ const UTILITY_SMALL_MODEL_SETTING = 'chat.utilitySmallModel';
 /**
  * Shows a chat input notification in air-gapped BYOK scenarios (no GitHub
  * session) when at least one BYOK model is available but the utility model
- * settings are still defaults. The default utility models require GitHub
- * Copilot access, so without it the utility slots silently fall back and
- * degrade the experience until the user points them at a BYOK model.
+ * settings are still defaults. Some utility flows are unavailable until the
+ * user points them at a BYOK model.
  *
  * The notification hides automatically once the user signs in, BYOK models
  * disappear, or both utility settings are configured.

--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -17,7 +17,7 @@ import { CustomDataPartMimeTypes } from '../../../platform/endpoint/common/endpo
 import { encodeStatefulMarker } from '../../../platform/endpoint/common/statefulMarkerContainer';
 import { AutoChatEndpoint } from '../../../platform/endpoint/node/autoChatEndpoint';
 import { IAutomodeService } from '../../../platform/endpoint/node/automodeService';
-import { CopilotChatEndpoint, CopilotUtilitySmallChatEndpoint } from '../../../platform/endpoint/node/copilotChatEndpoint';
+import { CopilotChatEndpoint } from '../../../platform/endpoint/node/copilotChatEndpoint';
 import { IEnvService, isScenarioAutomation } from '../../../platform/env/common/envService';
 import { IVSCodeExtensionContext } from '../../../platform/extContext/common/extensionContext';
 import { IOctoKitService } from '../../../platform/github/common/githubService';
@@ -32,6 +32,7 @@ import { ITelemetryService } from '../../../platform/telemetry/common/telemetry'
 import { isEncryptedThinkingDelta } from '../../../platform/thinking/common/thinking';
 import { BaseTokensPerCompletion } from '../../../platform/tokenizer/node/tokenizer';
 import { TelemetryCorrelationId } from '../../../util/common/telemetryCorrelationId';
+import { CancellationTokenSource } from '../../../util/vs/base/common/cancellation';
 import { Emitter } from '../../../util/vs/base/common/event';
 import { Disposable, MutableDisposable } from '../../../util/vs/base/common/lifecycle';
 import { isBoolean, isDefined, isNumber, isString, isStringArray } from '../../../util/vs/base/common/types';
@@ -142,23 +143,6 @@ function buildConfigurationSchema(endpoint: IChatEndpoint): { configurationSchem
 const utilityAliasFamilies: readonly ChatEndpointFamily[] = ['copilot-utility-small', 'copilot-utility'];
 
 /**
- * Checks whether `endpoint` is the built-in Copilot endpoint for a utility alias.
- */
-function isDefaultEndpointForUtilityFamily(family: ChatEndpointFamily, endpoint: IChatEndpoint): boolean {
-	if (!(endpoint instanceof CopilotChatEndpoint)) {
-		return false;
-	}
-	switch (family) {
-		case 'copilot-utility-small':
-			return endpoint.family === CopilotUtilitySmallChatEndpoint.capiFamily;
-		case 'copilot-utility':
-			return endpoint.isFallback;
-		default:
-			return false;
-	}
-}
-
-/**
  * Builds the {@link vscode.LanguageModelChatInformation} entry that publishes a
  * utility-family alias (e.g. `copilot-utility-small`) under the copilot vendor.
  *
@@ -229,6 +213,7 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 	private _utilityAliasEndpoints: Map<string, IChatEndpoint> = new Map();
 	// Overrides resolved outside model-info publication, reused on the next alias publish.
 	private readonly _resolvedUtilityEndpoints = new Map<ChatEndpointFamily, { endpoint: IChatEndpoint; baseCount: number }>();
+	private readonly _utilityOverridesRefresh = this._register(new MutableDisposable<CancellationTokenSource>());
 	private _lmWrapper: CopilotLanguageModelWrapper;
 	private _promptBaseCountCache: LanguageModelAccessPromptBaseCountCache;
 
@@ -260,6 +245,7 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 	}
 
 	override dispose(): void {
+		this._utilityOverridesRefresh.value?.cancel();
 		super.dispose();
 	}
 
@@ -283,7 +269,7 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 			this._onDidChange.fire();
 		}));
 		this._register(this._endpointProvider.onDidModelsRefresh(() => {
-			// Drop stale overrides; model publication uses defaults until refresh completes.
+			// Drop stale resolutions; aliases are re-published once the refresh re-resolves them.
 			this._resolvedUtilityEndpoints.clear();
 			void this._refreshUtilityOverrides();
 			this._onDidChange.fire();
@@ -414,14 +400,18 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 		this._currentModels = models;
 		this._chatEndpoints = chatEndpoints;
 
-		this._registerUtilityAliasModels(models, allEndpoints);
+		this._registerUtilityAliasModels(models);
 		return models;
 	}
 
-	/** Publishes utility aliases without waiting for override resolution. */
+	/**
+	 * Publishes utility aliases from the resolved-endpoint cache. The cache is
+	 * populated asynchronously by {@link _refreshUtilityOverrides} (the single
+	 * gate that decides, per the BYOK/override policy, whether a family resolves
+	 * to a model at all), so a family with no cached endpoint publishes nothing.
+	 */
 	private _registerUtilityAliasModels(
 		models: vscode.LanguageModelChatInformation[],
-		allEndpoints: readonly IChatEndpoint[],
 	): void {
 		this._utilityAliasEndpoints.clear();
 		const session = this._authenticationService.anyGitHubSession;
@@ -429,15 +419,15 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 
 		for (const family of utilityAliasFamilies) {
 			const cached = this._resolvedUtilityEndpoints.get(family);
-			const endpoint = cached?.endpoint ?? allEndpoints.find(e => isDefaultEndpointForUtilityFamily(family, e));
-			if (!endpoint) {
+			if (!cached) {
 				continue;
 			}
+			const endpoint = cached.endpoint;
 			this._utilityAliasEndpoints.set(family, endpoint);
 
 			try {
 				// Copilot defaults clone an existing entry; synthesized override aliases need baseCount.
-				const aliasInfo = buildUtilityAliasModelInfo(family, endpoint, models, cached?.baseCount ?? 0, requiresAuthorization);
+				const aliasInfo = buildUtilityAliasModelInfo(family, endpoint, models, cached.baseCount, requiresAuthorization);
 				this._logService.trace(`[LanguageModelAccess] Publishing alias '${family}' -> ${endpoint.model} (${aliasInfo.synthesized ? 'synthesized' : 'cloned'}, ${endpoint instanceof CopilotChatEndpoint ? 'copilot' : 'override'}).`);
 				models.push(aliasInfo.info);
 			} catch (err) {
@@ -445,22 +435,43 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 			}
 		}
 
-		// Override resolution may hang, so keep it off the model-info request path.
+		// Resolution may hang (override lookups, base-count tokenization), so keep it off
+		// the model-info request path. Newly resolved endpoints are published on the next
+		// request once `_refreshUtilityOverrides` fires `_onDidChange`.
 		void this._refreshUtilityOverrides().catch(err => {
 			this._logService.warn(`[LanguageModelAccess] Failed to refresh utility overrides: ${err}`);
 		});
 	}
 
-	/** Resolves configured utility model overrides for the next alias publish. */
+	/**
+	 * Resolves each utility family through {@link IEndpointProvider.getChatEndpoint},
+	 * which applies the BYOK/override policy (returning the configured override, the
+	 * built-in Copilot model, or throwing when no model should be used). Successful
+	 * resolutions are cached for {@link _registerUtilityAliasModels} to publish.
+	 */
 	private async _refreshUtilityOverrides(): Promise<void> {
+		this._utilityOverridesRefresh.value?.cancel();
+		const cancellationSource = new CancellationTokenSource();
+		this._utilityOverridesRefresh.value = cancellationSource;
+		const token = cancellationSource.token;
 		let didChange = false;
 		for (const family of utilityAliasFamilies) {
 			let resolved: IChatEndpoint | undefined;
 			try {
 				resolved = await this._endpointProvider.getChatEndpoint(family);
 			} catch (err) {
-				this._logService.warn(`[LanguageModelAccess] Failed to resolve utility alias '${family}' in background: ${err}`);
+				if (token.isCancellationRequested) {
+					return;
+				}
+				// Expected when the policy declines a family (e.g. BYOK main model with no
+				// configured utility model), so this is not necessarily a failure. The cache
+				// is cleared on policy changes via `onDidModelsRefresh`, so leaving any prior
+				// entry intact here only preserves a still-valid alias across transient errors.
+				this._logService.trace(`[LanguageModelAccess] No utility alias resolved for '${family}' in background: ${err}`);
 				continue;
+			}
+			if (token.isCancellationRequested) {
+				return;
 			}
 			if (!resolved) {
 				continue;
@@ -475,8 +486,14 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 			try {
 				baseCount = await this._promptBaseCountCache.getBaseCount(resolved);
 			} catch (err) {
+				if (token.isCancellationRequested) {
+					return;
+				}
 				this._logService.warn(`[LanguageModelAccess] Failed to compute baseCount for utility alias '${family}' -> ${resolved.model}; keeping previously-published alias. Error: ${err}`);
 				continue;
+			}
+			if (token.isCancellationRequested) {
+				return;
 			}
 			this._resolvedUtilityEndpoints.set(family, { endpoint: resolved, baseCount });
 			didChange = true;

--- a/extensions/copilot/src/extension/conversation/vscode-node/test/languageModelAccess.test.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/test/languageModelAccess.test.ts
@@ -248,6 +248,89 @@ suite('LanguageModelAccess model info', () => {
 			languageModelAccess.dispose();
 		}
 	});
+
+	test('does not publish utility aliases when the provider declines to resolve them (BYOK)', async () => {
+		const testingServiceCollection = createExtensionTestingServices();
+		testingServiceCollection.define(IEndpointProvider, {
+			_serviceBrand: undefined,
+			onDidModelsRefresh: Event.None,
+			getAllCompletionModels: async () => [],
+			getAllChatEndpoints: async () => [],
+			getChatEndpoint: async () => { throw new Error('No utility model is configured while the selected main model is BYOK.'); },
+			getEmbeddingsEndpoint: async () => { throw new Error('Not implemented in test'); },
+		} as unknown as IEndpointProvider);
+		const accessor = testingServiceCollection.createTestingAccessor();
+		const languageModelAccess = accessor.get(IInstantiationService).createInstance(LanguageModelAccess);
+		const internals = languageModelAccess as unknown as {
+			_resolvedUtilityEndpoints: Map<string, { endpoint: IChatEndpoint; baseCount: number }>;
+			_promptBaseCountCache: { getBaseCount(endpoint: IChatEndpoint): Promise<number> };
+			_registerUtilityAliasModels(models: vscode.LanguageModelChatInformation[]): void;
+			_refreshUtilityOverrides(): Promise<void>;
+		};
+		internals._promptBaseCountCache = { getBaseCount: async () => 0 };
+
+		try {
+			// The provider gates every utility family, so nothing is resolved or cached.
+			await internals._refreshUtilityOverrides();
+			assert.strictEqual(internals._resolvedUtilityEndpoints.size, 0);
+
+			// With an empty cache, no aliases are published into the model list.
+			const models: vscode.LanguageModelChatInformation[] = [];
+			internals._registerUtilityAliasModels(models);
+			assert.deepStrictEqual(models.map(model => model.id), []);
+		} finally {
+			languageModelAccess.dispose();
+		}
+	});
+
+	test('does not cache a utility endpoint from an obsolete refresh', async () => {
+		const endpoint = {
+			model: 'gpt-4o-mini',
+			modelProvider: 'copilot',
+		} as IChatEndpoint;
+		const baseCount = new DeferredPromise<number>();
+		const baseCountStarted = new DeferredPromise<void>();
+		let endpointRequestCount = 0;
+		const testingServiceCollection = createExtensionTestingServices();
+		testingServiceCollection.define(IEndpointProvider, {
+			_serviceBrand: undefined,
+			onDidModelsRefresh: Event.None,
+			getAllCompletionModels: async () => [],
+			getAllChatEndpoints: async () => [],
+			getChatEndpoint: async () => {
+				if (endpointRequestCount++ === 0) {
+					return endpoint;
+				}
+				throw new Error('No utility model configured');
+			},
+			getEmbeddingsEndpoint: async () => { throw new Error('Not implemented in test'); },
+		} as unknown as IEndpointProvider);
+		const accessor = testingServiceCollection.createTestingAccessor();
+		const languageModelAccess = accessor.get(IInstantiationService).createInstance(LanguageModelAccess);
+		const internals = languageModelAccess as unknown as {
+			_resolvedUtilityEndpoints: Map<string, { endpoint: IChatEndpoint; baseCount: number }>;
+			_promptBaseCountCache: { getBaseCount(endpoint: IChatEndpoint): Promise<number> };
+			_refreshUtilityOverrides(): Promise<void>;
+		};
+		internals._promptBaseCountCache = {
+			getBaseCount: async () => {
+				baseCountStarted.complete();
+				return baseCount.p;
+			}
+		};
+
+		try {
+			const obsoleteRefresh = internals._refreshUtilityOverrides();
+			await baseCountStarted.p;
+			const currentRefresh = internals._refreshUtilityOverrides();
+			baseCount.complete(0);
+			await Promise.all([obsoleteRefresh, currentRefresh]);
+
+			assert.strictEqual(internals._resolvedUtilityEndpoints.size, 0);
+		} finally {
+			languageModelAccess.dispose();
+		}
+	});
 });
 
 suite('buildUtilityAliasModelInfo', () => {
@@ -480,4 +563,3 @@ suite('formatPricingLabel', () => {
 		assert.strictEqual(formatPricingLabel(tier(3, 15)), 'In: 3 · Out: 15 AICs/1M tokens');
 	});
 });
-

--- a/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
+++ b/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
@@ -53,11 +53,14 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 			this._onDidModelsRefresh.fire();
 		}));
 
-		// When the user changes their utility model overrides we need to invalidate any
-		// previously-resolved utility alias endpoints so the next request re-resolves.
+		// Utility model configuration changes invalidate previously resolved aliases.
 		this._register(this._configService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(ProductionEndpointProvider.UTILITY_MODEL_CONFIG_KEY) || e.affectsConfiguration(ProductionEndpointProvider.UTILITY_SMALL_MODEL_CONFIG_KEY)) {
-				this._logService.trace(`[ProductionEndpointProvider] Utility model override changed; invalidating alias endpoints.`);
+			if (
+				e.affectsConfiguration(ProductionEndpointProvider.UTILITY_MODEL_CONFIG_KEY)
+				|| e.affectsConfiguration(ProductionEndpointProvider.UTILITY_SMALL_MODEL_CONFIG_KEY)
+				|| e.affectsConfiguration(ProductionEndpointProvider.USE_COPILOT_MODELS_FOR_UTILITY_MODELS_CONFIG_KEY)
+			) {
+				this._logService.trace(`[ProductionEndpointProvider] Utility model configuration changed; invalidating alias endpoints.`);
 				// Clear telemetry fingerprints so a re-applied override emits
 				// once for its new value.
 				this._lastOverrideTelemetryFingerprint.clear();
@@ -76,6 +79,8 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 	// `vscode.lm.selectChatModels({ vendor, id })`.
 	private static readonly UTILITY_MODEL_CONFIG_KEY = 'chat.utilityModel';
 	private static readonly UTILITY_SMALL_MODEL_CONFIG_KEY = 'chat.utilitySmallModel';
+	private static readonly USE_COPILOT_MODELS_FOR_UTILITY_MODELS_CONFIG_KEY = 'chat.useCopilotModelsForUtilityModels';
+	private _mainModelIsBYOK = false;
 
 	/**
 	 * Per-family marker recording that we already emitted a telemetry event
@@ -106,6 +111,15 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 
 		if (!model) {
 			return this.getChatEndpoint('copilot-utility');
+		}
+
+		if (model.id !== 'copilot-utility' && model.id !== 'copilot-utility-small') {
+			const mainModelIsBYOK = model.vendor !== 'copilot';
+			if (this._mainModelIsBYOK !== mainModelIsBYOK) {
+				this._mainModelIsBYOK = mainModelIsBYOK;
+				this._lastOverrideTelemetryFingerprint.clear();
+				this._onDidModelsRefresh.fire();
+			}
 		}
 
 		if (model.vendor !== 'copilot') {
@@ -156,22 +170,34 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 	 * `copilot-utility`) to a concrete `CopilotChatEndpoint`. The model
 	 * selection for each family lives in the corresponding resolver
 	 * class so callers don't need to know which CAPI family backs each
-	 * purpose. For any other string, falls through to a direct CAPI
-	 * family lookup so callers can resolve arbitrary CAPI-registered
-	 * model families (e.g. `trajectory-compaction`) by name.
+	 * purpose.
 	 */
-	private async _resolveUtilityFamily(family: ChatEndpointFamily): Promise<IChatEndpoint> {
+	private async _resolveUtilityFamily(family: 'copilot-utility' | 'copilot-utility-small'): Promise<IChatEndpoint> {
 		const override = await this._resolveUtilityOverride(family);
 		if (override) {
 			return override;
 		}
-		if (family === 'copilot-utility-small') {
-			return CopilotUtilitySmallChatEndpoint.resolve(this._modelFetcher, this._instantiationService);
-		} else if (family === 'copilot-utility') {
-			return CopilotUtilityChatEndpoint.resolve(this._modelFetcher, this._instantiationService);
+
+		if (!this._useCopilotModelsForUtilityModelsByDefault()) {
+			throw new Error(`No utility model is configured for '${family}' while the selected main model is BYOK.`);
 		}
-		const modelMetadata = await this._modelFetcher.getChatModelFromCapiFamily(family);
-		return this.getOrCreateChatEndpointInstance(modelMetadata);
+
+		switch (family) {
+			case 'copilot-utility-small':
+				return CopilotUtilitySmallChatEndpoint.resolve(this._modelFetcher, this._instantiationService);
+			case 'copilot-utility':
+				return CopilotUtilityChatEndpoint.resolve(this._modelFetcher, this._instantiationService);
+		}
+	}
+
+	/**
+	 * Whether an unset utility model should resolve to a built-in GitHub Copilot
+	 * model. `true` when the selected main model is itself a Copilot model, or
+	 * when the user opted in via {@link USE_COPILOT_MODELS_FOR_UTILITY_MODELS_CONFIG_KEY}.
+	 */
+	private _useCopilotModelsForUtilityModelsByDefault(): boolean {
+		return !this._mainModelIsBYOK
+			|| this._configService.getNonExtensionConfig<unknown>(ProductionEndpointProvider.USE_COPILOT_MODELS_FOR_UTILITY_MODELS_CONFIG_KEY) === true;
 	}
 
 	/**

--- a/extensions/copilot/src/extension/test/vscode-node/endpoints.test.ts
+++ b/extensions/copilot/src/extension/test/vscode-node/endpoints.test.ts
@@ -196,6 +196,39 @@ suite('ProductionEndpointProvider — utility model overrides', () => {
 		assert.strictEqual(endpoint.model, 'copilot-utility');
 	});
 
+	test('no override configured — does not use a Copilot utility model when the selected main model is BYOK', async () => {
+		setFetcher([makeChatModel('copilot-utility')]);
+		await endpointProvider.getChatEndpoint(makeFakeLanguageModelChat({ vendor: 'anthropic' }));
+
+		await assert.rejects(
+			() => endpointProvider.getChatEndpoint('copilot-utility'),
+			/No utility model is configured/
+		);
+	});
+
+	test('Copilot utility model opt-in applies when the selected main model is BYOK', async () => {
+		setFetcher([makeChatModel('copilot-utility')]);
+		await endpointProvider.getChatEndpoint(makeFakeLanguageModelChat({ vendor: 'anthropic' }));
+		await configService.setNonExtensionConfig('chat.useCopilotModelsForUtilityModels', true);
+
+		const endpoint = await endpointProvider.getChatEndpoint('copilot-utility');
+
+		assert.strictEqual(endpoint.model, 'copilot-utility');
+	});
+
+	test('explicit utility override applies when the selected main model is BYOK', async () => {
+		setFetcher([makeChatModel('copilot-utility')]);
+		await endpointProvider.getChatEndpoint(makeFakeLanguageModelChat({ vendor: 'anthropic' }));
+		const fakeModel = makeFakeLanguageModelChat({ vendor: 'anthropic', id: 'claude-haiku-4.5' });
+		sandbox.stub(lm, 'selectChatModels').resolves([fakeModel]);
+		await configService.setNonExtensionConfig('chat.utilityModel', 'anthropic/claude-haiku-4.5');
+
+		const endpoint = await endpointProvider.getChatEndpoint('copilot-utility');
+
+		assert.ok(endpoint instanceof ExtensionContributedChatEndpoint);
+		assert.strictEqual(endpoint.model, 'claude-haiku-4.5');
+	});
+
 	test('copilot-vendor override resolves to the matching model from the model fetcher', async () => {
 		setFetcher([makeChatModel('copilot-utility'), makeChatModel('gpt-4o-mini')]);
 		await configService.setNonExtensionConfig('chat.utilityModel', 'copilot/gpt-4o-mini');
@@ -250,7 +283,8 @@ suite('ProductionEndpointProvider — utility model overrides', () => {
 		try {
 			await configService.setNonExtensionConfig('chat.utilityModel', 'copilot/gpt-4o-mini');
 			await configService.setNonExtensionConfig('chat.utilitySmallModel', 'copilot/gpt-4o-mini');
-			assert.strictEqual(refreshCount, 2);
+			await configService.setNonExtensionConfig('chat.useCopilotModelsForUtilityModels', true);
+			assert.strictEqual(refreshCount, 3);
 		} finally {
 			sub.dispose();
 		}

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -1296,9 +1296,14 @@ configurationRegistry.registerConfiguration({
 			enumItemLabels: ExploreAgentDefaultModel.modelLabels,
 			markdownEnumDescriptions: ExploreAgentDefaultModel.modelDescriptions
 		},
+		[ChatConfiguration.UseCopilotModelsForUtilityModels]: {
+			type: 'boolean',
+			markdownDescription: nls.localize('chat.useCopilotModelsForUtilityModels.description', "Use default GitHub Copilot models for built-in utility flows when the main chat model is a bring your own key (BYOK) model. Utility flows power background features such as generating chat titles and summaries. This setting does not apply when a specific model is configured in {0} or {1}.", '`#chat.utilityModel#`', '`#chat.utilitySmallModel#`'),
+			default: false,
+		},
 		[ChatConfiguration.UtilityModel]: {
 			type: 'string',
-			description: nls.localize('chat.utilityModel.description', "Override the language model used by built-in utility flows. Leave empty to use the default model."),
+			description: nls.localize('chat.utilityModel.description', "Override the language model used by built-in utility flows. Leave empty to use the default model when the main chat model is provided by GitHub Copilot."),
 			default: '',
 			enum: UtilityModelContribution.modelIds,
 			enumItemLabels: UtilityModelContribution.modelLabels,
@@ -1306,7 +1311,7 @@ configurationRegistry.registerConfiguration({
 		},
 		[ChatConfiguration.UtilitySmallModel]: {
 			type: 'string',
-			description: nls.localize('chat.utilitySmallModel.description', "Override the language model used by built-in small/fast utility flows. A fast and inexpensive model is recommended. Leave empty to use the default model."),
+			description: nls.localize('chat.utilitySmallModel.description', "Override the language model used by built-in small/fast utility flows. A fast and inexpensive model is recommended. Leave empty to use the default model when the main chat model is provided by GitHub Copilot."),
 			default: '',
 			enum: UtilitySmallModelContribution.modelIds,
 			enumItemLabels: UtilitySmallModelContribution.modelLabels,

--- a/src/vs/workbench/contrib/chat/browser/utilityModelContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/utilityModelContribution.ts
@@ -10,12 +10,10 @@ import { ChatConfiguration } from '../common/constants.js';
 import { COPILOT_VENDOR_ID, ILanguageModelsService } from '../common/languageModels.js';
 import { createDefaultModelArrays, DefaultModelContribution } from './defaultModelContribution.js';
 
-// The empty value for these settings means "use the built-in utility-family
-// default" (i.e. whatever the copilot-utility / copilot-utility-small family
-// resolves to via CAPI), not a vendor-specific default. Use setting-specific
-// copy so the Settings UI doesn't say "Auto (Vendor Default)".
+// The empty value uses the default utility behavior: a built-in model for a
+// Copilot main model, or no model for BYOK unless the user opts in.
 const defaultEntryLabel = localize('chat.utilityModel.defaultEntry.label', 'Default');
-const defaultEntryDescription = localize('chat.utilityModel.defaultEntry.description', "Use the built-in default utility model");
+const defaultEntryDescription = localize('chat.utilityModel.defaultEntry.description', "Use the default behavior for utility models");
 
 const utilityArrays = createDefaultModelArrays(defaultEntryLabel, defaultEntryDescription);
 const utilitySmallArrays = createDefaultModelArrays(defaultEntryLabel, defaultEntryDescription);

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -27,6 +27,7 @@ export enum ChatConfiguration {
 	ExploreAgentDefaultModel = 'chat.exploreAgent.defaultModel',
 	UtilityModel = 'chat.utilityModel',
 	UtilitySmallModel = 'chat.utilitySmallModel',
+	UseCopilotModelsForUtilityModels = 'chat.useCopilotModelsForUtilityModels',
 	RequestQueueingDefaultAction = 'chat.requestQueuing.defaultAction',
 	AgentStatusEnabled = 'chat.agentsControl.enabled',
 	EditorAssociations = 'chat.editorAssociations',


### PR DESCRIPTION
When you pick a bring-your-own-key (BYOK) chat model, built-in "utility" flows (chat titles, summaries, and other small background calls) used to quietly fall back to GitHub Copilot's models — even without Copilot access. This PR stops that.

Now, when your main model is BYOK:

Utility flows no longer default to Copilot models.
Set chat.utilityModel / chat.utilitySmallModel to use your own model, or
Flip on the new chat.useCopilotModelsForUtilityModels setting to keep the old behavior.
Copilot main models are unaffected.