### PR TITLE
Style overrides: Add border-radius and box-shadow for terminal resize overlay

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
@@ -240,3 +240,7 @@
 .style-override.monaco-workbench .pane-body.integrated-terminal .tabs-container.has-text .terminal-tabs-chat-entry .terminal-tabs-entry {
 	border-radius: var(--vscode-cornerRadius-small);
 }
+
+.style-override.monaco-workbench .terminal-resize-overlay {
+	border-radius: var(--vscode-cornerRadius-large);
+}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/shadows.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/shadows.css
@@ -42,3 +42,7 @@
 .style-override.monaco-workbench .part.editor .tabs-container > .tab.active {
 	box-shadow: none !important;
 }
+
+.style-override.monaco-workbench .terminal-resize-overlay {
+	box-shadow: var(--vscode-shadow-lg);
+}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/shadows.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/shadows.css
@@ -43,6 +43,6 @@
 	box-shadow: none !important;
 }
 
-.style-override.monaco-workbench .terminal-resize-overlay {
+.style-override.monaco-workbench:not(.hc-black):not(.hc-light) .terminal-resize-overlay {
 	box-shadow: var(--vscode-shadow-lg);
 }


### PR DESCRIPTION
Enhance the terminal resize overlay by adding a border-radius and box-shadow for improved aesthetics. Test the changes by observing the terminal resize overlay in the workbench.

