### PR TITLE
Rename `copilotCLI` group to `Copilot` in chat model picker

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -108,6 +108,8 @@ const CACHE_BREAK_HINT_DISMISSED_STORAGE_KEY = 'chat.cacheBreakHintDismissed';
  */
 function getVendorDisplayName(languageModelsService: ILanguageModelsService, vendor: string): string {
 	if (vendor === 'copilotcli') {
+		// @vritant24: This is temporary until we we have 2 distinct vendors for Copilot CLI vs Copilot Chat.
+		// For now, we want to show "Copilot" in the model picker for both.
 		return localize('chat.modelPicker.copilotGroup', "Copilot");
 	}
 	const descriptor = languageModelsService.getVendors().find(v => v.vendor === vendor);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -103,10 +103,13 @@ const CACHE_BREAK_HINT_DISMISSED_STORAGE_KEY = 'chat.cacheBreakHintDismissed';
 
 /**
  * Returns a human-readable display name for a model vendor.
- * Looks up the registered provider descriptor's displayName first,
- * then falls back to capitalizing the raw vendor id.
+ * Uses known product names before falling back to the registered provider
+ * descriptor or a capitalized vendor id.
  */
 function getVendorDisplayName(languageModelsService: ILanguageModelsService, vendor: string): string {
+	if (vendor === 'copilotcli') {
+		return localize('chat.modelPicker.copilotGroup', "Copilot");
+	}
 	const descriptor = languageModelsService.getVendors().find(v => v.vendor === vendor);
 	if (descriptor?.displayName) {
 		return descriptor.displayName;

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
@@ -1292,7 +1292,6 @@ suite('buildModelPickerItems', () => {
 	});
 });
 
-
 /**
  * Regression coverage for the chat model picker.
  *

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
@@ -783,7 +783,7 @@ suite('buildModelPickerItems', () => {
 		assert.strictEqual(promoted.badge, 'OpenAI Compatible');
 	});
 
-	test('Other Models splits agent-host models into sections by their modelGroup', () => {
+	test('Other Models splits agent-host models into sections by their modelGroup and labels copilotcli as Copilot', () => {
 		// Agent-host models all share one vendor but declare their upstream provider's
 		// vendor id via `modelGroup`; the picker resolves each group's display name from
 		// the vendor registry and renders one section per provider instead of collapsing
@@ -801,7 +801,7 @@ suite('buildModelPickerItems', () => {
 		const items = callBuild([auto, cli, openai, hf], { languageModelsService: service });
 		const labelledSeparators = items.filter(i => i.kind === ActionListItemKind.Separator && i.label);
 		// Buckets sorted alphabetically by resolved group display name.
-		assert.deepStrictEqual(labelledSeparators.map(s => s.label), ['Copilot CLI', 'Hugging Face', 'OpenAI']);
+		assert.deepStrictEqual(labelledSeparators.map(s => s.label), ['Copilot', 'Hugging Face', 'OpenAI']);
 	});
 
 	test('Other Models keeps a single section when agent-host models share one modelGroup', () => {
@@ -1292,6 +1292,7 @@ suite('buildModelPickerItems', () => {
 	});
 });
 
+
 /**
  * Regression coverage for the chat model picker.
  *
@@ -1538,4 +1539,3 @@ suite('chat model picker - languageModelChatProvider visibility regression', () 
 		);
 	});
 });
-


### PR DESCRIPTION
This pull request updates the chat model picker to rename the `copilotCLI` group to `Copilot`. The changes include:

- Renamed the `copilotcli` picker group to the localized **Copilot** in `chatModelPicker.ts`.
- Updated the regression test coverage in `chatModelPicker.test.ts` to reflect this change.

All changes have been validated with successful type-checks and passing tests, ensuring that the functionality remains intact.