### PR TITLE
Use AnimatedCounterWidget for the changes pill above chat input

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesSummaryWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesSummaryWidget.ts
@@ -7,12 +7,11 @@ import './media/changesSummaryWidget.css';
 import * as dom from '../../../../base/browser/dom.js';
 import { structuralEquals } from '../../../../base/common/equals.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { autorun, derived, derivedObservableWithCache, derivedOpts, IObservable } from '../../../../base/common/observable.js';
+import { derived, derivedObservableWithCache, derivedOpts, IObservable } from '../../../../base/common/observable.js';
 import { ISessionChangesSummary } from '../../../services/sessions/common/session.js';
 import { IChangesViewService } from '../common/changesViewService.js';
-import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { Throttler } from '../../../../base/common/async.js';
+import { AnimatedCounterWidget } from '../../../../workbench/browser/animatedCounterWidget.js';
 
 export class ChangesSummaryWidget extends Disposable {
 	private readonly _summaryObs: IObservable<ISessionChangesSummary | undefined>;
@@ -74,134 +73,5 @@ export class ChangesSummaryWidget extends Disposable {
 				return this._summaryObs.read(reader)?.deletions;
 			})
 		}));
-	}
-}
-
-interface IAnimatedCounterWidgetOptions {
-	readonly prefix?: string;
-	readonly cssClassName?: string;
-	/**
-	 * The direction of the animation when the count
-	 * increases. The direction will be the opposite
-	 * when the count decreases.
-	 * */
-	readonly direction?: 'topToBottom' | 'bottomToTop';
-	readonly duration?: number;
-	readonly count: IObservable<number | undefined>;
-}
-
-class AnimatedCounterWidget extends Disposable {
-	private _element: HTMLElement;
-	private _count: number | undefined;
-	private readonly _animationOptions: KeyframeAnimationOptions;
-	private readonly _updateThrottler = this._register(new Throttler());
-
-	constructor(
-		container: HTMLElement,
-		private readonly _options: IAnimatedCounterWidgetOptions,
-		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService
-	) {
-		super();
-
-		const { cssClassName, duration } = _options;
-
-		this._element = cssClassName
-			? dom.$(`div.${cssClassName}`)
-			: dom.$('div');
-
-		this._element.appendChild(dom.$(`div`));
-		container.appendChild(this._element);
-
-		this._animationOptions = {
-			duration: duration ?? 240,
-			easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
-			fill: 'both',
-		} satisfies KeyframeAnimationOptions;
-
-		this._register(autorun(reader => {
-			const count = this._options.count.read(reader);
-			this._updateThrottler.queue(() => this._update(count));
-		}));
-	}
-
-	private async _update(count: number | undefined): Promise<void> {
-		if (!this._element || this._element.children.length === 0) {
-			return;
-		}
-
-		const outgoingElement = this._element.children[0];
-
-		if (count === undefined) {
-			outgoingElement.textContent = '';
-			this._count = undefined;
-			return;
-		}
-
-		// Create incoming element
-		const incomingElementText = `${this._options.prefix ?? ''}${count}`;
-
-		// Skip the animation when it is disabled (duration of 0) or when
-		// the user prefers reduced motion, just update the text content.
-		if (this._options.duration === 0 || this._accessibilityService.isMotionReduced()) {
-			outgoingElement.textContent = incomingElementText;
-			this._count = count;
-			return;
-		}
-
-		// Measure the current width before adding the incoming element so
-		// that a change in the number of digits can be animated smoothly.
-		const previousWidth = this._element.getBoundingClientRect().width;
-
-		const incomingElement = dom.$(`div`, undefined, incomingElementText);
-		this._element?.appendChild(incomingElement);
-
-		// The incoming element is content-sized, so its width is the width the
-		// container will have once the outgoing element is removed. Animate the
-		// container between the two widths for both growing and shrinking digit
-		// counts.
-		const nextWidth = incomingElement.getBoundingClientRect().width;
-
-		if (Math.abs(previousWidth - nextWidth) > 0.5) {
-			this._element.animate([
-				{ width: `${previousWidth}px` },
-				{ width: `${nextWidth}px` },
-			], this._animationOptions);
-		}
-
-		const directionOption = this._options.direction ?? 'topToBottom';
-		const directionTopBottom = directionOption === 'topToBottom'
-			? count > (this._count ?? 0)
-			: count < (this._count ?? 0);
-
-		const enterFrom = directionTopBottom ? '-100%' : '100%';
-		const exitTo = directionTopBottom ? '100%' : '-100%';
-
-		incomingElement.animate([
-			{ transform: `translateY(${enterFrom})`, opacity: 0 },
-			{ transform: 'translateY(0)', opacity: 1 },
-		], this._animationOptions);
-
-		const exit = outgoingElement.animate([
-			{ transform: 'translateY(0)', opacity: 1 },
-			{ transform: `translateY(${exitTo})`, opacity: 0 },
-		], this._animationOptions);
-
-		await new Promise<void>(resolve => {
-			let didCleanup = false;
-
-			const cleanup = () => {
-				if (didCleanup) {
-					return;
-				}
-
-				didCleanup = true;
-				this._count = count;
-				this._element?.removeChild(outgoingElement);
-				resolve();
-			};
-
-			exit.addEventListener('cancel', cleanup);
-			exit.addEventListener('finish', cleanup);
-		});
 	}
 }

