### PR TITLE
feat(chat): enhance model selection logic and session handling

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostModeSynchronizer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostModeSynchronizer.ts
@@ -9,6 +9,7 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { AgentSession } from '../../../../../../platform/agentHost/common/agentService.js';
 import { fromAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { agentHostAgentPickerStorageKey } from '../../../../../../platform/agentHost/common/customAgents.js';
+import { isUntitledChatSession } from '../../../common/model/chatUri.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../common/contributions.js';
 import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
@@ -98,6 +99,15 @@ export class AgentHostModeSynchronizer extends Disposable implements IWorkbenchC
 		const sessionResource = widget.viewModel?.sessionResource;
 		const backendSession = sessionResource ? this._resolveBackendSession(sessionResource) : undefined;
 		if (!sessionResource || !backendSession) {
+			return;
+		}
+
+		// The per-scheme stored agent is only a SEED for NEW (untitled) sessions — the same
+		// semantics as the Agents Window new-session picker. An established or restored session's
+		// agent is its own persisted mode, so applying the shared value here would override it
+		// (e.g. flipping the user's `Agent` to a stale custom agent the moment the backend session
+		// resolves on the first send).
+		if (!isUntitledChatSession(sessionResource)) {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -93,7 +93,7 @@ import { ILanguageModelChatMetadata, ILanguageModelChatMetadataAndIdentifier, IL
 import { ChatModelConfigurationStore } from './chatModelConfigurationStore.js';
 import { deserializeUntitledInputAttachments, deserializeUntitledInputState, serializeUntitledInputAttachments, serializeUntitledInputState } from './chatInputStatePersistence.js';
 import { IChatModelInputState, IChatRequestModeInfo, IInputModel, logChangesToStateModel } from '../../../common/model/chatModel.js';
-import { filterModelsForSession, findBestMatchingModel, findDefaultModel, hasModelsTargetingSession, isModelValidForSession, mergeModelsWithCache, resolveConfiguredModel, resolveModelFromSyncState, shouldResetModelToDefault, shouldResetOnModelListChange, shouldRestoreLateArrivingModel, shouldRestorePersistedModel } from './chatModelSelectionLogic.js';
+import { filterModelsForSession, findBestMatchingModel, findDefaultModel, hasModelsTargetingSession, isModelValidForSession, mergeModelsWithCache, resolveConfiguredModel, resolveModelFromSyncState, shouldDropAgnosticDraftModel, shouldPersistModelSelection, shouldResetModelToDefault, shouldResetOnModelListChange, shouldRestoreLateArrivingModel, shouldRestorePersistedModel, shouldRestorePerTypeModelOnSessionSwitch, shouldSuppressModelPersistenceOnSessionSwitch, shouldWaitForSessionModel } from './chatModelSelectionLogic.js';
 import { getChatSessionType, LocalChatSessionUri } from '../../../common/model/chatUri.js';
 import { IChatResponseViewModel, isResponseVM } from '../../../common/model/chatViewModel.js';
 import { IChatAgentService } from '../../../common/participants/chatAgents.js';
@@ -268,6 +268,11 @@ export interface IChatWidgetLocationInfo {
 
 export interface IChatModeChangeEvent {
 	readonly isUserInitiated: boolean;
+}
+
+interface IModelSelectionSessionSwitch {
+	readonly suppressPersistence: boolean;
+	readonly restorePerTypeModel: boolean;
 }
 
 const LEGACY_SHARED_INPUT_STATE_TAGS = new Set(['view', 'editor', 'quick']);
@@ -512,6 +517,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private chatSessionPickerContainer: HTMLElement | undefined;
 	private _lastSessionPickerAction: MenuItemAction | undefined;
 	private _lastSessionPickerOptions: IChatInputPickerOptions | undefined;
+	/**
+	 * One pending wait for a model choice that should beat temporary fallback models.
+	 * Examples are `chat.defaultModel`, a stored picker selection, or a restored session model; history-based preselection uses `_waitForSessionHistoryLanguageModel`.
+	 */
 	private readonly _waitForPersistedLanguageModel: MutableDisposable<IDisposable> = this._register(new MutableDisposable<IDisposable>());
 	private readonly _waitForSessionHistoryLanguageModel: MutableDisposable<IDisposable> = this._register(new MutableDisposable<IDisposable>());
 	private readonly _chatSessionOptionEmitters = this._register(new DisposableMap<string, Emitter<IChatSessionProviderOptionItem>>());
@@ -663,6 +672,11 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private _userExplicitlySelectedModel = false;
 	private _pendingDelegationTarget: AgentSessionTarget | undefined = undefined;
 	private _currentSessionType: string | undefined = undefined;
+	/**
+	 * Decisions for the session switch currently being wired through the input.
+	 * The object's presence does not mean persistence is suppressed or a restore is required; read its fields for those decisions.
+	 */
+	private _modelSelectionSessionSwitch: IModelSelectionSessionSwitch | undefined;
 
 	constructor(
 		// private readonly editorOptions: ChatEditorOptions, // TODO this should be used
@@ -912,12 +926,15 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				return;
 			}
 			if (shouldResetOnModelListChange(modelIdentifier, models)) {
+				// Keep the picker usable with a best match/default while an expected model is still loading,
+				// but do not store that temporary choice over the expected model.
+				const storeSelection = !this.hasPendingAuthoritativeModelWait();
 				// Carry the previous selection across pools when targeted models arrive late.
 				const match = findBestMatchingModel(this._currentLanguageModel.get(), models);
 				if (match) {
-					this.setCurrentLanguageModel(match);
+					this.setCurrentLanguageModel(match, false, storeSelection);
 				} else {
-					this.setCurrentLanguageModelToDefault();
+					this.setCurrentLanguageModelToDefault(undefined, storeSelection);
 				}
 			}
 			// The available-model set changed: re-evaluate whether sending is
@@ -948,6 +965,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			const modes = this._currentChatModesObservable.read(reader);
 			reader.store.add(modes.onDidChange(() => {
 				this.validateCurrentChatMode();
+				this._restorePersistedCustomModeIfAvailable();
 			}));
 		}));
 		this._register(autorun(r => {
@@ -1001,21 +1019,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private sessionTypeHasOwnModelPool(sessionType: string): boolean {
 		return this.chatSessionsService.requiresCustomModelsForSessionType(sessionType)
 			|| hasModelsTargetingSession(this.getAllMergedModels(), sessionType);
-	}
-
-	/**
-	 * Returns the persisted model for the current session type, if it exists in the current model pool.
-	 */
-	private _getRememberedSessionTypeModel(): ILanguageModelChatMetadataAndIdentifier | undefined {
-		const sessionType = this._currentSessionType;
-		if (!sessionType || !this.sessionTypeHasOwnModelPool(sessionType)) {
-			return undefined;
-		}
-		const persisted = this.storageService.get(this.getSelectedModelStorageKey(), StorageScope.APPLICATION);
-		if (!persisted) {
-			return undefined;
-		}
-		return this.getModels().find(m => m.identifier === persisted);
 	}
 
 	private initSelectedModel() {
@@ -1084,6 +1087,14 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				});
 			}
 		}
+	}
+
+	/**
+	 * Whether we are waiting for a specific model that should win once it appears.
+	 * Callers use this to avoid storing or validating temporary defaults while `chat.defaultModel`, a remembered picker selection, or a restored session model is still loading.
+	 */
+	private hasPendingAuthoritativeModelWait(): boolean {
+		return !!this._waitForPersistedLanguageModel.value;
 	}
 
 	public setEditing(enabled: boolean, editingSentRequest: ChatContextKeys.EditingRequestType | undefined) {
@@ -1437,10 +1448,22 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this._currentChatModesObservable.set(chatModes, undefined);
 		this.selectedToolsModel.resetSessionEnablementState();
 		this._chatSessionIsEmpty = chatSessionIsEmpty;
-		// A freshly bound session starts with no explicit in-conversation model
+		// A session that was just opened starts with no explicit in-conversation model
 		// pick, so the configured default (e.g. enterprise policy) is again allowed
 		// to win for a new empty conversation.
 		this._userExplicitlySelectedModel = false;
+
+		// Compute the model-selection decisions for this session switch. They are applied while the
+		// input and view model finish wiring together, then cleared in the view-model-change finally.
+		const ownsPool = !!this._currentSessionType && this.sessionTypeHasOwnModelPool(this._currentSessionType);
+		const hadIncomingModel = !!model.state.get()?.selectedModel;
+		this._modelSelectionSessionSwitch = {
+			suppressPersistence: shouldSuppressModelPersistenceOnSessionSwitch(chatSessionIsEmpty, ownsPool),
+			restorePerTypeModel: shouldRestorePerTypeModelOnSessionSwitch(chatSessionIsEmpty, ownsPool, hadIncomingModel),
+		};
+		// Drop any pending persisted-model wait from a PREVIOUS session so it can't later fire
+		// into this (or a subsequent) session's storage key.
+		this._waitForPersistedLanguageModel.clear();
 
 		if (chatSessionIsEmpty) {
 			const persistedState = model.state.get() ? undefined : this._getPersistedEmptyInputState();
@@ -1482,13 +1505,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			if (!state && this._chatSessionIsEmpty) {
 				state = this._getPersistedEmptyInputState();
 				message = `syncing from empty input state for ${forSessionResource.toString()}`;
-				// Seed model/config from the last-used selection for this session type (configured default still wins).
-				const rememberedSessionTypeModel = this._getRememberedSessionTypeModel();
-				if (rememberedSessionTypeModel) {
-					const base = state ?? this.getCurrentInputState();
-					const rememberedModelConfiguration = this._modelConfigStore.getModelConfiguration(rememberedSessionTypeModel.identifier);
-					state = { ...base, selectedModel: rememberedSessionTypeModel, modelConfiguration: rememberedModelConfiguration };
-				}
 				// A configured default model (e.g. set by enterprise policy via
 				// `chat.defaultModel`) starts every NEW conversation and
 				// must win over the remembered empty-input draft model. `initSelectedModel`
@@ -1551,6 +1567,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			...state,
 			attachments: persistedAttachments.length > 0 ? persistedAttachments : state.attachments,
 		};
+
+		if (shouldDropAgnosticDraftModel(state.selectedModel, this.getAllMergedModels(), this._currentSessionType)) {
+			state = { ...state, selectedModel: undefined, modelConfiguration: undefined };
+		}
 
 		// A configured default model starts every new conversation and wins over the remembered draft model.
 		if (this.getConfiguredModelValue()) {
@@ -1653,6 +1673,12 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 					const match = findBestMatchingModel(state.selectedModel, pool) ?? findBestMatchingModel(currentLm, pool);
 					if (match) {
 						this.setCurrentLanguageModel(match);
+					} else if (shouldWaitForSessionModel(state.selectedModel, sessionType, allModels)) {
+						// The session's remembered model belongs to this pool but has not been
+						// contributed yet (cold/partial pool at restore). Wait for it instead of
+						// persisting a transient pool default over it; while this wait is pending,
+						// the model-list-change reset also skips persistence.
+						this._waitForSessionModel(state.selectedModel, state.modelConfiguration, forSessionResource);
 					} else {
 						this.setCurrentLanguageModelToDefault(sessionType);
 					}
@@ -1697,6 +1723,25 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		} finally {
 			this._isSyncingToOrFromInputModel = false;
 		}
+	}
+
+	/**
+	 * Wait for a restored session's saved model when that model belongs to this session's pool but
+	 * has not been contributed yet. This uses the same authoritative wait slot so fallback/default
+	 * selections do not get stored while we wait, and it checks the session resource before applying.
+	 */
+	private _waitForSessionModel(desiredModel: ILanguageModelChatMetadataAndIdentifier, modelConfiguration: IStringDictionary<unknown> | undefined, forSessionResource: URI): void {
+		this._waitForPersistedLanguageModel.value = this.languageModelsService.onDidChangeLanguageModels(() => {
+			if (this._inputModelSessionResource?.toString() !== forSessionResource.toString()) {
+				return;
+			}
+			const liveModel = this.getAllMergedModels().find(m => m.identifier === desiredModel.identifier);
+			if (liveModel) {
+				this._waitForPersistedLanguageModel.clear();
+				this.restoreModelConfiguration(desiredModel.identifier, modelConfiguration);
+				this.setCurrentLanguageModel(liveModel);
+			}
+		});
 	}
 
 	/**
@@ -1753,10 +1798,11 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		}
 
 		// Store as global user preference (session-specific state is in the model's inputModel).
-		// `storeSelection: false` lets transient surfaces (e.g. the automations dialog
-		// applying an automation's saved model on open) apply the model to the input only,
-		// without overwriting the regular chat input's persisted selection.
-		if (storeSelection) {
+		// `storeSelection: false` lets transient surfaces (e.g. the automations dialog applying an
+		// automation's saved model on open) apply the model to the input only, without overwriting
+		// the regular chat input's persisted selection. The session-switch guard is documented on
+		// `_modelSelectionSessionSwitch` / `shouldPersistModelSelection`.
+		if (shouldPersistModelSelection(storeSelection, !!this._modelSelectionSessionSwitch?.suppressPersistence)) {
 			this.storageService.store(this.getSelectedModelStorageKey(), model.identifier, StorageScope.APPLICATION, StorageTarget.USER);
 			this.storageService.store(this.getSelectedModelIsDefaultStorageKey(), !!model.metadata.isDefaultForLocation[this.location], StorageScope.APPLICATION, StorageTarget.USER);
 		}
@@ -2062,7 +2108,9 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		const defaultModel = configuredModel ?? findDefaultModel(allModels, this.location);
 		logChangesToStateModel(this._inputModel, `[DEFAULT] setCurrentLanguageModelToDefault called (defaultModel=${defaultModel?.identifier}, configuredModel=${configuredModel?.identifier}, currentLm=${this._currentLanguageModel.get()?.identifier}, storeSelection=${storeSelection}) in ${this._currentSessionKey}`, undefined, this._inputModel?.state.get(), this.logService);
 		if (defaultModel) {
-			this.setCurrentLanguageModel(defaultModel, false, storeSelection);
+			// Apply the default in memory while an expected model is still loading, but do not store it.
+			const persist = storeSelection && !this.hasPendingAuthoritativeModelWait();
+			this.setCurrentLanguageModel(defaultModel, false, persist);
 		}
 	}
 
@@ -2204,6 +2252,26 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		if (currentMode.kind === ChatModeKind.Agent && !isAgentModeEnabled) {
 			this.setChatMode(ChatModeKind.Ask);
 			return;
+		}
+	}
+
+	/**
+	 * Re-apply the session's own persisted custom agent once its mode becomes available.
+	 *
+	 * A restored agent-host session persists its selected custom agent in `mode`, but the agent
+	 * host's custom modes only register after the backend connects. Until then `setChatMode` falls
+	 * back to the builtin Agent, so when the custom modes arrive (`modes.onDidChange`) re-apply the
+	 * persisted custom agent. Builtin/default modes are handled by {@link validateCurrentChatMode}.
+	 */
+	private _restorePersistedCustomModeIfAvailable(): void {
+		const persistedMode = this._inputModel?.state.get()?.mode;
+		if (!persistedMode) {
+			return;
+		}
+		const modes = this._currentChatModesObservable.get();
+		const found = modes.findModeById(persistedMode.id) ?? modes.findModeByName(persistedMode.id);
+		if (found && !found.isBuiltin && this._currentModeObservable.get().id !== found.id) {
+			this.setChatMode(found.id, false);
 		}
 	}
 
@@ -2901,6 +2969,103 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this.contextUsageWidget.update(model.lastRequest, model.sessionCost);
 	}
 
