### PR TITLE
Git - treat clean paths as literal pathspecs

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -2289,7 +2289,7 @@ export class Repository {
 
 		const limiter = new Limiter<IExecutionResult<string>>(5);
 		const promises: Promise<IExecutionResult<string>>[] = [];
-		const args = ['clean', '-f', '-q'];
+		const args = ['--literal-pathspecs', 'clean', '-f', '-q'];
 
 		for (const paths of groups) {
 			for (const chunk of splitInChunks(paths.map(p => this.sanitizeRelativePath(p)), MAX_CLI_LENGTH)) {

--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import type { GitExtension, API, Repository } from '../api/git';
 import { Status } from '../api/git.constants';
 import { eventToPromise } from '../util';
+import { Git } from '../git';
 
 suite('git smoke test', function () {
 	const cwd = workspace.workspaceFolders![0].uri.fsPath;
@@ -145,6 +146,31 @@ suite('git smoke test', function () {
 
 		assert.strictEqual(repository.state.workingTreeChanges.length, 0);
 		assert.strictEqual(repository.state.indexChanges.length, 0);
+	});
+
+	test('cleans paths literally #133566', async function () {
+		const repositoryRoot = file('repository with spaces');
+		const literalPath = path.join(repositoryRoot, '[target]');
+		const globMatchPath = path.join(repositoryRoot, 't');
+		const logger = window.createOutputChannel('Git Clean Test', { log: true });
+
+		try {
+			fs.mkdirSync(repositoryRoot);
+			const git = new Git({ gitPath: 'git', version: '2.0.0', userAgent: 'test' });
+			await git.init(repositoryRoot);
+			const testRepository = git.open(repositoryRoot, undefined, await git.getRepositoryDotGit(repositoryRoot), logger);
+
+			fs.writeFileSync(literalPath, '');
+			fs.writeFileSync(globMatchPath, '');
+
+			await testRepository.clean([literalPath]);
+
+			assert.strictEqual(fs.existsSync(literalPath), false);
+			assert.strictEqual(fs.existsSync(globMatchPath), true);
+		} finally {
+			logger.dispose();
+			fs.rmSync(repositoryRoot, { recursive: true, force: true });
+		}
 	});
 
 	test('rename/delete conflict', async function () {


### PR DESCRIPTION
## Summary

- pass `--literal-pathspecs` to targeted `git clean` operations so pathspec metacharacters in filenames cannot match other untracked files
- add a cross-platform regression test using a repository path with spaces and the filenames `[target]` and `t`

The previous fix in #236849 escaped shell-sensitive characters in paths, but it was reverted by #237388 after breaking repositories whose paths contained spaces (#237331). This change leaves paths untouched and instead asks Git to interpret every clean pathspec literally.

## Testing

- `npm --prefix extensions/git run compile`
- `./scripts/test-integration.sh --suite git --grep "cleans paths literally"`
- `./node_modules/.bin/eslint extensions/git/src/git.ts extensions/git/src/test/smoke.test.ts`

Fixes #133566