### PR TITLE
fix(diagnostics): ignore invalid uri deletes

### DIFF
--- a/src/vs/workbench/api/common/extHostDiagnostics.ts
+++ b/src/vs/workbench/api/common/extHostDiagnostics.ts
@@ -172,6 +172,9 @@ export class DiagnosticCollection implements vscode.DiagnosticCollection {
 
 	delete(uri: vscode.Uri): void {
 		this._checkDisposed();
+		if (!URI.isUri(uri)) {
+			return;
+		}
 		this.#onDidChangeDiagnostics.fire([uri]);
 		this.#data.delete(uri);
 		this.#proxy?.$changeMany(this._owner, [[uri, undefined]]);

--- a/src/vs/workbench/api/test/browser/extHostDiagnostics.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostDiagnostics.test.ts
@@ -385,6 +385,23 @@ suite('ExtHostDiagnostics', () => {
 		await p;
 	});
 
+	test('diagnostic collection ignores invalid uri on delete', function () {
+		let changeCount = 0;
+		let eventCount = 0;
+		const emitter = new Emitter<readonly URI[]>();
+		store.add(emitter.event(() => eventCount += 1));
+		const collection = new DiagnosticCollection('ddd', 'test', 100, 100, versionProvider, extUri, new class extends DiagnosticsShape {
+			override $changeMany(): void {
+				changeCount += 1;
+			}
+		}, emitter);
+		const invalidUri = { scheme: 'file', authority: '', path: '/broken', query: '', fragment: '' } as unknown as vscode.Uri;
+
+		collection.delete(invalidUri);
+
+		assert.deepStrictEqual({ changeCount, eventCount }, { changeCount: 0, eventCount: 0 });
+	});
+
 	test('diagnostics with related information', function (done) {
 
 		const collection = new DiagnosticCollection('ddd', 'test', 100, 100, versionProvider, extUri, new class extends DiagnosticsShape {


### PR DESCRIPTION
Addresses the `t.with is not a function` diagnostics path in microsoft/vscode#322755.

Summary
- guard `DiagnosticCollection.delete` against non-`URI` input before firing `onDidChangeDiagnostics`
- add regression coverage for deleting a plain URI-shaped object that is not a real VS Code `URI`

Verification
- `npm run typecheck-client` with Node 24.17.0
- focused runtime assertion via `npx -y tsx --tsconfig src/tsconfig.json`: invalid delete input is ignored without firing a diagnostics event or proxy change
- `git diff --check`

Note: I could not run `./scripts/test.sh --grep "diagnostic collection ignores invalid uri on delete"` locally because the Electron download failed with `ERR_TLS_CERT_ALTNAME_INVALID` for `github.com` on this network.