### PR TITLE
Style overrides: improve scroll shadows

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/scrollShadows.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/scrollShadows.css
@@ -63,13 +63,22 @@
 	z-index: 10;
 }
 
+.style-override .monaco-list > .monaco-scrollable-element::before {
+	top: 0;
+	background: linear-gradient(to bottom, var(--scroll-shadow-surface), transparent);
+}
+
+.style-override .monaco-list > .monaco-scrollable-element::after {
+	bottom: 0;
+	background: linear-gradient(to top, var(--scroll-shadow-surface), transparent);
+}
+
 /* =============================================================================
  * Editor area. The main editor viewport scrolls inside `.editor-scrollable`;
  * pin the fades to that scrollable element so they share the scrollbar's
  * stacking context and sit below it. Scope to the editor / panel parts so the
  * fade never leaks onto inline editors such as the chat input.
  * ========================================================================== */
-.style-override .part.editor .monaco-editor .editor-scrollable::before,
 .style-override .part.editor .monaco-editor .editor-scrollable::after {
 	content: "";
 	position: absolute;
@@ -81,7 +90,26 @@
 	z-index: 10;
 }
 
-.style-override .part.editor .monaco-editor .editor-scrollable::before,
+/* Editor top shadow: delegate to the built-in scroll-decoration element. */
+.style-override .part.editor .monaco-editor .scroll-decoration {
+	position: absolute;
+	top: 0;
+	left: 0;
+	height: 8px;
+	box-shadow: var(--vscode-editor-background) 0 8px 8px -8px inset;
+}
+
+.style-override .part.panel .monaco-editor .editor-scrollable::before,
+.style-override .part.panel .monaco-editor .editor-scrollable::after {
+	content: "";
+	position: absolute;
+	left: 0;
+	right: 0;
+	height: 8px;
+	pointer-events: none;
+	z-index: 10;
+}
+
 .style-override .part.panel .monaco-editor .editor-scrollable::before {
 	top: 0;
 	background: linear-gradient(to bottom, var(--scroll-shadow-surface), transparent);


### PR DESCRIPTION
This pull request updates the scroll shadow styles in the editor and list components to improve visual consistency and delegate some effects to built-in elements. The main changes involve adjusting how and where scroll shadows are rendered for both lists and editor areas.

**Scroll shadow improvements:**

* Added custom top and bottom scroll shadows for `.monaco-list` elements using `::before` and `::after` pseudo-elements in `scrollShadows.css`.
* Updated editor area scroll shadows to use the built-in `.scroll-decoration` element for the top shadow, improving maintainability and consistency.
* Refined panel editor scroll shadows by explicitly defining `::before` and `::after` pseudo-elements for `.editor-scrollable`, ensuring correct positioning and appearance.