### PR TITLE
Preserve focus on stepping and take focus on breakpoint hit

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/callStackView.ts
+++ b/src/vs/workbench/contrib/debug/browser/callStackView.ts
@@ -141,10 +141,7 @@ async function expandTo(session: IDebugSession, tree: WorkbenchCompressibleAsync
 	if (session.parentSession) {
 		await expandTo(session.parentSession, tree);
 	}
-	// Refresh the session's children before expanding. This ensures that if the session was
-	// previously expanded with empty or stale children (e.g. the thread was running when it
-	// was last expanded), the children are reloaded so that stack frames are present in the
-	// tree's nodes map and can be selected via setSelection().
+	// Refresh children before expanding so setSelection() can find stack frames even after a stale/empty expansion
 	await tree.updateChildren(session);
 	await tree.expand(session);
 }

--- a/src/vs/workbench/contrib/debug/browser/callStackView.ts
+++ b/src/vs/workbench/contrib/debug/browser/callStackView.ts
@@ -141,6 +141,11 @@ async function expandTo(session: IDebugSession, tree: WorkbenchCompressibleAsync
 	if (session.parentSession) {
 		await expandTo(session.parentSession, tree);
 	}
+	// Refresh the session's children before expanding. This ensures that if the session was
+	// previously expanded with empty or stale children (e.g. the thread was running when it
+	// was last expanded), the children are reloaded so that stack frames are present in the
+	// tree's nodes map and can be selected via setSelection().
+	await tree.updateChildren(session);
 	await tree.expand(session);
 }
 
@@ -419,24 +424,38 @@ export class CallStackView extends ViewPane {
 			return;
 		}
 
