### PR TITLE
Bump @anthropic-ai/claude-agent-sdk to 0.3.198

### DIFF
--- a/build/agent-sdk/agents/claude/package-lock.json
+++ b/build/agent-sdk/agents/claude/package-lock.json
@@ -6,26 +6,26 @@
 		"": {
 			"name": "agent-sdk-claude",
 			"dependencies": {
-				"@anthropic-ai/claude-agent-sdk": "0.3.187"
+				"@anthropic-ai/claude-agent-sdk": "0.3.198"
 			}
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk": {
-			"version": "0.3.187",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.187.tgz",
-			"integrity": "sha512-HHkuC3he/Wi8fX/WjfS8mJr4TFPGoAd1QyxOuTwjnyOLboGkX1H+UhBYLxHX1ouFvHnYVJglB2wsuWemVQgahQ==",
+			"version": "0.3.198",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.198.tgz",
+			"integrity": "sha512-xt469sSCyclTPtzpLAg0Aschy665GiRMgZKabSmESbGUA5/H56HcILVOiFxclXswkeMUk2fQxfHJUY9UZfiTnA==",
 			"license": "SEE LICENSE IN README.md",
 			"engines": {
 				"node": ">=18.0.0"
 			},
 			"optionalDependencies": {
-				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.187",
-				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.187",
-				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.187",
-				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.187",
-				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.187",
-				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.187",
-				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.187",
-				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.187"
+				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.198",
+				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.198",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.198",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.198",
+				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.198",
+				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.198",
+				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.198",
+				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.198"
 			},
 			"peerDependencies": {
 				"@anthropic-ai/sdk": ">=0.93.0",
@@ -34,9 +34,9 @@
 			}
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-			"version": "0.3.187",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.187.tgz",
-			"integrity": "sha512-0DNzATzaRmjS/Q1T4T9SLP/VT67gRX7J4reYPnEdcTm91lJwjqOPkHr17+sv+7DoerZ421ZG38dPsQd/V67qQw==",
+			"version": "0.3.198",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.198.tgz",
+			"integrity": "sha512-ZmiAybQKIKcP1qEAE/vfXvfxtKxG9CnJn98QTXC5Zxiwuy7Mllx2ALXh9dfmsf0V87CGEodlZQmMgUJotNIsUw==",
 			"cpu": [
 				"arm64"
 			],
@@ -47,9 +47,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-			"version": "0.3.187",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.187.tgz",
-			"integrity": "sha512-Va3O8lTDa9IHq/DbSJwU63JJknNV3YCBh4PEznOHXJtyFoXHgRjrks4QQvN3baZm79avVq2sn+6tvpTz9CuY8A==",
+			"version": "0.3.198",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.198.tgz",
+			"integrity": "sha512-XwH5vgN46WSwg8aC1OagNofnJpV/G1ciEu118GEKer8ZhVkq/dvK/DqShxMkb6r1jV7u5IJ7zPXu9uKliyNJAw==",
 			"cpu": [
 				"x64"
 			],
@@ -60,9 +60,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-			"version": "0.3.187",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.187.tgz",
-			"integrity": "sha512-VEvrs3MgwckdWRNa7+2rJdyOBbCWGoRaM6OnL+/n9qi4gKlZnXZlj/90Tw9o8ttcN260Opz120/SE1fYwzu/JA==",
+			"version": "0.3.198",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.198.tgz",
+			"integrity": "sha512-qmz8dxEtDIlKntU5qYe0R4aWTxTue5S7zIQknatLX7aJ6HN/nq1aCNXWn5smTH2FViBkUPPR+sCIsNwSk6AT6Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -76,9 +76,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-			"version": "0.3.187",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.187.tgz",
-			"integrity": "sha512-XQ7w2pX0mjPYUC7ayTKiHeAbePOny/ezBATxTWt5JVDZZPfljzvHA0jyXHsN8aLphbgRUfbUpdrtt5b57Bhx5g==",
+			"version": "0.3.198",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.198.tgz",
+			"integrity": "sha512-Q7lKVNjIrUQ2B/AR77OvRf0zeOdEjonFVaR9FYrrwtzGeEqum69WSht5nM7Y7el3wjbNi0/eV0QTUM0DlsTEfw==",
 			"cpu": [
 				"arm64"
 			],
@@ -92,9 +92,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-			"version": "0.3.187",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.187.tgz",
-			"integrity": "sha512-s/Fmg29tzMrbdeCbseTpL3DlzfWineSQ3bDPvhdKw4jcsgLC1YgQhIkAyE8WlceUyhQyw82NAUgYoPwfGny6hQ==",
+			"version": "0.3.198",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.198.tgz",
+			"integrity": "sha512-Zqxyz2AT1UM5WlOOoLJhLssZDgZo8rBK5ku6daveK12zp+UTJGZhGsjFghz1/ASxH08KqOTbUePNTORnPhHAEQ==",
 			"cpu": [
 				"x64"
 			],
@@ -108,9 +108,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-			"version": "0.3.187",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.187.tgz",
-			"integrity": "sha512-yi2/L5oztFqTDnAZl4mWOINr+r7WBot70gYUxG2jOoqdYUl6j50vG/ME605X80v+l2qBmKjSGxb5trY/6DkRzQ==",
+			"version": "0.3.198",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.198.tgz",
+			"integrity": "sha512-h1SrWVIMjLInYNPlf+TxXuKTOdoiOfJLBSoQG97315Z2Nh0IpBfqWExlqYTtPCgKE7q2iga31U283QfHpIDlSQ==",
 			"cpu": [
 				"x64"
 			],
@@ -124,9 +124,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-			"version": "0.3.187",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.187.tgz",
-			"integrity": "sha512-HjEl3cDRLAWKopdlrLI54fxTVWq4lZpWA4bTTBVc9UDdDj6AmJIRHKxaCCYLQRvnoswbAUF1sJmJ8EFJ+b6lfw==",
+			"version": "0.3.198",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.198.tgz",
+			"integrity": "sha512-mjIHf1HFiRuXefewWTaNZFlTZlCaEt/xsRjc1nSTCEEpFolZayVhrDKz+O2QFVcDtPl8x8GeYSL0kiikg1DZjQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -137,9 +137,9 @@
 			]
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-			"version": "0.3.187",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.187.tgz",
-			"integrity": "sha512-FnrLhoZ8y/+gkZynL12UeQ8pWKCu6B/8myyRrYMNJRZqFw4DZlPvPCywAjFZf1e1hiXCoiSK0Orl5wzKfAeQsQ==",
+			"version": "0.3.198",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.198.tgz",
+			"integrity": "sha512-y3HLuCCz1kDwUrhd6OnqO+d5BUpTFSzNUsPT9kf3r1vk9HYKF+eMC9eIlcOhiW2kX491kxEvuEOfqgIkGx15cg==",
 			"cpu": [
 				"x64"
 			],

