### PR TITLE
fix: prevent unbounded PersistentProtocol replay buffer

### DIFF
--- a/src/vs/base/parts/ipc/common/ipc.net.ts
+++ b/src/vs/base/parts/ipc/common/ipc.net.ts
@@ -139,11 +139,13 @@ export type SocketCloseEvent = NodeSocketCloseEvent | WebSocketCloseEvent | unde
 export const enum SocketTimeoutReason {
 	UNACKNOWLEDGED_MESSAGE = 'unacknowledgedMessage',
 	KEEP_ALIVE = 'keepAlive',
+	UNACKNOWLEDGED_MESSAGE_REPLAY_BUFFER_OVERFLOW = 'unacknowledgedMessageReplayBufferOverflow',
 }
 
 export interface SocketTimeoutEvent {
 	readonly reason: SocketTimeoutReason;
 	readonly unacknowledgedMsgCount: number;
+	readonly unacknowledgedMsgBytes: number;
 	readonly timeSinceOldestUnacknowledgedMsg?: number;
 	readonly timeSinceLastReceivedSomeData: number;
 }
@@ -310,6 +312,14 @@ export const enum ProtocolConstants {
 	 * Send a message every 5 seconds to avoid that the connection is closed by the OS.
 	 */
 	KeepAliveSendTime = 5000, // 5 seconds
+	/**
+	 * Bound the reconnect replay buffer so a dead connection cannot retain unbounded memory.
+	 */
+	MaxOutgoingUnacknowledgedMessages = 10000,
+	/**
+	 * Bound the reconnect replay buffer to 256MB of message payloads.
+	 */
+	MaxOutgoingUnacknowledgedBytes = 256 * 1024 * 1024,
 }
 
 class ProtocolMessage {
@@ -737,6 +747,11 @@ class Queue<T> {
 		this._last!.next = element;
 		this._last = element;
 	}
+
+	public clear(): void {
+		this._first = null;
+		this._last = null;
+	}
 }
 
 export class LoadEstimator {
@@ -807,6 +822,14 @@ export interface PersistentProtocolOptions {
 	 * Whether to send keep alive messages. Defaults to true.
 	 */
 	sendKeepAlive?: boolean;
+	/**
+	 * Maximum number of unacknowledged regular messages to keep for reconnection replay.
+	 */
+	maxOutgoingUnacknowledgedMessages?: number;
+	/**
+	 * Maximum payload bytes of unacknowledged regular messages to keep for reconnection replay.
+	 */
+	maxOutgoingUnacknowledgedBytes?: number;
 }
 
 /**
@@ -819,6 +842,7 @@ export class PersistentProtocol implements IMessagePassingProtocol {
 	private _didSendDisconnect?: boolean;
 
 	private _outgoingUnackMsg: Queue<ProtocolMessage>;
+	private _outgoingUnackMsgBytes: number;
 	private _outgoingMsgId: number;
 	private _outgoingAckId: number;
 	private _outgoingAckTimeout: Timeout | null;
@@ -841,6 +865,8 @@ export class PersistentProtocol implements IMessagePassingProtocol {
 
 	private readonly _loadEstimator: ILoadEstimator;
 	private readonly _shouldSendKeepAlive: boolean;
+	private readonly _maxOutgoingUnacknowledgedMessages: number;
+	private readonly _maxOutgoingUnacknowledgedBytes: number;
 
 	private readonly _onControlMessage = new BufferedEmitter<VSBuffer>();
 	readonly onControlMessage: Event<VSBuffer> = this._onControlMessage.event;
@@ -864,8 +890,11 @@ export class PersistentProtocol implements IMessagePassingProtocol {
 	constructor(opts: PersistentProtocolOptions) {
 		this._loadEstimator = opts.loadEstimator ?? LoadEstimator.getInstance();
 		this._shouldSendKeepAlive = opts.sendKeepAlive ?? true;
+		this._maxOutgoingUnacknowledgedMessages = opts.maxOutgoingUnacknowledgedMessages ?? ProtocolConstants.MaxOutgoingUnacknowledgedMessages;
+		this._maxOutgoingUnacknowledgedBytes = opts.maxOutgoingUnacknowledgedBytes ?? ProtocolConstants.MaxOutgoingUnacknowledgedBytes;
 		this._isReconnecting = false;
 		this._outgoingUnackMsg = new Queue<ProtocolMessage>();
+		this._outgoingUnackMsgBytes = 0;
 		this._outgoingMsgId = 0;
 		this._outgoingAckId = 0;
 		this._outgoingAckTimeout = null;
@@ -912,6 +941,7 @@ export class PersistentProtocol implements IMessagePassingProtocol {
 			this._keepAliveInterval = null;
 		}
 		this._socketDisposables.dispose();
+		this._clearOutgoingUnacknowledgedMessages();
 	}
 
 	drain(): Promise<void> {
@@ -999,6 +1029,7 @@ export class PersistentProtocol implements IMessagePassingProtocol {
 				const first = this._outgoingUnackMsg.peek();
 				if (first && first.id <= msg.ack) {
 					// this message has been confirmed, remove it
+					this._outgoingUnackMsgBytes = Math.max(0, this._outgoingUnackMsgBytes - first.size);
 					this._outgoingUnackMsg.pop();
 				} else {
 					break;
@@ -1079,6 +1110,11 @@ export class PersistentProtocol implements IMessagePassingProtocol {
 		this._incomingAckId = this._incomingMsgId;
 		const msg = new ProtocolMessage(ProtocolMessageType.Regular, myId, this._incomingAckId, buffer);
 		this._outgoingUnackMsg.push(msg);
+		this._outgoingUnackMsgBytes += msg.size;
+
+		if (this._checkOutgoingUnacknowledgedOverflow()) {
+			return;
+		}
 		if (!this._isReconnecting) {
 			this._socketWriter.write(msg);
 			this._recvAckCheck();
@@ -1158,6 +1194,7 @@ export class PersistentProtocol implements IMessagePassingProtocol {
 					reason: SocketTimeoutReason.UNACKNOWLEDGED_MESSAGE,
 					unacknowledgedMsgCount: this._outgoingUnackMsg.length(),
 					timeSinceOldestUnacknowledgedMsg,
+					unacknowledgedMsgBytes: this._outgoingUnackMsgBytes,
 					timeSinceLastReceivedSomeData
 				});
 				return;
@@ -1205,11 +1242,41 @@ export class PersistentProtocol implements IMessagePassingProtocol {
 				this._onSocketTimeout.fire({
 					reason: SocketTimeoutReason.KEEP_ALIVE,
 					unacknowledgedMsgCount,
+					unacknowledgedMsgBytes: this._outgoingUnackMsgBytes,
 					timeSinceOldestUnacknowledgedMsg: oldestUnacknowledgedMsg ? now - oldestUnacknowledgedMsg.writtenTime : undefined,
 					timeSinceLastReceivedSomeData
 				});
 			}
 		}
+	}
+
+	private _checkOutgoingUnacknowledgedOverflow(): boolean {
+		const unacknowledgedMsgCount = this.unacknowledgedCount;
+		if (
+			unacknowledgedMsgCount <= this._maxOutgoingUnacknowledgedMessages
+			&& this._outgoingUnackMsgBytes <= this._maxOutgoingUnacknowledgedBytes
+		) {
+			return false;
+		}
+
+		const now = Date.now();
+		const oldestUnacknowledgedMsg = this._outgoingUnackMsg.peek();
+		this._lastSocketTimeoutTime = now;
+		this._onSocketTimeout.fire({
+			reason: SocketTimeoutReason.UNACKNOWLEDGED_MESSAGE_REPLAY_BUFFER_OVERFLOW,
+			unacknowledgedMsgCount,
+			unacknowledgedMsgBytes: this._outgoingUnackMsgBytes,
+			timeSinceOldestUnacknowledgedMsg: oldestUnacknowledgedMsg?.writtenTime ? now - oldestUnacknowledgedMsg.writtenTime : undefined,
+			timeSinceLastReceivedSomeData: now - this._socketReader.lastReadTime
+		});
+		this._clearOutgoingUnacknowledgedMessages();
+		this._outgoingAckId = this._outgoingMsgId;
+		return true;
+	}
+
+	private _clearOutgoingUnacknowledgedMessages(): void {
+		this._outgoingUnackMsg.clear();
+		this._outgoingUnackMsgBytes = 0;
 	}
 
 	private _sendAck(): void {

--- a/src/vs/base/parts/ipc/test/node/ipc.net.test.ts
+++ b/src/vs/base/parts/ipc/test/node/ipc.net.test.ts
@@ -475,6 +475,96 @@ suite('PersistentProtocol reconnection', () => {
 		);
 	});
 
+	test('drops the replay buffer when unacknowledged messages exceed the configured byte limit', async () => {
+		await runWithFakedTimers(
+			{
+				useFakeTimers: true,
+				useSetImmediate: true,
+				maxTaskCount: 1000
+			},
+			async () => {
+
+				const loadEstimator: ILoadEstimator = {
+					hasHighLoad: () => false
+				};
+				const ether = new Ether();
+				const aSocket = new NodeSocket(ether.a);
+				const a = new PersistentProtocol({ socket: aSocket, loadEstimator, sendKeepAlive: false, maxOutgoingUnacknowledgedBytes: 4 });
+				const aMessages = new MessageStream(a);
+				const bSocket = new NodeSocket(ether.b);
+				const b = new PersistentProtocol({ socket: bSocket, loadEstimator, sendKeepAlive: false });
+				const bMessages = new MessageStream(b);
+
+				// never receive acks
+				b.pauseSocketWriting();
+
+				const socketTimeoutPromise = Event.toPromise(a.onSocketTimeout);
+
+				a.send(VSBuffer.fromString('a1'));
+				a.send(VSBuffer.fromString('a2'));
+				assert.strictEqual(a.unacknowledgedCount, 2);
+
+				a.send(VSBuffer.fromString('a3'));
+				const socketTimeoutEvent = await socketTimeoutPromise;
+
+				assert.strictEqual(socketTimeoutEvent.reason, SocketTimeoutReason.UNACKNOWLEDGED_MESSAGE_REPLAY_BUFFER_OVERFLOW);
+				assert.strictEqual(socketTimeoutEvent.unacknowledgedMsgCount, 3);
+				assert.strictEqual(socketTimeoutEvent.unacknowledgedMsgBytes, 6);
+				assert.strictEqual(a.unacknowledgedCount, 0);
+
+				aMessages.dispose();
+				bMessages.dispose();
+				a.dispose();
+				b.dispose();
+			}
+		);
+	});
+
+	test('drops the replay buffer when unacknowledged messages exceed the configured count limit', async () => {
+		await runWithFakedTimers(
+			{
+				useFakeTimers: true,
+				useSetImmediate: true,
+				maxTaskCount: 1000
+			},
+			async () => {
+
+				const loadEstimator: ILoadEstimator = {
+					hasHighLoad: () => false
+				};
+				const ether = new Ether();
+				const aSocket = new NodeSocket(ether.a);
+				const a = new PersistentProtocol({ socket: aSocket, loadEstimator, sendKeepAlive: false, maxOutgoingUnacknowledgedMessages: 2 });
+				const aMessages = new MessageStream(a);
+				const bSocket = new NodeSocket(ether.b);
+				const b = new PersistentProtocol({ socket: bSocket, loadEstimator, sendKeepAlive: false });
+				const bMessages = new MessageStream(b);
+
+				// never receive acks
+				b.pauseSocketWriting();
+
+				const socketTimeoutPromise = Event.toPromise(a.onSocketTimeout);
+
+				a.send(VSBuffer.fromString('a1'));
+				a.send(VSBuffer.fromString('a2'));
+				assert.strictEqual(a.unacknowledgedCount, 2);
+
+				a.send(VSBuffer.fromString('a3'));
+				const socketTimeoutEvent = await socketTimeoutPromise;
+
+				assert.strictEqual(socketTimeoutEvent.reason, SocketTimeoutReason.UNACKNOWLEDGED_MESSAGE_REPLAY_BUFFER_OVERFLOW);
+				assert.strictEqual(socketTimeoutEvent.unacknowledgedMsgCount, 3);
+				assert.strictEqual(socketTimeoutEvent.unacknowledgedMsgBytes, 6);
+				assert.strictEqual(a.unacknowledgedCount, 0);
+
+				aMessages.dispose();
+				bMessages.dispose();
+				a.dispose();
+				b.dispose();
+			}
+		);
+	});
+
 	test('onSocketTimeout is emitted at most once every 20s', async () => {
 		await runWithFakedTimers(
 			{

--- a/src/vs/platform/remote/common/remoteAgentConnection.ts
+++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
@@ -14,7 +14,7 @@ import * as performance from '../../../base/common/performance.js';
 import { StopWatch } from '../../../base/common/stopwatch.js';
 import { generateUuid } from '../../../base/common/uuid.js';
 import { IIPCLogger } from '../../../base/parts/ipc/common/ipc.js';
-import { Client, ISocket, PersistentProtocol, ProtocolConstants, SocketCloseEventType } from '../../../base/parts/ipc/common/ipc.net.js';
+import { Client, ISocket, PersistentProtocol, ProtocolConstants, SocketCloseEventType, SocketTimeoutReason } from '../../../base/parts/ipc/common/ipc.net.js';
 import { ILogService } from '../../log/common/log.js';
 import { RemoteAgentConnectionContext } from './remoteAgentEnvironment.js';
 import { RemoteAuthorityResolverError, RemoteConnection } from './remoteAuthorityResolver.js';
@@ -596,7 +596,12 @@ export abstract class PersistentConnection extends Disposable {
 		}));
 		this._register(protocol.onSocketTimeout((e) => {
 			const logPrefix = commonLogPrefix(this._connectionType, this.reconnectionToken, true);
-			this._options.logService.info(`${logPrefix} received socket timeout event (reason: ${e.reason}, unacknowledgedMsgCount: ${e.unacknowledgedMsgCount}, timeSinceOldestUnacknowledgedMsg: ${e.timeSinceOldestUnacknowledgedMsg}, timeSinceLastReceivedSomeData: ${e.timeSinceLastReceivedSomeData}).`);
+			this._options.logService.info(`${logPrefix} received socket timeout event (reason: ${e.reason}, unacknowledgedMsgCount: ${e.unacknowledgedMsgCount}, unacknowledgedMsgBytes: ${e.unacknowledgedMsgBytes}, timeSinceOldestUnacknowledgedMsg: ${e.timeSinceOldestUnacknowledgedMsg}, timeSinceLastReceivedSomeData: ${e.timeSinceLastReceivedSomeData}).`);
+			if (e.reason === SocketTimeoutReason.UNACKNOWLEDGED_MESSAGE_REPLAY_BUFFER_OVERFLOW) {
+				this._options.logService.error(`${logPrefix} unacknowledged message replay buffer overflow is unrecoverable.`);
+				this._onReconnectionPermanentFailure(this.protocol.getMillisSinceLastIncomingData(), 0, false);
+				return;
+			}
 			this._beginReconnecting();
 		}));
 


### PR DESCRIPTION
Fixes a memory leak in `PersistentProtocol`.

### Details

`PersistentProtocol` keeps every regular message in `_outgoingUnackMsg` until the peer acknowledges it. That queue is also the replay buffer used when a connection reconnects.

When a connection is dead, congested, or stuck reconnecting, acknowledgements can stop advancing while callers continue to send messages. In that state, `_outgoingUnackMsg` keeps retaining every unacknowledged payload, including large `VSBuffer` instances, until the protocol is disposed.

### Change

The change bounds the replay buffer by both message count and retained payload bytes. It also tracks the retained bytes so timeout diagnostics can show how much payload memory is currently held by unacknowledged messages.

When either replay-buffer limit is exceeded, `PersistentProtocol` emits a dedicated `unacknowledgedMessageReplayBufferOverflow` timeout reason, clears the replay buffer, and advances the local acknowledgement state so the dropped entries are not kept alive.

For remote connections, replay-buffer overflow is treated as unrecoverable instead of reconnecting into a stream that is missing replay messages.

### Before

A dead or congested peer could stop sending acknowledgements while new messages were still appended to `_outgoingUnackMsg`. The replay buffer could then grow without a memory bound and retain all queued message payloads.

### After

The replay buffer is capped by configurable/default count and byte limits. When the cap is exceeded, the buffer is released, the timeout log includes the retained byte count, and node IPC regression tests cover both byte-limit and count-limit overflow paths.
