### PR TITLE
agentHost: emit restricted conversation.messageText trajectory telemetry

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -205,6 +205,64 @@ export class AgentHostTelemetryReporter {
 		}));
 	}
 
+	/**
+	 * Mirrors the Copilot extension's restricted `conversation.messageText` event (the panel-chat
+	 * prefix of `sendConversationalMessageTelemetry`) for the user's prompt. The extension emits it
+	 * for every user and model message, carrying the raw message text to the enhanced GH
+	 * (`copilot_v0_restricted_copilot_event`) and internal MSFT pipelines; the agent host observes
+	 * the same boundary at the SDK `user.message` event. The text is multiplexed across ~8192-char
+	 * chunks (`messageText`, `messageText_02`, …) so long prompts land untruncated, matching the
+	 * extension's `multiplexProperties`.
+	 *
+	 * @param session Session URI string; its id becomes `conversationId`.
+	 * @param content The user's prompt text. No-ops when empty.
+	 * @param turnId The SDK turn identifier this message belongs to, mapped to the extension's `turnIndex` field.
+	 */
+	userMessageText(session: string, content: string, turnId: string): void {
+		const restricted = this._restricted;
+		if (!restricted || !content) {
+			return;
+		}
+		const properties = multiplexProperties({
+			source: 'user',
+			conversationId: AgentSession.id(session),
+			...(turnId ? { turnIndex: turnId } : {}),
+			messageText: content,
+		});
+		const measurements = { messageCharLen: content.length };
+		restricted.sendEnhancedGHTelemetryEvent('conversation.messageText', properties, measurements);
+		restricted.sendInternalMSFTTelemetryEvent('conversation.messageText', properties, measurements);
+	}
+
+	/**
+	 * The model-message counterpart to {@link userMessageText}. Emitted when an `assistant.message`
+	 * arrives (the agent host's per-model-call boundary), carrying the assistant's response text.
+	 * `headerRequestId` is filled with the model call's `x-copilot-service-request-id` (the id the
+	 * SDK exposes), mirroring the field the extension populates from the client-minted request id.
+	 * VS Code-only enrichment dims (code-block languages/counts) are not reconstructed here.
+	 *
+	 * @param session Session URI string; its id becomes `conversationId`.
+	 * @param content The assistant's response text. No-ops when empty.
+	 * @param turnId The SDK turn identifier this message belongs to, mapped to the extension's `turnIndex` field.
+	 * @param serviceRequestId The model call's `x-copilot-service-request-id`, mapped to `headerRequestId`.
+	 */
+	modelMessageText(session: string, content: string, turnId: string, serviceRequestId: string | undefined): void {
+		const restricted = this._restricted;
+		if (!restricted || !content) {
+			return;
+		}
+		const properties = multiplexProperties({
+			source: 'model',
+			conversationId: AgentSession.id(session),
+			...(turnId ? { turnIndex: turnId } : {}),
+			...(serviceRequestId ? { headerRequestId: serviceRequestId } : {}),
+			messageText: content,
+		});
+		const measurements = { messageCharLen: content.length };
+		restricted.sendEnhancedGHTelemetryEvent('conversation.messageText', properties, measurements);
+		restricted.sendInternalMSFTTelemetryEvent('conversation.messageText', properties, measurements);
+	}
+
 	turnCompleted(report: IAgentHostTurnCompletedReport): void {
 		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
 		this._telemetryService.publicLog2<IAgentHostTurnCompletedEvent, IAgentHostTurnCompletedClassification>('agentHost.turnCompleted', {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -2546,6 +2546,8 @@ export class CopilotAgentSession extends Disposable {
 			// describe a subagent's model call, so subagent messages (mapped or dropped) are skipped.
 			if (!e.agentId) {
 				this._telemetryReporter.assistantMessageReceived(this.sessionUri.toString(), e.data.serviceRequestId, this._appliedSnapshot.tools);
+				// Restricted `conversation.messageText` (source=model): the model's raw response text.
+				this._telemetryReporter.modelMessageText(this.sessionUri.toString(), e.data.content, this._turnId, e.data.serviceRequestId);
 			}
 			// The SDK fires a `message` event with the full assembled content after
 			// streaming deltas. If deltas already created a markdown part for this
@@ -3369,6 +3371,13 @@ export class CopilotAgentSession extends Disposable {
 
 		this._register(wrapper.onUserMessage(e => {
 			this._logService.trace(`[Copilot:${sessionId}] User message: ${e.data.content.length} chars, ${e.data.attachments?.length ?? 0} attachments`);
+			// Restricted `conversation.messageText` (source=user): the raw user prompt text. Emit only
+			// for genuine human prompts on the main agent — skip subagent turns (driven by the parent)
+			// and SDK-injected synthetic messages (skill/harness injections carry a non-`user` source,
+			// matching `isSyntheticUserMessage`) so injected content is not reported as the user's prompt.
+			if (!e.agentId && (!e.data.source || e.data.source.toLowerCase() === 'user')) {
+				this._telemetryReporter.userMessageText(this.sessionUri.toString(), e.data.content, this._turnId);
+			}
 		}));
 
 		this._register(wrapper.onPendingMessagesModified(() => {

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
@@ -28,6 +28,7 @@ class TestRestrictedTelemetryService implements ITelemetryService, IAgentHostRes
 	firstSessionDate = 'firstSessionDate';
 
 	readonly enhancedEvents: IRestrictedCall[] = [];
+	readonly internalEvents: IRestrictedCall[] = [];
 
 	publicLog(): void { }
 	publicLogError(): void { }
@@ -40,7 +41,9 @@ class TestRestrictedTelemetryService implements ITelemetryService, IAgentHostRes
 	sendEnhancedGHTelemetryEvent(eventName: string, properties?: TelemetryProps, _measurements?: TelemetryMeasurements): void {
 		this.enhancedEvents.push({ eventName, properties });
 	}
-	sendInternalMSFTTelemetryEvent(): void { }
+	sendInternalMSFTTelemetryEvent(eventName: string, properties?: TelemetryProps, _measurements?: TelemetryMeasurements): void {
+		this.internalEvents.push({ eventName, properties });
+	}
 	setCopilotTrackingId(): void { }
 	setRestrictedTelemetryEndpoint(): void { }
 	setRestrictedTelemetryEnabled(): void { }
@@ -68,5 +71,46 @@ suite('AgentHostTelemetryReporter', () => {
 				messagesJson: JSON.stringify(tools),
 			},
 		}]);
+	});
+
+	test('userMessageText emits conversation.messageText (source=user) to enhanced + internal, and no-ops on empty content', () => {
+		const service = new TestRestrictedTelemetryService();
+		const reporter = new AgentHostTelemetryReporter(service);
+
+		reporter.userMessageText(session, '', '3'); // dropped: no content
+		reporter.userMessageText(session, 'hello agent', '3'); // emitted
+
+		const expected: IRestrictedCall = {
+			eventName: 'conversation.messageText',
+			properties: {
+				source: 'user',
+				conversationId: AgentSession.id(session),
+				turnIndex: '3',
+				messageText: 'hello agent',
+			},
+		};
+		assert.deepStrictEqual(service.enhancedEvents, [expected]);
+		assert.deepStrictEqual(service.internalEvents, [expected]);
+	});
+
+	test('modelMessageText emits conversation.messageText (source=model) with headerRequestId, and no-ops on empty content', () => {
+		const service = new TestRestrictedTelemetryService();
+		const reporter = new AgentHostTelemetryReporter(service);
+
+		reporter.modelMessageText(session, '', '3', 'svc-1'); // dropped: no content
+		reporter.modelMessageText(session, 'sure, here you go', '3', 'svc-1'); // emitted
+
+		const expected: IRestrictedCall = {
+			eventName: 'conversation.messageText',
+			properties: {
+				source: 'model',
+				conversationId: AgentSession.id(session),
+				turnIndex: '3',
+				headerRequestId: 'svc-1',
+				messageText: 'sure, here you go',
+			},
+		};
+		assert.deepStrictEqual(service.enhancedEvents, [expected]);
+		assert.deepStrictEqual(service.internalEvents, [expected]);
 	});
 });


### PR DESCRIPTION
Emits the restricted `conversation.messageText` event from the agent-host process for both the user prompt and the model response, mirroring the Copilot extension's existing event. This continues migrating the extension's restricted trajectory telemetry to the agent host so downstream consumers keep receiving the same events when chat runs on the SDK harness.

- User prompt text is reported at the SDK `user.message` boundary (`source=user`).
- Model response text is reported at `assistant.message` (`source=model`).
- Reuses the existing rt-gated restricted telemetry surface; emitted for the main agent only.

Refs microsoft/vscode-internalbacklog#8247, microsoft/vscode-internalbacklog#8265
