### PR TITLE
sessions: identify session in worktree delete prompt

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts
@@ -1063,7 +1063,7 @@ export function registerCLIChatCommands(
 ): IDisposable {
 	const disposableStore = new DisposableStore();
 
-	async function deleteSessionById(sessionId: string, options?: { keepWorktree?: boolean }): Promise<void> {
+	async function deleteSessionById(sessionId: string, options?: { keepWorktree?: boolean; sessionLabel?: string }): Promise<void> {
 		const worktree = await copilotCLIWorktreeManagerService.getWorktreeProperties(sessionId);
 		const worktreePath = await copilotCLIWorktreeManagerService.getWorktreePath(sessionId);
 
@@ -1078,7 +1078,7 @@ export function registerCLIChatCommands(
 					if (!repository) {
 						throw new Error(l10n.t('No active repository found to delete worktree.'));
 					}
-					await gitService.deleteWorktree(repository.rootUri, worktreePath.fsPath);
+					await gitService.deleteWorktree(repository.rootUri, worktreePath.fsPath, { label: options?.sessionLabel });
 				} catch (error) {
 					vscode.window.showErrorMessage(l10n.t('Failed to delete worktree: {0}', error instanceof Error ? error.message : String(error)));
 				}
@@ -1125,7 +1125,7 @@ export function registerCLIChatCommands(
 			);
 
 			if (result === deleteLabel) {
-				await deleteSessionById(id, { keepWorktree });
+				await deleteSessionById(id, { keepWorktree, sessionLabel: sessionItem.label });
 			}
 		}
 	}));
@@ -1154,7 +1154,7 @@ export function registerCLIChatCommands(
 				const id = SessionIdForCLI.parse(sessionItem.resource);
 				const worktreePath = await copilotCLIWorktreeManagerService.getWorktreePath(id);
 				const keepWorktree = !!worktreePath && await shouldKeepWorktreeForOtherSessions(id, worktreePath);
-				await deleteSessionById(id, { keepWorktree });
+				await deleteSessionById(id, { keepWorktree, sessionLabel: sessionItem.label });
 			}
 		}
 	}));

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
@@ -2224,7 +2224,7 @@ export function registerCLIChatCommands(
 		);
 		return siblings.length > 0;
 	}
-	async function deleteSessionById(sessionId: string, options?: { keepWorktree?: boolean }): Promise<void> {
+	async function deleteSessionById(sessionId: string, options?: { keepWorktree?: boolean; sessionLabel?: string }): Promise<void> {
 		const worktree = await copilotCLIWorktreeManagerService.getWorktreeProperties(sessionId);
 		const worktreePath = await copilotCLIWorktreeManagerService.getWorktreePath(sessionId);
 
@@ -2239,7 +2239,7 @@ export function registerCLIChatCommands(
 					if (!repository) {
 						throw new Error(l10n.t('No active repository found to delete worktree.'));
 					}
-					await gitService.deleteWorktree(repository.rootUri, worktreePath.fsPath);
+					await gitService.deleteWorktree(repository.rootUri, worktreePath.fsPath, { label: options?.sessionLabel });
 				} catch (error) {
 					vscode.window.showErrorMessage(l10n.t('Failed to delete worktree: {0}', error instanceof Error ? error.message : String(error)));
 				}
@@ -2265,7 +2265,7 @@ export function registerCLIChatCommands(
 			);
 
 			if (result === deleteLabel) {
-				await deleteSessionById(sessionId, { keepWorktree });
+				await deleteSessionById(sessionId, { keepWorktree, sessionLabel: sessionItem.label });
 				copilotcliSessionItemProvider.notifySessionsChange();
 			}
 		}
@@ -2296,7 +2296,7 @@ export function registerCLIChatCommands(
 				const sessionId = copilotcliSessionItemProvider.untitledSessionIdMapping.get(id) ?? id;
 				const worktreePath = await copilotCLIWorktreeManagerService.getWorktreePath(sessionId);
 				const keepWorktree = !!worktreePath && await shouldKeepWorktreeForOtherSessions(sessionId, worktreePath);
-				await deleteSessionById(sessionId, { keepWorktree });
+				await deleteSessionById(sessionId, { keepWorktree, sessionLabel: sessionItem.label });
 			}
 		}
 

