### PR TITLE
Improve context window handling for OpenRouter and Custom Endpoints

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -1918,11 +1918,15 @@
                   },
                   "maxInputTokens": {
                     "type": "number",
-                    "description": "Maximum number of input tokens supported by the model"
+                    "markdownDescription": "Maximum number of input (prompt) tokens supported by the model. Optional when `contextWindow` is set, in which case it is derived as `contextWindow - maxOutputTokens`."
                   },
                   "maxOutputTokens": {
                     "type": "number",
                     "description": "Maximum number of output tokens supported by the model"
+                  },
+                  "contextWindow": {
+                    "type": "number",
+                    "markdownDescription": "The model's full context window (input + output) in tokens, e.g. `1000000` for a 1M model. When set it is the source of truth for the context window and `maxInputTokens` can be omitted. Otherwise the window is derived as `maxInputTokens + maxOutputTokens`."
                   },
                   "editTools": {
                     "type": "array",
@@ -1981,7 +1985,6 @@
                   "url",
                   "toolCalling",
                   "vision",
-                  "maxInputTokens",
                   "maxOutputTokens"
                 ]
               }
@@ -2089,11 +2092,15 @@
                   },
                   "maxInputTokens": {
                     "type": "number",
-                    "description": "Maximum number of input tokens supported by the model"
+                    "markdownDescription": "Maximum number of input (prompt) tokens supported by the model. Optional when `contextWindow` is set, in which case it is derived as `contextWindow - maxOutputTokens`."
                   },
                   "maxOutputTokens": {
                     "type": "number",
                     "description": "Maximum number of output tokens supported by the model"
+                  },
+                  "contextWindow": {
+                    "type": "number",
+                    "markdownDescription": "The model's full context window (input + output) in tokens, e.g. `1000000` for a 1M model. When set it is the source of truth for the context window and `maxInputTokens` can be omitted. Otherwise the window is derived as `maxInputTokens + maxOutputTokens`."
                   },
                   "editTools": {
                     "type": "array",
@@ -2176,7 +2183,6 @@
                   "url",
                   "toolCalling",
                   "vision",
-                  "maxInputTokens",
                   "maxOutputTokens"
                 ]
               }
@@ -2240,11 +2246,15 @@
                   },
                   "maxInputTokens": {
                     "type": "number",
-                    "description": "Maximum number of input tokens supported by the model"
+                    "markdownDescription": "Maximum number of input (prompt) tokens supported by the model. Optional when `contextWindow` is set, in which case it is derived as `contextWindow - maxOutputTokens`."
                   },
                   "maxOutputTokens": {
                     "type": "number",
                     "description": "Maximum number of output tokens supported by the model"
+                  },
+                  "contextWindow": {
+                    "type": "number",
+                    "markdownDescription": "The model's full context window (input + output) in tokens, e.g. `1000000` for a 1M model. When set it is the source of truth for the context window and `maxInputTokens` can be omitted. Otherwise the window is derived as `maxInputTokens + maxOutputTokens`."
                   },
                   "thinking": {
                     "type": "boolean",
@@ -2290,7 +2300,6 @@
                   "url",
                   "toolCalling",
                   "vision",
-                  "maxInputTokens",
                   "maxOutputTokens"
                 ]
               }

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -1986,6 +1986,18 @@
                   "toolCalling",
                   "vision",
                   "maxOutputTokens"
+                ],
+                "anyOf": [
+                  {
+                    "required": [
+                      "maxInputTokens"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "contextWindow"
+                    ]
+                  }
                 ]
               }
             }
@@ -2184,6 +2196,18 @@
                   "toolCalling",
                   "vision",
                   "maxOutputTokens"
+                ],
+                "anyOf": [
+                  {
+                    "required": [
+                      "maxInputTokens"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "contextWindow"
+                    ]
+                  }
                 ]
               }
             }
@@ -2301,6 +2325,18 @@
                   "toolCalling",
                   "vision",
                   "maxOutputTokens"
+                ],
+                "anyOf": [
+                  {
+                    "required": [
+                      "maxInputTokens"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "contextWindow"
+                    ]
+                  }
                 ]
               }
             }

