### PR TITLE
Enable cache-break hint by default

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -498,8 +498,8 @@ function getKeyboardNavigationLabel<T>(item: IActionListItem<T>): string | undef
 export interface IActionListHeaderLink {
 	/** Visible link text (e.g. "Learn more"). Should be localized. */
 	readonly label: string;
-	/** Target opened via the opener service when the link is activated. */
-	readonly uri: URI;
+	/** Link target opened via the opener service when the link is activated. */
+	readonly href: string;
 }
 
 /**
@@ -857,10 +857,10 @@ export class ActionListWidget<T> extends Disposable {
 			text.textContent = this._options.headerText;
 
 			if (this._options.headerLink) {
-				const { label, uri } = this._options.headerLink;
+				const { label, href } = this._options.headerLink;
 				// Trailing space so the link reads as a continuation of the banner text.
 				text.textContent += ' ';
-				this._register(this._instantiationService.createInstance(Link, text, { label, href: uri.toString(true) }, {}));
+				this._register(this._instantiationService.createInstance(Link, text, { label, href }, {}));
 			}
 
 			if (this._options.headerDismiss) {

--- a/src/vs/platform/actionWidget/test/browser/actionList.test.ts
+++ b/src/vs/platform/actionWidget/test/browser/actionList.test.ts
@@ -19,7 +19,6 @@ import { IKeybindingService } from '../../../keybinding/common/keybinding.js';
 import { ILayoutService } from '../../../layout/browser/layoutService.js';
 import { IOpenerService } from '../../../opener/common/opener.js';
 import { NullOpenerService } from '../../../opener/test/common/nullOpenerService.js';
-import { URI } from '../../../../base/common/uri.js';
 import { ActionList, ActionListItemKind, ActionListWidget, IActionListItem, IActionListOptions } from '../../browser/actionList.js';
 
 interface ITestActionItem {
@@ -266,9 +265,9 @@ suite('ActionListWidget', () => {
 		);
 	});
 
-	test('header renders a "Learn more" link to the given uri', () => {
+	test('header renders a "Learn more" link to the given href', () => {
 		const widget = createActionListWidget(disposables, {
-			listOptions: { headerText: 'Cache hint', headerLink: { label: 'Learn more', uri: URI.parse('https://aka.ms/test') } },
+			listOptions: { headerText: 'Cache hint', headerLink: { label: 'Learn more', href: 'https://aka.ms/test' } },
 		});
 
 		const link = widget.headerContainer?.querySelector<HTMLAnchorElement>('a.monaco-link');

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -370,7 +370,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.tips.enabled', "Controls whether tips are shown above user messages in chat. New tips are added frequently, so this is a helpful way to stay up to date with the latest features."),
 			default: true,
 		},
-		'chat.cacheBreakHint.enabled': {
+		[ChatConfiguration.CacheBreakHintEnabled]: {
 			type: 'boolean',
 			scope: ConfigurationScope.APPLICATION,
 			description: nls.localize('chat.cacheBreakHint.enabled', "Controls whether the model and options pickers show a hint that switching the model or its options mid-session resets the prompt cache and may increase cost."),

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -370,13 +370,6 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.tips.enabled', "Controls whether tips are shown above user messages in chat. New tips are added frequently, so this is a helpful way to stay up to date with the latest features."),
 			default: true,
 		},
-		[ChatConfiguration.CacheBreakHintEnabled]: {
-			type: 'boolean',
-			scope: ConfigurationScope.APPLICATION,
-			description: nls.localize('chat.cacheBreakHint.enabled', "Controls whether the model and options pickers show a hint that switching the model or its options mid-session resets the prompt cache and may increase cost."),
-			default: false,
-			tags: ['experimental'],
-		},
 		'chat.upvoteAnimation': {
 			type: 'string',
 			enum: ['off', 'confetti', 'floatingThumbs', 'pulseWave', 'radiantLines'],

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -24,7 +24,7 @@ import { formatTokenCount } from '../../../../../../base/common/numbers.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { localize } from '../../../../../../nls.js';
-import { ActionListItemKind, IActionListHeaderLink, IActionListItem } from '../../../../../../platform/actionWidget/browser/actionList.js';
+import { ActionListItemKind, IActionListHeaderLink, IActionListItem, IActionListOptions } from '../../../../../../platform/actionWidget/browser/actionList.js';
 import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
 import { IActionWidgetDropdownAction } from '../../../../../../platform/actionWidget/browser/actionWidgetDropdown.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
@@ -34,7 +34,7 @@ import { ITelemetryService } from '../../../../../../platform/telemetry/common/t
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { TelemetryTrustedValue } from '../../../../../../platform/telemetry/common/telemetryUtils.js';
-import { MANAGE_CHAT_COMMAND_ID } from '../../../common/constants.js';
+import { ChatConfiguration, MANAGE_CHAT_COMMAND_ID } from '../../../common/constants.js';
 import { IModelControlEntry, ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService, IModelsControlManifest } from '../../../common/languageModels.js';
 import { ChatEntitlement, chatRequiresSetup, IChatEntitlementService, isProUser } from '../../../../../services/chat/common/chatEntitlementService.js';
 import * as semver from '../../../../../../base/common/semver/semver.js';
@@ -101,9 +101,6 @@ const PICKER_COMMAND_ACTION_IDS: ReadonlySet<string> = new Set([RESTRICTED_MODE_
 
 /** Storage key remembering that the user dismissed the cache-break hint. */
 const CACHE_BREAK_HINT_DISMISSED_STORAGE_KEY = 'chat.cacheBreakHintDismissed';