--- a/src/vs/sessions/contrib/changes/browser/media/changesSummaryWidget.css
+++ b/src/vs/sessions/contrib/changes/browser/media/changesSummaryWidget.css
@@ -7,20 +7,6 @@
 	display: inline-flex;
 	gap: 4px;
 
-	.changes-summary-lines-added,
-	.changes-summary-lines-removed {
-		position: relative;
-		display: inline-grid;
-		overflow: hidden;
-		justify-items: start;
-
-		div {
-			grid-area: 1 / 1;
-			display: block;
-			will-change: transform, opacity;
-		}
-	}
-
 	.changes-summary-lines-added {
 		color: var(--vscode-chat-linesAddedForeground);
 	}

--- a/src/vs/workbench/browser/animatedCounterWidget.ts
+++ b/src/vs/workbench/browser/animatedCounterWidget.ts
@@ -1,0 +1,145 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import './media/animatedCounterWidget.css';
+import * as dom from '../../base/browser/dom.js';
+import { Throttler } from '../../base/common/async.js';
+import { Disposable } from '../../base/common/lifecycle.js';
+import { autorun, IObservable } from '../../base/common/observable.js';
+import { IAccessibilityService } from '../../platform/accessibility/common/accessibility.js';
+
+export interface IAnimatedCounterWidgetOptions {
+	readonly prefix?: string;
+	readonly cssClassName?: string;
+	/**
+	 * The direction of the animation when the count
+	 * increases. The direction will be the opposite
+	 * when the count decreases.
+	 * */
+	readonly direction?: 'topToBottom' | 'bottomToTop';
+	readonly duration?: number;
+	readonly count: IObservable<number | undefined>;
+}
+
+/**
+ * A small widget that renders a number and animates transitions between values:
+ * the container width tweens as the number of digits changes and the outgoing /
+ * incoming digits slide in the configured direction. Respects reduced motion.
+ */
+export class AnimatedCounterWidget extends Disposable {
+	private _element: HTMLElement;
+	private _count: number | undefined;
+	private readonly _animationOptions: KeyframeAnimationOptions;
+	private readonly _updateThrottler = this._register(new Throttler());
+
+	constructor(
+		container: HTMLElement,
+		private readonly _options: IAnimatedCounterWidgetOptions,
+		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService
+	) {
+		super();
+
+		const { cssClassName, duration } = _options;
+
+		this._element = cssClassName
+			? dom.$(`div.monaco-animated-counter.${cssClassName}`)
+			: dom.$('div.monaco-animated-counter');
+
+		this._element.appendChild(dom.$(`div`));
+		container.appendChild(this._element);
+
+		this._animationOptions = {
+			duration: duration ?? 240,
+			easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+			fill: 'both',
+		} satisfies KeyframeAnimationOptions;
+
+		this._register(autorun(reader => {
+			const count = this._options.count.read(reader);
+			this._updateThrottler.queue(() => this._update(count));
+		}));
+	}
+
+	private async _update(count: number | undefined): Promise<void> {
+		if (!this._element || this._element.children.length === 0) {
+			return;
+		}
+
+		const outgoingElement = this._element.children[0];
+
+		if (count === undefined) {
+			outgoingElement.textContent = '';
+			this._count = undefined;
+			return;
+		}
+
+		// Create incoming element
+		const incomingElementText = `${this._options.prefix ?? ''}${count}`;
+
+		// Skip the animation when it is disabled (duration of 0) or when
+		// the user prefers reduced motion, just update the text content.
+		if (this._options.duration === 0 || this._accessibilityService.isMotionReduced()) {
+			outgoingElement.textContent = incomingElementText;
+			this._count = count;
+			return;
+		}
+
+		// Measure the current width before adding the incoming element so
+		// that a change in the number of digits can be animated smoothly.
+		const previousWidth = this._element.getBoundingClientRect().width;
+
+		const incomingElement = dom.$(`div`, undefined, incomingElementText);
+		this._element?.appendChild(incomingElement);
+
+		// The incoming element is content-sized, so its width is the width the
+		// container will have once the outgoing element is removed. Animate the
+		// container between the two widths for both growing and shrinking digit
+		// counts.
+		const nextWidth = incomingElement.getBoundingClientRect().width;
+
+		if (Math.abs(previousWidth - nextWidth) > 0.5) {
+			this._element.animate([
+				{ width: `${previousWidth}px` },
+				{ width: `${nextWidth}px` },
+			], this._animationOptions);
+		}
+
+		const directionOption = this._options.direction ?? 'topToBottom';
+		const directionTopBottom = directionOption === 'topToBottom'
+			? count > (this._count ?? 0)
+			: count < (this._count ?? 0);
+
+		const enterFrom = directionTopBottom ? '-100%' : '100%';
+		const exitTo = directionTopBottom ? '100%' : '-100%';
+
+		incomingElement.animate([
+			{ transform: `translateY(${enterFrom})`, opacity: 0 },
+			{ transform: 'translateY(0)', opacity: 1 },
+		], this._animationOptions);
+
+		const exit = outgoingElement.animate([
+			{ transform: 'translateY(0)', opacity: 1 },
+			{ transform: `translateY(${exitTo})`, opacity: 0 },
+		], this._animationOptions);
+
+		await new Promise<void>(resolve => {
+			let didCleanup = false;
+
+			const cleanup = () => {
+				if (didCleanup) {
+					return;
+				}
+
+				didCleanup = true;
+				this._count = count;
+				this._element?.removeChild(outgoingElement);
+				resolve();
+			};
+
+			exit.addEventListener('cancel', cleanup);
+			exit.addEventListener('finish', cleanup);
+		});
+	}
+}

