### PR TITLE
sessions: hide changes and workspace pills in quick chat session header

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesActions.ts
@@ -23,7 +23,7 @@ import { MultiDiffEditor } from '../../../../workbench/contrib/multiDiffEditor/b
 import { IAgentWorkbenchLayoutService } from '../../../browser/workbench.js';
 import { Menus } from '../../../browser/menus.js';
 import { SessionHeaderMetaActionViewItem } from '../../../browser/parts/sessionHeaderMetaActionViewItem.js';
-import { SessionHasChangesContext } from '../../../common/contextkeys.js';
+import { SessionHasChangesContext, IsQuickChatSessionContext } from '../../../common/contextkeys.js';
 import { ISessionContext } from '../../../services/sessions/browser/sessionContext.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { SessionChangesetOperationScope } from '../../../services/sessions/common/session.js';
@@ -58,7 +58,7 @@ class ViewAllChangesAction extends Action2 {
 				id: Menus.SessionHeaderMeta,
 				group: 'navigation',
 				order: 0,
-				when: SessionHasChangesContext
+				when: ContextKeyExpr.and(SessionHasChangesContext, IsQuickChatSessionContext.negate())
 			},
 		});
 	}

--- a/src/vs/sessions/contrib/files/browser/workspaceFolderActions.ts
+++ b/src/vs/sessions/contrib/files/browser/workspaceFolderActions.ts
@@ -16,12 +16,13 @@ import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
 import { Action2, MenuItemAction, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
 import { Menus } from '../../../browser/menus.js';
 import { SessionHeaderMetaActionViewItem } from '../../../browser/parts/sessionHeaderMetaActionViewItem.js';
-import { SessionHasWorkspaceContext } from '../../../common/contextkeys.js';
+import { SessionHasWorkspaceContext, IsQuickChatSessionContext } from '../../../common/contextkeys.js';
 import { ISessionContext } from '../../../services/sessions/browser/sessionContext.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
 import { IActiveSession } from '../../../services/sessions/common/sessionsManagement.js';
@@ -45,7 +46,7 @@ class OpenFilesViewAction extends Action2 {
 				id: Menus.SessionHeaderMeta,
 				group: 'navigation',
 				order: -10,
-				when: SessionHasWorkspaceContext
+				when: ContextKeyExpr.and(SessionHasWorkspaceContext, IsQuickChatSessionContext.negate())
 			},
 		});
 	}


### PR DESCRIPTION
## What

In the Agents window, quick chat sessions no longer show the changes diff-stats pill or the workspace folder pill in the session header.

## Why

Quick chats are workspace-less by design, so a workspace folder (Files) pill and a diff-stats (Changes) pill in their header are not meaningful.

## How

Both pills are menu actions contributed into `Menus.SessionHeaderMeta` and gated by `when` clauses. Added `IsQuickChatSessionContext.negate()` to each:

- **Changes diff-stats pill** — `ViewAllChangesAction`: `when` is now `ContextKeyExpr.and(SessionHasChangesContext, IsQuickChatSessionContext.negate())`.
- **Workspace folder pill** — `OpenFilesViewAction`: `when` is now `ContextKeyExpr.and(SessionHasWorkspaceContext, IsQuickChatSessionContext.negate())`.

`IsQuickChatSessionContext` is already bound per-session (scoped to each session view's context service, sourced from the session's `isQuickChat` tag), so the pills hide correctly for quick chats even when multiple session views are visible, and remain visible for workspace-bound sessions.

## Notes for reviewers

- No behavioral change for workspace-bound sessions.
- ESLint passes on both changed files; the pre-commit hygiene hook passed.