### PR TITLE
fix(mcp): correct sinon fake timers type for @types/sinon >=17

### DIFF
--- a/src/vs/workbench/contrib/mcp/test/common/mcpSamplingLog.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpSamplingLog.test.ts
@@ -36,7 +36,7 @@ suite('MCP - Sampling Log', () => {
 		// fail the renderer's no-console-output assertion. The option exists in
 		// @sinonjs/fake-timers but is missing from the @types/sinon typings, so
 		// we widen the config type locally.
-		const fakeTimerOpts: Partial<sinon.SinonFakeTimersConfig> & { shouldClearNativeTimers: boolean } = { shouldClearNativeTimers: true };
+		const fakeTimerOpts = { shouldClearNativeTimers: true } as Parameters<typeof sinon.useFakeTimers>[0];
 		clock = sinon.useFakeTimers(fakeTimerOpts);
 		clock.setSystemTime(new Date('2023-10-01T00:00:00Z').getTime());
 	});


### PR DESCRIPTION
@types/sinon removed SinonFakeTimersConfig alias in favor of FakeTimers.FakeTimerInstallOpts exported via Parameters helper. Update mcpSamplingLog test to use Parameters<typeof sinon.useFakeTimers> to unblock npm run compile on Node 24 / TS 5.9.

Fixes TS2724: 'Sinon' has no exported member named 'SinonFakeTimersConfig'

This change was required to successfully build the Modernity IDE fork locally as documented in ide/README.md running instructions updated 2026-07. Without this patch npm run compile fails at src/vs/workbench contrib mcp test with tsgo exit code 1.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
