### PR TITLE
Agent-driven session rename in the Agents window

### DIFF
--- a/src/vs/platform/agentHost/common/state/sessionState.ts
+++ b/src/vs/platform/agentHost/common/state/sessionState.ts
@@ -1009,6 +1009,58 @@ export function withSessionWorkspaceless(meta: SessionSummaryMeta | undefined, w
 	return Object.keys(next).length > 0 ? next : undefined;
 }
 
+/**
+ * Provenance of a session's title. `'auto'` = a placeholder or first-message
+ * fallback the agent is free to replace; `'agent'` = set by the agent via the
+ * `rename_session` server tool; `'user'` = a manual rename that the agent must
+ * never overwrite.
+ */
+export type SessionTitleSource = 'auto' | 'agent' | 'user';
+
+/**
+ * Reserved key under {@link SessionSummaryMeta} carrying a session's
+ * {@link SessionTitleSource}. VS Code-specific convention layered on the
+ * protocol's generic `_meta` bag; drives whether the agent-rename nudge fires
+ * and guards user-set titles from being overwritten.
+ */
+export const SESSION_META_TITLE_SOURCE_KEY = 'titleSource';
+
+/**
+ * Session-database metadata key recording a session's {@link SessionTitleSource}.
+ * Owned by the AH title controller, which persists it whenever it applies or
+ * attributes a title; re-emitted onto the session's `_meta` on restore
+ * (mirroring {@link AH_META_WORKSPACELESS_DB_KEY}).
+ */
+export const AH_META_TITLE_SOURCE_DB_KEY = 'agentHost.titleSource';
+
+/**
+ * Coerces an arbitrary value to a {@link SessionTitleSource}, or `undefined`
+ * when it is not one of the known sources.
+ */
+export function asSessionTitleSource(value: unknown): SessionTitleSource | undefined {
+	return value === 'auto' || value === 'agent' || value === 'user' ? value : undefined;
+}
+
+/** Reads the title provenance from {@link SessionSummaryMeta}. */
+export function readSessionTitleSource(meta: SessionSummaryMeta | undefined): SessionTitleSource | undefined {
+	return asSessionTitleSource(meta?.[SESSION_META_TITLE_SOURCE_KEY]);
+}
+
+/**
+ * Returns a new {@link SessionSummaryMeta} with the title provenance set, or
+ * with the slot removed when `source` is `undefined`. Returns `undefined` if
+ * the result would be empty.
+ */
+export function withSessionTitleSource(meta: SessionSummaryMeta | undefined, source: SessionTitleSource | undefined): SessionSummaryMeta | undefined {
+	const next: { [key: string]: unknown } = { ...meta };
+	if (source !== undefined) {
+		next[SESSION_META_TITLE_SOURCE_KEY] = source;
+	} else {
+		delete next[SESSION_META_TITLE_SOURCE_KEY];
+	}
+	return Object.keys(next).length > 0 ? next : undefined;
+}
+
 // ---- RootState _meta accessors ---------------------------------------------
 
 /**

--- a/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
+++ b/src/vs/platform/agentHost/node/agentHostSessionTitleController.ts
@@ -5,14 +5,15 @@
 
 import { CancellationToken, CancellationTokenSource } from '../../../base/common/cancellation.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
-import { URI } from '../../../base/common/uri.js';
 import { ILogService } from '../../log/common/log.js';
 import { ISessionDataService } from '../common/sessionDataService.js';
 import { ActionType } from '../common/state/sessionActions.js';
-import { isAhpChatChannel, isDefaultChatUri, type Turn, type URI as ProtocolURI } from '../common/state/sessionState.js';
+import { AH_META_TITLE_SOURCE_DB_KEY, isAhpChatChannel, isDefaultChatUri, readSessionTitleSource, withSessionTitleSource, type SessionMeta, type SessionTitleSource, type Turn, type URI as ProtocolURI } from '../common/state/sessionState.js';
 import { buildConversationContext, renderResponseMarkdown, truncateMiddle } from '../common/agentHostConversationContext.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
 import { ICopilotApiService, type ICopilotUtilityChatMessage } from './shared/copilotApiService.js';
+import { persistSessionMetadata } from './shared/persistSessionMetadata.js';
+import type { IRenameSessionToolResult } from './shared/agentRenameSessionServerTool.js';
 
 const MAX_TITLE_LENGTH = 200;
 
@@ -82,29 +83,26 @@ export class AgentHostSessionTitleController extends Disposable {
 			return;
 		}
 
-		const apply = (title: string) => this._applyTitle(channel, title, t => this._stateManager.dispatchServerAction(channel, {
+		this._applyTitle(channel, fallbackTitle, t => this._stateManager.dispatchServerAction(channel, {
 			type: ActionType.SessionTitleChanged,
 			title: t,
 		}));
-		apply(fallbackTitle);
-		this._generateTitleSoon(
-			channel,
-			userPrompt,
-			false,
-			fallbackTitle,
-			apply,
-			() => this._stateManager.getSessionState(channel)?.title === this._lastAppliedTitle.get(channel),
-			title => this._persistSessionFlag(channel, 'customTitle', title),
-		);
+		// Persist the fallback title and mark it `auto` provenance so a
+		// placeholder survives a restart and the agent's rename nudge keeps
+		// firing until the agent (or the user) gives the session a real title.
+		this._persistSessionFlag(channel, 'customTitle', fallbackTitle);
+		this._setTitleSource(channel, 'auto', state._meta);
 	}
 
 	/**
-	 * Re-generates the title once the first turn has completed, this time
-	 * using the full first-turn context (the user request plus the agent's
-	 * textual response) rather than just the opening message. This only runs
-	 * for the very first turn and only when the current title is still the one
-	 * this controller last applied — a manual `/rename`, a user edit, or a
-	 * forked session's inherited title all suppress it.
+	 * Re-generates a **peer (additional) chat's** title once its first turn has
+	 * completed, using the full first-turn context (the user request plus the
+	 * agent's textual response) rather than just the opening message. Peer chats
+	 * are not covered by the agent-driven session rename (that is session-level
+	 * only), so they keep the utility-model refinement. This only runs for the
+	 * very first turn and only when the chat title is still the one this
+	 * controller last applied — a manual `/rename` or user edit suppresses it.
+	 * A session/default-chat channel is a no-op.
 	 *
 	 * Only normal text response parts are considered (tool calls, reasoning,
 	 * and other parts are ignored). If the context still exceeds the budget
@@ -113,56 +111,30 @@ export class AgentHostSessionTitleController extends Disposable {
 	 */
 	refineTitleFromFirstTurn(channel: ProtocolURI, chatChannel?: ProtocolURI): void {
 		const isAdditionalChat = !!chatChannel && isAhpChatChannel(chatChannel) && !isDefaultChatUri(chatChannel);
-		if (isAdditionalChat) {
-			const chatState = this._stateManager.getChatState(chatChannel);
-			if (!chatState || chatState.turns.length !== 1) {
-				return;
-			}
-			const lastApplied = this._lastAppliedTitle.get(chatChannel);
-			if (lastApplied === undefined || chatState.title !== lastApplied) {
-				return;
-			}
-			const context = this._buildFirstTurnContext(chatState.turns[0]);
-			if (!context) {
-				return;
-			}
-			const apply = (title: string) => this._applyTitle(chatChannel, title, t => this._stateManager.updateChatTitle(channel, chatChannel, t));
-			this._generateTitleSoon(
-				chatChannel,
-				context,
-				true,
-				lastApplied,
-				apply,
-				() => this._stateManager.getChatState(chatChannel)?.title === this._lastAppliedTitle.get(chatChannel),
-				title => this._persistSessionFlag(channel, `customChatTitle:${chatChannel}`, title),
-			);
+		if (!isAdditionalChat) {
 			return;
 		}
-
-		const state = this._stateManager.getSessionState(channel);
-		if (!state || state.turns.length !== 1) {
+		const chatState = this._stateManager.getChatState(chatChannel);
+		if (!chatState || chatState.turns.length !== 1) {
 			return;
 		}
-		const lastApplied = this._lastAppliedTitle.get(channel);
-		if (lastApplied === undefined || state.title !== lastApplied) {
+		const lastApplied = this._lastAppliedTitle.get(chatChannel);
+		if (lastApplied === undefined || chatState.title !== lastApplied) {
 			return;
 		}
-		const context = this._buildFirstTurnContext(state.turns[0]);
+		const context = this._buildFirstTurnContext(chatState.turns[0]);
 		if (!context) {
 			return;
 		}
-		const apply = (title: string) => this._applyTitle(channel, title, t => this._stateManager.dispatchServerAction(channel, {
-			type: ActionType.SessionTitleChanged,
-			title: t,
-		}));
+		const apply = (title: string) => this._applyTitle(chatChannel, title, t => this._stateManager.updateChatTitle(channel, chatChannel, t));
 		this._generateTitleSoon(
-			channel,
+			chatChannel,
 			context,
 			true,
 			lastApplied,
 			apply,
-			() => this._stateManager.getSessionState(channel)?.title === this._lastAppliedTitle.get(channel),
-			title => this._persistSessionFlag(channel, 'customTitle', title),
+			() => this._stateManager.getChatState(chatChannel)?.title === this._lastAppliedTitle.get(chatChannel),
+			title => this._persistSessionFlag(channel, `customChatTitle:${chatChannel}`, title),
 		);
 	}
 
@@ -183,12 +155,20 @@ export class AgentHostSessionTitleController extends Disposable {
 	 * so generation costs at most a single small-model call.
 	 */
 	generateForkedTitle(channel: ProtocolURI, chatChannel: ProtocolURI | undefined, turns: readonly Turn[], fallbackTitle: string, sourceTitle?: string): void {
+		const isAdditionalChat = !!chatChannel && isAhpChatChannel(chatChannel) && !isDefaultChatUri(chatChannel);
+		if (!isAdditionalChat) {
+			// A forked session inherits a `Forked: …` placeholder. Stamp it
+			// `auto` provenance so the agent-rename nudge still fires and a
+			// later restore never mistakes a title of unknown provenance for a
+			// user-set one (which would permanently lock it).
+			this._setTitleSource(channel, 'auto', this._stateManager.getSessionState(channel)?._meta);
+		}
+
 		const context = this._buildConversationContext(turns, sourceTitle);
 		if (!context) {
 			return;
 		}
 
-		const isAdditionalChat = !!chatChannel && isAhpChatChannel(chatChannel) && !isDefaultChatUri(chatChannel);
 		if (isAdditionalChat) {
 			const key = chatChannel;
 			this._lastAppliedTitle.set(key, fallbackTitle);
@@ -224,6 +204,55 @@ export class AgentHostSessionTitleController extends Disposable {
 	private _applyTitle(key: ProtocolURI, title: string, dispatch: (title: string) => void): void {
 		this._lastAppliedTitle.set(key, title);
 		dispatch(title);
+	}
+
+	/**
+	 * Whether the agent should still be nudged to rename `session`: `true` while
+	 * the title provenance is `auto` (or absent), `false` once the agent or the
+	 * user has given it a real title. Durable across restart (backed by the
+	 * persisted title-source metadata).
+	 */
+	needsRename(session: ProtocolURI): boolean {
+		const source = readSessionTitleSource(this._stateManager.getSessionState(session)?._meta);
+		return source !== 'agent' && source !== 'user';
+	}
+
+	/**
+	 * Applies an agent-requested rename of `session` (via the `rename_session`
+	 * server tool), cleaning/validating `rawTitle` and refusing to overwrite a
+	 * user-set title. On success it updates the title, marks the provenance
+	 * `agent`, and persists both.
+	 */
+	applyAgentRename(session: ProtocolURI, rawTitle: string): IRenameSessionToolResult {
+		const title = this._cleanTitle(rawTitle);
+		if (!title) {
+			return { status: 'invalid' };
+		}
+		const state = this._stateManager.getSessionState(session);
+		if (readSessionTitleSource(state?._meta) === 'user') {
+			return { status: 'skippedUserNamed' };
+		}
+		this._applyTitle(session, title, t => this._stateManager.dispatchServerAction(session, {
+			type: ActionType.SessionTitleChanged,
+			title: t,
+		}));
+		this._persistSessionFlag(session, 'customTitle', title);
+		this._setTitleSource(session, 'agent', state?._meta);
+		return { status: 'renamed', title };
+	}
+
+	/**
+	 * Marks `session`'s title as user-set so the agent-rename nudge stops and the
+	 * agent can never overwrite it. The caller persists the title text itself;
+	 * this only records and persists the `user` provenance.
+	 */
+	markUserSessionTitle(session: ProtocolURI): void {
+		this._setTitleSource(session, 'user', this._stateManager.getSessionState(session)?._meta);
+	}
+
+	private _setTitleSource(session: ProtocolURI, source: SessionTitleSource, currentMeta: SessionMeta | undefined): void {
+		this._stateManager.setSessionMeta(session, withSessionTitleSource(currentMeta, source));
+		this._persistSessionFlag(session, AH_META_TITLE_SOURCE_DB_KEY, source);
 	}
 
 	cancelTitleGeneration(session: ProtocolURI): void {
@@ -406,12 +435,7 @@ export class AgentHostSessionTitleController extends Disposable {
 	}
 
 	private _persistSessionFlag(session: ProtocolURI, key: string, value: string): void {
-		const ref = this._options.sessionDataService.openDatabase(URI.parse(session));
-		ref.object.setMetadata(key, value).catch(err => {
-			this._logService.warn(`[AgentHostSessionTitleController] Failed to persist ${key}`, err);
-		}).finally(() => {
-			ref.dispose();
-		});
+		persistSessionMetadata(this._options.sessionDataService, this._logService, session, key, value);
 	}
 
 	private _cancelTitleGeneration(session: ProtocolURI): void {

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -29,7 +29,7 @@ import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } f
 import { AhpErrorCodes, AHP_SESSION_NOT_FOUND, ContentEncoding, JSON_RPC_INTERNAL_ERROR, ProtocolError, ResourceChangeType, ResourceType, ResourceWriteMode, type CreateResourceWatchParams, type CreateResourceWatchResult, type DirectoryEntry, type ResourceCopyParams, type ResourceCopyResult, type ResourceDeleteParams, type ResourceDeleteResult, type ResourceListResult, type ResourceMkdirParams, type ResourceMkdirResult, type ResourceMoveParams, type ResourceMoveResult, type ResourceReadResult, type ResourceResolveParams, type ResourceResolveResult, type ResourceWatchState, type ResourceWriteParams, type ResourceWriteResult, type IStateSnapshot } from '../common/state/sessionProtocol.js';
 import { ChangesSummary, ChatInteractivity, ChatOriginKind, MessageAttachmentKind, type Message, type MessageAttachment, type MessageResourceAttachment } from '../common/state/protocol/state.js';
 import type { ChatPendingMessageSetAction, ChatTurnStartedAction } from '../common/state/protocol/actions.js';
-import { ISessionGitHubState, ISessionGitState, ResponsePartKind, SESSION_META_GITHUB_KEY, SESSION_META_GIT_KEY, SessionStatus, ToolCallStatus, ToolResultContentType, AH_META_WORKSPACELESS_DB_KEY, buildDefaultChatUri, buildResourceWatchChannelUri, buildSubagentChatUri, hostBuildInfoFromProduct, isAhpChatChannel, isSubagentSession, parseDefaultChatUri, parseRequiredSessionUriFromChatUri, parseResourceWatchChannelUri, parseSubagentSessionUri, readSessionGitState, readSessionWorkspaceless, withSessionGitHubState, withSessionGitState, withSessionWorkspaceless, type SessionConfigState, type SessionSummary, type ToolResultSubagentContent, type Turn } from '../common/state/sessionState.js';
+import { ISessionGitHubState, ISessionGitState, ResponsePartKind, SESSION_META_GITHUB_KEY, SESSION_META_GIT_KEY, SessionStatus, ToolCallStatus, ToolResultContentType, AH_META_TITLE_SOURCE_DB_KEY, AH_META_WORKSPACELESS_DB_KEY, asSessionTitleSource, buildDefaultChatUri, buildResourceWatchChannelUri, buildSubagentChatUri, hostBuildInfoFromProduct, isAhpChatChannel, isSubagentSession, parseDefaultChatUri, parseRequiredSessionUriFromChatUri, parseResourceWatchChannelUri, parseSubagentSessionUri, readSessionGitState, readSessionWorkspaceless, withSessionGitHubState, withSessionGitState, withSessionTitleSource, withSessionWorkspaceless, type SessionConfigState, type SessionSummary, type SessionTitleSource, type ToolResultSubagentContent, type Turn } from '../common/state/sessionState.js';
 import { IProductService } from '../../product/common/productService.js';
 import { AgentConfigurationService, IAgentConfigurationService } from './agentConfigurationService.js';
 import { AgentHostTerminalManager, IAgentHostTerminalManager } from './agentHostTerminalManager.js';
@@ -40,7 +40,7 @@ import { IAgentHostGitService } from '../common/agentHostGitService.js';
 import { AgentSideEffects } from './agentSideEffects.js';
 import { AgentHostLocalTurns } from './agentHostLocalTurns.js';
 import { AgentServerToolHost } from './shared/agentServerToolHost.js';
-import { serverToolGroups } from './shared/serverToolGroups.js';
+import { createServerToolGroups } from './shared/serverToolGroups.js';
 import { AgentHostChangesetService } from './agentHostChangesetService.js';
 import { AgentHostFileMonitorService, IAgentHostFileMonitorService } from './agentHostFileMonitorService.js';
 import { IAgentHostCheckpointService, NULL_CHECKPOINT_SERVICE } from '../common/agentHostCheckpointService.js';
@@ -404,10 +404,13 @@ export class AgentService extends Disposable implements IAgentService {
 		}));
 
 		// Server-side tools, executed in-process against each session's own
-		// state. Tool groups are contributed here at startup (feedback today) and
-		// handed to providers that support them during registration (see
-		// registerProvider).
-		this._serverToolHost = new AgentServerToolHost(this._stateManager, serverToolGroups);
+		// state. Tool groups are contributed here at startup and handed to
+		// providers that support them during registration (see registerProvider).
+		// Host-side handlers (e.g. session rename) are bound to already-built
+		// collaborators so the tool groups stay free of state/persistence.
+		this._serverToolHost = new AgentServerToolHost(this._stateManager, createServerToolGroups({
+			renameSession: (sessionUri, rawTitle) => this._sideEffects.renameSessionFromAgent(sessionUri, rawTitle),
+		}));
 	}
 
 	// ---- provider registration ----------------------------------------------
@@ -1871,6 +1874,7 @@ export class AgentService extends Disposable implements IAgentService {
 		let gitMetadata: Record<string, string | undefined> | undefined;
 		let changesetMetadata: Record<string, string | undefined> | undefined;
 		let sessionMetadata: Record<string, unknown> | undefined;
+		let restoredTitleSource: SessionTitleSource | undefined;
 		const ref = this._sessionDataService.tryOpenDatabase?.(session);
 		if (ref) {
 			try {
@@ -1884,6 +1888,7 @@ export class AgentService extends Disposable implements IAgentService {
 							isDone: true,
 							configValues: true,
 							[AH_META_WORKSPACELESS_DB_KEY]: true,
+							[AH_META_TITLE_SOURCE_DB_KEY]: true,
 							...GIT_DB_METADATA_KEYS,
 							...CHANGESET_DB_METADATA_KEYS,
 						});
@@ -1933,6 +1938,19 @@ export class AgentService extends Disposable implements IAgentService {
 
 						if (m[AH_META_WORKSPACELESS_DB_KEY] !== undefined) {
 							sessionMetadata = withSessionWorkspaceless(sessionMetadata, m[AH_META_WORKSPACELESS_DB_KEY] === 'true');
+						}
+
+						restoredTitleSource = asSessionTitleSource(m[AH_META_TITLE_SOURCE_DB_KEY]);
+						if (!restoredTitleSource && m.customTitle) {
+							// A persisted custom title with no recorded provenance
+							// predates the title-source metadata (or is a partially
+							// persisted rename). Its origin is unknowable, so lock it
+							// as user-set so the agent can never overwrite a title the
+							// user may have chosen.
+							restoredTitleSource = 'user';
+						}
+						if (restoredTitleSource) {
+							sessionMetadata = withSessionTitleSource(sessionMetadata, restoredTitleSource);
 						}
 
 						if (m.configValues) {
@@ -2021,6 +2039,16 @@ export class AgentService extends Disposable implements IAgentService {
 		// state. This dispatches a SessionMetaChanged action.
 		if (meta._meta) {
 			this._stateManager.setSessionMeta(sessionStr, meta._meta);
+		}
+
+		// Re-apply the AH-owned title provenance last (merged into whatever
+		// `_meta` is now live): it is persisted by the title controller under
+		// its own DB key, so the provider's `meta._meta` above never carries it
+		// and would otherwise drop it. Drives the agent-rename nudge across a
+		// restart.
+		if (restoredTitleSource) {
+			const currentMeta = this._stateManager.getSessionState(sessionStr)?._meta;
+			this._stateManager.setSessionMeta(sessionStr, withSessionTitleSource(currentMeta, restoredTitleSource));
 		}
 
 		// Resolve the session config so clients (e.g. the running-session

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -48,6 +48,7 @@ import {
 } from '../common/state/sessionState.js';
 import { AgentHostLocalTurns } from './agentHostLocalTurns.js';
 import { AgentHostSessionTitleController } from './agentHostSessionTitleController.js';
+import type { IRenameSessionToolResult } from './shared/agentRenameSessionServerTool.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
 import { AgentHostTelemetryReporter } from './agentHostTelemetryReporter.js';
 import { AgentHostToolCallTracker } from './agentHostToolCallTracker.js';
@@ -59,6 +60,15 @@ import { SessionPermissionManager } from './sessionPermissions.js';
 import type { ICopilotApiService } from './shared/copilotApiService.js';
 import { stripProxyErrorMarker, toChatErrorMeta, tryParseForwardedChatError } from './shared/forwardedChatError.js';
 import { persistSessionMetadata } from './shared/persistSessionMetadata.js';
+
+/**
+ * Suffix appended to a session-level SDK prompt while the session still has an
+ * auto/placeholder name, asking the agent to call the `rename_session` tool.
+ * Model-facing (not localized); mirrors github/github-app's nudge. Self-healing:
+ * repeats each turn until the agent (or the user) gives the session a real name.
+ */
+const RENAME_SESSION_NUDGE = '\n\n<system_notification>\nReminder: This session currently has an auto-generated or placeholder name. Please call the `rename_session` tool to give it a short, descriptive title based on the user\'s intent.\n</system_notification>';
+
 
 /**
  * Options for constructing an {@link AgentSideEffects} instance.
@@ -1061,7 +1071,11 @@ export class AgentSideEffects extends Disposable {
 					this._persistSessionFlag(sessionChannel, `customChatTitle:${chatChannel}`, action.title);
 					break;
 				}
+				// A session-level (non-chat) client rename is a deliberate user
+				// action: mark the provenance `user` so the agent-rename nudge
+				// stops and the agent can never overwrite it.
 				this._persistSessionFlag(channel, 'customTitle', action.title);
+				this._titleController.markUserSessionTitle(channel);
 				break;
 			}
 			case ActionType.ChatPendingMessageSet:
@@ -1327,7 +1341,7 @@ export class AgentSideEffects extends Disposable {
 		turnId: string;
 		senderClientId: string | undefined;
 	}): Promise<void> {
-		const { agent, turnChannel, chat, message, turnId, senderClientId } = options;
+		const { agent, sessionChannel, turnChannel, chat, message, turnId, senderClientId } = options;
 
 		const chatUri = URI.parse(chat);
 
@@ -1343,7 +1357,12 @@ export class AgentSideEffects extends Disposable {
 
 		await Promise.all(selectionUpdates);
 
-		await agent.chats.sendMessage(chatUri, message.text, message.attachments, turnId, senderClientId).catch(err => {
+		// Append the session-rename nudge to the SDK prompt only (does not alter
+		// the already-displayed user turn) while the session name is still auto.
+		const nudge = this._maybeRenameNudge(sessionChannel, chat);
+		const promptText = nudge ? `${message.text}${nudge}` : message.text;
+
+		await agent.chats.sendMessage(chatUri, promptText, message.attachments, turnId, senderClientId).catch(err => {
 			const errCode = (err as { code?: number })?.code;
 			this._logService.error(`[AgentSideEffects] sendMessage failed for session=${turnChannel}: code=${errCode}, message=${err instanceof Error ? err.message : String(err)}, type=${err?.constructor?.name}`, err);
 			this._stateManager.dispatchServerAction(turnChannel, {
@@ -1354,6 +1373,32 @@ export class AgentSideEffects extends Disposable {
 			this._turnTracker.turnCompleted(turnChannel, turnId, 'error');
 			this._toolCallTracker.clearSession(turnChannel);
 		});
+	}
+
+	/**
+	 * Applies an agent-requested session rename (from the `rename_session`
+	 * server tool). Delegates to the title controller, which cleans/validates
+	 * the title, refuses to overwrite a user-set title, and persists both the
+	 * title and its `agent` provenance.
+	 */
+	renameSessionFromAgent(sessionUri: ProtocolURI, rawTitle: string): IRenameSessionToolResult {
+		return this._titleController.applyAgentRename(sessionUri, rawTitle);
+	}
+
+	/**
+	 * Returns the session-rename nudge suffix for the SDK prompt, or `undefined`
+	 * when it should not fire: peer (non-default) chats are session-level-exempt
+	 * in v1, and the session already has an agent- or user-set title.
+	 */
+	private _maybeRenameNudge(sessionChannel: ProtocolURI, chat: ProtocolURI): string | undefined {
+		if (isAhpChatChannel(chat) && !isDefaultChatUri(chat)) {
+			return undefined;
+		}
+		const needsRename = this._titleController.needsRename(sessionChannel);
+		if (!needsRename) {
+			return undefined;
+		}
+		return RENAME_SESSION_NUDGE;
 	}
 
 

--- a/src/vs/platform/agentHost/node/localCommands/renameLocalCommand.ts
+++ b/src/vs/platform/agentHost/node/localCommands/renameLocalCommand.ts
@@ -7,7 +7,7 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { localize } from '../../../../nls.js';
 import { ActionType } from '../../common/state/sessionActions.js';
-import { isAhpChatChannel, isDefaultChatUri, parseRequiredSessionUriFromChatUri, ResponsePartKind, type URI as ProtocolURI } from '../../common/state/sessionState.js';
+import { AH_META_TITLE_SOURCE_DB_KEY, isAhpChatChannel, isDefaultChatUri, parseRequiredSessionUriFromChatUri, ResponsePartKind, withSessionTitleSource, type URI as ProtocolURI } from '../../common/state/sessionState.js';
 import { parseRenameCommand } from '../agentHostRenameCommand.js';
 import { ILocalChatCommand, ILocalChatCommandContext, ILocalChatCommandRequest, LocalChatCommandRegistry } from './localChatCommand.js';
 
@@ -49,9 +49,14 @@ export class RenameLocalCommand extends Disposable implements ILocalChatCommand 
 		} else {
 			this._context.dispatch(sessionChannel, { type: ActionType.SessionTitleChanged, title });
 			// Server-dispatched actions bypass `handleAction`, so persist the
-			// new title here directly (the client-dispatched rename path relies
-			// on the `SessionTitleChanged` case in `handleAction` instead).
+			// new title AND mark it a user rename here directly (the
+			// client-dispatched rename path relies on the `SessionTitleChanged`
+			// case in `handleAction` instead). Marking it `user` stops the
+			// agent-rename nudge and guards it from being overwritten.
 			this._context.persistSessionFlag(sessionChannel, 'customTitle', title);
+			const currentMeta = this._context.getState(sessionChannel)?._meta;
+			this._context.dispatch(sessionChannel, { type: ActionType.SessionMetaChanged, _meta: withSessionTitleSource(currentMeta, 'user') });
+			this._context.persistSessionFlag(sessionChannel, AH_META_TITLE_SOURCE_DB_KEY, 'user');
 		}
 		// Acknowledge the rename with a brief response so the turn has visible
 		// content in the transcript.

--- a/src/vs/platform/agentHost/node/shared/agentRenameSessionServerTool.ts
+++ b/src/vs/platform/agentHost/node/shared/agentRenameSessionServerTool.ts
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { isAhpChatChannel, isDefaultChatUri, parseChatUri, type ToolDefinition, type URI } from '../../common/state/sessionState.js';
+import type { IServerToolDisplay, IServerToolDisplayResult, IServerToolGroup } from './agentServerToolHost.js';
+
+/** Name of the agent-facing session-rename server tool. */
+export const RENAME_SESSION_TOOL_NAME = 'rename_session';
+
+/**
+ * Outcome of a {@link IRenameSessionHandler} call: `'renamed'` (the session
+ * title was updated, `title` carries the cleaned value), `'skippedUserNamed'`
+ * (the user has already named the session, so the request was ignored), or
+ * `'invalid'` (the requested title was empty or could not be cleaned).
+ */
+export interface IRenameSessionToolResult {
+	readonly status: 'renamed' | 'skippedUserNamed' | 'invalid';
+	readonly title?: string;
+}
+
+/**
+ * Applies an agent-requested session rename. Wired at host construction to the
+ * title controller so the tool stays free of state-manager and persistence
+ * concerns.
+ */
+export type IRenameSessionHandler = (sessionUri: URI, rawTitle: string) => IRenameSessionToolResult;
+
+const renameSessionInputSchema: ToolDefinition['inputSchema'] = {
+	type: 'object',
+	properties: {
+		title: {
+			type: 'string',
+			description: 'Short, human-friendly session name in sentence case (1-4 words, e.g. "Adding JWT auth"). Never use kebab-case, snake_case, or raw git branch names.',
+			maxLength: 40,
+		},
+	},
+	required: ['title'],
+};
+
+/**
+ * Protocol {@link ToolDefinition}s for the rename-session server tool, advertised
+ * on {@link SessionState.serverTools} so clients know the tool is owned and
+ * executed by the agent host. The description is model-facing (not localized).
+ */
+export const renameSessionServerToolDefinitions: ToolDefinition[] = [
+	{
+		name: RENAME_SESSION_TOOL_NAME,
+		title: 'Rename Session',
+		description: 'Rename the current session so it is easy to find later. Use a short, human-friendly session name in sentence case (1-4 words, e.g. "Adding JWT auth"). Never use kebab-case, snake_case, or raw git branch names.',
+		inputSchema: renameSessionInputSchema,
+		annotations: { readOnlyHint: false },
+	},
+];
+
+interface IRenameSessionArgs {
+	readonly title?: unknown;
+}
+
+function readTitleArg(rawArgs: unknown): string | undefined {
+	const args = (rawArgs ?? {}) as IRenameSessionArgs;
+	return typeof args.title === 'string' ? args.title : undefined;
+}
+
+/**
+ * Display strings for the rename-session tool. Uses the requested title for the
+ * past-tense message when available. Localized (shown to the user in the UI).
+ */
+export function getRenameSessionToolDisplay(toolName: string, args: unknown, _result?: IServerToolDisplayResult): IServerToolDisplay | undefined {
+	if (toolName !== RENAME_SESSION_TOOL_NAME) {
+		return undefined;
+	}
+	const title = readTitleArg(args);
+	return {
+		displayName: localize('toolName.renameSession', "Rename Session"),
+		invocationMessage: localize('toolInvoke.renameSession', "Renaming session"),
+		pastTenseMessage: title
+			? localize('toolComplete.renameSessionTo', "Renamed session to \"{0}\"", title)
+			: localize('toolComplete.renameSession', "Renamed session"),
+	};
+}
+
+/**
+ * Creates the rename-session server-tool group, bound to {@link handler} at host
+ * construction (see `node/agentService.ts`). The tool renames the **session**
+ * only: a peer (non-default) chat URI is rejected; a default-chat URI is
+ * normalized to its owning session. All state and persistence live behind the
+ * handler.
+ */
+export function createRenameSessionServerToolGroup(handler: IRenameSessionHandler): IServerToolGroup {
+	return {
+		definitions: renameSessionServerToolDefinitions,
+		getDisplay(toolName, args, result): IServerToolDisplay | undefined {
+			return getRenameSessionToolDisplay(toolName, args, result);
+		},
+		execute(_stateManager, chatUri, _toolName, rawArgs): string {
+			if (isAhpChatChannel(chatUri) && !isDefaultChatUri(chatUri)) {
+				return 'Renaming additional chats is not supported; only the session can be renamed.';
+			}
+			const rawTitle = readTitleArg(rawArgs);
+			if (rawTitle === undefined || rawTitle.length === 0) {
+				throw new Error(`Invalid ${RENAME_SESSION_TOOL_NAME} input: title must be a non-empty string.`);
+			}
+			const sessionUri = parseChatUri(chatUri)?.session ?? chatUri;
+			const outcome = handler(sessionUri, rawTitle);
+			if (outcome.status === 'renamed') {
+				return `Renamed session to "${outcome.title}".`;
+			}
+			if (outcome.status === 'skippedUserNamed') {
+				return 'Skipped: the session was already renamed by the user.';
+			}
+			return 'Could not rename the session: the provided title was empty after normalization.';
+		},
+	};
+}

--- a/src/vs/platform/agentHost/node/shared/persistSessionMetadata.ts
+++ b/src/vs/platform/agentHost/node/shared/persistSessionMetadata.ts
@@ -17,7 +17,13 @@ import type { ISessionDataService } from '../../common/sessionDataService.js';
  * re-implement the open/write/dispose dance.
  */
 export function persistSessionMetadata(sessionDataService: ISessionDataService, logService: ILogService, session: string, key: string, value: string): void {
-	const ref = sessionDataService.openDatabase(URI.parse(session));
+	let ref;
+	try {
+		ref = sessionDataService.openDatabase(URI.parse(session));
+	} catch (err) {
+		logService.warn(`[AgentHost] Failed to open database to persist session metadata '${key}'`, err);
+		return;
+	}
 	ref.object.setMetadata(key, value).catch(err => {
 		logService.warn(`[AgentHost] Failed to persist session metadata '${key}'`, err);
 	}).finally(() => {

--- a/src/vs/platform/agentHost/node/shared/serverToolGroups.ts
+++ b/src/vs/platform/agentHost/node/shared/serverToolGroups.ts
@@ -3,21 +3,48 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { createRenameSessionServerToolGroup, getRenameSessionToolDisplay, renameSessionServerToolDefinitions, type IRenameSessionHandler } from './agentRenameSessionServerTool.js';
 import { feedbackServerToolGroup } from './agentFeedbackServerTools.js';
 import type { IServerToolDisplay, IServerToolDisplayResult, IServerToolGroup } from './agentServerToolHost.js';
 
 /**
- * The server-tool groups contributed to every agent host session, in priority
- * order. This is the single source of truth wired into the
- * {@link AgentServerToolHost} at startup (see `agentService.ts`) and consulted
- * by each provider's display layer via {@link getServerToolDisplay}.
+ * Host-side implementations that the contributed server-tool groups delegate to.
+ * Bound once at startup (see `agentService.ts`) so the groups themselves stay
+ * free of state-manager and persistence concerns.
+ */
+export interface IServerToolHandlers {
+	/** Applies an agent-requested session rename (the `rename_session` tool). */
+	readonly renameSession: IRenameSessionHandler;
+}
+
+/**
+ * Builds the server-tool groups contributed to every agent host session, in
+ * priority order, binding each group's host-side handlers from {@link handlers}.
+ * This is the single source of truth wired into the {@link AgentServerToolHost}
+ * at startup (see `agentService.ts`) and consulted by each provider's display
+ * layer via {@link getServerToolDisplay}.
  *
  * Adding a group here makes its tools available to all providers (Copilot,
- * Claude, Codex, …) and — if the group implements
- * {@link IServerToolGroup.getDisplay} — gives them nice display everywhere for
- * free.
+ * Claude, Codex, …). Contribute a matching entry to {@link serverToolDisplays}
+ * so history-replay (which has no host instance) can render it too.
  */
-export const serverToolGroups: readonly IServerToolGroup[] = [feedbackServerToolGroup];
+export function createServerToolGroups(handlers: IServerToolHandlers): readonly IServerToolGroup[] {
+	return [
+		feedbackServerToolGroup,
+		createRenameSessionServerToolGroup(handlers.renameSession),
+	];
+}
+
+/**
+ * Handler-free display descriptors for every contributed server tool, mirroring
+ * {@link createServerToolGroups}. Kept separate so {@link getServerToolDisplay}
+ * can render tools without the constructed {@link AgentServerToolHost} — the
+ * providers' history-replay paths build display from pure functions only.
+ */
+const serverToolDisplays: readonly Pick<IServerToolGroup, 'definitions' | 'getDisplay'>[] = [
+	feedbackServerToolGroup,
+	{ definitions: renameSessionServerToolDefinitions, getDisplay: getRenameSessionToolDisplay },
+];
 
 /**
  * Whether {@link toolName} (a tool name as seen on a tool call) refers to the
@@ -35,7 +62,7 @@ function matchesServerToolName(toolName: string, bareName: string): boolean {
  * owns {@link toolName} or the owning group has no bespoke display, so each
  * provider's display layer can fall back to its generic behavior.
  *
- * Pure over {@link serverToolGroups} (it does not need the constructed
+ * Pure over {@link serverToolDisplays} (it does not need the constructed
  * {@link AgentServerToolHost}) so the providers' history-replay paths — which
  * build display from pure functions without a host instance — can call it too.
  *
@@ -44,7 +71,7 @@ function matchesServerToolName(toolName: string, bareName: string): boolean {
  * @param result The tool result, once it has completed; absent while running.
  */
 export function getServerToolDisplay(toolName: string, args: unknown, result?: IServerToolDisplayResult): IServerToolDisplay | undefined {
-	for (const group of serverToolGroups) {
+	for (const group of serverToolDisplays) {
 		if (!group.getDisplay) {
 			continue;
 		}

--- a/src/vs/platform/agentHost/test/node/agentHostRenameCommand.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostRenameCommand.test.ts
@@ -5,10 +5,19 @@
 
 import assert from 'assert';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { NullLogService } from '../../../log/common/log.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { CompletionItemKind } from '../../common/state/protocol/commands.js';
 import { MessageAttachmentKind } from '../../common/state/protocol/state.js';
+import { ActionType, type StateAction } from '../../common/state/sessionActions.js';
+import { AH_META_TITLE_SOURCE_DB_KEY, buildChatUri, buildDefaultChatUri, SessionStatus, type URI as ProtocolURI } from '../../common/state/sessionState.js';
 import { AgentHostRenameCompletionProvider, parseRenameCommand } from '../../node/agentHostRenameCommand.js';
+import { AgentSession } from '../../common/agentService.js';
+import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
+import { RenameLocalCommand } from '../../node/localCommands/renameLocalCommand.js';
+import type { ILocalChatCommandContext } from '../../node/localCommands/localChatCommand.js';
+import { TestAgentHostTerminalManager } from './testAgentHostTerminalManager.js';
 
 suite('agentHostRenameCommand', () => {
 
@@ -84,6 +93,77 @@ suite('agentHostRenameCommand', () => {
 				label: '/rename',
 				_meta: { command: 'rename', description: 'Rename this chat' },
 			}]);
+		});
+	});
+
+	suite('RenameLocalCommand execution', () => {
+
+		const sessionUri = AgentSession.uri('mock', 's1').toString();
+
+		function setup() {
+			const store = new DisposableStore();
+			const stateManager = store.add(new AgentHostStateManager(new NullLogService()));
+			const dispatched: { channel: ProtocolURI; action: StateAction }[] = [];
+			const persisted: { session: ProtocolURI; key: string; value: string }[] = [];
+			const chatTitleUpdates: { session: ProtocolURI; chat: ProtocolURI; title: string }[] = [];
+			const context: ILocalChatCommandContext = {
+				logService: new NullLogService(),
+				terminalManager: store.add(new TestAgentHostTerminalManager()),
+				dispatch: (channel, action) => dispatched.push({ channel, action }),
+				getState: channel => stateManager.getSessionState(channel),
+				updateChatTitle: (session, chat, title) => chatTitleUpdates.push({ session, chat, title }),
+				persistSessionFlag: (session, key, value) => persisted.push({ session, key, value }),
+			};
+			const command = store.add(new RenameLocalCommand(context));
+			return { store, stateManager, dispatched, persisted, chatTitleUpdates, command };
+		}
+
+		test('a session-level /rename marks the title user-set (merging existing meta) and persists it', async () => {
+			const { store, stateManager, dispatched, persisted, command } = setup();
+			stateManager.createSession({
+				resource: sessionUri, provider: 'mock', title: '', status: SessionStatus.Idle,
+				createdAt: new Date().toISOString(), modifiedAt: new Date().toISOString(),
+				_meta: { existing: 'keep' },
+			});
+
+			const work = command.tryHandle({ turnChannel: buildDefaultChatUri(sessionUri), turnId: 't1', text: '/rename Login validation fix' });
+			assert.ok(work);
+			await work();
+
+			const titleActions = dispatched
+				.filter(d => d.action.type === ActionType.SessionTitleChanged || d.action.type === ActionType.SessionMetaChanged)
+				.map(d => d.action);
+			assert.deepStrictEqual({ titleActions, persisted }, {
+				titleActions: [
+					{ type: ActionType.SessionTitleChanged, title: 'Login validation fix' },
+					{ type: ActionType.SessionMetaChanged, _meta: { existing: 'keep', titleSource: 'user' } },
+				],
+				persisted: [
+					{ session: sessionUri, key: 'customTitle', value: 'Login validation fix' },
+					{ session: sessionUri, key: AH_META_TITLE_SOURCE_DB_KEY, value: 'user' },
+				],
+			});
+			store.dispose();
+		});
+
+		test('a peer-chat /rename renames only that chat and leaves the session provenance untouched', async () => {
+			const { store, dispatched, persisted, chatTitleUpdates, command } = setup();
+			const peerChat = buildChatUri(sessionUri, 'peer-1');
+
+			const work = command.tryHandle({ turnChannel: peerChat, turnId: 't1', text: '/rename Side quest' });
+			assert.ok(work);
+			await work();
+
+			assert.deepStrictEqual({
+				markedUser: dispatched.some(d => d.action.type === ActionType.SessionMetaChanged),
+				chatTitleUpdates,
+				persisted,
+			}, {
+				markedUser: false,
+				chatTitleUpdates: [{ session: sessionUri, chat: peerChat, title: 'Side quest' }],
+				persisted: [{ session: sessionUri, key: `customChatTitle:${peerChat}`, value: 'Side quest' }],
+			});
+			store.dispose();
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostSessionTitleController.test.ts
@@ -13,7 +13,7 @@ import { NullLogService } from '../../../log/common/log.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
 import { AgentHostSessionTitleController } from '../../node/agentHostSessionTitleController.js';
 import { ActionType } from '../../common/state/sessionActions.js';
-import { MessageKind, ResponsePartKind, SessionStatus, ToolCallConfirmationReason, ToolCallStatus, TurnState, type ResponsePart, type SessionSummary, type ToolCallCompletedState, type Turn } from '../../common/state/sessionState.js';
+import { AH_META_TITLE_SOURCE_DB_KEY, MessageKind, ResponsePartKind, SessionStatus, TurnState, readSessionTitleSource, readSessionWorkspaceless, withSessionWorkspaceless, type ResponsePart, type SessionSummary, type Turn } from '../../common/state/sessionState.js';
 import { type ICopilotApiService, type ICopilotApiServiceRequestOptions, type ICopilotUtilityChatCompletionRequest } from '../../node/shared/copilotApiService.js';
 import { createSessionDataService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
 
@@ -100,75 +100,37 @@ suite('AgentHostSessionTitleController', () => {
 		return { controller, stateManager, session, db, titleActions, copilotApiService };
 	}
 
-	test('seedTitleFromFirstMessage applies fallback and persists generated title', async () => {
+	function titleSourceOf(stateManager: AgentHostStateManager, session: URI) {
+		return readSessionTitleSource(stateManager.getSessionState(session.toString())?._meta);
+	}
+
+	test('seedTitleFromFirstMessage applies + persists the first-message fallback with auto provenance (no utility call)', async () => {
 		const copilotApiService = new TestCopilotApiService();
-		copilotApiService.response = '"Generated title."';
-		const { controller, session, db, titleActions } = setup(copilotApiService);
+		const { controller, stateManager, session, db, titleActions } = setup(copilotApiService);
 
 		controller.seedTitleFromFirstMessage(session.toString(), '  Please   explain title generation  ');
-		await waitForCondition(async () => await db.getMetadata('customTitle') === 'Generated title', 'generated title should be persisted');
+		await waitForCondition(async () => await db.getMetadata(AH_META_TITLE_SOURCE_DB_KEY) === 'auto', 'title source should be persisted');
 
 		assert.deepStrictEqual({
 			titles: titleActions,
-			token: copilotApiService.utilityCalls[0]?.token,
-			promptIncludesUserText: copilotApiService.utilityCalls[0]?.request.messages.some(message => message.content.includes('Please   explain title generation')),
-			persistedTitle: await db.getMetadata('customTitle'),
-		}, {
-			titles: ['Please explain title generation', 'Generated title'],
-			token: 'gh-token',
-			promptIncludesUserText: true,
-			persistedTitle: 'Generated title',
-		});
-	});
-
-	test('seedTitleFromFirstMessage does not clobber a changed title', async () => {
-		const copilotApiService = new TestCopilotApiService();
-		let resolveTitle!: (title: string) => void;
-		copilotApiService.responsePromise = new Promise(resolve => { resolveTitle = resolve; });
-		const { controller, stateManager, session, db } = setup(copilotApiService);
-
-		controller.seedTitleFromFirstMessage(session.toString(), 'Create title tests');
-		await waitForCondition(() => copilotApiService.utilityCalls.length === 1, 'title generation should start');
-		stateManager.dispatchServerAction(session.toString(), {
-			type: ActionType.SessionTitleChanged,
-			title: 'Manual title',
-		});
-		resolveTitle('Generated title');
-		await Promise.resolve();
-
-		assert.deepStrictEqual({
 			title: stateManager.getSessionState(session.toString())?.title,
+			utilityCalls: copilotApiService.utilityCalls.length,
 			persistedTitle: await db.getMetadata('customTitle'),
+			persistedSource: await db.getMetadata(AH_META_TITLE_SOURCE_DB_KEY),
+			titleSource: titleSourceOf(stateManager, session),
+			needsRename: controller.needsRename(session.toString()),
 		}, {
-			title: 'Manual title',
-			persistedTitle: undefined,
+			titles: ['Please explain title generation'],
+			title: 'Please explain title generation',
+			utilityCalls: 0,
+			persistedTitle: 'Please explain title generation',
+			persistedSource: 'auto',
+			titleSource: 'auto',
+			needsRename: true,
 		});
 	});
 
-	test('cancelTitleGeneration cancels delayed generated title application', async () => {
-		const copilotApiService = new TestCopilotApiService();
-		let resolveTitle!: (title: string) => void;
-		copilotApiService.responsePromise = new Promise(resolve => { resolveTitle = resolve; });
-		const { controller, stateManager, session, db } = setup(copilotApiService);
-
-		controller.seedTitleFromFirstMessage(session.toString(), 'Investigate title cancellation');
-		await waitForCondition(() => copilotApiService.utilityCalls.length === 1, 'title generation should start');
-		controller.cancelTitleGeneration(session.toString());
-		resolveTitle('Generated title');
-		await Promise.resolve();
-
-		assert.deepStrictEqual({
-			aborted: copilotApiService.utilityCalls[0].options?.signal?.aborted,
-			title: stateManager.getSessionState(session.toString())?.title,
-			persistedTitle: await db.getMetadata('customTitle'),
-		}, {
-			aborted: true,
-			title: 'Investigate title cancellation',
-			persistedTitle: undefined,
-		});
-	});
-
-	test('seedTitleFromFirstMessage skips sessions with an existing title', async () => {
+	test('seedTitleFromFirstMessage skips sessions with an existing title (e.g. forks)', async () => {
 		const copilotApiService = new TestCopilotApiService();
 		const { controller, stateManager, session, db, titleActions } = setup(copilotApiService, 'Forked: Source title');
 
@@ -180,151 +142,121 @@ suite('AgentHostSessionTitleController', () => {
 			title: stateManager.getSessionState(session.toString())?.title,
 			titles: titleActions,
 			persistedTitle: await db.getMetadata('customTitle'),
+			persistedSource: await db.getMetadata(AH_META_TITLE_SOURCE_DB_KEY),
 		}, {
 			calls: 0,
 			title: 'Forked: Source title',
 			titles: [],
 			persistedTitle: undefined,
+			persistedSource: undefined,
 		});
+	});
+
+	test('applyAgentRename renames the session with agent provenance and persists both', async () => {
+		const { controller, stateManager, session, db, titleActions } = setup();
+		controller.seedTitleFromFirstMessage(session.toString(), 'Fix the login bug');
+		await waitForCondition(async () => await db.getMetadata(AH_META_TITLE_SOURCE_DB_KEY) === 'auto', 'seed should persist');
+
+		const result = controller.applyAgentRename(session.toString(), '  "Login validation fix"  ');
+		await waitForCondition(async () => await db.getMetadata(AH_META_TITLE_SOURCE_DB_KEY) === 'agent', 'rename should persist agent provenance');
+
+		assert.deepStrictEqual({
+			result,
+			title: stateManager.getSessionState(session.toString())?.title,
+			lastDispatchedTitle: titleActions[titleActions.length - 1],
+			persistedTitle: await db.getMetadata('customTitle'),
+			persistedSource: await db.getMetadata(AH_META_TITLE_SOURCE_DB_KEY),
+			titleSource: titleSourceOf(stateManager, session),
+			needsRename: controller.needsRename(session.toString()),
+		}, {
+			result: { status: 'renamed', title: 'Login validation fix' },
+			title: 'Login validation fix',
+			lastDispatchedTitle: 'Login validation fix',
+			persistedTitle: 'Login validation fix',
+			persistedSource: 'agent',
+			titleSource: 'agent',
+			needsRename: false,
+		});
+	});
+
+	test('applyAgentRename is skipped when the user already named the session', async () => {
+		const { controller, stateManager, session } = setup();
+		controller.seedTitleFromFirstMessage(session.toString(), 'Fix the login bug');
+		controller.markUserSessionTitle(session.toString());
+
+		const result = controller.applyAgentRename(session.toString(), 'Agent chosen title');
+
+		assert.deepStrictEqual({
+			result,
+			title: stateManager.getSessionState(session.toString())?.title,
+			titleSource: titleSourceOf(stateManager, session),
+			needsRename: controller.needsRename(session.toString()),
+		}, {
+			result: { status: 'skippedUserNamed' },
+			title: 'Fix the login bug',
+			titleSource: 'user',
+			needsRename: false,
+		});
+	});
+
+	test('applyAgentRename rejects an empty/punctuation-only title', () => {
+		const { controller, stateManager, session } = setup();
+		controller.seedTitleFromFirstMessage(session.toString(), 'Fix the login bug');
+
+		const result = controller.applyAgentRename(session.toString(), '   ...   ');
+
+		assert.deepStrictEqual({
+			result,
+			title: stateManager.getSessionState(session.toString())?.title,
+			titleSource: titleSourceOf(stateManager, session),
+		}, {
+			result: { status: 'invalid' },
+			title: 'Fix the login bug',
+			titleSource: 'auto',
+		});
+	});
+
+	test('markUserSessionTitle sets user provenance and preserves other _meta', async () => {
+		const { controller, stateManager, session, db } = setup();
+		// Seed an unrelated `_meta` flag to prove the title-source merge preserves it.
+		stateManager.setSessionMeta(session.toString(), withSessionWorkspaceless(undefined, true));
+		controller.seedTitleFromFirstMessage(session.toString(), 'Fix the login bug');
+
+		controller.markUserSessionTitle(session.toString());
+		await waitForCondition(async () => await db.getMetadata(AH_META_TITLE_SOURCE_DB_KEY) === 'user', 'user provenance should persist');
+
+		const meta = stateManager.getSessionState(session.toString())?._meta;
+		assert.deepStrictEqual({
+			titleSource: readSessionTitleSource(meta),
+			workspaceless: readSessionWorkspaceless(meta),
+			persistedSource: await db.getMetadata(AH_META_TITLE_SOURCE_DB_KEY),
+			needsRename: controller.needsRename(session.toString()),
+		}, {
+			titleSource: 'user',
+			workspaceless: true,
+			persistedSource: 'user',
+			needsRename: false,
+		});
+	});
+
+	test('needsRename tracks the title provenance', () => {
+		const { controller, session } = setup();
+
+		const beforeSeed = controller.needsRename(session.toString());
+		controller.seedTitleFromFirstMessage(session.toString(), 'Fix the login bug');
+		const afterSeed = controller.needsRename(session.toString());
+		controller.applyAgentRename(session.toString(), 'Login fix');
+		const afterAgent = controller.needsRename(session.toString());
+
+		assert.deepStrictEqual(
+			{ beforeSeed, afterSeed, afterAgent },
+			{ beforeSeed: true, afterSeed: true, afterAgent: false },
+		);
 	});
 
 	function textPart(content: string): ResponsePart {
 		return { kind: ResponsePartKind.Markdown, id: 'm1', content };
 	}
-
-	function reasoningPart(content: string): ResponsePart {
-		return { kind: ResponsePartKind.Reasoning, id: 'r1', content };
-	}
-
-	function toolCallPart(displayName: string, invocationMessage: string): ResponsePart {
-		const toolCall: ToolCallCompletedState = {
-			status: ToolCallStatus.Completed,
-			toolCallId: 'tc1',
-			toolName: 'tool',
-			displayName,
-			invocationMessage,
-			success: true,
-			pastTenseMessage: 'done',
-			confirmed: ToolCallConfirmationReason.NotNeeded,
-		};
-		return { kind: ResponsePartKind.ToolCall, toolCall };
-	}
-
-	function firstTurn(text: string, responseParts: ResponsePart[]): Turn {
-		return {
-			id: 'turn-1',
-			message: { text, origin: { kind: MessageKind.User } },
-			responseParts,
-			usage: undefined,
-			state: TurnState.Complete,
-		};
-	}
-
-	async function seedFirstTitle(controller: AgentHostSessionTitleController, copilotApiService: TestCopilotApiService, db: TestSessionDatabase, session: URI, userPrompt: string, title: string): Promise<void> {
-		copilotApiService.response = title;
-		controller.seedTitleFromFirstMessage(session.toString(), userPrompt);
-		await waitForCondition(async () => await db.getMetadata('customTitle') === title, 'first title should be persisted');
-	}
-
-	test('refineTitleFromFirstTurn regenerates the title from the first-turn context', async () => {
-		const copilotApiService = new TestCopilotApiService();
-		const { controller, stateManager, session, db } = setup(copilotApiService);
-		await seedFirstTitle(controller, copilotApiService, db, session, 'Add dark mode toggle', 'First title');
-
-		copilotApiService.response = 'Dark mode setting';
-		stateManager.seedDefaultChatTurns(session.toString(), [firstTurn('Add dark mode toggle', [textPart('Implemented the toggle in the settings editor.')])]);
-		controller.refineTitleFromFirstTurn(session.toString());
-		await waitForCondition(async () => await db.getMetadata('customTitle') === 'Dark mode setting', 'refined title should be persisted');
-
-		const lastCall = copilotApiService.utilityCalls[copilotApiService.utilityCalls.length - 1];
-		const userMessage = lastCall.request.messages.find(message => message.role === 'user')?.content ?? '';
-		assert.deepStrictEqual({
-			title: stateManager.getSessionState(session.toString())?.title,
-			persistedTitle: await db.getMetadata('customTitle'),
-			mentionsConversation: userMessage.includes('conversation'),
-			includesUserRequest: userMessage.includes('Add dark mode toggle'),
-			includesResponse: userMessage.includes('Implemented the toggle in the settings editor.'),
-		}, {
-			title: 'Dark mode setting',
-			persistedTitle: 'Dark mode setting',
-			mentionsConversation: true,
-			includesUserRequest: true,
-			includesResponse: true,
-		});
-	});
-
-	test('refineTitleFromFirstTurn does not clobber a title changed in the meantime', async () => {
-		const copilotApiService = new TestCopilotApiService();
-		const { controller, stateManager, session, db } = setup(copilotApiService);
-		await seedFirstTitle(controller, copilotApiService, db, session, 'Add dark mode toggle', 'First title');
-		const callsAfterSeed = copilotApiService.utilityCalls.length;
-
-		stateManager.dispatchServerAction(session.toString(), { type: ActionType.SessionTitleChanged, title: 'Manual title' });
-		stateManager.seedDefaultChatTurns(session.toString(), [firstTurn('Add dark mode toggle', [textPart('Implemented the toggle.')])]);
-		controller.refineTitleFromFirstTurn(session.toString());
-		await Promise.resolve();
-
-		assert.deepStrictEqual({
-			calls: copilotApiService.utilityCalls.length,
-			title: stateManager.getSessionState(session.toString())?.title,
-		}, {
-			calls: callsAfterSeed,
-			title: 'Manual title',
-		});
-	});
-
-	test('refineTitleFromFirstTurn ignores tool calls and reasoning, keeping only text parts', async () => {
-		const copilotApiService = new TestCopilotApiService();
-		const { controller, stateManager, session, db } = setup(copilotApiService);
-		await seedFirstTitle(controller, copilotApiService, db, session, 'Add dark mode toggle', 'First title');
-
-		copilotApiService.response = 'Refined title';
-		stateManager.seedDefaultChatTurns(session.toString(), [firstTurn('Add dark mode toggle', [
-			reasoningPart('Thinking about THINKING_MARKER the approach'),
-			toolCallPart('SearchTool', 'searched the workspace TOOL_MARKER'),
-			textPart('Added the toggle TEXT_MARKER to settings.'),
-		])]);
-		controller.refineTitleFromFirstTurn(session.toString());
-		await waitForCondition(() => copilotApiService.utilityCalls.length >= 2, 'refine should issue a utility call');
-
-		const lastCall = copilotApiService.utilityCalls[copilotApiService.utilityCalls.length - 1];
-		const userMessage = lastCall.request.messages.find(message => message.role === 'user')?.content ?? '';
-		assert.deepStrictEqual({
-			includesText: userMessage.includes('TEXT_MARKER'),
-			excludesReasoning: !userMessage.includes('THINKING_MARKER'),
-			excludesToolCall: !userMessage.includes('TOOL_MARKER') && !userMessage.includes('SearchTool'),
-		}, {
-			includesText: true,
-			excludesReasoning: true,
-			excludesToolCall: true,
-		});
-	});
-
-	test('refineTitleFromFirstTurn truncates the middle of an oversized text response', async () => {
-		const copilotApiService = new TestCopilotApiService();
-		const { controller, stateManager, session, db } = setup(copilotApiService);
-		await seedFirstTitle(controller, copilotApiService, db, session, 'Add dark mode toggle', 'First title');
-
-		copilotApiService.response = 'Refined title';
-		const hugeResponse = 'A'.repeat(15000) + ' MIDDLE_MARKER ' + 'B'.repeat(15000);
-		stateManager.seedDefaultChatTurns(session.toString(), [firstTurn('Add dark mode toggle', [textPart(hugeResponse)])]);
-		controller.refineTitleFromFirstTurn(session.toString());
-		await waitForCondition(() => copilotApiService.utilityCalls.length >= 2, 'refine should issue a utility call');
-
-		const lastCall = copilotApiService.utilityCalls[copilotApiService.utilityCalls.length - 1];
-		const userMessage = lastCall.request.messages.find(message => message.role === 'user')?.content ?? '';
-		assert.deepStrictEqual({
-			withinBudget: userMessage.length <= 20200,
-			middleTruncated: userMessage.includes('...') && !userMessage.includes('MIDDLE_MARKER'),
-			includesUserRequest: userMessage.includes('Add dark mode toggle'),
-			keepsHeadAndTail: userMessage.includes('AAAA') && userMessage.includes('BBBB'),
-		}, {
-			withinBudget: true,
-			middleTruncated: true,
-			includesUserRequest: true,
-			keepsHeadAndTail: true,
-		});
-	});
 
 	function turn(id: string, text: string, responseParts: ResponsePart[]): Turn {
 		return {
@@ -353,6 +285,8 @@ suite('AgentHostSessionTitleController', () => {
 		assert.deepStrictEqual({
 			titles: titleActions,
 			persistedTitle: await db.getMetadata('customTitle'),
+			titleSource: titleSourceOf(stateManager, session),
+			needsRename: controller.needsRename(session.toString()),
 			mentionsConversation: userMessage.includes('conversation'),
 			framesAsBranch: userMessage.includes('branched from an earlier chat titled "Source title"'),
 			includesFirstTurn: userMessage.includes('Add dark mode toggle') && userMessage.includes('Implemented the toggle in settings.'),
@@ -360,6 +294,8 @@ suite('AgentHostSessionTitleController', () => {
 		}, {
 			titles: ['Compaction strategy'],
 			persistedTitle: 'Compaction strategy',
+			titleSource: 'auto',
+			needsRename: true,
 			mentionsConversation: true,
 			framesAsBranch: true,
 			includesFirstTurn: true,
@@ -385,6 +321,34 @@ suite('AgentHostSessionTitleController', () => {
 			persistedTitle: await db.getMetadata('customTitle'),
 		}, {
 			title: 'Manual title',
+			persistedTitle: undefined,
+		});
+	});
+
+	test('cancelTitleGeneration aborts an in-flight forked-title generation', async () => {
+		const copilotApiService = new TestCopilotApiService();
+		let resolveTitle!: (title: string) => void;
+		copilotApiService.responsePromise = new Promise(resolve => { resolveTitle = resolve; });
+		const { controller, stateManager, session, db } = setup(copilotApiService, 'Forked: Source title');
+
+		stateManager.seedDefaultChatTurns(session.toString(), [turn('turn-1', 'Add dark mode toggle', [textPart('Done.')])]);
+		controller.generateForkedTitle(session.toString(), undefined, stateManager.getSessionState(session.toString())!.turns, 'Forked: Source title');
+		await waitForCondition(() => copilotApiService.utilityCalls.length === 1, 'forked title generation should start');
+
+		// Mirrors the dispose path (disposeSession → cancelSessionTitleGeneration
+		// → cancelTitleGeneration): the utility request is aborted and no title
+		// is applied or persisted.
+		controller.cancelTitleGeneration(session.toString());
+		resolveTitle('Generated title');
+		await Promise.resolve();
+
+		assert.deepStrictEqual({
+			aborted: copilotApiService.utilityCalls[0].options?.signal?.aborted,
+			title: stateManager.getSessionState(session.toString())?.title,
+			persistedTitle: await db.getMetadata('customTitle'),
+		}, {
+			aborted: true,
+			title: 'Forked: Source title',
 			persistedTitle: undefined,
 		});
 	});

--- a/src/vs/platform/agentHost/test/node/agentRenameSessionServerTool.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentRenameSessionServerTool.test.ts
@@ -1,0 +1,102 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
+import { buildChatUri, buildDefaultChatUri, type StringOrMarkdown } from '../../common/state/sessionState.js';
+import { createRenameSessionServerToolGroup, getRenameSessionToolDisplay, RENAME_SESSION_TOOL_NAME, type IRenameSessionToolResult } from '../../node/shared/agentRenameSessionServerTool.js';
+
+function text(value: StringOrMarkdown | undefined): string | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	return typeof value === 'string' ? value : value.markdown;
+}
+
+suite('agentRenameSessionServerTool', () => {
+	const disposables = new DisposableStore();
+
+	teardown(() => disposables.clear());
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const SESSION = 'agenthost-session://copilot/rename-tool-test';
+
+	function setup(result: IRenameSessionToolResult) {
+		// `execute` ignores the state manager (it delegates to the handler), but
+		// its type requires one, so pass a real (disposable) instance.
+		const stateManager = disposables.add(new AgentHostStateManager(new NullLogService()));
+		const calls: { sessionUri: string; rawTitle: string }[] = [];
+		const group = createRenameSessionServerToolGroup((sessionUri, rawTitle) => {
+			calls.push({ sessionUri, rawTitle });
+			return result;
+		});
+		const run = (uri: string, args: unknown) => group.execute(stateManager, uri, RENAME_SESSION_TOOL_NAME, args);
+		return { calls, run };
+	}
+
+	test('renames via a plain session URI and confirms the cleaned title', () => {
+		const { calls, run } = setup({ status: 'renamed', title: 'Adding JWT auth' });
+		const message = run(SESSION, { title: '  Adding JWT auth  ' });
+		assert.deepStrictEqual({ message, calls }, {
+			message: 'Renamed session to "Adding JWT auth".',
+			calls: [{ sessionUri: SESSION, rawTitle: '  Adding JWT auth  ' }],
+		});
+	});
+
+	test('normalizes a default-chat URI to its owning session before delegating', () => {
+		const { calls, run } = setup({ status: 'renamed', title: 'Adding JWT auth' });
+		const message = run(buildDefaultChatUri(SESSION), { title: 'Adding JWT auth' });
+		assert.deepStrictEqual({ message, sessionUri: calls[0]?.sessionUri }, {
+			message: 'Renamed session to "Adding JWT auth".',
+			sessionUri: SESSION,
+		});
+	});
+
+	test('rejects a peer (non-default) chat URI without calling the handler', () => {
+		const { calls, run } = setup({ status: 'renamed', title: 'x' });
+		const message = run(buildChatUri(SESSION, 'chat-2'), { title: 'Adding JWT auth' });
+		assert.deepStrictEqual({ message, calls }, {
+			message: 'Renaming additional chats is not supported; only the session can be renamed.',
+			calls: [],
+		});
+	});
+
+	test('throws for a missing or empty title before delegating', () => {
+		const { calls, run } = setup({ status: 'renamed', title: 'x' });
+		assert.throws(() => run(SESSION, {}), /non-empty string/);
+		assert.throws(() => run(SESSION, { title: '' }), /non-empty string/);
+		assert.deepStrictEqual(calls, []);
+	});
+
+	test('surfaces the handler outcome for skipped and invalid results', () => {
+		assert.deepStrictEqual({
+			skipped: setup({ status: 'skippedUserNamed' }).run(SESSION, { title: 'Adding JWT auth' }),
+			invalid: setup({ status: 'invalid' }).run(SESSION, { title: '   ' }),
+		}, {
+			skipped: 'Skipped: the session was already renamed by the user.',
+			invalid: 'Could not rename the session: the provided title was empty after normalization.',
+		});
+	});
+
+	test('getRenameSessionToolDisplay renders localized invocation and past-tense strings', () => {
+		const withTitle = getRenameSessionToolDisplay(RENAME_SESSION_TOOL_NAME, { title: 'Adding JWT auth' });
+		assert.deepStrictEqual({
+			displayName: withTitle?.displayName,
+			invocation: text(withTitle?.invocationMessage),
+			pastWithTitle: text(withTitle?.pastTenseMessage),
+			pastWithoutTitle: text(getRenameSessionToolDisplay(RENAME_SESSION_TOOL_NAME, {})?.pastTenseMessage),
+			otherTool: getRenameSessionToolDisplay('addComment', { title: 'x' }),
+		}, {
+			displayName: 'Rename Session',
+			invocation: 'Renaming session',
+			pastWithTitle: 'Renamed session to "Adding JWT auth"',
+			pastWithoutTitle: 'Renamed session',
+			otherTool: undefined,
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -26,7 +26,7 @@ import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, IRestoredSubagentSessi
 import { ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { ActionType, ActionEnvelope } from '../../common/state/sessionActions.js';
-import { ChangesetStatus, CustomizationType, MessageAttachmentKind, MessageKind, SessionActiveClient, ResponsePartKind, ROOT_STATE_URI, SessionLifecycle, SessionStatus, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildChatUri, buildDefaultChatUri, buildSubagentChatUri, buildSubagentSessionUri, customizationId, isSubagentSession, parseChatUri, parseSubagentSessionUri, ChatOriginKind, type ChangesetState, type MarkdownResponsePart, type ToolCallCompletedState, type ToolCallResponsePart, type Turn } from '../../common/state/sessionState.js';
+import { AH_META_TITLE_SOURCE_DB_KEY, ChangesetStatus, CustomizationType, MessageAttachmentKind, MessageKind, SessionActiveClient, ResponsePartKind, ROOT_STATE_URI, SessionLifecycle, SessionStatus, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildChatUri, buildDefaultChatUri, buildSubagentChatUri, buildSubagentSessionUri, customizationId, isSubagentSession, parseChatUri, parseSubagentSessionUri, readSessionTitleSource, ChatOriginKind, type ChangesetState, type MarkdownResponsePart, type ToolCallCompletedState, type ToolCallResponsePart, type Turn } from '../../common/state/sessionState.js';
 import { type MessageResourceAttachment } from '../../common/state/protocol/state.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { AgentService } from '../../node/agentService.js';
@@ -291,9 +291,8 @@ suite('AgentService (node dispatcher)', () => {
 			}
 		});
 
-		test('generates and persists an AI title after first-turn fallback title', async () => {
+		test('seeds the first-message fallback title with auto provenance and no utility call', async () => {
 			const copilotApiService = new TestCopilotApiService();
-			copilotApiService.response = '"Fix TypeScript compile errors."';
 			const { svc, session, db } = await setupTitleGeneration(copilotApiService);
 			const titleActions: string[] = [];
 			disposables.add(svc.onDidAction(e => {
@@ -308,114 +307,40 @@ suite('AgentService (node dispatcher)', () => {
 				'test-client', 1,
 			);
 
-			await waitForCondition(() => svc.stateManager.getSessionState(session.toString())?.title === 'Fix TypeScript compile errors', 'generated title should be applied');
-			await waitForCondition(async () => await db.getMetadata('customTitle') !== undefined, 'generated title should be persisted');
+			// Session titling is now agent-driven: the seed persists the
+			// first-message fallback as an `auto` placeholder and makes no
+			// utility-model call.
+			await waitForCondition(async () => await db.getMetadata(AH_META_TITLE_SOURCE_DB_KEY) === 'auto', 'auto provenance should be persisted');
 
 			assert.deepStrictEqual({
 				titles: titleActions,
-				token: copilotApiService.utilityCalls[0]?.token,
-				promptIncludesUserText: copilotApiService.utilityCalls[0]?.request.messages.some(message => message.content.includes('Please help me fix the TypeScript compile errors')),
-				persistedTitle: await db.getMetadata('customTitle'),
-			}, {
-				titles: ['Please help me fix the TypeScript compile errors', 'Fix TypeScript compile errors'],
-				token: 'gh-token',
-				promptIncludesUserText: true,
-				persistedTitle: 'Fix TypeScript compile errors',
-			});
-		});
-
-		test('leaves fallback title when AI title generation fails', async () => {
-			const copilotApiService = new TestCopilotApiService();
-			copilotApiService.error = new Error('title failed');
-			const { svc, session, db } = await setupTitleGeneration(copilotApiService);
-
-			svc.dispatchAction(
-				buildDefaultChatUri(session.toString()),
-				{ type: ActionType.ChatTurnStarted, turnId: 'turn-1', message: { text: 'Explain workspace search indexing', origin: { kind: MessageKind.User } } },
-				'test-client', 1,
-			);
-
-			await waitForCondition(() => copilotApiService.utilityCalls.length === 1, 'title generation should be attempted');
-			await Promise.resolve();
-
-			assert.deepStrictEqual({
 				title: svc.stateManager.getSessionState(session.toString())?.title,
+				titleSource: readSessionTitleSource(svc.stateManager.getSessionState(session.toString())?._meta),
+				utilityCalls: copilotApiService.utilityCalls.length,
 				persistedTitle: await db.getMetadata('customTitle'),
+				persistedSource: await db.getMetadata(AH_META_TITLE_SOURCE_DB_KEY),
 			}, {
-				title: 'Explain workspace search indexing',
-				persistedTitle: undefined,
-			});
-		});
-
-		test('does not overwrite a manual rename with delayed AI title', async () => {
-			const copilotApiService = new TestCopilotApiService();
-			let resolveTitle!: (title: string) => void;
-			copilotApiService.responsePromise = new Promise(resolve => { resolveTitle = resolve; });
-			const { svc, session, db } = await setupTitleGeneration(copilotApiService);
-
-			svc.dispatchAction(
-				buildDefaultChatUri(session.toString()),
-				{ type: ActionType.ChatTurnStarted, turnId: 'turn-1', message: { text: 'Create tests for terminal persistence', origin: { kind: MessageKind.User } } },
-				'test-client', 1,
-			);
-			await waitForCondition(() => copilotApiService.utilityCalls.length === 1, 'title generation should be in flight');
-
-			svc.dispatchAction(
-				session.toString(),
-				{ type: ActionType.SessionTitleChanged, title: 'Manual title' },
-				'test-client', 2,
-			);
-			resolveTitle('Terminal persistence tests');
-			await waitForCondition(async () => await db.getMetadata('customTitle') === 'Manual title', 'manual title should be persisted');
-
-			assert.deepStrictEqual({
-				title: svc.stateManager.getSessionState(session.toString())?.title,
-				persistedTitle: await db.getMetadata('customTitle'),
-			}, {
-				title: 'Manual title',
-				persistedTitle: 'Manual title',
-			});
-		});
-
-		test('aborts pending AI title generation when session is disposed', async () => {
-			const copilotApiService = new TestCopilotApiService();
-			let resolveTitle!: (title: string) => void;
-			copilotApiService.responsePromise = new Promise(resolve => { resolveTitle = resolve; });
-			const { svc, session, db } = await setupTitleGeneration(copilotApiService);
-
-			svc.dispatchAction(
-				buildDefaultChatUri(session.toString()),
-				{ type: ActionType.ChatTurnStarted, turnId: 'turn-1', message: { text: 'Investigate flaky terminal tests', origin: { kind: MessageKind.User } } },
-				'test-client', 1,
-			);
-			await waitForCondition(() => copilotApiService.utilityCalls.length === 1, 'title generation should be in flight');
-
-			await svc.disposeSession(session);
-			resolveTitle('Flaky terminal tests');
-			await Promise.resolve();
-
-			assert.deepStrictEqual({
-				aborted: copilotApiService.utilityCalls[0].options?.signal?.aborted,
-				state: svc.stateManager.getSessionState(session.toString()),
-				persistedTitle: await db.getMetadata('customTitle'),
-			}, {
-				aborted: true,
-				state: undefined,
-				persistedTitle: undefined,
+				titles: ['Please help me fix the TypeScript compile errors'],
+				title: 'Please help me fix the TypeScript compile errors',
+				titleSource: 'auto',
+				utilityCalls: 0,
+				persistedTitle: 'Please help me fix the TypeScript compile errors',
+				persistedSource: 'auto',
 			});
 		});
 
 		test('generates an AI title for forked sessions from the forked chat', async () => {
 			const copilotApiService = new TestCopilotApiService();
-			copilotApiService.response = 'Source generated title';
 			const { svc, session: sourceSession } = await setupTitleGeneration(copilotApiService);
 
+			// Seed the source session with one completed turn to fork from.
+			// Session titling is agent-driven, so the source keeps its
+			// first-message fallback title and makes no utility call.
 			svc.dispatchAction(
 				buildDefaultChatUri(sourceSession.toString()),
 				{ type: ActionType.ChatTurnStarted, turnId: 'source-turn', message: { text: 'Seed fork title', origin: { kind: MessageKind.User } } },
 				'test-client', 1,
 			);
-			await waitForCondition(() => svc.stateManager.getSessionState(sourceSession.toString())?.title === 'Source generated title', 'source generated title should be applied');
 			svc.dispatchAction(
 				buildDefaultChatUri(sourceSession.toString()),
 				{ type: ActionType.ChatTurnComplete, turnId: 'source-turn' },
@@ -423,8 +348,10 @@ suite('AgentService (node dispatcher)', () => {
 			);
 			await waitForCondition(() => (svc.stateManager.getSessionState(sourceSession.toString())?.turns.length ?? 0) === 1, 'source turn should be complete before forking');
 
-			// The fork inherits a `Forked: …` placeholder, then regenerates a
-			// content-derived title from the copied chat.
+			// The fork inherits a `Forked: …` placeholder stamped `auto`, then
+			// regenerates a content-derived title from the copied chat via the
+			// utility model (a fork may never send a message, so it keeps
+			// utility titling rather than the agent-rename nudge).
 			copilotApiService.response = 'Forked branch title';
 			const forkedSession = await svc.createSession({
 				provider: 'copilot',
@@ -440,11 +367,13 @@ suite('AgentService (node dispatcher)', () => {
 			const userMessage = forkedCall.request.messages.find(message => message.role === 'user')?.content ?? '';
 			assert.deepStrictEqual({
 				title: svc.stateManager.getSessionState(forkedSession.toString())?.title,
+				titleSource: readSessionTitleSource(svc.stateManager.getSessionState(forkedSession.toString())?._meta),
 				utilityCalls: copilotApiService.utilityCalls.length,
 				includesForkedChat: userMessage.includes('Seed fork title'),
 			}, {
 				title: 'Forked branch title',
-				utilityCalls: 2,
+				titleSource: 'auto',
+				utilityCalls: 1,
 				includesForkedChat: true,
 			});
 		});
@@ -1873,6 +1802,31 @@ suite('AgentService (node dispatcher)', () => {
 			await localService.restoreSession(sessionResource);
 
 			assert.deepStrictEqual(localService.stateManager.getSessionState(sessionResource.toString())?._meta, { workspaceless: true });
+		});
+
+		test('locks a legacy custom title with no provenance as user-set on restore', async () => {
+			// A session renamed before title provenance existed persists a
+			// `customTitle` but no title-source metadata. Its origin is
+			// unknowable, so restore treats it as user-set — the agent-rename
+			// nudge stays off and `rename_session` refuses to overwrite it.
+			const db = new TestSessionDatabase();
+			const localService = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(db), { _serviceBrand: undefined } as IProductService, createNoopGitService()));
+			localService.registerProvider(copilotAgent);
+			await copilotAgent.createSession();
+			const sessionResource = (await copilotAgent.listSessions())[0].session;
+			copilotAgent.sessionMessages = [];
+			await db.setMetadata('customTitle', 'My Legacy Title');
+
+			await localService.restoreSession(sessionResource);
+
+			const state = localService.stateManager.getSessionState(sessionResource.toString());
+			assert.deepStrictEqual({
+				title: state?.title,
+				titleSource: readSessionTitleSource(state?._meta),
+			}, {
+				title: 'My Legacy Title',
+				titleSource: 'user',
+			});
 		});
 
 		test('restores a session with message history', async () => {

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -24,7 +24,7 @@ import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import type { RootConfigChangedAction } from '../../common/state/protocol/actions.js';
 import { ChangesSummary, ChatOriginKind, CustomizationType, SessionInputRequestKind } from '../../common/state/protocol/state.js';
 import { ActionType, ActionEnvelope, type ChatAction, type SessionAction } from '../../common/state/sessionActions.js';
-import { buildSubagentChatUri, buildChatUri, buildDefaultChatUri, CustomizationLoadStatus, MessageAttachmentKind, MessageKind, PendingMessageKind, ResponsePartKind, SessionInputResponseKind, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, customizationId, type ClientPluginCustomization, type Customization, type PluginCustomization } from '../../common/state/sessionState.js';
+import { buildSubagentChatUri, buildChatUri, buildDefaultChatUri, CustomizationLoadStatus, MessageAttachmentKind, MessageKind, PendingMessageKind, ResponsePartKind, SessionInputResponseKind, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, customizationId, readSessionTitleSource, withSessionTitleSource, type ClientPluginCustomization, type Customization, type PluginCustomization } from '../../common/state/sessionState.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
 import { NullTelemetryService } from '../../../telemetry/common/telemetryUtils.js';
@@ -166,6 +166,9 @@ suite('AgentSideEffects', () => {
 			modifiedAt: new Date().toISOString(),
 			project: { uri: 'file:///test-project', displayName: 'Test Project' },
 			workingDirectory,
+			// Mark the title as already agent-set so the rename nudge does not
+			// fire in the generic send tests; nudge behaviour has dedicated tests.
+			_meta: withSessionTitleSource(undefined, 'agent'),
 		});
 		stateManager.setSessionChangesets(sessionUri.toString(), buildDefaultChangesetCatalog(sessionUri.toString()));
 		stateManager.dispatchServerAction(sessionUri.toString(), { type: ActionType.SessionReady, });
@@ -831,6 +834,92 @@ suite('AgentSideEffects', () => {
 			await new Promise(r => setTimeout(r, 10));
 
 			assert.deepStrictEqual(agent.abortSessionCalls, [URI.parse(sessionUri.toString())]);
+		});
+	});
+
+	// ---- session-rename nudge + title provenance ---------------------------
+
+	suite('session rename nudge + provenance', () => {
+
+		function setupAutoTitledSession(): void {
+			stateManager.createSession({
+				resource: sessionUri.toString(),
+				provider: 'mock',
+				title: 'First message fallback',
+				status: SessionStatus.Idle,
+				createdAt: new Date().toISOString(),
+				modifiedAt: new Date().toISOString(),
+				project: { uri: 'file:///test-project', displayName: 'Test Project' },
+				_meta: withSessionTitleSource(undefined, 'auto'),
+			});
+			stateManager.dispatchServerAction(sessionUri.toString(), { type: ActionType.SessionReady, });
+		}
+
+		function titleSourceOf(): string | undefined {
+			return readSessionTitleSource(stateManager.getSessionState(sessionUri.toString())?._meta);
+		}
+
+		test('appends the rename nudge to the SDK prompt while the title is auto (default chat)', async () => {
+			setupAutoTitledSession();
+			sideEffects.handleAction(defaultChatUri, {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				message: { text: 'implement feature X', origin: { kind: MessageKind.User } },
+			});
+			await waitForSendMessageCalls(1);
+
+			const prompt = agent.sendMessageCalls[0].prompt;
+			assert.ok(prompt.startsWith('implement feature X'), 'keeps the original user message');
+			assert.ok(prompt.includes('rename_session'), 'appends the rename nudge referencing the tool');
+		});
+
+		test('does not nudge a peer (non-default) chat', async () => {
+			setupAutoTitledSession();
+			const peerChat = buildChatUri(sessionUri.toString(), 'peer-1');
+			sideEffects.handleAction(peerChat, {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				message: { text: 'peer message', origin: { kind: MessageKind.User } },
+			});
+			await waitForSendMessageCalls(1);
+
+			assert.strictEqual(agent.sendMessageCalls[0].prompt, 'peer message');
+		});
+
+		test('stops nudging once the agent has renamed the session', async () => {
+			setupAutoTitledSession();
+			const outcome = sideEffects.renameSessionFromAgent(sessionUri.toString(), 'Feature X work');
+			assert.strictEqual(outcome.status, 'renamed');
+			assert.strictEqual(titleSourceOf(), 'agent');
+
+			sideEffects.handleAction(defaultChatUri, {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				message: { text: 'keep going', origin: { kind: MessageKind.User } },
+			});
+			await waitForSendMessageCalls(1);
+
+			assert.strictEqual(agent.sendMessageCalls[0].prompt, 'keep going');
+		});
+
+		test('a session-level (non-chat) rename marks the title user-set', () => {
+			setupAutoTitledSession();
+			sideEffects.handleAction(sessionUri.toString(), {
+				type: ActionType.SessionTitleChanged,
+				title: 'User picked this',
+			});
+
+			assert.strictEqual(titleSourceOf(), 'user');
+		});
+
+		test('a chat-scoped title rename does not mark the session title user-set', () => {
+			setupAutoTitledSession();
+			sideEffects.handleAction(defaultChatUri, {
+				type: ActionType.SessionTitleChanged,
+				title: 'Chat tab title',
+			});
+
+			assert.strictEqual(titleSourceOf(), 'auto');
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/mockAgent.ts
+++ b/src/vs/platform/agentHost/test/node/mockAgent.ts
@@ -474,7 +474,11 @@ export class ScriptedMockAgent implements IAgent {
 			this._activeTurnIds.set(uriKey(chat), turnId);
 		}
 		const { sessionStr, turnId: tid } = this._ctx(chat);
-		switch (prompt) {
+		// The host appends `<system_notification>` blocks (e.g. the rename-session
+		// nudge) to the SDK prompt while a session still has an auto/placeholder
+		// name. Match on the user's command only, ignoring any such suffix.
+		const command = prompt.split('\n\n<system_notification>')[0];
+		switch (command) {
 			case 'hello':
 				this._fireSequence([
 					_markdown(chat, sessionStr, tid, 'Hello, world!'),
@@ -772,11 +776,11 @@ export class ScriptedMockAgent implements IAgent {
 			}
 
 			default:
-				if (prompt.startsWith('terminal-edit:')) {
+				if (command.startsWith('terminal-edit:')) {
 					// Test prompt: simulate a terminal command that edits a file on disk
 					// without emitting any ToolResultFileEditContent. The test relies on the
 					// git-driven diff path to pick this up. Format: `terminal-edit:<absPath>`.
-					const filePath = prompt.slice('terminal-edit:'.length);
+					const filePath = command.slice('terminal-edit:'.length);
 					void (async () => {
 						for (const s of _toolStart(chat, sessionStr, tid, 'tc-term-edit-1', 'bash', 'Run Command', 'Edit file via shell')) {
 							this._onDidSessionProgress.fire(s);
@@ -798,7 +802,7 @@ export class ScriptedMockAgent implements IAgent {
 					break;
 				}
 				this._fireSequence([
-					_markdown(chat, sessionStr, tid, 'Unknown prompt: ' + prompt),
+					_markdown(chat, sessionStr, tid, 'Unknown prompt: ' + command),
 					_idle(chat, sessionStr, tid),
 				]);
 				break;

--- a/src/vs/platform/agentHost/test/node/protocol/sessionFeatures.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/sessionFeatures.integrationTest.ts
@@ -9,7 +9,7 @@ import { SubscribeResult } from '../../../common/state/protocol/commands.js';
 import { ActionType, type IResponsePartAction, type ITurnStartedAction, type SessionAddedParams, type ITitleChangedAction } from '../../../common/state/sessionActions.js';
 import { PROTOCOL_VERSION } from '../../../common/state/protocol/version/registry.js';
 import type { ListSessionsResult } from '../../../common/state/sessionProtocol.js';
-import { MessageKind, PendingMessageKind, ResponsePartKind, ROOT_STATE_URI, type ISessionWithDefaultChat } from '../../../common/state/sessionState.js';
+import { MessageKind, PendingMessageKind, ResponsePartKind, ROOT_STATE_URI, readSessionTitleSource, type ISessionWithDefaultChat } from '../../../common/state/sessionState.js';
 import { MOCK_AUTO_TITLE } from '../mockAgent.js';
 import {
 	createAndSubscribeSession,
@@ -121,6 +121,18 @@ suite('Protocol WebSocket — Session Features', function () {
 		const session = result.items.find(s => s.resource === sessionUri);
 		assert.ok(session, 'session should appear in listSessions');
 		assert.strictEqual(session.title, 'Fix the login bug');
+	});
+
+	test('first turn records an auto title provenance so the rename nudge keeps firing', async function () {
+		this.timeout(10_000);
+
+		const sessionUri = await createAndSubscribeSession(client, 'test-title-provenance');
+		dispatchTurnStarted(client, sessionUri, 'turn-provenance', 'Fix the login bug', 1);
+		await client.waitForNotification(n => isActionNotification(n, 'chat/turnComplete'));
+
+		const snapshot = await client.call<SubscribeResult>('subscribe', { channel: sessionUri });
+		const state = snapshot.snapshot!.state as ISessionWithDefaultChat;
+		assert.strictEqual(readSessionTitleSource(state._meta), 'auto');
 	});
 
 	test('renamed session title persists across listSessions', async function () {

--- a/src/vs/platform/agentHost/test/node/serverToolGroups.test.ts
+++ b/src/vs/platform/agentHost/test/node/serverToolGroups.test.ts
@@ -81,4 +81,24 @@ suite('serverToolGroups display', () => {
 		assert.strictEqual(getServerToolDisplay('bash', { command: 'ls' }), undefined);
 		assert.strictEqual(getServerToolDisplay('someClientTool', undefined), undefined);
 	});
+
+	test('rename_session resolves to dedicated display strings, using the title for past tense', () => {
+		const display = (args: unknown) => {
+			const d = getServerToolDisplay('rename_session', args);
+			return { displayName: d?.displayName, invocation: text(d?.invocationMessage), past: text(d?.pastTenseMessage) };
+		};
+		assert.deepStrictEqual({
+			withTitle: display({ title: 'Adding JWT auth' }),
+			noTitle: display(undefined),
+			prefixed: display({ title: 'Fixing login bug' }),
+		}, {
+			withTitle: { displayName: 'Rename Session', invocation: 'Renaming session', past: 'Renamed session to "Adding JWT auth"' },
+			noTitle: { displayName: 'Rename Session', invocation: 'Renaming session', past: 'Renamed session' },
+			prefixed: { displayName: 'Rename Session', invocation: 'Renaming session', past: 'Renamed session to "Fixing login bug"' },
+		});
+	});
+
+	test('transport-prefixed rename_session (Claude mcp__host__) matches the bare tool', () => {
+		assert.strictEqual(getServerToolDisplay('mcp__host__rename_session', { title: 'My title' })?.displayName, 'Rename Session');
+	});
 });

--- a/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/providers/agentHost/AGENT_HOST_SESSIONS_PROVIDER.md
@@ -167,9 +167,19 @@ When restoring Copilot SDK history, `mapSessionEvents` best-effort reconstructs 
 
 - `archiveSession` / `unarchiveSession` / `deleteSession` — round-trip to the backend. `deleteSessions` is the batch variant (used when multiple sessions are selected): it disposes each backend session and emits a single removal change event. Sessions advertise `capabilities.supportsDelete`, so the shared sessions-list "Delete..." action (contributed by the sessions workbench, gated on `SessionSupportsDeleteContext`) confirms and invokes deletion — there is no provider-specific delete action.
 - `renameChat` — renames a single chat independently of the session title. For an additional peer chat it dispatches `SessionTitleChanged` on that chat's channel; for the default/main chat it dispatches on the default chat channel (`setDefaultChatTitle`). The host persists the new title under `customChatTitle:<chatUri>` and re-applies it on restore — the default chat's title is seeded back through `restoreSession`/`_ensureDefaultChat`, peer chats through `_restorePeerChats` — so an independently-renamed main/peer chat survives a process restart or idle eviction instead of reverting to the session title.
-- `renameSession` — updates the session-level title.
+- `renameSession` — updates the session-level title (dispatches `SessionTitleChanged` on the session URI). A user rename is durably attributed as `titleSource: 'user'` so the agent's auto-rename never overwrites it (see [Session title & agent rename](#session-title--agent-rename)).
 - `deleteChat` — no-op (agent host sessions don't model individually deletable chats).
 - `forkChat(sessionId, sourceChat, turnId)` — multi-chat only. Mints a peer chat URI and calls `connection.createChat(sessionUri, chatUri, { fork: { source, turnId } })`, where `source` is the backend chat URI (a `chatId` fragment addresses a peer chat, otherwise the session's default chat). The host seeds the new chat with the forked history; the provider waits for it to surface in `cached.chats` and returns it. Routed from the **Fork Conversation** gesture via `ISessionsManagementService.forkChatInSession`; single-chat sessions instead fork into a new session (the workbench `AgentHostSessionHandler.forkSession`).
+
+## Session title & agent rename
+
+A committed session's **title provenance** is tracked durably in session-state `_meta` as `titleSource: 'auto' | 'agent' | 'user'`, persisted under `agentHost.titleSource` and restored with the session. It is the single source of truth for whether the agent should still be nudged to rename the session (`AgentHostSessionTitleController.needsRename` is `true` while the source is `auto` or absent).
+
+- **`auto`** — on the first turn, `seedTitleFromFirstMessage` seeds the session title from the truncated first user message and persists it.
+- **`agent`** — while the title is still `auto`, `AgentSideEffects` suffixes each **session-level** SDK prompt with a `<system_notification>` nudge asking the agent to call the `rename_session` server tool (`agentRenameSessionServerTool.ts`). The tool delegates to `applyAgentRename`, which cleans/validates the title, refuses to overwrite a `user` title, updates the title, and marks the source `agent`. The nudge self-heals — it repeats each turn until the session is renamed. This replaces the previous small-model ("utility") auto-titling of the session title, matching github/github-app.
+- **`user`** — a browser `renameSession` (client `SessionTitleChanged` on the session URI, handled host-side) or the `/rename` local command marks the source `user` (via `markUserSessionTitle`); a user-set title is never overwritten.
+
+**Not covered by the agent rename** (these keep utility-model titling): **peer/additional chats** — auto-titled independently from their own first message plus a first-turn refinement (`refineTitleFromFirstTurn`) — and **forked** sessions/chats (`generateForkedTitle`), since a fork may never send a message to nudge.
 
 ## Picker & Action Contributions
 


### PR DESCRIPTION
Replaces the small utility-model auto-titling of agent-host (Copilot SDK) session titles with an agent-driven rename that mirrors github/github-app.

## What changes
- Adds a provider-agnostic `rename_session` server tool so the primary agent can set a short, descriptive session title.
- Appends a self-healing `<system_notification>` nudge to each session-level SDK prompt while the title is still auto-generated, asking the agent to call `rename_session`. The nudge repeats each turn until the session is renamed.
- Tracks durable title provenance (`titleSource: auto | agent | user`) in session-state `_meta`, persisted under `agentHost.titleSource` and restored with the session. A user-set title is never overwritten; a restored custom title of unknown provenance is locked as `user` so the agent cannot clobber it.
- Keeps the immediate first-message title seed (no utility model) stamped `auto`. Forks keep an `auto`-provenance utility title from inherited context so the nudge keeps firing; peer (additional) chats keep their own utility-model titling.

## Notes
- Reviewed via subagents (code-review + rubber-duck); findings addressed.
- Split from a combined local branch; #324951 grounds titles with resolved GitHub reference content and is filed independently against `main`.