### PR TITLE
Cache local agent host sessions for instant startup display

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
@@ -81,6 +81,17 @@ A single agent host session uses several distinct identifiers:
 
 `notify/sessionAdded` is an authoritative upsert rather than create-only. An active provisional session can already have entered `_sessionCache` through `listSessions()` with its original checkout; when materialization publishes the final project and worktree working directory, the provider updates that adapter in place and reports it as changed.
 
+### Startup session caching (persistence)
+
+To avoid an empty list on window startup — before the agent host has started, authentication has settled, and the first `listSessions()` round-trip returns — the base provider persists a lightweight snapshot of each session summary to `IStorageService` and re-hydrates it on the next launch. This machinery lives in `BaseAgentHostSessionsProvider` and is **shared by both the local and remote providers**:
+
+- A subclass opts in by calling `_enableSessionCachePersistence(storageKey)` at the end of its constructor (once the identity fields that `createAdapter` depends on are set). This hydrates persisted summaries into `_sessionCache` immediately, so `getSessions()` returns cached sessions before any live list.
+- `createAdapter`/`updateAdapter` capture the source `IAgentSessionMetadata` in `_metaByRawId`; `onWillSaveState` lazily serializes the cache (overlaying mutable fields — title, `updatedAt`, `isRead`, `isArchived` — read from each adapter's observables), capped at the 100 most-recently-modified entries under `StorageScope.APPLICATION`.
+- Hydrated entries are reconciled against the authoritative `listSessions()` on the first successful `_refreshSessions()`: stale sessions that no longer exist are pruned.
+- `_shouldTrackSessionCacheChanges()` is a hook (default `true`) the remote provider overrides to suspend dirty-tracking while its sessions are unpublished (offline), so the on-disk snapshot survives an unreachable host.
+
+The **only** per-provider difference is the storage key: local uses the fixed `localAgentHost.cachedSessions` (single machine-wide host); remote uses `remoteAgentHost.cachedSessions.${authority}` (one key per connection).
+
 ## How Chat Content Loads & Sends (no `IChatSessionItemController`)
 
 A common point of confusion is whether the Agents window needs to register an
@@ -201,6 +212,7 @@ Two synthetic filesystem providers expose JSONC settings editors:
 | Resource scheme | `agent-host-${sessionType.id}` | `remote-${authority}-${agent.provider}` |
 | Browse actions | none | host-filesystem "Folders" picker |
 | Diff URIs | `toAgentHostUri(uri, 'local')` | host-scoped mapper |
+| Startup session cache | Shared base persistence; fixed key `localAgentHost.cachedSessions` | Shared base persistence; key `remoteAgentHost.cachedSessions.${authority}` + `unpublishCachedSessions()` offline gate |
 | Extra interface members | — | `connectionStatus`, `remoteAddress`, `connect`/`disconnect` |
 
 ## Tests

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -58,6 +58,58 @@ import { createSessionFilesObs } from './agentHostSessionFiles.js';
 const STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES = 'sessions.agentHost.sessionConfigPicker.selectedValues';
 const UNSAFE_SESSION_CONFIG_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
+/** Maximum number of cached session summaries persisted per provider. */
+const CACHED_SESSIONS_MAX_PER_HOST = 100;
+
+/**
+ * Serialized shape of an {@link IAgentSessionMetadata} suitable for
+ * persisting via {@link IStorageService}. URIs are stored as strings
+ * and diffs are intentionally omitted (they are re-populated when the
+ * connection refreshes sessions).
+ */
+interface ISerializedSessionMetadata {
+	readonly session: string;
+	readonly startTime: number;
+	readonly modifiedTime: number;
+	readonly summary?: string;
+	readonly workingDirectory?: string;
+	readonly isRead?: boolean;
+	readonly isArchived?: boolean;
+	/** @deprecated Legacy name for `isArchived`. */
+	readonly isDone?: boolean;
+	readonly project?: { readonly uri: string; readonly displayName: string };
+}
+
+function serializeMetadata(meta: IAgentSessionMetadata): ISerializedSessionMetadata {
+	return {
+		session: meta.session.toString(),
+		startTime: meta.startTime,
+		modifiedTime: meta.modifiedTime,
+		summary: meta.summary,
+		workingDirectory: meta.workingDirectory?.toString(),
+		isRead: meta.isRead,
+		isArchived: meta.isArchived,
+		project: meta.project ? { uri: meta.project.uri.toString(), displayName: meta.project.displayName } : undefined,
+	};
+}
+
+function deserializeMetadata(raw: ISerializedSessionMetadata): IAgentSessionMetadata | undefined {
+	try {
+		return {
+			session: URI.parse(raw.session),
+			startTime: raw.startTime,
+			modifiedTime: raw.modifiedTime,
+			summary: raw.summary,
+			workingDirectory: raw.workingDirectory ? URI.parse(raw.workingDirectory) : undefined,
+			isRead: raw.isRead,
+			isArchived: raw.isArchived ?? raw.isDone,
+			project: raw.project ? { uri: URI.parse(raw.project.uri), displayName: raw.project.displayName } : undefined,
+		};
+	} catch {
+		return undefined;
+	}
+}
+
 function isSafeSessionConfigKey(property: string): boolean {
 	return !UNSAFE_SESSION_CONFIG_KEYS.has(property);
 }
@@ -1709,6 +1761,30 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	protected readonly _sessionCache = new Map<string, AgentHostSessionAdapter>();
 
 	/**
+	 * Storage key under which {@link _sessionCache} snapshots are persisted, or
+	 * `undefined` while persistence is disabled. Set via
+	 * {@link _enableSessionCachePersistence}, which subclasses call once their
+	 * identity fields are ready. When `undefined`, the cache is in-memory only.
+	 */
+	private _sessionCacheStorageKey: string | undefined;
+
+	/**
+	 * Snapshot of the source metadata for each adapter in {@link _sessionCache},
+	 * keyed by raw session ID. Captured in {@link createAdapter}/{@link updateAdapter}
+	 * and re-used by {@link _persistCache} to serialize sessions without having to
+	 * reconstruct every `IAgentSessionMetadata` field from observables.
+	 */
+	private readonly _metaByRawId = new Map<string, IAgentSessionMetadata>();
+
+	/**
+	 * Set when {@link _sessionCache} has changed since the last persist. The
+	 * actual write happens on the next `onWillSaveState` signal from
+	 * {@link IStorageService} so that bursts of notifications do not repeatedly
+	 * re-serialize the whole cache.
+	 */
+	private _cacheDirty = false;
+
+	/**
 	 * Active progress indicators keyed by `progressToken`. Today's only
 	 * producer is the agent host's lazy, first-use SDK download, which is
 	 * provider-global: the host emits a single stream per download keyed by the
@@ -1857,6 +1933,31 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		// live, instead of relying on the idle timer that only client actions
 		// refresh.
 		this._register(autorun(reader => this._syncVisibleSessionStatePins(reader)));
+
+		// Session-cache persistence. These listeners are inert until a subclass
+		// opts in via `_enableSessionCachePersistence` (which sets the storage
+		// key). They are safe to register unconditionally because they only act
+		// at event time and read the key lazily.
+		this._register(this._onDidChangeSessions.event(e => {
+			if (!this._shouldTrackSessionCacheChanges()) {
+				return;
+			}
+			if (e.added.length > 0 || e.removed.length > 0 || e.changed.length > 0) {
+				this._cacheDirty = true;
+			}
+			for (const removed of e.removed) {
+				const rawId = this._rawIdFromChatId(removed.sessionId);
+				if (rawId) {
+					this._metaByRawId.delete(rawId);
+				}
+			}
+		}));
+		this._register(this._storageService.onWillSaveState(() => {
+			if (this._sessionCacheStorageKey && this._cacheDirty) {
+				this._persistCache();
+				this._cacheDirty = false;
+			}
+		}));
 	}
 
 	// -- Subclass hooks -------------------------------------------------------
@@ -1892,10 +1993,13 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 			...this._adapterOptions(),
 		} satisfies IAgentHostAdapterOptions;
 
+		this._metaByRawId.set(AgentSession.id(meta.session), meta);
 		return this._instantiationService.createInstance(AgentHostSessionAdapter, meta, this.id, resourceScheme, provider, options);
 	}
 
 	protected updateAdapter(adapter: AgentHostSessionAdapter, meta: IAgentSessionMetadata): boolean {
+		this._metaByRawId.set(AgentSession.id(meta.session), meta);
+		this._cacheDirty = true;
 		return adapter.update(meta);
 	}
 
@@ -3583,6 +3687,87 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 	}
 
 	// -- Session cache management --------------------------------------------
+
+	/**
+	 * Opt in to persisting {@link _sessionCache} snapshots under `storageKey`.
+	 * Subclasses call this at the **end** of their constructor — once the
+	 * identity fields that {@link createAdapter}/{@link resourceSchemeForProvider}/
+	 * {@link _adapterOptions} depend on are initialized — because the initial
+	 * hydration builds adapters. This is why the base cannot auto-load in its
+	 * own constructor. Persisted summaries are hydrated into {@link _sessionCache}
+	 * immediately so {@link getSessions} returns them before the first
+	 * `listSessions()` round-trip resolves.
+	 */
+	protected _enableSessionCachePersistence(storageKey: string): void {
+		this._sessionCacheStorageKey = storageKey;
+		this._loadCachedSessions();
+	}
+
+	/**
+	 * Whether {@link _onDidChangeSessions} events should update the persistence
+	 * bookkeeping ({@link _cacheDirty} + {@link _metaByRawId}). Default `true`;
+	 * the remote provider overrides this to suspend tracking while its cached
+	 * sessions are unpublished (offline), so the on-disk snapshot survives.
+	 */
+	protected _shouldTrackSessionCacheChanges(): boolean {
+		return true;
+	}
+
+	/** Load persisted session summaries into {@link _sessionCache}. */
+	private _loadCachedSessions(): void {
+		if (!this._sessionCacheStorageKey) {
+			return;
+		}
+		const parsed = this._storageService.getObject(this._sessionCacheStorageKey, StorageScope.APPLICATION);
+		if (!Array.isArray(parsed)) {
+			return;
+		}
+		for (const entry of parsed as readonly ISerializedSessionMetadata[]) {
+			const meta = deserializeMetadata(entry);
+			if (!meta) {
+				continue;
+			}
+			const rawId = AgentSession.id(meta.session);
+			if (this._sessionCache.has(rawId)) {
+				continue;
+			}
+			const cached = this.createAdapter(meta);
+			this._sessionCache.set(rawId, cached);
+		}
+	}
+
+	/**
+	 * Persist the current {@link _sessionCache} to storage, capping at
+	 * {@link CACHED_SESSIONS_MAX_PER_HOST} most-recently-modified entries.
+	 * Mutable fields are read from each adapter's observables and overlaid on
+	 * top of the original metadata snapshot captured in {@link _metaByRawId}.
+	 */
+	private _persistCache(): void {
+		if (!this._sessionCacheStorageKey) {
+			return;
+		}
+		const entries: ISerializedSessionMetadata[] = [];
+		for (const [rawId, adapter] of this._sessionCache) {
+			const base = this._metaByRawId.get(rawId);
+			if (!base) {
+				continue;
+			}
+			entries.push(serializeMetadata({
+				...base,
+				summary: adapter.title.get() || base.summary,
+				modifiedTime: adapter.updatedAt.get().getTime(),
+				isRead: adapter.isRead.get(),
+				isArchived: adapter.isArchived.get(),
+			}));
+		}
+		if (entries.length === 0) {
+			this._storageService.remove(this._sessionCacheStorageKey, StorageScope.APPLICATION);
+			return;
+		}
+		entries.sort((a, b) => b.modifiedTime - a.modifiedTime);
+		const limited = entries.slice(0, CACHED_SESSIONS_MAX_PER_HOST);
+		this._storageService.store(this._sessionCacheStorageKey, JSON.stringify(limited), StorageScope.APPLICATION, StorageTarget.USER);
+	}
 
 	protected _ensureSessionCache(): void {
 		if (this._cacheInitialized) {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider.ts
@@ -39,6 +39,13 @@ import { BaseAgentHostSessionsProvider } from './baseAgentHostSessionsProvider.j
 const LOCAL_RESOURCE_SCHEME_PREFIX = 'agent-host-';
 
 /**
+ * Storage key for the local agent host's cached session summaries. There is a
+ * single machine-wide local agent host, so a fixed key (no per-authority
+ * suffix) is used; the base provider persists under `StorageScope.APPLICATION`.
+ */
+const LOCAL_AGENT_HOST_CACHED_SESSIONS_STORAGE_KEY = 'localAgentHost.cachedSessions';
+
+/**
  * Local-window sessions provider backed by the in-process
  * {@link IAgentHostService}. A thin subclass of
  * {@link BaseAgentHostSessionsProvider} that supplies the local-only
@@ -104,6 +111,12 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 		this.label = localize('localAgentHostLabel', "Local Agent Host");
 
 		this.browseActions = [];
+
+		// Hydrate previously-persisted session summaries so the sidebar shows
+		// local sessions immediately at startup, before the agent host has
+		// started and the first `listSessions()` round-trip (gated on
+		// authentication settling below) reconciles them.
+		this._enableSessionCachePersistence(LOCAL_AGENT_HOST_CACHED_SESSIONS_STORAGE_KEY);
 
 		this._attachConnectionListeners(this._agentHostService, this._store);
 

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -450,6 +450,25 @@ function fireSessionSummaryChanged(agentHost: MockAgentHostService, rawId: strin
 	});
 }
 
+/**
+ * Seed `storageService` with persisted session summaries by running a throwaway
+ * provider over a fresh agent host that lists `sessions`, then flushing so the
+ * base provider's `onWillSaveState` writes the cache to storage. Used to
+ * simulate what a previous window left behind for the next launch to hydrate.
+ */
+async function persistCachedSessions(disposables: DisposableStore, storageService: IStorageService, sessions: IAgentSessionMetadata[]): Promise<void> {
+	const host = new MockAgentHostService();
+	disposables.add(toDisposable(() => host.dispose()));
+	for (const session of sessions) {
+		host.addSession(session);
+	}
+	createProvider(disposables, host, undefined, { storageService });
+	// Let the eager refresh pick up the sessions (marking the cache dirty) then
+	// flush so the cache is persisted.
+	await timeout(0);
+	await storageService.flush();
+}
+
 suite('LocalAgentHostSessionsProvider', () => {
 	const disposables = new DisposableStore();
 	let agentHost: MockAgentHostService;
@@ -1034,6 +1053,69 @@ suite('LocalAgentHostSessionsProvider', () => {
 			eventCount: 1,
 			cachedTitles: ['Only'],
 		});
+	}));
+
+	// ---- Startup session cache (persistence) -------
+
+	test('hydrates persisted sessions on startup before the live list is available', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		const storageService = disposables.add(new InMemoryStorageService());
+		await persistCachedSessions(disposables, storageService, [createSession('cached-1', { summary: 'Cached One' })]);
+
+		// Fresh launch: authentication is still pending so the eager refresh is
+		// deferred, yet the persisted session must surface immediately.
+		const nextHost = new MockAgentHostService();
+		disposables.add(toDisposable(() => nextHost.dispose()));
+		nextHost.setAuthenticationPending(true);
+		const provider = createProvider(disposables, nextHost, undefined, { storageService });
+
+		assert.deepStrictEqual({
+			listSessionsCalls: nextHost.listSessionsCallCount,
+			cachedTitles: provider.getSessions().map(s => s.title.get()),
+		}, {
+			listSessionsCalls: 0,
+			cachedTitles: ['Cached One'],
+		});
+	}));
+
+	test('reconciles hydrated sessions against the authoritative list, pruning stale entries', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		const storageService = disposables.add(new InMemoryStorageService());
+		await persistCachedSessions(disposables, storageService, [createSession('stale-1', { summary: 'Stale' })]);
+
+		// Fresh launch with an authoritative (empty) list: the hydrated session
+		// shows immediately, then is pruned once the first refresh succeeds.
+		const nextHost = new MockAgentHostService();
+		disposables.add(toDisposable(() => nextHost.dispose()));
+		const provider = createProvider(disposables, nextHost, undefined, { storageService });
+
+		const beforeRefresh = provider.getSessions().map(s => s.title.get());
+		await timeout(0);
+		const afterRefresh = provider.getSessions().map(s => s.title.get());
+
+		assert.deepStrictEqual({ beforeRefresh, afterRefresh }, { beforeRefresh: ['Stale'], afterRefresh: [] });
+	}));
+
+	test('hydrated sessions survive a failed initial listSessions', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		const storageService = disposables.add(new InMemoryStorageService());
+		await persistCachedSessions(disposables, storageService, [createSession('resilient-1', { summary: 'Resilient' })]);
+
+		// Fresh launch where the first listSessions() throws (e.g.
+		// AHP_AUTH_REQUIRED before the token is effective). Without caching the
+		// list would be empty until the retry heals; the persisted session must
+		// stay visible throughout.
+		const nextHost = new MockAgentHostService();
+		disposables.add(toDisposable(() => nextHost.dispose()));
+		nextHost.failListSessionsCount = 1;
+		nextHost.addSession(createSession('resilient-1', { summary: 'Resilient' }));
+		const provider = createProvider(disposables, nextHost, undefined, { storageService });
+
+		await timeout(0);
+		const afterFailedList = provider.getSessions().map(s => s.title.get());
+
+		// The backoff retry (min 1s) heals; the session remains listed.
+		await timeout(1_100);
+		const afterRetry = provider.getSessions().map(s => s.title.get());
+
+		assert.deepStrictEqual({ afterFailedList, afterRetry }, { afterFailedList: ['Resilient'], afterRetry: ['Resilient'] });
 	}));
 
 	test('uses project metadata as workspace group source', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -16,7 +16,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
 import { agentHostUri } from '../../../../../platform/agentHost/common/agentHostFileSystemProvider.js';
 import { AGENT_HOST_SCHEME, agentHostAuthority, fromAgentHostUri, toAgentHostUri } from '../../../../../platform/agentHost/common/agentHostUri.js';
-import { AgentSession, type IAgentConnection, type IAgentSessionMetadata } from '../../../../../platform/agentHost/common/agentService.js';
+import { type IAgentConnection, type IAgentSessionMetadata } from '../../../../../platform/agentHost/common/agentService.js';
 import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus, remoteAgentHostLogOutputChannelId } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
 import type { ISessionGitState } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -26,7 +26,7 @@ import { IInstantiationService } from '../../../../../platform/instantiation/com
 import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
