### PR TITLE
Show ask-questions carousel in blocked sessions list

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/blockedSessionsIndicatorModel.ts
+++ b/src/vs/sessions/contrib/sessions/browser/blockedSessionsIndicatorModel.ts
@@ -343,6 +343,7 @@ export class BlockedSessionsIndicatorModel extends Disposable {
 					case AgentSessionApprovalKind.Terminal:
 						return RequiresInputKind.TerminalApproval;
 					case AgentSessionApprovalKind.Question:
+					case AgentSessionApprovalKind.QuestionCarousel:
 						return RequiresInputKind.Question;
 					default:
 						return undefined;

--- a/src/vs/sessions/contrib/sessions/browser/blockedSessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/blockedSessionsList.ts
@@ -13,8 +13,8 @@ import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../../platform/a
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { Menus } from '../../../browser/menus.js';
 import { ISession } from '../../../services/sessions/common/session.js';
-import { IApprovedSession, SessionsFlatList } from './views/sessionsList.js';
-import { AgentSessionApprovalModel } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
+import { IApprovedSession, SessionsFlatList, ALL_VISIBLE_APPROVAL_KINDS } from './views/sessionsList.js';
+import { AgentSessionApprovalKind, AgentSessionApprovalModel } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
 
 /** Fixed width of the blocked-sessions list, in pixels. */
 const BLOCKED_LIST_WIDTH = 360;
@@ -30,6 +30,12 @@ export interface IBlockedSessionsListOptions {
 	readonly width?: number;
 	/** Approval model forwarded to the underlying list (see {@link ISessionsFlatListOptions.approvalModel}). */
 	readonly approvalModel?: AgentSessionApprovalModel;
+	/**
+	 * Which pending-approval kinds render inline in a session row. Defaults to
+	 * every kind ({@link ALL_VISIBLE_APPROVAL_KINDS}) so the blocked-sessions list
+	 * surfaces the ask-questions carousel in addition to terminal approvals.
+	 */
+	readonly visibleApprovalKinds?: readonly AgentSessionApprovalKind[];
 }
 
 /**
@@ -86,6 +92,7 @@ export class BlockedSessionsList extends Disposable {
 			approvalModel: options.approvalModel,
 			approvalRowMaxLines: BLOCKED_LIST_APPROVAL_ROW_MAX_LINES,
 			toolbarActions: false,
+			visibleApprovalKinds: options.visibleApprovalKinds ?? ALL_VISIBLE_APPROVAL_KINDS,
 		}));
 
 		this._register(this._list.onDidChangeContentHeight(() => {

--- a/src/vs/sessions/contrib/sessions/browser/blockedSessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/blockedSessionsList.ts
@@ -15,6 +15,7 @@ import { Menus } from '../../../browser/menus.js';
 import { ISession } from '../../../services/sessions/common/session.js';
 import { IApprovedSession, SessionsFlatList, ALL_VISIBLE_APPROVAL_KINDS } from './views/sessionsList.js';
 import { AgentSessionApprovalKind, AgentSessionApprovalModel } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
+import { ISessionCIFailuresProvider, SessionCIFailuresModel } from './sessionCIFailuresModel.js';
 
 /** Fixed width of the blocked-sessions list, in pixels. */
 const BLOCKED_LIST_WIDTH = 360;
@@ -36,6 +37,12 @@ export interface IBlockedSessionsListOptions {
 	 * surfaces the ask-questions carousel in addition to terminal approvals.
 	 */
 	readonly visibleApprovalKinds?: readonly AgentSessionApprovalKind[];
+	/**
+	 * Provides per-session CI failure state so failing-CI rows show an inline
+	 * "Fix CI" row. Defaults to a {@link SessionCIFailuresModel} owned by the
+	 * list; injectable so tests/fixtures can supply preset failures.
+	 */
+	readonly ciFailuresProvider?: ISessionCIFailuresProvider;
 }
 
 /**
@@ -86,6 +93,8 @@ export class BlockedSessionsList extends Disposable {
 
 		this._rowsContainer = append(element, $('.agent-sessions-blocked-list-rows'));
 
+		const ciFailuresProvider = options.ciFailuresProvider ?? this._register(instantiationService.createInstance(SessionCIFailuresModel));
+
 		this._list = this._register(instantiationService.createInstance(SessionsFlatList, this._rowsContainer, {
 			showSessionHover: true,
 			onSessionOpen: options.onSessionOpen,
@@ -93,6 +102,7 @@ export class BlockedSessionsList extends Disposable {
 			approvalRowMaxLines: BLOCKED_LIST_APPROVAL_ROW_MAX_LINES,
 			toolbarActions: false,
 			visibleApprovalKinds: options.visibleApprovalKinds ?? ALL_VISIBLE_APPROVAL_KINDS,
+			ciFailuresProvider,
 		}));
 
 		this._register(this._list.onDidChangeContentHeight(() => {

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -309,6 +309,27 @@
 				white-space: nowrap;
 			}
 		}
+
+		/*
+		 * When a row hosts the ask-questions carousel widget it needs the full
+		 * width and its own (widget-managed) vertical layout, so switch the row
+		 * from the horizontal label + button flex to a single-column block.
+		 */
+		&.has-carousel {
+			display: none;
+			flex-direction: column;
+			align-items: stretch;
+			gap: 0;
+
+			&.visible {
+				display: flex;
+			}
+
+			.session-approval-carousel {
+				min-width: 0;
+				width: 100%;
+			}
+		}
 	}
 }
 

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -331,6 +331,48 @@
 			}
 		}
 	}
+
+	/*
+	 * Inline "Fix CI" row shown in the blocked-sessions list for sessions whose
+	 * pull request has failing checks. A single line of text plus an orange
+	 * "Fix CI" button, mirroring the CI input banner.
+	 */
+	.session-ci-row {
+		display: none;
+		gap: 8px;
+		margin-top: 4px;
+		margin-left: -6px;
+		padding: 4px 4px 4px 6px;
+		box-sizing: border-box;
+		border: 1px solid var(--vscode-contrastBorder, var(--vscode-widget-border, transparent));
+		border-radius: var(--vscode-cornerRadius-large);
+		background-color: var(--vscode-editor-background);
+		color: var(--vscode-editor-foreground);
+		align-items: center;
+
+		&.visible {
+			display: flex;
+		}
+
+		.session-ci-label {
+			flex: 1;
+			min-width: 0;
+			overflow: hidden;
+			white-space: nowrap;
+			text-overflow: ellipsis;
+			font-size: var(--vscode-agents-fontSize-label1, 12px);
+		}
+
+		.session-ci-button {
+			flex-shrink: 0;
+
+			.monaco-button {
+				padding: 2px 10px;
+				font-size: var(--vscode-agents-fontSize-label1, 12px);
+				white-space: nowrap;
+			}
+		}
+	}
 }
 
 /* Show More */

