### PR TITLE
Use chat session icons from agents window in chat panel

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -188,38 +188,11 @@ export function getAgentSessionStatusIcon(session: IAgentSession): ThemeIcon {
 		return { ...Codicon.passFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
 	}
 
-	const pullRequestIcon = getAgentSessionPullRequestIcon(session.metadata);
-	if (pullRequestIcon) {
-		return pullRequestIcon;
-	}
-
 	if (!session.isRead()) {
 		return { ...Codicon.circleFilled, color: themeColorFromId('textLink.foreground') };
 	}
 
 	return { ...Codicon.circleSmallFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
-}
-
-function getAgentSessionPullRequestIcon(metadata: IAgentSession['metadata']): ThemeIcon | undefined {
-	if (!metadata) {
-		return undefined;
-	}
-
-	const hasPullRequest = typeof metadata.pullRequestUrl === 'string' || typeof metadata.pullRequestNumber === 'number' || typeof metadata.pullRequestNumber === 'string';
-	if (!hasPullRequest) {
-		return undefined;
-	}
-
-	switch (metadata.pullRequestState) {
-		case 'merged':
-			return { ...Codicon.gitPullRequestDone, color: themeColorFromId('charts.purple') };
-		case 'closed':
-			return { ...Codicon.gitPullRequestClosed, color: themeColorFromId('charts.red') };
-		case 'draft':
-			return { ...Codicon.gitPullRequestDraft, color: themeColorFromId('descriptionForeground') };
-		default:
-			return { ...Codicon.gitPullRequest, color: themeColorFromId('charts.green') };
-	}
 }
 
 export interface IAgentSessionRendererOptions {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import './media/agentsessionsviewer.css';
-import { clearNode, h } from '../../../../../base/browser/dom.js';
+import { clearNode, h, isHTMLElement } from '../../../../../base/browser/dom.js';
 import { localize } from '../../../../../nls.js';
 import { IIdentityProvider, IListVirtualDelegate, NotSelectableGroupId, NotSelectableGroupIdType } from '../../../../../base/browser/ui/list/list.js';
 import { AriaRole } from '../../../../../base/browser/ui/aria/aria.js';
@@ -94,73 +94,131 @@ interface IAgentSessionItemTemplate {
 	readonly disposables: IDisposable;
 }
 
-interface IAgentSessionStatusIconInputs {
-	readonly session: IAgentSession;
-	readonly statusOnly: boolean | undefined;
-}
-
 class AgentSessionStatusIcon extends Disposable {
 
 	private static readonly PIXEL_SPINNER_GRID_KEY = '__pixel_spinner_grid__';
 	private static readonly PIXEL_SPINNER_RING_KEY = '__pixel_spinner_ring__';
 
 	private _currentCacheKey: string | undefined;
-	private _lastInputs: IAgentSessionStatusIconInputs | undefined;
+	private _lastSession: IAgentSession | undefined;
 
 	constructor(
 		private readonly container: HTMLElement,
-		private readonly getIcon: (session: IAgentSession, statusOnly?: boolean) => ThemeIcon,
+		private readonly getIcon: (session: IAgentSession) => ThemeIcon,
 		private readonly accessibilityService: IAccessibilityService,
 	) {
 		super();
 
 		this._register(this.accessibilityService.onDidChangeReducedMotion(() => {
-			if (this._lastInputs) {
-				this.render(this._lastInputs);
+			if (this._lastSession) {
+				this.render(this._lastSession);
 			}
 		}));
 	}
 
-	setStatus(session: IAgentSession, statusOnly?: boolean): void {
-		const inputs: IAgentSessionStatusIconInputs = { session, statusOnly };
-		this._lastInputs = inputs;
-		this.render(inputs);
+	setStatus(session: IAgentSession): void {
+		this._lastSession = session;
+		this.render(session);
 	}
 
 	reset(): void {
 		this._currentCacheKey = undefined;
-		this._lastInputs = undefined;
+		this._lastSession = undefined;
 		clearNode(this.container);
 	}
 
-	private render(inputs: IAgentSessionStatusIconInputs): void {
-		const { session, statusOnly } = inputs;
+	private render(session: IAgentSession): void {
 		this.container.className = `agent-session-icon${session.status === AgentSessionStatus.NeedsInput ? ' needs-input' : ''}`;
+		this.container.style.color = '';
 
 		if ((session.status === AgentSessionStatus.InProgress || session.status === AgentSessionStatus.NeedsInput) && !this.accessibilityService.isMotionReduced()) {
 			const isNeedsInput = session.status === AgentSessionStatus.NeedsInput;
 			const cacheKey = isNeedsInput ? AgentSessionStatusIcon.PIXEL_SPINNER_RING_KEY : AgentSessionStatusIcon.PIXEL_SPINNER_GRID_KEY;
-			this.container.style.color = isNeedsInput ? asCssVariable('list.warningForeground') : asCssVariable('textLink.foreground');
+			const color = isNeedsInput ? asCssVariable('list.warningForeground') : asCssVariable('textLink.foreground');
 			if (this._currentCacheKey === cacheKey) {
+				this.updateActiveIconColor(color);
 				return;
 			}
 
 			this._currentCacheKey = cacheKey;
 			clearNode(this.container);
-			createPixelSpinner(this.container, { variant: isNeedsInput ? 'ring' : 'grid' });
+			const spinner = createPixelSpinner(undefined, { variant: isNeedsInput ? 'ring' : 'grid' });
+			spinner.style.color = color;
+			this.container.appendChild(spinner);
 			return;
 		}
 
-		const icon = this.getIcon(session, statusOnly);
+		const icon = this.getIcon(session);
 		const cacheKey = ThemeIcon.asCSSSelector(icon);
-		this.container.style.color = icon.color ? asCssVariable(icon.color.id) : '';
+		const color = icon.color ? asCssVariable(icon.color.id) : '';
 		if (this._currentCacheKey === cacheKey) {
+			this.updateActiveIconColor(color);
 			return;
 		}
 
 		this._currentCacheKey = cacheKey;
 		clearNode(this.container);
-		this.container.appendChild(h(`span${cacheKey}`).root);
+		const iconElement = h(`span${cacheKey}`).root;
+		iconElement.style.color = color;
+		this.container.appendChild(iconElement);
+	}
+
+	private updateActiveIconColor(color: string): void {
+		const activeIcon = this.container.firstElementChild;
+		if (isHTMLElement(activeIcon)) {
+			activeIcon.style.color = color;
+		}
+	}
+}
+
+export function getAgentSessionStatusIcon(session: IAgentSession): ThemeIcon {
+	if (session.status === AgentSessionStatus.InProgress) {
+		return { ...Codicon.sessionInProgress, color: themeColorFromId('textLink.foreground') };
+	}
+
+	if (session.status === AgentSessionStatus.NeedsInput) {
+		return { ...Codicon.circleFilled, color: themeColorFromId('list.warningForeground') };
+	}
+
+	if (session.status === AgentSessionStatus.Failed) {
+		return { ...Codicon.error, color: themeColorFromId('errorForeground') };
+	}
+
+	if (session.isArchived()) {
+		return { ...Codicon.passFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
+	}
+
+	const pullRequestIcon = getAgentSessionPullRequestIcon(session.metadata);
+	if (pullRequestIcon) {
+		return pullRequestIcon;
+	}
+
+	if (!session.isRead()) {
+		return { ...Codicon.circleFilled, color: themeColorFromId('textLink.foreground') };
+	}
+
+	return { ...Codicon.circleSmallFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
+}
+
+function getAgentSessionPullRequestIcon(metadata: IAgentSession['metadata']): ThemeIcon | undefined {
+	if (!metadata) {
+		return undefined;
+	}
+
+	const hasPullRequest = typeof metadata.pullRequestUrl === 'string' || typeof metadata.pullRequestNumber === 'number' || typeof metadata.pullRequestNumber === 'string';
+	if (!hasPullRequest) {
+		return undefined;
+	}
+
+	switch (metadata.pullRequestState) {
+		case 'merged':
+			return { ...Codicon.gitPullRequestDone, color: themeColorFromId('charts.purple') };
+		case 'closed':
+			return { ...Codicon.gitPullRequestClosed, color: themeColorFromId('charts.red') };
+		case 'draft':
+			return { ...Codicon.gitPullRequestDraft, color: themeColorFromId('descriptionForeground') };
+		default:
+			return { ...Codicon.gitPullRequest, color: themeColorFromId('charts.green') };
 	}
 }
 
@@ -265,7 +323,7 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 		return {
 			element: elements.item,
 			icon: elements.icon,
-			statusIcon: disposables.add(new AgentSessionStatusIcon(elements.icon, (session, statusOnly) => this.getIcon(session, statusOnly), this.accessibilityService)),
+			statusIcon: disposables.add(new AgentSessionStatusIcon(elements.icon, session => this.getIcon(session), this.accessibilityService)),
 			title: disposables.add(new IconLabel(elements.title, { supportHighlights: true, supportIcons: true })),
 			pinnedIndicator: elements.pinnedIndicator,
 			titleToolbar,
@@ -311,9 +369,9 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 			template.element.removeAttribute('data-section-label');
 		}
 
-		// Icon — in status-only mode, show status indicator in icon column and session type icon in details row
+		// Icon - status in the icon column, optional session type icon in details.
 		if (this.options.useStatusOnlyIcons) {
-			template.statusIcon.setStatus(session.element, true);
+			template.statusIcon.setStatus(session.element);
 			if (session.element.providerType === AgentSessionProviders.Background) {
 				template.detailsIcon.className = 'agent-session-details-icon'; // hide default provider icon (same as Local in non-status-only mode)
 			} else {
@@ -494,50 +552,8 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 		return true;
 	}
 
-	private getIcon(session: IAgentSession, statusOnly?: boolean): ThemeIcon {
-		if (session.status === AgentSessionStatus.InProgress) {
-			return { ...Codicon.sessionInProgress, color: themeColorFromId('textLink.foreground') };
-		}
-
-		if (session.status === AgentSessionStatus.NeedsInput) {
-			return { ...Codicon.circleFilled, color: themeColorFromId('list.warningForeground') };
-		}
-
-		if (session.status === AgentSessionStatus.Failed) {
-			return { ...Codicon.error, color: themeColorFromId('errorForeground') };
-		}
-
-		if (statusOnly) {
-			// PR status icons
-			const metadata = session.metadata;
-			const hasPR = metadata?.pullRequestUrl || metadata?.pullRequestNumber;
-			if (hasPR) {
-				switch (metadata?.pullRequestState) {
-					case 'merged':
-						return { ...Codicon.gitPullRequestDone, color: themeColorFromId('charts.purple') };
-					case 'closed':
-						return { ...Codicon.gitPullRequestClosed, color: themeColorFromId('charts.red') };
-					case 'draft':
-						return { ...Codicon.gitPullRequestDraft, color: themeColorFromId('descriptionForeground') };
-					default:
-						return { ...Codicon.gitPullRequest, color: themeColorFromId('charts.green') };
-				}
-			}
-		}
-
-		if (!session.isRead() && !session.isArchived()) {
-			return { ...Codicon.circleFilled, color: themeColorFromId('textLink.foreground') };
-		}
-
-		if (!statusOnly && (session.providerType === AgentSessionProviders.Local || session.providerType === AgentSessionProviders.AgentHostCopilot)) {
-			return { ...Codicon.circleSmallFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
-		}
-
-		if (!statusOnly) {
-			return session.icon;
-		}
-
-		return { ...Codicon.circleSmallFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
+	private getIcon(session: IAgentSession): ThemeIcon {
+		return getAgentSessionStatusIcon(session);
 	}
 
 	private renderDescription(session: ITreeNode<IAgentSession, FuzzyScore>, template: IAgentSessionItemTemplate): boolean {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
@@ -142,7 +142,7 @@
 
 			.agent-session-icon {
 				flex-shrink: 0;
-				font-size: 12px;
+				font-size: var(--vscode-codiconFontSize, 16px);
 				height: 16px;
 				display: flex;
 				align-items: center;

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { AgentSessionsDataSource, AgentSessionListItem, IAgentSessionsFilter, sessionDateFromNow, getRepositoryName, AgentSessionsSorter, groupAgentSessionsByDate } from '../../../browser/agentSessions/agentSessionsViewer.js';
+import { AgentSessionsDataSource, AgentSessionListItem, IAgentSessionsFilter, sessionDateFromNow, getRepositoryName, AgentSessionsSorter, groupAgentSessionsByDate, getAgentSessionStatusIcon } from '../../../browser/agentSessions/agentSessionsViewer.js';
 import { AgentSessionSection, IAgentSession, IAgentSessionSection, IAgentSessionsModel, isAgentSession, isAgentSessionSection, isAgentSessionShowLess, isAgentSessionShowMore } from '../../../browser/agentSessions/agentSessionsModel.js';
 import { ChatSessionStatus } from '../../../common/chatSessionsService.js';
 import { ITreeSorter } from '../../../../../../base/browser/ui/tree/tree.js';
@@ -14,6 +14,7 @@ import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { AgentSessionsGrouping, AgentSessionsSorting } from '../../../browser/agentSessions/agentSessionsFilter.js';
 import { shouldShowSessionInPicker } from '../../../browser/agentSessions/agentSessionsPicker.js';
+import { themeColorFromId } from '../../../../../../base/common/themables.js';
 
 suite('sessionDateFromNow', () => {
 
@@ -120,6 +121,37 @@ suite('AgentSessionsDataSource', () => {
 			setRead: () => { },
 		};
 	}
+
+	suite('getAgentSessionStatusIcon', () => {
+
+		test('matches sessions window state icons', () => {
+			const cases = [
+				['read', createMockSession({ id: 'read' })],
+				['unread', createMockSession({ id: 'unread', isRead: false })],
+				['archived', createMockSession({ id: 'archived', isArchived: true, isRead: false })],
+				['in-progress', createMockSession({ id: 'in-progress', status: ChatSessionStatus.InProgress })],
+				['needs-input', createMockSession({ id: 'needs-input', status: ChatSessionStatus.NeedsInput })],
+				['failed', createMockSession({ id: 'failed', status: ChatSessionStatus.Failed })],
+				['open-pr', createMockSession({ id: 'open-pr', metadata: { pullRequestNumber: 1, pullRequestState: 'open' } })],
+				['draft-pr', createMockSession({ id: 'draft-pr', metadata: { pullRequestNumber: 1, pullRequestState: 'draft' } })],
+				['merged-pr', createMockSession({ id: 'merged-pr', metadata: { pullRequestNumber: 1, pullRequestState: 'merged' } })],
+				['closed-pr', createMockSession({ id: 'closed-pr', metadata: { pullRequestNumber: 1, pullRequestState: 'closed' } })],
+			] as const;
+
+			assert.deepStrictEqual(cases.map(([name, session]) => [name, getAgentSessionStatusIcon(session)]), [
+				['read', { ...Codicon.circleSmallFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') }],
+				['unread', { ...Codicon.circleFilled, color: themeColorFromId('textLink.foreground') }],
+				['archived', { ...Codicon.passFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') }],
+				['in-progress', { ...Codicon.sessionInProgress, color: themeColorFromId('textLink.foreground') }],
+				['needs-input', { ...Codicon.circleFilled, color: themeColorFromId('list.warningForeground') }],
+				['failed', { ...Codicon.error, color: themeColorFromId('errorForeground') }],
+				['open-pr', { ...Codicon.gitPullRequest, color: themeColorFromId('charts.green') }],
+				['draft-pr', { ...Codicon.gitPullRequestDraft, color: themeColorFromId('descriptionForeground') }],
+				['merged-pr', { ...Codicon.gitPullRequestDone, color: themeColorFromId('charts.purple') }],
+				['closed-pr', { ...Codicon.gitPullRequestClosed, color: themeColorFromId('charts.red') }],
+			]);
+		});
+	});
 
 	function createMockModel(sessions: IAgentSession[]): IAgentSessionsModel {
 		return {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -132,10 +132,6 @@ suite('AgentSessionsDataSource', () => {
 				['in-progress', createMockSession({ id: 'in-progress', status: ChatSessionStatus.InProgress })],
 				['needs-input', createMockSession({ id: 'needs-input', status: ChatSessionStatus.NeedsInput })],
 				['failed', createMockSession({ id: 'failed', status: ChatSessionStatus.Failed })],
-				['open-pr', createMockSession({ id: 'open-pr', metadata: { pullRequestNumber: 1, pullRequestState: 'open' } })],
-				['draft-pr', createMockSession({ id: 'draft-pr', metadata: { pullRequestNumber: 1, pullRequestState: 'draft' } })],
-				['merged-pr', createMockSession({ id: 'merged-pr', metadata: { pullRequestNumber: 1, pullRequestState: 'merged' } })],
-				['closed-pr', createMockSession({ id: 'closed-pr', metadata: { pullRequestNumber: 1, pullRequestState: 'closed' } })],
 			] as const;
 
 			assert.deepStrictEqual(cases.map(([name, session]) => [name, getAgentSessionStatusIcon(session)]), [
@@ -145,10 +141,6 @@ suite('AgentSessionsDataSource', () => {
 				['in-progress', { ...Codicon.sessionInProgress, color: themeColorFromId('textLink.foreground') }],
 				['needs-input', { ...Codicon.circleFilled, color: themeColorFromId('list.warningForeground') }],
 				['failed', { ...Codicon.error, color: themeColorFromId('errorForeground') }],
-				['open-pr', { ...Codicon.gitPullRequest, color: themeColorFromId('charts.green') }],
-				['draft-pr', { ...Codicon.gitPullRequestDraft, color: themeColorFromId('descriptionForeground') }],
-				['merged-pr', { ...Codicon.gitPullRequestDone, color: themeColorFromId('charts.purple') }],
-				['closed-pr', { ...Codicon.gitPullRequestClosed, color: themeColorFromId('charts.red') }],
 			]);
 		});
 	});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/325025

Update the icon usage in VS Code chat session list items so they match the icons we use in Agents window chat session list items. 

Changes include:

- Chat session list items now use:
  - Read: Small grey dot
  - Unread: Larger dot using `textLink-foreground` token
  - Archived: Grey check icon
- Also using the standard codicon size token for these status icons
- Note: In progress / needs input / failed icons and animations were not changed