### PR TITLE
Style override: Update badge overflow property and title padding

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -301,3 +301,8 @@
 .style-override.monaco-workbench .pane-composite-part.basepanel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .actions-container {
 	gap: 4px;
 }
+
+.style-override.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact,
+.style-override.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact {
+	overflow: visible;
+}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -118,5 +118,6 @@
 .style-override.monaco-workbench .part.basepanel.left .composite.title,
 .style-override.monaco-workbench .part.basepanel.right .composite.title {
 	padding-right: 2px;
+	overflow: visible;
 }
 


### PR DESCRIPTION
Adjust the overflow property for badge elements to ensure visibility and update padding for titles to enhance layout consistency.

Addresses: https://github.com/microsoft/vscode/issues/324002