### PR TITLE
Unstick a pinned tab dragged to the start of the unpinned row

### DIFF
--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -2338,6 +2338,10 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 
 						if (this.isMoveOperation(e, de.identifier.groupId, editor)) {
 							sourceGroup.moveEditor(editor, this.groupView, { ...options, index: targetEditorIndex });
+
+							if (this.tabsModel instanceof UnstickyEditorGroupModel && this.groupView.isSticky(editor)) {
+								this.groupView.unstickEditor(editor);
+							}
 						} else {
 							sourceGroup.copyEditor(editor, this.groupView, { ...options, index: targetEditorIndex });
 						}


### PR DESCRIPTION
Fixes #313987. In the two-row tab layout `(pinnedTabsOnSeparateRow)`, dragging a pinned tab to the first position of the unpinned row left it pinned at the end of the pinned row. The first unpinned slot is `stickyCount,` but the same-group order-preserving decrement lowers the target to `stickyCount` - 1, which `EditorGroupModel.moveEditor` still treats as inside the sticky range (it only unsticks when `toIndex > stickyCount - 1)`, so the editor stayed pinned. This unsticks the editor after the move when it's dropped onto the unpinned row and remained sticky a no-op for all other drops.