### PR TITLE
Add setting to use the main BYOK model as the default copilot utility model

### DIFF
--- a/extensions/copilot/src/extension/chatInputNotification/vscode-node/byokUtilityModel.contribution.ts
+++ b/extensions/copilot/src/extension/chatInputNotification/vscode-node/byokUtilityModel.contribution.ts
@@ -12,16 +12,17 @@ import { Disposable } from '../../../util/vs/base/common/lifecycle';
 const NOTIFICATION_ID = 'copilot.byokUtilityModelHint';
 const UTILITY_MODEL_SETTING = 'chat.utilityModel';
 const UTILITY_SMALL_MODEL_SETTING = 'chat.utilitySmallModel';
-const USE_MAIN_BYOK_MODEL_FOR_UTILITY_MODELS_SETTING = 'chat.useMainBYOKModelForUtilityModels';
+const BYOK_UTILITY_MODEL_DEFAULT_SETTING = 'chat.byokUtilityModelDefault';
+const MAIN_AGENT_BYOK_UTILITY_MODEL_DEFAULT = 'mainAgent';
 
 /**
  * Shows a chat input notification in air-gapped BYOK scenarios (no GitHub
  * session) when at least one BYOK model is available but the utility model
  * settings are still defaults. Some utility flows are unavailable until the
- * user points them at a BYOK model or opts to reuse the main agent BYOK model.
+ * user points them at a BYOK model or selects the main agent model as the BYOK utility default.
  *
  * The notification hides automatically once the user signs in, BYOK models
- * disappear, both utility settings are configured, or main agent model reuse is enabled.
+ * disappear, both utility settings are configured, or the main agent model is the BYOK utility default.
  */
 export class ByokUtilityModelNotificationContribution extends Disposable {
 
@@ -42,7 +43,7 @@ export class ByokUtilityModelNotificationContribution extends Disposable {
 			if (
 				e.affectsConfiguration(UTILITY_MODEL_SETTING)
 				|| e.affectsConfiguration(UTILITY_SMALL_MODEL_SETTING)
-				|| e.affectsConfiguration(USE_MAIN_BYOK_MODEL_FOR_UTILITY_MODELS_SETTING)
+				|| e.affectsConfiguration(BYOK_UTILITY_MODEL_DEFAULT_SETTING)
 			) {
 				this._update();
 			}
@@ -72,9 +73,9 @@ export class ByokUtilityModelNotificationContribution extends Disposable {
 		const signedOut = !this._authService.anyGitHubSession;
 		const utilityUnset = !this._isUtilityOverrideSet(UTILITY_MODEL_SETTING);
 		const utilitySmallUnset = !this._isUtilityOverrideSet(UTILITY_SMALL_MODEL_SETTING);
-		const useMainBYOKModelForUtilityModels = this._configService.getNonExtensionConfig<unknown>(USE_MAIN_BYOK_MODEL_FOR_UTILITY_MODELS_SETTING) === true;
+		const byokUtilityModelDefault = this._configService.getNonExtensionConfig<unknown>(BYOK_UTILITY_MODEL_DEFAULT_SETTING);
 
-		if (!signedOut || !this._hasByokModels || useMainBYOKModelForUtilityModels || (!utilityUnset && !utilitySmallUnset)) {
+		if (!signedOut || !this._hasByokModels || byokUtilityModelDefault === MAIN_AGENT_BYOK_UTILITY_MODEL_DEFAULT || (!utilityUnset && !utilitySmallUnset)) {
 			this._hideNotification();
 			return;
 		}
@@ -97,7 +98,7 @@ export class ByokUtilityModelNotificationContribution extends Disposable {
 			notification.message = vscode.l10n.t('Set BYOK utility models');
 			notification.description = vscode.l10n.t('Unlocks full AI features.');
 			notification.actions = [
-				{ label: vscode.l10n.t('Configure'), commandId: 'workbench.action.openSettings', commandArgs: ['chat.utility'] },
+				{ label: vscode.l10n.t('Configure'), commandId: 'workbench.action.openSettings', commandArgs: [BYOK_UTILITY_MODEL_DEFAULT_SETTING] },
 			];
 		} else if (utilityUnset) {
 			notification.message = vscode.l10n.t('Set BYOK utility model');

--- a/extensions/copilot/src/extension/chatInputNotification/vscode-node/byokUtilityModel.contribution.ts
+++ b/extensions/copilot/src/extension/chatInputNotification/vscode-node/byokUtilityModel.contribution.ts
@@ -12,15 +12,16 @@ import { Disposable } from '../../../util/vs/base/common/lifecycle';
 const NOTIFICATION_ID = 'copilot.byokUtilityModelHint';
 const UTILITY_MODEL_SETTING = 'chat.utilityModel';
 const UTILITY_SMALL_MODEL_SETTING = 'chat.utilitySmallModel';
+const USE_MAIN_BYOK_MODEL_FOR_UTILITY_MODELS_SETTING = 'chat.useMainBYOKModelForUtilityModels';
 
 /**
  * Shows a chat input notification in air-gapped BYOK scenarios (no GitHub
  * session) when at least one BYOK model is available but the utility model
  * settings are still defaults. Some utility flows are unavailable until the
- * user points them at a BYOK model.
+ * user points them at a BYOK model or opts to reuse the main agent BYOK model.
  *
  * The notification hides automatically once the user signs in, BYOK models
- * disappear, or both utility settings are configured.
+ * disappear, both utility settings are configured, or main agent model reuse is enabled.
  */
 export class ByokUtilityModelNotificationContribution extends Disposable {
 
@@ -38,7 +39,11 @@ export class ByokUtilityModelNotificationContribution extends Disposable {
 		this._register(this._authService.onDidAuthenticationChange(() => this._update()));
 		this._register(vscode.lm.onDidChangeChatModels(() => this._update()));
 		this._register(this._configService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(UTILITY_MODEL_SETTING) || e.affectsConfiguration(UTILITY_SMALL_MODEL_SETTING)) {
+			if (
+				e.affectsConfiguration(UTILITY_MODEL_SETTING)
+				|| e.affectsConfiguration(UTILITY_SMALL_MODEL_SETTING)
+				|| e.affectsConfiguration(USE_MAIN_BYOK_MODEL_FOR_UTILITY_MODELS_SETTING)
+			) {
 				this._update();
 			}
 		}));
@@ -67,8 +72,9 @@ export class ByokUtilityModelNotificationContribution extends Disposable {
 		const signedOut = !this._authService.anyGitHubSession;
 		const utilityUnset = !this._isUtilityOverrideSet(UTILITY_MODEL_SETTING);
 		const utilitySmallUnset = !this._isUtilityOverrideSet(UTILITY_SMALL_MODEL_SETTING);
+		const useMainBYOKModelForUtilityModels = this._configService.getNonExtensionConfig<unknown>(USE_MAIN_BYOK_MODEL_FOR_UTILITY_MODELS_SETTING) === true;
 
-		if (!signedOut || !this._hasByokModels || (!utilityUnset && !utilitySmallUnset)) {
+		if (!signedOut || !this._hasByokModels || useMainBYOKModelForUtilityModels || (!utilityUnset && !utilitySmallUnset)) {
 			this._hideNotification();
 			return;
 		}

--- a/extensions/copilot/src/extension/chatInputNotification/vscode-node/test/byokUtilityModel.contribution.spec.ts
+++ b/extensions/copilot/src/extension/chatInputNotification/vscode-node/test/byokUtilityModel.contribution.spec.ts
@@ -116,7 +116,7 @@ describe('ByokUtilityModelNotificationContribution', () => {
 		expect(mockNotification.message).toBe('Set BYOK utility models');
 		expect(mockNotification.actions).toHaveLength(1);
 		expect(mockNotification.actions[0].commandId).toBe('workbench.action.openSettings');
-		expect(mockNotification.actions[0].commandArgs).toEqual(['chat.utility']);
+		expect(mockNotification.actions[0].commandArgs).toEqual(['chat.byokUtilityModelDefault']);
 	});
 
 	test('shows notification with single action when only chat.utilityModel is unset', async () => {
@@ -166,16 +166,28 @@ describe('ByokUtilityModelNotificationContribution', () => {
 		expect(mockNotification.show).not.toHaveBeenCalled();
 	});
 
-	test('does not show notification when main agent model reuse is enabled', async () => {
+	test('does not show notification when the main agent model is the BYOK utility default', async () => {
 		const { authService } = createAuthService({ anyGitHubSession: undefined });
 		const { configService } = createConfigService({
-			'chat.useMainAgentModelForUtilityModels': true,
+			'chat.byokUtilityModelDefault': 'mainAgent',
 		});
 		contribution = new ByokUtilityModelNotificationContribution(authService, configService, noopLog);
 
 		await flushAsync();
 
 		expect(mockNotification.show).not.toHaveBeenCalled();
+	});
+
+	test('continues to show notification when Copilot is the BYOK utility default while signed out', async () => {
+		const { authService } = createAuthService({ anyGitHubSession: undefined });
+		const { configService } = createConfigService({
+			'chat.byokUtilityModelDefault': 'copilot',
+		});
+		contribution = new ByokUtilityModelNotificationContribution(authService, configService, noopLog);
+
+		await flushAsync();
+
+		expect(mockNotification.show).toHaveBeenCalled();
 	});
 
 	test('hides notification once both utility settings are configured', async () => {
@@ -195,7 +207,7 @@ describe('ByokUtilityModelNotificationContribution', () => {
 		expect(mockNotification.hide).toHaveBeenCalled();
 	});
 
-	test('hides notification when main agent model reuse is enabled', async () => {
+	test('hides notification when the main agent model is the BYOK utility default', async () => {
 		const { authService } = createAuthService({ anyGitHubSession: undefined });
 		const { configService, set } = createConfigService();
 		contribution = new ByokUtilityModelNotificationContribution(authService, configService, noopLog);
@@ -203,7 +215,7 @@ describe('ByokUtilityModelNotificationContribution', () => {
 		await flushAsync();
 		expect(mockNotification.show).toHaveBeenCalled();
 
-		set('chat.useMainAgentModelForUtilityModels', true);
+		set('chat.byokUtilityModelDefault', 'mainAgent');
 		await flushAsync();
 
 		expect(mockNotification.hide).toHaveBeenCalled();

--- a/extensions/copilot/src/extension/chatInputNotification/vscode-node/test/byokUtilityModel.contribution.spec.ts
+++ b/extensions/copilot/src/extension/chatInputNotification/vscode-node/test/byokUtilityModel.contribution.spec.ts
@@ -166,6 +166,18 @@ describe('ByokUtilityModelNotificationContribution', () => {
 		expect(mockNotification.show).not.toHaveBeenCalled();
 	});
 
+	test('does not show notification when main agent model reuse is enabled', async () => {
+		const { authService } = createAuthService({ anyGitHubSession: undefined });
+		const { configService } = createConfigService({
+			'chat.useMainAgentModelForUtilityModels': true,
+		});
+		contribution = new ByokUtilityModelNotificationContribution(authService, configService, noopLog);
+
+		await flushAsync();
+
+		expect(mockNotification.show).not.toHaveBeenCalled();
+	});
+
 	test('hides notification once both utility settings are configured', async () => {
 		const { authService } = createAuthService({ anyGitHubSession: undefined });
 		const { configService, set } = createConfigService();
@@ -180,6 +192,20 @@ describe('ByokUtilityModelNotificationContribution', () => {
 
 		set('chat.utilitySmallModel', 'ollama/llama3');
 		await flushAsync();
+		expect(mockNotification.hide).toHaveBeenCalled();
+	});
+
+	test('hides notification when main agent model reuse is enabled', async () => {
+		const { authService } = createAuthService({ anyGitHubSession: undefined });
+		const { configService, set } = createConfigService();
+		contribution = new ByokUtilityModelNotificationContribution(authService, configService, noopLog);
+
+		await flushAsync();
+		expect(mockNotification.show).toHaveBeenCalled();
+
+		set('chat.useMainAgentModelForUtilityModels', true);
+		await flushAsync();
+
 		expect(mockNotification.hide).toHaveBeenCalled();
 	});
 

--- a/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
+++ b/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
@@ -21,6 +21,12 @@ import { Disposable } from '../../../util/vs/base/common/lifecycle';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 
 
+const enum BYOKUtilityModelDefault {
+	None = 'none',
+	MainAgent = 'mainAgent',
+	Copilot = 'copilot',
+}
+
 export class ProductionEndpointProvider extends Disposable implements IEndpointProvider {
 
 	declare readonly _serviceBrand: undefined;
@@ -58,8 +64,7 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 			if (
 				e.affectsConfiguration(ProductionEndpointProvider.UTILITY_MODEL_CONFIG_KEY)
 				|| e.affectsConfiguration(ProductionEndpointProvider.UTILITY_SMALL_MODEL_CONFIG_KEY)
-				|| e.affectsConfiguration(ProductionEndpointProvider.USE_MAIN_AGENT_MODEL_FOR_UTILITY_MODELS_CONFIG_KEY)
-				|| e.affectsConfiguration(ProductionEndpointProvider.USE_COPILOT_MODELS_FOR_UTILITY_MODELS_CONFIG_KEY)
+				|| e.affectsConfiguration(ProductionEndpointProvider.BYOK_UTILITY_MODEL_DEFAULT_CONFIG_KEY)
 			) {
 				this._logService.trace(`[ProductionEndpointProvider] Utility model configuration changed; invalidating alias endpoints.`);
 				// Clear telemetry fingerprints so a re-applied override emits
@@ -80,8 +85,7 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 	// `vscode.lm.selectChatModels({ vendor, id })`.
 	private static readonly UTILITY_MODEL_CONFIG_KEY = 'chat.utilityModel';
 	private static readonly UTILITY_SMALL_MODEL_CONFIG_KEY = 'chat.utilitySmallModel';
-	private static readonly USE_MAIN_AGENT_MODEL_FOR_UTILITY_MODELS_CONFIG_KEY = 'chat.useMainAgentModelForUtilityModels';
-	private static readonly USE_COPILOT_MODELS_FOR_UTILITY_MODELS_CONFIG_KEY = 'chat.useCopilotModelsForUtilityModels';
+	private static readonly BYOK_UTILITY_MODEL_DEFAULT_CONFIG_KEY = 'chat.byokUtilityModelDefault';
 	private _mainAgentBYOKModel: LanguageModelChat | undefined;
 
 	/**
@@ -183,12 +187,15 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 			return override;
 		}
 
-		if (this._mainAgentBYOKModel && this._configService.getNonExtensionConfig<unknown>(ProductionEndpointProvider.USE_MAIN_AGENT_MODEL_FOR_UTILITY_MODELS_CONFIG_KEY) === true) {
-			return this._instantiationService.createInstance(ExtensionContributedChatEndpoint, this._mainAgentBYOKModel);
-		}
-
-		if (!this._useCopilotModelsForUtilityModelsByDefault()) {
-			throw new Error(`No utility model is configured for '${family}' while the selected main agent model is BYOK.`);
+		if (this._mainAgentBYOKModel) {
+			switch (this._getBYOKUtilityModelDefault()) {
+				case BYOKUtilityModelDefault.MainAgent:
+					return this._instantiationService.createInstance(ExtensionContributedChatEndpoint, this._mainAgentBYOKModel);
+				case BYOKUtilityModelDefault.None:
+					throw new Error(`No utility model is configured for '${family}' while the selected main agent model is BYOK.`);
+				case BYOKUtilityModelDefault.Copilot:
+					break;
+			}
 		}
 
 		switch (family) {
@@ -199,14 +206,19 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 		}
 	}
 
-	/**
-	 * Whether an unset utility model should resolve to a built-in GitHub Copilot
-	 * model. `true` when the selected main agent model is itself a Copilot model, or
-	 * when the user opted in via {@link USE_COPILOT_MODELS_FOR_UTILITY_MODELS_CONFIG_KEY}.
-	 */
-	private _useCopilotModelsForUtilityModelsByDefault(): boolean {
-		return !this._mainAgentBYOKModel
-			|| this._configService.getNonExtensionConfig<unknown>(ProductionEndpointProvider.USE_COPILOT_MODELS_FOR_UTILITY_MODELS_CONFIG_KEY) === true;
+	private _getBYOKUtilityModelDefault(): BYOKUtilityModelDefault {
+		const value = this._configService.getNonExtensionConfig<unknown>(ProductionEndpointProvider.BYOK_UTILITY_MODEL_DEFAULT_CONFIG_KEY);
+		switch (value) {
+			case undefined:
+				return BYOKUtilityModelDefault.None;
+			case BYOKUtilityModelDefault.None:
+			case BYOKUtilityModelDefault.MainAgent:
+			case BYOKUtilityModelDefault.Copilot:
+				return value;
+			default:
+				this._logService.warn(`[ProductionEndpointProvider] Ignoring invalid ${ProductionEndpointProvider.BYOK_UTILITY_MODEL_DEFAULT_CONFIG_KEY} value: '${String(value)}'.`);
+				return BYOKUtilityModelDefault.None;
+		}
 	}
 
 	/**

--- a/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
+++ b/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
@@ -58,6 +58,7 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 			if (
 				e.affectsConfiguration(ProductionEndpointProvider.UTILITY_MODEL_CONFIG_KEY)
 				|| e.affectsConfiguration(ProductionEndpointProvider.UTILITY_SMALL_MODEL_CONFIG_KEY)
+				|| e.affectsConfiguration(ProductionEndpointProvider.USE_MAIN_AGENT_MODEL_FOR_UTILITY_MODELS_CONFIG_KEY)
 				|| e.affectsConfiguration(ProductionEndpointProvider.USE_COPILOT_MODELS_FOR_UTILITY_MODELS_CONFIG_KEY)
 			) {
 				this._logService.trace(`[ProductionEndpointProvider] Utility model configuration changed; invalidating alias endpoints.`);
@@ -79,8 +80,9 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 	// `vscode.lm.selectChatModels({ vendor, id })`.
 	private static readonly UTILITY_MODEL_CONFIG_KEY = 'chat.utilityModel';
 	private static readonly UTILITY_SMALL_MODEL_CONFIG_KEY = 'chat.utilitySmallModel';
+	private static readonly USE_MAIN_AGENT_MODEL_FOR_UTILITY_MODELS_CONFIG_KEY = 'chat.useMainAgentModelForUtilityModels';
 	private static readonly USE_COPILOT_MODELS_FOR_UTILITY_MODELS_CONFIG_KEY = 'chat.useCopilotModelsForUtilityModels';
-	private _mainModelIsBYOK = false;
+	private _mainAgentBYOKModel: LanguageModelChat | undefined;
 
 	/**
 	 * Per-family marker recording that we already emitted a telemetry event
@@ -114,9 +116,12 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 		}
 
 		if (model.id !== 'copilot-utility' && model.id !== 'copilot-utility-small') {
-			const mainModelIsBYOK = model.vendor !== 'copilot';
-			if (this._mainModelIsBYOK !== mainModelIsBYOK) {
-				this._mainModelIsBYOK = mainModelIsBYOK;
+			const mainAgentBYOKModel = model.vendor !== 'copilot' ? model : undefined;
+			const mainAgentModelChanged = this._mainAgentBYOKModel?.vendor !== mainAgentBYOKModel?.vendor
+				|| this._mainAgentBYOKModel?.id !== mainAgentBYOKModel?.id
+				|| this._mainAgentBYOKModel?.version !== mainAgentBYOKModel?.version;
+			this._mainAgentBYOKModel = mainAgentBYOKModel;
+			if (mainAgentModelChanged) {
 				this._lastOverrideTelemetryFingerprint.clear();
 				this._onDidModelsRefresh.fire();
 			}
@@ -178,8 +183,12 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 			return override;
 		}
 
+		if (this._mainAgentBYOKModel && this._configService.getNonExtensionConfig<unknown>(ProductionEndpointProvider.USE_MAIN_AGENT_MODEL_FOR_UTILITY_MODELS_CONFIG_KEY) === true) {
+			return this._instantiationService.createInstance(ExtensionContributedChatEndpoint, this._mainAgentBYOKModel);
+		}
+
 		if (!this._useCopilotModelsForUtilityModelsByDefault()) {
-			throw new Error(`No utility model is configured for '${family}' while the selected main model is BYOK.`);
+			throw new Error(`No utility model is configured for '${family}' while the selected main agent model is BYOK.`);
 		}
 
 		switch (family) {
@@ -192,11 +201,11 @@ export class ProductionEndpointProvider extends Disposable implements IEndpointP
 
 	/**
 	 * Whether an unset utility model should resolve to a built-in GitHub Copilot
-	 * model. `true` when the selected main model is itself a Copilot model, or
+	 * model. `true` when the selected main agent model is itself a Copilot model, or
 	 * when the user opted in via {@link USE_COPILOT_MODELS_FOR_UTILITY_MODELS_CONFIG_KEY}.
 	 */
 	private _useCopilotModelsForUtilityModelsByDefault(): boolean {
-		return !this._mainModelIsBYOK
+		return !this._mainAgentBYOKModel
 			|| this._configService.getNonExtensionConfig<unknown>(ProductionEndpointProvider.USE_COPILOT_MODELS_FOR_UTILITY_MODELS_CONFIG_KEY) === true;
 	}
 

--- a/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
+++ b/extensions/copilot/src/extension/prompt/vscode-node/endpointProviderImpl.ts
@@ -21,6 +21,7 @@ import { Disposable } from '../../../util/vs/base/common/lifecycle';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 
 
+// Keep in sync with `BYOKUtilityModelDefault` in `src/vs/workbench/contrib/chat/common/constants.ts` and the `chat.byokUtilityModelDefault` enum in `chat.shared.contribution.ts`.
 const enum BYOKUtilityModelDefault {
 	None = 'none',
 	MainAgent = 'mainAgent',

--- a/extensions/copilot/src/extension/test/vscode-node/endpoints.test.ts
+++ b/extensions/copilot/src/extension/test/vscode-node/endpoints.test.ts
@@ -206,20 +206,20 @@ suite('ProductionEndpointProvider — utility model overrides', () => {
 		);
 	});
 
-	test('Copilot utility model opt-in applies when the selected main agent model is BYOK', async () => {
+	test('Copilot default applies when the selected main agent model is BYOK', async () => {
 		setFetcher([makeChatModel('copilot-utility')]);
 		await endpointProvider.getChatEndpoint(makeFakeLanguageModelChat({ vendor: 'anthropic' }));
-		await configService.setNonExtensionConfig('chat.useCopilotModelsForUtilityModels', true);
+		await configService.setNonExtensionConfig('chat.byokUtilityModelDefault', 'copilot');
 
 		const endpoint = await endpointProvider.getChatEndpoint('copilot-utility');
 
 		assert.strictEqual(endpoint.model, 'copilot-utility');
 	});
 
-	test('main agent model opt-in uses the selected BYOK model for utility families', async () => {
+	test('main agent default uses the selected BYOK model for utility families', async () => {
 		const mainAgentModel = makeFakeLanguageModelChat({ vendor: 'customendpoint', id: 'qwen3.6' });
 		await endpointProvider.getChatEndpoint(mainAgentModel);
-		await configService.setNonExtensionConfig('chat.useMainAgentModelForUtilityModels', true);
+		await configService.setNonExtensionConfig('chat.byokUtilityModelDefault', 'mainAgent');
 
 		const utilityEndpoint = await endpointProvider.getChatEndpoint('copilot-utility');
 		const smallUtilityEndpoint = await endpointProvider.getChatEndpoint('copilot-utility-small');
@@ -230,10 +230,10 @@ suite('ProductionEndpointProvider — utility model overrides', () => {
 		assert.strictEqual(smallUtilityEndpoint.model, 'qwen3.6');
 	});
 
-	test('main agent model opt-in does not replace utility models for a Copilot main agent model', async () => {
+	test('BYOK utility default does not replace utility models for a Copilot main agent model', async () => {
 		setFetcher([makeChatModel('copilot-utility')]);
 		await endpointProvider.getChatEndpoint(makeFakeLanguageModelChat({ vendor: 'copilot', id: 'gpt-5' }));
-		await configService.setNonExtensionConfig('chat.useMainAgentModelForUtilityModels', true);
+		await configService.setNonExtensionConfig('chat.byokUtilityModelDefault', 'mainAgent');
 
 		const endpoint = await endpointProvider.getChatEndpoint('copilot-utility');
 
@@ -241,20 +241,8 @@ suite('ProductionEndpointProvider — utility model overrides', () => {
 		assert.strictEqual(endpoint.model, 'copilot-utility');
 	});
 
-	test('main agent model opt-in takes precedence over Copilot utility model opt-in', async () => {
-		setFetcher([makeChatModel('copilot-utility')]);
-		await endpointProvider.getChatEndpoint(makeFakeLanguageModelChat({ vendor: 'customendpoint', id: 'qwen3.6' }));
-		await configService.setNonExtensionConfig('chat.useMainAgentModelForUtilityModels', true);
-		await configService.setNonExtensionConfig('chat.useCopilotModelsForUtilityModels', true);
-
-		const endpoint = await endpointProvider.getChatEndpoint('copilot-utility');
-
-		assert.ok(endpoint instanceof ExtensionContributedChatEndpoint);
-		assert.strictEqual(endpoint.model, 'qwen3.6');
-	});
-
-	test('main agent model opt-in follows changes to the selected BYOK model', async () => {
-		await configService.setNonExtensionConfig('chat.useMainAgentModelForUtilityModels', true);
+	test('main agent default follows changes to the selected BYOK model', async () => {
+		await configService.setNonExtensionConfig('chat.byokUtilityModelDefault', 'mainAgent');
 		await endpointProvider.getChatEndpoint(makeFakeLanguageModelChat({ vendor: 'customendpoint', id: 'qwen3.6' }));
 		const firstEndpoint = await endpointProvider.getChatEndpoint('copilot-utility');
 
@@ -270,7 +258,7 @@ suite('ProductionEndpointProvider — utility model overrides', () => {
 		await endpointProvider.getChatEndpoint(makeFakeLanguageModelChat({ vendor: 'anthropic' }));
 		const fakeModel = makeFakeLanguageModelChat({ vendor: 'anthropic', id: 'claude-haiku-4.5' });
 		sandbox.stub(lm, 'selectChatModels').resolves([fakeModel]);
-		await configService.setNonExtensionConfig('chat.useMainAgentModelForUtilityModels', true);
+		await configService.setNonExtensionConfig('chat.byokUtilityModelDefault', 'mainAgent');
 		await configService.setNonExtensionConfig('chat.utilityModel', 'anthropic/claude-haiku-4.5');
 
 		const endpoint = await endpointProvider.getChatEndpoint('copilot-utility');
@@ -333,9 +321,8 @@ suite('ProductionEndpointProvider — utility model overrides', () => {
 		try {
 			await configService.setNonExtensionConfig('chat.utilityModel', 'copilot/gpt-4o-mini');
 			await configService.setNonExtensionConfig('chat.utilitySmallModel', 'copilot/gpt-4o-mini');
-			await configService.setNonExtensionConfig('chat.useMainAgentModelForUtilityModels', true);
-			await configService.setNonExtensionConfig('chat.useCopilotModelsForUtilityModels', true);
-			assert.strictEqual(refreshCount, 4);
+			await configService.setNonExtensionConfig('chat.byokUtilityModelDefault', 'mainAgent');
+			assert.strictEqual(refreshCount, 3);
 		} finally {
 			sub.dispose();
 		}

--- a/extensions/copilot/src/extension/test/vscode-node/endpoints.test.ts
+++ b/extensions/copilot/src/extension/test/vscode-node/endpoints.test.ts
@@ -196,7 +196,7 @@ suite('ProductionEndpointProvider — utility model overrides', () => {
 		assert.strictEqual(endpoint.model, 'copilot-utility');
 	});
 
-	test('no override configured — does not use a Copilot utility model when the selected main model is BYOK', async () => {
+	test('no override configured — does not use a Copilot utility model when the selected main agent model is BYOK', async () => {
 		setFetcher([makeChatModel('copilot-utility')]);
 		await endpointProvider.getChatEndpoint(makeFakeLanguageModelChat({ vendor: 'anthropic' }));
 
@@ -206,7 +206,7 @@ suite('ProductionEndpointProvider — utility model overrides', () => {
 		);
 	});
 
-	test('Copilot utility model opt-in applies when the selected main model is BYOK', async () => {
+	test('Copilot utility model opt-in applies when the selected main agent model is BYOK', async () => {
 		setFetcher([makeChatModel('copilot-utility')]);
 		await endpointProvider.getChatEndpoint(makeFakeLanguageModelChat({ vendor: 'anthropic' }));
 		await configService.setNonExtensionConfig('chat.useCopilotModelsForUtilityModels', true);
@@ -216,11 +216,61 @@ suite('ProductionEndpointProvider — utility model overrides', () => {
 		assert.strictEqual(endpoint.model, 'copilot-utility');
 	});
 
-	test('explicit utility override applies when the selected main model is BYOK', async () => {
+	test('main agent model opt-in uses the selected BYOK model for utility families', async () => {
+		const mainAgentModel = makeFakeLanguageModelChat({ vendor: 'customendpoint', id: 'qwen3.6' });
+		await endpointProvider.getChatEndpoint(mainAgentModel);
+		await configService.setNonExtensionConfig('chat.useMainAgentModelForUtilityModels', true);
+
+		const utilityEndpoint = await endpointProvider.getChatEndpoint('copilot-utility');
+		const smallUtilityEndpoint = await endpointProvider.getChatEndpoint('copilot-utility-small');
+
+		assert.ok(utilityEndpoint instanceof ExtensionContributedChatEndpoint);
+		assert.strictEqual(utilityEndpoint.model, 'qwen3.6');
+		assert.ok(smallUtilityEndpoint instanceof ExtensionContributedChatEndpoint);
+		assert.strictEqual(smallUtilityEndpoint.model, 'qwen3.6');
+	});
+
+	test('main agent model opt-in does not replace utility models for a Copilot main agent model', async () => {
+		setFetcher([makeChatModel('copilot-utility')]);
+		await endpointProvider.getChatEndpoint(makeFakeLanguageModelChat({ vendor: 'copilot', id: 'gpt-5' }));
+		await configService.setNonExtensionConfig('chat.useMainAgentModelForUtilityModels', true);
+
+		const endpoint = await endpointProvider.getChatEndpoint('copilot-utility');
+
+		assert.ok(endpoint instanceof CopilotChatEndpoint);
+		assert.strictEqual(endpoint.model, 'copilot-utility');
+	});
+
+	test('main agent model opt-in takes precedence over Copilot utility model opt-in', async () => {
+		setFetcher([makeChatModel('copilot-utility')]);
+		await endpointProvider.getChatEndpoint(makeFakeLanguageModelChat({ vendor: 'customendpoint', id: 'qwen3.6' }));
+		await configService.setNonExtensionConfig('chat.useMainAgentModelForUtilityModels', true);
+		await configService.setNonExtensionConfig('chat.useCopilotModelsForUtilityModels', true);
+
+		const endpoint = await endpointProvider.getChatEndpoint('copilot-utility');
+
+		assert.ok(endpoint instanceof ExtensionContributedChatEndpoint);
+		assert.strictEqual(endpoint.model, 'qwen3.6');
+	});
+
+	test('main agent model opt-in follows changes to the selected BYOK model', async () => {
+		await configService.setNonExtensionConfig('chat.useMainAgentModelForUtilityModels', true);
+		await endpointProvider.getChatEndpoint(makeFakeLanguageModelChat({ vendor: 'customendpoint', id: 'qwen3.6' }));
+		const firstEndpoint = await endpointProvider.getChatEndpoint('copilot-utility');
+
+		await endpointProvider.getChatEndpoint(makeFakeLanguageModelChat({ vendor: 'customendpoint', id: 'gemma4' }));
+		const secondEndpoint = await endpointProvider.getChatEndpoint('copilot-utility');
+
+		assert.strictEqual(firstEndpoint.model, 'qwen3.6');
+		assert.strictEqual(secondEndpoint.model, 'gemma4');
+	});
+
+	test('explicit utility override applies when the selected main agent model is BYOK', async () => {
 		setFetcher([makeChatModel('copilot-utility')]);
 		await endpointProvider.getChatEndpoint(makeFakeLanguageModelChat({ vendor: 'anthropic' }));
 		const fakeModel = makeFakeLanguageModelChat({ vendor: 'anthropic', id: 'claude-haiku-4.5' });
 		sandbox.stub(lm, 'selectChatModels').resolves([fakeModel]);
+		await configService.setNonExtensionConfig('chat.useMainAgentModelForUtilityModels', true);
 		await configService.setNonExtensionConfig('chat.utilityModel', 'anthropic/claude-haiku-4.5');
 
 		const endpoint = await endpointProvider.getChatEndpoint('copilot-utility');
@@ -283,8 +333,9 @@ suite('ProductionEndpointProvider — utility model overrides', () => {
 		try {
 			await configService.setNonExtensionConfig('chat.utilityModel', 'copilot/gpt-4o-mini');
 			await configService.setNonExtensionConfig('chat.utilitySmallModel', 'copilot/gpt-4o-mini');
+			await configService.setNonExtensionConfig('chat.useMainAgentModelForUtilityModels', true);
 			await configService.setNonExtensionConfig('chat.useCopilotModelsForUtilityModels', true);
-			assert.strictEqual(refreshCount, 3);
+			assert.strictEqual(refreshCount, 4);
 		} finally {
 			sub.dispose();
 		}

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -60,7 +60,7 @@ import { ChatTransferService, IChatTransferService } from '../common/model/chatT
 import { LocalAgentDisabledInputTipContribution } from './agentSessions/localAgentDisabledInputTipContribution.js';
 import { IChatVariablesService } from '../common/attachments/chatVariables.js';
 import { ChatWidgetHistoryService, IChatWidgetHistoryService } from '../common/widget/chatWidgetHistoryService.js';
-import { ChatAgentLocation, ChatConfiguration, ChatNotificationMode, ChatPermissionLevel } from '../common/constants.js';
+import { BYOKUtilityModelDefault, ChatAgentLocation, ChatConfiguration, ChatNotificationMode, ChatPermissionLevel } from '../common/constants.js';
 import { ILanguageModelIgnoredFilesService, LanguageModelIgnoredFilesService } from '../common/ignoredFiles.js';
 import { ILanguageModelsService, LanguageModelsService } from '../common/languageModels.js';
 import { ILanguageModelStatsService, LanguageModelStatsService } from '../common/languageModelStats.js';
@@ -1311,15 +1311,21 @@ configurationRegistry.registerConfiguration({
 			enumItemLabels: ExploreAgentDefaultModel.modelLabels,
 			markdownEnumDescriptions: ExploreAgentDefaultModel.modelDescriptions
 		},
-		[ChatConfiguration.UseMainBYOKModelForUtilityModels]: {
-			type: 'boolean',
-			markdownDescription: nls.localize('chat.useMainBYOKModelForUtilityModels.description', "Use the selected main agent model for built-in utility flows when it is a bring your own key (BYOK) model. This setting only applies to BYOK models and has no effect when the selected main agent model is provided by GitHub Copilot. Utility flows power background features such as generating chat titles and summaries. This setting takes precedence over {0} and does not apply when a specific model is configured in {1} or {2}.", '`#chat.useCopilotModelsForUtilityModels#`', '`#chat.utilityModel#`', '`#chat.utilitySmallModel#`'),
-			default: false,
-		},
-		[ChatConfiguration.UseCopilotModelsForUtilityModels]: {
-			type: 'boolean',
-			markdownDescription: nls.localize('chat.useCopilotModelsForUtilityModels.description', "Use default GitHub Copilot models for built-in utility flows when the main chat model is a bring your own key (BYOK) model. Utility flows power background features such as generating chat titles and summaries. This setting does not apply when {0} is enabled or when a specific model is configured in {1} or {2}.", '`#chat.useMainBYOKModelForUtilityModels#`', '`#chat.utilityModel#`', '`#chat.utilitySmallModel#`'),
-			default: false,
+		[ChatConfiguration.BYOKUtilityModelDefault]: {
+			type: 'string',
+			markdownDescription: nls.localize('chat.byokUtilityModelDefault.description', "Controls the default model used by built-in utility flows when the selected main agent model is a bring your own key (BYOK) model. This setting has no effect when the selected main agent model is provided by GitHub Copilot. A specific model configured in {0} or {1} takes precedence.", '`#chat.utilityModel#`', '`#chat.utilitySmallModel#`'),
+			enum: [BYOKUtilityModelDefault.None, BYOKUtilityModelDefault.MainAgent, BYOKUtilityModelDefault.Copilot],
+			enumItemLabels: [
+				nls.localize('chat.byokUtilityModelDefault.none.label', "None"),
+				nls.localize('chat.byokUtilityModelDefault.mainAgent.label', "Main Agent Model"),
+				nls.localize('chat.byokUtilityModelDefault.copilot.label', "GitHub Copilot"),
+			],
+			markdownEnumDescriptions: [
+				nls.localize('chat.byokUtilityModelDefault.none.description', "Do not use a default utility model."),
+				nls.localize('chat.byokUtilityModelDefault.mainAgent.description', "Use the selected BYOK main agent model."),
+				nls.localize('chat.byokUtilityModelDefault.copilot.description', "Use the default GitHub Copilot utility models."),
+			],
+			default: BYOKUtilityModelDefault.None,
 		},
 		[ChatConfiguration.UtilityModel]: {
 			type: 'string',
@@ -1949,6 +1955,16 @@ Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration).
 			['chat.experimental.detectParticipant.enabled', { value: undefined }],
 			['chat.detectParticipant.enabled', { value: value !== false }]
 		])
+	},
+	{
+		key: 'chat.useCopilotModelsForUtilityModels',
+		migrateFn: (value: unknown, valueAccessor) => {
+			const result: ConfigurationKeyValuePairs = [['chat.useCopilotModelsForUtilityModels', { value: undefined }]];
+			if (typeof value === 'boolean' && valueAccessor(ChatConfiguration.BYOKUtilityModelDefault) === undefined) {
+				result.push([ChatConfiguration.BYOKUtilityModelDefault, { value: value ? BYOKUtilityModelDefault.Copilot : BYOKUtilityModelDefault.None }]);
+			}
+			return result;
+		}
 	},
 	{
 		key: 'chat.useClaudeSkills',

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -1311,14 +1311,19 @@ configurationRegistry.registerConfiguration({
 			enumItemLabels: ExploreAgentDefaultModel.modelLabels,
 			markdownEnumDescriptions: ExploreAgentDefaultModel.modelDescriptions
 		},
+		[ChatConfiguration.UseMainBYOKModelForUtilityModels]: {
+			type: 'boolean',
+			markdownDescription: nls.localize('chat.useMainBYOKModelForUtilityModels.description', "Use the selected main agent model for built-in utility flows when it is a bring your own key (BYOK) model. This setting only applies to BYOK models and has no effect when the selected main agent model is provided by GitHub Copilot. Utility flows power background features such as generating chat titles and summaries. This setting takes precedence over {0} and does not apply when a specific model is configured in {1} or {2}.", '`#chat.useCopilotModelsForUtilityModels#`', '`#chat.utilityModel#`', '`#chat.utilitySmallModel#`'),
+			default: false,
+		},
 		[ChatConfiguration.UseCopilotModelsForUtilityModels]: {
 			type: 'boolean',
-			markdownDescription: nls.localize('chat.useCopilotModelsForUtilityModels.description', "Use default GitHub Copilot models for built-in utility flows when the main chat model is a bring your own key (BYOK) model. Utility flows power background features such as generating chat titles and summaries. This setting does not apply when a specific model is configured in {0} or {1}.", '`#chat.utilityModel#`', '`#chat.utilitySmallModel#`'),
+			markdownDescription: nls.localize('chat.useCopilotModelsForUtilityModels.description', "Use default GitHub Copilot models for built-in utility flows when the main chat model is a bring your own key (BYOK) model. Utility flows power background features such as generating chat titles and summaries. This setting does not apply when {0} is enabled or when a specific model is configured in {1} or {2}.", '`#chat.useMainBYOKModelForUtilityModels#`', '`#chat.utilityModel#`', '`#chat.utilitySmallModel#`'),
 			default: false,
 		},
 		[ChatConfiguration.UtilityModel]: {
 			type: 'string',
-			description: nls.localize('chat.utilityModel.description', "Override the language model used by built-in utility flows. Leave empty to use the default model when the main chat model is provided by GitHub Copilot."),
+			description: nls.localize('chat.utilityModel.description', "Override the language model used by built-in utility flows. Leave empty to use the configured default behavior."),
 			default: '',
 			enum: UtilityModelContribution.modelIds,
 			enumItemLabels: UtilityModelContribution.modelLabels,
@@ -1326,7 +1331,7 @@ configurationRegistry.registerConfiguration({
 		},
 		[ChatConfiguration.UtilitySmallModel]: {
 			type: 'string',
-			description: nls.localize('chat.utilitySmallModel.description', "Override the language model used by built-in small/fast utility flows. A fast and inexpensive model is recommended. Leave empty to use the default model when the main chat model is provided by GitHub Copilot."),
+			description: nls.localize('chat.utilitySmallModel.description', "Override the language model used by built-in small/fast utility flows. A fast and inexpensive model is recommended. Leave empty to use the configured default behavior."),
 			default: '',
 			enum: UtilitySmallModelContribution.modelIds,
 			enumItemLabels: UtilitySmallModelContribution.modelLabels,

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -27,6 +27,7 @@ export enum ChatConfiguration {
 	ExploreAgentDefaultModel = 'chat.exploreAgent.defaultModel',
 	UtilityModel = 'chat.utilityModel',
 	UtilitySmallModel = 'chat.utilitySmallModel',
+	UseMainBYOKModelForUtilityModels = 'chat.useMainBYOKModelForUtilityModels',
 	UseCopilotModelsForUtilityModels = 'chat.useCopilotModelsForUtilityModels',
 	RequestQueueingDefaultAction = 'chat.requestQueuing.defaultAction',
 	AgentStatusEnabled = 'chat.agentsControl.enabled',

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -14,6 +14,12 @@ import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { LocalChatSessionUri } from './model/chatUri.js';
 
+export const enum BYOKUtilityModelDefault {
+	None = 'none',
+	MainAgent = 'mainAgent',
+	Copilot = 'copilot',
+}
+
 export enum ChatConfiguration {
 	AIDisabled = 'chat.disableAIFeatures',
 	PluginsEnabled = 'chat.plugins.enabled',
@@ -27,8 +33,7 @@ export enum ChatConfiguration {
 	ExploreAgentDefaultModel = 'chat.exploreAgent.defaultModel',
 	UtilityModel = 'chat.utilityModel',
 	UtilitySmallModel = 'chat.utilitySmallModel',
-	UseMainBYOKModelForUtilityModels = 'chat.useMainBYOKModelForUtilityModels',
-	UseCopilotModelsForUtilityModels = 'chat.useCopilotModelsForUtilityModels',
+	BYOKUtilityModelDefault = 'chat.byokUtilityModelDefault',
 	RequestQueueingDefaultAction = 'chat.requestQueuing.defaultAction',
 	AgentStatusEnabled = 'chat.agentsControl.enabled',
 	EditorAssociations = 'chat.editorAssociations',


### PR DESCRIPTION
Introduce a new setting to allow the main BYOK model to be the default for copilot utility models. Refactor existing utility model settings to unify the configuration.
This changes the setting introduced last week that let users simply fall back to old behavior, to be a dropdown that lets them also indicate being able to use the main BYOK model as a utility model as pointed out in #324007
