### PR TITLE
Fix flaky Copilot customizations integration test (settle-aware notification assertions)

### DIFF
--- a/src/vs/platform/agentHost/test/node/protocol/copilotCustomizations.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/copilotCustomizations.integrationTest.ts
@@ -16,8 +16,31 @@ import { join } from '../../../../../base/common/path.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ActionType, SessionCustomizationsChangedAction } from '../../../common/state/sessionActions.js';
 import { CustomizationType, type DirectoryCustomization } from '../../../common/state/sessionState.js';
+import { type AhpNotification } from '../../../common/state/sessionProtocol.js';
 import { createRealSession, dispatchTurn, IRealSdkProviderConfig } from './realSdkTestHelpers.js';
 import { getActionEnvelope, isActionNotification, IServerHandle, startRealServer, TestProtocolClient } from './testHelpers.js';
+
+/**
+ * Whether `notification` is a *settled* `session/customizationsChanged` for
+ * `sessionUri`.
+ *
+ * Filesystem customization discovery is asynchronous: a client
+ * `SessionActiveClientSet`/`sync` can publish a snapshot before the initial
+ * disk scan has settled, producing a transient `customizations: []`
+ * notification (see `SessionPluginController.getCustomizationsSettled`).
+ * Because `clearReceived()` clears the local buffer but cannot retract an
+ * already-sent socket message, such a pre-discovery snapshot may even be
+ * delivered *after* a `clearReceived()`. These empty snapshots are not
+ * meaningful state changes, so the tests match and count only non-empty
+ * (settled) notifications — every session discovers at least the standard
+ * customization directories, so a settled snapshot always has a non-empty list.
+ */
+function isSettledCustomizationsNotification(notification: AhpNotification, sessionUri: string): boolean {
+	if (!isActionNotification(notification, ActionType.SessionCustomizationsChanged) || getActionEnvelope(notification).channel !== sessionUri) {
+		return false;
+	}
+	return (getActionEnvelope(notification).action as SessionCustomizationsChangedAction).customizations.length > 0;
+}
 
 const COPILOT_CONFIG: IRealSdkProviderConfig = {
 	suiteTitle: 'Protocol WebSocket — Real Copilot SDK Mocked LLM',
@@ -109,7 +132,7 @@ suite('Protocol WebSocket — Real Copilot SDK, Mocked LLM (Copilot customizatio
 		dispatchTurn(client, sessionUri, 'turn-customizations-empty-mock', 'hello', 2);
 
 		const [customizationsNotif] = await Promise.all([
-			client.waitForNotification(n => isActionNotification(n, ActionType.SessionCustomizationsChanged) && getActionEnvelope(n).channel === sessionUri, NOTIFICATION_TIMEOUT_MS),
+			client.waitForNotification(n => isSettledCustomizationsNotification(n, sessionUri), NOTIFICATION_TIMEOUT_MS),
 			client.waitForNotification(n => isActionNotification(n, 'chat/turnComplete'), NOTIFICATION_TIMEOUT_MS),
 		]);
 
@@ -242,7 +265,7 @@ suite('Protocol WebSocket — Real Copilot SDK, Mocked LLM (Copilot customizatio
 		dispatchTurn(client, sessionUri, 'turn-customizations-mock', 'hello', 2);
 
 		const [customizationsNotif] = await Promise.all([
-			client.waitForNotification(n => isActionNotification(n, ActionType.SessionCustomizationsChanged) && getActionEnvelope(n).channel === sessionUri, NOTIFICATION_TIMEOUT_MS),
+			client.waitForNotification(n => isSettledCustomizationsNotification(n, sessionUri), NOTIFICATION_TIMEOUT_MS),
 			client.waitForNotification(n => isActionNotification(n, 'chat/turnComplete'), NOTIFICATION_TIMEOUT_MS),
 		]);
 
@@ -400,16 +423,21 @@ suite('Protocol WebSocket — Real Copilot SDK, Mocked LLM (Copilot customizatio
 					isActionNotification(notification, ActionType.SessionCustomizationsChanged) &&
 					getActionEnvelope(notification).channel === sessionUri
 				);
+				// Only settled (non-empty) notifications represent a real state
+				// change; transient pre-discovery `customizations: []` snapshots
+				// may straddle a `clearReceived()` (see
+				// `isSettledCustomizationsNotification`) and must not be counted.
+				const settledNotifications = matchingNotifications.filter(notification => isSettledCustomizationsNotification(notification, sessionUri));
 				assert.strictEqual(
-					matchingNotifications.length,
+					settledNotifications.length,
 					1,
-					`expected exactly one ${ActionType.SessionCustomizationsChanged} notification for ${directoryUri}; got ${matchingNotifications.length}: ${JSON.stringify(matchingNotifications)}`,
+					`expected exactly one settled ${ActionType.SessionCustomizationsChanged} notification for ${directoryUri}; got ${settledNotifications.length} settled of ${matchingNotifications.length} total: ${JSON.stringify(matchingNotifications)}`,
 				);
 			};
 
 			const getMatchingActionFromNotifications = (notifications: ReturnType<TestProtocolClient['receivedNotifications']>): SessionCustomizationsChangedAction | undefined => {
 				for (const notification of notifications) {
-					if (!isActionNotification(notification, ActionType.SessionCustomizationsChanged) || getActionEnvelope(notification).channel !== sessionUri) {
+					if (!isSettledCustomizationsNotification(notification, sessionUri)) {
 						continue;
 					}
 					const action = getActionEnvelope(notification).action as SessionCustomizationsChangedAction;
@@ -431,7 +459,7 @@ suite('Protocol WebSocket — Real Copilot SDK, Mocked LLM (Copilot customizatio
 			let notif;
 			try {
 				notif = await client.waitForNotification(n => {
-					if (!isActionNotification(n, ActionType.SessionCustomizationsChanged) || getActionEnvelope(n).channel !== sessionUri) {
+					if (!isSettledCustomizationsNotification(n, sessionUri)) {
 						return false;
 					}
 					const action = getActionEnvelope(n).action as SessionCustomizationsChangedAction;


### PR DESCRIPTION
Hi @aeschli my agent has found that this test is flaky. Here is the evidence, where the same sha failed on run 1 and then succeeded on run 2. I don't know if the proposed fix is any good, it talks about a race condition from an empty array to something else, which seems plausible:

🤖  content below this point

---


Each occurrence **failed, was re-run on the exact same commit (same `headSha`, no new code), and then passed.** GitHub Actions re-runs keep the same run id and head SHA and only increment `run_attempt`, so the code under test is byte-for-byte identical between attempts. A `failed → passed` transition on one commit is direct proof the failure is nondeterministic, not caused by the PR.

| Failed attempt (link) | PR / branch | Commit | Attempt | Latest result |
| --- | --- | --- | --- | --- |
| [Windows / Electron](https://github.com/microsoft/vscode/actions/runs/28666612411/job/85019798364) | sessions: identify session in worktree delete prompt (`agents/fix-vscode-issue-324220`) | `a708ea6d` | 1 → 2 | ✅ success on attempt 2 |
| [macOS / Electron](https://github.com/microsoft/vscode/actions/runs/28580966727/job/84740872422) | sessions: add icon + always-visible placeholder to Pinned section (`agents/agents-window-sessions-icon-update`) | `d2b54db8` | 1 → 2 | ✅ success on attempt 2 |
| [macOS / Electron](https://github.com/microsoft/vscode/actions/runs/28549680364/job/84643657321) | Fix issues with chat perf pipeline (`chat-perf-flake-fix`) | `44b42577` | 1 → 2 | ✅ success on attempt 2 |

In every case attempt 1 failed with the `2 !== 1` assertion above and attempt 2 passed on the same commit — 3 distinct PRs affected across Windows and macOS Electron.


---


> [!NOTE]
> Suggested reviewer: **@aeschli** (Martin Aeschlimann). He authored both the flaky test (`copilotCustomizations.integrationTest.ts`) and the underlying customization-discovery code (`sessionCustomizationDiscovery.ts` + the `SessionDiscoveredEntry`/publish path in `copilotAgent.ts`), so he owns this area.

## Summary

Fixes a flaky agent-host integration test:

- **Test**: `emits session/customizationsChanged when customization files are edited, added, and removed (mock LLM)` (plus its two sibling tests in the same suite, hardened for the same latent race).
- **What flaked**: the helper `assertSingleCustomizationChangeNotification` asserted **exactly one** `session/customizationsChanged` notification after `client.clearReceived()`, but sometimes got **2**.
- **Why**: customization discovery is asynchronous/eventually-consistent. A **pre-discovery empty snapshot** (`customizations: []`) can be emitted just before `clearReceived()` and delivered over the socket just after it — `clearReceived()` clears the local buffer but cannot retract an already-sent message.
- **Fix (test-only)**: match and count only **settled** (non-empty) `session/customizationsChanged` notifications. Empty pre-discovery snapshots are transient and not a real state change, so they are ignored. No production code changes.
- **Why not a source fix**: the interim empty snapshot is not a bug — it is the documented behavior of the eventually-consistent discovery pipeline, and no server-side coalescing can retract a message that was already sent before the test cleared its buffer.

## Details, reasoning and evidence

### The failure signature (from CI)

```
AssertionError [ERR_ASSERTION]: expected exactly one session/customizationsChanged
notification for file:///.../.copilot/agents; got 2
  at assertSingleCustomizationChangeNotification (copilotCustomizations.integrationTest.js:364:16)
  at waitForDirectoryChildNames (copilotCustomizations.integrationTest.js:404:7)
```

The two notifications observed were an initial one with `customizations: []` (empty), followed by the fully-populated one. Evidence it is a flake and not a real regression: CI run `28666612411` went red on attempt 1 and green on attempt 2 for the **same commit**, and it has flaked across 3 distinct PRs recently on Windows and macOS (Electron).

### How the notification is produced

`session/customizationsChanged` is produced by the Copilot agent's per-session plugin controller and forwarded to the client:

- `SessionPluginController` (`src/vs/platform/agentHost/node/copilot/copilotAgent.ts`) fires `onDidPublish({ type: SessionCustomizationsChanged, customizations: [...this.getCustomizations()] })` in several places — notably from `sync()` (client `SessionActiveClientSet`) and from the disk-watcher refresh callback wired into `SessionDiscoveredEntry`.
- On-disk discovery is asynchronous and debounced: `SessionDiscoveredEntry` (`REFRESH_DEBOUNCE_MS = 100`) wraps `SessionCustomizationDiscovery.scan()` in a `Delayer`, and only invokes its `onDidRefresh` callback once a scan has *actually changed* the discovered set (`areDiscoveredDirectoriesEqual` guard + `didRefresh && shouldNotify`).

### Where the interim empty notification comes from

The empty `customizations: []` snapshot is **not** produced by the disk-watcher refresh path:

- The scan functions in `sessionCustomizationDiscovery.ts` swallow per-entry FS errors (each `resolve()` is individually `try/catch`ed), so `scan()` only rejects on cancellation — which `_refresh()` handles explicitly without clearing state.
- The parsers (`parseAgentFile`, `parseSkillFile`, `parseRuleFile` in `src/vs/platform/agentPlugins/common/pluginParsers.ts`) never throw — they fall back to a filename-derived name. So a *populated* refresh essentially never yields an empty list.

Instead, the empty list comes from the **synchronous, not-yet-settled** snapshot path. `SessionPluginController.getCustomizations()` returns whatever the discovered entry currently holds, which is `[]` until the first async scan settles. Its settled counterpart documents exactly this:

```ts
// getCustomizationsSettled(): "... Callers that publish customizations into
// session state at session creation time MUST use this — the synchronous
// variant can return an empty list for a brand-new working directory because
// SessionDiscoveredEntry kicks off its _refresh() without anyone awaiting it."
```

When the client's `SessionActiveClientSet` triggers `sync()`, it publishes `getCustomizations()` immediately (before discovery settles), producing a transient `customizations: []` notification, followed later by the populated notification once discovery completes.

### Why `clearReceived()` doesn't prevent the count from reaching 2

The test brackets each mutation with `client.clearReceived()` and then asserts exactly one notification arrived afterwards. But `clearReceived()` only clears the **client-side buffer** — it cannot retract a message the server already put on the wire. Under heavier I/O and OS-timing variance (the watch test writes many files during setup; the failures cluster on Windows and macOS Electron), the empty pre-discovery snapshot is sometimes emitted *before* `clearReceived()` yet delivered/recorded *after* it. Result: the buffer contains the empty snapshot **plus** the populated one → count is 2 → the exact-count assertion fails.

This makes "exactly one notification received after clearReceived()" an inherently racy assertion for this transport combined with an eventually-consistent producer.

### The fix

Introduce a single predicate and use it at every match/count site:

```ts
function isSettledCustomizationsNotification(notification, sessionUri): boolean {
    if (!isActionNotification(notification, ActionType.SessionCustomizationsChanged)
        || getActionEnvelope(notification).channel !== sessionUri) {
        return false;
    }
    return (getActionEnvelope(notification).action as SessionCustomizationsChangedAction)
        .customizations.length > 0;
}
```

- Every session discovers at least the standard customization directories, so a **settled** snapshot always has a non-empty `customizations` list. A length-0 array therefore uniquely identifies the pre-discovery snapshot.
- `assertSingleCustomizationChangeNotification` now counts only settled notifications (it still fails on a genuine duplicate/flicker of a real state change).
- The wait/lookup predicates ignore the empty snapshots, and the two sibling tests' initial waits now wait for a settled snapshot too.

This does **not** weaken the test's guarantees: `waitForDirectoryChildNames` still requires convergence to the exact expected non-empty child set, so a stuck-empty or wrong state would still time out / fail.

### Validation

- Type-checked `src/tsconfig.json` with `tsgo`: identical error count before and after the change (all pre-existing, in unrelated files, from a local dependency version skew) — **zero** errors introduced by the edited file.
- Change is confined to test assertion logic; no production code touched.
- Note: the end-to-end integration test forks the compiled `agentHostServerMain.js` against a mock LLM and requires a full build, which wasn't feasible in my environment; the change directly targets the empty-then-populated signature from the CI logs.
