### PR TITLE
agentHost: handle stale custom agent selections

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -39,7 +39,6 @@ import { AgentHostMcpServersConfigKey, AgentHostSessionSyncEnabledConfigKey, Aut
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { AgentSessionEntry, decodeProviderData, encodeProviderData, type IPersistedChat } from '../agentPeerChats.js';
 import { AgentSession, AgentSignal, AuthenticateParams, GITHUB_COPILOT_PROTECTED_RESOURCE, GITHUB_REPO_PROTECTED_RESOURCE, IActiveClient, IAgent, IAgentChatDataChange, IAgentChats, IAgentLegacyChat, IAgentCreateChatForkSource, IAgentCreateChatOptions, IAgentCreateChatResult, IAgentCreateSessionConfig, IAgentCreateSessionResult, IAgentDescriptor, IAgentMaterializeSessionEvent, IAgentModelInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAgentSessionProjectInfo, IAgentSpawnChatEvent, IMcpNotification, IRestoredSubagentSession, SubagentChatSignal } from '../../common/agentService.js';
-import { getEffectiveAgents } from '../../common/customAgents.js';
 import { getReasoningEffortDescription, getReasoningEffortLabel } from '../../common/reasoningEffort.js';
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
 import { IAgentHostOTelService } from '../../common/otel/agentHostOTelService.js';
@@ -1156,22 +1155,15 @@ export class CopilotAgent extends Disposable implements IAgent {
 	}
 
 	/**
-	 * Resolves an {@link AgentSelection}'s SDK-facing name by looking it up in
-	 * the active client snapshot's parsed plugin agents. Falls back to `undefined`
-	 * when no matching plugin agent is found.
+	 * Resolves an {@link AgentSelection}'s SDK-facing name from the plugin
+	 * snapshot that is, or will be, applied to the SDK session.
 	 */
-	private async _resolveAgentName(sessionUri: URI, snapshot: IActiveClientSnapshot, agent: AgentSelection): Promise<string | undefined> {
+	private _resolveAgentName(snapshot: IActiveClientSnapshot, agent: AgentSelection): string | undefined {
 		for (const plugin of snapshot.plugins) {
 			const found = plugin.agents.find(a => a.uri.toString() === agent.uri);
 			if (found) {
 				return found.name;
 			}
-		}
-		const customizations = await this.getSessionCustomizations(sessionUri);
-		const agents = getEffectiveAgents(customizations);
-		const found = agents.find(a => a.uri.toString() === agent.uri);
-		if (found) {
-			return found.name;
 		}
 		return undefined;
 	}
@@ -1709,10 +1701,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 		}
 		const alternativeAgent = this._getAlternativeAgentForWorktree(provisional, workingDirectory);
 
-		const [originalAgentName, alternativeAgentName] = await Promise.all([
-			this._resolveAgentName(provisional.sessionUri, snapshot, agent),
-			alternativeAgent ? this._resolveAgentName(provisional.sessionUri, snapshot, alternativeAgent) : Promise.resolve(undefined),
-		]);
+		const originalAgentName = this._resolveAgentName(snapshot, agent);
+		const alternativeAgentName = alternativeAgent ? this._resolveAgentName(snapshot, alternativeAgent) : undefined;
 
 		if (originalAgentName) {
 			return { agent: agent, name: originalAgentName };
@@ -2608,7 +2598,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const context = this._getChatContext(chat);
 		if (context.isPeerChat) {
 			if (context.target) {
-				const resolvedAgentName = agent ? await this._resolveAgentName(context.session, context.target.appliedSnapshot, agent) : undefined;
+				const resolvedAgentName = agent ? this._resolveAgentName(context.target.appliedSnapshot, agent) : undefined;
 				await context.target.setAgent(resolvedAgentName);
 			}
 			return;
@@ -2624,7 +2614,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			// plugin snapshot. If the agent is no longer present (plugin
 			// removed, never loaded), pass `undefined` so the SDK clears its
 			// selection rather than silently keeping the previous one.
-			const resolvedAgentName = agent ? await this._resolveAgentName(context.session, entry.appliedSnapshot, agent) : undefined;
+			const resolvedAgentName = agent ? this._resolveAgentName(entry.appliedSnapshot, agent) : undefined;
 			await entry.setAgent(resolvedAgentName);
 		}
 		await this._storeSessionAgentMetadata(context.session, agent);
@@ -2935,7 +2925,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const snapshot = await activeClient.snapshot();
 
 		const shellManager = this._instantiationService.createInstance(ShellManager, sessionUri, workingDirectory);
-		const resolvedAgentName = storedMetadata.agent ? await this._resolveAgentName(sessionUri, snapshot, storedMetadata.agent) : undefined;
+		const resolvedAgentName = storedMetadata.agent ? this._resolveAgentName(snapshot, storedMetadata.agent) : undefined;
+		if (storedMetadata.agent && !resolvedAgentName) {
+			this._logService.info(`[Copilot:${sessionId}] Stored custom agent is not available in the current plugin snapshot; resuming without a custom agent`);
+		}
 		const launchPlan: CopilotSessionLaunchPlan = {
 			kind: 'resume',
 			client,
@@ -4113,7 +4106,7 @@ class SessionPluginController extends Disposable {
 	}
 
 	private _isEnabled(customization: Customization): boolean {
-		return this._enablement.get(customization.uri) ?? customization.enabled;
+		return this._enablement.get(customization.uri) ?? customization.enabled !== false;
 	}
 
 	private _applyEnablement<T extends Customization>(customization: T): T {

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -307,8 +307,6 @@ export async function resolveByokSessionConfig(
 	// `IByokLmBridgeRegistry`). Inbound inference is routed to that same serving
 	// connection by the proxy (`getServingConnection`).
 	let byokModels: IByokLmModelInfo[];
-	let fallbackPlan = plan;
-	let fallbackConfig = config;
 	try {
 		byokModels = await bridgeRegistry.listModels();
 	} catch (err) {
@@ -373,6 +371,8 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			return this._createSession(plan, config, sandboxConfig);
 		}
 
+		let fallbackPlan = plan;
+		let fallbackConfig = config;
 		try {
 			const stopWatch = new StopWatch();
 			this._logService.trace(`[Copilot:${plan.sessionId}] Calling SDK resumeSession...`);

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -215,6 +215,10 @@ function shouldCreateEmptySessionAfterResumeError(err: unknown): boolean {
 	return !/\b(corrupt|corrupted|invalid|validation|schema|must be|parse|malformed|unexpected token)\b/i.test(message);
 }
 
+function isCustomAgentNotFoundError(err: unknown): boolean {
+	return getCopilotSdkErrorCode(err) === -32603 && /\bCustom agent '.+' not found\b/i.test(getErrorMessage(err));
+}
+
 /**
  * Resolves the reasoning effort: a recognized override level wins over the
  * model picker's thinking level; an unrecognized override is ignored (degrades
@@ -303,6 +307,8 @@ export async function resolveByokSessionConfig(
 	// `IByokLmBridgeRegistry`). Inbound inference is routed to that same serving
 	// connection by the proxy (`getServingConnection`).
 	let byokModels: IByokLmModelInfo[];
+	let fallbackPlan = plan;
+	let fallbackConfig = config;
 	try {
 		byokModels = await bridgeRegistry.listModels();
 	} catch (err) {
@@ -370,33 +376,43 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 		try {
 			const stopWatch = new StopWatch();
 			this._logService.trace(`[Copilot:${plan.sessionId}] Calling SDK resumeSession...`);
-			const raw = await plan.client.resumeSession(plan.sessionId, {
-				...config,
-				workingDirectory: plan.workingDirectory.fsPath,
-				...(plan.resolvedAgentName ? { agent: plan.resolvedAgentName } : {}),
-			});
+			const raw = await plan.client.resumeSession(plan.sessionId, config);
 			this._logService.trace(`[Copilot:${plan.sessionId}] SDK resumeSession succeeded after ${stopWatch.elapsed()}ms`);
 			await this._applySandboxConfig(raw, sandboxConfig, plan.sessionId);
 			return new CopilotSessionWrapper(raw);
 		} catch (err) {
-			const errCode = getCopilotSdkErrorCode(err);
-			const errMsg = getErrorMessage(err);
+			let resumeError = err;
+			const errCode = getCopilotSdkErrorCode(resumeError);
+			const errMsg = getErrorMessage(resumeError);
 			this._logService.warn(`[Copilot:${plan.sessionId}] SDK resumeSession failed: code=${errCode}, message=${errMsg}`);
+			if (plan.resolvedAgentName && isCustomAgentNotFoundError(resumeError)) {
+				fallbackPlan = { ...plan, resolvedAgentName: undefined };
+				fallbackConfig = { ...config, agent: undefined };
+				this._logService.warn(`[Copilot:${plan.sessionId}] Stored custom agent '${plan.resolvedAgentName}' was not found; retrying resume without a custom agent`);
+				try {
+					const raw = await fallbackPlan.client.resumeSession(fallbackPlan.sessionId, fallbackConfig);
+					await this._applySandboxConfig(raw, sandboxConfig, plan.sessionId);
+					return new CopilotSessionWrapper(raw);
+				} catch (retryErr) {
+					resumeError = retryErr;
+					this._logService.warn(`[Copilot:${plan.sessionId}] SDK resumeSession without custom agent failed: code=${getCopilotSdkErrorCode(retryErr)}, message=${getErrorMessage(retryErr)}`);
+				}
+			}
 			// The SDK fails to resume sessions that have no messages.
 			// Fall back to creating a new session with the same ID,
 			// seeding model & working directory from stored metadata.
-			if (!shouldCreateEmptySessionAfterResumeError(err)) {
-				throw err;
+			if (!shouldCreateEmptySessionAfterResumeError(resumeError)) {
+				throw resumeError;
 			}
 
 			this._logService.warn(`[Copilot:${plan.sessionId}] Resume failed (code=-32603), falling back to createSession with same ID`);
 			const wrapper = await this._createSession({
-				...plan,
+				...fallbackPlan,
 				kind: 'create',
-				model: plan.fallback.model,
-				longContextWindow: plan.fallback.longContextWindow,
-				freeLongContext: plan.fallback.freeLongContext,
-			}, config, sandboxConfig);
+				model: fallbackPlan.fallback.model,
+				longContextWindow: fallbackPlan.fallback.longContextWindow,
+				freeLongContext: fallbackPlan.fallback.freeLongContext,
+			}, fallbackConfig, sandboxConfig);
 			this._logService.info(`[Copilot:${plan.sessionId}] Fallback createSession succeeded`);
 			return wrapper;
 		}
@@ -562,6 +578,7 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			onExitPlanModeRequest: (request, invocation) => runtime.handleExitPlanModeRequest(request, invocation),
 			workingDirectory: plan.workingDirectory?.fsPath,
 			customAgents,
+			agent: plan.resolvedAgentName,
 			skillDirectories,
 			instructionDirectories,
 			systemMessage,

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -588,7 +588,7 @@ function createTestAgentContext(disposables: Pick<DisposableStore, 'add'>, optio
 	return { agent, instantiationService, configurationService: configService, fileService };
 }
 
-function createTestAgent(disposables: Pick<DisposableStore, 'add'>, options?: { sessionDataService?: ISessionDataService; copilotClient?: ITestCopilotClient; useRealResumePath?: boolean; gitService?: TestAgentHostGitService; environmentServiceRegistration?: 'native' | 'none'; pluginManager?: IAgentPluginManager; copilotApiService?: ICopilotApiService; userHome?: URI }): CopilotAgent {
+function createTestAgent(disposables: Pick<DisposableStore, 'add'>, options?: { sessionDataService?: ISessionDataService; copilotClient?: ITestCopilotClient; useRealResumePath?: boolean; gitService?: TestAgentHostGitService; environmentServiceRegistration?: 'native' | 'none'; pluginManager?: IAgentPluginManager; fileService?: FileService; copilotApiService?: ICopilotApiService; userHome?: URI }): CopilotAgent {
 	return createTestAgentContext(disposables, options).agent;
 }
 
@@ -2612,7 +2612,7 @@ suite('CopilotAgent', () => {
 			_sessions: Map<string, CopilotSessionEntry>;
 			_createAgentSession: (launchPlan: CopilotSessionLaunchPlan, customizationDirectory: URI | undefined, activeClient: unknown, channelUri?: URI) => CopilotAgentSession;
 			_forkSdkChat: (client: unknown, sourceEntry: unknown, turnId: string, targetDbDir: URI) => Promise<string>;
-			_resolveAgentName: (sessionUri: URI, snapshot: IActiveClientSnapshot, agent: AgentSelection) => Promise<string | undefined>;
+			_resolveAgentName: (snapshot: IActiveClientSnapshot, agent: AgentSelection) => string | undefined;
 		};
 
 		interface IFakeChatRecorder {
@@ -2864,7 +2864,7 @@ suite('CopilotAgent', () => {
 				const a = makeFakeChatSession(session, 'sdk-a');
 				const internals = agent as unknown as ChatInternals;
 				setPeerChatStub(agent, chatA, a.fake);
-				internals._resolveAgentName = async (_sessionUri, _snapshot, selection) => selection.uri === 'agent://x' ? 'Resolved Agent' : undefined;
+				internals._resolveAgentName = (_snapshot, selection) => selection.uri === 'agent://x' ? 'Resolved Agent' : undefined;
 
 				await agent.chats.changeAgent(chatA, { uri: 'agent://x' });
 				await agent.chats.changeAgent(chatA, undefined);
@@ -3219,7 +3219,7 @@ suite('CopilotAgent', () => {
 				const session = AgentSession.uri('copilotcli', 'conv-ops');
 				const chatUri = URI.parse(buildChatUri(session, 'peer-a'));
 				const rec = installFake(agent, chatUri.toString(), 'chat', session);
-				(agent as unknown as { _resolveAgentName: (s: URI, snap: IActiveClientSnapshot, a: AgentSelection) => Promise<string | undefined> })._resolveAgentName = async (_s, _snap, sel) => sel.uri === 'agent://x' ? 'Resolved Agent' : undefined;
+				(agent as unknown as { _resolveAgentName: (snap: IActiveClientSnapshot, a: AgentSelection) => string | undefined })._resolveAgentName = (_snap, sel) => sel.uri === 'agent://x' ? 'Resolved Agent' : undefined;
 
 				await agent.chats.abort(chatUri);
 				await agent.chats.changeModel(chatUri, { id: 'model-x' });
@@ -3576,6 +3576,75 @@ suite('CopilotAgent', () => {
 				await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'token');
 				await assert.rejects(() => internals._resumeSession('s1'), /Session file is corrupted/);
 				assert.strictEqual(getCreateSessionCalls(), 0);
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('does not restore a persisted custom agent that is absent from the current plugin snapshot', async () => {
+			const sessionDataService = disposables.add(new TestSessionDataService());
+			const session = AgentSession.uri('copilotcli', 's1');
+			const dbRef = sessionDataService.openDatabase(session);
+			try {
+				await dbRef.object.setMetadata('copilot.agent', JSON.stringify({ uri: 'file:///old-client/data.md' }));
+			} finally {
+				dbRef.dispose();
+			}
+
+			const client = new TestCopilotClient([sdkSession('s1', '/workspace')]);
+			const resumeAgents: (string | undefined)[] = [];
+			client.resumeSession = async (_sessionId, options) => {
+				resumeAgents.push(options?.agent);
+				return new MockCopilotSession() as unknown as CopilotSession;
+			};
+			const agent = createTestAgent(disposables, { copilotClient: client, useRealResumePath: true, sessionDataService });
+			const internals = agent as unknown as AgentInternals;
+			try {
+				await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'token');
+				await internals._resumeSession('s1');
+				assert.deepStrictEqual(resumeAgents, [undefined]);
+			} finally {
+				await disposeAgent(agent);
+			}
+		});
+
+		test('retries resume without a custom agent when the SDK reports the stored agent is missing', async () => {
+			const fileService = disposables.add(new FileService(new NullLogService()));
+			disposables.add(fileService.registerProvider(Schemas.inMemory, disposables.add(new InMemoryFileSystemProvider())));
+
+			const repo = URI.from({ scheme: Schemas.inMemory, path: '/repo' });
+			const dataAgent = URI.joinPath(repo, '.github', 'agents', 'data.md');
+			await fileService.writeFile(dataAgent, VSBuffer.fromString('---\nname: Data\ndescription: data queries\n---\nbody'));
+
+			const sessionDataService = disposables.add(new TestSessionDataService());
+			const session = AgentSession.uri('copilotcli', 's1');
+			const dbRef = sessionDataService.openDatabase(session);
+			try {
+				await dbRef.object.setMetadata('copilot.workingDirectory', repo.toString());
+				await dbRef.object.setMetadata('copilot.agent', JSON.stringify({ uri: dataAgent.toString() }));
+			} finally {
+				dbRef.dispose();
+			}
+
+			const client = new TestCopilotClient([sdkSession('s1')]);
+			const resumeAgents: (string | undefined)[] = [];
+			client.resumeSession = async (_sessionId, options) => {
+				resumeAgents.push(options?.agent);
+				if (resumeAgents.length === 1) {
+					throw new TestSdkError(`Request session.resume failed with message: Custom agent 'Data' not found`, -32603);
+				}
+				return new MockCopilotSession() as unknown as CopilotSession;
+			};
+			client.createSession = async () => {
+				throw new Error('createSession should not be called');
+			};
+
+			const agent = createTestAgent(disposables, { copilotClient: client, useRealResumePath: true, sessionDataService, fileService });
+			const internals = agent as unknown as AgentInternals;
+			try {
+				await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'token');
+				await internals._resumeSession('s1');
+				assert.deepStrictEqual(resumeAgents, ['Data', undefined]);
 			} finally {
 				await disposeAgent(agent);
 			}
@@ -4150,7 +4219,7 @@ suite('CopilotAgent', () => {
 		type AgentInternals = {
 			_getAlternativeAgentForWorktree(provisional: unknown, workingDirectory: URI | undefined): AgentSelection | undefined;
 			_resolveAgentWhenMaterializing(provisional: unknown, snapshot: IActiveClientSnapshot, workingDirectory: URI | undefined): Promise<{ agent: AgentSelection; name: string } | undefined>;
-			_resolveAgentName(sessionUri: URI, snapshot: IActiveClientSnapshot, agent: AgentSelection): Promise<string | undefined>;
+			_resolveAgentName(snapshot: IActiveClientSnapshot, agent: AgentSelection): string | undefined;
 			_resolveSessionWorkingDirectory(config: unknown, sessionId: string, prompt?: string): Promise<URI | undefined>;
 			_createAgentSession(launchPlan: CopilotSessionLaunchPlan, customizationDirectory: URI | undefined, activeClient: unknown, channelUri?: URI): CopilotAgentSession;
 			_readSessionMetadata(session: URI): Promise<{ agent?: AgentSelection }>;
@@ -4208,7 +4277,7 @@ suite('CopilotAgent', () => {
 			const agent = createTestAgent(disposables, { copilotClient: new TestCopilotClient([]) });
 			try {
 				const internals = agent as unknown as AgentInternals;
-				internals._resolveAgentName = async (_sessionUri, _snapshot, selection) => selection.uri === repoAgentUri ? 'Repo Agent' : undefined;
+				internals._resolveAgentName = (_snapshot, selection) => selection.uri === repoAgentUri ? 'Repo Agent' : undefined;
 				// Folder isolation: the resolved working directory equals the
 				// user-picked folder, so there is no worktree copy to translate to
 				// and the originally selected agent is kept as-is.
@@ -4225,7 +4294,7 @@ suite('CopilotAgent', () => {
 			const agent = createTestAgent(disposables, { copilotClient: new TestCopilotClient([]) });
 			try {
 				const internals = agent as unknown as AgentInternals;
-				internals._resolveAgentName = async () => undefined;
+				internals._resolveAgentName = () => undefined;
 				assert.deepStrictEqual(
 					{
 						noAgent: await internals._resolveAgentWhenMaterializing(provisional(repo, undefined), emptySnapshot, worktree),


### PR DESCRIPTION
## Summary
- resolve stored custom agent selections only against the SDK plugin snapshot
- treat missing customization enabled state as enabled for applied plugins
- retry Copilot SDK resume without a stale custom agent when the SDK reports it missing

## Validation
- npm run typecheck-client
- ./scripts/test.sh --run src/vs/platform/agentHost/test/node/copilotAgent.test.ts --grep "_resumeSession fallback"
- node --experimental-strip-types build/hygiene.ts src/vs/platform/agentHost/node/copilot/copilotAgent.ts src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts src/vs/platform/agentHost/test/node/copilotAgent.test.ts