### PR TITLE
Fix Other Files separator spacing

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/sessionFilesWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionFilesWidget.ts
@@ -110,7 +110,7 @@ class SessionFileListRenderer implements IListRenderer<ISessionFile, ISessionFil
  */
 export class SessionFilesWidget extends Disposable {
 
-	static readonly HEADER_HEIGHT = 32; // 5px section margin + 6px header margin + 28px header
+	static readonly HEADER_HEIGHT = 34; // 6px top margin + 8px vertical padding + 20px min-height
 	static readonly MIN_BODY_HEIGHT = 3 * SessionFileListDelegate.ITEM_HEIGHT + 2;
 	static readonly PREFERRED_BODY_HEIGHT = 4 * SessionFileListDelegate.ITEM_HEIGHT;
 	static readonly MAX_BODY_HEIGHT = 240;


### PR DESCRIPTION
Fixes #324457

This updates the Other Files section's header height constant to match its CSS box model:

- 6px top margin
- 8px vertical padding
- 20px min-height

The SplitView body height subtraction now leaves enough room for the header, avoiding the separator/list sitting 2px too close or shifting when the section is toggled.

Verification:
- `git diff --check`
- `npm run typecheck-client` does not run locally because `tsgo` is not installed (`sh: tsgo: command not found`)
