### PR TITLE
Voice: fix responses not read out with multiple sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -1919,8 +1919,6 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	}
 
 	private _playChunk(sessionId: string | undefined, audio: string, isFirstChunk: boolean, isFinal: boolean, transcript: string | undefined): void {
-		this._currentPlaybackSessionId = sessionId;
-
 		// Streaming pipeline sends a monotonically-growing transcript on every
 		// chunk. On the FIRST chunk of a response we push a fresh assistant
 		// turn into the rolling buffer; on subsequent chunks we REPLACE that
@@ -1939,6 +1937,12 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 
 		const ttsEnabled = this.configurationService.getValue<boolean>('agents.voice.textToSpeech') !== false;
 		if (ttsEnabled && audio) {
+			// Claim the playback slot only when we actually have audio to play.
+			// A transcript-only frame (empty audio) must NOT claim it, or the
+			// slot would stay pinned to a session that never starts playback
+			// (onPlaybackStopped never fires), deadlocking every other
+			// session's queued audio.
+			this._currentPlaybackSessionId = sessionId;
 			this._clearAutoListenTimer();
 			this._replyPlayedSinceSend = true;
 			this.micCaptureService.suppressUntil(Date.now() + 800);
@@ -1949,29 +1953,35 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 			this._replyPlayedSinceSend = true;
 			if (isFinal) {
 				this._currentPlaybackSessionId = null;
-				this._processQueue();
+				// Avoid re-entering _processQueue if we're already inside its
+				// drain loop; that loop will continue on its own.
+				if (!this._isProcessingQueue) {
+					this._processQueue();
+				}
 				if (this._isHandsFreeEnabled()) {
 					this._scheduleAutoListen();
 				}
 			}
 		} else {
+			// TTS enabled but no audio in this frame. Forward it so a final
+			// frame can flush/stop an in-flight playback turn; a non-final
+			// empty frame is a no-op and leaves the slot untouched.
 			this.ttsPlaybackService.playAudioChunk(audio, isFinal, this._window!);
 		}
 	}
 
 	private _processQueue(): void {
-		if (this._audioQueue.length === 0 || this._currentPlaybackSessionId !== null) {
-			this._isProcessingQueue = false;
-			return;
-		}
-
+		// Drain entries until one actually claims the playback slot (starts
+		// audio) or the queue empties. Entries that produce no audio (e.g.
+		// transcript-only frames) would otherwise stall the chain, since
+		// nothing fires onPlaybackStopped to pump the next entry.
 		this._isProcessingQueue = true;
-		const next = this._audioQueue.shift()!;
-
-		for (const chunk of next.chunks) {
-			this._playChunk(next.sessionId, chunk.audio, chunk.isFirstChunk, chunk.isFinal, chunk.transcript);
+		while (this._currentPlaybackSessionId === null && this._audioQueue.length > 0) {
+			const next = this._audioQueue.shift()!;
+			for (const chunk of next.chunks) {
+				this._playChunk(next.sessionId, chunk.audio, chunk.isFirstChunk, chunk.isFinal, chunk.transcript);
+			}
 		}
-
 		this._isProcessingQueue = false;
 	}
 


### PR DESCRIPTION
Fixes microsoft/vscode-internalbacklog#8359

## Problem

When two chat sessions use voice mode, switching between them results in **neither** response being read out (TTS is silent).

Repro (from the issue):
1. Start a session and use voice mode
2. Switch to a new session and use voice mode
3. Switch between sessions
4. Neither response is read

## Root cause

`_playChunk` claimed the playback slot unconditionally at the top:

```ts
this._currentPlaybackSessionId = sessionId;
```

A streaming `audio_response` frame can carry a transcript but **no audio** (`audio` defaults to `''` when the field is absent — see `voiceClientService.ts`). For such an empty frame, no TTS playback starts, so `onPlaybackStopped` never fires and the slot is never released. It stays pinned to that session forever, and `_processQueue` / `_enqueueAudio` (which both bail while `_currentPlaybackSessionId !== null`) deadlock every other session's queued audio behind it — so nothing is read out for either session.

## Fix

- **Claim the slot only when there is real audio to play.** Transcript-only frames no longer pin `_currentPlaybackSessionId`.
- **Drain `_processQueue` in a loop** until an entry starts real playback or the queue empties, so entries that produce no audio don't stall the chain (nothing fires `onPlaybackStopped` to pump the next entry).


https://github.com/user-attachments/assets/789e41ae-ec2f-490a-857c-09331f48657e


