### PR TITLE
chore: bump windows-process-tree to 0.8.0 to fix UTF-8 command lines in Process Explorer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@vscode/tree-sitter-wasm": "^0.3.1",
         "@vscode/vscode-languagedetection": "1.0.23",
         "@vscode/windows-mutex": "^0.5.0",
-        "@vscode/windows-process-tree": "^0.7.0",
+        "@vscode/windows-process-tree": "^0.8.0",
         "@vscode/windows-registry": "^1.2.0",
         "@xterm/addon-clipboard": "^0.3.0-beta.288",
         "@xterm/addon-image": "^0.10.0-beta.288",
@@ -4308,9 +4308,9 @@
       }
     },
     "node_modules/@vscode/windows-process-tree": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@vscode/windows-process-tree/-/windows-process-tree-0.7.0.tgz",
-      "integrity": "sha512-uH58Fofu1bgiulsY2svyGOLLKAYNJ0Req4PioPd7BZzHRziuiBRw1SxyT7wvsYHvm7eKWwzwo6mZpExDfwX9iA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@vscode/windows-process-tree/-/windows-process-tree-0.8.0.tgz",
+      "integrity": "sha512-TI+h2GRwX+igD/YYJMQQVAFcsCNSg7Te2yYxQpKMzwto5RsJ8d2KKgOeur/p/6sAOQwZvopiTDOClyTHEn9MhQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@vscode/tree-sitter-wasm": "^0.3.1",
     "@vscode/vscode-languagedetection": "1.0.23",
     "@vscode/windows-mutex": "^0.5.0",
-    "@vscode/windows-process-tree": "^0.7.0",
+    "@vscode/windows-process-tree": "^0.8.0",
     "@vscode/windows-registry": "^1.2.0",
     "@xterm/addon-clipboard": "^0.3.0-beta.288",
     "@xterm/addon-image": "^0.10.0-beta.288",

--- a/package.json
+++ b/package.json
@@ -306,12 +306,12 @@
     "@vscode/sqlite3@5.1.12-vscode": true,
     "@vscode/windows-registry@1.2.0": true,
     "@vscode/windows-mutex@0.5.3": true,
-    "@vscode/windows-process-tree@0.7.0": true,
     "ssh2": false,
     "fsevents@2.3.2": true,
     "fsevents@1.2.13": true,
     "es5-ext": false,
     "husky": false,
-    "@vscode/windows-ca-certs@0.3.4": true
+    "@vscode/windows-ca-certs@0.3.4": true,
+    "@vscode/windows-process-tree@0.8.0": true
   }
 }

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -25,7 +25,7 @@
         "@vscode/sqlite3": "5.1.12-vscode",
         "@vscode/tree-sitter-wasm": "^0.3.1",
         "@vscode/vscode-languagedetection": "1.0.23",
-        "@vscode/windows-process-tree": "^0.7.0",
+        "@vscode/windows-process-tree": "^0.8.0",
         "@vscode/windows-registry": "^1.2.0",
         "@xterm/addon-clipboard": "^0.3.0-beta.288",
         "@xterm/addon-image": "^0.10.0-beta.288",
@@ -792,9 +792,9 @@
       }
     },
     "node_modules/@vscode/windows-process-tree": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@vscode/windows-process-tree/-/windows-process-tree-0.7.0.tgz",
-      "integrity": "sha512-uH58Fofu1bgiulsY2svyGOLLKAYNJ0Req4PioPd7BZzHRziuiBRw1SxyT7wvsYHvm7eKWwzwo6mZpExDfwX9iA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@vscode/windows-process-tree/-/windows-process-tree-0.8.0.tgz",
+      "integrity": "sha512-TI+h2GRwX+igD/YYJMQQVAFcsCNSg7Te2yYxQpKMzwto5RsJ8d2KKgOeur/p/6sAOQwZvopiTDOClyTHEn9MhQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/remote/package.json
+++ b/remote/package.json
@@ -20,7 +20,7 @@
     "@vscode/sqlite3": "5.1.12-vscode",
     "@vscode/tree-sitter-wasm": "^0.3.1",
     "@vscode/vscode-languagedetection": "1.0.23",
-    "@vscode/windows-process-tree": "^0.7.0",
+    "@vscode/windows-process-tree": "^0.8.0",
     "@vscode/windows-registry": "^1.2.0",
     "@xterm/addon-clipboard": "^0.3.0-beta.288",
     "@xterm/addon-image": "^0.10.0-beta.288",

--- a/remote/package.json
+++ b/remote/package.json
@@ -68,10 +68,10 @@
     "@vscode/native-watchdog@1.4.6": true,
     "@vscode/spdlog@0.15.8": true,
     "@vscode/windows-registry@1.2.0": true,
-    "@vscode/windows-process-tree@0.7.0": true,
     "ssh2": false,
     "@vscode/sqlite3@5.1.12-vscode": true,
     "cpu-features": false,
-    "@vscode/windows-ca-certs@0.3.4": true
+    "@vscode/windows-ca-certs@0.3.4": true,
+    "@vscode/windows-process-tree@0.8.0": true
   }
 }


### PR DESCRIPTION
Fixes #219183

The root cause was fixed upstream in `@vscode/windows-process-tree` 0.8.0: microsoft/vscode-windows-process-tree#87 changed the `WideCharToMultiByte` calls in `process_commandline.cc` from `CP_ACP` to `CP_UTF8`, so process command lines containing non-ANSI characters no longer collapse to `?`. VS Code still resolved 0.7.0, which is why the Process Explorer kept showing question marks.

This bumps `@vscode/windows-process-tree` to `^0.8.0` in `package.json` and `remote/package.json`, with lockfiles regenerated by npm 11.

Verified on Windows 11 by loading both module versions against a process spawned with Cyrillic in its command line:

```
0.7.0:  "C:\Program Files
odejs
ode.exe" -e "setTimeout(()=>{}, 20000)" -- ??????-???-?????????
0.8.0:  "C:\Program Files
odejs
ode.exe" -e "setTimeout(()=>{}, 20000)" -- Привет-мир-Кириллица
```

0.8.0 is otherwise additive over 0.7.0 (a new `getAllProcesses` API and CI/build maintenance).