### PR TITLE
chat: keep sticky scroll with pending messages

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -58,7 +58,7 @@ import { ChatQuestionCarouselData } from '../../common/model/chatProgressTypes/c
 import { localChatSessionType, SessionType } from '../../common/chatSessionsService.js';
 import { getChatSessionType } from '../../common/model/chatUri.js';
 import { getExplicitFileOrImageAttachmentSummary, IChatRequestVariableEntry, isExplicitFileOrImageVariableEntry, isPasteVariableEntry } from '../../common/attachments/chatVariableEntries.js';
-import { IChatChangesSummaryPart, IChatCodeCitations, IChatErrorDetailsPart, IChatReferences, IChatRendererContent, IChatRequestViewModel, IChatResponseViewModel, IChatViewModel, IChatWorkingProgress, isRequestVM, isResponseVM, IChatPendingDividerViewModel, isPendingDividerVM } from '../../common/model/chatViewModel.js';
+import { getStickyScrollTargetItem, IChatChangesSummaryPart, IChatCodeCitations, IChatErrorDetailsPart, IChatReferences, IChatRendererContent, IChatRequestViewModel, IChatResponseViewModel, IChatViewModel, IChatWorkingProgress, isRequestVM, isResponseVM, IChatPendingDividerViewModel, isPendingDividerVM } from '../../common/model/chatViewModel.js';
 import { getNWords } from '../../common/model/chatWordCounter.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, CollapsedToolsDisplayMode, ThinkingDisplayMode } from '../../common/constants.js';
 import { ClickAnimation } from '../../../../../base/browser/ui/animations/animations.js';
@@ -989,7 +989,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		const rowRoot = templateData.rowContainer.parentElement?.parentElement?.parentElement;
 		rowRoot?.classList.toggle('request', isRequestVM(element));
 		rowRoot?.classList.toggle('response', isResponseVM(element));
-		templateData.rowContainer.classList.toggle(mostRecentResponseClassName, index === this.delegate.getListLength() - 1);
+		const isMostRecentChatTreeItem = getStickyScrollTargetItem(this.viewModel?.getItems() ?? []) === element;
+		templateData.rowContainer.classList.toggle(mostRecentResponseClassName, isMostRecentChatTreeItem);
 		templateData.rowContainer.classList.toggle('confirmation-message', isRequestVM(element) && !!element.confirmation);
 
 		// TODO: @justschen decide if we want to hide the header for requests or not
@@ -1006,7 +1007,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		// - And the response is not complete
 		//   - Or, we previously started a progressive rendering of this element (if the element is complete, we will finish progressive rendering with a very fast rate)
 		const incrementalRendering = this.configService.getValue<boolean>(ChatConfiguration.IncrementalRendering);
