### PR TITLE
Editor type dropdown in the breadcrumbs bar

### DIFF
--- a/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
@@ -73,6 +73,7 @@ export abstract class BreadcrumbsConfig<T> {
 	static readonly SymbolSortOrder = BreadcrumbsConfig._stub<'position' | 'name' | 'type'>('breadcrumbs.symbolSortOrder');
 	static readonly SymbolPathSeparator = BreadcrumbsConfig._stub<string>('breadcrumbs.symbolPathSeparator');
 	static readonly Icons = BreadcrumbsConfig._stub<boolean>('breadcrumbs.icons');
+	static readonly ShowEditorType = BreadcrumbsConfig._stub<boolean>('breadcrumbs.showEditorType');
 	static readonly TitleScrollbarSizing = BreadcrumbsConfig._stub<IEditorPartOptions['titleScrollbarSizing']>('workbench.editor.titleScrollbarSizing');
 	static readonly TitleScrollbarVisibility = BreadcrumbsConfig._stub<IEditorPartOptions['titleScrollbarVisibility']>('workbench.editor.titleScrollbarVisibility');
 
@@ -166,6 +167,12 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			description: localize('icons', "Render breadcrumb items with icons."),
 			type: 'boolean',
 			default: true
+		},
+		'breadcrumbs.showEditorType': {
+			markdownDescription: localize('showEditorType', "Controls whether the breadcrumbs bar shows a dropdown to switch between the editors that can open the current file (for example the text editor and a custom editor). The dropdown only appears when a more specialized editor is available."),
+			type: 'boolean',
+			default: true,
+			tags: ['experimental']
 		},
 		'breadcrumbs.symbolPathSeparator': {
 			description: localize('symbolPathSeparator', "The separator used when copying the breadcrumb symbol path."),

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -9,9 +9,13 @@ import { PixelRatio } from '../../../../base/browser/pixelRatio.js';
 import { BreadcrumbsItem, BreadcrumbsWidget, IBreadcrumbsItemEvent, IBreadcrumbsWidgetStyles } from '../../../../base/browser/ui/breadcrumbs/breadcrumbsWidget.js';
 import { applyDragImage } from '../../../../base/browser/ui/dnd/dnd.js';
 import { IHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegate.js';
+import { IManagedHover } from '../../../../base/browser/ui/hover/hover.js';
 import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
+import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { timeout } from '../../../../base/common/async.js';
 import { Codicon } from '../../../../base/common/codicons.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { IAction, Separator, SubmenuAction, toAction } from '../../../../base/common/actions.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { combinedDisposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
@@ -22,10 +26,11 @@ import { OutlineElement } from '../../../../editor/contrib/documentSymbols/brows
 import { localize, localize2 } from '../../../../nls.js';
 import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
-import { IContextViewService } from '../../../../platform/contextview/browser/contextView.js';
+import { IContextViewService, IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { fillInSymbolsDragData, LocalSelectionTransfer } from '../../../../platform/dnd/browser/dnd.js';
 import { FileKind, IFileService, IFileStat } from '../../../../platform/files/common/files.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
@@ -36,8 +41,9 @@ import { IListService, WorkbenchAsyncDataTree, WorkbenchDataTree, WorkbenchListF
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 import { defaultBreadcrumbsWidgetStyles } from '../../../../platform/theme/browser/defaultStyles.js';
 import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js';
-import { EditorResourceAccessor, IEditorPartOptions, SideBySideEditor } from '../../../common/editor.js';
+import { EditorResourceAccessor, DEFAULT_EDITOR_ASSOCIATION, IEditorPartOptions, SideBySideEditor, isDiffEditorInput } from '../../../common/editor.js';
 import { IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
+import { IEditorResolverService, RegisteredEditorInfo } from '../../../services/editor/common/editorResolverService.js';
 import { ACTIVE_GROUP, ACTIVE_GROUP_TYPE, IEditorService, SIDE_GROUP, SIDE_GROUP_TYPE } from '../../../services/editor/common/editorService.js';
 import { IOutline, IOutlineService, OutlineTarget } from '../../../services/outline/browser/outline.js';
 import { DraggedEditorIdentifier, fillEditorsDragData } from '../../dnd.js';
@@ -46,6 +52,7 @@ import { BreadcrumbsConfig, IBreadcrumbsService } from './breadcrumbs.js';
 import { BreadcrumbsModel, FileElement, OutlineElement2 } from './breadcrumbsModel.js';
 import { BreadcrumbsFilePicker, BreadcrumbsOutlinePicker } from './breadcrumbsPicker.js';
 import { IEditorGroupView } from './editor.js';
+import { REOPEN_ACTIVE_EDITOR_WITH_COMMAND_ID } from './editorCommands.js';
 import './media/breadcrumbscontrol.css';
 import { ScrollbarVisibility } from '../../../../base/common/scrollable.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
@@ -211,6 +218,12 @@ export interface IBreadcrumbsControlOptions {
 	readonly showPlaceholder: boolean;
 	readonly dragEditor: boolean;
 	readonly widgetStyles?: IBreadcrumbsWidgetStyles;
+	/**
+	 * Whether to show a dropdown on the right-hand side that lets the user switch between the editors
+	 * that can open the active resource (e.g. Text Editor vs. Markdown Preview). Only makes sense for
+	 * the dedicated breadcrumbs bar below tabs, not the inline single-tab breadcrumbs.
+	 */
+	readonly showEditorTypePicker?: boolean;
 }
 
 const separatorIcon = registerIcon('breadcrumb-separator', Codicon.chevronRight, localize('separatorIcon', 'Icon for the separator in the breadcrumbs.'));
@@ -246,11 +259,16 @@ export class BreadcrumbsControl {
 
 	private readonly _cfUseQuickPick: BreadcrumbsConfig<boolean>;
 	private readonly _cfShowIcons: BreadcrumbsConfig<boolean>;
+	private readonly _cfShowEditorType: BreadcrumbsConfig<boolean>;
 	private readonly _cfTitleScrollbarSizing: BreadcrumbsConfig<IEditorPartOptions['titleScrollbarSizing']>;
 	private readonly _cfTitleScrollbarVisibility: BreadcrumbsConfig<IEditorPartOptions['titleScrollbarVisibility']>;
 
 	readonly domNode: HTMLDivElement;
 	private readonly _widget: BreadcrumbsWidget;
+	private readonly _editorTypeNode: HTMLDivElement;
+	private readonly _editorTypeLabel: HTMLSpanElement;
+	private readonly _editorTypeHover: IManagedHover;
+	private _lastLayoutDimension: dom.Dimension | undefined;
 
 	private readonly _disposables = new DisposableStore();
 	private readonly _breadcrumbsDisposables = new DisposableStore();
@@ -270,20 +288,26 @@ export class BreadcrumbsControl {
 		private readonly _editorGroup: IEditorGroupView,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@IContextViewService private readonly _contextViewService: IContextViewService,
+		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IQuickInputService private readonly _quickInputService: IQuickInputService,
 		@IFileService private readonly _fileService: IFileService,
 		@IEditorService private readonly _editorService: IEditorService,
+		@IEditorResolverService private readonly _editorResolverService: IEditorResolverService,
+		@ICommandService private readonly _commandService: ICommandService,
 		@ILabelService private readonly _labelService: ILabelService,
 		@IConfigurationService configurationService: IConfigurationService,
+		@IHoverService private readonly _hoverService: IHoverService,
 		@IBreadcrumbsService breadcrumbsService: IBreadcrumbsService
 	) {
 		this.domNode = document.createElement('div');
 		this.domNode.classList.add('breadcrumbs-control');
+		this.domNode.classList.toggle('with-editor-type', !!_options.showEditorTypePicker);
 		dom.append(container, this.domNode);
 
 		this._cfUseQuickPick = BreadcrumbsConfig.UseQuickPick.bindTo(configurationService);
 		this._cfShowIcons = BreadcrumbsConfig.Icons.bindTo(configurationService);
+		this._cfShowEditorType = BreadcrumbsConfig.ShowEditorType.bindTo(configurationService);
 		this._cfTitleScrollbarSizing = BreadcrumbsConfig.TitleScrollbarSizing.bindTo(configurationService);
 		this._cfTitleScrollbarVisibility = BreadcrumbsConfig.TitleScrollbarVisibility.bindTo(configurationService);
 
@@ -303,6 +327,28 @@ export class BreadcrumbsControl {
 		this._widget.onDidSelectItem(this._onSelectEvent, this, this._disposables);
 		this._widget.onDidFocusItem(this._onFocusEvent, this, this._disposables);
 		this._widget.onDidChangeFocus(this._updateCkBreadcrumbsActive, this, this._disposables);
+
+		// Editor type dropdown (right-aligned). Lets the user switch between the editors that can
+		// open the active resource (e.g. "Text Editor" vs. "Markdown Preview"). Only shown when a
+		// more specialized editor is available for the resource.
+		this._editorTypeNode = document.createElement('div');
+		this._editorTypeNode.classList.add('breadcrumbs-editor-type', 'hidden');
+		this._editorTypeNode.setAttribute('role', 'button');
+		this._editorTypeLabel = document.createElement('span');
+		this._editorTypeLabel.classList.add('label');
+		this._editorTypeNode.appendChild(this._editorTypeLabel);
+		const editorTypeChevron = document.createElement('span');
+		editorTypeChevron.classList.add(...ThemeIcon.asClassNameArray(Codicon.chevronDown));
+		this._editorTypeNode.appendChild(editorTypeChevron);
+		dom.append(this.domNode, this._editorTypeNode);
+		this._editorTypeHover = this._disposables.add(this._hoverService.setupManagedHover(getDefaultHoverDelegate('mouse'), this._editorTypeNode, ''));
+		this._disposables.add(dom.addDisposableListener(this._editorTypeNode, dom.EventType.CLICK, e => {
+			dom.EventHelper.stop(e, true);
+			this._showEditorTypePicker();
+		}));
+		if (this._options.showEditorTypePicker) {
+			this._disposables.add(this._cfShowEditorType.onDidChange(() => this._updateEditorTypeControl()));
+		}
 
 		this._ckBreadcrumbsPossible = BreadcrumbsControl.CK_BreadcrumbsPossible.bindTo(this._contextKeyService);
 		this._ckBreadcrumbsVisible = BreadcrumbsControl.CK_BreadcrumbsVisible.bindTo(this._contextKeyService);
@@ -325,6 +371,7 @@ export class BreadcrumbsControl {
 		this._ckBreadcrumbsHasSymbols.reset();
 		this._cfUseQuickPick.dispose();
 		this._cfShowIcons.dispose();
+		this._cfShowEditorType.dispose();
 		this._cfTitleScrollbarSizing.dispose();
 		this._cfTitleScrollbarVisibility.dispose();
 		this._widget.dispose();
@@ -337,6 +384,15 @@ export class BreadcrumbsControl {
 	}
 
 	layout(dim: dom.Dimension | undefined): void {
+		if (dim) {
+			this._lastLayoutDimension = dim;
+		}
+		// When the editor type dropdown is visible it occupies space on the right, so shrink the
+		// breadcrumbs widget accordingly to avoid it rendering behind the dropdown.
+		if (dim && !this._editorTypeNode.classList.contains('hidden')) {
+			const editorTypeWidth = this._editorTypeNode.offsetWidth;
+			dim = new dom.Dimension(Math.max(0, dim.width - editorTypeWidth), dim.height);
+		}
 		this._widget.layout(dim);
 	}
 
@@ -351,6 +407,7 @@ export class BreadcrumbsControl {
 		this._ckBreadcrumbsVisible.set(false);
 		this._ckBreadcrumbsHasSymbols.set(false);
 		this.domNode.classList.toggle('hidden', true);
+		this._editorTypeNode.classList.toggle('hidden', true);
 
 		if (!wasHidden) {
 			this._onDidVisibilityChange.fire();
@@ -397,6 +454,7 @@ export class BreadcrumbsControl {
 
 		this.show();
 		this._ckBreadcrumbsPossible.set(true);
+		this._updateEditorTypeControl();
 
 		const model = this._instantiationService.createInstance(BreadcrumbsModel,
 			fileInfoUri ?? uri,
@@ -470,6 +528,137 @@ export class BreadcrumbsControl {
 		});
 
 		return wasHidden !== this.isHidden();
+	}
+
+	/**
+	 * Determines the editors available for the active editor's resource. Returns `undefined` when
+	 * there is nothing meaningful to switch between: no resource, only the default text editor, or an
+	 * exclusive editor (e.g. the hex editor, for which `getEditors` returns an empty list).
+	 */
+	private _getAvailableEditors(): { resource: URI; isDiffEditor: boolean; originalResource?: URI; modifiedResource?: URI; currentId: string; editors: RegisteredEditorInfo[] } | undefined {
+		const activeEditor = this._editorGroup.activeEditor;
+		const resource = EditorResourceAccessor.getOriginalUri(activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
+		if (!resource) {
+			return undefined;
+		}
+		const editors = this._editorResolverService.getEditors(resource);
+		if (editors.length <= 1) {
+			return undefined;
+		}
+		const isDiffEditor = isDiffEditorInput(activeEditor);
+		return {
+			resource,
+			isDiffEditor,
+			originalResource: isDiffEditor ? activeEditor.original.resource : undefined,
+			modifiedResource: isDiffEditor ? activeEditor.modified.resource : undefined,
+			currentId: activeEditor?.editorId ?? DEFAULT_EDITOR_ASSOCIATION.id,
+			editors
+		};
+	}
+
+	/**
+	 * The label to show for an editor type. In a diff context the default text editor is presented as
+	 * "Text Diff Editor" to match how it actually opens.
+	 */
+	private _editorTypeDisplayLabel(editor: RegisteredEditorInfo, isDiffEditor: boolean): string {
+		if (isDiffEditor && editor.id === DEFAULT_EDITOR_ASSOCIATION.id) {
+			return localize('textDiffEditor', "Text Diff Editor");
+		}
+		return editor.label;
+	}
+
+	private _updateEditorTypeControl(): void {
+		const wasHidden = this._editorTypeNode.classList.contains('hidden');
+		const previousWidth = wasHidden ? 0 : this._editorTypeNode.offsetWidth;
+
+		const available = (this._options.showEditorTypePicker && this._cfShowEditorType.getValue()) ? this._getAvailableEditors() : undefined;
+		if (!available) {
+			this._editorTypeNode.classList.toggle('hidden', true);
+		} else {
+			const current = available.editors.find(editor => editor.id === available.currentId);
+			const label = current ? this._editorTypeDisplayLabel(current, available.isDiffEditor) : available.currentId;
+			this._editorTypeLabel.textContent = label;
+			this._editorTypeHover.update(localize('editorType.hover', "Editor: {0}", label));
+			this._editorTypeNode.classList.toggle('hidden', false);
+		}
+
+		// The dropdown width may have changed (different editor label or visibility toggled). Since the
+		// breadcrumbs widget uses an explicit pixel width that reserves room for the dropdown, re-run the
+		// layout so the widget shrinks/grows to match the new dropdown width.
+		const isHiddenNow = this._editorTypeNode.classList.contains('hidden');
+		const currentWidth = isHiddenNow ? 0 : this._editorTypeNode.offsetWidth;
+		if (this._lastLayoutDimension && currentWidth !== previousWidth) {
+			this.layout(this._lastLayoutDimension);
+		}
+	}
+
+	private _showEditorTypePicker(): void {
+		const available = this._getAvailableEditors();
+		if (!available) {
+			return;
+		}
+		const glob = `*${extUri.extname(available.resource)}`;
+		// Show the contributing extension in parentheses, but only for extension-provided editors.
+		// Built-in providers share this localized label, so their (redundant) source is omitted.
+		const builtinProviderLabel = localize('builtinProviderDisplayName', "Built-in");
+		const labelWithSource = (editor: RegisteredEditorInfo) => {
+			const label = this._editorTypeDisplayLabel(editor, available.isDiffEditor);
+			return editor.detail && editor.detail !== builtinProviderLabel
+				? localize('editorType.labelWithSource', "{0} - {1}", label, editor.detail)
+				: label;
+		};
+
+		// Reopen the active editor with the chosen editor type. The currently active type is checked.
+		const reopenActions: IAction[] = available.editors.map(editor => toAction({
+			id: editor.id,
+			label: labelWithSource(editor),
+			checked: editor.id === available.currentId,
+			run: () => this._commandService.executeCommand(REOPEN_ACTIVE_EDITOR_WITH_COMMAND_ID, editor.id)
+		}));
+
+		// Persist the chosen editor as the default for this file type. For diffs this updates the
+		// specialized `workbench.diffEditorAssociations` setting instead of the general one. The
+		// currently configured default (if any) is checked.
+		const configuredDefault = this._editorResolverService.getConfiguredDefaultEditor(available.resource, available.isDiffEditor);
+		const setDefaultActions: IAction[] = available.editors.map(editor => toAction({
+			id: `setDefault.${editor.id}`,
+			label: labelWithSource(editor),
+			checked: editor.id === configuredDefault,
+			run: () => this._editorResolverService.updateUserAssociations(glob, editor.id, available.isDiffEditor)
+		}));
+		const setDefaultSubmenu = new SubmenuAction(
+			'breadcrumbs.editorType.setDefault',
+			available.isDiffEditor
+				? localize('editorType.setDefaultDiff', "Set Default (Diff Only) for '{0}'", glob)
+				: localize('editorType.setDefault', "Set Default for '{0}'", glob),
+			setDefaultActions
+		);
+
+		const actions: IAction[] = [...reopenActions, new Separator(), setDefaultSubmenu];
+
+		// For diffs, offer to open either side as a standalone editor.
+		if (available.isDiffEditor) {
+			actions.push(new Separator());
+			if (available.originalResource) {
+				actions.push(toAction({
+					id: 'breadcrumbs.editorType.openOriginal',
+					label: localize('editorType.openOriginal', "Open Original"),
+					run: () => this._editorService.openEditor({ resource: available.originalResource! })
+				}));
+			}
+			if (available.modifiedResource) {
+				actions.push(toAction({
+					id: 'breadcrumbs.editorType.openModified',
+					label: localize('editorType.openModified', "Open Modified"),
+					run: () => this._editorService.openEditor({ resource: available.modifiedResource! })
+				}));
+			}
+		}
+
+		this._contextMenuService.showContextMenu({
+			getAnchor: () => this._editorTypeNode,
+			getActions: () => actions
+		});
 	}
 
 	private _onFocusEvent(event: IBreadcrumbsItemEvent): void {

--- a/src/vs/workbench/browser/parts/editor/editorTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTitleControl.ts
@@ -91,6 +91,7 @@ export class EditorTitleControl extends Themable {
 			showDecorationColors: false,
 			showPlaceholder: true,
 			dragEditor: false,
+			showEditorTypePicker: true,
 		}));
 
 		// Breadcrumbs enablement & visibility change have an impact on layout

--- a/src/vs/workbench/browser/parts/editor/media/breadcrumbscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/breadcrumbscontrol.css
@@ -11,6 +11,48 @@
 	display: none;
 }
 
+.monaco-workbench .breadcrumbs-control.with-editor-type {
+	display: flex;
+	flex-direction: row;
+	align-items: stretch;
+}
+
+.monaco-workbench .breadcrumbs-control.with-editor-type > .monaco-scrollable-element {
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.monaco-workbench .breadcrumbs-control.with-editor-type > .breadcrumbs-editor-type {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	max-width: 40%;
+	padding: 0 4px 0 8px;
+	cursor: pointer;
+	font-size: 11px;
+	background: var(--vscode-breadcrumb-background);
+	color: var(--vscode-breadcrumb-foreground);
+}
+
+.monaco-workbench .breadcrumbs-control.with-editor-type > .breadcrumbs-editor-type.hidden {
+	display: none;
+}
+
+.monaco-workbench .breadcrumbs-control.with-editor-type > .breadcrumbs-editor-type:hover {
+	color: var(--vscode-breadcrumb-focusForeground);
+}
+
+.monaco-workbench .breadcrumbs-control.with-editor-type > .breadcrumbs-editor-type > .label {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.monaco-workbench .breadcrumbs-control.with-editor-type > .breadcrumbs-editor-type > .codicon {
+	font-size: 13px;
+	margin-left: 2px;
+}
+
 .monaco-workbench .part.editor > .content .editor-group-container .breadcrumbs-control .monaco-breadcrumb-item.selected .monaco-icon-label,
 .monaco-workbench .part.editor > .content .editor-group-container .breadcrumbs-control .monaco-breadcrumb-item.focused .monaco-icon-label {
 	text-decoration-line: underline;

--- a/src/vs/workbench/services/editor/browser/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/browser/editorResolverService.ts
@@ -283,6 +283,11 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 		return this.getAssociationsForResourceFromSetting(resource, editorsAssociationsSettingId);
 	}
 
+	getConfiguredDefaultEditor(resource: URI, forDiffEditor?: boolean): string | undefined {
+		const settingId = forDiffEditor ? diffEditorsAssociationsSettingId : editorsAssociationsSettingId;
+		return this.getAssociationsForResourceFromSetting(resource, settingId)[0]?.viewType;
+	}
+
 	private getAssociationsForResourceByType(resource: URI, associationType: EditorAssociationType): EditorAssociations {
 		// The specialized diff/merge associations win over the general ones and are allowed to target
 		// an editor even if that editor opted out of diffs/merges through a `never` priority.
@@ -405,8 +410,8 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 		return Array.from(this._flattenedEditors.values()).flat();
 	}
 
-	updateUserAssociations(globPattern: string, editorID: string): void {
-		this.updateUserAssociationsForSetting(editorsAssociationsSettingId, globPattern, editorID);
+	updateUserAssociations(globPattern: string, editorID: string, forDiffEditor?: boolean): void {
+		this.updateUserAssociationsForSetting(forDiffEditor ? diffEditorsAssociationsSettingId : editorsAssociationsSettingId, globPattern, editorID);
 	}
 
 	private updateUserAssociationsForType(associationType: EditorAssociationType, globPattern: string, editorID: string): void {

--- a/src/vs/workbench/services/editor/common/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/common/editorResolverService.ts
@@ -201,11 +201,22 @@ export interface IEditorResolverService {
 	getAssociationsForResource(resource: URI): EditorAssociations;
 
 	/**
+	 * Returns the view type of the user-configured default editor for a resource, or `undefined` when
+	 * none is configured. When `forDiffEditor` is `true` the diff editor association setting
+	 * (`workbench.diffEditorAssociations`) is consulted instead of the general one.
+	 * @param resource The resource to match
+	 * @param forDiffEditor Whether to read the diff editor association setting
+	 */
+	getConfiguredDefaultEditor(resource: URI, forDiffEditor?: boolean): string | undefined;
+
+	/**
 	 * Updates the user's association to include a specific editor ID as a default for the given glob pattern
 	 * @param globPattern The glob pattern (must be a string as settings don't support relative glob)
 	 * @param editorID The ID of the editor to make a user default
+	 * @param forDiffEditor When `true`, the diff editor association (`workbench.diffEditorAssociations`)
+	 * is updated instead of the general editor association (`workbench.editorAssociations`).
 	 */
-	updateUserAssociations(globPattern: string, editorID: string): void;
+	updateUserAssociations(globPattern: string, editorID: string, forDiffEditor?: boolean): void;
 
 	/**
 	 * Emitted when an editor is registered or unregistered.


### PR DESCRIPTION
Fixes #324795

> [!NOTE]
> Targets `hediet/never-editor-priority` (#324793), which this builds on. Rebase onto `main` once that merges.

Adds a dropdown on the right-hand side of the breadcrumbs bar that shows the current editor type and lets the user switch editors, set the default, and (for diffs) open either side.

### Behavior

- The dropdown shows the **current editor type** as text (e.g. "Markdown Preview", "Text Editor", or "Text Diff Editor" in a diff).
- It appears only when **more than one editor** can open the resource, so plain text files (only the default editor) and exclusive editors such as the Hex editor do not show it.
- Clicking it opens a menu that:
  - **Switches** the active editor to any of the other available editors (via `reopenActiveEditorWith`); the current one is checked.
  - **Set Default** submenu persists the choice — writing to `workbench.diffEditorAssociations` in a diff context, otherwise `workbench.editorAssociations`; the configured default is checked.
  - In a diff, offers **Open Original** / **Open Modified**.
- Extension editors show their source as `Label - Extension Name`; built-in editors show just their label.
- Only rendered on the dedicated breadcrumbs bar (tabbed mode), not the inline single-tab breadcrumbs.
- Gated behind the experimental setting `breadcrumbs.showEditorType` (default `true`).

Also adds `IEditorResolverService.getConfiguredDefaultEditor` and a `forDiffEditor` flag on `updateUserAssociations`.

### Verification steps

1. Open a `*.md` file → the breadcrumbs bar shows a dropdown on the right with the current editor type.
2. Click it → the available editors are listed with the current one checked; picking another reopens the file with it.
3. Use **Set Default** → the chosen editor is written to `workbench.editorAssociations` for `*.md`.
4. Open a `*.md` diff → the dropdown shows "Text Diff Editor"; **Set Default (Diff Only)** writes to `workbench.diffEditorAssociations`; **Open Original** / **Open Modified** open each side.
5. Open a plain `*.txt` file or a Hex-editor file → the dropdown is hidden.
6. Toggle `"breadcrumbs.showEditorType": false` → the dropdown disappears; set back to `true` → it returns.
