### PR TITLE
Include request UUID in completion feedback (fix empty telemetry section)

### DIFF
--- a/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/copilotCompletionFeedbackTracker.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/copilotCompletionFeedbackTracker.ts
@@ -3,12 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, commands, InlineCompletionItem } from 'vscode';
+import { Command, commands } from 'vscode';
 import { Disposable } from '../../../../../util/vs/base/common/lifecycle';
 import { IInstantiationService, ServicesAccessor } from '../../../../../util/vs/platform/instantiation/common/instantiation';
 import { collectCompletionDiagnostics, formatDiagnosticsAsMarkdown } from '../../lib/src/diagnostics';
 import { telemetry, TelemetryData } from '../../lib/src/telemetry';
 import { CMDSendCompletionsFeedbackChat } from './constants';
+import type { GhostTextCompletionItem } from './ghostText/ghostTextProvider';
 
 export const sendCompletionFeedbackCommand: Command = {
 	command: CMDSendCompletionsFeedbackChat,
@@ -17,32 +18,27 @@ export const sendCompletionFeedbackCommand: Command = {
 };
 
 export class CopilotCompletionFeedbackTracker extends Disposable {
-	private lastShownCopilotCompletionItem: InlineCompletionItem | undefined;
+	private lastShownCopilotCompletionItem: GhostTextCompletionItem | undefined;
 
 	constructor(@IInstantiationService private readonly instantiationService: IInstantiationService) {
 		super();
 		this._register(commands.registerCommand(sendCompletionFeedbackCommand.command, async () => {
-			const commandArg: unknown = this.lastShownCopilotCompletionItem?.command?.arguments?.[0];
-			let telemetryArg: TelemetryData | undefined;
-			if (commandArg && typeof commandArg === 'object' && 'telemetry' in commandArg) {
-				if (commandArg.telemetry instanceof TelemetryData) {
-					telemetryArg = commandArg.telemetry;
-				}
-			}
+			const item = this.lastShownCopilotCompletionItem;
+			const telemetryArg: TelemetryData | undefined = item?.copilotCompletion.telemetry;
 			this.instantiationService.invokeFunction(telemetry, 'ghostText.sentFeedback', telemetryArg);
 
-			await this.instantiationService.invokeFunction(openGitHubIssue, this.lastShownCopilotCompletionItem, telemetryArg);
+			await this.instantiationService.invokeFunction(openGitHubIssue, item, telemetryArg);
 		}));
 	}
 
-	trackItem(item: InlineCompletionItem) {
+	trackItem(item: GhostTextCompletionItem) {
 		this.lastShownCopilotCompletionItem = item;
 	}
 }
 
 async function openGitHubIssue(
 	accessor: ServicesAccessor,
-	item: InlineCompletionItem | undefined,
+	item: GhostTextCompletionItem | undefined,
 	telemetry: TelemetryData | undefined
 ) {
 	const body = generateGitHubIssueBody(accessor, item, telemetry);
@@ -55,7 +51,7 @@ async function openGitHubIssue(
 
 function generateGitHubIssueBody(
 	accessor: ServicesAccessor,
-	item: InlineCompletionItem | undefined,
+	item: GhostTextCompletionItem | undefined,
 	telemetry: TelemetryData | undefined
 ) {
 	const diagnostics = collectCompletionDiagnostics(accessor, telemetry);

--- a/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/copilotCompletionFeedbackTracker.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/copilotCompletionFeedbackTracker.ts
@@ -54,7 +54,7 @@ function generateGitHubIssueBody(
 	item: GhostTextCompletionItem | undefined,
 	telemetry: TelemetryData | undefined
 ) {
-	const diagnostics = collectCompletionDiagnostics(accessor, telemetry);
+	const diagnostics = collectCompletionDiagnostics(accessor, telemetry, item?.opportunityId);
 	const formattedDiagnostics = formatDiagnosticsAsMarkdown(diagnostics);
 	if (typeof item?.insertText !== 'string') {
 		return '';

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/diagnostics.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/diagnostics.ts
@@ -23,13 +23,13 @@ interface Section {
 	items: SectionItems;
 }
 
-export function collectCompletionDiagnostics(accessor: ServicesAccessor, telemetry: TelemetryData | undefined, requestUuid?: string): Report {
+export function collectCompletionDiagnostics(accessor: ServicesAccessor, telemetry: TelemetryData | undefined, opportunityId?: string): Report {
 	const telemetryItems: SectionItems = {};
-	// The request UUID (VS Code core's `InlineCompletionContext.requestUuid`) is sourced from the shown
+	// The opportunity ID (VS Code core's `InlineCompletionContext.requestUuid`) is sourced from the shown
 	// item rather than `telemetry.properties.opportunityId`, since the latter can be stale for cached or
 	// typing-as-suggested completions whose telemetry is derived from an earlier request.
-	if (requestUuid) {
-		telemetryItems['Request UUID'] = requestUuid;
+	if (opportunityId) {
+		telemetryItems['Opportunity ID'] = opportunityId;
 	}
 	if (telemetry !== undefined) {
 		if (telemetry.properties.headerRequestId) {
@@ -37,9 +37,6 @@ export function collectCompletionDiagnostics(accessor: ServicesAccessor, telemet
 		}
 		if (telemetry.properties.choiceIndex) {
 			telemetryItems['Choice Index'] = telemetry.properties.choiceIndex;
-		}
-		if (telemetry.properties.opportunityId) {
-			telemetryItems['Opportunity ID'] = telemetry.properties.opportunityId;
 		}
 		if (telemetry.properties.clientCompletionId) {
 			telemetryItems['Client Completion ID'] = telemetry.properties.clientCompletionId;

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/diagnostics.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/diagnostics.ts
@@ -23,8 +23,14 @@ interface Section {
 	items: SectionItems;
 }
 
-export function collectCompletionDiagnostics(accessor: ServicesAccessor, telemetry: TelemetryData | undefined): Report {
+export function collectCompletionDiagnostics(accessor: ServicesAccessor, telemetry: TelemetryData | undefined, requestUuid?: string): Report {
 	const telemetryItems: SectionItems = {};
+	// The request UUID (VS Code core's `InlineCompletionContext.requestUuid`) is sourced from the shown
+	// item rather than `telemetry.properties.opportunityId`, since the latter can be stale for cached or
+	// typing-as-suggested completions whose telemetry is derived from an earlier request.
+	if (requestUuid) {
+		telemetryItems['Request UUID'] = requestUuid;
+	}
 	if (telemetry !== undefined) {
 		if (telemetry.properties.headerRequestId) {
 			telemetryItems['Header Request ID'] = telemetry.properties.headerRequestId;

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/test/diagnostics.test.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/test/diagnostics.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ServicesAccessor } from '../../../../../../util/vs/platform/instantiation/common/instantiation';
+import { BuildInfo } from '../config';
+import { collectCompletionDiagnostics, formatDiagnosticsAsMarkdown } from '../diagnostics';
+import { TelemetryWithExp } from '../telemetry';
+import { createLibTestingContext } from './context';
+
+suite('collectCompletionDiagnostics', function () {
+	let accessor: ServicesAccessor;
+
+	setup(function () {
+		accessor = createLibTestingContext().createTestingAccessor();
+	});
+
+	test('includes the request UUID alongside the telemetry fields', function () {
+		const telemetry = TelemetryWithExp.createEmptyConfigForTesting();
+		telemetry.properties.headerRequestId = 'header-123';
+		telemetry.properties.choiceIndex = '0';
+		// A different value than the passed request UUID to prove the two are sourced independently.
+		telemetry.properties.opportunityId = 'stale-opportunity-id';
+		telemetry.properties.clientCompletionId = 'client-abc';
+		telemetry.properties.engineName = 'test-model';
+
+		const report = collectCompletionDiagnostics(accessor, telemetry, 'icr-current-uuid');
+
+		assert.deepStrictEqual(report.sections, [
+			{
+				name: 'Copilot Extension',
+				items: {
+					Version: BuildInfo.getVersion(),
+					Editor: 'lib-tests-editor 1',
+					'Request UUID': 'icr-current-uuid',
+					'Header Request ID': 'header-123',
+					'Choice Index': '0',
+					'Opportunity ID': 'stale-opportunity-id',
+					'Client Completion ID': 'client-abc',
+					'Model ID': 'test-model',
+				},
+			},
+		]);
+		assert.ok(formatDiagnosticsAsMarkdown(report).includes('- Request UUID: icr-current-uuid'));
+	});
+
+	test('includes the request UUID even when no telemetry is available', function () {
+		const report = collectCompletionDiagnostics(accessor, undefined, 'icr-only');
+
+		assert.deepStrictEqual(report.sections, [
+			{
+				name: 'Copilot Extension',
+				items: {
+					Version: BuildInfo.getVersion(),
+					Editor: 'lib-tests-editor 1',
+					'Request UUID': 'icr-only',
+				},
+			},
+		]);
+	});
+});

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/test/diagnostics.test.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/test/diagnostics.test.ts
@@ -17,11 +17,11 @@ suite('collectCompletionDiagnostics', function () {
 		accessor = createLibTestingContext().createTestingAccessor();
 	});
 
-	test('includes the request UUID alongside the telemetry fields', function () {
+	test('includes the opportunity ID alongside the telemetry fields', function () {
 		const telemetry = TelemetryWithExp.createEmptyConfigForTesting();
 		telemetry.properties.headerRequestId = 'header-123';
 		telemetry.properties.choiceIndex = '0';
-		// A different value than the passed request UUID to prove the two are sourced independently.
+		// A stale value that must be ignored: the opportunity ID comes from the item, not from telemetry.
 		telemetry.properties.opportunityId = 'stale-opportunity-id';
 		telemetry.properties.clientCompletionId = 'client-abc';
 		telemetry.properties.engineName = 'test-model';
@@ -34,19 +34,18 @@ suite('collectCompletionDiagnostics', function () {
 				items: {
 					Version: BuildInfo.getVersion(),
 					Editor: 'lib-tests-editor 1',
-					'Request UUID': 'icr-current-uuid',
+					'Opportunity ID': 'icr-current-uuid',
 					'Header Request ID': 'header-123',
 					'Choice Index': '0',
-					'Opportunity ID': 'stale-opportunity-id',
 					'Client Completion ID': 'client-abc',
 					'Model ID': 'test-model',
 				},
 			},
 		]);
-		assert.ok(formatDiagnosticsAsMarkdown(report).includes('- Request UUID: icr-current-uuid'));
+		assert.ok(formatDiagnosticsAsMarkdown(report).includes('- Opportunity ID: icr-current-uuid'));
 	});
 
-	test('includes the request UUID even when no telemetry is available', function () {
+	test('includes the opportunity ID even when no telemetry is available', function () {
 		const report = collectCompletionDiagnostics(accessor, undefined, 'icr-only');
 
 		assert.deepStrictEqual(report.sections, [
@@ -55,7 +54,7 @@ suite('collectCompletionDiagnostics', function () {
 				items: {
 					Version: BuildInfo.getVersion(),
 					Editor: 'lib-tests-editor 1',
-					'Request UUID': 'icr-only',
+					'Opportunity ID': 'icr-only',
 				},
 			},
 		]);


### PR DESCRIPTION
The "Send Copilot Completion Feedback" command opens a prefilled GitHub issue with a diagnostics section so we can triage completion problems. Two issues motivated this change:

1. **The telemetry section was silently empty.** The tracker still read telemetry from `item.command?.arguments?.[0].telemetry`, a shape that only existed in the old standalone completions extension. After the move to the unified inline-completions provider the shown item is a `GhostTextCompletionItem` with no `command`, so extraction always returned `undefined` and the report showed no Header Request ID, Choice Index, Opportunity ID, etc.
2. **Reports had no request UUID.** There was no easy way to correlate a feedback report with editor logs and server-side telemetry for a specific request.

## What this does

- **Fix (commit 1):** Type the tracked item as `GhostTextCompletionItem` and read telemetry from `item.copilotCompletion.telemetry`, restoring the telemetry section.
- **Feature (commit 2):** Add a "Request UUID" line to the diagnostics, sourced from `item.opportunityId` (VS Code core's `InlineCompletionContext.requestUuid`).

## Notes for reviewers

- The request UUID is intentionally sourced from `item.opportunityId` rather than `telemetry.properties.opportunityId`. The telemetry property is built from the completion's original `choice.telemetryData`, so for cached or typing-as-suggested completions it can be a stale request id. The existing "Opportunity ID" line (from telemetry) is kept as a separate field since it matches core telemetry terminology and usually equals the request UUID.
- The two commits are independent and can be reviewed separately; the fix does not depend on the feature.
- Adds unit tests for `collectCompletionDiagnostics` covering the new line and the stale-source guard (the first tests for this file).

## How to test

1. Trigger a Copilot inline completion, then run "Send Copilot Completion Feedback".
2. Confirm the prefilled issue's Diagnostics section now shows a populated "Copilot Extension" block including a "Request UUID" line plus the telemetry fields (Header Request ID, Choice Index, Opportunity ID, Client Completion ID, Model ID).