### PR TITLE
chat: show "Starting MCP servers…" hint for slow agent-host startup

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Delayer } from '../../../../../../base/common/async.js';
+import { Delayer, disposableTimeout } from '../../../../../../base/common/async.js';
 import { encodeBase64, VSBuffer } from '../../../../../../base/common/buffer.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
 import { isCancellationError } from '../../../../../../base/common/errors.js';
@@ -14,7 +14,7 @@ import { Disposable, DisposableResourceMap, DisposableStore, IReference, Mutable
 import { ResourceMap } from '../../../../../../base/common/map.js';
 import { Schemas } from '../../../../../../base/common/network.js';
 import { equals } from '../../../../../../base/common/objects.js';
-import { autorun, autorunPerKeyedItem, derived, derivedOpts, IObservable, ISettableObservable, observableValue, transaction } from '../../../../../../base/common/observable.js';
+import { autorun, autorunPerKeyedItem, constObservable, derived, derivedOpts, IObservable, ISettableObservable, observableValue, transaction } from '../../../../../../base/common/observable.js';
 import { extUriBiasedIgnorePathCase, isEqual } from '../../../../../../base/common/resources.js';
 import { StopWatch } from '../../../../../../base/common/stopwatch.js';
 import { Mutable } from '../../../../../../base/common/types.js';
@@ -60,7 +60,7 @@ import {
 	type IImageVariableEntry
 } from '../../../common/attachments/chatVariableEntries.js';
 import { coerceImageBuffer } from '../../../common/chatImageExtraction.js';
-import { ChatRequestQueueKind, ConfirmedReason, ElicitationState, IChatProgress, IChatQuestion, IChatQuestionAnswers, IChatService, IChatToolInvocation, ToolConfirmKind, type IChatMcpAuthenticationRequired, type IChatMcpAuthenticationRequiredServer, type IChatMultiSelectAnswer, type IChatPlanReviewResult, type IChatQuestionAnswerValue, type IChatResponseErrorDetails, type IChatSingleSelectAnswer, type IChatTerminalToolInvocationData } from '../../../common/chatService/chatService.js';
+import { ChatRequestQueueKind, ConfirmedReason, ElicitationState, IChatProgress, IChatQuestion, IChatQuestionAnswers, IChatService, IChatToolInvocation, ToolConfirmKind, type IChatMcpAuthenticationRequired, type IChatMcpAuthenticationRequiredServer, type IChatMcpStartingServer, type IChatMultiSelectAnswer, type IChatPlanReviewResult, type IChatQuestionAnswerValue, type IChatResponseErrorDetails, type IChatSingleSelectAnswer, type IChatTerminalToolInvocationData } from '../../../common/chatService/chatService.js';
 import { IChatSession, IChatSessionContentProvider, IChatSessionHistoryItem, IChatSessionItem, IChatSessionRequestHistoryItem, SessionType, type IChatInputCompletionItem, type IChatInputCompletionsParams, type IChatInputCompletionsResult, type IChatSessionServerRequest } from '../../../common/chatSessionsService.js';
 import { IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { IWorkingCopyService } from '../../../../../services/workingCopy/common/workingCopyService.js';
@@ -1796,6 +1796,18 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				};
 			});
 		});
+		const mcpStarting$ = derivedOpts({ equalsFn: equals }, reader => {
+			const state = mergedState$.read(reader);
+			const servers = state?.customizations?.flatMap(c => c.type === CustomizationType.McpServer
+				? [c]
+				: c.children?.filter(c => c.type === CustomizationType.McpServer) ?? []) ?? [];
+			return servers
+				.filter(server => server.enabled && server.state.kind === McpServerStatus.Starting)
+				.map((server): IChatMcpStartingServer => ({
+					id: opts.sessionResource.authority + '/' + server.id,
+					name: server.name,
+				}));
+		});
 
 		// Subagent observation context: dedups subagent tool calls so each is
 		// observed once.
@@ -1876,6 +1888,43 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 					mcpAuthPart.servers.set(servers.slice(), undefined);
 				});
 			}));
