### PR TITLE
Show materialization failures as terminal session status

### DIFF
--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -1344,7 +1344,9 @@ export class AgentSideEffects extends Disposable {
 
 		await Promise.all(selectionUpdates);
 
-		await agent.chats.sendMessage(chatUri, message.text, message.attachments, turnId, senderClientId).catch(err => {
+		try {
+			await agent.chats.sendMessage(chatUri, message.text, message.attachments, turnId, senderClientId);
+		} catch (err) {
 			const errCode = (err as { code?: number })?.code;
 			this._logService.error(`[AgentSideEffects] sendMessage failed for session=${turnChannel}: code=${errCode}, message=${err instanceof Error ? err.message : String(err)}, type=${err?.constructor?.name}`, err);
 			this._stateManager.dispatchServerAction(turnChannel, {
@@ -1355,7 +1357,7 @@ export class AgentSideEffects extends Disposable {
 			this._turnTracker.turnCompleted(turnChannel, turnId, 'error');
 			this._toolCallTracker.clearSession(turnChannel);
 			this._failSessionCreationIfStillCreating(sessionChannel, err);
-		});
+		}
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -34,6 +34,7 @@ import {
 	PendingMessageKind,
 	ResponsePartKind,
 	ROOT_STATE_URI,
+	SessionLifecycle,
 	ToolCallStatus,
 	ToolResultContentType,
 	type ErrorInfo,
@@ -1327,7 +1328,7 @@ export class AgentSideEffects extends Disposable {
 		turnId: string;
 		senderClientId: string | undefined;
 	}): Promise<void> {
-		const { agent, turnChannel, chat, message, turnId, senderClientId } = options;
+		const { agent, sessionChannel, turnChannel, chat, message, turnId, senderClientId } = options;
 
 		const chatUri = URI.parse(chat);
 
@@ -1353,7 +1354,44 @@ export class AgentSideEffects extends Disposable {
 			});
 			this._turnTracker.turnCompleted(turnChannel, turnId, 'error');
 			this._toolCallTracker.clearSession(turnChannel);
+			this._failSessionCreationIfStillCreating(sessionChannel, err);
 		});
+	}
+
+	/**
+	 * Surfaces a failed first turn on a not-yet-materialized session as a
+	 * terminal creation failure.
+	 *
+	 * Provisional sessions defer both their root-catalog `SessionAdded`
+	 * notification and their `Creating -> Ready` lifecycle transition until the
+	 * agent materializes them (worktree setup, SDK session init, …) on the
+	 * first `sendMessage`. When that first send rejects — e.g. worktree/branch
+	 * creation throws — the session never entered the catalog and its lifecycle
+	 * is stuck at `Creating`, so clients that optimistically rendered it as
+	 * in-progress keep spinning forever.
+	 *
+	 * When the failing session is still `Creating`, dispatch
+	 * {@link ActionType.SessionCreationFailed} to move it to a terminal
+	 * `CreationFailed` lifecycle, then announce its catalog entry via
+	 * {@link AgentHostStateManager.markSessionPersisted}. The summary's status
+	 * was already aggregated to `Error` by the preceding `ChatError` dispatch,
+	 * so subscribers render the session as failed immediately rather than
+	 * waiting on a client-side timeout. The provisional session survives on the
+	 * agent, so resending re-attempts materialization.
+	 */
+	private _failSessionCreationIfStillCreating(sessionChannel: ProtocolURI, err: unknown): void {
+		const state = this._stateManager.getSessionState(sessionChannel);
+		if (state?.lifecycle !== SessionLifecycle.Creating) {
+			return;
+		}
+		this._stateManager.dispatchServerAction(sessionChannel, {
+			type: ActionType.SessionCreationFailed,
+			error: buildSendFailedError(err),
+		});
+		const summary = this._stateManager.getSessionSummary(sessionChannel);
+		if (summary) {
+			this._stateManager.markSessionPersisted(sessionChannel, summary);
+		}
 	}
 
 

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -23,8 +23,8 @@ import { ISessionDataService } from '../../common/sessionDataService.js';
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import type { RootConfigChangedAction } from '../../common/state/protocol/actions.js';
 import { ChangesSummary, ChatOriginKind, CustomizationType, SessionInputRequestKind } from '../../common/state/protocol/state.js';
-import { ActionType, ActionEnvelope, type ChatAction, type SessionAction } from '../../common/state/sessionActions.js';
-import { buildSubagentChatUri, buildChatUri, buildDefaultChatUri, CustomizationLoadStatus, MessageAttachmentKind, MessageKind, PendingMessageKind, ResponsePartKind, SessionInputResponseKind, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, customizationId, type ClientPluginCustomization, type Customization, type PluginCustomization } from '../../common/state/sessionState.js';
+import { ActionType, ActionEnvelope, type ChatAction, type INotification, type SessionAction } from '../../common/state/sessionActions.js';
+import { buildSubagentChatUri, buildChatUri, buildDefaultChatUri, CustomizationLoadStatus, MessageAttachmentKind, MessageKind, PendingMessageKind, ResponsePartKind, SessionInputResponseKind, SessionLifecycle, SessionStatus, ToolCallConfirmationReason, ToolCallContributorKind, ToolCallStatus, ToolResultContentType, customizationId, type ClientPluginCustomization, type Customization, type PluginCustomization } from '../../common/state/sessionState.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { ITelemetryService, TelemetryLevel } from '../../../telemetry/common/telemetry.js';
 import { NullTelemetryService } from '../../../telemetry/common/telemetryUtils.js';
@@ -417,6 +417,91 @@ suite('AgentSideEffects', () => {
 
 			const errorAction = envelopes.find(e => e.action.type === ActionType.ChatError);
 			assert.ok(errorAction, 'should dispatch session/error');
+		});
+	});
+
+	// ---- handleAction: first-turn materialization failure ---------------
+
+	suite('handleAction — first-turn materialization failure', () => {
+		/**
+		 * Create a provisional (not-yet-materialized) session: no `SessionReady`
+		 * (so lifecycle stays `Creating`) and a deferred `SessionAdded` — mirroring
+		 * how the agent host creates a session whose worktree/SDK setup happens on
+		 * the first `sendMessage`.
+		 */
+		function setupProvisionalSession(): void {
+			stateManager.createSession({
+				resource: sessionUri.toString(),
+				provider: 'mock',
+				title: 'Test',
+				status: SessionStatus.Idle,
+				createdAt: new Date().toISOString(),
+				modifiedAt: new Date().toISOString(),
+			}, { emitNotification: false });
+		}
+
+		test('surfaces a failed provisional first turn as a terminal creation failure', async () => {
+			setupProvisionalSession();
+			agent.sendMessageError = new Error('git -c exited with code 128: fatal: invalid reference: main');
+
+			// Reduce the turn start (as the client would) so the chat has an
+			// active turn for the subsequent ChatError to terminate, then invoke
+			// the side effects that drive `sendMessage`.
+			const turnStarted = {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				message: { text: 'hello', origin: { kind: MessageKind.User } },
+			} as const;
+			stateManager.dispatchClientAction(defaultChatUri, turnStarted, { clientId: 'test', clientSeq: 1 });
+
+			const envelopes: ActionEnvelope[] = [];
+			disposables.add(stateManager.onDidEmitEnvelope(e => envelopes.push(e)));
+			const notifications: INotification[] = [];
+			disposables.add(stateManager.onDidEmitNotification(n => notifications.push(n)));
+
+			sideEffects.handleAction(defaultChatUri, turnStarted);
+
+			// Wait for the async send rejection + catch handling to run.
+			await waitForState(stateManager, () => envelopes.some(e => e.action.type === ActionType.SessionCreationFailed) || undefined);
+
+			const sessionAdded = notifications.find(n => n.type === 'root/sessionAdded');
+			assert.deepStrictEqual({
+				chatError: envelopes.some(e => e.action.type === ActionType.ChatError),
+				creationFailed: envelopes.some(e => e.action.type === ActionType.SessionCreationFailed),
+				lifecycle: stateManager.getSessionState(sessionUri.toString())?.lifecycle,
+				sessionAddedWithError: !!sessionAdded && (sessionAdded.summary.status & SessionStatus.Error) === SessionStatus.Error,
+			}, {
+				chatError: true,
+				creationFailed: true,
+				lifecycle: SessionLifecycle.CreationFailed,
+				sessionAddedWithError: true,
+			});
+		});
+
+		test('does not fail creation when an already-ready session send rejects', async () => {
+			setupSession(); // dispatches SessionReady -> lifecycle Ready
+			agent.sendMessageError = new Error('transient send failure');
+
+			const envelopes: ActionEnvelope[] = [];
+			disposables.add(stateManager.onDidEmitEnvelope(e => envelopes.push(e)));
+
+			sideEffects.handleAction(defaultChatUri, {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				message: { text: 'hello', origin: { kind: MessageKind.User } },
+			});
+
+			await waitForState(stateManager, () => envelopes.some(e => e.action.type === ActionType.ChatError) || undefined);
+
+			assert.deepStrictEqual({
+				chatError: envelopes.some(e => e.action.type === ActionType.ChatError),
+				creationFailed: envelopes.some(e => e.action.type === ActionType.SessionCreationFailed),
+				lifecycle: stateManager.getSessionState(sessionUri.toString())?.lifecycle,
+			}, {
+				chatError: true,
+				creationFailed: false,
+				lifecycle: SessionLifecycle.Ready,
+			});
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/mockAgent.ts
+++ b/src/vs/platform/agentHost/test/node/mockAgent.ts
@@ -120,6 +120,12 @@ export class MockAgent implements IAgent {
 	/** Optional override for the working directory returned by createSession. */
 	resolvedWorkingDirectory: URI | undefined;
 
+	/**
+	 * When set, {@link sendMessage} rejects with this error after recording the
+	 * call — used to simulate a failed first-turn materialization (e.g. worktree
+	 * or branch setup throwing).
+	 */
+	sendMessageError: Error | undefined;
 	async createSession(config?: IAgentCreateSessionConfig): Promise<IAgentCreateSessionResult> {
 		const session = config?.session ?? AgentSession.uri(this.id, `${this.id}-session-${this._nextId++}`);
 		const rawId = AgentSession.id(session);
@@ -141,6 +147,9 @@ export class MockAgent implements IAgent {
 		this._onDidSendMessage.fire(call);
 		if (turnId) {
 			this._activeTurnIds.set(uriKey(session), turnId);
+		}
+		if (this.sendMessageError) {
+			throw this.sendMessageError;
 		}
 	}
 


### PR DESCRIPTION
Towards #324447

### Problem

When a provisional Agent Host session fails to materialize on its first turn (in the reported case, `git worktree add ... main` failed with `fatal: invalid reference: main` because the repo had no `main` branch), the failure was surfaced only as a transient chat/turn error. The session never entered the root catalog and its lifecycle stayed stuck at `Creating`, so the agent-window list item kept spinning as "in progress" indefinitely -- even though the turn had errored early.

Root cause: provisional sessions defer both their catalog `SessionAdded` notification and their `Creating` -> `Ready` lifecycle transition until the agent materializes them on the first `sendMessage`. That deferred transition only ran on **successful** materialization (`_onDidMaterializeSession`); a throw left the session with no catalog entry and no terminal state.

### Fix

Add a failure path symmetric to the success path. In `AgentSideEffects._sendTurnMessage`'s send-rejection handler, when the session is still `Creating`:

- dispatch `SessionCreationFailed` (moving the lifecycle to the terminal `CreationFailed`), and
- announce the deferred `SessionAdded` via `markSessionPersisted`.

The summary's status was already aggregated to `Error` by the preceding `ChatError` dispatch, so the existing client catalog machinery (`_handleSessionAdded` + `_waitForNewSession`) graduates the optimistic new-session skeleton into an errored list item **immediately**, rather than waiting on the 30s client-side timeout. The existing `ChatError` dispatch is kept, so the chat editor still renders the inline error.

The failure stays recoverable: the provisional session survives on the agent, so resending re-attempts materialization.

### Notes

- Gating on `lifecycle === Creating` is provider-agnostic (Copilot/Codex/Claude) -- non-provisional sessions receive `SessionReady` at create time, so only an unmaterialized provisional session is still `Creating` at first send.
- This is the first production dispatch site for `SessionCreationFailed`, which was already defined in the protocol and reducer.

### Tests

- New unit tests in `agentSideEffects.test.ts`: a failed provisional first turn emits `ChatError` + `SessionCreationFailed` + a `SessionAdded` carrying `Error` status and lands on `CreationFailed`; and a gate test proving an already-`Ready` session's send failure emits only `ChatError`.
- `MockAgent` gained a configurable `sendMessageError` to simulate a failed materialization.
- Full node unit suite green; `typecheck-client` and hygiene clean.

_(Written by Copilot)_
