### PR TITLE
Style overrides: Adjust title bar height and padding for better alignment

### DIFF
--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -156,10 +156,6 @@
 	padding-bottom: var(--vscode-spacing-size40);
 }
 
-.monaco-workbench.floating-panels .activitybar > .content > .composite-bar {
-	margin-top: var(--vscode-spacing-size20);
-}
-
 /*
  * When the status bar is hidden every floating card sits directly against the window
  * bottom edge. Double the bottom margin (4px → 8px) to match the doubled outer gutter

--- a/src/vs/workbench/browser/part.ts
+++ b/src/vs/workbench/browser/part.ts
@@ -80,7 +80,7 @@ export abstract class Part<MementoType extends object = object> extends Componen
 		this.titleArea = this.createTitleArea(parent, options);
 		this.contentArea = this.createContentArea(parent, options);
 
-		this.partLayout = new PartLayout(this.options, this.contentArea);
+		this.partLayout = new PartLayout(this.options, this.titleArea, this.contentArea);
 
 		this.updateStyles();
 	}
@@ -222,14 +222,15 @@ class PartLayout {
 	private headerVisible: boolean = false;
 	private footerVisible: boolean = false;
 
-	constructor(private options: IPartOptions, private contentArea: HTMLElement | undefined) { }
+	constructor(private options: IPartOptions, private titleArea: HTMLElement | undefined, private contentArea: HTMLElement | undefined) { }
 
 	layout(width: number, height: number): ILayoutContentResult {
 
 		// Title Size: Width (Fill), Height (Variable)
 		let titleSize: Dimension;
 		if (this.options.hasTitle) {
-			titleSize = new Dimension(width, Math.min(height, PartLayout.TITLE_HEIGHT));
+			const titleHeight = this.titleArea?.offsetHeight ?? PartLayout.TITLE_HEIGHT;
+			titleSize = new Dimension(width, Math.min(height, titleHeight));
 		} else {
 			titleSize = Dimension.None;
 		}

--- a/src/vs/workbench/browser/part.ts
+++ b/src/vs/workbench/browser/part.ts
@@ -80,7 +80,7 @@ export abstract class Part<MementoType extends object = object> extends Componen
 		this.titleArea = this.createTitleArea(parent, options);
 		this.contentArea = this.createContentArea(parent, options);
 
-		this.partLayout = new PartLayout(this.options, this.titleArea, this.contentArea);
+		this.partLayout = new PartLayout(this.options, this.contentArea);
 
 		this.updateStyles();
 	}
@@ -223,7 +223,7 @@ class PartLayout {
 	private headerVisible: boolean = false;
 	private footerVisible: boolean = false;
 
-	constructor(private options: IPartOptions, private titleArea: HTMLElement | undefined, private contentArea: HTMLElement | undefined) { }
+	constructor(private options: IPartOptions, private contentArea: HTMLElement | undefined) { }
 
 	layout(width: number, height: number): ILayoutContentResult {
 
@@ -234,7 +234,7 @@ class PartLayout {
 		// check as EditorTabsControl.tabHeight.
 		let titleSize: Dimension;
 		if (this.options.hasTitle) {
-			const isStyleOverride = !!this.titleArea?.closest('.style-override');
+			const isStyleOverride = !!this.contentArea?.closest('.style-override');
 			const titleHeight = isStyleOverride ? PartLayout.TITLE_HEIGHT_STYLE_OVERRIDE : PartLayout.TITLE_HEIGHT;
 			titleSize = new Dimension(width, Math.min(height, titleHeight));
 		} else {

--- a/src/vs/workbench/browser/part.ts
+++ b/src/vs/workbench/browser/part.ts
@@ -217,6 +217,7 @@ class PartLayout {
 
 	private static readonly HEADER_HEIGHT = 35;
 	private static readonly TITLE_HEIGHT = 35;
+	// KEEP IN SYNC WITH: styleOverrides/browser/media/padding.css `.style-override .part > .title { height: 32px }`
 	private static readonly TITLE_HEIGHT_STYLE_OVERRIDE = 32;
 	private static readonly Footer_HEIGHT = 35;
 

--- a/src/vs/workbench/browser/part.ts
+++ b/src/vs/workbench/browser/part.ts
@@ -217,6 +217,7 @@ class PartLayout {
 
 	private static readonly HEADER_HEIGHT = 35;
 	private static readonly TITLE_HEIGHT = 35;
+	private static readonly TITLE_HEIGHT_STYLE_OVERRIDE = 32;
 	private static readonly Footer_HEIGHT = 35;
 
 	private headerVisible: boolean = false;
@@ -226,10 +227,15 @@ class PartLayout {
 
 	layout(width: number, height: number): ILayoutContentResult {
 
-		// Title Size: Width (Fill), Height (Variable)
+		// Title Size: Width (Fill), Height (Variable).
+		// When the Modern UI style-override is active the title bar is 32 px
+		// (set in padding.css). Mirror that value here so the content area
+		// calculation stays in sync. Uses the same `.closest('.style-override')`
+		// check as EditorTabsControl.tabHeight.
 		let titleSize: Dimension;
 		if (this.options.hasTitle) {
-			const titleHeight = this.titleArea?.offsetHeight ?? PartLayout.TITLE_HEIGHT;
+			const isStyleOverride = !!this.titleArea?.closest('.style-override');
+			const titleHeight = isStyleOverride ? PartLayout.TITLE_HEIGHT_STYLE_OVERRIDE : PartLayout.TITLE_HEIGHT;
 			titleSize = new Dimension(width, Math.min(height, titleHeight));
 		} else {
 			titleSize = Dimension.None;

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -301,8 +301,3 @@
 .style-override.monaco-workbench .pane-composite-part.basepanel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .actions-container {
 	gap: 4px;
 }
-
-/* .style-override.monaco-workbench .pane-composite-part > .title.has-composite-bar > .title-actions .monaco-action-bar .action-item,
-.style-override.monaco-workbench .pane-composite-part > .title.has-composite-bar > .global-actions .monaco-action-bar .action-item {
-	margin-bottom: 4px;
-} */

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -262,7 +262,6 @@
 	box-sizing: border-box;
 	height: 24px;
 	line-height: 24px;
