### PR TITLE
Style overrides: Adjust badge positioning in activity bar for better alignment

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -319,3 +319,13 @@
 .style-override.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact {
 	overflow: visible;
 }
+
+.style-override.monaco-workbench .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {
+	right: 2px;
+	top: 17px;
+}
+
+.style-override.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {
+	top: 26px;
+	right: 2px;
+}

--- a/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/activityBar.css
@@ -320,12 +320,12 @@
 	overflow: visible;
 }
 
-.style-override.monaco-workbench .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {
-	right: 2px;
-	top: 17px;
-}
-
 .style-override.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {
 	top: 26px;
+	right: 2px;
+}
+
+.style-override.monaco-workbench .activitybar.compact > .content :not(.monaco-menu) > .monaco-action-bar .badge .badge-content {
+	top: 17px;
 	right: 2px;
 }


### PR DESCRIPTION
Improve the alignment of badges in the activity bar by adjusting their positioning in the CSS. This change enhances the visual consistency of the interface. Testing can be done by observing the badge placement in the activity bar after applying the changes.

