### PR TITLE
[release/1.128] Update GPT-5.6 model family detection

### DIFF
--- a/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
+++ b/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
@@ -155,17 +155,8 @@ export function isGpt55(model: LanguageModelChat | IChatEndpoint | string) {
 }
 
 export function isGpt56(model: LanguageModelChat | IChatEndpoint | string) {
-	return isGpt56SolOrTerra(model) || isGpt56Luna(model);
-}
-
-export function isGpt56SolOrTerra(model: LanguageModelChat | IChatEndpoint | string) {
 	const family = typeof model === 'string' ? model : model.family;
-	return family === 'ember-alpha';
-}
-
-export function isGpt56Luna(model: LanguageModelChat | IChatEndpoint | string) {
-	const family = typeof model === 'string' ? model : model.family;
-	return family === 'opal-alpha';
+	return family === 'gpt-5.6-sol' || family === 'gpt-5.6-terra' || family === 'gpt-5.6-luna';
 }
 
 export function isGpt53Codex(model: LanguageModelChat | IChatEndpoint | string) {

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -933,7 +933,7 @@ describe('createResponsesRequestBody', () => {
 
 describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 	const expectedPromptCacheBreakpoint = { mode: 'explicit' };
-	const cacheBreakpointEndpoint: IChatEndpoint = { ...testEndpoint, family: 'ember-alpha' };
+	const cacheBreakpointEndpoint: IChatEndpoint = { ...testEndpoint, family: 'gpt-5.6-sol' };
 
 	const cacheBreakpoint = (): Raw.ChatCompletionContentPart => ({
 		type: Raw.ChatCompletionContentPartKind.CacheBreakpoint,


### PR DESCRIPTION
## Summary
- recognize the GPT-5.6 Sol, Terra, and Luna model family names
- update the Responses API cache-breakpoint fixture to use the GPT-5.6 family

## Testing
- npm run test:unit -- src\platform\endpoint\node\test\responsesApi.spec.ts (53 passed)