### PR TITLE
Use custom Checkbox widget in bulk edit preview tree

### DIFF
--- a/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.css
+++ b/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.css
@@ -53,10 +53,6 @@
 	align-self: center;
 }
 
-.monaco-workbench .bulk-edit-panel .monaco-tl-contents .edit-checkbox.disabled {
-	opacity: .5;
-}
-
 .monaco-workbench .bulk-edit-panel .monaco-tl-contents .monaco-icon-label.delete .monaco-icon-label-container {
 	text-decoration: line-through;
 }

--- a/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree.ts
@@ -500,6 +500,8 @@ class FileElementTemplate {
 		} else {
 			this._checkbox.enable();
 		}
+		// enable()/disable() reset the tabIndex; keep the checkbox out of the tree's tab order
+		this._checkbox.domNode.tabIndex = -1;
 		this._localDisposables.add(this._checkbox.onChange(() => {
 			element.setChecked(this._checkbox.checked);
 		}));
@@ -600,6 +602,8 @@ class TextEditElementTemplate {
 		} else {
 			this._checkbox.enable();
 		}
+		// enable()/disable() reset the tabIndex; keep the checkbox out of the tree's tab order
+		this._checkbox.domNode.tabIndex = -1;
 
 		let value = '';
 		value += element.prefix;

--- a/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree.ts
@@ -10,7 +10,7 @@ import { IResourceLabel, ResourceLabels } from '../../../../browser/labels.js';
 import { HighlightedLabel, IHighlight } from '../../../../../base/browser/ui/highlightedlabel/highlightedLabel.js';
 import { IIdentityProvider, IListVirtualDelegate, IKeyboardNavigationLabelProvider } from '../../../../../base/browser/ui/list/list.js';
 import { Range } from '../../../../../editor/common/core/range.js';
