### PR TITLE
Voice Mode: warn when microphone is hardware-muted

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { addDisposableListener } from '../../../../../base/browser/dom.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
@@ -149,6 +150,13 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 	private _suppressUntilTs = 0;
 	private _pttAcquiring = false;
 	private _pttReleasedDuringAcquire = false;
+
+	// --- Hardware mute detection. ---
+	// A hardware microphone kill switch (e.g. on Framework laptops) leaves
+	// `getUserMedia` succeeding with a track whose `muted` flag is set, so no
+	// acquisition error surfaces. Track the mute state to warn the user.
+	private readonly _micTrackListeners = this._register(new DisposableStore());
+	private _micMutedNotified = false;
 
 	// --- Drain state (post-release continued streaming). ---
 	// Drain length is enforced primarily by counting samples shipped
@@ -336,6 +344,20 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 		}
 		this._micStream = micStream;
 
+		// Detect a hardware-muted microphone (e.g. a physical kill switch).
+		// `getUserMedia` succeeds in this case but the track produces silence,
+		// so without this check PTT would appear to work while capturing nothing.
+		this._micTrackListeners.clear();
+		this._micMutedNotified = false;
+		const audioTrack = micStream.getAudioTracks()[0];
+		if (audioTrack) {
+			if (audioTrack.muted) {
+				this._notifyMicrophoneMuted();
+			}
+			this._micTrackListeners.add(addDisposableListener(audioTrack, 'mute', () => this._notifyMicrophoneMuted()));
+			this._micTrackListeners.add(addDisposableListener(audioTrack, 'unmute', () => { this._micMutedNotified = false; }));
+		}
+
 		if (!this._micCtx) {
 			this._micCtx = new window.AudioContext({ sampleRate: 16000 });
 		}
@@ -422,6 +444,18 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 		}
 	}
 
+	private _notifyMicrophoneMuted(): void {
+		if (this._micMutedNotified) {
+			return;
+		}
+		this._micMutedNotified = true;
+		this.logService.warn('[mic] Microphone track is muted — likely a hardware mute switch is enabled');
+		this.notificationService.notify({
+			severity: Severity.Warning,
+			message: localize('mic.hardwareMuted', "Your microphone appears to be muted or disabled, possibly by a hardware switch. Voice Mode won't hear you until it's re-enabled."),
+		});
+	}
+
 	stopCapture(): void {
 		// Cancel any in-flight drain; do NOT fire `_onPttEnd` here
 		// because callers (reconnect / disconnect / dispose) have
@@ -444,6 +478,8 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 			this._micStream.getTracks().forEach(t => t.stop());
 			this._micStream = null;
 		}
+		this._micTrackListeners.clear();
+		this._micMutedNotified = false;
 		this._isCapturing = false;
 		this._pttHeld = false;
 		this._pttStreaming = false;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/8331

### Problem

When a microphone is disabled via a physical hardware kill switch (e.g. on Framework laptops), `getUserMedia()` still **succeeds** and returns a media stream — the OS just hands back an audio track whose `muted` flag is `true`, producing silence. Because no error is thrown, Voice Mode enters Push-To-Talk normally and everything "looks" fine, but nothing is captured and the user gets no feedback.

### Fix

In `micCaptureService.ts`, after the mic stream is acquired we now inspect the audio track:

- If the track is already `muted` at acquisition (hardware switch on before entering Voice Mode), a warning notification fires immediately.
- We also attach `mute` / `unmute` listeners so flipping the switch mid-session is caught, resetting the notified flag on `unmute` so it can warn again.
- A `_micMutedNotified` flag prevents duplicate notifications, and the listeners are cleaned up in `stopCapture` via a `DisposableStore`.

Notification text: *"Your microphone appears to be muted or disabled, possibly by a hardware switch. Voice Mode won't hear you until it's re-enabled."*

This sits alongside the existing `NotAllowedError` permission-denied notification, covering the hardware-mute gap that was previously silent.
