### PR TITLE
Markdown - preserve external link encoding

### DIFF
--- a/extensions/markdown-language-features/src/client/client.ts
+++ b/extensions/markdown-language-features/src/client/client.ts
@@ -19,6 +19,29 @@ function toLspRange(range: vscode.Range): lsp.Range {
 	return lsp.Range.create(range.start.line, range.start.character, range.end.line, range.end.character);
 }
 
+function getExternalLinkUri(linkText: string): vscode.Uri | undefined {
+	if (!/^https?:/i.test(linkText)) {
+		return undefined;
+	}
+
+	try {
+		const url = new URL(linkText);
+		const authority = url.username || url.password
+			? `${url.username}${url.password ? `:${url.password}` : ''}@${url.host}`
+			: url.host;
+
+		return vscode.Uri.from({
+			scheme: url.protocol.slice(0, -1),
+			authority,
+			path: url.pathname,
+			query: url.search.slice(1),
+			fragment: url.hash.slice(1),
+		});
+	} catch {
+		return undefined;
+	}
+}
+
 export class MdLanguageClient implements IDisposable {
 
 	readonly #client: lsp.BaseLanguageClient;
@@ -88,6 +111,29 @@ export async function startClient(factory: LanguageClientConstructor, parser: IM
 		},
 		markdown: {
 			supportHtml: true,
+		},
+		middleware: {
+			provideDocumentLinks: async (document, token, next) => {
+				const links = await next(document, token);
+				if (!links) {
+					return links;
+				}
+
+				for (const link of links) {
+					const target = link.target;
+					if (!target || (target.scheme !== 'http' && target.scheme !== 'https')) {
+						continue;
+					}
+
+					const linkText = document.getText(link.range);
+					const uri = getExternalLinkUri(linkText);
+					if (uri) {
+						link.target = uri;
+					}
+				}
+
+				return links;
+			},
 		}
 	};
 

--- a/extensions/markdown-language-features/src/test/documentLink.test.ts
+++ b/extensions/markdown-language-features/src/test/documentLink.test.ts
@@ -146,6 +146,20 @@ async function getLinksForFile(file: vscode.Uri): Promise<vscode.DocumentLink[]>
 		assertActiveDocumentUri(testFile);
 		assert.strictEqual(vscode.window.activeTextEditor!.selection.start.line, 1);
 	});
+
+	test('Should preserve percent-encoding in external links', async () => {
+		const firebaseUrl = 'https://firebasestorage.googleapis.com/v0/b/brewlangerie.appspot.com/o/products%2FzVNZkudXJyq8bPGTXUxx%2FBetterave-Sesame.jpg?alt=media&token=0b2310c4-3ea6-4207-bbde-9c3710ba0437';
+		const textFragmentUrl = 'https://ffmpeg.org/ffmpeg-all.html?test=a%23b%20c#:~:text=%2Dversion';
+
+		await withFileContents(testFileA, joinLines(
+			`[firebase](${firebaseUrl})`,
+			`[fragment](${textFragmentUrl})`));
+
+		const links = await getLinksForFile(testFileA);
+
+		assert.strictEqual(links[0].target?.toString(true), firebaseUrl);
+		assert.strictEqual(links[1].target?.toString(true), textFragmentUrl);
+	});
 });
 
 


### PR DESCRIPTION
Fixes #245128

This preserves percent-encoding for external Markdown document links before they are opened from the editor. The Markdown language service currently returns external link targets through URI parsing, which can decode significant encoded characters such as `%2F`, `%23`, and text-fragment `%2D`.

The client now rebuilds `http`/`https` document-link targets from the exact link text using URI components, so the target keeps the same encoded path/query/fragment that appeared in the Markdown file.

Added a regression test covering the Firebase `%2F` URL and a text-fragment URL from the issue.

Verification:
- `npm --prefix extensions/markdown-language-features run build-ext`
- `./scripts/test-integration.sh --suite markdown --grep "preserve percent-encoding"`
- `./node_modules/.bin/eslint extensions/markdown-language-features/src/client/client.ts extensions/markdown-language-features/src/test/documentLink.test.ts`
- `git diff --check`