### PR TITLE
Use startColumn in growUntilVariableBoundaries

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/longDistancePreviewEditor.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/longDistancePreviewEditor.ts
@@ -403,5 +403,5 @@ function growUntilVariableBoundaries(textModel: ITextModel, range: Range, maxGro
 		endColumn++;
 	}
 
-	return new Range(startPosition.lineNumber, startPosition.column, endPosition.lineNumber, endColumn + 1);
+	return new Range(startPosition.lineNumber, startColumn, endPosition.lineNumber, endColumn + 1);
 }


### PR DESCRIPTION
Seems that it should be used the same way as `endColumn` but due to the typo it is not used at all

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
