### PR TITLE
Inject resolved GitHub references into Agents window prompts

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -6,8 +6,9 @@
 import type { CopilotSession, ExitPlanModeRequest, MessageOptions, PermissionRequestResult, SessionConfig, Tool, ToolResultObject, McpServerStatus as SdkMcpServerStatus } from '@github/copilot-sdk';
 import { DeferredPromise, raceTimeout } from '../../../../base/common/async.js';
 import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
+import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { Emitter } from '../../../../base/common/event.js';
-import { CancellationError, getErrorMessage } from '../../../../base/common/errors.js';
+import { CancellationError, getErrorMessage, isCancellationError } from '../../../../base/common/errors.js';
 import { escapeMarkdownSyntaxTokens } from '../../../../base/common/htmlContent.js';
 import { Disposable, IReference, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
@@ -24,6 +25,8 @@ import { INativeEnvironmentService } from '../../../environment/common/environme
 import { IFileService } from '../../../files/common/files.js';
 import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
 import { ILogService } from '../../../log/common/log.js';
+import { asJson, asText, IRequestService } from '../../../request/common/request.js';
+import { IHeaders } from '../../../../base/parts/request/common/request.js';
 import { ITelemetryService } from '../../../telemetry/common/telemetry.js';
 import { AgentHostConfigKey, agentHostCustomizationConfigSchema } from '../../common/agentHostCustomizationConfig.js';
 import type { ChatInputRequestWithPlanReview, IAgentHostPlanReviewAction } from '../../common/agentHostPlanReview.js';
@@ -42,6 +45,7 @@ import { MessageKind, ResponsePartKind, ChatInputAnswerState, ChatInputAnswerVal
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import type { IExitPlanModeResponse } from './copilotAgent.js';
 import { CopilotSessionWrapper } from './copilotSessionWrapper.js';
+import { buildGitHubReferencesBlock, extractGitHubReferences, GitHubReferenceResolver, type IGitHubApiRequest, type IGitHubApiResponse } from './githubReferenceResolver.js';
 import { clientToolNamesFromSnapshot, type CopilotSessionLaunchPlan, type IActiveClientSnapshot, type ICopilotSessionLauncher, type ICopilotSessionRuntime } from './copilotSessionLauncher.js';
 import { ActiveClientToolSet } from '../activeClientState.js';
 import { AgentHostTelemetryReporter } from '../agentHostTelemetryReporter.js';
@@ -73,6 +77,9 @@ type RuntimeSlashCommandInfo = Awaited<ReturnType<CopilotSession['rpc']['command
 type McpAuthHandler = NonNullable<SessionConfig['onMcpAuthRequest']>;
 type McpAuthRequest = Parameters<McpAuthHandler>[0];
 type McpAuthResult = Awaited<ReturnType<McpAuthHandler>>;
+
+/** Upper bound on GitHub reference resolution before a send proceeds without it. */
+const GITHUB_REFERENCE_RESOLVE_TIMEOUT_MS = 4000;
 type RuntimeSlashCommandCatalog = {
 	readonly commands: readonly RuntimeSlashCommandInfo[];
 	readonly byName: ReadonlyMap<string, RuntimeSlashCommandInfo>;
@@ -592,6 +599,9 @@ export class CopilotAgentSession extends Disposable {
 	/** Stateless reporter used to emit restricted GH/MSFT telemetry for this session's model calls. */
 	private readonly _telemetryReporter: AgentHostTelemetryReporter;
 
+	/** Resolves github.com issue/PR references in outgoing prompts (per-session cache). */
+	private readonly _githubReferenceResolver: GitHubReferenceResolver;
+
 	constructor(
 		options: ICopilotAgentSessionOptions,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
@@ -601,6 +611,7 @@ export class CopilotAgentSession extends Disposable {
 		@INativeEnvironmentService private readonly _environmentService: INativeEnvironmentService,
 		@IAgentConfigurationService private readonly _configurationService: IAgentConfigurationService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@IRequestService private readonly _requestService: IRequestService,
 	) {
 		super();
 		this.sessionId = options.rawSessionId;
@@ -615,6 +626,7 @@ export class CopilotAgentSession extends Disposable {
 		this._serverToolHost = options.serverToolHost;
 		this._platform = options.platform ?? process.platform;
 		this._telemetryReporter = new AgentHostTelemetryReporter(this._telemetryService);
+		this._githubReferenceResolver = new GitHubReferenceResolver((request, token) => this._githubApiRequest(request, token), this._logService);
 
 		this._appliedSnapshot = options.clientSnapshot ?? { tools: [], plugins: [], mcpServers: {} };
 		this._clientToolNames = clientToolNamesFromSnapshot(this._appliedSnapshot);
@@ -1253,10 +1265,79 @@ export class CopilotAgentSession extends Disposable {
 			this._logService.trace(`[Copilot:${this.sessionId}] Attachments: ${JSON.stringify(sdkAttachments.map(a => ({ type: a.type })))}`);
 		}
 
+		const referencesBlock = await this._resolveGitHubReferencesBlock(prompt);
+		const finalPrompt = referencesBlock ? `${prompt}\n\n${referencesBlock}` : prompt;
+
 		await this.applyMode(mode);
 		await this._applyEffectiveSandboxConfig();
-		await this._wrapper.session.send({ prompt, attachments: sdkAttachments?.length ? sdkAttachments : undefined });
+		await this._wrapper.session.send({ prompt: finalPrompt, attachments: sdkAttachments?.length ? sdkAttachments : undefined });
 		this._logService.info(`[Copilot:${this.sessionId}] session.send() returned`);
+	}
+
+	/**
+	 * Resolves github.com issue/PR/discussion references found in the outgoing
+	 * prompt into a `<github_references>` text block (github/github-app's format)
+	 * appended to the prompt so the Copilot runtime grounds the agent (e.g. to
+	 * produce a content-based session title). Best-effort and bounded by a
+	 * timeout; returns an empty string on missing token, no references, timeout,
+	 * or any failure.
+	 */
+	private async _resolveGitHubReferencesBlock(prompt: string): Promise<string> {
+		if (!this._launchPlan.githubToken) {
+			return '';
+		}
+		const references = extractGitHubReferences(prompt);
+		if (references.length === 0) {
+			return '';
+		}
+		const cts = new CancellationTokenSource();
+		const timer = setTimeout(() => cts.cancel(), GITHUB_REFERENCE_RESOLVE_TIMEOUT_MS);
+		try {
+			const resolved = await this._githubReferenceResolver.resolveReferences(references, cts.token);
+			return buildGitHubReferencesBlock(resolved);
+		} catch (err) {
+			if (!isCancellationError(err)) {
+				this._logService.warn(`[Copilot:${this.sessionId}] GitHub reference resolution failed`, err);
+			}
+			return '';
+		} finally {
+			clearTimeout(timer);
+			cts.dispose();
+		}
+	}
+
+	/**
+	 * Performs an authenticated GitHub API request (REST GET or GraphQL POST)
+	 * using the session's launch token. Returns `{ status, body }` where `body`
+	 * is the parsed JSON for 2xx responses (or `undefined` otherwise); the stream
+	 * is always drained.
+	 */
+	private async _githubApiRequest(request: IGitHubApiRequest, token: CancellationToken): Promise<IGitHubApiResponse | undefined> {
+		const headers: IHeaders = {
+			'Accept': 'application/vnd.github+json',
+			'X-GitHub-Api-Version': '2022-11-28',
+			'User-Agent': 'VSCode-AgentHost',
+		};
+		if (this._launchPlan.githubToken) {
+			headers['Authorization'] = `Bearer ${this._launchPlan.githubToken}`;
+		}
+		if (request.method === 'POST') {
+			headers['Content-Type'] = 'application/json';
+		}
+		try {
+			const context = await this._requestService.request({ type: request.method, url: request.url, data: request.body, headers, callSite: 'agentHost.githubReferenceResolver' }, token);
+			const status = context.res.statusCode ?? 0;
+			if (status < 200 || status >= 300) {
+				await asText(context);
+				return { status, body: undefined };
+			}
+			const body = await asJson<IGitHubApiResponse['body']>(context);
+			return { status, body: body ?? undefined };
+		} catch {
+			// Honor the GitHubApiRequestFn contract: transport/parse/cancellation failures yield undefined, not a throw.
+			this._logService.trace(`[Copilot:${this.sessionId}] GitHub API request failed (skipping): ${request.url}`);
+			return undefined;
+		}
 	}
 
 	async hasRuntimeSlashCommand(command: string): Promise<boolean> {

--- a/src/vs/platform/agentHost/node/copilot/githubReferenceResolver.ts
+++ b/src/vs/platform/agentHost/node/copilot/githubReferenceResolver.ts
@@ -1,0 +1,258 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { ILogService } from '../../../log/common/log.js';
+
+/**
+ * Maximum number of distinct GitHub references resolved for a single prompt.
+ * Guards against a prompt with many URLs flooding the GitHub API.
+ */
+const MAX_GITHUB_REFERENCES = 5;
+
+/**
+ * Matches github.com issue, pull-request, and discussion web URLs. GitHub
+ * Enterprise hosts are intentionally excluded — they would not resolve against
+ * api.github.com.
+ */
+const GITHUB_REFERENCE_RE = /https?:\/\/github\.com\/([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)\/([A-Za-z0-9._-]+)\/(issues|pull|discussions)\/(\d+)(?!\w)/gi;
+
+/** The kind of GitHub item a reference points at (matches gh-app's `itemType`). */
+export type GitHubReferenceType = 'issue' | 'pr' | 'discussion';
+
+const URL_KIND_TO_REFERENCE_TYPE: Record<string, GitHubReferenceType> = {
+	issues: 'issue',
+	pull: 'pr',
+	discussions: 'discussion',
+};
+
+/** A github.com issue/PR/discussion reference parsed out of prompt text. */
+export interface IParsedGitHubReference {
+	readonly owner: string;
+	readonly repo: string;
+	readonly number: number;
+	readonly referenceType: GitHubReferenceType;
+	readonly url: string;
+}
+
+/** A GitHub reference resolved to the fields needed to ground the agent. */
+export interface IResolvedGitHubReference {
+	readonly number: number;
+	readonly title: string;
+	readonly state: string;
+	readonly referenceType: GitHubReferenceType;
+	readonly url: string;
+	readonly labels: readonly string[];
+}
+
+/** A GitHub API request: a REST GET or a GraphQL POST. */
+export interface IGitHubApiRequest {
+	readonly url: string;
+	readonly method: 'GET' | 'POST';
+	readonly body?: string;
+}
+
+/** Result of a GitHub API request: HTTP status plus the parsed JSON body. */
+export interface IGitHubApiResponse {
+	readonly status: number;
+	readonly body: unknown;
+}
+
+/**
+ * Performs an authenticated GitHub API request and returns the parsed JSON body.
+ * Returns `undefined` on transport failure/cancellation.
+ */
+export type GitHubApiRequestFn = (request: IGitHubApiRequest, token: CancellationToken) => Promise<IGitHubApiResponse | undefined>;
+
+/** Extracts unique github.com issue/PR/discussion references from prompt text. */
+export function extractGitHubReferences(text: string): IParsedGitHubReference[] {
+	const out: IParsedGitHubReference[] = [];
+	const seen = new Set<string>();
+	for (const match of text.matchAll(GITHUB_REFERENCE_RE)) {
+		const [url, owner, repo, kind, numberText] = match;
+		const number = Number(numberText);
+		if (!Number.isSafeInteger(number) || number <= 0) {
+			continue;
+		}
+		const referenceType = URL_KIND_TO_REFERENCE_TYPE[kind.toLowerCase()];
+		if (!referenceType) {
+			continue;
+		}
+		const key = `${owner.toLowerCase()}/${repo.toLowerCase()}#${number}:${referenceType}`;
+		if (seen.has(key)) {
+			continue;
+		}
+		seen.add(key);
+		out.push({ owner, repo, number, referenceType, url });
+	}
+	return out;
+}
+
+/**
+ * Builds the `<github_references>` prompt block from resolved references, using
+ * the same format as github/github-app so the Copilot runtime grounds the agent
+ * identically. Returns an empty string when there is nothing to inject.
+ */
+export function buildGitHubReferencesBlock(references: readonly IResolvedGitHubReference[]): string {
+	if (references.length === 0) {
+		return '';
+	}
+	const lines = references.map(reference => {
+		const title = reference.title || reference.referenceType;
+		let line = `#${reference.number} - ${escapeXml(title)} [${reference.referenceType}] [${escapeXml(reference.state.toUpperCase())}] (${escapeXml(reference.url)})`;
+		if (reference.labels.length > 0) {
+			line += `\n  Labels: ${reference.labels.map(escapeXml).join(', ')}`;
+		}
+		return line;
+	});
+	return `<github_references>\n${lines.join('\n')}\n</github_references>`;
+}
+
+function escapeXml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&apos;');
+}
+
+interface IGitHubItemPayload {
+	readonly title?: unknown;
+	readonly state?: unknown;
+	readonly merged_at?: unknown;
+	readonly labels?: unknown;
+}
+
+interface IGitHubDiscussionResponse {
+	readonly data?: {
+		readonly repository?: {
+			readonly discussion?: {
+				readonly title?: unknown;
+				readonly closed?: unknown;
+				readonly labels?: { readonly nodes?: unknown };
+			} | null;
+		} | null;
+	} | null;
+}
+
+const DISCUSSION_QUERY = 'query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){discussion(number:$number){title closed labels(first:20){nodes{name}}}}}';
+
+/**
+ * Resolves github.com references to title/state/labels via the GitHub API so the
+ * Copilot runtime can ground the agent (e.g. to produce a content-based session
+ * title). Resolution is best-effort: any failure yields no reference and the
+ * caller sends the message unchanged. Successful resolutions are cached per
+ * `(owner, repo, number, type)` for the lifetime of the instance (one per
+ * session); failures are not cached, so a later turn can retry.
+ */
+export class GitHubReferenceResolver {
+
+	private readonly _cache = new Map<string, IResolvedGitHubReference>();
+
+	constructor(
+		private readonly _request: GitHubApiRequestFn,
+		private readonly _logService: ILogService,
+	) { }
+
+	async resolveReferences(references: readonly IParsedGitHubReference[], token: CancellationToken): Promise<IResolvedGitHubReference[]> {
+		const limited = references.slice(0, MAX_GITHUB_REFERENCES);
+		const resolved = await Promise.all(limited.map(reference => this._resolveOne(reference, token)));
+		return resolved.filter((reference): reference is IResolvedGitHubReference => !!reference);
+	}
+
+	private async _resolveOne(reference: IParsedGitHubReference, token: CancellationToken): Promise<IResolvedGitHubReference | undefined> {
+		const key = `${reference.owner.toLowerCase()}/${reference.repo.toLowerCase()}#${reference.number}:${reference.referenceType}`;
+		const cached = this._cache.get(key);
+		if (cached) {
+			return cached;
+		}
+		try {
+			const resolved = reference.referenceType === 'discussion'
+				? await this._fetchDiscussion(reference, token)
+				: await this._fetchIssueOrPr(reference, token);
+			// Cache only successful resolutions; a failure stays uncached so a later turn can retry.
+			if (resolved) {
+				this._cache.set(key, resolved);
+			}
+			return resolved;
+		} catch {
+			// A single failing reference must not reject the whole batch (Promise.all in resolveReferences).
+			this._logService.trace(`[GitHubReferenceResolver] ${key} failed to resolve; skipping`);
+			return undefined;
+		}
+	}
+
+	private async _fetchIssueOrPr(reference: IParsedGitHubReference, token: CancellationToken): Promise<IResolvedGitHubReference | undefined> {
+		const apiPath = reference.referenceType === 'pr' ? 'pulls' : 'issues';
+		const url = `https://api.github.com/repos/${reference.owner}/${reference.repo}/${apiPath}/${reference.number}`;
+		const response = await this._request({ url, method: 'GET' }, token);
+		if (!this._isOk(response, url)) {
+			return undefined;
+		}
+		const payload = response.body as IGitHubItemPayload | null | undefined;
+		if (!payload || typeof payload.title !== 'string' || typeof payload.state !== 'string') {
+			return undefined;
+		}
+		const state = reference.referenceType === 'pr' && typeof payload.merged_at === 'string'
+			? 'merged'
+			: payload.state;
+		return {
+			number: reference.number,
+			title: payload.title,
+			state,
+			referenceType: reference.referenceType,
+			url: reference.url,
+			labels: extractLabelNames(payload.labels),
+		};
+	}
+
+	private async _fetchDiscussion(reference: IParsedGitHubReference, token: CancellationToken): Promise<IResolvedGitHubReference | undefined> {
+		const body = JSON.stringify({ query: DISCUSSION_QUERY, variables: { owner: reference.owner, name: reference.repo, number: reference.number } });
+		const response = await this._request({ url: 'https://api.github.com/graphql', method: 'POST', body }, token);
+		if (!this._isOk(response, `graphql discussion ${reference.owner}/${reference.repo}#${reference.number}`)) {
+			return undefined;
+		}
+		const discussion = (response.body as IGitHubDiscussionResponse | null | undefined)?.data?.repository?.discussion;
+		if (!discussion || typeof discussion.title !== 'string') {
+			return undefined;
+		}
+		return {
+			number: reference.number,
+			title: discussion.title,
+			state: discussion.closed === true ? 'closed' : 'open',
+			referenceType: 'discussion',
+			url: reference.url,
+			labels: extractLabelNames(discussion.labels?.nodes),
+		};
+	}
+
+	private _isOk(response: IGitHubApiResponse | undefined, label: string): response is IGitHubApiResponse {
+		if (!response) {
+			return false;
+		}
+		if (response.status < 200 || response.status >= 300) {
+			this._logService.trace(`[GitHubReferenceResolver] ${label} → HTTP ${response.status}; skipping`);
+			return false;
+		}
+		return true;
+	}
+}
+
+/** Extracts label names from a REST `labels` array or a GraphQL `nodes` array. */
+function extractLabelNames(raw: unknown): string[] {
+	if (!Array.isArray(raw)) {
+		return [];
+	}
+	const names: string[] = [];
+	for (const entry of raw) {
+		if (typeof entry === 'string') {
+			names.push(entry);
+		} else if (entry && typeof entry === 'object' && typeof (entry as { name?: unknown }).name === 'string') {
+			names.push((entry as { name: string }).name);
+		}
+	}
+	return names;
+}

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -6,8 +6,8 @@
 import type { CopilotSession, SessionEvent, SessionEventHandler, SessionEventPayload, SessionEventType, Tool, ToolResultObject, TypedSessionEventHandler } from '@github/copilot-sdk';
 import assert from 'assert';
 import { DeferredPromise, timeout } from '../../../../base/common/async.js';
-import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
-import { Emitter } from '../../../../base/common/event.js';
+import { bufferToStream, encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { join, sep } from '../../../../base/common/path.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -17,6 +17,7 @@ import { IFileService } from '../../../files/common/files.js';
 import { InstantiationService } from '../../../instantiation/common/instantiationService.js';
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
 import { ILogService, NullLogService } from '../../../log/common/log.js';
+import { IRequestService } from '../../../request/common/request.js';
 import { ITelemetryService } from '../../../telemetry/common/telemetry.js';
 import { NullTelemetryServiceShape } from '../../../telemetry/common/telemetryUtils.js';
 import { AgentSession, type AgentSignal, type IAgentActionSignal, type IAgentToolPendingConfirmationSignal } from '../../common/agentService.js';
@@ -254,6 +255,10 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 	rootValues?: Record<string, unknown>;
 	fileContents?: Record<string, string>;
 	fileReadErrors?: readonly string[];
+	/** GitHub token surfaced on the launch plan; enables GitHub reference resolution when set. */
+	githubToken?: string;
+	/** Optional handler for GitHub REST calls made during send. Defaults to HTTP 404 (skip). */
+	requestHandler?: (url: string) => { status: number; body?: unknown };
 	/** Configure the mock session before {@link CopilotAgentSession.initializeSession} runs. */
 	configureMockSession?: (session: MockCopilotSession) => void;
 	/** Optional server-tool host wired into the session. */
@@ -309,7 +314,7 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 		resolvedAgentName: undefined,
 		snapshot: options?.clientSnapshot ?? { tools: [], plugins: [], mcpServers: {} },
 		shellManager: undefined,
-		githubToken: undefined,
+		githubToken: options?.githubToken,
 		model: undefined,
 	};
 	let launchedRuntime: ICopilotSessionRuntime | undefined;
@@ -337,6 +342,20 @@ async function createAgentSession(disposables: DisposableStore, options?: {
 	} as Partial<IFileService> as IFileService);
 	services.set(ISessionDataService, createSessionDataService());
 	services.set(IDiffComputeService, createZeroDiffComputeService());
+	const requestHandler = options?.requestHandler;
+	services.set(IRequestService, {
+		_serviceBrand: undefined,
+		onDidCompleteRequest: Event.None,
+		request: async (requestOptions: { url?: string }) => {
+			const result = requestHandler?.(requestOptions.url ?? '') ?? { status: 404 };
+			const payload = result.body === undefined ? '' : JSON.stringify(result.body);
+			return { res: { statusCode: result.status, headers: {} }, stream: bufferToStream(VSBuffer.fromString(payload)) };
+		},
+		resolveProxy: async () => undefined,
+		lookupAuthorization: async () => undefined,
+		lookupKerberosAuthorization: async () => undefined,
+		loadCertificates: async () => [],
+	} as unknown as IRequestService);
 	const sessionConfigUpdates: Array<{ session: string; patch: Record<string, unknown> }> = [];
 	const configValues = options?.configValues ?? {};
 	const rootValues = options?.rootValues ?? {};
@@ -484,6 +503,53 @@ suite('CopilotAgentSession', () => {
 					},
 				},
 			],
+		}]);
+	});
+
+	test('appends a resolved github.com issue reference as a <github_references> block on the prompt', async () => {
+		const { session, mockSession } = await createAgentSession(disposables, {
+			githubToken: 'gh-token',
+			requestHandler: url => url === 'https://api.github.com/repos/microsoft/vscode/issues/313987'
+				? { status: 200, body: { title: 'Dragging a pinned editor tab', state: 'open' } }
+				: { status: 404 },
+		});
+
+		await session.send('fix https://github.com/microsoft/vscode/issues/313987');
+
+		assert.deepStrictEqual(mockSession.sendRequests, [{
+			prompt: [
+				'fix https://github.com/microsoft/vscode/issues/313987',
+				'',
+				'<github_references>',
+				'#313987 - Dragging a pinned editor tab [issue] [OPEN] (https://github.com/microsoft/vscode/issues/313987)',
+				'</github_references>',
+			].join('\n'),
+			attachments: undefined,
+		}]);
+	});
+
+	test('leaves the prompt unchanged when no github token is available', async () => {
+		const { session, mockSession } = await createAgentSession(disposables);
+
+		await session.send('fix https://github.com/microsoft/vscode/issues/313987');
+
+		assert.deepStrictEqual(mockSession.sendRequests, [{
+			prompt: 'fix https://github.com/microsoft/vscode/issues/313987',
+			attachments: undefined,
+		}]);
+	});
+
+	test('leaves the prompt unchanged when GitHub reference resolution fails', async () => {
+		const { session, mockSession } = await createAgentSession(disposables, {
+			githubToken: 'gh-token',
+			requestHandler: () => ({ status: 404 }),
+		});
+
+		await session.send('fix https://github.com/microsoft/vscode/issues/313987');
+
+		assert.deepStrictEqual(mockSession.sendRequests, [{
+			prompt: 'fix https://github.com/microsoft/vscode/issues/313987',
+			attachments: undefined,
 		}]);
 	});
 

--- a/src/vs/platform/agentHost/test/node/githubReferenceResolver.test.ts
+++ b/src/vs/platform/agentHost/test/node/githubReferenceResolver.test.ts
@@ -1,0 +1,206 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { buildGitHubReferencesBlock, extractGitHubReferences, GitHubReferenceResolver, type GitHubApiRequestFn, type IGitHubApiRequest, type IGitHubApiResponse } from '../../node/copilot/githubReferenceResolver.js';
+
+/**
+ * Routes a request to a canned response. REST GETs are keyed by URL; GraphQL
+ * POSTs are keyed by `graphql:<owner>/<name>#<number>` parsed from the body.
+ */
+function keyFor(request: IGitHubApiRequest): string {
+	if (request.method !== 'POST') {
+		return request.url;
+	}
+	const variables = request.body ? (JSON.parse(request.body).variables ?? {}) : {};
+	return `graphql:${variables.owner}/${variables.name}#${variables.number}`;
+}
+
+function createResolver(responses: Record<string, IGitHubApiResponse | undefined>, calls?: string[]): GitHubReferenceResolver {
+	const request: GitHubApiRequestFn = async (req: IGitHubApiRequest) => {
+		const key = keyFor(req);
+		calls?.push(key);
+		return responses[key];
+	};
+	return new GitHubReferenceResolver(request, new NullLogService());
+}
+
+suite('extractGitHubReferences', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('extracts issue/PR/discussion references, dedupes, and ignores non-github.com hosts', () => {
+		const text = [
+			'fix https://github.com/microsoft/vscode/issues/313987',
+			'see https://github.com/microsoft/vscode/pull/42',
+			'discuss https://github.com/microsoft/vscode/discussions/100',
+			'dup https://github.com/microsoft/vscode/issues/313987',
+			'enterprise https://github.example.com/org/repo/issues/7',
+			'gitlab https://gitlab.com/org/repo/issues/8',
+		].join('\n');
+
+		assert.deepStrictEqual(extractGitHubReferences(text), [
+			{ owner: 'microsoft', repo: 'vscode', number: 313987, referenceType: 'issue', url: 'https://github.com/microsoft/vscode/issues/313987' },
+			{ owner: 'microsoft', repo: 'vscode', number: 42, referenceType: 'pr', url: 'https://github.com/microsoft/vscode/pull/42' },
+			{ owner: 'microsoft', repo: 'vscode', number: 100, referenceType: 'discussion', url: 'https://github.com/microsoft/vscode/discussions/100' },
+		]);
+	});
+
+	test('stops the number at a URL delimiter and rejects a trailing word character', () => {
+		const text = [
+			'end https://github.com/o/r/issues/1',
+			'frag https://github.com/o/r/issues/2#issuecomment-9',
+			'query https://github.com/o/r/pull/3?w=1',
+			'paren (https://github.com/o/r/issues/4)',
+			'bad https://github.com/o/r/issues/5abc',
+		].join('\n');
+
+		assert.deepStrictEqual(extractGitHubReferences(text), [
+			{ owner: 'o', repo: 'r', number: 1, referenceType: 'issue', url: 'https://github.com/o/r/issues/1' },
+			{ owner: 'o', repo: 'r', number: 2, referenceType: 'issue', url: 'https://github.com/o/r/issues/2' },
+			{ owner: 'o', repo: 'r', number: 3, referenceType: 'pr', url: 'https://github.com/o/r/pull/3' },
+			{ owner: 'o', repo: 'r', number: 4, referenceType: 'issue', url: 'https://github.com/o/r/issues/4' },
+		]);
+	});
+});
+
+suite('GitHubReferenceResolver', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('resolves issues and PRs, deriving merged state from merged_at and extracting label names', async () => {
+		const resolver = createResolver({
+			'https://api.github.com/repos/o/r/issues/1': { status: 200, body: { title: 'Open issue', state: 'open', labels: [{ name: 'bug' }, { name: 'confirmed' }] } },
+			'https://api.github.com/repos/o/r/issues/2': { status: 200, body: { title: 'Closed issue', state: 'closed' } },
+			'https://api.github.com/repos/o/r/pulls/3': { status: 200, body: { title: 'Merged PR', state: 'closed', merged_at: '2020-01-01T00:00:00Z' } },
+			'https://api.github.com/repos/o/r/pulls/4': { status: 200, body: { title: 'Open PR', state: 'open', merged_at: null } },
+		});
+		const references = extractGitHubReferences([
+			'https://github.com/o/r/issues/1',
+			'https://github.com/o/r/issues/2',
+			'https://github.com/o/r/pull/3',
+			'https://github.com/o/r/pull/4',
+		].join('\n'));
+
+		const resolved = await resolver.resolveReferences(references, CancellationToken.None);
+
+		assert.deepStrictEqual(resolved, [
+			{ number: 1, title: 'Open issue', state: 'open', referenceType: 'issue', url: 'https://github.com/o/r/issues/1', labels: ['bug', 'confirmed'] },
+			{ number: 2, title: 'Closed issue', state: 'closed', referenceType: 'issue', url: 'https://github.com/o/r/issues/2', labels: [] },
+			{ number: 3, title: 'Merged PR', state: 'merged', referenceType: 'pr', url: 'https://github.com/o/r/pull/3', labels: [] },
+			{ number: 4, title: 'Open PR', state: 'open', referenceType: 'pr', url: 'https://github.com/o/r/pull/4', labels: [] },
+		]);
+	});
+
+	test('resolves discussions via GraphQL, mapping closed to state and reading label nodes', async () => {
+		const resolver = createResolver({
+			'graphql:o/r#5': { status: 200, body: { data: { repository: { discussion: { title: 'How do I X?', closed: false, labels: { nodes: [{ name: 'q-and-a' }] } } } } } },
+			'graphql:o/r#6': { status: 200, body: { data: { repository: { discussion: { title: 'Answered', closed: true, labels: { nodes: [] } } } } } },
+		});
+		const references = extractGitHubReferences('https://github.com/o/r/discussions/5 https://github.com/o/r/discussions/6');
+
+		const resolved = await resolver.resolveReferences(references, CancellationToken.None);
+
+		assert.deepStrictEqual(resolved, [
+			{ number: 5, title: 'How do I X?', state: 'open', referenceType: 'discussion', url: 'https://github.com/o/r/discussions/5', labels: ['q-and-a'] },
+			{ number: 6, title: 'Answered', state: 'closed', referenceType: 'discussion', url: 'https://github.com/o/r/discussions/6', labels: [] },
+		]);
+	});
+
+	test('skips references that fail to resolve (non-2xx, transport failure, or missing discussion)', async () => {
+		const resolver = createResolver({
+			'https://api.github.com/repos/o/r/issues/1': { status: 404, body: undefined },
+			'https://api.github.com/repos/o/r/issues/2': undefined,
+			'https://api.github.com/repos/o/r/issues/3': { status: 200, body: { title: 'Ok', state: 'open' } },
+			'graphql:o/r#7': { status: 200, body: { data: { repository: { discussion: null } }, errors: [{ message: 'Not found' }] } },
+		});
+		const references = extractGitHubReferences('https://github.com/o/r/issues/1 https://github.com/o/r/issues/2 https://github.com/o/r/issues/3 https://github.com/o/r/discussions/7');
+
+		const resolved = await resolver.resolveReferences(references, CancellationToken.None);
+
+		assert.deepStrictEqual(resolved, [
+			{ number: 3, title: 'Ok', state: 'open', referenceType: 'issue', url: 'https://github.com/o/r/issues/3', labels: [] },
+		]);
+	});
+
+	test('caches resolved references but retries ones that did not resolve', async () => {
+		const calls: string[] = [];
+		const resolver = createResolver({
+			'https://api.github.com/repos/o/r/issues/1': { status: 200, body: { title: 'A', state: 'open' } },
+			'https://api.github.com/repos/o/r/issues/9': { status: 404, body: undefined },
+		}, calls);
+		const references = extractGitHubReferences('https://github.com/o/r/issues/1 https://github.com/o/r/issues/9');
+
+		await resolver.resolveReferences(references, CancellationToken.None);
+		await resolver.resolveReferences(references, CancellationToken.None);
+
+		assert.deepStrictEqual(calls, [
+			'https://api.github.com/repos/o/r/issues/1',
+			'https://api.github.com/repos/o/r/issues/9',
+			'https://api.github.com/repos/o/r/issues/9',
+		]);
+	});
+
+	test('a reference whose request throws does not discard references that resolved', async () => {
+		const request: GitHubApiRequestFn = async (req: IGitHubApiRequest) => {
+			if (req.url === 'https://api.github.com/repos/o/r/issues/1') {
+				throw new Error('network down');
+			}
+			return { status: 200, body: { title: 'Good', state: 'open' } };
+		};
+		const resolver = new GitHubReferenceResolver(request, new NullLogService());
+		const references = extractGitHubReferences('https://github.com/o/r/issues/1 https://github.com/o/r/issues/2');
+
+		const resolved = await resolver.resolveReferences(references, CancellationToken.None);
+
+		assert.deepStrictEqual(resolved, [
+			{ number: 2, title: 'Good', state: 'open', referenceType: 'issue', url: 'https://github.com/o/r/issues/2', labels: [] },
+		]);
+	});
+
+	test('caps resolution at the maximum number of references', async () => {
+		const calls: string[] = [];
+		const urls: string[] = [];
+		const responses: Record<string, IGitHubApiResponse> = {};
+		for (let i = 1; i <= 6; i++) {
+			urls.push(`https://github.com/o/r/issues/${i}`);
+			responses[`https://api.github.com/repos/o/r/issues/${i}`] = { status: 200, body: { title: `T${i}`, state: 'open' } };
+		}
+		const resolver = createResolver(responses, calls);
+		const references = extractGitHubReferences(urls.join('\n'));
+
+		const resolved = await resolver.resolveReferences(references, CancellationToken.None);
+
+		assert.strictEqual(resolved.length, 5);
+		assert.strictEqual(calls.length, 5);
+	});
+});
+
+suite('buildGitHubReferencesBlock', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('returns an empty string when there are no references', () => {
+		assert.strictEqual(buildGitHubReferencesBlock([]), '');
+	});
+
+	test('formats references like github/github-app, escaping XML and listing labels', () => {
+		const block = buildGitHubReferencesBlock([
+			{ number: 313987, title: 'Dragging a pinned <tab> & "more"', state: 'open', referenceType: 'issue', url: 'https://github.com/microsoft/vscode/issues/313987', labels: ['bug', 'workbench-tabs'] },
+			{ number: 42, title: 'Add feature', state: 'merged', referenceType: 'pr', url: 'https://github.com/microsoft/vscode/pull/42', labels: [] },
+		]);
+
+		assert.strictEqual(block, [
+			'<github_references>',
+			'#313987 - Dragging a pinned &lt;tab&gt; &amp; &quot;more&quot; [issue] [OPEN] (https://github.com/microsoft/vscode/issues/313987)',
+			'  Labels: bug, workbench-tabs',
+			'#42 - Add feature [pr] [MERGED] (https://github.com/microsoft/vscode/pull/42)',
+			'</github_references>',
+		].join('\n'));
+	});
+});


### PR DESCRIPTION
Resolves github.com issue/PR/discussion URLs in the outgoing prompt and appends a literal `<github_references>` text block (matching github/github-app's format) so the Copilot agent grounds content-based session titles — e.g. "Fix pinned tab drag" instead of "Fixing VS Code issue 313987".

## What changes
- Issues/PRs resolve via the GitHub REST API (labels + merged state); discussions resolve via GraphQL.
- Resolution is best-effort, per-session cached, bounded by a 4s timeout, and gracefully skipped without a token or on any failure.

## Notes
- Reviewed via subagents (code-review + rubber-duck); findings addressed (per-reference isolation, cache-only-successes, regex boundary).
- Independent of #324950 (files are disjoint), but exists to improve the titles produced by that agent-driven rename feature. Best experienced with #324950 also merged.
