### PR TITLE
ssh: optimize ssh reconnect

### DIFF
--- a/src/vs/platform/remote/common/remoteAgentConnection.ts
+++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
@@ -723,6 +723,16 @@ export abstract class PersistentConnection extends Disposable {
 					this._onReconnectionPermanentFailure(this.protocol.getMillisSinceLastIncomingData(), attempt + 1, RemoteAuthorityResolverError.isHandled(err));
 					break;
 				}
+
+				const networkErrorCodes = ['ETIMEDOUT', 'ENETUNREACH', 'ECONNREFUSED', 'ECONNRESET'];
+				if (networkErrorCodes.includes(err.code)) {
+					this._options.logService.info(`${logPrefix}(1) A network error occurred while trying to reconnect, will try again...`);
+					continue;
+				}
+				if (networkErrorCodes.some(code => err.message?.includes(code))) {
+					this._options.logService.info(`${logPrefix}(2) A network error occurred while trying to reconnect, will try again...`);
+					continue;
+				}
 				this._options.logService.error(`${logPrefix} An unknown error occurred while trying to reconnect, since this is an unknown case, it will be treated as a permanent error! Will give up now! Error:`);
 				this._options.logService.error(err);
 				this._onReconnectionPermanentFailure(this.protocol.getMillisSinceLastIncomingData(), attempt + 1, false);

--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -910,10 +910,15 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 
 	private async _onRemoteExtensionHostCrashed(extensionHost: IExtensionHostManager, reconnectionToken: string): Promise<void> {
 		try {
-			const info = await this._getExtensionHostExitInfoWithTimeout(reconnectionToken);
-			if (info) {
-				this._logService.error(`Extension host (${extensionHost.friendyName}) terminated unexpectedly with code ${info.code}.`);
-			}
+			// This is not on the critical path and will not affect the subsequent logic.
+			this._getExtensionHostExitInfoWithTimeout(reconnectionToken)
+				.then(info => {
+					if (info) {
+						this._logService.error(`Extension host (${extensionHost.friendyName}) terminated unexpectedly with code ${info.code}.`);
+					}
+				}, err => {
+					this._logService.error(`Failed to get extension host exit info: ${err}`);
+				});
 
 			this._logExtensionHostCrash(extensionHost);
 			this._remoteCrashTracker.registerCrash();


### PR DESCRIPTION
When err.code is ETIMEDOUT, ENETUNREACH, ECONNREFUSED, ECONNRESET or err.message includes ETIMEDOUT, ENETUNREACH, ECONNREFUSED, ECONNRESET, we should retry.