### PR TITLE
sessions: tweak session files widget in changes view

### DIFF
--- a/.github/instructions/best-practices.instructions.md
+++ b/.github/instructions/best-practices.instructions.md
@@ -24,6 +24,10 @@ applyTo: src/vs/**
 - Don't hardcode URI scheme strings like `'file'`, `'untitled'`, or `'vscode-remote'`. Use the `Schemas` constants from `vs/base/common/network.ts` (e.g. `Schemas.file`, `Schemas.untitled`, `Schemas.vscodeRemote`).
 - Don't compare URIs with `===` or `uri.toString()`. Use the comparison utilities from `vs/base/common/resources.ts`: `isEqual` for equality, `isEqualOrParent` for containment, and `getComparisonKey` when a URI is used as a map/set key. These handle path-case sensitivity and fragment/authority correctly. When you need explicit control over case sensitivity, use an `ExtUri` instance (`extUri`, `extUriIgnorePathCase`, or `extUriBiasedIgnorePathCase`) instead of the bound helpers.
 
+## Resource Labels
+
+- Don't set `{ supportIcons: true }` when creating a `ResourceLabel` (`vs/workbench/browser/labels.ts`). This option makes the label parse `$(codicon)` syntax in the name/description and is only needed when you want to render a codicon inline with the resource text. By default (without it), the label shows the proper file icon for the resource, which is what we almost always want.
+
 ## Styling
 
 - Avoid `getComputedStyle`. If a style value is needed in both CSS and TypeScript, prefer hardcoding the value in TypeScript and setting it directly on the DOM element (e.g. `element.style.width = '100px'`), or set a CSS custom property via `element.style.setProperty('--my-var', value)` when the value is needed across multiple CSS rules.

--- a/src/vs/sessions/contrib/changes/browser/media/sessionFilesWidget.css
+++ b/src/vs/sessions/contrib/changes/browser/media/sessionFilesWidget.css
@@ -99,21 +99,6 @@
 	white-space: nowrap;
 }
 
-/* File count badge in the header */
-.session-files-widget-count {
-	flex-shrink: 0;
-	margin-left: auto;
-	padding-right: 8px;
-	font-size: var(--vscode-agents-fontSize-body2);
-	opacity: 0.7;
-}
-
-.session-files-widget-header:hover .session-files-widget-count,
-.session-files-widget-header:focus-visible .session-files-widget-count,
-.session-files-widget-header.collapsed .session-files-widget-count {
-	visibility: hidden;
-}
-
 /* Body - file list */
 .session-files-widget-body {
 	flex: 1;

--- a/src/vs/sessions/contrib/changes/browser/media/sessionFilesWidget.css
+++ b/src/vs/sessions/contrib/changes/browser/media/sessionFilesWidget.css
@@ -159,3 +159,40 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
+
+/* Decoration badge (A/M/D) */
+.session-files-widget-decoration-badge {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 16px;
+	min-width: 16px;
+	font-size: var(--vscode-agents-fontSize-body2);
+	font-weight: var(--vscode-agents-fontWeight-semiBold);
+	margin-right: 2px;
+	opacity: 0.9;
+}
+
+.session-files-widget-decoration-badge.added {
+	color: var(--vscode-gitDecoration-addedResourceForeground);
+}
+
+.session-files-widget-decoration-badge.modified {
+	color: var(--vscode-gitDecoration-modifiedResourceForeground);
+}
+
+.session-files-widget-decoration-badge.deleted {
+	color: var(--vscode-gitDecoration-deletedResourceForeground);
+}
+
+/* Inline action bar (Open File), shown on hover/focus/select — mirrors the changes view */
+.session-files-widget .monaco-list-row .chat-collapsible-list-action-bar {
+	padding-left: 6px;
+	display: none;
+}
+
+.session-files-widget .monaco-list-row:hover .chat-collapsible-list-action-bar:not(.has-no-actions),
+.session-files-widget .monaco-list-row.focused .chat-collapsible-list-action-bar:not(.has-no-actions),
+.session-files-widget .monaco-list-row.selected .chat-collapsible-list-action-bar:not(.has-no-actions) {
+	display: inherit;
+}

--- a/src/vs/sessions/contrib/changes/browser/sessionFilesWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionFilesWidget.ts
@@ -9,14 +9,16 @@ import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hover
 import { IListRenderer, IListVirtualDelegate } from '../../../../base/browser/ui/list/list.js';
 import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
 import { Codicon } from '../../../../base/common/codicons.js';
+import { toAction } from '../../../../base/common/actions.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun, IObservable } from '../../../../base/common/observable.js';
-import { basename, dirname } from '../../../../base/common/resources.js';
+import { basename } from '../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
-import { FileKind } from '../../../../platform/files/common/files.js';
+import { WorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
+import { FileKind, IFileService } from '../../../../platform/files/common/files.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
@@ -46,6 +48,8 @@ class SessionFileListDelegate implements IListVirtualDelegate<ISessionFile> {
 
 interface ISessionFileTemplateData {
 	readonly label: IResourceLabel;
+	readonly decorationBadge: HTMLElement;
+	readonly toolbar: WorkbenchToolBar;
 	readonly templateDisposables: DisposableStore;
 }
 
@@ -55,27 +59,59 @@ class SessionFileListRenderer implements IListRenderer<ISessionFile, ISessionFil
 
 	constructor(
 		private readonly _labels: ResourceLabels,
-		private readonly _labelService: ILabelService,
+		private readonly _onOpenFile: (file: ISessionFile) => void,
+		@ILabelService private readonly _labelService: ILabelService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) { }
 
 	renderTemplate(container: HTMLElement): ISessionFileTemplateData {
 		const templateDisposables = new DisposableStore();
 		const row = dom.append(container, $('.session-files-widget-file'));
-		const label = templateDisposables.add(this._labels.create(row, { supportIcons: true }));
-		return { label, templateDisposables };
+		const label = templateDisposables.add(this._labels.create(row));
+
+		const actionBarContainer = $('.chat-collapsible-list-action-bar');
+		const toolbar = templateDisposables.add(this._instantiationService.createInstance(WorkbenchToolBar, actionBarContainer, undefined));
+		label.element.appendChild(actionBarContainer);
+
+		const decorationBadge = dom.$('.session-files-widget-decoration-badge');
+		label.element.appendChild(decorationBadge);
+
+		return { label, decorationBadge, toolbar, templateDisposables };
 	}
 
 	renderElement(element: ISessionFile, _index: number, templateData: ISessionFileTemplateData): void {
-		const parent = dirname(element.uri);
 		templateData.label.setResource({
 			resource: element.uri,
 			name: basename(element.uri),
-			description: this._labelService.getUriLabel(parent, { noPrefix: true }),
 		}, {
 			fileKind: FileKind.FILE,
-			strikethrough: element.operation === SessionFileOperation.Deleted,
 			title: getSessionFileTitle(element, this._labelService),
 		});
+
+		const badge = templateData.decorationBadge;
+		badge.className = 'session-files-widget-decoration-badge';
+		switch (element.operation) {
+			case SessionFileOperation.Created:
+				badge.textContent = 'A';
+				badge.classList.add('added');
+				break;
+			case SessionFileOperation.Deleted:
+				badge.textContent = 'D';
+				badge.classList.add('deleted');
+				break;
+			case SessionFileOperation.Modified:
+			default:
+				badge.textContent = 'M';
+				badge.classList.add('modified');
+				break;
+		}
+
+		templateData.toolbar.setActions([toAction({
+			id: 'sessionFiles.openFile',
+			label: localize('sessionFiles.openFileAction', "Open File"),
+			class: ThemeIcon.asClassName(Codicon.goToFile),
+			run: () => this._onOpenFile(element),
+		})]);
 	}
 
 	disposeTemplate(templateData: ISessionFileTemplateData): void {
@@ -147,6 +183,7 @@ export class SessionFilesWidget extends Disposable {
 		@ILabelService private readonly _labelService: ILabelService,
 		@IEditorService private readonly _editorService: IEditorService,
 		@IHoverService private readonly _hoverService: IHoverService,
+		@IFileService private readonly _fileService: IFileService,
 	) {
 		super();
 		this._labels = this._register(this._instantiationService.createInstance(ResourceLabels, DEFAULT_LABELS_CONTAINER));
@@ -202,7 +239,7 @@ export class SessionFilesWidget extends Disposable {
 			'SessionFilesWidget',
 			listContainer,
 			new SessionFileListDelegate(),
-			[new SessionFileListRenderer(this._labels, this._labelService)],
+			[this._instantiationService.createInstance(SessionFileListRenderer, this._labels, (file: ISessionFile) => this._openFilePlain(file))],
 			{
 				multipleSelectionSupport: false,
 				openOnSingleClick: true,
@@ -324,8 +361,8 @@ export class SessionFilesWidget extends Disposable {
 
 	private async _openFile(file: ISessionFile, preserveFocus: boolean, pinned: boolean): Promise<void> {
 		// Created and deleted files open normally; modified files open a diff
-		// against their pre-session content when it is available.
-		if (file.operation === SessionFileOperation.Modified && file.originalUri) {
+		// against their pre-session content when it is available and non-empty.
+		if (file.operation === SessionFileOperation.Modified && file.originalUri && await this._hasContent(file.originalUri)) {
 			await this._editorService.openEditor({
 				original: { resource: file.originalUri },
 				modified: { resource: file.uri },
@@ -339,6 +376,20 @@ export class SessionFilesWidget extends Disposable {
 			resource: file.uri,
 			options: { preserveFocus, pinned },
 		}, ACTIVE_GROUP);
+	}
+
+	private async _hasContent(resource: URI): Promise<boolean> {
+		try {
+			const content = await this._fileService.readFile(resource);
+			return content.value.byteLength > 0;
+		} catch {
+			return false;
+		}
+	}
+
+	/** Open the file in a normal editor, ignoring the pre-session diff. */
+	private _openFilePlain(file: ISessionFile): void {
+		void this._editorService.openEditor({ resource: file.uri }, ACTIVE_GROUP);
 	}
 }
 

--- a/src/vs/sessions/contrib/changes/browser/sessionFilesWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionFilesWidget.ts
@@ -137,7 +137,6 @@ export class SessionFilesWidget extends Disposable {
 	private readonly _headerNode: HTMLElement;
 	private readonly _titleNode: HTMLElement;
 	private readonly _titleLabelNode: HTMLElement;
-	private readonly _countNode: HTMLElement;
 	private readonly _chevronNode: HTMLElement;
 	private readonly _bodyNode: HTMLElement;
 	private readonly _list: WorkbenchList<ISessionFile>;
@@ -196,7 +195,6 @@ export class SessionFilesWidget extends Disposable {
 		this._titleNode = dom.append(this._headerNode, $('.session-files-widget-title'));
 		this._titleLabelNode = dom.append(this._titleNode, $('.session-files-widget-title-label'));
 		this._titleLabelNode.textContent = localize('sessionFiles.label', "Session Files");
-		this._countNode = dom.append(this._titleNode, $('.session-files-widget-count'));
 		this._chevronNode = dom.append(this._headerNode, $('.group-chevron'));
 		this._chevronNode.classList.add(...ThemeIcon.asClassNameArray(Codicon.chevronDown));
 
@@ -279,17 +277,12 @@ export class SessionFilesWidget extends Disposable {
 			}
 
 			this._domNode.style.display = '';
-			this._renderHeader(files);
 			this._renderBody(files);
 
 			if (this._fileCount !== oldCount) {
 				this._onDidChangeHeight.fire();
 			}
 		});
-	}
-
-	private _renderHeader(files: readonly ISessionFile[]): void {
-		this._countNode.textContent = `${files.length}`;
 	}
 
 	/**

--- a/src/vs/sessions/contrib/changes/test/browser/sessionFilesWidget.fixture.ts
+++ b/src/vs/sessions/contrib/changes/test/browser/sessionFilesWidget.fixture.ts
@@ -6,7 +6,9 @@
 import { Event } from '../../../../../base/common/event.js';
 import { observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { mock } from '../../../../../base/test/common/mock.js';
+import { IFileContent, IFileService } from '../../../../../platform/files/common/files.js';
 import { IListService, ListService } from '../../../../../platform/list/browser/listService.js';
 import { IWorkspace, IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IDecorationsService } from '../../../../../workbench/services/decorations/common/decorations.js';
@@ -40,6 +42,14 @@ function renderWidget(ctx: ComponentFixtureContext, options?: { files?: readonly
 			reg.defineInstance(ITextFileService, new class extends mock<ITextFileService>() { override readonly untitled = new class extends mock<ITextFileService['untitled']>() { override readonly onDidChangeLabel = Event.None; }(); }());
 			reg.defineInstance(IWorkspaceContextService, new class extends mock<IWorkspaceContextService>() { override onDidChangeWorkspaceFolders = Event.None; override getWorkspace(): IWorkspace { return { id: '', folders: [], configuration: undefined }; } }());
 			reg.definePartialInstance(INotebookDocumentService, { getNotebook: () => undefined });
+			reg.defineInstance(IFileService, new class extends mock<IFileService>() {
+				override async readFile(resource: URI): Promise<IFileContent> {
+					return new class extends mock<IFileContent>() {
+						override readonly resource = resource;
+						override readonly value = VSBuffer.fromString('original content');
+					}();
+				}
+			}());
 			// Required by WorkbenchList (the files list).
 			reg.define(IListService, ListService);
 			registerWorkbenchServices(reg);


### PR DESCRIPTION
## What

Several tweaks to the session files widget in the Sessions window changes view:

- **File icons**: Create `ResourceLabels` without `{ supportIcons: true }` so the proper file icon is shown (that option is only for rendering inline codicons in the label text).
- **No path in description**: Removed the resource path from the file row description.
- **Smarter diff opening**: `_openFile` now only opens a diff editor for modified files when the original resource has non-empty content; otherwise it opens a normal editor.
- **Change decoration badges**: Files now show A/M/D decoration badges (added/modified/deleted) using the same `gitDecoration-*` color tokens as the changes view.
- **Removed strikethrough** rendering for deleted files.
- **Open File action**: Added an "Open File" action (`Codicon.goToFile`) to the row's inline toolbar, shown on hover/focus/selection, matching the look and behavior of the changes view items.

Also documented the `ResourceLabels` `supportIcons` guidance in `.github/instructions/best-practices.instructions.md`.

## Notes for reviewers

- The fixture (`sessionFilesWidget.fixture.ts`) now registers a mock `IFileService` since the widget depends on it.
- Typecheck (`typecheck-client`) and eslint both pass.