### PR TITLE
Style overrides: Adjust vertical alignment for codicons in integrated terminal tabs

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -226,3 +226,7 @@
 .style-override.monaco-workbench .pane-body.integrated-terminal .terminal-tabs-chat-entry {
 	padding: 4px;
 }
+
+.style-override.monaco-workbench .pane-body.integrated-terminal .tabs-list .codicon {
+	vertical-align: sub;
+}


### PR DESCRIPTION
Improve the vertical alignment of codicons within the integrated terminal tabs for better visual consistency. Test the changes by opening the integrated terminal and observing the alignment of the icons in the tabs.

