### PR TITLE
sessions: show file icons in Session Files changes list

### DIFF
--- a/.github/instructions/best-practices.instructions.md
+++ b/.github/instructions/best-practices.instructions.md
@@ -26,7 +26,8 @@ applyTo: src/vs/**
 
 ## Resource Labels
 
-- Don't set `{ supportIcons: true }` when creating a `ResourceLabel` (`vs/workbench/browser/labels.ts`). This option makes the label parse `$(codicon)` syntax in the name/description and is only needed when you want to render a codicon inline with the resource text. By default (without it), the label shows the proper file icon for the resource, which is what we almost always want.
+- Don't set `{ supportIcons: true }` when creating a `ResourceLabel` (`vs/workbench/browser/labels.ts`). This option makes the label parse `$(codicon)` syntax in the name/description and is only needed when you want to render a codicon inline with the resource text. By default (without it), the label computes the proper file-icon CSS classes for the resource, which is what we almost always want. Note that those classes only render as icons when an ancestor DOM element enables file icons (see below); otherwise the label shows text only.
+- To actually display file icons for resource labels in a tree/list, an ancestor container must have the `show-file-icons` class and be wired to the active file icon theme. Don't add the class by hand — call `createFileIconThemableTreeContainerScope` (`vs/workbench/contrib/files/browser/views/explorerView.ts`) on the container. It adds the required `show-file-icons` / `file-icon-themable-tree` classes and keeps `align-icons-and-twisties` / `hide-arrows` in sync with the file icon theme. Register the returned `IDisposable`. A common bug is placing a resource-label list/tree outside such a scoped container, which makes file icons silently disappear.
 
 ## Styling
 

--- a/src/vs/sessions/contrib/changes/browser/sessionFilesWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionFilesWidget.ts
@@ -23,7 +23,9 @@ import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { WorkbenchList } from '../../../../platform/list/browser/listService.js';
+import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { DEFAULT_LABELS_CONTAINER, IResourceLabel, ResourceLabels } from '../../../../workbench/browser/labels.js';
+import { createFileIconThemableTreeContainerScope } from '../../../../workbench/contrib/files/browser/views/explorerView.js';
 import { ACTIVE_GROUP, IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
 import { ISessionFile, SessionFileOperation } from '../../../services/sessions/common/session.js';
 
@@ -85,6 +87,8 @@ class SessionFileListRenderer implements IListRenderer<ISessionFile, ISessionFil
 			name: basename(element.uri),
 		}, {
 			fileKind: FileKind.FILE,
+			fileDecorations: undefined,
+			strikethrough: element.operation === SessionFileOperation.Deleted,
 			title: getSessionFileTitle(element, this._labelService),
 		});
 
@@ -183,12 +187,17 @@ export class SessionFilesWidget extends Disposable {
 		@IEditorService private readonly _editorService: IEditorService,
 		@IHoverService private readonly _hoverService: IHoverService,
 		@IFileService private readonly _fileService: IFileService,
+		@IThemeService private readonly _themeService: IThemeService,
 	) {
 		super();
 		this._labels = this._register(this._instantiationService.createInstance(ResourceLabels, DEFAULT_LABELS_CONTAINER));
 
 		this._domNode = dom.append(container, $('.session-files-widget'));
 		this._domNode.style.display = 'none';
+
+		// Enable file icons from the active file icon theme for the resource
+		// labels rendered in this widget's list.
+		this._register(createFileIconThemableTreeContainerScope(this._domNode, this._themeService));
 
 		// Header (always visible, click to collapse/expand)
 		this._headerNode = dom.append(this._domNode, $('.session-files-widget-header'));


### PR DESCRIPTION
## What

Fixes the **Session Files** list in the Changes view (Agents window) not rendering per-file-type icons.

## Why

`SessionFilesWidget` renders its file list with `ResourceLabels` and requests file icons via `fileKind: FileKind.FILE`. `ResourceLabels` only computes the file-icon CSS classes — those render as actual icons only when an ancestor DOM element carries the `show-file-icons` class and is wired to the active file icon theme (via `createFileIconThemableTreeContainerScope`).

In `changesView.ts`, only the changes-tree `contentContainer` got that treatment. The `SessionFilesWidget` is a sibling appended directly to `splitViewContainer`, so its list was outside the file-icon scope and showed text-only labels.

## Changes

- `sessionFilesWidget.ts`: register a file-icon themeable scope on the widget''s own root node (`createFileIconThemableTreeContainerScope`), injecting `IThemeService`.
- Align resource-label rendering with `ChangesTreeRenderer`: pass `fileDecorations: undefined` and apply `strikethrough` for deleted files.
- `.github/instructions/best-practices.instructions.md`: correct the Resource Labels note and document that `show-file-icons` / `createFileIconThemableTreeContainerScope` is required for trees/lists to show file icons.

## Notes for reviewers

- The line-count (+/-) and review/agent-feedback badges from `ChangesTreeRenderer` are intentionally not added here, since that data isn''t tracked for out-of-workspace session files.
- Pre-commit hygiene/eslint could not run in this environment (missing node modules); `typecheck-client` passed for the changed sources.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>