--- a/extensions/copilot/src/extension/byok/common/byokProvider.ts
+++ b/extensions/copilot/src/extension/byok/common/byokProvider.ts
@@ -47,8 +47,19 @@ export type BYOKModelConfig = BYOKGlobalKeyModelConfig | BYOKPerModelConfig | BY
 export interface BYOKModelCapabilities {
 	name: string;
 	url?: string;
-	maxInputTokens: number;
+	/**
+	 * The maximum number of prompt (input) tokens. Optional when {@link contextWindow}
+	 * is supplied, in which case it is derived as `contextWindow - maxOutputTokens`.
+	 */
+	maxInputTokens?: number;
 	maxOutputTokens: number;
+	/**
+	 * The model's full context window (input + output) in tokens. Many providers
+	 * publish this directly (e.g. "Context Length: 1M"). When set it is used as the
+	 * source of truth for the context window; otherwise the window is derived as
+	 * `maxInputTokens + maxOutputTokens` for backward compatibility.
+	 */
+	contextWindow?: number;
 	toolCalling: boolean;
 	vision: boolean;
 	thinking?: boolean;
@@ -93,6 +104,23 @@ export function isNoAuthConfig(config: BYOKModelConfig): config is BYOKNoAuthMod
 	return !('apiKey' in config) && !('deploymentUrl' in config);
 }
 
