### PR TITLE
Surface sessions requiring input in the agents titlebar

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -100,9 +100,17 @@ The center section shows a clickable session picker widget. When a session is ac
 
 When no session is active (new chat view) the widget hides its chrome so the center is empty. Clicking opens the session switcher quick pick.
 
+When the primary side bar is hidden and at least one session is **blocked** the widget instead switches to a **requires-input** state (see [Blocked Sessions](#blocked-sessions-center) below).
+
+After the user approves a pending action on a session from the sessions list (e.g. the **Allow** button on an approval row), the widget briefly shows a green "Approved N sessions" confirmation. Each approval within the rolling 3s window increments the count and restarts the countdown; while visible it takes precedence over the requires-input state. Driven by `ISessionActionFeedbackService` (`contrib/sessions`), whose `approvedCount` observable the widget reads.
+
 ### Agent Host Filter (Left)
 
 When multiple remote agent hosts are known, a dropdown pill in the left toolbar scopes the workbench to a specific host. When no hosts are known the pill acts as a re-discover trigger.
+
+### Blocked Sessions (Center)
+
+When the primary side bar is hidden and at least one session is **blocked**, the center session picker widget (`SessionsTitleBarWidget`) switches from the active-session pill to an orange "N sessions require input" state (orange foreground, background and border), and blinks twice whenever a newly blocked session appears. A session counts as blocked when it needs input, or — while not in progress — has failing CI checks or unresolved pull request comments. Detection is owned by `IBlockedSessionsService` (`contrib/blockedSessions`), which reuses the shared, background-polled GitHub CI / review-thread models via `computePullRequestIconStatus`. Clicking the widget opens those sessions rendered exactly like the sessions list but flat — no sections, groups or workspace headers — via the reusable `SessionsFlatList` (exported from `sessionsList.ts`) in a dropdown anchored below the command center box using `IContextViewService`; clicking a row opens the session like the main list. When the side bar is visible or no session is blocked, the widget behaves as the normal active-session pill. Whether the widget enters this state is driven directly by the `IBlockedSessionsService.blockedSessions` observable together with `Parts.SIDEBAR_PART` visibility.
 
 ### Account Widget (Right)
 

--- a/src/vs/sessions/SESSIONS_LIST.md
+++ b/src/vs/sessions/SESSIONS_LIST.md
@@ -34,6 +34,8 @@ Each session row displays:
 - **Status description or timestamp** — InProgress/NeedsInput/Error show a status message; otherwise a relative timestamp
 - **Approval row** (optional) — pending agent approvals with an "Allow" button
 
+`SessionsFlatList` reuses the same session row renderer for sectionless surfaces, including the approval row and dynamic row height updates. Consumers that size their own container listen for content-height changes and relayout the list. When embedded inside another hover, consumers disable row hovers so moving over the list does not replace the parent hover.
+
 ### Grouping
 
 Sessions are organized into sections with fixed priority:

--- a/src/vs/sessions/browser/menus.ts
+++ b/src/vs/sessions/browser/menus.ts
@@ -18,6 +18,7 @@ export const Menus = {
 	TitleBarCenterRight: new MenuId('SessionsTitleBarCenterRight'),
 	TitleBarSessionTitle: new MenuId('SessionsTitleBarSessionTitle'),
 	TitleBarSessionMenu: new MenuId('SessionsTitleBarSessionMenu'),
+	BlockedSessionsHeader: new MenuId('SessionsBlockedSessionsHeader'),
 	TitleBarRightLayout: new MenuId('SessionsTitleBarRightLayout'),
 	MobileTitleBarCenter: new MenuId('SessionsMobileTitleBarCenter'),
 	PanelTitle: new MenuId('SessionsPanelTitle'),

--- a/src/vs/sessions/contrib/blockedSessions/browser/blockedSessions.contribution.ts
+++ b/src/vs/sessions/contrib/blockedSessions/browser/blockedSessions.contribution.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { BlockedSessionsService, IBlockedSessionsService } from './blockedSessionsService.js';
+
+// The blocked-sessions UI is surfaced by the sessions titlebar widget
+// (see `contrib/sessions/browser/sessionsTitleBarWidget.ts`), which consumes this
+// service. Here we only register the detection service itself.
+registerSingleton(IBlockedSessionsService, BlockedSessionsService, InstantiationType.Delayed);

--- a/src/vs/sessions/contrib/blockedSessions/browser/blockedSessionsService.ts
+++ b/src/vs/sessions/contrib/blockedSessions/browser/blockedSessionsService.ts
@@ -14,6 +14,24 @@ import { computePullRequestIconStatus } from '../../github/browser/pullRequestIc
 export const IBlockedSessionsService = createDecorator<IBlockedSessionsService>('blockedSessionsService');
 
 /**
+ * Why a session is surfaced as "blocked" (i.e. needs the user's attention).
+ */
+export const enum BlockedSessionReason {
+	/** The session is waiting for the user to provide input or approve an action. */
+	NeedsInput = 'needsInput',
+	/** The session's pull request has failing CI checks. */
+	FailingCI = 'failingCI',
+	/** The session's pull request has unresolved review comments. */
+	UnresolvedComments = 'unresolvedComments',
+}
+
+/** A blocked session paired with the reason it needs attention. */
+export interface IBlockedSession {
+	readonly session: ISession;
+	readonly reason: BlockedSessionReason;
+}
+
+/**
  * Surfaces the set of "blocked" sessions — sessions that require the user's
  * attention. A session is considered blocked when it:
  *
@@ -28,6 +46,9 @@ export interface IBlockedSessionsService {
 
 	/** The blocked sessions, most-recently-updated first. */
 	readonly blockedSessions: IObservable<readonly ISession[]>;
+
+	/** The blocked sessions paired with their reason, most-recently-updated first. */
+	readonly blockedSessionsWithReasons: IObservable<readonly IBlockedSession[]>;
 }
 
 export class BlockedSessionsService extends Disposable implements IBlockedSessionsService {
@@ -37,6 +58,7 @@ export class BlockedSessionsService extends Disposable implements IBlockedSessio
 	private readonly _allSessions: IObservable<readonly ISession[]>;
 
 	readonly blockedSessions: IObservable<readonly ISession[]>;
+	readonly blockedSessionsWithReasons: IObservable<readonly IBlockedSession[]>;
 
 	constructor(
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
@@ -50,40 +72,54 @@ export class BlockedSessionsService extends Disposable implements IBlockedSessio
 			() => this._sessionsManagementService.getSessions(),
 		);
 
-		this.blockedSessions = derived(this, reader => {
-			const blocked = this._allSessions.read(reader).filter(session => this._isBlocked(reader, session));
-			return blocked.sort((a, b) => b.updatedAt.read(reader).getTime() - a.updatedAt.read(reader).getTime());
+		this.blockedSessionsWithReasons = derived(this, reader => {
+			const blocked: IBlockedSession[] = [];
+			for (const session of this._allSessions.read(reader)) {
+				const reason = this._getBlockedReason(reader, session);
+				if (reason !== undefined) {
+					blocked.push({ session, reason });
+				}
+			}
+			return blocked.sort((a, b) => b.session.updatedAt.read(reader).getTime() - a.session.updatedAt.read(reader).getTime());
 		});
+
+		this.blockedSessions = derived(this, reader => this.blockedSessionsWithReasons.read(reader).map(blocked => blocked.session));
 	}
 
-	private _isBlocked(reader: IReaderWithStore, session: ISession): boolean {
+	private _getBlockedReason(reader: IReaderWithStore, session: ISession): BlockedSessionReason | undefined {
 		if (session.isArchived.read(reader)) {
-			return false;
+			return undefined;
 		}
 
 		const status = session.status.read(reader);
 		if (status === SessionStatus.NeedsInput) {
-			return true;
+			return BlockedSessionReason.NeedsInput;
 		}
 
 		// CI failures and pull request comments only count while the session is
 		// not actively in progress.
 		if (status === SessionStatus.InProgress) {
-			return false;
+			return undefined;
 		}
 
 		const gitHubInfo = session.workspace.read(reader)?.folders[0]?.gitRepository?.gitHubInfo.read(reader);
 		if (!gitHubInfo?.pullRequest) {
-			return false;
+			return undefined;
 		}
 
 		const prRef = reader.store.add(this._gitHubService.createPullRequestModelReference(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number));
 		const livePR = prRef.object.pullRequest.read(reader);
 		if (!livePR) {
-			return false;
+			return undefined;
 		}
 
 		const prStatus = computePullRequestIconStatus(reader, this._gitHubService, gitHubInfo.owner, gitHubInfo.repo, livePR);
-		return !!prStatus.hasFailingChecks || !!prStatus.hasUnresolvedComments;
+		if (prStatus.hasFailingChecks) {
+			return BlockedSessionReason.FailingCI;
+		}
+		if (prStatus.hasUnresolvedComments) {
+			return BlockedSessionReason.UnresolvedComments;
+		}
+		return undefined;
 	}
 }

--- a/src/vs/sessions/contrib/blockedSessions/browser/blockedSessionsService.ts
+++ b/src/vs/sessions/contrib/blockedSessions/browser/blockedSessionsService.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { derived, IObservable, IReaderWithStore, observableFromEvent } from '../../../../base/common/observable.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { ISession, SessionStatus } from '../../../services/sessions/common/session.js';
+import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+import { IGitHubService } from '../../github/browser/githubService.js';
+import { computePullRequestIconStatus } from '../../github/browser/pullRequestIconStatus.js';
+
+export const IBlockedSessionsService = createDecorator<IBlockedSessionsService>('blockedSessionsService');
+
+/**
+ * Surfaces the set of "blocked" sessions — sessions that require the user's
+ * attention. A session is considered blocked when it:
+ *
+ * - needs input (`SessionStatus.NeedsInput`), or
+ * - has failing CI checks while not in progress, or
+ * - has unresolved pull request comments while not in progress.
+ *
+ * Archived (done) sessions are never reported as blocked.
+ */
+export interface IBlockedSessionsService {
+	readonly _serviceBrand: undefined;
+
+	/** The blocked sessions, most-recently-updated first. */
+	readonly blockedSessions: IObservable<readonly ISession[]>;
+}
+
+export class BlockedSessionsService extends Disposable implements IBlockedSessionsService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _allSessions: IObservable<readonly ISession[]>;
+
+	readonly blockedSessions: IObservable<readonly ISession[]>;
+
+	constructor(
+		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
+		@IGitHubService private readonly _gitHubService: IGitHubService,
+	) {
+		super();
+
+		this._allSessions = observableFromEvent(
+			this,
+			this._sessionsManagementService.onDidChangeSessions,
+			() => this._sessionsManagementService.getSessions(),
+		);
+
+		this.blockedSessions = derived(this, reader => {
+			const blocked = this._allSessions.read(reader).filter(session => this._isBlocked(reader, session));
+			return blocked.sort((a, b) => b.updatedAt.read(reader).getTime() - a.updatedAt.read(reader).getTime());
+		});
+	}
+
+	private _isBlocked(reader: IReaderWithStore, session: ISession): boolean {
+		if (session.isArchived.read(reader)) {
+			return false;
+		}
+
+		const status = session.status.read(reader);
+		if (status === SessionStatus.NeedsInput) {
+			return true;
+		}
+
+		// CI failures and pull request comments only count while the session is
+		// not actively in progress.
+		if (status === SessionStatus.InProgress) {
+			return false;
+		}
+
+		const gitHubInfo = session.workspace.read(reader)?.folders[0]?.gitRepository?.gitHubInfo.read(reader);
+		if (!gitHubInfo?.pullRequest) {
+			return false;
+		}
+
+		const prRef = reader.store.add(this._gitHubService.createPullRequestModelReference(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number));
+		const livePR = prRef.object.pullRequest.read(reader);
+		if (!livePR) {
+			return false;
+		}
+
+		const prStatus = computePullRequestIconStatus(reader, this._gitHubService, gitHubInfo.owner, gitHubInfo.repo, livePR);
+		return !!prStatus.hasFailingChecks || !!prStatus.hasUnresolvedComments;
+	}
+}

--- a/src/vs/sessions/contrib/blockedSessions/test/browser/blockedSessionsService.test.ts
+++ b/src/vs/sessions/contrib/blockedSessions/test/browser/blockedSessionsService.test.ts
@@ -17,7 +17,7 @@ import { GitHubPullRequestReviewThreadsModel } from '../../../github/browser/mod
 import { GitHubCIOverallStatus, GitHubPullRequestState, IGitHubPullRequest, IGitHubPullRequestReviewThread } from '../../../github/common/types.js';
 import { ISession, IGitHubInfo, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { ISessionsChangeEvent, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
-import { BlockedSessionsService } from '../../browser/blockedSessionsService.js';
+import { BlockedSessionReason, BlockedSessionsService } from '../../browser/blockedSessionsService.js';
 
 suite('BlockedSessionsService', () => {
 
@@ -37,6 +37,10 @@ suite('BlockedSessionsService', () => {
 
 	function blockedIds(service: BlockedSessionsService): string[] {
 		return service.blockedSessions.get().map(s => s.sessionId);
+	}
+
+	function blockedReasons(service: BlockedSessionsService): Array<[string, BlockedSessionReason]> {
+		return service.blockedSessionsWithReasons.get().map((b): [string, BlockedSessionReason] => [b.session.sessionId, b.reason]);
 	}
 
 	test('session needing input is blocked', () => {
@@ -103,6 +107,33 @@ suite('BlockedSessionsService', () => {
 		const newer = new TestSession('newer', SessionStatus.NeedsInput, { updatedAt: new Date(5000) });
 		const { service } = createService([older, newer], new TestGitHubService());
 		assert.deepStrictEqual(blockedIds(service), ['newer', 'older']);
+	});
+
+	test('reports the reason each session is blocked', () => {
+		const gitHub = new TestGitHubService();
+		gitHub.setPullRequest('owner', 'repo', 20, openPullRequest(20, 'sha20'));
+		gitHub.setCIStatus('owner', 'repo', 20, 'sha20', GitHubCIOverallStatus.Failure);
+		gitHub.setPullRequest('owner', 'repo', 21, openPullRequest(21, 'sha21'));
+		gitHub.setReviewThreads('owner', 'repo', 21, [{ isResolved: false } as IGitHubPullRequestReviewThread]);
+		const needsInput = new TestSession('needsinput', SessionStatus.NeedsInput, { updatedAt: new Date(3000) });
+		const failingCI = new TestSession('failingci', SessionStatus.Completed, { pr: { owner: 'owner', repo: 'repo', number: 20 }, updatedAt: new Date(2000) });
+		const comments = new TestSession('comments', SessionStatus.Completed, { pr: { owner: 'owner', repo: 'repo', number: 21 }, updatedAt: new Date(1000) });
+		const { service } = createService([needsInput, failingCI, comments], gitHub);
+		assert.deepStrictEqual(blockedReasons(service), [
+			['needsinput', BlockedSessionReason.NeedsInput],
+			['failingci', BlockedSessionReason.FailingCI],
+			['comments', BlockedSessionReason.UnresolvedComments],
+		]);
+	});
+
+	test('failing CI takes precedence over unresolved comments', () => {
+		const gitHub = new TestGitHubService();
+		gitHub.setPullRequest('owner', 'repo', 22, openPullRequest(22, 'sha22'));
+		gitHub.setCIStatus('owner', 'repo', 22, 'sha22', GitHubCIOverallStatus.Failure);
+		gitHub.setReviewThreads('owner', 'repo', 22, [{ isResolved: false } as IGitHubPullRequestReviewThread]);
+		const session = new TestSession('both', SessionStatus.Completed, { pr: { owner: 'owner', repo: 'repo', number: 22 } });
+		const { service } = createService([session], gitHub);
+		assert.deepStrictEqual(blockedReasons(service), [['both', BlockedSessionReason.FailingCI]]);
 	});
 });
 

--- a/src/vs/sessions/contrib/blockedSessions/test/browser/blockedSessionsService.test.ts
+++ b/src/vs/sessions/contrib/blockedSessions/test/browser/blockedSessionsService.test.ts
@@ -1,0 +1,246 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter } from '../../../../../base/common/event.js';
+import { DisposableStore, ImmortalReference, type IReference } from '../../../../../base/common/lifecycle.js';
+import { autorun, ISettableObservable, observableValue, type IObservable } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IGitHubService } from '../../../github/browser/githubService.js';
+import { GitHubPullRequestCIModel } from '../../../github/browser/models/githubPullRequestCIModel.js';
+import { GitHubPullRequestModel } from '../../../github/browser/models/githubPullRequestModel.js';
+import { GitHubPullRequestReviewThreadsModel } from '../../../github/browser/models/githubPullRequestReviewThreadsModel.js';
+import { GitHubCIOverallStatus, GitHubPullRequestState, IGitHubPullRequest, IGitHubPullRequestReviewThread } from '../../../github/common/types.js';
+import { ISession, IGitHubInfo, SessionStatus } from '../../../../services/sessions/common/session.js';
+import { ISessionsChangeEvent, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { BlockedSessionsService } from '../../browser/blockedSessionsService.js';
+
+suite('BlockedSessionsService', () => {
+
+	const store = new DisposableStore();
+
+	teardown(() => store.clear());
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createService(sessions: TestSession[], gitHubService: TestGitHubService): { service: BlockedSessionsService; management: TestSessionsManagementService } {
+		const management = new TestSessionsManagementService(sessions as unknown as ISession[]);
+		const service = store.add(new BlockedSessionsService(management as unknown as ISessionsManagementService, gitHubService as unknown as IGitHubService));
+		// Keep the derived live so per-session model references are actually read.
+		store.add(autorun(reader => { service.blockedSessions.read(reader); }));
+		return { service, management };
+	}
+
+	function blockedIds(service: BlockedSessionsService): string[] {
+		return service.blockedSessions.get().map(s => s.sessionId);
+	}
+
+	test('session needing input is blocked', () => {
+		const session = new TestSession('s1', SessionStatus.NeedsInput);
+		const { service } = createService([session], new TestGitHubService());
+		assert.deepStrictEqual(blockedIds(service), ['s1']);
+	});
+
+	test('in-progress, completed (no PR) and archived sessions are not blocked', () => {
+		const inProgress = new TestSession('inprogress', SessionStatus.InProgress);
+		const completed = new TestSession('completed', SessionStatus.Completed);
+		const archived = new TestSession('archived', SessionStatus.NeedsInput, { archived: true });
+		const { service } = createService([inProgress, completed, archived], new TestGitHubService());
+		assert.deepStrictEqual(blockedIds(service), []);
+	});
+
+	test('completed session with failing CI checks is blocked', () => {
+		const gitHub = new TestGitHubService();
+		gitHub.setPullRequest('owner', 'repo', 7, openPullRequest(7, 'sha7'));
+		gitHub.setCIStatus('owner', 'repo', 7, 'sha7', GitHubCIOverallStatus.Failure);
+		const session = new TestSession('ci', SessionStatus.Completed, { pr: { owner: 'owner', repo: 'repo', number: 7 } });
+		const { service } = createService([session], gitHub);
+		assert.deepStrictEqual(blockedIds(service), ['ci']);
+	});
+
+	test('completed session with unresolved PR comments is blocked', () => {
+		const gitHub = new TestGitHubService();
+		gitHub.setPullRequest('owner', 'repo', 8, openPullRequest(8, 'sha8'));
+		gitHub.setReviewThreads('owner', 'repo', 8, [{ isResolved: false } as IGitHubPullRequestReviewThread]);
+		const session = new TestSession('comments', SessionStatus.Completed, { pr: { owner: 'owner', repo: 'repo', number: 8 } });
+		const { service } = createService([session], gitHub);
+		assert.deepStrictEqual(blockedIds(service), ['comments']);
+	});
+
+	test('in-progress session with failing CI is not blocked', () => {
+		const gitHub = new TestGitHubService();
+		gitHub.setPullRequest('owner', 'repo', 9, openPullRequest(9, 'sha9'));
+		gitHub.setCIStatus('owner', 'repo', 9, 'sha9', GitHubCIOverallStatus.Failure);
+		const session = new TestSession('busy', SessionStatus.InProgress, { pr: { owner: 'owner', repo: 'repo', number: 9 } });
+		const { service } = createService([session], gitHub);
+		assert.deepStrictEqual(blockedIds(service), []);
+	});
+
+	test('completed session with passing CI and resolved comments is not blocked', () => {
+		const gitHub = new TestGitHubService();
+		gitHub.setPullRequest('owner', 'repo', 10, openPullRequest(10, 'sha10'));
+		gitHub.setCIStatus('owner', 'repo', 10, 'sha10', GitHubCIOverallStatus.Success);
+		gitHub.setReviewThreads('owner', 'repo', 10, [{ isResolved: true } as IGitHubPullRequestReviewThread]);
+		const session = new TestSession('clean', SessionStatus.Completed, { pr: { owner: 'owner', repo: 'repo', number: 10 } });
+		const { service } = createService([session], gitHub);
+		assert.deepStrictEqual(blockedIds(service), []);
+	});
+
+	test('blocked sessions update reactively when status changes', () => {
+		const session = new TestSession('reactive', SessionStatus.Completed);
+		const { service } = createService([session], new TestGitHubService());
+		assert.deepStrictEqual(blockedIds(service), []);
+		session.setStatus(SessionStatus.NeedsInput);
+		assert.deepStrictEqual(blockedIds(service), ['reactive']);
+	});
+
+	test('blocked sessions are sorted most-recently-updated first', () => {
+		const older = new TestSession('older', SessionStatus.NeedsInput, { updatedAt: new Date(1000) });
+		const newer = new TestSession('newer', SessionStatus.NeedsInput, { updatedAt: new Date(5000) });
+		const { service } = createService([older, newer], new TestGitHubService());
+		assert.deepStrictEqual(blockedIds(service), ['newer', 'older']);
+	});
+});
+
+function openPullRequest(number: number, headSha: string): IGitHubPullRequest {
+	return { number, headSha, isDraft: false, state: GitHubPullRequestState.Open } as unknown as IGitHubPullRequest;
+}
+
+interface ITestSessionOptions {
+	readonly archived?: boolean;
+	readonly pr?: { owner: string; repo: string; number: number };
+	readonly updatedAt?: Date;
+}
+
+class TestSession {
+	readonly sessionId: string;
+	readonly resource: URI;
+	readonly status: ISettableObservable<SessionStatus>;
+	readonly isArchived: IObservable<boolean>;
+	readonly updatedAt: IObservable<Date>;
+	readonly workspace: IObservable<unknown>;
+
+	private readonly _status: ISettableObservable<SessionStatus>;
+
+	constructor(id: string, status: SessionStatus, options: ITestSessionOptions = {}) {
+		this.sessionId = id;
+		this.resource = URI.parse(`test-session:/${id}`);
+		this._status = observableValue<SessionStatus>(`test.status.${id}`, status);
+		this.status = this._status;
+		this.isArchived = observableValue<boolean>(`test.archived.${id}`, options.archived ?? false);
+		this.updatedAt = observableValue<Date>(`test.updatedAt.${id}`, options.updatedAt ?? new Date(0));
+
+		const gitHubInfo: IGitHubInfo | undefined = options.pr
+			? { owner: options.pr.owner, repo: options.pr.repo, pullRequest: { number: options.pr.number, uri: URI.parse(`https://github.com/${options.pr.owner}/${options.pr.repo}/pull/${options.pr.number}`) } }
+			: undefined;
+		const gitHubInfoObs = observableValue<IGitHubInfo | undefined>(`test.gitHubInfo.${id}`, gitHubInfo);
+		this.workspace = observableValue<unknown>(`test.workspace.${id}`, {
+			folders: [{ gitRepository: { gitHubInfo: gitHubInfoObs } }],
+		});
+	}
+
+	setStatus(status: SessionStatus): void {
+		this._status.set(status, undefined);
+	}
+}
+
+class TestSessionsManagementService extends mock<ISessionsManagementService>() {
+
+	private readonly _onDidChangeSessions = new Emitter<ISessionsChangeEvent>();
+	override readonly onDidChangeSessions = this._onDidChangeSessions.event;
+
+	constructor(private readonly _sessions: ISession[]) {
+		super();
+	}
+
+	override getSessions(): ISession[] {
+		return this._sessions;
+	}
+
+	override getSession(resource: URI): ISession | undefined {
+		return this._sessions.find(s => s.resource.toString() === resource.toString());
+	}
+}
+
+class TestGitHubService extends mock<IGitHubService>() {
+
+	private readonly _prModels = new Map<string, TestPullRequestModel>();
+	private readonly _ciModels = new Map<string, TestCIModel>();
+	private readonly _reviewThreadModels = new Map<string, TestReviewThreadsModel>();
+
+	override createPullRequestModelReference(owner: string, repo: string, prNumber: number): IReference<GitHubPullRequestModel> {
+		return new ImmortalReference(this._prModel(owner, repo, prNumber) as unknown as GitHubPullRequestModel);
+	}
+
+	override createPullRequestCIModelReference(owner: string, repo: string, prNumber: number, headSha: string): IReference<GitHubPullRequestCIModel> {
+		return new ImmortalReference(this._ciModel(owner, repo, prNumber, headSha) as unknown as GitHubPullRequestCIModel);
+	}
+
+	override createPullRequestReviewThreadsModelReference(owner: string, repo: string, prNumber: number): IReference<GitHubPullRequestReviewThreadsModel> {
+		return new ImmortalReference(this._reviewThreadModel(owner, repo, prNumber) as unknown as GitHubPullRequestReviewThreadsModel);
+	}
+
+	setPullRequest(owner: string, repo: string, prNumber: number, pullRequest: IGitHubPullRequest): void {
+		this._prModel(owner, repo, prNumber).set(pullRequest);
+	}
+
+	setCIStatus(owner: string, repo: string, prNumber: number, headSha: string, status: GitHubCIOverallStatus): void {
+		this._ciModel(owner, repo, prNumber, headSha).set(status);
+	}
+
+	setReviewThreads(owner: string, repo: string, prNumber: number, threads: readonly IGitHubPullRequestReviewThread[]): void {
+		this._reviewThreadModel(owner, repo, prNumber).set(threads);
+	}
+
+	private _prModel(owner: string, repo: string, prNumber: number): TestPullRequestModel {
+		const key = `${owner}/${repo}/${prNumber}`;
+		let model = this._prModels.get(key);
+		if (!model) {
+			model = new TestPullRequestModel();
+			this._prModels.set(key, model);
+		}
+		return model;
+	}
+
+	private _ciModel(owner: string, repo: string, prNumber: number, headSha: string): TestCIModel {
+		const key = `${owner}/${repo}/${prNumber}/${headSha}`;
+		let model = this._ciModels.get(key);
+		if (!model) {
+			model = new TestCIModel();
+			this._ciModels.set(key, model);
+		}
+		return model;
+	}
+
+	private _reviewThreadModel(owner: string, repo: string, prNumber: number): TestReviewThreadsModel {
+		const key = `${owner}/${repo}/${prNumber}`;
+		let model = this._reviewThreadModels.get(key);
+		if (!model) {
+			model = new TestReviewThreadsModel();
+			this._reviewThreadModels.set(key, model);
+		}
+		return model;
+	}
+}
+
+class TestPullRequestModel {
+	private readonly _pullRequest = observableValue<IGitHubPullRequest | undefined>('test.pullRequest', undefined);
+	readonly pullRequest: IObservable<IGitHubPullRequest | undefined> = this._pullRequest;
+	set(pullRequest: IGitHubPullRequest): void { this._pullRequest.set(pullRequest, undefined); }
+}
+
+class TestCIModel {
+	private readonly _overallStatus = observableValue<GitHubCIOverallStatus>('test.ciStatus', GitHubCIOverallStatus.Neutral);
+	readonly overallStatus: IObservable<GitHubCIOverallStatus> = this._overallStatus;
+	set(status: GitHubCIOverallStatus): void { this._overallStatus.set(status, undefined); }
+}
+
+class TestReviewThreadsModel {
+	private readonly _reviewThreads = observableValue<readonly IGitHubPullRequestReviewThread[]>('test.reviewThreads', []);
+	readonly reviewThreads: IObservable<readonly IGitHubPullRequestReviewThread[]> = this._reviewThreads;
+	set(threads: readonly IGitHubPullRequestReviewThread[]): void { this._reviewThreads.set(threads, undefined); }
+}

--- a/src/vs/sessions/contrib/sessions/browser/blockedSessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/blockedSessionsList.ts
@@ -1,0 +1,128 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import './media/blockedSessionsList.css';
+import { $, append } from '../../../../base/browser/dom.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { localize } from '../../../../nls.js';
+import { URI } from '../../../../base/common/uri.js';
+import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { Menus } from '../../../browser/menus.js';
+import { ISession } from '../../../services/sessions/common/session.js';
+import { SessionsFlatList } from './views/sessionsList.js';
+import { AgentSessionApprovalModel } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
+
+/** Fixed width of the blocked-sessions list, in pixels. */
+const BLOCKED_LIST_WIDTH = 360;
+/** Maximum number of rows shown before the list scrolls. */
+const BLOCKED_LIST_MAX_VISIBLE_ROWS = 8;
+/** Maximum number of terminal-command lines shown in a session's approval prompt. */
+const BLOCKED_LIST_APPROVAL_ROW_MAX_LINES = 5;
+
+export interface IBlockedSessionsListOptions {
+	/** Invoked when a session row is activated (clicked or opened via keyboard). */
+	readonly onSessionOpen: (resource: URI, preserveFocus: boolean, sideBySide: boolean) => void;
+	/** Width of the list, in pixels. Defaults to a fixed width when omitted. */
+	readonly width?: number;
+	/** Approval model forwarded to the underlying list (see {@link ISessionsFlatListOptions.approvalModel}). */
+	readonly approvalModel?: AgentSessionApprovalModel;
+}
+
+/**
+ * A self-sizing, flat list of blocked sessions.
+ *
+ * Wraps {@link SessionsFlatList} with the fixed width and bounded height used by
+ * the blocked-sessions dropdown in the sessions titlebar. Hosts append it to a
+ * container, push sessions via {@link setSessions}, and listen to
+ * {@link onDidChangeContentHeight} to reposition the surrounding surface (e.g. a
+ * context view) as rows resolve their heights.
+ */
+export class BlockedSessionsList extends Disposable {
+
+	private readonly _onDidChangeContentHeight = this._register(new Emitter<void>());
+	/** Fires when the list resizes and the host should re-layout its container. */
+	readonly onDidChangeContentHeight: Event<void> = this._onDidChangeContentHeight.event;
+
+	private readonly _onDidApproveSession = this._register(new Emitter<ISession>());
+	/** Fires when a session's pending action is approved from its "Allow" button. */
+	readonly onDidApproveSession: Event<ISession> = this._onDidApproveSession.event;
+
+	private readonly _rowsContainer: HTMLElement;
+	private readonly _list: SessionsFlatList;
+	private _width: number;
+
+	constructor(
+		container: HTMLElement,
+		options: IBlockedSessionsListOptions,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+
+		this._width = options.width ?? BLOCKED_LIST_WIDTH;
+
+		const element = append(container, $('.agent-sessions-blocked-list'));
+
+		// Header row: a title on the left and a toolbar of contributed actions on the
+		// right (e.g. the action that opens the full sessions picker).
+		const header = append(element, $('.agent-sessions-blocked-list-header'));
+		const title = append(header, $('.agent-sessions-blocked-list-title'));
+		title.textContent = localize('sessionsRequiringInput', "Sessions requiring input");
+		const headerActions = append(header, $('.agent-sessions-blocked-list-header-actions'));
+		this._register(instantiationService.createInstance(MenuWorkbenchToolBar, headerActions, Menus.BlockedSessionsHeader, {
+			hiddenItemStrategy: HiddenItemStrategy.NoHide,
+			toolbarOptions: { primaryGroup: () => true },
+			telemetrySource: 'blockedSessionsList.header',
+		}));
+
+		this._rowsContainer = append(element, $('.agent-sessions-blocked-list-rows'));
+
+		this._list = this._register(instantiationService.createInstance(SessionsFlatList, this._rowsContainer, {
+			showSessionHover: true,
+			onSessionOpen: options.onSessionOpen,
+			approvalModel: options.approvalModel,
+			approvalRowMaxLines: BLOCKED_LIST_APPROVAL_ROW_MAX_LINES,
+		}));
+
+		this._register(this._list.onDidChangeContentHeight(() => {
+			this._layout();
+			this._onDidChangeContentHeight.fire();
+		}));
+
+		this._register(this._list.onDidApproveSession(session => this._onDidApproveSession.fire(session)));
+	}
+
+	/** Replace the sessions shown in the list and resize to fit their content. */
+	setSessions(sessions: readonly ISession[]): void {
+		this._list.setSessions(sessions);
+		this._layout();
+	}
+
+	/** Move keyboard focus into the list. */
+	focus(): void {
+		this._list.focus();
+	}
+
+	/**
+	 * Update the list width (e.g. when the anchoring widget reflows as the window
+	 * resizes) and re-layout to the new width.
+	 */
+	setWidth(width: number): void {
+		if (this._width === width) {
+			return;
+		}
+		this._width = width;
+		this._layout();
+	}
+
+	private _layout(): void {
+		const maxHeight = BLOCKED_LIST_MAX_VISIBLE_ROWS * this._list.getRowHeight();
+		const height = Math.min(this._list.getContentHeight(), maxHeight);
+		this._rowsContainer.style.width = `${this._width}px`;
+		this._rowsContainer.style.height = `${height}px`;
+		this._list.layout(height, this._width);
+	}
+}

--- a/src/vs/sessions/contrib/sessions/browser/media/blockedSessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/blockedSessionsList.css
@@ -1,0 +1,109 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Blocked-sessions list, shown below the command center box via the context view. */
+.agent-sessions-blocked-list {
+	display: flex;
+	flex-direction: column;
+	/* A small gap so the dropdown reads as separate from the command center box. */
+	margin-top: var(--vscode-spacing-size60);
+	background-color: var(--vscode-editorWidget-background);
+	border: 1px solid var(--vscode-editorWidget-border);
+	border-radius: var(--vscode-cornerRadius-medium);
+	box-shadow: 0 2px 8px var(--vscode-widget-shadow);
+	overflow: hidden;
+}
+
+/* Header row: title on the left, a toolbar of contributed actions on the right. */
+.agent-sessions-blocked-list .agent-sessions-blocked-list-header {
+	display: flex;
+	align-items: center;
+	gap: var(--vscode-spacing-size40);
+	padding: var(--vscode-spacing-size40) var(--vscode-spacing-size40) var(--vscode-spacing-size40) var(--vscode-spacing-size100);
+	border-bottom: 1px solid var(--vscode-editorWidget-border);
+}
+
+.agent-sessions-blocked-list .agent-sessions-blocked-list-title {
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-weight: var(--vscode-agents-fontWeight-semiBold);
+	color: var(--vscode-foreground);
+}
+
+.agent-sessions-blocked-list .agent-sessions-blocked-list-header-actions {
+	display: flex;
+	align-items: center;
+	flex-shrink: 0;
+	margin-left: auto;
+}
+
+.agent-sessions-blocked-list .agent-sessions-blocked-list-rows {
+	overflow: hidden;
+}
+
+.agent-sessions-blocked-list .agent-sessions-blocked-list-rows .sessions-list-control .monaco-list-row:has(.session-item) {
+	border-radius: 0;
+	margin: 0;
+	width: 100%;
+}
+
+/* Requires-input state of the sessions titlebar widget: shown when the primary
+	side bar is hidden and at least one session is blocked. The command center box
+	(owned by SessionsTitleBarWidget) adopts an orange accent. */
+.command-center .agent-sessions-titlebar-container.agent-sessions-titlebar-requires-input {
+	color: var(--vscode-charts-orange);
+	border-color: var(--vscode-charts-orange);
+	background-color: color-mix(in srgb, var(--vscode-charts-orange) 14%, transparent);
+}
+
+.command-center .agent-sessions-titlebar-container.agent-sessions-titlebar-requires-input:hover {
+	color: var(--vscode-charts-orange);
+	border-color: var(--vscode-charts-orange);
+	background-color: color-mix(in srgb, var(--vscode-charts-orange) 22%, transparent);
+}
+
+.command-center .agent-sessions-titlebar-container.agent-sessions-titlebar-requires-input:focus {
+	outline-color: var(--vscode-charts-orange);
+}
+
+/* The requires-input pill fills the box and centers its label (no dimming). */
+.command-center .agent-sessions-titlebar-container.agent-sessions-titlebar-requires-input .agent-sessions-titlebar-pill {
+	opacity: 1;
+	justify-content: center;
+}
+
+.command-center .agent-sessions-titlebar-requires-input-label {
+	flex: 0 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-weight: var(--vscode-agents-fontWeight-semiBold);
+}
+
+/* Attention blink: pulses the orange fill twice when a new session becomes blocked. */
+@keyframes agent-sessions-titlebar-attention-blink {
+	0%,
+	100% {
+		background-color: color-mix(in srgb, var(--vscode-charts-orange) 14%, transparent);
+	}
+
+	50% {
+		background-color: color-mix(in srgb, var(--vscode-charts-orange) 45%, transparent);
+	}
+}
+
+.command-center .agent-sessions-titlebar-container.agent-sessions-titlebar-requires-input.agent-sessions-titlebar-blink {
+	animation: agent-sessions-titlebar-attention-blink 450ms ease-in-out 2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.command-center .agent-sessions-titlebar-container.agent-sessions-titlebar-requires-input.agent-sessions-titlebar-blink {
+		animation: none;
+	}
+}

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
@@ -140,3 +140,32 @@
 		transition: none;
 	}
 }
+
+/* Approved state: a transient green confirmation shown after the user approves
+	one or more sessions' pending actions from the sessions list. It stays
+	clickable (activating whatever the underlying state would do). */
+.command-center .agent-sessions-titlebar-container.agent-sessions-titlebar-approved {
+	color: var(--vscode-charts-green);
+	border-color: var(--vscode-charts-green);
+	background-color: color-mix(in srgb, var(--vscode-charts-green) 14%, transparent);
+}
+
+.command-center .agent-sessions-titlebar-container.agent-sessions-titlebar-approved:hover {
+	color: var(--vscode-charts-green);
+	border-color: var(--vscode-charts-green);
+	background-color: color-mix(in srgb, var(--vscode-charts-green) 22%, transparent);
+}
+
+.command-center .agent-sessions-titlebar-container.agent-sessions-titlebar-approved .agent-sessions-titlebar-pill {
+	opacity: 1;
+	justify-content: center;
+}
+
+.command-center .agent-sessions-titlebar-approved-label {
+	flex: 0 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-weight: var(--vscode-agents-fontWeight-semiBold);
+}

--- a/src/vs/sessions/contrib/sessions/browser/sessionActionFeedback.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionActionFeedback.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { RunOnceScheduler } from '../../../../base/common/async.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IObservable, observableValue } from '../../../../base/common/observable.js';
+
+/**
+ * Tracks short-lived, user-facing feedback for actions taken on individual
+ * session items in the sessions list (e.g. approving a tool invocation).
+ *
+ * When a session's pending action is approved, {@link approvedCount} briefly
+ * reflects how many sessions were approved within a rolling window; each new
+ * approval increments the count and restarts the window. The sessions titlebar
+ * widget owns an instance and surfaces this as a transient "Approved N sessions"
+ * message.
+ */
+export class SessionActionFeedback extends Disposable {
+
+	/** How long the "Approved N sessions" message stays visible, in milliseconds. */
+	private static readonly WINDOW_MS = 3000;
+
+	private readonly _approvedCount = observableValue<number>('approvedCount', 0);
+	/** Number of sessions approved within the current window; `0` when idle. */
+	readonly approvedCount: IObservable<number> = this._approvedCount;
+
+	private readonly _resetScheduler = this._register(new RunOnceScheduler(
+		() => this._approvedCount.set(0, undefined),
+		SessionActionFeedback.WINDOW_MS,
+	));
+
+	/** Report that a session's pending action was approved. Restarts the window. */
+	notifyApproved(): void {
+		this._approvedCount.set(this._approvedCount.get() + 1, undefined);
+		this._resetScheduler.schedule();
+	}
+}

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -4,26 +4,46 @@
  *--------------------------------------------------------------------------------------------*/
 
 import './media/sessionsTitleBarWidget.css';
-import { $, addDisposableGenericMouseDownListener, addDisposableListener, EventType, reset } from '../../../../base/browser/dom.js';
-import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { $, addDisposableGenericMouseDownListener, addDisposableListener, EventType, isAncestor, reset } from '../../../../base/browser/dom.js';
+import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
+import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { localize } from '../../../../nls.js';
 import { BaseActionViewItem, IBaseActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { MenuRegistry, SubmenuItemAction } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
-import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
 import { Menus } from '../../../browser/menus.js';
 import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
-import { autorun } from '../../../../base/common/observable.js';
+import { autorun, derived, IObservable, observableFromEvent } from '../../../../base/common/observable.js';
+import { onUnexpectedError } from '../../../../base/common/errors.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { URI } from '../../../../base/common/uri.js';
+import { AnchorAlignment, AnchorPosition } from '../../../../base/common/layout.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
+import { IContextViewService, IOpenContextView } from '../../../../platform/contextview/browser/contextView.js';
 import { IsAuxiliaryWindowContext } from '../../../../workbench/common/contextkeys.js';
+import { IWorkbenchLayoutService, Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { SHOW_SESSIONS_PICKER_COMMAND_ID } from './sessionsActions.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
-import { getUntitledSessionTitle } from '../../../services/sessions/common/session.js';
+import { getUntitledSessionTitle, ISession } from '../../../services/sessions/common/session.js';
+import { IBlockedSessionsService } from '../../blockedSessions/browser/blockedSessionsService.js';
+import { BlockedSessionsList } from './blockedSessionsList.js';
+import { SessionActionFeedback } from './sessionActionFeedback.js';
+import { openSessionToTheSide } from './views/sessionsView.js';
+
+/**
+ * Internal command behind the blocked-sessions dropdown header's "Show All
+ * Sessions" action: it dismisses the dropdown (a transient context view) before
+ * opening the full sessions picker so the popup doesn't linger behind it.
+ */
+const SHOW_ALL_SESSIONS_FROM_BLOCKED_LIST_COMMAND_ID = 'sessions.blockedSessions.showAllSessions';
+
 /**
  * Sessions Title Bar Widget - renders the active chat session
  * in the command center of the agent sessions workbench.
@@ -32,15 +52,24 @@ import { getUntitledSessionTitle } from '../../../services/sessions/common/sessi
  * - Kind icon at the beginning (provider type icon)
  * - Repository folder name and active branch/worktree name when available
  *
+ * When the primary side bar is hidden and at least one session is blocked
+ * (needs input, has failing CI checks, or has unresolved pull request comments),
+ * the widget instead adopts an orange "N sessions require input" state and, on
+ * click, reveals those sessions as a flat list in a dropdown anchored below the
+ * command center box. A short blink animation plays whenever a new session
+ * becomes blocked. In every other case it behaves as the active-session pill and
+ * opens the sessions picker on click.
+ *
  * Session actions (changes, terminal, etc.) are rendered via the
  * SessionTitleActions menu toolbar next to this widget.
- *
- * On click, opens the sessions picker.
  */
 export class SessionsTitleBarWidget extends BaseActionViewItem {
 
 	private _container: HTMLElement | undefined;
 	private readonly _dynamicDisposables = this._register(new DisposableStore());
+
+	/** Owns the blink animation's `animationend` listener, kept across re-renders. */
+	private readonly _blinkListener = this._register(new MutableDisposable());
 
 	/** Cached render state to avoid unnecessary DOM rebuilds */
 	private _lastRenderState: string | undefined;
@@ -48,15 +77,69 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 	/** Guard to prevent re-entrant rendering */
 	private _isRendering = false;
 
+	/**
+	 * Last observed blocked-session count, tracked on every render regardless of
+	 * side-bar visibility. Because the count is captured even while the
+	 * requires-input state is hidden (side bar visible), toggling the side bar to
+	 * reveal the indicator leaves the count unchanged and never blinks.
+	 */
+	private _lastBlockedCount = 0;
+
+	/** Reactive primary-side-bar visibility. */
+	private readonly _sidebarVisible: IObservable<boolean>;
+
+	/**
+	 * Blocked sessions that are NOT currently visible on screen. A session the
+	 * user can already see doesn't need the titlebar indicator or a dropdown row,
+	 * so it is excluded from both the "N sessions require input" count and the list.
+	 */
+	private readonly _blockedSessions: IObservable<readonly ISession[]>;
+
+	/** The currently open blocked-sessions dropdown, if any. */
+	private _openContextView: IOpenContextView | undefined;
+	/** The blocked-sessions list rendered inside the open dropdown, if any. */
+	private _blockedList: BlockedSessionsList | undefined;
+
+	/** Drives the transient "Approved N sessions" confirmation. Owned by the widget. */
+	private readonly _sessionActionFeedback: SessionActionFeedback;
+
 	constructor(
 		action: SubmenuItemAction,
 		options: IBaseActionViewItemOptions | undefined,
+		sessionActionFeedback: SessionActionFeedback | undefined,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@ISessionsService private readonly sessionsService: ISessionsService,
 		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
 		@ICommandService private readonly commandService: ICommandService,
+		@IBlockedSessionsService private readonly blockedSessionsService: IBlockedSessionsService,
+		@IContextViewService private readonly contextViewService: IContextViewService,
+		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) {
 		super(undefined, action, options);
+
+		// The widget owns the approval-feedback state; the optional parameter is a
+		// test seam so fixtures can supply a preset instance.
+		this._sessionActionFeedback = sessionActionFeedback ?? this._register(new SessionActionFeedback());
+
+		this._sidebarVisible = observableFromEvent(
+			this,
+			this.layoutService.onDidChangePartVisibility,
+			() => this.layoutService.isVisible(Parts.SIDEBAR_PART),
+		);
+
+		// A session that is currently visible on screen is not treated as blocked:
+		// exclude visible sessions from the requires-input indicator and the dropdown.
+		this._blockedSessions = derived(this, reader => {
+			const visibleSessionIds = new Set<string>();
+			for (const session of this.sessionsService.visibleSessions.read(reader)) {
+				if (session) {
+					visibleSessionIds.add(session.sessionId);
+				}
+			}
+			return this.blockedSessionsService.blockedSessions.read(reader)
+				.filter(session => !visibleSessionIds.has(session.sessionId));
+		});
 
 		// Re-render when the active session's title, workspace, or quick-chat kind changes
 		this._register(autorun(reader => {
@@ -67,6 +150,19 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 				sessionData.isQuickChat?.read(reader);
 			}
 			this._lastRenderState = undefined;
+			this._render();
+		}));
+
+		// Re-render when the set of blocked sessions or the side bar visibility changes;
+		// both feed the "N sessions require input" state. Keep an open dropdown in sync.
+		this._register(autorun(reader => {
+			const blocked = this._blockedSessions.read(reader);
+			this._sidebarVisible.read(reader);
+			this._sessionActionFeedback.approvedCount.read(reader);
+			if (this._openContextView && this._blockedList) {
+				this._blockedList.setSessions(blocked);
+				this.contextViewService.layout();
+			}
 			this._render();
 		}));
 
@@ -81,6 +177,9 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			this._lastRenderState = undefined;
 			this._render();
 		}));
+
+		// Ensure any open dropdown is closed when the widget is disposed.
+		this._register(toDisposable(() => this._openContextView?.close()));
 	}
 
 	override render(container: HTMLElement): void {
@@ -114,18 +213,51 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 		this._isRendering = true;
 
 		try {
-			const icon = this._getActiveSessionIcon();
-			const sessionTitle = this._getSessionTitle() ?? getUntitledSessionTitle(this.sessionsService.activeSession.get()?.isQuickChat?.get() ?? false);
-			const workspaceLabel = this._getRepositoryLabel();
+			const approvedCount = this._sessionActionFeedback.approvedCount.get();
+			const blockedCount = this._blockedSessions.get().length;
+			const requiresInput = blockedCount > 0 && !this._sidebarVisible.get();
 
-			// Build a render-state key from all displayed data
-			const renderState = `${icon?.id ?? ''}|${sessionTitle ?? ''}|${workspaceLabel ?? ''}`;
+			// The transient "Approved N sessions" confirmation takes precedence over the
+			// requires-input state while it is showing.
+			const showApproved = approvedCount > 0;
+			const showRequiresInput = requiresInput && !showApproved;
+
+			// The attention blink fires only when a *new* blocked session pushes the
+			// count up while the requires-input state is shown — including the very first
+			// one. The count is tracked even while the state is hidden (side bar visible),
+			// so merely revealing the indicator by hiding the side bar (count unchanged)
+			// never blinks.
+			const previousBlockedCount = this._lastBlockedCount;
+			this._lastBlockedCount = blockedCount;
+			const shouldBlink = showRequiresInput && blockedCount > previousBlockedCount;
+
+			let renderState: string;
+			if (showApproved) {
+				renderState = `approved|${approvedCount}`;
+			} else if (showRequiresInput) {
+				renderState = `blocked|${blockedCount}`;
+			} else {
+				const icon = this._getActiveSessionIcon();
+				const sessionTitle = this._getSessionTitle() ?? getUntitledSessionTitle(this.sessionsService.activeSession.get()?.isQuickChat?.get() ?? false);
+				const workspaceLabel = this._getRepositoryLabel();
+				renderState = `normal|${icon?.id ?? ''}|${sessionTitle ?? ''}|${workspaceLabel ?? ''}`;
+			}
 
 			// Skip re-render if state hasn't changed
 			if (this._lastRenderState === renderState) {
 				return;
 			}
 			this._lastRenderState = renderState;
+
+			// Close the open blocked-sessions dropdown only when there are no blocked
+			// sessions left to show (or the requires-input UI no longer applies, e.g.
+			// the side bar became visible). Note this keys off `requiresInput`, not
+			// `showRequiresInput`: approving a session shows the transient green state
+			// (suppressing `showRequiresInput`) but the dropdown must stay open while
+			// other sessions remain blocked — it just drops the approved row.
+			if (!requiresInput && this._openContextView) {
+				this._openContextView.close();
+			}
 
 			// Clear existing content
 			reset(this._container);
@@ -134,64 +266,299 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			// Set up container as the button directly
 			this._container.removeAttribute('aria-hidden');
 			this._container.setAttribute('role', 'button');
-			this._container.setAttribute('aria-label', localize('agentSessionsShowSessions', "Show Sessions"));
 			this._container.tabIndex = 0;
-
-			// Session pill: icon + title + workspace together
-			const sessionPill = $('div.agent-sessions-titlebar-pill');
-
-			// Center group: icon + title + workspace name
-			const centerGroup = $('div.agent-sessions-titlebar-center');
-
-			// Kind icon at the beginning
-			if (icon) {
-				const iconEl = $('div.agent-sessions-titlebar-icon' + ThemeIcon.asCSSSelector(icon));
-				centerGroup.appendChild(iconEl);
+			// Preserve an in-progress blink when re-rendering the SAME requires-input
+			// count. Other autoruns (e.g. onDidChangeSessions) invalidate the cached
+			// render state and force a redundant rebuild of the identical pill; without
+			// this guard that rebuild would strip the freshly-added blink class and cut
+			// the animation short — which is why the first "1 session requires input"
+			// never appeared to animate.
+			if (!(showRequiresInput && blockedCount === previousBlockedCount)) {
+				this._container.classList.remove('agent-sessions-titlebar-blink');
 			}
+			this._container.classList.toggle('agent-sessions-titlebar-requires-input', showRequiresInput);
+			this._container.classList.toggle('agent-sessions-titlebar-approved', showApproved);
 
-			// Session title shown next to the icon
-			if (sessionTitle) {
-				const titleEl = $('div.agent-sessions-titlebar-title');
-				titleEl.textContent = sessionTitle;
-				centerGroup.appendChild(titleEl);
+			if (showApproved) {
+				this._renderApproved(approvedCount);
+			} else if (showRequiresInput) {
+				this._renderRequiresInput(blockedCount, shouldBlink);
+			} else {
+				this._renderActiveSession();
 			}
-
-			// Workspace name shown after the session title
-			if (workspaceLabel) {
-				const separatorEl = $('div.agent-sessions-titlebar-separator');
-				centerGroup.appendChild(separatorEl);
-
-				const workspaceEl = $('div.agent-sessions-titlebar-workspace');
-				workspaceEl.textContent = workspaceLabel;
-				centerGroup.appendChild(workspaceEl);
-			}
-
-			sessionPill.appendChild(centerGroup);
-
-			// Click handler on pill
-			this._dynamicDisposables.add(addDisposableGenericMouseDownListener(sessionPill, (e) => {
-				e.preventDefault();
-				e.stopPropagation();
-			}));
-			this._dynamicDisposables.add(addDisposableListener(sessionPill, EventType.CLICK, (e) => {
-				e.preventDefault();
-				e.stopPropagation();
-				this._showSessionsPicker();
-			}));
-
-			this._container.appendChild(sessionPill);
-
-			// Keyboard handler
-			this._dynamicDisposables.add(addDisposableListener(this._container, EventType.KEY_DOWN, (e: KeyboardEvent) => {
-				if (e.key === 'Enter' || e.key === ' ') {
-					e.preventDefault();
-					e.stopPropagation();
-					this._showSessionsPicker();
-				}
-			}));
 		} finally {
 			this._isRendering = false;
 		}
+	}
+
+	/**
+	 * Render the active-session pill: icon + title + workspace. Clicking opens the
+	 * sessions picker.
+	 */
+	private _renderActiveSession(): void {
+		const container = this._container!;
+		container.setAttribute('aria-label', localize('agentSessionsShowSessions', "Show Sessions"));
+
+		const icon = this._getActiveSessionIcon();
+		const sessionTitle = this._getSessionTitle() ?? getUntitledSessionTitle(this.sessionsService.activeSession.get()?.isQuickChat?.get() ?? false);
+		const workspaceLabel = this._getRepositoryLabel();
+
+		// Session pill: icon + title + workspace together
+		const sessionPill = $('div.agent-sessions-titlebar-pill');
+
+		// Center group: icon + title + workspace name
+		const centerGroup = $('div.agent-sessions-titlebar-center');
+
+		// Kind icon at the beginning
+		if (icon) {
+			const iconEl = $('div.agent-sessions-titlebar-icon' + ThemeIcon.asCSSSelector(icon));
+			centerGroup.appendChild(iconEl);
+		}
+
+		// Session title shown next to the icon
+		if (sessionTitle) {
+			const titleEl = $('div.agent-sessions-titlebar-title');
+			titleEl.textContent = sessionTitle;
+			centerGroup.appendChild(titleEl);
+		}
+
+		// Workspace name shown after the session title
+		if (workspaceLabel) {
+			const separatorEl = $('div.agent-sessions-titlebar-separator');
+			centerGroup.appendChild(separatorEl);
+
+			const workspaceEl = $('div.agent-sessions-titlebar-workspace');
+			workspaceEl.textContent = workspaceLabel;
+			centerGroup.appendChild(workspaceEl);
+		}
+
+		sessionPill.appendChild(centerGroup);
+
+		// Click handler on pill
+		this._dynamicDisposables.add(addDisposableGenericMouseDownListener(sessionPill, (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+		}));
+		this._dynamicDisposables.add(addDisposableListener(sessionPill, EventType.CLICK, (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			this._showSessionsPicker();
+		}));
+
+		container.appendChild(sessionPill);
+
+		// Keyboard handler
+		this._dynamicDisposables.add(addDisposableListener(container, EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				e.stopPropagation();
+				this._showSessionsPicker();
+			}
+		}));
+	}
+
+	/**
+	 * Render the "N sessions require input" pill. Clicking toggles a dropdown that
+	 * lists the blocked sessions below the command center box.
+	 */
+	private _renderRequiresInput(count: number, shouldBlink: boolean): void {
+		const container = this._container!;
+		const label = count === 1
+			? localize('oneSessionRequiresInput', "1 session requires input")
+			: localize('nSessionsRequireInput', "{0} sessions require input", count);
+		container.setAttribute('aria-label', label);
+
+		const pill = $('div.agent-sessions-titlebar-pill');
+		const labelEl = $('div.agent-sessions-titlebar-requires-input-label');
+		labelEl.textContent = label;
+		pill.appendChild(labelEl);
+
+		this._dynamicDisposables.add(addDisposableGenericMouseDownListener(pill, (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+		}));
+		this._dynamicDisposables.add(addDisposableListener(pill, EventType.CLICK, (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			this._toggleBlockedSessions();
+		}));
+
+		container.appendChild(pill);
+
+		this._dynamicDisposables.add(addDisposableListener(container, EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				e.stopPropagation();
+				this._toggleBlockedSessions();
+			}
+		}));
+
+		if (shouldBlink) {
+			this._triggerAttentionBlink();
+		}
+	}
+
+	/**
+	 * Render the transient green "Approved N sessions" confirmation shown briefly
+	 * after the user approves one or more sessions' pending actions from the list.
+	 */
+	private _renderApproved(count: number): void {
+		const container = this._container!;
+		const label = count === 1
+			? localize('oneSessionApproved', "Approved 1 session")
+			: localize('nSessionsApproved', "Approved {0} sessions", count);
+		container.setAttribute('aria-label', label);
+
+		const pill = $('div.agent-sessions-titlebar-pill');
+		const labelEl = $('div.agent-sessions-titlebar-approved-label');
+		labelEl.textContent = label;
+		pill.appendChild(labelEl);
+
+		// The confirmation is transient but stays clickable: clicking does whatever
+		// the widget's underlying (non-approved) state would do.
+		this._dynamicDisposables.add(addDisposableGenericMouseDownListener(pill, (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+		}));
+		this._dynamicDisposables.add(addDisposableListener(pill, EventType.CLICK, (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			this._activateDefaultAction();
+		}));
+
+		container.appendChild(pill);
+
+		this._dynamicDisposables.add(addDisposableListener(container, EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				e.stopPropagation();
+				this._activateDefaultAction();
+			}
+		}));
+	}
+
+	/**
+	 * Activate the widget as its non-approved state would: reveal the blocked
+	 * sessions when the requires-input state applies, otherwise the sessions picker.
+	 */
+	private _activateDefaultAction(): void {
+		const requiresInput = this._blockedSessions.get().length > 0 && !this._sidebarVisible.get();
+		if (requiresInput) {
+			this._toggleBlockedSessions();
+		} else {
+			this._showSessionsPicker();
+		}
+	}
+
+	/**
+	 * Restart the attention blink animation on the command center box. Re-adding
+	 * the class after a forced reflow guarantees the CSS animation replays even
+	 * when the container element persists across renders.
+	 */
+	private _triggerAttentionBlink(): void {
+		const container = this._container;
+		if (!container) {
+			return;
+		}
+		container.classList.remove('agent-sessions-titlebar-blink');
+		container.getBoundingClientRect(); // force reflow so the animation restarts
+		container.classList.add('agent-sessions-titlebar-blink');
+		// Own the listener outside `_dynamicDisposables` (cleared on every render) so a
+		// redundant re-render can't drop it before the animation finishes.
+		this._blinkListener.value = addDisposableListener(container, 'animationend', () => {
+			container.classList.remove('agent-sessions-titlebar-blink');
+			this._blinkListener.clear();
+		});
+	}
+
+	/**
+	 * Toggle the blocked-sessions dropdown open/closed.
+	 */
+	private _toggleBlockedSessions(): void {
+		if (this._openContextView) {
+			this._openContextView.close();
+			return;
+		}
+		this._showBlockedSessions();
+	}
+
+	/**
+	 * Show the blocked sessions as a flat list in a dropdown anchored below the
+	 * command center box.
+	 */
+	private _showBlockedSessions(): void {
+		const container = this._container;
+		if (!container) {
+			return;
+		}
+		if (this._blockedSessions.get().length === 0) {
+			return;
+		}
+
+		// Match the dropdown width to the command center box it hangs off.
+		const width = container.getBoundingClientRect().width;
+
+		const store = new DisposableStore();
+		this._openContextView = this.contextViewService.showContextView({
+			getAnchor: () => container,
+			anchorAlignment: AnchorAlignment.LEFT,
+			anchorPosition: AnchorPosition.BELOW,
+			render: (viewContainer): IDisposable => {
+				const list = store.add(this.instantiationService.createInstance(BlockedSessionsList, viewContainer, {
+					width,
+					onSessionOpen: (resource, preserveFocus, sideBySide) => {
+						this.contextViewService.hideContextView();
+						this._openBlockedSession(resource, preserveFocus, sideBySide);
+					},
+				}));
+				list.setSessions(this._blockedSessions.get());
+				store.add(list.onDidChangeContentHeight(() => this.contextViewService.layout()));
+				store.add(list.onDidApproveSession(() => this._sessionActionFeedback.notifyApproved()));
+
+				// Keep the dropdown width matched to the command center box as the
+				// window resizes (the command center reflows to a new width).
+				store.add(this.layoutService.onDidLayoutActiveContainer(() => {
+					list.setWidth(container.getBoundingClientRect().width);
+					this.contextViewService.layout();
+				}));
+
+				this._blockedList = list;
+				return store;
+			},
+			focus: () => this._blockedList?.focus(),
+			onDOMEvent: (e: Event) => {
+				// Dismiss on Escape, or on a click outside the dropdown. Clicks on the
+				// anchor are ignored here because the anchor toggles the dropdown itself.
+				if (e.type === EventType.KEY_DOWN) {
+					if (new StandardKeyboardEvent(e as KeyboardEvent).equals(KeyCode.Escape)) {
+						this.contextViewService.hideContextView();
+					}
+				} else if (e.type === EventType.CLICK) {
+					const target = e.target as HTMLElement | null;
+					if (target
+						&& !isAncestor(target, this.contextViewService.getContextViewElement())
+						&& !isAncestor(target, container)) {
+						this.contextViewService.hideContextView();
+					}
+				}
+			},
+			onHide: () => {
+				store.dispose();
+				this._openContextView = undefined;
+				this._blockedList = undefined;
+			},
+		});
+	}
+
+	private _openBlockedSession(resource: URI, preserveFocus: boolean, sideBySide: boolean): void {
+		if (sideBySide) {
+			const session = this.sessionsManagementService.getSession(resource);
+			if (session) {
+				openSessionToTheSide(this.sessionsService, session, { preserveFocus }).catch(onUnexpectedError);
+				return;
+			}
+		}
+		this.sessionsService.openSession(resource, { preserveFocus }).catch(onUnexpectedError);
 	}
 
 	/**
@@ -266,11 +633,31 @@ export class SessionsTitleBarContribution extends Disposable implements IWorkben
 			when: IsAuxiliaryWindowContext.negate()
 		}));
 
+		// The blocked-sessions dropdown header's "Show All Sessions" action dismisses
+		// the dropdown (a transient context view) before opening the full sessions
+		// picker, so the popup doesn't linger behind it.
+		this._register(CommandsRegistry.registerCommand(SHOW_ALL_SESSIONS_FROM_BLOCKED_LIST_COMMAND_ID, accessor => {
+			accessor.get(IContextViewService).hideContextView();
+			return accessor.get(ICommandService).executeCommand(SHOW_SESSIONS_PICKER_COMMAND_ID);
+		}));
+
+		// Contribute the action to the blocked-sessions dropdown header toolbar.
+		this._register(MenuRegistry.appendMenuItem(Menus.BlockedSessionsHeader, {
+			command: {
+				id: SHOW_ALL_SESSIONS_FROM_BLOCKED_LIST_COMMAND_ID,
+				title: localize('showAllSessions', "Show All Sessions"),
+				icon: Codicon.listSelection,
+			},
+			group: 'navigation',
+			order: 1,
+			when: IsAuxiliaryWindowContext.negate()
+		}));
+
 		this._register(actionViewItemService.register(Menus.CommandCenter, Menus.TitleBarSessionTitle, (action, options) => {
 			if (!(action instanceof SubmenuItemAction)) {
 				return undefined;
 			}
-			return instantiationService.createInstance(SessionsTitleBarWidget, action, options);
+			return instantiationService.createInstance(SessionsTitleBarWidget, action, options, undefined);
 		}, undefined));
 	}
 }

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -17,7 +17,7 @@ import { CommandsRegistry, ICommandService } from '../../../../platform/commands
 import { Menus } from '../../../browser/menus.js';
 import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
-import { autorun, derived, IObservable, observableFromEvent } from '../../../../base/common/observable.js';
+import { autorun, derived, IObservable, IReader, observableFromEvent } from '../../../../base/common/observable.js';
 import { onUnexpectedError } from '../../../../base/common/errors.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -31,10 +31,12 @@ import { ISessionsProvidersService } from '../../../services/sessions/browser/se
 import { SHOW_SESSIONS_PICKER_COMMAND_ID } from './sessionsActions.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
-import { getUntitledSessionTitle, ISession } from '../../../services/sessions/common/session.js';
-import { IBlockedSessionsService } from '../../blockedSessions/browser/blockedSessionsService.js';
+import { getUntitledSessionTitle } from '../../../services/sessions/common/session.js';
+import { BlockedSessionReason, IBlockedSession, IBlockedSessionsService } from '../../blockedSessions/browser/blockedSessionsService.js';
 import { BlockedSessionsList } from './blockedSessionsList.js';
 import { SessionActionFeedback } from './sessionActionFeedback.js';
+import { AgentSessionApprovalKind, AgentSessionApprovalModel } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
+import { getFirstApprovalAcrossChats } from './views/sessionsList.js';
 import { openSessionToTheSide } from './views/sessionsView.js';
 
 /**
@@ -43,6 +45,22 @@ import { openSessionToTheSide } from './views/sessionsView.js';
  * opening the full sessions picker so the popup doesn't linger behind it.
  */
 const SHOW_ALL_SESSIONS_FROM_BLOCKED_LIST_COMMAND_ID = 'sessions.blockedSessions.showAllSessions';
+
+/**
+ * The specific reason a homogeneous set of blocked sessions needs attention,
+ * used to render a more helpful requires-input message. `undefined` (a mix of
+ * reasons, or an indeterminate one) falls back to the generic message.
+ */
+const enum RequiresInputKind {
+	/** All sessions are waiting to run a terminal command. */
+	TerminalApproval,
+	/** All sessions are asking the user a question. */
+	Question,
+	/** All sessions have failing CI checks. */
+	FailingCI,
+	/** All sessions have unresolved pull request comments. */
+	UnresolvedComments,
+}
 
 /**
  * Sessions Title Bar Widget - renders the active chat session
@@ -93,7 +111,17 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 	 * user can already see doesn't need the titlebar indicator or a dropdown row,
 	 * so it is excluded from both the "N sessions require input" count and the list.
 	 */
-	private readonly _blockedSessions: IObservable<readonly ISession[]>;
+	private readonly _blockedSessions: IObservable<readonly IBlockedSession[]>;
+
+	/**
+	 * The homogeneous reason the blocked sessions need attention (all terminal
+	 * approvals, all failing CI, etc.), or `undefined` when they are a mix — which
+	 * drives whether a specific or the generic requires-input message is shown.
+	 */
+	private readonly _requiresInputKind: IObservable<RequiresInputKind | undefined>;
+
+	/** Tracks pending tool approvals per chat; distinguishes terminal vs question. */
+	private readonly _approvalModel: AgentSessionApprovalModel;
 
 	/** The currently open blocked-sessions dropdown, if any. */
 	private _openContextView: IOpenContextView | undefined;
@@ -107,6 +135,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 		action: SubmenuItemAction,
 		options: IBaseActionViewItemOptions | undefined,
 		sessionActionFeedback: SessionActionFeedback | undefined,
+		approvalModel: AgentSessionApprovalModel | undefined,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@ISessionsService private readonly sessionsService: ISessionsService,
 		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
@@ -121,6 +150,11 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 		// The widget owns the approval-feedback state; the optional parameter is a
 		// test seam so fixtures can supply a preset instance.
 		this._sessionActionFeedback = sessionActionFeedback ?? this._register(new SessionActionFeedback());
+
+		// Likewise the widget owns an approval model (shared with the dropdown list so
+		// both agree on each session's pending action); the optional parameter is a
+		// test seam.
+		this._approvalModel = approvalModel ?? this._register(this.instantiationService.createInstance(AgentSessionApprovalModel));
 
 		this._sidebarVisible = observableFromEvent(
 			this,
@@ -137,8 +171,33 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 					visibleSessionIds.add(session.sessionId);
 				}
 			}
