### PR TITLE
Agent Host: Use SDK shell exit metadata for command decorations

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/common/copilotCLITools.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/common/copilotCLITools.ts
@@ -1264,6 +1264,9 @@ function formatSearchToolInvocationCompleted(invocation: ChatToolInvocationPart,
 		}
 		const searchInPath = toolCall.arguments.path ? ` in \`${toolCall.arguments.path}\`` : '';
 		let files: string[] = [];
+		// TODO: Revisit this legacy SDK terminal content usage. SDK `terminal`
+		// content is deprecated for shell command exit metadata; this search
+		// result parsing should not rely on it long term.
 		if (Array.isArray(result.result?.contents) && result.result.contents.length > 0 && result.result.contents[0].type === 'terminal' && typeof result.result.contents[0].text === 'string') {
 			const matches = result.result.contents[0].text.trim();
 			const noMatches = matches.length === 0;

--- a/src/vs/platform/agentHost/common/state/protocol/channels-chat/state.ts
+++ b/src/vs/platform/agentHost/common/state/protocol/channels-chat/state.ts
@@ -1156,6 +1156,7 @@ export const enum ToolResultContentType {
 	Resource = 'resource',
 	FileEdit = 'fileEdit',
 	Terminal = 'terminal',
+	ShellExit = 'shell_exit',
 	Subagent = 'subagent',
 }
 
@@ -1224,6 +1225,25 @@ export interface ToolResultTerminalContent {
 }
 
 /**
+ * Shell command exit metadata emitted by the Copilot SDK shell tool.
+ *
+ * @category Tool Result Content
+ */
+export interface ToolResultShellExitContent {
+	type: ToolResultContentType.ShellExit;
+	/** Shell id, as assigned by Copilot runtime */
+	shellId: string;
+	/** Exit code from the completed shell command */
+	exitCode: number;
+	/** Working directory where the shell command was executed */
+	cwd?: string;
+	/** Output preview associated with the shell command, if available */
+	outputPreview?: string;
+	/** Whether outputPreview is known to be incomplete or truncated */
+	outputTruncated?: boolean;
+}
+
+/**
  * A reference, embedded in a tool result, to a worker chat spawned by the tool
  * call (a sub-agent delegation), referenced by a chat URI (`ahp-chat:/...`).
  *
@@ -1251,7 +1271,8 @@ export interface ToolResultSubagentContent {
  * Mirrors the content blocks in MCP `CallToolResult.content`, plus
  * `ToolResultResourceContent` for lazy-loading large results,
  * `ToolResultFileEditContent` for file edit diffs,
- * `ToolResultTerminalContent` for live terminal output, and
+ * `ToolResultTerminalContent` for live terminal output,
+ * `ToolResultShellExitContent` for shell command exit metadata, and
  * `ToolResultSubagentContent` for tool-spawned worker chats (AHP extensions).
  *
  * @category Tool Result Content
@@ -1262,4 +1283,5 @@ export type ToolResultContent =
 	| ToolResultResourceContent
 	| ToolResultFileEditContent
 	| ToolResultTerminalContent
+	| ToolResultShellExitContent
 	| ToolResultSubagentContent;

--- a/src/vs/platform/agentHost/common/state/sessionState.ts
+++ b/src/vs/platform/agentHost/common/state/sessionState.ts
@@ -84,6 +84,7 @@ export {
 	type ToolCallContributor,
 	type ToolDefinition, type ToolResultContent,
 	type ToolResultFileEditContent,
+	type ToolResultShellExitContent,
 	type ToolResultSubagentContent,
 	type ToolResultTextContent,
 	type Turn, type URI, type UsageInfo,

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -52,7 +52,7 @@ import { getEditFilePaths, getInvocationMessage, getPastTenseMessage, getPermiss
 import { FileEditTracker } from '../shared/fileEditTracker.js';
 import { stripProxyErrorMarker, tryBuildChatErrorMeta, tryBuildChatErrorMetaFromFields } from '../shared/forwardedChatError.js';
 import { McpCustomizationController, type ISdkMcpServer } from '../shared/mcpCustomizationController.js';
-import { mapSessionEvents } from './mapSessionEvents.js';
+import { appendSdkToolResultContent, mapSessionEvents } from './mapSessionEvents.js';
 import { buildPendingEditContentUri } from './pendingEditContentStore.js';
 import { McpServerStatus, type McpServerState } from '../../common/state/protocol/channels-session/state.js';
 
@@ -2622,6 +2622,7 @@ export class CopilotAgentSession extends Disposable {
 			if (toolOutput !== undefined) {
 				content.push({ type: ToolResultContentType.Text, text: toolOutput });
 			}
+			appendSdkToolResultContent(content, e.data.result?.contents);
 
 			const command = isString(tracked.parameters?.command) ? tracked.parameters.command : undefined;
 			const filePaths = isEditTool(tracked.toolName, command) ? this._getEditFilePaths(tracked.parameters) : [];

--- a/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
+++ b/src/vs/platform/agentHost/node/copilot/mapSessionEvents.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { AssistantMessageToolRequest, Attachment, SessionEvent, ToolExecutionCompleteData } from '@github/copilot-sdk';
+import type { AssistantMessageToolRequest, Attachment, SessionEvent, ToolExecutionCompleteContent, ToolExecutionCompleteData } from '@github/copilot-sdk';
 import { decodeBase64 } from '../../../../base/common/buffer.js';
 import { basename } from '../../../../base/common/path.js';
 import { isString } from '../../../../base/common/types.js';
@@ -40,6 +40,23 @@ function isSyntheticUserMessage(event: SessionEvent): boolean {
 	}
 	const source = event.data.source;
 	return !!source && source.toLowerCase() !== 'user';
+}
+
+export function appendSdkToolResultContent(content: ToolResultContent[], sdkContents: readonly ToolExecutionCompleteContent[] | undefined): void {
+	for (const sdkContent of sdkContents ?? []) {
+		switch (sdkContent.type) {
+			case 'shell_exit':
+				content.push({
+					type: ToolResultContentType.ShellExit,
+					shellId: sdkContent.shellId,
+					exitCode: sdkContent.exitCode,
+					...(sdkContent.cwd !== undefined ? { cwd: sdkContent.cwd } : {}),
+					...(sdkContent.outputPreview !== undefined ? { outputPreview: sdkContent.outputPreview } : {}),
+					...(sdkContent.outputTruncated !== undefined ? { outputTruncated: sdkContent.outputTruncated } : {}),
+				});
+				break;
+		}
+	}
 }
 
 // =============================================================================
@@ -619,6 +636,7 @@ function makeCompletedToolCallPart(
 	if (toolOutput !== undefined) {
 		content.push({ type: ToolResultContentType.Text, text: toolOutput });
 	}
+	appendSdkToolResultContent(content, d.result?.contents);
 
 	// Restore file edit content references from the database.
 	const edits = storedEdits?.get(d.toolCallId);

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -2249,6 +2249,37 @@ suite('CopilotAgentSession', () => {
 			}
 		});
 
+		test('live tool_complete preserves SDK shell_exit content', async () => {
+			const { mockSession, signals } = await createAgentSession(disposables);
+
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-shell-exit',
+				toolName: 'bash',
+				arguments: { command: 'gti status' },
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+			mockSession.fire('tool.execution_complete', {
+				toolCallId: 'tc-shell-exit',
+				success: true,
+				result: {
+					content: 'command not found\n',
+					contents: [{ type: 'shell_exit', shellId: '0', exitCode: 127, cwd: '/repo' }],
+				},
+			} as SessionEventPayload<'tool.execution_complete'>['data']);
+
+			assert.strictEqual(signals.length, 3);
+			const completeSignal = signals[2];
+			assert.ok(isAction(completeSignal, ActionType.ChatToolCallComplete));
+			if (isAction(completeSignal, ActionType.ChatToolCallComplete)) {
+				const action = completeSignal.action as ChatToolCallCompleteAction;
+				assert.strictEqual(action.result.success, true);
+				assert.deepStrictEqual(action.result.content, [
+					{ type: ToolResultContentType.Text, text: 'command not found\n' },
+					{ type: ToolResultContentType.ShellExit, shellId: '0', exitCode: 127, cwd: '/repo' },
+				]);
+				assert.ok(!action.result.content?.some(content => content.type === ToolResultContentType.Terminal));
+			}
+		});
+
 		test('live task_complete emits root markdown instead of a tool call', async () => {
 			const { mockSession, signals } = await createAgentSession(disposables);
 

--- a/src/vs/platform/agentHost/test/node/copilotTestEvents.ts
+++ b/src/vs/platform/agentHost/test/node/copilotTestEvents.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { Attachment, SessionEvent } from '@github/copilot-sdk';
+import type { Attachment, SessionEvent, ToolExecutionCompleteContent } from '@github/copilot-sdk';
 
 // =============================================================================
 // Minimal session-event shapes for tests
@@ -37,7 +37,11 @@ export interface ISessionEventToolComplete {
 	data: {
 		toolCallId: string;
 		success: boolean;
-		result?: { content?: string };
+		result?: {
+			/** `content` is result text; `contents` are typed SDK result blocks such as `shell_exit`. */
+			content?: string;
+			contents?: ToolExecutionCompleteContent[];
+		};
 		error?: { message: string; code?: string };
 		isUserRequested?: boolean;
 		toolTelemetry?: unknown;

