### PR TITLE
workbench: don't animate counter widget on first render

### DIFF
--- a/src/vs/workbench/browser/animatedCounterWidget.ts
+++ b/src/vs/workbench/browser/animatedCounterWidget.ts
@@ -31,6 +31,7 @@ export interface IAnimatedCounterWidgetOptions {
 export class AnimatedCounterWidget extends Disposable {
 	private _element: HTMLElement;
 	private _count: number | undefined;
+	private _hasRendered = false;
 	private readonly _animationOptions: KeyframeAnimationOptions;
 	private readonly _updateThrottler = this._register(new Throttler());
 
@@ -72,17 +73,21 @@ export class AnimatedCounterWidget extends Disposable {
 		if (count === undefined) {
 			outgoingElement.textContent = '';
 			this._count = undefined;
+			this._hasRendered = false;
 			return;
 		}
 
 		// Create incoming element
 		const incomingElementText = `${this._options.prefix ?? ''}${count}`;
 
-		// Skip the animation when it is disabled (duration of 0) or when
-		// the user prefers reduced motion, just update the text content.
-		if (this._options.duration === 0 || this._accessibilityService.isMotionReduced()) {
+		// Skip the animation when it is disabled (duration of 0), when the user
+		// prefers reduced motion, or on the first render (there is no previous
+		// value to animate from, so animating would look out of place). Just
+		// update the text content.
+		if (this._options.duration === 0 || !this._hasRendered || this._accessibilityService.isMotionReduced()) {
 			outgoingElement.textContent = incomingElementText;
 			this._count = count;
+			this._hasRendered = true;
 			return;
 		}
 


### PR DESCRIPTION
## What

Fixes a bug in `AnimatedCounterWidget` (used by the changes pill) where the counter animated on its very first render.

## Why

The first render transitions the widget's DOM element from empty to the first value. This was treated the same as any value update, so the slide/width animation played on initial render, which looks out of place. The counter should only animate when transitioning between actual values.

## How

- Added a `_hasRendered` flag. On the first render the value is set directly (joining the existing "skip animation" fast path alongside `duration === 0` and reduced-motion), so no animation plays.
- Reset the flag when the count returns to `undefined` (widget cleared/hidden), so the next value it shows renders fresh instead of animating out of an empty element.

## Notes for reviewers

Small, self-contained change to `src/vs/workbench/browser/animatedCounterWidget.ts`. The pre-commit hygiene hook could not run locally (dependencies not installable in this environment), so hygiene will be validated by CI.