### PR TITLE
agentHost: retry pending tools when approvals are bypassed

### DIFF
--- a/src/vs/platform/agentHost/common/state/protocol/channels-chat/reducer.ts
+++ b/src/vs/platform/agentHost/common/state/protocol/channels-chat/reducer.ts
@@ -359,7 +359,7 @@ export function chatReducer(state: ChatState, action: ChatAction, log?: (msg: st
 
 		case ActionType.ChatToolCallReady:
 			return refreshSummaryStatus(updateToolCallInParts(state, action.turnId, action.toolCallId, tc => {
-				if (tc.status !== ToolCallStatus.Streaming && tc.status !== ToolCallStatus.Running) {
+				if (tc.status !== ToolCallStatus.Streaming && tc.status !== ToolCallStatus.Running && tc.status !== ToolCallStatus.PendingConfirmation) {
 					return tc;
 				}
 				const base = tcBaseWithMeta(tc, action._meta);

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -86,6 +86,13 @@ interface IPendingSubagentSignal {
 	readonly agent: IAgent;
 }
 
+interface IPendingToolConfirmation {
+	readonly signal: IAgentToolPendingConfirmationSignal;
+	readonly sessionKey: ProtocolURI;
+	readonly turnId: string;
+	readonly agent: IAgent;
+}
+
 interface ISubagentSessionRef {
 	readonly parentChatUri: ProtocolURI;
 	readonly toolCallId: string;
@@ -107,6 +114,7 @@ export class AgentSideEffects extends Disposable {
 
 	/** Maps tool call IDs to the agent that owns them, for routing confirmations. */
 	private readonly _toolCallAgents = new Map<string, string>();
+	private readonly _pendingToolConfirmations = new Map<string, IPendingToolConfirmation>();
 	private _lastAgentInfos: readonly AgentInfo[] = [];
 
 	private readonly _permissionManager: SessionPermissionManager;
@@ -576,6 +584,7 @@ export class AgentSideEffects extends Disposable {
 		}
 
 		if (action.type === ActionType.ChatToolCallComplete) {
+			this._pendingToolConfirmations.delete(`${sessionKey}:${action.toolCallId}`);
 			// Emit `languageModelToolInvoked` telemetry for the completed tool
 			// call. `action.result` carries `success`/`error.code` even after the
 			// subagent-content merge above (which only touches `result.content`).
@@ -594,17 +603,20 @@ export class AgentSideEffects extends Disposable {
 		}
 
 		if (action.type === ActionType.ChatTurnComplete) {
+			this._clearPendingToolConfirmationsForChat(sessionKey);
 			this._turnTracker.turnCompleted(sessionKey, turnId, 'success');
 			this._toolCallTracker.clearSession(sessionKey);
 			this._runTurnCompleteSideEffects(sessionKey, turnId);
 		}
 
 		if (action.type === ActionType.ChatTurnCancelled) {
+			this._clearPendingToolConfirmationsForChat(sessionKey);
 			this._turnTracker.turnCompleted(sessionKey, turnId, 'cancelled');
 			this._toolCallTracker.clearSession(sessionKey);
 		}
 
 		if (action.type === ActionType.ChatError) {
+			this._clearPendingToolConfirmationsForChat(sessionKey);
 			this._turnTracker.turnCompleted(sessionKey, turnId, 'error');
 			this._toolCallTracker.clearSession(sessionKey);
 		}
@@ -780,6 +792,7 @@ export class AgentSideEffects extends Disposable {
 	 */
 	cancelSubagentSessions(parentChatURI: ProtocolURI): void {
 		for (const subagent of this._subagentChats.getAll(parentChatURI)) {
+			this._clearPendingToolConfirmationsForChat(subagent.chatUri);
 			const turnId = this._stateManager.getActiveTurnId(subagent.chatUri);
 			if (turnId) {
 				this._stateManager.dispatchServerAction(subagent.chatUri, {
@@ -813,6 +826,7 @@ export class AgentSideEffects extends Disposable {
 		if (!subagent) {
 			return;
 		}
+		this._clearPendingToolConfirmationsForChat(subagent.chatUri);
 
 		const turnId = this._stateManager.getActiveTurnId(subagent.chatUri);
 		if (turnId) {
@@ -831,6 +845,7 @@ export class AgentSideEffects extends Disposable {
 		const parentChatURIs = new Set<ProtocolURI>();
 		for (const subagent of this._subagentChats.values()) {
 			if (subagent.sessionUri === parentSession) {
+				this._clearPendingToolConfirmationsForChat(subagent.chatUri);
 				this._stateManager.removeChat(subagent.sessionUri, subagent.chatUri);
 				this._toolCallTracker.clearSession(subagent.chatUri);
 				parentChatURIs.add(subagent.parentChatUri);
@@ -892,6 +907,7 @@ export class AgentSideEffects extends Disposable {
 	 * for the client.
 	 */
 	private async _handleToolReady(e: IAgentToolPendingConfirmationSignal, sessionKey: ProtocolURI, turnId: string, agent: IAgent): Promise<void> {
+		const toolCallKey = `${sessionKey}:${e.state.toolCallId}`;
 		const approvalEvent = {
 			toolCallId: e.state.toolCallId,
 			session: e.chat,
@@ -909,15 +925,18 @@ export class AgentSideEffects extends Disposable {
 			&& contributor?.kind === ToolCallContributorKind.Client
 			&& !!e.state.confirmationTitle;
 		if (clientShouldAutoApprove) {
+			this._pendingToolConfirmations.delete(toolCallKey);
 			this._toolCallAgents.set(`${sessionKey}:${e.state.toolCallId}`, agent.id);
 			effective = { ...e, state: { ...e.state, _meta: { ...toolCall?._meta, ...e.state._meta, ...toToolCallMeta({ autoApproveBySetting: true }) } } };
 		} else if (autoApproval !== undefined) {
+			this._pendingToolConfirmations.delete(toolCallKey);
 			this._toolCallAgents.delete(`${sessionKey}:${e.state.toolCallId}`);
 			agent.respondToPermissionRequest(e.state.toolCallId, true);
 			// Strip confirmationTitle so createToolReadyAction emits the
 			// auto-approved (no-options) action.
 			effective = { ...e, state: { ...e.state, confirmationTitle: undefined } };
 		} else if (effective.state.confirmationTitle) {
+			this._pendingToolConfirmations.set(toolCallKey, { signal: e, sessionKey, turnId, agent });
 			// Make sure the agent is registered for the eventual `ChatToolCallConfirmed` response.
 			this._toolCallAgents.set(`${sessionKey}:${e.state.toolCallId}`, agent.id);
 		}
@@ -982,6 +1001,7 @@ export class AgentSideEffects extends Disposable {
 					throw new Error(`ChatToolCallConfirmed must be handled on an AHP chat channel: ${channel}`);
 				}
 				const toolCallKey = `${channel}:${action.toolCallId}`;
+				this._pendingToolConfirmations.delete(toolCallKey);
 				const agentId = this._toolCallAgents.get(toolCallKey);
 				if (agentId) {
 					this._toolCallAgents.delete(toolCallKey);
@@ -1012,6 +1032,7 @@ export class AgentSideEffects extends Disposable {
 				}
 				this._turnTracker.turnCompleted(channel, action.turnId, 'cancelled');
 				this._toolCallTracker.clearSession(channel);
+				this._clearPendingToolConfirmationsForChat(channel);
 				// Cancel all subagent sessions for this parent
 				this.cancelSubagentSessions(channel);
 				const agent = this._options.getAgent(sessionChannel);
@@ -1114,6 +1135,9 @@ export class AgentSideEffects extends Disposable {
 				if (values) {
 					this._persistSessionFlag(channel, 'configValues', JSON.stringify(values));
 				}
+				void this._retryPendingToolConfirmations(channel).catch(err => {
+					this._logService.error(`[AgentSideEffects] Failed to retry pending tool confirmations for ${channel}`, err);
+				});
 				break;
 			}
 			case ActionType.ChatToolCallComplete: {
@@ -1122,6 +1146,23 @@ export class AgentSideEffects extends Disposable {
 				}
 				this._notifyClientToolCallComplete(sessionChannel, chatChannel, action.toolCallId, action.result, 'client-dispatch');
 				break;
+			}
+		}
+	}
+
+	private async _retryPendingToolConfirmations(session: ProtocolURI): Promise<void> {
+		if (!this._permissionManager.isSessionAutoApproveEnabled(session)) {
+			return;
+		}
+		const pending = [...this._pendingToolConfirmations.values()].filter(item => parseRequiredSessionUriFromChatUri(item.sessionKey) === session);
+		await Promise.all(pending.map(item => this._handleToolReady(item.signal, item.sessionKey, item.turnId, item.agent)));
+	}
+
+	private _clearPendingToolConfirmationsForChat(chat: ProtocolURI): void {
+		const prefix = `${chat}:`;
+		for (const key of this._pendingToolConfirmations.keys()) {
+			if (key.startsWith(prefix)) {
+				this._pendingToolConfirmations.delete(key);
 			}
 		}
 	}

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -28,7 +28,7 @@ import { buildSubagentChatUri, buildChatUri, buildDefaultChatUri, CustomizationL
 import { IProductService } from '../../../product/common/productService.js';
 import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
 import { NullTelemetryService } from '../../../telemetry/common/telemetryUtils.js';
-import { AgentHostTelemetryLevelConfigKey, telemetryLevelToAgentHostConfigValue } from '../../common/agentHostSchema.js';
+import { AgentHostTelemetryLevelConfigKey, platformSessionSchema, telemetryLevelToAgentHostConfigValue } from '../../common/agentHostSchema.js';
 import { AgentConfigurationService, IAgentConfigurationService } from '../../node/agentConfigurationService.js';
 import { AgentHostTelemetryService } from '../../node/agentHostTelemetryService.js';
 import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
@@ -3228,6 +3228,131 @@ suite('AgentSideEffects', () => {
 			assert.deepStrictEqual(agent.respondToPermissionCalls, [
 				{ requestId: 'inner-write-1', approved: true },
 			]);
+		});
+
+		test('session-level autoApprove marks client tools in subagent sessions for client-side approval', async () => {
+			setupSession(URI.file('/workspace').toString());
+			startTurn('turn-1');
+			const bypassSideEffects = createTestSideEffects(disposables, stateManager, {
+				getAgent: () => agent,
+				agents: agentList,
+				sessionDataService: createSessionDataService(),
+				onTurnComplete: () => { },
+			});
+			disposables.add(bypassSideEffects.registerProgressListener(agent));
+
+			stateManager.setSessionConfig(sessionUri.toString(), {
+				schema: platformSessionSchema.toProtocol(),
+				values: { [SessionConfigKey.AutoApprove]: 'default' },
+			});
+
+			agent.fireProgress({ kind: 'action', resource: URI.parse(defaultChatUri), action: { type: ActionType.ChatToolCallStart, turnId: 'turn-1', toolCallId: 'tc-parent', toolName: 'task', displayName: 'Task', contributor: undefined, _meta: { toolKind: 'subagent' } } });
+			agent.fireProgress({ kind: 'action', resource: URI.parse(defaultChatUri), action: { type: ActionType.ChatToolCallReady, turnId: 'turn-1', toolCallId: 'tc-parent', invocationMessage: 'Delegating...', toolInput: undefined, confirmed: ToolCallConfirmationReason.NotNeeded } });
+			agent.fireProgress({ kind: 'subagent_started', chat: URI.parse(defaultChatUri), toolCallId: 'tc-parent', agentName: 'helper', agentDisplayName: 'Helper', agentDescription: 'Helps' });
+
+			agent.fireProgress({
+				kind: 'action', resource: URI.parse(defaultChatUri), parentToolCallId: 'tc-parent',
+				action: {
+					type: ActionType.ChatToolCallStart, turnId: 'turn-1',
+					toolCallId: 'inner-problems-1', toolName: 'problems', displayName: 'Problems',
+					contributor: { kind: ToolCallContributorKind.Client, clientId: 'test-client' },
+					_meta: { toolKind: undefined, language: undefined },
+				},
+			});
+			agent.fireProgress({
+				kind: 'pending_confirmation', chat: URI.parse(defaultChatUri), parentToolCallId: 'tc-parent',
+				state: {
+					status: ToolCallStatus.PendingConfirmation,
+					toolCallId: 'inner-problems-1', toolName: 'problems', displayName: 'Problems',
+					invocationMessage: 'Check problems', toolInput: '{"filePaths":[]}',
+					confirmationTitle: 'Allow tool call?', edits: undefined,
+				},
+				permissionKind: 'custom-tool',
+			});
+
+			const subagentUri = buildSubagentChatUri(sessionUri.toString(), 'tc-parent');
+			await waitForState(stateManager, () => {
+				const subagentState = stateManager.getSessionState(subagentUri);
+				const part = subagentState?.activeTurn?.responseParts.find(part => part.kind === ResponsePartKind.ToolCall && part.toolCall.toolCallId === 'inner-problems-1');
+				return part?.kind === ResponsePartKind.ToolCall && part.toolCall.status === ToolCallStatus.PendingConfirmation ? part.toolCall : undefined;
+			});
+
+			const configAction = {
+				type: ActionType.SessionConfigChanged,
+				config: { [SessionConfigKey.AutoApprove]: 'autoApprove' },
+			} as const;
+			stateManager.dispatchClientAction(sessionUri.toString(), configAction, { clientId: 'test-client', clientSeq: 1 });
+			bypassSideEffects.handleAction(sessionUri.toString(), configAction);
+
+			const state = await waitForState(stateManager, () => {
+				const subagentState = stateManager.getSessionState(subagentUri);
+				const part = subagentState?.activeTurn?.responseParts.find(part => part.kind === ResponsePartKind.ToolCall && part.toolCall.toolCallId === 'inner-problems-1');
+				return part?.kind === ResponsePartKind.ToolCall && part.toolCall._meta?.autoApproveBySetting === true ? part.toolCall : undefined;
+			});
+			assert.deepStrictEqual({
+				meta: state._meta,
+				permissionCalls: agent.respondToPermissionCalls,
+			}, {
+				meta: { toolKind: undefined, language: undefined, autoApproveBySetting: true },
+				permissionCalls: [],
+			});
+		});
+
+		test('cancelled subagent confirmations are not retried when bypass is enabled', async () => {
+			setupSession(URI.file('/workspace').toString());
+			startTurn('turn-1');
+			const bypassSideEffects = createTestSideEffects(disposables, stateManager, {
+				getAgent: () => agent,
+				agents: agentList,
+				sessionDataService: createSessionDataService(),
+				onTurnComplete: () => { },
+			});
+			disposables.add(bypassSideEffects.registerProgressListener(agent));
+			stateManager.setSessionConfig(sessionUri.toString(), {
+				schema: platformSessionSchema.toProtocol(),
+				values: { [SessionConfigKey.AutoApprove]: 'default' },
+			});
+
+			agent.fireProgress({ kind: 'action', resource: URI.parse(defaultChatUri), action: { type: ActionType.ChatToolCallStart, turnId: 'turn-1', toolCallId: 'tc-parent', toolName: 'task', displayName: 'Task', contributor: undefined, _meta: { toolKind: 'subagent' } } });
+			agent.fireProgress({ kind: 'action', resource: URI.parse(defaultChatUri), action: { type: ActionType.ChatToolCallReady, turnId: 'turn-1', toolCallId: 'tc-parent', invocationMessage: 'Delegating...', toolInput: undefined, confirmed: ToolCallConfirmationReason.NotNeeded } });
+			agent.fireProgress({ kind: 'subagent_started', chat: URI.parse(defaultChatUri), toolCallId: 'tc-parent', agentName: 'helper', agentDisplayName: 'Helper' });
+			agent.fireProgress({
+				kind: 'action', resource: URI.parse(defaultChatUri), parentToolCallId: 'tc-parent',
+				action: {
+					type: ActionType.ChatToolCallStart, turnId: 'turn-1',
+					toolCallId: 'inner-write-1', toolName: 'write', displayName: 'Write', contributor: undefined,
+					_meta: { toolKind: undefined, language: undefined },
+				},
+			});
+			agent.fireProgress({
+				kind: 'pending_confirmation', chat: URI.parse(defaultChatUri), parentToolCallId: 'tc-parent',
+				state: {
+					status: ToolCallStatus.PendingConfirmation,
+					toolCallId: 'inner-write-1', toolName: 'write', displayName: 'Write',
+					invocationMessage: 'Write file', toolInput: undefined,
+					confirmationTitle: 'Write file?', edits: undefined,
+				},
+				permissionKind: 'write',
+				permissionPath: '/tmp/cancelled-write',
+			});
+
+			const subagentUri = buildSubagentChatUri(sessionUri.toString(), 'tc-parent');
+			await waitForState(stateManager, () => {
+				const subagentState = stateManager.getSessionState(subagentUri);
+				const part = subagentState?.activeTurn?.responseParts.find(part => part.kind === ResponsePartKind.ToolCall && part.toolCall.toolCallId === 'inner-write-1');
+				return part?.kind === ResponsePartKind.ToolCall && part.toolCall.status === ToolCallStatus.PendingConfirmation ? part.toolCall : undefined;
+			});
+			bypassSideEffects.cancelSubagentSessions(defaultChatUri);
+
+			const configAction = {
+				type: ActionType.SessionConfigChanged,
+				config: { [SessionConfigKey.AutoApprove]: 'autoApprove' },
+			} as const;
+			stateManager.dispatchClientAction(sessionUri.toString(), configAction, { clientId: 'test-client', clientSeq: 1 });
+			bypassSideEffects.handleAction(sessionUri.toString(), configAction);
+			await new Promise(resolve => setTimeout(resolve, 20));
+
+			assert.deepStrictEqual(agent.respondToPermissionCalls, []);
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/reducers.test.ts
+++ b/src/vs/platform/agentHost/test/node/reducers.test.ts
@@ -70,6 +70,28 @@ suite('chatReducer – summaryStatus with tool call confirmations and input requ
 		assert.strictEqual(state.status, SessionStatus.InputNeeded);
 	});
 
+	test('ChatToolCallReady refreshes metadata while PendingConfirmation', () => {
+		let state = withActiveTurnAndToolCall(makeChat());
+		state = chatReducer(state, {
+			type: ActionType.ChatToolCallReady,
+			turnId: 'turn-1',
+			toolCallId: 'tc-1',
+			invocationMessage: 'Read file?',
+			toolInput: '/foo.ts',
+		});
+		state = chatReducer(state, {
+			type: ActionType.ChatToolCallReady,
+			turnId: 'turn-1',
+			toolCallId: 'tc-1',
+			invocationMessage: 'Read file?',
+			toolInput: '/foo.ts',
+			_meta: { autoApproveBySetting: true },
+		});
+
+		const part = state.activeTurn?.responseParts.find(part => part.kind === ResponsePartKind.ToolCall);
+		assert.deepStrictEqual(part?.kind === ResponsePartKind.ToolCall ? part.toolCall._meta : undefined, { autoApproveBySetting: true });
+	});
+
 	test('Chat status is InputNeeded when a tool call is PendingResultConfirmation', () => {
 		let state = withActiveTurnAndToolCall(makeChat());
 


### PR DESCRIPTION
- Re-evaluates confirmations that were already pending when an agent-host session switches to Bypass Approvals, preventing persisted subagent confirmations from remaining stuck after reconnects.
- Preserves the original permission request metadata so sandbox-bypass safeguards still apply instead of blanket-approving pending calls.
- Allows pending client tool state to receive setting-driven approval metadata and clears tracked confirmations across completion and cancellation paths.
- Adds regression coverage for subagent client tools, pending-state refresh, and cancellation races.

(Commit message generated by Copilot)