-			return this.blockedSessionsService.blockedSessions.read(reader)
-				.filter(session => !visibleSessionIds.has(session.sessionId));
+			return this.blockedSessionsService.blockedSessionsWithReasons.read(reader)
+				.filter(blocked => !visibleSessionIds.has(blocked.session.sessionId));
+		});
+
+		// The homogeneous reason across all blocked sessions (or `undefined` for a
+		// mix), refining `NeedsInput` into terminal-approval vs question via the
+		// approval model. Drives the specific requires-input message.
+		this._requiresInputKind = derived(this, reader => {
+			const blocked = this._blockedSessions.read(reader);
+			if (blocked.length === 0) {
+				return undefined;
+			}
+			let common: RequiresInputKind | undefined;
+			let hasCommon = false;
+			for (const entry of blocked) {
+				const kind = this._kindOf(entry, reader);
+				if (kind === undefined) {
+					return undefined;
+				}
+				if (!hasCommon) {
+					common = kind;
+					hasCommon = true;
+				} else if (common !== kind) {
+					return undefined;
+				}
+			}
+			return common;
 		});
 
 		// Re-render when the active session's title, workspace, or quick-chat kind changes
@@ -159,8 +218,9 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			const blocked = this._blockedSessions.read(reader);
 			this._sidebarVisible.read(reader);
 			this._sessionActionFeedback.approvedCount.read(reader);
