### PR TITLE
Fetch tool: tighten auto-approval of previously-referenced URLs

### DIFF
--- a/src/vs/workbench/contrib/chat/electron-browser/builtInTools/fetchPageTool.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/builtInTools/fetchPageTool.ts
@@ -369,36 +369,36 @@ export class FetchWebPageTool implements IToolImpl {
 }
 
 /**
- * Collects the resources a user explicitly referenced across their chat messages.
- *
- * This is used to decide whether a fetch was explicitly requested by the user and can
- * therefore skip the confirmation dialog. Each message is split on whitespace and every
- * token is parsed as a URI. Parsing at token granularity is what makes this safe: a
- * `file://` URI embedded inside another URL the user pasted (for example a web link with a
- * `?u=file:///…` query parameter) is parsed as part of its enclosing web URL, so it never
- * becomes a standalone referenced resource and cannot auto-approve a local file read.
- *
- * Only tokens that parse to a URI with an explicit scheme are collected, so ordinary words
- * are ignored. Parsing is strict so that scheme-less tokens (plain words or bare filesystem
- * paths) throw rather than silently defaulting to the `file:` scheme — otherwise every word in
- * a message would become a `file:///word` resource and could auto-approve a matching read.
- * Comparison is canonical via {@link ResourceSet} (keyed on `URI.toString()`).
+ * Matches the start of a URI scheme (RFC 3986: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) ":").
+ * Used as a cheap filter so only scheme-qualified tokens are parsed.
  */
