### PR TITLE
Source turn status pills from the session output stream

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/sessionChatInputToolbar.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionChatInputToolbar.ts
@@ -17,7 +17,7 @@ import { isIChatSessionFileChange2 } from '../../../../workbench/contrib/chat/co
 import { ChatTurnPillsWidget, diffStatsEqual, EMPTY_DIFF_STATS, IChatTurnPillsModel, IDiffStats, IPreviewFile, observeTurnStatusPillsConfig, openChatPreviewFile, previewFilesEqual, previewKind } from '../../../../workbench/contrib/chat/browser/widget/chatTurnPills.js';
 import { isAgentHostProviderId } from '../../../common/agentHostSessionsProvider.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
-import { SessionStatus, TURN_CHANGES_CHANGESET_ID } from '../../../services/sessions/common/session.js';
+import { SessionStatus } from '../../../services/sessions/common/session.js';
 import { IActiveSession } from '../../../services/sessions/common/sessionsManagement.js';
 import { VIEW_SESSION_CHANGES_COMMAND_ID } from '../../changes/browser/changesActions.js';
 import './media/sessionChatInputToolbar.css';
@@ -33,20 +33,17 @@ const EMPTY_TURN_DATA: ITurnData = { stats: EMPTY_DIFF_STATS, previewFiles: [] }
 
 /**
  * Compute the current turn's diff stats and previewable files from the session's
- * "Last Turn Changes" changeset ({@link TURN_CHANGES_CHANGESET_ID}). Files are
- * classified as created vs. edited with the same rules as the Changes view (an
- * addition has no original; a deletion has no modified resource). Created files
- * are listed before edited ones so the primary (first) file is the first created
- * one, falling back to the first edited one. Returns {@link EMPTY_TURN_DATA} when
- * the session exposes no turn changeset (e.g. before its first turn).
+ * last-turn changes ({@link ISession.lastTurnChanges}), which the provider
+ * derives from the live output stream. Files are classified as created vs.
+ * edited with the same rules as the Changes view (an addition has no original; a
+ * deletion has no modified resource). Created files are listed before edited ones
+ * so the primary (first) file is the first created one, falling back to the first
+ * edited one. Returns {@link EMPTY_TURN_DATA} when the session exposes no
+ * last-turn changes (e.g. before its first turn, or a provider that can't
+ * determine them).
  */
 function computeTurnData(session: IActiveSession, reader: IReader): ITurnData {
-	const turnChangeset = session.changesets.read(reader)?.find(cs => cs.id === TURN_CHANGES_CHANGESET_ID);
-	if (!turnChangeset) {
-		return EMPTY_TURN_DATA;
-	}
-
-	const changes = turnChangeset.changes.read(reader);
+	const changes = session.lastTurnChanges?.read(reader) ?? [];
 
 	let insertions = 0, deletions = 0;
 	const created: IPreviewFile[] = [];
@@ -82,8 +79,8 @@ function turnDataEqual(a: ITurnData, b: ITurnData): boolean {
  * session status as clickable pills (see {@link ChatTurnPillsWidget}). Only shown
  * for agent host sessions while a turn is actively in progress; once the turn
  * completes the pills disappear here and reappear inside the completed response.
- * The pills are scoped to the session's "Last Turn Changes" changeset so they
- * reflect only what the most recent request produced.
+ * The pills are scoped to the session's last-turn changes so they reflect only
+ * what the most recent request produced.
  */
 export class SessionChatInputToolbar extends Disposable {
 

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionChangesets.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionChangesets.ts
@@ -96,6 +96,29 @@ export function createActiveSessionSubscriptionObs<T>(
 	});
 }
 
+/**
+ * Selects the URI of the session's most recently modified chat — the one that
+ * holds the session's "last turn". Falls back to the session's default chat (or
+ * the synthesized default chat URI) when the state is absent/errored or no chat
+ * is more recent.
+ *
+ * Shared by {@link AgentHostLastTurnChangeset} and the output-stream-derived
+ * last-turn changes so the "Last Turn Changes" changeset and the chat input
+ * status pills always resolve the same chat.
+ */
+export function selectMostRecentChatUri(sessionState: SessionState | Error | undefined | null, sessionUri: URI): URI {
+	if (!sessionState || sessionState instanceof Error) {
+		return URI.parse(buildDefaultChatUri(sessionUri));
+	}
+
+	// `modifiedAt` is ISO 8601, so lexicographic compare is chronological.
+	const mostRecentChat = sessionState.chats.reduce<ChatSummary | undefined>(
+		(best, c) => !best || c.modifiedAt > best.modifiedAt ? c : best,
+		undefined
+	);
+	return URI.parse(mostRecentChat?.resource ?? sessionState.defaultChat ?? buildDefaultChatUri(sessionUri));
+}
+
 function toSessionChangesetOperationScope(scope: ChangesetOperationScope): SessionChangesetOperationScope {
 	switch (scope) {
 		case ChangesetOperationScope.Changeset: return SessionChangesetOperationScope.Changeset;
@@ -354,16 +377,7 @@ class AgentHostLastTurnChangeset extends AbstractAgentHostChangeset {
 
 		const mostRecentChatUriObs = derivedOpts({ equalsFn: isEqual }, reader => {
 			const sessionState = sessionStateObs.read(reader).read(reader);
-			if (!sessionState || sessionState instanceof Error) {
-				return URI.parse(buildDefaultChatUri(sessionUri));
-			}
-
-			// `modifiedAt` is ISO 8601, so lexicographic compare is chronological.
-			const mostRecentChat = sessionState.chats.reduce<ChatSummary | undefined>(
-				(best, c) => !best || c.modifiedAt > best.modifiedAt ? c : best,
-				undefined
-			);
-			return URI.parse(mostRecentChat?.resource ?? sessionState.defaultChat ?? buildDefaultChatUri(sessionUri));
+			return selectMostRecentChatUri(sessionState, sessionUri);
 		});
 
 		const chatStateObs = createActiveSessionSubscriptionObs<ChatState>(

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionFiles.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionFiles.ts
@@ -12,6 +12,7 @@ import type { FileEdit } from '../../../../../platform/agentHost/common/state/pr
 import {
 	buildDefaultChatUri,
 	type ChatState,
+	type ChatSummary,
 	FileEditKind,
 	ResponsePartKind,
 	type SessionState,
@@ -21,7 +22,8 @@ import {
 	ToolCallStatus,
 	ToolResultContentType,
 } from '../../../../../platform/agentHost/common/state/sessionState.js';
-import { ISessionFile, ISessionWorkspace, SessionFileOperation } from '../../../../services/sessions/common/session.js';
+import { IChatSessionFileChange2 } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { ISessionFile, ISessionFileChange, ISessionWorkspace, SessionFileOperation, sessionFileChangesEqual } from '../../../../services/sessions/common/session.js';
 import { createActiveSessionSubscriptionObs } from './agentHostSessionChangesets.js';
 import { IAgentHostAdapterOptions } from './baseAgentHostSessionsProvider.js';
 
@@ -38,33 +40,62 @@ export interface IParsedFileEdit {
 	readonly beforeUri?: URI;
 	/** Before-content URI, used to render a diff for modified files. */
 	readonly beforeContentUri?: URI;
+	/** Lines added by this edit, from the protocol diff metadata (0 when absent). */
+	readonly insertions: number;
+	/** Lines removed by this edit, from the protocol diff metadata (0 when absent). */
+	readonly deletions: number;
 }
 
 /**
- * Builds the observable list of files that were created, edited or deleted
- * **outside** the session's workspace folders during the session.
+ * The observable outputs derived from an agent-host session's live output
+ * stream (its chat-state turns). Both are parsed from the same underlying
+ * per-chat subscriptions so the stream is only walked once.
+ */
+export interface ISessionOutputObs {
+	/**
+	 * Files created, edited or deleted **outside** the session workspace folders
+	 * during the session (e.g. config files in the user's home directory),
+	 * reduced across every chat and turn.
+	 */
+	readonly externalFiles: IObservable<readonly ISessionFile[]>;
+	/**
+	 * File changes produced by the session's **last turn** only — the in-progress
+	 * turn of the most recently modified chat, or (when idle) that chat's last
+	 * completed turn. Used by the chat input status pills to reflect just what the
+	 * most recent request produced.
+	 */
+	readonly lastTurnChanges: IObservable<readonly ISessionFileChange[]>;
+}
+
+/**
+ * Builds the observable outputs derived from a session's live output stream.
  *
- * The data is parsed from the agent-host chat-state turns: each turn's
- * response parts are scanned for tool calls, and each tool call's file-edit
- * results (and pending edits) are collected. The resulting edits are reduced
- * per file so that a file first created and then edited is reported as
- * {@link SessionFileOperation.Created}, while a deleted file is removed from
- * the list entirely.
+ * The data is parsed from the agent-host chat-state turns: each turn's response
+ * parts are scanned for tool calls, and each tool call's file-edit results (and
+ * pending edits) are collected. Two views are produced from the same parse:
+ *
+ * - {@link ISessionOutputObs.externalFiles}: edits reduced per file across all
+ *   chats/turns so that a file first created and then edited is reported as
+ *   {@link SessionFileOperation.Created} while a deleted file is removed; only
+ *   files outside the workspace folders are kept.
+ * - {@link ISessionOutputObs.lastTurnChanges}: the last turn's edits reduced per
+ *   file into {@link ISessionFileChange | changes} (with diff stats), mirroring
+ *   the "Last Turn Changes" changeset without depending on it.
  *
  * Computation only happens for the active, non-archived session: archived
  * sessions never open a live chat-state subscription, so no parsing work is
  * done for them.
  */
-export function createSessionFilesObs(
+export function createSessionOutputObs(
 	sessionUri: URI,
 	options: IAgentHostAdapterOptions,
 	isActiveSessionObs: IObservable<boolean>,
 	isArchivedObs: IObservable<boolean>,
 	workspaceObs: IObservable<ISessionWorkspace | undefined>,
-): IObservable<readonly ISessionFile[]> {
+): ISessionOutputObs {
 	const mapDiffUri = options.mapDiffUri;
 
-	// Session files are only computed for the active, non-archived session. The
+	// Session output is only computed for the active, non-archived session. The
 	// subscriptions and parsing below are all gated on this so an archived
 	// session does no work.
 	const enabledObs = derivedOpts<boolean>({ equalsFn: (a, b) => a === b }, reader =>
@@ -99,14 +130,34 @@ export function createSessionFilesObs(
 		return [...uris.values()];
 	});
 
+	// The chat that holds the session's "last turn": the most recently modified
+	// chat (its in-progress turn, or last completed turn when idle). Mirrors the
+	// "Last Turn Changes" changeset's chat selection.
+	const mostRecentChatUriObs = derivedOpts<URI>({ equalsFn: isEqual }, reader => {
+		const defaultChatUri = URI.parse(buildDefaultChatUri(sessionUri));
+		if (!enabledObs.read(reader)) {
+			return defaultChatUri;
+		}
+		const sessionState = sessionStateObs.read(reader).read(reader);
+		if (!sessionState || sessionState instanceof Error) {
+			return defaultChatUri;
+		}
+		// `modifiedAt` is ISO 8601, so lexicographic compare is chronological.
+		const mostRecentChat = sessionState.chats.reduce<ChatSummary | undefined>(
+			(best, c) => !best || c.modifiedAt > best.modifiedAt ? c : best,
+			undefined,
+		);
+		return URI.parse(mostRecentChat?.resource ?? sessionState.defaultChat ?? buildDefaultChatUri(sessionUri));
+	});
+
 	// One observable of parsed edits per chat, subscribing to that chat's state.
 	//
 	// Completed turns (`chatState.turns`) are immutable once finalized, so each
 	// is parsed exactly once and memoized by turn id in a closure-scoped cache
 	// that lives for the chat's lifetime. Only the in-progress `activeTurn` is
 	// re-parsed on every streamed delta, making delta updates O(active turn)
-	// rather than O(all turns). The `equalsFn` ensures the downstream reducer
-	// only re-runs when the parsed edits actually change (e.g. not for markdown
+	// rather than O(all turns). The `equalsFn` ensures the downstream reducers
+	// only re-run when the parsed edits actually change (e.g. not for markdown
 	// or reasoning deltas that carry no file edits).
 	const editsPerChatObs = mapObservableArrayCached(undefined, chatUrisObs, (chatUri) => {
 		const chatStateObs = createActiveSessionSubscriptionObs<ChatState>(
@@ -116,26 +167,39 @@ export function createSessionFilesObs(
 			constObservable(chatUri),
 		);
 		const parse = createIncrementalChatFileEditsParser(mapDiffUri);
-		return derivedOpts<readonly IParsedFileEdit[]>({ equalsFn: parsedFileEditsEqual }, reader => {
+		return derivedOpts<IChatFileEdits & { readonly chatUri: URI }>({ equalsFn: (a, b) => isEqual(a.chatUri, b.chatUri) && chatFileEditsEqual(a, b) }, reader => {
 			const chatState = chatStateObs.read(reader).read(reader);
 			if (!chatState || chatState instanceof Error) {
-				return [];
+				return { chatUri, allEdits: [], lastTurnEdits: [] };
 			}
-			return parse(chatState);
+			return { chatUri, ...parse(chatState) };
 		});
 	}, chatUri => chatUri.toString());
 
-	return derivedOpts<readonly ISessionFile[]>({ equalsFn: sessionFilesEqual }, reader => {
+	const externalFiles = derivedOpts<readonly ISessionFile[]>({ equalsFn: sessionFilesEqual }, reader => {
 		const workspace = workspaceObs.read(reader);
 		const folderRoots = (workspace?.folders ?? []).map(f => f.workingDirectory);
 
 		const allEdits: IParsedFileEdit[] = [];
 		for (const chatEditsObs of editsPerChatObs.read(reader)) {
-			allEdits.push(...chatEditsObs.read(reader));
+			allEdits.push(...chatEditsObs.read(reader).allEdits);
 		}
 
 		return reduceSessionFiles(allEdits, folderRoots);
 	});
+
+	const lastTurnChanges = derivedOpts<readonly ISessionFileChange[]>({ equalsFn: sessionFileChangesEqual }, reader => {
+		const mostRecentChatUri = mostRecentChatUriObs.read(reader);
+		for (const chatEditsObs of editsPerChatObs.read(reader)) {
+			const chatEdits = chatEditsObs.read(reader);
+			if (isEqual(chatEdits.chatUri, mostRecentChatUri)) {
+				return reduceTurnChanges(chatEdits.lastTurnEdits);
+			}
+		}
+		return [];
+	});
+
+	return { externalFiles, lastTurnChanges };
 }
 
 /**
@@ -158,13 +222,31 @@ export interface IFileEditChatState {
 export type ParseTurnFileEdits = (responseParts: Turn['responseParts']) => readonly IParsedFileEdit[];
 
 /**
- * Creates a stateful parser that turns a chat state into its ordered list of
- * file edits, **parsing each completed turn at most once**.
+ * The file edits parsed from a chat's output stream, split into the full set
+ * (across all turns) and the last turn's edits alone.
+ */
+export interface IChatFileEdits {
+	/** All file edits across the chat's turns, in stream order. */
+	readonly allEdits: readonly IParsedFileEdit[];
+	/**
+	 * File edits of the chat's last turn only — the in-progress `activeTurn` when
+	 * present, otherwise the most recently completed turn.
+	 */
+	readonly lastTurnEdits: readonly IParsedFileEdit[];
+}
+
+/**
+ * Creates a stateful parser that turns a chat state into its file edits,
+ * **parsing each completed turn at most once**.
  *
  * Completed turns (`chatState.turns`) are immutable once finalized, so each is
  * parsed once and memoized by turn id in the returned closure. Only the
  * in-progress `activeTurn` is re-parsed on every call, making streamed-delta
  * updates O(active turn) rather than O(all turns).
+ *
+ * Returns both the full edit list (for session-wide reductions) and the last
+ * turn's edits alone (for turn-scoped reductions); the active turn is parsed
+ * once and reused for both.
  *
  * @param mapDiffUri Optional URI mapper applied while parsing.
  * @param parseTurn Per-turn parse function. Defaults to {@link parseResponseParts};
@@ -173,11 +255,11 @@ export type ParseTurnFileEdits = (responseParts: Turn['responseParts']) => reado
 export function createIncrementalChatFileEditsParser(
 	mapDiffUri?: (uri: URI) => URI,
 	parseTurn: ParseTurnFileEdits = responseParts => parseResponseParts(responseParts, mapDiffUri),
-): (chatState: IFileEditChatState) => IParsedFileEdit[] {
+): (chatState: IFileEditChatState) => IChatFileEdits {
 	const completedTurnCache = new Map<string, readonly IParsedFileEdit[]>();
 
-	return (chatState: IFileEditChatState): IParsedFileEdit[] => {
-		const edits: IParsedFileEdit[] = [];
+	return (chatState: IFileEditChatState): IChatFileEdits => {
+		const allEdits: IParsedFileEdit[] = [];
 		const turns: readonly IFileEditTurn[] = chatState.turns ?? [];
 
 		// Evict cache entries for turns that are no longer completed (e.g. a turn
@@ -197,15 +279,24 @@ export function createIncrementalChatFileEditsParser(
 				completedTurnCache.set(turn.id, parsed);
 			}
 			if (parsed.length > 0) {
-				edits.push(...parsed);
+				allEdits.push(...parsed);
 			}
 		}
 
+		// The last turn is the in-progress one when streaming, else the most
+		// recently completed turn. The active turn is parsed a single time and
+		// reused for both `allEdits` and `lastTurnEdits`.
+		let lastTurnEdits: readonly IParsedFileEdit[];
 		if (chatState.activeTurn) {
-			edits.push(...parseTurn(chatState.activeTurn.responseParts));
+			lastTurnEdits = parseTurn(chatState.activeTurn.responseParts);
+			allEdits.push(...lastTurnEdits);
+		} else if (turns.length > 0) {
+			lastTurnEdits = completedTurnCache.get(turns[turns.length - 1].id) ?? [];
+		} else {
+			lastTurnEdits = [];
 		}
 
-		return edits;
+		return { allEdits, lastTurnEdits };
 	};
 }
 
@@ -262,6 +353,8 @@ function parseFileEdit(fileEdit: FileEdit, mapDiffUri?: (uri: URI) => URI): IPar
 		afterUri: map(normalized.afterUri),
 		beforeUri: map(normalized.beforeUri),
 		beforeContentUri: map(normalized.beforeContentUri),
+		insertions: fileEdit.diff?.added ?? 0,
+		deletions: fileEdit.diff?.removed ?? 0,
 	};
 }
 
@@ -356,6 +449,113 @@ export function reduceSessionFiles(edits: readonly IParsedFileEdit[], folderRoot
 	return files;
 }
 
+interface IMutableTurnChange {
+	uri: URI;
+	modifiedUri: URI | undefined;
+	originalUri: URI | undefined;
+	/** Whether the file was created during the turn (kept across later edits). */
+	created: boolean;
+	insertions: number;
+	deletions: number;
+}
+
+/**
+ * Reduces a single turn's parsed file edits into one {@link ISessionFileChange}
+ * per file, aggregating diff stats. Mirrors the "Last Turn Changes" changeset
+ * so consumers (e.g. the chat input status pills) can reflect the last turn
+ * straight from the output stream.
+ *
+ * Rules:
+ * - Repeated edits to the same file collapse into a single change whose
+ *   insertions/deletions are the sum of the individual edits.
+ * - A file created during the turn stays a creation (no original side) even if
+ *   edited afterwards.
+ * - A create/edit followed by a delete in the same turn nets out; a pre-existing
+ *   file deleted during the turn is surfaced as a deletion (no modified side to
+ *   preview) but still counted in the stats.
+ * - Renames drop the source and surface the target as an edit of its
+ *   before-content, matching the changeset's classification.
+ */
+export function reduceTurnChanges(edits: readonly IParsedFileEdit[]): IChatSessionFileChange2[] {
+	const byUri = new Map<string, IMutableTurnChange>();
+
+	const setCreated = (uri: URI, insertions: number, deletions: number): void => {
+		const key = getComparisonKey(uri);
+		const existing = byUri.get(key);
+		if (existing) {
+			existing.created = true;
+			existing.modifiedUri = uri;
+			existing.originalUri = undefined;
+			existing.insertions += insertions;
+			existing.deletions += deletions;
+			return;
+		}
+		byUri.set(key, { uri, modifiedUri: uri, originalUri: undefined, created: true, insertions, deletions });
+	};
+
+	const setModified = (uri: URI, originalUri: URI | undefined, insertions: number, deletions: number): void => {
+		const key = getComparisonKey(uri);
+		const existing = byUri.get(key);
+		if (existing) {
+			existing.insertions += insertions;
+			existing.deletions += deletions;
+			if (!existing.created) {
+				// Keep the earliest known original content for the diff.
+				existing.originalUri = existing.originalUri ?? originalUri;
+			}
+			return;
+		}
+		byUri.set(key, { uri, modifiedUri: uri, originalUri, created: false, insertions, deletions });
+	};
+
+	const setDeleted = (uri: URI, originalUri: URI | undefined, insertions: number, deletions: number): void => {
+		const key = getComparisonKey(uri);
+		if (byUri.has(key)) {
+			// Created/edited earlier in the same turn and now deleted: nets out.
+			byUri.delete(key);
+			return;
+		}
+		// Pre-existing file deleted during the turn: no modified side to preview.
+		byUri.set(key, { uri, modifiedUri: undefined, originalUri, created: false, insertions, deletions });
+	};
+
+	for (const edit of edits) {
+		switch (edit.kind) {
+			case FileEditKind.Create:
+				if (edit.afterUri) {
+					setCreated(edit.afterUri, edit.insertions, edit.deletions);
+				}
+				break;
+			case FileEditKind.Edit:
+				if (edit.afterUri) {
+					setModified(edit.afterUri, edit.beforeContentUri, edit.insertions, edit.deletions);
+				}
+				break;
+			case FileEditKind.Delete:
+				if (edit.beforeUri) {
+					setDeleted(edit.beforeUri, edit.beforeContentUri, edit.insertions, edit.deletions);
+				}
+				break;
+			case FileEditKind.Rename:
+				if (edit.beforeUri) {
+					byUri.delete(getComparisonKey(edit.beforeUri));
+				}
+				if (edit.afterUri) {
+					setModified(edit.afterUri, edit.beforeContentUri, edit.insertions, edit.deletions);
+				}
+				break;
+		}
+	}
+
+	return [...byUri.values()].map(c => ({
+		uri: c.uri,
+		modifiedUri: c.modifiedUri,
+		originalUri: c.originalUri,
+		insertions: c.insertions,
+		deletions: c.deletions,
+	} satisfies IChatSessionFileChange2));
+}
+
 function sessionFilesEqual(a: readonly ISessionFile[], b: readonly ISessionFile[]): boolean {
 	if (a.length !== b.length) {
 		return false;
@@ -371,9 +571,10 @@ function sessionFilesEqual(a: readonly ISessionFile[], b: readonly ISessionFile[
 }
 
 /**
- * Structural equality over parsed edits, used as the per-chat observable's
- * `equalsFn` so streamed deltas that carry no file-edit change (e.g. markdown
- * or reasoning content) don't re-run the downstream reducer.
+ * Structural equality over parsed edits, used (via {@link chatFileEditsEqual})
+ * as the per-chat observable's `equalsFn` so streamed deltas that carry no
+ * file-edit change (e.g. markdown or reasoning content) don't re-run the
+ * downstream reducers.
  */
 function parsedFileEditsEqual(a: readonly IParsedFileEdit[], b: readonly IParsedFileEdit[]): boolean {
 	if (a === b) {
@@ -384,6 +585,8 @@ function parsedFileEditsEqual(a: readonly IParsedFileEdit[], b: readonly IParsed
 	}
 	for (let i = 0; i < a.length; i++) {
 		if (a[i].kind !== b[i].kind
+			|| a[i].insertions !== b[i].insertions
+			|| a[i].deletions !== b[i].deletions
 			|| !isEqual(a[i].afterUri, b[i].afterUri)
 			|| !isEqual(a[i].beforeUri, b[i].beforeUri)
 			|| !isEqual(a[i].beforeContentUri, b[i].beforeContentUri)) {
@@ -391,4 +594,9 @@ function parsedFileEditsEqual(a: readonly IParsedFileEdit[], b: readonly IParsed
 		}
 	}
 	return true;
+}
+
+/** Structural equality over a chat's parsed edits (full set and last turn). */
+function chatFileEditsEqual(a: IChatFileEdits, b: IChatFileEdits): boolean {
+	return parsedFileEditsEqual(a.allEdits, b.allEdits) && parsedFileEditsEqual(a.lastTurnEdits, b.lastTurnEdits);
 }

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionFiles.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionFiles.ts
@@ -12,7 +12,6 @@ import type { FileEdit } from '../../../../../platform/agentHost/common/state/pr
 import {
 	buildDefaultChatUri,
 	type ChatState,
-	type ChatSummary,
 	FileEditKind,
 	ResponsePartKind,
 	type SessionState,
@@ -24,7 +23,7 @@ import {
 } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { IChatSessionFileChange2 } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ISessionFile, ISessionFileChange, ISessionWorkspace, SessionFileOperation, sessionFileChangesEqual } from '../../../../services/sessions/common/session.js';
-import { createActiveSessionSubscriptionObs } from './agentHostSessionChangesets.js';
+import { createActiveSessionSubscriptionObs, selectMostRecentChatUri } from './agentHostSessionChangesets.js';
 import { IAgentHostAdapterOptions } from './baseAgentHostSessionsProvider.js';
 
 /**
@@ -132,22 +131,13 @@ export function createSessionOutputObs(
 
 	// The chat that holds the session's "last turn": the most recently modified
 	// chat (its in-progress turn, or last completed turn when idle). Mirrors the
-	// "Last Turn Changes" changeset's chat selection.
+	// "Last Turn Changes" changeset's chat selection via the shared helper.
 	const mostRecentChatUriObs = derivedOpts<URI>({ equalsFn: isEqual }, reader => {
-		const defaultChatUri = URI.parse(buildDefaultChatUri(sessionUri));
 		if (!enabledObs.read(reader)) {
-			return defaultChatUri;
+			return URI.parse(buildDefaultChatUri(sessionUri));
 		}
 		const sessionState = sessionStateObs.read(reader).read(reader);
-		if (!sessionState || sessionState instanceof Error) {
-			return defaultChatUri;
-		}
-		// `modifiedAt` is ISO 8601, so lexicographic compare is chronological.
-		const mostRecentChat = sessionState.chats.reduce<ChatSummary | undefined>(
-			(best, c) => !best || c.modifiedAt > best.modifiedAt ? c : best,
-			undefined,
-		);
-		return URI.parse(mostRecentChat?.resource ?? sessionState.defaultChat ?? buildDefaultChatUri(sessionUri));
+		return selectMostRecentChatUri(sessionState, sessionUri);
 	});
 
 	// One observable of parsed edits per chat, subscribing to that chat's state.

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -53,7 +53,7 @@ import { computePullRequestIcon, GitHubPullRequestState } from '../../../github/
 import { IPullRequestIconCache } from '../../../github/browser/pullRequestIconCache.js';
 import { mapProtocolStatus } from './agentHostDiffs.js';
 import { createChangesets } from './agentHostSessionChangesets.js';
-import { createSessionFilesObs } from './agentHostSessionFiles.js';
+import { createSessionOutputObs } from './agentHostSessionFiles.js';
 
 const STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES = 'sessions.agentHost.sessionConfigPicker.selectedValues';
 const UNSAFE_SESSION_CONFIG_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
@@ -393,6 +393,7 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 	readonly changes: IObservable<readonly (IChatSessionFileChange | IChatSessionFileChange2)[]>;
 	readonly changesets: ISettableObservable<readonly ISessionChangeset[] | undefined>;
 	readonly externalChanges: IObservable<readonly ISessionFile[]>;
+	readonly lastTurnChanges: IObservable<readonly ISessionFileChange[]>;
 	readonly modelId: ISettableObservable<string | undefined>;
 	modelSelection: ModelSelection | undefined;
 	readonly mode: ISettableObservable<{ readonly id: string; readonly kind: string } | undefined>;
@@ -671,11 +672,13 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 		// changeset.
 		this.changes = this._createChangesObs();
 
-		// Files created/edited/deleted outside the workspace, parsed from the
-		// chat-state turns. Computed lazily from the same active-session
-		// subscriptions used for changes.
+		// Files created/edited/deleted outside the workspace, plus the last turn's
+		// changes, parsed from the chat-state turns. Computed lazily from the same
+		// active-session subscriptions used for changes.
 		const sessionUri = AgentSession.uri(this.sessionType, rawId);
-		this.externalChanges = createSessionFilesObs(sessionUri, this._options, this.isActiveSessionObs, this.isArchived, this.workspace);
+		const sessionOutput = createSessionOutputObs(sessionUri, this._options, this.isActiveSessionObs, this.isArchived, this.workspace);
+		this.externalChanges = sessionOutput.externalFiles;
+		this.lastTurnChanges = sessionOutput.lastTurnChanges;
 
 		const mainChat: IChat = {
 			resource: this.resource,

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostSessionFiles.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/agentHostSessionFiles.test.ts
@@ -21,6 +21,7 @@ import {
 	IParsedFileEdit,
 	parseResponseParts,
 	reduceSessionFiles,
+	reduceTurnChanges,
 } from '../../browser/agentHostSessionFiles.js';
 
 // ── Protocol fixture helpers ────────────────────────────────────────────────
@@ -62,28 +63,31 @@ function pendingConfirmationToolCallPart(items: object[]): ResponsePart {
 	});
 }
 
-function createEdit(uri: string): object {
-	return { type: ToolResultContentType.FileEdit, after: { uri, content: { uri: `${uri}.after` } } };
+function createEdit(uri: string, diff?: { added?: number; removed?: number }): object {
+	return { type: ToolResultContentType.FileEdit, after: { uri, content: { uri: `${uri}.after` } }, diff };
 }
 
-function editEdit(uri: string): object {
+function editEdit(uri: string, diff?: { added?: number; removed?: number }): object {
 	return {
 		type: ToolResultContentType.FileEdit,
 		before: { uri, content: { uri: `${uri}.before` } },
 		after: { uri, content: { uri: `${uri}.after` } },
+		diff,
 	};
 }
 
-function deleteEdit(uri: string): object {
-	return { type: ToolResultContentType.FileEdit, before: { uri, content: { uri: `${uri}.before` } } };
+function deleteEdit(uri: string, diff?: { added?: number; removed?: number }): object {
+	return { type: ToolResultContentType.FileEdit, before: { uri, content: { uri: `${uri}.before` } }, diff };
 }
 
-function parsedEdit(kind: FileEditKind, uris: { after?: string; before?: string; beforeContent?: string }): IParsedFileEdit {
+function parsedEdit(kind: FileEditKind, uris: { after?: string; before?: string; beforeContent?: string }, diff?: { insertions?: number; deletions?: number }): IParsedFileEdit {
 	return {
 		kind,
 		afterUri: uris.after ? URI.file(uris.after) : undefined,
 		beforeUri: uris.before ? URI.file(uris.before) : undefined,
 		beforeContentUri: uris.beforeContent ? URI.file(uris.beforeContent) : undefined,
+		insertions: diff?.insertions ?? 0,
+		deletions: diff?.deletions ?? 0,
 	};
 }
 
@@ -138,7 +142,7 @@ suite('agentHostSessionFiles', () => {
 		);
 	});
 
-	test('incremental parser keeps completed-turn edits while a new turn streams', () => {
+	test('incremental parser keeps completed-turn edits while a new turn streams and tracks the last turn', () => {
 		const parse = createIncrementalChatFileEditsParser();
 
 		const t1Parts = [completedToolCallPart([createEdit('file:///a.txt')])];
@@ -152,12 +156,19 @@ suite('agentHostSessionFiles', () => {
 
 		assert.deepStrictEqual(
 			{
-				first: first.map(e => e.afterUri?.toString()),
-				streaming: streaming.map(e => e.afterUri?.toString()),
+				firstAll: first.allEdits.map(e => e.afterUri?.toString()),
+				firstLastTurn: first.lastTurnEdits.map(e => e.afterUri?.toString()),
+				streamingAll: streaming.allEdits.map(e => e.afterUri?.toString()),
+				streamingLastTurn: streaming.lastTurnEdits.map(e => e.afterUri?.toString()),
 			},
 			{
-				first: ['file:///a.txt'],
-				streaming: ['file:///a.txt', 'file:///b.txt'],
+				// When idle, the last turn is the most recently completed turn.
+				firstAll: ['file:///a.txt'],
+				firstLastTurn: ['file:///a.txt'],
+				// While streaming, `allEdits` unions every turn but `lastTurnEdits`
+				// reflects only the in-progress turn.
+				streamingAll: ['file:///a.txt', 'file:///b.txt'],
+				streamingLastTurn: ['file:///b.txt'],
 			},
 		);
 	});
@@ -229,5 +240,59 @@ suite('agentHostSessionFiles', () => {
 		const files = reduceSessionFiles(edits, [URI.file('/repo')]);
 
 		assert.deepStrictEqual(files, []);
+	});
+
+	test('reduceTurnChanges collapses repeated edits per file and aggregates diff stats', () => {
+		const edits: IParsedFileEdit[] = [
+			// created then edited → one created change, summed diffs, no original side
+			parsedEdit(FileEditKind.Create, { after: '/repo/new.ts' }, { insertions: 10 }),
+			parsedEdit(FileEditKind.Edit, { after: '/repo/new.ts', beforeContent: '/repo/new.ts.before' }, { insertions: 3, deletions: 1 }),
+			// pre-existing file edited twice → one modified change keeping the first original
+			parsedEdit(FileEditKind.Edit, { after: '/repo/existing.ts', beforeContent: '/repo/existing.ts.before' }, { insertions: 2, deletions: 4 }),
+			parsedEdit(FileEditKind.Edit, { after: '/repo/existing.ts', beforeContent: '/repo/existing.ts.before2' }, { insertions: 1 }),
+			// pre-existing file deleted → surfaced as a deletion (no modified side)
+			parsedEdit(FileEditKind.Delete, { before: '/repo/gone.ts', beforeContent: '/repo/gone.ts.before' }, { deletions: 8 }),
+		];
+
+		const changes = reduceTurnChanges(edits).map(c => ({
+			uri: c.uri.path,
+			modified: c.modifiedUri?.path,
+			original: c.originalUri?.path,
+			insertions: c.insertions,
+			deletions: c.deletions,
+		}));
+
+		assert.deepStrictEqual(changes, [
+			{ uri: '/repo/new.ts', modified: '/repo/new.ts', original: undefined, insertions: 13, deletions: 1 },
+			{ uri: '/repo/existing.ts', modified: '/repo/existing.ts', original: '/repo/existing.ts.before', insertions: 3, deletions: 4 },
+			{ uri: '/repo/gone.ts', modified: undefined, original: '/repo/gone.ts.before', insertions: 0, deletions: 8 },
+		]);
+	});
+
+	test('reduceTurnChanges nets out a file created and then deleted in the same turn', () => {
+		const edits: IParsedFileEdit[] = [
+			parsedEdit(FileEditKind.Create, { after: '/repo/scratch.tmp' }, { insertions: 5 }),
+			parsedEdit(FileEditKind.Delete, { before: '/repo/scratch.tmp' }),
+		];
+
+		assert.deepStrictEqual(reduceTurnChanges(edits), []);
+	});
+
+	test('reduceTurnChanges reports a rename as an edit of the target and drops the source', () => {
+		const edits: IParsedFileEdit[] = [
+			parsedEdit(FileEditKind.Rename, { before: '/repo/old.ts', after: '/repo/renamed.ts', beforeContent: '/repo/old.ts.before' }, { insertions: 1, deletions: 2 }),
+		];
+
+		const changes = reduceTurnChanges(edits).map(c => ({
+			uri: c.uri.path,
+			modified: c.modifiedUri?.path,
+			original: c.originalUri?.path,
+			insertions: c.insertions,
+			deletions: c.deletions,
+		}));
+
+		assert.deepStrictEqual(changes, [
+			{ uri: '/repo/renamed.ts', modified: '/repo/renamed.ts', original: '/repo/old.ts.before', insertions: 1, deletions: 2 },
+		]);
 	});
 });

--- a/src/vs/sessions/services/sessions/browser/visibleSessions.ts
+++ b/src/vs/sessions/services/sessions/browser/visibleSessions.ts
@@ -263,6 +263,7 @@ export class VisibleSession extends Disposable implements IActiveSession {
 	get changesets() { return this._session.changesets; }
 	get changes() { return this._session.changes; }
 	get externalChanges() { return this._session.externalChanges; }
+	get lastTurnChanges() { return this._session.lastTurnChanges; }
 	get modelId() { return this._activeChatModelId; }
 	get mode() { return this._activeChatMode; }
 	get loading() { return this._session.loading; }
@@ -304,6 +305,7 @@ class ResourceOverrideSession implements ISession {
 	get changes() { return this._session.changes; }
 	get changesets() { return this._session.changesets; }
 	get externalChanges() { return this._session.externalChanges; }
+	get lastTurnChanges() { return this._session.lastTurnChanges; }
 	get modelId() { return this._session.modelId; }
 	get mode() { return this._session.mode; }
 	get loading() { return this._session.loading; }

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -476,6 +476,14 @@ export interface ISession {
 	 * cannot determine this report an empty array (or omit the observable).
 	 */
 	readonly externalChanges?: IObservable<readonly ISessionFile[]>;
+	/**
+	 * File changes produced by the session's **last turn** only (as opposed to
+	 * the cumulative session {@link changes}). Derived from the session's live
+	 * output stream so consumers — e.g. the chat input status pills — can reflect
+	 * just what the most recent request produced. Providers that cannot determine
+	 * this omit the observable.
+	 */
+	readonly lastTurnChanges?: IObservable<readonly ISessionFileChange[]>;
 	/** Currently selected model identifier. */
 	readonly modelId: IObservable<string | undefined>;
 	readonly mode: IObservable<{ readonly id: string; readonly kind: string } | undefined>;

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/sessionChatInputToolbar.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/sessionChatInputToolbar.fixture.ts
@@ -14,7 +14,7 @@ import { SessionChatInputToolbar } from '../../../../../sessions/contrib/chat/br
 // eslint-disable-next-line local/code-import-patterns
 import { LOCAL_AGENT_HOST_PROVIDER_ID } from '../../../../../sessions/common/agentHostSessionsProvider.js';
 // eslint-disable-next-line local/code-import-patterns
-import { ISessionChangeset, ISessionFileChange, SessionStatus, TURN_CHANGES_CHANGESET_ID } from '../../../../../sessions/services/sessions/common/session.js';
+import { ISessionFileChange, SessionStatus } from '../../../../../sessions/services/sessions/common/session.js';
 // eslint-disable-next-line local/code-import-patterns
 import { IActiveSession } from '../../../../../sessions/services/sessions/common/sessionsManagement.js';
 import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup } from '../fixtureUtils.js';
@@ -27,37 +27,29 @@ import { IFixtureMessage, renderChatWidget } from '../chat/chatWidget.fixture.js
 
 /** A file created during the turn (no original => classified as "created"). */
 function createdFile(name: string, insertions: number, deletions: number): ISessionFileChange {
-	return { modifiedUri: URI.file(`/repo/${name}`), insertions, deletions };
+	return { uri: URI.file(`/repo/${name}`), modifiedUri: URI.file(`/repo/${name}`), insertions, deletions };
 }
 
 /** A file edited during the turn (has an original => classified as "modified"). */
 function editedFile(name: string, insertions: number, deletions: number): ISessionFileChange {
 	const uri = URI.file(`/repo/${name}`);
-	return { modifiedUri: uri, originalUri: uri, insertions, deletions };
-}
-
-/** A single "Last Turn Changes" changeset carrying the given file changes. */
-function turnChangeset(changes: readonly ISessionFileChange[]): ISessionChangeset {
-	return new class extends mock<ISessionChangeset>() {
-		override readonly id = TURN_CHANGES_CHANGESET_ID;
-		override readonly changes: IObservable<readonly ISessionFileChange[]> = constObservable(changes);
-	}();
+	return { uri, modifiedUri: uri, originalUri: uri, insertions, deletions };
 }
 
 interface ISessionSpec {
 	readonly providerId?: string;
-	/** File changes in the current turn; omit for a session with no turn changeset. */
+	/** File changes in the last turn; omit for a session with no last-turn changes. */
 	readonly turnChanges?: readonly ISessionFileChange[];
 }
 
 function createMockSession(spec: ISessionSpec): IActiveSession {
-	const changesets = spec.turnChanges !== undefined ? [turnChangeset(spec.turnChanges)] : [];
 	return new class extends mock<IActiveSession>() {
 		override readonly resource = URI.parse('session:1');
 		override readonly providerId = spec.providerId ?? LOCAL_AGENT_HOST_PROVIDER_ID;
 		// Pills above the input only show while a turn is actively in progress.
 		override readonly status: IObservable<SessionStatus> = constObservable(SessionStatus.InProgress);
-		override readonly changesets: IObservable<readonly ISessionChangeset[] | undefined> = constObservable(changesets);
+		override readonly lastTurnChanges: IObservable<readonly ISessionFileChange[]> | undefined =
+			spec.turnChanges !== undefined ? constObservable(spec.turnChanges) : undefined;
 	}();
 }
 


### PR DESCRIPTION
Refactors the chat input turn-status pills to source their data from the session's live output stream instead of the `Last Turn Changes` changeset.

## Changes
- `createSessionFilesObs` → **`createSessionOutputObs`**, now returning `{ externalFiles, lastTurnChanges }` derived from a single pass over the per-chat subscriptions (efficient incremental parsing preserved).
- `IParsedFileEdit` now carries `insertions`/`deletions` from the protocol `FileEdit.diff`.
- `createIncrementalChatFileEditsParser` returns `{ allEdits, lastTurnEdits }` — each completed turn parsed once, active turn parsed once.
- Added `reduceTurnChanges` to reduce the last turn's edits into one change per file with aggregated diff stats.
- Exposed optional `lastTurnChanges` on `ISession` (common `ISessionFileChange` type; no browser types leak into the common layer) and proxied it in `visibleSessions`.
- `computeTurnData` in the chat input toolbar now reads `session.lastTurnChanges` and classifies created vs edited / previewable files in the UI layer.

## Validation
- `npm run typecheck-client` passes clean
- ESLint passes on all changed files
- Updated + added unit tests for `lastTurnEdits` and `reduceTurnChanges`