### PR TITLE
copilot: force temperature=1 and top_p=0.95 for Kimi models

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/chatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/node/chatEndpoint.ts
@@ -29,7 +29,7 @@ import { ITelemetryService, TelemetryProperties } from '../../telemetry/common/t
 import { TelemetryData } from '../../telemetry/common/telemetryData';
 import { ITokenizerProvider } from '../../tokenizer/node/tokenizer';
 import { ICAPIClientService } from '../common/capiClient';
-import { getModelCapabilityOverride, isAnthropicFamily, isGeminiFamily, modelSupportsContextEditing, modelSupportsToolSearch } from '../common/chatModelCapabilities';
+import { getModelCapabilityOverride, isAnthropicFamily, isGeminiFamily, isKimiFamily, modelSupportsContextEditing, modelSupportsToolSearch } from '../common/chatModelCapabilities';
 import { IDomainService } from '../common/domainService';
 import { CustomModel, IChatModelInformation, ModelSupportedEndpoint } from '../common/endpointProvider';
 import { normalizeTokenPrices } from '../../../extension/conversation/common/languageModelAccess';
@@ -388,6 +388,12 @@ export class ChatEndpoint implements IChatEndpoint {
 			if (lowReasoningEnabled) {
 				body.reasoning_effort = 'low';
 			}
+		}
+
+		// Force temperature and top_p for Kimi models regardless of what the client would otherwise send (per Moonshot recommendations). Temperature 0 strongly increases chances of looping.
+		if (isKimiFamily(this)) {
+			body.temperature = 1;
+			body.top_p = 0.95;
 		}
 
 		return body;

--- a/extensions/copilot/src/platform/endpoint/node/test/copilotChatEndpoint.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/copilotChatEndpoint.spec.ts
@@ -452,3 +452,48 @@ describe('ChatEndpoint - Image Count Validation', () => {
 		});
 	});
 });
+
+describe('ChatEndpoint - Kimi temperature and top_p override', () => {
+	let mockServices: ReturnType<typeof createMockServices>;
+
+	beforeEach(() => {
+		mockServices = createMockServices();
+	});
+
+	const createEndpoint = (metadata: IChatModelInformation) =>
+		new ChatEndpoint(
+			metadata,
+			mockServices.domainService,
+			mockServices.chatMLFetcher,
+			mockServices.tokenizerProvider,
+			mockServices.instantiationService,
+			mockServices.configurationService,
+			mockServices.expService,
+			mockServices.chatWebSocketService,
+			mockServices.logService
+		);
+
+	const createTextMessage = (): Raw.ChatMessage => ({
+		role: Raw.ChatRole.User,
+		content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Hello' }]
+	});
+
+	const createOptionsWithPostOptions = (): ICreateEndpointBodyOptions => ({
+		...createTestOptions([createTextMessage()]),
+		postOptions: { temperature: 0, top_p: 1 }
+	});
+
+	it.each(['kimi-k2.6', 'kimi-k2.7-code'])('should force temperature=1 and top_p=0.95 for %s', (family) => {
+		const endpoint = createEndpoint(createNonAnthropicModelMetadata(family));
+		const body = endpoint.createRequestBody(createOptionsWithPostOptions());
+		expect(body.temperature).toBe(1);
+		expect(body.top_p).toBe(0.95);
+	});
+
+	it('should not override temperature or top_p for non-Kimi models', () => {
+		const endpoint = createEndpoint(createNonAnthropicModelMetadata('gpt-4o'));
+		const body = endpoint.createRequestBody(createOptionsWithPostOptions());
+		expect(body.temperature).toBe(0);
+		expect(body.top_p).toBe(1);
+	});
+});


### PR DESCRIPTION
## What

For Kimi models (`kimi-k2.6` and `kimi-k2.7-code`), always send `temperature = 1` and `top_p = 0.95` on outbound requests, overriding whatever the client would otherwise send.

## How

- Override in `customizeCapiBody` (`extensions/copilot/src/platform/endpoint/node/chatEndpoint.ts`), mirroring the existing `gemini-3` block. Kimi uses the Chat Completions (CAPI) request shape, so this is the single spot that covers all modes (agent/ask/edit) and both streaming and non-streaming paths.
- Gated on the existing `isKimiFamily` helper (matches both `kimi-k2.6` and `kimi-k2.7-code`).
- By the time this runs, `temperature`/`top_p` are already populated (via `createCapiRequestBody` → `Object.assign(request, options.postOptions)`), so this overwrites rather than introduces them.

This overrides the agent-mode default `temperature` (`AgentTemperature ?? 0`) and the default `top_p` of `1`.

## Tests

Added a `ChatEndpoint - Kimi temperature and top_p override` suite in `copilotChatEndpoint.spec.ts`:
- Parametrized over both Kimi families — asserts body ends up `temperature === 1`, `top_p === 0.95` starting from `{ temperature: 0, top_p: 1 }`.
- Non-Kimi guard (`gpt-4o`) — asserts no override.
