### PR TITLE
Style overrides: Add rounded corners for split buttons in action dropdowns

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/roundedCorners.css
@@ -70,6 +70,22 @@
 	border-radius: var(--vscode-cornerRadius-small) !important;
 }
 
+/*
+ * Split buttons (dropdown action items — e.g. the extension list/editor
+ * "Install"/"Disable" buttons). These connect a primary action label to a
+ * trailing dropdown chevron with a 1px separator between them. Rounding each
+ * label on all corners (via the rule above) puts radii on the inner seam where
+ * the two segments meet. Round only the outer edges of the pair — left corners
+ * on the primary label, right corners on the chevron — so the seam stays flat.
+ */
+.style-override .monaco-action-bar .action-item.action-dropdown-item > .action-label {
+	border-radius: var(--vscode-cornerRadius-small) 0 0 var(--vscode-cornerRadius-small) !important;
+}
+
+.style-override .monaco-action-bar .action-item.action-dropdown-item > .monaco-dropdown .action-label {
+	border-radius: 0 var(--vscode-cornerRadius-small) var(--vscode-cornerRadius-small) 0 !important;
+}
+
 /* Update indicator (title-bar "Update" button — base CSS uses medium, but as a
  * control it belongs to the controls tier). */
 .style-override .monaco-action-bar .update-indicator {


### PR DESCRIPTION
Introduce rounded corners for split buttons in action dropdowns to enhance the visual appeal and consistency of the UI. This change applies specific border-radius styles to the action labels and dropdowns, ensuring a polished look.

