### PR TITLE
editor: fix Agents window multi-diff header overlap

### DIFF
--- a/src/vs/editor/browser/widget/multiDiffEditor/style.css
+++ b/src/vs/editor/browser/widget/multiDiffEditor/style.css
@@ -89,18 +89,20 @@
 
 				.file-path {
 					display: flex;
-					flex: 1;
+					flex: 1 1 auto;
 					min-width: 0;
+					overflow: hidden;
 
 					.title {
 						font-size: 14px;
 						line-height: 22px;
+						flex: 0 1 auto;
 						min-width: 0;
 						overflow: hidden;
 						text-overflow: ellipsis;
 
 						&.original {
-							flex: 1;
+							flex: 1 1 auto;
 						}
 					}
 
@@ -132,6 +134,7 @@
 				}
 
 				.actions {
+					flex: 0 0 auto;
 					padding: 0 8px;
 				}
 			}


### PR DESCRIPTION
Fix the collapsed multi-diff file header in the Agents window so long file paths no longer run under the trailing action buttons.

Changes:
- Clip the file-path container so overflow cannot bleed into the actions area.
- Make the file titles shrink with ellipsis.
- Keep the actions block fixed-width so the icons retain their space.

This is a CSS-only fix.