### PR TITLE
Agent host: run `!`-prefixed chat messages as terminal commands

### DIFF
--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -1509,11 +1509,16 @@ export interface IAgent {
 	handleAuthenticationToken?(params: AuthenticateParams): Promise<boolean>;
 
 	/**
-	 * Truncate a session's history. If `turnId` is provided, keeps turns up to
+	 * Truncate a chat's history. If `turnId` is provided, keeps turns up to
 	 * and including that turn. If omitted, all turns are removed.
+	 *
+	 * `chat` identifies which chat to truncate: the session's default chat
+	 * (addressed by the session's default chat URI) or a peer (non-default)
+	 * chat, which has its own backing.
+	 *
 	 * Optional — not all providers support truncation.
 	 */
-	truncateSession?(session: URI, turnId?: string): Promise<void>;
+	truncateSession?(session: URI, turnId: string | undefined, chat: URI): Promise<void>;
 
 	/**
 	 * Notifies the provider that a session's archived state has changed.

--- a/src/vs/platform/agentHost/common/sessionDataService.ts
+++ b/src/vs/platform/agentHost/common/sessionDataService.ts
@@ -77,6 +77,29 @@ export interface IReviewedFileRecord {
 // ---- Session database ---------------------------------------------------
 
 /**
+ * A host-injected ("local") turn: a completed protocol `Turn` the agent SDK
+ * never saw — e.g. the `/rename` acknowledgement or a `!command` terminal run.
+ * These are persisted separately from SDK turns so they survive reload, and are
+ * interleaved back into the SDK-derived turns on restore.
+ */
+export interface ILocalTurnRecord {
+	/** The local turn's id (matches the payload `Turn.id`). */
+	turnId: string;
+	/** The chat this local turn belongs to (its channel URI string). */
+	chatUri: string;
+	/**
+	 * Id of the preceding concrete (SDK-backed) turn this local turn is
+	 * anchored after, or `undefined` when it precedes any real turn.
+	 */
+	anchorTurnId: string | undefined;
+	/** Monotonic ordering among local turns (used to interleave on restore). */
+	seq: number;
+	/** JSON-serialized protocol `Turn`. */
+	payload: string;
+}
+
+
+/**
  * A disposable handle to a per-session SQLite database backed by
  * `@vscode/sqlite3`.
  *
@@ -163,6 +186,25 @@ export interface ISessionDatabase extends IDisposable {
 	 * Deletes all turns and their associated file edits.
 	 */
 	deleteAllTurns(): Promise<void>;
+
+	// ---- Local (host-injected) turns -------------------------------------
+
+	/**
+	 * Persist a host-injected local turn (e.g. `/rename` or `!command`).
+	 * Replaces any existing record with the same `turnId`.
+	 */
+	insertLocalTurn(record: ILocalTurnRecord): Promise<void>;
+
+	/**
+	 * Retrieve all persisted local turns in this session, in `seq` order.
+	 * Callers filter by {@link ILocalTurnRecord.chatUri} for a given chat.
+	 */
+	getLocalTurns(): Promise<ILocalTurnRecord[]>;
+
+	/**
+	 * Delete the local turns with the given ids. Ids not present are ignored.
+	 */
+	deleteLocalTurns(turnIds: readonly string[]): Promise<void>;
 
 	/**
 	 * Store a file-edit snapshot (metadata + content) for a tool invocation

--- a/src/vs/platform/agentHost/node/agentHostBangCommand.ts
+++ b/src/vs/platform/agentHost/node/agentHostBangCommand.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * The leading character that marks a chat message as a terminal command.
+ */
+export const BANG_COMMAND_PREFIX = '!';
+
+/**
+ * Parses a leading `!<command>` at the very start of `prompt`.
+ *
+ * Like {@link parseRenameCommand}, the marker must be at position 0 (no leading
+ * whitespace). A lone `!` or `!` followed only by whitespace is not treated as
+ * a bang command — the caller should forward such messages normally.
+ *
+ * Returns the trimmed command string when the prompt is a bang command, or
+ * `undefined` when it is not.
+ */
+export function parseBangCommand(prompt: string): string | undefined {
+	if (!prompt.startsWith(BANG_COMMAND_PREFIX)) {
+		return undefined;
+	}
+	const command = prompt.slice(BANG_COMMAND_PREFIX.length).trim();
+	return command.length > 0 ? command : undefined;
+}

--- a/src/vs/platform/agentHost/node/agentHostLocalTurns.ts
+++ b/src/vs/platform/agentHost/node/agentHostLocalTurns.ts
@@ -1,0 +1,161 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { IReference } from '../../../base/common/lifecycle.js';
+import { URI } from '../../../base/common/uri.js';
+import { ILogService } from '../../log/common/log.js';
+import type { ILocalTurnRecord, ISessionDatabase, ISessionDataService } from '../common/sessionDataService.js';
+import type { Turn } from '../common/state/sessionState.js';
+
+/**
+ * Tracks host-injected ("local") turns — completed protocol turns the agent SDK
+ * never saw, such as the `/rename` acknowledgement or a `!command` terminal run.
+ *
+ * These turns exist only in the agent host: they are never forwarded to the
+ * agent SDK, so they are absent from the SDK transcript that
+ * {@link AgentService} replays on restore. This registry persists them (so they
+ * survive reload) and remembers, for each, the id of the preceding concrete
+ * (SDK-backed) turn — the *anchor* — so that fork/truncate operations targeting
+ * a local turn can be redirected to the concrete SDK message before it.
+ *
+ * Everything is scoped to a **chat** (its channel URI): a session's default
+ * chat and each of its peer chats are handled identically. Persistence lives in
+ * the owning session's database (one per session, shared across its chats),
+ * discriminated by {@link ILocalTurnRecord.chatUri}.
+ */
+export class AgentHostLocalTurns {
+
+	/** chat URI → (localTurnId → { anchorTurnId, seq }). */
+	private readonly _byChat = new Map<string, Map<string, { readonly anchorTurnId: string | undefined; readonly seq: number }>>();
+	/** session URI → highest `seq` assigned so far (seq is session-global for stable ordering). */
+	private readonly _seqBySession = new Map<string, number>();
+
+	constructor(
+		private readonly _sessionDataService: ISessionDataService,
+		private readonly _logService: ILogService,
+	) { }
+
+	/** Whether `turnId` is a known host-injected local turn in `chat`. */
+	isLocal(chat: string, turnId: string): boolean {
+		return this._byChat.get(chat)?.has(turnId) ?? false;
+	}
+
+	/** All known local turn ids for `chat`. */
+	getLocalTurnIds(chat: string): string[] {
+		const map = this._byChat.get(chat);
+		return map ? [...map.keys()] : [];
+	}
+
+	/**
+	 * Resolves `turnId` to the concrete (SDK-backed) turn a fork/truncate should
+	 * operate on within `chat`. For a local turn this is its anchor (the
+	 * preceding real turn, or `undefined` when it precedes any real turn); for a
+	 * concrete turn it is the turn itself.
+	 */
+	resolveConcreteTurnId(chat: string, turnId: string): string | undefined {
+		const entry = this._byChat.get(chat)?.get(turnId);
+		return entry ? entry.anchorTurnId : turnId;
+	}
+
+	/**
+	 * Persist a local turn and remember it in memory. `anchorTurnId` is the id
+	 * of the preceding concrete turn in `chat` (or `undefined` when there is
+	 * none). `session` identifies the database to persist into.
+	 */
+	record(session: string, chat: string, turn: Turn, anchorTurnId: string | undefined): void {
+		const seq = (this._seqBySession.get(session) ?? 0) + 1;
+		this._noteInMemory(session, chat, turn.id, anchorTurnId, seq);
+		const record: ILocalTurnRecord = { turnId: turn.id, chatUri: chat, anchorTurnId, seq, payload: JSON.stringify(turn) };
+		let ref: IReference<ISessionDatabase>;
+		try {
+			ref = this._sessionDataService.openDatabase(URI.parse(session));
+		} catch (err) {
+			this._logService.warn(`[AgentHostLocalTurns] Failed to open database to persist local turn ${turn.id}`, err);
+			return;
+		}
+		ref.object.insertLocalTurn(record).catch(err => {
+			this._logService.warn(`[AgentHostLocalTurns] Failed to persist local turn ${turn.id}`, err);
+		}).finally(() => ref.dispose());
+	}
+
+	/**
+	 * Loads persisted local turns for `session`, populating the in-memory index
+	 * (keyed by each record's chat), and returns the records for `chat` in
+	 * `seq` order so the caller can interleave them into that chat's SDK-derived
+	 * turns during restore.
+	 */
+	async loadForChat(session: string, chat: string): Promise<ILocalTurnRecord[]> {
+		const records = await this._load(session);
+		return records.filter(r => r.chatUri === chat);
+	}
+
+	/** Note a local turn in memory only (used by fork seeding). */
+	noteInMemory(session: string, chat: string, turnId: string, anchorTurnId: string | undefined, seq: number): void {
+		this._noteInMemory(session, chat, turnId, anchorTurnId, seq);
+	}
+
+	/** Delete the given local turns from memory and the session database. */
+	deleteLocals(session: string, turnIds: readonly string[]): void {
+		if (turnIds.length === 0) {
+			return;
+		}
+		const idSet = new Set(turnIds);
+		for (const map of this._byChat.values()) {
+			for (const id of idSet) {
+				map.delete(id);
+			}
+		}
+		let ref: IReference<ISessionDatabase>;
+		try {
+			ref = this._sessionDataService.openDatabase(URI.parse(session));
+		} catch (err) {
+			this._logService.warn(`[AgentHostLocalTurns] Failed to open database to delete local turns for ${session}`, err);
+			return;
+		}
+		ref.object.deleteLocalTurns(turnIds).catch(err => {
+			this._logService.warn(`[AgentHostLocalTurns] Failed to delete local turns for ${session}`, err);
+		}).finally(() => ref.dispose());
+	}
+
+	/** Drop all in-memory state for a chat. */
+	forgetChat(chat: string): void {
+		this._byChat.delete(chat);
+	}
+
+	private async _load(session: string): Promise<ILocalTurnRecord[]> {
+		const ref = this._sessionDataService.tryOpenDatabase?.(URI.parse(session));
+		if (!ref) {
+			return [];
+		}
+		try {
+			const db = await ref;
+			if (!db) {
+				return [];
+			}
+			try {
+				const records = await db.object.getLocalTurns();
+				for (const r of records) {
+					this._noteInMemory(session, r.chatUri, r.turnId, r.anchorTurnId, r.seq);
+				}
+				return records;
+			} finally {
+				db.dispose();
+			}
+		} catch (err) {
+			this._logService.warn(`[AgentHostLocalTurns] Failed to load local turns for ${session}`, err);
+			return [];
+		}
+	}
+
+	private _noteInMemory(session: string, chat: string, turnId: string, anchorTurnId: string | undefined, seq: number): void {
+		let map = this._byChat.get(chat);
+		if (!map) {
+			map = new Map();
+			this._byChat.set(chat, map);
+		}
+		map.set(turnId, { anchorTurnId, seq });
+		this._seqBySession.set(session, Math.max(this._seqBySession.get(session) ?? 0, seq));
+	}
+}

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -32,12 +32,13 @@ import type { ChatPendingMessageSetAction, ChatTurnStartedAction } from '../comm
 import { ISessionGitHubState, ISessionGitState, ResponsePartKind, SESSION_META_GITHUB_KEY, SESSION_META_GIT_KEY, SessionStatus, ToolCallStatus, ToolResultContentType, AH_META_WORKSPACELESS_DB_KEY, buildDefaultChatUri, buildResourceWatchChannelUri, buildSubagentChatUri, hostBuildInfoFromProduct, isAhpChatChannel, isSubagentSession, parseDefaultChatUri, parseRequiredSessionUriFromChatUri, parseResourceWatchChannelUri, parseSubagentSessionUri, readSessionGitState, readSessionWorkspaceless, withSessionGitHubState, withSessionGitState, withSessionWorkspaceless, type SessionConfigState, type SessionSummary, type ToolResultSubagentContent, type Turn } from '../common/state/sessionState.js';
 import { IProductService } from '../../product/common/productService.js';
 import { AgentConfigurationService, IAgentConfigurationService } from './agentConfigurationService.js';
-import { AgentHostTerminalManager, type IAgentHostTerminalManager } from './agentHostTerminalManager.js';
+import { AgentHostTerminalManager, IAgentHostTerminalManager } from './agentHostTerminalManager.js';
 import { ISessionDbUriFields, parseSessionDbUri } from './shared/fileEditTracker.js';
 import { IGitBlobUriFields, parseGitBlobUri } from './gitDiffContent.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
 import { IAgentHostGitService } from '../common/agentHostGitService.js';
 import { AgentSideEffects } from './agentSideEffects.js';
+import { AgentHostLocalTurns } from './agentHostLocalTurns.js';
 import { AgentServerToolHost } from './shared/agentServerToolHost.js';
 import { serverToolGroups } from './shared/serverToolGroups.js';
 import { AgentHostChangesetService } from './agentHostChangesetService.js';
@@ -197,6 +198,8 @@ export class AgentService extends Disposable implements IAgentService {
 	private readonly _gitStateService: IAgentHostGitStateService;
 	/** Manages PTY-backed terminals for the agent host protocol. */
 	private readonly _terminalManager: AgentHostTerminalManager;
+	/** Persists host-injected `/rename` / `!command` turns for restore & fork/truncate. */
+	private readonly _localTurns: AgentHostLocalTurns;
 	/** Server-side host for the agent host's server tools. */
 	private readonly _serverToolHost: AgentServerToolHost;
 	private readonly _configurationService: IAgentConfigurationService;
@@ -368,9 +371,20 @@ export class AgentService extends Disposable implements IAgentService {
 			),
 		));
 
+		// Terminal management — the terminal manager listens to the state
+		// manager's action stream and dispatches PTY output back through it.
+		// Created before AgentSideEffects and registered in the local scope so
+		// AgentSideEffects can consume it via DI (for inline `!command`
+		// execution).
+		this._terminalManager = this._register(instantiationService.createInstance(AgentHostTerminalManager, this._stateManager));
+		services.set(IAgentHostTerminalManager, this._terminalManager);
+
+		this._localTurns = new AgentHostLocalTurns(this._sessionDataService, this._logService);
+
 		this._sideEffects = this._register(instantiationService.createInstance(AgentSideEffects, this._stateManager, {
 			getAgent: session => this._findProviderForSession(session),
 			sessionDataService: this._sessionDataService,
+			localTurns: this._localTurns,
 			agents: this._agents,
 			copilotApiService: effectiveCopilotApiService,
 			getGitHubCopilotToken: () => {
@@ -388,10 +402,6 @@ export class AgentService extends Disposable implements IAgentService {
 				void this._gitStateService.attachSessionGitHubPullRequest(session.toString());
 			},
 		}));
-
-		// Terminal management — the terminal manager listens to the state
-		// manager's action stream and dispatches PTY output back through it.
-		this._terminalManager = this._register(instantiationService.createInstance(AgentHostTerminalManager, this._stateManager));
 
 		// Server-side tools, executed in-process against each session's own
 		// state. Tool groups are contributed here at startup (feedback today) and
@@ -667,9 +677,15 @@ export class AgentService extends Disposable implements IAgentService {
 				for (const t of sourceTurns) {
 					turnIdMapping.set(t.id, generateUuid());
 				}
+				// The SDK fork boundary must be a concrete (SDK-backed) turn.
+				// When the client forked at a host-injected local turn
+				// (`/rename` / `!command`), redirect the agent to the preceding
+				// concrete turn while still seeding the local turns up to the
+				// fork point into the new session's protocol state below.
+				const concreteForkTurnId = this._localTurns.resolveConcreteTurnId(buildDefaultChatUri(config.fork.session).toString(), config.fork.turnId);
 				config = {
 					...config,
-					fork: { ...config.fork, turnIdMapping },
+					fork: { ...config.fork, turnIdMapping, ...(concreteForkTurnId !== undefined ? { turnId: concreteForkTurnId } : {}) },
 				};
 			}
 		}
