### PR TITLE
nes: fix: too-narrow NES long-distance hint preview widget

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/inlineEditsLongDistanceHint.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/inlineEditsLongDistanceHint.ts
@@ -301,7 +301,11 @@ export class InlineEditsLongDistanceHint extends Disposable implements IInlineEd
 		}
 
 		const { previewEditorMargin, widgetPadding, widgetBorder, lowerBarHeight } = layoutConstants;
-		const maxWidgetWidth = Math.min(position === 'overlay' ? MAX_WIDGET_WIDTH.OVERLAY : MAX_WIDGET_WIDTH.EMPTY_SPACE, previewEditorContentLayout.maxEditorWidth + previewEditorMargin + widgetPadding);
+		const maxWidgetWidthUpperBound = position === 'overlay' ? MAX_WIDGET_WIDTH.OVERLAY : MAX_WIDGET_WIDTH.EMPTY_SPACE;
+		// Honor the same `minWidgetWidth` the placement logic guarantees, so a short/empty preview line
+		// (e.g. a jump onto an empty line) can't collapse the widget below its reserved space.
+		const contentBasedWidgetWidth = previewEditorContentLayout.maxEditorWidth + previewEditorMargin + widgetPadding;
+		const maxWidgetWidth = Math.min(maxWidgetWidthUpperBound, Math.max(contentBasedWidgetWidth, layoutConstants.minWidgetWidth));
 
 		const layout = distributeFlexBoxLayout(rectAvailableSpace.width, {
 			spaceBefore: { min: 0, max: 10, priority: 1 },


### PR DESCRIPTION
Fixes the NES (Next Edit Suggestion) "out-of-viewport" long-distance hint — the *"Tab to jump"* preview widget — rendering **too narrow despite ample horizontal space**.

### Problem
The placement logic (`tryFindWidgetOutline`) only accepts a location offering at least `minWidgetWidth` of horizontal space, but `maxWidgetWidth` was then computed purely from the preview **content** width. For a cursor jump landing on a **short or empty line**, `maxEditorWidth` shrinks down to just the gutter, collapsing the widget far below the space already reserved for it (observed: reserved 725px, widget rendered at the 150px flex floor).

### Fix
Floor `maxWidgetWidth` at `layoutConstants.minWidgetWidth` so the widget honors the same minimum the placement logic guarantees.

### Notes
- Split out of #324923 (the crash fix) so it can be reviewed/merged independently — the two changes touch different files and are unrelated.
- `npm run typecheck-client` ✅ and `eslint` ✅.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
