### PR TITLE
agentHost: add stalled tool call telemetry

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -6,8 +6,8 @@
 import type { LanguageModelToolInvokedClassification, LanguageModelToolInvokedEvent } from '../../telemetry/common/languageModelToolTelemetry.js';
 import type { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { AgentSession } from '../common/agentService.js';
-import type { MessageAttachment, ToolDefinition } from '../common/state/protocol/state.js';
-import { isAhpChatChannel, isSubagentSession, parseRequiredSessionUriFromChatUri, type ISessionWithDefaultChat } from '../common/state/sessionState.js';
+import type { MessageAttachment, SessionInputRequestKind, ToolDefinition } from '../common/state/protocol/state.js';
+import { isAhpChatChannel, isSubagentChatUri, isSubagentSession, parseRequiredSessionUriFromChatUri, type ISessionWithDefaultChat } from '../common/state/sessionState.js';
 import type { ToolInvokedResult } from './agentHostToolCallTracker.js';
 import { multiplexProperties, type IAgentHostRestrictedTelemetry } from './agentHostRestrictedTelemetry.js';
 
@@ -80,6 +80,74 @@ export interface IAgentHostToolInvokedReport {
 	toolSourceKind: string;
 	result: ToolInvokedResult;
 	invocationTimeMs: number;
+}
+
+export interface IAgentHostToolCallStalledEvent {
+	provider: string;
+	agentSessionId: string;
+	isSubagentSession: boolean;
+	blockerKind: SessionInputRequestKind.ToolConfirmation | SessionInputRequestKind.ToolClientExecution;
+	toolId: string;
+	toolSourceKind: string;
+	stalledTimeMs: number;
+}
+
+export type IAgentHostToolCallStalledClassification = {
+	provider: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The provider handling the stalled agent host tool call.' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The agent host session identifier.' };
+	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the stalled tool call belongs to a subagent session.' };
+	blockerKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether the tool call is waiting for confirmation or client execution.' };
+	toolId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The identifier of the stalled tool.' };
+	toolSourceKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether the stalled tool is provided by the agent host, an MCP server, or a client.' };
+	stalledTimeMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Time in milliseconds that the tool call has remained blocked.' };
+	owner: 'roblourens';
+	comment: 'Tracks agent host tool calls that remain blocked beyond the stall threshold.';
+};
+
+export interface IAgentHostToolCallStalledReport {
+	provider: string;
+	session: string;
+	blockerKind: SessionInputRequestKind.ToolConfirmation | SessionInputRequestKind.ToolClientExecution;
+	toolId: string;
+	toolSourceKind: string;
+	stalledTimeMs: number;
+}
+
+export interface IAgentHostStalledToolCallCompletedEvent {
+	provider: string;
+	agentSessionId: string;
+	isSubagentSession: boolean;
+	blockerKind: SessionInputRequestKind.ToolConfirmation | SessionInputRequestKind.ToolClientExecution;
+	toolId: string;
+	toolSourceKind: string;
+	result: ToolInvokedResult;
+	totalTimeMs: number;
+	timeAfterStallMs: number;
+}
+
+export type IAgentHostStalledToolCallCompletedClassification = {
+	provider: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The provider handling the completed agent host tool call.' };
+	agentSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The agent host session identifier.' };
+	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the completed tool call belongs to a subagent session.' };
+	blockerKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether the tool call had stalled waiting for confirmation or client execution.' };
+	toolId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The identifier of the completed tool.' };
+	toolSourceKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether the completed tool is provided by the agent host, an MCP server, or a client.' };
+	result: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether the stalled tool call eventually completed successfully, with an error, or through user cancellation.' };
+	totalTimeMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Total time in milliseconds from tool call start to completion.' };
+	timeAfterStallMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Time in milliseconds from the stall report to tool call completion.' };
+	owner: 'roblourens';
+	comment: 'Tracks agent host tool calls that complete after previously exceeding the stall threshold.';
+};
+
+export interface IAgentHostStalledToolCallCompletedReport {
+	provider: string;
+	session: string;
+	blockerKind: SessionInputRequestKind.ToolConfirmation | SessionInputRequestKind.ToolClientExecution;
+	toolId: string;
+	toolSourceKind: string;
+	result: ToolInvokedResult;
+	totalTimeMs: number;
+	timeAfterStallMs: number;
 }
 
 export class AgentHostTelemetryReporter {
@@ -163,6 +231,34 @@ export class AgentHostTelemetryReporter {
 			toolSourceKind: report.toolSourceKind,
 			invocationTimeMs: report.invocationTimeMs,
 			provider: report.provider,
+		});
+	}
+
+	toolCallStalled(report: IAgentHostToolCallStalledReport): void {
+		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
+		this._telemetryService.publicLog2<IAgentHostToolCallStalledEvent, IAgentHostToolCallStalledClassification>('agentHost.toolCallStalled', {
+			provider: report.provider,
+			agentSessionId: AgentSession.id(session),
+			isSubagentSession: isSubagentChatUri(report.session) || isSubagentSession(session),
+			blockerKind: report.blockerKind,
+			toolId: report.toolId,
+			toolSourceKind: report.toolSourceKind,
+			stalledTimeMs: report.stalledTimeMs,
+		});
+	}
+
+	stalledToolCallCompleted(report: IAgentHostStalledToolCallCompletedReport): void {
+		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
+		this._telemetryService.publicLog2<IAgentHostStalledToolCallCompletedEvent, IAgentHostStalledToolCallCompletedClassification>('agentHost.stalledToolCallCompleted', {
+			provider: report.provider,
+			agentSessionId: AgentSession.id(session),
+			isSubagentSession: isSubagentChatUri(report.session) || isSubagentSession(session),
+			blockerKind: report.blockerKind,
+			toolId: report.toolId,
+			toolSourceKind: report.toolSourceKind,
+			result: report.result,
+			totalTimeMs: report.totalTimeMs,
+			timeAfterStallMs: report.timeAfterStallMs,
 		});
 	}
 }

