### PR TITLE
Improve performance of fs operations in extension host (big performance boost for extension that process many files)

### DIFF
--- a/src/vs/workbench/api/common/extHostFileSystemConsumer.ts
+++ b/src/vs/workbench/api/common/extHostFileSystemConsumer.ts
@@ -24,7 +24,7 @@ export class ExtHostConsumerFileSystem {
 	readonly value: vscode.FileSystem;
 
 	private readonly _proxy: MainThreadFileSystemShape;
-	private readonly _fileSystemProvider = new Map<string, { impl: vscode.FileSystemProvider; extUri: IExtUri; isReadonly: boolean }>();
+	private readonly _fileSystemProvider = new Map<string, { impl: vscode.FileSystemProvider; extUri: IExtUri; isReadonly: boolean; activate: () => Promise<void> }>();
 
 	private readonly _writeQueue = new ResourceQueue();
 
@@ -43,7 +43,7 @@ export class ExtHostConsumerFileSystem {
 					const provider = that._fileSystemProvider.get(uri.scheme);
 					if (provider) {
 						// use shortcut
-						await that._proxy.$ensureActivation(uri.scheme);
+						await provider.activate();
 						stat = await provider.impl.stat(uri);
 					} else {
 						stat = await that._proxy.$stat(uri);
@@ -65,7 +65,7 @@ export class ExtHostConsumerFileSystem {
 					const provider = that._fileSystemProvider.get(uri.scheme);
 					if (provider) {
 						// use shortcut
-						await that._proxy.$ensureActivation(uri.scheme);
+						await provider.activate();
 						return (await provider.impl.readDirectory(uri)).slice(); // safe-copy
 					} else {
 						return await that._proxy.$readdir(uri);
@@ -79,7 +79,7 @@ export class ExtHostConsumerFileSystem {
 					const provider = that._fileSystemProvider.get(uri.scheme);
 					if (provider && !provider.isReadonly) {
 						// use shortcut
-						await that._proxy.$ensureActivation(uri.scheme);
+						await provider.activate();
 						return await that.mkdirp(provider.impl, provider.extUri, uri);
 					} else {
 						return await that._proxy.$mkdir(uri);
@@ -93,7 +93,7 @@ export class ExtHostConsumerFileSystem {
 					const provider = that._fileSystemProvider.get(uri.scheme);
 					if (provider) {
 						// use shortcut
-						await that._proxy.$ensureActivation(uri.scheme);
+						await provider.activate();
 						return (await provider.impl.readFile(uri)).slice(); // safe-copy
 					} else {
 						const buff = await that._proxy.$readFile(uri);
@@ -108,7 +108,7 @@ export class ExtHostConsumerFileSystem {
 					const provider = that._fileSystemProvider.get(uri.scheme);
 					if (provider && !provider.isReadonly) {
 						// use shortcut
-						await that._proxy.$ensureActivation(uri.scheme);
+						await provider.activate();
 						await that.mkdirp(provider.impl, provider.extUri, provider.extUri.dirname(uri));
 						return await that._writeQueue.queueFor(uri, () => Promise.resolve(provider.impl.writeFile(uri, content, { create: true, overwrite: true })));
 					} else {
@@ -123,7 +123,7 @@ export class ExtHostConsumerFileSystem {
 					const provider = that._fileSystemProvider.get(uri.scheme);
 					if (provider && !provider.isReadonly && !options?.useTrash /* no shortcut: use trash */) {
 						// use shortcut
-						await that._proxy.$ensureActivation(uri.scheme);
+						await provider.activate();
 						return await provider.impl.delete(uri, { recursive: false, ...options });
 					} else {
 						return await that._proxy.$delete(uri, { recursive: false, useTrash: false, atomic: false, ...options });
@@ -156,6 +156,22 @@ export class ExtHostConsumerFileSystem {
 				return undefined;
 			}
 		});
+	}
+
+	private buildActivator(scheme: string): () => Promise<void> {
+		let activated: Promise<void> | undefined = undefined;
+		return () => {
+			if (!activated) {
+				// we haven't had a succesfull activation (or maybe there is a race, but thats fine)
+				const result = this._proxy.$ensureActivation(scheme);
+				activated = result;
+				// in case of an error, we'll repeat the activation until it succeeds
+				result.catch(() => activated = undefined);
+				// but we want to report the error to the caller, so we'll pass the original promise to them
+				return result;
+			}
+			return activated;
+		};
 	}
 
 	private async mkdirp(provider: vscode.FileSystemProvider, providerExtUri: IExtUri, directory: vscode.Uri): Promise<void> {
@@ -247,7 +263,7 @@ export class ExtHostConsumerFileSystem {
 	// ---
 
 	addFileSystemProvider(scheme: string, provider: vscode.FileSystemProvider, options?: { isCaseSensitive?: boolean; isReadonly?: boolean | IMarkdownString }): IDisposable {
-		this._fileSystemProvider.set(scheme, { impl: provider, extUri: options?.isCaseSensitive ? extUri : extUriIgnorePathCase, isReadonly: !!options?.isReadonly });
+		this._fileSystemProvider.set(scheme, { impl: provider, extUri: options?.isCaseSensitive ? extUri : extUriIgnorePathCase, isReadonly: !!options?.isReadonly, activate: this.buildActivator(scheme) });
 		return toDisposable(() => this._fileSystemProvider.delete(scheme));
 	}
 


### PR DESCRIPTION
## Context

We have an extension that was doing some heavy IO operations using the `vscode.workspace.fs` interface (for operations on both `file` and custom virtual filesystems). We noticed it was quite a bit slower than using "raw" nodejs `fs/promise` (`readFile`/`readDirectory`). Important to note that it was many small files in many nested directories.

During profiling we noticed more than half of the time spend idling, and this let us to inspect the code of VS Code a bit more.

## Analysis

#136657 and #172345 created a fast path such that both `file:///` and virtual file systems registered inside the extension host do not need to "cross" the bridge to the rendering process that often. Especially the result of the fs functions did not need to be serialized across the RPC. For large files or large directory listing, this makes quite a big impact.

However, before every FS operation, VS Code would make sure that the VFS was registered (even for the `file` provider) like so:

```ts
await that._proxy.$ensureActivation(uri.scheme);
```

in side the rendering process this would quickly terminate if there is already a provider registered, so for infrequent IO, this small call and the rpc-overhead is fine, it takes some time, like you'll have to wait for one of the next ticks to arrive before it continues, but impact not so bad.

However if you're doing a lot small IO operations (like crawling a directory with many files, and then reading them, or first calling stat on them, etc) this starts to add up.

I've prepared a [repo extension show case the impact](https://github.com/SWAT-engineering/vscode-vfs-slow-vfs-overhead)

## Proposed solution

This PR introduces a small function that only sends this `ensureActivation` the first time, and that that does not send it anymore. As the `dispose` clears the map entry, I do not see why we would need to resend the activation every time.

An alternative would be to send the `ensureActivation` but leave the promise floating, so that we don't join the queue. I think that's less nice of a solution, but in a way it's less invasive of a change than this PR proposes.

Fixes #324223 