### PR TITLE
Add explicit message item types to Responses API

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -455,19 +455,19 @@ function rawMessagesToResponseAPI(modelId: string, messages: readonly Raw.ChatMe
 						// todod@connor4312: hack while responses API only supports text output from tools
 						input.push({ type: 'function_call_output', call_id: message.toolCallId, output: asText });
 						if (asImages.length) {
-							input.push({ role: 'user', content: [{ type: 'input_text', text: 'Image associated with the above tool call:' }, ...asImages] });
+							input.push({ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Image associated with the above tool call:' }, ...asImages] });
 						}
 						if (asFiles.length) {
-							input.push({ role: 'user', content: [{ type: 'input_text', text: 'PDF associated with the above tool call:' }, ...asFiles] });
+							input.push({ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'PDF associated with the above tool call:' }, ...asFiles] });
 						}
 					}
 				}
 				break;
 			case Raw.ChatRole.User:
-				input.push({ role: 'user', content: message.content.map(rawContentToResponsesContent).filter(isDefined) });
+				input.push({ type: 'message', role: 'user', content: message.content.map(rawContentToResponsesContent).filter(isDefined) });
 				break;
 			case Raw.ChatRole.System:
-				input.push({ role: 'system', content: message.content.map(rawContentToResponsesContent).filter(isDefined) });
+				input.push({ type: 'message', role: 'system', content: message.content.map(rawContentToResponsesContent).filter(isDefined) });
 				break;
 		}
 

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -427,6 +427,7 @@ describe('createResponsesRequestBody', () => {
 		const body = instantiationService.invokeFunction(servicesAccessor => createResponsesRequestBody(servicesAccessor, createRequestOptions(messages, false), endpoint.model, endpoint));
 
 		expect(body.input?.[0]).toMatchObject({
+			type: 'message',
 			role: 'user',
 			content: [{
 				type: 'input_file',
@@ -461,6 +462,7 @@ describe('createResponsesRequestBody', () => {
 
 		expect(body.input?.[1]).toMatchObject({ type: 'function_call_output', call_id: 'call_pdf', output: '' });
 		expect(body.input?.[2]).toMatchObject({
+			type: 'message',
 			role: 'user',
 			content: [
 				{ type: 'input_text', text: 'PDF associated with the above tool call:' },
@@ -535,6 +537,7 @@ describe('createResponsesRequestBody', () => {
 			encrypted_content: 'enc_ws',
 		});
 		expect(webSocketBody.input).toContainEqual({
+			type: 'message',
 			role: 'user',
 			content: [{ type: 'input_text', text: 'after marker' }],
 		});
@@ -759,6 +762,7 @@ describe('createResponsesRequestBody', () => {
 			encrypted_content: 'enc_http',
 		});
 		expect(body.input).toContainEqual({
+			type: 'message',
 			role: 'user',
 			content: [{ type: 'input_text', text: 'after marker' }],
 		});
@@ -980,6 +984,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		const body = buildBody(messages);
 
 		expect(body.input?.[0]).toMatchObject({
+			type: 'message',
 			role: 'user',
 			content: [
 				{ type: 'input_text', text: 'first' },
@@ -1001,6 +1006,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		const body = buildBody(messages);
 
 		expect(body.input?.[0]).toMatchObject({
+			type: 'message',
 			role: 'system',
 			content: [{ type: 'input_text', text: 'be concise', prompt_cache_breakpoint: expectedPromptCacheBreakpoint }],
 		});
@@ -1098,6 +1104,7 @@ describe('createResponsesRequestBody prompt_cache_breakpoint markers', () => {
 		const body = buildBody(messages);
 
 		expect(body.input?.at(-1)).toMatchObject({
+			type: 'message',
 			role: 'user',
 			content: [
 				{ type: 'input_text', text: 'Image associated with the above tool call:' },


### PR DESCRIPTION
fixes #318125 by adding the explicit `type: 'message'` field to all Responses input items that carry a message `role`. This change ensures compatibility with stricter endpoints, such as the Azure Foundry project endpoint, which requires this field for successful validation.

### Changes made:
- Updated `responsesApi.ts` to include `type: 'message'` for:
  - Tool-result image follow-up messages
  - Tool-result PDF follow-up messages
  - User messages
  - System messages
- Enhanced `responsesApi.spec.ts` to:
  - Assert the presence of `type: 'message'` for all relevant message types.
  - Update existing tests to accommodate the new field without causing regressions.

### Rationale:
- The explicit `type` field aligns with the documented canonical shape of the OpenAI Responses API, which states that the type should always be `message`.
- This change prevents potential request rejections from stricter endpoints and maintains consistency with existing assistant message handling.

### Testing:
- All tests have been run successfully, confirming that the changes do not introduce regressions and that the new field is correctly integrated into the existing framework.