### PR TITLE
Voice: cancel pending auto-listen when a response frame arrives

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController.ts
@@ -1875,6 +1875,15 @@ export class VoiceSessionController extends Disposable implements IVoiceSessionC
 	// --- Audio FIFO queue ---
 
 	private _enqueueAudio(sessionId: string | undefined, audio: string, isFirstChunk: boolean, isFinal: boolean, transcript: string | undefined): void {
+		// An incoming response frame means the assistant is actively replying, so
+		// cancel any pending auto-listen. Otherwise a debounced listen scheduled
+		// when the previous session's playback stopped can fire mid-response and
+		// its synthetic pttDown suppresses this session's audio. This matters most
+		// when a response leads with a transcript-only frame (empty audio): it
+		// consumes the first-chunk flag without starting playback, so the later
+		// audio chunks arrive as non-first chunks and would be dropped.
+		this._clearAutoListenTimer();
+
 		// User interrupted (pttDown / onSpeechStarted): drop late chunks from the
 		// previous turn. The backend marks the first audio chunk of a new
 		// response with `is_first_chunk: true` — that's our signal that a fresh


### PR DESCRIPTION
Follow-up to #324977.

## Problem
In hands-free voice mode with two concurrent sessions, session 2's response sometimes still isn't read out, even after #324977.

## Root cause
When session 1's playback stops, a debounced auto-listen is scheduled (`_scheduleAutoListen`, 1200ms). If session 2's response then **leads with a transcript-only frame** (empty `audio`, `isFirstChunk=true`), that frame:
- consumes the first-chunk flag (clearing suppression state), but
- starts no TTS playback and does **not** cancel the pending auto-listen timer.

The auto-listen then fires and its synthetic `pttDown()` sets `_suppressIncomingAudio = true` and clears the queue. Session 2's subsequent audio chunks arrive as non-first chunks and get dropped, so nothing is read out.

## Fix
Cancel any pending auto-listen at the top of `_enqueueAudio`. An incoming response frame means the assistant is actively replying, so we must not barge in with a synthetic listen. Re-arming still happens normally via `onPlaybackStopped` once playback ends.

Ref: microsoft/vscode-internalbacklog#8359