### PR TITLE
Fall back to a custom diff editor for binary content

### DIFF
--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -9,7 +9,7 @@ import { isObject, assertReturnsDefined } from '../../../../base/common/types.js
 import { ICodeEditor, IDiffEditor } from '../../../../editor/browser/editorBrowser.js';
 import { IDiffEditorOptions, IEditorOptions as ICodeEditorOptions } from '../../../../editor/common/config/editorOptions.js';
 import { AbstractTextEditor, IEditorConfiguration } from './textEditor.js';
-import { TEXT_DIFF_EDITOR_ID, IEditorFactoryRegistry, EditorExtensions, ITextDiffEditorPane, IEditorOpenContext, isEditorInput, isTextEditorViewState, createTooLargeFileError } from '../../../common/editor.js';
+import { TEXT_DIFF_EDITOR_ID, IEditorFactoryRegistry, EditorExtensions, ITextDiffEditorPane, IEditorOpenContext, isEditorInput, isEditorInputWithOptionsAndGroup, isTextEditorViewState, createTooLargeFileError } from '../../../common/editor.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { applyTextEditorOptions } from '../../../common/editor/editorOptions.js';
 import { DiffEditorInput } from '../../../common/editor/diffEditorInput.js';
@@ -25,6 +25,7 @@ import { Registry } from '../../../../platform/registry/common/platform.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IEditorGroup, IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IEditorResolverService } from '../../../services/editor/common/editorResolverService.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { EditorActivation, ITextEditorOptions } from '../../../../platform/editor/common/editor.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -68,7 +69,8 @@ export class TextDiffEditor extends AbstractTextEditor<IDiffEditorViewState> imp
 		@IThemeService themeService: IThemeService,
 		@IEditorGroupsService editorGroupService: IEditorGroupsService,
 		@IFileService fileService: IFileService,
-		@IPreferencesService private readonly preferencesService: IPreferencesService
+		@IPreferencesService private readonly preferencesService: IPreferencesService,
+		@IEditorResolverService private readonly editorResolverService: IEditorResolverService
 	) {
 		super(TextDiffEditor.ID, group, telemetryService, instantiationService, storageService, configurationService, themeService, editorService, editorGroupService, fileService);
 	}
@@ -117,7 +119,7 @@ export class TextDiffEditor extends AbstractTextEditor<IDiffEditorViewState> imp
 
 			// Fallback to open as binary if not text
 			if (!(resolvedModel instanceof TextDiffEditorModel)) {
-				this.openAsBinary(input, options);
+				await this.openAsBinary(input, options);
 				return undefined;
 			}
 
@@ -207,9 +209,42 @@ export class TextDiffEditor extends AbstractTextEditor<IDiffEditorViewState> imp
 		return false;
 	}
 
