### PR TITLE
Steer terminal tool away from blocking password prompts

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -169,6 +169,7 @@ function createPowerShellModelDescription(shell: string, sandboxingOptions: ISan
 		'- NEVER pipe interactive commands through Select-Object, Where-Object, or other filters — this hides prompts and prevents the terminal from detecting when input is needed. Run interactive commands without pipes.',
 		'',
 		'Interactive Input Handling:',
+		'- Prefer commands that will not block on a credential or secret prompt. Avoid triggering interactive elevation or Get-Credential prompts, and pass non-interactive flags where available. If a step genuinely requires elevated privileges or a secret, do NOT run it unattended — tell the user to run that step interactively themselves, because in auto-approve/autopilot mode the prompt cannot be answered and the command will be cancelled, wasting the turn.',
 		'- When a terminal command is waiting for interactive input, do NOT suggest alternatives or ask the user whether to proceed. Instead, use the vscode_askQuestions tool to collect the needed values from the user, then send them.',
 		`- NEVER use vscode_askQuestions to request sensitive input such as passwords, passphrases, API keys, tokens, or other secrets — answers to that tool are sent through the model. If the prompt requires a secret, tell the user to type it directly into the terminal and stop; do not call vscode_askQuestions or ${TerminalToolId.SendToTerminal} for that prompt.`,
 		`- Send exactly one answer per prompt using ${TerminalToolId.SendToTerminal}. Never send multiple answers in a single send.`,
@@ -316,6 +317,7 @@ Best Practices:
 - NEVER pipe interactive commands through tail, head, grep, or other filters — this hides prompts and prevents the terminal from detecting when input is needed. Run interactive commands without pipes.
 
 Interactive Input Handling:
+- Prefer commands that will not block on a password or secret prompt. For privileged steps use sudo -n so they fail fast instead of hanging, prefer user-level installs (e.g. pip install --user, a local npm install instead of a global one), and pass non-interactive flags (e.g. -y, DEBIAN_FRONTEND=noninteractive). If a step genuinely requires sudo or another secret, do NOT run it unattended — tell the user to run that step interactively themselves, because in auto-approve/autopilot mode the prompt cannot be answered and the command will be cancelled, wasting the turn.
 - When a terminal command is waiting for interactive input, do NOT suggest alternatives or ask the user whether to proceed. Instead, use the vscode_askQuestions tool to collect the needed values from the user, then send them.
 - NEVER use vscode_askQuestions to request sensitive input such as passwords, passphrases, API keys, tokens, or other secrets — answers to that tool are sent through the model. If the prompt requires a secret, tell the user to type it directly into the terminal and stop; do not call vscode_askQuestions or send_to_terminal for that prompt.
 - Send exactly one answer per prompt using ${TerminalToolId.SendToTerminal}. Never send multiple answers in a single send.


### PR DESCRIPTION
Fixes #324319

## Problem

When the agent runs a command that triggers a blocking secret prompt (e.g. interactive `sudo`), the terminal halts waiting for input the user often can't provide. In auto-approve/autopilot mode we (correctly) never route secrets through the model, so the command is cancelled and the turn ends — from the user's perspective the agent "opened a terminal I can't access, asked for a sudo password, then halted," wasting the prompt.

The cancel-on-secret behavior itself is the right security posture (secrets must never go through the model, and blocking on stdin in an unattended run would hang indefinitely). The real fix is **prevention**: keep the model from provoking a blocking password prompt in the first place.

## Change

Adds preventive guidance to the `run_in_terminal` tool description (both the PowerShell and generic bash/zsh/fish variants) under "Interactive Input Handling". It instructs the model to:

- Prefer commands that won't block on a credential/secret prompt.
- Use non-interactive forms for privileged steps — `sudo -n` (fails fast instead of hanging), user-level installs, and non-interactive flags (`-y`, `DEBIAN_FRONTEND=noninteractive`).
- When a step genuinely needs elevated privileges or a secret, **not** run it unattended, but tell the user to run that step interactively — since in auto-approve/autopilot mode the prompt can't be answered and the command will be cancelled.

The existing sensitive-input detection, auto-cancel, and steering note remain as the safe backstop.

## Notes

The tool description is static (built per shell/sandbox, not per session), so the guidance is present in all modes. It is beneficial everywhere — interactive mode still gets the Focus-Terminal elicitation flow — and it explicitly names the auto-approve/autopilot consequence so unattended runs are handled most cautiously.