### PR TITLE
feat(chat): Enhance chat session management and user preferences

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -35,6 +35,7 @@ import { INotificationService } from '../../../../../platform/notification/commo
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
 import product from '../../../../../platform/product/common/product.js';
 import { GitHubPaths, IDefaultAccountService } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { ActiveEditorContext } from '../../../../common/contextkeys.js';
 import { IViewDescriptorService, ViewContainerLocation } from '../../../../common/views.js';
@@ -451,7 +452,7 @@ abstract class OpenChatGlobalAction extends Action2 {
 			if (!chatModeCheck) {
 				return;
 			}
-			chatWidget.input.setChatMode(switchToMode.id);
+			chatWidget.input.setChatMode(switchToMode.id, true, true);
 
 			if (chatModeCheck.needToClearSession) {
 				await commandService.executeCommand(ACTION_ID_NEW_CHAT);
@@ -573,12 +574,10 @@ export abstract class ModeOpenChatGlobalAction extends OpenChatGlobalAction {
 export function registerChatActions() {
 	/**
 	 * Returns the session URI to use when opening a brand-new chat editor,
-	 * honoring the experimental {@link ChatConfiguration.EditorDefaultProvider}
-	 * setting. Falls back to a new local session when the setting selects
-	 * `local` or the chosen provider is unavailable.
+	 * honoring the remembered harness preference and then the configured default.
 	 */
 	function getNewChatEditorSessionUri(accessor: ServicesAccessor): URI {
-		return getDefaultNewChatSessionResource(accessor.get(IConfigurationService), accessor.get(IChatSessionsService));
+		return getDefaultNewChatSessionResource(accessor.get(IConfigurationService), accessor.get(IChatSessionsService), accessor.get(IStorageService));
 	}
 
 	registerAction2(PrimaryOpenChatGlobalAction);
@@ -1760,15 +1759,13 @@ export interface IClearEditingSessionConfirmationOptions {
 }
 
 /**
- * Clears the current chat session and starts a new one, preserving
- * the session type (e.g. Claude, Cloud, Background) for non-local sessions
- * in the sidebar.
+ * Clears the current chat session and starts a new one using the shared
+ * new-session harness resolver.
  */
-export async function clearChatSessionPreservingType(widget: IChatWidget, viewsService: IViewsService, sessionType: string | undefined, configurationService: IConfigurationService, chatSessionsService: IChatSessionsService): Promise<void> {
+export async function clearChatSessionPreservingType(widget: IChatWidget, viewsService: IViewsService, sessionType: string | undefined, configurationService: IConfigurationService, chatSessionsService: IChatSessionsService, storageService: IStorageService): Promise<void> {
 	const currentResource = widget.viewModel?.model.sessionResource;
-	const defaultType = getDefaultNewChatSessionType(configurationService, chatSessionsService);
 	const currentSessionType = currentResource ? getChatSessionType(currentResource) : undefined;
-	const newSessionType = sessionType ?? (currentSessionType === localChatSessionType && defaultType !== localChatSessionType ? defaultType : currentSessionType ?? defaultType);
+	const newSessionType = getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, { explicitOverride: sessionType, currentSessionType });
 	if (isIChatViewViewContext(widget.viewContext) && newSessionType !== localChatSessionType) {
 		// For the sidebar, we need to explicitly load a session with the same type
 		const newResource = URI.from({ scheme: newSessionType, path: `/untitled-${generateUuid()}` });

--- a/src/vs/workbench/contrib/chat/browser/actions/chatClear.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatClear.ts
@@ -7,6 +7,7 @@ import { Schemas } from '../../../../../base/common/network.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IChatSessionsService } from '../../common/chatSessionsService.js';
 import { getDefaultNewChatSessionResource } from '../../common/constants.js';
@@ -17,6 +18,7 @@ export async function clearChatEditor(accessor: ServicesAccessor, chatEditorInpu
 	const editorService = accessor.get(IEditorService);
 	const configurationService = accessor.get(IConfigurationService);
 	const chatSessionsService = accessor.get(IChatSessionsService);
+	const storageService = accessor.get(IStorageService);
 
 	if (!chatEditorInput) {
 		const editorInput = editorService.activeEditor;
@@ -28,7 +30,7 @@ export async function clearChatEditor(accessor: ServicesAccessor, chatEditorInpu
 		// Otherwise create a generic new chat editor.
 		const resource = chatEditorInput.sessionResource && chatEditorInput.sessionResource.scheme !== Schemas.vscodeLocalChatSession
 			? chatEditorInput.sessionResource.with({ path: `/untitled-${generateUuid()}` })
-			: getDefaultNewChatSessionResource(configurationService, chatSessionsService);
+			: getDefaultNewChatSessionResource(configurationService, chatSessionsService, storageService);
 
 		// A chat editor can only be open in one group
 		const identifier = editorService.findEditors(chatEditorInput.resource)[0];

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -21,6 +21,7 @@ import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.j
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import { IsSessionsWindowContext } from '../../../../common/contextkeys.js';
@@ -347,7 +348,7 @@ class ToggleChatModeAction extends Action2 {
 			isClaudeAgent
 		});
 
-		widget.input.setChatMode(switchToMode.id);
+		widget.input.setChatMode(switchToMode.id, true, true);
 
 		if (chatModeCheck.needToClearSession) {
 			await commandService.executeCommand(ACTION_ID_NEW_CHAT);
@@ -942,6 +943,7 @@ class SendToNewChatAction extends Action2 {
 		const chatService = accessor.get(IChatService);
 		const configurationService = accessor.get(IConfigurationService);
 		const chatSessionsService = accessor.get(IChatSessionsService);
+		const storageService = accessor.get(IStorageService);
 		const widget = context?.widget ?? widgetService.lastFocusedWidget;
 		if (!widget) {
 			return;
@@ -963,7 +965,7 @@ class SendToNewChatAction extends Action2 {
 		// Clear the input from the current session before creating a new one
 		widget.setInput('');
 
-		await clearChatSessionPreservingType(widget, viewsService, undefined, configurationService, chatSessionsService);
+		await clearChatSessionPreservingType(widget, viewsService, undefined, configurationService, chatSessionsService, storageService);
 
 		widget.acceptInput(inputBeforeClear, { storeToHistory: true });
 	}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatNewActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatNewActions.ts
@@ -13,6 +13,7 @@ import { CommandsRegistry } from '../../../../../platform/commands/common/comman
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import { ChatContextKeyExprs, ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { IChatEditingSession } from '../../common/editing/chatEditingService.js';
@@ -317,6 +318,7 @@ async function runNewChatAction(
 	const viewsService = accessor.get(IViewsService);
 	const configurationService = accessor.get(IConfigurationService);
 	const chatSessionsService = accessor.get(IChatSessionsService);
+	const storageService = accessor.get(IStorageService);
 
 	const { editingSession, chatWidget: widget } = context ?? {};
 	if (!widget) {
@@ -333,7 +335,7 @@ async function runNewChatAction(
 	await editingSession?.stop();
 
 	// Create a new session, preserving the session type (or using the specified one)
-	await clearChatSessionPreservingType(widget, viewsService, sessionType, configurationService, chatSessionsService);
+	await clearChatSessionPreservingType(widget, viewsService, sessionType, configurationService, chatSessionsService, storageService);
 
 	widget.attachmentModel.clear(true);
 	widget.focusInput();

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostModeSynchronizer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostModeSynchronizer.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, DisposableMap, DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { AgentSession } from '../../../../../../platform/agentHost/common/agentService.js';
 import { fromAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
@@ -14,11 +15,12 @@ import { IWorkbenchEnvironmentService } from '../../../../../services/environmen
 import { IChatWidget, IChatWidgetService } from '../../chat.js';
 import { ChatMode, IChatMode, IChatModes } from '../../../common/chatModes.js';
 import { ChatModeKind } from '../../../common/constants.js';
+import type { IChatModeChangeEvent } from '../../widget/input/chatInputPart.js';
 import { IAgentHostUntitledProvisionalSessionService } from './agentHostUntitledProvisionalSessionService.js';
 
 const AGENT_HOST_SESSION_SCHEME_PREFIX = 'agent-host-';
 
-class AgentHostModeSynchronizer extends Disposable implements IWorkbenchContribution {
+export class AgentHostModeSynchronizer extends Disposable implements IWorkbenchContribution {
 	static readonly ID = 'workbench.contrib.agentHostModeSynchronizer';
 
 	private readonly _widgetListeners = this._register(new DisposableMap<IChatWidget>());
@@ -59,13 +61,21 @@ class AgentHostModeSynchronizer extends Disposable implements IWorkbenchContribu
 		}
 
 		const store = new DisposableStore();
-		store.add(widget.input.onDidChangeCurrentChatMode(() => this._onWidgetModeChanged(widget)));
+		store.add(widget.input.onDidChangeCurrentChatMode(e => this._onWidgetModeChanged(widget, e)));
 		store.add(widget.onDidChangeViewModel(() => this._syncWidgetFromBackend(widget)));
+		store.add(autorun(reader => {
+			const modes = widget.input.currentChatModesObs.read(reader);
+			reader.store.add(modes.onDidChange(() => this._syncWidgetFromBackend(widget)));
+		}));
 		this._widgetListeners.set(widget, store);
 		this._syncWidgetFromBackend(widget);
 	}
 
-	private _onWidgetModeChanged(widget: IChatWidget): void {
+	private _onWidgetModeChanged(widget: IChatWidget, e: IChatModeChangeEvent): void {
+		if (!e.isUserInitiated) {
+			return;
+		}
+
 		if (this._updatingWidgets.has(widget)) {
 			return;
 		}
@@ -92,10 +102,13 @@ class AgentHostModeSynchronizer extends Disposable implements IWorkbenchContribu
 		}
 
 		const agentUri = this._readSelectedAgent(sessionResource);
+		if (agentUri === undefined) {
+			return;
+		}
 		void this._applyMode(widget, sessionResource, agentUri);
 	}
 
-	private async _applyMode(widget: IChatWidget, sessionResource: URI, agentUri: string | undefined): Promise<void> {
+	private async _applyMode(widget: IChatWidget, sessionResource: URI, agentUri: string): Promise<void> {
 		const modes = widget.input.currentChatModesObs.get();
 		await modes.waitForPendingUpdates();
 
@@ -103,8 +116,7 @@ class AgentHostModeSynchronizer extends Disposable implements IWorkbenchContribu
 			return;
 		}
 
-		const modeId = agentUri ?? ChatMode.Agent.id;
-		const mode = this._findMode(modes, modeId);
+		const mode = this._findMode(modes, agentUri);
 		if (!mode || widget.input.currentModeObs.get().id === mode.id) {
 			return;
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
@@ -11,14 +11,11 @@ import { isEqual } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ILayoutService } from '../../../../../platform/layout/browser/layoutService.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
-import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { ACTIVE_GROUP, IEditorService, type PreferredGroup } from '../../../../services/editor/common/editorService.js';
 import { IEditorGroup, IEditorGroupsService, isEditorGroup } from '../../../../services/editor/common/editorGroupsService.js';
 import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import { IChatService } from '../../common/chatService/chatService.js';
-import { localChatSessionType } from '../../common/chatSessionsService.js';
-import { ChatAgentLocation, ChatLastUsedEditorSessionTypeStorageKey } from '../../common/constants.js';
-import { getChatSessionType } from '../../common/model/chatUri.js';
+import { ChatAgentLocation } from '../../common/constants.js';
 import { ChatViewId, ChatViewPaneTarget, IChatWidget, IChatWidgetService, IQuickChatService, isIChatViewViewContext } from '../chat.js';
 import { ChatEditor, IChatEditorOptions } from '../widgetHosts/editor/chatEditor.js';
 import { ChatEditorInput } from '../widgetHosts/editor/chatEditorInput.js';
@@ -51,7 +48,6 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 		@IEditorService private readonly editorService: IEditorService,
 		@IChatService private readonly chatService: IChatService,
 		@ILogService private readonly logService: ILogService,
-		@IStorageService private readonly storageService: IStorageService,
 	) {
 		super();
 	}
@@ -237,28 +233,8 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 		}
 
 		this._lastFocusedWidget = widget;
-		this.recordLastUsedSessionType(widget);
 		this._onDidChangeFocusedWidget.fire(widget);
 		this._onDidChangeFocusedSession.fire();
-	}
-
-	/**
-	 * Stores the session type (agent) of the last-focused user-facing chat so new chat editors can reuse it (excluding Quick Chat).
-	 */
-	private recordLastUsedSessionType(widget: IChatWidget | undefined): void {
-		const sessionResource = widget?.viewModel?.sessionResource;
-		if (!sessionResource) {
-			return;
-		}
-		if (this.quickChatService.sessionResource && isEqual(sessionResource, this.quickChatService.sessionResource)) {
-			return;
-		}
-		const sessionType = getChatSessionType(sessionResource);
-		// Only remember non-local agents to avoid clobbering the user's last-used agent.
-		if (sessionType === localChatSessionType) {
-			return;
-		}
-		this.storageService.store(ChatLastUsedEditorSessionTypeStorageKey, sessionType, StorageScope.PROFILE, StorageTarget.USER);
 	}
 
 	register(newWidget: IChatWidget): IDisposable {
@@ -277,7 +253,6 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 			newWidget.onDidFocus(() => this.setLastFocusedWidget(newWidget)),
 			newWidget.onDidChangeViewModel(({ previousSessionResource, currentSessionResource }) => {
 				if (this._lastFocusedWidget === newWidget && !isEqual(previousSessionResource, currentSessionResource)) {
-					this.recordLastUsedSessionType(newWidget);
 					this._onDidChangeFocusedSession.fire();
 				}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -266,6 +266,10 @@ export interface IChatWidgetLocationInfo {
 	readonly isMaximized: boolean;
 }
 
+export interface IChatModeChangeEvent {
+	readonly isUserInitiated: boolean;
+}
+
 const LEGACY_SHARED_INPUT_STATE_TAGS = new Set(['view', 'editor', 'quick']);
 
 function getInputStateStorageKey(widgetViewKindTag: string): string {
@@ -542,8 +546,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		return this._currentLanguageModel;
 	}
 
-	private _onDidChangeCurrentChatMode: Emitter<void> = this._register(new Emitter<void>());
-	readonly onDidChangeCurrentChatMode: Event<void> = this._onDidChangeCurrentChatMode.event;
+	private _onDidChangeCurrentChatMode: Emitter<IChatModeChangeEvent> = this._register(new Emitter<IChatModeChangeEvent>());
+	readonly onDidChangeCurrentChatMode: Event<IChatModeChangeEvent> = this._onDidChangeCurrentChatMode.event;
 
 	private readonly _currentModeObservable: ISettableObservable<IChatMode>;
 	private readonly _currentChatModesObservable: ISettableObservable<IChatModes>;
@@ -1779,7 +1783,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	/**
 	 * By ID- prefer this method
 	 */
-	setChatMode(mode: ChatModeKind | string, storeSelection = true): void {
+	setChatMode(mode: ChatModeKind | string, storeSelection = true, isUserInitiated = false): void {
 		if (!this.options.supportsChangingModes) {
 			return;
 		}
@@ -1789,22 +1793,22 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			modes.findModeByName(mode) ??
 			modes.findModeById(ChatModeKind.Agent) ??
 			ChatMode.Ask;
-		this.setChatMode2(mode2, storeSelection);
+		this.setChatMode2(mode2, storeSelection, isUserInitiated);
 	}
 
-	private setChatMode2(mode: IChatMode, storeSelection = true): void {
+	private setChatMode2(mode: IChatMode, storeSelection = true, isUserInitiated = false): void {
 		if (!this.options.supportsChangingModes) {
 			return;
 		}
 
 		this._currentModeObservable.set(mode, undefined);
-		this._onDidChangeCurrentChatMode.fire();
+		this._onDidChangeCurrentChatMode.fire({ isUserInitiated });
 
 		if (storeSelection) {
 			// Sync to model (mode is now persisted in the model's input state)
 			// Log first so the upcoming _syncInputStateToModel write can be attributed
 			// to a mode change.
-			logChangesToStateModel(this._inputModel, `setChatMode2 -> _syncInputStateToModel (mode=${mode.id}, storeSelection=${storeSelection}, currentLanguageModel=${this._currentLanguageModel.get()?.identifier}) in ${this._currentSessionKey}`, undefined, undefined, this.logService);
+			logChangesToStateModel(this._inputModel, `setChatMode2 -> _syncInputStateToModel (mode=${mode.id}, storeSelection=${storeSelection}, isUserInitiated=${isUserInitiated}, currentLanguageModel=${this._currentLanguageModel.get()?.identifier}) in ${this._currentSessionKey}`, undefined, undefined, this.logService);
 			this._syncInputStateToModel();
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/delegationSessionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/delegationSessionPickerActionItem.ts
@@ -16,8 +16,8 @@ import { IConfigurationService } from '../../../../../../platform/configuration/
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
+import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
-import { IsSessionsWindowContext } from '../../../../../common/contextkeys.js';
 import { IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { IChatSessionsService } from '../../../common/chatSessionsService.js';
 import { ILanguageModelsService } from '../../../common/languageModels.js';
@@ -35,8 +35,6 @@ import { IGitService } from '../../../../git/common/gitService.js';
  */
 export class DelegationSessionPickerActionItem extends SessionTypePickerActionItem {
 
-	private readonly _isSessionsWindow: boolean;
-
 	constructor(
 		action: MenuItemAction,
 		chatSessionPosition: 'sidebar' | 'editor',
@@ -52,10 +50,10 @@ export class DelegationSessionPickerActionItem extends SessionTypePickerActionIt
 		@IChatEntitlementService chatEntitlementService: IChatEntitlementService,
 		@ILanguageModelsService languageModelsService: ILanguageModelsService,
 		@IConfigurationService configurationService: IConfigurationService,
+		@IStorageService storageService: IStorageService,
 		@IGitService private readonly gitService: IGitService,
 	) {
-		super(action, chatSessionPosition, delegate, pickerOptions, actionWidgetService, keybindingService, contextKeyService, chatSessionsService, commandService, openerService, telemetryService, chatEntitlementService, languageModelsService, configurationService);
-		this._isSessionsWindow = IsSessionsWindowContext.getValue(contextKeyService) === true;
+		super(action, chatSessionPosition, delegate, pickerOptions, actionWidgetService, keybindingService, contextKeyService, chatSessionsService, commandService, openerService, telemetryService, chatEntitlementService, languageModelsService, configurationService, storageService);
 	}
 
 	protected override _run(sessionTypeItem: ISessionTypeItem): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
@@ -19,13 +19,15 @@ import { IConfigurationService } from '../../../../../../platform/configuration/
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
+import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
+import { IsSessionsWindowContext } from '../../../../../common/contextkeys.js';
 import { IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { IChatSessionsService } from '../../../common/chatSessionsService.js';
 import { ILanguageModelsService } from '../../../common/languageModels.js';
 import { AgentSessionProviders, AgentSessionTarget, getAgentSessionProvider, getAgentSessionProviderDescription, getAgentSessionProviderIcon, getAgentSessionProviderName, isFirstPartyAgentSessionProvider } from '../../agentSessions/agentSessions.js';
 import { getSessionTypeAvailability, getSessionTypeUnavailableDescription, getSessionTypeUnavailableHover, SessionTypeAvailability } from '../../agentSessions/sessionTypeAvailability.js';
-import { ChatConfiguration, getDefaultNewChatSessionType, isVisibleEditorChatSessionType } from '../../../common/constants.js';
+import { ChatConfiguration, getDefaultNewChatSessionType, isVisibleEditorChatSessionType, recordUserSelectedSessionType } from '../../../common/constants.js';
 import { ChatInputPickerActionViewItem, IChatInputPickerOptions } from './chatInputPickerActionItem.js';
 import { ISessionTypePickerDelegate } from '../../chat.js';
 import { IActionProvider } from '../../../../../../base/browser/ui/dropdown/dropdown.js';
@@ -47,6 +49,7 @@ const otherCategory = { label: localize('chat.sessionTarget.category.other', "Ot
  */
 export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 	private _sessionTypeItems: ISessionTypeItem[] = [];
+	protected readonly _isSessionsWindow: boolean;
 
 	constructor(
 		action: MenuItemAction,
@@ -63,6 +66,7 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 		@IChatEntitlementService protected readonly chatEntitlementService: IChatEntitlementService,
 		@ILanguageModelsService protected readonly languageModelsService: ILanguageModelsService,
 		@IConfigurationService protected readonly configurationService: IConfigurationService,
+		@IStorageService protected readonly storageService: IStorageService,
 	) {
 
 		const actionProvider: IActionWidgetDropdownActionProvider = {
@@ -109,6 +113,8 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 
 		super(action, sessionTargetPickerOptions, pickerOptions, actionWidgetService, keybindingService, contextKeyService, telemetryService);
 
+		this._isSessionsWindow = IsSessionsWindowContext.getValue(contextKeyService) === true;
+
 		this._register(this.chatSessionsService.onDidChangeAvailability(() => {
 			this._updateAgentSessionItems();
 		}));
@@ -128,6 +134,10 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 	}
 
 	protected _run(sessionTypeItem: ISessionTypeItem): void {
+		if (!this._isSessionsWindow) {
+			recordUserSelectedSessionType(this.storageService, this.configurationService, this.chatSessionsService, sessionTypeItem.type);
+		}
+
 		if (this.delegate.setActiveSessionProvider) {
 			// Use provided setter (for welcome view)
 			this.delegate.setActiveSessionProvider(sessionTypeItem.type);
@@ -224,7 +234,7 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 	 * when the selected provider is registered.
 	 */
 	protected _getDefaultSessionType(): AgentSessionTarget {
-		return getDefaultNewChatSessionType(this.configurationService, this.chatSessionsService) as AgentSessionTarget;
+		return getDefaultNewChatSessionType(this.configurationService, this.chatSessionsService, this.storageService) as AgentSessionTarget;
 	}
 
 	protected _isVisible(type: AgentSessionTarget): boolean {

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditorInput.ts
@@ -16,16 +16,17 @@ import * as nls from '../../../../../../nls.js';
 import { ConfirmResult, IDialogService } from '../../../../../../platform/dialogs/common/dialogs.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
-import { IStorageService, StorageScope } from '../../../../../../platform/storage/common/storage.js';
+import { ILogService } from '../../../../../../platform/log/common/log.js';
+import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
 import { registerIcon } from '../../../../../../platform/theme/common/iconRegistry.js';
 import { EditorInputCapabilities, IEditorIdentifier, IEditorSerializer, IUntypedEditorInput, Verbosity } from '../../../../../common/editor.js';
 import { EditorInput, IEditorCloseHandler } from '../../../../../common/editor/editorInput.js';
 import { IChatModelReference, IChatService } from '../../../common/chatService/chatService.js';
 import { IChatSessionsService, localChatSessionType } from '../../../common/chatSessionsService.js';
-import { ChatAgentLocation, ChatEditorTitleMaxLength, ChatLastUsedEditorSessionTypeStorageKey, getDefaultNewChatSessionResource, getDefaultNewChatSessionType, getNewChatEditorSessionResource } from '../../../common/constants.js';
+import { ChatAgentLocation, ChatEditorTitleMaxLength, getComputedDefaultSessionResource, getComputedDefaultSessionType, getDefaultNewChatSessionResource } from '../../../common/constants.js';
 import { IChatEditingSession, ModifiedFileEntryState } from '../../../common/editing/chatEditingService.js';
 import { IChatModel } from '../../../common/model/chatModel.js';
-import { LocalChatSessionUri, getChatSessionType } from '../../../common/model/chatUri.js';
+import { LocalChatSessionUri, getChatSessionType, isUntitledChatSession } from '../../../common/model/chatUri.js';
 import { IClearEditingSessionConfirmationOptions } from '../../actions/chatActions.js';
 import type { IChatEditorOptions } from './chatEditor.js';
 
@@ -67,6 +68,7 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IStorageService private readonly storageService: IStorageService,
+		@ILogService private readonly logService: ILogService,
 	) {
 		super();
 
@@ -218,13 +220,32 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 		const inputType = chatSessionType ?? this.resource.authority;
 
 		if (this._sessionResource) {
-			this.modelRef.value = await this.chatService.acquireOrLoadSession(this._sessionResource, ChatAgentLocation.Chat, CancellationToken.None, 'ChatEditorInput#resolve');
+			try {
+				this.modelRef.value = await this.chatService.acquireOrLoadSession(this._sessionResource, ChatAgentLocation.Chat, CancellationToken.None, 'ChatEditorInput#resolve');
+			} catch (error) {
+				this.logService.warn(`[ChatEditorInput] Failed to acquire session ${this._sessionResource.toString()}`, error);
+			}
+
+			if (!this.model && isUntitledChatSession(this._sessionResource) && getChatSessionType(this._sessionResource) !== localChatSessionType) {
+				this.logService.warn(`[ChatEditorInput] Falling back to a local chat session because ${this._sessionResource.toString()} could not be acquired`);
+				this.modelRef.value = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: !inputType, debugOwner: 'ChatEditorInput#resolveUntitledFallback' });
+			}
 
 			if (this.shouldReplaceEmptyLocalSession(this._sessionResource)) {
-				const defaultResource = getDefaultNewChatSessionResource(this.configurationService, this.chatSessionsService);
+				const defaultResource = getComputedDefaultSessionResource(this.configurationService, this.chatSessionsService);
 				if (getChatSessionType(defaultResource) !== localChatSessionType) {
-					this._sessionResource = defaultResource;
-					this.modelRef.value = await this.chatService.acquireOrLoadSession(defaultResource, ChatAgentLocation.Chat, CancellationToken.None, 'ChatEditorInput#resolveDefaultSession');
+					let modelRef: IChatModelReference | undefined;
+					try {
+						modelRef = await this.chatService.acquireOrLoadSession(defaultResource, ChatAgentLocation.Chat, CancellationToken.None, 'ChatEditorInput#resolveDefaultSession');
+					} catch (error) {
+						this.logService.warn(`[ChatEditorInput] Failed to acquire default session ${defaultResource.toString()}`, error);
+					}
+					if (modelRef) {
+						this._sessionResource = defaultResource;
+						this.modelRef.value = modelRef;
+					} else {
+						this.logService.warn(`[ChatEditorInput] Keeping local chat session because default session ${defaultResource.toString()} could not be acquired`);
+					}
 				}
 			}
 
@@ -236,13 +257,21 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 			if (this.options.explicitSessionType === localChatSessionType) {
 				this.modelRef.value = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: !inputType, debugOwner: 'ChatEditorInput#resolveExplicitLocal' });
 			} else {
-				const lastUsedSessionType = this.storageService.get(ChatLastUsedEditorSessionTypeStorageKey, StorageScope.PROFILE);
-				const defaultResource = getNewChatEditorSessionResource(this.configurationService, this.chatSessionsService, lastUsedSessionType);
+				const defaultResource = getDefaultNewChatSessionResource(this.configurationService, this.chatSessionsService, this.storageService);
 				if (getChatSessionType(defaultResource) === localChatSessionType) {
 					this.modelRef.value = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: !inputType, debugOwner: 'ChatEditorInput#resolveUntitled' });
 				} else {
-					this._sessionResource = defaultResource;
-					this.modelRef.value = await this.chatService.acquireOrLoadSession(defaultResource, ChatAgentLocation.Chat, CancellationToken.None, 'ChatEditorInput#resolveDefaultUntitled');
+					try {
+						this.modelRef.value = await this.chatService.acquireOrLoadSession(defaultResource, ChatAgentLocation.Chat, CancellationToken.None, 'ChatEditorInput#resolveDefaultUntitled');
+					} catch (error) {
+						this.logService.warn(`[ChatEditorInput] Failed to acquire default session ${defaultResource.toString()}`, error);
+					}
+					if (this.model) {
+						this._sessionResource = defaultResource;
+					} else {
+						this.logService.warn(`[ChatEditorInput] Falling back to a local chat session because ${defaultResource.toString()} could not be acquired`);
+						this.modelRef.value = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: !inputType, debugOwner: 'ChatEditorInput#resolveUntitledFallback' });
+					}
 				}
 			}
 		} else if (this.options.target.data) {
@@ -273,7 +302,7 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 			&& this.options.explicitSessionType !== localChatSessionType
 			&& !!this.model
 			&& !this.model.hasRequests
-			&& getDefaultNewChatSessionType(this.configurationService, this.chatSessionsService) !== localChatSessionType;
+			&& getComputedDefaultSessionType(this.configurationService, this.chatSessionsService) !== localChatSessionType;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -50,7 +50,7 @@ import { CHAT_PROVIDER_ID } from '../../../common/participants/chatParticipantCo
 import { IChatModelReference, IChatService } from '../../../common/chatService/chatService.js';
 import { IChatSessionsService, localChatSessionType } from '../../../common/chatSessionsService.js';
 import { LocalChatSessionUri, getChatSessionType } from '../../../common/model/chatUri.js';
-import { ChatAgentLocation, ChatConfiguration, ChatModeKind, getDefaultNewChatSessionResource, getDefaultNewChatSessionType } from '../../../common/constants.js';
+import { ChatAgentLocation, ChatConfiguration, ChatModeKind, getComputedDefaultSessionType, getDefaultNewChatSessionResource, getDefaultNewChatSessionType } from '../../../common/constants.js';
 import { AgentSessionsControl } from '../../agentSessions/agentSessionsControl.js';
 import { ACTION_ID_NEW_CHAT } from '../../actions/chatActions.js';
 import { ChatWidget } from '../../widget/chatWidget.js';
@@ -1028,11 +1028,11 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 	 * Returns `undefined` to fall back to `startNewLocalSession`.
 	 */
 	private async acquireDefaultNewSession(token: CancellationToken): Promise<IChatModelReference | undefined> {
-		const defaultType = getDefaultNewChatSessionType(this.configurationService, this.chatSessionsService);
+		const defaultType = getDefaultNewChatSessionType(this.configurationService, this.chatSessionsService, this.storageService);
 		if (defaultType === localChatSessionType) {
 			return undefined;
 		}
-		const resource = getDefaultNewChatSessionResource(this.configurationService, this.chatSessionsService);
+		const resource = getDefaultNewChatSessionResource(this.configurationService, this.chatSessionsService, this.storageService);
 		try {
 			return await this.chatService.acquireOrLoadSession(resource, ChatAgentLocation.Chat, token, 'ChatViewPane#acquireDefaultNewSession');
 		} catch (error) {
@@ -1061,7 +1061,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 	}
 
 	private shouldSkipRestoredLocalSession(sessionResource: URI, model: IChatModel): boolean {
-		const defaultType = getDefaultNewChatSessionType(this.configurationService, this.chatSessionsService);
+		const defaultType = getComputedDefaultSessionType(this.configurationService, this.chatSessionsService);
 		const prefersAgentHostCopilot = this.configurationService.getValue<boolean>(ChatConfiguration.EditorLocalAgentEnabled) === false
 			&& this.configurationService.getValue<string>(ChatConfiguration.EditorDefaultProvider) === 'copilotAh';
 		return (defaultType !== localChatSessionType || prefersAgentHostCopilot)

--- a/src/vs/workbench/contrib/chat/common/chatSessionTypePreference.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionTypePreference.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+
+export const CHAT_USER_SELECTED_SESSION_TYPE_STORAGE_KEY = 'chat.userSelectedSessionType';
+
+export function getRememberedSessionType(storageService: IStorageService): string | undefined {
+	return storageService.get(CHAT_USER_SELECTED_SESSION_TYPE_STORAGE_KEY, StorageScope.PROFILE);
+}
+
+export function storeUserSelectedSessionType(storageService: IStorageService, sessionType: string): void {
+	storageService.store(CHAT_USER_SELECTED_SESSION_TYPE_STORAGE_KEY, sessionType, StorageScope.PROFILE, StorageTarget.MACHINE);
+}
+
+export function clearUserSelectedSessionType(storageService: IStorageService): void {
+	storageService.remove(CHAT_USER_SELECTED_SESSION_TYPE_STORAGE_KEY, StorageScope.PROFILE);
+}

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Schemas } from '../../../../base/common/network.js';
-import { IChatSessionsService, localChatSessionType, SessionType } from './chatSessionsService.js';
+import { IChatSessionsService, isAgentHostTarget, localChatSessionType, SessionType } from './chatSessionsService.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { ContextKeyExpr, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { ChatEntitlementContextKeys } from '../../../services/chat/common/chatEntitlementService.js';
@@ -13,6 +14,7 @@ import { IsAuxiliaryWindowContext, IsSessionsWindowContext } from '../../../comm
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { LocalChatSessionUri } from './model/chatUri.js';
+import { clearUserSelectedSessionType, getRememberedSessionType, storeUserSelectedSessionType } from './chatSessionTypePreference.js';
 
 export const enum BYOKUtilityModelDefault {
 	None = 'none',
@@ -262,7 +264,7 @@ export function isSupportedChatFileScheme(accessor: ServicesAccessor, scheme: st
  * Falls back to {@link localChatSessionType} when local is enabled, or when no
  * visible non-local provider is available.
  */
-export function getDefaultNewChatSessionType(
+export function getComputedDefaultSessionType(
 	configurationService: IConfigurationService,
 	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>
 ): string {
@@ -283,62 +285,80 @@ export function getDefaultNewChatSessionType(
 	return getVisibleNonLocalEditorChatSessionTypes(configurationService, chatSessionsService)[0] ?? localChatSessionType;
 }
 
-export function getDefaultNewChatSessionResource(
+export function getComputedDefaultSessionResource(
 	configurationService: IConfigurationService,
 	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>
 ): URI {
-	const defaultType = getDefaultNewChatSessionType(configurationService, chatSessionsService);
+	const defaultType = getComputedDefaultSessionType(configurationService, chatSessionsService);
 	return defaultType === localChatSessionType
 		? LocalChatSessionUri.getNewSessionUri()
 		: URI.from({ scheme: defaultType, path: `/untitled-${generateUuid()}` });
 }
 
-/**
- * Storage key for the last-used non-local editor chat session type (agent), persisted at profile scope.
- */
-export const ChatLastUsedEditorSessionTypeStorageKey = 'chat.lastUsedEditorSessionType';
-
-/**
- * Resolves the session type (agent) for a new chat editor, preferring the last-used visible non-local agent when `chat.editor.defaultProvider` isn't explicitly configured.
- */
-export function getNewChatEditorSessionType(
+export function isRememberedSessionTypeUsable(
+	sessionType: string,
 	configurationService: IConfigurationService,
-	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
-	lastUsedSessionType: string | undefined,
-): string {
-	const inspected = configurationService.inspect<string>(ChatConfiguration.EditorDefaultProvider);
-	const explicitlyConfigured = inspected.applicationValue !== undefined
-		|| inspected.userValue !== undefined
-		|| inspected.userLocalValue !== undefined
-		|| inspected.userRemoteValue !== undefined
-		|| inspected.workspaceValue !== undefined
-		|| inspected.workspaceFolderValue !== undefined
-		|| inspected.memoryValue !== undefined
-		|| inspected.policyValue !== undefined;
-
-	if (!explicitlyConfigured
-		&& lastUsedSessionType
-		&& lastUsedSessionType !== localChatSessionType
-		&& isVisibleEditorChatSessionType(lastUsedSessionType, configurationService, chatSessionsService)) {
-		return lastUsedSessionType;
+	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>
+): boolean {
+	if (sessionType === localChatSessionType) {
+		return isEditorLocalAgentEnabled(configurationService);
 	}
-
-	return getDefaultNewChatSessionType(configurationService, chatSessionsService);
+	if (isAgentHostTarget(sessionType)) {
+		return true;
+	}
+	return !!chatSessionsService.getChatSessionContribution(sessionType);
 }
 
-/**
- * Like {@link getDefaultNewChatSessionResource}, but prefers the user's
- * last-used session type via {@link getNewChatEditorSessionType}.
- */
-export function getNewChatEditorSessionResource(
+export interface IDefaultNewChatSessionTypeOptions {
+	readonly explicitOverride?: string;
+	readonly currentSessionType?: string;
+}
+
+export function getDefaultNewChatSessionType(
 	configurationService: IConfigurationService,
 	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
-	lastUsedSessionType: string | undefined,
+	storageService: IStorageService,
+	options?: IDefaultNewChatSessionTypeOptions
+): string {
+	if (options?.explicitOverride) {
+		return options.explicitOverride;
+	}
+
+	const remembered = getRememberedSessionType(storageService);
+	if (remembered && isRememberedSessionTypeUsable(remembered, configurationService, chatSessionsService)) {
+		return remembered;
+	}
+
+	if (options?.currentSessionType) {
+		return options.currentSessionType;
+	}
+
+	return getComputedDefaultSessionType(configurationService, chatSessionsService);
+}
+
+export function getDefaultNewChatSessionResource(
+	configurationService: IConfigurationService,
+	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
+	storageService: IStorageService,
+	options?: IDefaultNewChatSessionTypeOptions
 ): URI {
-	const sessionType = getNewChatEditorSessionType(configurationService, chatSessionsService, lastUsedSessionType);
-	return sessionType === localChatSessionType
+	const defaultType = getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, options);
+	return defaultType === localChatSessionType
 		? LocalChatSessionUri.getNewSessionUri()
-		: URI.from({ scheme: sessionType, path: `/untitled-${generateUuid()}` });
+		: URI.from({ scheme: defaultType, path: `/untitled-${generateUuid()}` });
+}
+
+export function recordUserSelectedSessionType(
+	storageService: IStorageService,
+	configurationService: IConfigurationService,
+	chatSessionsService: Pick<IChatSessionsService, 'getChatSessionContribution' | 'getAllChatSessionContributions'>,
+	sessionType: string
+): void {
+	if (sessionType === getComputedDefaultSessionType(configurationService, chatSessionsService)) {
+		clearUserSelectedSessionType(storageService);
+	} else {
+		storeUserSelectedSessionType(storageService, sessionType);
+	}
 }
 
 export function isEditorLocalAgentEnabled(configurationService: IConfigurationService): boolean {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostModeSynchronizer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostModeSynchronizer.test.ts
@@ -1,0 +1,137 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { timeout } from '../../../../../../base/common/async.js';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { observableValue } from '../../../../../../base/common/observable.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { agentHostAgentPickerStorageKey } from '../../../../../../platform/agentHost/common/customAgents.js';
+import { StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
+import { TestStorageService } from '../../../../../test/common/workbenchTestServices.js';
+import { AgentHostModeSynchronizer } from '../../../browser/agentSessions/agentHost/agentHostModeSynchronizer.js';
+import { IAgentHostUntitledProvisionalSessionService } from '../../../browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.js';
+import { IChatWidget, IChatWidgetService } from '../../../browser/chat.js';
+import { ChatMode, IChatMode, IChatModes } from '../../../common/chatModes.js';
+import { ChatModeKind } from '../../../common/constants.js';
+import type { IChatModeChangeEvent } from '../../../browser/widget/input/chatInputPart.js';
+
+suite('AgentHostModeSynchronizer', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	const sessionResource = URI.parse('agent-host-claude:/session-1');
+	const agentUri = 'file:///agent.md';
+
+	function createCustomMode(): IChatMode {
+		return {
+			id: agentUri,
+			kind: ChatModeKind.Agent,
+			isBuiltin: false,
+		} as IChatMode;
+	}
+
+	function createModes(customModes: () => readonly IChatMode[], onDidChange: Event<void>): IChatModes {
+		return {
+			onDidChange,
+			builtin: [ChatMode.Agent, ChatMode.Ask, ChatMode.Edit],
+			get custom() {
+				return customModes();
+			},
+			findModeById: id => [ChatMode.Agent, ChatMode.Ask, ChatMode.Edit, ...customModes()].find(mode => mode.id === id),
+			findModeByName: name => [ChatMode.Agent, ChatMode.Ask, ChatMode.Edit, ...customModes()].find(mode => mode.name?.get() === name),
+			waitForPendingUpdates: async () => { },
+		};
+	}
+
+	function createSynchronizer(initialMode: IChatMode, initialCustomModes: readonly IChatMode[] = []) {
+		let customModes = [...initialCustomModes];
+		const modeChanges = store.add(new Emitter<IChatModeChangeEvent>());
+		const modesChanges = store.add(new Emitter<void>());
+		const mode = observableValue<IChatMode>('mode', initialMode);
+		const modes = createModes(() => customModes, modesChanges.event);
+		const modesObservable = observableValue<IChatModes>('modes', modes);
+		const setChatModeCalls: string[] = [];
+
+		const widget = {
+			viewModel: { sessionResource },
+			input: {
+				onDidChangeCurrentChatMode: modeChanges.event,
+				currentModeObs: mode,
+				currentChatModesObs: modesObservable,
+				setChatMode: (modeId: string) => {
+					setChatModeCalls.push(modeId);
+					const next = modes.findModeById(modeId);
+					if (next) {
+						mode.set(next, undefined);
+					}
+				},
+			},
+			onDidChangeViewModel: Event.None,
+		} as unknown as IChatWidget;
+
+		const widgetService = {
+			getAllWidgets: () => [widget],
+			onDidAddWidget: Event.None,
+			onDidChangeFocusedSession: Event.None,
+			getWidgetBySessionResource: (resource: URI) => resource.toString() === sessionResource.toString() ? widget : undefined,
+			lastFocusedWidget: widget,
+		} as unknown as IChatWidgetService;
+
+		const provisionalSessionService = {
+			onDidChange: Event.None,
+			get: () => undefined,
+		} as unknown as IAgentHostUntitledProvisionalSessionService;
+
+		const storageService = store.add(new TestStorageService());
+		const environmentService = { isSessionsWindow: false } as IWorkbenchEnvironmentService;
+		const synchronizer = store.add(new AgentHostModeSynchronizer(widgetService, provisionalSessionService, storageService, environmentService));
+
+		return {
+			modeChanges,
+			modesChanges,
+			setCustomModes: (next: readonly IChatMode[]) => {
+				customModes = [...next];
+			},
+			setChatModeCalls,
+			storageService,
+			synchronizer,
+		};
+	}
+
+	test('persists only user initiated custom agent changes', () => {
+		const { modeChanges, storageService } = createSynchronizer(createCustomMode(), [createCustomMode()]);
+		const key = agentHostAgentPickerStorageKey(sessionResource.scheme);
+
+		modeChanges.fire({ isUserInitiated: false });
+		assert.strictEqual(storageService.get(key, StorageScope.PROFILE), undefined);
+
+		modeChanges.fire({ isUserInitiated: true });
+		assert.strictEqual(storageService.get(key, StorageScope.PROFILE), agentUri);
+	});
+
+	test('does not force default Agent when storage is empty', async () => {
+		const { setChatModeCalls } = createSynchronizer(ChatMode.Ask);
+
+		await timeout(0);
+
+		assert.deepStrictEqual(setChatModeCalls, []);
+	});
+
+	test('retries restore when custom modes load late', async () => {
+		const { modesChanges, setChatModeCalls, setCustomModes, storageService } = createSynchronizer(ChatMode.Agent);
+		storageService.store(agentHostAgentPickerStorageKey(sessionResource.scheme), agentUri, StorageScope.PROFILE, StorageTarget.MACHINE);
+
+		await timeout(0);
+		assert.deepStrictEqual(setChatModeCalls, []);
+
+		setCustomModes([createCustomMode()]);
+		modesChanges.fire();
+		await timeout(0);
+
+		assert.deepStrictEqual(setChatModeCalls, [agentUri]);
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/widgetHosts/editor/chatEditorInput.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widgetHosts/editor/chatEditorInput.test.ts
@@ -10,6 +10,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../ba
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { IDialogService } from '../../../../../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js';
+import { NullLogService } from '../../../../../../../platform/log/common/log.js';
 import { IStorageService } from '../../../../../../../platform/storage/common/storage.js';
 import { ChatEditorInput } from '../../../../browser/widgetHosts/editor/chatEditorInput.js';
 import { IChatService, IChatSessionStartOptions } from '../../../../common/chatService/chatService.js';
@@ -52,6 +53,7 @@ suite('ChatEditorInput', () => {
 			{} as IChatSessionsService,
 			{} as IInstantiationService,
 			{} as IStorageService,
+			new NullLogService(),
 		);
 
 		try {
@@ -104,6 +106,7 @@ suite('ChatEditorInput', () => {
 			{} as IChatSessionsService,
 			{} as IInstantiationService,
 			{} as IStorageService,
+			new NullLogService(),
 		);
 
 		try {

--- a/src/vs/workbench/contrib/chat/test/common/constants.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/constants.test.ts
@@ -6,13 +6,15 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { ChatConfiguration, getDefaultNewChatSessionType, isVisibleEditorChatSessionType } from '../../common/constants.js';
+import { ChatConfiguration, getComputedDefaultSessionType, getDefaultNewChatSessionType, isRememberedSessionTypeUsable, isVisibleEditorChatSessionType, recordUserSelectedSessionType } from '../../common/constants.js';
 import { localChatSessionType, SessionType, IChatSessionsExtensionPoint } from '../../common/chatSessionsService.js';
 import { MockChatSessionsService } from './mockChatSessionsService.js';
+import { TestStorageService } from '../../../../test/common/workbenchTestServices.js';
+import { getRememberedSessionType } from '../../common/chatSessionTypePreference.js';
 
 suite('ChatConfiguration defaults', () => {
 
-	ensureNoDisposablesAreLeakedInTestSuite();
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	function createChatSessionsService(...types: string[]): MockChatSessionsService {
 		const service = new MockChatSessionsService();
@@ -28,9 +30,17 @@ suite('ChatConfiguration defaults', () => {
 	test('editor default returns local when local is enabled', () => {
 		const configurationService = new TestConfigurationService();
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
+		const storageService = disposables.add(new TestStorageService());
 
-		assert.strictEqual(getDefaultNewChatSessionType(configurationService, chatSessionsService), localChatSessionType);
-		assert.strictEqual(isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService), true);
+		assert.deepStrictEqual({
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService),
+			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService),
+		}, {
+			computed: localChatSessionType,
+			rememberedAware: localChatSessionType,
+			localVisible: true,
+		});
 	});
 
 	test('editor default returns agent host Copilot when local is disabled and copilotAh is configured', () => {
@@ -39,9 +49,17 @@ suite('ChatConfiguration defaults', () => {
 			[ChatConfiguration.EditorDefaultProvider]: 'copilotAh',
 		});
 		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot);
+		const storageService = disposables.add(new TestStorageService());
 
-		assert.strictEqual(getDefaultNewChatSessionType(configurationService, chatSessionsService), SessionType.AgentHostCopilot);
-		assert.strictEqual(isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService), false);
+		assert.deepStrictEqual({
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService),
+			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService),
+		}, {
+			computed: SessionType.AgentHostCopilot,
+			rememberedAware: SessionType.AgentHostCopilot,
+			localVisible: false,
+		});
 	});
 
 	test('editor default keeps configured agent host Copilot before contribution registers', () => {
@@ -50,9 +68,17 @@ suite('ChatConfiguration defaults', () => {
 			[ChatConfiguration.EditorDefaultProvider]: 'copilotAh',
 		});
 		const chatSessionsService = createChatSessionsService(SessionType.CopilotCLI);
+		const storageService = disposables.add(new TestStorageService());
 
-		assert.strictEqual(getDefaultNewChatSessionType(configurationService, chatSessionsService), SessionType.AgentHostCopilot);
-		assert.strictEqual(isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService), false);
+		assert.deepStrictEqual({
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService),
+			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService),
+		}, {
+			computed: SessionType.AgentHostCopilot,
+			rememberedAware: SessionType.AgentHostCopilot,
+			localVisible: false,
+		});
 	});
 
 	test('editor default skips hidden extension host Copilot CLI', () => {
@@ -62,9 +88,17 @@ suite('ChatConfiguration defaults', () => {
 			[ChatConfiguration.CopilotCliHideExtensionHostEditor]: true,
 		});
 		const chatSessionsService = createChatSessionsService(SessionType.CopilotCLI, SessionType.AgentHostCopilot);
+		const storageService = disposables.add(new TestStorageService());
 
-		assert.strictEqual(getDefaultNewChatSessionType(configurationService, chatSessionsService), SessionType.AgentHostCopilot);
-		assert.strictEqual(isVisibleEditorChatSessionType(SessionType.CopilotCLI, configurationService, chatSessionsService), false);
+		assert.deepStrictEqual({
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService),
+			extensionHostVisible: isVisibleEditorChatSessionType(SessionType.CopilotCLI, configurationService, chatSessionsService),
+		}, {
+			computed: SessionType.AgentHostCopilot,
+			rememberedAware: SessionType.AgentHostCopilot,
+			extensionHostVisible: false,
+		});
 	});
 
 	test('editor default keeps local as last resort when local is disabled without configured provider', () => {
@@ -72,8 +106,105 @@ suite('ChatConfiguration defaults', () => {
 			[ChatConfiguration.EditorLocalAgentEnabled]: false,
 		});
 		const chatSessionsService = createChatSessionsService();
+		const storageService = disposables.add(new TestStorageService());
 
-		assert.strictEqual(getDefaultNewChatSessionType(configurationService, chatSessionsService), localChatSessionType);
-		assert.strictEqual(isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService), true);
+		assert.deepStrictEqual({
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService),
+			localVisible: isVisibleEditorChatSessionType(localChatSessionType, configurationService, chatSessionsService),
+		}, {
+			computed: localChatSessionType,
+			rememberedAware: localChatSessionType,
+			localVisible: true,
+		});
+	});
+
+	test('remembered explicit selection wins for new sessions', () => {
+		const configurationService = new TestConfigurationService();
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
+		const storageService = disposables.add(new TestStorageService());
+
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, SessionType.AgentHostClaude);
+
+		assert.deepStrictEqual({
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService),
+			remembered: getRememberedSessionType(storageService),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService),
+		}, {
+			computed: localChatSessionType,
+			remembered: SessionType.AgentHostClaude,
+			rememberedAware: SessionType.AgentHostClaude,
+		});
+	});
+
+	test('explicit override wins over remembered selection', () => {
+		const configurationService = new TestConfigurationService();
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
+		const storageService = disposables.add(new TestStorageService());
+
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, SessionType.AgentHostClaude);
+
+		assert.deepStrictEqual({
+			remembered: getRememberedSessionType(storageService),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, { explicitOverride: SessionType.AgentHostCopilot }),
+		}, {
+			remembered: SessionType.AgentHostClaude,
+			rememberedAware: SessionType.AgentHostCopilot,
+		});
+	});
+
+	test('current session type is fallback after remembered selection', () => {
+		const configurationService = new TestConfigurationService();
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
+		const storageService = disposables.add(new TestStorageService());
+
+		assert.deepStrictEqual({
+			withoutRemembered: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, { currentSessionType: SessionType.AgentHostCopilot }),
+		}, {
+			withoutRemembered: SessionType.AgentHostCopilot,
+		});
+
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, SessionType.AgentHostClaude);
+
+		assert.deepStrictEqual({
+			withRemembered: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService, { currentSessionType: SessionType.AgentHostCopilot }),
+		}, {
+			withRemembered: SessionType.AgentHostClaude,
+		});
+	});
+
+	test('selecting computed default clears remembered selection', () => {
+		const configurationService = new TestConfigurationService({
+			[ChatConfiguration.EditorLocalAgentEnabled]: false,
+			[ChatConfiguration.EditorDefaultProvider]: 'copilotAh',
+		});
+		const chatSessionsService = createChatSessionsService(SessionType.AgentHostCopilot, SessionType.AgentHostClaude);
+		const storageService = disposables.add(new TestStorageService());
+
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, SessionType.AgentHostClaude);
+		recordUserSelectedSessionType(storageService, configurationService, chatSessionsService, SessionType.AgentHostCopilot);
+
+		assert.deepStrictEqual({
+			computed: getComputedDefaultSessionType(configurationService, chatSessionsService),
+			remembered: getRememberedSessionType(storageService),
+			rememberedAware: getDefaultNewChatSessionType(configurationService, chatSessionsService, storageService),
+		}, {
+			computed: SessionType.AgentHostCopilot,
+			remembered: undefined,
+			rememberedAware: SessionType.AgentHostCopilot,
+		});
+	});
+
+	test('remembered agent host is usable before contribution registers', () => {
+		const configurationService = new TestConfigurationService();
+		const chatSessionsService = createChatSessionsService();
+
+		assert.deepStrictEqual({
+			agentHost: isRememberedSessionTypeUsable(SessionType.AgentHostClaude, configurationService, chatSessionsService),
+			extensionContributed: isRememberedSessionTypeUsable('my-extension-agent', configurationService, chatSessionsService),
+		}, {
+			agentHost: true,
+			extensionContributed: false,
+		});
 	});
 });


### PR DESCRIPTION
- Introduced IChatModeChangeEvent to track user-initiated mode changes.
- Updated ChatInputPart to handle user-initiated chat mode changes and fire events accordingly.
- Refactored session type handling in DelegationSessionPickerActionItem and SessionTypePickerActionItem to utilize storage service for user-selected session types.
- Added new utility functions for managing user-selected session types in chatSessionTypePreference.ts.
- Updated constants and session management logic to consider remembered session types and user preferences.
- Enhanced ChatEditorInput and ChatViewPane to utilize computed default session types and handle errors gracefully.
- Added tests for AgentHostModeSynchronizer and updated existing tests to cover new session type logic and preferences.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
For https://github.com/microsoft/vscode/issues/322792