### PR TITLE
chat: add turn status pills for agent sessions

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesActions.ts
@@ -32,10 +32,17 @@ import { ChangesMultiDiffSourceResolver, SessionChangesFileResourceContext, Sess
 import { ISessionChangesService } from './sessionChangesService.js';
 import { isEqual } from '../../../../base/common/resources.js';
 
+/**
+ * Command id of the {@link ViewAllChangesAction}. Opens the session's multi-file
+ * diff editor. Exported so other session surfaces (e.g. the chat input pills)
+ * can trigger the same "View Changes" behavior without duplicating the id.
+ */
+export const VIEW_SESSION_CHANGES_COMMAND_ID = 'workbench.agentSessions.action.viewChanges';
+
 // --- View All Changes action
 
 class ViewAllChangesAction extends Action2 {
-	static readonly ID = 'workbench.agentSessions.action.viewChanges';
+	static readonly ID = VIEW_SESSION_CHANGES_COMMAND_ID;
 
 	constructor() {
 		super({

--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -25,6 +25,7 @@ import { NewChatWidget } from './newChatWidget.js';
 import { NewChatInSessionWidget } from './newChatInSessionWidget.js';
 import { SessionInputBanners } from '../../sessionInputBanners/browser/sessionInputBanners.js';
 import { SessionRunningSubagentsControl } from './sessionRunningSubagentsControl.js';
+import { SessionChatInputToolbar } from './sessionChatInputToolbar.js';
 import { AGENT_SESSIONS_SCOPED_INPUT_HISTORY_SETTING } from './sessionsChatHistory.js';
 import { activeSessionViewBackground, activeSessionViewForeground, agentsPanelBackground, inactiveSessionViewBackground, inactiveSessionViewForeground } from '../../../common/theme.js';
 import { isEqual } from '../../../../base/common/resources.js';
@@ -108,6 +109,8 @@ export class ChatView extends AbstractChatView {
 	private readonly _banners: SessionInputBanners;
 	/** Ephemeral chip above the input listing the active chat's running subagents. */
 	private readonly _runningSubagents: SessionRunningSubagentsControl;
+	/** Floating status pills (changes, preview) above the input; agent host only. */
+	private readonly _chatPills: SessionChatInputToolbar;
 
 	/** Reference to the loaded chat model; disposing releases the model. */
 	private readonly _modelRef = this._register(new MutableDisposable<IChatModelReference>());
@@ -171,6 +174,9 @@ export class ChatView extends AbstractChatView {
 
 		// Ephemeral running-subagents chip above the input (hidden while idle).
 		this._runningSubagents = this._register(instantiationService.createInstance(SessionRunningSubagentsControl));
+		// Floating status pills above the input (hidden unless an agent host session
+		// has changes or a previewable file).
+		this._chatPills = this._register(instantiationService.createInstance(SessionChatInputToolbar));
 		this._ensureBannersMounted();
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
@@ -207,6 +213,9 @@ export class ChatView extends AbstractChatView {
 
 		// Monitor this chat's running subagents in the ephemeral chip.
 		this._runningSubagents.setChat(resource);
+
+		// Reflect this chat's session status in the floating pills.
+		this._chatPills.setChat(resource);
 
 		// Reflect read-only (non-interactive) chats: hide the composer and gate
 		// mutating actions (Start Over / Restore Checkpoint) via the widget. Any
@@ -307,12 +316,16 @@ export class ChatView extends AbstractChatView {
 	 */
 	private _ensureBannersMounted(): void {
 		const inputPartElement = this._widget.inputPart.element;
+		const pillsNode = this._chatPills.element;
 		const subagentsNode = this._runningSubagents.element;
 		const bannersNode = this._banners.domNode;
-		// Desired order at the top of the input part: [subagentsNode, bannersNode, ...].
-		// Keyed off the chip first so this is a true no-op once the DOM has settled.
-		if (inputPartElement.firstChild !== subagentsNode) {
-			inputPartElement.insertBefore(subagentsNode, inputPartElement.firstChild);
+		// Desired order at the top of the input part: [pillsNode, subagentsNode, bannersNode, ...].
+		// Keyed off the pills first so this is a true no-op once the DOM has settled.
+		if (inputPartElement.firstChild !== pillsNode) {
+			inputPartElement.insertBefore(pillsNode, inputPartElement.firstChild);
+		}
+		if (pillsNode.nextSibling !== subagentsNode) {
+			inputPartElement.insertBefore(subagentsNode, pillsNode.nextSibling);
 		}
 		if (subagentsNode.nextSibling !== bannersNode) {
 			inputPartElement.insertBefore(bannersNode, subagentsNode.nextSibling);

--- a/src/vs/sessions/contrib/chat/browser/media/sessionChatInputToolbar.css
+++ b/src/vs/sessions/contrib/chat/browser/media/sessionChatInputToolbar.css
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Floating status pills centered above the chat input. The pills themselves are
+	the shared `.chat-turn-pills` widget (styled in chatTurnPills.css); this file
+	only positions and centers that widget above the input. */
+
+.session-chat-input-toolbar {
+	display: flex;
+	justify-content: center;
+	padding: 2px 0 6px 0;
+}
+
+.session-chat-input-toolbar.hidden {
+	display: none;
+}
+

--- a/src/vs/sessions/contrib/chat/browser/sessionChatInputToolbar.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionChatInputToolbar.ts
@@ -1,0 +1,190 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { $ } from '../../../../base/browser/dom.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { autorun, derived, derivedOpts, IObservable, IReader, observableValue } from '../../../../base/common/observable.js';
+import { isEqual } from '../../../../base/common/resources.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IOpenerService } from '../../../../platform/opener/common/opener.js';
+import { isIChatSessionFileChange2 } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { ChatTurnPillsWidget, diffStatsEqual, EMPTY_DIFF_STATS, IChatTurnPillsModel, IDiffStats, IPreviewFile, observeTurnStatusPillsConfig, openChatPreviewFile, previewFilesEqual, previewKind } from '../../../../workbench/contrib/chat/browser/widget/chatTurnPills.js';
+import { isAgentHostProviderId } from '../../../common/agentHostSessionsProvider.js';
+import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+import { SessionStatus, TURN_CHANGES_CHANGESET_ID } from '../../../services/sessions/common/session.js';
+import { IActiveSession } from '../../../services/sessions/common/sessionsManagement.js';
+import { VIEW_SESSION_CHANGES_COMMAND_ID } from '../../changes/browser/changesActions.js';
+import './media/sessionChatInputToolbar.css';
+
+/** The per-turn data both pills reflect. */
+interface ITurnData {
+	readonly stats: IDiffStats;
+	/** Previewable files changed in the turn, primary (first) first. */
+	readonly previewFiles: readonly IPreviewFile[];
+}
+
+const EMPTY_TURN_DATA: ITurnData = { stats: EMPTY_DIFF_STATS, previewFiles: [] };
+
+/**
+ * Compute the current turn's diff stats and previewable files from the session's
+ * "Last Turn Changes" changeset ({@link TURN_CHANGES_CHANGESET_ID}). Files are
+ * classified as created vs. edited with the same rules as the Changes view (an
+ * addition has no original; a deletion has no modified resource). Created files
+ * are listed before edited ones so the primary (first) file is the first created
+ * one, falling back to the first edited one. Returns {@link EMPTY_TURN_DATA} when
+ * the session exposes no turn changeset (e.g. before its first turn).
+ */
+function computeTurnData(session: IActiveSession, reader: IReader): ITurnData {
+	const turnChangeset = session.changesets.read(reader)?.find(cs => cs.id === TURN_CHANGES_CHANGESET_ID);
+	if (!turnChangeset) {
+		return EMPTY_TURN_DATA;
+	}
+
+	const changes = turnChangeset.changes.read(reader);
+
+	let insertions = 0, deletions = 0;
+	const created: IPreviewFile[] = [];
+	const edited: IPreviewFile[] = [];
+	for (const change of changes) {
+		insertions += change.insertions;
+		deletions += change.deletions;
+
+		if (change.modifiedUri === undefined) {
+			continue; // a deletion has nothing to preview
+		}
+		const uri = isIChatSessionFileChange2(change) ? change.uri : change.modifiedUri;
+		const kind = previewKind(uri);
+		if (!kind) {
+			continue;
+		}
+		const isCreated = change.originalUri === undefined;
+		(isCreated ? created : edited).push({ uri, kind, created: isCreated });
+	}
+
+	return {
+		stats: { files: changes.length, insertions, deletions },
+		previewFiles: [...created, ...edited],
+	};
+}
+
+function turnDataEqual(a: ITurnData, b: ITurnData): boolean {
+	return diffStatsEqual(a.stats, b.stats) && previewFilesEqual(a.previewFiles, b.previewFiles);
+}
+
+/**
+ * A floating toolbar shown above the chat input that surfaces the current turn's
+ * session status as clickable pills (see {@link ChatTurnPillsWidget}). Only shown
+ * for agent host sessions while a turn is actively in progress; once the turn
+ * completes the pills disappear here and reappear inside the completed response.
+ * The pills are scoped to the session's "Last Turn Changes" changeset so they
+ * reflect only what the most recent request produced.
+ */
+export class SessionChatInputToolbar extends Disposable {
+
+	readonly element: HTMLElement;
+
+	/** Sentinel distinguishing "no override" from an explicit `undefined` session. */
+	private readonly _sessionOverride = observableValue<IActiveSession | undefined | 'unset'>('sessionOverride', 'unset');
+	private readonly _chatResource = observableValue<URI | undefined>('chatResource', undefined);
+
+	/** The session whose status is reflected, from an explicit override or resolved from the chat. */
+	private readonly _session: IObservable<IActiveSession | undefined> = derived(reader => {
+		const override = this._sessionOverride.read(reader);
+		if (override !== 'unset') {
+			return override;
+		}
+		const resource = this._chatResource.read(reader);
+		if (!resource) {
+			return undefined;
+		}
+		return this._findOwningSession(resource, reader);
+	});
+
+	/** The current turn's diff stats and previewable files. */
+	private readonly _turnData = derivedOpts<ITurnData>({ owner: this, equalsFn: turnDataEqual }, reader => {
+		const session = this._session.read(reader);
+		return session ? computeTurnData(session, reader) : EMPTY_TURN_DATA;
+	});
+
+	private readonly _diffStats = derivedOpts<IDiffStats>({ owner: this, equalsFn: diffStatsEqual }, reader => this._turnData.read(reader).stats);
+	private readonly _previewFiles = derivedOpts<readonly IPreviewFile[]>({ owner: this, equalsFn: previewFilesEqual }, reader => this._turnData.read(reader).previewFiles);
+
+	/** Whether pills may show at all: an agent host session while a turn is streaming. */
+	private readonly _active = derived(reader => {
+		const session = this._session.read(reader);
+		return !!session && isAgentHostProviderId(session.providerId) && session.status.read(reader) === SessionStatus.InProgress;
+	});
+
+	constructor(
+		@ICommandService private readonly _commandService: ICommandService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IOpenerService private readonly _openerService: IOpenerService,
+		@ILogService private readonly _logService: ILogService,
+		@ISessionsService private readonly _sessionsService: ISessionsService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+
+		this.element = $('.session-chat-input-toolbar.hidden');
+
+		// Combine the active-turn gate with the per-pill visibility setting.
+		const pillsConfig = observeTurnStatusPillsConfig(this._configurationService);
+		const model: IChatTurnPillsModel = {
+			stats: this._diffStats,
+			previewFiles: this._previewFiles,
+			changesEnabled: derived(reader => this._active.read(reader) && pillsConfig.read(reader).changes),
+			previewEnabled: derived(reader => this._active.read(reader) && pillsConfig.read(reader).preview),
+			openChanges: () => this._openChanges(),
+			openPreviewFile: file => openChatPreviewFile(file, this._commandService, this._openerService, this._logService),
+		};
+
+		const pills = this._register(instantiationService.createInstance(ChatTurnPillsWidget, model));
+		this.element.appendChild(pills.element);
+
+		this._register(autorun(reader => {
+			this.element.classList.toggle('hidden', !pills.isVisible.read(reader));
+		}));
+	}
+
+	/**
+	 * Track the currently-viewed chat; the toolbar resolves and reflects the
+	 * status of the session that owns it. Clears any explicit {@link setSession}
+	 * override.
+	 */
+	setChat(chatResource: URI | undefined): void {
+		this._sessionOverride.set('unset', undefined);
+		this._chatResource.set(chatResource, undefined);
+	}
+
+	/**
+	 * Explicitly set the session to reflect, bypassing chat resolution. Intended
+	 * for component fixtures and callers that already hold the session.
+	 */
+	setSession(session: IActiveSession | undefined): void {
+		this._sessionOverride.set(session, undefined);
+	}
+
+	private _findOwningSession(chatResource: URI, reader: IReader): IActiveSession | undefined {
+		for (const session of this._sessionsService.visibleSessions.read(reader)) {
+			if (session?.chats.read(reader).some(c => isEqual(c.resource, chatResource))) {
+				return session;
+			}
+		}
+		const active = this._sessionsService.activeSession.read(reader);
+		return active?.chats.read(reader).some(c => isEqual(c.resource, chatResource)) ? active : undefined;
+	}
+
+	private async _openChanges(): Promise<void> {
+		const session = this._session.get();
+		if (!session) {
+			return;
+		}
+		await this._commandService.executeCommand(VIEW_SESSION_CHANGES_COMMAND_ID, session);
+	}
+}

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionChangesets.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionChangesets.ts
@@ -343,7 +343,8 @@ class AgentHostLastTurnChangeset extends AbstractAgentHostChangeset {
 		// Turns moved off the session and onto a per-chat channel with the
 		// multi-chat protocol. Subscribe to the session to discover its
 		// chats, then track the chat that was modified most recently — its
-		// last completed turn is the session's "last turn".
+		// in-progress turn (or, when idle, its last completed turn) is the
+		// session's "last turn".
 		const sessionStateObs = createActiveSessionSubscriptionObs<SessionState>(
 			options,
 			isActiveSessionObs,
@@ -377,7 +378,10 @@ class AgentHostLastTurnChangeset extends AbstractAgentHostChangeset {
 			if (!chatState || chatState instanceof Error) {
 				return undefined;
 			}
-			return chatState.turns?.at(-1)?.id;
+			// Prefer the in-progress turn so the "last turn" reflects streaming
+			// edits live; once it completes it moves into `turns` under the same
+			// id, so the tracked changeset transitions seamlessly.
+			return chatState.activeTurn?.id ?? chatState.turns?.at(-1)?.id;
 		});
 
 		// Last turn changes

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -211,6 +211,16 @@ export interface ISessionFile {
  */
 export const BRANCH_CHANGES_CHANGESET_ID = 'branchChanges';
 
+/**
+ * Well-known id of the changeset that holds the diff made during the session's
+ * **last turn** only (as opposed to the cumulative session diff). Consumers that
+ * want to reflect just the most recent turn — e.g. the chat input status pills —
+ * can locate it in {@link ISession.changesets} by id.
+ *
+ * Must match the agent host provider's `ChangesetKind.Turn` value.
+ */
+export const TURN_CHANGES_CHANGESET_ID = 'turn';
+
 export interface ISessionChangeset {
 	/** Unique identifier for the changeset. */
 	readonly id: string;

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -823,6 +823,24 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.checkpoints.showFileChanges', "Controls whether to show chat checkpoint file changes."),
 			default: false
 		},
+		[ChatConfiguration.TurnStatusPills]: {
+			type: 'object',
+			markdownDescription: nls.localize('chat.turnStatusPills', "Controls which agent turn status pills are shown above the chat input while a turn is in progress and inside the completed response. Only applies to agent sessions."),
+			properties: {
+				changes: {
+					type: 'boolean',
+					default: false,
+					description: nls.localize('chat.turnStatusPills.changes', "Show a pill summarizing the files changed and the lines added and removed in the turn."),
+				},
+				preview: {
+					type: 'boolean',
+					default: false,
+					description: nls.localize('chat.turnStatusPills.preview', "Show a pill to preview a Markdown or HTML file created or edited in the turn."),
+				},
+			},
+			default: { changes: false, preview: false },
+			additionalProperties: false,
+		},
 		[mcpAccessConfig]: {
 			type: 'string',
 			description: nls.localize('chat.mcp.access', "Controls access to installed Model Context Protocol servers."),

--- a/src/vs/workbench/contrib/chat/browser/media/chatTurnPills.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatTurnPills.css
@@ -1,0 +1,157 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Pills reflecting a single turn's status (changes + preview). Shared between
+	the floating widget above the chat input and the completed chat response. This
+	file styles the pills themselves; callers position the `.chat-turn-pills`
+	toolbar element. */
+
+.chat-turn-pills,
+.chat-turn-pills .monaco-toolbar,
+.chat-turn-pills .monaco-action-bar,
+.chat-turn-pills .monaco-action-bar .actions-container {
+	display: flex;
+	align-items: center;
+	min-width: 0;
+}
+
+.chat-turn-pills.hidden {
+	display: none;
+}
+
+/* Space the pills evenly next to each other. */
+.chat-turn-pills .monaco-action-bar .actions-container {
+	gap: 6px;
+}
+
+/* Changes pill: <icon> N Files +x -y, rendered as a compact secondary button.
+	Its sizing/colors come from the standard `.monaco-text-button.small.secondary`
+	styles; only inline layout is set here. */
+.chat-turn-pill-changes {
+	display: inline-flex;
+	align-items: center;
+	flex-shrink: 0;
+}
+
+.chat-turn-pill-changes .monaco-button.chat-turn-pill-changes-button {
+	display: inline-flex;
+	width: auto;
+	gap: 4px;
+	font-variant-numeric: tabular-nums;
+	white-space: nowrap;
+	touch-action: manipulation;
+}
+
+/* Hug the border with the focus ring instead of the base `outline-offset: 2px`,
+	which reads as a bloated ring on such a small pill. */
+.chat-turn-pill-changes .monaco-button.chat-turn-pill-changes-button:focus {
+	outline-offset: 0 !important;
+}
+
+.monaco-workbench .chat-turn-pill-meta-icon.codicon[class*='codicon-'] {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: var(--vscode-codiconFontSize-compact, 12px);
+	height: var(--vscode-codiconFontSize-compact, 12px);
+	margin: 0;
+	font-size: var(--vscode-codiconFontSize-compact, 12px);
+	flex-shrink: 0;
+}
+
+.chat-turn-pill-meta-added {
+	color: var(--vscode-chat-linesAddedForeground);
+}
+
+.chat-turn-pill-meta-removed {
+	color: var(--vscode-chat-linesRemovedForeground);
+}
+
+/* Preview pill: a single unified control — a resource label (file icon + name +
+	"preview" description), an in-pill separator, and a dropdown chevron. The pill
+	background/border live on the container so the inner (transparent) buttons read
+	as one pill; each inner button is an independent, tab-focusable click zone. The
+	3-class selector beats `.monaco-action-bar .action-item { display: block }`. */
+.chat-turn-pills .monaco-action-bar .chat-turn-pill-preview {
+	display: inline-flex;
+	align-items: stretch;
+	flex-shrink: 0;
+	/* Match the height of the changes pill (a small secondary button). */
+	height: 22px;
+	max-width: 280px;
+	border-radius: 4px;
+	color: var(--vscode-button-secondaryForeground);
+	background-color: var(--vscode-button-secondaryBackground);
+	border: 1px solid var(--vscode-button-secondaryBorder, transparent);
+	overflow: hidden;
+}
+
+.chat-turn-pill-preview .monaco-button {
+	touch-action: manipulation;
+}
+
+/* Left zone: the resource label (file icon + name + "preview"). The height is
+	set by the pill, so no vertical padding here. */
+.chat-turn-pill-preview .monaco-button.chat-turn-pill-preview-primary {
+	display: inline-flex;
+	align-items: center;
+	width: auto;
+	min-width: 0;
+	padding: 0 8px;
+	overflow: hidden;
+}
+
+.chat-turn-pill-preview-primary .monaco-icon-label {
+	min-width: 0;
+	overflow: hidden;
+	/* Match the changes pill, which uses the `.monaco-text-button.small` size. */
+	font-size: 11px;
+}
+
+.chat-turn-pill-preview .monaco-button.chat-turn-pill-preview-primary:hover {
+	background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+/* In-pill separator between the label and the chevron. A 2px vertical margin
+	keeps it centered with a small gap at the top and bottom rather than spanning
+	the full pill height. */
+.chat-turn-pill-preview-separator {
+	width: 1px;
+	flex-shrink: 0;
+	margin: 2px 0;
+	background-color: var(--vscode-button-secondaryBorder, var(--vscode-menu-separatorBackground));
+	opacity: 0.6;
+}
+
+.chat-turn-pill-preview-separator.hidden {
+	display: none;
+}
+
+/* Right zone: the dropdown chevron. The button stretches to the pill's full
+	height so its hover background spans top to bottom; the icon child stays
+	centered. */
+.chat-turn-pill-preview .monaco-button.chat-turn-pill-preview-chevron {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: auto;
+	padding: 0 5px;
+}
+
+.chat-turn-pill-preview .monaco-button.chat-turn-pill-preview-chevron:hover {
+	background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.chat-turn-pill-preview .monaco-button.chat-turn-pill-preview-chevron.hidden {
+	display: none;
+}
+
+/* Keyboard focus indicator: an inset ring so it stays visible inside the pill's
+	`overflow: hidden` rounded corners. */
+.chat-turn-pill-preview .monaco-button:focus,
+.chat-turn-pill-preview .monaco-button:focus-visible {
+	outline: none;
+	box-shadow: inset 0 0 0 1px var(--vscode-focusBorder);
+}

--- a/src/vs/workbench/contrib/chat/browser/media/chatTurnPills.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatTurnPills.css
@@ -104,6 +104,11 @@
 }
 
 .chat-turn-pill-preview-primary .monaco-icon-label {
+	/* Center the icon and the name/description together — the label is a flex
+		row whose file icon `::before` is a fixed 22px tall, so without this the
+		shorter text sits at the top of the stretched row rather than on the icon's
+		vertical center. */
+	align-items: center;
 	min-width: 0;
 	overflow: hidden;
 	/* Match the changes pill, which uses the `.monaco-text-button.small` size. */

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTurnPillsPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTurnPillsPart.ts
@@ -1,0 +1,128 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { $ } from '../../../../../../base/browser/dom.js';
+import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { autorun, constObservable, derived, derivedOpts, IObservable } from '../../../../../../base/common/observable.js';
+import { isEqual } from '../../../../../../base/common/resources.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { localize } from '../../../../../../nls.js';
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../../../../../platform/log/common/log.js';
+import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
+import { IEditorService } from '../../../../../services/editor/common/editorService.js';
+import { IEditSessionEntryDiff } from '../../../common/editing/chatEditingService.js';
+import { IChatRendererContent, IChatTurnPillsPart } from '../../../common/model/chatViewModel.js';
+import { MultiDiffEditorInput } from '../../../../multiDiffEditor/browser/multiDiffEditorInput.js';
+import { MultiDiffEditorItem } from '../../../../multiDiffEditor/browser/multiDiffSourceResolverService.js';
+import { ChatTreeItem } from '../../chat.js';
+import { IChatResponseFileChangesService } from '../../chatResponseFileChangesService.js';
+import { ChatTurnPillsWidget, diffStatsEqual, EMPTY_DIFF_STATS, IChatTurnPillsModel, IDiffStats, IPreviewFile, observeTurnStatusPillsConfig, openChatPreviewFile, previewFilesEqual, previewKind } from '../chatTurnPills.js';
+import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
+
+/**
+ * Renders the turn's status pills (changes + preview) inside a completed chat
+ * response, mirroring the floating pills shown above the input while the turn
+ * streams. Fed by the per-request diffs from {@link IChatResponseFileChangesService}
+ * (agent host sessions), so it reflects the same authoritative per-turn changes as
+ * the "Changed N files" summary. The part self-hides when the turn produced no
+ * changes.
+ */
+export class ChatTurnPillsContentPart extends Disposable implements IChatContentPart {
+
+	readonly domNode: HTMLElement;
+
+	private readonly _diffs: IObservable<readonly IEditSessionEntryDiff[]>;
+
+	constructor(
+		private readonly _content: IChatTurnPillsPart,
+		_context: IChatContentPartRenderContext,
+		@IChatResponseFileChangesService chatResponseFileChangesService: IChatResponseFileChangesService,
+		@ICommandService commandService: ICommandService,
+		@IOpenerService openerService: IOpenerService,
+		@ILogService logService: ILogService,
+		@IEditorService private readonly _editorService: IEditorService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+	) {
+		super();
+
+		this.domNode = $('.chat-turn-pills-part');
+
+		this._diffs = chatResponseFileChangesService.getChangesForRequest(_content.sessionResource, _content.requestId) ?? constObservable([]);
+
+		const stats = derivedOpts<IDiffStats>({ owner: this, equalsFn: diffStatsEqual }, reader => {
+			const diffs = this._diffs.read(reader);
+			if (diffs.length === 0) {
+				return EMPTY_DIFF_STATS;
+			}
+			let insertions = 0, deletions = 0;
+			for (const diff of diffs) {
+				insertions += diff.added;
+				deletions += diff.removed;
+			}
+			return { files: diffs.length, insertions, deletions };
+		});
+
+		const previewFiles = derivedOpts<readonly IPreviewFile[]>({ owner: this, equalsFn: previewFilesEqual }, reader => {
+			const created: IPreviewFile[] = [];
+			const edited: IPreviewFile[] = [];
+			for (const diff of this._diffs.read(reader)) {
+				const kind = previewKind(diff.modifiedURI);
+				if (!kind) {
+					continue;
+				}
+				// The agent host provider maps a created file's `originalURI` to its
+				// `modifiedURI` (there is no before-content), so equal URIs mark a
+				// creation. Created files are listed first so the primary preview is
+				// the first created file, else the first edited one.
+				const isCreated = isEqual(diff.originalURI, diff.modifiedURI);
+				(isCreated ? created : edited).push({ uri: diff.modifiedURI, kind, created: isCreated });
+			}
+			return [...created, ...edited];
+		});
+
+		const pillsConfig = observeTurnStatusPillsConfig(configurationService);
+		const model: IChatTurnPillsModel = {
+			stats,
+			previewFiles,
+			changesEnabled: derived(reader => pillsConfig.read(reader).changes),
+			previewEnabled: derived(reader => pillsConfig.read(reader).preview),
+			openChanges: () => this._openChanges(),
+			openPreviewFile: file => openChatPreviewFile(file, commandService, openerService, logService),
+		};
+
+		const widget = this._register(this._instantiationService.createInstance(ChatTurnPillsWidget, model));
+		this.domNode.appendChild(widget.element);
+
+		this._register(autorun(reader => {
+			this.domNode.style.display = widget.isVisible.read(reader) ? '' : 'none';
+		}));
+	}
+
+	private _openChanges(): void {
+		const diffs = this._diffs.get();
+		if (diffs.length === 0) {
+			return;
+		}
+		const source = URI.parse(`multi-diff-editor:${Date.now().toString()}-${Math.random().toString(36).slice(2)}`);
+		const input = this._instantiationService.createInstance(
+			MultiDiffEditorInput,
+			source,
+			localize('chatTurnPills.changes.title', "Turn File Changes"),
+			diffs.map(diff => new MultiDiffEditorItem(diff.originalURI, diff.modifiedURI, undefined)),
+			false,
+		);
+		this._editorService.openEditor(input);
+	}
+
+	hasSameContent(other: IChatRendererContent, _followingContent: IChatRendererContent[], _element: ChatTreeItem): boolean {
+		return other.kind === 'turnPills'
+			&& other.requestId === this._content.requestId
+			&& isEqual(other.sessionResource, this._content.sessionResource);
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -58,7 +58,7 @@ import { ChatQuestionCarouselData } from '../../common/model/chatProgressTypes/c
 import { localChatSessionType, SessionType } from '../../common/chatSessionsService.js';
 import { getChatSessionType } from '../../common/model/chatUri.js';
 import { getExplicitFileOrImageAttachmentSummary, IChatRequestVariableEntry, isExplicitFileOrImageVariableEntry, isPasteVariableEntry } from '../../common/attachments/chatVariableEntries.js';
-import { getStickyScrollTargetItem, IChatChangesSummaryPart, IChatCodeCitations, IChatErrorDetailsPart, IChatReferences, IChatRendererContent, IChatRequestViewModel, IChatResponseViewModel, IChatViewModel, IChatWorkingProgress, isRequestVM, isResponseVM, IChatPendingDividerViewModel, isPendingDividerVM } from '../../common/model/chatViewModel.js';
+import { getStickyScrollTargetItem, IChatChangesSummaryPart, IChatCodeCitations, IChatErrorDetailsPart, IChatReferences, IChatRendererContent, IChatRequestViewModel, IChatResponseViewModel, IChatViewModel, IChatWorkingProgress, isRequestVM, isResponseVM, IChatPendingDividerViewModel, isPendingDividerVM, IChatTurnPillsPart } from '../../common/model/chatViewModel.js';
 import { getNWords } from '../../common/model/chatWordCounter.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, CollapsedToolsDisplayMode, ThinkingDisplayMode } from '../../common/constants.js';
 import { ClickAnimation } from '../../../../../base/browser/ui/animations/animations.js';
@@ -74,6 +74,8 @@ import { ChatAnonymousRateLimitedPart } from './chatContentParts/chatAnonymousRa
 import { ChatAttachmentsContentPart } from './chatContentParts/chatAttachmentsContentPart.js';
 import { ChatAutoModeResolutionContentPart } from './chatContentParts/chatAutoModeResolutionContentPart.js';
 import { ChatCheckpointFileChangesSummaryContentPart } from './chatContentParts/chatChangesSummaryPart.js';
+import { ChatTurnPillsContentPart } from './chatContentParts/chatTurnPillsPart.js';
+import { IChatTurnStatusPillsConfig } from './chatTurnPills.js';
 import { ChatCodeCitationContentPart } from './chatContentParts/chatCodeCitationContentPart.js';
 import { ChatCommandButtonContentPart } from './chatContentParts/chatCommandContentPart.js';
 import { ChatConfirmationContentPart } from './chatContentParts/chatConfirmationContentPart.js';
@@ -1181,6 +1183,11 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			content.push(fileChangesSummaryPart);
 		}
 
+		const turnPillsPart = this.getChatTurnPillsPart(element);
+		if (turnPillsPart) {
+			content.push(turnPillsPart);
+		}
+
 		const workingProgress = this.shouldShowWorkingProgress(element, content, false, templateData);
 		if (workingProgress) {
 			content.push(workingProgress);
@@ -1500,6 +1507,25 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}
 
 		return { kind: 'changesSummary', requestId: element.requestId, sessionResource: element.sessionResource };
+	}
+
+	private getChatTurnPillsPart(element: IChatResponseViewModel): IChatTurnPillsPart | undefined {
+		// The turn status pills mirror the floating pills shown above the input
+		// while the turn streams. They are opt-in per pill, only apply to agent
+		// host sessions (which supply authoritative per-turn changes via
+		// IChatResponseFileChangesService) and, like the pills above the input,
+		// appear once the turn is complete.
+		if (!element.isComplete) {
+			return undefined;
+		}
+		const pillsConfig = this.configService.getValue<IChatTurnStatusPillsConfig | undefined>(ChatConfiguration.TurnStatusPills);
+		if (!pillsConfig?.changes && !pillsConfig?.preview) {
+			return undefined;
+		}
+		if (!isAgentHostTarget(getChatSessionType(element.sessionResource))) {
+			return undefined;
+		}
+		return { kind: 'turnPills', requestId: element.requestId, sessionResource: element.sessionResource };
 	}
 
 	private renderChatRequest(element: IChatRequestViewModel, index: number, templateData: IChatListItemTemplate) {
@@ -2028,6 +2054,11 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			partsToRender.push(fileChangesSummaryPart);
 		}
 
+		const turnPillsPart = this.getChatTurnPillsPart(element);
+		if (turnPillsPart) {
+			partsToRender.push(turnPillsPart);
+		}
+
 		return { content: partsToRender, moreContentAvailable };
 	}
 
@@ -2481,6 +2512,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				return this.renderPlanReview(context, content, templateData);
 			} else if (content.kind === 'changesSummary') {
 				return this.renderChangesSummary(content, context, templateData);
+			} else if (content.kind === 'turnPills') {
+				return this.renderTurnPills(content, context);
 			} else if (content.kind === 'mcpServersStarting') {
 				return this.renderMcpServersInteractionRequired(content, context, templateData);
 			} else if (content.kind === 'mcpAuthenticationRequired') {
@@ -3302,6 +3335,10 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 	private renderChangesSummary(content: IChatChangesSummaryPart, context: IChatContentPartRenderContext, templateData: IChatListItemTemplate): IChatContentPart {
 		const part = this.instantiationService.createInstance(ChatCheckpointFileChangesSummaryContentPart, content, context);
 		return part;
+	}
+
+	private renderTurnPills(content: IChatTurnPillsPart, context: IChatContentPartRenderContext): IChatContentPart {
+		return this.instantiationService.createInstance(ChatTurnPillsContentPart, content, context);
 	}
 
 	private renderAttachments(variables: readonly IChatRequestVariableEntry[], contentReferences: ReadonlyArray<IChatContentReference> | undefined, modelId: string | undefined, templateData: IChatListItemTemplate, resolvedModelId?: string) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatTurnPills.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatTurnPills.ts
@@ -1,0 +1,387 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { $, append, reset } from '../../../../../base/browser/dom.js';
+import { ActionsOrientation } from '../../../../../base/browser/ui/actionbar/actionbar.js';
+import { BaseActionViewItem, IActionViewItemOptions } from '../../../../../base/browser/ui/actionbar/actionViewItems.js';
+import { Button, IButtonStyles } from '../../../../../base/browser/ui/button/button.js';
+import { ToolBar } from '../../../../../base/browser/ui/toolbar/toolbar.js';
+import { Action, IAction, toAction } from '../../../../../base/common/actions.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { autorun, derived, IObservable, IReader } from '../../../../../base/common/observable.js';
+import { basename, isEqual } from '../../../../../base/common/resources.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { localize } from '../../../../../nls.js';
+import { BrowserViewCommandId } from '../../../../../platform/browserView/common/browserView.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
+import { FileKind } from '../../../../../platform/files/common/files.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
+import { observableConfigValue } from '../../../../../platform/observable/common/platformObservableUtils.js';
+import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
+import { DEFAULT_LABELS_CONTAINER, ResourceLabels } from '../../../../browser/labels.js';
+import { ChatConfiguration } from '../../common/constants.js';
+import '../media/chatTurnPills.css';
+
+const CHANGES_PILL_ACTION_ID = 'chat.turnPills.changes';
+const PREVIEW_PILL_ACTION_ID = 'chat.turnPills.preview';
+
+/**
+ * All-transparent button styles so the inner preview-pill buttons inherit the
+ * pill container's own background/border and read as a single control.
+ */
+const TRANSPARENT_BUTTON_STYLES: IButtonStyles = {
+	buttonBackground: undefined,
+	buttonHoverBackground: undefined,
+	buttonForeground: undefined,
+	buttonSeparator: undefined,
+	buttonSecondaryBackground: undefined,
+	buttonSecondaryHoverBackground: undefined,
+	buttonSecondaryForeground: undefined,
+	buttonSecondaryBorder: undefined,
+	buttonBorder: undefined,
+};
+
+/** Aggregate diff counts shown in the changes pill (scoped to a single turn). */
+export interface IDiffStats {
+	readonly files: number;
+	readonly insertions: number;
+	readonly deletions: number;
+}
+
+export const EMPTY_DIFF_STATS: IDiffStats = { files: 0, insertions: 0, deletions: 0 };
+
+/** A markdown/HTML file the preview pill can open. */
+export interface IPreviewFile {
+	readonly uri: URI;
+	readonly kind: 'markdown' | 'html';
+	/** Whether the file was created (vs. edited) during the turn. */
+	readonly created: boolean;
+}
+
+/** Classify a resource as a previewable markdown or HTML file, if applicable. */
+export function previewKind(uri: URI): 'markdown' | 'html' | undefined {
+	const path = uri.path.toLowerCase();
+	if (path.endsWith('.md') || path.endsWith('.markdown')) {
+		return 'markdown';
+	}
+	if (path.endsWith('.html') || path.endsWith('.htm')) {
+		return 'html';
+	}
+	return undefined;
+}
+
+export function diffStatsEqual(a: IDiffStats, b: IDiffStats): boolean {
+	return a.files === b.files && a.insertions === b.insertions && a.deletions === b.deletions;
+}
+
+export function previewFilesEqual(a: readonly IPreviewFile[], b: readonly IPreviewFile[]): boolean {
+	if (a.length !== b.length) {
+		return false;
+	}
+	for (let i = 0; i < a.length; i++) {
+		if (a[i].kind !== b[i].kind || a[i].created !== b[i].created || !isEqual(a[i].uri, b[i].uri)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * Open a previewable file: markdown files open as a markdown preview, HTML files
+ * open in the integrated browser (desktop only), falling back to the default
+ * opener when neither is available (e.g. web).
+ */
+export async function openChatPreviewFile(file: IPreviewFile, commandService: ICommandService, openerService: IOpenerService, logService: ILogService): Promise<void> {
+	try {
+		if (file.kind === 'markdown') {
+			await commandService.executeCommand('markdown.showPreview', file.uri);
+		} else {
+			await commandService.executeCommand(BrowserViewCommandId.Open, file.uri.toString());
+		}
+	} catch (err) {
+		logService.trace('[ChatTurnPills] Falling back to default opener for preview', err);
+		await openerService.open(file.uri);
+	}
+}
+
+/** The data and interactions a {@link ChatTurnPillsWidget} reflects. */
+export interface IChatTurnPillsModel {
+	readonly stats: IObservable<IDiffStats>;
+	readonly previewFiles: IObservable<readonly IPreviewFile[]>;
+	/** When `false` the changes pill stays hidden regardless of the data. */
+	readonly changesEnabled: IObservable<boolean>;
+	/** When `false` the preview pill stays hidden regardless of the data. */
+	readonly previewEnabled: IObservable<boolean>;
+	openChanges(): void;
+	openPreviewFile(file: IPreviewFile): void;
+}
+
+/** Per-pill visibility for the agent turn status pills ({@link ChatConfiguration.TurnStatusPills}). */
+export interface IChatTurnStatusPillsConfig {
+	readonly changes: boolean;
+	readonly preview: boolean;
+}
+
+const TURN_STATUS_PILLS_DEFAULT: IChatTurnStatusPillsConfig = { changes: false, preview: false };
+
+/** Observe the per-pill turn status pills visibility setting. */
+export function observeTurnStatusPillsConfig(configurationService: IConfigurationService): IObservable<IChatTurnStatusPillsConfig> {
+	return observableConfigValue(ChatConfiguration.TurnStatusPills, TURN_STATUS_PILLS_DEFAULT, configurationService);
+}
+
+/**
+ * The changes pill: `<diff-icon> <n> Files +insertions -deletions`, updating
+ * live as {@link _statsObs} changes.
+ */
+class ChangesPillActionViewItem extends BaseActionViewItem {
+
+	private _button: Button | undefined;
+
+	constructor(
+		action: IAction,
+		options: IActionViewItemOptions,
+		private readonly _statsObs: IObservable<IDiffStats>,
+	) {
+		super(undefined, action, options);
+	}
+
+	override render(container: HTMLElement): void {
+		this.element = container;
+		container.classList.add('chat-turn-pill-changes');
+
+		const button = this._button = this._register(new Button(container, { secondary: true, small: true, ...defaultButtonStyles }));
+		button.element.classList.add('monaco-text-button', 'chat-turn-pill-changes-button');
+		this._register(button.onDidClick(() => {
+			if (this._action.enabled) {
+				this.actionRunner.run(this._action, this._context);
+			}
+		}));
+
+		this._register(autorun(reader => {
+			this._statsObs.read(reader);
+			this._updateLabel();
+		}));
+	}
+
+	private _updateLabel(): void {
+		if (!this._button) {
+			return;
+		}
+		const { files, insertions, deletions } = this._statsObs.get();
+		const filesLabel = files === 1
+			? localize('chatTurnPills.changes.file', "{0} File", files)
+			: localize('chatTurnPills.changes.files', "{0} Files", files);
+		reset(
+			this._button.element,
+			$(`span.chat-turn-pill-meta-icon${ThemeIcon.asCSSSelector(Codicon.diffMultiple)}`),
+			$('span.chat-turn-pill-meta-label', undefined, filesLabel),
+			$('span.chat-turn-pill-meta-added', undefined, `+${insertions}`),
+			$('span.chat-turn-pill-meta-removed', undefined, `-${deletions}`),
+		);
+		this._button.setTitle(localize('chatTurnPills.changes.tooltip', "View Changes"));
+		this._button.element.setAttribute('aria-label', localize('chatTurnPills.changes.ariaLabel', "View Changes: {0}, +{1}, -{2}", filesLabel, insertions, deletions));
+	}
+
+	override focus(): void {
+		this._button?.focus();
+	}
+}
+
+/**
+ * The preview pill: renders the primary previewable file as a resource label
+ * (file icon + name) with a "preview" description. When more than one previewable
+ * file exists, a separator and a dropdown chevron are shown; the chevron lists
+ * every previewable file. Activating the label opens the primary file's preview.
+ */
+class PreviewPillActionViewItem extends BaseActionViewItem {
+
+	private _primary: Button | undefined;
+
+	constructor(
+		action: IAction,
+		options: IActionViewItemOptions,
+		private readonly _previewFilesObs: IObservable<readonly IPreviewFile[]>,
+		private readonly _resourceLabels: ResourceLabels,
+		private readonly _openFile: (file: IPreviewFile) => void,
+		private readonly _showAll: (anchor: HTMLElement) => void,
+	) {
+		super(undefined, action, options);
+	}
+
+	override render(container: HTMLElement): void {
+		this.element = container;
+		container.classList.add('chat-turn-pill-preview');
+
+		// The whole pill is one unified control: a primary resource label (file
+		// icon + name + "preview") on the left, an in-pill separator, and a dropdown
+		// chevron on the right. The inner buttons are transparent so the pill reads
+		// as a single element; each is an independent, tab-focusable button.
+		const primary = this._primary = this._register(new Button(container, { ...TRANSPARENT_BUTTON_STYLES }));
+		primary.element.classList.add('chat-turn-pill-preview-primary');
+		const label = this._register(this._resourceLabels.create(primary.element));
+		this._register(primary.onDidClick(() => {
+			const primaryFile = this._previewFilesObs.get().at(0);
+			if (primaryFile) {
+				this._openFile(primaryFile);
+			}
+		}));
+
+		const separator = append(container, $('.chat-turn-pill-preview-separator'));
+
+		const chevron = this._register(new Button(container, { ...TRANSPARENT_BUTTON_STYLES }));
+		chevron.element.classList.add('chat-turn-pill-preview-chevron');
+		// Render the chevron as a child element (not via `chevron.icon`, which puts a
+		// fixed-height codicon class on the button itself) so the button can stretch
+		// to the pill's full height and its hover background spans top to bottom.
+		append(chevron.element, $(`span${ThemeIcon.asCSSSelector(Codicon.chevronDown)}`));
+		const moreLabel = localize('chatTurnPills.preview.more', "Show All Previewable Files");
+		chevron.setTitle(moreLabel);
+		chevron.setAriaLabel(moreLabel);
+		this._register(chevron.onDidClick(() => this._showAll(chevron.element)));
+
+		this._register(autorun(reader => {
+			const files = this._previewFilesObs.read(reader);
+			const primaryFile = files.at(0);
+			if (primaryFile) {
+				label.setResource(
+					{ resource: primaryFile.uri, name: basename(primaryFile.uri), description: localize('chatTurnPills.preview.description', "preview") },
+					{ fileKind: FileKind.FILE },
+				);
+				const tooltip = localize('chatTurnPills.preview.tooltipOne', "Open Preview: {0}", basename(primaryFile.uri));
+				primary.setTitle(tooltip);
+				primary.setAriaLabel(tooltip);
+			}
+			const hasMultiple = files.length > 1;
+			separator.classList.toggle('hidden', !hasMultiple);
+			chevron.element.classList.toggle('hidden', !hasMultiple);
+		}));
+	}
+
+	override focus(): void {
+		this._primary?.focus();
+	}
+}
+
+/**
+ * A toolbar of clickable pills reflecting a single turn's status. Used both as a
+ * floating widget above the chat input (live, active turn) and inside a completed
+ * chat response. The pills are actions inside a {@link ToolBar}:
+ *
+ * - **Changes** — `<n> Files +ins -del` for the turn. Activating it opens the
+ *   changes.
+ * - **Preview** — shown when the turn created or edited a markdown or HTML file.
+ *   Rendered as a resource label (file icon + name) with a "preview" description
+ *   for the primary file. Activating it opens that file as a markdown preview or
+ *   in the integrated browser; when several exist, a dropdown lists them all.
+ *
+ * The data and the open actions are supplied by the {@link IChatTurnPillsModel}
+ * so the same widget serves surfaces with different data sources.
+ */
+export class ChatTurnPillsWidget extends Disposable {
+
+	readonly element: HTMLElement;
+
+	/** Whether the widget currently has any pill to show. */
+	readonly isVisible: IObservable<boolean>;
+
+	private readonly _toolbar: ToolBar;
+	private readonly _changesAction: Action;
+	private readonly _previewAction: Action;
+	private readonly _resourceLabels: ResourceLabels;
+
+	/** Ids of the currently mounted pills, so we only rebuild the toolbar when the set changes. */
+	private _visibleSignature: string | undefined;
+
+	constructor(
+		private readonly _model: IChatTurnPillsModel,
+		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+
+		// `show-file-icons` lets the preview pill's resource label render the file's
+		// themed icon — the label always computes the file-icon classes, but they
+		// only paint when an ancestor opts in.
+		this.element = $('.chat-turn-pills.show-file-icons.hidden');
+		this._resourceLabels = this._register(instantiationService.createInstance(ResourceLabels, DEFAULT_LABELS_CONTAINER));
+
+		this._changesAction = this._register(new Action(CHANGES_PILL_ACTION_ID, localize('chatTurnPills.changes.tooltip', "View Changes"), undefined, true, async () => this._model.openChanges()));
+		this._previewAction = this._register(new Action(PREVIEW_PILL_ACTION_ID, localize('chatTurnPills.preview.label', "Open Preview"), undefined, true, async () => this._openPrimaryPreview()));
+
+		this._toolbar = this._register(new ToolBar(this.element, this._contextMenuService, {
+			orientation: ActionsOrientation.HORIZONTAL,
+			ariaLabel: localize('chatTurnPills.ariaLabel', "Turn status"),
+			actionViewItemProvider: (action, options) => {
+				if (action.id === CHANGES_PILL_ACTION_ID) {
+					return new ChangesPillActionViewItem(action, options, this._model.stats);
+				}
+				if (action.id === PREVIEW_PILL_ACTION_ID) {
+					return new PreviewPillActionViewItem(action, options, this._model.previewFiles, this._resourceLabels, file => this._model.openPreviewFile(file), anchor => this._showAllPreviews(anchor));
+				}
+				return undefined;
+			},
+		}));
+
+		this.isVisible = derived(this, reader => this._showChanges(reader) || this._showPreview(reader));
+
+		this._register(autorun(reader => {
+			this._updateVisibleActions(this._showChanges(reader), this._showPreview(reader));
+		}));
+	}
+
+	private _showChanges(reader: IReader): boolean {
+		return this._model.changesEnabled.read(reader) && this._model.stats.read(reader).files > 0;
+	}
+
+	private _showPreview(reader: IReader): boolean {
+		return this._model.previewEnabled.read(reader) && this._model.previewFiles.read(reader).length > 0;
+	}
+
+	private _updateVisibleActions(showChanges: boolean, showPreview: boolean): void {
+		const actions: IAction[] = [];
+		if (showChanges) {
+			actions.push(this._changesAction);
+		}
+		if (showPreview) {
+			actions.push(this._previewAction);
+		}
+
+		const signature = actions.map(a => a.id).join(',');
+		if (signature !== this._visibleSignature) {
+			this._visibleSignature = signature;
+			this._toolbar.setActions(actions);
+		}
+		this.element.classList.toggle('hidden', actions.length === 0);
+	}
+
+	private _openPrimaryPreview(): void {
+		const primaryFile = this._model.previewFiles.get().at(0);
+		if (primaryFile) {
+			this._model.openPreviewFile(primaryFile);
+		}
+	}
+
+	private _showAllPreviews(anchor: HTMLElement): void {
+		const files = this._model.previewFiles.get();
+		if (files.length === 0) {
+			return;
+		}
+		this._contextMenuService.showContextMenu({
+			getAnchor: () => anchor,
+			getActions: () => files.map(file => toAction({
+				id: `${PREVIEW_PILL_ACTION_ID}.${file.uri.toString()}`,
+				label: basename(file.uri),
+				class: ThemeIcon.asClassName(file.kind === 'html' ? Codicon.globe : Codicon.openPreview),
+				run: () => this._model.openPreviewFile(file),
+			})),
+		});
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -97,6 +97,7 @@ export enum ChatConfiguration {
 	EditorLocalAgentEnabled = 'chat.editor.localAgent.enabled',
 	CopilotCliHideExtensionHostEditor = 'chat.editor.copilotCli.hideExtensionHost',
 	AgentsHandoffTipMode = 'chat.agentsHandoffTip.mode',
+	TurnStatusPills = 'chat.turnStatusPills',
 
 	IncrementalRendering = 'chat.experimental.incrementalRendering.enabled',
 	IncrementalRenderingStyle = 'chat.experimental.incrementalRendering.animationStyle',

--- a/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
@@ -221,10 +221,16 @@ export interface IChatChangesSummaryPart {
 	readonly sessionResource: URI;
 }
 
+export interface IChatTurnPillsPart {
+	readonly kind: 'turnPills';
+	readonly requestId: string;
+	readonly sessionResource: URI;
+}
+
 /**
  * Type for content parts rendered by IChatListRenderer (not necessarily in the model)
  */
-export type IChatRendererContent = IChatProgressRenderableResponseContent | IChatReferences | IChatCodeCitations | IChatErrorDetailsPart | IChatChangesSummaryPart | IChatWorkingProgress | IChatMcpServersStarting | IChatMcpAuthenticationRequired | IChatMcpServersStartingSlow | IChatQuestionCarousel | IChatPlanReview | IChatDisabledClaudeHooksPart;
+export type IChatRendererContent = IChatProgressRenderableResponseContent | IChatReferences | IChatCodeCitations | IChatErrorDetailsPart | IChatChangesSummaryPart | IChatWorkingProgress | IChatMcpServersStarting | IChatMcpAuthenticationRequired | IChatMcpServersStartingSlow | IChatQuestionCarousel | IChatPlanReview | IChatDisabledClaudeHooksPart | IChatTurnPillsPart;
 
 export interface IChatResponseViewModel {
 	readonly model: IChatResponseModel;

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatTurnPills.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatTurnPills.fixture.ts
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { constObservable } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock, upcastPartial } from '../../../../../base/test/common/mock.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IEditSessionEntryDiff } from '../../../../contrib/chat/common/editing/chatEditingService.js';
+import { IChatResponseFileChangesService } from '../../../../contrib/chat/browser/chatResponseFileChangesService.js';
+import { ChatTurnPillsContentPart } from '../../../../contrib/chat/browser/widget/chatContentParts/chatTurnPillsPart.js';
+import { IChatContentPartRenderContext } from '../../../../contrib/chat/browser/widget/chatContentParts/chatContentParts.js';
+import { ChatConfiguration } from '../../../../contrib/chat/common/constants.js';
+import { IChatTurnPillsPart } from '../../../../contrib/chat/common/model/chatViewModel.js';
+import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup } from '../fixtureUtils.js';
+import { registerChatFixtureServices } from './chatFixtureUtils.js';
+
+// ============================================================================
+// Mock helpers
+// ============================================================================
+
+/**
+ * A per-request file diff. A created file has no before-content, so the agent
+ * host provider maps its `originalURI` to the `modifiedURI` (equal URIs); an
+ * edited file keeps a distinct original.
+ */
+function fileDiff(name: string, added: number, removed: number, created: boolean): IEditSessionEntryDiff {
+	const modifiedURI = URI.file(`/repo/${name}`);
+	const originalURI = created ? modifiedURI : URI.file(`/repo/.original/${name}`);
+	return { originalURI, modifiedURI, added, removed, quitEarly: false, identical: false, isFinal: true, isBusy: false };
+}
+
+function stubFileChangesService(diffs: readonly IEditSessionEntryDiff[]): IChatResponseFileChangesService {
+	return new class extends mock<IChatResponseFileChangesService>() {
+		override getChangesForRequest() {
+			return constObservable(diffs);
+		}
+	}();
+}
+
+// ============================================================================
+// Render helper
+// ============================================================================
+
+function renderTurnPills(ctx: ComponentFixtureContext, diffs: readonly IEditSessionEntryDiff[]): void {
+	const { container, disposableStore } = ctx;
+
+	const instantiationService = createEditorServices(disposableStore, {
+		colorTheme: ctx.theme,
+		additionalServices: (reg) => {
+			// Broad chat service graph: IContextMenuService, IEditorService and the
+			// ResourceLabels dependencies the preview pill needs.
+			registerChatFixtureServices(reg);
+			reg.defineInstance(IChatResponseFileChangesService, stubFileChangesService(diffs));
+		},
+	});
+
+	// Both pills are off by default; enable them so the fixture renders.
+	(instantiationService.get(IConfigurationService) as TestConfigurationService).setUserConfiguration(ChatConfiguration.TurnStatusPills, { changes: true, preview: true });
+
+	const content: IChatTurnPillsPart = {
+		kind: 'turnPills',
+		requestId: 'request-1',
+		sessionResource: URI.parse('vscode-chat-session://agent-host/session-1'),
+	};
+	const context = upcastPartial<IChatContentPartRenderContext>({ container });
+
+	const part = disposableStore.add(instantiationService.createInstance(ChatTurnPillsContentPart, content, context));
+
+	container.style.padding = '12px';
+	container.style.backgroundColor = 'var(--vscode-editor-background)';
+	container.appendChild(part.domNode);
+}
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+export default defineThemedFixtureGroup({ path: 'chat/' }, {
+
+	ChangesSingleFile: defineComponentFixture({
+		render: (ctx) => renderTurnPills(ctx, [fileDiff('app.ts', 12, 5, false)]),
+	}),
+
+	ChangesMultipleFiles: defineComponentFixture({
+		render: (ctx) => renderTurnPills(ctx, [
+			fileDiff('app.ts', 42, 7, false),
+			fileDiff('util.ts', 118, 64, false),
+			fileDiff('index.ts', 5, 0, true),
+		]),
+	}),
+
+	PreviewMarkdown: defineComponentFixture({
+		render: (ctx) => renderTurnPills(ctx, [
+			fileDiff('README.md', 20, 0, true),
+			fileDiff('app.ts', 8, 3, false),
+		]),
+	}),
+
+	PreviewMultiple: defineComponentFixture({
+		render: (ctx) => renderTurnPills(ctx, [
+			fileDiff('app.ts', 8, 3, false),
+			fileDiff('README.md', 20, 0, true),
+			fileDiff('index.html', 30, 4, true),
+			fileDiff('CHANGELOG.md', 6, 1, false),
+		]),
+	}),
+
+	NoChanges_Hidden: defineComponentFixture({
+		render: (ctx) => renderTurnPills(ctx, []),
+	}),
+});

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatWidget.fixture.ts
@@ -17,6 +17,7 @@ import { ChatModel } from '../../../../contrib/chat/common/model/chatModel.js';
 import { ChatViewModel } from '../../../../contrib/chat/common/model/chatViewModel.js';
 import { ChatListWidget } from '../../../../contrib/chat/browser/widget/chatListWidget.js';
 import { ChatInputPart, IChatInputPartOptions, IChatInputStyles } from '../../../../contrib/chat/browser/widget/input/chatInputPart.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IChatWidget, IChatWidgetService } from '../../../../contrib/chat/browser/chat.js';
 import { ElicitationState, IChatService } from '../../../../contrib/chat/common/chatService/chatService.js';
 import { ChatElicitationRequestPart } from '../../../../contrib/chat/common/model/chatProgressTypes/chatElicitationRequestPart.js';
@@ -53,6 +54,13 @@ export interface IChatWidgetFixtureOptions {
 	 * When omitted, behaves like today (auto-detected from message risk data).
 	 */
 	readonly riskAssessmentEnabled?: boolean;
+	/**
+	 * Optional hook invoked after the chat input part renders, e.g. to mount
+	 * widgets above the input. Receives the rendered input part and the fixture's
+	 * instantiation service so callers can create instances against the same
+	 * service graph.
+	 */
+	readonly decorateInputPart?: (inputPart: ChatInputPart, instantiationService: IInstantiationService) => void;
 }
 
 function makeUserMessage(text: string) {
@@ -262,6 +270,8 @@ export async function renderChatWidget(context: ComponentFixtureContext, options
 
 	inputPart.render(session, '', fixtureWidget);
 	inputPart.layout(width);
+
+	options.decorateInputPart?.(inputPart, instantiationService);
 
 	const listContainer = dom.$('.interactive-list');
 	listContainer.style.flex = '1 1 auto';

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/sessionChatInputToolbar.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/sessionChatInputToolbar.fixture.ts
@@ -95,7 +95,9 @@ async function renderChatViewWithPills(ctx: ComponentFixtureContext, session: IA
 		messages,
 		decorateInputPart: (inputPart, instantiationService) => {
 			// Both pills are off by default; enable them so the fixture renders.
-			(instantiationService.get(IConfigurationService) as TestConfigurationService).setUserConfiguration(ChatConfiguration.TurnStatusPills, { changes: true, preview: true });
+			instantiationService.invokeFunction(accessor => {
+				(accessor.get(IConfigurationService) as TestConfigurationService).setUserConfiguration(ChatConfiguration.TurnStatusPills, { changes: true, preview: true });
+			});
 			const pills = ctx.disposableStore.add(instantiationService.createInstance(SessionChatInputToolbar));
 			pills.setSession(session);
 			// Mount above the input, mirroring the sessions ChatView.

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/sessionChatInputToolbar.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/sessionChatInputToolbar.fixture.ts
@@ -1,0 +1,205 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { mock } from '../../../../../base/test/common/mock.js';
+import { constObservable, IObservable } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { ChatConfiguration } from '../../../../contrib/chat/common/constants.js';
+// eslint-disable-next-line local/code-import-patterns
+import { SessionChatInputToolbar } from '../../../../../sessions/contrib/chat/browser/sessionChatInputToolbar.js';
+// eslint-disable-next-line local/code-import-patterns
+import { LOCAL_AGENT_HOST_PROVIDER_ID } from '../../../../../sessions/common/agentHostSessionsProvider.js';
+// eslint-disable-next-line local/code-import-patterns
+import { ISessionChangeset, ISessionFileChange, SessionStatus, TURN_CHANGES_CHANGESET_ID } from '../../../../../sessions/services/sessions/common/session.js';
+// eslint-disable-next-line local/code-import-patterns
+import { IActiveSession } from '../../../../../sessions/services/sessions/common/sessionsManagement.js';
+import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup } from '../fixtureUtils.js';
+import { registerChatFixtureServices } from '../chat/chatFixtureUtils.js';
+import { IFixtureMessage, renderChatWidget } from '../chat/chatWidget.fixture.js';
+
+// ============================================================================
+// Mock helpers
+// ============================================================================
+
+/** A file created during the turn (no original => classified as "created"). */
+function createdFile(name: string, insertions: number, deletions: number): ISessionFileChange {
+	return { modifiedUri: URI.file(`/repo/${name}`), insertions, deletions };
+}
+
+/** A file edited during the turn (has an original => classified as "modified"). */
+function editedFile(name: string, insertions: number, deletions: number): ISessionFileChange {
+	const uri = URI.file(`/repo/${name}`);
+	return { modifiedUri: uri, originalUri: uri, insertions, deletions };
+}
+
+/** A single "Last Turn Changes" changeset carrying the given file changes. */
+function turnChangeset(changes: readonly ISessionFileChange[]): ISessionChangeset {
+	return new class extends mock<ISessionChangeset>() {
+		override readonly id = TURN_CHANGES_CHANGESET_ID;
+		override readonly changes: IObservable<readonly ISessionFileChange[]> = constObservable(changes);
+	}();
+}
+
+interface ISessionSpec {
+	readonly providerId?: string;
+	/** File changes in the current turn; omit for a session with no turn changeset. */
+	readonly turnChanges?: readonly ISessionFileChange[];
+}
+
+function createMockSession(spec: ISessionSpec): IActiveSession {
+	const changesets = spec.turnChanges !== undefined ? [turnChangeset(spec.turnChanges)] : [];
+	return new class extends mock<IActiveSession>() {
+		override readonly resource = URI.parse('session:1');
+		override readonly providerId = spec.providerId ?? LOCAL_AGENT_HOST_PROVIDER_ID;
+		// Pills above the input only show while a turn is actively in progress.
+		override readonly status: IObservable<SessionStatus> = constObservable(SessionStatus.InProgress);
+		override readonly changesets: IObservable<readonly ISessionChangeset[] | undefined> = constObservable(changesets);
+	}();
+}
+
+// ============================================================================
+// Render helpers
+// ============================================================================
+
+function renderPills(ctx: ComponentFixtureContext, session: IActiveSession): void {
+	const { container, disposableStore } = ctx;
+
+	const instantiationService = createEditorServices(disposableStore, {
+		colorTheme: ctx.theme,
+		additionalServices: (reg) => {
+			// Broad chat service graph: provides IContextMenuService and the
+			// ResourceLabels dependencies (decorations, text file, workspace, label
+			// services) the preview pill needs, on top of the base editor services
+			// (which register a partial ISessionsService).
+			registerChatFixtureServices(reg);
+		},
+	});
+
+	// Both pills are off by default; enable them so the fixture renders.
+	(instantiationService.get(IConfigurationService) as TestConfigurationService).setUserConfiguration(ChatConfiguration.TurnStatusPills, { changes: true, preview: true });
+
+	const pills = disposableStore.add(instantiationService.createInstance(SessionChatInputToolbar));
+	pills.setSession(session);
+	container.appendChild(pills.element);
+
+	container.style.padding = '12px';
+	container.style.backgroundColor = 'var(--vscode-sideBar-background)';
+}
+
+async function renderChatViewWithPills(ctx: ComponentFixtureContext, session: IActiveSession, messages: IFixtureMessage[]): Promise<void> {
+	await renderChatWidget(ctx, {
+		messages,
+		decorateInputPart: (inputPart, instantiationService) => {
+			// Both pills are off by default; enable them so the fixture renders.
+			(instantiationService.get(IConfigurationService) as TestConfigurationService).setUserConfiguration(ChatConfiguration.TurnStatusPills, { changes: true, preview: true });
+			const pills = ctx.disposableStore.add(instantiationService.createInstance(SessionChatInputToolbar));
+			pills.setSession(session);
+			// Mount above the input, mirroring the sessions ChatView.
+			inputPart.element.insertBefore(pills.element, inputPart.element.firstChild);
+		},
+	});
+}
+
+const FULL_VIEW_MESSAGES: IFixtureMessage[] = [
+	{
+		user: 'Add a README describing the project',
+		assistant: [
+			{ kind: 'markdown', text: 'I created `README.md` with a project overview, setup steps, and usage examples.' },
+		],
+	},
+	{
+		user: 'Now scaffold a simple landing page',
+		assistant: [
+			{ kind: 'markdown', text: 'Added `index.html` with a minimal landing page and linked it from the README.' },
+		],
+	},
+];
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+export default defineThemedFixtureGroup({ path: 'sessions/' }, {
+
+	// --- Changes pill (per turn) --------------------------------------------
+
+	SessionChatPills_ChangesSingleFile: defineComponentFixture({
+		render: (ctx) => renderPills(ctx, createMockSession({ turnChanges: [editedFile('app.ts', 12, 5)] })),
+	}),
+
+	SessionChatPills_ChangesMultipleFiles: defineComponentFixture({
+		render: (ctx) => renderPills(ctx, createMockSession({
+			turnChanges: [editedFile('app.ts', 42, 7), editedFile('util.ts', 118, 64), editedFile('index.ts', 5, 0)],
+		})),
+	}),
+
+	SessionChatPills_ChangesOnlyInsertions: defineComponentFixture({
+		render: (ctx) => renderPills(ctx, createMockSession({ turnChanges: [editedFile('feature.ts', 256, 0)] })),
+	}),
+
+	SessionChatPills_ChangesOnlyDeletions: defineComponentFixture({
+		render: (ctx) => renderPills(ctx, createMockSession({ turnChanges: [editedFile('legacy.ts', 0, 89)] })),
+	}),
+
+	// --- Preview pill (resource label + dropdown) ---------------------------
+
+	SessionChatPills_PreviewMarkdown: defineComponentFixture({
+		render: (ctx) => renderPills(ctx, createMockSession({
+			turnChanges: [createdFile('README.md', 20, 0), editedFile('app.ts', 8, 3)],
+		})),
+	}),
+
+	SessionChatPills_PreviewHtml: defineComponentFixture({
+		render: (ctx) => renderPills(ctx, createMockSession({
+			turnChanges: [createdFile('index.html', 60, 2), editedFile('styles.css', 14, 1)],
+		})),
+	}),
+
+	SessionChatPills_PreviewMultiple_PrimaryCreated: defineComponentFixture({
+		render: (ctx) => renderPills(ctx, createMockSession({
+			turnChanges: [
+				editedFile('app.ts', 8, 3),
+				createdFile('README.md', 20, 0),
+				createdFile('index.html', 30, 4),
+				editedFile('CHANGELOG.md', 6, 1),
+			],
+		})),
+	}),
+
+	SessionChatPills_PreviewMultiple_PrimaryEdited: defineComponentFixture({
+		render: (ctx) => renderPills(ctx, createMockSession({
+			turnChanges: [editedFile('docs.md', 10, 2), editedFile('page.html', 4, 1)],
+		})),
+	}),
+
+	// --- Gating -------------------------------------------------------------
+
+	SessionChatPills_NotAgentHost_Hidden: defineComponentFixture({
+		render: (ctx) => renderPills(ctx, createMockSession({
+			providerId: 'copilot-cloud',
+			turnChanges: [editedFile('app.ts', 12, 5)],
+		})),
+	}),
+
+	SessionChatPills_NoActivity_Hidden: defineComponentFixture({
+		render: (ctx) => renderPills(ctx, createMockSession({})),
+	}),
+
+	// --- Full chat view -----------------------------------------------------
+
+	SessionChatView_ChangesPill: defineComponentFixture({
+		render: (ctx) => renderChatViewWithPills(ctx, createMockSession({
+			turnChanges: [editedFile('app.ts', 12, 5), editedFile('util.ts', 4, 2)],
+		}), FULL_VIEW_MESSAGES),
+	}),
+
+	SessionChatView_BothPills: defineComponentFixture({
+		render: (ctx) => renderChatViewWithPills(ctx, createMockSession({
+			turnChanges: [createdFile('README.md', 20, 0), createdFile('index.html', 30, 4), editedFile('app.ts', 8, 3)],
+		}), FULL_VIEW_MESSAGES),
+	}),
+});


### PR DESCRIPTION
Adds two "turn status pills" for agent sessions:

- **Changes** — `N Files +ins -del` for the current turn; opens the turn's changes.
- **Preview** — a resource label + dropdown for Markdown/HTML files created or edited in the turn; opens a Markdown preview or the integrated browser.

While a turn is streaming the pills float above the chat input; once the turn completes they move into that response (between the file-changes summary and the working-progress indicator) and fresh pills appear above the input for the next turn.

Scoped to agent-host sessions. A shared `ChatTurnPillsWidget` backs both surfaces: the above-input toolbar lives in `vs/sessions`, and the in-response pills are a new workbench chat content part fed by `IChatResponseFileChangesService`.

### Setting

New object setting `chat.turnStatusPills`, both keys off by default:

- `chat.turnStatusPills.changes`
- `chat.turnStatusPills.preview`

### Fixtures

Component fixtures for the pills (above-input, in-response, and full chat view).