### PR TITLE
NES: centralize NextEditProvider config reads into a per-request snapshot (#324752 item 4)

### DIFF
--- a/extensions/copilot/src/extension/inlineEdits/node/nesConfigs.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nesConfigs.ts
@@ -3,6 +3,38 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { SpeculativeRequestsAutoExpandEditWindowLines, SpeculativeRequestsCursorPlacement } from '../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
+
 export interface INesConfigs {
 	isAsyncCompletions: boolean;
+}
+
+/**
+ * Snapshot of the experiment-based configuration values read once per NES request on
+ * the main request path (`_getNextEditCanThrow` -> `fetchNextEdit` ->
+ * `_executeNewNextEditRequest` / `computeMinimumResponseDelay`). Reading these once up
+ * front and threading the snapshot keeps `getExperimentBasedConfig` calls out of the
+ * individual methods. Extends {@link INesConfigs} so the telemetry-facing subset stays
+ * intact.
+ */
+export interface INesRequestConfigs extends INesConfigs {
+	debounceUseCoreRequestTime: boolean;
+	autoExpandEditWindowLines: number | undefined;
+	cacheDelay: number;
+	rebasedCacheDelay: number | undefined;
+	subsequentCacheDelay: number | undefined;
+	speculativeRequestDelay: number | undefined;
+}
+
+/**
+ * Snapshot of the experiment-based configuration values read once per speculative NES
+ * request (`_triggerSpeculativeRequest` -> `_createSpeculativeRequest`). Kept separate
+ * from {@link INesRequestConfigs} because the speculative path is a distinct
+ * request-producing flow; separating them preserves each flow's experiment-exposure
+ * timing (neither flow reads the other's flags).
+ */
+export interface INesSpeculativeConfigs {
+	cursorPlacement: SpeculativeRequestsCursorPlacement;
+	autoExpandEditWindowLinesSetting: SpeculativeRequestsAutoExpandEditWindowLines;
+	autoExpandEditWindowLines: number | undefined;
 }

--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
@@ -42,7 +42,7 @@ import { checkEditConsistency } from '../common/editRebase';
 import { NesChangeHint } from '../common/nesTriggerHint';
 import { RejectionCollector } from '../common/rejectionCollector';
 import { DebugRecorder } from './debugRecorder';
-import { INesConfigs } from './nesConfigs';
+import { INesConfigs, INesRequestConfigs, INesSpeculativeConfigs } from './nesConfigs';
 import { CachedEdit, CachedOrRebasedEdit, NextEditCache } from './nextEditCache';
 import { LlmNESTelemetryBuilder, ReusedRequestKind } from './nextEditProviderTelemetry';
 import { INextEditResult, NextEditResult } from './nextEditResult';
@@ -286,6 +286,8 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 	 * `SpeculativeRequestManager.onActiveDocumentChanged` (trajectory check).
 	 */
 	private _cancelPendingRequestDueToDocChange(docId: DocumentId, docValue: StringText) {
+		// Intentionally read directly (not via the per-request config snapshot): this is a
+		// per-keystroke autorun gate, not part of a request lifecycle (see #324752 item 4).
 		const isAsyncCompletions = this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsAsyncCompletions, this._expService);
 
 		if (isAsyncCompletions || this._pendingStatelessNextEditRequest === null) {
@@ -359,7 +361,12 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 		const documentAtInvocationTime = doc.value.get();
 		const selections = doc.selection.get();
 
-		const nesConfigs = this.determineNesConfigs(telemetryBuilder, logContext);
+		const nesConfigs = this._readRequestConfigs();
+		// Preserve the original telemetry + log side effects exactly: telemetry and the logged
+		// codeblock stay the `{ isAsyncCompletions }` subset (see INesConfigs).
+		const telemetryConfigs: INesConfigs = { isAsyncCompletions: nesConfigs.isAsyncCompletions };
+		telemetryBuilder.setNESConfigs(telemetryConfigs);
+		logContext.addCodeblockToLog(JSON.stringify(telemetryConfigs, null, '\t'));
 
 		let cachedEdit = this._nextEditCache.lookupNextEdit(docId, documentAtInvocationTime, selections);
 		if (cachedEdit?.rejected) {
@@ -436,7 +443,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 
 		} else {
 			logger.trace(`fetching next edit with shouldExpandEditWindow=${shouldExpandEditWindow}`);
-			const providerRequestStartDateTime = (this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsDebounceUseCoreRequestTime, this._expService)
+			const providerRequestStartDateTime = (nesConfigs.debounceUseCoreRequestTime
 				? (context.requestIssuedDateTime ?? undefined)
 				: undefined);
 			req = new NextEditFetchRequest(context.requestUuid, logContext, providerRequestStartDateTime, false);
@@ -528,7 +535,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 
 		telemetryBuilder.setHasNextEdit(true);
 
-		const delay = this.computeMinimumResponseDelay({ triggerTime, isRebasedCachedEdit, isSubsequentCachedEdit, isFromSpeculativeRequest, enforceCacheDelay: context.enforceCacheDelay }, logger);
+		const delay = this.computeMinimumResponseDelay({ triggerTime, isRebasedCachedEdit, isSubsequentCachedEdit, isFromSpeculativeRequest, enforceCacheDelay: context.enforceCacheDelay }, nesConfigs, logger);
 		if (delay > 0) {
 			await timeout(delay);
 			if (cancellationToken.isCancellationRequested) {
@@ -580,15 +587,35 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 		return true;
 	}
 
-	private determineNesConfigs(telemetryBuilder: LlmNESTelemetryBuilder, logContext: InlineEditRequestLogContext): INesConfigs {
-		const nesConfigs: INesConfigs = {
+	/**
+	 * Reads all experiment-based configuration used by the main NES request path into a
+	 * single snapshot, so the individual methods can consume config from the snapshot
+	 * instead of reading it inline. Computed once per request in `_getNextEditCanThrow`.
+	 */
+	private _readRequestConfigs(): INesRequestConfigs {
+		return {
 			isAsyncCompletions: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsAsyncCompletions, this._expService),
+			debounceUseCoreRequestTime: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsDebounceUseCoreRequestTime, this._expService),
+			autoExpandEditWindowLines: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsAutoExpandEditWindowLines, this._expService),
+			cacheDelay: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsCacheDelay, this._expService),
+			rebasedCacheDelay: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsRebasedCacheDelay, this._expService),
+			subsequentCacheDelay: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsSubsequentCacheDelay, this._expService),
+			speculativeRequestDelay: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsSpeculativeRequestDelay, this._expService),
 		};
