### PR TITLE
Exclude `electron/get`'s `ELECTRON_GET_USE_PROXY` variable from exclusion

### DIFF
--- a/src/vs/base/common/processes.ts
+++ b/src/vs/base/common/processes.ts
@@ -107,7 +107,7 @@ export function sanitizeProcessEnvironment(env: IProcessEnvironment, ...preserve
 		return set;
 	}, {});
 	const keysToRemove = [
-		/^ELECTRON_.+$/,
+		/^ELECTRON_(?!GET_USE_PROXY).+$/,
 		/^VSCODE_(?!(PORTABLE|SHELL_LOGIN|ENV_REPLACE|ENV_APPEND|ENV_PREPEND)).+$/,
 		/^SNAP(|_.*)$/,
 		/^GDK_PIXBUF_.+$/,

--- a/src/vs/base/test/common/processes.test.ts
+++ b/src/vs/base/test/common/processes.test.ts
@@ -15,6 +15,7 @@ suite('Processes', () => {
 			FOO: 'bar',
 			ELECTRON_ENABLE_STACK_DUMPING: 'x',
 			ELECTRON_ENABLE_LOGGING: 'x',
+			ELECTRON_GET_USE_PROXY: '2',
 			ELECTRON_NO_ASAR: 'x',
 			ELECTRON_NO_ATTACH_CONSOLE: 'x',
 			ELECTRON_RUN_AS_NODE: 'x',
@@ -37,6 +38,7 @@ suite('Processes', () => {
 		};
 		processes.sanitizeProcessEnvironment(env);
 		assert.strictEqual(env['FOO'], 'bar');
+		assert.strictEqual(env['ELECTRON_GET_USE_PROXY'], '2');
 		assert.strictEqual(env['VSCODE_SHELL_LOGIN'], '1');
 		assert.strictEqual(env['VSCODE_PORTABLE'], '3');
 		assert.strictEqual(env['VSCODE_PYTHON_BASH_ACTIVATE'], undefined);
@@ -44,6 +46,6 @@ suite('Processes', () => {
 		assert.strictEqual(env['VSCODE_PYTHON_PWSH_ACTIVATE'], undefined);
 		assert.strictEqual(env['VSCODE_PYTHON_FISH_ACTIVATE'], undefined);
 		assert.strictEqual(env['VSCODE_PYTHON_AUTOACTIVATE_GUARD'], undefined);
-		assert.strictEqual(Object.keys(env).length, 3);
+		assert.strictEqual(Object.keys(env).length, 4);
 	});
 });


### PR DESCRIPTION
`ELECTRON_GET_USE_PROXY` is used in the Electron download performed by [electron/get](https://github.com/electron/get) to enable proxy rerouting. It's very confusing that the download doesn't work when the download is run from an integrated terminal session. Since the variable doesn't have an effect on running Electron instances (especially the one hosting VS Code itself), it's safe to exclude it from the exclusion.

Resolves #324748.
