### PR TITLE
Fix double microphone entries in Voice: Select Microphone

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -391,7 +391,20 @@ registerAction2(class extends Action2 {
 		const storageService = accessor.get(IStorageService);
 
 		const devices = await navigator.mediaDevices.enumerateDevices();
-		const audioInputs = devices.filter(d => d.kind === 'audioinput' && d.deviceId !== 'default');
+
+		// Filter out the virtual "default"/"communications" entries (which duplicate a real
+		// device) and de-duplicate by deviceId so a single microphone shows up only once.
+		const seenDeviceIds = new Set<string>();
+		const audioInputs = devices.filter(d => {
+			if (d.kind !== 'audioinput' || d.deviceId === 'default' || d.deviceId === 'communications') {
+				return false;
+			}
+			if (seenDeviceIds.has(d.deviceId)) {
+				return false;
+			}
+			seenDeviceIds.add(d.deviceId);
+			return true;
+		});
 
 		if (audioInputs.length === 0) {
 			quickInputService.pick([{ label: nls.localize('noMicrophones', "No microphones found") }]);


### PR DESCRIPTION
Fixes microsoft/vscode-internalbacklog#8344

### Problem
Running **Voice: Select Microphone** showed a single physical microphone as two entries.

### Cause
`navigator.mediaDevices.enumerateDevices()` returns virtual `'default'` and `'communications'` audio-input entries that mirror a real device's label (and the same real `deviceId` can appear more than once). The picker only filtered out `'default'`, so the `'communications'` pseudo-device produced a duplicate.

### Fix
Filter out both `'default'` and `'communications'` pseudo-devices and de-duplicate by `deviceId` so each microphone appears exactly once.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>