### PR TITLE
Add exp-driven config to preview context lines for NES long-distance hint

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -4493,6 +4493,12 @@ export interface IInlineSuggestOptions {
 		showLongDistanceHint?: boolean;
 
 		/**
+		 * Controls how many lines of surrounding context are shown above and below the target line
+		 * in the long distance inline suggestion hint preview. `0` shows only the target line.
+		 */
+		longDistanceHintContextLineCount?: number;
+
+		/**
 		* @internal
 		*/
 		enabled?: boolean;
@@ -4551,6 +4557,7 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 				renderSideBySide: 'auto',
 				allowCodeShifting: 'always',
 				showLongDistanceHint: true,
+				longDistanceHintContextLineCount: 0,
 			},
 			triggerCommandOnProviderChange: false,
 			experimental: {
@@ -4656,6 +4663,17 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 					description: nls.localize('inlineSuggest.edits.showLongDistanceHint', "Controls whether long distance inline suggestions are shown."),
 					tags: ['nextEditSuggestions', 'experimental']
 				},
+				'editor.inlineSuggest.edits.longDistanceHintContextLineCount': {
+					type: 'number',
+					default: defaults.edits.longDistanceHintContextLineCount,
+					minimum: 0,
+					maximum: 10,
+					description: nls.localize('inlineSuggest.edits.longDistanceHintContextLineCount', "Controls how many lines of surrounding context are shown above and below the target line in the long distance inline suggestion preview. Set to 0 to only show the target line."),
+					tags: ['nextEditSuggestions', 'experimental'],
+					experiment: {
+						mode: 'auto'
+					}
+				},
 				'editor.inlineSuggest.edits.renderSideBySide': {
 					type: 'string',
 					default: defaults.edits.renderSideBySide,
@@ -4708,6 +4726,7 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 			showCollapsed: boolean(input.showCollapsed, this.defaultValue.edits.showCollapsed),
 			allowCodeShifting: stringSet(input.allowCodeShifting, this.defaultValue.edits.allowCodeShifting, ['always', 'horizontal', 'never']),
 			showLongDistanceHint: boolean(input.showLongDistanceHint, this.defaultValue.edits.showLongDistanceHint),
+			longDistanceHintContextLineCount: EditorIntOption.clampedInt(input.longDistanceHintContextLineCount, this.defaultValue.edits.longDistanceHintContextLineCount, 0, 10),
 			renderSideBySide: stringSet(input.renderSideBySide, this.defaultValue.edits.renderSideBySide, ['never', 'auto']),
 		};
 	}

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/longDistancePreviewEditor.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/longDistancePreviewEditor.ts
@@ -9,6 +9,7 @@ import { clamp } from '../../../../../../../../base/common/numbers.js';
 import { IObservable, derived, constObservable, IReader, autorun, observableValue } from '../../../../../../../../base/common/observable.js';
 import { IInstantiationService } from '../../../../../../../../platform/instantiation/common/instantiation.js';
 import { ICodeEditor } from '../../../../../../../browser/editorBrowser.js';
+import { EditorOption } from '../../../../../../../common/config/editorOptions.js';
 import { ObservableCodeEditor, observableCodeEditor } from '../../../../../../../browser/observableCodeEditor.js';
 import { EmbeddedCodeEditorWidget } from '../../../../../../../browser/widget/codeEditor/embeddedCodeEditorWidget.js';
 import { IDimension } from '../../../../../../../common/core/2d/dimension.js';
@@ -36,6 +37,16 @@ export interface ILongDistancePreviewProps {
 	 * When undefined (or same as the editor's model URI), the edit targets the current file.
 	 */
 	target: TextModelValueReference;
+}
+
+/**
+ * Widens the previewed range around `targetLineNumber` by `contextLineCount` lines on each side,
+ * clamped to the model bounds. With `contextLineCount === 0` this returns just the target line.
+ */
+function expandLineRangeWithContext(targetLineNumber: number, contextLineCount: number, lineCount: number): LineRange {
+	const startLineNumber = Math.max(1, targetLineNumber - contextLineCount);
+	const endLineNumberExclusive = Math.min(lineCount + 1, targetLineNumber + contextLineCount + 1);
+	return new LineRange(startLineNumber, endLineNumberExclusive);
 }
 
 export class LongDistancePreviewEditor extends Disposable {
@@ -107,7 +118,7 @@ export class LongDistancePreviewEditor extends Disposable {
 				return;
 			}
 			// Ensure there is enough space to the left of the line number for the gutter indicator to fits.
-			const lineNumberDigets = state.visibleLineRange.startLineNumber.toString().length;
+			const lineNumberDigets = (state.visibleLineRange.endLineNumberExclusive - 1).toString().length;
 			this.previewEditor.updateOptions({ lineNumbersMinChars: lineNumberDigets + 1 });
 		}));
 
