### PR TITLE
Cache assignment filter results per filter in the assignment service

### DIFF
--- a/src/vs/workbench/contrib/onboarding/browser/onboardingService.ts
+++ b/src/vs/workbench/contrib/onboarding/browser/onboardingService.ts
@@ -104,6 +104,7 @@ export class OnboardingScenarioService extends Disposable implements IOnboarding
 		// flags resolve. The filter blocks any id with the reserved onboarding prefix unless its
 		// gate has already been opened (this session or persisted from a previous one).
 		this.assignmentService.addTelemetryAssignmentFilter({
+			id: 'onboarding',
 			exclude: assignment => assignment.startsWith(ONBOARDING_ASSIGNMENT_CONTEXT_PREFIX) && !this._openedAssignmentContextIds.has(assignment),
 			onDidChange: this._onDidChangeOpenedIds.event
 		});

--- a/src/vs/workbench/services/assignment/common/assignmentContextFilter.ts
+++ b/src/vs/workbench/services/assignment/common/assignmentContextFilter.ts
@@ -1,0 +1,193 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import type { IAssignmentFilter } from './assignmentService.js';
+
+/**
+ * Applies the registered {@link IAssignmentFilter assignment filters} to the assignment context
+ * and remembers, per filter, which assignment-context ids each filter excluded.
+ *
+ * The excluded ids are persisted so that they stay filtered out across reloads even before the
+ * owning filter has been registered again. Once a filter is registered it becomes authoritative
+ * for its own id: the persisted state is repopulated from the ids it currently excludes and any
+ * id that is no longer excluded is dropped from storage.
+ */
+export class AssignmentContextFilter extends Disposable {
+
+	private static readonly STORAGE_KEY = 'workbench.assignment.filteredOutAssignmentContextIds';
+
+	private readonly _filters: IAssignmentFilter[] = [];
+	private readonly _filterDisposables = this._register(new DisposableStore());
+
+	/**
+	 * Assignment-context ids that were filtered out, keyed by the id of the filter that
+	 * excluded them. Entries owned by a filter that has not been registered yet are honored
+	 * across reloads so those ids stay excluded until the filter takes over.
+	 */
+	private _cachedFilteredOutIds: Map<string, Set<string>>;
+
+	/**
+	 * Ids of filters that have been registered this session. Once a filter is registered it
+	 * becomes authoritative for its own id and the persisted cache is repopulated from the
+	 * ids it actually excludes.
+	 */
+	private readonly _registeredFilterIds = new Set<string>();
+
+	private readonly _onDidChange = this._register(new Emitter<void>());
+	/** Fires when a filter is added or an already registered filter changes its exclusions. */
+	readonly onDidChange: Event<void> = this._onDidChange.event;
+
+	constructor(
+		private readonly storageService: IStorageService
+	) {
+		super();
+
+		this._cachedFilteredOutIds = this._loadFilteredOutIds();
+	}
+
+	addFilter(filter: IAssignmentFilter): void {
+		this._filters.push(filter);
+
+		// This filter now owns exclusion decisions for its id: drop the state persisted for it
+		// in a previous session and let it repopulate the cache as ids actually get filtered out.
+		this._registeredFilterIds.add(filter.id);
+		if (this._cachedFilteredOutIds.has(filter.id)) {
+			const next = new Map(this._cachedFilteredOutIds);
+			next.delete(filter.id);
+			this._storeFilteredOutIds(next);
+		}
+
+		this._filterDisposables.add(filter.onDidChange(() => this._onDidChange.fire()));
+		this._onDidChange.fire();
+	}
+
+	/**
+	 * Removes the excluded assignment-context ids from the given context and persists the
+	 * reconciled per-filter cache.
+	 */
+	filter(assignmentContext: string): string {
+		const assignments = assignmentContext.split(';');
+
+		// Fresh exclusions produced by the currently registered filters, keyed by filter id.
+		const freshFilteredOut = new Map<string, Set<string>>();
+
+		const filteredAssignments = assignments.filter(assignment => {
+			let excluded = false;
+			for (const filter of this._filters) {
+				if (filter.exclude(assignment)) {
+					let set = freshFilteredOut.get(filter.id);
+					if (!set) {
+						set = new Set<string>();
+						freshFilteredOut.set(filter.id, set);
+					}
+					set.add(assignment);
+					excluded = true;
+				}
+			}
+			if (excluded) {
+				return false;
+			}
+
+			// Honor ids cached by filters that have not been registered yet, so they remain
+			// excluded until the owning filter takes over.
+			for (const [filterId, ids] of this._cachedFilteredOutIds) {
+				if (!this._registeredFilterIds.has(filterId) && ids.has(assignment)) {
+					return false;
+				}
+			}
+
+			return true;
+		});
+
+		// Persist the reconciled cache: registered filters contribute exactly what they
+		// currently exclude (dropping ids that are no longer filtered out), while entries owned
+		// by not-yet-registered filters are preserved.
+		const next = new Map<string, Set<string>>();
+		for (const [filterId, ids] of this._cachedFilteredOutIds) {
+			if (!this._registeredFilterIds.has(filterId)) {
+				next.set(filterId, ids);
+			}
+		}
+		for (const [filterId, ids] of freshFilteredOut) {
+			next.set(filterId, ids);
+		}
+		this._storeFilteredOutIds(next);
+
+		return filteredAssignments.join(';');
+	}
+
+	private _loadFilteredOutIds(): Map<string, Set<string>> {
+		const result = new Map<string, Set<string>>();
+		const raw = this.storageService.get(AssignmentContextFilter.STORAGE_KEY, StorageScope.APPLICATION);
+		if (!raw) {
+			return result;
+		}
+
+		try {
+			const parsed = JSON.parse(raw);
+			if (parsed && typeof parsed === 'object') {
+				for (const [filterId, ids] of Object.entries(parsed)) {
+					if (Array.isArray(ids)) {
+						const set = new Set(ids.filter((id): id is string => typeof id === 'string'));
+						if (set.size > 0) {
+							result.set(filterId, set);
+						}
+					}
+				}
+			}
+		} catch {
+			// Ignore malformed cache.
+		}
+
+		return result;
+	}
+
+	private _storeFilteredOutIds(next: Map<string, Set<string>>): void {
+		// Drop empty entries so an id disappears from storage once nothing is filtered out for it.
+		const normalized = new Map<string, Set<string>>();
+		for (const [filterId, ids] of next) {
+			if (ids.size > 0) {
+				normalized.set(filterId, ids);
+			}
+		}
+
+		if (areCachesEqual(normalized, this._cachedFilteredOutIds)) {
+			return;
+		}
+
+		this._cachedFilteredOutIds = normalized;
+
+		if (normalized.size === 0) {
+			this.storageService.remove(AssignmentContextFilter.STORAGE_KEY, StorageScope.APPLICATION);
+		} else {
+			const serializable: Record<string, string[]> = {};
+			for (const [filterId, ids] of normalized) {
+				serializable[filterId] = Array.from(ids);
+			}
+			this.storageService.store(AssignmentContextFilter.STORAGE_KEY, JSON.stringify(serializable), StorageScope.APPLICATION, StorageTarget.MACHINE);
+		}
+	}
+}
+
+function areCachesEqual(a: Map<string, Set<string>>, b: Map<string, Set<string>>): boolean {
+	if (a.size !== b.size) {
+		return false;
+	}
+	for (const [filterId, ids] of a) {
+		const other = b.get(filterId);
+		if (!other || other.size !== ids.size) {
+			return false;
+		}
+		for (const id of ids) {
+			if (!other.has(id)) {
+				return false;
+			}
+		}
+	}
+	return true;
+}

