### PR TITLE
Style overrides: Remove unused scroll shadow styles for lists and trees

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/scrollShadows.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/scrollShadows.css
@@ -45,27 +45,6 @@
 	--scroll-shadow-surface: var(--vscode-sideBar-background, var(--vscode-editor-background));
 }
 
-/* =============================================================================
- * Lists and trees.
- * ========================================================================== */
-.style-override .monaco-list {
-	position: relative;
-}
-
-.style-override .monaco-list > .monaco-scrollable-element::after {
-	content: "";
-	position: absolute;
-	left: 0;
-	right: 0;
-	height: 12px;
-	pointer-events: none;
-	z-index: 10;
-}
-
-.style-override .monaco-list > .monaco-scrollable-element::after {
-	bottom: 0;
-	background: linear-gradient(to top, var(--scroll-shadow-surface), transparent);
-}
 
 /* =============================================================================
  * Editor area. The main editor viewport scrolls inside `.editor-scrollable`;


### PR DESCRIPTION
Eliminate unnecessary scroll shadow styles for lists and trees to streamline the CSS. This change enhances code maintainability by removing unused styles. Testing involves verifying that the appearance of lists and trees remains consistent without the removed styles.

