### PR TITLE
agentHost: route GitHub protected resources through a GitHub Enterprise endpoint service

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostCustomizationConfig.ts
+++ b/src/vs/platform/agentHost/common/agentHostCustomizationConfig.ts
@@ -27,6 +27,16 @@ export const enum AgentHostConfigKey {
 	 * the user's own credentials (BYO Anthropic — Phase 19).
 	 */
 	ClaudeUseCopilotProxy = 'claudeUseCopilotProxy',
+	/**
+	 * Optional GitHub Enterprise base URI (e.g. `https://ghe.example.com` for a
+	 * GitHub Enterprise Server, or `https://tenant.ghe.com` for GitHub Enterprise
+	 * Cloud). When set, the agent host computes its GitHub protected resources and
+	 * REST/GraphQL endpoints from this base instead of github.com. Normally pushed
+	 * by the local VS Code client from the workbench `github-enterprise.uri`
+	 * setting; remote operators set it directly in the remote
+	 * `agent-host-config.json`.
+	 */
+	GithubEnterpriseUri = 'githubEnterpriseUri',
 }
 
 /**
@@ -78,6 +88,11 @@ export const agentHostCustomizationConfigSchema = createSchema({
 		title: localize('agentHost.config.claudeUseCopilotProxy.title', "Route Claude Through Copilot"),
 		description: localize('agentHost.config.claudeUseCopilotProxy.description', "When enabled (the default), the Claude agent routes all requests through GitHub Copilot. When disabled, Claude talks to Anthropic directly using your own credentials (API key or Claude subscription)."),
 		default: true,
+	}),
+	[AgentHostConfigKey.GithubEnterpriseUri]: schemaProperty<string>({
+		type: 'string',
+		title: localize('agentHost.config.githubEnterpriseUri.title', "GitHub Enterprise URI"),
+		description: localize('agentHost.config.githubEnterpriseUri.description', "Optional base URI of a GitHub Enterprise instance (for example \"https://ghe.example.com\" for GitHub Enterprise Server, or \"https://tenant.ghe.com\" for GitHub Enterprise Cloud). When set, the agent host authenticates and makes GitHub API calls against this instance instead of github.com. Normally pushed by the connected VS Code client from the `github-enterprise.uri` setting; remote agent host operators can set it directly in the remote `agent-host-config.json`."),
 	}),
 });
 

--- a/src/vs/platform/agentHost/common/githubEndpoints.ts
+++ b/src/vs/platform/agentHost/common/githubEndpoints.ts
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../base/common/uri.js';
+import { ProtectedResourceMetadata } from './state/protocol/state.js';
+
+/**
+ * The GitHub endpoints an agent host talks to, derived from an optional
+ * GitHub Enterprise base URI. All values are string URIs with no trailing slash.
+ */
+export interface IGitHubEndpoints {
+	/** REST API base (e.g. `https://api.github.com`), used as the resource identifier and the REST host. */
+	readonly apiBaseUri: string;
+	/** GraphQL endpoint (distinct from `apiBaseUri` for on-prem: `/api/graphql`, not `/api/v3/graphql`). */
+	readonly graphQlUri: string;
+	/** OAuth authorization server URI, advertised in `authorization_servers`. */
+	readonly oauthServer: string;
+	/**
+	 * The configured GitHub Enterprise host (authority only, e.g. `acme.ghe.com`),
+	 * or `undefined` for github.com. Used to point the Copilot CLI at an enterprise
+	 * host via `COPILOT_GH_HOST`.
+	 */
+	readonly enterpriseHost: string | undefined;
+}
+
+/** Canonical github.com endpoints, used when no enterprise URI is configured. */
+const GITHUB_DOT_COM_ENDPOINTS: IGitHubEndpoints = {
+	apiBaseUri: 'https://api.github.com',
+	graphQlUri: 'https://api.github.com/graphql',
+	oauthServer: 'https://github.com/login/oauth',
+	enterpriseHost: undefined,
+};
+
+/**
+ * Derives the {@link IGitHubEndpoints} for a GitHub Enterprise base URI, mirroring
+ * the URL derivation in the built-in `github-authentication` extension
+ * (`githubServer.ts` / `common/env.ts`):
+ *
+ * - unset / empty / unparseable → github.com defaults (byte-for-byte, preserving
+ *   the resource identifiers used by every non-enterprise install).
+ * - GitHub Enterprise **Cloud** (authority ends in `.ghe.com`) → API on an `api.`
+ *   subdomain: `https://api.<authority>`.
+ * - GitHub Enterprise **Server** (on-prem) → API under `/api/v3`, GraphQL under
+ *   `/api/graphql`.
+ *
+ * The OAuth server is always `<scheme>://<authority>/login/oauth` for enterprise.
+ */
+export function deriveGitHubEndpoints(enterpriseUri: string | undefined): IGitHubEndpoints {
+	if (!enterpriseUri) {
+		return GITHUB_DOT_COM_ENDPOINTS;
+	}
+
+	let uri: URI;
+	try {
+		uri = URI.parse(enterpriseUri);
+	} catch {
+		return GITHUB_DOT_COM_ENDPOINTS;
+	}
+
+	const authority = uri.authority;
+	if (!authority) {
+		return GITHUB_DOT_COM_ENDPOINTS;
+	}
+
+	// A github.com authority is never a GitHub Enterprise host — treat it as the
+	// default rather than deriving a nonsensical `github.com/api/v3`. Guards the
+	// case where the enterprise host can't be resolved and falls back to github.com.
+	if (authority === 'github.com' || authority === 'www.github.com' || authority === 'api.github.com') {
+		return GITHUB_DOT_COM_ENDPOINTS;
+	}
+
+	const scheme = uri.scheme || 'https';
+	const isCloud = /\.ghe\.com$/.test(authority);
+	return {
+		apiBaseUri: isCloud ? `${scheme}://api.${authority}` : `${scheme}://${authority}/api/v3`,
+		graphQlUri: isCloud ? `${scheme}://api.${authority}/graphql` : `${scheme}://${authority}/api/graphql`,
+		oauthServer: `${scheme}://${authority}/login/oauth`,
+		enterpriseHost: authority,
+	};
+}
+
+/**
+ * The GitHub Copilot protected resource for the given endpoints. Shared by the
+ * endpoint service and tests so the resource identity is defined once.
+ */
+export function gitHubCopilotResource(endpoints: IGitHubEndpoints): ProtectedResourceMetadata {
+	return {
+		resource: endpoints.apiBaseUri,
+		resource_name: 'GitHub Copilot',
+		authorization_servers: [endpoints.oauthServer],
+		scopes_supported: ['read:user', 'user:email'],
+		required: true,
+	};
+}
+
+/** The GitHub repository protected resource for the given endpoints. */
+export function gitHubRepoResource(endpoints: IGitHubEndpoints): ProtectedResourceMetadata {
+	return {
+		resource: `${endpoints.apiBaseUri}/repos`,
+		resource_name: 'GitHub Repository',
+		authorization_servers: [endpoints.oauthServer],
+		scopes_supported: ['repo'],
+		required: false,
+	};
+}

--- a/src/vs/platform/agentHost/node/agentHostCommitOperationHandler.ts
+++ b/src/vs/platform/agentHost/node/agentHostCommitOperationHandler.ts
@@ -7,7 +7,8 @@ import { basename } from '../../../base/common/resources.js';
 import { CancellationToken } from '../../../base/common/cancellation.js';
 import { URI } from '../../../base/common/uri.js';
 import { localize } from '../../../nls.js';
-import { GITHUB_COPILOT_PROTECTED_RESOURCE, IAgentService } from '../common/agentService.js';
+import { IAgentService } from '../common/agentService.js';
+import { IAgentHostGitHubEndpointService } from './agentHostGitHubEndpointService.js';
 import { parseChangesetUri } from '../common/changesetUri.js';
 import { type IChangesetOperationHandler } from '../common/agentHostChangesetOperationService.js';
 import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } from '../common/state/protocol/channels-changeset/commands.js';
@@ -27,6 +28,7 @@ export class AgentHostCommitOperationHandler implements IChangesetOperationHandl
 		private readonly _getSessionState: (sessionKey: string) => SessionState | undefined,
 		private readonly _onCommitted: (sessionKey: string) => Promise<void>,
 		@IAgentService private readonly _agentService: IAgentService,
+		@IAgentHostGitHubEndpointService private readonly _gitHubEndpointService: IAgentHostGitHubEndpointService,
 		@IAgentHostGitService private readonly _gitService: IAgentHostGitService,
 		@ICopilotApiService private readonly _copilotApiService: ICopilotApiService,
 		@ILogService private readonly _logService: ILogService,
@@ -75,15 +77,16 @@ export class AgentHostCommitOperationHandler implements IChangesetOperationHandl
 		}
 		this._throwIfCancelled(token);
 
+		const copilotResource = this._gitHubEndpointService.getCopilotResource();
 		const authToken = this._agentService.getAuthToken({
-			resource: GITHUB_COPILOT_PROTECTED_RESOURCE.resource,
-			scopes: GITHUB_COPILOT_PROTECTED_RESOURCE.scopes_supported,
+			resource: copilotResource.resource,
+			scopes: copilotResource.scopes_supported,
 		});
 		if (!authToken) {
 			throw new ProtocolError(
 				AHP_AUTH_REQUIRED,
 				localize('agentHost.changeset.commit.authRequired', "Sign in to GitHub Copilot to generate a commit message."),
-				[GITHUB_COPILOT_PROTECTED_RESOURCE],
+				[copilotResource],
 			);
 		}
 
@@ -104,7 +107,7 @@ export class AgentHostCommitOperationHandler implements IChangesetOperationHandl
 				throw new ProtocolError(
 					AHP_AUTH_REQUIRED,
 					localize('agentHost.changeset.commit.authExpired', "Authentication is required to generate a commit message. Please sign in to GitHub Copilot and try again."),
-					[GITHUB_COPILOT_PROTECTED_RESOURCE],
+					[copilotResource],
 				);
 			}
 			throw err;

--- a/src/vs/platform/agentHost/node/agentHostGitHubEndpointService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitHubEndpointService.ts
@@ -1,0 +1,127 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, Event } from '../../../base/common/event.js';
+import { Disposable } from '../../../base/common/lifecycle.js';
+import { createDecorator } from '../../instantiation/common/instantiation.js';
+import { ILogService } from '../../log/common/log.js';
+import { AgentHostConfigKey, agentHostCustomizationConfigSchema } from '../common/agentHostCustomizationConfig.js';
+import { deriveGitHubEndpoints, gitHubCopilotResource, gitHubRepoResource, IGitHubEndpoints } from '../common/githubEndpoints.js';
+import { ProtectedResourceMetadata } from '../common/state/protocol/state.js';
+import { IAgentConfigurationService } from './agentConfigurationService.js';
+
+export const IAgentHostGitHubEndpointService = createDecorator<IAgentHostGitHubEndpointService>('agentHostGitHubEndpointService');
+
+/**
+ * Single source of truth for the GitHub endpoints (protected resources + REST /
+ * GraphQL hosts) the agent host talks to. Computed from the optional
+ * `githubEnterpriseUri` root config so that every consumer — agent
+ * `authenticate` / `getProtectedResources`, changeset operation `getAuthToken`
+ * lookups, and the REST client — agrees on the same resource identifiers and API
+ * base. With no enterprise URI configured, the values are byte-for-byte the
+ * github.com defaults.
+ */
+export interface IAgentHostGitHubEndpointService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Fires when the configured GitHub endpoints change (e.g. `githubEnterpriseUri`
+	 * was set, cleared, or repointed). Does NOT fire for unrelated root-config
+	 * changes.
+	 */
+	readonly onDidChange: Event<void>;
+
+	/** The GitHub Copilot protected resource, computed against the configured endpoints. */
+	getCopilotResource(): ProtectedResourceMetadata;
+
+	/** The GitHub repository protected resource, computed against the configured endpoints. */
+	getRepoResource(): ProtectedResourceMetadata;
+
+	/** The REST API base URI (no trailing slash), e.g. `https://api.github.com`. */
+	getApiBaseUri(): string;
+
+	/** The GraphQL endpoint URI, e.g. `https://api.github.com/graphql`. */
+	getGraphQlUri(): string;
+
+	/**
+	 * The configured GitHub Enterprise host (authority only, e.g. `acme.ghe.com`),
+	 * or `undefined` for github.com. Used to set `COPILOT_GH_HOST` for the Copilot CLI.
+	 */
+	getEnterpriseHost(): string | undefined;
+
+	/**
+	 * The raw configured GitHub Enterprise base URI (e.g. `https://acme.ghe.com`),
+	 * or `undefined` for github.com. This is the value the `@vscode/copilot-api`
+	 * `CAPIClient.updateDomains(..., enterpriseUrlConfig)` expects: it derives the
+	 * GitHub API host (`api.<host>`) used for `copilot_internal` endpoints (token
+	 * mint, etc.) from it. Distinct from {@link getApiBaseUri} (the already-derived
+	 * `api.` host) - the package does that derivation itself.
+	 */
+	getEnterpriseUri(): string | undefined;
+}
+
+export class AgentHostGitHubEndpointService extends Disposable implements IAgentHostGitHubEndpointService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onDidChange = this._register(new Emitter<void>());
+	readonly onDidChange = this._onDidChange.event;
+
+	private _endpoints: IGitHubEndpoints;
+	private _enterpriseUri: string | undefined;
+
+	constructor(
+		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+		const resolved = this._resolve();
+		this._endpoints = resolved.endpoints;
+		this._enterpriseUri = resolved.enterpriseUri;
+		this._register(this._configurationService.onDidRootConfigChange(() => {
+			const next = this._resolve();
+			// `onDidRootConfigChange` fires for every root-config key; only react
+			// when the derived GitHub endpoints actually change.
+			if (next.endpoints.apiBaseUri === this._endpoints.apiBaseUri
+				&& next.endpoints.graphQlUri === this._endpoints.graphQlUri
+				&& next.endpoints.oauthServer === this._endpoints.oauthServer) {
+				return;
+			}
+			this._logService.info(`[AgentHost] GitHub endpoints changed (api=${next.endpoints.apiBaseUri})`);
+			this._endpoints = next.endpoints;
+			this._enterpriseUri = next.enterpriseUri;
+			this._onDidChange.fire();
+		}));
+	}
+
+	private _resolve(): { endpoints: IGitHubEndpoints; enterpriseUri: string | undefined } {
+		const enterpriseUri = this._configurationService.getRootValue(agentHostCustomizationConfigSchema, AgentHostConfigKey.GithubEnterpriseUri);
+		return { endpoints: deriveGitHubEndpoints(enterpriseUri), enterpriseUri: enterpriseUri || undefined };
+	}
+
+	getApiBaseUri(): string {
+		return this._endpoints.apiBaseUri;
+	}
+
+	getGraphQlUri(): string {
+		return this._endpoints.graphQlUri;
+	}
+
+	getEnterpriseHost(): string | undefined {
+		return this._endpoints.enterpriseHost;
+	}
+
+	getEnterpriseUri(): string | undefined {
+		return this._enterpriseUri;
+	}
+
+	getCopilotResource(): ProtectedResourceMetadata {
+		return gitHubCopilotResource(this._endpoints);
+	}
+
+	getRepoResource(): ProtectedResourceMetadata {
+		return gitHubRepoResource(this._endpoints);
+	}
+}