--- a/src/vs/sessions/contrib/sessions/browser/sessionCIFailuresModel.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionCIFailuresModel.ts
@@ -1,0 +1,225 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { raceTimeout } from '../../../../base/common/async.js';
+import { derivedOpts, IObservable, IReaderWithStore } from '../../../../base/common/observable.js';
+import { structuralEquals } from '../../../../base/common/equals.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IChatWidget, IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
+import { ISession } from '../../../services/sessions/common/session.js';
+import { ISessionsService } from '../../../services/sessions/browser/sessionsService.js';
+import { IGitHubService } from '../../github/browser/githubService.js';
+import { GitHubCheckStatus } from '../../github/common/types.js';
+import { buildFixChecksPrompt, getFailedChecks, getPullRequestUrl } from '../../changes/browser/checksActions.js';
+
+/**
+ * Safety bound for waiting on a session's chat widget to bind after opening it.
+ * The wait is primarily event-driven; this only prevents a permanently pending
+ * promise if the widget never appears.
+ */
+const WAIT_FOR_WIDGET_TIMEOUT_MS = 15_000;
+
+/** Snapshot of a session's failing CI checks, used to render the blocked-list CI row. */
+export interface ISessionCIFailures {
+	/** Number of completed checks that failed. */
+	readonly failed: number;
+	/** Number of checks that have completed (succeeded or failed). */
+	readonly completed: number;
+	/** Number of checks still running or queued. */
+	readonly pending: number;
+}
+
+/**
+ * Provides per-session CI failure state to the sessions list so a "Fix CI" row
+ * can be rendered inline (only where the provider is supplied, i.e. the
+ * blocked-sessions list). Mirrors the role of the approval model for terminal
+ * confirmations.
+ */
+export interface ISessionCIFailuresProvider {
+	/**
+	 * Observable of the session's failing-CI state, or `undefined` when the
+	 * session has no failing checks (or the user has already requested a fix).
+	 */
+	getCIFailures(session: ISession): IObservable<ISessionCIFailures | undefined>;
+	/** Send the `fix-ci` prompt for the session's failed checks, opening it first. */
+	fixChecks(session: ISession): Promise<void>;
+}
+
+/**
+ * Concrete {@link ISessionCIFailuresProvider} backed by the GitHub CI models.
+ * The CI check data itself is kept warm by the GitHub polling contribution; this
+ * model only observes the shared, reference-counted models for the sessions it
+ * is asked about.
+ */
+export class SessionCIFailuresModel extends Disposable implements ISessionCIFailuresProvider {
+
+	private readonly _perSession = new Map<string, IObservable<ISessionCIFailures | undefined>>();
+	/** Session resources with a fix-CI request currently in flight (guards double submits). */
+	private readonly _fixInFlight = new Set<string>();
+
+	constructor(
+		@IGitHubService private readonly _gitHubService: IGitHubService,
+		@ISessionsService private readonly _sessionsService: ISessionsService,
+		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+	}
+
+	getCIFailures(session: ISession): IObservable<ISessionCIFailures | undefined> {
+		const key = session.resource.toString();
+		let obs = this._perSession.get(key);
+		if (!obs) {
+			obs = derivedOpts<ISessionCIFailures | undefined>({
+				owner: this,
+				equalsFn: structuralEquals,
+			}, reader => this._compute(reader as IReaderWithStore, session));
+			this._perSession.set(key, obs);
+		}
+		return obs;
+	}
+
+	private _compute(reader: IReaderWithStore, session: ISession): ISessionCIFailures | undefined {
+		const gitHubInfo = session.workspace.read(reader)?.folders[0]?.gitRepository?.gitHubInfo.read(reader);
+		if (!gitHubInfo?.pullRequest) {
+			return undefined;
+		}
+
+		const prRef = reader.store.add(this._gitHubService.createPullRequestModelReference(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number));
+		const livePR = prRef.object.pullRequest.read(reader);
+		if (!livePR) {
+			return undefined;
+		}
+
+		const ciRef = reader.store.add(this._gitHubService.createPullRequestCIModelReference(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number, livePR.headSha));
+		const ciModel = ciRef.object;
+
+		// Once a fix has been requested for this head commit, hide the row until a
+		// new commit lands (a new head SHA yields a fresh model without the flag).
+		if (ciModel.fixRequested.read(reader)) {
+			return undefined;
+		}
+
+		const checks = ciModel.checks.read(reader);
+		const failed = getFailedChecks(checks).length;
+		if (failed === 0) {
+			return undefined;
+		}
+
+		const completed = checks.filter(check => check.status === GitHubCheckStatus.Completed).length;
+		const pending = checks.length - completed;
+		return { failed, completed, pending };
+	}
+
+	async fixChecks(session: ISession): Promise<void> {
+		const key = session.resource.toString();
+		// Guard against overlapping submits (e.g. rapid double clicks): the fix is
+		// only remembered via `markFixRequested()` after the prompt is accepted, so
+		// without this a second click could send a duplicate request.
+		if (this._fixInFlight.has(key)) {
+			return;
+		}
+		this._fixInFlight.add(key);
+		try {
+			await this._fixChecks(session);
+		} catch (err) {
+			this._logService.error('[SessionCIFailuresModel] Failed to fix CI checks for session', session.resource.toString(), err);
+		} finally {
+			this._fixInFlight.delete(key);
+		}
+	}
+
+	private async _fixChecks(session: ISession): Promise<void> {
+		const gitHubInfo = session.workspace.get()?.folders[0]?.gitRepository?.gitHubInfo.get();
+		if (!gitHubInfo?.pullRequest) {
+			return;
+		}
+
+		const store = new DisposableStore();
+		try {
+			const prRef = store.add(this._gitHubService.createPullRequestModelReference(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number));
+			const livePR = prRef.object.pullRequest.get();
+			if (!livePR) {
+				return;
+			}
+
+			const ciRef = store.add(this._gitHubService.createPullRequestCIModelReference(gitHubInfo.owner, gitHubInfo.repo, gitHubInfo.pullRequest.number, livePR.headSha));
+			const ciModel = ciRef.object;
+
+			const failedChecks = getFailedChecks(ciModel.checks.get());
+			if (failedChecks.length === 0) {
+				return;
+			}
+
+			const failedCheckDetails = await Promise.all(failedChecks.map(async check => {
+				const annotations = await ciModel.getCheckRunAnnotations(check.id);
+				return { check, annotations };
+			}));
+
+			const prompt = buildFixChecksPrompt(failedCheckDetails, getPullRequestUrl(ciModel));
+
+			// Open the session, then wait for its chat widget to bind — `openSession`
+			// resolving does not guarantee the widget's view model is set yet.
+			await this._sessionsService.openSession(session.resource);
+			const chatWidget = await this._waitForChatWidget(session.resource);
+			if (!chatWidget) {
+				this._logService.error('[SessionCIFailuresModel] Cannot fix CI checks: no chat widget for session', session.resource.toString());
+				return;
+			}
+
+			const response = await chatWidget.acceptInput(prompt);
+			if (response) {
+				ciModel.markFixRequested();
+			}
+		} finally {
+			store.dispose();
+		}
+	}
+
+	/**
+	 * Resolve the chat widget bound to the given session, waiting for it to be
+	 * added and to bind its view model. Event-driven so it settles as soon as the
+	 * widget appears; a generous timeout only guards against a widget that never
+	 * binds so the promise cannot hang forever.
+	 */
+	private async _waitForChatWidget(sessionResource: URI): Promise<IChatWidget | undefined> {
+		const existing = this._chatWidgetService.getWidgetBySessionResource(sessionResource);
+		if (existing) {
+			return existing;
+		}
+
+		const store = new DisposableStore();
+		const wait = new Promise<IChatWidget>(resolve => {
+			const check = (): boolean => {
+				const widget = this._chatWidgetService.getWidgetBySessionResource(sessionResource);
+				if (widget) {
+					resolve(widget);
+					return true;
+				}
+				return false;
+			};
+			const observe = (widget: IChatWidget) => {
+				// A widget may bind its session view model after being added.
+				store.add(widget.onDidChangeViewModel(() => check()));
+			};
+			for (const widget of this._chatWidgetService.getAllWidgets()) {
+				observe(widget);
+			}
+			store.add(this._chatWidgetService.onDidAddWidget(widget => {
+				observe(widget);
+				check();
+			}));
+			check();
+		});
+
+		try {
+			return await raceTimeout(wait, WAIT_FOR_WIDGET_TIMEOUT_MS);
+		} finally {
+			store.dispose();
+		}
+	}
+}

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -356,9 +356,90 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 	}
 
 	/**
-	 * Render the requires-input pill. Clicking toggles a dropdown that lists the
-	 * blocked sessions below the command center box.
+	 * Whether a blocked session should stay hidden because the user just approved
+	 * its pending action: hidden while that approval resolves (no current approval,
+	 * status lagging) or is unchanged; a new, distinct approval re-surfaces it.
 	 */
+	private _isApprovalDismissed(blocked: IBlockedSession, dismissed: ReadonlyMap<string, string>, reader: IReader): boolean {
+		const dismissedId = dismissed.get(blocked.session.sessionId);
+		if (dismissedId === undefined || blocked.reason !== BlockedSessionReason.NeedsInput) {
+			return false;
+		}
+		const approval = getFirstApprovalAcrossChats(this._approvalModel, blocked.session, reader);
+		return approval === undefined || agentSessionApprovalId(approval) === dismissedId;
+	}
+
+	/**
+	 * Remember that the user allowed this exact approval so the session drops out of
+	 * the blocked set immediately (see {@link _isApprovalDismissed}).
+	 */
+	private _dismissApproval(approved: IApprovedSession): void {
+		const next = new Map(this._dismissedApprovals.get());
+		next.set(approved.session.sessionId, approved.approvalId);
+		this._dismissedApprovals.set(next, undefined);
+	}
+
+	/**
+	 * Classify a single blocked session into a specific requires-input kind, or
+	 * `undefined` when it can't be classified (which forces the generic message).
+	 */
+	private _kindOf(blocked: IBlockedSession, reader: IReader): RequiresInputKind | undefined {
+		switch (blocked.reason) {
+			case BlockedSessionReason.FailingCI:
+				return RequiresInputKind.FailingCI;
+			case BlockedSessionReason.UnresolvedComments:
+				return RequiresInputKind.UnresolvedComments;
+			case BlockedSessionReason.NeedsInput: {
+				const approval = getFirstApprovalAcrossChats(this._approvalModel, blocked.session, reader);
+				switch (approval?.kind) {
+					case AgentSessionApprovalKind.Terminal:
+						return RequiresInputKind.TerminalApproval;
+					case AgentSessionApprovalKind.Question:
+					case AgentSessionApprovalKind.QuestionCarousel:
+						return RequiresInputKind.Question;
+					default:
+						return undefined;
+				}
+			}
+			default:
+				return undefined;
+		}
+	}
+
+	/**
+	 * Build the requires-input pill label. A homogeneous set of blocked sessions
+	 * gets a specific, more actionable message; a mix (or an unclassified session)
+	 * falls back to the generic "N sessions require input".
+	 */
+	private _getRequiresInputLabel(count: number, kind: RequiresInputKind | undefined): string {
+		switch (kind) {
+			case RequiresInputKind.TerminalApproval:
+				return count === 1
+					? localize('oneSessionTerminalApproval', "1 session requires terminal approval")
+					: localize('nSessionsTerminalApproval', "{0} sessions require terminal approval", count);
+			case RequiresInputKind.Question:
+				return count === 1
+					? localize('oneSessionQuestion', "1 session has a question")
+					: localize('nSessionsQuestion', "{0} sessions have questions", count);
+			case RequiresInputKind.FailingCI:
+				return count === 1
+					? localize('oneSessionFailingCI', "1 session is failing CI")
+					: localize('nSessionsFailingCI', "{0} sessions are failing CI", count);
+			case RequiresInputKind.UnresolvedComments:
+				return count === 1
+					? localize('oneSessionUnresolvedComments', "1 session has unresolved comments")
+					: localize('nSessionsUnresolvedComments', "{0} sessions have unresolved comments", count);
+			default:
+				return count === 1
+					? localize('oneSessionRequiresInput', "1 session requires input")
+					: localize('nSessionsRequireInput', "{0} sessions require input", count);
+		}
+}
+
+/**
+ * Render the requires-input pill. Clicking toggles a dropdown that lists the
+ * blocked sessions below the command center box.
+ */
 	private _renderRequiresInput(count: number, kind: RequiresInputKind | undefined, shouldBlink: boolean): void {
 		const container = this._container!;
 		const label = this._blockedIndicator.getRequiresInputLabel(count, kind);

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -356,90 +356,9 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 	}
 
 	/**
-	 * Whether a blocked session should stay hidden because the user just approved
-	 * its pending action: hidden while that approval resolves (no current approval,
-	 * status lagging) or is unchanged; a new, distinct approval re-surfaces it.
+	 * Render the requires-input pill. Clicking toggles a dropdown that lists the
+	 * blocked sessions below the command center box.
 	 */
