### PR TITLE
Debug: capture corrupt apt repo metadata breaking Compile & Hygiene

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,8 +39,83 @@ jobs:
           key-args: "compile $(node -p process.arch)"
 
       - name: Install build tools
+        id: install-build-tools
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: sudo apt update -y && sudo apt install -y build-essential pkg-config libx11-dev libx11-xcb-dev libxkbfile-dev libnotify-bin libkrb5-dev
+
+      # TEMPORARY DIAGNOSTIC: capture the corrupt apt repository metadata that
+      # intermittently breaks `apt update` on the runner (packages.microsoft.com
+      # serving invalid InRelease/Release.gpg -> NOSPLIT/NODATA). Remove once the
+      # bad payload has been captured. See discussion on the apt CDN flakiness.
+      - name: Debug apt repository failure
+        if: always()
+        run: |
+          set +e
+
+          echo "::group::apt-get update (verbose, capture errors)"
+          sudo apt-get update -o Debug::Acquire::gpgv=true 2> apt-update.err
+          cat apt-update.err
+          echo "::endgroup::"
+
+          echo "::group::apt partial lists (raw bytes apt rejected)"
+          sudo ls -la /var/lib/apt/lists/partial/ 2>/dev/null
+          for f in /var/lib/apt/lists/partial/*; do
+            [ -e "$f" ] || continue
+            echo "----- $f -----"
+            sudo file "$f"
+            sudo head -40 "$f"
+            echo "----- hexdump (first 256 bytes) -----"
+            sudo hexdump -C "$f" | head -16
+          done
+          echo "::endgroup::"
+
+          # Build the list of URLs to probe: any InRelease apt just failed to
+          # fetch, plus the known Microsoft repositories that showed NOSPLIT/NODATA.
+          grep -oE 'https?://[^ ]+/InRelease' apt-update.err | sort -u > urls.txt
+          printf '%s\n' \
+            "https://packages.microsoft.com/repos/azure-cli/dists/jammy/InRelease" \
+            "https://packages.microsoft.com/ubuntu/22.04/prod/dists/jammy/InRelease" \
+            "https://packages.microsoft.com/repos/microsoft-ubuntu-jammy-prod/dists/jammy/InRelease" \
+            "https://packages.microsoft.com/repos/microsoft-ubuntu-jammy-prod/dists/jammy/Release.gpg" \
+            "https://packages.microsoft.com/repos/azurecore/dists/jammy/InRelease" \
+            "https://packages.microsoft.com/repos/azurecore/dists/jammy/Release.gpg" \
+            >> urls.txt
+          sort -u urls.txt -o urls.txt
+
+          bad=0
+          while read -r url; do
+            [ -z "$url" ] && continue
+            echo "::group::Probe $url"
+            for attempt in $(seq 1 10); do
+              hdr=$(mktemp); body=$(mktemp)
+              code=$(curl -sS -H 'Cache-Control: no-cache' -D "$hdr" -o "$body" -w '%{http_code}' "$url")
+              size=$(wc -c < "$body")
+              xcache=$(awk 'tolower($0) ~ /^x-cache:/ {sub(/\r/,""); print}' "$hdr")
+              xref=$(awk 'tolower($0) ~ /^x-azure-ref:/ {sub(/\r/,""); print}' "$hdr")
+              ok=1
+              if [ "$code" != "200" ]; then
+                ok=0
+              else
+                case "$url" in
+                  *InRelease) head -1 "$body" | grep -q 'BEGIN PGP SIGNED MESSAGE' || ok=0 ;;
+                  *Release.gpg) file "$body" | grep -qi 'PGP' || ok=0 ;;
+                esac
+              fi
+              echo "attempt=$attempt code=$code size=$size ok=$ok | $xcache | $xref"
+              if [ "$ok" = "0" ]; then
+                bad=1
+                echo "--- BAD: response headers ---"; cat "$hdr"
+                echo "--- BAD: first 40 lines of body ---"; head -40 "$body"
+                echo "--- BAD: file type ---"; file "$body"
+                echo "--- BAD: hexdump (first 512 bytes) ---"; hexdump -C "$body" | head -32
+              fi
+              rm -f "$hdr" "$body"
+              sleep 1
+            done
+            echo "::endgroup::"
+          done < urls.txt
+
+          echo "Reproduced at least one bad response: $bad"
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,9 +52,12 @@ jobs:
         run: |
           set +e
 
+          # Work outside the checkout so temp files aren't picked up by hygiene.
+          tmp="$(mktemp -d)"
+
           echo "::group::apt-get update (verbose, capture errors)"
-          sudo apt-get update -o Debug::Acquire::gpgv=true 2> apt-update.err
-          cat apt-update.err
+          sudo apt-get update -o Debug::Acquire::gpgv=true 2> "$tmp/apt-update.err"
+          cat "$tmp/apt-update.err"
           echo "::endgroup::"
 
           echo "::group::apt partial lists (raw bytes apt rejected)"
@@ -71,7 +74,7 @@ jobs:
 
           # Build the list of URLs to probe: any InRelease apt just failed to
           # fetch, plus the known Microsoft repositories that showed NOSPLIT/NODATA.
-          grep -oE 'https?://[^ ]+/InRelease' apt-update.err | sort -u > urls.txt
+          grep -oE 'https?://[^ ]+/InRelease' "$tmp/apt-update.err" | sort -u > "$tmp/urls.txt"
           printf '%s\n' \
             "https://packages.microsoft.com/repos/azure-cli/dists/jammy/InRelease" \
             "https://packages.microsoft.com/ubuntu/22.04/prod/dists/jammy/InRelease" \
@@ -79,8 +82,8 @@ jobs:
             "https://packages.microsoft.com/repos/microsoft-ubuntu-jammy-prod/dists/jammy/Release.gpg" \
             "https://packages.microsoft.com/repos/azurecore/dists/jammy/InRelease" \
             "https://packages.microsoft.com/repos/azurecore/dists/jammy/Release.gpg" \
-            >> urls.txt
-          sort -u urls.txt -o urls.txt
+            >> "$tmp/urls.txt"
+          sort -u "$tmp/urls.txt" -o "$tmp/urls.txt"
 
           bad=0
           while read -r url; do
@@ -113,8 +116,9 @@ jobs:
               sleep 1
             done
             echo "::endgroup::"
-          done < urls.txt
+          done < "$tmp/urls.txt"
 
+          rm -rf "$tmp"
           echo "Reproduced at least one bad response: $bad"
 
       - name: Install dependencies


### PR DESCRIPTION
## What

Temporary **diagnostic** step added to the `Compile & Hygiene` job in [pr.yml](https://github.com/microsoft/vscode/blob/roblou/debug-apt-repo-failure/.github/workflows/pr.yml). **Not intended to merge** — this is a trap to capture the bad payload from a transient CI failure.

## Why

The `Install build tools` step runs:

```bash
sudo apt update -y && sudo apt install -y build-essential pkg-config ...
```

It has been failing consistently across multiple PRs (e.g. [run 28899725406](https://github.com/microsoft/vscode/actions/runs/28899725406/job/85739126699)) with:

```
E: Failed to fetch .../azure-cli/dists/jammy/InRelease  Clearsigned file isn't valid, got 'NOSPLIT'
E: GPG error: ...azurecore jammy Release: Signed file isn't valid, got 'NODATA'
```

Root cause is two things combining:
1. **`packages.microsoft.com`** intermittently serves invalid `InRelease`/`Release.gpg` metadata (NOSPLIT/NODATA) from some Front Door edge nodes — a CDN-side glitch on repos we don't even need.
2. The **`&&` short-circuit**: none of the packages we actually install come from Microsoft (they're all from the Ubuntu archive, which is healthy), but `apt update` returning non-zero because of the unrelated MS repos means `apt install` never runs. It only surfaces on a node_modules cache miss (the step is gated on `cache-hit != 'true'`).

The corrupt content recovers per-edge within seconds, so it can't be reproduced after the fact. This step traps it live.

## What the debug step does

On every run of this branch (`if: always()`) it:
- Re-runs `apt-get update` verbosely and dumps any files apt rejected in `/var/lib/apt/lists/partial/`.
- Loop-fetches the Microsoft repo `InRelease`/`Release.gpg` URLs (cache-busting), printing a compact status line per attempt, and dumping **full headers + body + hexdump** for any response that isn't a valid signed file.

## Follow-up

Once we've captured the bad payload, this step will be removed and replaced with the real fix (make `apt update` failure on unrelated third-party repos non-fatal, e.g. `apt update -y || true`, so the needed Ubuntu-archive packages still install).

(Written by Copilot)