### PR TITLE
Use local icon treatment for Agent Host Copilot

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
@@ -54,6 +54,8 @@ The Electron-only `electron-browser/agentHost.contribution.ts` adds desktop-only
 
 When the default-provider setting flips, the provider re-fires `onDidChangeSessionTypes` so the management service re-collects and re-sorts session types with the new `order`.
 
+These session-type icons are specific to the Agents window provider. In the editor window, `agentSessions.ts` maps local Agent Host Copilot to the Local harness's `Codicon.vm` picker icon, while `agentSessionsViewer.ts` uses the same session-list status dot as the Local harness.
+
 ## IDs and URI Schemes
 
 A single agent host session uses several distinct identifiers:

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
@@ -96,7 +96,7 @@ export function getAgentSessionProviderIcon(provider: AgentSessionTarget): Theme
 		case AgentSessionProviders.Growth:
 			return Codicon.lightbulb;
 		case AgentSessionProviders.AgentHostCopilot:
-			return Codicon.copilot;
+			return Codicon.vm;
 		default:
 			return Codicon.extensions;
 	}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -529,7 +529,7 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 			return { ...Codicon.circleFilled, color: themeColorFromId('textLink.foreground') };
 		}
 
-		if (!statusOnly && session.providerType === AgentSessionProviders.Local) {
+		if (!statusOnly && (session.providerType === AgentSessionProviders.Local || session.providerType === AgentSessionProviders.AgentHostCopilot)) {
 			return { ...Codicon.circleSmallFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
 		}
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
@@ -2171,7 +2171,7 @@ suite('AgentSessions', () => {
 
 		test('should return correct icon for AgentHostCopilot provider', () => {
 			const icon = getAgentSessionProviderIcon(AgentSessionProviders.AgentHostCopilot);
-			assert.strictEqual(icon.id, Codicon.copilot.id);
+			assert.strictEqual(icon.id, Codicon.vm.id);
 		});
 
 		test('should return simplified AgentHostCopilot name', () => {


### PR DESCRIPTION
## Summary
- use the Local harness VM icon for local Agent Host Copilot in the Editor window picker
- use the Local harness status-dot treatment for local Agent Host Copilot sessions in the Editor window list
- preserve the Copilot icon in the Agents window

## Validation
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `npm run precommit`
- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts`
- local Agent Host provider icon regression tests
- live Editor window verification of the `codicon-vm` picker entry

(Written by Copilot)