### PR TITLE
Add client tool completion routing logs

### DIFF
--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -44,6 +44,7 @@ import {
 	type URI as ProtocolURI,
 	type SessionState,
 	type ToolCallState,
+	type ToolCallResult,
 	type ToolResultContent,
 	type Turn
 } from '../common/state/sessionState.js';
@@ -173,8 +174,7 @@ export class AgentSideEffects extends Disposable {
 					return; // Not a chat channel; ignore (already logged elsewhere).
 				}
 				const sessionChannel = parseRequiredSessionUriFromChatUri(envelope.channel);
-				const agent = this._options.getAgent(sessionChannel);
-				agent?.onClientToolCallComplete(URI.parse(sessionChannel), URI.parse(this._toolCallCompletionChat(envelope.channel)), action.toolCallId, action.result);
+				this._notifyClientToolCallComplete(sessionChannel, envelope.channel, action.toolCallId, action.result, 'server-envelope');
 			}
 			if (envelope.action.type === ActionType.ChatDraftChanged) {
 				this._persistChatDraft(envelope.channel, envelope.action.draft);
@@ -869,7 +869,19 @@ export class AgentSideEffects extends Disposable {
 			}
 		}
 
+		this._logService.warn(`[AgentSideEffects] Missing parent chat for subagent tool completion: chat=${chatChannel}`);
 		return chatChannel;
+	}
+
+	private _notifyClientToolCallComplete(sessionChannel: ProtocolURI, chatChannel: ProtocolURI, toolCallId: string, result: ToolCallResult, source: 'client-dispatch' | 'server-envelope'): void {
+		const completionChat = this._toolCallCompletionChat(chatChannel);
+		const agent = this._options.getAgent(sessionChannel);
+		if (!agent) {
+			this._logService.warn(`[AgentSideEffects] No agent for client tool completion: source=${source}, session=${sessionChannel}, chat=${chatChannel}, completionChat=${completionChat}, toolCallId=${toolCallId}`);
+			return;
+		}
+		this._logService.info(`[AgentSideEffects] Forwarding client tool completion: source=${source}, session=${sessionChannel}, chat=${chatChannel}, completionChat=${completionChat}, toolCallId=${toolCallId}, success=${result.success}`);
+		agent.onClientToolCallComplete(URI.parse(sessionChannel), URI.parse(completionChat), toolCallId, result);
 	}
 
 	// ---- Side-effect handlers --------------------------------------------------
@@ -1109,8 +1121,7 @@ export class AgentSideEffects extends Disposable {
 				if (!chatChannel) {
 					break; // Not a chat channel; ignore.
 				}
-				const agent = this._options.getAgent(sessionChannel);
-				agent?.onClientToolCallComplete(URI.parse(sessionChannel), URI.parse(this._toolCallCompletionChat(chatChannel)), action.toolCallId, action.result);
+				this._notifyClientToolCallComplete(sessionChannel, chatChannel, action.toolCallId, action.result, 'client-dispatch');
 				break;
 			}
 		}

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1679,12 +1679,25 @@ export class CopilotAgent extends Disposable implements IAgent {
 	}
 
 	onClientToolCallComplete(session: URI, chat: URI, toolCallId: string, result: ToolCallResult): void {
+		const sessionId = AgentSession.id(session);
 		// Peer (non-default) chats own their SDK chat within the owning
 		// session entry, keyed by the chat URI. Mirrors the routing in `sendMessage`.
 		if (!isDefaultChatUri(chat)) {
-			this._findPeerChat(session, chat)?.handleClientToolCallComplete(toolCallId, result);
+			const peerChat = this._findPeerChat(session, chat);
+			if (!peerChat) {
+				this._logService.warn(`[Copilot:${sessionId}] Dropping client tool completion for missing peer chat: chat=${chat.toString()}, toolCallId=${toolCallId}, success=${result.success}`);
+				return;
+			}
+			this._logService.info(`[Copilot:${sessionId}] Routing client tool completion to peer chat: chat=${chat.toString()}, toolCallId=${toolCallId}, success=${result.success}`);
+			peerChat.handleClientToolCallComplete(toolCallId, result);
 		} else {
-			this._findAnySession(AgentSession.id(session))?.handleClientToolCallComplete(toolCallId, result);
+			const entry = this._findAnySession(sessionId);
+			if (!entry) {
+				this._logService.warn(`[Copilot:${sessionId}] Dropping client tool completion for missing default chat: chat=${chat.toString()}, toolCallId=${toolCallId}, success=${result.success}`);
+				return;
+			}
+			this._logService.info(`[Copilot:${sessionId}] Routing client tool completion to default chat: chat=${chat.toString()}, toolCallId=${toolCallId}, success=${result.success}`);
+			entry.handleClientToolCallComplete(toolCallId, result);
 		}
 	}
 


### PR DESCRIPTION
Adds targeted diagnostic logging around the agent-host client-tool completion handoff.

Summary:
- Log when `AgentSideEffects` forwards a client tool completion, including the original chat and resolved completion chat.
- Warn when a completion cannot be forwarded because the agent is missing or a subagent parent chat cannot be resolved.
- Log/drop diagnostics in `CopilotAgent.onClientToolCallComplete` for missing default or peer chat entries.

Validation:
- `npm run typecheck-client`
- pre-commit hygiene via commit hook

This is diagnostic-only logging intended to distinguish future reports where the UI observes `chat/toolCallComplete` but the SDK/runtime does not resume.