### PR TITLE
Make grep the new default search tool output format

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -4342,7 +4342,7 @@
           },
           "github.copilot.chat.tools.grepSearch.outputFormat": {
             "type": "string",
-            "default": "tag",
+            "default": "grep",
             "enum": [
               "grep",
               "tag"

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -278,7 +278,7 @@
 	"github.copilot.config.autoFix": "Automatically fix diagnostics for edited files.",
 	"github.copilot.config.rateLimitAutoSwitchToAuto": "Automatically switch to the Auto model and retry when you hit a per-model rate limit.",
 	"github.copilot.tools.createNewWorkspace.userDescription": "Scaffold a new workspace in VS Code",
-	"github.copilot.chat.tools.grepSearch.outputFormat": "The output format for the grep search tool. Can be either 'grep' or 'tag'. The default is 'tag'.",
+	"github.copilot.chat.tools.grepSearch.outputFormat": "The output format for the grep search tool. Can be either 'grep' or 'tag'. The default is 'grep'.",
 	"github.copilot.chat.tools.grepSearch.defaultMaxResults": "The default maximum number of results to return from the grep search tool. The default is 20.",
 	"github.copilot.chat.tools.grepSearch.maxResultsCap": "The maximum number of results that can be returned from the grep search tool. The default is 200.",
 	"copilot.tools.errors.description": "Check errors for a particular file",

--- a/extensions/copilot/src/extension/tools/node/findTextInFilesTool.tsx
+++ b/extensions/copilot/src/extension/tools/node/findTextInFilesTool.tsx
@@ -456,7 +456,7 @@ Then if you want to include those files you can call the tool again by setting "
 
 	private getOutputFormat(): 'grep' | 'tag' {
 		const expFlag = this.configurationService.getExperimentBasedConfig(ConfigKey.GrepSearchOutputFormat, this.experimentationService);
-		return expFlag === 'grep' ? 'grep' : 'tag';
+		return expFlag === 'tag' ? 'tag' : 'grep';
 	}
 
 	private getDefaultMaxResults(): number {

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -1093,7 +1093,7 @@ export namespace ConfigKey {
 	export const LocalIndexEnabled = defineSetting<boolean>('chat.localIndex.enabled', ConfigType.ExperimentBased, false);
 
 	/** grep_search configs */
-	export const GrepSearchOutputFormat = defineSetting<'grep' | 'tag'>('chat.tools.grepSearch.outputFormat', ConfigType.ExperimentBased, 'tag');
+	export const GrepSearchOutputFormat = defineSetting<'grep' | 'tag'>('chat.tools.grepSearch.outputFormat', ConfigType.ExperimentBased, 'grep');
 	export const GrepSearchDefaultMaxResults = defineSetting<number>('chat.tools.grepSearch.defaultMaxResults', ConfigType.ExperimentBased, 20);
 	export const GrepSearchMaxResultsCap = defineSetting<number>('chat.tools.grepSearch.maxResultsCap', ConfigType.ExperimentBased, 200);
 }


### PR DESCRIPTION
Update the default output format for the grep search tool from 'tag' to 'grep'. This change ensures that users will now receive results in the grep format by default. No issues are associated with this update.

