### PR TITLE
Fix client tools hanging after Copilot SDK bump (1.0.6-preview)

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -454,6 +454,16 @@ export class CopilotAgentSession extends Disposable {
 	 * cleared on turn boundaries.
 	 */
 	private readonly _parentToolCallIdsByAgentId = new Map<string, string>();
+	/**
+	 * Maps a tool call id to the `agentId` carried on its `permission.requested`
+	 * event, captured from the raw SDK event because the SDK's permission
+	 * handler callback does not receive `agentId`. Used by
+	 * {@link _ensureClientToolCallStarted} to resolve the parent tool call for a
+	 * subagent client tool synthesized at permission time (SDK >= 1.0.6-preview
+	 * fires `permission.requested` before `tool.execution_start`). Entries are
+	 * cleared when the tool completes or the session is disposed.
+	 */
+	private readonly _permissionRequestAgentIds = new Map<string, string>();
 	/** Pending permission requests awaiting a renderer-side decision. */
 	private readonly _pendingPermissions = new Map<string, DeferredPromise<boolean>>();
 	/** Pending user input requests awaiting a renderer-side answer. */
@@ -671,6 +681,7 @@ export class CopilotAgentSession extends Disposable {
 			}));
 		}
 		this._register(toDisposable(() => this._cancelPendingClientToolCalls()));
+		this._register(toDisposable(() => this._permissionRequestAgentIds.clear()));
 	}
 
 	// ---- AgentSignal helpers ------------------------------------------------
