### PR TITLE
Fix chat progressive rendering after hidden updates

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -230,6 +230,10 @@ export function shouldScheduleInitialHeightChange(normalizedHeight: number, allo
 	return typeof allocatedHeight !== 'number' || normalizedHeight > allocatedHeight;
 }
 
+export function shouldRenderInitialProgressiveContentImmediately(isComplete: boolean, hasMarkdownParts: boolean, hasRenderData: boolean): boolean {
+	return !isComplete && hasMarkdownParts && !hasRenderData;
+}
+
 const forceVerboseLayoutTracing = false
 	// || Boolean("TRUE") // causes a linter warning so that it cannot be pushed
 	;
@@ -2036,9 +2040,9 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 	private getDataForProgressiveRender(element: IChatResponseViewModel) {
 		const hasMarkdownParts = element.response.value.some(part => part.kind === 'markdownContent' && part.content.value.trim().length > 0);
-		if (!element.isComplete && hasMarkdownParts && (element.contentUpdateTimings ? element.contentUpdateTimings.lastWordCount : 0) === 0) {
+		if (shouldRenderInitialProgressiveContentImmediately(element.isComplete, hasMarkdownParts, element.renderData !== undefined)) {
 			/**
-			 * None of the content parts in the ongoing response have been rendered yet,
+			 * None of the markdown in the ongoing response has been rendered yet,
 			 * so we should render all existing parts without animation.
 			 */
 			return {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { buildPlanReviewProgressContent, getWorkingProgressRelevantParts, shouldHideChatUserIdentity, shouldScheduleInitialHeightChange } from '../../../browser/widget/chatListRenderer.js';
+import { buildPlanReviewProgressContent, getWorkingProgressRelevantParts, shouldHideChatUserIdentity, shouldRenderInitialProgressiveContentImmediately, shouldScheduleInitialHeightChange } from '../../../browser/widget/chatListRenderer.js';
 import { IChatToolInvocationSerialized, ToolConfirmKind } from '../../../common/chatService/chatService.js';
 import { IChatRendererContent } from '../../../common/model/chatViewModel.js';
 import { ToolDataSource } from '../../../common/tools/languageModelToolsService.js';
@@ -28,6 +28,22 @@ suite('ChatListRenderer', () => {
 				false,
 				true,
 				true,
+			]);
+		});
+	});
+
+	suite('shouldRenderInitialProgressiveContentImmediately', () => {
+		test('renders accumulated markdown immediately only when progressive rendering has not started', () => {
+			assert.deepStrictEqual([
+				shouldRenderInitialProgressiveContentImmediately(false, true, false),
+				shouldRenderInitialProgressiveContentImmediately(false, true, true),
+				shouldRenderInitialProgressiveContentImmediately(true, true, false),
+				shouldRenderInitialProgressiveContentImmediately(false, false, false),
+			], [
+				true,
+				false,
+				false,
+				false,
 			]);
 		});
 	});


### PR DESCRIPTION
## Summary

- render accumulated response markdown immediately when a hidden chat is first shown
- use the response render cursor to distinguish never-rendered content from partially rendered content
- add regression coverage for the initial progressive-render catch-up decision

## Testing

- `npm run typecheck-client`
- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts`
- `npm run valid-layers-check`
- `npm run precommit`

(Written by Copilot)