--- a/build/agent-sdk/agents/claude/package.json
+++ b/build/agent-sdk/agents/claude/package.json
@@ -3,6 +3,6 @@
 	"private": true,
 	"comment": "Pinned dependency set for the build/agent-sdk claude tarball. The package-lock.json alongside is the source of truth for transitive deps — produce.ts runs `npm ci` against this directory to get byte-deterministic output across pipeline runs.",
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.187"
+		"@anthropic-ai/claude-agent-sdk": "0.3.198"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.187",
+        "@anthropic-ai/claude-agent-sdk": "0.3.198",
         "@openai/codex": "0.142.0",
         "@playwright/cli": "^0.1.9",
         "@playwright/test": "^1.61.1",
@@ -185,23 +185,23 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.187",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.187.tgz",
-      "integrity": "sha512-HHkuC3he/Wi8fX/WjfS8mJr4TFPGoAd1QyxOuTwjnyOLboGkX1H+UhBYLxHX1ouFvHnYVJglB2wsuWemVQgahQ==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.198.tgz",
+      "integrity": "sha512-xt469sSCyclTPtzpLAg0Aschy665GiRMgZKabSmESbGUA5/H56HcILVOiFxclXswkeMUk2fQxfHJUY9UZfiTnA==",
       "dev": true,
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.187",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.187",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.187",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.187",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.187",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.187",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.187",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.187"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.198",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.198",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.198",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.198",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.198",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.198",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.198",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.198"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -210,9 +210,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.187",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.187.tgz",
-      "integrity": "sha512-0DNzATzaRmjS/Q1T4T9SLP/VT67gRX7J4reYPnEdcTm91lJwjqOPkHr17+sv+7DoerZ421ZG38dPsQd/V67qQw==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.198.tgz",
+      "integrity": "sha512-ZmiAybQKIKcP1qEAE/vfXvfxtKxG9CnJn98QTXC5Zxiwuy7Mllx2ALXh9dfmsf0V87CGEodlZQmMgUJotNIsUw==",
       "cpu": [
         "arm64"
       ],
