### PR TITLE
GA vision in vs code

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -3474,6 +3474,11 @@
             "tags": [
               "onExp"
             ]
+          },
+          "github.copilot.chat.imageUpload.enabled": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "%github.copilot.config.imageUpload.enabled%"
           }
         }
       },
@@ -3618,11 +3623,6 @@
               "experimental",
               "onExp"
             ]
-          },
-          "github.copilot.chat.imageUpload.enabled": {
-            "type": "boolean",
-            "default": true,
-            "markdownDescription": "%github.copilot.config.imageUpload.enabled%"
           },
           "github.copilot.chat.codeGeneration.instructions": {
             "markdownDeprecationMessage": "%github.copilot.config.codeGeneration.instructions.deprecated%",

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -3622,10 +3622,6 @@
           "github.copilot.chat.imageUpload.enabled": {
             "type": "boolean",
             "default": true,
-            "tags": [
-              "experimental",
-              "onExp"
-            ],
             "markdownDescription": "%github.copilot.config.imageUpload.enabled%"
           },
           "github.copilot.chat.codeGeneration.instructions": {

--- a/extensions/copilot/src/extension/prompts/node/panel/image.tsx
+++ b/extensions/copilot/src/extension/prompts/node/panel/image.tsx
@@ -44,14 +44,13 @@ export class HistoricalImage extends PromptElement<HistoricalImageProps, unknown
 	constructor(
 		props: HistoricalImageProps,
 		@IPromptEndpoint private readonly promptEndpoint: IPromptEndpoint,
-		@IAuthenticationService private readonly authService: IAuthenticationService,
 	) {
 		super(props);
 	}
 
 	override async render(_state: unknown, sizing: PromptSizing) {
 		// If the model doesn't support vision, omit historical images
-		if (!this.promptEndpoint.supportsVision || !this.authService.copilotToken?.isEditorPreviewFeaturesEnabled()) {
+		if (!this.promptEndpoint.supportsVision) {
 			return undefined;
 		}
 
@@ -78,7 +77,7 @@ export class Image extends PromptElement<ImageProps, unknown> {
 		const fillerUri: Uri = this.props.reference ?? Uri.parse('Attached Image');
 
 		try {
-			if (!this.promptEndpoint.supportsVision || !this.authService.copilotToken?.isEditorPreviewFeaturesEnabled()) {
+			if (!this.promptEndpoint.supportsVision) {
 				if (this.props.omitReferences) {
 					return;
 				}

--- a/extensions/copilot/src/extension/prompts/node/panel/image.tsx
+++ b/extensions/copilot/src/extension/prompts/node/panel/image.tsx
@@ -11,7 +11,6 @@ import { ConfigKey, IConfigurationService } from '../../../../platform/configura
 import { modelCanUseImageURL } from '../../../../platform/endpoint/common/chatModelCapabilities';
 import { IImageService } from '../../../../platform/image/common/imageService';
 import { ILogService } from '../../../../platform/log/common/logService';
-import { IExperimentationService } from '../../../../platform/telemetry/common/nullExperimentationService';
 import { getMimeType } from '../../../../util/common/imageUtils';
 import { Uri } from '../../../../vscodeTypes';
 import { IPromptEndpoint } from '../base/promptRenderer';
@@ -65,8 +64,7 @@ export class Image extends PromptElement<ImageProps, unknown> {
 		@IAuthenticationService private readonly authService: IAuthenticationService,
 		@ILogService private readonly logService: ILogService,
 		@IImageService private readonly imageService: IImageService,
-		@IConfigurationService private readonly configurationService: IConfigurationService,
-		@IExperimentationService private readonly experimentationService: IExperimentationService
+		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
 		super(props);
 	}
@@ -93,7 +91,7 @@ export class Image extends PromptElement<ImageProps, unknown> {
 			let imageMimeType: string | undefined = undefined;
 
 			const isChatRequest = typeof this.promptEndpoint.urlOrRequestMetadata !== 'string' && (this.promptEndpoint.urlOrRequestMetadata.type === RequestType.ChatCompletions || this.promptEndpoint.urlOrRequestMetadata.type === RequestType.ChatResponses || this.promptEndpoint.urlOrRequestMetadata.type === RequestType.ChatMessages);
-			const enabled = this.configurationService.getExperimentBasedConfig(ConfigKey.EnableChatImageUpload, this.experimentationService);
+			const enabled = this.configurationService.getConfig(ConfigKey.EnableChatImageUpload);
 			if (isChatRequest && enabled && modelCanUseImageURL(this.promptEndpoint)) {
 				try {
 					const githubToken = (await this.authService.getGitHubSession('any', { silent: true }))?.accessToken;

--- a/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
+++ b/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
@@ -751,8 +751,7 @@ class PrimitiveToolResult<T extends IPrimitiveToolResultProps> extends PromptEle
 		@IAuthenticationService private readonly authService?: IAuthenticationService,
 		@ILogService private readonly logService?: ILogService,
 		@IImageService private readonly imageService?: IImageService,
-		@IConfigurationService private readonly configurationService?: IConfigurationService,
-		@IExperimentationService private readonly experimentationService?: IExperimentationService
+		@IConfigurationService private readonly configurationService?: IConfigurationService
 	) {
 		super(props);
 		this.linkedResources = this.props.content.filter((c): c is LanguageModelDataPart => c instanceof LanguageModelDataPart && c.mimeType === McpLinkedResourceToolResult.mimeType);
@@ -803,8 +802,8 @@ class PrimitiveToolResult<T extends IPrimitiveToolResultProps> extends PromptEle
 			return '[Image content is not available because vision is not supported by the current model.]';
 		}
 
-		const uploadsEnabled = this.configurationService && this.experimentationService
-			? this.configurationService.getExperimentBasedConfig(ConfigKey.EnableChatImageUpload, this.experimentationService)
+		const uploadsEnabled = this.configurationService
+			? this.configurationService.getConfig(ConfigKey.EnableChatImageUpload)
 			: false;
 
 		// Anthropic (from CAPI) currently does not support image uploads from tool calls.
@@ -897,7 +896,7 @@ export class ToolResult extends PrimitiveToolResult<IToolResultProps> {
 		@IExperimentationService private readonly _experimentationService: IExperimentationService,
 		@IChatDiskSessionResources private readonly diskSessionResources: IChatDiskSessionResources,
 	) {
-		super(props, endpoint, authService, _logService, imageService, _configurationService, _experimentationService);
+		super(props, endpoint, authService, _logService, imageService, _configurationService);
 	}
 
 	protected override async onTSX(part: JSONTree.PromptElementJSON): Promise<any> {

--- a/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
+++ b/extensions/copilot/src/extension/prompts/node/panel/toolCalling.tsx
@@ -800,7 +800,7 @@ class PrimitiveToolResult<T extends IPrimitiveToolResultProps> extends PromptEle
 
 	protected async onImage(part: LanguageModelDataPart, _imageIndex?: number) {
 		if (!this.endpoint?.supportsVision) {
-			return '[Image content is not available because vision is not supported by the current model or is disabled by your organization.]';
+			return '[Image content is not available because vision is not supported by the current model.]';
 		}
 
 		const uploadsEnabled = this.configurationService && this.experimentationService

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -980,7 +980,7 @@ export namespace ConfigKey {
 	export const EnableGemini3LowReasoningEffort = defineSetting<boolean>('chat.gemini3LowReasoningEffort.enabled', ConfigType.ExperimentBased, false);
 	/** Enable read_file tool for GPT-5.5 models */
 	export const EnableGpt55ReadFileTool = defineSetting<boolean>('chat.gpt55ReadFileTool.enabled', ConfigType.ExperimentBased, true);
-	export const EnableChatImageUpload = defineSetting<boolean>('chat.imageUpload.enabled', ConfigType.ExperimentBased, true);
+	export const EnableChatImageUpload = defineSetting<boolean>('chat.imageUpload.enabled', ConfigType.Simple, true);
 	/** Enable Anthropic web search tool for BYOK Claude models */
 	export const AnthropicWebSearchToolEnabled = defineSetting<boolean>('chat.anthropic.tools.websearch.enabled', ConfigType.ExperimentBased, false);
 	/** Maximum number of web searches allowed per request */

--- a/src/vs/sessions/test/web.test.ts
+++ b/src/vs/sessions/test/web.test.ts
@@ -93,7 +93,6 @@ class MockChatEntitlementService implements IChatEntitlementService {
 	readonly entitlement = ChatEntitlement.Free;
 	readonly entitlementObs: IObservable<ChatEntitlement> = observableValue('entitlement', ChatEntitlement.Free);
 
-	readonly previewFeaturesDisabled = false;
 	readonly clientByokEnabled = false;
 	readonly hasByokModels = false;
 	readonly organisations: string[] | undefined = undefined;

--- a/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
@@ -71,7 +71,6 @@ import { coerceImageBuffer } from '../../common/chatImageExtraction.js';
 import { ChatConfiguration } from '../../common/constants.js';
 import { getImageAttachmentLimit, IChatRequestPasteVariableEntry, IChatRequestVariableEntry, IBrowserViewVariableEntry, IElementVariableEntry, INotebookOutputVariableEntry, IPromptFileVariableEntry, IPromptTextVariableEntry, ISCMHistoryItemVariableEntry, OmittedState, PromptFileVariableKind, ChatRequestToolReferenceEntry, ISCMHistoryItemChangeVariableEntry, ISCMHistoryItemChangeRangeVariableEntry, ITerminalVariableEntry, isStringVariableEntry } from '../../common/attachments/chatVariableEntries.js';
 import { ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService, isAutoLanguageModel } from '../../common/languageModels.js';
-import { IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
 import { ILanguageModelToolsService, isToolSet } from '../../common/tools/languageModelToolsService.js';
 import { getCleanPromptName } from '../../common/promptSyntax/config/promptFileLocations.js';
 import { IChatContextService } from '../contextContrib/chatContextService.js';
@@ -497,7 +496,6 @@ export class ImageAttachmentWidget extends AbstractChatAttachmentWidget {
 		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ILabelService private readonly labelService: ILabelService,
-		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
 		@IChatImageCarouselService private readonly chatImageCarouselService: IChatImageCarouselService,
 		@IFileDialogService private readonly fileDialogService: IFileDialogService,
 		@IFileService private readonly fileService: IFileService,
@@ -539,7 +537,7 @@ export class ImageAttachmentWidget extends AbstractChatAttachmentWidget {
 		const currentLanguageModelName = this.currentLanguageModel ? this.languageModelsService.lookupLanguageModel(this.currentLanguageModel.identifier)?.name ?? this.currentLanguageModel.identifier : 'Current model';
 
 		const fullName = resource ? this.labelService.getUriLabel(resource) : (attachment.fullName || attachment.name);
-		this._register(createImageElements(resource, attachment.name, fullName, this.element, imageData ?? (attachment.value as Uint8Array), attachment.id, this.hoverService, ariaLabel, currentLanguageModelName, clickHandler, this.currentLanguageModel, omittedState, this.chatEntitlementService.previewFeaturesDisabled));
+		this._register(createImageElements(resource, attachment.name, fullName, this.element, imageData ?? (attachment.value as Uint8Array), attachment.id, this.hoverService, ariaLabel, currentLanguageModelName, clickHandler, this.currentLanguageModel, omittedState));
 		this.attachSaveButton(resource, imageData, attachment.name, options.supportsDeletion);
 		this.element.ariaLabel = this.appendDeletionHint(ariaLabel);
 
@@ -616,8 +614,7 @@ function createImageElements(resource: URI | undefined, name: string, fullName: 
 	currentLanguageModelName: string | undefined,
 	clickHandler: () => void,
 	currentLanguageModel?: ILanguageModelChatMetadataAndIdentifier,
-	omittedState?: OmittedState,
-	previewFeaturesDisabled?: boolean): IDisposable {
+	omittedState?: OmittedState): IDisposable {
 
 	const disposable = new DisposableStore();
 	if (omittedState === OmittedState.Partial) {
@@ -631,7 +628,7 @@ function createImageElements(resource: URI | undefined, name: string, fullName: 
 		element.style.cursor = 'pointer';
 	}
 	const supportsVision = modelSupportsVision(currentLanguageModel);
-	const pillIcon = dom.$('div.chat-attached-context-pill', {}, dom.$((supportsVision && !previewFeaturesDisabled) ? 'span.codicon.codicon-file-media' : 'span.codicon.codicon-warning'));
+	const pillIcon = dom.$('div.chat-attached-context-pill', {}, dom.$(supportsVision ? 'span.codicon.codicon-file-media' : 'span.codicon.codicon-warning'));
 	const textLabel = dom.$('span.chat-attached-context-custom-text', {}, name);
 	element.appendChild(pillIcon);
 	element.appendChild(textLabel);
@@ -646,14 +643,7 @@ function createImageElements(resource: URI | undefined, name: string, fullName: 
 	const hoverElement = dom.$('div.chat-attached-context-hover');
 	hoverElement.setAttribute('aria-label', ariaLabel);
 
-	if (previewFeaturesDisabled) {
-		element.classList.add('warning');
-		hoverElement.textContent = localize('chat.imageAttachmentPreviewFeaturesDisabled', "Vision is disabled by your organization.");
-		disposable.add(hoverService.setupDelayedHover(element, {
-			content: hoverElement,
-			style: HoverStyle.Pointer,
-		}));
-	} else if ((!supportsVision && currentLanguageModel) || omittedState === OmittedState.Full) {
+	if ((!supportsVision && currentLanguageModel) || omittedState === OmittedState.Full) {
 		element.classList.add('warning');
 		hoverElement.textContent = localize('chat.imageAttachmentHover', "{0} does not support images.", currentLanguageModelName ?? 'This model');
 		disposable.add(hoverService.setupDelayedHover(element, {
@@ -1057,7 +1047,6 @@ export class NotebookCellOutputChatAttachmentWidget extends AbstractChatAttachme
 		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
 		@INotebookService private readonly notebookService: INotebookService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
 	) {
 		super(attachment, options, container, contextResourceLabels, currentLanguageModel, commandService, openerService, configurationService);
 
@@ -1118,7 +1107,7 @@ export class NotebookCellOutputChatAttachmentWidget extends AbstractChatAttachme
 		const clickHandler = async () => await this.openResource(resource, { editorOptions: { preserveFocus: true } }, false, undefined);
 		const currentLanguageModelName = this.currentLanguageModel ? this.languageModelsService.lookupLanguageModel(this.currentLanguageModel.identifier)?.name ?? this.currentLanguageModel.identifier : undefined;
 		const buffer = this.getOutputItem(resource, attachment)?.data.buffer ?? new Uint8Array();
-		this._register(createImageElements(resource, attachment.name, attachment.name, this.element, buffer, attachment.id, this.hoverService, ariaLabel, currentLanguageModelName, clickHandler, this.currentLanguageModel, attachment.omittedState, this.chatEntitlementService.previewFeaturesDisabled));
+		this._register(createImageElements(resource, attachment.name, attachment.name, this.element, buffer, attachment.id, this.hoverService, ariaLabel, currentLanguageModelName, clickHandler, this.currentLanguageModel, attachment.omittedState));
 		this.element.ariaLabel = this.appendDeletionHint(ariaLabel);
 	}
 

--- a/src/vs/workbench/contrib/chat/test/browser/chatQuotaExceededPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatQuotaExceededPart.test.ts
@@ -33,7 +33,6 @@ function createMockEntitlementService(entitlement: ChatEntitlement): IChatEntitl
 		isInternal: false,
 		sku: undefined,
 		copilotTrackingId: undefined,
-		previewFeaturesDisabled: false,
 		clientByokEnabled: false,
 		hasByokModels: false,
 		onDidChangeSentiment: Event.None,

--- a/src/vs/workbench/contrib/chat/test/browser/chatQuotaNotification.integrationTest.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatQuotaNotification.integrationTest.ts
@@ -90,7 +90,6 @@ function createEntitlementService(opts?: {
 		isInternal: false,
 		sku: undefined,
 		copilotTrackingId: undefined,
-		previewFeaturesDisabled: false,
 		clientByokEnabled: false,
 		hasByokModels: false,
 		onDidChangeSentiment: Event.None,

--- a/src/vs/workbench/contrib/chat/test/browser/chatQuotaNotification.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatQuotaNotification.test.ts
@@ -70,7 +70,6 @@ function createMockEntitlementService(opts?: {
 		isInternal: false,
 		sku: undefined,
 		copilotTrackingId: undefined,
-		previewFeaturesDisabled: false,
 		clientByokEnabled: false,
 		hasByokModels: false,
 		onDidChangeSentiment: Event.None,

--- a/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatStatusDashboard.test.ts
@@ -67,7 +67,6 @@ function createEntitlementService(opts: {
 		markAnonymousRateLimited: () => { },
 		markSetupCompleted: () => { },
 		setForceHidden: () => { },
-		previewFeaturesDisabled: false,
 		clientByokEnabled: false,
 		hasByokModels: false,
 	} as IChatEntitlementService;

--- a/src/vs/workbench/contrib/imageCarousel/browser/imageCarousel.contribution.ts
+++ b/src/vs/workbench/contrib/imageCarousel/browser/imageCarousel.contribution.ts
@@ -47,7 +47,6 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			type: 'boolean',
 			default: true,
 			description: localize('imageCarousel.chat.enabled', "Controls whether clicking an image attachment in chat opens the Images Preview viewer."),
-			tags: ['experimental'],
 		},
 	}
 });

--- a/src/vs/workbench/services/chat/common/chatEntitlementService.ts
+++ b/src/vs/workbench/services/chat/common/chatEntitlementService.ts
@@ -206,7 +206,6 @@ export interface IChatEntitlementService {
 	readonly entitlement: ChatEntitlement;
 	readonly entitlementObs: IObservable<ChatEntitlement>;
 
-	readonly previewFeaturesDisabled: boolean;
 	readonly clientByokEnabled: boolean;
 	readonly hasByokModels: boolean;
 
@@ -511,10 +510,6 @@ export class ChatEntitlementService extends Disposable implements IChatEntitleme
 
 	get copilotTrackingId(): string | undefined {
 		return this.context?.value.state.copilotTrackingId;
-	}
-
-	get previewFeaturesDisabled(): boolean {
-		return this.contextKeyService.getContextKeyValue<boolean>('github.copilot.previewFeaturesDisabled') === true;
 	}
 
 	get clientByokEnabled(): boolean {

--- a/src/vs/workbench/test/common/workbenchTestServices.ts
+++ b/src/vs/workbench/test/common/workbenchTestServices.ts
@@ -821,7 +821,6 @@ export class TestChatEntitlementService implements IChatEntitlementService {
 	markSetupCompleted(): void { }
 	setForceHidden(_hidden: boolean): void { }
 
-	readonly previewFeaturesDisabled = false;
 	readonly clientByokEnabled = false;
 	readonly hasByokModels = false;
 }


### PR DESCRIPTION
ref https://github.blog/changelog/2026-07-01-copilot-vision-is-generally-available/

fix https://github.com/microsoft/vscode-internalbacklog/issues/7317

- removes experimental settings
- image carousel by default
- preview checks and language in regular images and tool results