+/**
+ * Resolves a model's token limits from its BYOK capabilities, honoring an explicit
+ * {@link BYOKModelCapabilities.contextWindow} when provided.
+ *
+ * - When `contextWindow` is set it is the source of truth for the full window and, if
+ *   `maxInputTokens` is omitted, the prompt budget is derived as
+ *   `contextWindow - maxOutputTokens`.
+ * - Otherwise the window falls back to `maxInputTokens + maxOutputTokens` for backward
+ *   compatibility.
+ */
+export function resolveModelTokenLimits(capabilities: Pick<BYOKModelCapabilities, 'maxInputTokens' | 'maxOutputTokens' | 'contextWindow'>): { contextWindow: number; maxInputTokens: number; maxOutputTokens: number } {
+	const maxOutputTokens = capabilities.maxOutputTokens;
+	const contextWindow = capabilities.contextWindow ?? ((capabilities.maxInputTokens ?? 0) + maxOutputTokens);
+	const maxInputTokens = capabilities.maxInputTokens ?? Math.max(0, contextWindow - maxOutputTokens);
+	return { contextWindow, maxInputTokens, maxOutputTokens };
+}
+
 export function resolveModelInfo(modelId: string, providerName: string, knownModels: BYOKKnownModels | undefined, modelCapabilities?: BYOKModelCapabilities): IChatModelInformation {
 	// Model Capabilities are something the user has decided on so those take precedence, then we rely on known model info, then defaults.
 	let knownModelInfo = modelCapabilities;
@@ -100,7 +128,9 @@ export function resolveModelInfo(modelId: string, providerName: string, knownMod
 		knownModelInfo = knownModels[modelId];
 	}
 	const modelName = knownModelInfo?.name || modelId;
-	const contextWinow = knownModelInfo ? (knownModelInfo.maxInputTokens + knownModelInfo.maxOutputTokens) : 128000;
+	const limits = knownModelInfo
+		? resolveModelTokenLimits(knownModelInfo)
+		: { contextWindow: 128000, maxInputTokens: 100000, maxOutputTokens: 8192 };
 	const modelInfo: IChatModelInformation = {
 		id: modelId,
 		name: modelName,
@@ -119,9 +149,9 @@ export function resolveModelInfo(modelId: string, providerName: string, knownMod
 			},
 			tokenizer: TokenizerType.O200K,
 			limits: {
-				max_context_window_tokens: contextWinow,
-				max_prompt_tokens: knownModelInfo?.maxInputTokens || 100000,
-				max_output_tokens: knownModelInfo?.maxOutputTokens || 8192
+				max_context_window_tokens: limits.contextWindow,
+				max_prompt_tokens: limits.maxInputTokens,
+				max_output_tokens: limits.maxOutputTokens
 			}
 		},
 		is_chat_default: false,
@@ -146,12 +176,13 @@ export function byokKnownModelsToAPIInfo(providerName: string, knownModels: BYOK
 }
 
 export function byokKnownModelToAPIInfo(providerName: string, id: string, capabilities: BYOKModelCapabilities): LanguageModelChatInformation {
+	const limits = resolveModelTokenLimits(capabilities);
 	return {
 		id,
 		name: capabilities.name,
 		version: '1.0.0',
-		maxOutputTokens: capabilities.maxOutputTokens,
-		maxInputTokens: capabilities.maxInputTokens,
+		maxOutputTokens: limits.maxOutputTokens,
+		maxInputTokens: limits.maxInputTokens,
 		// `detail` is intentionally omitted: when this model is resolved
 		// via a configured provider group, `LanguageModelsService` will
 		// fall back to the group name so multiple instances of the same

--- a/extensions/copilot/src/extension/byok/common/byokProvider.ts
+++ b/extensions/copilot/src/extension/byok/common/byokProvider.ts
@@ -113,11 +113,21 @@ export function isNoAuthConfig(config: BYOKModelConfig): config is BYOKNoAuthMod
  *   `contextWindow - maxOutputTokens`.
  * - Otherwise the window falls back to `maxInputTokens + maxOutputTokens` for backward
  *   compatibility.
+ *
+ * The returned limits are always internally consistent: `maxOutputTokens` is clamped so
+ * it never exceeds the context window, and `maxInputTokens` is clamped to the remaining
+ * budget (`contextWindow - maxOutputTokens`). This prevents invalid combinations such as
+ * `maxOutputTokens > contextWindow`, or a `maxInputTokens` supplied alongside a smaller
+ * `contextWindow` overflowing the window.
  */
 export function resolveModelTokenLimits(capabilities: Pick<BYOKModelCapabilities, 'maxInputTokens' | 'maxOutputTokens' | 'contextWindow'>): { contextWindow: number; maxInputTokens: number; maxOutputTokens: number } {
-	const maxOutputTokens = capabilities.maxOutputTokens;
-	const contextWindow = capabilities.contextWindow ?? ((capabilities.maxInputTokens ?? 0) + maxOutputTokens);
-	const maxInputTokens = capabilities.maxInputTokens ?? Math.max(0, contextWindow - maxOutputTokens);
+	const contextWindow = capabilities.contextWindow ?? ((capabilities.maxInputTokens ?? 0) + capabilities.maxOutputTokens);
+	// The output budget can never exceed the full window.
+	const maxOutputTokens = Math.min(capabilities.maxOutputTokens, contextWindow);
+	// The prompt budget is whatever remains after the output reservation; an explicitly
+	// provided maxInputTokens is clamped to that remaining budget.
+	const remainingInputBudget = Math.max(0, contextWindow - maxOutputTokens);
+	const maxInputTokens = Math.min(capabilities.maxInputTokens ?? remainingInputBudget, remainingInputBudget);
 	return { contextWindow, maxInputTokens, maxOutputTokens };
 }
 

--- a/extensions/copilot/src/extension/byok/common/test/byokProvider.spec.ts
+++ b/extensions/copilot/src/extension/byok/common/test/byokProvider.spec.ts
@@ -5,7 +5,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { CopilotToken } from '../../../../platform/authentication/common/copilotToken';
-import { byokKnownModelToAPIInfo, BYOKModelCapabilities, isClientBYOKAllowed, resolveModelInfo } from '../byokProvider';
+import { byokKnownModelToAPIInfo, BYOKModelCapabilities, isClientBYOKAllowed, resolveModelInfo, resolveModelTokenLimits } from '../byokProvider';
 
 describe('byokKnownModelToAPIInfo', () => {
 	const baseCapabilities: BYOKModelCapabilities = {
@@ -133,6 +133,40 @@ describe('resolveModelInfo', () => {
 		const info = resolveModelInfo('m1', 'TestProvider', undefined, undefined);
 
 		expect(info.capabilities.limits?.max_context_window_tokens).toBe(128000);
+	});
+});
+
+describe('resolveModelTokenLimits', () => {
+	it('derives the window from maxInputTokens + maxOutputTokens when contextWindow is absent', () => {
+		expect(resolveModelTokenLimits({ maxInputTokens: 616000, maxOutputTokens: 384000 })).toEqual({
+			contextWindow: 1000000,
+			maxInputTokens: 616000,
+			maxOutputTokens: 384000,
+		});
+	});
+
+	it('derives maxInputTokens from contextWindow when maxInputTokens is omitted', () => {
+		expect(resolveModelTokenLimits({ contextWindow: 1000000, maxOutputTokens: 384000 })).toEqual({
+			contextWindow: 1000000,
+			maxInputTokens: 616000,
+			maxOutputTokens: 384000,
+		});
+	});
+
+	it('clamps maxOutputTokens so it never exceeds the context window', () => {
+		expect(resolveModelTokenLimits({ contextWindow: 1000, maxOutputTokens: 8192 })).toEqual({
+			contextWindow: 1000,
+			maxInputTokens: 0,
+			maxOutputTokens: 1000,
+		});
+	});
+
+	it('clamps an explicit maxInputTokens to the remaining budget when it overflows the window', () => {
+		expect(resolveModelTokenLimits({ contextWindow: 1000000, maxInputTokens: 900000, maxOutputTokens: 384000 })).toEqual({
+			contextWindow: 1000000,
+			maxInputTokens: 616000,
+			maxOutputTokens: 384000,
+		});
 	});
 });
 

--- a/extensions/copilot/src/extension/byok/common/test/byokProvider.spec.ts
+++ b/extensions/copilot/src/extension/byok/common/test/byokProvider.spec.ts
@@ -43,6 +43,21 @@ describe('byokKnownModelToAPIInfo', () => {
 
 		expect(info.capabilities.editTools).toBeUndefined();
 	});
+
+	it('derives maxInputTokens from contextWindow when maxInputTokens is omitted', () => {
+		// The value surfaced here becomes `model.maxInputTokens`, which the custom
+		// endpoint/OAI/azure providers read when building the endpoint.
+		const info = byokKnownModelToAPIInfo('TestProvider', 'm1', {
+			name: 'BigContextModel',
+			contextWindow: 1000000,
+			maxOutputTokens: 384000,
+			toolCalling: true,
+			vision: false,
+		});
+
+		expect(info.maxInputTokens).toBe(1000000 - 384000);
+		expect(info.maxOutputTokens).toBe(384000);
+	});
 });
 
 describe('resolveModelInfo', () => {
@@ -85,6 +100,39 @@ describe('resolveModelInfo', () => {
 			temperature: null,
 			top_p: 0.95,
 		});
+	});
+
+	it('honors an explicit contextWindow as the source of truth for the context window', () => {
+		// A model documented as: Context Length 1M, Max Output 384K. The user can now
+		// declare the real capability directly instead of back-computing maxInputTokens.
+		const info = resolveModelInfo('m1', 'TestProvider', undefined, {
+			...baseCapabilities,
+			contextWindow: 1000000,
+			maxOutputTokens: 384000,
+			maxInputTokens: undefined,
+		});
+
+		expect(info.capabilities.limits?.max_context_window_tokens).toBe(1000000);
+		// The prompt budget is derived as contextWindow - maxOutputTokens.
+		expect(info.capabilities.limits?.max_prompt_tokens).toBe(1000000 - 384000);
+		expect(info.capabilities.limits?.max_output_tokens).toBe(384000);
+	});
+
+	it('derives the context window as maxInputTokens + maxOutputTokens when contextWindow is absent', () => {
+		const info = resolveModelInfo('m1', 'TestProvider', undefined, {
+			...baseCapabilities,
+			maxInputTokens: 616000,
+			maxOutputTokens: 384000,
+		});
+
+		expect(info.capabilities.limits?.max_context_window_tokens).toBe(616000 + 384000);
+		expect(info.capabilities.limits?.max_prompt_tokens).toBe(616000);
+	});
+
+	it('falls back to a 128000 context window when no capabilities are known', () => {
+		const info = resolveModelInfo('m1', 'TestProvider', undefined, undefined);
+
+		expect(info.capabilities.limits?.max_context_window_tokens).toBe(128000);
 	});
 });
 

