### PR TITLE
chat: accept local folder paths in Install Plugin from Source

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
@@ -81,8 +81,8 @@ class InstallFromSourceAction extends Action2 {
 
 		const store = new DisposableStore();
 		const inputBox = store.add(quickInputService.createInputBox());
-		inputBox.placeholder = localize('pluginSourcePlaceholder', "owner/repo or git clone URL");
-		inputBox.prompt = localize('pluginSourcePrompt', "Enter a GitHub repository or git URL to install a plugin from");
+		inputBox.placeholder = localize('pluginSourcePlaceholder', "owner/repo, git URL, or local folder path");
+		inputBox.prompt = localize('pluginSourcePrompt', "Enter a GitHub repository, git URL, or local folder path to install a plugin from");
 		inputBox.ignoreFocusOut = true;
 		inputBox.show();
 
@@ -122,7 +122,7 @@ class InstallFromSourceAction extends Action2 {
 					// Hide the input box so it doesn't conflict with trust/progress dialogs.
 					inputBox.hide();
 
-					const result = await pluginInstallService.installPluginFromValidatedSource(source);
+					const result = await pluginInstallService.installPluginFromSource(source);
 					if (!result.success) {
 						if (result.message) {
 							// Re-open with the error so the user can correct their input.

--- a/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
@@ -7,6 +7,8 @@ import { Action } from '../../../../base/common/actions.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { CancellationError } from '../../../../base/common/errors.js';
+import { untildify } from '../../../../base/common/labels.js';
+import { posix, win32 } from '../../../../base/common/path.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
@@ -17,6 +19,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { IProgressService, ProgressLocation } from '../../../../platform/progress/common/progress.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
+import { IPathService } from '../../../services/path/common/pathService.js';
 import { IAgentPluginRepositoryService } from '../common/plugins/agentPluginRepositoryService.js';
 import { ChatConfiguration } from '../common/constants.js';
 import { IPluginInstallService, IInstallPluginFromSourceOptions, IInstallPluginFromSourceResult, IUpdateAllPluginsOptions, IUpdateAllPluginsResult } from '../common/plugins/pluginInstallService.js';
@@ -36,6 +39,7 @@ export class PluginInstallService implements IPluginInstallService {
 		@ICommandService private readonly _commandService: ICommandService,
 		@IQuickInputService private readonly _quickInputService: IQuickInputService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IPathService private readonly _pathService: IPathService,
 	) { }
 
 	async installPlugin(plugin: IMarketplacePlugin): Promise<void> {
@@ -58,60 +62,29 @@ export class PluginInstallService implements IPluginInstallService {
 		return this._installGitPlugin(plugin);
 	}
 
-	async installPluginFromSource(source: string, options?: IInstallPluginFromSourceOptions): Promise<void> {
-		const reference = parseMarketplaceReference(source);
-		if (!reference) {
-			this._notificationService.notify({
-				severity: Severity.Error,
-				message: localize('invalidSource', "'{0}' is not a valid plugin source. Enter a GitHub repository (owner/repo) or a git clone URL.", source),
-			});
-			return;
-		}
-
-		if (reference.kind === MarketplaceReferenceKind.LocalFileUri) {
-			this._notificationService.notify({
-				severity: Severity.Error,
-				message: localize('localSourceNotSupported', "Local file paths are not supported. Enter a GitHub repository (owner/repo) or a git clone URL."),
-			});
-			return;
-		}
-
-		const result = await this._doInstallFromSource(reference, options);
-		if (!result.success && result.message) {
-			this._notificationService.notify({
-				severity: Severity.Error,
-				message: result.message,
-			});
-		}
-	}
-
 	validatePluginSource(source: string): string | undefined {
 		const reference = parseMarketplaceReference(source);
-		if (!reference) {
-			return localize('invalidSource', "'{0}' is not a valid plugin source. Enter a GitHub repository (owner/repo) or a git clone URL.", source);
+		if (reference || this._isLocalPathSource(source)) {
+			return undefined;
 		}
-		if (reference.kind === MarketplaceReferenceKind.LocalFileUri) {
-			return localize('localSourceNotSupported', "Local file paths are not supported. Enter a GitHub repository (owner/repo) or a git clone URL.");
-		}
-		return undefined;
+		return localize('invalidSource', "'{0}' is not a valid plugin source. Enter a GitHub repository (owner/repo), a git clone URL, or a local folder path.", source);
 	}
 
-	async installPluginFromValidatedSource(source: string, options?: IInstallPluginFromSourceOptions): Promise<IInstallPluginFromSourceResult> {
+	async installPluginFromSource(source: string, options?: IInstallPluginFromSourceOptions): Promise<IInstallPluginFromSourceResult> {
 		const reference = parseMarketplaceReference(source);
-		if (!reference) {
-			return {
-				success: false,
-				message: localize('invalidSource', "'{0}' is not a valid plugin source. Enter a GitHub repository (owner/repo) or a git clone URL.", source),
-			};
-		}
-		if (reference.kind === MarketplaceReferenceKind.LocalFileUri) {
-			return {
-				success: false,
-				message: localize('localSourceNotSupported', "Local file paths are not supported. Enter a GitHub repository (owner/repo) or a git clone URL."),
-			};
+		if (reference && reference.kind !== MarketplaceReferenceKind.LocalFileUri) {
+			return this._doInstallFromSource(reference, options);
 		}
 
-		return this._doInstallFromSource(reference, options);
+		const local = await this._resolveLocalDirectorySource(source);
+		if (local) {
+			return this._doInstallFromLocalSource(local.reference, local.configPath, options);
+		}
+
+		return {
+			success: false,
+			message: localize('invalidSource', "'{0}' is not a valid plugin source. Enter a GitHub repository (owner/repo), a git clone URL, or a local folder path.", source),
+		};
 	}
 
 	private async _doInstallFromSource(reference: IMarketplaceReference, options?: IInstallPluginFromSourceOptions): Promise<IInstallPluginFromSourceResult> {
@@ -191,6 +164,63 @@ export class PluginInstallService implements IPluginInstallService {
 		}
 
 		// When targeting a specific plugin, find it, register it, and return.
+		return this._installDiscoveredPlugins(reference, discoveredPlugins, options);
+	}
+
+	/**
+	 * Installs a plugin from a local folder path (`file://` URI, absolute path,
+	 * or `~`-prefixed path). Inspects the directory to decide whether it is a
+	 * marketplace or a standalone plugin and writes to the appropriate setting:
+	 * - a marketplace is registered under `chat.plugins.marketplaces`,
+	 * - a standalone plugin path is registered under `chat.pluginLocations`.
+	 */
+	private async _doInstallFromLocalSource(reference: IMarketplaceReference, configPath: string, options?: IInstallPluginFromSourceOptions): Promise<IInstallPluginFromSourceResult> {
+		const repoDir = reference.localRepositoryUri;
+		if (!repoDir) {
+			return {
+				success: false,
+				message: localize('invalidSource', "'{0}' is not a valid plugin source. Enter a GitHub repository (owner/repo), a git clone URL, or a local folder path.", reference.rawValue),
+			};
+		}
+
+		let isDirectory = false;
+		try {
+			isDirectory = (await this._fileService.resolve(repoDir)).isDirectory;
+		} catch {
+			// resolve throws when the path doesn't exist — handled below.
+		}
+		if (!isDirectory) {
+			return {
+				success: false,
+				message: localize('localSourceNotFound', "The folder '{0}' does not exist or is not a directory.", repoDir.fsPath),
+			};
+		}
+
+		// A directory with a marketplace index is registered as a marketplace.
+		const discoveredPlugins = await this._pluginMarketplaceService.readPluginsFromDirectory(repoDir, reference);
+		if (discoveredPlugins.length > 0) {
+			return this._installDiscoveredPlugins(reference, discoveredPlugins, options);
+		}
+
+		// Otherwise, a directory with a single-plugin manifest is registered as
+		// a standalone plugin location.
+		if (await this._pluginMarketplaceService.isPluginDirectory(repoDir)) {
+			await this._addPluginLocationToConfig(configPath);
+			return { success: true };
+		}
+
+		return {
+			success: false,
+			message: localize('localNoPlugins', "No plugin or marketplace found in '{0}'. This folder does not contain a plugin or marketplace manifest.", repoDir.fsPath),
+		};
+	}
+
+	/**
+	 * Registers the marketplace and installs the discovered plugin(s): when a
+	 * specific plugin is targeted it installs that one, when there is exactly
+	 * one it installs it directly, and otherwise prompts the user to choose.
+	 */
+	private async _installDiscoveredPlugins(reference: IMarketplaceReference, discoveredPlugins: readonly IMarketplacePlugin[], options?: IInstallPluginFromSourceOptions): Promise<IInstallPluginFromSourceResult> {
 		if (options?.plugin) {
 			const matchedPlugin = discoveredPlugins.find(p => p.name === options.plugin);
 			if (!matchedPlugin) {
@@ -239,6 +269,73 @@ export class PluginInstallService implements IPluginInstallService {
 			return;
 		}
 		return this._configurationService.updateValue(ChatConfiguration.PluginMarketplaces, [...userValues, reference.rawValue]);
+	}
+
+	private _addPluginLocationToConfig(pathKey: string) {
+		const current = this._configurationService.inspect<Record<string, boolean>>(ChatConfiguration.PluginLocations).userValue ?? {};
+		if (current[pathKey] === true) {
+			return;
+		}
+		return this._configurationService.updateValue(ChatConfiguration.PluginLocations, { ...current, [pathKey]: true });
+	}
+
+	/**
+	 * Returns `true` when the source string looks like a local folder path —
+	 * a `file://` URI, an absolute filesystem path, or a `~`-prefixed path.
+	 * This is a synchronous format check only; existence is verified later.
+	 */
+	private _isLocalPathSource(source: string): boolean {
+		const trimmed = source.trim();
+		if (!trimmed) {
+			return false;
+		}
+		if (/^file:\/\//i.test(trimmed)) {
+			return true;
+		}
+		if (trimmed === '~' || trimmed.startsWith('~/') || trimmed.startsWith('~\\')) {
+			return true;
+		}
+		return win32.isAbsolute(trimmed) || posix.isAbsolute(trimmed);
+	}
+
+	/**
+	 * Resolves a local folder source string to a {@link MarketplaceReferenceKind.LocalFileUri}
+	 * reference plus the path to persist in `chat.pluginLocations`. Tilde paths
+	 * are expanded against the user home. Returns `undefined` when the string
+	 * does not resolve to an absolute local folder.
+	 */
+	private async _resolveLocalDirectorySource(source: string): Promise<{ reference: IMarketplaceReference; configPath: string } | undefined> {
+		const trimmed = source.trim();
+
+		// Already a `file://` URI — parseMarketplaceReference yields a LocalFileUri reference.
+		const parsed = parseMarketplaceReference(trimmed);
+		if (parsed?.kind === MarketplaceReferenceKind.LocalFileUri && parsed.localRepositoryUri) {
+			return { reference: parsed, configPath: parsed.localRepositoryUri.fsPath };
+		}
+
+		if (!this._isLocalPathSource(trimmed)) {
+			return undefined;
+		}
+
+		let resolvedPath = trimmed;
+		if (resolvedPath.startsWith('~')) {
+			const userHome = await this._pathService.userHome();
+			const home = userHome.scheme === 'file' ? userHome.fsPath : userHome.path;
+			resolvedPath = untildify(resolvedPath, home);
+		}
+
+		if (!win32.isAbsolute(resolvedPath) && !posix.isAbsolute(resolvedPath)) {
+			return undefined;
+		}
+
+		const reference = parseMarketplaceReference(URI.file(resolvedPath).toString());
+		if (reference?.kind !== MarketplaceReferenceKind.LocalFileUri) {
+			return undefined;
+		}
+
+		// Preserve the user's original path form (e.g. `~/plugins/foo`) so that
+		// the persisted `chat.pluginLocations` key stays portable.
+		return { reference, configPath: trimmed };
 	}
 
 	async updatePlugin(plugin: IMarketplacePlugin, silent?: boolean): Promise<boolean> {

--- a/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
@@ -199,6 +199,22 @@ export class PluginInstallService implements IPluginInstallService {
 		// A directory with a marketplace index is registered as a marketplace.
 		const discoveredPlugins = await this._pluginMarketplaceService.readPluginsFromDirectory(repoDir, reference);
 		if (discoveredPlugins.length > 0) {
+			// Verify trust before writing to config, mirroring the git path
+			// (_doInstallFromSource): declining the prompt must not persist the
+			// marketplace under `chat.plugins.marketplaces`.
+			const tempPlugin: IMarketplacePlugin = {
+				name: reference.displayLabel,
+				description: '',
+				version: '',
+				source: '',
+				sourceDescriptor: { kind: PluginSourceKind.RelativePath, path: '' },
+				marketplace: reference.displayLabel,
+				marketplaceReference: reference,
+				marketplaceType: MarketplaceType.OpenPlugin,
+			};
+			if (!await this._ensureMarketplaceTrusted(tempPlugin)) {
+				return { success: false };
+			}
 			return this._installDiscoveredPlugins(reference, discoveredPlugins, options);
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/pluginUrlHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginUrlHandler.ts
@@ -13,6 +13,7 @@ import { ConfigurationTarget, IConfigurationService } from '../../../../platform
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { IURLHandler, IURLService } from '../../../../platform/url/common/url.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IHostService } from '../../../services/host/browser/host.js';
@@ -46,6 +47,7 @@ export class PluginUrlHandler extends Disposable implements IWorkbenchContributi
 		@IExtensionsWorkbenchService private readonly _extensionsWorkbenchService: IExtensionsWorkbenchService,
 		@IHostService private readonly _hostService: IHostService,
 		@ILogService private readonly _logService: ILogService,
+		@INotificationService private readonly _notificationService: INotificationService,
 		@IEditorService private readonly _editorService: IEditorService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
@@ -110,7 +112,10 @@ export class PluginUrlHandler extends Disposable implements IWorkbenchContributi
 			return this._handleInstallTargetedPlugin(source, ref.displayLabel, pluginName);
 		}
 
-		await this._pluginInstallService.installPluginFromSource(source);
+		const result = await this._pluginInstallService.installPluginFromSource(source);
+		if (!result.success && result.message) {
+			this._notificationService.notify({ severity: Severity.Error, message: result.message });
+		}
 		this._extensionsWorkbenchService.openSearch(`@agentPlugins ${ref.displayLabel}`);
 		return true;
 	}
@@ -121,7 +126,7 @@ export class PluginUrlHandler extends Disposable implements IWorkbenchContributi
 	 * then opens the plugin details in a modal editor.
 	 */
 	private async _handleInstallTargetedPlugin(source: string, displayLabel: string, pluginName: string): Promise<boolean> {
-		const result = await this._pluginInstallService.installPluginFromValidatedSource(source, { plugin: pluginName });
+		const result = await this._pluginInstallService.installPluginFromSource(source, { plugin: pluginName });
 
 		if (!result.success) {
 			if (result.message) {

--- a/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
+++ b/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
@@ -144,6 +144,7 @@ Checked in order per repository:
 Orchestrates install and update workflows:
 
 - `installPlugin()` — checks marketplace trust, delegates to the appropriate source strategy to ensure files are locally available, and registers the plugin in installed storage.
+- `installPluginFromSource()` — installs from a source string: GitHub shorthand (`owner/repo`), a git clone URL, or a local folder path (`file://` URI, absolute path, or `~`-prefixed path). Local folders are inspected to decide whether they are a marketplace (registered under `chat.pluginMarketplaces`) or a standalone plugin (registered under `chat.pluginLocations`).
 - `updatePlugin()` / `updateAllPlugins()` — pulls latest changes for cloned repositories and re-runs package-manager installs where applicable.
 
 ### Plugin Source Strategies (IPluginSource)

--- a/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
+++ b/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
@@ -125,7 +125,7 @@ Auto-detection logic: if a `.plugin/plugin.json` manifest exists, the Open Plugi
 
 Manages the catalog of available and installed plugins:
 
-- **Fetch** — reads `chat.pluginMarketplaces` config (GitHub shorthand, Git URLs, or file URIs), fetches `marketplace.json` from each, and returns parsed `IMarketplacePlugin` entries.
+- **Fetch** — reads `chat.plugins.marketplaces` config (GitHub shorthand, Git URLs, or file URIs), fetches `marketplace.json` from each, and returns parsed `IMarketplacePlugin` entries.
 - **Installed storage** — persists installed plugins in application-scoped storage (`chat.plugins.installed.v1`). Each entry tracks `{ pluginUri, plugin, enabled }`.
 - **Trust** — marketplace canonical IDs must be explicitly trusted before install proceeds (`chat.plugins.trustedMarketplaces.v1`).
 - **Auto-update** — checks for upstream changes approximately every 24 hours when `extensions.autoUpdate` is enabled; sets `hasUpdatesAvailable` observable.
@@ -144,7 +144,7 @@ Checked in order per repository:
 Orchestrates install and update workflows:
 
 - `installPlugin()` — checks marketplace trust, delegates to the appropriate source strategy to ensure files are locally available, and registers the plugin in installed storage.
-- `installPluginFromSource()` — installs from a source string: GitHub shorthand (`owner/repo`), a git clone URL, or a local folder path (`file://` URI, absolute path, or `~`-prefixed path). Local folders are inspected to decide whether they are a marketplace (registered under `chat.pluginMarketplaces`) or a standalone plugin (registered under `chat.pluginLocations`).
+- `installPluginFromSource()` — installs from a source string: GitHub shorthand (`owner/repo`), a git clone URL, or a local folder path (`file://` URI, absolute path, or `~`-prefixed path). Local folders are inspected to decide whether they are a marketplace (registered under `chat.plugins.marketplaces`) or a standalone plugin (registered under `chat.pluginLocations`).
 - `updatePlugin()` / `updateAllPlugins()` — pulls latest changes for cloned repositories and re-runs package-manager installs where applicable.
 
 ### Plugin Source Strategies (IPluginSource)

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginInstallService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginInstallService.ts
@@ -63,31 +63,26 @@ export interface IPluginInstallService {
 
 	/**
 	 * Installs a plugin directly from a source location string. Accepts
-	 * GitHub shorthand (`owner/repo`) or a full git clone URL. Clones the
-	 * repository, reads marketplace metadata to discover plugins, and
-	 * registers the selected plugin.
+	 * GitHub shorthand (`owner/repo`), a full git clone URL, or a local
+	 * folder path (`file://` URI, absolute path, or `~`-prefixed path).
+	 * For git sources, clones the repository, reads marketplace metadata to
+	 * discover plugins, and registers the selected plugin. For local folders,
+	 * detects whether the folder is a marketplace or a standalone plugin and
+	 * registers it under the appropriate configuration.
 	 *
-	 * When {@link IInstallPluginFromSourceOptions.plugin} is set, targets
-	 * a specific plugin, installs it, and returns it.
+	 * Returns a result with an optional error message (e.g. invalid source or
+	 * no plugins found); callers are responsible for surfacing it. When
+	 * {@link IInstallPluginFromSourceOptions.plugin} is set, targets a specific
+	 * plugin, installs it, and returns it in
+	 * {@link IInstallPluginFromSourceResult.matchedPlugin}.
 	 */
-	installPluginFromSource(source: string, options?: IInstallPluginFromSourceOptions): Promise<void>;
+	installPluginFromSource(source: string, options?: IInstallPluginFromSourceOptions): Promise<IInstallPluginFromSourceResult>;
 
 	/**
 	 * Synchronously validates the format of a plugin source string.
 	 * Returns an error message if the format is invalid, or undefined if valid.
 	 */
 	validatePluginSource(source: string): string | undefined;
-
-	/**
-	 * Installs a plugin from an already-validated source string.
-	 * Handles trust, cloning, scanning, and registration. Returns a result
-	 * with an optional error message (e.g. no plugins found).
-	 *
-	 * When {@link IInstallPluginFromSourceOptions.plugin} is set, targets
-	 * a specific plugin, installs it, and returns it in
-	 * {@link IInstallPluginFromSourceResult.matchedPlugin}.
-	 */
-	installPluginFromValidatedSource(source: string, options?: IInstallPluginFromSourceOptions): Promise<IInstallPluginFromSourceResult>;
 
 	/**
 	 * Pulls the latest changes for an already-cloned marketplace repository.

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -199,6 +199,14 @@ export interface IPluginMarketplaceService {
 	 * root.
 	 */
 	readSinglePluginManifest(repoDir: URI, reference: IMarketplaceReference): Promise<IMarketplacePlugin | undefined>;
+	/**
+	 * Returns whether the given directory is a standalone plugin — i.e. it
+	 * contains a single-plugin manifest (e.g. `.plugin/plugin.json`,
+	 * `.claude-plugin/plugin.json`, or `plugin.json`) at its root but is not a
+	 * marketplace. Used by direct-install flows to route a local folder to the
+	 * appropriate configuration.
+	 */
+	isPluginDirectory(repoDir: URI): Promise<boolean>;
 }
 
 /**
@@ -887,6 +895,15 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 
 		this._logService.debug(`[PluginMarketplaceService] No single-plugin manifest found in ${reference.rawValue}`);
 		return undefined;
+	}
+
+	async isPluginDirectory(repoDir: URI): Promise<boolean> {
+		for (const def of SINGLE_PLUGIN_MANIFEST_DEFINITIONS) {
+			if (await this._fileService.exists(joinPath(repoDir, def.path))) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private async _readPluginsFromDirectory(repoDir: URI, reference: IMarketplaceReference, token?: CancellationToken): Promise<IMarketplacePlugin[]> {

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/pluginInstallService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/pluginInstallService.test.ts
@@ -15,6 +15,7 @@ import { ILogService, NullLogService } from '../../../../../../platform/log/comm
 import { INotificationService } from '../../../../../../platform/notification/common/notification.js';
 import { IProgressService } from '../../../../../../platform/progress/common/progress.js';
 import { IQuickInputService } from '../../../../../../platform/quickinput/common/quickInput.js';
+import { IPathService } from '../../../../../services/path/common/pathService.js';
 import { ITerminalService } from '../../../../terminal/browser/terminal.js';
 import { PluginInstallService } from '../../../browser/pluginInstallService.js';
 import { IAgentPluginRepositoryService, IEnsureRepositoryOptions, IPullRepositoryOptions } from '../../../common/plugins/agentPluginRepositoryService.js';
@@ -84,6 +85,16 @@ suite('PluginInstallService', () => {
 		configuredMarketplaces: string[];
 		/** Updated marketplace config values */
 		updatedMarketplaces: string[] | undefined;
+		/** Whether readResult resolves to a directory (IFileService.resolve) */
+		resolveIsDirectory: boolean;
+		/** Whether the directory is a standalone plugin (isPluginDirectory) */
+		isPluginDirectoryResult: boolean;
+		/** Current configured plugin location values */
+		configuredPluginLocations: Record<string, boolean>;
+		/** Updated plugin location config values */
+		updatedPluginLocations: Record<string, boolean> | undefined;
+		/** User home directory used to expand `~` paths */
+		userHome: string;
 	}
 
 	function createDefaults(): MockState {
@@ -109,6 +120,11 @@ suite('PluginInstallService', () => {
 			quickInputResult: undefined,
 			configuredMarketplaces: [],
 			updatedMarketplaces: undefined,
+			resolveIsDirectory: true,
+			isPluginDirectoryResult: false,
+			configuredPluginLocations: {},
+			updatedPluginLocations: undefined,
+			userHome: '/home/user',
 		};
 	}
 
@@ -124,6 +140,7 @@ suite('PluginInstallService', () => {
 				}
 				return state.fileExistsResult;
 			},
+			resolve: async (resource: URI) => ({ resource, isDirectory: state.resolveIsDirectory }),
 		} as unknown as IFileService);
 
 		// INotificationService
@@ -278,6 +295,7 @@ suite('PluginInstallService', () => {
 			},
 			readPluginsFromDirectory: async () => state.readPluginsResult,
 			readSinglePluginManifest: async () => state.singlePluginManifestResult,
+			isPluginDirectory: async () => state.isPluginDirectoryResult,
 		} as unknown as IPluginMarketplaceService);
 
 		// IConfigurationService
@@ -286,11 +304,17 @@ suite('PluginInstallService', () => {
 				if (key === ChatConfiguration.PluginMarketplaces) {
 					return state.configuredMarketplaces;
 				}
+				if (key === ChatConfiguration.PluginLocations) {
+					return state.configuredPluginLocations;
+				}
 				return undefined;
 			},
 			inspect: (key: string) => {
 				if (key === ChatConfiguration.PluginMarketplaces) {
 					return { userValue: state.configuredMarketplaces, defaultValue: undefined, policyValue: undefined };
+				}
+				if (key === ChatConfiguration.PluginLocations) {
+					return { userValue: state.configuredPluginLocations, defaultValue: undefined, policyValue: undefined };
 				}
 				return { userValue: undefined, defaultValue: undefined, policyValue: undefined };
 			},
@@ -298,8 +322,16 @@ suite('PluginInstallService', () => {
 				if (key === ChatConfiguration.PluginMarketplaces) {
 					state.updatedMarketplaces = value as string[];
 				}
+				if (key === ChatConfiguration.PluginLocations) {
+					state.updatedPluginLocations = value as Record<string, boolean>;
+				}
 			},
 		} as unknown as IConfigurationService);
+
+		// IPathService
+		instantiationService.stub(IPathService, {
+			userHome: async () => URI.file(state.userHome),
+		} as unknown as IPathService);
 
 		// IQuickInputService
 		instantiationService.stub(IQuickInputService, {
@@ -853,16 +885,109 @@ suite('PluginInstallService', () => {
 
 		test('rejects invalid source strings', async () => {
 			const { service, state } = createService();
-			await service.installPluginFromSource('not a valid source');
+			const result = await service.installPluginFromSource('not a valid source');
+			assert.strictEqual(result.success, false);
+			assert.ok(result.message);
 			assert.strictEqual(state.addedPlugins.length, 0);
-			assert.strictEqual(state.notifications.length, 1);
 		});
 
-		test('rejects local file URIs', async () => {
-			const { service, state } = createService();
-			await service.installPluginFromSource('file:///some/local/path');
+		test('validatePluginSource accepts git and local sources and rejects garbage', () => {
+			const { service } = createService();
+			assert.strictEqual(service.validatePluginSource('owner/repo'), undefined);
+			assert.strictEqual(service.validatePluginSource('https://github.com/owner/repo.git'), undefined);
+			assert.strictEqual(service.validatePluginSource('file:///some/path'), undefined);
+			assert.strictEqual(service.validatePluginSource('/abs/path'), undefined);
+			assert.strictEqual(service.validatePluginSource('~/plugins/foo'), undefined);
+			assert.ok(service.validatePluginSource('not a valid source'));
+		});
+
+		test('installs a local folder marketplace and registers it under chat.plugins.marketplaces', async () => {
+			const ref = makeMarketplaceRef('file:///some/marketplace');
+			const discoveredPlugin = createPlugin({
+				name: 'local-marketplace-plugin',
+				sourceDescriptor: { kind: PluginSourceKind.RelativePath, path: '' },
+				marketplace: ref.displayLabel,
+				marketplaceReference: ref,
+				marketplaceType: MarketplaceType.OpenPlugin,
+			});
+			const { service, state } = createService({
+				readPluginsResult: [discoveredPlugin],
+			});
+
+			await service.installPluginFromSource('file:///some/marketplace');
+
+			assert.strictEqual(state.notifications.length, 0);
+			assert.strictEqual(state.addedPlugins.length, 1);
+			assert.strictEqual(state.addedPlugins[0].plugin.name, 'local-marketplace-plugin');
+			assert.deepStrictEqual(state.updatedMarketplaces, ['file:///some/marketplace']);
+			assert.strictEqual(state.updatedPluginLocations, undefined);
+		});
+
+		test('registers a local folder standalone plugin under chat.pluginLocations', async () => {
+			const { service, state } = createService({
+				readPluginsResult: [],
+				isPluginDirectoryResult: true,
+			});
+
+			await service.installPluginFromSource('/abs/my-plugin');
+
+			assert.strictEqual(state.notifications.length, 0);
 			assert.strictEqual(state.addedPlugins.length, 0);
-			assert.strictEqual(state.notifications.length, 1);
+			assert.deepStrictEqual(state.updatedPluginLocations, { '/abs/my-plugin': true });
+			assert.strictEqual(state.updatedMarketplaces, undefined);
+		});
+
+		test('expands ~ paths but persists the original form in chat.pluginLocations', async () => {
+			const { service, state } = createService({
+				readPluginsResult: [],
+				isPluginDirectoryResult: true,
+				userHome: '/home/user',
+			});
+
+			await service.installPluginFromSource('~/my-plugin');
+
+			assert.deepStrictEqual(state.updatedPluginLocations, { '~/my-plugin': true });
+		});
+
+		test('registers a file:// standalone plugin using its filesystem path', async () => {
+			const { service, state } = createService({
+				readPluginsResult: [],
+				isPluginDirectoryResult: true,
+			});
+
+			await service.installPluginFromSource('file:///some/plugin');
+
+			assert.strictEqual(state.addedPlugins.length, 0);
+			assert.ok(state.updatedPluginLocations);
+			assert.deepStrictEqual(Object.values(state.updatedPluginLocations!), [true]);
+			assert.strictEqual(Object.keys(state.updatedPluginLocations!).length, 1);
+		});
+
+		test('shows error when local folder does not exist', async () => {
+			const { service, state } = createService({
+				resolveIsDirectory: false,
+			});
+
+			const result = await service.installPluginFromSource('/abs/missing');
+
+			assert.strictEqual(result.success, false);
+			assert.ok(result.message);
+			assert.strictEqual(state.addedPlugins.length, 0);
+			assert.strictEqual(state.updatedPluginLocations, undefined);
+		});
+
+		test('shows error when local folder is neither a marketplace nor a plugin', async () => {
+			const { service, state } = createService({
+				readPluginsResult: [],
+				isPluginDirectoryResult: false,
+			});
+
+			const result = await service.installPluginFromSource('/abs/empty');
+
+			assert.strictEqual(result.success, false);
+			assert.ok(result.message?.includes('No plugin or marketplace found'));
+			assert.strictEqual(state.addedPlugins.length, 0);
+			assert.strictEqual(state.updatedPluginLocations, undefined);
 		});
 
 		test('installs single plugin from GitHub shorthand with marketplace.json', async () => {
@@ -892,11 +1017,11 @@ suite('PluginInstallService', () => {
 				readPluginsResult: [],
 			});
 
-			await service.installPluginFromSource('owner/cool-tool');
+			const result = await service.installPluginFromSource('owner/cool-tool');
 
+			assert.strictEqual(result.success, false);
+			assert.ok(result.message?.includes('No plugins found'));
 			assert.strictEqual(state.addedPlugins.length, 0);
-			assert.strictEqual(state.notifications.length, 1);
-			assert.ok(state.notifications[0].message.includes('No plugins found'));
 		});
 
 		test('shows quick pick for multi-plugin repos', async () => {
@@ -971,11 +1096,11 @@ suite('PluginInstallService', () => {
 				readPluginsResult: [],
 			});
 
-			await service.installPluginFromSource('https://github.com/owner/my-tool.git');
+			const result = await service.installPluginFromSource('https://github.com/owner/my-tool.git');
 
+			assert.strictEqual(result.success, false);
+			assert.ok(result.message?.includes('No plugins found'));
 			assert.strictEqual(state.addedPlugins.length, 0);
-			assert.strictEqual(state.notifications.length, 1);
-			assert.ok(state.notifications[0].message.includes('No plugins found'));
 		});
 
 		test('shows error when clone directory does not exist', async () => {
@@ -984,10 +1109,11 @@ suite('PluginInstallService', () => {
 				fileExistsResult: false,
 			});
 
-			await service.installPluginFromSource('owner/missing');
+			const result = await service.installPluginFromSource('owner/missing');
 
+			assert.strictEqual(result.success, false);
+			assert.ok(result.message);
 			assert.strictEqual(state.addedPlugins.length, 0);
-			assert.strictEqual(state.notifications.length, 1);
 		});
 
 		test('adds marketplace to config after installing single plugin', async () => {
@@ -1095,7 +1221,7 @@ suite('PluginInstallService', () => {
 				singlePluginManifestResult: singlePlugin,
 			});
 
-			const result = await service.installPluginFromValidatedSource('owner/single-plugin-repo', { plugin: 'requested-name' });
+			const result = await service.installPluginFromSource('owner/single-plugin-repo', { plugin: 'requested-name' });
 
 			assert.strictEqual(result.success, false);
 			assert.ok(result.message?.includes('not found'));
@@ -1109,11 +1235,11 @@ suite('PluginInstallService', () => {
 				singlePluginManifestResult: undefined,
 			});
 
-			await service.installPluginFromSource('owner/empty-repo');
+			const result = await service.installPluginFromSource('owner/empty-repo');
 
+			assert.strictEqual(result.success, false);
+			assert.ok(result.message?.includes('No plugins found'));
 			assert.strictEqual(state.addedPlugins.length, 0);
-			assert.strictEqual(state.notifications.length, 1);
-			assert.ok(state.notifications[0].message.includes('No plugins found'));
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/pluginInstallService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/pluginInstallService.test.ts
@@ -923,6 +923,28 @@ suite('PluginInstallService', () => {
 			assert.strictEqual(state.updatedPluginLocations, undefined);
 		});
 
+		test('does not persist a local marketplace to config when trust is declined', async () => {
+			const ref = makeMarketplaceRef('file:///some/marketplace');
+			const discoveredPlugin = createPlugin({
+				name: 'local-marketplace-plugin',
+				sourceDescriptor: { kind: PluginSourceKind.RelativePath, path: '' },
+				marketplace: ref.displayLabel,
+				marketplaceReference: ref,
+				marketplaceType: MarketplaceType.OpenPlugin,
+			});
+			const { service, state } = createService({
+				readPluginsResult: [discoveredPlugin],
+				marketplaceTrusted: false,
+				dialogConfirmResult: false,
+			});
+
+			const result = await service.installPluginFromSource('file:///some/marketplace');
+
+			assert.strictEqual(result.success, false);
+			assert.strictEqual(state.addedPlugins.length, 0);
+			assert.strictEqual(state.updatedMarketplaces, undefined);
+		});
+
 		test('registers a local folder standalone plugin under chat.pluginLocations', async () => {
 			const { service, state } = createService({
 				readPluginsResult: [],

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/pluginUrlHandler.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/pluginUrlHandler.test.ts
@@ -13,6 +13,7 @@ import { IDialogService } from '../../../../../../platform/dialogs/common/dialog
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../../../platform/notification/common/notification.js';
 import { IURLService } from '../../../../../../platform/url/common/url.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
 import { IHostService } from '../../../../../services/host/browser/host.js';
@@ -36,7 +37,8 @@ suite('PluginUrlHandler', () => {
 		configUpdates: { key: string; value: unknown; target: ConfigurationTarget }[];
 		openedEditorInputs: AgentPluginEditorInput[];
 		openSearchQueries: string[];
-		installFromValidatedSourceResult: IInstallPluginFromSourceResult;
+		installFromSourceResult: IInstallPluginFromSourceResult;
+		notifications: { severity: number; message: string }[];
 	}
 
 	function createHandler(stateOverrides?: Partial<MockState>): { handler: PluginUrlHandler; state: MockState } {
@@ -46,7 +48,8 @@ suite('PluginUrlHandler', () => {
 			configUpdates: [],
 			openedEditorInputs: [],
 			openSearchQueries: [],
-			installFromValidatedSourceResult: { success: false },
+			installFromSourceResult: { success: true },
+			notifications: [],
 			...stateOverrides,
 		};
 
@@ -57,8 +60,10 @@ suite('PluginUrlHandler', () => {
 		} as unknown as IURLService);
 
 		instantiationService.stub(IPluginInstallService, {
-			installPluginFromSource: async (source: string) => { state.installedSources.push(source); },
-			installPluginFromValidatedSource: async (_source: string, _options?: IInstallPluginFromSourceOptions) => state.installFromValidatedSourceResult,
+			installPluginFromSource: async (source: string, _options?: IInstallPluginFromSourceOptions) => {
+				state.installedSources.push(source);
+				return state.installFromSourceResult;
+			},
 		} as unknown as IPluginInstallService);
 
 		instantiationService.stub(IDialogService, {
@@ -96,6 +101,13 @@ suite('PluginUrlHandler', () => {
 		instantiationService.stub(IInstantiationService, instantiationService);
 
 		instantiationService.stub(ILogService, new NullLogService());
+
+		instantiationService.stub(INotificationService, {
+			notify: (notification: { severity: number; message: string }) => {
+				state.notifications.push({ severity: notification.severity, message: notification.message });
+				return undefined;
+			},
+		} as unknown as INotificationService);
 
 		const handler = store.add(instantiationService.createInstance(PluginUrlHandler));
 		return { handler, state };
@@ -257,15 +269,14 @@ suite('PluginUrlHandler', () => {
 		};
 	}
 
-	test('install with plugin param delegates to installPluginFromValidatedSource and opens editor', async () => {
+	test('install with plugin param targets the plugin and opens editor', async () => {
 		const plugin = makeMarketplacePlugin('my-plugin', 'acme/plugins');
 		const { handler, state } = createHandler({
-			installFromValidatedSourceResult: { success: true, matchedPlugin: plugin },
+			installFromSourceResult: { success: true, matchedPlugin: plugin },
 		});
 		const result = await handler.handleURL(uri('/install', 'source=acme/plugins&plugin=my-plugin'));
 		assert.strictEqual(result, true);
-		// Broad install (installPluginFromSource) is not used on the targeted path.
-		assert.deepStrictEqual(state.installedSources, []);
+		assert.deepStrictEqual(state.installedSources, ['acme/plugins']);
 		// Plugin editor was opened
 		assert.strictEqual(state.openedEditorInputs.length, 1);
 		assert.strictEqual(state.openedEditorInputs[0].item.name, 'my-plugin');
@@ -275,7 +286,7 @@ suite('PluginUrlHandler', () => {
 		const plugin = makeMarketplacePlugin('my-plugin', 'acme/plugins');
 		const { handler, state } = createHandler({
 			dialogConfirmResult: false,
-			installFromValidatedSourceResult: { success: true, matchedPlugin: plugin },
+			installFromSourceResult: { success: true, matchedPlugin: plugin },
 		});
 		const result = await handler.handleURL(uri('/install', 'source=acme/plugins&plugin=my-plugin'));
 		assert.strictEqual(result, true);
@@ -287,7 +298,7 @@ suite('PluginUrlHandler', () => {
 	test('install with base64-encoded plugin param opens editor', async () => {
 		const plugin = makeMarketplacePlugin('my-plugin', 'acme/plugins');
 		const { handler, state } = createHandler({
-			installFromValidatedSourceResult: { success: true, matchedPlugin: plugin },
+			installFromSourceResult: { success: true, matchedPlugin: plugin },
 		});
 		const encodedPlugin = toBase64('my-plugin');
 		const result = await handler.handleURL(uri('/install', `source=acme/plugins&plugin=${encodedPlugin}`));
@@ -298,7 +309,7 @@ suite('PluginUrlHandler', () => {
 
 	test('install with plugin param falls back to search on failure', async () => {
 		const { handler, state } = createHandler({
-			installFromValidatedSourceResult: { success: false, message: 'Plugin not found' },
+			installFromSourceResult: { success: false, message: 'Plugin not found' },
 		});
 		const result = await handler.handleURL(uri('/install', 'source=acme/plugins&plugin=nonexistent'));
 		assert.strictEqual(result, true);
@@ -309,7 +320,7 @@ suite('PluginUrlHandler', () => {
 
 	test('install with plugin param falls back to search when no matchedPlugin', async () => {
 		const { handler, state } = createHandler({
-			installFromValidatedSourceResult: { success: true },
+			installFromSourceResult: { success: true },
 		});
 		const result = await handler.handleURL(uri('/install', 'source=acme/plugins&plugin=my-plugin'));
 		assert.strictEqual(result, true);


### PR DESCRIPTION
## What

"Install Plugin from Source" now accepts local folder paths in addition to GitHub shorthand (`owner/repo`) and git clone URLs. Supported local forms:

- `file://` URIs
- Absolute filesystem paths (posix / win32)
- `~`-prefixed paths (tilde-expanded via `IPathService`; the original form is preserved in config for portability)

When given a local folder, the install flow inspects the directory and routes it to the appropriate setting:

- **Marketplace** (contains a `marketplace.json`) → registered under `chat.plugins.marketplaces` (as a `file://` URI) and its plugin(s) installed.
- **Standalone plugin** (contains a single-plugin manifest like `.plugin/plugin.json`, `.claude-plugin/plugin.json`, or `plugin.json`) → registered under `chat.pluginLocations`.

## Why

Previously local file paths were explicitly rejected. Users with plugins checked out locally (or a local marketplace clone) had no way to install them through this command.

## Notable changes

- `IPluginMarketplaceService.isPluginDirectory(dir)` added to detect a standalone-plugin manifest (reuses the existing single-plugin manifest definitions).
- `PluginInstallService` gains local-source resolution/routing (`_doInstallFromLocalSource`, `_addPluginLocationToConfig`, path helpers) and injects `IPathService`. Shared discovery/install branching extracted into `_installDiscoveredPlugins`.
- **API consolidation:** `installPluginFromSource` and `installPluginFromValidatedSource` collapsed into a single result-returning `installPluginFromSource`. The service no longer emits UI notifications for source-level errors — callers surface the returned message. `pluginUrlHandler` now notifies on the untargeted path (newly injects `INotificationService`).
- Updated the action's input-box placeholder/prompt and `AGENTS_PLUGINS.md`.

## Reviewer notes

- `validatePluginSource` is kept for live input-box validation and now also accepts local path formats.
- Internal install-time errors (e.g. "plugin directory not found", package-install failures) still notify directly from within `installPlugin`; only source-level errors moved to the result contract.

## Validation

- `npm run typecheck-client`
- `npm run valid-layers-check`
- eslint on changed files
- Unit tests: `pluginInstallService` + `pluginUrlHandler` (74 passing), `pluginMarketplaceService` (79 passing)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
