### PR TITLE
Fix shell/managed tools hanging on confirmation after Copilot SDK reorder

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -29,7 +29,7 @@ import { CopilotCliConfigKey, copilotCliConfigSchema } from '../../common/copilo
 import type { ChatInputRequestWithPlanReview, IAgentHostPlanReviewAction } from '../../common/agentHostPlanReview.js';
 import { AgentHostSandboxConfigKey, sandboxConfigSchema } from '../../common/sandboxConfigSchema.js';
 import { AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostAutoReplyEnabledConfigKey, platformRootSchema, platformSessionSchema } from '../../common/agentHostSchema.js';
-import { AgentSignal, AuthenticateParams, IMcpNotification, IRestoredSubagentSession, subagentChatTitle } from '../../common/agentService.js';
+import { AgentSignal, AuthenticateParams, IAgentToolPendingConfirmationSignal, IMcpNotification, IRestoredSubagentSession, subagentChatTitle } from '../../common/agentService.js';
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
 import { readToolCallMeta, toToolCallMeta, type IToolCallMeta, type IToolCallUiMeta } from '../../common/meta/agentToolCallMeta.js';
 import { OtelData, type OtelAttributeValue } from '../../common/otlp/otlpLogEmitter.js';
@@ -476,6 +476,19 @@ export class CopilotAgentSession extends Disposable {
 	 * cleared when the tool completes or the session is disposed.
 	 */
 	private readonly _permissionRequestAgentIds = new Map<string, string>();
+	/**
+	 * Stashes a `pending_confirmation` signal whose tool-call part did not exist
+	 * when the confirmation was first fired, keyed by tool call id. The Copilot
+	 * SDK (>= 1.0.6-preview) fires `permission.requested` slightly *before*
+	 * `tool.execution_start` for server-managed tools (shell/read/etc.), so the
+	 * permission-derived `ChatToolCallReady` is dropped by the reducer (no part
+	 * yet). {@link onToolStart} re-fires the stashed confirmation onto the newly
+	 * created part when the permission is still pending, so the user's approval
+	 * prompt is not lost. (Client tools take the
+	 * {@link _ensureClientToolCallStarted} synthesis path instead, so nothing is
+	 * stashed for them.) Cleared on tool completion and on session dispose.
+	 */
+	private readonly _bufferedPendingConfirmations = new Map<string, IAgentToolPendingConfirmationSignal>();
 	/** Pending permission requests awaiting a renderer-side decision. */
 	private readonly _pendingPermissions = new Map<string, DeferredPromise<boolean>>();
 	/** Pending user input requests awaiting a renderer-side answer. */
@@ -698,6 +711,7 @@ export class CopilotAgentSession extends Disposable {
 		}
 		this._register(toDisposable(() => this._cancelPendingClientToolCalls()));
 		this._register(toDisposable(() => this._permissionRequestAgentIds.clear()));
+		this._register(toDisposable(() => this._bufferedPendingConfirmations.clear()));
 	}
 
 	// ---- AgentSignal helpers ------------------------------------------------
