### PR TITLE
chat: show turn previews as resource labels

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostResponseFileChanges.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostResponseFileChanges.ts
@@ -4,19 +4,53 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
-import { constObservable, derived, derivedOpts, IObservable, observableFromEvent } from '../../../../../../base/common/observable.js';
-import { isEqual } from '../../../../../../base/common/resources.js';
+import { constObservable, derived, derivedOpts, IObservable, mapObservableArrayCached, observableFromEvent } from '../../../../../../base/common/observable.js';
+import { getComparisonKey, isEqual } from '../../../../../../base/common/resources.js';
 import { isDefined } from '../../../../../../base/common/types.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
 import { buildTurnChangesetUri, ChangesetKind } from '../../../../../../platform/agentHost/common/changesetUri.js';
 import { normalizeFileEdit } from '../../../../../../platform/agentHost/common/fileEditDiff.js';
 import { toAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
-import { StateComponents, type ChangesetFile, type ChangesetState, type SessionState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import {
+	buildDefaultChatUri,
+	FileEditKind,
+	ResponsePartKind,
+	StateComponents,
+	ToolCallStatus,
+	ToolResultContentType,
+	type ChangesetFile,
+	type ChangesetState,
+	type ChatState,
+	type ISessionFileDiff,
+	type ResponsePart,
+	type SessionState,
+	type ToolCallState
+} from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IEditSessionEntryDiff } from '../../../common/editing/chatEditingService.js';
 import { IChatResponseFileChangesProvider } from '../../chatResponseFileChangesService.js';
 
 const SUBSCRIPTION_OWNER = 'AgentHostResponseFileChangesProvider';
+
+function uriArrayEquals(a: readonly URI[], b: readonly URI[]): boolean {
+	return a.length === b.length && a.every((uri, index) => isEqual(uri, b[index]));
+}
+
+function getToolCallFileEdits(toolCall: ToolCallState): ISessionFileDiff[] {
+	const edits: ISessionFileDiff[] = [];
+	if (toolCall.status === ToolCallStatus.Running
+		|| toolCall.status === ToolCallStatus.Completed
+		|| toolCall.status === ToolCallStatus.PendingResultConfirmation) {
+		for (const content of toolCall.content ?? []) {
+			if (content.type === ToolResultContentType.FileEdit) {
+				edits.push(content);
+			}
+		}
+	} else if (toolCall.status === ToolCallStatus.PendingConfirmation) {
+		edits.push(...(toolCall.edits?.items ?? []));
+	}
+	return edits;
+}
 
 /**
  * Supplies the chat "Changed N files" summary for agent host responses from the
@@ -34,6 +68,7 @@ const SUBSCRIPTION_OWNER = 'AgentHostResponseFileChangesProvider';
 export class AgentHostResponseFileChangesProvider extends Disposable implements IChatResponseFileChangesProvider {
 
 	private readonly _perRequest = new Map<string, IObservable<readonly IEditSessionEntryDiff[]>>();
+	private readonly _perRequestFileEdits = new Map<string, IObservable<readonly IEditSessionEntryDiff[]>>();
 
 	constructor(
 		private readonly _connection: IAgentConnection,
@@ -54,6 +89,21 @@ export class AgentHostResponseFileChangesProvider extends Disposable implements 
 		if (!obs) {
 			obs = this._createDiffsObservable(backendSession, requestId);
 			this._perRequest.set(key, obs);
+		}
+		return obs;
+	}
+
+	getFileEditsForRequest(sessionResource: URI, requestId: string): IObservable<readonly IEditSessionEntryDiff[]> | undefined {
+		const backendSession = this._resolveBackendSession(sessionResource);
+		if (!backendSession || !requestId) {
+			return undefined;
+		}
+
+		const key = `${backendSession.toString()}\0${requestId}`;
+		let obs = this._perRequestFileEdits.get(key);
+		if (!obs) {
+			obs = this._createFileEditDiffsObservable(backendSession, requestId);
+			this._perRequestFileEdits.set(key, obs);
 		}
 		return obs;
 	}
@@ -90,6 +140,47 @@ export class AgentHostResponseFileChangesProvider extends Disposable implements 
 		});
 	}
 
+	private _createFileEditDiffsObservable(backendSession: URI, requestId: string): IObservable<readonly IEditSessionEntryDiff[]> {
+		const sessionStateObs = this._subscribe<SessionState>(StateComponents.Session, constObservable(backendSession));
+		const defaultChatUri = URI.parse(buildDefaultChatUri(backendSession.toString()));
+
+		const chatUrisObs = derivedOpts<readonly URI[]>({ equalsFn: uriArrayEquals }, reader => {
+			const sessionState = sessionStateObs.read(reader).read(reader);
+			if (!sessionState || sessionState instanceof Error) {
+				return [defaultChatUri];
+			}
+
+			const uris = new Map<string, URI>();
+			uris.set(defaultChatUri.toString(), defaultChatUri);
+			for (const chat of sessionState.chats) {
+				const uri = URI.parse(chat.resource);
+				uris.set(uri.toString(), uri);
+			}
+			return [...uris.values()];
+		});
+
+		const chatStateObs = mapObservableArrayCached(this, chatUrisObs, chatUri => {
+			const obs = this._subscribe<ChatState>(StateComponents.Chat, constObservable(chatUri));
+			return derived(reader => obs.read(reader).read(reader));
+		}, chatUri => chatUri.toString());
+
+		return derived(reader => {
+			for (const obs of chatStateObs.read(reader)) {
+				const chatState = obs.read(reader);
+				if (!chatState || chatState instanceof Error) {
+					continue;
+				}
+				const turn = chatState.activeTurn?.id === requestId
+					? chatState.activeTurn
+					: chatState.turns.find(turn => turn.id === requestId);
+				if (turn) {
+					return this._responsePartsToEntryDiffs(turn.responseParts);
+				}
+			}
+			return [];
+		});
+	}
+
 	/**
 	 * Builds a two-level observable that owns a refcounted subscription to
 	 * `component` at the (observable) resource. The outer observable acquires
@@ -97,7 +188,7 @@ export class AgentHostResponseFileChangesProvider extends Disposable implements 
 	 * resource changes or no one observes; the inner observable tracks the
 	 * subscription's value.
 	 */
-	private _subscribe<T>(component: StateComponents.Session | StateComponents.Changeset, resourceObs: IObservable<URI | undefined>): IObservable<IObservable<T | Error | undefined>> {
+	private _subscribe<T>(component: StateComponents.Session | StateComponents.Changeset | StateComponents.Chat, resourceObs: IObservable<URI | undefined>): IObservable<IObservable<T | Error | undefined>> {
 		return derived(reader => {
 			const resource = resourceObs.read(reader);
 			if (!resource) {
@@ -106,6 +197,57 @@ export class AgentHostResponseFileChangesProvider extends Disposable implements 
 			const subscriptionRef = reader.store.add(this._connection.getSubscription(component, resource, SUBSCRIPTION_OWNER));
 			return observableFromEvent(this, subscriptionRef.object.onDidChange, () => subscriptionRef.object.value as T | Error | undefined);
 		});
+	}
+
+	private _responsePartsToEntryDiffs(responseParts: readonly ResponsePart[]): IEditSessionEntryDiff[] {
+		const byUri = new Map<string, IEditSessionEntryDiff>();
+		for (const responsePart of responseParts) {
+			if (responsePart.kind !== ResponsePartKind.ToolCall) {
+				continue;
+			}
+			for (const fileEdit of getToolCallFileEdits(responsePart.toolCall)) {
+				const diff = this._fileEditToEntryDiff(fileEdit);
+				if (!diff) {
+					continue;
+				}
+				const key = getComparisonKey(diff.modifiedURI);
+				const existing = byUri.get(key);
+				if (existing) {
+					existing.added += diff.added;
+					existing.removed += diff.removed;
+				} else {
+					byUri.set(key, diff);
+				}
+			}
+		}
+		return [...byUri.values()];
+	}
+
+	private _fileEditToEntryDiff(fileEdit: ISessionFileDiff): IEditSessionEntryDiff | undefined {
+		const normalized = normalizeFileEdit(fileEdit);
+		if (!normalized || !normalized.afterUri) {
+			return undefined;
+		}
+
+		const modifiedURI = toAgentHostUri(normalized.afterUri, this._connectionAuthority);
+		const originalURI = normalized.kind === FileEditKind.Create || !normalized.beforeContentUri
+			? modifiedURI
+			: toAgentHostUri(normalized.beforeContentUri, this._connectionAuthority);
+		const modifiedSnapshotURI = normalized.afterContentUri
+			? toAgentHostUri(normalized.afterContentUri, this._connectionAuthority)
+			: undefined;
+
+		return {
+			originalURI,
+			modifiedURI,
+			modifiedSnapshotURI,
+			added: fileEdit.diff?.added ?? 0,
+			removed: fileEdit.diff?.removed ?? 0,
+			quitEarly: false,
+			identical: false,
+			isFinal: true,
+			isBusy: false,
+		};
 	}
 
 	private _changesetFileToEntryDiff(file: ChangesetFile): IEditSessionEntryDiff | undefined {

--- a/src/vs/workbench/contrib/chat/browser/chatResponseFileChangesService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatResponseFileChangesService.ts
@@ -30,6 +30,14 @@ export interface IChatResponseFileChangesProvider {
 	 * the chat editing session).
 	 */
 	getChangesForRequest(sessionResource: URI, requestId: string): IObservable<readonly IEditSessionEntryDiff[]> | undefined;
+
+	/**
+	 * Returns the file edits produced by `requestId` from the response output
+	 * stream, or `undefined` when unavailable. Unlike {@link getChangesForRequest},
+	 * this is not limited to a changeset and can include files outside the
+	 * workspace.
+	 */
+	getFileEditsForRequest?(sessionResource: URI, requestId: string): IObservable<readonly IEditSessionEntryDiff[]> | undefined;
 }
 
 export interface IChatResponseFileChangesService {
@@ -48,6 +56,12 @@ export interface IChatResponseFileChangesService {
 	 * no provider or the provider cannot supply changes for this request.
 	 */
 	getChangesForRequest(sessionResource: URI, requestId: string): IObservable<readonly IEditSessionEntryDiff[]> | undefined;
+
+	/**
+	 * Returns file edits produced by `requestId` from the response output stream,
+	 * when the provider can supply them.
+	 */
+	getFileEditsForRequest?(sessionResource: URI, requestId: string): IObservable<readonly IEditSessionEntryDiff[]> | undefined;
 }
 
 export class ChatResponseFileChangesService extends Disposable implements IChatResponseFileChangesService {
@@ -70,5 +84,10 @@ export class ChatResponseFileChangesService extends Disposable implements IChatR
 	getChangesForRequest(sessionResource: URI, requestId: string): IObservable<readonly IEditSessionEntryDiff[]> | undefined {
 		const provider = this._providers.get(getChatSessionType(sessionResource));
 		return provider?.getChangesForRequest(sessionResource, requestId);
+	}
+
+	getFileEditsForRequest(sessionResource: URI, requestId: string): IObservable<readonly IEditSessionEntryDiff[]> | undefined {
+		const provider = this._providers.get(getChatSessionType(sessionResource));
+		return provider?.getFileEditsForRequest?.(sessionResource, requestId);
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/media/chatTurnPills.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatTurnPills.css
@@ -69,8 +69,8 @@
 	color: var(--vscode-chat-linesRemovedForeground);
 }
 
-/* Preview pill: a single unified control — a resource label (file icon + name +
-	"preview" description), an in-pill separator, and a dropdown chevron. The pill
+/* Preview pill: a single unified control - a resource label (file icon + name),
+	an in-pill separator, and a dropdown chevron. The pill
 	background/border live on the container so the inner (transparent) buttons read
 	as one pill; each inner button is an independent, tab-focusable click zone. The
 	3-class selector beats `.monaco-action-bar .action-item { display: block }`. */
@@ -92,8 +92,7 @@
 	touch-action: manipulation;
 }
 
-/* Left zone: the resource label (file icon + name + "preview"). The height is
-	set by the pill, so no vertical padding here. */
+/* Left zone: the resource label. The height is set by the pill, so no vertical padding here. */
 .chat-turn-pill-preview .monaco-button.chat-turn-pill-preview-primary {
 	display: inline-flex;
 	align-items: center;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTurnPillsPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTurnPillsPart.ts
@@ -9,7 +9,7 @@ import { IAction, toAction } from '../../../../../../base/common/actions.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { combinedDisposable, Disposable, IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { autorun, constObservable, derived, derivedOpts, IObservable } from '../../../../../../base/common/observable.js';
-import { basename, isEqual } from '../../../../../../base/common/resources.js';
+import { basename, getComparisonKey, isEqual } from '../../../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { localize, localize2 } from '../../../../../../nls.js';
@@ -37,13 +37,10 @@ import { IChatContentPart, IChatContentPartRenderContext } from './chatContentPa
 /**
  * Renders a single agent turn's changes as a checkpoint-style summary: a
  * `N files changed +ins -del` header with a "View All File Changes" action, an
- * optional inline "preview <file>" action for the first previewable file the turn
- * produced, and a disclosure that expands to the list of changed files. Fed by
- * the per-request diffs from {@link IChatResponseFileChangesService} (agent host
- * sessions), so it reflects the same authoritative per-turn changes as the
- * checkpoint "N files changed" summary. Which pieces show is controlled per-turn
- * by the {@link observeTurnStatusPillsConfig} setting; the part self-hides when
- * nothing is shown.
+ * optional inline resource-label action for the first previewable file the turn
+ * produced, and a disclosure that expands to the list of changed files. Preview
+ * candidates prefer the turn's file-edit stream so files outside the workspace
+ * can appear.
  */
 export class ChatTurnPillsContentPart extends Disposable implements IChatContentPart {
 
@@ -83,21 +80,32 @@ export class ChatTurnPillsContentPart extends Disposable implements IChatContent
 			return { files: diffs.length, insertions, deletions };
 		});
 
+		const previewDiffs = chatResponseFileChangesService.getFileEditsForRequest?.(_content.sessionResource, _content.requestId) ?? this._diffs;
 		const previewFiles = derivedOpts<readonly IPreviewFile[]>({ owner: this, equalsFn: previewFilesEqual }, reader => {
 			const created: IPreviewFile[] = [];
 			const edited: IPreviewFile[] = [];
-			for (const diff of this._diffs.read(reader)) {
-				const kind = previewKind(diff.modifiedURI);
-				if (!kind) {
-					continue;
+			const seen = new Set<string>();
+			const addDiffs = (diffs: readonly IEditSessionEntryDiff[]) => {
+				for (const diff of diffs) {
+					const kind = previewKind(diff.modifiedURI);
+					if (!kind) {
+						continue;
+					}
+					const key = getComparisonKey(diff.modifiedURI);
+					if (seen.has(key)) {
+						continue;
+					}
+					seen.add(key);
+					// The agent host provider maps a created file's `originalURI` to its
+					// `modifiedURI` (there is no before-content), so equal URIs mark a
+					// creation. Created files are listed first so the primary preview is
+					// the first created file, else the first edited one.
+					const isCreated = isEqual(diff.originalURI, diff.modifiedURI);
+					(isCreated ? created : edited).push({ uri: diff.modifiedURI, kind, created: isCreated });
 				}
-				// The agent host provider maps a created file's `originalURI` to its
-				// `modifiedURI` (there is no before-content), so equal URIs mark a
-				// creation. Created files are listed first so the primary preview is
-				// the first created file, else the first edited one.
-				const isCreated = isEqual(diff.originalURI, diff.modifiedURI);
-				(isCreated ? created : edited).push({ uri: diff.modifiedURI, kind, created: isCreated });
-			}
+			};
+			addDiffs(previewDiffs.read(reader));
+			addDiffs(this._diffs.read(reader));
 			return [...created, ...edited];
 		});
 
@@ -192,9 +200,7 @@ export class ChatTurnPillsContentPart extends Disposable implements IChatContent
 		const button = container.appendChild(document.createElement('button'));
 		button.classList.add('chat-turn-preview-action');
 		button.type = 'button';
-		const verb = button.appendChild($('span.chat-turn-preview-verb'));
-		verb.textContent = localize('chat.turnPreview.verb', 'preview');
-		const label = this._register(resourceLabels.create(button, { supportIcons: true }));
+		const label = this._register(resourceLabels.create(button));
 
 		const clickDisposable = dom.addDisposableListener(button, 'click', (e) => {
 			this._openPrimaryPreview(previewFiles.get());

--- a/src/vs/workbench/contrib/chat/browser/widget/chatTurnPills.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatTurnPills.ts
@@ -216,9 +216,9 @@ class ChangesPillActionViewItem extends BaseActionViewItem {
 
 /**
  * The preview pill: renders the primary previewable file as a resource label
- * (file icon + name) with a "preview" description. When more than one previewable
- * file exists, a separator and a dropdown chevron are shown; the chevron lists
- * every previewable file. Activating the label opens the primary file's preview.
+ * (file icon + name). When more than one previewable file exists, a separator
+ * and a dropdown chevron are shown; the chevron lists every previewable file.
+ * Activating the label opens the primary file's preview.
  */
 class PreviewPillActionViewItem extends BaseActionViewItem {
 
@@ -239,10 +239,6 @@ class PreviewPillActionViewItem extends BaseActionViewItem {
 		this.element = container;
 		container.classList.add('chat-turn-pill-preview');
 
-		// The whole pill is one unified control: a primary resource label (file
-		// icon + name + "preview") on the left, an in-pill separator, and a dropdown
-		// chevron on the right. The inner buttons are transparent so the pill reads
-		// as a single element; each is an independent, tab-focusable button.
 		const primary = this._primary = this._register(new Button(container, { ...TRANSPARENT_BUTTON_STYLES }));
 		primary.element.classList.add('chat-turn-pill-preview-primary');
 		const label = this._register(this._resourceLabels.create(primary.element));
@@ -271,7 +267,7 @@ class PreviewPillActionViewItem extends BaseActionViewItem {
 			const primaryFile = files.at(0);
 			if (primaryFile) {
 				label.setResource(
-					{ resource: primaryFile.uri, name: basename(primaryFile.uri), description: localize('chatTurnPills.preview.description', "preview") },
+					{ resource: primaryFile.uri, name: basename(primaryFile.uri) },
 					{ fileKind: FileKind.FILE },
 				);
 				const tooltip = localize('chatTurnPills.preview.tooltipOne', "Open Preview: {0}", basename(primaryFile.uri));
@@ -297,9 +293,9 @@ class PreviewPillActionViewItem extends BaseActionViewItem {
  * - **Changes** — `<n> Files +ins -del` for the turn. Activating it opens the
  *   changes.
  * - **Preview** — shown when the turn created or edited a markdown or HTML file.
- *   Rendered as a resource label (file icon + name) with a "preview" description
- *   for the primary file. Activating it opens that file as a markdown preview or
- *   in the integrated browser; when several exist, a dropdown lists them all.
+ *   Rendered as a resource label for the primary file. Activating it opens that
+ *   file as a markdown preview or in the integrated browser; when several exist,
+ *   a dropdown lists them all.
  *
  * The data and the open actions are supplied by the {@link IChatTurnPillsModel}
  * so the same widget serves surfaces with different data sources.

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -2986,7 +2986,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 /* Turn changes summary: reuses the compact checkpoint summary styling and adds an
-	inline "preview <file>" action shown when the turn produced a previewable file. */
+	inline resource-label action shown when the turn produced a previewable file. */
 .interactive-session .chat-turn-pills-part .chat-turn-preview {
 	display: flex;
 	align-items: center;
@@ -3040,10 +3040,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 .interactive-session .chat-turn-pills-part .chat-turn-preview-action:focus-visible {
 	outline: var(--vscode-strokeThickness) solid var(--vscode-focusBorder);
 	outline-offset: calc(-1 * var(--vscode-strokeThickness));
-}
-
-.interactive-session .chat-turn-pills-part .chat-turn-preview-verb {
-	flex: none;
 }
 
 .interactive-session .chat-turn-pills-part .chat-turn-preview-action .monaco-icon-label {

--- a/src/vs/workbench/contrib/chat/test/browser/agentHost/agentHostResponseFileChanges.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentHost/agentHostResponseFileChanges.test.ts
@@ -14,7 +14,20 @@ import { IAgentConnection } from '../../../../../../platform/agentHost/common/ag
 import { buildTurnChangesetUri } from '../../../../../../platform/agentHost/common/changesetUri.js';
 import { fromAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
-import { ChangesetStatus, StateComponents, type ChangesetState, type SessionState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import {
+	buildDefaultChatUri,
+	ChangesetStatus,
+	ResponsePartKind,
+	SessionStatus,
+	StateComponents,
+	ToolCallConfirmationReason,
+	ToolCallStatus,
+	ToolResultContentType,
+	TurnState,
+	type ChangesetState,
+	type ChatState,
+	type SessionState
+} from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IEditSessionEntryDiff } from '../../../common/editing/chatEditingService.js';
 import { AgentHostResponseFileChangesProvider } from '../../../browser/agentSessions/agentHost/agentHostResponseFileChanges.js';
 
@@ -122,6 +135,56 @@ suite('AgentHostResponseFileChangesProvider', () => {
 			subscriptionCountBeforeUpdate,
 			conn.getSubscriptionCount(turnChangesetUri('t1')),
 		], [1, 1]);
+	});
+
+	test('maps turn file edits into entry diffs', () => {
+		const ds = store.add(new DisposableStore());
+		const conn = new FakeAgentConnection();
+		const provider = ds.add(new AgentHostResponseFileChangesProvider(conn, authority, () => backendSession));
+		const defaultChatUri = URI.parse(buildDefaultChatUri(backendSession.toString()));
+
+		conn.setState(defaultChatUri.toString(), {
+			resource: defaultChatUri.toString(),
+			title: 'Chat',
+			status: SessionStatus.Idle,
+			modifiedAt: new Date(0).toISOString(),
+			turns: [{
+				id: 't1',
+				message: {},
+				responseParts: [{
+					kind: ResponsePartKind.ToolCall,
+					toolCall: {
+						status: ToolCallStatus.Completed,
+						toolCallId: 'tool-1',
+						toolName: 'write_file',
+						displayName: 'Write File',
+						invocationMessage: 'Write file',
+						confirmed: ToolCallConfirmationReason.NotNeeded,
+						success: true,
+						pastTenseMessage: 'Wrote file',
+						content: [{
+							type: ToolResultContentType.FileEdit,
+							after: { uri: URI.file('/outside/README.md').toString(), content: { uri: 'git-blob://readme-after' } },
+							diff: { added: 7, removed: 0 },
+						}],
+					},
+				}],
+				usage: undefined,
+				state: TurnState.Complete,
+			}],
+		} as unknown as ChatState);
+
+		const obs = provider.getFileEditsForRequest(chatResource, 't1')!;
+		let latest: readonly IEditSessionEntryDiff[] = [];
+		ds.add(autorun(r => { latest = obs.read(r); }));
+
+		assert.deepStrictEqual(latest.map(diff => ({
+			modified: fromAgentHostUri(diff.modifiedURI).path,
+			added: diff.added,
+			removed: diff.removed,
+		})), [
+			{ modified: '/outside/README.md', added: 7, removed: 0 },
+		]);
 	});
 
 	test('returns empty when the agent does not advertise a turn changeset', () => {


### PR DESCRIPTION
## Summary
- render turn preview pills as resource labels without the visible "preview" prefix/description
- derive completed-turn preview candidates from per-turn file edits so markdown files outside the workspace stay available
- add coverage for mapping agent-host turn file edits into response diffs

## Validation
- npm run typecheck-client
- npm run valid-layers-check
- npm run precommit

Note: targeted unit test `scripts\test.bat --run src/vs/workbench/contrib/chat/test/browser/agentHost/agentHostResponseFileChanges.test.ts` could not complete because this worktree lacks compiled `out/` output; attempting `npm run transpile-client` was blocked by additional missing install-time dependencies after the initial npm install auth failure.