-import * as dom from '../../../../../base/browser/dom.js';
+import { Checkbox } from '../../../../../base/browser/ui/toggle/toggle.js';
 import { ITextModel } from '../../../../../editor/common/model.js';
 import { IDisposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { TextModel } from '../../../../../editor/common/model/textModel.js';
@@ -31,6 +31,7 @@ import { SnippetParser } from '../../../../../editor/contrib/snippet/browser/sni
 import { AriaRole } from '../../../../../base/browser/ui/aria/aria.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import * as css from '../../../../../base/browser/cssValue.js';
+import { defaultCheckboxStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 
 // --- VIEW MODEL
 
@@ -462,7 +463,7 @@ class FileElementTemplate {
 	private readonly _disposables = new DisposableStore();
 	private readonly _localDisposables = new DisposableStore();
 
-	private readonly _checkbox: HTMLInputElement;
+	private readonly _checkbox: Checkbox;
 	private readonly _label: IResourceLabel;
 	private readonly _details: HTMLSpanElement;
 
@@ -472,11 +473,10 @@ class FileElementTemplate {
 		@ILabelService private readonly _labelService: ILabelService,
 	) {
 
-		this._checkbox = document.createElement('input');
-		this._checkbox.className = 'edit-checkbox';
-		this._checkbox.type = 'checkbox';
-		this._checkbox.setAttribute('role', 'checkbox');
-		container.appendChild(this._checkbox);
+		this._checkbox = this._disposables.add(new Checkbox('', false, defaultCheckboxStyles));
+		this._checkbox.domNode.classList.add('edit-checkbox');
+		this._checkbox.domNode.tabIndex = -1;
+		container.appendChild(this._checkbox.domNode);
 
 		this._label = resourceLabels.create(container, { supportHighlights: true });
 
@@ -495,8 +495,12 @@ class FileElementTemplate {
 		this._localDisposables.clear();
 
 		this._checkbox.checked = element.isChecked();
-		this._checkbox.disabled = element.isDisabled();
-		this._localDisposables.add(dom.addDisposableListener(this._checkbox, 'change', () => {
+		if (element.isDisabled()) {
+			this._checkbox.disable();
+		} else {
+			this._checkbox.enable();
+		}
+		this._localDisposables.add(this._checkbox.onChange(() => {
 			element.setChecked(this._checkbox.checked);
 		}));
 
@@ -561,18 +565,17 @@ class TextEditElementTemplate {
 	private readonly _disposables = new DisposableStore();
 	private readonly _localDisposables = new DisposableStore();
 
-	private readonly _checkbox: HTMLInputElement;
+	private readonly _checkbox: Checkbox;
 	private readonly _icon: HTMLDivElement;
 	private readonly _label: HighlightedLabel;
 
 	constructor(container: HTMLElement, @IThemeService private readonly _themeService: IThemeService) {
 		container.classList.add('textedit');
 
-		this._checkbox = document.createElement('input');
-		this._checkbox.className = 'edit-checkbox';
-		this._checkbox.type = 'checkbox';
-		this._checkbox.setAttribute('role', 'checkbox');
-		container.appendChild(this._checkbox);
+		this._checkbox = this._disposables.add(new Checkbox('', false, defaultCheckboxStyles));
+		this._checkbox.domNode.classList.add('edit-checkbox');
+		this._checkbox.domNode.tabIndex = -1;
+		container.appendChild(this._checkbox.domNode);
 
 		this._icon = document.createElement('div');
 		container.appendChild(this._icon);
@@ -588,16 +591,14 @@ class TextEditElementTemplate {
 	set(element: TextEditElement) {
 		this._localDisposables.clear();
 
-		this._localDisposables.add(dom.addDisposableListener(this._checkbox, 'change', e => {
+		this._localDisposables.add(this._checkbox.onChange(() => {
 			element.setChecked(this._checkbox.checked);
-			e.preventDefault();
 		}));
-		if (element.parent.isChecked()) {
-			this._checkbox.checked = element.isChecked();
-			this._checkbox.disabled = element.isDisabled();
+		this._checkbox.checked = element.isChecked();
+		if (element.isDisabled()) {
+			this._checkbox.disable();
 		} else {
-			this._checkbox.checked = element.isChecked();
-			this._checkbox.disabled = element.isDisabled();
+			this._checkbox.enable();
 		}
 
 		let value = '';


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/317982

## What

The bulk edit preview tree rendered its file/text-edit checkboxes with raw `<input type="checkbox">` elements. This PR swaps them for the themed `Checkbox` widget (`vs/base/browser/ui/toggle/toggle.ts`), matching the convention used across other workbench trees (e.g. breakpoints).

<img width="552" height="202" alt="image" src="https://github.com/user-attachments/assets/0ab9a21c-dd7d-4ef4-b282-17e4c516b240" />


## Changes

- **`bulkEditTree.ts`** — `FileElementTemplate` and `TextEditElementTemplate` now create a `Checkbox` (with `defaultCheckboxStyles`), registered to the template's `DisposableStore`:
  - `disabled = …` → `enable()`/`disable()`
  - `dom.addDisposableListener(…, 'change')` → `checkbox.onChange(…)`
  - The `edit-checkbox` class is kept on the widget's `domNode` for layout; `tabIndex = -1` since the tree row is the focusable/checkbox-role element (keyboard toggling already flows through the pane's `toggleChecked()`).
  - Removed the now-unused `dom` import; collapsed a pre-existing identical `if/else` in `TextEditElementTemplate.set()`.
- **`bulkEdit.css`** — removed the redundant `.edit-checkbox.disabled { opacity: .5 }` rule; the custom checkbox dims itself when disabled via `.monaco-custom-toggle.disabled`. Kept `.edit-checkbox { align-self: center }` for vertical centering in the row.

## Notes

- Visual change by design: the native ~13px OS checkbox becomes VS Code's themed 18px custom checkbox.
- Behavioral nuance: the custom `Toggle` calls `stopPropagation()` on click, so clicking a checkbox now only toggles it and no longer also selects the tree row — consistent with the breakpoints/search trees.

`npm run typecheck-client` passes clean.