### PR TITLE
Agents - add Open File action to session changes diff editor

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesActions.ts
@@ -95,6 +95,44 @@ class ViewAllChangesAction extends Action2 {
 }
 registerAction2(ViewAllChangesAction);
 
+// --- Open File action (per-file toolbar in the session changes multi-diff editor)
+
+/**
+ * Opens the file shown in a diff row of the Agents window's session Changes
+ * multi-diff editor as a regular editor. The workbench {@link GoToFileAction}
+ * only appears for the generic {@link MultiDiffEditor}, so the session Changes
+ * editor needs its own entry in the per-file toolbar.
+ */
+class OpenChangedFileAction extends Action2 {
+
+	static readonly ID = 'workbench.agentSessions.changes.openFile';
+
+	constructor() {
+		super({
+			id: OpenChangedFileAction.ID,
+			title: localize2('agentSessions.changes.openFile', 'Open File'),
+			icon: Codicon.goToFile,
+			f1: false,
+			menu: {
+				id: MenuId.MultiDiffEditorFileToolbar,
+				when: ContextKeyExpr.equals('resourceScheme', 'changes-multi-diff-source'),
+				group: 'navigation',
+				order: 22,
+			},
+		});
+	}
+
+	override async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
+		const resource = args[0];
+		if (!(resource instanceof URI)) {
+			return;
+		}
+
+		await accessor.get(IEditorService).openEditor({ resource });
+	}
+}
+registerAction2(OpenChangedFileAction);
+
 // --- View All Changes action view item (session header diff stats)
 
 interface IDiffStats {


### PR DESCRIPTION
## What

Adds an **Open File** action to the per-file toolbar of the Agents window's session Changes (multi-file diff) editor.

## Why

The per-file toolbar in the session Changes multi-diff editor had no way to jump from a diff row to the actual file. The workbench already ships a `GoToFileAction` ("Open File"), but it is gated on the generic `MultiDiffEditor` (`ActiveEditorContext.isEqualTo(MultiDiffEditor.ID)`), and the Agents window renders its own `SessionChangesEditor`, so that action never appeared there.

## How

- New `OpenChangedFileAction` contributed to `MenuId.MultiDiffEditorFileToolbar`, scoped with `resourceScheme == 'changes-multi-diff-source'` so it only shows for session changes files (alongside the existing "Mark as Reviewed" actions).
- The handler opens the file resource forwarded by the toolbar action runner via `IEditorService.openEditor({ resource })`.

## Notes for reviewers

- The whole change lives in a single file: `changesActions.ts`.
- No editor-pane indirection is needed — for session changes the `goToFileUri` equals the `modifiedUri` already forwarded as the toolbar arg, so opening the resource directly is sufficient.