--- a/src/vs/workbench/browser/media/animatedCounterWidget.css
+++ b/src/vs/workbench/browser/media/animatedCounterWidget.css
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Structural styles for the AnimatedCounterWidget. The stacked incoming/outgoing
+	value elements share a single grid cell so they can cross-fade and slide while
+	the container width tweens. Callers add their own class for color/typography. */
+
+.monaco-animated-counter {
+	position: relative;
+	display: inline-grid;
+	overflow: hidden;
+	justify-items: start;
+}
+
+.monaco-animated-counter > div {
+	grid-area: 1 / 1;
+	display: block;
+	will-change: transform, opacity;
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatTurnPills.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatTurnPills.ts
@@ -26,6 +26,7 @@ import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
 import { observableConfigValue } from '../../../../../platform/observable/common/platformObservableUtils.js';
 import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
+import { AnimatedCounterWidget } from '../../../../browser/animatedCounterWidget.js';
 import { DEFAULT_LABELS_CONTAINER, ResourceLabels } from '../../../../browser/labels.js';
 import { ChatConfiguration } from '../../common/constants.js';
 import '../media/chatTurnPills.css';
@@ -144,11 +145,13 @@ export function observeTurnStatusPillsConfig(configurationService: IConfiguratio
 class ChangesPillActionViewItem extends BaseActionViewItem {
 
 	private _button: Button | undefined;
+	private _filesLabel: HTMLElement | undefined;
 
 	constructor(
 		action: IAction,
 		options: IActionViewItemOptions,
 		private readonly _statsObs: IObservable<IDiffStats>,
+		private readonly _instantiationService: IInstantiationService,
 	) {
 		super(undefined, action, options);
 	}
@@ -165,27 +168,43 @@ class ChangesPillActionViewItem extends BaseActionViewItem {
 			}
 		}));
 
+		// Build the label structure once so the animated counters persist across
+		// updates and can transition smoothly between values instead of being
+		// torn down and rebuilt on every stats change.
+		this._filesLabel = $('span.chat-turn-pill-meta-label');
+		reset(
+			button.element,
+			$(`span.chat-turn-pill-meta-icon${ThemeIcon.asCSSSelector(Codicon.diffMultiple)}`),
+			this._filesLabel,
+		);
+
+		this._register(this._instantiationService.createInstance(AnimatedCounterWidget, button.element, {
+			prefix: '+',
+			direction: 'topToBottom',
+			cssClassName: 'chat-turn-pill-meta-added',
+			count: derived(this, reader => this._statsObs.read(reader).insertions),
+		}));
+		this._register(this._instantiationService.createInstance(AnimatedCounterWidget, button.element, {
+			prefix: '-',
+			direction: 'bottomToTop',
+			cssClassName: 'chat-turn-pill-meta-removed',
+			count: derived(this, reader => this._statsObs.read(reader).deletions),
+		}));
+
 		this._register(autorun(reader => {
-			this._statsObs.read(reader);
-			this._updateLabel();
+			this._updateLabel(this._statsObs.read(reader));
 		}));
 	}
 
