### PR TITLE
Fix cache break tip hover showing wrong hover content

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -801,6 +801,13 @@ export class ActionListWidget<T> extends Disposable {
 		this._register(this._list.onDidChangeFocus(() => this.onFocus()));
 		this._register(this._list.onDidChangeSelection(e => this.onListSelection(e)));
 
+		// Hide the submenu/hover panel when the mouse leaves the list area
+		// (e.g. moves to the header banner such as the cache-break tip).
+		// Without this, the last visible item's hover persists on sibling elements.
+		this._register(dom.addDisposableListener(this._list.getHTMLElement(), 'mouseleave', () => {
+			this._scheduleSubmenuHide();
+		}));
+
 		this._allMenuItems = [...items];
 
 		// Create filter input and/or secondary heading

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -109,7 +109,7 @@ const CACHE_BREAK_HINT_DISMISSED_STORAGE_KEY = 'chat.cacheBreakHintDismissed';
  */
 function getVendorDisplayName(languageModelsService: ILanguageModelsService, vendor: string): string {
 	if (vendor === 'copilotcli') {
-		// @vritant24: This is temporary until we we have 2 distinct vendors for Copilot CLI vs Copilot Chat.
+		// @vritant24: This is temporary until we have 2 distinct vendors for Copilot CLI vs Copilot Chat.
 		// For now, we want to show "Copilot" in the model picker for both.
 		return localize('chat.modelPicker.copilotGroup', "Copilot");
 	}


### PR DESCRIPTION
## Summary

Fixes #324770 — hovering the cache-break tip in the model picker shows the Auto model's hover instead of the tip's own hover.

## Root Cause

In `ActionListWidget`, the list widget registers `onMouseOver` for hover handling but has **no `mouseleave` handler**. When the mouse moves from a list item (e.g. the Auto model entry) to a sibling element like the header banner (cache-break tip), the submenu/hover panel from the last hovered item persists because nothing triggers `_scheduleSubmenuHide()`.

The `_submenuContainer` itself already has proper `mouseenter`/`mouseleave` handlers (lines 706-711), but the list container does not — creating a gap where the hover leaks to non-list sibling areas.

## Changes

### `src/vs/platform/actionWidget/browser/actionList.ts`
- Added a `mouseleave` listener on the list's DOM element that calls `_scheduleSubmenuHide()`. This ensures the hover/submenu panel is hidden (after the existing 300ms grace period) when the mouse leaves the list area toward any sibling element (header, footer, etc.).
- The 300ms delay correctly interacts with the submenu container's `mouseenter` handler: if the mouse moves from the list to the submenu panel, the submenu's `mouseenter` cancels the scheduled hide.

### `src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts`
- Fixed a minor comment typo: `until we we have` → `until we have` (line 112).

## Testing

- Hover over a model item (e.g. Auto) in the model picker — hover panel appears as expected.
- Move mouse from the model item to the cache-break tip header — the hover panel should now dismiss after ~300ms instead of persisting.
- Move mouse from the model item to the submenu hover panel — the panel should remain visible (existing behavior preserved via `_cancelSubmenuHide`).