### PR TITLE
Normalize file URIs before the fetch tool's workspace membership check

### DIFF
--- a/src/vs/workbench/contrib/chat/electron-browser/builtInTools/fetchPageTool.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/builtInTools/fetchPageTool.ts
@@ -298,14 +298,7 @@ export class FetchWebPageTool implements IToolImpl {
 						webUris.set(url, uriObj);
 					}
 				} else {
-					// Try to handle other schemes via file service.
-					// Normalize the URI up-front so that path-traversal segments (e.g. `..`)
-					// are resolved to their canonical location. The workspace-membership check
-					// in `prepareToolInvocation` (which decides whether a confirmation dialog is
-					// needed) must operate on the same path that `readFile` ultimately reads;
-					// otherwise a URL like `file:///<workspace>/../../secret` is judged to be
-					// inside the workspace (raw path-prefix match) while actually reading a file
-					// outside of it, bypassing the confirmation prompt.
+					// Normalize `..` so the confirmation-gating workspace check and the eventual read agree on one path.
 					fileUris.set(url, normalizePath(uriObj));
 				}
 			} catch (e) {

--- a/src/vs/workbench/contrib/chat/electron-browser/builtInTools/fetchPageTool.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/builtInTools/fetchPageTool.ts
@@ -9,6 +9,7 @@ import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Iterable } from '../../../../../base/common/iterator.js';
 import { ResourceSet } from '../../../../../base/common/map.js';
 import { extname } from '../../../../../base/common/path.js';
+import { normalizePath } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
@@ -297,8 +298,15 @@ export class FetchWebPageTool implements IToolImpl {
 						webUris.set(url, uriObj);
 					}
 				} else {
-					// Try to handle other schemes via file service
-					fileUris.set(url, uriObj);
+					// Try to handle other schemes via file service.
+					// Normalize the URI up-front so that path-traversal segments (e.g. `..`)
+					// are resolved to their canonical location. The workspace-membership check
+					// in `prepareToolInvocation` (which decides whether a confirmation dialog is
+					// needed) must operate on the same path that `readFile` ultimately reads;
+					// otherwise a URL like `file:///<workspace>/../../secret` is judged to be
+					// inside the workspace (raw path-prefix match) while actually reading a file
+					// outside of it, bypassing the confirmation prompt.
+					fileUris.set(url, normalizePath(uriObj));
 				}
 			} catch (e) {
 				invalidUris.add(url);

--- a/src/vs/workbench/contrib/chat/test/electron-browser/tools/builtinTools/fetchPageTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/electron-browser/tools/builtinTools/fetchPageTool.test.ts
@@ -276,6 +276,63 @@ suite('FetchWebPageTool', () => {
 		assert.strictEqual(preparation.confirmationMessages?.confirmResults, true, 'File outside workspace should require post-confirmation');
 	});
 
+	test('file URI that traverses out of the workspace requires confirmation', async () => {
+		// Regression: a `..` traversal that escapes the workspace must not be judged as inside it.
+		// The membership check and the read must agree on the canonical (normalized) path.
+		const workspaceRoot = URI.file('/workspaceRoot');
+		const workspaceContextService = new TestContextService(testWorkspace(workspaceRoot));
+
+		// The real target, after resolving `..`, lives outside the workspace.
+		const fileContentMap = new ResourceMap<string | VSBuffer>([
+			[URI.file('/etc/secret.txt'), 'secret content'],
+		]);
+
+		const tool = new FetchWebPageTool(
+			new TestWebContentExtractorService(new ResourceMap<string>()),
+			new ExtendedTestFileService(fileContentMap),
+			new MockTrustedDomainService([]),
+			new MockChatService(),
+			workspaceContextService,
+			new MockAgentNetworkFilterService(),
+		);
+
+		const preparation = await tool.prepareToolInvocation(
+			{ parameters: { urls: ['file:///workspaceRoot/../../etc/secret.txt'] }, toolCallId: 'test-file-traversal', chatSessionResource: undefined },
+			CancellationToken.None
+		);
+		assert.ok(preparation, 'Should return prepared invocation');
+		assert.ok(preparation.confirmationMessages?.title, 'Traversal escaping the workspace should show confirmation dialog');
+		assert.strictEqual(preparation.confirmationMessages?.confirmResults, true, 'Traversal escaping the workspace should require post-confirmation');
+	});
+
+	test('file URI with `..` that stays inside the workspace still skips confirmation', async () => {
+		// Normalization must not over-block: an in-workspace path that happens to contain `..`
+		// resolves back inside the workspace and should not prompt.
+		const workspaceRoot = URI.file('/workspaceRoot');
+		const workspaceContextService = new TestContextService(testWorkspace(workspaceRoot));
+
+		const fileContentMap = new ResourceMap<string | VSBuffer>([
+			[URI.file('/workspaceRoot/plan.md'), 'Plan content'],
+		]);
+
+		const tool = new FetchWebPageTool(
+			new TestWebContentExtractorService(new ResourceMap<string>()),
+			new ExtendedTestFileService(fileContentMap),
+			new MockTrustedDomainService([]),
+			new MockChatService(),
+			workspaceContextService,
+			new MockAgentNetworkFilterService(),
+		);
+
+		const preparation = await tool.prepareToolInvocation(
+			{ parameters: { urls: ['file:///workspaceRoot/subdir/../plan.md'] }, toolCallId: 'test-file-inside-traversal', chatSessionResource: undefined },
+			CancellationToken.None
+		);
+		assert.ok(preparation, 'Should return prepared invocation');
+		assert.strictEqual(preparation.confirmationMessages?.title, undefined, 'In-workspace file (after normalization) should not show confirmation dialog');
+		assert.strictEqual(preparation.confirmationMessages?.confirmResults, false, 'In-workspace file should not require post-confirmation');
+	});
+
 	test('workspace file mixed with untrusted web URI: only web URI triggers confirmation', async () => {
 		const workspaceRoot = URI.file('/workspaceRoot');
 		const workspaceContextService = new TestContextService(testWorkspace(workspaceRoot));


### PR DESCRIPTION
Draft. Addresses microsoft/vscode-internalbacklog#8356 (details in the linked private issue).

### Background
The Fetch Web Page tool routes non-`http(s)` URLs (including `file://`) to the file service, and skips the confirmation prompt for files that resolve inside a workspace folder. The "is it inside the workspace?" check compared raw URI path segments, while the read path normalizes `..` segments. For a path containing `..`, the two could disagree — a resource that resolves *outside* the workspace could be judged *inside* it, and read without a prompt.

### Change
Canonicalize the URI with `normalizePath` at parse time so the membership check (`prepareToolInvocation`) and the read (`invoke`) operate on the same resolved path:
- resolves outside the workspace → confirmation prompt (as expected)
- resolves inside the workspace → no prompt (unchanged)

### Validation
- Regression tests added: a `..` path that escapes the workspace (must prompt) and one that stays inside it (must not prompt). Full `fetchPageTool.test.ts` suite green (26).
- Verified end-to-end in a signed-in Code OSS build: the traversal URL now surfaces the **Fetch web page?** confirmation showing the resolved path, and content is gated behind approval.

Repro / verification steps are in microsoft/vscode-internalbacklog#8356.

Fixes microsoft/vscode-internalbacklog#8356

🤖 Generated with [Claude Code](https://claude.com/claude-code)
