### PR TITLE
Automations TPI feedback

### DIFF
--- a/src/vs/sessions/contrib/automations/browser/automationDialogService.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationDialogService.ts
@@ -22,10 +22,12 @@ import { IAutomationSchedule } from '../../../../workbench/contrib/chat/common/a
 import { IAutomationDialogResult, IAutomationDialogService, IShowAutomationDialogOptions } from '../../../../workbench/contrib/chat/common/automations/automationDialogService.js';
 import { ICreateAutomationOptions, IUpdateAutomationOptions } from '../../../../workbench/contrib/chat/common/automations/automationService.js';
 import { IAutomationSessionTypeProvider } from '../../../../workbench/contrib/chat/common/automations/automationSessionTypes.js';
+import { SessionType } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { IHostService } from '../../../../workbench/services/host/browser/host.js';
 import { IFormState, IValidationState, isAutomationDialogPopupTarget, renderForm, updateSaveButtonState } from './automationDialog.js';
 
 const $ = DOM.$;
+const COPILOT_PROVIDER_ID = 'default-copilot';
 
 /**
  * Owns the Automations create/edit dialog in the sessions layer, where the
@@ -163,8 +165,9 @@ export class AutomationDialogService implements IAutomationDialogService {
 					prompt,
 					schedule,
 					folderUri: state.folderUri,
-					providerId: state.providerId ?? null,
-					sessionTypeId: state.sessionTypeId ?? null,
+					// v0: Only copilot cli supported, explicitly mark as such to avoid accidental fallbacks
+					providerId: COPILOT_PROVIDER_ID,
+					sessionTypeId: SessionType.CopilotCLI,
 					modelId: modelId ?? null,
 					mode: mode ?? null,
 					permissionLevel: permissionLevel ?? null,
@@ -180,8 +183,9 @@ export class AutomationDialogService implements IAutomationDialogService {
 				prompt,
 				schedule,
 				folderUri: state.folderUri,
-				providerId: state.providerId,
-				sessionTypeId: state.sessionTypeId,
+				// v0: Only copilot cli supported, explicitly mark as such to avoid accidental fallbacks
+				providerId: COPILOT_PROVIDER_ID,
+				sessionTypeId: SessionType.CopilotCLI,
 				modelId,
 				mode,
 				permissionLevel,

--- a/src/vs/sessions/contrib/automations/browser/automationDialogService.ts
+++ b/src/vs/sessions/contrib/automations/browser/automationDialogService.ts
@@ -165,9 +165,8 @@ export class AutomationDialogService implements IAutomationDialogService {
 					prompt,
 					schedule,
 					folderUri: state.folderUri,
-					// v0: Only copilot cli supported, explicitly mark as such to avoid accidental fallbacks
-					providerId: COPILOT_PROVIDER_ID,
-					sessionTypeId: SessionType.CopilotCLI,
+					providerId: state.providerId ?? COPILOT_PROVIDER_ID,
+					sessionTypeId: state.sessionTypeId ?? SessionType.CopilotCLI,
 					modelId: modelId ?? null,
 					mode: mode ?? null,
 					permissionLevel: permissionLevel ?? null,
@@ -183,9 +182,8 @@ export class AutomationDialogService implements IAutomationDialogService {
 				prompt,
 				schedule,
 				folderUri: state.folderUri,
-				// v0: Only copilot cli supported, explicitly mark as such to avoid accidental fallbacks
-				providerId: COPILOT_PROVIDER_ID,
-				sessionTypeId: SessionType.CopilotCLI,
+				providerId: state.providerId ?? COPILOT_PROVIDER_ID,
+				sessionTypeId: state.sessionTypeId ?? SessionType.CopilotCLI,
 				modelId,
 				mode,
 				permissionLevel,

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -2459,17 +2459,21 @@ body:has(.automation-dialog) .monaco-menu-container {
 }
 
 /*
- * Suppress every inter-chip divider drawn by chat.css
- * (`.chat-input-toolbar ... .action-item + .action-item::before`) inside
- * the dialog. CSS `+` matches by DOM order regardless of `display:none`,
- * so the divider would otherwise appear as an orphan vertical line on
- * whichever visible chip follows our hidden `+`/settings items. The
- * remaining visible chips (Agent, model, mode) already have enough
- * intrinsic padding to read as separate without the divider. Dropping
- * dividers entirely is simpler and more resilient than per-pair
- * suppression rules that depend on DOM order.
+ * Suppress every inter-chip divider drawn by chat.css inside the dialog,
+ * in both the primary (`.chat-input-toolbar`) and secondary
+ * (`.chat-secondary-input-toolbar`) toolbars. CSS `+` matches by DOM
+ * order regardless of `display:none`, so the divider would otherwise
+ * appear as an orphan vertical line on whichever visible chip follows
+ * our hidden `+`/settings items. For example the bar drawn to the left
+ * of the Folder/Worktree isolation chip because it follows the Copilot
+ * CLI chip in the secondary toolbar (microsoft/vscode-internalbacklog#8304). The remaining visible
+ * chips (Agent, model, mode, isolation) already have enough intrinsic
+ * padding to read as separate without the divider. Dropping dividers
+ * entirely is simpler and more resilient than per-pair suppression rules
+ * that depend on DOM order.
  */
