### PR TITLE
chat: use comment icon for comment tools in thinking widget

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -1254,7 +1254,7 @@ export function stringOrMarkdownToString(value: StringOrMarkdown | undefined, co
  * Number of comment-body characters shown inline in the {@link addCommentReference}
  * pill before it is truncated with an ellipsis.
  */
-const ADD_COMMENT_PREVIEW_LENGTH = 20;
+const ADD_COMMENT_PREVIEW_LENGTH = 40;
 
 /**
  * Builds the inline preview of an `addComment` comment body: whitespace is
@@ -1290,7 +1290,7 @@ function isOneBasedRange(value: unknown): value is IRange {
 
 /**
  * Builds a rich, clickable reference for the agent host `addComment` feedback
- * tool call — a comment icon, the tool name, and the first
+ * tool call — the tool name and the first
  * {@link ADD_COMMENT_PREVIEW_LENGTH} characters of the comment body in quotes.
  * Clicking it runs {@link AgentFeedbackReviewCommandId.RevealAt} to open the
  * file and reveal the comment (agent feedback) in the editor.
@@ -1320,7 +1320,7 @@ function addCommentReference(tc: ToolCallState): IMarkdownString | undefined {
 	// link only needs the resource and range (both known here).
 	const commandArgs = encodeURIComponent(JSON.stringify([args.resourceUri, args.range]));
 	const link = `command:${AgentFeedbackReviewCommandId.RevealAt}?${commandArgs}`;
-	return new MarkdownString(`$(comment) [addComment "${preview}"](${link})`, {
+	return new MarkdownString(`[addComment "${preview}"](${link})`, {
 		isTrusted: { enabledCommands: [AgentFeedbackReviewCommandId.RevealAt] },
 		supportThemeIcons: true,
 	});

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
@@ -116,6 +116,10 @@ export function getToolInvocationIcon(toolId: string, registeredIcon?: ThemeIcon
 
 	const lowerToolId = toolId.toLowerCase();
 
+	if (lowerToolId.includes('comment')) {
+		return Codicon.comment;
+	}
+
 	if (
 		lowerToolId.includes('search') ||
 		lowerToolId.includes('grep') ||

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -813,7 +813,7 @@ suite('stateToProgressAdapter', () => {
 			return message;
 		}
 
-		test('renders comment icon, tool name, truncated quoted preview and a reveal command link', () => {
+		test('renders tool name, truncated quoted preview and a reveal command link', () => {
 			const tc = createToolCallState({ toolName: 'addComment', invocationMessage: 'Adding comment', toolInput: addCommentInput('This comment is quite long and should be truncated') });
 			const message = markdown(toolCallStateToInvocation(tc).invocationMessage);
 
@@ -824,7 +824,7 @@ suite('stateToProgressAdapter', () => {
 					isTrusted: message.isTrusted,
 				},
 				{
-					value: `$(comment) [addComment "This comment is quit…"](command:_agentFeedbackReview.revealAt?${encodeURIComponent(JSON.stringify(['file:///workspace/a.ts', commentRange]))})`,
+					value: `[addComment "This comment is quite long and should be…"](command:_agentFeedbackReview.revealAt?${encodeURIComponent(JSON.stringify(['file:///workspace/a.ts', commentRange]))})`,
 					supportThemeIcons: true,
 					isTrusted: { enabledCommands: ['_agentFeedbackReview.revealAt'] },
 				},

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatThinkingContentPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatThinkingContentPart.test.ts
@@ -160,6 +160,24 @@ suite('ChatThinkingContentPart', () => {
 		});
 	});
 
+	test('uses a comment icon for comment tools', () => {
+		assert.deepStrictEqual({
+			addComment: getToolInvocationIcon('addComment'),
+			listComments: getToolInvocationIcon('listComments'),
+			deleteComments: getToolInvocationIcon('deleteComments'),
+			resolveComments: getToolInvocationIcon('resolveComments'),
+			viewUnreviewedComments: getToolInvocationIcon('viewUnreviewedComments'),
+			prefixedComment: getToolInvocationIcon('mcp__host__addComment'),
+		}, {
+			addComment: Codicon.comment,
+			listComments: Codicon.comment,
+			deleteComments: Codicon.comment,
+			resolveComments: Codicon.comment,
+			viewUnreviewedComments: Codicon.comment,
+			prefixedComment: Codicon.comment,
+		});
+	});
+
 	suite('ThinkingDisplayMode.Collapsed', () => {
 		setup(() => {
 			mockConfigurationService.setUserConfiguration('chat.agent.thinkingStyle', ThinkingDisplayMode.Collapsed);


### PR DESCRIPTION
## What
Render the comment codicon as the `chat-thinking-icon` for comment tools (`addComment`, `listComments`, `deleteComments`, `resolveComments`, `viewUnreviewedComments`, including Claude-prefixed forms like `mcp__host__addComment`) instead of the generic `codicon-tool` icon.

Previously, the `chat-thinking-tool-wrapper` for these tools showed a generic tool icon while a redundant comment icon was also rendered inline inside the invocation message (e.g. `$(comment) addComment "PREFIX…"`). Now the thinking icon itself is the comment icon and the inline icon is removed from the message.

## Changes
- `getToolInvocationIcon` returns `Codicon.comment` for tool ids containing `comment` (placed before the search/list checks so `listComments` doesn't resolve to a search icon).
- Removed the leading `$(comment)` from the `addComment` invocation reference in `stateToProgressAdapter.ts`.
- Bumped `ADD_COMMENT_PREVIEW_LENGTH` from 20 to 40 characters.
- Updated unit tests accordingly.

## Notes for reviewers
The pre-commit hygiene hook and typecheck could not run in the worktree because `node_modules` was not installed (missing ambient `@types` / `event-stream`); changes are minimal edits to existing files.