--- a/src/vs/workbench/services/assignment/common/assignmentService.ts
+++ b/src/vs/workbench/services/assignment/common/assignmentService.ts
@@ -22,11 +22,17 @@ import { importAMDNodeModule } from '../../../../amdX.js';
 import { timeout } from '../../../../base/common/async.js';
 import { StopWatch } from '../../../../base/common/stopwatch.js';
 import { CopilotAssignmentFilterProvider } from './assignmentFilters.js';
+import { AssignmentContextFilter } from './assignmentContextFilter.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { experimentsEnabled } from '../../telemetry/common/workbenchTelemetryUtils.js';
 
 export interface IAssignmentFilter {
+	/**
+	 * Stable identifier for this filter. Used to persist and reconcile the set of
+	 * assignment-context ids this filter has excluded, independently of other filters.
+	 */
+	readonly id: string;
 	exclude(assignment: string): boolean;
 	onDidChange: Event<void>;
 }
@@ -69,50 +75,28 @@ class WorkbenchAssignmentServiceTelemetry extends Disposable implements IExperim
 		return this._lastAssignmentContext?.split(';');
 	}
 
-	private _assignmentFilters: IAssignmentFilter[] = [];
-	private _assignmentFilterDisposables = this._register(new DisposableStore());
-
 	constructor(
 		private readonly telemetryService: ITelemetryService,
-		private readonly productService: IProductService
+		private readonly productService: IProductService,
+		private readonly contextFilter: AssignmentContextFilter
 	) {
 		super();
-	}
 