+		const thread = this.debugService.getViewModel().focusedThread;
+		const revealElement = (element: IStackFrame | IDebugSession) => {
+			// If the element is outside of the screen bounds, position it in the middle
+			if (this.tree.getRelativeTop(element) === null) {
+				this.tree.reveal(element, 0.5);
+			} else {
+				this.tree.reveal(element);
+			}
+		};
 		const updateSelectionAndReveal = (element: IStackFrame | IDebugSession) => {
 			this.ignoreSelectionChangedEvent = true;
 			try {
 				this.tree.setSelection([element]);
-				// If the element is outside of the screen bounds,
-				// position it in the middle
-				if (this.tree.getRelativeTop(element) === null) {
-					this.tree.reveal(element, 0.5);
-				} else {
-					this.tree.reveal(element);
+				revealElement(element);
+			} catch (e) {
+				// The element may not be in the tree — e.g. when two concurrent fetchCallStack
+				// calls created different StackFrame instances. Fall back to the thread's
+				// current top frame which is guaranteed to match what is in the tree.
+				if (thread && element instanceof StackFrame) {
+					const freshFrame = thread.getTopStackFrame();
+					if (freshFrame && freshFrame !== element) {
+						try {
+							this.tree.setSelection([freshFrame]);
+							revealElement(freshFrame);
+						} catch (e2) { }
+					}
 				}
-			} catch (e) { }
-			finally {
+			} finally {
 				this.ignoreSelectionChangedEvent = false;
 			}
 		};
 
-		const thread = this.debugService.getViewModel().focusedThread;
 		const session = this.debugService.getViewModel().focusedSession;
 		const stackFrame = this.debugService.getViewModel().focusedStackFrame;
 		if (!thread) {

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -1637,7 +1637,7 @@ export class DebugSession implements IDebugSession {
  * Returns whether the given stopped reason indicates that a thread hit a breakpoint
  * (of any kind) or an exception. Such stops should always grab focus, even across sessions.
  */
-function stoppedOnBreakpointOrException(reason: string | undefined): boolean {
+export function stoppedOnBreakpointOrException(reason: string | undefined): boolean {
 	switch (reason) {
 		case 'breakpoint':
 		case 'function breakpoint':

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -742,7 +742,12 @@ export class DebugSession implements IDebugSession {
 
 		this.setLastSteppingGranularity(threadId, granularity);
 		this.steppingThreadIds.add(threadId);
-		await this.raw.next({ threadId, granularity });
+		try {
+			await this.raw.next({ threadId, granularity });
+		} catch (e) {
+			this.steppingThreadIds.delete(threadId);
+			throw e;
+		}
 	}
 
 	async stepIn(threadId: number, targetId?: number, granularity?: DebugProtocol.SteppingGranularity): Promise<void> {
@@ -753,7 +758,12 @@ export class DebugSession implements IDebugSession {
 
 		this.setLastSteppingGranularity(threadId, granularity);
 		this.steppingThreadIds.add(threadId);
-		await this.raw.stepIn({ threadId, targetId, granularity });
+		try {
+			await this.raw.stepIn({ threadId, targetId, granularity });
+		} catch (e) {
+			this.steppingThreadIds.delete(threadId);
+			throw e;
+		}
 	}
 
 	async stepOut(threadId: number, granularity?: DebugProtocol.SteppingGranularity): Promise<void> {
@@ -764,7 +774,12 @@ export class DebugSession implements IDebugSession {
 
 		this.setLastSteppingGranularity(threadId, granularity);
 		this.steppingThreadIds.add(threadId);
-		await this.raw.stepOut({ threadId, granularity });
+		try {
+			await this.raw.stepOut({ threadId, granularity });
+		} catch (e) {
+			this.steppingThreadIds.delete(threadId);
+			throw e;
+		}
 	}
 
 	async stepBack(threadId: number, granularity?: DebugProtocol.SteppingGranularity): Promise<void> {
@@ -775,7 +790,12 @@ export class DebugSession implements IDebugSession {
 
 		this.setLastSteppingGranularity(threadId, granularity);
 		this.steppingThreadIds.add(threadId);
-		await this.raw.stepBack({ threadId, granularity });
+		try {
+			await this.raw.stepBack({ threadId, granularity });
+		} catch (e) {
+			this.steppingThreadIds.delete(threadId);
+			throw e;
+		}
 	}
 
 	async continue(threadId: number): Promise<void> {

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -75,6 +75,7 @@ export class DebugSession implements IDebugSession {
 	});
 	private passFocusScheduler: RunOnceScheduler;
 	private lastContinuedThreadId: number | undefined;
+	private readonly steppingThreadIds = new Set<number>();
 	private repl: ReplModel;
 	private stoppedDetails: IRawStoppedDetails[] = [];
 	private readonly statusQueue = this.rawListeners.add(new ThreadStatusScheduler());
@@ -740,6 +741,7 @@ export class DebugSession implements IDebugSession {
 		}
 
 		this.setLastSteppingGranularity(threadId, granularity);
+		this.steppingThreadIds.add(threadId);
 		await this.raw.next({ threadId, granularity });
 	}
 
@@ -750,6 +752,7 @@ export class DebugSession implements IDebugSession {
 		}
 
 		this.setLastSteppingGranularity(threadId, granularity);
+		this.steppingThreadIds.add(threadId);
 		await this.raw.stepIn({ threadId, targetId, granularity });
 	}
 
@@ -760,6 +763,7 @@ export class DebugSession implements IDebugSession {
 		}
 
 		this.setLastSteppingGranularity(threadId, granularity);
+		this.steppingThreadIds.add(threadId);
 		await this.raw.stepOut({ threadId, granularity });
 	}
 
@@ -770,6 +774,7 @@ export class DebugSession implements IDebugSession {
 		}
 
 		this.setLastSteppingGranularity(threadId, granularity);
+		this.steppingThreadIds.add(threadId);
 		await this.raw.stepBack({ threadId, granularity });
 	}
 
@@ -1159,8 +1164,13 @@ export class DebugSession implements IDebugSession {
 			});
 
 			// We need to pass focus to other sessions / threads with a timeout in case a quick stop event occurs #130321
+			// However, when this continue was caused by a step request (next / stepIn / stepOut / stepBack) we keep
+			// the focus on the thread being stepped so it does not swap to another stopped session / thread.
+			const isStepping = this.steppingThreadIds.has(event.body.threadId);
 			this.lastContinuedThreadId = allThreads ? undefined : event.body.threadId;
-			this.passFocusScheduler.schedule();
+			if (!isStepping) {
+				this.passFocusScheduler.schedule();
+			}
 			this._onDidChangeState.fire();
 		}));
 
@@ -1366,6 +1376,9 @@ export class DebugSession implements IDebugSession {
 			async (threadId, token) => {
 				const hasLotsOfThreads = event.threadId === undefined && this.threadIds.length > 10;
 
+				// The thread has stopped again, so it is no longer stepping.
+				this.steppingThreadIds.delete(threadId);
+
 				// If the focus for the current session is on a non-existent thread, clear the focus.
 				const focusedThread = this.debugService.getViewModel().focusedThread;
 				const focusedThreadDoesNotExist = focusedThread !== undefined && focusedThread.session === this && !this.threads.has(focusedThread.threadId);
@@ -1382,8 +1395,9 @@ export class DebugSession implements IDebugSession {
 					const focus = async () => {
 						if (focusedThreadDoesNotExist || (!event.preserveFocusHint && thread.getCallStack().length)) {
 							const focusedStackFrame = this.debugService.getViewModel().focusedStackFrame;
-							if (!focusedStackFrame || focusedStackFrame.thread.session === this) {
-								// Only take focus if nothing is focused, or if the focus is already on the current session
+							// Take focus if nothing is focused, if the focus is already on the current session,
+							// or if this thread hit a breakpoint or exception
+							if (!focusedStackFrame || focusedStackFrame.thread.session === this || stoppedOnBreakpointOrException(thread.stoppedDetails?.reason)) {
 								const preserveFocus = !this.configurationService.getValue<IDebugConfiguration>('debug').focusEditorOnBreak;
 								await this.debugService.focusStackFrame(undefined, thread, undefined, { preserveFocus });
 							}
@@ -1596,6 +1610,23 @@ export class DebugSession implements IDebugSession {
 		if (isImportant) {
 			this.notificationService.notify({ message: data.output.toString(), severity: data.sev, source: this.name });
 		}
+	}
+}
+
+/**
+ * Returns whether the given stopped reason indicates that a thread hit a breakpoint
+ * (of any kind) or an exception. Such stops should always grab focus, even across sessions.
+ */
+function stoppedOnBreakpointOrException(reason: string | undefined): boolean {
+	switch (reason) {
+		case 'breakpoint':
+		case 'function breakpoint':
+		case 'data breakpoint':
+		case 'instruction breakpoint':
+		case 'exception':
+			return true;
+		default:
+			return false;
 	}
 }
 

--- a/src/vs/workbench/contrib/debug/test/browser/debugSession.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/debugSession.test.ts
@@ -4,8 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { Emitter, Event } from '../../../../../base/common/event.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { ThreadStatusScheduler } from '../../browser/debugSession.js';
+import { DebugSession, ThreadStatusScheduler, stoppedOnBreakpointOrException } from '../../browser/debugSession.js';
+import { RawDebugSession } from '../../browser/rawDebugSession.js';
+import { createTestSession } from './callStack.test.js';
+import { createMockDebugModel } from './mockDebugModel.js';
 
 
 suite('DebugSession - ThreadStatusScheduler', () => {
@@ -105,5 +109,103 @@ suite('DebugSession - ThreadStatusScheduler', () => {
 		});
 
 		assert.strictEqual(innerCalled, false);
+	});
+});
+
+suite('stoppedOnBreakpointOrException', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('returns true for breakpoint and exception reasons', () => {
+		assert.deepStrictEqual(
+			['breakpoint', 'function breakpoint', 'data breakpoint', 'instruction breakpoint', 'exception']
+				.map(r => stoppedOnBreakpointOrException(r)),
+			[true, true, true, true, true]
+		);
+	});
+
+	test('returns false for non-breakpoint reasons', () => {
+		assert.deepStrictEqual(
+			['step', 'pause', 'goto', 'entry', undefined].map(r => stoppedOnBreakpointOrException(r)),
+			[false, false, false, false, false]
+		);
+	});
+});
+
+suite('DebugSession - steppingThreadIds', () => {
+	const ds = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function setup(): { session: DebugSession; fireContinued: (threadId: number) => void } {
+		const model = createMockDebugModel(ds);
+		const session = ds.add(createTestSession(model));
+
+		// Use direct Emitters to avoid AbstractDebugAdapter.processQueue's timeout(0) calls
+		// which create CancellationToken disposables that interfere with leak tracking.
+		const onDidContinuedEmitter = ds.add(new Emitter<any>());
+		const mockRaw = {
+			onDidInitialize: Event.None,
+			onDidStop: Event.None,
+			onDidThread: Event.None,
+			onDidTerminateDebugee: Event.None,
+			onDidContinued: onDidContinuedEmitter.event,
+			onDidOutput: Event.None,
+			onDidBreakpoint: Event.None,
+			onDidLoadedSource: Event.None,
+			onDidCustomEvent: Event.None,
+			onDidProgressStart: Event.None,
+			onDidProgressUpdate: Event.None,
+			onDidProgressEnd: Event.None,
+			onDidInvalidateMemory: Event.None,
+			onDidInvalidated: Event.None,
+			onDidExitAdapter: Event.None,
+			// eslint-disable-next-line local/code-no-any-casts
+			next: (_args: any) => Promise.resolve({} as any),
+			// eslint-disable-next-line local/code-no-any-casts
+			threads: () => Promise.resolve({ seq: 0, type: 'response' as const, request_seq: 0, command: 'threads', success: true, body: { threads: [] } } as any),
+			capabilities: {},
+		} as unknown as RawDebugSession;
+
+		session.initializeForTest(mockRaw);
+
+		return {
+			session,
+			fireContinued: (threadId: number) => onDidContinuedEmitter.fire({ seq: 0, type: 'event', event: 'continued', body: { threadId, allThreadsContinued: false } }),
+		};
+	}
+
+	test('step commands add thread id to steppingThreadIds', async () => {
+		const { session } = setup();
+
+		await session.next(1);
+
+		// steppingThreadIds retains the id until the next stopped event clears it
+		// eslint-disable-next-line local/code-no-any-casts
+		assert.strictEqual((session as any).steppingThreadIds.has(1), true);
+	});
+
+	test('continued event while stepping suppresses passFocusScheduler', async () => {
+		const { session, fireContinued } = setup();
+
+		// Simulate a step being in progress for thread 1
+		// eslint-disable-next-line local/code-no-any-casts
+		(session as any).steppingThreadIds.add(1);
+
+		const stateChanged = Event.toPromise(session.onDidChangeState);
+		fireContinued(1);
+		await stateChanged;
+
+		// eslint-disable-next-line local/code-no-any-casts
+		assert.strictEqual((session as any).passFocusScheduler.isScheduled(), false);
+	});
+
+	test('continued event without stepping schedules passFocusScheduler', async () => {
+		const { session, fireContinued } = setup();
+
+		// Thread 1 is NOT in steppingThreadIds (plain continue, not a step)
+		const stateChanged = Event.toPromise(session.onDidChangeState);
+		fireContinued(1);
+		await stateChanged;
+
+		// eslint-disable-next-line local/code-no-any-casts
+		assert.strictEqual((session as any).passFocusScheduler.isScheduled(), true);
 	});
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #322448 

During multi-target debugging, these changes will prevent focus from passing to another thread if you step a thread that does not stop again fast enough. Also, if any threads hit a breakpoint, the focus will be passed to the thread that hit the breakpoint since the user will likely want to focus on it.