### PR TITLE
Fix editor actions overlaying tabs

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -168,11 +168,12 @@
 	box-shadow: var(--vscode-shadow-sm);
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .tabs-container > .tab:last-child {
+.monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .tabs-container > .tab:last-child,
+.monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .tabs-container > .tab:has(+ .tabs-bar-add-tab) {
 	margin-right: var(--last-tab-margin-right); /* when tabs wrap, we need a margin away from the absolute positioned editor actions */
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .tabs-container > .tab.last-in-row:not(:last-child) {
+.monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .tabs-container > .tab.last-in-row:not(:last-child):not(:has(+ .tabs-bar-add-tab)) {
 	border-right: 0 !important; /* ensure no border for every last tab in a row except last row (#115046) */
 }
 
@@ -202,7 +203,7 @@
 	min-width: calc(var(--tab-sizing-current-width, var(--tab-sizing-fixed-min-width, 50px)) - 1px);
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .tabs-container > .tab.sizing-fit.last-in-row:not(:last-child) {
+.monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .tabs-container > .tab.sizing-fit.last-in-row:not(:last-child):not(:has(+ .tabs-bar-add-tab)) {
 	flex-grow: 1; /* grow the last tab in a row for a more homogeneous look except for last row (#113801) */
 }
 
@@ -580,13 +581,14 @@
 
 /* Make drop target edge cases more visible (wrapped tabs & first/last) */
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.last-in-row.drop-target-left:not(:last-child)::after {
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.last-in-row.drop-target-left:not(:last-child):not(:has(+ .tabs-bar-add-tab))::after {
 	right: 0px;
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.last-in-row.drop-target-left::after,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.last-in-row + .tab.drop-target-right::before,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab:last-child.drop-target-left::after,
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab:has(+ .tabs-bar-add-tab).drop-target-left::after,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab:first-child.drop-target-right::before {
 	width: 2px;
 }


### PR DESCRIPTION
### Problem

https://github.com/microsoft/vscode/issues/324902

tldr; with "Show Tabs: multiple" and "Wrap Tabs", the last tab stretched to fill the whole row and the editor actions toolbar overlapped it.

### Cause

The always-present `.tabs-bar-add-tab` control (added in https://github.com/microsoft/vscode/pull/324257) is the last DOM child of `.tabs-container`, so the CSS wrapping rules that identified the last tab via `:last-child` no longer matched a real tab:
- the last tab lost its `--last-tab-margin-right` gap, so editor actions overlapped it
- the real last tab started matching `.last-in-row:not(:last-child)`, got `flex-grow: 1` and filled the row

### Fix

Treat the real last tab as `:last-child` or the tab immediately followed by the add-tab control (`:has(+ .tabs-bar-add-tab)`), and exclude it from the "not last" rules. CSS-only change.