### PR TITLE
Fix collapsed view spacing issue in changes view

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/sessionFilesWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/sessionFilesWidget.ts
@@ -110,7 +110,7 @@ class SessionFileListRenderer implements IListRenderer<ISessionFile, ISessionFil
  */
 export class SessionFilesWidget extends Disposable {
 
-	static readonly HEADER_HEIGHT = 32; // 5px section margin + 6px header margin + 28px header
+	static readonly HEADER_HEIGHT = 34; // 6px header margin-top + 8px header padding + 20px header min-height
 	static readonly MIN_BODY_HEIGHT = 3 * SessionFileListDelegate.ITEM_HEIGHT + 2;
 	static readonly PREFERRED_BODY_HEIGHT = 4 * SessionFileListDelegate.ITEM_HEIGHT;
 	static readonly MAX_BODY_HEIGHT = 240;


### PR DESCRIPTION
This pull request addresses a spacing issue in the "Other Files" section of the changes view when it is collapsed. 

### Changes made:
- Updated the `HEADER_HEIGHT` constant in `sessionFilesWidget.ts` from `32` to `34` to match the actual occupied height of the header, which includes:
  - `margin-top: 6px`
  - `padding: 4px` (top + bottom)
  - `min-height: 20px`
  
### Reason for change:
- The previous `HEADER_HEIGHT` value of `32px` was insufficient, causing the bottom 2px of the header to be clipped when the section was collapsed. This fix ensures that the header is fully visible and resolves the clipping issue.

### Additional notes:
- The same issue exists in the "Checks" section, which has the same CSS and `HEADER_HEIGHT`. If desired, I can apply a similar fix there for consistency. 
- The type-check errors encountered are unrelated to this change and stem from pre-existing environment issues.