### PR TITLE
Make voice transcript per-session

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -549,23 +549,50 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 		}));
 		this._register({ dispose: () => stopGlowAnimation() });
 
+		// Voice transcript is per-session. The transcript is "owned" by the
+		// session the user is dictating into (the explicit target session, or the
+		// focused session when dictation began) and is only shown in that
+		// session's view. Switching focus to a different session hides the
+		// transcript here; switching while actively dictating also stops
+		// transcription so it isn't misrouted to the newly focused session.
+		let listeningSession: URI | undefined;
+		let ownerSession: URI | undefined;
 		this._register(autorun(reader => {
 			const turns = this.voiceSessionController.transcriptTurns.read(reader);
 			const connected = this.voiceSessionController.isConnected.read(reader);
 			const voiceState = this.voiceSessionController.voiceState.read(reader);
+			const targetSession = this.voiceSessionController.targetSession.read(reader);
+			const currentSession = this._currentSessionResource.read(reader);
 			const showTranscript = this.configurationService.getValue<boolean>('agents.voice.showTranscript') !== false;
 			const visible = turns.filter(t => t.text.length > 0 || (t.speaker === 'user' && t.isPartial));
 
 			if (!connected) {
+				listeningSession = undefined;
+				ownerSession = undefined;
 				transcriptOverlayNode.style.display = 'none';
 				transcriptOverlayNode.classList.remove('has-transcript');
 				return;
 			}
 
-			// Don't show transcript from a different session in this widget
-			const targetSession = this.voiceSessionController.targetSession.read(reader);
-			const currentSession = this._currentSessionResource.read(reader);
-			if (targetSession && currentSession && !isEqual(targetSession, currentSession)) {
+			// Capture / maintain the session the current transcript belongs to.
+			if (voiceState === 'listening') {
+				if (!listeningSession) {
+					listeningSession = targetSession ?? currentSession;
+					ownerSession = listeningSession;
+				} else if (!targetSession && currentSession && !isEqual(currentSession, listeningSession)) {
+					// User switched to a different session mid-dictation — stop
+					// transcription so it isn't sent to the newly focused session.
+					this.voiceSessionController.stopListening();
+					listeningSession = undefined;
+				}
+			} else {
+				// Allow the next dictation to re-capture the owning session.
+				listeningSession = undefined;
+			}
+
+			// Don't show a transcript that belongs to a different session here.
+			const effectiveOwner = targetSession ?? ownerSession;
+			if (effectiveOwner && currentSession && !isEqual(effectiveOwner, currentSession)) {
 				transcriptOverlayNode.style.display = 'none';
 				transcriptOverlayNode.classList.remove('has-transcript');
 				return;


### PR DESCRIPTION
Fixes microsoft/vscode-internalbacklog#8346

### Problem
The voice transcript overlay was not per-session:
1. The response transcript from session A stayed visible after switching to session B.
2. Starting voice transcription and then switching sessions could leave voice in a broken state (keybinding did nothing, mic button exited voice mode).

### Root cause
In `chatViewPane.ts`, the transcript overlay only hid content for a *different* session when an **explicit** target session was set (`targetSession`). In the common case where voice targets the currently active session (`targetSession === undefined`), the overlay had no notion of which session the transcript belonged to, so it kept rendering across session switches.

### Fix
The transcript overlay autorun now binds the transcript to an *owning* session:
- **Per-session transcript (bug 1):** The transcript is owned by the explicit target session, or — when none is set — the session that was focused when dictation began. The overlay is only shown when the currently displayed session matches the owner; switching focus to another session hides it.
- **Stop transcription on switch (bug 2):** If the user switches to a different session while actively dictating (`listening`) with no explicit target, `stopListening()` is called so the in-flight transcription isn't misrouted to the newly focused session, avoiding the broken state.

Explicit target sessions are left untouched (switching views won't stop transcription there), preserving intentional cross-session targeting.