### PR TITLE
Voice: default voice to Maya

### DIFF
--- a/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
+++ b/src/vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution.ts
@@ -503,7 +503,7 @@ configurationRegistry.registerConfiguration({
 				nls.localize('agents.voice.voice.daniel', "Daniel."),
 			],
 			description: nls.localize('agents.voice.voice', "The voice used when the assistant reads responses aloud. Changing this while voice mode is connected takes effect immediately."),
-			default: 'victoria_neutral',
+			default: 'maya_neutral',
 			scope: ConfigurationScope.APPLICATION,
 		},
 		'agents.voice.showTranscript': {

--- a/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
+++ b/src/vs/workbench/contrib/chat/browser/voiceClient/voiceClientService.ts
@@ -123,12 +123,12 @@ export class VoiceClientService extends Disposable implements IVoiceClientServic
 	}
 
 	/**
-	 * Resolve the configured voice key (e.g. ``victoria_neutral``) sent to the
+	 * Resolve the configured voice key (e.g. ``maya_neutral``) sent to the
 	 * backend on ``start_session`` and via ``set_voice`` when changed live.
 	 */
 	private _getVoice(): string {
 		const raw = this._configurationService.getValue<string>('agents.voice.voice');
-		return typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : 'victoria_neutral';
+		return typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : 'maya_neutral';
 	}
 
 	private _sendSetVoice(): void {


### PR DESCRIPTION
Changes the default `agents.voice.voice` from Victoria to Maya, and aligns the `_getVoice()` fallback in voiceClientService accordingly so Maya is the default everywhere. Aligns with Codex's bidirectional chat voice.