--- a/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { AgentSession } from '../../common/agentService.js';
-import { MessageAttachmentKind, ResponsePartKind, TurnState, type ResponsePart } from '../../common/state/sessionState.js';
+import { MessageAttachmentKind, ResponsePartKind, ToolCallStatus, ToolResultContentType, TurnState, type ResponsePart, type ToolCallResponsePart } from '../../common/state/sessionState.js';
 import { mapSessionEvents } from '../../node/copilot/mapSessionEvents.js';
 import { toSessionEvents, type ISessionEvent } from './copilotTestEvents.js';
 
@@ -88,6 +88,65 @@ suite('mapSessionEvents — history replay', () => {
 		assert.deepStrictEqual(partKinds(turns[0].responseParts), [
 			{ kind: ResponsePartKind.ToolCall },
 		]);
+	});
+
+	test('preserves SDK shell_exit content on replayed tool completion', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', data: { interactionId: 'm1', content: 'hi' } },
+			{ type: 'assistant.message', data: { messageId: 'm2', content: '', toolRequests: [{ toolCallId: 'tc-1', name: 'bash' }] } },
+			{ type: 'tool.execution_start', data: { toolCallId: 'tc-1', toolName: 'bash', arguments: { command: 'echo hi' } } },
+			{
+				type: 'tool.execution_complete',
+				data: {
+					toolCallId: 'tc-1',
+					success: true,
+					result: {
+						content: 'hi\n',
+						contents: [{ type: 'shell_exit', shellId: '0', exitCode: 0, cwd: '/repo', outputPreview: 'hi\n' }],
+					},
+				},
+			},
+		];
+
+		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+
+		const part = turns[0].responseParts[0] as ToolCallResponsePart;
+		assert.strictEqual(part.kind, ResponsePartKind.ToolCall);
+		assert.strictEqual(part.toolCall.status, ToolCallStatus.Completed);
+		if (part.toolCall.status !== ToolCallStatus.Completed) { return; }
+		assert.deepStrictEqual(part.toolCall.content, [
+			{ type: ToolResultContentType.Text, text: 'hi\n' },
+			{ type: ToolResultContentType.ShellExit, shellId: '0', exitCode: 0, cwd: '/repo', outputPreview: 'hi\n' },
+		]);
+	});
+
+	test('preserves non-zero shell_exit even when SDK tool completion succeeded', async () => {
+		const events: ISessionEvent[] = [
+			{ type: 'user.message', data: { interactionId: 'm1', content: 'hi' } },
+			{ type: 'assistant.message', data: { messageId: 'm2', content: '', toolRequests: [{ toolCallId: 'tc-1', name: 'bash' }] } },
+			{ type: 'tool.execution_start', data: { toolCallId: 'tc-1', toolName: 'bash', arguments: { command: 'gti status' } } },
+			{
+				type: 'tool.execution_complete',
+				data: {
+					toolCallId: 'tc-1',
+					success: true,
+					result: {
+						content: 'command not found\n',
+						contents: [{ type: 'shell_exit', shellId: '0', exitCode: 127, cwd: '/repo' }],
+					},
+				},
+			},
+		];
+
+		const { turns } = await mapSessionEvents(session, undefined, toSessionEvents(events));
+
+		const part = turns[0].responseParts[0] as ToolCallResponsePart;
+		assert.strictEqual(part.kind, ResponsePartKind.ToolCall);
+		assert.strictEqual(part.toolCall.status, ToolCallStatus.Completed);
+		if (part.toolCall.status !== ToolCallStatus.Completed) { return; }
+		assert.strictEqual(part.toolCall.success, true);
+		assert.ok(part.toolCall.content?.some(content => content.type === ToolResultContentType.ShellExit && content.exitCode === 127));
+		assert.ok(!part.toolCall.content?.some(content => content.type === ToolResultContentType.Terminal));
 	});
 
 	test('restores best-effort model, fallback agent, and attachments onto user messages', async () => {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -684,7 +684,9 @@ function getTerminalInput(tc: ToolCallState): string | undefined {
 	return undefined;
 }
 function getTerminalOutput(tc: ToolCallState) {
-	const text = tc.status === ToolCallStatus.Completed || tc.status === ToolCallStatus.Running ? tc.content?.find(c => c.type === ToolResultContentType.Text)?.text : undefined;
+	// TODO: Revisit whether SDK shell tool output should continue coming from
+	// ToolResultContentType.Text, or from shell_exit.outputPreview when available.
+	const text = tc.status === ToolCallStatus.Completed || tc.status === ToolCallStatus.Running ? tc.content?.find(isToolResultTextContent)?.text : undefined;
 	if (!text) {
 		return undefined;
 	}
@@ -695,14 +697,22 @@ function getTerminalOutput(tc: ToolCallState) {
 	return { text: text.replace(/\r?\n/g, '\r\n') };
 }
 
+function isToolResultTextContent(content: ToolResultContent): content is Extract<ToolResultContent, { type: ToolResultContentType.Text }> {
+	return content.type === ToolResultContentType.Text;
+}
+
 function getTerminalCommandState(tc: ToolCallState, fallbackSuccess?: boolean): IChatTerminalToolInvocationData['terminalCommandState'] | undefined {
 	const shellExit = tc.status === ToolCallStatus.Completed || tc.status === ToolCallStatus.Running
-		? tc.content?.find(c => c.type === ToolResultContentType.ShellExit)
+		? tc.content?.find(isToolResultShellExitContent)
 		: undefined;
 	if (shellExit) {
 		return { exitCode: shellExit.exitCode };
 	}
 	return fallbackSuccess === undefined ? undefined : { exitCode: fallbackSuccess ? 0 : 1 };
+}
+
+function isToolResultShellExitContent(content: ToolResultContent): content is Extract<ToolResultContent, { type: ToolResultContentType.ShellExit }> {
+	return content.type === ToolResultContentType.ShellExit;
 }
 
 function getTerminalLanguage(tc: ToolCallState) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -684,7 +684,7 @@ function getTerminalInput(tc: ToolCallState): string | undefined {
 	return undefined;
 }
 function getTerminalOutput(tc: ToolCallState) {
-	const text = tc.status === ToolCallStatus.Completed || tc.status === ToolCallStatus.Running ? tc.content?.find(c => c.type === 'text')?.text : undefined;
+	const text = tc.status === ToolCallStatus.Completed || tc.status === ToolCallStatus.Running ? tc.content?.find(c => c.type === ToolResultContentType.Text)?.text : undefined;
 	if (!text) {
 		return undefined;
 	}
@@ -693,6 +693,16 @@ function getTerminalOutput(tc: ToolCallState) {
 	// staircase). SDK terminal tools return plain text with `\n` line endings, so
 	// normalize to `\r\n` here. The replace is idempotent on already-CRLF input.
 	return { text: text.replace(/\r?\n/g, '\r\n') };
+}
+
+function getTerminalCommandState(tc: ToolCallState, fallbackSuccess?: boolean): IChatTerminalToolInvocationData['terminalCommandState'] | undefined {
+	const shellExit = tc.status === ToolCallStatus.Completed || tc.status === ToolCallStatus.Running
+		? tc.content?.find(c => c.type === ToolResultContentType.ShellExit)
+		: undefined;
+	if (shellExit) {
+		return { exitCode: shellExit.exitCode };
+	}
+	return fallbackSuccess === undefined ? undefined : { exitCode: fallbackSuccess ? 0 : 1 };
 }
 
 function getTerminalLanguage(tc: ToolCallState) {
@@ -748,8 +758,8 @@ function isTerminalToolCall(tc: ToolCallState, existingKind?: string): boolean {
  * block arrives — refreshing from `tc` alone would clobber them whenever the
  * block hasn't landed yet.
  *
- * Completion-only fields (e.g. `terminalCommandState` from `tc.success`)
- * are layered on top by the caller; the helper is status-agnostic.
+ * Completion-only fields (e.g. `terminalCommandState`) are layered on top by
+ * the caller; the helper is status-agnostic.
  */
 function buildTerminalToolSpecificData(
 	tc: ToolCallState,
@@ -945,7 +955,7 @@ export function completedToolCallToSerialized(tc: ICompletedToolCall, subAgentIn
 	if (isTerminal) {
 		toolSpecificData = {
 			...buildTerminalToolSpecificData(tc, sessionResource),
-			terminalCommandState: { exitCode: isSuccess ? 0 : 1 },
+			terminalCommandState: getTerminalCommandState(tc, isSuccess),
 		};
 	} else if (getToolKind(tc) === 'search') {
 		toolSpecificData = { kind: 'search' };
@@ -1569,7 +1579,7 @@ export function finalizeToolInvocation(invocation: ChatToolInvocation, tc: ToolC
 		invocation.presentation = undefined;
 		invocation.toolSpecificData = {
 			...buildTerminalToolSpecificData(tc, backendSession, existing),
-			terminalCommandState: { exitCode: isCompleted && tc.success ? 0 : 1 },
+			terminalCommandState: getTerminalCommandState(tc, isCompleted && tc.success),
 		};
 	} else if (isCompleted && tc.pastTenseMessage) {
 		invocation.pastTenseMessage = stringOrMarkdownToString(tc.pastTenseMessage, connectionAuthority);

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -1432,6 +1432,57 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(termData.terminalCommandOutput?.text, 'text-output');
 		});
 
+		test('uses shell_exit exit code for completed SDK shell tool history', () => {
+			const tc = createCompletedToolCall({
+				_meta: { toolKind: 'terminal' },
+				toolInput: 'gti status',
+				content: [
+					{ type: ToolResultContentType.Text, text: 'command not found\n' },
+					{ type: ToolResultContentType.ShellExit, shellId: '0', exitCode: 127, cwd: '/repo', outputPreview: 'preview only\n' },
+				],
+				success: true,
+			});
+
+			const turn = createTurn({
+				responseParts: [{ kind: ResponsePartKind.ToolCall, toolCall: tc } as ToolCallResponsePart],
+			});
+
+			const history = turnsToHistory(URI.file('/'), [turn], 'p');
+			const response = history[1];
+			assert.strictEqual(response.type, 'response');
+			if (response.type !== 'response') { return; }
+			const serialized = response.parts[0] as IChatToolInvocationSerialized;
+			assert.strictEqual(serialized.toolSpecificData?.kind, 'terminal');
+			const termData = serialized.toolSpecificData as { kind: 'terminal'; terminalCommandOutput?: { text: string }; terminalCommandState?: { exitCode: number } };
+			assert.strictEqual(termData.terminalCommandState?.exitCode, 127);
+			assert.strictEqual(termData.terminalCommandOutput?.text, 'command not found\r\n');
+		});
+
+		test('keeps zero shell_exit exit code as success for completed SDK shell tool history', () => {
+			const tc = createCompletedToolCall({
+				_meta: { toolKind: 'terminal' },
+				toolInput: 'pwd',
+				content: [
+					{ type: ToolResultContentType.Text, text: '/repo\n' },
+					{ type: ToolResultContentType.ShellExit, shellId: '0', exitCode: 0, cwd: '/repo' },
+				],
+				success: true,
+			});
+
+			const turn = createTurn({
+				responseParts: [{ kind: ResponsePartKind.ToolCall, toolCall: tc } as ToolCallResponsePart],
+			});
+
+			const history = turnsToHistory(URI.file('/'), [turn], 'p');
+			const response = history[1];
+			assert.strictEqual(response.type, 'response');
+			if (response.type !== 'response') { return; }
+			const serialized = response.parts[0] as IChatToolInvocationSerialized;
+			assert.strictEqual(serialized.toolSpecificData?.kind, 'terminal');
+			const termData = serialized.toolSpecificData as { kind: 'terminal'; terminalCommandState?: { exitCode: number } };
+			assert.strictEqual(termData.terminalCommandState?.exitCode, 0);
+		});
+
 		test('running tool call with terminal content block sets terminalCommandUri', () => {
 			const tc = createToolCallState({
 				_meta: { toolKind: 'terminal' },
@@ -1481,6 +1532,36 @@ suite('stateToProgressAdapter', () => {
 			assert.ok(termData.terminalCommandUri);
 			assert.strictEqual(termData.terminalCommandUri.toString(), 'agenthost-terminal:/final-term');
 			assert.strictEqual(termData.terminalCommandState?.exitCode, 0);
+		});
+
+		test('finalize uses shell_exit exit code over SDK tool success', () => {
+			const tc = createToolCallState({
+				_meta: { toolKind: 'terminal' },
+				toolInput: 'false',
+				status: ToolCallStatus.Running,
+			});
+			const invocation = toolCallStateToInvocation(tc);
+
+			finalizeToolInvocation(invocation, {
+				status: ToolCallStatus.Completed,
+				toolCallId: 'tc-1',
+				toolName: 'bash',
+				displayName: 'Run Shell Command',
+				invocationMessage: 'Running shell command',
+				_meta: { toolKind: 'terminal' },
+				toolInput: 'false',
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+				success: true,
+				pastTenseMessage: 'Ran false',
+				content: [
+					{ type: ToolResultContentType.Text, text: '' },
+					{ type: ToolResultContentType.ShellExit, shellId: '0', exitCode: 1, cwd: '/repo' },
+				],
+			});
+
+			assert.strictEqual(invocation.toolSpecificData?.kind, 'terminal');
+			const termData = invocation.toolSpecificData as { kind: 'terminal'; terminalCommandState?: { exitCode: number } };
+			assert.strictEqual(termData.terminalCommandState?.exitCode, 1);
 		});
 
 	});


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/322163
Context:  https://github.com/github/copilot-sdk/issues/1803

You will now see proper command decoration when using shell tool from SDK:
<img width="1401" height="1002" alt="Screenshot 2026-07-01 at 2 05 21 PM" src="https://github.com/user-attachments/assets/e490f1a5-0723-4897-a839-aa41a85fab33" />


- Add `shell_exit` as Agent Host tool result content for SDK shell command exit metadata.
- Preserve SDK `tool.execution_complete.result.contents[]` shell exit blocks in both live Copilot Agent Host events and replay/history mapping.
- Use `shell_exit.exitCode` as the terminal command state source when the custom terminal tool is disabled.
- Treat `exitCode === 0` as success, non-zero exit codes as failure, and missing shell exit metadata as unknown/compatibility fallback.
- Keep `result.content` as the displayed text output and avoid rendering `shell_exit.outputPreview` as duplicate terminal output.
- Do not create fake terminal URI/resource content for SDK shell exit metadata.


-----------------------------------------
Inspirations from:

- Terminal command decoration state follows existing chat terminal behavior where `exitCode === undefined` means unfinished and non-zero exit codes are failures: [`chatTerminalToolProgressPart.ts`](https://github.com/microsoft/vscode/blob/92592a639ed277a861cb8a3fac7fd190aed17f6e/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts#L551-L562).