--- a/src/vs/platform/agentHost/node/agentHostToolCallTracker.ts
+++ b/src/vs/platform/agentHost/node/agentHostToolCallTracker.ts
@@ -3,11 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { disposableTimeout } from '../../../base/common/async.js';
+import { Disposable, DisposableMap } from '../../../base/common/lifecycle.js';
 import { StopWatch } from '../../../base/common/stopwatch.js';
+import type { SessionToolClientExecutionRequest, SessionToolConfirmationRequest } from '../common/state/protocol/state.js';
 import { ToolCallContributorKind, type ToolCallContributor, type ToolCallResult } from '../common/state/sessionState.js';
 import type { AgentHostTelemetryReporter } from './agentHostTelemetryReporter.js';
 
 export type ToolInvokedResult = 'success' | 'error' | 'userCancelled';
+
+const TOOL_CALL_STALL_THRESHOLD_MS = 5 * 60 * 1000;
+
+type ToolCallBlockerRequest = SessionToolConfirmationRequest | SessionToolClientExecutionRequest;
 
 /**
  * Maps a completed tool call's result to the telemetry result bucket. Mirrors
@@ -57,25 +64,34 @@ interface IToolCallTiming {
 	readonly toolSourceKind: string;
 }
 
+interface IStalledToolCall {
+	readonly blockerKind: ToolCallBlockerRequest['kind'];
+	readonly stalledTimeMs: number;
+}
+
 /**
- * Tracks per-tool-call timing for agent host sessions and reports a
- * `languageModelToolInvoked` event via the provided
- * {@link AgentHostTelemetryReporter} when a tool call completes.
+ * Tracks completed and stalled tool calls for agent host sessions.
  *
  * Lifecycle per tool call:
  *   1. {@link toolCallStarted} — begins a stopwatch and records the tool's
  *      name and source kind (only the start action carries these)
  *   2. {@link toolCallCompleted} — emits the telemetry event and clears state
+ *   3. {@link toolCallBlocked} / {@link toolCallUnblocked} — emits once when a
+ *      confirmation or client execution remains unresolved past the threshold
  *
  * In-flight tool calls that never complete (e.g. the turn is cancelled mid
  * tool call) are dropped via {@link clearSession} / {@link clear} so the
  * tracking map cannot leak.
  */
