### PR TITLE
Show friendly voice names in voice selection setting

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -466,11 +466,12 @@ configurationRegistry.registerConfiguration({
 		'agents.voice.voice': {
 			type: 'string',
 			enum: ['victoria_neutral', 'kevin_neutral', 'maya_neutral', 'daniel_neutral'],
+			enumItemLabels: ['Victoria', 'Kevin', 'Maya', 'Daniel'],
 			enumDescriptions: [
-				nls.localize('agents.voice.voice.victoria', "Victoria (neutral)."),
-				nls.localize('agents.voice.voice.kevin', "Kevin (neutral)."),
-				nls.localize('agents.voice.voice.maya', "Maya (neutral)."),
-				nls.localize('agents.voice.voice.daniel', "Daniel (neutral)."),
+				nls.localize('agents.voice.voice.victoria', "Victoria."),
+				nls.localize('agents.voice.voice.kevin', "Kevin."),
+				nls.localize('agents.voice.voice.maya', "Maya."),
+				nls.localize('agents.voice.voice.daniel', "Daniel."),
 			],
 			description: nls.localize('agents.voice.voice', "The voice used when the assistant reads responses aloud. Changing this while voice mode is connected takes effect immediately."),
 			default: 'victoria_neutral',


### PR DESCRIPTION
## Show friendly voice names in the voice selection setting

The `agents.voice.voice` dropdown was showing the raw backend keys (`victoria_neutral`, `kevin_neutral`, ...). This adds `enumItemLabels` so the Settings UI displays capitalized, human-friendly names instead, and drops the redundant "(neutral)" from the enum descriptions.

| Before | After |
|---|---|
| `victoria_neutral` | Victoria |
| `kevin_neutral` | Kevin |
| `maya_neutral` | Maya |
| `daniel_neutral` | Daniel |

The underlying enum **values** (the voice keys sent to the backend on `start_session` / `set_voice`) are unchanged, so this is purely a display improvement.