+			this._requiresInputKind.read(reader);
 			if (this._openContextView && this._blockedList) {
-				this._blockedList.setSessions(blocked);
+				this._blockedList.setSessions(blocked.map(entry => entry.session));
 				this.contextViewService.layout();
 			}
 			this._render();
@@ -231,11 +291,13 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			this._lastBlockedCount = blockedCount;
 			const shouldBlink = showRequiresInput && blockedCount > previousBlockedCount;
 
+			const requiresInputKind = this._requiresInputKind.get();
+
 			let renderState: string;
 			if (showApproved) {
 				renderState = `approved|${approvedCount}`;
 			} else if (showRequiresInput) {
-				renderState = `blocked|${blockedCount}`;
+				renderState = `blocked|${blockedCount}|${requiresInputKind ?? 'mixed'}`;
 			} else {
 				const icon = this._getActiveSessionIcon();
 				const sessionTitle = this._getSessionTitle() ?? getUntitledSessionTitle(this.sessionsService.activeSession.get()?.isQuickChat?.get() ?? false);
@@ -282,7 +344,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			if (showApproved) {
 				this._renderApproved(approvedCount);
 			} else if (showRequiresInput) {
-				this._renderRequiresInput(blockedCount, shouldBlink);
+				this._renderRequiresInput(blockedCount, requiresInputKind, shouldBlink);
 			} else {
 				this._renderActiveSession();
 			}
@@ -358,14 +420,68 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 	}
 
 	/**
-	 * Render the "N sessions require input" pill. Clicking toggles a dropdown that
-	 * lists the blocked sessions below the command center box.
+	 * Classify a single blocked session into a specific requires-input kind, or
+	 * `undefined` when it can't be classified (which forces the generic message).
 	 */
