### PR TITLE
sessions: add Toggle Inline View and Expand/Collapse All to Changes editor

### DIFF
--- a/src/vs/editor/browser/widget/multiDiffEditor/diffEditorItemTemplate.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/diffEditorItemTemplate.ts
@@ -6,7 +6,7 @@ import { addDisposableListener, EventType, h } from '../../../../base/browser/do
 import { Button } from '../../../../base/browser/ui/button/button.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
-import { autorun, derived, globalTransaction, observableValue } from '../../../../base/common/observable.js';
+import { autorun, derived, globalTransaction, IObservable, observableValue } from '../../../../base/common/observable.js';
 import { createActionViewItem } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { MenuWorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
 import { MenuId } from '../../../../platform/actions/common/actions.js';
@@ -68,6 +68,7 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 		private readonly _container: HTMLElement,
 		private readonly _overflowWidgetsDomNode: HTMLElement,
 		private readonly _workbenchUIElementFactory: IWorkbenchUIElementFactory,
+		private readonly _optionsOverride: IObservable<IDiffEditorOptions> | undefined,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IContextKeyService _parentContextKeyService: IContextKeyService,
 	) {
@@ -241,9 +242,11 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 
 	public setData(data: TemplateData | undefined): void {
 		this._data = data;
+		const optionsOverride = this._optionsOverride;
 		function updateOptions(options: IDiffEditorOptions): IDiffEditorOptions {
 			return {
 				...options,
+				...optionsOverride?.get(),
 				scrollBeyondLastLine: false,
 				hideUnchangedRegions: {
 					enabled: true,
@@ -302,6 +305,12 @@ export class DiffEditorItemTemplate extends Disposable implements IPooledObject<
 		});
 		if (value.onOptionsDidChange) {
 			this._dataStore.add(value.onOptionsDidChange(() => {
+				this.editor.updateOptions(updateOptions(value.options ?? {}));
+			}));
+		}
+		if (optionsOverride) {
+			this._dataStore.add(autorun(reader => {
+				optionsOverride.read(reader);
 				this.editor.updateOptions(updateOptions(value.options ?? {}));
 			}));
 		}

--- a/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidget.ts
@@ -25,6 +25,7 @@ import { IWorkbenchUIElementFactory } from './workbenchUIElementFactory.js';
 export class MultiDiffEditorWidget extends Disposable {
 	private readonly _dimension = observableValue<Dimension | undefined>(this, undefined);
 	private readonly _viewModel = observableValue<MultiDiffEditorViewModel | undefined>(this, undefined);
+	private readonly _renderSideBySide = observableValue<boolean | undefined>(this, undefined);
 
 	private readonly _widgetImpl = derived(this, (reader) => {
 		readHotReloadableExport(DiffEditorItemTemplate, reader);
@@ -34,6 +35,7 @@ export class MultiDiffEditorWidget extends Disposable {
 			this._dimension,
 			this._viewModel,
 			this._workbenchUIElementFactory,
+			this._renderSideBySide,
 		));
 	});
 
@@ -65,6 +67,19 @@ export class MultiDiffEditorWidget extends Disposable {
 
 	public layout(dimension: Dimension): void {
 		this._dimension.set(dimension, undefined);
+	}
+
+	/**
+	 * Overrides whether the embedded diffs render side by side (`true`) or inline
+	 * (`false`) as editor-local state, independent of the
+	 * `diffEditor.renderSideBySide` setting. When left unset the setting applies.
+	 */
+	public setRenderSideBySide(renderSideBySide: boolean): void {
+		this._renderSideBySide.set(renderSideBySide, undefined);
+	}
+
+	public toggleRenderSideBySide(): void {
+		this._renderSideBySide.set(!(this._renderSideBySide.get() ?? true), undefined);
 	}
 
 	private readonly _activeControl = derived(this, (reader) => this._widgetImpl.read(reader).activeControl.read(reader));

--- a/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditor/multiDiffEditorWidgetImpl.ts
@@ -18,6 +18,7 @@ import { ITextEditorOptions } from '../../../../platform/editor/common/editor.js
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
 import { OffsetRange } from '../../../common/core/ranges/offsetRange.js';
+import { IDiffEditorOptions } from '../../../common/config/editorOptions.js';
 import { IRange } from '../../../common/core/range.js';
 import { ISelection, Selection } from '../../../common/core/selection.js';
 import { IDiffEditor } from '../../../common/editorCommon.js';
@@ -44,6 +45,8 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 	private readonly _sizeObserver;
 
 	private readonly _objectPool;
+
+	private readonly _optionsOverride: IObservable<IDiffEditorOptions>;
 
 	public readonly scrollTop;
 	public readonly scrollLeft;
@@ -74,6 +77,7 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 		private readonly _dimension: IObservable<Dimension | undefined>,
 		private readonly _viewModel: IObservable<MultiDiffEditorViewModel | undefined>,
 		private readonly _workbenchUIElementFactory: IWorkbenchUIElementFactory,
+		private readonly _renderSideBySide: IObservable<boolean | undefined>,
 		@IContextKeyService private readonly _parentContextKeyService: IContextKeyService,
 		@IInstantiationService private readonly _parentInstantiationService: IInstantiationService,
 	) {
@@ -102,12 +106,20 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 			h('div.placeholder@placeholder', {}, [h('div')]),
 		]);
 		this._sizeObserver = this._register(new ObservableElementSizeObserver(this._element, undefined));
+		this._optionsOverride = derived(this, reader => {
+			const renderSideBySide = this._renderSideBySide.read(reader);
+			// Also pin `useInlineViewWhenSpaceIsLimited` off so the toggle deterministically
+			// controls inline vs. side-by-side regardless of the available width.
+			const options: IDiffEditorOptions = renderSideBySide === undefined ? {} : { renderSideBySide, useInlineViewWhenSpaceIsLimited: false };
+			return options;
+		});
 		this._objectPool = this._register(new ObjectPool<TemplateData, DiffEditorItemTemplate>((data) => {
 			const template = this._instantiationService.createInstance(
 				DiffEditorItemTemplate,
 				this._scrollableElements.content,
 				this._scrollableElements.overflowWidgetsDomNode,
-				this._workbenchUIElementFactory
+				this._workbenchUIElementFactory,
+				this._optionsOverride,
 			);
 			template.setData(data);
 			return template;
@@ -173,6 +185,14 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 			if (viewModel) {
 				const allCollapsed = viewModel.items.read(reader).every(item => item.collapsed.read(reader));
 				ctxAllCollapsed.set(allCollapsed);
+			}
+		}));
+
+		const ctxRenderSideBySide = this._parentContextKeyService.createKey<boolean>(EditorContextKeys.multiDiffEditorRenderSideBySide.key, true);
+		this._register(autorun((reader) => {
+			const renderSideBySide = this._renderSideBySide.read(reader);
+			if (renderSideBySide !== undefined) {
+				ctxRenderSideBySide.set(renderSideBySide);
 			}
 		}));
 

--- a/src/vs/editor/common/editorContextKeys.ts
+++ b/src/vs/editor/common/editorContextKeys.ts
@@ -29,6 +29,7 @@ export namespace EditorContextKeys {
 	export const isEmbeddedDiffEditor = new RawContextKey<boolean>('isEmbeddedDiffEditor', false, nls.localize('isEmbeddedDiffEditor', "Whether the context is an embedded diff editor"));
 	export const inMultiDiffEditor = new RawContextKey<boolean>('inMultiDiffEditor', false, nls.localize('inMultiDiffEditor', "Whether the context is a multi diff editor"));
 	export const multiDiffEditorAllCollapsed = new RawContextKey<boolean>('multiDiffEditorAllCollapsed', undefined, nls.localize('multiDiffEditorAllCollapsed', "Whether all files in multi diff editor are collapsed"));
+	export const multiDiffEditorRenderSideBySide = new RawContextKey<boolean>('multiDiffEditorRenderSideBySide', true, nls.localize('multiDiffEditorRenderSideBySide', "Whether the multi diff editor renders diffs side by side instead of inline"));
 	export const hasChanges = new RawContextKey<boolean>('diffEditorHasChanges', false, nls.localize('diffEditorHasChanges', "Whether the diff editor has changes"));
 	export const comparingMovedCode = new RawContextKey<boolean>('comparingMovedCode', false, nls.localize('comparingMovedCode', "Whether a moved code block is selected for comparison"));
 	export const accessibleDiffViewerVisible = new RawContextKey<boolean>('accessibleDiffViewerVisible', false, nls.localize('accessibleDiffViewerVisible', "Whether the accessible diff viewer is visible"));

--- a/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
@@ -15,10 +15,14 @@ import { ContextKeyExpr, IContextKeyService } from '../../../../platform/context
 import { bindContextKey } from '../../../../platform/observable/common/platformObservableUtils.js';
 import { ActiveSessionContextKeys, CHANGES_VIEW_ID, ChangesContextKeys, SESSIONS_CHANGES_OPEN_SINGLE_FILE_DIFF_SETTING } from '../common/changes.js';
 import { ActiveEditorContext, IsAuxiliaryWindowContext, IsSessionsWindowContext, IsTopRightEditorGroupContext, MainEditorAreaVisibleContext } from '../../../../workbench/common/contextkeys.js';
+import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { URI } from '../../../../base/common/uri.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
+import { IEditorGroupsService } from '../../../../workbench/services/editor/common/editorGroupsService.js';
+import { IListService } from '../../../../platform/list/browser/listService.js';
+import { resolveCommandsContext } from '../../../../workbench/browser/parts/editor/editorCommandsContext.js';
 import { IChangesViewService } from '../common/changesViewService.js';
 import { DOCK_DETAIL_PANEL_SETTING } from '../../../common/sessionConfig.js';
 import { SessionChangesEditor } from './sessionChangesEditor.js';
@@ -147,6 +151,73 @@ class CollapseAllSessionChangesDiffsAction extends Action2 {
 }
 
 registerAction2(CollapseAllSessionChangesDiffsAction);
+
+class ExpandAllSessionChangesDiffsAction extends Action2 {
+	static readonly ID = 'workbench.action.agentSessions.expandAllDiffs';
+
+	constructor() {
+		super({
+			id: ExpandAllSessionChangesDiffsAction.ID,
+			title: localize2('agentSessions.expandAllDiffs', "Expand All Diffs"),
+			icon: Codicon.expandAll,
+			f1: false,
+			menu: {
+				id: MenuId.EditorTitle,
+				group: 'navigation',
+				order: 100,
+				when: ContextKeyExpr.and(
+					singlePaneChangesEditorActive,
+					IsAuxiliaryWindowContext.toNegated(),
+					IsTopRightEditorGroupContext,
+					MainEditorAreaVisibleContext,
+					ContextKeyExpr.has('multiDiffEditorAllCollapsed'))
+			}
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		const activeEditorPane = accessor.get(IEditorService).activeEditorPane;
+		if (activeEditorPane instanceof SessionChangesEditor) {
+			activeEditorPane.expandAllDiffs();
+		}
+	}
+}
+
+registerAction2(ExpandAllSessionChangesDiffsAction);
+
+class ToggleSessionChangesInlineViewAction extends Action2 {
+	static readonly ID = 'workbench.action.agentSessions.toggleInlineView';
+
+	constructor() {
+		super({
+			id: ToggleSessionChangesInlineViewAction.ID,
+			title: localize2('agentSessions.toggleInlineView', "Toggle Inline View"),
+			icon: Codicon.diffSidebyside,
+			f1: false,
+			toggled: EditorContextKeys.multiDiffEditorRenderSideBySide.negate(),
+			menu: {
+				id: MenuId.EditorTitle,
+				group: 'navigation',
+				order: 99,
+				when: ContextKeyExpr.and(
+					singlePaneChangesEditorActive,
+					IsAuxiliaryWindowContext.toNegated(),
+					IsTopRightEditorGroupContext,
+					MainEditorAreaVisibleContext)
+			}
+		});
+	}
+
+	run(accessor: ServicesAccessor, ...args: unknown[]): void {
+		const resolvedContext = resolveCommandsContext(args, accessor.get(IEditorService), accessor.get(IEditorGroupsService), accessor.get(IListService));
+		const pane = resolvedContext.groupedEditors[0]?.group.activeEditorPane ?? accessor.get(IEditorService).activeEditorPane;
+		if (pane instanceof SessionChangesEditor) {
+			pane.toggleInlineView();
+		}
+	}
+}
+
+registerAction2(ToggleSessionChangesInlineViewAction);
 
 class OpenChangesAction extends Action2 {
 	static readonly ID = 'workbench.action.agentSessions.openChanges';

--- a/src/vs/sessions/contrib/changes/browser/sessionChangesEditor.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionChangesEditor.ts
@@ -112,11 +112,23 @@ export class SessionChangesEditor extends EditorPane {
 		}
 
 		this.bodyContainer = append(root, $('.session-changes-editor-body'));
-		this.widget = this._register(scopedInstantiationService.createInstance(
+
+		// Create the widget in the editor-pane context (not the deeper scoped one)
+		// so its own multiDiffEditor* context keys (all-collapsed, render-side-by-side)
+		// are visible to the EditorTitle menu that drives the collapse/expand-all and
+		// inline-view toggle actions.
+		const paneInstantiationService = this._register(this.instantiationService.createChild(
+			new ServiceCollection([IContextKeyService, this.contextKeyService])));
+		this.widget = this._register(paneInstantiationService.createInstance(
 			MultiDiffEditorWidget,
 			this.bodyContainer,
-			scopedInstantiationService.createInstance(SessionChangesUIElementFactory),
+			paneInstantiationService.createInstance(SessionChangesUIElementFactory),
 		));
+		this.widget.setRenderSideBySide(this.configurationService.getValue<boolean>('diffEditor.renderSideBySide') ?? true);
+	}
+
+	toggleInlineView(): void {
+		this.widget?.toggleRenderSideBySide();
 	}
 
 	/** Creates the classic (non-single-pane) internal header toolbars. */
@@ -160,6 +172,10 @@ export class SessionChangesEditor extends EditorPane {
 
 	collapseAllDiffs(): void {
 		this.viewModel?.collapseAll();
+	}
+
+	expandAllDiffs(): void {
+		this.viewModel?.expandAll();
 	}
 
 	override setOptions(options: IMultiDiffEditorOptions | undefined): void {

--- a/src/vs/sessions/contrib/changes/test/browser/changesViewActions.test.ts
+++ b/src/vs/sessions/contrib/changes/test/browser/changesViewActions.test.ts
@@ -44,6 +44,34 @@ suite('Changes View Actions', () => {
 		});
 	});
 
+	test('expand all diffs is contributed to the single-pane editor title bar', () => {
+		const item = MenuRegistry.getMenuItems(MenuId.EditorTitle)
+			.filter(isIMenuItem)
+			.find(item => item.command.id === 'workbench.action.agentSessions.expandAllDiffs');
+
+		assert.ok(item, 'expected expand all diffs action on EditorTitle');
+		const when = item.when?.serialize() ?? '';
+		assert.deepStrictEqual({
+			group: item.group,
+			order: item.order,
+			icon: ThemeIcon.isThemeIcon(item.command.icon) ? item.command.icon.id : undefined,
+			hasSessionsWindowGate: when.includes(IsSessionsWindowContext.key),
+			hasActiveEditorGate: when.includes(ActiveEditorContext.key) && when.includes(SessionChangesEditor.ID),
+			hasSinglePaneConfigGate: when.includes(`config.${DOCK_DETAIL_PANEL_SETTING}`),
+			hasEditorAreaVisibleGate: when.includes(MainEditorAreaVisibleContext.key),
+			hasAllCollapsedGate: when.includes(EditorContextKeys.multiDiffEditorAllCollapsed.key),
+		}, {
+			group: 'navigation',
+			order: 100,
+			icon: Codicon.expandAll.id,
+			hasSessionsWindowGate: true,
+			hasActiveEditorGate: true,
+			hasSinglePaneConfigGate: true,
+			hasEditorAreaVisibleGate: true,
+			hasAllCollapsedGate: true,
+		});
+	});
+
 	test('toggle inline view command is contributed to the single-pane editor title bar', () => {
 		const item = MenuRegistry.getMenuItems(MenuId.EditorTitle)
 			.filter(isIMenuItem)

--- a/src/vs/sessions/contrib/changes/test/browser/changesViewActions.test.ts
+++ b/src/vs/sessions/contrib/changes/test/browser/changesViewActions.test.ts
@@ -8,6 +8,8 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { isIMenuItem, MenuId, MenuRegistry } from '../../../../../platform/actions/common/actions.js';
+import { ContextKeyExpression } from '../../../../../platform/contextkey/common/contextkey.js';
+import { EditorContextKeys } from '../../../../../editor/common/editorContextKeys.js';
 import { ActiveEditorContext, IsSessionsWindowContext, MainEditorAreaVisibleContext } from '../../../../../workbench/common/contextkeys.js';
 import { DOCK_DETAIL_PANEL_SETTING } from '../../../../common/sessionConfig.js';
 import { SessionChangesEditor } from '../../browser/sessionChangesEditor.js';
@@ -35,6 +37,34 @@ suite('Changes View Actions', () => {
 			group: 'navigation',
 			order: 100,
 			icon: Codicon.collapseAll.id,
+			hasSessionsWindowGate: true,
+			hasActiveEditorGate: true,
+			hasSinglePaneConfigGate: true,
+			hasEditorAreaVisibleGate: true,
+		});
+	});
+
+	test('toggle inline view command is contributed to the single-pane editor title bar', () => {
+		const item = MenuRegistry.getMenuItems(MenuId.EditorTitle)
+			.filter(isIMenuItem)
+			.find(item => item.command.id === 'workbench.action.agentSessions.toggleInlineView');
+
+		assert.ok(item, 'expected toggle inline view command on EditorTitle');
+		const when = item.when?.serialize() ?? '';
+		assert.deepStrictEqual({
+			group: item.group,
+			order: item.order,
+			icon: ThemeIcon.isThemeIcon(item.command.icon) ? item.command.icon.id : undefined,
+			toggled: (item.command.toggled as ContextKeyExpression | undefined)?.serialize(),
+			hasSessionsWindowGate: when.includes(IsSessionsWindowContext.key),
+			hasActiveEditorGate: when.includes(ActiveEditorContext.key) && when.includes(SessionChangesEditor.ID),
+			hasSinglePaneConfigGate: when.includes(`config.${DOCK_DETAIL_PANEL_SETTING}`),
+			hasEditorAreaVisibleGate: when.includes(MainEditorAreaVisibleContext.key),
+		}, {
+			group: 'navigation',
+			order: 99,
+			icon: Codicon.diffSidebyside.id,
+			toggled: EditorContextKeys.multiDiffEditorRenderSideBySide.negate().serialize(),
 			hasSessionsWindowGate: true,
 			hasActiveEditorGate: true,
 			hasSinglePaneConfigGate: true,


### PR DESCRIPTION
## What

Adds a **Toggle Inline View** action to the Agents window **Changes** editor title, and swaps the **Collapse All** action to **Expand All** when all diffs are collapsed — matching the multi-file diff editor in the VS Code editor window.

## Why

The Changes editor embeds a `MultiDiffEditorWidget` but had no way to switch between inline and side-by-side diff rendering, and only offered Collapse All (never the Expand All counterpart).

## How

- **Inline view is editor-local state, not a global setting.** `MultiDiffEditorWidget` gains an opt-in `renderSideBySide` override that also pins `useInlineViewWhenSpaceIsLimited` off so the toggle is deterministic regardless of the editor width. It's surfaced through a new `multiDiffEditorRenderSideBySide` context key for the action's checked state.
  - When the override is left unset (i.e. the normal editor-window multi-diff editor), the `diffEditor.renderSideBySide` setting drives everything exactly as before — no behavior change there, and no action/menu is registered in the editor contrib.
- **The Changes editor hosts its `MultiDiffEditorWidget` in the editor-pane context**, so the widget's own `multiDiffEditorAllCollapsed` / `multiDiffEditorRenderSideBySide` context keys are visible to the `EditorTitle` menu. This reuses the widget's existing state (collapse/render mode) instead of duplicating it, and fixes the collapse/expand-all swap + the toggle's checked state.
- The sessions layer owns the `ToggleInlineView` / `CollapseAll` / `ExpandAll` actions (gated to the single-pane Changes editor) and drives the shared widget capability.

## Notes for reviewers

- The workbench `MultiDiffEditor` (editor window) is intentionally left untouched — the override is opt-in and defaults to "follow the setting".
- Per-file diff-row toolbars only depend on `SessionChangesReviewedFilesContext` / `SessionChangesFileResourceContext` / `resourceScheme` (not `HasGitRepository` / `hasAgentSessionChanges`), so moving the widget to the pane context is safe; the header keeps using the scoped service for those keys.

`npm run typecheck-client`, `npm run valid-layers-check`, and ESLint on the changed files all pass.
