### PR TITLE
NES: add suggestionLineDistanceToCursor to provideInlineEdit telemetry

### DIFF
--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditProviderTelemetry.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditProviderTelemetry.ts
@@ -145,6 +145,11 @@ export interface INextEditProviderTelemetry extends ILlmNESTelemetry, IDiagnosti
 	readonly notebookCellLines: string | undefined;
 	readonly isActiveDocument?: boolean;
 	readonly isMultilineEdit?: boolean;
+	/**
+	 * Signed line distance from the cursor line to the suggested edit's range start line
+	 * (`rangeStartLine - cursorLine`, 0-based). Undefined for cross-document suggestions.
+	 */
+	readonly suggestionLineDistanceToCursor?: number;
 	readonly isEolDifferent?: boolean;
 	readonly isNextEditorVisible?: boolean;
 	readonly isNextEditorRangeVisible?: boolean;
@@ -492,6 +497,7 @@ export class NextEditProviderTelemetryBuilder extends Disposable {
 			pickedNES: this._nesTypePicked,
 			hadLlmNES: this._hadLlmNES,
 			isMultilineEdit: this._isMultilineEdit,
+			suggestionLineDistanceToCursor: this._suggestionLineDistanceToCursor,
 			isEolDifferent: this._isEolDifferent,
 			isActiveDocument: this._isActiveDocument,
 			isNextEditorVisible: this._isNextEditorVisible,
@@ -599,6 +605,17 @@ export class NextEditProviderTelemetryBuilder extends Disposable {
 	private _isMultilineEdit?: boolean;
 	public setIsMultilineEdit(isMultiLine: boolean): this {
 		this._isMultilineEdit = isMultiLine;
+		return this;
+	}
+
+	private _suggestionLineDistanceToCursor?: number;
+	/**
+	 * @param distance Signed line distance from the cursor line to the suggested edit's range
+	 * start line (`rangeStartLine - cursorLine`, 0-based). Pass `undefined` for cross-document
+	 * suggestions where the distance is not meaningful.
+	 */
+	public setSuggestionLineDistanceToCursor(distance: number | undefined): this {
+		this._suggestionLineDistanceToCursor = distance;
 		return this;
 	}
 
@@ -1026,6 +1043,7 @@ export class TelemetrySender implements IDisposable {
 			isActiveDocument,
 			isEolDifferent,
 			isMultilineEdit,
+			suggestionLineDistanceToCursor,
 			isNextEditorRangeVisible,
 			isNextEditorVisible,
 			acceptance,
@@ -1124,6 +1142,7 @@ export class TelemetrySender implements IDisposable {
 				"isNotebook": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the document is a notebook", "isMeasurement": true },
 				"isNESForAnotherDoc": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the NES if for another document", "isMeasurement": true },
 				"isMultilineEdit": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the NES is for a multiline edit", "isMeasurement": true },
+				"suggestionLineDistanceToCursor": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Signed line distance from the cursor line to the suggested edit's range start line (rangeStartLine - cursorLine), 0-based; positive means the suggestion starts below the cursor, negative above, 0 on the same line. Uses the inline-completion request cursor position; undefined for cross-document suggestions.", "isMeasurement": true },
 				"isEolDifferent": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the NES edit and original text have different end of lines", "isMeasurement": true },
 				"isNextEditorVisible": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the next editor is visible", "isMeasurement": true },
 				"isNextEditorRangeVisible": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the next editor range is visible", "isMeasurement": true },
@@ -1239,6 +1258,7 @@ export class TelemetrySender implements IDisposable {
 				isActiveDocument: this._boolToNum(isActiveDocument),
 				isEolDifferent: this._boolToNum(isEolDifferent),
 				isMultilineEdit: this._boolToNum(isMultilineEdit),
+				suggestionLineDistanceToCursor,
 				isNextEditorRangeVisible: this._boolToNum(isNextEditorRangeVisible),
 				isNextEditorVisible: this._boolToNum(isNextEditorVisible),
 				hasNotebookCellMarker: notebookCellMarkerCount > 0 ? 1 : 0,

--- a/extensions/copilot/src/extension/inlineEdits/test/node/nextEditProviderTelemetry.spec.ts
+++ b/extensions/copilot/src/extension/inlineEdits/test/node/nextEditProviderTelemetry.spec.ts
@@ -10,18 +10,23 @@ import { MutableObservableDocument, MutableObservableWorkspace } from '../../../
 import { FetchResultWithStats, IStatelessNextEditTelemetry } from '../../../../platform/inlineEdits/common/statelessNextEditProvider';
 import { eventPropertiesToSimpleObject } from '../../../../platform/telemetry/common/telemetryData';
 import { NullTelemetryService } from '../../../../platform/telemetry/common/nullTelemetryService';
-import { TelemetryEventProperties, TelemetryProperties } from '../../../../platform/telemetry/common/telemetry';
+import { TelemetryEventMeasurements, TelemetryEventProperties, TelemetryProperties } from '../../../../platform/telemetry/common/telemetry';
 import { URI } from '../../../../util/vs/base/common/uri';
 import { OffsetRange } from '../../../../util/vs/editor/common/core/ranges/offsetRange';
 import { StringText } from '../../../../util/vs/editor/common/core/text/abstractText';
-import { IEnhancedTelemetrySendingReason, NextEditProviderTelemetryBuilder, TelemetrySender } from '../../node/nextEditProviderTelemetry';
+import { IEnhancedTelemetrySendingReason, NES_GH_TELEMETRY_EVENT_NAME, NextEditProviderTelemetryBuilder, TelemetrySender } from '../../node/nextEditProviderTelemetry';
 import { INextEditResult } from '../../node/nextEditResult';
 
 class RecordingTelemetryService extends NullTelemetryService {
 	readonly enhancedEvents: { eventName: string; properties?: TelemetryEventProperties }[] = [];
+	readonly ghEvents: { eventName: string; properties?: TelemetryEventProperties; measurements?: TelemetryEventMeasurements }[] = [];
 
 	override sendEnhancedGHTelemetryEvent(eventName: string, properties?: TelemetryEventProperties): void {
 		this.enhancedEvents.push({ eventName, properties });
+	}
+
+	override sendGHTelemetryEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void {
+		this.ghEvents.push({ eventName, properties, measurements });
 	}
 }
 
@@ -558,6 +563,27 @@ describe('TelemetrySender', () => {
 			const properties = await sendAndFlush(response);
 			expect(properties?.fetchResult).toBe(ChatFetchResponseType.Canceled);
 			expect(properties?.modelResponse).toBeUndefined();
+		});
+	});
+
+	describe('suggestionLineDistanceToCursor', () => {
+		function sendAndGetMeasurements(configure: (builder: NextEditProviderTelemetryBuilder) => void): TelemetryEventMeasurements | undefined {
+			telemetryService.ghEvents.length = 0;
+			const result = createMockNextEditResult();
+			const builder = createMockBuilder(undefined);
+			configure(builder);
+			sender.sendTelemetry(result, builder);
+			return telemetryService.ghEvents.find(e => e.eventName === NES_GH_TELEMETRY_EVENT_NAME)?.measurements;
+		}
+
+		test('emits the signed distance, including 0 (same line) which survives serialization', () => {
+			expect(sendAndGetMeasurements(b => b.setSuggestionLineDistanceToCursor(0))?.suggestionLineDistanceToCursor).toBe(0);
+			expect(sendAndGetMeasurements(b => b.setSuggestionLineDistanceToCursor(5))?.suggestionLineDistanceToCursor).toBe(5);
+			expect(sendAndGetMeasurements(b => b.setSuggestionLineDistanceToCursor(-3))?.suggestionLineDistanceToCursor).toBe(-3);
+		});
+
+		test('is undefined when not set (e.g. cross-document suggestion)', () => {
+			expect(sendAndGetMeasurements(() => { })?.suggestionLineDistanceToCursor).toBeUndefined();
 		});
 	});
 });

--- a/extensions/copilot/src/extension/inlineEdits/vscode-node/inlineCompletionProvider.ts
+++ b/extensions/copilot/src/extension/inlineEdits/vscode-node/inlineCompletionProvider.ts
@@ -410,6 +410,12 @@ export class InlineCompletionProviderImpl extends Disposable implements InlineCo
 			telemetryBuilder.setIsNESForOtherEditor(targetDocument !== undefined && targetDocument !== document);
 			telemetryBuilder.setIsActiveDocument(window.activeTextEditor?.document === targetDocument);
 
+			// Signed line distance from the request cursor to the suggested edit's range start.
+			// Only meaningful when both share the active document's coordinate space.
+			if (range && targetDocument === document) {
+				telemetryBuilder.setSuggestionLineDistanceToCursor(range.start.line - position.line);
+			}
+
 			if (!targetDocument) {
 				logger.trace('no next edit suggestion');
 			} else if (hasNotebookCellMarker(document, result.edit.newText)) {


### PR DESCRIPTION
## Why

For Next Edit Suggestions (NES) we can see whether a suggestion was shown/accepted, but not how far it landed from where the user's cursor actually was. Knowing that distance helps us understand suggestion locality and reason about jump/scroll behavior.

## What

Adds a new `suggestionLineDistanceToCursor` measurement to the `provideInlineEdit` telemetry event.

- Value is the **signed** line distance from the request cursor line to the suggested edit's range start line: `rangeStartLine - cursorLine` (0-based). Positive means the suggestion starts below the cursor, negative above, `0` on the same line. This matches the existing `nextCursorLineDistance` convention, so consumers can `abs()` if they only want magnitude.
- Computed in `inlineCompletionProvider` right after the edit range is resolved, using the inline-completion request `position` (same coordinate space as the resolved range). It is only set when the suggestion targets the **active document**; for cross-document / cross-cell NES the single-axis line distance is not meaningful, so it is left `undefined`.
- Plumbed through `NextEditProviderTelemetryBuilder` (field + setter + `build()`), the `__GDPR__` block, and the measurements payload.

## Notes for reviewers

- Emitted as a **measurement** (not a property) on purpose: property serialization drops falsy values, which would silently drop `0` (same line). Measurements are passed through untouched, so `0` stays distinct from `undefined` (not computed / cross-document).
- The value is set for every resolved suggestion (LLM, cached LLM, diagnostics NES), not only shown ones; analysis can filter on the existing `isShown` dimension.
- Added unit tests asserting the emitted measurement for signed values including `0`, and `undefined` when unset.