-	private _filterAssignmentContext(assignmentContext: string): string {
-		const assignments = assignmentContext.split(';');
-
-		const filteredAssignments = assignments.filter(assignment => {
-			for (const filter of this._assignmentFilters) {
-				if (filter.exclude(assignment)) {
-					return false;
-				}
+		// Re-apply the filters whenever a filter is added or changes its exclusion decisions.
+		this._register(this.contextFilter.onDidChange(() => {
+			if (this._previousAssignmentContext) {
+				this._setAssignmentContext(this._previousAssignmentContext);
 			}
-			return true;
-		});
-
-		return filteredAssignments.join(';');
+		}));
 	}
 
 	private _setAssignmentContext(value: string): void {
-		const filteredValue = this._filterAssignmentContext(value);
+		const filteredValue = this.contextFilter.filter(value);
 		this._lastAssignmentContext = filteredValue;
 		this._onDidUpdateAssignmentContext.fire();
 
 		if (this.productService.tasConfig?.assignmentContextTelemetryPropertyName) {
 			this.telemetryService.setExperimentProperty(this.productService.tasConfig.assignmentContextTelemetryPropertyName, filteredValue);
-		}
-	}
-
-	addAssignmentFilter(filter: IAssignmentFilter): void {
-		this._assignmentFilters.push(filter);
-		this._assignmentFilterDisposables.add(filter.onDidChange(() => {
-			if (this._previousAssignmentContext) {
-				this._setAssignmentContext(this._previousAssignmentContext);
-			}
-		}));
-		if (this._previousAssignmentContext) {
-			this._setAssignmentContext(this._previousAssignmentContext);
 		}
 	}
 
@@ -153,6 +137,7 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 	private networkInitialized = false;
 	private readonly overrideInitDelay: Promise<void>;
 
+	private readonly contextFilter: AssignmentContextFilter;
 	private readonly telemetry: WorkbenchAssignmentServiceTelemetry;
 	private readonly keyValueStorage: IKeyValueStorage;
 
@@ -177,7 +162,8 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 			this.tasClient = this.setupTASClient();
 		}
 
-		this.telemetry = this._register(new WorkbenchAssignmentServiceTelemetry(telemetryService, productService));
+		this.contextFilter = this._register(new AssignmentContextFilter(storageService));
+		this.telemetry = this._register(new WorkbenchAssignmentServiceTelemetry(telemetryService, productService, this.contextFilter));
 		this._register(this.telemetry.onDidUpdateAssignmentContext(() => this._onDidRefetchAssignments.fire()));
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration('experiments.override')) {
@@ -348,7 +334,7 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 	}
 
 	addTelemetryAssignmentFilter(filter: IAssignmentFilter): void {
-		this.telemetry.addAssignmentFilter(filter);
+		this.contextFilter.addFilter(filter);
 	}
 }
 