@@ -735,10 +751,18 @@ export class AgentService extends Disposable implements IAgentService {
 		// the source session's turns so the client sees the forked history.
 		if (config?.fork) {
 			const sourceState = this._stateManager.getSessionState(config.fork.session.toString());
+			const sourceChatUri = buildDefaultChatUri(config.fork.session).toString();
+			const newChatUri = buildDefaultChatUri(session).toString();
 			let sourceTurns: Turn[] = [];
 			if (sourceState && config.fork.turnIdMapping) {
-				sourceTurns = sourceState.turns.slice(0, config.fork.turnIndex + 1)
-					.map(t => ({ ...t, id: config!.fork!.turnIdMapping!.get(t.id) ?? generateUuid() }));
+				const originalSlice = sourceState.turns.slice(0, config.fork.turnIndex + 1);
+				const mapping = config.fork.turnIdMapping;
+				sourceTurns = originalSlice.map(t => ({ ...t, id: mapping.get(t.id) ?? generateUuid() }));
+				// Re-persist forked local turns (`/rename`, `!command`) under the
+				// new session's default chat. `record` (keyed by turn id)
+				// overwrites any rows a DB copy carried with the SOURCE chat URI,
+				// and seeds the in-memory index for same-process fork/truncate.
+				this._persistForkedLocalTurns(session.toString(), sourceChatUri, newChatUri, originalSlice, sourceTurns, mapping);
 			}
 
 			// Prefix the forked session's title so consumers (sidebar, chat
@@ -833,8 +857,12 @@ export class AgentService extends Disposable implements IAgentService {
 		let createOptions = options;
 		if (options?.fork) {
 			const sourceKey = options.fork.source.toString();
-			const sourceState = this._stateManager.getChatState(sourceKey)
-				?? this._stateManager.getDefaultChatState(sourceKey);
+			const peerState = this._stateManager.getChatState(sourceKey);
+			const sourceState = peerState ?? this._stateManager.getDefaultChatState(sourceKey);
+			// Canonical chat URI the source's local turns are keyed by: when the
+			// source was found as a peer chat it is `sourceKey`; otherwise it was
+			// addressed by session URI and its default chat URI is canonical.
+			const sourceChatUri = peerState ? sourceKey : buildDefaultChatUri(sourceKey);
 			const sourceTurns = sourceState?.turns ?? [];
 			const forkIndex = sourceTurns.findIndex(t => t.id === options.fork!.turnId);
 			if (forkIndex < 0) {
@@ -850,12 +878,22 @@ export class AgentService extends Disposable implements IAgentService {
 				}
 				forkedTurns = slice.map(t => ({ ...t, id: turnIdMapping.get(t.id) ?? generateUuid() }));
 
+				// Carry forked host-injected local turns (`/rename`, `!command`)
+				// into the new chat so they survive reload and anchor future
+				// fork/truncate.
+				this._persistForkedLocalTurns(sessionKey, sourceChatUri, chat.toString(), slice, forkedTurns, turnIdMapping);
+
 				const forkedTitlePrefix = localize('agentHost.forkedTitlePrefix', "Forked: ");
 				forkedSourceTitle = sourceState?.title || this._stateManager.getSessionState(sessionKey)?.title;
 				forkedTitle = forkedSourceTitle
 					? (forkedSourceTitle.startsWith(forkedTitlePrefix) ? forkedSourceTitle : `${forkedTitlePrefix}${forkedSourceTitle}`)
 					: localize('agentHost.forkedChatFallback', "Forked Chat");
-				createOptions = { ...options, fork: { ...options.fork, turnIdMapping } };
+				// The SDK fork boundary must be a concrete (SDK-backed) turn. When
+				// the client forked at a host-injected local turn, redirect the
+				// agent to the preceding concrete turn (the local turns are still
+				// seeded into the new chat's protocol state above).
+				const concreteForkTurnId = this._localTurns.resolveConcreteTurnId(sourceChatUri, options.fork.turnId);
+				createOptions = { ...options, fork: { ...options.fork, turnIdMapping, ...(concreteForkTurnId !== undefined ? { turnId: concreteForkTurnId } : {}) } };
 			}
 		}
 
@@ -931,6 +969,74 @@ export class AgentService extends Disposable implements IAgentService {
 	 */
 	private _getChatMessages(provider: IAgent, chat: URI): Promise<readonly Turn[]> {
 		return provider.chats.getMessages(chat);
+	}
+
+	/**
+	 * Merges persisted host-injected local turns (`/rename`, `!command`) for
+	 * `chatUri` back into that chat's SDK-derived `turns`, positioned after
+	 * their anchor turn (the concrete turn they were recorded after). Locals
+	 * anchored before any real turn are prepended; locals whose anchor is absent
+	 * from the SDK turns (e.g. truncated away) are dropped. Also seeds the
+	 * in-memory local-turn index so fork/truncate resolve correctly before the
+	 * next reload.
+	 */
+	private async _interleaveLocalTurns(sessionStr: string, chatUri: string, turns: readonly Turn[]): Promise<Turn[]> {
+		const records = await this._localTurns.loadForChat(sessionStr, chatUri);
+		if (records.length === 0) {
+			return [...turns];
+		}
+		const knownIds = new Set(turns.map(t => t.id));
+		const byAnchor = new Map<string, Turn[]>();
+		const head: Turn[] = [];
+		for (const record of records) {
+			let turn: Turn;
+			try {
+				turn = JSON.parse(record.payload) as Turn;
+			} catch {
+				continue;
+			}
+			if (record.anchorTurnId === undefined) {
+				head.push(turn);
+			} else if (knownIds.has(record.anchorTurnId)) {
+				const list = byAnchor.get(record.anchorTurnId) ?? [];
+				list.push(turn);
+				byAnchor.set(record.anchorTurnId, list);
+			}
+			// else: orphaned (anchor truncated away) → drop.
+		}
+		const merged: Turn[] = [...head];
+		for (const turn of turns) {
+			merged.push(turn);
+			const locals = byAnchor.get(turn.id);
+			if (locals) {
+				merged.push(...locals);
+			}
+		}
+		return merged;
+	}
+
+	/**
+	 * Re-persists forked host-injected local turns (`/rename`, `!command`) into
+	 * a newly forked chat so they survive reload and anchor future
+	 * fork/truncate. `originalSlice[i]` and `forkedTurns[i]` are the source turn
+	 * and its remapped copy (same length, 1:1); `mapping` is the old→new turn id
+	 * map used to remap each local turn's anchor. `persistSession` owns the
+	 * destination database; `sourceChatUri` / `newChatUri` key the source and
+	 * destination local-turn indexes.
+	 *
+	 * Shared by the {@link createSession} (default-chat) and {@link createChat}
+	 * (peer-chat) fork paths.
+	 */
+	private _persistForkedLocalTurns(persistSession: string, sourceChatUri: string, newChatUri: string, originalSlice: readonly Turn[], forkedTurns: readonly Turn[], mapping: ReadonlyMap<string, string>): void {
+		for (let i = 0; i < originalSlice.length; i++) {
+			const original = originalSlice[i];
+			if (!this._localTurns.isLocal(sourceChatUri, original.id)) {
+				continue;
+			}
+			const originalAnchor = this._localTurns.resolveConcreteTurnId(sourceChatUri, original.id);
+			const newAnchor = originalAnchor !== undefined ? mapping.get(originalAnchor) : undefined;
+			this._localTurns.record(persistSession, newChatUri, forkedTurns[i], newAnchor);
+		}
 	}
 
 	/**
@@ -1864,7 +1970,8 @@ export class AgentService extends Disposable implements IAgentService {
 			this._getChatDraft(session, defaultChatUri),
 			this._readPersistedChatTitle(session, defaultChatUri),
 		]);
-		this._stateManager.restoreSession(summary, [...turns], { draft: defaultDraft, defaultChatTitle });
+		const mergedTurns = await this._interleaveLocalTurns(sessionStr, defaultChatUri.toString(), turns);
+		this._stateManager.restoreSession(summary, mergedTurns, { draft: defaultDraft, defaultChatTitle });
 
 		const promises: Promise<unknown>[] = [];
 		// Eagerly register subagent child sessions discovered in the event log
@@ -2042,7 +2149,8 @@ export class AgentService extends Disposable implements IAgentService {
 				this._readPersistedChatTitle(session, chatUri),
 				this._getChatDraft(session, chatUri),
 			]);
-			return { chatUri, title, turns: [...turns], draft, providerData: entry.providerData };
+			const mergedTurns = await this._interleaveLocalTurns(session.toString(), chatUri.toString(), turns);
+			return { chatUri, title, turns: mergedTurns, draft, providerData: entry.providerData };
 		}));
 		for (const item of restored) {
 			if (!item) {
@@ -2828,6 +2936,10 @@ export class AgentService extends Disposable implements IAgentService {
 		const title = subagentContent?.title ?? 'Subagent';
 
 		const subagentNow = new Date().toISOString();
+		// Local turns for a subagent chat are persisted in the parent session's
+		// database (its chat URI resolves to the parent session), keyed by the
+		// subagent chat URI.
+		const mergedChildTurns = await this._interleaveLocalTurns(parentSession.toString(), subagentUri, childTurns);
 		this._stateManager.restoreSession(
 			{
 				resource: subagentUri,
@@ -2838,7 +2950,7 @@ export class AgentService extends Disposable implements IAgentService {
 				modifiedAt: subagentNow,
 				...(parentState?.project ? { project: parentState.project } : {}),
 			},
-			[...childTurns],
+			mergedChildTurns,
 		);
 		this._logService.info(`[AgentService] Restored subagent session: ${subagentUri} with ${childTurns.length} turn(s)`);
 	}

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -10,7 +10,6 @@ import { autorun, IObservable, IReader } from '../../../base/common/observable.j
 import { hasKey } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
-import { localize } from '../../../nls.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { ILogService } from '../../log/common/log.js';
 import { IAgentHostChangesetService } from '../common/agentHostChangesetService.js';
@@ -47,16 +46,19 @@ import {
 	type ToolResultContent,
 	type Turn
 } from '../common/state/sessionState.js';
-import { parseRenameCommand } from './agentHostRenameCommand.js';
+import { AgentHostLocalTurns } from './agentHostLocalTurns.js';
 import { AgentHostSessionTitleController } from './agentHostSessionTitleController.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
 import { AgentHostTelemetryReporter } from './agentHostTelemetryReporter.js';
 import { AgentHostToolCallTracker } from './agentHostToolCallTracker.js';
 import { updateAgentHostTelemetryLevelFromConfig } from './agentHostTelemetryService.js';
 import { AgentHostTurnTracker } from './agentHostTurnTracker.js';
+import { AgentHostLocalCommands } from './localCommands/localChatCommand.js';
+import './localCommands/localChatCommands.contribution.js';
 import { SessionPermissionManager } from './sessionPermissions.js';
 import type { ICopilotApiService } from './shared/copilotApiService.js';
 import { stripProxyErrorMarker, toChatErrorMeta, tryParseForwardedChatError } from './shared/forwardedChatError.js';
+import { persistSessionMetadata } from './shared/persistSessionMetadata.js';
 
 /**
  * Options for constructing an {@link AgentSideEffects} instance.
@@ -68,6 +70,8 @@ export interface IAgentSideEffectsOptions {
 	readonly agents: IObservable<readonly IAgent[]>;
 	/** Session data service for cleaning up per-session data on disposal. */
 	readonly sessionDataService: ISessionDataService;
+	/** Registry that persists host-injected `/rename` and `!command` turns. */
+	readonly localTurns: AgentHostLocalTurns;
 	/** Get the GitHub token used for Copilot utility title generation. */
 	readonly getGitHubCopilotToken?: () => string | undefined;
 	/** CAPI service used for Copilot utility title generation. */
@@ -111,6 +115,9 @@ export class AgentSideEffects extends Disposable {
 
 	private readonly _permissionManager: SessionPermissionManager;
 
+	/** Registry-driven dispatcher for host-handled `/rename` / `!command` etc. */
+	private readonly _localCommands: AgentHostLocalCommands;
+
 	private readonly _subagentChats = new NKeyMap<ISubagentSessionRef, [ProtocolURI, string]>();
 
 	/**
@@ -143,6 +150,15 @@ export class AgentSideEffects extends Disposable {
 		this._turnTracker = new AgentHostTurnTracker(this._telemetryReporter);
 		this._toolCallTracker = new AgentHostToolCallTracker(this._telemetryReporter);
 		this._permissionManager = this._register(instantiationService.createInstance(SessionPermissionManager, this._stateManager));
+		this._localCommands = this._register(instantiationService.createInstance(
+			AgentHostLocalCommands,
+			this._stateManager,
+			this._options.localTurns,
+			// Draining the queue re-enters agent lookup / telemetry / sendMessage,
+			// which is this class's responsibility, so the dispatcher hands the
+			// turn back here once it has completed a host-handled command.
+			(turnChannel: ProtocolURI) => this._tryConsumeNextQueuedMessage(turnChannel),
+		));
 		this._titleController = this._register(instantiationService.createInstance(AgentHostSessionTitleController, this._stateManager, {
 			sessionDataService: this._options.sessionDataService,
 			getGitHubCopilotToken: this._options.getGitHubCopilotToken,
@@ -938,12 +954,10 @@ export class AgentSideEffects extends Disposable {
 				// Per-turn streaming part tracking is owned by the agent
 				// (e.g. CopilotAgentSession) and reset on its `send()` call.
 
-				// `/rename [title]` is a generic, agent-agnostic slash command:
-				// it is intercepted here and redirected to a title change rather
-				// than forwarded to the agent SDK. Mirrors the per-agent text-side
-				// dispatch (`parseLeadingSlashCommand` in CopilotAgentSession), but
-				// applies to every session type.
-				if (this._tryHandleRenameCommand(channel, action.turnId, action.message.text)) {
+				// Generic, agent-agnostic host commands (`/rename`, `!command`,
+				// …) are intercepted here and handled by the local-command
+				// dispatcher rather than forwarded to the agent SDK.
+				if (this._localCommands.tryHandle({ turnChannel: channel, turnId: action.turnId, text: action.message.text })) {
 					break;
 				}
 
@@ -1054,9 +1068,23 @@ export class AgentSideEffects extends Disposable {
 					throw new Error(`ChatTruncated must be handled on an AHP chat channel: ${channel}`);
 				}
 				const agent = this._options.getAgent(sessionChannel);
-				agent?.truncateSession?.(URI.parse(sessionChannel), action.turnId).catch(err => {
+				// When the truncation boundary is a host-injected local turn
+				// (`/rename` / `!command`), redirect the SDK truncation to the
+				// preceding concrete turn so the agent keeps everything up to
+				// the real message before it.
+				const sdkTurnId = action.turnId !== undefined
+					? this._options.localTurns.resolveConcreteTurnId(chatChannel, action.turnId)
+					: action.turnId;
+				// Route to the chat being truncated: the default chat (addressed
+				// by the session) or a peer chat with its own backing.
+				agent?.truncateSession?.(URI.parse(sessionChannel), sdkTurnId, URI.parse(chatChannel)).catch(err => {
 					this._logService.error('[AgentSideEffects] truncateSession failed', err);
 				});
+				// Drop persisted local turns that no longer survive in the
+				// (already-truncated) chat state.
+				const survivingIds = new Set((this._stateManager.getChatState(chatChannel)?.turns ?? []).map(t => t.id));
+				const removed = this._options.localTurns.getLocalTurnIds(chatChannel).filter(id => !survivingIds.has(id));
+				this._options.localTurns.deleteLocals(sessionChannel, removed);
 				this._changesets.onSessionTruncated(sessionChannel);
 				break;
 			}
@@ -1140,84 +1168,12 @@ export class AgentSideEffects extends Disposable {
 	}
 
 	/**
-	 * Handles the generic `/rename [title]` slash command. When `text` is a
-	 * rename command it is redirected to a {@link ActionType.SessionTitleChanged}
-	 * action (when a non-empty title is supplied) and the just-started turn is
-	 * immediately completed, so the command is never forwarded to the agent SDK.
-	 *
-	 * @returns `true` when the message was a rename command and was handled here
-	 * (the caller MUST NOT forward it to the agent), `false` otherwise.
-	 */
-	private _tryHandleRenameCommand(channel: ProtocolURI, turnId: string, text: string): boolean {
-		const title = parseRenameCommand(text);
-		if (title === undefined) {
-			return false;
-		}
-		const isAdditional = (uri: ProtocolURI | undefined): uri is ProtocolURI =>
-			!!uri && isAhpChatChannel(uri) && !isDefaultChatUri(uri);
-		const chatTarget = isAdditional(channel) ? channel : undefined;
-		const sessionChannel = chatTarget ? parseRequiredSessionUriFromChatUri(chatTarget) : (isAhpChatChannel(channel) ? parseRequiredSessionUriFromChatUri(channel) : channel);
-		// The just-opened turn lives wherever the message was dispatched.
-		const turnTarget = chatTarget ?? channel;
-		if (title.length > 0) {
-			if (chatTarget) {
-				// Rename only this chat, independently of the session title.
-				this._stateManager.updateChatTitle(sessionChannel, chatTarget, title);
-				this._persistSessionFlag(sessionChannel, `customChatTitle:${chatTarget}`, title);
-			} else {
-				this._stateManager.dispatchServerAction(sessionChannel, {
-					type: ActionType.SessionTitleChanged,
-					title,
-				});
-				// Server-dispatched actions bypass `handleAction`, so persist the
-				// new title here directly (the client-dispatched rename path relies
-				// on the `SessionTitleChanged` case in `handleAction` instead).
-				this._persistSessionFlag(sessionChannel, 'customTitle', title);
-			}
-			// Acknowledge the rename with a brief response so the turn has
-			// visible content in the transcript.
-			this._stateManager.dispatchServerAction(turnTarget, {
-				type: ActionType.ChatResponsePart,
-				turnId,
-				part: {
-					kind: ResponsePartKind.Markdown,
-					id: generateUuid(),
-					content: localize('agentHostRename.renamed', "Renamed: {0}", title),
-				},
-			});
-		}
-		// Close out the turn that the reducer opened for this message so the
-		// session returns to idle instead of waiting on an agent response.
-		this._stateManager.dispatchServerAction(turnTarget, {
-			type: ActionType.ChatTurnComplete,
-			turnId,
-		});
-		// This turn was completed via a direct server dispatch rather than
-		// `_runTurnCompleteSideEffects`, so drain any messages queued behind
-		// the rename ourselves; otherwise they would stall until the next
-		// unrelated state change re-triggers consumption.
-		this._tryConsumeNextQueuedMessage(turnTarget);
-		return true;
-	}
-
-	/**
 	 * Persists a session metadata key/value pair to the session database.
 	 * Used for fields the host needs to remember across restarts (custom
 	 * title, isRead/isArchived flags, merged config values).
-	 *
-	 * Counterpart in `agentHostChangesetService.ts` (`AgentHostChangesetService._persistSessionFlag`):
-	 * keep both copies in sync if the signature changes. Duplicated rather
-	 * than lifted because the two consumers persist disjoint metadata
-	 * (changeset diffs there vs. customTitle / isRead / isArchived /
-	 * configValues here) and a shared util would only have two callers.
 	 */
 	private _persistSessionFlag(session: ProtocolURI, key: string, value: string): void {
-		const ref = this._options.sessionDataService.openDatabase(URI.parse(session));
-		ref.object.setMetadata(key, value).catch(err => {
-			this._logService.warn(`[AgentSideEffects] Failed to persist ${key}`, err);
-		}).finally(() => {
-			ref.dispose();
-		});
+		persistSessionMetadata(this._options.sessionDataService, this._logService, session, key, value);
 	}
 
 	private _persistChatDraft(channel: ProtocolURI, draft: Message | undefined): void {
@@ -1298,9 +1254,10 @@ export class AgentSideEffects extends Disposable {
 			queuedMessageId: msg.id,
 		});
 
-		// `/rename` is intercepted generically (see the ChatTurnStarted
-		// handler) and must not reach the agent SDK even when queued.
-		if (this._tryHandleRenameCommand(session, turnId, msg.message.text)) {
+		// Generic host commands (`/rename`, `!command`, …) are intercepted by
+		// the local-command dispatcher (see the ChatTurnStarted handler) and
+		// must not reach the agent SDK even when queued.
+		if (this._localCommands.tryHandle({ turnChannel: session, turnId, text: msg.message.text })) {
 			return;
 		}
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1487,6 +1487,9 @@ export class CopilotAgent extends Disposable implements IAgent {
 					if (sourceDbRef) {
 						try {
 							await fs.mkdir(targetDbDir.fsPath, { recursive: true });
+							// VACUUM INTO fails if the target already exists; clear
+							// any stale DB left by a previous (e.g. crashed) attempt.
+							await fs.rm(targetDbPath.fsPath, { force: true });
 							await sourceDbRef.object.vacuumInto(targetDbPath.fsPath);
 						} finally {
 							sourceDbRef.dispose();
@@ -2339,6 +2342,9 @@ export class CopilotAgent extends Disposable implements IAgent {
 			if (sourceDbRef) {
 				try {
 					await fs.mkdir(targetDbDir.fsPath, { recursive: true });
+					// VACUUM INTO fails if the target already exists; clear any
+					// stale DB left by a previous (e.g. crashed) attempt.
+					await fs.rm(targetDbPath.fsPath, { force: true });
 					await sourceDbRef.object.vacuumInto(targetDbPath.fsPath);
 				} finally {
 					sourceDbRef.dispose();
@@ -2526,16 +2532,25 @@ export class CopilotAgent extends Disposable implements IAgent {
 		});
 	}
 
-	async truncateSession(session: URI, turnId?: string): Promise<void> {
+	async truncateSession(session: URI, turnId: string | undefined, chat: URI): Promise<void> {
 		const sessionId = AgentSession.id(session);
 		if (this._provisionalSessions.has(sessionId)) {
 			return;
 		}
+		const isPeerChat = !isDefaultChatUri(chat);
 		await this._sessionSequencer.queue(sessionId, async () => {
-			this._logService.info(`[Copilot:${sessionId}] Truncating session${turnId !== undefined ? ` at turnId=${turnId}` : ' (all turns)'}`);
+			this._logService.info(`[Copilot:${sessionId}] Truncating ${isPeerChat ? `peer chat ${chat.toString()}` : 'session'}${turnId !== undefined ? ` at turnId=${turnId}` : ' (all turns)'}`);
 
-			// Ensure the session is loaded so we can use the SDK RPC
-			const entry = this._findAnySession(sessionId) ?? await this._resumeSession(sessionId);
+			// Resolve the entry whose history is being truncated: a peer chat has
+			// its own backing SDK session, so route to it rather than the default
+			// chat. `_resolveChatEntry` resumes/materializes the chat if needed.
+			const entry = isPeerChat
+				? await this._resolveChatEntry(session, chat)
+				: (this._findAnySession(sessionId) ?? await this._resumeSession(sessionId));
+			if (!entry) {
+				this._logService.info(`[Copilot:${sessionId}] No chat entry resolved for truncation; nothing to truncate`);
+				return;
+			}
 
 			// Look up the SDK event ID for the truncation boundary.
 			// The protocol semantics: turnId is the last turn to KEEP.

--- a/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
@@ -6,8 +6,6 @@
 import type { Tool, ToolResultObject } from '@github/copilot-sdk';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { URI } from '../../../../base/common/uri.js';
-import { removeAnsiEscapeCodes } from '../../../../base/common/strings.js';
-import * as platform from '../../../../base/common/platform.js';
 import { Disposable, DisposableStore, type IReference, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { IEnvironmentService } from '../../../environment/common/environment.js';
@@ -22,22 +20,18 @@ import { isZsh } from '../agentHostShellUtils.js';
 import { IAgentHostTerminalManager } from '../agentHostTerminalManager.js';
 import { createAgentHostSandboxEngine } from './agentHostSandboxEngine.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
+import { DEFAULT_SHELL_COMMAND_TIMEOUT_MS, executeShellCommand, isMultilineCommand, prefixForHistorySuppression, prepareOutputForModel, shellTypeForExecutable, type IShellCommandResult, type ShellType } from '../shared/shellCommandExecution.js';
+
+// Re-exported for consumers (and tests) that historically imported these
+// shell helpers from this module. Their canonical home is the shared,
+// agent-agnostic shellCommandExecution module.
+export { isMultilineCommand, prefixForHistorySuppression, shellTypeForExecutable };
+export type { ShellType };
 
 /**
- * Maximum scrollback content (in bytes) returned to the model in tool results.
+ * Message returned to the model when a command switches to the terminal's
+ * alternate buffer (typically an interactive full-screen UI).
  */
-const MAX_OUTPUT_BYTES = 80_000;
-
-/**
- * Default command timeout in milliseconds (120 seconds).
- */
-const DEFAULT_TIMEOUT_MS = 120_000;
-
-/**
- * The sentinel prefix used to detect command completion in terminal output.
- * The full sentinel format is: `<<<COPILOT_SENTINEL_<uuid>_EXIT_<code>>>`.
- */
-const SENTINEL_PREFIX = '<<<COPILOT_SENTINEL_';
 const ALT_BUFFER_MESSAGE = 'The command opened the alternate buffer and is still running in the terminal. It likely launched an interactive terminal UI. Use write_bash/write_powershell to interact with it, or shutdown the shell to stop it.';
 
 /**
@@ -48,48 +42,6 @@ interface IManagedShell {
 	readonly terminalUri: string;
 	readonly shellType: ShellType;
 	readonly executable: string;
-}
-
-export type ShellType = 'bash' | 'powershell';
-
-/**
- * Routes a resolved shell executable to one of the Copilot SDK's two
- * built-in shell tools (`bash` / `powershell`). Falls back to the platform
- * default for unknown shells.
- */
-export function shellTypeForExecutable(shellPath: string): ShellType {
-	// Strip path on either separator and the .exe suffix.
-	const lastSep = Math.max(shellPath.lastIndexOf('/'), shellPath.lastIndexOf('\\'));
-	const base = shellPath.slice(lastSep + 1).toLowerCase().replace(/\.exe$/, '');
-	switch (base) {
-		// PowerShell
-		case 'pwsh':
-		case 'powershell':
-		case 'pwsh-preview':
-			return 'powershell';
-		// POSIX shells
-		case 'bash':
-		case 'sh':
-		case 'zsh':
-		case 'fish':
-		case 'csh':
-		case 'ksh':
-		case 'nu':
-		case 'xonsh':
-		// Git for Windows bash entry points
-		case 'git-cmd':
-		// WSL launchers — bash inside, but invoked via these stubs
-		case 'wsl':
-		case 'ubuntu':
-		case 'ubuntu1804':
-		case 'kali':
-		case 'debian':
-		case 'opensuse-42':
-		case 'sles-12':
-			return 'bash';
-		default:
-			return platform.isWindows ? 'powershell' : 'bash';
-	}
 }
 
 // ---------------------------------------------------------------------------
@@ -323,75 +275,6 @@ export class ShellManager extends Disposable {
 }
 
 // ---------------------------------------------------------------------------
-// Sentinel helpers
-// ---------------------------------------------------------------------------
-
-function makeSentinelId(): string {
-	return generateUuid().replace(/-/g, '');
-}
-
-function buildSentinelCommand(sentinelId: string, shellType: ShellType): string {
-	if (shellType === 'powershell') {
-		return `Write-Output "${SENTINEL_PREFIX}${sentinelId}_EXIT_$LASTEXITCODE>>>"`;
-	}
-	return `echo "${SENTINEL_PREFIX}${sentinelId}_EXIT_$?>>>"`;
-}
-
-/**
- * For POSIX shells (bash/zsh) that honor `HISTCONTROL=ignorespace` /
- * `HIST_IGNORE_SPACE`, prepending a single space prevents the command from
- * being recorded in shell history. The shell integration scripts opt these
- * settings in via the `VSCODE_PREVENT_SHELL_HISTORY` env var (set when the
- * terminal is created with `preventShellHistory: true`). PowerShell
- * suppresses history through PSReadLine instead, so no prefix is needed.
- */
-export function prefixForHistorySuppression(shellType: ShellType): string {
-	return shellType === 'powershell' ? '' : ' ';
-}
-
-export function isMultilineCommand(command: string): boolean {
-	const normalized = command.replace(/\r\n|\r/g, '\n');
-	return /(?<!\\)\n/.test(normalized);
-}
-
-function shouldUseBracketedPasteMode(command: string): boolean {
-	return platform.isMacintosh || isMultilineCommand(command);
-}
-
-function parseSentinel(content: string, sentinelId: string): { found: boolean; exitCode: number; outputBeforeSentinel: string } {
-	const marker = `${SENTINEL_PREFIX}${sentinelId}_EXIT_`;
-	let markerIndex = content.lastIndexOf(marker);
-	while (markerIndex !== -1) {
-		const outputBeforeSentinel = content.substring(0, markerIndex);
-		const afterMarker = content.substring(markerIndex + marker.length);
-		const endIdx = afterMarker.indexOf('>>>');
-		if (endIdx !== -1) {
-			const exitCodeStr = afterMarker.substring(0, endIdx).trim();
-			if (/^-?\d+$/.test(exitCodeStr)) {
-				return {
-					found: true,
-					exitCode: parseInt(exitCodeStr, 10),
-					outputBeforeSentinel,
-				};
-			}
-		}
-		// Ignore echoed sentinel command text (for example `$?`) and continue
-		// scanning for the latest complete numeric sentinel marker.
-		markerIndex = content.lastIndexOf(marker, markerIndex - 1);
-	}
-
-	return { found: false, exitCode: -1, outputBeforeSentinel: content };
-}
-
-function prepareOutputForModel(rawOutput: string): string {
-	let text = removeAnsiEscapeCodes(rawOutput).trim();
-	if (text.length > MAX_OUTPUT_BYTES) {
-		text = text.substring(text.length - MAX_OUTPUT_BYTES);
-	}
-	return text;
-}
-
-// ---------------------------------------------------------------------------
 // Tool implementations
 // ---------------------------------------------------------------------------
 
@@ -412,25 +295,33 @@ function makeExecutionResult(toolResult: ToolResultObject, options?: { keepShell
 	return { toolResult, keepShellBusy: options?.keepShellBusy };
 }
 
-function makeBackgroundExecutionResult(text: string): IShellExecutionResult {
-	return makeExecutionResult(makeSuccessResult(text), { keepShellBusy: true });
-}
-
-function makeAltBufferExecutionResult(): IShellExecutionResult {
-	return makeExecutionResult(makeFailureResult(ALT_BUFFER_MESSAGE, 'alternateBuffer'), { keepShellBusy: true });
-}
-
-function registerAltBufferHandler(
-	shell: IManagedShell,
-	terminalManager: IAgentHostTerminalManager,
-	logService: ILogService,
-	disposables: DisposableStore,
-	finish: (result: IShellExecutionResult) => void,
-): void {
-	void terminalManager.createAltBufferPromise(shell.terminalUri, disposables).then(() => {
-		logService.info('[ShellTool] Command entered alternate buffer');
-		finish(makeAltBufferExecutionResult());
-	});
+/**
+ * Maps the neutral {@link IShellCommandResult} produced by the shared shell
+ * executor to the Copilot SDK {@link ToolResultObject} shape expected by the
+ * shell tools.
+ */
+function shellCommandResultToExecutionResult(result: IShellCommandResult, timeoutMs: number): IShellExecutionResult {
+	switch (result.status) {
+		case 'completed': {
+			const exitCode = result.exitCode ?? 0;
+			const text = `Exit code: ${exitCode}\n${result.output}`;
+			return makeExecutionResult(exitCode === 0 ? makeSuccessResult(text) : makeFailureResult(text));
+		}
+		case 'shellExited':
+			return makeExecutionResult(makeFailureResult(`Shell exited with code ${result.exitCode}\n${result.output}`));
+		case 'timeout':
+			return makeExecutionResult(makeFailureResult(
+				`Command timed out after ${Math.round(timeoutMs / 1000)}s. Partial output:\n${result.output}`,
+				'timeout',
+			));
+		case 'background':
+			return makeExecutionResult(
+				makeSuccessResult('The user chose to continue this command in the background. The terminal is still running.'),
+				{ keepShellBusy: true },
+			);
+		case 'altBuffer':
+			return makeExecutionResult(makeFailureResult(ALT_BUFFER_MESSAGE, 'alternateBuffer'), { keepShellBusy: true });
+	}
 }
 
 async function executeCommandInShell(
@@ -440,9 +331,10 @@ async function executeCommandInShell(
 	terminalManager: IAgentHostTerminalManager,
 	logService: ILogService,
 ): Promise<IShellExecutionResult> {
-	const result = terminalManager.supportsCommandDetection(shell.terminalUri)
-		? await executeCommandWithShellIntegration(shell, command, timeoutMs, terminalManager, logService)
-		: await executeCommandWithSentinel(shell, command, timeoutMs, terminalManager, logService);
+	const result = shellCommandResultToExecutionResult(
+		await executeShellCommand(shell, command, timeoutMs, terminalManager, logService),
+		timeoutMs,
+	);
 	return {
 		...result,
 		toolResult: {
@@ -450,182 +342,6 @@ async function executeCommandInShell(
 			textResultForLlm: `Shell ID: ${shell.id}\n${result.toolResult.textResultForLlm}`,
 		},
 	};
-}
-
-/**
- * Execute a command using shell integration (OSC 633) for completion detection.
- * No sentinel echo is injected — the shell's own command-finished signal
- * provides the exit code and cleanly delineated output.
- */
-async function executeCommandWithShellIntegration(
-	shell: IManagedShell,
-	command: string,
-	timeoutMs: number,
-	terminalManager: IAgentHostTerminalManager,
-	logService: ILogService,
-): Promise<IShellExecutionResult> {
-	const disposables = new DisposableStore();
-
-	const result = new Promise<IShellExecutionResult>(resolve => {
-		let resolved = false;
-		const finish = (result: IShellExecutionResult) => {
-			if (resolved) {
-				return;
-			}
-			resolved = true;
-			disposables.dispose();
-			resolve(result);
-		};
-
-		disposables.add(terminalManager.onCommandFinished(shell.terminalUri, event => {
-			const output = prepareOutputForModel(event.output);
-			const exitCode = event.exitCode ?? 0;
-			logService.info(`[ShellTool] Command completed (shell integration) with exit code ${exitCode}`);
-			if (exitCode === 0) {
-				finish(makeExecutionResult(makeSuccessResult(`Exit code: ${exitCode}\n${output}`)));
-			} else {
-				finish(makeExecutionResult(makeFailureResult(`Exit code: ${exitCode}\n${output}`)));
-			}
-		}));
-
-		registerAltBufferHandler(shell, terminalManager, logService, disposables, finish);
-
-		disposables.add(terminalManager.onExit(shell.terminalUri, (exitCode: number) => {
-			logService.info(`[ShellTool] Shell exited unexpectedly with code ${exitCode}`);
-			const fullContent = terminalManager.getContent(shell.terminalUri) ?? '';
-			const output = prepareOutputForModel(fullContent);
-			finish(makeExecutionResult(makeFailureResult(`Shell exited with code ${exitCode}\n${output}`)));
-		}));
-
-		disposables.add(terminalManager.onClaimChanged(shell.terminalUri, (claim) => {
-			if (claim.kind === TerminalClaimKind.Session && !claim.toolCallId) {
-				logService.info(`[ShellTool] Continuing in background (claim narrowed)`);
-				finish(makeBackgroundExecutionResult('The user chose to continue this command in the background. The terminal is still running.'));
-			}
-		}));
-
-		const timer = setTimeout(() => {
-			logService.warn(`[ShellTool] Command timed out after ${timeoutMs}ms`);
-			const fullContent = terminalManager.getContent(shell.terminalUri) ?? '';
-			const output = prepareOutputForModel(fullContent);
-			finish(makeExecutionResult(makeFailureResult(
-				`Command timed out after ${Math.round(timeoutMs / 1000)}s. Partial output:\n${output}`,
-				'timeout',
-			)));
-		}, timeoutMs);
-		disposables.add(toDisposable(() => clearTimeout(timer)));
-
-	});
-
-	try {
-		await terminalManager.sendText(shell.terminalUri, `${prefixForHistorySuppression(shell.shellType)}${command}`, {
-			shouldExecute: true,
-			bracketedPasteMode: shouldUseBracketedPasteMode(command),
-		});
-	} catch (err) {
-		disposables.dispose();
-		throw err;
-	}
-
-	return result;
-}
-
-/**
- * Fallback: execute a command using a sentinel echo to detect completion.
- * Used when shell integration is not available.
- */
-async function executeCommandWithSentinel(
-	shell: IManagedShell,
-	command: string,
-	timeoutMs: number,
-	terminalManager: IAgentHostTerminalManager,
-	logService: ILogService,
-): Promise<IShellExecutionResult> {
-	const sentinelId = makeSentinelId();
-	const sentinelCmd = buildSentinelCommand(sentinelId, shell.shellType);
-	const disposables = new DisposableStore();
-
-	const contentBefore = terminalManager.getContent(shell.terminalUri) ?? '';
-	const offsetBefore = contentBefore.length;
-
-	const result = new Promise<IShellExecutionResult>(resolve => {
-		let resolved = false;
-		const finish = (result: IShellExecutionResult) => {
-			if (resolved) {
-				return;
-			}
-			resolved = true;
-			disposables.dispose();
-			resolve(result);
-		};
-
-		const checkForSentinel = () => {
-			const fullContent = terminalManager.getContent(shell.terminalUri) ?? '';
-			// Clamp offset: the terminal manager trims content when it exceeds
-			// 100k chars (slices to last 80k). If trimming happened after we
-			// captured offsetBefore, scan from the start of the current buffer.
-			const clampedOffset = Math.min(offsetBefore, fullContent.length);
-			const newContent = fullContent.substring(clampedOffset);
-			const parsed = parseSentinel(newContent, sentinelId);
-			if (parsed.found) {
-				const output = prepareOutputForModel(parsed.outputBeforeSentinel);
-				logService.info(`[ShellTool] Command completed with exit code ${parsed.exitCode}`);
-				if (parsed.exitCode === 0) {
-					finish(makeExecutionResult(makeSuccessResult(`Exit code: ${parsed.exitCode}\n${output}`)));
-				} else {
-					finish(makeExecutionResult(makeFailureResult(`Exit code: ${parsed.exitCode}\n${output}`)));
-				}
-			}
-		};
-
-		disposables.add(terminalManager.onData(shell.terminalUri, () => {
-			checkForSentinel();
-		}));
-
-		registerAltBufferHandler(shell, terminalManager, logService, disposables, finish);
-
-		disposables.add(terminalManager.onExit(shell.terminalUri, (exitCode: number) => {
-			logService.info(`[ShellTool] Shell exited unexpectedly with code ${exitCode}`);
-			const fullContent = terminalManager.getContent(shell.terminalUri) ?? '';
-			const newContent = fullContent.substring(offsetBefore);
-			const output = prepareOutputForModel(newContent);
-			finish(makeExecutionResult(makeFailureResult(`Shell exited with code ${exitCode}\n${output}`)));
-		}));
-
-		disposables.add(terminalManager.onClaimChanged(shell.terminalUri, (claim) => {
-			if (claim.kind === TerminalClaimKind.Session && !claim.toolCallId) {
-				logService.info(`[ShellTool] Continuing in background (claim narrowed)`);
-				finish(makeBackgroundExecutionResult('The user chose to continue this command in the background. The terminal is still running.'));
-			}
-		}));
-
-		const timer = setTimeout(() => {
-			logService.warn(`[ShellTool] Command timed out after ${timeoutMs}ms`);
-			const fullContent = terminalManager.getContent(shell.terminalUri) ?? '';
-			const newContent = fullContent.substring(offsetBefore);
-			const output = prepareOutputForModel(newContent);
-			finish(makeExecutionResult(makeFailureResult(
-				`Command timed out after ${Math.round(timeoutMs / 1000)}s. Partial output:\n${output}`,
-				'timeout',
-			)));
-		}, timeoutMs);
-		disposables.add(toDisposable(() => clearTimeout(timer)));
-
-		checkForSentinel();
-	});
-
-	try {
-		await terminalManager.sendText(shell.terminalUri, `${prefixForHistorySuppression(shell.shellType)}${command}`, {
-			shouldExecute: true,
-			bracketedPasteMode: shouldUseBracketedPasteMode(command),
-		});
-		await terminalManager.sendText(shell.terminalUri, sentinelCmd, { shouldExecute: true });
-	} catch (err) {
-		disposables.dispose();
-		throw err;
-	}
-
-	return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -705,7 +421,7 @@ export async function createShellTools(
 		},
 		overridesBuiltInTool: true,
 		handler: async (args, invocation) => {
-			const timeoutMs = args.timeout ?? DEFAULT_TIMEOUT_MS;
+			const timeoutMs = args.timeout ?? DEFAULT_SHELL_COMMAND_TIMEOUT_MS;
 			const ref = await shellManager.getOrCreateShell(
 				shellType,
 				invocation.toolCallId,

--- a/src/vs/platform/agentHost/node/localCommands/bangLocalCommand.ts
+++ b/src/vs/platform/agentHost/node/localCommands/bangLocalCommand.ts
@@ -1,0 +1,158 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
+import { localize } from '../../../../nls.js';
+import type { CreateTerminalParams } from '../../common/state/protocol/commands.js';
+import { TerminalClaimKind, type TerminalSessionClaim } from '../../common/state/protocol/state.js';
+import { ActionType } from '../../common/state/sessionActions.js';
+import { isAhpChatChannel, parseRequiredSessionUriFromChatUri, ToolCallConfirmationReason, ToolResultContentType, type ToolResultContent, type URI as ProtocolURI } from '../../common/state/sessionState.js';
+import { parseBangCommand } from '../agentHostBangCommand.js';
+import { DEFAULT_SHELL_COMMAND_TIMEOUT_MS, executeShellCommand, shellTypeForExecutable, type IShellCommandResult } from '../shared/shellCommandExecution.js';
+import { ILocalChatCommand, ILocalChatCommandContext, ILocalChatCommandRequest, LocalChatCommandRegistry } from './localChatCommand.js';
+
+/**
+ * The generic `!command` command: runs the message as a terminal command via
+ * the {@link IAgentHostTerminalManager} shell integration and surfaces it as a
+ * terminal tool call in the transcript, instead of forwarding it to the agent
+ * SDK. Runs immediately (the user typed it explicitly — no confirmation).
+ */
+export class BangLocalCommand extends Disposable implements ILocalChatCommand {
+
+	readonly name = 'bang';
+	readonly recordsLocalTurn = true;
+
+	/** Terminals kept alive for transcript output; disposed with this command. */
+	private readonly _terminals = new Set<string>();
+
+	constructor(private readonly _context: ILocalChatCommandContext) {
+		super();
+		this._register(toDisposable(() => {
+			for (const terminalUri of this._terminals) {
+				this._context.terminalManager.disposeTerminal(terminalUri);
+			}
+			this._terminals.clear();
+		}));
+	}
+
+	tryHandle(request: ILocalChatCommandRequest): (() => Promise<void>) | undefined {
+		const command = parseBangCommand(request.text);
+		if (command === undefined) {
+			return undefined;
+		}
+		return () => this._run(request.turnChannel, request.turnId, command);
+	}
+
+	private async _run(turnChannel: ProtocolURI, turnId: string, command: string): Promise<void> {
+		const ctx = this._context;
+		const sessionChannel = isAhpChatChannel(turnChannel) ? parseRequiredSessionUriFromChatUri(turnChannel) : turnChannel;
+		const toolCallId = generateUuid();
+		const terminalUri = `agenthost-terminal://bang/${generateUuid()}`;
+		const displayName = localize('agentHostBang.terminal', "Terminal");
+		let terminalCreated = false;
+		try {
+			const workingDirStr = ctx.getState(sessionChannel)?.workingDirectory;
+			const cwd = workingDirStr ? URI.parse(workingDirStr).fsPath : undefined;
+			const shellPath = await ctx.terminalManager.getDefaultShell();
+			const shellType = shellTypeForExecutable(shellPath);
+
+			// Surface the command as a tool call and transition it straight to
+			// running — the user typed it explicitly, so no confirmation.
+			ctx.dispatch(turnChannel, {
+				type: ActionType.ChatToolCallStart,
+				turnId,
+				toolCallId,
+				toolName: 'terminal',
+				displayName,
+				intention: command,
+			});
+			ctx.dispatch(turnChannel, {
+				type: ActionType.ChatToolCallReady,
+				turnId,
+				toolCallId,
+				invocationMessage: command,
+				toolInput: command,
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+			});
+
+			const claim: TerminalSessionClaim = {
+				kind: TerminalClaimKind.Session,
+				session: sessionChannel,
+				turnId,
+				toolCallId,
+			};
+			const params: CreateTerminalParams = { channel: terminalUri, claim, name: displayName, cwd };
+			await ctx.terminalManager.createTerminal(params, { shell: shellPath, preventShellHistory: true, nonInteractive: true });
+			terminalCreated = true;
+			this._terminals.add(terminalUri);
+
+			// Reference the terminal so the client can stream live output while
+			// the command runs.
+			const terminalContent: ToolResultContent = { type: ToolResultContentType.Terminal, resource: terminalUri, title: displayName };
+			ctx.dispatch(turnChannel, {
+				type: ActionType.ChatToolCallContentChanged,
+				turnId,
+				toolCallId,
+				content: [terminalContent],
+			});
+
+			const result = await executeShellCommand({ terminalUri, shellType }, command, DEFAULT_SHELL_COMMAND_TIMEOUT_MS, ctx.terminalManager, ctx.logService);
+			const { success, pastTenseMessage } = this._summarizeResult(result);
+			const content: ToolResultContent[] = [terminalContent];
+			if (result.output) {
+				content.push({ type: ToolResultContentType.Text, text: result.output });
+			}
+			ctx.dispatch(turnChannel, {
+				type: ActionType.ChatToolCallComplete,
+				turnId,
+				toolCallId,
+				result: { success, pastTenseMessage, content },
+			});
+		} catch (err) {
+			ctx.logService.error(`[BangLocalCommand] Command failed for session=${sessionChannel}: ${err instanceof Error ? err.message : String(err)}`, err);
+			if (terminalCreated) {
+				ctx.terminalManager.disposeTerminal(terminalUri);
+				this._terminals.delete(terminalUri);
+			}
+			ctx.dispatch(turnChannel, {
+				type: ActionType.ChatToolCallComplete,
+				turnId,
+				toolCallId,
+				result: {
+					success: false,
+					pastTenseMessage: localize('agentHostBang.failed', "Failed to run command"),
+					error: { message: err instanceof Error ? err.message : String(err) },
+				},
+			});
+		}
+	}
+
+	/**
+	 * Maps a shell command result to a success flag and past-tense summary for
+	 * the completed tool call.
+	 */
+	private _summarizeResult(result: IShellCommandResult): { success: boolean; pastTenseMessage: string } {
+		switch (result.status) {
+			case 'completed': {
+				const exitCode = result.exitCode ?? 0;
+				return exitCode === 0
+					? { success: true, pastTenseMessage: localize('agentHostBang.ran', "Ran command") }
+					: { success: false, pastTenseMessage: localize('agentHostBang.exited', "Command exited with code {0}", exitCode) };
+			}
+			case 'timeout':
+				return { success: false, pastTenseMessage: localize('agentHostBang.timedOut', "Command timed out") };
+			case 'shellExited':
+				return { success: false, pastTenseMessage: localize('agentHostBang.shellExited', "Shell exited unexpectedly") };
+			case 'background':
+				return { success: true, pastTenseMessage: localize('agentHostBang.background', "Command is running in the background") };
+			case 'altBuffer':
+				return { success: true, pastTenseMessage: localize('agentHostBang.interactive', "Command opened an interactive terminal") };
+		}
+	}
+}
+
+LocalChatCommandRegistry.register(BangLocalCommand);

--- a/src/vs/platform/agentHost/node/localCommands/localChatCommand.ts
+++ b/src/vs/platform/agentHost/node/localCommands/localChatCommand.ts
@@ -1,0 +1,228 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
+import { ILogService } from '../../../log/common/log.js';
+import { ISessionDataService } from '../../common/sessionDataService.js';
+import { ActionType, StateAction } from '../../common/state/sessionActions.js';
+import { isAhpChatChannel, parseRequiredSessionUriFromChatUri, ResponsePartKind, ToolCallStatus, ToolResultContentType, type ISessionWithDefaultChat, type Turn, type URI as ProtocolURI } from '../../common/state/sessionState.js';
+import { AgentHostLocalTurns } from '../agentHostLocalTurns.js';
+import { IAgentHostTerminalManager } from '../agentHostTerminalManager.js';
+import { AgentHostStateManager } from '../agentHostStateManager.js';
+import { persistSessionMetadata } from '../shared/persistSessionMetadata.js';
+
+/**
+ * A just-started chat turn offered to the local-command dispatcher before it is
+ * forwarded to the agent SDK.
+ */
+export interface ILocalChatCommandRequest {
+	/** The chat channel the turn was started on (default or peer chat). */
+	readonly turnChannel: ProtocolURI;
+	/** The turn identifier opened by the reducer for this message. */
+	readonly turnId: string;
+	/** The raw user message text. */
+	readonly text: string;
+}
+
+/**
+ * The narrow set of agent-host capabilities a {@link ILocalChatCommand} may use
+ * to fulfil a request. Keeps commands decoupled from `AgentSideEffects`
+ * internals — they emit response content by dispatching server actions and read
+ * conversation state, plus the few extra capabilities specific commands need
+ * (terminal execution, chat rename/persist).
+ */
+export interface ILocalChatCommandContext {
+	readonly logService: ILogService;
+	readonly terminalManager: IAgentHostTerminalManager;
+	/** Dispatch a server-originated action on a channel. */
+	dispatch(channel: ProtocolURI, action: StateAction): void;
+	/** Read the merged session/chat state for a session or chat channel. */
+	getState(channel: ProtocolURI): ISessionWithDefaultChat | undefined;
+	/** Rename a single chat (independently of the session title). */
+	updateChatTitle(session: ProtocolURI, chat: ProtocolURI, title: string): void;
+	/** Persist a session-metadata key/value pair (e.g. a custom title). */
+	persistSessionFlag(session: ProtocolURI, key: string, value: string): void;
+}
+
+/**
+ * A generic, agent-agnostic chat command handled entirely by the agent host
+ * (never forwarded to the agent SDK) — for example `/rename` or `!command`.
+ *
+ * A command decides synchronously whether it applies (so the caller knows
+ * immediately not to forward the message), then performs its work — emitting
+ * response parts/tool calls via {@link ILocalChatCommandContext}. The
+ * {@link AgentHostLocalCommands} dispatcher owns the common tail: completing the
+ * turn, optionally persisting it as a local turn (so it survives reload and
+ * anchors fork/truncate), and draining the message queue.
+ */
+export interface ILocalChatCommand extends IDisposable {
+	/** Stable identifier for logging/telemetry. */
+	readonly name: string;
+	/**
+	 * Whether the completed turn should be persisted as a host-injected local
+	 * turn (survives reload; anchors fork/truncate to the preceding concrete
+	 * turn). Most user-visible commands want `true`.
+	 */
+	readonly recordsLocalTurn: boolean;
+	/**
+	 * Synchronously decide whether this command handles `request`. Returns a
+	 * thunk that performs the (possibly async) work when it does, or `undefined`
+	 * to decline so the dispatcher tries the next command (and ultimately
+	 * forwards the message to the agent).
+	 */
+	tryHandle(request: ILocalChatCommandRequest): (() => Promise<void>) | undefined;
+}
+
+/** Constructs a {@link ILocalChatCommand} bound to a context. */
+export interface ILocalChatCommandCtor {
+	new(context: ILocalChatCommandContext): ILocalChatCommand;
+}
+
+/**
+ * Global registry of {@link ILocalChatCommand} constructors. Command modules
+ * register themselves at load time; {@link AgentHostLocalCommands} instantiates
+ * all registered commands per session-effects instance with its context.
+ */
+class LocalChatCommandRegistryImpl {
+	private readonly _ctors: ILocalChatCommandCtor[] = [];
+
+	register(ctor: ILocalChatCommandCtor): void {
+		this._ctors.push(ctor);
+	}
+
+	createAll(context: ILocalChatCommandContext): ILocalChatCommand[] {
+		return this._ctors.map(ctor => new ctor(context));
+	}
+}
+
+export const LocalChatCommandRegistry = new LocalChatCommandRegistryImpl();
+
+/**
+ * Dispatches just-started turns to the registered {@link ILocalChatCommand}s
+ * and owns everything a host-handled command needs end-to-end: it builds the
+ * {@link ILocalChatCommandContext} from the state manager and injected services,
+ * runs the first accepting command, then performs the common tail — completing
+ * the turn, persisting it as a local turn (so it survives reload and anchors
+ * fork/truncate), and asking the owner to drain the message queue.
+ */
+export class AgentHostLocalCommands extends Disposable {
+
+	private readonly _commands: readonly ILocalChatCommand[];
+
+	constructor(
+		private readonly _stateManager: AgentHostStateManager,
+		private readonly _localTurns: AgentHostLocalTurns,
+		/**
+		 * Invoked after a handled turn is completed so the owner can start the
+		 * next queued message. Draining re-enters the agent-send pipeline, which
+		 * is the owner's concern — not the dispatcher's.
+		 */
+		private readonly _notifyTurnConsumable: (turnChannel: ProtocolURI) => void,
+		@ILogService private readonly _logService: ILogService,
+		@IAgentHostTerminalManager private readonly _terminalManager: IAgentHostTerminalManager,
+		@ISessionDataService private readonly _sessionDataService: ISessionDataService,
+	) {
+		super();
+		const context: ILocalChatCommandContext = {
+			logService: this._logService,
+			terminalManager: this._terminalManager,
+			dispatch: (channel, action) => this._stateManager.dispatchServerAction(channel, action),
+			getState: channel => this._stateManager.getSessionState(channel),
+			updateChatTitle: (session, chat, title) => this._stateManager.updateChatTitle(session, chat, title),
+			persistSessionFlag: (session, key, value) => persistSessionMetadata(this._sessionDataService, this._logService, session, key, value),
+		};
+		this._commands = LocalChatCommandRegistry.createAll(context).map(command => this._register(command));
+	}
+
+	/**
+	 * Offers `request` to each command. Returns `true` when one handled it (the
+	 * caller MUST NOT forward the message to the agent), `false` otherwise.
+	 */
+	tryHandle(request: ILocalChatCommandRequest): boolean {
+		for (const command of this._commands) {
+			const work = command.tryHandle(request);
+			if (work) {
+				void this._run(command, work, request);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private async _run(command: ILocalChatCommand, work: () => Promise<void>, request: ILocalChatCommandRequest): Promise<void> {
+		try {
+			await work();
+		} catch (err) {
+			this._logService.error(`[AgentHostLocalCommands] Command '${command.name}' failed: ${err instanceof Error ? err.message : String(err)}`, err);
+		} finally {
+			// Common tail for every host-handled command: close out the turn the
+			// reducer opened, optionally persist it as a local turn (so it
+			// survives reload and anchors fork/truncate), then let the owner
+			// drain any messages queued behind it.
+			this._stateManager.dispatchServerAction(request.turnChannel, { type: ActionType.ChatTurnComplete, turnId: request.turnId });
+			if (command.recordsLocalTurn) {
+				this._recordLocalTurn(request.turnChannel, request.turnId);
+			}
+			this._notifyTurnConsumable(request.turnChannel);
+		}
+	}
+
+	/**
+	 * Records the just-completed turn `turnId` as a host-injected local turn so
+	 * it survives reload and fork/truncate can resolve it to the preceding
+	 * concrete turn. Works uniformly for the default chat and any peer chat —
+	 * the turn is keyed by its chat channel. Live terminal references are
+	 * stripped from the payload (the PTY does not survive a reload).
+	 */
+	private _recordLocalTurn(turnChannel: ProtocolURI, turnId: string): void {
+		const chat = turnChannel;
+		const session = isAhpChatChannel(turnChannel) ? parseRequiredSessionUriFromChatUri(turnChannel) : turnChannel;
+		const turns = this._stateManager.getSessionState(turnChannel)?.turns;
+		if (!turns) {
+			return;
+		}
+		const index = turns.findIndex(t => t.id === turnId);
+		if (index < 0) {
+			return;
+		}
+		// Anchor = the nearest preceding turn in this chat that is not itself a
+		// local turn.
+		let anchorTurnId: string | undefined;
+		for (let i = index - 1; i >= 0; i--) {
+			if (!this._localTurns.isLocal(chat, turns[i].id)) {
+				anchorTurnId = turns[i].id;
+				break;
+			}
+		}
+		this._localTurns.record(session, chat, sanitizeLocalTurnForPersistence(turns[index]), anchorTurnId);
+	}
+}
+
+/**
+ * Prepares a host-injected local turn for persistence by dropping live
+ * {@link ToolResultContentType.Terminal} references from its tool calls — the
+ * PTY does not survive a reload, so only the captured output (text) is kept.
+ */
+function sanitizeLocalTurnForPersistence(turn: Turn): Turn {
+	const responseParts = turn.responseParts.map(part => {
+		if (part.kind !== ResponsePartKind.ToolCall) {
+			return part;
+		}
+		const tc = part.toolCall;
+		// Only these tool-call states carry `content` (a live terminal ref lives here).
+		if (tc.status !== ToolCallStatus.Running && tc.status !== ToolCallStatus.Completed && tc.status !== ToolCallStatus.PendingResultConfirmation) {
+			return part;
+		}
+		if (!tc.content) {
+			return part;
+		}
+		const content = tc.content.filter(c => c.type !== ToolResultContentType.Terminal);
+		if (content.length === tc.content.length) {
+			return part;
+		}
+		return { ...part, toolCall: { ...tc, content } };
+	});
+	return { ...turn, responseParts };
+}

--- a/src/vs/platform/agentHost/node/localCommands/localChatCommands.contribution.ts
+++ b/src/vs/platform/agentHost/node/localCommands/localChatCommands.contribution.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Importing this module registers all built-in local chat commands with the
+// LocalChatCommandRegistry (via each command module's bottom-of-file
+// `register(...)` side effect). Import it wherever the registry must be
+// populated (e.g. AgentSideEffects) so adding a new command is just a new file
+// plus an import here.
+import './renameLocalCommand.js';
+import './bangLocalCommand.js';

--- a/src/vs/platform/agentHost/node/localCommands/renameLocalCommand.ts
+++ b/src/vs/platform/agentHost/node/localCommands/renameLocalCommand.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
+import { localize } from '../../../../nls.js';
+import { ActionType } from '../../common/state/sessionActions.js';
+import { isAhpChatChannel, isDefaultChatUri, parseRequiredSessionUriFromChatUri, ResponsePartKind, type URI as ProtocolURI } from '../../common/state/sessionState.js';
+import { parseRenameCommand } from '../agentHostRenameCommand.js';
+import { ILocalChatCommand, ILocalChatCommandContext, ILocalChatCommandRequest, LocalChatCommandRegistry } from './localChatCommand.js';
+
+/**
+ * The generic `/rename [title]` command: renames the session (or an individual
+ * peer chat) instead of forwarding the message to the agent SDK. Intercepted
+ * for every agent-host session type.
+ */
+export class RenameLocalCommand extends Disposable implements ILocalChatCommand {
+
+	readonly name = 'rename';
+	readonly recordsLocalTurn = true;
+
+	constructor(private readonly _context: ILocalChatCommandContext) {
+		super();
+	}
+
+	tryHandle(request: ILocalChatCommandRequest): (() => Promise<void>) | undefined {
+		const title = parseRenameCommand(request.text);
+		if (title === undefined) {
+			return undefined;
+		}
+		return async () => this._run(request.turnChannel, request.turnId, title);
+	}
+
+	private _run(channel: ProtocolURI, turnId: string, title: string): void {
+		if (title.length === 0) {
+			// `/rename` with no title: nothing to change; the dispatcher still
+			// completes the turn.
+			return;
+		}
+		const isAdditional = (uri: ProtocolURI): boolean => isAhpChatChannel(uri) && !isDefaultChatUri(uri);
+		const chatTarget = isAdditional(channel) ? channel : undefined;
+		const sessionChannel = isAhpChatChannel(channel) ? parseRequiredSessionUriFromChatUri(channel) : channel;
+		if (chatTarget) {
+			// Rename only this chat, independently of the session title.
+			this._context.updateChatTitle(sessionChannel, chatTarget, title);
+			this._context.persistSessionFlag(sessionChannel, `customChatTitle:${chatTarget}`, title);
+		} else {
+			this._context.dispatch(sessionChannel, { type: ActionType.SessionTitleChanged, title });
+			// Server-dispatched actions bypass `handleAction`, so persist the
+			// new title here directly (the client-dispatched rename path relies
+			// on the `SessionTitleChanged` case in `handleAction` instead).
+			this._context.persistSessionFlag(sessionChannel, 'customTitle', title);
+		}
+		// Acknowledge the rename with a brief response so the turn has visible
+		// content in the transcript.
+		this._context.dispatch(channel, {
+			type: ActionType.ChatResponsePart,
+			turnId,
+			part: {
+				kind: ResponsePartKind.Markdown,
+				id: generateUuid(),
+				content: localize('agentHostRename.renamed', "Renamed: {0}", title),
+			},
+		});
+	}
+}
+
+LocalChatCommandRegistry.register(RenameLocalCommand);

--- a/src/vs/platform/agentHost/node/sessionDataService.ts
+++ b/src/vs/platform/agentHost/node/sessionDataService.ts
@@ -71,7 +71,7 @@ export class SessionDataService implements ISessionDataService {
 	}
 
 	getSessionDataDir(session: URI): URI {
-		return this.getSessionDataDirById(AgentSession.id(session));
+		return URI.joinPath(this._basePath, this._sanitizedSessionKey(session));
 	}
 
 	getSessionDataDirById(sessionId: string): URI {
@@ -80,7 +80,21 @@ export class SessionDataService implements ISessionDataService {
 	}
 
 	private _sanitizedSessionKey(session: URI): string {
-		return AgentSession.id(session).replace(/[^a-zA-Z0-9_.-]/g, '-');
+		return this._dataKey(session).replace(/[^a-zA-Z0-9_.-]/g, '-');
+	}
+
+	/**
+	 * Derives the per-URI storage key. Chat channel URIs
+	 * (`ahp-chat://<chatId>/<base64(session)>`) carry the chat id in the
+	 * authority while encoding the SAME owning-session URI in the path, so
+	 * keying only by the path (via {@link AgentSession.id}) would collapse
+	 * every peer chat of a session onto one data directory and database.
+	 * Prefixing with the authority gives each chat its own storage while
+	 * leaving plain session URIs (no authority) unchanged.
+	 */
+	private _dataKey(uri: URI): string {
+		const id = AgentSession.id(uri);
+		return uri.authority ? `${uri.authority}-${id}` : id;
 	}
 
 	openDatabase(session: URI): IReference<ISessionDatabase> {

--- a/src/vs/platform/agentHost/node/sessionDatabase.ts
+++ b/src/vs/platform/agentHost/node/sessionDatabase.ts
@@ -6,7 +6,7 @@
 import * as fs from 'fs';
 import { SequencerByKey } from '../../../base/common/async.js';
 import type { Database, RunResult } from '@vscode/sqlite3';
-import type { IFileEditContent, IFileEditRecord, IReviewedFileRecord, ISessionDatabase } from '../common/sessionDataService.js';
+import type { IFileEditContent, IFileEditRecord, ILocalTurnRecord, IReviewedFileRecord, ISessionDatabase } from '../common/sessionDataService.js';
 import { dirname } from '../../../base/common/path.js';
 import { URI } from '../../../base/common/uri.js';
 import type { Message } from '../common/state/sessionState.js';
@@ -100,6 +100,16 @@ export const sessionDatabaseMigrations: readonly ISessionDatabaseMigration[] = [
 			uri   TEXT NOT NULL,
 			nonce TEXT NOT NULL,
 			PRIMARY KEY (uri, nonce)
+		)`,
+	},
+	{
+		version: 8,
+		sql: `CREATE TABLE IF NOT EXISTS local_turns (
+			turn_id        TEXT PRIMARY KEY NOT NULL,
+			chat_uri       TEXT NOT NULL,
+			anchor_turn_id TEXT,
+			seq            INTEGER NOT NULL,
+			payload        TEXT NOT NULL
 		)`,
 	},
 ];
@@ -418,6 +428,41 @@ export class SessionDatabase implements ISessionDatabase {
 		});
 	}
 
+	// ---- Local (host-injected) turns ------------------------------------
+
+	insertLocalTurn(record: ILocalTurnRecord): Promise<void> {
+		return this._track(async () => {
+			const db = await this._ensureDb();
+			await dbRun(db,
+				'INSERT OR REPLACE INTO local_turns (turn_id, chat_uri, anchor_turn_id, seq, payload) VALUES (?, ?, ?, ?, ?)',
+				[record.turnId, record.chatUri, record.anchorTurnId ?? null, record.seq, record.payload],
+			);
+		});
+	}
+
+	async getLocalTurns(): Promise<ILocalTurnRecord[]> {
+		const db = await this._ensureDb();
+		const rows = await dbAll(db, 'SELECT turn_id, chat_uri, anchor_turn_id, seq, payload FROM local_turns ORDER BY seq', []);
+		return rows.map(r => ({
+			turnId: r.turn_id as string,
+			chatUri: r.chat_uri as string,
+			anchorTurnId: (r.anchor_turn_id as string | null) ?? undefined,
+			seq: r.seq as number,
+			payload: r.payload as string,
+		}));
+	}
+
+	deleteLocalTurns(turnIds: readonly string[]): Promise<void> {
+		return this._track(async () => {
+			if (turnIds.length === 0) {
+				return;
+			}
+			const db = await this._ensureDb();
+			const placeholders = turnIds.map(() => '?').join(',');
+			await dbRun(db, `DELETE FROM local_turns WHERE turn_id IN (${placeholders})`, [...turnIds]);
+		});
+	}
+
 	// ---- File edits -----------------------------------------------------
 
 	storeFileEdit(edit: IFileEditRecord & IFileEditContent): Promise<void> {
@@ -649,6 +694,18 @@ export class SessionDatabase implements ISessionDatabase {
 				for (const [oldId, newId] of mapping) {
 					await dbRun(db, 'UPDATE turns SET id = ? WHERE id = ?', [newId, oldId]);
 					await dbRun(db, 'UPDATE file_edits SET turn_id = ? WHERE turn_id = ?', [newId, oldId]);
+				}
+
+				if (oldIds.length > 0) {
+					const placeholders = oldIds.map(() => '?').join(',');
+					await dbRun(db,
+						`DELETE FROM local_turns WHERE turn_id NOT IN (${placeholders})`,
+						oldIds,
+					);
+				}
+				for (const [oldId, newId] of mapping) {
+					await dbRun(db, 'UPDATE local_turns SET turn_id = ? WHERE turn_id = ?', [newId, oldId]);
+					await dbRun(db, 'UPDATE local_turns SET anchor_turn_id = ? WHERE anchor_turn_id = ?', [newId, oldId]);
 				}
 				await dbExec(db, 'COMMIT');
 			} catch (err) {

--- a/src/vs/platform/agentHost/node/shared/persistSessionMetadata.ts
+++ b/src/vs/platform/agentHost/node/shared/persistSessionMetadata.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../../base/common/uri.js';
+import { ILogService } from '../../../log/common/log.js';
+import type { ISessionDataService } from '../../common/sessionDataService.js';
+
+/**
+ * Fire-and-forget persistence of a single session-metadata key/value pair to a
+ * session's database. Opens the database, writes the value, and disposes the
+ * handle; failures are logged, not thrown.
+ *
+ * Used for host-owned fields that must survive restart (custom titles, isRead /
+ * isArchived flags, merged config values, …). Shared so callers do not each
+ * re-implement the open/write/dispose dance.
+ */
+export function persistSessionMetadata(sessionDataService: ISessionDataService, logService: ILogService, session: string, key: string, value: string): void {
+	const ref = sessionDataService.openDatabase(URI.parse(session));
+	ref.object.setMetadata(key, value).catch(err => {
+		logService.warn(`[AgentHost] Failed to persist session metadata '${key}'`, err);
+	}).finally(() => {
+		ref.dispose();
+	});
+}

--- a/src/vs/platform/agentHost/node/shared/shellCommandExecution.ts
+++ b/src/vs/platform/agentHost/node/shared/shellCommandExecution.ts
@@ -1,0 +1,372 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
+import * as platform from '../../../../base/common/platform.js';
+import { removeAnsiEscapeCodes } from '../../../../base/common/strings.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
+import { ILogService } from '../../../log/common/log.js';
+import { TerminalClaimKind } from '../../common/state/protocol/state.js';
+import { IAgentHostTerminalManager } from '../agentHostTerminalManager.js';
+
+/**
+ * Maximum scrollback content (in bytes) returned to the model / caller in
+ * command results.
+ */
+export const SHELL_COMMAND_MAX_OUTPUT_BYTES = 80_000;
+
+/**
+ * Default command timeout in milliseconds (120 seconds).
+ */
+export const DEFAULT_SHELL_COMMAND_TIMEOUT_MS = 120_000;
+
+/**
+ * The sentinel prefix used to detect command completion in terminal output
+ * when shell integration is unavailable. The full sentinel format is:
+ * `<<<COPILOT_SENTINEL_<uuid>_EXIT_<code>>>`.
+ */
+const SENTINEL_PREFIX = '<<<COPILOT_SENTINEL_';
+
+/**
+ * The kind of shell a command runs in. Determines sentinel syntax, history
+ * suppression and bracketed-paste heuristics.
+ */
+export type ShellType = 'bash' | 'powershell';
+
+/**
+ * Routes a resolved shell executable to a {@link ShellType}. Falls back to the
+ * platform default for unknown shells.
+ */
+export function shellTypeForExecutable(shellPath: string): ShellType {
+	// Strip path on either separator and the .exe suffix.
+	const lastSep = Math.max(shellPath.lastIndexOf('/'), shellPath.lastIndexOf('\\'));
+	const base = shellPath.slice(lastSep + 1).toLowerCase().replace(/\.exe$/, '');
+	switch (base) {
+		// PowerShell
+		case 'pwsh':
+		case 'powershell':
+		case 'pwsh-preview':
+			return 'powershell';
+		// POSIX shells
+		case 'bash':
+		case 'sh':
+		case 'zsh':
+		case 'fish':
+		case 'csh':
+		case 'ksh':
+		case 'nu':
+		case 'xonsh':
+		// Git for Windows bash entry points
+		case 'git-cmd':
+		// WSL launchers — bash inside, but invoked via these stubs
+		case 'wsl':
+		case 'ubuntu':
+		case 'ubuntu1804':
+		case 'kali':
+		case 'debian':
+		case 'opensuse-42':
+		case 'sles-12':
+			return 'bash';
+		default:
+			return platform.isWindows ? 'powershell' : 'bash';
+	}
+}
+
+/**
+ * For POSIX shells (bash/zsh) that honor `HISTCONTROL=ignorespace` /
+ * `HIST_IGNORE_SPACE`, prepending a single space prevents the command from
+ * being recorded in shell history. The shell integration scripts opt these
+ * settings in via the `VSCODE_PREVENT_SHELL_HISTORY` env var (set when the
+ * terminal is created with `preventShellHistory: true`). PowerShell
+ * suppresses history through PSReadLine instead, so no prefix is needed.
+ */
+export function prefixForHistorySuppression(shellType: ShellType): string {
+	return shellType === 'powershell' ? '' : ' ';
+}
+
+export function isMultilineCommand(command: string): boolean {
+	const normalized = command.replace(/\r\n|\r/g, '\n');
+	return /(?<!\\)\n/.test(normalized);
+}
+
+function shouldUseBracketedPasteMode(command: string): boolean {
+	return platform.isMacintosh || isMultilineCommand(command);
+}
+
+function makeSentinelId(): string {
+	return generateUuid().replace(/-/g, '');
+}
+
+function buildSentinelCommand(sentinelId: string, shellType: ShellType): string {
+	if (shellType === 'powershell') {
+		return `Write-Output "${SENTINEL_PREFIX}${sentinelId}_EXIT_$LASTEXITCODE>>>"`;
+	}
+	return `echo "${SENTINEL_PREFIX}${sentinelId}_EXIT_$?>>>"`;
+}
+
+function parseSentinel(content: string, sentinelId: string): { found: boolean; exitCode: number; outputBeforeSentinel: string } {
+	const marker = `${SENTINEL_PREFIX}${sentinelId}_EXIT_`;
+	let markerIndex = content.lastIndexOf(marker);
+	while (markerIndex !== -1) {
+		const outputBeforeSentinel = content.substring(0, markerIndex);
+		const afterMarker = content.substring(markerIndex + marker.length);
+		const endIdx = afterMarker.indexOf('>>>');
+		if (endIdx !== -1) {
+			const exitCodeStr = afterMarker.substring(0, endIdx).trim();
+			if (/^-?\d+$/.test(exitCodeStr)) {
+				return {
+					found: true,
+					exitCode: parseInt(exitCodeStr, 10),
+					outputBeforeSentinel,
+				};
+			}
+		}
+		// Ignore echoed sentinel command text (for example `$?`) and continue
+		// scanning for the latest complete numeric sentinel marker.
+		markerIndex = content.lastIndexOf(marker, markerIndex - 1);
+	}
+
+	return { found: false, exitCode: -1, outputBeforeSentinel: content };
+}
+
+/**
+ * Strips ANSI escape codes and trims the terminal output to the last
+ * {@link SHELL_COMMAND_MAX_OUTPUT_BYTES} bytes so it is safe to surface to a
+ * model or the transcript.
+ */
+export function prepareOutputForModel(rawOutput: string): string {
+	let text = removeAnsiEscapeCodes(rawOutput).trim();
+	if (text.length > SHELL_COMMAND_MAX_OUTPUT_BYTES) {
+		text = text.substring(text.length - SHELL_COMMAND_MAX_OUTPUT_BYTES);
+	}
+	return text;
+}
+
+/**
+ * Terminal against which a shell command is executed.
+ */
+export interface IShellCommandTarget {
+	/** URI of the managed terminal the command runs in. */
+	readonly terminalUri: string;
+	/** The kind of shell backing the terminal. */
+	readonly shellType: ShellType;
+}
+
+/**
+ * How a shell command execution finished.
+ *
+ * - `completed` — the command finished; {@link IShellCommandResult.exitCode} holds the exit code.
+ * - `timeout` — the command did not finish within the timeout; output is partial.
+ * - `background` — the terminal claim was narrowed (user chose to continue in background).
+ * - `altBuffer` — the command switched to the terminal's alternate buffer (interactive UI).
+ * - `shellExited` — the shell process exited unexpectedly.
+ */
+export type ShellCommandStatus = 'completed' | 'timeout' | 'background' | 'altBuffer' | 'shellExited';
+
+/**
+ * Neutral, agent-agnostic result of executing a shell command. Callers map this
+ * to their own result shape (e.g. an SDK `ToolResultObject` or an AHP tool call
+ * completion).
+ */
+export interface IShellCommandResult {
+	/** How the command execution finished. */
+	readonly status: ShellCommandStatus;
+	/** Exit code, when known (`completed` and `shellExited`). */
+	readonly exitCode?: number;
+	/** Cleaned command output (empty for `background`/`altBuffer`). */
+	readonly output: string;
+}
+
+/**
+ * Execute a command on an already-created managed terminal, resolving once the
+ * command finishes, times out, backgrounds, enters the alternate buffer, or the
+ * shell exits. Uses shell integration (OSC 633) for completion detection when
+ * available and falls back to a sentinel echo otherwise.
+ *
+ * This is the shared shell-integration primitive used by both the Copilot SDK
+ * shell tools and the agent-host `!command` runner.
+ */
+export function executeShellCommand(
+	target: IShellCommandTarget,
+	command: string,
+	timeoutMs: number,
+	terminalManager: IAgentHostTerminalManager,
+	logService: ILogService,
+): Promise<IShellCommandResult> {
+	return terminalManager.supportsCommandDetection(target.terminalUri)
+		? executeCommandWithShellIntegration(target, command, timeoutMs, terminalManager, logService)
+		: executeCommandWithSentinel(target, command, timeoutMs, terminalManager, logService);
+}
+
+function registerAltBufferHandler(
+	target: IShellCommandTarget,
+	terminalManager: IAgentHostTerminalManager,
+	logService: ILogService,
+	disposables: DisposableStore,
+	finish: (result: IShellCommandResult) => void,
+): void {
+	void terminalManager.createAltBufferPromise(target.terminalUri, disposables).then(() => {
+		logService.info('[ShellCommand] Command entered alternate buffer');
+		finish({ status: 'altBuffer', output: '' });
+	});
+}
+
+/**
+ * Execute a command using shell integration (OSC 633) for completion detection.
+ * No sentinel echo is injected — the shell's own command-finished signal
+ * provides the exit code and cleanly delineated output.
+ */
+async function executeCommandWithShellIntegration(
+	target: IShellCommandTarget,
+	command: string,
+	timeoutMs: number,
+	terminalManager: IAgentHostTerminalManager,
+	logService: ILogService,
+): Promise<IShellCommandResult> {
+	const disposables = new DisposableStore();
+
+	const result = new Promise<IShellCommandResult>(resolve => {
+		let resolved = false;
+		const finish = (result: IShellCommandResult) => {
+			if (resolved) {
+				return;
+			}
+			resolved = true;
+			disposables.dispose();
+			resolve(result);
+		};
+
+		disposables.add(terminalManager.onCommandFinished(target.terminalUri, event => {
+			const output = prepareOutputForModel(event.output);
+			const exitCode = event.exitCode ?? 0;
+			logService.info(`[ShellCommand] Command completed (shell integration) with exit code ${exitCode}`);
+			finish({ status: 'completed', exitCode, output });
+		}));
+
+		registerAltBufferHandler(target, terminalManager, logService, disposables, finish);
+
+		disposables.add(terminalManager.onExit(target.terminalUri, (exitCode: number) => {
+			logService.info(`[ShellCommand] Shell exited unexpectedly with code ${exitCode}`);
+			const fullContent = terminalManager.getContent(target.terminalUri) ?? '';
+			finish({ status: 'shellExited', exitCode, output: prepareOutputForModel(fullContent) });
+		}));
+
+		disposables.add(terminalManager.onClaimChanged(target.terminalUri, (claim) => {
+			if (claim.kind === TerminalClaimKind.Session && !claim.toolCallId) {
+				logService.info(`[ShellCommand] Continuing in background (claim narrowed)`);
+				finish({ status: 'background', output: '' });
+			}
+		}));
+
+		const timer = setTimeout(() => {
+			logService.warn(`[ShellCommand] Command timed out after ${timeoutMs}ms`);
+			const fullContent = terminalManager.getContent(target.terminalUri) ?? '';
+			finish({ status: 'timeout', output: prepareOutputForModel(fullContent) });
+		}, timeoutMs);
+		disposables.add(toDisposable(() => clearTimeout(timer)));
+
+	});
+
+	try {
+		await terminalManager.sendText(target.terminalUri, `${prefixForHistorySuppression(target.shellType)}${command}`, {
+			shouldExecute: true,
+			bracketedPasteMode: shouldUseBracketedPasteMode(command),
+		});
+	} catch (err) {
+		disposables.dispose();
+		throw err;
+	}
+
+	return result;
+}
+
+/**
+ * Fallback: execute a command using a sentinel echo to detect completion.
+ * Used when shell integration is not available.
+ */
+async function executeCommandWithSentinel(
+	target: IShellCommandTarget,
+	command: string,
+	timeoutMs: number,
+	terminalManager: IAgentHostTerminalManager,
+	logService: ILogService,
+): Promise<IShellCommandResult> {
+	const sentinelId = makeSentinelId();
+	const sentinelCmd = buildSentinelCommand(sentinelId, target.shellType);
+	const disposables = new DisposableStore();
+
+	const contentBefore = terminalManager.getContent(target.terminalUri) ?? '';
+	const offsetBefore = contentBefore.length;
+
+	const result = new Promise<IShellCommandResult>(resolve => {
+		let resolved = false;
+		const finish = (result: IShellCommandResult) => {
+			if (resolved) {
+				return;
+			}
+			resolved = true;
+			disposables.dispose();
+			resolve(result);
+		};
+
+		const checkForSentinel = () => {
+			const fullContent = terminalManager.getContent(target.terminalUri) ?? '';
+			// Clamp offset: the terminal manager trims content when it exceeds
+			// 100k chars (slices to last 80k). If trimming happened after we
+			// captured offsetBefore, scan from the start of the current buffer.
+			const clampedOffset = Math.min(offsetBefore, fullContent.length);
+			const newContent = fullContent.substring(clampedOffset);
+			const parsed = parseSentinel(newContent, sentinelId);
+			if (parsed.found) {
+				const output = prepareOutputForModel(parsed.outputBeforeSentinel);
+				logService.info(`[ShellCommand] Command completed with exit code ${parsed.exitCode}`);
+				finish({ status: 'completed', exitCode: parsed.exitCode, output });
+			}
+		};
+
+		disposables.add(terminalManager.onData(target.terminalUri, () => {
+			checkForSentinel();
+		}));
+
+		registerAltBufferHandler(target, terminalManager, logService, disposables, finish);
+
+		disposables.add(terminalManager.onExit(target.terminalUri, (exitCode: number) => {
+			logService.info(`[ShellCommand] Shell exited unexpectedly with code ${exitCode}`);
+			const fullContent = terminalManager.getContent(target.terminalUri) ?? '';
+			const newContent = fullContent.substring(offsetBefore);
+			finish({ status: 'shellExited', exitCode, output: prepareOutputForModel(newContent) });
+		}));
+
+		disposables.add(terminalManager.onClaimChanged(target.terminalUri, (claim) => {
+			if (claim.kind === TerminalClaimKind.Session && !claim.toolCallId) {
+				logService.info(`[ShellCommand] Continuing in background (claim narrowed)`);
+				finish({ status: 'background', output: '' });
+			}
+		}));
+
+		const timer = setTimeout(() => {
+			logService.warn(`[ShellCommand] Command timed out after ${timeoutMs}ms`);
+			const fullContent = terminalManager.getContent(target.terminalUri) ?? '';
+			const newContent = fullContent.substring(offsetBefore);
+			finish({ status: 'timeout', output: prepareOutputForModel(newContent) });
+		}, timeoutMs);
+		disposables.add(toDisposable(() => clearTimeout(timer)));
+
+		checkForSentinel();
+	});
+
+	try {
+		await terminalManager.sendText(target.terminalUri, `${prefixForHistorySuppression(target.shellType)}${command}`, {
+			shouldExecute: true,
+			bracketedPasteMode: shouldUseBracketedPasteMode(command),
+		});
+		await terminalManager.sendText(target.terminalUri, sentinelCmd, { shouldExecute: true });
+	} catch (err) {
+		disposables.dispose();
+		throw err;
+	}
+
+	return result;
+}

--- a/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
@@ -8,7 +8,7 @@ import { Schemas } from '../../../../base/common/network.js';
 import { URI } from '../../../../base/common/uri.js';
 import { Event } from '../../../../base/common/event.js';
 import type { IDiffComputeService, IDiffCountResult } from '../../common/diffComputeService.js';
-import type { IFileEditContent, IFileEditRecord, IReviewedFileRecord, ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
+import type { IFileEditContent, IFileEditRecord, ILocalTurnRecord, IReviewedFileRecord, ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
 import type { Message } from '../../common/state/sessionState.js';
 
 export class TestSessionDatabase implements ISessionDatabase {
@@ -16,6 +16,7 @@ export class TestSessionDatabase implements ISessionDatabase {
 	private readonly _metadata = new Map<string, string>();
 	private readonly _drafts = new Map<string, Message>();
 	private readonly _reviewedFiles: IReviewedFileRecord[] = [];
+	private readonly _localTurns = new Map<string, ILocalTurnRecord>();
 
 	getAllFileEditsCalls = 0;
 	getFileEditsByTurnCalls = 0;
@@ -114,6 +115,19 @@ export class TestSessionDatabase implements ISessionDatabase {
 		this._edits.length = 0;
 	}
 
+	async insertLocalTurn(record: ILocalTurnRecord): Promise<void> {
+		this._localTurns.set(record.turnId, record);
+	}
+
+	async getLocalTurns(): Promise<ILocalTurnRecord[]> {
+		return [...this._localTurns.values()].sort((a, b) => a.seq - b.seq);
+	}
+
+	async deleteLocalTurns(turnIds: readonly string[]): Promise<void> {
+		for (const id of turnIds) {
+			this._localTurns.delete(id);
+		}
+	}
 	async remapTurnIds(_mapping: ReadonlyMap<string, string>): Promise<void> { }
 
 	async markFileReviewed(uri: URI, nonce: string): Promise<void> {

--- a/src/vs/platform/agentHost/test/node/agentHostBangCommand.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostBangCommand.test.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { parseBangCommand } from '../../node/agentHostBangCommand.js';
+
+suite('agentHostBangCommand', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('parses a leading ! command', () => {
+		assert.strictEqual(parseBangCommand('!echo hi'), 'echo hi');
+		assert.strictEqual(parseBangCommand('!ls -la'), 'ls -la');
+		assert.strictEqual(parseBangCommand('!  npm test  '), 'npm test');
+	});
+
+	test('is undefined for non-bang messages', () => {
+		assert.strictEqual(parseBangCommand('echo hi'), undefined);
+		assert.strictEqual(parseBangCommand(' !echo hi'), undefined);
+		assert.strictEqual(parseBangCommand('run !echo'), undefined);
+	});
+
+	test('is undefined for a lone ! or whitespace-only command', () => {
+		assert.strictEqual(parseBangCommand('!'), undefined);
+		assert.strictEqual(parseBangCommand('!   '), undefined);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentHostLocalTurns.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostLocalTurns.test.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { NullLogService } from '../../../log/common/log.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { MessageKind, TurnState, type Turn } from '../../common/state/sessionState.js';
+import { AgentHostLocalTurns } from '../../node/agentHostLocalTurns.js';
+import { TestSessionDatabase, createSessionDataService } from '../common/sessionTestHelpers.js';
+
+suite('AgentHostLocalTurns', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const session = 'mock:/session-1';
+
+	function turn(id: string): Turn {
+		return { id, message: { text: id, origin: { kind: MessageKind.User } }, responseParts: [], usage: undefined, state: TurnState.Complete };
+	}
+
+	test('records, resolves anchors, persists, and deletes local turns', async () => {
+		const db = new TestSessionDatabase();
+		const registry = new AgentHostLocalTurns(createSessionDataService(db), new NullLogService());
+		const chat = 'ahp-chat://default/xyz';
+
+		// Two locals: one anchored to a real turn, one anchored before any real turn.
+		registry.record(session, chat, turn('local-a'), 'real-1');
+		registry.record(session, chat, turn('local-b'), undefined);
+
+		assert.strictEqual(registry.isLocal(chat, 'local-a'), true);
+		assert.strictEqual(registry.isLocal(chat, 'real-1'), false);
+		// Local resolves to its concrete anchor; a concrete turn resolves to itself.
+		assert.strictEqual(registry.resolveConcreteTurnId(chat, 'local-a'), 'real-1');
+		assert.strictEqual(registry.resolveConcreteTurnId(chat, 'local-b'), undefined);
+		assert.strictEqual(registry.resolveConcreteTurnId(chat, 'real-1'), 'real-1');
+		assert.deepStrictEqual(new Set(registry.getLocalTurnIds(chat)), new Set(['local-a', 'local-b']));
+
+		// Persisted to the database with the chat discriminator.
+		const persisted = await db.getLocalTurns();
+		assert.deepStrictEqual(persisted.map(r => ({ turnId: r.turnId, chatUri: r.chatUri, anchorTurnId: r.anchorTurnId })), [
+			{ turnId: 'local-a', chatUri: chat, anchorTurnId: 'real-1' },
+			{ turnId: 'local-b', chatUri: chat, anchorTurnId: undefined },
+		]);
+
+		// Delete removes from memory and the database.
+		registry.deleteLocals(session, ['local-a']);
+		assert.strictEqual(registry.isLocal(chat, 'local-a'), false);
+		assert.deepStrictEqual((await db.getLocalTurns()).map(r => r.turnId), ['local-b']);
+	});
+
+	test('load re-populates the in-memory index from the database, scoped per chat', async () => {
+		const db = new TestSessionDatabase();
+		const chatA = 'ahp-chat://default/a';
+		const chatB = 'ahp-chat://peer/b';
+		await db.insertLocalTurn({ turnId: 'local-x', chatUri: chatA, anchorTurnId: 'real-9', seq: 3, payload: JSON.stringify(turn('local-x')) });
+		await db.insertLocalTurn({ turnId: 'local-y', chatUri: chatB, anchorTurnId: undefined, seq: 4, payload: JSON.stringify(turn('local-y')) });
+
+		const registry = new AgentHostLocalTurns(createSessionDataService(db), new NullLogService());
+		const recordsA = await registry.loadForChat(session, chatA);
+
+		// loadForChat returns only the requested chat's records...
+		assert.deepStrictEqual(recordsA.map(r => r.turnId), ['local-x']);
+		// ...but the in-memory index is populated for every chat in the session.
+		assert.strictEqual(registry.isLocal(chatA, 'local-x'), true);
+		assert.strictEqual(registry.resolveConcreteTurnId(chatA, 'local-x'), 'real-9');
+		assert.strictEqual(registry.isLocal(chatB, 'local-y'), true);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentHostToolCallTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostToolCallTelemetry.test.ts
@@ -16,13 +16,17 @@ import { AgentSession, IAgent } from '../../common/agentService.js';
 import { ActionType, type ChatAction } from '../../common/state/sessionActions.js';
 import { buildDefaultChatUri, MessageKind, SessionStatus, ToolCallContributorKind, type ToolCallContributor, type ToolCallResult } from '../../common/state/sessionState.js';
 import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
+import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
+import { AgentHostLocalTurns } from '../../node/agentHostLocalTurns.js';
 import { AgentHostTelemetryService } from '../../node/agentHostTelemetryService.js';
 import { AgentConfigurationService, IAgentConfigurationService } from '../../node/agentConfigurationService.js';
 import { IAgentHostChangesetService } from '../../common/agentHostChangesetService.js';
 import { AgentSideEffects } from '../../node/agentSideEffects.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 import { createNullSessionDataService } from '../common/sessionTestHelpers.js';
+import { ISessionDataService } from '../../common/sessionDataService.js';
 import { MockAgent } from './mockAgent.js';
+import { TestAgentHostTerminalManager } from './testAgentHostTerminalManager.js';
 
 class FakeChangesetService implements IAgentHostChangesetService {
 	declare readonly _serviceBrand: undefined;
@@ -145,17 +149,21 @@ suite('AgentSideEffects — tool call telemetry', () => {
 		const logService = new NullLogService();
 		const configService = disposables.add(new AgentConfigurationService(stateManager, logService));
 		const telemetryService = disposables.add(new AgentHostTelemetryService(telemetry));
+		const sessionDataService = createNullSessionDataService();
 		const instantiationService = disposables.add(new InstantiationService(new ServiceCollection(
 			[ILogService, logService],
 			[IAgentConfigurationService, configService],
 			[IAgentHostChangesetService, new FakeChangesetService()],
 			[IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE],
 			[ITelemetryService, telemetryService],
+			[IAgentHostTerminalManager, disposables.add(new TestAgentHostTerminalManager())],
+			[ISessionDataService, sessionDataService],
 		), /*strict*/ true));
 		sideEffects = disposables.add(instantiationService.createInstance(AgentSideEffects, stateManager, {
 			getAgent: () => agent,
 			agents: agentList,
-			sessionDataService: createNullSessionDataService(),
+			sessionDataService,
+			localTurns: new AgentHostLocalTurns(sessionDataService, logService),
 			onTurnComplete: () => { },
 		}));
 		disposables.add(sideEffects.registerProgressListener(agent));

--- a/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTurnTelemetry.test.ts
@@ -16,13 +16,17 @@ import { AgentSession, IAgent } from '../../common/agentService.js';
 import { ActionType, type ChatAction } from '../../common/state/sessionActions.js';
 import { buildDefaultChatUri, MessageKind, PendingMessageKind, ResponsePartKind, SessionStatus } from '../../common/state/sessionState.js';
 import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
+import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
+import { AgentHostLocalTurns } from '../../node/agentHostLocalTurns.js';
 import { AgentHostTelemetryService } from '../../node/agentHostTelemetryService.js';
 import { AgentConfigurationService, IAgentConfigurationService } from '../../node/agentConfigurationService.js';
 import { IAgentHostChangesetService } from '../../common/agentHostChangesetService.js';
 import { AgentSideEffects } from '../../node/agentSideEffects.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 import { createNullSessionDataService } from '../common/sessionTestHelpers.js';
+import { ISessionDataService } from '../../common/sessionDataService.js';
 import { MockAgent } from './mockAgent.js';
+import { TestAgentHostTerminalManager } from './testAgentHostTerminalManager.js';
 
 class FakeChangesetService implements IAgentHostChangesetService {
 	declare readonly _serviceBrand: undefined;
@@ -150,17 +154,21 @@ suite('AgentSideEffects — turn tracker telemetry', () => {
 		const logService = new NullLogService();
 		const configService = disposables.add(new AgentConfigurationService(stateManager, logService));
 		const telemetryService = disposables.add(new AgentHostTelemetryService(telemetry));
+		const sessionDataService = createNullSessionDataService();
 		const instantiationService = disposables.add(new InstantiationService(new ServiceCollection(
 			[ILogService, logService],
 			[IAgentConfigurationService, configService],
 			[IAgentHostChangesetService, new FakeChangesetService()],
 			[IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE],
 			[ITelemetryService, telemetryService],
+			[IAgentHostTerminalManager, disposables.add(new TestAgentHostTerminalManager())],
+			[ISessionDataService, sessionDataService],
 		), /*strict*/ true));
 		sideEffects = disposables.add(instantiationService.createInstance(AgentSideEffects, stateManager, {
 			getAgent: () => agent,
 			agents: agentList,
-			sessionDataService: createNullSessionDataService(),
+			sessionDataService,
+			localTurns: new AgentHostLocalTurns(sessionDataService, logService),
 			onTurnComplete: () => { },
 		}));
 		// Wire the agent's progress signals through side-effects (this is how

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -1855,6 +1855,37 @@ suite('AgentService (node dispatcher)', () => {
 			assert.strictEqual(state!.turns[0].state, TurnState.Complete);
 		});
 
+		test('interleaves persisted host-injected local turns after their anchor on restore', async () => {
+			const db = new TestSessionDatabase();
+			const localService = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(db), { _serviceBrand: undefined } as IProductService, createNoopGitService()));
+			localService.registerProvider(copilotAgent);
+			const { session } = await copilotAgent.createSession();
+			const sessionResource = (await copilotAgent.listSessions())[0].session;
+			const defaultChatUri = buildDefaultChatUri(sessionResource.toString());
+
+			// SDK transcript reconstructs a single real turn keyed by the user
+			// envelope id (`msg-real`, per mapSessionEvents).
+			copilotAgent.sessionMessages = [
+				{ type: 'message', session, role: 'user', messageId: 'msg-real', content: 'Hello', toolRequests: [] },
+				{ type: 'message', session, role: 'assistant', messageId: 'msg-real-a', content: 'Hi there!', toolRequests: [] },
+			];
+
+			// A host-injected local turn anchored after the real turn, plus one
+			// with no anchor (precedes any real turn), plus an orphan whose
+			// anchor is absent from the SDK transcript (should be dropped).
+			const localTurn = (id: string, text: string) => ({ id, message: { text, origin: { kind: MessageKind.User } }, responseParts: [], usage: undefined, state: TurnState.Complete });
+			await db.insertLocalTurn({ turnId: 'local-head', chatUri: defaultChatUri, anchorTurnId: undefined, seq: 1, payload: JSON.stringify(localTurn('local-head', '!pwd')) });
+			await db.insertLocalTurn({ turnId: 'local-after', chatUri: defaultChatUri, anchorTurnId: 'msg-real', seq: 2, payload: JSON.stringify(localTurn('local-after', '!ls')) });
+			await db.insertLocalTurn({ turnId: 'local-orphan', chatUri: defaultChatUri, anchorTurnId: 'gone', seq: 3, payload: JSON.stringify(localTurn('local-orphan', '!echo')) });
+
+			await localService.restoreSession(sessionResource);
+
+			const state = localService.stateManager.getSessionState(sessionResource.toString());
+			// head (no anchor) first, then the real turn, then its anchored local; orphan dropped.
+			assert.deepStrictEqual(state!.turns.map(t => t.id), ['local-head', 'msg-real', 'local-after']);
+		});
+
+
 		test('restores the default chat\'s independently-renamed title', async () => {
 			const db = new TestSessionDatabase();
 			const localService = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(db), { _serviceBrand: undefined } as IProductService, createNoopGitService()));
@@ -2654,6 +2685,60 @@ suite('AgentService (node dispatcher)', () => {
 			}, {
 				forkForwarded: false,
 				newTurnCount: 0,
+			});
+		});
+
+		test('fork at a host-injected local turn redirects the SDK boundary to the concrete anchor and carries the local turn into the new chat', async () => {
+			let receivedFork: IAgentCreateChatForkSource | undefined;
+			class MultiChatAgent extends MockAgent {
+				override async createChat(_session: URI, _chat: URI, options?: IAgentCreateChatOptions): Promise<void> {
+					receivedFork = options?.fork;
+				}
+			}
+			const db = new TestSessionDatabase();
+			const agent = disposables.add(new MultiChatAgent('copilot'));
+			const localService = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(db), { _serviceBrand: undefined } as IProductService, createNoopGitService()));
+			localService.registerProvider(agent);
+			const { session } = await agent.createSession();
+			const sessionResource = (await agent.listSessions())[0].session;
+			const defaultChatUri = buildDefaultChatUri(sessionResource.toString());
+
+			// SDK transcript reconstructs a single real turn keyed by the user
+			// message id; a host-injected local turn is persisted after it.
+			agent.sessionMessages = [
+				{ type: 'message', session, role: 'user', messageId: 'real-1', content: 'Hello', toolRequests: [] },
+				{ type: 'message', session, role: 'assistant', messageId: 'real-1-a', content: 'Hi', toolRequests: [] },
+			];
+			const localTurn: Turn = { id: 'local-1', state: TurnState.Complete, message: { text: '!echo hi', origin: { kind: MessageKind.User } }, responseParts: [], usage: undefined };
+			await db.insertLocalTurn({ turnId: 'local-1', chatUri: defaultChatUri, anchorTurnId: 'real-1', seq: 1, payload: JSON.stringify(localTurn) });
+
+			// Restore so the source chat interleaves [real-1, local-1] and the
+			// in-memory local index knows local-1 is a local turn.
+			await localService.restoreSession(sessionResource);
+			assert.deepStrictEqual(localService.stateManager.getSessionState(sessionResource.toString())?.turns.map(t => t.id), ['real-1', 'local-1']);
+
+			// Fork the default chat AT the local turn into a new peer chat.
+			const peerUri = URI.parse(buildChatUri(sessionResource, 'peer-1'));
+			await localService.createChat(sessionResource, peerUri, { fork: { source: URI.parse(defaultChatUri), turnId: 'local-1' } });
+
+			const peerTurns = localService.stateManager.getChatState(peerUri.toString())?.turns ?? [];
+			const forkedLocals = (await db.getLocalTurns()).filter(r => r.chatUri === peerUri.toString());
+			assert.deepStrictEqual({
+				// SDK fork boundary redirected from the local turn to its concrete anchor.
+				sdkForkTurnId: receivedFork?.turnId,
+				// New chat seeded with remapped copies of both turns.
+				peerTurnCount: peerTurns.length,
+				// The forked local turn is persisted under the new chat, anchored to
+				// the forked copy of the real turn.
+				forkedLocalCount: forkedLocals.length,
+				forkedLocalAnchor: forkedLocals[0]?.anchorTurnId,
+				anchorIsPeerFirstTurn: forkedLocals[0]?.anchorTurnId === peerTurns[0]?.id,
+			}, {
+				sdkForkTurnId: 'real-1',
+				peerTurnCount: 2,
+				forkedLocalCount: 1,
+				forkedLocalAnchor: peerTurns[0]?.id,
+				anchorIsPeerFirstTurn: true,
 			});
 		});
 

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -36,10 +36,13 @@ import { IAgentHostChangesetService, StaticChangesetKind } from '../../common/ag
 import { IAgentHostGitService } from '../../common/agentHostGitService.js';
 import { AgentService } from '../../node/agentService.js';
 import { AgentSideEffects, IAgentSideEffectsOptions } from '../../node/agentSideEffects.js';
+import { AgentHostLocalTurns } from '../../node/agentHostLocalTurns.js';
+import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
-import { createNoopGitService, createNullSessionDataService, createSessionDataService } from '../common/sessionTestHelpers.js';
+import { createNoopGitService, createNullSessionDataService, createSessionDataService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
 import { MockAgent } from './mockAgent.js';
+import { TestAgentHostTerminalManager } from './testAgentHostTerminalManager.js';
 
 // ---- Tests ------------------------------------------------------------------
 
@@ -95,10 +98,11 @@ class FakeChangesetService implements IAgentHostChangesetService {
 function createTestSideEffects(
 	disposables: DisposableStore,
 	stateManager: AgentHostStateManager,
-	options: IAgentSideEffectsOptions,
+	options: Omit<IAgentSideEffectsOptions, 'localTurns'> & { localTurns?: AgentHostLocalTurns },
 	_gitService?: IAgentHostGitService,
 	telemetryService: ITelemetryService = NullTelemetryService,
 	changesets: IAgentHostChangesetService = new FakeChangesetService(),
+	terminalManager: IAgentHostTerminalManager = disposables.add(new TestAgentHostTerminalManager()),
 ): AgentSideEffects {
 	const logService = new NullLogService();
 	const configService = disposables.add(new AgentConfigurationService(stateManager, logService));
@@ -108,8 +112,14 @@ function createTestSideEffects(
 		[IAgentHostChangesetService, changesets],
 		[IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE],
 		[ITelemetryService, telemetryService],
+		[IAgentHostTerminalManager, terminalManager],
+		[ISessionDataService, options.sessionDataService],
 	), /*strict*/ true));
-	return disposables.add(instantiationService.createInstance(AgentSideEffects, stateManager, options));
+	const resolvedOptions: IAgentSideEffectsOptions = {
+		...options,
+		localTurns: options.localTurns ?? new AgentHostLocalTurns(options.sessionDataService, logService),
+	};
+	return disposables.add(instantiationService.createInstance(AgentSideEffects, stateManager, resolvedOptions));
 }
 
 class TestTelemetryService implements ITelemetryService {
@@ -479,6 +489,208 @@ suite('AgentSideEffects', () => {
 			await new Promise(r => setTimeout(r, 10));
 
 			assert.deepStrictEqual(agent.sendMessageCalls, [{ session: URI.parse(sessionUri.toString()), chat: URI.parse(defaultChatUri), prompt: '/renamed thing', attachments: undefined }]);
+		});
+	});
+
+	// ---- handleAction: generic ! terminal command ------------------------
+
+	suite('handleAction — ! terminal command', () => {
+
+		function createBangSideEffects(terminalManager: TestAgentHostTerminalManager): AgentSideEffects {
+			return createTestSideEffects(disposables, stateManager, {
+				getAgent: () => agent,
+				agents: agentList,
+				sessionDataService: createNullSessionDataService(),
+				onTurnComplete: () => { },
+			}, undefined, undefined, undefined, terminalManager);
+		}
+
+		test('runs a ! message as a terminal command and completes the turn without calling the agent', async () => {
+			setupSession('file:///work');
+			const terminalManager = disposables.add(new TestAgentHostTerminalManager());
+			const bangSideEffects = createBangSideEffects(terminalManager);
+			const action: ChatAction = {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				message: { text: '!echo hi', origin: { kind: MessageKind.User } },
+			};
+			// Mirror production: the reducer opens the turn, then side effects run.
+			stateManager.dispatchClientAction(defaultChatUri, action, { clientId: 'test', clientSeq: 1 });
+			bangSideEffects.handleAction(defaultChatUri, action);
+
+			// Wait until the command is running (its completion listener is
+			// registered), then signal that the command finished.
+			await terminalManager.commandFinishedListenerRegistered.p;
+			const terminalUri = terminalManager.created[0].channel;
+			terminalManager.fireCommandFinished({ commandId: '1', command: 'echo hi', exitCode: 0, output: 'hi\n' });
+
+			// Wait for the turn to be closed out.
+			await waitForState(stateManager, () => stateManager.getActiveTurnId(sessionUri.toString()) === undefined ? true : undefined);
+
+			assert.deepStrictEqual(agent.sendMessageCalls, []);
+			const state = stateManager.getSessionState(sessionUri.toString());
+			const part = state?.turns.at(-1)?.responseParts[0];
+			assert.strictEqual(part?.kind, ResponsePartKind.ToolCall);
+			const toolCall = part?.kind === ResponsePartKind.ToolCall ? part.toolCall : undefined;
+			assert.strictEqual(toolCall?.status, ToolCallStatus.Completed);
+			assert.strictEqual(toolCall?.status === ToolCallStatus.Completed ? toolCall.success : undefined, true);
+			assert.ok(toolCall?.status === ToolCallStatus.Completed
+				&& toolCall.content?.some(c => c.type === ToolResultContentType.Terminal && c.resource === terminalUri));
+			assert.strictEqual(terminalManager.created.length, 1);
+			assert.ok(terminalManager.sentTexts.some(s => s.data.includes('echo hi')));
+		});
+
+		test('a lone ! is forwarded to the agent instead of running a command', async () => {
+			setupSession();
+			const terminalManager = disposables.add(new TestAgentHostTerminalManager());
+			const bangSideEffects = createBangSideEffects(terminalManager);
+			const action: ChatAction = {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				message: { text: '!', origin: { kind: MessageKind.User } },
+			};
+			stateManager.dispatchClientAction(defaultChatUri, action, { clientId: 'test', clientSeq: 1 });
+			bangSideEffects.handleAction(defaultChatUri, action);
+
+			await waitForSendMessageCalls(1);
+
+			assert.strictEqual(agent.sendMessageCalls[0].prompt, '!');
+			assert.strictEqual(terminalManager.created.length, 0);
+		});
+
+		test('records the completed bang turn as a local turn, stripped of the live terminal reference', async () => {
+			setupSession('file:///work');
+			const db = new TestSessionDatabase();
+			const localTurns = new AgentHostLocalTurns(createSessionDataService(db), new NullLogService());
+			const terminalManager = disposables.add(new TestAgentHostTerminalManager());
+			const bangSideEffects = createTestSideEffects(disposables, stateManager, {
+				getAgent: () => agent,
+				agents: agentList,
+				sessionDataService: createSessionDataService(db),
+				localTurns,
+				onTurnComplete: () => { },
+			}, undefined, undefined, undefined, terminalManager);
+
+			const action: ChatAction = {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				message: { text: '!echo hi', origin: { kind: MessageKind.User } },
+			};
+			stateManager.dispatchClientAction(defaultChatUri, action, { clientId: 'test', clientSeq: 1 });
+			bangSideEffects.handleAction(defaultChatUri, action);
+
+			await terminalManager.commandFinishedListenerRegistered.p;
+			terminalManager.fireCommandFinished({ commandId: '1', command: 'echo hi', exitCode: 0, output: 'hi\n' });
+			await waitForState(stateManager, () => stateManager.getActiveTurnId(sessionUri.toString()) === undefined ? true : undefined);
+
+			// The turn with no preceding real turn has no anchor.
+			assert.strictEqual(localTurns.resolveConcreteTurnId(defaultChatUri, 'turn-1'), undefined);
+			const persisted = await db.getLocalTurns();
+			assert.strictEqual(persisted.length, 1);
+			const payload = JSON.parse(persisted[0].payload) as { responseParts: { kind: string; toolCall?: { content?: { type: string }[] } }[] };
+			const toolCallPart = payload.responseParts.find(p => p.kind === ResponsePartKind.ToolCall);
+			// Live terminal reference is stripped; text output is retained.
+			assert.ok(toolCallPart?.toolCall?.content?.every(c => c.type !== ToolResultContentType.Terminal));
+			assert.ok(toolCallPart?.toolCall?.content?.some(c => c.type === ToolResultContentType.Text));
+		});
+	});
+
+	// ---- local turn persistence: anchoring + truncate resolution ---------
+
+	suite('local turn persistence', () => {
+
+		let clientSeq: number;
+
+		setup(() => {
+			clientSeq = 0;
+		});
+
+		/** Drives a normal (SDK-backed) turn into `turns[]` via the reducer. */
+		function seedRealTurn(turnId: string, text: string): void {
+			stateManager.dispatchClientAction(defaultChatUri, {
+				type: ActionType.ChatTurnStarted, turnId, message: { text, origin: { kind: MessageKind.User } },
+			}, { clientId: 'test', clientSeq: ++clientSeq });
+			stateManager.dispatchServerAction(defaultChatUri, { type: ActionType.ChatTurnComplete, turnId });
+		}
+
+		async function runBang(se: AgentSideEffects, terminalManager: TestAgentHostTerminalManager, turnId: string): Promise<void> {
+			const action: ChatAction = {
+				type: ActionType.ChatTurnStarted, turnId, message: { text: '!echo hi', origin: { kind: MessageKind.User } },
+			};
+			stateManager.dispatchClientAction(defaultChatUri, action, { clientId: 'test', clientSeq: ++clientSeq });
+			se.handleAction(defaultChatUri, action);
+			await terminalManager.commandFinishedListenerRegistered.p;
+			terminalManager.fireCommandFinished({ commandId: turnId, command: 'echo hi', exitCode: 0, output: 'hi\n' });
+			await waitForState(stateManager, () => stateManager.getActiveTurnId(sessionUri.toString()) === undefined ? true : undefined);
+		}
+
+		let localTurns: AgentHostLocalTurns;
+
+		function createLocalTurnSideEffects(db: TestSessionDatabase, terminalManager: TestAgentHostTerminalManager): AgentSideEffects {
+			const sessionDataService = createSessionDataService(db);
+			localTurns = new AgentHostLocalTurns(sessionDataService, new NullLogService());
+			return createTestSideEffects(disposables, stateManager, {
+				getAgent: () => agent,
+				agents: agentList,
+				sessionDataService,
+				localTurns,
+				onTurnComplete: () => { },
+			}, undefined, undefined, undefined, terminalManager);
+		}
+
+		test('anchors a bang turn to the preceding concrete turn', async () => {
+			setupSession('file:///work');
+			const db = new TestSessionDatabase();
+			const terminalManager = disposables.add(new TestAgentHostTerminalManager());
+			const se = createLocalTurnSideEffects(db, terminalManager);
+
+			seedRealTurn('real-1', 'hello');
+			await runBang(se, terminalManager, 'local-1');
+
+			assert.strictEqual(localTurns.resolveConcreteTurnId(defaultChatUri, 'local-1'), 'real-1');
+			const persisted = await db.getLocalTurns();
+			assert.deepStrictEqual(persisted.map(r => ({ turnId: r.turnId, chatUri: r.chatUri, anchorTurnId: r.anchorTurnId })), [
+				{ turnId: 'local-1', chatUri: defaultChatUri, anchorTurnId: 'real-1' },
+			]);
+		});
+
+		test('truncating at a local turn redirects the SDK truncation to the concrete anchor', async () => {
+			setupSession('file:///work');
+			const db = new TestSessionDatabase();
+			const terminalManager = disposables.add(new TestAgentHostTerminalManager());
+			const se = createLocalTurnSideEffects(db, terminalManager);
+
+			seedRealTurn('real-1', 'hello');
+			await runBang(se, terminalManager, 'local-1');
+
+			// Truncate at the local turn (keep it). Reducer keeps [real-1, local-1].
+			stateManager.dispatchClientAction(defaultChatUri, { type: ActionType.ChatTruncated, turnId: 'local-1' }, { clientId: 'test', clientSeq: ++clientSeq });
+			se.handleAction(defaultChatUri, { type: ActionType.ChatTruncated, turnId: 'local-1' });
+
+			// The SDK is told to keep up to the concrete turn before the local one.
+			const truncateCall = agent.truncateSessionCalls.at(-1);
+			assert.strictEqual(truncateCall?.session.toString(), sessionUri.toString());
+			assert.strictEqual(truncateCall?.turnId, 'real-1');
+		});
+
+		test('truncating at a real turn drops the trailing local turn', async () => {
+			setupSession('file:///work');
+			const db = new TestSessionDatabase();
+			const terminalManager = disposables.add(new TestAgentHostTerminalManager());
+			const se = createLocalTurnSideEffects(db, terminalManager);
+
+			seedRealTurn('real-1', 'hello');
+			await runBang(se, terminalManager, 'local-1');
+
+			// Truncate at the real turn (drop the local turn after it).
+			stateManager.dispatchClientAction(defaultChatUri, { type: ActionType.ChatTruncated, turnId: 'real-1' }, { clientId: 'test', clientSeq: ++clientSeq });
+			se.handleAction(defaultChatUri, { type: ActionType.ChatTruncated, turnId: 'real-1' });
+
+			assert.strictEqual(agent.truncateSessionCalls.at(-1)?.turnId, 'real-1');
+			// The local turn is dropped from memory synchronously and from the DB async.
+			assert.strictEqual(localTurns.isLocal(defaultChatUri, 'local-1'), false);
+			await new Promise(r => setTimeout(r, 10));
+			assert.deepStrictEqual(await db.getLocalTurns(), []);
 		});
 	});
 
@@ -2651,6 +2863,40 @@ suite('AgentSideEffects', () => {
 			assert.strictEqual(state!.title, 'Restored Title');
 		});
 
+		test('restore interleaves a persisted local turn after its anchor', async () => {
+			const sessionDataService = createSessionDataService(sessionDb);
+			const localAgent = new MockAgent();
+			disposables.add(toDisposable(() => localAgent.dispose()));
+			const localService = disposables.add(new AgentService(new NullLogService(), fileService, sessionDataService, { _serviceBrand: undefined } as IProductService, createNoopGitService()));
+			localService.registerProvider(localAgent);
+
+			const { session } = await localAgent.createSession();
+			const sessions = await localAgent.listSessions();
+			const sessionResource = sessions[0].session;
+
+			// The SDK transcript yields a single real turn keyed by the first
+			// user message id (`buildTurnsFromHistory`).
+			localAgent.sessionMessages = [
+				{ type: 'message', session, role: 'user', messageId: 'real-1', content: 'Hello', toolRequests: [] },
+				{ type: 'message', session, role: 'assistant', messageId: 'a-1', content: 'Hi', toolRequests: [] },
+			];
+
+			// A host-injected local turn recorded against that real turn.
+			const localTurn = {
+				id: 'local-1',
+				message: { text: '!echo hi', origin: { kind: MessageKind.User } },
+				responseParts: [{ kind: ResponsePartKind.Markdown, id: 'p1', content: 'ran' }],
+				usage: undefined,
+				state: 2, // TurnState.Complete
+			};
+			await sessionDb.insertLocalTurn({ turnId: 'local-1', chatUri: buildDefaultChatUri(sessionResource.toString()), anchorTurnId: 'real-1', seq: 1, payload: JSON.stringify(localTurn) });
+
+			await localService.restoreSession(sessionResource);
+
+			const state = localService.stateManager.getSessionState(sessionResource.toString());
+			assert.deepStrictEqual(state?.turns.map(t => t.id), ['real-1', 'local-1']);
+		});
+
 		test('SessionConfigChanged persists merged config values to the database', async () => {
 			const sessionDataService = createSessionDataService(sessionDb);
 			const localStateManager = disposables.add(new AgentHostStateManager(new NullLogService()));
@@ -3678,6 +3924,34 @@ suite('AgentSideEffects', () => {
 			});
 
 			assert.deepStrictEqual(changesets.truncates, [sessionUri.toString()]);
+		});
+
+		test('truncating a chat forwards that chat to the agent (default and peer)', () => {
+			setupSession();
+			const peerChatUri = buildChatUri(sessionUri.toString(), 'peer-1');
+
+			// Peer chat: the chat URI is forwarded so the agent targets that
+			// chat's own backing rather than the session's default chat.
+			sideEffects.handleAction(peerChatUri, { type: ActionType.ChatTruncated, turnId: 'turn-peer' });
+			const peerCall = agent.truncateSessionCalls.at(-1);
+
+			// Default chat: forwarded as the session's default chat URI.
+			sideEffects.handleAction(defaultChatUri, { type: ActionType.ChatTruncated, turnId: 'turn-default' });
+			const defaultCall = agent.truncateSessionCalls.at(-1);
+
+			assert.deepStrictEqual({
+				peerSession: peerCall?.session.toString(),
+				peerTurnId: peerCall?.turnId,
+				peerChat: peerCall?.chat?.toString(),
+				defaultTurnId: defaultCall?.turnId,
+				defaultChat: defaultCall?.chat?.toString(),
+			}, {
+				peerSession: sessionUri.toString(),
+				peerTurnId: 'turn-peer',
+				peerChat: peerChatUri,
+				defaultTurnId: 'turn-default',
+				defaultChat: defaultChatUri,
+			});
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/mockAgent.ts
+++ b/src/vs/platform/agentHost/test/node/mockAgent.ts
@@ -70,6 +70,7 @@ export class MockAgent implements IAgent {
 	readonly setClientToolsCalls: { clientId: string; tools: readonly ToolDefinition[] }[] = [];
 	readonly removeActiveClientCalls: { clientId: string }[] = [];
 	readonly clientToolCallCompleteCalls: { session: URI; chat: URI; toolCallId: string; result: ToolCallResult }[] = [];
+	readonly truncateSessionCalls: { session: URI; turnId: string | undefined; chat: URI | undefined }[] = [];
 	readonly setCustomizationEnabledCalls: { id: string; enabled: boolean }[] = [];
 	/** Configurable return value for getCustomizations. */
 	customizations: Customization[] = [];
@@ -162,6 +163,10 @@ export class MockAgent implements IAgent {
 
 	async abortSession(session: URI): Promise<void> {
 		this.abortSessionCalls.push(session);
+	}
+
+	async truncateSession(session: URI, turnId?: string, chat?: URI): Promise<void> {
+		this.truncateSessionCalls.push({ session, turnId, chat });
 	}
 
 	respondToPermissionRequest(requestId: string, approved: boolean): void {

--- a/src/vs/platform/agentHost/test/node/sessionDataService.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionDataService.test.ts
@@ -13,6 +13,7 @@ import { FileService } from '../../../files/common/fileService.js';
 import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesystemProvider.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { AgentSession } from '../../common/agentService.js';
+import { buildChatUri } from '../../common/state/sessionState.js';
 import { SessionDataService } from '../../node/sessionDataService.js';
 
 suite('SessionDataService', () => {
@@ -41,6 +42,17 @@ suite('SessionDataService', () => {
 		const session = AgentSession.uri('copilot', 'foo/bar:baz\\qux');
 		const dir = service.getSessionDataDir(session);
 		assert.strictEqual(dir.toString(), URI.joinPath(basePath, 'agentSessionData', 'foo-bar-baz-qux').toString());
+	});
+
+	test('getSessionDataDir gives each peer chat of a session its own directory', () => {
+		const session = AgentSession.uri('copilotcli', 'session-1');
+		const chatA = URI.parse(buildChatUri(session, 'chat-a'));
+		const chatB = URI.parse(buildChatUri(session, 'chat-b'));
+		const dirA = service.getSessionDataDir(chatA);
+		const dirB = service.getSessionDataDir(chatB);
+		assert.notStrictEqual(dirA.toString(), dirB.toString());
+		// The plain session URI keeps its authority-free directory.
+		assert.strictEqual(service.getSessionDataDir(session).toString(), URI.joinPath(basePath, 'agentSessionData', 'session-1').toString());
 	});
 
 	test('deleteSessionData removes directory', async () => {

--- a/src/vs/platform/agentHost/test/node/testAgentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/test/node/testAgentHostTerminalManager.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DeferredPromise } from '../../../../base/common/async.js';
+import { Emitter } from '../../../../base/common/event.js';
+import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
+import type { CreateTerminalParams } from '../../common/state/protocol/commands.js';
+import type { TerminalClaim, TerminalInfo, TerminalState } from '../../common/state/protocol/state.js';
+import type { IAgentHostTerminalManager, ICommandFinishedEvent } from '../../node/agentHostTerminalManager.js';
+
+/**
+ * Controllable fake {@link IAgentHostTerminalManager} for tests. `createTerminal`
+ * records the request and announces the terminal URI via
+ * {@link onDidCreateTerminal}; tests drive command completion with
+ * {@link fireCommandFinished}. When no terminal interaction is needed it also
+ * serves as a benign no-op stand-in.
+ */
+export class TestAgentHostTerminalManager extends Disposable implements IAgentHostTerminalManager {
+	declare readonly _serviceBrand: undefined;
+
+	defaultShell = '/bin/bash';
+	commandDetectionSupported = true;
+	readonly created: CreateTerminalParams[] = [];
+	readonly sentTexts: { uri: string; data: string }[] = [];
+	readonly disposedTerminals: string[] = [];
+
+	/** Resolves once a command-finished listener is registered (i.e. a command is running). */
+	readonly commandFinishedListenerRegistered = new DeferredPromise<void>();
+
+	private readonly _onCommandFinished = this._register(new Emitter<ICommandFinishedEvent>());
+	private readonly _onData = this._register(new Emitter<string>());
+	private readonly _onExit = this._register(new Emitter<number>());
+	private readonly _onClaimChanged = this._register(new Emitter<TerminalClaim>());
+	private readonly _onDidCreateTerminal = this._register(new Emitter<string>());
+	readonly onDidCreateTerminal = this._onDidCreateTerminal.event;
+
+	async createTerminal(params: CreateTerminalParams): Promise<void> {
+		this.created.push(params);
+		this._onDidCreateTerminal.fire(params.channel);
+	}
+	writeInput(): void { }
+	async sendText(uri: string, data: string): Promise<void> { this.sentTexts.push({ uri, data }); }
+	onData(_uri: string, cb: (data: string) => void): IDisposable { return this._onData.event(cb); }
+	onExit(_uri: string, cb: (exitCode: number) => void): IDisposable { return this._onExit.event(cb); }
+	onClaimChanged(_uri: string, cb: (claim: TerminalClaim) => void): IDisposable { return this._onClaimChanged.event(cb); }
+	onCommandFinished(_uri: string, cb: (event: ICommandFinishedEvent) => void): IDisposable {
+		this.commandFinishedListenerRegistered.complete();
+		return this._onCommandFinished.event(cb);
+	}
+	createAltBufferPromise(): Promise<void> { return new Promise<void>(() => { }); }
+	getContent(): string | undefined { return undefined; }
+	getClaim(): TerminalClaim | undefined { return undefined; }
+	hasTerminal(): boolean { return false; }
+	getExitCode(): number | undefined { return undefined; }
+	supportsCommandDetection(): boolean { return this.commandDetectionSupported; }
+	disposeTerminal(uri: string): void { this.disposedTerminals.push(uri); }
+	getTerminalInfos(): TerminalInfo[] { return []; }
+	getTerminalState(): TerminalState | undefined { return undefined; }
+	async getDefaultShell(): Promise<string> { return this.defaultShell; }
+	fireCommandFinished(event: ICommandFinishedEvent): void { this._onCommandFinished.fire(event); }
+}


### PR DESCRIPTION
## Summary

Adds a "bang command" feature to the agent host and refactors host-injected command handling into a pluggable registry, plus several related fixes.

- **New `!command` feature**: In any chat agent, a message starting with `!` runs as a terminal command (via the existing agent-host terminal/shell integration) instead of being sent to the model. The host emits a transcript-only tool-call response for the command.
- **Persisted "local turns"**: Host-injected turns (`!command` and `/rename`) are now persisted so they survive reload, and `fork`/`truncate`/`rename` resolve them to the preceding concrete SDK turn. Handled uniformly per-chat (default, peer and subagent chats) — no default-chat special-casing.
- **Pluggable command registry (refactor)**: Extracted local command handling out of `AgentSideEffects` into a composable `LocalChatCommandRegistry` with a self-contained `AgentHostLocalCommands` dispatcher, plus `renameLocalCommand` and `bangLocalCommand`. Shared helpers extracted: `shellCommandExecution` (agent-agnostic shell exec core) and `persistSessionMetadata`.
- **Fix: peer-chat truncation routing**: `truncateSession` now takes the chat URI and routes peer chats to their own backing session instead of only resolving the default chat.
- **Fix: truncate no-op after forking into a second peer chat**: `SessionDataService` keyed every peer chat of a session onto one data dir/DB, because the chat id lives in the URI authority which `AgentSession.id` dropped. A second fork's `vacuumInto` then failed with "output file already exists", so the forked chat never inherited its turn event IDs and truncation could not resolve the anchor. The storage key now includes the URI authority (plain session URIs are unchanged), and both fork copy sites clear any stale target DB before copying.

## Testing
- `npm run test-node` — all agent host suites green
- typecheck-client / eslint / valid-layers-check / hygiene clean for the changed files

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
