### PR TITLE
Fix subagent display in chat transcript by synthesizing chatResource

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -11,7 +11,7 @@ import { Schemas } from '../../../../../../base/common/network.js';
 import { posix, win32 } from '../../../../../../base/common/path.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
-import { MessageKind, ToolCallContributorKind, ToolCallStatus, TurnState, ResponsePartKind, getToolFileEdits, getToolOutputText, getToolSubagentContent, readUsageInfoMeta, type ActiveTurn, type ICompletedToolCall, type Message, type ToolCallState, type Turn, FileEditKind, ToolResultContentType, type ToolResultContent, type UsageInfo, type UsageInfoMeta } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { buildSubagentChatUri, MessageKind, ToolCallContributorKind, ToolCallStatus, TurnState, ResponsePartKind, getToolFileEdits, getToolOutputText, getToolSubagentContent, readUsageInfoMeta, type ActiveTurn, type ICompletedToolCall, type Message, type ToolCallState, type ToolResultSubagentContent, type Turn, FileEditKind, ToolResultContentType, type ToolResultContent, type UsageInfo, type UsageInfoMeta } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { getToolKind } from '../../../../../../platform/agentHost/common/state/sessionReducers.js';
 import { readToolCallMeta } from '../../../../../../platform/agentHost/common/meta/agentToolCallMeta.js';
 import { getChatErrorDetailsFromMeta, IChatErrorContext } from '../../../common/chatErrorMessages.js';
