### PR TITLE
Reopen bulk-closed editors together

### DIFF
--- a/src/vs/workbench/services/history/browser/historyService.ts
+++ b/src/vs/workbench/services/history/browser/historyService.ts
@@ -22,7 +22,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { EditorServiceImpl } from '../../../browser/parts/editor/editor.js';
 import { IWorkbenchLayoutService } from '../../layout/browser/layoutService.js';
 import { IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
-import { coalesce, remove } from '../../../../base/common/arrays.js';
+import { coalesce } from '../../../../base/common/arrays.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { addDisposableListener, EventType, EventHelper, WindowIdleValue } from '../../../../base/browser/dom.js';
 import { IWorkspacesService } from '../../../../platform/workspaces/common/workspaces.js';
@@ -48,6 +48,13 @@ interface IRecentlyClosedEditor {
 
 	readonly index: number;
 	readonly sticky: boolean;
+
+	/**
+	 * Identifies the batch of editors that were closed together (e.g. via
+	 * "Close All Editors" or "Close Others"). Editors sharing the same batch
+	 * identifier are reopened together by "Reopen Closed Editor".
+	 */
+	readonly batchId: number;
 }
 
 export class HistoryService extends Disposable implements IHistoryService {
@@ -659,6 +666,9 @@ export class HistoryService extends Disposable implements IHistoryService {
 	private recentlyClosedEditors: IRecentlyClosedEditor[] = [];
 	private ignoreEditorCloseEvent = false;
 
+	private recentlyClosedEditorsBatchId = 0;
+	private recentlyClosedEditorsBatchScheduled = false;
+
 	private handleEditorCloseEventInReopen(event: IEditorCloseEvent): void {
 		if (this.ignoreEditorCloseEvent) {
 			return; // blocked
@@ -696,7 +706,8 @@ export class HistoryService extends Disposable implements IHistoryService {
 			resource: EditorResourceAccessor.getOriginalUri(editor),
 			associatedResources,
 			index: event.index,
-			sticky: event.sticky
+			sticky: event.sticky,
+			batchId: this.currentRecentlyClosedEditorsBatchId()
 		});
 
 		// Bounding
@@ -708,13 +719,29 @@ export class HistoryService extends Disposable implements IHistoryService {
 		this.canReopenClosedEditorContextKey.set(true);
 	}
 
+	private currentRecentlyClosedEditorsBatchId(): number {
+
+		// All editors that are closed within the same synchronous turn
+		// (e.g. "Close All Editors" or "Close Others") share the same batch
+		// identifier so that they are reopened together. We open a new batch
+		// on the first close event and reset it on the next microtask, after
+		// all synchronously fired close events have been handled.
+		if (!this.recentlyClosedEditorsBatchScheduled) {
+			this.recentlyClosedEditorsBatchScheduled = true;
+			this.recentlyClosedEditorsBatchId++;
+			queueMicrotask(() => this.recentlyClosedEditorsBatchScheduled = false);
+		}
+
+		return this.recentlyClosedEditorsBatchId;
+	}
+
 	async reopenLastClosedEditor(): Promise<void> {
 
-		// Open editor if we have one
-		const lastClosedEditor = this.recentlyClosedEditors.pop();
+		// Reopen the last batch of editors that were closed together
+		const lastClosedEditors = this.takeLastClosedEditorsBatch();
 		let reopenClosedEditorPromise: Promise<void> | undefined = undefined;
-		if (lastClosedEditor) {
-			reopenClosedEditorPromise = this.doReopenLastClosedEditor(lastClosedEditor);
+		if (lastClosedEditors.length) {
+			reopenClosedEditorPromise = this.doReopenLastClosedEditors(lastClosedEditors);
 		}
 
 		// Update context
@@ -723,7 +750,44 @@ export class HistoryService extends Disposable implements IHistoryService {
 		return reopenClosedEditorPromise;
 	}
 
-	private async doReopenLastClosedEditor(lastClosedEditor: IRecentlyClosedEditor): Promise<void> {
+	private takeLastClosedEditorsBatch(): IRecentlyClosedEditor[] {
+		const lastClosedEditor = this.recentlyClosedEditors.at(-1);
+		if (!lastClosedEditor) {
+			return [];
+		}
+
+		// Collect all trailing editors that belong to the same batch. They are
+		// contiguous at the end of the list because editors are appended in the
+		// order they are closed.
+		const batch: IRecentlyClosedEditor[] = [];
+		while (this.recentlyClosedEditors.length && this.recentlyClosedEditors[this.recentlyClosedEditors.length - 1].batchId === lastClosedEditor.batchId) {
+			batch.unshift(this.recentlyClosedEditors.pop()!);
+		}
+
+		return batch;
+	}
+
+	private async doReopenLastClosedEditors(lastClosedEditors: IRecentlyClosedEditor[]): Promise<void> {
+
+		// Reopen all editors of the batch in the order they were originally closed
+		let anyReopened = false;
+		for (const lastClosedEditor of lastClosedEditors) {
+			const editorPane = await this.doReopenLastClosedEditor(lastClosedEditor);
+			if (editorPane) {
+				anyReopened = true;
+			}
+		}
+
+		// Fix for https://github.com/microsoft/vscode/issues/67882
+		// If none of the editors in the batch could be reopened, make sure to
+		// try the previous batch. The failing editors have already been removed
+		// from the list of recently closed editors to prevent endless loops.
+		if (!anyReopened && this.recentlyClosedEditors.length) {
+			return this.reopenLastClosedEditor();
+		}
+	}
+
+	private async doReopenLastClosedEditor(lastClosedEditor: IRecentlyClosedEditor): Promise<IEditorPane | undefined> {
 		const options: IEditorOptions = { pinned: true, sticky: lastClosedEditor.sticky, index: lastClosedEditor.index, ignoreError: true };
 
 		// Special sticky handling: remove the index property from options
@@ -760,18 +824,7 @@ export class HistoryService extends Disposable implements IHistoryService {
 			}
 		}
 
-		// If no editor was opened, try with the next one
-		if (!editorPane) {
-
-			// Fix for https://github.com/microsoft/vscode/issues/67882
-			// If opening of the editor fails, make sure to try the next one
-			// but make sure to remove this one from the list to prevent
-			// endless loops.
-			remove(this.recentlyClosedEditors, lastClosedEditor);
-
-			// Try with next one
-			this.reopenLastClosedEditor();
-		}
+		return editorPane;
 	}
 
 	private removeFromRecentlyClosedEditors(arg1: EditorInput | FileChangesEvent | FileOperationEvent): void {

--- a/src/vs/workbench/services/history/test/browser/historyService.test.ts
+++ b/src/vs/workbench/services/history/test/browser/historyService.test.ts
@@ -652,6 +652,32 @@ suite('HistoryService', function () {
 		return workbenchTeardown(instantiationService);
 	});
 
+	test('reopen closed editors as a batch when closed together', async function () {
+		const [part, historyService, editorService, , instantiationService] = await createServices();
+
+		const resource1 = toResource.call(this, '/path/one.txt');
+		const resource2 = toResource.call(this, '/path/two.txt');
+		const resource3 = toResource.call(this, '/path/three.txt');
+
+		await editorService.openEditor({ resource: resource1, options: { pinned: true } });
+		await editorService.openEditor({ resource: resource2, options: { pinned: true } });
+		await editorService.openEditor({ resource: resource3, options: { pinned: true } });
+
+		assert.strictEqual(part.activeGroup.count, 3);
+
+		// Bulk close: all editors closed together should reopen together
+		await part.activeGroup.closeAllEditors();
+		assert.strictEqual(part.activeGroup.count, 0);
+
+		await historyService.reopenLastClosedEditor();
+
+		assert.strictEqual(part.activeGroup.count, 3);
+		const reopened = part.activeGroup.editors.map(editor => editor.resource?.toString()).sort();
+		assert.deepStrictEqual(reopened, [resource1, resource2, resource3].map(resource => resource.toString()).sort());
+
+		return workbenchTeardown(instantiationService);
+	});
+
 	test('getHistory', async () => {
 
 		class TestFileEditorInputWithUntyped extends TestFileEditorInput {


### PR DESCRIPTION
When `Close All Editors`, `Close Others`, or a similar action closes many editors at once, **Reopen Closed Editor** now reopens all of them together as a single batch — instead of one editor per invocation.

## How it works

In `historyService.ts` (Reopen Closed Editor region):

- Each recently-closed editor is tagged with a `batchId`. A new batch is opened on the first `onDidCloseEditor` of a synchronous turn and reset on the next microtask, so editors closed together in one operation share a batch id, while editors closed via separate user gestures get distinct ids. Multi-group `Close All Editors` (chained via microtasks) is also grouped correctly.
- `reopenLastClosedEditor()` now pops and reopens the whole trailing batch in original close order, preserving each editor's index and sticky state. If none of the batch can be reopened it falls back to the previous batch (preserving the #67882 behavior).

Single-editor closes remain a batch of one, so that behavior is unchanged.

## Tests

Added `reopen closed editors as a batch when closed together`: opens 3 editors, closes them all, then reopens and asserts all 3 are restored. Existing + new tests pass, typecheck and ESLint clean.