--- a/src/vs/workbench/services/assignment/test/common/assignmentContextFilter.test.ts
+++ b/src/vs/workbench/services/assignment/test/common/assignmentContextFilter.test.ts
@@ -1,0 +1,124 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { InMemoryStorageService, IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { AssignmentContextFilter } from '../../common/assignmentContextFilter.js';
+import { IAssignmentFilter } from '../../common/assignmentService.js';
+
+const FILTERED_OUT_IDS_STORAGE_KEY = 'workbench.assignment.filteredOutAssignmentContextIds';
+
+suite('AssignmentContextFilter', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let storageService: IStorageService;
+
+	setup(() => {
+		storageService = disposables.add(new InMemoryStorageService());
+	});
+
+	function createContextFilter(): AssignmentContextFilter {
+		return disposables.add(new AssignmentContextFilter(storageService));
+	}
+
+	/** Creates a filter whose exclusion predicate can be swapped at runtime. */
+	function createFilter(id: string, initialExclude: (assignment: string) => boolean, store: DisposableStore): { filter: IAssignmentFilter; setExclude(fn: (assignment: string) => boolean): void } {
+		const onDidChange = store.add(new Emitter<void>());
+		let excludeFn = initialExclude;
+		return {
+			filter: { id, exclude: assignment => excludeFn(assignment), onDidChange: onDidChange.event },
+			setExclude(fn) {
+				excludeFn = fn;
+				onDidChange.fire();
+			}
+		};
+	}
+
+	function readCache(): Record<string, string[]> | undefined {
+		const raw = storageService.get(FILTERED_OUT_IDS_STORAGE_KEY, StorageScope.APPLICATION);
+		return raw ? JSON.parse(raw) : undefined;
+	}
+
+	test('persists filtered-out ids keyed by filter id and removes them from the context', () => {
+		const store = disposables.add(new DisposableStore());
+		const contextFilter = createContextFilter();
+		contextFilter.addFilter(createFilter('onboarding', a => a === 'onb-test1', store).filter);
+
+		const result = contextFilter.filter('onb-test1;onb-test2;keep');
+
+		assert.strictEqual(result, 'onb-test2;keep');
+		assert.deepStrictEqual(readCache(), { onboarding: ['onb-test1'] });
+	});
+
+	test('honors cached ids across reload before the owning filter is registered', () => {
+		// Simulate a previous session that persisted a filtered-out id.
+		storageService.store(FILTERED_OUT_IDS_STORAGE_KEY, JSON.stringify({ onboarding: ['onb-test1'] }), StorageScope.APPLICATION, StorageTarget.MACHINE);
+
+		const contextFilter = createContextFilter();
+
+		assert.strictEqual(contextFilter.filter('onb-test1;keep'), 'keep');
+	});
+
+	test('registering a filter drops only its own cached state and preserves other filters', () => {
+		storageService.store(FILTERED_OUT_IDS_STORAGE_KEY, JSON.stringify({ onboarding: ['onb-test1'], unification: ['cmp-ext-a'] }), StorageScope.APPLICATION, StorageTarget.MACHINE);
+
+		const store = disposables.add(new DisposableStore());
+		const contextFilter = createContextFilter();
+		// The onboarding filter is registered but no longer excludes onb-test1.
+		contextFilter.addFilter(createFilter('onboarding', () => false, store).filter);
+
+		const result = contextFilter.filter('onb-test1;cmp-ext-a;keep');
+
+		// onb-test1 is no longer excluded (its filter took over), but cmp-ext-a stays excluded
+		// because the unification filter has not been registered yet.
+		assert.strictEqual(result, 'onb-test1;keep');
+		assert.deepStrictEqual(readCache(), { unification: ['cmp-ext-a'] });
+	});
+
+	test('removes an id from storage once it is no longer filtered out', () => {
+		const store = disposables.add(new DisposableStore());
+		const contextFilter = createContextFilter();
+		const onboarding = createFilter('onboarding', a => a === 'onb-test1', store);
+		contextFilter.addFilter(onboarding.filter);
+
+		contextFilter.filter('onb-test1;keep');
+		assert.deepStrictEqual(readCache(), { onboarding: ['onb-test1'] });
+
+		// The gate opens: the filter no longer excludes the id.
+		onboarding.setExclude(() => false);
+
+		assert.strictEqual(contextFilter.filter('onb-test1;keep'), 'onb-test1;keep');
+		assert.strictEqual(readCache(), undefined);
+	});
+
+	test('tracks multiple registered filters independently', () => {
+		const store = disposables.add(new DisposableStore());
+		const contextFilter = createContextFilter();
+		contextFilter.addFilter(createFilter('onboarding', a => a.startsWith('onb-'), store).filter);
+		contextFilter.addFilter(createFilter('unification', a => a.startsWith('cmp-'), store).filter);
+
+		const result = contextFilter.filter('onb-a;cmp-b;keep');
+
+		assert.strictEqual(result, 'keep');
+		assert.deepStrictEqual(readCache(), { onboarding: ['onb-a'], unification: ['cmp-b'] });
+	});
+
+	test('fires onDidChange when a filter is added and when a filter changes', () => {
+		const store = disposables.add(new DisposableStore());
+		const contextFilter = createContextFilter();
+		let changes = 0;
+		disposables.add(contextFilter.onDidChange(() => changes++));
+
+		const onboarding = createFilter('onboarding', () => false, store);
+		contextFilter.addFilter(onboarding.filter);
+		onboarding.setExclude(a => a === 'onb-test1');
+
+		assert.strictEqual(changes, 2);
+	});
+});

