### PR TITLE
chat: keep shell intention chevron adjacent

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTerminalToolProgressPart.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTerminalToolProgressPart.css
@@ -14,9 +14,13 @@
  * single non-wrapping line. Each cell ellipsis-truncates and they split the
  * available width equally when the content overflows the row.
  */
-.chat-terminal-thinking-collapsible.chat-terminal-has-intention .chat-used-context-label,
-.chat-terminal-thinking-collapsible.chat-terminal-has-intention .monaco-button.monaco-icon-button {
+.chat-terminal-thinking-collapsible.chat-terminal-has-intention .chat-used-context-label {
 	width: 100%;
+	max-width: 100%;
+}
+
+.chat-terminal-thinking-collapsible.chat-terminal-has-intention .monaco-button.monaco-icon-button {
+	width: fit-content;
 	max-width: 100%;
 	justify-content: flex-start;
 }


### PR DESCRIPTION
Stacked on #324800.

Short terminal intention rows currently stretch the collapse button across the available width, leaving the decorative expand chevron at the far right. Keep the outer label full-width but let the button shrink-wrap its contents, capped at 100% for overflowing rows.

This keeps the chevron immediately after the command for short rows while preserving the existing two-cell ellipsis behavior for long intentions and commands.

Validation:
- `npm run stylelint`
- targeted hygiene check
- dark/light component explorer measurements for short and overflowing intention rows
- verified the chevron remains `aria-hidden`

(Written by Copilot)