### PR TITLE
markdown: repair incomplete streaming links inside bold/lists

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -816,27 +816,11 @@ function completeSingleLinePattern(token: marked.Tokens.Text | marked.Tokens.Par
 		if (subtoken.type === 'text') {
 			const lines = subtoken.raw.split('\n');
 			const lastLine = lines[lines.length - 1];
-			if (lastLine.includes('`')) {
-				return completeCodespan(token);
-			}
 
-			else if (lastLine.includes('**')) {
-				return completeDoublestar(token);
-			}
-
-			else if (lastLine.match(/\*\w/)) {
-				return completeStar(token);
-			}
-
-			else if (lastLine.match(/(^|\s)__\w/)) {
-				return completeDoubleUnderscore(token);
-			}
-
-			else if (lastLine.match(/(^|\s)_\w/)) {
-				return completeUnderscore(token);
-			}
-
-			else if (
+			// An incomplete link target must be completed before emphasis/codespan. The link is the
+			// innermost unfinished construct, so any emphasis marker (e.g. the `**` in `**[text](htt`)
+			// belongs to an enclosing span. Completing the emphasis first would leave the link broken.
+			if (
 				// Text with start of link target
 				hasLinkTextAndStartOfLinkTarget(lastLine) ||
 				// This token doesn't have the link text, eg if it contains other markdown constructs that are in other subtokens.
@@ -860,6 +844,26 @@ function completeSingleLinePattern(token: marked.Tokens.Text | marked.Tokens.Par
 				return completeLinkTarget(token);
 			}
 
+			else if (lastLine.includes('`')) {
+				return completeCodespan(token);
+			}
+
+			else if (lastLine.includes('**')) {
+				return completeDoublestar(token);
+			}
+
+			else if (lastLine.match(/\*\w/)) {
+				return completeStar(token);
+			}
+
+			else if (lastLine.match(/(^|\s)__\w/)) {
+				return completeDoubleUnderscore(token);
+			}
+
+			else if (lastLine.match(/(^|\s)_\w/)) {
+				return completeUnderscore(token);
+			}
+
 			// Contains the start of link text, and no following tokens contain the link target
 			else if (lastLine.match(/(^|\s)\[\w*[^\]]*$/)) {
 				return completeLinkText(token);
@@ -871,7 +875,9 @@ function completeSingleLinePattern(token: marked.Tokens.Text | marked.Tokens.Par
 }
 
 function hasLinkTextAndStartOfLinkTarget(str: string): boolean {
-	return !!str.match(/(^|\s)\[.*\]\(\w*/);
+	// The `[` may be preceded by start-of-line, whitespace, or an emphasis/strikethrough marker
+	// (e.g. `**[text](htt`) so that links nested inside bold/italic/strikethrough are detected.
+	return !!str.match(/(^|\s|\*|_|~)\[.*\]\(\w*/);
 }
 
 function hasStartOfLinkTargetAndNoLinkText(str: string): boolean {

--- a/src/vs/base/test/browser/markdownRenderer.test.ts
+++ b/src/vs/base/test/browser/markdownRenderer.test.ts
@@ -818,6 +818,26 @@ suite('MarkdownRenderer', () => {
 				assert.deepStrictEqual(newTokens, completeTokens);
 			});
 
+			test('list with bold incomplete link target', () => {
+				const incomplete = `- list item one
+- **[link](http://microsoft`;
+				const tokens = marked.marked.lexer(incomplete);
+				const newTokens = fillInIncompleteTokens(tokens);
+
+				const completeTokens = marked.marked.lexer(incomplete + ')**');
+				assert.deepStrictEqual(newTokens, completeTokens);
+			});
+
+			test('ordered list with bold incomplete link target', () => {
+				const incomplete = `1. list item one
+2. **[link](http://microsoft`;
+				const tokens = marked.marked.lexer(incomplete);
+				const newTokens = fillInIncompleteTokens(tokens);
+
+				const completeTokens = marked.marked.lexer(incomplete + ')**');
+				assert.deepStrictEqual(newTokens, completeTokens);
+			});
+
 			test('list with incomplete subitem', () => {
 				const incomplete = `1. list item one
 	- `;
@@ -1063,12 +1083,30 @@ suite('MarkdownRenderer', () => {
 				assert.deepStrictEqual(newTokens, completeTokens);
 			});
 
-			test.skip('incomplete link in list', () => {
+			test('incomplete link in list', () => {
 				const incomplete = '- [text';
 				const tokens = marked.marked.lexer(incomplete);
 				const newTokens = fillInIncompleteTokens(tokens);
 
 				const completeTokens = marked.marked.lexer(incomplete + '](https://microsoft.com)');
+				assert.deepStrictEqual(newTokens, completeTokens);
+			});
+
+			test('incomplete link target inside bold', () => {
+				const incomplete = '**[text](http://microsoft';
+				const tokens = marked.marked.lexer(incomplete);
+				const newTokens = fillInIncompleteTokens(tokens);
+
+				const completeTokens = marked.marked.lexer(incomplete + ')**');
+				assert.deepStrictEqual(newTokens, completeTokens);
+			});
+
+			test('incomplete link target with arg inside bold', () => {
+				const incomplete = '**[text](http://microsoft.com "more text ';
+				const tokens = marked.marked.lexer(incomplete);
+				const newTokens = fillInIncompleteTokens(tokens);
+
+				const completeTokens = marked.marked.lexer(incomplete + '")**');
 				assert.deepStrictEqual(newTokens, completeTokens);
 			});
 


### PR DESCRIPTION
## Problem

When streaming markdown, we repair "incomplete" tokens so partial content doesn't render as broken raw text. This wasn't working for links that are nested inside emphasis (bold/italic) — they rendered as raw text like `[start-vm.sh](file:///Users/roblou/code/debugtest/start` until the link finished streaming. The issue was especially visible for bold links inside a list, e.g.:

```
- **[start-vm.sh](file:///Users/roblou/code/debugtest/start
```

## Root cause

In `completeSingleLinePattern` (`src/vs/base/browser/markdownRenderer.ts`):

1. **Wrong priority.** Emphasis/codespan were checked *before* links. Since the line contains `**`, the bold branch fired first and appended `**`, leaving the link target unterminated — so the bold looked fixed but the link stayed raw.
2. **Regex too strict.** `hasLinkTextAndStartOfLinkTarget` used `/(^|\s)\[.*\]\(\w*/`, which only detects a link when `[` is at start-of-line or after whitespace. Here `[` follows `**`, so it wasn't detected as a link at all.

## Fix

- Complete an incomplete **link target** before emphasis/codespan. The link target is the innermost unfinished construct; the enclosing emphasis is closed on a subsequent repair round.
- Broaden `hasLinkTextAndStartOfLinkTarget` to allow `[` after emphasis/strikethrough markers (`*`, `_`, `~`).

Now `- **[start-vm.sh](file:///…/start` repairs to `- **[start-vm.sh](file:///…/start)**` — a properly closed bold link — instead of raw text. Works in bulleted/numbered lists, paragraphs, with italics/underscores, and with link title args.

## Tests

- Un-skipped the previously-skipped `incomplete link in list` test.
- Added tests for bold incomplete link targets in lists (bulleted + numbered), inside bold in a paragraph, and with an incomplete title arg inside bold.

Verified: `typecheck-client` passes; full `markdownRenderer.test.ts` suite green (149 passing), and the chat markdown renderer / content-part suites remain green.

(Written by Copilot)