-export function collectReferencedResources(messages: readonly string[]): ResourceSet {
+const _schemePrefix = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
+/**
+ * Collects the URIs a user explicitly referenced across their chat messages, used to decide
+ * whether a fetch may skip its confirmation dialog. Each message is split on whitespace and
+ * scheme-qualified tokens are parsed into URIs; parsing at token granularity is what makes
+ * this safe — a `file://` URI embedded inside another URL the user pasted (e.g. a
+ * `?u=file:///…` query parameter) is parsed as part of its enclosing URL and never becomes a
+ * standalone reference. Membership is compared by {@link ResourceSet} (keyed on `URI.toString()`).
+ */
+function collectReferencedResources(messages: readonly string[]): ResourceSet {
 	const resources = new ResourceSet();
 	for (const message of messages) {
 		for (const rawToken of message.split(/\s+/)) {
 			// Trim common punctuation/brackets a user might type around a URL.
 			const token = rawToken.replace(/^[<("'`[{]+/, '').replace(/[>)"'`\]},.;]+$/, '');
-			if (!token) {
+			// Cheap pre-check: only tokens that start with a URI scheme are worth parsing.
+			// This avoids using exceptions for control flow on every plain word in a message.
+			if (!_schemePrefix.test(token)) {
 				continue;
 			}
 			try {
-				// Strict parsing throws when no scheme is present, so only genuine
-				// `scheme://…` tokens (http, https, file, …) are treated as references.
+				// Strict parsing rejects scheme-less tokens, so only genuine `scheme:…`
+				// tokens (http, https, file, …) are treated as references.
 				resources.add(URI.parse(token, true));
 			} catch {
-				// Not a scheme-qualified URI token; ignore.
+				// Scheme-like but not a valid URI; ignore.
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/chat/electron-browser/builtInTools/fetchPageTool.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/builtInTools/fetchPageTool.ts
@@ -236,12 +236,17 @@ export class FetchWebPageTool implements IToolImpl {
 		let confirmationNotNeededReason: string | undefined;
 		if (context.chatSessionResource) {
 			const model = this._chatService.getSession(context.chatSessionResource);
-			const userMessages = model?.getRequests().map(r => r.message.text.toLowerCase());
+			const userMessages = model?.getRequests().map(r => r.message.text) ?? [];
+			// Collect the resources the user actually referenced by parsing whole
+			// whitespace-delimited tokens from their messages. Parsing at token granularity
+			// (rather than a substring match) ensures a `file://` URI embedded inside another
+			// URL the user pasted — e.g. `https://host/p?u=file:///home/victim/.ssh/id_rsa` —
+			// is parsed as part of its enclosing web URL and is not mistaken for an explicit
+			// request for that local file, which would otherwise auto-approve the read.
+			const referencedResources = collectReferencedResources(userMessages);
 			let urlsMentionedInPrompt = false;
 			for (const uri of urlsNeedingConfirmation) {
-				// Normalize to lowercase and remove any trailing slash
-				const toToCheck = uri.toString(true).toLowerCase().replace(/\/$/, '');
-				if (userMessages?.some(m => m.includes(toToCheck))) {
+				if (referencedResources.has(uri)) {
 					urlsNeedingConfirmation.delete(uri);
 					urlsMentionedInPrompt = true;
 				}
@@ -362,3 +367,41 @@ export class FetchWebPageTool implements IToolImpl {
 		}
 	}
 }
+
+/**
+ * Collects the resources a user explicitly referenced across their chat messages.
+ *
+ * This is used to decide whether a fetch was explicitly requested by the user and can
+ * therefore skip the confirmation dialog. Each message is split on whitespace and every
+ * token is parsed as a URI. Parsing at token granularity is what makes this safe: a
+ * `file://` URI embedded inside another URL the user pasted (for example a web link with a
+ * `?u=file:///…` query parameter) is parsed as part of its enclosing web URL, so it never
+ * becomes a standalone referenced resource and cannot auto-approve a local file read.
+ *
+ * Only tokens that parse to a URI with an explicit scheme are collected, so ordinary words
+ * are ignored. Parsing is strict so that scheme-less tokens (plain words or bare filesystem
+ * paths) throw rather than silently defaulting to the `file:` scheme — otherwise every word in
+ * a message would become a `file:///word` resource and could auto-approve a matching read.
+ * Comparison is canonical via {@link ResourceSet} (keyed on `URI.toString()`).
+ */
+export function collectReferencedResources(messages: readonly string[]): ResourceSet {
+	const resources = new ResourceSet();
+	for (const message of messages) {
+		for (const rawToken of message.split(/\s+/)) {
+			// Trim common punctuation/brackets a user might type around a URL.
+			const token = rawToken.replace(/^[<("'`[{]+/, '').replace(/[>)"'`\]},.;]+$/, '');
+			if (!token) {
+				continue;
+			}
+			try {
+				// Strict parsing throws when no scheme is present, so only genuine
+				// `scheme://…` tokens (http, https, file, …) are treated as references.
+				resources.add(URI.parse(token, true));
+			} catch {
+				// Not a scheme-qualified URI token; ignore.
+			}
+		}
+	}
+	return resources;
+}
+

--- a/src/vs/workbench/contrib/chat/test/electron-browser/tools/builtinTools/fetchPageTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/electron-browser/tools/builtinTools/fetchPageTool.test.ts
@@ -418,6 +418,122 @@ suite('FetchWebPageTool', () => {
 		assert.ok(preparation2.confirmationMessages?.title);
 	});
 
+	test('should require confirmation for a file URI embedded inside a pasted web URL', async () => {
+		const fileContentMap = new ResourceMap<string | VSBuffer>([
+			[URI.parse('file:///home/victim/.ssh/id_rsa'), 'secret key']
+		]);
+
+		// The user only ever pasted a web URL that happens to contain the file URI as a
+		// query-parameter value. It must NOT be treated as an explicit request for the file,
+		// so the confirmation dialog must still be shown.
+		const tool = new FetchWebPageTool(
+			new TestWebContentExtractorService(new ResourceMap<string>()),
+			new ExtendedTestFileService(fileContentMap),
+			new MockTrustedDomainService(),
+			upcastDeepPartial<IChatService>({
+				getSession: () => {
+					return {
+						getRequests: () => [{
+							message: {
+								text: 'fetch https://attacker.example/p.html?u=file:///home/victim/.ssh/id_rsa'
+							}
+						}],
+					};
+				},
+			}),
+			new TestContextService(),
+			new MockAgentNetworkFilterService(),
+		);
+
+		const preparation = await tool.prepareToolInvocation(
+			{ parameters: { urls: ['file:///home/victim/.ssh/id_rsa'] }, toolCallId: 'test-call-injection', chatSessionResource: LocalChatSessionUri.forSession('a') },
+			CancellationToken.None
+		);
+
+		assert.ok(preparation, 'Should return prepared invocation');
+		assert.ok(preparation.confirmationMessages?.title, 'Embedded file URI should still show confirmation dialog');
+		assert.strictEqual(preparation.confirmationMessages?.confirmResults, true, 'Embedded file URI should still require post-confirmation');
+	});
+
+	test('should auto-approve a standalone out-of-workspace file URI the user pasted', async () => {
+		const workspaceRoot = URI.file('/workspaceRoot');
+		const workspaceContextService = new TestContextService(testWorkspace(workspaceRoot));
+
+		const fileContentMap = new ResourceMap<string | VSBuffer>([
+			[URI.file('/tmp/external-plan.md'), 'External plan content']
+		]);
+
+		// The user explicitly referenced the file URI as its own token, so it should be
+		// treated as user-approved even though it lives outside the workspace.
+		const tool = new FetchWebPageTool(
+			new TestWebContentExtractorService(new ResourceMap<string>()),
+			new ExtendedTestFileService(fileContentMap),
+			new MockTrustedDomainService([]),
+			upcastDeepPartial<IChatService>({
+				getSession: () => {
+					return {
+						getRequests: () => [{
+							message: {
+								text: 'please fetch (file:///tmp/external-plan.md) for me'
+							}
+						}],
+					};
+				},
+			}),
+			workspaceContextService,
+			new MockAgentNetworkFilterService(),
+		);
+
+		const preparation = await tool.prepareToolInvocation(
+			{ parameters: { urls: [URI.file('/tmp/external-plan.md').toString()] }, toolCallId: 'test-call-standalone-file', chatSessionResource: LocalChatSessionUri.forSession('a') },
+			CancellationToken.None
+		);
+
+		assert.ok(preparation, 'Should return prepared invocation');
+		assert.strictEqual(preparation.confirmationMessages?.title, undefined, 'Explicitly referenced file URI should not show confirmation dialog');
+		assert.strictEqual(preparation.confirmationMessages?.confirmResults, false, 'Explicitly referenced file URI should not require post-confirmation');
+	});
+
+	test('should require confirmation when a prior message only mentions a bare (scheme-less) path', async () => {
+		const workspaceRoot = URI.file('/workspaceRoot');
+		const workspaceContextService = new TestContextService(testWorkspace(workspaceRoot));
+
+		const fileContentMap = new ResourceMap<string | VSBuffer>([
+			[URI.file('/etc/secret.txt'), 'secret content']
+		]);
+
+		// The user only ever typed a bare filesystem path (no `file://` scheme). It must not be
+		// treated as a referenced resource — a scheme-less token must not default to a file URI
+		// and auto-approve a matching read.
+		const tool = new FetchWebPageTool(
+			new TestWebContentExtractorService(new ResourceMap<string>()),
+			new ExtendedTestFileService(fileContentMap),
+			new MockTrustedDomainService([]),
+			upcastDeepPartial<IChatService>({
+				getSession: () => {
+					return {
+						getRequests: () => [{
+							message: {
+								text: 'the config lives at /etc/secret.txt on the box'
+							}
+						}],
+					};
+				},
+			}),
+			workspaceContextService,
+			new MockAgentNetworkFilterService(),
+		);
+
+		const preparation = await tool.prepareToolInvocation(
+			{ parameters: { urls: ['file:///etc/secret.txt'] }, toolCallId: 'test-call-bare-path', chatSessionResource: LocalChatSessionUri.forSession('a') },
+			CancellationToken.None
+		);
+
+		assert.ok(preparation, 'Should return prepared invocation');
+		assert.ok(preparation.confirmationMessages?.title, 'Bare path mention should still show confirmation dialog');
+		assert.strictEqual(preparation.confirmationMessages?.confirmResults, true, 'Bare path mention should still require post-confirmation');
+	});
+
 	test('should return message for binary files indicating they are not supported', async () => {
 		// Create binary content (a simple PNG-like header with null bytes)
 		const binaryContent = new Uint8Array([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D]);


### PR DESCRIPTION
The `FetchWebPageTool` decided whether to skip its pre-fetch confirmation by checking whether a target URL's string appeared anywhere in a prior user message using a **substring** match. A substring match is too loose: a URI can appear *inside* an unrelated URL a user pasted (for example as a query-parameter value) without the user having actually referenced that resource.

### Change
- Replace the substring check with **token-level parsing**: each whitespace-delimited token of prior user messages is parsed **strictly** as a URI (scheme required), collected into a `ResourceSet`, and the target is matched by **canonical URI equality**.
- A URI embedded within another URL is therefore parsed as part of that enclosing URL and no longer counts as a standalone user reference, so it still requires confirmation.
- Standalone, explicitly-referenced URLs continue to auto-approve.
- Strict parsing also avoids a prior pitfall where scheme-less tokens defaulted to the `file:` scheme (`_schemeFix`), which polluted the referenced set.

### Tests
Adds unit tests covering:
- a file URI embedded inside a pasted web URL → still requires confirmation,
- a standalone out-of-workspace file URI the user pasted → auto-approves,
- a bare (scheme-less) path mention → still requires confirmation.

Fixes microsoft/vscode-internalbacklog#8353