### PR TITLE
Detect Command Code as an agent CLI for terminal tab titles

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -156,6 +156,7 @@ export const enum WindowsShellType {
 export const enum GeneralShellType {
 	Claude = 'claude',
 	Codex = 'codex',
+	CommandCode = 'commandcode',
 	Copilot = 'copilot',
 	Gemini = 'gemini',
 	PowerShell = 'pwsh',

--- a/src/vs/platform/terminal/node/terminalProcess.ts
+++ b/src/vs/platform/terminal/node/terminalProcess.ts
@@ -71,6 +71,7 @@ const posixShellTypeMap = new Map<string, PosixShellType>([
 const generalShellTypeMap = new Map<string, GeneralShellType>([
 	['claude', GeneralShellType.Claude],
 	['codex', GeneralShellType.Codex],
+	['commandcode', GeneralShellType.CommandCode],
 	['copilot', GeneralShellType.Copilot],
 	['gemini', GeneralShellType.Gemini],
 	['pwsh', GeneralShellType.PowerShell],

--- a/src/vs/platform/terminal/node/windowsShellHelper.ts
+++ b/src/vs/platform/terminal/node/windowsShellHelper.ts
@@ -48,6 +48,7 @@ const SHELL_EXECUTABLE_REGEXES = [
 const NODE_AGENT_CLI_PATTERNS: ReadonlyArray<{ regex: RegExp; executable: string }> = [
 	{ regex: /[\\/]claude-code[\\/]/i, executable: 'claude.exe' },
 	{ regex: /[\\/]codex[\\/]/i, executable: 'codex.exe' },
+	{ regex: /[\\/]command-code[\\/]/i, executable: 'commandcode.exe' },
 	{ regex: /[\\/]copilot[\\/]/i, executable: 'copilot.exe' },
 	{ regex: /[\\/]gemini-cli[\\/]/i, executable: 'gemini.exe' },
 ];
@@ -189,6 +190,8 @@ export class WindowsShellHelper extends Disposable implements IWindowsShellHelpe
 				return GeneralShellType.Claude;
 			case 'codex.exe':
 				return GeneralShellType.Codex;
+			case 'commandcode.exe':
+				return GeneralShellType.CommandCode;
 			case 'copilot.exe':
 				return GeneralShellType.Copilot;
 			case 'gemini.exe':

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -132,6 +132,7 @@ const shellIntegrationSupportedShellTypes: (PosixShellType | GeneralShellType | 
 const agentCliTitlePatterns: ReadonlyMap<GeneralShellType, RegExp> = new Map([
 	[GeneralShellType.Claude, /claude\s*code/i],
 	// [GeneralShellType.Codex, /\bcodex\b/i], // codex does not report osc title.
+	[GeneralShellType.CommandCode, /command\s*code/i],
 	[GeneralShellType.Copilot, /\bcopilot\b/i],
 	[GeneralShellType.Gemini, /\bgemini\b/i],
 ]);
@@ -2711,6 +2712,7 @@ export class TerminalLabelComputer extends Disposable {
 	static readonly agentCliShellTypes: ReadonlySet<GeneralShellType> = new Set([
 		GeneralShellType.Claude,
 		GeneralShellType.Codex,
+		GeneralShellType.CommandCode,
 		GeneralShellType.Copilot,
 		GeneralShellType.Gemini,
 	]);

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -137,7 +137,7 @@ const terminalConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 		description: localize('terminal.integrated.tabs.focusMode', "Controls whether focusing the terminal of a tab happens on double or single click.")
 	},
 	[TerminalSettingId.TabsAllowAgentCliTitle]: {
-		description: localize('terminal.integrated.tabs.allowAgentCliTitle', "Controls whether agentic CLIs (such as Claude Code, Codex, GitHub Copilot CLI, and Gemini CLI) are allowed to set the terminal tab title via escape sequences. When disabled, the configured tab title template is used instead."),
+		description: localize('terminal.integrated.tabs.allowAgentCliTitle', "Controls whether agentic CLIs (such as Claude Code, Codex, Command Code, GitHub Copilot CLI, and Gemini CLI) are allowed to set the terminal tab title via escape sequences. When disabled, the configured tab title template is used instead."),
 		type: 'boolean',
 		default: true,
 	},

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
@@ -221,6 +221,15 @@ suite('Workbench - TerminalInstance', () => {
 			strictEqual(instance.shellType, PosixShellType.Zsh);
 		});
 
+		test('should detect Command Code agent shell type from its OSC title', async () => {
+			const instance = await createTerminalInstance() as TerminalInstance;
+			const onTitleChange = (title: string) => (instance as unknown as Record<string, (value: string) => void>)['_onTitleChange'](title);
+
+			strictEqual(instance.shellType, undefined);
+			onTitleChange('\u2733 Command Code \u00b7 my-project');
+			strictEqual(instance.shellType, GeneralShellType.CommandCode);
+		});
+
 		test('custom key event handler should handle commands in DEFAULT_COMMANDS_TO_SKIP_SHELL in VS Code and not xterm when sendKeybindingsToShell is disabled', async () => {
 			const instance = await createTerminalInstance();
 			const keybindingService = instance['_keybindingService'];
@@ -514,6 +523,11 @@ suite('Workbench - TerminalInstance', () => {
 			const terminalLabelComputer = createLabelComputer({ terminal: { integrated: { tabs: { separator: ' - ', title: '${process}', description: '${cwd}', allowAgentCliTitle: true } } } });
 			terminalLabelComputer.refreshLabel(createInstance({ capabilities, shellType: GeneralShellType.Gemini, sequence: 'Gemini - my-project', processName: 'node' }));
 			strictEqual(terminalLabelComputer.title, 'Gemini - my-project');
+		});
+		test('should use ${sequence} for Command Code agent CLI shell type', () => {
+			const terminalLabelComputer = createLabelComputer({ terminal: { integrated: { tabs: { separator: ' - ', title: '${process}', description: '${cwd}', allowAgentCliTitle: true } } } });
+			terminalLabelComputer.refreshLabel(createInstance({ capabilities, shellType: GeneralShellType.CommandCode, sequence: 'Fix Parser Bug', processName: 'node' }));
+			strictEqual(terminalLabelComputer.title, 'Fix Parser Bug');
 		});
 		test('should prefer shellLaunchConfig.titleTemplate over agent CLI shell type override', () => {
 			const terminalLabelComputer = createLabelComputer({ terminal: { integrated: { tabs: { separator: ' - ', title: '${process}', description: '${cwd}', allowAgentCliTitle: true } } } });


### PR DESCRIPTION
Hey folks, founder of [Command Code](https://commandcode.ai) here. We got over [100K developers using it](https://x.com/MrAhmadAwais/status/2073037292554657869?s=20) so it will have a huge impact to fix one of the constant asks we get to be able to enable terminal tab titles in VS Code. Only we're not able to do it, even with the `terminal.integrated.tabs.allowAgentCliTitle` setting, as I believe there's a hard coded list that needs updating. Hence this PR. 



Follows up on #290830 / #304528, adding [Command Code](https://commandcode.ai) (npm: [`command-code`](https://www.npmjs.com/package/command-code), binaries `commandcode` / `cmd` / `cmdc`) to the agent CLIs whose OSC 0/2 title sequences drive the terminal tab title under `terminal.integrated.tabs.allowAgentCliTitle`.

Command Code already emits OSC 0 + OSC 2 title sequences on every session-title change (its first title is always `✳ Command Code · <project>`, later ones carry the live session name), so all four existing detection hooks apply cleanly:

- **`GeneralShellType.CommandCode`** (`'commandcode'`) added to the enum.
- **OSC title pattern** (`terminalInstance.ts`): `/command\s*code/i` — like Claude Code, the CLI runs as `node` on POSIX, so the title sequence is the cross-platform detection signal. The existing `_agentShellTypeFromSequence` stickiness keeps the shell type locked once the first title matches, so later titles without the product name still flow to `${sequence}`.
- **POSIX process-name map** (`terminalProcess.ts`): `['commandcode', GeneralShellType.CommandCode]`, matching the `commandcode` binary name.
- **Windows node.exe command-line pattern** (`windowsShellHelper.ts`): `/[\\/]command-code[\\/]/i` → `commandcode.exe`, matching the npm package directory (`node_modules/command-code/dist/index.mjs`) regardless of which bin alias (`cmd`, `cmdc`, `commandcode`, `command-code`) launched it. The `cmd` alias is deliberately NOT added anywhere — it would collide with `cmd.exe`.
- `TerminalLabelComputer.agentCliShellTypes` + the setting description updated accordingly.

Tests: mirrors the existing coverage — OSC-title shell-type detection for the Command Code default title, and a `TerminalLabelComputer` case asserting `${sequence}` is used for `GeneralShellType.CommandCode` when `allowAgentCliTitle` is enabled.

cc @anthonykim1
