### PR TITLE
Fix auto-approve flicker in agent host sessions list

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -2577,6 +2577,13 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				parameters,
 				context: { sessionResource: opts.sessionResource },
 				chatStreamToolCallId: toolCallId,
+				// If the agent host already resolved auto-approval for this call,
+				// pass it through so the invocation transitions straight to
+				// executing instead of briefly flashing a confirmation prompt
+				// (which would flicker "needs input" in the sessions list).
+				preApproved: shouldAutoApproveClientToolCall(tc)
+					? { type: ToolConfirmKind.Setting, id: SessionConfigKey.AutoApprove }
+					: undefined,
 			};
 			const noOpCountTokens = async () => 0;
 			this._logService.info(`[AgentHost] Invoking client tool: ${toolName} (callId=${toolCallId})`);

--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -617,10 +617,18 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				const { autoConfirmed: resolvedAutoConfirmed, preparedInvocation: updatedPreparedInvocation } = await this.resolveAutoConfirmFromHook(preToolUseHookResult, tool, dto, preparedInvocation, dto.context?.sessionResource);
 				preparedInvocation = updatedPreparedInvocation;
 
+				// A caller (e.g. the agent host) may have resolved auto-approval
+				// out-of-band. Treat it like a local auto-confirmation so the
+				// invocation never briefly enters `WaitingForConfirmation`. A
+				// preToolUse hook that returned `ask` explicitly forces a
+				// confirmation, so never let `preApproved` override it.
+				const preResolvedAutoConfirmed = resolvedAutoConfirmed
+					?? (preToolUseHookResult?.permissionDecision === 'ask' ? undefined : dto.preApproved);
+
 				// In Autopilot, run the risk classifier on an auto-approved call that would
 				// otherwise show a confirmation. A "red" rating skips the call; anything else
 				// (including a classifier failure) keeps the original auto-confirmation.
-				const { autoConfirmed, skipExplanation: riskSkipExplanation } = await this._maybeApplyAutopilotRiskGate(tool, dto, preparedInvocation, resolvedAutoConfirmed, token);
+				const { autoConfirmed, skipExplanation: riskSkipExplanation } = await this._maybeApplyAutopilotRiskGate(tool, dto, preparedInvocation, preResolvedAutoConfirmed, token);
 
 				// Important: a tool invocation that will be autoconfirmed should never
 				// be in the chat response in the `NeedsConfirmation` state, even briefly,

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -25,7 +25,7 @@ import { createDecorator } from '../../../../../platform/instantiation/common/in
 import { IProgress } from '../../../../../platform/progress/common/progress.js';
 import { ChatRequestToolReferenceEntry } from '../attachments/chatVariableEntries.js';
 import { IVariableReference } from '../chatModes.js';
-import { IChatAgentFeedbackReviewConfirmationData, IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSearchToolInvocationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, type IChatTerminalToolInvocationData } from '../chatService/chatService.js';
+import { ConfirmedReason, IChatAgentFeedbackReviewConfirmationData, IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSearchToolInvocationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, type IChatTerminalToolInvocationData } from '../chatService/chatService.js';
 import { ILanguageModelChatMetadata, LanguageModelPartAudience } from '../languageModels.js';
 import { UserSelectedTools } from '../participants/chatAgents.js';
 import { PromptElementJSON, stringifyPromptElementJSON } from './promptTsxTypes.js';
