### PR TITLE
Remove extra empty space in welcome tab

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -39,6 +39,19 @@
 	--tab-border-top-color: transparent !important;
 }
 
+.style-override .part.editor .tabs-container > .tab.sizing-fit {
+	width: auto !important;
+	min-width: 0 !important;
+	flex: 0 0 auto !important;
+}
+
+.style-override .part.editor .tabs-container > .tab.sizing-fit .monaco-icon-label,
+.style-override .part.editor .tabs-container > .tab.sizing-fit .monaco-icon-label > .monaco-icon-label-container {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
+}
+
 /* Center tabs vertically and strip the bottom border so the pills float. */
 .style-override .part.editor .tabs-and-actions-container {
 	--tabs-border-bottom-color: transparent !important;

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -45,13 +45,6 @@
 	flex: 0 0 auto !important;
 }
 
-.style-override .part.editor .tabs-container > .tab.sizing-fit .monaco-icon-label,
-.style-override .part.editor .tabs-container > .tab.sizing-fit .monaco-icon-label > .monaco-icon-label-container {
-	overflow: hidden;
-	text-overflow: ellipsis;
-	min-width: 0;
-}
-
 /* Center tabs vertically and strip the bottom border so the pills float. */
 .style-override .part.editor .tabs-and-actions-container {
 	--tabs-border-bottom-color: transparent !important;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/324627

Before:

<img width="392" height="67" alt="Screenshot 2026-07-06 at 2 56 30 PM" src="https://github.com/user-attachments/assets/d1137fb1-3682-4341-ac9f-9ebea100337f" />
<img width="390" height="69" alt="Screenshot 2026-07-06 at 2 56 39 PM" src="https://github.com/user-attachments/assets/621452e9-6065-4daf-993c-cbbce3f65c63" />

After:

<img width="303" height="55" alt="Screenshot 2026-07-06 at 5 34 04 PM" src="https://github.com/user-attachments/assets/2ff97633-949a-4765-8087-e0cfc418ace6" />
<img width="295" height="54" alt="Screenshot 2026-07-06 at 5 34 11 PM" src="https://github.com/user-attachments/assets/f212c33e-d702-414b-91f8-ebdb1aa16824" />

