### PR TITLE
chat: avoid relayout while hidden

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -1269,6 +1269,10 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 	private layoutingBody = false;
 
 	private relayout(): void {
+		if (!this._widget?.visible) {
+			return;
+		}
+
 		if (this.lastDimensions) {
 			this.layoutBody(this.lastDimensions.height, this.lastDimensions.width);
 		}


### PR DESCRIPTION
## Summary

- skip `ChatViewPane` relayouts while its chat widget is hidden
- prevent dynamic-height chat rows from being measured against detached or `display: none` DOM
- preserve the normal layout pass when the chat view is reopened

## Validation

- `npm run build-fast`
- `npm run typecheck-client`
- `npm run precommit`

(Written by Copilot)