### PR TITLE
Custom editors opt out of diff/merge by default via `never` priority

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -11,7 +11,8 @@
     "customEditorDiffs",
     "documentDiff",
     "documentSyntaxHighlighting",
-    "textEditorDiffInformation"
+    "textEditorDiffInformation",
+    "customEditorPriority"
   ],
   "engines": {
     "vscode": "^1.70.0"
@@ -860,7 +861,11 @@
       {
         "viewType": "vscode.markdown.preview.editor",
         "displayName": "Markdown Preview",
-        "priority": "option",
+        "priority": {
+          "diffEditor": "option",
+          "textEditor": "option",
+          "mergeEditor": "never"
+        },
         "selector": [
           {
             "filenamePattern": "*.md"
@@ -870,7 +875,11 @@
       {
         "viewType": "vscode.markdown.editor",
         "displayName": "Markdown Editor (Experimental)",
-        "priority": "option",
+        "priority": {
+          "diffEditor": "never",
+          "textEditor": "option",
+          "mergeEditor": "never"
+        },
         "selector": [
           {
             "filenamePattern": "*.md"

--- a/src/vs/workbench/contrib/customEditor/common/contributedCustomEditors.ts
+++ b/src/vs/workbench/contrib/customEditor/common/contributedCustomEditors.ts
@@ -108,12 +108,12 @@ function normalizeStoredCustomEditorDescriptor(descriptor: StoredCustomEditorDes
 		selector: descriptor.selector,
 		priority: typeof descriptor.priority === 'string' ? {
 			editor: descriptor.priority,
-			diff: descriptor.priority,
-			merge: descriptor.priority,
+			diff: RegisteredEditorPriority.never,
+			merge: RegisteredEditorPriority.never,
 		} : {
 			editor: descriptor.priority.editor,
-			diff: descriptor.priority.diff ?? descriptor.priority.editor,
-			merge: descriptor.priority.merge ?? descriptor.priority.editor,
+			diff: descriptor.priority.diff ?? RegisteredEditorPriority.never,
+			merge: descriptor.priority.merge ?? RegisteredEditorPriority.never,
 		},
 	};
 }
@@ -123,11 +123,16 @@ function getPriorityFromContribution(
 	extension: IExtensionDescription,
 	includeDiffAndMergePriority: boolean,
 ): CustomEditorDescriptor['priority'] {
+	// The `textEditor` value drives the normal editor and keeps its historical `default` fallback when
+	// omitted. `diffEditor` and `mergeEditor` do not inherit from `textEditor`: they default to
+	// `never`, so a custom editor is not used for diffs or merges unless it explicitly opts in (which
+	// requires the `customEditorPriority` proposal).
 	const editorPriority = getSinglePriorityFromContribution(typeof contribution === 'string' ? contribution : contribution?.textEditor, extension) ?? RegisteredEditorPriority.default;
+	const readObjectField = includeDiffAndMergePriority && typeof contribution !== 'string';
 	return {
 		editor: editorPriority,
-		diff: includeDiffAndMergePriority && typeof contribution !== 'string' ? getSinglePriorityFromContribution(contribution?.diffEditor, extension) ?? editorPriority : editorPriority,
-		merge: includeDiffAndMergePriority && typeof contribution !== 'string' ? getSinglePriorityFromContribution(contribution?.mergeEditor, extension) ?? editorPriority : editorPriority,
+		diff: (readObjectField ? getSinglePriorityFromContribution(contribution?.diffEditor, extension) : undefined) ?? RegisteredEditorPriority.never,
+		merge: (readObjectField ? getSinglePriorityFromContribution(contribution?.mergeEditor, extension) : undefined) ?? RegisteredEditorPriority.never,
 	};
 }
 
@@ -138,6 +143,9 @@ function getSinglePriorityFromContribution(value: CustomEditorPriority | undefin
 
 		case CustomEditorPriority.option:
 			return RegisteredEditorPriority.option;
+
+		case CustomEditorPriority.never:
+			return RegisteredEditorPriority.never;
 
 		case CustomEditorPriority.builtin:
 			// Builtin is only valid for builtin extensions

--- a/src/vs/workbench/contrib/customEditor/common/customEditor.ts
+++ b/src/vs/workbench/contrib/customEditor/common/customEditor.ts
@@ -81,6 +81,7 @@ export const enum CustomEditorPriority {
 	default = 'default',
 	builtin = 'builtin',
 	option = 'option',
+	never = 'never',
 }
 
 export const enum CustomEditorDiffEditorLayout {

--- a/src/vs/workbench/contrib/customEditor/common/extensionPoint.ts
+++ b/src/vs/workbench/contrib/customEditor/common/extensionPoint.ts
@@ -33,10 +33,12 @@ const customEditorPrioritySchema = {
 	enum: [
 		CustomEditorPriority.default,
 		CustomEditorPriority.option,
+		CustomEditorPriority.never,
 	],
 	markdownEnumDescriptions: [
 		nls.localize('contributes.priority.default', 'The editor is automatically used when the user opens a resource, provided that no other default custom editors are registered for that resource.'),
 		nls.localize('contributes.priority.option', 'The editor is not automatically used when the user opens a resource, but a user can switch to the editor using the `Reopen With` command.'),
+		nls.localize('contributes.priority.never', 'The editor is never automatically used, and it is also skipped when the user points a `workbench.editorAssociations` entry at it. It can still be opened via the `Reopen With` command or the specialized `workbench.diffEditorAssociations` setting.'),
 	],
 } as const satisfies IJSONSchema;
 
@@ -77,7 +79,7 @@ const customEditorsContributionSchema = {
 			}
 		},
 		[Fields.priority]: {
-			markdownDescription: nls.localize('contributes.priority', 'Controls if the custom editor is enabled automatically when the user opens a file, diff, or merge editor. This may be overridden by users using the `workbench.editorAssociations` or `workbench.diffEditorAssociations` setting.'),
+			markdownDescription: nls.localize('contributes.priority', 'Controls if the custom editor is enabled automatically when the user opens a file, diff, or merge editor. This may be overridden by users using the `workbench.editorAssociations` or `workbench.diffEditorAssociations` setting. When omitted, the custom editor defaults to `default` for the normal editor and `never` for diff and merge editors, so it is not used for diffs or merges unless it opts in.'),
 			anyOf: [
 				customEditorPrioritySchema,
 				{
@@ -87,15 +89,15 @@ const customEditorsContributionSchema = {
 					properties: {
 						[PriorityFields.textEditor]: {
 							...customEditorPrioritySchema,
-							markdownDescription: nls.localize('contributes.priority.textEditor', 'Controls if the custom editor is enabled automatically when the user opens a file. This is the base value: when `diffEditor` or `mergeEditor` are not specified, they fall back to this value.'),
+							markdownDescription: nls.localize('contributes.priority.textEditor', 'Controls if the custom editor is enabled automatically when the user opens a file. `diffEditor` and `mergeEditor` do not inherit this value; when they are not specified they default to `never`.'),
 						},
 						[PriorityFields.diffEditor]: {
 							...customEditorPrioritySchema,
-							markdownDescription: nls.localize('contributes.priority.diffEditor', 'Controls if the custom editor is enabled automatically when the user opens a diff. When not specified, the value of `textEditor` is used.'),
+							markdownDescription: nls.localize('contributes.priority.diffEditor', 'Controls if the custom editor is enabled automatically when the user opens a diff. When not specified this defaults to `never`, so the custom editor is not used for diffs unless it opts in.'),
 						},
 						[PriorityFields.mergeEditor]: {
 							...customEditorPrioritySchema,
-							markdownDescription: nls.localize('contributes.priority.mergeEditor', 'Controls if the custom editor is enabled automatically when the user opens a merge editor. When not specified, the value of `textEditor` is used.'),
+							markdownDescription: nls.localize('contributes.priority.mergeEditor', 'Controls if the custom editor is enabled automatically when the user opens a merge editor. When not specified this defaults to `never`, so the custom editor is not used for merges unless it opts in.'),
 						},
 					}
 				}

--- a/src/vs/workbench/services/editor/browser/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/browser/editorResolverService.ts
@@ -61,6 +61,7 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 
 	// Constants
 	private static readonly configureDefaultID = 'promptOpenWith.configureDefault';
+	private static readonly configureDefaultDiffID = 'promptOpenWith.configureDefaultDiff';
 	private static readonly cacheStorageID = 'editorOverrideService.cache';
 	private static readonly conflictingDefaultsStorageID = 'editorOverrideService.conflictingDefaults';
 
@@ -283,6 +284,8 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 	}
 
 	private getAssociationsForResourceByType(resource: URI, associationType: EditorAssociationType): EditorAssociations {
+		// The specialized diff/merge associations win over the general ones and are allowed to target
+		// an editor even if that editor opted out of diffs/merges through a `never` priority.
 		if (associationType === EditorAssociationType.DiffEditor || associationType === EditorAssociationType.MergeEditor) {
 			const diffAssociations = this.getAssociationsForResourceFromSetting(resource, diffEditorsAssociationsSettingId);
 			if (diffAssociations.length) {
@@ -290,7 +293,21 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 			}
 		}
 
-		return this.getAssociationsForResource(resource);
+		// General `editorAssociations` entries must not select an editor that opted out of this kind of
+		// input via a `never` priority (e.g. a custom editor that only handles the normal editor, not diffs).
+		const r = this.getAssociationsForResource(resource);
+		return r.filter(association => !this.isNeverForAssociationType(association.viewType, associationType));
+	}
+
+	/**
+	 * Whether every editor registered under `viewType` opts out of the given kind of input via a
+	 * `never` priority. Such editors can only be selected explicitly (e.g. `Reopen Editor With`) or
+	 * through the specialized `workbench.diffEditorAssociations` setting, never through a general
+	 * `workbench.editorAssociations` entry.
+	 */
+	private isNeverForAssociationType(viewType: string, associationType: EditorAssociationType): boolean {
+		const editor = this._registeredEditors.filter(editor => editor.editorInfo.id === viewType).at(0);
+		return !!editor && this.getEffectivePriority(editor.editorInfo, associationType) === RegisteredEditorPriority.never;
 	}
 
 	private getAssociationsForResourceFromSetting(resource: URI, settingId: string): EditorAssociations {
@@ -403,6 +420,20 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 		// Form the new setting object including the newest associations
 		for (const association of [...currentAssociations, newAssociation]) {
 			if (association.filenamePattern) {
+				newSettingObject[association.filenamePattern] = association.viewType;
+			}
+		}
+		this.configurationService.updateValue(settingId, newSettingObject);
+	}
+
+	private removeUserAssociationForSetting(settingId: string, globPattern: string): void {
+		const currentAssociations = this.getAllUserAssociationsForSetting(settingId);
+		if (!currentAssociations.some(association => association.filenamePattern === globPattern)) {
+			return;
+		}
+		const newSettingObject = Object.create(null);
+		for (const association of currentAssociations) {
+			if (association.filenamePattern && association.filenamePattern !== globPattern) {
 				newSettingObject[association.filenamePattern] = association.viewType;
 			}
 		}
@@ -784,11 +815,20 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 				label: localize('promptOpenWith.configureDefault', "Configure default editor for '{0}'...", `*${extname(resource)}`),
 			};
 			quickPickEntries.push(configureDefaultEntry);
+			// For diffs, additionally offer to configure a diff-only default so the choice does not
+			// affect how the resource opens as a normal editor (writes to `diffEditorAssociations`).
+			if (associationType === EditorAssociationType.DiffEditor) {
+				const configureDefaultDiffEntry = {
+					id: EditorResolverService.configureDefaultDiffID,
+					label: localize('promptOpenWith.configureDefaultDiff', "Configure default editor (diff only) for '{0}'...", `*${extname(resource)}`),
+				};
+				quickPickEntries.push(configureDefaultDiffEntry);
+			}
 		}
 		return quickPickEntries;
 	}
 
-	private async doPickEditor(editor: IUntypedEditorInput, showDefaultPicker?: boolean): Promise<IEditorOptions | undefined> {
+	private async doPickEditor(editor: IUntypedEditorInput, showDefaultPicker?: boolean, updateAssociationType?: EditorAssociationType): Promise<IEditorOptions | undefined> {
 
 		type EditorPick = {
 			readonly item: IQuickPickItem;
@@ -802,6 +842,21 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 			resource = URI.from({ scheme: Schemas.untitled });
 		}
 		const associationType = isResourceDiffEditorInput(editor) ? EditorAssociationType.DiffEditor : EditorAssociationType.Editor;
+		// Which setting the default picker should write to. Defaults to the resource's association type
+		// so that the per-item gear button keeps writing to the matching setting, but the "Configure
+		// default editor" entries can target a specific setting (general vs. diff-only).
+		const updateSettingType = updateAssociationType ?? associationType;
+
+		// Persists the picked editor as the default for this resource's glob. When the user configures
+		// the general default from a diff context, any diff-only override for the same glob is cleared
+		// so that the general default also takes effect for diffs.
+		const persistDefaultAssociation = (editorID: string) => {
+			const globPattern = `*${extname(resource)}`;
+			this.updateUserAssociationsForType(updateSettingType, globPattern, editorID);
+			if (updateSettingType === EditorAssociationType.Editor && associationType === EditorAssociationType.DiffEditor) {
+				this.removeUserAssociationForSetting(diffEditorsAssociationsSettingId, globPattern);
+			}
+		};
 
 		// Get all the editors for the resource as quickpick entries
 		const editorPicks = this.mapEditorsToQuickPickEntry(resource, showDefaultPicker, associationType);
@@ -810,7 +865,9 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 		const disposables = new DisposableStore();
 		const editorPicker = disposables.add(this.quickInputService.createQuickPick<IQuickPickItem>({ useSeparators: true }));
 		const placeHolderMessage = showDefaultPicker ?
-			localize('promptOpenWith.updateDefaultPlaceHolder', "Select new default editor for '{0}'", `*${extname(resource)}`) :
+			(updateSettingType === EditorAssociationType.DiffEditor ?
+				localize('promptOpenWith.updateDefaultDiffPlaceHolder', "Select new default editor (diff only) for '{0}'", `*${extname(resource)}`) :
+				localize('promptOpenWith.updateDefaultPlaceHolder', "Select new default editor for '{0}'", `*${extname(resource)}`)) :
 			localize('promptOpenWith.placeHolder', "Select editor for '{0}'", basename(resource));
 		editorPicker.placeholder = placeHolderMessage;
 		editorPicker.canAcceptInBackground = true;
@@ -835,7 +892,7 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 
 				// If asked to always update the setting then update it even if the gear isn't clicked
 				if (resource && showDefaultPicker && result?.item.id) {
-					this.updateUserAssociationsForType(associationType, `*${extname(resource)}`, result.item.id);
+					persistDefaultAssociation(result.item.id);
 				}
 
 				resolve(result);
@@ -853,7 +910,7 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 
 				// Persist setting
 				if (resource && e.item?.id) {
-					this.updateUserAssociationsForType(associationType, `*${extname(resource)}`, e.item.id);
+					persistDefaultAssociation(e.item.id);
 				}
 			}));
 
@@ -870,7 +927,12 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 
 			// If the user selected to configure default we trigger this picker again and tell it to show the default picker
 			if (picked.item.id === EditorResolverService.configureDefaultID) {
-				return this.doPickEditor(editor, true);
+				return this.doPickEditor(editor, true, EditorAssociationType.Editor);
+			}
+			// The diff-only variant writes to `diffEditorAssociations` so it does not change how the
+			// resource opens as a normal editor.
+			if (picked.item.id === EditorResolverService.configureDefaultDiffID) {
+				return this.doPickEditor(editor, true, EditorAssociationType.DiffEditor);
 			}
 
 			// Figure out options

--- a/src/vs/workbench/services/editor/common/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/common/editorResolverService.ts
@@ -105,7 +105,15 @@ export enum RegisteredEditorPriority {
 	builtin = 'builtin',
 	option = 'option',
 	exclusive = 'exclusive',
-	default = 'default'
+	default = 'default',
+	/**
+	 * The editor is never automatically used for this kind of input, and it is
+	 * also skipped when the user points a `workbench.editorAssociations` entry at
+	 * it. Unlike `option`, a `never` editor is only used when it is the target of
+	 * the specialized `workbench.diffEditorAssociations` setting or when the user
+	 * explicitly opens it (for example via `Reopen Editor With`).
+	 */
+	never = 'never'
 }
 
 /**
@@ -263,6 +271,9 @@ export function priorityToRank(priority: RegisteredEditorPriority): number {
 			return 3;
 		// Text editor is priority 2
 		case RegisteredEditorPriority.option:
+			return 1;
+		case RegisteredEditorPriority.never:
+			return 0;
 		default:
 			return 1;
 	}

--- a/src/vs/workbench/services/editor/test/browser/editorResolverService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorResolverService.test.ts
@@ -348,6 +348,160 @@ suite('EditorResolverService', () => {
 		diffAssociationRegisteredEditor.dispose();
 	});
 
+	test('Diff editor Resolve - editorAssociations does not force a `never` diff editor', async () => {
+		const DEFAULT_DIFF_INPUT_ID = 'testDefaultDiffInput';
+		const NEVER_DIFF_INPUT_ID = 'testNeverDiffInput';
+		const instantiationService = workbenchInstantiationService({
+			configurationService: () => new TestConfigurationService({
+				[editorsAssociationsSettingId]: {
+					'*.test-never-diff': 'NEVER_DIFF_EDITOR'
+				}
+			})
+		}, disposables);
+		const [part, service, accessor] = await createEditorResolverService(instantiationService);
+		let defaultDiffCounter = 0;
+		let neverDiffCounter = 0;
+
+		const defaultRegisteredEditor = service.registerEditor('*',
+			{
+				id: 'default',
+				label: 'Default Editor',
+				detail: 'Default',
+				priority: RegisteredEditorPriority.builtin
+			},
+			{},
+			{
+				createEditorInput: ({ resource }) => ({ editor: constructDisposableFileEditorInput(resource, TEST_EDITOR_INPUT_ID, disposables) }),
+				createDiffEditorInput: ({ modified, original }) => {
+					defaultDiffCounter++;
+					return { editor: constructDisposableDiffEditorInput(accessor, original, modified, DEFAULT_DIFF_INPUT_ID) };
+				}
+			}
+		);
+
+		// An editor that handles the normal editor but explicitly opts out of diffs via a `never` priority.
+		const neverDiffRegisteredEditor = service.registerEditor('*.test-never-diff',
+			{
+				id: 'NEVER_DIFF_EDITOR',
+				label: 'Never Diff Editor Label',
+				detail: 'Never Diff Editor Details',
+				priority: {
+					editor: RegisteredEditorPriority.option,
+					diff: RegisteredEditorPriority.never,
+					merge: RegisteredEditorPriority.never
+				}
+			},
+			{},
+			{
+				createEditorInput: ({ resource }) => ({ editor: constructDisposableFileEditorInput(resource, NEVER_DIFF_INPUT_ID, disposables) }),
+				createDiffEditorInput: ({ modified, original }) => {
+					neverDiffCounter++;
+					return { editor: constructDisposableDiffEditorInput(accessor, original, modified, NEVER_DIFF_INPUT_ID) };
+				}
+			}
+		);
+
+		// The diff must fall back to the default diff editor, not the `never` editor.
+		const diffResolution = await service.resolveEditor({
+			original: { resource: URI.file('resource-basics.test-never-diff') },
+			modified: { resource: URI.file('resource-basics.test-never-diff') }
+		}, part.activeGroup);
+		assert.ok(diffResolution);
+		assert.notStrictEqual(typeof diffResolution, 'number');
+		if (diffResolution !== ResolvedStatus.ABORT && diffResolution !== ResolvedStatus.NONE) {
+			assert.strictEqual(neverDiffCounter, 0);
+			assert.strictEqual(defaultDiffCounter, 1);
+			diffResolution.editor.dispose();
+		} else {
+			assert.fail();
+		}
+
+		// The normal editor association is still honored (`editor` priority is `option`, not `never`).
+		const editorResolution = await service.resolveEditor({ resource: URI.file('resource-basics.test-never-diff') }, part.activeGroup);
+		assert.ok(editorResolution);
+		assert.notStrictEqual(typeof editorResolution, 'number');
+		if (editorResolution !== ResolvedStatus.ABORT && editorResolution !== ResolvedStatus.NONE) {
+			assert.strictEqual(editorResolution.editor.typeId, NEVER_DIFF_INPUT_ID);
+			editorResolution.editor.dispose();
+		} else {
+			assert.fail();
+		}
+
+		defaultRegisteredEditor.dispose();
+		neverDiffRegisteredEditor.dispose();
+	});
+
+	test('Diff editor Resolve - diffEditorAssociations force a `never` diff editor', async () => {
+		const DEFAULT_DIFF_INPUT_ID = 'testDefaultDiffInput';
+		const NEVER_DIFF_INPUT_ID = 'testNeverDiffInput';
+		const instantiationService = workbenchInstantiationService({
+			configurationService: () => new TestConfigurationService({
+				[diffEditorsAssociationsSettingId]: {
+					'*.test-never-diff': 'NEVER_DIFF_EDITOR'
+				}
+			})
+		}, disposables);
+		const [part, service, accessor] = await createEditorResolverService(instantiationService);
+		let defaultDiffCounter = 0;
+		let neverDiffCounter = 0;
+
+		const defaultRegisteredEditor = service.registerEditor('*',
+			{
+				id: 'default',
+				label: 'Default Editor',
+				detail: 'Default',
+				priority: RegisteredEditorPriority.builtin
+			},
+			{},
+			{
+				createEditorInput: ({ resource }) => ({ editor: constructDisposableFileEditorInput(resource, TEST_EDITOR_INPUT_ID, disposables) }),
+				createDiffEditorInput: ({ modified, original }) => {
+					defaultDiffCounter++;
+					return { editor: constructDisposableDiffEditorInput(accessor, original, modified, DEFAULT_DIFF_INPUT_ID) };
+				}
+			}
+		);
+
+		const neverDiffRegisteredEditor = service.registerEditor('*.test-never-diff',
+			{
+				id: 'NEVER_DIFF_EDITOR',
+				label: 'Never Diff Editor Label',
+				detail: 'Never Diff Editor Details',
+				priority: {
+					editor: RegisteredEditorPriority.option,
+					diff: RegisteredEditorPriority.never,
+					merge: RegisteredEditorPriority.never
+				}
+			},
+			{},
+			{
+				createEditorInput: ({ resource }) => ({ editor: constructDisposableFileEditorInput(resource, NEVER_DIFF_INPUT_ID, disposables) }),
+				createDiffEditorInput: ({ modified, original }) => {
+					neverDiffCounter++;
+					return { editor: constructDisposableDiffEditorInput(accessor, original, modified, NEVER_DIFF_INPUT_ID) };
+				}
+			}
+		);
+
+		// The specialized diff association forces the `never` editor even though it opted out of diffs.
+		const diffResolution = await service.resolveEditor({
+			original: { resource: URI.file('resource-basics.test-never-diff') },
+			modified: { resource: URI.file('resource-basics.test-never-diff') }
+		}, part.activeGroup);
+		assert.ok(diffResolution);
+		assert.notStrictEqual(typeof diffResolution, 'number');
+		if (diffResolution !== ResolvedStatus.ABORT && diffResolution !== ResolvedStatus.NONE) {
+			assert.strictEqual(defaultDiffCounter, 0);
+			assert.strictEqual(neverDiffCounter, 1);
+			diffResolution.editor.dispose();
+		} else {
+			assert.fail();
+		}
+
+		defaultRegisteredEditor.dispose();
+		neverDiffRegisteredEditor.dispose();
+	});
+
 	test('Diff editor Resolve - Different Types', async () => {
 		const [part, service, accessor] = await createEditorResolverService();
 		let diffOneCounter = 0;


### PR DESCRIPTION
Fixes #324791

Makes custom editors opt out of diff and merge editors by default, instead of requiring users to reset them via `workbench.diffEditorAssociations`.

### Problem

Registering a custom editor with `default` priority (or pointing `workbench.editorAssociations` at one) also takes over the **diff** and **merge** views for that file type, because diff/merge inherit the `textEditor` priority. The only escape hatch was an opt-out: users had to add `workbench.diffEditorAssociations: { "*.ext": "default" }` to get the normal text diff editor back.

### Change

- **New `never` priority** (`RegisteredEditorPriority.never` / `CustomEditorPriority.never`, rank `0`). A `never` editor is never auto-selected for that input type and is skipped by general `workbench.editorAssociations`, but can still be forced by `workbench.diffEditorAssociations` or picked via `Reopen Editor With…`.
- **Diff/merge opt out by default.** The `customEditors` contribution priority is resolved per input type: a string / omitted `priority` maps `diff` and `merge` to `never`; only an explicit `diffEditor` / `mergeEditor` (behind the `customEditorPriority` proposal) opts the editor back in. The `textEditor` priority keeps its historical `default` fallback when omitted.
- **Resolver respects `never`.** `getAssociationsForResourceByType` filters out general `editorAssociations` entries whose editor is `never` for the requested input type (normal / diff / merge). The specialized `diffEditorAssociations` setting may still force a `never` editor. `getEditor` is unchanged.
- Updated the built-in Markdown custom editors: `vscode.markdown.editor` sets `diffEditor: never`, `vscode.markdown.preview.editor` opts into diffs with `diffEditor: option`.

### Behavior

| Setting | Normal editor | Diff / merge |
| --- | --- | --- |
| `editorAssociations: *.md → vscode.markdown.editor` | Markdown editor | **Text diff editor** (`diffEditor: never`) |
| `editorAssociations: *.md → vscode.markdown.preview.editor` | Markdown Preview | Markdown Preview (`diffEditor: option`) |
| `diffEditorAssociations: *.md → vscode.markdown.editor` | (unchanged) | Markdown editor (forced) |

### Compatibility

Breaking for extensions that relied on the implicit diff registration: an extension registering a default editor was previously used for diffs automatically. It must now opt in via `priority.diffEditor` / `priority.mergeEditor`.

### Verification steps

1. Set `"workbench.editorAssociations": { "*.md": "vscode.markdown.editor" }`.
2. Open a `*.md` file → opens in the Markdown editor.
3. Open a `*.md` diff → opens in the **text diff editor**, not the Markdown editor.
4. Add `"workbench.diffEditorAssociations": { "*.md": "vscode.markdown.editor" }` and re-open the diff → now uses the Markdown editor (forced).
5. Remove the diff association and use **Reopen Editor With…** on a `*.md` diff → the Markdown editor is still offered and works when picked.
6. Exclusive custom editors (e.g. Hex editor) are unaffected.

Also covered by new `EditorResolverService` unit tests.
