### PR TITLE
Update activity bar dimensions for consistency

### DIFF
--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -42,11 +42,11 @@ import { SwitchCompositeViewAction } from '../compositeBarActions.js';
 
 export class ActivitybarPart extends Part {
 
-	static readonly ACTION_HEIGHT = 48;
+	static readonly ACTION_HEIGHT = 44;
 	static readonly COMPACT_ACTION_HEIGHT = 32;
 
-	static readonly ACTIVITYBAR_WIDTH = 48;
-	static readonly COMPACT_ACTIVITYBAR_WIDTH = 36;
+	static readonly ACTIVITYBAR_WIDTH = 44;
+	static readonly COMPACT_ACTIVITYBAR_WIDTH = 32;
 
 	static readonly ICON_SIZE = 24;
 	static readonly COMPACT_ICON_SIZE = 16;

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -85,6 +85,14 @@ export class ActivitybarPart extends Part {
 		return this._isCompact ? ActivitybarPart.COMPACT_ACTIVITYBAR_WIDTH : ActivitybarPart.ACTIVITYBAR_WIDTH;
 	}
 
+	/** The action (item) height that drives visible item sizing and the composite bar overflow size. */
+	private get actionHeight(): number {
+		if (this._isCompact) {
+			return ActivitybarPart.COMPACT_ACTION_HEIGHT;
+		}
+		return this.layoutService.isFloatingPanelsEnabled() ? ActivitybarPart.FLOATING_ACTION_HEIGHT : ActivitybarPart.ACTION_HEIGHT;
+	}
+
 	/** Extra space reserved around the part when the floating panels experiment is enabled. */
 	private get floatingGutter(): number { return this.layoutService.isFloatingPanelsEnabled() ? ActivitybarPart.FLOATING_MARGIN : 0; }
 
@@ -125,12 +133,9 @@ export class ActivitybarPart extends Part {
 
 	private updateCompactStyle(): void {
 		if (this.element) {
-			const actionHeight = this._isCompact
-				? ActivitybarPart.COMPACT_ACTION_HEIGHT
-				: (this.layoutService.isFloatingPanelsEnabled() ? ActivitybarPart.FLOATING_ACTION_HEIGHT : ActivitybarPart.ACTION_HEIGHT);
 			this.element.classList.toggle('compact', this._isCompact);
 			this.element.style.setProperty('--activity-bar-width', `${this.baseWidth}px`);
-			this.element.style.setProperty('--activity-bar-action-height', `${actionHeight}px`);
+			this.element.style.setProperty('--activity-bar-action-height', `${this.actionHeight}px`);
 			this.element.style.setProperty('--activity-bar-icon-size', `${this._isCompact ? ActivitybarPart.COMPACT_ICON_SIZE : ActivitybarPart.ICON_SIZE}px`);
 		}
 	}
@@ -151,9 +156,7 @@ export class ActivitybarPart extends Part {
 	}
 
 	private createCompositeBar(): PaneCompositeBar {
-		const actionHeight = this._isCompact
-			? ActivitybarPart.COMPACT_ACTION_HEIGHT
-			: (this.layoutService.isFloatingPanelsEnabled() ? ActivitybarPart.FLOATING_ACTION_HEIGHT : ActivitybarPart.ACTION_HEIGHT);
+		const actionHeight = this.actionHeight;
 		const iconSize = this._isCompact ? ActivitybarPart.COMPACT_ICON_SIZE : ActivitybarPart.ICON_SIZE;
 
 		return this.instantiationService.createInstance(ActivityBarCompositeBar, this.location, {

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -117,6 +117,7 @@ export class ActivitybarPart extends Part {
 			// the fixed part width): signal the grid that the size constraint changed.
 			if (e.affectsConfiguration(LayoutSettings.MODERN_UI)) {
 				this.updateCompactStyle();
+				this.recreateCompositeBar();
 				this._onDidChange.fire(undefined);
 			}
 		}));

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -42,11 +42,16 @@ import { SwitchCompositeViewAction } from '../compositeBarActions.js';
 
 export class ActivitybarPart extends Part {
 
-	static readonly ACTION_HEIGHT = 44;
+	static readonly ACTION_HEIGHT = 48;
 	static readonly COMPACT_ACTION_HEIGHT = 32;
 
-	static readonly ACTIVITYBAR_WIDTH = 44;
-	static readonly COMPACT_ACTIVITYBAR_WIDTH = 32;
+	static readonly ACTIVITYBAR_WIDTH = 48;
+	static readonly COMPACT_ACTIVITYBAR_WIDTH = 36;
+
+	/** Narrower dimensions used when the floating panels (Modern UI) experiment is enabled. */
+	static readonly FLOATING_ACTION_HEIGHT = 44;
+	static readonly FLOATING_ACTIVITYBAR_WIDTH = 44;
+	static readonly FLOATING_COMPACT_ACTIVITYBAR_WIDTH = 32;
 
 	static readonly ICON_SIZE = 24;
 	static readonly COMPACT_ICON_SIZE = 16;
@@ -73,7 +78,12 @@ export class ActivitybarPart extends Part {
 	//#endregion
 
 	/** The intrinsic activity bar width (excludes any floating gutter). */
-	private get baseWidth(): number { return this._isCompact ? ActivitybarPart.COMPACT_ACTIVITYBAR_WIDTH : ActivitybarPart.ACTIVITYBAR_WIDTH; }
+	private get baseWidth(): number {
+		if (this.layoutService.isFloatingPanelsEnabled()) {
+			return this._isCompact ? ActivitybarPart.FLOATING_COMPACT_ACTIVITYBAR_WIDTH : ActivitybarPart.FLOATING_ACTIVITYBAR_WIDTH;
+		}
+		return this._isCompact ? ActivitybarPart.COMPACT_ACTIVITYBAR_WIDTH : ActivitybarPart.ACTIVITYBAR_WIDTH;
+	}
 
 	/** Extra space reserved around the part when the floating panels experiment is enabled. */
 	private get floatingGutter(): number { return this.layoutService.isFloatingPanelsEnabled() ? ActivitybarPart.FLOATING_MARGIN : 0; }
@@ -106,6 +116,7 @@ export class ActivitybarPart extends Part {
 			// Floating panels changes the reserved left/bottom gutter (and therefore
 			// the fixed part width): signal the grid that the size constraint changed.
 			if (e.affectsConfiguration(LayoutSettings.MODERN_UI)) {
+				this.updateCompactStyle();
 				this._onDidChange.fire(undefined);
 			}
 		}));
@@ -113,9 +124,12 @@ export class ActivitybarPart extends Part {
 
 	private updateCompactStyle(): void {
 		if (this.element) {
+			const actionHeight = this._isCompact
+				? ActivitybarPart.COMPACT_ACTION_HEIGHT
+				: (this.layoutService.isFloatingPanelsEnabled() ? ActivitybarPart.FLOATING_ACTION_HEIGHT : ActivitybarPart.ACTION_HEIGHT);
 			this.element.classList.toggle('compact', this._isCompact);
 			this.element.style.setProperty('--activity-bar-width', `${this.baseWidth}px`);
-			this.element.style.setProperty('--activity-bar-action-height', `${this._isCompact ? ActivitybarPart.COMPACT_ACTION_HEIGHT : ActivitybarPart.ACTION_HEIGHT}px`);
+			this.element.style.setProperty('--activity-bar-action-height', `${actionHeight}px`);
 			this.element.style.setProperty('--activity-bar-icon-size', `${this._isCompact ? ActivitybarPart.COMPACT_ICON_SIZE : ActivitybarPart.ICON_SIZE}px`);
 		}
 	}
@@ -136,7 +150,9 @@ export class ActivitybarPart extends Part {
 	}
 
 	private createCompositeBar(): PaneCompositeBar {
-		const actionHeight = this._isCompact ? ActivitybarPart.COMPACT_ACTION_HEIGHT : ActivitybarPart.ACTION_HEIGHT;
+		const actionHeight = this._isCompact
+			? ActivitybarPart.COMPACT_ACTION_HEIGHT
+			: (this.layoutService.isFloatingPanelsEnabled() ? ActivitybarPart.FLOATING_ACTION_HEIGHT : ActivitybarPart.ACTION_HEIGHT);
 		const iconSize = this._isCompact ? ActivitybarPart.COMPACT_ICON_SIZE : ActivitybarPart.ICON_SIZE;
 
 		return this.instantiationService.createInstance(ActivityBarCompositeBar, this.location, {

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -18,8 +18,8 @@
  * pushed behind the icon (which lives on the action-label at z-index 1) so the
  * icon stays legible on top of the fill. The size is derived from the activity
  * bar's own CSS variables so it works for both the normal (44px) and compact
- * (32px wide / 32px tall) layouts. The square side tracks the action height
- * (the limiting dimension), and `left` keeps it horizontally centered.
+ * (32px wide / 32px tall) layouts. Bar width equals action height in both sizes,
+ * so the box is a centered square and `left` keeps it horizontally centered.
  */
 .style-override .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator {
 	z-index: 0;
@@ -33,6 +33,7 @@
 
 /* Compact: minimal horizontal inset — 28×28px box centered in the 32px item. */
 .style-override .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator {
+	top: 2px;
 	left: 2px;
 	width: calc(var(--activity-bar-action-height, 32px) - 4px);
 	height: calc(var(--activity-bar-action-height, 32px) - 4px);

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -17,18 +17,25 @@
  * Turn the active item indicator into an inset, rounded background box. It is
  * pushed behind the icon (which lives on the action-label at z-index 1) so the
  * icon stays legible on top of the fill. The size is derived from the activity
- * bar's own CSS variables so it works for both the normal (48px) and compact
- * (36px wide / 32px tall) layouts. The square side tracks the action height
+ * bar's own CSS variables so it works for both the normal (44px) and compact
+ * (32px wide / 32px tall) layouts. The square side tracks the action height
  * (the limiting dimension), and `left` keeps it horizontally centered.
  */
 .style-override .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator {
 	z-index: 0;
 	top: 0;
-	left: calc((var(--activity-bar-width, 48px) - var(--activity-bar-action-height, 48px) + 8px) / 2);
-	width: calc(var(--activity-bar-action-height, 48px) - 8px);
-	height: calc(var(--activity-bar-action-height, 48px) - 8px);
+	left: calc((var(--activity-bar-width, 44px) - var(--activity-bar-action-height, 44px) + 4px) / 2);
+	width: calc(var(--activity-bar-action-height, 44px) - 4px);
+	height: calc(var(--activity-bar-action-height, 44px) - 4px);
 	border-radius: var(--vscode-cornerRadius-medium);
 	background-color: var(--vscode-activityBar-activeBackground, var(--vscode-list-inactiveSelectionBackground));
+}
+
+/* Compact: minimal horizontal inset — 28×28px box centered in the 32px item. */
+.style-override .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator {
+	left: 2px;
+	width: calc(var(--activity-bar-action-height, 32px) - 4px);
+	height: calc(var(--activity-bar-action-height, 32px) - 4px);
 }
 
 /*
@@ -79,11 +86,18 @@
 	top: 0;
 	bottom: 0;
 	margin: auto;
-	left: calc((var(--activity-bar-width, 48px) - var(--activity-bar-action-height, 48px) + 8px) / 2);
-	width: calc(var(--activity-bar-action-height, 48px) - 8px);
-	height: calc(var(--activity-bar-action-height, 48px) - 8px);
+	left: calc((var(--activity-bar-width, 44px) - var(--activity-bar-action-height, 44px) + 4px) / 2);
+	width: calc(var(--activity-bar-action-height, 44px) - 4px);
+	height: calc(var(--activity-bar-action-height, 44px) - 4px);
 	border-radius: var(--vscode-cornerRadius-medium);
 	background-color: var(--vscode-list-hoverBackground);
+}
+
+/* Compact: minimal horizontal inset — 28×28px box centered in the 32px item. */
+.style-override .activitybar.compact > .content:not(.dragged-over):not(.dragged-over-head):not(.dragged-over-tail) :not(.monaco-menu) > .monaco-action-bar .action-item:not(.checked):hover::before {
+	left: 2px;
+	width: calc(var(--activity-bar-action-height, 32px) - 4px);
+	height: calc(var(--activity-bar-action-height, 32px) - 4px);
 }
 
 /*

--- a/src/vs/workbench/test/browser/parts/activitybar/activitybarPart.test.ts
+++ b/src/vs/workbench/test/browser/parts/activitybar/activitybarPart.test.ts
@@ -294,6 +294,19 @@ suite('ActivitybarPart', () => {
 		assert.strictEqual(el.classList.contains('compact'), true);
 	});
 
+	test('updateCompactStyle sets correct CSS custom properties in floating mode', () => {
+		const { part } = createActivitybarPart(false, true);
+
+		const el = document.createElement('div');
+		fixture.appendChild(el);
+		part.create(el);
+
+		assert.strictEqual(el.style.getPropertyValue('--activity-bar-width'), `${ActivitybarPart.FLOATING_ACTIVITYBAR_WIDTH}px`);
+		assert.strictEqual(el.style.getPropertyValue('--activity-bar-action-height'), `${ActivitybarPart.FLOATING_ACTION_HEIGHT}px`);
+		assert.strictEqual(el.style.getPropertyValue('--activity-bar-icon-size'), `${ActivitybarPart.ICON_SIZE}px`);
+		assert.strictEqual(el.classList.contains('compact'), false);
+	});
+
 	test('toggling compact updates CSS custom properties on element', () => {
 		const { part, configService } = createActivitybarPart(false);
 

--- a/src/vs/workbench/test/browser/parts/activitybar/activitybarPart.test.ts
+++ b/src/vs/workbench/test/browser/parts/activitybar/activitybarPart.test.ts
@@ -110,7 +110,7 @@ suite('ActivitybarPart', () => {
 
 	// --- Static constants ---------------------------------------------------
 
-	test('default constants match original (pre-compact) dimensions', () => {
+	test('default constants match expected dimensions', () => {
 		assert.deepStrictEqual(
 			{
 				width: ActivitybarPart.ACTIVITYBAR_WIDTH,

--- a/src/vs/workbench/test/browser/parts/activitybar/activitybarPart.test.ts
+++ b/src/vs/workbench/test/browser/parts/activitybar/activitybarPart.test.ts
@@ -118,8 +118,8 @@ suite('ActivitybarPart', () => {
 				iconSize: ActivitybarPart.ICON_SIZE,
 			},
 			{
-				width: 44,
-				actionHeight: 44,
+				width: 48,
+				actionHeight: 48,
 				iconSize: 24,
 			}
 		);
@@ -133,9 +133,24 @@ suite('ActivitybarPart', () => {
 				iconSize: ActivitybarPart.COMPACT_ICON_SIZE,
 			},
 			{
-				width: 32,
+				width: 36,
 				actionHeight: 32,
 				iconSize: 16,
+			}
+		);
+	});
+
+	test('floating constants are narrower than default', () => {
+		assert.deepStrictEqual(
+			{
+				width: ActivitybarPart.FLOATING_ACTIVITYBAR_WIDTH,
+				actionHeight: ActivitybarPart.FLOATING_ACTION_HEIGHT,
+				compactWidth: ActivitybarPart.FLOATING_COMPACT_ACTIVITYBAR_WIDTH,
+			},
+			{
+				width: 44,
+				actionHeight: 44,
+				compactWidth: 32,
 			}
 		);
 	});
@@ -170,8 +185,8 @@ suite('ActivitybarPart', () => {
 		assert.deepStrictEqual(
 			{ min: part.minimumWidth, max: part.maximumWidth },
 			{
-				min: ActivitybarPart.ACTIVITYBAR_WIDTH + ActivitybarPart.FLOATING_MARGIN,
-				max: ActivitybarPart.ACTIVITYBAR_WIDTH + ActivitybarPart.FLOATING_MARGIN,
+				min: ActivitybarPart.FLOATING_ACTIVITYBAR_WIDTH + ActivitybarPart.FLOATING_MARGIN,
+				max: ActivitybarPart.FLOATING_ACTIVITYBAR_WIDTH + ActivitybarPart.FLOATING_MARGIN,
 			}
 		);
 	});
@@ -248,7 +263,7 @@ suite('ActivitybarPart', () => {
 		fireConfigChange(configService, LayoutSettings.MODERN_UI);
 
 		assert.deepStrictEqual(events, [undefined]);
-		assert.strictEqual(part.minimumWidth, ActivitybarPart.ACTIVITYBAR_WIDTH + ActivitybarPart.FLOATING_MARGIN);
+		assert.strictEqual(part.minimumWidth, ActivitybarPart.FLOATING_ACTIVITYBAR_WIDTH + ActivitybarPart.FLOATING_MARGIN);
 	});
 
 	// --- CSS custom properties on element -----------------------------------

--- a/src/vs/workbench/test/browser/parts/activitybar/activitybarPart.test.ts
+++ b/src/vs/workbench/test/browser/parts/activitybar/activitybarPart.test.ts
@@ -118,8 +118,8 @@ suite('ActivitybarPart', () => {
 				iconSize: ActivitybarPart.ICON_SIZE,
 			},
 			{
-				width: 48,
-				actionHeight: 48,
+				width: 44,
+				actionHeight: 44,
 				iconSize: 24,
 			}
 		);
@@ -133,7 +133,7 @@ suite('ActivitybarPart', () => {
 				iconSize: ActivitybarPart.COMPACT_ICON_SIZE,
 			},
 			{
-				width: 36,
+				width: 32,
 				actionHeight: 32,
 				iconSize: 16,
 			}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/324217

This pull request updates the Activity Bar to support narrower dimensions when the floating panels (Modern UI) experiment is enabled. It introduces new constants, adapts sizing logic in the TypeScript implementation, and updates CSS for correct visual appearance. It also adds and updates tests to verify the new behavior.

**Activity Bar dimension and logic updates:**

- Added new constants for floating panel dimensions (`FLOATING_ACTION_HEIGHT`, `FLOATING_ACTIVITYBAR_WIDTH`, `FLOATING_COMPACT_ACTIVITYBAR_WIDTH`) in `ActivitybarPart` to support the Modern UI experiment.
- Updated the `baseWidth` getter and related sizing logic in `ActivitybarPart` to use the new floating constants when floating panels are enabled, ensuring the Activity Bar is narrower in this mode. [[1]](diffhunk://#diff-7aaf3f75660a11bc7c949d968b2c9c0178d9aed7eebeae75c4255e2e1a597b9bL76-R86) [[2]](diffhunk://#diff-7aaf3f75660a11bc7c949d968b2c9c0178d9aed7eebeae75c4255e2e1a597b9bR119-R132) [[3]](diffhunk://#diff-7aaf3f75660a11bc7c949d968b2c9c0178d9aed7eebeae75c4255e2e1a597b9bL139-R155)

**CSS adjustments for new dimensions:**

- Modified `activityBar.css` to use the new default widths and action heights for both normal and compact layouts, and added styles for compact mode to ensure the active item indicator and hover effects are correctly sized and positioned. [[1]](diffhunk://#diff-c718522311de21a7658a924bbd223350855e39acf9ddd9e1c4eaffa8f76a34dbL20-R41) [[2]](diffhunk://#diff-c718522311de21a7658a924bbd223350855e39acf9ddd9e1c4eaffa8f76a34dbL82-R103)

**Test updates:**

- Added and updated tests in `activitybarPart.test.ts` to verify that the new floating constants are used and that the Activity Bar's dimensions are correct when Modern UI is enabled. [[1]](diffhunk://#diff-135e107eef9b2267a39b501c87c9943b9d9b2ed0ae622898be10759d14a1c8cfL113-R113) [[2]](diffhunk://#diff-135e107eef9b2267a39b501c87c9943b9d9b2ed0ae622898be10759d14a1c8cfR143-R157) [[3]](diffhunk://#diff-135e107eef9b2267a39b501c87c9943b9d9b2ed0ae622898be10759d14a1c8cfL173-R189) [[4]](diffhunk://#diff-135e107eef9b2267a39b501c87c9943b9d9b2ed0ae622898be10759d14a1c8cfL251-R266)