### PR TITLE
Render chat turn changes as a checkpoint-style summary

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatChangesSummaryPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatChangesSummaryPart.ts
@@ -5,7 +5,9 @@
 
 import * as dom from '../../../../../../base/browser/dom.js';
 import { $ } from '../../../../../../base/browser/dom.js';
+import { ActionBar } from '../../../../../../base/browser/ui/actionbar/actionbar.js';
 import { IListRenderer, IListVirtualDelegate } from '../../../../../../base/browser/ui/list/list.js';
+import { IAction } from '../../../../../../base/common/actions.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Iterable } from '../../../../../../base/common/iterator.js';
 import { combinedDisposable, Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
@@ -35,17 +37,92 @@ import { ChatTreeItem } from '../../chat.js';
 import { ResourcePool } from './chatCollections.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
 
+const CHANGES_SUMMARY_ELEMENT_HEIGHT = 22;
+const CHANGES_SUMMARY_MAX_ITEMS_SHOWN = 6;
+
+/** Options controlling how {@link renderChangesSummaryFileList} renders each row. */
+export interface IChangesSummaryFileListOptions {
+	/**
+	 * Provides the actions shown in a per-row action bar (right-aligned). Return
+	 * an empty array for rows that should have no actions. When omitted, no action
+	 * bar is rendered.
+	 */
+	readonly getRowActions?: (diff: IEditSessionEntryDiff) => IAction[];
+}
+
+/**
+ * Renders the collapsible list of changed files (one row per {@link IEditSessionEntryDiff},
+ * showing the file's resource label and its +added/-removed counts) into `container`,
+ * keeping it in sync with `diffs`. Rows open the file or its diff on activation.
+ * Shared by the checkpoint file changes summary and the agent turn changes summary
+ * so both render an identical list.
+ */
+export function renderChangesSummaryFileList(
+	container: HTMLElement,
+	diffs: IObservable<readonly IEditSessionEntryDiff[]>,
+	instantiationService: IInstantiationService,
+	editorService: IEditorService,
+	configurationService: IConfigurationService,
+	options?: IChangesSummaryFileListOptions,
+): IDisposable {
+	const store = new DisposableStore();
+	const list = store.add(instantiationService.createInstance(CollapsibleChangesSummaryListPool, options)).get();
+	const listNode = list.getHTMLElement();
+	container.appendChild(listNode.parentElement!);
+
+	store.add(list.onDidOpen((item) => {
+		const diff = item.element;
+		if (!diff) {
+			return;
+		}
+
+		const altKey = (dom.isMouseEvent(item.browserEvent) || dom.isKeyboardEvent(item.browserEvent)) && item.browserEvent.altKey;
+		const openInDiffEditorByDefault = configurationService.getValue<boolean>(ChatConfiguration.OpenChangedFileInDiffEditor);
+		const openInDiffEditor = altKey ? !openInDiffEditorByDefault : openInDiffEditorByDefault;
+
+		if (!openInDiffEditor) {
+			const fileURI = ChatEditingSnapshotTextModelContentProvider.getOriginalFileURI(diff.modifiedURI);
+			if (fileURI) {
+				editorService.openEditor({ resource: fileURI, options: { preserveFocus: true } });
+				return;
+			}
+			// The file's origin cannot be recovered (e.g. legacy snapshot URIs):
+			// fall back to the diff editor.
+		}
+
+		editorService.openEditor({
+			original: { resource: diff.originalURI },
+			modified: { resource: diff.modifiedURI },
+			options: { preserveFocus: true }
+		});
+	}));
+
+	store.add(list.onContextMenu(e => {
+		dom.EventHelper.stop(e.browserEvent, true);
+	}));
+
+	store.add(autorun((r) => {
+		const currentDiffs = diffs.read(r);
+
+		const itemsShown = Math.min(currentDiffs.length, CHANGES_SUMMARY_MAX_ITEMS_SHOWN);
+		const height = itemsShown * CHANGES_SUMMARY_ELEMENT_HEIGHT;
+		list.layout(height);
+		listNode.style.height = height + 'px';
+
+		list.splice(0, list.length, currentDiffs);
+	}));
+
+	return store;
+}
+
+
 export class ChatCheckpointFileChangesSummaryContentPart extends Disposable implements IChatContentPart {
 
 	public readonly domNode: HTMLElement;
 
-	public readonly ELEMENT_HEIGHT = 22;
-	public readonly MAX_ITEMS_SHOWN = 6;
-
 	private readonly diffsBetweenRequests = new Map<string, IObservable<IEditSessionEntryDiff | undefined>>();
 
 	private fileChangesDiffsObservable: IObservable<readonly IEditSessionEntryDiff[]>;
-	private list!: WorkbenchList<IEditSessionEntryDiff>;
 	private readonly detailsElement: HTMLDetailsElement;
 
 	constructor(
@@ -182,54 +259,7 @@ export class ChatCheckpointFileChangesSummaryContentPart extends Disposable impl
 	}
 
 	private renderFilesList(container: HTMLElement): IDisposable {
-		const store = new DisposableStore();
-		this.list = store.add(this.instantiationService.createInstance(CollapsibleChangesSummaryListPool)).get();
-		const listNode = this.list.getHTMLElement();
-		container.appendChild(listNode.parentElement!);
-
-		store.add(this.list.onDidOpen((item) => {
-			const diff = item.element;
-			if (!diff) {
-				return;
-			}
-
-			const altKey = (dom.isMouseEvent(item.browserEvent) || dom.isKeyboardEvent(item.browserEvent)) && item.browserEvent.altKey;
-			const openInDiffEditorByDefault = this.configurationService.getValue<boolean>(ChatConfiguration.OpenChangedFileInDiffEditor);
-			const openInDiffEditor = altKey ? !openInDiffEditorByDefault : openInDiffEditorByDefault;
-
-			if (!openInDiffEditor) {
-				const fileURI = ChatEditingSnapshotTextModelContentProvider.getOriginalFileURI(diff.modifiedURI);
-				if (fileURI) {
-					this.editorService.openEditor({ resource: fileURI, options: { preserveFocus: true } });
-					return;
-				}
-				// The file's origin cannot be recovered (e.g. legacy snapshot URIs):
-				// fall back to the diff editor.
-			}
-
-			this.editorService.openEditor({
-				original: { resource: diff.originalURI },
-				modified: { resource: diff.modifiedURI },
-				options: { preserveFocus: true }
-			});
-		}));
-
-		store.add(this.list.onContextMenu(e => {
-			dom.EventHelper.stop(e.browserEvent, true);
-		}));
-
-		store.add(autorun((r) => {
-			const diffs = this.fileChangesDiffsObservable.read(r);
-
-			const itemsShown = Math.min(diffs.length, this.MAX_ITEMS_SHOWN);
-			const height = itemsShown * this.ELEMENT_HEIGHT;
-			this.list.layout(height);
-			listNode.style.height = height + 'px';
-
-			this.list.splice(0, this.list.length, diffs);
-		}));
-
-		return store;
+		return renderChangesSummaryFileList(container, this.fileChangesDiffsObservable, this.instantiationService, this.editorService, this.configurationService);
 	}
 
 	hasSameContent(other: IChatRendererContent, followingContent: IChatRendererContent[], element: ChatTreeItem): boolean {
@@ -250,6 +280,7 @@ class CollapsibleChangesSummaryListPool extends Disposable {
 	private _resourcePool: ResourcePool<IChatFileChangesSummaryListWrapper>;
 
 	constructor(
+		private readonly options: IChangesSummaryFileListOptions | undefined,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IThemeService private readonly themeService: IThemeService
 	) {
@@ -267,7 +298,7 @@ class CollapsibleChangesSummaryListPool extends Disposable {
 			'ChatListRenderer',
 			container,
 			new CollapsibleChangesSummaryListDelegate(),
-			[this.instantiationService.createInstance(CollapsibleChangesSummaryListRenderer, resourceLabels)],
+			[new CollapsibleChangesSummaryListRenderer(resourceLabels, this.options)],
 			{
 				alwaysConsumeMouseWheel: false
 			}
@@ -287,6 +318,7 @@ class CollapsibleChangesSummaryListPool extends Disposable {
 
 interface ICollapsibleChangesSummaryListTemplate extends IDisposable {
 	readonly label: IResourceLabel;
+	readonly actionBar?: ActionBar;
 	changesElement?: HTMLElement;
 }
 
@@ -308,11 +340,30 @@ class CollapsibleChangesSummaryListRenderer implements IListRenderer<IEditSessio
 
 	readonly templateId: string = CollapsibleChangesSummaryListRenderer.TEMPLATE_ID;
 
-	constructor(private labels: ResourceLabels) { }
+	constructor(
+		private labels: ResourceLabels,
+		private readonly options?: IChangesSummaryFileListOptions,
+	) { }
 
 	renderTemplate(container: HTMLElement): ICollapsibleChangesSummaryListTemplate {
 		const label = this.labels.create(container, { supportHighlights: true, supportIcons: true });
-		return { label, dispose: () => label.dispose() };
+		// Only when a row-action provider is supplied do we add a right-aligned
+		// action bar; the row becomes a flex row so the label fills the remaining
+		// width and the actions hug the right edge.
+		let actionBar: ActionBar | undefined;
+		if (this.options?.getRowActions) {
+			container.classList.add('chat-summary-list-row-with-actions');
+			const actionsContainer = container.appendChild($('.chat-summary-list-actions'));
+			actionBar = new ActionBar(actionsContainer);
+		}
+		return {
+			label,
+			actionBar,
+			dispose: () => {
+				label.dispose();
+				actionBar?.dispose();
+			}
+		};
 	}
 
 	renderElement(data: IEditSessionEntryDiff, index: number, templateData: ICollapsibleChangesSummaryListTemplate): void {
@@ -335,6 +386,11 @@ class CollapsibleChangesSummaryListRenderer implements IListRenderer<IEditSessio
 			removed.textContent = `-${data.removed}`;
 
 			templateData.changesElement = changesSummary;
+		}
+
+		if (templateData.actionBar && this.options?.getRowActions) {
+			templateData.actionBar.clear();
+			templateData.actionBar.push(this.options.getRowActions(data), { icon: false, label: true });
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatChangesSummaryPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatChangesSummaryPart.ts
@@ -325,7 +325,7 @@ interface ICollapsibleChangesSummaryListTemplate extends IDisposable {
 class CollapsibleChangesSummaryListDelegate implements IListVirtualDelegate<IEditSessionEntryDiff> {
 
 	getHeight(element: IEditSessionEntryDiff): number {
-		return 22;
+		return CHANGES_SUMMARY_ELEMENT_HEIGHT;
 	}
 
 	getTemplateId(element: IEditSessionEntryDiff): string {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTurnPillsPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTurnPillsPart.ts
@@ -3,34 +3,47 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as dom from '../../../../../../base/browser/dom.js';
 import { $ } from '../../../../../../base/browser/dom.js';
-import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { IAction, toAction } from '../../../../../../base/common/actions.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
+import { combinedDisposable, Disposable, IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { autorun, constObservable, derived, derivedOpts, IObservable } from '../../../../../../base/common/observable.js';
-import { isEqual } from '../../../../../../base/common/resources.js';
+import { basename, isEqual } from '../../../../../../base/common/resources.js';
+import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { URI } from '../../../../../../base/common/uri.js';
-import { localize } from '../../../../../../nls.js';
+import { localize, localize2 } from '../../../../../../nls.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { FileKind } from '../../../../../../platform/files/common/files.js';
+import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
+import { IThemeService } from '../../../../../../platform/theme/common/themeService.js';
+import { DEFAULT_LABELS_CONTAINER, ResourceLabels } from '../../../../../browser/labels.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
-import { IEditSessionEntryDiff } from '../../../common/editing/chatEditingService.js';
-import { IChatRendererContent, IChatTurnPillsPart } from '../../../common/model/chatViewModel.js';
+import { createFileIconThemableTreeContainerScope } from '../../../../files/browser/views/explorerView.js';
 import { MultiDiffEditorInput } from '../../../../multiDiffEditor/browser/multiDiffEditorInput.js';
 import { MultiDiffEditorItem } from '../../../../multiDiffEditor/browser/multiDiffSourceResolverService.js';
+import { IEditSessionEntryDiff } from '../../../common/editing/chatEditingService.js';
+import { IChatRendererContent, IChatTurnPillsPart } from '../../../common/model/chatViewModel.js';
 import { ChatTreeItem } from '../../chat.js';
 import { IChatResponseFileChangesService } from '../../chatResponseFileChangesService.js';
-import { ChatTurnPillsWidget, diffStatsEqual, EMPTY_DIFF_STATS, IChatTurnPillsModel, IDiffStats, IPreviewFile, observeTurnStatusPillsConfig, openChatPreviewFile, previewFilesEqual, previewKind } from '../chatTurnPills.js';
+import { diffStatsEqual, EMPTY_DIFF_STATS, IDiffStats, IPreviewFile, observeTurnStatusPillsConfig, openChatPreviewFile, previewFilesEqual, previewKind } from '../chatTurnPills.js';
+import { renderChangesSummaryFileList } from './chatChangesSummaryPart.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
 
 /**
- * Renders the turn's status pills (changes + preview) inside a completed chat
- * response, mirroring the floating pills shown above the input while the turn
- * streams. Fed by the per-request diffs from {@link IChatResponseFileChangesService}
- * (agent host sessions), so it reflects the same authoritative per-turn changes as
- * the "Changed N files" summary. The part self-hides when the turn produced no
- * changes.
+ * Renders a single agent turn's changes as a checkpoint-style summary: a
+ * `N files changed +ins -del` header with a "View All File Changes" action, an
+ * optional inline "preview <file>" action for the first previewable file the turn
+ * produced, and a disclosure that expands to the list of changed files. Fed by
+ * the per-request diffs from {@link IChatResponseFileChangesService} (agent host
+ * sessions), so it reflects the same authoritative per-turn changes as the
+ * checkpoint "N files changed" summary. Which pieces show is controlled per-turn
+ * by the {@link observeTurnStatusPillsConfig} setting; the part self-hides when
+ * nothing is shown.
  */
 export class ChatTurnPillsContentPart extends Disposable implements IChatContentPart {
 
@@ -42,11 +55,13 @@ export class ChatTurnPillsContentPart extends Disposable implements IChatContent
 		private readonly _content: IChatTurnPillsPart,
 		_context: IChatContentPartRenderContext,
 		@IChatResponseFileChangesService chatResponseFileChangesService: IChatResponseFileChangesService,
-		@ICommandService commandService: ICommandService,
-		@IOpenerService openerService: IOpenerService,
-		@ILogService logService: ILogService,
+		@ICommandService private readonly _commandService: ICommandService,
+		@IOpenerService private readonly _openerService: IOpenerService,
+		@ILogService private readonly _logService: ILogService,
+		@IHoverService private readonly _hoverService: IHoverService,
 		@IEditorService private readonly _editorService: IEditorService,
 		@IConfigurationService configurationService: IConfigurationService,
+		@IThemeService themeService: IThemeService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
 		super();
@@ -87,21 +102,138 @@ export class ChatTurnPillsContentPart extends Disposable implements IChatContent
 		});
 
 		const pillsConfig = observeTurnStatusPillsConfig(configurationService);
-		const model: IChatTurnPillsModel = {
-			stats,
-			previewFiles,
-			changesEnabled: derived(reader => pillsConfig.read(reader).changes),
-			previewEnabled: derived(reader => pillsConfig.read(reader).preview),
-			openChanges: () => this._openChanges(),
-			openPreviewFile: file => openChatPreviewFile(file, commandService, openerService, logService),
-		};
+		const changesEnabled = derived(this, reader => pillsConfig.read(reader).changes);
+		const previewEnabled = derived(this, reader => pillsConfig.read(reader).preview);
+		const showChanges = derived(this, reader => changesEnabled.read(reader) && stats.read(reader).files > 0);
+		const showPreview = derived(this, reader => previewEnabled.read(reader) && previewFiles.read(reader).length > 0);
 
-		const widget = this._register(this._instantiationService.createInstance(ChatTurnPillsWidget, model));
-		this.domNode.appendChild(widget.element);
+		// Reuse the checkpoint summary's structure and classes so the two look
+		// identical. `show-file-icons` (added by the themable tree scope below)
+		// lets the preview action's resource label render the file's themed icon.
+		const root = this.domNode.appendChild($('.checkpoint-file-changes-summary.checkpoint-file-changes-compact'));
+		this._register(createFileIconThemableTreeContainerScope(root, themeService));
+
+		const details = root.appendChild(document.createElement('details'));
+		details.classList.add('checkpoint-file-changes-disclosure');
+		const header = details.appendChild(document.createElement('summary'));
+		header.classList.add('checkpoint-file-changes-summary-header');
+
+		const resourceLabels = this._register(this._instantiationService.createInstance(ResourceLabels, DEFAULT_LABELS_CONTAINER));
+
+		this._register(this._renderChangesHeader(header, stats, showChanges));
+		this._register(this._renderPreviewAction(header, previewFiles, showPreview, resourceLabels));
+		this._register(this._renderChevron(header, details, showChanges));
+
+		// Only feed diffs into the list when the changes summary is shown, so the
+		// disclosure stays empty when just the preview action is enabled. Each
+		// previewable row gets a "Preview" action that opens the file's preview.
+		const listDiffs = derived(this, reader => showChanges.read(reader) ? this._diffs.read(reader) : []);
+		this._register(renderChangesSummaryFileList(details, listDiffs, this._instantiationService, this._editorService, configurationService, {
+			getRowActions: diff => this._getRowActions(diff),
+		}));
 
 		this._register(autorun(reader => {
-			this.domNode.style.display = widget.isVisible.read(reader) ? '' : 'none';
+			this.domNode.style.display = (showChanges.read(reader) || showPreview.read(reader)) ? '' : 'none';
 		}));
+	}
+
+	private _renderChangesHeader(header: HTMLElement, stats: IObservable<IDiffStats>, showChanges: IObservable<boolean>): IDisposable {
+		const filesLabel = header.appendChild($('span.chat-file-changes-label'));
+		const counts = header.appendChild($('span.chat-file-changes-counts', { 'aria-hidden': 'true' }));
+		const addedLabel = counts.appendChild($('span.insertions'));
+		const removedLabel = counts.appendChild($('span.deletions'));
+		const viewAll = this._renderViewAllFileChangesButton(header);
+
+		return combinedDisposable(viewAll, autorun(reader => {
+			const { files, insertions, deletions } = stats.read(reader);
+			const fileCountLabel = files === 1
+				? localize('chat.turnChanges.oneFile', '1 file changed')
+				: localize('chat.turnChanges.manyFiles', '{0} files changed', files);
+			filesLabel.textContent = fileCountLabel;
+			addedLabel.textContent = `+${insertions}`;
+			removedLabel.textContent = `-${deletions}`;
+			header.setAttribute('aria-label', localize(
+				'chat.turnChanges.accessibleSummary',
+				'{0}, {1} lines added, {2} lines deleted',
+				fileCountLabel,
+				insertions,
+				deletions
+			));
+
+			const show = showChanges.read(reader);
+			filesLabel.classList.toggle('hidden', !show);
+			counts.classList.toggle('hidden', !show);
+			viewAll.element.classList.toggle('hidden', !show);
+		}));
+	}
+
+	private _renderViewAllFileChangesButton(header: HTMLElement): { readonly element: HTMLElement } & IDisposable {
+		const button = header.appendChild(document.createElement('button'));
+		button.classList.add('chat-view-changes-icon');
+		button.type = 'button';
+		button.classList.add(...ThemeIcon.asClassNameArray(Codicon.diffMultiple));
+		button.setAttribute('aria-label', localize('chat.viewTurnFileChangesSummary', 'View All File Changes'));
+		const hoverDisposable = this._hoverService.setupDelayedHover(button, () => ({
+			content: localize2('chat.viewTurnFileChangesSummary', 'View All File Changes')
+		}));
+
+		const clickDisposable = dom.addDisposableListener(button, 'click', (e) => {
+			this._openChanges();
+			dom.EventHelper.stop(e, true);
+		});
+
+		return { element: button, dispose: () => combinedDisposable(hoverDisposable, clickDisposable).dispose() };
+	}
+
+	private _renderPreviewAction(header: HTMLElement, previewFiles: IObservable<readonly IPreviewFile[]>, showPreview: IObservable<boolean>, resourceLabels: ResourceLabels): IDisposable {
+		const container = header.appendChild($('.chat-turn-preview'));
+		container.appendChild($('span.chat-turn-preview-separator', { 'aria-hidden': 'true' }));
+
+		const button = container.appendChild(document.createElement('button'));
+		button.classList.add('chat-turn-preview-action');
+		button.type = 'button';
+		const verb = button.appendChild($('span.chat-turn-preview-verb'));
+		verb.textContent = localize('chat.turnPreview.verb', 'preview');
+		const label = this._register(resourceLabels.create(button, { supportIcons: true }));
+
+		const clickDisposable = dom.addDisposableListener(button, 'click', (e) => {
+			this._openPrimaryPreview(previewFiles.get());
+			dom.EventHelper.stop(e, true);
+		});
+
+		return combinedDisposable(clickDisposable, autorun(reader => {
+			const files = previewFiles.read(reader);
+			const primaryFile = files.at(0);
+			if (primaryFile) {
+				label.setResource(
+					{ resource: primaryFile.uri, name: basename(primaryFile.uri) },
+					{ fileKind: FileKind.FILE },
+				);
+				const tooltip = localize('chat.turnPreview.tooltip', 'Open Preview: {0}', basename(primaryFile.uri));
+				button.setAttribute('aria-label', tooltip);
+				button.title = tooltip;
+			}
+			container.classList.toggle('hidden', !showPreview.read(reader));
+		}));
+	}
+
+	private _renderChevron(header: HTMLElement, details: HTMLDetailsElement, showChanges: IObservable<boolean>): IDisposable {
+		const chevron = header.appendChild($('span.chat-file-changes-chevron.chat-collapsible-hover-chevron', { 'aria-hidden': 'true' }));
+		chevron.classList.add(...ThemeIcon.asClassNameArray(Codicon.chevronRight));
+
+		const setExpansionState = () => {
+			header.setAttribute('aria-expanded', String(details.open));
+			chevron.classList.toggle('codicon-chevron-right', !details.open);
+			chevron.classList.toggle('codicon-chevron-down', details.open);
+		};
+		setExpansionState();
+
+		return combinedDisposable(
+			dom.addDisposableListener(details, 'toggle', setExpansionState),
+			autorun(reader => {
+				chevron.classList.toggle('hidden', !showChanges.read(reader));
+			}),
+		);
 	}
 
 	private _openChanges(): void {
@@ -118,6 +250,31 @@ export class ChatTurnPillsContentPart extends Disposable implements IChatContent
 			false,
 		);
 		this._editorService.openEditor(input);
+	}
+
+	private _openPrimaryPreview(files: readonly IPreviewFile[]): void {
+		const primaryFile = files.at(0);
+		if (primaryFile) {
+			openChatPreviewFile(primaryFile, this._commandService, this._openerService, this._logService);
+		}
+	}
+
+	/**
+	 * Row actions for the changed-files list: markdown and HTML files get a
+	 * labelless-icon-free "Preview" action that opens the file as a markdown
+	 * preview or in the integrated browser.
+	 */
+	private _getRowActions(diff: IEditSessionEntryDiff): IAction[] {
+		const kind = previewKind(diff.modifiedURI);
+		if (!kind) {
+			return [];
+		}
+		const file: IPreviewFile = { uri: diff.modifiedURI, kind, created: isEqual(diff.originalURI, diff.modifiedURI) };
+		return [toAction({
+			id: 'chat.turnChanges.previewFile',
+			label: localize('chat.turnChanges.preview', "Preview"),
+			run: () => openChatPreviewFile(file, this._commandService, this._openerService, this._logService),
+		})];
 	}
 
 	hasSameContent(other: IChatRendererContent, _followingContent: IChatRendererContent[], _element: ChatTreeItem): boolean {

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -2946,6 +2946,95 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	display: none;
 }
 
+/* Turn changes summary: reuses the compact checkpoint summary styling and adds an
+	inline "preview <file>" action shown when the turn produced a previewable file. */
+.interactive-session .chat-turn-pills-part .chat-turn-preview {
+	display: flex;
+	align-items: center;
+	flex: none;
+	gap: var(--vscode-spacing-size40);
+	min-width: 0;
+	overflow: hidden;
+}
+
+.interactive-session .chat-turn-pills-part .chat-turn-preview.hidden,
+.interactive-session .chat-turn-pills-part > .checkpoint-file-changes-summary > .checkpoint-file-changes-disclosure > .checkpoint-file-changes-summary-header > .hidden {
+	display: none;
+}
+
+.interactive-session .chat-turn-pills-part .chat-turn-preview-separator {
+	flex: none;
+	width: var(--vscode-strokeThickness);
+	align-self: stretch;
+	margin: var(--vscode-spacing-size20) 0;
+	background-color: var(--vscode-chat-requestBorder);
+}
+
+.interactive-session .chat-turn-pills-part .chat-turn-preview-action {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--vscode-spacing-size40);
+	min-width: 0;
+	max-width: 200px;
+	padding: var(--vscode-spacing-sizeNone) var(--vscode-spacing-size40);
+	border: none;
+	border-radius: var(--vscode-cornerRadius-small);
+	color: inherit;
+	background: transparent;
+	font: inherit;
+	cursor: pointer;
+	overflow: hidden;
+}
+
+.interactive-session .chat-turn-pills-part .chat-turn-preview-action:hover {
+	color: var(--vscode-foreground);
+	background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.interactive-session .chat-turn-pills-part .chat-turn-preview-action:focus-visible {
+	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder);
+	outline-offset: calc(-1 * var(--vscode-strokeThickness));
+}
+
+.interactive-session .chat-turn-pills-part .chat-turn-preview-verb {
+	flex: none;
+}
+
+.interactive-session .chat-turn-pills-part .chat-turn-preview-action .monaco-icon-label {
+	min-width: 0;
+	align-items: center;
+	overflow: hidden;
+}
+
+/* Per-row action bar in the changed-files list (e.g. the "Preview" action). The
+	row becomes a flex row so the file label fills the remaining width and the
+	actions hug the right edge. Scoped via the class the renderer adds only when a
+	row-action provider is supplied. */
+.interactive-session .chat-summary-list .monaco-list-row.chat-summary-list-row-with-actions,
+.interactive-session .chat-summary-list-row-with-actions {
+	display: flex;
+	align-items: center;
+}
+
+.interactive-session .chat-summary-list-row-with-actions > .monaco-icon-label {
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.interactive-session .chat-summary-list-row-with-actions > .chat-summary-list-actions {
+	flex: 0 0 auto;
+	padding-right: var(--vscode-spacing-size40);
+}
+
+.interactive-session .chat-summary-list-actions .action-label {
+	color: var(--vscode-textLink-foreground);
+	cursor: pointer;
+}
+
+.interactive-session .chat-summary-list-actions .action-label:hover {
+	color: var(--vscode-textLink-activeForeground);
+}
+
 .interactive-session .chat-used-context {
 	display: flex;
 	flex-direction: column;

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -2970,6 +2970,13 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	background-color: var(--vscode-chat-requestBorder);
 }
 
+/* In preview-only mode the changes summary (and its label) is hidden, leaving the
+	preview action as the only header content — drop its leading separator so there
+	is no divider with nothing before it. */
+.interactive-session .chat-turn-pills-part .chat-file-changes-label.hidden ~ .chat-turn-preview .chat-turn-preview-separator {
+	display: none;
+}
+
 .interactive-session .chat-turn-pills-part .chat-turn-preview-action {
 	display: inline-flex;
 	align-items: center;

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
@@ -4,7 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from '../../../../../base/common/event.js';
+import { IReference } from '../../../../../base/common/lifecycle.js';
 import { IObservable, observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
@@ -33,6 +35,8 @@ import { INotebookDocumentService } from '../../../../services/notebook/common/n
 import { IViewDescriptorService } from '../../../../common/views.js';
 import { ISCMService } from '../../../../contrib/scm/common/scm.js';
 import { IAgentHostService } from '../../../../../platform/agentHost/common/agentService.js';
+import { IAgentSubscription } from '../../../../../platform/agentHost/common/state/agentSubscription.js';
+import { StateComponents } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { IAgentSessionsService } from '../../../../contrib/chat/browser/agentSessions/agentSessionsService.js';
 import { IAgentHostUntitledProvisionalSessionService } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostSessionWorkingDirectoryResolver.js';
@@ -235,7 +239,27 @@ export function registerChatFixtureServices(reg: ServiceRegistration, options: I
 		override getActiveNotification() { return undefined; }
 	}());
 	reg.defineInstance(IAgentSessionsService, new class extends mock<IAgentSessionsService>() { override readonly model = new class extends mock<IAgentSessionsService['model']>() { override readonly onDidChangeSessions = Event.None; }(); }());
-	reg.defineInstance(IAgentHostService, new class extends mock<IAgentHostService>() { }());
+	// Agent-host chat widgets (e.g. the turn changes summary fixtures) create the
+	// generic config chips lane, which opens a session subscription. Return an
+	// inert, never-hydrating subscription (value `undefined`) so no config chips
+	// render and nothing crashes.
+	reg.defineInstance(IAgentHostService, new class extends mock<IAgentHostService>() {
+		override getSubscription<T>(_kind: StateComponents, _resource: URI): IReference<IAgentSubscription<T>> {
+			return {
+				object: {
+					value: undefined,
+					verifiedValue: undefined,
+					onDidChange: Event.None,
+					onWillApplyAction: Event.None,
+					onDidApplyAction: Event.None,
+				},
+				dispose: () => { },
+			};
+		}
+		override getSubscriptionUnmanaged<T>(_kind: StateComponents, _resource: URI): IAgentSubscription<T> | undefined {
+			return undefined;
+		}
+	}());
 	reg.defineInstance(IAgentHostUntitledProvisionalSessionService, new class extends mock<IAgentHostUntitledProvisionalSessionService>() {
 		override readonly onDidChange = Event.None;
 		override get() { return undefined; }

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatTurnPills.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatTurnPills.fixture.ts
@@ -16,6 +16,7 @@ import { ChatConfiguration } from '../../../../contrib/chat/common/constants.js'
 import { IChatTurnPillsPart } from '../../../../contrib/chat/common/model/chatViewModel.js';
 import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup } from '../fixtureUtils.js';
 import { registerChatFixtureServices } from './chatFixtureUtils.js';
+import { renderChatWidget } from './chatWidget.fixture.js';
 
 // ============================================================================
 // Mock helpers
@@ -41,34 +42,53 @@ function stubFileChangesService(diffs: readonly IEditSessionEntryDiff[]): IChatR
 }
 
 // ============================================================================
-// Render helper
+// Render helper (standalone content part)
 // ============================================================================
 
-function renderTurnPills(ctx: ComponentFixtureContext, diffs: readonly IEditSessionEntryDiff[]): void {
+interface IRenderTurnPillsOptions {
+	readonly diffs: readonly IEditSessionEntryDiff[];
+	/** Per-pill visibility, mirroring the `chat.turnStatusPills` setting. */
+	readonly config?: { readonly changes?: boolean; readonly preview?: boolean };
+	/** When `true`, the changed-files disclosure is expanded. */
+	readonly expanded?: boolean;
+}
+
+function renderTurnPills(ctx: ComponentFixtureContext, options: IRenderTurnPillsOptions): void {
 	const { container, disposableStore } = ctx;
 
 	const instantiationService = createEditorServices(disposableStore, {
 		colorTheme: ctx.theme,
 		additionalServices: (reg) => {
 			// Broad chat service graph: IContextMenuService, IEditorService and the
-			// ResourceLabels dependencies the preview pill needs.
+			// ResourceLabels dependencies the preview action needs.
 			registerChatFixtureServices(reg);
-			reg.defineInstance(IChatResponseFileChangesService, stubFileChangesService(diffs));
+			reg.defineInstance(IChatResponseFileChangesService, stubFileChangesService(options.diffs));
 		},
 	});
 
-	// Both pills are off by default; enable them so the fixture renders.
-	(instantiationService.get(IConfigurationService) as TestConfigurationService).setUserConfiguration(ChatConfiguration.TurnStatusPills, { changes: true, preview: true });
+	// Both pills are off by default; enable the requested ones so the fixture renders.
+	(instantiationService.get(IConfigurationService) as TestConfigurationService).setUserConfiguration(ChatConfiguration.TurnStatusPills, {
+		changes: options.config?.changes ?? true,
+		preview: options.config?.preview ?? true,
+	});
 
 	const content: IChatTurnPillsPart = {
 		kind: 'turnPills',
 		requestId: 'request-1',
 		sessionResource: URI.parse('vscode-chat-session://agent-host/session-1'),
 	};
-	const context = upcastPartial<IChatContentPartRenderContext>({ container });
+	const partContext = upcastPartial<IChatContentPartRenderContext>({ container });
 
-	const part = disposableStore.add(instantiationService.createInstance(ChatTurnPillsContentPart, content, context));
+	const part = disposableStore.add(instantiationService.createInstance(ChatTurnPillsContentPart, content, partContext));
 
+	if (options.expanded) {
+		part.domNode.querySelector<HTMLDetailsElement>('.checkpoint-file-changes-disclosure')!.open = true;
+	}
+
+	// The turn changes summary reuses the checkpoint summary styling, which is
+	// scoped under `.interactive-session` (and relies on `.monaco-workbench` for
+	// codicon sizing custom properties).
+	container.classList.add('monaco-workbench', 'interactive-session');
 	container.style.padding = '12px';
 	container.style.backgroundColor = 'var(--vscode-editor-background)';
 	container.appendChild(part.domNode);
@@ -78,37 +98,137 @@ function renderTurnPills(ctx: ComponentFixtureContext, diffs: readonly IEditSess
 // Fixtures
 // ============================================================================
 
+const CHANGES_ONLY = { changes: true, preview: false } as const;
+const PREVIEW_ONLY = { changes: false, preview: true } as const;
+
 export default defineThemedFixtureGroup({ path: 'chat/' }, {
 
-	ChangesSingleFile: defineComponentFixture({
-		render: (ctx) => renderTurnPills(ctx, [fileDiff('app.ts', 12, 5, false)]),
+	// --- Standalone content part in each of its states ---
+
+	part: defineThemedFixtureGroup({
+		ChangesOnly_SingleFile: defineComponentFixture({
+			render: (ctx) => renderTurnPills(ctx, { config: CHANGES_ONLY, diffs: [fileDiff('app.ts', 12, 5, false)] }),
+		}),
+
+		ChangesOnly_MultipleFiles: defineComponentFixture({
+			render: (ctx) => renderTurnPills(ctx, {
+				config: CHANGES_ONLY,
+				diffs: [
+					fileDiff('app.ts', 42, 7, false),
+					fileDiff('util.ts', 118, 64, false),
+					fileDiff('index.ts', 5, 0, true),
+				],
+			}),
+		}),
+
+		ChangesOnly_Expanded: defineComponentFixture({
+			render: (ctx) => renderTurnPills(ctx, {
+				config: CHANGES_ONLY,
+				expanded: true,
+				diffs: [
+					fileDiff('app.ts', 42, 7, false),
+					fileDiff('util.ts', 118, 64, false),
+					fileDiff('index.ts', 5, 0, true),
+				],
+			}),
+		}),
+
+		ChangesAndPreview_Markdown: defineComponentFixture({
+			render: (ctx) => renderTurnPills(ctx, {
+				diffs: [
+					fileDiff('README.md', 20, 0, true),
+					fileDiff('app.ts', 8, 3, false),
+				],
+			}),
+		}),
+
+		// Expanded list showing the per-row "Preview" action on the markdown and
+		// HTML rows (edited `.ts`/`.css` rows have no preview action).
+		ChangesAndPreview_Expanded: defineComponentFixture({
+			render: (ctx) => renderTurnPills(ctx, {
+				expanded: true,
+				diffs: [
+					fileDiff('README.md', 20, 0, true),
+					fileDiff('index.html', 30, 4, true),
+					fileDiff('app.ts', 8, 3, false),
+					fileDiff('styles.css', 4, 1, false),
+				],
+			}),
+		}),
+
+		ChangesAndPreview_Html: defineComponentFixture({
+			render: (ctx) => renderTurnPills(ctx, {
+				diffs: [
+					fileDiff('index.html', 30, 4, true),
+					fileDiff('styles.css', 8, 3, false),
+				],
+			}),
+		}),
+
+		// With several previewable files only the first is offered.
+		ChangesAndPreview_MultiplePreviewable: defineComponentFixture({
+			render: (ctx) => renderTurnPills(ctx, {
+				diffs: [
+					fileDiff('app.ts', 8, 3, false),
+					fileDiff('README.md', 20, 0, true),
+					fileDiff('index.html', 30, 4, true),
+					fileDiff('CHANGELOG.md', 6, 1, false),
+				],
+			}),
+		}),
+
+		PreviewOnly: defineComponentFixture({
+			render: (ctx) => renderTurnPills(ctx, {
+				config: PREVIEW_ONLY,
+				diffs: [
+					fileDiff('README.md', 20, 0, true),
+					fileDiff('app.ts', 8, 3, false),
+				],
+			}),
+		}),
+
+		NoChanges_Hidden: defineComponentFixture({
+			render: (ctx) => renderTurnPills(ctx, { diffs: [] }),
+		}),
 	}),
 
-	ChangesMultipleFiles: defineComponentFixture({
-		render: (ctx) => renderTurnPills(ctx, [
-			fileDiff('app.ts', 42, 7, false),
-			fileDiff('util.ts', 118, 64, false),
-			fileDiff('index.ts', 5, 0, true),
-		]),
-	}),
+	// --- Turn changes summary inside the entire chat ---
 
-	PreviewMarkdown: defineComponentFixture({
-		render: (ctx) => renderTurnPills(ctx, [
-			fileDiff('README.md', 20, 0, true),
-			fileDiff('app.ts', 8, 3, false),
-		]),
-	}),
+	inChat: defineThemedFixtureGroup({
+		Changes: defineComponentFixture({
+			render: (ctx) => renderChatWidget(ctx, {
+				turnStatusPills: { changes: true },
+				messages: [
+					{
+						user: 'Refactor the fibonacci helper to be iterative',
+						assistant: [
+							{ kind: 'markdown', text: 'I rewrote `fibonacci(n)` to use an iterative loop and updated its callers, avoiding the exponential recursion.' },
+						],
+						fileChanges: [
+							{ name: 'fibon.ts', added: 12, removed: 8, created: false },
+							{ name: 'app.ts', added: 3, removed: 1, created: false },
+						],
+					},
+				],
+			}),
+		}),
 
-	PreviewMultiple: defineComponentFixture({
-		render: (ctx) => renderTurnPills(ctx, [
-			fileDiff('app.ts', 8, 3, false),
-			fileDiff('README.md', 20, 0, true),
-			fileDiff('index.html', 30, 4, true),
-			fileDiff('CHANGELOG.md', 6, 1, false),
-		]),
-	}),
-
-	NoChanges_Hidden: defineComponentFixture({
-		render: (ctx) => renderTurnPills(ctx, []),
+		ChangesAndPreview: defineComponentFixture({
+			render: (ctx) => renderChatWidget(ctx, {
+				turnStatusPills: { changes: true, preview: true },
+				messages: [
+					{
+						user: 'Add a README describing the project',
+						assistant: [
+							{ kind: 'markdown', text: 'I added a `README.md` with an overview, setup steps, and usage notes, and linked it from the docs index.' },
+						],
+						fileChanges: [
+							{ name: 'README.md', added: 42, removed: 0, created: true },
+							{ name: 'docs/index.md', added: 4, removed: 1, created: false },
+						],
+					},
+				],
+			}),
+		}),
 	}),
 });

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatWidget.fixture.ts
@@ -6,8 +6,10 @@
 import * as dom from '../../../../../base/browser/dom.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
+import { constObservable } from '../../../../../base/common/observable.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
+import { URI } from '../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
 import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
 import { Range } from '../../../../../editor/common/core/range.js';
@@ -27,11 +29,22 @@ import { IChatToolRiskAssessmentService, IToolRiskAssessment, ToolRiskLevel } fr
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../../../../contrib/chat/common/constants.js';
+import { SessionType } from '../../../../contrib/chat/common/chatSessionsService.js';
+import { IEditSessionEntryDiff } from '../../../../contrib/chat/common/editing/chatEditingService.js';
+import { IChatResponseFileChangesService } from '../../../../contrib/chat/browser/chatResponseFileChangesService.js';
 import { MockChatService } from '../../../../contrib/chat/test/common/chatService/mockChatService.js';
 import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup } from '../fixtureUtils.js';
 import { FixtureMenuService, registerChatFixtureServices } from './chatFixtureUtils.js';
 
 import '../../../../contrib/chat/browser/widget/media/chat.css';
+
+export interface IFixtureFileChange {
+	readonly name: string;
+	readonly added: number;
+	readonly removed: number;
+	/** Whether the file was created (vs. edited) during the turn. */
+	readonly created: boolean;
+}
 
 export interface IFixtureMessage {
 	readonly user: string; // user prompt text
@@ -42,6 +55,12 @@ export interface IFixtureMessage {
 		| { kind: 'elicitation'; title: string; message: string; confirmation?: { commandLine: string; cwdLabel?: string; cdPrefix?: string }; riskAssessment?: { risk: ToolRiskLevel; explanation: string }; riskLoading?: boolean }
 	>;
 	readonly responseComplete?: boolean;
+	/**
+	 * Per-turn file changes surfaced via {@link IChatResponseFileChangesService},
+	 * used by the turn changes summary. Requires `turnStatusPills` on the fixture
+	 * options to be rendered.
+	 */
+	readonly fileChanges?: ReadonlyArray<IFixtureFileChange>;
 }
 
 export interface IChatWidgetFixtureOptions {
@@ -61,6 +80,22 @@ export interface IChatWidgetFixtureOptions {
 	 * service graph.
 	 */
 	readonly decorateInputPart?: (inputPart: ChatInputPart, instantiationService: IInstantiationService) => void;
+	/**
+	 * When set, renders the chat as an agent host session and enables the turn
+	 * changes summary (`chat.turnStatusPills`), so completed turns with
+	 * {@link IFixtureMessage.fileChanges} show the summary/preview under the
+	 * response.
+	 */
+	readonly turnStatusPills?: { readonly changes?: boolean; readonly preview?: boolean };
+}
+
+function makeFileDiff(change: IFixtureFileChange): IEditSessionEntryDiff {
+	// A created file has no before-content, so the agent host provider maps its
+	// `originalURI` to the `modifiedURI` (equal URIs); an edited file keeps a
+	// distinct original.
+	const modifiedURI = URI.file(`/repo/${change.name}`);
+	const originalURI = change.created ? modifiedURI : URI.file(`/repo/.original/${change.name}`);
+	return { originalURI, modifiedURI, added: change.added, removed: change.removed, quitEarly: false, identical: false, isFinal: true, isBusy: false };
 }
 
 function makeUserMessage(text: string) {
@@ -89,6 +124,11 @@ export async function renderChatWidget(context: ComponentFixtureContext, options
 	const riskFeatureExplicitlyDisabled = options.riskAssessmentEnabled === false;
 	const needsRiskService = hasRiskAssessment || hasRiskLoading || riskFeatureExplicitlyDisabled;
 
+	// Maps a completed turn's requestId to its per-turn file diffs, consumed by
+	// the turn changes summary via the stubbed IChatResponseFileChangesService.
+	const requestDiffs = new Map<string, readonly IEditSessionEntryDiff[]>();
+	const needsTurnPills = !!options.turnStatusPills;
+
 	const instantiationService = createEditorServices(disposableStore, {
 		colorTheme: context.theme,
 		additionalServices: (reg) => {
@@ -107,6 +147,14 @@ export async function renderChatWidget(context: ComponentFixtureContext, options
 				override getWidgetsByLocations() { return []; }
 				override register() { return { dispose() { } }; }
 			}());
+
+			if (needsTurnPills) {
+				reg.defineInstance(IChatResponseFileChangesService, new class extends mock<IChatResponseFileChangesService>() {
+					override getChangesForRequest(_sessionResource: URI, requestId: string) {
+						return constObservable(requestDiffs.get(requestId) ?? []);
+					}
+				}());
+			}
 
 			if (needsRiskService) {
 				reg.defineInstance(ILanguageModelToolsService, new class extends mock<ILanguageModelToolsService>() {
@@ -141,20 +189,32 @@ export async function renderChatWidget(context: ComponentFixtureContext, options
 	});
 	configService.setUserConfiguration('editor', { fontFamily: 'monospace', fontLigatures: false });
 	configService.setUserConfiguration(ChatConfiguration.ToolConfirmationCarousel, true);
+	if (needsTurnPills) {
+		configService.setUserConfiguration(ChatConfiguration.TurnStatusPills, {
+			changes: !!options.turnStatusPills?.changes,
+			preview: !!options.turnStatusPills?.preview,
+		});
+	}
 
 	// Build a real ChatModel populated with hand-crafted requests/responses, then drive a
 	// real ChatViewModel + ChatListWidget — the same components used in production.
+	// The turn changes summary only renders for agent host sessions, so use an
+	// agent-host session resource when turn pills are requested.
+	const sessionResource = needsTurnPills ? URI.parse(`${SessionType.AgentHostCopilot}://turn-pills/session`) : undefined;
 	const chatService = instantiationService.get(IChatService) as MockChatService;
 	const model = disposableStore.add(instantiationService.createInstance(
 		ChatModel,
 		undefined,
-		{ initialLocation: ChatAgentLocation.Chat, canUseTools: true }
+		{ initialLocation: ChatAgentLocation.Chat, canUseTools: true, resource: sessionResource }
 	));
 	chatService.addSession(model);
 
 	for (const message of options.messages) {
 		const request = model.addRequest(makeUserMessage(message.user), { variables: [] }, 0);
 		const response = request.response!;
+		if (message.fileChanges) {
+			requestDiffs.set(request.id, message.fileChanges.map(makeFileDiff));
+		}
 		for (const part of message.assistant ?? []) {
 			if (part.kind === 'markdown') {
 				model.acceptResponseProgress(request, { kind: 'markdownContent', content: new MarkdownString(part.text) });

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatWidget.fixture.ts
@@ -198,9 +198,12 @@ export async function renderChatWidget(context: ComponentFixtureContext, options
 
 	// Build a real ChatModel populated with hand-crafted requests/responses, then drive a
 	// real ChatViewModel + ChatListWidget — the same components used in production.
-	// The turn changes summary only renders for agent host sessions, so use an
-	// agent-host session resource when turn pills are requested.
-	const sessionResource = needsTurnPills ? URI.parse(`${SessionType.AgentHostCopilot}://turn-pills/session`) : undefined;
+	// The turn changes summary only renders for agent host sessions, whose frontend
+	// resource uses the session type as the scheme (e.g. `agent-host-copilotcli:/…`),
+	// which is what `getChatSessionType` / `toAgentHostBackendSessionUri` recognize.
+	const sessionResource = needsTurnPills
+		? URI.from({ scheme: SessionType.AgentHostCopilot, path: '/turn-pills-session' })
+		: undefined;
 	const chatService = instantiationService.get(IChatService) as MockChatService;
 	const model = disposableStore.add(instantiationService.createInstance(
 		ChatModel,


### PR DESCRIPTION
Restyles the chat turn pills part so it no longer looks like floating pills and instead matches the checkpoint file changes summary.

## What changed
- **Checkpoint-style turn summary**: The turn changes part now renders a `N files changed +ins -del` header with a *View All File Changes* action, an optional inline *preview <file>* action for the first previewable (Markdown/HTML) file the turn produced, and an expandable list of changed files. Reuses the checkpoint summary's structure/classes so the two look identical.
- **Shared file list**: Extracted the collapsible file-list rendering into a shared `renderChangesSummaryFileList` helper used by both the checkpoint summary and the turn summary.
- **Per-row Preview action**: Each Markdown/HTML row in the expanded file list gets a right-aligned action bar with a labelless `Preview` action that opens the file in the Markdown preview or the integrated browser.
- **Fixtures**: Added component fixtures for the part in all its states, plus two `entire chat` fixtures rendering the summary in-situ via the real chat list renderer.

## Validation
- `typecheck-client`, ESLint, and repo stylelint all pass on the changed files.
- Local pre-commit hygiene hook could not run in this environment (missing gulp build deps / npm auth); relying on CI hygiene. Committed with `--no-verify` per author approval.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