-	private _updateLabel(): void {
-		if (!this._button) {
+	private _updateLabel(stats: IDiffStats): void {
+		if (!this._button || !this._filesLabel) {
 			return;
 		}
-		const { files, insertions, deletions } = this._statsObs.get();
+		const { files, insertions, deletions } = stats;
 		const filesLabel = files === 1
 			? localize('chatTurnPills.changes.file', "{0} File", files)
 			: localize('chatTurnPills.changes.files', "{0} Files", files);
-		reset(
-			this._button.element,
-			$(`span.chat-turn-pill-meta-icon${ThemeIcon.asCSSSelector(Codicon.diffMultiple)}`),
-			$('span.chat-turn-pill-meta-label', undefined, filesLabel),
-			$('span.chat-turn-pill-meta-added', undefined, `+${insertions}`),
-			$('span.chat-turn-pill-meta-removed', undefined, `-${deletions}`),
-		);
+		this._filesLabel.textContent = filesLabel;
 		this._button.setTitle(localize('chatTurnPills.changes.tooltip', "View Changes"));
 		this._button.element.setAttribute('aria-label', localize('chatTurnPills.changes.ariaLabel', "View Changes: {0}, +{1}, -{2}", filesLabel, insertions, deletions));
 	}
@@ -303,7 +322,7 @@ export class ChatTurnPillsWidget extends Disposable {
 	constructor(
 		private readonly _model: IChatTurnPillsModel,
 		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
-		@IInstantiationService instantiationService: IInstantiationService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
 		super();
 
@@ -311,7 +330,7 @@ export class ChatTurnPillsWidget extends Disposable {
 		// themed icon — the label always computes the file-icon classes, but they
 		// only paint when an ancestor opts in.
 		this.element = $('.chat-turn-pills.show-file-icons.hidden');
-		this._resourceLabels = this._register(instantiationService.createInstance(ResourceLabels, DEFAULT_LABELS_CONTAINER));
+		this._resourceLabels = this._register(this._instantiationService.createInstance(ResourceLabels, DEFAULT_LABELS_CONTAINER));
 
 		this._changesAction = this._register(new Action(CHANGES_PILL_ACTION_ID, localize('chatTurnPills.changes.tooltip', "View Changes"), undefined, true, async () => this._model.openChanges()));
 		this._previewAction = this._register(new Action(PREVIEW_PILL_ACTION_ID, localize('chatTurnPills.preview.label', "Open Preview"), undefined, true, async () => this._openPrimaryPreview()));
@@ -321,7 +340,7 @@ export class ChatTurnPillsWidget extends Disposable {
 			ariaLabel: localize('chatTurnPills.ariaLabel', "Turn status"),
 			actionViewItemProvider: (action, options) => {
 				if (action.id === CHANGES_PILL_ACTION_ID) {
-					return new ChangesPillActionViewItem(action, options, this._model.stats);
+					return new ChangesPillActionViewItem(action, options, this._model.stats, this._instantiationService);
 				}
 				if (action.id === PREVIEW_PILL_ACTION_ID) {
 					return new PreviewPillActionViewItem(action, options, this._model.previewFiles, this._resourceLabels, file => this._model.openPreviewFile(file), anchor => this._showAllPreviews(anchor));


### PR DESCRIPTION
The changes pill above the chat input now uses the same `AnimatedCounterWidget` as the changes summary widget, so its `+insertions` / `-deletions` counts animate (digit slide + width tween) when they update during a streaming turn.

### Changes
- **Extracted the reusable widget** — `AnimatedCounterWidget` was private to the sessions-layer `changesSummaryWidget.ts`. Since `workbench` can't import from `sessions`, it was moved to a shared `src/vs/workbench/browser/animatedCounterWidget.ts` (+ CSS) that both consumers can reach. Structural styles now travel with the widget via a `monaco-animated-counter` base class; consumers supply only color/typography.
- **Updated the sessions consumer** — `changesSummaryWidget.ts` imports the shared widget and drops the local copy; its CSS keeps only layout + colors.
- **Applied it to the pill** — `ChangesPillActionViewItem` in `chatTurnPills.ts` builds its label structure once and mounts two `AnimatedCounterWidget` instances for added/removed counts, refreshing only the file-count and aria-label per update.

### Validation
- `npm run typecheck-client` — passes
- `npm run valid-layers-check` — passes (cross-layer imports legal)
- ESLint on changed files — passes