@@ -224,9 +224,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.187",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.187.tgz",
-      "integrity": "sha512-Va3O8lTDa9IHq/DbSJwU63JJknNV3YCBh4PEznOHXJtyFoXHgRjrks4QQvN3baZm79avVq2sn+6tvpTz9CuY8A==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.198.tgz",
+      "integrity": "sha512-XwH5vgN46WSwg8aC1OagNofnJpV/G1ciEu118GEKer8ZhVkq/dvK/DqShxMkb6r1jV7u5IJ7zPXu9uKliyNJAw==",
       "cpu": [
         "x64"
       ],
@@ -238,13 +238,16 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.187",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.187.tgz",
-      "integrity": "sha512-VEvrs3MgwckdWRNa7+2rJdyOBbCWGoRaM6OnL+/n9qi4gKlZnXZlj/90Tw9o8ttcN260Opz120/SE1fYwzu/JA==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.198.tgz",
+      "integrity": "sha512-qmz8dxEtDIlKntU5qYe0R4aWTxTue5S7zIQknatLX7aJ6HN/nq1aCNXWn5smTH2FViBkUPPR+sCIsNwSk6AT6Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -252,13 +255,16 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.187",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.187.tgz",
-      "integrity": "sha512-XQ7w2pX0mjPYUC7ayTKiHeAbePOny/ezBATxTWt5JVDZZPfljzvHA0jyXHsN8aLphbgRUfbUpdrtt5b57Bhx5g==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.198.tgz",
+      "integrity": "sha512-Q7lKVNjIrUQ2B/AR77OvRf0zeOdEjonFVaR9FYrrwtzGeEqum69WSht5nM7Y7el3wjbNi0/eV0QTUM0DlsTEfw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -266,13 +272,16 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.187",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.187.tgz",
-      "integrity": "sha512-s/Fmg29tzMrbdeCbseTpL3DlzfWineSQ3bDPvhdKw4jcsgLC1YgQhIkAyE8WlceUyhQyw82NAUgYoPwfGny6hQ==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.198.tgz",
+      "integrity": "sha512-Zqxyz2AT1UM5WlOOoLJhLssZDgZo8rBK5ku6daveK12zp+UTJGZhGsjFghz1/ASxH08KqOTbUePNTORnPhHAEQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -280,13 +289,16 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.187",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.187.tgz",
-      "integrity": "sha512-yi2/L5oztFqTDnAZl4mWOINr+r7WBot70gYUxG2jOoqdYUl6j50vG/ME605X80v+l2qBmKjSGxb5trY/6DkRzQ==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.198.tgz",
+      "integrity": "sha512-h1SrWVIMjLInYNPlf+TxXuKTOdoiOfJLBSoQG97315Z2Nh0IpBfqWExlqYTtPCgKE7q2iga31U283QfHpIDlSQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -294,9 +306,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.187",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.187.tgz",
-      "integrity": "sha512-HjEl3cDRLAWKopdlrLI54fxTVWq4lZpWA4bTTBVc9UDdDj6AmJIRHKxaCCYLQRvnoswbAUF1sJmJ8EFJ+b6lfw==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.198.tgz",
+      "integrity": "sha512-mjIHf1HFiRuXefewWTaNZFlTZlCaEt/xsRjc1nSTCEEpFolZayVhrDKz+O2QFVcDtPl8x8GeYSL0kiikg1DZjQ==",
       "cpu": [
         "arm64"
       ],