+	}
 
-		telemetryBuilder.setNESConfigs({ ...nesConfigs });
-		logContext.addCodeblockToLog(JSON.stringify(nesConfigs, null, '\t'));
-
-		return nesConfigs;
+	/**
+	 * Reads all experiment-based configuration used by the speculative NES request path
+	 * into a single snapshot. Kept separate from `_readRequestConfigs` so each
+	 * request-producing flow only reads (and exposes) its own experiment flags. Computed
+	 * once per speculative request in `_triggerSpeculativeRequest`.
+	 */
+	private _readSpeculativeConfigs(): INesSpeculativeConfigs {
+		return {
+			cursorPlacement: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsSpeculativeRequestsCursorPlacement, this._expService),
+			autoExpandEditWindowLinesSetting: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsSpeculativeRequestsAutoExpandEditWindowLines, this._expService),
+			autoExpandEditWindowLines: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsAutoExpandEditWindowLines, this._expService),
+		};
 	}
 
 	private _processDoc(doc: DocumentHistory): ProcessedDoc {
@@ -622,7 +649,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 		};
 	}
 
-	private async fetchNextEdit(req: NextEditFetchRequest, doc: IObservableDocument, nesConfigs: INesConfigs, shouldExpandEditWindow: boolean, parentLogger: ILogger, telemetryBuilder: LlmNESTelemetryBuilder, cancellationToken: CancellationToken): Promise<Result<CachedOrRebasedEdit, NoNextEditReason>> {
+	private async fetchNextEdit(req: NextEditFetchRequest, doc: IObservableDocument, nesConfigs: INesRequestConfigs, shouldExpandEditWindow: boolean, parentLogger: ILogger, telemetryBuilder: LlmNESTelemetryBuilder, cancellationToken: CancellationToken): Promise<Result<CachedOrRebasedEdit, NoNextEditReason>> {
 		const curDocId = doc.id;
 		const logger = parentLogger.createSubLogger('fetchNextEdit');
 		const historyContext = this._historyContextProvider.getHistoryContext(curDocId);
@@ -812,7 +839,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 		req: NextEditFetchRequest,
 		doc: IObservableDocument,
 		historyContext: HistoryContext,
-		nesConfigs: INesConfigs,
+		nesConfigs: INesRequestConfigs,
 		shouldExpandEditWindow: boolean,
 		parentLogger: ILogger,
 		telemetryBuilder: LlmNESTelemetryBuilder,
@@ -846,7 +873,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 		const firstEdit = new DeferredPromise<Result<CachedOrRebasedEdit, NoNextEditReason>>();
 
 		const nLinesEditWindow = (shouldExpandEditWindow
-			? this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsAutoExpandEditWindowLines, this._expService)
+			? nesConfigs.autoExpandEditWindowLines
 			: undefined);
 
 		const nextEditRequest = new StatelessNextEditRequest(
@@ -1104,17 +1131,14 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 		return disposables;
 	}
 
-	private computeMinimumResponseDelay({ triggerTime, isRebasedCachedEdit, isSubsequentCachedEdit, isFromSpeculativeRequest, enforceCacheDelay }: { triggerTime: number; isRebasedCachedEdit: boolean; isSubsequentCachedEdit: boolean; isFromSpeculativeRequest: boolean; enforceCacheDelay: boolean }, logger: ILogger): number {
+	private computeMinimumResponseDelay({ triggerTime, isRebasedCachedEdit, isSubsequentCachedEdit, isFromSpeculativeRequest, enforceCacheDelay }: { triggerTime: number; isRebasedCachedEdit: boolean; isSubsequentCachedEdit: boolean; isFromSpeculativeRequest: boolean; enforceCacheDelay: boolean }, nesConfigs: INesRequestConfigs, logger: ILogger): number {
 
 		if (!enforceCacheDelay) {
 			logger.trace('[minimumDelay] no minimum delay enforced due to enforceCacheDelay being false');
 			return 0;
 		}
 
-		const cacheDelay = this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsCacheDelay, this._expService);
-		const rebasedCacheDelay = this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsRebasedCacheDelay, this._expService);
-		const subsequentCacheDelay = this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsSubsequentCacheDelay, this._expService);
-		const speculativeRequestDelay = this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsSpeculativeRequestDelay, this._expService);
+		const { cacheDelay, rebasedCacheDelay, subsequentCacheDelay, speculativeRequestDelay } = nesConfigs;
 
 		let minimumResponseDelay = cacheDelay;
 		if (isRebasedCachedEdit && rebasedCacheDelay !== undefined) {
@@ -1141,7 +1165,9 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 		this._lastOutcome = undefined; // clear so that outcome is "pending" until resolved
 		this._specManager.clearScheduled(); // clear any previously scheduled speculative
 
-		// Trigger speculative request for the post-edit document state
+		// Trigger speculative request for the post-edit document state.
+		// Intentionally read directly (not via the per-request config snapshot): this is a
+		// per-shown enablement gate checked before a speculative request exists (see #324752 item 4).
 		const speculativeRequestsEnablement = this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsSpeculativeRequests, this._expService);
 		if (speculativeRequestsEnablement === SpeculativeRequestsEnablement.On) {
 			// If the originating stream is still running, defer the speculative request
@@ -1171,6 +1197,8 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 			return;
 		}
 
