### PR TITLE
build: gate "Release build if successful" checkbox to insider quality

### DIFF
--- a/build/azure-pipelines/product-build-template.yml
+++ b/build/azure-pipelines/product-build-template.yml
@@ -75,7 +75,7 @@ parameters:
     type: boolean
     default: true
   - name: VSCODE_RELEASE
-    displayName: "Release build if successful"
+    displayName: "Release build if successful (ONLY FOR INSIDER)"
     type: boolean
     default: false
   - name: VSCODE_STEP_ON_IT
@@ -609,7 +609,7 @@ stages:
                   container: ubuntu-24
                   arch: arm64
 
-        - ${{ if and(parameters.VSCODE_RELEASE, eq(variables['VSCODE_PRIVATE_BUILD'], false), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
+        - ${{ if and(parameters.VSCODE_RELEASE, eq(variables['VSCODE_QUALITY'], 'insider'), eq(variables['VSCODE_PRIVATE_BUILD'], false), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
           - stage: ApproveRelease
             dependsOn: [] # run in parallel to compile stage
             pool:

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -104,7 +104,7 @@ parameters:
     type: boolean
     default: true
   - name: VSCODE_RELEASE
-    displayName: "Release build if successful"
+    displayName: "Release build if successful (ONLY FOR INSIDER)"
     type: boolean
     default: false
   - name: VSCODE_STEP_ON_IT
@@ -777,7 +777,7 @@ extends:
                   container: ubuntu-24
                   arch: arm64
 
-        - ${{ if and(parameters.VSCODE_RELEASE, eq(variables['VSCODE_PRIVATE_BUILD'], false), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
+        - ${{ if and(parameters.VSCODE_RELEASE, eq(variables['VSCODE_QUALITY'], 'insider'), eq(variables['VSCODE_PRIVATE_BUILD'], false), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
           - stage: ApproveRelease
             dependsOn: [] # run in parallel to compile stage
             pool:


### PR DESCRIPTION
## What

Scopes the manual **"Release build if successful"** build parameter (`VSCODE_RELEASE`) so it only takes effect for **insider** quality builds.

In `product-build.yml` and `product-build-template.yml`:

1. **Clearer label** — the parameter is renamed to `"Release build if successful (ONLY FOR INSIDER)"` so it's obvious in the queue-build UI that the checkbox only applies to insiders.
2. **Effect gating** — the existing `ApproveRelease` + `Release` stage condition gains an `eq(variables['VSCODE_QUALITY'], 'insider')` guard, so the release stages are only emitted for insider quality even if the box is checked on a `stable`/`exploration` build.

## Why

While reviewing usage of this checkbox, I looked at all Insiders **Product** builds of definition 111 over the last 4 weeks: the box was used on only ~8.6% of manual builds, by a small handful of people, and it is never intended to fire for non-insider quality. Rather than removing the checkbox entirely, this keeps it but makes its scope explicit and safe — it can no longer accidentally kick off a release on a non-insider build.

## Notes for reviewers

- The gate references `variables['VSCODE_QUALITY']`, which is resolved at template-compile time exactly like the neighbouring `variables['VSCODE_PRIVATE_BUILD']` guard already used in the same condition. In `product-build.yml` it's the local variable set from the parameter; in `product-build-template.yml` it's inherited from the parent (distro) pipeline, matching how `VSCODE_PRIVATE_BUILD` is consumed there.
- No behavior change for insider builds — the checkbox works exactly as before.
- The scheduled release path (`product-publish.yml` -> `releaseBuild.ts`) is untouched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
