### PR TITLE
Show the system-wide keybindings first-run notice in only one window

### DIFF
--- a/src/vs/platform/globalKeybindings/electron-main/globalKeybindingsMainService.ts
+++ b/src/vs/platform/globalKeybindings/electron-main/globalKeybindingsMainService.ts
@@ -8,7 +8,7 @@ import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { ILifecycleMainService } from '../../lifecycle/electron-main/lifecycleMainService.js';
 import { ILogService } from '../../log/common/log.js';
-import { INativeSystemWideKeybinding } from '../../native/common/native.js';
+import { INativeSystemWideKeybinding, INativeSystemWideKeybindingResult } from '../../native/common/native.js';
 import { INativeRunActionInWindowRequest } from '../../window/common/window.js';
 import { ICodeWindow } from '../../window/electron-main/window.js';
 import { IWindowsMainService } from '../../windows/electron-main/windows.js';
@@ -31,11 +31,12 @@ export interface IGlobalKeybindingsMainService {
 
 	/**
 	 * Replaces the set of system-wide (OS global) keybindings owned by the given window with the
-	 * provided set, reconciling the actual OS registrations. Returns the user settings labels (or
-	 * accelerators) that could not be registered, e.g. because the accelerator is already taken by
-	 * the OS or another application.
+	 * provided set, reconciling the actual OS registrations. The result reports the user settings
+	 * labels (or accelerators) that could not be registered (e.g. because the accelerator is already
+	 * taken by the OS or another application), and whether this window has been elected to show the
+	 * one-time first-run notice (see {@link INativeSystemWideKeybindingResult.showFirstRunNotice}).
 	 */
-	updateKeybindings(windowId: number, keybindings: readonly INativeSystemWideKeybinding[]): string[];
+	updateKeybindings(windowId: number, keybindings: readonly INativeSystemWideKeybinding[]): INativeSystemWideKeybindingResult;
 }
 
 export class GlobalKeybindingsMainService extends Disposable implements IGlobalKeybindingsMainService {
@@ -51,6 +52,25 @@ export class GlobalKeybindingsMainService extends Disposable implements IGlobalK
 	/** Accelerators that were desired but failed to register (e.g. already taken). */
 	private readonly failedAccelerators = new Set<string>();
 
+	/**
+	 * The window elected to show the one-time first-run notice in this app run, or `undefined` if no
+	 * window has been elected yet. The renderer contribution runs per window and would otherwise show
+	 * the notice in every window that registers a system-wide keybinding on startup; electing a single
+	 * window here (the first to register one) keeps it to a single dialog.
+	 *
+	 * This is app-run scoped and NOT persisted - the renderer persists whether the user has actually
+	 * acknowledged the notice and always gates on that, so a re-election can never show the notice
+	 * twice. Two invariants keep the single-election correct and must be preserved:
+	 * 1. `updateKeybindings` (which reads and sets this) must stay synchronous - no `await` between
+	 *    the read and the set - so concurrent renderer syncs can't both observe "not elected".
+	 * 2. `showFirstRunNotice` means "you were elected", not "you must show it"; the renderer still
+	 *    gates on its persisted acknowledgement before showing.
+	 *
+	 * If the elected window is destroyed before it acknowledges, the election is cleared so another
+	 * window can be elected this run (see {@link onDidDestroyWindow}).
+	 */
+	private electedFirstRunNoticeWindowId: number | undefined = undefined;
+
 	constructor(
 		private readonly globalShortcut: IGlobalShortcutRegistry,
 		@IWindowsMainService private readonly windowsMainService: IWindowsMainService,
@@ -64,7 +84,7 @@ export class GlobalKeybindingsMainService extends Disposable implements IGlobalK
 		this._register(toDisposable(() => this.unregisterAll()));
 	}
 
-	updateKeybindings(windowId: number, keybindings: readonly INativeSystemWideKeybinding[]): string[] {
+	updateKeybindings(windowId: number, keybindings: readonly INativeSystemWideKeybinding[]): INativeSystemWideKeybindingResult {
 		const perWindow = new Map<string, INativeSystemWideKeybinding>();
 		for (const keybinding of keybindings) {
 			if (!this.isValid(keybinding)) {
@@ -92,7 +112,17 @@ export class GlobalKeybindingsMainService extends Disposable implements IGlobalK
 				failed.push(keybinding.userSettingsLabel ?? keybinding.accelerator);
 			}
 		}
-		return failed;
+
+		// Elect the first window that registers a system-wide keybinding to show the one-time
+		// first-run notice, and suppress it in every other window. Running here (in the single
+		// process all windows sync through) avoids the notice popping up in each window at once.
+		let showFirstRunNotice = false;
+		if (perWindow.size > 0 && this.electedFirstRunNoticeWindowId === undefined) {
+			this.electedFirstRunNoticeWindowId = windowId;
+			showFirstRunNotice = true;
+		}
+
+		return { failed, showFirstRunNotice };
 	}
 
 	private isValid(keybinding: INativeSystemWideKeybinding): boolean {
@@ -200,6 +230,12 @@ export class GlobalKeybindingsMainService extends Disposable implements IGlobalK
 	}
 
 	private onDidDestroyWindow(window: ICodeWindow): void {
+		// If the window elected to show the first-run notice is gone before it acknowledged, release
+		// the election so another window can be elected this run. The renderer still gates on the
+		// persisted acknowledgement, so this can never show the notice more than once.
+		if (this.electedFirstRunNoticeWindowId === window.id) {
+			this.electedFirstRunNoticeWindowId = undefined;
+		}
 		if (this.registry.delete(window.id)) {
 			this.reconcile();
 		}

--- a/src/vs/platform/globalKeybindings/test/electron-main/globalKeybindingsMainService.test.ts
+++ b/src/vs/platform/globalKeybindings/test/electron-main/globalKeybindingsMainService.test.ts
@@ -129,7 +129,7 @@ suite('GlobalKeybindingsMainService', () => {
 
 	test('registers desired accelerators and reports no failures', () => {
 		const { service, shortcut } = createService();
-		const failed = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a'), binding('Control+Cmd+B', 'b')]);
+		const { failed } = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a'), binding('Control+Cmd+B', 'b')]);
 
 		assert.deepStrictEqual(failed, []);
 		assert.deepStrictEqual([...shortcut.registered.keys()].sort(), ['Control+Cmd+A', 'Control+Cmd+B']);
@@ -149,19 +149,19 @@ suite('GlobalKeybindingsMainService', () => {
 		shortcut.failFor.add('Control+Cmd+A');
 		const { service } = createService(shortcut);
 
-		const failed = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a', undefined, 'ctrl+cmd+a')]);
+		const { failed } = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a', undefined, 'ctrl+cmd+a')]);
 		assert.deepStrictEqual(failed, ['ctrl+cmd+a']);
 
 		// Now the accelerator becomes available; a re-sync should register it.
 		shortcut.failFor.delete('Control+Cmd+A');
-		const failedAgain = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a', undefined, 'ctrl+cmd+a')]);
+		const { failed: failedAgain } = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a', undefined, 'ctrl+cmd+a')]);
 		assert.deepStrictEqual(failedAgain, []);
 		assert.ok(shortcut.isRegistered('Control+Cmd+A'));
 	});
 
 	test('deduplicates accelerators within a single window payload', () => {
 		const { service, shortcut } = createService();
-		const failed = service.updateKeybindings(1, [binding('Control+Cmd+A', 'first'), binding('Control+Cmd+A', 'second')]);
+		const { failed } = service.updateKeybindings(1, [binding('Control+Cmd+A', 'first'), binding('Control+Cmd+A', 'second')]);
 
 		assert.deepStrictEqual(failed, []);
 		assert.strictEqual(shortcut.registered.size, 1);
@@ -248,5 +248,66 @@ suite('GlobalKeybindingsMainService', () => {
 
 		lifecycle.shutdown();
 		assert.strictEqual(shortcut.registered.size, 0);
+	});
+
+	test('elects only the first window that registers a keybinding to show the first-run notice', () => {
+		const { service } = createService();
+
+		// First non-empty registration is elected; every subsequent one (same or other window) is not.
+		const first = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a')]);
+		const secondSameWindow = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a'), binding('Control+Cmd+B', 'b')]);
+		const otherWindow = service.updateKeybindings(2, [binding('Control+Cmd+C', 'c')]);
+
+		assert.deepStrictEqual(
+			[first.showFirstRunNotice, secondSameWindow.showFirstRunNotice, otherWindow.showFirstRunNotice],
+			[true, false, false]
+		);
+	});
+
+	test('does not elect a window when the payload has no valid keybindings', () => {
+		const { service } = createService();
+
+		// An empty payload must not consume the election, so a later real registration still shows the notice.
+		const empty = service.updateKeybindings(1, []);
+		const firstReal = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a')]);
+
+		assert.deepStrictEqual(
+			[empty.showFirstRunNotice, firstReal.showFirstRunNotice],
+			[false, true]
+		);
+	});
+
+	test('re-elects another window when the elected window is destroyed before acknowledging', () => {
+		const { service, windows } = createService();
+		const window1 = windows.addWindow(1);
+		windows.addWindow(2);
+
+		// Window 1 is elected. Before it can acknowledge, it is closed - window 2 should then be
+		// eligible to show the notice on its next sync (the renderer still gates on persisted ack).
+		const elected = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a')]);
+		windows.destroyWindow(window1);
+		const reElected = service.updateKeybindings(2, [binding('Control+Cmd+B', 'b')]);
+
+		assert.deepStrictEqual(
+			[elected.showFirstRunNotice, reElected.showFirstRunNotice],
+			[true, true]
+		);
+	});
+
+	test('does not re-elect when a non-elected window is destroyed', () => {
+		const { service, windows } = createService();
+		windows.addWindow(1);
+		const window2 = windows.addWindow(2);
+
+		// Window 1 is elected; closing the unrelated window 2 must not release the election.
+		const elected = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a')]);
+		service.updateKeybindings(2, [binding('Control+Cmd+B', 'b')]);
+		windows.destroyWindow(window2);
+		const afterOtherClosed = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a'), binding('Control+Cmd+C', 'c')]);
+
+		assert.deepStrictEqual(
+			[elected.showFirstRunNotice, afterOtherClosed.showFirstRunNotice],
+			[true, false]
+		);
 	});
 });

--- a/src/vs/platform/native/common/native.ts
+++ b/src/vs/platform/native/common/native.ts
@@ -119,6 +119,13 @@ export interface INativeSystemWideKeybindingResult {
 	 * accelerator is already taken by the OS or another application.
 	 */
 	readonly failed: string[];
+
+	/**
+	 * Whether this window has been elected to show the one-time first-run notice. The main process
+	 * hands this to exactly one window per app run (the first to register a system-wide keybinding)
+	 * so that, when several windows register on startup, the notice is not shown by every window.
+	 */
+	readonly showFirstRunNotice: boolean;
 }
 
 export interface ICommonNativeHostService {

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -328,10 +328,9 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 
 	async syncSystemWideKeybindings(windowId: number | undefined, keybindings: INativeSystemWideKeybinding[]): Promise<INativeSystemWideKeybindingResult> {
 		if (typeof windowId !== 'number') {
-			return { failed: [] };
+			return { failed: [], showFirstRunNotice: false };
 		}
-		const failed = this.globalKeybindingsMainService.updateKeybindings(windowId, keybindings);
-		return { failed };
+		return this.globalKeybindingsMainService.updateKeybindings(windowId, keybindings);
 	}
 
 	async isFullScreen(windowId: number | undefined, options?: INativeHostOptions): Promise<boolean> {

--- a/src/vs/workbench/contrib/keybindings/electron-browser/systemWideKeybindings.contribution.ts
+++ b/src/vs/workbench/contrib/keybindings/electron-browser/systemWideKeybindings.contribution.ts
@@ -104,9 +104,6 @@ export class SystemWideKeybindingsContribution extends Disposable implements IWo
 	/** User settings labels whose ignored `when` clause we already warned about. */
 	private readonly warnedWhenLabels = new Set<string>();
 
-	/** Guards against showing the one-time notice more than once concurrently. */
-	private noticeInFlight = false;
-
 	constructor(
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@INativeHostService private readonly nativeHostService: INativeHostService,
@@ -140,23 +137,25 @@ export class SystemWideKeybindingsContribution extends Disposable implements IWo
 			return;
 		}
 
-		// Show a one-time heads-up before the very first registration so the user is aware the combo
-		// is captured globally (fires while unfocused). Informational only - the feature stays on.
-		if (!this.storageService.getBoolean(ACKNOWLEDGED_STORAGE_KEY, StorageScope.APPLICATION, false)) {
-			if (this.noticeInFlight) {
-				return;
-			}
-			this.noticeInFlight = true;
-			try {
-				await this.notifyFirstRun(candidates);
-			} finally {
-				this.noticeInFlight = false;
-			}
-			this.storageService.store(ACKNOWLEDGED_STORAGE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+		this.warnAboutIgnoredWhenClauses(candidates);
+		const showFirstRunNotice = await this.pushToMainProcess(candidates);
+
+		// The main process elects a single window per app run to show the one-time notice, so it
+		// appears once rather than in every window that registers a system-wide keybinding on
+		// startup. We still gate on the persisted acknowledgement so it is never shown again once
+		// the user has seen it.
+		if (showFirstRunNotice) {
+			await this.showFirstRunNoticeIfNeeded(candidates);
+		}
+	}
+
+	private async showFirstRunNoticeIfNeeded(candidates: readonly ISystemWideKeybindingCandidate[]): Promise<void> {
+		if (this.storageService.getBoolean(ACKNOWLEDGED_STORAGE_KEY, StorageScope.APPLICATION, false)) {
+			return; // already acknowledged in this or a previous session
 		}
 
-		this.warnAboutIgnoredWhenClauses(candidates);
-		await this.pushToMainProcess(candidates);
+		await this.notifyFirstRun(candidates);
+		this.storageService.store(ACKNOWLEDGED_STORAGE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
 	}
 
 	private collectCandidates(): ISystemWideKeybindingCandidate[] {
@@ -189,7 +188,7 @@ export class SystemWideKeybindingsContribution extends Disposable implements IWo
 		}
 	}
 
-	private async pushToMainProcess(candidates: readonly ISystemWideKeybindingCandidate[]): Promise<void> {
+	private async pushToMainProcess(candidates: readonly ISystemWideKeybindingCandidate[]): Promise<boolean> {
 		const payload: INativeSystemWideKeybinding[] = candidates.map(candidate => ({
 			accelerator: candidate.accelerator,
 			commandId: candidate.commandId,
@@ -197,16 +196,14 @@ export class SystemWideKeybindingsContribution extends Disposable implements IWo
 			userSettingsLabel: candidate.userSettingsLabel,
 		}));
 
-		let failed: string[];
 		try {
 			const result = await this.nativeHostService.syncSystemWideKeybindings(payload);
-			failed = result.failed;
+			this.reportFailures(result.failed);
+			return result.showFirstRunNotice;
 		} catch (error) {
 			this.logService.error('[SystemWideKeybindings] failed to sync system-wide keybindings with the main process', error);
-			return;
+			return false;
 		}
-
-		this.reportFailures(failed);
 	}
 
 	private reportFailures(failed: string[]): void {

--- a/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
@@ -105,7 +105,7 @@ export class TestNativeHostService implements INativeHostService {
 
 	async openAgentsWindow(_options?: { folderUri?: UriComponents; sessionResource?: UriComponents }): Promise<void> { }
 
-	async syncSystemWideKeybindings(_keybindings: INativeSystemWideKeybinding[]): Promise<INativeSystemWideKeybindingResult> { return { failed: [] }; }
+	async syncSystemWideKeybindings(_keybindings: INativeSystemWideKeybinding[]): Promise<INativeSystemWideKeybindingResult> { return { failed: [], showFirstRunNotice: false }; }
 
 	async toggleFullScreen(): Promise<void> { }
 	async isMaximized(): Promise<boolean> { return true; }


### PR DESCRIPTION
## What

Follow-up to #323871 (system-wide / OS-global keybindings).

Fixes a bug where the one-time **"I Understand"** first-run notice for system-wide keybindings was shown in **every open window** (a user reported seeing it in all 6 of their windows).

### Why it happened

The `SystemWideKeybindingsContribution` runs once per window. On startup every window syncs its keybindings to the main process ~200ms after `AfterRestored`, and each one reads the shared, `APPLICATION`-scoped `systemWideKeybindings.acknowledged` flag as `false` *before* any window has had a chance to persist it as `true`. So all N windows independently decided to show the dialog. The pre-existing `noticeInFlight` guard only dedups within a single window, so it couldn't help across windows.

### The fix — elect a single window in the main process

The main-process singleton `GlobalKeybindingsMainService` is the one place all windows already sync through, so it's the natural coordination point:

- `updateKeybindings` now returns `INativeSystemWideKeybindingResult` (`{ failed, showFirstRunNotice }`) instead of just `failed`.
- It elects **exactly one window per app run** — the first to register a system-wide keybinding — by handing back `showFirstRunNotice: true` to that window and `false` to everyone else. This is race-free because the main process is single-threaded and the election read+set is fully synchronous (no `await` in the path).
- The renderer keeps the persisted `acknowledged` gate and the same styled dialog: it shows the notice only when `showFirstRunNotice && !acknowledged`, then persists. So the notice appears **at most once per app run** and **never again once acknowledged**.
- If the elected window is destroyed before the user acknowledges, the election is released so another window can show the notice in the same run (tracked by window id, cleared in `onDidDestroyWindow`).
- The now-redundant per-window `noticeInFlight` guard is removed — its concurrency-dedup role is subsumed by the single-window election.

## Files

- `platform/globalKeybindings/electron-main/globalKeybindingsMainService.ts` — election flag (by window id) + new return shape + release-on-destroy.
- `platform/native/common/native.ts` — add `showFirstRunNotice` to `INativeSystemWideKeybindingResult`.
- `platform/native/electron-main/nativeHostMainService.ts` — return the full result object.
- `workbench/contrib/keybindings/electron-browser/systemWideKeybindings.contribution.ts` — consume `showFirstRunNotice`; drop `noticeInFlight`.
- Tests: `globalKeybindingsMainService.test.ts` (4 election/re-election tests + destructure `.failed`); `workbenchTestServices.ts` stub updated.

## Testing

- `npm run typecheck-client` — clean on all touched files.
- ESLint + layer-boundary checker — clean.
- Unit tests — `globalKeybindingsMainService.test.ts` (16) and `systemWideKeybindings.test.ts` (3) all pass, including new coverage for: only the first window is elected; empty payloads don't consume the election; re-election after the elected window is destroyed; and no re-election when an unrelated window closes.

## Notes for reviewers

The main process owns *concurrency coordination* (which single window may show the notice this run); the renderer keeps *persistence* (whether the user has acknowledged). The two compose so the dialog shows at most once and never after acknowledgment. The change was reviewed by code-review and rubber-duck subagents — no blocking issues.