### PR TITLE
Read remote user mcp.json into configuration model

### DIFF
--- a/src/vs/workbench/services/configuration/browser/configuration.ts
+++ b/src/vs/workbench/services/configuration/browser/configuration.ts
@@ -398,7 +398,11 @@ export class RemoteUserConfiguration extends Disposable {
 		this._userConfiguration = this._cachedConfiguration = new CachedRemoteUserConfiguration(remoteAuthority, configurationCache, { scopes: REMOTE_MACHINE_SCOPES }, logService);
 		remoteAgentService.getEnvironment().then(async environment => {
 			if (environment) {
-				const userConfiguration = this._register(new FileServiceBasedRemoteUserConfiguration(environment.settingsPath, { scopes: REMOTE_MACHINE_SCOPES }, this._fileService, uriIdentityService, logService));
+				const standAloneConfigurationResources: [string, URI][] = [];
+				if (environment.mcpResource) {
+					standAloneConfigurationResources.push([MCP_CONFIGURATION_KEY, environment.mcpResource]);
+				}
+				const userConfiguration = this._register(new FileServiceBasedRemoteUserConfiguration(environment.settingsPath, standAloneConfigurationResources, { scopes: REMOTE_MACHINE_SCOPES }, this._fileService, uriIdentityService, logService));
 				this._register(userConfiguration.onDidChangeConfiguration(configurationModel => this.onDidUserConfigurationChange(configurationModel)));
 				this._userConfigurationInitializationPromise = userConfiguration.initialize();
 				const configurationModel = await this._userConfigurationInitializationPromise;
@@ -463,15 +467,19 @@ class FileServiceBasedRemoteUserConfiguration extends Disposable {
 
 	private readonly parser: ConfigurationModelParser;
 	private parseOptions: ConfigurationParseOptions;
+	private _standAloneConfigurations: ConfigurationModel[] = [];
+	private _cache: ConfigurationModel;
 	private readonly reloadConfigurationScheduler: RunOnceScheduler;
 	protected readonly _onDidChangeConfiguration: Emitter<ConfigurationModel> = this._register(new Emitter<ConfigurationModel>());
 	readonly onDidChangeConfiguration: Event<ConfigurationModel> = this._onDidChangeConfiguration.event;
 
 	private readonly fileWatcherDisposable = this._register(new MutableDisposable());
 	private readonly directoryWatcherDisposable = this._register(new MutableDisposable());
+	private readonly standAloneWatchers = this._register(new DisposableStore());
 
 	constructor(
 		private readonly configurationResource: URI,
+		private readonly standAloneConfigurationResources: [string, URI][],
 		configurationParseOptions: ConfigurationParseOptions,
 		private readonly fileService: IFileService,
 		private readonly uriIdentityService: IUriIdentityService,
@@ -481,6 +489,7 @@ class FileServiceBasedRemoteUserConfiguration extends Disposable {
 
 		this.parser = new ConfigurationModelParser(this.configurationResource.toString(), logService);
 		this.parseOptions = configurationParseOptions;
+		this._cache = ConfigurationModel.createEmptyModel(this.logService);
 		this._register(fileService.onDidFilesChange(e => this.handleFileChangesEvent(e)));
 		this._register(fileService.onDidRunOperation(e => this.handleFileOperationEvent(e)));
 		this.reloadConfigurationScheduler = this._register(new RunOnceScheduler(() => this.reload().then(configurationModel => this._onDidChangeConfiguration.fire(configurationModel)), 50));
@@ -488,6 +497,11 @@ class FileServiceBasedRemoteUserConfiguration extends Disposable {
 			this.stopWatchingResource();
 			this.stopWatchingDirectory();
 		}));
+		for (const [, resource] of this.standAloneConfigurationResources) {
+			// Watch both the file and its parent dir to catch create/delete after startup.
+			this.standAloneWatchers.add(this.fileService.watch(resource));
+			this.standAloneWatchers.add(this.fileService.watch(this.uriIdentityService.extUri.dirname(resource)));
+		}
 	}
 
 	private watchResource(): void {
@@ -518,24 +532,51 @@ class FileServiceBasedRemoteUserConfiguration extends Disposable {
 		return content.value.toString();
 	}
 
-	async reload(): Promise<ConfigurationModel> {
+	private async resolveStandAloneContent(resource: URI): Promise<string | undefined> {
 		try {
-			const content = await this.resolveContent();
-			this.parser.parse(content, this.parseOptions);
-			return this.parser.configurationModel;
-		} catch (e) {
-			return ConfigurationModel.createEmptyModel(this.logService);
+			const content = await this.fileService.readFile(resource, { atomic: true });
+			return content.value.toString();
+		} catch (error) {
+			if ((<FileOperationError>error).fileOperationResult !== FileOperationResult.FILE_NOT_FOUND
+				&& (<FileOperationError>error).fileOperationResult !== FileOperationResult.FILE_NOT_DIRECTORY) {
+				this.logService.error(error);
+			}
+			return undefined;
 		}
+	}
+
+	async reload(): Promise<ConfigurationModel> {
+		const [settingsContent, standAloneContents] = await Promise.all([
+			this.resolveContent().then(c => c, () => undefined),
+			Promise.all(this.standAloneConfigurationResources.map(([, resource]) => this.resolveStandAloneContent(resource))),
+		]);
+		this.parser.parse(settingsContent ?? '', this.parseOptions);
+		this._standAloneConfigurations = [];
+		for (let index = 0; index < this.standAloneConfigurationResources.length; index++) {
+			const contents = standAloneContents[index];
+			if (contents !== undefined) {
+				const standAloneParser = new StandaloneConfigurationModelParser(this.standAloneConfigurationResources[index][1].toString(), this.standAloneConfigurationResources[index][0], this.logService);
+				standAloneParser.parse(contents);
+				this._standAloneConfigurations.push(standAloneParser.configurationModel);
+			}
+		}
+		this.consolidate();
+		return this._cache;
 	}
 
 	reparse(configurationParseOptions: ConfigurationParseOptions): ConfigurationModel {
 		this.parseOptions = configurationParseOptions;
 		this.parser.reparse(this.parseOptions);
-		return this.parser.configurationModel;
+		this.consolidate();
+		return this._cache;
 	}
 
 	getRestrictedSettings(): string[] {
 		return this.parser.restrictedConfigurations;
+	}
+
+	private consolidate(): void {
+		this._cache = this.parser.configurationModel.merge(...this._standAloneConfigurations);
 	}
 
 	private handleFileChangesEvent(event: FileChangesEvent): void {
@@ -552,15 +593,26 @@ class FileServiceBasedRemoteUserConfiguration extends Disposable {
 			affectedByChanges = true;
 		}
 
+		if (!affectedByChanges) {
+			for (const [, resource] of this.standAloneConfigurationResources) {
+				if (event.contains(resource)) {
+					affectedByChanges = true;
+					break;
+				}
+			}
+		}
+
 		if (affectedByChanges) {
 			this.reloadConfigurationScheduler.schedule();
 		}
 	}
 
 	private handleFileOperationEvent(event: FileOperationEvent): void {
-		if ((event.isOperation(FileOperation.CREATE) || event.isOperation(FileOperation.COPY) || event.isOperation(FileOperation.DELETE) || event.isOperation(FileOperation.WRITE))
-			&& this.uriIdentityService.extUri.isEqual(event.resource, this.configurationResource)) {
-			this.reloadConfigurationScheduler.schedule();
+		if (event.isOperation(FileOperation.CREATE) || event.isOperation(FileOperation.COPY) || event.isOperation(FileOperation.DELETE) || event.isOperation(FileOperation.WRITE)) {
+			if (this.uriIdentityService.extUri.isEqual(event.resource, this.configurationResource)
+				|| this.standAloneConfigurationResources.some(([, resource]) => this.uriIdentityService.extUri.isEqual(event.resource, resource))) {
+				this.reloadConfigurationScheduler.schedule();
+			}
 		}
 	}
 

--- a/src/vs/workbench/services/configuration/test/browser/configurationService.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configurationService.test.ts
@@ -2953,19 +2953,15 @@ suite('WorkspaceConfigurationService - Remote Folder', () => {
 	}));
 
 	test('remote user-level mcp.json is loaded into userRemoteValue', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
-		const mcpContent = JSON.stringify({
+		const mcpContent = {
 			inputs: [{ id: 'test-token', type: 'promptString', description: 'Test token' }],
 			servers: { echo: { command: 'echo', args: ['${input:test-token}'] } }
-		});
-		await fileService.writeFile(machineMcpResource, VSBuffer.fromString(mcpContent));
+		};
+		await fileService.writeFile(machineMcpResource, VSBuffer.fromString(JSON.stringify(mcpContent)));
 		registerRemoteFileSystemProvider();
 		resolveRemoteEnvironment();
 		await initialize();
-		const mcp = testObject.inspect<{ inputs?: unknown[]; servers?: Record<string, unknown> }>('mcp').userRemoteValue;
-		assert.ok(mcp, 'mcp userRemoteValue should be populated from remote mcp.json');
-		assert.ok(Array.isArray(mcp!.inputs), 'mcp.inputs should be an array');
-		assert.strictEqual(mcp!.inputs!.length, 1);
-		assert.ok(mcp!.servers && (mcp!.servers as Record<string, unknown>).echo);
+		assert.deepStrictEqual(testObject.inspect('mcp').userRemoteValue, mcpContent);
 	}));
 
 	test('remote application machine settings override globals', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {

--- a/src/vs/workbench/services/configuration/test/browser/configurationService.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configurationService.test.ts
@@ -2796,7 +2796,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 suite('WorkspaceConfigurationService - Remote Folder', () => {
 
 	let testObject: WorkspaceService, folder: URI,
-		machineSettingsResource: URI, remoteSettingsResource: URI, fileSystemProvider: InMemoryFileSystemProvider, resolveRemoteEnvironment: () => void,
+		machineSettingsResource: URI, remoteSettingsResource: URI, machineMcpResource: URI, remoteMcpResource: URI, fileSystemProvider: InMemoryFileSystemProvider, resolveRemoteEnvironment: () => void,
 		instantiationService: TestInstantiationService, fileService: IFileService, environmentService: BrowserWorkbenchEnvironmentService, userDataProfileService: IUserDataProfileService;
 	const remoteAuthority = 'configuraiton-tests';
 	const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
@@ -2848,10 +2848,12 @@ suite('WorkspaceConfigurationService - Remote Folder', () => {
 		await fileService.createFolder(appSettingsHome);
 		machineSettingsResource = joinPath(ROOT, 'machine-settings.json');
 		remoteSettingsResource = machineSettingsResource.with({ scheme: Schemas.vscodeRemote, authority: remoteAuthority });
+		machineMcpResource = joinPath(ROOT, 'machine-mcp.json');
+		remoteMcpResource = machineMcpResource.with({ scheme: Schemas.vscodeRemote, authority: remoteAuthority });
 
 		instantiationService = workbenchInstantiationService(undefined, disposables);
 		environmentService = TestEnvironmentService;
-		const remoteEnvironmentPromise = new Promise<Partial<IRemoteAgentEnvironment>>(c => resolveRemoteEnvironment = () => c({ settingsPath: remoteSettingsResource }));
+		const remoteEnvironmentPromise = new Promise<Partial<IRemoteAgentEnvironment>>(c => resolveRemoteEnvironment = () => c({ settingsPath: remoteSettingsResource, mcpResource: remoteMcpResource }));
 		const remoteAgentService = instantiationService.stub(IRemoteAgentService, <Partial<IRemoteAgentService>>{ getEnvironment: () => remoteEnvironmentPromise });
 		const configurationCache: IConfigurationCache = { read: () => Promise.resolve(''), write: () => Promise.resolve(), remove: () => Promise.resolve(), needsCaching: () => false };
 		const uriIdentityService = disposables.add(new UriIdentityService(fileService));
@@ -2948,6 +2950,22 @@ suite('WorkspaceConfigurationService - Remote Folder', () => {
 		resolveRemoteEnvironment();
 		await initialize();
 		assert.strictEqual(testObject.getValue('configurationService.remote.machineSetting'), 'isSet');
+	}));
+
+	test('remote user-level mcp.json is loaded into userRemoteValue', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		const mcpContent = JSON.stringify({
+			inputs: [{ id: 'test-token', type: 'promptString', description: 'Test token' }],
+			servers: { echo: { command: 'echo', args: ['${input:test-token}'] } }
+		});
+		await fileService.writeFile(machineMcpResource, VSBuffer.fromString(mcpContent));
+		registerRemoteFileSystemProvider();
+		resolveRemoteEnvironment();
+		await initialize();
+		const mcp = testObject.inspect<{ inputs?: unknown[]; servers?: Record<string, unknown> }>('mcp').userRemoteValue;
+		assert.ok(mcp, 'mcp userRemoteValue should be populated from remote mcp.json');
+		assert.ok(Array.isArray(mcp!.inputs), 'mcp.inputs should be an array');
+		assert.strictEqual(mcp!.inputs!.length, 1);
+		assert.ok(mcp!.servers && (mcp!.servers as Record<string, unknown>).echo);
 	}));
 
 	test('remote application machine settings override globals', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {


### PR DESCRIPTION
Fixes #256546

### Problem

`RemoteUserConfiguration` constructed `FileServiceBasedRemoteUserConfiguration` with only `settingsPath`, so the user-level `mcp.json` on a remote host (`environment.mcpResource`) was never read into the configuration model and never watched for changes. As a result, `inspect('mcp').userRemoteValue` was always `undefined` in remote windows (SSH / WSL / dev containers), and starting an MCP server that references `${input:...}` variables failed with:

```
Error starting <mcp server>: CodeExpectedError: Variable '<input>' must be defined in an 'inputs' section of the debug or task configuration.
```

This also explains the known workaround: `.vscode/mcp.json` works because the workspace folder layer already handles standalone configuration resources.

### Fix

Wires `environment.mcpResource` through to `FileServiceBasedRemoteUserConfiguration` as a standalone configuration resource, mirroring the existing handling in `UserConfiguration` (local user `mcp.json`/`tasks.json`) and `FolderConfiguration` (`.vscode/*.json`):

- reads remote `mcp.json` in parallel with `settings.json` on reload, parses it with `StandaloneConfigurationModelParser`, and merges it into the model (`consolidate`)
- tolerates a missing file (`FILE_NOT_FOUND` / `FILE_NOT_DIRECTORY`), since `mcp.json` is optional
- watches the resource and its parent directory, so an `mcp.json` created or edited after the window connects is picked up without a reload

### Verification

- New unit test in the `WorkspaceConfigurationService - Remote Folder` suite asserting that remote `mcp.json` contents (inputs + servers) surface through `inspect('mcp').userRemoteValue`
- Verified live against a from-source build with the `vscode-test-resolver` remote authority: created `mcp.json` in the remote server's `data/User` folder while the window was open — the MCP server appeared without a reload, the `promptString` input was prompted for, and the server started with the resolved value
- Reproduced the original error on a current Remote-WSL install (pre-fix server build) to confirm the root cause