### PR TITLE
Preserve explicit local chat editor sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -1539,6 +1539,7 @@ export async function openChatSession(accessor: ServicesAccessor, openOptions: N
 				const options: IChatEditorOptions = {
 					override: ChatEditorInput.EditorID,
 					pinned: true,
+					...(openOptions.type === AgentSessionProviders.Local ? { explicitSessionType: localChatSessionType } : {}),
 					title: {
 						fallback: localize('chatEditorContributionName', "{0}", openOptions.displayName),
 					}

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.ts
@@ -42,6 +42,13 @@ export interface IChatEditorOptions extends IEditorOptions {
 	 * https://github.com/microsoft/vscode/pull/278476 as input state is stored on the model.
 	 */
 	modelInputState?: IChatModelInputState;
+	/**
+	 * Session type explicitly selected by the user when opening a new chat editor.
+	 * Non-local session types are already encoded in the editor resource, so this
+	 * currently preserves an explicit local selection when default/last-used
+	 * provider resolution would otherwise apply.
+	 */
+	explicitSessionType?: string;
 	target?: { data: IExportableChatData | ISerializableChatData };
 	title?: {
 		preferred?: string;

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditorInput.ts
@@ -233,13 +233,17 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 				this.modelRef.value = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: true, debugOwner: 'ChatEditorInput#resolveNewLocalSession' });
 			}
 		} else if (!this.options.target) {
-			const lastUsedSessionType = this.storageService.get(ChatLastUsedEditorSessionTypeStorageKey, StorageScope.PROFILE);
-			const defaultResource = getNewChatEditorSessionResource(this.configurationService, this.chatSessionsService, lastUsedSessionType);
-			if (getChatSessionType(defaultResource) === localChatSessionType) {
-				this.modelRef.value = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: !inputType, debugOwner: 'ChatEditorInput#resolveUntitled' });
+			if (this.options.explicitSessionType === localChatSessionType) {
+				this.modelRef.value = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: !inputType, debugOwner: 'ChatEditorInput#resolveExplicitLocal' });
 			} else {
-				this._sessionResource = defaultResource;
-				this.modelRef.value = await this.chatService.acquireOrLoadSession(defaultResource, ChatAgentLocation.Chat, CancellationToken.None, 'ChatEditorInput#resolveDefaultUntitled');
+				const lastUsedSessionType = this.storageService.get(ChatLastUsedEditorSessionTypeStorageKey, StorageScope.PROFILE);
+				const defaultResource = getNewChatEditorSessionResource(this.configurationService, this.chatSessionsService, lastUsedSessionType);
+				if (getChatSessionType(defaultResource) === localChatSessionType) {
+					this.modelRef.value = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: !inputType, debugOwner: 'ChatEditorInput#resolveUntitled' });
+				} else {
+					this._sessionResource = defaultResource;
+					this.modelRef.value = await this.chatService.acquireOrLoadSession(defaultResource, ChatAgentLocation.Chat, CancellationToken.None, 'ChatEditorInput#resolveDefaultUntitled');
+				}
 			}
 		} else if (this.options.target.data) {
 			this.modelRef.value = this.chatService.loadSessionFromData(this.options.target.data, 'ChatEditorInput#resolveImportedData');
@@ -266,6 +270,7 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 
 	private shouldReplaceEmptyLocalSession(sessionResource: URI): boolean {
 		return LocalChatSessionUri.isLocalSession(sessionResource)
+			&& this.options.explicitSessionType !== localChatSessionType
 			&& !!this.model
 			&& !this.model.hasRequests
 			&& getDefaultNewChatSessionType(this.configurationService, this.chatSessionsService) !== localChatSessionType;

--- a/src/vs/workbench/contrib/chat/test/browser/widgetHosts/editor/chatEditorInput.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widgetHosts/editor/chatEditorInput.test.ts
@@ -1,0 +1,125 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event } from '../../../../../../../base/common/event.js';
+import { URI } from '../../../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
+import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
+import { IDialogService } from '../../../../../../../platform/dialogs/common/dialogs.js';
+import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js';
+import { IStorageService } from '../../../../../../../platform/storage/common/storage.js';
+import { ChatEditorInput } from '../../../../browser/widgetHosts/editor/chatEditorInput.js';
+import { IChatService, IChatSessionStartOptions } from '../../../../common/chatService/chatService.js';
+import { IChatSessionsService, localChatSessionType } from '../../../../common/chatSessionsService.js';
+import { ChatAgentLocation } from '../../../../common/constants.js';
+import { IChatModel } from '../../../../common/model/chatModel.js';
+import { LocalChatSessionUri } from '../../../../common/model/chatUri.js';
+
+suite('ChatEditorInput', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('explicit local session type starts local session for generic editor URI', async () => {
+		const sessionResource = LocalChatSessionUri.forSession('explicit-local');
+		const model = {
+			onDidDispose: Event.None,
+			onDidChange: Event.None,
+			sessionResource,
+		} as Partial<IChatModel> as IChatModel;
+
+		let startCall: { location: ChatAgentLocation; options: IChatSessionStartOptions | undefined } | undefined;
+		let didTryDefaultLoad = false;
+		const chatService = {
+			startNewLocalSession(location: ChatAgentLocation, options?: IChatSessionStartOptions) {
+				startCall = { location, options };
+				return { object: model, dispose: () => { } };
+			},
+			async acquireOrLoadSession() {
+				didTryDefaultLoad = true;
+				return undefined;
+			},
+		} as Partial<IChatService> as IChatService;
+
+		const input = new ChatEditorInput(
+			ChatEditorInput.getNewEditorUri(),
+			{ explicitSessionType: localChatSessionType },
+			chatService,
+			{} as IDialogService,
+			{} as IConfigurationService,
+			{} as IChatSessionsService,
+			{} as IInstantiationService,
+			{} as IStorageService,
+		);
+
+		try {
+			const resolved = await input.resolve();
+
+			assert.deepStrictEqual({
+				model: resolved?.model,
+				sessionResource: input.sessionResource,
+				startLocation: startCall?.location,
+				debugOwner: startCall?.options?.debugOwner,
+				didTryDefaultLoad,
+			}, {
+				model,
+				sessionResource,
+				startLocation: ChatAgentLocation.Chat,
+				debugOwner: 'ChatEditorInput#resolveExplicitLocal',
+				didTryDefaultLoad: false,
+			});
+		} finally {
+			input.dispose();
+		}
+	});
+
+	test('explicit local session type preserves empty local session resource', async () => {
+		const sessionResource = LocalChatSessionUri.forSession('explicit-empty-local');
+		const model = {
+			hasRequests: false,
+			onDidDispose: Event.None,
+			onDidChange: Event.None,
+			sessionResource,
+		} as Partial<IChatModel> as IChatModel;
+
+		const loadedResources: string[] = [];
+		const chatService = {
+			async acquireOrLoadSession(resource: URI) {
+				loadedResources.push(resource.toString());
+				return { object: model, dispose: () => { } };
+			},
+			startNewLocalSession() {
+				throw new Error('Should not create a new local session when the local session resource resolves');
+			},
+		} as Partial<IChatService> as IChatService;
+
+		const input = new ChatEditorInput(
+			sessionResource,
+			{ explicitSessionType: localChatSessionType },
+			chatService,
+			{} as IDialogService,
+			{} as IConfigurationService,
+			{} as IChatSessionsService,
+			{} as IInstantiationService,
+			{} as IStorageService,
+		);
+
+		try {
+			const resolved = await input.resolve();
+
+			assert.deepStrictEqual({
+				model: resolved?.model,
+				sessionResource: input.sessionResource,
+				loadedResources,
+			}, {
+				model,
+				sessionResource,
+				loadedResources: [sessionResource.toString()],
+			});
+		} finally {
+			input.dispose();
+		}
+	});
+});


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/324648
Mirror main: https://github.com/microsoft/vscode/pull/324672 

