### PR TITLE
Preserve advanced sandbox network settings

### DIFF
--- a/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxEngine.ts
@@ -681,7 +681,7 @@ export class TerminalSandboxEngine extends Disposable {
 		};
 		if (this._os !== OperatingSystem.Windows) {
 			const sandboxRuntimeSettings = sandboxSettings as Record<string, unknown>;
-			this._mergeAdditionalSandboxConfigProperties(sandboxRuntimeSettings, allowNetwork ? this._withoutNetworkRuntimeSetting(runtimeSetting) : runtimeSetting);
+			this._mergeAdditionalSandboxConfigProperties(sandboxRuntimeSettings, runtimeSetting);
 			this._mergeAdditionalSandboxConfigProperties(sandboxRuntimeSettings, commandRuntimeSetting);
 			if (this._os === OperatingSystem.Macintosh) {
 				sandboxRuntimeSettings.allowPty ??= true;
@@ -841,12 +841,6 @@ export class TerminalSandboxEngine extends Disposable {
 		}
 
 		return paths.filter((path): path is string => typeof path === 'string');
-	}
-
-	private _withoutNetworkRuntimeSetting(runtimeSetting: Record<string, unknown>): Record<string, unknown> {
-		const sanitizedRuntimeSetting = { ...runtimeSetting };
-		delete sanitizedRuntimeSetting.network;
-		return sanitizedRuntimeSetting;
 	}
 
 	private _mergeAdditionalSandboxConfigProperties(target: Record<string, unknown>, additional: Record<string, unknown>): void {

--- a/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
+++ b/src/vs/platform/sandbox/test/common/terminalSandboxEngine.test.ts
@@ -254,6 +254,28 @@ suite('TerminalSandboxEngine', () => {
 		strictEqual(config.allowPty, false);
 	});
 
+	test('sandbox config preserves advanced runtime network settings when allowNetwork is enabled', async () => {
+		setSandboxSetting(AgentSandboxSettingId.AgentSandboxAllowNetwork, true);
+		setSandboxSetting(AgentSandboxSettingId.AgentSandboxAdvancedRuntime, {
+			network: {
+				allowAllUnixSockets: true,
+				enabled: true,
+			},
+		});
+		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, createHost()));
+
+		const configPath = await engine.getSandboxConfigPath();
+		ok(configPath, 'Config path should be defined');
+		const config = JSON.parse(createdFiles.get(configPath)!);
+
+		deepStrictEqual(config.network, {
+			allowedDomains: [],
+			deniedDomains: [],
+			enabled: false,
+			allowAllUnixSockets: true,
+		});
+	});
+
 	test('requestAllowNetwork keeps the command sandboxed and refreshes its network config', async () => {
 		setSandboxSetting(AgentSandboxSettingId.AgentSandboxRetryWithAllowNetworkRequests, true);
 		const engine = store.add(instantiationService.createInstance(TerminalSandboxEngine, createHost()));

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
@@ -418,7 +418,7 @@ suite('TerminalSandboxService - network domains', () => {
 		ok(configContent, 'Config file should be created');
 
 		const config = JSON.parse(configContent);
-		deepStrictEqual(config.network, { allowedDomains: [], deniedDomains: [], enabled: false });
+		deepStrictEqual(config.network, { allowedDomains: [], deniedDomains: [], enabled: false, allowUnixSockets: true });
 		strictEqual(config.allowPty, true, 'Non-network runtime settings should still be merged');
 	});
 


### PR DESCRIPTION
## Summary

Preserve advanced sandbox runtime network options when unrestricted network access is enabled, while keeping generated network settings authoritative.

Adds regression coverage for `allowAllUnixSockets`.

Fixes #323944