### PR TITLE
Refactor gettingStarted.css to use CSS variables

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
@@ -187,7 +187,7 @@
 
 .monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .category-title {
 	margin: 4px 0 4px;
-	font-size: var(--vscode-agents-fontSize-label1);
+	font-size: var(--vscode-bodyFontSize);
 	font-weight: var(--vscode-agents-fontWeight-semiBold);
 	text-align: left;
 	display: inline-block;

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
@@ -187,8 +187,8 @@
 
 .monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .category-title {
 	margin: 4px 0 4px;
-	font-size: 14px;
-	font-weight: 500;
+	font-size: var(--vscode-agents-fontSize-label1);
+	font-weight: var(--vscode-agents-fontWeight-semiBold);
 	text-align: left;
 	display: inline-block;
 	overflow: hidden;
@@ -204,7 +204,7 @@
 }
 
 .monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category.no-progress {
-	padding: 3px 6px;
+	padding: 4px 4px 4px 6px;
 }
 
 .monaco-workbench .part.editor > .content .gettingStartedContainer .getting-started-category.no-progress .category-progress {
@@ -247,8 +247,8 @@
 	right: 0;
 	top: 50%;
 	transform: translateY(-50%);
-	padding: 3px;
-	border-radius: 5px;
+	padding: 4px;
+	border-radius: var(--vscode-cornerRadius-small);
 }
 
 .monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .recently-opened li {
@@ -312,11 +312,11 @@
 
 .monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category {
 	width: calc(100% - 16px);
-	font-size: 13px;
+	font-size: var(--vscode-bodyFontSize);
 	box-sizing: border-box;
 	line-height: normal;
-	margin: 8px 8px 8px 1px;
-	padding: 3px 6px 6px;
+	margin: 8px 8px 8px 0;
+	padding: 4px 6px;
 	text-align: left;
 }
 
@@ -340,7 +340,7 @@
 }
 
 .monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category .description-content > .codicon {
-	padding-right: 1px;
+	padding-right: 2px;
 	font-size: 16px;
 }
 
@@ -351,10 +351,10 @@
 .monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category .new-badge {
 	justify-self: flex-end;
 	align-self: flex-start;
-	border-radius: 4px;
+	border-radius: var(--vscode-cornerRadius-small);
 	padding: 2px 4px;
 	margin: 4px;
-	font-size: 11px;
+	font-size: var(--vscode-bodyFontSize-xSmall);
 	white-space: nowrap;
 }
 
@@ -401,7 +401,7 @@
 	padding-right: 8px;
 	max-width: 24px;
 	max-height: 24px;
-	border-radius: 4px;
+	border-radius: var(--vscode-cornerRadius-small);
 	position: relative;
 	top: auto;
 }
@@ -1105,10 +1105,6 @@
 
 .monaco-workbench .part.editor > .content .gettingStartedContainer button.button-link {
 	border: inherit;
-}
-
-.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .progress-bar-outer {
-	background-color: var(--vscode-welcomePage-progress-background);
 }
 
 .monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .progress-bar-inner {


### PR DESCRIPTION
Improve consistency and maintainability of styles in gettingStarted.css by replacing fixed font sizes and padding with CSS variables. This change enhances the flexibility of the styling system.

Fixes: https://github.com/microsoft/vscode/issues/324628