+
+			// Surface a "Starting MCP servers …" progress hint when servers
+			// remain in the `Starting` state past a short grace period after the
+			// turn begins without any content arriving from the host. The part
+			// updates as servers finish and hides once every server has started,
+			// content starts being received, or the turn ends — whichever comes
+			// first. It carries no interactive affordance (no "Skip").
+			{
+				const MCP_STARTING_GRACE_MS = 5000;
+
+				let didAppend = false;
+				const hasContent$ = responseParts$.map(r => r.length > 0);
+				const hasServersStarting$ = mcpStarting$.map(s => s.length > 0);
+				const serversStartingInput = observableValue('mcpStartingServersInput', constObservable<IChatMcpStartingServer[]>([]));
+
+				store.add(autorun(reader => {
+					if (hasContent$.read(reader) || !hasServersStarting$.read(reader)) {
+						serversStartingInput.set(constObservable([]), undefined);
+						return;
+					}
+
+					reader.store.add(disposableTimeout(() => {
+						serversStartingInput.set(mcpStarting$, undefined);
+						if (!didAppend) {
+							didAppend = true;
+							opts.sink([{
+								kind: 'mcpServersStartingSlow',
+								sessionResource: opts.sessionResource,
+								servers: serversStartingInput.map((o, r) => o.read(r)),
+							}]);
+						}
+
+					}, MCP_STARTING_GRACE_MS));
+				}));
+
+				store.add(toDisposable(() => serversStartingInput.set(constObservable([]), undefined)));
+			}
 
 			store.add(autorun(reader => {
 				const rawUsage = usage$.read(reader);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMcpServersStartingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMcpServersStartingContentPart.ts
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../../../base/browser/dom.js';
+import { IRenderedMarkdown } from '../../../../../../base/browser/markdownRenderer.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
+import { escapeMarkdownSyntaxTokens, MarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { Disposable, IDisposable, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../../../base/common/observable.js';
+import { ThemeIcon } from '../../../../../../base/common/themables.js';
+import { localize } from '../../../../../../nls.js';
+import { IMarkdownRendererService } from '../../../../../../platform/markdown/browser/markdownRenderer.js';
+import { IChatMcpServersStartingSlow, IChatMcpStartingServer } from '../../../common/chatService/chatService.js';
+import { ChatTreeItem } from '../../chat.js';
+import { IChatRendererContent } from '../../../common/model/chatViewModel.js';
+import { IChatContentPart } from './chatContentParts.js';
+import './media/chatMcpServersInteractionContent.css';
+
+/**
+ * Renders a lightweight "Starting MCP servers …" progress hint for agent-host
+ * sessions. The set of servers still starting is driven by the observable on
+ * {@link IChatMcpServersStartingSlow.servers}; when it empties (all servers
+ * started, content began arriving, or the turn ended) the part hides itself.
+ * There is no interactive affordance — this is a progress indicator only.
+ */
+export class ChatMcpServersStartingContentPart extends Disposable implements IChatContentPart {
+	public readonly domNode: HTMLElement;
+
+	private readonly rendered = this._register(new MutableDisposable<IRenderedMarkdown>());
+
+	constructor(
+		private readonly data: IChatMcpServersStartingSlow,
+		@IMarkdownRendererService private readonly markdownRendererService: IMarkdownRendererService,
+	) {
+		super();
+		this.domNode = dom.$('.chat-mcp-servers-interaction');
+		this._register(autorun(reader => {
+			this.render(this.data.servers.read(reader));
+		}));
+	}
+
+	private render(servers: readonly IChatMcpStartingServer[]): void {
+		dom.clearNode(this.domNode);
+		this.rendered.clear();
+
+		if (!servers.length) {
+			this.domNode.style.display = 'none';
+			return;
+		}
+		this.domNode.style.display = '';
+
+		const links = servers
+			.map(server => '`' + escapeMarkdownSyntaxTokens(server.name) + '`')
+			.join(', ');
+		this._renderMessage(
+			ThemeIcon.modify(Codicon.loading, 'spin'),
+			localize('mcp.starting.servers', 'Starting MCP servers {0}...', links),
+		);
+	}
+
+	private _renderMessage(icon: ThemeIcon, content: string): void {
+		const container = dom.$('.chat-mcp-servers-interaction-hint');
+		const messageContainer = dom.$('.chat-mcp-servers-message');
+		const iconElement = dom.$('.chat-mcp-servers-icon');
+		iconElement.classList.add(...ThemeIcon.asClassNameArray(icon));
+
+		const rendered = this.rendered.value = this.markdownRendererService.render(new MarkdownString(content, { isTrusted: true }));
+
+		messageContainer.appendChild(iconElement);
+		messageContainer.appendChild(rendered.element);
+		container.appendChild(messageContainer);
+		this.domNode.appendChild(container);
+	}
+
+	hasSameContent(other: IChatRendererContent, _followingContent: IChatRendererContent[], _element: ChatTreeItem): boolean {
+		return other.kind === 'mcpServersStartingSlow';
+	}
+
+	addDisposable(disposable: IDisposable): void {
+		this._register(disposable);
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMcpServersStartingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMcpServersStartingContentPart.ts
@@ -66,8 +66,7 @@ export class ChatMcpServersStartingContentPart extends Disposable implements ICh
 		const iconElement = dom.$('.chat-mcp-servers-icon');
 		iconElement.classList.add(...ThemeIcon.asClassNameArray(icon));
 
-		const rendered = this.rendered.value = this.markdownRendererService.render(new MarkdownString(content, { isTrusted: true }));
-
+		const rendered = this.rendered.value = this.markdownRendererService.render(new MarkdownString(content));
 		messageContainer.appendChild(iconElement);
 		messageContainer.appendChild(rendered.element);
 		container.appendChild(messageContainer);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -88,6 +88,7 @@ import { ChatExtensionsContentPart } from './chatContentParts/chatExtensionsCont
 import { ChatMarkdownContentPart, codeblockHasClosingBackticks } from './chatContentParts/chatMarkdownContentPart.js';
 import { ChatMcpServersInteractionContentPart } from './chatContentParts/chatMcpServersInteractionContentPart.js';
 import { ChatMcpAuthenticationContentPart } from './chatContentParts/chatMcpAuthenticationContentPart.js';
+import { ChatMcpServersStartingContentPart } from './chatContentParts/chatMcpServersStartingContentPart.js';
 import { ChatDisabledClaudeHooksContentPart } from './chatContentParts/chatDisabledClaudeHooksContentPart.js';
 import { ChatMultiDiffContentPart } from './chatContentParts/chatMultiDiffContentPart.js';
 import { ChatProgressContentPart, ChatProgressSubPart, ChatWorkingProgressContentPart } from './chatContentParts/chatProgressContentPart.js';
@@ -1319,6 +1320,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			(lastPart.kind === 'progressTask' && lastPart.deferred.isSettled) ||
 			lastPart.kind === 'mcpServersStarting' ||
 			lastPart.kind === 'mcpAuthenticationRequired' ||
+			lastPart.kind === 'mcpServersStartingSlow' ||
 			lastPart.kind === 'disabledClaudeHooks' ||
 			lastPart.kind === 'hook'
 		) {
@@ -2479,6 +2481,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				return this.renderMcpServersInteractionRequired(content, context, templateData);
 			} else if (content.kind === 'mcpAuthenticationRequired') {
 				return this.instantiationService.createInstance(ChatMcpAuthenticationContentPart, content);
+			} else if (content.kind === 'mcpServersStartingSlow') {
+				return this.instantiationService.createInstance(ChatMcpServersStartingContentPart, content);
 			} else if (content.kind === 'disabledClaudeHooks') {
 				return this.renderDisabledClaudeHooks(content, context);
 			} else if (content.kind === 'thinking') {

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -1209,6 +1209,29 @@ export interface IChatMcpAuthenticationRequiredServer {
 	readonly reason?: string;
 }
 
+/**
+ * Surfaced by agent-host sessions when one or more MCP servers are still in the
+ * {@link McpServerStatus.Starting starting} state a noticeable time after a
+ * turn began without any content arriving from the host. The part lists the
+ * servers still starting and updates dynamically via {@link servers}: it hides
+ * itself (by emptying the observable) once every server has started, content
+ * starts being received, or the turn ends — whichever happens first.
+ *
+ * Unlike {@link IChatMcpServersStarting} (used by the in-process MCP autostart
+ * flow), this is a lightweight progress hint with no interactive affordance
+ * (there is no "Skip" button).
+ */
+export interface IChatMcpServersStartingSlow {
+	readonly kind: 'mcpServersStartingSlow';
+	readonly sessionResource: UriComponents;
+	readonly servers: IObservable<readonly IChatMcpStartingServer[]>;
+}
+
+export interface IChatMcpStartingServer {
+	readonly id: string;
+	readonly name: string;
+}
+
 export interface IChatDisabledClaudeHooksPart {
 	readonly kind: 'disabledClaudeHooks';
 }
@@ -1345,6 +1368,7 @@ export type IChatProgress =
 	| IChatMcpServersStarting
 	| IChatMcpServersStartingSerialized
 	| IChatMcpAuthenticationRequired
+	| IChatMcpServersStartingSlow
 	| IChatHookPart
 	| IChatExternalToolInvocationUpdate
 	| IChatDisabledClaudeHooksPart

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -31,7 +31,7 @@ import { CellUri, ICellEditOperation } from '../../../notebook/common/notebookCo
 import { ChatRequestToolReferenceEntry, IChatRequestVariableEntry, isImplicitVariableEntry, isStringImplicitContextValue, isStringVariableEntry } from '../attachments/chatVariableEntries.js';
 import { migrateLegacyTerminalToolSpecificData } from '../chat.js';
 import { ChatPerfMark, markChat } from '../chatPerf.js';
-import { ChatAgentVoteDirection, ChatRequestQueueKind, ChatResponseClearToPreviousToolInvocationReason, ElicitationState, IChatAgentMarkdownContentWithVulnerability, IChatAutoModeResolutionPart, IChatClearToPreviousToolInvocation, IChatCodeCitation, IChatCommandButton, IChatConfirmation, IChatContentInlineReference, IChatContentReference, IChatDisabledClaudeHooksPart, IChatEditingSessionAction, IChatElicitationRequest, IChatElicitationRequestSerialized, IChatExternalEdit, IChatExternalToolInvocationUpdate, IChatExtensionsContent, IChatFollowup, IChatHookPart, IChatLocationData, IChatMarkdownContent, IChatMcpAuthenticationRequired, IChatMcpServersStarting, IChatMcpServersStartingSerialized, IChatModelReference, IChatMultiDiffData, IChatMultiDiffDataSerialized, IChatNotebookEdit, IChatProgress, IChatPlanReview, IChatProgressMessage, IChatPullRequestContent, IChatQuestionCarousel, IChatResponseCodeblockUriPart, IChatResponseProgressFileTreeData, IChatSendRequestOptions, IChatService, IChatSessionTiming, IChatTask, IChatTaskSerialized, IChatTextEdit, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, IChatUsage, IChatUsagePromptTokenDetail, IChatUsedContext, IChatWarningMessage, IChatInfoMessage, IChatWorkspaceEdit, ResponseModelState, ToolConfirmKind, isIUsedContext } from '../chatService/chatService.js';
+import { ChatAgentVoteDirection, ChatRequestQueueKind, ChatResponseClearToPreviousToolInvocationReason, ElicitationState, IChatAgentMarkdownContentWithVulnerability, IChatAutoModeResolutionPart, IChatClearToPreviousToolInvocation, IChatCodeCitation, IChatCommandButton, IChatConfirmation, IChatContentInlineReference, IChatContentReference, IChatDisabledClaudeHooksPart, IChatEditingSessionAction, IChatElicitationRequest, IChatElicitationRequestSerialized, IChatExternalEdit, IChatExternalToolInvocationUpdate, IChatExtensionsContent, IChatFollowup, IChatHookPart, IChatLocationData, IChatMarkdownContent, IChatMcpAuthenticationRequired, IChatMcpServersStarting, IChatMcpServersStartingSerialized, IChatMcpServersStartingSlow, IChatModelReference, IChatMultiDiffData, IChatMultiDiffDataSerialized, IChatNotebookEdit, IChatProgress, IChatPlanReview, IChatProgressMessage, IChatPullRequestContent, IChatQuestionCarousel, IChatResponseCodeblockUriPart, IChatResponseProgressFileTreeData, IChatSendRequestOptions, IChatService, IChatSessionTiming, IChatTask, IChatTaskSerialized, IChatTextEdit, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, IChatUsage, IChatUsagePromptTokenDetail, IChatUsedContext, IChatWarningMessage, IChatInfoMessage, IChatWorkspaceEdit, ResponseModelState, ToolConfirmKind, isIUsedContext } from '../chatService/chatService.js';
 import { ChatAgentLocation, ChatModeKind, ChatPermissionLevel } from '../constants.js';
 import { ChatToolInvocation } from './chatProgressTypes/chatToolInvocation.js';
 import { ChatPlanReviewData } from './chatProgressTypes/chatPlanReviewData.js';
@@ -224,6 +224,7 @@ export type IChatProgressResponseContent =
 	| IChatMcpServersStarting
 	| IChatMcpServersStartingSerialized
 	| IChatMcpAuthenticationRequired
+	| IChatMcpServersStartingSlow
 	| IChatDisabledClaudeHooksPart;
 
 export type IChatProgressResponseContentSerialized = Exclude<IChatProgressResponseContent,
@@ -233,6 +234,7 @@ export type IChatProgressResponseContentSerialized = Exclude<IChatProgressRespon
 	| IChatMultiDiffData
 	| IChatMcpServersStarting
 	| IChatMcpAuthenticationRequired
+	| IChatMcpServersStartingSlow
 	| IChatDisabledClaudeHooksPart
 >;
 
@@ -616,6 +618,7 @@ class AbstractResponse implements IResponse {
 				case 'multiDiffData':
 				case 'mcpServersStarting':
 				case 'mcpAuthenticationRequired':
+				case 'mcpServersStartingSlow':
 				case 'questionCarousel':
 				case 'planReview':
 				case 'disabledClaudeHooks':

--- a/src/vs/workbench/contrib/chat/common/model/chatSessionOperationLog.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatSessionOperationLog.ts
@@ -10,7 +10,7 @@ import { isEqual as _urisEqual } from '../../../../../base/common/resources.js';
 import { hasKey } from '../../../../../base/common/types.js';
 import { URI, UriComponents } from '../../../../../base/common/uri.js';
 import { IChatRequestVariableEntry } from '../attachments/chatVariableEntries.js';
-import { IChatMarkdownContent, IChatMcpAuthenticationRequired, ResponseModelState } from '../chatService/chatService.js';
+import { IChatMarkdownContent, IChatMcpAuthenticationRequired, IChatMcpServersStartingSlow, ResponseModelState } from '../chatService/chatService.js';
 import { ModifiedFileEntryState } from '../editing/chatEditingService.js';
 import { IParsedChatRequest } from '../requestParser/chatParserTypes.js';
 import { IChatAgentEditedFileEvent, IChatDataSerializerLog, IChatModel, IChatPendingRequest, IChatProgressResponseContent, IChatRequestModel, IChatRequestVariableData, ISerializableChatData, ISerializableChatModelInputState, ISerializableChatRequestData, ISerializablePendingRequestData, SerializedChatResponsePart, serializeSendOptions } from './chatModel.js';
@@ -38,7 +38,7 @@ const toJson = <T>(obj: T): T extends { toJSON?(): infer R } ? R : T => {
 	return (cast && typeof cast.toJSON === 'function' ? cast.toJSON() : obj) as any;
 };
 
-const responsePartSchema = Adapt.v<Exclude<IChatProgressResponseContent, IChatMcpAuthenticationRequired>, SerializedChatResponsePart>(
+const responsePartSchema = Adapt.v<Exclude<IChatProgressResponseContent, IChatMcpAuthenticationRequired | IChatMcpServersStartingSlow>, SerializedChatResponsePart>(
 	(obj): SerializedChatResponsePart => obj.kind === 'markdownContent' ? obj.content : toJson(obj),
 	(a, b) => {
 		if (isMarkdownString(a) && isMarkdownString(b)) {
@@ -138,7 +138,7 @@ const requestSchema = Adapt.object<IChatRequestModel, ISerializableChatRequestDa
 	isHidden: Adapt.v(() => undefined), // deprecated, always undefined for new data
 	isCanceled: Adapt.v(() => undefined), // deprecated, modelState is used instead
 
-	response: Adapt.t(m => m.response?.entireResponse.value.filter((p): p is Exclude<IChatProgressResponseContent, IChatMcpAuthenticationRequired> => p.kind !== 'mcpAuthenticationRequired'), Adapt.array(responsePartSchema)),
+	response: Adapt.t(m => m.response?.entireResponse.value.filter((p): p is Exclude<IChatProgressResponseContent, IChatMcpAuthenticationRequired | IChatMcpServersStartingSlow> => p.kind !== 'mcpAuthenticationRequired' && p.kind !== 'mcpServersStartingSlow'), Adapt.array(responsePartSchema)),
 	responseId: Adapt.v(m => m.response?.id),
 	result: Adapt.v(m => m.response?.result, objectsEqual),
 	responseMarkdownInfo: Adapt.v(

--- a/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
@@ -13,7 +13,7 @@ import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IChatRequestVariableEntry } from '../attachments/chatVariableEntries.js';
-import { ChatAgentVoteDirection, ChatRequestQueueKind, IChatCodeCitation, IChatContentReference, IChatDisabledClaudeHooksPart, IChatFollowup, IChatMcpAuthenticationRequired, IChatMcpServersStarting, IChatPlanReview, IChatProgressMessage, IChatQuestionCarousel, IChatResponseErrorDetails, IChatTask, IChatUsage, IChatUsedContext } from '../chatService/chatService.js';
+import { ChatAgentVoteDirection, ChatRequestQueueKind, IChatCodeCitation, IChatContentReference, IChatDisabledClaudeHooksPart, IChatFollowup, IChatMcpAuthenticationRequired, IChatMcpServersStarting, IChatMcpServersStartingSlow, IChatPlanReview, IChatProgressMessage, IChatQuestionCarousel, IChatResponseErrorDetails, IChatTask, IChatUsage, IChatUsedContext } from '../chatService/chatService.js';
 import { getFullyQualifiedId, IChatAgentCommand, IChatAgentData, IChatAgentNameService, IChatAgentResult } from '../participants/chatAgents.js';
 import { IParsedChatRequest } from '../requestParser/chatParserTypes.js';
 import { IChatModel, IChatProgressRenderableResponseContent, IChatRequestDisablement, IChatRequestModel, IChatResponseModel, IChatTextEditGroup, IResponse } from './chatModel.js';
@@ -224,7 +224,7 @@ export interface IChatChangesSummaryPart {
 /**
  * Type for content parts rendered by IChatListRenderer (not necessarily in the model)
  */
-export type IChatRendererContent = IChatProgressRenderableResponseContent | IChatReferences | IChatCodeCitations | IChatErrorDetailsPart | IChatChangesSummaryPart | IChatWorkingProgress | IChatMcpServersStarting | IChatMcpAuthenticationRequired | IChatQuestionCarousel | IChatPlanReview | IChatDisabledClaudeHooksPart;
+export type IChatRendererContent = IChatProgressRenderableResponseContent | IChatReferences | IChatCodeCitations | IChatErrorDetailsPart | IChatChangesSummaryPart | IChatWorkingProgress | IChatMcpServersStarting | IChatMcpAuthenticationRequired | IChatMcpServersStartingSlow | IChatQuestionCarousel | IChatPlanReview | IChatDisabledClaudeHooksPart;
 
 export interface IChatResponseViewModel {
 	readonly model: IChatResponseModel;

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatMcpServersStartingContentPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatMcpServersStartingContentPart.test.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../../../../base/common/lifecycle.js';
+import { observableValue } from '../../../../../../../base/common/observable.js';
+import { URI } from '../../../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
+import { TestInstantiationService } from '../../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { workbenchInstantiationService } from '../../../../../../test/browser/workbenchTestServices.js';
+import { ChatMcpServersStartingContentPart } from '../../../../browser/widget/chatContentParts/chatMcpServersStartingContentPart.js';
+import { IChatMcpServersStartingSlow, IChatMcpStartingServer } from '../../../../common/chatService/chatService.js';
+import { IChatRendererContent } from '../../../../common/model/chatViewModel.js';
+
+suite('ChatMcpServersStartingContentPart', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let disposables: DisposableStore;
+	let instantiationService: TestInstantiationService;
+
+	setup(() => {
+		disposables = store.add(new DisposableStore());
+		instantiationService = workbenchInstantiationService(undefined, disposables);
+	});
+
+	function createPart(servers: readonly IChatMcpStartingServer[]) {
+		const servers$ = observableValue<readonly IChatMcpStartingServer[]>('servers', servers);
+		const data: IChatMcpServersStartingSlow = {
+			kind: 'mcpServersStartingSlow',
+			sessionResource: URI.parse('chat-session://test/session1'),
+			servers: servers$,
+		};
+		const part = disposables.add(instantiationService.createInstance(ChatMcpServersStartingContentPart, data));
+		return { part, servers$ };
+	}
+
+	test('reflects the starting servers and hides when empty as the observable updates', () => {
+		const { part, servers$ } = createPart([{ id: 'a', name: 'alpha' }, { id: 'b', name: 'beta' }]);
+
+		const snapshot = () => ({ hidden: part.domNode.style.display === 'none', text: part.domNode.textContent ?? '' });
+
+		const initial = snapshot();
+
+		servers$.set([{ id: 'a', name: 'alpha' }], undefined);
+		const afterOneFinished = snapshot();
+
+		servers$.set([], undefined);
+		const afterAllFinished = snapshot();
+
+		assert.deepStrictEqual({ initial, afterOneFinished, afterAllFinished }, {
+			initial: { hidden: false, text: 'Starting MCP servers alpha, beta...' },
+			afterOneFinished: { hidden: false, text: 'Starting MCP servers alpha...' },
+			afterAllFinished: { hidden: true, text: '' },
+		});
+	});
+
+	test('hasSameContent matches only the same kind', () => {
+		const { part } = createPart([{ id: 'a', name: 'alpha' }]);
+
+		assert.deepStrictEqual(
+			[
+				part.hasSameContent({ kind: 'mcpServersStartingSlow' } as IChatRendererContent, [], null!),
+				part.hasSameContent({ kind: 'mcpAuthenticationRequired' } as IChatRendererContent, [], null!),
+			],
+			[true, false],
+		);
+	});
+});


### PR DESCRIPTION
Addresses #323908.

We already surface `ChatMcpAuthenticationContentPart` for agent-host sessions, but there was no representation of the long delay that can happen at startup while MCP servers spin up. This adds a lightweight, observable-backed "Starting MCP servers…" progress hint, in the spirit of the existing `ChatMcpServersInteractionContentPart`.

### Behavior
- After a new turn begins, if one or more MCP servers remain in the `starting` state past a short grace period (**5s**) **without any content arriving from the host**, a part is shown: _"Starting MCP servers \`x\`, \`y\`..."_.
- It updates dynamically as servers finish starting, and hides itself once **all servers have started**, **content starts being received**, or **the turn ends** — whichever happens first.
- There is **no** "Skip" affordance (unlike the in-process autostart flow).

### Changes
- New progress kind `IChatMcpServersStartingSlow` (+ `IChatMcpStartingServer`) wired through `IChatProgress`, `IChatProgressResponseContent`, `IChatRendererContent`, and excluded from operation-log serialization (it is observable-backed, like the auth part).
- New renderer `ChatMcpServersStartingContentPart` + wiring in `chatListRenderer` (render case + "working" progress detection).
- `agentHostSessionHandler`: a `mcpStarting$` derived over enabled servers in the `Starting` state, plus the grace-period / content-arrival / turn-end orchestration that emits and updates the part.
- Unit test for the new content part (render/update/hide + `hasSameContent`).

### Validation
- `npm run typecheck-client`, `npm run valid-layers-check`, ESLint, and the new unit test all pass.