### PR TITLE
Refactor agent sessions header actions layout

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsViewPane.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsViewPane.css
@@ -113,9 +113,12 @@
 	.agent-sessions-header-actions {
 		display: flex;
 		align-items: center;
-		gap: 4px;
 		margin-left: auto;
 		flex-shrink: 0;
+	}
+
+	.agent-sessions-header-actions .actions-container {
+		gap: 4px;
 	}
 
 	/* Inline search input — replaces label + actions when active */


### PR DESCRIPTION
This pull request makes a minor adjustment to the CSS styling for the agent sessions header actions. The `gap: 4px` property is moved from the `.agent-sessions-header-actions` container to its child `.actions-container`, which will affect the spacing between action items.

- Moved the `gap: 4px` property from `.agent-sessions-header-actions` to `.agent-sessions-header-actions .actions-container` to better scope the spacing between action elements.