-		if (isResponseVM(element) && index === this.delegate.getListLength() - 1 && (!element.isComplete || element.renderData)) {
+		if (isResponseVM(element) && isMostRecentChatTreeItem && (!element.isComplete || element.renderData)) {
 			this.traceLayout('renderElement', `start progressive render, index=${index}`);
 
 			if (incrementalRendering && !element.renderData) {
@@ -1167,7 +1168,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}
 
 		if (element.model.response === element.model.entireResponse && !element.isCanceled && element.errorDetails?.message && element.errorDetails.message !== canceledName) {
-			content.push({ kind: 'errorDetails', errorDetails: element.errorDetails, isLast: index === this.delegate.getListLength() - 1 });
+			content.push({ kind: 'errorDetails', errorDetails: element.errorDetails, isLast: getStickyScrollTargetItem(this.viewModel?.getItems() ?? []) === element });
 		}
 
 		const fileChangesSummaryPart = this.getChatFileChangesSummaryPart(element);
@@ -2514,7 +2515,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			return this.renderNoContent(other => content.kind === other.kind);
 		}
 
-		const isLast = context.elementIndex === this.delegate.getListLength() - 1;
+		const isLast = content.isLast;
 		if (content.errorDetails.isQuotaExceeded) {
 			const renderedError = this.instantiationService.createInstance(ChatQuotaExceededPart, context.element, content, this.chatContentMarkdownRenderer);
 			return renderedError;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
@@ -27,7 +27,7 @@ import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { IChatFollowup, IChatSendRequestOptions, IChatService } from '../../common/chatService/chatService.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../../common/constants.js';
 import { IChatRequestModeInfo } from '../../common/model/chatModel.js';
-import { IChatRequestViewModel, IChatResponseViewModel, IChatViewModel, isRequestVM, isResponseVM } from '../../common/model/chatViewModel.js';
+import { getStickyScrollTargetItem, IChatRequestViewModel, IChatResponseViewModel, IChatViewModel, isRequestVM, isResponseVM } from '../../common/model/chatViewModel.js';
 import { ChatAccessibilityProvider } from '../accessibility/chatAccessibilityProvider.js';
 import { ChatTreeItem, IChatAccessibilityService, IChatCodeBlockInfo, IChatFileTreeInfo, IChatListItemRendererOptions } from '../chat.js';
 import { CodeBlockPart } from './chatContentParts/codeBlockPart.js';
@@ -182,6 +182,7 @@ export class ChatListWidget extends Disposable {
 	private _viewModel: IChatViewModel | undefined;
 	private _visible = true;
 	private _lastItem: ChatTreeItem | undefined;
+	private _stickyScrollTargetItem: ChatTreeItem | undefined;
 	private _mostRecentlyFocusedItemIndex: number = -1;
 	private _scrollLock: boolean = true;
 	private _suppressAutoScroll: boolean = false;
@@ -237,6 +238,10 @@ export class ChatListWidget extends Disposable {
 	 */
 	get lastItem(): ChatTreeItem | undefined {
 		return this._lastItem;
+	}
+
+	get stickyScrollTargetItem(): ChatTreeItem | undefined {
+		return this._stickyScrollTargetItem;
 	}
 
 
@@ -329,8 +334,7 @@ export class ChatListWidget extends Disposable {
 		this._register(this._renderer.onDidChangeItemHeight(e => {
 			this._updateElementHeight(e.element, e.height);
 
-			// If the second-to-last item's height changed, update the last item's min height
-			const secondToLastItem = this._viewModel?.getItems().at(-2);
+			const secondToLastItem = this.getItemBeforeStickyScrollTarget();
 			if (e.element.id === secondToLastItem?.id) {
 				this.updateLastItemMinHeight();
 			}
@@ -525,14 +529,16 @@ export class ChatListWidget extends Disposable {
 		if (!this._viewModel) {
 			this._tree.setChildren(null, []);
 			this._lastItem = undefined;
+			this._stickyScrollTargetItem = undefined;
 			this._lastItemIdContextKey.set([]);
 			return;
 		}
 
 		const items = this._viewModel.getItems();
 		this._lastItem = items.at(-1);
+		this._stickyScrollTargetItem = getStickyScrollTargetItem(items);
 		this._lastItemIdContextKey.set(this._lastItem ? [this._lastItem.id] : []);
-		const previousItem = items.at(-2);
+		const previousItem = this.getItemBeforeStickyScrollTarget();
 		const needsInitialPreviousItemHeight = (isRequestVM(previousItem) || isResponseVM(previousItem)) && previousItem.currentRenderedHeight === undefined;
 
 		const treeItems: ITreeElement<ChatTreeItem>[] = items.map(item => ({
@@ -879,7 +885,7 @@ export class ChatListWidget extends Disposable {
 		if (this._renderStyle === 'compact' || this._renderStyle === 'minimal') {
 			this._container.style.removeProperty('--chat-current-response-min-height');
 		} else {
-			const secondToLastItem = this._viewModel?.getItems().at(-2);
+			const secondToLastItem = this.getItemBeforeStickyScrollTarget();
 			const maxRequestShownHeight = 200;
 			const secondToLastItemHeight = Math.min(
 				(isRequestVM(secondToLastItem) || isResponseVM(secondToLastItem)) ?
@@ -889,12 +895,21 @@ export class ChatListWidget extends Disposable {
 			this._container.style.setProperty('--chat-current-response-min-height', lastItemMinHeight + 'px');
 			if (lastItemMinHeight !== this._previousLastItemMinHeight) {
 				this._previousLastItemMinHeight = lastItemMinHeight;
-				const lastItem = this._viewModel?.getItems().at(-1);
+				const lastItem = this._stickyScrollTargetItem;
 				if (lastItem && this._visible && this._tree.hasElement(lastItem)) {
 					this._updateElementHeight(lastItem, undefined);
 				}
 			}
 		}
+	}
+
+	private getItemBeforeStickyScrollTarget(): ChatTreeItem | undefined {
+		const items = this._viewModel?.getItems();
+		if (!items || !this._stickyScrollTargetItem) {
+			return undefined;
+		}
+		const targetIndex = items.indexOf(this._stickyScrollTargetItem);
+		return targetIndex > 0 ? items[targetIndex - 1] : undefined;
 	}
 
 	//#endregion

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2952,7 +2952,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 		const inputHeight = this._inputVisible ? this.inputPart.height.get() : 0;
 		const lastElementVisible = this.listWidget.isScrolledToBottom;
-		const lastItem = this.listWidget.lastItem;
+		const lastItem = this.listWidget.stickyScrollTargetItem;
 
 		const contentHeight = Math.max(0, height - inputHeight - chatSuggestNextWidgetHeight);
 		this.listWidget.layout(contentHeight, width);

--- a/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
@@ -32,13 +32,13 @@ export function isPendingDividerVM(item: unknown): item is IChatPendingDividerVi
 	return !!item && typeof item === 'object' && (item as IChatPendingDividerViewModel).kind === 'pendingDivider';
 }
 
-export interface IChatViewModelItemWithPendingState {
+interface IChatViewModelItemWithPendingState {
 	readonly id: string;
 	readonly kind?: string;
 	readonly pendingKind?: ChatRequestQueueKind;
 }
 
-export function isPendingChatViewModelItem(item: IChatViewModelItemWithPendingState): boolean {
+function isPendingChatViewModelItem(item: IChatViewModelItemWithPendingState): boolean {
 	return item.kind === 'pendingDivider' || item.pendingKind !== undefined;
 }
 

--- a/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
@@ -32,6 +32,26 @@ export function isPendingDividerVM(item: unknown): item is IChatPendingDividerVi
 	return !!item && typeof item === 'object' && (item as IChatPendingDividerViewModel).kind === 'pendingDivider';
 }
 
+export interface IChatViewModelItemWithPendingState {
+	readonly id: string;
+	readonly kind?: string;
+	readonly pendingKind?: ChatRequestQueueKind;
+}
+
+export function isPendingChatViewModelItem(item: IChatViewModelItemWithPendingState): boolean {
+	return item.kind === 'pendingDivider' || item.pendingKind !== undefined;
+}
+
+export function getStickyScrollTargetItem<T extends IChatViewModelItemWithPendingState>(items: readonly T[]): T | undefined {
+	for (let i = items.length - 1; i >= 0; i--) {
+		const item = items[i];
+		if (!isPendingChatViewModelItem(item)) {
+			return item;
+		}
+	}
+	return items.at(-1);
+}
+
 export function isChatTreeItem(item: unknown): item is IChatRequestViewModel | IChatResponseViewModel {
 	return isRequestVM(item) || isResponseVM(item);
 }
@@ -642,7 +662,7 @@ export class ChatResponseViewModel extends Disposable implements IChatResponseVi
 	}
 
 	get isLast(): boolean {
-		return this.session.getItems().at(-1) === this;
+		return getStickyScrollTargetItem(this.session.getItems()) === this;
 	}
 
 	renderData: IChatResponseRenderData | undefined = undefined;

--- a/src/vs/workbench/contrib/chat/test/common/model/chatViewModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatViewModel.test.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { ChatRequestQueueKind } from '../../../common/chatService/chatService.js';
+import { getStickyScrollTargetItem } from '../../../common/model/chatViewModel.js';
+
+interface ITestChatViewModelItem {
+	readonly id: string;
+	readonly kind?: string;
+	readonly pendingKind?: ChatRequestQueueKind;
+}
+
+suite('ChatViewModel', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('sticky scroll target ignores trailing pending items', () => {
+		const response: ITestChatViewModelItem = { id: 'response' };
+		const pendingOnly: ITestChatViewModelItem = { id: 'pending-only', pendingKind: ChatRequestQueueKind.Queued };
+		const emptyItems: ITestChatViewModelItem[] = [];
+
+		assert.deepStrictEqual([
+			getStickyScrollTargetItem([
+				{ id: 'request' },
+				response,
+				{ id: 'pending-divider-steering', kind: 'pendingDivider' },
+				{ id: 'pending-steering', pendingKind: ChatRequestQueueKind.Steering },
+				{ id: 'pending-divider-queued', kind: 'pendingDivider' },
+				{ id: 'pending-queued', pendingKind: ChatRequestQueueKind.Queued },
+			])?.id,
+			getStickyScrollTargetItem([pendingOnly])?.id,
+			getStickyScrollTargetItem(emptyItems)?.id,
+		], [
+			'response',
+			'pending-only',
+			undefined,
+		]);
+	});
+});


### PR DESCRIPTION
## Summary
- Treat the last non-pending chat item as the sticky scroll target so active responses keep following while queued or steering messages are shown below them.
- Keep most-recent response rendering/progressive rendering semantics aligned with that target.
- Add unit coverage for pending rows trailing a response.

## Validation
- npm run typecheck-client
- .\scripts\test.bat --run src\vs\workbench\contrib\chat\test\common\model\chatViewModel.test.ts --grep "sticky scroll target ignores trailing pending items"
- node --experimental-strip-types build\hygiene.ts src\vs\workbench\contrib\chat\common\model\chatViewModel.ts src\vs\workbench\contrib\chat\browser\widget\chatListWidget.ts src\vs\workbench\contrib\chat\browser\widget\chatWidget.ts src\vs\workbench\contrib\chat\browser\widget\chatListRenderer.ts src\vs\workbench\contrib\chat\test\common\model\chatViewModel.test.ts
- npm run valid-layers-check