### PR TITLE
Style overrides: Adjust padding and margin for SCM, search, and extensions views

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/padding.css
@@ -121,3 +121,15 @@
 	overflow: visible;
 }
 
+.style-override.monaco-workbench .scm-view .monaco-tl-contents > div {
+	padding-right: 4px;
+}
+
+.style-override.monaco-workbench .search-view .search-widgets-container {
+	margin: 0px 8px 0 2px;
+}
+
+.style-override.monaco-workbench .extensions-viewlet > .header {
+	padding: 4px 8px;
+}
+


### PR DESCRIPTION
Enhance the layout of SCM, search, and extensions views by adding padding and margin adjustments to improve visual consistency and usability.

