### PR TITLE
feat(find): add option to ignore folded regions in find widget

### DIFF
--- a/src/vs/editor/contrib/find/browser/findController.ts
+++ b/src/vs/editor/contrib/find/browser/findController.ts
@@ -149,7 +149,8 @@ export class CommonFindController extends Disposable implements IEditorContribut
 				matchCase: this._storageService.getBoolean('editor.matchCase', StorageScope.WORKSPACE, false),
 				wholeWord: this._storageService.getBoolean('editor.wholeWord', StorageScope.WORKSPACE, false),
 				isRegex: this._storageService.getBoolean('editor.isRegex', StorageScope.WORKSPACE, false),
-				preserveCase: this._storageService.getBoolean('editor.preserveCase', StorageScope.WORKSPACE, false)
+				preserveCase: this._storageService.getBoolean('editor.preserveCase', StorageScope.WORKSPACE, false),
+				ignoreFoldedRegions: this._storageService.getBoolean('editor.ignoreFoldedRegions', StorageScope.WORKSPACE, false)
 			}, false);
 
 			if (shouldRestartFind) {
@@ -208,6 +209,9 @@ export class CommonFindController extends Disposable implements IEditorContribut
 		if (e.preserveCase) {
 			this._storageService.store('editor.preserveCase', this._state.actualPreserveCase, StorageScope.WORKSPACE, StorageTarget.MACHINE);
 		}
+		if (e.ignoreFoldedRegions) {
+			this._storageService.store('editor.ignoreFoldedRegions', this._state.ignoreFoldedRegions, StorageScope.WORKSPACE, StorageTarget.MACHINE);
+		}
 	}
 
 	private loadQueryState() {
@@ -215,7 +219,8 @@ export class CommonFindController extends Disposable implements IEditorContribut
 			matchCase: this._storageService.getBoolean('editor.matchCase', StorageScope.WORKSPACE, this._state.matchCase),
 			wholeWord: this._storageService.getBoolean('editor.wholeWord', StorageScope.WORKSPACE, this._state.wholeWord),
 			isRegex: this._storageService.getBoolean('editor.isRegex', StorageScope.WORKSPACE, this._state.isRegex),
-			preserveCase: this._storageService.getBoolean('editor.preserveCase', StorageScope.WORKSPACE, this._state.preserveCase)
+			preserveCase: this._storageService.getBoolean('editor.preserveCase', StorageScope.WORKSPACE, this._state.preserveCase),
+			ignoreFoldedRegions: this._storageService.getBoolean('editor.ignoreFoldedRegions', StorageScope.WORKSPACE, this._state.ignoreFoldedRegions)
 		}, false);
 	}
 
@@ -302,6 +307,13 @@ export class CommonFindController extends Disposable implements IEditorContribut
 					this._state.change({ searchScope: selections }, true);
 				}
 			}
+		}
+	}
+
+	public toggleIgnoreFoldedRegions(): void {
+		this._state.change({ ignoreFoldedRegions: !this._state.ignoreFoldedRegions }, false);
+		if (!this._state.isRevealed) {
+			this.highlightFindOptions();
 		}
 	}
 
@@ -1133,6 +1145,16 @@ registerEditorCommand(new FindCommand({
 		mac: ToggleSearchScopeKeybinding.mac,
 		win: ToggleSearchScopeKeybinding.win,
 		linux: ToggleSearchScopeKeybinding.linux
+	}
+}));
+
+registerEditorCommand(new FindCommand({
+	id: FIND_IDS.ToggleIgnoreFoldedCommand,
+	precondition: undefined,
+	handler: x => x.toggleIgnoreFoldedRegions(),
+	kbOpts: {
+		weight: KeybindingWeight.EditorContrib + 5,
+		kbExpr: EditorContextKeys.focus,
 	}
 }));
 