+	private handleViewModelChange(e: IChatWidgetViewModelChangeEvent): void {
+		try {
+			this.resetPendingDelegationForViewModelChange();
+			this.refreshViewModelScopedState();
+			this.clearQuestionCarouselIfSessionChanged(e);
+			this.clearPlanReviewIfSessionChanged(e);
+			// Swap the visible tool confirmation carousel for the new session
+			this._syncToolConfirmationCarouselForSession();
+			this.reconcileSessionTypeForViewModelChange(e);
+			// For contributed sessions with history, pre-select the model
+			// from the last request so the user resumes with the same model.
+			this.preselectModelFromSessionHistory();
+		} finally {
+			// Always finish the session switch, even on an exception before this point, so an
+			// explicit user model pick after the switch persists normally.
+			this._modelSelectionSessionSwitch = undefined;
+		}
+	}
+
+	private resetPendingDelegationForViewModelChange(): void {
+		this._pendingDelegationTarget = undefined;
+		this.chatHasPendingDelegationTargetKey.set(false);
+	}
+
+	private refreshViewModelScopedState(): void {
+		// Update agentSessionType when view model changes
+		this.updateAgentSessionTypeContextKey();
+		this.refreshChatSessionPickers();
+		this.ensureNotificationWidget();
+		this.updateContextUsageWidget();
+	}
+
+	private clearQuestionCarouselIfSessionChanged(e: IChatWidgetViewModelChangeEvent): void {
+		let hasMatchingResource = false;
+		if (e.currentSessionResource) {
+			for (const r of this._questionCarouselSessionResources.values()) {
+				if (isEqual(r, e.currentSessionResource)) {
+					hasMatchingResource = true;
+					break;
+				}
+			}
+		}
+		if (this._questionCarouselSessionResources.size > 0 && (!e.currentSessionResource || !hasMatchingResource)) {
+			this.clearQuestionCarousel();
+		}
+	}
+
+	private clearPlanReviewIfSessionChanged(e: IChatWidgetViewModelChangeEvent): void {
+		let hasMatchingPlanReviewResource = false;
+		if (e.currentSessionResource) {
+			for (const r of this._planReviewSessionResources.values()) {
+				if (isEqual(r, e.currentSessionResource)) {
+					hasMatchingPlanReviewResource = true;
+					break;
+				}
+			}
+		}
+		if (this._planReviewSessionResources.size > 0 && (!e.currentSessionResource || !hasMatchingPlanReviewResource)) {
+			this.clearPlanReview();
+		}
+	}
+
+	private reconcileSessionTypeForViewModelChange(e: IChatWidgetViewModelChangeEvent): void {
+		// Track the current session type and re-initialize model selection
+		// when the session type changes (different session types may have
+		// different model pools via targetChatSessionType).
+		const newSessionType = this.getCurrentSessionType();
+		if (e.currentSessionResource && this._currentSessionType && newSessionType !== this._currentSessionType) {
+			logChangesToStateModel(this._inputModel, `[CVVM].1 onDidChangeViewModel -> session change: ${this._currentSessionType} -> ${newSessionType} in ${this._currentSessionKey}, ${e.currentSessionResource.toString()}`, undefined, this._inputModel?.state.get(), this.logService);
+			this._currentSessionType = newSessionType;
+			this.initSelectedModel();
+			this.checkModelInSessionPool();
+			this.checkModeInSessionPool();
+			this._notificationWidget.value?.rerender();
+		} else if (e.currentSessionResource) {
+			logChangesToStateModel(this._inputModel, `[CVVM].2 onDidChangeViewModel -> session change: ${this._currentSessionType} -> ${newSessionType} in ${this._currentSessionKey}, ${e.currentSessionResource.toString()}`, undefined, this._inputModel?.state.get(), this.logService);
+			this._currentSessionType = newSessionType;
+			this.restorePerTypeModelAfterViewModelAssignment();
+		}
+	}
+
+	private restorePerTypeModelAfterViewModelAssignment(): void {
+		// Fresh untitled own-pool session: `setInputModel` pre-advanced `_currentSessionType`
+		// before this event, so the branch above can't detect it. The view model is now
+		// assigned, so `getCurrentSessionType()` is correct and it is safe to restore the
+		// remembered per-session-type model. Persistence is still suppressed for this
+		// switch, so this only updates the picker — the intact per-type key is not rewritten.
+		// If the remembered model has not loaded yet, skip pool validation so the picker does not
+		// move away from the model that will be applied when it appears.
+		if (this._modelSelectionSessionSwitch?.restorePerTypeModel) {
+			this.initSelectedModel();
+			if (!this.hasPendingAuthoritativeModelWait()) {
+				this.checkModelInSessionPool();
+			}
+		}
+	}
+
 	render(container: HTMLElement, initialValue: string, widget: IChatWidget) {
 		this._widget = widget;
 		this.getVisibleOptionGroupsModeAndUpdateContextKeys(this.getCurrentSessionResource());
@@ -2914,63 +3079,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			}
 		}
 
