### PR TITLE
Allow custom image preview extensions to hide SVG preview action

### DIFF
--- a/extensions/media-preview/package.json
+++ b/extensions/media-preview/package.json
@@ -122,7 +122,7 @@
         },
         {
           "command": "imagePreview.reopenAsPreview",
-          "when": "activeEditor == workbench.editors.files.textFileEditor && resourceExtname == '.svg'",
+          "when": "activeEditor == workbench.editors.files.textFileEditor && resourceExtname == '.svg' && !hasCustomImagePreview",
           "group": "navigation"
         },
         {
@@ -140,7 +140,7 @@
       "editor/title": [
         {
           "command": "imagePreview.reopenAsPreview",
-          "when": "editorFocus && resourceExtname == '.svg'",
+          "when": "editorFocus && resourceExtname == '.svg' && !hasCustomImagePreview",
           "group": "navigation"
         },
         {


### PR DESCRIPTION
## Summary

This adds a `!hasCustomImagePreview` context guard to the built-in media preview extension's `imagePreview.reopenAsPreview` menu contributions for SVG files.

The Markdown extension already has a similar integration point through `hasCustomMarkdownPreview`, which lets third-party Markdown preview extensions hide the built-in Markdown preview actions. This change gives custom SVG/image preview extensions the same kind of opt-in hook without overriding built-in commands or changing editor associations.

Fixes #324863

## Testing

- Parsed `extensions/media-preview/package.json` with `JSON.parse`