-	private openAsBinary(input: DiffEditorInput, options: ITextEditorOptions | undefined): void {
+	private async openAsBinary(input: DiffEditorInput, options: ITextEditorOptions | undefined): Promise<void> {
 		const original = input.original;
 		const modified = input.modified;
+
+		// The text diff editor cannot render binary content. Before falling back to the generic binary
+		// "cannot display" panel, check whether a custom editor can render a diff for this resource and
+		// use it instead. This intentionally includes editors that opted out of diffs via a `never`
+		// priority: they opt out for text files, but a custom diff editor is strictly better than the
+		// binary fallback when the content is binary (e.g. an image or hex diff editor).
+		const modifiedResource = modified.resource;
+		if (modifiedResource) {
+			const fallbackEditorId = this.editorResolverService.getBinaryDiffFallbackEditor(modifiedResource);
+			const originalResource = original.resource;
+			if (fallbackEditorId && originalResource) {
+				const resolved = await this.editorResolverService.resolveEditor({
+					original: { resource: originalResource },
+					modified: { resource: modifiedResource },
+					// Passing an explicit `override` bypasses the automatic `never` filtering and the diff
+					// special-casing, so the resolver returns the custom diff editor directly.
+					options: { ...options, override: fallbackEditorId }
+				}, this.group);
+				if (isEditorInputWithOptionsAndGroup(resolved)) {
+					this.group.replaceEditors([{
+						editor: input,
+						replacement: resolved.editor,
+						options: {
+							...resolved.options,
+							activation: EditorActivation.PRESERVE,
+							pinned: this.group.isPinned(input),
+							sticky: this.group.isSticky(input)
+						}
+					}]);
+					return;
+				}
+			}
+		}
 
 		const binaryDiffInput = this.instantiationService.createInstance(DiffEditorInput, input.getName(), input.getDescription(), original, modified, true);
 

--- a/src/vs/workbench/services/editor/browser/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/browser/editorResolverService.ts
@@ -488,6 +488,20 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 		return distinct(this._registeredEditors.map(editor => editor.editorInfo), editor => editor.id);
 	}
 
+	getBinaryDiffFallbackEditor(resource: URI): string | undefined {
+		this._flattenedEditors = this._flattenEditorsMap();
+
+		// `findMatchingEditors(..., DiffEditor)` only keeps editors that provide a diff editor factory
+		// and sorts them by their diff priority. It still includes `never` editors (they match by glob),
+		// which is exactly what we want here: a `never` editor opts out of diffs for text files, but is
+		// the better choice than the generic binary fallback when the text diff editor cannot render the
+		// content. We exclude the built-in default text editor since that is the editor that already
+		// failed to render the binary content.
+		const editors = this.findMatchingEditors(resource, EditorAssociationType.DiffEditor)
+			.filter(editor => editor.editorInfo.id !== DEFAULT_EDITOR_ASSOCIATION.id);
+		return editors[0]?.editorInfo.id;
+	}
+
 	/**
 	 * Given a resource and an editorId selects the best possible editor
 	 * @returns The editor and whether there was another default which conflicted with it

--- a/src/vs/workbench/services/editor/common/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/common/editorResolverService.ts
@@ -253,6 +253,16 @@ export interface IEditorResolverService {
 	getEditors(): RegisteredEditorInfo[];
 
 	/**
+	 * Returns the id of the best editor that can render a *diff* for the resource, excluding the
+	 * built-in default text editor. This intentionally includes editors that opted out of diffs via a
+	 * `never` priority: such editors opt out for text files, but when the default text diff editor
+	 * cannot render the content (e.g. it is binary) a custom diff editor is preferable to the generic
+	 * "cannot display" fallback. Returns `undefined` when no such (diff-capable) editor exists.
+	 * @param resource The resource being diffed
+	 */
+	getBinaryDiffFallbackEditor(resource: URI): string | undefined;
+
+	/**
 	 * Get a complete list of editor associations.
 	 */
 	getAllUserAssociations(): EditorAssociations;

--- a/src/vs/workbench/services/editor/test/browser/editorResolverService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorResolverService.test.ts
@@ -502,6 +502,50 @@ suite('EditorResolverService', () => {
 		neverDiffRegisteredEditor.dispose();
 	});
 
+	test('getBinaryDiffFallbackEditor returns a diff-capable `never` editor and ignores non-diff editors', async () => {
+		const [, service] = await createEditorResolverService();
+
+		// A custom editor that opts out of diffs (`never`) but *does* provide a diff editor factory.
+		const neverWithDiff = service.registerEditor('*.bin',
+			{
+				id: 'BINARY_EDITOR',
+				label: 'Binary Editor',
+				detail: 'Binary Editor Details',
+				priority: {
+					editor: RegisteredEditorPriority.default,
+					diff: RegisteredEditorPriority.never,
+					merge: RegisteredEditorPriority.never
+				}
+			},
+			{},
+			{
+				createEditorInput: ({ resource }) => ({ editor: constructDisposableFileEditorInput(resource, 'binaryInput', disposables) }),
+				createDiffEditorInput: ({ modified, original }) => ({ editor: constructDisposableFileEditorInput(modified.resource ?? original.resource!, 'binaryDiffInput', disposables) })
+			}
+		);
+
+		// A custom editor that provides no diff factory must never be used as a binary diff fallback.
+		const noDiff = service.registerEditor('*.noDiff',
+			{
+				id: 'NO_DIFF_EDITOR',
+				label: 'No Diff Editor',
+				detail: 'No Diff Editor Details',
+				priority: RegisteredEditorPriority.default
+			},
+			{},
+			{
+				createEditorInput: ({ resource }) => ({ editor: constructDisposableFileEditorInput(resource, 'noDiffInput', disposables) })
+			}
+		);
+
+		assert.strictEqual(service.getBinaryDiffFallbackEditor(URI.file('file.bin')), 'BINARY_EDITOR');
+		assert.strictEqual(service.getBinaryDiffFallbackEditor(URI.file('file.noDiff')), undefined);
+		assert.strictEqual(service.getBinaryDiffFallbackEditor(URI.file('file.unrelated')), undefined);
+
+		neverWithDiff.dispose();
+		noDiff.dispose();
+	});
+
 	test('Diff editor Resolve - Different Types', async () => {
 		const [part, service, accessor] = await createEditorResolverService();
 		let diffOneCounter = 0;


### PR DESCRIPTION
Fixes #324804

When the built-in text diff editor cannot render a diff because the content is binary (or an unsupported encoding), prefer a custom editor that can render a diff for the resource instead of showing the generic "cannot display" binary panel.

### Why

This complements the `never` diff priority (#324791): a custom editor that opts out of diffs for text files (e.g. a `priority: default` editor, which now maps diff/merge to `never`) is still the best choice for **binary** diffs, where the text diff editor is useless. Previously such a diff degraded to:

> The file is not displayed in the text editor because it is either binary or uses an unsupported text encoding.

### Change

- Add `IEditorResolverService.getBinaryDiffFallbackEditor(resource)` — returns the best diff-capable editor for the resource (must provide a diff editor factory), **including `never` editors**, excluding the built-in default text editor. Returns `undefined` when none exists.
- In `TextDiffEditor.openAsBinary`, resolve and use that editor (via an explicit `override`, which bypasses the `never` filtering and the diff special-casing) before falling back to the binary panel.
- No recursion: the custom editor's diff is created with `forceOpenAsBinary`, so it opens in the binary diff pane rather than re-entering the text diff editor.

### Behavior

- **Binary** diff with a diff-capable custom editor → opens in that custom editor.
- **Text** diff with a `never` custom editor → unchanged (text diff editor).
- No diff-capable custom editor → the binary "cannot display" panel is shown as before.

Also fixes the equivalent regression risk for the built-in hex editor when it opts out of text diffs.

### Verification steps

1. Use the sample extension in `dev/playground/test-custom-editor` (a `*.bin` custom editor with `priority: default`).
2. Open a `.bin` file → the custom editor is used.
3. Diff two `.bin` files → the diff opens in the custom editor instead of the "cannot display" panel.
4. Diff two text files that have a `never` custom editor → still opens in the text diff editor.

Covered by a new `EditorResolverService` unit test for `getBinaryDiffFallbackEditor`.
