### PR TITLE
Enable provider-level ZDR for OpenAI BYOK and surface Responses API stream errors as terminal failures

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -1826,6 +1826,11 @@
               "secret": true,
               "description": "API key for OpenAI",
               "title": "API Key"
+            },
+            "zeroDataRetentionEnabled": {
+              "type": "boolean",
+              "default": false,
+              "markdownDescription": "Whether Zero Data Retention (ZDR) is enabled for this provider group. When `true`, OpenAI Responses requests from this group do not send `previous_response_id`."
             }
           },
           "required": [

--- a/extensions/copilot/src/extension/byok/vscode-node/openAIProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/openAIProvider.ts
@@ -9,10 +9,22 @@ import { IFetcherService } from '../../../platform/networking/common/fetcherServ
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { BYOKKnownModels } from '../common/byokProvider';
-import { AbstractOpenAICompatibleLMProvider } from './abstractLanguageModelChatProvider';
+import { OpenAIEndpoint } from '../node/openAIEndpoint';
+import { AbstractOpenAICompatibleLMProvider, LanguageModelChatConfiguration, OpenAICompatibleLanguageModelChatInformation } from './abstractLanguageModelChatProvider';
 import { IBYOKStorageService } from './byokStorageService';
 
-export class OAIBYOKLMProvider extends AbstractOpenAICompatibleLMProvider {
+export interface OpenAIProviderConfig extends LanguageModelChatConfiguration {
+	readonly zeroDataRetentionEnabled?: boolean;
+}
+
+export function applyOpenAIProviderConfig(modelInfo: IChatModelInformation, configuration: OpenAIProviderConfig | undefined): IChatModelInformation {
+	return {
+		...modelInfo,
+		zeroDataRetentionEnabled: configuration?.zeroDataRetentionEnabled ?? modelInfo.zeroDataRetentionEnabled,
+	};
+}
+
+export class OAIBYOKLMProvider extends AbstractOpenAICompatibleLMProvider<OpenAIProviderConfig> {
 
 	public static readonly providerName = 'OpenAI';
 	public static readonly providerId = this.providerName.toLowerCase();
@@ -41,6 +53,14 @@ export class OAIBYOKLMProvider extends AbstractOpenAICompatibleLMProvider {
 
 	protected override getModelsBaseUrl(): string {
 		return 'https://api.openai.com/v1';
+	}
+
+	protected override async createOpenAIEndPoint(model: OpenAICompatibleLanguageModelChatInformation<OpenAIProviderConfig>): Promise<OpenAIEndpoint> {
+		const modelInfo = applyOpenAIProviderConfig(this.getModelInfo(model.id, model.url), model.configuration);
+		const url = modelInfo.supported_endpoints?.includes(ModelSupportedEndpoint.Responses) ?
+			`${model.url}/responses` :
+			`${model.url}/chat/completions`;
+		return this._instantiationService.createInstance(OpenAIEndpoint, modelInfo, model.configuration?.apiKey ?? '', url);
 	}
 
 	protected override getModelInfo(modelId: string, modelUrl: string): IChatModelInformation {

--- a/extensions/copilot/src/extension/byok/vscode-node/test/openAIProvider.spec.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/test/openAIProvider.spec.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from 'vitest';
+import { IChatModelInformation } from '../../../../platform/endpoint/common/endpointProvider';
+import { TokenizerType } from '../../../../util/common/tokenizer';
+import { applyOpenAIProviderConfig } from '../openAIProvider';
+
+function createModelInfo(zeroDataRetentionEnabled: boolean | undefined): IChatModelInformation {
+	return {
+		id: 'gpt-4.1',
+		name: 'GPT-4.1',
+		vendor: 'OpenAI',
+		version: '1.0.0',
+		is_chat_default: false,
+		is_chat_fallback: false,
+		model_picker_enabled: true,
+		zeroDataRetentionEnabled,
+		capabilities: {
+			type: 'chat',
+			family: 'gpt-4.1',
+			supports: {
+				streaming: true,
+				tool_calls: true,
+				vision: false,
+				thinking: false,
+			},
+			tokenizer: TokenizerType.O200K,
+			limits: {
+				max_context_window_tokens: 128000,
+				max_prompt_tokens: 100000,
+				max_output_tokens: 8192,
+			},
+		},
+	};
+}
+
+describe('applyOpenAIProviderConfig', () => {
+	it('uses provider-level zeroDataRetentionEnabled when configured', () => {
+		const merged = applyOpenAIProviderConfig(createModelInfo(undefined), {
+			apiKey: 'test-key',
+			zeroDataRetentionEnabled: true,
+		});
+
+		expect(merged.zeroDataRetentionEnabled).toBe(true);
+	});
+
+	it('falls back to model metadata zeroDataRetentionEnabled when provider-level value is unset', () => {
+		const merged = applyOpenAIProviderConfig(createModelInfo(true), {
+			apiKey: 'test-key',
+		});
+
+		expect(merged.zeroDataRetentionEnabled).toBe(true);
+	});
+});

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -1174,7 +1174,16 @@ export class OpenAIResponsesProcessor {
 
 		switch (chunk.type) {
 			case 'error':
-				return onProgress({ text: '', copilotErrors: [{ agent: 'openai', code: chunk.code || 'unknown', message: chunk.message, type: 'error', identifier: chunk.param || undefined }] });
+				// Surface the error as a progress delta, but also produce a terminal
+				// completion so the request resolves to a meaningful server error
+				// instead of collapsing into the generic "Response contained no
+				// choices" fallback when the stream ends without a terminal event.
+				onProgress({ text: '', copilotErrors: [{ agent: 'openai', code: chunk.code || 'unknown', message: chunk.message, type: 'error', identifier: chunk.param || undefined }] });
+				return this.buildTerminalCompletion(
+					{ output: [] } as unknown as CapiResponseTerminalEvent['response'],
+					FinishedCompletionReason.ServerError,
+					{ error: mapResponsesApiError({ code: chunk.code, message: chunk.message } as OpenAI.Responses.ResponseError) }
+				);
 			case 'response.output_text.delta': {
 				const capiChunk: CapiResponsesTextDeltaEvent = chunk;
 				// When text arrives from a new output item, emit a paragraph

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -1916,4 +1916,28 @@ describe('processResponseFromChatEndpoint terminal events', () => {
 			metadata: { code: 'internal_error' },
 		});
 	});
+
+	it('maps a raw error stream event to a terminal ServerError completion', async () => {
+		// Root cause of #322209: a raw Responses API `error` stream event is only
+		// surfaced as a `copilotErrors` progress delta and never yields a terminal
+		// completion. With no completion, the downstream chat fetcher falls through
+		// to the generic `RESPONSE_CONTAINED_NO_CHOICES` ("Response contained no
+		// choices") instead of a meaningful server-error message.
+		const errorEvent = {
+			type: 'error',
+			code: 'server_error',
+			message: 'The server had an error while processing your request.',
+			param: null,
+		};
+
+		const [completion] = await runStream(`data: ${JSON.stringify(errorEvent)}\n\n`);
+
+		expect(completion).toBeDefined();
+		expect(completion.finishReason).toBe(FinishedCompletionReason.ServerError);
+		expect(completion.error).toEqual({
+			code: 0,
+			message: 'The server had an error while processing your request.',
+			metadata: { code: 'server_error' },
+		});
+	});
 });


### PR DESCRIPTION
This PR improves two OpenAI BYOK behaviors:

- Adds `zeroDataRetentionEnabled` at the OpenAI provider group level in `chatLanguageModels.json`.
    - Wires provider config into openAIProvider so group-level ZDR applies consistently (while preserving model-level fallback behavior).
- Ensures raw Responses API error stream events resolve as a terminal server error instead of falling through to generic “no choices” failures.
- Adds/updates unit tests for both the provider-level ZDR merge behavior and Responses API terminal error mapping.
