### PR TITLE
Fix codeblock spacing when it follows a list in chat

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -696,6 +696,17 @@
 	margin: 4px 0;
 }
 
+/* Codeblocks only carry a bottom margin (see codeBlockPart.css) and rely on the previous element's bottom
+margin for the space above them. Inside lists that margin is collapsed away to keep items tight, so a codeblock
+following list content ends up with no space above it. Add a matching top margin in just those cases. */
+.interactive-item-container .value .rendered-markdown {
+	ul + [data-code],
+	ol + [data-code],
+	li > [data-code]:not(:first-child) {
+		margin-top: 16px;
+	}
+}
+
 /* NOTE- We want to dedent codeblocks in lists specifically to give them the full width. No more elegant way to do this, these values
 have to be updated for changes to the rules above, or to support more deeply nested lists. */
 .interactive-item-container .value .rendered-markdown ul .interactive-result-code-block {

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
@@ -38,6 +38,9 @@ import { IAgentHostUntitledProvisionalSessionService } from '../../../../contrib
 import { IAgentHostSessionWorkingDirectoryResolver } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostSessionWorkingDirectoryResolver.js';
 import { IAgentHostNewSessionFolderService } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostNewSessionFolderService.js';
 import { IChatAccessibilityService, IChatWidget, IChatWidgetService } from '../../../../contrib/chat/browser/chat.js';
+import { IChatOutputRendererService } from '../../../../contrib/chat/browser/chatOutputItemRenderer.js';
+import { IAiEditTelemetryService } from '../../../../contrib/editTelemetry/browser/telemetry/aiEditTelemetry/aiEditTelemetryService.js';
+import { EditSuggestionId } from '../../../../../editor/common/textModelEditSource.js';
 import { IChatAttachmentResolveService } from '../../../../contrib/chat/browser/attachments/chatAttachmentResolveService.js';
 import { IChatAttachmentWidgetRegistry } from '../../../../contrib/chat/browser/attachments/chatAttachmentWidgetRegistry.js';
 import { IChatContextPickService } from '../../../../contrib/chat/browser/attachments/chatContextPickService.js';
@@ -213,6 +216,15 @@ export function registerChatFixtureServices(reg: ServiceRegistration, options: I
 	}());
 	reg.defineInstance(IChatContextService, new class extends mock<IChatContextService>() { }());
 	reg.defineInstance(IChatContextPickService, new class extends mock<IChatContextPickService>() { }());
+	// Needed whenever chat markdown contains a code block; returns no custom renderer so
+	// code blocks fall back to the normal editor-backed CodeBlockPart.
+	reg.defineInstance(IChatOutputRendererService, new class extends mock<IChatOutputRendererService>() {
+		override hasCodeBlockRenderer() { return false; }
+	}());
+	// Chat code blocks generate a suggestion id for edit telemetry when the response completes.
+	reg.defineInstance(IAiEditTelemetryService, new class extends mock<IAiEditTelemetryService>() {
+		override createSuggestionId() { return EditSuggestionId.newId(); }
+	}());
 	reg.defineInstance(IChatAttachmentWidgetRegistry, new class extends mock<IChatAttachmentWidgetRegistry>() { }());
 	reg.defineInstance(IChatAttachmentResolveService, new class extends mock<IChatAttachmentResolveService>() { }());
 	reg.defineInstance(IChatWidgetHistoryService, new class extends mock<IChatWidgetHistoryService>() { override getHistory() { return []; } override readonly onDidChangeHistory = Event.None; }());

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatWidget.fixture.ts
@@ -373,10 +373,42 @@ const MULTI_TURN: IFixtureMessage[] = [
 	},
 ];
 
+// Code blocks that follow or are nested in list items should have symmetric spacing
+// above and below. Covers the two DOM shapes markdown produces: a code block that is a
+// sibling after a list, and a code block nested inside a list item (indented fence).
+const CODE_BLOCK_IN_LIST: IFixtureMessage[] = [
+	{
+		user: 'How do I set up the project?',
+		assistant: [
+			{
+				kind: 'markdown', text: [
+					'Follow these steps:',
+					'',
+					'- Clone the repository',
+					'- Install the dependencies',
+					'',
+					'```bash',
+					'npm install',
+					'```',
+					'',
+					'- Then start the build watcher:',
+					'',
+					'  ```bash',
+					'  npm run watch',
+					'  ```',
+					'',
+					'- Finally, launch the app',
+				].join('\n')
+			},
+		],
+	},
+];
+
 export default defineThemedFixtureGroup({ path: 'chat/widget/' }, {
 	SimpleQA: defineComponentFixture({ render: ctx => renderChatWidget(ctx, { messages: SIMPLE_QA }) }),
 	Streaming: defineComponentFixture({ labels: { kind: 'animated' }, render: ctx => renderChatWidget(ctx, { messages: STREAMING }) }),
 	PendingToolApproval: defineComponentFixture({ render: ctx => renderChatWidget(ctx, { messages: PENDING_TOOL_APPROVAL }) }),
+	CodeBlockInList: defineComponentFixture({ render: ctx => renderChatWidget(ctx, { messages: CODE_BLOCK_IN_LIST }) }),
 	bugs: defineThemedFixtureGroup({
 		'issue-309796-missing-backslash': defineComponentFixture({ render: ctx => renderChatWidget(ctx, { messages: ISSUE_309796_MISSING_BACKSLASH }) }),
 	}),


### PR DESCRIPTION
Fixes #324339

### Problem

In the chat view, a fenced code block that follows or is nested in a list had asymmetric spacing — no padding above, normal padding below:

```
- list item
- another list item
```code```
- list
```

### Cause

Chat code blocks (`.rendered-markdown [data-code]`) carry only a bottom margin and rely on the *previous* element's bottom margin for the space above them. Inside lists, list items collapse their inner paragraph margins to stay tight (`li > p { margin: 0 }`), so a code block following list content ends up with `0` above and `16px` below.

### Fix

Add a matching `16px` top margin to code blocks that follow a list or are nested in a list item. Margin collapsing leaves all other cases (after a paragraph, first child, tool calls / progress UI) unchanged.

```css
.interactive-item-container .value .rendered-markdown {
	ul + [data-code],
	ol + [data-code],
	li > [data-code]:not(:first-child) {
		margin-top: 16px;
	}
}
```

### Tests / fixtures

- Added a `CodeBlockInList` variant to `chatWidget.fixture.ts` covering both DOM shapes (code block as a sibling after a list, and nested inside a list item). It renders a real `ChatModel` through the actual chat markdown pipeline, so the screenshot baseline guards this spacing going forward.
- Writing the fixture exposed a gap: chat fixtures couldn't render any markdown code block because two services weren't registered. Added minimal mocks for `IChatOutputRendererService` and `IAiEditTelemetryService` in `chatFixtureUtils.ts`, which benefits any future chat fixture containing a code block.

Verified in the component explorer (Dark + Light) that both code blocks now have symmetric spacing.

(Written by Copilot)
