### PR TITLE
Don't crash BYOK/custom models when the response hits the length limit

### DIFF
--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -789,6 +789,15 @@ export class CopilotLanguageModelWrapper extends Disposable {
 
 		const result = await wrappedRequest();
 
+		if (result.type === ChatFetchResponseType.Length) {
+			// The model stopped generating because it hit the length/context-window limit
+			// (finish_reason "length"). The partial text has already been streamed to the
+			// consumer via the finished callback, so treat this as a successful (truncated)
+			// response instead of throwing "Response too long." and discarding the output.
+			this._logService.warn(`[LanguageModelAccess] Response from model '${_endpoint.model}' was truncated because it hit the length limit; returning the partial response.`);
+			return undefined;
+		}
+
 		if (result.type !== ChatFetchResponseType.Success) {
 			if (result.type === ChatFetchResponseType.ExtensionBlocked) {
 				if (extensionId) {

--- a/extensions/copilot/src/extension/conversation/vscode-node/test/languageModelAccess.test.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/test/languageModelAccess.test.ts
@@ -143,6 +143,41 @@ suite('CopilotLanguageModelWrapper', () => {
 			assert.deepStrictEqual(decoded, expectedUsage);
 		});
 	});
+
+	suite('length finish reason', () => {
+		let wrapper: CopilotLanguageModelWrapper;
+		let endpoint: IChatEndpoint;
+		let fetcher: MockChatMLFetcher;
+		setup(async () => {
+			createAccessor();
+			fetcher = accessor.get(IChatMLFetcher) as MockChatMLFetcher;
+			endpoint = await accessor.get(IEndpointProvider).getChatEndpoint('copilot-utility');
+			wrapper = instaService.createInstance(CopilotLanguageModelWrapper);
+		});
+
+		test('does not throw when the response is truncated due to length', async () => {
+			// A model (e.g. a custom/BYOK endpoint) can legitimately stop generating
+			// because it hit the context window ceiling, returning finish_reason "length"
+			// together with the partial text it already streamed. This must not surface
+			// as a hard "Response too long." failure that discards the generated text.
+			fetcher.setNextResponse({
+				type: ChatFetchResponseType.Length,
+				reason: 'Response too long.',
+				requestId: 'test-request-id',
+				serverRequestId: 'test-server-request-id',
+				truncatedValue: 'partial answer'
+			});
+
+			await wrapper.provideLanguageModelResponse(
+				endpoint,
+				[vscode.LanguageModelChatMessage.User('hello')],
+				{ requestInitiator: 'unknown', toolMode: vscode.LanguageModelChatToolMode.Auto },
+				vscode.extensions.all[0].id,
+				{ report: () => { } },
+				CancellationToken.None
+			);
+		});
+	});
 });
 
 suite('LanguageModelAccess model info', () => {


### PR DESCRIPTION
Fixes #319592

When a custom/BYOK model returns `finish_reason: "length"` (hit its context
window), we threw `Error: Response too long.` and discarded everything the model
already streamed.

By the time we get the `Length` result the partial text has already been
streamed via the finished callback, so instead of throwing we just resolve and
keep it. This matches how the rest of the codebase already handles `Length`
(`defaultIntentRequestHandler`, `agentIntent`, `codeMapper` all use the partial
text rather than failing).