-	private _isApprovalDismissed(blocked: IBlockedSession, dismissed: ReadonlyMap<string, string>, reader: IReader): boolean {
-		const dismissedId = dismissed.get(blocked.session.sessionId);
-		if (dismissedId === undefined || blocked.reason !== BlockedSessionReason.NeedsInput) {
-			return false;
-		}
-		const approval = getFirstApprovalAcrossChats(this._approvalModel, blocked.session, reader);
-		return approval === undefined || agentSessionApprovalId(approval) === dismissedId;
-	}
-
-	/**
-	 * Remember that the user allowed this exact approval so the session drops out of
-	 * the blocked set immediately (see {@link _isApprovalDismissed}).
-	 */
-	private _dismissApproval(approved: IApprovedSession): void {
-		const next = new Map(this._dismissedApprovals.get());
-		next.set(approved.session.sessionId, approved.approvalId);
-		this._dismissedApprovals.set(next, undefined);
-	}
-
-	/**
-	 * Classify a single blocked session into a specific requires-input kind, or
-	 * `undefined` when it can't be classified (which forces the generic message).
-	 */
-	private _kindOf(blocked: IBlockedSession, reader: IReader): RequiresInputKind | undefined {
-		switch (blocked.reason) {
-			case BlockedSessionReason.FailingCI:
-				return RequiresInputKind.FailingCI;
-			case BlockedSessionReason.UnresolvedComments:
-				return RequiresInputKind.UnresolvedComments;
-			case BlockedSessionReason.NeedsInput: {
-				const approval = getFirstApprovalAcrossChats(this._approvalModel, blocked.session, reader);
-				switch (approval?.kind) {
-					case AgentSessionApprovalKind.Terminal:
-						return RequiresInputKind.TerminalApproval;
-					case AgentSessionApprovalKind.Question:
-					case AgentSessionApprovalKind.QuestionCarousel:
-						return RequiresInputKind.Question;
-					default:
-						return undefined;
-				}
-			}
-			default:
-				return undefined;
-		}
-	}
-
-	/**
-	 * Build the requires-input pill label. A homogeneous set of blocked sessions
-	 * gets a specific, more actionable message; a mix (or an unclassified session)
-	 * falls back to the generic "N sessions require input".
-	 */
-	private _getRequiresInputLabel(count: number, kind: RequiresInputKind | undefined): string {
-		switch (kind) {
-			case RequiresInputKind.TerminalApproval:
-				return count === 1
-					? localize('oneSessionTerminalApproval', "1 session requires terminal approval")
-					: localize('nSessionsTerminalApproval', "{0} sessions require terminal approval", count);
-			case RequiresInputKind.Question:
-				return count === 1
-					? localize('oneSessionQuestion', "1 session has a question")
-					: localize('nSessionsQuestion', "{0} sessions have questions", count);
-			case RequiresInputKind.FailingCI:
-				return count === 1
-					? localize('oneSessionFailingCI', "1 session is failing CI")
-					: localize('nSessionsFailingCI', "{0} sessions are failing CI", count);
-			case RequiresInputKind.UnresolvedComments:
-				return count === 1
-					? localize('oneSessionUnresolvedComments', "1 session has unresolved comments")
-					: localize('nSessionsUnresolvedComments', "{0} sessions have unresolved comments", count);
-			default:
-				return count === 1
-					? localize('oneSessionRequiresInput', "1 session requires input")
-					: localize('nSessionsRequireInput', "{0} sessions require input", count);
-		}
-}
-
-/**
- * Render the requires-input pill. Clicking toggles a dropdown that lists the
- * blocked sessions below the command center box.
- */
 	private _renderRequiresInput(count: number, kind: RequiresInputKind | undefined, shouldBlink: boolean): void {
 		const container = this._container!;
 		const label = this._blockedIndicator.getRequiresInputLabel(count, kind);

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -39,6 +39,9 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../../pla
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { GITHUB_REMOTE_FILE_SCHEME, ISession, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { AgentSessionApprovalKind, AgentSessionApprovalModel, agentSessionApprovalId, IAgentSessionApprovalInfo } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
+import { ISessionCIFailuresProvider } from '../sessionCIFailuresModel.js';
+import { asCssVariable } from '../../../../../platform/theme/common/colorUtils.js';
+import { chartsOrange } from '../../../../../platform/theme/common/colors/chartsColors.js';
 import { ChatQuestionCarouselPart } from '../../../../../workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.js';
 import { IChatContentPartRenderContext } from '../../../../../workbench/contrib/chat/browser/widget/chatContentParts/chatContentParts.js';
 import { IChatQuestionAnswerValue } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
@@ -205,6 +208,12 @@ const APPROVAL_CAROUSEL_ESTIMATE_HEIGHT = 240;
 /** Top-margin of the approval row (matches `.session-approval-row` in the CSS), added to the measured carousel height. */
 const APPROVAL_ROW_CAROUSEL_MARGIN = 4;
 
+/**
+ * Height (px) added to a session row for the inline "Fix CI" row. A single line
+ * of text plus the button, matching `.session-ci-row` in `sessionsList.css`.
+ */
+const CI_ROW_HEIGHT = 36;
+
 //#endregion
 
 //#region Tree Delegate
@@ -229,6 +238,7 @@ class SessionsTreeDelegate implements IListVirtualDelegate<SessionListItem> {
 		private readonly _approvalRowMaxLines: number = DEFAULT_APPROVAL_ROW_MAX_LINES,
 		private readonly _visibleApprovalKinds: readonly AgentSessionApprovalKind[] = DEFAULT_VISIBLE_APPROVAL_KINDS,
 		private readonly _getMeasuredApprovalHeight: (session: ISession) => number | undefined = () => undefined,
+		private readonly _ciFailuresProvider: ISessionCIFailuresProvider | undefined = undefined,
 	) { }
 
 	getHeight(element: SessionListItem): number {
@@ -251,11 +261,14 @@ class SessionsTreeDelegate implements IListVirtualDelegate<SessionListItem> {
 				height += SessionItemRenderer.getApprovalRowHeight(approval.label, this._approvalRowMaxLines);
 			}
 		}
+		if (this._ciFailuresProvider?.getCIFailures(element as ISession).get()) {
+			height += CI_ROW_HEIGHT;
+		}
 		return height;
 	}
 
 	hasDynamicHeight(element: SessionListItem): boolean {
-		return !!this._approvalModel && isSessionItem(element);
+		return (!!this._approvalModel || !!this._ciFailuresProvider) && isSessionItem(element);
 	}
 
 	getTemplateId(element: SessionListItem): string {
@@ -315,6 +328,9 @@ interface ISessionItemTemplate {
 	readonly approvalRow: HTMLElement;
 	readonly approvalLabel: HTMLElement;
 	readonly approvalButtonContainer: HTMLElement;
+	readonly ciRow: HTMLElement;
+	readonly ciLabel: HTMLElement;
+	readonly ciButtonContainer: HTMLElement;
 	readonly contextKeyService: IContextKeyService;
 	readonly disposables: DisposableStore;
 	readonly elementDisposables: DisposableStore;
@@ -362,7 +378,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 	}
 
 	constructor(
-		private readonly options: { grouping: () => SessionsGrouping; isPinned: (session: ISession) => boolean; isRead: (session: ISession) => boolean; visibleSessions: IObservable<readonly (IActiveSession | undefined)[]>; getMultiSelectedSessions: (session: ISession) => ISession[]; isInChatsSection: (session: ISession) => boolean; showHover: boolean; approvalRowMaxLines: number; toolbarActions: boolean; visibleApprovalKinds: readonly AgentSessionApprovalKind[] },
+		private readonly options: { grouping: () => SessionsGrouping; isPinned: (session: ISession) => boolean; isRead: (session: ISession) => boolean; visibleSessions: IObservable<readonly (IActiveSession | undefined)[]>; getMultiSelectedSessions: (session: ISession) => ISession[]; isInChatsSection: (session: ISession) => boolean; showHover: boolean; approvalRowMaxLines: number; toolbarActions: boolean; visibleApprovalKinds: readonly AgentSessionApprovalKind[]; ciFailuresProvider: ISessionCIFailuresProvider | undefined },
 		private readonly approvalModel: AgentSessionApprovalModel | undefined,
 		private readonly instantiationService: IInstantiationService,
 		private readonly contextKeyService: IContextKeyService,
@@ -414,6 +430,16 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		const approvalLabel = DOM.append(approvalRow, $('span.session-approval-label'));
 		const approvalButtonContainer = DOM.append(approvalRow, $('.session-approval-button'));
 
+		// CI failures row ("N checks failed, X pending" + a Fix CI button).
+		const ciRow = DOM.append(mainCol, $('.session-ci-row'));
+		const ciLabel = DOM.append(ciRow, $('span.session-ci-label'));
+		const ciButtonContainer = DOM.append(ciRow, $('.session-ci-button'));
+		// Keep clicks on the CI row (its button) from opening the session.
+		for (const eventType of ['pointerdown', 'pointerup', 'click', 'dblclick'] as const) {
+			disposables.add(DOM.addDisposableListener(ciRow, eventType, e => e.stopPropagation()));
+		}
+		disposables.add(Gesture.ignoreTarget(ciRow));
+
 		const contextKeyService = disposables.add(this.contextKeyService.createScoped(container));
 		const scopedInstantiationService = disposables.add(this.instantiationService.createChild(new ServiceCollection([IContextKeyService, contextKeyService])));
 		// When toolbar actions are disabled (e.g. the blocked-sessions dropdown) the row
@@ -427,7 +453,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			}));
 		}
 
