### PR TITLE
Style override: Add style override class for Modern UI Update experiment

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -1912,11 +1912,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			this.state.runtime.mainWindowFullscreen ? LayoutClasses.FULLSCREEN : undefined,
 			this.isShadowsDisabled() ? LayoutClasses.NO_SHADOWS : undefined,
 			this.isFloatingPanelsEnabled() ? LayoutClasses.FLOATING_PANELS : undefined,
-			// Apply the Modern UI presentation class before the first layout so parts
-			// that read it back during layout (part title height, editor tab height)
-			// are sized correctly from the start. `StyleOverridesContribution` still
-			// owns runtime toggling and auxiliary windows; this only seeds the main
-			// container at render time. Gated on the same setting as the class itself.
+			// Also seed the style-override class here (see `LayoutClasses.STYLE_OVERRIDE`).
 			this.isFloatingPanelsEnabled() ? LayoutClasses.STYLE_OVERRIDE : undefined,
 			`panel-position-${positionToString(this.getPanelPosition())}`,
 			`panel-alignment-${this.getPanelAlignment()}`

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -102,7 +102,16 @@ enum LayoutClasses {
 	MAXIMIZED = 'maximized',
 	WINDOW_BORDER = 'border',
 	NO_SHADOWS = 'no-shadows',
-	FLOATING_PANELS = 'floating-panels'
+	FLOATING_PANELS = 'floating-panels',
+	// Presentation class for the Modern UI Update experiment, owned/toggled at
+	// runtime by `StyleOverridesContribution`. It is *also* applied here at render
+	// time (see `getLayoutClasses`) because parts read it back during layout (e.g.
+	// the 32px vs 35px part title height in `PartLayout`, and the editor tab
+	// height) via `.closest('.style-override')`. The contribution runs in the
+	// `Restored` phase — after the first layout — so without this early
+	// application the first layout would size parts against the default (35px)
+	// title and leave them mismatched until the next relayout.
+	STYLE_OVERRIDE = 'style-override'
 }
 
 interface IPathToOpen extends IPath {
@@ -1903,6 +1912,12 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			this.state.runtime.mainWindowFullscreen ? LayoutClasses.FULLSCREEN : undefined,
 			this.isShadowsDisabled() ? LayoutClasses.NO_SHADOWS : undefined,
 			this.isFloatingPanelsEnabled() ? LayoutClasses.FLOATING_PANELS : undefined,
+			// Apply the Modern UI presentation class before the first layout so parts
+			// that read it back during layout (part title height, editor tab height)
+			// are sized correctly from the start. `StyleOverridesContribution` still
+			// owns runtime toggling and auxiliary windows; this only seeds the main
+			// container at render time. Gated on the same setting as the class itself.
+			this.isFloatingPanelsEnabled() ? LayoutClasses.STYLE_OVERRIDE : undefined,
 			`panel-position-${positionToString(this.getPanelPosition())}`,
 			`panel-alignment-${this.getPanelAlignment()}`
 		]);


### PR DESCRIPTION
This pull request updates the layout logic to ensure the Modern UI presentation class (`style-override`) is applied early during the initial render. This change ensures that UI parts relying on this class (such as part title and editor tab heights) are sized correctly from the start, preventing visual mismatches before the first relayout. The runtime toggling of this class remains managed by `StyleOverridesContribution`.

**Modern UI presentation class improvements:**

* Added `STYLE_OVERRIDE` to the `LayoutClasses` enum with detailed documentation explaining its dual application and the motivation for early application during render.
* Updated the main layout logic to apply the `STYLE_OVERRIDE` class at render time when floating panels are enabled, ensuring correct sizing from the first layout.