-	private _renderRequiresInput(count: number, shouldBlink: boolean): void {
+	private _kindOf(blocked: IBlockedSession, reader: IReader): RequiresInputKind | undefined {
+		switch (blocked.reason) {
+			case BlockedSessionReason.FailingCI:
+				return RequiresInputKind.FailingCI;
+			case BlockedSessionReason.UnresolvedComments:
+				return RequiresInputKind.UnresolvedComments;
+			case BlockedSessionReason.NeedsInput: {
+				const approval = getFirstApprovalAcrossChats(this._approvalModel, blocked.session, reader);
+				switch (approval?.kind) {
+					case AgentSessionApprovalKind.Terminal:
+						return RequiresInputKind.TerminalApproval;
+					case AgentSessionApprovalKind.Question:
+						return RequiresInputKind.Question;
+					default:
+						return undefined;
+				}
+			}
+			default:
+				return undefined;
+		}
+	}
+
+	/**
+	 * Build the requires-input pill label. A homogeneous set of blocked sessions
+	 * gets a specific, more actionable message; a mix (or an unclassified session)
+	 * falls back to the generic "N sessions require input".
+	 */
+	private _getRequiresInputLabel(count: number, kind: RequiresInputKind | undefined): string {
+		switch (kind) {
+			case RequiresInputKind.TerminalApproval:
+				return count === 1
+					? localize('oneSessionTerminalApproval', "1 session requires terminal approval")
+					: localize('nSessionsTerminalApproval', "{0} sessions require terminal approval", count);
+			case RequiresInputKind.Question:
+				return count === 1
+					? localize('oneSessionQuestion', "1 session has a question")
+					: localize('nSessionsQuestion', "{0} sessions have questions", count);
+			case RequiresInputKind.FailingCI:
+				return count === 1
+					? localize('oneSessionFailingCI', "1 session is failing CI")
+					: localize('nSessionsFailingCI', "{0} sessions are failing CI", count);
+			case RequiresInputKind.UnresolvedComments:
+				return count === 1
+					? localize('oneSessionUnresolvedComments', "1 session has unresolved comments")
+					: localize('nSessionsUnresolvedComments', "{0} sessions have unresolved comments", count);
+			default:
+				return count === 1
+					? localize('oneSessionRequiresInput', "1 session requires input")
+					: localize('nSessionsRequireInput', "{0} sessions require input", count);
+		}
+	}
+
+	/**
+	 * Render the requires-input pill. Clicking toggles a dropdown that lists the
+	 * blocked sessions below the command center box.
+	 */
+	private _renderRequiresInput(count: number, kind: RequiresInputKind | undefined, shouldBlink: boolean): void {
 		const container = this._container!;
-		const label = count === 1
-			? localize('oneSessionRequiresInput', "1 session requires input")
-			: localize('nSessionsRequireInput', "{0} sessions require input", count);
+		const label = this._getRequiresInputLabel(count, kind);
 		container.setAttribute('aria-label', label);
 
 		const pill = $('div.agent-sessions-titlebar-pill');
@@ -506,12 +622,13 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			render: (viewContainer): IDisposable => {
 				const list = store.add(this.instantiationService.createInstance(BlockedSessionsList, viewContainer, {
 					width,
+					approvalModel: this._approvalModel,
 					onSessionOpen: (resource, preserveFocus, sideBySide) => {
 						this.contextViewService.hideContextView();
 						this._openBlockedSession(resource, preserveFocus, sideBySide);
 					},
 				}));
-				list.setSessions(this._blockedSessions.get());
+				list.setSessions(this._blockedSessions.get().map(entry => entry.session));
 				store.add(list.onDidChangeContentHeight(() => this.contextViewService.layout()));
 				store.add(list.onDidApproveSession(() => this._sessionActionFeedback.notifyApproved()));
 
@@ -657,7 +774,7 @@ export class SessionsTitleBarContribution extends Disposable implements IWorkben
 			if (!(action instanceof SubmenuItemAction)) {
 				return undefined;
 			}
-			return instantiationService.createInstance(SessionsTitleBarWidget, action, options, undefined);
+			return instantiationService.createInstance(SessionsTitleBarWidget, action, options, undefined, undefined);
 		}, undefined));
 	}
 }

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -2876,7 +2876,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 
 //#region Approval Helpers
 
