### PR TITLE
Guard node_modules cache against missing native optional-dep packages

### DIFF
--- a/.github/workflows/pr-node-modules.yml
+++ b/.github/workflows/pr-node-modules.yml
@@ -135,6 +135,10 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           GITHUB_TOKEN: ${{ secrets.VSCODE_OSS }}
 
+      - name: Verify native optional dependency binaries
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
+
       - name: Save node_modules cache
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         uses: ./.github/actions/save-node-modules
@@ -190,6 +194,10 @@ jobs:
           # on macOS.
           GYP_DEFINES: "kerberos_use_rtld=false"
 
+      - name: Verify native optional dependency binaries
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
+
       - name: Save node_modules cache
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         uses: ./.github/actions/save-node-modules
@@ -244,6 +252,10 @@ jobs:
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           GITHUB_TOKEN: ${{ secrets.VSCODE_OSS }}
+
+      - name: Verify native optional dependency binaries
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: node build/azure-pipelines/common/checkNativeOptionalDeps.ts
 
       - name: Save node_modules cache
         if: steps.node-modules-cache.outputs.cache-hit != 'true'

--- a/build/azure-pipelines/common/checkNativeOptionalDeps.ts
+++ b/build/azure-pipelines/common/checkNativeOptionalDeps.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import fs from 'fs';
+import path from 'path';
+
+// Some dependencies ship their native binary in a per-platform package that is
+// declared as an *optional* dependency of a small base package — e.g.
+// `@openai/codex` and `@anthropic-ai/claude-agent-sdk` are thin launchers and
+// the real binaries live in `@openai/codex-<platform>-<arch>` /
+// `@anthropic-ai/claude-agent-sdk-<platform>-<arch>`. `npm install` / `npm ci`
+// do NOT fail when an optional dependency cannot be installed, so a transient
+// hiccup can leave the base package present while the per-platform package is
+// missing. That broken tree then gets frozen into the node_modules cache and
+// served to every consumer, failing far away from the cause
+// (see https://github.com/microsoft/vscode/pull/323881).
+//
+// This check runs after `npm ci` when building a node_modules cache and fails
+// the job when a required per-platform package is missing, so a poisoned cache
+// is never saved.
+
+const ROOT = path.join(import.meta.dirname, '../../../');
+
+// Base packages whose per-platform package (`<base>-<platform>-<arch>`) is
+// required whenever the base package itself is installed.
+const NATIVE_OPTIONAL_DEP_BASE_PACKAGES = [
+	'@openai/codex',
+	'@anthropic-ai/claude-agent-sdk',
+];
+
+// Platform/arch combinations these packages publish a per-platform package for.
+const SUPPORTED_PLATFORMS = new Set(['linux', 'darwin', 'win32']);
+const SUPPORTED_ARCHS = new Set(['x64', 'arm64']);
+
+function isInstalled(pkg: string): boolean {
+	return fs.existsSync(path.join(ROOT, 'node_modules', pkg));
+}
+
+const { platform, arch } = process;
+
+if (!SUPPORTED_PLATFORMS.has(platform) || !SUPPORTED_ARCHS.has(arch)) {
+	console.log(`Skipping native optional-dependency check on unsupported ${platform}-${arch}.`);
+	process.exit(0);
+}
+
+const errors: string[] = [];
+for (const basePackage of NATIVE_OPTIONAL_DEP_BASE_PACKAGES) {
+	// Only enforce when the base package is installed; if it is not, the
+	// dependency simply was not requested here and there is nothing to verify.
+	if (!isInstalled(basePackage)) {
+		continue;
+	}
+	// The glibc Linux package (no `-musl` suffix) is the one required on the
+	// glibc-based CI hosts; the naming is always `<base>-<platform>-<arch>`.
+	const platformPackage = `${basePackage}-${platform}-${arch}`;
+	if (!isInstalled(platformPackage)) {
+		errors.push(`${basePackage}: required per-platform package '${platformPackage}' is missing from node_modules — the optional dependency was silently skipped during install`);
+	}
+}
+
+if (errors.length > 0) {
+	console.error('\x1b[1;31m*** Missing native optional-dependency packages — refusing to save a poisoned node_modules cache ***\x1b[0m');
+	for (const err of errors) {
+		console.error(`  - ${err}`);
+	}
+	console.error('\nnpm does not fail when an optional dependency cannot be installed, so this tree would poison the shared node_modules cache. Re-run a fresh `npm ci` (e.g. after bumping build/.cachesalt) to restore the package before the cache is saved.');
+	process.exit(1);
+}
+
+console.log(`Verified native optional-dependency packages for ${platform}-${arch}.`);


### PR DESCRIPTION
## Why

Follow-up hardening for #323881. Some dependencies ship their native binary in a per-platform package declared as an **optional** dependency of a small base package:
- `@openai/codex` → `@openai/codex-<platform>-<arch>`
- `@anthropic-ai/claude-agent-sdk` → `@anthropic-ai/claude-agent-sdk-<platform>-<arch>`

`npm install`/`npm ci` **do not fail** when an optional dependency can't be installed, so a transient hiccup can leave the base package present while the per-platform package is missing. That broken tree then gets frozen into the shared `node_modules` cache and served to every consumer — exactly what poisoned the Linux cache and broke the Codex smoke test.

There is no npm flag to make an optional-dependency install failure fatal (npm can't tell a legitimate platform-skip from a failed fetch), so the only reliable guard is an explicit post-install check.

## What

- Add `build/azure-pipelines/common/checkNativeOptionalDeps.ts`: for each configured base package that is installed, assert the matching `<base>-<platform>-<arch>` package exists in `node_modules`. If it's missing, exit non-zero with an actionable message; if the base package isn't installed, it's a no-op. Currently covers `@openai/codex` and `@anthropic-ai/claude-agent-sdk` — adding more is a one-line change.
- Run it in the **linux**, **macOS** and **windows** cache-build jobs of `pr-node-modules.yml`, after the root `npm ci` and **before** the cache is saved (gated on a cache miss, i.e. only when an install actually ran).

Result: a `node_modules` cache missing a required native package can never be saved — the job fails loudly at build time instead of silently poisoning every downstream consumer.

## Verification

Ran the guard on all three platforms via temporary commits (dropped from this PR):

- **Fails** when the codex + claude platform packages are missing (removed before the check): https://github.com/microsoft/vscode/actions/runs/28650817801 — each platform's verify step exits 1 and reports both `@openai/codex-*` and `@anthropic-ai/claude-agent-sdk-*` missing.
- **Passes** on a normal fresh install (binaries present): https://github.com/microsoft/vscode/actions/runs/28651527368 — `Verified native optional-dependency packages for linux-x64 / darwin-arm64 / win32-x64`.
