### PR TITLE
Agent host: feed `!command` context into the next model message

### DIFF
--- a/src/vs/platform/agentHost/common/sessionDataService.ts
+++ b/src/vs/platform/agentHost/common/sessionDataService.ts
@@ -96,6 +96,13 @@ export interface ILocalTurnRecord {
 	seq: number;
 	/** JSON-serialized protocol `Turn`. */
 	payload: string;
+	/**
+	 * Optional model-facing context contributed by this local turn (e.g. the
+	 * command a `!command` ran and its output). Prepended to the next real
+	 * message so the model learns what the user did out-of-band. `undefined`
+	 * for local turns that contribute nothing (e.g. `/rename`).
+	 */
+	modelContext?: string;
 }
 
 

--- a/src/vs/platform/agentHost/node/agentHostLocalTurns.ts
+++ b/src/vs/platform/agentHost/node/agentHostLocalTurns.ts
@@ -27,8 +27,8 @@ import type { Turn } from '../common/state/sessionState.js';
  */
 export class AgentHostLocalTurns {
 
-	/** chat URI → (localTurnId → { anchorTurnId, seq }). */
-	private readonly _byChat = new Map<string, Map<string, { readonly anchorTurnId: string | undefined; readonly seq: number }>>();
+	/** chat URI → (localTurnId → { anchorTurnId, seq, modelContext }). */
+	private readonly _byChat = new Map<string, Map<string, { readonly anchorTurnId: string | undefined; readonly seq: number; readonly modelContext: string | undefined }>>();
 	/** session URI → highest `seq` assigned so far (seq is session-global for stable ordering). */
 	private readonly _seqBySession = new Map<string, number>();
 
@@ -60,14 +60,52 @@ export class AgentHostLocalTurns {
 	}
 
 	/**
+	 * Returns the model-facing context contributed by the local turn `turnId` in
+	 * `chat`, or `undefined` when it is not a local turn or contributes nothing.
+	 */
+	getModelContext(chat: string, turnId: string): string | undefined {
+		return this._byChat.get(chat)?.get(turnId)?.modelContext;
+	}
+
+	/**
+	 * Collects the model-facing context of the *pending* local turns in `chat`:
+	 * the trailing local turns in `turns` (the completed transcript), i.e. those
+	 * recorded after the last concrete (SDK-backed) turn and not yet followed by
+	 * a real message, so the model has not seen them. The in-flight real message
+	 * being sent is not part of `turns` (it lives in the active turn), so the
+	 * pending locals are exactly the trailing ones. Returned in chronological
+	 * order so callers can prepend them to the next real message.
+	 */
+	collectPendingModelContext(chat: string, turns: readonly Turn[]): string[] {
+		const map = this._byChat.get(chat);
+		if (!map) {
+			return [];
+		}
+		const contexts: string[] = [];
+		for (let i = turns.length - 1; i >= 0; i--) {
+			const entry = map.get(turns[i].id);
+			if (!entry) {
+				// Hit a concrete turn the model has already seen — stop.
+				break;
+			}
+			if (entry.modelContext !== undefined) {
+				contexts.unshift(entry.modelContext);
+			}
+		}
+		return contexts;
+	}
+
+	/**
 	 * Persist a local turn and remember it in memory. `anchorTurnId` is the id
 	 * of the preceding concrete turn in `chat` (or `undefined` when there is
-	 * none). `session` identifies the database to persist into.
+	 * none). `session` identifies the database to persist into. `modelContext`,
+	 * when provided, is prepended to the next real message so the model learns
+	 * what the user did out-of-band.
 	 */
-	record(session: string, chat: string, turn: Turn, anchorTurnId: string | undefined): void {
+	record(session: string, chat: string, turn: Turn, anchorTurnId: string | undefined, modelContext?: string): void {
 		const seq = (this._seqBySession.get(session) ?? 0) + 1;
-		this._noteInMemory(session, chat, turn.id, anchorTurnId, seq);
-		const record: ILocalTurnRecord = { turnId: turn.id, chatUri: chat, anchorTurnId, seq, payload: JSON.stringify(turn) };
+		this._noteInMemory(session, chat, turn.id, anchorTurnId, seq, modelContext);
+		const record: ILocalTurnRecord = { turnId: turn.id, chatUri: chat, anchorTurnId, seq, payload: JSON.stringify(turn), modelContext };
 		let ref: IReference<ISessionDatabase>;
 		try {
 			ref = this._sessionDataService.openDatabase(URI.parse(session));
@@ -89,11 +127,6 @@ export class AgentHostLocalTurns {
 	async loadForChat(session: string, chat: string): Promise<ILocalTurnRecord[]> {
 		const records = await this._load(session);
 		return records.filter(r => r.chatUri === chat);
-	}
-
-	/** Note a local turn in memory only (used by fork seeding). */
-	noteInMemory(session: string, chat: string, turnId: string, anchorTurnId: string | undefined, seq: number): void {
-		this._noteInMemory(session, chat, turnId, anchorTurnId, seq);
 	}
 
 	/** Delete the given local turns from memory and the session database. */
@@ -119,11 +152,6 @@ export class AgentHostLocalTurns {
 		}).finally(() => ref.dispose());
 	}
 
-	/** Drop all in-memory state for a chat. */
-	forgetChat(chat: string): void {
-		this._byChat.delete(chat);
-	}
-
 	private async _load(session: string): Promise<ILocalTurnRecord[]> {
 		const ref = this._sessionDataService.tryOpenDatabase?.(URI.parse(session));
 		if (!ref) {
@@ -137,7 +165,7 @@ export class AgentHostLocalTurns {
 			try {
 				const records = await db.object.getLocalTurns();
 				for (const r of records) {
-					this._noteInMemory(session, r.chatUri, r.turnId, r.anchorTurnId, r.seq);
+					this._noteInMemory(session, r.chatUri, r.turnId, r.anchorTurnId, r.seq, r.modelContext);
 				}
 				return records;
 			} finally {
@@ -149,13 +177,13 @@ export class AgentHostLocalTurns {
 		}
 	}
 
-	private _noteInMemory(session: string, chat: string, turnId: string, anchorTurnId: string | undefined, seq: number): void {
+	private _noteInMemory(session: string, chat: string, turnId: string, anchorTurnId: string | undefined, seq: number, modelContext: string | undefined): void {
 		let map = this._byChat.get(chat);
 		if (!map) {
 			map = new Map();
 			this._byChat.set(chat, map);
 		}
-		map.set(turnId, { anchorTurnId, seq });
+		map.set(turnId, { anchorTurnId, seq, modelContext });
 		this._seqBySession.set(session, Math.max(this._seqBySession.get(session) ?? 0, seq));
 	}
 }

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -1042,7 +1042,8 @@ export class AgentService extends Disposable implements IAgentService {
 			}
 			const originalAnchor = this._localTurns.resolveConcreteTurnId(sourceChatUri, original.id);
 			const newAnchor = originalAnchor !== undefined ? mapping.get(originalAnchor) : undefined;
-			this._localTurns.record(persistSession, newChatUri, forkedTurns[i], newAnchor);
+			const modelContext = this._localTurns.getModelContext(sourceChatUri, original.id);
+			this._localTurns.record(persistSession, newChatUri, forkedTurns[i], newAnchor, modelContext);
 		}
 	}
 

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -1343,7 +1343,13 @@ export class AgentSideEffects extends Disposable {
 
 		await Promise.all(selectionUpdates);
 
-		await agent.chats.sendMessage(chatUri, message.text, message.attachments, turnId, senderClientId).catch(err => {
+		// Prepend the context of any pending host-injected local turns (e.g.
+		// `!command` runs the model never saw) so the model learns what the user
+		// did out-of-band. Only the text sent to the agent is augmented — the
+		// transcript / UI message is unchanged.
+		const text = this._augmentWithPendingLocalContext(chat, message.text);
+
+		await agent.chats.sendMessage(chatUri, text, message.attachments, turnId, senderClientId).catch(err => {
 			const errCode = (err as { code?: number })?.code;
 			this._logService.error(`[AgentSideEffects] sendMessage failed for session=${turnChannel}: code=${errCode}, message=${err instanceof Error ? err.message : String(err)}, type=${err?.constructor?.name}`, err);
 			this._stateManager.dispatchServerAction(turnChannel, {
@@ -1354,6 +1360,26 @@ export class AgentSideEffects extends Disposable {
 			this._turnTracker.turnCompleted(turnChannel, turnId, 'error');
 			this._toolCallTracker.clearSession(turnChannel);
 		});
+	}
+
+	/**
+	 * Prepends the model-facing context of the pending host-injected local turns
+	 * in `chat` (the trailing locals in the transcript — see
+	 * {@link AgentHostLocalTurns.collectPendingModelContext}) to `text`. Returns
+	 * `text` unchanged when there is no pending context. The in-flight real
+	 * message being sent lives in the active turn, so the pending locals are the
+	 * trailing completed turns the model has not yet seen.
+	 */
+	private _augmentWithPendingLocalContext(chat: ProtocolURI, text: string): string {
+		const turns = this._stateManager.getSessionState(chat)?.turns;
+		if (!turns) {
+			return text;
+		}
+		const context = this._options.localTurns.collectPendingModelContext(chat, turns);
+		if (context.length === 0) {
+			return text;
+		}
+		return `${context.join('\n\n')}\n\n${text}`;
 	}
 
 

--- a/src/vs/platform/agentHost/node/localCommands/bangLocalCommand.ts
+++ b/src/vs/platform/agentHost/node/localCommands/bangLocalCommand.ts
@@ -10,7 +10,7 @@ import { localize } from '../../../../nls.js';
 import type { CreateTerminalParams } from '../../common/state/protocol/commands.js';
 import { TerminalClaimKind, type TerminalSessionClaim } from '../../common/state/protocol/state.js';
 import { ActionType } from '../../common/state/sessionActions.js';
-import { isAhpChatChannel, parseRequiredSessionUriFromChatUri, ToolCallConfirmationReason, ToolResultContentType, type ToolResultContent, type URI as ProtocolURI } from '../../common/state/sessionState.js';
+import { isAhpChatChannel, parseRequiredSessionUriFromChatUri, ResponsePartKind, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, type ToolResultContent, type Turn, type URI as ProtocolURI } from '../../common/state/sessionState.js';
 import { parseBangCommand } from '../agentHostBangCommand.js';
 import { DEFAULT_SHELL_COMMAND_TIMEOUT_MS, executeShellCommand, shellTypeForExecutable, type IShellCommandResult } from '../shared/shellCommandExecution.js';
 import { ILocalChatCommand, ILocalChatCommandContext, ILocalChatCommandRequest, LocalChatCommandRegistry } from './localChatCommand.js';
@@ -45,6 +45,41 @@ export class BangLocalCommand extends Disposable implements ILocalChatCommand {
 			return undefined;
 		}
 		return () => this._run(request.turnChannel, request.turnId, command);
+	}
+
+	/**
+	 * Contributes the command the user ran and its captured output as
+	 * model-facing context so the next real message tells the model what
+	 * happened out-of-band. Reads the completed terminal tool call from the
+	 * (already sanitized) turn; returns `undefined` when no command is present.
+	 */
+	getModelContext(turn: Turn): string | undefined {
+		const part = turn.responseParts.find(p => p.kind === ResponsePartKind.ToolCall && p.toolCall.toolName === 'terminal');
+		if (!part || part.kind !== ResponsePartKind.ToolCall) {
+			return undefined;
+		}
+		const toolCall = part.toolCall;
+		// A finished bang tool call is always Completed (it never requests
+		// result confirmation); this narrows to the state carrying toolInput and
+		// content without an `in` check.
+		if (toolCall.status !== ToolCallStatus.Completed) {
+			return undefined;
+		}
+		const command = toolCall.toolInput;
+		if (!command) {
+			return undefined;
+		}
+		const output = (toolCall.content ?? [])
+			.flatMap(c => c.type === ToolResultContentType.Text ? [c.text] : [])
+			.join('\n')
+			.trim();
+		const lines = [`The user ran a terminal command themselves (not the assistant):`, '', `$ ${command}`];
+		if (output) {
+			lines.push('', 'Output:', output);
+		} else {
+			lines.push('', '(no output)');
+		}
+		return lines.join('\n');
 	}
 
 	private async _run(turnChannel: ProtocolURI, turnId: string, command: string): Promise<void> {

--- a/src/vs/platform/agentHost/node/localCommands/localChatCommand.ts
+++ b/src/vs/platform/agentHost/node/localCommands/localChatCommand.ts
@@ -73,6 +73,16 @@ export interface ILocalChatCommand extends IDisposable {
 	 * forwards the message to the agent).
 	 */
 	tryHandle(request: ILocalChatCommandRequest): (() => Promise<void>) | undefined;
+
+	/**
+	 * Optional model-facing context contributed by this command's completed
+	 * local turn `turn` — for example the command a `!command` ran and its
+	 * output. Persisted with the local turn and prepended to the next real
+	 * message so the model learns what the user did out-of-band. Return
+	 * `undefined` to contribute nothing (the default for commands that omit
+	 * this).
+	 */
+	getModelContext?(turn: Turn): string | undefined;
 }
 
 /** Constructs a {@link ILocalChatCommand} bound to a context. */
@@ -163,7 +173,7 @@ export class AgentHostLocalCommands extends Disposable {
 			// drain any messages queued behind it.
 			this._stateManager.dispatchServerAction(request.turnChannel, { type: ActionType.ChatTurnComplete, turnId: request.turnId });
 			if (command.recordsLocalTurn) {
-				this._recordLocalTurn(request.turnChannel, request.turnId);
+				this._recordLocalTurn(command, request.turnChannel, request.turnId);
 			}
 			this._notifyTurnConsumable(request.turnChannel);
 		}
@@ -174,9 +184,12 @@ export class AgentHostLocalCommands extends Disposable {
 	 * it survives reload and fork/truncate can resolve it to the preceding
 	 * concrete turn. Works uniformly for the default chat and any peer chat —
 	 * the turn is keyed by its chat channel. Live terminal references are
-	 * stripped from the payload (the PTY does not survive a reload).
+	 * stripped from the payload (the PTY does not survive a reload). The
+	 * handling `command` may contribute model-facing context (see
+	 * {@link ILocalChatCommand.getModelContext}) that is prepended to the next
+	 * real message.
 	 */
-	private _recordLocalTurn(turnChannel: ProtocolURI, turnId: string): void {
+	private _recordLocalTurn(command: ILocalChatCommand, turnChannel: ProtocolURI, turnId: string): void {
 		const chat = turnChannel;
 		const session = isAhpChatChannel(turnChannel) ? parseRequiredSessionUriFromChatUri(turnChannel) : turnChannel;
 		const turns = this._stateManager.getSessionState(turnChannel)?.turns;
@@ -196,7 +209,9 @@ export class AgentHostLocalCommands extends Disposable {
 				break;
 			}
 		}
-		this._localTurns.record(session, chat, sanitizeLocalTurnForPersistence(turns[index]), anchorTurnId);
+		const sanitized = sanitizeLocalTurnForPersistence(turns[index]);
+		const modelContext = command.getModelContext?.(sanitized);
+		this._localTurns.record(session, chat, sanitized, anchorTurnId, modelContext);
 	}
 }
 

--- a/src/vs/platform/agentHost/node/sessionDatabase.ts
+++ b/src/vs/platform/agentHost/node/sessionDatabase.ts
@@ -112,6 +112,10 @@ export const sessionDatabaseMigrations: readonly ISessionDatabaseMigration[] = [
 			payload        TEXT NOT NULL
 		)`,
 	},
+	{
+		version: 9,
+		sql: `ALTER TABLE local_turns ADD COLUMN model_context TEXT`,
+	},
 ];
 
 // ---- Promise wrappers around callback-based @vscode/sqlite3 API -----------
@@ -434,21 +438,22 @@ export class SessionDatabase implements ISessionDatabase {
 		return this._track(async () => {
 			const db = await this._ensureDb();
 			await dbRun(db,
-				'INSERT OR REPLACE INTO local_turns (turn_id, chat_uri, anchor_turn_id, seq, payload) VALUES (?, ?, ?, ?, ?)',
-				[record.turnId, record.chatUri, record.anchorTurnId ?? null, record.seq, record.payload],
+				'INSERT OR REPLACE INTO local_turns (turn_id, chat_uri, anchor_turn_id, seq, payload, model_context) VALUES (?, ?, ?, ?, ?, ?)',
+				[record.turnId, record.chatUri, record.anchorTurnId ?? null, record.seq, record.payload, record.modelContext ?? null],
 			);
 		});
 	}
 
 	async getLocalTurns(): Promise<ILocalTurnRecord[]> {
 		const db = await this._ensureDb();
-		const rows = await dbAll(db, 'SELECT turn_id, chat_uri, anchor_turn_id, seq, payload FROM local_turns ORDER BY seq', []);
+		const rows = await dbAll(db, 'SELECT turn_id, chat_uri, anchor_turn_id, seq, payload, model_context FROM local_turns ORDER BY seq', []);
 		return rows.map(r => ({
 			turnId: r.turn_id as string,
 			chatUri: r.chat_uri as string,
 			anchorTurnId: (r.anchor_turn_id as string | null) ?? undefined,
 			seq: r.seq as number,
 			payload: r.payload as string,
+			modelContext: (r.model_context as string | null) ?? undefined,
 		}));
 	}
 

--- a/src/vs/platform/agentHost/test/node/agentHostLocalTurns.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostLocalTurns.test.ts
@@ -67,4 +67,40 @@ suite('AgentHostLocalTurns', () => {
 		assert.strictEqual(registry.resolveConcreteTurnId(chatA, 'local-x'), 'real-9');
 		assert.strictEqual(registry.isLocal(chatB, 'local-y'), true);
 	});
+
+	test('carries model context through record, persistence, and reload', async () => {
+		const db = new TestSessionDatabase();
+		const chat = 'ahp-chat://default/xyz';
+		const registry = new AgentHostLocalTurns(createSessionDataService(db), new NullLogService());
+		registry.record(session, chat, turn('local-a'), 'real-1', 'ran !ls\nfoo');
+		registry.record(session, chat, turn('local-b'), 'real-1');
+
+		assert.strictEqual(registry.getModelContext(chat, 'local-a'), 'ran !ls\nfoo');
+		assert.strictEqual(registry.getModelContext(chat, 'local-b'), undefined);
+
+		// Survives a reload into a fresh registry backed by the same database.
+		const reloaded = new AgentHostLocalTurns(createSessionDataService(db), new NullLogService());
+		await reloaded.loadForChat(session, chat);
+		assert.strictEqual(reloaded.getModelContext(chat, 'local-a'), 'ran !ls\nfoo');
+		assert.strictEqual(reloaded.getModelContext(chat, 'local-b'), undefined);
+	});
+
+	test('collectPendingModelContext returns context of the trailing locals after the last concrete turn, in order, skipping context-less locals', () => {
+		const db = new TestSessionDatabase();
+		const chat = 'ahp-chat://default/xyz';
+		const registry = new AgentHostLocalTurns(createSessionDataService(db), new NullLogService());
+		// A bang (ctx) and a context-less local (e.g. /rename) recorded after real-1.
+		registry.record(session, chat, turn('local-a'), 'real-1', 'ctx-a');
+		registry.record(session, chat, turn('local-rename'), 'real-1');
+		// The in-flight real message being sent is NOT part of the completed
+		// transcript, so the pending locals are the trailing entries.
+		const transcript = [turn('real-1'), turn('local-a'), turn('local-rename')];
+
+		// Context of the pending locals since real-1, in order (rename skipped).
+		assert.deepStrictEqual(registry.collectPendingModelContext(chat, transcript), ['ctx-a']);
+		// No trailing locals once the transcript ends on a concrete turn.
+		assert.deepStrictEqual(registry.collectPendingModelContext(chat, [turn('real-1')]), []);
+		// Empty transcript yields nothing.
+		assert.deepStrictEqual(registry.collectPendingModelContext(chat, []), []);
+	});
 });

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -692,6 +692,29 @@ suite('AgentSideEffects', () => {
 			await new Promise(r => setTimeout(r, 10));
 			assert.deepStrictEqual(await db.getLocalTurns(), []);
 		});
+
+		test('prepends pending bang command + output to the next real message sent to the agent', async () => {
+			setupSession('file:///work');
+			const db = new TestSessionDatabase();
+			const terminalManager = disposables.add(new TestAgentHostTerminalManager());
+			const se = createLocalTurnSideEffects(db, terminalManager);
+
+			seedRealTurn('real-1', 'hello');
+			await runBang(se, terminalManager, 'local-1');
+
+			// A subsequent real message carries the out-of-band command + output.
+			const action: ChatAction = {
+				type: ActionType.ChatTurnStarted, turnId: 'real-2', message: { text: 'what did that show?', origin: { kind: MessageKind.User } },
+			};
+			stateManager.dispatchClientAction(defaultChatUri, action, { clientId: 'test', clientSeq: ++clientSeq });
+			se.handleAction(defaultChatUri, action);
+			await waitForSendMessageCalls(1);
+
+			const prompt = agent.sendMessageCalls.at(-1)!.prompt;
+			assert.ok(prompt.includes('echo hi'), `expected command in prompt: ${prompt}`);
+			assert.ok(prompt.includes('hi'), `expected output in prompt: ${prompt}`);
+			assert.ok(prompt.endsWith('what did that show?'), `expected user message last: ${prompt}`);
+		});
 	});
 
 	// ---- immediate title on first turn -----------------------------------


### PR DESCRIPTION
## Summary

Host-injected "local turns" (notably `!command` terminal runs) show in the transcript but are never sent to the agent SDK — so after a user runs `!` commands, the model has no idea what they ran or what the output was. This PR feeds the commands + outputs the user executed out-of-band into their **next real message**, built generically on top of the existing **Local Turns** abstraction so any future local command can opt in.

## What changed

- **Model context on local turns:** each local turn may carry an optional `modelContext` string, rendered by the command that produced it (`!command` → the command + captured output; `/rename` contributes nothing).
  - `ILocalTurnRecord.modelContext` + migration **v9** (`model_context` column), plumbed through `AgentHostLocalTurns` (`record` / `getModelContext` / `collectPendingModelContext`) and `ILocalChatCommand.getModelContext`.
- **Injection:** before sending a real message, `AgentSideEffects._sendTurnMessage` prepends the context of the **pending** local turns (the trailing locals in the transcript) to the text passed to `sendMessage`. Only the model input is augmented — the transcript / UI message is unchanged.
- **No watermark needed:** pending turns are derived purely from transcript position. Once the augmented message is sent it becomes a concrete turn, so its locals stop being "pending" and are never re-injected; on restore, delivered context is already baked into past messages.
- **Fork:** `modelContext` is carried into re-persisted forked local turns.
- **Cleanup:** removed the unused `noteInMemory` / `forgetChat` from `AgentHostLocalTurns` (the Copilot review items from the merged bang-command PR).

## Testing
- New unit tests: `modelContext` record/persist/reload round-trip, `collectPendingModelContext` (trailing locals, order, context-less skip), and an end-to-end `AgentSideEffects` test asserting a bang's command + output is prepended to the next real message.
- `npm run test-node` (agent host suites green), typecheck-client / eslint / valid-layers-check / hygiene clean for the changed files.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
