### PR TITLE
Add validation for deprecated design tokens

### DIFF
--- a/build/lib/stylelint/validateDesignTokens.ts
+++ b/build/lib/stylelint/validateDesignTokens.ts
@@ -121,12 +121,12 @@ export function validateCodiconFontSizes(text: string): IDesignTokenViolation[] 
 
 /** Exact px value -> suggested token var(s). Ambiguous values list alternatives. */
 const FONT_SIZE_RAMP: ReadonlyMap<number, string> = new Map([
-	[26, 'var(--vscode-agents-fontSize-heading1)'],
-	[18, 'var(--vscode-agents-fontSize-heading2)'],
-	[13, 'var(--vscode-bodyFontSize) or var(--vscode-agents-fontSize-heading3) or var(--vscode-agents-fontSize-body1)'],
-	[12, 'var(--vscode-bodyFontSize-small) or var(--vscode-agents-fontSize-label1)'],
-	[11, 'var(--vscode-bodyFontSize-xSmall) or var(--vscode-agents-fontSize-body2) or var(--vscode-agents-fontSize-label2)'],
-	[10, 'var(--vscode-agents-fontSize-label3)'],
+	[26, 'var(--vscode-fontSize-heading1)'],
+	[18, 'var(--vscode-fontSize-heading2)'],
+	[13, 'var(--vscode-fontSize-body1) or var(--vscode-fontSize-heading3)'],
+	[12, 'var(--vscode-fontSize-label1)'],
+	[11, 'var(--vscode-fontSize-body2) or var(--vscode-fontSize-label2)'],
+	[10, 'var(--vscode-fontSize-label3)'],
 ]);
 
 /**
@@ -255,7 +255,7 @@ export function validateCornerRadiusTokens(text: string): IDesignTokenViolation[
 // Font-weight token suggestions (sessions design-system area only)
 // ---------------------------------------------------------------------------
 //
-// The agents font ramp defines exactly two weights: regular (400) and
+// The font ramp defines exactly two weights: regular (400) and
 // semiBold (600). Any other numeric weight (e.g. 500, 700) is off the ramp and
 // snaps to the nearer of the two. The CSS keywords `normal` (400) and `bold`
 // (700) are normalised before snapping. `inherit`, `lighter`, `bolder` and
@@ -268,7 +268,7 @@ interface IFontWeightToken {
 	readonly name: string;
 }
 
-/** The only two weights in the agents ramp. */
+/** The only two weights in the font ramp. */
 const FONT_WEIGHT_TOKENS: readonly IFontWeightToken[] = [
 	{ weight: 400, name: 'regular' },
 	{ weight: 600, name: 'semiBold' },
@@ -303,7 +303,7 @@ function snapFontWeight(weight: number): IFontWeightToken {
 }
 
 /**
- * Finds hardcoded `font-weight` values and suggests the agents weight-ramp var.
+ * Finds hardcoded `font-weight` values and suggests the weight-ramp var.
  * Exact ramp values (400 / 600, plus `normal` = 400) are flagged as drop-in
  * replacements; off-ramp values (e.g. 500, 700, `bold`) snap to the nearer
  * token and call out that the value is off the two-weight ramp. `inherit`,
@@ -332,7 +332,7 @@ export function validateFontWeightTokens(text: string): IDesignTokenViolation[] 
 		const note = exact ? '' : ' (off-ramp, 400/600 only)';
 		violations.push({
 			line,
-			message: `${shown} -> var(--vscode-agents-fontWeight-${token.name})${note}`
+			message: `${shown} -> var(--vscode-fontWeight-${token.name})${note}`
 		});
 	});
 
@@ -471,6 +471,58 @@ export function validateStrokeTokens(text: string): IDesignTokenViolation[] {
 			line,
 			message: `${decl[1].trim()}: ${value.trim()} -> use var(--vscode-strokeThickness) for the 1px width`
 		});
+	});
+
+	return violations;
+}
+
+// ---------------------------------------------------------------------------
+// Deprecated token usage
+// ---------------------------------------------------------------------------
+//
+// Some `--vscode-*` size tokens have been superseded by more generic ones and
+// are marked `@deprecated` in the size registry. Any remaining usage of a
+// deprecated token var is reported with its drop-in replacement, regardless of
+// which property it appears in.
+
+interface IDeprecatedToken {
+	readonly deprecated: string;
+	readonly replacement: string;
+}
+
+/** Deprecated token var -> its replacement. */
+const DEPRECATED_TOKENS: readonly IDeprecatedToken[] = [
+	{ deprecated: '--vscode-bodyFontSize', replacement: '--vscode-fontSize-body1' },
+	{ deprecated: '--vscode-bodyFontSize-small', replacement: '--vscode-fontSize-label1' },
+	{ deprecated: '--vscode-bodyFontSize-xSmall', replacement: '--vscode-fontSize-body2' },
+];
+
+// Longest-first so a suffixed token (e.g. `-small`) matches before the base
+// token that is its prefix (`--vscode-bodyFontSize`).
+const DEPRECATED_TOKENS_SORTED = [...DEPRECATED_TOKENS].sort((a, b) => b.deprecated.length - a.deprecated.length);
+
+/**
+ * Finds usages of deprecated token vars and suggests the replacement token.
+ * A match is only reported when the token is not the prefix of a longer token
+ * (the next character does not continue the identifier). Returns one finding
+ * per occurrence so the terminal can linkify each `file(line,col)`.
+ */
+export function validateDeprecatedTokens(text: string): IDesignTokenViolation[] {
+	const violations: IDesignTokenViolation[] = [];
+
+	forEachDeclaration(text, (line, _selector, declaration) => {
+		for (const { deprecated, replacement } of DEPRECATED_TOKENS_SORTED) {
+			for (let idx = declaration.indexOf(deprecated); idx !== -1; idx = declaration.indexOf(deprecated, idx + deprecated.length)) {
+				const nextChar = declaration[idx + deprecated.length] ?? '';
+				if (/[\w-]/.test(nextChar)) {
+					continue; // prefix of a longer token
+				}
+				violations.push({
+					line,
+					message: `${deprecated} -> ${replacement} (deprecated)`
+				});
+			}
+		}
 	});
 
 	return violations;

--- a/build/stylelint.ts
+++ b/build/stylelint.ts
@@ -7,7 +7,7 @@ import es from 'event-stream';
 import vfs from 'vinyl-fs';
 import { stylelintFilter } from './filters.ts';
 import { getVariableNameValidator } from './lib/stylelint/validateVariableNames.ts';
-import { validateCodiconFontSizes, validateFontSizeTokens, validateFontWeightTokens, validateCornerRadiusTokens, validateSpacingTokens, validateStrokeTokens } from './lib/stylelint/validateDesignTokens.ts';
+import { validateCodiconFontSizes, validateFontSizeTokens, validateFontWeightTokens, validateCornerRadiusTokens, validateSpacingTokens, validateStrokeTokens, validateDeprecatedTokens } from './lib/stylelint/validateDesignTokens.ts';
 
 interface FileWithLines {
 	__lines?: string[];
@@ -32,7 +32,7 @@ export default function gulpstylelint(reporter: Reporter, designTokensEverywhere
 	const layerCheckerDisablePattern = /\/\*\s*stylelint-disable\s+layer-checker\s*\*\//;
 
 	// Per-category tally of design-token suggestions for the summary footer.
-	const designTokenCounts: Record<string, number> = { codicon: 0, 'font-size': 0, weight: 0, radius: 0, spacing: 0, stroke: 0 };
+	const designTokenCounts: Record<string, number> = { codicon: 0, 'font-size': 0, weight: 0, radius: 0, spacing: 0, stroke: 0, deprecated: 0 };
 	let designTokenFileCount = 0;
 
 	return es.through(function (this, file: FileWithLines) {
@@ -73,6 +73,7 @@ export default function gulpstylelint(reporter: Reporter, designTokensEverywhere
 			for (const v of validateCornerRadiusTokens(contents)) { findings.push({ line: v.line, category: 'radius', message: v.message }); }
 			for (const v of validateSpacingTokens(contents)) { findings.push({ line: v.line, category: 'spacing', message: v.message }); }
 			for (const v of validateStrokeTokens(contents)) { findings.push({ line: v.line, category: 'stroke', message: v.message }); }
+			for (const v of validateDeprecatedTokens(contents)) { findings.push({ line: v.line, category: 'deprecated', message: v.message }); }
 
 			if (findings.length > 0) {
 				findings.sort((a, b) => a.line - b.line);
@@ -91,7 +92,7 @@ export default function gulpstylelint(reporter: Reporter, designTokensEverywhere
 		if (errorCount > 0) {
 			reporter('All valid variable names are in `build/lib/stylelint/vscode-known-variables.json`\nTo update that file, run `./scripts/test-documentation.sh|bat.`', false);
 		}
-		const designTokenTotal = designTokenCounts.codicon + designTokenCounts['font-size'] + designTokenCounts.weight + designTokenCounts.radius + designTokenCounts.spacing + designTokenCounts.stroke;
+		const designTokenTotal = designTokenCounts.codicon + designTokenCounts['font-size'] + designTokenCounts.weight + designTokenCounts.radius + designTokenCounts.spacing + designTokenCounts.stroke + designTokenCounts.deprecated;
 		if (designTokenTotal > 0) {
 			reporter('', false);
 			reporter(
@@ -101,7 +102,8 @@ export default function gulpstylelint(reporter: Reporter, designTokensEverywhere
 				', weight ' + designTokenCounts.weight +
 				', radius ' + designTokenCounts.radius +
 				', spacing ' + designTokenCounts.spacing +
-				', stroke ' + designTokenCounts.stroke + ')',
+				', stroke ' + designTokenCounts.stroke +
+				', deprecated ' + designTokenCounts.deprecated + ')',
 				false
 			);
 		}


### PR DESCRIPTION
This pull request updates the design token validation logic to align with the latest naming conventions and adds a new check for deprecated token usage. The most significant changes are the renaming of several font size and weight tokens to their new generic forms, and the introduction of a linter that detects and reports deprecated tokens, suggesting their replacements. The summary reporting at the end of the stylelint run now also includes a count of deprecated token findings.

**Design token naming updates:**

* Updated font size and weight token suggestions in `validateDesignTokens.ts` to use the new `--vscode-fontSize-*` and `--vscode-fontWeight-*` variables instead of the old `--vscode-agents-*` and `--vscode-bodyFontSize*` variables. This affects the mapping, comments, and violation messages. [[1]](diffhunk://#diff-64a6ef1f9f62e80fe1c49ec7567fc2b5df3e9a12c4c895ee24c3c313adf3cb85L124-R129) [[2]](diffhunk://#diff-64a6ef1f9f62e80fe1c49ec7567fc2b5df3e9a12c4c895ee24c3c313adf3cb85L258-R258) [[3]](diffhunk://#diff-64a6ef1f9f62e80fe1c49ec7567fc2b5df3e9a12c4c895ee24c3c313adf3cb85L271-R271) [[4]](diffhunk://#diff-64a6ef1f9f62e80fe1c49ec7567fc2b5df3e9a12c4c895ee24c3c313adf3cb85L306-R306) [[5]](diffhunk://#diff-64a6ef1f9f62e80fe1c49ec7567fc2b5df3e9a12c4c895ee24c3c313adf3cb85L335-R335)

**Deprecated token detection:**

* Added a new function `validateDeprecatedTokens` in `validateDesignTokens.ts` that scans for usages of deprecated design tokens and reports them with suggested replacements.
* Integrated `validateDeprecatedTokens` into the stylelint pipeline in `build/stylelint.ts`, so deprecated token usage is now detected and reported during linting. [[1]](diffhunk://#diff-d16787746a35ae3087a7c1005380a15ac6a1336bff3b3c45aadc1d988c41b377L10-R10) [[2]](diffhunk://#diff-d16787746a35ae3087a7c1005380a15ac6a1336bff3b3c45aadc1d988c41b377R76)

**Reporting improvements:**

* Added a new `deprecated` category to the design token summary counts and included it in the final summary output. [[1]](diffhunk://#diff-d16787746a35ae3087a7c1005380a15ac6a1336bff3b3c45aadc1d988c41b377L35-R35) [[2]](diffhunk://#diff-d16787746a35ae3087a7c1005380a15ac6a1336bff3b3c45aadc1d988c41b377L94-R95) [[3]](diffhunk://#diff-d16787746a35ae3087a7c1005380a15ac6a1336bff3b3c45aadc1d988c41b377L104-R106)