### PR TITLE
Style overrides: Add padding to tabs with left positioned action buttons

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -39,6 +39,10 @@
 	--tab-border-top-color: transparent !important;
 }
 
+.style-override .part.editor .tabs-container > .tab.tab-actions-left:not(.sticky-compact) {
+	padding: 0 10px 0 0 !important;
+}
+
 .style-override .part.editor .tabs-container > .tab.sizing-fit {
 	width: auto !important;
 	min-width: 0 !important;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/324783

Before:

<img width="446" height="51" alt="Screenshot 2026-07-08 at 11 57 05 AM" src="https://github.com/user-attachments/assets/46c361d5-5ac4-4eca-acba-8535fcf1b500" />

After:

<img width="461" height="60" alt="Screenshot 2026-07-08 at 11 56 57 AM" src="https://github.com/user-attachments/assets/3548dd5e-a42a-44e4-92aa-9f77cd8b24cf" />