### PR TITLE
Style overrides: Add border-radius and padding to terminal tab entries

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
@@ -237,7 +237,6 @@
 	border-radius: var(--vscode-sash-size);
 }
 
-
 .style-override.monaco-workbench .pane-body.integrated-terminal .tabs-container.has-text .terminal-tabs-chat-entry .terminal-tabs-entry {
-	border-radius: var(--vscode-cornerRadius-small)
+	border-radius: var(--vscode-cornerRadius-small);
 }

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
@@ -236,3 +236,8 @@
 .style-override .monaco-sash:not(.disabled) > .orthogonal-drag-handle {
 	border-radius: var(--vscode-sash-size);
 }
+
+
+.style-override.monaco-workbench .pane-body.integrated-terminal .tabs-container.has-text .terminal-tabs-chat-entry .terminal-tabs-entry {
+	border-radius: var(--vscode-cornerRadius-small)
+}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -211,3 +211,12 @@
 .style-override .settings-editor > .settings-header > .settings-header-controls {
 	border-bottom: none !important;
 }
+
+.style-override.monaco-workbench .pane-body.integrated-terminal .tabs-container.has-text .tabs-list .terminal-tabs-entry {
+	padding-left: 8px;
+	padding-right: 8px;
+}
+
+.style-override.monaco-workbench .pane-body.integrated-terminal .terminal-tabs-chat-entry {
+	padding: 4px;
+}


### PR DESCRIPTION
Enhance the appearance of terminal tab entries by adding border-radius and padding for improved aesthetics and usability. Test the changes by observing the updated styles in the integrated terminal tabs.