@@ -73,6 +73,21 @@ function getSubagentTaskDescription(tc: ToolCallState): string | undefined {
 function getSubagentAgentName(tc: ToolCallState): string | undefined {
 	const v = readToolCallMeta(tc).subagentAgentName;
 	return v && v.length > 0 ? v : undefined;
+}
+
+/**
+ * The subagent chat resource for a subagent-spawning tool call: the discovery
+ * content block's resource when present, else the deterministic child chat URI
+ * derived from the session + tool call id (matching the host's
+ * {@link buildSubagentChatUri}, and how {@link _observeSubagentSession}
+ * subscribes). Deriving it from the tool call id alone keeps the inline subagent
+ * pill linkable even when the discovery content block never reaches this chat —
+ * e.g. a background subagent whose `subagent_started` arrives after its spawning
+ * tool call has already completed, so the running-only content update is dropped
+ * by the reducer.
+ */
+function getSubagentChatResource(tc: ToolCallState, subagentContent: ToolResultSubagentContent | undefined, sessionResource: URI): string {
+	return subagentContent?.resource ?? buildSubagentChatUri(sessionResource.toString(), tc.toolCallId);
 }
 
 /**
@@ -971,7 +986,7 @@ export function completedToolCallToSerialized(tc: ICompletedToolCall, subAgentIn
 				description: getSubagentTaskDescription(tc) ?? tc.displayName,
 				agentName: subagentContent?.agentName ?? getSubagentAgentName(tc),
 				result: resultText,
-				chatResource: subagentContent?.resource,
+				chatResource: getSubagentChatResource(tc, subagentContent, sessionResource),
 			},
 		};
 	}
@@ -1558,7 +1573,7 @@ export function toolCallStateToInvocation(tc: ToolCallState, subAgentInvocationI
 			kind: 'subagent',
 			description: getSubagentTaskDescription(tc),
 			agentName: subagentContent?.agentName ?? getSubagentAgentName(tc),
-			chatResource: subagentContent?.resource,
+			chatResource: getSubagentChatResource(tc, subagentContent, sessionResource),
 		};
 	} else if (getToolKind(tc) === 'search') {
 		invocation.toolSpecificData = { kind: 'search' };
@@ -1689,7 +1704,7 @@ export function finalizeToolInvocation(invocation: ChatToolInvocation, tc: ToolC
 				result: resultText,
 				credits: invocation.toolSpecificData?.kind === 'subagent' ? invocation.toolSpecificData.credits : undefined,
 				modelName: invocation.toolSpecificData?.kind === 'subagent' ? invocation.toolSpecificData.modelName : undefined,
-				chatResource: subagentContent.resource,
+				chatResource: getSubagentChatResource(tc, subagentContent, backendSession),
 			};
 		} else if (invocation.toolSpecificData?.kind === 'subagent') {
 			// Subagent-spawning tool that completed without a Subagent content
@@ -1702,7 +1717,7 @@ export function finalizeToolInvocation(invocation: ChatToolInvocation, tc: ToolC
 				result: getToolOutputText(tc),
 				credits: invocation.toolSpecificData.credits,
 				modelName: invocation.toolSpecificData.modelName,
-				chatResource: invocation.toolSpecificData.chatResource,
+				chatResource: invocation.toolSpecificData.chatResource ?? getSubagentChatResource(tc, undefined, backendSession),
 			};
 		}
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -9,7 +9,7 @@ import { URI } from '../../../../../../base/common/uri.js';
 import type { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { fromAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
-import { MessageKind, ToolCallStatus, ToolCallConfirmationReason, ToolResultContentType, TurnState, ResponsePartKind, type ActiveTurn, type ICompletedToolCall, type ToolCallRunningState, type Turn, type ToolCallResponsePart, ToolCallCancellationReason, type Message } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { buildSubagentChatUri, MessageKind, ToolCallStatus, ToolCallConfirmationReason, ToolResultContentType, TurnState, ResponsePartKind, type ActiveTurn, type ICompletedToolCall, type ToolCallRunningState, type Turn, type ToolCallResponsePart, ToolCallCancellationReason, type Message } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IChatToolInvocation, IChatToolInvocationSerialized, type IChatMarkdownContent, type IChatThinkingPart, type IChatUsage } from '../../../common/chatService/chatService.js';
 import { isToolResultInputOutputDetails, type IToolResultInputOutputDetails, ToolDataSource, ToolInvocationPresentation } from '../../../common/tools/languageModelToolsService.js';
 import { turnsToHistory as rawTurnsToHistory, activeTurnToProgress as rawActiveTurnToProgress, toolCallStateToInvocation as rawToolCallStateToInvocation, finalizeToolInvocation as rawFinalizeToolInvocation, updateRunningToolSpecificData as rawUpdateRunningToolSpecificData, usageInfoToQuotas, formatTurnResponseDetails, rewriteAgentHostLinkTarget, rewriteMarkdownLinks } from '../../../browser/agentSessions/agentHost/stateToProgressAdapter.js';
@@ -829,6 +829,24 @@ suite('stateToProgressAdapter', () => {
 			if (invocation.toolSpecificData.kind === 'subagent') {
 				assert.strictEqual(invocation.toolSpecificData.description, 'Review code');
 				assert.strictEqual(invocation.toolSpecificData.agentName, 'code-reviewer');
+			}
+		});
+
+		test('synthesizes subagent chatResource from the tool call id when no discovery content block is present', () => {
+			// A background subagent's `subagent_started` can arrive after its
+			// spawning tool call has already completed, so the running-only
+			// discovery content update is dropped and the child chat resource
+			// never lands on the tool call. The chat resource must still be
+			// derivable from the session + tool call id so the inline subagent
+			// pill remains linkable.
+			const tc = createToolCallState({
+				_meta: { toolKind: 'subagent', subagentDescription: 'Map aux bar + editor part creation' },
+			});
+
+			const invocation = toolCallStateToInvocation(tc);
+			assert.strictEqual(invocation.toolSpecificData?.kind, 'subagent');
+			if (invocation.toolSpecificData?.kind === 'subagent') {
+				assert.strictEqual(invocation.toolSpecificData.chatResource, buildSubagentChatUri(URI.file('/').toString(), 'tc-1'));
 			}
 		});
 


### PR DESCRIPTION
This pull request addresses the issue where the "Map aux bar + editor part creation" subagent is visible in the Conversations dropdown but not as an inline widget in the chat transcript. The root cause was identified as a missing `ToolResultContentType.Subagent` discovery content block, which is necessary for the inline widget to function correctly.

### Changes made:
- Introduced a new helper function `getSubagentChatResource()` in `stateToProgressAdapter.ts` to synthesize the `chatResource` when the discovery block is absent.
- Updated three call sites to utilize this new helper, ensuring that the inline widget can link to its corresponding tab both during live sessions and after reloads.
- Added a unit test to verify the correct synthesis of `chatResource` when no discovery block is present.

### Validation:
- The changes have been type-checked and pass without errors.
- The layers checker confirms no violations, and the new test compiles successfully.