### PR TITLE
Use modifier properties on mouse event instead of tracking keydown/keyup

### DIFF
--- a/src/vs/editor/contrib/dnd/browser/dnd.ts
+++ b/src/vs/editor/contrib/dnd/browser/dnd.ts
@@ -37,7 +37,6 @@ export class DragAndDropController extends Disposable implements IEditorContribu
 	private _dragSelection: Selection | null;
 	private readonly _dndDecorationIds: IEditorDecorationsCollection;
 	private _mouseDown: boolean;
-	private _modifierPressed: boolean;
 	static readonly TRIGGER_KEY_VALUE = isMacintosh ? KeyCode.Alt : KeyCode.Ctrl;
 
 	static get(editor: ICodeEditor): DragAndDropController | null {
@@ -58,7 +57,6 @@ export class DragAndDropController extends Disposable implements IEditorContribu
 		this._register(this._editor.onDidBlurEditorWidget(() => this.onEditorBlur()));
 		this._register(this._editor.onDidBlurEditorText(() => this.onEditorBlur()));
 		this._mouseDown = false;
-		this._modifierPressed = false;
 		this._dragSelection = null;
 	}
 
@@ -66,16 +64,11 @@ export class DragAndDropController extends Disposable implements IEditorContribu
 		this._removeDecoration();
 		this._dragSelection = null;
 		this._mouseDown = false;
-		this._modifierPressed = false;
 	}
 
 	private onEditorKeyDown(e: IKeyboardEvent): void {
 		if (!this._editor.getOption(EditorOption.dragAndDrop) || this._editor.getOption(EditorOption.columnSelection)) {
 			return;
-		}
-
-		if (hasTriggerModifier(e)) {
-			this._modifierPressed = true;
 		}
 
 		if (this._mouseDown && hasTriggerModifier(e)) {
@@ -88,10 +81,6 @@ export class DragAndDropController extends Disposable implements IEditorContribu
 	private onEditorKeyUp(e: IKeyboardEvent): void {
 		if (!this._editor.getOption(EditorOption.dragAndDrop) || this._editor.getOption(EditorOption.columnSelection)) {
 			return;
-		}
-
-		if (hasTriggerModifier(e)) {
-			this._modifierPressed = false;
 		}
 
 		if (this._mouseDown && e.keyCode === DragAndDropController.TRIGGER_KEY_VALUE) {
@@ -180,15 +169,12 @@ export class DragAndDropController extends Disposable implements IEditorContribu
 				(<CodeEditorWidget>this._editor).setSelections(newSelections || [], 'mouse', CursorChangeReason.Explicit);
 			} else if (!this._dragSelection.containsPosition(newCursorPosition) ||
 				(
-					(
-						hasTriggerModifier(mouseEvent.event) ||
-						this._modifierPressed
-					) && (
+					hasTriggerModifier(mouseEvent.event) && (
 						this._dragSelection.getEndPosition().equals(newCursorPosition) || this._dragSelection.getStartPosition().equals(newCursorPosition)
 					) // we allow users to paste content beside the selection
 				)) {
 				this._editor.pushUndoStop();
-				this._editor.executeCommand(DragAndDropController.ID, new DragAndDropCommand(this._dragSelection, newCursorPosition, hasTriggerModifier(mouseEvent.event) || this._modifierPressed));
+				this._editor.executeCommand(DragAndDropController.ID, new DragAndDropCommand(this._dragSelection, newCursorPosition, hasTriggerModifier(mouseEvent.event)));
 				this._editor.pushUndoStop();
 			}
 		}
@@ -234,7 +220,6 @@ export class DragAndDropController extends Disposable implements IEditorContribu
 		this._removeDecoration();
 		this._dragSelection = null;
 		this._mouseDown = false;
-		this._modifierPressed = false;
 		super.dispose();
 	}
 }


### PR DESCRIPTION
Fixes #58515

As suggested in the [original conversation](https://github.com/microsoft/vscode/commit/e82498a544b88f5041ec7f8b531ab8ca6eb29eaf#commitcomment-30440469), the drop decision in `_onEditorMouseDrop` now reads the modifier state directly off the mouse event (`hasTriggerModifier(mouseEvent.event)`), and the `_modifierPressed` field is removed entirely. This also removes a source of stale state: `_modifierPressed` could stay `true` if the keyup was missed (the blur reset from #53142 papered over one such case).

The keydown/keyup listeners are kept, but now serve only the live cursor-style feedback while a drag is in progress — no mousemove fires when the modifier is pressed/released with the mouse held still, so the mouse event alone can't drive the cursor update.

Two deliberate details:

- The keyup path keeps the `e.keyCode === DragAndDropController.TRIGGER_KEY_VALUE` check instead of switching to `hasTriggerModifier(e)`: on keyup of the modifier key itself, the event's modifier flag is already `false`, so `hasTriggerModifier(e)` would never match and the cursor style would never revert. (This is where the earlier attempt in #124406 went wrong.)
- Behavior at drop time is unchanged in the normal flow: the mouseup event carries the current `ctrlKey`/`altKey` state, which is exactly what `_modifierPressed` was approximating via key events.

Deletion-only refactor, `-17/+2`, no dependency changes.