### PR TITLE
Remove the system-wide keybindings first-run dialog

### DIFF
--- a/src/vs/platform/globalKeybindings/electron-main/globalKeybindingsMainService.ts
+++ b/src/vs/platform/globalKeybindings/electron-main/globalKeybindingsMainService.ts
@@ -8,7 +8,7 @@ import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { ILifecycleMainService } from '../../lifecycle/electron-main/lifecycleMainService.js';
 import { ILogService } from '../../log/common/log.js';
-import { INativeSystemWideKeybinding } from '../../native/common/native.js';
+import { INativeSystemWideKeybinding, INativeSystemWideKeybindingResult } from '../../native/common/native.js';
 import { INativeRunActionInWindowRequest } from '../../window/common/window.js';
 import { ICodeWindow } from '../../window/electron-main/window.js';
 import { IWindowsMainService } from '../../windows/electron-main/windows.js';
@@ -31,11 +31,11 @@ export interface IGlobalKeybindingsMainService {
 
 	/**
 	 * Replaces the set of system-wide (OS global) keybindings owned by the given window with the
-	 * provided set, reconciling the actual OS registrations. Returns the user settings labels (or
-	 * accelerators) that could not be registered, e.g. because the accelerator is already taken by
-	 * the OS or another application.
+	 * provided set, reconciling the actual OS registrations. The result reports the user settings
+	 * labels (or accelerators) that could not be registered (e.g. because the accelerator is already
+	 * taken by the OS or another application).
 	 */
-	updateKeybindings(windowId: number, keybindings: readonly INativeSystemWideKeybinding[]): string[];
+	updateKeybindings(windowId: number, keybindings: readonly INativeSystemWideKeybinding[]): INativeSystemWideKeybindingResult;
 }
 
 export class GlobalKeybindingsMainService extends Disposable implements IGlobalKeybindingsMainService {
@@ -64,7 +64,7 @@ export class GlobalKeybindingsMainService extends Disposable implements IGlobalK
 		this._register(toDisposable(() => this.unregisterAll()));
 	}
 
