### PR TITLE
MenuService: reduce menu rebuild overhead through caching

### DIFF
--- a/src/vs/platform/action/common/action.ts
+++ b/src/vs/platform/action/common/action.ts
@@ -14,12 +14,12 @@ export interface ILocalizedString {
 	/**
 	 * The localized value of the string.
 	 */
-	value: string;
+	readonly value: string;
 
 	/**
 	 * The original (non localized value of the string)
 	 */
-	original: string;
+	readonly original: string;
 }
 
 export function isLocalizedString(thing: unknown): thing is ILocalizedString {
@@ -72,7 +72,7 @@ export interface ICommandActionSource {
 
 export interface ICommandAction {
 	id: string;
-	title: string | ICommandActionTitle;
+	readonly title: string | ICommandActionTitle;
 	shortTitle?: string | ICommandActionTitle;
 	/**
 	 * Metadata about this command, used for:

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -16,24 +16,24 @@ import { createDecorator, ServicesAccessor } from '../../instantiation/common/in
 import { IKeybindingRule, KeybindingsRegistry } from '../../keybinding/common/keybindingsRegistry.js';
 
 export interface IMenuItem {
-	command: ICommandAction;
+	readonly command: ICommandAction;
 	alt?: ICommandAction;
 	/**
 	 * Menu item is hidden if this expression returns false.
 	 */
 	when?: ContextKeyExpression;
-	group?: 'navigation' | string;
-	order?: number;
+	readonly group?: 'navigation' | string;
+	readonly order?: number;
 	isHiddenByDefault?: boolean;
 }
 
 export interface ISubmenuItem {
-	title: string | ICommandActionTitle;
+	readonly title: string | ICommandActionTitle;
 	submenu: MenuId;
 	icon?: Icon;
 	when?: ContextKeyExpression;
-	group?: 'navigation' | string;
-	order?: number;
+	readonly group?: 'navigation' | string;
+	readonly order?: number;
 	isSelection?: boolean;
 	/**
 	 * A split button shows the first action

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -469,7 +469,7 @@ export interface IMenuRegistry {
 	 */
 	appendMenuItems(items: Iterable<{ id: MenuId; item: IMenuItem | ISubmenuItem }>): IDisposable;
 	appendMenuItem(menu: MenuId, item: IMenuItem | ISubmenuItem): IDisposable;
-	getMenuItems(loc: MenuId): Array<IMenuItem | ISubmenuItem>;
+	getMenuItems(loc: MenuId): readonly (IMenuItem | ISubmenuItem)[];
 }
 
 export const MenuRegistry: IMenuRegistry = new class implements IMenuRegistry {
@@ -482,12 +482,16 @@ export const MenuRegistry: IMenuRegistry = new class implements IMenuRegistry {
 
 	readonly onDidChangeMenu: Event<IMenuRegistryChangeEvent> = this._onDidChangeMenu.event;
 
+	private readonly _menuItemCache = new Map<MenuId, readonly (IMenuItem | ISubmenuItem)[]>();
+
 	addCommand(command: ICommandAction): IDisposable {
 		this._commands.set(command.id, command);
+		this._menuItemCache.delete(MenuId.CommandPalette);
 		this._onDidChangeMenu.fire(MenuRegistryChangeEvent.for(MenuId.CommandPalette));
 
 		return markAsSingleton(toDisposable(() => {
 			if (this._commands.delete(command.id)) {
+				this._menuItemCache.delete(MenuId.CommandPalette);
 				this._onDidChangeMenu.fire(MenuRegistryChangeEvent.for(MenuId.CommandPalette));
 			}
 		}));
@@ -509,10 +513,12 @@ export const MenuRegistry: IMenuRegistry = new class implements IMenuRegistry {
 			list = new LinkedList();
 			this._menuItems.set(id, list);
 		}
+		this._menuItemCache.delete(id);
 		const rm = list.push(item);
 		this._onDidChangeMenu.fire(MenuRegistryChangeEvent.for(id));
 		return markAsSingleton(toDisposable(() => {
 			rm();
+			this._menuItemCache.delete(id);
 			this._onDidChangeMenu.fire(MenuRegistryChangeEvent.for(id));
 		}));
 	}
@@ -525,18 +531,21 @@ export const MenuRegistry: IMenuRegistry = new class implements IMenuRegistry {
 		return result;
 	}
 
-	getMenuItems(id: MenuId): Array<IMenuItem | ISubmenuItem> {
-		let result: Array<IMenuItem | ISubmenuItem>;
-		if (this._menuItems.has(id)) {
-			result = [...this._menuItems.get(id)!];
-		} else {
-			result = [];
+	getMenuItems(id: MenuId): readonly (IMenuItem | ISubmenuItem)[] {
+		const cached = this._menuItemCache.get(id);
+		if (cached) {
+			return cached;
 		}
+
+		const menuItems = this._menuItems.get(id);
+		const result = menuItems ? [...menuItems] : [];
 		if (id === MenuId.CommandPalette) {
 			// CommandPalette is special because it shows
 			// all commands by default
 			this._appendImplicitItems(result);
 		}
+		Object.freeze(result);
+		this._menuItemCache.set(id, result);
 		return result;
 	}
 

--- a/src/vs/platform/actions/common/menuService.ts
+++ b/src/vs/platform/actions/common/menuService.ts
@@ -166,6 +166,9 @@ class PersistedMenuHideState implements IDisposable {
 type MenuItemGroup = [string, Array<IMenuItem | ISubmenuItem>];
 
 class MenuInfoSnapshot {
+
+	private static readonly _contextKeysCache = new WeakMap<ContextKeyExpression, readonly string[]>();
+
 	protected _menuGroups: MenuItemGroup[] = [];
 	private _allMenuIds: Set<MenuId> = new Set();
 	private _structureContextKeys: Set<string> = new Set();
@@ -252,13 +255,29 @@ class MenuInfoSnapshot {
 	}
 
 	private static _fillInKbExprKeys(exp: ContextKeyExpression | undefined, set: Set<string>): void {
-		if (exp) {
-			for (const key of exp.keys()) {
-				set.add(key);
-			}
+		if (!exp) {
+			return;
+		}
+
+		const keys = MenuInfoSnapshot._getKeys(exp);
+		const len = keys.length;
+		for (let i = 0; i < len; i++) {
+			set.add(keys[i]);
 		}
 	}
 
+	private static _getKeys(exp: ContextKeyExpression): readonly string[] {
+		const cached = MenuInfoSnapshot._contextKeysCache.get(exp);
+
+		if (cached) {
+			return cached;
+		}
+
+		const keys = [...exp.keys()];
+		MenuInfoSnapshot._contextKeysCache.set(exp, keys);
+
+		return keys;
+	}
 }
 
 class MenuInfo extends MenuInfoSnapshot {

--- a/src/vs/platform/actions/common/menuService.ts
+++ b/src/vs/platform/actions/common/menuService.ts
@@ -263,6 +263,8 @@ class MenuInfoSnapshot {
 
 class MenuInfo extends MenuInfoSnapshot {
 
+	private static readonly _sortedMenuItems = new WeakMap<readonly (IMenuItem | ISubmenuItem)[], readonly (IMenuItem | ISubmenuItem)[]>();
+
 	constructor(
 		_id: MenuId,
 		private readonly _hiddenStates: PersistedMenuHideState,
@@ -311,7 +313,17 @@ class MenuInfo extends MenuInfoSnapshot {
 	}
 
 	protected override _sort(menuItems: readonly (IMenuItem | ISubmenuItem)[]): readonly (IMenuItem | ISubmenuItem)[] {
-		return [...menuItems].sort(MenuInfo._compareMenuItems);
+		const cached = MenuInfo._sortedMenuItems.get(menuItems);
+
+		if (cached) {
+			return cached;
+		}
+
+		const sorted = Object.freeze([...menuItems].sort(MenuInfo._compareMenuItems));
+
+		MenuInfo._sortedMenuItems.set(menuItems, sorted);
+
+		return sorted;
 	}
 
 	private static _compareMenuItems(a: IMenuItem | ISubmenuItem, b: IMenuItem | ISubmenuItem): number {

--- a/src/vs/platform/actions/common/menuService.ts
+++ b/src/vs/platform/actions/common/menuService.ts
@@ -222,7 +222,7 @@ class MenuInfoSnapshot {
 		this._allMenuIds.add(this._id);
 	}
 
-	protected _sort(menuItems: (IMenuItem | ISubmenuItem)[]) {
+	protected _sort(menuItems: readonly (IMenuItem | ISubmenuItem)[]): readonly (IMenuItem | ISubmenuItem)[] {
 		// no sorting needed in snapshot
 		return menuItems;
 	}
@@ -310,8 +310,8 @@ class MenuInfo extends MenuInfoSnapshot {
 		return result;
 	}
 
-	protected override _sort(menuItems: (IMenuItem | ISubmenuItem)[]): (IMenuItem | ISubmenuItem)[] {
-		return menuItems.sort(MenuInfo._compareMenuItems);
+	protected override _sort(menuItems: readonly (IMenuItem | ISubmenuItem)[]): readonly (IMenuItem | ISubmenuItem)[] {
+		return [...menuItems].sort(MenuInfo._compareMenuItems);
 	}
 
 	private static _compareMenuItems(a: IMenuItem | ISubmenuItem, b: IMenuItem | ISubmenuItem): number {

--- a/src/vs/platform/actions/common/menuService.ts
+++ b/src/vs/platform/actions/common/menuService.ts
@@ -272,7 +272,6 @@ class MenuInfo extends MenuInfoSnapshot {
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService
 	) {
 		super(_id, _collectContextKeysForSubmenus);
-		this.refresh();
 	}
 
 	createActionGroups(options: IMenuActionOptions | undefined): [string, Array<MenuItemAction | SubmenuItemAction>][] {

--- a/src/vs/platform/actions/test/common/menuService.test.ts
+++ b/src/vs/platform/actions/test/common/menuService.test.ts
@@ -214,4 +214,56 @@ suite('MenuService', function () {
 		assert.throws(() => new MenuId(id));
 		assert.ok(menu === MenuId.for(id));
 	});
+
+	test('getMenuItems cache stability and invalidation', function () {
+		const stable1 = MenuRegistry.getMenuItems(testMenuId);
+		const stable2 = MenuRegistry.getMenuItems(testMenuId);
+		assert.strictEqual(stable1, stable2);
+
+		disposables.add(MenuRegistry.appendMenuItem(testMenuId, {
+			command: { id: 'c1', title: 'cache invalidation on append' }
+		}));
+		const afterAppend1 = MenuRegistry.getMenuItems(testMenuId);
+		const afterAppend2 = MenuRegistry.getMenuItems(testMenuId);
+		assert.notStrictEqual(stable1, afterAppend1);
+		assert.strictEqual(stable1.length + 1, afterAppend1.length);
+		assert.strictEqual(afterAppend1, afterAppend2);
+
+		const cmdDisposable = disposables.add(MenuRegistry.appendMenuItem(testMenuId, {
+			command: { id: 'c2', title: 'cache invalidation on remove' }
+		}));
+		const beforeRemove = MenuRegistry.getMenuItems(testMenuId);
+		cmdDisposable.dispose();
+		const afterRemove1 = MenuRegistry.getMenuItems(testMenuId);
+		const afterRemove2 = MenuRegistry.getMenuItems(testMenuId);
+		assert.notStrictEqual(beforeRemove, afterRemove1);
+		assert.strictEqual(beforeRemove.length - 1, afterRemove1.length);
+		assert.strictEqual(afterRemove1, afterRemove2);
+	});
+
+	test('getMenuItems cache stability and invalidation for Command Palette', function () {
+		const stable1 = MenuRegistry.getMenuItems(MenuId.CommandPalette);
+		const stable2 = MenuRegistry.getMenuItems(MenuId.CommandPalette);
+		assert.strictEqual(stable1, stable2);
+
+		disposables.add(MenuRegistry.addCommand({
+			id: 'c1', title: 'cPalette cache invalidation on add'
+		}));
+		const afterAdd1 = MenuRegistry.getMenuItems(MenuId.CommandPalette);
+		const afterAdd2 = MenuRegistry.getMenuItems(MenuId.CommandPalette);
+		assert.notStrictEqual(stable1, afterAdd1);
+		assert.strictEqual(stable1.length + 1, afterAdd1.length);
+		assert.strictEqual(afterAdd1, afterAdd2);
+
+		const cmdDisposable = disposables.add(MenuRegistry.addCommand({
+			id: 'c2', title: 'cPalette cache invalidation on remove'
+		}));
+		const beforeRemove = MenuRegistry.getMenuItems(MenuId.CommandPalette);
+		cmdDisposable.dispose();
+		const afterRemove1 = MenuRegistry.getMenuItems(MenuId.CommandPalette);
+		const afterRemove2 = MenuRegistry.getMenuItems(MenuId.CommandPalette);
+		assert.notStrictEqual(beforeRemove, afterRemove1);
+		assert.strictEqual(beforeRemove.length - 1, afterRemove1.length);
+		assert.strictEqual(afterRemove1, afterRemove2);
+	});
 });

--- a/src/vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution.ts
+++ b/src/vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution.ts
@@ -93,6 +93,12 @@ function registerOpenTerminalCommand(id: string, explorerKind: 'integrated' | 'e
 registerOpenTerminalCommand(OPEN_IN_TERMINAL_COMMAND_ID, 'external');
 registerOpenTerminalCommand(OPEN_IN_INTEGRATED_TERMINAL_COMMAND_ID, 'integrated');
 
+function shouldShowOnLocal(mode: 'integrated' | 'external'): ContextKeyExpression | undefined {
+	return ContextKeyExpr.and(
+		ResourceContextKey.Scheme.isEqualTo(Schemas.file),
+		ContextKeyExpr.or(ContextKeyExpr.equals('config.terminal.explorerKind', mode), ContextKeyExpr.equals('config.terminal.explorerKind', 'both')));
+}
+
 const enum TerminalMenuVariant {
 	External,
 	Windows
@@ -189,11 +195,5 @@ export class ExternalTerminalContribution extends Disposable implements IWorkben
 		this.registerMenuItemOpenInTerminal(nextVariant);
 	}
 }
-
-const shouldShowOnLocal = (mode: 'integrated' | 'external'): ContextKeyExpression | undefined => {
-	return ContextKeyExpr.and(
-		ResourceContextKey.Scheme.isEqualTo(Schemas.file),
-		ContextKeyExpr.or(ContextKeyExpr.equals('config.terminal.explorerKind', mode), ContextKeyExpr.equals('config.terminal.explorerKind', 'both')));
-};
 
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(ExternalTerminalContribution, LifecyclePhase.Restored);

--- a/src/vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution.ts
+++ b/src/vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution.ts
@@ -6,7 +6,7 @@
 import * as nls from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { URI } from '../../../../base/common/uri.js';
-import { MenuId, MenuRegistry, IMenuItem } from '../../../../platform/actions/common/actions.js';
+import { MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
 import { ITerminalGroupService, ITerminalService as IIntegratedTerminalService } from '../../terminal/browser/terminal.js';
 import { ResourceContextKey } from '../../../common/contextkeys.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
@@ -15,9 +15,9 @@ import { CommandsRegistry } from '../../../../platform/commands/common/commands.
 import { Schemas } from '../../../../base/common/network.js';
 import { distinct } from '../../../../base/common/arrays.js';
 import { IRemoteAgentService } from '../../../services/remote/common/remoteAgentService.js';
-import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr, ContextKeyExpression } from '../../../../platform/contextkey/common/contextkey.js';
 import { IWorkbenchContribution, IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from '../../../common/contributions.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { isWindows } from '../../../../base/common/platform.js';
 import { dirname, basename } from '../../../../base/common/path.js';
 import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
@@ -93,56 +93,77 @@ function registerOpenTerminalCommand(id: string, explorerKind: 'integrated' | 'e
 registerOpenTerminalCommand(OPEN_IN_TERMINAL_COMMAND_ID, 'external');
 registerOpenTerminalCommand(OPEN_IN_INTEGRATED_TERMINAL_COMMAND_ID, 'integrated');
 
+const enum TerminalMenuVariant {
+	External,
+	Windows
+}
+
 export class ExternalTerminalContribution extends Disposable implements IWorkbenchContribution {
-	private _openInIntegratedTerminalMenuItem: IMenuItem;
-	private _openInTerminalMenuItem: IMenuItem;
+	private _openInIntegratedTerminalDisposable: IDisposable | undefined;
+	private _openInTerminalDisposable: IDisposable | undefined;
+	private _openInTerminalVariant: TerminalMenuVariant | undefined;
 
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService
 	) {
 		super();
 
-		const shouldShowIntegratedOnLocal = ContextKeyExpr.and(
-			ResourceContextKey.Scheme.isEqualTo(Schemas.file),
-			ContextKeyExpr.or(ContextKeyExpr.equals('config.terminal.explorerKind', 'integrated'), ContextKeyExpr.equals('config.terminal.explorerKind', 'both')));
+		this.registerMenuItemOpenInIntegratedTerminal();
+		this.registerMenuItemOpenInTerminal(TerminalMenuVariant.External);
 
+		this._register(toDisposable(() => {
+			this._openInIntegratedTerminalDisposable?.dispose();
+			this._openInTerminalDisposable?.dispose();
+			this._openInTerminalVariant = undefined;
+		}));
 
-		const shouldShowExternalKindOnLocal = ContextKeyExpr.and(
-			ResourceContextKey.Scheme.isEqualTo(Schemas.file),
-			ContextKeyExpr.or(ContextKeyExpr.equals('config.terminal.explorerKind', 'external'), ContextKeyExpr.equals('config.terminal.explorerKind', 'both')));
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('terminal.explorerKind') || e.affectsConfiguration('terminal.external')) {
+				this._refreshOpenInTerminalMenuItemVariant();
+			}
+		}));
 
-		this._openInIntegratedTerminalMenuItem = {
+		this._refreshOpenInTerminalMenuItemVariant();
+	}
+
+	private registerMenuItemOpenInIntegratedTerminal(): void {
+		this._openInIntegratedTerminalDisposable?.dispose();
+
+		const openInIntegratedTerminalMenuItem = {
 			group: 'navigation',
 			order: 30,
 			command: {
 				id: OPEN_IN_INTEGRATED_TERMINAL_COMMAND_ID,
 				title: nls.localize('scopedConsoleAction.Integrated', "Open in Integrated Terminal")
 			},
-			when: ContextKeyExpr.or(shouldShowIntegratedOnLocal, ResourceContextKey.Scheme.isEqualTo(Schemas.vscodeRemote))
+			when: ContextKeyExpr.or(
+				shouldShowOnLocal('integrated'),
+				ResourceContextKey.Scheme.isEqualTo(Schemas.vscodeRemote)
+			)
 		};
 
+		this._openInIntegratedTerminalDisposable = MenuRegistry.appendMenuItem(MenuId.ExplorerContext, openInIntegratedTerminalMenuItem);
+	}
 
-		this._openInTerminalMenuItem = {
+	private registerMenuItemOpenInTerminal(variant: TerminalMenuVariant): void {
+		this._openInTerminalDisposable?.dispose();
+
+		const title = variant === TerminalMenuVariant.External
+			? nls.localize('scopedConsoleAction.external', "Open in External Terminal")
+			: nls.localize('scopedConsoleAction.wt', "Open in Windows Terminal");
+
+		const openInTerminalMenuItem = {
 			group: 'navigation',
 			order: 31,
 			command: {
 				id: OPEN_IN_TERMINAL_COMMAND_ID,
-				title: nls.localize('scopedConsoleAction.external', "Open in External Terminal")
+				title
 			},
-			when: shouldShowExternalKindOnLocal
+			when: shouldShowOnLocal('external')
 		};
 
-
-		MenuRegistry.appendMenuItem(MenuId.ExplorerContext, this._openInTerminalMenuItem);
-		MenuRegistry.appendMenuItem(MenuId.ExplorerContext, this._openInIntegratedTerminalMenuItem);
-
-		this._register(this._configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration('terminal.explorerKind') || e.affectsConfiguration('terminal.external')) {
-				this._refreshOpenInTerminalMenuItemTitle();
-			}
-		}));
-
-		this._refreshOpenInTerminalMenuItemTitle();
+		this._openInTerminalDisposable = MenuRegistry.appendMenuItem(MenuId.ExplorerContext, openInTerminalMenuItem);
+		this._openInTerminalVariant = variant;
 	}
 
 	private isWindows(): boolean {
@@ -156,11 +177,23 @@ export class ExternalTerminalContribution extends Disposable implements IWorkben
 		return false;
 	}
 
-	private _refreshOpenInTerminalMenuItemTitle(): void {
-		if (this.isWindows()) {
-			this._openInTerminalMenuItem.command.title = nls.localize('scopedConsoleAction.wt', "Open in Windows Terminal");
+	private _refreshOpenInTerminalMenuItemVariant(): void {
+		const nextVariant = this.isWindows()
+			? TerminalMenuVariant.Windows
+			: TerminalMenuVariant.External;
+
+		if (nextVariant === this._openInTerminalVariant) {
+			return;
 		}
+
+		this.registerMenuItemOpenInTerminal(nextVariant);
 	}
 }
+
+const shouldShowOnLocal = (mode: 'integrated' | 'external'): ContextKeyExpression | undefined => {
+	return ContextKeyExpr.and(
+		ResourceContextKey.Scheme.isEqualTo(Schemas.file),
+		ContextKeyExpr.or(ContextKeyExpr.equals('config.terminal.explorerKind', mode), ContextKeyExpr.equals('config.terminal.explorerKind', 'both')));
+};
 
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(ExternalTerminalContribution, LifecyclePhase.Restored);

--- a/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
@@ -1088,7 +1088,27 @@ menusExtensionPoint.setHandler(extensions => {
 			}
 
 			for (const menuItem of entry[1]) {
+				if (menu.id === MenuId.ViewContainerTitle && !menuItem.when?.includes('viewContainer == workbench.view.debug')) {
+					// Not a perfect check but enough to communicate that this proposed extension point is currently only for the debug view container
+					collector.error(localize('viewContainerTitle.when', "The {0} menu contribution must check {1} in its {2} clause.", '`viewContainer/title`', '`viewContainer == workbench.view.debug`', '"when"'));
+					continue;
+				}
+
 				let item: IMenuItem | ISubmenuItem;
+
+				let group: string | undefined;
+				let order: number | undefined;
+				const when = ContextKeyExpr.deserialize(menuItem.when);
+
+				if (menuItem.group) {
+					const idx = menuItem.group.lastIndexOf('@');
+					if (idx > 0) {
+						group = menuItem.group.substr(0, idx);
+						order = Number(menuItem.group.substr(idx + 1)) || undefined;
+					} else {
+						group = menuItem.group;
+					}
+				}
 
 				if (schema.isMenuItem(menuItem)) {
 					const command = MenuRegistry.getCommand(menuItem.command);
@@ -1105,7 +1125,7 @@ menusExtensionPoint.setHandler(extensions => {
 						collector.info(localize('dupe.command', "Menu item references the same command as default and alt-command"));
 					}
 
-					item = { command, alt, group: undefined, order: undefined, when: undefined };
+					item = { command, alt, group, order, when };
 				} else {
 					if (menu.supportsSubmenus === false) {
 						collector.error(localize('unsupported.submenureference', "Menu item references a submenu for a menu which doesn't have submenu support."));
@@ -1133,26 +1153,9 @@ menusExtensionPoint.setHandler(extensions => {
 
 					submenuRegistrations.add(submenu.id.id);
 
-					item = { submenu: submenu.id, icon: submenu.icon, title: submenu.label, group: undefined, order: undefined, when: undefined };
+					item = { submenu: submenu.id, icon: submenu.icon, title: submenu.label, group, order, when };
 				}
 
-				if (menuItem.group) {
-					const idx = menuItem.group.lastIndexOf('@');
-					if (idx > 0) {
-						item.group = menuItem.group.substr(0, idx);
-						item.order = Number(menuItem.group.substr(idx + 1)) || undefined;
-					} else {
-						item.group = menuItem.group;
-					}
-				}
-
-				if (menu.id === MenuId.ViewContainerTitle && !menuItem.when?.includes('viewContainer == workbench.view.debug')) {
-					// Not a perfect check but enough to communicate that this proposed extension point is currently only for the debug view container
-					collector.error(localize('viewContainerTitle.when', "The {0} menu contribution must check {1} in its {2} clause.", '`viewContainer/title`', '`viewContainer == workbench.view.debug`', '"when"'));
-					continue;
-				}
-
-				item.when = ContextKeyExpr.deserialize(menuItem.when);
 				_menuRegistrations.add(MenuRegistry.appendMenuItem(menu.id, item));
 			}
 		}


### PR DESCRIPTION
Partially addresses #324355

## Overview

This PR reduces MenuService overhead during TreeView scrolling and other components item rendering by eliminating repeated work performed while menus are rebuilt for visible items.

Performance investigation #324355 showed that menu processing is executed multiple times for the same element during a single rendering cycle, causing identical menu structures to be repeatedly sorted and analyzed even though neither menu registrations nor context key expressions change during scrolling. This PR focuses on removing that redundant work.

* `_sort`
* `_collectContextKeysAndSubmenuIds`

was responsible for a substantial portion of the frame time. In addition, context key expression processing continuously allocated new arrays during menu reconstruction.

The changes in this PR focus on removing these repeated computations and allocations while preserving correctness through immutability guarantees and cache-safe data structures.

## Changes (per commit)

### 1. MenuInfo: Remove duplicate refresh during initialization

`MenuInfo` extends `MenuInfoSnapshot`, and both constructors ended up triggering `refresh()` during initialization.

This change removes the duplicate refresh call, avoiding redundant menu processing during construction.

### 2. Make IMenuItem and ISubmenuItem properties immutable

Caching sorted menu structures requires stable sorting inputs.

The properties involved in menu ordering were made `readonly` to guarantee sorting cache correctness. More properties could potentially be made immutable in the future, but this PR limits changes to the fields required for sorting stability. For example, the `when` property is still constructed and modified in multiple places before command registration and would require a broader refactoring before the entire interface can become immutable.

During this work, `ExternalTerminalContribution` was identified as the only place in the codebase mutating a registered menu command title. The mutation was replaced with command re-registration, preserving immutability assumptions.

This also fixes an existing issue where the terminal command title could switch to the Windows-specific variant but never switch back when the configuration changed.

### 3. MenuRegistry: cache stable readonly menu item arrays

`MenuRegistry.getMenuItems()` previously produced new array instances even when menu contents remained unchanged.

This change introduces stable `readonly` arrays that are reused while the underlying menu structure remains unchanged.

Since menu registrations typically change very infrequently compared to how often menus are queried, reusing stable arrays is beneficial on its own and also enables additional optimizations built on top of array identity.

### 4. MenuInfo: cache sorted menu item arrays

As of the previous change, `MenuRegistry` now returns stable menu item arrays.

This makes it possible to cache `MenuInfo._sort` results and reuse them whenever the source menu array instance is unchanged, relying on the fact that all properties participating in sorting are now immutable.

This removes repeated sorting work and the associated allocations during menu reconstruction.

Caching was initially implemented at the `MenuInfo` instance level, but this proved ineffective because `MenuInfo` instances themselves are not reused. As a result, a global `WeakMap` cache keyed by the stable source array identity was adopted as the most effective approach.

### 5. MenuService: cache ContextKeyExpression.keys() results

Profiling showed that `ContextKeyExpression.keys()` is the primary contributor to the cost of `MenuInfoSnapshot._collectContextKeysAndSubmenuIds`.

Every call recursively created new arrays even though context key expressions are immutable and frequently reused.

All expression implementations were reviewed to verify that the contents and ordering of `keys()` results remain stable for the lifetime of an expression instance.

While expression classes could potentially cache their own `keys()` results internally, this PR intentionally avoids changing expression implementations and instead introduces caching at the `MenuService` level using a `WeakMap`.

Benefits:

* Eliminates repeated `keys()` allocations
* Removes most `keys()` processing from performance traces
* Reduces garbage collection pressure
* Further improves menu refresh performance after sorting costs have been removed

## Notes

The optimizations intentionally rely on object identity and immutability guarantees rather than invalidation logic.

Where caching was introduced, prerequisites were implemented and inspected first to guarantee correctness and prevent stale results.

## Performance Results

Tests were performed incrementally after each optimization commit by rapidly scrolling up and down for approximately 10 seconds in an OSS debug build.

<details>
  <summary>Measurement code</summary>
  Counts renderElement calls and outputs result on 2 seconds of idling.
  <br><br>

```ts
export class ListView<T> implements IListView<T> {
	private insertItemInDOM(index: number, row?: IRow): void {

		// ...

		const renderer = this.renderers.get(item.templateId);

		if (!renderer) {
			throw new Error(`No renderer found for template id ${item.templateId}`);
		} else {
			perfTickStart();
			try {
				renderer.renderElement(item.element, index, item.row.templateData, { height: item.size });
			} finally {
				perfTickEnd();
			}
		}

		// ...

	}
}

let measureTimeout: TimeoutHandle | undefined;
let measureStart = 0;
let measureTickStart = 0;
let measureCount = 0;
let measureLoad = 0;
let measureLastTickEnd = 0;

const perfTickStart = () => {
	if (measureTimeout === undefined) {
		measureTimeout = setTimeout(perfStop, 2000);

		measureStart = performance.now();
		measureTickStart = measureStart;
		measureCount = 0;
		measureLoad = 0;
	} else {
		clearTimeout(measureTimeout);
		measureTimeout = setTimeout(perfStop, 2000);
		measureTickStart = performance.now();
	}
};

const perfTickEnd = () => {
	const now = performance.now();
	measureLoad += now - measureTickStart;
	measureCount++;
	measureLastTickEnd = now;
};

const perfStop = () => {
	measureTimeout = undefined;

	const duration = measureLastTickEnd - measureStart;
	if (measureCount > 0 && duration > 0) {
		const loadPercent = (measureLoad / duration) * 100;
		console.log(`renderElement: calls=${measureCount}, avg=${(measureLoad / measureCount).toFixed(3)}ms, total ${measureLoad.toFixed(1)}ms, duration=${duration.toFixed(1)}ms, utilization=${loadPercent.toFixed(1)}%`);
	}
};
```
</details>

<details>
  <summary>Measurement results</summary>

```
0. Baseline
renderElement: calls=549, avg=3.964ms, total 2176.1ms, duration=8820.6ms, utilization=24.7%
renderElement: calls=563, avg=3.645ms, total 2052.0ms, duration=9847.7ms, utilization=20.8%
renderElement: calls=466, avg=3.925ms, total 1828.9ms, duration=8901.2ms, utilization=20.5%


1. Remove duplicate refresh
renderElement: calls=493, avg=2.969ms, total 1463.5ms, duration=8202.1ms, utilization=17.8%
renderElement: calls=552, avg=2.918ms, total 1610.9ms, duration=9727.0ms, utilization=16.6%
renderElement: calls=538, avg=2.916ms, total 1568.7ms, duration=8983.2ms, utilization=17.5%

Approximately 24% average renderElement time reduction.


2. Immutability changes

No measurable performance impact by themselves.
These changes were introduced to guarantee cache correctness for subsequent optimizations.


3. Cache stable menu item arrays in MenuRegistry
renderElement: calls=612, avg=2.787ms, total 1705.4ms, duration=9362.6ms, utilization=18.2%
renderElement: calls=620, avg=2.861ms, total 1773.8ms, duration=9345.3ms, utilization=19.0%
renderElement: calls=555, avg=2.954ms, total 1639.3ms, duration=8371.2ms, utilization=19.6%

No significant average renderElement improvement was observed directly, but the number of completed render calls
increased noticeably. This is likely a consequence of reduced allocation pressure and less GC interference.


### 4. Cache MenuInfo sorting results
renderElement: calls=611, avg=2.736ms, total 1671.8ms, duration=9455.5ms, utilization=17.7%
renderElement: calls=618, avg=2.765ms, total 1708.8ms, duration=9388.7ms, utilization=18.2%
renderElement: calls=676, avg=2.703ms, total 1826.9ms, duration=9644.7ms, utilization=18.9%

Total average improvement versus baseline: approximately 29%.


### 5. Cache ContextKeyExpression.keys() results
renderElement: calls=706, avg=2.349ms, total 1658.4ms, duration=9397.7ms, utilization=17.6%
renderElement: calls=727, avg=2.344ms, total 1704.1ms, duration=9728.9ms, utilization=17.5%
renderElement: calls=752, avg=2.367ms, total 1780.3ms, duration=9824.9ms, utilization=18.1%

Both render call count and average renderElement duration improved. Profiling also showed that
ContextKeyExpression.keys() almost completely disappeared from the relevant performance traces
after this change. Total average improvement versus baseline: approximately 35-40%.
```
</details>

### Summary

Average renderElement duration:

* Baseline: approximately **3.8–4.0 ms**
* After all optimizations: approximately **2.3–2.4 ms**

This represents roughly a 35–40% reduction in renderElement execution time during scrolling, and likely benefits other menu-heavy scenarios as well.

## Notes

The OSS build does not exhibit the same severity of performance issues described in the #324355. In particular, `_sort` is not always visible as a significant contributor in OSS traces, even before these optimizations, so commit 4 may be somewhat underrepresented in the measurements above.

However, in the user setup that motivated the investigation, animation frame execution could reach **100–200 ms**, with `_sort` and `_collectContextKeysAndSubmenuIds` together contributing up to approximately **65%** of the total frame cost.

Because these optimizations directly target those hot paths and eliminate a large amount of repeated work and allocations, the expected impact should scale more favorably in scenarios similar to the linked issue than is reflected by the OSS measurements alone.