-function getFirstApprovalAcrossChats(approvalModel: AgentSessionApprovalModel, session: ISession, reader: IReader | undefined,): IAgentSessionApprovalInfo | undefined {
+export function getFirstApprovalAcrossChats(approvalModel: AgentSessionApprovalModel, session: ISession, reader: IReader | undefined,): IAgentSessionApprovalInfo | undefined {
 	let oldest: IAgentSessionApprovalInfo | undefined;
 	for (const chat of session.chats.read(reader)) {
 		const approval = approvalModel.getApproval(chat.resource).read(reader);

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -166,6 +166,12 @@ function isSessionItem(item: SessionListItem): item is ISession {
 const SHOW_MORE_FOLDERS_LABEL = '__more_folders__';
 const FOUR_DAYS_MS = 4 * 24 * 60 * 60 * 1000;
 
+/**
+ * Default number of terminal-command lines shown in a session row's approval
+ * prompt. The blocked-sessions dropdown overrides this to show more lines.
+ */
+const DEFAULT_APPROVAL_ROW_MAX_LINES = 3;
+
 //#endregion
 
 //#region Tree Delegate
@@ -187,6 +193,7 @@ class SessionsTreeDelegate implements IListVirtualDelegate<SessionListItem> {
 	constructor(
 		private readonly _approvalModel: AgentSessionApprovalModel | undefined,
 		private readonly _isPhone: () => boolean,
+		private readonly _approvalRowMaxLines: number = DEFAULT_APPROVAL_ROW_MAX_LINES,
 	) { }
 
 	getHeight(element: SessionListItem): number {
@@ -204,7 +211,7 @@ class SessionsTreeDelegate implements IListVirtualDelegate<SessionListItem> {
 		if (this._approvalModel) {
 			const approval = getFirstApprovalAcrossChats(this._approvalModel, element as ISession, undefined);
 			if (approval) {
-				height += SessionItemRenderer.getApprovalRowHeight(approval.label);
+				height += SessionItemRenderer.getApprovalRowHeight(approval.label, this._approvalRowMaxLines);
 			}
 		}
 		return height;
@@ -274,20 +281,23 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 	static readonly TEMPLATE_ID = 'session-item';
 	readonly templateId = SessionItemRenderer.TEMPLATE_ID;
 
-	private static readonly APPROVAL_ROW_MAX_LINES = 3;
 	private static readonly _APPROVAL_ROW_LINE_HEIGHT = 18;
 	private static readonly _APPROVAL_ROW_OVERHEAD = 14;
 
-	static getApprovalRowHeight(label: string): number {
-		const lineCount = Math.min(label.split(/\r?\n/).length, SessionItemRenderer.APPROVAL_ROW_MAX_LINES);
+	static getApprovalRowHeight(label: string, maxLines: number = DEFAULT_APPROVAL_ROW_MAX_LINES): number {
+		const lineCount = Math.min(label.split(/\r?\n/).length, maxLines);
 		return lineCount * SessionItemRenderer._APPROVAL_ROW_LINE_HEIGHT + SessionItemRenderer._APPROVAL_ROW_OVERHEAD;
 	}
 
 	private readonly _onDidChangeItemHeight = new Emitter<ISession>();
 	readonly onDidChangeItemHeight: Event<ISession> = this._onDidChangeItemHeight.event;
 
+	private readonly _onDidApproveSession = new Emitter<ISession>();
+	/** Fires when the user approves a session's pending action via its "Allow" button. */
+	readonly onDidApproveSession: Event<ISession> = this._onDidApproveSession.event;
+
 	constructor(
-		private readonly options: { grouping: () => SessionsGrouping; isPinned: (session: ISession) => boolean; isRead: (session: ISession) => boolean; visibleSessions: IObservable<readonly (IActiveSession | undefined)[]>; getMultiSelectedSessions: (session: ISession) => ISession[]; isInChatsSection: (session: ISession) => boolean },
+		private readonly options: { grouping: () => SessionsGrouping; isPinned: (session: ISession) => boolean; isRead: (session: ISession) => boolean; visibleSessions: IObservable<readonly (IActiveSession | undefined)[]>; getMultiSelectedSessions: (session: ISession) => ISession[]; isInChatsSection: (session: ISession) => boolean; showHover: boolean; approvalRowMaxLines: number },
 		private readonly approvalModel: AgentSessionApprovalModel | undefined,
 		private readonly instantiationService: IInstantiationService,
 		private readonly contextKeyService: IContextKeyService,
@@ -296,8 +306,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		private readonly sessionsProvidersService: ISessionsProvidersService,
 		// TEMPORARY — see the note on the `IAgentSessionsService` import above (#320480).
 		private readonly agentSessionsService: IAgentSessionsService,
-	) {
-	}
+	) { }
 
 	renderTemplate(container: HTMLElement): ISessionItemTemplate {
 		const disposables = new DisposableStore();
@@ -357,14 +366,15 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		// moved into the provider — see the note on the import above.
 		this.agentSessionsService.model.observeSession(element.resource);
 
-		// Rich hover on the row showing folder, branch, diff stats and provider.
-		// Shown to the right of the row, similar to the extensions list.
-		template.elementDisposables.add(this.hoverService.setupDelayedHover(template.container, () => ({
-			content: buildSessionHoverContent(element, this.sessionsProvidersService),
-			appearance: { showPointer: true },
-			position: { hoverPosition: HoverPosition.RIGHT, forcePosition: true },
-			persistence: { hideOnHover: false },
-		}), { groupId: 'sessions-list' }));
+		if (this.options.showHover) {
+			// Rich hover on the row showing folder, branch, diff stats and provider.
+			template.elementDisposables.add(this.hoverService.setupDelayedHover(template.container, () => ({
+				content: buildSessionHoverContent(element, this.sessionsProvidersService),
+				appearance: { showPointer: true },
+				position: { hoverPosition: HoverPosition.RIGHT, forcePosition: true },
+				persistence: { hideOnHover: false },
+			}), { groupId: 'sessions-list' }));
+		}
 
 		// Toolbar context
 		template.titleToolbar.context = element;
@@ -589,9 +599,9 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			template.approvalRow.classList.toggle('visible', visible);
 
 			if (info) {
-				// Render up to 3 lines as separate code blocks
+				// Render up to `maxLines` lines as separate code blocks
 				const lines = info.label.split('\n');
-				const maxLines = SessionItemRenderer.APPROVAL_ROW_MAX_LINES;
+				const maxLines = this.options.approvalRowMaxLines;
 				const visibleLines = lines.slice(0, maxLines);
 				if (lines.length > maxLines) {
 					visibleLines[maxLines - 1] = `${visibleLines[maxLines - 1]} \u2026`;
@@ -605,13 +615,14 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 				template.approvalLabel.textContent = '';
 				buttonStore.add(this.markdownRendererService.render(labelContent, {}, template.approvalLabel));
 
-				// Hover with full content as a code block
-				const fullContent = new MarkdownString().appendCodeblock(info.languageId ?? 'json', info.label);
-				buttonStore.add(this.hoverService.setupDelayedHover(template.approvalLabel, {
-					content: fullContent,
-					style: HoverStyle.Pointer,
-					position: { hoverPosition: HoverPosition.BELOW },
-				}));
+				if (this.options.showHover) {
+					const fullContent = new MarkdownString().appendCodeblock(info.languageId ?? 'json', info.label);
+					buttonStore.add(this.hoverService.setupDelayedHover(template.approvalLabel, {
+						content: fullContent,
+						style: HoverStyle.Pointer,
+						position: { hoverPosition: HoverPosition.BELOW },
+					}));
+				}
 
 				template.approvalButtonContainer.textContent = '';
 				const button = buttonStore.add(new Button(template.approvalButtonContainer, {
@@ -620,7 +631,10 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 					...defaultButtonStyles
 				}));
 				button.label = localize('allowAction', "Allow");
-				buttonStore.add(button.onDidClick(() => info.confirm()));
+				buttonStore.add(button.onDidClick(() => {
+					info.confirm();
+					this._onDidApproveSession.fire(element);
+				}));
 			}
 
 			if (wasVisible !== visible) {
@@ -1564,7 +1578,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		// TEMPORARY (#320480): see the note on the `IAgentSessionsService` import.
 		const agentSessionsService = instantiationService.invokeFunction(accessor => accessor.get(IAgentSessionsService));
 		const sessionRenderer = new SessionItemRenderer(
-			{ grouping: this.options.grouping, isPinned: s => this.isSessionPinned(s), isRead: s => this.isSessionRead(s), visibleSessions: this._sessionsService.visibleSessions, getMultiSelectedSessions: s => this.getMultiSelectedSessions(s), isInChatsSection: s => this._chatsSectionSessionIds.has(s.resource.toString()) },
+			{ grouping: this.options.grouping, isPinned: s => this.isSessionPinned(s), isRead: s => this.isSessionRead(s), visibleSessions: this._sessionsService.visibleSessions, getMultiSelectedSessions: s => this.getMultiSelectedSessions(s), isInChatsSection: s => this._chatsSectionSessionIds.has(s.resource.toString()), showHover: true, approvalRowMaxLines: DEFAULT_APPROVAL_ROW_MAX_LINES },
 			approvalModel,
 			instantiationService,
 			contextKeyService,
@@ -3143,6 +3157,159 @@ export function groupByDate(sessions: ISession[], sorting: SessionsSorting, getS
 	addGroup('older', localize('older', "Older"), older);
 
 	return sections;
+}
+
+//#endregion
+
+//#region Flat List
+
+export interface ISessionsFlatListOptions {
+	readonly overrideStyles?: IStyleOverride<IListStyles>;
+	readonly showSessionHover?: boolean;
+	/** Called when a session row is opened (clicked / activated). */
+	onSessionOpen(resource: URI, preserveFocus: boolean, sideBySide: boolean): void;
+	/**
+	 * Approval model tracking pending tool confirmations for the shown sessions.
+	 * When omitted the list creates and owns its own; injectable so tests and
+	 * fixtures can supply pending approvals without a live chat session.
+	 */
+	readonly approvalModel?: AgentSessionApprovalModel;
+	/**
+	 * Maximum number of terminal-command lines shown in a session's approval
+	 * prompt. Defaults to the same limit as the main sessions list; the
+	 * blocked-sessions dropdown passes a larger value.
+	 */
+	readonly approvalRowMaxLines?: number;
+}
+
+/**
+ * A lightweight, flat sessions list that renders session rows exactly like the
+ * main {@link SessionsList} but without any sections, groups or workspace
+ * headers. Only the sessions passed to {@link setSessions} are shown. Used by
+ * surfaces that need a focused, sectionless view of a specific set of sessions
+ * (e.g. the titlebar "N blocked" hover).
+ */
+export class SessionsFlatList extends Disposable {
+
+	private static readonly ROW_HEIGHT = 54;
+
+	private readonly _onDidChangeContentHeight = this._register(new Emitter<void>());
+	readonly onDidChangeContentHeight = this._onDidChangeContentHeight.event;
+	private readonly _onDidApproveSession = this._register(new Emitter<ISession>());
+	/** Fires when a session's pending action is approved from its "Allow" button. */
+	readonly onDidApproveSession: Event<ISession> = this._onDidApproveSession.event;
+	private readonly tree: WorkbenchObjectTree<SessionListItem, FuzzyScore>;
+	private readonly _delegate: SessionsTreeDelegate;
+	private _sessions: readonly ISession[] = [];
+
+	constructor(
+		container: HTMLElement,
+		private readonly options: ISessionsFlatListOptions,
+		@ISessionsService private readonly _sessionsService: ISessionsService,
+		@ISessionsListModelService private readonly _sessionsListModelService: ISessionsListModelService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IMarkdownRendererService markdownRendererService: IMarkdownRendererService,
+		@IHoverService hoverService: IHoverService,
+		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
+	) {
+		super();
+
+		// Wrap in `.sessions-list-control` so the row styles scoped to that class
+		// (needs-input/pinned row highlights) apply exactly like the main list.
+		const listRoot = DOM.append(container, $('.sessions-list-control'));
+		const approvalModel = this.options.approvalModel ?? this._register(instantiationService.createInstance(AgentSessionApprovalModel));
+
+		// TEMPORARY (#320480): the row renderer reaches into a Copilot-provider
+		// internal to lazily resolve expensive session properties. Resolved via
+		// the instantiation service so this file's single suppressed import stays
+		// the only reference. See the note on the `IAgentSessionsService` import.
+		const agentSessionsService = instantiationService.invokeFunction(accessor => accessor.get(IAgentSessionsService));
+
+		const sessionRenderer = new SessionItemRenderer(
+			{
+				grouping: () => SessionsGrouping.Date,
+				isPinned: s => this._sessionsListModelService.isSessionPinned(s),
+				isRead: s => this._sessionsListModelService.isSessionRead(s),
+				visibleSessions: this._sessionsService.visibleSessions,
+				getMultiSelectedSessions: s => [s],
+				showHover: this.options.showSessionHover ?? true,
+				isInChatsSection: s => false,
+				approvalRowMaxLines: this.options.approvalRowMaxLines ?? DEFAULT_APPROVAL_ROW_MAX_LINES,
+			},
+			approvalModel,
+			instantiationService,
+			contextKeyService,
+			markdownRendererService,
+			hoverService,
+			sessionsProvidersService,
+			agentSessionsService,
+		);
+
+		this._delegate = new SessionsTreeDelegate(approvalModel, () => false, this.options.approvalRowMaxLines ?? DEFAULT_APPROVAL_ROW_MAX_LINES);
+
+		this.tree = this._register(instantiationService.createInstance(
+			WorkbenchObjectTree<SessionListItem, FuzzyScore>,
+			'SessionsFlatList',
+			listRoot,
+			this._delegate,
+			[sessionRenderer],
+			{
+				accessibilityProvider: new SessionsAccessibilityProvider(),
+				identityProvider: {
+					getId: (element: SessionListItem) => (element as ISession).resource.toString(),
+				},
+				horizontalScrolling: false,
+				multipleSelectionSupport: false,
+				indent: 0,
+				overrideStyles: this.options.overrideStyles,
+				renderIndentGuides: RenderIndentGuides.None,
+				twistieAdditionalCssClass: () => 'force-no-twistie',
+			}
+		));
+
+		this._register(this.tree.onDidOpen(e => {
+			const element = e.element;
+			if (!element || !isSessionItem(element)) {
+				return;
+			}
+			this._sessionsListModelService.markRead(element);
+			const isLeftClick = DOM.isMouseEvent(e.browserEvent) && e.browserEvent.button === 0;
+			const preserveFocus = isLeftClick ? false : (e.editorOptions.preserveFocus ?? false);
+			this.options.onSessionOpen(element.resource, preserveFocus, e.sideBySide);
+		}));
+
+		this._register(sessionRenderer.onDidChangeItemHeight(session => {
+			if (this.tree.hasElement(session)) {
+				this.tree.updateElementHeight(session, this._delegate.getHeight(session));
+				this._onDidChangeContentHeight.fire();
+			}
+		}));
+
+		this._register(sessionRenderer.onDidApproveSession(session => this._onDidApproveSession.fire(session)));
+	}
+
+	setSessions(sessions: readonly ISession[]): void {
+		this._sessions = sessions;
+		this.tree.setChildren(null, sessions.map(session => ({ element: session })));
+	}
+
+	/** The total pixel height required to render all current rows without scrolling. */
+	getContentHeight(): number {
+		return this._sessions.reduce((total, session) => total + this._delegate.getHeight(session), 0);
+	}
+
+	getRowHeight(): number {
+		return SessionsFlatList.ROW_HEIGHT;
+	}
+
+	layout(height: number, width: number): void {
+		this.tree.layout(height, width);
+	}
+
+	focus(): void {
+		this.tree.domFocus();
+	}
 }
 
 //#endregion

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -471,6 +471,7 @@ import './contrib/changes/browser/changes.contribution.js';
 import './contrib/codeReview/browser/codeReview.contributions.js';
 import './contrib/files/browser/files.contribution.js';
 import './contrib/github/browser/github.contribution.js';
+import './contrib/blockedSessions/browser/blockedSessions.contribution.js';
 import './contrib/applyCommitsToParentRepo/browser/applyChangesToParentRepo.js';
 import './contrib/fileTreeView/browser/fileTreeView.contribution.js'; // view registration disabled; filesystem provider still needed
 import './contrib/configuration/browser/configuration.contribution.js';

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.ts
@@ -12,7 +12,21 @@ import { IChatModel } from '../../common/model/chatModel.js';
 import { IChatService, IChatToolInvocation, ToolConfirmKind } from '../../common/chatService/chatService.js';
 import { ILanguageService } from '../../../../../editor/common/languages/language.js';
 
+/**
+ * The kind of attention a pending approval needs. Lets consumers tailor UI
+ * (e.g. a summary message) to what the user is actually being asked to do.
+ */
+export const enum AgentSessionApprovalKind {
+	/** A terminal command is waiting to be run. */
+	Terminal = 'terminal',
+	/** The agent is asking the user a question / needs a free-form response. */
+	Question = 'question',
+	/** Some other tool invocation is waiting for confirmation. */
+	Other = 'other',
+}
+
 export interface IAgentSessionApprovalInfo {
+	readonly kind: AgentSessionApprovalKind;
 	readonly label: string;
 	readonly languageId: string | undefined;
 	readonly since: Date;
@@ -71,7 +85,7 @@ export class AgentSessionApprovalModel extends Disposable {
 			if (current === value) {
 				return;
 			}
-			if (current !== undefined && value !== undefined && current.label === value.label && current.languageId === value.languageId) {
+			if (current !== undefined && value !== undefined && current.kind === value.kind && current.label === value.label && current.languageId === value.languageId) {
 				return;
 			}
 			settable.set(value, undefined);
@@ -98,19 +112,24 @@ export class AgentSessionApprovalModel extends Disposable {
 				if (state.type === IChatToolInvocation.StateKind.WaitingForConfirmation || state.type === IChatToolInvocation.StateKind.WaitingForPostApproval) {
 					let label: string;
 					let languageId: string | undefined;
+					let kind: AgentSessionApprovalKind;
 					if (part.toolSpecificData?.kind === 'terminal') {
 						const terminalData = migrateLegacyTerminalToolSpecificData(part.toolSpecificData);
 						label = terminalData.presentationOverrides?.commandLine ?? terminalData.commandLine.forDisplay ?? terminalData.commandLine.userEdited ?? terminalData.commandLine.toolEdited ?? terminalData.commandLine.original;
 						languageId = this._languageService.getLanguageIdByLanguageName(terminalData.presentationOverrides?.language ?? terminalData.language) ?? undefined;
+						kind = AgentSessionApprovalKind.Terminal;
 					} else if (needsInput.detail) {
 						label = needsInput.detail;
+						kind = AgentSessionApprovalKind.Question;
 					} else {
 						const msg = part.invocationMessage;
 						label = typeof msg === 'string' ? msg : renderAsPlaintext(msg);
+						kind = AgentSessionApprovalKind.Other;
 					}
 
 					const confirmState = state;
 					setIfChanged({
+						kind,
 						label,
 						languageId,
 						since: new Date(),

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/agentSessionsViewer.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/agentSessionsViewer.fixture.ts
@@ -21,7 +21,7 @@ import { AgentSessionRenderer, AgentSessionSectionRenderer, IAgentSessionRendere
 import { IChatSessionsService } from '../../../../contrib/chat/common/chatSessionsService.js';
 import { AgentSessionStatus, IAgentSession, AgentSessionSection, IAgentSessionSection } from '../../../../contrib/chat/browser/agentSessions/agentSessionsModel.js';
 import { AgentSessionProviders } from '../../../../contrib/chat/browser/agentSessions/agentSessions.js';
-import { AgentSessionApprovalModel, IAgentSessionApprovalInfo } from '../../../../contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
+import { AgentSessionApprovalKind, AgentSessionApprovalModel, IAgentSessionApprovalInfo } from '../../../../contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
 import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.js';
 import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup, registerWorkbenchServices } from '../fixtureUtils.js';
 
@@ -599,6 +599,7 @@ export default defineThemedFixtureGroup({
 			const now = Date.now();
 			const resource = URI.parse('vscode-chat-session://local/approval-json');
 			const approvalModel = createMockApprovalModel(resource, {
+				kind: AgentSessionApprovalKind.Other,
 				label: '{ "action": "deleteFile", "path": "/src/old-module.ts" }',
 				languageId: 'json',
 				since: new Date(),
@@ -623,6 +624,7 @@ export default defineThemedFixtureGroup({
 			const now = Date.now();
 			const resource = URI.parse('vscode-chat-session://local/approval-bash');
 			const approvalModel = createMockApprovalModel(resource, {
+				kind: AgentSessionApprovalKind.Terminal,
 				label: 'npm install --save express@latest',
 				languageId: 'sh',
 				since: new Date(),
@@ -647,6 +649,7 @@ export default defineThemedFixtureGroup({
 			const now = Date.now();
 			const resource = URI.parse('vscode-chat-session://local/approval-powershell');
 			const approvalModel = createMockApprovalModel(resource, {
+				kind: AgentSessionApprovalKind.Terminal,
 				label: 'Start-Job -ScriptBlock { Set-Location \'c:\\some\\path\'; npm install } | Out-Null',
 				languageId: 'pwsh',
 				since: new Date(),
@@ -671,6 +674,7 @@ export default defineThemedFixtureGroup({
 			const now = Date.now();
 			const resource = URI.parse('vscode-chat-session://local/approval-long');
 			const approvalModel = createMockApprovalModel(resource, {
+				kind: AgentSessionApprovalKind.Terminal,
 				label: 'rm -rf node_modules && npm cache clean --force && npm install --legacy-peer-deps --ignore-scripts',
 				languageId: 'sh',
 				since: new Date(),
@@ -697,6 +701,7 @@ export default defineThemedFixtureGroup({
 			const now = Date.now();
 			const resource = URI.parse('vscode-chat-session://local/approval-1line');
 			const approvalModel = createMockApprovalModel(resource, {
+				kind: AgentSessionApprovalKind.Terminal,
 				label: 'npm install --save express@latest',
 				languageId: 'sh',
 				since: new Date(),
@@ -721,6 +726,7 @@ export default defineThemedFixtureGroup({
 			const now = Date.now();
 			const resource = URI.parse('vscode-chat-session://local/approval-2lines');
 			const approvalModel = createMockApprovalModel(resource, {
+				kind: AgentSessionApprovalKind.Terminal,
 				label: 'cd /workspace/project\nnpm install',
 				languageId: 'sh',
 				since: new Date(),
@@ -745,6 +751,7 @@ export default defineThemedFixtureGroup({
 			const now = Date.now();
 			const resource = URI.parse('vscode-chat-session://local/approval-3lines');
 			const approvalModel = createMockApprovalModel(resource, {
+				kind: AgentSessionApprovalKind.Terminal,
 				label: 'cd /workspace/project\nnpm install\nnpm run build',
 				languageId: 'sh',
 				since: new Date(),
@@ -769,6 +776,7 @@ export default defineThemedFixtureGroup({
 			const now = Date.now();
 			const resource = URI.parse('vscode-chat-session://local/approval-4lines');
 			const approvalModel = createMockApprovalModel(resource, {
+				kind: AgentSessionApprovalKind.Terminal,
 				label: 'cd /workspace/project\nnpm install\nnpm run build\nnpm run test -- --coverage',
 				languageId: 'sh',
 				since: new Date(),
@@ -793,6 +801,7 @@ export default defineThemedFixtureGroup({
 			const now = Date.now();
 			const resource = URI.parse('vscode-chat-session://local/approval-3longlines');
 			const approvalModel = createMockApprovalModel(resource, {
+				kind: AgentSessionApprovalKind.Terminal,
 				label: 'RUSTFLAGS="-C target-cpu=native -C opt-level=3" cargo build --release --target x86_64-unknown-linux-gnu\nfind ./target/release -name "*.so" -exec strip --strip-unneeded {} \\; && tar czf release-bundle.tar.gz -C target/release .\ncurl -X POST https://deploy.internal.example.com/api/v2/artifacts/upload --header "Authorization: Bearer $DEPLOY_TOKEN" --form "bundle=@release-bundle.tar.gz"',
 				languageId: 'sh',
 				since: new Date(),

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/blockedSessionsList.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/blockedSessionsList.fixture.ts
@@ -1,0 +1,345 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../../../base/common/uri.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { ThemeIcon, themeColorFromId } from '../../../../../base/common/themables.js';
+import { Event } from '../../../../../base/common/event.js';
+import { IObservable, constObservable } from '../../../../../base/common/observable.js';
+import { IMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { IMarkdownRendererService, MarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
+import { IListService, ListService } from '../../../../../platform/list/browser/listService.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { EditorMarkdownCodeBlockRenderer } from '../../../../../editor/browser/widget/markdownRenderer/browser/editorMarkdownCodeBlockRenderer.js';
+// eslint-disable-next-line local/code-import-patterns
+import { IChat, IGitHubInfo, ISession, ISessionChangesSummary, ISessionFileChange, ISessionFolder, ISessionGitRepository, ISessionWorkspace, SessionStatus } from '../../../../../sessions/services/sessions/common/session.js';
+// eslint-disable-next-line local/code-import-patterns
+import { IActiveSession } from '../../../../../sessions/services/sessions/common/sessionsManagement.js';
+// eslint-disable-next-line local/code-import-patterns
+import { ISessionsService } from '../../../../../sessions/services/sessions/browser/sessionsService.js';
+// eslint-disable-next-line local/code-import-patterns
+import { ISessionsListModelService } from '../../../../../sessions/services/sessions/browser/sessionsListModelService.js';
+// eslint-disable-next-line local/code-import-patterns
+import { ISessionsProvidersService } from '../../../../../sessions/services/sessions/browser/sessionsProvidersService.js';
+// eslint-disable-next-line local/code-import-patterns
+import { BlockedSessionsList } from '../../../../../sessions/contrib/sessions/browser/blockedSessionsList.js';
+import { IChatService } from '../../../../contrib/chat/common/chatService/chatService.js';
+import { IChatModel } from '../../../../contrib/chat/common/model/chatModel.js';
+import { IAgentSessionsService } from '../../../../contrib/chat/browser/agentSessions/agentSessionsService.js';
+import { IAgentSession, IAgentSessionsModel } from '../../../../contrib/chat/browser/agentSessions/agentSessionsModel.js';
+import { AgentSessionApprovalModel, IAgentSessionApprovalInfo } from '../../../../contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
+import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup, registerWorkbenchServices } from '../fixtureUtils.js';
+
+// The blocked-sessions list reuses the shared session-row styles.
+// eslint-disable-next-line local/code-import-patterns
+import '../../../../../sessions/contrib/sessions/browser/media/sessionsList.css';
+
+// ============================================================================
+// Mock helpers
+// ============================================================================
+
+function createMockWorkspace(label: string, branchName: string, pullRequest?: IGitHubInfo['pullRequest']): ISessionWorkspace {
+	const root = URI.file(`/home/user/projects/${label}`);
+	const gitHubInfo: IGitHubInfo | undefined = pullRequest ? { owner: 'microsoft', repo: label, pullRequest } : undefined;
+
+	const gitRepository: ISessionGitRepository = {
+		uri: root,
+		workTreeUri: undefined,
+		branchName,
+		baseBranchName: 'main',
+		hasGitHubRemote: true,
+		gitHubInfo: constObservable(gitHubInfo),
+	};
+
+	const folder: ISessionFolder = {
+		root,
+		workingDirectory: root,
+		name: label,
+		description: undefined,
+		gitRepository,
+	};
+
+	return {
+		uri: root,
+		label,
+		icon: Codicon.folder,
+		folders: [folder],
+		requiresWorkspaceTrust: false,
+		isVirtualWorkspace: false,
+	};
+}
+
+function createMockChangesSummary(files: number, additions: number, deletions: number): ISessionChangesSummary {
+	return { files, additions, deletions };
+}
+
+interface IBlockedSessionOptions {
+	title: string;
+	status: SessionStatus;
+	/** How long ago the session was last updated, in minutes. */
+	minutesAgo: number;
+	workspace?: ISessionWorkspace;
+	/** Rendered in the details row for sessions that need input. */
+	description?: string;
+	/** Diff stats shown for completed sessions. */
+	changesSummary?: ISessionChangesSummary;
+	/** A terminal command awaiting approval; renders an approval row with an Allow button. */
+	approvalCommand?: string;
+}
+
+function createBlockedSession(options: IBlockedSessionOptions, approvals?: Map<string, IAgentSessionApprovalInfo>): ISession {
+	const updatedAt = new Date(Date.now() - options.minutesAgo * 60 * 1000);
+	const description: IMarkdownString | undefined = options.description ? new MarkdownString(options.description) : undefined;
+
+	// A session awaiting a tool approval carries a chat whose resource the (mock)
+	// approval model keys the pending approval on.
+	let chats: readonly IChat[] = [];
+	if (options.approvalCommand !== undefined && approvals) {
+		const chatResource = URI.parse(`vscode-chat://chat/${Math.random().toString(36).slice(2)}`);
+		approvals.set(chatResource.toString(), {
+			label: options.approvalCommand,
+			languageId: undefined,
+			since: new Date(),
+			confirm: () => { },
+		});
+		chats = [new class extends mock<IChat>() {
+			override readonly resource = chatResource;
+		}()];
+	}
+
+	return new class extends mock<ISession>() {
+		override readonly sessionId = `local:${options.title}`;
+		override readonly resource = URI.parse(`vscode-session://session/${Math.random().toString(36).slice(2)}`);
+		override readonly providerId = 'local';
+		override readonly sessionType = 'local';
+		override readonly icon = Codicon.account;
+		override readonly createdAt = updatedAt;
+		override readonly title: IObservable<string> = constObservable(options.title);
+		override readonly updatedAt: IObservable<Date> = constObservable(updatedAt);
+		override readonly status: IObservable<SessionStatus> = constObservable(options.status);
+		override readonly workspace: IObservable<ISessionWorkspace | undefined> = constObservable(options.workspace);
+		override readonly isArchived: IObservable<boolean> = constObservable<boolean>(false);
+		override readonly isRead: IObservable<boolean> = constObservable<boolean>(true);
+		override readonly changes: IObservable<readonly ISessionFileChange[]> = constObservable<readonly ISessionFileChange[]>([]);
+		override readonly changesSummary: IObservable<ISessionChangesSummary | undefined> = constObservable<ISessionChangesSummary | undefined>(options.changesSummary);
+		override readonly description: IObservable<IMarkdownString | undefined> = constObservable<IMarkdownString | undefined>(description);
+		override readonly chats: IObservable<readonly IChat[]> = constObservable<readonly IChat[]>(chats);
+	}();
+}
+
+function createApprovalModel(approvals: Map<string, IAgentSessionApprovalInfo>): AgentSessionApprovalModel {
+	return new class extends mock<AgentSessionApprovalModel>() {
+		override getApproval(resource: URI): IObservable<IAgentSessionApprovalInfo | undefined> {
+			return constObservable(approvals.get(resource.toString()));
+		}
+	}();
+}
+
+/**
+ * Build a set of sessions together with a matching approval model: each session
+ * whose spec has an `approvalCommand` shows a pending terminal approval row.
+ */
+function buildApprovalScenario(specs: readonly IBlockedSessionOptions[]): { sessions: ISession[]; approvalModel: AgentSessionApprovalModel } {
+	const approvals = new Map<string, IAgentSessionApprovalInfo>();
+	const sessions = specs.map(spec => createBlockedSession(spec, approvals));
+	return { sessions, approvalModel: createApprovalModel(approvals) };
+}
+
+function createMockListModelService(): ISessionsListModelService {
+	return new class extends mock<ISessionsListModelService>() {
+		override readonly onDidChange = Event.None;
+		override isSessionRead(): boolean { return true; }
+		override isSessionPinned(): boolean { return false; }
+		override markRead(): void { }
+		override getStatusIcon(status: SessionStatus, _isRead: boolean, isArchived: boolean, completedStateIcon?: ThemeIcon): ThemeIcon {
+			switch (status) {
+				case SessionStatus.InProgress:
+					return { ...Codicon.sessionInProgress, color: themeColorFromId('textLink.foreground') };
+				case SessionStatus.NeedsInput:
+					return { ...Codicon.circleFilled, color: themeColorFromId('list.warningForeground') };
+				case SessionStatus.Error:
+					return { ...Codicon.error, color: themeColorFromId('errorForeground') };
+				default:
+					if (isArchived) {
+						return { ...Codicon.passFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
+					}
+					if (completedStateIcon) {
+						return completedStateIcon;
+					}
+					return { ...Codicon.circleSmallFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
+			}
+		}
+	}();
+}
+
+// A failing-CI pull request (red) and a pull request with unresolved comments
+// (yellow) — the two non-needs-input reasons a session counts as blocked.
+const failingChecksPr: IGitHubInfo['pullRequest'] = {
+	number: 4821,
+	uri: URI.parse('https://github.com/microsoft/vscode/pull/4821'),
+	icon: { ...Codicon.gitPullRequest, color: themeColorFromId('charts.red') },
+};
+
+const unresolvedCommentsPr: IGitHubInfo['pullRequest'] = {
+	number: 4750,
+	uri: URI.parse('https://github.com/microsoft/vscode/pull/4750'),
+	icon: { ...Codicon.gitPullRequest, color: themeColorFromId('charts.yellow') },
+};
+
+// ============================================================================
+// Render helper
+// ============================================================================
+
+function renderBlockedList(ctx: ComponentFixtureContext, sessions: readonly ISession[], approvalModel?: AgentSessionApprovalModel): void {
+	const { container, disposableStore } = ctx;
+
+	const instantiationService = createEditorServices(disposableStore, {
+		colorTheme: ctx.theme,
+		additionalServices: (reg) => {
+			registerWorkbenchServices(reg);
+			reg.define(IListService, ListService);
+			reg.define(IMarkdownRendererService, MarkdownRendererService);
+			// `SessionsFlatList` creates an `AgentSessionApprovalModel` (reads
+			// `IChatService.chatModels`) and observes each session through the
+			// agent-sessions model. Both are stubbed to no-ops for the fixture.
+			reg.defineInstance(IChatService, new class extends mock<IChatService>() {
+				override readonly chatModels: IObservable<Iterable<IChatModel>> = constObservable<Iterable<IChatModel>>([]);
+			}());
+			reg.defineInstance(IAgentSessionsService, new class extends mock<IAgentSessionsService>() {
+				override readonly model = new class extends mock<IAgentSessionsModel>() {
+					override observeSession(): IObservable<IAgentSession | undefined> {
+						return constObservable<IAgentSession | undefined>(undefined);
+					}
+				}();
+			}());
+			reg.defineInstance(ISessionsService, new class extends mock<ISessionsService>() {
+				override readonly visibleSessions: IObservable<readonly (IActiveSession | undefined)[]> = constObservable<readonly (IActiveSession | undefined)[]>([]);
+			}());
+			reg.defineInstance(ISessionsListModelService, createMockListModelService());
+			reg.defineInstance(ISessionsProvidersService, new class extends mock<ISessionsProvidersService>() {
+				override readonly onDidChangeProviders = Event.None;
+				override getProviders() { return []; }
+				override getProvider() { return undefined; }
+			}());
+		},
+	});
+
+	// Render terminal-approval labels as real (monospace) code blocks — otherwise
+	// the markdown renderer emits empty code-block spans and the command is blank.
+	(instantiationService.get(IConfigurationService) as TestConfigurationService).setUserConfiguration('editor', { fontFamily: 'monospace' });
+	instantiationService.get(IMarkdownRendererService).setDefaultCodeBlockRenderer(instantiationService.createInstance(EditorMarkdownCodeBlockRenderer));
+
+	// The blocked-sessions list is shown as a floating dropdown anchored below
+	// the command center box in the agents window; approximate that surface (and
+	// its backdrop) here so the widget's own background/border/shadow read as
+	// they do in production.
+	container.style.width = '392px';
+	container.style.padding = '16px';
+	container.style.backgroundColor = 'var(--vscode-titleBar-activeBackground, var(--vscode-editor-background))';
+
+	const list = disposableStore.add(instantiationService.createInstance(BlockedSessionsList, container, {
+		onSessionOpen: () => { },
+		approvalModel,
+	}));
+	list.setSessions(sessions);
+}
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+export default defineThemedFixtureGroup({ path: 'sessions/' }, {
+
+	// A mix of the three reasons a session is "blocked": it needs input, its PR
+	// has failing CI checks, or its PR has unresolved comments.
+	BlockedSessionsList_Mixed: defineComponentFixture({
+		render: (ctx) => renderBlockedList(ctx, [
+			createBlockedSession({
+				title: 'Fix authentication redirect loop',
+				status: SessionStatus.NeedsInput,
+				minutesAgo: 3,
+				workspace: createMockWorkspace('vscode', 'feature/auth-fix'),
+				description: 'Waiting for you to confirm running the database migration.',
+			}),
+			createBlockedSession({
+				title: 'Add telemetry for startup performance',
+				status: SessionStatus.Completed,
+				minutesAgo: 62,
+				workspace: createMockWorkspace('vscode', 'perf/startup-telemetry', failingChecksPr),
+				changesSummary: createMockChangesSummary(8, 240, 58),
+			}),
+			createBlockedSession({
+				title: 'Refactor the notification service',
+				status: SessionStatus.Completed,
+				minutesAgo: 184,
+				workspace: createMockWorkspace('vscode', 'refactor/notifications', unresolvedCommentsPr),
+				changesSummary: createMockChangesSummary(12, 96, 140),
+			}),
+		]),
+	}),
+
+	// A single session that needs input — the most common blocked state.
+	BlockedSessionsList_SingleNeedsInput: defineComponentFixture({
+		render: (ctx) => renderBlockedList(ctx, [
+			createBlockedSession({
+				title: 'Update the onboarding walkthrough copy',
+				status: SessionStatus.NeedsInput,
+				minutesAgo: 1,
+				workspace: createMockWorkspace('vscode', 'docs/onboarding'),
+				description: 'Which tone should the welcome step use — formal or friendly?',
+			}),
+		]),
+	}),
+
+	// Enough sessions to fill the dropdown and show the bounded, scrollable height.
+	BlockedSessionsList_Many: defineComponentFixture({
+		render: (ctx) => renderBlockedList(ctx, [
+			createBlockedSession({ title: 'Fix authentication redirect loop', status: SessionStatus.NeedsInput, minutesAgo: 3, workspace: createMockWorkspace('vscode', 'feature/auth-fix'), description: 'Waiting for you to confirm running the database migration.' }),
+			createBlockedSession({ title: 'Add telemetry for startup performance', status: SessionStatus.Completed, minutesAgo: 62, workspace: createMockWorkspace('vscode', 'perf/startup-telemetry', failingChecksPr), changesSummary: createMockChangesSummary(8, 240, 58) }),
+			createBlockedSession({ title: 'Refactor the notification service', status: SessionStatus.Completed, minutesAgo: 184, workspace: createMockWorkspace('vscode', 'refactor/notifications', unresolvedCommentsPr), changesSummary: createMockChangesSummary(12, 96, 140) }),
+			createBlockedSession({ title: 'Migrate settings sync to the new store', status: SessionStatus.NeedsInput, minutesAgo: 240, workspace: createMockWorkspace('vscode', 'feature/settings-store'), description: 'Should I keep the legacy keys for one more release?' }),
+			createBlockedSession({ title: 'Investigate flaky terminal integration test', status: SessionStatus.Completed, minutesAgo: 320, workspace: createMockWorkspace('vscode', 'fix/flaky-terminal-test', failingChecksPr), changesSummary: createMockChangesSummary(3, 41, 12) }),
+			createBlockedSession({ title: 'Polish the command center hover states', status: SessionStatus.Completed, minutesAgo: 600, workspace: createMockWorkspace('vscode', 'polish/command-center', unresolvedCommentsPr), changesSummary: createMockChangesSummary(5, 64, 9) }),
+		]),
+	}),
+
+	// One session with a pending terminal approval — shows the approval row + Allow button.
+	BlockedSessionsList_OneApproval: defineComponentFixture({
+		render: (ctx) => {
+			const { sessions, approvalModel } = buildApprovalScenario([
+				{ title: 'Build the production bundle', status: SessionStatus.NeedsInput, minutesAgo: 1, workspace: createMockWorkspace('vscode', 'release/prod-build'), approvalCommand: 'npm run build:prod' },
+			]);
+			renderBlockedList(ctx, sessions, approvalModel);
+		},
+	}),
+
+	// Two sessions awaiting approval — a short command and a long single-line command.
+	BlockedSessionsList_TwoApprovals: defineComponentFixture({
+		render: (ctx) => {
+			const { sessions, approvalModel } = buildApprovalScenario([
+				{ title: 'Push the auth fix', status: SessionStatus.NeedsInput, minutesAgo: 2, workspace: createMockWorkspace('vscode', 'feature/auth-fix'), approvalCommand: 'git push --force-with-lease origin feature/auth-fix' },
+				{ title: 'Publish the release image', status: SessionStatus.NeedsInput, minutesAgo: 6, workspace: createMockWorkspace('vscode', 'release/docker'), approvalCommand: 'docker run --rm -it -v "$(pwd)":/workspace -w /workspace -e NODE_ENV=production -e REGISTRY=ghcr.io/microsoft --network host node:20-alpine npm run build:image -- --push --tag latest --no-cache' },
+			]);
+			renderBlockedList(ctx, sessions, approvalModel);
+		},
+	}),
+
+	// Five sessions awaiting approval, spanning short, long single-line and
+	// multi-line terminal commands (the approval row shows up to three lines).
+	BlockedSessionsList_FiveApprovals: defineComponentFixture({
+		render: (ctx) => {
+			const { sessions, approvalModel } = buildApprovalScenario([
+				{ title: 'Install dependencies', status: SessionStatus.NeedsInput, minutesAgo: 1, workspace: createMockWorkspace('vscode', 'chore/deps'), approvalCommand: 'npm ci' },
+				{ title: 'Rebase onto main', status: SessionStatus.NeedsInput, minutesAgo: 3, workspace: createMockWorkspace('vscode', 'feature/rebase'), approvalCommand: 'git rebase --onto main feature/old-base feature/new-work' },
+				{ title: 'Provision the review environment', status: SessionStatus.NeedsInput, minutesAgo: 7, workspace: createMockWorkspace('vscode', 'infra/review-env'), approvalCommand: 'kubectl apply -f ./deploy/review.yaml --namespace review-pr-4821 && kubectl rollout status deployment/web --namespace review-pr-4821 --timeout=180s && kubectl get pods --namespace review-pr-4821 -o wide' },
+				{ title: 'Format changed files', status: SessionStatus.NeedsInput, minutesAgo: 12, workspace: createMockWorkspace('vscode', 'chore/format'), approvalCommand: 'for f in $(git diff --name-only main); do\n  npx prettier --write "$f"\n  git add "$f"\ndone' },
+				{ title: 'Reset and reinstall', status: SessionStatus.NeedsInput, minutesAgo: 20, workspace: createMockWorkspace('vscode', 'fix/clean-install'), approvalCommand: 'rm -rf node_modules\nrm -f package-lock.json\nnpm cache clean --force\nnpm install\nnpm run test:integration' },
+			]);
+			renderBlockedList(ctx, sessions, approvalModel);
+		},
+	}),
+});

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/blockedSessionsList.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/blockedSessionsList.fixture.ts
@@ -31,7 +31,7 @@ import { IChatService } from '../../../../contrib/chat/common/chatService/chatSe
 import { IChatModel } from '../../../../contrib/chat/common/model/chatModel.js';
 import { IAgentSessionsService } from '../../../../contrib/chat/browser/agentSessions/agentSessionsService.js';
 import { IAgentSession, IAgentSessionsModel } from '../../../../contrib/chat/browser/agentSessions/agentSessionsModel.js';
-import { AgentSessionApprovalModel, IAgentSessionApprovalInfo } from '../../../../contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
+import { AgentSessionApprovalKind, AgentSessionApprovalModel, IAgentSessionApprovalInfo } from '../../../../contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
 import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup, registerWorkbenchServices } from '../fixtureUtils.js';
 
 // The blocked-sessions list reuses the shared session-row styles.
@@ -101,6 +101,7 @@ function createBlockedSession(options: IBlockedSessionOptions, approvals?: Map<s
 	if (options.approvalCommand !== undefined && approvals) {
 		const chatResource = URI.parse(`vscode-chat://chat/${Math.random().toString(36).slice(2)}`);
 		approvals.set(chatResource.toString(), {
+			kind: AgentSessionApprovalKind.Terminal,
 			label: options.approvalCommand,
 			languageId: undefined,
 			since: new Date(),

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/sessionsTitleBarWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/sessionsTitleBarWidget.fixture.ts
@@ -8,9 +8,11 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { Event } from '../../../../../base/common/event.js';
 import { IObservable, constObservable } from '../../../../../base/common/observable.js';
 import { mock } from '../../../../../base/test/common/mock.js';
+import { URI } from '../../../../../base/common/uri.js';
 import { SubmenuItemAction } from '../../../../../platform/actions/common/actions.js';
+import { AgentSessionApprovalKind, AgentSessionApprovalModel, IAgentSessionApprovalInfo } from '../../../../contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
 // eslint-disable-next-line local/code-import-patterns
-import { ISession, ISessionWorkspace } from '../../../../../sessions/services/sessions/common/session.js';
+import { IChat, ISession, ISessionWorkspace } from '../../../../../sessions/services/sessions/common/session.js';
 // eslint-disable-next-line local/code-import-patterns
 import { IActiveSession, ISessionsManagementService } from '../../../../../sessions/services/sessions/common/sessionsManagement.js';
 // eslint-disable-next-line local/code-import-patterns
@@ -18,7 +20,7 @@ import { ISessionsService } from '../../../../../sessions/services/sessions/brow
 // eslint-disable-next-line local/code-import-patterns
 import { ISessionsProvidersService } from '../../../../../sessions/services/sessions/browser/sessionsProvidersService.js';
 // eslint-disable-next-line local/code-import-patterns
-import { IBlockedSessionsService } from '../../../../../sessions/contrib/blockedSessions/browser/blockedSessionsService.js';
+import { BlockedSessionReason, IBlockedSession, IBlockedSessionsService } from '../../../../../sessions/contrib/blockedSessions/browser/blockedSessionsService.js';
 // eslint-disable-next-line local/code-import-patterns
 import { SessionActionFeedback } from '../../../../../sessions/contrib/sessions/browser/sessionActionFeedback.js';
 // eslint-disable-next-line local/code-import-patterns
@@ -42,11 +44,55 @@ function createMockActiveSession(title: string, workspaceLabel: string): IActive
 	}();
 }
 
+/** A blocked session to synthesize for a fixture. */
+interface IBlockedSpec {
+	/** Why the session is blocked. */
+	readonly reason: BlockedSessionReason;
+	/** For `NeedsInput`, the kind of pending approval (terminal vs question). */
+	readonly approvalKind?: AgentSessionApprovalKind;
+}
+
+/**
+ * Build mock blocked sessions plus an approval model that reports the requested
+ * approval kind for each session's chat, so the widget classifies them exactly.
+ */
+function buildBlocked(specs: readonly IBlockedSpec[]): { blocked: IBlockedSession[]; approvalModel: AgentSessionApprovalModel } {
+	const approvals = new Map<string, IAgentSessionApprovalInfo>();
+	const blocked = specs.map((spec, i): IBlockedSession => {
+		const chatResource = URI.parse(`session-chat:/blocked/${i}`);
+		if (spec.approvalKind) {
+			approvals.set(chatResource.toString(), {
+				kind: spec.approvalKind,
+				label: 'npm run build',
+				languageId: undefined,
+				since: new Date(),
+				confirm: () => { },
+			});
+		}
+		const chat = new class extends mock<IChat>() {
+			override readonly resource = chatResource;
+		}();
+		const session = new class extends mock<ISession>() {
+			override readonly sessionId = `blocked-${i}`;
+			override readonly chats: IObservable<readonly IChat[]> = constObservable([chat]);
+		}();
+		return { session, reason: spec.reason };
+	});
+	const approvalModel = new class extends mock<AgentSessionApprovalModel>() {
+		override getApproval(resource: URI): IObservable<IAgentSessionApprovalInfo | undefined> {
+			return constObservable(approvals.get(resource.toString()));
+		}
+	}();
+	return { blocked, approvalModel };
+}
+
 interface ITitleBarState {
 	/** The active session shown in the default pill (falls back to "New Session"). */
 	activeSession?: IActiveSession;
 	/** Number of blocked sessions (drives the orange "N sessions require input"). */
 	blockedCount?: number;
+	/** Explicit typed blocked sessions (drives the specific requires-input message). */
+	blocked?: readonly IBlockedSpec[];
 	/** Whether the primary side bar is visible (requires-input only shows when hidden). */
 	sidebarVisible?: boolean;
 	/** Number of recently approved sessions (drives the green "Approved N sessions"). */
@@ -60,9 +106,11 @@ interface ITitleBarState {
 function renderTitleBar(ctx: ComponentFixtureContext, state: ITitleBarState): void {
 	const { container, disposableStore } = ctx;
 
-	// Only the count is read for the requires-input state, so a shared filler is fine.
-	const blockedFiller = new class extends mock<ISession>() { }();
-	const blocked: readonly ISession[] = Array.from({ length: state.blockedCount ?? 0 }, () => blockedFiller);
+	// Blocked sessions: either an explicit typed list, or a plain count of
+	// unclassified needs-input sessions (which yield the generic message).
+	const specs: readonly IBlockedSpec[] = state.blocked
+		?? Array.from({ length: state.blockedCount ?? 0 }, (): IBlockedSpec => ({ reason: BlockedSessionReason.NeedsInput }));
+	const { blocked, approvalModel } = buildBlocked(specs);
 	const sidebarVisible = state.sidebarVisible ?? true;
 
 	const instantiationService = createEditorServices(disposableStore, {
@@ -80,7 +128,8 @@ function renderTitleBar(ctx: ComponentFixtureContext, state: ITitleBarState): vo
 				override readonly onDidChangeProviders = Event.None;
 			}());
 			reg.defineInstance(IBlockedSessionsService, new class extends mock<IBlockedSessionsService>() {
-				override readonly blockedSessions: IObservable<readonly ISession[]> = constObservable(blocked);
+				override readonly blockedSessions: IObservable<readonly ISession[]> = constObservable(blocked.map(entry => entry.session));
+				override readonly blockedSessionsWithReasons: IObservable<readonly IBlockedSession[]> = constObservable(blocked);
 			}());
 			reg.defineInstance(IWorkbenchLayoutService, new class extends mock<IWorkbenchLayoutService>() {
 				override readonly onDidChangePartVisibility = Event.None;
@@ -112,7 +161,7 @@ function renderTitleBar(ctx: ComponentFixtureContext, state: ITitleBarState): vo
 		override notifyApproved(): void { }
 	}();
 
-	const widget = disposableStore.add(instantiationService.createInstance(SessionsTitleBarWidget, action, undefined, sessionActionFeedback));
+	const widget = disposableStore.add(instantiationService.createInstance(SessionsTitleBarWidget, action, undefined, sessionActionFeedback, approvalModel));
 	widget.render(widgetHost);
 }
 
@@ -129,11 +178,58 @@ export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 		}),
 	}),
 
-	// Requires-input: orange state when the side bar is hidden and sessions are blocked.
+	// Requires-input: generic orange state (a mix, or unclassified needs-input).
 	SessionsTitleBar_RequiresInput: defineComponentFixture({
 		render: (ctx) => renderTitleBar(ctx, {
 			activeSession: createMockActiveSession('Fix authentication redirect loop', 'vscode'),
 			blockedCount: 3,
+			sidebarVisible: false,
+		}),
+	}),
+
+	// Requires-input (terminal): all blocked sessions are waiting on a terminal command.
+	SessionsTitleBar_RequiresInputTerminal: defineComponentFixture({
+		render: (ctx) => renderTitleBar(ctx, {
+			activeSession: createMockActiveSession('Fix authentication redirect loop', 'vscode'),
+			blocked: [
+				{ reason: BlockedSessionReason.NeedsInput, approvalKind: AgentSessionApprovalKind.Terminal },
+				{ reason: BlockedSessionReason.NeedsInput, approvalKind: AgentSessionApprovalKind.Terminal },
+			],
+			sidebarVisible: false,
+		}),
+	}),
+
+	// Requires-input (question): all blocked sessions are asking a question.
+	SessionsTitleBar_RequiresInputQuestion: defineComponentFixture({
+		render: (ctx) => renderTitleBar(ctx, {
+			activeSession: createMockActiveSession('Fix authentication redirect loop', 'vscode'),
+			blocked: [
+				{ reason: BlockedSessionReason.NeedsInput, approvalKind: AgentSessionApprovalKind.Question },
+			],
+			sidebarVisible: false,
+		}),
+	}),
+
+	// Requires-input (failing CI): all blocked sessions have failing CI checks.
+	SessionsTitleBar_RequiresInputFailingCI: defineComponentFixture({
+		render: (ctx) => renderTitleBar(ctx, {
+			activeSession: createMockActiveSession('Fix authentication redirect loop', 'vscode'),
+			blocked: [
+				{ reason: BlockedSessionReason.FailingCI },
+				{ reason: BlockedSessionReason.FailingCI },
+			],
+			sidebarVisible: false,
+		}),
+	}),
+
+	// Requires-input (mixed): a mix of reasons falls back to the generic message.
+	SessionsTitleBar_RequiresInputMixed: defineComponentFixture({
+		render: (ctx) => renderTitleBar(ctx, {
+			activeSession: createMockActiveSession('Fix authentication redirect loop', 'vscode'),
+			blocked: [
+				{ reason: BlockedSessionReason.NeedsInput, approvalKind: AgentSessionApprovalKind.Terminal },
+				{ reason: BlockedSessionReason.FailingCI },
+			],
 			sidebarVisible: false,
 		}),
 	}),

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/sessionsTitleBarWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/sessionsTitleBarWidget.fixture.ts
@@ -1,0 +1,159 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { $, append } from '../../../../../base/browser/dom.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { Event } from '../../../../../base/common/event.js';
+import { IObservable, constObservable } from '../../../../../base/common/observable.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { SubmenuItemAction } from '../../../../../platform/actions/common/actions.js';
+// eslint-disable-next-line local/code-import-patterns
+import { ISession, ISessionWorkspace } from '../../../../../sessions/services/sessions/common/session.js';
+// eslint-disable-next-line local/code-import-patterns
+import { IActiveSession, ISessionsManagementService } from '../../../../../sessions/services/sessions/common/sessionsManagement.js';
+// eslint-disable-next-line local/code-import-patterns
+import { ISessionsService } from '../../../../../sessions/services/sessions/browser/sessionsService.js';
+// eslint-disable-next-line local/code-import-patterns
+import { ISessionsProvidersService } from '../../../../../sessions/services/sessions/browser/sessionsProvidersService.js';
+// eslint-disable-next-line local/code-import-patterns
+import { IBlockedSessionsService } from '../../../../../sessions/contrib/blockedSessions/browser/blockedSessionsService.js';
+// eslint-disable-next-line local/code-import-patterns
+import { SessionActionFeedback } from '../../../../../sessions/contrib/sessions/browser/sessionActionFeedback.js';
+// eslint-disable-next-line local/code-import-patterns
+import { SessionsTitleBarWidget } from '../../../../../sessions/contrib/sessions/browser/sessionsTitleBarWidget.js';
+import { IWorkbenchLayoutService, Parts } from '../../../../services/layout/browser/layoutService.js';
+import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup, registerWorkbenchServices } from '../fixtureUtils.js';
+
+// ============================================================================
+// Mock helpers
+// ============================================================================
+
+function createMockActiveSession(title: string, workspaceLabel: string): IActiveSession {
+	const workspace = new class extends mock<ISessionWorkspace>() {
+		override readonly label = workspaceLabel;
+	}();
+	return new class extends mock<IActiveSession>() {
+		override readonly icon = Codicon.copilot;
+		override readonly title: IObservable<string> = constObservable(title);
+		override readonly workspace: IObservable<ISessionWorkspace | undefined> = constObservable(workspace);
+		override readonly isQuickChat: IObservable<boolean> = constObservable<boolean>(false);
+	}();
+}
+
+interface ITitleBarState {
+	/** The active session shown in the default pill (falls back to "New Session"). */
+	activeSession?: IActiveSession;
+	/** Number of blocked sessions (drives the orange "N sessions require input"). */
+	blockedCount?: number;
+	/** Whether the primary side bar is visible (requires-input only shows when hidden). */
+	sidebarVisible?: boolean;
+	/** Number of recently approved sessions (drives the green "Approved N sessions"). */
+	approvedCount?: number;
+}
+
+// ============================================================================
+// Render helper
+// ============================================================================
+
+function renderTitleBar(ctx: ComponentFixtureContext, state: ITitleBarState): void {
+	const { container, disposableStore } = ctx;
+
+	// Only the count is read for the requires-input state, so a shared filler is fine.
+	const blockedFiller = new class extends mock<ISession>() { }();
+	const blocked: readonly ISession[] = Array.from({ length: state.blockedCount ?? 0 }, () => blockedFiller);
+	const sidebarVisible = state.sidebarVisible ?? true;
+
+	const instantiationService = createEditorServices(disposableStore, {
+		colorTheme: ctx.theme,
+		additionalServices: (reg) => {
+			registerWorkbenchServices(reg);
+			reg.defineInstance(ISessionsService, new class extends mock<ISessionsService>() {
+				override readonly activeSession: IObservable<IActiveSession | undefined> = constObservable(state.activeSession);
+				override readonly visibleSessions: IObservable<readonly (IActiveSession | undefined)[]> = constObservable<readonly (IActiveSession | undefined)[]>([]);
+			}());
+			reg.defineInstance(ISessionsManagementService, new class extends mock<ISessionsManagementService>() {
+				override readonly onDidChangeSessions = Event.None;
+			}());
+			reg.defineInstance(ISessionsProvidersService, new class extends mock<ISessionsProvidersService>() {
+				override readonly onDidChangeProviders = Event.None;
+			}());
+			reg.defineInstance(IBlockedSessionsService, new class extends mock<IBlockedSessionsService>() {
+				override readonly blockedSessions: IObservable<readonly ISession[]> = constObservable(blocked);
+			}());
+			reg.defineInstance(IWorkbenchLayoutService, new class extends mock<IWorkbenchLayoutService>() {
+				override readonly onDidChangePartVisibility = Event.None;
+				override isVisible(part: Parts): boolean {
+					return part === Parts.SIDEBAR_PART ? sidebarVisible : true;
+				}
+			}());
+		},
+	});
+
+	// The widget's pill styles are scoped under `.command-center`, so recreate
+	// that ancestor. The command center box sizes itself relative to the
+	// viewport, so give the host a representative width.
+	container.classList.add('agent-sessions-workbench');
+	container.style.width = '460px';
+	const commandCenter = append(container, $('.command-center'));
+	const widgetHost = append(commandCenter, $('div'));
+
+	const action = new class extends mock<SubmenuItemAction>() {
+		override readonly id = 'workbench.agentSessions.titlebar';
+		override readonly label = 'Agent Sessions';
+		override readonly tooltip = '';
+		override readonly enabled = true;
+		override async run() { }
+	}();
+
+	const sessionActionFeedback = new class extends mock<SessionActionFeedback>() {
+		override readonly approvedCount: IObservable<number> = constObservable<number>(state.approvedCount ?? 0);
+		override notifyApproved(): void { }
+	}();
+
+	const widget = disposableStore.add(instantiationService.createInstance(SessionsTitleBarWidget, action, undefined, sessionActionFeedback));
+	widget.render(widgetHost);
+}
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+export default defineThemedFixtureGroup({ path: 'sessions/' }, {
+
+	// Default: shows the active session pill (icon + title + workspace).
+	SessionsTitleBar_ActiveSession: defineComponentFixture({
+		render: (ctx) => renderTitleBar(ctx, {
+			activeSession: createMockActiveSession('Fix authentication redirect loop', 'vscode'),
+		}),
+	}),
+
+	// Requires-input: orange state when the side bar is hidden and sessions are blocked.
+	SessionsTitleBar_RequiresInput: defineComponentFixture({
+		render: (ctx) => renderTitleBar(ctx, {
+			activeSession: createMockActiveSession('Fix authentication redirect loop', 'vscode'),
+			blockedCount: 3,
+			sidebarVisible: false,
+		}),
+	}),
+
+	// Approved (one): transient green confirmation after approving a session action.
+	SessionsTitleBar_ApprovedOne: defineComponentFixture({
+		render: (ctx) => renderTitleBar(ctx, {
+			activeSession: createMockActiveSession('Fix authentication redirect loop', 'vscode'),
+			approvedCount: 1,
+		}),
+	}),
+
+	// Approved (many): green confirmation after approving several sessions in a row.
+	// Takes precedence over the orange requires-input state while visible.
+	SessionsTitleBar_ApprovedMany: defineComponentFixture({
+		render: (ctx) => renderTitleBar(ctx, {
+			activeSession: createMockActiveSession('Fix authentication redirect loop', 'vscode'),
+			blockedCount: 3,
+			sidebarVisible: false,
+			approvedCount: 3,
+		}),
+	}),
+});


### PR DESCRIPTION
## Sessions requiring input

Adds a command-center indicator in the agents window that surfaces sessions needing attention when the primary side bar is hidden, and lets you act on them from a dropdown.

### Highlights
- **Requires-input pill** — when the side bar is hidden and one or more sessions are blocked (need input, failing CI, or unresolved PR comments), the command center shows an orange `N sessions require input` pill; a short blink plays when a new session becomes blocked (including the first).
- **Context-specific messages** — when all blocked sessions share one reason the pill is more specific: *requires terminal approval*, *are failing CI*, *have questions*, *have unresolved comments*. A mix of reasons falls back to the generic message.
- **Blocked-sessions dropdown** — clicking opens a flat list of the blocked sessions (width matched to the command center, kept in sync on resize) with inline Allow buttons; approving shows a transient green `Approved N sessions` confirmation. The dropdown dismisses on Escape or an outside click, and a header action opens the full sessions picker.
- Sessions already visible on screen are excluded from the indicator and the list.

### Validation
- `npm run typecheck-client` and ESLint clean.
- Unit tests for `BlockedSessionsService` (per-session reason + CI precedence) and `AgentSessionApprovalModel`.
- Component fixtures for the titlebar states (active / requires-input variants / approved) and the blocked-sessions list.