### PR TITLE
Make file explorer title respect associated workspace folder capitalization

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/fontRamp.css
@@ -137,13 +137,14 @@
 }
 
 /*
- * File Explorer root header — respect the real casing of the workspace / folder
- * name (user input). `text-transform: none` overrides both the base
- * `uppercase` rule and the `capitalize` override above (the `:has(...)`
- * argument raises specificity). System labels such as "Untitled (Workspace)"
- * are already title-cased in source, so they still render correctly; only
- * user-provided folder names (e.g. "vscode-dev") are left untouched.
+ * File Explorer titles — respect the real casing of the workspace / folder name
+ * (user input). `text-transform: none` overrides both the base `uppercase` rule
+ * and the `capitalize` override above (the `:has(...)` argument raises
+ * specificity). System labels such as "Untitled (Workspace)" are already
+ * title-cased in source, so they still render correctly; only user-provided
+ * folder names (e.g. "vscode-dev") are left untouched.
  */
+.style-override.monaco-workbench .part:not(.editor):has(> .content > .composite.explorer-viewlet) > .title > .title-label h2,
 .style-override .monaco-pane-view .pane > .pane-header:has(> .icon.codicon-explorer-view-icon) > .title {
 	text-transform: none;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/324642

File explorer view title will now perfectly reflect the capitalization used by the associated workspace folder.

<img width="404" height="255" alt="Screenshot 2026-07-08 at 2 43 17 PM" src="https://github.com/user-attachments/assets/57aaa9ca-e79c-47cc-80e4-3687451afd29" />