@@ -1820,6 +1834,29 @@ export class CopilotAgentSession extends Disposable {
 	// ---- permission handling ------------------------------------------------
 
 	/**
+	 * Fires a `pending_confirmation` signal, additionally stashing it when the
+	 * tool-call part does not exist yet so it can be re-fired once
+	 * `onToolStart` creates the part.
+	 *
+	 * Server-managed tools (shell, read, …) fire `permission.requested` a few
+	 * milliseconds *before* `tool.execution_start` under the Copilot SDK
+	 * (>= 1.0.6-preview). The `ChatToolCallReady` this produces is dropped by the
+	 * reducer when no matching part exists yet, losing the user's approval prompt
+	 * and hanging the tool at "running". Firing immediately preserves the
+	 * existing behavior (and callers that never start a tool, e.g. isolated
+	 * permission tests); the stashed copy lets {@link onToolStart} re-fire the
+	 * confirmation onto the freshly created part when the permission is still
+	 * pending. Client tools reach this with a part already synthesized by
+	 * {@link _ensureClientToolCallStarted}, so nothing is stashed for them.
+	 */
+	private _firePendingConfirmation(signal: IAgentToolPendingConfirmationSignal): void {
+		if (!this._activeToolCalls.has(signal.state.toolCallId)) {
+			this._bufferedPendingConfirmations.set(signal.state.toolCallId, signal);
+		}
+		this._onDidSessionProgress.fire(signal);
+	}
+
+	/**
 	 * Emits a `ChatToolCallStart` for a client tool that is about to have a
 	 * permission-derived `ChatToolCallReady` dispatched for it, when the real
 	 * `tool.execution_start` has not been observed yet.
@@ -2014,7 +2051,7 @@ export class CopilotAgentSession extends Disposable {
 			// subagent session — without it the action would land on the
 			// parent session, which has no matching ChatToolCallStart.
 			const parentToolCallId = this._activeToolCalls.get(toolCallId)?.parentToolCallId;
-			this._onDidSessionProgress.fire({
+			this._firePendingConfirmation({
 				kind: 'pending_confirmation',
 				chat: this._chatChannelUri,
 				state: {
@@ -2260,7 +2297,7 @@ export class CopilotAgentSession extends Disposable {
 				: localize('agentHost.unsandboxedCommandConfirmation.generic', "This command needs to run outside the sandbox.");
 
 		const parentToolCallId = this._activeToolCalls.get(request.toolCallId)?.parentToolCallId;
-		this._onDidSessionProgress.fire({
+		this._firePendingConfirmation({
 			kind: 'pending_confirmation',
 			chat: this._chatChannelUri,
 			state: {
@@ -2874,6 +2911,7 @@ export class CopilotAgentSession extends Disposable {
 			if (isClientTool && !contributor) {
 				this._logService.warn(`[Copilot:${sessionId}] Client tool '${e.data.toolName}' started with no connected client; failing it immediately.`);
 				this._activeToolCalls.delete(e.data.toolCallId);
+				this._bufferedPendingConfirmations.delete(e.data.toolCallId);
 				this._emitAction({
 					type: ActionType.ChatToolCallReady,
 					turnId: this._turnId,
@@ -2905,6 +2943,24 @@ export class CopilotAgentSession extends Disposable {
 				return;
 			}
 
+			// A permission confirmation for this tool may have been fired before
+			// this `tool.execution_start` (the SDK fires `permission.requested`
+			// first for server-managed tools) and dropped by the reducer because
+			// no part existed yet. Now that the part exists, re-fire the stashed
+			// confirmation — but only if the permission is still pending; if it
+			// was already auto-approved the deferred is gone and the normal
+			// not-needed ready below is correct. When re-firing, skip the
+			// not-needed ready (the confirmation owns the transition) and re-stamp
+			// the parent tool call id so subagent tools route correctly.
+			const stashedConfirmation = this._bufferedPendingConfirmations.get(e.data.toolCallId);
+			if (stashedConfirmation) {
+				this._bufferedPendingConfirmations.delete(e.data.toolCallId);
+				if (this._pendingPermissions.has(e.data.toolCallId)) {
+					this._onDidSessionProgress.fire({ ...stashedConfirmation, parentToolCallId });
+					return;
+				}
+			}
+
 			this._emitAction({
 				type: ActionType.ChatToolCallReady,
 				turnId: this._turnId,
@@ -2928,6 +2984,7 @@ export class CopilotAgentSession extends Disposable {
 			this._logService.info(`[Copilot:${sessionId}] Tool completed: ${e.data.toolCallId}`);
 			this._activeToolCalls.delete(e.data.toolCallId);
 			this._permissionRequestAgentIds.delete(e.data.toolCallId);
+			this._bufferedPendingConfirmations.delete(e.data.toolCallId);
 			const displayName = tracked.displayName;
 			const toolOutput = e.data.error?.message ?? e.data.result?.content;
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -477,18 +477,34 @@ export class CopilotAgentSession extends Disposable {
 	 */
 	private readonly _permissionRequestAgentIds = new Map<string, string>();
 	/**
-	 * Stashes a `pending_confirmation` signal whose tool-call part did not exist
-	 * when the confirmation was first fired, keyed by tool call id. The Copilot
-	 * SDK (>= 1.0.6-preview) fires `permission.requested` slightly *before*
-	 * `tool.execution_start` for server-managed tools (shell/read/etc.), so the
-	 * permission-derived `ChatToolCallReady` is dropped by the reducer (no part
-	 * yet). {@link onToolStart} re-fires the stashed confirmation onto the newly
-	 * created part when the permission is still pending, so the user's approval
-	 * prompt is not lost. (Client tools take the
-	 * {@link _ensureClientToolCallStarted} synthesis path instead, so nothing is
-	 * stashed for them.) Cleared on tool completion and on session dispose.
+	 * Coordination for the SDK's permission/tool-start event-ordering race.
+	 *
+	 * The Copilot SDK (>= 1.0.6-preview) fires `permission.requested` *before*
+	 * `tool.execution_start` for server-managed tools (shell/read/etc.), but the
+	 * host derives the tool `ChatToolCallReady` from the permission request while
+	 * the tool-call *part* is only created by `ChatToolCallStart` (from
+	 * `tool.execution_start`). Because `_handlePermissionRequest` has `await`s
+	 * before it fires the confirmation, the confirmation can land either side of
+	 * the start. These two maps normalize the emitted AHP sequence so it is
+	 * identical regardless of which side wins the race — always
+	 * `ChatToolCallStart` then exactly one `ChatToolCallReady` (confirmation or
+	 * not-needed), never a not-needed ready wrongly preceding a confirmation.
+	 *
+	 * - {@link _bufferedPendingConfirmations}: a confirmation signal fired before
+	 *   its part existed (confirmation-wins). {@link onToolStart} re-fires it
+	 *   once the part is created.
+	 * - {@link _deferredServerToolReady}: the default not-needed ready that
+	 *   {@link onToolStart} would emit, deferred because a permission decision is
+	 *   still in flight (start-wins). The decision then either fires a
+	 *   confirmation (which supersedes and discards this) or auto-approves (which
+	 *   invokes it).
+	 *
+	 * (Client tools take the {@link _ensureClientToolCallStarted} synthesis path
+	 * instead, so neither map is used for them.) Both are cleared on tool
+	 * completion and on session dispose.
 	 */
 	private readonly _bufferedPendingConfirmations = new Map<string, IAgentToolPendingConfirmationSignal>();
+	private readonly _deferredServerToolReady = new Map<string, () => void>();
 	/** Pending permission requests awaiting a renderer-side decision. */
 	private readonly _pendingPermissions = new Map<string, DeferredPromise<boolean>>();
 	/** Pending user input requests awaiting a renderer-side answer. */
@@ -712,6 +728,7 @@ export class CopilotAgentSession extends Disposable {
 		this._register(toDisposable(() => this._cancelPendingClientToolCalls()));
 		this._register(toDisposable(() => this._permissionRequestAgentIds.clear()));
 		this._register(toDisposable(() => this._bufferedPendingConfirmations.clear()));
+		this._register(toDisposable(() => this._deferredServerToolReady.clear()));
 	}
 
 	// ---- AgentSignal helpers ------------------------------------------------
@@ -1846,14 +1863,33 @@ export class CopilotAgentSession extends Disposable {
 	 * existing behavior (and callers that never start a tool, e.g. isolated
 	 * permission tests); the stashed copy lets {@link onToolStart} re-fire the
 	 * confirmation onto the freshly created part when the permission is still
-	 * pending. Client tools reach this with a part already synthesized by
-	 * {@link _ensureClientToolCallStarted}, so nothing is stashed for them.
+	 * pending. Producing a confirmation also supersedes any not-needed ready that
+	 * `onToolStart` deferred (start-wins race), so the two race outcomes emit an
+	 * identical sequence. Client tools reach this with a part already synthesized
+	 * by {@link _ensureClientToolCallStarted}, so nothing is stashed for them.
 	 */
 	private _firePendingConfirmation(signal: IAgentToolPendingConfirmationSignal): void {
+		this._deferredServerToolReady.delete(signal.state.toolCallId);
 		if (!this._activeToolCalls.has(signal.state.toolCallId)) {
 			this._bufferedPendingConfirmations.set(signal.state.toolCallId, signal);
 		}
 		this._onDidSessionProgress.fire(signal);
+	}
+
+	/**
+	 * Emits the not-needed `ChatToolCallReady` that {@link onToolStart} deferred
+	 * while a permission decision was in flight, if one is registered. Called
+	 * when the permission resolves to an auto-approval that does not surface a
+	 * confirmation (e.g. sandboxed shell). No-op when nothing was deferred (the
+	 * part did not exist yet, so `onToolStart` will emit the default ready
+	 * itself once it runs).
+	 */
+	private _emitDeferredServerToolReady(toolCallId: string): void {
+		const emit = this._deferredServerToolReady.get(toolCallId);
+		if (emit) {
+			this._deferredServerToolReady.delete(toolCallId);
+			emit();
+		}
 	}
 
 	/**
@@ -2011,6 +2047,12 @@ export class CopilotAgentSession extends Disposable {
 				if (this._pendingPermissions.get(toolCallId) === deferred) {
 					this._pendingPermissions.delete(toolCallId);
 					this._logService.info(`[Copilot:${this.sessionId}] Auto-approving sandboxed shell command for tool call ${toolCallId}`);
+					// Auto-approved without confirmation. If `onToolStart` already
+					// created the part it deferred its not-needed ready (a
+					// permission was pending); emit it now. If the part does not
+					// exist yet, `onToolStart` will emit the default ready itself
+					// once it runs (the pending permission is now cleared).
+					this._emitDeferredServerToolReady(toolCallId);
 					return { kind: 'approve-once' };
 				}
 				return { kind: 'reject' };
@@ -2912,6 +2954,7 @@ export class CopilotAgentSession extends Disposable {
 				this._logService.warn(`[Copilot:${sessionId}] Client tool '${e.data.toolName}' started with no connected client; failing it immediately.`);
 				this._activeToolCalls.delete(e.data.toolCallId);
 				this._bufferedPendingConfirmations.delete(e.data.toolCallId);
+				this._deferredServerToolReady.delete(e.data.toolCallId);
 				this._emitAction({
 					type: ActionType.ChatToolCallReady,
 					turnId: this._turnId,
@@ -2943,25 +2986,11 @@ export class CopilotAgentSession extends Disposable {
 				return;
 			}
 
-			// A permission confirmation for this tool may have been fired before
-			// this `tool.execution_start` (the SDK fires `permission.requested`
-			// first for server-managed tools) and dropped by the reducer because
-			// no part existed yet. Now that the part exists, re-fire the stashed
-			// confirmation — but only if the permission is still pending; if it
-			// was already auto-approved the deferred is gone and the normal
-			// not-needed ready below is correct. When re-firing, skip the
-			// not-needed ready (the confirmation owns the transition) and re-stamp
-			// the parent tool call id so subagent tools route correctly.
-			const stashedConfirmation = this._bufferedPendingConfirmations.get(e.data.toolCallId);
-			if (stashedConfirmation) {
-				this._bufferedPendingConfirmations.delete(e.data.toolCallId);
-				if (this._pendingPermissions.has(e.data.toolCallId)) {
-					this._onDidSessionProgress.fire({ ...stashedConfirmation, parentToolCallId });
-					return;
-				}
-			}
-
-			this._emitAction({
+			// Emit the tool `ChatToolCallReady`, normalizing the SDK's
+			// permission/tool-start ordering race so both outcomes produce an
+			// identical AHP sequence (see `_bufferedPendingConfirmations` /
+			// `_deferredServerToolReady`).
+			const emitNotNeededReady = () => this._emitAction({
 				type: ActionType.ChatToolCallReady,
 				turnId: this._turnId,
 				toolCallId: e.data.toolCallId,
@@ -2969,6 +2998,29 @@ export class CopilotAgentSession extends Disposable {
 				toolInput: getToolInputString(e.data.toolName, parameters, toolArgs),
 				confirmed: ToolCallConfirmationReason.NotNeeded,
 			}, parentToolCallId);
+
+			// Confirmation-wins: a confirmation was fired before this part
+			// existed and dropped by the reducer. Re-fire it onto the part now.
+			const stashedConfirmation = this._bufferedPendingConfirmations.get(e.data.toolCallId);
+			if (stashedConfirmation) {
+				this._bufferedPendingConfirmations.delete(e.data.toolCallId);
+				this._deferredServerToolReady.delete(e.data.toolCallId);
+				this._onDidSessionProgress.fire({ ...stashedConfirmation, parentToolCallId });
+				return;
+			}
+
+			// Start-wins: a permission decision for this tool is still in flight
+			// (its `await`s have not resolved). Defer the default not-needed
+			// ready — the decision will either fire a confirmation (which
+			// supersedes it) or auto-approve (which invokes it via
+			// `_emitDeferredServerToolReady`). This keeps the emitted sequence
+			// identical to the confirmation-wins ordering.
+			if (this._pendingPermissions.has(e.data.toolCallId)) {
+				this._deferredServerToolReady.set(e.data.toolCallId, emitNotNeededReady);
+				return;
+			}
+
+			emitNotNeededReady();
 		}));
 
 		this._register(wrapper.onToolComplete(async e => {
@@ -2985,6 +3037,7 @@ export class CopilotAgentSession extends Disposable {
 			this._activeToolCalls.delete(e.data.toolCallId);
 			this._permissionRequestAgentIds.delete(e.data.toolCallId);
 			this._bufferedPendingConfirmations.delete(e.data.toolCallId);
+			this._deferredServerToolReady.delete(e.data.toolCallId);
 			const displayName = tracked.displayName;
 			const toolOutput = e.data.error?.message ?? e.data.result?.content;
 

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -1730,6 +1730,46 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual((await resultPromise).kind, 'reject');
 		});
 
+		test('shell tool: tool.execution_start arriving before the confirmation fires still emits start-then-confirmation with no not-needed ready (SDK >= 1.0.6 ordering, start-wins race)', async () => {
+			// The confirmation is fired from `handlePermissionRequest` only after
+			// its internal `await`s resolve, so `tool.execution_start` can arrive
+			// first (start-wins race). The emitted AHP sequence must be identical
+			// to the confirmation-wins ordering: `ChatToolCallStart` then the
+			// confirmation, with NO intermediate not-needed ready (which would
+			// otherwise briefly flip the tool to "running").
+			const { session, runtime, mockSession, signals, waitForSignal } = await createAgentSession(disposables);
+
+			// Permission fires first and begins awaiting; do not await it.
+			const resultPromise = runtime.handlePermissionRequest({
+				kind: 'shell',
+				toolCallId: 'tc-shell-startwins',
+				fullCommandText: 'gh search code "x"',
+			});
+
+			// tool.execution_start arrives while the permission handler is still
+			// mid-await (before it fires the confirmation).
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-shell-startwins',
+				toolName: 'bash',
+				arguments: { command: 'gh search code "x"' },
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+
+			await waitForSignal(s => s.kind === 'pending_confirmation');
+
+			// Exactly one start, exactly one confirmation, start before it, and
+			// crucially NO not-needed ready.
+			const startSignals = signals.filter(s => isAction(s, ActionType.ChatToolCallStart));
+			assert.strictEqual(startSignals.length, 1);
+			const pendingConfirmations = signals.filter(s => s.kind === 'pending_confirmation');
+			assert.strictEqual(pendingConfirmations.length, 1);
+			assert.ok(signals.indexOf(startSignals[0]) < signals.indexOf(pendingConfirmations[0]), 'ChatToolCallStart must precede the confirmation');
+			const notNeededReady = signals.filter(s => isAction(s, ActionType.ChatToolCallReady) && (s.action as ChatToolCallReadyAction).confirmed === ToolCallConfirmationReason.NotNeeded);
+			assert.strictEqual(notNeededReady.length, 0, 'no not-needed ready may precede the confirmation in the start-wins race');
+
+			session.respondToPermissionRequest('tc-shell-startwins', false);
+			assert.strictEqual((await resultPromise).kind, 'reject');
+		});
+
 		test('auto-approves sandboxed-by-default shell command without prompting', async () => {
 			const { runtime, signals } = await createAgentSession(disposables, {
 				rootValues: { [AgentHostSandboxConfigKey.Sandbox]: { [AgentHostSandboxKey.Enabled]: AgentSandboxEnabledValue.On } },

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -1684,6 +1684,52 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual(result.kind, 'reject');
 		});
 
+		test('shell tool: permission before tool.execution_start re-fires the dropped confirmation and suppresses the not-needed ready (SDK >= 1.0.6 ordering)', async () => {
+			// Regression: server-managed tools (shell/read) fire
+			// `permission.requested` a few ms *before* `tool.execution_start`
+			// under the SDK 1.0.6 reorder. The permission-derived
+			// `ChatToolCallReady` (with confirmationTitle) is dropped by the
+			// reducer because no part exists yet; `onToolStart` then emits a
+			// not-needed ready that wrongly transitions the tool to "running",
+			// losing the user's approval prompt and hanging the tool. The host
+			// must re-fire the confirmation onto the freshly created part and
+			// suppress the not-needed ready.
+			const { session, runtime, mockSession, signals, waitForSignal } = await createAgentSession(disposables);
+
+			// Permission fires FIRST — no tool.execution_start yet.
+			const resultPromise = runtime.handlePermissionRequest({
+				kind: 'shell',
+				toolCallId: 'tc-shell-reorder',
+				fullCommandText: 'gh search code "x"',
+			});
+			await waitForSignal(s => s.kind === 'pending_confirmation');
+			assert.strictEqual(signals.filter(s => s.kind === 'pending_confirmation').length, 1);
+			assert.strictEqual(signals.filter(s => isAction(s, ActionType.ChatToolCallStart)).length, 0);
+
+			// The real shell tool.execution_start arrives.
+			mockSession.fire('tool.execution_start', {
+				toolCallId: 'tc-shell-reorder',
+				toolName: 'bash',
+				arguments: { command: 'gh search code "x"' },
+			} as SessionEventPayload<'tool.execution_start'>['data']);
+
+			// A ChatToolCallStart was emitted, and the confirmation was re-fired
+			// AFTER it so it lands on the part.
+			const startSignals = signals.filter(s => isAction(s, ActionType.ChatToolCallStart));
+			assert.strictEqual(startSignals.length, 1);
+			const pendingConfirmations = signals.filter(s => s.kind === 'pending_confirmation');
+			assert.strictEqual(pendingConfirmations.length, 2, 'confirmation should be re-fired after the tool start');
+			assert.ok(signals.indexOf(startSignals[0]) < signals.indexOf(pendingConfirmations[1]), 'ChatToolCallStart must precede the re-fired confirmation');
+
+			// The not-needed ready must NOT be emitted — it would clobber the
+			// pending confirmation and hang the tool at "running".
+			const notNeededReady = signals.filter(s => isAction(s, ActionType.ChatToolCallReady) && (s.action as ChatToolCallReadyAction).confirmed === ToolCallConfirmationReason.NotNeeded);
+			assert.strictEqual(notNeededReady.length, 0, 'onToolStart must not emit a not-needed ready when a confirmation is pending');
+
+			session.respondToPermissionRequest('tc-shell-reorder', false);
+			assert.strictEqual((await resultPromise).kind, 'reject');
+		});
+
 		test('auto-approves sandboxed-by-default shell command without prompting', async () => {
 			const { runtime, signals } = await createAgentSession(disposables, {
 				rootValues: { [AgentHostSandboxConfigKey.Sandbox]: { [AgentHostSandboxKey.Enabled]: AgentSandboxEnabledValue.On } },

--- a/src/vs/platform/agentHost/test/node/protocol/realSdkTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/realSdkTestHelpers.ts
@@ -679,6 +679,43 @@ export function defineSharedRealSdkTests(config: IRealSdkProviderConfig): void {
 
 			const toolStarts = client.receivedNotifications(n => isActionNotification(n, 'chat/toolCallStart'));
 			assert.ok(toolStarts.length > 0, 'expected at least one shell tool call');
+
+			// Regression guard (SDK >= 1.0.6 permission/tool-start reorder): for a
+			// tool that surfaced a confirmation prompt, the host must emit an
+			// identical AHP sequence regardless of the SDK's event-order race —
+			// `toolCallStart` first, then the confirmation `toolCallReady`, with
+			// NO not-needed ready in between. Before the fix, when
+			// `tool.execution_start` arrived before the confirmation fired, the
+			// host emitted a spurious not-needed ready ahead of the confirmation
+			// (briefly flipping the tool to "running"); when the confirmation
+			// arrived first it was dropped entirely and the tool hung. Assert the
+			// normalized order per tool call.
+			const readies = client.receivedNotifications(n => isActionNotification(n, 'chat/toolCallReady'))
+				.map(n => {
+					const envelope = getActionEnvelope(n);
+					const action = envelope.action as { toolCallId: string; confirmed?: string };
+					return { toolCallId: action.toolCallId, confirmed: action.confirmed, serverSeq: envelope.serverSeq };
+				});
+			const startSeqByToolCall = new Map<string, number>();
+			for (const n of toolStarts) {
+				const envelope = getActionEnvelope(n);
+				const toolCallId = (envelope.action as { toolCallId: string }).toolCallId;
+				if (!startSeqByToolCall.has(toolCallId)) {
+					startSeqByToolCall.set(toolCallId, envelope.serverSeq);
+				}
+			}
+			for (const ready of readies) {
+				if (ready.confirmed !== undefined) {
+					continue; // only confirmation-requiring readies matter here
+				}
+				const startSeq = startSeqByToolCall.get(ready.toolCallId);
+				assert.ok(startSeq !== undefined && startSeq < ready.serverSeq,
+					`toolCallStart (seq ${startSeq}) must precede the confirmation toolCallReady (seq ${ready.serverSeq}) for ${ready.toolCallId}`);
+				const notNeededBefore = readies.some(r =>
+					r.toolCallId === ready.toolCallId && r.confirmed !== undefined && r.serverSeq < ready.serverSeq);
+				assert.ok(!notNeededBefore,
+					`no not-needed toolCallReady may precede the confirmation toolCallReady for ${ready.toolCallId}`);
+			}
 		});
 
 		(config.supportsPlanMode ? test : test.skip)('planning-mode session-state writes are auto-approved in default mode', async function () {


### PR DESCRIPTION
## Problem

Follow-up to #324869 (client tools hanging after the Copilot SDK bump). The **same** SDK `1.0.6-preview` event reorder also breaks **server-managed tools that require confirmation** — shell commands, unsandboxed commands, etc. They hang at "running" and the user's approval prompt never appears.

Reproduced from a user log ("running trusted-signing-keys tool"): for a `powershell` tool needing confirmation, the AHP stream showed `chat/toolCallReady` (confirmationTitle) **before** `chat/toolCallStart`, then a `not-needed` ready — the confirmation was dropped by the reducer and the tool hung.

## Root cause

Same reorder as #324869: the SDK now fires `permission.requested` **before** `tool.execution_start`. The host derives the tool `ChatToolCallReady` from the permission request, but the tool-call part is only created by `ChatToolCallStart` (from `tool.execution_start`).

It's a **race**: `_handlePermissionRequest` has `await`s before it fires the confirmation, so the confirmation can land on either side of the start:
- **Confirmation-wins**: confirmation fires before the part exists → dropped by the reducer → tool hangs.
- **Start-wins**: `onToolStart` runs first → emits a not-needed ready → the tool briefly flips to "running", then the confirmation arrives.

## Fix

Normalize both race outcomes to emit an **identical AHP sequence**: `ChatToolCallStart` then exactly one `ChatToolCallReady` (confirmation or not-needed), never a not-needed ready preceding a confirmation.

- **Confirmation-wins**: the confirmation is stashed when its part doesn't exist yet, and re-fired by `onToolStart` once the part is created.
- **Start-wins**: `onToolStart` defers its default not-needed ready while a permission decision is in flight, instead of emitting it eagerly. The decision then either fires the confirmation (which supersedes and discards the deferred ready) or auto-approves — e.g. sandboxed shell — which invokes the deferred ready.

This is a different tool class than #324869 with the opposite ordering (start arrives right after the permission, and shell permission requests carry no `toolName`), so it needs this coordination rather than the client-tool synthesis path.

## Testing

- **Unit** (deterministic, CI): regression tests for both race outcomes — confirmation-wins and start-wins. Each was confirmed to fail without the fix (confirmation dropped / not-needed ready precedes the confirmation).
- **Real-SDK** (gated `AGENT_HOST_REAL_SDK=1`): strengthened the existing shell-permission test to assert the normalized order on the live `@github/copilot` process — `toolCallStart` precedes the confirmation `toolCallReady`, with no not-needed ready in between. Because the fix makes the sequence identical regardless of race, this assertion holds in both outcomes and never fails on correct code. Verified passing against the real endpoint.
- All green: `CopilotAgentSession` (174), `CopilotAgent` (300), `AgentSideEffects` (128). Type-check and hygiene clean.

(Written by Copilot)
