### PR TITLE
Style overrides: Remove redundant scroll shadow styles

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/scrollShadows.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/scrollShadows.css
@@ -52,7 +52,6 @@
 	position: relative;
 }
 
-.style-override .monaco-list > .monaco-scrollable-element::before,
 .style-override .monaco-list > .monaco-scrollable-element::after {
 	content: "";
 	position: absolute;
@@ -61,11 +60,6 @@
 	height: 12px;
 	pointer-events: none;
 	z-index: 10;
-}
-
-.style-override .monaco-list > .monaco-scrollable-element::before {
-	top: 0;
-	background: linear-gradient(to bottom, var(--scroll-shadow-surface), transparent);
 }
 
 .style-override .monaco-list > .monaco-scrollable-element::after {
@@ -99,7 +93,6 @@
 	box-shadow: var(--vscode-editor-background) 0 8px 8px -8px inset;
 }
 
-.style-override .part.panel .monaco-editor .editor-scrollable::before,
 .style-override .part.panel .monaco-editor .editor-scrollable::after {
 	content: "";
 	position: absolute;
@@ -108,11 +101,6 @@
 	height: 8px;
 	pointer-events: none;
 	z-index: 10;
-}
-
-.style-override .part.panel .monaco-editor .editor-scrollable::before {
-	top: 0;
-	background: linear-gradient(to bottom, var(--scroll-shadow-surface), transparent);
 }
 
 .style-override .part.editor .monaco-editor .editor-scrollable::after,


### PR DESCRIPTION
Eliminate unnecessary scroll shadow styles from list and panel elements to streamline the CSS.

