### PR TITLE
Add open/close motion to picker menus in chat input area

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -502,6 +502,11 @@ export interface IActionListHeaderLink {
 	readonly uri: URI;
 }
 
+export interface IActionListCloseAnimation {
+	readonly className: string;
+	readonly duration: number;
+}
+
 /**
  * Options for configuring the action list.
  */
@@ -621,6 +626,12 @@ export interface IActionListOptions {
 	 * Optional CSS class name added to the action list container, for scoped styling.
 	 */
 	readonly className?: string;
+
+	/**
+	 * Optional CSS class and duration used to animate the containing action widget
+	 * before the context view is hidden.
+	 */
+	readonly closeAnimation?: IActionListCloseAnimation;
 }
 
 /**
@@ -1153,6 +1164,10 @@ export class ActionListWidget<T> extends Disposable {
 
 	get filterInput(): HTMLInputElement | undefined {
 		return this._filterInput;
+	}
+
+	get closeAnimation(): IActionListCloseAnimation | undefined {
+		return this._options?.closeAnimation;
 	}
 
 	private focusCondition(element: IActionListItem<unknown>): boolean {
@@ -2012,6 +2027,10 @@ export class ActionList<T> extends Disposable {
 		return this._widget.filterInput;
 	}
 
+	get closeAnimation(): IActionListCloseAnimation | undefined {
+		return this._widget.closeAnimation;
+	}
+
 	/**
 	 * Returns the resolved anchor position after the first layout.
 	 * Used by the context view delegate to lock the dropdown direction.
@@ -2060,9 +2079,11 @@ export class ActionList<T> extends Disposable {
 		this._widget.focus();
 	}
 
-	hide(didCancel?: boolean): void {
+	hide(didCancel?: boolean, hideContextView = true): void {
 		this._widget.hide(didCancel);
-		this._contextViewService.hideContextView();
+		if (hideContextView) {
+			this._contextViewService.hideContextView();
+		}
 	}
 
 	clearFilter(): boolean {

--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -505,6 +505,7 @@ export interface IActionListHeaderLink {
 export interface IActionListCloseAnimation {
 	readonly className: string;
 	readonly duration: number;
+	readonly requiredAncestorClasses?: readonly string[];
 }
 
 /**

--- a/src/vs/platform/actionWidget/browser/actionWidget.ts
+++ b/src/vs/platform/actionWidget/browser/actionWidget.ts
@@ -6,6 +6,7 @@ import * as dom from '../../../base/browser/dom.js';
 import { ActionBar } from '../../../base/browser/ui/actionbar/actionbar.js';
 import { IAnchor } from '../../../base/browser/ui/contextview/contextview.js';
 import { IAction } from '../../../base/common/actions.js';
+import { disposableTimeout } from '../../../base/common/async.js';
 import { KeyCode, KeyMod } from '../../../base/common/keyCodes.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../base/common/lifecycle.js';
 import './actionWidget.css';
@@ -65,6 +66,9 @@ class ActionWidgetService extends Disposable implements IActionWidgetService {
 	}
 
 	private readonly _list = this._register(new MutableDisposable<ActionList<unknown>>());
+	private readonly _closeAnimation = this._register(new MutableDisposable<IDisposable>());
+	private _widgetElement: HTMLElement | undefined;
+	private _closingList: ActionList<unknown> | undefined;
 
 	constructor(
 		@IContextViewService private readonly _contextViewService: IContextViewService,
@@ -129,11 +133,34 @@ class ActionWidgetService extends Disposable implements IActionWidgetService {
 	}
 
 	hide(didCancel?: boolean) {
-		this._list.value?.hide(didCancel);
-		this._list.clear();
+		const list = this._list.value;
+		const widget = this._widgetElement;
+		if (!list || this._closingList === list) {
+			return;
+		}
+
+		const closeAnimation = list.closeAnimation;
+		const reducedMotion = widget ? dom.getWindow(widget).matchMedia('(prefers-reduced-motion: reduce)').matches : true;
+		if (!widget || !closeAnimation || closeAnimation.duration <= 0 || reducedMotion) {
+			this._closingList = list;
+			list.hide(didCancel);
+			return;
+		}
+
+		this._closingList = list;
+		widget.classList.add(closeAnimation.className);
+		list.hide(didCancel, false);
+		this._closeAnimation.value = disposableTimeout(() => {
+			if (this._list.value === list) {
+				this._contextViewService.hideContextView(didCancel);
+			}
+		}, closeAnimation.duration);
 	}
 
 	clear() {
+		this._closeAnimation.clear();
+		this._closingList = undefined;
+		this._widgetElement = undefined;
 		this._list.clear();
 	}
 
@@ -141,6 +168,7 @@ class ActionWidgetService extends Disposable implements IActionWidgetService {
 		const widget = document.createElement('div');
 		widget.classList.add('action-widget');
 		element.appendChild(widget);
+		this._widgetElement = widget;
 
 		this._list.value = list;
 		if (this._list.value) {
@@ -231,6 +259,16 @@ class ActionWidgetService extends Disposable implements IActionWidgetService {
 	}
 
 	private _onWidgetClosed(didCancel?: boolean): void {
+		if (this._closingList === this._list.value) {
+			this._closeAnimation.clear();
+			this._closingList = undefined;
+			this._widgetElement = undefined;
+			this._list.clear();
+			return;
+		}
+		this._closeAnimation.clear();
+		this._closingList = undefined;
+		this._widgetElement = undefined;
 		this._list.value?.hide(didCancel);
 	}
 }

--- a/src/vs/platform/actionWidget/browser/actionWidget.ts
+++ b/src/vs/platform/actionWidget/browser/actionWidget.ts
@@ -271,10 +271,7 @@ class ActionWidgetService extends Disposable implements IActionWidgetService {
 
 	private _onWidgetClosed(didCancel?: boolean): void {
 		if (this._closingList === this._list.value) {
-			this._closeAnimation.clear();
-			this._closingList = undefined;
-			this._widgetElement = undefined;
-			this._list.clear();
+			this.clear();
 			return;
 		}
 		this._closeAnimation.clear();

--- a/src/vs/platform/actionWidget/browser/actionWidget.ts
+++ b/src/vs/platform/actionWidget/browser/actionWidget.ts
@@ -140,8 +140,7 @@ class ActionWidgetService extends Disposable implements IActionWidgetService {
 		}
 
 		const closeAnimation = list.closeAnimation;
-		const reducedMotion = widget ? dom.getWindow(widget).matchMedia('(prefers-reduced-motion: reduce)').matches : true;
-		if (!widget || !closeAnimation || closeAnimation.duration <= 0 || reducedMotion) {
+		if (!widget || !closeAnimation || closeAnimation.duration <= 0 || !this._hasRequiredAncestorClasses(widget, closeAnimation.requiredAncestorClasses)) {
 			this._closingList = list;
 			list.hide(didCancel);
 			return;
@@ -256,6 +255,18 @@ class ActionWidgetService extends Disposable implements IActionWidgetService {
 		const actionBar = new ActionBar(container);
 		actionBar.push(actions, { icon: false, label: true });
 		return actionBar;
+	}
+
+	private _hasRequiredAncestorClasses(element: HTMLElement, classNames: readonly string[] | undefined): boolean {
+		if (!classNames?.length) {
+			return true;
+		}
+		for (let candidate: HTMLElement | null = element; candidate; candidate = candidate.parentElement) {
+			if (classNames.every(className => candidate.classList.contains(className))) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private _onWidgetClosed(didCancel?: boolean): void {

--- a/src/vs/platform/actionWidget/browser/actionWidgetDropdown.ts
+++ b/src/vs/platform/actionWidget/browser/actionWidgetDropdown.ts
@@ -275,6 +275,14 @@ export class ActionWidgetDropdown extends BaseDropdown {
 		);
 	}
 
+	override hide(): void {
+		const wasVisible = this.isVisible();
+		super.hide();
+		if (wasVisible) {
+			this.actionWidgetService.hide(true);
+		}
+	}
+
 	setEnabled(enabled: boolean): void {
 		this._enabled = enabled;
 	}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.ts
@@ -9,6 +9,7 @@ import { autorun, IObservable } from '../../../../../../base/common/observable.j
 import { ActionWidgetDropdownActionViewItem } from '../../../../../../platform/actions/browser/actionWidgetDropdownActionViewItem.js';
 import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
 import { IActionWidgetDropdownOptions } from '../../../../../../platform/actionWidget/browser/actionWidgetDropdown.js';
+import { IActionListOptions } from '../../../../../../platform/actionWidget/browser/actionList.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
@@ -24,6 +25,21 @@ export interface IChatInputPickerOptions {
 	readonly actionContext?: IChatExecuteActionContext;
 
 	readonly compact: IObservable<boolean>;
+}
+
+export const CHAT_INPUT_PICKER_DROPDOWN_CLASS = 'chat-input-picker-dropdown';
+export const CHAT_INPUT_PICKER_DROPDOWN_CLOSING_CLASS = 'chat-input-picker-dropdown-closing';
+export const CHAT_INPUT_PICKER_CLOSE_ANIMATION_DURATION = 150;
+
+function withChatInputPickerMotion(listOptions: IActionListOptions | undefined): IActionListOptions {
+	return {
+		...listOptions,
+		className: [listOptions?.className, CHAT_INPUT_PICKER_DROPDOWN_CLASS].filter(Boolean).join(' '),
+		closeAnimation: listOptions?.closeAnimation ?? {
+			className: CHAT_INPUT_PICKER_DROPDOWN_CLOSING_CLASS,
+			duration: CHAT_INPUT_PICKER_CLOSE_ANIMATION_DURATION,
+		},
+	};
 }
 
 /**
@@ -45,6 +61,7 @@ export abstract class ChatInputPickerActionViewItem extends ActionWidgetDropdown
 		const optionsWithAnchor: Omit<IActionWidgetDropdownOptions, 'label' | 'labelRenderer'> = {
 			...actionWidgetOptions,
 			getAnchor: () => this.getAnchorElement(),
+			listOptions: withChatInputPickerMotion(actionWidgetOptions.listOptions),
 		};
 
 		super(action, optionsWithAnchor, actionWidgetService, keybindingService, contextKeyService, telemetryService);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.ts
@@ -30,6 +30,7 @@ export interface IChatInputPickerOptions {
 export const CHAT_INPUT_PICKER_DROPDOWN_CLASS = 'chat-input-picker-dropdown';
 export const CHAT_INPUT_PICKER_DROPDOWN_CLOSING_CLASS = 'chat-input-picker-dropdown-closing';
 export const CHAT_INPUT_PICKER_CLOSE_ANIMATION_DURATION = 150;
+export const CHAT_INPUT_PICKER_MOTION_ANCESTOR_CLASSES = ['style-override', 'monaco-enable-motion'];
 
 function withChatInputPickerMotion(listOptions: IActionListOptions | undefined): IActionListOptions {
 	return {
@@ -38,6 +39,7 @@ function withChatInputPickerMotion(listOptions: IActionListOptions | undefined):
 		closeAnimation: listOptions?.closeAnimation ?? {
 			className: CHAT_INPUT_PICKER_DROPDOWN_CLOSING_CLASS,
 			duration: CHAT_INPUT_PICKER_CLOSE_ANIMATION_DURATION,
+			requiredAncestorClasses: CHAT_INPUT_PICKER_MOTION_ANCESTOR_CLASSES,
 		},
 	};
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -45,7 +45,7 @@ import { IUriIdentityService } from '../../../../../../platform/uriIdentity/comm
 import { GitHubPaths, IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IUpdateService, StateType } from '../../../../../../platform/update/common/update.js';
 import { IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
-import { CHAT_INPUT_PICKER_CLOSE_ANIMATION_DURATION, CHAT_INPUT_PICKER_DROPDOWN_CLASS, CHAT_INPUT_PICKER_DROPDOWN_CLOSING_CLASS } from './chatInputPickerActionItem.js';
+import { CHAT_INPUT_PICKER_CLOSE_ANIMATION_DURATION, CHAT_INPUT_PICKER_DROPDOWN_CLASS, CHAT_INPUT_PICKER_DROPDOWN_CLOSING_CLASS, CHAT_INPUT_PICKER_MOTION_ANCESTOR_CLASSES } from './chatInputPickerActionItem.js';
 
 function isVersionAtLeast(current: string, required: string): boolean {
 	const currentSemver = semver.coerce(current);
@@ -1446,6 +1446,7 @@ export class ModelPickerWidget extends Disposable {
 			closeAnimation: {
 				className: CHAT_INPUT_PICKER_DROPDOWN_CLOSING_CLASS,
 				duration: CHAT_INPUT_PICKER_CLOSE_ANIMATION_DURATION,
+				requiredAncestorClasses: CHAT_INPUT_PICKER_MOTION_ANCESTOR_CLASSES,
 			},
 		};
 		const previouslyFocusedElement = dom.getActiveElement();
@@ -1793,6 +1794,7 @@ export class ModelPickerWidget extends Disposable {
 				closeAnimation: {
 					className: CHAT_INPUT_PICKER_DROPDOWN_CLOSING_CLASS,
 					duration: CHAT_INPUT_PICKER_CLOSE_ANIMATION_DURATION,
+					requiredAncestorClasses: CHAT_INPUT_PICKER_MOTION_ANCESTOR_CLASSES,
 				},
 			}
 		);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -45,6 +45,7 @@ import { IUriIdentityService } from '../../../../../../platform/uriIdentity/comm
 import { GitHubPaths, IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IUpdateService, StateType } from '../../../../../../platform/update/common/update.js';
 import { IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
+import { CHAT_INPUT_PICKER_CLOSE_ANIMATION_DURATION, CHAT_INPUT_PICKER_DROPDOWN_CLASS, CHAT_INPUT_PICKER_DROPDOWN_CLOSING_CLASS } from './chatInputPickerActionItem.js';
 
 function isVersionAtLeast(current: string, required: string): boolean {
 	const currentSemver = semver.coerce(current);
@@ -1325,6 +1326,10 @@ export class ModelPickerWidget extends Disposable {
 		if (!anchorElement || this._domNode?.classList.contains('disabled')) {
 			return;
 		}
+		if (this._nameButton?.getAttribute('aria-expanded') === 'true') {
+			this._actionWidgetService.hide(true);
+			return;
+		}
 
 		const previousModel = this._selectedModel;
 
@@ -1437,6 +1442,11 @@ export class ModelPickerWidget extends Disposable {
 				void this._openerService.open(uri, { allowCommands: true });
 			},
 			minWidth: 200,
+			className: CHAT_INPUT_PICKER_DROPDOWN_CLASS,
+			closeAnimation: {
+				className: CHAT_INPUT_PICKER_DROPDOWN_CLOSING_CLASS,
+				duration: CHAT_INPUT_PICKER_CLOSE_ANIMATION_DURATION,
+			},
 		};
 		const previouslyFocusedElement = dom.getActiveElement();
 
@@ -1779,6 +1789,11 @@ export class ModelPickerWidget extends Disposable {
 				headerIcon: showCacheBreakHint ? Codicon.info : undefined,
 				headerLink: showCacheBreakHint ? this.getCacheBreakLearnMoreLink() : undefined,
 				headerDismiss: showCacheBreakHint ? () => this.dismissCacheBreakHint() : undefined,
+				className: CHAT_INPUT_PICKER_DROPDOWN_CLASS,
+				closeAnimation: {
+					className: CHAT_INPUT_PICKER_DROPDOWN_CLOSING_CLASS,
+					duration: CHAT_INPUT_PICKER_CLOSE_ANIMATION_DURATION,
+				},
 			}
 		);
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -2019,6 +2019,52 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	margin-bottom: 4px;
 }
 
+.action-widget:has(.chat-input-picker-dropdown) {
+	animation: chat-input-picker-dropdown-open 250ms cubic-bezier(0.22, 1, 0.36, 1) both;
+	transform-origin: bottom left;
+	will-change: transform, opacity;
+}
+
+.context-view.bottom .action-widget:has(.chat-input-picker-dropdown) {
+	transform-origin: top left;
+}
+
+.action-widget.chat-input-picker-dropdown-closing:has(.chat-input-picker-dropdown) {
+	animation: chat-input-picker-dropdown-close 150ms cubic-bezier(0.22, 1, 0.36, 1) both;
+	pointer-events: none;
+}
+
+@keyframes chat-input-picker-dropdown-open {
+	0% {
+		opacity: 0;
+		transform: scale(0.97);
+	}
+
+	100% {
+		opacity: 1;
+		transform: scale(1);
+	}
+}
+
+@keyframes chat-input-picker-dropdown-close {
+	0% {
+		opacity: 1;
+		transform: scale(1);
+	}
+
+	100% {
+		opacity: 0;
+		transform: scale(0.99);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.action-widget:has(.chat-input-picker-dropdown) {
+		animation: none;
+		transform: none;
+	}
+}
+
 .action-widget .monaco-list-row.chat-model-picker-section-toggle.has-toolbar .action-list-item-toolbar {
 	display: flex;
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -2019,17 +2019,17 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	margin-bottom: 4px;
 }
 
-.action-widget:has(.chat-input-picker-dropdown) {
+.style-override.monaco-enable-motion .action-widget:has(.chat-input-picker-dropdown) {
 	animation: chat-input-picker-dropdown-open 250ms cubic-bezier(0.22, 1, 0.36, 1) both;
 	transform-origin: bottom left;
 	will-change: transform, opacity;
 }
 
-.context-view.bottom .action-widget:has(.chat-input-picker-dropdown) {
+.style-override.monaco-enable-motion .context-view.bottom .action-widget:has(.chat-input-picker-dropdown) {
 	transform-origin: top left;
 }
 
-.action-widget.chat-input-picker-dropdown-closing:has(.chat-input-picker-dropdown) {
+.style-override.monaco-enable-motion .action-widget.chat-input-picker-dropdown-closing:has(.chat-input-picker-dropdown) {
 	animation: chat-input-picker-dropdown-close 150ms cubic-bezier(0.22, 1, 0.36, 1) both;
 	pointer-events: none;
 }
@@ -2055,13 +2055,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	100% {
 		opacity: 0;
 		transform: scale(0.99);
-	}
-}
-
-@media (prefers-reduced-motion: reduce) {
-	.action-widget:has(.chat-input-picker-dropdown) {
-		animation: none;
-		transform: none;
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Related to https://github.com/microsoft/vscode/issues/325020

Adds a subtle opening and closing animation to the picker menus in the chat input area (i.e. model picker, configure model picker, etc).


https://github.com/user-attachments/assets/abb9afeb-321b-49a1-af52-a69a63e8753c
