### PR TITLE
Fix pixel spinner stuck paused when created detached

### DIFF
--- a/src/vs/base/browser/ui/pixelSpinner/pixelSpinner.ts
+++ b/src/vs/base/browser/ui/pixelSpinner/pixelSpinner.ts
@@ -60,6 +60,12 @@ const PAUSED_CLASS = 'monaco-pixel-spinner-paused';
 const observersByWindow = new Map<CodeWindow, IntersectionObserver>();
 let unregisterWindowListener: IDisposable | undefined;
 
+// Tracks spinners that have been connected to the DOM at least once, so we can
+// tell a spinner that is not yet inserted (keep observing — it may be appended
+// later) apart from one that was removed (stop observing to avoid leaking a
+// strong reference to a detached element).
+const everConnected = new WeakSet<HTMLElement>();
+
 function getObserverFor(targetWindow: CodeWindow): IntersectionObserver | undefined {
 	if (typeof targetWindow.IntersectionObserver !== 'function') {
 		return undefined;
@@ -70,9 +76,18 @@ function getObserverFor(targetWindow: CodeWindow): IntersectionObserver | undefi
 			for (const entry of entries) {
 				const target = entry.target as HTMLElement;
 				if (!target.isConnected) {
-					observer!.unobserve(target);
+					// A spinner is created detached and observed before it is
+					// appended to the DOM; the observer's initial callback can
+					// arrive while it is still detached. Only stop observing
+					// once it has been connected and is now removed, otherwise
+					// keep observing so it unpauses when it is inserted.
+					if (everConnected.has(target)) {
+						observer!.unobserve(target);
+						everConnected.delete(target);
+					}
 					continue;
 				}
+				everConnected.add(target);
 				target.classList.toggle(PAUSED_CLASS, !entry.isIntersecting);
 			}
 		});


### PR DESCRIPTION
Fixes #324018

## Problem

The in-progress pixel spinner in the sessions list sometimes never animates and stays stuck with the `monaco-pixel-spinner-paused` class — reproducibly when creating a new session.

## Root cause

The pixel spinner is created **paused** and relies on a per-window `IntersectionObserver` to unpause it once it is on screen. However `SessionStatusIcon` creates the spinner **detached** (`createPixelSpinner(undefined, …)`) and appends it to the DOM a moment later.

An `IntersectionObserver` always delivers an **initial callback** for every observed target. If that callback arrives while the element is still detached, the old code hit the `!target.isConnected` branch and called `observer.unobserve(target)` **permanently**. Once the spinner was inserted into the list it was no longer being observed, so it never got the class removed. When the append happened to win the race (e.g. re-renders of existing sessions), it worked — hence "works sometimes".

## Fix

The `unobserve` cleanup exists to avoid leaking references to spinners that get **removed** from the DOM (e.g. the outgoing icons during a cross-fade swap). A `WeakSet` (`everConnected`) now lets the observer distinguish the two cases:

- **Detached but never connected** → keep observing (it will unpause when appended).
- **Was connected, now removed** → unobserve and clean up, as before.