--- a/src/vs/workbench/services/inlineCompletions/common/inlineCompletionsUnification.ts
+++ b/src/vs/workbench/services/inlineCompletions/common/inlineCompletionsUnification.ts
@@ -76,6 +76,7 @@ export class InlineCompletionsUnificationImpl extends Disposable implements IInl
 		this.isRunningUnificationExperiment = isRunningUnificationExperiment.bindTo(this._contextKeyService);
 
 		this._assignmentService.addTelemetryAssignmentFilter({
+			id: 'inlineCompletionsUnification',
 			exclude: (assignment) => assignment.startsWith(EXTENSION_UNIFICATION_PREFIX) && this._state.extensionUnification !== this._configurationService.getValue<boolean>(ExtensionUnificationSetting),
 			onDidChange: Event.any(this._onDidChangeExtensionUnificationState.event, this._onDidChangeExtensionUnificationSetting.event)
 		});


### PR DESCRIPTION
Caches assignment filter results in the assignment service so that filtered-out assignment-context ids stay filtered out across reloads.

## What
- When a telemetry assignment filter excludes a context id (e.g. `onb-test1`), that id is now persisted, keyed by the filter''s id.
- On reload, cached ids are honored until the owning filter is registered again, so they remain excluded from telemetry before the filter''s treatment flags resolve.
- Once a filter is registered it becomes authoritative for its own id: the persisted state is repopulated from the ids it currently excludes, and ids that are no longer excluded are dropped from storage.
- Each `IAssignmentFilter` now carries a stable `id` so cache entries are tracked per filter and reconciled independently.

## How
- Extracted all filtering + caching into a dedicated `AssignmentContextFilter` class, created and consumed by `WorkbenchAssignmentService`. `WorkbenchAssignmentServiceTelemetry` now just delegates to it.

## Testing
- Added `assignmentContextFilter.test.ts` covering persistence, cross-reload honoring, per-filter reset, removal when no longer excluded, independent multi-filter tracking, and change events.