### PR TITLE
Make onboarding tours ready for experiment

### DIFF
--- a/src/vs/sessions/contrib/onboardingTours/browser/tours/newSessionTour.ts
+++ b/src/vs/sessions/contrib/onboardingTours/browser/tours/newSessionTour.ts
@@ -36,6 +36,21 @@ export const NEW_SESSION_TOUR_ID = 'sessions.onboarding.newSession';
  */
 export const NEW_SESSION_ONBOARDING_SEEN_KEY = NEW_SESSION_TOUR_ID;
 
+/**
+ * ExP treatment flag names for Tour 2's A/B experiment.
+ *
+ * - `behaviorFlag` — boolean: `true` shows the tour (treatment), `false` is control.
+ * - `assignmentContextIdFlag` — string: this tour's assignment-context identifier,
+ *   the key its scorecard groups on. Both arms MUST resolve it to the *same* value,
+ *   which MUST start with the reserved `onb-` prefix (see
+ *   `ONBOARDING_ASSIGNMENT_CONTEXT_PREFIX`). It is distinct from Tour 1's id so the
+ *   two tours report into separate scorecards.
+ */
+const NEW_SESSION_EXPERIMENT = {
+	behaviorFlag: 'onb.newSession.show',
+	assignmentContextIdFlag: 'onb.newSession.id',
+} as const;
+
 const newSessionPayload: ISpotlightPayload = {
 	steps: [
 		{
@@ -70,6 +85,7 @@ export function createNewSessionTour(signal: IObservable<boolean>): IOnboardingS
 		when: ContextKeyExpr.and(ChatContextKeys.enabled, EditorPartModalContext.toNegated()),
 		trigger: { kind: 'observable', signal },
 		priority: 100,
+		experiment: NEW_SESSION_EXPERIMENT,
 		presentation: {
 			kind: SPOTLIGHT_PRESENTATION_KIND,
 			payload: newSessionPayload,

--- a/src/vs/sessions/contrib/onboardingTours/browser/tours/newSessionViewTour.ts
+++ b/src/vs/sessions/contrib/onboardingTours/browser/tours/newSessionViewTour.ts
@@ -38,6 +38,21 @@ import { SessionHarnessPickerVisibleContext, SessionIsolationPickerVisibleContex
  */
 export const NEW_SESSION_VIEW_TOUR_ID = 'sessions.onboarding.newSessionView';
 
+/**
+ * ExP treatment flag names for Tour 1's A/B experiment.
+ *
+ * - `behaviorFlag` — boolean: `true` shows the tour (treatment), `false` is control.
+ * - `assignmentContextIdFlag` — string: this tour's assignment-context identifier,
+ *   the key its scorecard groups on. Both arms MUST resolve it to the *same* value,
+ *   which MUST start with the reserved `onb-` prefix (see
+ *   `ONBOARDING_ASSIGNMENT_CONTEXT_PREFIX`). It is distinct from Tour 2's id so the
+ *   two tours report into separate scorecards.
+ */
+const NEW_SESSION_VIEW_EXPERIMENT = {
+	behaviorFlag: 'onb.newSessionView.show',
+	assignmentContextIdFlag: 'onb.newSessionView.id',
+} as const;
+
 const newSessionViewPayload: ISpotlightPayload = {
 	steps: [
 		{
@@ -86,6 +101,7 @@ export function createNewSessionViewTour(signal: IObservable<boolean>): IOnboard
 		when: ContextKeyExpr.and(ChatContextKeys.enabled, EditorPartModalContext.toNegated()),
 		trigger: { kind: 'observable', signal },
 		priority: 100,
+		experiment: NEW_SESSION_VIEW_EXPERIMENT,
 		presentation: {
 			kind: SPOTLIGHT_PRESENTATION_KIND,
 			payload: newSessionViewPayload,

--- a/src/vs/workbench/contrib/onboarding/browser/onboarding.contribution.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/onboarding.contribution.ts
@@ -59,7 +59,7 @@ configurationRegistry.registerConfiguration({
 	properties: {
 		[ONBOARDING_ENABLED_CONFIG]: {
 			type: 'boolean',
-			default: false,
+			default: true,
 			description: localize('onboarding.enabled', "When enabled, onboarding tours and hints may appear automatically to highlight features. Disabling this does not affect tours you start manually.")
 		}
 	}


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce A/B experiment flags for the new session and new session view tours, enabling control over their visibility. Update the onboarding configuration to enable onboarding tours by default.