Regressed by: https://github.com/microsoft/vscode/pull/323914

- Add `explicitSessionType?: string` to `IChatEditorOptions` so callers can preserve an explicit session picker choice when opening a new chat editor.
- Set `explicitSessionType: localChatSessionType` in `openChatSession` only when the user picks Local for an editor session.
- Make `ChatEditorInput.resolve()` honor explicit Local before applying last-used-agent/default-provider resolution, so switching from Copilot AH to Local starts a local session instead of resolving back to Copilot.
- Make `shouldReplaceEmptyLocalSession()` skip replacing an empty session that was explicitly opened as Local, so it is not swapped back to the default provider on a later resolve.
- Add unit tests covering both paths: starting a fresh explicit Local session, and preserving an already-resolved empty Local session.

-----------------------------------------
Regression history:

- #323011 introduced remembering the last-used non-local agent for new chat editors ([`34a9b07`](https://github.com/microsoft/vscode/commit/34a9b07a4703637543920667a91d2a8776c01f2f)).
- #323484 removed that last-used session type / agent logic ([`b802a62`](https://github.com/microsoft/vscode/commit/b802a62be50dba26931409d45e7094884639179a)), and the removal was also cherry-picked to `release/1.127` as #323555.
- #323914 reintroduced the last-used session type behavior removed by #323484. Once the session is released, a new chat editor opened from the picker can inherit the last selected non-local agent, such as Copilot AH, instead of staying on the intended local agent.
- Local editor opens use a generic `vscode-chat-editor` resource, so the editor input could not distinguish "the user explicitly picked Local" from "open a normal new chat editor." This PR preserves that explicit Local intent.

