### PR TITLE
NES telemetry: add `isForAnotherDocument` to `inlineCompletion.endOfLife` for UI-accurate cursor-jump metrics

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -1138,6 +1138,7 @@ export type LifetimeSummary = {
 	editKind: string | undefined;
 	longDistanceHintVisible?: boolean;
 	longDistanceHintDistance?: number;
+	isForAnotherDocument?: boolean;
 };
 
 export interface CodeAction {

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -539,6 +539,7 @@ export class InlineCompletionsSource extends Disposable {
 			sameShapeReplacements: undefined,
 			longDistanceHintVisible: undefined,
 			longDistanceHintDistance: undefined,
+			isForAnotherDocument: undefined,
 			notShownReason: undefined,
 			renameCreated: false,
 			renameDuration: undefined,

--- a/src/vs/editor/contrib/inlineCompletions/browser/telemetry.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/telemetry.ts
@@ -60,6 +60,7 @@ export type InlineCompletionEndOfLifeEvent = {
 	sameShapeReplacements: boolean | undefined;
 	longDistanceHintVisible: boolean | undefined;
 	longDistanceHintDistance: number | undefined;
+	isForAnotherDocument: boolean | undefined;
 	// empty
 	noSuggestionReason: string | undefined;
 	// shape
@@ -113,6 +114,7 @@ type InlineCompletionsEndOfLifeClassification = {
 	sameShapeReplacements: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether all inner replacements are the same shape' };
 	longDistanceHintVisible: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether a long distance hint was rendered' };
 	longDistanceHintDistance: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The distance in lines between the long distance hint and the inline edit' };
+	isForAnotherDocument: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the inline edit targets a different document than the one currently being edited' };
 	noSuggestionReason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The reason why no inline completion was provided' };
 	notShownReason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The reason why the inline completion was not shown' };
 	performanceMarkers: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Performance markers for the inline completion lifecycle' };

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -292,7 +292,8 @@ export class InlineEditsView extends Disposable {
 		if (model.inlineEdit.action === undefined) {
 			return undefined;
 		}
-		if (model.inlineEdit.originalText.uri.toString() !== this._editorObs.model.read(reader)?.uri.toString()) {
+		const editorModel = this._editorObs.model.read(reader);
+		if (!editorModel || !model.inlineEdit.originalText.targets(editorModel)) {
 			return {
 				isVisible: true,
 				lineNumber: model.inlineEdit.cursorPosition.lineNumber,
@@ -358,6 +359,8 @@ export class InlineEditsView extends Disposable {
 		if (longDistanceHint && longDistanceHint.isVisible) {
 			state.viewData.setLongDistanceViewData(longDistanceHint.lineNumber, inlineEdit.lineEdit.lineRange.startLineNumber);
 		}
+
+		state.viewData.isForAnotherDocument = !inlineEdit.originalText.targets(textModel);
 
 		if (state.kind === InlineCompletionViewKind.SideBySide) {
 			const indentationAdjustmentEdit = createReindentEdit(newText.getValue(), inlineEdit.modifiedLineRange, textModel.getOptions().tabSize);
@@ -553,7 +556,7 @@ export class InlineEditsView extends Disposable {
 			return {
 				kind: InlineCompletionViewKind.JumpTo as const,
 				position: model.inlineEdit.action.position,
-				viewData: emptyViewData,
+				viewData: createEmptyViewData(),
 			};
 		}
 
@@ -676,10 +679,10 @@ export class InlineEditsView extends Disposable {
 	}
 }
 
-const emptyViewData = new InlineCompletionViewData(-1, -1, -1, -1, -1, -1, -1, true);
+const createEmptyViewData = () => new InlineCompletionViewData(-1, -1, -1, -1, -1, -1, -1, true);
 function getViewData(inlineEdit: InlineEditWithChanges, stringChanges: { originalRange: Range; modifiedRange: Range; original: string; modified: string }[], textModel: ITextModel) {
 	if (!inlineEdit.edit) {
-		return emptyViewData;
+		return createEmptyViewData();
 	}
 
 	const cursorPosition = inlineEdit.cursorPosition;

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
@@ -49,13 +49,8 @@ export class InlineCompletionViewData {
 	public longDistanceHintVisible: boolean | undefined = undefined;
 	public longDistanceHintDistance: number | undefined = undefined;
 	/**
-	 * Whether the suggestion targets a different text model (URI) than the one in the active
-	 * editor, i.e. a cross-document Next Edit Suggestion. Stays `undefined` for inline completions /
-	 * ghost text, which are never cross-document.
-	 *
-	 * While shown, a cross-document suggestion is always surfaced via the long distance hint, so
-	 * `longDistanceHintVisible` co-occurs (`true`) whenever this is `true`. Consumers that want the
-	 * same-document long-distance case should therefore use `longDistanceHintVisible && !isForAnotherDocument`.
+	 * Whether the suggestion targets a different text model (URI) than the active editor's,
+	 * i.e. a cross-document Next Edit Suggestion. `undefined` for inline completions / ghost text.
 	 */
 	public isForAnotherDocument: boolean | undefined = undefined;
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViewInterface.ts
@@ -48,6 +48,16 @@ export class InlineCompletionViewData {
 
 	public longDistanceHintVisible: boolean | undefined = undefined;
 	public longDistanceHintDistance: number | undefined = undefined;
+	/**
+	 * Whether the suggestion targets a different text model (URI) than the one in the active
+	 * editor, i.e. a cross-document Next Edit Suggestion. Stays `undefined` for inline completions /
+	 * ghost text, which are never cross-document.
+	 *
+	 * While shown, a cross-document suggestion is always surfaced via the long distance hint, so
+	 * `longDistanceHintVisible` co-occurs (`true`) whenever this is `true`. Consumers that want the
+	 * same-document long-distance case should therefore use `longDistanceHintVisible && !isForAnotherDocument`.
+	 */
+	public isForAnotherDocument: boolean | undefined = undefined;
 
 	constructor(
 		public readonly cursorColumnDistance: number,
@@ -76,7 +86,8 @@ export class InlineCompletionViewData {
 			disjointReplacements: this.disjointReplacements,
 			sameShapeReplacements: this.sameShapeReplacements,
 			longDistanceHintVisible: this.longDistanceHintVisible,
-			longDistanceHintDistance: this.longDistanceHintDistance
+			longDistanceHintDistance: this.longDistanceHintDistance,
+			isForAnotherDocument: this.isForAnotherDocument
 		};
 	}
 }

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/inlineEditsLongDistanceHint.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/inlineEditsLongDistanceHint.ts
@@ -413,9 +413,9 @@ export class InlineEditsLongDistanceHint extends Disposable implements IInlineEd
 					}
 
 					// Check if this is a cross-file edit
-					const currentUri = this._editorObs.model.read(reader)?.uri;
+					const currentModel = this._editorObs.model.read(reader);
 					const targetUri = viewState.target.uri;
-					const isCrossFileEdit = targetUri && (!currentUri || targetUri.toString() !== currentUri.toString());
+					const isCrossFileEdit = !currentModel || !viewState.target.targets(currentModel);
 
 					if (isCrossFileEdit) {
 						// For cross-file edits, show target filename instead of outline

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7794,6 +7794,7 @@ declare namespace monaco.languages {
 		editKind: string | undefined;
 		longDistanceHintVisible?: boolean;
 		longDistanceHintDistance?: number;
+		isForAnotherDocument?: boolean;
 	};
 
 	export interface CodeAction {

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -1513,6 +1513,7 @@ class ExtensionBackedInlineCompletionsProvider extends Disposable implements lan
 			editKind: lifetimeSummary.editKind,
 			longDistanceHintVisible: lifetimeSummary.longDistanceHintVisible,
 			longDistanceHintDistance: lifetimeSummary.longDistanceHintDistance,
+			isForAnotherDocument: lifetimeSummary.isForAnotherDocument,
 			...forwardToChannelIf(isCopilotLikeExtension(this.providerId.extensionId!)),
 		};
 


### PR DESCRIPTION
Fixes microsoft/vscode-internalbacklog#7953 

cc @bstee615 @hediet 

## Problem

Inline-suggestion scorecards track **Shown/Accepted/RejectedCursorJump** metrics, but they're filtered on whether the _separate cursor-jump model_ ran. Diff-patch models subsume that model, so the metric decays toward ~0 even though users still see and act on cursor jumps in the UI. We need UI-accurate, **model-agnostic** jump metrics.

## Approach

The core `inlineCompletion.endOfLife` telemetry event already reports UI-accurate, model-agnostic fields (`shown`, `reason`, `viewKind`, `longDistanceHintVisible`, `longDistanceHintDistance`). The only missing piece: `longDistanceHintVisible` is `true` for **both** same-document long-distance jumps **and** cross-document (another-file) jumps, with no way to tell them apart on the core event. Cross-file was previously only knowable by joining to the Copilot `provideInlineEdit` event, whose distance fields _also_ regress under diff-patch.

This PR adds a single boolean **`isForAnotherDocument`** to the event, computed at render time via the existing `TextModelValueReference.targets()` helper — the same notion that already drives cross-document long-distance-hint rendering. The event is already forwarded to GitHub telemetry as `vscode.inlineCompletion.endOfLife`, so **no Copilot-side change is needed**.

### Changes
- Thread `isForAnotherDocument` through the render → `LifetimeSummary` → telemetry pipeline (`inlineEditsView`, `InlineCompletionViewData`, `languages.ts`, `monaco.d.ts`, `mainThreadLanguageFeatures`, `telemetry.ts`).
- Reuse `TextModelValueReference.targets()` at the two remaining raw URI-comparison sites (`_getLongDistanceHintState` and the long-distance-hint view) so the cross-document definition lives in one place and can't drift.
- Convert the shared mutable `emptyViewData` singleton to a factory so per-suggestion view data (including the new flag) can't leak across suggestions.

## How to consume the telemetry (scorecard)

**Event:** `vscode.inlineCompletion.endOfLife` (GitHub telemetry; core/data-channel name `inlineCompletion.endOfLife`).

A "cursor jump" is a suggestion shown _away from the cursor_ — i.e. surfaced via the long-distance hint. Every field below is independent of the cursor-jump model, so the metrics stay valid under diff-patch models.

**Base cursor-jump metrics**

| Metric | Condition |
|---|---|
| `ShownCursorJump` | `shown = true AND longDistanceHintVisible = true` |
| `AcceptedCursorJump` | _(above)_ `AND reason = 'accepted'` |
| `RejectedCursorJump` | _(above)_ `AND reason = 'rejected'` |

**Split by UI shape (enabled by this PR)**

| Bucket | Condition |
|---|---|
| Another-document jump (cross-file NES UI) | `isForAnotherDocument = true` |
| Same-document long-distance jump | `longDistanceHintVisible = true AND isForAnotherDocument != true` |

**Supplementary fields**
- `viewKind = 'jumpTo'` — the dedicated pre-jump indicator frame.
- `longDistanceHintDistance` — jump magnitude in lines.
- `cursorLineDistance` / `cursorColumnDistance` — cursor→edit offset (same-document).
- `opportunityId` / `correlationId` — correlate with other events if needed.

**Notes / gotchas**
- `longDistanceHintVisible` and `isForAnotherDocument` are `undefined` for plain inline completions, ghost text, and the no-suggestion event — treat `undefined` as **not a jump**.
- At show time, a cross-document suggestion sets **both** `longDistanceHintVisible` and `isForAnotherDocument` to `true`; the `AND isForAnotherDocument != true` exclusion keeps the same-document bucket clean.
- `reason` also has an `'ignored'` value (shown but neither accepted nor explicitly rejected) — bucket it per the existing scorecard convention.
- This replaces reliance on the Copilot `provideInlineEdit` fields `nextCursorLineDistance` / `cursorJumpModelName`, which only populate when the separate cursor-jump model runs.

## Validation
- `npm run typecheck-client`, `npm run monaco-compile-check`, ESLint on touched files, and the hygiene pre-commit hook all pass.
- No behavioral change to rendering; the `targets()` reuse is behavior-preserving (verified equivalent, including null-editor handling).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>