@@ -1755,6 +1766,78 @@ export class CopilotAgentSession extends Disposable {
 	// ---- permission handling ------------------------------------------------
 
 	/**
+	 * Emits a `ChatToolCallStart` for a client tool that is about to have a
+	 * permission-derived `ChatToolCallReady` dispatched for it, when the real
+	 * `tool.execution_start` has not been observed yet.
+	 *
+	 * The Copilot SDK (>= 1.0.6-preview) reordered client-tool events so that
+	 * `permission.requested` now fires *before* `tool.execution_start`. The host
+	 * derives `ChatToolCallReady` from the permission request, but the tool-call
+	 * part is only created by `ChatToolCallStart` (emitted from
+	 * `tool.execution_start`). Without this, the ready would arrive before the
+	 * part exists, be dropped by the reducer, and leave the client tool stuck in
+	 * `Streaming` — the workbench never invokes it, the parked SDK handler never
+	 * resolves, and the turn hangs. Synthesizing the start here restores the
+	 * start-before-ready ordering the downstream pipeline assumes.
+	 *
+	 * No-ops for: non-client tools (server/shell tools execute in-process and
+	 * don't depend on this), tools already started (the real
+	 * `tool.execution_start`, or a previous call here), and client tools with no
+	 * connected owning client (the no-client failure path in `onToolStart`
+	 * handles those).
+	 */
+	private _ensureClientToolCallStarted(request: ITypedPermissionRequest): void {
+		const toolCallId = request.toolCallId;
+		const toolName = request.toolName;
+		if (!toolCallId || !toolName) {
+			return;
+		}
+		if (this._activeToolCalls.has(toolCallId)) {
+			return;
+		}
+		if (!this._clientToolNames.has(toolName)) {
+			return;
+		}
+		const ownerClientId = this._activeClientToolSet.ownerOf(toolName, this._currentTurn?.senderClientId);
+		if (!ownerClientId) {
+			return;
+		}
+		// Resolve the parent tool call for subagent client tools. The SDK's
+		// permission handler callback drops the event's `agentId`, so we recover
+		// it from the raw `permission.requested` event captured in
+		// `_permissionRequestAgentIds`. Routing the synthesized start (and, via
+		// `_activeToolCalls`, the subsequent permission `pending_confirmation`)
+		// to the subagent session keeps the tool rendering in the right chat.
+		const agentId = this._permissionRequestAgentIds.get(toolCallId);
+		const parentToolCallId = agentId ? this._parentToolCallIdsByAgentId.get(agentId) : undefined;
+		const parameters = request.args;
+		const toolArgs = parameters !== undefined ? tryStringify(parameters) : undefined;
+		const displayName = getToolDisplayName(toolName);
+		const meta: Mutable<IToolCallMeta> = { toolKind: getToolKind(toolName) };
+		if (toolArgs !== undefined) {
+			meta.toolArguments = toolArgs;
+		}
+		this._logService.info(`[Copilot:${this.sessionId}] Synthesizing tool start for client tool ahead of permission ready: ${toolName} (toolCallId=${toolCallId}, parentToolCallId=${parentToolCallId ?? 'none'})`);
+		this._activeToolCalls.set(toolCallId, { toolName, displayName, parameters, content: [], parentToolCallId, mcpServerName: undefined, meta });
+
+		// A new tool call invalidates the current markdown and reasoning parts
+		// so the next delta starts a fresh part (mirrors `onToolStart`).
+		this._currentTurn?.markdownPartIds.delete(parentToolCallId ?? '');
+		this._currentTurn?.reasoningPartIds.delete(parentToolCallId ?? '');
+
+		this._emitAction({
+			type: ActionType.ChatToolCallStart,
+			turnId: this._turnId,
+			toolCallId,
+			toolName,
+			displayName,
+			intention: getShellIntention(toolName, parameters),
+			contributor: { kind: ToolCallContributorKind.Client, clientId: ownerClientId },
+			_meta: toToolCallMeta(meta),
+		}, parentToolCallId);
+	}
+
+	/**
 	 * Handles a permission request from the SDK by firing a `tool_ready` event
 	 * (which transitions the tool to PendingConfirmation) and waiting for the
 	 * side-effects layer to respond via {@link respondToPermissionRequest}.
@@ -1862,6 +1945,16 @@ export class CopilotAgentSession extends Disposable {
 
 			// Fire a pending_confirmation signal to transition the tool to PendingConfirmation
 			const toolName = request.toolName ?? request.kind;
+
+			// The Copilot SDK (>= 1.0.6-preview) fires `permission.requested`
+			// *before* `tool.execution_start`, so for client tools the
+			// `ChatToolCallStart` that creates the tool-call part has not been
+			// emitted yet. Synthesize it here so the permission-derived
+			// `ChatToolCallReady` below lands on an existing part rather than
+			// being dropped (which would leave the client tool stuck streaming
+			// and hang the turn). No-op for non-client / already-started tools.
+			this._ensureClientToolCallStarted(request);
+
 			// Forward the tool's parentToolCallId (if any) so the host can
 			// route the resulting ChatToolCallReady to the correct
 			// subagent session — without it the action would land on the
@@ -2576,9 +2669,33 @@ export class CopilotAgentSession extends Disposable {
 			}, parentToolCallId);
 		}));
 
+		this._register(wrapper.onPermissionRequested(e => {
+			// Capture the raw event's `agentId` (dropped by the SDK's permission
+			// handler callback) so `_ensureClientToolCallStarted` can route a
+			// subagent client tool's synthesized start to the right session.
+			// This fires synchronously during SDK event dispatch, before the
+			// permission handler resumes past its first await, so the mapping is
+			// available by synthesis time.
+			const toolCallId = e.data.permissionRequest.toolCallId;
+			if (toolCallId && e.agentId) {
+				this._permissionRequestAgentIds.set(toolCallId, e.agentId);
+			}
+		}));
+
 		this._register(wrapper.onToolStart(e => {
 			if (isHiddenTool(e.data.toolName)) {
 				this._logService.trace(`[Copilot:${sessionId}] Tool started (hidden): ${e.data.toolName}`);
+				return;
+			}
+			// The client-tool start may already have been synthesized at
+			// permission time (SDK >= 1.0.6-preview fires `permission.requested`
+			// before `tool.execution_start`; see `_ensureClientToolCallStarted`).
+			// In that case the part already exists with the correct client
+			// contributor, so skip emitting a duplicate `ChatToolCallStart`.
+			// Client tools emit no `ChatToolCallReady` from here anyway, so
+			// there is nothing else to do.
+			if (this._activeToolCalls.has(e.data.toolCallId)) {
+				this._logService.trace(`[Copilot:${sessionId}] Tool start already emitted for ${e.data.toolCallId}; skipping duplicate.`);
 				return;
 			}
 			this._logService.info(`[Copilot:${sessionId}] Tool started: ${e.data.toolName}`);
@@ -2732,6 +2849,7 @@ export class CopilotAgentSession extends Disposable {
 			}
 			this._logService.info(`[Copilot:${sessionId}] Tool completed: ${e.data.toolCallId}`);
 			this._activeToolCalls.delete(e.data.toolCallId);
+			this._permissionRequestAgentIds.delete(e.data.toolCallId);
 			const displayName = tracked.displayName;
 			const toolOutput = e.data.error?.message ?? e.data.result?.content;
 

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionWrapper.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionWrapper.ts
@@ -53,6 +53,11 @@ export class CopilotSessionWrapper extends Disposable {
 		return this._onToolComplete ??= this._sdkEvent('tool.execution_complete');
 	}
 
+	private _onPermissionRequested: Event<SessionEventPayload<'permission.requested'>> | undefined;
+	get onPermissionRequested(): Event<SessionEventPayload<'permission.requested'>> {
+		return this._onPermissionRequested ??= this._sdkEvent('permission.requested');
+	}
+
 	private _onIdle: Event<SessionEventPayload<'session.idle'>> | undefined;
 	get onIdle(): Event<SessionEventPayload<'session.idle'>> {
 		return this._onIdle ??= this._sdkEvent('session.idle');

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -3760,6 +3760,62 @@ suite('CopilotAgentSession', () => {
 			});
 		});
 
+		test('permission before tool.execution_start synthesizes the client tool start so the ready is not dropped (SDK >= 1.0.6 ordering)', async () => {
+			// Regression for the client-tool hang after the Copilot SDK bump
+			// (1.0.6-preview): the SDK reordered client-tool events so
+			// `permission.requested` now fires *before* `tool.execution_start`.
+			// The permission-derived `ChatToolCallReady` must land on an
+			// existing tool-call part, so the host synthesizes the
+			// `ChatToolCallStart` at permission time. Without this the ready is
+			// dropped, the client tool stays streaming, and the turn hangs.
+			const activeClientToolSet = new ActiveClientToolSet();
+			activeClientToolSet.set('client-reorder', snapshot.tools);
+			const { session, runtime, mockSession, signals, waitForSignal } = await createAgentSession(disposables, { clientSnapshot: snapshot, activeClientToolSet });
+
+			// Permission fires FIRST — no tool.execution_start yet.
+			const resultPromise = runtime.handlePermissionRequest({
+				kind: 'custom-tool',
+				toolCallId: 'tc-reorder',
+				toolName: 'my_tool',
+				args: { file: 'test.ts' },
+			});
+			await waitForSignal(s => s.kind === 'pending_confirmation');
+
+			// A single ChatToolCallStart was synthesized (with the client
+			// contributor) and it precedes the pending_confirmation, so the
+			// permission-derived ready has a part to land on.
+			const startSignals = signals.filter(s => isAction(s, ActionType.ChatToolCallStart));
+			assert.strictEqual(startSignals.length, 1);
+			assert.deepStrictEqual((startSignals[0].action as ChatToolCallStartAction).contributor, { kind: ToolCallContributorKind.Client, clientId: 'client-reorder' });
+			const startIndex = signals.indexOf(startSignals[0]);
+			const pendingIndex = signals.findIndex(s => s.kind === 'pending_confirmation');
+			assert.ok(startIndex >= 0 && startIndex < pendingIndex, 'ChatToolCallStart must be emitted before pending_confirmation');
+
+			// The real tool.execution_start now arrives — it must NOT emit a
+			// duplicate ChatToolCallStart.
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-reorder',
+				toolName: 'my_tool',
+				arguments: { file: 'test.ts' },
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+			assert.strictEqual(signals.filter(s => isAction(s, ActionType.ChatToolCallStart)).length, 1, 'tool.execution_start must not emit a duplicate ChatToolCallStart');
+
+			// The parked SDK handler resolves once the client completes the
+			// call — i.e. the tool runs instead of hanging.
+			const tools = runtime.createClientSdkTools();
+			const handlerPromise = invokeClientToolHandler(tools[0], 'tc-reorder', { file: 'test.ts' });
+			session.respondToPermissionRequest('tc-reorder', true);
+			assert.strictEqual((await resultPromise).kind, 'approve-once');
+			session.handleClientToolCallComplete('tc-reorder', {
+				success: true,
+				pastTenseMessage: 'did it',
+				content: [{ type: ToolResultContentType.Text, text: 'result text' }],
+			});
+			const result = await handlerPromise;
+			assert.strictEqual(result.resultType, 'success');
+			assert.strictEqual(result.textResultForLlm, 'result text');
+		});
+
 		test('pending_confirmation forwards parentToolCallId for tools inside subagents', async () => {
 			// Regression: when a client tool runs inside a subagent the
 			// permission-flow `pending_confirmation` must carry the
@@ -3793,6 +3849,61 @@ suite('CopilotAgentSession', () => {
 			const permSignals = signals.filter((s): s is IAgentToolPendingConfirmationSignal => s.kind === 'pending_confirmation');
 			assert.strictEqual(permSignals.length, 1);
 			assert.strictEqual(permSignals[0].parentToolCallId, 'tc-parent-subagent');
+
+			session.respondToPermissionRequest('tc-sub-client', false);
+			await resultPromise;
+		});
+
+		test('subagent client tool: permission before tool.execution_start routes the synthesized start and ready to the subagent (SDK >= 1.0.6 ordering)', async () => {
+			// Regression for the SDK 1.0.6-preview reorder applied to a client
+			// tool running *inside a subagent*: `permission.requested` fires
+			// before `tool.execution_start`, so the start is synthesized at
+			// permission time. The synthesized start (and, via `_activeToolCalls`,
+			// the permission `pending_confirmation`) must route to the subagent
+			// session — the raw `permission.requested` event's `agentId` is used
+			// to recover the parent tool call because the SDK's permission handler
+			// callback drops it.
+			const { session, runtime, mockSession, signals, waitForSignal } = await createAgentSession(disposables, { clientSnapshot: snapshot, activeClientToolSet: activeClientToolSetWith('test-client') });
+
+			mockSession.fire('subagent.started', {
+				toolCallId: 'tc-parent-subagent',
+				agentName: 'helper',
+				agentDisplayName: 'Helper',
+				agentDescription: 'Helps',
+			} as SessionEventPayload<'subagent.started'>['data'], { agentId: 'agent-client-tool' });
+
+			// NEW ordering: the raw permission.requested event (carrying agentId)
+			// arrives before tool.execution_start.
+			mockSession.fire('permission.requested', {
+				requestId: 'req-sub',
+				permissionRequest: { kind: 'custom-tool', toolCallId: 'tc-sub-client', toolName: 'my_tool', toolDescription: 'A test tool', args: {} },
+			} as SessionEventPayload<'permission.requested'>['data'], { agentId: 'agent-client-tool' });
+
+			const resultPromise = runtime.handlePermissionRequest({
+				kind: 'custom-tool',
+				toolCallId: 'tc-sub-client',
+				toolName: 'my_tool',
+			});
+			await waitForSignal(s => s.kind === 'pending_confirmation');
+
+			// The synthesized start routes to the subagent (parentToolCallId set).
+			const startSignals = signals.filter(s => isAction(s, ActionType.ChatToolCallStart));
+			assert.strictEqual(startSignals.length, 1);
+			assert.strictEqual(startSignals[0].parentToolCallId, 'tc-parent-subagent');
+			assert.deepStrictEqual((startSignals[0].action as ChatToolCallStartAction).contributor, { kind: ToolCallContributorKind.Client, clientId: 'test-client' });
+
+			// The permission pending_confirmation also routes to the subagent.
+			const permSignals = signals.filter((s): s is IAgentToolPendingConfirmationSignal => s.kind === 'pending_confirmation');
+			assert.strictEqual(permSignals.length, 1);
+			assert.strictEqual(permSignals[0].parentToolCallId, 'tc-parent-subagent');
+
+			// The real subagent tool.execution_start must not emit a duplicate.
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-sub-client',
+				toolName: 'my_tool',
+				arguments: {},
+			} as SessionEventPayload<'tool.execution_start'>['data'], { agentId: 'agent-client-tool' });
+			assert.strictEqual(signals.filter(s => isAction(s, ActionType.ChatToolCallStart)).length, 1, 'tool.execution_start must not emit a duplicate ChatToolCallStart');
 
 			session.respondToPermissionRequest('tc-sub-client', false);
 			await resultPromise;


### PR DESCRIPTION
## Problem

After the SDK bump in #324667 (`@github/copilot-sdk` `1.0.5 → 1.0.6-preview.1`), **all client tools hang** in Agent Host sessions (browser tools, tasks, tool search, etc.). The turn never completes and the user has to abort.

## Root cause

The new SDK **reordered client-tool events**: `permission.requested` now fires **before** `tool.execution_start` (and adds `external_tool.requested`).

The agent host derives `ChatToolCallReady` from the permission request, but the tool-call *part* is only created by `ChatToolCallStart` (emitted from `tool.execution_start`). With the new ordering:

1. `chat/toolCallReady` arrives first — but no part exists yet, so the reducer **drops it** (`updateToolCallInParts` requires `Streaming`/`Running`).
2. `chat/toolCallStart` then creates the part stuck in `Streaming`.
3. The workbench waits for the part to leave `Streaming` before calling `invokeTool` — it never does.
4. The parked SDK client-tool handler never receives a completion, so the turn hangs.

Confirmed end-to-end from AHP logs: `chat/toolCallReady` (serverSeq 21122) was applied before `chat/toolCallStart` (serverSeq 21124). Server/shell tools don't hang because the SDK executes their handlers in-process regardless of AHP display state; only client tools require the workbench to drive execution.

## Fix

- **Synthesize `ChatToolCallStart` at permission time** (`_ensureClientToolCallStarted`) so the permission-derived `ChatToolCallReady` lands on an existing part. Skip the now-duplicate start when the real `tool.execution_start` arrives. This restores the start-before-ready ordering the downstream pipeline assumes, so the existing (known-good) permission → ready → confirm → invoke → complete machinery works unchanged.
- **Subagent client tools**: the SDK's permission handler callback drops the event's `agentId`, so the parent tool call can't be resolved at permission time. Recover it from the raw `permission.requested` event (newly exposed as `onPermissionRequested` on the session wrapper) and stamp the synthesized entry with the correct parent. Because the synthesized `_activeToolCalls` entry now carries the right parent, the existing permission-flow code automatically routes the confirmation to the subagent session too — so the tool renders in the correct chat. Degrades gracefully to the parent session if the mapping is ever missing — never a hang.

## Testing

- Added unit regression tests for both the top-level and subagent event orderings. Both were confirmed to **fail without the fix** (top-level: start dropped; subagent: start routes to parent instead of subagent).
- All affected suites green: `CopilotAgentSession` (172), `CopilotAgent` (293), `AgentSideEffects` (128), workbench client-tools (39), protocol `clientTools` integration (4). Type-check and hygiene clean.

### Note on real-SDK-mocked coverage
I attempted a real-SDK-mocked integration test, but the mock-LLM path emits the *old* event order (`toolCallStart` before `toolCallReady`), so it can't reproduce the production reordering. The mock-vs-real ordering gap is itself worth noting — the mocked-LLM harness currently can't guard this class of SDK event-ordering regression, so the unit tests (which reproduce the exact contract deterministically) are the guard here.

(Written by Copilot)
