### PR TITLE
Keep focus on the next resource when staging in the SCM view

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -1983,6 +1983,12 @@ export class SCMViewPane extends ViewPane {
 				async () => {
 					const focusedInput = this.inputRenderer.getFocusedInput();
 
+					const treeHasDomFocus = isActiveElement(this.tree.getHTMLElement());
+					const focus = this.tree.getFocus().at(0);
+					const nextFocus = treeHasDomFocus && focus && isSCMResource(focus)
+						? this.tree.navigate(focus).next() ?? this.tree.navigate(focus).previous() ?? focus.resourceGroup
+						: undefined;
+
 					if (element && this.tree.hasNode(element)) {
 						// Refresh specific repository
 						await this.tree.updateChildren(element);
@@ -1993,6 +1999,13 @@ export class SCMViewPane extends ViewPane {
 
 					if (focusedInput) {
 						this.inputRenderer.getRenderedInputWidget(focusedInput)?.focus();
+					}
+
+					if (focus && nextFocus && !this.tree.hasNode(focus) && this.tree.hasNode(nextFocus)) {
+						this.tree.setFocus([nextFocus]);
+						if (treeHasDomFocus) {
+							this.tree.domFocus();
+						}
 					}
 
 					this.updateScmProviderContextKeys();


### PR DESCRIPTION
Fixes #207066. #201309 removed the general focus/selection preservation from the list/tree widgets and re-added it explicitly to the Explorer, but the SCM view never got the equivalent, so staging or unstaging dropped focus out of the resource list. This restores focus to the next resource (falling back to the previous one, then the resource group) when the focused resource is removed by a refresh, matching the behavior lszomoru outlined. Gated so focus only moves when the focused resource actually disappears; unrelated tree updates are untouched.