### PR TITLE
Sort the git timeline topologically to fix out-of-order diffs

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -70,6 +70,7 @@ export interface LogFileOptions {
 	/** Optional. Specifies whether to start retrieving log entries in reverse order. */
 	readonly reverse?: boolean;
 	readonly sortByAuthorDate?: boolean;
+	readonly sortByTopology?: boolean;
 	readonly shortStats?: boolean;
 }
 
@@ -1531,6 +1532,10 @@ export class Repository {
 
 		if (options?.sortByAuthorDate) {
 			args.push('--author-date-order');
+		}
+
+		if (options?.sortByTopology) {
+			args.push('--topo-order');
 		}
 
 		if (options?.follow) {

--- a/extensions/git/src/timelineProvider.ts
+++ b/extensions/git/src/timelineProvider.ts
@@ -144,7 +144,7 @@ export class GitTimelineProvider implements TimelineProvider {
 				hash: options.cursor,
 				follow: true,
 				shortStats: true,
-				// sortByAuthorDate: true
+				sortByTopology: true
 			},
 			token
 		);


### PR DESCRIPTION
Fixes #226068. #187174 added `--follow` to the timeline's` git log`, but without an explicit ordering git's default walk isn't strictly chronological, so consecutive timeline entries aren't parent/child and their diffs come out wrong (and merge commits appear out of place). As @thierer noted, `--topo-order` restores a correct order this passes it for the timeline's file `log`, reusing the same flag the repository log method already uses.