### PR TITLE
nes: fix: long-distance hint insertion-overlay negative-height crash

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsInsertionView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsInsertionView.ts
@@ -54,27 +54,35 @@ export class InlineEditsInsertionView extends Disposable implements IInlineEdits
 
 	private readonly _trimVertically = derived(this, reader => {
 		const state = this._state.read(reader);
-		const text = state?.text;
-		if (!text || text.trim() === '') {
-			return { topOffset: 0, bottomOffset: 0, linesTop: 0, linesBottom: 0 };
+		if (!state) {
+			return { topOffset: 0, contentHeight: 0, linesTop: 0, linesBottom: 0 };
 		}
 
-		// Adjust for leading/trailing newlines
+		const text = state.text;
 		const lineHeight = this._editor.getLineHeightForPosition(new Position(state.lineNumber, 1));
 		const eol = this._editor.getModel()!.getEOL();
+		const lineCount = text.split(eol).length;
+
+		// Count leading/trailing blank lines so the overlay can be trimmed to the actual inserted content.
 		let linesTop = 0;
 		let linesBottom = 0;
+		if (text.trim() !== '') {
+			let i = 0;
+			for (; i < text.length && text.startsWith(eol, i); i += eol.length) {
+				linesTop += 1;
+			}
 
-		let i = 0;
-		for (; i < text.length && text.startsWith(eol, i); i += eol.length) {
-			linesTop += 1;
+			for (let j = text.length; j > i && text.endsWith(eol, j); j -= eol.length) {
+				linesBottom += 1;
+			}
 		}
 
-		for (let j = text.length; j > i && text.endsWith(eol, j); j -= eol.length) {
-			linesBottom += 1;
-		}
-
-		return { topOffset: linesTop * lineHeight, bottomOffset: linesBottom * lineHeight, linesTop, linesBottom };
+		return {
+			topOffset: linesTop * lineHeight,
+			contentHeight: (lineCount - linesTop - linesBottom) * lineHeight,
+			linesTop,
+			linesBottom,
+		};
 	});
 
 	private readonly _maxPrefixTrim = derived(this, reader => {
@@ -240,10 +248,14 @@ export class InlineEditsInsertionView extends Disposable implements IInlineEdits
 			return null;
 		}
 
-		const { topOffset: topTrim, bottomOffset: bottomTrim } = this._trimVertically.read(reader);
+		const { topOffset: topTrim, contentHeight: height } = this._trimVertically.read(reader);
 
 		const scrollTop = this._editorObs.scrollTop.read(reader);
-		const height = this._ghostTextView.height.read(reader) - topTrim - bottomTrim;
+		// Derive the overlay height synchronously from the model (via _trimVertically) rather than the
+		// asynchronously measured ghost text view zone height, which is transiently just a single line while
+		// the view zone is (re)created. Because it uses the same line height and line accounting as the trims,
+		// top/height/bottom stay consistent and height is always positive: leading and trailing blank lines
+		// can never cover every inserted line.
 		const top = this._editor.getTopForLineNumber(state.lineNumber) - scrollTop + topTrim;
 		const bottom = top + height;
 


### PR DESCRIPTION
Fixes a crash with the NES (Next Edit Suggestion) "out-of-viewport" long-distance hint: `BugIndicatingError: Invalid arguments: Vertically offset by N`.

### Root cause
`InlineEditsInsertionView._overlayLayout` built the overlay `Rect` height by subtracting the model-derived vertical trims (`topTrim`/`bottomTrim`, computed **synchronously** from the inserted text) from the ghost-text view-zone height (`ghostTextView.height`), which is measured **asynchronously** (`onComputedHeight`). Right after a suggestion is triggered / while the view zone is being (re)created, the measured height is transiently just a single line while the trims already reflect the full multi-line insertion, so `height` went negative and `new Rect(...)` threw.

The previous iteration guarded this with `if (height <= 0) { return null; }` — but that only hides the transient rather than fixing it.

### Fix
Compute the overlay height **synchronously from the model**, using the same line height and leading/trailing blank-line accounting as the trims (`contentLineCount * lineHeight`). This keeps `top`/`height`/`bottom` consistent and makes the height structurally positive (leading + trailing blank lines can never cover every inserted line), so the transient negative-height case can no longer occur and no guard is needed. It is algebraically identical to the settled value of the old formula, so there is no visual change once the view zone has been measured.

### Notes
- The **too-narrow preview widget** fix has been split into its own PR: #324930.
- The config to *preview surrounding context lines* for these hints will follow as a stacked PR on top of this branch (#324924).
- `npm run typecheck-client` ✅ and `eslint` ✅.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>