### PR TITLE
Add eligibility guard for final background todo pass

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -366,7 +366,8 @@ export class AgentIntent extends EditCodeIntent {
 		@IAutomodeService private readonly _automodeService: IAutomodeService,
 		@ILogService private readonly _logService: ILogService,
 		@IToolsService private readonly _toolsService: IToolsService,
-		@ITelemetryService private readonly _telemetryService: ITelemetryService
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@IAuthenticationService private readonly _authenticationService: IAuthenticationService
 	) {
 		super(instantiationService, endpointProvider, configurationService, expService, codeMapperService, workspaceService, { intentInvocation: AgentIntentInvocation, processCodeblocks: false });
 		this._sessionListeners.add(chatSessionService.onDidDisposeChatSession(sessionId => {
@@ -465,23 +466,37 @@ export class AgentIntent extends EditCodeIntent {
 		try {
 			return await super.handleRequest(conversation, request, stream, token, documentContext, agentName, location, chatTelemetry, yieldRequested);
 		} finally {
-			// Fire one final bg todo review pass once the agent loop has ended for
-			// this turn. The per-round passes never see the very last round, so any
-			// task that just completed otherwise stays stuck as 'in-progress'.
-			// Await completion so this final pass runs before we return, while the
-			// request's tool invocation token is (hopefully) still valid.
-
-			if (request.subAgentInvocationId === undefined && request.subAgentName === undefined) {
-				const todoProcessor = this._backgroundTodoProcessors.get(conversation.sessionId);
-				if (todoProcessor) {
-					await raceTimeout(
-						todoProcessor.endTurn(conversation.getLatestTurn().id, request.toolInvocationToken),
-						5000,
-						() => todoProcessor.cancel()
-					);
-				}
-			}
+			await this._runFinalBackgroundTodoPass(conversation, request);
 		}
+	}
+
+	/**
+	 * Fire one final bg todo review pass once the agent loop has ended for this
+	 * turn. The per-round passes never see the very last round, so any task that
+	 * just completed otherwise stays stuck as 'in-progress'. Awaits completion so
+	 * this final pass runs before we return, while the request's tool invocation
+	 * token is (hopefully) still valid.
+	 */
+	private async _runFinalBackgroundTodoPass(conversation: Conversation, request: vscode.ChatRequest): Promise<void> {
+		if (request.subAgentInvocationId !== undefined || request.subAgentName !== undefined) {
+			return;
+		}
+		const todoProcessor = this._backgroundTodoProcessors.get(conversation.sessionId);
+		if (!todoProcessor) {
+			return;
+		}
+		// Only run the final review pass when the background todo agent is still
+		// enabled for the current model. If the user switched to a BYOK (non-CAPI)
+		// model mid-session, the existing processor must not fire against it.
+		const endpoint = await this.endpointProvider.getChatEndpoint(request).catch(() => undefined);
+		if (!endpoint || !isBackgroundTodoAgentEnabled(endpoint, this.configurationService, this.expService, this._authenticationService, request)) {
+			return;
+		}
+		await raceTimeout(
+			todoProcessor.endTurn(conversation.getLatestTurn().id, request.toolInvocationToken),
+			5000,
+			() => todoProcessor.cancel()
+		);
 	}
 
 	private async handleSummarizeCommand(

--- a/extensions/copilot/src/extension/intents/node/test/backgroundTodoEnablement.spec.ts
+++ b/extensions/copilot/src/extension/intents/node/test/backgroundTodoEnablement.spec.ts
@@ -23,7 +23,7 @@ import { IInstantiationService } from '../../../../util/vs/platform/instantiatio
 import { createExtensionUnitTestingServices } from '../../../test/node/services';
 import { TestChatRequest } from '../../../test/node/testHelpers';
 import { ToolName } from '../../../tools/common/toolNames';
-import { AgentIntentInvocation, getAgentTools, isBackgroundTodoAgentEnabled, isTodoToolExplicitlyEnabled } from '../agentIntent';
+import { AgentIntent, AgentIntentInvocation, getAgentTools, isBackgroundTodoAgentEnabled, isTodoToolExplicitlyEnabled } from '../agentIntent';
 
 // ─── isTodoToolExplicitlyEnabled unit tests ──────────────────────
 
@@ -276,3 +276,70 @@ describe('AgentIntentInvocation._maybeStartBackgroundTodoAgentPass subagent guar
 		expect(processorLookups).toBe(0);
 	});
 });
+
+// ─── AgentIntent._runFinalBackgroundTodoPass model-eligibility guard ───
+
+// The final review pass reuses a previously-created processor, so a mid-session
+// switch to a BYOK (non-CAPI) model must not fire it. Like the subagent-guard
+// tests above, we invoke the private method directly against a minimal stub.
+
+describe('AgentIntent._runFinalBackgroundTodoPass model-eligibility guard', () => {
+
+	const capiEndpoint = { urlOrRequestMetadata: { type: RequestType.ChatCompletions }, modelProvider: 'copilot' } as unknown as IChatEndpoint;
+	const byokEndpoint = { urlOrRequestMetadata: 'https://api.example.com/v1/chat', modelProvider: 'custom' } as unknown as IChatEndpoint;
+	const paidToken = new CopilotToken(createTestExtendedTokenInfo({ sku: 'copilot_individual', copilot_plan: 'individual' }));
+
+	function getMethod(): (this: unknown, conversation: unknown, request: unknown) => Promise<void> {
+		return (AgentIntent.prototype as unknown as { _runFinalBackgroundTodoPass: (this: unknown, conversation: unknown, request: unknown) => Promise<void> })._runFinalBackgroundTodoPass;
+	}
+
+	function makeStub(endpoint: IChatEndpoint | undefined, processor: unknown) {
+		return {
+			_backgroundTodoProcessors: { get: (_id: string) => processor },
+			endpointProvider: { getChatEndpoint: async () => endpoint },
+			configurationService: { getExperimentBasedConfig: () => true },
+			expService: {},
+			_authenticationService: { copilotToken: paidToken },
+		};
+	}
+
+	const conversation = { sessionId: 'sess-1', getLatestTurn: () => ({ id: 'turn-1' }) };
+
+	function makeProcessor() {
+		let endTurnCalls = 0;
+		return {
+			get endTurnCalls() { return endTurnCalls; },
+			endTurn: async () => { endTurnCalls++; },
+			cancel: () => { },
+		};
+	}
+
+	test('runs the final pass on a CAPI endpoint with paid auth and experiment on', async () => {
+		const processor = makeProcessor();
+		const request = new TestChatRequest('fix the bug');
+		await getMethod().call(makeStub(capiEndpoint, processor), conversation, request);
+		expect(processor.endTurnCalls).toBe(1);
+	});
+
+	test('does not run the final pass when the model switched to a BYOK (non-CAPI) endpoint', async () => {
+		const processor = makeProcessor();
+		const request = new TestChatRequest('fix the bug');
+		await getMethod().call(makeStub(byokEndpoint, processor), conversation, request);
+		expect(processor.endTurnCalls).toBe(0);
+	});
+
+	test('does not run the final pass for a subagent request', async () => {
+		const processor = makeProcessor();
+		const request = new TestChatRequest('fix the bug');
+		(request as unknown as { subAgentInvocationId: string }).subAgentInvocationId = 'subagent-uuid-1';
+		await getMethod().call(makeStub(capiEndpoint, processor), conversation, request);
+		expect(processor.endTurnCalls).toBe(0);
+	});
+
+	test('does nothing when there is no processor for the session', async () => {
+		const request = new TestChatRequest('fix the bug');
+		await getMethod().call(makeStub(capiEndpoint, undefined), conversation, request);
+		// No throw and nothing to assert beyond reaching here.
+	});
+});
+


### PR DESCRIPTION
Implement a model eligibility guard to prevent the final background todo pass from executing when switching to a BYOK (non-CAPI) model. This ensures that tasks do not incorrectly process under incompatible conditions.

