### PR TITLE
Style overrides: Add notifications and dialogs style overrides

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/notificationsDialogs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/notificationsDialogs.css
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*
+ * Style-override module: "Notifications and Dialogs".
+ *
+ */
+
+.style-override.monaco-workbench .notifications-list-container .notification-list-item {
+	padding: 6px 2px;
+}
+
+.style-override.monaco-workbench .notifications-list-container .notification-list-item .notification-list-item-icon {
+	font-size: var(--vscode-codiconFontSize);
+	margin: 0 8px 0 6px;
+}
+
+.style-override.monaco-workbench .notifications-list-container .notification-list-item .notification-list-item-buttons-container > .monaco-button-dropdown,
+.style-override.monaco-workbench .notifications-list-container .notification-list-item .notification-list-item-buttons-container > .monaco-button {
+	margin: 0 4px 0 0;
+}
+
+.style-override.monaco-workbench .notifications-list-container .notification-list-item .notification-list-item-source {
+	color: var(--vscode-descriptionForeground);
+	margin-left: 24px;
+}
+
+
+.style-override .monaco-dialog-box {
+	padding: 4px;
+	min-width: 440px;
+}
+
+.style-override .monaco-dialog-box:not(.align-vertical) .dialog-message-row .dialog-message-container {
+	padding-left: 8px;
+}
+
+.style-override .monaco-dialog-box .dialog-message-row .dialog-message-container .dialog-message {
+	margin: 2px 0 12px 0;
+	font-size: var(--vscode-fontSize-heading3);
+	font-weight: var(--vscode-agents-fontWeight-semiBold);
+}
+
+.style-override .monaco-dialog-box .dialog-toolbar-row {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+}
+
+.style-override .monaco-dialog-box .dialog-footer-row {
+	padding: 0 8px;
+}
+
+.style-override .monaco-dialog-box .dialog-message-row {
+	padding: 16px 8px 0px;
+}
+
+.style-override .monaco-dialog-box > .dialog-buttons-row {
+	padding: 16px 0px 0px;
+}
+

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/notificationsDialogs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/notificationsDialogs.css
@@ -35,6 +35,7 @@
 
 .style-override .monaco-dialog-box:not(.align-vertical) .dialog-message-row .dialog-message-container {
 	padding-left: 8px;
+	padding-right: 20px;
 }
 
 .style-override .monaco-dialog-box .dialog-message-row .dialog-message-container .dialog-message {

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/notificationsDialogs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/notificationsDialogs.css
@@ -27,7 +27,6 @@
 	margin-left: 24px;
 }
 
-
 .style-override .monaco-dialog-box {
 	padding: 4px;
 	min-width: 440px;

--- a/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
+++ b/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
@@ -27,6 +27,7 @@ import './media/shadows.css';
 import './media/statusBar.css';
 import './media/tabs.css';
 import './media/titlebar.css';
+import './media/notificationsDialogs.css';
 
 interface IStyleOverrideModule {
 	readonly id: string;
@@ -68,7 +69,8 @@ const STYLE_OVERRIDE_MODULES: readonly IStyleOverrideModule[] = [
 	{ id: 'shadows' },
 	{ id: 'statusBar' },
 	{ id: 'tabs' },
-	{ id: 'titlebar' }
+	{ id: 'titlebar' },
+	{ id: 'notificationsDialogs' },
 ];
 
 /**

--- a/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
+++ b/src/vs/workbench/contrib/styleOverrides/browser/styleOverrides.contribution.ts
@@ -18,6 +18,7 @@ import './media/commandCenter.css';
 import './media/editorBorder.css';
 import './media/fontRamp.css';
 import './media/keyboardFocusOnly.css';
+import './media/notificationsDialogs.css';
 import './media/padding.css';
 import './media/paneHeaders.css';
 import './media/roundedCorners.css';
@@ -27,7 +28,6 @@ import './media/shadows.css';
 import './media/statusBar.css';
 import './media/tabs.css';
 import './media/titlebar.css';
-import './media/notificationsDialogs.css';
 
 interface IStyleOverrideModule {
 	readonly id: string;


### PR DESCRIPTION
Introduce a new style override module for notifications and dialogs, enhancing the visual presentation of these components within the application. The changes include new CSS rules for notifications and dialog boxes to improve layout and styling consistency.

<img width="499" height="189" alt="Screenshot 2026-07-08 at 14 41 27" src="https://github.com/user-attachments/assets/1af5a29e-bd62-4a59-827b-8a33f96f5927" />

<img width="471" height="269" alt="Screenshot 2026-07-08 at 14 41 52" src="https://github.com/user-attachments/assets/00903835-b124-4d29-8a18-888e3f4d077d" />

