### PR TITLE
fix: dispose orphaned simple browser panel on duplicate restore

### DIFF
--- a/extensions/simple-browser/src/simpleBrowserManager.ts
+++ b/extensions/simple-browser/src/simpleBrowserManager.ts
@@ -35,7 +35,13 @@ export class SimpleBrowserManager {
 		const url = state?.url ?? '';
 		const view = SimpleBrowserView.restore(this.extensionUri, url, panel);
 		this.registerWebviewListeners(view);
-		this._activeView ??= view;
+		if (this._activeView) {
+			// show() already created a view while restore was pending (race on startup).
+			// Dispose this panel to avoid a duplicate simple browser.
+			view.dispose();
+		} else {
+			this._activeView = view;
+		}
 	}
 
 	private registerWebviewListeners(view: SimpleBrowserView) {


### PR DESCRIPTION
Fixes #182795

## Root cause

When VS Code restores a session, `deserializeWebviewPanel` calls `SimpleBrowserManager.restore()`. If `show()` is triggered around the same time (e.g. from an external URI opener or a LiveShare/dev-server notification), a race exists:

1. `show()` runs first — `_activeView` is `undefined`, so it creates a new panel and sets `_activeView`
2. `restore()` then runs — creates a second panel from the saved state, but `_activeView ??= view` does nothing because `_activeView` is already set
3. The restored panel is now visible in the UI but completely untracked by the manager — two simple browser panels are open

## Fix

Replace the silent `??=` with an explicit check. When `_activeView` is already set, dispose the restored panel immediately so it never becomes visible to the user. When `_activeView` is not set (the normal path), assign it as before.

```diff
- this._activeView ??= view;
+ if (this._activeView) {
+     view.dispose();
+ } else {
+     this._activeView = view;
+ }
```

One file changed, `extensions/simple-browser/src/simpleBrowserManager.ts`.