### PR TITLE
Include editor headers in proxy models request

### DIFF
--- a/extensions/copilot/src/lib/node/chatLibMain.ts
+++ b/extensions/copilot/src/lib/node/chatLibMain.ts
@@ -185,6 +185,18 @@ export interface INESProviderOptions {
 	readonly telemetrySender: ITelemetrySender;
 	readonly logTarget?: ILogTarget;
 	/**
+	 * Identifies the host editor (e.g. `{ name: 'vscode', version: '1.99.0' }`).
+	 * Together with {@link editorPluginInfo} this sets the `Editor-Version` and
+	 * `Editor-Plugin-Version` headers on outgoing requests (including the model
+	 * list fetch) so the backend can identify the caller.
+	 */
+	readonly editorInfo: IEditorInfo;
+	/**
+	 * Identifies the plugin/integration embedding the provider (e.g.
+	 * `{ name: 'copilot-chat', version: '0.1.0' }`). See {@link editorInfo}.
+	 */
+	readonly editorPluginInfo: IEditorPluginInfo;
+	/**
 	 * If true, the provider will wait for treatment variables to be set.
 	 * INESProvider.updateTreatmentVariables() must be called to unblock.
 	 */
@@ -386,7 +398,7 @@ class NESProvider extends Disposable implements INESProvider<NESResult> {
 }
 
 function setupServices(options: INESProviderOptions) {
-	const { fetcher, copilotTokenManager, telemetrySender, logTarget } = options;
+	const { fetcher, copilotTokenManager, telemetrySender, logTarget, editorInfo, editorPluginInfo } = options;
 	const builder = new InstantiationServiceBuilder();
 	builder.define(IConfigurationService, new SyncDescriptor(OverridableConfigurationService, [options.configOverrides ?? new Map()]));
 	builder.define(IExperimentationService, new SyncDescriptor(SimpleExperimentationService, [options.waitForTreatmentVariables]));
@@ -402,7 +414,14 @@ function setupServices(options: INESProviderOptions) {
 	builder.define(IDomainService, new SyncDescriptor(DomainService));
 	builder.define(ICAPIClientService, new SyncDescriptor(CAPIClientImpl));
 	builder.define(ICopilotTokenStore, new SyncDescriptor(CopilotTokenStore));
-	builder.define(IEnvService, new SyncDescriptor(NullEnvService));
+	builder.define(IEnvService, new class extends NullEnvService {
+		override getEditorInfo(): NameAndVersion {
+			return new NameAndVersion(editorInfo.name, editorInfo.version);
+		}
+		override getEditorPluginInfo(): NameAndVersion {
+			return new NameAndVersion(editorPluginInfo.name, editorPluginInfo.version);
+		}
+	});
 	builder.define(IFetcherService, new SyncDescriptor(SingleFetcherService, [fetcher]));
 	builder.define(ITelemetryService, new SyncDescriptor(SimpleTelemetryService, [telemetrySender]));
 	builder.define(IAuthenticationService, new SyncDescriptor(StaticGitHubAuthenticationService, [createStaticGitHubTokenProvider()]));

--- a/extensions/copilot/src/lib/vscode-node/test/nesProvider.spec.ts
+++ b/extensions/copilot/src/lib/vscode-node/test/nesProvider.spec.ts
@@ -160,6 +160,8 @@ describe('NESProvider Facade', () => {
 			telemetrySender,
 			terminalService,
 			logTarget,
+			editorInfo: { name: 'my-editor', version: '1.2.3' },
+			editorPluginInfo: { name: 'my-plugin', version: '4.5.6' },
 		});
 		nextEditProvider.updateTreatmentVariables({
 			'config.github.copilot.chat.advanced.inlineEdits.xtabProvider.defaultModelConfigurationString': '{ "modelName": "xtab-test", "promptingStrategy": "copilotNesXtab", "includeTagsInCurrentFile": false }',
@@ -172,6 +174,15 @@ describe('NESProvider Facade', () => {
 		assert.strictEqual(fetcher.requests.length, 2, `Unexpected requests: ${JSON.stringify(fetcher.requests, null, 2)}`);
 		assert.ok(fetcher.requests[0].url.endsWith('/models'), `Unexpected URL: ${fetcher.requests[0].url}`);
 		assert.ok(fetcher.requests[1].url.endsWith('/chat/completions'), `Unexpected URL: ${fetcher.requests[1].url}`);
+
+		// The model list request must carry the editor headers derived from the provided editor info.
+		assert.deepStrictEqual({
+			'Editor-Version': fetcher.requests[0].options.headers?.['Editor-Version'],
+			'Editor-Plugin-Version': fetcher.requests[0].options.headers?.['Editor-Plugin-Version'],
+		}, {
+			'Editor-Version': 'my-editor/1.2.3',
+			'Editor-Plugin-Version': 'my-plugin/4.5.6',
+		});
 
 		assert(fetcher.requests[1].options.json);
 		assert(typeof fetcher.requests[1].options.json === 'object');
@@ -251,6 +262,8 @@ describe('NESProvider Facade', () => {
 				terminalService: new NullTerminalService(),
 				logTarget: new TestLogTarget(),
 				languageDiagnosticsService: diagnosticsService,
+				editorInfo: { name: 'my-editor', version: '1.2.3' },
+				editorPluginInfo: { name: 'my-plugin', version: '4.5.6' },
 			});
 
 			nextEditProvider.updateTreatmentVariables({

--- a/extensions/copilot/src/platform/authentication/test/node/simulationTestCopilotTokenManager.ts
+++ b/extensions/copilot/src/platform/authentication/test/node/simulationTestCopilotTokenManager.ts
@@ -6,6 +6,7 @@
 import { BugIndicatingError } from '../../../../util/vs/base/common/errors';
 import { Emitter, Event, Relay } from '../../../../util/vs/base/common/event';
 import { safeStringify } from '../../../../util/vs/base/common/objects';
+import { getEditorVersionHeaders } from '../../../env/common/envService';
 import { NullEnvService } from '../../../env/common/nullEnvService';
 import { CopilotToken, createTestExtendedTokenInfo, ExtendedTokenInfo, TokenEnvelope } from '../../common/copilotToken';
 import { ICopilotTokenManager, nowSeconds } from '../../common/copilotTokenManager';
@@ -73,7 +74,7 @@ class SimulationTestCopilotTokenManagerFromGitHubToken {
 				{
 					headers: {
 						Authorization: `token ${this._githubToken}`,
-						...NullEnvService.Instance.getEditorVersionHeaders(),
+						...getEditorVersionHeaders(NullEnvService.Instance),
 					}
 				}
 			);

--- a/extensions/copilot/src/platform/env/common/envService.ts
+++ b/extensions/copilot/src/platform/env/common/envService.ts
@@ -135,14 +135,22 @@ export abstract class AbstractEnvService implements IEnvService {
 	 */
 	abstract getEditorPluginInfo(): NameAndVersion;
 
-	getEditorVersionHeaders(): { [key: string]: string } {
-		return {
-			'Editor-Version': this.getEditorInfo().format(),
-			'Editor-Plugin-Version': this.getEditorPluginInfo().format(),
-		};
-	}
-
 	abstract openExternal(target: URI): Promise<boolean>;
+}
+
+/**
+ * Builds the editor-related request headers (`Editor-Version` and `Editor-Plugin-Version`)
+ * that identify the host editor and the Copilot plugin to the backend.
+ *
+ * Implemented as a free function taking any {@link IEnvService} so that it works for every
+ * environment (VS Code, the standalone chat-lib/CLI host, tests) - including implementations
+ * that do not extend {@link AbstractEnvService}.
+ */
+export function getEditorVersionHeaders(envService: IEnvService): { [key: string]: string } {
+	return {
+		'Editor-Version': envService.getEditorInfo().format(),
+		'Editor-Plugin-Version': envService.getEditorPluginInfo().format(),
+	};
 }
 
 // FIXME: This needs to be used in locations where the EnvService is not yet available, so it's

--- a/extensions/copilot/src/platform/proxyModels/node/proxyModelsService.ts
+++ b/extensions/copilot/src/platform/proxyModels/node/proxyModelsService.ts
@@ -12,6 +12,7 @@ import { autorun, observableFromEvent } from '../../../util/vs/base/common/obser
 import { CopilotToken } from '../../authentication/common/copilotToken';
 import { ICopilotTokenStore } from '../../authentication/common/copilotTokenStore';
 import { ICAPIClientService } from '../../endpoint/common/capiClient';
+import { getEditorVersionHeaders, IEnvService } from '../../env/common/envService';
 import { WireTypes } from '../../inlineEdits/common/dataTypes/inlineEditsModelsTypes';
 import { ILogService } from '../../log/common/logService';
 import { IFetcherService, Response } from '../../networking/common/fetcherService';
@@ -30,6 +31,7 @@ export class ProxyModelsService extends Disposable implements IProxyModelsServic
 		@ICAPIClientService private readonly _capiClient: ICAPIClientService,
 		@IFetcherService private readonly _fetchService: IFetcherService,
 		@ILogService private readonly _logService: ILogService,
+		@IEnvService private readonly _envService: IEnvService,
 	) {
 		super();
 
@@ -89,6 +91,7 @@ export class ProxyModelsService extends Disposable implements IProxyModelsServic
 			r = await this._fetchService.fetch(url, {
 				headers: {
 					'Authorization': `Bearer ${copilotToken.token}`,
+					...getEditorVersionHeaders(this._envService),
 				},
 				method: 'GET',
 				timeout: 10_000,

--- a/extensions/copilot/src/platform/proxyModels/test/node/proxyModelsService.spec.ts
+++ b/extensions/copilot/src/platform/proxyModels/test/node/proxyModelsService.spec.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { suite, test } from 'vitest';
+import { Event } from '../../../../util/vs/base/common/event';
+import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
+import { CopilotToken, createTestExtendedTokenInfo } from '../../../authentication/common/copilotToken';
+import { ICopilotTokenStore } from '../../../authentication/common/copilotTokenStore';
+import { getEditorVersionHeaders, IEnvService } from '../../../env/common/envService';
+import { FetchOptions, IAbortController, IFetcherService, PaginationOptions, Response, WebSocketConnection } from '../../../networking/common/fetcherService';
+import { createFakeResponse } from '../../../test/node/fetcher';
+import { createPlatformServices } from '../../../test/node/services';
+import { ProxyModelsService } from '../../node/proxyModelsService';
+
+suite('ProxyModelsService', function () {
+
+	test('includes editor-related headers when fetching the models list', async function () {
+		let capturedHeaders: { [name: string]: string } | undefined;
+
+		class CapturingFetcherService implements IFetcherService {
+			declare readonly _serviceBrand: undefined;
+			readonly onDidFetch = Event.None;
+			readonly onDidCompleteFetch = Event.None;
+
+			getUserAgentLibrary(): string {
+				return 'test';
+			}
+			fetch(url: string, options: FetchOptions): Promise<Response> {
+				capturedHeaders = options.headers;
+				return Promise.resolve(createFakeResponse(200, { models: [] }));
+			}
+			createWebSocket(): WebSocketConnection {
+				throw new Error('Method not implemented.');
+			}
+			disconnectAll(): Promise<unknown> {
+				throw new Error('Method not implemented.');
+			}
+			makeAbortController(): IAbortController {
+				return new AbortController();
+			}
+			isAbortError(): boolean {
+				return false;
+			}
+			isInternetDisconnectedError(): boolean {
+				return false;
+			}
+			isFetcherError(): boolean {
+				return false;
+			}
+			isNetworkProcessCrashedError(): boolean {
+				return false;
+			}
+			getUserMessageForFetcherError(): string {
+				throw new Error('Method not implemented.');
+			}
+			fetchWithPagination<T>(_baseUrl: string, _options: PaginationOptions<T>): Promise<T[]> {
+				throw new Error('Method not implemented.');
+			}
+		}
+
+		const testingServiceCollection = createPlatformServices();
+		testingServiceCollection.define(IFetcherService, new CapturingFetcherService());
+		const accessor = testingServiceCollection.createTestingAccessor();
+
+		// Seed the token store so the service fetches the models list on construction.
+		accessor.get(ICopilotTokenStore).copilotToken = new CopilotToken(createTestExtendedTokenInfo({ token: 'test-token' }));
+
+		const service = accessor.get(IInstantiationService).createInstance(ProxyModelsService);
+		try {
+			await Event.toPromise(service.onModelListUpdated);
+		} finally {
+			service.dispose();
+		}
+
+		assert.deepStrictEqual(capturedHeaders, {
+			'Authorization': `Bearer test-token`,
+			...getEditorVersionHeaders(accessor.get(IEnvService)),
+		});
+	});
+});


### PR DESCRIPTION
## Problem

`ProxyModelsService` fetches the models list with a raw request to `${proxyBaseURL}/models` that only set an `Authorization` header. Unlike the `CAPIClient` request path, it bypassed the logic that injects the editor-identifying headers (`Editor-Version`, `Editor-Plugin-Version`), so the backend couldn't identify the caller for that request.

Additionally, the chat-lib NES provider path (`createNESProvider`) registered `NullEnvService`, meaning even after adding the headers it would have emitted placeholder test values (e.g. `simulation-tests-editor/...`) instead of the embedder's real editor identity.

## Fix

- **`envService.ts`**: refactored `getEditorVersionHeaders()` from an `AbstractEnvService` method into an exported free function that accepts any `IEnvService`. This makes it usable across every environment (VS Code, chat-lib/CLI host, tests), including `IEnvService` implementations that don't extend `AbstractEnvService`.
- **`proxyModelsService.ts`**: injected `IEnvService` and spread `...getEditorVersionHeaders(this._envService)` into the `/models` request headers.
- **`chatLibMain.ts`**: `INESProviderOptions` now requires `editorInfo`/`editorPluginInfo` (mirroring the existing completions API `IInlineCompletionsProviderOptions`), and `setupServices` registers a real `IEnvService` built from them. Making these fields **required** means external callers get a compile error on upgrade instead of silently shipping placeholder headers.

## Testing

- New `proxyModelsService.spec.ts` asserts the editor headers are present on the `/models` fetch.
- `nesProvider.spec.ts` extended to prove end-to-end that a chat-lib consumer providing editor info gets the correct `Editor-Version`/`Editor-Plugin-Version` on the `/models` request.
- Typecheck, affected unit tests, and eslint all pass.

## Note

`createNESProvider` callers (e.g. Copilot CLI) must now pass `editorInfo`/`editorPluginInfo`. This is intentional — it surfaces as a compile error rather than a silent behavior regression.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