@@ -197,6 +197,16 @@ export interface IToolInvocation {
 	selectedCustomButton?: string;
 	/** Pre-tool-use hook result passed from the extension, if the hook was already executed externally. */
 	preToolUseResult?: IExternalPreToolUseHookResult;
+	/**
+	 * A confirmation reason resolved out-of-band by the caller (e.g. the agent
+	 * host, which decides auto-approval server-side). When set, the invocation
+	 * is treated as already auto-approved and transitions straight to executing
+	 * without ever entering the `WaitingForConfirmation` state. This avoids a
+	 * transient "needs input" flicker in surfaces (like the sessions list) that
+	 * observe pending confirmations, for tool calls that will be auto-approved
+	 * anyway.
+	 */
+	preApproved?: ConfirmedReason;
 	/**
 	 * Optional W3C trace context `traceparent` value identifying the parent distributed
 	 * tracing span for this tool invocation. Forwarded to MCP tool implementations as

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostClientTools.test.ts
@@ -11,7 +11,7 @@ import { CancellationError } from '../../../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { DisposableStore, IReference, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../../base/common/uri.js';
-import { constObservable, observableValue } from '../../../../../../base/common/observable.js';
+import { constObservable, observableValue, autorun } from '../../../../../../base/common/observable.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
@@ -247,6 +247,7 @@ suite('AgentHostClientTools', () => {
 			const pendingToolCalls = new Map<string, ChatToolInvocation>();
 			const begunToolCalls: ChatToolInvocation[] = [];
 			const invokedToolCalls: IToolInvocation[] = [];
+			const recordedStateKinds = new Map<string, IChatToolInvocation.StateKind[]>();
 			return {
 				onDidChangeTools: onDidChangeTools.event,
 				getToolByName: (name: string) => tools.find(t => t.toolReferenceName === name),
@@ -265,13 +266,17 @@ suite('AgentHostClientTools', () => {
 						throw options.throwBeforeConfirmation;
 					}
 					if (options?.requireConfirmation && toolInvocation) {
+						// Mirror the real service: a caller-provided `preApproved`
+						// reason is treated as auto-confirmation so the invocation
+						// transitions straight to executing without ever entering
+						// `WaitingForConfirmation`.
 						toolInvocation.transitionFromStreaming({
 							invocationMessage: 'Run Task',
 							confirmationMessages: {
 								title: 'Confirm tool execution',
 								message: 'Run the task?',
 							},
-						}, invocation.parameters, undefined);
+						}, invocation.parameters, invocation.preApproved);
 						await IChatToolInvocation.awaitConfirmation(toolInvocation, CancellationToken.None);
 					} else {
 						toolInvocation?.transitionFromStreaming(undefined, invocation.parameters, { type: ToolConfirmKind.ConfirmationNotNeeded });
@@ -293,6 +298,14 @@ suite('AgentHostClientTools', () => {
 					});
 					pendingToolCalls.set(options.toolCallId, invocation);
 					begunToolCalls.push(invocation);
+					// Record every state the invocation passes through so tests can
+					// assert it never flickers into `WaitingForConfirmation` when
+					// the call is auto-approved.
+					const stateKinds: IChatToolInvocation.StateKind[] = [];
+					recordedStateKinds.set(options.toolCallId, stateKinds);
+					disposables.add(autorun(reader => {
+						stateKinds.push(invocation.state.read(reader).type);
+					}));
 					return invocation;
 				},
 				updateToolStream: async () => { },
@@ -321,7 +334,8 @@ suite('AgentHostClientTools', () => {
 				fireOnDidChangeTools: () => onDidChangeTools.fire(),
 				begunToolCalls,
 				invokedToolCalls,
-			} satisfies ILanguageModelToolsService & { fireOnDidChangeTools: () => void; begunToolCalls: ChatToolInvocation[]; invokedToolCalls: IToolInvocation[] };
+				recordedStateKinds,
+			} satisfies ILanguageModelToolsService & { fireOnDidChangeTools: () => void; begunToolCalls: ChatToolInvocation[]; invokedToolCalls: IToolInvocation[]; recordedStateKinds: Map<string, IChatToolInvocation.StateKind[]> };
 		}
 
 		class MockAgentHostConnection extends mock<IAgentHostService>() {
@@ -785,6 +799,54 @@ suite('AgentHostClientTools', () => {
 					success: true,
 				},
 			]);
+		});
+
+		test('auto-approved client tool never enters WaitingForConfirmation (no needs-input flicker)', async () => {
+			const { handler, connection, toolsService } = createHandlerWithMocks(disposables, [testRunTaskTool], { requireConfirmation: true });
+			const sessionResource = URI.parse('agent-host-copilot:/session-1');
+			const backendSession = AgentSession.uri('copilot', 'session-1').toString();
+
+			connection.applySessionAction(URI.parse(buildDefaultChatUri(backendSession)), {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				message: { text: 'run the task', origin: { kind: MessageKind.User } },
+			} as ChatAction);
+			connection.applySessionAction(URI.parse(buildDefaultChatUri(backendSession)), {
+				type: ActionType.ChatToolCallStart,
+				turnId: 'turn-1',
+				toolCallId: 'tool-call-1',
+				toolName: 'runTask',
+				displayName: 'Run Task',
+				contributor: { kind: ToolCallContributorKind.Client, clientId: connection.clientId },
+			} as ChatAction);
+			connection.applySessionAction(URI.parse(buildDefaultChatUri(backendSession)), {
+				type: ActionType.ChatToolCallReady,
+				turnId: 'turn-1',
+				toolCallId: 'tool-call-1',
+				invocationMessage: 'Run Task',
+				toolInput: '{"task":"build"}',
+				confirmationTitle: 'Run Task',
+				_meta: { autoApproveBySetting: true },
+			} as ChatAction);
+
+			await handler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			await timeout(0);
+			await timeout(0);
+			await timeout(0);
+
+			// The invocation carries the pre-resolved approval, and it transitions
+			// straight from streaming to executing without ever surfacing a pending
+			// confirmation (which would flicker "needs input" in the sessions list).
+			assert.deepStrictEqual(
+				{
+					preApprovedKind: toolsService.invokedToolCalls[0]?.preApproved?.type,
+					sawWaitingForConfirmation: (toolsService.recordedStateKinds.get('tool-call-1') ?? []).includes(IChatToolInvocation.StateKind.WaitingForConfirmation),
+				},
+				{
+					preApprovedKind: ToolConfirmKind.Setting,
+					sawWaitingForConfirmation: false,
+				},
+			);
 		});
 
 		test('reconnecting to an active turn with owned client tool completes the initial snapshot invocation', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
@@ -8,6 +8,7 @@ import { Barrier } from '../../../../../../base/common/async.js';
 import { VSBuffer } from '../../../../../../base/common/buffer.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
 import { CancellationError, isCancellationError } from '../../../../../../base/common/errors.js';
+import { autorun } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IAccessibilityService } from '../../../../../../platform/accessibility/common/accessibility.js';
@@ -4983,6 +4984,88 @@ suite('LanguageModelToolsService', () => {
 
 			// Updated parameters should be applied since validation passed
 			assert.deepStrictEqual(receivedParameters, { command: 'safe-command' });
+		});
+	});
+
+	suite('preApproved (out-of-band auto-approval)', () => {
+		let preApprovedService: LanguageModelToolsService;
+		let preApprovedChatService: MockChatService;
+
+		setup(() => {
+			const setup = createTestToolsService(store);
+			preApprovedService = setup.service;
+			preApprovedChatService = setup.chatService;
+		});
+
+		test('a confirmable tool with dto.preApproved never enters WaitingForConfirmation', async () => {
+			let invokeCompleted = false;
+			const tool = registerToolForTest(preApprovedService, store, 'preApprovedTool', {
+				invoke: async () => {
+					invokeCompleted = true;
+					return { content: [{ kind: 'text', value: 'success' }] };
+				},
+				prepareToolInvocation: async () => ({
+					confirmationMessages: {
+						title: 'Confirm this action?',
+						message: 'This tool would normally require confirmation',
+						allowAutoConfirm: true,
+					},
+				}),
+			});
+
+			const capture: { invocation?: ChatToolInvocation } = {};
+			stubGetSession(preApprovedChatService, 'pre-approved', { requestId: 'req1', capture });
+
+			const dto = tool.makeDto({ test: 1 }, { sessionId: 'pre-approved' });
+			dto.preApproved = { type: ToolConfirmKind.Setting, id: 'autoApprove' };
+
+			// Record every state the published invocation passes through.
+			const seenStates: IChatToolInvocation.StateKind[] = [];
+			const result = await preApprovedService.invokeTool(dto, async () => 0, CancellationToken.None);
+			const invocation = await waitForPublishedInvocation(capture);
+			store.add(autorun(reader => { seenStates.push(invocation.state.read(reader).type); }));
+
+			assert.deepStrictEqual(
+				{
+					invokeCompleted,
+					value: (result.content[0] as IToolResultTextPart).value,
+					sawWaitingForConfirmation: seenStates.includes(IChatToolInvocation.StateKind.WaitingForConfirmation),
+				},
+				{
+					invokeCompleted: true,
+					value: 'success',
+					sawWaitingForConfirmation: false,
+				},
+			);
+		});
+
+		test('dto.preApproved does not override a preToolUse hook that returned ask', async () => {
+			const tool = registerToolForTest(preApprovedService, store, 'preApprovedAskTool', {
+				invoke: async () => ({ content: [{ kind: 'text', value: 'success' }] }),
+				prepareToolInvocation: async () => ({
+					confirmationMessages: {
+						title: 'Confirm this action?',
+						message: 'This tool requires confirmation',
+						allowAutoConfirm: true,
+					},
+				}),
+			});
+
+			const capture: { invocation?: ChatToolInvocation } = {};
+			stubGetSession(preApprovedChatService, 'pre-approved-ask', { requestId: 'req1', capture });
+
+			const dto = tool.makeDto({ test: 1 }, { sessionId: 'pre-approved-ask' });
+			dto.preApproved = { type: ToolConfirmKind.Setting, id: 'autoApprove' };
+			dto.preToolUseResult = { permissionDecision: 'ask', permissionDecisionReason: 'Requires user confirmation' };
+
+			const invokePromise = preApprovedService.invokeTool(dto, async () => 0, CancellationToken.None);
+			const invocation = await waitForPublishedInvocation(capture);
+
+			assert.strictEqual(invocation.state.get().type, IChatToolInvocation.StateKind.WaitingForConfirmation,
+				'preApproved must not override an explicit hook ask');
+
+			IChatToolInvocation.confirmWith(invocation, { type: ToolConfirmKind.UserAction });
+			await invokePromise;
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
@@ -8,7 +8,6 @@ import { Barrier } from '../../../../../../base/common/async.js';
 import { VSBuffer } from '../../../../../../base/common/buffer.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
 import { CancellationError, isCancellationError } from '../../../../../../base/common/errors.js';
-import { autorun } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IAccessibilityService } from '../../../../../../platform/accessibility/common/accessibility.js';
@@ -5019,22 +5018,32 @@ suite('LanguageModelToolsService', () => {
 			const dto = tool.makeDto({ test: 1 }, { sessionId: 'pre-approved' });
 			dto.preApproved = { type: ToolConfirmKind.Setting, id: 'autoApprove' };
 
-			// Record every state the published invocation passes through.
-			const seenStates: IChatToolInvocation.StateKind[] = [];
-			const result = await preApprovedService.invokeTool(dto, async () => 0, CancellationToken.None);
+			// Start the invocation without awaiting so the state at publish time is
+			// observable: an auto-approved call must be published already executing
+			// and must never surface a confirmation prompt (which would flicker
+			// "needs input" in the sessions list).
+			const invokePromise = preApprovedService.invokeTool(dto, async () => 0, CancellationToken.None);
 			const invocation = await waitForPublishedInvocation(capture);
-			store.add(autorun(reader => { seenStates.push(invocation.state.read(reader).type); }));
+			const publishedState = invocation.state.get().type;
+
+			// If the fix regressed, the call would be stuck awaiting confirmation;
+			// confirm it so the promise resolves and the assertion below (rather
+			// than a test timeout) reports the failure.
+			if (publishedState === IChatToolInvocation.StateKind.WaitingForConfirmation) {
+				IChatToolInvocation.confirmWith(invocation, { type: ToolConfirmKind.UserAction });
+			}
+			const result = await invokePromise;
 
 			assert.deepStrictEqual(
 				{
 					invokeCompleted,
 					value: (result.content[0] as IToolResultTextPart).value,
-					sawWaitingForConfirmation: seenStates.includes(IChatToolInvocation.StateKind.WaitingForConfirmation),
+					publishedWaitingForConfirmation: publishedState === IChatToolInvocation.StateKind.WaitingForConfirmation,
 				},
 				{
 					invokeCompleted: true,
 					value: 'success',
-					sawWaitingForConfirmation: false,
+					publishedWaitingForConfirmation: false,
 				},
 			);
 		});


### PR DESCRIPTION
## Problem

When using the **agent host provider**, a tool approval that gets auto-approved (via auto-approve / bypass approvals) briefly flickers in the sessions list: the session shows *"Input needed"* for a moment, then reverts because the call was auto-approved. The same transient state affects other surfaces that observe pending confirmations.

## Root cause

For agent-host **client tool calls**, the invocation was created and first transitioned into the `WaitingForConfirmation` state before a separate autorun confirmed it. That flips the chat model's `requestNeedsInput` observable, which `AgentSessionApprovalModel` feeds into the sessions list — producing the flicker. (Server-driven tools don't flicker because their auto-approval strips the confirmation upstream in `agentSideEffects`.) The local chat path already guarded against this; the agent-host path did not.

## Fix

- Add an optional `preApproved?: ConfirmedReason` field to `IToolInvocation`. When set, the tool service treats the call as already auto-approved and transitions straight to `Executing` — never surfacing `WaitingForConfirmation`.
- `AgentHostSessionHandler._setupClientToolCall` sets `preApproved` from `shouldAutoApproveClientToolCall(tc)` (the `autoApproveBySetting` meta the agent host stamps) when invoking the tool. The existing confirmation autoruns remain as a fallback.
- A preToolUse hook that returns `ask` explicitly forces confirmation and is never overridden by `preApproved`.

## Tests

- `languageModelToolsService.test.ts` — real-service tests: a confirmable tool with `preApproved` never enters `WaitingForConfirmation`; and `preApproved` does **not** override a hook `ask`.
- `agentHostClientTools.test.ts` — regression test asserting the auto-approved client tool never flickers into `WaitingForConfirmation`. Verified it fails without the handler fix.

All affected suites pass (133 + 21).