### PR TITLE
Style overrides: Improve tab height handling and clarity in editor

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
@@ -101,7 +101,12 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 
 	private static readonly EDITOR_TAB_HEIGHT = {
 		normal: 35 as const,
-		compact: 22 as const
+		compact: 22 as const,
+		// Style-override (Modern UI) multi-tab mode adds 4px top + 4px bottom padding to
+		// the tabs-and-actions-container (tabs.css), so the total title-bar height is the
+		// --editor-group-tab-height CSS value (24px / 14px) plus that 8px padding.
+		styleOverride: 32 as const,        // 24px tab  + 4px top + 4px bottom padding
+		styleOverrideCompact: 22 as const, // 14px tab  + 4px top + 4px bottom padding
 	};
 
 	protected editorActionsToolbarContainer: HTMLElement | undefined;
@@ -548,7 +553,15 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 	}
 
 	protected get tabHeight() {
-		return this.groupsView.partOptions.tabHeight !== 'compact' ? EditorTabsControl.EDITOR_TAB_HEIGHT.normal : EditorTabsControl.EDITOR_TAB_HEIGHT.compact;
+		const isCompact = this.groupsView.partOptions.tabHeight === 'compact';
+		// In style-override multi-tab mode the tabs-and-actions-container gains extra
+		// padding (tabs.css), so the total height differs from the base values.
+		// The `.tabs` class is present only when showTabs === 'multiple'; single-tab
+		// and no-tab modes are not affected by those CSS overrides.
+		if (this.parent.classList.contains('tabs') && !!this.parent.closest('.style-override')) {
+			return isCompact ? EditorTabsControl.EDITOR_TAB_HEIGHT.styleOverrideCompact : EditorTabsControl.EDITOR_TAB_HEIGHT.styleOverride;
+		}
+		return isCompact ? EditorTabsControl.EDITOR_TAB_HEIGHT.compact : EditorTabsControl.EDITOR_TAB_HEIGHT.normal;
 	}
 
 	protected getHoverTitle(editor: EditorInput): string | IManagedHoverTooltipMarkdownString {
@@ -566,6 +579,9 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 
 	protected updateTabHeight(): void {
 		this.parent.style.setProperty('--editor-group-tab-height', `${this.tabHeight}px`);
+		// Signal compact mode via a CSS class so the style-override rules in tabs.css
+		// can apply a proportionally smaller --editor-group-tab-height value.
+		this.parent.classList.toggle('compact-height', this.groupsView.partOptions.tabHeight === 'compact');
 	}
 
 	updateOptions(oldOptions: IEditorPartOptions, newOptions: IEditorPartOptions): void {

--- a/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
@@ -106,7 +106,7 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 		// the tabs-and-actions-container (tabs.css), so the total title-bar height is the
 		// --editor-group-tab-height CSS value (24px / 14px) plus that 8px padding.
 		styleOverride: 32 as const,        // 24px tab  + 4px top + 4px bottom padding
-		styleOverrideCompact: 22 as const, // 14px tab  + 4px top + 4px bottom padding
+		styleOverrideCompact: 28 as const, // 20px tab  + 4px top + 4px bottom padding (20px = minimum to fit 16px icon + 2px padding)
 	};
 
 	protected editorActionsToolbarContainer: HTMLElement | undefined;

--- a/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
@@ -558,7 +558,7 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 		// padding (tabs.css), so the total height differs from the base values.
 		// The `.tabs` class is present only when showTabs === 'multiple'; single-tab
 		// and no-tab modes are not affected by those CSS overrides.
-		if (this.parent.classList.contains('tabs') && !!this.parent.closest('.style-override')) {
+		if (this.parent.classList.contains('tabs') && this.parent.closest('.style-override')) {
 			return isCompact ? EditorTabsControl.EDITOR_TAB_HEIGHT.styleOverrideCompact : EditorTabsControl.EDITOR_TAB_HEIGHT.styleOverride;
 		}
 		return isCompact ? EditorTabsControl.EDITOR_TAB_HEIGHT.compact : EditorTabsControl.EDITOR_TAB_HEIGHT.normal;

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -1860,8 +1860,8 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		const newDimension = this.dimensions.used = new Dimension(dimensions.container.width, this.computeHeight());
 
 		// In case the height of the title control changed from before
-		// (currently only possible if wrapping changed on/off), we need
-		// to signal this to the outside via a `relayout` call so that
+		// (e.g. when wrapping toggles on/off or the tab height setting changes),
+		// we need to signal this to the outside via a `relayout` call so that
 		// e.g. the editor control can be adjusted accordingly.
 		if (oldDimension && oldDimension.height !== newDimension.height) {
 			this.groupView.relayout();

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -21,6 +21,11 @@
 	--editor-group-tab-height: 24px !important;
 }
 
+/* Compact tab height: 14px tab + 4px top + 4px bottom padding = 22px total (matches base compact). */
+.style-override .part.editor .title.tabs.compact-height {
+	--editor-group-tab-height: 14px !important;
+}
+
 .style-override .part.editor .tabs-container > .tab {
 	background-color: color-mix(in srgb, var(--vscode-foreground) 5%, transparent) !important;
 	border-right: none !important;

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -21,9 +21,10 @@
 	--editor-group-tab-height: 24px !important;
 }
 
-/* Compact tab height: 14px tab + 4px top + 4px bottom padding = 22px total (matches base compact). */
+/* Compact tab height: 20px tab + 4px top + 4px bottom padding = 28px total.
+ * 20px is the minimum to fit the tab action icons (16px codicon + 2px padding on each side). */
 .style-override .part.editor .title.tabs.compact-height {
-	--editor-group-tab-height: 14px !important;
+	--editor-group-tab-height: 20px !important;
 }
 
 .style-override .part.editor .tabs-container > .tab {


### PR DESCRIPTION
This pull request updates the logic and styling for editor tab heights in multi-tab mode, especially when the "Modern UI" style override is enabled. The changes ensure that tab heights and padding are calculated correctly for both normal and compact modes, and that the UI responds appropriately to style and configuration changes.

**Tab Height Calculation and Styling Updates:**

* Added new tab height values (`styleOverride` and `styleOverrideCompact`) to `EditorTabsControl.EDITOR_TAB_HEIGHT` to account for extra padding in style-override multi-tab mode.
* Updated the `tabHeight` getter in `EditorTabsControl` to use the new style-override heights when the relevant CSS classes are present, ensuring correct height in multi-tab and style-override scenarios.
* Modified `updateTabHeight()` to toggle a `compact-height` CSS class, allowing style-override CSS rules to apply a proportionally smaller tab height in compact mode.

**CSS Adjustments:**

* Added a CSS rule in `tabs.css` for `.style-override .part.editor .title.tabs.compact-height` to set a smaller `--editor-group-tab-height` for compact mode, matching the updated logic in TypeScript.

**Documentation and Clarity:**

* Improved a comment in `MultiEditorTabsControl` to clarify that height changes can now be triggered by tab height setting changes, not just wrapping.