### PR TITLE
chat: preserve shell intention command height

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTerminalToolProgressPart.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTerminalToolProgressPart.css
@@ -14,9 +14,13 @@
  * single non-wrapping line. Each cell ellipsis-truncates and they split the
  * available width equally when the content overflows the row.
  */
-.chat-terminal-thinking-collapsible.chat-terminal-has-intention .chat-used-context-label,
-.chat-terminal-thinking-collapsible.chat-terminal-has-intention .monaco-button.monaco-icon-button {
+.chat-terminal-thinking-collapsible.chat-terminal-has-intention .chat-used-context-label {
 	width: 100%;
+	max-width: 100%;
+}
+
+.chat-terminal-thinking-collapsible.chat-terminal-has-intention .monaco-button.monaco-icon-button {
+	width: fit-content;
 	max-width: 100%;
 	justify-content: flex-start;
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTerminalToolProgressPart.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTerminalToolProgressPart.css
@@ -47,6 +47,10 @@
 	white-space: nowrap;
 }
 
+.chat-terminal-label-flex > .chat-terminal-command > code {
+	white-space: nowrap;
+}
+
 .chat-terminal-label-flex > .chat-terminal-label-suffix {
 	flex: 0 0 auto;
 	white-space: nowrap;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTerminalToolProgressPart.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTerminalToolProgressPart.css
@@ -14,13 +14,9 @@
  * single non-wrapping line. Each cell ellipsis-truncates and they split the
  * available width equally when the content overflows the row.
  */
-.chat-terminal-thinking-collapsible.chat-terminal-has-intention .chat-used-context-label {
-	width: 100%;
-	max-width: 100%;
-}
-
+.chat-terminal-thinking-collapsible.chat-terminal-has-intention .chat-used-context-label,
 .chat-terminal-thinking-collapsible.chat-terminal-has-intention .monaco-button.monaco-icon-button {
-	width: fit-content;
+	width: 100%;
 	max-width: 100%;
 	justify-content: flex-start;
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -1745,10 +1745,12 @@ export class ChatTerminalThinkingCollapsibleWrapper extends ChatCollapsibleConte
 			const row = dom.$('span.chat-terminal-label-flex');
 			const intentionElement = dom.$('span.chat-terminal-intention');
 			intentionElement.textContent = this._intention;
-			const codeElement = dom.$('code.chat-terminal-command');
+			const commandElement = dom.$('span.chat-terminal-command');
+			const codeElement = document.createElement('code');
 			codeElement.textContent = this._commandText;
+			commandElement.appendChild(codeElement);
 			row.appendChild(intentionElement);
-			row.appendChild(codeElement);
+			row.appendChild(commandElement);
 			if (suffixText) {
 				const suffixElement = dom.$('span.chat-terminal-label-suffix');
 				suffixElement.textContent = suffixText;

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatTerminalCollapsible.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatTerminalCollapsible.fixture.ts
@@ -40,10 +40,10 @@ function renderCollapsible(context: ComponentFixtureContext, commandText: string
 
 	container.style.width = '500px';
 	container.style.padding = '8px';
-	container.classList.add('monaco-workbench');
+	container.classList.add('monaco-workbench', 'interactive-session');
 
-	const session = dom.$('.interactive-session');
-	container.appendChild(session);
+	const itemContainer = dom.$('.interactive-item-container');
+	container.appendChild(itemContainer);
 
 	const contentElement = dom.$('.chat-terminal-output-placeholder');
 	contentElement.textContent = '(terminal output would appear here)';
@@ -64,7 +64,7 @@ function renderCollapsible(context: ComponentFixtureContext, commandText: string
 		undefined,
 	));
 
-	session.appendChild(wrapper.domNode);
+	itemContainer.appendChild(wrapper.domNode);
 }
 
 export default defineThemedFixtureGroup({ path: 'chat/terminalCollapsible/' }, {
@@ -97,6 +97,12 @@ export default defineThemedFixtureGroup({ path: 'chat/terminalCollapsible/' }, {
 	}),
 	'Ran - with intention': defineComponentFixture({
 		render: ctx => renderCollapsible(ctx, 'ls -lh', false, true, false, false, 'List files in the repo root'),
+	}),
+	'Height parity - with and without intention': defineComponentFixture({
+		render: ctx => {
+			renderCollapsible(ctx, 'ls -lh', false, true);
+			renderCollapsible(ctx, 'ls -lh', false, true, false, false, 'List files in the repo root');
+		},
 	}),
 	'Running - with intention': defineComponentFixture({
 		render: ctx => renderCollapsible(ctx, 'npm test', false, false, false, false, 'Run the test suite'),


### PR DESCRIPTION
Fixes the collapsed terminal tool row height regression introduced when shell intentions were added in #324347.

The command now remains an inline code element inside a separate flex/ellipsis wrapper, so intention rows match other inline code spans while preserving truncation. The terminal component fixture now uses the production chat ancestors and includes a with/without-intention height parity case.

Validation:
- `npm run typecheck-client`
- targeted hygiene checks
- `npm run stylelint`
- dark/light component explorer height measurements
- long intention/command overflow and ellipsis checks

(Written by Copilot)