### PR TITLE
Guard agent-SDK release build against missing native optional-dep packages

### DIFF
--- a/build/agent-sdk/package.ts
+++ b/build/agent-sdk/package.ts
@@ -36,6 +36,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as tar from 'tar';
+import { findMissingNativeOptionalDep } from '../azure-pipelines/common/checkNativeOptionalDeps.ts';
 import { getAgentDir, getAgentMeta, parseFlags, type Sdk, sha256OfFile } from './common.ts';
 
 const SCRIPT = 'package.ts';
@@ -85,6 +86,20 @@ export async function buildOne(args: IBuildArgs): Promise<IBuildResult> {
 		npmCi(stagingDir, npmEnv);
 
 		const nodeModulesDir = path.join(stagingDir, 'node_modules');
+
+		// The SDK ships its native binary in a per-platform package declared as
+		// an *optional* dependency (e.g. `@openai/codex-linux-x64`). npm does not
+		// fail when an optional dependency can't be installed, so a transient
+		// registry hiccup can leave the base package present but the native
+		// package missing — which would silently produce a binary-less tarball
+		// and upload it to the (immutable, content-addressed) CDN path, failing
+		// only at runtime for end users. Fail loud here instead.
+		// See https://github.com/microsoft/vscode/pull/323881.
+		const missingNativeDep = findMissingNativeOptionalDep(nodeModulesDir, packageName, args.sdkTarget);
+		if (missingNativeDep) {
+			throw new Error(`[${SCRIPT}] npm ci left ${packageName}@${sdkVersion} without its native package '${missingNativeDep}' for target ${args.sdkTarget} — the optional dependency was silently skipped. Refusing to build a binary-less tarball; re-run to re-fetch it.`);
+		}
+
 		chmodPlatformBinaries(nodeModulesDir, args.sdk);
 
 		fs.mkdirSync(args.outDir, { recursive: true });

--- a/build/azure-pipelines/common/checkNativeOptionalDeps.ts
+++ b/build/azure-pipelines/common/checkNativeOptionalDeps.ts
@@ -13,15 +13,52 @@ import path from 'path';
 // `@anthropic-ai/claude-agent-sdk-<platform>-<arch>`. `npm install` / `npm ci`
 // do NOT fail when an optional dependency cannot be installed, so a transient
 // hiccup can leave the base package present while the per-platform package is
-// missing. That broken tree then gets frozen into the node_modules cache and
-// served to every consumer, failing far away from the cause
-// (see https://github.com/microsoft/vscode/pull/323881).
+// missing (see https://github.com/microsoft/vscode/pull/323881).
 //
-// This check runs after `npm ci` when building a node_modules cache and fails
-// the job when a required per-platform package is missing, so a poisoned cache
-// is never saved.
+// `findMissingNativeOptionalDep` is the reusable primitive that detects this.
+// It is used from two places:
+//   - The CLI entry point below runs after `npm ci` in the node_modules
+//     cache-build jobs (.github/workflows/pr-node-modules.yml) and fails the
+//     job so a poisoned cache is never saved.
+//   - The agent-SDK producer (build/agent-sdk/package.ts) runs it after its
+//     scratch `npm ci` so a binary-less tarball is never built and uploaded to
+//     the CDN.
 
-const ROOT = path.join(import.meta.dirname, '../../../');
+/**
+ * Returns the name of the required per-platform package that is missing from
+ * `nodeModulesDir`, or `undefined` when nothing is wrong.
+ *
+ * A base package (e.g. `@openai/codex`) ships its native binary in a
+ * per-platform optional dependency named `<base>-<target>` (e.g.
+ * `@openai/codex-linux-x64`, `@anthropic-ai/claude-agent-sdk-linux-x64-musl`).
+ * npm does not fail when an optional dependency cannot be installed, so this
+ * detects a base package that ended up installed without its matching native
+ * package.
+ *
+ * `target` is the `<platform>-<arch>[-<libc>]` suffix — e.g. `darwin-arm64`,
+ * `linux-x64`, `linux-x64-musl`.
+ *
+ * Only enforced when the base package itself is installed; if it is not, the
+ * dependency simply was not requested here and there is nothing to verify.
+ */
+export function findMissingNativeOptionalDep(nodeModulesDir: string, basePackage: string, target: string): string | undefined {
+	if (!fs.existsSync(path.join(nodeModulesDir, basePackage))) {
+		return undefined;
+	}
+	const platformPackage = `${basePackage}-${target}`;
+	if (!fs.existsSync(path.join(nodeModulesDir, platformPackage))) {
+		return platformPackage;
+	}
+	return undefined;
+}
+
+// #region CLI entry point
+//
+// Runs after the root `npm ci` in the node_modules cache-build jobs (see
+// .github/workflows/pr-node-modules.yml), before the cache is saved. Verifies
+// the repo-root node_modules has the per-platform package for the current host
+// so a poisoned cache (base package present, native package silently skipped)
+// is never persisted.
 
 // Base packages whose per-platform package (`<base>-<platform>-<arch>`) is
 // required whenever the base package itself is installed.
@@ -34,39 +71,44 @@ const NATIVE_OPTIONAL_DEP_BASE_PACKAGES = [
 const SUPPORTED_PLATFORMS = new Set(['linux', 'darwin', 'win32']);
 const SUPPORTED_ARCHS = new Set(['x64', 'arm64']);
 
-function isInstalled(pkg: string): boolean {
-	return fs.existsSync(path.join(ROOT, 'node_modules', pkg));
+function isCliInvocation(): boolean {
+	// `import.meta.filename` is already a real filesystem path; comparing it
+	// directly to `process.argv[1]` works on Windows too. Matches the pattern
+	// in `build/agent-sdk/package.ts` and `build/npm/installStateHash.ts`.
+	return import.meta.filename === process.argv[1];
 }
 
-const { platform, arch } = process;
-
-if (!SUPPORTED_PLATFORMS.has(platform) || !SUPPORTED_ARCHS.has(arch)) {
-	console.log(`Skipping native optional-dependency check on unsupported ${platform}-${arch}.`);
-	process.exit(0);
-}
-
-const errors: string[] = [];
-for (const basePackage of NATIVE_OPTIONAL_DEP_BASE_PACKAGES) {
-	// Only enforce when the base package is installed; if it is not, the
-	// dependency simply was not requested here and there is nothing to verify.
-	if (!isInstalled(basePackage)) {
-		continue;
+function main(): void {
+	const { platform, arch } = process;
+	if (!SUPPORTED_PLATFORMS.has(platform) || !SUPPORTED_ARCHS.has(arch)) {
+		console.log(`Skipping native optional-dependency check on unsupported ${platform}-${arch}.`);
+		return;
 	}
-	// The glibc Linux package (no `-musl` suffix) is the one required on the
-	// glibc-based CI hosts; the naming is always `<base>-<platform>-<arch>`.
-	const platformPackage = `${basePackage}-${platform}-${arch}`;
-	if (!isInstalled(platformPackage)) {
-		errors.push(`${basePackage}: required per-platform package '${platformPackage}' is missing from node_modules — the optional dependency was silently skipped during install`);
+
+	const nodeModulesDir = path.join(import.meta.dirname, '../../../', 'node_modules');
+	const target = `${platform}-${arch}`;
+	const errors: string[] = [];
+	for (const basePackage of NATIVE_OPTIONAL_DEP_BASE_PACKAGES) {
+		const missing = findMissingNativeOptionalDep(nodeModulesDir, basePackage, target);
+		if (missing) {
+			errors.push(`${basePackage}: required per-platform package '${missing}' is missing from node_modules — the optional dependency was silently skipped during install`);
+		}
 	}
+
+	if (errors.length > 0) {
+		console.error('\x1b[1;31m*** Missing native optional-dependency packages — refusing to save a poisoned node_modules cache ***\x1b[0m');
+		for (const err of errors) {
+			console.error(`  - ${err}`);
+		}
+		console.error('\nnpm does not fail when an optional dependency cannot be installed, so this tree would poison the shared node_modules cache. Re-run a fresh `npm ci` (e.g. after bumping build/.cachesalt) to restore the package before the cache is saved.');
+		process.exit(1);
+	}
+
+	console.log(`Verified native optional-dependency packages for ${platform}-${arch}.`);
 }
 
-if (errors.length > 0) {
-	console.error('\x1b[1;31m*** Missing native optional-dependency packages — refusing to save a poisoned node_modules cache ***\x1b[0m');
-	for (const err of errors) {
-		console.error(`  - ${err}`);
-	}
-	console.error('\nnpm does not fail when an optional dependency cannot be installed, so this tree would poison the shared node_modules cache. Re-run a fresh `npm ci` (e.g. after bumping build/.cachesalt) to restore the package before the cache is saved.');
-	process.exit(1);
+if (isCliInvocation()) {
+	main();
 }
 
-console.log(`Verified native optional-dependency packages for ${platform}-${arch}.`);
+// #endregion


### PR DESCRIPTION
## Why

PR #324064 guards the **PR-check** `node_modules` cache against npm silently skipping a native *optional* dependency (`@openai/codex-<target>`, `@anthropic-ai/claude-agent-sdk-<target>`). That guard only covers the repo-root install for the **host** platform.

The **release pipeline** takes a different path that the guard never sees. `build/azure-pipelines/common/agent-sdk-produce.yml` runs `build/agent-sdk/produce.ts` → `buildOne` (in `package.ts`), which does its own scratch `npm ci` to **cross-install** each SDK's per-platform native package for a (possibly foreign) target, then tars it and uploads to the CDN.

Because npm exits `0` when an optional dependency can't be installed, a transient registry hiccup on that scratch install leaves the base package present but the native package **missing**. Nothing on the release path checks for it, so on a real publish run that binary-less tarball would be:

1. tarred (exit 0),
2. uploaded to the **immutable, content-addressed** CDN path (exit 0),
3. stamped into `product.json` (exit 0),

and the failure would surface only at **runtime for end users** — the exact class of bug #323881 set out to prevent, but on the ship path instead of CI.

## What

Reuse the guard logic from #324064 instead of duplicating it:

- **`checkNativeOptionalDeps.ts`** — extract the core check into an exported `findMissingNativeOptionalDep(nodeModulesDir, basePackage, target)`. The CLI behavior used by `pr-node-modules.yml` is unchanged; it's just moved behind an `isCliInvocation()` guard so importing the module no longer runs the check or calls `process.exit`.
- **`package.ts`** — call `findMissingNativeOptionalDep` inside `buildOne`, right after the scratch `npm ci` and before tarring. It's keyed on the exact base package and `sdkTarget` (so it's correct for cross-target and `-musl` builds, unlike a host-platform check). If the native package is missing it throws, so `produce.ts` exits non-zero and refuses to build/upload a binary-less tarball.

A separate YAML step can't do this: the scratch install dir is created and `rmSync`'d inside `buildOne`, so it's invisible to any later pipeline step. The check has to live inside `buildOne`.

## Verification

Both paths were exercised on real GitHub-hosted runners (ubuntu / macOS / windows → linux-x64 / darwin-arm64 / win32-x64) via a temporary instrumented workflow on this branch — same approach as #324064. The workflow has been removed from the branch; the run URLs remain valid in the Actions history:

- ❌ **FAIL run** (missing-dep condition forced via `npm_config_omit=optional`): https://github.com/microsoft/vscode/actions/runs/28671451238
  - All 6 jobs red. Release path threw e.g. `npm ci left @anthropic-ai/claude-agent-sdk@… without its native package '@anthropic-ai/claude-agent-sdk-<target>' … Refusing to build a binary-less tarball`; `produce.ts` exited 1 **instead of** shipping a broken tarball. CLI path printed the same "poisoned cache" refusal as #324064.
- ✅ **PASS run** (healthy install): https://github.com/microsoft/vscode/actions/runs/28672308112
  - All 6 jobs green. CLI path printed `Verified native optional-dependency packages for <target>`; release path built real tarballs on every OS (claude ≈72–83 MB, codex ≈99–118 MB).

Also verified locally, including the claude `linux-x64-musl` cross-target (no host equivalent), plus CLI pass/fail/no-op and typecheck (`cd build && npm run typecheck`).

Refs #324064, #323881

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
