### PR TITLE
fix: match uppercase query characters in fuzzyContains

### DIFF
--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -917,11 +917,12 @@ export function fuzzyContains(target: string, query: string): boolean {
 
 	const queryLen = query.length;
 	const targetLower = target.toLowerCase();
+	const queryLower = query.toLowerCase();
 
 	let index = 0;
 	let lastIndexOf = -1;
 	while (index < queryLen) {
-		const indexOf = targetLower.indexOf(query[index], lastIndexOf + 1);
+		const indexOf = targetLower.indexOf(queryLower[index], lastIndexOf + 1);
 		if (indexOf < 0) {
 			return false;
 		}

--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -915,9 +915,10 @@ export function fuzzyContains(target: string, query: string): boolean {
 		return false; // impossible for query to be contained in target
 	}
 
-	const queryLen = query.length;
 	const targetLower = target.toLowerCase();
 	const queryLower = query.toLowerCase();
+	// toLowerCase() can change a string's length (e.g. İ -> i̇), so iterate over the lowered query.
+	const queryLen = queryLower.length;
 
 	let index = 0;
 	let lastIndexOf = -1;

--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -917,7 +917,7 @@ export function fuzzyContains(target: string, query: string): boolean {
 
 	const targetLower = target.toLowerCase();
 	const queryLower = query.toLowerCase();
-	// toLowerCase() can change a string's length (e.g. İ -> i̇), so iterate over the lowered query.
+	// toLowerCase() can change a string's length (e.g. \u0130 -> i\u0307), so iterate over the lowered query.
 	const queryLen = queryLower.length;
 
 	let index = 0;

--- a/src/vs/base/test/common/strings.test.ts
+++ b/src/vs/base/test/common/strings.test.ts
@@ -410,6 +410,9 @@ suite('Strings', () => {
 		assert.ok(strings.fuzzyContains('hello world', 'd'));
 		assert.ok(!strings.fuzzyContains('hello world', 'wh'));
 		assert.ok(!strings.fuzzyContains('d', 'dd'));
+		assert.ok(strings.fuzzyContains('hello world', 'H'));
+		assert.ok(strings.fuzzyContains('Explorer', 'E'));
+		assert.ok(strings.fuzzyContains('hello world', 'HW'));
 	});
 
 	test('startsWithUTF8BOM', () => {

--- a/src/vs/base/test/common/strings.test.ts
+++ b/src/vs/base/test/common/strings.test.ts
@@ -413,6 +413,9 @@ suite('Strings', () => {
 		assert.ok(strings.fuzzyContains('hello world', 'H'));
 		assert.ok(strings.fuzzyContains('Explorer', 'E'));
 		assert.ok(strings.fuzzyContains('hello world', 'HW'));
+		// toLowerCase() can lengthen the query (İ -> i̇); every lowered code unit must still be matched
+		assert.ok(strings.fuzzyContains('\u0130ab', '\u0130b'));
+		assert.ok(!strings.fuzzyContains('\u0130ab', '\u0130x'));
 	});
 
 	test('startsWithUTF8BOM', () => {


### PR DESCRIPTION
`fuzzyContains` lowercases the target but compares it against the original-case
query characters, so any uppercase character in the query can never match.

    fuzzyContains('hello world', 'H')  // false, should be true
    fuzzyContains('Explorer', 'E')     // false, should be true

The `viewQuickAccess` picker passes the raw user filter into
`fuzzyContains(entry.containerLabel, filter)` after only trimming it, so typing
an uppercase letter fails to fuzzy-match views by container label. Other callers
happened to work only because they lowercase both sides before calling, which
hid the defect at the utility level.

The fix lowercases the query as well, so the comparison is case-insensitive on
both sides. Added assertions for uppercase and mixed-case queries.