-	margin-bottom: 4px;
 }
 
 .style-override.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label::before,
@@ -285,7 +284,6 @@
 	height: 24px;
 	padding: 0;
 	width: 24px;
-	margin-bottom: 4px;
 }
 
 .style-override.monaco-workbench .part.auxiliarybar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .active-item-indicator,
@@ -304,7 +302,7 @@
 	gap: 4px;
 }
 
-.style-override.monaco-workbench .pane-composite-part > .title.has-composite-bar > .title-actions .monaco-action-bar .action-item,
+/* .style-override.monaco-workbench .pane-composite-part > .title.has-composite-bar > .title-actions .monaco-action-bar .action-item,
 .style-override.monaco-workbench .pane-composite-part > .title.has-composite-bar > .global-actions .monaco-action-bar .action-item {
 	margin-bottom: 4px;
-}
+} */

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -45,7 +45,8 @@
 	width: auto;
 }
 
-/* Tighten the part title bar gutters: flush-left, small right inset. Reduce height from 35px to 32px. */
+/* Tighten the part title bar gutters: flush-left, small right inset. Reduce height from 35px to 32px.
+ * KEEP IN SYNC WITH: part.ts PartLayout.TITLE_HEIGHT_STYLE_OVERRIDE */
 .style-override.monaco-workbench .part > .title {
 	height: 32px;
 	padding-left: var(--vscode-spacing-size40, 4px);
@@ -82,6 +83,16 @@
 	.agent-session-item .agent-session-title-toolbar .actions-container {
 		gap: 4px;
 	}
+	&.chat-view-location-auxiliarybar {
+		.chat-view-title-inner {
+			padding: var(--vscode-spacing-size40, 4px);
+		}
+	}
+	&.chat-view-location-sidebar, &.chat-view-location-panel {
+		.chat-view-title-inner {
+			padding: 0 var(--vscode-spacing-size40, 4px) 0 var(--vscode-spacing-size80, 8px);
+		}
+	}
 }
 
 .style-override.monaco-workbench .monaco-pane-view .pane > .pane-header > .actions {
@@ -109,15 +120,3 @@
 	padding-right: 2px;
 }
 
-.style-override.monaco-workbench .chat-viewpane {
-	&.chat-view-location-auxiliarybar {
-		.chat-view-title-inner {
-			padding: 4px;
-		}
-	}
-	&.chat-view-location-sidebar, &.chat-view-location-panel {
-		.chat-view-title-inner {
-			padding: 0 4px 0 8px;
-		}
-	}
-}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -45,14 +45,28 @@
 	width: auto;
 }
 
