### PR TITLE
sessions: persist workspaceless tag in agent host session cache

### DIFF
--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -26,7 +26,7 @@ import type { IAgentSubscription } from '../../../../../platform/agentHost/commo
 import { ResolveSessionConfigResult } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
 import { AgentCustomization, ChangesSummary, ChatInteractivity as ProtocolChatInteractivity, ChatOriginKind as ProtocolChatOriginKind, type ClientPluginCustomization, Customization, CustomizationType, ModelSelection, SessionStatus as ProtocolSessionStatus, RootConfigState, RootState, SessionActiveClient, SessionState, SessionSummary, type Changeset } from '../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ActionType, isChatAction, isSessionAction, NotificationType, type ProgressParams } from '../../../../../platform/agentHost/common/state/sessionActions.js';
-import { AgentCapabilities, AgentInfo, buildChatUri, buildDefaultChatUri, isDefaultChatUri, parseChatUri, readSessionGitHubState, readSessionGitState, readSessionWorkspaceless, ROOT_STATE_URI, SessionMeta, StateComponents, type ChatSummary, type ISessionGitState } from '../../../../../platform/agentHost/common/state/sessionState.js';
+import { AgentCapabilities, AgentInfo, buildChatUri, buildDefaultChatUri, isDefaultChatUri, parseChatUri, readSessionGitHubState, readSessionGitState, readSessionWorkspaceless, ROOT_STATE_URI, SessionMeta, StateComponents, withSessionWorkspaceless, type ChatSummary, type ISessionGitState } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
@@ -78,6 +78,13 @@ interface ISerializedSessionMetadata {
 	/** @deprecated Legacy name for `isArchived`. */
 	readonly isDone?: boolean;
 	readonly project?: { readonly uri: string; readonly displayName: string };
+	/**
+	 * Whether the session is a workspace-less quick chat. Persisted because the
+	 * adapter's session-kind is fixed at construction from this tag (see
+	 * {@link AgentHostSessionAdapter}); dropping it on restore would leak the
+	 * host's scratch dir as a workspace folder.
+	 */
+	readonly workspaceless?: boolean;
 }
 
 function serializeMetadata(meta: IAgentSessionMetadata): ISerializedSessionMetadata {
@@ -90,6 +97,7 @@ function serializeMetadata(meta: IAgentSessionMetadata): ISerializedSessionMetad
 		isRead: meta.isRead,
 		isArchived: meta.isArchived,
 		project: meta.project ? { uri: meta.project.uri.toString(), displayName: meta.project.displayName } : undefined,
+		workspaceless: readSessionWorkspaceless(meta._meta) || undefined,
 	};
 }
 
@@ -104,6 +112,7 @@ function deserializeMetadata(raw: ISerializedSessionMetadata): IAgentSessionMeta
 			isRead: raw.isRead,
 			isArchived: raw.isArchived ?? raw.isDone,
 			project: raw.project ? { uri: URI.parse(raw.project.uri), displayName: raw.project.displayName } : undefined,
+			...(raw.workspaceless ? { _meta: withSessionWorkspaceless(undefined, true) } : {}),
 		};
 	} catch {
 		return undefined;

--- a/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -1077,6 +1077,36 @@ suite('LocalAgentHostSessionsProvider', () => {
 		});
 	}));
 
+	test('hydrated quick chat stays workspace-less after reload despite a scratch working directory', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		// Regression #324581: a committed quick chat persisted into the startup
+		// cache carries a scratch cwd. The adapter's session-kind is fixed at
+		// construction from `_meta.workspaceless`, so the tag must survive the
+		// serialize/deserialize round-trip — otherwise the restored session
+		// leaks the scratch dir as a workspace folder.
+		const storageService = disposables.add(new InMemoryStorageService());
+		await persistCachedSessions(disposables, storageService, [
+			createSession('quick-cached', {
+				summary: 'Quick Chat',
+				workingDirectory: URI.file('/tmp/copilot-scratch/quick-cached'),
+				quickChat: true,
+			}),
+		]);
+
+		const nextHost = new MockAgentHostService();
+		disposables.add(toDisposable(() => nextHost.dispose()));
+		nextHost.setAuthenticationPending(true);
+		const provider = createProvider(disposables, nextHost, undefined, { storageService });
+
+		const session = provider.getSessions().find(s => AgentSession.id(s.resource.toString()) === 'quick-cached');
+		assert.deepStrictEqual({
+			workspace: session?.workspace.get(),
+			isQuickChat: session?.isQuickChat?.get(),
+		}, {
+			workspace: undefined,
+			isQuickChat: true,
+		});
+	}));
+
 	test('reconciles hydrated sessions against the authoritative list, pruning stale entries', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
 		const storageService = disposables.add(new InMemoryStorageService());
 		await persistCachedSessions(disposables, storageService, [createSession('stale-1', { summary: 'Stale' })]);


### PR DESCRIPTION
Fixes #324581

## What
Persist the `_meta.workspaceless` tag through the Agents window's startup session cache (`serializeMetadata`/`deserializeMetadata` in `baseAgentHostSessionsProvider.ts`).

## Why
The Agents window hydrates its session list from a persisted cache on startup so sessions appear before the first `listSessions()` round-trip resolves. The cache serializer dropped the `_meta.workspaceless` marker. Because an `AgentHostSessionAdapter` fixes its session-kind (`QuickChatSessionKind` vs `WorkspaceSessionKind`) at construction from that tag, a restored quick chat was locked into `WorkspaceSessionKind` and leaked its `~/.copilot/chats/<id>` scratch dir as a workspace folder — the "unexpected long folder name" reported when unsetting `sessions.layout.singlePaneDetailPanel` and reloading.

## How
- Added a `workspaceless` field to `ISerializedSessionMetadata`.
- Write it in `serializeMetadata` via `readSessionWorkspaceless(meta._meta)`.
- Restore it in `deserializeMetadata` via `withSessionWorkspaceless(undefined, true)`.

This mirrors the existing requirement that **every** adapter-construction path carry the `_meta.workspaceless` tag; the `_refreshSessions`/`listSessions` and live `_handleSessionAdded` paths already did — the persistence round-trip was the missing one.

## Notes for reviewers
Added a regression test (`hydrated quick chat stays workspace-less after reload despite a scratch working directory`) asserting the restored session has no workspace and `isQuickChat === true`.

Validation: `npm run typecheck-client` ✅, `npm run valid-layers-check` ✅, `scripts/test.sh --grep "LocalAgentHostSessionsProvider"` ✅ (126 passing).
