### PR TITLE
Style overrides: Add border-radius to floating panels content

### DIFF
--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -37,6 +37,10 @@
 	color: var(--vscode-agentsPanel-foreground);
 }
 
+.monaco-workbench.floating-panels .part > .content {
+	border-radius: var(--vscode-cornerRadius-large, 8px);
+}
+
 /* Keep the auxiliary bar background aligned with the primary sidebar in light theme. */
 .monaco-workbench.floating-panels .part.auxiliarybar {
 	background-color: var(--vscode-sideBar-background) !important;

--- a/src/vs/workbench/browser/media/floatingPanels.css
+++ b/src/vs/workbench/browser/media/floatingPanels.css
@@ -37,7 +37,7 @@
 	color: var(--vscode-agentsPanel-foreground);
 }
 
-.monaco-workbench.floating-panels .part > .content {
+.monaco-workbench.floating-panels .part.editor > .content {
 	border-radius: var(--vscode-cornerRadius-large, 8px);
 }
 


### PR DESCRIPTION
Introduce a border-radius style to the content of floating panels for improved aesthetics. Test by observing the updated appearance of floating panels in the application.

Fixes: https://github.com/microsoft/vscode/issues/324214