--- a/src/vs/platform/agentHost/node/agentHostGitStateService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitStateService.ts
@@ -13,7 +13,8 @@ import { IAgentHostGitService } from '../common/agentHostGitService.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
 import { ISessionDataService } from '../common/sessionDataService.js';
 import { IAgentHostOctoKitService } from './shared/agentHostOctoKitService.js';
-import { GITHUB_REPO_PROTECTED_RESOURCE, IAgentService } from '../common/agentService.js';
+import { IAgentService } from '../common/agentService.js';
+import { IAgentHostGitHubEndpointService } from './agentHostGitHubEndpointService.js';
 import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { CancellationTokenSource } from '../../../base/common/cancellation.js';
 import { ThrottlerByKey, timeout } from '../../../base/common/async.js';
@@ -33,6 +34,7 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 		@IAgentHostGitService private readonly _gitService: IAgentHostGitService,
 		@IAgentHostOctoKitService private readonly _octoKitService: IAgentHostOctoKitService,
 		@IAgentService private readonly _agentService: IAgentService,
+		@IAgentHostGitHubEndpointService private readonly _gitHubEndpointService: IAgentHostGitHubEndpointService,
 		@ILogService private readonly _logService: ILogService,
 		@ISessionDataService private readonly _sessionDataService: ISessionDataService,
 	) {
@@ -65,9 +67,10 @@ export class AgentHostGitStateService extends Disposable implements IAgentHostGi
 		}
 
 		try {
+			const repoResource = this._gitHubEndpointService.getRepoResource();
 			const authToken = this._agentService.getAuthToken({
-				resource: GITHUB_REPO_PROTECTED_RESOURCE.resource,
-				scopes: GITHUB_REPO_PROTECTED_RESOURCE.scopes_supported,
+				resource: repoResource.resource,
+				scopes: repoResource.scopes_supported,
 			});
 			if (!authToken) {
 				return;

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -19,6 +19,7 @@ import { AgentHostByokModelsEnabledEnvVar, AgentHostClaudeAgentEnabledEnvVar, Ag
 import { AgentHostCodexEnabledConfigKey, platformRootSchema } from '../common/agentHostSchema.js';
 import { AgentService } from './agentService.js';
 import { IAgentConfigurationService } from './agentConfigurationService.js';
+import { IAgentHostGitHubEndpointService } from './agentHostGitHubEndpointService.js';
 import { IAgentHostCompletions } from './agentHostCompletions.js';
 import { IAgentHostTerminalManager } from './agentHostTerminalManager.js';
 import { CopilotAgent } from './copilot/copilotAgent.js';
@@ -182,15 +183,8 @@ async function startAgentHost(): Promise<void> {
 		const agentSdkDownloader = disposables.add(instantiationService.createInstance(AgentSdkDownloader));
 		diServices.set(IAgentSdkDownloader, agentSdkDownloader);
 		sdkDownloadProgress = agentSdkDownloader.onDidDownloadProgress;
-		const copilotApiService = instantiationService.createInstance(CopilotApiService, undefined);
-		diServices.set(ICopilotApiService, copilotApiService);
-		diServices.set(ICopilotBranchNameGenerator, instantiationService.createInstance(CopilotBranchNameGenerator));
-		const claudeProxyService = disposables.add(instantiationService.createInstance(ClaudeProxyService));
-		diServices.set(IClaudeProxyService, claudeProxyService);
 		const claudeAgentSdkService = instantiationService.createInstance(ClaudeAgentSdkService);
 		diServices.set(IClaudeAgentSdkService, claudeAgentSdkService);
-		const codexProxyService = disposables.add(instantiationService.createInstance(CodexProxyService));
-		diServices.set(ICodexProxyService, codexProxyService);
 		// BYOK language-model proxy + bridge registry. Always registered so the
 		// session launcher can inject them, but BYOK *use* is gated: the
 		// per-connection bridge below (and the renderer's server channel) are only
@@ -214,7 +208,19 @@ async function startAgentHost(): Promise<void> {
 
 		diServices.set(IAgentHostTerminalManager, agentService.terminalManager);
 		diServices.set(IAgentConfigurationService, agentService.configurationService);
+		diServices.set(IAgentHostGitHubEndpointService, agentService.gitHubEndpointService);
 		diServices.set(IAgentHostCompletions, agentService.completionsService);
+
+		// CopilotApiService and the proxies that consume it are created AFTER the
+		// GitHub endpoint service is re-exported (above) so CAPI endpoint discovery
+		// can target a GitHub Enterprise host. Matches agentHostServerMain ordering.
+		const copilotApiService = instantiationService.createInstance(CopilotApiService, undefined);
+		diServices.set(ICopilotApiService, copilotApiService);
+		diServices.set(ICopilotBranchNameGenerator, instantiationService.createInstance(CopilotBranchNameGenerator));
+		const claudeProxyService = disposables.add(instantiationService.createInstance(ClaudeProxyService));
+		diServices.set(IClaudeProxyService, claudeProxyService);
+		const codexProxyService = disposables.add(instantiationService.createInstance(CodexProxyService));
+		diServices.set(ICodexProxyService, codexProxyService);
 		agentService.registerProvider(instantiationService.createInstance(CopilotAgent));
 		// Claude and Codex providers are gated on two things:
 		//  1. The user-facing enable toggle (`chat.agentHost.<x>Agent.enabled`,

--- a/src/vs/platform/agentHost/node/agentHostPullRequestOperationHandler.ts
+++ b/src/vs/platform/agentHost/node/agentHostPullRequestOperationHandler.ts
@@ -6,7 +6,8 @@
 import { CancellationToken } from '../../../base/common/cancellation.js';
 import { URI } from '../../../base/common/uri.js';
 import { localize } from '../../../nls.js';
-import { GITHUB_COPILOT_PROTECTED_RESOURCE, GITHUB_REPO_PROTECTED_RESOURCE, IAgentService } from '../common/agentService.js';
+import { IAgentService } from '../common/agentService.js';
+import { IAgentHostGitHubEndpointService } from './agentHostGitHubEndpointService.js';
 import { parseChangesetUri } from '../common/changesetUri.js';
 import { AHP_AUTH_REQUIRED, AHP_SESSION_NOT_FOUND, JsonRpcErrorCodes, ProtocolError } from '../common/state/sessionProtocol.js';
 import { readSessionGitHubState, readSessionGitState, type ChangesetOperationFollowUp, type ISessionFileDiff, type ISessionWithDefaultChat } from '../common/state/sessionState.js';
@@ -72,6 +73,7 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 		@IAgentService private readonly _agentService: IAgentService,
 		@IAgentHostGitService private readonly _gitService: IAgentHostGitService,
 		@IAgentHostOctoKitService private readonly _octoKitService: IAgentHostOctoKitService,
+		@IAgentHostGitHubEndpointService private readonly _gitHubEndpointService: IAgentHostGitHubEndpointService,
 		@ICopilotApiService private readonly _copilotApiService: ICopilotApiService,
 		@ILogService private readonly _logService: ILogService,
 	) { }
@@ -129,15 +131,16 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 		// `getDefaultBranch` may return `origin/<branch>` — `pulls` API wants the bare name.
 		const base = baseBranchName.startsWith('origin/') ? baseBranchName.substring('origin/'.length) : baseBranchName;
 
+		const repoResource = this._gitHubEndpointService.getRepoResource();
 		const authToken = this._agentService.getAuthToken({
-			resource: GITHUB_REPO_PROTECTED_RESOURCE.resource,
-			scopes: GITHUB_REPO_PROTECTED_RESOURCE.scopes_supported,
+			resource: repoResource.resource,
+			scopes: repoResource.scopes_supported,
 		});
 		if (!authToken) {
 			throw new ProtocolError(
 				AHP_AUTH_REQUIRED,
 				localize('agentHost.changeset.pr.authRequired', "Sign in to GitHub with repository access to create a pull request."),
-				[GITHUB_REPO_PROTECTED_RESOURCE],
+				[repoResource],
 			);
 		}
 
@@ -344,9 +347,10 @@ export class AgentHostPullRequestOperationHandler implements IChangesetOperation
 		signal: AbortSignal,
 		token: CancellationToken,
 	): Promise<{ title: string; description: string } | undefined> {
+		const copilotResource = this._gitHubEndpointService.getCopilotResource();
 		const copilotToken = this._agentService.getAuthToken({
-			resource: GITHUB_COPILOT_PROTECTED_RESOURCE.resource,
-			scopes: GITHUB_COPILOT_PROTECTED_RESOURCE.scopes_supported,
+			resource: copilotResource.resource,
+			scopes: copilotResource.scopes_supported,
 		});
 		if (!copilotToken) {
 			return undefined;

--- a/src/vs/platform/agentHost/node/agentHostServerMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostServerMain.ts
@@ -51,6 +51,7 @@ import { AgentHostOTelService } from './otel/agentHostOTelService.js';
 import { AgentService } from './agentService.js';
 import { AgentHostClaudeAgentEnabledEnvVar, AgentHostClaudeSdkRootEnvVar, AgentHostCodexAgentEnabledEnvVar, IAgentService, AgentHostCodexAgentSdkRootEnvVar, isAgentEnabled } from '../common/agentService.js';
 import { IAgentConfigurationService } from './agentConfigurationService.js';
+import { IAgentHostGitHubEndpointService } from './agentHostGitHubEndpointService.js';
 import { IAgentHostCompletions } from './agentHostCompletions.js';
 import { IAgentHostTerminalManager } from './agentHostTerminalManager.js';
 import { WebSocketProtocolServer } from './webSocketTransport.js';
@@ -262,6 +263,7 @@ async function main(): Promise<void> {
 		diServices.set(IEditSurvivalReporterFactory, instantiationService.createInstance(EditSurvivalReporterFactory));
 		diServices.set(IAgentHostTerminalManager, agentService.terminalManager);
 		diServices.set(IAgentConfigurationService, agentService.configurationService);
+		diServices.set(IAgentHostGitHubEndpointService, agentService.gitHubEndpointService);
 		diServices.set(IAgentHostCompletions, agentService.completionsService);
 		diServices.set(IAgentHostGitService, gitService);
 		// Register `ICopilotApiService` BEFORE `IClaudeProxyService` —

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -20,10 +20,10 @@ import { FileChangeType, FileOperationError, FileOperationResult, FileSystemProv
 import { InstantiationService } from '../../instantiation/common/instantiationService.js';
 import { ServiceCollection } from '../../instantiation/common/serviceCollection.js';
 import { ILogService } from '../../log/common/log.js';
-import { AgentProvider, AgentSession, AgentSignal, GITHUB_COPILOT_PROTECTED_RESOURCE, IAgent, IAgentChatDataChange, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentHostAuthTokenRequest, IAgentMaterializeSessionEvent, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSpawnChatEvent, AuthenticateParams, AuthenticateResult, IMcpNotification, IRestoredSubagentSession, SubagentChatSignal } from '../common/agentService.js';
+import { AgentProvider, AgentSession, AgentSignal, IAgent, IAgentChatDataChange, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentHostAuthTokenRequest, IAgentMaterializeSessionEvent, IAgentResolveSessionConfigParams, IAgentService, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSpawnChatEvent, AuthenticateParams, AuthenticateResult, IMcpNotification, IRestoredSubagentSession, SubagentChatSignal } from '../common/agentService.js';
 import { ISessionDataService, SESSION_ATTACHMENTS_DIRNAME } from '../common/sessionDataService.js';
 import { parseChangesetUri } from '../common/changesetUri.js';
-import { ActionType, ActionEnvelope, INotification, type ChatAction, type IRootConfigChangedAction, type SessionAction, type TerminalAction, type ClientAnnotationsAction } from '../common/state/sessionActions.js';
+import { ActionType, ActionEnvelope, AuthRequiredReason, INotification, type ChatAction, type IRootConfigChangedAction, type SessionAction, type TerminalAction, type ClientAnnotationsAction } from '../common/state/sessionActions.js';
 import type { CompletionsParams, CompletionsResult, CreateTerminalParams, ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../common/state/protocol/commands.js';
 import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } from '../common/state/protocol/channels-changeset/commands.js';
 import { AhpErrorCodes, AHP_SESSION_NOT_FOUND, ContentEncoding, JSON_RPC_INTERNAL_ERROR, ProtocolError, ResourceChangeType, ResourceType, ResourceWriteMode, type CreateResourceWatchParams, type CreateResourceWatchResult, type DirectoryEntry, type ResourceCopyParams, type ResourceCopyResult, type ResourceDeleteParams, type ResourceDeleteResult, type ResourceListResult, type ResourceMkdirParams, type ResourceMkdirResult, type ResourceMoveParams, type ResourceMoveResult, type ResourceReadResult, type ResourceResolveParams, type ResourceResolveResult, type ResourceWatchState, type ResourceWriteParams, type ResourceWriteResult, type IStateSnapshot } from '../common/state/sessionProtocol.js';
@@ -56,6 +56,7 @@ import { parseMcpChannelUri } from './shared/mcpCustomizationController.js';
 import { toAgentClientUri } from '../common/agentClientUri.js';
 import { AgentHostChangesetOperationService } from './agentHostChangesetOperationService.js';
 import { AgentHostGitStateService } from './agentHostGitStateService.js';
+import { AgentHostGitHubEndpointService, IAgentHostGitHubEndpointService } from './agentHostGitHubEndpointService.js';
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { NullTelemetryService } from '../../telemetry/common/telemetryUtils.js';
 import { AgentHostAuthenticationService } from './agentHostAuthenticationService.js';
@@ -153,6 +154,9 @@ export class AgentService extends Disposable implements IAgentService {
 	/** Exposes the configuration service so agent providers can share root config plumbing. */
 	get configurationService(): IAgentConfigurationService { return this._configurationService; }
 
+	/** Exposes the GitHub endpoint service so agent providers share GitHub (Enterprise) resource resolution. */
+	get gitHubEndpointService(): IAgentHostGitHubEndpointService { return this._gitHubEndpointService; }
+
 	/** Registered providers keyed by their {@link AgentProvider} id. */
 	private readonly _providers = new Map<AgentProvider, IAgent>();
 	/** Maps each active session URI (toString) to its owning provider. */
@@ -203,6 +207,8 @@ export class AgentService extends Disposable implements IAgentService {
 	/** Server-side host for the agent host's server tools. */
 	private readonly _serverToolHost: AgentServerToolHost;
 	private readonly _configurationService: IAgentConfigurationService;
+	/** Single source of truth for GitHub (Enterprise) endpoints and protected resources. */
+	private readonly _gitHubEndpointService: IAgentHostGitHubEndpointService;
 	/** Pluggable completion item providers (e.g. workspace file completions, agent-specific @-mentions). */
 	private readonly _completions: IAgentHostCompletions;
 	private _skillCompletionProviderRegistered = false;
@@ -313,6 +319,18 @@ export class AgentService extends Disposable implements IAgentService {
 			[ISessionDataService, this._sessionDataService],
 		);
 		const instantiationService = this._register(new InstantiationService(services, /*strict*/ true));
+		this._gitHubEndpointService = this._register(instantiationService.createInstance(AgentHostGitHubEndpointService));
+		services.set(IAgentHostGitHubEndpointService, this._gitHubEndpointService);
+		// A GitHub Enterprise URI change repoints every agent's GitHub resource
+		// identity to a different authorization server, so the client must obtain a
+		// token for the new resource. One root-channel `auth/required` covers all
+		// agents (the URI is host-level config).
+		this._register(this._gitHubEndpointService.onDidChange(() => {
+			this._stateManager.emitAuthRequired({
+				resource: this._gitHubEndpointService.getCopilotResource().resource,
+				reason: AuthRequiredReason.Required,
+			});
+		}));
 		const agentHostOctoKitService = instantiationService.createInstance(AgentHostOctoKitService, undefined);
 		services.set(IAgentHostOctoKitService, agentHostOctoKitService);
 		const effectiveCopilotApiService = copilotApiService ?? instantiationService.createInstance(CopilotApiService, undefined);
@@ -389,8 +407,8 @@ export class AgentService extends Disposable implements IAgentService {
 			copilotApiService: effectiveCopilotApiService,
 			getGitHubCopilotToken: () => {
 				return this.getAuthToken({
-					resource: GITHUB_COPILOT_PROTECTED_RESOURCE.resource,
-					scopes: GITHUB_COPILOT_PROTECTED_RESOURCE.scopes_supported,
+					resource: this._gitHubEndpointService.getCopilotResource().resource,
+					scopes: this._gitHubEndpointService.getCopilotResource().scopes_supported,
 				});
 			},
 			onTurnComplete: async session => {

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -26,7 +26,7 @@ import { createSchema, platformSessionSchema, schemaProperty } from '../../commo
 import { ClaudePermissionMode, ClaudeSessionConfigKey, narrowClaudePermissionMode } from '../../common/claudeSessionConfigKeys.js';
 import { createClaudeThinkingLevelSchema, isClaudeEffortLevel } from '../../common/claudeModelConfig.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
-import { AgentProvider, AgentSession, AgentSignal, CLAUDE_AGENT_PROVIDER_ID, GITHUB_COPILOT_PROTECTED_RESOURCE, GITHUB_REPO_PROTECTED_RESOURCE, IActiveClient, IAgent, IAgentChatDataChange, IAgentChats, IAgentCreateChatForkSource, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSessionProjectInfo, IAgentSpawnChatEvent, SubagentChatSignal } from '../../common/agentService.js';
+import { AgentProvider, AgentSession, AgentSignal, CLAUDE_AGENT_PROVIDER_ID, IActiveClient, IAgent, IAgentChatDataChange, IAgentChats, IAgentCreateChatForkSource, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSessionProjectInfo, IAgentSpawnChatEvent, SubagentChatSignal } from '../../common/agentService.js';
 import { ensureWorkspacelessScratchDir } from '../workspacelessScratchDir.js';
 import { ActionType, AuthRequiredReason, type AuthRequiredParams } from '../../common/state/sessionActions.js';
 import type { ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../../common/state/protocol/commands.js';
@@ -34,6 +34,7 @@ import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProt
 import { PolicyState, ProtectedResourceMetadata, type AgentSelection, type ModelSelection, type ToolDefinition } from '../../common/state/protocol/state.js';
 import { isSubagentSession, parseSubagentSessionUri, buildDefaultChatUri, parseChatUri, parseRequiredSessionUriFromChatUri, isDefaultChatUri, ChatInputResponseKind, type ClientPluginCustomization, type Customization, type MessageAttachment, type PendingMessage, type ChatInputAnswer, type ToolCallResult, type Turn } from '../../common/state/sessionState.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
+import { IAgentHostGitHubEndpointService } from '../agentHostGitHubEndpointService.js';
 import { IAgentHostGitService } from '../../common/agentHostGitService.js';
 import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
 import { projectFromCopilotContext } from '../copilot/copilotGitProject.js';
@@ -436,6 +437,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		@IClaudeAgentSdkService private readonly _sdkService: IClaudeAgentSdkService,
 		@IAgentHostGitService private readonly _gitService: IAgentHostGitService,
 		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
+		@IAgentHostGitHubEndpointService private readonly _gitHubEndpointService: IAgentHostGitHubEndpointService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IAgentPluginManager private readonly _pluginManager: IAgentPluginManager,
 		@IProductService private readonly _productService: IProductService,
@@ -470,7 +472,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 				// fires only when a credential is genuinely missing.
 				if (next === 'proxy' && !this._proxyHandle) {
 					this._onDidRequireAuth.fire({
-						resource: GITHUB_COPILOT_PROTECTED_RESOURCE.resource,
+						resource: this._gitHubEndpointService.getCopilotResource().resource,
 						reason: AuthRequiredReason.Required,
 					});
 				}
@@ -511,11 +513,11 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		// the Anthropic credential — so the required Copilot resource is dropped.
 		// The optional repo resource is kept for git operations either way.
 		if (this._transportMode !== 'proxy') {
-			return [GITHUB_REPO_PROTECTED_RESOURCE];
+			return [this._gitHubEndpointService.getRepoResource()];
 		}
 		return [
-			GITHUB_COPILOT_PROTECTED_RESOURCE,
-			GITHUB_REPO_PROTECTED_RESOURCE,
+			this._gitHubEndpointService.getCopilotResource(),
+			this._gitHubEndpointService.getRepoResource(),
 		];
 	}
 
@@ -540,10 +542,10 @@ export class ClaudeAgent extends Disposable implements IAgent {
 	}
 
 	async authenticate(resource: string, token: string): Promise<boolean> {
-		if (resource === GITHUB_REPO_PROTECTED_RESOURCE.resource) {
+		if (resource === this._gitHubEndpointService.getRepoResource().resource) {
 			return true;
 		}
-		if (resource !== GITHUB_COPILOT_PROTECTED_RESOURCE.resource) {
+		if (resource !== this._gitHubEndpointService.getCopilotResource().resource) {
 			return false;
 		}
 		// Native (BYO-Anthropic) mode needs no proxy and no GitHub token. Record

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -19,7 +19,7 @@ import { IProductService } from '../../../product/common/productService.js';
 import { createSchema, platformSessionSchema, schemaProperty, type SessionMode } from '../../common/agentHostSchema.js';
 import { createPricingMetaFromBilling, normalizeCAPIBilling } from '../../common/agentModelPricing.js';
 import { getReasoningEffortDescription, getReasoningEffortLabel } from '../../common/reasoningEffort.js';
-import { AgentHostCodexAgentBinaryArgsEnvVar, AgentHostCodexAgentCodexHomeEnvVar, AgentHostCodexAgentSdkRootEnvVar, AgentSession, AgentSignal, GITHUB_COPILOT_PROTECTED_RESOURCE, GITHUB_REPO_PROTECTED_RESOURCE, IActiveClient, IAgent, IAgentChats, IAgentCreateChatForkSource, IAgentCreateChatResult, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IMcpNotification, type AgentProvider } from '../../common/agentService.js';
+import { AgentHostCodexAgentBinaryArgsEnvVar, AgentHostCodexAgentCodexHomeEnvVar, AgentHostCodexAgentSdkRootEnvVar, AgentSession, AgentSignal, IActiveClient, IAgent, IAgentChats, IAgentCreateChatForkSource, IAgentCreateChatResult, IAgentCreateChatOptions, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IMcpNotification, type AgentProvider } from '../../common/agentService.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProtocol.js';
 import { ActionType, isChatAction, type SessionAction, type ChatAction } from '../../common/state/sessionActions.js';
@@ -33,6 +33,7 @@ import { buildCodexMcpReadResult, codexMcpListToInventory, codexMcpToolsChanged,
 import { buildElicitationRequest, cancelledElicitationResponse, declinedElicitationResponse, elicitationResponseFromAnswers } from './codexElicitationMapper.js';
 import type { AhpMcpUiHostCapabilities, Customization } from '../../common/state/protocol/channels-session/state.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
+import { IAgentHostGitHubEndpointService } from '../agentHostGitHubEndpointService.js';
 import { ICopilotApiService } from '../shared/copilotApiService.js';
 import { extractForwardedErrorInfo } from '../shared/forwardedChatError.js';
 import { IAgentSdkDownloader, IAgentSdkPackage } from '../agentSdkDownloader.js';
@@ -584,6 +585,7 @@ export class CodexAgent extends Disposable implements IAgent {
 		@ICopilotApiService private readonly _copilotApiService: ICopilotApiService,
 		@ICodexProxyService private readonly _codexProxyService: ICodexProxyService,
 		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
+		@IAgentHostGitHubEndpointService private readonly _gitHubEndpointService: IAgentHostGitHubEndpointService,
 		@IAgentSdkDownloader private readonly _agentSdkDownloader: IAgentSdkDownloader,
 		@IProductService private readonly _productService: IProductService,
 		@IInstantiationService instantiationService: IInstantiationService,
@@ -596,16 +598,16 @@ export class CodexAgent extends Disposable implements IAgent {
 
 	getProtectedResources(): ProtectedResourceMetadata[] {
 		return [
-			GITHUB_COPILOT_PROTECTED_RESOURCE,
-			GITHUB_REPO_PROTECTED_RESOURCE
+			this._gitHubEndpointService.getCopilotResource(),
+			this._gitHubEndpointService.getRepoResource()
 		];
 	}
 
 	async authenticate(resource: string, token: string): Promise<boolean> {
-		if (resource === GITHUB_REPO_PROTECTED_RESOURCE.resource) {
+		if (resource === this._gitHubEndpointService.getRepoResource().resource) {
 			return true;
 		}
-		if (resource !== GITHUB_COPILOT_PROTECTED_RESOURCE.resource) {
+		if (resource !== this._gitHubEndpointService.getCopilotResource().resource) {
 			return false;
 		}
 		const changed = this._githubToken !== token;

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -38,7 +38,7 @@ import { CopilotCliConfigKey, copilotCliConfigSchema } from '../../common/copilo
 import { AgentHostMcpServersConfigKey, AgentHostSessionSyncEnabledConfigKey, AutoApproveLevel, ISchemaProperty, SessionMode, createSchema, migrateLegacyAutopilotConfig, platformRootSchema, platformSessionSchema, schemaProperty, type AgentHostMcpServers } from '../../common/agentHostSchema.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { AgentSessionEntry, decodeProviderData, encodeProviderData, type IPersistedChat } from '../agentPeerChats.js';
-import { AgentSession, AgentSignal, AuthenticateParams, GITHUB_COPILOT_PROTECTED_RESOURCE, GITHUB_REPO_PROTECTED_RESOURCE, IActiveClient, IAgent, IAgentChatDataChange, IAgentChats, IAgentLegacyChat, IAgentCreateChatForkSource, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSessionProjectInfo, IAgentSpawnChatEvent, IMcpNotification, IRestoredSubagentSession, SubagentChatSignal } from '../../common/agentService.js';
+import { AgentSession, AgentSignal, AuthenticateParams, IActiveClient, IAgent, IAgentChatDataChange, IAgentChats, IAgentLegacyChat, IAgentCreateChatForkSource, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSessionProjectInfo, IAgentSpawnChatEvent, IMcpNotification, IRestoredSubagentSession, SubagentChatSignal } from '../../common/agentService.js';
 import { getReasoningEffortDescription, getReasoningEffortLabel } from '../../common/reasoningEffort.js';
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
 import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
@@ -51,6 +51,7 @@ import { ActionType, type SessionAction } from '../../common/state/sessionAction
 import { AgentCustomization, CustomizationLoadStatus, CustomizationType, ResponsePartKind, RuleCustomization, ChatInputResponseKind, SkillCustomization, customizationId, buildChatUri, buildDefaultChatUri, isDefaultChatUri, parseChatUri, parseRequiredSessionUriFromChatUri, parseSubagentSessionUri, AH_META_WORKSPACELESS_DB_KEY, type ChildCustomization, type ClientPluginCustomization, type Customization, type DirectoryCustomization, type HookCustomization, type MessageAttachment, type PendingMessage, type PluginCustomization, type PolicyState, type ResponsePart, type ChatInputAnswer, type ToolCallResult, type Turn } from '../../common/state/sessionState.js';
 import { ActiveClientToolSet } from '../activeClientState.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
+import { IAgentHostGitHubEndpointService } from '../agentHostGitHubEndpointService.js';
 import { IAgentHostCompletions } from '../agentHostCompletions.js';
 import { IAgentHostGitService, META_DIFF_BASE_BRANCH } from '../../common/agentHostGitService.js';
 import { findMcpChildId, type IMcpServerRuntimeState } from '../shared/mcpCustomizationController.js';
@@ -478,6 +479,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		@ISessionDataService private readonly _sessionDataService: ISessionDataService,
 		@IAgentHostGitService private readonly _gitService: IAgentHostGitService,
 		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
+		@IAgentHostGitHubEndpointService private readonly _gitHubEndpointService: IAgentHostGitHubEndpointService,
 		@IAgentHostOTelService private readonly _otelService: IAgentHostOTelService,
 		@ICopilotBranchNameGenerator private readonly _branchNameGenerator: ICopilotBranchNameGenerator,
 		@IAgentHostCompletions completions: IAgentHostCompletions,
@@ -524,6 +526,19 @@ export class CopilotAgent extends Disposable implements IAgent {
 			this._logService.info('[Copilot] BYOK bridge changed; refreshing models');
 			this._refreshByokModels();
 		}));
+
+		// `COPILOT_GH_HOST` is a subprocess env var (applied in `_ensureClient`) the
+		// CLI reads only at spawn time. When the configured GitHub Enterprise host
+		// changes - notably the startup race where the workbench pushes
+		// `githubEnterpriseUri` just after the client's initial spawn - restart the
+		// client so it comes up pointed at the right host. Driven off the endpoint
+		// service's `onDidChange` (which fires after its endpoints are recomputed)
+		// rather than the raw config event, so `getEnterpriseHost()` is current here.
+		this._register(this._gitHubEndpointService.onDidChange(() => {
+			this._restartClientIfStartupConfigChanged().catch(err =>
+				this._logService.error('[Copilot] Failed to restart client after endpoint change', err)
+			);
+		}));
 	}
 
 	/**
@@ -543,6 +558,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 	private _lastSessionSyncEnabled: boolean = this._isSessionSyncEnabled();
 	private _lastRubberDuckEnabled: boolean = this._isRubberDuckEnabled();
+	private _lastEnterpriseHost: string | undefined = this._gitHubEndpointService.getEnterpriseHost();
 
 	private _isSessionSyncEnabled(): boolean {
 		return this._configurationService.getRootValue(platformRootSchema, AgentHostSessionSyncEnabledConfigKey) === true;
@@ -555,24 +571,28 @@ export class CopilotAgent extends Disposable implements IAgent {
 	/**
 	 * Restarts the CLI client when a config value that is only read at client
 	 * startup ({@link _isSessionSyncEnabled} client option, {@link _isRubberDuckEnabled}
-	 * subprocess env var) has changed. Any active sessions are disposed before
-	 * the client is stopped; the latest values are picked up the next time
-	 * {@link _ensureClient} runs. If the client is still starting up, the
-	 * in-flight start detects the change against {@link _lastSessionSyncEnabled} /
-	 * {@link _lastRubberDuckEnabled} and aborts so it never comes up stale.
+	 * subprocess env var, or the `COPILOT_GH_HOST` enterprise host env var) has
+	 * changed. Any active sessions are disposed before the client is stopped; the
+	 * latest values are picked up the next time {@link _ensureClient} runs. If the
+	 * client is still starting up, the in-flight start detects the change against
+	 * {@link _lastSessionSyncEnabled} / {@link _lastRubberDuckEnabled} /
+	 * {@link _lastEnterpriseHost} and aborts so it never comes up stale.
 	 */
 	private async _restartClientIfStartupConfigChanged(): Promise<void> {
 		const sessionSync = this._isSessionSyncEnabled();
 		const rubberDuck = this._isRubberDuckEnabled();
-		if (this._lastSessionSyncEnabled === sessionSync && this._lastRubberDuckEnabled === rubberDuck) {
+		const enterpriseHost = this._gitHubEndpointService.getEnterpriseHost();
+		if (this._lastSessionSyncEnabled === sessionSync && this._lastRubberDuckEnabled === rubberDuck && this._lastEnterpriseHost === enterpriseHost) {
 			return;
 		}
 		const changed = [
 			this._lastSessionSyncEnabled !== sessionSync ? `sessionSync=${sessionSync}` : undefined,
 			this._lastRubberDuckEnabled !== rubberDuck ? `rubberDuck=${rubberDuck}` : undefined,
+			this._lastEnterpriseHost !== enterpriseHost ? `enterpriseHost=${enterpriseHost}` : undefined,
 		].filter((v): v is string => v !== undefined).join(', ');
 		this._lastSessionSyncEnabled = sessionSync;
 		this._lastRubberDuckEnabled = rubberDuck;
+		this._lastEnterpriseHost = enterpriseHost;
 		if (this._client) {
 			this._logService.info(`[Copilot] Startup config changed (${changed}), restarting CopilotClient`);
 			this._sessions.clearAndDisposeAll();
@@ -598,8 +618,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 	getProtectedResources(): ProtectedResourceMetadata[] {
 		return [
-			GITHUB_COPILOT_PROTECTED_RESOURCE,
-			GITHUB_REPO_PROTECTED_RESOURCE
+			this._gitHubEndpointService.getCopilotResource(),
+			this._gitHubEndpointService.getRepoResource()
 		];
 	}
 
@@ -644,10 +664,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 	}
 
 	async authenticate(resource: string, token: string): Promise<boolean> {
-		if (resource === GITHUB_REPO_PROTECTED_RESOURCE.resource) {
+		if (resource === this._gitHubEndpointService.getRepoResource().resource) {
 			return true;
 		}
-		if (resource !== GITHUB_COPILOT_PROTECTED_RESOURCE.resource) {
+		if (resource !== this._gitHubEndpointService.getCopilotResource().resource) {
 			return false;
 		}
 		const tokenChanged = this._githubToken !== token;
@@ -873,6 +893,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		// into the client options / subprocess env below).
 		const sessionSyncAtStartup = this._isSessionSyncEnabled();
 		const rubberDuckAtStartup = this._isRubberDuckEnabled();
+		const enterpriseHostAtStartup = this._gitHubEndpointService.getEnterpriseHost();
 		const clientStarting = (async () => {
 			this._logService.info('[Copilot] Starting CopilotClient...');
 
@@ -918,8 +939,19 @@ export class CopilotAgent extends Disposable implements IAgent {
 			}
 
 			// Identify VS Code's agent host traffic in CAPI
-			env['GITHUB_COPILOT_INTEGRATION_ID'] = COPILOT_INTEGRATION_ID;
-			this._logService.info(`[Copilot] Set CLI env: GITHUB_COPILOT_INTEGRATION_ID=${COPILOT_INTEGRATION_ID}`);
+			// [TEMP] integration-id disabled to test enterprise model enumeration
+			// env['GITHUB_COPILOT_INTEGRATION_ID'] = COPILOT_INTEGRATION_ID;
+			// this._logService.info(`[Copilot] Set CLI env: GITHUB_COPILOT_INTEGRATION_ID=${COPILOT_INTEGRATION_ID}`);
+
+			// Point the Copilot CLI at a configured GitHub Enterprise host for its
+			// authentication and CAPI endpoint discovery. `COPILOT_GH_HOST` is
+			// Copilot-CLI-specific (it does not affect the `gh` CLI). Unset for
+			// github.com so the CLI uses its default host.
+			const enterpriseHost = this._gitHubEndpointService.getEnterpriseHost();
+			if (enterpriseHost) {
+				env['COPILOT_GH_HOST'] = enterpriseHost;
+				this._logService.info(`[Copilot] Set CLI env: COPILOT_GH_HOST=${enterpriseHost}`);
+			}
 
 			// Enable the rubber duck critic subagent in the CLI when the agent host
 			// config opts in. `RUBBER_DUCK_AGENT` is the SDK's required interface for
@@ -965,7 +997,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			};
 			const client = this._createCopilotClient(clientOptions);
 			await client.start();
-			if (this._isSessionSyncEnabled() !== sessionSyncAtStartup || this._isRubberDuckEnabled() !== rubberDuckAtStartup) {
+			if (this._isSessionSyncEnabled() !== sessionSyncAtStartup || this._isRubberDuckEnabled() !== rubberDuckAtStartup || this._gitHubEndpointService.getEnterpriseHost() !== enterpriseHostAtStartup) {
 				await client.stop();
 				throw new Error('Copilot startup config changed while the client was starting');
 			}

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -939,9 +939,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 			}
 
 			// Identify VS Code's agent host traffic in CAPI
-			// [TEMP] integration-id disabled to test enterprise model enumeration
-			// env['GITHUB_COPILOT_INTEGRATION_ID'] = COPILOT_INTEGRATION_ID;
-			// this._logService.info(`[Copilot] Set CLI env: GITHUB_COPILOT_INTEGRATION_ID=${COPILOT_INTEGRATION_ID}`);
+			env['GITHUB_COPILOT_INTEGRATION_ID'] = COPILOT_INTEGRATION_ID;
+			this._logService.info(`[Copilot] Set CLI env: GITHUB_COPILOT_INTEGRATION_ID=${COPILOT_INTEGRATION_ID}`);
 
 			// Point the Copilot CLI at a configured GitHub Enterprise host for its
 			// authentication and CAPI endpoint discovery. `COPILOT_GH_HOST` is

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -558,7 +558,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 	private _lastSessionSyncEnabled: boolean = this._isSessionSyncEnabled();
 	private _lastRubberDuckEnabled: boolean = this._isRubberDuckEnabled();
-	private _lastEnterpriseHost: string | undefined = this._gitHubEndpointService.getEnterpriseHost();
+	private _lastEnterpriseHost: string | undefined = this._getEnterpriseHost();
 
 	private _isSessionSyncEnabled(): boolean {
 		return this._configurationService.getRootValue(platformRootSchema, AgentHostSessionSyncEnabledConfigKey) === true;
@@ -566,6 +566,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 	private _isRubberDuckEnabled(): boolean {
 		return this._configurationService.getRootValue(copilotCliConfigSchema, CopilotCliConfigKey.RubberDuck) === true;
+	}
+
+	private _getEnterpriseHost(): string | undefined {
+		return this._gitHubEndpointService.getEnterpriseHost();
 	}
 
 	/**
@@ -581,7 +585,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	private async _restartClientIfStartupConfigChanged(): Promise<void> {
 		const sessionSync = this._isSessionSyncEnabled();
 		const rubberDuck = this._isRubberDuckEnabled();
-		const enterpriseHost = this._gitHubEndpointService.getEnterpriseHost();
+		const enterpriseHost = this._getEnterpriseHost();
 		if (this._lastSessionSyncEnabled === sessionSync && this._lastRubberDuckEnabled === rubberDuck && this._lastEnterpriseHost === enterpriseHost) {
 			return;
 		}
@@ -893,7 +897,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		// into the client options / subprocess env below).
 		const sessionSyncAtStartup = this._isSessionSyncEnabled();
 		const rubberDuckAtStartup = this._isRubberDuckEnabled();
-		const enterpriseHostAtStartup = this._gitHubEndpointService.getEnterpriseHost();
+		const enterpriseHostAtStartup = this._getEnterpriseHost();
 		const clientStarting = (async () => {
 			this._logService.info('[Copilot] Starting CopilotClient...');
 
@@ -946,7 +950,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			// authentication and CAPI endpoint discovery. `COPILOT_GH_HOST` is
 			// Copilot-CLI-specific (it does not affect the `gh` CLI). Unset for
 			// github.com so the CLI uses its default host.
-			const enterpriseHost = this._gitHubEndpointService.getEnterpriseHost();
+			const enterpriseHost = this._getEnterpriseHost();
 			if (enterpriseHost) {
 				env['COPILOT_GH_HOST'] = enterpriseHost;
 				this._logService.info(`[Copilot] Set CLI env: COPILOT_GH_HOST=${enterpriseHost}`);
@@ -996,7 +1000,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			};
 			const client = this._createCopilotClient(clientOptions);
 			await client.start();
-			if (this._isSessionSyncEnabled() !== sessionSyncAtStartup || this._isRubberDuckEnabled() !== rubberDuckAtStartup || this._gitHubEndpointService.getEnterpriseHost() !== enterpriseHostAtStartup) {
+			if (this._isSessionSyncEnabled() !== sessionSyncAtStartup || this._isRubberDuckEnabled() !== rubberDuckAtStartup || this._getEnterpriseHost() !== enterpriseHostAtStartup) {
 				await client.stop();
 				throw new Error('Copilot startup config changed while the client was starting');
 			}

--- a/src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts
+++ b/src/vs/platform/agentHost/node/shared/agentHostOctoKitService.ts
@@ -6,6 +6,7 @@
 import { LRUCache } from '../../../../base/common/map.js';
 import { createDecorator } from '../../../instantiation/common/instantiation.js';
 import { ILogService } from '../../../log/common/log.js';
+import { IAgentHostGitHubEndpointService } from '../agentHostGitHubEndpointService.js';
 
 export type FetchFunction = typeof globalThis.fetch;
 
@@ -95,7 +96,6 @@ export interface IAgentHostOctoKitService {
 
 export const IAgentHostOctoKitService = createDecorator<IAgentHostOctoKitService>('agentHostOctoKitService');
 
-const GITHUB_API_HOST = 'https://api.github.com';
 const GITHUB_API_VERSION = '2022-11-28';
 const MAX_ERROR_RESPONSE_BODY_LENGTH = 500;
 
@@ -119,6 +119,7 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 	constructor(
 		fetchFn: FetchFunction | undefined,
 		@ILogService private readonly _logService: ILogService,
+		@IAgentHostGitHubEndpointService private readonly _endpoint: IAgentHostGitHubEndpointService,
 	) {
 		this._fetch = fetchFn ?? globalThis.fetch;
 	}
@@ -197,7 +198,7 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 		body?: Record<string, unknown>,
 		etag?: string
 	): Promise<IGitHubApiResponse<T>> {
-		const url = `${GITHUB_API_HOST}/${routeSlug}`;
+		const url = `${this._endpoint.getApiBaseUri()}/${routeSlug}`;
 		const headers: Record<string, string> = {
 			'Accept': 'application/vnd.github+json',
 			'Authorization': `Bearer ${token}`,
@@ -267,7 +268,7 @@ export class AgentHostOctoKitService implements IAgentHostOctoKitService {
 		token: string,
 		signal: AbortSignal,
 	): Promise<unknown> {
-		const url = `${GITHUB_API_HOST}/graphql`;
+		const url = this._endpoint.getGraphQlUri();
 		const headers: Record<string, string> = {
 			'Accept': 'application/json',
 			'Authorization': `Bearer ${token}`,

--- a/src/vs/platform/agentHost/node/shared/copilotApiService.ts
+++ b/src/vs/platform/agentHost/node/shared/copilotApiService.ts
@@ -8,6 +8,7 @@ import { CAPIClient, RequestType, type CCAModel, type IExtensionInformation } fr
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { getDevDeviceId, getMachineId } from '../../../../base/node/id.js';
 import { createDecorator } from '../../../instantiation/common/instantiation.js';
+import { IAgentHostGitHubEndpointService } from '../agentHostGitHubEndpointService.js';
 import { ILogService } from '../../../log/common/log.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { COPILOT_LICENSE_AGREEMENT } from '../../../endpoint/common/licenseAgreement.js';
@@ -526,6 +527,7 @@ export class CopilotApiService implements ICopilotApiService {
 		fetchFn: FetchFunction | undefined,
 		@ILogService private readonly _logService: ILogService,
 		@IProductService private readonly _productService: IProductService,
+		@IAgentHostGitHubEndpointService private readonly _gitHubEndpointService: IAgentHostGitHubEndpointService,
 	) {
 		this._fetch = fetchFn ?? globalThis.fetch;
 	}
@@ -723,10 +725,13 @@ export class CopilotApiService implements ICopilotApiService {
 			buildType: this._productService.quality === 'stable' ? 'prod' : 'dev',
 		};
 
-		// The user-info endpoint is hosted on api.github.com for consumer accounts.
-		// For GitHub Enterprise the host changes, but we don't currently support
-		// GHE in the agent host — see CopilotAgent for the same assumption.
-		const userUrl = 'https://api.github.com/copilot_internal/user';
+		// Copilot endpoint discovery: GET `/copilot_internal/user` on the GitHub API
+		// host. For GitHub Enterprise the host is derived from `githubEnterpriseUri`
+		// (via the endpoint service); the response's `endpoints.api` then carries the
+		// enterprise CAPI base that CAPIClient routes through. Defaults to
+		// api.github.com when no enterprise URI is set. (GHE Cloud `*.ghe.com` is
+		// handled; GHE Server on-prem `/copilot_internal` routing is unverified.)
+		const userUrl = `${this._gitHubEndpointService.getApiBaseUri()}/copilot_internal/user`;
 
 		return { extensionInfo, userUrl };
 	}
@@ -945,7 +950,12 @@ export class CopilotApiService implements ICopilotApiService {
 
 		capiClient.updateDomains(
 			{ endpoints: envelope.endpoints ?? {}, sku: envelope.access_type_sku ?? '' },
-			undefined,
+			// Enterprise base URI (e.g. `https://acme.ghe.com`), or `undefined` for
+			// github.com. The package derives the GitHub API host (`api.<host>`) from
+			// this for `copilot_internal` endpoints - notably the Copilot session
+			// token mint (`/copilot_internal/v2/token`). Omitting it strands the mint
+			// on `api.github.com`, which 401s an enterprise token ("Bad credentials").
+			this._gitHubEndpointService.getEnterpriseUri(),
 		);
 
 		this._logService.debug('[CopilotApiService] CAPI endpoint discovered, api=', envelope.endpoints?.api);

--- a/src/vs/platform/agentHost/test/common/githubEndpoints.test.ts
+++ b/src/vs/platform/agentHost/test/common/githubEndpoints.test.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { GITHUB_COPILOT_PROTECTED_RESOURCE, GITHUB_REPO_PROTECTED_RESOURCE } from '../../common/agentService.js';
+import { deriveGitHubEndpoints, gitHubCopilotResource, gitHubRepoResource } from '../../common/githubEndpoints.js';
+
+suite('githubEndpoints', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const DOT_COM = {
+		apiBaseUri: 'https://api.github.com',
+		graphQlUri: 'https://api.github.com/graphql',
+		oauthServer: 'https://github.com/login/oauth',
+		enterpriseHost: undefined,
+	};
+
+	test('deriveGitHubEndpoints: github.com defaults for unset / empty / unparseable / github.com host', () => {
+		assert.deepStrictEqual({
+			unset: deriveGitHubEndpoints(undefined),
+			empty: deriveGitHubEndpoints(''),
+			garbage: deriveGitHubEndpoints('not a uri'),
+			dotCom: deriveGitHubEndpoints('https://github.com'),
+			apiDotCom: deriveGitHubEndpoints('https://api.github.com'),
+		}, {
+			unset: DOT_COM,
+			empty: DOT_COM,
+			garbage: DOT_COM,
+			dotCom: DOT_COM,
+			apiDotCom: DOT_COM,
+		});
+	});
+
+	test('deriveGitHubEndpoints: GitHub Enterprise Cloud (.ghe.com) uses the api. subdomain', () => {
+		assert.deepStrictEqual(deriveGitHubEndpoints('https://acme.ghe.com'), {
+			apiBaseUri: 'https://api.acme.ghe.com',
+			graphQlUri: 'https://api.acme.ghe.com/graphql',
+			oauthServer: 'https://acme.ghe.com/login/oauth',
+			enterpriseHost: 'acme.ghe.com',
+		});
+	});
+
+	test('deriveGitHubEndpoints: GitHub Enterprise Server uses /api/v3 and /api/graphql', () => {
+		// The GraphQL endpoint is `/api/graphql`, NOT `apiBaseUri + /graphql`
+		// (which would give the wrong `/api/v3/graphql`).
+		assert.deepStrictEqual(deriveGitHubEndpoints('https://ghe.acme.com'), {
+			apiBaseUri: 'https://ghe.acme.com/api/v3',
+			graphQlUri: 'https://ghe.acme.com/api/graphql',
+			oauthServer: 'https://ghe.acme.com/login/oauth',
+			enterpriseHost: 'ghe.acme.com',
+		});
+	});
+
+	test('deriveGitHubEndpoints: preserves scheme and ignores path', () => {
+		assert.deepStrictEqual(deriveGitHubEndpoints('http://ghe.local/some/path'), {
+			apiBaseUri: 'http://ghe.local/api/v3',
+			graphQlUri: 'http://ghe.local/api/graphql',
+			oauthServer: 'http://ghe.local/login/oauth',
+			enterpriseHost: 'ghe.local',
+		});
+	});
+
+	test('resource builders derive resource + authorization_servers from endpoints', () => {
+		const endpoints = deriveGitHubEndpoints('https://ghe.acme.com');
+		assert.deepStrictEqual({
+			copilot: gitHubCopilotResource(endpoints),
+			repo: gitHubRepoResource(endpoints),
+		}, {
+			copilot: {
+				resource: 'https://ghe.acme.com/api/v3',
+				resource_name: 'GitHub Copilot',
+				authorization_servers: ['https://ghe.acme.com/login/oauth'],
+				scopes_supported: ['read:user', 'user:email'],
+				required: true,
+			},
+			repo: {
+				resource: 'https://ghe.acme.com/api/v3/repos',
+				resource_name: 'GitHub Repository',
+				authorization_servers: ['https://ghe.acme.com/login/oauth'],
+				scopes_supported: ['repo'],
+				required: false,
+			},
+		});
+	});
+
+	test('github.com resources are byte-for-byte the canonical protected-resource constants', () => {
+		// Backward-compat invariant: with no enterprise URI, token-store keys and
+		// advertised metadata must be unchanged for the common non-enterprise case.
+		const endpoints = deriveGitHubEndpoints(undefined);
+		assert.deepStrictEqual({
+			copilot: gitHubCopilotResource(endpoints),
+			repo: gitHubRepoResource(endpoints),
+		}, {
+			copilot: GITHUB_COPILOT_PROTECTED_RESOURCE,
+			repo: GITHUB_REPO_PROTECTED_RESOURCE,
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentHostCommitOperationHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostCommitOperationHandler.test.ts
@@ -15,6 +15,7 @@ import { buildUncommittedChangesetUri } from '../../common/changesetUri.js';
 import { SessionStatus, withSessionGitState, type ISessionFileDiff } from '../../common/state/sessionState.js';
 import type { IAgentHostGitService } from '../../common/agentHostGitService.js';
 import { AgentHostCommitOperationHandler } from '../../node/agentHostCommitOperationHandler.js';
+import { createTestGitHubEndpointService } from './testGitHubEndpointService.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 import { CopilotApiError, type ICopilotApiService, type ICopilotApiServiceRequestOptions, type ICopilotUtilityChatCompletionRequest } from '../../node/shared/copilotApiService.js';
 import { GITHUB_COPILOT_PROTECTED_RESOURCE, IAgentService } from '../../common/agentService.js';
@@ -159,7 +160,7 @@ function setup(disposables: Pick<DisposableStore, 'add'>, gitService: TestGitSer
 			if (options?.onCommittedError) {
 				throw options.onCommittedError;
 			}
-		}, createAgentService('gh-repo-token'), gitService, copilotApiService, new NullLogService()),
+		}, createAgentService('gh-repo-token'), createTestGitHubEndpointService(), gitService, copilotApiService, new NullLogService()),
 		session,
 		committedSessions,
 	};

--- a/src/vs/platform/agentHost/test/node/agentHostGitHubEndpointService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitHubEndpointService.test.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { AgentHostConfigKey } from '../../common/agentHostCustomizationConfig.js';
+import { AgentConfigurationService } from '../../node/agentConfigurationService.js';
+import { AgentHostGitHubEndpointService } from '../../node/agentHostGitHubEndpointService.js';
+import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
+
+suite('AgentHostGitHubEndpointService', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createService(enterpriseUri?: string): { service: AgentHostGitHubEndpointService; configService: AgentConfigurationService } {
+		const logService = new NullLogService();
+		const stateManager = disposables.add(new AgentHostStateManager(logService));
+		const configService = disposables.add(new AgentConfigurationService(stateManager, logService));
+		if (enterpriseUri !== undefined) {
+			configService.updateRootConfig({ [AgentHostConfigKey.GithubEnterpriseUri]: enterpriseUri });
+		}
+		const service = disposables.add(new AgentHostGitHubEndpointService(configService, logService));
+		return { service, configService };
+	}
+
+	function snapshot(service: AgentHostGitHubEndpointService) {
+		return {
+			api: service.getApiBaseUri(),
+			graphql: service.getGraphQlUri(),
+			copilotResource: service.getCopilotResource().resource,
+			repoResource: service.getRepoResource().resource,
+			oauth: service.getCopilotResource().authorization_servers,
+			enterpriseHost: service.getEnterpriseHost(),
+		};
+	}
+
+	test('defaults to github.com when unset', () => {
+		const { service } = createService();
+		assert.deepStrictEqual(snapshot(service), {
+			api: 'https://api.github.com',
+			graphql: 'https://api.github.com/graphql',
+			copilotResource: 'https://api.github.com',
+			repoResource: 'https://api.github.com/repos',
+			oauth: ['https://github.com/login/oauth'],
+			enterpriseHost: undefined,
+		});
+	});
+
+	test('computes enterprise resources and endpoints when set', () => {
+		const { service } = createService('https://ghe.acme.com');
+		assert.deepStrictEqual(snapshot(service), {
+			api: 'https://ghe.acme.com/api/v3',
+			graphql: 'https://ghe.acme.com/api/graphql',
+			copilotResource: 'https://ghe.acme.com/api/v3',
+			repoResource: 'https://ghe.acme.com/api/v3/repos',
+			oauth: ['https://ghe.acme.com/login/oauth'],
+			enterpriseHost: 'ghe.acme.com',
+		});
+	});
+
+	test('onDidChange fires only when the enterprise URI actually changes', () => {
+		const { service, configService } = createService();
+		let fires = 0;
+		disposables.add(service.onDidChange(() => fires++));
+
+		// An unrelated root-config change must NOT fire.
+		configService.updateRootConfig({ [AgentHostConfigKey.ClaudeUseCopilotProxy]: false });
+		assert.strictEqual(fires, 0);
+
+		// Setting the enterprise URI fires once and repoints the endpoints.
+		configService.updateRootConfig({ [AgentHostConfigKey.GithubEnterpriseUri]: 'https://ghe.acme.com' });
+		assert.strictEqual(fires, 1);
+		assert.strictEqual(service.getApiBaseUri(), 'https://ghe.acme.com/api/v3');
+
+		// Re-applying the same URI must NOT fire again.
+		configService.updateRootConfig({ [AgentHostConfigKey.GithubEnterpriseUri]: 'https://ghe.acme.com' });
+		assert.strictEqual(fires, 1);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitStateService.test.ts
@@ -13,6 +13,7 @@ import type { IAgentService } from '../../common/agentService.js';
 import { readSessionGitHubState, readSessionGitState, withSessionGitState, SessionStatus, type ISessionGitState, type SessionSummary } from '../../common/state/sessionState.js';
 import { META_GIT_STATE } from '../../common/agentHostGitStateService.js';
 import { AgentHostGitStateService } from '../../node/agentHostGitStateService.js';
+import { createTestGitHubEndpointService } from './testGitHubEndpointService.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 import type { IAgentHostOctoKitService } from '../../node/shared/agentHostOctoKitService.js';
 import { TestSessionDatabase, createNoopGitService, createSessionDataService } from '../common/sessionTestHelpers.js';
@@ -50,6 +51,7 @@ suite('AgentHostGitStateService', () => {
 			gitService,
 			{} as unknown as IAgentHostOctoKitService,
 			{} as unknown as IAgentService,
+			createTestGitHubEndpointService(),
 			new NullLogService(),
 			sessionDataService,
 		));

--- a/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationHandler.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostPullRequestOperationHandler.test.ts
@@ -14,6 +14,7 @@ import { buildSessionChangesetUri } from '../../common/changesetUri.js';
 import { withSessionGitHubState, withSessionGitState, type ISessionFileDiff, MessageKind, ResponsePartKind, SessionStatus, TurnState, type Turn } from '../../common/state/sessionState.js';
 import type { IAgentHostGitService, IPushOptions } from '../../common/agentHostGitService.js';
 import { AgentHostPullRequestOperationHandler } from '../../node/agentHostPullRequestOperationHandler.js';
+import { createTestGitHubEndpointService } from './testGitHubEndpointService.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 import type { AutoMergeMethod, CreatedPullRequest, IAgentHostOctoKitService } from '../../node/shared/agentHostOctoKitService.js';
 import type { ICopilotApiService, ICopilotApiServiceRequestOptions, ICopilotUtilityChatCompletionRequest } from '../../node/shared/copilotApiService.js';
@@ -189,7 +190,7 @@ function setup(disposables: Pick<DisposableStore, 'add'>, gitService: TestGitSer
 				return state;
 			},
 			event => createdEvents.push(`${event.sessionKey}:${event.pullRequestUrl}`),
-			createAgentService(options?.withCopilotToken), gitService, octoKitService, copilotApiService, new NullLogService()),
+			createAgentService(options?.withCopilotToken), gitService, octoKitService, createTestGitHubEndpointService(), copilotApiService, new NullLogService()),
 		session,
 		createdEvents,
 		copilotApiService,

--- a/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.integrationTest.ts
@@ -54,6 +54,8 @@ import { ActionType } from '../../common/state/sessionActions.js';
 import { ResponsePartKind, ToolResultContentType, type ClientPluginCustomization } from '../../common/state/sessionState.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
 import { AgentConfigurationService, IAgentConfigurationService } from '../../node/agentConfigurationService.js';
+import { IAgentHostGitHubEndpointService } from '../../node/agentHostGitHubEndpointService.js';
+import { createTestGitHubEndpointService } from './testGitHubEndpointService.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 import { IAgentHostGitService } from '../../common/agentHostGitService.js';
 import { ClaudeAgent } from '../../node/claude/claudeAgent.js';
@@ -633,6 +635,7 @@ suite('ClaudeAgent integration (proxy-backed)', function () {
 				async syncCustomizations(_clientId: string, _customizations: ClientPluginCustomization[]) { return []; },
 			}],
 			[IAgentConfigurationService, configService],
+			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 			[IAgentHostGitService, createNoopGitService()],
 			...claudeFileEnvServices(disposables),
 		);
@@ -763,6 +766,7 @@ suite('ClaudeAgent integration (proxy-backed)', function () {
 				async syncCustomizations(_clientId: string, _customizations: ClientPluginCustomization[]) { return []; },
 			}],
 			[IAgentConfigurationService, configService],
+			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 			[IAgentHostGitService, createNoopGitService()],
 			...claudeFileEnvServices(disposables),
 		);
@@ -822,6 +826,7 @@ suite('ClaudeAgent integration (proxy-backed)', function () {
 				async syncCustomizations(_clientId: string, _customizations: ClientPluginCustomization[]) { return []; },
 			}],
 			[IAgentConfigurationService, configService],
+			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 			[IAgentHostGitService, createNoopGitService()],
 			...claudeFileEnvServices(disposables),
 		);

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -54,6 +54,8 @@ import { ProtectedResourceMetadata, ChatInputAnswerState, ChatInputAnswerValueKi
 import { IAgentHostGitService } from '../../common/agentHostGitService.js';
 import { AgentConfigurationService, IAgentConfigurationService } from '../../node/agentConfigurationService.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
+import { IAgentHostGitHubEndpointService } from '../../node/agentHostGitHubEndpointService.js';
+import { createTestGitHubEndpointService } from './testGitHubEndpointService.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { ClaudeAgent, fromSdkModelInfo } from '../../node/claude/claudeAgent.js';
 import { ClaudeAgentSession } from '../../node/claude/claudeAgentSession.js';
@@ -748,7 +750,7 @@ class CapturingLogService extends NullLogService {
 
 function createTestContext(
 	disposables: Pick<DisposableStore, 'add'>,
-	overrides?: { logService?: ILogService; database?: TestSessionDatabase; rootConfig?: Record<string, unknown>; userHome?: URI },
+	overrides?: { logService?: ILogService; database?: TestSessionDatabase; rootConfig?: Record<string, unknown>; userHome?: URI; gitHubEndpointService?: IAgentHostGitHubEndpointService },
 ): ITestContext {
 	const proxy = new FakeClaudeProxyService();
 	const api = new FakeCopilotApiService();
@@ -780,6 +782,7 @@ function createTestContext(
 		[IAgentHostGitService, createNoopGitService()],
 		[IAgentConfigurationService, configService],
 		[IProductService, FakeProductService],
+		[IAgentHostGitHubEndpointService, overrides?.gitHubEndpointService ?? createTestGitHubEndpointService()],
 	);
 	const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 	// Phase 19: seed root config (e.g. `claudeUseCopilotProxy`) BEFORE the agent
@@ -882,6 +885,25 @@ suite('ClaudeAgent', () => {
 			scopes_supported: ['repo'],
 			required: false,
 		}]);
+	});
+
+	test('enterprise: getProtectedResources + authenticate use the computed enterprise resource', async () => {
+		const { agent } = createTestContext(disposables, {
+			gitHubEndpointService: createTestGitHubEndpointService('https://ghe.acme.com'),
+		});
+
+		assert.deepStrictEqual({
+			resources: agent.getProtectedResources().map(r => ({ resource: r.resource, servers: r.authorization_servers })),
+			acceptsEnterpriseCopilot: await agent.authenticate('https://ghe.acme.com/api/v3', 'tok'),
+			rejectsDotCom: await agent.authenticate('https://api.github.com', 'tok'),
+		}, {
+			resources: [
+				{ resource: 'https://ghe.acme.com/api/v3', servers: ['https://ghe.acme.com/login/oauth'] },
+				{ resource: 'https://ghe.acme.com/api/v3/repos', servers: ['https://ghe.acme.com/login/oauth'] },
+			],
+			acceptsEnterpriseCopilot: true,
+			rejectsDotCom: false,
+		});
 	});
 
 	test('models observable is empty before authenticate', () => {
@@ -1310,6 +1332,7 @@ suite('ClaudeAgent', () => {
 			[IAgentPluginManager, new FakeAgentPluginManager()],
 			[IAgentHostGitService, createNoopGitService()],
 			[IProductService, FakeProductService],
+			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 		);
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		const agent = disposables.add(instantiationService.createInstance(ClaudeAgent));
@@ -1373,6 +1396,7 @@ suite('ClaudeAgent', () => {
 			[IClaudeAgentSdkService, new FakeClaudeAgentSdkService()],
 			[IAgentPluginManager, new FakeAgentPluginManager()],
 			[IProductService, FakeProductService],
+			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 		);
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		const agent = instantiationService.createInstance(ClaudeAgent);
@@ -1443,6 +1467,7 @@ suite('ClaudeAgent', () => {
 			[IClaudeAgentSdkService, new FakeClaudeAgentSdkService()],
 			[IAgentPluginManager, new FakeAgentPluginManager()],
 			[IProductService, FakeProductService],
+			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 		);
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		const agent = disposables.add(instantiationService.createInstance(ClaudeAgent));
@@ -2907,6 +2932,7 @@ suite('ClaudeAgent', () => {
 			[IAgentHostGitService, createNoopGitService()],
 			[IAgentConfigurationService, configService],
 			[IProductService, FakeProductService],
+			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 		);
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		const agent: ClaudeAgent = disposables.add(instantiationService.createInstance(ClaudeAgent));
@@ -3537,6 +3563,7 @@ suite('ClaudeAgent', () => {
 			[IClaudeAgentSdkService, sdk],
 			[IAgentPluginManager, new FakeAgentPluginManager()],
 			[IProductService, FakeProductService],
+			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 		);
 		const instantiationService = disposables.add(new InstantiationService(services));
 		const agent = disposables.add(instantiationService.createInstance(ClaudeAgent));
@@ -3609,6 +3636,7 @@ suite('ClaudeAgent', () => {
 			[IClaudeAgentSdkService, sdk],
 			[IAgentPluginManager, new FakeAgentPluginManager()],
 			[IProductService, FakeProductService],
+			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 		);
 		const instantiationService = disposables.add(new InstantiationService(services));
 		const agent = disposables.add(instantiationService.createInstance(ClaudeAgent));
@@ -3652,6 +3680,7 @@ suite('ClaudeAgent', () => {
 			[IClaudeAgentSdkService, sdk],
 			[IAgentPluginManager, new FakeAgentPluginManager()],
 			[IProductService, FakeProductService],
+			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 		);
 		const instantiationService = disposables.add(new InstantiationService(services));
 		const agent = disposables.add(instantiationService.createInstance(ClaudeAgent));
@@ -3700,6 +3729,7 @@ suite('ClaudeAgent', () => {
 			[IClaudeAgentSdkService, sdk],
 			[IAgentPluginManager, new FakeAgentPluginManager()],
 			[IProductService, FakeProductService],
+			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 		);
 		const instantiationService = disposables.add(new InstantiationService(services));
 		const agent = disposables.add(instantiationService.createInstance(ClaudeAgent));
@@ -4019,6 +4049,7 @@ suite('ClaudeAgent', () => {
 			[IAgentPluginManager, new FakeAgentPluginManager()],
 			[IAgentHostGitService, createNoopGitService()],
 			[IProductService, FakeProductService],
+			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 		);
 		const instantiationService = disposables.add(new InstantiationService(services));
 		const agent = instantiationService.createInstance(ClaudeAgent);
@@ -4073,6 +4104,7 @@ suite('ClaudeAgent', () => {
 			[IAgentHostGitService, createNoopGitService()],
 			[IAgentConfigurationService, configService],
 			[IProductService, FakeProductService],
+			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 		);
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		const agent: ClaudeAgent = instantiationService.createInstance(ClaudeAgent);
@@ -5818,6 +5850,7 @@ suite('ClaudeAgent — Phase 11 customizations', () => {
 			[IAgentHostGitService, createNoopGitService()],
 			[IAgentConfigurationService, configService],
 			[IProductService, FakeProductService],
+			[IAgentHostGitHubEndpointService, createTestGitHubEndpointService()],
 		);
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		const agent = disposables.add(instantiationService.createInstance(ClaudeAgent));

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -48,6 +48,8 @@ import { COPILOT_AGENT_HOST_SYSTEM_MESSAGE, CopilotAgent, CopilotSessionEntry, g
 import { COPILOT_AGENT_HOST_FILE_LINK_INSTRUCTIONS } from '../../node/copilot/prompts/systemMessage.js';
 import { NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
 import { IAgentHostReviewService, NULL_REVIEW_SERVICE } from '../../common/agentHostReviewService.js';
+import { IAgentHostGitHubEndpointService } from '../../node/agentHostGitHubEndpointService.js';
+import { createTestGitHubEndpointService } from './testGitHubEndpointService.js';
 import { CopilotAgentSession } from '../../node/copilot/copilotAgentSession.js';
 import { CopilotBranchNameGenerator, ICopilotBranchNameGenerator, getCopilotBranchNameHintFromMessage, normalizeCopilotBranchName } from '../../node/copilot/copilotBranchNameGenerator.js';
 import type { CopilotSessionLaunchPlan, IActiveClientSnapshot } from '../../node/copilot/copilotSessionLauncher.js';
@@ -465,7 +467,7 @@ class ResumePathCopilotAgent extends CopilotAgent {
 		@IAgentHostProxyResolver proxyResolver: IAgentHostProxyResolver,
 		@ICopilotApiService copilotApiService: ICopilotApiService,
 	) {
-		super(logService, instantiationService, sessionDataService, gitService, configurationService, new MockAgentHostOTelService(), branchNameGenerator, completions, NULL_CHECKPOINT_SERVICE, NULL_REVIEW_SERVICE, environmentService, byokBridgeRegistry, NullTelemetryService, copilotApiService, proxyResolver);
+		super(logService, instantiationService, sessionDataService, gitService, configurationService, createTestGitHubEndpointService(), new MockAgentHostOTelService(), branchNameGenerator, completions, NULL_CHECKPOINT_SERVICE, NULL_REVIEW_SERVICE, environmentService, byokBridgeRegistry, NullTelemetryService, copilotApiService, proxyResolver);
 		this._enablePlanModeOnClient(this._copilotClient as CopilotClient);
 	}
 
@@ -496,7 +498,7 @@ class TestableCopilotAgent extends CopilotAgent {
 		@IAgentHostProxyResolver proxyResolver: IAgentHostProxyResolver,
 		@ICopilotApiService copilotApiService: ICopilotApiService,
 	) {
-		super(logService, instantiationService, sessionDataService, gitService, configurationService, new MockAgentHostOTelService(), branchNameGenerator, completions, NULL_CHECKPOINT_SERVICE, NULL_REVIEW_SERVICE, environmentService, byokBridgeRegistry, NullTelemetryService, copilotApiService, proxyResolver);
+		super(logService, instantiationService, sessionDataService, gitService, configurationService, createTestGitHubEndpointService(), new MockAgentHostOTelService(), branchNameGenerator, completions, NULL_CHECKPOINT_SERVICE, NULL_REVIEW_SERVICE, environmentService, byokBridgeRegistry, NullTelemetryService, copilotApiService, proxyResolver);
 		this._enablePlanModeOnClient(this._copilotClient as CopilotClient);
 	}
 
@@ -555,6 +557,7 @@ function createTestAgentContext(disposables: Pick<DisposableStore, 'add'>, optio
 	services.set(ILogService, logService);
 	services.set(IFileService, fileService);
 	services.set(IAgentConfigurationService, configService);
+	services.set(IAgentHostGitHubEndpointService, createTestGitHubEndpointService());
 	services.set(ISessionDataService, options?.sessionDataService ?? createNullSessionDataService());
 	services.set(IAgentPluginManager, options?.pluginManager ?? new TestAgentPluginManager());
 	services.set(IAgentHostGitService, options?.gitService ?? new TestAgentHostGitService());

--- a/src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/agentHostOctoKitService.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../../log/common/log.js';
 import { AgentHostOctoKitService, type FetchFunction } from '../../../node/shared/agentHostOctoKitService.js';
+import { createTestGitHubEndpointService } from '../testGitHubEndpointService.js';
 
 type Captured = { url: string; init: RequestInit | undefined };
 
@@ -17,8 +18,8 @@ function getUrl(input: string | URL | Request): string {
 	return input instanceof URL ? input.href : input.url;
 }
 
-function makeService(fetchImpl: FetchFunction): AgentHostOctoKitService {
-	return new AgentHostOctoKitService(fetchImpl, new NullLogService());
+function makeService(fetchImpl: FetchFunction, enterpriseUri?: string): AgentHostOctoKitService {
+	return new AgentHostOctoKitService(fetchImpl, new NullLogService(), createTestGitHubEndpointService(enterpriseUri));
 }
 
 function signal(): AbortSignal {
@@ -161,5 +162,23 @@ suite('AgentHostOctoKitService', () => {
 			() => service.enablePullRequestAutoMerge('PR_node_42', 'MERGE', 'tok', signal()),
 			/GitHub GraphQL request failed: Pull request is in clean status/,
 		);
+	});
+
+	test('routes REST calls to the GitHub Enterprise Server API base', async () => {
+		const { fetch, captured } = capturingFetch(jsonResponse({ html_url: 'https://ghe.acme.com/o/r/pull/7', number: 7, node_id: 'n' }));
+		const service = makeService(fetch, 'https://ghe.acme.com');
+
+		await service.createPullRequest('o', 'r', 'T', 'B', 'feature', 'main', false, 'tok', signal());
+
+		assert.strictEqual(captured().url, 'https://ghe.acme.com/api/v3/repos/o/r/pulls');
+	});
+
+	test('routes GraphQL calls to the GitHub Enterprise Server GraphQL endpoint', async () => {
+		const { fetch, captured } = capturingFetch(jsonResponse({ data: { enablePullRequestAutoMerge: { pullRequest: { id: 'PR_1' } } } }));
+		const service = makeService(fetch, 'https://ghe.acme.com');
+
+		await service.enablePullRequestAutoMerge('PR_1', 'MERGE', 'tok', signal());
+
+		assert.strictEqual(captured().url, 'https://ghe.acme.com/api/graphql');
 	});
 });

--- a/src/vs/platform/agentHost/test/node/shared/copilotApiService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/shared/copilotApiService.integrationTest.ts
@@ -20,6 +20,7 @@ import { NullLogService } from '../../../../log/common/log.js';
 import product from '../../../../product/common/product.js';
 import { IProductService } from '../../../../product/common/productService.js';
 import { CopilotApiService } from '../../../node/shared/copilotApiService.js';
+import { createTestGitHubEndpointService } from '../testGitHubEndpointService.js';
 
 suite('CopilotApiService.utilityChatCompletion (real CAPI)', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -34,7 +35,7 @@ suite('CopilotApiService.utilityChatCompletion (real CAPI)', () => {
 		// `globalThis.fetch` through `this._fetch(...)` throws
 		// "Illegal invocation" in the Electron renderer.
 		const boundFetch: typeof globalThis.fetch = (...args) => globalThis.fetch(...args);
-		return new CopilotApiService(boundFetch, new NullLogService(), productService);
+		return new CopilotApiService(boundFetch, new NullLogService(), productService, createTestGitHubEndpointService());
 	}
 
 	(hasToken ? test : test.skip)('answers a trivial arithmetic prompt', async function () {

--- a/src/vs/platform/agentHost/test/node/shared/copilotApiService.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/copilotApiService.test.ts
@@ -8,6 +8,7 @@ import type Anthropic from '@anthropic-ai/sdk';
 import { Iterable } from '../../../../../base/common/iterator.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { COPILOT_API_ERROR_STATUS_STREAMING, CopilotApiError, CopilotApiService, type FetchFunction } from '../../../node/shared/copilotApiService.js';
+import { createTestGitHubEndpointService } from '../testGitHubEndpointService.js';
 import { NullLogService } from '../../../../log/common/log.js';
 import { IProductService } from '../../../../product/common/productService.js';
 import product from '../../../../product/common/product.js';
@@ -84,8 +85,8 @@ function modelsResponse(models: object[]): Response {
 	});
 }
 
-function createService(fetchImpl: FetchFunction): CopilotApiService {
-	return new CopilotApiService(fetchImpl, new NullLogService(), testProductService);
+function createService(fetchImpl: FetchFunction, enterpriseUri?: string): CopilotApiService {
+	return new CopilotApiService(fetchImpl, new NullLogService(), testProductService, createTestGitHubEndpointService(enterpriseUri));
 }
 
 type CapturedRequest = { url: string; init: RequestInit | undefined };
@@ -270,6 +271,21 @@ suite('CopilotApiService', () => {
 
 			await service.messages('my-secret-gh-token', baseRequest);
 			assert.strictEqual(capturedAuthHeader, 'Bearer my-secret-gh-token');
+		});
+
+		test('routes endpoint discovery to the GitHub Enterprise host when configured', async () => {
+			let discoveryUrl: string | undefined;
+			const service = createService(async (input) => {
+				const url = getUrl(input);
+				if (url.includes('/copilot_internal')) {
+					discoveryUrl = url;
+					return tokenResponse();
+				}
+				return anthropicResponse([{ type: 'text', text: 'ok' }]);
+			}, 'https://acme.ghe.com');
+
+			await service.messages('gh-tok', baseRequest);
+			assert.strictEqual(discoveryUrl, 'https://api.acme.ghe.com/copilot_internal/user');
 		});
 
 		test('throws on 403 from endpoint discovery', async () => {

--- a/src/vs/platform/agentHost/test/node/testGitHubEndpointService.ts
+++ b/src/vs/platform/agentHost/test/node/testGitHubEndpointService.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../../../base/common/event.js';
+import { deriveGitHubEndpoints, gitHubCopilotResource, gitHubRepoResource } from '../../common/githubEndpoints.js';
+import { IAgentHostGitHubEndpointService } from '../../node/agentHostGitHubEndpointService.js';
+
+/**
+ * A static {@link IAgentHostGitHubEndpointService} for tests. Resolves the same
+ * endpoints as production for a given (optional) enterprise URI; `onDidChange`
+ * never fires.
+ */
+export function createTestGitHubEndpointService(enterpriseUri?: string): IAgentHostGitHubEndpointService {
+	const endpoints = deriveGitHubEndpoints(enterpriseUri);
+	return {
+		_serviceBrand: undefined,
+		onDidChange: Event.None,
+		getApiBaseUri: () => endpoints.apiBaseUri,
+		getGraphQlUri: () => endpoints.graphQlUri,
+		getEnterpriseHost: () => endpoints.enterpriseHost,
+		getEnterpriseUri: () => enterpriseUri || undefined,
+		getCopilotResource: () => gitHubCopilotResource(endpoints),
+		getRepoResource: () => gitHubRepoResource(endpoints),
+	};
+}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution.ts
@@ -10,6 +10,7 @@ import { AgentHostEnabledSettingId, IAgentHostService } from '../../../../../../
 import { AgentHostConfigKey } from '../../../../../../platform/agentHost/common/agentHostCustomizationConfig.js';
 import { AgentHostCustomTerminalToolEnabledSettingId, CopilotCliConfigKey } from '../../../../../../platform/agentHost/common/copilotCliConfig.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { TerminalSettingId } from '../../../../../../platform/terminal/common/terminal.js';
 import { IWorkbenchContribution } from '../../../../../../workbench/common/contributions.js';
 import { ITerminalProfileResolverService, ITerminalProfileService } from '../../../../../../workbench/contrib/terminal/common/terminal.js';
@@ -52,6 +53,7 @@ export class AgentHostTerminalContribution extends Disposable implements IWorkbe
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ITerminalProfileService private readonly _terminalProfileService: ITerminalProfileService,
 		@ITerminalProfileResolverService private readonly _terminalProfileResolverService: ITerminalProfileResolverService,
+		@IDefaultAccountService private readonly _defaultAccountService: IDefaultAccountService,
 	) {
 		super();
 
@@ -77,6 +79,24 @@ export class AgentHostTerminalContribution extends Disposable implements IWorkbe
 							push();
 						}
 					}));
+				},
+			},
+			{
+				// Mirror the connected GitHub Enterprise host to the agent host so its
+				// GitHub resources / CAPI calls target the enterprise instance. Sourced
+				// from the account service — the authoritative "am I signed in to GHE"
+				// state — rather than reading the setting directly. Push `''` (not
+				// `undefined`) for github.com: the push pipeline skips `undefined`,
+				// which would strand a stale host on the agent host.
+				key: AgentHostConfigKey.GithubEnterpriseUri,
+				computeValue: () => {
+					const provider = this._defaultAccountService.getDefaultAccountAuthenticationProvider();
+					// `resolveGitHubUrl('')` yields the GitHub Enterprise base (e.g.
+					// `https://acme.ghe.com/`) when signed in via a GHE provider.
+					return provider.enterprise ? this._defaultAccountService.resolveGitHubUrl('').replace(/\/+$/, '') : '';
+				},
+				registerTriggers: (store, push) => {
+					store.add(this._defaultAccountService.onDidChangeDefaultAccount(() => push()));
 				},
 			},
 		];

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostTerminalContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostTerminalContribution.test.ts
@@ -12,6 +12,8 @@ import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
+import type { IDefaultAccount, IDefaultAccountAuthenticationProvider } from '../../../../../../base/common/defaultAccount.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { AgentHostEnabledSettingId, IAgentHostService } from '../../../../../../platform/agentHost/common/agentService.js';
 import { AgentHostCustomTerminalToolEnabledSettingId, CopilotCliConfigKey } from '../../../../../../platform/agentHost/common/copilotCliConfig.js';
@@ -122,6 +124,34 @@ class MockTerminalProfileService extends mock<ITerminalProfileService>() {
 	}
 }
 
+// ---- Mock default account service (enterprise state + GitHub base URL) ----
+
+class MockDefaultAccountService extends mock<IDefaultAccountService>() {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onDidChangeDefaultAccount = new Emitter<IDefaultAccount | null>();
+	override readonly onDidChangeDefaultAccount = this._onDidChangeDefaultAccount.event;
+
+	public enterprise = false;
+	public gitHubBaseUrl = 'https://github.com';
+
+	override getDefaultAccountAuthenticationProvider(): IDefaultAccountAuthenticationProvider {
+		return { id: 'github', name: 'GitHub', enterprise: this.enterprise };
+	}
+
+	override resolveGitHubUrl(path: string): string {
+		return `${this.gitHubBaseUrl}/${path}`;
+	}
+
+	fireChange(): void {
+		this._onDidChangeDefaultAccount.fire(null);
+	}
+
+	dispose(): void {
+		this._onDidChangeDefaultAccount.dispose();
+	}
+}
+
 // ---- Helpers ----
 
 function makeRootStateWithSchema(properties: Record<string, unknown>): RootState {
@@ -154,12 +184,19 @@ function rootStateWithEnableCustomTerminalToolKey(): RootState {
 	});
 }
 
+function rootStateWithGithubEnterpriseUriKey(): RootState {
+	return makeRootStateWithSchema({
+		[AgentHostConfigKey.GithubEnterpriseUri]: { type: 'string', title: 'GitHub Enterprise URI' },
+	});
+}
+
 interface ITestSetup {
 	contribution: AgentHostTerminalContribution;
 	agentHostService: MockAgentHostService;
 	resolver: MockTerminalProfileResolverService;
 	profileService: MockTerminalProfileService;
 	configurationService: TestConfigurationService;
+	defaultAccountService: MockDefaultAccountService;
 }
 
 function setup(disposables: DisposableStore, agentHostEnabled: boolean = true): ITestSetup {
@@ -169,6 +206,8 @@ function setup(disposables: DisposableStore, agentHostEnabled: boolean = true): 
 	const resolver = new MockTerminalProfileResolverService();
 	const profileService = new MockTerminalProfileService();
 	disposables.add({ dispose: () => profileService.dispose() });
+	const defaultAccountService = new MockDefaultAccountService();
+	disposables.add({ dispose: () => defaultAccountService.dispose() });
 	const configurationService = new TestConfigurationService({
 		[AgentHostEnabledSettingId]: agentHostEnabled,
 		[AgentHostCustomTerminalToolEnabledSettingId]: true,
@@ -178,13 +217,14 @@ function setup(disposables: DisposableStore, agentHostEnabled: boolean = true): 
 	instantiationService.stub(IConfigurationService, configurationService);
 	instantiationService.stub(ITerminalProfileResolverService, resolver);
 	instantiationService.stub(ITerminalProfileService, profileService);
+	instantiationService.stub(IDefaultAccountService, defaultAccountService);
 	instantiationService.stub(IAgentHostTerminalService, {
 		registerEntry: (): IDisposable => ({ dispose() { } }),
 		profiles: observableValue('test', []),
 	});
 
 	const contribution = disposables.add(instantiationService.createInstance(AgentHostTerminalContribution));
-	return { contribution, agentHostService, resolver, profileService, configurationService };
+	return { contribution, agentHostService, resolver, profileService, configurationService, defaultAccountService };
 }
 
 /** Wait for any in-flight `_pushDefaultShell` promises to settle. */
@@ -440,6 +480,49 @@ suite('AgentHostTerminalContribution', () => {
 		await flush();
 
 		assert.deepStrictEqual(agentHostService.dispatchedActions as readonly unknown[], []);
+	});
+
+	test('dispatches the enterprise base when signed in via a GHE provider', async () => {
+		const { agentHostService, defaultAccountService } = setup(disposables);
+		defaultAccountService.enterprise = true;
+		defaultAccountService.gitHubBaseUrl = 'https://acme.ghe.com';
+
+		agentHostService.setRootState(rootStateWithGithubEnterpriseUriKey());
+		await flush();
+
+		assert.strictEqual(agentHostService.dispatchedActions.length, 1);
+		assert.deepStrictEqual((agentHostService.dispatchedActions[0].action as IRootConfigChangedAction).config, {
+			[AgentHostConfigKey.GithubEnterpriseUri]: 'https://acme.ghe.com',
+		});
+	});
+
+	test('dispatches an empty enterprise URI for a github.com account', async () => {
+		const { agentHostService } = setup(disposables); // default account is not enterprise
+
+		agentHostService.setRootState(rootStateWithGithubEnterpriseUriKey());
+		await flush();
+
+		assert.strictEqual(agentHostService.dispatchedActions.length, 1);
+		assert.deepStrictEqual((agentHostService.dispatchedActions[0].action as IRootConfigChangedAction).config, {
+			[AgentHostConfigKey.GithubEnterpriseUri]: '',
+		});
+	});
+
+	test('re-dispatches the enterprise URI when the default account changes', async () => {
+		const { agentHostService, defaultAccountService } = setup(disposables);
+		agentHostService.setRootState(rootStateWithGithubEnterpriseUriKey());
+		await flush();
+		assert.strictEqual(agentHostService.dispatchedActions.length, 1); // initial '' push
+
+		defaultAccountService.enterprise = true;
+		defaultAccountService.gitHubBaseUrl = 'https://acme.ghe.com';
+		defaultAccountService.fireChange();
+		await flush();
+
+		assert.strictEqual(agentHostService.dispatchedActions.length, 2);
+		assert.deepStrictEqual((agentHostService.dispatchedActions[1].action as IRootConfigChangedAction).config, {
+			[AgentHostConfigKey.GithubEnterpriseUri]: 'https://acme.ghe.com',
+		});
 	});
 });
 


### PR DESCRIPTION
Fixes #313396

## What

Introduce `IAgentHostGitHubEndpointService` / `AgentHostGitHubEndpointService` as a single source of truth for GitHub (Enterprise) endpoints and their protected resources, so the agent host can target a configured GitHub Enterprise host instead of hardcoded `github.com` constants. This makes the agent host's Copilot auth and CAPI paths usable against a GHE instance without a rebuild.

## Changes

- Add `githubEndpoints.ts` (endpoint/resource derivation) and the endpoint service, exposed off `AgentService` via `gitHubEndpointService`.
- Copilot, Claude, and Codex agents resolve their Copilot/repo protected resources via `getCopilotResource()` / `getRepoResource()` rather than the hardcoded `GITHUB_*_PROTECTED_RESOURCE` constants — so the OAuth device-code flow targets the configured host.
- `CopilotApiService` derives its token mint URL from the endpoint service (`api.<ghe-host>/copilot_internal/v2/token`) instead of the hardcoded `defaultChatAgent.tokenEntitlementUrl`, resolving the `TODO(GHE)` in `_buildCapiInit`.
- Order `CopilotApiService` and the proxies that consume it after the endpoint service is registered (`agentHostMain` mirrors `agentHostServerMain`) so CAPI endpoint discovery can target a GHE host.
- `CopilotAgent` sets `COPILOT_GH_HOST` for the CLI and restarts the client when the enterprise host changes; `AgentService` emits `auth/required` on GHE URI change so clients re-authenticate against the new resource.
- Add unit tests (`githubEndpoints.test.ts`, `agentHostGitHubEndpointService.test.ts`) plus a `testGitHubEndpointService` helper, and thread the service through the affected agent/service tests.
