### PR TITLE
sessions: only show blocked sessions in non-stable builds

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -11,6 +11,7 @@ import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { localize } from '../../../../nls.js';
 import { BaseActionViewItem, IBaseActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IProductService } from '../../../../platform/product/common/productService.js';
 import { MenuRegistry, SubmenuItemAction } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
@@ -156,6 +157,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 		@IContextViewService private readonly contextViewService: IContextViewService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IProductService private readonly productService: IProductService,
 	) {
 		super(undefined, action, options);
 
@@ -180,7 +182,12 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 
 		// A session that is currently visible on screen is not treated as blocked:
 		// exclude visible sessions from the requires-input indicator and the dropdown.
+		// The blocked-sessions feature is only enabled outside of stable builds.
+		const blockedSessionsEnabled = this.productService.quality !== 'stable';
 		this._blockedSessions = derived(this, reader => {
+			if (!blockedSessionsEnabled) {
+				return [];
+			}
 			const visibleSessionIds = new Set<string>();
 			for (const session of this.sessionsService.visibleSessions.read(reader)) {
 				if (session) {

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/sessionsTitleBarWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/sessionsTitleBarWidget.fixture.ts
@@ -10,6 +10,7 @@ import { IObservable, constObservable } from '../../../../../base/common/observa
 import { mock } from '../../../../../base/test/common/mock.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { SubmenuItemAction } from '../../../../../platform/actions/common/actions.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { AgentSessionApprovalKind, AgentSessionApprovalModel, IAgentSessionApprovalInfo } from '../../../../contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
 // eslint-disable-next-line local/code-import-patterns
 import { IChat, ISession, ISessionWorkspace } from '../../../../../sessions/services/sessions/common/session.js';
@@ -132,6 +133,10 @@ function renderTitleBar(ctx: ComponentFixtureContext, state: ITitleBarState): vo
 				override isVisible(part: Parts): boolean {
 					return part === Parts.SIDEBAR_PART ? sidebarVisible : true;
 				}
+			}());
+			// The blocked-sessions feature is only enabled outside of stable builds.
+			reg.defineInstance(IProductService, new class extends mock<IProductService>() {
+				override readonly quality = 'insider';
 			}());
 		},
 	});


### PR DESCRIPTION
## What

Gates the blocked-sessions indicator in the sessions titlebar widget (the "N sessions require input" pill and its dropdown) so it only shows when the product quality is **not** `stable`. In stable/public builds the feature is now disabled.

## Why

The blocked-sessions feature is not enabled in stable builds, so it shouldn't surface in the titlebar there.

## How

- `sessionsTitleBarWidget.ts`: inject `IProductService` and gate the `_blockedSessions` derived observable — when `productService.quality === 'stable'` it returns an empty array. This cleanly disables the whole feature: no requires-input pill renders, the attention blink never fires, `_requiresInputKind` collapses to `undefined`, and the dropdown can't open (its show logic early-returns on an empty set). Because the underlying `BlockedSessions` model uses lazy observables, no GitHub CI/PR work runs when the feature is off.
- `sessionsTitleBarWidget.fixture.ts`: register an `IProductService` mock with `quality = 'insider'` so the component fixture continues to render blocked sessions (the widget now depends on that service).

## Notes for reviewers

- "Not stable" is interpreted as `quality !== 'stable'`, matching the established pattern in the sessions layer (e.g. `desktopSessionLayoutController.ts`, `chatDebug.contribution.ts`). The feature stays enabled in `insider`, `exploration`, and dev builds (`quality === undefined`).