-import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IProgressService } from '../../../../../platform/progress/common/progress.js';
 import { IAgentHostActiveClientService } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostActiveClientService.js';
 import { IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
@@ -38,63 +38,11 @@ import { buildAgentHostSessionWorkspace, readBranchProtectionPatterns } from '..
 import { IGitHubInfo, ISession, ISessionType, ISessionWorkspace, ISessionWorkspaceBrowseAction, SESSION_WORKSPACE_GROUP_REMOTE } from '../../../../services/sessions/common/session.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
 import { IGitHubService } from '../../../github/browser/githubService.js';
-import { AgentHostSessionAdapter, BaseAgentHostSessionsProvider } from '../../agentHost/browser/baseAgentHostSessionsProvider.js';
+import { BaseAgentHostSessionsProvider } from '../../agentHost/browser/baseAgentHostSessionsProvider.js';
 import { remoteAgentHostSessionTypeId } from '../../../../../platform/agentHost/common/agentHostSessionType.js';
 
 /** Storage key prefix for cached session summaries, per remote address. */
 const CACHED_SESSIONS_STORAGE_PREFIX = 'remoteAgentHost.cachedSessions.';
-
-/** Maximum number of cached session summaries persisted per host. */
-const CACHED_SESSIONS_MAX_PER_HOST = 100;
-
-/**
- * Serialized shape of an {@link IAgentSessionMetadata} suitable for
- * persisting via {@link IStorageService}. URIs are stored as strings
- * and diffs are intentionally omitted (they are re-populated when the
- * connection refreshes sessions).
- */
-interface ISerializedSessionMetadata {
-	readonly session: string;
-	readonly startTime: number;
-	readonly modifiedTime: number;
-	readonly summary?: string;
-	readonly workingDirectory?: string;
-	readonly isRead?: boolean;
-	readonly isArchived?: boolean;
-	/** @deprecated Legacy name for `isArchived`. */
-	readonly isDone?: boolean;
-	readonly project?: { readonly uri: string; readonly displayName: string };
-}
-
-function serializeMetadata(meta: IAgentSessionMetadata): ISerializedSessionMetadata {
-	return {
-		session: meta.session.toString(),
-		startTime: meta.startTime,
-		modifiedTime: meta.modifiedTime,
-		summary: meta.summary,
-		workingDirectory: meta.workingDirectory?.toString(),
-		isRead: meta.isRead,
-		isArchived: meta.isArchived,
-		project: meta.project ? { uri: meta.project.uri.toString(), displayName: meta.project.displayName } : undefined,
-	};
-}
-
-function deserializeMetadata(raw: ISerializedSessionMetadata): IAgentSessionMetadata | undefined {
-	try {
-		return {
-			session: URI.parse(raw.session),
-			startTime: raw.startTime,
-			modifiedTime: raw.modifiedTime,
-			summary: raw.summary,
-			workingDirectory: raw.workingDirectory ? URI.parse(raw.workingDirectory) : undefined,
-			isRead: raw.isRead,
-			isArchived: raw.isArchived ?? raw.isDone,
-			project: raw.project ? { uri: URI.parse(raw.project.uri), displayName: raw.project.displayName } : undefined,
-		};
-	} catch {
-		return undefined;
-	}
-}
 
 function toLocalProjectUri(uri: URI, connectionAuthority: string): URI {
 	return uri.scheme === Schemas.file ? toAgentHostUri(uri, connectionAuthority) : uri;
@@ -128,7 +76,7 @@ export interface IRemoteAgentHostSessionsProviderConfig {
  * - **sessionId** - `{providerId}:{resource}` - the provider-scoped ID used by
  *   {@link ISessionsProvider} methods.
  * - Protocol operations (e.g. `disposeSession`) use the canonical agent
- *   session URI (`copilot:///abc123`), reconstructed via {@link AgentSession.uri}.
+ *   session URI (`copilot:///abc123`), reconstructed via `AgentSession.uri`.
  */
 export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvider {
 
@@ -174,20 +122,6 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 	private readonly _disconnectOnDemand: (() => Promise<void>) | undefined;
 	/** Storage key used for persisting {@link _sessionCache} snapshots. */
 	private readonly _storageKey: string;
-	/**
-	 * Set when {@link _sessionCache} has changed since the last persist.
-	 * The actual write happens on the next `onWillSaveState` signal from
-	 * {@link IStorageService} so that bursts of notifications do not
-	 * repeatedly re-serialize the whole cache.
-	 */
-	private _cacheDirty = false;
-	/**
-	 * Snapshot of the source metadata for each adapter in {@link _sessionCache},
-	 * keyed by raw session ID. Captured in {@link createAdapter} and re-used by
-	 * {@link _persistCache} to serialize sessions without having to reconstruct
-	 * every `IAgentSessionMetadata` field from observables.
-	 */
-	private readonly _metaByRawId = new Map<string, IAgentSessionMetadata>();
 	/**
 	 * When `true`, the provider has been marked unreachable and sessions are
 	 * hidden from {@link getSessions}, even though {@link _sessionCache} and
@@ -243,29 +177,7 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 			listFolders: (query, token) => this._listRemoteFolders(query, token),
 		}];
 
-		this._loadCachedSessions();
-
-		this._register(this._onDidChangeSessions.event(e => {
-			if (this._unpublished) {
-				return;
-			}
-			if (e.added.length > 0 || e.removed.length > 0 || e.changed.length > 0) {
-				this._cacheDirty = true;
-			}
-			for (const removed of e.removed) {
-				const rawId = this._rawIdFromChatId(removed.sessionId);
-				if (rawId) {
-					this._metaByRawId.delete(rawId);
-				}
-			}
-		}));
-
-		this._register(this._storageService.onWillSaveState(() => {
-			if (this._cacheDirty) {
-				this._persistCache();
-				this._cacheDirty = false;
-			}
-		}));
+		this._enableSessionCachePersistence(this._storageKey);
 	}
 
 	// -- BaseAgentHostSessionsProvider hooks ---------------------------------
@@ -274,15 +186,13 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 
 	protected get authenticationPending(): IObservable<boolean> { return this._authenticationPending; }
 
-	protected override createAdapter(meta: IAgentSessionMetadata): AgentHostSessionAdapter {
-		this._metaByRawId.set(AgentSession.id(meta.session), meta);
-		return super.createAdapter(meta);
-	}
-
-	protected override updateAdapter(adapter: AgentHostSessionAdapter, meta: IAgentSessionMetadata): boolean {
-		this._metaByRawId.set(AgentSession.id(meta.session), meta);
-		this._cacheDirty = true;
-		return super.updateAdapter(adapter, meta);
+	/**
+	 * Suspend cache-change tracking while sessions are unpublished (offline) so
+	 * the on-disk snapshot survives an unreachable host. See
+	 * {@link unpublishCachedSessions}.
+	 */
+	protected override _shouldTrackSessionCacheChanges(): boolean {
+		return !this._unpublished;
 	}
 
 	protected _adapterOptions() {
@@ -468,56 +378,6 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 		if (this._sessionCache.size > 0) {
 			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [] });
 		}
-	}
-
-	/** Load persisted session summaries into {@link _sessionCache}. */
-	private _loadCachedSessions(): void {
-		const parsed = this._storageService.getObject(this._storageKey, StorageScope.APPLICATION);
-		if (!Array.isArray(parsed)) {
-			return;
-		}
-		for (const entry of parsed as readonly ISerializedSessionMetadata[]) {
-			const meta = deserializeMetadata(entry);
-			if (!meta) {
-				continue;
-			}
-			const rawId = AgentSession.id(meta.session);
-			if (this._sessionCache.has(rawId)) {
-				continue;
-			}
-			const cached = this.createAdapter(meta);
-			this._sessionCache.set(rawId, cached);
-		}
-	}
-
-	/**
-	 * Persist the current {@link _sessionCache} to storage, capping at
-	 * {@link CACHED_SESSIONS_MAX_PER_HOST} most-recently-modified entries.
-	 * Mutable fields are read from each adapter's observables and overlaid on
-	 * top of the original metadata snapshot captured in {@link _metaByRawId}.
-	 */
-	private _persistCache(): void {
-		const entries: ISerializedSessionMetadata[] = [];
-		for (const [rawId, adapter] of this._sessionCache) {
-			const base = this._metaByRawId.get(rawId);
-			if (!base) {
-				continue;
-			}
-			entries.push(serializeMetadata({
-				...base,
-				summary: adapter.title.get() || base.summary,
-				modifiedTime: adapter.updatedAt.get().getTime(),
-				isRead: adapter.isRead.get(),
-				isArchived: adapter.isArchived.get(),
-			}));
-		}
-		if (entries.length === 0) {
-			this._storageService.remove(this._storageKey, StorageScope.APPLICATION);
-			return;
-		}
-		entries.sort((a, b) => b.modifiedTime - a.modifiedTime);
-		const limited = entries.slice(0, CACHED_SESSIONS_MAX_PER_HOST);
-		this._storageService.store(this._storageKey, JSON.stringify(limited), StorageScope.APPLICATION, StorageTarget.USER);
 	}
 
 	// -- Session-type sync ---------------------------------------------------


### PR DESCRIPTION
Fixes #324329

## What

The remote agent host sessions provider already persists a lightweight snapshot of its session summaries to storage and re-hydrates them on startup, so remote sessions show up immediately when the Agents window opens (then get reconciled against the live list). The **local** agent host had no such caching, so its list stayed empty until the in-process agent host started, authentication settled, and the first `listSessions()` round-trip returned.

This PR gives the local agent host the same "show sessions immediately at startup" behavior by **sharing one implementation** across local and remote instead of duplicating the persistence machinery.

## How

Hoist the session-summary persistence layer from `RemoteAgentHostSessionsProvider` into `BaseAgentHostSessionsProvider`:

- The base now owns serialize/deserialize, the `_metaByRawId`/`_cacheDirty` bookkeeping, and `_loadCachedSessions()` / `_persistCache()`, behind an explicit `_enableSessionCachePersistence(storageKey)` opt-in that subclasses call at the end of their constructor (once the identity fields `createAdapter` needs are set).
- A `_shouldTrackSessionCacheChanges()` hook preserves the remote provider's offline (`unpublishCachedSessions`) gate.
- The remote provider drops the migrated code and just supplies its per-authority key (`remoteAgentHost.cachedSessions.<authority>`); the local provider supplies a fixed key (`localAgentHost.cachedSessions`).

This is a behavior-preserving refactor for the remote path; the only net-new behavior is local startup hydration. Scope is the Agents window only — the editor-window agent-host surface is a separate provider and is untouched.

## Notes

- Hydrated sessions are reconciled against the authoritative `listSessions()` on the first successful refresh; stale entries are pruned.
- Starting the agent host process earlier (prewarm) and reordering the contribution so the persisted list paints even sooner is tracked separately in #324330.

## Validation

- `npm run typecheck-client`, ESLint, and `npm run valid-layers-check`: clean
- Local + remote provider unit suites: 176 passing (3 new local caching tests mirroring the remote ones; existing remote caching tests unchanged)

(Written by Copilot)
