### PR TITLE
fix: read OS clipboard file paths per platform for explorer paste

### DIFF
--- a/src/vs/platform/native/common/native.ts
+++ b/src/vs/platform/native/common/native.ts
@@ -265,6 +265,7 @@ export interface ICommonNativeHostService {
 	readClipboardBuffer(format: string): Promise<VSBuffer>;
 	hasClipboard(format: string, type?: 'selection' | 'clipboard'): Promise<boolean>;
 	readImage(): Promise<Uint8Array>;
+	readClipboardFilePaths(): Promise<string[]>;
 
 	// macOS Touchbar
 	newWindowTab(): Promise<void>;

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -1028,6 +1028,59 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 		return VSBuffer.wrap(clipboard.readBuffer(format));
 	}
 
+	async readClipboardFilePaths(windowId: number | undefined): Promise<string[]> {
+		const paths: string[] = [];
+		if (isWindows) {
+			const buffer = clipboard.readBuffer('FileNameW');
+			if (buffer.length === 0) {
+				return [];
+			}
+			const rawPath = buffer.toString('ucs2').replace(/\0+$/, '');
+			if (!rawPath) {
+				return [];
+			}
+			try {
+				paths.push(URI.file(rawPath).fsPath);
+			} catch (error) {
+				this.logService.trace(`[readClipboardFilePaths] failed to parse path: ${rawPath}`, error);
+			}
+			return paths;
+		}
+		if (isMacintosh) {
+			const rawURI = clipboard.read('public.file-url');
+			if (!rawURI) {
+				return [];
+			}
+			const trimmed = rawURI.trim();
+			try {
+				paths.push(URI.parse(trimmed).fsPath);
+			} catch (error) {
+				this.logService.trace(`[readClipboardFilePaths] failed to parse URI: ${trimmed}`, error);
+			}
+			return paths;
+		}
+		if (isLinux) {
+			const rawURI = clipboard.read('text/uri-list');
+			if (!rawURI) {
+				return [];
+			}
+			const lines = rawURI.split(/[\r\n]+/);
+			for (const line of lines) {
+				const trimmed = line.trim();
+				if (!trimmed || trimmed[0] === '#') {
+					continue;
+				}
+				try {
+					paths.push(URI.parse(trimmed).fsPath);
+				} catch (error) {
+					this.logService.trace(`[readClipboardFilePaths] failed to parse URI: ${trimmed}`, error);
+				}
+			}
+			return paths;
+		}
+		return [];
+	}
+
 	async hasClipboard(windowId: number | undefined, format: string, type?: 'selection' | 'clipboard'): Promise<boolean> {
 		return clipboard.has(format, type);
 	}

--- a/src/vs/workbench/services/clipboard/electron-browser/clipboardService.ts
+++ b/src/vs/workbench/services/clipboard/electron-browser/clipboardService.ts
@@ -62,11 +62,24 @@ export class NativeClipboardService implements IClipboardService {
 	}
 
 	async readResources(): Promise<URI[]> {
-		return this.bufferToResources(await this.nativeHostService.readClipboardBuffer(NativeClipboardService.FILE_FORMAT));
+		const internalBuffer = await this.nativeHostService.readClipboardBuffer(NativeClipboardService.FILE_FORMAT);
+		const internalResources = this.bufferToResources(internalBuffer);
+		if (internalResources.length > 0) {
+			return internalResources;
+		}
+
+		const nativePaths = await this.nativeHostService.readClipboardFilePaths();
+		return nativePaths.map(path => URI.file(path));
 	}
 
 	async hasResources(): Promise<boolean> {
-		return this.nativeHostService.hasClipboard(NativeClipboardService.FILE_FORMAT);
+		const hasInternal = await this.nativeHostService.hasClipboard(NativeClipboardService.FILE_FORMAT);
+		if (hasInternal) {
+			return true;
+		}
+
+		const nativePaths = await this.nativeHostService.readClipboardFilePaths();
+		return nativePaths.length > 0;
 	}
 
 	private resourcesToBuffer(resources: URI[]): VSBuffer {

--- a/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
@@ -183,6 +183,7 @@ export class TestNativeHostService implements INativeHostService {
 	async triggerPaste(options?: INativeHostOptions): Promise<void> { }
 	async readImage(): Promise<Uint8Array> { return Uint8Array.from([]); }
 	async readClipboardBuffer(format: string): Promise<VSBuffer> { return VSBuffer.wrap(Uint8Array.from([])); }
+	async readClipboardFilePaths(): Promise<string[]> { return []; }
 	async hasClipboard(format: string, type?: 'selection' | 'clipboard' | undefined): Promise<boolean> { return false; }
 	async windowsGetStringRegKey(hive: 'HKEY_CURRENT_USER' | 'HKEY_LOCAL_MACHINE' | 'HKEY_CLASSES_ROOT' | 'HKEY_USERS' | 'HKEY_CURRENT_CONFIG', path: string, name: string): Promise<string | undefined> { return undefined; }
 	async createZipFile(zipPath: URI, files: { path: string; contents: string }[]): Promise<void> { }


### PR DESCRIPTION
## Summary

Fixes #323997: copying a file in the OS file manager and pasting it into the
VS Code Explorer silently does nothing.

`NativeClipboardService.readResources()` only ever read VS Code's own internal
clipboard buffer (`CodeFiles`), which is written when copying inside VS Code.
Files copied in the host file manager are never in that buffer, so paste had
nothing to work with.

## The fix

Adds `readClipboardFilePaths()` to the native host service as a fallback in
`readResources()`/`hasResources()`: when the internal buffer is empty, read the
file paths the OS file manager actually put on the clipboard.

Each platform exposes those paths under a different format, so the
implementation branches:

- **Linux**: `clipboard.read('text/uri-list')`, one URI per line per RFC 2483.
  Verified under Wayland; the format is populated by the file manager, not by
  the display server.
- **Windows**: `clipboard.readBuffer('FileNameW')`, decoded as UTF-16.
- **macOS**: `clipboard.read('public.file-url')`.

Each line/path goes through `URI.parse()`/`URI.file()` inside a try/catch, so a
malformed entry is skipped and logged rather than rejecting the whole
`readResources()` promise.

## Why not `text/uri-list` everywhere

`text/uri-list` looked like a cross-platform answer, and on Windows
`clipboard.availableFormats()` does report it after copying a file in Explorer.
But `read('text/uri-list')` returns an empty string and
`readBuffer('text/uri-list')` returns 0 bytes — this is electron/electron#39853.
`FileNameW` is populated and readable, so Windows uses that instead.

`readBuffer` rather than `read` for `FileNameW`: `read()` returns each byte as a
separate character (`"C\0:\0\\\0U\0..."`). Stripping the NUL bytes works for
ASCII paths but corrupts any path with characters outside Latin-1.
`readBuffer(...).toString('ucs2')` decodes the UTF-16 correctly.

## Testing

- **Linux** (niri, Wayland compositor): verified working. Copy a file in the
  file manager, focus the Explorer, Ctrl+V — the file is pasted.
- **Windows 11**: verified working, same steps in Explorer.
- **macOS**: not tested — I don't have access to a machine. The
  `public.file-url` branch is written from the documented format name but is
  unverified. Would appreciate someone with a Mac confirming it.

## Known limitation

`FileNameW` carries a single path, so on Windows this handles pasting one file.
Multi-select would need `CF_HDROP`, which Electron's clipboard API does not
expose under that name. #323997 describes the single-file case; multi-select
would be worth a follow-up.