### PR TITLE
voice: add Escape keybinding to disconnect voice mode

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -272,6 +272,15 @@ registerAction2(class extends Action2 {
 				group: 'navigation',
 				order: -9
 			},
+			keybinding: {
+				weight: KeybindingWeight.WorkbenchContrib,
+				primary: KeyCode.Escape,
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('config.agents.voice.enabled', true),
+					ChatContextKeys.inChatInput,
+					AGENTS_VOICE_CONNECTED.isEqualTo(true),
+				),
+			},
 		});
 	}
 	async run(accessor: ServicesAccessor): Promise<void> {

--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -41,6 +41,7 @@ import {
 import { mainWindow } from '../../../../base/browser/window.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { ChatContextKeys } from '../../chat/common/actions/chatContextKeys.js';
+import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
 import { ChatAgentLocation } from '../../chat/common/constants.js';
 import { IChatWidgetService } from '../../chat/browser/chat.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
@@ -273,12 +274,18 @@ registerAction2(class extends Action2 {
 				order: -9
 			},
 			keybinding: {
-				weight: KeybindingWeight.WorkbenchContrib,
+				// Keep this below the editor widgets and negate their contexts so
+				// Escape still dismisses IntelliSense/hover and clears selections
+				// while the user is typing in the chat input.
+				weight: KeybindingWeight.EditorContrib - 5,
 				primary: KeyCode.Escape,
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals('config.agents.voice.enabled', true),
 					ChatContextKeys.inChatInput,
 					AGENTS_VOICE_CONNECTED.isEqualTo(true),
+					EditorContextKeys.hoverVisible.toNegated(),
+					EditorContextKeys.hasNonEmptySelection.toNegated(),
+					EditorContextKeys.hasMultipleSelections.toNegated(),
 				),
 			},
 		});


### PR DESCRIPTION
Fixes microsoft/vscode-internalbacklog#8330

## What

Wires the <kbd>Escape</kbd> key to the existing `agentsVoice.disconnect` action so users can exit voice / push-to-talk (PTT) mode from the chat input.

## Why

Previously, once a user entered voice/PTT mode in chat (via `ctrl+shift+space`), the only way to exit was the toolbar "Disconnect Voice Mode" button — there was no keyboard way out. As reported in the issue, pressing <kbd>Escape</kbd> did nothing. Per the discussion on the issue, a disconnect action bound to <kbd>Escape</kbd> makes sense.

## Details

The keybinding is scoped tightly to avoid stealing <kbd>Escape</kbd> in other contexts, mirroring the `when` conditions used by the connect/stop actions:

- `config.agents.voice.enabled` is `true`
- `ChatContextKeys.inChatInput` — focus is in the chat input
- `AGENTS_VOICE_CONNECTED` is `true` — a voice session is actually active

So <kbd>Escape</kbd> only disconnects when a voice session is live and focus is in the chat input; otherwise it behaves normally.