### PR TITLE
sessions: dismiss blocked-sessions dropdown on Escape and quick pick open

### DIFF
--- a/src/vs/sessions/common/contextkeys.ts
+++ b/src/vs/sessions/common/contextkeys.ts
@@ -86,6 +86,12 @@ export const SessionChatsPickerVisibleContext = new RawContextKey<boolean>('sess
 
 //#endregion
 
+//#region < --- Blocked Sessions --- >
+
+export const SessionsBlockedSessionsVisibleContext = new RawContextKey<boolean>('sessionsBlockedSessionsVisible', false, localize('sessionsBlockedSessionsVisible', "Whether the blocked-sessions dropdown (surfacing sessions that require input) is open in the sessions titlebar"));
+
+//#endregion
+
 //#region < --- Aquarium --- >
 
 export const SessionsAquariumActiveContext = new RawContextKey<boolean>('sessionsAquariumActive', false, localize('sessionsAquariumActive', "Whether the sessions aquarium overlay is active"));

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -5,14 +5,14 @@
 
 import './media/sessionsTitleBarWidget.css';
 import { $, addDisposableGenericMouseDownListener, addDisposableListener, EventType, getDomNodePagePosition, getWindow, isAncestor, reset } from '../../../../base/browser/dom.js';
-import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { localize } from '../../../../nls.js';
 import { BaseActionViewItem, IBaseActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { MenuRegistry, SubmenuItemAction } from '../../../../platform/actions/common/actions.js';
-import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr, IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
 import { Menus } from '../../../browser/menus.js';
 import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
@@ -24,9 +24,10 @@ import { URI } from '../../../../base/common/uri.js';
 import { AnchorAlignment, AnchorPosition, IAnchor } from '../../../../base/common/layout.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { IContextViewService, IOpenContextView } from '../../../../platform/contextview/browser/contextView.js';
+import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 import { IsAuxiliaryWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
-import { SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
+import { SessionsBlockedSessionsVisibleContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { SHOW_SESSIONS_PICKER_COMMAND_ID } from './sessionsActions.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
@@ -45,6 +46,24 @@ import { openSessionToTheSide } from './views/sessionsView.js';
  * opening the full sessions picker so the popup doesn't linger behind it.
  */
 const SHOW_ALL_SESSIONS_FROM_BLOCKED_LIST_COMMAND_ID = 'sessions.blockedSessions.showAllSessions';
+
+/**
+ * Internal command that dismisses the blocked-sessions dropdown. Bound to Escape
+ * (scoped to {@link SessionsBlockedSessionsVisibleContext}) so the dropdown can
+ * be closed from anywhere in the sessions window while it is open, not only when
+ * focus happens to be inside it.
+ */
+const HIDE_BLOCKED_SESSIONS_COMMAND_ID = 'sessions.blockedSessions.hide';
+
+/**
+ * The currently-open blocked-sessions dropdown, if any. Shared at module scope so
+ * command handlers registered outside the widget instance (the Escape keybinding
+ * and the "Show All Sessions" action) can close this specific context view via its
+ * {@link IOpenContextView.close}, rather than blindly hiding whatever context view
+ * happens to be open. Owned by {@link SessionsTitleBarWidget}, which keeps it in
+ * sync when the dropdown opens and clears it when it hides.
+ */
+let openBlockedSessionsView: IOpenContextView | undefined;
 
 /**
  * Minimum width of the blocked-sessions dropdown, in pixels. The dropdown is at
@@ -103,6 +122,9 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 	/** The blocked-sessions list rendered inside the open dropdown, if any. */
 	private _blockedList: BlockedSessionsList | undefined;
 
+	/** Tracks whether the blocked-sessions dropdown is open (drives the Escape keybinding). */
+	private readonly _blockedSessionsVisibleContext: IContextKey<boolean>;
+
 	/** Drives the transient "Approved N sessions" confirmation. Owned by the widget. */
 	private readonly _sessionActionFeedback: SessionActionFeedback;
 
@@ -119,8 +141,12 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 		@IContextViewService private readonly contextViewService: IContextViewService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IQuickInputService private readonly quickInputService: IQuickInputService,
 	) {
 		super(undefined, action, options);
+
+		this._blockedSessionsVisibleContext = SessionsBlockedSessionsVisibleContext.bindTo(contextKeyService);
 
 		// The widget owns the approval-feedback state; the optional parameter is a
 		// test seam so fixtures can supply a preset instance.
@@ -506,7 +532,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 					width,
 					approvalModel: this._blockedIndicator.approvalModel,
 					onSessionOpen: (resource, preserveFocus, sideBySide) => {
-						this.contextViewService.hideContextView();
+						this._openContextView?.close();
 						this._openBlockedSession(resource, preserveFocus, sideBySide);
 					},
 				}));
@@ -525,32 +551,41 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 					this.contextViewService.layout();
 				}));
 
