### PR TITLE
Hide Tools Marketplace in sessions window

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -69,6 +69,8 @@ The management editor opens as a compact modal editor. The modal title and welco
 
 The first sidebar entry is a static `Overview` navigation item. It is styled like the other sidebar labels and does not mirror the active harness label; harness identity is represented by the modal title and welcome heading instead.
 
+The Tools section can browse the Marketplace in the core workbench, where extension gallery browsing and installation are available. The Sessions window hides Tools Marketplace browsing and only shows the tool enablement list.
+
 ### IAICustomizationWorkspaceService
 
 The `IAICustomizationWorkspaceService` interface controls per-window behavior:

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/toolsListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/toolsListWidget.ts
@@ -146,7 +146,7 @@ export class ToolsListWidget extends Disposable {
 	private _searchRow!: HTMLElement;
 	private _treeContainer!: HTMLElement;
 	private _treeScrollable!: DomScrollableElement;
-	private _browseButtonContainer!: HTMLElement;
+	private _browseButtonContainer: HTMLElement | undefined;
 	private _backButtonContainer!: HTMLElement;
 	private _galleryContainer!: HTMLElement;
 	private _galleryEmpty!: HTMLElement;
@@ -262,11 +262,13 @@ export class ToolsListWidget extends Disposable {
 			}).catch(() => { /* delayer disposed */ });
 		}));
 
-		const browseLabel = localize('toolsBrowseMarketplace', "Browse Marketplace");
-		this._browseButtonContainer = DOM.append(this._searchRow, $('.tools-list-browse-button-container'));
-		const browseButton = this._register(new Button(this._browseButtonContainer, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: browseLabel, ariaLabel: browseLabel }));
-		browseButton.label = `$(${Codicon.library.id}) ${browseLabel}`;
-		this._register(browseButton.onDidClick(() => this._setBrowseMode(true)));
+		if (!this._environmentService.isSessionsWindow) {
+			const browseLabel = localize('toolsBrowseMarketplace', "Browse Marketplace");
+			this._browseButtonContainer = DOM.append(this._searchRow, $('.tools-list-browse-button-container'));
+			const browseButton = this._register(new Button(this._browseButtonContainer, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: browseLabel, ariaLabel: browseLabel }));
+			browseButton.label = `$(${Codicon.library.id}) ${browseLabel}`;
+			this._register(browseButton.onDidClick(() => this._setBrowseMode(true)));
+		}
 
 		const backLabel = localize('toolsBrowseBack', "Back");
 		this._backButtonContainer = DOM.append(this._searchRow, $('.tools-list-browse-button-container'));
@@ -411,6 +413,9 @@ export class ToolsListWidget extends Disposable {
 
 	/** Enters/leaves marketplace browse mode, swapping the tree for the gallery list. */
 	private _setBrowseMode(browse: boolean): void {
+		if (browse && this._environmentService.isSessionsWindow) {
+			return;
+		}
 		if (this._browseMode === browse) {
 			return;
 		}
@@ -418,7 +423,9 @@ export class ToolsListWidget extends Disposable {
 
 		this._treeScrollable.getDomNode().style.display = browse ? 'none' : '';
 		this._galleryContainer.style.display = browse ? '' : 'none';
-		this._browseButtonContainer.style.display = browse ? 'none' : '';
+		if (this._browseButtonContainer) {
+			this._browseButtonContainer.style.display = browse ? 'none' : '';
+		}
 		this._backButtonContainer.style.display = browse ? '' : 'none';
 
 		this._searchInput.setPlaceHolder(browse


### PR DESCRIPTION
The Tools Marketplace relies on core workbench extension gallery browsing and install flows, which are not available in the Sessions window. This hides the Browse Marketplace affordance there so the Tools page only exposes tool enablement.

Fixes #324505

Validation:
- VS Code - Build
- npm run valid-layers-check