### PR TITLE
Auto mode: use the router's chosen_model instead of candidate_models[0]

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/automodeService.ts
+++ b/extensions/copilot/src/platform/endpoint/node/automodeService.ts
@@ -404,25 +404,33 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 				return { lastRoutedPrompt: prompt, fallbackReason: 'emptyCandidateList' };
 			}
 
-			// Trust the router's ranked candidate list directly.
+			// Prefer chosen_model — it is the router's authoritative pick after any
+			// server-side re-ranking (e.g. Cost Sorting experiments). candidate_models
+			// is the ordered fallback list per the auto-intent-service contract
+			// (docs/integrators_onboarding.md: "Use chosen_model for the upcoming chat
+			// call, and use candidate_models as the ordered fallback list").
 			// Same-provider preference is intentionally NOT applied here — the router
 			// already accounts for available models and re-runs after /compact, so
 			// overriding its pick with same-provider negates cost-saving decisions.
 			// Same-provider is still used in _selectDefaultModel (the non-router fallback).
-			const selectedModel = this._findFirstAvailableModel(result.candidate_models, knownEndpoints);
+			const routerModel = result.chosen_model ?? result.candidate_models[0];
+			let selectedModel = result.chosen_model ? knownEndpoints.find(e => e.model === result.chosen_model) : undefined;
+			if (!selectedModel) {
+				selectedModel = this._findFirstAvailableModel(result.candidate_models, knownEndpoints);
+			}
 
 			if (!selectedModel) {
-				this._logService.warn(`[AutomodeService] None of the router's candidate_models matched knownEndpoints: [${result.candidate_models.join(', ')}]`);
+				this._logService.warn(`[AutomodeService] Router pick not in knownEndpoints: chosen_model=${result.chosen_model ?? 'n/a'}, candidate_models=[${result.candidate_models.join(', ')}]`);
 				return { lastRoutedPrompt: prompt, fallbackReason: 'noMatchingEndpoint' };
 			}
 
 			if (result.sticky_override) {
-				this._logService.trace(`[AutomodeService] Sticky routing override: confidence=${(result.confidence * 100).toFixed(1)}%, label=${result.predicted_label}, router_model=${result.candidate_models[0]}, actual_model=${selectedModel.model}`);
+				this._logService.trace(`[AutomodeService] Sticky routing override: confidence=${(result.confidence * 100).toFixed(1)}%, label=${result.predicted_label}, router_model=${routerModel}, actual_model=${selectedModel.model}`);
 			}
 			return {
 				selectedModel,
 				lastRoutedPrompt: prompt,
-				candidateModel: result.candidate_models[0],
+				candidateModel: routerModel,
 				routingDecision: {
 					resolvedModel: selectedModel.model,
 					resolvedModelName: selectedModel.name,

--- a/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
@@ -1312,6 +1312,33 @@ describe('AutomodeService', () => {
 			expect(result.model).toBe('gpt-5.4-mini');
 		});
 
+		it('should surface chosen_model in the routing decision the UI displays', async () => {
+			enableRouter();
+			const codexEndpoint = createEndpoint('gpt-5.3-codex', 'OpenAI');
+			const miniEndpoint = createEndpoint('gpt-5.4-mini', 'OpenAI');
+
+			// The "Routed to <model>" explainability label reads the routing
+			// decision surfaced via consumeLastRoutingDecision(). It must match the
+			// served endpoint (chosen_model), otherwise the label diverges from the
+			// model shown in the response footer (candidate_models[0]).
+			mockRouterResponse(
+				['gpt-5.3-codex', 'gpt-5.4-mini'],
+				{ chosen_model: 'gpt-5.4-mini', candidate_models: ['gpt-5.3-codex', 'gpt-5.4-mini'] }
+			);
+
+			automodeService = createService();
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'refactor this function',
+				sessionId: 'session-routing-decision'
+			};
+
+			const result = await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [codexEndpoint, miniEndpoint]);
+			const decision = automodeService.consumeLastRoutingDecision();
+			expect(decision?.resolvedModel).toBe('gpt-5.4-mini');
+			expect(decision?.resolvedModel).toBe(result.model);
+		});
+
 		it('should fall back to first known endpoint when all available_models are unknown', async () => {
 			enableRouter();
 			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI');

--- a/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
@@ -1076,6 +1076,38 @@ describe('AutomodeService', () => {
 			});
 		});
 
