### PR TITLE
codex: disable hosted image_generation tool to fix CAPI 400

### DIFF
--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -924,8 +924,8 @@ export class CodexAgent extends Disposable implements IAgent {
 			// elicitation handler is reserved for genuine server-to-user
 			// elicitations.
 			`features.tool_call_mcp_elicitation=false`,
+			// CAPI rejects the hosted `image_generation` tool; disable it so codex does not emit it.
 			`features.image_generation=false`,
-		];
 
 		// Extra args forwarded as JSON from the workbench setting.
 		const extraArgs = parseBinaryArgs(process.env[AgentHostCodexAgentBinaryArgsEnvVar]);

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -924,6 +924,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			// elicitation handler is reserved for genuine server-to-user
 			// elicitations.
 			`features.tool_call_mcp_elicitation=false`,
+			`features.image_generation=false`,
 		];
 
 		// Extra args forwarded as JSON from the workbench setting.

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -926,6 +926,7 @@ export class CodexAgent extends Disposable implements IAgent {
 			`features.tool_call_mcp_elicitation=false`,
 			// CAPI rejects the hosted `image_generation` tool; disable it so codex does not emit it.
 			`features.image_generation=false`,
+		];
 
 		// Extra args forwarded as JSON from the workbench setting.
 		const extraArgs = parseBinaryArgs(process.env[AgentHostCodexAgentBinaryArgsEnvVar]);


### PR DESCRIPTION
### Problem

Using the Codex harness in the Agents window (Code OSS from sources) can fail a turn with:

> The requested tool `image_generation` is not supported.

The Copilot CAPI returns `400 unsupported_value` (`param: tools`) because the request carries the hosted `image_generation` tool, which CAPI cannot serve.

### Root cause

The bundled `@openai/codex` (0.142.0) app-server includes the hosted `image_generation` tool in its `/responses` request when **all** of these hold:

1. `current_auth_uses_codex_backend()` — codex's login uses a codex backend
2. the provider capability `image_generation` is on
3. the model has the `Image` input modality
4. the `image_generation` feature is enabled

In our `vscode-proxy` setup, (2), (3) and (4) are effectively constant (capability is a hardcoded trait default, the codex models advertise `Image`, and the feature is Stable/default-on). **The only condition that varies is (1)** — and it is read from the developer's **own `~/.codex/auth.json`**, independent of VS Code:

- API-key / no login (`auth_mode: "apikey"`) → tool **not** emitted → request succeeds.
- ChatGPT / agent-identity / PAT login → tool emitted → CAPI **400**.

This is why the failure is non-deterministic across machines even with the same model, VS Code build, and spawn args. VS Code sets `OPENAI_API_KEY=<proxy nonce>` (the provider's wire key), not `CODEX_API_KEY`, so codex's gating falls back to the on-disk login state. (`account/read accountType=none` in the logs is unrelated — that's the proxy provider's account, not the auth state used for gating.)

`CodexProxyService` forwards the request body verbatim to CAPI with no hosted-tool filtering, so the `image_generation` tool reaches CAPI and triggers the 400.

### Fix

Disable the codex `image_generation` feature at spawn time so codex never emits the hosted tool, deterministically for every developer regardless of their local codex login:

```
-c features.image_generation=false
```

