### PR TITLE
agentPlugins: align plugin MCP root handling

### DIFF
--- a/src/vs/platform/agentPlugins/common/pluginParsers.ts
+++ b/src/vs/platform/agentPlugins/common/pluginParsers.ts
@@ -135,8 +135,8 @@ export interface IPluginFormatConfig {
 	readonly format: PluginFormat;
 	readonly manifestPath: string;
 	readonly hookConfigPath: string;
-	readonly pluginRootToken: string | undefined;
-	readonly pluginRootEnvVar: string | undefined;
+	readonly pluginRootTokens: readonly string[];
+	readonly pluginRootEnvVars: readonly string[];
 	/** Parses hooks from a JSON object using the format's conventions. */
 	parseHooks(hookUri: URI, json: unknown, pluginUri: URI, workspaceRoot: URI | undefined, userHome: URI): IParsedHookGroup[];
 }
@@ -145,8 +145,8 @@ const COPILOT_FORMAT: IPluginFormatConfig = {
 	format: PluginFormat.Copilot,
 	manifestPath: 'plugin.json',
 	hookConfigPath: 'hooks.json',
-	pluginRootToken: undefined,
-	pluginRootEnvVar: undefined,
+	pluginRootTokens: ['${PLUGIN_ROOT}', '${CLAUDE_PLUGIN_ROOT}'],
+	pluginRootEnvVars: ['PLUGIN_ROOT', 'CLAUDE_PLUGIN_ROOT'],
 	parseHooks(hookUri, json, _pluginUri, workspaceRoot, userHome) {
 		return parseHooksJson(hookUri, json, workspaceRoot, userHome);
 	},
@@ -156,8 +156,8 @@ const CLAUDE_FORMAT: IPluginFormatConfig = {
 	format: PluginFormat.Claude,
 	manifestPath: '.claude-plugin/plugin.json',
 	hookConfigPath: 'hooks/hooks.json',
-	pluginRootToken: '${CLAUDE_PLUGIN_ROOT}',
-	pluginRootEnvVar: 'CLAUDE_PLUGIN_ROOT',
+	pluginRootTokens: ['${PLUGIN_ROOT}', '${CLAUDE_PLUGIN_ROOT}'],
+	pluginRootEnvVars: ['PLUGIN_ROOT', 'CLAUDE_PLUGIN_ROOT'],
 	parseHooks(hookUri, json, pluginUri, workspaceRoot, userHome) {
 		return interpolateHookPluginRoot(hookUri, json, pluginUri, workspaceRoot, userHome, '${CLAUDE_PLUGIN_ROOT}', 'CLAUDE_PLUGIN_ROOT');
 	},
@@ -167,8 +167,8 @@ const OPEN_PLUGIN_FORMAT: IPluginFormatConfig = {
 	format: PluginFormat.OpenPlugin,
 	manifestPath: '.plugin/plugin.json',
 	hookConfigPath: 'hooks/hooks.json',
-	pluginRootToken: '${PLUGIN_ROOT}',
-	pluginRootEnvVar: 'PLUGIN_ROOT',
+	pluginRootTokens: ['${PLUGIN_ROOT}', '${CLAUDE_PLUGIN_ROOT}'],
+	pluginRootEnvVars: ['PLUGIN_ROOT', 'CLAUDE_PLUGIN_ROOT'],
 	parseHooks(hookUri, json, pluginUri, workspaceRoot, userHome) {
 		return interpolateHookPluginRoot(hookUri, json, pluginUri, workspaceRoot, userHome, '${PLUGIN_ROOT}', 'PLUGIN_ROOT');
 	},
@@ -448,10 +448,10 @@ export function shellQuotePluginRootInCommand(command: string, fsPath: string, t
 export function interpolateMcpPluginRoot(
 	def: IMcpServerDefinition,
 	fsPath: string,
-	token: string,
-	envVar: string,
+	tokens: readonly string[],
+	envVars: readonly string[],
 ): IMcpServerDefinition {
-	const replace = (s: string) => s.replaceAll(token, fsPath);
+	const replace = (s: string) => tokens.reduce((result, token) => result.replaceAll(token, fsPath), s);
 
 	const config = def.configuration;
 	let interpolated: IMcpServerConfiguration;
@@ -471,7 +471,9 @@ export function interpolateMcpPluginRoot(
 				local.env[k] = replace(v);
 			}
 		}
-		local.env[envVar] = fsPath;
+		for (const envVar of envVars) {
+			local.env[envVar] = fsPath;
+		}
 		if (local.envFile) {
 			local.envFile = replace(local.envFile);
 		}
@@ -1094,8 +1096,9 @@ export function parseMcpServerDefinitionMap(
 			uri: definitionURI,
 			customization: makeMcpServerCustomization(definitionURI, name),
 		};
-		if (formatConfig.pluginRootToken && formatConfig.pluginRootEnvVar) {
-			def = interpolateMcpPluginRoot(def, pluginFsPath, formatConfig.pluginRootToken, formatConfig.pluginRootEnvVar);
+		def = interpolateMcpPluginRoot(def, pluginFsPath, formatConfig.pluginRootTokens, formatConfig.pluginRootEnvVars);
+		if (def.configuration.type === McpServerType.LOCAL && def.configuration.cwd === undefined) {
+			def = { ...def, configuration: { ...def.configuration, cwd: pluginFsPath } };
 		}
 		def = convertBareEnvVarsToVsCodeSyntax(def);
 		definitions.push(def);

--- a/src/vs/platform/agentPlugins/test/common/pluginParsers.test.ts
+++ b/src/vs/platform/agentPlugins/test/common/pluginParsers.test.ts
@@ -22,6 +22,7 @@ import {
 	resolveComponentDirs,
 	normalizeMcpServerConfiguration,
 	shellQuotePluginRootInCommand,
+	interpolateMcpPluginRoot,
 	convertBareEnvVarsToVsCodeSyntax,
 	toParsedAgent,
 	toParsedSkill,
@@ -238,6 +239,29 @@ suite('pluginParsers', () => {
 				'${PLUGIN_ROOT}'
 			);
 			assert.ok(!result.includes('""'), 'should not double-quote');
+		});
+	});
+
+	suite('interpolateMcpPluginRoot', () => {
+
+		test('replaces tokens and sets env vars without pairing array entries', () => {
+			const result = interpolateMcpPluginRoot({
+				name: 'test',
+				uri: URI.file('/plugin/.mcp.json'),
+				configuration: {
+					type: McpServerType.LOCAL,
+					command: '${PLUGIN_ROOT}/bin/server',
+					args: ['--data', '${CLAUDE_PLUGIN_ROOT}/data'],
+				},
+				customization: stubMcpCustomization(),
+			}, '/plugin', ['${PLUGIN_ROOT}', '${CLAUDE_PLUGIN_ROOT}'], ['PLUGIN_ROOT']);
+
+			assert.deepStrictEqual(result.configuration, {
+				type: McpServerType.LOCAL,
+				command: '/plugin/bin/server',
+				args: ['--data', '/plugin/data'],
+				env: { PLUGIN_ROOT: '/plugin' },
+			});
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/common/plugins/agentPluginFormatDetection.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/agentPluginFormatDetection.test.ts
@@ -16,6 +16,7 @@ import { InMemoryFileSystemProvider } from '../../../../../../platform/files/com
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { McpServerType } from '../../../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
 import { testWorkspace } from '../../../../../../platform/workspace/test/common/testWorkspace.js';
 import { TestContextService } from '../../../../../test/common/workbenchTestServices.js';
@@ -982,5 +983,70 @@ suite('AgentPlugin format detection', () => {
 		assert.ok(!config.command.includes('${CLAUDE_PLUGIN_ROOT}'), `Expected CLAUDE_PLUGIN_ROOT to be expanded in command, got: ${config.command}`);
 		assert.ok(!config.args[1].includes('${CLAUDE_PLUGIN_ROOT}'), `Expected CLAUDE_PLUGIN_ROOT to be expanded in args, got: ${config.args[1]}`);
 		assert.strictEqual(config.env['CLAUDE_PLUGIN_ROOT'], uri.fsPath, 'Expected CLAUDE_PLUGIN_ROOT env var to be set');
+	}));
+
+	test('Copilot Plugin MCP servers expand root aliases and default cwd to plugin root', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/copilot-mcp-root');
+		await writeFile('/plugins/copilot-mcp-root/plugin.json', JSON.stringify({ name: 'copilot-mcp-root' }));
+		await writeFile('/plugins/copilot-mcp-root/.mcp.json', JSON.stringify({
+			mcpServers: {
+				'copilot-server': {
+					command: '${PLUGIN_ROOT}/bin/server',
+					args: ['--data', '${CLAUDE_PLUGIN_ROOT}/data'],
+					env: { CONFIG_DIR: '${PLUGIN_ROOT}/etc' },
+				},
+				'explicit-cwd-server': {
+					command: 'node',
+					cwd: '/custom/cwd',
+				},
+			},
+		}));
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = getDiscoveredPlugins(discovery);
+		assert.strictEqual(plugins.length, 1);
+
+		await waitForState(plugins[0].mcpServerDefinitions, d => d.length === 2);
+		const servers = new Map(plugins[0].mcpServerDefinitions.get().map(server => [server.name, server.configuration]));
+		const defaultCwdConfig = servers.get('copilot-server');
+		assert.strictEqual(defaultCwdConfig?.type, McpServerType.LOCAL);
+		if (defaultCwdConfig?.type !== McpServerType.LOCAL) {
+			assert.fail('Expected a local MCP server configuration');
+		}
+		const explicitCwdConfig = servers.get('explicit-cwd-server');
+		assert.strictEqual(explicitCwdConfig?.type, McpServerType.LOCAL);
+		if (explicitCwdConfig?.type !== McpServerType.LOCAL) {
+			assert.fail('Expected a local MCP server configuration');
+		}
+		assert.deepStrictEqual({
+			defaultCwd: {
+				command: defaultCwdConfig.command,
+				args: defaultCwdConfig.args,
+				cwd: defaultCwdConfig.cwd,
+				env: defaultCwdConfig.env,
+			},
+			explicitCwd: {
+				command: explicitCwdConfig.command,
+				cwd: explicitCwdConfig.cwd,
+			},
+		}, {
+			defaultCwd: {
+				command: `${uri.fsPath}/bin/server`,
+				args: ['--data', `${uri.fsPath}/data`],
+				cwd: uri.fsPath,
+				env: {
+					CONFIG_DIR: `${uri.fsPath}/etc`,
+					PLUGIN_ROOT: uri.fsPath,
+					CLAUDE_PLUGIN_ROOT: uri.fsPath,
+				},
+			},
+			explicitCwd: {
+				command: 'node',
+				cwd: '/custom/cwd',
+			},
+		});
 	}));
 });


### PR DESCRIPTION
Fixes #323475

## What changed
- Default plugin-installed local MCP servers to run from the plugin root when `cwd` is not explicitly set.
- Expand both `${PLUGIN_ROOT}` and `${CLAUDE_PLUGIN_ROOT}` aliases for MCP definitions across all plugin formats.
- Add parser and discovery regression coverage, including explicit `cwd` preservation.

## Validation
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `./scripts/test.sh --run src/vs/platform/agentPlugins/test/common/pluginParsers.test.ts --grep "replaces tokens and sets env vars without pairing array entries"`
- `./scripts/test.sh --run src/vs/workbench/contrib/chat/test/common/plugins/agentPluginFormatDetection.test.ts --grep "Copilot Plugin MCP servers expand root aliases and default cwd to plugin root"`
- `git diff --check`