### PR TITLE
Improve file list handling and UI elements

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -926,7 +926,7 @@ export class ChangesViewPane extends ViewPane {
 			return EMPTY_FILE_CHANGES_MIN_HEIGHT;
 		}
 
-		// Grow the minimum size to fit the file list (capped at 15 rows) plus header chrome.
+		// Grow the minimum size to fit the file list (capped at TREE_PANE_MIN_SIZE_MAX_ROWS rows) plus header chrome.
 		const filesHeaderHeight = this.filesHeaderNode?.offsetHeight ?? 0;
 		const treeContentHeight = this.tree?.contentHeight ?? 0;
 		const maxRowsHeight = TREE_PANE_MIN_SIZE_MAX_ROWS * ChangesTreeDelegate.ROW_HEIGHT;

--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -90,6 +90,12 @@ const $ = dom.$;
 const RUN_SESSION_CODE_REVIEW_ACTION_ID = 'sessions.codeReview.run';
 const EMPTY_FILE_CHANGES_MIN_HEIGHT = 140;
 
+/** Maximum number of file rows the tree pane's minimum size grows to accommodate. */
+const TREE_PANE_MIN_SIZE_MAX_ROWS = 13;
+
+/** Breathing room rendered beneath the last file row when the whole list fits. */
+const TREE_PANE_LIST_BOTTOM_PADDING = 12;
+
 // --- ButtonBar widget
 
 class ChangesMenuWorkbenchButtonBarWidget extends Disposable {
@@ -919,7 +925,15 @@ export class ChangesViewPane extends ViewPane {
 		if (this.listContainer?.style.display === 'none') {
 			return EMPTY_FILE_CHANGES_MIN_HEIGHT;
 		}
-		return 3 * ChangesTreeDelegate.ROW_HEIGHT;
+
+		// Grow the minimum size to fit the file list (capped at 15 rows) plus header chrome.
+		const filesHeaderHeight = this.filesHeaderNode?.offsetHeight ?? 0;
+		const treeContentHeight = this.tree?.contentHeight ?? 0;
+		const maxRowsHeight = TREE_PANE_MIN_SIZE_MAX_ROWS * ChangesTreeDelegate.ROW_HEIGHT;
+		const cappedContentHeight = Math.min(treeContentHeight, maxRowsHeight);
+		const bottomPadding = treeContentHeight <= maxRowsHeight ? TREE_PANE_LIST_BOTTOM_PADDING : 0;
+
+		return Math.max(EMPTY_FILE_CHANGES_MIN_HEIGHT, filesHeaderHeight + cappedContentHeight + bottomPadding);
 	}
 
 	private getTreePaneMaximumSize(): number {
@@ -929,7 +943,8 @@ export class ChangesViewPane extends ViewPane {
 
 		const filesHeaderHeight = this.filesHeaderNode?.offsetHeight ?? 0;
 		const treeContentHeight = this.listContainer?.style.display === 'none' ? 0 : this.tree?.contentHeight ?? 0;
-		return Math.max(this.getTreePaneMinimumSize(), filesHeaderHeight + treeContentHeight);
+		const bottomPadding = treeContentHeight > 0 ? TREE_PANE_LIST_BOTTOM_PADDING : 0;
+		return Math.max(this.getTreePaneMinimumSize(), filesHeaderHeight + treeContentHeight + bottomPadding);
 	}
 
 	private fireTreePaneSizeChange(): void {

--- a/src/vs/sessions/contrib/changes/browser/media/sessionFilesWidget.css
+++ b/src/vs/sessions/contrib/changes/browser/media/sessionFilesWidget.css
@@ -99,6 +99,19 @@
 	white-space: nowrap;
 }
 
+/* File count — shown in the header only while collapsed */
+.session-files-widget-count {
+	flex-shrink: 0;
+	color: var(--vscode-descriptionForeground);
+	font-size: var(--vscode-agents-fontSize-label2, 11px);
+	font-weight: var(--vscode-agents-fontWeight-regular);
+	line-height: 1;
+}
+
+.session-files-widget-count.hidden {
+	display: none;
+}
+
 /* Body - file list */
 .session-files-widget-body {
 	flex: 1;
@@ -143,31 +156,6 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-}
-
-/* Decoration badge (A/M/D) */
-.session-files-widget-decoration-badge {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: 16px;
-	min-width: 16px;
-	font-size: var(--vscode-agents-fontSize-body2);
-	font-weight: var(--vscode-agents-fontWeight-semiBold);
-	margin-right: 2px;
-	opacity: 0.9;
-}
-
-.session-files-widget-decoration-badge.added {
-	color: var(--vscode-gitDecoration-addedResourceForeground);
-}
-
-.session-files-widget-decoration-badge.modified {
-	color: var(--vscode-gitDecoration-modifiedResourceForeground);
-}
-
-.session-files-widget-decoration-badge.deleted {
-	color: var(--vscode-gitDecoration-deletedResourceForeground);
 }
 
 /* Inline action bar (Open File), shown on hover/focus/select — mirrors the changes view */

--- a/src/vs/sessions/contrib/changes/browser/sessionFilesWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionFilesWidget.ts
@@ -50,7 +50,6 @@ class SessionFileListDelegate implements IListVirtualDelegate<ISessionFile> {
 
 interface ISessionFileTemplateData {
 	readonly label: IResourceLabel;
-	readonly decorationBadge: HTMLElement;
 	readonly toolbar: WorkbenchToolBar;
 	readonly templateDisposables: DisposableStore;
 }
@@ -75,10 +74,7 @@ class SessionFileListRenderer implements IListRenderer<ISessionFile, ISessionFil
 		const toolbar = templateDisposables.add(this._instantiationService.createInstance(WorkbenchToolBar, actionBarContainer, undefined));
 		label.element.appendChild(actionBarContainer);
 
-		const decorationBadge = dom.$('.session-files-widget-decoration-badge');
-		label.element.appendChild(decorationBadge);
-
-		return { label, decorationBadge, toolbar, templateDisposables };
+		return { label, toolbar, templateDisposables };
 	}
 
 	renderElement(element: ISessionFile, _index: number, templateData: ISessionFileTemplateData): void {
@@ -91,24 +87,6 @@ class SessionFileListRenderer implements IListRenderer<ISessionFile, ISessionFil
 			strikethrough: element.operation === SessionFileOperation.Deleted,
 			title: getSessionFileTitle(element, this._labelService),
 		});
-
-		const badge = templateData.decorationBadge;
-		badge.className = 'session-files-widget-decoration-badge';
-		switch (element.operation) {
-			case SessionFileOperation.Created:
-				badge.textContent = 'A';
-				badge.classList.add('added');
-				break;
-			case SessionFileOperation.Deleted:
-				badge.textContent = 'D';
-				badge.classList.add('deleted');
-				break;
-			case SessionFileOperation.Modified:
-			default:
-				badge.textContent = 'M';
-				badge.classList.add('modified');
-				break;
-		}
 
 		templateData.toolbar.setActions([toAction({
 			id: 'sessionFiles.openFile',
@@ -141,6 +119,7 @@ export class SessionFilesWidget extends Disposable {
 	private readonly _headerNode: HTMLElement;
 	private readonly _titleNode: HTMLElement;
 	private readonly _titleLabelNode: HTMLElement;
+	private readonly _countNode: HTMLElement;
 	private readonly _chevronNode: HTMLElement;
 	private readonly _bodyNode: HTMLElement;
 	private readonly _list: WorkbenchList<ISessionFile>;
@@ -204,6 +183,9 @@ export class SessionFilesWidget extends Disposable {
 		this._titleNode = dom.append(this._headerNode, $('.session-files-widget-title'));
 		this._titleLabelNode = dom.append(this._titleNode, $('.session-files-widget-title-label'));
 		this._titleLabelNode.textContent = localize('sessionFiles.label', "Other Files");
+		// File count shown in the header only while collapsed (mirrors the
+		// customizations section in the sessions view).
+		this._countNode = dom.append(this._headerNode, $('.session-files-widget-count.hidden'));
 		this._chevronNode = dom.append(this._headerNode, $('.group-chevron'));
 		this._chevronNode.classList.add(...ThemeIcon.asClassNameArray(Codicon.chevronDown));
 
@@ -213,7 +195,7 @@ export class SessionFilesWidget extends Disposable {
 		this._headerNode.tabIndex = 0;
 
 		this._register(this._hoverService.setupManagedHover(
-			getDefaultHoverDelegate('element'),
+			getDefaultHoverDelegate('mouse'),
 			this._headerNode,
 			localize('sessionFiles.hover', "Files created, edited, or deleted outside the workspace during this session. These files are not part of the workspace and won't be committed."),
 		));
@@ -287,6 +269,7 @@ export class SessionFilesWidget extends Disposable {
 
 			this._domNode.style.display = '';
 			this._renderBody(files);
+			this._renderCount();
 
 			if (this._fileCount !== oldCount) {
 				this._onDidChangeHeight.fire();
@@ -346,6 +329,13 @@ export class SessionFilesWidget extends Disposable {
 		this._updateChevron();
 		this._headerNode.classList.toggle('collapsed', collapsed);
 		this._headerNode.setAttribute('aria-expanded', String(!collapsed));
+		this._renderCount();
+	}
+
+	/** Show the file count in the header only while collapsed. */
+	private _renderCount(): void {
+		this._countNode.textContent = this._fileCount > 0 ? `${this._fileCount}` : '';
+		this._countNode.classList.toggle('hidden', !this._collapsed || this._fileCount === 0);
 	}
 
 	private _updateChevron(): void {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionFiles.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionFiles.ts
@@ -48,8 +48,8 @@ export interface IParsedFileEdit {
  * response parts are scanned for tool calls, and each tool call's file-edit
  * results (and pending edits) are collected. The resulting edits are reduced
  * per file so that a file first created and then edited is reported as
- * {@link SessionFileOperation.Created}, while a deleted file is reported as
- * {@link SessionFileOperation.Deleted}.
+ * {@link SessionFileOperation.Created}, while a deleted file is removed from
+ * the list entirely.
  *
  * Computation only happens for the active, non-archived session: archived
  * sessions never open a live chat-state subscription, so no parsing work is
@@ -276,8 +276,9 @@ interface IMutableSessionFile {
  * Rules:
  * - A file created during the session stays {@link SessionFileOperation.Created}
  *   even if edited afterwards.
- * - A deleted file becomes {@link SessionFileOperation.Deleted} (overriding any
- *   earlier create/edit).
+ * - A deleted file is removed from the list entirely: a file created or edited
+ *   during the session and then deleted nets out, and a pre-existing file that
+ *   is deleted is not surfaced.
  * - Renames are modeled as a delete of the source plus a create of the target.
  * - Only files outside every workspace folder root are kept.
  */
@@ -310,12 +311,11 @@ export function reduceSessionFiles(edits: readonly IParsedFileEdit[], folderRoot
 		byUri.set(getComparisonKey(uri), { uri, file: { operation: SessionFileOperation.Modified, originalUri } });
 	};
 
-	const setDeleted = (uri: URI, originalUri: URI | undefined): void => {
-		if (!isOutsideWorkspace(uri)) {
-			return;
-		}
-		const existing = byUri.get(getComparisonKey(uri));
-		byUri.set(getComparisonKey(uri), { uri, file: { operation: SessionFileOperation.Deleted, originalUri: existing?.file.originalUri ?? originalUri } });
+	// A delete removes the file from the list entirely rather than surfacing it
+	// as a deleted entry: a create/edit followed by a delete nets out, and a
+	// pre-existing deleted file simply never appears.
+	const removeFile = (uri: URI): void => {
+		byUri.delete(getComparisonKey(uri));
 	};
 
 	for (const edit of edits) {
@@ -332,12 +332,12 @@ export function reduceSessionFiles(edits: readonly IParsedFileEdit[], folderRoot
 				break;
 			case FileEditKind.Delete:
 				if (edit.beforeUri) {
-					setDeleted(edit.beforeUri, edit.beforeContentUri);
+					removeFile(edit.beforeUri);
 				}
 				break;
 			case FileEditKind.Rename:
 				if (edit.beforeUri) {
-					setDeleted(edit.beforeUri, edit.beforeContentUri);
+					removeFile(edit.beforeUri);
 				}
 				if (edit.afterUri) {
 					setCreated(edit.afterUri);

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostSessionFiles.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostSessionFiles.test.ts
@@ -188,7 +188,7 @@ suite('agentHostSessionFiles', () => {
 			parsedEdit(FileEditKind.Edit, { after: '/home/user/.config/app.json', beforeContent: '/home/user/.config/app.json.before' }),
 			// edited outside workspace → Modified (keeps original for diff)
 			parsedEdit(FileEditKind.Edit, { after: '/home/user/.bashrc', beforeContent: '/home/user/.bashrc.before' }),
-			// deleted outside workspace → Deleted
+			// deleted outside workspace → removed from the list entirely
 			parsedEdit(FileEditKind.Delete, { before: '/tmp/scratch.log', beforeContent: '/tmp/scratch.log.before' }),
 			// inside workspace → excluded
 			parsedEdit(FileEditKind.Create, { after: '/repo/src/index.ts' }),
@@ -201,12 +201,11 @@ suite('agentHostSessionFiles', () => {
 			[
 				{ uri: '/home/user/.bashrc', operation: SessionFileOperation.Modified, original: '/home/user/.bashrc.before' },
 				{ uri: '/home/user/.config/app.json', operation: SessionFileOperation.Created, original: undefined },
-				{ uri: '/tmp/scratch.log', operation: SessionFileOperation.Deleted, original: '/tmp/scratch.log.before' },
 			],
 		);
 	});
 
-	test('reduceSessionFiles models a rename as a delete of the source and a create of the target', () => {
+	test('reduceSessionFiles reports a rename as a create of the target and drops the source', () => {
 		const edits: IParsedFileEdit[] = [
 			parsedEdit(FileEditKind.Rename, { before: '/home/user/old.txt', after: '/home/user/new.txt', beforeContent: '/home/user/old.txt.before' }),
 		];
@@ -217,8 +216,18 @@ suite('agentHostSessionFiles', () => {
 			files.map(f => ({ uri: f.uri.path, operation: f.operation })),
 			[
 				{ uri: '/home/user/new.txt', operation: SessionFileOperation.Created },
-				{ uri: '/home/user/old.txt', operation: SessionFileOperation.Deleted },
 			],
 		);
+	});
+
+	test('reduceSessionFiles drops a file that is created and then deleted', () => {
+		const edits: IParsedFileEdit[] = [
+			parsedEdit(FileEditKind.Create, { after: '/home/user/scratch.tmp' }),
+			parsedEdit(FileEditKind.Delete, { before: '/home/user/scratch.tmp' }),
+		];
+
+		const files = reduceSessionFiles(edits, [URI.file('/repo')]);
+
+		assert.deepStrictEqual(files, []);
 	});
 });


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a maximum size for the tree pane, add a file count display in the header, and remove the decoration badge from the session files widget. Adjust the logic for handling deleted files to remove them entirely from the list rather than marking them as deleted.

