### PR TITLE
Style override: Add border-radius to update indicator in action bar

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
@@ -70,6 +70,12 @@
 	border-radius: var(--vscode-cornerRadius-small) !important;
 }
 
+/* Update indicator (title-bar "Update" button — base CSS uses medium, but as a
+ * control it belongs to the controls tier). */
+.style-override .monaco-action-bar .update-indicator {
+	border-radius: var(--vscode-cornerRadius-small) !important;
+}
+
 /*
  * Agent status pill (experimental title-bar widget). A connected pill/badge
  * group whose segments hardcode 5-6px per-corner radii, with a few intentional


### PR DESCRIPTION
Introduce a border-radius style for the update indicator in the action bar to enhance the visual appearance. This change improves consistency with other UI elements.