+		const speculativeConfigs = this._readSpeculativeConfigs();
+
 		const logContext = new InlineEditRequestLogContext(docId.uri, 0, undefined);
 
 		const sw = new StopWatch();
@@ -1197,7 +1225,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 				return;
 			} else if (cachedEdit.editWindow) {
 				logger.trace('have cached no-suggestions entry for post-edit state, but it has an edit window. Checking if shifting selection based on cursor placement config can yield a cached edit');
-				const cursorPlacement = this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsSpeculativeRequestsCursorPlacement, this._expService);
+				const cursorPlacement = speculativeConfigs.cursorPlacement;
 				if (cursorPlacement === SpeculativeRequestsCursorPlacement.AfterEditWindow) {
 					logger.trace('cursor placement config is AfterEditWindow, shifting selection to after edit window');
 					shiftedSelection = NextEditProvider.shiftSelectionAfterEditWindow(postEditContentST, cachedEdit.editWindow);
@@ -1268,6 +1296,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 					triggeredBySpeculativeRequest: suggestion.source.isSpeculative,
 					isSubsequentEdit: suggestion.result?.isSubsequentEdit ?? false,
 				},
+				speculativeConfigs,
 				logger
 			);
 
@@ -1310,6 +1339,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 		rootedEdit: RootedEdit,
 		appliedEdit: StringReplacement,
 		{ triggeredBySpeculativeRequest, isSubsequentEdit }: { triggeredBySpeculativeRequest: boolean; isSubsequentEdit: boolean },
