### PR TITLE
Fix: Recompute long distance preview layout upon tokenization and font changes

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/longDistancePreviewEditor.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/longDistancePreviewEditor.ts
@@ -6,7 +6,8 @@
 import { n } from '../../../../../../../../base/browser/dom.js';
 import { Disposable } from '../../../../../../../../base/common/lifecycle.js';
 import { clamp } from '../../../../../../../../base/common/numbers.js';
-import { IObservable, derived, constObservable, IReader, autorun, observableValue } from '../../../../../../../../base/common/observable.js';
+import { Event } from '../../../../../../../../base/common/event.js';
+import { IObservable, derived, constObservable, IReader, autorun, observableValue, observableSignal } from '../../../../../../../../base/common/observable.js';
 import { IInstantiationService } from '../../../../../../../../platform/instantiation/common/instantiation.js';
 import { ICodeEditor } from '../../../../../../../browser/editorBrowser.js';
 import { ObservableCodeEditor, observableCodeEditor } from '../../../../../../../browser/observableCodeEditor.js';
@@ -46,6 +47,7 @@ export class LongDistancePreviewEditor extends Disposable {
 	public readonly element = n.div({ class: 'preview', style: { /*pointerEvents: 'none'*/ }, ref: this._previewRef });
 
 	private _parentEditorObs: ObservableCodeEditor;
+	private readonly _previewEditorLayoutInvalidated = observableSignal(this);
 
 	constructor(
 		private readonly _previewTextModel: ITextModel,
@@ -131,6 +133,22 @@ export class LongDistancePreviewEditor extends Disposable {
 			constObservable(false),
 			observableValue(this, false),
 		));
+
+		this._register(autorun((reader) => {
+			const model = this._previewEditorObs.model.read(reader);
+			if (!model) {
+				return;
+			}
+			const onLayoutInvalidated = Event.any(
+				model.onDidChangeTokens,
+				model.onDidChangeOptions,
+				model.onDidChangeLanguage,
+				model.onDidChangeFont,
+			);
+			reader.store.add(onLayoutInvalidated(() => {
+				this._previewEditorLayoutInvalidated.trigger(undefined);
+			}));
+		}));
 
 		this.updatePreviewEditorEffect.recomputeInitiallyAndOnChange(this._store);
 	}
@@ -255,6 +273,7 @@ export class LongDistancePreviewEditor extends Disposable {
 	}).flatten();
 
 	private _getHorizontalContentRangeInPreviewEditorToShow(editor: ICodeEditor, reader: IReader) {
+		this._previewEditorLayoutInvalidated.read(reader);
 		const state = this._state.read(reader);
 		if (!state) { return undefined; }
 


### PR DESCRIPTION
Fixes #324484

**Problem:** When the `LongDistancePreviewEditor` initializes, the editor hasn't fully completed tokenization, layout, or font resolution. As a result, character offsets (like indentationEnd) calculated via `_previewEditorObs.getLeftOfPosition` fall back to a rough layout approximation.

Because `_getHorizontalContentRangeInPreviewEditorToShow` previously lacked reactivity to the text model's rendering events, it never recomputed the layout. This left the widget permanently stuck with the invalid, approximated indentationEnd and offset range.

**Solution:** This PR introduces an `_previewEditorLayoutInvalidated` observable signal that tracks events known to invalidate horizontal layout offsets. We listen for:

- `onDidChangeTokens`
- `onDidChangeOptions`
- `onDidChangeLanguage`
- `onDidChangeFont`

When on of the events above is triggered, we force reindentation of the content in the preview widget.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