--- a/extensions/copilot/src/extension/byok/vscode-node/azureProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/azureProvider.ts
@@ -131,6 +131,7 @@ export class AzureBYOKModelProvider extends AbstractCustomOAIBYOKModelProvider {
 		const modelCapabilities = {
 			maxInputTokens: model.maxInputTokens,
 			maxOutputTokens: model.maxOutputTokens,
+			contextWindow: modelConfiguration?.contextWindow,
 			toolCalling: !!model.capabilities?.toolCalling || false,
 			vision: !!model.capabilities?.imageInput || false,
 			name: model.name,

--- a/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
@@ -90,8 +90,11 @@ interface _CustomEndpointModelConfig {
 	name: string;
 	url: string;
 	apiType?: CustomEndpointApiType;
-	maxInputTokens: number;
+	/** Optional when {@link contextWindow} is set; then derived as `contextWindow - maxOutputTokens`. */
+	maxInputTokens?: number;
 	maxOutputTokens: number;
+	/** The model's full context window (input + output) in tokens, e.g. 1000000 for a 1M model. */
+	contextWindow?: number;
 	toolCalling: boolean;
 	vision: boolean;
 	thinking?: boolean;
@@ -153,6 +156,7 @@ export class CustomEndpointBYOKModelProvider extends AbstractOpenAICompatibleLMP
 		const modelCapabilities = {
 			maxInputTokens: model.maxInputTokens,
 			maxOutputTokens: model.maxOutputTokens,
+			contextWindow: modelConfiguration?.contextWindow,
 			toolCalling: !!model.capabilities?.toolCalling || false,
 			vision: !!model.capabilities?.imageInput || false,
 			name: model.name,

--- a/extensions/copilot/src/extension/byok/vscode-node/customOAIProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/customOAIProvider.ts
@@ -53,8 +53,11 @@ export interface CustomOAIModelProviderConfig extends LanguageModelChatConfigura
 interface _CustomOAIModelConfig {
 	name: string;
 	url: string;
-	maxInputTokens: number;
+	/** Optional when {@link contextWindow} is set; then derived as `contextWindow - maxOutputTokens`. */
+	maxInputTokens?: number;
 	maxOutputTokens: number;
+	/** The model's full context window (input + output) in tokens, e.g. 1000000 for a 1M model. */
+	contextWindow?: number;
 	toolCalling: boolean;
 	vision: boolean;
 	thinking?: boolean;
@@ -138,6 +141,7 @@ export abstract class AbstractCustomOAIBYOKModelProvider extends AbstractOpenAIC
 		const modelCapabilities = {
 			maxInputTokens: model.maxInputTokens,
 			maxOutputTokens: model.maxOutputTokens,
+			contextWindow: modelConfiguration?.contextWindow,
 			toolCalling: !!model.capabilities?.toolCalling || false,
 			vision: !!model.capabilities?.imageInput || false,
 			name: model.name,

--- a/extensions/copilot/src/extension/byok/vscode-node/openRouterProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/openRouterProvider.ts
@@ -25,10 +25,27 @@ interface OpenRouterModelData {
 	architecture?: {
 		input_modalities?: string[];
 	};
+	/**
+	 * The model's actual maximum context window, independent of which provider
+	 * OpenRouter ranks highest. Prefer this over `top_provider.context_length`,
+	 * which only reflects the primary provider and can be far smaller for
+	 * multi-provider models.
+	 * @see https://openrouter.ai/docs/guides/overview/models
+	 */
+	context_length?: number;
 	top_provider: {
 		context_length: number;
+		/** Maximum tokens the primary provider will produce in a response. */
+		max_completion_tokens?: number;
 	};
 }
+
+/**
+ * Fallback output-token budget used only when OpenRouter does not report
+ * `top_provider.max_completion_tokens` for a model. The value is heuristic — most
+ * tool-capable models do report an explicit budget, in which case this is unused.
+ */
+const DEFAULT_MAX_OUTPUT_TOKENS = 16_000;
 
 export class OpenRouterLMProvider extends AbstractOpenAICompatibleLMProvider {
 
@@ -73,12 +90,21 @@ export class OpenRouterLMProvider extends AbstractOpenAICompatibleLMProvider {
 		const supportsReasoningEffort = supportedParameters.includes('reasoning') || supportedParameters.includes('reasoning_effort')
 			? ['low', 'medium', 'high']
 			: undefined;
+		// Prefer the model-level `context_length` (the real capability) over
+		// `top_provider.context_length`, which only reflects OpenRouter's
+		// highest-ranked provider and can be much smaller for multi-provider models.
+		const contextWindow = openRouterModelData.context_length ?? openRouterModelData.top_provider.context_length;
+		// Reserve output tokens from the window. Clamp the reserve so a small-context
+		// model (or a missing/oversized `max_completion_tokens`) never yields a
+		// non-positive prompt budget.
+		const requestedMaxOutputTokens = openRouterModelData.top_provider.max_completion_tokens ?? DEFAULT_MAX_OUTPUT_TOKENS;
+		const maxOutputTokens = Math.min(requestedMaxOutputTokens, Math.floor(contextWindow / 2));
 		return {
 			name: openRouterModelData.name,
 			toolCalling: supportedParameters.includes('tools'),
 			vision: openRouterModelData.architecture?.input_modalities?.includes('image') ?? false,
-			maxInputTokens: openRouterModelData.top_provider.context_length - 16000,
-			maxOutputTokens: 16000,
+			maxInputTokens: contextWindow - maxOutputTokens,
+			maxOutputTokens,
 			supportsReasoningEffort
 		};
 	}

--- a/extensions/copilot/src/extension/byok/vscode-node/test/openRouterProvider.spec.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/test/openRouterProvider.spec.ts
@@ -8,13 +8,12 @@ import { BYOKModelCapabilities } from '../../common/byokProvider';
 import { OpenRouterLMProvider } from '../openRouterProvider';
 
 /**
- * Diagnostic tests for issue #324671:
- * OpenRouter BYOK derives the context window from `top_provider.context_length`,
- * which is the window of the highest-ranked provider — NOT the model's real
- * capability (`context_length`). For multi-provider models this can be off by 32×.
- *
- * These tests characterize the CURRENT (buggy) behavior and document, in comments,
- * the value expected once the fix (prefer model-level `context_length`) lands.
+ * Tests for issue #324671:
+ * OpenRouter BYOK previously derived the context window from `top_provider.context_length`,
+ * which is the window of the highest-ranked provider — NOT the model's real capability
+ * (`context_length`). For multi-provider models this could be off by 32×. These tests
+ * verify the fix: the model-level `context_length` is preferred, with `top_provider`
+ * used only as a fallback.
  */
 
 /** Exposes the protected `resolveModelCapabilities` for focused testing. */

--- a/extensions/copilot/src/extension/byok/vscode-node/test/openRouterProvider.spec.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/test/openRouterProvider.spec.ts
@@ -1,0 +1,110 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it, vi } from 'vitest';
+import { BYOKModelCapabilities } from '../../common/byokProvider';
+import { OpenRouterLMProvider } from '../openRouterProvider';
+
+/**
+ * Diagnostic tests for issue #324671:
+ * OpenRouter BYOK derives the context window from `top_provider.context_length`,
+ * which is the window of the highest-ranked provider — NOT the model's real
+ * capability (`context_length`). For multi-provider models this can be off by 32×.
+ *
+ * These tests characterize the CURRENT (buggy) behavior and document, in comments,
+ * the value expected once the fix (prefer model-level `context_length`) lands.
+ */
+
+/** Exposes the protected `resolveModelCapabilities` for focused testing. */
+class TestableOpenRouterLMProvider extends OpenRouterLMProvider {
+	public resolveCapabilities(modelData: unknown): BYOKModelCapabilities | undefined {
+		return this.resolveModelCapabilities(modelData);
+	}
+}
+
+function createProvider(): TestableOpenRouterLMProvider {
+	const logService = {
+		trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+		show: vi.fn(), createSubLogger: vi.fn(), withExtraTarget: vi.fn(),
+	};
+	logService.createSubLogger.mockReturnValue(logService);
+	logService.withExtraTarget.mockReturnValue(logService);
+
+	return new TestableOpenRouterLMProvider(
+		{ getAPIKey: vi.fn().mockResolvedValue(undefined), storeAPIKey: vi.fn(), deleteAPIKey: vi.fn() } as any,
+		{ fetch: vi.fn() } as any,
+		logService as any,
+		{ createInstance: vi.fn().mockReturnValue({}) } as any,
+		{ isConfigured: vi.fn().mockReturnValue(false), getConfig: vi.fn(), setConfig: vi.fn() } as any,
+		{} as any,
+	);
+}
+
+describe('OpenRouterLMProvider context window (issue #324671)', () => {
+	it('derives maxInputTokens from the model-level context_length, not top_provider', () => {
+		const provider = createProvider();
+
+		// `xiaomi/mimo-v2.5`: the model supports 1M tokens, but the highest-ranked
+		// provider only serves 32K. The Xiaomi provider (1M) is not the top provider.
+		const caps = provider.resolveCapabilities({
+			id: 'xiaomi/mimo-v2.5',
+			name: 'MiMo v2.5',
+			supported_parameters: ['tools'],
+			architecture: { input_modalities: ['text'] },
+			context_length: 1048576,            // actual model capability (1M)
+			top_provider: { context_length: 32000 }, // highest-ranked provider (32K)
+		});
+
+		// Uses the real 1M window minus the default 16K output reserve.
+		expect(caps?.maxInputTokens).toBe(1048576 - 16000);
+		expect(caps?.maxOutputTokens).toBe(16000);
+	});
+
+	it('honors top_provider.max_completion_tokens as the output budget', () => {
+		const provider = createProvider();
+
+		const caps = provider.resolveCapabilities({
+			id: 'some/reasoning-model',
+			name: 'Reasoning Model',
+			supported_parameters: ['tools'],
+			context_length: 200000,
+			top_provider: { context_length: 200000, max_completion_tokens: 64000 },
+		});
+
+		expect(caps?.maxOutputTokens).toBe(64000);
+		expect(caps?.maxInputTokens).toBe(200000 - 64000);
+	});
+
+	it('falls back to top_provider.context_length when the model omits context_length', () => {
+		const provider = createProvider();
+
+		const caps = provider.resolveCapabilities({
+			id: 'legacy/model',
+			name: 'Legacy Model',
+			supported_parameters: ['tools'],
+			top_provider: { context_length: 128000 },
+		});
+
+		expect(caps?.maxInputTokens).toBe(128000 - 16000);
+	});
+
+	it('clamps the output reserve so a small-context model keeps a positive prompt budget', () => {
+		const provider = createProvider();
+
+		// An 8K model whose provider reports a 16K completion budget larger than the
+		// window. Without clamping, maxInputTokens would go negative (8000 - 16000).
+		const caps = provider.resolveCapabilities({
+			id: 'tiny/model',
+			name: 'Tiny Model',
+			supported_parameters: ['tools'],
+			context_length: 8000,
+			top_provider: { context_length: 8000, max_completion_tokens: 16000 },
+		});
+
+		// Reserve is capped at half the window, so the prompt budget stays positive.
+		expect(caps?.maxOutputTokens).toBe(4000);
+		expect(caps?.maxInputTokens).toBe(4000);
+	});
+});


### PR DESCRIPTION
fix #324671
fix #320353

1. OpenRouter now derives `context_length` and falls back to `top_provider.context_length`. Also derive `maxOutputTokens` from `top_provider.max_completion_tokens` when available
2. Added optional `contextWindow` to be specified for custom endpoints, and as a result make `maxInputTokens` optional.