@@ -121,7 +132,7 @@ export class LongDistancePreviewEditor extends Disposable {
 				if (!props) { return undefined; }
 				return new InlineEditsGutterIndicatorData(
 					props.inlineSuggestInfo,
-					LineRange.ofLength(state.visibleLineRange.startLineNumber, 1),
+					LineRange.ofLength(state.targetLineNumber, 1),
 					props.model,
 					undefined,
 				);
@@ -137,6 +148,7 @@ export class LongDistancePreviewEditor extends Disposable {
 
 	private readonly _state = derived<{
 		mode: 'original' | 'modified';
+		targetLineNumber: number;
 		visibleLineRange: LineRange;
 		textModel: TextModelValueReference | undefined;
 		diff: DetailedLineRangeMapping[];
@@ -147,18 +159,18 @@ export class LongDistancePreviewEditor extends Disposable {
 		}
 
 		let mode: 'original' | 'modified';
-		let visibleRange: LineRange;
+		let targetLineNumber: number;
 
 		if (props.nextCursorPosition !== null) {
 			mode = 'original';
-			visibleRange = LineRange.ofLength(props.nextCursorPosition.lineNumber, 1);
+			targetLineNumber = props.nextCursorPosition.lineNumber;
 		} else {
 			if (props.diff[0].innerChanges?.every(c => c.modifiedRange.isEmpty())) {
 				mode = 'original';
-				visibleRange = LineRange.ofLength(props.diff[0].original.startLineNumber, 1);
+				targetLineNumber = props.diff[0].original.startLineNumber;
 			} else {
 				mode = 'modified';
-				visibleRange = LineRange.ofLength(props.diff[0].modified.startLineNumber, 1);
+				targetLineNumber = props.diff[0].modified.startLineNumber;
 			}
 		}
 
@@ -166,9 +178,17 @@ export class LongDistancePreviewEditor extends Disposable {
 			? TextModelValueReference.snapshot(this._previewTextModel)
 			: props.target;
 
+		// Optionally widen the previewed range to include surrounding context lines. This gives the user
+		// a sense of where the jump lands (e.g. when the target line itself is empty) and lets the widget
+		// size itself to the actual code rather than to a single, possibly-empty line.
+		const contextLineCount = this._parentEditorObs.getOption(EditorOption.inlineSuggest).read(reader).edits.longDistanceHintContextLineCount;
+		const displayModel = mode === 'modified' ? this._previewTextModel : props.target.dangerouslyGetUnderlyingModel();
+		const visibleLineRange = expandLineRangeWithContext(targetLineNumber, contextLineCount, displayModel.getLineCount());
+
 		return {
 			mode,
-			visibleLineRange: visibleRange,
+			targetLineNumber,
+			visibleLineRange,
 			textModel,
 			diff: props.diff,
 		};
@@ -250,8 +270,8 @@ export class LongDistancePreviewEditor extends Disposable {
 			return constObservable(null);
 		}
 
-		const previewEditorHeight = this._previewEditorObs.observeLineHeightForLine(viewState.visibleLineRange.startLineNumber);
-		return previewEditorHeight;
+		return this._previewEditorObs.observeLineHeightsForLineRange(viewState.visibleLineRange)
+			.map(heights => heights.reduce((sum, height) => sum + height, 0));
 	}).flatten();
 
 	private _getHorizontalContentRangeInPreviewEditorToShow(editor: ICodeEditor, reader: IReader) {


### PR DESCRIPTION
> **Stacked on #324923** — please review/merge that PR first. This PR's diff is only the config + context changes.

Adds an experiment-driven config that lets the NES "out-of-viewport" long-distance hint preview show surrounding **context lines** instead of only the target line.

### Motivation
When a cursor jump lands on an **empty line**, there is nothing to preview, so the hint widget looks empty (and previously collapsed — see the width fix in the base PR). Showing a few lines of surrounding code gives the user a sense of *where* the jump lands and lets the widget size itself to real content.

### New setting
`editor.inlineSuggest.edits.longDistanceHintContextLineCount`
- `number`, default `0`, range `0–10`
- Experiment-driven (`experiment: { mode: 'auto' }`, tagged `experimental`)
- `0` = current single-line behavior (unchanged). `N` = show `N` context lines above and below the target line.

### Changes
- **`editorOptions.ts`** — interface field, default, registration (min/max + auto-experiment), and `_validateEdits` clamp.
- **`longDistancePreviewEditor.ts`**
  - `expandLineRangeWithContext(target, ctx, lineCount)` helper (clamped to model bounds).
  - `_state` now tracks the target line separately from an expanded `visibleLineRange` (reads the option reactively, clamped to the display model's line count).
  - `contentHeight` sums `observeLineHeightsForLineRange(...)` (was a single-line height).
  - Gutter indicator pinned to the true target line (range start may now be a context line).
  - `lineNumbersMinChars` derived from the max visible line number.
  - `updatePreviewEditorEffect` hidden areas + horizontal-range logic already handled multi-line ranges — no change needed.

### Validation
- `npm run typecheck-client` ✅ and `eslint` ✅.
- To try it: set `"editor.inlineSuggest.edits.longDistanceHintContextLineCount": 2` and trigger an out-of-viewport jump onto an empty line — the preview now shows 2 lines of context on each side.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