-/* Tighten the part title bar gutters: flush-left, small right inset. */
+/* Tighten the part title bar gutters: flush-left, small right inset. Reduce height from 35px to 32px. */
 .style-override.monaco-workbench .part > .title {
+	height: 32px;
 	padding-left: var(--vscode-spacing-size40, 4px);
 	padding-right: var(--vscode-spacing-size40, 4px);
 }
 
+.style-override.monaco-workbench .part > .title > .title-label {
+	line-height: 32px;
+}
+
+.style-override.monaco-workbench .part > .title > .title-actions {
+	height: 32px;
+}
+
 .style-override.monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions {
 	padding: 0 4px;
+}
+
+.style-override.monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions .actions-container > li:last-child,
+.style-override.monaco-workbench .part > .title .title-actions .actions-container > li:last-child {
+	margin-right: 0;
 }
 
 /* Inset the part title label (e.g. "Explorer") to align with the content below. */
@@ -92,5 +106,18 @@
 .style-override.monaco-workbench .part.basepanel.top .composite.title,
 .style-override.monaco-workbench .part.basepanel.left .composite.title,
 .style-override.monaco-workbench .part.basepanel.right .composite.title {
-	padding-right: 0;
+	padding-right: 2px;
+}
+
+.style-override.monaco-workbench .chat-viewpane {
+	&.chat-view-location-auxiliarybar {
+		.chat-view-title-inner {
+			padding: 4px;
+		}
+	}
+	&.chat-view-location-sidebar, &.chat-view-location-panel {
+		.chat-view-title-inner {
+			padding: 0 4px 0 8px;
+		}
+	}
 }


### PR DESCRIPTION
This pull request refines the Modern UI style overrides for the VS Code workbench, focusing on making the part title bars more compact and visually consistent. The changes synchronize CSS and TypeScript logic for title bar sizing, tighten spacing and gutters, and remove redundant margins for a cleaner appearance.

**Title Bar Height and Style Synchronization:**
- Reduced the title bar height from 35px to 32px in `.style-override` mode, and ensured this value is kept in sync between the CSS (`padding.css`) and the `PartLayout` logic in `part.ts`. The layout code now dynamically checks for the style override and applies the correct height. [[1]](diffhunk://#diff-c8ee8affb5927140b6da1cb8ec3b4b31cbf0e4116f95bbbfd9d35154799833cbL48-R72) [[2]](diffhunk://#diff-897ee1b8c7895d892a0a4b3bb3b42c25f16d475a640cff8e968b52703b83c561R220-R221) [[3]](diffhunk://#diff-897ee1b8c7895d892a0a4b3bb3b42c25f16d475a640cff8e968b52703b83c561L229-R240)

**Spacing and Margin Adjustments:**
- Removed unnecessary bottom margins from composite bar and action bar items in the activity bar and pane titles, resulting in a tighter and more unified look. [[1]](diffhunk://#diff-c718522311de21a7658a924bbd223350855e39acf9ddd9e1c4eaffa8f76a34dbL265) [[2]](diffhunk://#diff-c718522311de21a7658a924bbd223350855e39acf9ddd9e1c4eaffa8f76a34dbL288) [[3]](diffhunk://#diff-c718522311de21a7658a924bbd223350855e39acf9ddd9e1c4eaffa8f76a34dbL306-L310) [[4]](diffhunk://#diff-96cb2d8573ce4ce529610b032f2044a61b322357bff73870ab0196ceec6f17b3L159-L162)

**Gutter and Padding Improvements:**
- Adjusted paddings for part titles and chat view titles to better align with the new compact design, including specific tweaks for auxiliary bar, sidebar, and panel locations. [[1]](diffhunk://#diff-c8ee8affb5927140b6da1cb8ec3b4b31cbf0e4116f95bbbfd9d35154799833cbL48-R72) [[2]](diffhunk://#diff-c8ee8affb5927140b6da1cb8ec3b4b31cbf0e4116f95bbbfd9d35154799833cbR86-R95)

**Fine-tuning Visual Details:**
- Tweaked right padding on certain panel titles for improved alignment.

These updates ensure a more polished and consistent Modern UI appearance across the workbench.