### PR TITLE
Restrict sovereign-cloud config in untrusted workspaces

### DIFF
--- a/extensions/microsoft-authentication/package.json
+++ b/extensions/microsoft-authentication/package.json
@@ -21,7 +21,11 @@
   "capabilities": {
     "virtualWorkspaces": true,
     "untrustedWorkspaces": {
-      "supported": true
+      "supported": "limited",
+      "restrictedConfigurations": [
+        "microsoft-sovereign-cloud.environment",
+        "microsoft-sovereign-cloud.customEnvironment"
+      ]
     }
   },
   "extensionKind": [


### PR DESCRIPTION
## Problem

`microsoft-sovereign-cloud.environment` and `microsoft-sovereign-cloud.customEnvironment` are `window`-scoped, unrestricted settings. The `microsoft-authentication` extension supports untrusted workspaces (`untrustedWorkspaces.supported: true`), so an attacker-supplied folder could set these via `.vscode/settings.json` and have them survive Restricted Mode.

These values feed directly into the MSAL authority/endpoint URLs (`activeDirectoryEndpointUrl` → `new URL(tenant, activeDirectoryEndpointUrl)` in `node/authProvider.ts`), so allowing untrusted workspace content to override them is a security-sensitive configuration exposure.

## Change

Declare both settings as `restrictedConfigurations` under `capabilities.untrustedWorkspaces` so their **workspace-level values are ignored in untrusted workspaces** (user/default scopes still apply). This required switching `untrustedWorkspaces.supported` from `true` to `"limited"`, since `restrictedConfigurations` is only honored for `"limited"` support — see `configurationExtensionPoint.ts` (`restrictedProperties` is only populated when `supported === 'limited'`).

This mirrors how `github-authentication`, `typescript-language-features`, `markdown-language-features`, and `php-language-features` already restrict their endpoint/path settings.

## Verification

- ✅ `package.json` is valid JSON and the extension compiles (`gulp compile-extension:microsoft-authentication`, 0 errors).
- ✅ Shape matches existing built-in extensions using `restrictedConfigurations` with `"limited"` support.
- Manual runtime check (untrusted folder drops the workspace value; trusting the folder applies it) is recommended as a follow-up.

Fixes microsoft/vscode-internalbacklog#8355