### PR TITLE
sessions: make blocked-sessions dropdown responsive and centered

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import './media/sessionsTitleBarWidget.css';
-import { $, addDisposableGenericMouseDownListener, addDisposableListener, EventType, isAncestor, reset } from '../../../../base/browser/dom.js';
+import { $, addDisposableGenericMouseDownListener, addDisposableListener, EventType, getDomNodePagePosition, getWindow, isAncestor, reset } from '../../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
@@ -22,7 +22,7 @@ import { autorun, derived, IObservable, IReader, observableValue } from '../../.
 import { onUnexpectedError } from '../../../../base/common/errors.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { URI } from '../../../../base/common/uri.js';
-import { AnchorAlignment, AnchorPosition } from '../../../../base/common/layout.js';
+import { AnchorAlignment, AnchorPosition, IAnchor } from '../../../../base/common/layout.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { IContextViewService, IOpenContextView } from '../../../../platform/contextview/browser/contextView.js';
 import { IsAuxiliaryWindowContext } from '../../../../workbench/common/contextkeys.js';
@@ -46,6 +46,19 @@ import { openSessionToTheSide } from './views/sessionsView.js';
  * opening the full sessions picker so the popup doesn't linger behind it.
  */
 const SHOW_ALL_SESSIONS_FROM_BLOCKED_LIST_COMMAND_ID = 'sessions.blockedSessions.showAllSessions';
+
+/**
+ * Minimum width of the blocked-sessions dropdown, in pixels. The dropdown is at
+ * least as wide as the command center box it hangs off, but never narrower than
+ * this so its rows have room to breathe.
+ */
+const BLOCKED_DROPDOWN_MIN_WIDTH = 550;
+
+/**
+ * Maximum width of the blocked-sessions dropdown as a fraction of the window
+ * width, so it never spans (nearly) the entire window on narrow layouts.
+ */
+const BLOCKED_DROPDOWN_MAX_WIDTH_RATIO = 0.9;
 
 /**
  * The specific reason a homogeneous set of blocked sessions needs attention,
@@ -673,12 +686,14 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			return;
 		}
 
-		// Match the dropdown width to the command center box it hangs off.
-		const width = container.getBoundingClientRect().width;
+		// Match the dropdown width to the command center box it hangs off, but keep
+		// it within a sensible min/max so it stays readable on wide layouts and
+		// doesn't overflow on narrow ones.
+		const width = this._computeBlockedDropdownWidth(container);
 
 		const store = new DisposableStore();
 		this._openContextView = this.contextViewService.showContextView({
-			getAnchor: () => container,
+			getAnchor: () => this._getBlockedDropdownAnchor(container),
 			anchorAlignment: AnchorAlignment.LEFT,
 			anchorPosition: AnchorPosition.BELOW,
 			render: (viewContainer): IDisposable => {
@@ -698,9 +713,10 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 				}));
 
 				// Keep the dropdown width matched to the command center box as the
-				// window resizes (the command center reflows to a new width).
+				// window resizes (the command center reflows to a new width, and the
+				// min/max clamp tracks the new window width).
 				store.add(this.layoutService.onDidLayoutActiveContainer(() => {
-					list.setWidth(container.getBoundingClientRect().width);
+					list.setWidth(this._computeBlockedDropdownWidth(container));
 					this.contextViewService.layout();
 				}));
 
@@ -730,6 +746,38 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 				this._blockedList = undefined;
 			},
 		});
+	}
+
+	/**
+	 * Compute the width of the blocked-sessions dropdown: at least as wide as the
+	 * command center box (the anchor) and {@link BLOCKED_DROPDOWN_MIN_WIDTH}, but
+	 * never wider than {@link BLOCKED_DROPDOWN_MAX_WIDTH_RATIO} of the window so it
+	 * stays within the viewport on narrow layouts.
+	 */
+	private _computeBlockedDropdownWidth(container: HTMLElement): number {
+		const anchorWidth = getDomNodePagePosition(container).width;
+		const windowWidth = getWindow(container).innerWidth;
+		const minWidth = Math.max(anchorWidth, BLOCKED_DROPDOWN_MIN_WIDTH);
+		const maxWidth = windowWidth * BLOCKED_DROPDOWN_MAX_WIDTH_RATIO;
+		return Math.round(Math.min(minWidth, maxWidth));
+	}
+
+	/**
+	 * Anchor the blocked-sessions dropdown so it is horizontally centered on the
+	 * command center box. Because the dropdown can be wider than the box, we hand
+	 * the context view a zero-width anchor positioned at the dropdown's target
+	 * left edge (the box center minus half the dropdown width).
+	 */
+	private _getBlockedDropdownAnchor(container: HTMLElement): IAnchor {
+		const position = getDomNodePagePosition(container);
+		const width = this._computeBlockedDropdownWidth(container);
+		const centerX = position.left + position.width / 2;
+		return {
+			x: Math.round(centerX - width / 2),
+			y: position.top,
+			width: 0,
+			height: position.height,
+		};
 	}
 
 	private _openBlockedSession(resource: URI, preserveFocus: boolean, sideBySide: boolean): void {


### PR DESCRIPTION
## What changed

Makes the blocked-sessions dropdown (context view anchored below the command center box in the sessions titlebar) responsive and horizontally centered on the session title widget.

- Width is now clamped: at least the titlebar widget width **and** at least 550px, but never more than 90% of the window width.
- The dropdown is centered on the command center box instead of left-aligned, using a zero-width anchor at oxCenter - dropdownWidth/2.
- Width and centering re-compute on window resize (existing onDidLayoutActiveContainer handler), so it tracks the reflowing box and changing window width.

## Why

Previously the dropdown matched the command center box width exactly, which could be too narrow to read comfortably and looked off-center once its own sizing needs diverged from the box.

## Notes for reviewers

Uses getDomNodePagePosition (page coordinates) to match the coordinate space the context view service uses internally for anchors/viewport.