--- a/src/vs/editor/contrib/find/browser/findModel.ts
+++ b/src/vs/editor/contrib/find/browser/findModel.ts
@@ -73,6 +73,7 @@ export const FIND_IDS = {
 	ToggleRegexCommand: 'toggleFindRegex',
 	ToggleSearchScopeCommand: 'toggleFindInSelection',
 	TogglePreserveCaseCommand: 'togglePreserveCase',
+	ToggleIgnoreFoldedCommand: 'toggleFindIgnoreFolded',
 	ReplaceOneAction: 'editor.action.replaceOne',
 	ReplaceAllAction: 'editor.action.replaceAll',
 	SelectAllMatchesAction: 'editor.action.selectAllMatches'
@@ -135,6 +136,12 @@ export class FindModelBoundToEditorModel {
 
 		this._toDispose.add(this._state.onFindReplaceStateChange((e) => this._onStateChanged(e)));
 
+		this._toDispose.add(this._editor.onDidChangeHiddenAreas(() => {
+			if (this._state.ignoreFoldedRegions) {
+				this._updateDecorationsScheduler.schedule();
+			}
+		}));
+
 		this.research(false, this._state.searchScope);
 	}
 
@@ -153,7 +160,7 @@ export class FindModelBoundToEditorModel {
 			// The find model will be disposed momentarily
 			return;
 		}
-		if (e.searchString || e.isReplaceRevealed || e.isRegex || e.wholeWord || e.matchCase || e.searchScope) {
+		if (e.searchString || e.isReplaceRevealed || e.isRegex || e.wholeWord || e.matchCase || e.searchScope || e.ignoreFoldedRegions) {
 			const model = this._editor.getModel();
 
 			if (model.isTooLargeForSyncing()) {
@@ -286,7 +293,7 @@ export class FindModelBoundToEditorModel {
 		return new Position(lineNumber, column);
 	}
 
-	private _moveToPrevMatch(before: Position, isRecursed: boolean = false): void {
+	private _moveToPrevMatch(before: Position, isRecursed: boolean = false, startPosition: Position | null = null): void {
 		if (!this._state.canNavigateBack()) {
 			// we are beyond the first matched find result
 			// instead of doing nothing, we should refocus the first item
@@ -348,7 +355,21 @@ export class FindModelBoundToEditorModel {
 		}
 
 		if (!isRecursed && !searchRange.containsRange(prevMatch.range)) {
-			return this._moveToPrevMatch(prevMatch.range.getStartPosition(), true);
+			return this._moveToPrevMatch(prevMatch.range.getStartPosition(), true, startPosition ?? before);
+		}
+
+		if (this._state.ignoreFoldedRegions) {
+			const hiddenAreas = this._editor._getViewModel()?.getHiddenAreas();
+			if (hiddenAreas && hiddenAreas.length > 0) {
+				const isFolded = hiddenAreas.some(area => Range.areIntersecting(prevMatch.range, area));
+				if (isFolded) {
+					const prevPosition = prevMatch.range.getStartPosition();
+					if (prevPosition.equals(startPosition ?? before)) {
+						return;
+					}
+					return this._moveToPrevMatch(prevPosition, true, startPosition ?? before);
+				}
+			}
 		}
 
 		this._setCurrentFindMatch(prevMatch.range);
@@ -413,7 +434,7 @@ export class FindModelBoundToEditorModel {
 		}
 	}
 
-	private _getNextMatch(after: Position, captureMatches: boolean, forceMove: boolean, isRecursed: boolean = false): FindMatch | null {
+	private _getNextMatch(after: Position, captureMatches: boolean, forceMove: boolean, isRecursed: boolean = false, startPosition: Position | null = null): FindMatch | null {
 		if (this._cannotFind()) {
 			return null;
 		}
@@ -450,7 +471,21 @@ export class FindModelBoundToEditorModel {
 		}
 
 		if (!isRecursed && !searchRange.containsRange(nextMatch.range)) {
-			return this._getNextMatch(nextMatch.range.getEndPosition(), captureMatches, forceMove, true);
+			return this._getNextMatch(nextMatch.range.getEndPosition(), captureMatches, forceMove, true, startPosition ?? after);
+		}
+
+		if (this._state.ignoreFoldedRegions) {
+			const hiddenAreas = this._editor._getViewModel()?.getHiddenAreas();
+			if (hiddenAreas && hiddenAreas.length > 0) {
+				const isFolded = hiddenAreas.some(area => Range.areIntersecting(nextMatch.range, area));
+				if (isFolded) {
+					const nextPosition = nextMatch.range.getEndPosition();
+					if (nextPosition.equals(startPosition ?? after)) {
+						return null;
+					}
+					return this._getNextMatch(nextPosition, captureMatches, forceMove, true, startPosition ?? after);
+				}
+			}
 		}
 
 		return nextMatch;
@@ -509,7 +544,16 @@ export class FindModelBoundToEditorModel {
 			FindModelBoundToEditorModel._getSearchRange(this._editor.getModel(), scope)
 		);
 
-		return this._editor.getModel().findMatches(this._state.searchString, searchRanges, this._state.isRegex, this._state.matchCase, this._state.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, captureMatches, limitResultCount);
+		const matches = this._editor.getModel().findMatches(this._state.searchString, searchRanges, this._state.isRegex, this._state.matchCase, this._state.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, captureMatches, limitResultCount);
+
+		if (this._state.ignoreFoldedRegions) {
+			const hiddenAreas = this._editor._getViewModel()?.getHiddenAreas();
+			if (hiddenAreas && hiddenAreas.length > 0) {
+				return matches.filter(match => !hiddenAreas.some(area => Range.areIntersecting(match.range, area)));
+			}
+		}
+
+		return matches;
 	}
 
 	public replaceAll(): void {

--- a/src/vs/editor/contrib/find/browser/findState.ts
+++ b/src/vs/editor/contrib/find/browser/findState.ts
@@ -27,6 +27,7 @@ export interface FindReplaceStateChangedEvent {
 	loop: boolean;
 	isSearching: boolean;
 	filters: boolean;
+	ignoreFoldedRegions: boolean;
 }
 
 export const enum FindOptionOverride {
@@ -52,6 +53,7 @@ export interface INewFindReplaceState<T extends { update: (value: T) => void } =
 	loop?: boolean;
 	isSearching?: boolean;
 	filters?: T;
+	ignoreFoldedRegions?: boolean;
 }
 
 function effectiveOptionValue(override: FindOptionOverride, value: boolean): boolean {
@@ -84,6 +86,7 @@ export class FindReplaceState<T extends { update: (value: T) => void } = { updat
 	private _loop: boolean;
 	private _isSearching: boolean;
 	private _filters: T | null;
+	private _ignoreFoldedRegions: boolean;
 	private readonly _onFindReplaceStateChange = this._register(new Emitter<FindReplaceStateChangedEvent>());
 
 	public get searchString(): string { return this._searchString; }
@@ -94,6 +97,7 @@ export class FindReplaceState<T extends { update: (value: T) => void } = { updat
 	public get wholeWord(): boolean { return effectiveOptionValue(this._wholeWordOverride, this._wholeWord); }
 	public get matchCase(): boolean { return effectiveOptionValue(this._matchCaseOverride, this._matchCase); }
 	public get preserveCase(): boolean { return effectiveOptionValue(this._preserveCaseOverride, this._preserveCase); }
+	public get ignoreFoldedRegions(): boolean { return this._ignoreFoldedRegions; }
 
 	public get actualIsRegex(): boolean { return this._isRegex; }
 	public get actualWholeWord(): boolean { return this._wholeWord; }
@@ -129,6 +133,7 @@ export class FindReplaceState<T extends { update: (value: T) => void } = { updat
 		this._loop = true;
 		this._isSearching = false;
 		this._filters = null;
+		this._ignoreFoldedRegions = false;
 	}
 
 	public changeMatchInfo(matchesPosition: number, matchesCount: number, currentMatch: Range | undefined): void {
@@ -149,7 +154,8 @@ export class FindReplaceState<T extends { update: (value: T) => void } = { updat
 			currentMatch: false,
 			loop: false,
 			isSearching: false,
-			filters: false
+			filters: false,
+			ignoreFoldedRegions: false
 		};
 		let somethingChanged = false;
 
@@ -202,7 +208,8 @@ export class FindReplaceState<T extends { update: (value: T) => void } = { updat
 			currentMatch: false,
 			loop: false,
 			isSearching: false,
-			filters: false
+			filters: false,
+			ignoreFoldedRegions: false
 		};
 		let somethingChanged = false;
 
@@ -250,6 +257,13 @@ export class FindReplaceState<T extends { update: (value: T) => void } = { updat
 		}
 		if (typeof newState.preserveCase !== 'undefined') {
 			this._preserveCase = newState.preserveCase;
+		}
+		if (typeof newState.ignoreFoldedRegions !== 'undefined') {
+			if (this._ignoreFoldedRegions !== newState.ignoreFoldedRegions) {
+				this._ignoreFoldedRegions = newState.ignoreFoldedRegions;
+				changeEvent.ignoreFoldedRegions = true;
+				somethingChanged = true;
+			}
 		}
 		if (typeof newState.searchScope !== 'undefined') {
 			if (!newState.searchScope?.every((newSearchScope) => {

--- a/src/vs/editor/contrib/find/browser/findWidget.css
+++ b/src/vs/editor/contrib/find/browser/findWidget.css
@@ -140,8 +140,9 @@
 	justify-content: center;
 }
 
-/* find in selection button */
-.monaco-editor .find-widget .codicon-find-selection {
+/* find in selection button & ignore folded regions button */
+.monaco-editor .find-widget .codicon-find-selection,
+.monaco-editor .find-widget .codicon-find-ignore-folded {
 	width: 22px;
 	height: 22px;
 	padding: 3px;

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -50,6 +50,7 @@ const findCollapsedIcon = registerIcon('find-collapsed', Codicon.chevronRight, n
 const findExpandedIcon = registerIcon('find-expanded', Codicon.chevronDown, nls.localize('findExpandedIcon', 'Icon to indicate that the editor find widget is expanded.'));
 
 export const findSelectionIcon = registerIcon('find-selection', Codicon.selection, nls.localize('findSelectionIcon', 'Icon for \'Find in Selection\' in the editor find widget.'));
+export const findIgnoreFoldedIcon = registerIcon('find-ignore-folded', Codicon.fold, nls.localize('findIgnoreFoldedIcon', 'Icon for \'Ignore Folded Regions\' in the editor find widget.'));
 export const findReplaceIcon = registerIcon('find-replace', Codicon.replace, nls.localize('findReplaceIcon', 'Icon for \'Replace\' in the editor find widget.'));
 export const findReplaceAllIcon = registerIcon('find-replace-all', Codicon.replaceAll, nls.localize('findReplaceAllIcon', 'Icon for \'Replace All\' in the editor find widget.'));
 export const findPreviousMatchIcon = registerIcon('find-previous-match', Codicon.arrowUp, nls.localize('findPreviousMatchIcon', 'Icon for \'Find Previous\' in the editor find widget.'));
@@ -67,6 +68,7 @@ const NLS_FIND_INPUT_PLACEHOLDER = nls.localize('placeholder.find', "Find");
 const NLS_PREVIOUS_MATCH_BTN_LABEL = nls.localize('label.previousMatchButton', "Previous Match");
 const NLS_NEXT_MATCH_BTN_LABEL = nls.localize('label.nextMatchButton', "Next Match");
 const NLS_TOGGLE_SELECTION_FIND_TITLE = nls.localize('label.toggleSelectionFind', "Find in Selection");
+const NLS_TOGGLE_IGNORE_FOLDED_TITLE = nls.localize('label.toggleIgnoreFolded', "Ignore Folded Regions");
 const NLS_CLOSE_BTN_LABEL = nls.localize('label.closeButton', "Close");
 const NLS_REPLACE_INPUT_LABEL = nls.localize('label.replace', "Replace");
 const NLS_REPLACE_INPUT_PLACEHOLDER = nls.localize('placeholder.replace', "Replace");
@@ -138,6 +140,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 	private _prevBtn!: SimpleButton;
 	private _nextBtn!: SimpleButton;
 	private _toggleSelectionFind!: Toggle;
+	private _toggleIgnoreFoldedRegions!: Toggle;
 	private _closeBtn!: SimpleButton;
 	private _replaceBtn!: SimpleButton;
 	private _replaceAllBtn!: SimpleButton;
@@ -423,6 +426,9 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 			}
 			this._updateToggleSelectionFindButton();
 		}
+		if (e.ignoreFoldedRegions) {
+			this._toggleIgnoreFoldedRegions.checked = !!this._state.ignoreFoldedRegions;
+		}
 		if (e.searchString || e.matchesCount || e.matchesPosition) {
 			const showRedOutline = (this._state.searchString.length > 0 && this._state.matchesCount === 0);
 			this._domNode.classList.toggle('no-results', showRedOutline);
@@ -530,6 +536,11 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		this._findInput.setEnabled(this._isVisible);
 		this._replaceInput.setEnabled(this._isVisible && this._isReplaceVisible);
 		this._updateToggleSelectionFindButton();
+		if (this._isVisible) {
+			this._toggleIgnoreFoldedRegions.enable();
+		} else {
+			this._toggleIgnoreFoldedRegions.disable();
+		}
 		this._closeBtn.setEnabled(this._isVisible);
 
 		const findInputIsNonEmpty = (this._state.searchString.length > 0);
@@ -1018,6 +1029,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		this._findInput.setRegex(!!this._state.isRegex);
 		this._findInput.setCaseSensitive(!!this._state.matchCase);
 		this._findInput.setWholeWords(!!this._state.wholeWord);
+		this._toggleIgnoreFoldedRegions.checked = !!this._state.ignoreFoldedRegions;
 		this._register(this._findInput.onKeyDown((e) => {
 			if (e.equals(KeyCode.Enter) && !this._codeEditor.getOption(EditorOption.find).findOnType) {
 				this._state.change({ searchString: this._findInput.getValue() }, true);
@@ -1133,6 +1145,23 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		}));
 
 		actionsContainer.appendChild(this._toggleSelectionFind.domNode);
+
+		// Toggle ignore folded regions button
+		this._toggleIgnoreFoldedRegions = this._register(new Toggle({
+			icon: findIgnoreFoldedIcon,
+			title: NLS_TOGGLE_IGNORE_FOLDED_TITLE + this._keybindingLabelFor(FIND_IDS.ToggleIgnoreFoldedCommand),
+			isChecked: false,
+			hoverLifecycleOptions,
+			inputActiveOptionBackground: asCssVariable(inputActiveOptionBackground),
+			inputActiveOptionBorder: asCssVariable(inputActiveOptionBorder),
+			inputActiveOptionForeground: asCssVariable(inputActiveOptionForeground),
+		}));
+
+		this._register(this._toggleIgnoreFoldedRegions.onChange(() => {
+			this._state.change({ ignoreFoldedRegions: this._toggleIgnoreFoldedRegions.checked }, true);
+		}));
+
+		actionsContainer.appendChild(this._toggleIgnoreFoldedRegions.domNode);
 
 		// Close button
 		this._closeBtn = this._register(new SimpleButton({

--- a/src/vs/editor/contrib/find/test/browser/findModel.test.ts
+++ b/src/vs/editor/contrib/find/test/browser/findModel.test.ts
@@ -2402,4 +2402,45 @@ suite('FindModel', () => {
 		});
 	});
 
+	findTest('ignoreFoldedRegions works correctly', (editor) => {
+		editor.setPosition({ lineNumber: 1, column: 1 });
+		const findState = disposables.add(new FindReplaceState());
+		disposables.add(new FindModelBoundToEditorModel(editor, findState));
+
+		// Find "hello" in:
+		// Line 1: // my cool header
+		// Line 2: #include "cool.h"
+		// Line 3: #include <iostream>
+		// Line 4: 
+		// Line 5: int main() {
+		// Line 6:     cout << "hello world, Hello!" << endl;
+		// Line 7:     cout << "hello world again" << endl;
+		// Line 8:     cout << "Hello world again" << endl;
+		// Line 9:     cout << "helloworld again" << endl;
+		// Line 10: }
+		// Line 11: // blablablaciao
+
+		// There are 3 exact matches for "hello" on lines 6, 7, and 9 (case-sensitive).
+		findState.change({ searchString: 'hello', matchCase: true, ignoreFoldedRegions: false }, true);
+		assert.strictEqual(findState.matchesCount, 3);
+
+		// Now fold line 7
+		editor.setHiddenAreas([new Range(7, 1, 7, 1)]);
+
+		// Since ignoreFoldedRegions is false, matchesCount should still be 3
+		assert.strictEqual(findState.matchesCount, 3);
+
+		// Now turn ignoreFoldedRegions on
+		findState.change({ ignoreFoldedRegions: true }, true);
+
+		// Matches count should reduce to 2 (line 6 and line 9)
+		assert.strictEqual(findState.matchesCount, 2);
+
+		// Now unfold line 7 (clear hidden areas)
+		editor.setHiddenAreas([]);
+
+		// Matches count should go back to 3
+		assert.strictEqual(findState.matchesCount, 3);
+	});
+
 });


### PR DESCRIPTION
Fixes issue 324071

Added a new toggle option to the editor Find Widget to ignore matches inside folded (collapsed) code blocks. This is really useful when you've folded large sections of code (like imports or utility functions) and want to search only through your visible, expanded text.

How it works:
- Adds a new toggle button (fold icon) next to the 'Find in Selection' button.
- Filters out matches that overlap with hidden lines using the editor's getHiddenAreas().
- Updates highlights and match count automatically if you fold/unfold regions while the find widget is active.
- Saves your toggle preference in workspace storage.

Testing:
- Added a new test case in findModel.test.ts to verify the count changes correctly when folding/unfolding and toggling the option.
- Verified client typecheck passes cleanly.