### PR TITLE
sessions: collapse Pinned and Chats sections on first open

### DIFF
--- a/src/vs/sessions/SESSIONS_LIST.md
+++ b/src/vs/sessions/SESSIONS_LIST.md
@@ -95,6 +95,8 @@ A built-in find widget filters the list by session title and section label. When
 
 Pinned sessions appear in a dedicated "Pinned" section at the top. The section is **always visible** (even with no pinned sessions), mirroring the "Chats" section; when empty it shows a muted, centered **"No pinned sessions" placeholder row**. Pin state is managed by `ISessionsListModelService` and persisted locally (not synced to providers).
 
+The **Pinned** and **Chats** sections start **collapsed on first open** (their default collapse state is `PreserveOrCollapsed` when no saved state exists). Once the user expands or collapses either section, that choice is persisted per-section under `sessionsListControl.sectionCollapseState` and honored on subsequent loads.
+
 ### Manual Reordering (Drag & Drop)
 
 Two things can be reordered by dragging: **sessions** (within a section/group) and **top-level headers** (user groups and workspace sections). An insertion line is shown between rows/headers while dragging.

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -2084,6 +2084,13 @@ export class SessionsList extends Disposable implements ISessionsList {
 				defaultCollapsed = ObjectTreeElementCollapseState.PreserveOrCollapsed;
 			}
 
+			// The always-visible "Pinned" and "Chats" sections start collapsed on
+			// first open; the user's later choice is persisted and honored via
+			// getSavedCollapseState.
+			if (section.id === 'pinned' || section.id === QUICK_CHATS_SECTION_ID) {
+				defaultCollapsed = ObjectTreeElementCollapseState.PreserveOrCollapsed;
+			}
+
 			return {
 				element: section as SessionListItem,
 				collapsible: true,


### PR DESCRIPTION
## What

In the Agents window sessions sidebar, the **Pinned** and **Chats** sections previously defaulted to expanded. This changes their default collapse state to **collapsed on first open** (when no saved state exists), while continuing to persist and honor the user's later expand/collapse choice.

## Why

Both sections are always visible even when empty (showing a "No pinned sessions" / "No chats" placeholder). Defaulting them expanded added noise at the top of the list. Collapsing them by default keeps the list compact while remaining discoverable.

## How

In `SessionsList.renderSection` (`src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts`), the `pinned` and `QUICK_CHATS_SECTION_ID` sections now use `ObjectTreeElementCollapseState.PreserveOrCollapsed` as their default. Since the effective state is `getSavedCollapseState(section.id) ?? defaultCollapsed`, any saved user choice (persisted under `sessionsListControl.sectionCollapseState`) still takes precedence — only the first-open default changed.

## Notes for reviewers

- `SESSIONS_LIST.md` spec updated to document the behavior.
- `npm run typecheck-client` and `npm run valid-layers-check` pass.