### PR TITLE
agentHost: emit enhanced GH request.options.tools telemetry

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostRestrictedTelemetry.ts
+++ b/src/vs/platform/agentHost/node/agentHostRestrictedTelemetry.ts
@@ -1,0 +1,167 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { generateUuid } from '../../../base/common/uuid.js';
+import { ILogService } from '../../log/common/log.js';
+import { ICommonProperties } from '../../telemetry/common/telemetry.js';
+
+/**
+ * Public GitHub Copilot telemetry ingestion keys. These are instrumentation keys, not
+ * secrets; the iKey selects the destination hydro table:
+ *  - standard  -> `copilot_v0_copilot_event`
+ *  - enhanced  -> `copilot_v0_restricted_copilot_event`
+ */
+const GH_STANDARD_IKEY = '7d7048df-6dd0-4048-bb23-b716c1461f8f';
+const GH_ENHANCED_IKEY = '3fdd7f28-937a-48c8-9a21-ba337db23bd1';
+
+/** Default Copilot telemetry endpoint (CAPI `telemetryURL`). Accepts unauthenticated POSTs. */
+const GH_TELEMETRY_URL = 'https://copilot-telemetry.githubusercontent.com/telemetry';
+
+/** Event names are namespaced by client category; the CTS name filter requires this. */
+const NAMESPACE = 'copilot-chat';
+
+export type TelemetryProps = Record<string, string | undefined>;
+export type TelemetryMeasurements = Record<string, number | undefined>;
+
+/**
+ * App Insights caps a single property value at ~8192 chars. Long values are split across
+ * numbered keys (`key`, `key_02`, `key_03`, …) so the Copilot Telemetry Service reassembles
+ * them, mirroring the Copilot extension's `multiplexProperties` so events look identical on the
+ * wire and downstream.
+ */
+const MAX_PROPERTY_LENGTH = 8192;
+const MAX_CONCATENATED_PROPERTIES = 50;
+
+export function multiplexProperties(properties: TelemetryProps): TelemetryProps {
+	const newProperties: TelemetryProps = { ...properties };
+	for (const key in properties) {
+		const value = properties[key];
+		let remaining = value?.length ?? 0;
+		if (remaining > MAX_PROPERTY_LENGTH) {
+			let lastStartIndex = 0;
+			let count = 0;
+			while (remaining > 0 && count < MAX_CONCATENATED_PROPERTIES) {
+				count += 1;
+				let propertyName = key;
+				if (count > 1) {
+					propertyName = key + '_' + (count < 10 ? '0' : '') + count;
+				}
+				let offsetIndex = lastStartIndex + MAX_PROPERTY_LENGTH;
+				if (remaining < MAX_PROPERTY_LENGTH) {
+					offsetIndex = lastStartIndex + remaining;
+				}
+				newProperties[propertyName] = value!.slice(lastStartIndex, offsetIndex);
+				remaining -= MAX_PROPERTY_LENGTH;
+				lastStartIndex += MAX_PROPERTY_LENGTH;
+			}
+		}
+	}
+	return newProperties;
+}
+
+/**
+ * The restricted telemetry surface the agent host exposes, mirroring the Copilot extension's
+ * `ITelemetryService` restricted methods so agent-host code can emit the same GH/MSFT events.
+ */
+export interface IAgentHostRestrictedTelemetry {
+	/** GH standard (non-restricted) telemetry -> `copilot_v0_copilot_event`. */
+	sendGHTelemetryEvent(eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void;
+	/** GH enhanced/restricted telemetry (prompts, tools, etc.) -> `copilot_v0_restricted_copilot_event`. */
+	sendEnhancedGHTelemetryEvent(eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void;
+	/** MSFT-internal telemetry -> Aria/Collector++ (internal-only table). No-op without an internal key. */
+	sendInternalMSFTTelemetryEvent(eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void;
+}
+
+/**
+ * Emits GitHub Copilot restricted/enhanced telemetry from the agent-host process by POSTing
+ * Application-Insights envelopes to the Copilot telemetry endpoint (the same wire format the
+ * Copilot extension uses). Fire-and-forget; failures are logged, never thrown.
+ */
+export class AgentHostRestrictedTelemetrySender implements IAgentHostRestrictedTelemetry {
+
+	private readonly _commonProps: TelemetryProps;
+
+	constructor(
+		commonProperties: ICommonProperties,
+		private readonly _logService: ILogService,
+		private readonly _endpointUrl: string = GH_TELEMETRY_URL,
+		private readonly _internalSink?: (eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements) => void,
+	) {
+		// Map the resolved common properties onto the GH property names the hydro schema reads.
+		this._commonProps = {
+			client_machineid: asString(commonProperties['common.machineId']),
+			client_deviceid: asString(commonProperties['common.devDeviceId']),
+			client_sessionid: asString(commonProperties['sessionID']),
+			common_os: asString(commonProperties['common.nodePlatform']) ?? process.platform,
+			editor_version: asString(commonProperties['version']),
+		};
+	}
+
+	sendGHTelemetryEvent(eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void {
+		this._post(GH_STANDARD_IKEY, eventName, properties, measurements);
+	}
+
+	sendEnhancedGHTelemetryEvent(eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void {
+		this._post(GH_ENHANCED_IKEY, eventName, properties, measurements);
+	}
+
+	sendInternalMSFTTelemetryEvent(eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void {
+		// Internal MSFT telemetry lands in the Aria/Collector++ pipeline via a dedicated key,
+		// which is not present in the agent-host product config. Route to the optional sink when
+		// wired; otherwise trace so the event is at least visible in the agent-host log.
+		if (this._internalSink) {
+			this._internalSink(eventName, properties, measurements);
+			return;
+		}
+		this._logService.trace(`[ahp-restricted] internal MSFT event (not sent, no internal key): ${eventName}`);
+	}
+
+	private _post(iKey: string, eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void {
+		const name = eventName.includes('/') ? eventName : `${NAMESPACE}/${eventName}`;
+		const envelope = {
+			ver: 1,
+			name: `Microsoft.ApplicationInsights.${iKey.replace(/-/g, '')}.Event`,
+			time: new Date().toISOString(),
+			sampleRate: 100,
+			seq: '',
+			iKey,
+			tags: { 'ai.operation.id': generateUuid() },
+			data: {
+				baseType: 'EventData',
+				baseData: {
+					name,
+					properties: { ...this._commonProps, ...properties },
+					measurements: measurements ?? {},
+				},
+			},
+		};
+
+		this._logService.trace(`[ahp-restricted] emit ${name} (iKey ${iKey.slice(0, 8)})`);
+
+		if (typeof fetch !== 'function') {
+			this._logService.warn('[ahp-restricted] global fetch unavailable; telemetry not sent');
+			return;
+		}
+
+		// Fire-and-forget: post the event and move on. Delivery/robustness is intentionally kept
+		// simple here — failures are logged, not retried (a retry loop would only mask local
+		// telemetry-blocking resolvers, which do not exist in production).
+		fetch(this._endpointUrl, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-json-stream' },
+			body: JSON.stringify(envelope),
+		}).then(res => {
+			if (!res.ok) {
+				this._logService.warn(`[ahp-restricted] ${name} rejected: HTTP ${res.status}`);
+			}
+		}).catch(err => {
+			this._logService.warn(`[ahp-restricted] ${name} POST failed: ${err instanceof Error ? err.message : String(err)}`);
+		});
+	}
+}
+
+function asString(value: string | boolean | undefined): string | undefined {
+	return typeof value === 'string' ? value : value === undefined ? undefined : String(value);
+}

--- a/src/vs/platform/agentHost/node/agentHostRestrictedTelemetry.ts
+++ b/src/vs/platform/agentHost/node/agentHostRestrictedTelemetry.ts
@@ -30,6 +30,9 @@ const NAMESPACE = 'copilot-chat';
 export type TelemetryProps = Record<string, string | undefined>;
 export type TelemetryMeasurements = Record<string, number | undefined>;
 
+/** The subset of the global `fetch` used to POST envelopes; injectable so tests avoid live network calls. */
+type FetchFn = typeof globalThis.fetch;
+
 /**
  * App Insights caps a single property value at ~8192 chars. Long values are split across
  * numbered keys (`key`, `key_02`, `key_03`, …) so the Copilot Telemetry Service reassembles
@@ -81,6 +84,8 @@ export interface IAgentHostRestrictedTelemetry {
 	setCopilotTrackingId(trackingId: string | undefined): void;
 	/** Overrides the POST endpoint with the user's CAPI `endpoints.telemetry`; falsy restores the default. */
 	setRestrictedTelemetryEndpoint(endpointUrl: string | undefined): void;
+	/** Enables enhanced GH telemetry once the token opts in (`rt=1`); off by default and on flip/logout. */
+	setRestrictedTelemetryEnabled(enabled: boolean): void;
 }
 
 /**
@@ -92,11 +97,20 @@ export class AgentHostRestrictedTelemetrySender implements IAgentHostRestrictedT
 
 	private readonly _commonProps: TelemetryProps;
 
+	/**
+	 * Whether the current Copilot token opts into enhanced/restricted telemetry (`rt=1`). Off by
+	 * default so the sole writer to the restricted table never emits for public users — a hard
+	 * safety boundary that holds even if the enclosing service's gate is bypassed. Mirrors the
+	 * Copilot extension, which only creates the restricted reporter for opted-in users.
+	 */
+	private _restrictedTelemetryEnabled = false;
+
 	constructor(
 		commonProperties: ICommonProperties,
 		private readonly _logService: ILogService,
 		private _endpointUrl: string = GH_TELEMETRY_URL,
 		private readonly _internalSink?: (eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements) => void,
+		private readonly _fetchFn: FetchFn = globalThis.fetch,
 	) {
 		// Map the resolved common properties onto the GH property names the hydro schema reads.
 		this._commonProps = {
@@ -113,6 +127,13 @@ export class AgentHostRestrictedTelemetrySender implements IAgentHostRestrictedT
 	}
 
 	sendEnhancedGHTelemetryEvent(eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void {
+		// Hard safety boundary: enhanced/restricted telemetry is the pipeline that may carry prompt
+		// and tool content, so the only writer to the restricted table refuses to emit unless the
+		// user's token opted in (`rt=1`). This holds even if a caller reaches the sender without the
+		// service-level `rt`/telemetry-level gate.
+		if (!this._restrictedTelemetryEnabled) {
+			return;
+		}
 		this._post(GH_ENHANCED_IKEY, eventName, properties, measurements);
 	}
 
@@ -138,6 +159,10 @@ export class AgentHostRestrictedTelemetrySender implements IAgentHostRestrictedT
 		// The user's telemetry host comes from the CAPI `endpoints.telemetry` discovery; fall back
 		// to the dotcom default when it is unknown so events are never sent to an empty URL.
 		this._endpointUrl = endpointUrl || GH_TELEMETRY_URL;
+	}
+
+	setRestrictedTelemetryEnabled(enabled: boolean): void {
+		this._restrictedTelemetryEnabled = enabled;
 	}
 
 	private _post(iKey: string, eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void {
@@ -166,7 +191,7 @@ export class AgentHostRestrictedTelemetrySender implements IAgentHostRestrictedT
 
 		this._logService.trace(`[ahp-restricted] emit ${name} (iKey ${iKey.slice(0, 8)})`);
 
-		if (typeof fetch !== 'function') {
+		if (typeof this._fetchFn !== 'function') {
 			this._logService.warn('[ahp-restricted] global fetch unavailable; telemetry not sent');
 			return;
 		}
@@ -174,7 +199,7 @@ export class AgentHostRestrictedTelemetrySender implements IAgentHostRestrictedT
 		// Fire-and-forget: post the event and move on. Delivery/robustness is intentionally kept
 		// simple here — failures are logged, not retried (a retry loop would only mask local
 		// telemetry-blocking resolvers, which do not exist in production).
-		fetch(this._endpointUrl, {
+		this._fetchFn(this._endpointUrl, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/x-json-stream' },
 			body: JSON.stringify(envelope),

--- a/src/vs/platform/agentHost/node/agentHostRestrictedTelemetry.ts
+++ b/src/vs/platform/agentHost/node/agentHostRestrictedTelemetry.ts
@@ -72,6 +72,8 @@ export interface IAgentHostRestrictedTelemetry {
 	sendEnhancedGHTelemetryEvent(eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void;
 	/** MSFT-internal telemetry -> Aria/Collector++ (internal-only table). No-op without an internal key. */
 	sendInternalMSFTTelemetryEvent(eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void;
+	/** Sets the Copilot user tracking id (`copilot_trackingId`) carried on every subsequent event. */
+	setCopilotTrackingId(trackingId: string | undefined): void;
 }
 
 /**
@@ -118,6 +120,13 @@ export class AgentHostRestrictedTelemetrySender implements IAgentHostRestrictedT
 		this._logService.trace(`[ahp-restricted] internal MSFT event (not sent, no internal key): ${eventName}`);
 	}
 
+	setCopilotTrackingId(trackingId: string | undefined): void {
+		// `copilot_trackingId` is the Copilot token's `tid` claim: a stable per-user id (one user
+		// per agent-host process). The Copilot Telemetry Service reads it into the
+		// `copilot_tracking_id` column, matching the Copilot extension.
+		this._commonProps.copilot_trackingId = trackingId || undefined;
+	}
+
 	private _post(iKey: string, eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void {
 		const name = eventName.includes('/') ? eventName : `${NAMESPACE}/${eventName}`;
 		const envelope = {
@@ -132,7 +141,11 @@ export class AgentHostRestrictedTelemetrySender implements IAgentHostRestrictedT
 				baseType: 'EventData',
 				baseData: {
 					name,
-					properties: { ...this._commonProps, ...properties },
+					// `unique_id` is a fresh per-event id (its hydro column is read by the Copilot
+					// Telemetry Service from the snake_case `unique_id` property, NOT `uniqueId`),
+					// mirroring the Copilot extension so each emitted event stays individually
+					// addressable. Placed first so explicit properties still win on collision.
+					properties: { unique_id: generateUuid(), ...this._commonProps, ...properties },
 					measurements: measurements ?? {},
 				},
 			},

--- a/src/vs/platform/agentHost/node/agentHostRestrictedTelemetry.ts
+++ b/src/vs/platform/agentHost/node/agentHostRestrictedTelemetry.ts
@@ -16,7 +16,12 @@ import { ICommonProperties } from '../../telemetry/common/telemetry.js';
 const GH_STANDARD_IKEY = '7d7048df-6dd0-4048-bb23-b716c1461f8f';
 const GH_ENHANCED_IKEY = '3fdd7f28-937a-48c8-9a21-ba337db23bd1';
 
-/** Default Copilot telemetry endpoint (CAPI `telemetryURL`). Accepts unauthenticated POSTs. */
+/**
+ * Fallback Copilot telemetry endpoint (the dotcom value of the CAPI token's
+ * `endpoints.telemetry`, with the `/telemetry` path the Copilot CLI/runtime appends).
+ * Used until {@link IAgentHostRestrictedTelemetry.setRestrictedTelemetryEndpoint} supplies
+ * the user's discovered endpoint (dotcom, GHE, or proxy). Accepts unauthenticated POSTs.
+ */
 const GH_TELEMETRY_URL = 'https://copilot-telemetry.githubusercontent.com/telemetry';
 
 /** Event names are namespaced by client category; the CTS name filter requires this. */
@@ -74,6 +79,8 @@ export interface IAgentHostRestrictedTelemetry {
 	sendInternalMSFTTelemetryEvent(eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void;
 	/** Sets the Copilot user tracking id (`copilot_trackingId`) carried on every subsequent event. */
 	setCopilotTrackingId(trackingId: string | undefined): void;
+	/** Overrides the POST endpoint with the user's CAPI `endpoints.telemetry`; falsy restores the default. */
+	setRestrictedTelemetryEndpoint(endpointUrl: string | undefined): void;
 }
 
 /**
@@ -88,7 +95,7 @@ export class AgentHostRestrictedTelemetrySender implements IAgentHostRestrictedT
 	constructor(
 		commonProperties: ICommonProperties,
 		private readonly _logService: ILogService,
-		private readonly _endpointUrl: string = GH_TELEMETRY_URL,
+		private _endpointUrl: string = GH_TELEMETRY_URL,
 		private readonly _internalSink?: (eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements) => void,
 	) {
 		// Map the resolved common properties onto the GH property names the hydro schema reads.
@@ -125,6 +132,12 @@ export class AgentHostRestrictedTelemetrySender implements IAgentHostRestrictedT
 		// per agent-host process). The Copilot Telemetry Service reads it into the
 		// `copilot_tracking_id` column, matching the Copilot extension.
 		this._commonProps.copilot_trackingId = trackingId || undefined;
+	}
+
+	setRestrictedTelemetryEndpoint(endpointUrl: string | undefined): void {
+		// The user's telemetry host comes from the CAPI `endpoints.telemetry` discovery; fall back
+		// to the dotcom default when it is unknown so events are never sent to an empty URL.
+		this._endpointUrl = endpointUrl || GH_TELEMETRY_URL;
 	}
 
 	private _post(iKey: string, eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void {

--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -6,9 +6,10 @@
 import type { LanguageModelToolInvokedClassification, LanguageModelToolInvokedEvent } from '../../telemetry/common/languageModelToolTelemetry.js';
 import type { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { AgentSession } from '../common/agentService.js';
-import type { MessageAttachment } from '../common/state/protocol/state.js';
+import type { MessageAttachment, ToolDefinition } from '../common/state/protocol/state.js';
 import { isAhpChatChannel, isSubagentSession, parseRequiredSessionUriFromChatUri, type ISessionWithDefaultChat } from '../common/state/sessionState.js';
 import type { ToolInvokedResult } from './agentHostToolCallTracker.js';
+import { multiplexProperties, type IAgentHostRestrictedTelemetry } from './agentHostRestrictedTelemetry.js';
 
 export type AgentHostUserMessageSentSource = 'direct' | 'queued';
 
@@ -85,6 +86,21 @@ export class AgentHostTelemetryReporter {
 
 	constructor(private readonly _telemetryService: ITelemetryService) { }
 
+	/** The restricted GH/MSFT telemetry surface, present when the agent-host telemetry service is wired. */
+	private get _restricted(): IAgentHostRestrictedTelemetry | undefined {
+		const ts = this._telemetryService as Partial<IAgentHostRestrictedTelemetry>;
+		return typeof ts.sendEnhancedGHTelemetryEvent === 'function' ? ts as IAgentHostRestrictedTelemetry : undefined;
+	}
+
+	/**
+	 * Records the Copilot user tracking id (the token's `tid` claim) as a restricted-telemetry
+	 * common property so every enhanced GH event carries it, matching the Copilot extension's
+	 * `copilot_trackingId`. Safe to call repeatedly; the underlying sender is a process singleton.
+	 */
+	setCopilotTrackingId(trackingId: string | undefined): void {
+		this._restricted?.setCopilotTrackingId(trackingId);
+	}
+
 	userMessageSent(provider: string, session: string, sessionState: ISessionWithDefaultChat | undefined, source: AgentHostUserMessageSentSource, attachments: readonly MessageAttachment[] | undefined): void {
 		const attachmentCount = attachments?.length ?? 0;
 		const activeClients = sessionState?.activeClients ?? [];
@@ -102,6 +118,32 @@ export class AgentHostTelemetryReporter {
 			} : {}),
 			attachmentCount,
 		});
+	}
+
+	/**
+	 * Mirrors the Copilot extension's enhanced GH `request.options.tools` event for the agent-host
+	 * flow. The extension emits it per LLM request from its model fetcher; the agent host observes
+	 * the equivalent boundary when an `assistant.message` arrives (one per model call). The
+	 * extension populates `headerRequestId` with the client-minted `x-request-id`, which the SDK
+	 * does not surface on success; we keep the same field name (so science queries are undisturbed)
+	 * but fill it with the model call's `x-copilot-service-request-id`, the per-call id the SDK does
+	 * expose. `messagesJson` is the raw tool definitions offered for the call, multiplexed across
+	 * ~8192-char chunks like the extension, so it lands identically downstream.
+	 *
+	 * @param session Session URI string; its id becomes `conversationId`.
+	 * @param serviceRequestId The model call's `x-copilot-service-request-id`, mapped to the extension's `headerRequestId`. No-ops when absent (e.g. providers that don't surface it).
+	 * @param tools The tool definitions offered to the model for this call.
+	 */
+	assistantMessageReceived(session: string, serviceRequestId: string | undefined, tools: readonly ToolDefinition[]): void {
+		const restricted = this._restricted;
+		if (!restricted || !serviceRequestId || tools.length === 0) {
+			return;
+		}
+		restricted.sendEnhancedGHTelemetryEvent('request.options.tools', multiplexProperties({
+			headerRequestId: serviceRequestId,
+			conversationId: AgentSession.id(session),
+			messagesJson: JSON.stringify(tools),
+		}));
 	}
 
 	turnCompleted(report: IAgentHostTurnCompletedReport): void {

--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -92,15 +92,6 @@ export class AgentHostTelemetryReporter {
 		return typeof ts.sendEnhancedGHTelemetryEvent === 'function' ? ts as IAgentHostRestrictedTelemetry : undefined;
 	}
 
-	/**
-	 * Records the Copilot user tracking id (the token's `tid` claim) as a restricted-telemetry
-	 * common property so every enhanced GH event carries it, matching the Copilot extension's
-	 * `copilot_trackingId`. Safe to call repeatedly; the underlying sender is a process singleton.
-	 */
-	setCopilotTrackingId(trackingId: string | undefined): void {
-		this._restricted?.setCopilotTrackingId(trackingId);
-	}
-
 	userMessageSent(provider: string, session: string, sessionState: ISessionWithDefaultChat | undefined, source: AgentHostUserMessageSentSource, attachments: readonly MessageAttachment[] | undefined): void {
 		const attachmentCount = attachments?.length ?? 0;
 		const activeClients = sessionState?.activeClients ?? [];

--- a/src/vs/platform/agentHost/node/agentHostTelemetryService.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryService.ts
@@ -21,6 +21,7 @@ import { TelemetryLogAppender } from '../../telemetry/common/telemetryLogAppende
 import { TelemetryService } from '../../telemetry/common/telemetryService.js';
 import { getPiiPathsFromEnvironment, isInternalTelemetry, isLoggingOnly, NullTelemetryService, supportsTelemetry, type ITelemetryAppender } from '../../telemetry/common/telemetryUtils.js';
 import { AgentHostTelemetryLevelConfigKey, agentHostConfigValueToTelemetryLevel } from '../common/agentHostSchema.js';
+import { AgentHostRestrictedTelemetrySender, IAgentHostRestrictedTelemetry, TelemetryMeasurements, TelemetryProps } from './agentHostRestrictedTelemetry.js';
 
 export interface IAgentHostTelemetryServiceOptions {
 	readonly environmentService: INativeEnvironmentService;
@@ -32,7 +33,7 @@ export interface IAgentHostTelemetryServiceOptions {
 	readonly disableTelemetry?: boolean;
 }
 
-export interface IAgentHostTelemetryService extends ITelemetryService {
+export interface IAgentHostTelemetryService extends ITelemetryService, IAgentHostRestrictedTelemetry {
 	updateTelemetryLevel(telemetryLevel: TelemetryLevel): void;
 }
 
@@ -41,7 +42,10 @@ export class AgentHostTelemetryService extends Disposable implements IAgentHostT
 
 	private _telemetryLevel = TelemetryLevel.USAGE;
 
-	constructor(private readonly _delegate: ITelemetryService) {
+	constructor(
+		private readonly _delegate: ITelemetryService,
+		private readonly _restricted?: IAgentHostRestrictedTelemetry,
+	) {
 		super();
 		if (isDisposable(_delegate)) {
 			this._register(_delegate);
@@ -108,6 +112,27 @@ export class AgentHostTelemetryService extends Disposable implements IAgentHostT
 		this._delegate.publicLogError2(eventName, data);
 	}
 
+	sendGHTelemetryEvent(eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void {
+		if (this.telemetryLevel < TelemetryLevel.USAGE) {
+			return;
+		}
+		this._restricted?.sendGHTelemetryEvent(eventName, properties, measurements);
+	}
+
+	sendEnhancedGHTelemetryEvent(eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void {
+		if (this.telemetryLevel < TelemetryLevel.USAGE) {
+			return;
+		}
+		this._restricted?.sendEnhancedGHTelemetryEvent(eventName, properties, measurements);
+	}
+
+	sendInternalMSFTTelemetryEvent(eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void {
+		if (this.telemetryLevel < TelemetryLevel.USAGE) {
+			return;
+		}
+		this._restricted?.sendInternalMSFTTelemetryEvent(eventName, properties, measurements);
+	}
+
 	setExperimentProperty(name: string, value: string): void {
 		this._delegate.setExperimentProperty(name, value);
 	}
@@ -159,12 +184,16 @@ export async function createAgentHostTelemetryService(options: IAgentHostTelemet
 		getDevDeviceId(error => logService.error(error)),
 	]);
 
+	const commonProperties = resolveCommonProperties(release(), hostname(), process.arch, productService.commit, productService.version, machineId, sqmId, devDeviceId, internalTelemetry, productService.date);
+
 	const telemetryService = new TelemetryService({
 		appenders,
 		sendErrorTelemetry: true,
-		commonProperties: resolveCommonProperties(release(), hostname(), process.arch, productService.commit, productService.version, machineId, sqmId, devDeviceId, internalTelemetry, productService.date),
+		commonProperties,
 		piiPaths: getPiiPathsFromEnvironment(environmentService),
 	}, configurationService, productService);
 
-	return disposables.add(new AgentHostTelemetryService(telemetryService));
+	const restricted = new AgentHostRestrictedTelemetrySender(commonProperties, logService);
+
+	return disposables.add(new AgentHostTelemetryService(telemetryService, restricted));
 }

--- a/src/vs/platform/agentHost/node/agentHostTelemetryService.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryService.ts
@@ -35,8 +35,6 @@ export interface IAgentHostTelemetryServiceOptions {
 
 export interface IAgentHostTelemetryService extends ITelemetryService, IAgentHostRestrictedTelemetry {
 	updateTelemetryLevel(telemetryLevel: TelemetryLevel): void;
-	/** Gates enhanced GH (restricted) telemetry on the token's `rt=1` claim. Off until enabled. */
-	setRestrictedTelemetryEnabled(enabled: boolean): void;
 }
 
 export class AgentHostTelemetryService extends Disposable implements IAgentHostTelemetryService {
@@ -152,6 +150,9 @@ export class AgentHostTelemetryService extends Disposable implements IAgentHostT
 
 	setRestrictedTelemetryEnabled(enabled: boolean): void {
 		this._restrictedTelemetryEnabled = enabled;
+		// Mirror onto the sender so the restricted-table writer enforces the same `rt` gate
+		// independently (defense in depth), matching the extension's opted-in-only reporter.
+		this._restricted?.setRestrictedTelemetryEnabled(enabled);
 	}
 
 	setExperimentProperty(name: string, value: string): void {

--- a/src/vs/platform/agentHost/node/agentHostTelemetryService.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryService.ts
@@ -133,6 +133,10 @@ export class AgentHostTelemetryService extends Disposable implements IAgentHostT
 		this._restricted?.sendInternalMSFTTelemetryEvent(eventName, properties, measurements);
 	}
 
+	setCopilotTrackingId(trackingId: string | undefined): void {
+		this._restricted?.setCopilotTrackingId(trackingId);
+	}
+
 	setExperimentProperty(name: string, value: string): void {
 		this._delegate.setExperimentProperty(name, value);
 	}

--- a/src/vs/platform/agentHost/node/agentHostTelemetryService.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryService.ts
@@ -35,12 +35,21 @@ export interface IAgentHostTelemetryServiceOptions {
 
 export interface IAgentHostTelemetryService extends ITelemetryService, IAgentHostRestrictedTelemetry {
 	updateTelemetryLevel(telemetryLevel: TelemetryLevel): void;
+	/** Gates enhanced GH (restricted) telemetry on the token's `rt=1` claim. Off until enabled. */
+	setRestrictedTelemetryEnabled(enabled: boolean): void;
 }
 
 export class AgentHostTelemetryService extends Disposable implements IAgentHostTelemetryService {
 	declare readonly _serviceBrand: undefined;
 
 	private _telemetryLevel = TelemetryLevel.USAGE;
+
+	/**
+	 * Whether the current Copilot token opts into enhanced/restricted telemetry (`rt=1`). Defaults
+	 * to `false` so nothing restricted is sent until an authenticated token confirms the opt-in,
+	 * keeping public users off the enhanced pipeline the way the Copilot extension does.
+	 */
+	private _restrictedTelemetryEnabled = false;
 
 	constructor(
 		private readonly _delegate: ITelemetryService,
@@ -120,7 +129,7 @@ export class AgentHostTelemetryService extends Disposable implements IAgentHostT
 	}
 
 	sendEnhancedGHTelemetryEvent(eventName: string, properties?: TelemetryProps, measurements?: TelemetryMeasurements): void {
-		if (this.telemetryLevel < TelemetryLevel.USAGE) {
+		if (this.telemetryLevel < TelemetryLevel.USAGE || !this._restrictedTelemetryEnabled) {
 			return;
 		}
 		this._restricted?.sendEnhancedGHTelemetryEvent(eventName, properties, measurements);
@@ -135,6 +144,10 @@ export class AgentHostTelemetryService extends Disposable implements IAgentHostT
 
 	setCopilotTrackingId(trackingId: string | undefined): void {
 		this._restricted?.setCopilotTrackingId(trackingId);
+	}
+
+	setRestrictedTelemetryEnabled(enabled: boolean): void {
+		this._restrictedTelemetryEnabled = enabled;
 	}
 
 	setExperimentProperty(name: string, value: string): void {
@@ -159,7 +172,7 @@ export function updateAgentHostTelemetryLevelFromConfig(telemetryService: ITelem
 	telemetryService.updateTelemetryLevel(telemetryLevelValue);
 }
 
-function isAgentHostTelemetryService(telemetryService: ITelemetryService): telemetryService is IAgentHostTelemetryService {
+export function isAgentHostTelemetryService(telemetryService: ITelemetryService): telemetryService is IAgentHostTelemetryService {
 	return typeof (telemetryService as IAgentHostTelemetryService).updateTelemetryLevel === 'function';
 }
 

--- a/src/vs/platform/agentHost/node/agentHostTelemetryService.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryService.ts
@@ -146,6 +146,10 @@ export class AgentHostTelemetryService extends Disposable implements IAgentHostT
 		this._restricted?.setCopilotTrackingId(trackingId);
 	}
 
+	setRestrictedTelemetryEndpoint(endpointUrl: string | undefined): void {
+		this._restricted?.setRestrictedTelemetryEndpoint(endpointUrl);
+	}
+
 	setRestrictedTelemetryEnabled(enabled: boolean): void {
 		this._restrictedTelemetryEnabled = enabled;
 	}

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -683,7 +683,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	private _applyRestrictedTelemetry(rtEnabled: boolean, trackingId: string | undefined, telemetryEndpoint: string | undefined): void {
 		if (rtEnabled !== this._restrictedTelemetryEnabled) {
 			this._restrictedTelemetryEnabled = rtEnabled;
-			this._logService.info(`[Copilot] Restricted telemetry ${rtEnabled ? 'enabled' : 'disabled'}`);
+			this._logService.info(`[Copilot] Enhanced (restricted) telemetry ${rtEnabled ? 'enabled for this account' : 'disabled'}`);
 			this._onDidChangeRestrictedTelemetry.fire();
 		}
 		// Push the token-derived telemetry policy/identity to the restricted sender: `rt` gates

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -670,9 +670,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 			if (this._githubToken !== githubToken) {
 				return; // token changed while resolving; a newer call owns the state
 			}
-			// TEMP DIAGNOSTIC (remove before merge): resolved restricted-telemetry context from the
-			// minted CAPI Copilot token — rt opt-in, whether a tracking id is present, and the endpoint.
-			this._logService.info(`[Copilot] rt-debug resolved rt=${ctx.restrictedTelemetryEnabled} tid=${ctx.trackingId ? 'set' : '<none>'} endpoint=${ctx.telemetryEndpoint ?? '<none>'}`);
 			this._applyRestrictedTelemetry(
 				ctx.restrictedTelemetryEnabled,
 				ctx.trackingId,

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -59,7 +59,6 @@ import { ICopilotSessionContext, projectFromCopilotContext } from './copilotGitP
 import { parsedPluginsEqual, toChildCustomizations } from './copilotPluginConverters.js';
 import { CopilotSessionLauncher, ContextSizeConfigKey, ThinkingLevelConfigKey, getCopilotContextTier, getCopilotReasoningEffort, type CopilotSessionLaunchPlan, type IActiveClientSnapshot } from './copilotSessionLauncher.js';
 import { ShellManager } from './copilotShellTools.js';
-import { isRestrictedTelemetryEnabled, parseCopilotTokenFields } from './copilotTokenFields.js';
 import { isAgentHostTelemetryService } from '../agentHostTelemetryService.js';
 import { ICopilotApiService } from '../shared/copilotApiService.js';
 import { CopilotSlashCommandCompletionProvider } from './copilotSlashCommandCompletionProvider.js';
@@ -653,32 +652,50 @@ export class CopilotAgent extends Disposable implements IAgent {
 		return handled;
 	}
 
-	private _updateRestrictedTelemetry(token: string | undefined): void {
-		const rtEnabled = isRestrictedTelemetryEnabled(token);
+	private _updateRestrictedTelemetry(githubToken: string | undefined): void {
+		// Safe default synchronously: keep restricted/enhanced telemetry disabled until the minted
+		// CAPI Copilot session token confirms the `rt=1` opt-in. The GitHub token here carries no
+		// `rt`/`tid` claims — those live in the Copilot session token, which the API service mints —
+		// so the real values are resolved asynchronously below. Mirrors how the Copilot extension
+		// reads `rt`/`tid` off its `CopilotToken` rather than the GitHub token.
+		this._applyRestrictedTelemetry(false, undefined, undefined);
+		if (githubToken) {
+			void this._resolveRestrictedTelemetry(githubToken);
+		}
+	}
+
+	private async _resolveRestrictedTelemetry(githubToken: string): Promise<void> {
+		try {
+			const ctx = await this._copilotApiService.resolveRestrictedTelemetryContext(githubToken);
+			if (this._githubToken !== githubToken) {
+				return; // token changed while resolving; a newer call owns the state
+			}
+			// TEMP DIAGNOSTIC (remove before merge): resolved restricted-telemetry context from the
+			// minted CAPI Copilot token — rt opt-in, whether a tracking id is present, and the endpoint.
+			this._logService.info(`[Copilot] rt-debug resolved rt=${ctx.restrictedTelemetryEnabled} tid=${ctx.trackingId ? 'set' : '<none>'} endpoint=${ctx.telemetryEndpoint ?? '<none>'}`);
+			this._applyRestrictedTelemetry(
+				ctx.restrictedTelemetryEnabled,
+				ctx.trackingId,
+				ctx.telemetryEndpoint ? `${ctx.telemetryEndpoint}/telemetry` : undefined,
+			);
+		} catch (err) {
+			this._logService.debug(`[Copilot] Restricted telemetry resolution failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+
+	private _applyRestrictedTelemetry(rtEnabled: boolean, trackingId: string | undefined, telemetryEndpoint: string | undefined): void {
 		if (rtEnabled !== this._restrictedTelemetryEnabled) {
 			this._restrictedTelemetryEnabled = rtEnabled;
 			this._logService.info(`[Copilot] Restricted telemetry ${rtEnabled ? 'enabled' : 'disabled'}`);
 			this._onDidChangeRestrictedTelemetry.fire();
 		}
 		// Push the token-derived telemetry policy/identity to the restricted sender: `rt` gates
-		// enhanced GH telemetry (kept off for public users) and `tid` becomes `copilot_trackingId`.
-		if (!isAgentHostTelemetryService(this._telemetryService)) {
-			return;
-		}
-		const telemetryService = this._telemetryService;
-		telemetryService.setRestrictedTelemetryEnabled(rtEnabled);
-		telemetryService.setCopilotTrackingId(parseCopilotTokenFields(token).get('tid'));
-		// Route restricted telemetry at the user's CAPI `endpoints.telemetry` (dotcom, GHE, or proxy)
-		// rather than the dotcom default. Only opted-in (`rt=1`) users emit it, so only they pay the
-		// discovery; resolution is async, so any events before it resolves use the fallback URL.
-		if (rtEnabled && token) {
-			void this._copilotApiService.resolveTelemetryEndpoint(token).then(endpoint => {
-				if (this._githubToken === token) {
-					telemetryService.setRestrictedTelemetryEndpoint(endpoint ? `${endpoint}/telemetry` : undefined);
-				}
-			}, err => {
-				this._logService.debug(`[Copilot] Telemetry endpoint discovery failed: ${err instanceof Error ? err.message : String(err)}`);
-			});
+		// enhanced GH telemetry (kept off for public users), `tid` becomes `copilot_trackingId`, and
+		// the endpoint routes at the user's CAPI telemetry host (dotcom, GHE, or proxy).
+		if (isAgentHostTelemetryService(this._telemetryService)) {
+			this._telemetryService.setRestrictedTelemetryEnabled(rtEnabled);
+			this._telemetryService.setCopilotTrackingId(trackingId);
+			this._telemetryService.setRestrictedTelemetryEndpoint(telemetryEndpoint);
 		}
 	}
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -27,6 +27,7 @@ import { IParsedAgent, IParsedPlugin, IParsedRule, IParsedSkill, parseAgentFile,
 import { IFileService } from '../../../files/common/files.js';
 import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
 import { ILogService, LogLevel } from '../../../log/common/log.js';
+import { ITelemetryService } from '../../../telemetry/common/telemetry.js';
 import { INativeEnvironmentService } from '../../../../platform/environment/common/environment.js';
 import { workspacelessScratchDir } from '../workspacelessScratchDir.js';
 import { IAgentHostCheckpointService } from '../../common/agentHostCheckpointService.js';
@@ -58,7 +59,8 @@ import { ICopilotSessionContext, projectFromCopilotContext } from './copilotGitP
 import { parsedPluginsEqual, toChildCustomizations } from './copilotPluginConverters.js';
 import { CopilotSessionLauncher, ContextSizeConfigKey, ThinkingLevelConfigKey, getCopilotContextTier, getCopilotReasoningEffort, type CopilotSessionLaunchPlan, type IActiveClientSnapshot } from './copilotSessionLauncher.js';
 import { ShellManager } from './copilotShellTools.js';
-import { isRestrictedTelemetryEnabled } from './copilotTokenFields.js';
+import { isRestrictedTelemetryEnabled, parseCopilotTokenFields } from './copilotTokenFields.js';
+import { isAgentHostTelemetryService } from '../agentHostTelemetryService.js';
 import { CopilotSlashCommandCompletionProvider } from './copilotSlashCommandCompletionProvider.js';
 import { DiscoveredType, SessionCustomizationDiscovery, areDiscoveredDirectoriesEqual, type IDiscoveredDirectory } from './sessionCustomizationDiscovery.js';
 import { COPILOT_INTEGRATION_ID } from '../../../endpoint/common/licenseAgreement.js';
@@ -465,6 +467,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		@IAgentHostCheckpointService private readonly _checkpointService: IAgentHostCheckpointService,
 		@INativeEnvironmentService private readonly _environmentService: INativeEnvironmentService,
 		@IByokLmBridgeRegistry private readonly _byokBridgeRegistry: IByokLmBridgeRegistry,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
 		this._plugins = this._register(this._instantiationService.createInstance(PluginController));
@@ -654,6 +657,12 @@ export class CopilotAgent extends Disposable implements IAgent {
 			this._restrictedTelemetryEnabled = rtEnabled;
 			this._logService.info(`[Copilot] Restricted telemetry ${rtEnabled ? 'enabled' : 'disabled'}`);
 			this._onDidChangeRestrictedTelemetry.fire();
+		}
+		// Push the token-derived telemetry policy/identity to the restricted sender: `rt` gates
+		// enhanced GH telemetry (kept off for public users) and `tid` becomes `copilot_trackingId`.
+		if (isAgentHostTelemetryService(this._telemetryService)) {
+			this._telemetryService.setRestrictedTelemetryEnabled(rtEnabled);
+			this._telemetryService.setCopilotTrackingId(parseCopilotTokenFields(token).get('tid'));
 		}
 	}
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -61,6 +61,7 @@ import { CopilotSessionLauncher, ContextSizeConfigKey, ThinkingLevelConfigKey, g
 import { ShellManager } from './copilotShellTools.js';
 import { isRestrictedTelemetryEnabled, parseCopilotTokenFields } from './copilotTokenFields.js';
 import { isAgentHostTelemetryService } from '../agentHostTelemetryService.js';
+import { ICopilotApiService } from '../shared/copilotApiService.js';
 import { CopilotSlashCommandCompletionProvider } from './copilotSlashCommandCompletionProvider.js';
 import { DiscoveredType, SessionCustomizationDiscovery, areDiscoveredDirectoriesEqual, type IDiscoveredDirectory } from './sessionCustomizationDiscovery.js';
 import { COPILOT_INTEGRATION_ID } from '../../../endpoint/common/licenseAgreement.js';
@@ -468,6 +469,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		@INativeEnvironmentService private readonly _environmentService: INativeEnvironmentService,
 		@IByokLmBridgeRegistry private readonly _byokBridgeRegistry: IByokLmBridgeRegistry,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@ICopilotApiService private readonly _copilotApiService: ICopilotApiService,
 	) {
 		super();
 		this._plugins = this._register(this._instantiationService.createInstance(PluginController));
@@ -660,9 +662,23 @@ export class CopilotAgent extends Disposable implements IAgent {
 		}
 		// Push the token-derived telemetry policy/identity to the restricted sender: `rt` gates
 		// enhanced GH telemetry (kept off for public users) and `tid` becomes `copilot_trackingId`.
-		if (isAgentHostTelemetryService(this._telemetryService)) {
-			this._telemetryService.setRestrictedTelemetryEnabled(rtEnabled);
-			this._telemetryService.setCopilotTrackingId(parseCopilotTokenFields(token).get('tid'));
+		if (!isAgentHostTelemetryService(this._telemetryService)) {
+			return;
+		}
+		const telemetryService = this._telemetryService;
+		telemetryService.setRestrictedTelemetryEnabled(rtEnabled);
+		telemetryService.setCopilotTrackingId(parseCopilotTokenFields(token).get('tid'));
+		// Route restricted telemetry at the user's CAPI `endpoints.telemetry` (dotcom, GHE, or proxy)
+		// rather than the dotcom default. Only opted-in (`rt=1`) users emit it, so only they pay the
+		// discovery; resolution is async, so any events before it resolves use the fallback URL.
+		if (rtEnabled && token) {
+			void this._copilotApiService.resolveTelemetryEndpoint(token).then(endpoint => {
+				if (this._githubToken === token) {
+					telemetryService.setRestrictedTelemetryEndpoint(endpoint ? `${endpoint}/telemetry` : undefined);
+				}
+			}, err => {
+				this._logService.debug(`[Copilot] Telemetry endpoint discovery failed: ${err instanceof Error ? err.message : String(err)}`);
+			});
 		}
 	}
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -43,7 +43,6 @@ import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import type { IExitPlanModeResponse } from './copilotAgent.js';
 import { CopilotSessionWrapper } from './copilotSessionWrapper.js';
 import { clientToolNamesFromSnapshot, type CopilotSessionLaunchPlan, type IActiveClientSnapshot, type ICopilotSessionLauncher, type ICopilotSessionRuntime } from './copilotSessionLauncher.js';
-import { parseCopilotTokenFields } from './copilotTokenFields.js';
 import { ActiveClientToolSet } from '../activeClientState.js';
 import { AgentHostTelemetryReporter } from '../agentHostTelemetryReporter.js';
 import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
@@ -616,7 +615,6 @@ export class CopilotAgentSession extends Disposable {
 		this._serverToolHost = options.serverToolHost;
 		this._platform = options.platform ?? process.platform;
 		this._telemetryReporter = new AgentHostTelemetryReporter(this._telemetryService);
-		this._telemetryReporter.setCopilotTrackingId(parseCopilotTokenFields(this._launchPlan.githubToken).get('tid'));
 
 		this._appliedSnapshot = options.clientSnapshot ?? { tools: [], plugins: [], mcpServers: {} };
 		this._clientToolNames = clientToolNamesFromSnapshot(this._appliedSnapshot);

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -24,6 +24,7 @@ import { INativeEnvironmentService } from '../../../environment/common/environme
 import { IFileService } from '../../../files/common/files.js';
 import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
 import { ILogService } from '../../../log/common/log.js';
+import { ITelemetryService } from '../../../telemetry/common/telemetry.js';
 import { AgentHostConfigKey, agentHostCustomizationConfigSchema } from '../../common/agentHostCustomizationConfig.js';
 import type { ChatInputRequestWithPlanReview, IAgentHostPlanReviewAction } from '../../common/agentHostPlanReview.js';
 import { AgentHostSandboxConfigKey, sandboxConfigSchema } from '../../common/sandboxConfigSchema.js';
@@ -42,7 +43,9 @@ import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import type { IExitPlanModeResponse } from './copilotAgent.js';
 import { CopilotSessionWrapper } from './copilotSessionWrapper.js';
 import { clientToolNamesFromSnapshot, type CopilotSessionLaunchPlan, type IActiveClientSnapshot, type ICopilotSessionLauncher, type ICopilotSessionRuntime } from './copilotSessionLauncher.js';
+import { parseCopilotTokenFields } from './copilotTokenFields.js';
 import { ActiveClientToolSet } from '../activeClientState.js';
+import { AgentHostTelemetryReporter } from '../agentHostTelemetryReporter.js';
 import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
 import { buildCopilotSystemNotification } from './copilotSystemNotification.js';
 import { parseLeadingSlashCommand } from './copilotSlashCommandCompletionProvider.js';
@@ -587,6 +590,9 @@ export class CopilotAgentSession extends Disposable {
 		return this._mcpCustomizations.runtimeStates;
 	}
 
+	/** Stateless reporter used to emit restricted GH/MSFT telemetry for this session's model calls. */
+	private readonly _telemetryReporter: AgentHostTelemetryReporter;
+
 	constructor(
 		options: ICopilotAgentSessionOptions,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
@@ -595,6 +601,7 @@ export class CopilotAgentSession extends Disposable {
 		@IFileService private readonly _fileService: IFileService,
 		@INativeEnvironmentService private readonly _environmentService: INativeEnvironmentService,
 		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
 		this.sessionId = options.rawSessionId;
@@ -608,6 +615,8 @@ export class CopilotAgentSession extends Disposable {
 		this._customizationDirectory = options.customizationDirectory;
 		this._serverToolHost = options.serverToolHost;
 		this._platform = options.platform ?? process.platform;
+		this._telemetryReporter = new AgentHostTelemetryReporter(this._telemetryService);
+		this._telemetryReporter.setCopilotTrackingId(parseCopilotTokenFields(this._launchPlan.githubToken).get('tid'));
 
 		this._appliedSnapshot = options.clientSnapshot ?? { tools: [], plugins: [], mcpServers: {} };
 		this._clientToolNames = clientToolNamesFromSnapshot(this._appliedSnapshot);
@@ -2532,6 +2541,10 @@ export class CopilotAgentSession extends Disposable {
 
 		this._register(wrapper.onMessage(e => {
 			this._logService.info(`[Copilot:${sessionId}] Full message received: ${e.data.content.length} chars`);
+			// Report the enhanced GH `request.options.tools` event for this model call — parity with
+			// the Copilot extension, which emits it per LLM request. `assistant.message` is the
+			// agent-host's per-model-call boundary; we correlate on its `x-copilot-service-request-id`.
+			this._telemetryReporter.assistantMessageReceived(this.sessionUri.toString(), e.data.serviceRequestId, this._appliedSnapshot.tools);
 			// The SDK fires a `message` event with the full assembled content after
 			// streaming deltas. If deltas already created a markdown part for this
 			// turn, the live state is up to date and we skip. Only emit a fresh

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -2542,7 +2542,11 @@ export class CopilotAgentSession extends Disposable {
 			// Report the enhanced GH `request.options.tools` event for this model call — parity with
 			// the Copilot extension, which emits it per LLM request. `assistant.message` is the
 			// agent-host's per-model-call boundary; we correlate on its `x-copilot-service-request-id`.
-			this._telemetryReporter.assistantMessageReceived(this.sessionUri.toString(), e.data.serviceRequestId, this._appliedSnapshot.tools);
+			// Main agent only: `_appliedSnapshot.tools` is the session's tool set, which does not
+			// describe a subagent's model call, so subagent messages (mapped or dropped) are skipped.
+			if (!e.agentId) {
+				this._telemetryReporter.assistantMessageReceived(this.sessionUri.toString(), e.data.serviceRequestId, this._appliedSnapshot.tools);
+			}
 			// The SDK fires a `message` event with the full assembled content after
 			// streaming deltas. If deltas already created a markdown part for this
 			// turn, the live state is up to date and we skip. Only emit a fresh

--- a/src/vs/platform/agentHost/node/shared/copilotApiService.ts
+++ b/src/vs/platform/agentHost/node/shared/copilotApiService.ts
@@ -11,6 +11,7 @@ import { createDecorator } from '../../../instantiation/common/instantiation.js'
 import { ILogService } from '../../../log/common/log.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { COPILOT_LICENSE_AGREEMENT } from '../../../endpoint/common/licenseAgreement.js';
+import { parseCopilotTokenFields } from '../copilot/copilotTokenFields.js';
 
 // #region Types
 
@@ -382,6 +383,20 @@ export const ICopilotApiService = createDecorator<ICopilotApiService>('copilotAp
  *   and is not part of the Anthropic-shaped CAPI surface.
  * - Malformed JSON in an SSE `data:` line is logged and skipped, not thrown.
  */
+/**
+ * Restricted/enhanced telemetry context derived from a user's minted CAPI Copilot session token,
+ * mirroring what the Copilot extension reads off its `CopilotToken` (`rt` opt-in, `tid` tracking id)
+ * plus the CAPI `endpoints.telemetry` host.
+ */
+export interface IRestrictedTelemetryContext {
+	/** Whether the token opts into enhanced/restricted telemetry (the `rt=1` claim). */
+	readonly restrictedTelemetryEnabled: boolean;
+	/** The Copilot user tracking id (`tid` claim), or `undefined` when absent. */
+	readonly trackingId: string | undefined;
+	/** The CAPI `endpoints.telemetry` base URL, resolved only when enabled; `undefined` otherwise. */
+	readonly telemetryEndpoint: string | undefined;
+}
+
 export interface ICopilotApiService {
 
 	readonly _serviceBrand: undefined;
@@ -477,14 +492,13 @@ export interface ICopilotApiService {
 	): Promise<string>;
 
 	/**
-	 * Resolve this user's CAPI-provided restricted-telemetry endpoint — the
-	 * `/copilot_internal/user` response's `endpoints.telemetry` base URL — reusing
-	 * the same cached endpoint discovery used for CAPI routing. Returns `undefined`
-	 * when the response advertises none. Lets agent-host restricted telemetry target
-	 * the user's telemetry host (dotcom, GHE, proxy) the way the Copilot extension
-	 * and CLI do, rather than assuming the dotcom default.
+	 * Resolve this user's restricted-telemetry context from the minted CAPI Copilot session token —
+	 * the `rt` opt-in and `tid` tracking id — plus the CAPI `endpoints.telemetry` host. The GitHub
+	 * token itself carries none of these claims; they live in the Copilot session token (minted via
+	 * `RequestType.CopilotToken`), exactly as the Copilot extension reads them off its `CopilotToken`.
+	 * The telemetry endpoint is resolved only when enabled, so public users incur no extra discovery.
 	 */
-	resolveTelemetryEndpoint(githubToken: string): Promise<string | undefined>;
+	resolveRestrictedTelemetryContext(githubToken: string): Promise<IRestrictedTelemetryContext>;
 }
 
 export class CopilotApiService implements ICopilotApiService {
@@ -815,13 +829,19 @@ export class CopilotApiService implements ICopilotApiService {
 	}
 
 	/**
-	 * Resolve this user's CAPI-provided restricted-telemetry endpoint (the
-	 * `/copilot_internal/user` response's `endpoints.telemetry`), reusing the
-	 * cached endpoint discovery. Returns `undefined` when none is advertised.
+	 * Resolve this user's restricted-telemetry context. Reads the `rt`/`tid` claims from the minted
+	 * CAPI Copilot session token (the GitHub token has neither), and resolves the CAPI
+	 * `endpoints.telemetry` host from the cached `/copilot_internal/user` discovery only when the
+	 * user is opted in, so public users pay no extra discovery call.
 	 */
-	async resolveTelemetryEndpoint(githubToken: string): Promise<string | undefined> {
-		const entry = await this._getEntryForToken(githubToken);
-		return entry.telemetryEndpoint;
+	async resolveRestrictedTelemetryContext(githubToken: string): Promise<IRestrictedTelemetryContext> {
+		const fields = parseCopilotTokenFields(await this._getCopilotToken(githubToken));
+		const restrictedTelemetryEnabled = fields.get('rt') === '1';
+		const trackingId = fields.get('tid');
+		const telemetryEndpoint = restrictedTelemetryEnabled
+			? (await this._getEntryForToken(githubToken)).telemetryEndpoint
+			: undefined;
+		return { restrictedTelemetryEnabled, trackingId, telemetryEndpoint };
 	}
 
 	private _getEntryForToken(githubToken: string): Promise<ICachedClient> {

--- a/src/vs/platform/agentHost/node/shared/copilotApiService.ts
+++ b/src/vs/platform/agentHost/node/shared/copilotApiService.ts
@@ -92,6 +92,8 @@ interface ICopilotUserResponse {
 interface ICachedClient {
 	readonly capiClient: CAPIClient;
 	readonly expiresAt: number;
+	/** The CAPI `endpoints.telemetry` base URL discovered for this token, if any. */
+	readonly telemetryEndpoint?: string;
 }
 
 /**
@@ -473,6 +475,16 @@ export interface ICopilotApiService {
 		request: ICopilotUtilityChatCompletionRequest,
 		options?: ICopilotApiServiceRequestOptions,
 	): Promise<string>;
+
+	/**
+	 * Resolve this user's CAPI-provided restricted-telemetry endpoint — the
+	 * `/copilot_internal/user` response's `endpoints.telemetry` base URL — reusing
+	 * the same cached endpoint discovery used for CAPI routing. Returns `undefined`
+	 * when the response advertises none. Lets agent-host restricted telemetry target
+	 * the user's telemetry host (dotcom, GHE, proxy) the way the Copilot extension
+	 * and CLI do, rather than assuming the dotcom default.
+	 */
+	resolveTelemetryEndpoint(githubToken: string): Promise<string | undefined>;
 }
 
 export class CopilotApiService implements ICopilotApiService {
@@ -799,16 +811,30 @@ export class CopilotApiService implements ICopilotApiService {
 	 * dispatched for token B.
 	 */
 	private _getClientForToken(githubToken: string): Promise<CAPIClient> {
+		return this._getEntryForToken(githubToken).then(entry => entry.capiClient);
+	}
+
+	/**
+	 * Resolve this user's CAPI-provided restricted-telemetry endpoint (the
+	 * `/copilot_internal/user` response's `endpoints.telemetry`), reusing the
+	 * cached endpoint discovery. Returns `undefined` when none is advertised.
+	 */
+	async resolveTelemetryEndpoint(githubToken: string): Promise<string | undefined> {
+		const entry = await this._getEntryForToken(githubToken);
+		return entry.telemetryEndpoint;
+	}
+
+	private _getEntryForToken(githubToken: string): Promise<ICachedClient> {
 		const nowSeconds = Date.now() / 1000;
 		const existing = this._clientsByToken.get(githubToken);
 		if (existing) {
 			return existing.then(entry => {
 				if (entry.expiresAt - nowSeconds > CAPI_CONTEXT_REFRESH_BUFFER_SECONDS) {
-					return entry.capiClient;
+					return entry;
 				}
 				// Stale — evict and recurse to build a fresh entry.
 				this._clientsByToken.delete(githubToken);
-				return this._getClientForToken(githubToken);
+				return this._getEntryForToken(githubToken);
 			}).catch(err => {
 				// A previous failed build leaked into the cache; evict and rebuild.
 				this._clientsByToken.delete(githubToken);
@@ -824,7 +850,7 @@ export class CopilotApiService implements ICopilotApiService {
 			throw err;
 		});
 		this._clientsByToken.set(githubToken, pending);
-		return pending.then(entry => entry.capiClient);
+		return pending;
 	}
 
 	private _invalidateClientForToken(githubToken: string): void {
@@ -890,6 +916,7 @@ export class CopilotApiService implements ICopilotApiService {
 		return {
 			capiClient,
 			expiresAt: Date.now() / 1000 + CAPI_CONTEXT_TTL_SECONDS,
+			telemetryEndpoint: envelope.endpoints?.telemetry,
 		};
 	}
 

--- a/src/vs/platform/agentHost/test/node/agentHostCommitOperationHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostCommitOperationHandler.test.ts
@@ -88,7 +88,7 @@ class TestCopilotApiService implements ICopilotApiService {
 	}
 	async countTokens(): Promise<Anthropic.MessageTokensCount> { throw new Error('not used'); }
 	async models(): Promise<CCAModel[]> { return []; }
-	async resolveTelemetryEndpoint(): Promise<string | undefined> { return undefined; }
+	async resolveRestrictedTelemetryContext() { return { restrictedTelemetryEnabled: false, trackingId: undefined, telemetryEndpoint: undefined }; }
 	async utilityChatCompletion(githubToken: string, request: ICopilotUtilityChatCompletionRequest, options?: ICopilotApiServiceRequestOptions): Promise<string> {
 		this.calls.push({ token: githubToken, request, options });
 		if (this.error) {

--- a/src/vs/platform/agentHost/test/node/agentHostCommitOperationHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostCommitOperationHandler.test.ts
@@ -88,6 +88,7 @@ class TestCopilotApiService implements ICopilotApiService {
 	}
 	async countTokens(): Promise<Anthropic.MessageTokensCount> { throw new Error('not used'); }
 	async models(): Promise<CCAModel[]> { return []; }
+	async resolveTelemetryEndpoint(): Promise<string | undefined> { return undefined; }
 	async utilityChatCompletion(githubToken: string, request: ICopilotUtilityChatCompletionRequest, options?: ICopilotApiServiceRequestOptions): Promise<string> {
 		this.calls.push({ token: githubToken, request, options });
 		if (this.error) {

--- a/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationHandler.test.ts
@@ -35,7 +35,7 @@ class TestCopilotApiService implements ICopilotApiService {
 	async countTokens(): Promise<Anthropic.MessageTokensCount> { throw new Error('not used'); }
 	async models(): Promise<CCAModel[]> { return []; }
 	async responses(): Promise<Response> { throw new Error('not used'); }
-	async resolveTelemetryEndpoint(): Promise<string | undefined> { return undefined; }
+	async resolveRestrictedTelemetryContext() { return { restrictedTelemetryEnabled: false, trackingId: undefined, telemetryEndpoint: undefined }; }
 	async utilityChatCompletion(githubToken: string, request: ICopilotUtilityChatCompletionRequest, options?: ICopilotApiServiceRequestOptions): Promise<string> {
 		this.calls.push({ token: githubToken, request, options });
 		if (this.error) {

--- a/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationHandler.test.ts
@@ -35,6 +35,7 @@ class TestCopilotApiService implements ICopilotApiService {
 	async countTokens(): Promise<Anthropic.MessageTokensCount> { throw new Error('not used'); }
 	async models(): Promise<CCAModel[]> { return []; }
 	async responses(): Promise<Response> { throw new Error('not used'); }
+	async resolveTelemetryEndpoint(): Promise<string | undefined> { return undefined; }
 	async utilityChatCompletion(githubToken: string, request: ICopilotUtilityChatCompletionRequest, options?: ICopilotApiServiceRequestOptions): Promise<string> {
 		this.calls.push({ token: githubToken, request, options });
 		if (this.error) {

--- a/src/vs/platform/agentHost/test/node/agentHostRestrictedTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostRestrictedTelemetry.test.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { ICommonProperties } from '../../../telemetry/common/telemetry.js';
+import { AgentHostRestrictedTelemetrySender } from '../../node/agentHostRestrictedTelemetry.js';
+
+/** The enhanced/restricted iKey (`copilot_v0_restricted_copilot_event`). */
+const GH_ENHANCED_IKEY = '3fdd7f28-937a-48c8-9a21-ba337db23bd1';
+
+interface ICapturedPost {
+	url: string;
+	iKey: string;
+}
+
+suite('AgentHostRestrictedTelemetrySender', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const commonProperties = {} as ICommonProperties;
+
+	function createSender(): { sender: AgentHostRestrictedTelemetrySender; posts: ICapturedPost[] } {
+		const posts: ICapturedPost[] = [];
+		const fetchFn = (async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			const envelope = JSON.parse(String(init?.body));
+			posts.push({ url: String(url), iKey: envelope.iKey });
+			return { ok: true, status: 200 } as Response;
+		}) as typeof globalThis.fetch;
+		const sender = new AgentHostRestrictedTelemetrySender(commonProperties, new NullLogService(), 'https://default.example/telemetry', undefined, fetchFn);
+		return { sender, posts };
+	}
+
+	test('enhanced GH telemetry is dropped until the token opts in (rt=1), then routes to the enhanced iKey', () => {
+		const { sender, posts } = createSender();
+
+		// Public user (rt not opted in): the restricted sink must not emit, even with content.
+		sender.sendEnhancedGHTelemetryEvent('request.options.tools', { messagesJson: 'x' });
+		assert.deepStrictEqual(posts, [], 'enhanced telemetry must not be sent without rt opt-in');
+
+		// Opt in, then flip back off: emits only while enabled, and to the enhanced iKey.
+		sender.setRestrictedTelemetryEnabled(true);
+		sender.setRestrictedTelemetryEndpoint('https://ghe.example');
+		sender.sendEnhancedGHTelemetryEvent('request.options.tools', { messagesJson: 'x' });
+		sender.setRestrictedTelemetryEnabled(false);
+		sender.sendEnhancedGHTelemetryEvent('request.options.tools', { messagesJson: 'x' });
+
+		assert.deepStrictEqual(posts, [{ url: 'https://ghe.example', iKey: GH_ENHANCED_IKEY }]);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
@@ -33,7 +33,7 @@ class TestCopilotApiService implements ICopilotApiService {
 	async countTokens(): Promise<Anthropic.MessageTokensCount> { throw new Error('not used'); }
 	async models(): Promise<CCAModel[]> { return []; }
 	async responses(): Promise<Response> { throw new Error('not used'); }
-	async resolveTelemetryEndpoint(): Promise<string | undefined> { return undefined; }
+	async resolveRestrictedTelemetryContext() { return { restrictedTelemetryEnabled: false, trackingId: undefined, telemetryEndpoint: undefined }; }
 	async utilityChatCompletion(githubToken: string, request: ICopilotUtilityChatCompletionRequest, options?: ICopilotApiServiceRequestOptions): Promise<string> {
 		this.utilityCalls.push({ token: githubToken, request, options });
 		if (this.error) {

--- a/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
@@ -33,6 +33,7 @@ class TestCopilotApiService implements ICopilotApiService {
 	async countTokens(): Promise<Anthropic.MessageTokensCount> { throw new Error('not used'); }
 	async models(): Promise<CCAModel[]> { return []; }
 	async responses(): Promise<Response> { throw new Error('not used'); }
+	async resolveTelemetryEndpoint(): Promise<string | undefined> { return undefined; }
 	async utilityChatCompletion(githubToken: string, request: ICopilotUtilityChatCompletionRequest, options?: ICopilotApiServiceRequestOptions): Promise<string> {
 		this.utilityCalls.push({ token: githubToken, request, options });
 		if (this.error) {

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
@@ -28,7 +28,6 @@ class TestRestrictedTelemetryService implements ITelemetryService, IAgentHostRes
 	firstSessionDate = 'firstSessionDate';
 
 	readonly enhancedEvents: IRestrictedCall[] = [];
-	readonly trackingIds: (string | undefined)[] = [];
 
 	publicLog(): void { }
 	publicLogError(): void { }
@@ -42,9 +41,7 @@ class TestRestrictedTelemetryService implements ITelemetryService, IAgentHostRes
 		this.enhancedEvents.push({ eventName, properties });
 	}
 	sendInternalMSFTTelemetryEvent(): void { }
-	setCopilotTrackingId(trackingId: string | undefined): void {
-		this.trackingIds.push(trackingId);
-	}
+	setCopilotTrackingId(): void { }
 }
 
 suite('AgentHostTelemetryReporter', () => {
@@ -69,14 +66,5 @@ suite('AgentHostTelemetryReporter', () => {
 				messagesJson: JSON.stringify(tools),
 			},
 		}]);
-	});
-
-	test('setCopilotTrackingId is forwarded to the restricted surface', () => {
-		const service = new TestRestrictedTelemetryService();
-		const reporter = new AgentHostTelemetryReporter(service);
-
-		reporter.setCopilotTrackingId('tid-123');
-
-		assert.deepStrictEqual(service.trackingIds, ['tid-123']);
 	});
 });

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
+import { AgentSession } from '../../common/agentService.js';
+import type { ToolDefinition } from '../../common/state/protocol/state.js';
+import { IAgentHostRestrictedTelemetry, TelemetryMeasurements, TelemetryProps } from '../../node/agentHostRestrictedTelemetry.js';
+import { AgentHostTelemetryReporter } from '../../node/agentHostTelemetryReporter.js';
+
+interface IRestrictedCall {
+	eventName: string;
+	properties: TelemetryProps | undefined;
+}
+
+class TestRestrictedTelemetryService implements ITelemetryService, IAgentHostRestrictedTelemetry {
+	declare readonly _serviceBrand: undefined;
+
+	telemetryLevel = TelemetryLevel.USAGE;
+	sendErrorTelemetry = true;
+	sessionId = 'sessionId';
+	machineId = 'machineId';
+	sqmId = 'sqmId';
+	devDeviceId = 'devDeviceId';
+	firstSessionDate = 'firstSessionDate';
+
+	readonly enhancedEvents: IRestrictedCall[] = [];
+	readonly trackingIds: (string | undefined)[] = [];
+
+	publicLog(): void { }
+	publicLogError(): void { }
+	publicLog2(): void { }
+	publicLogError2(): void { }
+	setExperimentProperty(): void { }
+	setCommonProperty(): void { }
+
+	sendGHTelemetryEvent(): void { }
+	sendEnhancedGHTelemetryEvent(eventName: string, properties?: TelemetryProps, _measurements?: TelemetryMeasurements): void {
+		this.enhancedEvents.push({ eventName, properties });
+	}
+	sendInternalMSFTTelemetryEvent(): void { }
+	setCopilotTrackingId(trackingId: string | undefined): void {
+		this.trackingIds.push(trackingId);
+	}
+}
+
+suite('AgentHostTelemetryReporter', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const session = 'agent-session://copilot/abc';
+	const tools: ToolDefinition[] = [{ name: 'grep' }, { name: 'edit' }];
+
+	test('assistantMessageReceived emits request.options.tools keyed on the service request id, and no-ops without one or without tools', () => {
+		const service = new TestRestrictedTelemetryService();
+		const reporter = new AgentHostTelemetryReporter(service);
+
+		reporter.assistantMessageReceived(session, undefined, tools); // dropped: no service request id
+		reporter.assistantMessageReceived(session, 'svc-1', []); // dropped: no tools
+		reporter.assistantMessageReceived(session, 'svc-1', tools); // emitted
+
+		assert.deepStrictEqual(service.enhancedEvents, [{
+			eventName: 'request.options.tools',
+			properties: {
+				headerRequestId: 'svc-1',
+				conversationId: AgentSession.id(session),
+				messagesJson: JSON.stringify(tools),
+			},
+		}]);
+	});
+
+	test('setCopilotTrackingId is forwarded to the restricted surface', () => {
+		const service = new TestRestrictedTelemetryService();
+		const reporter = new AgentHostTelemetryReporter(service);
+
+		reporter.setCopilotTrackingId('tid-123');
+
+		assert.deepStrictEqual(service.trackingIds, ['tid-123']);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
@@ -42,6 +42,7 @@ class TestRestrictedTelemetryService implements ITelemetryService, IAgentHostRes
 	}
 	sendInternalMSFTTelemetryEvent(): void { }
 	setCopilotTrackingId(): void { }
+	setRestrictedTelemetryEndpoint(): void { }
 }
 
 suite('AgentHostTelemetryReporter', () => {

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
@@ -43,6 +43,7 @@ class TestRestrictedTelemetryService implements ITelemetryService, IAgentHostRes
 	sendInternalMSFTTelemetryEvent(): void { }
 	setCopilotTrackingId(): void { }
 	setRestrictedTelemetryEndpoint(): void { }
+	setRestrictedTelemetryEnabled(): void { }
 }
 
 suite('AgentHostTelemetryReporter', () => {

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryService.test.ts
@@ -47,6 +47,7 @@ class TestRestrictedSink implements IAgentHostRestrictedTelemetry {
 	readonly enhanced: string[] = [];
 	readonly standard: string[] = [];
 	readonly trackingIds: (string | undefined)[] = [];
+	readonly endpoints: (string | undefined)[] = [];
 
 	sendGHTelemetryEvent(eventName: string, _properties?: TelemetryProps): void {
 		this.standard.push(eventName);
@@ -57,6 +58,9 @@ class TestRestrictedSink implements IAgentHostRestrictedTelemetry {
 	sendInternalMSFTTelemetryEvent(): void { }
 	setCopilotTrackingId(trackingId: string | undefined): void {
 		this.trackingIds.push(trackingId);
+	}
+	setRestrictedTelemetryEndpoint(endpointUrl: string | undefined): void {
+		this.endpoints.push(endpointUrl);
 	}
 }
 
@@ -116,15 +120,18 @@ suite('AgentHostTelemetryService', () => {
 		service.setRestrictedTelemetryEnabled(true);
 		service.sendEnhancedGHTelemetryEvent('request.options.tools'); // sent: rt now enabled
 		service.setCopilotTrackingId('tid-1');
+		service.setRestrictedTelemetryEndpoint('https://ghe.example/telemetry');
 
 		assert.deepStrictEqual({
 			enhanced: restricted.enhanced,
 			standard: restricted.standard,
 			trackingIds: restricted.trackingIds,
+			endpoints: restricted.endpoints,
 		}, {
 			enhanced: ['request.options.tools'],
 			standard: ['completion'],
 			trackingIds: ['tid-1'],
+			endpoints: ['https://ghe.example/telemetry'],
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryService.test.ts
@@ -48,6 +48,7 @@ class TestRestrictedSink implements IAgentHostRestrictedTelemetry {
 	readonly standard: string[] = [];
 	readonly trackingIds: (string | undefined)[] = [];
 	readonly endpoints: (string | undefined)[] = [];
+	readonly enabledFlags: boolean[] = [];
 
 	sendGHTelemetryEvent(eventName: string, _properties?: TelemetryProps): void {
 		this.standard.push(eventName);
@@ -61,6 +62,9 @@ class TestRestrictedSink implements IAgentHostRestrictedTelemetry {
 	}
 	setRestrictedTelemetryEndpoint(endpointUrl: string | undefined): void {
 		this.endpoints.push(endpointUrl);
+	}
+	setRestrictedTelemetryEnabled(enabled: boolean): void {
+		this.enabledFlags.push(enabled);
 	}
 }
 
@@ -133,5 +137,22 @@ suite('AgentHostTelemetryService', () => {
 			trackingIds: ['tid-1'],
 			endpoints: ['https://ghe.example/telemetry'],
 		});
+		// The rt opt-in is mirrored onto the sender (defense in depth), matching the extension's
+		// opted-in-only restricted reporter.
+		assert.deepStrictEqual(restricted.enabledFlags, [true]);
+	});
+
+	test('enhanced GH telemetry stays suppressed when telemetry is disabled, even for an rt=1 user', () => {
+		const delegate = new TestTelemetryService();
+		delegate.telemetryLevel = TelemetryLevel.ERROR; // user opted below USAGE
+		const restricted = new TestRestrictedSink();
+		const service = disposables.add(new AgentHostTelemetryService(delegate, restricted));
+
+		service.setRestrictedTelemetryEnabled(true); // rt=1
+		service.sendEnhancedGHTelemetryEvent('request.options.tools');
+		service.sendGHTelemetryEvent('completion');
+
+		// Neither standard nor enhanced GH telemetry is delegated below USAGE, regardless of rt.
+		assert.deepStrictEqual({ enhanced: restricted.enhanced, standard: restricted.standard }, { enhanced: [], standard: [] });
 	});
 });

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryService.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { ITelemetryData, ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
 import { AgentHostTelemetryLevelConfigKey, telemetryLevelToAgentHostConfigValue } from '../../common/agentHostSchema.js';
+import { IAgentHostRestrictedTelemetry, TelemetryProps } from '../../node/agentHostRestrictedTelemetry.js';
 import { AgentHostTelemetryService, updateAgentHostTelemetryLevelFromConfig } from '../../node/agentHostTelemetryService.js';
 
 class TestTelemetryService implements ITelemetryService {
@@ -40,6 +41,23 @@ class TestTelemetryService implements ITelemetryService {
 
 	setExperimentProperty(): void { }
 	setCommonProperty(): void { }
+}
+
+class TestRestrictedSink implements IAgentHostRestrictedTelemetry {
+	readonly enhanced: string[] = [];
+	readonly standard: string[] = [];
+	readonly trackingIds: (string | undefined)[] = [];
+
+	sendGHTelemetryEvent(eventName: string, _properties?: TelemetryProps): void {
+		this.standard.push(eventName);
+	}
+	sendEnhancedGHTelemetryEvent(eventName: string, _properties?: TelemetryProps): void {
+		this.enhanced.push(eventName);
+	}
+	sendInternalMSFTTelemetryEvent(): void { }
+	setCopilotTrackingId(trackingId: string | undefined): void {
+		this.trackingIds.push(trackingId);
+	}
 }
 
 suite('AgentHostTelemetryService', () => {
@@ -87,5 +105,26 @@ suite('AgentHostTelemetryService', () => {
 		});
 
 		assert.strictEqual(service.telemetryLevel, TelemetryLevel.ERROR);
+	});
+
+	test('enhanced GH telemetry is gated on the restricted (rt) opt-in; standard GH telemetry is not', () => {
+		const restricted = new TestRestrictedSink();
+		const service = disposables.add(new AgentHostTelemetryService(new TestTelemetryService(), restricted));
+
+		service.sendEnhancedGHTelemetryEvent('request.options.tools'); // dropped: rt disabled by default
+		service.sendGHTelemetryEvent('completion'); // sent: standard GH telemetry is not rt-gated
+		service.setRestrictedTelemetryEnabled(true);
+		service.sendEnhancedGHTelemetryEvent('request.options.tools'); // sent: rt now enabled
+		service.setCopilotTrackingId('tid-1');
+
+		assert.deepStrictEqual({
+			enhanced: restricted.enhanced,
+			standard: restricted.standard,
+			trackingIds: restricted.trackingIds,
+		}, {
+			enhanced: ['request.options.tools'],
+			standard: ['completion'],
+			trackingIds: ['tid-1'],
+		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -79,7 +79,7 @@ class TestCopilotApiService implements ICopilotApiService {
 	async countTokens(): Promise<Anthropic.MessageTokensCount> { throw new Error('not used'); }
 	async models(): Promise<CCAModel[]> { return []; }
 	async responses(): Promise<Response> { throw new Error('not used'); }
-	async resolveTelemetryEndpoint(): Promise<string | undefined> { return undefined; }
+	async resolveRestrictedTelemetryContext() { return { restrictedTelemetryEnabled: false, trackingId: undefined, telemetryEndpoint: undefined }; }
 	async utilityChatCompletion(githubToken: string, request: ICopilotUtilityChatCompletionRequest, options?: ICopilotApiServiceRequestOptions): Promise<string> {
 		this.utilityCalls.push({ token: githubToken, request, options });
 		if (this.error) {

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -79,6 +79,7 @@ class TestCopilotApiService implements ICopilotApiService {
 	async countTokens(): Promise<Anthropic.MessageTokensCount> { throw new Error('not used'); }
 	async models(): Promise<CCAModel[]> { return []; }
 	async responses(): Promise<Response> { throw new Error('not used'); }
+	async resolveTelemetryEndpoint(): Promise<string | undefined> { return undefined; }
 	async utilityChatCompletion(githubToken: string, request: ICopilotUtilityChatCompletionRequest, options?: ICopilotApiServiceRequestOptions): Promise<string> {
 		this.utilityCalls.push({ token: githubToken, request, options });
 		if (this.error) {

--- a/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
@@ -239,7 +239,7 @@ class StubCopilotApiService implements ICopilotApiService {
 
 	readonly messagesCallCount = { count: 0 };
 
-	async resolveTelemetryEndpoint(): Promise<string | undefined> { return undefined; }
+	async resolveRestrictedTelemetryContext() { return { restrictedTelemetryEnabled: false, trackingId: undefined, telemetryEndpoint: undefined }; }
 
 	messages(
 		token: string,

--- a/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
@@ -239,6 +239,8 @@ class StubCopilotApiService implements ICopilotApiService {
 
 	readonly messagesCallCount = { count: 0 };
 
+	async resolveTelemetryEndpoint(): Promise<string | undefined> { return undefined; }
+
 	messages(
 		token: string,
 		request: Anthropic.MessageCreateParamsStreaming,

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -149,7 +149,7 @@ class FakeCopilotApiService implements ICopilotApiService {
 	countTokens(): Promise<Anthropic.MessageTokensCount> { throw new Error('not used in ClaudeAgent tests'); }
 	responses(): Promise<Response> { throw new Error('not used in ClaudeAgent tests'); }
 	utilityChatCompletion(): Promise<never> { throw new Error('not used in ClaudeAgent tests'); }
-	resolveTelemetryEndpoint(): Promise<string | undefined> { return Promise.resolve(undefined); }
+	resolveRestrictedTelemetryContext() { return Promise.resolve({ restrictedTelemetryEnabled: false, trackingId: undefined, telemetryEndpoint: undefined }); }
 }
 
 const FakeProductService: IProductService = {

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -149,6 +149,7 @@ class FakeCopilotApiService implements ICopilotApiService {
 	countTokens(): Promise<Anthropic.MessageTokensCount> { throw new Error('not used in ClaudeAgent tests'); }
 	responses(): Promise<Response> { throw new Error('not used in ClaudeAgent tests'); }
 	utilityChatCompletion(): Promise<never> { throw new Error('not used in ClaudeAgent tests'); }
+	resolveTelemetryEndpoint(): Promise<string | undefined> { return Promise.resolve(undefined); }
 }
 
 const FakeProductService: IProductService = {

--- a/src/vs/platform/agentHost/test/node/claudeProxyService.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeProxyService.test.ts
@@ -56,7 +56,7 @@ type MessagesResult =
 class FakeCopilotApiService implements ICopilotApiService {
 	declare readonly _serviceBrand: undefined;
 
-	async resolveTelemetryEndpoint(): Promise<string | undefined> { return undefined; }
+	async resolveRestrictedTelemetryContext() { return { restrictedTelemetryEnabled: false, trackingId: undefined, telemetryEndpoint: undefined }; }
 
 	messagesResult: MessagesResult = { kind: 'error', error: new Error('not configured') };
 	modelsResult: { kind: 'value'; value: CCAModel[] } | { kind: 'error'; error: Error } = { kind: 'value', value: [] };
@@ -1254,7 +1254,7 @@ suite('ClaudeProxyService', () => {
 				models: () => Promise.resolve([]),
 				responses: () => Promise.reject(new Error('not used')),
 				utilityChatCompletion: () => Promise.reject(new Error('not used')),
-				resolveTelemetryEndpoint: () => Promise.resolve(undefined),
+				resolveRestrictedTelemetryContext: () => Promise.resolve({ restrictedTelemetryEnabled: false, trackingId: undefined, telemetryEndpoint: undefined }),
 			};
 			const service = new ClaudeProxyService(new NullLogService(), wrapped);
 			const handle = await service.start(TOKEN);
@@ -1324,7 +1324,7 @@ suite('ClaudeProxyService', () => {
 				models: fake.models.bind(fake),
 				responses: fake.responses.bind(fake),
 				utilityChatCompletion: fake.utilityChatCompletion.bind(fake),
-				resolveTelemetryEndpoint: fake.resolveTelemetryEndpoint.bind(fake),
+				resolveRestrictedTelemetryContext: fake.resolveRestrictedTelemetryContext.bind(fake),
 			};
 			const service = new ClaudeProxyService(new NullLogService(), wrapped);
 			const handle = await service.start(TOKEN);

--- a/src/vs/platform/agentHost/test/node/claudeProxyService.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeProxyService.test.ts
@@ -56,6 +56,8 @@ type MessagesResult =
 class FakeCopilotApiService implements ICopilotApiService {
 	declare readonly _serviceBrand: undefined;
 
+	async resolveTelemetryEndpoint(): Promise<string | undefined> { return undefined; }
+
 	messagesResult: MessagesResult = { kind: 'error', error: new Error('not configured') };
 	modelsResult: { kind: 'value'; value: CCAModel[] } | { kind: 'error'; error: Error } = { kind: 'value', value: [] };
 
@@ -1252,6 +1254,7 @@ suite('ClaudeProxyService', () => {
 				models: () => Promise.resolve([]),
 				responses: () => Promise.reject(new Error('not used')),
 				utilityChatCompletion: () => Promise.reject(new Error('not used')),
+				resolveTelemetryEndpoint: () => Promise.resolve(undefined),
 			};
 			const service = new ClaudeProxyService(new NullLogService(), wrapped);
 			const handle = await service.start(TOKEN);
@@ -1321,6 +1324,7 @@ suite('ClaudeProxyService', () => {
 				models: fake.models.bind(fake),
 				responses: fake.responses.bind(fake),
 				utilityChatCompletion: fake.utilityChatCompletion.bind(fake),
+				resolveTelemetryEndpoint: fake.resolveTelemetryEndpoint.bind(fake),
 			};
 			const service = new ClaudeProxyService(new NullLogService(), wrapped);
 			const handle = await service.start(TOKEN);

--- a/src/vs/platform/agentHost/test/node/codex/codexProxyService.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexProxyService.test.ts
@@ -24,7 +24,7 @@ interface IResponsesCall {
 class FakeCopilotApiService implements ICopilotApiService {
 	declare readonly _serviceBrand: undefined;
 
-	async resolveTelemetryEndpoint(): Promise<string | undefined> { return undefined; }
+	async resolveRestrictedTelemetryContext() { return { restrictedTelemetryEnabled: false, trackingId: undefined, telemetryEndpoint: undefined }; }
 
 	readonly responsesCalls: IResponsesCall[] = [];
 

--- a/src/vs/platform/agentHost/test/node/codex/codexProxyService.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexProxyService.test.ts
@@ -24,6 +24,8 @@ interface IResponsesCall {
 class FakeCopilotApiService implements ICopilotApiService {
 	declare readonly _serviceBrand: undefined;
 
+	async resolveTelemetryEndpoint(): Promise<string | undefined> { return undefined; }
+
 	readonly responsesCalls: IResponsesCall[] = [];
 
 	messages(): never {

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -213,8 +213,7 @@ class TestCopilotApiService implements ICopilotApiService {
 	async countTokens(): Promise<Anthropic.MessageTokensCount> { throw new Error('not used'); }
 	async models(): Promise<CCAModel[]> { return []; }
 	async responses(): Promise<Response> { throw new Error('not used'); }
-	telemetryEndpoint: string | undefined;
-	async resolveTelemetryEndpoint(): Promise<string | undefined> { return this.telemetryEndpoint; }
+	async resolveRestrictedTelemetryContext() { return { restrictedTelemetryEnabled: false, trackingId: undefined, telemetryEndpoint: undefined }; }
 	async utilityChatCompletion(githubToken: string, request: ICopilotUtilityChatCompletionRequest, options?: ICopilotApiServiceRequestOptions): Promise<string> {
 		this.utilityCalls.push({ token: githubToken, request, options });
 		if (this.error) {

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -443,7 +443,7 @@ class ResumePathCopilotAgent extends CopilotAgent {
 		@INativeEnvironmentService environmentService: INativeEnvironmentService,
 		@IByokLmBridgeRegistry byokBridgeRegistry: IByokLmBridgeRegistry,
 	) {
-		super(logService, instantiationService, sessionDataService, gitService, configurationService, new MockAgentHostOTelService(), branchNameGenerator, completions, NULL_CHECKPOINT_SERVICE, environmentService, byokBridgeRegistry);
+		super(logService, instantiationService, sessionDataService, gitService, configurationService, new MockAgentHostOTelService(), branchNameGenerator, completions, NULL_CHECKPOINT_SERVICE, environmentService, byokBridgeRegistry, NullTelemetryService);
 		this._enablePlanModeOnClient(this._copilotClient as CopilotClient);
 	}
 
@@ -472,7 +472,7 @@ class TestableCopilotAgent extends CopilotAgent {
 		@INativeEnvironmentService environmentService: INativeEnvironmentService,
 		@IByokLmBridgeRegistry byokBridgeRegistry: IByokLmBridgeRegistry,
 	) {
-		super(logService, instantiationService, sessionDataService, gitService, configurationService, new MockAgentHostOTelService(), branchNameGenerator, completions, NULL_CHECKPOINT_SERVICE, environmentService, byokBridgeRegistry);
+		super(logService, instantiationService, sessionDataService, gitService, configurationService, new MockAgentHostOTelService(), branchNameGenerator, completions, NULL_CHECKPOINT_SERVICE, environmentService, byokBridgeRegistry, NullTelemetryService);
 		this._enablePlanModeOnClient(this._copilotClient as CopilotClient);
 	}
 

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -213,6 +213,8 @@ class TestCopilotApiService implements ICopilotApiService {
 	async countTokens(): Promise<Anthropic.MessageTokensCount> { throw new Error('not used'); }
 	async models(): Promise<CCAModel[]> { return []; }
 	async responses(): Promise<Response> { throw new Error('not used'); }
+	telemetryEndpoint: string | undefined;
+	async resolveTelemetryEndpoint(): Promise<string | undefined> { return this.telemetryEndpoint; }
 	async utilityChatCompletion(githubToken: string, request: ICopilotUtilityChatCompletionRequest, options?: ICopilotApiServiceRequestOptions): Promise<string> {
 		this.utilityCalls.push({ token: githubToken, request, options });
 		if (this.error) {
@@ -442,8 +444,9 @@ class ResumePathCopilotAgent extends CopilotAgent {
 		@IAgentHostCompletions completions: IAgentHostCompletions,
 		@INativeEnvironmentService environmentService: INativeEnvironmentService,
 		@IByokLmBridgeRegistry byokBridgeRegistry: IByokLmBridgeRegistry,
+		@ICopilotApiService copilotApiService: ICopilotApiService,
 	) {
-		super(logService, instantiationService, sessionDataService, gitService, configurationService, new MockAgentHostOTelService(), branchNameGenerator, completions, NULL_CHECKPOINT_SERVICE, environmentService, byokBridgeRegistry, NullTelemetryService);
+		super(logService, instantiationService, sessionDataService, gitService, configurationService, new MockAgentHostOTelService(), branchNameGenerator, completions, NULL_CHECKPOINT_SERVICE, environmentService, byokBridgeRegistry, NullTelemetryService, copilotApiService);
 		this._enablePlanModeOnClient(this._copilotClient as CopilotClient);
 	}
 
@@ -471,8 +474,9 @@ class TestableCopilotAgent extends CopilotAgent {
 		@IAgentHostCompletions completions: IAgentHostCompletions,
 		@INativeEnvironmentService environmentService: INativeEnvironmentService,
 		@IByokLmBridgeRegistry byokBridgeRegistry: IByokLmBridgeRegistry,
+		@ICopilotApiService copilotApiService: ICopilotApiService,
 	) {
-		super(logService, instantiationService, sessionDataService, gitService, configurationService, new MockAgentHostOTelService(), branchNameGenerator, completions, NULL_CHECKPOINT_SERVICE, environmentService, byokBridgeRegistry, NullTelemetryService);
+		super(logService, instantiationService, sessionDataService, gitService, configurationService, new MockAgentHostOTelService(), branchNameGenerator, completions, NULL_CHECKPOINT_SERVICE, environmentService, byokBridgeRegistry, NullTelemetryService, copilotApiService);
 		this._enablePlanModeOnClient(this._copilotClient as CopilotClient);
 	}
 


### PR DESCRIPTION
Brings agent-host restricted telemetry to parity with the Copilot extension's `request.options.tools` event.

- Emitted per `assistant.message` (the per-model-call boundary).
- `headerRequestId` carries the call's `x-copilot-service-request-id` (the runtime doesn't surface the client `x-request-id`); `conversationId` is the session id.
- Tool definitions ride in `messagesJson` (routed to the code-snippet table like the extension), each event gets a fresh `unique_id`, and `copilot_trackingId` (token `tid`) is set as a restricted-telemetry common property.