### PR TITLE
Add @TylerLeonhardt to CODENOTIFY for Claude agent areas

### DIFF
--- a/.github/CODENOTIFY
+++ b/.github/CODENOTIFY
@@ -12,6 +12,7 @@ src/vs/base/browser/ui/table/** @benibenj
 src/vs/base/browser/ui/tree/** @benibenj
 
 # Platform
+src/vs/platform/agentHost/node/claude/** @TylerLeonhardt
 src/vs/platform/browserView/** @kycutler @jruales
 src/vs/platform/quickinput/** @TylerLeonhardt
 src/vs/platform/secrets/** @TylerLeonhardt
@@ -38,6 +39,7 @@ src/vs/workbench/services/views/** @sandy081 @benibenj
 src/vs/workbench/contrib/authentication/** @TylerLeonhardt
 src/vs/workbench/contrib/browserView/** @kycutler @jruales
 src/vs/workbench/contrib/chat/browser/chatListRenderer.ts @roblourens
+src/vs/workbench/contrib/chat/electron-browser/builtInTools/fetchPageTool.ts @TylerLeonhardt
 src/vs/workbench/contrib/localization/** @TylerLeonhardt
 src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts @TylerLeonhardt
 src/vs/workbench/contrib/scm/** @lszomoru
@@ -70,6 +72,8 @@ src/vs/workbench/api/common/extHostQuickOpen.ts @TylerLeonhardt
 src/vs/workbench/api/browser/mainThreadSecretState.ts @TylerLeonhardt
 
 # Extensions
+extensions/copilot/src/extension/chatSessions/claude/** @TylerLeonhardt
+extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSession* @TylerLeonhardt
 extensions/microsoft-authentication/** @TylerLeonhardt
 extensions/github-authentication/** @TylerLeonhardt
 extensions/git/** @lszomoru
@@ -78,6 +82,7 @@ extensions/github/** @lszomoru
 extensions/vscode-api-tests/src/singlefolder-tests/browser*.test.ts @kycutler @jruales
 
 # Testing
+test/mcp/** @TylerLeonhardt
 test/sanity/** @dmitrivMS
 
 # Agents Workbench


### PR DESCRIPTION
Adds CODENOTIFY globs for areas I actively own that weren't yet covered. This file is FYI-only (notifications, not required approvals).

| Path | My share of commits |
|------|---------------------|
| `src/vs/platform/agentHost/node/claude/**` | 34/98 (`claudeAgent.ts` 22/55) |
| `extensions/copilot/src/extension/chatSessions/claude/**` | 37/94 |
| `extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSession*` | contentProvider 56, participant 9, itemProvider 5 |
| `test/mcp/**` | 24/71 (aligns with existing `extHostMcp`/`mainThreadMcp` ownership) |
| `src/vs/workbench/contrib/chat/electron-browser/builtInTools/fetchPageTool.ts` | actively iterating on it |

Scoped to `.../claude/**` rather than all of `agentHost/**` or `chatSessions/**`, since the `codex`/`copilotcli` siblings belong to other folks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)