--- a/extensions/copilot/src/platform/git/common/gitService.ts
+++ b/extensions/copilot/src/platform/git/common/gitService.ts
@@ -70,7 +70,7 @@ export interface IGitService extends IDisposable {
 	restore(uri: URI, paths: string[], options?: { staged?: boolean; ref?: string }): Promise<void>;
 
 	createWorktree(uri: URI, options?: { path?: string; commitish?: string; branch?: string; noTrack?: boolean }): Promise<string | undefined>;
-	deleteWorktree(uri: URI, path: string, options?: { force?: boolean }): Promise<void>;
+	deleteWorktree(uri: URI, path: string, options?: { force?: boolean; label?: string }): Promise<void>;
 
 	migrateChanges(uri: URI, sourceRepositoryUri: URI, options?: { confirmation?: boolean; deleteFromSource?: boolean; untracked?: boolean }): Promise<void>;
 

--- a/extensions/copilot/src/platform/git/vscode-node/gitServiceImpl.ts
+++ b/extensions/copilot/src/platform/git/vscode-node/gitServiceImpl.ts
@@ -316,7 +316,7 @@ export class GitServiceImpl extends Disposable implements IGitService {
 		return await repository?.createWorktree(options);
 	}
 
-	async deleteWorktree(uri: URI, path: string, options?: { force?: boolean }): Promise<void> {
+	async deleteWorktree(uri: URI, path: string, options?: { force?: boolean; label?: string }): Promise<void> {
 		const gitAPI = this.gitExtensionService.getExtensionApi();
 		const repository = gitAPI?.getRepository(uri);
 		return await repository?.deleteWorktree(path, options);

--- a/extensions/copilot/src/platform/git/vscode/git.d.ts
+++ b/extensions/copilot/src/platform/git/vscode/git.d.ts
@@ -315,7 +315,7 @@ export interface Repository {
 	dropStash(index?: number): Promise<void>;
 
 	createWorktree(options?: { path?: string; commitish?: string; branch?: string; noTrack?: boolean }): Promise<string>;
-	deleteWorktree(path: string, options?: { force?: boolean }): Promise<void>;
+	deleteWorktree(path: string, options?: { force?: boolean; label?: string }): Promise<void>;
 
 	migrateChanges(sourceRepositoryPath: string, options?: { confirmation?: boolean; deleteFromSource?: boolean; untracked?: boolean }): Promise<void>;
 

--- a/extensions/copilot/src/platform/ignore/node/test/mockGitService.ts
+++ b/extensions/copilot/src/platform/ignore/node/test/mockGitService.ts
@@ -122,7 +122,7 @@ export class MockGitService implements IGitService {
 		return Promise.resolve(undefined);
 	}
 
-	deleteWorktree(_uri: URI, _path: string, _options?: { force?: boolean }): Promise<void> {
+	deleteWorktree(_uri: URI, _path: string, _options?: { force?: boolean; label?: string }): Promise<void> {
 		return Promise.resolve();
 	}
 

--- a/extensions/copilot/src/platform/test/node/simulationWorkspaceServices.ts
+++ b/extensions/copilot/src/platform/test/node/simulationWorkspaceServices.ts
@@ -801,7 +801,7 @@ export class TestingGitService implements IGitService {
 		return undefined;
 	}
 
-	async deleteWorktree(uri: URI, path: string, options?: { force?: boolean }): Promise<void> {
+	async deleteWorktree(uri: URI, path: string, options?: { force?: boolean; label?: string }): Promise<void> {
 		return;
 	}
 

--- a/extensions/git/src/api/api1.ts
+++ b/extensions/git/src/api/api1.ts
@@ -354,7 +354,7 @@ export class ApiRepository implements Repository {
 		return this.#repository.createWorktree(options);
 	}
 
-	deleteWorktree(path: string, options?: { force?: boolean }): Promise<void> {
+	deleteWorktree(path: string, options?: { force?: boolean; label?: string }): Promise<void> {
 		return this.#repository.deleteWorktree(path, options);
 	}
 

--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -326,7 +326,7 @@ export interface Repository {
 	dropStash(index?: number): Promise<void>;
 
 	createWorktree(options?: { path?: string; commitish?: string; branch?: string; noTrack?: boolean }): Promise<string>;
-	deleteWorktree(path: string, options?: { force?: boolean }): Promise<void>;
+	deleteWorktree(path: string, options?: { force?: boolean; label?: string }): Promise<void>;
 
 	migrateChanges(sourceRepositoryPath: string, options?: { confirmation?: boolean; deleteFromSource?: boolean; untracked?: boolean }): Promise<void>;
 

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -2120,7 +2120,7 @@ export class Repository implements Disposable {
 		}
 	}
 
-	async deleteWorktree(path: string, options?: { force?: boolean }): Promise<void> {
+	async deleteWorktree(path: string, options?: { force?: boolean; label?: string }): Promise<void> {
 		await this.run(Operation.Worktree(false), async () => {
 			const worktree = this.repositoryResolver.getRepository(path);
 
@@ -2130,12 +2130,14 @@ export class Repository implements Disposable {
 			};
 
 			try {
-				await deleteWorktree();
+				await deleteWorktree(options);
 			} catch (err) {
 				if (err.gitErrorCode === GitErrorCodes.WorktreeContainsChanges) {
 					const forceDelete = l10n.t('Force Delete');
-					const message = l10n.t('The worktree contains modified or untracked files. Do you want to force delete?');
-					const choice = await window.showWarningMessage(message, { modal: true }, forceDelete);
+					const message = options?.label
+						? l10n.t('The worktree for session "{0}" contains modified or untracked files. Do you want to force delete?', options.label)
+						: l10n.t('The worktree contains modified or untracked files. Do you want to force delete?');
+					const choice = await window.showWarningMessage(message, { modal: true, detail: l10n.t('Worktree: {0}', path) }, forceDelete);
 					if (choice === forceDelete) {
 						await deleteWorktree({ ...options, force: true });
 					}

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/COPILOT_CHAT_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/COPILOT_CHAT_SESSIONS_PROVIDER.md
@@ -89,6 +89,10 @@ For multi-chat sessions (`capabilities.supportsMultipleChats === true`), `create
 
 The provider never opens the chat widget itself; widget opening is owned by the management service.
 
+## Delete Flow
+
+For Copilot CLI sessions, `_deleteAgentSessions()` delegates to the extension-host command `agents.github.copilot.cli.deleteSessions` and passes both the session resource and current session label. The extension may later hit the Git extension's force-delete confirmation when removing a dirty worktree, so the label must be preserved in that command payload to identify which session owns the worktree.
+
 ## New-Session Picker Contribution Model
 
 **File:** `src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts`

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -1928,10 +1928,10 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	}
 
 	private async _deleteAgentSessions(agentSessions: IAgentSession[]): Promise<void> {
-		const cliSessionItems: { resource: URI }[] = [];
+		const cliSessionItems: { resource: URI; label: string }[] = [];
 		for (const agentSession of agentSessions) {
 			if (agentSession.providerType === CopilotCLISessionType.id) {
-				cliSessionItems.push({ resource: agentSession.resource });
+				cliSessionItems.push({ resource: agentSession.resource, label: agentSession.label });
 			} else {
 				await this.chatService.removeHistoryEntry(agentSession.resource);
 			}

--- a/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
@@ -121,12 +121,30 @@ class MockAgentSessionsModel {
 	}
 }
 
+interface IExecutedCommand {
+	readonly id: string;
+	readonly args: readonly unknown[];
+}
+
+interface ICreateProviderOptions {
+	readonly multiChatEnabled?: boolean;
+	readonly claudeEnabled?: boolean;
+	readonly preferAgentHost?: boolean;
+	readonly hideCopilotCli?: boolean;
+	readonly agentHostEnabled?: boolean;
+	readonly commandExecutions?: IExecutedCommand[];
+}
+
+function isCommandSessionItem(item: unknown): item is { readonly resource: URI; readonly label?: string } {
+	return typeof item === 'object' && item !== null && 'resource' in item && URI.isUri(item.resource);
+}
+
 // ---- Provider factory -------------------------------------------------------
 
 function createProvider(
 	disposables: DisposableStore,
 	model: MockAgentSessionsModel,
-	opts?: { multiChatEnabled?: boolean; claudeEnabled?: boolean; preferAgentHost?: boolean; hideCopilotCli?: boolean; agentHostEnabled?: boolean },
+	opts?: ICreateProviderOptions,
 ): CopilotChatSessionsProvider {
 	return createProviderWithConfig(disposables, model, opts).provider;
 }
@@ -134,7 +152,7 @@ function createProvider(
 function createProviderWithConfig(
 	disposables: DisposableStore,
 	model: MockAgentSessionsModel,
-	opts?: { multiChatEnabled?: boolean; claudeEnabled?: boolean; preferAgentHost?: boolean; hideCopilotCli?: boolean; agentHostEnabled?: boolean },
+	opts?: ICreateProviderOptions,
 ): { provider: CopilotChatSessionsProvider; configService: TestConfigurationService } {
 	const instantiationService = disposables.add(new TestInstantiationService());
 
@@ -153,16 +171,17 @@ function createProviderWithConfig(
 		confirm: async () => ({ confirmed: true }),
 	});
 	instantiationService.stub(ICommandService, {
-		executeCommand: async (_id: string, ...args: any[]) => {
+		executeCommand: async (id: string, ...args: unknown[]) => {
+			opts?.commandExecutions?.push({ id, args });
 			// Simulate 'agents.github.copilot.cli.deleteSessions' removing sessions
 			const items = args[0];
 			if (Array.isArray(items)) {
 				for (const item of items) {
-					if (item?.resource) {
+					if (isCommandSessionItem(item)) {
 						model.removeSession(item.resource);
 					}
 				}
-			} else if (items?.resource) {
+			} else if (isCommandSessionItem(items)) {
 				model.removeSession(items.resource);
 			}
 			return undefined;
@@ -897,6 +916,29 @@ suite('CopilotChatSessionsProvider', () => {
 		const remainingSessions = provider.getSessions();
 		assert.strictEqual(remainingSessions.length, 1);
 		assert.strictEqual(remainingSessions[0].title.get(), 'Session 2');
+	});
+
+	test('deleteSession passes Copilot CLI session label to delete command', async () => {
+		const resource = URI.from({ scheme: CopilotCLISessionType.id, path: '/session-1' });
+		const commandExecutions: IExecutedCommand[] = [];
+		model.addSession(createMockAgentSession(resource, { providerType: CopilotCLISessionType.id, title: 'Fix Build' }));
+
+		const provider = createProvider(disposables, model, { commandExecutions });
+		const sessions = provider.getSessions();
+
+		await provider.deleteSession(sessions[0].sessionId);
+
+		assert.deepStrictEqual(commandExecutions.map(command => ({
+			id: command.id,
+			items: Array.isArray(command.args[0])
+				? command.args[0].map(item => isCommandSessionItem(item) ? { resource: item.resource.toString(), label: item.label } : undefined)
+				: undefined,
+			options: command.args[1],
+		})), [{
+			id: 'agents.github.copilot.cli.deleteSessions',
+			items: [{ resource: resource.toString(), label: 'Fix Build' }],
+			options: { skipConfirmation: true },
+		}]);
 	});
 
 	test('deleteChat with single chat delegates to deleteSession', async () => {


### PR DESCRIPTION
## Summary
- pass Copilot CLI session labels from the Agents Window delete flow into extension-host deletion
- include the owning session label and worktree path in the dirty-worktree force-delete prompt
- add provider test coverage for the label handoff

Fixes #324220

## Validation
- npm run typecheck-client
- npm run valid-layers-check
- npm run gulp compile-extensions
- npm run compile-copilot
- npm --prefix extensions/copilot run typecheck
- .\scripts\test.bat --grep "deleteSession passes Copilot CLI session label"
- npm run precommit