### PR TITLE
Tweak collapsible view chevron positioning

### DIFF
--- a/src/vs/base/browser/ui/splitview/paneview.css
+++ b/src/vs/base/browser/ui/splitview/paneview.css
@@ -50,6 +50,10 @@
 	margin: 0 2px;
 }
 
+.monaco-pane-view .pane > .pane-header.expanded > .codicon:first-of-type {
+	transform: translateY(1px);
+}
+
 .monaco-pane-view .pane.horizontal:not(.expanded) > .pane-header > .codicon:first-of-type {
 	margin: 2px;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/325011

Tweaks the chevron positioning in collapsible view components to optically align with the label it sits next too. This change only applies to chevron icons when the view is open –– closed chevrons are not moved.

Note: While under the "modernization" banner, I'm just making this change directly to existing VS Code, rather than hiding behind modern UI setting.

https://github.com/user-attachments/assets/d39862a4-c291-4581-b2e3-14fcdc506909