### PR TITLE
Fix height calculation in MultiEditorTabsControl

### DIFF
--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -1797,11 +1797,10 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 
 		if (!this.visible) {
 			height = 0;
-		} else if (this.tabsAndActionsContainer?.offsetHeight) {
-			// Use the actual rendered height to correctly account for CSS-driven
-			// height changes: tab wrapping (multiple rows) and style-override mode
-			// (which reduces the tab height via `--editor-group-tab-height`).
-			height = this.tabsAndActionsContainer.offsetHeight;
+		} else if (this.tabsAndActionsContainer) {
+			// Use the rendered height to account for wrapping and CSS overrides.
+			const renderedHeight = this.tabsAndActionsContainer.offsetHeight;
+			height = renderedHeight || this.tabHeight;
 		} else {
 			height = this.tabHeight;
 		}

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -1797,9 +1797,10 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 
 		if (!this.visible) {
 			height = 0;
-		} else if (this.groupsView.partOptions.wrapTabs && this.tabsAndActionsContainer?.classList.contains('wrapping')) {
-			// Wrap: we need to ask `offsetHeight` to get
-			// the real height of the title area with wrapping.
+		} else if (this.tabsAndActionsContainer?.offsetHeight) {
+			// Use the actual rendered height to correctly account for CSS-driven
+			// height changes: tab wrapping (multiple rows) and style-override mode
+			// (which reduces the tab height via `--editor-group-tab-height`).
 			height = this.tabsAndActionsContainer.offsetHeight;
 		} else {
 			height = this.tabHeight;

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -1861,9 +1861,9 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		const newDimension = this.dimensions.used = new Dimension(dimensions.container.width, this.computeHeight());
 
 		// In case the height of the title control changed from before
-		// (currently only possible if wrapping changed on/off), we need
-		// to signal this to the outside via a `relayout` call so that
-		// e.g. the editor control can be adjusted accordingly.
+		// (e.g. wrapping changed on/off, or a CSS style-override changed the
+		// tab height), we need to signal this to the outside via a `relayout`
+		// call so that e.g. the editor control can be adjusted accordingly.
 		if (oldDimension && oldDimension.height !== newDimension.height) {
 			this.groupView.relayout();
 		}


### PR DESCRIPTION
Improve the height calculation for the MultiEditorTabsControl by utilizing the rendered height, which accounts for CSS-driven changes.Testing can be done by verifying the tab height adjustments.