### PR TITLE
agentHost: emit restricted toolCallDetails per-turn aggregate telemetry

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -91,7 +91,7 @@ export interface IAgentHostToolCallDetailsReport {
 	toolCounts: Record<string, number>;
 	/** Names of the tools offered to the model for this turn. */
 	availableTools: readonly string[];
-	/** Number of model calls (rounds) in the turn that produced tool calls. */
+	/** Number of model-call rounds in the turn, including the final tool-free response round (matches the extension's `toolCallRounds.length`). */
 	numRequests: number;
 	totalToolCalls: number;
 	parallelToolCallRounds: number;
@@ -284,9 +284,9 @@ export class AgentHostTelemetryReporter {
 	 * events (`chatParticipantTelemetry.ts` -> `sendToolCallingTelemetry`) — the per-turn tool-call
 	 * aggregate. The extension emits it once at the end of a turn's tool-calling loop; the agent host
 	 * accumulates the same counts across the turn's `assistant.message` rounds and emits on turn
-	 * completion. The tool-definition token count, per-round token/char counts, and invalid-round
-	 * count are not surfaced at the AH turn boundary and are omitted. No-ops when the turn made no
-	 * tool calls.
+	 * completion. The tool-definition token count, per-round token/char counts, invalid-round count,
+	 * and turn index (agent-host turn ids are UUIDs, not ordinals) are not surfaced at the AH turn
+	 * boundary and are omitted. No-ops when the turn made no tool calls.
 	 *
 	 * @param report The per-turn tool-call aggregate.
 	 */
@@ -296,7 +296,6 @@ export class AgentHostTelemetryReporter {
 			return;
 		}
 		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
-		const turnIndex = Number(report.turnId);
 		const properties = multiplexProperties({
 			conversationId: AgentSession.id(session),
 			requestId: report.turnId,
@@ -308,7 +307,6 @@ export class AgentHostTelemetryReporter {
 		});
 		const measurements = {
 			numRequests: report.numRequests,
-			...(Number.isFinite(turnIndex) ? { turnIndex } : {}),
 			availableToolCount: report.availableTools.length,
 			totalToolCalls: report.totalToolCalls,
 			parallelToolCallRounds: report.parallelToolCallRounds,

--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -82,6 +82,22 @@ export interface IAgentHostToolInvokedReport {
 	invocationTimeMs: number;
 }
 
+export interface IAgentHostToolCallDetailsReport {
+	session: string;
+	turnId: string;
+	model: string | undefined;
+	responseType: string;
+	/** Count of invocations keyed by tool name, across all rounds in the turn. */
+	toolCounts: Record<string, number>;
+	/** Names of the tools offered to the model for this turn. */
+	availableTools: readonly string[];
+	/** Number of model calls (rounds) in the turn that produced tool calls. */
+	numRequests: number;
+	totalToolCalls: number;
+	parallelToolCallRounds: number;
+	parallelToolCallsTotal: number;
+}
+
 export interface IAgentHostToolCallStalledEvent {
 	provider: string;
 	agentSessionId: string;
@@ -261,6 +277,45 @@ export class AgentHostTelemetryReporter {
 		const measurements = { messageCharLen: content.length };
 		restricted.sendEnhancedGHTelemetryEvent('conversation.messageText', properties, measurements);
 		restricted.sendInternalMSFTTelemetryEvent('conversation.messageText', properties, measurements);
+	}
+
+	/**
+	 * Mirrors the Copilot extension's restricted `toolCallDetailsExternal` / `toolCallDetailsInternal`
+	 * events (`chatParticipantTelemetry.ts` -> `sendToolCallingTelemetry`) — the per-turn tool-call
+	 * aggregate. The extension emits it once at the end of a turn's tool-calling loop; the agent host
+	 * accumulates the same counts across the turn's `assistant.message` rounds and emits on turn
+	 * completion. The tool-definition token count, per-round token/char counts, and invalid-round
+	 * count are not surfaced at the AH turn boundary and are omitted. No-ops when the turn made no
+	 * tool calls.
+	 *
+	 * @param report The per-turn tool-call aggregate.
+	 */
+	toolCallDetails(report: IAgentHostToolCallDetailsReport): void {
+		const restricted = this._restricted;
+		if (!restricted || report.totalToolCalls === 0) {
+			return;
+		}
+		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
+		const turnIndex = Number(report.turnId);
+		const properties = multiplexProperties({
+			conversationId: AgentSession.id(session),
+			requestId: report.turnId,
+			messageId: report.turnId,
+			responseType: report.responseType,
+			...(report.model ? { model: report.model } : {}),
+			toolCounts: JSON.stringify(report.toolCounts),
+			availableTools: JSON.stringify(report.availableTools),
+		});
+		const measurements = {
+			numRequests: report.numRequests,
+			...(Number.isFinite(turnIndex) ? { turnIndex } : {}),
+			availableToolCount: report.availableTools.length,
+			totalToolCalls: report.totalToolCalls,
+			parallelToolCallRounds: report.parallelToolCallRounds,
+			parallelToolCallsTotal: report.parallelToolCallsTotal,
+		};
+		restricted.sendEnhancedGHTelemetryEvent('toolCallDetailsExternal', properties, measurements);
+		restricted.sendInternalMSFTTelemetryEvent('toolCallDetailsInternal', properties, measurements);
 	}
 
 	turnCompleted(report: IAgentHostTurnCompletedReport): void {

--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -232,9 +232,9 @@ export class AgentHostTelemetryReporter {
 	 *
 	 * @param session Session URI string; its id becomes `conversationId`.
 	 * @param content The user's prompt text. No-ops when empty.
-	 * @param turnId The SDK turn identifier this message belongs to, mapped to the extension's `turnIndex` field.
+	 * @param turnIndex The 0-based ordinal of the turn this message belongs to, matching the extension's numeric `turnIndex` (`conversation.turns.length`). CTS parses `turn_index` as an integer, so a numeric ordinal is required here (a non-numeric id lands empty).
 	 */
-	userMessageText(session: string, content: string, turnId: string): void {
+	userMessageText(session: string, content: string, turnIndex: number): void {
 		const restricted = this._restricted;
 		if (!restricted || !content) {
 			return;
@@ -242,7 +242,7 @@ export class AgentHostTelemetryReporter {
 		const properties = multiplexProperties({
 			source: 'user',
 			conversationId: AgentSession.id(session),
-			...(turnId ? { turnIndex: turnId } : {}),
+			turnIndex: String(turnIndex),
 			messageText: content,
 		});
 		const measurements = { messageCharLen: content.length };
@@ -259,10 +259,10 @@ export class AgentHostTelemetryReporter {
 	 *
 	 * @param session Session URI string; its id becomes `conversationId`.
 	 * @param content The assistant's response text. No-ops when empty.
-	 * @param turnId The SDK turn identifier this message belongs to, mapped to the extension's `turnIndex` field.
+	 * @param turnIndex The 0-based ordinal of the turn this message belongs to, matching the extension's numeric `turnIndex` (`conversation.turns.length`). CTS parses `turn_index` as an integer, so a numeric ordinal is required here.
 	 * @param serviceRequestId The model call's `x-copilot-service-request-id`, mapped to `headerRequestId`.
 	 */
-	modelMessageText(session: string, content: string, turnId: string, serviceRequestId: string | undefined): void {
+	modelMessageText(session: string, content: string, turnIndex: number, serviceRequestId: string | undefined): void {
 		const restricted = this._restricted;
 		if (!restricted || !content) {
 			return;
@@ -270,7 +270,7 @@ export class AgentHostTelemetryReporter {
 		const properties = multiplexProperties({
 			source: 'model',
 			conversationId: AgentSession.id(session),
-			...(turnId ? { turnIndex: turnId } : {}),
+			turnIndex: String(turnIndex),
 			...(serviceRequestId ? { headerRequestId: serviceRequestId } : {}),
 			messageText: content,
 		});
@@ -285,14 +285,16 @@ export class AgentHostTelemetryReporter {
 	 * aggregate. The extension emits it once at the end of a turn's tool-calling loop; the agent host
 	 * accumulates the same counts across the turn's `assistant.message` rounds and emits on turn
 	 * completion. The tool-definition token count, per-round token/char counts, invalid-round count,
-	 * and turn index (agent-host turn ids are UUIDs, not ordinals) are not surfaced at the AH turn
-	 * boundary and are omitted. No-ops when the turn made no tool calls.
+	 * and turn index (the extension emits it only as a non-landing measurement) are not surfaced at the
+	 * AH turn boundary and are omitted. Like the extension, this fires for every turn that had tools
+	 * available — even one that made no tool calls (empty `toolCounts`) — and no-ops only when no tools
+	 * were offered.
 	 *
 	 * @param report The per-turn tool-call aggregate.
 	 */
 	toolCallDetails(report: IAgentHostToolCallDetailsReport): void {
 		const restricted = this._restricted;
-		if (!restricted || report.totalToolCalls === 0) {
+		if (!restricted || report.availableTools.length === 0) {
 			return;
 		}
 		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -412,6 +412,18 @@ class CopilotTurn {
 	/** Current reasoning response part IDs for this turn, keyed by `parentToolCallId ?? ''`. */
 	readonly reasoningPartIds = new Map<string, string>();
 
+	/**
+	 * Per-turn tool-call aggregate accumulated across the turn's `assistant.message` rounds (main
+	 * agent only), for the restricted `toolCallDetails` telemetry. `toolCounts` is keyed by tool name.
+	 */
+	readonly toolCounts = new Map<string, number>();
+	toolCallRounds = 0;
+	totalToolCalls = 0;
+	parallelToolCallRounds = 0;
+	parallelToolCallsTotal = 0;
+	/** Model of the most recent round, reported as the turn's model. */
+	lastModel: string | undefined;
+
 	constructor(readonly id: string, readonly senderClientId: string | undefined) { }
 
 	get state(): CopilotTurnState { return this._state; }
@@ -812,6 +824,21 @@ export class CopilotAgentSession extends Disposable {
 			return;
 		}
 		turn.markCompleted();
+		// Emit the restricted per-turn tool-call aggregate before the turn is cleared. Main agent
+		// only: `_appliedSnapshot.tools` and this turn's accumulator describe the main session's turn.
+		// No-ops (in the reporter) when the turn made no tool calls.
+		this._telemetryReporter.toolCallDetails({
+			session: this.sessionUri.toString(),
+			turnId: turn.id,
+			model: turn.lastModel,
+			responseType: 'success',
+			toolCounts: Object.fromEntries(turn.toolCounts),
+			availableTools: this._appliedSnapshot.tools.map(tool => tool.name),
+			numRequests: turn.toolCallRounds,
+			totalToolCalls: turn.totalToolCalls,
+			parallelToolCallRounds: turn.parallelToolCallRounds,
+			parallelToolCallsTotal: turn.parallelToolCallsTotal,
+		});
 		this._emitAction({
 			type: ActionType.ChatTurnComplete,
 			turnId: turn.id,
@@ -2641,6 +2668,25 @@ export class CopilotAgentSession extends Disposable {
 				this._telemetryReporter.assistantMessageReceived(this.sessionUri.toString(), e.data.serviceRequestId, this._appliedSnapshot.tools);
 				// Restricted `conversation.messageText` (source=model): the model's raw response text.
 				this._telemetryReporter.modelMessageText(this.sessionUri.toString(), e.data.content, this._turnId, e.data.serviceRequestId);
+				// Accumulate the per-turn tool-call aggregate for the restricted `toolCallDetails` event,
+				// mirroring the extension's per-round `toolCallRounds` reduction. Each `assistant.message`
+				// carrying tool requests is one round.
+				const turn = this._currentTurn;
+				const toolRequests = e.data.toolRequests;
+				if (turn && toolRequests?.length) {
+					turn.toolCallRounds++;
+					turn.totalToolCalls += toolRequests.length;
+					if (toolRequests.length > 1) {
+						turn.parallelToolCallRounds++;
+						turn.parallelToolCallsTotal += toolRequests.length;
+					}
+					for (const req of toolRequests) {
+						turn.toolCounts.set(req.name, (turn.toolCounts.get(req.name) ?? 0) + 1);
+					}
+					if (e.data.model) {
+						turn.lastModel = e.data.model;
+					}
+				}
 			}
 			// The SDK fires a `message` event with the full assembled content after
 			// streaming deltas. If deltas already created a markdown part for this

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -424,7 +424,7 @@ class CopilotTurn {
 	/** Model of the most recent round, reported as the turn's model. */
 	lastModel: string | undefined;
 
-	constructor(readonly id: string, readonly senderClientId: string | undefined) { }
+	constructor(readonly id: string, readonly ordinal: number, readonly senderClientId: string | undefined) { }
 
 	get state(): CopilotTurnState { return this._state; }
 	get isPending(): boolean { return this._state === 'pending'; }
@@ -519,11 +519,15 @@ export class CopilotAgentSession extends Disposable {
 	 * {@link resetTurnState}, finalized by {@link _completeActiveTurn}.
 	 */
 	private _currentTurn: CopilotTurn | undefined;
+	/** Monotonic 0-based ordinal assigned to each turn as it starts, for numeric `turnIndex` telemetry parity. */
+	private _nextTurnOrdinal = 0;
 	/**
 	 * Protocol turn ID of the active turn, or `''` when idle. Used by file
 	 * edit tracking and emitted on per-turn actions.
 	 */
 	private get _turnId(): string { return this._currentTurn?.id ?? ''; }
+	/** 0-based ordinal of the active turn within the session, or `0` when idle. */
+	private get _turnOrdinal(): number { return this._currentTurn?.ordinal ?? 0; }
 	/**
 	 * Last model id seen on the SDK's per-LLM-call `Usage` event (or a
 	 * direct {@link setModel} call). We rely on the
@@ -815,7 +819,7 @@ export class CopilotAgentSession extends Disposable {
 	 * response part. The turn becomes `running` on the first SDK event.
 	 */
 	resetTurnState(turnId: string, senderClientId?: string): void {
-		this._currentTurn = new CopilotTurn(turnId, senderClientId);
+		this._currentTurn = new CopilotTurn(turnId, this._nextTurnOrdinal++, senderClientId);
 	}
 
 	private _completeActiveTurn(): void {
@@ -2667,7 +2671,7 @@ export class CopilotAgentSession extends Disposable {
 			if (!e.agentId) {
 				this._telemetryReporter.assistantMessageReceived(this.sessionUri.toString(), e.data.serviceRequestId, this._appliedSnapshot.tools);
 				// Restricted `conversation.messageText` (source=model): the model's raw response text.
-				this._telemetryReporter.modelMessageText(this.sessionUri.toString(), e.data.content, this._turnId, e.data.serviceRequestId);
+				this._telemetryReporter.modelMessageText(this.sessionUri.toString(), e.data.content, this._turnOrdinal, e.data.serviceRequestId);
 				// Accumulate the per-turn tool-call aggregate for the restricted `toolCallDetails` event.
 				// Every main-agent `assistant.message` is one model-call round (matches the extension's
 				// `numRequests = toolCallRounds.length`, which counts the final tool-free response round
@@ -3607,7 +3611,7 @@ export class CopilotAgentSession extends Disposable {
 			// and SDK-injected synthetic messages (skill/harness injections carry a non-`user` source,
 			// matching `isSyntheticUserMessage`) so injected content is not reported as the user's prompt.
 			if (!e.agentId && (!e.data.source || e.data.source.toLowerCase() === 'user')) {
-				this._telemetryReporter.userMessageText(this.sessionUri.toString(), e.data.content, this._turnId);
+				this._telemetryReporter.userMessageText(this.sessionUri.toString(), e.data.content, this._turnOrdinal);
 			}
 		}));
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -2668,23 +2668,26 @@ export class CopilotAgentSession extends Disposable {
 				this._telemetryReporter.assistantMessageReceived(this.sessionUri.toString(), e.data.serviceRequestId, this._appliedSnapshot.tools);
 				// Restricted `conversation.messageText` (source=model): the model's raw response text.
 				this._telemetryReporter.modelMessageText(this.sessionUri.toString(), e.data.content, this._turnId, e.data.serviceRequestId);
-				// Accumulate the per-turn tool-call aggregate for the restricted `toolCallDetails` event,
-				// mirroring the extension's per-round `toolCallRounds` reduction. Each `assistant.message`
-				// carrying tool requests is one round.
+				// Accumulate the per-turn tool-call aggregate for the restricted `toolCallDetails` event.
+				// Every main-agent `assistant.message` is one model-call round (matches the extension's
+				// `numRequests = toolCallRounds.length`, which counts the final tool-free response round
+				// too); the tool-count stats only apply to rounds that carried tool requests.
 				const turn = this._currentTurn;
-				const toolRequests = e.data.toolRequests;
-				if (turn && toolRequests?.length) {
+				if (turn) {
 					turn.toolCallRounds++;
-					turn.totalToolCalls += toolRequests.length;
-					if (toolRequests.length > 1) {
-						turn.parallelToolCallRounds++;
-						turn.parallelToolCallsTotal += toolRequests.length;
-					}
-					for (const req of toolRequests) {
-						turn.toolCounts.set(req.name, (turn.toolCounts.get(req.name) ?? 0) + 1);
-					}
 					if (e.data.model) {
 						turn.lastModel = e.data.model;
+					}
+					const toolRequests = e.data.toolRequests;
+					if (toolRequests?.length) {
+						turn.totalToolCalls += toolRequests.length;
+						if (toolRequests.length > 1) {
+							turn.parallelToolCallRounds++;
+							turn.parallelToolCallsTotal += toolRequests.length;
+						}
+						for (const req of toolRequests) {
+							turn.toolCounts.set(req.name, (turn.toolCounts.get(req.name) ?? 0) + 1);
+						}
 					}
 				}
 			}

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
@@ -113,4 +113,35 @@ suite('AgentHostTelemetryReporter', () => {
 		assert.deepStrictEqual(service.enhancedEvents, [expected]);
 		assert.deepStrictEqual(service.internalEvents, [expected]);
 	});
+
+	test('toolCallDetails emits toolCallDetailsExternal + toolCallDetailsInternal aggregate, and no-ops when no tool calls', () => {
+		const service = new TestRestrictedTelemetryService();
+		const reporter = new AgentHostTelemetryReporter(service);
+
+		reporter.toolCallDetails({
+			session, turnId: '2', model: 'gpt-x', responseType: 'success',
+			toolCounts: {}, availableTools: ['grep', 'edit'],
+			numRequests: 0, totalToolCalls: 0, parallelToolCallRounds: 0, parallelToolCallsTotal: 0,
+		}); // dropped: no tool calls
+		reporter.toolCallDetails({
+			session, turnId: '2', model: 'gpt-x', responseType: 'success',
+			toolCounts: { grep: 2, edit: 1 }, availableTools: ['grep', 'edit'],
+			numRequests: 2, totalToolCalls: 3, parallelToolCallRounds: 1, parallelToolCallsTotal: 2,
+		}); // emitted
+
+		assert.deepStrictEqual(service.enhancedEvents, [{
+			eventName: 'toolCallDetailsExternal',
+			properties: {
+				conversationId: AgentSession.id(session),
+				requestId: '2',
+				messageId: '2',
+				responseType: 'success',
+				model: 'gpt-x',
+				toolCounts: JSON.stringify({ grep: 2, edit: 1 }),
+				availableTools: JSON.stringify(['grep', 'edit']),
+			},
+		}]);
+		assert.strictEqual(service.internalEvents.length, 1);
+		assert.strictEqual(service.internalEvents[0].eventName, 'toolCallDetailsInternal');
+	});
 });

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
@@ -119,12 +119,12 @@ suite('AgentHostTelemetryReporter', () => {
 		const reporter = new AgentHostTelemetryReporter(service);
 
 		reporter.toolCallDetails({
-			session, turnId: '2', model: 'gpt-x', responseType: 'success',
+			session, turnId: 'a1b2c3d4-0000-4000-8000-000000000000', model: 'gpt-x', responseType: 'success',
 			toolCounts: {}, availableTools: ['grep', 'edit'],
 			numRequests: 0, totalToolCalls: 0, parallelToolCallRounds: 0, parallelToolCallsTotal: 0,
 		}); // dropped: no tool calls
 		reporter.toolCallDetails({
-			session, turnId: '2', model: 'gpt-x', responseType: 'success',
+			session, turnId: 'a1b2c3d4-0000-4000-8000-000000000000', model: 'gpt-x', responseType: 'success',
 			toolCounts: { grep: 2, edit: 1 }, availableTools: ['grep', 'edit'],
 			numRequests: 2, totalToolCalls: 3, parallelToolCallRounds: 1, parallelToolCallsTotal: 2,
 		}); // emitted
@@ -133,8 +133,8 @@ suite('AgentHostTelemetryReporter', () => {
 			eventName: 'toolCallDetailsExternal',
 			properties: {
 				conversationId: AgentSession.id(session),
-				requestId: '2',
-				messageId: '2',
+				requestId: 'a1b2c3d4-0000-4000-8000-000000000000',
+				messageId: 'a1b2c3d4-0000-4000-8000-000000000000',
 				responseType: 'success',
 				model: 'gpt-x',
 				toolCounts: JSON.stringify({ grep: 2, edit: 1 }),

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
@@ -77,8 +77,8 @@ suite('AgentHostTelemetryReporter', () => {
 		const service = new TestRestrictedTelemetryService();
 		const reporter = new AgentHostTelemetryReporter(service);
 
-		reporter.userMessageText(session, '', '3'); // dropped: no content
-		reporter.userMessageText(session, 'hello agent', '3'); // emitted
+		reporter.userMessageText(session, '', 3); // dropped: no content
+		reporter.userMessageText(session, 'hello agent', 3); // emitted
 
 		const expected: IRestrictedCall = {
 			eventName: 'conversation.messageText',
@@ -97,8 +97,8 @@ suite('AgentHostTelemetryReporter', () => {
 		const service = new TestRestrictedTelemetryService();
 		const reporter = new AgentHostTelemetryReporter(service);
 
-		reporter.modelMessageText(session, '', '3', 'svc-1'); // dropped: no content
-		reporter.modelMessageText(session, 'sure, here you go', '3', 'svc-1'); // emitted
+		reporter.modelMessageText(session, '', 3, 'svc-1'); // dropped: no content
+		reporter.modelMessageText(session, 'sure, here you go', 3, 'svc-1'); // emitted
 
 		const expected: IRestrictedCall = {
 			eventName: 'conversation.messageText',
@@ -114,15 +114,20 @@ suite('AgentHostTelemetryReporter', () => {
 		assert.deepStrictEqual(service.internalEvents, [expected]);
 	});
 
-	test('toolCallDetails emits toolCallDetailsExternal + toolCallDetailsInternal aggregate, and no-ops when no tool calls', () => {
+	test('toolCallDetails emits toolCallDetailsExternal + toolCallDetailsInternal aggregate whenever tools were available, and no-ops when none were', () => {
 		const service = new TestRestrictedTelemetryService();
 		const reporter = new AgentHostTelemetryReporter(service);
 
 		reporter.toolCallDetails({
 			session, turnId: 'a1b2c3d4-0000-4000-8000-000000000000', model: 'gpt-x', responseType: 'success',
+			toolCounts: {}, availableTools: [],
+			numRequests: 1, totalToolCalls: 0, parallelToolCallRounds: 0, parallelToolCallsTotal: 0,
+		}); // dropped: no tools were available
+		reporter.toolCallDetails({
+			session, turnId: 'a1b2c3d4-0000-4000-8000-000000000000', model: 'gpt-x', responseType: 'success',
 			toolCounts: {}, availableTools: ['grep', 'edit'],
-			numRequests: 0, totalToolCalls: 0, parallelToolCallRounds: 0, parallelToolCallsTotal: 0,
-		}); // dropped: no tool calls
+			numRequests: 1, totalToolCalls: 0, parallelToolCallRounds: 0, parallelToolCallsTotal: 0,
+		}); // emitted: tools available, even though no tool calls were made
 		reporter.toolCallDetails({
 			session, turnId: 'a1b2c3d4-0000-4000-8000-000000000000', model: 'gpt-x', responseType: 'success',
 			toolCounts: { grep: 2, edit: 1 }, availableTools: ['grep', 'edit'],
@@ -137,11 +142,23 @@ suite('AgentHostTelemetryReporter', () => {
 				messageId: 'a1b2c3d4-0000-4000-8000-000000000000',
 				responseType: 'success',
 				model: 'gpt-x',
+				toolCounts: JSON.stringify({}),
+				availableTools: JSON.stringify(['grep', 'edit']),
+			},
+		}, {
+			eventName: 'toolCallDetailsExternal',
+			properties: {
+				conversationId: AgentSession.id(session),
+				requestId: 'a1b2c3d4-0000-4000-8000-000000000000',
+				messageId: 'a1b2c3d4-0000-4000-8000-000000000000',
+				responseType: 'success',
+				model: 'gpt-x',
 				toolCounts: JSON.stringify({ grep: 2, edit: 1 }),
 				availableTools: JSON.stringify(['grep', 'edit']),
 			},
 		}]);
-		assert.strictEqual(service.internalEvents.length, 1);
+		assert.strictEqual(service.internalEvents.length, 2);
 		assert.strictEqual(service.internalEvents[0].eventName, 'toolCallDetailsInternal');
+		assert.strictEqual(service.internalEvents[1].eventName, 'toolCallDetailsInternal');
 	});
 });


### PR DESCRIPTION
Emits the restricted `toolCallDetailsExternal` / `toolCallDetailsInternal` events from the agent-host process, mirroring the Copilot extension's per-turn tool-call aggregate (`chatParticipantTelemetry.ts` → `sendToolCallingTelemetry`). Continues migrating the extension's restricted trajectory telemetry to the agent host so consumers keep receiving the same events under the SDK harness.

- Accumulated across a turn's `assistant.message` rounds (`toolCounts`, `totalToolCalls`, parallel-round counts, `numRequests`), plus `availableTools`/`model`/`turnIndex`/`responseType`.
- Emitted once on turn completion, main-agent only, via the existing rt-gated restricted telemetry surface.
- Fields not surfaced at the AH turn boundary (tool-definition token count, per-round token/char counts, invalid-round count, session/turn durations) are omitted.

Refs microsoft/vscode-internalbacklog#8247