-		this._register(widget.onDidChangeViewModel((e: IChatWidgetViewModelChangeEvent) => {
-			this._pendingDelegationTarget = undefined;
-			this.chatHasPendingDelegationTargetKey.set(false);
-			// Update agentSessionType when view model changes
-			this.updateAgentSessionTypeContextKey();
-			this.refreshChatSessionPickers();
-			this.ensureNotificationWidget();
-			this.updateContextUsageWidget();
-			let hasMatchingResource = false;
-			if (e.currentSessionResource) {
-				for (const r of this._questionCarouselSessionResources.values()) {
-					if (isEqual(r, e.currentSessionResource)) {
-						hasMatchingResource = true;
-						break;
-					}
-				}
-			}
-			if (this._questionCarouselSessionResources.size > 0 && (!e.currentSessionResource || !hasMatchingResource)) {
-				this.clearQuestionCarousel();
-			}
-
-			let hasMatchingPlanReviewResource = false;
-			if (e.currentSessionResource) {
-				for (const r of this._planReviewSessionResources.values()) {
-					if (isEqual(r, e.currentSessionResource)) {
-						hasMatchingPlanReviewResource = true;
-						break;
-					}
-				}
-			}
-			if (this._planReviewSessionResources.size > 0 && (!e.currentSessionResource || !hasMatchingPlanReviewResource)) {
-				this.clearPlanReview();
-			}
-
-			// Swap the visible tool confirmation carousel for the new session
-			this._syncToolConfirmationCarouselForSession();
-
-			// Track the current session type and re-initialize model selection
-			// when the session type changes (different session types may have
-			// different model pools via targetChatSessionType).
-			const newSessionType = this.getCurrentSessionType();
-			if (e.currentSessionResource && this._currentSessionType && newSessionType !== this._currentSessionType) {
-				logChangesToStateModel(this._inputModel, `[CVVM].1 onDidChangeViewModel -> session change: ${this._currentSessionType} -> ${newSessionType} in ${this._currentSessionKey}, ${e.currentSessionResource.toString()}`, undefined, this._inputModel?.state.get(), this.logService);
-				this._currentSessionType = newSessionType;
-				this.initSelectedModel();
-				this.checkModelInSessionPool();
-				this.checkModeInSessionPool();
-				this._notificationWidget.value?.rerender();
-			} else if (e.currentSessionResource) {
-				logChangesToStateModel(this._inputModel, `[CVVM].2 onDidChangeViewModel -> session change: ${this._currentSessionType} -> ${newSessionType} in ${this._currentSessionKey}, ${e.currentSessionResource.toString()}`, undefined, this._inputModel?.state.get(), this.logService);
-				this._currentSessionType = newSessionType;
-			}
-
-			// For contributed sessions with history, pre-select the model
-			// from the last request so the user resumes with the same model.
-			this.preselectModelFromSessionHistory();
-		}));
+		this._register(widget.onDidChangeViewModel(e => this.handleViewModelChange(e)));
 
 		let elements;
 		if (this.options.renderStyle === 'compact') {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelSelectionLogic.ts
@@ -100,6 +100,89 @@ export function isModelValidForSession(
 }
 
 /**
+ * Whether the selected model carried by the shared, session-type-agnostic untitled draft
+ * (`chat.untitledInputState`) must be dropped before the draft is applied to an empty session
+ * that is being opened.
+ *
+ * The draft is shared across all session types, so its `selectedModel` can belong to a
+ * different pool in either direction — e.g. a `copilot/*` model leaking into an agent-host
+ * session, or an `agent-host-*` model leaking into a general/local session. Applying such a
+ * cross-pool model while the session is opening lets the sync resolve it to (and persist) a
+ * wrong default over the destination pool's persisted model. Dropped when present but not valid
+ * for `sessionType`; an in-pool draft model is kept. See
+ * `chatInputPart._getPersistedEmptyInputState`.
+ */
+export function shouldDropAgnosticDraftModel(
+	draftModel: ILanguageModelChatMetadataAndIdentifier | undefined,
+	allModels: ILanguageModelChatMetadataAndIdentifier[],
+	sessionType: string | undefined,
+): boolean {
+	return !!draftModel && !isModelValidForSession(draftModel, allModels, sessionType);
+}
+
+/**
+ * Whether an {@link ILanguageModelChatMetadataAndIdentifier} selection should be written to the
+ * persisted per-(location, sessionType) model storage key.
+ *
+ * A model selection is only persisted for an explicit request (`storeSelection`) that is NOT
+ * happening while the input is switching to a session (`suppressDuringSessionSwitch`). While
+ * switching, the model may be set in-memory (for the picker) and restored from the key, but must
+ * never WRITE the key — only an explicit user action may. This is the single guard on
+ * `chatInputPart`'s sole storage writer (`setCurrentLanguageModel`).
+ */
+export function shouldPersistModelSelection(storeSelection: boolean, suppressDuringSessionSwitch: boolean): boolean {
+	return storeSelection && !suppressDuringSessionSwitch;
+}
+
+/**
+ * Whether model-selection persistence must be suppressed while the input switches to a session.
+ *
+ * True for every empty session of an own-pool (agent-host) session type: the per-type key holds
+ * the user's last explicit pick, and switching to the session must not clobber it via any of the
+ * paths that run during the switch (draft sync, empty-state seeding, autorun default).
+ * General/local (no own pool) is unaffected.
+ */
+export function shouldSuppressModelPersistenceOnSessionSwitch(isEmpty: boolean, sessionOwnsPool: boolean): boolean {
+	return isEmpty && sessionOwnsPool;
+}
+
+/**
+ * Whether the persisted per-session-type model should be restored (into the picker) when the
+ * input switches to a session.
+ *
+ * True only for a FRESH untitled own-pool session — one with no incoming `selectedModel` in its
+ * own input state. A session that already carries its own model (a transferred/handoff or
+ * startup-restored draft) keeps that model in-memory and is left alone. Distinct from
+ * {@link shouldSuppressModelPersistenceOnSessionSwitch}, which suppresses the STORAGE write for
+ * ALL empty own-pool sessions regardless.
+ */
+export function shouldRestorePerTypeModelOnSessionSwitch(isEmpty: boolean, sessionOwnsPool: boolean, hadIncomingModel: boolean): boolean {
+	return isEmpty && sessionOwnsPool && !hadIncomingModel;
+}
+
+/**
+ * Whether the input should WAIT for a restored session's own remembered model to be contributed,
+ * instead of falling back to the pool default.
+ *
+ * True when the session's remembered `desiredModel` belongs to this session's own pool (it
+ * targets `sessionType`) but is not yet present in `allModels` — i.e. the session-type pool has
+ * not finished loading at restore time (cold or partial). Waiting avoids persisting a transient
+ * pool default (e.g. Haiku) over the session's remembered model (e.g. Opus) while the pool
+ * settles. A model that does not belong to this session's pool returns false, so the caller
+ * defaults instead of waiting forever.
+ */
+export function shouldWaitForSessionModel(
+	desiredModel: ILanguageModelChatMetadataAndIdentifier,
+	sessionType: string | undefined,
+	allModels: ILanguageModelChatMetadataAndIdentifier[],
+): boolean {
+	if (!sessionType || desiredModel.metadata.targetChatSessionType !== sessionType) {
+		return false;
+	}
+	return !allModels.some(m => m.identifier === desiredModel.identifier);
+}
+
+/**
  * Find a model in `pool` that matches `previous` by id, then family, then
  * name (case-insensitive). Used to carry a selection across model pools
  * (e.g. `copilot/claude-sonnet-4.6` → `agent-host-copilotcli:claude-sonnet-4.6`).

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -122,6 +122,40 @@ class CancellableRequest implements IDisposable {
 const EMPTY_REFERENCES: ReadonlyArray<IDynamicVariable> = Object.freeze([]);
 const EMPTY_TOOL_ENABLEMENT_MAP: ToolAndToolSetEnablementMap = ToolAndToolSetEnablementMap.fromEntries([]);
 
+/**
+ * Fill in the picker selections (`selectedModel`, `mode`) that `stateToApply` is missing, using
+ * the session's previously `savedState`.
+ *
+ * `stateToApply` is the input state about to be applied to the session being restored (an
+ * agent-host transferred draft, or the saved draft as a fallback). `savedState` is the session's
+ * own previously saved input state. At cold restore `stateToApply` can lose these two picker
+ * selections, so take them from `savedState`:
+ * - `selectedModel`: `stateToApply` leaves it undefined when the model is not registered yet (the
+ *   agent-host model list has not loaded). `savedState` keeps the full model (id + capabilities),
+ *   so use it. The input part re-validates it against the live model list and re-resolves it once
+ *   the list loads, so a genuinely stale/wrong model is still dropped safely.
+ * - `mode`: `stateToApply` falls back to the default Agent when it did not capture the user's
+ *   custom agent. Prefer the custom agent from `savedState`, but only promote it OVER the plain
+ *   default Agent — never override a different explicit mode.
+ */
+export function backfillRestoredPickerState(
+	stateToApply: ISerializableChatModelInputState | undefined,
+	savedState: ISerializableChatModelInputState | undefined,
+	defaultAgentModeId: string,
+): ISerializableChatModelInputState | undefined {
+	if (!stateToApply || !savedState) {
+		return stateToApply;
+	}
+	const selectedModel = stateToApply.selectedModel ?? savedState.selectedModel;
+	const mode = (stateToApply.mode.id === defaultAgentModeId && savedState.mode.id !== defaultAgentModeId)
+		? savedState.mode
+		: stateToApply.mode;
+	if (selectedModel === stateToApply.selectedModel && mode === stateToApply.mode) {
+		return stateToApply;
+	}
+	return { ...stateToApply, selectedModel, mode };
+}
+
 export class ChatService extends Disposable implements IChatService {
 	declare _serviceBrand: undefined;
 
@@ -698,13 +732,18 @@ export class ChatService extends Disposable implements IChatService {
 		const restoredDraft: ISerializableChatModelInputState | undefined = storedInputState
 			? { ...storedInputState, selectedModel: historyDerivedModel }
 			: undefined;
+		// At cold restore the agent-host transferred draft can drop the user's per-session picker
+		// selections (model/mode); restore them from the session's own saved `storedInputState`
+		// (see {@link backfillRestoredPickerState}).
+		const stateToApply = providedSession.transferredState?.inputState ?? restoredDraft;
+		const inputState = backfillRestoredPickerState(stateToApply, storedInputState, ChatMode.Agent.id);
 		const modelRef = this._sessionModels.acquireOrCreate({
 			initialData,
 			location,
 			sessionResource: sessionResource,
 			canUseTools: false,
 			transferEditingSession: providedSession.transferredState?.editingSession,
-			inputState: providedSession.transferredState?.inputState ?? restoredDraft,
+			inputState,
 		}, debugOwner ?? 'ChatService#loadRemoteSession');
 
 		logChangesToStateModel(modelRef.object.inputModel, `loadRemoteSession inputState source: session=${sessionResource.toString()}, chatSessionType=${chatSessionType}, historyModelId=${modelId}, agentUri=${agentUri?.toString()}, historySelectedModel=${historySelectedModel}, transferredSelectedModel=${providedSession.transferredState?.inputState?.selectedModel?.identifier}, storedSelectedModel=${storedInputState?.selectedModel?.identifier}, finalSelectedModel=${modelRef.object.inputModel.state.get()?.selectedModel?.identifier}, hasTransferredInputState=${!!providedSession.transferredState?.inputState}, hasStoredInputState=${!!storedInputState}, hasInitialData=${!!initialData}`, modelRef.object.inputModel.state.get(), undefined, this.logService);

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostModeSynchronizer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostModeSynchronizer.test.ts
@@ -47,7 +47,7 @@ suite('AgentHostModeSynchronizer', () => {
 		};
 	}
 
-	function createSynchronizer(initialMode: IChatMode, initialCustomModes: readonly IChatMode[] = []) {
+	function createSynchronizer(initialMode: IChatMode, initialCustomModes: readonly IChatMode[] = [], resource: URI = sessionResource) {
 		let customModes = [...initialCustomModes];
 		const modeChanges = store.add(new Emitter<IChatModeChangeEvent>());
 		const modesChanges = store.add(new Emitter<void>());
@@ -57,7 +57,7 @@ suite('AgentHostModeSynchronizer', () => {
 		const setChatModeCalls: string[] = [];
 
 		const widget = {
-			viewModel: { sessionResource },
+			viewModel: { sessionResource: resource },
 			input: {
 				onDidChangeCurrentChatMode: modeChanges.event,
 				currentModeObs: mode,
@@ -77,7 +77,7 @@ suite('AgentHostModeSynchronizer', () => {
 			getAllWidgets: () => [widget],
 			onDidAddWidget: Event.None,
 			onDidChangeFocusedSession: Event.None,
-			getWidgetBySessionResource: (resource: URI) => resource.toString() === sessionResource.toString() ? widget : undefined,
+			getWidgetBySessionResource: (r: URI) => r.toString() === resource.toString() ? widget : undefined,
 			lastFocusedWidget: widget,
 		} as unknown as IChatWidgetService;
 
@@ -122,8 +122,12 @@ suite('AgentHostModeSynchronizer', () => {
 	});
 
 	test('retries restore when custom modes load late', async () => {
-		const { modesChanges, setChatModeCalls, setCustomModes, storageService } = createSynchronizer(ChatMode.Agent);
-		storageService.store(agentHostAgentPickerStorageKey(sessionResource.scheme), agentUri, StorageScope.PROFILE, StorageTarget.MACHINE);
+		// The synchronizer only SEEDS the shared per-scheme agent into untitled (new) sessions;
+		// established sessions restore their own persisted mode elsewhere (ChatInputPart). Use an
+		// untitled resource so this exercises the seed-retry path when custom modes load late.
+		const untitledResource = URI.parse('agent-host-claude:/untitled-session-1');
+		const { modesChanges, setChatModeCalls, setCustomModes, storageService } = createSynchronizer(ChatMode.Agent, [], untitledResource);
+		storageService.store(agentHostAgentPickerStorageKey(untitledResource.scheme), agentUri, StorageScope.PROFILE, StorageTarget.MACHINE);
 
 		await timeout(0);
 		assert.deepStrictEqual(setChatModeCalls, []);
@@ -133,5 +137,20 @@ suite('AgentHostModeSynchronizer', () => {
 		await timeout(0);
 
 		assert.deepStrictEqual(setChatModeCalls, [agentUri]);
+	});
+
+	test('does not restore the shared per-scheme agent to an established (non-untitled) session', async () => {
+		// Regression for the "custom agent picker flips to a stale agent after send" bug: the
+		// shared per-scheme agent is a seed for NEW sessions only, so an established/restored
+		// session must never have it applied — even when its custom modes load late.
+		const { modesChanges, setChatModeCalls, setCustomModes, storageService } = createSynchronizer(ChatMode.Agent);
+		storageService.store(agentHostAgentPickerStorageKey(sessionResource.scheme), agentUri, StorageScope.PROFILE, StorageTarget.MACHINE);
+
+		await timeout(0);
+		setCustomModes([createCustomMode()]);
+		modesChanges.fire();
+		await timeout(0);
+
+		assert.deepStrictEqual(setChatModeCalls, []);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionLogic.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelSelectionLogic.test.ts
@@ -21,10 +21,15 @@ import {
 	mergeModelsWithCache,
 	resolveConfiguredModel,
 	resolveModelFromSyncState,
+	shouldDropAgnosticDraftModel,
+	shouldPersistModelSelection,
 	shouldResetModelToDefault,
 	shouldResetOnModelListChange,
 	shouldRestoreLateArrivingModel,
 	shouldRestorePersistedModel,
+	shouldRestorePerTypeModelOnSessionSwitch,
+	shouldSuppressModelPersistenceOnSessionSwitch,
+	shouldWaitForSessionModel,
 } from '../../../../browser/widget/input/chatModelSelectionLogic.js';
 
 /**
@@ -1839,6 +1844,229 @@ suite('ChatModelSelectionLogic', () => {
 
 		test('accepts a Set of live ids', () => {
 			assert.strictEqual(reason({ trusted: true, requiresSetup: true, pickerModels: [gpt], liveModelIds: new Set([gpt.identifier]) }), undefined);
+		});
+	});
+
+	/**
+	 * Regression coverage for the "new/reused agent-host chat editor reverts the model to the
+	 * pool default (Auto/Haiku) instead of the remembered per-harness model, AND corrupts the
+	 * persisted per-type key so it's wrong after restart too" bug.
+	 *
+	 * The fix's invariant: switching the input to a session must never WRITE the per-session-type
+	 * model storage key; it may only set the model in-memory and RESTORE it from the key. Only an
+	 * explicit user action (after the switch completes) persists. These tests lock the extracted
+	 * decisions plus a storage-write "ledger" that replays the real session-switch sequence —
+	 * including a NEGATIVE control that reproduces the v1 hazard (persisting during the switch) to
+	 * prove the ledger genuinely catches it rather than being theatre.
+	 *
+	 * NOTE: `ChatInputPart` has 29 DI dependencies and no unit harness, so these tests exercise
+	 * the extracted pure decisions and a faithful sequence simulation, not the DOM wiring.
+	 * Manual repro (pick a model, open a new editor, restart) remains the final gate.
+	 */
+	suite('agent-host per-type model restore on session switch (regression)', () => {
+		const sessionType = 'agent-host-claude';
+		const perTypeKey = `chat.currentLanguageModel.panel.${sessionType}`;
+		const generalKey = 'chat.currentLanguageModel.panel';
+
+		// Cross-pool draft model leaked from a prior general chat.
+		const agnosticAuto = createModel('auto', 'Auto'); // `copilot/auto`, no target
+		// The agent-host pool: its own default + the user's picked Opus.
+		const agentHostHaiku: ILanguageModelChatMetadataAndIdentifier = {
+			...createSessionModel('claude-haiku-4.5', 'Claude Haiku 4.5', sessionType, { isDefaultForLocation: { [ChatAgentLocation.Chat]: true } }),
+			identifier: 'agent-host-claude:claude-haiku-4.5',
+		};
+		const agentHostOpus: ILanguageModelChatMetadataAndIdentifier = {
+			...createSessionModel('claude-opus-4.8', 'Claude Opus 4.8', sessionType),
+			identifier: 'agent-host-claude:claude-opus-4.8',
+		};
+		const agentHostPool = [agentHostHaiku, agentHostOpus];
+		const allMerged = [agnosticAuto, agentHostHaiku, agentHostOpus];
+
+		suite('predicates', () => {
+			test('suppress persistence for every empty own-pool session switch (regardless of incoming model)', () => {
+				assert.strictEqual(shouldSuppressModelPersistenceOnSessionSwitch(true, true), true);   // fresh own-pool
+				assert.strictEqual(shouldSuppressModelPersistenceOnSessionSwitch(false, true), false);  // non-empty (reopened)
+				assert.strictEqual(shouldSuppressModelPersistenceOnSessionSwitch(true, false), false);  // general/local
+			});
+
+			test('restore per-type model only for a FRESH untitled own-pool session (no incoming model)', () => {
+				assert.strictEqual(shouldRestorePerTypeModelOnSessionSwitch(true, true, false), true);   // fresh untitled
+				assert.strictEqual(shouldRestorePerTypeModelOnSessionSwitch(true, true, true), false);   // carries its own model (transfer/restored)
+				assert.strictEqual(shouldRestorePerTypeModelOnSessionSwitch(false, true, false), false); // non-empty
+				assert.strictEqual(shouldRestorePerTypeModelOnSessionSwitch(true, false, false), false); // general/local
+			});
+
+			test('persist a model selection only when requested AND not during a session switch', () => {
+				assert.strictEqual(shouldPersistModelSelection(true, false), true);   // explicit user pick, no switch
+				assert.strictEqual(shouldPersistModelSelection(true, true), false);   // during a switch → never persist
+				assert.strictEqual(shouldPersistModelSelection(false, false), false); // transient (storeSelection=false)
+			});
+
+			test('drop a cross-pool draft model in either direction; keep an in-pool one', () => {
+				assert.strictEqual(shouldDropAgnosticDraftModel(agnosticAuto, allMerged, sessionType), true);   // general model → agent-host session
+				assert.strictEqual(shouldDropAgnosticDraftModel(agentHostOpus, allMerged, undefined), true);    // agent-host model → general session (reverse leak)
+				assert.strictEqual(shouldDropAgnosticDraftModel(agentHostOpus, allMerged, sessionType), false); // in-pool
+				assert.strictEqual(shouldDropAgnosticDraftModel(undefined, allMerged, sessionType), false);     // no draft model
+			});
+		});
+
+		/**
+		 * Faithful storage-write ledger: writes a key only when {@link shouldPersistModelSelection}
+		 * allows, exactly like `chatInputPart.setCurrentLanguageModel`. Returns the in-memory model
+		 * and the storage map so tests can assert both the picker value and the persisted key.
+		 */
+		function runSessionSwitchSequence(opts: {
+			isEmpty: boolean;
+			ownsPool: boolean;
+			hadIncomingModel: boolean;
+			key: string;
+			storedModel: ILanguageModelChatMetadataAndIdentifier | undefined; // persisted per-type value at bind time
+			draftModel: ILanguageModelChatMetadataAndIdentifier | undefined;  // shared agnostic draft's model
+			pool: ILanguageModelChatMetadataAndIdentifier[];                  // models available to this session at bind
+			poolDefault: ILanguageModelChatMetadataAndIdentifier;
+			startingInMemory: ILanguageModelChatMetadataAndIdentifier;        // reused-widget stale model
+			/** When true, reproduce the v1 hazard: never suppress persistence during the bind. */
+			persistDuringSessionSwitch?: boolean;
+		}): { storage: Map<string, string>; inMemory: ILanguageModelChatMetadataAndIdentifier; keyAfterSessionSwitch: string | undefined } {
+			const storage = new Map<string, string>();
+			if (opts.storedModel) {
+				storage.set(opts.key, opts.storedModel.identifier);
+			}
+			let inMemory = opts.startingInMemory;
+
+			const suppress = opts.persistDuringSessionSwitch ? false : shouldSuppressModelPersistenceOnSessionSwitch(opts.isEmpty, opts.ownsPool);
+			const restore = shouldRestorePerTypeModelOnSessionSwitch(opts.isEmpty, opts.ownsPool, opts.hadIncomingModel);
+
+			const setModel = (model: ILanguageModelChatMetadataAndIdentifier, storeSelection: boolean) => {
+				inMemory = model;
+				if (shouldPersistModelSelection(storeSelection, suppress)) {
+					storage.set(opts.key, model.identifier);
+				}
+			};
+
+			// 1. Draft sync during the switch. A cross-pool draft model is stripped, so the switch
+			//    falls back to the pool default; an in-pool draft model would apply as-is.
+			const draftModel = shouldDropAgnosticDraftModel(opts.draftModel, opts.pool, opts.ownsPool ? sessionType : undefined)
+				? undefined
+				: opts.draftModel;
+			if (draftModel) {
+				setModel(draftModel, /*storeSelection*/ true);
+			} else {
+				// _syncFromModel/_setEmptyModelState land on the pool default during the switch.
+				setModel(opts.poolDefault, /*storeSelection*/ true);
+			}
+
+			// Snapshot of the key at the end of the switch, BEFORE the authoritative restore.
+			// The invariant is that a correct (suppressed) switch leaves this equal to the stored
+			// value; the v1 hazard clobbers it here.
+			const keyAfterSessionSwitch = storage.get(opts.key);
+
+			// 2. [CVVM].2 restore (view model now assigned; session type correct).
+			if (restore && opts.storedModel && opts.pool.some(m => m.identifier === opts.storedModel!.identifier)) {
+				setModel(opts.storedModel, /*storeSelection*/ true);
+			}
+
+			return { storage, inMemory, keyAfterSessionSwitch };
+		}
+
+		test('Repro A (copilotcli-style): cross-pool `auto` draft, key=Opus → key stays Opus, picker=Opus', () => {
+			const { storage, inMemory, keyAfterSessionSwitch } = runSessionSwitchSequence({
+				isEmpty: true, ownsPool: true, hadIncomingModel: false,
+				key: perTypeKey, storedModel: agentHostOpus, draftModel: agnosticAuto,
+				pool: agentHostPool, poolDefault: agentHostHaiku, startingInMemory: agnosticAuto,
+			});
+			assert.strictEqual(keyAfterSessionSwitch, agentHostOpus.identifier, 'no write during the switch may reach the per-type key');
+			assert.strictEqual(storage.get(perTypeKey), agentHostOpus.identifier, 'per-type key must not be clobbered during the switch');
+			assert.strictEqual(inMemory.identifier, agentHostOpus.identifier, 'picker must show the remembered Opus');
+		});
+
+		test('Repro B (reused widget): stale in-memory Haiku, key=Opus → key stays Opus, picker=Opus', () => {
+			const { storage, inMemory } = runSessionSwitchSequence({
+				isEmpty: true, ownsPool: true, hadIncomingModel: false,
+				key: perTypeKey, storedModel: agentHostOpus, draftModel: undefined,
+				pool: agentHostPool, poolDefault: agentHostHaiku, startingInMemory: agentHostHaiku,
+			});
+			assert.strictEqual(storage.get(perTypeKey), agentHostOpus.identifier);
+			assert.strictEqual(inMemory.identifier, agentHostOpus.identifier);
+		});
+
+		test('a session that carries its own model (transfer/restored) keeps it and does not clobber the key', () => {
+			const { storage, inMemory } = runSessionSwitchSequence({
+				isEmpty: true, ownsPool: true, hadIncomingModel: true, // has its own model
+				key: perTypeKey, storedModel: agentHostOpus, draftModel: agentHostHaiku,
+				pool: agentHostPool, poolDefault: agentHostHaiku, startingInMemory: agentHostHaiku,
+			});
+			// Suppression still on (empty own-pool) → key not written during the switch; restore skipped → keeps its own Haiku.
+			assert.strictEqual(storage.get(perTypeKey), agentHostOpus.identifier, 'key preserved');
+			assert.strictEqual(inMemory.identifier, agentHostHaiku.identifier, 'incoming model honored in-memory');
+		});
+
+		test('cold pool on session switch: restore is deferred and the key is not clobbered', () => {
+			// Pool empty during the switch (targeted models not loaded). Restore can't resolve yet;
+			// the switch falls to (a suppressed) default and the key stays Opus for the late wait to restore.
+			const { storage } = runSessionSwitchSequence({
+				isEmpty: true, ownsPool: true, hadIncomingModel: false,
+				key: perTypeKey, storedModel: agentHostOpus, draftModel: agnosticAuto,
+				pool: [], poolDefault: agentHostHaiku, startingInMemory: agnosticAuto,
+			});
+			assert.strictEqual(storage.get(perTypeKey), agentHostOpus.identifier);
+		});
+
+		test('reverse leak: an agent-host model in the general draft does not clobber the general key', () => {
+			const generalGpt = createDefaultModelForLocation('gpt', 'GPT', ChatAgentLocation.Chat);
+			const { storage } = runSessionSwitchSequence({
+				isEmpty: true, ownsPool: false, hadIncomingModel: false, // general/local session
+				key: generalKey, storedModel: generalGpt, draftModel: agentHostOpus,
+				pool: [generalGpt], poolDefault: generalGpt, startingInMemory: generalGpt,
+			});
+			// A general session switch is NOT suppressed, but the cross-pool agent-host draft model
+			// is stripped, so the general default (== stored) applies and the general key is not corrupted.
+			assert.strictEqual(storage.get(generalKey), generalGpt.identifier);
+		});
+
+		test('NEGATIVE control: reproducing the v1 hazard (persist during the switch) DOES clobber the key', () => {
+			// Proves the ledger is a genuine guard: with persistence NOT suppressed during the switch
+			// (the v1 behavior), the cross-pool `auto` draft resolves to the pool default and
+			// overwrites the remembered Opus during the switch — exactly the reported corruption.
+			// (The later restore step is what v1's mistimed init defeated; the faithful signal is
+			// the key state at the end of the switch.)
+			const { keyAfterSessionSwitch } = runSessionSwitchSequence({
+				isEmpty: true, ownsPool: true, hadIncomingModel: false,
+				key: perTypeKey, storedModel: agentHostOpus, draftModel: agnosticAuto,
+				pool: agentHostPool, poolDefault: agentHostHaiku, startingInMemory: agnosticAuto,
+				persistDuringSessionSwitch: true,
+			});
+			assert.strictEqual(keyAfterSessionSwitch, agentHostHaiku.identifier, 'v1 clobbers the key to the pool default during the switch');
+			assert.notStrictEqual(keyAfterSessionSwitch, agentHostOpus.identifier);
+		});
+
+		/**
+		 * Cold-restore wait: a restored session persists its own model (e.g. Opus), but at restart
+		 * the agent-host pool loads late. `shouldWaitForSessionModel` decides whether to WAIT for
+		 * the session's own model to arrive instead of persisting a transient pool default (Haiku)
+		 * over it — the second half of the "reverts to Haiku after restart" fix.
+		 */
+		suite('shouldWaitForSessionModel (cold-restore wait)', () => {
+			test('waits when the session model targets this pool but is not loaded yet', () => {
+				// Cold pool: nothing loaded.
+				assert.strictEqual(shouldWaitForSessionModel(agentHostOpus, sessionType, []), true);
+				// Partial pool: the pool default (Haiku) loaded but the remembered Opus has not.
+				assert.strictEqual(shouldWaitForSessionModel(agentHostOpus, sessionType, [agnosticAuto, agentHostHaiku]), true);
+			});
+
+			test('does NOT wait once the session model is available (normal apply path handles it)', () => {
+				assert.strictEqual(shouldWaitForSessionModel(agentHostOpus, sessionType, allMerged), false);
+			});
+
+			test('does NOT wait for a model that does not belong to this session pool (would wait forever)', () => {
+				// A general/cross-pool model in an agent-host session: not our pool → default instead.
+				assert.strictEqual(shouldWaitForSessionModel(agnosticAuto, sessionType, [agentHostHaiku]), false);
+				// A model targeting a DIFFERENT agent-host type.
+				const otherType = { ...agentHostOpus, metadata: { ...agentHostOpus.metadata, targetChatSessionType: 'agent-host-copilotcli' } };
+				assert.strictEqual(shouldWaitForSessionModel(otherType, sessionType, []), false);
+				// No session type at all.
+				assert.strictEqual(shouldWaitForSessionModel(agentHostOpus, undefined, []), false);
+			});
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -46,11 +46,11 @@ import { IChatVariablesService } from '../../../common/attachments/chatVariables
 import { IChatDebugService } from '../../../common/chatDebugService.js';
 import { ChatDebugServiceImpl } from '../../../common/chatDebugServiceImpl.js';
 import { ChatRequestQueueKind, ChatSendResult, IChatFollowup, IChatModelReference, IChatProgress, IChatService, ResponseModelState } from '../../../common/chatService/chatService.js';
-import { ChatService } from '../../../common/chatService/chatServiceImpl.js';
+import { backfillRestoredPickerState, ChatService } from '../../../common/chatService/chatServiceImpl.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../common/constants.js';
 import { ChatEditingSessionState, IChatEditingService, IChatEditingSession, IModifiedFileEntry, ModifiedFileEntryState } from '../../../common/editing/chatEditingService.js';
 import { ILanguageModelChatMetadata, ILanguageModelsService } from '../../../common/languageModels.js';
-import { ChatModel, IChatModel, IChatRequestVariableData, ISerializableChatData } from '../../../common/model/chatModel.js';
+import { ChatModel, IChatModel, IChatRequestVariableData, ISerializableChatData, ISerializableChatModelInputState } from '../../../common/model/chatModel.js';
 import { LocalChatSessionUri } from '../../../common/model/chatUri.js';
 import { ChatAgentService, IChatAgent, IChatAgentData, IChatAgentImplementation, IChatAgentService } from '../../../common/participants/chatAgents.js';
 import { ChatSlashCommandService, IChatSlashCommandService } from '../../../common/participants/chatSlashCommands.js';
@@ -2316,6 +2316,44 @@ suite('ChatService', () => {
 			!historyItems.some(item => item.sessionResource.toString() === model.sessionResource.toString()),
 			'Deleted session should NOT reappear in history after model disposal'
 		);
+	});
+});
+
+suite('backfillRestoredPickerState', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const AGENT = 'agent';
+	const model = (identifier: string): ISerializableChatModelInputState['selectedModel'] => ({
+		identifier,
+		metadata: {
+			id: identifier, name: identifier, vendor: 'copilot', version: '1.0', family: 'test',
+			extension: new ExtensionIdentifier('a.b'), isUserSelectable: true, maxInputTokens: 8192, maxOutputTokens: 1024,
+			isDefaultForLocation: {}
+		}
+	});
+	const state = (modeId: string, selectedModel: ISerializableChatModelInputState['selectedModel']): ISerializableChatModelInputState => ({
+		attachments: [], mode: { id: modeId, kind: ChatModeKind.Agent }, selectedModel, inputText: '', selections: [], contrib: {}
+	});
+
+	test('backfills a model dropped at cold restore from the per-session stored selection', () => {
+		const result = backfillRestoredPickerState(state(AGENT, undefined), state(AGENT, model('agent-host-claude:opus')), AGENT);
+		assert.strictEqual(result?.selectedModel?.identifier, 'agent-host-claude:opus');
+	});
+
+	test('keeps the chosen model when present (never overrides it with the stored one)', () => {
+		const result = backfillRestoredPickerState(state(AGENT, model('agent-host-claude:opus')), state(AGENT, model('agent-host-claude:haiku')), AGENT);
+		assert.strictEqual(result?.selectedModel?.identifier, 'agent-host-claude:opus');
+	});
+
+	test('promotes a stored custom agent over the default Agent only, never over an explicit mode', () => {
+		assert.strictEqual(backfillRestoredPickerState(state(AGENT, undefined), state('custom-uri', undefined), AGENT)?.mode.id, 'custom-uri', 'default Agent → stored custom agent');
+		assert.strictEqual(backfillRestoredPickerState(state('other-uri', undefined), state('custom-uri', undefined), AGENT)?.mode.id, 'other-uri', 'explicit mode is not overridden');
+		assert.strictEqual(backfillRestoredPickerState(state(AGENT, undefined), state(AGENT, undefined), AGENT)?.mode.id, AGENT, 'stored default Agent leaves chosen Agent');
+	});
+
+	test('returns the chosen state unchanged when there is no stored state', () => {
+		const chosen = state(AGENT, undefined);
+		assert.strictEqual(backfillRestoredPickerState(chosen, undefined, AGENT), chosen);
 	});
 });
 


### PR DESCRIPTION
- Implemented functions to manage model selection persistence and validation during session switches:
  - `shouldDropAgnosticDraftModel`: Determines if a draft model should be dropped based on session type compatibility.
  - `shouldPersistModelSelection`: Checks if a model selection should be persisted based on user actions and session state.
  - `shouldSuppressModelPersistenceOnSessionSwitch`: Suppresses model persistence during session switches for empty own-pool sessions.
  - `shouldRestorePerTypeModelOnSessionSwitch`: Restores the persisted model for fresh untitled own-pool sessions.
  - `shouldWaitForSessionModel`: Decides whether to wait for a session's remembered model to load before applying a default.

- Enhanced `ChatService` to backfill missing picker selections from previously saved states during session restoration, ensuring user selections are honored.

- Added comprehensive tests for new logic and regression scenarios to prevent model selection issues during session transitions.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/322792