### PR TITLE
sessions: scope last-turn changes pill to the viewed chat

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/chatView.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatView.ts
@@ -214,8 +214,8 @@ export class ChatView extends AbstractChatView {
 		// Monitor this chat's running subagents in the ephemeral chip.
 		this._runningSubagents.setChat(resource);
 
-		// Reflect this chat's session status in the floating pills.
-		this._chatPills.setChat(resource);
+		// Reflect this chat's last-turn changes and status in the floating pills.
+		this._chatPills.setChat(chat);
 
 		// Reflect read-only (non-interactive) chats: hide the composer and gate
 		// mutating actions (Start Over / Restore Checkpoint) via the widget. Any

--- a/src/vs/sessions/contrib/chat/browser/sessionChatInputToolbar.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionChatInputToolbar.ts
@@ -17,7 +17,7 @@ import { isIChatSessionFileChange2 } from '../../../../workbench/contrib/chat/co
 import { ChatTurnPillsWidget, diffStatsEqual, EMPTY_DIFF_STATS, IChatTurnPillsModel, IDiffStats, IPreviewFile, observeTurnStatusPillsConfig, openChatPreviewFile, previewFilesEqual, previewKind } from '../../../../workbench/contrib/chat/browser/widget/chatTurnPills.js';
 import { isAgentHostProviderId } from '../../../common/agentHostSessionsProvider.js';
 import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
-import { SessionStatus } from '../../../services/sessions/common/session.js';
+import { IChat, SessionStatus } from '../../../services/sessions/common/session.js';
 import { IActiveSession } from '../../../services/sessions/common/sessionsManagement.js';
 import { VIEW_SESSION_CHANGES_COMMAND_ID } from '../../changes/browser/changesActions.js';
 import './media/sessionChatInputToolbar.css';
@@ -32,18 +32,17 @@ interface ITurnData {
 const EMPTY_TURN_DATA: ITurnData = { stats: EMPTY_DIFF_STATS, previewFiles: [] };
 
 /**
- * Compute the current turn's diff stats and previewable files from the session's
- * last-turn changes ({@link ISession.lastTurnChanges}), which the provider
- * derives from the live output stream. Files are classified as created vs.
- * edited with the same rules as the Changes view (an addition has no original; a
- * deletion has no modified resource). Created files are listed before edited ones
- * so the primary (first) file is the first created one, falling back to the first
- * edited one. Returns {@link EMPTY_TURN_DATA} when the session exposes no
- * last-turn changes (e.g. before its first turn, or a provider that can't
- * determine them).
+ * Compute the current turn's diff stats and previewable files from the chat's
+ * last-turn changes ({@link IChat.lastTurnChanges}), which the provider derives
+ * from the live output stream. Files are classified as created vs. edited with
+ * the same rules as the Changes view (an addition has no original; a deletion
+ * has no modified resource). Created files are listed before edited ones so the
+ * primary (first) file is the first created one, falling back to the first
+ * edited one. Returns {@link EMPTY_TURN_DATA} when the chat exposes no last-turn
+ * changes (e.g. before its first turn, or a provider that can't determine them).
  */
-function computeTurnData(session: IActiveSession, reader: IReader): ITurnData {
-	const changes = session.lastTurnChanges?.read(reader) ?? [];
+function computeTurnData(chat: IChat, reader: IReader): ITurnData {
+	const changes = chat.lastTurnChanges?.read(reader) ?? [];
 
 	let insertions = 0, deletions = 0;
 	const created: IPreviewFile[] = [];
@@ -76,11 +75,11 @@ function turnDataEqual(a: ITurnData, b: ITurnData): boolean {
 
 /**
  * A floating toolbar shown above the chat input that surfaces the current turn's
- * session status as clickable pills (see {@link ChatTurnPillsWidget}). Only shown
- * for agent host sessions while a turn is actively in progress; once the turn
- * completes the pills disappear here and reappear inside the completed response.
- * The pills are scoped to the session's last-turn changes so they reflect only
- * what the most recent request produced.
+ * chat status as clickable pills (see {@link ChatTurnPillsWidget}). Only shown
+ * for agent host sessions while the viewed chat's turn is actively in progress;
+ * once the turn completes the pills disappear here and reappear inside the
+ * completed response. The pills are scoped to the viewed chat's last-turn changes
+ * so they reflect only what that chat's most recent request produced.
  */
 export class SessionChatInputToolbar extends Disposable {
 
@@ -88,34 +87,36 @@ export class SessionChatInputToolbar extends Disposable {
 
 	/** Sentinel distinguishing "no override" from an explicit `undefined` session. */
 	private readonly _sessionOverride = observableValue<IActiveSession | undefined | 'unset'>('sessionOverride', 'unset');
-	private readonly _chatResource = observableValue<URI | undefined>('chatResource', undefined);
+	/** The chat whose last-turn changes are reflected. */
+	private readonly _chat = observableValue<IChat | undefined>('chat', undefined);
 
-	/** The session whose status is reflected, from an explicit override or resolved from the chat. */
+	/** The session that owns the reflected chat, from an explicit override or resolved from the chat. */
 	private readonly _session: IObservable<IActiveSession | undefined> = derived(reader => {
 		const override = this._sessionOverride.read(reader);
 		if (override !== 'unset') {
 			return override;
 		}
-		const resource = this._chatResource.read(reader);
-		if (!resource) {
+		const chat = this._chat.read(reader);
+		if (!chat) {
 			return undefined;
 		}
-		return this._findOwningSession(resource, reader);
+		return this._findOwningSession(chat.resource, reader);
 	});
 
 	/** The current turn's diff stats and previewable files. */
 	private readonly _turnData = derivedOpts<ITurnData>({ owner: this, equalsFn: turnDataEqual }, reader => {
-		const session = this._session.read(reader);
-		return session ? computeTurnData(session, reader) : EMPTY_TURN_DATA;
+		const chat = this._chat.read(reader);
+		return chat ? computeTurnData(chat, reader) : EMPTY_TURN_DATA;
 	});
 
 	private readonly _diffStats = derivedOpts<IDiffStats>({ owner: this, equalsFn: diffStatsEqual }, reader => this._turnData.read(reader).stats);
 	private readonly _previewFiles = derivedOpts<readonly IPreviewFile[]>({ owner: this, equalsFn: previewFilesEqual }, reader => this._turnData.read(reader).previewFiles);
 
-	/** Whether pills may show at all: an agent host session while a turn is streaming. */
+	/** Whether pills may show at all: an agent host session while the viewed chat's turn is streaming. */
 	private readonly _active = derived(reader => {
 		const session = this._session.read(reader);
-		return !!session && isAgentHostProviderId(session.providerId) && session.status.read(reader) === SessionStatus.InProgress;
+		const chat = this._chat.read(reader);
+		return !!session && !!chat && isAgentHostProviderId(session.providerId) && chat.status.read(reader) === SessionStatus.InProgress;
 	});
 
 	constructor(
@@ -150,21 +151,23 @@ export class SessionChatInputToolbar extends Disposable {
 	}
 
 	/**
-	 * Track the currently-viewed chat; the toolbar resolves and reflects the
-	 * status of the session that owns it. Clears any explicit {@link setSession}
-	 * override.
+	 * Track the currently-viewed chat; the toolbar reflects that chat's last-turn
+	 * changes and status, resolving the owning session for provider gating and the
+	 * open-changes action. Clears any explicit {@link setSession} override.
 	 */
-	setChat(chatResource: URI | undefined): void {
+	setChat(chat: IChat | undefined): void {
 		this._sessionOverride.set('unset', undefined);
-		this._chatResource.set(chatResource, undefined);
+		this._chat.set(chat, undefined);
 	}
 
 	/**
-	 * Explicitly set the session to reflect, bypassing chat resolution. Intended
-	 * for component fixtures and callers that already hold the session.
+	 * Explicitly set the session and chat to reflect, bypassing chat-to-session
+	 * resolution. Intended for component fixtures and callers that already hold
+	 * both.
 	 */
-	setSession(session: IActiveSession | undefined): void {
+	setSession(session: IActiveSession | undefined, chat: IChat | undefined): void {
 		this._sessionOverride.set(session, undefined);
+		this._chat.set(chat, undefined);
 	}
 
 	private _findOwningSession(chatResource: URI, reader: IReader): IActiveSession | undefined {

--- a/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionFiles.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/agentHostSessionFiles.ts
@@ -23,7 +23,7 @@ import {
 } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { IChatSessionFileChange2 } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ISessionFile, ISessionFileChange, ISessionWorkspace, SessionFileOperation, sessionFileChangesEqual } from '../../../../services/sessions/common/session.js';
-import { createActiveSessionSubscriptionObs, selectMostRecentChatUri } from './agentHostSessionChangesets.js';
+import { createActiveSessionSubscriptionObs } from './agentHostSessionChangesets.js';
 import { IAgentHostAdapterOptions } from './baseAgentHostSessionsProvider.js';
 
 /**
@@ -58,12 +58,15 @@ export interface ISessionOutputObs {
 	 */
 	readonly externalFiles: IObservable<readonly ISessionFile[]>;
 	/**
-	 * File changes produced by the session's **last turn** only — the in-progress
-	 * turn of the most recently modified chat, or (when idle) that chat's last
-	 * completed turn. Used by the chat input status pills to reflect just what the
-	 * most recent request produced.
+	 * Returns the file changes produced by a specific chat's **last turn** only,
+	 * keyed by that chat's AHP chat URI (the default chat's
+	 * {@link buildDefaultChatUri}, or a peer chat's protocol resource). Reduces
+	 * that chat's last-turn edits into per-file {@link ISessionFileChange |
+	 * changes} (with diff stats), mirroring the "Last Turn Changes" changeset
+	 * without depending on it. Used by the chat input status pills to reflect
+	 * just what the chat's most recent request produced.
 	 */
-	readonly lastTurnChanges: IObservable<readonly ISessionFileChange[]>;
+	getLastTurnChanges(chatUri: URI): IObservable<readonly ISessionFileChange[]>;
 }
 
 /**
@@ -77,9 +80,10 @@ export interface ISessionOutputObs {
  *   chats/turns so that a file first created and then edited is reported as
  *   {@link SessionFileOperation.Created} while a deleted file is removed; only
  *   files outside the workspace folders are kept.
- * - {@link ISessionOutputObs.lastTurnChanges}: the last turn's edits reduced per
- *   file into {@link ISessionFileChange | changes} (with diff stats), mirroring
- *   the "Last Turn Changes" changeset without depending on it.
+ * - {@link ISessionOutputObs.getLastTurnChanges}: given a chat's AHP URI, that
+ *   chat's last turn's edits reduced per file into {@link ISessionFileChange |
+ *   changes} (with diff stats), mirroring the "Last Turn Changes" changeset
+ *   without depending on it.
  *
  * Computation only happens for the active, non-archived session: archived
  * sessions never open a live chat-state subscription, so no parsing work is
@@ -129,17 +133,6 @@ export function createSessionOutputObs(
 		return [...uris.values()];
 	});
 
-	// The chat that holds the session's "last turn": the most recently modified
-	// chat (its in-progress turn, or last completed turn when idle). Mirrors the
-	// "Last Turn Changes" changeset's chat selection via the shared helper.
-	const mostRecentChatUriObs = derivedOpts<URI>({ equalsFn: isEqual }, reader => {
-		if (!enabledObs.read(reader)) {
-			return URI.parse(buildDefaultChatUri(sessionUri));
-		}
-		const sessionState = sessionStateObs.read(reader).read(reader);
-		return selectMostRecentChatUri(sessionState, sessionUri);
-	});
-
 	// One observable of parsed edits per chat, subscribing to that chat's state.
 	//
 	// Completed turns (`chatState.turns`) are immutable once finalized, so each
@@ -178,18 +171,18 @@ export function createSessionOutputObs(
 		return reduceSessionFiles(allEdits, folderRoots);
 	});
 
-	const lastTurnChanges = derivedOpts<readonly ISessionFileChange[]>({ equalsFn: sessionFileChangesEqual }, reader => {
-		const mostRecentChatUri = mostRecentChatUriObs.read(reader);
-		for (const chatEditsObs of editsPerChatObs.read(reader)) {
-			const chatEdits = chatEditsObs.read(reader);
-			if (isEqual(chatEdits.chatUri, mostRecentChatUri)) {
-				return reduceTurnChanges(chatEdits.lastTurnEdits);
+	const getLastTurnChanges = (chatUri: URI): IObservable<readonly ISessionFileChange[]> =>
+		derivedOpts<readonly ISessionFileChange[]>({ equalsFn: sessionFileChangesEqual }, reader => {
+			for (const chatEditsObs of editsPerChatObs.read(reader)) {
+				const chatEdits = chatEditsObs.read(reader);
+				if (isEqual(chatEdits.chatUri, chatUri)) {
+					return reduceTurnChanges(chatEdits.lastTurnEdits);
+				}
 			}
-		}
-		return [];
-	});
+			return [];
+		});
 
-	return { externalFiles, lastTurnChanges };
+	return { externalFiles, getLastTurnChanges };
 }
 
 /**

--- a/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -53,7 +53,7 @@ import { computePullRequestIcon, GitHubPullRequestState } from '../../../github/
 import { IPullRequestIconCache } from '../../../github/browser/pullRequestIconCache.js';
 import { mapProtocolStatus } from './agentHostDiffs.js';
 import { createChangesets } from './agentHostSessionChangesets.js';
-import { createSessionOutputObs } from './agentHostSessionFiles.js';
+import { createSessionOutputObs, ISessionOutputObs } from './agentHostSessionFiles.js';
 
 const STORAGE_KEY_REMEMBERED_SESSION_CONFIG_VALUES = 'sessions.agentHost.sessionConfigPicker.selectedValues';
 const UNSAFE_SESSION_CONFIG_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
@@ -297,7 +297,7 @@ class AdditionalChat extends Disposable {
 	private readonly _interactivity: ISettableObservable<ChatInteractivity>;
 	private readonly _isNew: ISettableObservable<boolean>;
 
-	constructor(resource: URI, summary: ChatSummary, isNew: boolean = false, parentChat?: URI) {
+	constructor(resource: URI, summary: ChatSummary, isNew: boolean = false, parentChat?: URI, lastTurnChanges?: IObservable<readonly ISessionFileChange[]>) {
 		super();
 		const modifiedAt = summary.modifiedAt ? new Date(summary.modifiedAt) : new Date();
 		this._title = observableValue('chatTitle', summary.title || localize('newChatTab', "New Chat"));
@@ -316,6 +316,7 @@ class AdditionalChat extends Disposable {
 			updatedAt: this._updatedAt,
 			status: derived(reader => this._isNew.read(reader) ? SessionStatus.Untitled : this._status.read(reader)),
 			changes: constObservable([]),
+			lastTurnChanges,
 			checkpoints: observableValue(this, undefined),
 			modelId: this._modelId,
 			mode: this._mode,
@@ -402,7 +403,6 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 	readonly changes: IObservable<readonly (IChatSessionFileChange | IChatSessionFileChange2)[]>;
 	readonly changesets: ISettableObservable<readonly ISessionChangeset[] | undefined>;
 	readonly externalChanges: IObservable<readonly ISessionFile[]>;
-	readonly lastTurnChanges: IObservable<readonly ISessionFileChange[]>;
 	readonly modelId: ISettableObservable<string | undefined>;
 	modelSelection: ModelSelection | undefined;
 	readonly mode: ISettableObservable<{ readonly id: string; readonly kind: string } | undefined>;
@@ -437,6 +437,13 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 	 * for single-chat sessions it is the only chat and `chats === [it]`.
 	 */
 	private readonly _defaultChat: IChat;
+	/**
+	 * The session's live output observables (external files + per-chat last-turn
+	 * changes), parsed once from the active-session subscriptions and shared by
+	 * the default chat and every peer chat so each chat's status pills reflect
+	 * that chat's own last turn.
+	 */
+	private readonly _sessionOutput: ISessionOutputObs;
 	/**
 	 * Independent title override for the default chat tab. `undefined` means the
 	 * default chat inherits the session title; a non-empty value means the user
@@ -686,8 +693,8 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 		// active-session subscriptions used for changes.
 		const sessionUri = AgentSession.uri(this.sessionType, rawId);
 		const sessionOutput = createSessionOutputObs(sessionUri, this._options, this.isActiveSessionObs, this.isArchived, this.workspace);
+		this._sessionOutput = sessionOutput;
 		this.externalChanges = sessionOutput.externalFiles;
-		this.lastTurnChanges = sessionOutput.lastTurnChanges;
 
 		const mainChat: IChat = {
 			resource: this.resource,
@@ -696,6 +703,7 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 			updatedAt: this.updatedAt,
 			status: derived(this, reader => this._defaultChatStatusOverride.read(reader) ?? this.status.read(reader)),
 			changes: this.changes,
+			lastTurnChanges: sessionOutput.getLastTurnChanges(URI.parse(buildDefaultChatUri(sessionUri))),
 			checkpoints: observableValue(this, undefined),
 			modelId: this.modelId,
 			mode: this.mode,
@@ -836,7 +844,8 @@ export class AgentHostSessionAdapter extends Disposable implements ISession {
 
 	private _createAdditionalChat(chatId: string, summary: ChatSummary): AdditionalChat {
 		const resource = URI.from({ scheme: this._resourceScheme, path: `/${this._rawId}`, fragment: chatId });
-		return new AdditionalChat(resource, summary, this._newChatIds.has(chatId), this._resolveParentChatResource(summary.origin));
+		const lastTurnChanges = this._sessionOutput.getLastTurnChanges(URI.parse(summary.resource));
+		return new AdditionalChat(resource, summary, this._newChatIds.has(chatId), this._resolveParentChatResource(summary.origin), lastTurnChanges);
 	}
 
 	/**

--- a/src/vs/sessions/services/sessions/browser/visibleSessions.ts
+++ b/src/vs/sessions/services/sessions/browser/visibleSessions.ts
@@ -263,7 +263,6 @@ export class VisibleSession extends Disposable implements IActiveSession {
 	get changesets() { return this._session.changesets; }
 	get changes() { return this._session.changes; }
 	get externalChanges() { return this._session.externalChanges; }
-	get lastTurnChanges() { return this._session.lastTurnChanges; }
 	get modelId() { return this._activeChatModelId; }
 	get mode() { return this._activeChatMode; }
 	get loading() { return this._session.loading; }
@@ -305,7 +304,6 @@ class ResourceOverrideSession implements ISession {
 	get changes() { return this._session.changes; }
 	get changesets() { return this._session.changesets; }
 	get externalChanges() { return this._session.externalChanges; }
-	get lastTurnChanges() { return this._session.lastTurnChanges; }
 	get modelId() { return this._session.modelId; }
 	get mode() { return this._session.mode; }
 	get loading() { return this._session.loading; }

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -382,6 +382,14 @@ export interface IChat {
 	readonly status: IObservable<SessionStatus>;
 	/** File changes produced by the chat. */
 	readonly changes: IObservable<readonly ISessionFileChange[]>;
+	/**
+	 * File changes produced by the chat's **last turn** only (as opposed to the
+	 * cumulative chat {@link changes}). Derived from the chat's live output
+	 * stream so consumers — e.g. the chat input status pills — can reflect just
+	 * what the most recent request produced. Providers that cannot determine
+	 * this omit the observable.
+	 */
+	readonly lastTurnChanges?: IObservable<readonly ISessionFileChange[]>;
 	/** Checkpoints associated with the chat. */
 	readonly checkpoints: IObservable<IChatCheckpoints | undefined>;
 	/** Currently selected model identifier. */
@@ -476,14 +484,6 @@ export interface ISession {
 	 * cannot determine this report an empty array (or omit the observable).
 	 */
 	readonly externalChanges?: IObservable<readonly ISessionFile[]>;
-	/**
-	 * File changes produced by the session's **last turn** only (as opposed to
-	 * the cumulative session {@link changes}). Derived from the session's live
-	 * output stream so consumers — e.g. the chat input status pills — can reflect
-	 * just what the most recent request produced. Providers that cannot determine
-	 * this omit the observable.
-	 */
-	readonly lastTurnChanges?: IObservable<readonly ISessionFileChange[]>;
 	/** Currently selected model identifier. */
 	readonly modelId: IObservable<string | undefined>;
 	readonly mode: IObservable<{ readonly id: string; readonly kind: string } | undefined>;

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/sessionChatInputToolbar.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/sessionChatInputToolbar.fixture.ts
@@ -14,7 +14,7 @@ import { SessionChatInputToolbar } from '../../../../../sessions/contrib/chat/br
 // eslint-disable-next-line local/code-import-patterns
 import { LOCAL_AGENT_HOST_PROVIDER_ID } from '../../../../../sessions/common/agentHostSessionsProvider.js';
 // eslint-disable-next-line local/code-import-patterns
-import { ISessionFileChange, SessionStatus } from '../../../../../sessions/services/sessions/common/session.js';
+import { ISessionFileChange, IChat, SessionStatus } from '../../../../../sessions/services/sessions/common/session.js';
 // eslint-disable-next-line local/code-import-patterns
 import { IActiveSession } from '../../../../../sessions/services/sessions/common/sessionsManagement.js';
 import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup } from '../fixtureUtils.js';
@@ -38,26 +38,36 @@ function editedFile(name: string, insertions: number, deletions: number): ISessi
 
 interface ISessionSpec {
 	readonly providerId?: string;
-	/** File changes in the last turn; omit for a session with no last-turn changes. */
+	/** File changes in the last turn; omit for a chat with no last-turn changes. */
 	readonly turnChanges?: readonly ISessionFileChange[];
 }
 
-function createMockSession(spec: ISessionSpec): IActiveSession {
-	return new class extends mock<IActiveSession>() {
-		override readonly resource = URI.parse('session:1');
-		override readonly providerId = spec.providerId ?? LOCAL_AGENT_HOST_PROVIDER_ID;
-		// Pills above the input only show while a turn is actively in progress.
+/** A mock session + its viewed chat, as the toolbar consumes them. */
+interface IMockSessionAndChat {
+	readonly session: IActiveSession;
+	readonly chat: IChat;
+}
+
+function createMockSession(spec: ISessionSpec): IMockSessionAndChat {
+	const chat = new class extends mock<IChat>() {
+		override readonly resource = URI.parse('chat:1');
+		// Pills above the input only show while the chat's turn is in progress.
 		override readonly status: IObservable<SessionStatus> = constObservable(SessionStatus.InProgress);
 		override readonly lastTurnChanges: IObservable<readonly ISessionFileChange[]> | undefined =
 			spec.turnChanges !== undefined ? constObservable(spec.turnChanges) : undefined;
 	}();
+	const session = new class extends mock<IActiveSession>() {
+		override readonly resource = URI.parse('session:1');
+		override readonly providerId = spec.providerId ?? LOCAL_AGENT_HOST_PROVIDER_ID;
+	}();
+	return { session, chat };
 }
 
 // ============================================================================
 // Render helpers
 // ============================================================================
 
-function renderPills(ctx: ComponentFixtureContext, session: IActiveSession): void {
+function renderPills(ctx: ComponentFixtureContext, mock: IMockSessionAndChat): void {
 	const { container, disposableStore } = ctx;
 
 	const instantiationService = createEditorServices(disposableStore, {
@@ -75,14 +85,14 @@ function renderPills(ctx: ComponentFixtureContext, session: IActiveSession): voi
 	(instantiationService.get(IConfigurationService) as TestConfigurationService).setUserConfiguration(ChatConfiguration.TurnStatusPills, { changes: true, preview: true });
 
 	const pills = disposableStore.add(instantiationService.createInstance(SessionChatInputToolbar));
-	pills.setSession(session);
+	pills.setSession(mock.session, mock.chat);
 	container.appendChild(pills.element);
 
 	container.style.padding = '12px';
 	container.style.backgroundColor = 'var(--vscode-sideBar-background)';
 }
 
-async function renderChatViewWithPills(ctx: ComponentFixtureContext, session: IActiveSession, messages: IFixtureMessage[]): Promise<void> {
+async function renderChatViewWithPills(ctx: ComponentFixtureContext, mock: IMockSessionAndChat, messages: IFixtureMessage[]): Promise<void> {
 	await renderChatWidget(ctx, {
 		messages,
 		decorateInputPart: (inputPart, instantiationService) => {
@@ -91,7 +101,7 @@ async function renderChatViewWithPills(ctx: ComponentFixtureContext, session: IA
 				(accessor.get(IConfigurationService) as TestConfigurationService).setUserConfiguration(ChatConfiguration.TurnStatusPills, { changes: true, preview: true });
 			});
 			const pills = ctx.disposableStore.add(instantiationService.createInstance(SessionChatInputToolbar));
-			pills.setSession(session);
+			pills.setSession(mock.session, mock.chat);
 			// Mount above the input, mirroring the sessions ChatView.
 			inputPart.element.insertBefore(pills.element, inputPart.element.firstChild);
 		},


### PR DESCRIPTION
## What

Moves the "last turn changes" concept from the **session** to the **chat**. The changes pill shown above the chat input now reflects the last-turn changes of the **specific chat** being viewed. In a session with multiple chats, each chat tracks its own last-turn changes.

## Why

Previously `lastTurnChanges` lived on `ISession` and picked the session's "most recent chat", so the pill above one chat's input could reflect a different chat's turn. This scopes it correctly to the chat the user is looking at.

## Changes

- **Model** (`session.ts`): removed `lastTurnChanges` from `ISession`; added optional `lastTurnChanges` to `IChat`.
- **Agent host provider** (`agentHostSessionFiles.ts`): replaced the session-level `lastTurnChanges` (which selected the most-recent chat) with a per-chat `getLastTurnChanges(chatUri)` lookup that reduces that chat's last-turn edits. Reuses the already-parsed per-chat edits; dropped the now-unused most-recent-chat selection.
- **Provider wiring** (`baseAgentHostSessionsProvider.ts`): stores the session output and wires the main chat and each peer chat to their own last-turn changes.
- **Delegation cleanup** (`visibleSessions.ts`): dropped the session-level `lastTurnChanges` getters.
- **Pill widget host** (`sessionChatInputToolbar.ts`): now tracks an `IChat`, reads `chat.lastTurnChanges`, and gates visibility on the chat's status (`InProgress`). Still resolves the owning session for the agent-host provider gate and the open-changes action. `setChat` takes an `IChat`; `setSession(session, chat)` is the explicit fixture override.
- **ChatView** (`chatView.ts`): passes the `IChat` into the toolbar.
- **Fixture** (`sessionChatInputToolbar.fixture.ts`): mock now provides an `IChat` (status + `lastTurnChanges`) plus a session.

## Notes for reviewers

- Pill visibility now gates on the **chat's** status rather than the session's aggregate status.
- The "Last Turn Changes" *changeset* (Changes-view filter) is a separate feature and was intentionally left untouched.
- Validated with `typecheck-client` and ESLint on the changed files.