### PR TITLE
sessions: fix endless spinner in Changes view for non-git folders

### DIFF
--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsChangesets.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsChangesets.ts
@@ -35,7 +35,7 @@ class GitRepositoryChangesetResolver implements IChangesetResolver {
 	async resolve(firstCheckpointRef: string, lastCheckpointRef: string | undefined): Promise<IChatSessionFileChange2[] | undefined> {
 		const repositoryUri = this._repositoryUriObs.get();
 		if (!repositoryUri) {
-			return undefined;
+			return [];
 		}
 
 		const repository = await this._gitService.openRepository(repositoryUri);


### PR DESCRIPTION
This PR fixes GitHub issue #324066: endless loading spinner in the Changes view when opening non-git directories.

### Root Cause Analysis
For non-git workspaces or non-git folders, `activeSessionHasGitRepositoryObs` in `ChangesViewService` evaluates to `false`. When there's no Git repository, the changeset's `isLoadingChanges` can remain stuck in a loading state if it tries to resolve refs via Git. Specifically, in `UncommittedChangesChangeset` and other git-backed changesets, `isLoadingChanges` evaluates to `true` whenever the changeset resolver returns `undefined`.

In `GitRepositoryChangesetResolver.resolve(...)`, if `repositoryUri` is not present, it returns `undefined`. Because it returns `undefined`, `changesPromiseObs.read(reader).read(reader)` remains `undefined`, which keeps the changeset's `isLoadingChanges` stuck as `true` indefinitely. This propagates up to the UI, leading to an endless spinner.

### Fix
Modify `GitRepositoryChangesetResolver.resolve(...)` to return an empty array `[]` instead of `undefined` when the repository is not available. This signals to the changeset state observable that the resolution has completed (yielding no changes) rather than indicating that it is still loading.