@@ -308,9 +320,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.187",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.187.tgz",
-      "integrity": "sha512-FnrLhoZ8y/+gkZynL12UeQ8pWKCu6B/8myyRrYMNJRZqFw4DZlPvPCywAjFZf1e1hiXCoiSK0Orl5wzKfAeQsQ==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.198.tgz",
+      "integrity": "sha512-y3HLuCCz1kDwUrhd6OnqO+d5BUpTFSzNUsPT9kf3r1vk9HYKF+eMC9eIlcOhiW2kX491kxEvuEOfqgIkGx15cg==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.187",
+    "@anthropic-ai/claude-agent-sdk": "0.3.198",
     "@openai/codex": "0.142.0",
     "@playwright/cli": "^0.1.9",
     "@playwright/test": "^1.61.1",

--- a/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
@@ -492,6 +492,7 @@ class RoundTripQuery implements AsyncGenerator<SDKMessage, void> {
 	setMaxThinkingTokens(): never { throw new Error('not modeled'); }
 	applyFlagSettings(): never { throw new Error('not modeled'); }
 	initializationResult(): never { throw new Error('not modeled'); }
+	reinitialize(): never { throw new Error('not modeled'); }
 	supportedCommands(): never { throw new Error('not modeled'); }
 	supportedModels(): never { throw new Error('not modeled'); }
 	supportedAgents(): never { throw new Error('not modeled'); }

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -567,6 +567,7 @@ class FakeQuery implements AsyncGenerator<SDKMessage, void> {
 	setMaxThinkingTokens(): never { throw new Error('FakeQuery: setMaxThinkingTokens not modeled'); }
 	async applyFlagSettings(s: Settings): Promise<void> { this.recordedFlagSettings.push(s); }
 	initializationResult(): never { throw new Error('FakeQuery: initializationResult not modeled'); }
+	reinitialize(): never { throw new Error('FakeQuery: reinitialize not modeled'); }
 
 	supportedCommands(): never {
 		return Promise.resolve(this._sdk.supportedCommandsResult) as never;

--- a/src/vs/platform/agentHost/test/node/claudeSdkPipeline.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeSdkPipeline.test.ts
@@ -69,6 +69,7 @@ class ImmediatelyDoneQuery implements Query {
 	async [Symbol.asyncDispose](): Promise<void> { /* not exercised here */ }
 	setMaxThinkingTokens(): never { throw new Error('not modeled'); }
 	initializationResult(): never { throw new Error('not modeled'); }
+	reinitialize(): never { throw new Error('not modeled'); }
 	supportedCommands(): never { throw new Error('not modeled'); }
 	supportedModels(): never { throw new Error('not modeled'); }
 	supportedAgents(): never { throw new Error('not modeled'); }


### PR DESCRIPTION
Bumps the pinned Claude agent SDK from `0.3.187` to `0.3.198` (latest stable) following the procedure in `build/agent-sdk/README.md`.

## Changes
- `build/agent-sdk/agents/claude/package.json` — exact `dependencies` pin → `0.3.198`
- `build/agent-sdk/agents/claude/package-lock.json` — refreshed via `npm install --package-lock-only --ignore-scripts`
- `package.json` — matching root `devDependencies` types pin → `0.3.198`
- `package-lock.json` — refreshed via root `npm install`

This keeps the build-time pin and the shipped types in lockstep. The next pipeline run rebuilds + uploads each platform tarball at the new content-addressed CDN path and re-stamps `product.agentSdks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)