### PR TITLE
sessions: use default cursor in chat list gutters

### DIFF
--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -492,6 +492,15 @@
 	background: transparent !important;
 }
 
+/* Chat list rows inherit the list's `cursor: pointer` (from `.monaco-list.mouse-support`),
+ * but chat requests/responses are not clickable as a whole row. Because the item container
+ * is centered with a max-width, the row extends into gutters on either side where the pointer
+ * cursor would otherwise show even though the item container itself uses `cursor: default`.
+ * Force the default cursor on the rows so the gutters match the item container. */
+.agent-sessions-workbench .interactive-list > .monaco-list.mouse-support > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row {
+	cursor: default;
+}
+
 /* Constrain content items to the same max-width, centered.
  * Scoped to the chat panel (`.part.sessionspart`) and the chat editor host
  * (`.chat-editor-relative`) so the "card style" doesn't leak into other chat


### PR DESCRIPTION
## What changed

Chat list rows in the Agents window span the full viewport width, while the .interactive-item-container is centered with a `max-width` (see `style.css`). The base list stylesheet (`list.css`) sets `cursor: pointer` on `.monaco-list.mouse-support .monaco-list-row`, so the empty gutters on either side of the centered item container showed a **pointer** cursor even though the item container itself correctly uses `cursor: default`.

This adds a scoped rule forcing `cursor: default` on chat list rows within `.agent-sessions-workbench` so the gutters match the item container.

## Why

Fixes the inconsistent pointer cursor shown in the whitespace/gutter area around chat messages.

Fixes #324173

## Notes for reviewers

- The rule is scoped to `.agent-sessions-workbench .interactive-list > .monaco-list.mouse-support` so it only affects the chat message list and does not leak into other lists.