### PR TITLE
Update subagent pill click behavior for single subagent case

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/sessionRunningSubagentsControl.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionRunningSubagentsControl.ts
@@ -55,7 +55,7 @@ export class SessionRunningSubagentsControl extends Disposable {
 		this.element = $('.session-running-subagents');
 		this._button = this._register(new Button(this.element, { secondary: true, supportIcons: true, ...defaultButtonStyles }));
 		this._button.element.classList.add('session-running-subagents-button');
-		this._register(this._button.onDidClick(() => this._showMenu()));
+		this._register(this._button.onDidClick(() => this._onDidClick()));
 		this._setVisible(false);
 	}
 
@@ -124,6 +124,18 @@ export class SessionRunningSubagentsControl extends Disposable {
 			this._button.label = `$(${Codicon.loading.id}~spin) ${localize('runningSubagents.running', "{0} subagents running", count)}`;
 		}
 		this._setVisible(count > 0);
+	}
+
+	private _onDidClick(): void {
+		const session = this._session;
+		if (!session || this._subagents.length === 0) {
+			return;
+		}
+		if (this._subagents.length === 1) {
+			this.sessionsService.openChat(session, this._subagents[0].chat.resource);
+			return;
+		}
+		this._showMenu();
 	}
 
 	private _showMenu(): void {


### PR DESCRIPTION
This pull request modifies the behavior of the running subagents pill in the chat interface. 

- The click handler has been updated to route through a new `_onDidClick()` method.
- If there is only one running subagent, clicking the pill will now directly open that subagent's chat instead of displaying a dropdown menu.
- If there are two or more subagents, the existing `_showMenu()` context menu will still be shown.

This change improves user experience by streamlining access to a single subagent's chat. Note that type checks could not be run in this worktree due to missing dependencies, but the change is small and self-contained, leveraging existing methods for functionality.