-----------------------------------------
Evidence:

- #323914 reintroduced storing the last-used non-local session type in `ChatWidgetService`: [`recordLastUsedSessionType`](https://github.com/microsoft/vscode/blob/4c959fa67475df50c291e2c24e4dd0fd8695989f/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts#L248-L262), called from [`setLastFocusedWidget`](https://github.com/microsoft/vscode/blob/4c959fa67475df50c291e2c24e4dd0fd8695989f/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts#L240) and the [view-model change listener](https://github.com/microsoft/vscode/blob/4c959fa67475df50c291e2c24e4dd0fd8695989f/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts#L280). Note `recordLastUsedSessionType` intentionally never stores `local`, so an explicit Local picker choice needs a separate signal to bypass last-used non-local resolution.
- #323914 changed `ChatEditorInput.resolve()` back to reading `ChatLastUsedEditorSessionTypeStorageKey` and calling `getNewChatEditorSessionResource(...)`: [`chatEditorInput.ts#L236-L237`](https://github.com/microsoft/vscode/blob/4c959fa67475df50c291e2c24e4dd0fd8695989f/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditorInput.ts#L236-L237).
- `getNewChatEditorSessionType(...)` prefers that last-used non-local session type when `chat.editor.defaultProvider` is not explicitly configured: [`constants.ts#L319-L324`](https://github.com/microsoft/vscode/blob/4c959fa67475df50c291e2c24e4dd0fd8695989f/src/vs/workbench/contrib/chat/common/constants.ts#L319-L324).
- This PR fixes the missing intent signal by setting `explicitSessionType` from `openChatSession` and checking it before the last-used/default-provider path in `ChatEditorInput.resolve()`.

-----------------------------------------
Inspirations from:

- The `explicitSessionType` branching in `resolve()` follows the existing `options.target` handling in the same method: [`ChatEditorInput.resolve()`](https://github.com/microsoft/vscode/blob/4c959fa67475df50c291e2c24e4dd0fd8695989f/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditorInput.ts#L215-L250).
- The `shouldReplaceEmptyLocalSession()` guard extends the existing predicate rather than adding a new code path: [`shouldReplaceEmptyLocalSession`](https://github.com/microsoft/vscode/blob/4c959fa67475df50c291e2c24e4dd0fd8695989f/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditorInput.ts#L264-L269).

-----------------------------------------
Validation:

- `git diff --check` clean.
- `npm run typecheck-client` fails on unrelated `src/vs/workbench/api/node/proxyResolver.ts(115,52)` / `resolveProxyByURL`, which is outside this PR's touched files.
- Added two unit tests in `chatEditorInput.test.ts`: explicit Local resolves to a fresh local session without consulting the default/last-used path, and an empty explicitly-Local session is preserved instead of replaced.

Manual test:

1. Open a Copilot (AH) chat editor, then use the picker to switch to Local -> stays Local, no flicker back to Copilot.
2. Repeat with `chat.editor.defaultProvider` set to a non-local provider -> explicit Local still sticks, including after a window reload with the empty session open.
3. Open a plain new chat editor without an explicit picker choice -> existing default/last-used behavior is unchanged.


/cc @benvillalobos 