+		it('should emit candidateModel from chosen_model, not candidate_models[0]', async () => {
+			enableRouter();
+			const codexEndpoint = createEndpoint('gpt-5.3-codex', 'OpenAI');
+			const miniEndpoint = createEndpoint('gpt-5.4-mini', 'OpenAI');
+
+			// Server re-ranked the pick: candidate_models[0] is gpt-5.3-codex but the
+			// authoritative chosen_model is gpt-5.4-mini. The telemetry candidateModel
+			// must reflect chosen_model so router-pick vs actual comparisons are valid.
+			mockRouterResponse(
+				['gpt-5.3-codex', 'gpt-5.4-mini'],
+				{ chosen_model: 'gpt-5.4-mini', candidate_models: ['gpt-5.3-codex', 'gpt-5.4-mini'] }
+			);
+
+			automodeService = createService();
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'refactor this function',
+				sessionId: 'session-telemetry-chosen-model'
+			};
+
+			await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [codexEndpoint, miniEndpoint]);
+
+			const telemetryCalls = mockTelemetryService.sendMSFTTelemetryEvent.mock.calls;
+			const selectionEvent = telemetryCalls.find((call: unknown[]) => call[0] === 'automode.routerModelSelection');
+			expect(selectionEvent).toBeDefined();
+			expect(selectionEvent![1]).toMatchObject({
+				candidateModel: 'gpt-5.4-mini',
+				actualModel: 'gpt-5.4-mini',
+				overrideReason: 'none',
+			});
+		});
+
 		it('should emit overrideReason=clientOverride when vision fallback changes the model', async () => {
 			enableRouter();
 			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI', { supportsVision: true });
@@ -1234,13 +1266,15 @@ describe('AutomodeService', () => {
 			);
 		});
 
-		it('should iterate all candidate_models when first candidate has no endpoint', async () => {
+		it('should fall back to candidate_models when chosen_model has no endpoint', async () => {
 			enableRouter();
 			const gpt41Endpoint = createEndpoint('gpt-4.1', 'OpenAI');
 
+			// chosen_model is not in knownEndpoints, so selection falls back to
+			// the ordered candidate_models list and picks the first resolvable one.
 			mockRouterResponse(
 				['gpt-4.1'],
-				{ chosen_model: 'gpt-4.1', candidate_models: ['unknown-new-model', 'gpt-4.1'] }
+				{ chosen_model: 'unknown-new-model', candidate_models: ['unknown-new-model', 'gpt-4.1'] }
 			);
 
 			automodeService = createService();
@@ -1252,6 +1286,30 @@ describe('AutomodeService', () => {
 
 			const result = await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [gpt41Endpoint]);
 			expect(result.model).toBe('gpt-4.1');
+		});
+
+		it('should prefer chosen_model over candidate_models[0]', async () => {
+			enableRouter();
+			const codexEndpoint = createEndpoint('gpt-5.3-codex', 'OpenAI');
+			const miniEndpoint = createEndpoint('gpt-5.4-mini', 'OpenAI');
+
+			// Server re-ranked the pick (e.g. Cost Sorting experiment): chosen_model
+			// is gpt-5.4-mini even though candidate_models[0] is gpt-5.3-codex. The
+			// client must send the chosen_model, per the auto-intent-service contract.
+			mockRouterResponse(
+				['gpt-5.3-codex', 'gpt-5.4-mini'],
+				{ chosen_model: 'gpt-5.4-mini', candidate_models: ['gpt-5.3-codex', 'gpt-5.4-mini'] }
+			);
+
+			automodeService = createService();
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'refactor this function',
+				sessionId: 'session-chosen-model'
+			};
+
+			const result = await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [codexEndpoint, miniEndpoint]);
+			expect(result.model).toBe('gpt-5.4-mini');
 		});
 
 		it('should fall back to first known endpoint when all available_models are unknown', async () => {


### PR DESCRIPTION
Auto mode was picking the wrong model. When resolving the `auto` pseudo-model, we took `candidate_models[0]` from the router response and ignored `chosen_model` entirely. `chosen_model` is the router's actual pick after any server-side re-ranking (the Cost Sorting experiment being the one that bit us). The integrator contract is explicit about this:

> Use `chosen_model` for the upcoming chat call, and use `candidate_models` as the ordered fallback list.

— [auto-intent-service integrator docs](https://github.com/github/auto-intent-service/blob/main/docs/integrators_onboarding.md). The Copilot CLI already does this; VS Code was the odd one out.

This showed up as two separate-looking bugs that are really the same root cause:

1. **We sent a different model than the router chose.** In the report, `/models/session/intent` returned GPT-5.4 mini but the chat completion actually went to GPT-5.3 Codex.
2. **The "Routed to …" label didn't match the response footer.** The explainability label read the router's pick (GPT-5.4 mini) while the credits footer showed what actually served the request (GPT-5.3 Codex). Once selection reads `chosen_model`, the label, the request, and the footer all line up.

There's a knock-on effect too: because the Cost Sorting experiment only re-ranks `chosen_model`, anything reading `candidate_models[0]` was effectively invisible to it. That matches what we saw — the experiment moved the CLI but not VS Code.

## What changed

In `_tryRouterSelection` (`automodeService.ts`):

- Resolve `chosen_model` against the client's known endpoints first.
- Only fall back to walking `candidate_models` when `chosen_model` is missing or we don't have an endpoint for it.
- Emit `chosen_model` as `candidateModel` in the `automode.routerModelSelection` telemetry, so the "router pick vs actual model" comparison is actually meaningful.

## Why the tests didn't catch it

Every mocked router response in the spec set `chosen_model === candidate_models[0]`, so reading the wrong field gave the right answer by accident. The new tests decouple them:

- `should prefer chosen_model over candidate_models[0]` — resolved endpoint follows `chosen_model` when the two differ.
- `should surface chosen_model in the routing decision the UI displays` — the decision the "Routed to" label consumes matches the served endpoint (guards bug #2).
- `should emit candidateModel from chosen_model, not candidate_models[0]` — pins the telemetry field.
- Reworked the old `iterate all candidate_models` test into `should fall back to candidate_models when chosen_model has no endpoint` so it actually exercises the fallback path.

I confirmed the new tests fail on the pre-fix code (resolving `gpt-5.3-codex` instead of `gpt-5.4-mini`) and pass after the fix.

## Test plan

- [x] `vitest run automodeService.spec.ts` — 37 passing
- [x] Verified the decoupled tests fail on the old code, reproducing the reported GPT-5.4 mini → GPT-5.3 Codex mismatch