-	updateKeybindings(windowId: number, keybindings: readonly INativeSystemWideKeybinding[]): string[] {
+	updateKeybindings(windowId: number, keybindings: readonly INativeSystemWideKeybinding[]): INativeSystemWideKeybindingResult {
 		const perWindow = new Map<string, INativeSystemWideKeybinding>();
 		for (const keybinding of keybindings) {
 			if (!this.isValid(keybinding)) {
@@ -92,7 +92,8 @@ export class GlobalKeybindingsMainService extends Disposable implements IGlobalK
 				failed.push(keybinding.userSettingsLabel ?? keybinding.accelerator);
 			}
 		}
-		return failed;
+
+		return { failed };
 	}
 
 	private isValid(keybinding: INativeSystemWideKeybinding): boolean {

--- a/src/vs/platform/globalKeybindings/test/electron-main/globalKeybindingsMainService.test.ts
+++ b/src/vs/platform/globalKeybindings/test/electron-main/globalKeybindingsMainService.test.ts
@@ -129,7 +129,7 @@ suite('GlobalKeybindingsMainService', () => {
 
 	test('registers desired accelerators and reports no failures', () => {
 		const { service, shortcut } = createService();
-		const failed = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a'), binding('Control+Cmd+B', 'b')]);
+		const { failed } = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a'), binding('Control+Cmd+B', 'b')]);
 
 		assert.deepStrictEqual(failed, []);
 		assert.deepStrictEqual([...shortcut.registered.keys()].sort(), ['Control+Cmd+A', 'Control+Cmd+B']);
@@ -149,19 +149,19 @@ suite('GlobalKeybindingsMainService', () => {
 		shortcut.failFor.add('Control+Cmd+A');
 		const { service } = createService(shortcut);
 
-		const failed = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a', undefined, 'ctrl+cmd+a')]);
+		const { failed } = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a', undefined, 'ctrl+cmd+a')]);
 		assert.deepStrictEqual(failed, ['ctrl+cmd+a']);
 
 		// Now the accelerator becomes available; a re-sync should register it.
 		shortcut.failFor.delete('Control+Cmd+A');
-		const failedAgain = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a', undefined, 'ctrl+cmd+a')]);
+		const { failed: failedAgain } = service.updateKeybindings(1, [binding('Control+Cmd+A', 'a', undefined, 'ctrl+cmd+a')]);
 		assert.deepStrictEqual(failedAgain, []);
 		assert.ok(shortcut.isRegistered('Control+Cmd+A'));
 	});
 
 	test('deduplicates accelerators within a single window payload', () => {
 		const { service, shortcut } = createService();
-		const failed = service.updateKeybindings(1, [binding('Control+Cmd+A', 'first'), binding('Control+Cmd+A', 'second')]);
+		const { failed } = service.updateKeybindings(1, [binding('Control+Cmd+A', 'first'), binding('Control+Cmd+A', 'second')]);
 
 		assert.deepStrictEqual(failed, []);
 		assert.strictEqual(shortcut.registered.size, 1);

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -330,8 +330,7 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 		if (typeof windowId !== 'number') {
 			return { failed: [] };
 		}
-		const failed = this.globalKeybindingsMainService.updateKeybindings(windowId, keybindings);
-		return { failed };
+		return this.globalKeybindingsMainService.updateKeybindings(windowId, keybindings);
 	}
 
 	async isFullScreen(windowId: number | undefined, options?: INativeHostOptions): Promise<boolean> {

--- a/src/vs/workbench/contrib/keybindings/electron-browser/systemWideKeybindings.contribution.ts
+++ b/src/vs/workbench/contrib/keybindings/electron-browser/systemWideKeybindings.contribution.ts
@@ -7,21 +7,13 @@ import * as nls from '../../../../nls.js';
 import { RunOnceScheduler } from '../../../../base/common/async.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { equals } from '../../../../base/common/arrays.js';
-import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { ResolvedKeybindingItem } from '../../../../platform/keybinding/common/resolvedKeybindingItem.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { INativeHostService, INativeSystemWideKeybinding } from '../../../../platform/native/common/native.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
-import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
-
-/**
- * Persisted flag recording that the user has been shown the one-time heads-up explaining that their
- * `systemWide` keybindings are captured globally. Set once the notice has been acknowledged.
- */
-const ACKNOWLEDGED_STORAGE_KEY = 'systemWideKeybindings.acknowledged';
 
 export interface ISystemWideKeybindingCandidate {
 	readonly accelerator: string;
@@ -88,9 +80,8 @@ export function selectSystemWideKeybindings(items: readonly ResolvedKeybindingIt
 
 /**
  * Watches the resolved keybindings for entries opted into `systemWide` and mirrors them to the
- * main process (which owns Electron's `globalShortcut`). The mechanism is always active; a one-time
- * notice the first time such a keybinding is registered makes the user aware the combo is captured
- * globally.
+ * main process (which owns Electron's `globalShortcut`). The mechanism is always active for any
+ * user keybinding marked `systemWide`.
  */
 export class SystemWideKeybindingsContribution extends Disposable implements IWorkbenchContribution {
 
@@ -104,14 +95,9 @@ export class SystemWideKeybindingsContribution extends Disposable implements IWo
 	/** User settings labels whose ignored `when` clause we already warned about. */
 	private readonly warnedWhenLabels = new Set<string>();
 
-	/** Guards against showing the one-time notice more than once concurrently. */
-	private noticeInFlight = false;
-
 	constructor(
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@INativeHostService private readonly nativeHostService: INativeHostService,
-		@IStorageService private readonly storageService: IStorageService,
-		@IDialogService private readonly dialogService: IDialogService,
 		@INotificationService private readonly notificationService: INotificationService,
 		@IProductService private readonly productService: IProductService,
 		@ILogService private readonly logService: ILogService,
@@ -138,21 +124,6 @@ export class SystemWideKeybindingsContribution extends Disposable implements IWo
 		if (candidates.length === 0) {
 			await this.pushToMainProcess([]);
 			return;
-		}
-
-		// Show a one-time heads-up before the very first registration so the user is aware the combo
-		// is captured globally (fires while unfocused). Informational only - the feature stays on.
-		if (!this.storageService.getBoolean(ACKNOWLEDGED_STORAGE_KEY, StorageScope.APPLICATION, false)) {
-			if (this.noticeInFlight) {
-				return;
-			}
-			this.noticeInFlight = true;
-			try {
-				await this.notifyFirstRun(candidates);
-			} finally {
-				this.noticeInFlight = false;
-			}
-			this.storageService.store(ACKNOWLEDGED_STORAGE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
 		}
 
 		this.warnAboutIgnoredWhenClauses(candidates);
@@ -197,16 +168,12 @@ export class SystemWideKeybindingsContribution extends Disposable implements IWo
 			userSettingsLabel: candidate.userSettingsLabel,
 		}));
 
-		let failed: string[];
 		try {
 			const result = await this.nativeHostService.syncSystemWideKeybindings(payload);
-			failed = result.failed;
+			this.reportFailures(result.failed);
 		} catch (error) {
 			this.logService.error('[SystemWideKeybindings] failed to sync system-wide keybindings with the main process', error);
-			return;
 		}
-
-		this.reportFailures(failed);
 	}
 
 	private reportFailures(failed: string[]): void {
@@ -223,19 +190,6 @@ export class SystemWideKeybindingsContribution extends Disposable implements IWo
 		this.notificationService.notify({
 			severity: Severity.Warning,
 			message: nls.localize('systemWideKeybindings.registrationFailed', "Some system-wide keybindings could not be registered ({0}); the key combination may already be taken by the operating system or another application.", sorted.join(', ')),
-		});
-	}
-
-	private async notifyFirstRun(candidates: readonly ISystemWideKeybindingCandidate[]): Promise<void> {
-		const labels = candidates.map(candidate => candidate.userSettingsLabel).join(', ');
-		await this.dialogService.prompt({
-			type: Severity.Info,
-			message: nls.localize('systemWideKeybindings.notice.message', "{0} is registering system-wide keybindings", this.productName()),
-			detail: nls.localize('systemWideKeybindings.notice.detail', "The keybindings you marked with \"systemWide\" ({0}) are captured by the operating system and trigger their command even when {1} is not focused, taking the key combination away from other applications.", labels, this.productName()),
-			buttons: [{
-				label: nls.localize({ key: 'systemWideKeybindings.notice.acknowledge', comment: ['&& denotes a mnemonic'] }, "&&I Understand"),
-				run: () => { },
-			}],
 		});
 	}
 

--- a/src/vs/workbench/contrib/keybindings/electron-browser/systemWideKeybindings.specification.md
+++ b/src/vs/workbench/contrib/keybindings/electron-browser/systemWideKeybindings.specification.md
@@ -1,0 +1,194 @@
+# System-wide (OS global) keybindings
+
+This document is the canonical spec for the **system-wide keybindings** feature: user
+`keybindings.json` entries that fire even when VS Code is not the focused application, backed by
+Electron's [`globalShortcut`](https://www.electronjs.org/docs/latest/api/accelerator) module.
+
+History: introduced in PR microsoft/vscode#323871; the first-run notice dialog was later removed in
+PR microsoft/vscode#324045 (it could appear in multiple windows at once, and the single-window
+election meant to prevent that was racy). The feature is **desktop only** and **always on**.
+
+## User-facing contract
+
+A user adds `"systemWide": true` to a keybinding entry in **`keybindings.json`**:
+
+```jsonc
+{
+  "key": "ctrl+cmd+a",
+  "command": "workbench.action.openAgentsWindow",
+  "systemWide": true
+}
+```
+
+While VS Code is running (even unfocused), pressing that combination runs the command. Rules:
+
+- **User keybindings only.** Default and extension-contributed keybindings can never be
+  system-wide — this prevents extensions from silently grabbing OS-global shortcuts.
+- **Single key combinations only.** Chords (`ctrl+k ctrl+c`) and single-modifier bindings cannot be
+  expressed as an Electron accelerator; they are skipped with a `warn` log.
+- **`when` clauses are ignored** for the global trigger — an OS-global shortcut has no editor/UI
+  context, so it is always active while VS Code runs. The user is warned once per binding label.
+- **First binding wins** on accelerator conflicts (deduped both in the renderer selection and in the
+  main-process per-window payload).
+- **Desktop only.** The flag is inert on web/server (there is no `globalShortcut` there, and the
+  contribution is `electron-browser`).
+- **Always on.** There is no setting to enable/disable it and no first-run dialog.
+
+The `systemWide` boolean is declared in the `keybindings.json` JSON schema in
+`src/vs/workbench/services/keybinding/browser/keybindingService.ts`.
+
+## Architecture at a glance
+
+The feature spans the renderer (electron-browser) and the Electron main process, connected by the
+existing native-host IPC channel.
+
+```mermaid
+sequenceDiagram
+    participant KB as IKeybindingService (renderer)
+    participant C as SystemWideKeybindingsContribution (renderer)
+    participant NH as NativeHostMainService (main)
+    participant G as GlobalKeybindingsMainService (main)
+    participant OS as Electron globalShortcut / OS
+    participant W as window.ts vscode:runAction (renderer)
+
+    KB->>C: onDidUpdateKeybindings (also fires on layout change)
+    C->>C: selectSystemWideKeybindings() (debounced 200ms)
+    C->>NH: syncSystemWideKeybindings(payload)  [per window]
+    NH->>G: updateKeybindings(windowId, payload)
+    G->>OS: register / unregister accelerators (union across windows)
+    G-->>C: { failed: string[] }  (surfaced as a warning notification)
+    OS->>G: accelerator pressed -> onTrigger(accelerator)
+    G->>W: sendWhenReady('vscode:runAction', { id, from:'systemWideKeybinding', args })
+    W->>W: commandService.executeCommand(id, ...args)
+```
+
+### Renderer
+
+**`src/vs/workbench/contrib/keybindings/electron-browser/systemWideKeybindings.contribution.ts`** —
+the heart of the renderer side. Registered as a workbench contribution at
+`WorkbenchPhase.AfterRestored` (never blocks startup).
+
+- `selectSystemWideKeybindings(items)` — a **pure** function that filters the full set of resolved
+  keybindings down to eligible candidates. Eligibility: `item.systemWide && !item.isDefault &&
+  item.command && item.resolvedKeybinding && getElectronAccelerator() !== null` and the accelerator
+  has not already been claimed. Returns `{ candidates, unsupported, duplicates }` so the caller can
+  log why entries were dropped. Kept pure and separately unit-tested.
+- `SystemWideKeybindingsContribution` — subscribes to `IKeybindingService.onDidUpdateKeybindings`
+  (which also fires on keyboard-layout changes, since accelerator strings depend on layout),
+  debounces via a 200ms `RunOnceScheduler`, and on each `sync()`:
+  1. collects candidates (logging unsupported/duplicate entries),
+  2. warns once per label about ignored `when` clauses (`warnedWhenLabels` guard),
+  3. pushes the payload to the main process via `INativeHostService.syncSystemWideKeybindings`,
+  4. reports registration failures via `INotificationService`, deduped against the last reported set
+     (`lastReportedFailures`) so unchanged failures are not re-notified.
+
+**`src/vs/workbench/electron-browser/window.ts`** — handles the `vscode:runAction` IPC in the
+renderer. For `request.from === 'systemWideKeybinding'` it runs the command with **exactly** the
+args configured in `keybindings.json` — unlike the `menu`/`mouse` senders it does **not** append a
+`{ from }` sentinel, so a command taking positional args receives the same payload it would from a
+normal in-window keybinding. Emits the standard `workbenchActionExecuted` telemetry.
+
+### IPC contract
+
+**`src/vs/platform/native/common/native.ts`**
+
+- `INativeSystemWideKeybinding` — `{ accelerator, commandId, args?, userSettingsLabel? }`. The
+  `accelerator` is in Electron accelerator format (e.g. `Control+Cmd+A`).
+- `INativeSystemWideKeybindingResult` — `{ failed: string[] }`. `failed` lists user-settings labels
+  (or accelerators) that could not be registered.
+- `ICommonNativeHostService.syncSystemWideKeybindings(keybindings)` — the method exposed to the
+  renderer.
+
+**`src/vs/platform/window/common/window.ts`** — `INativeRunActionInWindowRequest.from` includes
+`'systemWideKeybinding'` in its union.
+
+### Main process
+
+**`src/vs/platform/native/electron-main/nativeHostMainService.ts`** — `syncSystemWideKeybindings`
+delegates to `IGlobalKeybindingsMainService.updateKeybindings(windowId, ...)`. If there is no
+`windowId` it returns `{ failed: [] }`.
+
+**`src/vs/platform/globalKeybindings/electron-main/globalKeybindingsMainService.ts`** — owns the OS
+registrations. Wired up in `src/vs/code/electron-main/app.ts` with the real Electron global:
+`services.set(IGlobalKeybindingsMainService, new SyncDescriptor(GlobalKeybindingsMainService, [globalShortcut]))`.
+
+- `IGlobalShortcutRegistry` — the tiny `register/unregister/isRegistered` subset of Electron's
+  `globalShortcut`, injected as a constructor arg (not imported directly) so tests can supply a fake.
+- State:
+  - `registry: Map<windowId, Map<accelerator, binding>>` — each window's desired bindings.
+  - `registeredAccelerators: Set<string>` — accelerators this service currently owns an OS
+    registration for.
+  - `failedAccelerators: Set<string>` — desired accelerators that failed to register (e.g. already
+    taken); retried on the next reconcile.
+- `updateKeybindings(windowId, keybindings)` — validates + dedups the payload for that window,
+  replaces (or clears) the window's entry, calls `reconcile()`, and returns the `failed` labels for
+  that window.
+- `reconcile()` — computes the union of desired accelerators across **all** windows. Unregisters
+  only accelerators this service owns that are no longer desired (never touches shortcuts owned
+  elsewhere), then registers newly desired ones (retrying previously failed). Each accelerator is
+  registered **once** with a stable callback `() => this.onTrigger(accelerator)` that reads the
+  **current** registry at fire time, so command/args are never captured from a stale snapshot.
+- `onTrigger(accelerator)` — resolves the target window: the focused window if it owns the
+  accelerator, otherwise the deterministic winner (lowest window id) among alive owners. Sends
+  `vscode:runAction` via `target.sendWhenReady(...)`. It deliberately does **not** force-focus the
+  routing window — a system-wide keybinding fires while VS Code is typically unfocused, and pulling
+  the routing window forward would flicker when the command opens/reveals a *different* window
+  (e.g. `workbench.action.openAgentsWindow`). This matches every other `vscode:runAction` sender.
+- Lifecycle: on `IWindowsMainService.onDidDestroyWindow` it drops the window's entry and reconciles;
+  on `ILifecycleMainService.onWillShutdown` and on dispose it unregisters everything.
+
+### How the `systemWide` flag is plumbed
+
+The boolean travels from `keybindings.json` to `ResolvedKeybindingItem`:
+
+- `src/vs/workbench/services/keybinding/common/keybindingIO.ts` — parses `systemWide` from each
+  entry (`IUserKeybindingItem`) and writes it back out on serialization.
+- `src/vs/platform/keybinding/common/keybinding.ts` — `IUserKeybindingItem.systemWide?: boolean`.
+- `src/vs/platform/keybinding/common/resolvedKeybindingItem.ts` — `ResolvedKeybindingItem.systemWide`
+  (defaults `false`; only ever `true` for user keybindings).
+- `src/vs/workbench/services/keybinding/browser/keybindingService.ts` — threads `item.systemWide`
+  into every `ResolvedKeybindingItem` it builds, and declares the schema property.
+
+## Design decisions and rationale
+
+1. **User-only, single-combo, `when`-ignored** — hard constraints of OS-global shortcuts; each is
+   enforced and surfaced (log for unsupported/duplicate, notification for ignored `when`).
+2. **Per-window registry + union registration** — multiple windows may each request the same or
+   different system-wide bindings. The main service registers the union and routes a press to a
+   single window (focused owner, else deterministic lowest id). It only ever unregisters
+   accelerators it owns, so it never stomps global shortcuts registered by the OS or other apps.
+3. **No force-focus on trigger** — avoids visible flicker and lets the invoked command decide what
+   to surface/focus.
+4. **Always-on, no dialog** — the feature is unconditionally active; the earlier one-time notice was
+   removed because it leaked into multiple windows and its single-window election was racy. Users who
+   opt a binding into `systemWide` are assumed to understand the implication.
+5. **Deduped failure notifications** — `reportFailures` only notifies when the failed set changes, so
+   a persistent conflict is reported once, not on every re-sync.
+6. **Stable trigger callback reading live state** — registering once per accelerator (rather than
+   re-registering on every payload change) avoids races and stale command/args capture.
+
+## Testing
+
+- `src/vs/platform/globalKeybindings/test/electron-main/globalKeybindingsMainService.test.ts` — the
+  main service against a fake `IGlobalShortcutRegistry` and fake windows service: register/reconcile,
+  dedup within a window, failed-registration reporting + retry, trigger routing (focused owner,
+  deterministic lowest-id, no force-focus, undefined args), cross-window conflict resolution, window
+  destroy unregistration, and shutdown unregister-all. Pure electron-main (node-safe, no DOM/CSS).
+- `src/vs/workbench/contrib/keybindings/test/electron-browser/systemWideKeybindings.test.ts` — the
+  pure `selectSystemWideKeybindings`: eligibility filtering, unsupported (chords/modifiers),
+  duplicates.
+- `keybindingIO.test.ts` / `keybindingEditing.test.ts` — round-trip of the `systemWide` flag through
+  parse/serialize.
+
+## Gotchas for future work
+
+- Adding another `vscode:runAction` sender kind requires extending the `from` union in
+  `INativeRunActionInWindowRequest` (`src/vs/platform/window/common/window.ts`) and handling it in
+  `window.ts`.
+- Accelerator strings are keyboard-layout dependent; the contribution re-syncs on
+  `onDidUpdateKeybindings`, which also fires on layout changes.
+- `globalShortcut.register` returns `false` (or throws) when an accelerator is already taken by the
+  OS or another application; such accelerators land in `failedAccelerators`, are retried on the next
+  reconcile, and are surfaced to the user as a warning.
+- Keep `selectSystemWideKeybindings` pure — it is the primary unit-tested seam for renderer
+  eligibility logic.

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -930,7 +930,7 @@ class KeybindingsJsonSchema {
 				'systemWide': {
 					'type': 'boolean',
 					'default': false,
-					'markdownDescription': nls.localize('keybindings.json.systemWide', "When `true`, registers this keybinding as a system-wide (OS global) shortcut that fires even when the application is not focused. Desktop only. Only single key combinations are supported (no chords), and any `when` clause is ignored for the global trigger. The first time such a keybinding is registered you will see a one-time notice.")
+					'markdownDescription': nls.localize('keybindings.json.systemWide', "When `true`, registers this keybinding as a system-wide (OS global) shortcut that fires even when the application is not focused. Desktop only. Only single key combinations are supported (no chords), and any `when` clause is ignored for the global trigger.")
 				}
 			},
 			'$ref': '#/definitions/commandsSchemas'


### PR DESCRIPTION
Follow-up to #323871.

## Why

We got feedback that the first-run notice for system-wide keybindings can pop up in more than one window at the same time on startup. The feature had a main-process "elect one window" mechanism meant to prevent that, but it was racy across renderers that sync concurrently, so the notice still leaked into multiple windows.

Rather than harden the election, we're removing the dialog entirely. The feature is always on, and a user who marks a keybinding `"systemWide": true` in `keybindings.json` already knows what they are doing, so a one-time notice adds little.

## What

Deletes the whole notice path, which only existed to serve that dialog:

- **Renderer** (`systemWideKeybindings.contribution.ts`): drops the first-run notification, the acknowledged-storage gate, and the `IDialogService`/`IStorageService` dependencies. `sync()` now just warns about ignored `when` clauses and pushes bindings to the main process.
- **Main process** (`globalKeybindingsMainService.ts`, `nativeHostMainService.ts`): drops the elected-window bookkeeping, so `INativeSystemWideKeybindingResult` reports only registration failures.
- **Schema / tests**: updates the `systemWide` description in the `keybindings.json` schema and removes the now-obsolete election unit tests.

Global registration and trigger routing are unchanged.

## Notes for reviewers

The diff is a net removal (+17 / -63 across 5 files). It builds on an unmerged follow-up that had added the election machinery, so the squashed change relative to `main` cleanly deletes the dialog without leaving `native.ts` or the test service mock touched.

## How to test

1. Add a `systemWide` keybinding to `keybindings.json`, e.g. `{ "key": "ctrl+cmd+a", "command": "workbench.action.openAgentsWindow", "systemWide": true }`.
2. Restart with multiple windows open and confirm no first-run dialog appears in any window.
3. Confirm the keybinding still registers and triggers the command system-wide.