+				// Dismiss the dropdown when a quick pick opens on top of it (e.g. the
+				// sessions picker), so it doesn't linger behind the quick input. Close
+				// our specific context view rather than whatever happens to be open.
+				store.add(this.quickInputService.onShow(() => this._openContextView?.close()));
+
 				this._blockedList = list;
 				return store;
 			},
 			focus: () => this._blockedList?.focus(),
 			onDOMEvent: (e: Event) => {
-				// Dismiss on Escape, or on a click outside the dropdown. Clicks on the
-				// anchor are ignored here because the anchor toggles the dropdown itself.
-				if (e.type === EventType.KEY_DOWN) {
-					if (new StandardKeyboardEvent(e as KeyboardEvent).equals(KeyCode.Escape)) {
-						this.contextViewService.hideContextView();
-					}
-				} else if (e.type === EventType.CLICK) {
+				// Dismiss on a click outside the dropdown. Clicks on the anchor are
+				// ignored here because the anchor toggles the dropdown itself. Escape
+				// is handled by a dedicated high-weight keybinding (see
+				// HIDE_BLOCKED_SESSIONS_COMMAND_ID) so it dismisses the dropdown even
+				// when focus is outside of it.
+				if (e.type === EventType.CLICK) {
 					const target = e.target as HTMLElement | null;
 					if (target
 						&& !isAncestor(target, this.contextViewService.getContextViewElement())
 						&& !isAncestor(target, container)) {
-						this.contextViewService.hideContextView();
+						this._openContextView?.close();
 					}
 				}
 			},
 			onHide: () => {
+				this._blockedSessionsVisibleContext.set(false);
 				store.dispose();
 				this._openContextView = undefined;
+				openBlockedSessionsView = undefined;
 				this._blockedList = undefined;
 			},
 		});
+
+		openBlockedSessionsView = this._openContextView;
+		this._blockedSessionsVisibleContext.set(true);
 	}
 
 	/**
@@ -672,7 +707,7 @@ export class SessionsTitleBarContribution extends Disposable implements IWorkben
 		// the dropdown (a transient context view) before opening the full sessions
 		// picker, so the popup doesn't linger behind it.
 		this._register(CommandsRegistry.registerCommand(SHOW_ALL_SESSIONS_FROM_BLOCKED_LIST_COMMAND_ID, accessor => {
-			accessor.get(IContextViewService).hideContextView();
+			openBlockedSessionsView?.close();
 			return accessor.get(ICommandService).executeCommand(SHOW_SESSIONS_PICKER_COMMAND_ID);
 		}));
 
@@ -696,3 +731,16 @@ export class SessionsTitleBarContribution extends Disposable implements IWorkben
 		}, undefined));
 	}
 }
+
+// Escape closes the blocked-sessions dropdown while it is open. Registered as a
+// high-weight keybinding scoped to `SessionsBlockedSessionsVisibleContext` (rather
+// than relying on focus being inside the dropdown) so it reliably wins over other
+// Escape handlers, mirroring how the quick pick scopes its dismiss keybinding to an
+// "is visible" context key.
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: HIDE_BLOCKED_SESSIONS_COMMAND_ID,
+	weight: KeybindingWeight.SessionsContrib + 100,
+	when: SessionsBlockedSessionsVisibleContext,
+	primary: KeyCode.Escape,
+	handler: () => openBlockedSessionsView?.close(),
+});

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/sessionsTitleBarWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/sessionsTitleBarWidget.fixture.ts
@@ -11,6 +11,7 @@ import { mock } from '../../../../../base/test/common/mock.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { SubmenuItemAction } from '../../../../../platform/actions/common/actions.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { IQuickInputService } from '../../../../../platform/quickinput/common/quickInput.js';
 import { AgentSessionApprovalKind, AgentSessionApprovalModel, IAgentSessionApprovalInfo } from '../../../../contrib/chat/browser/agentSessions/agentSessionApprovalModel.js';
 // eslint-disable-next-line local/code-import-patterns
 import { IChat, ISession, ISessionWorkspace } from '../../../../../sessions/services/sessions/common/session.js';
@@ -127,6 +128,9 @@ function renderTitleBar(ctx: ComponentFixtureContext, state: ITitleBarState): vo
 			}());
 			reg.defineInstance(IWorkbenchLayoutService, new class extends mock<IWorkbenchLayoutService>() {
 				override readonly onDidChangePartVisibility = Event.None;
+			}());
+			reg.defineInstance(IQuickInputService, new class extends mock<IQuickInputService>() {
+				override readonly onShow = Event.None;
 			}());
 			// The blocked-sessions feature is only enabled outside of stable builds.
 			reg.defineInstance(IProductService, new class extends mock<IProductService>() {


### PR DESCRIPTION
## Why

The blocked-sessions dropdown in the Agents window titlebar (the "N sessions require input" context view) was hard to dismiss. Its only Escape handling lived in the context view's `onDOMEvent` callback, which **only fires when keyboard focus is inside the dropdown**. If focus was anywhere else in the window, pressing Esc did nothing.

## What changed

- **Escape closes the dropdown regardless of focus.** Added a `SessionsBlockedSessionsVisibleContext` context key that is toggled while the dropdown is open, and registered a high-weight Escape keybinding scoped to it (`KeybindingWeight.SessionsContrib + 100`). This mirrors how the quick pick scopes its dismiss keybinding to an "is visible" context key, so Esc reliably wins over other Agents-window Escape handlers while the dropdown is up.
- **Dismiss when a quick pick opens.** Subscribed to `IQuickInputService.onShow` (within the dropdown''s render store) so the dropdown closes when a quick pick opens over it (e.g. the sessions picker), instead of lingering behind the quick input.
- **Close the specific context view everywhere.** Replaced all `IContextViewService.hideContextView()` calls in this file with `IOpenContextView.close()` on the view we created. `close()` only hides when our view is still the active one, so it can never tear down an unrelated context view. A module-scoped reference is kept in sync by the widget so the out-of-instance handlers (the Escape keybinding command and the "Show All Sessions" action) can also target the specific view.

## Notes for reviewers

- The redundant Escape branch in `onDOMEvent` was removed; click-outside dismissal remains.
- The context key is toggled on show and cleared in `onHide` (which also runs on dispose).

## Validation

- ESLint on the changed files — passes.
- `typecheck-client` — no errors in the changed files.
- `valid-layers-check` — no layering violations from the new imports.
