### PR TITLE
Voice: allow barge-in over the assistant in hands-free mode (client)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
@@ -175,6 +175,7 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 	private _isMuted = false;
 	private _suppressUntilTs = 0;
 	private _pttAcquiring = false;
+	private _capturePromise: Promise<void> | undefined;
 	private _pttReleasedDuringAcquire = false;
 	private _monitoring = false;
 
@@ -362,9 +363,11 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 			try {
 				await this.startCapture(window);
 			} catch (err) {
+				// Surface the failure so the controller resets its own
+				// _bargeInMonitorActive flag (keeping the two in sync).
 				this._monitoring = false;
 				this.logService.warn('[mic] barge-in monitor could not acquire microphone', err);
-				return;
+				throw err;
 			}
 			// Monitoring may have been cancelled while acquiring; release the
 			// freshly-opened mic so it isn't left running unused.
@@ -386,7 +389,19 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 	async startCapture(window: Window & typeof globalThis): Promise<void> {
 		this._window = window;
 		if (this._isCapturing) { return; }
+		// Serialize concurrent acquisitions (e.g. barge-in monitor + a PTT press
+		// racing to open the mic) so only one getUserMedia/AudioContext is created.
+		if (this._capturePromise) { return this._capturePromise; }
+		this._capturePromise = this._acquireCapture(window);
+		try {
+			await this._capturePromise;
+		} finally {
+			this._capturePromise = undefined;
+		}
+	}
 
