### PR TITLE
sessions: cache configuration default overrides and fix reloadConfiguration in agents window

### DIFF
--- a/src/vs/sessions/browser/web.main.ts
+++ b/src/vs/sessions/browser/web.main.ts
@@ -24,6 +24,8 @@ import { BrowserMain, IBrowserMainWorkbench } from '../../workbench/browser/web.
 import { getWorkspaceIdentifier } from '../../platform/workspaces/common/workspaceIdentifier.js';
 import { SessionsWorkspaceContextService } from '../services/workspace/browser/workspaceContextService.js';
 import { ConfigurationService } from '../services/configuration/browser/configurationService.js';
+import { ConfigurationCache } from '../../workbench/services/configuration/common/configurationCache.js';
+import { Schemas } from '../../base/common/network.js';
 import { createSessionsWorkbench } from './workbenchFactory.js';
 
 export class SessionsBrowserMain extends BrowserMain {
@@ -59,13 +61,16 @@ export class SessionsBrowserMain extends BrowserMain {
 
 		// Configuration — the sessions ConfigurationService works against the
 		// in-memory workspace model rather than a real .code-workspace file on disk.
+		const configurationCache = new ConfigurationCache([Schemas.file, Schemas.vscodeUserData], environmentService, fileService);
 		const configurationService = new ConfigurationService(
 			userDataProfileService,
 			workspaceContextService,
 			uriIdentityService,
 			fileService,
 			policyService,
-			logService
+			logService,
+			configurationCache,
+			environmentService,
 		);
 
 		try {

--- a/src/vs/sessions/electron-browser/sessions.main.ts
+++ b/src/vs/sessions/electron-browser/sessions.main.ts
@@ -70,6 +70,7 @@ import { createSessionsWorkbench } from '../browser/workbenchFactory.js';
 import { NativeMenubarControl } from '../../workbench/electron-browser/parts/titlebar/menubarControl.js';
 import { IWorkspaceEditingService } from '../../workbench/services/workspaces/common/workspaceEditing.js';
 import { ConfigurationService } from '../services/configuration/browser/configurationService.js';
+import { ConfigurationCache } from '../../workbench/services/configuration/common/configurationCache.js';
 import { SessionsWorkspaceContextService } from '../services/workspace/browser/workspaceContextService.js';
 import { getWorkspaceIdentifier } from '../../platform/workspaces/common/workspaceIdentifier.js';
 
@@ -309,7 +310,7 @@ export class SessionsMain extends Disposable {
 		serviceCollection.set(IWorkspaceEditingService, workspaceContextService);
 
 		const [configurationService, storageService] = await Promise.all([
-			this.createConfigurationService(workspaceContextService, userDataProfileService, uriIdentityService, fileService, logService, policyService).then(configurationService => {
+			this.createConfigurationService(workspaceContextService, userDataProfileService, uriIdentityService, fileService, logService, policyService, environmentService).then(configurationService => {
 
 				// Configuration
 				serviceCollection.set(IWorkbenchConfigurationService, configurationService);
@@ -361,9 +362,11 @@ export class SessionsMain extends Disposable {
 		uriIdentityService: IUriIdentityService,
 		fileService: FileService,
 		logService: ILogService,
-		policyService: IPolicyService
+		policyService: IPolicyService,
+		environmentService: INativeWorkbenchEnvironmentService,
 	): Promise<ConfigurationService> {
-		const configurationService = new ConfigurationService(userDataProfileService, workspaceContextService, uriIdentityService, fileService, policyService, logService);
+		const configurationCache = new ConfigurationCache([Schemas.file, Schemas.vscodeUserData], environmentService, fileService);
+		const configurationService = new ConfigurationService(userDataProfileService, workspaceContextService, uriIdentityService, fileService, policyService, logService, configurationCache, environmentService);
 		try {
 			await configurationService.initialize();
 		} catch (error) {

--- a/src/vs/sessions/services/configuration/browser/configurationService.ts
+++ b/src/vs/sessions/services/configuration/browser/configurationService.ts
@@ -19,7 +19,7 @@ import { OS, OperatingSystem } from '../../../../base/common/platform.js';
 import { IConfigurationChange, IConfigurationChangeEvent, IConfigurationData, IConfigurationOverrides, IConfigurationUpdateOptions, IConfigurationUpdateOverrides, IConfigurationValue, ConfigurationTarget, isConfigurationOverrides, isConfigurationUpdateOverrides } from '../../../../platform/configuration/common/configuration.js';
 import { ChatConfiguration } from '../../../../workbench/contrib/chat/common/constants.js';
 import { ConfigurationChangeEvent, ConfigurationModel } from '../../../../platform/configuration/common/configurationModels.js';
-import { DefaultConfiguration, IPolicyConfiguration, NullPolicyConfiguration, PolicyConfiguration } from '../../../../platform/configuration/common/configurations.js';
+import { IPolicyConfiguration, NullPolicyConfiguration, PolicyConfiguration } from '../../../../platform/configuration/common/configurations.js';
 import { Extensions, IConfigurationRegistry, IRegisteredConfigurationPropertySchema, keyFromOverrideIdentifiers } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { IFileService, FileOperationError, FileOperationResult } from '../../../../platform/files/common/files.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -27,10 +27,11 @@ import { IPolicyService, NullPolicyService } from '../../../../platform/policy/c
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IWorkspaceContextService, IWorkspaceFoldersChangeEvent, IWorkspaceFolder, WorkbenchState, Workspace } from '../../../../platform/workspace/common/workspace.js';
-import { FolderConfiguration, UserConfiguration, WorkspaceConfiguration } from '../../../../workbench/services/configuration/browser/configuration.js';
-import { APPLICATION_SCOPES, APPLY_ALL_PROFILES_SETTING, FOLDER_CONFIG_FOLDER_NAME, FOLDER_SETTINGS_PATH, IWorkbenchConfigurationService, RestrictedSettings } from '../../../../workbench/services/configuration/common/configuration.js';
+import { DefaultConfiguration, FolderConfiguration, UserConfiguration, WorkspaceConfiguration } from '../../../../workbench/services/configuration/browser/configuration.js';
+import { APPLICATION_SCOPES, APPLY_ALL_PROFILES_SETTING, FOLDER_CONFIG_FOLDER_NAME, FOLDER_SETTINGS_PATH, IConfigurationCache, IWorkbenchConfigurationService, RestrictedSettings } from '../../../../workbench/services/configuration/common/configuration.js';
 import { Configuration } from '../../../../workbench/services/configuration/common/configurationModels.js';
 import { IUserDataProfileService } from '../../../../workbench/services/userDataProfile/common/userDataProfile.js';
+import { IBrowserWorkbenchEnvironmentService } from '../../../../workbench/services/environment/browser/environmentService.js';
 
 // Import to register configuration contributions
 import '../../../../workbench/services/configuration/browser/configurationService.js';
@@ -76,11 +77,13 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 		private readonly fileService: IFileService,
 		policyService: IPolicyService,
 		private readonly logService: ILogService,
+		configurationCache: IConfigurationCache,
+		environmentService: IBrowserWorkbenchEnvironmentService,
 	) {
 		super();
 
 		this.settingsResource = userDataProfileService.currentProfile.settingsResource;
-		this.defaultConfiguration = this._register(new SessionsDefaultConfiguration(logService));
+		this.defaultConfiguration = this._register(new SessionsDefaultConfiguration(userDataProfileService.currentProfile.id, configurationCache, environmentService, logService));
 		this.policyConfiguration = policyService instanceof NullPolicyService ? new NullPolicyConfiguration() : this._register(new PolicyConfiguration(this.defaultConfiguration, policyService, logService));
 		this.initAgentsWindowReadOnlyKeys();
 		this.userConfiguration = this._register(new UserConfiguration(userDataProfileService.currentProfile.settingsResource, userDataProfileService.currentProfile.tasksResource, userDataProfileService.currentProfile.mcpResource, { exclude: [...this.agentsWindowReadOnlyKeys] }, fileService, uriIdentityService, logService));
@@ -271,6 +274,11 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 	}
 
 	async reloadConfiguration(_target?: ConfigurationTarget | IWorkspaceFolder): Promise<void> {
+		this.reloadDefaultConfiguration();
+		if (_target === ConfigurationTarget.DEFAULT) {
+			return;
+		}
+
 		const userModel = await this.userConfiguration.initialize();
 		const previousData = this._configuration.toData();
 		const change = this._configuration.compareAndUpdateLocalUserConfiguration(userModel);
@@ -294,8 +302,12 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 		this.triggerConfigurationChange(change, previousData, ConfigurationTarget.USER);
 	}
 
+	private reloadDefaultConfiguration(): void {
+		this.onDefaultConfigurationChanged(this.defaultConfiguration.reload());
+	}
+
 	hasCachedConfigurationDefaultsOverrides(): boolean {
-		return false;
+		return this.defaultConfiguration.hasCachedConfigurationDefaultsOverrides();
 	}
 
 	async whenRemoteConfigurationLoaded(): Promise<void> { }

--- a/src/vs/sessions/services/configuration/test/browser/configurationService.test.ts
+++ b/src/vs/sessions/services/configuration/test/browser/configurationService.test.ts
@@ -27,6 +27,7 @@ import { SessionsWorkspaceContextService } from '../../../workspace/browser/work
 import { getWorkspaceIdentifier } from '../../../../../platform/workspaces/common/workspaceIdentifier.js';
 import { Event } from '../../../../../base/common/event.js';
 import { IUserDataProfileService } from '../../../../../workbench/services/userDataProfile/common/userDataProfile.js';
+import { IConfigurationCache } from '../../../../../workbench/services/configuration/common/configuration.js';
 
 const ROOT = URI.file('tests').with({ scheme: 'vscode-tests' });
 
@@ -105,7 +106,8 @@ suite('Sessions ConfigurationService', () => {
 		await fileService.writeFile(configResource, VSBuffer.fromString(JSON.stringify({ folders: [] })));
 
 		workspaceService = disposables.add(new SessionsWorkspaceContextService(getWorkspaceIdentifier(configResource), uriIdentityService));
-		testObject = disposables.add(new ConfigurationService(userDataProfileService, workspaceService, uriIdentityService, fileService, new NullPolicyService(), logService));
+		const nullConfigurationCache: IConfigurationCache = { needsCaching: () => false, read: async () => '', write: async () => { }, remove: async () => { } };
+		testObject = disposables.add(new ConfigurationService(userDataProfileService, workspaceService, uriIdentityService, fileService, new NullPolicyService(), logService, nullConfigurationCache, TestEnvironmentService));
 		await testObject.initialize();
 	});
 


### PR DESCRIPTION
## Problem

The Agents window had two gaps related to configuration default overrides (e.g. experiment-driven overrides for `chat.agentHost.enabled`):

1. **No caching**: `SessionsDefaultConfiguration` extended the base platform `DefaultConfiguration` which has no persistence. Every startup, experiment overrides had to be re-fetched async — so on the first call to `configurationService.getValue()` (including in `AgentHostEnablementService`), the override wasn't available yet.

2. **`reloadConfiguration(DEFAULT)` was a no-op**: When `ConfigurationDefaultOverridesContribution` called `configurationService.reloadConfiguration(ConfigurationTarget.DEFAULT)` after extensions registered, the sessions `ConfigurationService` ignored the target and only reloaded user/workspace config.

## Fix

- `SessionsDefaultConfiguration` now extends the **workbench** `DefaultConfiguration` (from `configuration.ts`), which caches experiment overrides to disk and reads them back on startup before building the model
- `IConfigurationCache` and `IBrowserWorkbenchEnvironmentService` are now passed to `ConfigurationService` in both `sessions.main.ts` (desktop) and `web.main.ts`
- `hasCachedConfigurationDefaultsOverrides()` now delegates to the default configuration instead of hardcoding `false`
- `reloadConfiguration()` now always calls `reloadDefaultConfiguration()` first (new private helper mirroring the editor window pattern); when called with `ConfigurationTarget.DEFAULT` it returns after that