-		return { container, statusIcon, title, titleContainer, titleToolbar, detailsRow, approvalRow, approvalLabel, approvalButtonContainer, contextKeyService, disposables, elementDisposables };
+		return { container, statusIcon, title, titleContainer, titleToolbar, detailsRow, approvalRow, approvalLabel, approvalButtonContainer, ciRow, ciLabel, ciButtonContainer, contextKeyService, disposables, elementDisposables };
 	}
 
 	renderElement(node: ITreeNode<SessionListItem, FuzzyScore>, _index: number, template: ISessionItemTemplate): void {
@@ -663,6 +689,79 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		if (this.approvalModel) {
 			this.renderApprovalRow(element, template);
 		}
+
+		// CI failures row — reactive
+		if (this.options.ciFailuresProvider) {
+			this.renderCIRow(element, template);
+		}
+	}
+
+	/**
+	 * Render the inline "Fix CI" row for a session whose pull request has failing
+	 * CI checks: a single line summarising the failures and an orange "Fix CI"
+	 * button that dispatches the same fix flow as the CI input banner.
+	 */
+	private renderCIRow(element: ISession, template: ISessionItemTemplate): void {
+		const provider = this.options.ciFailuresProvider;
+		if (!provider) {
+			return;
+		}
+
+		const failuresObs = provider.getCIFailures(element);
+		let wasVisible = !!failuresObs.get();
+		template.ciRow.classList.toggle('visible', wasVisible);
+
+		const rowStore = template.elementDisposables.add(new DisposableStore());
+
+		template.elementDisposables.add(autorun(reader => {
+			rowStore.clear();
+
+			const failures = failuresObs.read(reader);
+			const visible = !!failures;
+			template.ciRow.classList.toggle('visible', visible);
+
+			if (failures) {
+				const failedText = failures.completed === 1
+					? localize('sessionCi.oneCheckFailed', "1 check failed")
+					: localize('sessionCi.checksFailed', "{0} out of {1} checks failed", failures.failed, failures.completed);
+				const text = failures.pending > 0
+					? localize('sessionCi.checksFailedPending', "{0}, {1} pending", failedText, failures.pending)
+					: failedText;
+
+				template.ciLabel.textContent = text;
+				if (this.options.showHover) {
+					rowStore.add(this.hoverService.setupDelayedHover(template.ciLabel, {
+						content: text,
+						position: { hoverPosition: HoverPosition.BELOW },
+					}));
+				}
+
+				template.ciButtonContainer.textContent = '';
+				const button = rowStore.add(new Button(template.ciButtonContainer, {
+					title: localize('sessionCi.fixTitle', "Fix failing CI checks"),
+					...defaultButtonStyles,
+					buttonBackground: asCssVariable(chartsOrange),
+					buttonHoverBackground: `color-mix(in srgb, ${asCssVariable(chartsOrange)} 88%, black)`,
+					buttonBorder: asCssVariable(chartsOrange),
+				}));
+				button.label = localize('sessionCi.fix', "Fix CI");
+				rowStore.add(button.onDidClick(async () => {
+					// Disable while the fix is dispatched so a second click can't
+					// submit a duplicate request (the model also guards internally).
+					button.enabled = false;
+					try {
+						await provider.fixChecks(element);
+					} finally {
+						button.enabled = true;
+					}
+				}));
+			}
+
+			if (wasVisible !== visible) {
+				wasVisible = visible;
+				this._onDidChangeItemHeight.fire(element);
+			}
+		}));
 	}
 
 	private renderApprovalRow(element: ISession, template: ISessionItemTemplate): void {
@@ -1748,7 +1847,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		// TEMPORARY (#320480): see the note on the `IAgentSessionsService` import.
 		const agentSessionsService = instantiationService.invokeFunction(accessor => accessor.get(IAgentSessionsService));
 		const sessionRenderer = new SessionItemRenderer(
-			{ grouping: this.options.grouping, isPinned: s => this.isSessionPinned(s), isRead: s => this.isSessionRead(s), visibleSessions: this._sessionsService.visibleSessions, getMultiSelectedSessions: s => this.getMultiSelectedSessions(s), isInChatsSection: s => this._chatsSectionSessionIds.has(s.resource.toString()), showHover: true, approvalRowMaxLines: DEFAULT_APPROVAL_ROW_MAX_LINES, toolbarActions: true, visibleApprovalKinds: DEFAULT_VISIBLE_APPROVAL_KINDS },
+			{ grouping: this.options.grouping, isPinned: s => this.isSessionPinned(s), isRead: s => this.isSessionRead(s), visibleSessions: this._sessionsService.visibleSessions, getMultiSelectedSessions: s => this.getMultiSelectedSessions(s), isInChatsSection: s => this._chatsSectionSessionIds.has(s.resource.toString()), showHover: true, approvalRowMaxLines: DEFAULT_APPROVAL_ROW_MAX_LINES, toolbarActions: true, visibleApprovalKinds: DEFAULT_VISIBLE_APPROVAL_KINDS, ciFailuresProvider: undefined },
 			approvalModel,
 			instantiationService,
 			contextKeyService,
@@ -3406,6 +3505,12 @@ export interface ISessionsFlatListOptions {
 	 * (the blocked-sessions list) opt into {@link AgentSessionApprovalKind.QuestionCarousel}.
 	 */
 	readonly visibleApprovalKinds?: readonly AgentSessionApprovalKind[];
+	/**
+	 * Provides per-session CI failure state. When set, session rows whose pull
+	 * request has failing CI checks render an inline "Fix CI" row. Only supplied
+	 * by the blocked-sessions list; omitted elsewhere so no other list shows it.
+	 */
+	readonly ciFailuresProvider?: ISessionCIFailuresProvider;
 }
 
 /**
@@ -3464,6 +3569,7 @@ export class SessionsFlatList extends Disposable {
 				approvalRowMaxLines: this.options.approvalRowMaxLines ?? DEFAULT_APPROVAL_ROW_MAX_LINES,
 				toolbarActions: this.options.toolbarActions ?? true,
 				visibleApprovalKinds: this.options.visibleApprovalKinds ?? DEFAULT_VISIBLE_APPROVAL_KINDS,
+				ciFailuresProvider: this.options.ciFailuresProvider,
 			},
 			approvalModel,
 			instantiationService,
@@ -3474,7 +3580,7 @@ export class SessionsFlatList extends Disposable {
 			agentSessionsService,
 		);
 
-		this._delegate = new SessionsTreeDelegate(approvalModel, () => false, this.options.approvalRowMaxLines ?? DEFAULT_APPROVAL_ROW_MAX_LINES, this.options.visibleApprovalKinds ?? DEFAULT_VISIBLE_APPROVAL_KINDS, s => sessionRenderer.getMeasuredApprovalHeight(s));
+		this._delegate = new SessionsTreeDelegate(approvalModel, () => false, this.options.approvalRowMaxLines ?? DEFAULT_APPROVAL_ROW_MAX_LINES, this.options.visibleApprovalKinds ?? DEFAULT_VISIBLE_APPROVAL_KINDS, s => sessionRenderer.getMeasuredApprovalHeight(s), this.options.ciFailuresProvider);
 
 		this.tree = this._register(instantiationService.createInstance(
 			WorkbenchObjectTree<SessionListItem, FuzzyScore>,

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -3164,10 +3164,29 @@ export class SessionsList extends Disposable implements ISessionsList {
  * as lightweight stand-ins that the widget never touches.
  */
 function createCarouselRenderContext(container: HTMLElement): IChatContentPartRenderContext {
+	const requestVm: IChatRequestViewModel = {
+		id: 'blockedSessionsCarousel',
+		sessionResource: URI.parse('vscode-chat://blocked-sessions-carousel'),
+		dataId: 'blockedSessionsCarousel',
+		username: '',
+		message: { kind: 'reply', message: '', agentId: '' },
+		messageText: '',
+		attempt: 0,
+		variables: [],
+		currentRenderedHeight: undefined,
+		shouldBeRemovedOnSend: undefined,
+		isComplete: false,
+		isCompleteAddedRequest: false,
+		slashCommand: undefined,
+		agentOrSlashCommandDetected: false,
+		shouldBeBlocked: constObservable(false),
+		timestamp: 0,
+	};
+
 	return {
 		// A bare, non-response object so `isResponseVM` is false and the carousel
 		// renders interactively rather than as a completed summary.
-		element: { id: 'blockedSessionsCarousel' } as unknown as IChatRequestViewModel,
+		element: requestVm,
 		elementIndex: 0,
 		container,
 		content: [],

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -17,7 +17,7 @@ import { HighlightedLabel } from '../../../../../base/browser/ui/highlightedlabe
 import { createMatches, FuzzyScore, IMatch } from '../../../../../base/common/filters.js';
 import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
-import { IObservable, IReader, autorun, observableSignalFromEvent, observableValue } from '../../../../../base/common/observable.js';
+import { IObservable, IReader, autorun, constObservable, observableSignalFromEvent, observableValue } from '../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { fromNow } from '../../../../../base/common/date.js';
@@ -38,7 +38,11 @@ import { IStyleOverride, defaultButtonStyles, defaultFindWidgetStyles, defaultIn
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { GITHUB_REMOTE_FILE_SCHEME, ISession, ISessionWorkspace, SessionStatus } from '../../../../services/sessions/common/session.js';
-import { AgentSessionApprovalModel, agentSessionApprovalId, IAgentSessionApprovalInfo } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
+import { AgentSessionApprovalKind, AgentSessionApprovalModel, agentSessionApprovalId, IAgentSessionApprovalInfo } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
+import { ChatQuestionCarouselPart } from '../../../../../workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.js';
+import { IChatContentPartRenderContext } from '../../../../../workbench/contrib/chat/browser/widget/chatContentParts/chatContentParts.js';
+import { IChatQuestionAnswerValue } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { IChatRequestViewModel } from '../../../../../workbench/contrib/chat/common/model/chatViewModel.js';
 import { Button } from '../../../../../base/browser/ui/button/button.js';
 import { IMarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
 import { Action, ActionRunner, IAction, Separator, SubmenuAction } from '../../../../../base/common/actions.js';
@@ -178,6 +182,29 @@ const FOUR_DAYS_MS = 4 * 24 * 60 * 60 * 1000;
  */
 const DEFAULT_APPROVAL_ROW_MAX_LINES = 3;
 
+/**
+ * Approval kinds shown inline in a session row by default. The ask-questions
+ * tool's structured carousel ({@link AgentSessionApprovalKind.QuestionCarousel})
+ * is intentionally excluded so it only renders in surfaces that explicitly opt
+ * in (the blocked-sessions list), which can host its dedicated widget. Generic
+ * (non-carousel) question and other confirmations still render inline as
+ * before.
+ */
+export const DEFAULT_VISIBLE_APPROVAL_KINDS: readonly AgentSessionApprovalKind[] = [AgentSessionApprovalKind.Terminal, AgentSessionApprovalKind.Question, AgentSessionApprovalKind.Other];
+
+/** Every approval kind — used by surfaces that render all of them (e.g. the blocked-sessions list). */
+export const ALL_VISIBLE_APPROVAL_KINDS: readonly AgentSessionApprovalKind[] = [AgentSessionApprovalKind.Terminal, AgentSessionApprovalKind.Question, AgentSessionApprovalKind.QuestionCarousel, AgentSessionApprovalKind.Other];
+
+/**
+ * Fallback height (px) reserved for a question-carousel approval row before its
+ * widget has been measured. The delegate replaces this with the measured height
+ * once the carousel renders.
+ */
+const APPROVAL_CAROUSEL_ESTIMATE_HEIGHT = 240;
+
+/** Top-margin of the approval row (matches `.session-approval-row` in the CSS), added to the measured carousel height. */
+const APPROVAL_ROW_CAROUSEL_MARGIN = 4;
+
 //#endregion
 
 //#region Tree Delegate
@@ -200,6 +227,8 @@ class SessionsTreeDelegate implements IListVirtualDelegate<SessionListItem> {
 		private readonly _approvalModel: AgentSessionApprovalModel | undefined,
 		private readonly _isPhone: () => boolean,
 		private readonly _approvalRowMaxLines: number = DEFAULT_APPROVAL_ROW_MAX_LINES,
+		private readonly _visibleApprovalKinds: readonly AgentSessionApprovalKind[] = DEFAULT_VISIBLE_APPROVAL_KINDS,
+		private readonly _getMeasuredApprovalHeight: (session: ISession) => number | undefined = () => undefined,
 	) { }
 
 	getHeight(element: SessionListItem): number {
@@ -215,8 +244,10 @@ class SessionsTreeDelegate implements IListVirtualDelegate<SessionListItem> {
 
 		let height = this._isPhone() ? SessionsTreeDelegate.ITEM_HEIGHT_PHONE : SessionsTreeDelegate.ITEM_HEIGHT;
 		if (this._approvalModel) {
-			const approval = getFirstApprovalAcrossChats(this._approvalModel, element as ISession, undefined);
-			if (approval) {
+			const approval = getFirstApprovalAcrossChats(this._approvalModel, element as ISession, undefined, this._visibleApprovalKinds);
+			if (approval?.kind === AgentSessionApprovalKind.QuestionCarousel && approval.carousel) {
+				height += this._getMeasuredApprovalHeight(element as ISession) ?? APPROVAL_CAROUSEL_ESTIMATE_HEIGHT;
+			} else if (approval) {
 				height += SessionItemRenderer.getApprovalRowHeight(approval.label, this._approvalRowMaxLines);
 			}
 		}
@@ -318,8 +349,20 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 	/** Fires when the user approves a session's pending action via its "Allow" button. */
 	readonly onDidApproveSession: Event<IApprovedSession> = this._onDidApproveSession.event;
 
+	/**
+	 * Measured heights (px) of rendered question-carousel approval widgets, keyed
+	 * by session resource. Shared with the tree delegate so it can size rows that
+	 * host the carousel, whose height isn't known ahead of render.
+	 */
+	private readonly _measuredApprovalHeights = new Map<string, number>();
+
+	/** Measured height of a session's carousel approval widget, if one is rendered. */
+	getMeasuredApprovalHeight(session: ISession): number | undefined {
+		return this._measuredApprovalHeights.get(session.resource.toString());
+	}
+
 	constructor(
-		private readonly options: { grouping: () => SessionsGrouping; isPinned: (session: ISession) => boolean; isRead: (session: ISession) => boolean; visibleSessions: IObservable<readonly (IActiveSession | undefined)[]>; getMultiSelectedSessions: (session: ISession) => ISession[]; isInChatsSection: (session: ISession) => boolean; showHover: boolean; approvalRowMaxLines: number; toolbarActions: boolean },
+		private readonly options: { grouping: () => SessionsGrouping; isPinned: (session: ISession) => boolean; isRead: (session: ISession) => boolean; visibleSessions: IObservable<readonly (IActiveSession | undefined)[]>; getMultiSelectedSessions: (session: ISession) => ISession[]; isInChatsSection: (session: ISession) => boolean; showHover: boolean; approvalRowMaxLines: number; toolbarActions: boolean; visibleApprovalKinds: readonly AgentSessionApprovalKind[] },
 		private readonly approvalModel: AgentSessionApprovalModel | undefined,
 		private readonly instantiationService: IInstantiationService,
 		private readonly contextKeyService: IContextKeyService,
@@ -628,67 +671,141 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		}
 
 		const approvalModel = this.approvalModel;
-		const initialInfo = getFirstApprovalAcrossChats(approvalModel, element, undefined);
-		let wasVisible = !!initialInfo;
-		template.approvalRow.classList.toggle('visible', wasVisible);
+		const visibleKinds = this.options.visibleApprovalKinds;
+		const initialInfo = getFirstApprovalAcrossChats(approvalModel, element, undefined, visibleKinds);
+		let lastHeightKey = this._approvalHeightKey(initialInfo);
+		template.approvalRow.classList.toggle('visible', !!initialInfo);
 
 		const buttonStore = template.elementDisposables.add(new DisposableStore());
 
 		template.elementDisposables.add(autorun(reader => {
 			buttonStore.clear();
+			template.approvalRow.classList.remove('has-carousel');
 
-			const info = getFirstApprovalAcrossChats(approvalModel, element, reader);
-			const visible = !!info;
+			const info = getFirstApprovalAcrossChats(approvalModel, element, reader, visibleKinds);
+			template.approvalRow.classList.toggle('visible', !!info);
 
-			template.approvalRow.classList.toggle('visible', visible);
-
-			if (info) {
-				// Render up to `maxLines` lines as separate code blocks
-				const lines = info.label.split('\n');
-				const maxLines = this.options.approvalRowMaxLines;
-				const visibleLines = lines.slice(0, maxLines);
-				if (lines.length > maxLines) {
-					visibleLines[maxLines - 1] = `${visibleLines[maxLines - 1]} \u2026`;
-				}
-				const langId = info.languageId ?? 'json';
-				const labelContent = new MarkdownString();
-				for (const line of visibleLines) {
-					labelContent.appendCodeblock(langId, line);
-				}
-
-				template.approvalLabel.textContent = '';
-				buttonStore.add(this.markdownRendererService.render(labelContent, {}, template.approvalLabel));
-
-				if (this.options.showHover) {
-					const fullContent = new MarkdownString().appendCodeblock(info.languageId ?? 'json', info.label);
-					buttonStore.add(this.hoverService.setupDelayedHover(template.approvalLabel, {
-						content: fullContent,
-						style: HoverStyle.Pointer,
-						position: { hoverPosition: HoverPosition.BELOW },
-					}));
-				}
-
-				template.approvalButtonContainer.textContent = '';
-				const button = buttonStore.add(new Button(template.approvalButtonContainer, {
-					title: localize('allowActionOnce', "Allow once"),
-					secondary: true,
-					...defaultButtonStyles
-				}));
-				button.label = localize('allowAction', "Allow");
-				buttonStore.add(button.onDidClick(() => {
-					// Capture the approval's identity BEFORE confirming: `confirm()` may
-					// synchronously clear the pending approval, so we can't read it after.
-					const approvalId = agentSessionApprovalId(info);
-					info.confirm();
-					this._onDidApproveSession.fire({ session: element, approvalId });
-				}));
+			if (info && info.kind === AgentSessionApprovalKind.QuestionCarousel && info.carousel) {
+				this.renderApprovalCarousel(element, info, template, buttonStore);
+			} else if (info) {
+				this.renderApprovalCommand(element, info, template, buttonStore);
 			}
 
-			if (wasVisible !== visible) {
-				wasVisible = visible;
+			// Re-layout whenever the row's contribution to its height changes:
+			// visibility toggles, switching between a carousel and a command row,
+			// or a command's line count changing. Carousel rows publish their exact
+			// measured height separately once rendered.
+			const heightKey = this._approvalHeightKey(info);
+			if (heightKey !== lastHeightKey) {
+				lastHeightKey = heightKey;
 				this._onDidChangeItemHeight.fire(element);
 			}
 		}));
+	}
+
+	/** A stable key describing a row's height contribution for a given approval. */
+	private _approvalHeightKey(info: IAgentSessionApprovalInfo | undefined): string {
+		if (!info) {
+			return 'none';
+		}
+		if (info.kind === AgentSessionApprovalKind.QuestionCarousel && info.carousel) {
+			// Exact height is measured after render and published via onDidChangeItemHeight.
+			return 'carousel';
+		}
+		return `cmd:${SessionItemRenderer.getApprovalRowHeight(info.label, this.options.approvalRowMaxLines)}`;
+	}
+
+	/** Render a terminal-style approval: the pending command plus an "Allow" button. */
+	private renderApprovalCommand(element: ISession, info: IAgentSessionApprovalInfo, template: ISessionItemTemplate, buttonStore: DisposableStore): void {
+		// Render up to `maxLines` lines as separate code blocks
+		const lines = info.label.split('\n');
+		const maxLines = this.options.approvalRowMaxLines;
+		const visibleLines = lines.slice(0, maxLines);
+		if (lines.length > maxLines) {
+			visibleLines[maxLines - 1] = `${visibleLines[maxLines - 1]} \u2026`;
+		}
+		const langId = info.languageId ?? 'json';
+		const labelContent = new MarkdownString();
+		for (const line of visibleLines) {
+			labelContent.appendCodeblock(langId, line);
+		}
+
+		template.approvalLabel.textContent = '';
+		buttonStore.add(this.markdownRendererService.render(labelContent, {}, template.approvalLabel));
+
+		if (this.options.showHover) {
+			const fullContent = new MarkdownString().appendCodeblock(info.languageId ?? 'json', info.label);
+			buttonStore.add(this.hoverService.setupDelayedHover(template.approvalLabel, {
+				content: fullContent,
+				style: HoverStyle.Pointer,
+				position: { hoverPosition: HoverPosition.BELOW },
+			}));
+		}
+
+		template.approvalButtonContainer.textContent = '';
+		const button = buttonStore.add(new Button(template.approvalButtonContainer, {
+			title: localize('allowActionOnce', "Allow once"),
+			secondary: true,
+			...defaultButtonStyles
+		}));
+		button.label = localize('allowAction', "Allow");
+		buttonStore.add(button.onDidClick(() => {
+			// Capture the approval's identity BEFORE confirming: `confirm()` may
+			// synchronously clear the pending approval, so we can't read it after.
+			const approvalId = agentSessionApprovalId(info);
+			info.confirm();
+			this._onDidApproveSession.fire({ session: element, approvalId });
+		}));
+	}
+
+	/**
+	 * Render the ask-questions tool's own carousel widget inline so the user can
+	 * answer without opening the session. The row height isn't known ahead of
+	 * time, so we measure the widget and publish the height to the delegate.
+	 */
+	private renderApprovalCarousel(element: ISession, info: IAgentSessionApprovalInfo, template: ISessionItemTemplate, buttonStore: DisposableStore): void {
+		const carousel = info.carousel;
+		if (!carousel) {
+			return;
+		}
+
+		template.approvalRow.classList.add('has-carousel');
+		template.approvalLabel.textContent = '';
+		template.approvalButtonContainer.textContent = '';
+
+		const carouselContainer = DOM.append(template.approvalRow, $('.session-approval-carousel'));
+		buttonStore.add(toDisposable(() => carouselContainer.remove()));
+
+		const context = createCarouselRenderContext(carouselContainer);
+		const part = buttonStore.add(this.instantiationService.createInstance(ChatQuestionCarouselPart, carousel, context, {
+			shouldAutoFocus: false,
+			onSubmit: (answers: Map<string, IChatQuestionAnswerValue> | undefined) => {
+				const approvalId = agentSessionApprovalId(info);
+				info.submitCarousel?.(answers ? Object.fromEntries(answers) : undefined);
+				this._onDidApproveSession.fire({ session: element, approvalId });
+			},
+		}));
+		carouselContainer.appendChild(part.domNode);
+
+		const key = element.resource.toString();
+		const updateHeight = () => {
+			// Measure the whole approval row so its border/padding are included; the
+			// delegate adds this on top of the base row height. Include the row's
+			// top margin so the widget isn't clipped.
+			const measured = template.approvalRow.offsetHeight;
+			const total = measured > 0 ? measured + APPROVAL_ROW_CAROUSEL_MARGIN : 0;
+			if (total > 0 && this._measuredApprovalHeights.get(key) !== total) {
+				this._measuredApprovalHeights.set(key, total);
+				this._onDidChangeItemHeight.fire(element);
+			}
+		};
+		buttonStore.add(part.onDidChangeHeight(() => updateHeight()));
+		buttonStore.add(toDisposable(() => this._measuredApprovalHeights.delete(key)));
+
+		// Measure once laid out; offsetHeight is 0 before the row is in the DOM.
+		const targetWindow = DOM.getWindow(template.approvalRow);
+		const rafHandle = targetWindow.requestAnimationFrame(() => updateHeight());
+		buttonStore.add(toDisposable(() => targetWindow.cancelAnimationFrame(rafHandle)));
 	}
 
 	private getWorkspaceBadgeLabel(workspace: ISessionWorkspace): string | undefined {
@@ -1631,7 +1748,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		// TEMPORARY (#320480): see the note on the `IAgentSessionsService` import.
 		const agentSessionsService = instantiationService.invokeFunction(accessor => accessor.get(IAgentSessionsService));
 		const sessionRenderer = new SessionItemRenderer(
-			{ grouping: this.options.grouping, isPinned: s => this.isSessionPinned(s), isRead: s => this.isSessionRead(s), visibleSessions: this._sessionsService.visibleSessions, getMultiSelectedSessions: s => this.getMultiSelectedSessions(s), isInChatsSection: s => this._chatsSectionSessionIds.has(s.resource.toString()), showHover: true, approvalRowMaxLines: DEFAULT_APPROVAL_ROW_MAX_LINES, toolbarActions: true },
+			{ grouping: this.options.grouping, isPinned: s => this.isSessionPinned(s), isRead: s => this.isSessionRead(s), visibleSessions: this._sessionsService.visibleSessions, getMultiSelectedSessions: s => this.getMultiSelectedSessions(s), isInChatsSection: s => this._chatsSectionSessionIds.has(s.resource.toString()), showHover: true, approvalRowMaxLines: DEFAULT_APPROVAL_ROW_MAX_LINES, toolbarActions: true, visibleApprovalKinds: DEFAULT_VISIBLE_APPROVAL_KINDS },
 			approvalModel,
 			instantiationService,
 			contextKeyService,
@@ -1655,7 +1772,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		// observe the workbench's value rather than shadowing it with a fresh
 		// scoped default of `false`. The reactive height refresh below listens
 		// on the same scoped service for changes.
-		const delegate = new SessionsTreeDelegate(approvalModel, () => !!IsPhoneLayoutContext.getValue(contextKeyService));
+		const delegate = new SessionsTreeDelegate(approvalModel, () => !!IsPhoneLayoutContext.getValue(contextKeyService), DEFAULT_APPROVAL_ROW_MAX_LINES, DEFAULT_VISIBLE_APPROVAL_KINDS, s => sessionRenderer.getMeasuredApprovalHeight(s));
 
 		this.tree = this._register(instantiationService.createInstance(
 			WorkbenchObjectTree<SessionListItem, FuzzyScore>,
@@ -2940,11 +3057,43 @@ export class SessionsList extends Disposable implements ISessionsList {
 
 //#region Approval Helpers
 
-export function getFirstApprovalAcrossChats(approvalModel: AgentSessionApprovalModel, session: ISession, reader: IReader | undefined,): IAgentSessionApprovalInfo | undefined {
+/**
+ * Builds a minimal {@link IChatContentPartRenderContext} for a
+ * {@link ChatQuestionCarouselPart} rendered outside the chat view (inside a
+ * session row). The carousel widget only reads `element` — to decide whether
+ * the response is complete — so the remaining, view-specific fields are supplied
+ * as lightweight stand-ins that the widget never touches.
+ */
+function createCarouselRenderContext(container: HTMLElement): IChatContentPartRenderContext {
+	return {
+		// A bare, non-response object so `isResponseVM` is false and the carousel
+		// renders interactively rather than as a completed summary.
+		element: { id: 'blockedSessionsCarousel' } as unknown as IChatRequestViewModel,
+		elementIndex: 0,
+		container,
+		content: [],
+		contentIndex: 0,
+		editorPool: undefined!,
+		codeBlockStartIndex: 0,
+		treeStartIndex: 0,
+		diffEditorPool: undefined!,
+		currentWidth: constObservable(0),
+		onDidChangeVisibility: Event.None,
+		inlineTextModels: undefined!,
+	};
+}
+
+export function getFirstApprovalAcrossChats(approvalModel: AgentSessionApprovalModel, session: ISession, reader: IReader | undefined, kinds?: readonly AgentSessionApprovalKind[]): IAgentSessionApprovalInfo | undefined {
 	let oldest: IAgentSessionApprovalInfo | undefined;
 	for (const chat of session.chats.read(reader)) {
 		const approval = approvalModel.getApproval(chat.resource).read(reader);
-		if (approval && (!oldest || approval.since.getTime() < oldest.since.getTime())) {
+		if (!approval) {
+			continue;
+		}
+		if (kinds && !kinds.includes(approval.kind)) {
+			continue;
+		}
+		if (!oldest || approval.since.getTime() < oldest.since.getTime()) {
 			oldest = approval;
 		}
 	}
@@ -3250,6 +3399,13 @@ export interface ISessionsFlatListOptions {
 	 * don't apply (e.g. the blocked-sessions dropdown), which renders no toolbar.
 	 */
 	readonly toolbarActions?: boolean;
+	/**
+	 * Which pending-approval kinds render inline in a session row. Defaults to
+	 * {@link DEFAULT_VISIBLE_APPROVAL_KINDS} (terminal and other tool
+	 * confirmations); surfaces that can host the ask-questions carousel widget
+	 * (the blocked-sessions list) opt into {@link AgentSessionApprovalKind.QuestionCarousel}.
+	 */
+	readonly visibleApprovalKinds?: readonly AgentSessionApprovalKind[];
 }
 
 /**
@@ -3307,6 +3463,7 @@ export class SessionsFlatList extends Disposable {
 				isInChatsSection: s => false,
 				approvalRowMaxLines: this.options.approvalRowMaxLines ?? DEFAULT_APPROVAL_ROW_MAX_LINES,
 				toolbarActions: this.options.toolbarActions ?? true,
+				visibleApprovalKinds: this.options.visibleApprovalKinds ?? DEFAULT_VISIBLE_APPROVAL_KINDS,
 			},
 			approvalModel,
 			instantiationService,
@@ -3317,7 +3474,7 @@ export class SessionsFlatList extends Disposable {
 			agentSessionsService,
 		);
 
-		this._delegate = new SessionsTreeDelegate(approvalModel, () => false, this.options.approvalRowMaxLines ?? DEFAULT_APPROVAL_ROW_MAX_LINES);
+		this._delegate = new SessionsTreeDelegate(approvalModel, () => false, this.options.approvalRowMaxLines ?? DEFAULT_APPROVAL_ROW_MAX_LINES, this.options.visibleApprovalKinds ?? DEFAULT_VISIBLE_APPROVAL_KINDS, s => sessionRenderer.getMeasuredApprovalHeight(s));
 
 		this.tree = this._register(instantiationService.createInstance(
 			WorkbenchObjectTree<SessionListItem, FuzzyScore>,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.ts
@@ -38,7 +38,7 @@ export interface IAgentSessionApprovalInfo {
 	readonly since: Date;
 	/**
 	 * The question carousel awaiting answers, present only for
-	 * {@link AgentSessionApprovalKind.Question} approvals produced by the
+	 * {@link AgentSessionApprovalKind.QuestionCarousel} approvals produced by the
 	 * ask-questions tool. Consumers that can render the carousel widget (e.g. the
 	 * blocked-sessions list) use this to show the tool's own UI inline.
 	 */

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionApprovalModel.ts
@@ -9,7 +9,8 @@ import { autorun, autorunIterableDelta, IObservable, ISettableObservable, observ
 import { URI } from '../../../../../base/common/uri.js';
 import { migrateLegacyTerminalToolSpecificData } from '../../common/chat.js';
 import { IChatModel } from '../../common/model/chatModel.js';
-import { IChatService, IChatToolInvocation, ToolConfirmKind } from '../../common/chatService/chatService.js';
+import { IChatQuestionAnswers, IChatQuestionCarousel, IChatService, IChatToolInvocation, ToolConfirmKind } from '../../common/chatService/chatService.js';
+import { ChatQuestionCarouselData } from '../../common/model/chatProgressTypes/chatQuestionCarouselData.js';
 import { ILanguageService } from '../../../../../editor/common/languages/language.js';
 
 /**
@@ -21,6 +22,11 @@ export const enum AgentSessionApprovalKind {
 	Terminal = 'terminal',
 	/** The agent is asking the user a question / needs a free-form response. */
 	Question = 'question',
+	/**
+	 * The ask-questions tool is presenting a structured question carousel that
+	 * carries its own interactive widget (see {@link IAgentSessionApprovalInfo.carousel}).
+	 */
+	QuestionCarousel = 'questionCarousel',
 	/** Some other tool invocation is waiting for confirmation. */
 	Other = 'other',
 }
@@ -30,7 +36,18 @@ export interface IAgentSessionApprovalInfo {
 	readonly label: string;
 	readonly languageId: string | undefined;
 	readonly since: Date;
+	/**
+	 * The question carousel awaiting answers, present only for
+	 * {@link AgentSessionApprovalKind.Question} approvals produced by the
+	 * ask-questions tool. Consumers that can render the carousel widget (e.g. the
+	 * blocked-sessions list) use this to show the tool's own UI inline.
+	 */
+	readonly carousel?: IChatQuestionCarousel;
 	confirm(): void;
+	/**
+	 * Submit answers for {@link carousel}. No-op for approvals without a carousel.
+	 */
+	submitCarousel?(answers: IChatQuestionAnswers | undefined): void;
 }
 
 /**
@@ -93,7 +110,7 @@ export class AgentSessionApprovalModel extends Disposable {
 			if (current === value) {
 				return;
 			}
-			if (current !== undefined && value !== undefined && current.kind === value.kind && current.label === value.label && current.languageId === value.languageId) {
+			if (current !== undefined && value !== undefined && current.kind === value.kind && current.label === value.label && current.languageId === value.languageId && current.carousel === value.carousel) {
 				return;
 			}
 			settable.set(value, undefined);
@@ -113,6 +130,26 @@ export class AgentSessionApprovalModel extends Disposable {
 			}
 
 			for (const part of lastResponse.response.value) {
+				if (part.kind === 'questionCarousel') {
+					if (part.isUsed) {
+						continue;
+					}
+					const carousel = part;
+					const requestId = model.lastRequest?.id;
+					const firstQuestion = carousel.questions[0];
+					const messageSource = carousel.message ?? firstQuestion?.message ?? firstQuestion?.title;
+					const label = messageSource === undefined ? '' : (typeof messageSource === 'string' ? messageSource : renderAsPlaintext(messageSource));
+					setIfChanged({
+						kind: AgentSessionApprovalKind.QuestionCarousel,
+						label,
+						languageId: undefined,
+						since: new Date(),
+						carousel,
+						confirm: () => this._submitCarousel(requestId, carousel, undefined),
+						submitCarousel: answers => this._submitCarousel(requestId, carousel, answers),
+					});
+					return;
+				}
 				if (part.kind !== 'toolInvocation' || part.toolSpecificData?.kind === 'modifiedFilesConfirmation') {
 					continue; // unsupported
 				}
@@ -149,5 +186,26 @@ export class AgentSessionApprovalModel extends Disposable {
 
 			setIfChanged(undefined);
 		});
+	}
+
+	/**
+	 * Resolve a pending question carousel with the given answers, completing the
+	 * ask-questions tool invocation that produced it. Safe to call once — later
+	 * calls are no-ops once the carousel is used.
+	 */
+	private _submitCarousel(requestId: string | undefined, carousel: IChatQuestionCarousel, answers: IChatQuestionAnswers | undefined): void {
+		if (carousel.isUsed) {
+			return;
+		}
+		carousel.data = answers ?? {};
+		carousel.isUsed = true;
+		if (carousel instanceof ChatQuestionCarouselData) {
+			carousel.draftAnswers = undefined;
+			carousel.draftCurrentIndex = undefined;
+			carousel.completion.complete({ answers });
+		}
+		if (requestId && carousel.resolveId) {
+			this._chatService.notifyQuestionCarouselAnswer(requestId, carousel.resolveId, answers);
+		}
 	}
 }

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/blockedSessionsList.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/blockedSessionsList.fixture.ts
@@ -27,8 +27,9 @@ import { ISessionsListModelService } from '../../../../../sessions/services/sess
 import { ISessionsProvidersService } from '../../../../../sessions/services/sessions/browser/sessionsProvidersService.js';
 // eslint-disable-next-line local/code-import-patterns
 import { BlockedSessionsList } from '../../../../../sessions/contrib/sessions/browser/blockedSessionsList.js';
-import { IChatService } from '../../../../contrib/chat/common/chatService/chatService.js';
+import { IChatService, IChatQuestion, IChatQuestionCarousel } from '../../../../contrib/chat/common/chatService/chatService.js';
 import { IChatModel } from '../../../../contrib/chat/common/model/chatModel.js';
+import { ITerminalChatService } from '../../../../contrib/terminal/browser/terminal.js';
 import { IAgentSessionsService } from '../../../../contrib/chat/browser/agentSessions/agentSessionsService.js';
 import { IAgentSession, IAgentSessionsModel } from '../../../../contrib/chat/browser/agentSessions/agentSessionsModel.js';
 import { AgentSessionApprovalKind, AgentSessionApprovalModel, IAgentSessionApprovalInfo } from '../../../../contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
@@ -89,6 +90,8 @@ interface IBlockedSessionOptions {
 	changesSummary?: ISessionChangesSummary;
 	/** A terminal command awaiting approval; renders an approval row with an Allow button. */
 	approvalCommand?: string;
+	/** A pending ask-questions carousel; renders the question widget inline in the row. */
+	questionCarousel?: IChatQuestionCarousel;
 }
 
 function createBlockedSession(options: IBlockedSessionOptions, approvals?: Map<string, IAgentSessionApprovalInfo>): ISession {
@@ -98,15 +101,30 @@ function createBlockedSession(options: IBlockedSessionOptions, approvals?: Map<s
 	// A session awaiting a tool approval carries a chat whose resource the (mock)
 	// approval model keys the pending approval on.
 	let chats: readonly IChat[] = [];
-	if (options.approvalCommand !== undefined && approvals) {
+	if ((options.approvalCommand !== undefined || options.questionCarousel !== undefined) && approvals) {
 		const chatResource = URI.parse(`vscode-chat://chat/${Math.random().toString(36).slice(2)}`);
-		approvals.set(chatResource.toString(), {
-			kind: AgentSessionApprovalKind.Terminal,
-			label: options.approvalCommand,
-			languageId: undefined,
-			since: new Date(),
-			confirm: () => { },
-		});
+		if (options.questionCarousel !== undefined) {
+			const carousel = options.questionCarousel;
+			const firstQuestion = carousel.questions[0];
+			const message = carousel.message ?? firstQuestion?.message ?? firstQuestion?.title ?? '';
+			approvals.set(chatResource.toString(), {
+				kind: AgentSessionApprovalKind.QuestionCarousel,
+				label: typeof message === 'string' ? message : message.value,
+				languageId: undefined,
+				since: new Date(),
+				carousel,
+				confirm: () => { },
+				submitCarousel: () => { },
+			});
+		} else {
+			approvals.set(chatResource.toString(), {
+				kind: AgentSessionApprovalKind.Terminal,
+				label: options.approvalCommand!,
+				languageId: undefined,
+				since: new Date(),
+				confirm: () => { },
+			});
+		}
 		chats = [new class extends mock<IChat>() {
 			override readonly resource = chatResource;
 		}()];
@@ -192,6 +210,49 @@ const unresolvedCommentsPr: IGitHubInfo['pullRequest'] = {
 };
 
 // ============================================================================
+// Question carousels (ask-questions tool)
+// ============================================================================
+
+function createCarousel(questions: IChatQuestion[], allowSkip: boolean = true, message?: string): IChatQuestionCarousel {
+	return { questions, allowSkip, message, kind: 'questionCarousel' };
+}
+
+const textQuestion: IChatQuestion = {
+	id: 'migration-name',
+	type: 'text',
+	title: 'Migration name',
+	message: 'What should the new database migration be called?',
+	defaultValue: 'add-user-roles',
+};
+
+const singleSelectQuestion: IChatQuestion = {
+	id: 'welcome-tone',
+	type: 'singleSelect',
+	title: 'Welcome tone',
+	message: 'Which tone should the onboarding welcome step use?',
+	options: [
+		{ id: 'formal', label: 'Formal - Professional and precise', value: 'formal' },
+		{ id: 'friendly', label: 'Friendly - Warm and conversational', value: 'friendly' },
+		{ id: 'playful', label: 'Playful - Light and informal', value: 'playful' },
+	],
+	defaultValue: 'friendly',
+};
+
+const multiSelectQuestion: IChatQuestion = {
+	id: 'release-targets',
+	type: 'multiSelect',
+	title: 'Release targets',
+	message: 'Which platforms should this release build for?',
+	options: [
+		{ id: 'win', label: 'Windows', value: 'windows' },
+		{ id: 'mac', label: 'macOS', value: 'macos' },
+		{ id: 'linux', label: 'Linux', value: 'linux' },
+		{ id: 'web', label: 'Web', value: 'web' },
+	],
+	defaultValue: ['win', 'mac'],
+};
+
+// ============================================================================
 // Render helper
 // ============================================================================
 
@@ -226,6 +287,10 @@ function renderBlockedList(ctx: ComponentFixtureContext, sessions: readonly ISes
 				override getProviders() { return []; }
 				override getProvider() { return undefined; }
 			}());
+			// Required by `ChatQuestionCarouselPart` (rendered for question approvals).
+			reg.definePartialInstance(ITerminalChatService, {
+				getTerminalInstanceByExecutionId: () => undefined,
+			});
 		},
 	});
 
@@ -339,6 +404,49 @@ export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 				{ title: 'Provision the review environment', status: SessionStatus.NeedsInput, minutesAgo: 7, workspace: createMockWorkspace('vscode', 'infra/review-env'), approvalCommand: 'kubectl apply -f ./deploy/review.yaml --namespace review-pr-4821 && kubectl rollout status deployment/web --namespace review-pr-4821 --timeout=180s && kubectl get pods --namespace review-pr-4821 -o wide' },
 				{ title: 'Format changed files', status: SessionStatus.NeedsInput, minutesAgo: 12, workspace: createMockWorkspace('vscode', 'chore/format'), approvalCommand: 'for f in $(git diff --name-only main); do\n  npx prettier --write "$f"\n  git add "$f"\ndone' },
 				{ title: 'Reset and reinstall', status: SessionStatus.NeedsInput, minutesAgo: 20, workspace: createMockWorkspace('vscode', 'fix/clean-install'), approvalCommand: 'rm -rf node_modules\nrm -f package-lock.json\nnpm cache clean --force\nnpm install\nnpm run test:integration' },
+			]);
+			renderBlockedList(ctx, sessions, approvalModel);
+		},
+	}),
+
+	// A single session whose agent is asking a question — renders the
+	// ask-questions carousel widget inline (single-select).
+	BlockedSessionsList_OneQuestion: defineComponentFixture({
+		render: (ctx) => {
+			const { sessions, approvalModel } = buildApprovalScenario([
+				{ title: 'Update the onboarding walkthrough copy', status: SessionStatus.NeedsInput, minutesAgo: 1, workspace: createMockWorkspace('vscode', 'docs/onboarding'), questionCarousel: createCarousel([singleSelectQuestion]) },
+			]);
+			renderBlockedList(ctx, sessions, approvalModel);
+		},
+	}),
+
+	// A free-text question carousel inline in the row.
+	BlockedSessionsList_TextQuestion: defineComponentFixture({
+		render: (ctx) => {
+			const { sessions, approvalModel } = buildApprovalScenario([
+				{ title: 'Add the user-roles migration', status: SessionStatus.NeedsInput, minutesAgo: 2, workspace: createMockWorkspace('vscode', 'feature/user-roles'), questionCarousel: createCarousel([textQuestion]) },
+			]);
+			renderBlockedList(ctx, sessions, approvalModel);
+		},
+	}),
+
+	// A multi-question carousel (text, single- and multi-select) inline in the row.
+	BlockedSessionsList_MultipleQuestions: defineComponentFixture({
+		render: (ctx) => {
+			const { sessions, approvalModel } = buildApprovalScenario([
+				{ title: 'Prepare the next release', status: SessionStatus.NeedsInput, minutesAgo: 4, workspace: createMockWorkspace('vscode', 'release/next'), questionCarousel: createCarousel([textQuestion, singleSelectQuestion, multiSelectQuestion], true, 'A few details before I prepare the release.') },
+			]);
+			renderBlockedList(ctx, sessions, approvalModel);
+		},
+	}),
+
+	// A terminal approval and a question carousel side by side — both approval
+	// kinds render in the blocked-sessions list.
+	BlockedSessionsList_TerminalAndQuestion: defineComponentFixture({
+		render: (ctx) => {
+			const { sessions, approvalModel } = buildApprovalScenario([
+				{ title: 'Build the production bundle', status: SessionStatus.NeedsInput, minutesAgo: 1, workspace: createMockWorkspace('vscode', 'release/prod-build'), approvalCommand: 'npm run build:prod' },
+				{ title: 'Choose the release targets', status: SessionStatus.NeedsInput, minutesAgo: 3, workspace: createMockWorkspace('vscode', 'release/targets'), questionCarousel: createCarousel([multiSelectQuestion]) },
 			]);
 			renderBlockedList(ctx, sessions, approvalModel);
 		},

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/blockedSessionsList.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/blockedSessionsList.fixture.ts
@@ -27,6 +27,8 @@ import { ISessionsListModelService } from '../../../../../sessions/services/sess
 import { ISessionsProvidersService } from '../../../../../sessions/services/sessions/browser/sessionsProvidersService.js';
 // eslint-disable-next-line local/code-import-patterns
 import { BlockedSessionsList } from '../../../../../sessions/contrib/sessions/browser/blockedSessionsList.js';
+// eslint-disable-next-line local/code-import-patterns
+import { ISessionCIFailures, ISessionCIFailuresProvider } from '../../../../../sessions/contrib/sessions/browser/sessionCIFailuresModel.js';
 import { IChatService, IChatQuestion, IChatQuestionCarousel } from '../../../../contrib/chat/common/chatService/chatService.js';
 import { IChatModel } from '../../../../contrib/chat/common/model/chatModel.js';
 import { ITerminalChatService } from '../../../../contrib/terminal/browser/terminal.js';
@@ -92,6 +94,8 @@ interface IBlockedSessionOptions {
 	approvalCommand?: string;
 	/** A pending ask-questions carousel; renders the question widget inline in the row. */
 	questionCarousel?: IChatQuestionCarousel;
+	/** Failing-CI state; renders the inline "Fix CI" row. */
+	ciFailures?: ISessionCIFailures;
 }
 
 function createBlockedSession(options: IBlockedSessionOptions, approvals?: Map<string, IAgentSessionApprovalInfo>): ISession {
@@ -166,6 +170,30 @@ function buildApprovalScenario(specs: readonly IBlockedSessionOptions[]): { sess
 	const approvals = new Map<string, IAgentSessionApprovalInfo>();
 	const sessions = specs.map(spec => createBlockedSession(spec, approvals));
 	return { sessions, approvalModel: createApprovalModel(approvals) };
+}
+
+/** A CI failures provider backed by a fixed, per-session-resource map. */
+function createCIFailuresProvider(failures: ReadonlyMap<string, ISessionCIFailures>): ISessionCIFailuresProvider {
+	return {
+		getCIFailures: (session: ISession): IObservable<ISessionCIFailures | undefined> => constObservable(failures.get(session.resource.toString())),
+		fixChecks: async () => { },
+	};
+}
+
+/**
+ * Build a set of sessions together with a CI failures provider: each session
+ * whose spec has `ciFailures` shows the inline "Fix CI" row.
+ */
+function buildCIScenario(specs: readonly IBlockedSessionOptions[]): { sessions: ISession[]; ciFailuresProvider: ISessionCIFailuresProvider } {
+	const failures = new Map<string, ISessionCIFailures>();
+	const sessions = specs.map(spec => {
+		const session = createBlockedSession(spec);
+		if (spec.ciFailures) {
+			failures.set(session.resource.toString(), spec.ciFailures);
+		}
+		return session;
+	});
+	return { sessions, ciFailuresProvider: createCIFailuresProvider(failures) };
 }
 
 function createMockListModelService(): ISessionsListModelService {
@@ -256,7 +284,7 @@ const multiSelectQuestion: IChatQuestion = {
 // Render helper
 // ============================================================================
 
-function renderBlockedList(ctx: ComponentFixtureContext, sessions: readonly ISession[], approvalModel?: AgentSessionApprovalModel): void {
+function renderBlockedList(ctx: ComponentFixtureContext, sessions: readonly ISession[], approvalModel?: AgentSessionApprovalModel, ciFailuresProvider?: ISessionCIFailuresProvider): void {
 	const { container, disposableStore } = ctx;
 
 	const instantiationService = createEditorServices(disposableStore, {
@@ -310,6 +338,9 @@ function renderBlockedList(ctx: ComponentFixtureContext, sessions: readonly ISes
 	const list = disposableStore.add(instantiationService.createInstance(BlockedSessionsList, container, {
 		onSessionOpen: () => { },
 		approvalModel,
+		// Default to a no-op provider so fixtures don't instantiate the real
+		// GitHub-backed model (which needs services not registered here).
+		ciFailuresProvider: ciFailuresProvider ?? createCIFailuresProvider(new Map()),
 	}));
 	list.setSessions(sessions);
 }
@@ -449,6 +480,30 @@ export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 				{ title: 'Choose the release targets', status: SessionStatus.NeedsInput, minutesAgo: 3, workspace: createMockWorkspace('vscode', 'release/targets'), questionCarousel: createCarousel([multiSelectQuestion]) },
 			]);
 			renderBlockedList(ctx, sessions, approvalModel);
+		},
+	}),
+
+	// A single failing-CI session — renders the inline "Fix CI" row with an
+	// orange button, mirroring the CI input banner.
+	BlockedSessionsList_OneCIFailure: defineComponentFixture({
+		render: (ctx) => {
+			const { sessions, ciFailuresProvider } = buildCIScenario([
+				{ title: 'Add telemetry for startup performance', status: SessionStatus.Completed, minutesAgo: 62, workspace: createMockWorkspace('vscode', 'perf/startup-telemetry', failingChecksPr), changesSummary: createMockChangesSummary(8, 240, 58), ciFailures: { failed: 2, completed: 7, pending: 3 } },
+			]);
+			renderBlockedList(ctx, sessions, undefined, ciFailuresProvider);
+		},
+	}),
+
+	// Several failing-CI sessions spanning single-failure, multi-failure and
+	// no-pending variations of the "Fix CI" row.
+	BlockedSessionsList_CIFailures: defineComponentFixture({
+		render: (ctx) => {
+			const { sessions, ciFailuresProvider } = buildCIScenario([
+				{ title: 'Add telemetry for startup performance', status: SessionStatus.Completed, minutesAgo: 62, workspace: createMockWorkspace('vscode', 'perf/startup-telemetry', failingChecksPr), changesSummary: createMockChangesSummary(8, 240, 58), ciFailures: { failed: 1, completed: 6, pending: 0 } },
+				{ title: 'Investigate flaky terminal integration test', status: SessionStatus.Completed, minutesAgo: 320, workspace: createMockWorkspace('vscode', 'fix/flaky-terminal-test', failingChecksPr), changesSummary: createMockChangesSummary(3, 41, 12), ciFailures: { failed: 3, completed: 5, pending: 4 } },
+				{ title: 'Bump the bundler to the next major', status: SessionStatus.Completed, minutesAgo: 500, workspace: createMockWorkspace('vscode', 'chore/bundler-major', failingChecksPr), changesSummary: createMockChangesSummary(2, 18, 6), ciFailures: { failed: 5, completed: 9, pending: 0 } },
+			]);
+			renderBlockedList(ctx, sessions, undefined, ciFailuresProvider);
 		},
 	}),
 });


### PR DESCRIPTION
Blocked sessions currently render terminal-command approvals inline on each session row. This adds support for rendering the **ask-questions tool's own carousel widget** (ChatQuestionCarouselPart) inline for question approvals — but only in the blocked-sessions list, so users can answer without opening the session.

### What changed
- **`visibleApprovalKinds` option**: sessions lists now take a list of `AgentSessionApprovalKind`s that decides which pending approvals render inline. Every consuming widget passes this through (renderer, tree delegate, `getFirstApprovalAcrossChats`).
  - Default (main list / flat lists): `[Terminal, Question, Other]` — unchanged inline rendering.
  - Blocked-sessions list: all kinds, including the new `QuestionCarousel`.
- **New `QuestionCarousel` approval kind**: the approval model detects a pending `questionCarousel` response part from the ask-questions tool and exposes the carousel (plus a `submitCarousel` that completes the tool invocation). Generic `Question` approvals are untouched, so nothing regresses in other lists.
- **Renderer**: a `QuestionCarousel` approval renders the real carousel widget inline; its height is measured after render and published to the tree delegate so virtualized rows size correctly. Terminal/other approvals keep the existing command row + Allow button.
- **CSS**: block layout for carousel rows (`.has-carousel`).
- **Fixtures**: component fixtures for single-select, text, multi-question and mixed terminal+question scenarios in the blocked-sessions list.

### Notes
- Reviewed via rubber-duck; addressed stale-height-on-approval-shape-change and the risk of hiding generic question approvals from other lists (fixed by introducing the dedicated `QuestionCarousel` kind).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>