+	private async _acquireCapture(window: Window & typeof globalThis): Promise<void> {
+		if (this._isCapturing) { return; }
 		const deviceId = this.storageService.get(AgentsVoiceStorageKeys.MicrophoneDevice, StorageScope.APPLICATION);
 		const audioConstraints: MediaTrackConstraints = {
 			channelCount: 1,

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
@@ -92,11 +92,7 @@ export interface IMicCaptureService {
 	/** Fired when a PTT segment ends. All chunks have been sent before this fires. */
 	readonly onPttEnd: Event<void>;
 
-	/**
-	 * Fired during barge-in monitoring with base64 raw PCM16 chunks (see
-	 * `startMonitor`). Separate from `onPttAudioChunk` so it isn't treated as
-	 * turn input.
-	 */
+	/** Base64 raw PCM16 chunks during barge-in monitoring (not turn input). */
 	readonly onMonitorAudioChunk: Event<string>;
 
 	/**
@@ -136,11 +132,7 @@ export interface IMicCaptureService {
 	 */
 	abortPtt(): void;
 
-	/**
-	 * Stream raw mic audio for barge-in detection during assistant playback,
-	 * without opening a PTT turn. Emitted via `onMonitorAudioChunk` and NOT
-	 * subject to AEC suppression. Acquires the mic if not already capturing.
-	 */
+	/** Stream mic audio for barge-in detection (no PTT turn, no AEC gating). */
 	startMonitor(window: Window & typeof globalThis): Promise<void>;
 
 	/** Stop barge-in monitoring. Releases the mic only if no PTT press is active. */
@@ -357,20 +349,16 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 		this._window = window;
 		if (this._monitoring) { return; }
 		this._monitoring = true;
-		// Reuse an open PTT pipeline; otherwise acquire the mic. Acquisition
-		// failure disables monitoring silently (best-effort, not core flow).
 		if (!this._isCapturing) {
 			try {
 				await this.startCapture(window);
 			} catch (err) {
-				// Surface the failure so the controller resets its own
-				// _bargeInMonitorActive flag (keeping the two in sync).
+				// Rethrow so the controller resets its _bargeInMonitorActive flag.
 				this._monitoring = false;
 				this.logService.warn('[mic] barge-in monitor could not acquire microphone', err);
 				throw err;
 			}
-			// Monitoring may have been cancelled while acquiring; release the
-			// freshly-opened mic so it isn't left running unused.
+			// Cancelled mid-acquire: release the mic we just opened.
 			if (!this._monitoring && !this._pttHeld && !this._pttStreaming) {
 				this.stopCapture();
 			}
@@ -380,7 +368,7 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 	stopMonitor(): void {
 		if (!this._monitoring) { return; }
 		this._monitoring = false;
-		// Only release the mic if no push-to-talk press is relying on it.
+		// Keep the mic if a PTT press is using it.
 		if (!this._pttHeld && !this._pttStreaming) {
 			this.stopCapture();
 		}
@@ -389,8 +377,7 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 	async startCapture(window: Window & typeof globalThis): Promise<void> {
 		this._window = window;
 		if (this._isCapturing) { return; }
-		// Serialize concurrent acquisitions (e.g. barge-in monitor + a PTT press
-		// racing to open the mic) so only one getUserMedia/AudioContext is created.
+		// Serialize concurrent acquisitions (monitor + PTT) into one getUserMedia.
 		if (this._capturePromise) { return this._capturePromise; }
 		this._capturePromise = this._acquireCapture(window);
 		try {
@@ -494,8 +481,7 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 			}
 
 			// Barge-in monitor: stream raw audio during playback (not a turn,
-			// not AEC-gated) so the backend can detect the user talking over
-			// the assistant. Echo is handled by `echoCancellation` + backend VAD.
+			// not AEC-gated) so the backend can detect the user talking over it.
 			if (this._monitoring) {
 				const monitorData = e.inputBuffer.getChannelData(0);
 				const monitorSamples = new Float32Array(monitorData);

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/micCaptureService.ts
@@ -93,6 +93,13 @@ export interface IMicCaptureService {
 	readonly onPttEnd: Event<void>;
 
 	/**
+	 * Fired during barge-in monitoring with base64 raw PCM16 chunks (see
+	 * `startMonitor`). Separate from `onPttAudioChunk` so it isn't treated as
+	 * turn input.
+	 */
+	readonly onMonitorAudioChunk: Event<string>;
+
+	/**
 	 * Fired after the diagnostic window closes (~1s after `pttUp`) with
 	 * per-press telemetry. Always fires AFTER `onPttEnd` for normal
 	 * presses. Used for tail-loss diagnosis; safe to ignore for normal
@@ -129,6 +136,16 @@ export interface IMicCaptureService {
 	 */
 	abortPtt(): void;
 
+	/**
+	 * Stream raw mic audio for barge-in detection during assistant playback,
+	 * without opening a PTT turn. Emitted via `onMonitorAudioChunk` and NOT
+	 * subject to AEC suppression. Acquires the mic if not already capturing.
+	 */
+	startMonitor(window: Window & typeof globalThis): Promise<void>;
+
+	/** Stop barge-in monitoring. Releases the mic only if no PTT press is active. */
+	stopMonitor(): void;
+
 	// --- Mute / AEC suppression ---
 	isMuted: boolean;
 
@@ -159,6 +176,7 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 	private _suppressUntilTs = 0;
 	private _pttAcquiring = false;
 	private _pttReleasedDuringAcquire = false;
+	private _monitoring = false;
 
 	// --- Hardware mute detection. ---
 	// A hardware microphone kill switch (e.g. on Framework laptops) leaves
@@ -207,6 +225,9 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 
 	private readonly _onPttEnd = this._register(new Emitter<void>());
 	readonly onPttEnd: Event<void> = this._onPttEnd.event;
+
+	private readonly _onMonitorAudioChunk = this._register(new Emitter<string>());
+	readonly onMonitorAudioChunk: Event<string> = this._onMonitorAudioChunk.event;
 
 	private readonly _onPttDiagnostic = this._register(new Emitter<IPttDiagnostic>());
 	readonly onPttDiagnostic: Event<IPttDiagnostic> = this._onPttDiagnostic.event;
@@ -331,6 +352,37 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 		this._scheduleDiagnosticFire();
 	}
 
+	async startMonitor(window: Window & typeof globalThis): Promise<void> {
+		this._window = window;
+		if (this._monitoring) { return; }
+		this._monitoring = true;
+		// Reuse an open PTT pipeline; otherwise acquire the mic. Acquisition
+		// failure disables monitoring silently (best-effort, not core flow).
+		if (!this._isCapturing) {
+			try {
+				await this.startCapture(window);
+			} catch (err) {
+				this._monitoring = false;
+				this.logService.warn('[mic] barge-in monitor could not acquire microphone', err);
+				return;
+			}
+			// Monitoring may have been cancelled while acquiring; release the
+			// freshly-opened mic so it isn't left running unused.
+			if (!this._monitoring && !this._pttHeld && !this._pttStreaming) {
+				this.stopCapture();
+			}
+		}
+	}
+
+	stopMonitor(): void {
+		if (!this._monitoring) { return; }
+		this._monitoring = false;
+		// Only release the mic if no push-to-talk press is relying on it.
+		if (!this._pttHeld && !this._pttStreaming) {
+			this.stopCapture();
+		}
+	}
+
 	async startCapture(window: Window & typeof globalThis): Promise<void> {
 		this._window = window;
 		if (this._isCapturing) { return; }
@@ -425,6 +477,16 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 				if (isPostReleaseCallback) { this._diagPostReleaseSkippedByMute++; }
 				return;
 			}
+
+			// Barge-in monitor: stream raw audio during playback (not a turn,
+			// not AEC-gated) so the backend can detect the user talking over
+			// the assistant. Echo is handled by `echoCancellation` + backend VAD.
+			if (this._monitoring) {
+				const monitorData = e.inputBuffer.getChannelData(0);
+				const monitorSamples = new Float32Array(monitorData);
+				this._onMonitorAudioChunk.fire(encodeRawPcm16Base64(monitorSamples, this._window!));
+			}
+
 			if (nowTs < this._suppressUntilTs) {
 				if (isDrainCallback) { this._diagDrainSkippedBySuppression++; }
 				if (isPostReleaseCallback) { this._diagPostReleaseSkippedBySuppression++; }
@@ -514,6 +576,7 @@ export class MicCaptureService extends Disposable implements IMicCaptureService 
 		this._pttHeld = false;
 		this._pttStreaming = false;
 		this._pttReleasedDuringAcquire = false;
+		this._monitoring = false;
 	}
 
 	override dispose(): void {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
@@ -416,6 +416,24 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 		}
 	}
 
+	sendBargeInStart(): void {
+		if (this._ws?.readyState === WebSocket.OPEN) {
+			this._ws.send(JSON.stringify({ type: 'barge_in_start' }));
+		}
+	}
+
+	sendBargeInAudioChunk(audio: string): void {
+		if (this._ws?.readyState === WebSocket.OPEN) {
+			this._ws.send(JSON.stringify({ type: 'barge_in_audio_chunk', audio }));
+		}
+	}
+
+	sendBargeInStop(): void {
+		if (this._ws?.readyState === WebSocket.OPEN) {
+			this._ws.send(JSON.stringify({ type: 'barge_in_stop' }));
+		}
+	}
+
 	sendPttDiagnostic(turnId: string, metrics: Record<string, unknown>): void {
 		if (this._ws?.readyState === WebSocket.OPEN) {
 			this._ws.send(JSON.stringify({ type: 'ptt_diagnostic', turn_id: turnId, metrics }));

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -190,6 +190,13 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	/** Tracks whether the initial listen cue has been played after connecting. */
 	private _hasPlayedInitialListenCue = false;
 
+	/**
+	 * True while barge-in monitoring is active: the mic streams to the backend
+	 * during assistant playback (hands-free) so the user can interrupt by
+	 * talking over it. See `_startBargeInMonitor`.
+	 */
+	private _bargeInMonitorActive = false;
+
 	// --- Audio FIFO queue ---
 	private readonly _audioQueue: { sessionId: string | undefined; chunks: { audio: string; isFirstChunk: boolean; isFinal: boolean; transcript: string | undefined }[] }[] = [];
 	private _currentPlaybackSessionId: string | undefined | null = null; // null = nothing playing
@@ -528,6 +535,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._voiceEventDisposables.add(this.micCaptureService.onPttEnd(() => {
 			this.voiceClientService.sendPttEnd();
 		}));
+		// Barge-in: stream mic audio to the backend during assistant playback.
+		this._voiceEventDisposables.add(this.micCaptureService.onMonitorAudioChunk(b64 => {
+			this.voiceClientService.sendBargeInAudioChunk(b64);
+		}));
 		this._voiceEventDisposables.add(this.micCaptureService.onPttDiagnostic((diag: IPttDiagnostic) => {
 			// Local log so the same correlation key surfaces in the
 			// VS Code log files even if the WS is closed mid-flight.
@@ -585,6 +596,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			if (this._audioQueue.length > 0) {
 				setTimeout(() => this._processQueue(), 500);
 			} else {
+				this._stopBargeInMonitor();
 				if (this._pttHeld) {
 					this._voiceState.set('listening', undefined);
 					this._statusText.set('Listening...', undefined);
@@ -951,13 +963,27 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		// Speech started → stop TTS, suppress late chunks from the previous turn
 		// (same flow as pttDown, but for server-VAD path).
 		this._voiceEventDisposables.add(this.voiceClientService.onSpeechStarted(() => {
+			const wasMonitoring = this._bargeInMonitorActive;
 			this._clearAutoListenTimer();
-			this.ttsPlaybackService.stopPlayback();
-			this._audioQueue.length = 0;
-			this._currentPlaybackSessionId = null;
-			this._isProcessingQueue = false;
-			this._suppressIncomingAudio = true;
-			this._startUserTurn();
+			if (wasMonitoring && !this._pttHeld) {
+				// Barge-in: promote the monitor into a real turn. pttDown stops
+				// playback, clears the queue, and stops the monitor while
+				// keeping the mic warm (no re-acquire), so the utterance start
+				// isn't dropped.
+				this.pttDown();
+				this.pttUp();
+				// Playback kept pushing AEC suppression ~800ms ahead; clear it
+				// so the warm mic's audio isn't gated at the turn start.
+				this.micCaptureService.suppressUntil(0);
+			} else {
+				this.ttsPlaybackService.stopPlayback();
+				this._audioQueue.length = 0;
+				this._currentPlaybackSessionId = null;
+				this._isProcessingQueue = false;
+				this._suppressIncomingAudio = true;
+				this._stopBargeInMonitor();
+				this._startUserTurn();
+			}
 		}));
 
 		// Backend ended the held turn itself (server VAD silence / stop phrase).
@@ -1133,6 +1159,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._enterListenOnSessionInit = false;
 		this._hasPlayedInitialListenCue = false;
 		this._replyPlayedSinceSend = false;
+		this._bargeInMonitorActive = false;
 		this._audioQueue.length = 0;
 		this._currentPlaybackSessionId = null;
 		this._isProcessingQueue = false;
@@ -1218,6 +1245,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 		if (this._pttHeld) { this.logService.info('[voice] pttDown ignored: already held'); return; }
 		this._pttHeld = true;
+		// This press owns the mic now; stop the monitor. The mic stays warm
+		// because _pttHeld is already set (stopMonitor won't release it).
+		this._stopBargeInMonitor();
 		this._autoListenSuppressed = false;
 		this._clearAutoListenTimer();
 		this._pttCurrentTurnId = generateUuid();
@@ -1312,6 +1342,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 		this._autoListenSuppressed = true;
 		this._pttToggleMode = false;
 		this._clearAutoListenTimer();
+		this._stopBargeInMonitor();
 		if (this._pttHeld) {
 			this._finishPtt('local');
 		} else {
@@ -1454,6 +1485,39 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			clearTimeout(this._awaitingReplyWatchdog);
 			this._awaitingReplyWatchdog = undefined;
 		}
+	}
+
+	/**
+	 * Start barge-in monitoring: stream mic audio to the backend during
+	 * assistant playback so the user can interrupt by talking over it.
+	 * Hands-free only; no-op if already active, disconnected, mid-press, or the
+	 * window isn't ready. The backend emits `speech_started` on detection,
+	 * which `onSpeechStarted` promotes into a real turn. Inert until the
+	 * backend consumes `barge_in_*` (unknown messages are ignored server-side).
+	 */
+	private _startBargeInMonitor(): void {
+		if (this._bargeInMonitorActive || !this._isConnected.get() || this._pttHeld || !this._window) {
+			return;
+		}
+		if (!this._isHandsFreeEnabled()) {
+			return;
+		}
+		this._bargeInMonitorActive = true;
+		this.voiceClientService.sendBargeInStart();
+		this.micCaptureService.startMonitor(this._window).catch(err => {
+			this.logService.warn('[voice] barge-in monitor failed to start', err);
+			this._bargeInMonitorActive = false;
+		});
+	}
+
+	/** Stop barge-in monitoring and tell the backend to stop listening for it. */
+	private _stopBargeInMonitor(): void {
+		if (!this._bargeInMonitorActive) {
+			return;
+		}
+		this._bargeInMonitorActive = false;
+		this.micCaptureService.stopMonitor();
+		this.voiceClientService.sendBargeInStop();
 	}
 
 	/**
@@ -1944,6 +2008,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this.micCaptureService.suppressUntil(Date.now() + 800);
 			this._voiceState.set('speaking', undefined);
 			this._statusText.set('Speaking...', undefined);
+			// Hands-free: keep the mic open so the user can barge in.
+			this._startBargeInMonitor();
 			this.ttsPlaybackService.playAudioChunk(audio, isFinal, this._window!);
 		} else if (!ttsEnabled) {
 			this._replyPlayedSinceSend = true;

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -190,11 +190,7 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	/** Tracks whether the initial listen cue has been played after connecting. */
 	private _hasPlayedInitialListenCue = false;
 
-	/**
-	 * True while barge-in monitoring is active: the mic streams to the backend
-	 * during assistant playback (hands-free) so the user can interrupt by
-	 * talking over it. See `_startBargeInMonitor`.
-	 */
+	/** True while streaming mic audio to the backend during playback (barge-in). */
 	private _bargeInMonitorActive = false;
 
 	// --- Audio FIFO queue ---
@@ -966,14 +962,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			const wasMonitoring = this._bargeInMonitorActive;
 			this._clearAutoListenTimer();
 			if (wasMonitoring && !this._pttHeld) {
-				// Barge-in: promote the monitor into a real turn. pttDown stops
-				// playback, clears the queue, and stops the monitor while
-				// keeping the mic warm (no re-acquire), so the utterance start
-				// isn't dropped.
+				// Promote the monitor into a real turn (mic stays warm via pttDown).
 				this.pttDown();
 				this.pttUp();
-				// Playback kept pushing AEC suppression ~800ms ahead; clear it
-				// so the warm mic's audio isn't gated at the turn start.
+				// Clear the playback AEC suppression so the turn start isn't gated.
 				this.micCaptureService.suppressUntil(0);
 			} else {
 				this.ttsPlaybackService.stopPlayback();
@@ -1293,9 +1285,8 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			}
 			this.disconnect();
 		});
-		// Stop the monitor after mic pttDown so the mic service's own
-		// _pttStreaming flag is set first, so stopMonitor keeps the mic
-		// warm instead of releasing and re-acquiring it.
+		// Stop the monitor after mic pttDown so its _pttStreaming flag is set
+		// first, letting stopMonitor keep the mic warm instead of re-acquiring.
 		this._stopBargeInMonitor();
 		this.ttsPlaybackService.stopPlayback();
 		this._voiceState.set('listening', undefined);
@@ -1490,11 +1481,9 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 	/**
 	 * Start barge-in monitoring: stream mic audio to the backend during
-	 * assistant playback so the user can interrupt by talking over it.
-	 * Hands-free only; no-op if already active, disconnected, mid-press, or the
-	 * window isn't ready. The backend emits `speech_started` on detection,
-	 * which `onSpeechStarted` promotes into a real turn. Inert until the
-	 * backend consumes `barge_in_*` (unknown messages are ignored server-side).
+	 * playback so the user can talk over the assistant. Hands-free only;
+	 * the backend emits `speech_started`, which `onSpeechStarted` promotes
+	 * into a real turn. Inert until the backend consumes `barge_in_*`.
 	 */
 	private _startBargeInMonitor(): void {
 		if (this._bargeInMonitorActive || !this._isConnected.get() || this._pttHeld || !this._window) {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -1245,9 +1245,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 		if (this._pttHeld) { this.logService.info('[voice] pttDown ignored: already held'); return; }
 		this._pttHeld = true;
-		// This press owns the mic now; stop the monitor. The mic stays warm
-		// because _pttHeld is already set (stopMonitor won't release it).
-		this._stopBargeInMonitor();
 		this._autoListenSuppressed = false;
 		this._clearAutoListenTimer();
 		this._pttCurrentTurnId = generateUuid();
@@ -1296,6 +1293,10 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			}
 			this.disconnect();
 		});
+		// Stop the monitor after mic pttDown so the mic service's own
+		// _pttStreaming flag is set first, so stopMonitor keeps the mic
+		// warm instead of releasing and re-acquiring it.
+		this._stopBargeInMonitor();
 		this.ttsPlaybackService.stopPlayback();
 		this._voiceState.set('listening', undefined);
 		this._statusText.set('Listening...', undefined);

--- a/src/vs/workbench/contrib/chat/common/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/common/voiceClient/voiceClientService.ts
@@ -160,6 +160,16 @@ export interface IVoiceClientService {
 	sendPttAudioChunk(audio: string): void;
 	sendPttEnd(): void;
 	/**
+	 * Barge-in monitoring: while the assistant speaks in hands-free mode, the
+	 * client streams raw mic audio (`barge_in_start`/`barge_in_audio_chunk`/
+	 * `barge_in_stop`) so the backend can detect the user talking over it and
+	 * emit `speech_started`. This audio is NOT a turn and must not be
+	 * transcribed as user input.
+	 */
+	sendBargeInStart(): void;
+	sendBargeInAudioChunk(audio: string): void;
+	sendBargeInStop(): void;
+	/**
 	 * Send a per-press post-mortem diagnostic payload for tail-loss
 	 * investigation. Fired ~500ms after `pttUp` by the mic service.
 	 * `metrics` is an opaque object echoed straight into a structured

--- a/src/vs/workbench/contrib/chat/common/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/common/voiceClient/voiceClientService.ts
@@ -160,11 +160,8 @@ export interface IVoiceClientService {
 	sendPttAudioChunk(audio: string): void;
 	sendPttEnd(): void;
 	/**
-	 * Barge-in monitoring: while the assistant speaks in hands-free mode, the
-	 * client streams raw mic audio (`barge_in_start`/`barge_in_audio_chunk`/
-	 * `barge_in_stop`) so the backend can detect the user talking over it and
-	 * emit `speech_started`. This audio is NOT a turn and must not be
-	 * transcribed as user input.
+	 * Barge-in: stream raw mic audio while the assistant speaks (hands-free) so
+	 * the backend can detect the user talking over it. Not a turn; not transcribed.
 	 */
 	sendBargeInStart(): void;
 	sendBargeInAudioChunk(audio: string): void;


### PR DESCRIPTION
## Voice: allow barge-in over the assistant in hands-free mode (client half)

### Problem
In hands-free voice mode, while the assistant is speaking the mic is closed. No audio reaches the backend during playback, so there's no way for the user to **interrupt (barge-in) by talking over the assistant** — you have to wait for it to finish.

### Fix (client)
While the assistant is speaking in hands-free mode, the client now opens a lightweight **barge-in monitor**: it keeps the mic open and streams raw PCM to the backend over new `barge_in_start` / `barge_in_audio_chunk` / `barge_in_stop` messages — *without* opening a push-to-talk turn and *without* the AEC output-suppression that gates normal PTT drain audio. The mic's `echoCancellation` plus backend VAD are responsible for separating the user's voice from the assistant's playback.

When the backend detects the user talking over the assistant it emits `speech_started` (same signal used today for server-VAD interruption). The existing `onSpeechStarted` handler stops playback, and now **promotes the monitor into a real listening turn** so the interrupting utterance is captured (it enters hands-free toggle listening, ended by the backend's `turn_auto_ended` like any auto-listen turn).

### Changes
- **`micCaptureService`**: `startMonitor` / `stopMonitor` + `onMonitorAudioChunk`. Streams raw audio independent of PTT streaming and not gated by `suppressUntil`. Handles the acquire/cancel race so the mic can't leak if monitoring is stopped mid-acquisition.
- **`voiceClientService`**: `sendBargeInStart` / `sendBargeInAudioChunk` / `sendBargeInStop`.
- **`voiceSessionController`**: start the monitor when playback begins (hands-free only); stop it when playback ends, a press starts, on stop-listening, and on disconnect; promote to a real turn on `speech_started`.

### Requires a backend change
This is the **client half**. It needs a corresponding backend change to run VAD on the barge-in stream and emit `speech_started` during assistant playback. Until that lands, the new `barge_in_*` messages are inert — unknown message types are ignored server-side — so this is safe to ship on its own.

### Notes
- Non-hands-free (push-to-talk) mode is unchanged: the user already interrupts by pressing the button.
- No new settings.
