### PR TITLE
Fix double entries for a single microphone in Voice: Select Microphone

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -391,7 +391,23 @@ registerAction2(class extends Action2 {
 		const storageService = accessor.get(IStorageService);
 
 		const devices = await navigator.mediaDevices.enumerateDevices();
-		const audioInputs = devices.filter(d => d.kind === 'audioinput' && d.deviceId !== 'default');
+
+		// `enumerateDevices` can return the same physical microphone multiple times: once with its
+		// real `deviceId` and again under the special `default`/`communications` aliases (which share
+		// the same `groupId`). Skip those aliases and dedupe by `groupId` so each mic appears once.
+		const seenGroups = new Set<string>();
+		const audioInputs = devices.filter(d => {
+			if (d.kind !== 'audioinput' || d.deviceId === 'default' || d.deviceId === 'communications') {
+				return false;
+			}
+			if (d.groupId && seenGroups.has(d.groupId)) {
+				return false;
+			}
+			if (d.groupId) {
+				seenGroups.add(d.groupId);
+			}
+			return true;
+		});
 
 		if (audioInputs.length === 0) {
 			quickInputService.pick([{ label: nls.localize('noMicrophones', "No microphones found") }]);


### PR DESCRIPTION
Fixes microsoft/vscode-internalbacklog#8344

## Problem
Running **Voice: Select Microphone** showed two entries for a single physical microphone (e.g. a non-default external webcam mic).

## Cause
`navigator.mediaDevices.enumerateDevices()` can return the same physical microphone multiple times: once with its real `deviceId` and again under the special `default`/`communications` aliases. These aliases share the same `groupId` as the real device. The previous filter only excluded `default`, so the `communications` alias (and any other duplicate sharing a `groupId`) still produced a second entry.

## Fix
In the microphone picker filter:
- Skip both the `default` and `communications` alias device IDs.
- Dedupe remaining audio inputs by `groupId` so each physical microphone appears exactly once.

## Testing
- Type-check passes (no new errors in the modified file).
- Pre-commit hygiene passes.