### PR TITLE
a11y: Update warning icon colors in 2026 Light theme

### DIFF
--- a/extensions/theme-defaults/themes/2026-light.json
+++ b/extensions/theme-defaults/themes/2026-light.json
@@ -226,7 +226,7 @@
 		"notificationsWarningIcon.foreground": "#B69500",
 		"notificationsErrorIcon.foreground": "#ad0707",
 		"notificationsInfoIcon.foreground": "#0069CC",
-		"problemsWarningIcon.foreground": "#667309",
+		"problemsWarningIcon.foreground": "#895503",
 		"activityWarningBadge.foreground": "#202020",
 		"activityWarningBadge.background": "#F2C94C",
 		"activityErrorBadge.foreground": "#FFFFFF",

--- a/extensions/theme-defaults/themes/2026-light.json
+++ b/extensions/theme-defaults/themes/2026-light.json
@@ -226,6 +226,7 @@
 		"notificationsWarningIcon.foreground": "#B69500",
 		"notificationsErrorIcon.foreground": "#ad0707",
 		"notificationsInfoIcon.foreground": "#0069CC",
+		"problemsWarningIcon.foreground": "#667309",
 		"activityWarningBadge.foreground": "#202020",
 		"activityWarningBadge.background": "#F2C94C",
 		"activityErrorBadge.foreground": "#FFFFFF",

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -431,30 +431,18 @@
 
 .sessions-chat-picker-slot .action-label.warning {
 	color: var(--vscode-problemsWarningIcon-foreground);
-	opacity: 0.75;
 }
 
 .sessions-chat-picker-slot .action-label.warning .codicon {
 	color: var(--vscode-problemsWarningIcon-foreground) !important;
 }
 
-.sessions-chat-picker-slot .action-label.warning:hover {
-	color: var(--vscode-problemsWarningIcon-foreground);
-	opacity: 1;
-}
-
 .sessions-chat-picker-slot .action-label.info {
 	color: var(--vscode-problemsInfoIcon-foreground);
-	opacity: 0.75;
 }
 
 .sessions-chat-picker-slot .action-label.info .codicon {
 	color: var(--vscode-problemsInfoIcon-foreground) !important;
-}
-
-.sessions-chat-picker-slot .action-label.info:hover {
-	color: var(--vscode-problemsInfoIcon-foreground);
-	opacity: 1;
 }
 
 /* Tab bar styles live with the platform widget


### PR DESCRIPTION
Enhance the visibility of the problems warning icon by updating its foreground color in the 2026 Light theme. Remove opacity adjustments for warning and info labels in the chat widget to improve accessibility.

Addresses: https://github.com/microsoft/vscode/issues/321431