+		speculativeConfigs: INesSpeculativeConfigs,
 		parentLogger: ILogger
 	): Promise<StatelessNextEditRequest<CachedOrRebasedEdit> | undefined> {
 		const curDocId = doc.id;
@@ -1366,19 +1396,19 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 		const firstEdit = new DeferredPromise<Result<CachedOrRebasedEdit, NoNextEditReason>>();
 
 		// FIXME@ulugbekna: implement advanced expansion
-		const autoExpandEditWindowLinesSetting = this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsSpeculativeRequestsAutoExpandEditWindowLines, this._expService);
+		const autoExpandEditWindowLinesSetting = speculativeConfigs.autoExpandEditWindowLinesSetting;
 		let nLinesEditWindow: number | undefined;
 		switch (autoExpandEditWindowLinesSetting) {
 			case SpeculativeRequestsAutoExpandEditWindowLines.Off:
 				nLinesEditWindow = undefined;
 				break;
 			case SpeculativeRequestsAutoExpandEditWindowLines.Always:
-				nLinesEditWindow = this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsAutoExpandEditWindowLines, this._expService);
+				nLinesEditWindow = speculativeConfigs.autoExpandEditWindowLines;
 				break;
 			case SpeculativeRequestsAutoExpandEditWindowLines.Smart: {
 				const isModelOnRightTrack = triggeredBySpeculativeRequest || isSubsequentEdit;
 				nLinesEditWindow = (isModelOnRightTrack
-					? this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsAutoExpandEditWindowLines, this._expService)
+					? speculativeConfigs.autoExpandEditWindowLines
 					: undefined);
 				break;
 			}


### PR DESCRIPTION
Part of #324752 (item 4 — "Config reads scattered across ~13 call sites"). **Layer 1 of a stacked refactor**; layers #5 (per-request context object), #3 (split `_getNextEditCanThrow`), #1 (extract collaborators), and #6 (cleanups) will build on this branch.

## What

`getExperimentBasedConfig(...)` was inlined at 13 call sites throughout `nextEditProvider.ts`. This centralizes those reads into per-request config **snapshots** computed once per request and threaded through the methods that need them, instead of reading config inline.

Two snapshot types are added to `nesConfigs.ts`:

- **`INesRequestConfigs`** (main request path) — `isAsyncCompletions`, `debounceUseCoreRequestTime`, `autoExpandEditWindowLines`, `cacheDelay`, `rebasedCacheDelay`, `subsequentCacheDelay`, `speculativeRequestDelay`. Read once in `_getNextEditCanThrow` via `_readRequestConfigs()` and threaded through `fetchNextEdit` → `_executeNewNextEditRequest` and `computeMinimumResponseDelay` (+ the debounce read).
- **`INesSpeculativeConfigs`** (speculative request path) — `cursorPlacement`, `autoExpandEditWindowLinesSetting`, `autoExpandEditWindowLines`. Read once at the top of `_triggerSpeculativeRequest` via `_readSpeculativeConfigs()` and threaded into `_createSpeculativeRequest`.

`INesRequestConfigs extends INesConfigs`, so the telemetry-facing `{ isAsyncCompletions }` subset is unchanged.

## Why two snapshots (not one)

The issue framed this as "one snapshot", but the reads actually span **two independent request-producing flows** — the main request and the speculative request — which are separate invocations. Using two focused snapshots (rather than one shared type) keeps each flow reading only its own experiment flags, so it does **not** shift experiment-exposure timing for the other flow's `TeamInternal` flags. This keeps the change strictly behavior-preserving, which matters because later layers stack on it.

## Consolidation

- **11 of 13** inline reads consolidated into the two readers.
- **2 intentionally left as direct reads** (now commented): `InlineEditsAsyncCompletions` in `_cancelPendingRequestDueToDocChange` (per-keystroke autorun gate) and `InlineEditsSpeculativeRequests` in `handleShown` (per-shown enablement gate). These are enablement gates checked outside a request lifecycle; folding them into a snapshot would run ~10 config reads per keystroke / shown-event for no functional gain.

## Notes

- Main-flow telemetry + log side effects are preserved byte-for-byte (`setNESConfigs(...)` stays the `{ isAsyncCompletions }` subset; the logged codeblock is unchanged).
- `_expService` is retained — still required by the `NextEditCache` constructor and the two gate reads. It could not be dropped.
- No functional behavior change; the only difference is that a flow now reads its full config set once up front (eager rather than conditional), which affects experiment-exposure *timing* within a flow only.

## Validation

- `cd extensions/copilot && npx vitest --run --pool=forks nextEditProvider` → **3 files, 66 passed / 2 skipped** (unchanged from baseline): `nextEditProviderCaching.spec.ts`, `nextEditProviderSpeculative.spec.ts`, `nextEditProviderTelemetry.spec.ts`.
- `npx tsgo --noEmit --project tsconfig.json` → clean.