-.automation-form-prompt-host .chat-input-toolbar .monaco-action-bar .actions-container > .action-item + .action-item::before {
+.automation-form-prompt-host .chat-input-toolbar .monaco-action-bar .actions-container > .action-item + .action-item::before,
+.automation-form-prompt-host .chat-secondary-input-toolbar .monaco-action-bar .actions-container > .action-item + .action-item::before {
 	display: none;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -2212,7 +2212,7 @@ pane is first mounted. View switches inside the modal are not animated. */
 	min-width: min(520px, 92vw);
 	max-width: 92vw;
 	padding: 0;
-	background-color: var(--vscode-quickInput-background);
+	background-color: var(--vscode-editorWidget-background);
 	color: var(--vscode-quickInput-foreground);
 	/* Anchor for the absolutely-positioned close-X (see below). */
 	position: relative;
@@ -2272,11 +2272,15 @@ pane is first mounted. View switches inside the modal are not animated. */
 }
 
 /*
- * QuickInput-style titlebar. The visual "line" beneath it is purely
- * the background contrast between `quickInputTitle.background` (a
- * translucent stripe) and `quickInput.background` (the form area).
- * No `border-bottom`. Sticky so the title stays in view as the form
- * scrolls (the dialog's message-container is the scroll host).
+ * Titlebar background matches the dialog body so the header reads as
+ * part of the modal, with no contrasting stripe. Both are anchored to
+ * `editorWidget.background`, the dialog widget's own native background
+ * (see defaultDialogStyles), so the header and body are always the same
+ * color in every theme. Set explicitly (not transparent) because the
+ * titlebar is sticky. A transparent background would let scrolled form
+ * content show through. No `border-bottom`. Sticky so the title stays
+ * in view as the form scrolls (the dialog's message-container is the
+ * scroll host).
  */
 .automation-titlebar {
 	position: sticky;
@@ -2288,7 +2292,7 @@ pane is first mounted. View switches inside the modal are not animated. */
 	font-weight: var(--vscode-agents-fontWeight-semiBold);
 	font-size: var(--vscode-agents-fontSize-heading2);
 	color: var(--vscode-quickInput-foreground);
-	background-color: var(--vscode-quickInputTitle-background);
+	background-color: var(--vscode-editorWidget-background);
 }
 
 .automation-description {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -2213,7 +2213,7 @@ pane is first mounted. View switches inside the modal are not animated. */
 	max-width: 92vw;
 	padding: 0;
 	background-color: var(--vscode-editorWidget-background);
-	color: var(--vscode-quickInput-foreground);
+	color: var(--vscode-editorWidget-foreground);
 	/* Anchor for the absolutely-positioned close-X (see below). */
 	position: relative;
 }
@@ -2291,7 +2291,7 @@ pane is first mounted. View switches inside the modal are not animated. */
 	text-align: left;
 	font-weight: var(--vscode-agents-fontWeight-semiBold);
 	font-size: var(--vscode-agents-fontSize-heading2);
-	color: var(--vscode-quickInput-foreground);
+	color: var(--vscode-editorWidget-foreground);
 	background-color: var(--vscode-editorWidget-background);
 }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8304
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8319
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8334

- Remove extra separator
- Fix dialog title having a different background than the dialog itself
- Explicitly marks sessions using default value displayed by the modal by falling back to copilot cli (v0 expected scenario)

