### PR TITLE
Fix second Rerun Last Task failing to launch for reevaluateOnRerun tasks

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -845,6 +845,8 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 			return Promise.reject(new Error('No task previously run'));
 		}
 		const workspaceFolder = this._currentTask.workspaceFolder = lastTask.workspaceFolder;
+		// Carry systemInfo forward, else a later rerun resolves the shell on the local host (#175118).
+		this._currentTask.systemInfo = lastTask.systemInfo;
 		const variables = new Set<string>();
 		this._collectTaskVariables(variables, task);
 


### PR DESCRIPTION
Fixes #175118. Regression from #132916 (dccb659), which made rerun re-resolve the shell instead of reusing the cached config. The re-resolve derives `platform` from `resolver.taskSystemInfo`, but `_reexecuteCommand `never copied` systemInfo `onto the current task the way` _executeCommand` does — so after the first rerun the stored last task had an undefined `systemInfo`, and the next rerun resolved the shell on the local host (`Path to shell executable '\usr\bin\zsh' does not exist`). Carrying `systemInfo` forward fixes it without reverting the original change.