-export class AgentHostToolCallTracker {
+export class AgentHostToolCallTracker extends Disposable {
 
 	private readonly _toolCalls = new Map<string, IToolCallTiming>();
+	private readonly _toolCallStallTimers = this._register(new DisposableMap<string>());
+	private readonly _stalledToolCalls = new Map<string, IStalledToolCall>();
 
-	constructor(private readonly _reporter: AgentHostTelemetryReporter) { }
+	constructor(private readonly _reporter: AgentHostTelemetryReporter) {
+		super();
+	}
 
 	toolCallStarted(provider: string, session: string, toolCallId: string, toolName: string, contributor: ToolCallContributor | undefined): void {
 		this._toolCalls.set(this._key(session, toolCallId), {
@@ -97,15 +113,58 @@ export class AgentHostToolCallTracker {
 			return;
 		}
 		this._toolCalls.delete(key);
+		const resultBucket = deriveToolInvokedResult(result);
+		const totalTimeMs = timing.stopWatch.elapsed();
 
 		this._reporter.toolInvoked({
 			provider: timing.provider,
 			session: timing.session,
 			toolId: timing.toolId,
 			toolSourceKind: timing.toolSourceKind,
-			result: deriveToolInvokedResult(result),
-			invocationTimeMs: timing.stopWatch.elapsed(),
+			result: resultBucket,
+			invocationTimeMs: totalTimeMs,
 		});
+
+		const stalled = this._stalledToolCalls.get(key);
+		if (stalled) {
+			this._stalledToolCalls.delete(key);
+			this._reporter.stalledToolCallCompleted({
+				provider: timing.provider,
+				session: timing.session,
+				blockerKind: stalled.blockerKind,
+				toolId: timing.toolId,
+				toolSourceKind: timing.toolSourceKind,
+				result: resultBucket,
+				totalTimeMs,
+				timeAfterStallMs: Math.max(0, totalTimeMs - stalled.stalledTimeMs),
+			});
+		}
+	}
+
+	toolCallBlocked(provider: string, session: string, request: ToolCallBlockerRequest): void {
+		const key = this._key(session, request.id);
+		const toolCallKey = this._key(session, request.toolCall.toolCallId);
+		if (this._toolCallStallTimers.has(key) || this._stalledToolCalls.has(toolCallKey)) {
+			return;
+		}
+
+		const stopWatch = StopWatch.create(true);
+		this._toolCallStallTimers.set(key, disposableTimeout(() => {
+			const stalledTimeMs = stopWatch.elapsed();
+			this._stalledToolCalls.set(toolCallKey, { blockerKind: request.kind, stalledTimeMs });
+			this._reporter.toolCallStalled({
+				provider,
+				session,
+				blockerKind: request.kind,
+				toolId: request.toolCall.toolName,
+				toolSourceKind: toolSourceKindFromContributor(request.toolCall.contributor),
+				stalledTimeMs,
+			});
+		}, TOOL_CALL_STALL_THRESHOLD_MS));
+	}
+
+	toolCallUnblocked(session: string, requestId: string): void {
+		this._toolCallStallTimers.deleteAndDispose(this._key(session, requestId));
 	}
 
 	/**
@@ -120,10 +179,22 @@ export class AgentHostToolCallTracker {
 				this._toolCalls.delete(key);
 			}
 		}
+		for (const key of this._toolCallStallTimers.keys()) {
+			if (key.startsWith(prefix)) {
+				this._toolCallStallTimers.deleteAndDispose(key);
+			}
+		}
+		for (const key of this._stalledToolCalls.keys()) {
+			if (key.startsWith(prefix)) {
+				this._stalledToolCalls.delete(key);
+			}
+		}
 	}
 
 	clear(): void {
 		this._toolCalls.clear();
+		this._toolCallStallTimers.clearAndDisposeAll();
+		this._stalledToolCalls.clear();
 	}
 
 	private _key(session: string, toolCallId: string): string {

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -148,7 +148,7 @@ export class AgentSideEffects extends Disposable {
 		super();
 		this._telemetryReporter = new AgentHostTelemetryReporter(this._telemetryService);
 		this._turnTracker = new AgentHostTurnTracker(this._telemetryReporter);
-		this._toolCallTracker = new AgentHostToolCallTracker(this._telemetryReporter);
+		this._toolCallTracker = this._register(new AgentHostToolCallTracker(this._telemetryReporter));
 		this._permissionManager = this._register(instantiationService.createInstance(SessionPermissionManager, this._stateManager));
 		this._localCommands = this._register(instantiationService.createInstance(
 			AgentHostLocalCommands,
@@ -350,10 +350,17 @@ export class AgentSideEffects extends Disposable {
 			return;
 		}
 		this._stateManager.dispatchServerAction(sessionUri, { type: ActionType.SessionInputNeededSet, request });
+		if (request.kind !== SessionInputRequestKind.ChatInput) {
+			const agent = this._options.getAgent(sessionUri);
+			if (agent) {
+				this._toolCallTracker.toolCallBlocked(agent.id, chatUri, request);
+			}
+		}
 	}
 
 	private _removeSessionInputNeeded(chatUri: ProtocolURI, id: string): void {
 		const sessionUri = parseRequiredSessionUriFromChatUri(chatUri);
+		this._toolCallTracker.toolCallUnblocked(chatUri, id);
 		if (!this._stateManager.getSessionState(sessionUri)?.inputNeeded?.some(r => r.id === id)) {
 			return;
 		}
@@ -364,7 +371,7 @@ export class AgentSideEffects extends Disposable {
 		const sessionUri = parseRequiredSessionUriFromChatUri(chatUri);
 		for (const request of this._stateManager.getSessionState(sessionUri)?.inputNeeded ?? []) {
 			if (request.chat === chatUri) {
-				this._stateManager.dispatchServerAction(sessionUri, { type: ActionType.SessionInputNeededRemoved, id: request.id });
+				this._removeSessionInputNeeded(chatUri, request.id);
 			}
 		}
 	}

--- a/src/vs/platform/agentHost/test/node/agentHostToolCallTelemetry.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostToolCallTelemetry.test.ts
@@ -4,17 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { timeout } from '../../../../base/common/async.js';
 import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { observableValue } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { runWithFakedTimers } from '../../../../base/test/common/virtualScheduling/runWithFakedTimers.js';
 import { InstantiationService } from '../../../instantiation/common/instantiationService.js';
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
 import { AgentSession, IAgent } from '../../common/agentService.js';
+import { SessionInputRequestKind } from '../../common/state/protocol/state.js';
 import { ActionType, type ChatAction } from '../../common/state/sessionActions.js';
-import { buildDefaultChatUri, MessageKind, SessionStatus, ToolCallContributorKind, type ToolCallContributor, type ToolCallResult } from '../../common/state/sessionState.js';
+import { buildDefaultChatUri, MessageKind, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, type ToolCallContributor, type ToolCallResult } from '../../common/state/sessionState.js';
 import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../../common/agentHostCheckpointService.js';
 import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
 import { AgentHostLocalTurns } from '../../node/agentHostLocalTurns.js';
@@ -135,6 +138,34 @@ suite('AgentSideEffects — tool call telemetry', () => {
 				return {
 					eventName: e.eventName,
 					data: { ...data, invocationTimeMs: typeof data.invocationTimeMs === 'number' && data.invocationTimeMs >= 0 },
+				};
+			});
+	}
+
+	function stalledEvents(): { eventName: string; data: Record<string, unknown> }[] {
+		return telemetry.events
+			.filter(e => e.eventName === 'agentHost.toolCallStalled')
+			.map(e => {
+				const data = e.data as Record<string, unknown>;
+				return {
+					eventName: e.eventName,
+					data: { ...data, stalledTimeMs: typeof data.stalledTimeMs === 'number' && data.stalledTimeMs >= 0 },
+				};
+			});
+	}
+
+	function stalledCompletionEvents(): { eventName: string; data: Record<string, unknown> }[] {
+		return telemetry.events
+			.filter(e => e.eventName === 'agentHost.stalledToolCallCompleted')
+			.map(e => {
+				const data = e.data as Record<string, unknown>;
+				return {
+					eventName: e.eventName,
+					data: {
+						...data,
+						totalTimeMs: typeof data.totalTimeMs === 'number' && data.totalTimeMs >= 0,
+						timeAfterStallMs: typeof data.timeAfterStallMs === 'number' && data.timeAfterStallMs >= 0,
+					},
 				};
 			});
 	}
@@ -269,5 +300,136 @@ suite('AgentSideEffects — tool call telemetry', () => {
 		toolComplete('turn-1', 'tc-inflight', { success: true, pastTenseMessage: 'ran' });
 
 		assert.strictEqual(toolEvents().length, 0);
+	});
+
+	test('emits once when a tool confirmation remains blocked', async () => {
+		await runWithFakedTimers({}, async () => {
+			setupSession();
+			startTurn('turn-1');
+
+			toolStart('turn-1', 'tc-confirm', 'write');
+			fire({
+				type: ActionType.ChatToolCallReady,
+				turnId: 'turn-1',
+				toolCallId: 'tc-confirm',
+				invocationMessage: 'Write file',
+				confirmationTitle: 'Write file',
+			});
+			fire({
+				type: ActionType.ChatToolCallReady,
+				turnId: 'turn-1',
+				toolCallId: 'tc-confirm',
+				invocationMessage: 'Write file',
+				confirmationTitle: 'Write file',
+			});
+
+			await timeout(5 * 60 * 1000);
+		});
+
+		assert.deepStrictEqual(stalledEvents(), [{
+			eventName: 'agentHost.toolCallStalled',
+			data: {
+				provider: 'mock',
+				agentSessionId: 'session-1',
+				isSubagentSession: false,
+				blockerKind: SessionInputRequestKind.ToolConfirmation,
+				toolId: 'write',
+				toolSourceKind: 'agentHost',
+				stalledTimeMs: true,
+			},
+		}]);
+	});
+
+	test('replaces confirmation tracking with client execution tracking', async () => {
+		await runWithFakedTimers({}, async () => {
+			setupSession();
+			startTurn('turn-1');
+
+			toolStart('turn-1', 'tc-client-stall', 'run_tests', { kind: ToolCallContributorKind.Client, clientId: 'client-1' });
+			fire({
+				type: ActionType.ChatToolCallReady,
+				turnId: 'turn-1',
+				toolCallId: 'tc-client-stall',
+				invocationMessage: 'Run tests',
+				confirmationTitle: 'Run tests',
+			});
+			fire({
+				type: ActionType.ChatToolCallConfirmed,
+				turnId: 'turn-1',
+				toolCallId: 'tc-client-stall',
+				approved: true,
+				confirmed: ToolCallConfirmationReason.UserAction,
+			});
+
+			await timeout(5 * 60 * 1000);
+		});
+
+		assert.deepStrictEqual(stalledEvents().map(e => e.data.blockerKind), [SessionInputRequestKind.ToolClientExecution]);
+	});
+
+	test('does not emit after a client tool completes or its turn is cancelled', async () => {
+		await runWithFakedTimers({}, async () => {
+			setupSession();
+			startTurn('turn-1');
+
+			toolStart('turn-1', 'tc-complete', 'run_tests', { kind: ToolCallContributorKind.Client, clientId: 'client-1' });
+			fire({
+				type: ActionType.ChatToolCallReady,
+				turnId: 'turn-1',
+				toolCallId: 'tc-complete',
+				invocationMessage: 'Run tests',
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+			});
+			toolComplete('turn-1', 'tc-complete', { success: true, pastTenseMessage: 'ran tests' });
+
+			toolStart('turn-1', 'tc-cancel', 'write');
+			fire({
+				type: ActionType.ChatToolCallReady,
+				turnId: 'turn-1',
+				toolCallId: 'tc-cancel',
+				invocationMessage: 'Write file',
+				confirmationTitle: 'Write file',
+			});
+			fire({ type: ActionType.ChatTurnCancelled, turnId: 'turn-1' });
+
+			await timeout(5 * 60 * 1000);
+		});
+
+		assert.deepStrictEqual(stalledEvents(), []);
+		assert.deepStrictEqual(stalledCompletionEvents(), []);
+	});
+
+	test('emits when a stalled client tool later completes', async () => {
+		await runWithFakedTimers({}, async () => {
+			setupSession();
+			startTurn('turn-1');
+
+			toolStart('turn-1', 'tc-recovered', 'run_tests', { kind: ToolCallContributorKind.Client, clientId: 'client-1' });
+			fire({
+				type: ActionType.ChatToolCallReady,
+				turnId: 'turn-1',
+				toolCallId: 'tc-recovered',
+				invocationMessage: 'Run tests',
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+			});
+
+			await timeout(5 * 60 * 1000);
+			toolComplete('turn-1', 'tc-recovered', { success: true, pastTenseMessage: 'ran tests' });
+		});
+
+		assert.deepStrictEqual(stalledCompletionEvents(), [{
+			eventName: 'agentHost.stalledToolCallCompleted',
+			data: {
+				provider: 'mock',
+				agentSessionId: 'session-1',
+				isSubagentSession: false,
+				blockerKind: SessionInputRequestKind.ToolClientExecution,
+				toolId: 'run_tests',
+				toolSourceKind: 'client',
+				result: 'success',
+				totalTimeMs: true,
+				timeAfterStallMs: true,
+			},
+		}]);
 	});
 });


### PR DESCRIPTION
We've had repeated issues with hanging on client tools, so adding some telemetry so we can track the problem.

---

## Summary

- report `agentHost.toolCallStalled` when a tool remains blocked for five minutes
- distinguish confirmation and client-execution blockers, including whether the tool is client, MCP, or Agent Host provided
- report `agentHost.stalledToolCallCompleted` when a previously stalled tool later completes
- clean up and deduplicate tracking across completion, cancellation, turn teardown, and blocker transitions

## Validation

- `npm run typecheck-client`
- `npm run gulp compile`
- focused Agent Host unit tests (118 passing)
- `npm run valid-layers-check`
- hygiene checks

(Written by Copilot)