### PR TITLE
Optically center chat send button icon

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1091,6 +1091,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	transform: translateX(-0.5px);
 }
 
+.interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item > .action-label.codicon-newline::before {
+	display: inline-block;
+	transform: translateY(0.5px);
+}
+
 /* Focus indicator drawn on the action-item wrapper so it sits cleanly around
 	the button surface with a small offset. */
 .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled):has(> .action-label.codicon-arrow-up:focus-visible) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes: https://github.com/microsoft/vscode/issues/324633

Optically centers the chat send button icon within the button (when hover styles are shown).

https://github.com/user-attachments/assets/e3644be5-8ed4-43b3-9ab7-adff80b3a6d2