### PR TITLE
Only show completion feedback command for paid users

### DIFF
--- a/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/vscodeInlineCompletionItemProvider.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/vscodeInlineCompletionItemProvider.ts
@@ -33,6 +33,7 @@ import { NextEditProviderTelemetryBuilder, TelemetrySender } from '../../../../i
 import { InlineEditLogger } from '../../../../inlineEdits/vscode-node/parts/inlineEditLogger';
 import { GhostTextLogContext } from '../../../common/ghostTextContext';
 import { ICompletionsTelemetryService } from '../../bridge/src/completionsTelemetryServiceBridge';
+import { ICompletionsCopilotTokenManager } from '../../lib/src/auth/copilotTokenManager';
 import { BuildInfo } from '../../lib/src/config';
 import { CopilotConfigPrefix } from '../../lib/src/constants';
 import { handleException } from '../../lib/src/defaultHandlers';
@@ -82,6 +83,7 @@ export class CopilotInlineCompletionItemProvider extends Disposable implements I
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@ICompletionsTelemetryService private readonly telemetryService: ICompletionsTelemetryService,
 		@ICompletionsExtensionStatus private readonly extensionStatusService: ICompletionsExtensionStatus,
+		@ICompletionsCopilotTokenManager private readonly copilotTokenManager: ICompletionsCopilotTokenManager,
 		@ILogService logService: ILogService,
 		@IRequestLogger private readonly requestLogger: IRequestLogger,
 	) {
@@ -184,9 +186,14 @@ export class CopilotInlineCompletionItemProvider extends Disposable implements I
 			this.logSuggestion(logContext, doc, list);
 			logContext.setResponseResults(list.items);
 
+			// Only offer the "Send Copilot Completion Feedback" command to paid users.
+			// Free and unauthenticated users would otherwise spam the issue tracker.
+			const token = this.copilotTokenManager.token;
+			const canSendCompletionFeedback = !!token && !token.isFreeUser && !token.isNoAuthUser;
+
 			return {
 				...list,
-				commands: [sendCompletionFeedbackCommand],
+				commands: canSendCompletionFeedback ? [sendCompletionFeedbackCommand] : [],
 			};
 		} catch (e) {
 			this.instantiationService.invokeFunction(exception, e, '._provideInlineCompletionItems', myLogger);

--- a/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/vscodeInlineCompletionItemProvider.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/vscodeInlineCompletionItemProvider.ts
@@ -188,8 +188,8 @@ export class CopilotInlineCompletionItemProvider extends Disposable implements I
 
 			// Only offer the "Send Copilot Completion Feedback" command to paid users.
 			// Free and unauthenticated users would otherwise spam the issue tracker.
-			const token = this.copilotTokenManager.token;
-			const canSendCompletionFeedback = !!token && !token.isFreeUser && !token.isNoAuthUser;
+			const copilotToken = this.copilotTokenManager.token;
+			const canSendCompletionFeedback = !!copilotToken && !copilotToken.isFreeUser && !copilotToken.isNoAuthUser;
 
 			return {
 				...list,


### PR DESCRIPTION
## Why

The "Send Copilot Completion Feedback" command is attached to every inline completion list, so the feedback button shows for all users, including free and unauthenticated ones. That has been a source of low-signal spam on the issue tracker.

## What

Gate the command in `CopilotInlineCompletionItemProvider` so it is only offered when the current Copilot token belongs to a paid user, i.e. `token && !token.isFreeUser && !token.isNoAuthUser`. This mirrors the existing "paid user" check used elsewhere (e.g. `agentIntent.ts`) and how free/no-auth are grouped throughout the extension.

The provider now injects `ICompletionsCopilotTokenManager` (already registered in the completions service collection) and reads the cached token on the completion path. When the user is free or no-auth, the returned list simply carries no `commands`, so the button is not rendered.

## Notes

- The command is still registered globally; only its attachment to the completion list is gated, which is the sole surface that renders the button (there is no separate menu contribution).
- This worktree has no `node_modules`, so the pre-commit hygiene hook and a local compile could not run; types were verified against the real definitions. Please confirm the extension build stays green in CI.