### PR TITLE
Fix voice mode connecting button spinning its hover background

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -4724,6 +4724,21 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	color: var(--vscode-charts-green, #3fb950) !important;
 }
 
+/*
+ * Voice mode connecting indicator: only spin the spinner glyph, not the whole
+ * button. Otherwise the action-label (including its hover background) rotates
+ * along with the icon.
+ */
+.chat-input-container .chat-input-toolbars .action-label.codicon-loading {
+	animation: none;
+}
+
+.chat-input-container .chat-input-toolbars .action-label.codicon-loading::before {
+	display: inline-block;
+	transform-origin: center center;
+	animation: codicon-spin 1.5s steps(30) infinite;
+}
+
 .monaco-reduce-motion .action-item.chat-restore-checkpoint-item.confirming .action-label:first-child {
 	animation: none;
 	background: none;


### PR DESCRIPTION
Fixes microsoft/vscode-internalbacklog#8327

## Problem

Every time the voice mode "Connecting…" spinner is shown, the entire push-to-talk button rotates — including its hover background.

## Root cause

The `agentsVoice.connecting` action uses `icon: Codicon.loading`. In the chat input toolbar this renders as `.action-label.codicon-loading`, and per `codicon-modifiers.css` the `codicon-spin` animation is applied to the **entire element**. So the whole button (and its hover background) rotated along with the spinner glyph.

## Fix

Scope the spin animation to just the icon glyph (`::before`) rather than the whole action-label element, for loading spinners in the chat input toolbars. The button and its hover background now stay static while only the spinner rotates.

CSS-only change, verified against the repo's stylelint.