-
-/** Setting gating the cache-break hint, so it can be toggled / run as an experiment. */
-const CACHE_BREAK_HINT_ENABLED_SETTING = 'chat.cacheBreakHint.enabled';
 
 /**
  * Returns a human-readable display name for a model vendor.
@@ -1280,11 +1277,11 @@ export class ModelPickerWidget extends Disposable {
 	/** The "Learn more" header link for cache-break hints; `undefined` when the product has no URL. */
 	private getCacheBreakLearnMoreLink(): IActionListHeaderLink | undefined {
 		const url = this._productService.defaultChatAgent?.optimizeUsageDocumentationUrl;
-		return url ? { label: localize('chat.cacheBreak.learnMore', "Learn more"), uri: URI.parse(url) } : undefined;
+		return url ? { label: localize('chat.cacheBreak.learnMore', "Learn more"), href: url } : undefined;
 	}
 
 	private isCacheBreakHintEnabled(): boolean {
-		return this._configurationService.getValue<boolean>(CACHE_BREAK_HINT_ENABLED_SETTING) === true;
+		return this._configurationService.getValue<boolean>(ChatConfiguration.CacheBreakHintEnabled) === true;
 	}
 
 	private isCacheBreakHintDismissed(): boolean {
@@ -1310,10 +1307,28 @@ export class ModelPickerWidget extends Disposable {
 		if (!(this._delegate.isCacheWarm?.() ?? false)) {
 			return false;
 		}
-		if (excludeAutoModel && !!this._selectedModel && isAutoModel(this._selectedModel)) {
+		if (excludeAutoModel && this._selectedModel && isAutoModel(this._selectedModel)) {
 			return false;
 		}
 		return true;
+	}
+
+	/**
+	 * Header banner options shared by the model and options pickers. Returns the
+	 * cache-break hint banner when {@link shouldShowCacheBreakHint} allows it;
+	 * otherwise falls back to `fallbackText` (the options picker's generic cost
+	 * hint), or no banner at all when none is given.
+	 */
+	private getCacheBreakHeaderOptions(excludeAutoModel: boolean, text: string, fallbackText?: string): Pick<IActionListOptions, 'headerText' | 'headerIcon' | 'headerLink' | 'headerDismiss'> {
+		if (!this.shouldShowCacheBreakHint(excludeAutoModel)) {
+			return fallbackText ? { headerText: fallbackText, headerIcon: Codicon.info } : {};
+		}
+		return {
+			headerText: text,
+			headerIcon: Codicon.info,
+			headerLink: this.getCacheBreakLearnMoreLink(),
+			headerDismiss: () => this.dismissCacheBreakHint(),
+		};
 	}
 
 	show(anchor?: HTMLElement): void {
@@ -1409,12 +1424,8 @@ export class ModelPickerWidget extends Disposable {
 		// stale, unusable models. Shown otherwise (it also hosts the secondary
 		// heading).
 		const unavailable = this.isRestrictedMode() || this.isSetupRequired();
-		const showCacheBreakHint = this.shouldShowCacheBreakHint(/* excludeAutoModel */ true);
 		const listOptions = {
-			headerText: showCacheBreakHint ? localize('chat.modelPicker.cacheBreakHint', "Switching models mid-session resets the prompt cache and may increase cost.") : undefined,
-			headerIcon: showCacheBreakHint ? Codicon.info : undefined,
-			headerLink: showCacheBreakHint ? this.getCacheBreakLearnMoreLink() : undefined,
-			headerDismiss: showCacheBreakHint ? () => this.dismissCacheBreakHint() : undefined,
+			...this.getCacheBreakHeaderOptions(/* excludeAutoModel */ true, localize('chat.modelPicker.cacheBreakHint', "Switching models mid-session resets the prompt cache and may increase cost.")),
 			showFilter: !unavailable,
 			filterPlaceholder: localize('chat.modelPicker.search', "Search models"),
 			focusFilterOnOpen: true,
@@ -1744,8 +1755,6 @@ export class ModelPickerWidget extends Disposable {
 
 		this._configButton.setAttribute('aria-expanded', 'true');
 
-		const showCacheBreakHint = this.shouldShowCacheBreakHint(/* excludeAutoModel */ false);
-
 		this._actionWidgetService.show(
 			'ChatModelConfigPicker',
 			false,
@@ -1761,12 +1770,11 @@ export class ModelPickerWidget extends Disposable {
 				getRole: (element: IActionListItem<IActionWidgetDropdownAction>) => element.kind === ActionListItemKind.Action ? 'menuitemradio' as const : 'separator' as const,
 				getWidgetRole: () => 'menu' as const,
 			},
-			{
-				headerText: showCacheBreakHint ? localize('chat.config.cacheBreakHint', "Changing these options mid-session resets the prompt cache and may increase cost.") : undefined,
-				headerIcon: showCacheBreakHint ? Codicon.info : undefined,
-				headerLink: showCacheBreakHint ? this.getCacheBreakLearnMoreLink() : undefined,
-				headerDismiss: showCacheBreakHint ? () => this.dismissCacheBreakHint() : undefined,
-			}
+			this.getCacheBreakHeaderOptions(
+				/* excludeAutoModel */ false,
+				localize('chat.config.cacheBreakHint', "Changing these options mid-session resets the prompt cache and may increase cost."),
+				localize('chat.config.costHint', "Non-default options may increase cost"),
+			)
 		);
 
 		// Focus the requested section's first option (e.g. when opened from a

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -32,9 +32,8 @@ import { IOpenerService } from '../../../../../../platform/opener/common/opener.
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
-import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { TelemetryTrustedValue } from '../../../../../../platform/telemetry/common/telemetryUtils.js';
-import { ChatConfiguration, MANAGE_CHAT_COMMAND_ID } from '../../../common/constants.js';
+import { MANAGE_CHAT_COMMAND_ID } from '../../../common/constants.js';
 import { IModelControlEntry, ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService, IModelsControlManifest } from '../../../common/languageModels.js';
 import { ChatEntitlement, chatRequiresSetup, IChatEntitlementService, isProUser } from '../../../../../services/chat/common/chatEntitlementService.js';
 import * as semver from '../../../../../../base/common/semver/semver.js';
@@ -1055,7 +1054,6 @@ export class ModelPickerWidget extends Disposable {
 		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
 		@IWorkspaceTrustRequestService private readonly _workspaceTrustRequestService: IWorkspaceTrustRequestService,
 		@IStorageService private readonly _storageService: IStorageService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
 		this._register(this._languageModelsService.onDidChangeLanguageModels(() => {
@@ -1280,10 +1278,6 @@ export class ModelPickerWidget extends Disposable {
 		return url ? { label: localize('chat.cacheBreak.learnMore', "Learn more"), href: url } : undefined;
 	}
 
-	private isCacheBreakHintEnabled(): boolean {
-		return this._configurationService.getValue<boolean>(ChatConfiguration.CacheBreakHintEnabled) === true;
-	}
-
 	private isCacheBreakHintDismissed(): boolean {
 		return this._storageService.getBoolean(CACHE_BREAK_HINT_DISMISSED_STORAGE_KEY, StorageScope.APPLICATION, false);
 	}
@@ -1293,15 +1287,15 @@ export class ModelPickerWidget extends Disposable {
 	}
 
 	/**
-	 * Whether a picker should show the cache-break hint: the feature is enabled,
-	 * not dismissed, and the session's cache is warm. When `excludeAutoModel` is
+	 * Whether a picker should show the cache-break hint: the hint has not been
+	 * dismissed and the session's cache is warm. When `excludeAutoModel` is
 	 * set (the model picker), the hint is suppressed for the Auto model, since
 	 * Auto routes each request dynamically so "switching models" does not apply.
 	 * The options picker passes `false`: changing reasoning effort / context size
 	 * resets the cache even under Auto, which only routes the model.
 	 */
 	private shouldShowCacheBreakHint(excludeAutoModel: boolean): boolean {
-		if (!this.isCacheBreakHintEnabled() || this.isCacheBreakHintDismissed()) {
+		if (this.isCacheBreakHintDismissed()) {
 			return false;
 		}
 		if (!(this._delegate.isCacheWarm?.() ?? false)) {

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -97,7 +97,6 @@ export enum ChatConfiguration {
 	EditorLocalAgentEnabled = 'chat.editor.localAgent.enabled',
 	CopilotCliHideExtensionHostEditor = 'chat.editor.copilotCli.hideExtensionHost',
 	AgentsHandoffTipMode = 'chat.agentsHandoffTip.mode',
-	CacheBreakHintEnabled = 'chat.cacheBreakHint.enabled',
 
 	IncrementalRendering = 'chat.experimental.incrementalRendering.enabled',
 	IncrementalRenderingStyle = 'chat.experimental.incrementalRendering.animationStyle',

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -97,6 +97,7 @@ export enum ChatConfiguration {
 	EditorLocalAgentEnabled = 'chat.editor.localAgent.enabled',
 	CopilotCliHideExtensionHostEditor = 'chat.editor.copilotCli.hideExtensionHost',
 	AgentsHandoffTipMode = 'chat.agentsHandoffTip.mode',
+	CacheBreakHintEnabled = 'chat.cacheBreakHint.enabled',
 
 	IncrementalRendering = 'chat.experimental.incrementalRendering.enabled',
 	IncrementalRenderingStyle = 'chat.experimental.incrementalRendering.animationStyle',


### PR DESCRIPTION
Removes the experimental `chat.cacheBreakHint.enabled` setting and its gate so the model/options picker cache-break hint is shown by default.

